### PR TITLE
feat: NL template experiments with eval harness

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,7 +2,7 @@
 
 ## Right Now
 
-**Session complete** (2026-02-05)
+**v0.5.0 released** (2026-02-05)
 
 ### Completed This Session
 - **PR triage**: Merged #52, #54, #53, #51, #220. Closed #164, #50.
@@ -12,6 +12,7 @@
 - **Refactor**: Parser/registry consolidation. PR #223 merged. parser.rs: 1469 → 1056 lines (28% reduction).
 - **GPU setup**: CUDA 13.1 toolkit + conda + libcuvs 25.12 installed. `gpu-search` feature builds and passes all tests. Wrapper at `~/gpu-test.sh`.
 - **Test coverage**: 50 new tests across 6 modules. PR #224 merged. 375 tests (GPU) / 364 (no GPU).
+- **Release v0.5.0**: Docs updated, PR #225 merged. Published to crates.io + GitHub release.
 
 ### What's Next
 - **Phase 4**: Template experiments in nl.rs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -228,9 +228,12 @@
   - 50 new tests across 6 modules (cagra, index, mcp tools, pipeline, CLI)
   - Total: 375 tests (GPU) / 364 (no GPU)
 
-### Planned
+- [x] Template experiments (#226)
+  - 5 variants tested: Standard, NoPrefix, BodyKeywords, Compact, DocFirst
+  - All scored 100% Recall@5 — ceiling effect from doc comments
+  - Baseline stays; infra available for harder eval cases later
 
-- [ ] Template experiments (no prefix, body keywords) - run eval to compare
+### Planned
 - [ ] Multi-index support (reference codebases)
   - Search multiple indexes simultaneously (project + stdlib + deps)
   - Index popular crates as reference (tokio, serde, axum)


### PR DESCRIPTION
## Summary

- Add `NlTemplate` enum with 5 variants (Standard, NoPrefix, BodyKeywords, Compact, DocFirst)
- Add `generate_nl_with_template()` and `extract_body_keywords()` with per-language stopwords
- Add template comparison eval harness in `tests/model_eval.rs`
- All 5 templates score 100% Recall@5 — ceiling effect from doc comments in eval fixtures
- Baseline template unchanged; infrastructure available for future experiments
- ROADMAP updated to check off template experiments

## Test plan

- [x] `cargo test` — 364 passed, 0 failed
- [x] `cargo test test_template_comparison -- --ignored --nocapture` — all 5 variants 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
