### PR TITLE
feat: Phase 6 Discovery & UX (similar, explain, diff, workspace)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,11 @@ Use it for:
 
 Fall back to Grep/Glob only for exact string matches or when semantic search returns nothing.
 
-Tools: `cqs_search`, `cqs_stats` (run `cqs watch` to keep index fresh)
+Tools: `cqs_search`, `cqs_stats`, `cqs_similar`, `cqs_explain`, `cqs_diff` (run `cqs watch` to keep index fresh)
+
+**`cqs_similar`** — find code similar to a given function. Use for refactoring discovery, finding duplicates.
+**`cqs_explain`** — function card: signature, callers, callees, similar. Collapses 4+ tool calls into 1.
+**`cqs_diff`** — semantic diff between indexed snapshots. Requires references (`cqs ref add`).
 
 ## Audit Mode
 

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,17 +2,32 @@
 
 ## Right Now
 
-**v0.6.0 released** (2026-02-06)
+**Phase 6: Discovery & UX** — implementation complete, needs review + PR (2026-02-06)
 
-Clean state. No active work.
+### Implemented (all uncommitted on main)
+- [x] Store prereq methods (`get_chunk_with_embedding`, `all_chunk_identities`, `ChunkIdentity`)
+- [x] `cqs similar` (CLI + MCP) — search by example using stored embeddings
+- [x] `cqs explain` (CLI + MCP) — function card (signature, callers, callees, similar)
+- [x] `cqs diff` (CLI + MCP) — semantic diff between indexed snapshots
+- [x] Workspace-aware indexing — detect Cargo workspace root
 
-### v0.6.0 included
-- Multi-index search (PR #258)
-- P1 audit fixes — 12 items (PR #259)
-- P2 audit fixes — 5 items (PR #261)
-- P3 audit fixes — 11 items (PRs #262, #263)
-- Published to crates.io, GitHub release created
-- Remaining P3/P4 tracked in issues #264-270
+### New files
+- `src/diff.rs` — core diff algorithm
+- `src/cli/commands/similar.rs` — CLI handler
+- `src/cli/commands/explain.rs` — CLI handler
+- `src/cli/commands/diff.rs` — CLI handler
+- `src/mcp/tools/similar.rs` — MCP tool
+- `src/mcp/tools/explain.rs` — MCP tool
+- `src/mcp/tools/diff.rs` — MCP tool
+
+### Modified files
+- `src/store/chunks.rs`, `src/store/helpers.rs`, `src/store/mod.rs` — Store prereqs
+- `src/cli/mod.rs`, `src/cli/commands/mod.rs` — CLI wiring (3 new commands)
+- `src/mcp/tools/mod.rs` — MCP wiring (3 new tools)
+- `src/cli/display.rs` — `display_similar_results_json`
+- `src/cli/config.rs` — workspace-aware `find_project_root`
+- `src/lib.rs` — `pub mod diff`
+- `CLAUDE.md` — document new tools
 
 ### Dev environment
 - `~/.bashrc`: `LD_LIBRARY_PATH` for ort CUDA libs
@@ -20,8 +35,8 @@ Clean state. No active work.
 
 ## Parked
 
-- **Phase 6**: Discovery & UX (diff, similar, explain, workspace indexing)
 - **Phase 7**: Security (index encryption, rate limiting)
+- **ref install** — deferred from Phase 6, tracked in #255
 
 ## Open Issues
 
@@ -60,4 +75,5 @@ Clean state. No active work.
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, score-based merge with weight
 - 7 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java)
-- 418 tests (no GPU), 0 warnings, clippy clean
+- 431 tests (no GPU), 0 warnings, clippy clean
+- MCP tools: 12 (search, stats, callers, callees, read, add_note, update_note, remove_note, audit_mode, diff, explain, similar)

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -525,3 +525,18 @@ mentions = ["CHANGELOG.md", "git tag", "release"]
 sentiment = -0.5
 text = "cfg(test) only applies within the library crate's unit tests. Integration tests (tests/*.rs) are separate compilation units — they see the public API without cfg(test) gating. Can't use cfg(test) to hide types only needed by integration tests."
 mentions = ["cfg(test)", "tests/", "integration tests"]
+
+[[note]]
+sentiment = -0.5
+text = "parse_target (file:name resolution) is duplicated in 4 places: cli/commands/similar.rs, cli/commands/explain.rs, mcp/tools/similar.rs, mcp/tools/explain.rs. Should extract to shared utility if adding more commands that resolve targets."
+mentions = ["src/cli/commands/similar.rs", "src/cli/commands/explain.rs", "src/mcp/tools/similar.rs", "src/mcp/tools/explain.rs"]
+
+[[note]]
+sentiment = -0.5
+text = "cqs diff loads embeddings one-by-one for each matched pair via get_chunk_with_embedding. For large diffs (1000+ matched functions), this will be slow. Batch loading would help but adds complexity — defer until someone hits the perf wall."
+mentions = ["src/diff.rs", "semantic_diff", "get_chunk_with_embedding"]
+
+[[note]]
+sentiment = 0.0
+text = "Workspace detection uses string contains(\"[workspace]\") on Cargo.toml content. Simple but could false-positive on comments. Low risk — real TOML parsing would need toml crate dependency just for this check."
+mentions = ["src/cli/config.rs", "find_cargo_workspace_root"]

--- a/src/cli/commands/diff.rs
+++ b/src/cli/commands/diff.rs
@@ -1,0 +1,199 @@
+//! Diff command — semantic diff between indexed snapshots
+
+use anyhow::{bail, Result};
+use colored::Colorize;
+
+use cqs::diff::{semantic_diff, DiffResult};
+use cqs::Store;
+
+use crate::cli::find_project_root;
+
+pub(crate) fn cmd_diff(
+    source: &str,
+    target: Option<&str>,
+    threshold: f32,
+    lang: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let root = find_project_root();
+    let cq_dir = root.join(".cq");
+
+    // Load config to find reference paths
+    let config = cqs::config::Config::load(&root);
+
+    // Resolve source store (must be a reference)
+    let source_cfg = config
+        .references
+        .iter()
+        .find(|r| r.name == source)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Reference '{}' not found. Run 'cqs ref list' to see available references.",
+                source
+            )
+        })?;
+
+    let source_db = source_cfg.path.join("index.db");
+    if !source_db.exists() {
+        bail!(
+            "Reference '{}' has no index at {}. Run 'cqs ref update {}' first.",
+            source,
+            source_db.display(),
+            source
+        );
+    }
+    let source_store = Store::open(&source_db)?;
+
+    // Resolve target store
+    let target_label = target.unwrap_or("project");
+    let target_store = if target_label == "project" {
+        let index_path = cq_dir.join("index.db");
+        if !index_path.exists() {
+            bail!("Project index not found. Run 'cqs init && cqs index' first.");
+        }
+        Store::open(&index_path)?
+    } else {
+        let target_cfg = config
+            .references
+            .iter()
+            .find(|r| r.name == target_label)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Reference '{}' not found. Run 'cqs ref list' to see available references.",
+                    target_label
+                )
+            })?;
+        let target_db = target_cfg.path.join("index.db");
+        if !target_db.exists() {
+            bail!(
+                "Reference '{}' has no index at {}.",
+                target_label,
+                target_db.display()
+            );
+        }
+        Store::open(&target_db)?
+    };
+
+    let result = semantic_diff(
+        &source_store,
+        &target_store,
+        source,
+        target_label,
+        threshold,
+        lang,
+    )?;
+
+    if json {
+        display_diff_json(&result)?;
+    } else {
+        display_diff(&result)?;
+    }
+
+    Ok(())
+}
+
+fn display_diff(result: &DiffResult) -> Result<()> {
+    println!("Diff: {} → {}", result.source.bold(), result.target.bold());
+    println!();
+
+    if !result.added.is_empty() {
+        println!("{} ({}):", "Added".green().bold(), result.added.len());
+        for entry in &result.added {
+            println!("  + {} {} ({})", entry.chunk_type, entry.name, entry.file);
+        }
+        println!();
+    }
+
+    if !result.removed.is_empty() {
+        println!("{} ({}):", "Removed".red().bold(), result.removed.len());
+        for entry in &result.removed {
+            println!("  - {} {} ({})", entry.chunk_type, entry.name, entry.file);
+        }
+        println!();
+    }
+
+    if !result.modified.is_empty() {
+        println!(
+            "{} ({}):",
+            "Modified".yellow().bold(),
+            result.modified.len()
+        );
+        for entry in &result.modified {
+            let sim = entry
+                .similarity
+                .map(|s| format!("[{:.2}]", s))
+                .unwrap_or_else(|| "[?]".to_string());
+            println!(
+                "  ~ {} {} ({}) {}",
+                entry.chunk_type, entry.name, entry.file, sim
+            );
+        }
+        println!();
+    }
+
+    println!(
+        "Summary: {} added, {} removed, {} modified, {} unchanged",
+        result.added.len(),
+        result.removed.len(),
+        result.modified.len(),
+        result.unchanged_count,
+    );
+
+    Ok(())
+}
+
+fn display_diff_json(result: &DiffResult) -> Result<()> {
+    let added: Vec<_> = result
+        .added
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "name": e.name,
+                "file": e.file,
+                "type": e.chunk_type,
+            })
+        })
+        .collect();
+
+    let removed: Vec<_> = result
+        .removed
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "name": e.name,
+                "file": e.file,
+                "type": e.chunk_type,
+            })
+        })
+        .collect();
+
+    let modified: Vec<_> = result
+        .modified
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "name": e.name,
+                "file": e.file,
+                "type": e.chunk_type,
+                "similarity": e.similarity,
+            })
+        })
+        .collect();
+
+    let output = serde_json::json!({
+        "source": result.source,
+        "target": result.target,
+        "added": added,
+        "removed": removed,
+        "modified": modified,
+        "summary": {
+            "added": result.added.len(),
+            "removed": result.removed.len(),
+            "modified": result.modified.len(),
+            "unchanged": result.unchanged_count,
+        }
+    });
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}

