### PR TITLE
feat: Add C and Java language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -671,7 +671,9 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tree-sitter",
+ "tree-sitter-c",
  "tree-sitter-go",
+ "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-python",
  "tree-sitter-rust",
@@ -2768,7 +2770,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3665,10 +3667,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-c"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3aad8f0129083a59fe8596157552d2bb7148c492d44c21558d68ca1c722707"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-go"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ tree-sitter-python = { version = "0.25", optional = true }
 tree-sitter-typescript = { version = "0.23", optional = true }
 tree-sitter-javascript = { version = "0.25", optional = true }
 tree-sitter-go = { version = "0.25", optional = true }
+tree-sitter-c = { version = "0.24", optional = true }
+tree-sitter-java = { version = "0.23", optional = true }
 
 # ML
 ort = { version = "2.0.0-rc.11", features = ["cuda", "tensorrt"] }
@@ -98,7 +100,7 @@ once_cell = "1"
 libc = "0.2"
 
 [features]
-default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go"]
+default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-java"]
 
 # Language support (opt-in, all enabled by default)
 lang-rust = ["dep:tree-sitter-rust"]
@@ -106,7 +108,9 @@ lang-python = ["dep:tree-sitter-python"]
 lang-typescript = ["dep:tree-sitter-typescript"]
 lang-javascript = ["dep:tree-sitter-javascript"]
 lang-go = ["dep:tree-sitter-go"]
-lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go"]
+lang-c = ["dep:tree-sitter-c"]
+lang-java = ["dep:tree-sitter-java"]
+lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-java"]
 
 # Other features
 # encrypt feature removed - sqlx doesn't support SQLCipher directly

--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -1,0 +1,62 @@
+//! C language definition
+
+use super::{ChunkType, LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting C code chunks
+const CHUNK_QUERY: &str = r#"
+(function_definition
+  declarator: (function_declarator
+    declarator: (identifier) @name)) @function
+
+(struct_specifier
+  name: (type_identifier) @name
+  body: (field_declaration_list)) @struct
+
+(enum_specifier
+  name: (type_identifier) @name
+  body: (enumerator_list)) @enum
+
+(type_definition
+  declarator: (type_identifier) @name) @const
+
+(declaration
+  declarator: (init_declarator
+    declarator: (function_declarator
+      declarator: (identifier) @name))) @function
+"#;
+
+/// Tree-sitter query for extracting function calls
+const CALL_QUERY: &str = r#"
+(call_expression
+  function: (identifier) @callee)
+
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @callee))
+"#;
+
+/// Mapping from capture names to chunk types
+const TYPE_MAP: &[(&str, ChunkType)] = &[
+    ("function", ChunkType::Function),
+    ("struct", ChunkType::Struct),
+    ("enum", ChunkType::Enum),
+    ("const", ChunkType::Constant),
+];
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment"];
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "c",
+    grammar: || tree_sitter_c::LANGUAGE.into(),
+    extensions: &["c", "h"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    type_map: TYPE_MAP,
+    doc_nodes: DOC_NODES,
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}

