### PR TITLE
fix: P2 performance and platform fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,8 +90,10 @@ dirs = "6"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rand = "0.9"
-libc = "0.2"
 lru = "0.16"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 once_cell = "1"
 
 [features]


### PR DESCRIPTION
## Summary

- **#47** Batch prune_missing: 2 queries/file → batched (100 per query)
- **#49** Reuse HashSet/Vec in parse_file_calls loop
- **#28** Make libc Unix-only dependency (already cfg-gated)

## Test plan

- [x] `cargo test --lib` passes (172 tests)
- [x] `cargo build` compiles without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
