### PR TITLE
Update Cargo.lock for v0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
Updates Cargo.lock with v0.1.9 version (was missing from release PR).