### PR TITLE
feat: Add SQL language support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ src/
     watch.rs    - File watcher for incremental reindexing
   language/     - Tree-sitter language support
     mod.rs      - Language enum, LanguageRegistry, LanguageDef, ChunkType
-    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, java.rs
+    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, java.rs, sql.rs
   source/       - Source abstraction layer
     mod.rs      - Source trait
     filesystem.rs - File-based source implementation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,7 @@ dependencies = [
  "tree-sitter-javascript",
  "tree-sitter-python",
  "tree-sitter-rust",
+ "tree-sitter-sequel",
  "tree-sitter-typescript",
  "zeroize",
 ]
@@ -3734,6 +3735,15 @@ name = "tree-sitter-rust"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b9b18034c684a2420722be8b2a91c9c44f2546b631c039edf575ccba8c61be1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-sequel"
+version = "0.3.11"
+source = "git+https://github.com/jamie8johnson/tree-sitter-sql?branch=main#7f967d4ace4823e7dfe94eb009a7cb5aae675438"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tree-sitter-javascript = { version = "0.25", optional = true }
 tree-sitter-go = { version = "0.25", optional = true }
 tree-sitter-c = { version = "0.24", optional = true }
 tree-sitter-java = { version = "0.23", optional = true }
+tree-sitter-sql = { git = "https://github.com/jamie8johnson/tree-sitter-sql", branch = "main", package = "tree-sitter-sequel", optional = true }
 
 # ML
 ort = { version = "2.0.0-rc.11", features = ["cuda", "tensorrt"] }
@@ -103,7 +104,7 @@ once_cell = "1"
 libc = "0.2"
 
 [features]
-default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-java"]
+default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-java", "lang-sql"]
 
 # Language support (opt-in, all enabled by default)
 lang-rust = ["dep:tree-sitter-rust"]
@@ -113,7 +114,8 @@ lang-javascript = ["dep:tree-sitter-javascript"]
 lang-go = ["dep:tree-sitter-go"]
 lang-c = ["dep:tree-sitter-c"]
 lang-java = ["dep:tree-sitter-java"]
-lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-java"]
+lang-sql = ["dep:tree-sitter-sql"]
+lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-java", "lang-sql"]
 
 # Other features
 # encrypt feature removed - sqlx doesn't support SQLCipher directly

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -326,16 +326,17 @@
 
 ### Priority: High (needed for VS2005 project)
 
