### PR TITLE
chore: Release v0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.6] - 2026-02-08
+
+### Added
+- **Markdown language support**: 9th language. Indexes `.md` and `.mdx` files with heading-based chunking, adaptive heading detection (handles both standard and inverted hierarchies), and cross-reference extraction from links and backtick function patterns.
+- `ChunkType::Section` for documentation chunks
+- `SignatureStyle::Breadcrumb` for heading-path signatures (e.g., "Doc Title > Chapter > Subsection")
+- `scripts/clean_md.py` for one-time PDF-to-markdown artifact preprocessing
+- `lang-markdown` feature flag (enabled by default)
+- Optional `grammar` field on `LanguageDef` for non-tree-sitter languages
+
 ## [0.9.5] - 2026-02-08
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ src/
     watch.rs    - File watcher for incremental reindexing
   language/     - Tree-sitter language support
     mod.rs      - Language enum, LanguageRegistry, LanguageDef, ChunkType
-    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, java.rs, sql.rs
+    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, java.rs, sql.rs, markdown.rs
   source/       - Source abstraction layer
     mod.rs      - Source trait
     filesystem.rs - File-based source implementation
@@ -115,11 +115,12 @@ src/
     tools/      - MCP tool implementations
       mod.rs, search.rs, read.rs, notes.rs, stats.rs, call_graph.rs, audit.rs, similar.rs, explain.rs, diff.rs, trace.rs, impact.rs, test_map.rs, batch.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs
     transports/ - stdio.rs, http.rs transport implementations
-  parser/       - Tree-sitter code parsing (delegates to language/ registry)
+  parser/       - Code parsing (tree-sitter + custom parsers, delegates to language/ registry)
     mod.rs      - Parser struct, parse_file(), supported_extensions()
     types.rs    - Chunk, CallSite, FunctionCalls, ParserError
     chunk.rs    - Chunk extraction, signatures, doc comments
     calls.rs    - Call graph extraction, callee filtering
+    markdown.rs - Heading-based markdown parser, cross-reference extraction
   embedder.rs   - ONNX model (E5-base-v2), 769-dim embeddings
   search.rs     - Search algorithms, name matching, HNSW-guided search
   math.rs       - Vector math utilities (cosine similarity, SIMD)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 rust-version = "1.88"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML, MCP server."

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -12,7 +12,7 @@ cqs processes your code entirely on your machine. Nothing is transmitted externa
 
 When you run `cqs index`, the following is stored in `.cq/index.db`:
 
-- Code chunks (functions, methods)
+- Code chunks (functions, methods, documentation sections)
 - Embedding vectors (769-dimensional floats: 768 from E5-base-v2 + 1 sentiment dimension)
 - File paths and line numbers
 - File modification times

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,12 +2,12 @@
 
 ## Right Now
 
-**Markdown indexing — implementation in progress.** 2026-02-08. Branch: `feat/markdown-indexing`.
+**Releasing v0.9.6.** 2026-02-08.
 
-### Done this session
+### Done
+- Markdown indexing merged (PR #315)
 - Design doc: `docs/plans/2026-02-08-markdown-indexing-design.md`
-- Plan: `/home/user001/.claude/plans/vectorized-swinging-starfish.md` (18 steps, 3 fresh-eyes reviews)
-- Steps 0-14 implemented and passing:
+- 18-step plan fully implemented:
   - `scripts/clean_md.py` — 7-rule PDF artifact preprocessor (tested on 39 files)
   - `ChunkType::Section`, `SignatureStyle::Breadcrumb` added
   - `grammar: Option<fn()>` — made grammar optional for non-tree-sitter languages
@@ -23,22 +23,11 @@
   - `.mcp.json` fixed (added miniforge3/lib + cuda to LD_LIBRARY_PATH)
 - 298 lib + 233 integration tests pass, 0 warnings, clippy clean
 
-### Remaining
-- Steps 15-17: test fixture (`tests/fixtures/sample.md`) + integration tests
-- No PR yet — needs commit first
-
 ### Key implementation details
 - **Adaptive heading detection**: "shallowest heading level appearing more than once" = primary split level. Handles both standard (H1→H2→H3) and inverted (H2→H1→H3) AVEVA hierarchies.
 - **Merge logic**: small sections (<30 lines) merge INTO the next big section (not the other way)
 - **Regex fix**: Rust `regex` crate doesn't support lookbehind — filter image links by checking preceding `!` byte
 - **Overflow split**: excludes title level from candidates (inverted hierarchy fix)
-
-### Uncommitted (26 files)
-- All changes listed above — nothing committed yet on `feat/markdown-indexing`
-- `docs/plans/2026-02-08-markdown-indexing-design.md` — design doc
-- `scripts/clean_md.py` — preprocessor
-- `src/language/markdown.rs` — language def
-- `src/parser/markdown.rs` — parser
 
 ### Recent merges
 - PR #314: Release v0.9.5
@@ -91,7 +80,7 @@
 
 ## Architecture
 
-- Version: 0.9.5
+- Version: 0.9.6
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)

--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ Implements MCP Streamable HTTP spec 2025-11-25 with Origin validation and protoc
 - Go
 - C
 - Java
+- SQL (T-SQL, PostgreSQL)
+- Markdown (.md, .mdx — heading-based chunking with cross-reference extraction)
 
 ## Indexing
 
@@ -386,11 +388,12 @@ cqs index --dry-run    # Show what would be indexed
 
 ## How It Works
 
-1. Parses code with tree-sitter to extract:
+1. Parses code to extract:
    - Functions and methods
    - Classes and structs
    - Enums, traits, interfaces
    - Constants
+   - Documentation sections (Markdown)
 2. Generates embeddings with E5-base-v2 (runs locally)
    - Includes doc comments for better semantic matching
 3. Stores in SQLite with vector search + FTS5 keyword index

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - **Semantic search**: Uses E5-base-v2 embeddings (769-dim: 768 model + sentiment)
 //! - **Notes with sentiment**: Unified memory system for AI collaborators
-//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, Java
+//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, Markdown
 //! - **GPU acceleration**: CUDA/TensorRT with CPU fallback
 //! - **MCP integration**: Works with Claude Code and other AI assistants
 //!


### PR DESCRIPTION
## Summary

- Version bump 0.9.5 -> 0.9.6
- Changelog entry for markdown indexing feature
- Docs updated: language lists (9 languages), parser description, architecture overview
- PROJECT_CONTINUITY.md updated for release

## Test plan

- [x] All tests pass (298 lib + 233 integration)
- [x] Clippy clean, zero warnings
- [x] Docs reviewed for staleness
