### PR TITLE
docs: Add agent teams workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,32 @@ After: `cqs_audit_mode(false)` or let it auto-expire (30 min default).
 
 Audit mode prevents false confidence from stale notes - forces you to examine code directly instead of trusting prior observations.
 
+## Agent Teams
+
+Use teams when dispatching 2+ agents that need coordination. Teams provide task lists, message passing, and structured shutdown.
+
+**When to use:**
+- Audit batches (5 parallel category reviewers)
+- Multi-file implementation with independent units
+- Research + implementation in parallel
+- Any work that benefits from task tracking across agents
+
+**Conventions:**
+- Name teams by purpose: `audit-batch-1`, `feat-streaming`, `refactor-errors`
+- Use `haiku` for simple/mechanical tasks, `sonnet` for judgment-heavy work, `opus` for complex reasoning
+- Always clean up teams when done (`Teammate cleanup`)
+- Teammates can't see your text output — use `SendMessage` to communicate
+
+**Task workflow:**
+1. `spawnTeam` — create team
+2. `TaskCreate` — define work items with clear acceptance criteria
+3. Spawn teammates via `Task` with `team_name` and `name`
+4. Teammates claim tasks, execute, report back
+5. `shutdown_request` each teammate when done
+6. `Teammate cleanup` to tear down
+
+**Teammate prompts must be self-contained.** Include file paths, context, and acceptance criteria. Teammates start with zero context — they can't see your conversation.
+
 ## 20-Category Audit
 
 Full design: `docs/plans/2026-02-04-20-category-audit-design.md`
@@ -71,9 +97,10 @@ Full design: `docs/plans/2026-02-04-20-category-audit-design.md`
 
 **Execution:**
 1. Enable audit mode before each batch
-2. Dispatch 5 agents in parallel
-3. Aggregate findings to `docs/audit-findings.md`
-4. After all batches: triage, prioritize, fix
+2. `spawnTeam` per batch, 5 teammates (one per category, haiku or sonnet)
+3. Each teammate writes findings to `docs/audit-findings.md` (append, don't overwrite)
+4. Shutdown team, cleanup before next batch
+5. After all batches: triage, prioritize, fix
 
 **Why:** Findings get lost when context compacts. Issues make work visible to future sessions.
 

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,9 +2,17 @@
 
 ## Right Now
 
-**v0.4.6 released** (2026-02-05)
+**Agent teams smoke-tested** (2026-02-05)
 
-All sprint work published to GitHub and crates.io.
+- Teams research preview is enabled and working
+- Smoke test passed: spawnTeam → TaskCreate → spawn teammate → task execution → message → shutdown → cleanup
+- Added "Agent Teams" section to CLAUDE.md with conventions (naming, model selection, cleanup, self-contained prompts)
+- Updated 20-Category Audit execution to use teams (one team per batch, 5 teammates per batch)
+- Built cqs binary to `/home/user001/.cargo-target/cq/debug/cqs` — MCP server needs Claude Code restart to connect
+
+### Pending
+- CLAUDE.md has uncommitted changes (Agent Teams section + audit execution update)
+- Restart Claude Code to pick up cqs MCP server
 
 ### What shipped in v0.4.6
 - Schema migration framework (#188)


### PR DESCRIPTION
## Summary
- Add "Agent Teams" section to CLAUDE.md with conventions for naming, model selection, cleanup, and self-contained prompts
- Update 20-category audit execution to use teams (one team per batch, structured shutdown between batches)
- Update PROJECT_CONTINUITY.md with current state

## Test plan
- [x] Smoke tested full team loop: spawn → task → message → shutdown → cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
