### PR TITLE
chore: Release v0.9.0

### DIFF
--- a/.claude/skills/cqs-bootstrap/SKILL.md
+++ b/.claude/skills/cqs-bootstrap/SKILL.md
@@ -104,6 +104,9 @@ None.
    - `cqs-test-map` — map functions to their tests
    - `cqs-batch` — execute multiple queries in one call
    - `cqs-context` — module-level file overview
+   - `cqs-gather` — smart context assembly (seed search + call graph BFS)
+   - `cqs-dead` — find dead code (functions with no callers)
+   - `cqs-gc` — report index staleness
    - `troubleshoot` — diagnose common cqs issues
    - `migrate` — handle schema version upgrades
 
@@ -172,7 +175,7 @@ Use it for:
 
 Fall back to Grep/Glob only for exact string matches or when semantic search returns nothing.
 
-Tools: `cqs_search`, `cqs_stats`, `cqs_similar`, `cqs_explain`, `cqs_diff`, `cqs_trace`, `cqs_impact`, `cqs_test_map`, `cqs_batch`, `cqs_context` (run `cqs watch` to keep index fresh)
+Tools: `cqs_search`, `cqs_stats`, `cqs_similar`, `cqs_explain`, `cqs_diff`, `cqs_trace`, `cqs_impact`, `cqs_test_map`, `cqs_batch`, `cqs_context`, `cqs_gather`, `cqs_dead`, `cqs_gc` (run `cqs watch` to keep index fresh)
 
 ## Audit Mode
 

--- a/.claude/skills/cqs-dead/SKILL.md
+++ b/.claude/skills/cqs-dead/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: cqs-dead
+description: Find functions/methods never called by indexed code.
+disable-model-invocation: false
+argument-hint: "[--include-pub]"
+---
+
+# Dead Code
+
+Call `cqs_dead` MCP tool. Parse arguments:
+
+- `--include-pub` → include public API functions (excluded by default)
+
+Finds functions and methods with no callers in the indexed codebase. Excludes main, test functions, and trait implementations by default. Useful for cleanup and maintenance.

--- a/.claude/skills/cqs-gather/SKILL.md
+++ b/.claude/skills/cqs-gather/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: cqs-gather
+description: Smart context assembly — seed search + call graph BFS expansion.
+disable-model-invocation: false
+argument-hint: "<query> [--expand 1] [--direction both|callers|callees] [--limit 10]"
+---
+
+# Gather
+
+Call `cqs_gather` MCP tool. Parse arguments:
+
+- First positional arg = `query` — semantic search query (required)
+- `--expand <n>` → BFS expansion depth (default 1, max 5)
+- `--direction <d>` → expansion direction: both, callers, callees (default both)
+- `--limit <n>` → max results (default 10)
+
+Returns seed search results expanded via call graph traversal. One call for "show me everything related to X". Cap: 200 nodes.

--- a/.claude/skills/cqs-gc/SKILL.md
+++ b/.claude/skills/cqs-gc/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: cqs-gc
+description: Reports staleness (CLI version prunes + rebuilds).
+disable-model-invocation: false
+argument-hint: ""
+---
+
+# GC
+
+Call `cqs_gc` MCP tool. No arguments.
+
+Reports index staleness: stale file count and missing file count. The CLI version (`cqs gc`) prunes chunks for deleted files, cleans orphan call graph entries, and rebuilds HNSW. The MCP version is read-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-02-07
+
+### Added
+- **`--chunk-type` filter** (CLI + MCP): narrow search to function/method/class/struct/enum/trait/interface/constant
+- **`--pattern` filter** (CLI + MCP): post-search structural matching — builder, error_swallow, async, mutex, unsafe, recursion
+- **`cqs dead`** (CLI + MCP): find functions/methods never called by indexed code. Excludes main, tests, trait impls. `--include-pub` for full audit
+- **`cqs gc`** (CLI + MCP): prune chunks for deleted files, clean orphan call graph entries, rebuild HNSW. MCP reports staleness without modifying
+- **`cqs gather`** (CLI + MCP): smart context assembly — BFS call graph expansion from semantic seed results. `--expand`, `--direction`, `--limit` params
+- **`cqs project`** (CLI): cross-project search via `~/.config/cqs/projects.toml` registry. `register`, `list`, `remove`, `search` subcommands
+- **`--format mermaid`** on `cqs trace`: generate Mermaid diagrams from call paths
+- **Index staleness warnings**: `cqs stats` and MCP stats report stale/missing file counts
+- 31 new unit tests (structural patterns, gather algorithm, project registry)
+- MCP tool count: 17 → 21
+
 ## [0.8.0] - 2026-02-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Project skills in `.claude/skills/`. Use `/skill-name` to invoke:
 - `/update-tears` -- capture state before compaction or task switch
 - `/groom-notes` -- review and clean up stale notes
 - `/release` -- version bump, changelog, publish, GitHub release
