### PR TITLE
refactor: Audit batch 1 - unwrap to expect, SAFETY docs

### DIFF
--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -157,7 +157,7 @@ impl CagraIndex {
 
         // Take the index (cuVS search consumes it)
         let index = {
-            let mut guard = self.index.lock().unwrap();
+            let mut guard = self.index.lock().expect("CAGRA index mutex poisoned");
             guard.take()
         };
 
@@ -183,7 +183,7 @@ impl CagraIndex {
             Err(e) => {
                 tracing::error!("Failed to create search params: {}", e);
                 // Put index back
-                let mut guard = self.index.lock().unwrap();
+                let mut guard = self.index.lock().expect("CAGRA index mutex poisoned");
                 *guard = Some(index);
                 return Vec::new();
             }
@@ -198,7 +198,7 @@ impl CagraIndex {
             Ok(t) => t,
             Err(e) => {
                 tracing::error!("Failed to copy query to device: {}", e);
-                let mut guard = self.index.lock().unwrap();
+                let mut guard = self.index.lock().expect("CAGRA index mutex poisoned");
                 *guard = Some(index);
                 return Vec::new();
             }
@@ -213,7 +213,7 @@ impl CagraIndex {
                 Ok(t) => t,
                 Err(e) => {
                     tracing::error!("Failed to allocate neighbors on device: {}", e);
-                    let mut guard = self.index.lock().unwrap();
+                    let mut guard = self.index.lock().expect("CAGRA index mutex poisoned");
                     *guard = Some(index);
                     return Vec::new();
                 }
@@ -224,7 +224,7 @@ impl CagraIndex {
                 Ok(t) => t,
                 Err(e) => {
                     tracing::error!("Failed to allocate distances on device: {}", e);
-                    let mut guard = self.index.lock().unwrap();
+                    let mut guard = self.index.lock().expect("CAGRA index mutex poisoned");
                     *guard = Some(index);
                     return Vec::new();
                 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -357,7 +357,8 @@ fn enumerate_files(root: &Path, parser: &CqParser, no_ignore: bool) -> Result<Ve
 /// Check if a process with the given PID exists
 #[cfg(unix)]
 fn process_exists(pid: u32) -> bool {
-    // kill with signal 0 checks if process exists without sending a signal
+    // SAFETY: kill(pid, 0) is safe - it only checks if process exists without
+    // sending any signal. The pid is u32 cast to i32 which is valid for PIDs.
     unsafe { libc::kill(pid as i32, 0) == 0 }
 }
 

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -178,7 +178,9 @@ impl Embedder {
             _ => 16,
         };
 
-        let query_cache = Mutex::new(LruCache::new(NonZeroUsize::new(100).unwrap()));
+        let query_cache = Mutex::new(LruCache::new(
+            NonZeroUsize::new(100).expect("100 is non-zero"),
+        ));
 
         Ok(Self {
             session: OnceCell::new(),
@@ -199,7 +201,9 @@ impl Embedder {
     pub fn new_cpu() -> Result<Self, EmbedderError> {
         let (model_path, tokenizer_path) = ensure_model()?;
 
-        let query_cache = Mutex::new(LruCache::new(NonZeroUsize::new(100).unwrap()));
+        let query_cache = Mutex::new(LruCache::new(
+            NonZeroUsize::new(100).expect("100 is non-zero"),
+        ));
 
         Ok(Self {
             session: OnceCell::new(),
@@ -299,7 +303,7 @@ impl Embedder {
         // Check cache first
         {
             let mut cache = self.query_cache.lock().unwrap_or_else(|poisoned| {
-                tracing::warn!("Query cache lock poisoned, recovering");
+                tracing::debug!("Query cache lock poisoned, recovering");
                 poisoned.into_inner()
             });
             if let Some(cached) = cache.get(text) {
@@ -321,7 +325,7 @@ impl Embedder {
         // Store in cache
         {
             let mut cache = self.query_cache.lock().unwrap_or_else(|poisoned| {
-                tracing::warn!("Query cache lock poisoned, recovering");
+                tracing::debug!("Query cache lock poisoned, recovering");
                 poisoned.into_inner()
             });
             cache.put(text.to_string(), embedding.clone());

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -244,6 +244,7 @@ impl McpServer {
                 Embedder::new_cpu()?
             });
         }
+        // unwrap is safe: we just set it to Some above if it was None
         Ok(self.embedder.as_mut().unwrap())
     }
 


### PR DESCRIPTION
## Summary

Batch 1 quick wins from 10-category audit:

- **#64**: Replace `unwrap()` with `expect()` for better panic messages (7 locations)
- **#65**: Add SAFETY comments to all unsafe blocks (4 locations)
- **#70**: Change lock poisoning log WARN → DEBUG

## Changes

| File | Changes |
|------|---------|
| `src/cagra.rs` | 5x `lock().unwrap()` → `lock().expect("CAGRA index mutex poisoned")` |
| `src/cli.rs` | Add SAFETY comment to `libc::kill` |
| `src/embedder.rs` | 2x `NonZeroUsize` expect, log level WARN→DEBUG |
| `src/hnsw.rs` | Expand SAFETY comments for Send+Sync, pointer handling |
| `src/mcp.rs` | Add comment explaining unwrap safety |

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] Fresh-eyes review complete

Closes #64, closes #65, partially addresses #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
