### PR TITLE
chore: Release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-02-06
+
+### Changed
+- **Refactor**: Split `parser.rs` (1072 lines) into `src/parser/` directory — mod.rs, types.rs, chunk.rs, calls.rs
+- **Refactor**: Split `hnsw.rs` (1150 lines) into `src/hnsw/` directory — mod.rs, build.rs, search.rs, persist.rs, safety.rs
+- Updated public-facing messaging to lead with token savings for AI agents
+- Enhanced `groom-notes` skill with Phase 2 (suggest new notes from git history)
+- Updated CONTRIBUTING.md architecture tree for new directory layout
+
+### Fixed
+- Flaky `test_loaded_index_multiple_searches` — replaced sin-based test embeddings with well-separated one-hot vectors
+
 ## [0.9.0] - 2026-02-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.88"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML, MCP server."


### PR DESCRIPTION
## Summary
Release v0.9.1 — housekeeping release.

- **Refactor**: parser.rs → src/parser/ directory (4 modules)
- **Refactor**: hnsw.rs → src/hnsw/ directory (5 modules)
- **Fix**: Flaky `test_loaded_index_multiple_searches` with well-separated one-hot embeddings
- **Docs**: Token savings messaging, CONTRIBUTING.md architecture tree, notes grooming

No new features or API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
