### PR TITLE
chore: Groom notes, update tears, enhance groom-notes skill

### DIFF
--- a/.claude/skills/groom-notes/SKILL.md
+++ b/.claude/skills/groom-notes/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: groom-notes
-description: Review and clean up stale notes in notes.toml. Use when notes accumulate and need pruning.
+description: Review, prune, and suggest notes in notes.toml. Cleans stale notes and proposes new ones from recent changes.
 disable-model-invocation: false
 argument-hint: "[--warnings|--patterns|--all]"
 ---
 
 # Groom Notes
 
-Review all notes in `docs/notes.toml` and interactively clean up stale, outdated, or redundant ones.
+Review all notes in `docs/notes.toml` — clean up stale ones and suggest new ones from recent work.
 
-## Process
+## Phase 1: Prune
 
 1. **Parse notes**: Read `docs/notes.toml` and list all notes with their sentiment, text preview, and mentions.
 
@@ -24,12 +24,38 @@ Review all notes in `docs/notes.toml` and interactively clean up stale, outdated
    - **Stale**: References removed code or fixed issues
    - **Superseded**: Newer note covers the same ground
    - **Duplicate**: Multiple notes saying essentially the same thing
+   - **Update mentions**: File paths that moved but lesson is still valid
 
-4. **Get approval**: Present the list of proposed removals. Ask the user to confirm before making changes.
+4. **Get approval**: Present the list of proposed changes. Ask the user to confirm before making changes.
 
-5. **Execute**: Use `cqs_remove_note` MCP tool for each confirmed removal. If the MCP server isn't running, edit `docs/notes.toml` directly using `rewrite_notes_file` pattern (atomic write).
+5. **Execute**: Use `cqs_remove_note` / `cqs_update_note` MCP tools. If the MCP server isn't running, edit `docs/notes.toml` directly.
 
-6. **Report**: Show before/after count and what was removed.
+6. **Report**: Show before/after count and what was changed.
+
+## Phase 2: Suggest
+
+After pruning, scan for note-worthy events that aren't already captured:
+
+1. **Check recent git history**: `git log --since="1 week ago" --oneline` (or since last groom)
+2. **Look for surprise-worthy patterns**:
+   - Bug fixes — what was the non-obvious cause? (sentiment: -0.5 or -1)
+   - Refactoring lessons — what pattern worked or didn't? (sentiment: 0.5 or -0.5)
+   - New features — any architectural decisions worth remembering? (sentiment: 0)
+   - CI/tooling changes — any gotchas? (sentiment: -0.5)
+   - Performance discoveries — unexpectedly fast or slow? (sentiment: 0.5 or -0.5)
+3. **Cross-check existing notes**: Don't suggest notes that duplicate existing ones
+4. **Present suggestions**: Show proposed notes with text, sentiment, and mentions
+5. **Get approval**: User confirms which to add
+6. **Execute**: Use `cqs_add_note` for each approved suggestion
+
+### What makes a good note
+
+Notes capture **surprises** — things that broke predictions or would trip up a future session:
+- "X looks like it should work but doesn't because Y" (negative surprise)
+- "Doing X this way was unexpectedly effective" (positive surprise)
+- "X and Y are coupled in non-obvious ways" (neutral observation)
+
+**Not** good notes: routine changes, things obvious from code, activity logs.
 
 ## Staleness checks
 
@@ -42,8 +68,9 @@ Cross-reference with git log — if a note mentions an issue number, check if th
 
 ## Rules
 
-- Never remove notes without user approval
+- Never remove or add notes without user approval
 - Preserve the file header comments
 - Keep notes that capture general lessons even if the specific code changed
 - When in doubt, keep the note — false negatives (missing a useful note) are worse than false positives (keeping a stale one)
+- Sentiment is DISCRETE: only -1, -0.5, 0, 0.5, 1
 - After grooming, suggest running `cqs index` to update the search index

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,19 +2,14 @@
 
 ## Right Now
 
-**Post-Phase 7 features merged** (2026-02-07). PR #280 squash-merged to main.
+**Idle** (2026-02-06). All planned work complete and merged.
 
