### PR TITLE
chore: Enable auto-invocation for safe skills

### DIFF
--- a/.claude/skills/docs-review/SKILL.md
+++ b/.claude/skills/docs-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-review
 description: Review project docs for staleness. Checks lib.rs, Cargo.toml, README, CONTRIBUTING, SECURITY, PRIVACY, and GitHub repo metadata.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # Docs Review

--- a/.claude/skills/groom-notes/SKILL.md
+++ b/.claude/skills/groom-notes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: groom-notes
 description: Review and clean up stale notes in notes.toml. Use when notes accumulate and need pruning.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[--warnings|--patterns|--all]"
 ---
 

--- a/.claude/skills/reindex/SKILL.md
+++ b/.claude/skills/reindex/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reindex
 description: Rebuild the cqs index and show before/after stats comparison.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[--force]"
 ---
 

--- a/.claude/skills/update-tears/SKILL.md
+++ b/.claude/skills/update-tears/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update-tears
 description: Update PROJECT_CONTINUITY.md and notes.toml with current session state. Use proactively before context compaction or when switching tasks.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # Update Tears

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -4,10 +4,18 @@
 
 **Clean state** (2026-02-06)
 
-Branch: main. Commit `9be4453` (notes grooming) not yet pushed.
+Branch: main, synced with remote. No pending work.
 
-### This session
-- Groomed notes.toml: 40 → 31 notes (removed 9 stale/duplicate/superseded)
+### Recently merged
+- PR #248: docs-review skill, notes grooming, stale doc fixes
+
+### Dev environment changes (not in repo)
+- `~/.bashrc`: added `LD_LIBRARY_PATH` for ort CUDA libs
+- `~/.config/systemd/user/cqs-watch.service`: auto-starts `cqs watch` on WSL boot
+- Index reindexed: 1,612 chunks, 78 files, HNSW current
+
+### Skills
+8 skills in `.claude/skills/`: audit, bootstrap, docs-review, groom-notes, pr, reindex, release, update-tears
 
 ## Parked
 


### PR DESCRIPTION
## Summary

- Enable auto-invocation (`disable-model-invocation: false`) for 4 safe skills: update-tears, groom-notes, docs-review, reindex
- These can now trigger without explicit `/skill-name` prefix since they're read-only or interactive with user approval
- Update tears with dev environment changes (CUDA LD_LIBRARY_PATH, systemd cqs-watch service)

## Test plan

- [x] Skills appear in system reminder without `/` prefix
- [ ] Verify "update tears" (without slash) auto-invokes the skill
- [ ] Verify "groom notes", "docs review", "reindex" similarly auto-invoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)
