### PR TITLE
chore: Change lock poisoning recovery logs to DEBUG

### DIFF
--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -168,14 +168,14 @@ impl CagraIndex {
 
         // Lock resources for the entire search operation (CUDA contexts aren't thread-safe)
         let resources = self.resources.lock().unwrap_or_else(|poisoned| {
-            tracing::warn!("CAGRA resources mutex poisoned, recovering");
+            tracing::debug!("CAGRA resources mutex poisoned, recovering");
             poisoned.into_inner()
         });
 
         // Take the index (cuVS search consumes it)
         let index = {
             let mut guard = self.index.lock().unwrap_or_else(|poisoned| {
-                tracing::warn!("CAGRA index mutex poisoned, recovering");
+                tracing::debug!("CAGRA index mutex poisoned, recovering");
                 poisoned.into_inner()
             });
             guard.take()
@@ -204,7 +204,7 @@ impl CagraIndex {
                 tracing::error!("Failed to create search params: {}", e);
                 // Put index back
                 let mut guard = self.index.lock().unwrap_or_else(|poisoned| {
-                    tracing::warn!("CAGRA index mutex poisoned, recovering");
+                    tracing::debug!("CAGRA index mutex poisoned, recovering");
                     poisoned.into_inner()
                 });
                 *guard = Some(index);
@@ -223,7 +223,7 @@ impl CagraIndex {
                     e
                 );
                 let mut guard = self.index.lock().unwrap_or_else(|poisoned| {
-                    tracing::warn!("CAGRA index mutex poisoned, recovering");
+                    tracing::debug!("CAGRA index mutex poisoned, recovering");
                     poisoned.into_inner()
                 });
                 *guard = Some(index);
@@ -237,7 +237,7 @@ impl CagraIndex {
             Err(e) => {
                 tracing::error!("Failed to copy query to device: {}", e);
                 let mut guard = self.index.lock().unwrap_or_else(|poisoned| {
-                    tracing::warn!("CAGRA index mutex poisoned, recovering");
+                    tracing::debug!("CAGRA index mutex poisoned, recovering");
                     poisoned.into_inner()
                 });
                 *guard = Some(index);
@@ -255,7 +255,7 @@ impl CagraIndex {
                 Err(e) => {
                     tracing::error!("Failed to allocate neighbors on device: {}", e);
                     let mut guard = self.index.lock().unwrap_or_else(|poisoned| {
-                        tracing::warn!("CAGRA index mutex poisoned, recovering");
+                        tracing::debug!("CAGRA index mutex poisoned, recovering");
                         poisoned.into_inner()
                     });
                     *guard = Some(index);
@@ -269,7 +269,7 @@ impl CagraIndex {
                 Err(e) => {
                     tracing::error!("Failed to allocate distances on device: {}", e);
                     let mut guard = self.index.lock().unwrap_or_else(|poisoned| {
-                        tracing::warn!("CAGRA index mutex poisoned, recovering");
+                        tracing::debug!("CAGRA index mutex poisoned, recovering");
                         poisoned.into_inner()
                     });
                     *guard = Some(index);

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1463,7 +1463,7 @@ async fn handle_mcp_post(
         let server = match state.server.read() {
             Ok(s) => s,
             Err(poisoned) => {
-                tracing::warn!("Server lock poisoned, recovering");
+                tracing::debug!("Server lock poisoned, recovering");
                 poisoned.into_inner()
             }
         };


### PR DESCRIPTION
## Summary

Addresses logging item from #70:

- Change lock poisoning recovery log from WARN to DEBUG (expected in tests)
  - `mcp.rs`: Server lock poisoned
  - `cagra.rs`: CAGRA resources/index mutex poisoned (7 occurrences)

Lock poisoning recovery is expected behavior when tests panic - logging at WARN creates noise.

## Remaining #70 items

- [ ] Add doc comments to internal helper functions
- [ ] Document embedding dimension (769) - already done in embedder.rs
- [ ] Add structured fields to more tracing calls
- [ ] Move hardcoded model names in tests to constants
- [ ] Add test helper for creating temp indexed directories
- [ ] Consistent error message capitalization
- [ ] Remove commented-out code if any remains

## Test plan

- [x] `cargo build` - compiles cleanly
- [x] `cargo test` - all tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)
