### PR TITLE
chore: Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-02-05
+
+### Added
+- **C and Java language support** (#222)
+  - tree-sitter-c and tree-sitter-java grammars
+  - 7 languages total (Rust, Python, TypeScript, JavaScript, Go, C, Java)
+- **Test coverage expansion** (#224)
+  - 50 new tests across 6 modules (cagra, index, MCP tools, pipeline, CLI)
+  - Total: 375 tests (GPU) / 364 (no GPU)
+
+### Changed
+- **Model evaluation complete** (#221)
+  - E5-base-v2 confirmed as best option: 100% Recall@5 (50/50 eval queries)
+- **Parser/registry consolidation** (#223)
+  - parser.rs reduced from 1469 to 1056 lines (28% reduction)
+  - Parser re-exports Language, ChunkType from language module
+
 ## [0.4.6] - 2026-02-05
 
 ### Added
@@ -453,6 +470,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI commands: init, doctor, index, stats, serve
 - Filter by language (`-l`) and path pattern (`-p`)
 
+[0.5.0]: https://github.com/jamie8johnson/cqs/compare/v0.4.6...v0.5.0
 [0.4.6]: https://github.com/jamie8johnson/cqs/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/jamie8johnson/cqs/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/jamie8johnson/cqs/compare/v0.4.3...v0.4.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Thank you for your interest in contributing to cqs!
 
 ### Feature Ideas
 
-- Additional language support (tree-sitter grammars: C, C++, Java, Ruby)
+- Additional language support (tree-sitter grammars: C++, Ruby, and more)
 - Non-CUDA GPU support (ROCm for AMD, Metal for Apple Silicon)
 - VS Code extension
 - Performance improvements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.4.6"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.88"
 description = "Semantic code search for Claude Code. Find functions by what they do, not their names. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,9 +2,7 @@
 
 ## Right Now
 
-**Test coverage expansion — complete, needs commit/PR** (2026-02-05)
-
-All 6 modules covered. 375 tests (with GPU) / 364 (without GPU). 0 failures.
+**Session complete** (2026-02-05)
 
 ### Completed This Session
 - **PR triage**: Merged #52, #54, #53, #51, #220. Closed #164, #50.
@@ -13,10 +11,9 @@ All 6 modules covered. 375 tests (with GPU) / 364 (without GPU). 0 failures.
 - **Phase 3**: C and Java language support. PR #222 merged.
 - **Refactor**: Parser/registry consolidation. PR #223 merged. parser.rs: 1469 → 1056 lines (28% reduction).
 - **GPU setup**: CUDA 13.1 toolkit + conda + libcuvs 25.12 installed. `gpu-search` feature builds and passes all tests. Wrapper at `~/gpu-test.sh`.
-- **Test coverage**: 50 new tests across 6 modules (index: 4, cagra: 11, mcp/tools: 22, pipeline: 6, doctor: 3, graph: 4).
+- **Test coverage**: 50 new tests across 6 modules. PR #224 merged. 375 tests (GPU) / 364 (no GPU).
 
 ### What's Next
-- Commit + PR for test coverage
 - **Phase 4**: Template experiments in nl.rs
 - **Phase 5**: Multi-index (5 sub-phases)
 
@@ -42,7 +39,7 @@ Nothing active.
 
 ## Architecture
 
-- Version: 0.4.6
+- Version: 0.5.0
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - Unified HNSW index (chunks + notes with prefix)
@@ -50,4 +47,4 @@ Nothing active.
 - Parser re-exports Language, ChunkType from language module
 - Store: split into focused modules (7 files including migrations)
 - CLI: mod.rs + display.rs + watch.rs + pipeline.rs
-- 326+ tests (including CLI, server, stress tests)
+- 375 tests with GPU / 364 without (including CLI, server, stress tests)

--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ Implements MCP Streamable HTTP spec 2025-11-25 with Origin validation and protoc
 - TypeScript
 - JavaScript (JSDoc `@param`/`@returns` tags improve search quality)
 - Go
+- C
+- Java
 
 ## Indexing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@
 ### Deferred
 
 - Signature-aware search (name boost covers most cases)
-- More languages (C, C++, Java, Ruby)
+- More languages (C++, Ruby) [C and Java shipped in Phase 5]
 - MCP extras: cqs_similar, cqs_index, progress notifications
 
 ## Phase 3: Integration
@@ -211,10 +211,25 @@
   - Atomic HNSW writes for crash safety (#186)
   - Note search warning at WARN level (#203)
 
+- [x] Model evaluation (#221)
+  - E5-base-v2 confirmed: 100% Recall@5 (50/50 eval queries)
+  - CodeSage/Qwen3 evaluation unnecessary — E5 wins
+
+- [x] C and Java language support (#222)
+  - tree-sitter-c, tree-sitter-java grammars
+  - Language enum + LanguageDef registry entries
+  - 7 languages total (Rust, Python, TypeScript, JavaScript, Go, C, Java)
+
+- [x] Parser/registry consolidation (#223)
+  - parser.rs: 1469 → 1056 lines (28% reduction)
+  - Parser re-exports Language, ChunkType from language module
+
+- [x] Test coverage expansion (#224)
+  - 50 new tests across 6 modules (cagra, index, mcp tools, pipeline, CLI)
+  - Total: 375 tests (GPU) / 364 (no GPU)
+
 ### Planned
 
-- [ ] C and Java language support (tree-sitter-c, tree-sitter-java)
-- [ ] Code-specific embedding model (CodeSage, Qwen3-Embedding vs E5)
 - [ ] Template experiments (no prefix, body keywords) - run eval to compare
 - [ ] Multi-index support (reference codebases)
   - Search multiple indexes simultaneously (project + stdlib + deps)


### PR DESCRIPTION
## Summary

- Bump version to 0.5.0
- Add C and Java to README supported languages
- Update ROADMAP: check off model eval, C/Java, parser refactor, test coverage
- Update CONTRIBUTING: remove shipped languages from feature ideas
- Add changelog entries for PRs #221-#224

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — 364 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