-All 8 post-roadmap features shipped:
-- Batch A: `--chunk-type` filter + `cqs dead`
-- Batch B: Staleness warnings + `cqs gc`
-- Batch C: `--format mermaid` on trace + `cqs project` cross-project search
-- Batch D: `cqs gather` (smart context assembly) + `--pattern` structural filter
-
-**In progress**: docs review (agent running), then version bump to 0.9.0, changelog, release
-
-### Refactoring roadmapped
-- Split `parser.rs` (1071 lines) → per-language modules under `src/language/`
-- Split `hnsw.rs` (1150 lines) → `src/hnsw/` directory (build, persist, search)
+### What shipped this session
+- v0.9.0 released (from previous context, already on crates.io + GitHub)
+- PR #282: parser.rs → src/parser/ directory (mod.rs, types.rs, chunk.rs, calls.rs)
+- PR #283: hnsw.rs → src/hnsw/ directory (mod.rs, build.rs, search.rs, persist.rs, safety.rs) + flaky test fix
+- PR #284: Token savings messaging — README, Cargo.toml, GitHub description/topics
+- Roadmap refactoring items checked off, flaky test bug resolved
 
 ### Dev environment
 - `~/.bashrc`: `LD_LIBRARY_PATH` for ort CUDA libs
@@ -24,7 +19,8 @@ All 8 post-roadmap features shipped:
 
 - **Phase 8**: Security (index encryption, rate limiting)
 - **ref install** — deferred from Phase 6, tracked in #255
-- **Relevance feedback** — Feature 9, deferred indefinitely (low impact)
+- **Relevance feedback** — deferred indefinitely (low impact)
+- **`.cq` rename to `.cqs`** — breaking change needing migration, no issue filed yet
 
 ## Open Issues
 
@@ -57,11 +53,12 @@ All 8 post-roadmap features shipped:
 
 ## Architecture
 
-- Version: 0.8.0
+- Version: 0.9.0
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, score-based merge with weight
 - 7 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java)
 - 258 lib tests (no GPU), 0 warnings, clippy clean
