### PR TITLE
chore: Housekeeping cleanup

### DIFF
--- a/examples/bench_embed.rs
+++ b/examples/bench_embed.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 fn main() {
     println!("Initializing embedder...");
     let start = Instant::now();
-    let mut embedder = Embedder::new().unwrap();
+    let embedder = Embedder::new().unwrap();
     println!("Init: {:?}", start.elapsed());
     println!("Provider: {}", embedder.provider());
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -29,7 +29,9 @@ impl TestStore {
         let dir = TempDir::new().expect("Failed to create temp dir");
         let db_path = dir.path().join("index.db");
         let store = Store::open(&db_path).expect("Failed to open store");
-        store.init(&ModelInfo::default()).expect("Failed to init store");
+        store
+            .init(&ModelInfo::default())
+            .expect("Failed to init store");
         Self { store, _dir: dir }
     }
 

--- a/tests/eval_test.rs
+++ b/tests/eval_test.rs
@@ -299,7 +299,7 @@ fn fixture_path(lang: Language) -> PathBuf {
 fn test_recall_at_5() {
     // Initialize embedder
     eprintln!("Initializing embedder...");
-    let mut embedder = Embedder::new().expect("Failed to initialize embedder");
+    let embedder = Embedder::new().expect("Failed to initialize embedder");
 
     // Initialize parser
     let parser = Parser::new().expect("Failed to initialize parser");

--- a/tests/mcp_test.rs
+++ b/tests/mcp_test.rs
@@ -42,7 +42,7 @@ fn make_request(method: &str, params: Option<Value>) -> JsonRpcRequest {
 
 #[test]
 fn test_initialize() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     let request = make_request(
         "initialize",
@@ -74,7 +74,7 @@ fn test_initialize() {
 
 #[test]
 fn test_tools_list() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     let request = make_request("tools/list", None);
     let response = server.handle_request(request);
@@ -101,7 +101,7 @@ fn test_tools_list() {
 
 #[test]
 fn test_tools_call_stats() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     let request = make_request(
         "tools/call",
@@ -136,7 +136,7 @@ fn test_tools_call_stats() {
 
 #[test]
 fn test_unknown_method() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     let request = make_request("unknown/method", None);
     let response = server.handle_request(request);
@@ -149,7 +149,7 @@ fn test_unknown_method() {
 
 #[test]
 fn test_tools_call_unknown_tool() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     let request = make_request(
         "tools/call",
@@ -168,7 +168,7 @@ fn test_tools_call_unknown_tool() {
 
 #[test]
 fn test_tools_call_missing_params() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     let request = make_request("tools/call", None);
     let response = server.handle_request(request);
@@ -180,7 +180,7 @@ fn test_tools_call_missing_params() {
 
 #[test]
 fn test_initialized_notification() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     // initialized is a notification, should return null
     let request = make_request("initialized", None);
@@ -192,7 +192,7 @@ fn test_initialized_notification() {
 
 #[test]
 fn test_response_has_id() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     let request = JsonRpcRequest {
         jsonrpc: "2.0".into(),
@@ -209,7 +209,7 @@ fn test_response_has_id() {
 
 #[test]
 fn test_cqs_read_valid_file() {
-    let (dir, mut server) = setup_test_server();
+    let (dir, server) = setup_test_server();
 
     // Create a test file
     let test_file = dir.path().join("test.rs");
@@ -237,7 +237,7 @@ fn test_cqs_read_valid_file() {
 
 #[test]
 fn test_cqs_read_path_traversal_blocked() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     // Try to read /etc/passwd via path traversal
     let request = make_request(
@@ -262,7 +262,7 @@ fn test_cqs_read_path_traversal_blocked() {
 
 #[test]
 fn test_cqs_read_file_not_found() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     let request = make_request(
         "tools/call",
@@ -281,7 +281,7 @@ fn test_cqs_read_file_not_found() {
 
 #[test]
 fn test_cqs_read_with_notes() {
-    let (dir, mut server) = setup_test_server();
+    let (dir, server) = setup_test_server();
 
     // Create docs directory and notes.toml
     let docs_dir = dir.path().join("docs");
@@ -328,7 +328,7 @@ mentions = ["test.rs"]
 
 #[test]
 fn test_initialize_with_old_protocol_version() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     // Use an older protocol version - server should accept and respond with its version
     let request = make_request(
@@ -351,7 +351,7 @@ fn test_initialize_with_old_protocol_version() {
 
 #[test]
 fn test_string_request_id() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     let request = JsonRpcRequest {
         jsonrpc: "2.0".into(),
@@ -368,7 +368,7 @@ fn test_string_request_id() {
 
 #[test]
 fn test_null_request_id_notification() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     // Null ID is valid for notifications
     let request = JsonRpcRequest {
@@ -386,7 +386,7 @@ fn test_null_request_id_notification() {
 
 #[test]
 fn test_tools_call_wrong_param_type() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     // Pass a string for arguments instead of object
     let request = make_request(
@@ -406,7 +406,7 @@ fn test_tools_call_wrong_param_type() {
 
 #[test]
 fn test_tools_call_null_arguments() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     // Null arguments should be treated as empty object
     let request = make_request(
@@ -429,7 +429,7 @@ fn test_tools_call_null_arguments() {
 
 #[test]
 fn test_tools_call_missing_name() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     // Missing required "name" field
     let request = make_request(
@@ -453,7 +453,7 @@ fn test_tools_call_missing_name() {
 
 #[test]
 fn test_empty_method() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     let request = make_request("", None);
     let response = server.handle_request(request);
@@ -463,7 +463,7 @@ fn test_empty_method() {
 
 #[test]
 fn test_very_long_query_rejected() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     // Create a query longer than MAX_QUERY_LENGTH (10000 bytes)
     let long_query = "a".repeat(15000);
@@ -490,7 +490,7 @@ fn test_very_long_query_rejected() {
 
 #[test]
 fn test_initialize_without_params() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     // Initialize with no params - should use defaults
     let request = make_request("initialize", None);
@@ -503,7 +503,7 @@ fn test_initialize_without_params() {
 
 #[test]
 fn test_cqs_search_with_all_optional_params() {
-    let (_dir, mut server) = setup_test_server();
+    let (_dir, server) = setup_test_server();
 
     let request = make_request(
         "tools/call",

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -1,56 +1,16 @@
 //! Store tests
 
-use cqs::embedder::Embedding;
-use cqs::parser::{Chunk, ChunkType, Language};
-use cqs::store::{normalize_for_fts, ModelInfo, SearchFilter, Store};
+mod common;
+
+use common::{mock_embedding, test_chunk, TestStore};
+use cqs::parser::{ChunkType, Language};
+use cqs::store::{normalize_for_fts, SearchFilter};
 use std::collections::HashSet;
 use std::path::PathBuf;
-use tempfile::TempDir;
-
-fn create_test_chunk(name: &str, content: &str) -> Chunk {
-    Chunk {
-        id: format!(
-            "test.rs:1:{}",
-            &blake3::hash(content.as_bytes()).to_hex()[..8]
-        ),
-        file: PathBuf::from("test.rs"),
-        language: Language::Rust,
-        chunk_type: ChunkType::Function,
-        name: name.to_string(),
-        signature: format!("fn {}()", name),
-        content: content.to_string(),
-        doc: None,
-        line_start: 1,
-        line_end: 5,
-        content_hash: blake3::hash(content.as_bytes()).to_hex().to_string(),
-        parent_id: None,
-        window_idx: None,
-    }
-}
-
-fn create_mock_embedding(seed: f32) -> Embedding {
-    // Create a simple mock embedding (not L2 normalized, but good enough for testing)
-    // 769 dims = 768 model + 1 sentiment
-    let mut v = vec![seed; 768];
-    // Normalize
-    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
-    if norm > 0.0 {
-        for x in &mut v {
-            *x /= norm;
-        }
-    }
-    // Add sentiment dimension (769th)
-    v.push(0.0);
-    Embedding::new(v)
-}
 
 #[test]
 fn test_store_init() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("index.db");
-
-    let store = Store::open(&db_path).unwrap();
-    store.init(&ModelInfo::default()).unwrap();
+    let store = TestStore::new();
 
     // Stats should show empty index
     let stats = store.stats().unwrap();
@@ -62,15 +22,11 @@ fn test_store_init() {
 
 #[test]
 fn test_upsert_and_search() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("index.db");
-
-    let store = Store::open(&db_path).unwrap();
-    store.init(&ModelInfo::default()).unwrap();
+    let store = TestStore::new();
 
     // Insert a chunk
-    let chunk = create_test_chunk("add", "fn add(a: i32, b: i32) -> i32 { a + b }");
-    let embedding = create_mock_embedding(1.0);
+    let chunk = test_chunk("add", "fn add(a: i32, b: i32) -> i32 { a + b }");
+    let embedding = mock_embedding(1.0);
     store.upsert_chunk(&chunk, &embedding, Some(12345)).unwrap();
 
     // Search should find it
@@ -85,25 +41,21 @@ fn test_upsert_and_search() {
 
 #[test]
 fn test_search_with_threshold() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("index.db");
-
-    let store = Store::open(&db_path).unwrap();
-    store.init(&ModelInfo::default()).unwrap();
+    let store = TestStore::new();
 
     // Insert chunks with different embeddings
-    let chunk1 = create_test_chunk("add", "fn add(a, b) { a + b }");
-    let chunk2 = create_test_chunk("subtract", "fn subtract(a, b) { a - b }");
+    let chunk1 = test_chunk("add", "fn add(a, b) { a + b }");
+    let chunk2 = test_chunk("subtract", "fn subtract(a, b) { a - b }");
 
     store
-        .upsert_chunk(&chunk1, &create_mock_embedding(1.0), Some(12345))
+        .upsert_chunk(&chunk1, &mock_embedding(1.0), Some(12345))
         .unwrap();
     store
-        .upsert_chunk(&chunk2, &create_mock_embedding(-1.0), Some(12345))
+        .upsert_chunk(&chunk2, &mock_embedding(-1.0), Some(12345))
         .unwrap();
 
     // Search with query similar to chunk1
-    let query = create_mock_embedding(0.9);
+    let query = mock_embedding(0.9);
     let results = store.search(&query, 5, 0.5).unwrap();
 
     // Should find chunk1 (similar) but not chunk2 (dissimilar)
@@ -112,21 +64,17 @@ fn test_search_with_threshold() {
 
 #[test]
 fn test_search_limit() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("index.db");
-
-    let store = Store::open(&db_path).unwrap();
-    store.init(&ModelInfo::default()).unwrap();
+    let store = TestStore::new();
 
     // Insert multiple chunks
     for i in 0..10 {
-        let chunk = create_test_chunk(&format!("fn{}", i), &format!("fn fn{}() {{}}", i));
-        let emb = create_mock_embedding(1.0 + i as f32 * 0.01);
+        let chunk = test_chunk(&format!("fn{}", i), &format!("fn fn{}() {{}}", i));
+        let emb = mock_embedding(1.0 + i as f32 * 0.01);
         store.upsert_chunk(&chunk, &emb, Some(12345)).unwrap();
     }
 
     // Search with limit
-    let query = create_mock_embedding(1.0);
+    let query = mock_embedding(1.0);
     let results = store.search(&query, 3, 0.0).unwrap();
 
     assert_eq!(results.len(), 3);
@@ -134,24 +82,20 @@ fn test_search_limit() {
 
 #[test]
 fn test_search_filtered_by_language() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("index.db");
-
-    let store = Store::open(&db_path).unwrap();
-    store.init(&ModelInfo::default()).unwrap();
+    let store = TestStore::new();
 
     // Insert Rust chunk
-    let rust_chunk = create_test_chunk("rust_fn", "fn rust_fn() {}");
+    let rust_chunk = test_chunk("rust_fn", "fn rust_fn() {}");
     store
-        .upsert_chunk(&rust_chunk, &create_mock_embedding(1.0), Some(12345))
+        .upsert_chunk(&rust_chunk, &mock_embedding(1.0), Some(12345))
         .unwrap();
 
     // Insert Python chunk
-    let mut py_chunk = create_test_chunk("py_fn", "def py_fn(): pass");
+    let mut py_chunk = test_chunk("py_fn", "def py_fn(): pass");
     py_chunk.language = Language::Python;
     py_chunk.file = PathBuf::from("test.py");
     store
-        .upsert_chunk(&py_chunk, &create_mock_embedding(1.0), Some(12345))
+        .upsert_chunk(&py_chunk, &mock_embedding(1.0), Some(12345))
         .unwrap();
 
     // Search for Rust only
@@ -161,7 +105,7 @@ fn test_search_filtered_by_language() {
         ..Default::default()
     };
     let results = store
-        .search_filtered(&create_mock_embedding(1.0), &filter, 10, 0.0)
+        .search_filtered(&mock_embedding(1.0), &filter, 10, 0.0)
         .unwrap();
 
     assert_eq!(results.len(), 1);
@@ -170,23 +114,19 @@ fn test_search_filtered_by_language() {
 
 #[test]
 fn test_prune_missing() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("index.db");
-
-    let store = Store::open(&db_path).unwrap();
-    store.init(&ModelInfo::default()).unwrap();
+    let store = TestStore::new();
 
     // Insert chunks from two files
-    let chunk1 = create_test_chunk("fn1", "fn fn1() {}");
-    let mut chunk2 = create_test_chunk("fn2", "fn fn2() {}");
+    let chunk1 = test_chunk("fn1", "fn fn1() {}");
+    let mut chunk2 = test_chunk("fn2", "fn fn2() {}");
     chunk2.file = PathBuf::from("other.rs");
     chunk2.id = format!("other.rs:1:{}", &chunk2.content_hash[..8]);
 
     store
-        .upsert_chunk(&chunk1, &create_mock_embedding(1.0), Some(12345))
+        .upsert_chunk(&chunk1, &mock_embedding(1.0), Some(12345))
         .unwrap();
     store
-        .upsert_chunk(&chunk2, &create_mock_embedding(1.0), Some(12345))
+        .upsert_chunk(&chunk2, &mock_embedding(1.0), Some(12345))
         .unwrap();
 
     // Prune with only test.rs existing
@@ -196,22 +136,18 @@ fn test_prune_missing() {
     assert_eq!(pruned, 1);
 
     // Only chunk1 should remain
-    let results = store.search(&create_mock_embedding(1.0), 10, 0.0).unwrap();
+    let results = store.search(&mock_embedding(1.0), 10, 0.0).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].chunk.name, "fn1");
 }
 
 #[test]
 fn test_get_by_content_hash() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("index.db");
-
-    let store = Store::open(&db_path).unwrap();
-    store.init(&ModelInfo::default()).unwrap();
+    let store = TestStore::new();
 
     let content = "fn test() { 42 }";
-    let chunk = create_test_chunk("test", content);
-    let embedding = create_mock_embedding(0.5);
+    let chunk = test_chunk("test", content);
+    let embedding = mock_embedding(0.5);
     store.upsert_chunk(&chunk, &embedding, Some(12345)).unwrap();
 
     // Should find embedding by content hash
@@ -225,17 +161,13 @@ fn test_get_by_content_hash() {
 
 #[test]
 fn test_get_embeddings_by_hashes() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("index.db");
-
-    let store = Store::open(&db_path).unwrap();
-    store.init(&ModelInfo::default()).unwrap();
+    let store = TestStore::new();
 
     // Insert two chunks with different content
-    let chunk1 = create_test_chunk("fn1", "fn fn1() { 1 }");
-    let chunk2 = create_test_chunk("fn2", "fn fn2() { 2 }");
-    let emb1 = create_mock_embedding(0.1);
-    let emb2 = create_mock_embedding(0.2);
+    let chunk1 = test_chunk("fn1", "fn fn1() { 1 }");
+    let chunk2 = test_chunk("fn2", "fn fn2() { 2 }");
+    let emb1 = mock_embedding(0.1);
+    let emb2 = mock_embedding(0.2);
 
     store.upsert_chunk(&chunk1, &emb1, Some(12345)).unwrap();
     store.upsert_chunk(&chunk2, &emb2, Some(12345)).unwrap();
@@ -261,29 +193,25 @@ fn test_get_embeddings_by_hashes() {
 
 #[test]
 fn test_stats() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("index.db");
-
-    let store = Store::open(&db_path).unwrap();
-    store.init(&ModelInfo::default()).unwrap();
+    let store = TestStore::new();
 
     // Insert various chunks
-    let chunk1 = create_test_chunk("fn1", "fn fn1() {}");
-    let mut chunk2 = create_test_chunk("fn2", "fn fn2() {}");
+    let chunk1 = test_chunk("fn1", "fn fn1() {}");
+    let mut chunk2 = test_chunk("fn2", "fn fn2() {}");
     chunk2.file = PathBuf::from("other.rs");
     chunk2.id = format!("other.rs:1:{}", &chunk2.content_hash[..8]);
 
-    let mut chunk3 = create_test_chunk("method1", "fn method1(&self) {}");
+    let mut chunk3 = test_chunk("method1", "fn method1(&self) {}");
     chunk3.chunk_type = ChunkType::Method;
 
     store
-        .upsert_chunk(&chunk1, &create_mock_embedding(1.0), Some(12345))
+        .upsert_chunk(&chunk1, &mock_embedding(1.0), Some(12345))
         .unwrap();
     store
-        .upsert_chunk(&chunk2, &create_mock_embedding(1.0), Some(12345))
+        .upsert_chunk(&chunk2, &mock_embedding(1.0), Some(12345))
         .unwrap();
     store
-        .upsert_chunk(&chunk3, &create_mock_embedding(1.0), Some(12345))
+        .upsert_chunk(&chunk3, &mock_embedding(1.0), Some(12345))
         .unwrap();
 
     let stats = store.stats().unwrap();
@@ -306,31 +234,27 @@ fn test_stats() {
 
 #[test]
 fn test_fts_search() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("index.db");
-
-    let store = Store::open(&db_path).unwrap();
-    store.init(&ModelInfo::default()).unwrap();
+    let store = TestStore::new();
 
     // Insert chunks with distinctive names
-    let chunk1 = create_test_chunk(
+    let chunk1 = test_chunk(
         "parseConfigFile",
         "fn parseConfigFile() { /* parse config */ }",
     );
-    let chunk2 = create_test_chunk(
+    let chunk2 = test_chunk(
         "loadUserSettings",
         "fn loadUserSettings() { /* load settings */ }",
     );
-    let chunk3 = create_test_chunk("calculateTotal", "fn calculateTotal() { /* math */ }");
+    let chunk3 = test_chunk("calculateTotal", "fn calculateTotal() { /* math */ }");
 
     store
-        .upsert_chunk(&chunk1, &create_mock_embedding(0.1), Some(12345))
+        .upsert_chunk(&chunk1, &mock_embedding(0.1), Some(12345))
         .unwrap();
     store
-        .upsert_chunk(&chunk2, &create_mock_embedding(0.2), Some(12345))
+        .upsert_chunk(&chunk2, &mock_embedding(0.2), Some(12345))
         .unwrap();
     store
-        .upsert_chunk(&chunk3, &create_mock_embedding(0.3), Some(12345))
+        .upsert_chunk(&chunk3, &mock_embedding(0.3), Some(12345))
         .unwrap();
 
     // FTS search for "config" should find parseConfigFile
@@ -364,24 +288,20 @@ fn test_fts_search() {
 
 #[test]
 fn test_rrf_search() {
-    let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("index.db");
-
-    let store = Store::open(&db_path).unwrap();
-    store.init(&ModelInfo::default()).unwrap();
+    let store = TestStore::new();
 
     // Insert chunks
-    let chunk1 = create_test_chunk("handleError", "fn handleError(err: Error) { log(err); }");
-    let chunk2 = create_test_chunk(
+    let chunk1 = test_chunk("handleError", "fn handleError(err: Error) { log(err); }");
+    let chunk2 = test_chunk(
         "processData",
         "fn processData(data: Vec<u8>) { /* process */ }",
     );
 
     store
-        .upsert_chunk(&chunk1, &create_mock_embedding(0.5), Some(12345))
+        .upsert_chunk(&chunk1, &mock_embedding(0.5), Some(12345))
         .unwrap();
     store
-        .upsert_chunk(&chunk2, &create_mock_embedding(0.5), Some(12345))
+        .upsert_chunk(&chunk2, &mock_embedding(0.5), Some(12345))
         .unwrap();
 
     // Search with RRF enabled
@@ -392,7 +312,7 @@ fn test_rrf_search() {
     };
 
     let results = store
-        .search_filtered(&create_mock_embedding(0.5), &filter, 5, 0.0)
+        .search_filtered(&mock_embedding(0.5), &filter, 5, 0.0)
         .unwrap();
 
     // Should return results (RRF combines semantic + FTS)


### PR DESCRIPTION
## Summary
- Remove unused `mut` from 12 test/example variable declarations
- Remove unused `ExitCode` variants (`IndexMissing`, `ModelMissing`)
- Migrate `store_test.rs` to use `tests/common/mod.rs` helper
- Refactor `cmd_serve` to use `ServeConfig` struct (removes clippy `too_many_arguments`)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (162 tests)
- [x] `cargo test --no-run 2>&1 | grep -c "variable does not need to be mutable"` returns 0

---
Generated with [Claude Code](https://claude.com/claude-code)
