### PR TITLE
chore: Release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-02-07
+
+### Fixed
+- **96 audit fixes** across P1 (43), P2 (23), P3 (30) from 14-category code audit
+- **Config safety**: `add_reference_to_config` no longer destroys config on I/O errors
+- **Watch mode**: call graph now updates during incremental reindex
+- **Gather**: results sorted by score before truncation (was file order)
+- **Diff**: language filter uses stored language field instead of file extension matching
+- **Search robustness**: limit=0 early return, NaN score defense in BoundedScoreHeap, max_tokens=0 guard
+- **Migration safety**: schema migrations wrapped in single transaction
+- **Watch paths**: `dunce::canonicalize` for Windows UNC path handling
+- **Config validation**: reference weights clamped to [0.0, 1.0], reference count limited to 20
+- **Error propagation**: unwrap → Result throughout CLI and MCP tools
+- **N+1 queries**: batched embedding lookups in diff and pipeline
+- **Code consolidation**: DRY refactors in explain.rs, search.rs, notes.rs
+
+### Added
+- Tracing spans on `search_unified` and `search_by_candidates` for performance visibility
+- MCP observability: tool entry/exit logging, client info on connect, pipeline stats
+- Docstrings for `cosine_similarity` variants and `tool_stats` response fields
+- Integration tests: dead code, semantic diff, gather BFS, call graph, reference search, MCP format
+- `ChunkIdentity.language` field for language-aware operations
+- MCP tool count corrected: 20 (was documented as 21)
+
+### Changed
+- `run_migration` accepts `&mut SqliteConnection` instead of `&SqlitePool` for transaction safety
+- Context dedup uses typed struct instead of JSON string comparison
+
 ## [0.9.1] - 2026-02-06
 
 ### Changed
@@ -621,6 +649,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI commands: init, doctor, index, stats, serve
 - Filter by language (`-l`) and path pattern (`-p`)
 
+[0.9.2]: https://github.com/jamie8johnson/cqs/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/jamie8johnson/cqs/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/jamie8johnson/cqs/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/jamie8johnson/cqs/compare/v0.7.0...v0.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 rust-version = "1.88"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML, MCP server."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,23 +2,15 @@
 
 ## Right Now
 
-**v0.9.1 Audit complete** (2026-02-07). Full 14-category audit done, triage written.
+**v0.9.1 Audit — P1/P2/P3 complete** (2026-02-07). 96 fixes merged across 3 PRs.
 
 ### Audit status
 - 157 raw findings → ~138 unique after dedup
