### PR TITLE
feat: Add API key authentication for HTTP transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 # CLI
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 
 # Parsing (tree-sitter) - core is required, grammars are optional

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,8 @@
 //! // Stdio transport (for Claude Code)
 //! cqs::serve_stdio(".".into(), false)?;  // false = CPU, true = GPU
 //!
-//! // HTTP transport with GPU embedding
-//! cqs::serve_http(".".into(), "127.0.0.1", 3000, true)?;
+//! // HTTP transport with GPU embedding (None = no auth)
+//! cqs::serve_http(".".into(), "127.0.0.1", 3000, true, None)?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/store.rs
+++ b/src/store.rs
@@ -844,8 +844,8 @@ impl Store {
                         signature: row.get(5),
                         content: row.get(6),
                         doc: row.get(7),
-                        line_start: row.get::<i64, _>(8) as u32,
-                        line_end: row.get::<i64, _>(9) as u32,
+                        line_start: row.get::<i64, _>(8).clamp(0, u32::MAX as i64) as u32,
+                        line_end: row.get::<i64, _>(9).clamp(0, u32::MAX as i64) as u32,
                         parent_id: row.get(10),
                     };
                     (chunk_row.id.clone(), chunk_row)
@@ -1173,8 +1173,8 @@ impl Store {
                         signature: row.get(5),
                         content: row.get(6),
                         doc: row.get(7),
-                        line_start: row.get::<i64, _>(8) as u32,
-                        line_end: row.get::<i64, _>(9) as u32,
+                        line_start: row.get::<i64, _>(8).clamp(0, u32::MAX as i64) as u32,
+                        line_end: row.get::<i64, _>(9).clamp(0, u32::MAX as i64) as u32,
                         parent_id: row.get(11),
                     };
                     let embedding_bytes: Vec<u8> = row.get(10);
@@ -1320,8 +1320,8 @@ impl Store {
                         signature: row.get(5),
                         content: row.get(6),
                         doc: row.get(7),
-                        line_start: row.get::<i64, _>(8) as u32,
-                        line_end: row.get::<i64, _>(9) as u32,
+                        line_start: row.get::<i64, _>(8).clamp(0, u32::MAX as i64) as u32,
+                        line_end: row.get::<i64, _>(9).clamp(0, u32::MAX as i64) as u32,
                         parent_id: row.get(10),
                     })
                 })
@@ -1414,7 +1414,7 @@ impl Store {
                 .map(|(file, name, line)| CallerInfo {
                     file: PathBuf::from(file),
                     name,
-                    line: line as u32,
+                    line: line.clamp(0, u32::MAX as i64) as u32,
                 })
                 .collect();
 
@@ -1437,7 +1437,7 @@ impl Store {
 
             Ok(rows
                 .into_iter()
-                .map(|(name, line)| (name, line as u32))
+                .map(|(name, line)| (name, line.clamp(0, u32::MAX as i64) as u32))
                 .collect())
         })
     }


### PR DESCRIPTION
## Summary

Security improvements from 16-category audit:

- Add `--api-key` flag and `CQS_API_KEY` env var for HTTP authentication
- Require API key for non-localhost HTTP binds (fail-safe)
- Bearer token validation in POST and SSE handlers
- Saturating casts for all DB i64→u32 line number conversions

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy -- -D warnings` passes  
- [x] `cargo test` passes (58 tests)
- [x] `cargo fmt -- --check` passes
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