-- MCP tools: 21 (search, stats, callers, callees, read, add_note, update_note, remove_note, dead, audit_mode, diff, explain, similar, impact, trace, test_map, batch, context, gc, gather + pattern on search)
+- MCP tools: 21
+- Source layout: parser/ and hnsw/ are now directories (split from monoliths in v0.9.0)

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -50,14 +50,14 @@ sentiment = 0.0
 text = "store.search() and hnsw.search() both match callee name 'search'. No type info in call graph - can't distinguish which is called. Documented limitation."
 mentions = [
     "src/store/mod.rs",
-    "src/parser.rs",
+    "src/parser/calls.rs",
 ]
 
 [[note]]
 sentiment = 0.0
 text = "hnsw_rs uses bincode 1.3.3 (unmaintained, RUSTSEC-2025-0141). Mitigated with blake3 checksums on save/load. verify_hnsw_checksums validates extension allowlist to prevent path traversal."
 mentions = [
-    "hnsw.rs",
+    "src/hnsw/persist.rs",
     "hnsw_rs",
     "bincode",
     "blake3",
@@ -69,7 +69,7 @@ text = "769th embedding dimension can encode explicit sentiment. Similarity sear
 mentions = [
     "src/embedder.rs",
     "src/store/mod.rs",
-    "src/hnsw.rs",
+    "src/hnsw/mod.rs",
 ]
 
 [[note]]
@@ -84,7 +84,7 @@ mentions = [
 sentiment = 1.0
 text = "cuVS CAGRA: 8-12x faster index builds, 4-8x faster search vs CPU HNSW. Rust bindings exist (cuvs crate). Feature-flagged as gpu-search for CUDA-equipped infrastructure."
 mentions = [
-    "hnsw.rs",
+    "src/hnsw/mod.rs",
     "Cargo.toml",
 ]
 
@@ -274,7 +274,7 @@ mentions = [
 sentiment = 0.5
 text = "Path traversal via checksum file: verify_hnsw_checksums read extensions from file, could be '../../../etc/passwd'. Fixed with HNSW_EXTENSIONS allowlist. Low severity (local read-only) but still worth hardening."
 mentions = [
-    "hnsw.rs",
+    "src/hnsw/persist.rs",
     "security",
     "path traversal",
 ]
@@ -284,7 +284,7 @@ sentiment = 1.0
 text = "Streaming HNSW build for large repos: Store::embedding_batches() yields chunks in 10k batches via LIMIT/OFFSET, HnswIndex::build_batched() inserts incrementally. Memory drops from O(n) to O(batch_size). Fixes #107 OOM on huge repos."
 mentions = [
     "src/store/chunks.rs",
-    "src/hnsw.rs",
+    "src/hnsw/build.rs",
     "embedding_batches",
     "build_batched",
 ]
@@ -423,16 +423,6 @@ mentions = [
 
 [[note]]
 sentiment = -0.5
-text = "parse_target (file:name resolution) is duplicated in 4 places: cli/commands/similar.rs, cli/commands/explain.rs, mcp/tools/similar.rs, mcp/tools/explain.rs. Should extract to shared utility if adding more commands that resolve targets."
-mentions = [
-    "src/cli/commands/similar.rs",
-    "src/cli/commands/explain.rs",
-    "src/mcp/tools/similar.rs",
-    "src/mcp/tools/explain.rs",
-]
-
-[[note]]
-sentiment = -0.5
 text = "cqs diff loads embeddings one-by-one for each matched pair via get_chunk_with_embedding. For large diffs (1000+ matched functions), this will be slow. Batch loading would help but adds complexity — defer until someone hits the perf wall."
 mentions = [
     "src/diff.rs",
@@ -458,11 +448,35 @@ mentions = [
 ]
 
 [[note]]
-sentiment = -0.5
-text = "test_loaded_index_multiple_searches is flaky in CI. HNSW approximate search with 10 random embeddings doesn't reliably find exact match in top-5. Pre-existing, not related to any feature changes. Rerun CI when it fails."
-mentions = ["src/hnsw.rs", "CI", "flaky test"]
-
-[[note]]
 sentiment = 1.0
 text = "Post-v0.8.0 features shipped across 3 context windows with zero regressions. Tears + MEMORY.md system worked — each window picked up exactly where the last left off. Key: commit per batch, update tears after each commit, keep MEMORY.md under 200 lines."
-mentions = ["PROJECT_CONTINUITY.md", "MEMORY.md", "tears", "workflow"]
+mentions = [
+    "PROJECT_CONTINUITY.md",
+    "MEMORY.md",
+    "tears",
+    "workflow",
+]
+
+[[note]]
+sentiment = -0.5
+text = "Splitting monolithic .rs files into directories: trait method imports (e.g. `use hnsw_rs::api::AnnT`) don't carry across submodule files — each file needs its own import. Caught as build error after initial split."
+mentions = [
+    "src/hnsw/search.rs",
+    "src/hnsw/build.rs",
+    "src/hnsw/persist.rs",
+]
+
+[[note]]
+sentiment = 0.5
+text = "One-hot embeddings for HNSW test stability: sin-based make_embedding(seed) produced vectors too similar in 769-dim cosine space — HNSW approximate search couldn't reliably rank the exact match. Fix: one-hot-like vectors (0.01 baseline + 1.0 spike at seed-specific dimension). Cosine similarity ~0.01 between seeds, 1.0 for same seed. Reusable pattern for any HNSW test needing well-separated embeddings."
+mentions = ["src/hnsw/safety.rs", "src/hnsw/build.rs", "make_embedding", "flaky test"]
+
+[[note]]
+sentiment = 0.5
+text = "Rust impl blocks split across module files: when splitting monolithic .rs into a directory module, impl Foo blocks can live in separate files (chunk.rs, calls.rs each have `impl Parser { ... }`). No trait needed, no delegation. Public API unchanged. Key enabler for the parser/ and hnsw/ refactors."
+mentions = ["src/parser/chunk.rs", "src/parser/calls.rs", "src/hnsw/build.rs", "src/hnsw/search.rs", "src/hnsw/persist.rs"]
+
+[[note]]
+sentiment = 0.5
+text = "Token efficiency tools: cqs_trace, cqs_impact, cqs_gather collapse 5-10 file reads into one MCP call by combining search + call graph traversal server-side. The savings compound: fewer tool calls = fewer round-trips = less context burn. This is the core value prop for AI agent consumers."
+mentions = ["src/mcp/tools/mod.rs", "src/trace.rs", "src/impact.rs", "src/gather.rs"]


### PR DESCRIPTION
## Summary
- Pruned 2 superseded notes (flaky test fixed, parse_target dedup resolved)
- Updated 6 stale file mentions (parser.rs → parser/, hnsw.rs → hnsw/)
- Added 3 new notes: one-hot test embeddings, impl blocks across files, token efficiency tools
- Enhanced groom-notes skill with Phase 2 (suggest new notes from git history)
- Updated PROJECT_CONTINUITY.md for v0.9.0 idle state

## Test plan
- [x] Notes indexed via `cqs_add_note` (immediate indexing)
- [x] No code changes — docs/skill only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
