### PR TITLE
fix: P3 polish — data safety, algorithm, observability, platform (audit PR7a)

### DIFF
--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -29,7 +29,12 @@ fn process_exists(pid: u32) -> bool {
     Command::new("tasklist")
         .args(["/FI", &format!("PID eq {}", pid), "/NH"])
         .output()
-        .map(|o| String::from_utf8_lossy(&o.stdout).contains(&pid.to_string()))
+        .map(|o| {
+            let output = String::from_utf8_lossy(&o.stdout);
+            // tasklist /FI "PID eq N" does exact filtering.
+            // "INFO:" appears when no process matches; its absence means a match.
+            !output.contains("INFO:")
+        })
         .unwrap_or(false)
 }
 

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -389,8 +389,10 @@ impl Embedder {
                 poisoned.into_inner()
             });
             if let Some(cached) = cache.get(text) {
+                tracing::trace!(query = text, "Embedding cache hit");
                 return Ok(cached.clone());
             }
+            tracing::trace!(query = text, "Embedding cache miss");
         }
 
         // Compute embedding (outside lock - allows parallel queries)
@@ -410,6 +412,7 @@ impl Embedder {
                 poisoned.into_inner()
             });
             cache.put(text.to_string(), embedding.clone());
+            tracing::trace!(query = text, cache_len = cache.len(), "Embedding cached");
         }
 
         Ok(embedding)

--- a/src/gather.rs
+++ b/src/gather.rs
@@ -25,6 +25,33 @@ pub struct GatherOptions {
     pub decay_factor: f32,
 }
 
