### PR TITLE
refactor: Extract embedding helpers in pipeline.rs (H5)

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -458,7 +458,7 @@ After de-duplication: **~225 unique findings**
 #### Code Hygiene (1 hard)
 | # | Finding | Location |
 |---|---------|----------|
-| H5 | run_index_pipeline ~400 lines | `src/cli/mod.rs:450-850` |
+| H5 | run_index_pipeline ~400 lines | `src/cli/mod.rs:450-850` | ✅ Extracted helpers, simplified CPU thread |
 
 #### Module Boundaries (2 hard)
 | # | Finding | Location |


### PR DESCRIPTION
## Summary
Refactor pipeline.rs to address H5 audit finding (run_index_pipeline ~400 lines).

## Changes
Extract common embedding preparation logic into reusable helpers:
- `PreparedEmbedding` struct: holds cached chunks, to-embed chunks, and generated texts
- `prepare_for_embedding()`: consolidates windowing, cache lookup, and text generation
- `create_embedded_batch()`: combines cached and newly embedded chunks

The CPU embedder thread now uses these helpers, reducing duplication and improving readability.

GPU embedder thread kept mostly as-is due to its unique requeue-on-failure requirements (needs to preserve batch for potential requeue to CPU).

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` - all 21 tests pass
- [x] `cargo clippy -- -D warnings` - no warnings
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
