### PR TITLE
chore: Update tears for v0.6.0 release

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,15 +2,16 @@
 
 ## Right Now
 
-**Releasing v0.6.0** (2026-02-06)
+**v0.6.0 released** (2026-02-06)
 
-Branch: `main` — multi-index + all audit fixes merged.
+Clean state. No active work.
 
-### What's in v0.6.0
+### v0.6.0 included
 - Multi-index search (PR #258)
 - P1 audit fixes — 12 items (PR #259)
 - P2 audit fixes — 5 items (PR #261)
 - P3 audit fixes — 11 items (PRs #262, #263)
+- Published to crates.io, GitHub release created
 - Remaining P3/P4 tracked in issues #264-270
 
 ### Dev environment
@@ -19,7 +20,8 @@ Branch: `main` — multi-index + all audit fixes merged.
 
 ## Parked
 
-- **Phase 6**: Security (index encryption, rate limiting)
+- **Phase 6**: Discovery & UX (diff, similar, explain, workspace indexing)
+- **Phase 7**: Security (index encryption, rate limiting)
 
 ## Open Issues
 
@@ -32,7 +34,16 @@ Branch: `main` — multi-index + all audit fixes merged.
 - #256: Cross-store dedup
 - #257: Parallel search + shared Runtime
 
-### P4 Deferred (7 remaining from v0.5.1 audit)
+### Remaining audit items (v0.6.0 audit)
+- #264: Config load_file silently ignores parse errors (P3)
+- #265: search_reference swallows errors (P3)
+- #266: embedding_to_bytes should validate dimensions (P3)
+- #267: Module boundary cleanup (P4)
+- #268: Language extensibility (P4)
+- #269: Brute-force search loads all embeddings (P4)
+- #270: HNSW LoadedHnsw unsafe transmute (P4)
+
+### P4 Deferred (v0.5.1 audit, still open)
 - #231: Notes file locking
 - #232: CAGRA RAII guard pattern
 - #233: Cache parsed notes.toml in MCP server

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -266,7 +266,17 @@
   - Remaining items tracked in issues #264-270
   - Test count: 418 (no GPU)
 
-## Phase 6: Security
+## Phase 6: Discovery & UX
+
+### Ideas
+
+- `cqs diff` — semantic diff between branches/versions ("what changed conceptually?" vs line-level)
+- `cqs similar <file>` — find semantically similar functions/files for refactoring discovery
+- Pre-built reference packages (#255) — downloadable indexes for popular crates (`cqs ref install tokio`)
+- Workspace-aware indexing — detect Cargo workspaces, index all crates with cross-crate call graphs
+- `cqs explain <function>` — generate NL explanation of what a function does (NL pipeline in reverse)
+
+## Phase 7: Security
 
 ### Done
 

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -454,7 +454,7 @@ mentions = [
 
 [[note]]
 sentiment = 1.0
-text = "Audits consistently find real bugs. History: 10-category (v0.4): 16 issues closed, proptest found RRF bound bug. 20-category v1 (v0.5.1): ~85 actionable from ~120 raw, 3 PRs for P1-P3, 13 P4 issues. 20-category v2 (v0.5.3): ~120 unique from 193 raw, 12 P1 fixed in PR #259. Key: 5 parallel agents per batch, audit mode on, collect ALL findings before fixing ANY. Batch by priority tier."
+text = "Audits consistently find real bugs. History: 10-category (v0.4): 16 issues closed, proptest found RRF bound bug. 20-category v1 (v0.5.1): ~85 actionable from ~120 raw, 3 PRs for P1-P3, 13 P4 issues. 20-category v2 (v0.6.0): ~120 unique from 193 raw, 28 fixes across P1-P3 (PRs #259, #261, #262, #263), 7 issues for remaining items. Key: 5 parallel agents per batch, audit mode on, collect ALL findings before fixing ANY. Batch by priority tier."
 mentions = [
     "docs/audit-findings.md",
     "audit",
@@ -515,3 +515,13 @@ mentions = [
     ".claude/skills/audit/SKILL.md",
     "audit",
 ]
+
+[[note]]
+sentiment = -0.5
+text = "CHANGELOG pollution trap: if you update CHANGELOG entries after the tag is already cut, the entry drifts from reality. Always verify with `git show vX.Y.Z:CHANGELOG.md` before a release to catch drift. v0.5.3 entry had multi-index content that wasn't in that release."
+mentions = ["CHANGELOG.md", "git tag", "release"]
+
+[[note]]
+sentiment = -0.5
+text = "cfg(test) only applies within the library crate's unit tests. Integration tests (tests/*.rs) are separate compilation units — they see the public API without cfg(test) gating. Can't use cfg(test) to hide types only needed by integration tests."
+mentions = ["cfg(test)", "tests/", "integration tests"]


### PR DESCRIPTION
## Summary
- Update tears and notes for v0.6.0 release state
- Add 2 new notes (CHANGELOG drift, cfg(test) integration tests)
- Update audit note with v0.6.0 stats