-- `/audit` -- 20-category code audit with parallel agents
+- `/audit` -- 14-category code audit with parallel agents
 - `/pr` -- WSL-safe PR creation (always `--body-file`)
 - `/cqs-bootstrap` -- set up tears infrastructure for new projects
 - `/reindex` -- rebuild index with before/after stats
@@ -51,11 +51,13 @@ Use it for:
 
 Fall back to Grep/Glob only for exact string matches or when semantic search returns nothing.
 
-Tools: `cqs_search`, `cqs_stats`, `cqs_similar`, `cqs_explain`, `cqs_diff` (run `cqs watch` to keep index fresh)
+Tools: `cqs_search`, `cqs_stats`, `cqs_callers`, `cqs_callees`, `cqs_read`, `cqs_similar`, `cqs_explain`, `cqs_diff`, `cqs_trace`, `cqs_impact`, `cqs_test_map`, `cqs_batch`, `cqs_context`, `cqs_gather`, `cqs_dead`, `cqs_gc`, `cqs_add_note`, `cqs_update_note`, `cqs_remove_note`, `cqs_audit_mode` (21 tools — run `cqs watch` to keep index fresh)
 
 **`cqs_similar`** — find code similar to a given function. Use for refactoring discovery, finding duplicates.
 **`cqs_explain`** — function card: signature, callers, callees, similar. Collapses 4+ tool calls into 1.
 **`cqs_diff`** — semantic diff between indexed snapshots. Requires references (`cqs ref add`).
+**`cqs_gather`** — smart context assembly: seed search + BFS call graph expansion. One call for "show me everything related to X".
+**`cqs_dead`** — find dead code: functions/methods with no callers in the index.
 
 ## Audit Mode
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ src/
   cli/          - Command-line interface (clap)
     mod.rs      - Argument parsing, command dispatch
     commands/   - Command implementations
-      mod.rs, query.rs, index.rs, stats.rs, graph.rs, serve.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, trace.rs, impact.rs, test_map.rs, context.rs, resolve.rs
+      mod.rs, query.rs, index.rs, stats.rs, graph.rs, serve.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, trace.rs, impact.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs
     config.rs   - Configuration file loading
     display.rs  - Output formatting, result display
     files.rs    - File enumeration, lock files, path utilities
@@ -113,7 +113,7 @@ src/
     validation.rs - Input validation, path checks
     audit_mode.rs - Audit mode state
     tools/      - MCP tool implementations
-      mod.rs, search.rs, read.rs, notes.rs, stats.rs, call_graph.rs, audit.rs, similar.rs, explain.rs, diff.rs, trace.rs, impact.rs, test_map.rs, batch.rs, context.rs, resolve.rs
+      mod.rs, search.rs, read.rs, notes.rs, stats.rs, call_graph.rs, audit.rs, similar.rs, explain.rs, diff.rs, trace.rs, impact.rs, test_map.rs, batch.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs
     transports/ - stdio.rs, http.rs transport implementations
   parser.rs     - tree-sitter code parsing (delegates to language/ registry)
   embedder.rs   - ONNX model (E5-base-v2), 769-dim embeddings
@@ -125,6 +125,9 @@ src/
   note.rs       - Developer notes with sentiment, rewrite_notes_file()
   diff.rs       - Semantic diff between indexed snapshots
   reference.rs  - Multi-index: ReferenceIndex, load, search, merge
+  gather.rs     - Smart context assembly (BFS call graph expansion)
+  structural.rs - Structural pattern matching on code chunks
+  project.rs    - Cross-project search registry
   config.rs     - Configuration file support
   index.rs      - VectorIndex trait (HNSW, CAGRA)
   lib.rs        - Public API
@@ -133,7 +136,7 @@ src/
     groom-notes/  - Interactive note review and cleanup
     update-tears/ - Session state capture for context persistence
     release/      - Version bump, changelog, publish workflow
