### PR TITLE
chore: Release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5] - 2026-02-05
+
+### Added
+- **20-category audit complete** - All P1-P4 items addressed (#199, #200, #201, #209)
+  - ~243 findings across security, correctness, maintainability, and test coverage
+  - Future improvements tracked in issues #202-208
+
+### Changed
+- FTS errors now propagate instead of silently failing (#201)
+- Note scan capped at 1000 entries for memory safety (#201)
+- HNSW build progress logging shows chunk/note breakdown (#201)
+
+### Fixed
+- Unicode/emoji handling in FTS5 search (#201)
+- Go return type extraction for multiple returns (#201)
+- CAGRA batch progress logging (#201)
+
 ## [0.4.4] - 2026-02-05
 
 ### Added
@@ -402,6 +419,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI commands: init, doctor, index, stats, serve
 - Filter by language (`-l`) and path pattern (`-p`)
 
+[0.4.5]: https://github.com/jamie8johnson/cqs/compare/v0.4.4...v0.4.5
+[0.4.4]: https://github.com/jamie8johnson/cqs/compare/v0.4.3...v0.4.4
+[0.4.3]: https://github.com/jamie8johnson/cqs/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/jamie8johnson/cqs/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/jamie8johnson/cqs/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/jamie8johnson/cqs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/jamie8johnson/cqs/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/jamie8johnson/cqs/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/jamie8johnson/cqs/compare/v0.1.18...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 rust-version = "1.88"
 description = "Semantic code search for Claude Code. Find functions by what they do, not their names. Local ML, GPU-accelerated."


### PR DESCRIPTION
## Summary

Release v0.4.5 - 20-category audit completion.

## Changes

### Added
- 20-category audit complete (~243 findings addressed)
- Future improvements tracked in issues #202-208

### Changed
- FTS errors now propagate instead of silently failing
- Note scan capped at 1000 entries for memory safety
- HNSW build progress logging shows chunk/note breakdown

### Fixed
- Unicode/emoji handling in FTS5 search
- Go return type extraction for multiple returns
- CAGRA batch progress logging

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` passes
- [ ] Tag and create GitHub release after merge
- [ ] Publish to crates.io after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
