### PR TITLE
docs: Update tears for v0.1.15

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,13 +2,13 @@
 
 ## Right Now
 
-v0.1.13 in progress. NL module extraction, JSDoc parsing, eval improvements.
+v0.1.15 released. Full call graph coverage - large functions (>100 lines) now captured.
 
 ## Parked
 
 - C and Java language support (no user requests yet)
 - Code-specific embedding model (CodeSage, Qwen3-Embedding)
-- Call graph analysis (grepai has this)
+- NL template experiments (from previous session - need to evaluate)
 
 ## Open Questions
 

--- a/docs/HUNCHES.md
+++ b/docs/HUNCHES.md
@@ -340,6 +340,6 @@ When schema version bumps (v3→v4→v5), users must run `cqs index --force` to 
 
 Functions >100 lines are skipped during chunk extraction (embedding quality filter). Their calls aren't captured in call graph. CLI handlers particularly affected.
 
-**PLANNED:** Separate call extraction from chunking. Extract calls from ALL functions regardless of size. See plan in session notes.
+**RESOLVED 2026-02-01:** v0.1.15 separates call extraction from chunking. New `function_calls` table captures calls from ALL functions regardless of size. Schema v5.
 
 ---


### PR DESCRIPTION
Update PROJECT_CONTINUITY.md and HUNCHES.md to reflect v0.1.15 release with full call graph coverage.