### PR TITLE
feat: Language extensibility via define_languages\! macro

### DIFF
--- a/src/cli/commands/query.rs
+++ b/src/cli/commands/query.rs
@@ -29,9 +29,10 @@ pub(crate) fn cmd_query(cli: &Cli, query: &str) -> Result<()> {
     let query_embedding = embedder.embed_query(query)?;
 
     let languages = match &cli.lang {
-        Some(l) => Some(vec![l.parse().context(
-            "Invalid language. Valid: rust, python, typescript, javascript, go, c, java",
-        )?]),
+        Some(l) => Some(vec![l.parse().context(format!(
+            "Invalid language. Valid: {}",
+            cqs::parser::Language::valid_names_display()
+        ))?]),
         None => None,
     };
 

--- a/src/cli/commands/similar.rs
+++ b/src/cli/commands/similar.rs
@@ -67,9 +67,10 @@ pub(crate) fn cmd_similar(
 
     // Build search filter (code only, no notes)
     let languages = match &cli.lang {
-        Some(l) => Some(vec![l.parse().context(
-            "Invalid language. Valid: rust, python, typescript, javascript, go, c, java",
-        )?]),
+        Some(l) => Some(vec![l.parse().context(format!(
+            "Invalid language. Valid: {}",
+            cqs::parser::Language::valid_names_display()
+        ))?]),
         None => None,
     };
 

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -738,12 +738,9 @@ mod tests {
 
     #[test]
     fn test_windowing_constants() {
-        // Verify constants are sensible
-        assert!(MAX_TOKENS_PER_WINDOW <= 512, "Should be under E5 limit");
-        assert!(
-            WINDOW_OVERLAP_TOKENS < MAX_TOKENS_PER_WINDOW,
-            "Overlap must be less than window"
-        );
-        assert!(WINDOW_OVERLAP_TOKENS > 0, "Overlap should be positive");
+        // Verify constants are sensible (const blocks for compile-time checks)
+        const { assert!(MAX_TOKENS_PER_WINDOW <= 512) };
+        const { assert!(WINDOW_OVERLAP_TOKENS < MAX_TOKENS_PER_WINDOW) };
+        const { assert!(WINDOW_OVERLAP_TOKENS > 0) };
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -589,7 +589,7 @@ weight = 0.7
         .unwrap();
 
         // Load config (should clamp weights)
-        let config = Config::load(&dir.path());
+        let config = Config::load(dir.path());
 
         // Find the references
         let over_ref = config.references.iter().find(|r| r.name == "over").unwrap();

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -1000,7 +1000,7 @@ mod tests {
             fn prop_sentiment_clamped(sentiment in -10.0f32..10.0f32) {
                 let emb = Embedding::new(vec![0.5; MODEL_DIM]).with_sentiment(sentiment);
                 if let Some(s) = emb.sentiment() {
-                    prop_assert!(s >= -1.0 && s <= 1.0, "Sentiment {} out of range", s);
+                    prop_assert!((-1.0..=1.0).contains(&s), "Sentiment {} out of range", s);
                 }
             }
 
@@ -1037,7 +1037,7 @@ mod tests {
                 .expect("token_count failed");
             // E5-base-v2 tokenizer: "hello" and "world" are single tokens
             assert!(
-                count >= 2 && count <= 4,
+                (2..=4).contains(&count),
                 "Expected 2-4 tokens, got {}",
                 count
             );

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -45,6 +45,19 @@ const TYPE_MAP: &[(&str, ChunkType)] = &[
 /// Doc comment node types
 const DOC_NODES: &[&str] = &["comment"];
 
+const STOPWORDS: &[&str] = &[
+    "function", "const", "let", "var", "return", "if", "else", "for", "while", "do",
+    "switch", "case", "break", "continue", "new", "this", "class", "extends", "import",
+    "export", "from", "default", "try", "catch", "finally", "throw", "async", "await",
+    "true", "false", "null", "undefined", "typeof", "instanceof", "void",
+];
+
+fn extract_return(_signature: &str) -> Option<String> {
+    // JavaScript doesn't have type annotations in signatures.
+    // JSDoc parsing is handled separately in NL generation.
+    None
+}
+
 static DEFINITION: LanguageDef = LanguageDef {
     name: "javascript",
     grammar: || tree_sitter_javascript::LANGUAGE.into(),
@@ -56,6 +69,8 @@ static DEFINITION: LanguageDef = LanguageDef {
     doc_nodes: DOC_NODES,
     method_node_kinds: &[],
     method_containers: &["class_body", "class_declaration"],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -30,6 +30,25 @@ const TYPE_MAP: &[(&str, ChunkType)] = &[
 /// Doc comment node types (sibling comments and standalone strings before a definition)
 const DOC_NODES: &[&str] = &["string", "comment"];
 
+const STOPWORDS: &[&str] = &[
+    "def", "class", "self", "return", "if", "elif", "else", "for", "while", "import",
+    "from", "as", "with", "try", "except", "finally", "raise", "pass", "break", "continue",
+    "and", "or", "not", "in", "is", "true", "false", "none", "lambda", "yield", "global",
+    "nonlocal",
+];
+
+fn extract_return(signature: &str) -> Option<String> {
+    if let Some(arrow) = signature.rfind("->") {
+        let ret = signature[arrow + 2..].trim().trim_end_matches(':');
+        if ret.is_empty() {
+            return None;
+        }
+        let ret_words = crate::nl::tokenize_identifier(ret).join(" ");
+        return Some(format!("Returns {}", ret_words));
+    }
+    None
+}
+
 static DEFINITION: LanguageDef = LanguageDef {
     name: "python",
     grammar: || tree_sitter_python::LANGUAGE.into(),
@@ -41,6 +60,8 @@ static DEFINITION: LanguageDef = LanguageDef {
     doc_nodes: DOC_NODES,
     method_node_kinds: &[],
     method_containers: &["class_definition"],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -52,6 +52,25 @@ const TYPE_MAP: &[(&str, ChunkType)] = &[
 /// Doc comment node types
 const DOC_NODES: &[&str] = &["line_comment", "block_comment"];
 
+const STOPWORDS: &[&str] = &[
+    "fn", "let", "mut", "pub", "use", "impl", "mod", "struct", "enum", "trait", "type",
+    "where", "const", "static", "unsafe", "async", "await", "move", "ref", "self", "super",
+    "crate", "return", "if", "else", "for", "while", "loop", "match", "break", "continue",
+    "as", "in", "true", "false", "some", "none", "ok", "err",
+];
+
+fn extract_return(signature: &str) -> Option<String> {
+    if let Some(arrow) = signature.find("->") {
+        let ret = signature[arrow + 2..].trim();
+        if ret.is_empty() {
+            return None;
+        }
+        let ret_words = crate::nl::tokenize_identifier(ret).join(" ");
+        return Some(format!("Returns {}", ret_words));
+    }
+    None
+}
+
 static DEFINITION: LanguageDef = LanguageDef {
     name: "rust",
     grammar: || tree_sitter_rust::LANGUAGE.into(),
@@ -63,6 +82,8 @@ static DEFINITION: LanguageDef = LanguageDef {
     doc_nodes: DOC_NODES,
     method_node_kinds: &[],
     method_containers: &["impl_item", "trait_item"],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -21,8 +21,6 @@ pub use types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
 
 #[cfg(test)]
 mod tests {
-    use super::types::JsonRpcRequest;
-
     mod fuzz {
         use super::super::types::JsonRpcRequest;
         use proptest::prelude::*;

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -28,15 +28,12 @@ use super::server::McpServer;
 use super::types::{Tool, ToolsListResult};
 
 fn language_enum_schema() -> serde_json::Value {
-    serde_json::json!([
-        "rust",
-        "python",
-        "typescript",
-        "javascript",
-        "go",
-        "c",
-        "java"
-    ])
+    serde_json::Value::Array(
+        crate::language::Language::valid_names()
+            .iter()
+            .map(|n| serde_json::Value::String((*n).to_string()))
+            .collect(),
+    )
 }
 
 /// Handle tools/list request - return available tools
@@ -539,4 +536,23 @@ pub fn handle_tools_call(server: &McpServer, params: Option<Value>) -> Result<Va
         "MCP tool call completed"
     );
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_language_enum_schema_matches_variants() {
+        let schema = language_enum_schema();
+        let schema_array = schema.as_array().expect("schema should be an array");
+        let variant_count = crate::language::Language::all_variants().len();
+        assert_eq!(
+            schema_array.len(),
+            variant_count,
+            "language_enum_schema() has {} entries but all_variants() has {}",
+            schema_array.len(),
+            variant_count
+        );
+    }
 }

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -50,9 +50,13 @@ pub fn tool_search(server: &McpServer, arguments: Value) -> Result<Value> {
         languages: args
             .language
             .map(|l| {
-                l.parse::<Language>()
-                    .map(|lang| vec![lang])
-                    .map_err(|_| anyhow::anyhow!("Unknown language '{}'. Supported: rust, python, typescript, javascript, go, c, java", l))
+                l.parse::<Language>().map(|lang| vec![lang]).map_err(|_| {
+                    anyhow::anyhow!(
+                        "Unknown language '{}'. Supported: {}",
+                        l,
+                        Language::valid_names_display()
+                    )
+                })
             })
             .transpose()?,
         chunk_types,

--- a/src/mcp/tools/similar.rs
+++ b/src/mcp/tools/similar.rs
@@ -34,7 +34,13 @@ pub fn tool_similar(server: &McpServer, arguments: Value) -> Result<Value> {
         .map(|l| {
             l.parse::<crate::parser::Language>()
                 .map(|lang| vec![lang])
-                .map_err(|_| anyhow::anyhow!("Unknown language '{}'. Supported: rust, python, typescript, javascript, go, c, java", l))
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "Unknown language '{}'. Supported: {}",
+                        l,
+                        crate::parser::Language::valid_names_display()
+                    )
+                })
         })
         .transpose()?;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -61,6 +61,7 @@ impl std::ops::Deref for TestStore {
 }
 
 /// Create a test chunk with sensible defaults
+#[allow(dead_code)]
 pub fn test_chunk(name: &str, content: &str) -> Chunk {
     let hash = blake3::hash(content.as_bytes()).to_hex().to_string();
     Chunk {

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -744,7 +744,7 @@ fn test_get_call_graph() {
         "func_b should call 1 function"
     );
     assert!(
-        graph.forward.get("func_c").is_none(),
+        !graph.forward.contains_key("func_c"),
         "func_c should call nothing"
     );
 
@@ -760,7 +760,7 @@ fn test_get_call_graph() {
         "func_b should be called by 1 function"
     );
     assert!(
-        graph.reverse.get("func_a").is_none(),
+        !graph.reverse.contains_key("func_a"),
         "func_a should not be called by anyone"
     );
 }
@@ -769,8 +769,6 @@ fn test_get_call_graph() {
 
 #[test]
 fn test_all_chunk_identities() {
-    use cqs::parser::Language;
-
     let store = TestStore::new();
 
     // Insert chunks with various properties

--- a/tests/stress_test.rs
+++ b/tests/stress_test.rs
@@ -114,7 +114,7 @@ fn test_search_threshold_performance() {
     for i in 0..1000 {
         let chunk = test_chunk(&format!("func_{}", i), &format!("fn func_{}() {{}}", i));
         // Use golden ratio for better distribution
-        let seed = (i as f32 * 0.618033988749895) % 1.0;
+        let seed = (i as f32 * 0.618_034) % 1.0;
         let embedding = mock_embedding(seed);
         ts.upsert_chunk(&chunk, &embedding, Some(12345))
             .expect("Failed to upsert");


### PR DESCRIPTION
## Summary

Closes #268. Adding a new language now requires **1 new file + 1 line in mod.rs + Cargo.toml features**, down from ~14 changes across 8 files.

- `define_languages!` macro generates `Language` enum, `Display`, `FromStr`, `all_variants()`, `valid_names()`, `valid_names_display()`, and `LanguageRegistry::new()` from a single declaration table
- `LanguageDef` extended with `stopwords` and `extract_return_nl` function pointer fields, marked `#[non_exhaustive]`
- `nl.rs` exhaustive match arms for return extraction (155 lines) and stopwords (120 lines) replaced with single-line LanguageDef delegation
- All 6 hardcoded language name strings replaced with `valid_names()` / `valid_names_display()`
- 6 new tests + fuzz test updated to use `all_variants()` for automatic new-language coverage
- Bonus: fixed all 15 pre-existing clippy warnings (zero warnings now)

## Test plan

- [x] `cargo build` — zero errors
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test --lib` — 267 passed (6 new)
- [x] `cargo test --test '*'` — 28 integration tests passed
- [x] Smoke test: `cqs "language registration"` returns results
- [x] Fresh-eyes review: all 7 `extract_return` implementations verified against original nl.rs match arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
