### PR TITLE
chore: Add Phase 7 skill wrappers and update bootstrap

### DIFF
--- a/.claude/skills/cqs-batch/SKILL.md
+++ b/.claude/skills/cqs-batch/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: cqs-batch
+description: Execute multiple cqs queries in a single tool call. MCP-only, max 10.
+disable-model-invocation: false
+argument-hint: "<query1> <query2> ..."
+---
+
+# Batch
+
+Call `cqs_batch` MCP tool. Build a `queries` array from the user's arguments.
+
+Each query is `{"tool": "<tool_name>", "arguments": {...}}`. Supported tools: search, callers, callees, explain, similar, stats.
+
+Example: if user says `/cqs-batch search "retry logic" callers search_filtered`, build:
+```json
+{"queries": [
+  {"tool": "search", "arguments": {"query": "retry logic"}},
+  {"tool": "callers", "arguments": {"name": "search_filtered"}}
+]}
+```
+
+Max 10 queries per batch. Returns per-query results or errors.

--- a/.claude/skills/cqs-bootstrap/SKILL.md
+++ b/.claude/skills/cqs-bootstrap/SKILL.md
@@ -99,6 +99,11 @@ None.
    - `cqs-audit-mode` — toggle audit mode for unbiased review
    - `cqs-ref` — manage reference indexes (add/remove/update/list)
    - `cqs-watch` — start file watcher for live index updates
+   - `cqs-trace` — follow call chain between two functions
+   - `cqs-impact` — what breaks if you change X
+   - `cqs-test-map` — map functions to their tests
+   - `cqs-batch` — execute multiple queries in one call
+   - `cqs-context` — module-level file overview
    - `troubleshoot` — diagnose common cqs issues
    - `migrate` — handle schema version upgrades
 
@@ -167,7 +172,7 @@ Use it for:
 
 Fall back to Grep/Glob only for exact string matches or when semantic search returns nothing.
 
-Tools: `cqs_search`, `cqs_stats`, `cqs_similar`, `cqs_explain`, `cqs_diff` (run `cqs watch` to keep index fresh)
+Tools: `cqs_search`, `cqs_stats`, `cqs_similar`, `cqs_explain`, `cqs_diff`, `cqs_trace`, `cqs_impact`, `cqs_test_map`, `cqs_batch`, `cqs_context` (run `cqs watch` to keep index fresh)
 
 ## Audit Mode
 

--- a/.claude/skills/cqs-context/SKILL.md
+++ b/.claude/skills/cqs-context/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: cqs-context
+description: Module-level understanding — chunks, callers, callees, notes for a file.
+disable-model-invocation: false
+argument-hint: "<file_path>"
+---
+
+# Context
+
+Call `cqs_context` MCP tool with `path` set to the user's argument.
+
+Returns a module overview for the given file: all chunks (signatures), external callers, external callees, dependent files, and related notes. Useful for understanding a file's role before making changes.

--- a/.claude/skills/cqs-impact/SKILL.md
+++ b/.claude/skills/cqs-impact/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: cqs-impact
+description: What breaks if you change X? Callers with snippets + affected tests.
+disable-model-invocation: false
+argument-hint: "<function_name> [--depth 1]"
+---
+
+# Impact
+
+Call `cqs_impact` MCP tool. Parse arguments:
+
+- First positional arg = `name` — function to analyze (required)
+- `--depth <n>` → caller depth (default 1 = direct callers only)
+
+Returns callers with call-site snippets and affected tests via reverse BFS. Collapses ~5 tool calls (callers + reading each caller file + grepping tests) into 1.

--- a/.claude/skills/cqs-test-map/SKILL.md
+++ b/.claude/skills/cqs-test-map/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: cqs-test-map
+description: Map functions to tests that exercise them via reverse call graph traversal.
+disable-model-invocation: false
+argument-hint: "<function_name> [--depth 5]"
+---
+
+# Test Map
+
+Call `cqs_test_map` MCP tool. Parse arguments:
+
+- First positional arg = `name` — function to find tests for (required)
+- `--depth <n>` → max reverse BFS depth (default 5)
+
+Returns tests reachable via reverse call graph with full call chains. Useful before refactoring to know which tests to run.

--- a/.claude/skills/cqs-trace/SKILL.md
+++ b/.claude/skills/cqs-trace/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: cqs-trace
+description: Follow a call chain between two functions. BFS shortest path through the call graph.
+disable-model-invocation: false
+argument-hint: "<source> <target> [--max-depth 10]"
+---
+
+# Trace
+
+Call `cqs_trace` MCP tool. Parse arguments:
+
+- First positional arg = `source` — starting function name (required)
+- Second positional arg = `target` — destination function name (required)
+- `--max-depth <n>` → maximum BFS depth (default 10)
+
+Returns the shortest call path from source to target with file/line/signature for each step. Saves 5-10 sequential file reads per code-flow question.


### PR DESCRIPTION
## Summary

- Add 5 skill wrappers for Phase 7 MCP tools: cqs-trace, cqs-impact, cqs-test-map, cqs-batch, cqs-context
- Update cqs-bootstrap portable skills list and CLAUDE.md template with Phase 7 tools

## Test plan

- [x] Skills appear in Claude Code skill list
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
