### PR TITLE
fix: P3 polish — tests, perf, security, API docs (audit PR7b)

### DIFF
--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -28,6 +28,9 @@ pub enum StoreError {
     #[error("System time error: file mtime before Unix epoch")]
     SystemTime,
     #[error("Runtime error: {0}")]
+    /// Catch-all for errors that don't fit other variants: tokio runtime init,
+    /// JSON serialization failures, and query resolution errors.
+    /// No caller currently matches on this variant specifically.
     Runtime(String),
     #[error("Schema version mismatch in {0}: index is v{1}, cqs expects v{2}. Run 'cqs index --force' to rebuild.")]
     SchemaMismatch(String, i32, i32),
@@ -352,10 +355,15 @@ impl UnifiedResult {
     }
 }
 
-/// Filter and scoring options for search
+/// Filter and scoring options for search.
+///
+/// Fields are public for direct construction via struct literals.
+/// Builder methods ([`SearchFilter::new()`], [`SearchFilter::with_query()`])
+/// are provided as convenience helpers for common patterns — both styles
+/// are supported and equivalent.
 ///
 /// All fields are optional. Unset filters match all chunks.
-/// Use `validate()` to check constraints before searching.
+/// Use [`SearchFilter::validate()`] to check constraints before searching.
 pub struct SearchFilter {
     /// Filter by programming language(s)
     pub languages: Option<Vec<Language>>,

--- a/tests/mcp_test.rs
+++ b/tests/mcp_test.rs
@@ -458,7 +458,13 @@ fn test_empty_method() {
     let request = make_request("", None);
     let response = server.handle_request(request);
 
-    assert!(response.error.is_some());
+    assert!(response.error.is_some(), "Empty method should return error");
+    let error = response.error.unwrap();
+    assert!(
+        error.message.contains("Unknown method"),
+        "Error should mention unknown method: {}",
+        error.message
+    );
 }
 
 #[test]
@@ -898,6 +904,12 @@ fn test_cqs_search_missing_query() {
         response.error.is_some(),
         "Missing query should return error"
     );
+    let error = response.error.unwrap();
+    assert!(
+        error.message.contains("query") || error.message.contains("missing field"),
+        "Error should mention missing query: {}",
+        error.message
+    );
 }
 
 #[test]
@@ -983,6 +995,12 @@ fn test_cqs_add_note_empty_text() {
     let response = server.handle_request(request);
 
     assert!(response.error.is_some(), "Empty text should return error");
+    let error = response.error.unwrap();
+    assert!(
+        error.message.contains("empty") || error.message.contains("text"),
+        "Error should mention empty text: {}",
+        error.message
+    );
 }
 
 #[test]
@@ -1000,6 +1018,12 @@ fn test_cqs_add_note_missing_text() {
     let response = server.handle_request(request);
 
     assert!(response.error.is_some(), "Missing text should return error");
+    let error = response.error.unwrap();
+    assert!(
+        error.message.contains("Missing") || error.message.contains("text"),
+        "Error should mention missing text: {}",
+        error.message
+    );
 }
 
 #[test]
@@ -1156,6 +1180,12 @@ fn test_cqs_callers_missing_name() {
     let response = server.handle_request(request);
 
     assert!(response.error.is_some(), "Missing name should return error");
+    let error = response.error.unwrap();
+    assert!(
+        error.message.contains("Missing") || error.message.contains("name"),
+        "Error should mention missing name: {}",
+        error.message
+    );
 }
 
 #[test]
@@ -1202,6 +1232,12 @@ fn test_cqs_callees_missing_name() {
     let response = server.handle_request(request);
 
     assert!(response.error.is_some(), "Missing name should return error");
+    let error = response.error.unwrap();
+    assert!(
+        error.message.contains("Missing") || error.message.contains("name"),
+        "Error should mention missing name: {}",
+        error.message
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

14 P3 fixes from v0.9.7 audit — test coverage, performance, security defense-in-depth, and API documentation.

**Test Coverage (5 new test suites):**
- TC7: Note round-trip test (insert, retrieve, verify text/sentiment/mentions)
- TC10: `cmd_gc` CLI tests (requires-index, JSON output, prune stale chunks)
- TC11: `cmd_dead` CLI tests (requires-index, JSON structure, --include-pub)
- TC13: `find_project_root` unit tests (.git marker, Cargo.toml, walk-up, workspace)
- TC15: MCP error assertions now check message content, not just `is_some()`

**Performance (3 fixes):**
- P6: Pre-compute `normalize_for_fts` values before SQL bind (was called 4x per chunk)
- P9: Pipeline writer consumes chunks via `into_iter()` instead of clone
- DS9: `embedding_batches` uses cursor-based pagination (`WHERE rowid > N`) instead of LIMIT/OFFSET

**Security:**
- S1: `sanitize_fts_query()` strips FTS5 special chars and boolean operators before MATCH

**API/Documentation (3 verified, 2 documented):**
- A6: `SearchFilter` doc comment explains pub fields + builder design choice
- EH12: `StoreError::Runtime` doc comment explains catch-all role
- A8: `serve_stdio`/`serve_http` already consistent (verified)
- S8: HNSW ID map already has 500MB file size limit (verified)
- RM10: CAGRA/HNSW overlap lives in `cagra.rs`/`index.rs`, not HNSW files

## Test plan

- [x] `cargo build --features gpu-search` — clean
- [x] `cargo test --features gpu-search` — 315 lib + 150 integration pass
- [x] `cargo clippy --features gpu-search` — clean
- [x] `cargo fmt --check` — clean
- [x] Fresh-eyes review of all 8 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
