### PR TITLE
feat: Add cqs skill wrappers and self-contained bootstrap

### DIFF
--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -1,16 +1,29 @@
 ---
 name: bootstrap
-description: Bootstrap a new project with cqs tears infrastructure (notes.toml, PROJECT_CONTINUITY.md, ROADMAP.md).
-disable-model-invocation: true
+description: One-command setup for cqs in a new project — MCP config, skills, tears infrastructure, CLAUDE.md, init, index.
+disable-model-invocation: false
+argument-hint: "[project_path]"
 ---
 
 # Bootstrap Project
 
-Set up tears infrastructure for a new project.
+Fully self-contained setup for cqs in a new project. After running this, the project has semantic search, notes, continuity tracking, and all skills working.
 
-## Files to create
+## Prerequisites
 
-### docs/notes.toml
+- `cqs` binary installed (check with `which cqs`)
+- Project has a git repo initialized
+- Running inside Claude Code in the target project directory (or pass project path as argument)
+
+## Process
+
+### Phase 1: Tears Infrastructure
+
+1. Check if files already exist — **don't overwrite**
+2. Create `docs/` directory if needed
+3. Write each file:
+
+#### docs/notes.toml
 
 ```toml
 # Notes - unified memory for AI collaborators
@@ -24,7 +37,7 @@ text = "Project bootstrapped with cqs tears infrastructure."
 mentions = ["docs/notes.toml", "PROJECT_CONTINUITY.md"]
 ```
 
-### PROJECT_CONTINUITY.md
+#### PROJECT_CONTINUITY.md
 
 ```markdown
 # Project Continuity
@@ -50,7 +63,7 @@ None.
 (uncommitted work)
 ```
 
-### ROADMAP.md
+#### ROADMAP.md
 
 ```markdown
 # Roadmap
@@ -64,27 +77,126 @@ None.
 - [ ] ...
 ```
 
-## Process
+### Phase 2: Skills
 
-1. Check if files already exist — don't overwrite
-2. Create `docs/` directory if needed
-3. Write each file
 4. Create `.claude/skills/` directory
-5. Copy portable skills from `/mnt/c/Projects/cq/.claude/skills/` if available:
+5. Copy all portable skills from `/mnt/c/Projects/cq/.claude/skills/`:
    - `update-tears` — session state capture
    - `groom-notes` — note cleanup
    - `reindex` — rebuild index with stats
    - `bootstrap` — this skill (for nested projects)
-6. Run `cqs init` if not already initialized
-7. Run `cqs index` to index the new notes
-8. Suggest adding to `.gitignore`: `.cq/` (index database)
-9. Add skills section to CLAUDE.md (see cqs project for reference format)
+   - `cqs-search` — semantic code search
+   - `cqs-stats` — index statistics
+   - `cqs-callers` — find callers of a function
+   - `cqs-callees` — find callees of a function
+   - `cqs-read` — read file with contextual notes
+   - `cqs-explain` — function card (signature, callers, callees, similar)
+   - `cqs-similar` — find similar code
+   - `cqs-diff` — semantic diff between snapshots
+   - `cqs-add-note` — add a note to project memory
+   - `cqs-update-note` — update an existing note
+   - `cqs-remove-note` — remove a note
+   - `cqs-audit-mode` — toggle audit mode for unbiased review
+   - `cqs-ref` — manage reference indexes (add/remove/update/list)
+   - `cqs-watch` — start file watcher for live index updates
+   - `troubleshoot` — diagnose common cqs issues
+   - `migrate` — handle schema version upgrades
 
-## Notes
+### Phase 3: MCP Server Config
 
