### PR TITLE
fix: Address high-impact and easy audit findings

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -63,7 +63,7 @@ After de-duplication: **~225 unique findings**
 | H3 | InitializeParams fields unused | `src/mcp/types.rs:45-55` | ✅ Fixed |
 | H4 | _no_ignore parameter unused | `src/cli/watch.rs:39` | ✅ Warns user |
 | H9 | Note search scoring duplicated | `src/store/notes.rs` | ✅ Fixed |
-| H11 | Redundant .to_string() calls | Multiple files | Open |
+| H11 | Redundant .to_string() calls | Multiple files | ✅ Fixed |
 | H12 | Magic sentiment thresholds | `src/store/notes.rs` | ✅ Fixed |
 
 ### Error Propagation (15 easy fixes)
@@ -82,7 +82,7 @@ After de-duplication: **~225 unique findings**
 | E17 | Poisoned mutex at debug, not warn | `src/embedder.rs:314` | ✅ Fixed |
 | E18 | Index guard poisoning not logged | `src/mcp/tools/*.rs` | ✅ Fixed |
 | E19 | Generic "Failed to open index" missing path | `src/mcp/server.rs:58` | ✅ Fixed |
-| E20 | Store schema mismatch error missing path | `src/store/helpers.rs:32-35` | Open |
+| E20 | Store schema mismatch error missing path | `src/store/helpers.rs:32-35` | ✅ Fixed |
 
 ### API Design (11 easy fixes)
 
@@ -97,8 +97,8 @@ After de-duplication: **~225 unique findings**
 | A11 | embedding_batches non-fused iterator | `src/store/chunks.rs:405-415` | Open |
 | A13 | HnswIndex::build vs build_batched asymmetry | `src/hnsw.rs:195,268` | Open |
 | A14 | Config fields all Option, no defaults | `src/config.rs:24-37` | Open |
-| A15 | **cosine_similarity panics** (dedup) | `src/search.rs:23-25` | Open |
-| A16 | Embedding::new() no validation | `src/embedder.rs:62-65` | Open |
+| A15 | **cosine_similarity precision** (dedup) | `src/math.rs:17` | ✅ Fixed |
+| A16 | Embedding with_sentiment validation | `src/embedder.rs:121` | ✅ Fixed |
 
 ### Module Boundaries (4 easy fixes)
 
@@ -142,7 +142,7 @@ After de-duplication: **~225 unique findings**
 | P3 | Unwrap on enabled field in MCP | `src/mcp/tools/audit.rs:42` | ✅ Fixed |
 | P4 | Embedder initialization expect | `src/mcp/server.rs` | ✅ Fixed |
 | P6 | Ctrl+C handler expect | `src/cli/signal.rs:26-34` | ✅ Fixed |
-| P7 | Progress bar template expect | `src/cli/pipeline.rs:471` | Open |
+| P7 | Progress bar template expect | `src/cli/pipeline.rs:520` | ✅ Fixed |
 
 ### Algorithm Correctness (9 easy fixes)
 
@@ -195,8 +195,8 @@ After de-duplication: **~225 unique findings**
 | DI8 | ID map/HNSW count mismatch only checked on load | `src/hnsw.rs:503-515` | Open |
 | DI9 | No foreign key enforcement | `src/store/mod.rs:68-96` | ✅ FK enabled |
 | DI10 | notes.toml ID collision with hash truncation | `src/note.rs:122` | ✅ Documented |
-| DI13 | Checksum doc limitation | `src/hnsw.rs:97-131` | Open |
-| DI14 | Missing WAL checkpoint on shutdown | `src/store/mod.rs:55-114` | Open |
+| DI13 | Checksum doc limitation | `src/hnsw.rs:94-101` | ✅ Fixed |
+| DI14 | Missing WAL checkpoint on shutdown | `src/store/mod.rs` | ✅ Fixed |
 
 #### Edge Cases (5 easy)
 | # | Finding | Location | Status |
