### PR TITLE
chore: Update tears for v0.9.4 release

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,25 +2,17 @@
 
 ## Right Now
 
-**SQL language support** — implementation complete, tests passing. Ready for branch + PR.
+**Clean slate.** v0.9.4 shipped with SQL language support.
 
 ### Uncommitted
-- SQL language support (Part 1: forked tree-sitter-sql, Part 2: cqs integration)
-  - `Cargo.toml`: tree-sitter-sql git dep, lang-sql feature
-  - `src/language/sql.rs`: new module (chunk query, call query, stopwords, extract_return)
-  - `src/language/mod.rs`: SignatureStyle::UntilAs, define_languages! entry for Sql
-  - `src/parser/chunk.rs`: UntilAs match arm in extract_signature
-  - `tests/fixtures/sample.sql`: SQL test fixture (5 objects, GO separators)
-  - `tests/parser_test.rs`: 5 new SQL tests
-  - `tests/eval_test.rs`, `tests/model_eval.rs`: Sql match arms
-  - CLAUDE.md, CONTRIBUTING.md, ROADMAP.md: updated for 8 languages
-- Grammar fork: `jamie8johnson/tree-sitter-sql` (CREATE PROCEDURE, GO, EXEC added)
+None.
 
 ### Recent merges
+- PR #311: Use crates.io dep for tree-sitter-sql
+- PR #310: Release v0.9.4
+- PR #309: SQL language support
 - PR #308: Audit cleanup batch (#265, #264, #241, #267, #239, #232)
 - PR #307: Language extensibility via define_languages! macro (#268)
-- PR #306: v0.9.3 release
-- PR #305: Fix gather/cross-project search to use RRF hybrid
 
 ### P4 audit items tracked in issues
 - #300: Search/algorithm edge cases (5 items)
@@ -77,3 +69,4 @@
 - 286 lib + 233 integration tests (with gpu-search), 0 warnings, clippy clean
 - MCP tools: 20 (note_only, summary, mermaid added as params in v0.9.2+)
 - Source layout: parser/ and hnsw/ are now directories (split from monoliths in v0.9.0)
+- SQL grammar: tree-sitter-sequel-tsql v0.4.0 on crates.io (forked from DerekStride/tree-sitter-sql)

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -497,16 +497,6 @@ mentions = [
 ]
 
 [[note]]
-sentiment = -0.5
-text = "gather() and search_across_projects() were using store.search() (raw embedding) instead of search_filtered() (RRF hybrid). This caused gather to miss results that cqs_search found via keyword matching. Fixed in PR #305. Rule: never call store.search() in production code — always use search_filtered or search_unified_with_index."
-mentions = [
-    "src/gather.rs",
-    "src/project.rs",
-    "store.search",
-    "search_filtered",
-]
-
-[[note]]
 sentiment = 0.5
 text = "define_languages! macro reduces language addition from 13 scattered changes to 1 macro invocation. Each language: enum variant, extension mapping, grammar loading, query patterns, display impl. Parser tests verify grammar availability at compile time. PR #307."
 mentions = [
@@ -551,4 +541,22 @@ mentions = [
     "src/parser/chunk.rs",
     "src/language/sql.rs",
     "extract_chunk",
+]
+
+[[note]]
+sentiment = -0.5
+text = "Git deps in Cargo.toml block cargo publish. For tree-sitter grammar forks, publish the fork to crates.io under a new name (e.g. tree-sitter-sequel-tsql) then use version dep. One-time effort per grammar fork."
+mentions = [
+    "Cargo.toml",
+    "tree-sitter-sql",
+    "cargo publish",
+]
+
+[[note]]
+sentiment = 0.5
+text = "Adding a new language to cqs requires: (1) tree-sitter grammar crate, (2) one-liner in define_languages! macro, (3) LanguageDef with chunk_query + call_query, (4) test fixture + parser tests, (5) match arms in eval_test.rs and model_eval.rs. The define_languages! macro (PR #307) reduced this from 13 scattered changes."
+mentions = [
+    "src/language/mod.rs",
+    "define_languages",
+    "src/language/sql.rs",
 ]


### PR DESCRIPTION
## Summary

Post-release housekeeping for v0.9.4.

- Updated PROJECT_CONTINUITY.md (clean slate, recent merges)
- Groomed notes: removed duplicate store.search() warning, added 2 new notes
