### PR TITLE
chore: update tears after PR7a/PR7b fixes

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -5,22 +5,22 @@
 **v0.9.7 audit fix session.** 2026-02-10.
 
 ### Active
-- Next: PR7 (P3 Polish) — 45 fixes: test coverage, observability, resource management, remaining P3
+- Next: PR7c (remaining P3) or PR8 (P4 issues) — 18 unfixed P3 remain
+- Remaining P3: TC2-TC5, TC8, TC9, TC14 (test coverage), A2, A9 (API), P8, P11 (perf), RM1, RM3, RM4, RM8 (resources), DS12 (data safety), X7 (extensibility)
 
 ### Completed This Session
+- PR7b (P3 batch 2): merged as PR #341 — 14 fixes
+  - Test coverage: TC7, TC10, TC11, TC13, TC15
+  - Performance: P6 (FTS dedup), P9 (pipeline clone), DS9 (cursor pagination)
+  - Security: S1 (FTS sanitization)
+  - API docs: A6, A8 (verified), EH12, S8 (verified), RM10 (documented)
+- PR7a (P3 batch 1): merged as PR #340 — 13 fixes
+  - Data safety: DS1, DS10, DS13
+  - Algorithm: AC8, AC6, A10, RM11
+  - Perf: P12. Observability: O10, O11
+  - Platform: PB7, S7, PB8
 - PR6 (API+Algorithm): merged as PR #338 — 13 fixes
-  - DiffEntry typed fields, ChunkKey excludes line_start (A1, AC4)
-  - Note slot capping, gather BFS best-score, search_across_projects HNSW (AC1, AC3, AC7)
-  - Named CallStats structs, test pattern constants (A3, X4)
-  - Language::try_def(), Pattern::all_names(), config defaults (R2, X2, X9)
-  - Impact/markdown unwrap removal (R3, R5)
 - PR5 (Safety+Security): merged as PR #337 — 14 fixes
-  - Config/project file locking, atomic writes (DS4/S9, DS5)
-  - Watch/pipeline atomic operations (DS3, DS2)
-  - Path normalization, traversal validation (PB1/PB2/DS11, S2)
-  - Notes locked read, error sanitization (DS7, S3, S4, S5/S6)
-  - HNSW/embedder assert→Result, tensor validation (R9, R10, R6)
-  - HNSW cross-device rename fallback (PB3)
 
 ### Completed Prior Sessions
 - PR4 (Performance): merged as PR #336 — 10 fixes

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -225,8 +225,8 @@ After de-duplication: **~140 unique findings**
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 1 | Reference search no per-reference timing | O10 | medium | |
-| 2 | Embedding cache hit/miss not observable | O11 | medium | |
+| 1 | Reference search no per-reference timing | O10 | medium | PR #340 |
+| 2 | Embedding cache hit/miss not observable | O11 | medium | PR #340 |
 
 ### Test Coverage
 
@@ -238,11 +238,11 @@ After de-duplication: **~140 unique findings**
 | 6 | `search_across_projects` zero tests | TC5 | medium | |
 | 7 | `store/chunks.rs` 817 lines no inline tests | TC8 | medium | |
 | 8 | `reference.rs` load/search no direct tests | TC9 | medium | |
-| 9 | `cmd_gc` zero tests | TC10 | easy | |
-| 10 | `cmd_dead` no CLI integration test | TC11 | easy | |
-| 11 | MCP error assertions only check `is_some()` | TC15 | easy | |
-| 12 | Note round-trip test missing | TC7 | easy | |
-| 13 | `find_project_root` no tests | TC13 | easy | |
+| 9 | `cmd_gc` zero tests | TC10 | easy | PR #341 |
+| 10 | `cmd_dead` no CLI integration test | TC11 | easy | PR #341 |
+| 11 | MCP error assertions only check `is_some()` | TC15 | easy | PR #341 |
+| 12 | Note round-trip test missing | TC7 | easy | PR #341 |
+| 13 | `find_project_root` no tests | TC13 | easy | PR #341 |
 | 14 | 127 dead functions, most untested | TC14 | medium | |
 
 ### API Design
@@ -250,21 +250,21 @@ After de-duplication: **~140 unique findings**
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
 | 15 | Asymmetric callers/callees return types | A2 | medium | |
-| 16 | `SearchFilter` mixed encapsulation (pub fields + builder) | A6 | easy | |
-| 17 | `serve_stdio`/`serve_http` inconsistent path param types | A8 | easy | |
+| 16 | `SearchFilter` mixed encapsulation (pub fields + builder) | A6 | easy | PR #341 |
+| 17 | `serve_stdio`/`serve_http` inconsistent path param types | A8 | easy | PR #341 (already consistent) |
 | 18 | Note/NoteEntry/NoteSummary naming overload | A9 | medium | |
