### PR TITLE
Add CJK tokenization for FTS search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,8 @@ The HNSW disaster: built an index, wrote save/load, marked "done" - but search n
 
 **"Done" means a user can use it, not that code exists.**
 
+5. **Update the roadmap.** Check off completed items in `ROADMAP.md`. Stale roadmaps cause duplicate work.
+
 ## Project Conventions
 
 - Rust edition 2021

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -243,10 +243,13 @@
   - MCP tools: `cqs_update_note`, `cqs_remove_note` (atomic TOML rewrite)
   - `rewrite_notes_file()` helper with header preservation
 
-### Planned
-- [ ] Note grooming command/skill (#245)
+### Done (cont.)
+
+- [x] Note grooming command/skill (#245)
   - `cqs notes list` — display all notes with sentiment, staleness
   - `/groom-notes` skill — interactive review + batch cleanup
+
+### Planned
 - [ ] Multi-index support (reference codebases)
   - Search multiple indexes simultaneously (project + stdlib + deps)
   - Index popular crates as reference (tokio, serde, axum)


### PR DESCRIPTION
## Summary

- Split CJK characters (Chinese, Japanese kanji, Korean hangul, hiragana, katakana) into individual tokens in `tokenize_identifier` and `TokenizeIdentifierIter`
- Added `is_cjk()` helper covering CJK Unified Ideographs, Extensions, Hiragana, Katakana, Hangul
- No schema changes needed — pre-normalization handles CJK before FTS5 insertion

Also:
- Added "update the roadmap" to CLAUDE.md completion checklist
- Marked note grooming (#245) as done in ROADMAP.md

## Test plan

- [x] `test_tokenize_identifier_cjk` — Chinese, Japanese, Korean, mixed Latin+CJK, underscore-separated
- [x] `test_normalize_for_fts_cjk` — verifies FTS normalization path
- [x] Doctest for `tokenize_identifier` with CJK example
- [x] Full test suite passes (0 warnings)

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)
