### PR TITLE
fix: critical bugs — byte truncation, dead code detection, search fallbacks (audit PR2)

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -5,12 +5,18 @@
 **v0.9.7 audit fix session.** 2026-02-10.
 
 ### Active
-- PR1 (Foundation): 3 parallel agents running — extracting shared modules + dedup (11 fixes)
-  - Agent A: CQ-1, CQ-2, CQ-5, CQ-7 (search.rs, focused_read.rs, store/helpers.rs)
-  - Agent B: CQ-3, CQ-4 (note.rs, impact.rs)
-  - Agent C: CQ-6, CQ-8, CQ-9, CQ-10, PB4 (diff.rs, markdown.rs, nl.rs, hnsw/mod.rs)
-- Branch: `audit/pr1-foundation`
-- Team: `pr1-foundation`
+- PR2 (Critical Bugs): 3 parallel agents running — 10 bug fixes
+  - Agent A: R7/S10 (nl.rs byte truncation), R8/EH13 (notes byte truncation), AC10 (chunk ID path), EH11 (resolve fallback)
+  - Agent B: AC5 (dead code trait impl), R4 (CLI limit clamp), AC2 (gather determinism), EH4 (gather fallback)
+  - Agent C: EH5/EH6 (impact .ok() swallowing), TC1 (tautological gather test), TC12 (diff modified assert)
+- Branch: `audit-pr2-critical-bugs`
+- Team: `pr2-bugs`
+
+### Completed
+- PR1 (Foundation): merged as PR #333 — extracted shared modules + dedup (11 fixes)
+  - New: src/focused_read.rs, src/impact.rs
+  - Modified: search.rs, store/helpers.rs, note.rs, math.rs, diff.rs, markdown.rs, nl.rs, hnsw/mod.rs, cli/commands/impact.rs, mcp/tools/impact.rs, cli/commands/read.rs, mcp/tools/read.rs, cli/commands/resolve.rs, mcp/tools/resolve.rs, mcp/validation.rs, lib.rs, store/mod.rs, store/chunks.rs
+- Release binary updated after PR1 merge
 
 ### Plan
 Full audit fix plan at `/home/user001/.claude/plans/witty-strolling-melody.md`

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -43,12 +43,12 @@ After de-duplication: **~140 unique findings**
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 10 | Duplicate `cosine_similarity` in diff.rs (different behavior from math.rs) | A5/CQ-6 | easy | |
-| 11 | Duplicate name scoring logic in store | A4/CQ-7 | easy | |
-| 12 | resolve.rs copied identically between CLI and MCP (52 lines x2) | CQ-1 | easy | |
-| 13 | Per-call `Regex::new().unwrap()` in markdown parser (should be LazyLock) | CQ-8/R1 | easy | |
-| 14 | Duplicate `make_embedding` test helper across HNSW modules | CQ-10 | easy | |
-| 15 | Duplicate tokenization impl in nl.rs (function + iterator) | CQ-9 | easy | |
+| 10 | Duplicate `cosine_similarity` in diff.rs (different behavior from math.rs) | A5/CQ-6 | easy | PR #333 |
+| 11 | Duplicate name scoring logic in store | A4/CQ-7 | easy | PR #333 |
+| 12 | resolve.rs copied identically between CLI and MCP (52 lines x2) | CQ-1 | easy | PR #333 |
+| 13 | Per-call `Regex::new().unwrap()` in markdown parser (should be LazyLock) | CQ-8/R1 | easy | PR #333 |
+| 14 | Duplicate `make_embedding` test helper across HNSW modules | CQ-10 | easy | PR #333 |
+| 15 | Duplicate tokenization impl in nl.rs (function + iterator) | CQ-9 | easy | PR #333 |
 
 ### eprintln → tracing (5 locations)
 
@@ -102,7 +102,7 @@ After de-duplication: **~140 unique findings**
 |---|---------|--------|------------|--------|
 | 42 | `save_audit_state` no 0o600 permissions | PB5 | easy | |
 | 43 | `ProjectRegistry.save()` no 0o600 permissions | PB6 | easy | |
-| 44 | Inconsistent canonicalization (3 patterns, dunce already a dep) | PB4 | easy | |
+| 44 | Inconsistent canonicalization (3 patterns, dunce already a dep) | PB4 | easy | PR #333 |
 | 45 | HNSW temp cleanup uses `remove_dir` not `remove_dir_all` | PB9 | easy | |
 
 ### Extensibility (easy)
