### PR TITLE
fix: Use constant-time comparison for API key validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,6 +851,7 @@ dependencies = [
  "serde_json",
  "simsimd",
  "sqlx",
+ "subtle",
  "tempfile",
  "thiserror 2.0.18",
  "tokenizers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ toml = "0.9"
 
 # Utilities
 blake3 = "1"
+subtle = "2"
 bytemuck = { version = "1", features = ["derive"] }
 ignore = "0.4"
 notify = { version = "8", features = ["serde"] }


### PR DESCRIPTION
## Summary

- Fix critical timing attack vulnerability in API key validation
- Replace `.all()` iterator (short-circuits on first byte mismatch) with `subtle::ConstantTimeEq`
- Add comment documenting that length comparison still leaks length (acceptable for API keys)

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes

Fixes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)