-| 19 | `GatherOptions` lacks builder methods | A10 | easy | |
+| 19 | `GatherOptions` lacks builder methods | A10 | easy | PR #340 |
 
 ### Performance
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 20 | `normalize_for_fts` called 4x per chunk | P6 | easy | |
-| 21 | Diff loads all identities even with language filter | P5 | medium | |
+| 20 | `normalize_for_fts` called 4x per chunk | P6 | easy | PR #341 |
+| 21 | Diff loads all identities even with language filter | P5 | medium | PR #340 (RM11) |
 | 22 | `search_across_projects` new Store per project per search | P8 | medium | |
 | 23 | Gather loads entire call graph every invocation | P11 | medium | |
-| 24 | Pipeline writer clones chunk+embedding pairs | P9 | easy | |
-| 25 | `get_call_graph` clones all strings into both maps | P12 | easy | |
+| 24 | Pipeline writer clones chunk+embedding pairs | P9 | easy | PR #341 |
+| 25 | `get_call_graph` clones all strings into both maps | P12 | easy | PR #340 |
 
 ### Resource Management
 
@@ -274,33 +274,33 @@ After de-duplication: **~140 unique findings**
 | 27 | Reference hot-reload blocks search during WAL checkpoint | RM3 | medium | |
 | 28 | Each Store creates own tokio Runtime (7+ with refs) | RM4 | medium | |
 | 29 | Embedder ~500MB persists forever via OnceLock | RM8 | easy | |
-| 30 | HNSW+CAGRA held simultaneously during upgrade | RM10 | easy | |
-| 31 | `all_chunk_identities` loads full table no SQL filter | RM11 | easy | |
+| 30 | HNSW+CAGRA held simultaneously during upgrade | RM10 | easy | PR #341 (not in HNSW files) |
+| 31 | `all_chunk_identities` loads full table no SQL filter | RM11 | easy | PR #340 |
 
 ### Data Safety
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 32 | `embedding_batches` LIMIT/OFFSET unstable under writes | DS9 | medium | |
-| 33 | Store::init() DDL without transaction | DS1 | medium | |
-| 34 | WAL checkpoint failure silently returns Ok | DS13 | easy | |
+| 32 | `embedding_batches` LIMIT/OFFSET unstable under writes | DS9 | medium | PR #341 |
+| 33 | Store::init() DDL without transaction | DS1 | medium | PR #340 |
+| 34 | WAL checkpoint failure silently returns Ok | DS13 | easy | PR #340 |
 | 35 | No SQLite integrity check on open | DS12 | medium | |
-| 36 | Schema migration no downgrade guard | DS10 | medium | |
+| 36 | Schema migration no downgrade guard | DS10 | medium | PR #340 |
 
 ### Security
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 37 | FTS5 injection via double-quote escape | S1 | medium | |
-| 38 | HNSW ID map no size limit on deser | S8 | medium | |
-| 39 | Windows PID substring matching false positive | S7 | easy | |
+| 37 | FTS5 injection via double-quote escape | S1 | medium | PR #341 |
+| 38 | HNSW ID map no size limit on deser | S8 | medium | PR #341 (already guarded) |
+| 39 | Windows PID substring matching false positive | S7 | easy | PR #340 |
 
 ### Platform
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 40 | WSL detection heuristic only checks `/mnt/` | PB7 | easy | |
-| 41 | project.rs tests use Unix-only paths | PB8 | easy | |
+| 40 | WSL detection heuristic only checks `/mnt/` | PB7 | easy | PR #340 |
+| 41 | project.rs tests use Unix-only paths | PB8 | easy | PR #340 |
 
 ### Extensibility
 
@@ -312,9 +312,9 @@ After de-duplication: **~140 unique findings**
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 43 | `StoreError::Runtime` catch-all string variant | EH12 | medium | |
-| 44 | `note_stats` thresholds assume discrete sentiment, no DB constraint | AC6 | easy | |
-| 45 | `BoundedScoreHeap` drops equal-score newcomers (iteration-order bias) | AC8 | easy | |
+| 43 | `StoreError::Runtime` catch-all string variant | EH12 | medium | PR #341 |
+| 44 | `note_stats` thresholds assume discrete sentiment, no DB constraint | AC6 | easy | PR #340 |
+| 45 | `BoundedScoreHeap` drops equal-score newcomers (iteration-order bias) | AC8 | easy | PR #340 |
 
 **P3 Total: 45 findings**
 


### PR DESCRIPTION
Update PROJECT_CONTINUITY.md and audit-triage.md status columns after PR7a (#340) and PR7b (#341).
