### PR TITLE
chore: Update tears, add --body-file rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ powershell.exe -Command 'gh pr merge N --squash --delete-branch'
 
 **Use `gh pr checks --watch`** to wait for CI. Don't use `sleep` + poll.
 
-**PowerShell mangles complex strings.** Backticks, quotes, newlines in `gh issue create --body` or `gh pr create --body` will break. Write to a file on `/mnt/c/` and use `--body-file` instead.
+**ALWAYS use `--body-file` for PR/issue bodies.** Never inline heredocs or multiline strings in `gh pr create --body` or `gh issue create --body`. Two reasons: (1) PowerShell mangles complex strings, (2) Claude Code captures the entire multiline command as a permission entry in `settings.local.json`, corrupting the file and breaking startup. Write body to `/mnt/c/Projects/cq/pr_body.md`, use `--body-file`, delete after.
 
 **main is protected** - all changes via PR.
 

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,13 +2,12 @@
 
 ## Right Now
 
-**v0.5.1 released** (2026-02-05)
+**Housekeeping** (2026-02-06)
 
-### What Happened
-- 20-category audit: ~85 actionable findings
-- P1 fixed in PR #227, P2 in #228, P3 in #229
-- 13 P4 items deferred to issues #230-#241
-- v0.5.1 released to GitHub and crates.io
+- v0.5.1 released (2026-02-05), audit complete
+- Fixed heredoc-in-permissions bug in settings.local.json (previous session)
+- Notes groomed, CLAUDE.md updated with --body-file rule
+- Committing leftover tears from v0.5.1 session
 
 ### Open PRs
 None.
@@ -23,6 +22,7 @@ Needs: CUDA 13.1, conda base env (miniforge3), libcuvs 25.12
 ## Parked
 
 - **Phase 5**: Multi-index (deferred for audit)
+- **Note management tools**: `cqs_update_note`, `cqs_remove_note` (roadmap planned)
 - **P4 issues**: #230-#241 (HNSW staleness, file locking, CAGRA guard, etc.)
 
 ## Open Issues

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -239,6 +239,10 @@
   - 15 new search path tests, test count 379 (no GPU)
 
 ### Planned
+- [ ] Note management tools (`cqs_update_note`, `cqs_remove_note`)
+  - MCP tools for updating/removing notes by ID or text match
+  - Enable regular note grooming without manual TOML editing
+  - CLI: `cqs notes list`, `cqs notes remove <id>`
 - [ ] Multi-index support (reference codebases)
   - Search multiple indexes simultaneously (project + stdlib + deps)
   - Index popular crates as reference (tokio, serde, axum)

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -256,13 +256,13 @@ mentions = ["cqs watch", "notes.toml", "indexing"]
 
 [[note]]
 sentiment = 0.5
-text = "--bind flag added with safety check. Non-localhost requires --dangerously-allow-network-bind. API key auth parked - reverse proxy with real auth is better for serious network exposure."
+text = "--bind flag with safety check. Non-localhost requires --dangerously-allow-network-bind + --api-key. API key uses constant-time comparison (subtle crate). --api-key-file for secure loading with zeroize."
 mentions = ["cli.rs", "mcp.rs", "--bind", "auth"]
 
 [[note]]
 sentiment = 0.5
 text = "sqlx migration complete: replaced rusqlite/r2d2 with sqlx async SQLite. Key design choice: sync wrappers via internal Runtime::block_on() preserve existing API so cli.rs/mcp.rs didn't need changes. Schema init needed fix: split SQL by semicolons AND skip leading comment-only lines (not just statements that start with --)."
-mentions = ["src/store.rs", "Cargo.toml"]
+mentions = ["src/store/mod.rs", "Cargo.toml"]
 
 [[note]]
 sentiment = 0.5
@@ -276,18 +276,8 @@ mentions = ["hnsw.rs", "security", "path traversal"]
 
 [[note]]
 sentiment = 1
-text = "Skeptical 10-category audit complete. 16 issues closed. Property tests (proptest) added - found RRF bound bug immediately. Test count: 145. Security docs expanded with threat model, filesystem access, symlink behavior."
-mentions = ["SECURITY.md", "src/store.rs", "src/embedder.rs", "tests/mcp_test.rs"]
-
-[[note]]
-sentiment = 1
-text = "Post-audit assessment: codebase is solid. 145 tests, property tests found real bug, security documented honestly. Remaining gaps (cache/GPU testing) would need refactoring - adequate as-is. Ready for users."
-mentions = ["PROJECT_CONTINUITY.md"]
-
-[[note]]
-sentiment = 1.0
-text = "Proptest fuzz targets added (17 tests). Covers TOML parser, tokenizer, JSDoc, FTS sanitization, JSON-RPC, origin validation. Total tests now 162 - more than doubled from pre-audit 75."
-mentions = ["src/note.rs", "src/nl.rs", "src/store.rs", "src/mcp.rs", "proptest"]
+text = "First 10-category audit: 16 issues closed, proptest found RRF bound bug immediately, security docs expanded. Second 20-category audit (v0.5.1): ~85 findings, P1-P3 fixed in 3 PRs, 13 P4 items deferred. Test count: 379 (no GPU). Audits consistently find real bugs."
+mentions = ["SECURITY.md", "src/store/", "tests/", "audit"]
 
 [[note]]
 sentiment = 1.0
