### PR TITLE
chore: update tears after #348/#349 fixes

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,27 +2,17 @@
 
 ## Right Now
 
-**Preparing v0.9.8 release.** 2026-02-11.
-
-### Active
-- v0.9.7 audit complete. 125 fixes across 9 PRs (#333-#343). 5 P4 deferred as issues. 11 P3 deferred (lower ROI).
-- Preparing v0.9.8 release with all audit fixes
+**Post-release maintenance.** 2026-02-10.
 
 ### Completed This Session
-- PR8: Created 2 new P4 issues (#344 TC6, #345 X8). 3 existing (#269, #236, #302).
-- PR7c (P3 batch 3): merged as PR #343 — 7 fixes
-- PR7b (P3 batch 2): merged as PR #341 — 14 fixes
-- PR7a (P3 batch 1): merged as PR #340 — 13 fixes
-- PR6 (API+Algorithm): merged as PR #338 — 13 fixes
-- PR5 (Safety+Security): merged as PR #337 — 14 fixes
+- PR #348: HNSW staleness fix (#236) — watch rebuilds HNSW after reindexing, MCP lazy-reloads via mtime check
+- PR #349: MSRV bump 1.88→1.93 — removed fs4 dep (std file locking), removed custom floor_char_boundary (std since 1.91), added MSRV CI job
+- Issue #236 closed
+- Release binary updated
 
 ### Completed Prior Sessions
-- PR4 (Performance): merged as PR #336 — 10 fixes
-- PR3 (Mechanical): merged as PR #335 — 33 fixes
-- PR2 (Critical Bugs): merged as PR #334 — 10 fixes
-- PR1 (Foundation): merged as PR #333 — 11 fixes
+- v0.9.8 released with 125 audit fixes across 9 PRs (#333-#343)
 - Notes groomed: 8 removed, 2 updated, 4 added (79 → 75)
-- Release binary updated, index rebuilt (2249 chunks, 9316 calls)
 
 ### Pending
 - `.cqs.toml` — untracked, has aveva-docs reference config
@@ -52,14 +42,14 @@
 
 ### Remaining audit items (P4 deferred)
 - #269: Brute-force search loads all embeddings
-- #236: HNSW-SQLite freshness validation
 - #302: CAGRA OOM guard
 - #344: embed_documents tests
 - #345: MCP schema generation from types
 
 ## Architecture
 
-- Version: 0.9.8 (pending release)
+- Version: 0.9.8
+- MSRV: 1.93
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -201,7 +201,7 @@ sentiment = 0.5
 text = "Notes surface heavily in search results because they contain dense semantic content about architecture decisions. That's intentional - observations are indexed to be found when conceptually relevant."
 mentions = [
     "notes.toml",
-    "store.rs",
+    "src/store/mod.rs",
     "search",
 ]
 
@@ -517,14 +517,6 @@ mentions = [
 
 [[note]]
 sentiment = -0.5
-text = "tree-sitter-sequel-tsql v0.4.2 not yet published to crates.io — bracket-quoted identifiers and ALTER PROCEDURE/FUNCTION only available via git dep. Any project using crates.io dep gets v0.4.0 without those fixes."
-mentions = [
-    "Cargo.toml",
-    "tree-sitter-sequel-tsql",
-]
-
-[[note]]
-sentiment = -0.5
 text = "extract_name_fallback() in chunk.rs searches for SQL keywords (PROCEDURE, FUNCTION, VIEW, TRIGGER) but lives in generic parser code. Harmless for non-SQL languages (returns None) but couples generic parsing to SQL-specific knowledge."
 mentions = [
     "src/parser/chunk.rs",
@@ -651,4 +643,30 @@ mentions = [
     "src/embedder.rs",
     "clear_session",
     "OnceCell",
+]
+
+[[note]]
+sentiment = -0.5
+text = '''WSL vhdx doesn't auto-shrink. Deleting files inside WSL frees space on ext4 but the vhdx on C: stays the same size. Must wsl --shutdown + diskpart compact vdisk to reclaim Windows disk space. Our vhdx is at C:\Users\user001\AppData\Local\wsl\{830cd9dc-...}\ext4.vhdx (180GB allocated, ~69GB used).'''
+mentions = [
+    "WSL",
+    "disk-space",
+]
+
+[[note]]
+sentiment = 0.5
+text = "MCP server lazy-reloads HNSW via index.hnsw.checksum mtime as sentinel. Checksum file written last by save(), so safe freshness indicator. maybe_reload_hnsw() called from search/similar/explain/stats — cheap fs::metadata stat per request."
+mentions = [
+    "src/mcp/server.rs",
+    "src/hnsw/persist.rs",
+    "maybe_reload_hnsw",
+]
+
+[[note]]
+sentiment = -0.5
+text = "maybe_reload_hnsw() replaces GPU CAGRA with CPU HNSW when disk index changes. Freshness trumps GPU speed (~12ms HNSW vs ~6ms CAGRA). CAGRA background build will re-promote on next server restart."
+mentions = [
+    "src/mcp/server.rs",
+    "src/cagra.rs",
+    "maybe_reload_hnsw",
 ]


### PR DESCRIPTION
## Summary
- Update PROJECT_CONTINUITY.md after PRs #348 and #349
- Groom notes: removed stale tsql crates.io note, updated store.rs mention, added HNSW reload and CAGRA downgrade notes

## Test plan
- No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
