### PR TITLE
test: Add error path tests for config and MCP tools

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -56,3 +56,129 @@ impl Config {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_load_valid_config() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join(".cqs.toml");
+
+        std::fs::write(
+            &config_path,
+            r#"
+            limit = 10
+            threshold = 0.5
+            name_boost = 0.3
+            quiet = true
+            "#,
+        )
+        .unwrap();
+
+        let config = Config::load_file(&config_path).unwrap();
+        assert_eq!(config.limit, Some(10));
+        assert_eq!(config.threshold, Some(0.5));
+        assert_eq!(config.name_boost, Some(0.3));
+        assert_eq!(config.quiet, Some(true));
+        assert_eq!(config.verbose, None);
+    }
+
+    #[test]
+    fn test_load_partial_config() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join(".cqs.toml");
+
+        std::fs::write(&config_path, "limit = 5\n").unwrap();
+
+        let config = Config::load_file(&config_path).unwrap();
+        assert_eq!(config.limit, Some(5));
+        assert_eq!(config.threshold, None);
+    }
+
+    #[test]
+    fn test_load_empty_config() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join(".cqs.toml");
+
+        std::fs::write(&config_path, "").unwrap();
+
+        let config = Config::load_file(&config_path).unwrap();
+        assert_eq!(config.limit, None);
+    }
+
+    #[test]
+    fn test_load_missing_file() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join("nonexistent.toml");
+
+        let config = Config::load_file(&config_path);
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn test_load_malformed_toml() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join(".cqs.toml");
+
+        std::fs::write(&config_path, "this is not valid toml [[[").unwrap();
+
+        let config = Config::load_file(&config_path);
+        assert!(config.is_none()); // Silently returns None for invalid TOML
+    }
+
+    #[test]
+    fn test_load_wrong_types() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join(".cqs.toml");
+
+        // limit should be usize, not string
+        std::fs::write(&config_path, "limit = \"not a number\"\n").unwrap();
+
+        let config = Config::load_file(&config_path);
+        assert!(config.is_none()); // Type mismatch returns None
+    }
+
+    #[test]
+    fn test_merge_override() {
+        let base = Config {
+            limit: Some(10),
+            threshold: Some(0.5),
+            name_boost: None,
+            quiet: Some(false),
+            verbose: None,
+        };
+
+        let override_config = Config {
+            limit: Some(20),
+            threshold: None,
+            name_boost: Some(0.3),
+            quiet: None,
+            verbose: Some(true),
+        };
+
+        let merged = base.merge(override_config);
+        assert_eq!(merged.limit, Some(20)); // overridden
+        assert_eq!(merged.threshold, Some(0.5)); // kept from base
+        assert_eq!(merged.name_boost, Some(0.3)); // new from override
+        assert_eq!(merged.quiet, Some(false)); // kept from base
+        assert_eq!(merged.verbose, Some(true)); // new from override
+    }
+
+    #[test]
+    fn test_load_project_overrides_user() {
+        let dir = TempDir::new().unwrap();
+        let project_config = dir.path().join(".cqs.toml");
+
+        std::fs::write(&project_config, "limit = 15\nquiet = true\n").unwrap();
+
+        // Load from project root (user config may not exist)
+        let config = Config::load(dir.path());
+
+        // Project config should be loaded
+        assert_eq!(config.limit, Some(15));
+        assert_eq!(config.quiet, Some(true));
+    }
+}


### PR DESCRIPTION
## Summary

Partially addresses #126: Add error path test coverage for config and MCP tools.

## Changes

### Config tests (8 new tests in `src/config.rs`)
- `test_load_valid_config` - full config parsing
- `test_load_partial_config` - subset of fields
- `test_load_empty_config` - empty file
- `test_load_missing_file` - nonexistent file
- `test_load_malformed_toml` - invalid syntax
- `test_load_wrong_types` - type mismatch
- `test_merge_override` - config merge behavior
- `test_load_project_overrides_user` - precedence

### MCP error tests (10 new tests in `tests/mcp_test.rs`)
- `test_cqs_add_note_missing_text` - required field
- `test_cqs_add_note_empty_text` - validation
- `test_cqs_add_note_text_too_long` - length limit
- `test_cqs_audit_mode_invalid_duration` - parse error
- `test_cqs_audit_mode_query_state` - query mode
- `test_cqs_callers_missing_name` - required field
- `test_cqs_callees_missing_name` - required field
- `test_cqs_search_empty_query` - validation
- `test_cqs_search_missing_query` - required field
- `test_cqs_read_missing_path` - required field

## Test plan
- [x] `cargo test` - all 32 MCP tests + 8 config tests pass

