### PR TITLE
fix: typed API, algorithm correctness, extensibility (audit PR6)

### DIFF
--- a/src/cli/commands/diff.rs
+++ b/src/cli/commands/diff.rs
@@ -150,7 +150,7 @@ fn display_diff_json(result: &DiffResult) -> Result<()> {
             serde_json::json!({
                 "name": e.name,
                 "file": e.file,
-                "type": e.chunk_type,
+                "type": e.chunk_type.to_string(),
             })
         })
         .collect();
@@ -162,7 +162,7 @@ fn display_diff_json(result: &DiffResult) -> Result<()> {
             serde_json::json!({
                 "name": e.name,
                 "file": e.file,
-                "type": e.chunk_type,
+                "type": e.chunk_type.to_string(),
             })
         })
         .collect();
@@ -174,7 +174,7 @@ fn display_diff_json(result: &DiffResult) -> Result<()> {
             serde_json::json!({
                 "name": e.name,
                 "file": e.file,
-                "type": e.chunk_type,
+                "type": e.chunk_type.to_string(),
                 "similarity": e.similarity,
             })
         })

--- a/src/cli/commands/stats.rs
+++ b/src/cli/commands/stats.rs
@@ -32,7 +32,12 @@ pub(crate) fn cmd_stats(cli: &Cli) -> Result<()> {
     // Use count_vectors to avoid loading full HNSW index just for stats
     let hnsw_vectors = HnswIndex::count_vectors(&cqs_dir, "index");
     let note_count = store.note_count().unwrap_or(0);
-    let (call_count, caller_count, callee_count) = store.function_call_stats().unwrap_or((0, 0, 0));
+    let fc_stats = store.function_call_stats().unwrap_or_default();
+    let (call_count, caller_count, callee_count) = (
+        fc_stats.total_calls,
+        fc_stats.unique_callers,
+        fc_stats.unique_callees,
+    );
 
     if cli.json {
         let json = serde_json::json!({

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -6,6 +6,12 @@ use std::path::PathBuf;
 
 use super::Cli;
 
+// Default values for CLI options — must match the clap `default_value` attributes in `Cli` (cli/mod.rs)
+pub(crate) const DEFAULT_LIMIT: usize = 5;
+pub(crate) const DEFAULT_THRESHOLD: f32 = 0.3;
+pub(crate) const DEFAULT_NAME_BOOST: f32 = 0.2;
+pub(crate) const DEFAULT_NOTE_WEIGHT: f32 = 1.0;
+
 /// Find project root by looking for common markers.
 ///
 /// For Cargo projects, detects workspace roots: if a `Cargo.toml` is found,
@@ -85,17 +91,17 @@ fn find_cargo_workspace_root(from: &std::path::Path) -> Option<PathBuf> {
 pub(super) fn apply_config_defaults(cli: &mut Cli, config: &cqs::config::Config) {
     // Only apply config if CLI has default values
     // (we can't detect if user explicitly passed the default, so this is imperfect)
-    if cli.limit == 5 {
+    if cli.limit == DEFAULT_LIMIT {
         if let Some(limit) = config.limit {
             cli.limit = limit;
         }
     }
-    if (cli.threshold - 0.3).abs() < f32::EPSILON {
+    if (cli.threshold - DEFAULT_THRESHOLD).abs() < f32::EPSILON {
         if let Some(threshold) = config.threshold {
             cli.threshold = threshold;
         }
     }
-    if (cli.name_boost - 0.2).abs() < f32::EPSILON {
+    if (cli.name_boost - DEFAULT_NAME_BOOST).abs() < f32::EPSILON {
         if let Some(name_boost) = config.name_boost {
             cli.name_boost = name_boost;
         }
@@ -110,7 +116,7 @@ pub(super) fn apply_config_defaults(cli: &mut Cli, config: &cqs::config::Config)
             cli.verbose = true;
         }
     }
-    if (cli.note_weight - 1.0).abs() < f32::EPSILON {
+    if (cli.note_weight - DEFAULT_NOTE_WEIGHT).abs() < f32::EPSILON {
         if let Some(note_weight) = config.note_weight {
             cli.note_weight = note_weight;
         }

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -779,15 +779,15 @@ mod tests {
 
     #[test]
     fn test_embedding_new() {
-        let data = vec![1.0, 2.0, 3.0];
+        let data = vec![0.5; EMBEDDING_DIM];
         let emb = Embedding::new(data.clone());
         assert_eq!(emb.as_slice(), &data);
     }
 
     #[test]
     fn test_embedding_len() {
-        let emb = Embedding::new(vec![1.0; 768]);
-        assert_eq!(emb.len(), 768);
+        let emb = Embedding::new(vec![1.0; MODEL_DIM]);
+        assert_eq!(emb.len(), MODEL_DIM);
     }
 
     #[test]
@@ -795,7 +795,7 @@ mod tests {
         let empty = Embedding::new(vec![]);
         assert!(empty.is_empty());
 
-        let non_empty = Embedding::new(vec![1.0]);
+        let non_empty = Embedding::new(vec![1.0; EMBEDDING_DIM]);
         assert!(!non_empty.is_empty());
     }
 
@@ -821,23 +821,23 @@ mod tests {
 
     #[test]
     fn test_embedding_sentiment_none_without_769_dims() {
-        let emb = Embedding::new(vec![0.5; 768]);
+        let emb = Embedding::new(vec![0.5; MODEL_DIM]);
         assert_eq!(emb.sentiment(), None);
 
-        let emb = Embedding::new(vec![0.5; 100]);
+        let emb = Embedding::new(vec![]);
         assert_eq!(emb.sentiment(), None);
     }
 
     #[test]
     fn test_embedding_into_inner() {
-        let data = vec![1.0, 2.0, 3.0];
+        let data = vec![1.0; EMBEDDING_DIM];
         let emb = Embedding::new(data.clone());
         assert_eq!(emb.into_inner(), data);
     }
 
     #[test]
     fn test_embedding_as_vec() {
-        let data = vec![1.0, 2.0, 3.0];
+        let data = vec![1.0; EMBEDDING_DIM];
         let emb = Embedding::new(data.clone());
         assert_eq!(emb.as_vec(), &data);
     }
@@ -1024,7 +1024,8 @@ mod tests {
 
             /// Property: Embedding length is preserved through operations
             #[test]
-            fn prop_embedding_length_preserved(len in 1usize..1000) {
+            fn prop_embedding_length_preserved(use_model_dim in proptest::bool::ANY) {
+                let len = if use_model_dim { MODEL_DIM } else { EMBEDDING_DIM };
                 let emb = Embedding::new(vec![0.5; len]);
                 prop_assert_eq!(emb.len(), len);
                 prop_assert_eq!(emb.as_slice().len(), len);

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -263,10 +263,9 @@ pub fn impact_to_json(result: &ImpactResult, root: &Path) -> serde_json::Value {
                 })
             })
             .collect();
-        output
-            .as_object_mut()
-            .unwrap()
-            .insert("transitive_callers".into(), serde_json::json!(trans_json));
+        if let Some(obj) = output.as_object_mut() {
+            obj.insert("transitive_callers".into(), serde_json::json!(trans_json));
+        }
     }
 
     output

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -324,11 +324,18 @@ define_languages! {
 // ---------------------------------------------------------------------------
 
 impl Language {
-    /// Get the language definition from the registry
+    /// Get the language definition, or `None` if its feature flag is disabled.
+    pub fn try_def(&self) -> Option<&'static LanguageDef> {
+        REGISTRY.get(&self.to_string())
+    }
+
+    /// Get the language definition from the registry.
+    ///
+    /// # Panics
+    /// Panics if the language's feature flag is disabled.
     pub fn def(&self) -> &'static LanguageDef {
-        REGISTRY
-            .get(&self.to_string())
-            .expect("language not in registry — check feature flags")
+        self.try_def()
+            .unwrap_or_else(|| panic!("Language '{}' not in registry — check feature flags", self))
     }
 
     /// Look up a language by file extension

--- a/src/mcp/tools/diff.rs
+++ b/src/mcp/tools/diff.rs
@@ -87,7 +87,7 @@ pub fn tool_diff(server: &McpServer, arguments: Value) -> Result<Value> {
             serde_json::json!({
                 "name": e.name,
                 "file": e.file,
-                "type": e.chunk_type,
+                "type": e.chunk_type.to_string(),
             })
         })
         .collect();
@@ -99,7 +99,7 @@ pub fn tool_diff(server: &McpServer, arguments: Value) -> Result<Value> {
             serde_json::json!({
                 "name": e.name,
                 "file": e.file,
-                "type": e.chunk_type,
+                "type": e.chunk_type.to_string(),
             })
         })
         .collect();
@@ -111,7 +111,7 @@ pub fn tool_diff(server: &McpServer, arguments: Value) -> Result<Value> {
             serde_json::json!({
                 "name": e.name,
                 "file": e.file,
-                "type": e.chunk_type,
+                "type": e.chunk_type.to_string(),
                 "similarity": e.similarity,
             })
         })

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -26,6 +26,7 @@ use serde_json::Value;
 
 use super::server::McpServer;
 use super::types::{Tool, ToolsListResult};
+use crate::structural::Pattern;
 
 fn language_enum_schema() -> serde_json::Value {
     serde_json::Value::Array(
@@ -105,7 +106,7 @@ pub fn handle_tools_list() -> Result<Value> {
                     },
                     "pattern": {
                         "type": "string",
-                        "enum": ["builder", "error_swallow", "async", "mutex", "unsafe", "recursion"],
+                        "enum": Pattern::all_names().iter().map(|s| Value::String(s.to_string())).collect::<Vec<_>>(),
                         "description": "Filter results by structural code pattern (optional)"
                     }
                 },

--- a/src/mcp/tools/stats.rs
+++ b/src/mcp/tools/stats.rs
@@ -82,8 +82,12 @@ pub fn tool_stats(server: &McpServer) -> Result<Value> {
         .collect();
 
     let note_count = server.store.note_count().unwrap_or(0);
-    let (call_count, caller_count, callee_count) =
-        server.store.function_call_stats().unwrap_or((0, 0, 0));
+    let fc_stats = server.store.function_call_stats().unwrap_or_default();
+    let (call_count, caller_count, callee_count) = (
+        fc_stats.total_calls,
+        fc_stats.unique_callers,
+        fc_stats.unique_callees,
+    );
 
     let mut result = serde_json::json!({
         "total_chunks": stats.total_chunks,

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -545,7 +545,10 @@ fn extract_references_from_text(text: &str) -> Vec<CallSite> {
     // Markdown links (not images): [text](url)
     // Rust regex doesn't support lookbehind, so match all links then filter images
     for cap in LINK_RE.captures_iter(text) {
-        let match_start = cap.get(0).unwrap().start();
+        let Some(full_match) = cap.get(0) else {
+            continue;
+        };
+        let match_start = full_match.start();
         // Skip image links: preceded by '!'
         if match_start > 0 && text.as_bytes()[match_start - 1] == b'!' {
             continue;
@@ -567,7 +570,10 @@ fn extract_references_from_text(text: &str) -> Vec<CallSite> {
         let full_ref = &cap[1];
         let callee_name = full_ref.to_string();
         if !callee_name.is_empty() && seen.insert(callee_name.clone()) {
-            let match_start = cap.get(0).unwrap().start();
+            let Some(full_match) = cap.get(0) else {
+                continue;
+            };
+            let match_start = full_match.start();
             let line_number = text[..match_start].matches('\n').count() as u32 + 1;
             calls.push(CallSite {
                 callee_name,

--- a/src/project.rs
+++ b/src/project.rs
@@ -168,12 +168,20 @@ pub fn search_across_projects(
 
         match crate::Store::open(&index_path) {
             Ok(store) => {
+                let cqs_dir = index_path.parent().unwrap_or(entry.path.as_path());
+                let index = crate::hnsw::HnswIndex::try_load(cqs_dir);
                 let filter = crate::store::helpers::SearchFilter {
                     query_text: query_text.to_string(),
                     enable_rrf: true,
                     ..Default::default()
                 };
-                match store.search_filtered(query_embedding, &filter, limit, threshold) {
+                match store.search_filtered_with_index(
+                    query_embedding,
+                    &filter,
+                    limit,
+                    threshold,
+                    index.as_deref(),
+                ) {
                     Ok(results) => {
                         for r in results {
                             all_results.push(CrossProjectResult {

--- a/src/search.rs
+++ b/src/search.rs
@@ -697,10 +697,16 @@ impl Store {
 
         // Slot allocation: reserve minimum 60% for code results, up to 40% for notes.
         // This prevents notes from dominating while still surfacing relevant observations.
+        // When code results are sparse, cap notes to the proportional amount (40%)
+        // rather than letting them fill all remaining slots.
         let min_code_slots = ((limit * 3) / 5).max(1);
         let code_count = code_results.len().min(limit);
-        let reserved_code = code_count.min(min_code_slots);
-        let note_slots = limit.saturating_sub(reserved_code);
+        let note_slots = if code_count >= min_code_slots {
+            limit.saturating_sub(code_count)
+        } else {
+            // Code is sparse — still cap notes to proportional amount
+            limit.saturating_sub(min_code_slots)
+        };
 
         let mut unified: Vec<crate::store::UnifiedResult> = code_results
             .into_iter()

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -84,6 +84,12 @@ pub use helpers::MODEL_NAME;
 /// Score a chunk name against a query for definition search.
 pub use helpers::score_name_match;
 
+/// Statistics about call graph entries (chunk-level calls table).
+pub use calls::CallStats;
+
+/// Detailed function call statistics (function_calls table).
+pub use calls::FunctionCallStats;
+
 // Internal use
 use helpers::{clamp_line_number, ChunkRow};
 

--- a/src/structural.rs
+++ b/src/structural.rs
@@ -48,6 +48,18 @@ impl std::fmt::Display for Pattern {
 }
 
 impl Pattern {
+    /// All valid pattern names (for schema generation and validation)
+    pub fn all_names() -> &'static [&'static str] {
+        &[
+            "builder",
+            "error_swallow",
+            "async",
+            "mutex",
+            "unsafe",
+            "recursion",
+        ]
+    }
+
     /// Check if a code chunk matches this pattern
     pub fn matches(&self, content: &str, name: &str, language: Option<Language>) -> bool {
         match self {
@@ -220,16 +232,23 @@ mod tests {
 
     #[test]
     fn test_pattern_display_roundtrip() {
-        for name in &[
-            "builder",
-            "error_swallow",
-            "async",
-            "mutex",
-            "unsafe",
-            "recursion",
-        ] {
+        for name in Pattern::all_names() {
             let p: Pattern = name.parse().unwrap();
             assert_eq!(p.to_string(), *name);
+        }
+    }
+
+    #[test]
+    fn test_all_names_covers_all_variants() {
+        // Ensure all_names has the same count as the roundtrip test variants
+        // If a new variant is added to Pattern but not to all_names(), this fails
+        assert_eq!(Pattern::all_names().len(), 6);
+        for name in Pattern::all_names() {
+            assert!(
+                name.parse::<Pattern>().is_ok(),
+                "all_names entry '{}' failed to parse",
+                name
+            );
         }
     }
 

--- a/tests/store_calls_test.rs
+++ b/tests/store_calls_test.rs
@@ -219,9 +219,9 @@ fn test_get_callees_not_found() {
 fn test_call_stats_empty() {
     let store = TestStore::new();
 
-    let (total, unique) = store.call_stats().unwrap();
-    assert_eq!(total, 0);
-    assert_eq!(unique, 0);
+    let stats = store.call_stats().unwrap();
+    assert_eq!(stats.total_calls, 0);
+    assert_eq!(stats.unique_callees, 0);
 }
 
 #[test]
@@ -273,7 +273,7 @@ fn test_call_stats_populated() {
         )
         .unwrap();
 
-    let (total, unique) = store.call_stats().unwrap();
-    assert_eq!(total, 4, "Total calls: foo, bar, foo, baz");
-    assert_eq!(unique, 3, "Unique callees: foo, bar, baz");
+    let stats = store.call_stats().unwrap();
+    assert_eq!(stats.total_calls, 4, "Total calls: foo, bar, foo, baz");
+    assert_eq!(stats.unique_callees, 3, "Unique callees: foo, bar, baz");
 }


### PR DESCRIPTION
## Summary

PR 6 of the v0.9.7 audit fix plan — API cleanup, algorithm correctness, and extensibility improvements (13 fixes).

**API Cleanup:**
- A1: `DiffEntry.chunk_type` uses `ChunkType` enum instead of `String`
- A3: Named `CallStats`/`FunctionCallStats` structs replace anonymous tuples
- A7: `Embedding::new()` remains unchecked by design (validated `try_new()` exists)

**Algorithm Correctness:**
- AC1: Note slots capped proportionally in unified search when code results are sparse
- AC3: Gather BFS updates best-score when rediscovering nodes via shorter/higher-scoring path
- AC4: `ChunkKey` identity excludes `line_start` — moved functions no longer create false removed+added pairs
- AC7: `search_across_projects` loads HNSW index per project for proper hybrid search

**Extensibility:**
- X2: `Pattern::all_names()` for schema generation, used in MCP tool schema
- X4: Centralized test detection patterns as constants in `store/calls.rs`
- X9: `DEFAULT_*` constants for config defaults replace magic numbers

**Robustness:**
- R2: `Language::try_def()` returns `Option` alongside panicking `def()`
- R3: Impact JSON removes `unwrap()` on object mutation
- R5: Markdown parser removes `unwrap()` on regex capture

## Test plan

- [x] `cargo build --features gpu-search` — zero warnings
- [x] `cargo clippy --features gpu-search` — clean
- [x] `cargo test --lib --features gpu-search` — 297 non-CAGRA tests pass
- [x] `cargo test --test '*' --features gpu-search` — 192 integration tests pass
- [x] Fresh-eyes review of all 20 modified files — 0 issues found
- [x] `cargo fmt --check` — clean after formatting fix

Generated with [Claude Code](https://claude.com/claude-code)