--- a/src/cli/commands/explain.rs
+++ b/src/cli/commands/explain.rs
@@ -1,0 +1,204 @@
+//! Explain command — generate a function card
+
+use anyhow::{bail, Result};
+
+use cqs::{HnswIndex, SearchFilter, Store};
+
+use crate::cli::find_project_root;
+
+/// Parse a target string into (optional_file, name) — same as similar.rs
+fn parse_target(target: &str) -> (Option<&str>, &str) {
+    if let Some(pos) = target.rfind(':') {
+        let file = &target[..pos];
+        let name = &target[pos + 1..];
+        if !file.is_empty() && !name.is_empty() {
+            return (Some(file), name);
+        }
+    }
+    (None, target)
+}
+
+pub(crate) fn cmd_explain(_cli: &crate::cli::Cli, target: &str, json: bool) -> Result<()> {
+    let root = find_project_root();
+    let cq_dir = root.join(".cq");
+    let index_path = cq_dir.join("index.db");
+
+    if !index_path.exists() {
+        bail!("Index not found. Run 'cqs init && cqs index' first.");
+    }
+
+    let store = Store::open(&index_path)?;
+
+    // Resolve target to chunk
+    let (file_filter, name) = parse_target(target);
+    let results = store.search_by_name(name, 20)?;
+    if results.is_empty() {
+        bail!(
+            "No function found matching '{}'. Check the name and try again.",
+            name
+        );
+    }
+
+    let matched = if let Some(file) = file_filter {
+        results.iter().find(|r| {
+            let path = r.chunk.file.to_string_lossy();
+            path.ends_with(file) || path.contains(file)
+        })
+    } else {
+        None
+    };
+
+    let source = matched.unwrap_or(&results[0]);
+    let chunk = &source.chunk;
+
+    // Get callers
+    let callers = store.get_callers_full(&chunk.name).unwrap_or_default();
+
+    // Get callees
+    let callees = store.get_callees_full(&chunk.name).unwrap_or_default();
+
+    // Get similar (top 3) using embedding
+    let similar = match store.get_chunk_with_embedding(&chunk.id)? {
+        Some((_, embedding)) => {
+            let filter = SearchFilter {
+                languages: None,
+                path_pattern: None,
+                name_boost: 0.0,
+                query_text: String::new(),
+                enable_rrf: false,
+                note_weight: 0.0,
+            };
+            let index = HnswIndex::try_load(&cq_dir);
+            let sim_results = store.search_filtered_with_index(
+                &embedding,
+                &filter,
+                4, // +1 to exclude self
+                0.3,
+                index.as_deref(),
+            )?;
+            sim_results
+                .into_iter()
+                .filter(|r| r.chunk.id != chunk.id)
+                .take(3)
+                .collect::<Vec<_>>()
+        }
+        None => vec![],
+    };
+
+    if json {
+        let callers_json: Vec<_> = callers
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "name": c.name,
+                    "file": c.file.to_string_lossy().replace('\\', "/"),
+                    "line": c.line,
+                })
+            })
+            .collect();
+
+        let callees_json: Vec<_> = callees
+            .iter()
+            .map(|(name, line)| {
+                serde_json::json!({
+                    "name": name,
+                    "line": line,
+                })
+            })
+            .collect();
+
+        let similar_json: Vec<_> = similar
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "name": r.chunk.name,
+                    "file": r.chunk.file.to_string_lossy().replace('\\', "/"),
+                    "score": r.score,
+                })
+            })
+            .collect();
+
+        let rel_file = chunk
+            .file
+            .strip_prefix(&root)
+            .unwrap_or(&chunk.file)
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        let output = serde_json::json!({
+            "name": chunk.name,
+            "file": rel_file,
+            "language": chunk.language.to_string(),
+            "chunk_type": chunk.chunk_type.to_string(),
+            "lines": [chunk.line_start, chunk.line_end],
+            "signature": chunk.signature,
+            "doc": chunk.doc,
+            "callers": callers_json,
+            "callees": callees_json,
+            "similar": similar_json,
+        });
+
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        use colored::Colorize;
+
+        let rel_file = chunk.file.strip_prefix(&root).unwrap_or(&chunk.file);
+
+        println!(
+            "{} ({} {})",
+            chunk.name.bold(),
+            chunk.chunk_type,
+            chunk.language
+        );
+        println!(
+            "{}:{}-{}",
+            rel_file.display(),
+            chunk.line_start,
+            chunk.line_end
+        );
+
+        if !chunk.signature.is_empty() {
+            println!();
+            println!("{}", chunk.signature.dimmed());
+        }
+
+        if let Some(ref doc) = chunk.doc {
+            println!();
+            println!("{}", doc.green());
+        }
+
+        if !callers.is_empty() {
+            println!();
+            println!("{}", "Callers:".cyan());
+            for c in &callers {
+                let rel = c.file.strip_prefix(&root).unwrap_or(&c.file);
+                println!("  {} ({}:{})", c.name, rel.display(), c.line);
+            }
+        }
+
+        if !callees.is_empty() {
+            println!();
+            println!("{}", "Callees:".cyan());
+            for (name, _) in &callees {
+                println!("  {}", name);
+            }
+        }
+
+        if !similar.is_empty() {
+            println!();
+            println!("{}", "Similar:".cyan());
+            for r in &similar {
+                let rel = r.chunk.file.strip_prefix(&root).unwrap_or(&r.chunk.file);
+                println!(
+                    "  {} ({}:{}) [{:.2}]",
+                    r.chunk.name,
+                    rel.display(),
+                    r.chunk.line_start,
+                    r.score
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! Each submodule handles one CLI subcommand.
 
+mod diff;
 mod doctor;
+mod explain;
 mod graph;
 mod index;
 mod init;
@@ -10,9 +12,12 @@ mod notes;
 mod query;
 mod reference;
 mod serve;
+mod similar;
 mod stats;
 
+pub(crate) use diff::cmd_diff;
 pub(crate) use doctor::cmd_doctor;
+pub(crate) use explain::cmd_explain;
 pub(crate) use graph::{cmd_callees, cmd_callers};
 pub(crate) use index::cmd_index;
 pub(crate) use init::cmd_init;
@@ -20,4 +25,5 @@ pub(crate) use notes::{cmd_notes, NotesCommand};
 pub(crate) use query::cmd_query;
 pub(crate) use reference::{cmd_ref, RefCommand};
 pub(crate) use serve::{cmd_serve, ServeConfig};
+pub(crate) use similar::cmd_similar;
 pub(crate) use stats::cmd_stats;

--- a/src/cli/commands/similar.rs
+++ b/src/cli/commands/similar.rs
@@ -1,0 +1,190 @@
+//! Similar command — find code similar to a given function
+
+use anyhow::{bail, Context, Result};
+
+use cqs::{HnswIndex, SearchFilter, Store};
+
+use crate::cli::{display, find_project_root, Cli};
+
+/// Parse a target string into (optional_file, name)
+///
+/// Formats:
+///   "function_name"              → (None, "function_name")
+///   "src/foo.rs:function_name"   → (Some("src/foo.rs"), "function_name")
+fn parse_target(target: &str) -> (Option<&str>, &str) {
+    // Split on last colon to handle paths with colons (Windows drive letters)
+    if let Some(pos) = target.rfind(':') {
+        let file = &target[..pos];
+        let name = &target[pos + 1..];
+        // Only treat as file:name if both parts are non-empty
+        if !file.is_empty() && !name.is_empty() {
+            return (Some(file), name);
+        }
+    }
+    (None, target)
+}
+
+/// Resolve a target to a chunk ID by searching by name and optionally filtering by file
+fn resolve_target(store: &Store, target: &str) -> Result<(String, String)> {
+    let (file_filter, name) = parse_target(target);
+
+    let results = store.search_by_name(name, 20)?;
+    if results.is_empty() {
+        bail!(
+            "No function found matching '{}'. Check the name and try again.",
+            name
+        );
+    }
+
+    // Filter by file if specified
+    let matched = if let Some(file) = file_filter {
+        results.iter().find(|r| {
+            let path = r.chunk.file.to_string_lossy();
+            path.ends_with(file) || path.contains(file)
+        })
+    } else {
+        None
+    };
+
+    let result = matched.unwrap_or(&results[0]);
+    Ok((result.chunk.id.clone(), result.chunk.name.clone()))
+}
+
+pub(crate) fn cmd_similar(
+    cli: &Cli,
+    target: &str,
+    limit: usize,
+    threshold: f32,
+    json: bool,
+) -> Result<()> {
+    let root = find_project_root();
+    let cq_dir = root.join(".cq");
+    let index_path = cq_dir.join("index.db");
+
+    if !index_path.exists() {
+        bail!("Index not found. Run 'cqs init && cqs index' first.");
+    }
+
+    let store = Store::open(&index_path)?;
+
+    // Resolve target to chunk
+    let (chunk_id, chunk_name) = resolve_target(&store, target)?;
+
+    // Fetch embedding for the target chunk
+    let (source_chunk, embedding) =
+        store
+            .get_chunk_with_embedding(&chunk_id)?
+            .with_context(|| {
+                format!(
+                    "Could not load embedding for '{}'. Index may be corrupt.",
+                    chunk_name
+                )
+            })?;
+
+    // Build search filter (code only, no notes)
+    let languages = match &cli.lang {
+        Some(l) => Some(vec![l.parse().context(
+            "Invalid language. Valid: rust, python, typescript, javascript, go, c, java",
+        )?]),
+        None => None,
+    };
+
+    let filter = SearchFilter {
+        languages,
+        path_pattern: cli.path.clone(),
+        name_boost: 0.0, // Pure embedding similarity
+        query_text: String::new(),
+        enable_rrf: false, // No RRF — direct embedding comparison
+        note_weight: 0.0,  // Code only
+    };
+
+    // Load vector index
+    let index = HnswIndex::try_load(&cq_dir);
+
+    // Search with the chunk's embedding as query (request one extra to exclude self)
+    let results = store.search_filtered_with_index(
+        &embedding,
+        &filter,
+        limit + 1,
+        threshold,
+        index.as_deref(),
+    )?;
+
+    // Exclude the source chunk
+    let filtered: Vec<_> = results
+        .into_iter()
+        .filter(|r| r.chunk.id != source_chunk.id)
+        .take(limit)
+        .collect();
+
+    if filtered.is_empty() {
+        if json {
+            println!(r#"{{"results":[],"target":"{}","total":0}}"#, chunk_name);
+        } else {
+            println!("No similar functions found for '{}'.", chunk_name);
+        }
+        return Ok(());
+    }
+
+    if json {
+        display::display_similar_results_json(&filtered, &chunk_name)?;
+    } else {
+        if !cli.quiet {
+            println!(
+                "Similar to '{}' ({}):",
+                chunk_name,
+                source_chunk.file.display()
+            );
+            println!();
+        }
+        let unified: Vec<cqs::store::UnifiedResult> = filtered
+            .into_iter()
+            .map(cqs::store::UnifiedResult::Code)
+            .collect();
+        display::display_unified_results(&unified, &root, cli.no_content, cli.context)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_target_name_only() {
+        let (file, name) = parse_target("search_filtered");
+        assert_eq!(file, None);
+        assert_eq!(name, "search_filtered");
+    }
+
+    #[test]
+    fn test_parse_target_file_and_name() {
+        let (file, name) = parse_target("src/search.rs:search_filtered");
+        assert_eq!(file, Some("src/search.rs"));
+        assert_eq!(name, "search_filtered");
+    }
+
+    #[test]
+    fn test_parse_target_nested_path() {
+        let (file, name) = parse_target("src/mcp/tools/search.rs:tool_search");
+        assert_eq!(file, Some("src/mcp/tools/search.rs"));
+        assert_eq!(name, "tool_search");
+    }
+
+    #[test]
+    fn test_parse_target_empty_name_fallback() {
+        // Trailing colon — treat entire string as name
+        let (file, name) = parse_target("something:");
+        assert_eq!(file, None);
+        assert_eq!(name, "something:");
+    }
+
+    #[test]
+    fn test_parse_target_leading_colon_fallback() {
+        // Leading colon — treat entire string as name
+        let (file, name) = parse_target(":name");
+        assert_eq!(file, None);
+        assert_eq!(name, ":name");
+    }
+}

--- a/src/cli/display.rs
+++ b/src/cli/display.rs
@@ -326,6 +326,38 @@ pub fn display_tagged_results(
     Ok(())
 }
 
+/// Display similar results as JSON
+pub fn display_similar_results_json(
+    results: &[cqs::store::SearchResult],
+    target: &str,
+) -> Result<()> {
+    let json_results: Vec<_> = results
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "file": r.chunk.file.to_string_lossy().replace('\\', "/"),
+                "line_start": r.chunk.line_start,
+                "line_end": r.chunk.line_end,
+                "name": r.chunk.name,
+                "signature": r.chunk.signature,
+                "language": r.chunk.language.to_string(),
+                "chunk_type": r.chunk.chunk_type.to_string(),
+                "score": r.score,
+                "content": r.chunk.content,
+            })
+        })
+        .collect();
+
+    let output = serde_json::json!({
+        "target": target,
+        "results": json_results,
+        "total": results.len(),
+    });
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
 /// Display tagged results as JSON (multi-index with source field)
 pub fn display_tagged_results_json(results: &[TaggedResult], query: &str) -> Result<()> {
     let json_results: Vec<_> = results

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,314 @@
+//! Semantic diff between indexed snapshots
+//!
+//! Compares chunks by identity match + embedding similarity.
+//! Reports added, removed, modified, and unchanged functions.
+
+use std::collections::HashMap;
+
+use crate::store::{ChunkIdentity, Store, StoreError};
+
+/// A single diff entry
+#[derive(Debug)]
+pub struct DiffEntry {
+    /// Function/class name
+    pub name: String,
+    /// Source file path
+    pub file: String,
+    /// Type of code element
+    pub chunk_type: String,
+    /// Embedding similarity (only for Modified)
+    pub similarity: Option<f32>,
+}
+
+/// Result of a semantic diff
+#[derive(Debug)]
+pub struct DiffResult {
+    /// Source label (reference name)
+    pub source: String,
+    /// Target label ("project" or reference name)
+    pub target: String,
+    /// Functions in target but not source
+    pub added: Vec<DiffEntry>,
+    /// Functions in source but not target
+    pub removed: Vec<DiffEntry>,
+    /// Functions in both with embedding similarity < threshold
+    pub modified: Vec<DiffEntry>,
+    /// Count of unchanged functions
+    pub unchanged_count: usize,
+}
+
+/// Composite key for matching chunks across stores
+#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+struct ChunkKey {
+    origin: String,
+    name: String,
+    chunk_type: String,
+    line_start: u32,
+}
+
+impl From<&ChunkIdentity> for ChunkKey {
+    fn from(c: &ChunkIdentity) -> Self {
+        ChunkKey {
+            origin: c.origin.clone(),
+            name: c.name.clone(),
+            chunk_type: c.chunk_type.clone(),
+            line_start: c.line_start,
+        }
+    }
+}
+
+/// Compute cosine similarity between two embeddings
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut norm_a = 0.0f32;
+    let mut norm_b = 0.0f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        norm_a += x * x;
+        norm_b += y * y;
+    }
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom == 0.0 {
+        0.0
+    } else {
+        dot / denom
+    }
+}
+
+/// Run a semantic diff between two stores
+pub fn semantic_diff(
+    source_store: &Store,
+    target_store: &Store,
+    source_label: &str,
+    target_label: &str,
+    threshold: f32,
+    language_filter: Option<&str>,
+) -> Result<DiffResult, StoreError> {
+    // Load identities from both stores
+    let source_ids = source_store.all_chunk_identities()?;
+    let target_ids = target_store.all_chunk_identities()?;
+
+    // Collapse windowed chunks: keep only window_idx=0 (or None)
+    let source_ids: Vec<_> = source_ids
+        .into_iter()
+        .filter(|c| c.window_idx.is_none_or(|i| i == 0))
+        .collect();
+    let target_ids: Vec<_> = target_ids
+        .into_iter()
+        .filter(|c| c.window_idx.is_none_or(|i| i == 0))
+        .collect();
+
+    // Apply language filter
+    let source_ids: Vec<_> = if let Some(lang) = language_filter {
+        source_ids
+            .into_iter()
+            .filter(|c| {
+                c.chunk_type != "unknown"
+                    && c.origin.ends_with(&format!(".{}", lang_extension(lang)))
+            })
+            .collect()
+    } else {
+        source_ids
+    };
+
+    let target_ids: Vec<_> = if let Some(lang) = language_filter {
+        target_ids
+            .into_iter()
+            .filter(|c| {
+                c.chunk_type != "unknown"
+                    && c.origin.ends_with(&format!(".{}", lang_extension(lang)))
+            })
+            .collect()
+    } else {
+        target_ids
+    };
+
+    // Build lookup maps: key → (id, identity)
+    let source_map: HashMap<ChunkKey, &ChunkIdentity> =
+        source_ids.iter().map(|c| (ChunkKey::from(c), c)).collect();
+    let target_map: HashMap<ChunkKey, &ChunkIdentity> =
+        target_ids.iter().map(|c| (ChunkKey::from(c), c)).collect();
+
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
+    let mut modified = Vec::new();
+    let mut unchanged_count = 0usize;
+
+    // Find added (in target but not source) and matched pairs
+    let mut matched_pairs: Vec<(&ChunkIdentity, &ChunkIdentity)> = Vec::new();
+
+    for (key, target_chunk) in &target_map {
+        if let Some(source_chunk) = source_map.get(key) {
+            matched_pairs.push((source_chunk, target_chunk));
+        } else {
+            added.push(DiffEntry {
+                name: target_chunk.name.clone(),
+                file: target_chunk.origin.clone(),
+                chunk_type: target_chunk.chunk_type.clone(),
+                similarity: None,
+            });
+        }
+    }
+
+    // Find removed (in source but not target)
+    for (key, source_chunk) in &source_map {
+        if !target_map.contains_key(key) {
+            removed.push(DiffEntry {
+                name: source_chunk.name.clone(),
+                file: source_chunk.origin.clone(),
+                chunk_type: source_chunk.chunk_type.clone(),
+                similarity: None,
+            });
+        }
+    }
+
+    // Compare embeddings for matched pairs
+    for (source_chunk, target_chunk) in &matched_pairs {
+        let source_emb = source_store.get_chunk_with_embedding(&source_chunk.id)?;
+        let target_emb = target_store.get_chunk_with_embedding(&target_chunk.id)?;
+
+        match (source_emb, target_emb) {
+            (Some((_, s_emb)), Some((_, t_emb))) => {
+                let sim = cosine_similarity(s_emb.as_slice(), t_emb.as_slice());
+                if sim < threshold {
+                    modified.push(DiffEntry {
+                        name: target_chunk.name.clone(),
+                        file: target_chunk.origin.clone(),
+                        chunk_type: target_chunk.chunk_type.clone(),
+                        similarity: Some(sim),
+                    });
+                } else {
+                    unchanged_count += 1;
+                }
+            }
+            _ => {
+                // Can't compare — treat as modified
+                modified.push(DiffEntry {
+                    name: target_chunk.name.clone(),
+                    file: target_chunk.origin.clone(),
+                    chunk_type: target_chunk.chunk_type.clone(),
+                    similarity: None,
+                });
+            }
+        }
+    }
+
+    // Sort modified by similarity (most changed first)
+    modified.sort_by(|a, b| {
+        a.similarity
+            .unwrap_or(0.0)
+            .partial_cmp(&b.similarity.unwrap_or(0.0))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    Ok(DiffResult {
+        source: source_label.to_string(),
+        target: target_label.to_string(),
+        added,
+        removed,
+        modified,
+        unchanged_count,
+    })
+}
+
+/// Map language name to file extension for filtering
+fn lang_extension(lang: &str) -> &str {
+    match lang {
+        "rust" => "rs",
+        "python" => "py",
+        "typescript" => "ts",
+        "javascript" => "js",
+        "go" => "go",
+        "c" => "c",
+        "java" => "java",
+        _ => lang,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cosine_similarity_identical() {
+        let a = vec![1.0, 0.0, 0.0];
+        let b = vec![1.0, 0.0, 0.0];
+        assert!((cosine_similarity(&a, &b) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_cosine_similarity_orthogonal() {
+        let a = vec![1.0, 0.0, 0.0];
+        let b = vec![0.0, 1.0, 0.0];
+        assert!(cosine_similarity(&a, &b).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_cosine_similarity_opposite() {
+        let a = vec![1.0, 0.0];
+        let b = vec![-1.0, 0.0];
+        assert!((cosine_similarity(&a, &b) + 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_cosine_similarity_empty() {
+        assert_eq!(cosine_similarity(&[], &[]), 0.0);
+    }
+
+    #[test]
+    fn test_cosine_similarity_zero_vector() {
+        let a = vec![0.0, 0.0];
+        let b = vec![1.0, 0.0];
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn test_chunk_key_equality() {
+        let k1 = ChunkKey {
+            origin: "src/foo.rs".into(),
+            name: "bar".into(),
+            chunk_type: "function".into(),
+            line_start: 10,
+        };
+        let k2 = ChunkKey {
+            origin: "src/foo.rs".into(),
+            name: "bar".into(),
+            chunk_type: "function".into(),
+            line_start: 10,
+        };
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn test_chunk_key_different_line() {
+        // Java overloads: same name, different line
+        let k1 = ChunkKey {
+            origin: "Foo.java".into(),
+            name: "process".into(),
+            chunk_type: "method".into(),
+            line_start: 10,
+        };
+        let k2 = ChunkKey {
+            origin: "Foo.java".into(),
+            name: "process".into(),
+            chunk_type: "method".into(),
+            line_start: 25,
+        };
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn test_lang_extension() {
+        assert_eq!(lang_extension("rust"), "rs");
+        assert_eq!(lang_extension("python"), "py");
+        assert_eq!(lang_extension("typescript"), "ts");
+        assert_eq!(lang_extension("javascript"), "js");
+        assert_eq!(lang_extension("go"), "go");
+        assert_eq!(lang_extension("c"), "c");
+        assert_eq!(lang_extension("java"), "java");
+        assert_eq!(lang_extension("unknown"), "unknown");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 //! ```
 
 pub mod config;
+pub mod diff;
 pub mod embedder;
 pub mod hnsw;
 pub mod index;

--- a/src/mcp/tools/diff.rs
+++ b/src/mcp/tools/diff.rs
@@ -1,0 +1,140 @@
+//! Diff tool — semantic diff between indexed snapshots
+
+use anyhow::{bail, Result};
+use serde_json::Value;
+
+use crate::diff::semantic_diff;
+use crate::Store;
+
+use super::super::server::McpServer;
+
+pub fn tool_diff(server: &McpServer, arguments: Value) -> Result<Value> {
+    let source = arguments
+        .get("source")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Missing required parameter: source"))?;
+
+    let target = arguments
+        .get("target")
+        .and_then(|v| v.as_str())
+        .unwrap_or("project");
+
+    let threshold = arguments
+        .get("threshold")
+        .and_then(|v| v.as_f64())
+        .map(|v| v as f32)
+        .unwrap_or(0.95);
+
+    let language = arguments.get("language").and_then(|v| v.as_str());
+
+    // Load config to find reference paths
+    let config = crate::config::Config::load(&server.project_root);
+
+    // Resolve source store
+    let source_cfg = config
+        .references
+        .iter()
+        .find(|r| r.name == source)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Reference '{}' not found. Run 'cqs ref list' to see available references.",
+                source
+            )
+        })?;
+
+    let source_db = source_cfg.path.join("index.db");
+    if !source_db.exists() {
+        bail!(
+            "Reference '{}' has no index. Run 'cqs ref update {}' first.",
+            source,
+            source
+        );
+    }
+    let source_store = Store::open(&source_db)?;
+
+    // Target store
+    let target_store_owned;
+    let target_store: &Store = if target == "project" {
+        &server.store
+    } else {
+        let target_cfg = config
+            .references
+            .iter()
+            .find(|r| r.name == target)
+            .ok_or_else(|| anyhow::anyhow!("Reference '{}' not found.", target))?;
+        let target_db = target_cfg.path.join("index.db");
+        if !target_db.exists() {
+            bail!("Reference '{}' has no index.", target);
+        }
+        target_store_owned = Store::open(&target_db)?;
+        &target_store_owned
+    };
+
+    let result = semantic_diff(
+        &source_store,
+        target_store,
+        source,
+        target,
+        threshold,
+        language,
+    )?;
+
+    // Format result
+    let added: Vec<Value> = result
+        .added
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "name": e.name,
+                "file": e.file,
+                "type": e.chunk_type,
+            })
+        })
+        .collect();
+
+    let removed: Vec<Value> = result
+        .removed
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "name": e.name,
+                "file": e.file,
+                "type": e.chunk_type,
+            })
+        })
+        .collect();
+
+    let modified: Vec<Value> = result
+        .modified
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "name": e.name,
+                "file": e.file,
+                "type": e.chunk_type,
+                "similarity": e.similarity,
+            })
+        })
+        .collect();
+
+    let output = serde_json::json!({
+        "source": result.source,
+        "target": result.target,
+        "added": added,
+        "removed": removed,
+        "modified": modified,
+        "summary": {
+            "added": result.added.len(),
+            "removed": result.removed.len(),
+            "modified": result.modified.len(),
+            "unchanged": result.unchanged_count,
+        }
+    });
+
+    Ok(serde_json::json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string_pretty(&output)?
+        }]
+    }))
+}

