### PR TITLE
fix: P3 polish — tests, integrity check, API docs, embedder lifecycle (audit PR7c)

### DIFF
--- a/src/gather.rs
+++ b/src/gather.rs
@@ -147,6 +147,10 @@ pub fn gather(
     }
 
     // 2. Load call graph for expansion
+    // NOTE: This loads the entire function_calls table into memory each call.
+    // Current callers (CLI, MCP) invoke gather() once per request so this is fine.
+    // If gather() is ever called in a loop, accept a pre-loaded &CallGraph parameter
+    // to avoid redundant loads.
     let graph = store.get_call_graph()?;
 
     // Seed names with their scores

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -46,6 +46,8 @@ pub enum StoreError {
         "Dimension mismatch: index has {0}-dim embeddings, current model expects {1}. Run 'cqs index --force' to rebuild."
     )]
     DimensionMismatch(u32, u32),
+    #[error("Database integrity check failed: {0}")]
+    Corruption(String),
 }
 
 /// Raw row from chunks table (crate-internal, used by search module)

--- a/tests/reference_test.rs
+++ b/tests/reference_test.rs
@@ -1,0 +1,235 @@
+//! Reference index tests (TC9)
+//!
+//! Tests for merge_results, search_reference, weight application,
+//! and reference name validation.
+
+mod common;
+
+use common::{mock_embedding, test_chunk, TestStore};
+use cqs::parser::{ChunkType, Language};
+use cqs::reference::{self, merge_results, ReferenceIndex};
+use cqs::store::{SearchFilter, SearchResult, UnifiedResult};
+use std::path::PathBuf;
+
+// ============ Helpers ============
+
+fn make_code_result(name: &str, score: f32) -> SearchResult {
+    SearchResult {
+        chunk: cqs::store::ChunkSummary {
+            id: format!("id-{}", name),
+            file: PathBuf::from(format!("src/{}.rs", name)),
+            language: Language::Rust,
+            chunk_type: ChunkType::Function,
+            name: name.to_string(),
+            signature: String::new(),
+            content: format!("fn {}() {{}}", name),
+            doc: None,
+            line_start: 1,
+            line_end: 1,
+        },
+        score,
+    }
+}
+
+/// Insert chunks with identical embeddings
+fn insert_chunks(store: &TestStore, chunks: &[cqs::Chunk], seed: f32) {
+    let emb = mock_embedding(seed);
+    let pairs: Vec<_> = chunks.iter().map(|c| (c.clone(), emb.clone())).collect();
+    store.upsert_chunks_batch(&pairs, Some(12345)).unwrap();
+}
+
+// ===== merge_results tests =====
+
+#[test]
+fn test_merge_results_interleaves_by_score() {
+    let primary = vec![
+        UnifiedResult::Code(make_code_result("p1", 0.95)),
+        UnifiedResult::Code(make_code_result("p2", 0.5)),
+    ];
+    let refs = vec![
+        (
+            "ref_a".to_string(),
+            vec![make_code_result("r1", 0.8), make_code_result("r2", 0.6)],
+        ),
+        ("ref_b".to_string(), vec![make_code_result("r3", 0.7)]),
+    ];
+
+    let merged = merge_results(primary, refs, 10);
+    assert_eq!(merged.len(), 5);
+
+    // Verify descending score order
+    for w in merged.windows(2) {
+        assert!(
+            w[0].result.score() >= w[1].result.score(),
+            "Scores should be descending: {} >= {}",
+            w[0].result.score(),
+            w[1].result.score()
+        );
+    }
+
+    // Verify source tags
+    assert!(merged[0].source.is_none()); // p1 at 0.95
+}
+
+#[test]
+fn test_merge_results_multiple_refs_tagged_correctly() {
+    let primary = vec![];
+    let refs = vec![
+        ("alpha".to_string(), vec![make_code_result("a1", 0.9)]),
+        ("beta".to_string(), vec![make_code_result("b1", 0.8)]),
+        ("gamma".to_string(), vec![make_code_result("g1", 0.7)]),
+    ];
+
+    let merged = merge_results(primary, refs, 10);
+    assert_eq!(merged.len(), 3);
+    assert_eq!(merged[0].source.as_deref(), Some("alpha"));
+    assert_eq!(merged[1].source.as_deref(), Some("beta"));
+    assert_eq!(merged[2].source.as_deref(), Some("gamma"));
+}
+
+#[test]
+fn test_merge_results_truncates_strictly() {
+    let primary: Vec<UnifiedResult> = (0..5)
+        .map(|i| UnifiedResult::Code(make_code_result(&format!("p{}", i), 0.9 - i as f32 * 0.1)))
+        .collect();
+    let refs = vec![(
+        "ref".to_string(),
+        (0..5)
+            .map(|i| make_code_result(&format!("r{}", i), 0.85 - i as f32 * 0.1))
+            .collect(),
+    )];
+
+    let merged = merge_results(primary, refs, 3);
+    assert_eq!(merged.len(), 3, "Should truncate to limit=3");
+}
+
+#[test]
+fn test_merge_results_empty_inputs() {
+    let primary: Vec<UnifiedResult> = vec![];
+    let refs: Vec<(String, Vec<SearchResult>)> = vec![];
+
+    let merged = merge_results(primary, refs, 10);
+    assert!(merged.is_empty());
+}
+
+// ===== search_reference tests =====
+
+#[test]
+fn test_search_reference_applies_weight() {
+    let store = TestStore::new();
+    let c1 = test_chunk("weighted_fn", "fn weighted_fn() { test }");
+    insert_chunks(&store, &[c1], 1.0);
+
+    let ref_store = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_idx = ReferenceIndex {
+        name: "test-ref".to_string(),
+        store: ref_store,
+        index: None,
+        weight: 0.7,
+    };
+
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter::default();
+
+    let results = reference::search_reference(&ref_idx, &query, &filter, 10, 0.0).unwrap();
+    assert!(!results.is_empty());
+
+    // All scores should be multiplied by weight
+    for r in &results {
+        assert!(
+            r.score <= 0.71,
+            "Score {} should be <= weight 0.7 (with rounding)",
+            r.score
+        );
+    }
+}
+
+#[test]
+fn test_search_reference_weight_filters_below_threshold() {
+    let store = TestStore::new();
+    let c1 = test_chunk("fn_a", "fn fn_a() { test }");
+    insert_chunks(&store, &[c1], 1.0);
+
+    let ref_store = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_idx = ReferenceIndex {
+        name: "test-ref".to_string(),
+        store: ref_store,
+        index: None,
+        weight: 0.5, // Low weight
+    };
+
+    let query = mock_embedding(1.0);
+    let filter = SearchFilter::default();
+
+    // With weight=0.5, max score is ~0.5. Threshold 0.8 should filter everything.
+    let results = reference::search_reference(&ref_idx, &query, &filter, 10, 0.8).unwrap();
+    assert!(
+        results.is_empty(),
+        "Weighted scores below threshold should be filtered"
+    );
+}
+
+#[test]
+fn test_search_reference_by_name_weight() {
+    let store = TestStore::new();
+    let c1 = test_chunk("lookup_fn", "fn lookup_fn() { lookup }");
+    insert_chunks(&store, &[c1], 1.0);
+
+    let ref_store = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_idx = ReferenceIndex {
+        name: "test-ref".to_string(),
+        store: ref_store,
+        index: None,
+        weight: 0.6,
+    };
+
+    let results = reference::search_reference_by_name(&ref_idx, "lookup_fn", 10, 0.0).unwrap();
+    assert!(!results.is_empty());
+
+    // Score should be scaled by weight
+    for r in &results {
+        assert!(
+            r.score <= 0.61,
+            "Name search score {} should be <= weight 0.6",
+            r.score
+        );
+    }
+}
+
+// ===== validate_ref_name tests =====
+
+#[test]
+fn test_validate_ref_name_edge_cases() {
+    // Single character names are valid
+    assert!(reference::validate_ref_name("a").is_ok());
+
+    // Numeric names are valid
+    assert!(reference::validate_ref_name("123").is_ok());
+
+    // Dots are valid (not ".." though)
+    assert!(reference::validate_ref_name("v1.0").is_ok());
+
+    // Hyphens and underscores
+    assert!(reference::validate_ref_name("my-ref_v2").is_ok());
+
+    // Double dot in name
+    assert!(reference::validate_ref_name("foo..bar").is_err());
+}
+
+// ===== Integration: merge with weighted reference results =====
+
+#[test]
+fn test_merge_weighted_ref_results_rank_correctly() {
+    // Simulate: primary result at 0.8, reference result at raw 0.9 * weight 0.7 = 0.63
+    let primary = vec![UnifiedResult::Code(make_code_result("primary_fn", 0.8))];
+    let refs = vec![(
+        "ref".to_string(),
+        vec![make_code_result("ref_fn", 0.63)], // Already weighted
+    )];
+
+    let merged = merge_results(primary, refs, 10);
+    assert_eq!(merged.len(), 2);
+    // Primary (0.8) should rank above weighted ref (0.63)
+    assert!(merged[0].source.is_none(), "Primary should rank first");
+    assert_eq!(merged[1].source.as_deref(), Some("ref"));
+}


### PR DESCRIPTION
## Summary
- **30 new tests** across search_filtered (TC4), store/chunks (TC8), and reference (TC9)
- **SQLite integrity check** (DS12): `PRAGMA quick_check` on `Store::open()` catches B-tree corruption early with clear `StoreError::Corruption` error
- **API docs** (A2): Doc comments on `get_callers`/`get_callees` explaining the intentional asymmetry (name vs ID input, full ChunkSummary vs names output)
- **Embedder lifecycle** (RM8): Doc comment on ~500MB session memory + `clear_session()` method for long-running processes
- **Gather doc** (P11): Documented call graph loading tradeoff — caching unnecessary for current single-call-per-request pattern

v0.9.7 audit PR7c: 7 P3 fixes (TC4, TC8, TC9, DS12, P11, A2, RM8)

## Test plan
- [x] `cargo build --features gpu-search` — clean
- [x] `cargo test --features gpu-search --lib` — 339 pass
- [x] `cargo clippy --features gpu-search` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Fresh-eyes review — 0 issues

Generated with [Claude Code](https://claude.com/claude-code)