@@ -223,7 +223,7 @@ After de-duplication: **~225 unique findings**
 | MM3 | HnswIndex::build() loads all | `src/hnsw.rs:202-208` | ✅ Documented |
 | MM5 | Unbounded Vec in search results | `src/search.rs:194-228` | Open |
 | MM6 | FileSystemSource collects all files | `src/source/filesystem.rs:39-76` | Open |
-| MM7 | **HNSW checksum reads entire file** (dedup) | `src/hnsw.rs:117` | Open |
+| MM7 | **HNSW checksum reads entire file** (dedup) | `src/hnsw.rs:125` | ✅ Fixed |
 | MM9 | MCP tool_read() no file size limit | `src/mcp/tools/read.rs:39-48` | ✅ Fixed (10MB) |
 | MM10 | embed_documents temporary Strings | `src/embedder.rs:294-296` | Open |
 
@@ -532,13 +532,13 @@ After de-duplication: **~225 unique findings**
 
 | Priority | Original | Fixed | Remaining | Action |
 |----------|----------|-------|-----------|--------|
-| P1 | ~93 | ~70 | ~23 | Fix immediately |
-| P2 | ~79 | ~35 | ~44 | Fix next |
+| P1 | ~93 | ~76 | ~17 | Fix immediately |
+| P2 | ~79 | ~39 | ~40 | Fix next |
 | P3 | ~41 | ~5 | ~36 | Fix if time permits |
 | P4 | ~30 | ~3 | ~27 | Create issue, defer |
-| **Total** | **~243** | **~113** | **~130** | |
+| **Total** | **~243** | **~123** | **~120** | |
 
-*Updated 2026-02-05 after PR #190, #191, #192, and current batch*
+*Updated 2026-02-05 after PR #190-196 and high-impact/easy batch*
 
 ---
 
@@ -563,15 +563,16 @@ After de-duplication: **~225 unique findings**
 - ✅ D16: README GPU timing (verified accurate)
 - ✅ D17: nl.rs XMLParser example (included)
 