--- a/src/mcp/tools/explain.rs
+++ b/src/mcp/tools/explain.rs
@@ -1,0 +1,158 @@
+//! Explain tool — generate a function card
+
+use anyhow::{bail, Result};
+use serde_json::Value;
+
+use crate::store::SearchFilter;
+
+use super::super::server::McpServer;
+
+/// Parse target into (optional_file, name)
+fn parse_target(target: &str) -> (Option<&str>, &str) {
+    if let Some(pos) = target.rfind(':') {
+        let file = &target[..pos];
+        let name = &target[pos + 1..];
+        if !file.is_empty() && !name.is_empty() {
+            return (Some(file), name);
+        }
+    }
+    (None, target)
+}
+
+pub fn tool_explain(server: &McpServer, arguments: Value) -> Result<Value> {
+    let target = arguments
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Missing required parameter: name"))?;
+
+    // Resolve target
+    let (file_filter, name) = parse_target(target);
+    let name_results = server.store.search_by_name(name, 20)?;
+    if name_results.is_empty() {
+        bail!(
+            "No function found matching '{}'. Check the name and try again.",
+            name
+        );
+    }
+
+    let matched = if let Some(file) = file_filter {
+        name_results.iter().find(|r| {
+            let path = r.chunk.file.to_string_lossy();
+            path.ends_with(file) || path.contains(file)
+        })
+    } else {
+        None
+    };
+
+    let source = matched.unwrap_or(&name_results[0]);
+    let chunk = &source.chunk;
+
+    // Get callers
+    let callers = server
+        .store
+        .get_callers_full(&chunk.name)
+        .unwrap_or_default();
+
+    // Get callees
+    let callees = server
+        .store
+        .get_callees_full(&chunk.name)
+        .unwrap_or_default();
+
+    // Get similar (top 3)
+    let similar = match server.store.get_chunk_with_embedding(&chunk.id)? {
+        Some((_, embedding)) => {
+            let filter = SearchFilter {
+                languages: None,
+                path_pattern: None,
+                name_boost: 0.0,
+                query_text: String::new(),
+                enable_rrf: false,
+                note_weight: 0.0,
+            };
+            let index_guard = server.index.read().unwrap_or_else(|e| {
+                tracing::debug!("Index RwLock poisoned, recovering");
+                e.into_inner()
+            });
+            let sim_results = server.store.search_filtered_with_index(
+                &embedding,
+                &filter,
+                4,
+                0.3,
+                index_guard.as_deref(),
+            )?;
+            sim_results
+                .into_iter()
+                .filter(|r| r.chunk.id != chunk.id)
+                .take(3)
+                .collect::<Vec<_>>()
+        }
+        None => vec![],
+    };
+
+    // Build card
+    let callers_json: Vec<Value> = callers
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "name": c.name,
+                "file": c.file.strip_prefix(&server.project_root)
+                    .unwrap_or(&c.file)
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+                "line": c.line,
+            })
+        })
+        .collect();
+
+    let callees_json: Vec<Value> = callees
+        .iter()
+        .map(|(name, line)| {
+            serde_json::json!({
+                "name": name,
+                "line": line,
+            })
+        })
+        .collect();
+
+    let similar_json: Vec<Value> = similar
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "name": r.chunk.name,
+                "file": r.chunk.file.strip_prefix(&server.project_root)
+                    .unwrap_or(&r.chunk.file)
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+                "score": r.score,
+            })
+        })
+        .collect();
+
+    let rel_file = chunk
+        .file
+        .strip_prefix(&server.project_root)
+        .unwrap_or(&chunk.file)
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    let card = serde_json::json!({
+        "name": chunk.name,
+        "file": rel_file,
+        "language": chunk.language.to_string(),
+        "chunk_type": chunk.chunk_type.to_string(),
+        "lines": [chunk.line_start, chunk.line_end],
+        "signature": chunk.signature,
+        "doc": chunk.doc,
+        "callers": callers_json,
+        "callees": callees_json,
+        "similar": similar_json,
+    });
+
+    Ok(serde_json::json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string_pretty(&card)?
+        }]
+    }))
+}

