### PR TITLE
chore: Release v0.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18] - 2026-02-03
+
 ### Added
 - `--api-key` flag and `CQS_API_KEY` env var for HTTP transport authentication
   - Required for non-localhost network exposure
@@ -245,7 +247,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI commands: init, doctor, index, stats, serve
 - Filter by language (`-l`) and path pattern (`-p`)
 
-[Unreleased]: https://github.com/jamie8johnson/cqs/compare/v0.1.17...HEAD
+[Unreleased]: https://github.com/jamie8johnson/cqs/compare/v0.1.18...HEAD
+[0.1.18]: https://github.com/jamie8johnson/cqs/compare/v0.1.17...v0.1.18
 [0.1.17]: https://github.com/jamie8johnson/cqs/compare/v0.1.16...v0.1.17
 [0.1.16]: https://github.com/jamie8johnson/cqs/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/jamie8johnson/cqs/compare/v0.1.14...v0.1.15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 description = "Semantic code search for Claude Code. Find functions by what they do, not their names. Local ML, GPU-accelerated."
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.18
- Update CHANGELOG with release date

## Changes in 0.1.18
- `--api-key` flag and `CQS_API_KEY` env var for HTTP auth
- `--bind` flag for listen address configuration
- Migrated from rusqlite to sqlx async SQLite (schema v10)
- Security: Path traversal fix in HNSW checksum verification
- Security: Updated bytes to 1.11.1 (RUSTSEC-2026-0007)

## Test plan
- [x] `cargo build --release`
- [x] `cargo test`
- [ ] CI passes
- [ ] After merge: `git tag v0.1.18 && git push --tags`
- [ ] After tag: `cargo publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
