### PR TITLE
fix: Add CodeQL suppression for allocation size alert

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -279,6 +279,7 @@ impl McpServer {
 
     fn handle_initialize(&self, params: Option<Value>) -> Result<Value> {
         // SAFETY: Allocation bounded by 1MB request body limit (HTTP) or trusted client (stdio)
+        // codeql[rust/uncontrolled-allocation-size]
         let _params: InitializeParams =
             params
                 .map(serde_json::from_value)


### PR DESCRIPTION
## Summary
- Add inline CodeQL suppression comment for `rust/uncontrolled-allocation-size` alert

The `serde_json::from_value` call is protected by:
- HTTP: 1MB request body limit (tower middleware)
- stdio: trusted local client

The suppression comment prevents the alert from reappearing after dismissal.

## Test plan
- [x] Code compiles
- [ ] CodeQL scan runs without flagging this line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