--- a/src/mcp/tools/similar.rs
+++ b/src/mcp/tools/similar.rs
@@ -1,0 +1,150 @@
+//! Similar tool — find code similar to a given function
+
+use anyhow::{bail, Result};
+use serde_json::Value;
+
+use crate::store::SearchFilter;
+
+use super::super::server::McpServer;
+
+/// Parse target into (optional_file, name)
+fn parse_target(target: &str) -> (Option<&str>, &str) {
+    if let Some(pos) = target.rfind(':') {
+        let file = &target[..pos];
+        let name = &target[pos + 1..];
+        if !file.is_empty() && !name.is_empty() {
+            return (Some(file), name);
+        }
+    }
+    (None, target)
+}
+
+pub fn tool_similar(server: &McpServer, arguments: Value) -> Result<Value> {
+    let target = arguments
+        .get("target")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Missing required parameter: target"))?;
+
+    let limit = arguments
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as usize)
+        .unwrap_or(5)
+        .clamp(1, 20);
+
+    let threshold = arguments
+        .get("threshold")
+        .and_then(|v| v.as_f64())
+        .map(|v| v as f32)
+        .unwrap_or(0.3);
+
+    let language_filter = arguments
+        .get("language")
+        .and_then(|v| v.as_str())
+        .map(|l| {
+            l.parse::<crate::parser::Language>()
+                .map(|lang| vec![lang])
+                .map_err(|_| anyhow::anyhow!("Unknown language '{}'. Supported: rust, python, typescript, javascript, go, c, java", l))
+        })
+        .transpose()?;
+
+    // Resolve target to chunk
+    let (file_filter, name) = parse_target(target);
+
+    let name_results = server.store.search_by_name(name, 20)?;
+    if name_results.is_empty() {
+        bail!(
+            "No function found matching '{}'. Check the name and try again.",
+            name
+        );
+    }
+
+    // Filter by file if specified
+    let matched = if let Some(file) = file_filter {
+        name_results.iter().find(|r| {
+            let path = r.chunk.file.to_string_lossy();
+            path.ends_with(file) || path.contains(file)
+        })
+    } else {
+        None
+    };
+
+    let source = matched.unwrap_or(&name_results[0]);
+    let source_id = source.chunk.id.clone();
+    let source_name = source.chunk.name.clone();
+
+    // Fetch embedding
+    let (_, embedding) = server
+        .store
+        .get_chunk_with_embedding(&source_id)?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Could not load embedding for '{}'. Index may be corrupt.",
+                source_name
+            )
+        })?;
+
+    // Search with embedding as query
+    let filter = SearchFilter {
+        languages: language_filter,
+        path_pattern: None,
+        name_boost: 0.0,
+        query_text: String::new(),
+        enable_rrf: false,
+        note_weight: 0.0,
+    };
+
+    let index_guard = server.index.read().unwrap_or_else(|e| {
+        tracing::debug!("Index RwLock poisoned, recovering");
+        e.into_inner()
+    });
+
+    let results = server.store.search_filtered_with_index(
+        &embedding,
+        &filter,
+        limit + 1,
+        threshold,
+        index_guard.as_deref(),
+    )?;
+
+    // Exclude source chunk
+    let filtered: Vec<_> = results
+        .into_iter()
+        .filter(|r| r.chunk.id != source_id)
+        .take(limit)
+        .collect();
+
+    // Format results
+    let json_results: Vec<Value> = filtered
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "file": r.chunk.file.strip_prefix(&server.project_root)
+                    .unwrap_or(&r.chunk.file)
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+                "line_start": r.chunk.line_start,
+                "line_end": r.chunk.line_end,
+                "name": r.chunk.name,
+                "signature": r.chunk.signature,
+                "language": r.chunk.language.to_string(),
+                "chunk_type": r.chunk.chunk_type.to_string(),
+                "score": r.score,
+                "content": r.chunk.content,
+            })
+        })
+        .collect();
+
+    let result = serde_json::json!({
+        "target": source_name,
+        "results": json_results,
+        "total": filtered.len(),
+    });
+
+    Ok(serde_json::json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string_pretty(&result)?
+        }]
+    }))
+}

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -165,6 +165,28 @@ pub struct CallerInfo {
     pub line: u32,
 }
 