-- P1: 47 findings (easy + high impact) — **fix next**
-- P2: 37 findings (medium effort or moderate impact)
-- P3: 37 findings (test coverage, observability, polish)
-- P4: 17 findings (defer/existing issues)
+- P1: 43 fixes merged (PR #293)
+- P2: 23 fixes merged (PR #295)
+- P3: 30 fixes merged (PR #296) — 6 non-issues, 1 deferred (#19 param naming)
+- P4: 17 findings deferred
 - Files: `docs/audit-findings.md`, `docs/audit-triage.md` (v0.9.1 section appended)
-- Previous findings archived to `docs/audit-findings-v0.5.3.md`
-
-### Top P1 items to fix first
-1. `config.rs:184` unwrap_or_default destroys config on I/O error
-2. Watch mode never updates call graph
-3. `gather.rs` truncates by file order not score
-4. `parse_duration` integer overflow bypasses 24h cap
-5. 7 dead code methods to remove
 
 ### Post-audit roadmap items
 - Add `format: "mermaid"` output to `cqs_impact`, `cqs_context`, `cqs_dead` — added to ROADMAP.md
@@ -72,6 +64,6 @@
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, score-based merge with weight
 - 7 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java)
-- 262 lib tests (no GPU), 0 warnings, clippy clean
+- 261 lib + 176 integration tests (no GPU), 0 warnings, clippy clean
 - MCP tools: 20
 - Source layout: parser/ and hnsw/ are now directories (split from monoliths in v0.9.0)

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -469,34 +469,38 @@ mentions = [
 [[note]]
 sentiment = 0.5
 text = "One-hot embeddings for HNSW test stability: sin-based make_embedding(seed) produced vectors too similar in 769-dim cosine space — HNSW approximate search couldn't reliably rank the exact match. Fix: one-hot-like vectors (0.01 baseline + 1.0 spike at seed-specific dimension). Cosine similarity ~0.01 between seeds, 1.0 for same seed. Reusable pattern for any HNSW test needing well-separated embeddings."
-mentions = ["src/hnsw/safety.rs", "src/hnsw/build.rs", "make_embedding", "flaky test"]
+mentions = [
+    "src/hnsw/safety.rs",
+    "src/hnsw/build.rs",
+    "make_embedding",
+    "flaky test",
+]
 
 [[note]]
 sentiment = 0.5
 text = "Rust impl blocks split across module files: when splitting monolithic .rs into a directory module, impl Foo blocks can live in separate files (chunk.rs, calls.rs each have `impl Parser { ... }`). No trait needed, no delegation. Public API unchanged. Key enabler for the parser/ and hnsw/ refactors."
-mentions = ["src/parser/chunk.rs", "src/parser/calls.rs", "src/hnsw/build.rs", "src/hnsw/search.rs", "src/hnsw/persist.rs"]
+mentions = [
+    "src/parser/chunk.rs",
+    "src/parser/calls.rs",
+    "src/hnsw/build.rs",
+    "src/hnsw/search.rs",
+    "src/hnsw/persist.rs",
+]
 
 [[note]]
 sentiment = 0.5
 text = "Token efficiency tools: cqs_trace, cqs_impact, cqs_gather collapse 5-10 file reads into one MCP call by combining search + call graph traversal server-side. The savings compound: fewer tool calls = fewer round-trips = less context burn. This is the core value prop for AI agent consumers."
-mentions = ["src/mcp/tools/mod.rs", "src/trace.rs", "src/impact.rs", "src/gather.rs"]
-
-[[note]]
-sentiment = -1.0
-text = "v0.9.1 audit: watch mode never updates call graph (function_calls table). All cqs_callers/callees/trace/impact/dead/test_map return stale data for files modified via watch. Must add upsert_function_calls call to reindex_files."
-mentions = ["src/cli/watch.rs", "reindex_files", "upsert_function_calls"]
-
-[[note]]
-sentiment = -1.0
-text = 'v0.9.1 audit: config.rs:184 unwrap_or_default on read_to_string treats ALL errors as "file missing" — permission errors or I/O errors silently destroy config on next write. Fix: match on error kind like remove_reference_from_config does.'
-mentions = ["src/config.rs", "add_reference_to_config"]
-
-[[note]]
-sentiment = -1.0
-text = "v0.9.1 audit: gather.rs sorts by file order THEN truncates to limit — discards highest-scored chunks in favor of alphabetically-first files. Fix: sort by score desc, truncate, then re-sort by file+line for display."
-mentions = ["src/gather.rs", "gather"]
+mentions = [
+    "src/mcp/tools/mod.rs",
+    "src/trace.rs",
+    "src/impact.rs",
+    "src/gather.rs",
+]
 
 [[note]]
 sentiment = -0.5
 text = "v0.9.1 audit found actual MCP tool count is 20, not 21. Multiple docs (CLAUDE.md, ROADMAP, CHANGELOG, PROJECT_CONTINUITY) say 21. Verify by counting tool definitions in src/mcp/tools/mod.rs."
-mentions = ["src/mcp/tools/mod.rs", "CLAUDE.md"]
+mentions = [
+    "src/mcp/tools/mod.rs",
+    "CLAUDE.md",
+]


### PR DESCRIPTION
## Summary

Release v0.9.2 — 96 audit fixes from the v0.9.1 14-category code audit.

- Version bump: 0.9.1 → 0.9.2
- CHANGELOG: new section with categorized fixes (Fixed, Added, Changed)
- Tears: updated PROJECT_CONTINUITY.md and notes.toml for P3 completion
- Docs reviewed: all current, no fixes needed

### Audit fix breakdown
- **P1** (43 fixes, PR #293): config safety, watch call graph, gather sort, dead code removal
- **P2** (23 fixes, PR #295): error propagation, N+1 queries, code consolidation
- **P3** (30 fixes, PR #296): search robustness, observability, integration tests
- **P4** (17 findings): deferred

## Test plan

- [x] `cargo test` — 261 lib + 176 integration, 0 failures
- [x] `cargo clippy` — clean
- [x] Docs review — all files current
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
