### PR TITLE
fix: Enable concurrent MCP request handling with read locks

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -448,7 +448,7 @@ fn cmd_init(cli: &Cli) -> Result<()> {
         println!("Downloading model (~547MB)...");
     }
 
-    let mut embedder = Embedder::new().context("Failed to initialize embedder")?;
+    let embedder = Embedder::new().context("Failed to initialize embedder")?;
 
     if !cli.quiet {
         println!("Detecting hardware... {}", embedder.provider());
@@ -475,7 +475,7 @@ fn cmd_doctor(_cli: &Cli) -> Result<()> {
 
     // Check model
     match Embedder::new() {
-        Ok(mut embedder) => {
+        Ok(embedder) => {
             println!("  {} Model: intfloat/e5-base-v2", "[✓]".green());
             println!("  {} Tokenizer: loaded", "[✓]".green());
             println!("  {} Execution: {}", "[✓]".green(), embedder.provider());
@@ -738,7 +738,7 @@ fn run_index_pipeline(
 
     // Stage 2a: GPU Embedder thread - embed chunks, requeue failures to CPU
     let gpu_embedder_handle = thread::spawn(move || -> Result<()> {
-        let mut embedder = Embedder::new()?;
+        let embedder = Embedder::new()?;
         embedder.warm()?;
         let store = Store::open(&store_path_for_embedder)?;
 
@@ -855,7 +855,7 @@ fn run_index_pipeline(
 
     // Stage 2b: CPU Embedder thread - handles failures + overflow (GPU gets priority)
     let cpu_embedder_handle = thread::spawn(move || -> Result<()> {
-        let mut embedder = Embedder::new_cpu()?;
+        let embedder = Embedder::new_cpu()?;
         let store = Store::open(&store_path_for_cpu)?;
 
         loop {
@@ -1153,7 +1153,7 @@ fn cmd_index(cli: &Cli, force: bool, dry_run: bool, no_ignore: bool) -> Result<(
                     Ok(notes) => {
                         if !notes.is_empty() {
                             // Embed note content with sentiment
-                            let mut embedder = Embedder::new()?;
+                            let embedder = Embedder::new()?;
                             let texts: Vec<String> =
                                 notes.iter().map(|n| n.embedding_text()).collect();
                             let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
@@ -1234,7 +1234,7 @@ fn cmd_query(cli: &Cli, query: &str) -> Result<()> {
     }
 
     let store = Store::open(&index_path)?;
-    let mut embedder = Embedder::new()?;
+    let embedder = Embedder::new()?;
 
     let query_embedding = embedder.embed_query(query)?;
 
@@ -1650,7 +1650,7 @@ fn reindex_files(
     _no_ignore: bool,
     quiet: bool,
 ) -> Result<usize> {
-    let mut embedder = Embedder::new()?;
+    let embedder = Embedder::new()?;
     let store = Store::open(index_path)?;
 
     // Parse the changed files
@@ -1726,7 +1726,7 @@ fn reindex_notes(root: &Path, index_path: &Path, quiet: bool) -> Result<usize> {
         return Ok(0);
     }
 
-    let mut embedder = Embedder::new()?;
+    let embedder = Embedder::new()?;
     let store = Store::open(index_path)?;
 
     // Embed note content with sentiment prefix

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -288,13 +288,13 @@ impl Embedder {
     }
 
     /// Embed documents (code chunks). Adds "passage: " prefix for E5.
-    pub fn embed_documents(&mut self, texts: &[&str]) -> Result<Vec<Embedding>, EmbedderError> {
+    pub fn embed_documents(&self, texts: &[&str]) -> Result<Vec<Embedding>, EmbedderError> {
         let prefixed: Vec<String> = texts.iter().map(|t| format!("passage: {}", t)).collect();
         self.embed_batch(&prefixed)
     }
 
     /// Embed a query. Adds "query: " prefix for E5. Uses LRU cache for repeated queries.
-    pub fn embed_query(&mut self, text: &str) -> Result<Embedding, EmbedderError> {
+    pub fn embed_query(&self, text: &str) -> Result<Embedding, EmbedderError> {
         let text = text.trim();
         if text.is_empty() {
             return Err(EmbedderError::EmptyQuery);
@@ -345,12 +345,12 @@ impl Embedder {
     }
 
     /// Warm up the model with a dummy inference
-    pub fn warm(&mut self) -> Result<(), EmbedderError> {
+    pub fn warm(&self) -> Result<(), EmbedderError> {
         let _ = self.embed_query("warmup")?;
         Ok(())
     }
 
-    fn embed_batch(&mut self, texts: &[String]) -> Result<Vec<Embedding>, EmbedderError> {
+    fn embed_batch(&self, texts: &[String]) -> Result<Vec<Embedding>, EmbedderError> {
         use ort::value::Tensor;
 
         let _span = tracing::info_span!("embed_batch", count = texts.len()).entered();


### PR DESCRIPTION
## Summary

Fixes #121: MCP server was serializing all requests with a write lock, causing 10x latency for concurrent searches.

**BREAKING CHANGE:** Embedder methods now take `&self` instead of `&mut self`. This is a better API anyway since Embedder already uses interior mutability (Mutex for session, OnceLock for lazy init).

## Changes

### MCP Server (`src/mcp.rs`)
- `McpServer.embedder`: `Option<Embedder>` → `OnceLock<Embedder>`
- `McpServer.audit_mode`: `AuditMode` → `Mutex<AuditMode>`
- `ensure_embedder(&mut self)` → `ensure_embedder(&self)`
- `handle_request(&mut self)` → `handle_request(&self)`
- HTTP handler: `state.server.write()` → `state.server.read()`

### Embedder (`src/embedder.rs`)
- `embed_query(&mut self)` → `embed_query(&self)`
- `embed_documents(&mut self)` → `embed_documents(&self)`
- `embed_batch(&mut self)` → `embed_batch(&self)`
- `warm(&mut self)` → `warm(&self)`

## Impact

Before: All MCP requests serialized (10 concurrent searches = 10x latency)
After: Concurrent read operations run in parallel

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [ ] Manual: Start MCP server, send concurrent search requests

