### PR TITLE
refactor: Extract watch.rs from cli/mod.rs

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,11 +2,25 @@
 
 ## Right Now
 
-**P2 audit in progress** (2026-02-04)
+**Pivoting to definition search feature** (2026-02-04)
 
-Triage: `docs/audit-triage.md` | Findings: `docs/audit-findings.md`
+P2 audit paused at 23/58 to add definition search mode to cqs_search.
+This will help with ongoing code navigation during fixes.
 
-### P2 Progress: 22 of 58 Fixed
+### Pending Changes (uncommitted on fix/p2-batch-6)
+
+- `src/cli/watch.rs` - new file, extracted from mod.rs (~270 lines)
+- `src/cli/mod.rs` - reduced from 2167 to 1893 lines
+- `src/hnsw.rs` - added `count_vectors()` for fast stats (P2 #52)
+
+### Next: Definition Search Feature
+
+Add `--definition` mode to cqs_search for "where is X defined?" queries.
+- Boost name matching heavily (or exact match only)
+- Return function/struct definitions, not semantic matches
+- Complements current semantic search ("what does X do?")
+
+### P2 Progress: 23 of 58 Fixed
 
 | # | Issue | Resolution |
 |---|-------|------------|
@@ -29,7 +43,9 @@ Triage: `docs/audit-triage.md` | Findings: `docs/audit-findings.md`
 | 48 | stats() multiple queries | Fixed: batched metadata query |
 | 49 | HashSet per function | Fixed: reuse across iterations |
 | 50 | HNSW checksum I/O | Fixed: hash ids from memory |
+| 52 | Stats loads HNSW for length | Fixed: count_vectors() reads ids only |
 | - | Glob pattern tests | Fixed: 3 new tests + FTS bounds tests |
+| - | CLI file split | watch.rs extracted (274 lines)
 
 ### P1 Status: 62 of 64 Closed
 
@@ -101,7 +117,7 @@ Triage: `docs/audit-triage.md` | Findings: `docs/audit-findings.md`
 | Tier | Count | Status |
 |------|-------|--------|
 | P1 | 2 deferred | Move to P4 |
-| P2 | 36 remaining | 22 fixed |
+| P2 | 35 remaining | 23 fixed |
 | P3 | 43 | Pending |
 | P4 | 19 + 2 = 21 | Pending |
 
@@ -126,6 +142,7 @@ Triage: `docs/audit-triage.md` | Findings: `docs/audit-findings.md`
 
 - 769-dim embeddings (768 + sentiment)
 - Store: split into focused modules (6 files)
+- CLI: mod.rs + display.rs + watch.rs
 - Schema v10, WAL mode
 - tests/common/mod.rs for test fixtures
-- 272 tests
+- 172 tests

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -1,0 +1,288 @@
+//! Watch mode - monitor for file changes and reindex
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
+
+use cqs::embedder::{Embedder, Embedding};
+use cqs::nl::generate_nl_description;
+use cqs::note::parse_notes;
+use cqs::parser::Parser as CqParser;
+use cqs::store::Store;
+
+use super::{check_interrupted, find_project_root, Cli};
+
+/// Maximum pending files to prevent unbounded memory growth
+const MAX_PENDING_FILES: usize = 10_000;
+
+pub fn cmd_watch(cli: &Cli, debounce_ms: u64, no_ignore: bool) -> Result<()> {
+    let root = find_project_root();
+    let cq_dir = root.join(".cq");
+    let index_path = cq_dir.join("index.db");
+
+    if !index_path.exists() {
+        bail!("No index found. Run 'cqs index' first.");
+    }
+
+    let parser = CqParser::new()?;
+    let supported_ext: HashSet<_> = parser.supported_extensions().iter().cloned().collect();
+
+    println!(
+        "Watching {} for changes (Ctrl+C to stop)...",
+        root.display()
+    );
+    println!(
+        "Code extensions: {}",
+        supported_ext.iter().cloned().collect::<Vec<_>>().join(", ")
+    );
+    println!("Also watching: docs/notes.toml");
+
+    let (tx, rx) = mpsc::channel();
+
+    let config = Config::default().with_poll_interval(Duration::from_millis(debounce_ms));
+
+    let mut watcher = RecommendedWatcher::new(tx, config)?;
+    watcher.watch(&root, RecursiveMode::Recursive)?;
+
+    // Track pending changes for debouncing
+    let mut pending_files: HashSet<PathBuf> = HashSet::new();
+    let mut pending_notes = false;
+    let mut last_event = std::time::Instant::now();
+    let debounce = Duration::from_millis(debounce_ms);
+    let notes_path = root.join("docs/notes.toml");
+
+    loop {
+        match rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(Ok(event)) => {
+                for path in event.paths {
+                    // Skip .cq directory
+                    if path.starts_with(&cq_dir) {
+                        continue;
+                    }
+
+                    // Check if it's notes.toml
+                    if path == notes_path {
+                        pending_notes = true;
+                        last_event = std::time::Instant::now();
+                        continue;
+                    }
+
+                    // Skip if not a supported extension
+                    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                    if !supported_ext.contains(ext) {
+                        continue;
+                    }
+
+                    // Convert to relative path
+                    if let Ok(rel) = path.strip_prefix(&root) {
+                        if pending_files.len() < MAX_PENDING_FILES {
+                            pending_files.insert(rel.to_path_buf());
+                        }
+                        last_event = std::time::Instant::now();
+                    }
+                }
+            }
+            Ok(Err(e)) => {
+                if !cli.quiet {
+                    eprintln!("Watch error: {}", e);
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                // Check if we should process pending changes
+                let should_process = (!pending_files.is_empty() || pending_notes)
+                    && last_event.elapsed() >= debounce;
+
+                if should_process {
+                    // Reindex code files if any changed
+                    if !pending_files.is_empty() {
+                        let files: Vec<PathBuf> = pending_files.drain().collect();
+                        if !cli.quiet {
+                            println!("\n{} file(s) changed, reindexing...", files.len());
+                            for f in &files {
+                                println!("  {}", f.display());
+                            }
+                        }
+
+                        match reindex_files(
+                            &root,
+                            &index_path,
+                            &files,
+                            &parser,
+                            no_ignore,
+                            cli.quiet,
+                        ) {
+                            Ok(count) => {
+                                if !cli.quiet {
+                                    println!("Indexed {} chunk(s)", count);
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("Reindex error: {}", e);
+                            }
+                        }
+                    }
+
+                    // Reindex notes if notes.toml changed
+                    if pending_notes {
+                        pending_notes = false;
+                        if !cli.quiet {
+                            println!("\nNotes changed, reindexing...");
+                        }
+                        match reindex_notes(&root, &index_path, cli.quiet) {
+                            Ok(count) => {
+                                if !cli.quiet {
+                                    println!("Indexed {} note(s)", count);
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("Notes reindex error: {}", e);
+                            }
+                        }
+                    }
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                bail!(
+                    "File watcher disconnected unexpectedly. \
+                     Hint: Restart 'cqs watch' to resume monitoring."
+                );
+            }
+        }
+
+        if check_interrupted() {
+            println!("\nStopping watch...");
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+/// Reindex specific files
+fn reindex_files(
+    root: &Path,
+    index_path: &Path,
+    files: &[PathBuf],
+    parser: &CqParser,
+    _no_ignore: bool,
+    quiet: bool,
+) -> Result<usize> {
+    let embedder = Embedder::new()?;
+    let store = Store::open(index_path)?;
+
+    // Parse the changed files
+    let chunks: Vec<_> = files
+        .iter()
+        .flat_map(|rel_path| {
+            let abs_path = root.join(rel_path);
+            if !abs_path.exists() {
+                // File was deleted, we'll handle this by removing old chunks
+                return vec![];
+            }
+            match parser.parse_file(&abs_path) {
+                Ok(mut file_chunks) => {
+                    // Rewrite paths to be relative
+                    for chunk in &mut file_chunks {
+                        chunk.file = rel_path.clone();
+                    }
+                    file_chunks
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to parse {}: {}", abs_path.display(), e);
+                    vec![]
+                }
+            }
+        })
+        .collect();
+
+    if chunks.is_empty() {
+        return Ok(0);
+    }
+
+    // Generate embeddings with neutral sentiment for code chunks
+    let texts: Vec<String> = chunks.iter().map(generate_nl_description).collect();
+    let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+    let embeddings: Vec<Embedding> = embedder
+        .embed_documents(&text_refs)?
+        .into_iter()
+        .map(|e| e.with_sentiment(0.0))
+        .collect();
+
+    // Delete old chunks for these files and insert new ones
+    for rel_path in files {
+        store.delete_by_origin(rel_path)?;
+    }
+
+    for (chunk, embedding) in chunks.iter().zip(embeddings.iter()) {
+        let abs_path = root.join(&chunk.file);
+        let mtime = abs_path
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs() as i64);
+        store.upsert_chunk(chunk, embedding, mtime)?;
+    }
+
+    if !quiet {
+        println!("Updated {} file(s)", files.len());
+    }
+
+    Ok(chunks.len())
+}
+
+/// Reindex notes from docs/notes.toml
+fn reindex_notes(root: &Path, index_path: &Path, quiet: bool) -> Result<usize> {
+    let notes_path = root.join("docs/notes.toml");
+    if !notes_path.exists() {
+        return Ok(0);
+    }
+
+    let notes = parse_notes(&notes_path)?;
+    if notes.is_empty() {
+        return Ok(0);
+    }
+
+    let embedder = Embedder::new()?;
+    let store = Store::open(index_path)?;
+
+    // Embed note content with sentiment prefix
+    let texts: Vec<String> = notes.iter().map(|n| n.embedding_text()).collect();
+    let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+    let base_embeddings = embedder.embed_documents(&text_refs)?;
+
+    // Add sentiment as 769th dimension
+    let embeddings_with_sentiment: Vec<Embedding> = base_embeddings
+        .into_iter()
+        .zip(notes.iter())
+        .map(|(emb, note)| emb.with_sentiment(note.sentiment()))
+        .collect();
+
+    // Get file mtime
+    let file_mtime = notes_path
+        .metadata()
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+
+    // Delete old notes and insert new
+    store.delete_notes_by_file(&notes_path)?;
+    let note_embeddings: Vec<_> = notes.into_iter().zip(embeddings_with_sentiment).collect();
+    store.upsert_notes_batch(&note_embeddings, &notes_path, file_mtime)?;
+
+    if !quiet {
+        let (total, warnings, patterns) = store.note_stats()?;
+        println!(
+            "  Notes: {} total ({} warnings, {} patterns)",
+            total, warnings, patterns
+        );
+    }
+
+    Ok(note_embeddings.len())
+}

--- a/src/hnsw.rs
+++ b/src/hnsw.rs
@@ -429,6 +429,14 @@ impl HnswIndex {
         graph_path.exists() && data_path.exists() && id_map_path.exists()
     }
 
+    /// Get vector count without loading the full index (fast, for stats)
+    pub fn count_vectors(dir: &Path, basename: &str) -> Option<usize> {
+        let id_map_path = dir.join(format!("{}.hnsw.ids", basename));
+        let content = std::fs::read_to_string(&id_map_path).ok()?;
+        let ids: Vec<String> = serde_json::from_str(&content).ok()?;
+        Some(ids.len())
+    }
+
     /// Get the number of vectors in the index
     pub fn len(&self) -> usize {
         self.id_map.len()


### PR DESCRIPTION
## Summary
- Extract watch mode to `cli/watch.rs` (~270 lines)
- Add `HnswIndex::count_vectors()` for fast stats without loading full index (P2 #52)
- Reduce `cli/mod.rs` from 2167 to 1893 lines

## Test plan
- [x] `cargo test --lib` passes (172 tests)
- [x] `cargo build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