+/// Chunk identity for diff comparison
+///
+/// Minimal metadata needed to identify and match chunks across stores.
+/// Does not include content or embeddings.
+#[derive(Debug, Clone)]
+pub struct ChunkIdentity {
+    /// Unique chunk identifier
+    pub id: String,
+    /// Source file path
+    pub origin: String,
+    /// Function/class/etc. name
+    pub name: String,
+    /// Type of code element (e.g., "function", "class")
+    pub chunk_type: String,
+    /// Starting line number (1-indexed)
+    pub line_start: u32,
+    /// Parent chunk ID (for windowed chunks)
+    pub parent_id: Option<String>,
+    /// Window index within parent (for long functions split into windows)
+    pub window_idx: Option<u32>,
+}
+
 /// Note statistics (total count and categorized counts)
 #[derive(Debug, Clone)]
 pub struct NoteStats {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -32,6 +32,9 @@ use tokio::runtime::Runtime;
 /// Information about a function caller (from call graph).
 pub use helpers::CallerInfo;
 
+/// Chunk identity for diff comparison (name, file, line, window info).
+pub use helpers::ChunkIdentity;
+
 /// Summary of an indexed code chunk (function, class, etc.).
 pub use helpers::ChunkSummary;
 


### PR DESCRIPTION
## Summary

Phase 6: Discovery & UX — 5 features that reduce tool calls and improve codebase navigation:

- **`cqs similar`** (CLI + MCP): Find semantically similar functions using a stored embedding as the query vector. Search by example instead of by text.
- **`cqs explain`** (CLI + MCP): Generate a function card — signature, docs, callers, callees, and top-3 similar functions — in one call instead of 4+.
- **`cqs diff`** (CLI + MCP): Semantic diff between indexed snapshots. Compare project vs reference or two references. Reports added/removed/modified functions with similarity scores.
- **Workspace-aware indexing**: Detect Cargo workspace roots so `cqs index` from a member crate indexes the whole workspace.
- **Store prereqs**: `get_chunk_with_embedding()`, `all_chunk_identities()`, `ChunkIdentity` struct.

### New files (7)
- `src/diff.rs` — core diff algorithm
- `src/cli/commands/{similar,explain,diff}.rs` — CLI handlers
- `src/mcp/tools/{similar,explain,diff}.rs` — MCP tool handlers

### Modified files (12)
- Store: `chunks.rs`, `helpers.rs`, `mod.rs` — new public methods and types
- CLI: `mod.rs`, `commands/mod.rs`, `display.rs`, `config.rs` — wiring + workspace detection
- MCP: `tools/mod.rs` — 3 new tool registrations
- `lib.rs` — `pub mod diff`
- `CLAUDE.md`, `PROJECT_CONTINUITY.md`, `docs/notes.toml` — docs and continuity

### Stats
- 19 files changed, +1690 lines
- 431 tests passing, 0 warnings, clippy clean
- 13 new unit tests (cosine similarity, chunk key, lang extension, parse_target)

## Test plan

- [x] `cargo build` — 0 warnings
- [x] `cargo test` — 431 pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual: `cqs similar search_filtered --json` returns similar functions
- [x] Manual: `cqs explain src/search.rs:search_filtered --json` returns function card
- [x] Fresh-eyes review completed, 0 issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)
