### PR TITLE
fix: safety+security hardening — locking, atomic ops, path validation (audit PR5)

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -214,7 +214,7 @@ impl McpServer {
     /// or generic descriptions to prevent information leakage to clients.
     pub(crate) fn sanitize_error_message(&self, error: &str) -> String {
         static RE_UNIX: LazyLock<regex::Regex> = LazyLock::new(|| {
-            regex::Regex::new(r"/(?:home|Users|tmp|var|usr|opt|etc|mnt|root|run|srv|proc|snap|Library|Applications|private)/[^\s:]+")
+            regex::Regex::new(r"/(?:home|Users|tmp|var|usr|opt|etc|mnt|root|run|srv|proc|snap|Library|Applications|private|data|workspace|workspaces|nix|app|builds|store)/[^\s:]+")
                 .expect("hardcoded regex")
         });
         static RE_WINDOWS: LazyLock<regex::Regex> = LazyLock::new(|| {

--- a/src/mcp/transports/http.rs
+++ b/src/mcp/transports/http.rs
@@ -288,13 +288,19 @@ async fn handle_mcp_post(
             && version_str != MCP_PROTOCOL_VERSION
             && version_str != "2025-03-26"
         {
+            // Truncate to prevent log/response amplification from oversized headers
+            let version_display = if version_str.len() > 32 {
+                &version_str[..32]
+            } else {
+                version_str
+            };
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({
                     "jsonrpc": "2.0",
                     "error": {
                         "code": -32600,
-                        "message": format!("Unsupported protocol version: {}. Supported: {}", version_str, MCP_PROTOCOL_VERSION)
+                        "message": format!("Unsupported protocol version: {}. Supported: {}", version_display, MCP_PROTOCOL_VERSION)
                     }
                 })),
             );

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -37,6 +37,20 @@ pub fn load_references(configs: &[ReferenceConfig]) -> Vec<ReferenceIndex> {
     let mut refs = Vec::with_capacity(configs.len());
 
     for cfg in configs {
+        // Warn if reference path is a symlink (trust boundary)
+        if cfg
+            .path
+            .symlink_metadata()
+            .map(|m| m.is_symlink())
+            .unwrap_or(false)
+        {
+            tracing::warn!(
+                name = cfg.name,
+                path = %cfg.path.display(),
+                "Reference path is a symlink — verify it points to a trusted location"
+            );
+        }
+
         let db_path = cfg.path.join("index.db");
         let store = match Store::open(&db_path) {
             Ok(s) => s,

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -34,7 +34,7 @@ async fn insert_note_with_fts(
     .bind(&note.text)
     .bind(note.sentiment)
     .bind(&mentions_json)
-    .bind(embedding_to_bytes(embedding))
+    .bind(embedding_to_bytes(embedding)?)
     .bind(source_str)
     .bind(file_mtime)
     .bind(now)


### PR DESCRIPTION
## Summary

Safety+Security fixes from the v0.9.7 audit (14 findings across 3 agents):

**Data Safety (5 fixes)**
- Atomic delete+reinsert in watch mode (`replace_file_chunks`) — prevents data loss on crash
- Atomic chunks+calls in pipeline (`upsert_chunks_and_calls`) — single transaction
- Config file locking (`fs4` exclusive lock) for read-modify-write operations
- ProjectRegistry atomic write with lock + cross-device rename fallback
- `parse_notes` reads directly from locked file handle (was reading via separate handle)

**Security (5 fixes)**
- Path traversal validation in `tool_context` (dunce canonicalize + starts_with check)
- Broader `sanitize_error_message` regex (added data/workspace/nix/app/builds/store prefixes)
- Protocol version header truncation (32 char limit prevents response amplification)
- Reference config trust boundary warnings (log when project overrides user references)
- Symlink detection on reference paths

**Robustness (3 fixes)**
- HNSW save `assert_eq!` → `Result` (no panic in MCP server context)
- `embedding_to_bytes` `assert_eq!` → `Result` (propagates error instead of panic)
- `embed_batch` validates tensor shape from ONNX model output

**Platform (1 fix)**
- Origin path normalization to forward slashes (Windows compatibility)
- HNSW save cross-device rename fallback (Docker overlayfs, NFS)

## Test plan

- [x] `cargo build --features gpu-search` — 0 warnings
- [x] `cargo clippy --features gpu-search -- -D warnings` — clean
- [x] `cargo test --features gpu-search --lib` — 310 passed
- [x] `cargo test --features gpu-search --test '*'` — 192 passed
- [x] Fresh-eyes review — 0 issues found
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
