### PR TITLE
Release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-01-31
+
 ### Added
 - RRF (Reciprocal Rank Fusion) hybrid search combining semantic + FTS5 keyword search
 - FTS5 virtual table for full-text keyword search
@@ -124,7 +126,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI commands: init, doctor, index, stats, serve
 - Filter by language (`-l`) and path pattern (`-p`)
 
-[Unreleased]: https://github.com/jamie8johnson/cqs/compare/v0.1.8...HEAD
+[Unreleased]: https://github.com/jamie8johnson/cqs/compare/v0.1.10...HEAD
+[0.1.10]: https://github.com/jamie8johnson/cqs/compare/v0.1.9...v0.1.10
+[0.1.9]: https://github.com/jamie8johnson/cqs/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/jamie8johnson/cqs/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/jamie8johnson/cqs/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/jamie8johnson/cqs/compare/v0.1.5...v0.1.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "Semantic code search for Claude Code. Find functions by what they do, not their names. Local ML, GPU-accelerated."
 license = "MIT"


### PR DESCRIPTION
## v0.1.10

### Added
- RRF (Reciprocal Rank Fusion) hybrid search combining semantic + FTS5 keyword search
- FTS5 virtual table for full-text keyword search
- Chunk-level incremental indexing (skip re-embedding unchanged chunks via content_hash)

### Changed
- Schema version bumped from 1 to 2 (FTS5 support)
- RRF enabled by default in CLI and MCP for improved recall

---

After merge: tag, GitHub release, cargo publish