### PR TITLE
fix: Use crates.io dep for tree-sitter-sql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
  "tree-sitter-javascript",
  "tree-sitter-python",
  "tree-sitter-rust",
- "tree-sitter-sequel",
+ "tree-sitter-sequel-tsql",
  "tree-sitter-typescript",
  "zeroize",
 ]
@@ -3741,9 +3741,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-sequel"
-version = "0.3.11"
-source = "git+https://github.com/jamie8johnson/tree-sitter-sql?branch=main#7f967d4ace4823e7dfe94eb009a7cb5aae675438"
+name = "tree-sitter-sequel-tsql"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9139d6e55249e7705d7142bd2e1664751217d03741ab9bf57c54d6946519bee2"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tree-sitter-javascript = { version = "0.25", optional = true }
 tree-sitter-go = { version = "0.25", optional = true }
 tree-sitter-c = { version = "0.24", optional = true }
 tree-sitter-java = { version = "0.23", optional = true }
-tree-sitter-sql = { git = "https://github.com/jamie8johnson/tree-sitter-sql", branch = "main", package = "tree-sitter-sequel", optional = true }
+tree-sitter-sql = { version = "0.4", package = "tree-sitter-sequel-tsql", optional = true }
 
 # ML
 ort = { version = "2.0.0-rc.11", features = ["cuda", "tensorrt"] }


### PR DESCRIPTION
## Summary

Switch tree-sitter-sql from git dep to crates.io dep so `cargo publish` works.

- Published fork as `tree-sitter-sequel-tsql` v0.4.0 on crates.io
- Replaces `git = "..."` with `version = "0.4"`

## Test plan

- [x] `cargo test --features gpu-search --test parser_test` — all 20 tests pass with crates.io dep
