### PR TITLE
feat: Add note_weight parameter to attenuate note scores

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -100,6 +100,10 @@ pub struct Cli {
     #[arg(long, default_value = "0.2")]
     name_boost: f32,
 
+    /// Weight for note scores in results (0.0-1.0, lower = notes rank below code)
+    #[arg(long, default_value = "1.0")]
+    note_weight: f32,
+
     /// Filter by language
     #[arg(short = 'l', long)]
     lang: Option<String>,
@@ -1336,6 +1340,7 @@ fn cmd_query(cli: &Cli, query: &str) -> Result<()> {
         name_boost: cli.name_boost,
         query_text: query.to_string(),
         enable_rrf: true, // Enable RRF hybrid search by default
+        note_weight: cli.note_weight,
     };
 
     // Load vector index for O(log n) search

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -141,6 +141,9 @@ struct SearchArgs {
     /// Definition search mode - find by name only, no semantic matching.
     /// Use for "where is X defined?" queries. Much faster than semantic search.
     name_only: Option<bool>,
+    /// Weight for note scores in results (0.0-1.0, default 1.0)
+    /// Lower values make notes rank lower than code with similar semantic scores.
+    note_weight: Option<f32>,
 }
 
 /// Audit mode arguments
@@ -438,6 +441,11 @@ impl McpServer {
                             "type": "boolean",
                             "description": "Definition search: find by name only, skip semantic matching. Use for 'where is X defined?' queries. Much faster.",
                             "default": false
+                        },
+                        "note_weight": {
+                            "type": "number",
+                            "description": "Weight for note scores 0.0-1.0 (default: 1.0). Lower values make notes rank below code.",
+                            "default": 1.0
                         }
                     },
                     "required": ["query"]
@@ -631,6 +639,7 @@ impl McpServer {
             name_boost: args.name_boost.unwrap_or(0.2),
             query_text: args.query.clone(),
             enable_rrf: !args.semantic_only.unwrap_or(false), // RRF on by default, disable with semantic_only
+            note_weight: args.note_weight.unwrap_or(1.0),
         };
 
         // Read-lock the index (allows background CAGRA build to upgrade it)

--- a/src/search.rs
+++ b/src/search.rs
@@ -537,10 +537,14 @@ impl Store {
             .map(crate::store::UnifiedResult::Code)
             .collect();
 
+        // Apply note_weight to attenuate note scores before merging
         let notes_to_add: Vec<crate::store::UnifiedResult> = note_results
             .into_iter()
             .take(note_slots)
-            .map(crate::store::UnifiedResult::Note)
+            .map(|mut r| {
+                r.score *= filter.note_weight;
+                crate::store::UnifiedResult::Note(r)
+            })
             .collect();
         unified.extend(notes_to_add);
 

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -190,7 +190,6 @@ impl UnifiedResult {
 ///
 /// All fields are optional. Unset filters match all chunks.
 /// Use `validate()` to check constraints before searching.
-#[derive(Default)]
 pub struct SearchFilter {
     /// Filter by programming language(s)
     pub languages: Option<Vec<Language>>,
@@ -210,6 +209,25 @@ pub struct SearchFilter {
     /// using the formula: score = Σ 1/(k + rank), where k=60.
     /// This typically improves recall for identifier-heavy queries.
     pub enable_rrf: bool,
+    /// Weight multiplier for note scores in unified search (0.0-1.0)
+    ///
+    /// 1.0 = notes scored equally with code (default)
+    /// 0.5 = notes scored at half weight
+    /// 0.0 = notes excluded from results
+    pub note_weight: f32,
+}
+
+impl Default for SearchFilter {
+    fn default() -> Self {
+        Self {
+            languages: None,
+            path_pattern: None,
+            name_boost: 0.0,
+            query_text: String::new(),
+            enable_rrf: false,
+            note_weight: 1.0, // Notes weighted equally by default
+        }
+    }
 }
 
 impl SearchFilter {
@@ -220,6 +238,11 @@ impl SearchFilter {
         // name_boost must be in [0.0, 1.0]
         if self.name_boost < 0.0 || self.name_boost > 1.0 {
             return Err("name_boost must be between 0.0 and 1.0");
+        }
+
+        // note_weight must be in [0.0, 1.0]
+        if self.note_weight < 0.0 || self.note_weight > 1.0 {
+            return Err("note_weight must be between 0.0 and 1.0");
         }
 
         // query_text required when name_boost > 0 or enable_rrf


### PR DESCRIPTION
## Summary
- Add `note_weight` field to SearchFilter (default 1.0)
- Lower values make notes rank below code with similar semantic scores
- Exposed via CLI (`--note-weight`) and MCP (`note_weight` parameter)
- Validated in range 0.0-1.0

## Example
```bash
# Default: notes can dominate if they have high semantic match
cqs "error handling"

# With note_weight=0.5: notes score halved, code ranks higher
cqs --note-weight 0.5 "error handling"
```

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] Manually tested: notes drop in ranking with lower weight
- [ ] CI checks pass