### PR TITLE
chore: Use MODEL_NAME constant in doctor command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -476,7 +476,7 @@ fn cmd_doctor(_cli: &Cli) -> Result<()> {
     // Check model
     match Embedder::new() {
         Ok(embedder) => {
-            println!("  {} Model: intfloat/e5-base-v2", "[✓]".green());
+            println!("  {} Model: {}", "[✓]".green(), cqs::store::MODEL_NAME);
             println!("  {} Tokenizer: loaded", "[✓]".green());
             println!("  {} Execution: {}", "[✓]".green(), embedder.provider());
 


### PR DESCRIPTION
Part of #70. Replaces hardcoded model name with the constant from store/helpers.rs.