@@ -136,10 +136,10 @@ After de-duplication: **~140 unique findings**
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 8 | Focused-read logic (TYPE_NAME_RE, COMMON_TYPES) duplicated CLI/MCP | CQ-2 | medium | |
-| 9 | Note injection logic duplicated in 4 places | CQ-3 | medium | |
-| 10 | Impact command duplicated CLI/MCP (377+256 lines) | CQ-4 | medium | |
-| 11 | JSON result formatting duplicated in 5+ locations | CQ-5 | medium | |
+| 8 | Focused-read logic (TYPE_NAME_RE, COMMON_TYPES) duplicated CLI/MCP | CQ-2 | medium | PR #333 |
+| 9 | Note injection logic duplicated in 4 places | CQ-3 | medium | PR #333 |
+| 10 | Impact command duplicated CLI/MCP (377+256 lines) | CQ-4 | medium | PR #333 |
+| 11 | JSON result formatting duplicated in 5+ locations | CQ-5 | medium | PR #333 |
 
 ### Performance (high-impact easy/medium)
 

--- a/src/cli/commands/gather.rs
+++ b/src/cli/commands/gather.rs
@@ -57,6 +57,7 @@ pub(crate) fn cmd_gather(
             "query": query,
             "chunks": json_chunks,
             "expansion_capped": result.expansion_capped,
+            "search_degraded": result.search_degraded,
         });
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else if result.chunks.is_empty() {
@@ -70,6 +71,12 @@ pub(crate) fn cmd_gather(
         );
         if result.expansion_capped {
             println!("{}", "Warning: expansion capped at 200 nodes".yellow());
+        }
+        if result.search_degraded {
+            println!(
+                "{}",
+                "Warning: batch name search failed, results may be incomplete".yellow()
+            );
         }
         println!();
 

--- a/src/cli/commands/notes.rs
+++ b/src/cli/commands/notes.rs
@@ -445,9 +445,15 @@ fn cmd_notes_list(cli: &Cli, warnings_only: bool, patterns_only: bool) -> Result
     for note in &filtered {
         let sentiment_marker = format!("[{:+.1}]", note.sentiment);
 
-        // Truncate text for display
-        let preview = if note.text.len() > 120 {
-            format!("{}...", &note.text[..117])
+        // Truncate text for display (char-safe)
+        let preview = if note.text.chars().count() > 120 {
+            let end = note
+                .text
+                .char_indices()
+                .nth(117)
+                .map(|(i, _)| i)
+                .unwrap_or(note.text.len());
+            format!("{}...", &note.text[..end])
         } else {
             note.text.clone()
         };

--- a/src/mcp/tools/gather.rs
+++ b/src/mcp/tools/gather.rs
@@ -71,6 +71,7 @@ pub fn tool_gather(server: &McpServer, arguments: Value) -> Result<Value> {
         "query": query,
         "chunks": json_chunks,
         "expansion_capped": result.expansion_capped,
+        "search_degraded": result.search_degraded,
     });
 
     Ok(serde_json::json!({

--- a/tests/gather_test.rs
+++ b/tests/gather_test.rs
@@ -65,11 +65,14 @@ fn test_gather_basic() {
     assert!(result.is_ok(), "Gather should execute without error");
     let gather_result = result.unwrap();
 
-    // Should find at least some chunks (exact count depends on search + expansion)
-    assert!(
-        !gather_result.chunks.is_empty() || gather_result.chunks.is_empty(),
-        "Gather should return results (or empty if search found nothing)"
-    );
+    // Verify gather results are well-formed when present
+    for chunk in &gather_result.chunks {
+        assert!(!chunk.name.is_empty(), "Gathered chunk should have a name");
+        assert!(
+            chunk.depth <= 1,
+            "With expand_depth=1, max depth should be 1"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

10 critical bug fixes from v0.9.7 audit (P1/P2 findings):

- **R7/S10**: `normalize_for_fts` panics on CJK text due to byte-level truncation mid-character. Added `floor_char_boundary` polyfill (MSRV 1.88 compatible) to truncate at char boundaries.
- **R8/EH13**: Notes list preview truncation at byte index could split multi-byte chars. Now uses `char_indices` for safe truncation.
- **AC10**: `resolve_target` extracted wrong file path from windowed chunk IDs (3 trailing segments instead of 2). Now detects window index suffix.
- **EH11**: `resolve_target` silently returned first result when file filter didn't match. Now returns descriptive error.
- **AC5**: `find_dead_code` reported trait impl methods (Display::fmt, Iterator::next, etc.) as dead code. Added `TRAIT_METHOD_NAMES` set for detection.
- **R4**: CLI `--limit` accepted any value including 0 and negatives. Now clamped to 1..100.
- **AC2**: `gather` sort was non-deterministic for equal scores. Added name tiebreaker.
- **EH4**: `gather` silently returned empty results when batch name search failed. Now flags `search_degraded` in result.
- **EH5/EH6**: `impact` and `test_map` swallowed errors with `.ok()`. Now logs warnings via tracing.
- **TC1/TC12**: Fixed tautological gather test assertion + added missing diff modified list assertion.

Follows PR #333 (Foundation — shared modules + dedup).

## Test plan

- [x] `cargo build --features gpu-search` — 0 warnings
- [x] `cargo clippy --features gpu-search` — clean
- [x] `cargo test --features gpu-search` — 553 tests pass (310 lib + 243 integration)
- [x] Fresh-eyes review of all 13 changed files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
