### PR TITLE
fix: Quick wins batch - improve error handling and consistency

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -954,7 +954,7 @@ fn run_index_pipeline(
         pb.set_style(
             ProgressStyle::default_bar()
                 .template("[{elapsed_precise}] {bar:40.cyan/blue} {msg}")
-                .unwrap(),
+                .expect("valid progress bar template"),
         );
         pb
     };

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -552,7 +552,9 @@ fn ensure_ort_provider_libs() {
                 }
             }
             // Remove stale symlink
-            let _ = std::fs::remove_file(&dst);
+            if let Err(e) = std::fs::remove_file(&dst) {
+                tracing::debug!("Failed to remove stale symlink {}: {}", dst.display(), e);
+            }
         }
 
         // Create symlink

--- a/src/store.rs
+++ b/src/store.rs
@@ -1119,8 +1119,8 @@ impl Store {
                     signature: r.get(5),
                     content: r.get(6),
                     doc: r.get(7),
-                    line_start: r.get::<i64, _>(8) as u32,
-                    line_end: r.get::<i64, _>(9) as u32,
+                    line_start: r.get::<i64, _>(8).clamp(0, u32::MAX as i64) as u32,
+                    line_end: r.get::<i64, _>(9).clamp(0, u32::MAX as i64) as u32,
                     parent_id: r.get(10),
                 })
             }))


### PR DESCRIPTION
## Summary

Batch of small improvements from audit findings:

- **cagra.rs**: Return empty results instead of panic on invalid query shape
- **cli.rs**: Replace `unwrap()` with `expect()` for progress bar template
- **embedder.rs**: Add logging when stale symlink removal fails
- **store.rs**: Add `.clamp()` for line numbers in `get_chunk_by_id()` for consistency

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes

Closes #64, #82, #83, #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)
