### PR TITLE
docs: Update continuity after Sprint 4 completion

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,26 +2,23 @@
 
 ## Right Now
 
-**Sprints 1-3 complete** (2026-02-05)
+**All 4 sprints complete** (2026-02-05)
 
-PR #213 merged - implemented 8 issues from Sprint 1, 2, and 3 of the plan.
+All 9 issues from the sprint plan have been implemented and merged.
 
 ### Session Summary (2026-02-05)
 - Sprint 1: Lazy grammar loading (#208), note search warning (#203), API key security (#202)
 - Sprint 2: CLI integration tests (#206), server tests (#205), atomic HNSW writes (#186)
 - Sprint 3: Pipeline resource sharing (#204), stress tests (#207)
+- Sprint 4: Schema migration framework (#188)
 - Fixed CI lock contention with serial_test crate
 
 ### Recent PRs
+- #215: Schema migration framework
+- #214: Docs update
 - #213: Sprint 1-3 improvements (8 issues closed)
-- #211: Release v0.4.5
-- #210: Docs update (continuity, roadmap)
-- #209: P4 triage completion
 
 ## Open Issues
-
-### Remaining from plan
-- #188: Schema migrations (Sprint 4 - hard, architectural)
 
 ### External/Waiting
 - #106: ort stable (currently 2.0.0-rc.11)
@@ -31,7 +28,7 @@ PR #213 merged - implemented 8 issues from Sprint 1, 2, and 3 of the plan.
 
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - Unified HNSW index (chunks + notes with prefix)
-- Store: split into focused modules (6 files)
+- Store: split into focused modules (7 files including migrations)
 - CLI: mod.rs + display.rs + watch.rs + pipeline.rs
-- Schema v10, WAL mode
+- Schema v10, WAL mode, migration framework ready
 - 290+ tests (including new CLI, server, stress tests)


### PR DESCRIPTION
Update PROJECT_CONTINUITY.md to reflect completion of all 4 sprints.