### PR TITLE
docs: Add doc comments and test helper (#70)

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,58 +2,44 @@
 
 ## Right Now
 
-**Store Refactor Complete** (2026-02-04)
+**#70 Low Priority Items Complete** (2026-02-04)
 
-Issue #125 implemented. Pending PR.
+All cleanup items finished. Ready to close #70.
 
 ## Session Summary
 
-### Completed This Session
-- #125: Store god object refactor (1,916 lines → 6 files, largest 531)
+### Merged This Session
+- #133: Store god object refactor (#125 closed)
+- #134: CHANGELOG update
+- #135: Lock poisoning DEBUG logs (#70)
+- #136: MODEL_NAME constant (#70)
 
-### Merged PRs (Previous)
-- #132: embedder.rs + cli.rs unit tests (#62)
-- #128: MCP concurrency (CRITICAL)
-- #115-#120: First audit batch
-- #131: name_match_score + config tests
+### Pending
+- #137 (branch: chore/cleanup-70-final): Doc comments + test helper
 
-### Open Issues (8)
+## #70 All Items Complete
+
+- [x] Add doc comments to internal helpers (CLI commands)
+- [x] Add structured tracing fields (already good)
+- [x] Add temp directory test helper (tests/common/mod.rs)
+- [x] Consistent error capitalization (verified)
+- [x] Move hardcoded model names to constants
+- [x] Remove commented-out code (none found)
+- [x] Lock poisoning logs to DEBUG
+
+## Open Issues (6)
+
 | Issue | Description | Status |
 |-------|-------------|--------|
 | #130 | Tracking | Keep |
 | #126 | Error tests | Partial |
-| #125 | Store refactor | **DONE** |
 | #107 | Memory | v0.3.0 |
 | #106 | ort stable | External |
 | #103 | O(n) notes | v0.3.0 |
-| #70 | Cleanup | Low |
 | #63 | paste dep | External |
-
-## Store Refactor (#125)
-
-Split `src/store.rs` (1,916 lines) into:
-```
-src/store/
-  mod.rs       468 lines  (Store struct, open/init, FTS, RRF)
-  chunks.rs    352 lines  (chunk CRUD)
-  notes.rs     197 lines  (note CRUD)
-  calls.rs     220 lines  (call graph)
-  helpers.rs   245 lines  (types, embedding conversion)
-src/search.rs  531 lines  (search algorithms, scoring)
-```
-
-Largest file: 531 lines (down from 1,916, 3.6x reduction)
 
 ## Architecture
 
-- 769-dim embeddings (768 model + 1 sentiment)
-- CAGRA (GPU) > HNSW (CPU)
+- 769-dim embeddings (768 + sentiment)
+- Store: split into focused modules (6 files)
 - Schema v10, WAL mode
-- MCP: interior mutability
-- Store: split into focused modules
-
-## Next
-
-1. Create PR for #125
-2. CHANGELOG
-3. v0.3.0: memory (#107), notes HNSW (#103)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,91 @@
+//! Common test fixtures and helpers
+//!
+//! Usage in test files:
+//! ```ignore
+//! mod common;
+//! use common::TestStore;
+//! ```
+
+use cqs::embedder::Embedding;
+use cqs::parser::{Chunk, ChunkType, Language};
+use cqs::store::{ModelInfo, Store};
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// Test store with automatic cleanup
+///
+/// Wraps a `Store` with its backing `TempDir`, ensuring the directory
+/// lives as long as the store is in use.
+pub struct TestStore {
+    /// The store instance
+    pub store: Store,
+    /// Temp directory (kept alive to prevent cleanup)
+    _dir: TempDir,
+}
+
+impl TestStore {
+    /// Create an initialized test store in a temporary directory
+    pub fn new() -> Self {
+        let dir = TempDir::new().expect("Failed to create temp dir");
+        let db_path = dir.path().join("index.db");
+        let store = Store::open(&db_path).expect("Failed to open store");
+        store.init(&ModelInfo::default()).expect("Failed to init store");
+        Self { store, _dir: dir }
+    }
+
+    /// Create a test store with custom model info
+    pub fn with_model(model: &ModelInfo) -> Self {
+        let dir = TempDir::new().expect("Failed to create temp dir");
+        let db_path = dir.path().join("index.db");
+        let store = Store::open(&db_path).expect("Failed to open store");
+        store.init(model).expect("Failed to init store");
+        Self { store, _dir: dir }
+    }
+}
+
+impl std::ops::Deref for TestStore {
+    type Target = Store;
+
+    fn deref(&self) -> &Self::Target {
+        &self.store
+    }
+}
+
+/// Create a test chunk with sensible defaults
+pub fn test_chunk(name: &str, content: &str) -> Chunk {
+    let hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+    Chunk {
+        id: format!("test.rs:1:{}", &hash[..8]),
+        file: PathBuf::from("test.rs"),
+        language: Language::Rust,
+        chunk_type: ChunkType::Function,
+        name: name.to_string(),
+        signature: format!("fn {}()", name),
+        content: content.to_string(),
+        doc: None,
+        line_start: 1,
+        line_end: 5,
+        content_hash: hash,
+        parent_id: None,
+        window_idx: None,
+    }
+}
+
+/// Create a mock 769-dim embedding (768 model + 1 sentiment)
+///
+/// The seed value determines the direction of the embedding vector.
+/// Same seed = same direction = high similarity.
+/// Different seeds = different directions = lower similarity.
+pub fn mock_embedding(seed: f32) -> Embedding {
+    let mut v = vec![seed; 768];
+    // Normalize to unit length
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in &mut v {
+            *x /= norm;
+        }
+    }
+    // Add sentiment dimension (769th)
+    v.push(0.0);
+    Embedding::new(v)
+}


### PR DESCRIPTION
## Summary
- Add doc comments to internal CLI command functions (cmd_init, cmd_doctor, etc.)
- Create `tests/common/mod.rs` test helper module with `TestStore`, `test_chunk()`, and `mock_embedding()`
- Complete all remaining items from #70

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (162 tests)
- [x] Doc comments visible on internal functions

Closes #70

---
Generated with [Claude Code](https://claude.com/claude-code)
