### PR TITLE
chore: Release v0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.5] - 2026-02-08
+
+### Fixed
+- **T-SQL name extraction**: `ALTER PROCEDURE` and `ALTER FUNCTION` now indexed (previously only `CREATE` variants)
+- **Tree-sitter error recovery**: Position-based validation detects when `@name` capture matched wrong node; falls back to regex extraction from content text
+- **Multi-line names**: Truncate to first line when tree-sitter error recovery extends name nodes past actual identifier
+- Bump `tree-sitter-sequel-tsql` to 0.4.2 (bracket-quoted identifier support)
+
 ## [0.9.4] - 2026-02-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 rust-version = "1.88"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML, MCP server."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,12 +2,13 @@
 
 ## Right Now
 
-**Clean slate.** v0.9.4 shipped with SQL language support.
+**PR #313 open** — T-SQL name extraction fix (ALTER PROCEDURE/FUNCTION, position-based fallback).
 
 ### Uncommitted
 None.
 
 ### Recent merges
+- PR #312: Update tears for v0.9.4 release
 - PR #311: Use crates.io dep for tree-sitter-sql
 - PR #310: Release v0.9.4
 - PR #309: SQL language support
@@ -60,7 +61,7 @@ None.
 
 ## Architecture
 
-- Version: 0.9.4
+- Version: 0.9.5
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
@@ -69,4 +70,4 @@ None.
 - 286 lib + 233 integration tests (with gpu-search), 0 warnings, clippy clean
 - MCP tools: 20 (note_only, summary, mermaid added as params in v0.9.2+)
 - Source layout: parser/ and hnsw/ are now directories (split from monoliths in v0.9.0)
-- SQL grammar: tree-sitter-sequel-tsql v0.4.0 on crates.io (forked from DerekStride/tree-sitter-sql)
+- SQL grammar: tree-sitter-sequel-tsql v0.4.2 on crates.io (forked from DerekStride/tree-sitter-sql)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -326,7 +326,7 @@
 
 ### Priority: High (needed for VS2005 project)
 
-- [x] **SQL** — forked tree-sitter-sql with CREATE PROCEDURE, GO batch separator, EXEC statement support. Stored procedures, functions, views extracted. 8 languages total.
+- [x] **SQL** — forked tree-sitter-sql with CREATE/ALTER PROCEDURE/FUNCTION, GO batch separator, EXEC statement support. T-SQL name extraction with error recovery fallback. 8 languages total.
 - [ ] **VB.NET** — `tree-sitter-vb-dotnet` (git dep, not on crates.io). Subs, Functions, Classes, Modules.
 - [x] P3 audit fixes (#264-266) — completed in PR #296
 - [x] Audit cleanup batch (PR #308): #265 error propagation, #264 config errors, #241 config validation, #267 module boundaries, #239 test coverage, #232 CAGRA RAII guard

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -560,3 +560,28 @@ mentions = [
     "define_languages",
     "src/language/sql.rs",
 ]
+
+[[note]]
+sentiment = -0.5
+text = "tree-sitter-sequel-tsql v0.4.2 not yet published to crates.io — bracket-quoted identifiers and ALTER PROCEDURE/FUNCTION only available via git dep. Any project using crates.io dep gets v0.4.0 without those fixes."
+mentions = [
+    "Cargo.toml",
+    "tree-sitter-sequel-tsql",
+]
+
+[[note]]
+sentiment = -0.5
+text = "extract_name_fallback() in chunk.rs searches for SQL keywords (PROCEDURE, FUNCTION, VIEW, TRIGGER) but lives in generic parser code. Harmless for non-SQL languages (returns None) but couples generic parsing to SQL-specific knowledge."
+mentions = [
+    "src/parser/chunk.rs",
+    "extract_name_fallback",
+]
+
+[[note]]
+sentiment = -0.5
+text = '''SignatureStyle::UntilAs doesn't handle \r\n line endings. Patterns " AS ", "\nAS\n", "\nAS " won't match "\r\nAS\r\n". Git usually normalizes but raw Windows .sql files will break signature extraction.'''
+mentions = [
+    "src/parser/chunk.rs",
+    "extract_signature",
+    "SignatureStyle::UntilAs",
+]


### PR DESCRIPTION
## Summary

Release v0.9.5 — T-SQL name extraction fixes.

### Fixed
- `ALTER PROCEDURE` and `ALTER FUNCTION` now indexed
- Position-based validation detects wrong `@name` captures from tree-sitter error recovery
- Multi-line name truncation
- Bump `tree-sitter-sequel-tsql` to 0.4.2