-    audit/        - 20-category code audit with parallel agents
+    audit/        - 14-category code audit with parallel agents
     pr/           - WSL-safe PR creation
     cqs-bootstrap/ - New project setup with tears infrastructure
     reindex/      - Rebuild index with before/after stats

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.88"
 description = "Semantic code search for Claude Code. Find functions by what they do, not their names. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,24 +2,19 @@
 
 ## Right Now
 
-**Post-Phase 7: Uncharted Features** (2026-02-06). Implementing 8 features in 4 batches. Plan approved at `/home/user001/.claude/plans/hashed-spinning-cookie.md`.
+**Post-Phase 7 features merged** (2026-02-07). PR #280 squash-merged to main.
 
-### Active: Batch A — Chunk Type Filter + Dead Code Detection
-- Branch: `feat/batch-a-chunk-type-dead-code`
-- **In progress**: Adding `chunk_types` field to `SearchFilter`, just started editing `src/store/helpers.rs`
-- Still need: wire through CLI (`--chunk-type`), MCP (`chunk_type` param), search filtering (SQL + HNSW post-filter)
-- Still need: Dead code detection (`cqs dead` CLI + `cqs_dead` MCP)
-- 7 tests planned for batch
+All 8 post-roadmap features shipped:
+- Batch A: `--chunk-type` filter + `cqs dead`
+- Batch B: Staleness warnings + `cqs gc`
+- Batch C: `--format mermaid` on trace + `cqs project` cross-project search
+- Batch D: `cqs gather` (smart context assembly) + `--pattern` structural filter
 
-### Batches remaining (not started)
-- **Batch B**: Index staleness warning + GC (~250 LOC)
-- **Batch C**: Mermaid trace output + Cross-project search (~400 LOC)
-- **Batch D**: Smart context assembly (gather) + Structural queries (~500 LOC)
+**In progress**: docs review (agent running), then version bump to 0.9.0, changelog, release
 
-### What shipped this session (earlier)
-- v0.8.0 released (Phase 7 Token Efficiency) — crates.io + GitHub release
-- PRs #277 (Phase 7), #278 (docs), #279 (skill wrappers) all merged
-- Plan written and fresh-eyes reviewed for 8 post-roadmap features
+### Refactoring roadmapped
+- Split `parser.rs` (1071 lines) → per-language modules under `src/language/`
+- Split `hnsw.rs` (1150 lines) → `src/hnsw/` directory (build, persist, search)
 
 ### Dev environment
 - `~/.bashrc`: `LD_LIBRARY_PATH` for ort CUDA libs
@@ -68,5 +63,5 @@
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, score-based merge with weight
 - 7 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java)
-- 431 tests (no GPU), 0 warnings, clippy clean
-- MCP tools: 17 (search, stats, callers, callees, read, add_note, update_note, remove_note, audit_mode, diff, explain, similar, impact, trace, test_map, batch, context)
+- 258 lib tests (no GPU), 0 warnings, clippy clean
+- MCP tools: 21 (search, stats, callers, callees, read, add_note, update_note, remove_note, dead, audit_mode, diff, explain, similar, impact, trace, test_map, batch, context, gc, gather + pattern on search)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -298,6 +298,40 @@
 - [x] Shared infrastructure: `CallGraph`, `CallerWithContext`, `get_call_graph()`, `find_test_chunks()`, `get_chunks_by_origin()`, shared `resolve.rs` modules
 - [x] 17 MCP tools (up from 12), 4 new CLI subcommands, 431+ tests passing
 
