### PR TITLE
docs: Comprehensive MD review for v0.1.10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,8 +160,10 @@ Date format: `YYYY-MM-DD` (UTC)
 - ort 2.x (ONNX Runtime) - uses `try_extract_array`, `axis_iter`
 - tokenizers 0.22
 - hf-hub 0.4
-- rusqlite 0.31
+- rusqlite 0.31 + r2d2-sqlite 0.24 (connection pooling)
+- hnsw_rs 0.3 + simsimd 6 (fast vector search)
 - nomic-embed-text-v1.5 (768-dim, Matryoshka truncatable)
+- lru 0.16 (query embedding cache)
 
 ## Phase 1 Languages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,8 +84,8 @@ src/
   cli.rs      - Command-line interface (clap)
   parser.rs   - tree-sitter code parsing
   embedder.rs - ONNX model embedding generation
-  store.rs    - SQLite storage and brute-force search
-  hnsw.rs     - HNSW index for fast O(log n) search
+  store.rs    - SQLite storage, FTS5 keyword search, RRF hybrid fusion
+  hnsw.rs     - HNSW index for fast O(log n) vector search
   mcp.rs      - MCP server implementation
   lib.rs      - Public API
 ```

--- a/PROJECT_CONTINUITY_2026-01-31.md
+++ b/PROJECT_CONTINUITY_2026-01-31.md
@@ -1,19 +1,19 @@
 # cqs - Project Continuity
 
-Updated: 2026-01-31T23:45Z
+Updated: 2026-01-31T24:00Z
 
 ## Current State
 
-**main branch ready for v0.1.10 release.**
+**v0.1.10 released.**
 
-- Published to crates.io: `cargo install cqs` (v0.1.9)
-- GitHub release: https://github.com/jamie8johnson/cqs/releases/tag/v0.1.9
-- ~4600 lines across 9 modules
-- 42 tests passing, 5 doctests, clippy clean
+- Published to crates.io: `cargo install cqs` (v0.1.10)
+- GitHub release: https://github.com/jamie8johnson/cqs/releases/tag/v0.1.10
+- ~4800 lines across 9 modules
+- 45 tests passing (12 store tests including FTS/RRF), clippy clean
 
-## Implemented (pending release as v0.1.10)
+## Released in v0.1.10
 
-### 1. Chunk-Level Incremental Indexing (merged)
+### 1. Chunk-Level Incremental Indexing
 
 **Problem:** Editing one function re-embeds entire file. Wastes GPU/CPU time.
 
@@ -25,7 +25,7 @@ Updated: 2026-01-31T23:45Z
 - Stats output: "Indexed X chunks (Y cached, Z embedded)"
 - Verified 80-90% cache hit rate
 
-### 2. RRF Hybrid Search (PR #24, merged)
+### 2. RRF Hybrid Search
 
 **Problem:** Semantic search misses exact identifier matches.
 
@@ -34,32 +34,31 @@ Updated: 2026-01-31T23:45Z
 **Implementation:**
 - FTS5 virtual table `chunks_fts` for full-text search
 - `normalize_for_fts()`: splits camelCase/snake_case → words
-  - Example: `parseConfigFile` → "parse config file"
 - RRF fusion: `score = Σ 1/(k + rank)` where k=60
 - Enabled by default in CLI and MCP
 - Schema version bumped from 1 to 2
 
-**Key Files:**
-- `src/schema.sql` - FTS5 virtual table
-- `src/store.rs` - normalize_for_fts, search_fts, rrf_fuse, enable_rrf
-- `src/cli.rs`, `src/mcp.rs` - RRF enabled by default
-- `tests/store_test.rs` - 12 tests including FTS and RRF
-
 ## Next Steps
 
-1. **Release v0.1.10** - Package incremental indexing + RRF
-2. **Optional: C and Java language support**
+1. **Optional: C and Java language support**
    - Add tree-sitter-c, tree-sitter-java to Cargo.toml
    - C: `function_definition`, `struct_specifier`
    - Java: `method_declaration`, `class_declaration`, `interface_declaration`
 
 ## Recent PRs
 
+- PR #28: Mark resolved hunches (merged)
+- PR #27: Document RRF in README (merged)
+- PR #26: Release v0.1.10 (merged)
+- PR #25: Update docs after RRF merge (merged)
 - PR #24: RRF hybrid search (merged)
 - PR #23: Cleanup - tests, warnings, pre-commit hooks (merged)
 - PR #22: Chunk-level incremental indexing (merged)
 
-## Hunches
+## Upgrade Note
 
-- hnsw_rs lifetime forces reload (~1-2ms overhead) - library limitation
-- FTS5 tokenization with preprocessing works well for code identifiers (resolved)
+Users upgrading from v0.1.9 or earlier need to rebuild their index:
+```bash
+cqs index --force
+```
+This rebuilds the FTS5 keyword index for RRF hybrid search.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -148,14 +148,16 @@
   - Fuse semantic + keyword with `1/(k + rank)` scoring (k=60)
   - Enabled by default for better recall
 
+- [x] v0.1.10 release (includes incremental indexing + RRF)
+  - Published to crates.io 2026-01-31
+  - Schema version bumped to 2 (FTS5 support)
+
 ### Planned
 
 - [ ] C and Java language support
   - tree-sitter-c, tree-sitter-java grammars
   - C: function_definition, struct_specifier
   - Java: method_declaration, class_declaration, interface_declaration
-
-- [ ] v0.1.10 release (includes incremental indexing + RRF)
 
 ## Phase 6: Security
 

--- a/docs/SESSION_CONTEXT.md
+++ b/docs/SESSION_CONTEXT.md
@@ -30,7 +30,7 @@
 - hf-hub 0.4
 - rusqlite 0.31 + r2d2-sqlite 0.24 (connection pooling)
 - nomic-embed-text-v1.5 (768-dim, Matryoshka truncatable)
-- lru 0.12 (query embedding cache)
+- lru 0.16 (query embedding cache)
 
 ## Phase 1 Languages
 


### PR DESCRIPTION
Thorough review of all MD files to update for v0.1.10 release.

## Changes

- **ROADMAP.md**: Mark v0.1.10 as released (was listed as planned)
- **PROJECT_CONTINUITY_2026-01-31.md**: Update to reflect released state, add recent PRs
- **CONTRIBUTING.md**: Update store.rs description (now has FTS5, RRF)
- **docs/SESSION_CONTEXT.md**: Fix lru version 0.12 to 0.16
- **CLAUDE.md**: Update SESSION_CONTEXT template with newer deps
