### PR TITLE
chore: Release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2026-02-05
+
+### Added
+- **`note_weight` parameter** for controlling note prominence in search results (#183)
+  - CLI: `--note-weight 0.5` (0.0-1.0, default 1.0)
+  - MCP: `note_weight` parameter in cqs_search
+  - Lower values make notes rank below code with similar semantic scores
+
+### Changed
+- CAGRA GPU index now uses streaming embeddings and includes notes (#180)
+- Removed dead `search_unified()` function (#182) - only `search_unified_with_index()` was used
+
 ## [0.4.3] - 2026-02-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.88"
 description = "Semantic code search for Claude Code. Find functions by what they do, not their names. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,26 +2,20 @@
 
 ## Right Now
 
-**v0.4.3 released** (2026-02-05)
+**v0.4.4 releasing** (2026-02-05)
 
-**Audit complete.** All P2-P4 items fixed or verified as design choices.
+**Audit complete.** Codebase in good shape after fresh-eyes review found and fixed dead code.
 
 ### Session Summary (2026-02-05)
-Fixed the two "hard" deferred issues:
-- **#107 Memory OOM** - Streaming HNSW build (PR #176)
-- **#103 O(n) note search** - Notes in unified HNSW (PR #177)
+Post-audit cleanup:
+- **CAGRA streaming** - GPU index now streams embeddings like HNSW (PR #180)
+- **Dead code removed** - `search_unified()` was never called (PR #182)
+- **`note_weight` parameter** - tune how prominently notes appear in results (PR #183)
 
-Then shipped v0.4.3 (PR #178) to GitHub + crates.io.
-
-**Also fixed:** CAGRA GPU index now uses streaming embeddings and includes notes (PR #180). Aligns CAGRA with HNSW approach - streams from SQLite to avoid double-buffering.
-
-### Key Changes in v0.4.3
-- `Store::embedding_batches()` - streams in 10k batches via LIMIT/OFFSET
-- `HnswIndex::build_batched()` - incremental build, O(batch_size) memory
-- Notes in HNSW with `note:` prefix - O(log n) search
-- `Store::note_embeddings()` and `search_notes_by_ids()`
-- HNSW build moved after note indexing
-- Index output: `HNSW index: 879 vectors (811 chunks, 68 notes)`
+### Key Changes in v0.4.4
+- `--note-weight 0.5` to make notes rank below code
+- CAGRA streams from SQLite, includes notes with `note:` prefix
+- Cleaner search.rs after dead code removal
 
 ## Open Issues
 

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -353,3 +353,8 @@ mentions = ["src/store/chunks.rs", "src/hnsw.rs", "embedding_batches", "build_ba
 sentiment = 1.0
 text = "Notes now included in HNSW index with 'note:' prefix. search_unified_with_index partitions candidates by prefix, fetches from chunks/notes tables separately. O(n) brute-force eliminated. Fixes #103."
 mentions = ["src/store/notes.rs", "src/search.rs", "src/cli/mod.rs", "note_embeddings", "search_notes_by_ids"]
+
+[[note]]
+sentiment = 0.5
+text = "note_weight parameter added to SearchFilter. Default 1.0, lower values attenuate note scores before merging with code results. CLI --note-weight, MCP note_weight. Useful when notes dominate due to high semantic match."
+mentions = ["SearchFilter", "search.rs", "mcp.rs", "cli/mod.rs"]


### PR DESCRIPTION
## Summary
Release v0.4.4 with:
- `note_weight` parameter for tuning note prominence in search
- CAGRA streaming embeddings + notes support
- Dead code removal

## Changes since v0.4.3
- #180: CAGRA streaming embeddings and notes
- #182: Remove dead search_unified function
- #183: Add note_weight parameter