### PR TITLE
feat: Full call graph coverage (v0.1.15)

### DIFF
--- a/docs/HUNCHES.md
+++ b/docs/HUNCHES.md
@@ -315,3 +315,31 @@ Every chunk now starts with "A function named..." or "A method named...". This r
 **RESOLVED 2026-01-31:** Added `parse_jsdoc_tags()` in nl.rs to extract @param and @returns from JSDoc comments. JavaScript now gets type info from JSDoc when signature parsing fails.
 
 ---
+
+## 2026-02-01 - ONNX runtime logs ignore RUST_LOG
+
+The ort crate's underlying ONNX runtime logs INFO messages to stderr even with `RUST_LOG=error`. These aren't Rust tracing logs - they're from the C++ ONNX runtime. Cosmetic annoyance but clutters CLI output.
+
+Potential fix: ort has `OrtLoggingLevel` but it's set at session creation time, not globally. Would need to change `Embedder::new()`.
+
+---
+
+## 2026-02-01 - No schema migrations, just rebuild
+
+When schema version bumps (v3→v4→v5), users must run `cqs index --force` to rebuild. No incremental migrations. Acceptable for now since reindexing is fast (<30s for most projects), but could be painful for large codebases.
+
+---
+
+## 2026-02-01 - Call graph method ambiguity
+
+`store.search()` and `hnsw.search()` both match callee name "search". No type information in call graph - can't distinguish which `search` is called. Would need type analysis to resolve. Documented limitation, won't fix soon.
+
+---
+
+## 2026-02-01 - Large functions skipped from call graph
+
+Functions >100 lines are skipped during chunk extraction (embedding quality filter). Their calls aren't captured in call graph. CLI handlers particularly affected.
+
+**PLANNED:** Separate call extraction from chunking. Extract calls from ALL functions regardless of size. See plan in session notes.
+
+---

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,4 +1,4 @@
--- cq index schema v2
+-- cq index schema v5
 
 CREATE TABLE IF NOT EXISTS metadata (
     key TEXT PRIMARY KEY,
@@ -49,3 +49,17 @@ CREATE TABLE IF NOT EXISTS calls (
 );
 CREATE INDEX IF NOT EXISTS idx_calls_caller ON calls(caller_id);
 CREATE INDEX IF NOT EXISTS idx_calls_callee ON calls(callee_name);
+
+-- Full call graph: captures ALL function calls, including from large functions
+-- that are skipped during chunk extraction (>100 lines)
+CREATE TABLE IF NOT EXISTS function_calls (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file TEXT NOT NULL,           -- source file path
+    caller_name TEXT NOT NULL,    -- name of the calling function
+    caller_line INTEGER NOT NULL, -- line where function starts
+    callee_name TEXT NOT NULL,    -- name of the called function
+    call_line INTEGER NOT NULL    -- line where call occurs
+);
+CREATE INDEX IF NOT EXISTS idx_fcalls_file ON function_calls(file);
+CREATE INDEX IF NOT EXISTS idx_fcalls_caller ON function_calls(caller_name);
+CREATE INDEX IF NOT EXISTS idx_fcalls_callee ON function_calls(callee_name);

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -51,7 +51,7 @@ fn test_store_init() {
     let stats = store.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
     assert_eq!(stats.total_files, 0);
-    assert_eq!(stats.schema_version, 4); // v4: Call graph
+    assert_eq!(stats.schema_version, 5); // v5: Full call graph
     assert_eq!(stats.model_name, "nomic-embed-text-v1.5");
 }
 


### PR DESCRIPTION
## Summary

- Large functions (>100 lines) were skipped during chunk extraction, so their calls weren't captured
- CLI handlers like `cmd_index` had no call graph coverage
- Fix: Separate call extraction from chunk extraction with new `function_calls` table

## Changes

- **parser.rs**: Add `parse_file_calls()` method that extracts calls without size filtering
- **schema.sql**: Add `function_calls` table (schema v5)
- **store.rs**: Add `get_callers_full()` and `get_callees_full()` using new table
- **cli.rs/mcp.rs**: Wire up callers/callees commands to use full call graph

## Result

Call graph now captures 1889 calls (was missing CLI callers before)

## Test plan

- [x] `cargo test` passes
- [x] `cqs callers upsert_chunks_batch` now shows `cmd_index` as caller
- [x] Schema migration triggers on `cqs index --force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
