### PR TITLE
Release v0.1.8: HNSW index + P0 audit fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,9 @@ Thank you for your interest in contributing to cqs!
 
 ### Feature Ideas
 
-- Additional language support (tree-sitter grammars)
+- Additional language support (tree-sitter grammars: C, C++, Java, Ruby)
+- Non-CUDA GPU support (ROCm for AMD, Metal for Apple Silicon)
+- VS Code extension
 - Performance improvements
 - CLI enhancements
 
@@ -82,7 +84,8 @@ src/
   cli.rs      - Command-line interface (clap)
   parser.rs   - tree-sitter code parsing
   embedder.rs - ONNX model embedding generation
-  store.rs    - SQLite storage and search
+  store.rs    - SQLite storage and brute-force search
+  hnsw.rs     - HNSW index for fast O(log n) search
   mcp.rs      - MCP server implementation
   lib.rs      - Public API
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "anndists"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4bbb2296f2525e53a52680f5c2df6de9a83b8a94cc22a8cc629301a27b5e0b7"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cpu-time",
+ "env_logger",
+ "lazy_static",
+ "log",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +212,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -360,6 +386,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +459,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpu-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +493,7 @@ dependencies = [
  "futures",
  "globset",
  "hf-hub",
+ "hnsw_rs",
  "ignore",
  "indicatif 0.17.11",
  "insta",
@@ -529,7 +576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
 dependencies = [
  "dispatch2",
- "nix",
+ "nix 0.30.1",
  "windows-sys 0.61.2",
 ]
 
@@ -705,6 +752,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +861,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -984,13 +1072,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1043,6 +1142,31 @@ name = "hmac-sha256"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f0ae375a85536cac3a243e3a9cda80a47910348abdea7e2c22f8ec556d586d"
+
+[[package]]
+name = "hnsw_rs"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22884c1debedfe585612f1f6da7bfe257f557639143cac270a8ac2f8702de750"
+dependencies = [
+ "anndists",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "cpu-time",
+ "env_logger",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "lazy_static",
+ "log",
+ "mmap-rs",
+ "num-traits",
+ "num_cpus",
+ "parking_lot",
+ "rand 0.9.2",
+ "rayon",
+ "serde",
+]
 
 [[package]]
 name = "http"
@@ -1320,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -1422,6 +1546,30 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jiff"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -1536,6 +1684,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "macro_rules_attribute"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,6 +1729,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1616,6 +1782,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mmap-rs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86968d85441db75203c34deefd0c88032f275aaa85cee19a1dcfff6ae9df56da"
+dependencies = [
+ "bitflags 1.3.2",
+ "combine",
+ "libc",
+ "mach2",
+ "nix 0.26.4",
+ "sysctl",
+ "thiserror 1.0.69",
+ "widestring",
+ "windows",
 ]
 
 [[package]]
@@ -1670,6 +1853,19 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -2615,6 +2811,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
+dependencies = [
+ "bitflags 2.10.0",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,6 +3563,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3382,6 +3598,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Semantic code search with local ML embeddings. Find functions by concept, not name. GPU-accelerated. MCP server included."
 license = "MIT"
@@ -40,6 +40,9 @@ tokio-stream = "0.1"
 rusqlite = { version = "0.31", features = ["bundled"] }
 r2d2 = "0.8"
 r2d2_sqlite = "0.24"
+
+# Vector search (HNSW)
+hnsw_rs = "0.3"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -120,7 +120,10 @@ impl Embedder {
 
         // Check cache first
         {
-            let mut cache = self.query_cache.lock().unwrap();
+            let mut cache = self.query_cache.lock().unwrap_or_else(|poisoned| {
+                tracing::warn!("Query cache lock poisoned, recovering");
+                poisoned.into_inner()
+            });
             if let Some(cached) = cache.get(text) {
                 return Ok(cached.clone());
             }
@@ -136,7 +139,10 @@ impl Embedder {
 
         // Store in cache
         {
-            let mut cache = self.query_cache.lock().unwrap();
+            let mut cache = self.query_cache.lock().unwrap_or_else(|poisoned| {
+                tracing::warn!("Query cache lock poisoned, recovering");
+                poisoned.into_inner()
+            });
             cache.put(text.to_string(), embedding.clone());
         }
 

--- a/src/hnsw.rs
+++ b/src/hnsw.rs
@@ -1,0 +1,362 @@
+//! HNSW (Hierarchical Navigable Small World) index for fast vector search
+//!
+//! Provides O(log n) approximate nearest neighbor search, scaling to >50k chunks.
+
+use std::path::{Path, PathBuf};
+
+use hnsw_rs::anndists::dist::distances::DistCosine;
+use hnsw_rs::api::AnnT;
+use hnsw_rs::hnsw::Hnsw;
+use hnsw_rs::hnswio::HnswIo;
+use thiserror::Error;
+
+use crate::embedder::Embedding;
+
+/// HNSW index parameters
+const MAX_NB_CONNECTION: usize = 24; // M parameter - connections per node
+const MAX_LAYER: usize = 16; // Maximum layers in the graph
+const EF_CONSTRUCTION: usize = 200; // Construction-time search width
+
+/// Embedding dimension (nomic-embed-text-v1.5)
+const EMBEDDING_DIM: usize = 768;
+
+/// Search width for queries (higher = more accurate but slower)
+const EF_SEARCH: usize = 100;
+
+#[derive(Error, Debug)]
+pub enum HnswError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("HNSW index not found at {0}")]
+    NotFound(String),
+    #[error("Dimension mismatch: expected {expected}, got {actual}")]
+    DimensionMismatch { expected: usize, actual: usize },
+    #[error("HNSW error: {0}")]
+    Internal(String),
+}
+
+/// Search result from HNSW index
+#[derive(Debug, Clone)]
+pub struct HnswResult {
+    /// Chunk ID (matches Store chunk IDs)
+    pub id: String,
+    /// Cosine similarity score (0.0 to 1.0)
+    pub score: f32,
+}
+
+/// HNSW index wrapper for semantic code search
+///
+/// This wraps the hnsw_rs library, handling:
+/// - Building indexes from embeddings
+/// - Searching for nearest neighbors
+/// - Saving/loading to disk
+/// - Mapping between internal IDs and chunk IDs
+pub struct HnswIndex {
+    /// Internal state - either built in memory or loaded from disk
+    inner: HnswInner,
+    /// Mapping from internal index to chunk ID
+    id_map: Vec<String>,
+}
+
+/// Internal HNSW state
+enum HnswInner {
+    /// Built in memory - owns its data
+    Owned(Hnsw<'static, f32, DistCosine>),
+    /// Loaded from disk - stores path info for reloading
+    Loaded { dir: PathBuf, basename: String },
+}
+
+impl HnswIndex {
+    /// Build a new HNSW index from embeddings
+    ///
+    /// # Arguments
+    /// * `embeddings` - Vector of (chunk_id, embedding) pairs
+    pub fn build(embeddings: Vec<(String, Embedding)>) -> Result<Self, HnswError> {
+        if embeddings.is_empty() {
+            // Create empty index
+            let hnsw = Hnsw::new(MAX_NB_CONNECTION, 1, MAX_LAYER, EF_CONSTRUCTION, DistCosine);
+            return Ok(Self {
+                inner: HnswInner::Owned(hnsw),
+                id_map: Vec::new(),
+            });
+        }
+
+        // Validate dimensions
+        for (id, emb) in &embeddings {
+            if emb.0.len() != EMBEDDING_DIM {
+                return Err(HnswError::DimensionMismatch {
+                    expected: EMBEDDING_DIM,
+                    actual: emb.0.len(),
+                });
+            }
+            tracing::trace!("Adding {} to HNSW index", id);
+        }
+
+        let nb_elem = embeddings.len();
+        tracing::info!("Building HNSW index with {} vectors", nb_elem);
+
+        // Create HNSW with cosine distance
+        let mut hnsw = Hnsw::new(
+            MAX_NB_CONNECTION,
+            nb_elem,
+            MAX_LAYER,
+            EF_CONSTRUCTION,
+            DistCosine,
+        );
+
+        // Build ID map and prepare data for insertion
+        let mut id_map = Vec::with_capacity(nb_elem);
+        let mut data_for_insert: Vec<(&Vec<f32>, usize)> = Vec::with_capacity(nb_elem);
+
+        for (idx, (chunk_id, embedding)) in embeddings.iter().enumerate() {
+            id_map.push(chunk_id.clone());
+            data_for_insert.push((&embedding.0, idx));
+        }
+
+        // Parallel insert for performance
+        hnsw.parallel_insert_data(&data_for_insert);
+
+        tracing::info!("HNSW index built successfully");
+
+        Ok(Self {
+            inner: HnswInner::Owned(hnsw),
+            id_map,
+        })
+    }
+
+    /// Search for nearest neighbors
+    ///
+    /// # Arguments
+    /// * `query` - Query embedding
+    /// * `k` - Number of results to return
+    ///
+    /// # Returns
+    /// Vector of (chunk_id, score) pairs, sorted by descending score
+    pub fn search(&self, query: &Embedding, k: usize) -> Vec<HnswResult> {
+        if self.id_map.is_empty() {
+            return Vec::new();
+        }
+
+        if query.0.len() != EMBEDDING_DIM {
+            tracing::warn!(
+                "Query dimension mismatch: expected {}, got {}",
+                EMBEDDING_DIM,
+                query.0.len()
+            );
+            return Vec::new();
+        }
+
+        let neighbors = match &self.inner {
+            HnswInner::Owned(hnsw) => hnsw.search_neighbours(&query.0, k, EF_SEARCH),
+            HnswInner::Loaded { dir, basename, .. } => {
+                // For loaded indexes, we need to reload and search
+                // This is a limitation of the library's lifetime design
+                let mut hnsw_io = HnswIo::new(dir, basename);
+                let hnsw: Hnsw<f32, DistCosine> = match hnsw_io.load_hnsw() {
+                    Ok(h) => h,
+                    Err(e) => {
+                        tracing::error!("Failed to reload HNSW for search: {}", e);
+                        return Vec::new();
+                    }
+                };
+                // Collect results while hnsw is still alive
+                hnsw.search_neighbours(&query.0, k, EF_SEARCH)
+            }
+        };
+
+        neighbors
+            .into_iter()
+            .filter_map(|n| {
+                let idx = n.d_id;
+                if idx < self.id_map.len() {
+                    // Convert distance to similarity score
+                    // Cosine distance is 1 - cosine_similarity, so we convert back
+                    let score = 1.0 - n.distance;
+                    Some(HnswResult {
+                        id: self.id_map[idx].clone(),
+                        score,
+                    })
+                } else {
+                    tracing::warn!("Invalid index {} in HNSW result", idx);
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Save the index to disk
+    ///
+    /// Creates files in the directory:
+    /// - `{basename}.hnsw.data` - Vector data
+    /// - `{basename}.hnsw.graph` - HNSW graph structure
+    /// - `{basename}.hnsw.ids` - Chunk ID mapping (our addition)
+    pub fn save(&self, dir: &Path, basename: &str) -> Result<(), HnswError> {
+        tracing::info!("Saving HNSW index to {}/{}", dir.display(), basename);
+
+        // Ensure directory exists
+        std::fs::create_dir_all(dir)?;
+
+        // Save the HNSW graph and data using the library's file_dump
+        match &self.inner {
+            HnswInner::Owned(hnsw) => {
+                hnsw.file_dump(dir, basename)
+                    .map_err(|e| HnswError::Internal(format!("Failed to dump HNSW: {}", e)))?;
+            }
+            HnswInner::Loaded {
+                dir: src_dir,
+                basename: src_basename,
+                ..
+            } => {
+                // Copy existing files to new location if different
+                if src_dir != dir || src_basename != basename {
+                    for ext in &["hnsw.graph", "hnsw.data"] {
+                        let src = src_dir.join(format!("{}.{}", src_basename, ext));
+                        let dst = dir.join(format!("{}.{}", basename, ext));
+                        if src.exists() {
+                            std::fs::copy(&src, &dst)?;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Save the ID map separately (the library doesn't store our string IDs)
+        let id_map_path = dir.join(format!("{}.hnsw.ids", basename));
+        let id_map_json = serde_json::to_string(&self.id_map)
+            .map_err(|e| HnswError::Internal(format!("Failed to serialize ID map: {}", e)))?;
+        std::fs::write(&id_map_path, id_map_json)?;
+
+        tracing::info!("HNSW index saved: {} vectors", self.id_map.len());
+
+        Ok(())
+    }
+
+    /// Load an index from disk
+    pub fn load(dir: &Path, basename: &str) -> Result<Self, HnswError> {
+        let graph_path = dir.join(format!("{}.hnsw.graph", basename));
+        let data_path = dir.join(format!("{}.hnsw.data", basename));
+        let id_map_path = dir.join(format!("{}.hnsw.ids", basename));
+
+        if !graph_path.exists() || !data_path.exists() || !id_map_path.exists() {
+            return Err(HnswError::NotFound(dir.display().to_string()));
+        }
+
+        tracing::info!("Loading HNSW index from {}/{}", dir.display(), basename);
+
+        // Load ID map
+        let id_map_json = std::fs::read_to_string(&id_map_path)?;
+        let id_map: Vec<String> = serde_json::from_str(&id_map_json)
+            .map_err(|e| HnswError::Internal(format!("Failed to parse ID map: {}", e)))?;
+
+        // Verify the HNSW files can be loaded by doing a test load
+        let mut hnsw_io = HnswIo::new(dir, basename);
+        let _: Hnsw<f32, DistCosine> = hnsw_io
+            .load_hnsw()
+            .map_err(|e| HnswError::Internal(format!("Failed to load HNSW: {}", e)))?;
+
+        tracing::info!("HNSW index loaded: {} vectors", id_map.len());
+
+        Ok(Self {
+            inner: HnswInner::Loaded {
+                dir: dir.to_path_buf(),
+                basename: basename.to_string(),
+            },
+            id_map,
+        })
+    }
+
+    /// Check if an HNSW index exists at the given path
+    pub fn exists(dir: &Path, basename: &str) -> bool {
+        let graph_path = dir.join(format!("{}.hnsw.graph", basename));
+        let data_path = dir.join(format!("{}.hnsw.data", basename));
+        let id_map_path = dir.join(format!("{}.hnsw.ids", basename));
+
+        graph_path.exists() && data_path.exists() && id_map_path.exists()
+    }
+
+    /// Get the number of vectors in the index
+    pub fn len(&self) -> usize {
+        self.id_map.len()
+    }
+
+    /// Check if the index is empty
+    pub fn is_empty(&self) -> bool {
+        self.id_map.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_embedding(seed: u32) -> Embedding {
+        // Create a simple deterministic embedding for testing
+        let mut v = vec![0.0f32; EMBEDDING_DIM];
+        for (i, val) in v.iter_mut().enumerate() {
+            *val = ((seed as f32 * 0.1) + (i as f32 * 0.001)).sin();
+        }
+        // L2 normalize
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for val in &mut v {
+                *val /= norm;
+            }
+        }
+        Embedding(v)
+    }
+
+    #[test]
+    fn test_build_and_search() {
+        let embeddings = vec![
+            ("chunk1".to_string(), make_embedding(1)),
+            ("chunk2".to_string(), make_embedding(2)),
+            ("chunk3".to_string(), make_embedding(3)),
+        ];
+
+        let index = HnswIndex::build(embeddings).unwrap();
+        assert_eq!(index.len(), 3);
+
+        // Search for something similar to chunk1
+        let query = make_embedding(1);
+        let results = index.search(&query, 3);
+
+        assert!(!results.is_empty());
+        // The most similar should be chunk1 itself
+        assert_eq!(results[0].id, "chunk1");
+        assert!(results[0].score > 0.9); // Should be very similar
+    }
+
+    #[test]
+    fn test_save_and_load() {
+        let tmp = TempDir::new().unwrap();
+
+        let embeddings = vec![
+            ("chunk1".to_string(), make_embedding(1)),
+            ("chunk2".to_string(), make_embedding(2)),
+        ];
+
+        let index = HnswIndex::build(embeddings).unwrap();
+        index.save(tmp.path(), "index").unwrap();
+
+        assert!(HnswIndex::exists(tmp.path(), "index"));
+
+        let loaded = HnswIndex::load(tmp.path(), "index").unwrap();
+        assert_eq!(loaded.len(), 2);
+
+        // Verify search still works
+        let query = make_embedding(1);
+        let results = loaded.search(&query, 2);
+        assert_eq!(results[0].id, "chunk1");
+    }
+
+    #[test]
+    fn test_empty_index() {
+        let index = HnswIndex::build(vec![]).unwrap();
+        assert!(index.is_empty());
+
+        let query = make_embedding(1);
+        let results = index.search(&query, 5);
+        assert!(results.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
 //! cq - semantic code search with local embeddings
 
 pub mod embedder;
+pub mod hnsw;
 pub mod mcp;
 pub mod parser;
 pub mod store;
 
 pub use embedder::Embedder;
+pub use hnsw::HnswIndex;
 pub use mcp::{serve_http, serve_stdio};
 pub use parser::Parser;
 pub use store::Store;


### PR DESCRIPTION
## Summary
- Add HNSW index for O(log n) search scaling to >50k chunks
- Fix P0 audit findings (lock poisoning, query validation)
- Bump version to 0.1.8

## HNSW Implementation
- New src/hnsw.rs module using hnsw_rs v0.3.3 (pure Rust, no C++ deps)
- Auto-build HNSW after indexing
- Use HNSW for unfiltered searches, brute-force fallback for filtered
- Persistence: .cq/index.hnsw.{graph,data,ids}
- Parameters: M=24, max_layer=16, ef_construction=200, ef_search=100

## P0 Audit Fixes
- Fix RwLock panic risk in HTTP handler (recover from poison)
- Fix LRU cache lock poisoning risk in embedder
- Add query length validation (8KB max) in MCP
- Add embedding byte validation with warning in store

## Test plan
- [x] All 32 tests passing
- [x] Clippy clean
- [x] HNSW build/search/save/load tested

Generated with Claude Code