### PR TITLE
fix: rebuild HNSW in watch mode, lazy-reload in MCP server (#236)

### DIFF
--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -163,6 +163,19 @@ pub fn cmd_watch(cli: &Cli, debounce_ms: u64, no_ignore: bool) -> Result<()> {
                                 if !cli.quiet {
                                     println!("Indexed {} chunk(s)", count);
                                 }
+                                // Rebuild HNSW so MCP server can detect the fresh index
+                                match super::commands::build_hnsw_index(&store, &cqs_dir) {
+                                    Ok(Some(n)) => {
+                                        info!(vectors = n, "HNSW index rebuilt");
+                                        if !cli.quiet {
+                                            println!("  HNSW index: {} vectors", n);
+                                        }
+                                    }
+                                    Ok(None) => {} // empty store
+                                    Err(e) => {
+                                        warn!(error = %e, "HNSW rebuild failed (search falls back to brute-force)");
+                                    }
+                                }
                             }
                             Err(e) => {
                                 warn!(error = %e, "Reindex error");

--- a/src/mcp/tools/explain.rs
+++ b/src/mcp/tools/explain.rs
@@ -71,6 +71,9 @@ pub fn tool_explain(server: &McpServer, arguments: Value) -> Result<Value> {
                 note_weight: 0.0,
                 note_only: false,
             };
+            // Reload HNSW if watch mode has rebuilt it since last search
+            server.maybe_reload_hnsw();
+
             let index_guard = server.index.read().unwrap_or_else(|e| {
                 tracing::debug!("Index RwLock poisoned, recovering");
                 e.into_inner()

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -77,6 +77,9 @@ pub fn tool_search(server: &McpServer, arguments: Value) -> Result<Value> {
         .validate()
         .map_err(|e| anyhow::anyhow!("Invalid search filter: {}", e))?;
 
+    // Reload HNSW if watch mode has rebuilt it since last search
+    server.maybe_reload_hnsw();
+
     // Read-lock the index (allows background CAGRA build to upgrade it)
     let index_guard = server.index.read().unwrap_or_else(|e| {
         tracing::debug!("Index RwLock poisoned (prior panic), recovering");

--- a/src/mcp/tools/similar.rs
+++ b/src/mcp/tools/similar.rs
@@ -92,6 +92,9 @@ pub fn tool_similar(server: &McpServer, arguments: Value) -> Result<Value> {
         note_only: false,
     };
 
+    // Reload HNSW if watch mode has rebuilt it since last search
+    server.maybe_reload_hnsw();
+
     let index_guard = server.index.read().unwrap_or_else(|e| {
         tracing::debug!("Index RwLock poisoned, recovering");
         e.into_inner()

--- a/src/mcp/tools/stats.rs
+++ b/src/mcp/tools/stats.rs
@@ -48,6 +48,9 @@ pub fn tool_stats(server: &McpServer) -> Result<Value> {
         "not built".to_string()
     };
 
+    // Reload HNSW if watch mode has rebuilt it
+    server.maybe_reload_hnsw();
+
     // Check active index type (HNSW or CAGRA)
     let active_index = {
         let guard = server.index.read().unwrap_or_else(|e| {


### PR DESCRIPTION
## Summary

Fixes #236 — HNSW-SQLite freshness after watch mode updates.

- **Watch mode** now rebuilds the HNSW index after each batch of code file changes, keeping on-disk HNSW in sync with SQLite
- **MCP server** detects stale HNSW via `index.hnsw.checksum` file mtime and lazy-reloads before search requests
- Checksum file is used as sentinel (written last during `HnswIndex::save()`)
- If HNSW rebuild fails in watch mode, logs warning and continues (SQLite is already updated)

## Files changed

- `src/cli/watch.rs` — call `build_hnsw_index()` after successful `reindex_files()`
- `src/mcp/server.rs` — add `cqs_dir`, `hnsw_mtime` fields; `maybe_reload_hnsw()` method; `hnsw_checksum_mtime()` helper
- `src/mcp/tools/{search,similar,explain,stats}.rs` — call `maybe_reload_hnsw()` before index access

## Test plan

- [x] `cargo build --features gpu-search` — compiles
- [x] `cargo test --features gpu-search` — 339 lib + 243 integration tests pass
- [x] `cargo clippy --features gpu-search` — clean
- [ ] CI passes
