### PR TITLE
fix: Batch call graph inserts + add deny.toml (#112, #113)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,66 @@
+# cargo-deny configuration
+# Run: cargo deny check
+# Install: cargo install cargo-deny
+
+[advisories]
+version = 2
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "deny"
+notice = "warn"
+
+# Known unmaintained dependencies we accept (via transitive deps)
+ignore = [
+    # bincode 1.x - via hnsw_rs, mitigated by blake3 checksum verification
+    "RUSTSEC-2025-0141",
+    # derivative - via keyring -> secret-service -> zbus chain (optional feature)
+    "RUSTSEC-2024-0388",
+    # instant - via keyring -> zbus chain (optional feature)
+    "RUSTSEC-2024-0384",
+    # number_prefix - via indicatif (progress bars only)
+    "RUSTSEC-2025-0119",
+    # paste - via tokenizers (upstream dependency)
+    "RUSTSEC-2024-0436",
+]
+
+[licenses]
+version = 2
+# Confidence threshold for detecting license
+confidence-threshold = 0.8
+# List of allowed licenses (SPDX identifiers)
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "Unlicense",
+    "Zlib",
+    "0BSD",
+    "CC0-1.0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "CDLA-Permissive-2.0",
+]
+# Copyleft licenses that require careful consideration
+# copyleft = "warn"
+
+[bans]
+# Lint level for multiple versions of the same crate
+multiple-versions = "warn"
+# Lint level for crates with wildcard dependencies
+wildcards = "warn"
+# Allow-list specific crate duplicates we accept
+# skip = []
+
+[sources]
+# Only allow crates from crates.io
+unknown-registry = "deny"
+unknown-git = "deny"
+# Allow specific git sources if needed
+# allow-git = []

--- a/src/store.rs
+++ b/src/store.rs
@@ -1278,15 +1278,17 @@ impl Store {
                 .execute(&self.pool)
                 .await?;
 
-            for call in calls {
-                sqlx::query(
-                    "INSERT INTO calls (caller_id, callee_name, line_number) VALUES (?1, ?2, ?3)",
-                )
-                .bind(chunk_id)
-                .bind(&call.callee_name)
-                .bind(call.line_number as i64)
-                .execute(&self.pool)
-                .await?;
+            // Batch insert all calls at once (instead of N individual inserts)
+            if !calls.is_empty() {
+                let mut query_builder: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+                    "INSERT INTO calls (caller_id, callee_name, line_number) ",
+                );
+                query_builder.push_values(calls.iter(), |mut b, call| {
+                    b.push_bind(chunk_id)
+                        .push_bind(&call.callee_name)
+                        .push_bind(call.line_number as i64);
+                });
+                query_builder.build().execute(&self.pool).await?;
             }
 
             Ok(())
@@ -1376,20 +1378,29 @@ impl Store {
                 .execute(&self.pool)
                 .await?;
 
-            for fc in function_calls {
-                for call in &fc.calls {
-                    sqlx::query(
-                        "INSERT INTO function_calls (file, caller_name, caller_line, callee_name, call_line)
-                         VALUES (?1, ?2, ?3, ?4, ?5)",
-                    )
-                    .bind(&file_str)
-                    .bind(&fc.name)
-                    .bind(fc.line_start as i64)
-                    .bind(&call.callee_name)
-                    .bind(call.line_number as i64)
-                    .execute(&self.pool)
-                    .await?;
-                }
+            // Flatten all calls and batch insert (instead of N individual inserts)
+            let all_calls: Vec<_> = function_calls
+                .iter()
+                .flat_map(|fc| {
+                    fc.calls.iter().map(move |call| {
+                        (&fc.name, fc.line_start, &call.callee_name, call.line_number)
+                    })
+                })
+                .collect();
+
+            if !all_calls.is_empty() {
+                let mut query_builder: sqlx::QueryBuilder<sqlx::Sqlite> =
+                    sqlx::QueryBuilder::new(
+                        "INSERT INTO function_calls (file, caller_name, caller_line, callee_name, call_line) ",
+                    );
+                query_builder.push_values(all_calls.iter(), |mut b, (caller_name, caller_line, callee_name, call_line)| {
+                    b.push_bind(&file_str)
+                        .push_bind(*caller_name)
+                        .push_bind(*caller_line as i64)
+                        .push_bind(*callee_name)
+                        .push_bind(*call_line as i64);
+                });
+                query_builder.build().execute(&self.pool).await?;
             }
 
             Ok(())


### PR DESCRIPTION
## Summary

Fixes 2 issues from the 9-category audit:

- **#112**: Replace N+1 INSERT pattern with batch inserts using `sqlx::QueryBuilder`
  - `upsert_calls`: Single batch insert instead of N individual inserts
  - `upsert_function_calls`: Flatten nested loops, batch insert all calls at once

- **#113**: Add `deny.toml` for cargo-deny policy enforcement
  - License allowlist (MIT, Apache-2.0, BSD, ISC, etc.)
  - Advisory database checks with documented exceptions for known unmaintained deps
  - Multiple version warnings enabled

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes (21 tests)
- [ ] Manual test: `cqs index` on a codebase - verify call graph still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
