### PR TITLE
chore: mechanical improvements — observability, error handling, docs, permissions (audit PR3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ src/
   cli/          - Command-line interface (clap)
     mod.rs      - Argument parsing, command dispatch
     commands/   - Command implementations
-      mod.rs, query.rs, index.rs, stats.rs, graph.rs, serve.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, trace.rs, impact.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs
+      mod.rs, query.rs, index.rs, stats.rs, graph.rs, serve.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, trace.rs, impact.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs, audit_mode.rs, read.rs
     config.rs   - Configuration file loading
     display.rs  - Output formatting, result display
     files.rs    - File enumeration, lock files, path utilities
@@ -138,6 +138,9 @@ src/
   gather.rs     - Smart context assembly (BFS call graph expansion)
   structural.rs - Structural pattern matching on code chunks
   project.rs    - Cross-project search registry
+  audit.rs    - Audit mode persistence (file-based, shared CLI/MCP)
+  focused_read.rs - Focused read logic (extract type dependencies)
+  impact.rs       - Impact analysis (callers + affected tests)
   config.rs     - Configuration file support
   index.rs      - VectorIndex trait (HNSW, CAGRA)
   lib.rs        - Public API

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -5,18 +5,20 @@
 **v0.9.7 audit fix session.** 2026-02-10.
 
 ### Active
-- PR2 (Critical Bugs): 3 parallel agents running — 10 bug fixes
-  - Agent A: R7/S10 (nl.rs byte truncation), R8/EH13 (notes byte truncation), AC10 (chunk ID path), EH11 (resolve fallback)
-  - Agent B: AC5 (dead code trait impl), R4 (CLI limit clamp), AC2 (gather determinism), EH4 (gather fallback)
-  - Agent C: EH5/EH6 (impact .ok() swallowing), TC1 (tautological gather test), TC12 (diff modified assert)
-- Branch: `audit-pr2-critical-bugs`
-- Team: `pr2-bugs`
+- Next: PR3 (Mechanical Improvements) — 33 fixes across eprintln→tracing, docs, observability, error handling, permissions, extensibility
 
 ### Completed
+- PR2 (Critical Bugs): merged as PR #334 — 10 bug fixes
+  - nl.rs: floor_char_boundary for CJK-safe truncation (R7/S10)
+  - notes.rs: char_indices preview truncation (R8/EH13)
+  - search.rs: windowed chunk ID path + resolve_target error on filter miss (AC10, EH11)
+  - calls.rs: TRAIT_METHOD_NAMES set for dead code detection (AC5)
+  - cli/mod.rs: limit clamp 1..100 (R4)
+  - gather.rs: deterministic sort + search_degraded flag (AC2, EH4)
+  - impact.rs: tracing::warn instead of .ok() (EH5/EH6)
+  - tests: non-tautological assertions (TC1, TC12)
 - PR1 (Foundation): merged as PR #333 — extracted shared modules + dedup (11 fixes)
-  - New: src/focused_read.rs, src/impact.rs
-  - Modified: search.rs, store/helpers.rs, note.rs, math.rs, diff.rs, markdown.rs, nl.rs, hnsw/mod.rs, cli/commands/impact.rs, mcp/tools/impact.rs, cli/commands/read.rs, mcp/tools/read.rs, cli/commands/resolve.rs, mcp/tools/resolve.rs, mcp/validation.rs, lib.rs, store/mod.rs, store/chunks.rs
-- Release binary updated after PR1 merge
+- Release binary updated after PR2 merge
 
 ### Plan
 Full audit fix plan at `/home/user001/.claude/plans/witty-strolling-melody.md`
@@ -71,7 +73,7 @@ Full audit fix plan at `/home/user001/.claude/plans/witty-strolling-melody.md`
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, score-based merge with weight
 - 9 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, Markdown)
