### PR TITLE
feat: Include notes in HNSW index for O(log n) search

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -7,6 +7,12 @@
 **P2 audit tier complete.** Verified remaining items are either already fixed or design choices.
 
 ### Current Work
+- #103 O(n) note search - **FIXED**: Notes now in HNSW index
+  - Notes included in unified HNSW with `note:` prefix IDs
+  - Added `Store::note_embeddings()` and `search_notes_by_ids()`
+  - Search partitions HNSW candidates by prefix, fetches from respective tables
+  - Note search now O(log n) instead of O(n)
+
 - #107 Memory OOM on huge repos - **FIXED**: Streaming HNSW build
   - Added `Store::embedding_batches()` - streams embeddings in 10k batches via LIMIT/OFFSET
   - Added `HnswIndex::build_batched()` - builds index incrementally without loading all into RAM
@@ -106,9 +112,6 @@ P3 audit doc claimed 43 items but most were already fixed or low-value doc comme
 - Batched metadata queries (I/O #10)
 
 ## Open Issues
-
-### Hard (deferred)
-- #103: O(n) note search (notes are small, acceptable)
 
 ### External/Waiting
 - #106: ort stable

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -348,3 +348,8 @@ mentions = ["src/note.rs", "src/nl.rs", "src/store.rs", "src/mcp.rs", "proptest"
 sentiment = 1.0
 text = "Streaming HNSW build for large repos: Store::embedding_batches() yields chunks in 10k batches via LIMIT/OFFSET, HnswIndex::build_batched() inserts incrementally. Memory drops from O(n) to O(batch_size). Fixes #107 OOM on huge repos."
 mentions = ["src/store/chunks.rs", "src/hnsw.rs", "embedding_batches", "build_batched"]
+
+[[note]]
+sentiment = 1.0
+text = "Notes now included in HNSW index with 'note:' prefix. search_unified_with_index partitions candidates by prefix, fetches from chunks/notes tables separately. O(n) brute-force eliminated. Fixes #103."
+mentions = ["src/store/notes.rs", "src/search.rs", "src/cli/mod.rs", "note_embeddings", "search_notes_by_ids"]


### PR DESCRIPTION
## Summary

Fixes O(n) brute-force note search by including notes in the unified HNSW index.

**Changes:**
- Note IDs in HNSW are prefixed with `note:` to distinguish from chunks
- Added `Store::note_embeddings()` for HNSW build
- Added `Store::search_notes_by_ids()` for candidate-based lookup
- Updated `search_unified_with_index()` to partition HNSW results by prefix

**Complexity improvement:**
| Operation | Old | New |
|-----------|-----|-----|
| Note search | O(n) brute-force | O(log n) HNSW |
| Per query | Load all notes, compute similarity | Fetch top-k candidates |

Index output now shows both: `HNSW index: 879 vectors (811 chunks, 68 notes)`

## Test plan

- [x] `cargo test` - all 280+ tests pass
- [x] `cargo build --release` - no warnings
- [x] `cqs index --force` - shows chunks + notes in HNSW
- [x] `cqs "streaming HNSW memory"` - notes appear in search results via HNSW

🤖 Generated with [Claude Code](https://claude.com/claude-code)
