### PR TITLE
chore: Release v0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.7] - 2026-02-08
+
+### Added
+- **CLI-first migration**: All cqs features now available via CLI without MCP server. New commands: `cqs notes add/update/remove`, `cqs audit-mode on/off`, `cqs read <path> [--focus fn]`. New search flags: `--name-only`, `--semantic-only`. File-based audit mode persistence (`.cqs/audit-mode.json`) shared between CLI and MCP.
+- **Hot-reload reference indexes**: MCP server detects config file changes and reloads reference indexes automatically. No restart needed after `cqs ref add/remove`.
+
+### Fixed
+- **Renamed `.cq/` index directory to `.cqs/`** for consistency with binary name, config directory, and config file. Auto-migration renames existing `.cq/` directories on first access. Cross-project search falls back to `.cq/` for unmigrated projects.
+
 ## [0.9.6] - 2026-02-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2021"
 rust-version = "1.88"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML, MCP server."


### PR DESCRIPTION
## Summary

Release v0.9.7.

### What's new
- **CLI-first migration** — all features available without MCP (#320)
- **Hot-reload reference indexes** on config change (#317)
- **Renamed `.cq/` to `.cqs/`** with auto-migration (#321, closes #260)

## Test plan

- [x] `cargo check` passes with updated version
- [x] Changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