-- 302 lib + 233 integration tests (with gpu-search), 0 warnings, clippy clean
+- 310 lib + 243 integration tests (with gpu-search), 0 warnings, clippy clean
 - MCP tools: 20 (also available as CLI commands now)
 - Source layout: parser/ and hnsw/ are directories (split from monoliths in v0.9.0)
 - SQL grammar: tree-sitter-sequel-tsql v0.4.2 (crates.io)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ Find function call relationships:
 ```bash
 cqs callers <name>   # Functions that call <name>
 cqs callees <name>   # Functions called by <name>
-cqs notes list       # List all project notes with sentiment
 ```
 
 Use cases:
@@ -147,6 +146,15 @@ Use cases:
 - **Entry point discovery**: Find functions with no callers
 
 Call graph is indexed across all files - callers are found regardless of which file they're in.
+
+## Notes
+
+```bash
+cqs notes list       # List all project notes with sentiment
+cqs notes add "text" --sentiment -0.5 --mentions file.rs  # Add a note
+cqs notes update "text" --new-text "updated"               # Update a note
+cqs notes remove "text"                                    # Remove a note
+```
 
 ## Discovery Tools
 
@@ -228,7 +236,7 @@ cqs "spawn async task"    # Finds results in project AND tokio reference
 
 Reference results are ranked with a weight multiplier (default 0.8) so project results naturally appear first at equal similarity.
 
-**Source filtering**: Use the `--sources` flag to filter which indexes to search:
+**Source filtering** (MCP tool parameter only): Use `sources` to filter which indexes to search:
 - Omit to search all indexes
 - `--sources project` — search only the primary project
 - `--sources tokio` — search only the tokio reference

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -326,7 +326,7 @@
 
 ### Done
 