+impl GatherOptions {
+    pub fn with_expand_depth(mut self, depth: usize) -> Self {
+        self.expand_depth = depth;
+        self
+    }
+    pub fn with_direction(mut self, direction: GatherDirection) -> Self {
+        self.direction = direction;
+        self
+    }
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = limit;
+        self
+    }
+    pub fn with_seed_limit(mut self, limit: usize) -> Self {
+        self.seed_limit = limit;
+        self
+    }
+    pub fn with_seed_threshold(mut self, threshold: f32) -> Self {
+        self.seed_threshold = threshold;
+        self
+    }
+    pub fn with_decay_factor(mut self, factor: f32) -> Self {
+        self.decay_factor = factor;
+        self
+    }
+}
+
 impl Default for GatherOptions {
     fn default() -> Self {
         Self {
@@ -350,5 +377,22 @@ mod tests {
         let callers = get_neighbors(&graph, "D", GatherDirection::Callers);
         assert_eq!(callers.len(), 1);
         assert_eq!(callers[0], "B");
+    }
+
+    #[test]
+    fn test_gather_options_builder() {
+        let opts = GatherOptions::default()
+            .with_expand_depth(3)
+            .with_direction(GatherDirection::Callers)
+            .with_limit(20)
+            .with_seed_limit(10)
+            .with_seed_threshold(0.5)
+            .with_decay_factor(0.9);
+        assert_eq!(opts.expand_depth, 3);
+        assert!(matches!(opts.direction, GatherDirection::Callers));
+        assert_eq!(opts.limit, 20);
+        assert_eq!(opts.seed_limit, 10);
+        assert!((opts.seed_threshold - 0.5).abs() < f32::EPSILON);
+        assert!((opts.decay_factor - 0.9).abs() < f32::EPSILON);
     }
 }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -90,6 +90,9 @@ pub fn search_reference(
     limit: usize,
     threshold: f32,
 ) -> anyhow::Result<Vec<SearchResult>> {
+    let _span =
+        tracing::info_span!("search_reference", name = %ref_idx.name, weight = ref_idx.weight)
+            .entered();
     let mut results = ref_idx.store.search_filtered_with_index(
         query_embedding,
         filter,
@@ -113,6 +116,9 @@ pub fn search_reference_by_name(
     limit: usize,
     threshold: f32,
 ) -> anyhow::Result<Vec<SearchResult>> {
+    let _span =
+        tracing::info_span!("search_reference_by_name", ref_name = %ref_idx.name, query = name)
+            .entered();
     let mut results = ref_idx.store.search_by_name(name, limit)?;
     results.retain(|r| r.score * ref_idx.weight >= threshold);
     for r in &mut results {

--- a/src/search.rs
+++ b/src/search.rs
@@ -285,7 +285,7 @@ impl BoundedScoreHeap {
 
         // At capacity - only insert if better than current minimum
         if let Some(Reverse((OrderedFloat(min_score), _))) = self.heap.peek() {
-            if score > *min_score {
+            if score >= *min_score {
                 self.heap.pop();
                 self.heap.push(Reverse((OrderedFloat(score), id)));
             }
@@ -850,5 +850,19 @@ mod tests {
     #[test]
     fn test_extract_file_no_colons() {
         assert_eq!(extract_file_from_chunk_id("justanid"), "justanid");
+    }
+
+    // ===== BoundedScoreHeap tests =====
+
+    #[test]
+    fn test_bounded_heap_equal_scores() {
+        let mut heap = BoundedScoreHeap::new(2);
+        heap.push("a".to_string(), 0.5);
+        heap.push("b".to_string(), 0.5);
+        heap.push("c".to_string(), 0.5);
+        let results = heap.into_sorted_vec();
+        assert_eq!(results.len(), 2);
+        // c should replace one of the earlier entries (no iteration-order bias)
+        assert!(results.iter().any(|(id, _)| id == "c"));
     }
 }

--- a/src/store/calls.rs
+++ b/src/store/calls.rs
@@ -404,11 +404,11 @@ impl Store {
                 std::collections::HashMap::new();
 
             for (caller, callee) in rows {
-                forward
-                    .entry(caller.clone())
+                reverse
+                    .entry(callee.clone())
                     .or_default()
-                    .push(callee.clone());
-                reverse.entry(callee).or_default().push(caller);
+                    .push(caller.clone());
+                forward.entry(caller).or_default().push(callee);
             }
 
             Ok(CallGraph { forward, reverse })

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -27,8 +27,11 @@ use super::helpers::CURRENT_SCHEMA_VERSION;
 
 /// Run all migrations from stored version to current version
 pub async fn migrate(pool: &SqlitePool, from: i32, to: i32) -> Result<(), StoreError> {
-    if from >= to {
-        return Ok(()); // Nothing to do
+    if from == to {
+        return Ok(()); // Already at target version
+    }
+    if from > to {
+        return Err(StoreError::SchemaNewerThanCq(from));
     }
 
     tracing::info!(


### PR DESCRIPTION
## Summary

13 P3 fixes from v0.9.7 audit — data safety, algorithm correctness, observability, and platform improvements.

**Data Safety:**
- DS1: `Store::init()` DDL+metadata wrapped in single transaction (crash-safe)
- DS10: Schema migration returns error on downgrade instead of silent Ok
- DS13: WAL checkpoint failure in Drop logged at `warn` (was `debug`)

**Algorithm/API:**
- AC6: Documented `note_stats()` discrete sentiment thresholds + validation test
- AC8: `BoundedScoreHeap::push()` uses `>=` instead of `>` (fixes equal-score bias)
- A10: `GatherOptions` builder methods (`with_expand_depth`, etc.)
- RM11: `all_chunk_identities_filtered(language)` pushes WHERE into SQL

**Performance:**
- P12: `get_call_graph()` reduces string cloning (1 clone/row saved)

**Observability:**
- O10: Per-reference `tracing::info_span!` in `search_reference`/`search_reference_by_name`
- O11: Embedding query cache hit/miss/insert at `trace` level

**Platform:**
- PB7: WSL detection reads `/proc/version` (not just `/mnt/` path prefix)
- PB8: `project.rs` tests use `tempdir()` instead of hardcoded Unix paths
- S7: Windows `process_exists()` checks tasklist "INFO:" absence (no PID substring match)

## Test plan

- [x] `cargo build --features gpu-search` — clean
- [x] `cargo test --features gpu-search` — 314 pass (1 pre-existing HNSW flake)
- [x] `cargo clippy --features gpu-search` — clean
- [x] `cargo fmt --check` — clean
- [x] Fresh-eyes review of all 13 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