+## Post-v0.8.0: Uncharted Features
+
+### Status: Complete (PR #280)
+
+### Done
+
+- [x] **`--chunk-type` filter** — narrow search to function/method/class/struct/enum/trait/interface/constant (CLI + MCP)
+- [x] **`cqs dead`** (CLI + MCP) — find functions/methods never called by indexed code. Excludes main, tests, trait impls. `--include-pub` for full audit.
+- [x] **Index staleness warnings** — `cqs stats` and MCP stats report stale/missing file counts
+- [x] **`cqs gc`** (CLI + MCP) — prune chunks for deleted files, clean orphan call graph entries, rebuild HNSW
+- [x] **`--format mermaid`** on `cqs trace` — generate Mermaid diagrams from call paths
+- [x] **`cqs project`** (CLI) — cross-project search via `~/.config/cqs/projects.toml` registry
+- [x] **`cqs gather`** (CLI + MCP) — smart context assembly: BFS call graph expansion from semantic seed results
+- [x] **`--pattern` filter** — post-search structural matching (builder, error_swallow, async, mutex, unsafe, recursion)
+- [x] 21 MCP tools (up from 17), 258 lib tests, 31 new unit tests
+
+## Refactoring
+
+### Planned
+
+- [ ] **Split `parser.rs`** (1071 lines) — 7 languages × (parsing + call extraction) in one file
+  - Extract per-language parsing to `src/language/{rust,python,typescript,javascript,go,c,java}.rs`
+  - Keep `parser.rs` as thin orchestrator: language detection → delegate to module
+  - Call extraction can stay with its language or move to `src/language/calls.rs`
+  - Target: `parser.rs` under 200 lines, language modules 80-150 each
+
+- [ ] **Split `hnsw.rs`** (1150 lines) — build, persistence, search, safety all interleaved
+  - `src/hnsw/mod.rs` — public types (HnswIndex, LoadedHnsw, HnswError) + VectorIndex impl
+  - `src/hnsw/build.rs` — `build()`, `build_batched()`, node insertion
+  - `src/hnsw/persist.rs` — `save()`, `load()`, checksum verification
+  - `src/hnsw/search.rs` — search implementation, SIMD cosine
+  - Tests stay with their respective modules
+  - Target: each file 200-350 lines
+
 ## Phase 8: Security
 
 ### Done

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -227,9 +227,9 @@ mentions = [
 sentiment = 1.0
 text = "Hybrid CAGRA startup: HNSW loads in 30ms (server ready), CAGRA builds in background (~1.2s), auto-swaps via Arc<RwLock>. Eliminated blocking startup delay."
 mentions = [
-    "mcp.rs",
-    "cagra.rs",
-    "hnsw.rs",
+    "src/mcp/server.rs",
+    "src/cagra.rs",
+    "src/hnsw.rs",
     "startup",
 ]
 
@@ -451,9 +451,18 @@ mentions = [
 [[note]]
 sentiment = 0.5
 text = "When adding new MCP tools/capabilities: create a cqs-prefixed skill in .claude/skills/, update bootstrap's portable skills list, and decide if it's project-local or global (~/.claude/skills/). Skill = SKILL.md with frontmatter (name, description, argument-hint) + usage docs. Keep names prefixed to avoid collisions."
-mentions = ["bootstrap/SKILL.md", ".claude/skills/", "src/mcp/tools/mod.rs"]
+mentions = [
+    ".claude/skills/cqs-bootstrap/SKILL.md",
+    ".claude/skills/",
+    "src/mcp/tools/mod.rs",
+]
 
 [[note]]
-sentiment = 0.5
-text = "Batch A shipped: --chunk-type filter for search (CLI + MCP) and cqs dead for dead code detection (CLI + MCP cqs_dead). Use --chunk-type function to find only functions, cqs dead --include-pub for full dead code audit. MCP search tool accepts chunk_type param (comma-separated)."
-mentions = ["src/store/helpers.rs", "SearchFilter", "src/cli/commands/dead.rs", "src/mcp/tools/dead.rs", "find_dead_code"]
+sentiment = -0.5
+text = "test_loaded_index_multiple_searches is flaky in CI. HNSW approximate search with 10 random embeddings doesn't reliably find exact match in top-5. Pre-existing, not related to any feature changes. Rerun CI when it fails."
+mentions = ["src/hnsw.rs", "CI", "flaky test"]
+
+[[note]]
+sentiment = 1.0
+text = "Post-v0.8.0 features shipped across 3 context windows with zero regressions. Tears + MEMORY.md system worked — each window picked up exactly where the last left off. Key: commit per batch, update tears after each commit, keep MEMORY.md under 200 lines."
+mentions = ["PROJECT_CONTINUITY.md", "MEMORY.md", "tears", "workflow"]


### PR DESCRIPTION
## Summary

Release v0.9.0 with 8 post-roadmap features from PR #280.

- Version bump 0.8.0 → 0.9.0
- CHANGELOG entry for all 8 features
- README: new filters (--chunk-type, --pattern), new CLI commands (dead, gc, gather, project), new MCP tools
- CONTRIBUTING: architecture tree updated with new files (dead.rs, gc.rs, gather.rs, project.rs, structural.rs)
- CLAUDE.md: audit count 20→14, complete tools list (21 tools)
- New skills: cqs-gather, cqs-dead, cqs-gc
- Bootstrap skill updated with new tools

## Test plan

- [x] `cargo build` — zero warnings
- [x] `cargo test --lib` — 258 passed
- [ ] CI passes (fmt, clippy, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
