### PR TITLE
feat: Call graph analysis (v0.1.14)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,9 +82,9 @@ When reporting bugs, please include:
 ```
 src/
   cli.rs      - Command-line interface (clap)
-  parser.rs   - tree-sitter code parsing
+  parser.rs   - tree-sitter code parsing, call extraction
   embedder.rs - ONNX model embedding generation
-  store.rs    - SQLite storage, FTS5 keyword search, RRF hybrid fusion
+  store.rs    - SQLite storage, FTS5 keyword search, RRF hybrid fusion, call graph
   hnsw.rs     - HNSW index for fast O(log n) vector search
   mcp.rs      - MCP server implementation
   nl.rs       - NL description generation, JSDoc parsing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 description = "Semantic code search for Claude Code. Find functions by what they do, not their names. Local ML, GPU-accelerated."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ cqs watch --debounce 1000  # Custom debounce (ms)
 
 Watch mode respects `.gitignore` by default. Use `--no-ignore` to index ignored files.
 
+## Call Graph
+
+Find function call relationships:
+
+```bash
+cqs callers <name>   # Functions that call <name>
+cqs callees <name>   # Functions called by <name>
+```
+
+Use cases:
+- **Impact analysis**: What calls this function I'm about to change?
+- **Context expansion**: Show related functions
+- **Entry point discovery**: Find functions with no callers
+
+Note: Currently resolves within-file calls only. Cross-file resolution is planned.
+
 ## Claude Code Integration
 
 ### Why use cqs?
@@ -124,6 +140,8 @@ Use `cqs_search` for semantic code search instead of grep/glob when looking for:
 Available tools:
 - `cqs_search` - semantic search with `language`, `path_pattern`, `threshold`, `limit`, `name_boost`, `semantic_only`
 - `cqs_stats` - index stats, chunk counts, HNSW index status
+- `cqs_callers` - find functions that call a given function
+- `cqs_callees` - find functions called by a given function
 
 Keep index fresh: run `cqs watch` in a background terminal, or `cqs index` after significant changes.
 ```

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -38,3 +38,14 @@ CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
     doc,           -- documentation text
     tokenize='unicode61'
 );
+
+-- Call graph: function call relationships (within-file resolution)
+CREATE TABLE IF NOT EXISTS calls (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    caller_id TEXT NOT NULL,      -- chunk ID of the calling function
+    callee_name TEXT NOT NULL,    -- name of the called function
+    line_number INTEGER NOT NULL, -- line where call occurs
+    FOREIGN KEY (caller_id) REFERENCES chunks(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_calls_caller ON calls(caller_id);
+CREATE INDEX IF NOT EXISTS idx_calls_callee ON calls(callee_name);

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -51,7 +51,7 @@ fn test_store_init() {
     let stats = store.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
     assert_eq!(stats.total_files, 0);
-    assert_eq!(stats.schema_version, 3); // v3: NL-based embeddings
+    assert_eq!(stats.schema_version, 4); // v4: Call graph
     assert_eq!(stats.model_name, "nomic-embed-text-v1.5");
 }
 


### PR DESCRIPTION
## Summary
- Add function call relationship extraction using tree-sitter
- Store caller→callee edges in SQLite for impact analysis and context expansion
- New CLI commands: `cqs callers` and `cqs callees`
- New MCP tools: `cqs_callers` and `cqs_callees`
- Schema v4: `calls` table with caller_id, callee_name, line_number

## Use Cases
- **Impact analysis**: "What calls this function I'm about to change?"
- **Context expansion**: "Show related functions"
- **Entry point discovery**: "Find functions with no callers"

## Limitations
- Within-file resolution only (cross-file requires import analysis)
- Extracts direct calls, not indirect (callbacks, function pointers)

## Test plan
- [x] All existing tests pass
- [x] New schema creates `calls` table
- [x] `cqs index --force` populates call graph
- [x] `cqs callers embed_query` returns correct results
- [x] `cqs callees tool_search` returns correct results

---
Generated with [Claude Code](https://claude.com/claude-code)
