### PR TITLE
fix: Address P3 audit findings

### DIFF
--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -16,8 +16,8 @@ const MODEL_FILE: &str = "onnx/model.onnx";
 const TOKENIZER_FILE: &str = "onnx/tokenizer.json";
 
 // blake3 checksums for model verification (empty = skip validation)
-const MODEL_BLAKE3: &str = "";
-const TOKENIZER_BLAKE3: &str = "";
+const MODEL_BLAKE3: &str = "5ca98b5db8c2d0e354163bff1160e4ca67b48e51e724d7b4a621270552fd5c04";
+const TOKENIZER_BLAKE3: &str = "6e933bf59db40b8b2a0de480fe5006662770757e1e1671eb7e48ff6a5f00b0b4";
 
 #[derive(Error, Debug)]
 pub enum EmbedderError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,14 +168,13 @@ pub fn index_notes(
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
 
-    // Delete old notes and insert new
-    store.delete_notes_by_file(notes_path)?;
+    // Atomically replace notes (delete old + insert new in single transaction)
     let note_embeddings: Vec<_> = notes
         .iter()
         .cloned()
         .zip(embeddings_with_sentiment)
         .collect();
-    store.upsert_notes_batch(&note_embeddings, notes_path, file_mtime)?;
+    store.replace_notes_for_file(&note_embeddings, notes_path, file_mtime)?;
 
     Ok(notes.len())
 }

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -97,6 +97,7 @@ pub fn tool_search(server: &McpServer, arguments: Value) -> Result<Value> {
         });
         (guard.is_active(), guard.status_line())
     };
