### PR TITLE
fix: P2 error handling and query optimization

### DIFF
--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -17,6 +17,8 @@ pub enum StoreError {
     Database(#[from] sqlx::Error),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("System time error: file mtime before Unix epoch")]
+    SystemTime,
     #[error("Runtime error: {0}")]
     Runtime(String),
     #[error("Schema version mismatch: index is v{0}, cq expects v{1}. Run 'cq index --force' to rebuild.")]

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -154,7 +154,7 @@ impl Store {
             .metadata()?
             .modified()?
             .duration_since(std::time::UNIX_EPOCH)
-            .map_err(|_| std::io::Error::other("time error"))?
+            .map_err(|_| StoreError::SystemTime)?
             .as_secs() as i64;
 
         self.rt.block_on(async {


### PR DESCRIPTION
## Summary

- Add `StoreError::SystemTime` variant for time-related errors
- Replace `std::io::Error::other` with typed error in `needs_reindex`
- Optimize `stats()` from 7 queries to 4 using batched metadata query

## Test plan

- [x] `cargo test --lib` passes (170 tests)
- [x] `cargo build` compiles without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
