### PR TITLE
test: Add MCP protocol edge case tests and IPv6 localhost support

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1137,6 +1137,8 @@ fn is_localhost_origin(origin: &str) -> bool {
         "http://127.0.0.1",
         "https://localhost",
         "https://127.0.0.1",
+        "http://[::1]",
+        "https://[::1]",
     ];
 
     for prefix in prefixes {
@@ -1432,6 +1434,27 @@ mod tests {
     fn test_origin_localhost_with_path() {
         let mut headers = HeaderMap::new();
         headers.insert("origin", "http://localhost/api".parse().unwrap());
+        assert!(validate_origin_header(&headers).is_ok());
+    }
+
+    #[test]
+    fn test_origin_ipv6_localhost() {
+        let mut headers = HeaderMap::new();
+        headers.insert("origin", "http://[::1]".parse().unwrap());
+        assert!(validate_origin_header(&headers).is_ok());
+    }
+
+    #[test]
+    fn test_origin_ipv6_localhost_with_port() {
+        let mut headers = HeaderMap::new();
+        headers.insert("origin", "http://[::1]:3000".parse().unwrap());
+        assert!(validate_origin_header(&headers).is_ok());
+    }
+
+    #[test]
+    fn test_origin_ipv6_localhost_https() {
+        let mut headers = HeaderMap::new();
+        headers.insert("origin", "https://[::1]:8443".parse().unwrap());
         assert!(validate_origin_header(&headers).is_ok());
     }
 


### PR DESCRIPTION
## Summary
- Add IPv6 localhost (`[::1]`) support to origin validation
- Add 13 MCP protocol edge case tests

Closes #68

## Changes

**Feature:**
- `is_localhost_origin()` now accepts `http://[::1]` and `https://[::1]`

**New tests:**
- IPv6 localhost origin (3 unit tests)
- Protocol version handling
- String vs numeric request IDs
- Notification handling (null ID)
- Wrong parameter types
- Null/missing arguments
- Empty method
- Query length validation
- Initialize without params
- Search with all optional params

## Test plan
- [x] `cargo test mcp --lib` - 24 tests pass
- [x] `cargo test --test mcp_test` - 22 tests pass
- [x] `cargo test` - 136 total tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