+    let search_start = std::time::Instant::now();
     let results: Vec<UnifiedResult> = if audit_active {
         // Code-only search when audit mode is active
         let code_results = server.store.search_filtered_with_index(
@@ -117,6 +118,13 @@ pub fn tool_search(server: &McpServer, arguments: Value) -> Result<Value> {
             index_guard.as_deref(),
         )?
     };
+    let search_ms = search_start.elapsed().as_millis();
+    tracing::info!(
+        results = results.len(),
+        elapsed_ms = search_ms,
+        audit = audit_active,
+        "MCP search completed"
+    );
 
     let json_results: Vec<_> = results
         .iter()

--- a/src/mcp/transports/http.rs
+++ b/src/mcp/transports/http.rs
@@ -100,16 +100,16 @@ pub fn serve_http(
     let is_localhost = bind == "127.0.0.1" || bind == "localhost" || bind == "::1";
     if !is_localhost {
         if has_api_key {
-            eprintln!("WARNING: Binding to {} with API key authentication.", bind);
+            tracing::warn!("Binding to {} with API key authentication.", bind);
         } else {
-            eprintln!("WARNING: Binding to {} WITHOUT authentication!", bind);
+            tracing::warn!("Binding to {} WITHOUT authentication!", bind);
         }
     }
 
-    eprintln!("MCP HTTP server listening on http://{}", addr);
-    eprintln!("MCP Protocol Version: {}", MCP_PROTOCOL_VERSION);
+    tracing::info!("MCP HTTP server listening on http://{}", addr);
+    tracing::info!("MCP Protocol Version: {}", MCP_PROTOCOL_VERSION);
     if has_api_key {
-        eprintln!("Authentication: API key required (Authorization: Bearer <key>)");
+        tracing::info!("Authentication: API key required (Authorization: Bearer <key>)");
     }
 
     // Note: Creates separate runtime from Store's internal runtime.
@@ -120,7 +120,7 @@ pub fn serve_http(
         let listener = tokio::net::TcpListener::bind(&addr).await?;
         let shutdown = async {
             tokio::signal::ctrl_c().await.ok();
-            eprintln!("\nShutting down HTTP server...");
+            tracing::info!("Shutting down HTTP server...");
         };
         axum::serve(listener, app)
             .with_graceful_shutdown(shutdown)

--- a/tests/search_test.rs
+++ b/tests/search_test.rs
@@ -1,0 +1,411 @@
+//! Search path tests (P3 #36, #37)
+//!
+//! Tests for HNSW-guided search, brute-force search, glob filtering,
+//! name_boost hybrid scoring, and unified code+notes search.
+
+mod common;
+
+use common::{mock_embedding, test_chunk, TestStore};
+use cqs::embedder::Embedding;
+use cqs::index::{IndexResult, VectorIndex};
+use cqs::note::Note;
+use cqs::parser::{ChunkType, Language};
+use cqs::store::{SearchFilter, UnifiedResult};
+use std::path::PathBuf;
+
+// ============ Mock VectorIndex ============
+
+/// A mock vector index that returns pre-configured results
+struct MockIndex {
+    results: Vec<IndexResult>,
+}
+
+impl MockIndex {
+    fn new(results: Vec<IndexResult>) -> Self {
+        Self { results }
+    }
+}
+
+impl VectorIndex for MockIndex {
+    fn search(&self, _query: &Embedding, k: usize) -> Vec<IndexResult> {
+        self.results.iter().take(k).cloned().collect()
+    }
+
+    fn len(&self) -> usize {
+        self.results.len()
+    }
+
+    fn name(&self) -> &'static str {
+        "Mock"
+    }
+}
+
+// ============ Helpers ============
+
+/// Create a chunk with a specific file path and language
+fn chunk_with_path(name: &str, file: &str, lang: Language) -> cqs::Chunk {
+    let content = format!("fn {}() {{ /* body */ }}", name);
+    let hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+    cqs::Chunk {
+        id: format!("{}:1:{}", file, &hash[..8]),
+        file: PathBuf::from(file),
+        language: lang,
+        chunk_type: ChunkType::Function,
+        name: name.to_string(),
+        signature: format!("fn {}()", name),
+        content,
+        doc: None,
+        line_start: 1,
+        line_end: 5,
+        content_hash: hash,
+        parent_id: None,
+        window_idx: None,
+    }
+}
+
+/// Insert chunks with identical embeddings and return their IDs
+fn insert_chunks(store: &TestStore, chunks: &[cqs::Chunk], seed: f32) -> Vec<String> {
+    let emb = mock_embedding(seed);
+    let pairs: Vec<_> = chunks.iter().map(|c| (c.clone(), emb.clone())).collect();
+    store.upsert_chunks_batch(&pairs, Some(12345)).unwrap();
+    chunks.iter().map(|c| c.id.clone()).collect()
+}
+
+/// Insert a note and return its ID
+fn insert_note(store: &TestStore, id: &str, text: &str, sentiment: f32, seed: f32) {
+    let note = Note {
+        id: id.to_string(),
+        text: text.to_string(),
+        sentiment,
+        mentions: vec![],
+    };
+    let emb = mock_embedding(seed);
+    store
+        .upsert_notes_batch(&[(note, emb)], &PathBuf::from("notes.toml"), 12345)
+        .unwrap();
+}
+
+// ===== #36: search_by_candidate_ids =====
+
+#[test]
+fn test_search_by_candidate_ids_basic() {
+    let store = TestStore::new();
+    let c1 = test_chunk("foo", "fn foo() { 1 + 1 }");
+    let c2 = test_chunk("bar", "fn bar() { 2 + 2 }");
+    let c3 = test_chunk("baz", "fn baz() { 3 + 3 }");
+
+    let ids = insert_chunks(&store, &[c1, c2, c3], 1.0);
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter::default();
+
+    // Search only for c1 and c2
+    let candidate_ids: Vec<&str> = ids[..2].iter().map(|s| s.as_str()).collect();
+    let results = store
+        .search_by_candidate_ids(&candidate_ids, &query, &filter, 10, 0.0)
+        .unwrap();
+
+    assert_eq!(results.len(), 2, "Should find exactly 2 candidates");
+    let found_ids: Vec<&str> = results.iter().map(|r| r.chunk.id.as_str()).collect();
+    assert!(!found_ids.contains(&ids[2].as_str()), "Should not find c3");
+}
+
+#[test]
+fn test_search_by_candidate_ids_empty() {
+    let store = TestStore::new();
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter::default();
+
+    let results = store
+        .search_by_candidate_ids(&[], &query, &filter, 10, 0.0)
+        .unwrap();
+    assert!(results.is_empty());
+}
+
+#[test]
+fn test_search_by_candidate_ids_respects_threshold() {
+    let store = TestStore::new();
+    let c1 = test_chunk("foo", "fn foo() { opposite }");
+    let emb = mock_embedding(-1.0);
+    store
+        .upsert_chunks_batch(&[(c1.clone(), emb)], Some(12345))
+        .unwrap();
+
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter::default();
+
+    let results = store
+        .search_by_candidate_ids(&[c1.id.as_str()], &query, &filter, 10, 0.99)
+        .unwrap();
+    assert!(
+        results.is_empty(),
+        "Opposite embedding should not meet 0.99 threshold"
+    );
+}
+
+#[test]
+fn test_search_by_candidate_ids_with_glob_filter() {
+    let store = TestStore::new();
+    let c1 = chunk_with_path("foo", "src/main.rs", Language::Rust);
+    let c2 = chunk_with_path("bar", "tests/test.rs", Language::Rust);
+
+    let ids = insert_chunks(&store, &[c1, c2], 1.0);
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter {
+        path_pattern: Some("src/**".to_string()),
+        ..Default::default()
+    };
+
+    let candidate_ids: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
+    let results = store
+        .search_by_candidate_ids(&candidate_ids, &query, &filter, 10, 0.0)
+        .unwrap();
+
+    assert_eq!(results.len(), 1, "Glob should filter to src/ only");
+    assert!(results[0].chunk.file.to_string_lossy().contains("src/"));
+}
+
+// ===== #36: search_filtered_with_index =====
+
+#[test]
+fn test_search_filtered_with_index_uses_index() {
+    let store = TestStore::new();
+    let c1 = test_chunk("indexed_fn", "fn indexed_fn() { indexed }");
+    let c2 = test_chunk("other_fn", "fn other_fn() { other }");
+
+    let ids = insert_chunks(&store, &[c1, c2], 1.0);
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter::default();
+
+    // Mock index returns only c1
+    let mock = MockIndex::new(vec![IndexResult {
+        id: ids[0].clone(),
+        score: 0.9,
+    }]);
+
+    let results = store
+        .search_filtered_with_index(&query, &filter, 10, 0.0, Some(&mock))
+        .unwrap();
+
+    // Should only return c1 (the one the index returned)
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].chunk.id, ids[0]);
+}
+
+#[test]
+fn test_search_filtered_with_index_falls_back_without_index() {
+    let store = TestStore::new();
+    let c1 = test_chunk("brute_fn", "fn brute_fn() { brute }");
+    insert_chunks(&store, &[c1], 1.0);
+
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter::default();
+
+    // No index provided — should fall back to brute-force
+    let results = store
+        .search_filtered_with_index(&query, &filter, 10, 0.0, None)
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+}
+
+// ===== #36: search_unified_with_index =====
+
+#[test]
+fn test_search_unified_with_index_returns_both() {
+    let store = TestStore::new();
+    let c1 = test_chunk("unified_fn", "fn unified_fn() { code }");
+    let ids = insert_chunks(&store, &[c1], 1.0);
+
+    insert_note(&store, "note1", "Important pattern", 0.5, 1.0);
+
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter::default();
+
+    // Mock index returns both chunk and note
+    let mock = MockIndex::new(vec![
+        IndexResult {
+            id: ids[0].clone(),
+            score: 0.9,
+        },
+        IndexResult {
+            id: "note:note1".to_string(),
+            score: 0.85,
+        },
+    ]);
+
+    let results = store
+        .search_unified_with_index(&query, &filter, 10, 0.0, Some(&mock))
+        .unwrap();
+
+    let has_code = results.iter().any(|r| matches!(r, UnifiedResult::Code(_)));
+    let has_note = results.iter().any(|r| matches!(r, UnifiedResult::Note(_)));
+
+    assert!(has_code, "Should include code results");
+    assert!(has_note, "Should include note results");
+}
+
+#[test]
+fn test_search_unified_without_index() {
+    let store = TestStore::new();
+    let c1 = test_chunk("no_idx_fn", "fn no_idx_fn() { stuff }");
+    insert_chunks(&store, &[c1], 1.0);
+
+    insert_note(&store, "note2", "Another note", 0.0, 1.0);
+
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter::default();
+
+    // No index — brute-force for both
+    let results = store
+        .search_unified_with_index(&query, &filter, 10, 0.0, None)
+        .unwrap();
+
+    let has_code = results.iter().any(|r| matches!(r, UnifiedResult::Code(_)));
+    let has_note = results.iter().any(|r| matches!(r, UnifiedResult::Note(_)));
+
+    assert!(has_code, "Should include code from brute-force");
+    assert!(has_note, "Should include notes from brute-force");
+}
+
+#[test]
+fn test_search_unified_note_weight_zero_excludes_notes() {
+    let store = TestStore::new();
+    let c1 = test_chunk("weighted_fn", "fn weighted_fn() { w }");
+    insert_chunks(&store, &[c1], 1.0);
+    insert_note(&store, "note3", "Excluded note", 0.0, 1.0);
+
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter {
+        note_weight: 0.0,
+        ..Default::default()
+    };
+
+    let results = store
+        .search_unified_with_index(&query, &filter, 10, 0.0, None)
+        .unwrap();
+
+    let has_note = results.iter().any(|r| matches!(r, UnifiedResult::Note(_)));
+    assert!(!has_note, "note_weight=0 should exclude notes");
+}
+
+// ===== #37: search_filtered with glob =====
+
+#[test]
+fn test_search_filtered_glob_pattern() {
+    let store = TestStore::new();
+    let c1 = chunk_with_path("src_fn", "src/lib.rs", Language::Rust);
+    let c2 = chunk_with_path("test_fn", "tests/test.rs", Language::Rust);
+    let c3 = chunk_with_path("bench_fn", "benches/bench.rs", Language::Rust);
+
+    insert_chunks(&store, &[c1, c2, c3], 1.0);
+
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter {
+        path_pattern: Some("src/**".to_string()),
+        ..Default::default()
+    };
+
+    let results = store.search_filtered(&query, &filter, 10, 0.0).unwrap();
+
+    assert_eq!(results.len(), 1, "Glob should filter to src/ only");
+    assert_eq!(results[0].chunk.name, "src_fn");
+}
+
+// ===== #37: search_filtered with language filter =====
+
+#[test]
+fn test_search_filtered_language() {
+    let store = TestStore::new();
+    let c1 = chunk_with_path("rust_fn", "src/main.rs", Language::Rust);
+    let c2 = chunk_with_path("py_fn", "src/main.py", Language::Python);
+
+    insert_chunks(&store, &[c1, c2], 1.0);
+
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter::new().with_language(Language::Rust);
+
+    let results = store.search_filtered(&query, &filter, 10, 0.0).unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].chunk.name, "rust_fn");
+}
+
+// ===== #37: brute-force note search =====
+
+#[test]
+fn test_search_notes_brute_force() {
+    let store = TestStore::new();
+    insert_note(&store, "n1", "First note about errors", -0.5, 1.0);
+    insert_note(&store, "n2", "Second note about patterns", 0.5, 1.0);
+    insert_note(&store, "n3", "Unrelated note", 0.0, -1.0);
+
+    let query = mock_embedding(1.0);
+    let results = store.search_notes(&query, 10, 0.0).unwrap();
+
+    // n1 and n2 have same direction as query, n3 is opposite
+    assert!(results.len() >= 2, "Should find at least 2 matching notes");
+
+    // Check ordering (highest score first)
+    for window in results.windows(2) {
+        assert!(
+            window[0].score >= window[1].score,
+            "Results should be sorted by score"
+        );
+    }
+}
+
+#[test]
+fn test_search_notes_brute_force_threshold() {
+    let store = TestStore::new();
+    insert_note(&store, "n1", "Matching note", 0.0, 1.0);
+    insert_note(&store, "n2", "Opposite note", 0.0, -1.0);
+
+    let query = mock_embedding(1.0);
+    let results = store.search_notes(&query, 10, 0.9).unwrap();
+
+    // Only n1 should match (same direction), n2 is opposite
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].note.id, "n1");
+}
+
+#[test]
+fn test_search_notes_brute_force_limit() {
+    let store = TestStore::new();
+    for i in 0..10 {
+        insert_note(
+            &store,
+            &format!("n{}", i),
+            &format!("Note number {}", i),
+            0.0,
+            1.0,
+        );
+    }
+
+    let query = mock_embedding(1.0);
+    let results = store.search_notes(&query, 3, 0.0).unwrap();
+
+    assert_eq!(results.len(), 3, "Should respect limit");
+}
+
+// ===== #37: search_by_name FTS =====
+
+#[test]
+fn test_search_by_name() {
+    let store = TestStore::new();
+    let c1 = test_chunk("parse_config", "fn parse_config() { parse }");
+    let c2 = test_chunk("render_ui", "fn render_ui() { render }");
+    let c3 = test_chunk("parse_args", "fn parse_args() { args }");
+
+    insert_chunks(&store, &[c1, c2, c3], 1.0);
+
+    let results = store.search_by_name("parse", 10).unwrap();
+    assert!(results.len() >= 2, "Should find at least 2 'parse' chunks");
+
+    for r in &results {
+        assert!(
+            r.chunk.name.contains("parse"),
+            "FTS results should match 'parse', got: {}",
+            r.chunk.name
+        );
+    }
+}


