### PR TITLE
fix: P2 edge case improvements

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -695,11 +695,13 @@ fn run_index_pipeline(
                             // Rewrite paths to be relative for storage
                             for chunk in &mut chunks {
                                 chunk.file = rel_path.clone();
+                                let hash_prefix =
+                                    chunk.content_hash.get(..8).unwrap_or(&chunk.content_hash);
                                 chunk.id = format!(
                                     "{}:{}:{}",
                                     rel_path.display(),
                                     chunk.line_start,
-                                    &chunk.content_hash[..8]
+                                    hash_prefix
                                 );
                             }
                             chunks


### PR DESCRIPTION
## Summary

- Content hash slicing: use `.get(..8)` instead of `[..8]` for defensive coding
- Parser capture index: add bounds check with `.get().copied()`
- FTS normalization: cap output at 16KB to prevent memory issues

## Test plan

- [x] `cargo test --lib` passes (174 tests)
- [x] New tests for FTS output bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
