### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.3] - 2026-02-06
+## [0.6.0] - 2026-02-06
 
 ### Added
 - **Multi-index search**: search across project + reference codebases simultaneously
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Score-based merge with configurable weight multiplier (default 0.8)
   - `cqs doctor` validates reference index health
   - `[[reference]]` config entries in `.cqs.toml`
+
+### Fixed
+- **P1 audit fixes** (12 items): path traversal in glob filter, pipeline mtime race, threshold consistency, SSE origin validation, stale documentation, error message leaks
+- **P2 audit fixes** (5 items): dead `search_unified()` removal, CAGRA streaming gap, brute-force note search O(n) elimination, call graph error propagation, config parse error surfacing
+- **P3 audit fixes** (11 items): `check_interrupted` stale flag, `unreachable!()` in name_only search, duplicated glob compilation, empty query bypass, CRLF handling, config file permissions (0o600), duplicated note insert SQL, HNSW match duplication, pipeline parse error reporting, panic payload extraction, IO error context in note rewrite
+
+## [0.5.3] - 2026-02-06
+
+### Added
 - CJK tokenization: Chinese, Japanese, Korean characters split into individual FTS tokens
 - `ChunkRow::from_row()` centralized SQLite row mapping in store layer
 - `fetch_chunks_by_ids_async()` and `fetch_chunks_with_embeddings_by_ids_async()` store methods
@@ -563,6 +572,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI commands: init, doctor, index, stats, serve
 - Filter by language (`-l`) and path pattern (`-p`)
 
+[0.6.0]: https://github.com/jamie8johnson/cqs/compare/v0.5.3...v0.6.0
+[0.5.3]: https://github.com/jamie8johnson/cqs/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/jamie8johnson/cqs/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/jamie8johnson/cqs/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jamie8johnson/cqs/compare/v0.4.6...v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.88"
 description = "Semantic code search for Claude Code. Find functions by what they do, not their names. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,34 +2,16 @@
 
 ## Right Now
 
-**20-category audit complete, triage done, ready to fix P1** (2026-02-06)
+**Releasing v0.6.0** (2026-02-06)
 
-Branch: `main` — PR #258 merged (multi-index).
+Branch: `main` — multi-index + all audit fixes merged.
 
-### Audit state
-- Full 20-category audit completed (4 batches × 5 parallel agents)
-- 193 raw findings in `docs/audit-findings.md`, ~120 unique after dedup
-- Triage done: 12 P1, 6 P2, 15 P3, 15 P4
-- Previous audit P4 issues (#231-241) cross-checked — overlapping findings noted
-
-### P1 fixes needed (easy + high impact)
-1. Reference name path traversal (security)
-2. Glob filter wrong path extraction in brute-force search (correctness)
-3. Pipeline wrong file_mtime across batched files (correctness)
-4. StoreError messages say `cq` not `cqs` (user-facing)
-5. Language param silently defaults to Rust (user-facing)
-6. SECURITY.md stale (docs)
-7. `tagged_score()` redundant (dead code)
-8. Reference threshold before vs after weight (correctness)
-9. SSE endpoint missing origin validation (security)
-10. 5 stale doc fixes (search.rs, note.rs, language/mod.rs, store/mod.rs, CONTRIBUTING.md)
-11. lib.rs Quick Start unnecessary `mut` (docs)
-12. serde_json unwrap_or_default in notes (error handling)
-
-### Uncommitted files
-- `docs/audit-findings.md` — full audit findings
-- `docs/notes.toml` — groomed (4 removed, 10 mentions updated)
-- `PROJECT_CONTINUITY.md` — this file
+### What's in v0.6.0
+- Multi-index search (PR #258)
+- P1 audit fixes — 12 items (PR #259)
+- P2 audit fixes — 5 items (PR #261)
+- P3 audit fixes — 11 items (PRs #262, #263)
+- Remaining P3/P4 tracked in issues #264-270
 
 ### Dev environment
 - `~/.bashrc`: `LD_LIBRARY_PATH` for ort CUDA libs
@@ -61,10 +43,10 @@ Branch: `main` — PR #258 merged (multi-index).
 
 ## Architecture
 
-- Version: 0.5.3
+- Version: 0.6.0
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, score-based merge with weight
 - 7 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java)
-- 388 tests (no GPU), 0 warnings, clippy clean
+- 418 tests (no GPU), 0 warnings, clippy clean

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -258,6 +258,14 @@
   - `cqs doctor` validates reference health
   - `[[reference]]` config in `.cqs.toml`
 
+- [x] 20-category audit v3 (PRs #259, #261, #262, #263)
+  - 193 raw findings, ~120 unique, P1-P4 triaged
+  - P1: 12 fixes (path traversal, glob filter, pipeline mtime, threshold, SSE origin, docs, error messages)
+  - P2: 5 fixes (dead code, CAGRA streaming, brute-force notes, call graph errors, config parse)
+  - P3: 11 fixes (signal reset, unreachable, glob dedup, empty query, CRLF, permissions, SQL dedup, HNSW accessor, pipeline stats, panic messages, IO context)
+  - Remaining items tracked in issues #264-270
+  - Test count: 418 (no GPU)
+
 ## Phase 6: Security
 
 ### Done


### PR DESCRIPTION
## Summary

Release v0.6.0 — first multi-index release.

- Version bump: 0.5.3 → 0.6.0
- CHANGELOG: new 0.6.0 section, restored correct 0.5.3 entry
- Updated ROADMAP, PROJECT_CONTINUITY with audit fix status

### What's in v0.6.0 (since v0.5.3)
- **Multi-index search** across reference codebases (#258)
- **P1 audit fixes** — 12 items (#259)
- **P2 audit fixes** — 5 items (#261)
- **P3 audit fixes** — 11 items (#262, #263)

## Test plan
- [ ] `cargo test` — 418 tests pass
- [ ] `cargo clippy` — clean
- [ ] Version in Cargo.toml is 0.6.0
- [ ] CHANGELOG 0.5.3 entry matches v0.5.3 tag content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
