### PR TITLE
Fix CodeQL security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 9 * * 1'  # Weekly on Monday 9am UTC
   workflow_dispatch:  # Manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   check-crates:
     name: Check Rust Crates

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,4 +1,10 @@
 //! MCP (Model Context Protocol) server implementation
+//!
+//! # Security
+//!
+//! JSON deserialization from untrusted input is bounded by:
+//! - HTTP transport: 1MB request body limit (RequestBodyLimitLayer)
+//! - Stdio transport: trusted client (Claude Code) with reasonable message sizes
 
 use std::io::{BufRead, Write};
 use std::path::PathBuf;


### PR DESCRIPTION
Addresses GitHub code scanning alerts:

- Add explicit \permissions: contents: read\ to workflows (#1-6)
- Document JSON deserialization security bounds in mcp.rs (#7)

The uncontrolled allocation warning in mcp.rs is mitigated by the 1MB request body limit.