-- These files are checked into git (they're shared team context)
-- `.cq/` directory is NOT checked in (local index)
-- `.claude/skills/` is checked into git (shared skill definitions)
-- CLAUDE.md should reference these files in its "Read First" section
-- Skills are auto-discovered by Claude Code from `.claude/skills/*/SKILL.md`
-- No registration needed — they appear in `/` autocomplete automatically
+6. Create `.mcp.json` in project root (if it doesn't exist) or add cqs to existing:
+
+```json
+{
+  "mcpServers": {
+    "cqs": {
+      "command": "cqs",
+      "args": ["serve", "--project", "."]
+    }
+  }
+}
+```
+
+**Notes on the MCP config:**
+- Uses bare `cqs` command (assumes it's in PATH via `~/.cargo/bin/`)
+- Uses `.` for project path — Claude Code resolves this relative to project root
+- If user has a custom install path, ask them and adjust
+- If `LD_LIBRARY_PATH` is needed (GPU/CUDA), add an `env` field
+- `.mcp.json` is checked into git (shared config for all collaborators)
+
+### Phase 4: cqs Init & Index
+
+7. Run `cqs init` (creates `.cq/` directory with database)
+8. Run `cqs index` (indexes all source files + notes)
+9. Verify with `cqs stats` — should show chunk count > 0
+
+### Phase 5: .gitignore
+
+10. Add `.cq/` to `.gitignore` if not already present (the index database is local, not shared)
+
+### Phase 6: CLAUDE.md Integration
+
+11. If CLAUDE.md exists, **append** the cqs sections below. If it doesn't exist, create it with these sections plus a basic header.
+
+**Check for existing sections first** — don't duplicate if the user already has cqs config in their CLAUDE.md.
+
+#### Sections to add to CLAUDE.md:
+
+```markdown
+## Read First
+
+* `PROJECT_CONTINUITY.md` -- what's happening right now
+* `docs/notes.toml` -- observations indexed by cqs (warnings, patterns)
+* `ROADMAP.md` -- what's done, what's next
+
+## Skills
+
+Project skills in `.claude/skills/`. Use `/skill-name` to invoke.
+Skills are auto-discovered — they appear in `/` autocomplete automatically.
+
+## Code Search
+
+**Use `cqs_search` instead of grep/glob.** It finds code by what it does, not text matching.
+
+Use it for:
+- Exploring unfamiliar code
+- Finding implementations by behavior
+- When you don't know exact names
+
+**Definition search:** Use `name_only=true` for "where is X defined?" queries. Skips embedding, searches function/struct names directly. Faster than glob.
+
+Fall back to Grep/Glob only for exact string matches or when semantic search returns nothing.
+
+Tools: `cqs_search`, `cqs_stats`, `cqs_similar`, `cqs_explain`, `cqs_diff` (run `cqs watch` to keep index fresh)
+
+## Audit Mode
+
+Before audits or fresh-eyes reviews:
+`cqs_audit_mode(true)` to exclude notes and force direct code examination.
+After: `cqs_audit_mode(false)` or let it auto-expire (30 min default).
+
+## Continuity (Tears)
+
+"Update tears" = capture state before context compacts.
+
+* `PROJECT_CONTINUITY.md` -- right now, parked, blockers, open questions, pending
+* `docs/notes.toml` -- observations with sentiment (indexed by cqs)
+
+**Use `cqs_add_note` to add notes** - it indexes immediately. Direct file edits require `cqs index` to become searchable.
+
+**Sentiment is DISCRETE** — only 5 valid values: -1, -0.5, 0, 0.5, 1
+```
+
+### Phase 7: Verify
+
+12. Run `cqs stats` to confirm indexing worked
+13. Test a search: `cqs search "main entry point"` (should return results)
+14. Report summary: files created, chunks indexed, skills installed
+
+## Rules
+
+- **Never overwrite** existing files — skip with a message
+- **Append, don't replace** CLAUDE.md content
+- **Ask before** modifying `.gitignore` if it has complex rules
+- If `cqs` binary isn't found, stop and tell the user to install it first
+- If `.mcp.json` already has a `cqs` entry, don't duplicate — just verify it's correct

--- a/.claude/skills/cqs-add-note/SKILL.md
+++ b/.claude/skills/cqs-add-note/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: cqs-add-note
+description: Add a note to project memory. Indexed immediately for future search.
+disable-model-invocation: false
+argument-hint: "<text> [--sentiment -1|-0.5|0|0.5|1] [--mentions file1,file2]"
+---
+
+# Add Note
+
+Call `cqs_add_note` MCP tool. Parse arguments:
+
+- First positional arg (or quoted string) = `text` (required)
+- `--sentiment <value>` → only discrete values: -1, -0.5, 0, 0.5, 1
+- `--mentions <file1,file2,...>` → array of file paths or concepts
+
+## Sentiment guide
+
+| Value | Meaning |
+|-------|---------|
+| `-1` | Serious pain (broke something, lost time) |
+| `-0.5` | Notable pain (friction, annoyance) |
+| `0` | Neutral observation |
+| `0.5` | Notable gain (useful pattern) |
+| `1` | Major win (saved significant time/effort) |
+
+Notes are indexed immediately and surface in future `cqs_search` results.

--- a/.claude/skills/cqs-audit-mode/SKILL.md
+++ b/.claude/skills/cqs-audit-mode/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cqs-audit-mode
+description: Toggle audit mode — excludes notes from search/read for unbiased code review.
+disable-model-invocation: false
+argument-hint: "[on|off] [--expires 1h]"
+---
+
+# Audit Mode
+
+Call `cqs_audit_mode` MCP tool. Parse arguments:
+
+- `on` → `enabled: true`
+- `off` → `enabled: false`
+- No argument → query current state (omit `enabled`)
+- `--expires <duration>` → `expires_in` (e.g., "30m", "1h", "2h"). Default: 30m.
+
+Audit mode prevents notes from influencing search and read results. Use before code audits, fresh-eyes reviews, or any time you need unbiased analysis.
+
+Auto-expires after the specified duration.

--- a/.claude/skills/cqs-callees/SKILL.md
+++ b/.claude/skills/cqs-callees/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: cqs-callees
+description: Find functions called by a given function. Dependency analysis.
+disable-model-invocation: false
+argument-hint: "<function_name>"
+---
+
+# Callees
+
+Call `cqs_callees` MCP tool with `name` set to the user's argument.
+
+Shows all functions called by the named function. Useful for understanding what a function depends on.

--- a/.claude/skills/cqs-callers/SKILL.md
+++ b/.claude/skills/cqs-callers/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: cqs-callers
+description: Find functions that call a given function. Impact analysis.
+disable-model-invocation: false
+argument-hint: "<function_name>"
+---
+
+# Callers
+
+Call `cqs_callers` MCP tool with `name` set to the user's argument.
+
+Shows all call sites for the named function. Useful for:
+- Impact analysis before refactoring
+- Verifying a function is actually called (dead code check)
+- Understanding how a function is used

--- a/.claude/skills/cqs-diff/SKILL.md
+++ b/.claude/skills/cqs-diff/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: cqs-diff
+description: Semantic diff between indexed snapshots. Compare project vs reference.
+disable-model-invocation: false
+argument-hint: "<source_ref> [--target project|<ref>] [--threshold 0.95] [--lang rust]"
+---
+
+# Diff
+
+Call `cqs_diff` MCP tool. Parse arguments:
+
+- First positional arg = `source` reference name (required)
+- `--target <name>` → `target` (default: "project")
+- `--threshold <n>` → similarity threshold for "modified" classification (default: 0.95)
+- `--lang <language>` → filter by language
+
+Shows added, removed, and modified functions between two indexed snapshots. Requires references to be set up via `cqs ref add`.

--- a/.claude/skills/cqs-explain/SKILL.md
+++ b/.claude/skills/cqs-explain/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: cqs-explain
+description: Function card — signature, docs, callers, callees, similar functions in one call.
+disable-model-invocation: false
+argument-hint: "<function_name>"
+---
+
+# Explain
+
+Call `cqs_explain` MCP tool with `name` set to the user's argument.
+
+Accepts function name or `file:function` format (e.g., `search_filtered` or `src/search.rs:search_filtered`).
+
+Returns a comprehensive function card: signature, docstring, callers, callees, and similar functions. Collapses what would be 4+ separate tool calls into 1.

--- a/.claude/skills/cqs-read/SKILL.md
+++ b/.claude/skills/cqs-read/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: cqs-read
+description: Read a file with contextual notes injected as comments. Richer than raw Read.
+disable-model-invocation: false
+argument-hint: "<path>"
+---
+
+# CQS Read
+
+Call `cqs_read` MCP tool with `path` set to the user's argument (relative to project root).
+
+Returns the file contents with relevant notes and observations injected as comments at the appropriate locations. Use instead of raw `Read` tool when you want contextual awareness from prior sessions.

--- a/.claude/skills/cqs-ref/SKILL.md
+++ b/.claude/skills/cqs-ref/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: cqs-ref
+description: Manage reference indexes — add, remove, update, list external codebases for multi-index search.
+disable-model-invocation: false
+argument-hint: "<add|remove|update|list> [name] [source_path] [--weight 0.8]"
+---
+
+# Reference Management
+
+Manage reference indexes for multi-index search. References are read-only indexes of external codebases that surface in search results alongside the primary project.
+
+## Subcommands
+
+### `/cqs-ref add <name> <source_path> [--weight 0.8]`
+
+Run: `cqs ref add <name> <source_path> --weight <weight>`
+
+Steps:
+1. Validates the source path exists
+2. Creates reference storage directory (`~/.local/share/cqs/refs/<name>/`)
+3. Indexes all supported source files
+4. Builds HNSW index for the reference
+5. Adds reference config to `.cqs.toml`
+
+**Weight** (0.0–1.0, default 0.8): Score multiplier for reference results. Lower = reference results rank below project results. Never exceed 1.0.
+
+### `/cqs-ref list`
+
+Run: `cqs ref list`
+
+Shows all configured references with name, weight, chunk count, and source path.
+
+### `/cqs-ref update <name>`
+
+Run: `cqs ref update <name>`
+
+Re-indexes a reference from its original source path. Incremental — only re-embeds changed files, prunes deleted ones, rebuilds HNSW.
+
+### `/cqs-ref remove <name>`
+
+Run: `cqs ref remove <name>`
+
+Removes reference from config and deletes its storage directory.
+
+## Tips
+
+- Use `/cqs-diff` after adding a reference to compare it against your project
+- Use `/cqs-search --sources <name>` to search only within a specific reference
+- References are stored in `~/.local/share/cqs/refs/`, not in the project directory
+- Config lives in `.cqs.toml` at project root (checked into git)

--- a/.claude/skills/cqs-remove-note/SKILL.md
+++ b/.claude/skills/cqs-remove-note/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: cqs-remove-note
+description: Remove a note from project memory by exact text match.
+disable-model-invocation: false
+argument-hint: "<exact_text>"
+---
+
+# Remove Note
+
+Call `cqs_remove_note` MCP tool with `text` set to exact text of the note to delete.
+
+Tip: Use `/cqs-search` or `/groom-notes` first to find the exact text of notes to remove.

--- a/.claude/skills/cqs-search/SKILL.md
+++ b/.claude/skills/cqs-search/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: cqs-search
+description: Semantic code search. Finds functions by concept, not text. Use instead of grep/glob.
+disable-model-invocation: false
+argument-hint: "<query> [--lang rust] [--limit 10] [--name-only] [--semantic-only]"
+---
+
+# Search
+
+Semantic code search using `cqs_search` MCP tool.
+
+## Usage
+
+Call `cqs_search` with the user's query. Parse arguments from the invocation:
+
+- First positional arg = `query` (required)
+- `--lang <language>` → `language` filter (rust, python, typescript, javascript, go, c, java)
+- `--limit <n>` → `limit` (default 5, max 20)
+- `--threshold <n>` → `threshold` (default 0.3)
+- `--name-only` → `name_only: true` — definition search, skips embedding. Use for "where is X defined?"
+- `--semantic-only` → `semantic_only: true` — pure vector similarity, no hybrid RRF
+- `--path <glob>` → `path_pattern` filter (e.g., `src/mcp/**`)
+- `--sources <name,...>` → `sources` array — filter which indexes (e.g., `project`, reference names)
+
+## Examples
+
+- `/cqs-search retry with exponential backoff` — find retry logic by concept
+- `/cqs-search Store::open --name-only` — find where Store::open is defined
+- `/cqs-search error handling --lang rust --path src/mcp/**` — scoped search
+- `/cqs-search authentication --sources project,stdlib` — multi-index search

--- a/.claude/skills/cqs-similar/SKILL.md
+++ b/.claude/skills/cqs-similar/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: cqs-similar
+description: Find code similar to a given function. Search by example.
+disable-model-invocation: false
+argument-hint: "<function_name> [--limit 5] [--threshold 0.3] [--lang rust]"
+---
+
+# Similar
+
+Call `cqs_similar` MCP tool. Parse arguments:
+
+- First positional arg = `target` — function name or `file:function` (required)
+- `--limit <n>` → max results (default 5, max 20)
+- `--threshold <n>` → minimum similarity (default 0.3)
+- `--lang <language>` → filter by language
+
+Useful for refactoring discovery, finding duplicates, and understanding patterns.

--- a/.claude/skills/cqs-stats/SKILL.md
+++ b/.claude/skills/cqs-stats/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: cqs-stats
+description: Show index statistics — chunk counts, languages, last update.
+disable-model-invocation: false
+argument-hint: ""
+---
+
+# Stats
+
+Call `cqs_stats` MCP tool (no arguments). Display the results clearly — chunk counts by language, total indexed, last update time.

--- a/.claude/skills/cqs-update-note/SKILL.md
+++ b/.claude/skills/cqs-update-note/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: cqs-update-note
+description: Update an existing note's text, sentiment, or mentions.
+disable-model-invocation: false
+argument-hint: "<exact_text> [--new-text ...] [--sentiment N] [--mentions ...]"
+---
+
+# Update Note
+
+Call `cqs_update_note` MCP tool. Parse arguments:
+
+- First positional arg = `text` (exact match to find the note)
+- `--new-text <text>` → `new_text` replacement
+- `--sentiment <value>` → `new_sentiment` (-1, -0.5, 0, 0.5, 1)
+- `--mentions <file1,file2,...>` → `new_mentions` replacement array
+
+All update fields are optional — omit to keep current value.

--- a/.claude/skills/cqs-watch/SKILL.md
+++ b/.claude/skills/cqs-watch/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: cqs-watch
+description: Start the cqs file watcher to keep the index fresh automatically.
+disable-model-invocation: false
+argument-hint: "[--debounce 500] [--no-ignore]"
+---
+
+# Watch Mode
+
+Start the cqs file watcher to keep the index updated as files change.
+
+## Usage
+
+Run: `cqs watch [--debounce <ms>] [--no-ignore]`
+
+- `--debounce <ms>` — Debounce interval in milliseconds (default: 500). How long to wait after a file change before re-indexing.
+- `--no-ignore` — Don't respect `.gitignore` rules. Index all files including those normally ignored.
+
+## Behavior
+
+- Watches the project directory recursively for file changes
+- Re-indexes changed files automatically (incremental — only changed files)
+- Respects `.gitignore` by default
+- Debounces rapid changes to avoid re-indexing on every keystroke
+- Runs in foreground — use a separate terminal or background it
+
+## When to use
+
+- During active development to keep search results current
+- Before relying on `cqs_search` results if you've made recent changes
+- Not needed if you manually run `cqs index` when needed
+
+## Alternative
+
+If you just need a one-time refresh: `cqs index` (or `/reindex` for before/after stats).

--- a/.claude/skills/migrate/SKILL.md
+++ b/.claude/skills/migrate/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: migrate
+description: Handle cqs schema version upgrades — check version, attempt migration, rebuild if needed.
+disable-model-invocation: false
+argument-hint: ""
+---
+
+# Migrate
+
+Handle schema version mismatches when upgrading cqs.
+
+## Process
+
+### 1. Check current schema version
+
+```bash
+cqs stats 2>&1
+```
+
+If it works normally, no migration needed. If you see a schema error, continue.
+
+### 2. Identify the mismatch
+
+Errors tell you the versions:
+- **SchemaMismatch(path, from, to)**: Index is at version `from`, cqs expects `to`. Auto-migration was attempted but no migration path exists.
+- **SchemaNewerThanCq(version)**: Index was created by a newer cqs version. Update your binary.
+
+### 3. Attempt migration
+
+cqs attempts auto-migration when it opens the database. If you're seeing SchemaMismatch, it means no migration path exists for that version jump.
+
+Check available migrations:
+```bash
+grep -n "migrate_v" src/store/migrations.rs
+```
+
+### 4. Rebuild if no migration path
+
+When auto-migration isn't available, the only option is a full rebuild:
+
+```bash
+# Back up the old index (just in case)
+cp -r .cq/ .cq.backup/
+
+# Delete and rebuild
+rm -rf .cq/
+cqs init
+cqs index
+```
+
+This re-parses all source files and re-embeds them. Notes in `docs/notes.toml` are preserved (they live outside `.cq/`).
+
+### 5. Rebuild references too
+
+References have their own databases at the same schema version:
+
+```bash
+cqs ref list
+```
+
+For each reference:
+```bash
+cqs ref update <name>
+```
+
+If that fails with schema errors, remove and re-add:
+```bash
+cqs ref remove <name>
+cqs ref add <name> <source_path> --weight <weight>
+```
+
+### 6. Verify
+
+```bash
+cqs stats
+```
+
+Should show the current schema version and correct chunk counts.
+
+### 7. Clean up
+
+```bash
+rm -rf .cq.backup/
+```
+
+## Notes
+
+- `.cq/` is gitignored — rebuilding only costs time, not data
+- Notes (`docs/notes.toml`) are never lost — they're separate from the index
+- Schema version is stored in `metadata` table: `SELECT value FROM metadata WHERE key = 'schema_version'`
+- Current version: v10 (check `src/store/helpers.rs:CURRENT_SCHEMA_VERSION`)

--- a/.claude/skills/troubleshoot/SKILL.md
+++ b/.claude/skills/troubleshoot/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: troubleshoot
+description: Diagnose common cqs issues — stale index, MCP not connecting, model download, schema mismatch.
+disable-model-invocation: false
+argument-hint: ""
+---
+
+# Troubleshoot
+
+Guided diagnosis of common cqs issues. Run through checks in order, stop at first problem found.
+
+## Checklist
+
+### 1. Is cqs installed and working?
+
+```bash
+cqs --version
+```
+
+If not found: `cargo install --path .` (from source) or check `~/.cargo/bin/` is in PATH.
+
+### 2. Is the project initialized?
+
+```bash
+ls -la .cq/
+```
+
+Should contain `index.db` and `hnsw.bin`. If missing: `cqs init && cqs index`.
+
+### 3. Is the index populated?
+
+Call `cqs_stats` MCP tool (or `cqs stats`). Check:
+- Chunk count > 0
+- Last update is recent
+- Expected languages are present
+
+If empty: `cqs index` to rebuild.
+
+### 4. Schema version mismatch?
+
+```bash
+cqs stats 2>&1
+```
+
+If you see "SchemaMismatch" or "SchemaNewerThanCq":
+- **Older schema**: Run `/migrate` to upgrade
+- **Newer schema**: Update cqs binary to latest version
+
+Current schema version: check `src/store/helpers.rs` for `CURRENT_SCHEMA_VERSION`.
+
+### 5. Model downloaded?
+
+```bash
+ls -la ~/.cache/huggingface/hub/models--intfloat--e5-base-v2/
+```
+
+If missing or incomplete, cqs downloads on first use. Check network access to huggingface.co.
+If corrupted: delete the directory and let cqs re-download (blake3 checksums verify integrity).
+
+### 6. MCP server connecting?
+
+```bash
+cqs serve --stdio 2>/dev/null
+```
+
+Should start without error. Common issues:
+- Port conflict (HTTP mode): another process on the port
+- API key mismatch: check `CQS_API_KEY` env var or `--api-key-file`
+- Check Claude Code MCP config: `.claude/mcp.json` or global `~/.claude/mcp.json`
+
+### 7. Index stale?
+
+Compare `cqs stats` last update time vs recent file modifications.
+Fix: `cqs index` (one-time) or `cqs watch` (continuous).
+
+### 8. References broken?
+
+```bash
+cqs ref list
+```
+
+Check that source paths still exist and chunk counts are > 0.
+If source moved: `cqs ref remove <name>` and re-add with new path.
+
+## Report
+
+After running checks, summarize:
+- What was checked
+- What failed (if anything)
+- What was fixed or needs fixing

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,32 +2,14 @@
 
 ## Right Now
 
-**Phase 6: Discovery & UX** — implementation complete, needs review + PR (2026-02-06)
+**v0.7.0 released** (2026-02-06). Clean state. No active work.
 
-### Implemented (all uncommitted on main)
-- [x] Store prereq methods (`get_chunk_with_embedding`, `all_chunk_identities`, `ChunkIdentity`)
-- [x] `cqs similar` (CLI + MCP) — search by example using stored embeddings
-- [x] `cqs explain` (CLI + MCP) — function card (signature, callers, callees, similar)
-- [x] `cqs diff` (CLI + MCP) — semantic diff between indexed snapshots
-- [x] Workspace-aware indexing — detect Cargo workspace root
-
-### New files
-- `src/diff.rs` — core diff algorithm
-- `src/cli/commands/similar.rs` — CLI handler
-- `src/cli/commands/explain.rs` — CLI handler
-- `src/cli/commands/diff.rs` — CLI handler
-- `src/mcp/tools/similar.rs` — MCP tool
-- `src/mcp/tools/explain.rs` — MCP tool
-- `src/mcp/tools/diff.rs` — MCP tool
-
-### Modified files
-- `src/store/chunks.rs`, `src/store/helpers.rs`, `src/store/mod.rs` — Store prereqs
-- `src/cli/mod.rs`, `src/cli/commands/mod.rs` — CLI wiring (3 new commands)
-- `src/mcp/tools/mod.rs` — MCP wiring (3 new tools)
-- `src/cli/display.rs` — `display_similar_results_json`
-- `src/cli/config.rs` — workspace-aware `find_project_root`
-- `src/lib.rs` — `pub mod diff`
-- `CLAUDE.md` — document new tools
+### What shipped in v0.7.0
+- `cqs similar` (CLI + MCP) — search by example using stored embeddings
+- `cqs explain` (CLI + MCP) — function card (signature, callers, callees, similar)
+- `cqs diff` (CLI + MCP) — semantic diff between indexed snapshots
+- Workspace-aware indexing — detect Cargo workspace root
+- Store prereqs: `get_chunk_with_embedding`, `all_chunk_identities`, `ChunkIdentity`
 
 ### Dev environment
 - `~/.bashrc`: `LD_LIBRARY_PATH` for ort CUDA libs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -268,15 +268,42 @@
 
 ## Phase 6: Discovery & UX
 
-### Ideas
+### Status: Complete (v0.7.0)
 
-- `cqs diff` — semantic diff between branches/versions ("what changed conceptually?" vs line-level)
-- `cqs similar <file>` — find semantically similar functions/files for refactoring discovery
-- Pre-built reference packages (#255) — downloadable indexes for popular crates (`cqs ref install tokio`)
-- Workspace-aware indexing — detect Cargo workspaces, index all crates with cross-crate call graphs
-- `cqs explain <function>` — generate NL explanation of what a function does (NL pipeline in reverse)
+### Done
 
-## Phase 7: Security
+- [x] `cqs similar` (CLI + MCP) — find similar functions by example using stored embeddings
+- [x] `cqs explain` (CLI + MCP) — function card (signature, callers, callees, similar)
+- [x] `cqs diff` (CLI + MCP) — semantic diff between indexed snapshots
+- [x] Workspace-aware indexing — detect Cargo workspace root from member crates
+- [x] Store prereqs: `get_chunk_with_embedding`, `all_chunk_identities`, `ChunkIdentity`
+- [x] 431 tests (no GPU), 12 MCP tools
+
+### Deferred
+
+- Pre-built reference packages (#255) — `cqs ref install tokio`
+
+## Phase 7: Token Efficiency
+
+### Rationale
+
+Each feature targets a specific multi-tool-call pattern that burns tokens in AI sessions.
+
+### Ideas (ordered by projected savings)
+
+1. **`cqs trace`** — Follow a call chain end-to-end. "Trace search from CLI to results" returns the ordered function chain with condensed signatures. Replaces 5-10 sequential file reads per code-flow question. *Highest savings — most common multi-tool pattern.*
+
+2. **`cqs impact`** — "What breaks if I change X?" Returns callers with usage context (the relevant lines, not whole files), plus tests that reference X. Replaces callers + reading each caller's file + grepping tests. ~5 tool calls → 1.
+
+3. **`cqs batch`** — Execute multiple queries in one tool call. `{queries: [{search: "X"}, {callers: "Y"}, {explain: "Z"}]}` → single response. Eliminates round-trip overhead for independent lookups.
+
+4. **`cqs context`** — "What do I need to know to work on module X?" Returns public API, internal types, imports, dependents, and recent notes. Like `explain` but at module/file scope.
+
+5. **`cqs test-map`** — Map functions to tests that exercise them. "What tests cover `search_filtered`?" Returns test names + files. Saves grep rounds before refactoring.
+
+6. **Focused `cqs_read`** — Mode that returns just the target function + its type dependencies (struct defs, trait bounds) instead of the whole file. Cuts file-read tokens by 50-80% in large files.
+
+## Phase 8: Security
 
 ### Done
 

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -5,15 +5,6 @@
 
 [[note]]
 sentiment = -1.0
-text = "tree-sitter 0.26 with grammar crates pinned to 0.23.x causes mysterious parsing failures. No clear error messages. Keep grammar versions aligned with tree-sitter core."
-mentions = [
-    "tree-sitter",
-    "parser.rs",
-    "Cargo.toml",
-]
-
-[[note]]
-sentiment = -1.0
 text = 'MCP tools/call responses MUST wrap in {"content":[{"type":"text","text":"..."}]}. Returning plain JSON causes silent failure - tool runs but results appear empty in Claude Code.'
 mentions = [
     "src/mcp/tools/mod.rs",
@@ -35,23 +26,6 @@ mentions = [
     "gh",
     "CI",
     "github",
-]
-
-[[note]]
-sentiment = -1.0
-text = "Context compacts suddenly without warning. Lose state mid-task. Update tears proactively - don't wait for compaction. The trap in CLAUDE.md helps on resume."
-mentions = [
-    "anthropic",
-    "claude",
-    "context",
-]
-
-[[note]]
-sentiment = -1.0
-text = "Asking instead of doing wastes turns. 'Do as thou wilt shall be the whole of the law.' Act on clear patterns, update tears without asking, reserve questions for genuine ambiguity."
-mentions = [
-    "workflow",
-    "autonomy",
 ]
 
 [[note]]
@@ -90,22 +64,6 @@ mentions = [
 ]
 
 [[note]]
-sentiment = 1.0
-text = "cqs is Tears - context persistence for AI collaborators. Code chunks are entity 1, notes are entity 2. The name was always right."
-mentions = [
-    "README.md",
-    "CLAUDE.md",
-]
-
-[[note]]
-sentiment = 1.0
-text = "Natural language carries sentiment. Words like 'failed', 'broke', 'wasted' are negative. 'Worked', 'clean', 'saved' are positive. Embedding model learned this. Schema simplifies to just text."
-mentions = [
-    "note.rs",
-    "embedder.rs",
-]
-
-[[note]]
 sentiment = 0.5
 text = "769th embedding dimension can encode explicit sentiment. Similarity search then weights by feeling automatically. Breaking schema change but enables sentiment-aware retrieval."
 mentions = [
@@ -124,26 +82,10 @@ mentions = [
 
 [[note]]
 sentiment = 1.0
-text = "Locality is the feature, not limitation. cqs indexes YOUR codebase, YOUR team's memory. Context persistence is inherently local. Specificity is the value."
-mentions = [
-    "CLAUDE.md",
-    "tears",
-]
-
-[[note]]
-sentiment = 1.0
 text = "cuVS CAGRA: 8-12x faster index builds, 4-8x faster search vs CPU HNSW. Rust bindings exist (cuvs crate). Feature-flagged as gpu-search for CUDA-equipped infrastructure."
 mentions = [
     "hnsw.rs",
     "Cargo.toml",
-]
-
-[[note]]
-sentiment = 0.5
-text = "Notes with sentiment are prediction errors - expected X, got Y. Negative = pain, positive = gain. High-value because they mark where understanding needs updating. Index surprises, not routine."
-mentions = [
-    "note.rs",
-    "tears",
 ]
 
 [[note]]
@@ -153,15 +95,6 @@ mentions = [
     "embedder.rs",
     "ort",
     "DirectML",
-]
-
-[[note]]
-sentiment = 0.5
-text = "Tears actually work. Context resumes correctly after compaction - read PROJECT_CONTINUITY.md and pick up where we left off. The system serves its purpose."
-mentions = [
-    "PROJECT_CONTINUITY.md",
-    "tears",
-    "context",
 ]
 
 [[note]]
@@ -208,15 +141,6 @@ mentions = [
 ]
 
 [[note]]
-sentiment = 0.0
-text = 'PowerShell workaround for WSL git credentials is reliable. `powershell.exe -Command "cd C:\Projects\cq; git push"` - ugly but works every time.'
-mentions = [
-    "WSL",
-    "git",
-    "PowerShell",
-]
-
-[[note]]
 sentiment = 0.5
 text = "Pre-commit hook catches fmt issues before CI roundtrip. Fast feedback loop. Worth the setup."
 mentions = [
@@ -249,34 +173,6 @@ mentions = [
     "CUDA",
     "LD_LIBRARY_PATH",
     "embedder.rs",
-]
-
-[[note]]
-sentiment = 0.0
-text = "Switched from nomic-embed-text-v1.5 to E5-base-v2 (Feb 2026). E5 prefixes: 'passage: ' for docs, 'query: ' for search. Window params adjusted: 480 tokens/64 overlap (E5's 512 limit vs nomic's 8192)."
-mentions = [
-    "src/embedder.rs",
-    "src/cli/mod.rs",
-    "E5",
-    "windowing",
-]
-
-[[note]]
-sentiment = -0.5
-text = "ensure_ort_provider_libs() had a bug: if ort cache dir was first in LD_LIBRARY_PATH, it would create circular symlinks in the source directory, corrupting the ort cache. Fixed by skipping dirs containing ort_cache path."
-mentions = [
-    "embedder.rs",
-    "ort",
-    "symlink",
-]
-
-[[note]]
-sentiment = -0.5
-text = "cfg(feature) dead code trap: if a constant is defined outside a #[cfg(feature)] block but only used inside it, clippy reports dead_code when feature is disabled. Move constants inside the cfg block or gate with #[cfg(feature)] too."
-mentions = [
-    "src/cli/commands/query.rs",
-    "CAGRA_THRESHOLD",
-    "clippy",
 ]
 
 [[note]]
@@ -345,15 +241,6 @@ mentions = [
     "LD_LIBRARY_PATH",
     "WSL",
     "cuvs",
-]
-
-[[note]]
-sentiment = 0.0
-text = "Run `cqs watch` in background terminal to keep notes.toml indexed. Manual edits without watch = stale search results."
-mentions = [
-    "cqs watch",
-    "notes.toml",
-    "indexing",
 ]
 
 [[note]]
@@ -519,24 +406,49 @@ mentions = [
 [[note]]
 sentiment = -0.5
 text = "CHANGELOG pollution trap: if you update CHANGELOG entries after the tag is already cut, the entry drifts from reality. Always verify with `git show vX.Y.Z:CHANGELOG.md` before a release to catch drift. v0.5.3 entry had multi-index content that wasn't in that release."
-mentions = ["CHANGELOG.md", "git tag", "release"]
+mentions = [
+    "CHANGELOG.md",
+    "git tag",
+    "release",
+]
 
 [[note]]
 sentiment = -0.5
 text = "cfg(test) only applies within the library crate's unit tests. Integration tests (tests/*.rs) are separate compilation units — they see the public API without cfg(test) gating. Can't use cfg(test) to hide types only needed by integration tests."
-mentions = ["cfg(test)", "tests/", "integration tests"]
+mentions = [
+    "cfg(test)",
+    "tests/",
+    "integration tests",
+]
 
 [[note]]
 sentiment = -0.5
 text = "parse_target (file:name resolution) is duplicated in 4 places: cli/commands/similar.rs, cli/commands/explain.rs, mcp/tools/similar.rs, mcp/tools/explain.rs. Should extract to shared utility if adding more commands that resolve targets."
-mentions = ["src/cli/commands/similar.rs", "src/cli/commands/explain.rs", "src/mcp/tools/similar.rs", "src/mcp/tools/explain.rs"]
+mentions = [
+    "src/cli/commands/similar.rs",
+    "src/cli/commands/explain.rs",
+    "src/mcp/tools/similar.rs",
+    "src/mcp/tools/explain.rs",
+]
 
 [[note]]
 sentiment = -0.5
 text = "cqs diff loads embeddings one-by-one for each matched pair via get_chunk_with_embedding. For large diffs (1000+ matched functions), this will be slow. Batch loading would help but adds complexity — defer until someone hits the perf wall."
-mentions = ["src/diff.rs", "semantic_diff", "get_chunk_with_embedding"]
+mentions = [
+    "src/diff.rs",
+    "semantic_diff",
+    "get_chunk_with_embedding",
+]
 
 [[note]]
 sentiment = 0.0
-text = "Workspace detection uses string contains(\"[workspace]\") on Cargo.toml content. Simple but could false-positive on comments. Low risk — real TOML parsing would need toml crate dependency just for this check."
-mentions = ["src/cli/config.rs", "find_cargo_workspace_root"]
+text = 'Workspace detection uses string contains("[workspace]") on Cargo.toml content. Simple but could false-positive on comments. Low risk — real TOML parsing would need toml crate dependency just for this check.'
+mentions = [
+    "src/cli/config.rs",
+    "find_cargo_workspace_root",
+]
+
+[[note]]
+sentiment = 0.5
+text = "When adding new MCP tools/capabilities: create a cqs-prefixed skill in .claude/skills/, update bootstrap's portable skills list, and decide if it's project-local or global (~/.claude/skills/). Skill = SKILL.md with frontmatter (name, description, argument-hint) + usage docs. Keep names prefixed to avoid collisions."
+mentions = ["bootstrap/SKILL.md", ".claude/skills/", "src/mcp/tools/mod.rs"]


### PR DESCRIPTION
## Summary

- Add 16 new Claude Code skills wrapping all 12 cqs MCP tools plus 4 CLI workflows (`cqs-ref`, `cqs-watch`, `troubleshoot`, `migrate`)
- All tool skills prefixed with `cqs-` to avoid name collisions with other skill sets
- Rewrite `/bootstrap` to be fully self-contained: one command sets up MCP config, skills, tears infrastructure, CLAUDE.md integration, init, and index for any new project
- Also moved `fix-settings` skill to `~/.claude/skills/` (global, not in this PR)

## Test plan

- [x] All 16 new skills appear in Claude Code's `/` autocomplete
- [x] Fresh-eyes review passed (2 stale references fixed)
- [x] Skill frontmatter `name` fields match directory names
- [x] MCP tool parameters in skills verified against `src/mcp/tools/mod.rs` schemas
- [ ] Test `/bootstrap` in a fresh project directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
