### PR TITLE
test: Add 50 tests across 6 coverage gaps

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,23 +2,33 @@
 
 ## Right Now
 
-**Parser/registry refactor complete** (2026-02-05)
+**Test coverage expansion — complete, needs commit/PR** (2026-02-05)
 
-Consolidated parser.rs duplication with language/ registry. parser.rs: 1469 → 1056 lines (28% reduction).
+All 6 modules covered. 375 tests (with GPU) / 364 (without GPU). 0 failures.
 
 ### Completed This Session
 - **PR triage**: Merged #52, #54, #53, #51, #220. Closed #164, #50.
 - **Phase 1**: Model eval — E5-base-v2 stays (100% Recall@5). PR #221 merged.
 - **Phase 2**: Skipped (E5 wins).
 - **Phase 3**: C and Java language support. PR #222 merged.
-- **Refactor**: Parser/registry consolidation. Language enum moved to language/mod.rs. Query constants deleted from parser.rs. Methods delegate to REGISTRY via Language::def(). infer_chunk_type data-driven via LanguageDef fields.
+- **Refactor**: Parser/registry consolidation. PR #223 merged. parser.rs: 1469 → 1056 lines (28% reduction).
+- **GPU setup**: CUDA 13.1 toolkit + conda + libcuvs 25.12 installed. `gpu-search` feature builds and passes all tests. Wrapper at `~/gpu-test.sh`.
+- **Test coverage**: 50 new tests across 6 modules (index: 4, cagra: 11, mcp/tools: 22, pipeline: 6, doctor: 3, graph: 4).
 
-### What's Next (per approved plan)
+### What's Next
+- Commit + PR for test coverage
 - **Phase 4**: Template experiments in nl.rs
 - **Phase 5**: Multi-index (5 sub-phases)
 
 ### Open PRs
-None. (Refactor uncommitted — needs PR.)
+None.
+
+### GPU Build
+```bash
+bash ~/gpu-test.sh test --features gpu-search  # all env vars set
+bash ~/gpu-test.sh build --features gpu-search
+```
+Needs: CUDA 13.1, conda base env (miniforge3), libcuvs 25.12
 
 ## Parked
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -40,3 +40,92 @@ pub trait VectorIndex: Send + Sync {
     /// Index type name (e.g., "HNSW", "CAGRA")
     fn name(&self) -> &'static str;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mock VectorIndex for testing trait behavior
+    struct MockIndex {
+        results: Vec<IndexResult>,
+        size: usize,
+    }
+
+    impl MockIndex {
+        fn new(size: usize) -> Self {
+            Self {
+                results: Vec::new(),
+                size,
+            }
+        }
+
+        fn with_results(results: Vec<IndexResult>) -> Self {
+            let size = results.len();
+            Self { results, size }
+        }
+    }
+
+    impl VectorIndex for MockIndex {
+        fn search(&self, _query: &Embedding, k: usize) -> Vec<IndexResult> {
+            self.results.iter().take(k).cloned().collect()
+        }
+
+        fn len(&self) -> usize {
+            self.size
+        }
+
+        fn name(&self) -> &'static str {
+            "Mock"
+        }
+    }
+
+    #[test]
+    fn test_index_result_fields() {
+        let result = IndexResult {
+            id: "chunk_1".to_string(),
+            score: 0.95,
+        };
+        assert_eq!(result.id, "chunk_1");
+        assert!((result.score - 0.95).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_default_is_empty() {
+        let empty = MockIndex::new(0);
+        assert!(empty.is_empty());
+
+        let nonempty = MockIndex::new(5);
+        assert!(!nonempty.is_empty());
+    }
+
+    #[test]
+    fn test_mock_search() {
+        let index = MockIndex::with_results(vec![
+            IndexResult {
+                id: "a".into(),
+                score: 0.9,
+            },
+            IndexResult {
+                id: "b".into(),
+                score: 0.8,
+            },
+            IndexResult {
+                id: "c".into(),
+                score: 0.7,
+            },
+        ]);
+        let query = Embedding::new(vec![0.0; 769]);
+        let results = index.search(&query, 2);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].id, "a");
+        assert_eq!(results[1].id, "b");
+    }
+
+    #[test]
+    fn test_trait_object_dispatch() {
+        let index: Box<dyn VectorIndex> = Box::new(MockIndex::new(42));
+        assert_eq!(index.len(), 42);
+        assert!(!index.is_empty());
+        assert_eq!(index.name(), "Mock");
+    }
+}


### PR DESCRIPTION
## Summary

- Add 50 new tests across 6 previously uncovered modules
- **index.rs**: 4 unit tests (MockIndex, trait dispatch, is_empty)
- **cagra.rs**: 11 GPU tests with static mutex serialization to prevent CUDA SIGSEGV
- **MCP tools**: 22 integration tests (search params, notes CRUD/escaping, callers/callees, audit mode, stats)
- **pipeline.rs**: 6 unit tests (create_embedded_batch variants, windowing constants)
- **doctor CLI**: 3 integration tests (runs, shows Runtime, shows Parser)
- **graph CLI**: 4 integration tests (callers/callees no-index error, JSON output)

Total: 326 → 375 tests (with GPU) / 364 (without GPU). 0 failures.

## Test plan

- [x] `cargo test` — 364 passed, 0 failed
- [x] `bash ~/gpu-test.sh test --features gpu-search` — 375 passed, 0 failed
- [x] CI: fmt, clippy, test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
