### PR TITLE
fix: correct action name in dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-outdated
         run: cargo install cargo-outdated


### PR DESCRIPTION
## Summary
- Fix typo in dependency review workflow: `dtolnay/rust-action` → `dtolnay/rust-toolchain`
- The workflow has been failing every Monday since it was added

## Test plan
- [ ] CI green
- [ ] Manually trigger dependency review workflow to confirm it passes
