### PR TITLE
fix: Audit quick wins (#104, #109, #110, #114)

### DIFF
--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -157,7 +157,10 @@ impl CagraIndex {
 
         // Take the index (cuVS search consumes it)
         let index = {
-            let mut guard = self.index.lock().expect("CAGRA index mutex poisoned");
+            let mut guard = self.index.lock().unwrap_or_else(|poisoned| {
+                tracing::warn!("CAGRA index mutex poisoned, recovering");
+                poisoned.into_inner()
+            });
             guard.take()
         };
 
@@ -183,7 +186,10 @@ impl CagraIndex {
             Err(e) => {
                 tracing::error!("Failed to create search params: {}", e);
                 // Put index back
-                let mut guard = self.index.lock().expect("CAGRA index mutex poisoned");
+                let mut guard = self.index.lock().unwrap_or_else(|poisoned| {
+                    tracing::warn!("CAGRA index mutex poisoned, recovering");
+                    poisoned.into_inner()
+                });
                 *guard = Some(index);
                 return Vec::new();
             }
@@ -199,7 +205,10 @@ impl CagraIndex {
                     EMBEDDING_DIM,
                     e
                 );
-                let mut guard = self.index.lock().expect("CAGRA index mutex poisoned");
+                let mut guard = self.index.lock().unwrap_or_else(|poisoned| {
+                    tracing::warn!("CAGRA index mutex poisoned, recovering");
+                    poisoned.into_inner()
+                });
                 *guard = Some(index);
                 return Vec::new();
             }
@@ -210,7 +219,10 @@ impl CagraIndex {
             Ok(t) => t,
             Err(e) => {
                 tracing::error!("Failed to copy query to device: {}", e);
-                let mut guard = self.index.lock().expect("CAGRA index mutex poisoned");
+                let mut guard = self.index.lock().unwrap_or_else(|poisoned| {
+                    tracing::warn!("CAGRA index mutex poisoned, recovering");
+                    poisoned.into_inner()
+                });
                 *guard = Some(index);
                 return Vec::new();
             }
@@ -225,7 +237,10 @@ impl CagraIndex {
                 Ok(t) => t,
                 Err(e) => {
                     tracing::error!("Failed to allocate neighbors on device: {}", e);
-                    let mut guard = self.index.lock().expect("CAGRA index mutex poisoned");
+                    let mut guard = self.index.lock().unwrap_or_else(|poisoned| {
+                        tracing::warn!("CAGRA index mutex poisoned, recovering");
+                        poisoned.into_inner()
+                    });
                     *guard = Some(index);
                     return Vec::new();
                 }
@@ -236,7 +251,10 @@ impl CagraIndex {
                 Ok(t) => t,
                 Err(e) => {
                     tracing::error!("Failed to allocate distances on device: {}", e);
-                    let mut guard = self.index.lock().expect("CAGRA index mutex poisoned");
+                    let mut guard = self.index.lock().unwrap_or_else(|poisoned| {
+                        tracing::warn!("CAGRA index mutex poisoned, recovering");
+                        poisoned.into_inner()
+                    });
                     *guard = Some(index);
                     return Vec::new();
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -526,7 +526,7 @@ impl Parser {
         while let Some(m) = matches.next() {
             for cap in m.captures {
                 let callee_name = source[cap.node.byte_range()].to_string();
-                let line_number = cap.node.start_position().row as u32 + 1 - line_offset + 1;
+                let line_number = cap.node.start_position().row as u32 + 1 - line_offset;
 
                 // Skip common noise (self, this, super, etc.)
                 if !should_skip_callee(&callee_name) {


### PR DESCRIPTION
## Summary

Fixes 4 issues from the 9-category audit (2026-02-04):

- **#104**: Move glob pattern compilation outside filter loops - prevents 10K+ regex compilations per search
- **#109**: Fix off-by-one in call site line numbers - `extract_calls` had extra `+1`
- **#110**: CAGRA mutex uses recoverable pattern - no more cascading panics
- **#114**: Config file parse errors now logged - malformed `.cqs.toml` no longer silently ignored

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes (21 tests)
- [ ] Manual test: `cqs query "test" --path "src/**"` - verify path filtering works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
