### PR TITLE
fix: ref remove cleanup and ref update prune guard

### DIFF
--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -215,29 +215,29 @@ impl Store {
                 sqlx::query(stmt).execute(&self.pool).await?;
             }
 
-            // Store metadata
+            // Store metadata (OR REPLACE handles re-init after incomplete cleanup)
             let now = chrono::Utc::now().to_rfc3339();
-            sqlx::query("INSERT INTO metadata (key, value) VALUES (?1, ?2)")
+            sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES (?1, ?2)")
                 .bind("schema_version")
                 .bind(CURRENT_SCHEMA_VERSION.to_string())
                 .execute(&self.pool)
                 .await?;
-            sqlx::query("INSERT INTO metadata (key, value) VALUES (?1, ?2)")
+            sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES (?1, ?2)")
                 .bind("model_name")
                 .bind(&model_info.name)
                 .execute(&self.pool)
                 .await?;
-            sqlx::query("INSERT INTO metadata (key, value) VALUES (?1, ?2)")
+            sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES (?1, ?2)")
                 .bind("dimensions")
                 .bind(model_info.dimensions.to_string())
                 .execute(&self.pool)
                 .await?;
-            sqlx::query("INSERT INTO metadata (key, value) VALUES (?1, ?2)")
+            sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES (?1, ?2)")
                 .bind("created_at")
                 .bind(&now)
                 .execute(&self.pool)
                 .await?;
-            sqlx::query("INSERT INTO metadata (key, value) VALUES (?1, ?2)")
+            sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES (?1, ?2)")
                 .bind("cq_version")
                 .bind(env!("CARGO_PKG_VERSION"))
                 .execute(&self.pool)


### PR DESCRIPTION
## Summary

- **#319**: `ref remove` now falls back to canonical `ref_path()` when the config-parsed path doesn't exist, ensuring the reference directory is always cleaned up. `Store::init` uses `INSERT OR REPLACE` for metadata so re-init after incomplete cleanup doesn't hit UNIQUE constraint.
- **#318**: `ref update` aborts with a clear error when `enumerate_files` finds 0 supported files but the index already has chunks (language mismatch). Also warns on large prune operations (>50% of chunks removed).

## Test plan

- [x] `cargo build --features gpu-search` — 0 warnings
- [x] `cargo test --features gpu-search` — 302 lib + 233 integration pass
- [x] `cargo clippy --features gpu-search` — clean
- [ ] Manual: `cqs ref add test-ref /path && cqs ref remove test-ref && cqs ref add test-ref /path` — no UNIQUE constraint error
- [ ] Manual: verify `ref update` with mismatched binary aborts instead of pruning

Fixes #318, Fixes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)
