### PR TITLE
docs: Update README and CHANGELOG for recent PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--api-key` flag and `CQS_API_KEY` env var for HTTP transport authentication
+  - Required for non-localhost network exposure
+  - Constant-time comparison to prevent timing attacks
+- `--bind` flag to specify listen address (default: 127.0.0.1)
+  - Non-localhost binding requires `--dangerously-allow-network-bind` and `--api-key`
+
+### Changed
+- Migrated from rusqlite to sqlx async SQLite (schema v10)
+- Extracted validation functions for better code discoverability
+  - `validate_api_key`, `validate_origin_header`, `validate_query_length`
+  - `verify_hnsw_checksums` with extension allowlist
+- Replaced `unwrap()` with `expect()` for better panic messages
+- Added SAFETY comments to all unsafe blocks
+
+### Fixed
+- Path traversal vulnerability in HNSW checksum verification
+- Integer overflow in saturating i64→u32 casts for database fields
+
+### Security
+- Updated `bytes` to 1.11.1 (RUSTSEC-2026-0007 integer overflow fix)
+- HNSW checksum verification now validates extensions against allowlist
+
 ## [0.1.17] - 2026-02-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -180,6 +180,26 @@ Endpoints:
 - `GET /mcp` - SSE stream for server-to-client messages
 - `GET /health` - Health check
 
+**Authentication:** For network-exposed servers, API key authentication is required:
+
+```bash
+# Via flag
+cqs serve --transport http --api-key SECRET --project /path/to/project
+
+# Via environment variable
+export CQS_API_KEY=SECRET
+cqs serve --transport http --project /path/to/project
+```
+
+Clients must include `Authorization: Bearer SECRET` header.
+
+**Network binding:** By default, cqs binds to localhost only. To expose on a network:
+
+```bash
+# Requires both flags for safety
+cqs serve --transport http --bind 0.0.0.0 --dangerously-allow-network-bind --api-key SECRET
+```
+
 Implements MCP Streamable HTTP spec 2025-11-25 with Origin validation and protocol version headers.
 
 ## Supported Languages


### PR DESCRIPTION
Update user-facing docs for PRs #58-#71.

## README
- Add \--api-key\ and \CQS_API_KEY\ documentation
- Add \--bind\ and \--dangerously-allow-network-bind\ docs
- Document \Authorization: Bearer\ header requirement

## CHANGELOG
- Add [Unreleased] section for upcoming v0.1.18
- API key auth, bind flags, sqlx migration
- Validation extraction, path traversal fix
- Security fixes (bytes, HNSW checksums)

Generated with [Claude Code](https://claude.com/claude-code)