@@ -297,7 +287,7 @@ mentions = ["src/store/chunks.rs", "src/hnsw.rs", "embedding_batches", "build_ba
 [[note]]
 sentiment = 1.0
 text = "Notes now included in HNSW index with 'note:' prefix. search_unified_with_index partitions candidates by prefix, fetches from chunks/notes tables separately. O(n) brute-force eliminated. Fixes #103."
-mentions = ["src/store/notes.rs", "src/search.rs", "src/cli/mod.rs", "note_embeddings", "search_notes_by_ids"]
+mentions = ["src/store/notes.rs", "src/search.rs", "src/cli/pipeline.rs", "note_embeddings", "search_notes_by_ids"]
 
 [[note]]
 sentiment = 0.5
@@ -311,8 +301,8 @@ mentions = ["audit mode", "verification", "dead code"]
 
 [[note]]
 sentiment = 0.5
-text = "Always update docs/audit-triage.md status column when fixing audit items. Mark as ✅ Fixed with brief note (e.g., \"logs warning\", \"documented\"). Update summary counts after each batch."
-mentions = ["docs/audit-triage.md", "audit findings"]
+text = "Audit findings file: docs/audit-findings.md. Triage by impact x effort into P1-P4. Fix P1 first (easy + high-impact), create issues for P4 (hard or low-impact). Collect ALL findings before fixing ANY."
+mentions = ["docs/audit-findings.md", "audit"]
 
 [[note]]
 sentiment = 0.5
@@ -333,3 +323,23 @@ mentions = ["multi-index", "model selection", "roadmap"]
 sentiment = 0.5
 text = "Model eval complete (Phase 1): E5-base-v2, BGE-base-en-v1.5, and E5-large-v2 all scored 100% Recall@5 on 50-query eval suite. Eval is saturated - need harder queries to differentiate models. Decision: stay with E5-base-v2 (smallest, proven, no schema change needed). Phase 2 (model switch) skipped."
 mentions = ["embedder.rs", "model selection", "eval", "E5"]
+
+[[note]]
+sentiment = -1.0
+text = "Glob filter BEFORE heap was the #1 correctness bug from the 20-category audit. Brute-force search applied glob AFTER selecting top-k from heap, meaning filtered results could miss relevant chunks that were displaced by non-matching ones. Always filter before ranking."
+mentions = ["src/search.rs", "glob", "brute-force", "algorithm correctness"]
+
+[[note]]
+sentiment = 0.5
+text = "note_weight=0 bug: documented as 'excludes notes from results' but only zeroed scores - notes still appeared. Caught by test_search_unified_note_weight_zero_excludes_notes. Tests that assert absence (not just presence) find real bugs. Write negative-case tests."
+mentions = ["src/search.rs", "SearchFilter", "note_weight", "testing"]
+
+[[note]]
+sentiment = 1.0
+text = "20-category audit v2 (v0.5.1): 5 parallel agents per batch, 4 batches, audit mode enabled. Found ~85 actionable items from ~120 raw. Key: collect ALL findings before fixing ANY. Batch by priority tier (P1-P4), fix in order. Took 3 PRs to fix P1-P3, created 13 issues for P4."
+mentions = ["docs/audit-findings.md", "audit", "v0.5.1", "workflow"]
+
+[[note]]
+sentiment = -0.5
+text = "Heredoc in `gh pr create --body` gets captured as a permission entry in .claude/settings.local.json, causing parse errors on next startup. Fix: always write PR/release bodies to a temp file and use --body-file instead of inline heredocs. The multiline content gets serialized into the permissions allow list as a malformed Bash() entry."
+mentions = ["settings.local.json", "gh pr create", "powershell.exe", "heredoc"]


### PR DESCRIPTION
## Summary
- Add `--body-file` rule to CLAUDE.md — heredoc in `gh pr create --body` gets captured as a permission entry in `settings.local.json`, corrupting the file
- Groom notes (consolidated 3 audit notes into 1, updated stale mentions, added new findings)
- Update PROJECT_CONTINUITY.md and ROADMAP.md from v0.5.1 session

## Test plan
- [x] No code changes — docs/notes only
- [x] `cargo build` not needed

Generated with [Claude Code](https://claude.com/claude-code)
