### PR TITLE
chore: Promote cqs_read as default, roadmap agent UX

### DIFF
--- a/.claude/skills/cqs-bootstrap/SKILL.md
+++ b/.claude/skills/cqs-bootstrap/SKILL.md
@@ -175,7 +175,9 @@ Use it for:
 
 Fall back to Grep/Glob only for exact string matches or when semantic search returns nothing.
 
-Tools: `cqs_search`, `cqs_stats`, `cqs_similar`, `cqs_explain`, `cqs_diff`, `cqs_trace`, `cqs_impact`, `cqs_test_map`, `cqs_batch`, `cqs_context`, `cqs_gather`, `cqs_dead`, `cqs_gc` (run `cqs watch` to keep index fresh)
+**`cqs_read`** — use instead of raw `Read` tool. Returns file contents with relevant notes injected as comments. Default to this for any source file.
+
+Tools: `cqs_search`, `cqs_stats`, `cqs_read`, `cqs_similar`, `cqs_explain`, `cqs_diff`, `cqs_trace`, `cqs_impact`, `cqs_test_map`, `cqs_batch`, `cqs_context`, `cqs_gather`, `cqs_dead`, `cqs_gc` (run `cqs watch` to keep index fresh)
 
 ## Audit Mode
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Fall back to Grep/Glob only for exact string matches or when semantic search ret
 
 Tools: `cqs_search`, `cqs_stats`, `cqs_callers`, `cqs_callees`, `cqs_read`, `cqs_similar`, `cqs_explain`, `cqs_diff`, `cqs_trace`, `cqs_impact`, `cqs_test_map`, `cqs_batch`, `cqs_context`, `cqs_gather`, `cqs_dead`, `cqs_gc`, `cqs_add_note`, `cqs_update_note`, `cqs_remove_note`, `cqs_audit_mode` (21 tools — run `cqs watch` to keep index fresh)
 
+**`cqs_read`** — **use instead of raw `Read` tool.** Returns file contents with relevant notes injected as comments. Same content, richer context. Default to this for any source file in an indexed project.
 **`cqs_similar`** — find code similar to a given function. Use for refactoring discovery, finding duplicates.
 **`cqs_explain`** — function card: signature, callers, callees, similar. Collapses 4+ tool calls into 1.
 **`cqs_diff`** — semantic diff between indexed snapshots. Requires references (`cqs ref add`).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -337,6 +337,15 @@
 - Each language needs: Language enum variant, extension mapping, grammar loading, query patterns, display impl (~5 changes per #268)
 - After: 9 languages total
 
+## Agent Experience Improvements
+
+### Planned
+
+- [ ] **Token cost estimates** — include approximate token count in tool responses so agents can budget context window usage
+- [ ] **Proactive hints in cqs_read/cqs_explain** — auto-surface "0 callers" (dead code) and "no tests" flags without requiring separate tool calls
+- [ ] **Refactor assistant** — "move function X from A to B" → checklist of import changes, visibility fixes, re-exports needed
+- [ ] **Batch UX** — common batch patterns (e.g., "callers for these N functions") as named shortcuts instead of raw JSON construction
+
 ## Phase 8: Security
 
 ### Done


### PR DESCRIPTION
## Summary
- Promote `cqs_read` as default over raw `Read` in CLAUDE.md and bootstrap template
- Add "Agent Experience Improvements" section to roadmap: token cost estimates, proactive hints, refactor assistant, batch UX

## Test plan
- [x] Docs-only change, no code modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)
