### PR TITLE
fix: Address P2 audit findings from 20-category review

### DIFF
--- a/src/cli/commands/graph.rs
+++ b/src/cli/commands/graph.rs
@@ -37,7 +37,7 @@ pub(crate) fn cmd_callers(_cli: &Cli, name: &str, json: bool) -> Result<()> {
             .map(|c| {
                 serde_json::json!({
                     "name": c.name,
-                    "file": c.file.to_string_lossy(),
+                    "file": c.file.to_string_lossy().replace('\\', "/"),
                     "line": c.line,
                 })
             })

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -22,6 +22,13 @@ pub(crate) fn cmd_init(cli: &Cli) -> Result<()> {
     // Create .cq directory
     std::fs::create_dir_all(&cq_dir).context("Failed to create .cq directory")?;
 
+    // Set restrictive permissions on .cq directory (Unix only)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&cq_dir, std::fs::Permissions::from_mode(0o700));
+    }
+
     // Create .gitignore
     let gitignore = cq_dir.join(".gitignore");
     std::fs::write(

--- a/src/math.rs
+++ b/src/math.rs
@@ -21,7 +21,11 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Option<f32> {
             .map(|(&x, &y)| (x as f64) * (y as f64))
             .sum::<f64>()
     }) as f32;
-    Some(score)
+    if score.is_finite() {
+        Some(score)
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -184,7 +184,7 @@ impl McpServer {
     ///
     /// Replaces absolute paths (starting with / or drive letter) with relative paths
     /// or generic descriptions to prevent information leakage to clients.
-    fn sanitize_error_message(&self, error: &str) -> String {
+    pub(crate) fn sanitize_error_message(&self, error: &str) -> String {
         static RE_UNIX: LazyLock<regex::Regex> = LazyLock::new(|| {
             regex::Regex::new(r"/(?:home|Users|tmp|var|usr|opt|etc|mnt|root)/[^\s:]+")
                 .expect("hardcoded regex")

--- a/src/mcp/tools/call_graph.rs
+++ b/src/mcp/tools/call_graph.rs
@@ -25,7 +25,7 @@ pub fn tool_callers(server: &McpServer, arguments: Value) -> Result<Value> {
             "callers": callers.iter().map(|c| {
                 serde_json::json!({
                     "name": c.name,
-                    "file": c.file.to_string_lossy(),
+                    "file": c.file.to_string_lossy().replace('\\', "/"),
                     "line": c.line,
                 })
             }).collect::<Vec<_>>(),

--- a/src/mcp/tools/notes.rs
+++ b/src/mcp/tools/notes.rs
@@ -164,7 +164,7 @@ pub fn tool_add_note(server: &McpServer, arguments: Value) -> Result<Value> {
 
     // Include index error in response if indexing failed
     if let Some(err) = index_error {
-        result["index_error"] = serde_json::json!(err);
+        result["index_error"] = serde_json::json!(server.sanitize_error_message(&err));
     }
 
     Ok(serde_json::json!({

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -22,6 +22,14 @@ pub fn tool_search(server: &McpServer, arguments: Value) -> Result<Value> {
 
     // Definition search mode - find by name only, skip embedding
     if args.name_only.unwrap_or(false) {
+        if args.query.trim().is_empty() {
+            return Ok(serde_json::json!({
+                "content": [{
+                    "type": "text",
+                    "text": "[]"
+                }]
+            }));
+        }
         let results = server.store.search_by_name(&args.query, limit)?;
         let json_results: Vec<_> = results
             .iter()

--- a/src/source/filesystem.rs
+++ b/src/source/filesystem.rs
@@ -55,6 +55,7 @@ impl FileSystemSource {
             .git_ignore(true)
             .git_global(true)
             .git_exclude(true)
+            .follow_links(false) // Don't follow symlinks (prevents cycles and traversal attacks)
             .build();
 
         for entry in walker.flatten() {
@@ -128,7 +129,7 @@ impl Source for FileSystemSource {
             let rel_path = path.strip_prefix(&self.root).unwrap_or(&path).to_path_buf();
 
             items.push(SourceItem {
-                origin: rel_path.to_string_lossy().into_owned(),
+                origin: rel_path.to_string_lossy().replace('\\', "/"),
                 source_type: "file",
                 content,
                 language,

--- a/src/store/calls.rs
+++ b/src/store/calls.rs
@@ -100,11 +100,8 @@ impl Store {
     /// Get call graph statistics
     pub fn call_stats(&self) -> Result<(u64, u64), StoreError> {
         self.rt.block_on(async {
-            let (total_calls,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM calls")
-                .fetch_one(&self.pool)
-                .await?;
-            let (unique_callees,): (i64,) =
-                sqlx::query_as("SELECT COUNT(DISTINCT callee_name) FROM calls")
+            let (total_calls, unique_callees): (i64, i64) =
+                sqlx::query_as("SELECT COUNT(*), COUNT(DISTINCT callee_name) FROM calls")
                     .fetch_one(&self.pool)
                     .await?;
 
@@ -224,17 +221,11 @@ impl Store {
     /// Get full call graph statistics
     pub fn function_call_stats(&self) -> Result<(u64, u64, u64), StoreError> {
         self.rt.block_on(async {
-            let (total_calls,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM function_calls")
-                .fetch_one(&self.pool)
-                .await?;
-            let (unique_callers,): (i64,) =
-                sqlx::query_as("SELECT COUNT(DISTINCT caller_name) FROM function_calls")
-                    .fetch_one(&self.pool)
-                    .await?;
-            let (unique_callees,): (i64,) =
-                sqlx::query_as("SELECT COUNT(DISTINCT callee_name) FROM function_calls")
-                    .fetch_one(&self.pool)
-                    .await?;
+            let (total_calls, unique_callers, unique_callees): (i64, i64, i64) = sqlx::query_as(
+                "SELECT COUNT(*), COUNT(DISTINCT caller_name), COUNT(DISTINCT callee_name) FROM function_calls",
+            )
+            .fetch_one(&self.pool)
+            .await?;
 
             Ok((
                 total_calls as u64,

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -144,6 +144,17 @@ pub struct CallerInfo {
     pub line: u32,
 }
 
+/// Note statistics (total count and categorized counts)
+#[derive(Debug, Clone)]
+pub struct NoteStats {
+    /// Total number of notes
+    pub total: u64,
+    /// Notes with negative sentiment (warnings)
+    pub warnings: u64,
+    /// Notes with positive sentiment (patterns)
+    pub patterns: u64,
+}
+
 /// Note metadata returned from search results
 #[derive(Debug, Clone)]
 pub struct NoteSummary {
@@ -292,13 +303,13 @@ impl SearchFilter {
     ///
     /// Returns Ok(()) if valid, or Err with description of what's wrong.
     pub fn validate(&self) -> Result<(), &'static str> {
-        // name_boost must be in [0.0, 1.0]
-        if self.name_boost < 0.0 || self.name_boost > 1.0 {
+        // name_boost must be in [0.0, 1.0] (NaN-safe: NaN is not contained in any range)
+        if !(0.0..=1.0).contains(&self.name_boost) {
             return Err("name_boost must be between 0.0 and 1.0");
         }
 
-        // note_weight must be in [0.0, 1.0]
-        if self.note_weight < 0.0 || self.note_weight > 1.0 {
+        // note_weight must be in [0.0, 1.0] (NaN-safe)
+        if !(0.0..=1.0).contains(&self.note_weight) {
             return Err("note_weight must be between 0.0 and 1.0");
         }
 

--- a/tests/store_notes_test.rs
+++ b/tests/store_notes_test.rs
@@ -205,10 +205,10 @@ fn test_note_embeddings_returns_prefixed_ids() {
 fn test_note_stats_empty() {
     let store = TestStore::new();
 
-    let (total, warnings, patterns) = store.note_stats().unwrap();
-    assert_eq!(total, 0);
-    assert_eq!(warnings, 0);
-    assert_eq!(patterns, 0);
+    let ns = store.note_stats().unwrap();
+    assert_eq!(ns.total, 0);
+    assert_eq!(ns.warnings, 0);
+    assert_eq!(ns.patterns, 0);
 }
 
 #[test]
@@ -235,8 +235,8 @@ fn test_note_stats_sentiments() {
         .upsert_notes_batch(&notes, &PathBuf::from("notes.toml"), 12345)
         .unwrap();
 
-    let (total, warnings, patterns) = store.note_stats().unwrap();
-    assert_eq!(total, 6, "Should have 6 total notes");
-    assert_eq!(warnings, 2, "Should have 2 warnings (sentiment < -0.3)");
-    assert_eq!(patterns, 2, "Should have 2 patterns (sentiment > 0.3)");
+    let ns = store.note_stats().unwrap();
+    assert_eq!(ns.total, 6, "Should have 6 total notes");
+    assert_eq!(ns.warnings, 2, "Should have 2 warnings (sentiment < -0.3)");
+    assert_eq!(ns.patterns, 2, "Should have 2 patterns (sentiment > 0.3)");
 }


### PR DESCRIPTION
## Summary

P2 audit fixes from the 20-category code review. 20 items addressed across store, MCP, CLI, and core modules.

### Fixes by category

**Data integrity & correctness:**
- NoteStats struct replaces tuple return type (#21)
- SQL IN clause batching in 500-row chunks (#23)
- NaN-safe SearchFilter validation (#27)
- FTS5 name query term quoting (#25)
- cosine_similarity NaN/infinity guard (#29)
- Glob filter correctness already fixed in P1; this adds empty query guard (#26)

**Performance & resource usage:**
- Consolidated 3→1 queries for note_stats, call_stats, function_call_stats (#33)
- SQLite cache_size reduced from 64MB to 16MB per connection (#32)
- HNSW save streaming checksum (no full file load) (#22)
- Watch reindex mtime caching per file (#35)
- index_notes_from_file deduplicated via shared cqs::index_notes (#13)

**Security & hardening:**
- Path normalization for Windows in call_graph, graph, filesystem (#15)
- .cq/ directory permissions 0o700 (#17)
- sanitize_error_message for notes index_error (#19)
- parse_file_calls file size guard (#24)
- count_vectors id map size guard (#28)
- FileSystemSource follow_links(false) (#30)
- Stdio transport 1MB line-length limit (#31)
- sanitize_error_message made pub(crate) (#19)

### Skipped P2 items
- #14 (search.rs → store refactor): Medium effort, deferred to P3
- #34 (batch metadata queries): Low impact, complex error handling paths

## Test plan
- [x] `cargo build` — no warnings
- [x] `cargo test` — 364 tests pass (0 failures)
- [x] `cargo clippy` — clean
- [x] Fresh-eyes review — 0 issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)
