### PR TITLE
chore: bump MSRV to 1.93, drop fs4 dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,14 @@ jobs:
       - name: Format check
         run: cargo fmt --check
 
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.93.0
+      - name: Check MSRV
+        run: cargo check --verbose
+
   # Eval suite - only runs on tagged releases (slow, requires model download)
   eval:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to cqs!
 
 ## Development Setup
 
-**Requires Rust 1.88+** (check with `rustc --version`)
+**Requires Rust 1.93+** (check with `rustc --version`)
 
 1. Clone the repository:
    ```bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,6 @@ dependencies = [
  "cuvs",
  "dirs",
  "dunce",
- "fs4",
  "futures",
  "globset",
  "hf-hub",
@@ -1144,16 +1143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs4"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
-dependencies = [
- "rustix 0.38.44",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1962,12 +1951,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2834,19 +2817,6 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.10.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -2854,7 +2824,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -3407,7 +3377,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cqs"
 version = "0.9.8"
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.93"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML, MCP server."
 license = "MIT"
 repository = "https://github.com/jamie8johnson/cqs"
@@ -83,7 +83,6 @@ zeroize = "1"
 bytemuck = { version = "1", features = ["derive"] }
 ignore = "0.4"
 notify = { version = "8", features = ["serde"] }
-fs4 = "0.12"
 ctrlc = "3"
 rayon = "1"
 crossbeam-channel = "0.5"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Code intelligence MCP server that saves AI agents tokens. Semantic search, call 
 
 ## Install
 
-**Requires Rust 1.88+** (due to `ort` ONNX runtime dependency)
+**Requires Rust 1.93+**
 
 ```bash
 cargo install cqs

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -41,7 +41,6 @@ fn process_exists(pid: u32) -> bool {
 /// Acquire file lock to prevent concurrent indexing
 /// Writes PID to lock file for stale lock detection
 pub(crate) fn acquire_index_lock(cqs_dir: &Path) -> Result<std::fs::File> {
-    use fs4::fs_std::FileExt;
     use std::io::Write;
 
     let lock_path = cqs_dir.join("index.lock");
@@ -72,7 +71,7 @@ pub(crate) fn acquire_index_lock(cqs_dir: &Path) -> Result<std::fs::File> {
             .open(&lock_path)
             .context("Failed to create lock file")?;
 
-        match lock_file.try_lock_exclusive() {
+        match lock_file.try_lock() {
             Ok(()) => {
                 // Write our PID to the lock file
                 let mut file = lock_file;

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,6 @@
 //!
 //! CLI flags override all config file values.
 
-use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -275,7 +274,7 @@ pub fn add_reference_to_config(
         .create(true)
         .truncate(false)
         .open(config_path)?;
-    FileExt::lock_exclusive(&lock_file)?;
+    lock_file.lock()?;
 
     let content = match std::fs::read_to_string(config_path) {
         Ok(c) => c,
@@ -358,7 +357,7 @@ pub fn remove_reference_from_config(config_path: &Path, name: &str) -> anyhow::R
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
         Err(e) => return Err(e.into()),
     };
-    FileExt::lock_exclusive(&lock_file)?;
+    lock_file.lock()?;
 
     let content = std::fs::read_to_string(config_path)?;
 

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -97,19 +97,6 @@ fn is_cjk(c: char) -> bool {
 /// expands text (e.g., "ABCD" → "a b c d" doubles length).
 const MAX_FTS_OUTPUT_LEN: usize = 16384;
 
-/// Find the largest byte index ≤ `index` that is on a UTF-8 char boundary.
-/// Equivalent to `str::floor_char_boundary` (stable since 1.91) but works with MSRV 1.88.
-fn floor_char_boundary(s: &str, index: usize) -> usize {
-    if index >= s.len() {
-        return s.len();
-    }
-    let mut i = index;
-    while i > 0 && !s.is_char_boundary(i) {
-        i -= 1;
-    }
-    i
-}
-
 /// Normalize code text for FTS5 indexing.
 ///
 /// Splits identifiers on camelCase/snake_case boundaries and joins with spaces.
@@ -154,7 +141,7 @@ pub fn normalize_for_fts(text: &str) -> String {
 
             // Cap output to prevent memory issues - truncate at last space boundary
             if result.len() >= MAX_FTS_OUTPUT_LEN {
-                let boundary = floor_char_boundary(&result, MAX_FTS_OUTPUT_LEN);
+                let boundary = result.floor_char_boundary(MAX_FTS_OUTPUT_LEN);
                 let truncate_at = result[..boundary].rfind(' ').unwrap_or(boundary);
                 result.truncate(truncate_at);
                 return result;
@@ -175,7 +162,7 @@ pub fn normalize_for_fts(text: &str) -> String {
 
     // Final cap check - truncate at last space to avoid splitting words
     if result.len() > MAX_FTS_OUTPUT_LEN {
-        let boundary = floor_char_boundary(&result, MAX_FTS_OUTPUT_LEN);
+        let boundary = result.floor_char_boundary(MAX_FTS_OUTPUT_LEN);
         let truncate_at = result[..boundary].rfind(' ').unwrap_or(boundary);
         result.truncate(truncate_at);
     }

--- a/src/note.rs
+++ b/src/note.rs
@@ -3,7 +3,6 @@
 //! Notes are developer observations with sentiment, stored in TOML and
 //! indexed for semantic search.
 
-use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use thiserror::Error;
@@ -140,7 +139,7 @@ pub fn parse_notes(path: &Path) -> Result<Vec<Note>, NoteError> {
                 format!("{}: {}", path.display(), e),
             ))
         })?;
-    FileExt::lock_shared(&lock_file).map_err(|e| {
+    lock_file.lock_shared().map_err(|e| {
         NoteError::Io(std::io::Error::new(
             std::io::ErrorKind::WouldBlock,
             format!("Could not lock {} for reading: {}", path.display(), e),
@@ -177,7 +176,7 @@ pub fn rewrite_notes_file(
                 format!("{}: {}", notes_path.display(), e),
             ))
         })?;
-    FileExt::lock_exclusive(&lock_file).map_err(|e| {
+    lock_file.lock().map_err(|e| {
         NoteError::Io(std::io::Error::new(
             std::io::ErrorKind::WouldBlock,
             format!("Could not lock {} for writing: {}", notes_path.display(), e),

--- a/src/project.rs
+++ b/src/project.rs
@@ -6,7 +6,6 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
-use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
 
 /// Global registry of indexed cqs projects
@@ -50,7 +49,8 @@ impl ProjectRegistry {
             .truncate(false)
             .open(&path)
             .with_context(|| format!("Failed to open {} for locking", path.display()))?;
-        FileExt::lock_exclusive(&lock_file)
+        lock_file
+            .lock()
             .with_context(|| format!("Failed to lock {}", path.display()))?;
 
         let content = toml::to_string_pretty(self)?;


### PR DESCRIPTION
## Summary

Bump MSRV from 1.88 to 1.93 (latest stable). We're the only users, so no compatibility concern.

- Replace custom `floor_char_boundary()` with `str::floor_char_boundary()` (stable since 1.91)
- Replace `fs4` file locking with `std::fs::File::lock()`/`lock_shared()` (stable since 1.89)
- Drop `fs4` dependency entirely (-39 lines from Cargo.lock)
- Add MSRV CI job (`cargo check` on 1.93)
- Update MSRV in README.md and CONTRIBUTING.md

## Test plan

- [x] `cargo build --features gpu-search` — compiles
- [x] `cargo test --features gpu-search` — all pass
- [x] `cargo clippy --features gpu-search` — clean
- [x] `fs4` absent from Cargo.lock
- [x] No custom `floor_char_boundary` in `src/nl.rs`
- [ ] CI passes (including new MSRV job)