### PR DESCRIPTION
## Summary

P3 audit fixes from the 20-category code review (12 items, 8 implemented):

- **Atomic note replacement**: `replace_notes_for_file()` single-transaction method replaces separate delete+insert (#38)
- **Store Drop panic guard**: `catch_unwind` around `block_on` to prevent panics in async contexts (#41)
- **Pipeline calls batching**: `upsert_calls_batch()` reduces N transactions to 1 per batch (#43)
- **GPU-to-CPU double-windowing fix**: GPU thread now uses `prepare_for_embedding` like CPU, sends cached chunks directly to writer on failure (#44)
- **Observability**: MCP search timing span, GPU/CPU thread termination logging, HTTP server eprintln→tracing (#45)
- **Model checksums**: BLAKE3 hashes populated for E5-base-v2 model and tokenizer (#47)
- **note_weight=0 bug fix**: Actually excludes notes from search (was documented but not implemented)
- **15 new search tests**: HNSW-guided search, brute-force, glob filtering, language filtering, unified code+notes, FTS name search (#36, #37)

Total tests: 379 (was 364)

## Skipped P3 Items (deferred to P4)

- #39: HNSW stale after MCP note additions (needs design)
- #40: Notes file locking (needs fs2 dependency)
- #42: CAGRA RAII guard pattern (GPU-only, complex)
- #46: Cache parsed notes.toml in MCP server (optimization)

## Test plan

- [x] All 379 tests pass
- [x] Clippy clean
- [x] No build warnings
- [x] Fresh-eyes review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
