### PR TITLE
docs: Verify A3 and A5 audit findings - already compliant

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -308,9 +308,9 @@ After de-duplication: **~225 unique findings**
 #### API Design (5 medium)
 | # | Finding | Location |
 |---|---------|----------|
-| A3 | &Path vs PathBuf inconsistency | Multiple |
+| A3 | &Path vs PathBuf inconsistency | Multiple | ✅ 91% consistent, exceptions are optimal |
 | A4 | **Two Language enums** (dedup) | `src/parser.rs:760`, `src/language/mod.rs` |
-| A5 | Error type inconsistency | Multiple |
+| A5 | Error type inconsistency | Multiple | ✅ Convention followed: thiserror in lib, anyhow in CLI |
 | A6 | SearchFilter missing builder pattern | `src/store/helpers.rs:247-287` | ✅ Has builder methods |
 | A12 | Exposed internal types | `src/store/mod.rs:27-31` |
 


### PR DESCRIPTION
## Summary
Verify A3 and A5 audit findings - both are already compliant.

## A3: &Path vs PathBuf Inconsistency

**Finding:** 91% of path-handling functions (20/22) correctly use `&Path` parameters.

**Exceptions are intentional:**
- `strip_unc_prefix(path: PathBuf) -> PathBuf`: Takes owned PathBuf to avoid unnecessary allocation. All callers pass `PathBuf` from `canonicalize()`. If we changed to `&Path`, we'd need to allocate a new `PathBuf` in ALL cases, even when no stripping is needed.

## A5: Error Type Inconsistency

**Finding:** Convention is 100% followed.

**Library code (thiserror):**
- `EmbedderError` in src/embedder.rs
- `ParserError` in src/parser.rs
- `HnswError` in src/hnsw.rs
- `StoreError` in src/store/helpers.rs
- `NoteError` in src/note.rs

**CLI code (anyhow):**
- All src/cli/*.rs functions return `anyhow::Result`

## Test plan
- [x] No code changes, documentation only
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
