### PR TITLE
fix: HNSW checksum efficiency and TOML injection prevention

### DIFF
--- a/src/hnsw.rs
+++ b/src/hnsw.rs
@@ -326,8 +326,10 @@ impl HnswIndex {
         std::fs::write(&id_map_path, &id_map_json)?;
 
         // Compute and save checksums for all files (mitigates bincode deserialization risks)
-        let mut checksums = Vec::new();
-        for ext in &["hnsw.graph", "hnsw.data", "hnsw.ids"] {
+        // For .ids we hash the in-memory data to avoid re-reading the file
+        let ids_hash = blake3::hash(id_map_json.as_bytes());
+        let mut checksums = vec![format!("hnsw.ids:{}", ids_hash.to_hex())];
+        for ext in &["hnsw.graph", "hnsw.data"] {
             let path = dir.join(format!("{}.{}", basename, ext));
             if path.exists() {
                 let data = std::fs::read(&path)?;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -917,7 +917,16 @@ impl McpServer {
                 "\nmentions = [{}]",
                 mentions
                     .iter()
-                    .map(|m| { format!("\"{}\"", m.replace('\\', "\\\\").replace('\"', "\\\"")) })
+                    .map(|m| {
+                        format!(
+                            "\"{}\"",
+                            m.replace('\\', "\\\\")
+                                .replace('\"', "\\\"")
+                                .replace('\n', "\\n")
+                                .replace('\r', "\\r")
+                                .replace('\t', "\\t")
+                        )
+                    })
                     .collect::<Vec<_>>()
                     .join(", ")
             )


### PR DESCRIPTION
## Summary
- Hash .ids file from in-memory data instead of re-reading after write (#50)
- Escape newlines/tabs in mentions to prevent TOML injection (#38)

## Test plan
- [x] `cargo test --lib hnsw` passes (10 tests)
- [x] `cargo test --lib mcp` passes (42 tests)
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
