### PR TITLE
Cleanup: add tests and warnings

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Pre-commit hook: Run cargo fmt check
+# Pre-commit hook: Run cargo fmt check and verify Cargo.lock
 
 echo "Running cargo fmt --check..."
 cargo fmt --check
@@ -8,5 +8,15 @@ if [ $? -ne 0 ]; then
     echo "Error: Code is not formatted. Run 'cargo fmt' to fix."
     exit 1
 fi
-
 echo "Format check passed."
+
+# Check if Cargo.lock needs updating (only if Cargo.toml is staged)
+if git diff --cached --name-only | grep -q "Cargo.toml"; then
+    echo "Checking Cargo.lock sync..."
+    cargo check --quiet 2>/dev/null
+    if git diff --name-only | grep -q "Cargo.lock"; then
+        echo ""
+        echo "Warning: Cargo.lock changed after cargo check."
+        echo "Consider staging Cargo.lock: git add Cargo.lock"
+    fi
+fi

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -911,6 +911,17 @@ fn cmd_stats(cli: &Cli) -> Result<()> {
                 println!("  Tip: Run 'cqs index' to build HNSW for faster search");
             }
         }
+
+        // Warning for very large indexes
+        if stats.total_chunks > 50_000 {
+            println!();
+            println!(
+                "Warning: {} chunks is a large index. Consider:",
+                stats.total_chunks
+            );
+            println!("  - Using --path to limit search scope");
+            println!("  - Splitting into multiple projects");
+        }
     }
 
     Ok(())


### PR DESCRIPTION
- Add test for get_embeddings_by_hashes() batch lookup (9 store tests now)
- Add warning in stats when index exceeds 50k chunks
- Improve pre-commit hook to check Cargo.lock sync