--- a/src/language/java.rs
+++ b/src/language/java.rs
@@ -1,0 +1,60 @@
+//! Java language definition
+
+use super::{ChunkType, LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting Java code chunks
+const CHUNK_QUERY: &str = r#"
+(method_declaration
+  name: (identifier) @name) @function
+
+(constructor_declaration
+  name: (identifier) @name) @function
+
+(class_declaration
+  name: (identifier) @name) @class
+
+(interface_declaration
+  name: (identifier) @name) @interface
+
+(enum_declaration
+  name: (identifier) @name) @enum
+
+(record_declaration
+  name: (identifier) @name) @struct
+"#;
+
+/// Tree-sitter query for extracting function calls
+const CALL_QUERY: &str = r#"
+(method_invocation
+  name: (identifier) @callee)
+
+(object_creation_expression
+  type: (type_identifier) @callee)
+"#;
+
+/// Mapping from capture names to chunk types
+const TYPE_MAP: &[(&str, ChunkType)] = &[
+    ("function", ChunkType::Function),
+    ("class", ChunkType::Class),
+    ("interface", ChunkType::Interface),
+    ("enum", ChunkType::Enum),
+    ("struct", ChunkType::Struct),
+];
+
+/// Doc comment node types (Javadoc /** ... */ and regular comments)
+const DOC_NODES: &[&str] = &["line_comment", "block_comment"];
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "java",
+    grammar: || tree_sitter_java::LANGUAGE.into(),
+    extensions: &["java"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    type_map: TYPE_MAP,
+    doc_nodes: DOC_NODES,
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -17,8 +17,12 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
+#[cfg(feature = "lang-c")]
+mod c;
 #[cfg(feature = "lang-go")]
 mod go;
+#[cfg(feature = "lang-java")]
+mod java;
 #[cfg(feature = "lang-javascript")]
 mod javascript;
 #[cfg(feature = "lang-python")]
@@ -167,6 +171,12 @@ impl LanguageRegistry {
         #[cfg(feature = "lang-go")]
         reg.register(go::definition());
 
+        #[cfg(feature = "lang-c")]
+        reg.register(c::definition());
+
+        #[cfg(feature = "lang-java")]
+        reg.register(java::definition());
+
         reg
     }
 
@@ -226,6 +236,13 @@ mod tests {
         assert!(REGISTRY.from_extension("js").is_some());
         #[cfg(feature = "lang-go")]
         assert!(REGISTRY.from_extension("go").is_some());
+        #[cfg(feature = "lang-c")]
+        {
+            assert!(REGISTRY.from_extension("c").is_some());
+            assert!(REGISTRY.from_extension("h").is_some());
+        }
+        #[cfg(feature = "lang-java")]
+        assert!(REGISTRY.from_extension("java").is_some());
         assert!(REGISTRY.from_extension("xyz").is_none());
     }
 
@@ -251,6 +268,14 @@ mod tests {
             expected += 1;
         }
         #[cfg(feature = "lang-go")]
+        {
+            expected += 1;
+        }
+        #[cfg(feature = "lang-c")]
+        {
+            expected += 1;
+        }
+        #[cfg(feature = "lang-java")]
         {
             expected += 1;
         }

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -41,7 +41,7 @@ pub fn handle_tools_list() -> Result<Value> {
                     "language": {
                         "type": "string",
                         // Keep in sync with crate::parser::Language variants
-                        "enum": ["rust", "python", "typescript", "javascript", "go"],
+                        "enum": ["rust", "python", "typescript", "javascript", "go", "c", "java"],
                         "description": "Filter by language (optional)"
                     },
                     "path_pattern": {

--- a/tests/eval_test.rs
+++ b/tests/eval_test.rs
@@ -287,6 +287,8 @@ fn fixture_path(lang: Language) -> PathBuf {
         Language::TypeScript => "ts",
         Language::JavaScript => "js",
         Language::Go => "go",
+        Language::C => "c",
+        Language::Java => "java",
     };
     PathBuf::from(manifest_dir)
         .join("tests")

--- a/tests/model_eval.rs
+++ b/tests/model_eval.rs
@@ -547,6 +547,8 @@ fn fixture_path(lang: Language) -> PathBuf {
         Language::TypeScript => "ts",
         Language::JavaScript => "js",
         Language::Go => "go",
+        Language::C => "c",
+        Language::Java => "java",
     };
     PathBuf::from(manifest_dir)
         .join("tests")


### PR DESCRIPTION
## Summary
- Add C language support: functions, structs, enums, typedefs, call extraction
- Add Java language support: methods, constructors, classes, interfaces, enums, records, call extraction
- New feature flags: `lang-c`, `lang-java` (enabled by default, included in `lang-all`)
- NL return type extraction for both C and Java signatures
- Doc comment parsing (C: `/* */`, Java: `/** */` Javadoc)
- MCP search schema updated with "c" and "java" language options
- 4 new parser tests, language detection tests updated

## Test plan
- [x] `cargo build` — clean, no warnings
- [x] `cargo test` — all tests pass (184 total)
- [x] C parsing: functions, structs, enums, doc comments
- [x] Java parsing: classes, methods, interfaces, enums, Javadoc
- [x] Language detection: `.c`, `.h` → C, `.java` → Java
- [x] `FromStr`/`Display` roundtrip for new variants