-- [ ] **SQL** — `tree-sitter-sql` crate on crates.io. Stored procedures, functions, views, triggers.
+- [x] **SQL** — forked tree-sitter-sql with CREATE PROCEDURE, GO batch separator, EXEC statement support. Stored procedures, functions, views extracted. 8 languages total.
 - [ ] **VB.NET** — `tree-sitter-vb-dotnet` (git dep, not on crates.io). Subs, Functions, Classes, Modules.
 - [x] P3 audit fixes (#264-266) — completed in PR #296
+- [x] Audit cleanup batch (PR #308): #265 error propagation, #264 config errors, #241 config validation, #267 module boundaries, #239 test coverage, #232 CAGRA RAII guard
 
 ### Notes
 
 - SQL: stored procs and functions are the main chunk types. Views/triggers optional.
 - VB.NET: grammar from [CodeAnt-AI/tree-sitter-vb-dotnet](https://github.com/CodeAnt-AI/tree-sitter-vb-dotnet). May need vendored C source if git dep doesn't work cleanly.
 - Each language needs: Language enum variant, extension mapping, grammar loading, query patterns, display impl (~5 changes per #268)
-- After: 9 languages total
+- After VB.NET: 9 languages total
 
 ## Agent Experience Improvements
 

--- a/src/language/sql.rs
+++ b/src/language/sql.rs
@@ -1,0 +1,79 @@
+//! SQL language definition
+
+use super::{ChunkType, LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting SQL code chunks
+const CHUNK_QUERY: &str = r#"
+(create_function
+  (object_reference) @name) @function
+
+(create_procedure
+  (object_reference) @name) @function
+
+(create_view
+  (object_reference) @name) @const
+
+(create_trigger
+  name: (identifier) @name) @function
+"#;
+
+/// Tree-sitter query for extracting calls (function invocations + EXEC)
+const CALL_QUERY: &str = r#"
+(invocation
+  (object_reference) @callee)
+
+(execute_statement
+  (object_reference) @callee)
+"#;
+
+/// Mapping from capture names to chunk types
+const TYPE_MAP: &[(&str, ChunkType)] = &[
+    ("function", ChunkType::Function),
+    ("const", ChunkType::Constant),
+];
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment", "marginalia"];
+
+const STOPWORDS: &[&str] = &[
+    "create", "procedure", "function", "view", "trigger", "begin", "end", "declare", "set",
+    "select", "from", "where", "insert", "into", "update", "delete", "exec", "execute", "as",
+    "returns", "return", "if", "else", "while", "and", "or", "not", "null", "int", "varchar",
+    "nvarchar", "decimal", "table", "on", "after", "before", "instead", "of", "for", "each",
+    "row", "order", "by", "group", "having", "join", "inner", "left", "right", "outer", "go",
+    "with", "nocount", "language", "replace",
+];
+
+fn extract_return(signature: &str) -> Option<String> {
+    // SQL functions: look for RETURNS type between name and AS
+    let upper = signature.to_uppercase();
+    if let Some(ret_pos) = upper.find("RETURNS") {
+        let after = &signature[ret_pos + 7..].trim();
+        // Take the first word as the return type, lowercase it
+        // SQL types are all-caps (DECIMAL, INT, VARCHAR) — just lowercase, don't tokenize
+        let type_str = after.split_whitespace().next()?;
+        // Strip precision suffix like (10,2)
+        let base_type = type_str.split('(').next().unwrap_or(type_str);
+        return Some(format!("Returns {}", base_type.to_lowercase()));
+    }
+    None
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "sql",
+    grammar: || tree_sitter_sql::LANGUAGE.into(),
+    extensions: &["sql"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilAs,
+    type_map: TYPE_MAP,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &[],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}

--- a/src/parser/chunk.rs
+++ b/src/parser/chunk.rs
@@ -92,6 +92,16 @@ pub(crate) fn extract_signature(content: &str, language: Language) -> String {
     let sig_end = match language.def().signature_style {
         SignatureStyle::UntilBrace => content.find('{').unwrap_or(content.len()),
         SignatureStyle::UntilColon => content.find(':').unwrap_or(content.len()),
+        SignatureStyle::UntilAs => {
+            // Case-insensitive search for AS as a standalone word
+            let upper = content.to_uppercase();
+            upper
+                .find(" AS ")
+                .or_else(|| upper.find("\nAS\n"))
+                .or_else(|| upper.find("\nAS "))
+                .or_else(|| upper.find(" AS\n"))
+                .unwrap_or(content.len())
+        }
     };
     let sig = &content[..sig_end];
     // Normalize whitespace

--- a/tests/eval_test.rs
+++ b/tests/eval_test.rs
@@ -289,6 +289,7 @@ fn fixture_path(lang: Language) -> PathBuf {
         Language::Go => "go",
         Language::C => "c",
         Language::Java => "java",
+        Language::Sql => "sql",
     };
     PathBuf::from(manifest_dir)
         .join("tests")

--- a/tests/fixtures/sample.sql
+++ b/tests/fixtures/sample.sql
@@ -1,0 +1,55 @@
+-- Stored procedure with params
+CREATE PROCEDURE dbo.usp_GetOrders
+    @CustomerID INT,
+    @Status VARCHAR(50)
+AS
+BEGIN
+    SELECT OrderID, OrderDate, Total
+    FROM Orders
+    WHERE CustomerID = @CustomerID AND Status = @Status
+    ORDER BY OrderDate DESC;
+END;
+GO
+
+-- Scalar function
+CREATE FUNCTION dbo.fn_CalcTotal(@OrderID INT)
+RETURNS DECIMAL(10,2)
+AS
+BEGIN
+    DECLARE @Total DECIMAL(10,2)
+    SELECT @Total = SUM(Quantity * UnitPrice)
+    FROM OrderDetails WHERE OrderID = @OrderID;
+    RETURN @Total
+END;
+GO
+
+-- View
+CREATE VIEW dbo.vw_ActiveCustomers
+AS
+SELECT CustomerID, Name, Email
+FROM Customers
+WHERE IsActive = 1;
+GO
+
+-- Trigger
+CREATE TRIGGER trg_AuditInsert
+ON Orders
+AFTER INSERT
+AS
+BEGIN
+    INSERT INTO AuditLog (TableName, Action, Timestamp)
+    SELECT 'Orders', 'INSERT', GETDATE()
+    FROM inserted;
+END;
+GO
+
+-- Procedure that calls other procs/functions
+CREATE PROCEDURE dbo.usp_ProcessOrder
+    @OrderID INT
+AS
+BEGIN
+    DECLARE @Total DECIMAL(10,2)
+    SET @Total = dbo.fn_CalcTotal(@OrderID);
+    EXEC dbo.usp_GetOrders @OrderID, 'Processed';
+END;
+GO

--- a/tests/model_eval.rs
+++ b/tests/model_eval.rs
@@ -551,6 +551,7 @@ fn fixture_path(lang: Language) -> PathBuf {
         Language::Go => "go",
         Language::C => "c",
         Language::Java => "java",
+        Language::Sql => "sql",
     };
     PathBuf::from(manifest_dir)
         .join("tests")


### PR DESCRIPTION
## Summary

Adds SQL as the 8th supported language, enabling indexing of stored procedures, functions, and views from `.sql` files.

- **Grammar fork**: [jamie8johnson/tree-sitter-sql](https://github.com/jamie8johnson/tree-sitter-sql) adds `CREATE PROCEDURE`, `GO` batch separator, and `EXEC`/`EXECUTE` statement support (474 tree-sitter tests passing)
- **New `SignatureStyle::UntilAs`**: SQL uses `AS BEGIN...END` instead of `{`, so signatures stop at the `AS` keyword
- **Schema-qualified names**: `dbo.usp_GetOrders` preserved as-is (useful where same name can exist in multiple schemas)
- **Call graph**: Captures both `SELECT dbo.fn_Foo()` (invocation) and `EXEC dbo.usp_Proc` (execute_statement) patterns
- **5 new parser tests**: fixture extraction, signature extraction, schema-qualified names, GO separator handling, call extraction

### Known limitations
- T-SQL `CREATE TRIGGER ... ON table AFTER INSERT` syntax not supported by the grammar (PostgreSQL-style triggers work)
- `type_map` field in `LanguageDef` is defined but never read by `extract_chunk` (pre-existing dead code, not introduced here)

## Test plan

- [x] `cargo test --features gpu-search` — all tests pass (286 lib + 233 integration)
- [x] `cargo clippy --features gpu-search` — zero warnings
- [x] `cargo fmt --check` — clean
- [ ] CI passes
- [ ] Smoke test: `cqs index` on a `.sql` file, `cqs search "stored procedure"`
