### PR TITLE
Release v0.1.6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,15 @@ Date format: `YYYY-MM-DD` (UTC)
 - **Cargo build**: `.cargo/config.toml` routes target-dir to native Linux path (avoids permission errors on `/mnt/c/`)
   - This file is gitignored (`.cargo/` in .gitignore) so CI uses default target-dir
 
+## Branch Protection
+
+**main branch is protected** - cannot push directly. All changes require:
+1. Create feature branch: `git checkout -b feature/name`
+2. Push branch: `powershell.exe -Command "cd C:\projects\cq; git push -u origin feature/name"`
+3. Create PR: `powershell.exe -Command 'gh pr create --title "..." --body "..."'`
+4. Wait for CI (test, clippy, fmt) to pass
+5. Merge via: `powershell.exe -Command 'gh pr merge N --squash --delete-branch'`
+
 ## Environment & Credentials
 
 - `.env` files are gitignored - use for local secrets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,9 +796,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -998,20 +998,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
@@ -1542,11 +1536,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ dirs = "5"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 rand = "0.8"
-lru = "0.12"
+lru = "0.16"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Version bump for Phase B audit fixes (connection pooling, caching, rate limiting, secure IDs).