-- [x] **SQL** — forked tree-sitter-sql with CREATE/ALTER PROCEDURE/FUNCTION, GO batch separator, EXEC statement support. T-SQL name extraction with error recovery fallback. 8 languages total.
+- [x] **SQL** — forked tree-sitter-sql with CREATE/ALTER PROCEDURE/FUNCTION, GO batch separator, EXEC statement support. T-SQL name extraction with error recovery fallback. 9 languages total (Markdown added in v0.9.6).
 - [x] P3 audit fixes (#264-266) — completed in PR #296
 - [x] Audit cleanup batch (PR #308): #265 error propagation, #264 config errors, #241 config validation, #267 module boundaries, #239 test coverage, #232 CAGRA RAII guard
 
@@ -356,8 +356,6 @@
 - [ ] **Batch UX** — common batch patterns (e.g., "callers for these N functions") as named shortcuts instead of raw JSON construction
 
 ## Parked
-
-- **Markdown support** — `tree-sitter-markdown`, headings as chunks, sections as content. Makes docs/READMEs/specs searchable. No call graph/signatures though — half the tools wouldn't apply.
 
 ## Phase 8: Security
 

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -29,15 +29,15 @@ After de-duplication: **~140 unique findings**
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 1 | `normalize_for_fts` byte-slices CJK text → panic (MCP crashable) | R7/S10 | medium | |
-| 2 | `notes list` byte-truncation `&note.text[..117]` → panic on CJK | R8/EH13 | easy | |
-| 3 | Windowed chunk ID path extraction via `rfind(':')` breaks glob filter | AC10 | easy | |
-| 4 | Dead code detection trait impl check matches method body, not impl block | AC5 | medium | |
-| 5 | `resolve_target` silently returns wrong-file result on filter miss | EH11 | medium | |
-| 6 | CLI `--limit` not clamped — `usize::MAX as i64` wraps to -1, returns all rows | R4 | easy | |
-| 7 | `gather()` BFS non-deterministic output (HashMap iteration order) | AC2 | easy | |
-| 8 | Tautological assertion in gather test (`!empty || empty`) | TC1 | easy | |
-| 9 | Diff test never asserts on `modified` list | TC12 | easy | |
+| 1 | `normalize_for_fts` byte-slices CJK text → panic (MCP crashable) | R7/S10 | medium | PR #334 |
+| 2 | `notes list` byte-truncation `&note.text[..117]` → panic on CJK | R8/EH13 | easy | PR #334 |
+| 3 | Windowed chunk ID path extraction via `rfind(':')` breaks glob filter | AC10 | easy | PR #334 |
+| 4 | Dead code detection trait impl check matches method body, not impl block | AC5 | medium | PR #334 |
+| 5 | `resolve_target` silently returns wrong-file result on filter miss | EH11 | medium | PR #334 |
+| 6 | CLI `--limit` not clamped — `usize::MAX as i64` wraps to -1, returns all rows | R4 | easy | PR #334 |
+| 7 | `gather()` BFS non-deterministic output (HashMap iteration order) | AC2 | easy | PR #334 |
+| 8 | Tautological assertion in gather test (`!empty || empty`) | TC1 | easy | PR #334 |
+| 9 | Diff test never asserts on `modified` list | TC12 | easy | PR #334 |
 
 ### Duplication / Code Quality
 
@@ -128,9 +128,9 @@ After de-duplication: **~140 unique findings**
 | 2 | Diff ChunkKey includes line_start → false add+remove on reorder | AC4 | medium | |
 | 3 | `search_across_projects` never uses HNSW (always O(n)) | AC7 | medium | |
 | 4 | Unified search note slots over-allocated when code sparse | AC1 | medium | |
-| 5 | impact/test_map MCP tools swallow DB errors with `.ok()` | EH5 | medium | |
-| 6 | impact/test_map CLI tools swallow DB errors with `.ok()` | EH6 | medium | |
-| 7 | `gather()` silently falls back to empty on batch search failure | EH4 | medium | |
+| 5 | impact/test_map MCP tools swallow DB errors with `.ok()` | EH5 | medium | PR #334 |
+| 6 | impact/test_map CLI tools swallow DB errors with `.ok()` | EH6 | medium | PR #334 |
+| 7 | `gather()` silently falls back to empty on batch search failure | EH4 | medium | PR #334 |
 
 ### Duplication (medium)
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -110,6 +110,11 @@ pub fn save_audit_state(cqs_dir: &Path, mode: &AuditMode) -> Result<()> {
     };
     let content = serde_json::to_string_pretty(&file).context("Failed to serialize audit mode")?;
     std::fs::write(&path, content).context("Failed to write audit-mode.json")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
     Ok(())
 }
 

--- a/src/cli/commands/gather.rs
+++ b/src/cli/commands/gather.rs
@@ -16,6 +16,8 @@ pub(crate) fn cmd_gather(
     limit: usize,
     json: bool,
 ) -> Result<()> {
+    let _span = tracing::info_span!("cmd_gather", query_len = query.len(), expand, limit).entered();
+
     let root = find_project_root();
     let index_path = cqs::resolve_index_dir(&root).join("index.db");
 
@@ -32,6 +34,7 @@ pub(crate) fn cmd_gather(
         expand_depth: expand.clamp(0, 5),
         direction: dir,
         limit,
+        ..GatherOptions::default()
     };
 
     let result = gather(&store, &query_embedding, query, &opts, &root)?;

--- a/src/cli/commands/gc.rs
+++ b/src/cli/commands/gc.rs
@@ -15,6 +15,8 @@ use super::build_hnsw_index;
 
 /// Run garbage collection on the index
 pub(crate) fn cmd_gc(json: bool) -> Result<()> {
+    let _span = tracing::info_span!("cmd_gc").entered();
+
     let root = find_project_root();
     let cqs_dir = cqs::resolve_index_dir(&root);
     let index_path = cqs_dir.join("index.db");
@@ -38,9 +40,11 @@ pub(crate) fn cmd_gc(json: bool) -> Result<()> {
 
     // Prune chunks for missing files
     let pruned_chunks = store.prune_missing(&file_set)?;
+    tracing::debug!(pruned_chunks, "Chunks pruned");
 
     // Prune orphan call graph entries
     let pruned_calls = store.prune_stale_calls()?;
+    tracing::debug!(pruned_calls, "Calls pruned");
 
     // Rebuild HNSW if we pruned anything
     let hnsw_vectors = if pruned_chunks > 0 {

--- a/src/cli/commands/index.rs
+++ b/src/cli/commands/index.rs
@@ -175,6 +175,7 @@ fn extract_call_graph(
     files: &HashSet<PathBuf>,
     store: &Store,
 ) -> Result<usize> {
+    let _span = tracing::info_span!("extract_call_graph", file_count = files.len()).entered();
     let mut total_calls = 0;
     for file in files {
         let abs_path = root.join(file);
@@ -190,6 +191,7 @@ fn extract_call_graph(
             }
         }
     }
+    tracing::info!(total_calls, "Call graph extraction complete");
     Ok(total_calls)
 }
 
@@ -238,6 +240,7 @@ fn index_notes_from_file(root: &Path, store: &Store, force: bool) -> Result<(usi
 /// so that notes added via MCP are immediately searchable without rebuild.
 pub(crate) fn build_hnsw_index(store: &Store, cqs_dir: &Path) -> Result<Option<usize>> {
     let chunk_count = store.chunk_count()? as usize;
+    let _span = tracing::info_span!("build_hnsw_index", chunk_count).entered();
 
     if chunk_count == 0 {
         return Ok(None);

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -26,7 +26,9 @@ pub(crate) fn cmd_init(cli: &Cli) -> Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&cqs_dir, std::fs::Permissions::from_mode(0o700));
+        if let Err(e) = std::fs::set_permissions(&cqs_dir, std::fs::Permissions::from_mode(0o700)) {
+            tracing::debug!(error = %e, "Failed to set .cqs directory permissions");
+        }
     }
 
     // Create .gitignore

--- a/src/cli/commands/notes.rs
+++ b/src/cli/commands/notes.rs
@@ -218,7 +218,7 @@ fn cmd_notes_add(
             println!("Indexed {} notes.", indexed);
         }
         if let Some(err) = index_error {
-            eprintln!("Warning: {}", err);
+            tracing::warn!(error = %err, "Note operation warning");
         }
     }
 
@@ -314,7 +314,7 @@ fn cmd_notes_update(
             println!("Indexed {} notes.", indexed);
         }
         if let Some(err) = index_error {
-            eprintln!("Warning: {}", err);
+            tracing::warn!(error = %err, "Note operation warning");
         }
     }
 
@@ -377,7 +377,7 @@ fn cmd_notes_remove(cli: &Cli, text: &str, no_reindex: bool) -> Result<()> {
             println!("Indexed {} notes.", indexed);
         }
         if let Some(err) = index_error {
-            eprintln!("Warning: {}", err);
+            tracing::warn!(error = %err, "Note operation warning");
         }
     }
 

--- a/src/cli/commands/reference.rs
+++ b/src/cli/commands/reference.rs
@@ -311,17 +311,18 @@ fn cmd_ref_update(cli: &Cli, name: &str) -> Result<()> {
     if pruned > 0 && existing_chunks > 0 {
         let remaining = existing_chunks.saturating_sub(pruned as u64);
         if remaining == 0 {
-            eprintln!(
-                "Warning: All {} chunks were pruned. The index is now empty.\n\
-                 If this was unintentional, re-index with 'cqs ref update {name}'.",
+            tracing::warn!(
                 pruned,
+                name,
+                "All chunks were pruned. The index is now empty. \
+                 If this was unintentional, re-index with 'cqs ref update'.",
             );
         } else if (pruned as u64) > existing_chunks / 2 {
-            eprintln!(
-                "Warning: Pruned {} of {} chunks (>{:.0}%). Verify source path is correct.",
+            tracing::warn!(
                 pruned,
                 existing_chunks,
-                (pruned as f64 / existing_chunks as f64) * 100.0,
+                pct = (pruned as f64 / existing_chunks as f64) * 100.0,
+                "Pruned over 50% of chunks. Verify source path is correct.",
             );
         }
     }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -110,4 +110,14 @@ pub(super) fn apply_config_defaults(cli: &mut Cli, config: &cqs::config::Config)
             cli.verbose = true;
         }
     }
+    if (cli.note_weight - 1.0).abs() < f32::EPSILON {
+        if let Some(note_weight) = config.note_weight {
+            cli.note_weight = note_weight;
+        }
+    }
+    if !cli.note_only {
+        if let Some(true) = config.note_only {
+            cli.note_only = true;
+        }
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -915,6 +915,8 @@ mod tests {
             quiet: Some(true),
             verbose: Some(true),
             references: vec![],
+            note_weight: None,
+            note_only: None,
         };
         apply_config_defaults(&mut cli, &config);
 
@@ -935,6 +937,8 @@ mod tests {
             quiet: Some(true),
             verbose: Some(true),
             references: vec![],
+            note_weight: None,
+            note_only: None,
         };
         apply_config_defaults(&mut cli, &config);
 

--- a/src/cli/signal.rs
+++ b/src/cli/signal.rs
@@ -30,7 +30,7 @@ pub fn setup_signal_handler() {
         }
         eprintln!("\nInterrupted. Finishing current batch...");
     }) {
-        eprintln!("Warning: Failed to set Ctrl+C handler: {e}");
+        tracing::warn!(error = %e, "Failed to set Ctrl+C handler");
     }
 }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -67,6 +67,8 @@ pub fn semantic_diff(
     threshold: f32,
     language_filter: Option<&str>,
 ) -> Result<DiffResult, StoreError> {
+    let _span = tracing::info_span!("semantic_diff").entered();
+
     // Load identities from both stores
     let source_ids = source_store.all_chunk_identities()?;
     let target_ids = target_store.all_chunk_identities()?;
@@ -99,6 +101,12 @@ pub fn semantic_diff(
     } else {
         target_ids
     };
+
+    tracing::debug!(
+        source_count = source_ids.len(),
+        target_count = target_ids.len(),
+        "Loaded chunk identities"
+    );
 
     // Build lookup maps: key → (id, identity)
     let source_map: HashMap<ChunkKey, &ChunkIdentity> =

--- a/src/hnsw/persist.rs
+++ b/src/hnsw/persist.rs
@@ -203,7 +203,9 @@ impl HnswIndex {
             for ext in &["hnsw.ids", "hnsw.graph", "hnsw.data", "hnsw.checksum"] {
                 let path = temp_dir.join(format!("{}.{}", basename, ext));
                 if path.exists() {
-                    let _ = std::fs::set_permissions(&path, restrictive.clone());
+                    if let Err(e) = std::fs::set_permissions(&path, restrictive.clone()) {
+                        tracing::debug!(path = %path.display(), error = %e, "Failed to set HNSW file permissions");
+                    }
                 }
             }
         }
@@ -226,7 +228,7 @@ impl HnswIndex {
         }
 
         // Clean up temp directory
-        let _ = std::fs::remove_dir(&temp_dir);
+        let _ = std::fs::remove_dir_all(&temp_dir);
 
         tracing::info!(
             "HNSW index saved: {} vectors (with checksums)",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 //!
 //! ```no_run
 //! use cqs::{Embedder, Parser, Store};
-//! use cqs::store::ModelInfo;
 //!
 //! # fn main() -> anyhow::Result<()> {
 //! // Initialize components
@@ -127,7 +126,7 @@ pub fn resolve_index_dir(project_root: &Path) -> PathBuf {
     let old_dir = project_root.join(LEGACY_INDEX_DIR);
 
     if old_dir.exists() && !new_dir.exists() && std::fs::rename(&old_dir, &new_dir).is_ok() {
-        eprintln!("Migrated index directory from .cq/ to .cqs/");
+        tracing::info!("Migrated index directory from .cq/ to .cqs/");
     }
 
     if new_dir.exists() {

--- a/src/math.rs
+++ b/src/math.rs
@@ -34,6 +34,13 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> Option<f32> {
 /// and may have arbitrary dimensions (not necessarily EMBEDDING_DIM).
 pub fn full_cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     if a.len() != b.len() || a.is_empty() {
+        if a.len() != b.len() {
+            tracing::warn!(
+                a_len = a.len(),
+                b_len = b.len(),
+                "full_cosine_similarity: dimension mismatch"
+            );
+        }
         return 0.0;
     }
     let mut dot = 0.0f32;

--- a/src/mcp/tools/gather.rs
+++ b/src/mcp/tools/gather.rs
@@ -40,6 +40,7 @@ pub fn tool_gather(server: &McpServer, arguments: Value) -> Result<Value> {
         expand_depth: expand,
         direction,
         limit,
+        ..GatherOptions::default()
     };
 
     let result = gather(

--- a/src/project.rs
+++ b/src/project.rs
@@ -42,8 +42,14 @@ impl ProjectRegistry {
                 .with_context(|| format!("Failed to create {}", parent.display()))?;
         }
         let content = toml::to_string_pretty(self)?;
-        std::fs::write(&path, content)
-            .with_context(|| format!("Failed to write {}", path.display()))
+        std::fs::write(&path, &content)
+            .with_context(|| format!("Failed to write {}", path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+        }
+        Ok(())
     }
 
     /// Register a project (replaces existing entry with same name)

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -219,6 +219,7 @@ impl Store {
             }
 
             tx.commit().await?;
+            tracing::info!(source = %source_str, count = notes.len(), "Notes replaced successfully");
             Ok(notes.len())
         })
     }

--- a/tests/gather_test.rs
+++ b/tests/gather_test.rs
@@ -52,6 +52,7 @@ fn test_gather_basic() {
         expand_depth: 1,
         direction: GatherDirection::Both,
         limit: 10,
+        ..GatherOptions::default()
     };
     let query = mock_embedding(1.0);
     let result = cqs::gather(
@@ -88,6 +89,7 @@ fn test_gather_no_expansion() {
         expand_depth: 0,
         direction: GatherDirection::Both,
         limit: 10,
+        ..GatherOptions::default()
     };
     let query = mock_embedding(1.0);
     let result = cqs::gather(
@@ -152,6 +154,7 @@ fn test_gather_callers_only() {
         expand_depth: 1,
         direction: GatherDirection::Callers,
         limit: 10,
+        ..GatherOptions::default()
     };
     let query = mock_embedding(1.0);
     let result = cqs::gather(
@@ -195,6 +198,7 @@ fn test_gather_callees_only() {
         expand_depth: 1,
         direction: GatherDirection::Callees,
         limit: 10,
+        ..GatherOptions::default()
     };
     let query = mock_embedding(1.0);
     let result = cqs::gather(


### PR DESCRIPTION
## Summary

33 mechanical fixes from v0.9.7 audit P1 findings across 6 categories:

- **eprintln -> tracing** (5): Config loading, index migration, notes CLI, signal handler, reference CLI
- **Documentation** (6): ROADMAP stale entries, CONTRIBUTING architecture tree, README section fixes, lib.rs Quick Start cleanup
- **Observability** (9): Tracing spans for gather, semantic_diff, cmd_gc, extract_call_graph, build_hnsw_index, find_dead_code, prune_stale_calls, replace_notes_for_file
- **Error handling** (6): Dimension parse failures, batch tool error logging, set_permissions debug logging, canonicalize failures, temp file cleanup
- **Permissions** (3): 0o600 on audit-mode.json and projects.toml, remove_dir_all for HNSW temp cleanup
- **Extensibility** (4): Batch tool expanded from 6 to 19 MCP tools, note_weight/note_only in Config, seed_limit/seed_threshold/decay_factor in GatherOptions

Follows PR #334 (Critical Bugs).

## Test plan

- [x] `cargo build --features gpu-search` -- 0 warnings
- [x] `cargo clippy --features gpu-search` -- clean
- [x] `cargo test --features gpu-search` -- all pass (310 lib + 51 bin + 8 doc + integration)
- [x] Fresh-eyes review of all 30 changed files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