-### Code Hygiene — 6 of 7 fixed
+### Code Hygiene — 7 of 7 fixed
 - ✅ H1: ExitCode enum (now used in tests)
 - ✅ H2: run() dead code (documented with #[allow])
 - ✅ H3: InitializeParams fields (documented for MCP compliance)
 - ✅ H4: _no_ignore parameter (now warns if used)
 - ✅ H9: Note scoring duplication (score_note_row extracted)
+- ✅ H11: Redundant .to_string() calls (now uses .into_owned())
 - ✅ H12: Magic sentiment thresholds (constants used)
 
-### Error Propagation — 10 of 15 fixed
+### Error Propagation — 11 of 15 fixed
 - ✅ E1: Glob pattern parsing (logs warning)
 - ✅ E2: Second glob failure (logs warning)
 - ✅ E6: Schema version parsing (logs warning)
@@ -581,23 +582,29 @@ After de-duplication: **~225 unique findings**
 - ✅ E17: Poisoned mutex (logs warning)
 - ✅ E18: Index guard poisoning (logs "prior panic, recovering")
 - ✅ E19: Index open error (includes path via .with_context())
+- ✅ E20: Schema mismatch error (includes path)
 
-### API Design — 1 of 11 fixed
+### API Design — 3 of 11 fixed
 - ✅ A1: usize vs u64 for counts (both use u64 consistently)
+- ✅ A15: cosine_similarity precision (accumulates in f64)
+- ✅ A16: Embedding with_sentiment (runtime check with warning)
 
-### Panic Paths — 3 of 4 fixed
+### Panic Paths — 4 of 4 fixed
 - ✅ P3: Unwrap on enabled field (uses unreachable!() after guard)
 - ✅ P4: Embedder initialization (uses ? not expect)
 - ✅ P6: Ctrl+C handler (uses if let Err with warning)
+- ✅ P7: Progress bar template (uses unwrap_or_else with fallback)
 
 ### Module Boundaries — 2 of 4 fixed (Hard → Done)
 - ✅ M1: CLI monolith (split into 15 files)
 - ✅ M2: MCP monolith (split into 15 files)
 
-### Data Integrity — 0 newly fixed, but verified correct
+### Data Integrity — 2 newly fixed
 - ✅ DI2-4: Transactions (already correct)
 - ✅ DI6: Embedding validation (already has brace depth check)
 - ✅ DI9: Foreign keys (PRAGMA enabled)
+- ✅ DI13: Checksum doc (clarified security model)
+- ✅ DI14: WAL checkpoint on drop (impl Drop for Store)
 
 ### Edge Cases — 1 of 5 fixed
 - ✅ EC6: Duration parsing overflow (capped at 24h)
@@ -607,7 +614,8 @@ After de-duplication: **~225 unique findings**
 - ✅ PB8: JSON output path slashes (fixed in MCP)
 - ✅ PB10: UNC path canonicalization (strip_unc_prefix())
 
-### Memory Management — 1 of 6 fixed
+### Memory Management — 2 of 6 fixed
+- ✅ MM7: HNSW checksum (now streams instead of loading into memory)
 - ✅ MM9: MCP tool_read file size (10MB limit)
 
 ### Concurrency Safety — 1 of 1 fixed

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -517,7 +517,10 @@ pub(crate) fn run_index_pipeline(
         pb.set_style(
             ProgressStyle::default_bar()
                 .template("[{elapsed_precise}] {bar:40.cyan/blue} {msg}")
-                .expect("valid progress bar template"),
+                .unwrap_or_else(|e| {
+                    tracing::warn!("Progress template error: {}, using default", e);
+                    ProgressStyle::default_bar()
+                }),
         );
         pb
     };

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -118,7 +118,13 @@ impl Embedding {
     /// Converts a 768-dim model embedding to 769-dim with sentiment.
     /// Sentiment should be -1.0 (negative) to +1.0 (positive).
     pub fn with_sentiment(mut self, sentiment: f32) -> Self {
-        debug_assert_eq!(self.0.len(), MODEL_DIM, "Expected 768-dim embedding");
+        if self.0.len() != MODEL_DIM {
+            tracing::warn!(
+                actual = self.0.len(),
+                expected = MODEL_DIM,
+                "Unexpected embedding dimension in with_sentiment"
+            );
+        }
         self.0.push(sentiment.clamp(-1.0, 1.0));
         self
     }

--- a/src/math.rs
+++ b/src/math.rs
@@ -13,8 +13,11 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Option<f32> {
     }
     use simsimd::SpatialSimilarity;
     let score = f32::dot(a, b).unwrap_or_else(|| {
-        // Fallback for unsupported architectures
-        a.iter().zip(b).map(|(x, y)| x * y).sum::<f32>() as f64
+        // Fallback for unsupported architectures - accumulate in f64 for precision
+        a.iter()
+            .zip(b)
+            .map(|(&x, &y)| (x as f64) * (y as f64))
+            .sum::<f64>()
     }) as f32;
     Some(score)
 }

--- a/src/source/filesystem.rs
+++ b/src/source/filesystem.rs
@@ -128,7 +128,7 @@ impl Source for FileSystemSource {
             let rel_path = path.strip_prefix(&self.root).unwrap_or(&path).to_path_buf();
 
             items.push(SourceItem {
-                origin: rel_path.to_string_lossy().to_string(),
+                origin: rel_path.to_string_lossy().into_owned(),
                 source_type: "file",
                 content,
                 language,

--- a/src/store/calls.rs
+++ b/src/store/calls.rs
@@ -120,7 +120,7 @@ impl Store {
         file: &Path,
         function_calls: &[crate::parser::FunctionCalls],
     ) -> Result<(), StoreError> {
-        let file_str = file.to_string_lossy().to_string();
+        let file_str = file.to_string_lossy().into_owned();
         let total_calls: usize = function_calls.iter().map(|fc| fc.calls.len()).sum();
         tracing::trace!(
             file = %file_str,

--- a/src/store/chunks.rs
+++ b/src/store/chunks.rs
@@ -37,7 +37,7 @@ impl Store {
                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
                 )
                 .bind(&chunk.id)
-                .bind(chunk.file.to_string_lossy().to_string())
+                .bind(chunk.file.to_string_lossy().into_owned())
                 .bind("file")
                 .bind(chunk.language.to_string())
                 .bind(chunk.chunk_type.to_string())
@@ -108,7 +108,7 @@ impl Store {
         self.rt.block_on(async {
             let row: Option<(Option<i64>,)> =
                 sqlx::query_as("SELECT source_mtime FROM chunks WHERE origin = ?1 LIMIT 1")
-                    .bind(path.to_string_lossy().to_string())
+                    .bind(path.to_string_lossy().into_owned())
                     .fetch_optional(&self.pool)
                     .await?;
 
@@ -121,7 +121,7 @@ impl Store {
 
     /// Delete all chunks for an origin (file path or source identifier)
     pub fn delete_by_origin(&self, origin: &Path) -> Result<u32, StoreError> {
-        let origin_str = origin.to_string_lossy().to_string();
+        let origin_str = origin.to_string_lossy().into_owned();
 
         self.rt.block_on(async {
             let mut tx = self.pool.begin().await?;

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -29,8 +29,8 @@ pub enum StoreError {
     SystemTime,
     #[error("Runtime error: {0}")]
     Runtime(String),
-    #[error("Schema version mismatch: index is v{0}, cq expects v{1}. Run 'cq index --force' to rebuild.")]
-    SchemaMismatch(i32, i32),
+    #[error("Schema version mismatch in {0}: index is v{1}, cq expects v{2}. Run 'cq index --force' to rebuild.")]
+    SchemaMismatch(String, i32, i32),
     #[error("Index created by newer cq version (schema v{0}). Please upgrade cq.")]
     SchemaNewerThanCq(i32),
     #[error(

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -59,7 +59,7 @@ impl Store {
         source_file: &Path,
         file_mtime: i64,
     ) -> Result<usize, StoreError> {
-        let source_str = source_file.to_string_lossy().to_string();
+        let source_str = source_file.to_string_lossy().into_owned();
         tracing::debug!(
             source = %source_str,
             count = notes.len(),
@@ -141,7 +141,7 @@ impl Store {
 
     /// Delete all notes from a source file
     pub fn delete_notes_by_file(&self, source_file: &Path) -> Result<u32, StoreError> {
-        let source_str = source_file.to_string_lossy().to_string();
+        let source_str = source_file.to_string_lossy().into_owned();
 
         self.rt.block_on(async {
             let mut tx = self.pool.begin().await?;
@@ -178,7 +178,7 @@ impl Store {
         self.rt.block_on(async {
             let row: Option<(i64,)> =
                 sqlx::query_as("SELECT file_mtime FROM notes WHERE source_file = ?1 LIMIT 1")
-                    .bind(source_file.to_string_lossy().to_string())
+                    .bind(source_file.to_string_lossy().into_owned())
                     .fetch_optional(&self.pool)
                     .await?;
 


### PR DESCRIPTION
## Summary

Fixes 8 high-impact and easy audit findings in 3 batches:

**Batch 1 - Trivial:**
- **A15**: Fix cosine_similarity precision loss by accumulating in f64 instead of f32
- **DI13**: Clarify checksum security model - warns about corruption detection only
- **H11**: Replace `.to_string_lossy().to_string()` with `.into_owned()` (8 sites)

**Batch 2 - Easy:**
- **P7**: Use `unwrap_or_else` for progress bar template with fallback
- **A16**: Add runtime validation to `Embedding::with_sentiment`
- **E20**: Include database path in `SchemaMismatch` error message

**Batch 3 - Medium:**
- **MM7**: Stream HNSW checksums through blake3 instead of loading entire file into memory
- **DI14**: Implement `Drop` for `Store` with best-effort WAL checkpoint

## Test plan

- [x] `cargo check` passes
- [x] `cargo test --lib` passes (174 tests)
- [x] `cargo clippy -- -D warnings` passes
- [x] Manual verification: All edited files compile correctly

Generated with [Claude Code](https://claude.ai/code)
