### PR TITLE
perf: batch upsert, embedding cache, lazy init, reduced resources (audit PR4)

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -117,7 +117,7 @@ impl McpServer {
         tracing::info!("MCP: Building CAGRA GPU index in background...");
 
         // Open a separate store connection for the background thread
-        let store = match Store::open(index_path) {
+        let store = match Store::open_readonly(index_path) {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!("MCP: Failed to open store for CAGRA build: {}", e);

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -578,11 +578,7 @@ pub fn embedding_to_bytes(embedding: &Embedding) -> Vec<u8> {
         EXPECTED_DIMENSIONS,
         embedding.len()
     );
-    embedding
-        .as_slice()
-        .iter()
-        .flat_map(|f| f.to_le_bytes())
-        .collect()
+    bytemuck::cast_slice::<f32, u8>(embedding.as_slice()).to_vec()
 }
 
 /// Zero-copy view of embedding bytes as f32 slice (for hot paths)


### PR DESCRIPTION
## Summary

10 performance fixes from v0.9.7 audit (P2, P3, P4, P7, P10, RM5, RM6, RM7, RM9, RM12):

- **Watch mode batch upsert** (P2): Group chunks by file, call `upsert_chunks_batch` per group instead of per-chunk `upsert_chunk` (reduces N transactions to 1 per file)
- **Watch mode embedding cache** (P3): Check content hashes via `get_embeddings_by_hashes` before embedding — skip unchanged chunks (can skip 90%+ for typical edits)
- **Batched FTS queries** (P4): `search_by_names_batch` now batches names into groups of 20 with FTS OR queries instead of N individual queries
- **bytemuck memcpy** (P7): `embedding_to_bytes` uses `bytemuck::cast_slice` instead of per-float iterator chain
- **Two-phase dead code query** (P10): `find_dead_code` first loads lightweight metadata, applies simple filters, then batch-fetches content only for survivors
- **Read-only store** (RM6): New `Store::open_readonly` with 1 connection, 4MB cache, 64MB mmap, single-threaded runtime
- **CAGRA lightweight store** (RM5): Background CAGRA build uses `open_readonly` instead of full store
- **Streaming JSON parse** (RM7): HNSW ID map uses `serde_json::from_reader` to avoid doubling memory during parse
- **Burst memory release** (RM9): Watch mode `pending_files` shrinks after drain
- **Lazy CPU embedder** (RM12): Pipeline CPU embedder only initialized when first batch arrives (saves ~500MB when GPU handles everything)

## Test plan

- [x] `cargo build --features gpu-search` — 0 warnings
- [x] `cargo clippy --features gpu-search -- -D warnings` — clean
- [x] `cargo test --features gpu-search --lib` — 310 passed
- [x] `cargo test --features gpu-search --test '*'` — all pass
- [x] Fresh-eyes review — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
