### PR TITLE
chore: release v0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.9] - 2026-02-10
+
+### Fixed
+- **HNSW staleness in watch mode** (#236): Watch mode now rebuilds the HNSW index after reindexing changed files, so searches immediately find newly indexed code.
+- **MCP server HNSW staleness** (#236): MCP server lazy-reloads the HNSW index when the on-disk checksum file changes, using mtime-based staleness detection.
+
+### Changed
+- **MSRV bumped to 1.93**: Minimum supported Rust version raised from 1.88 to 1.93.
+- **Removed `fs4` dependency**: File locking now uses `std::fs::File::lock()` / `lock_shared()` / `try_lock()` (stable since Rust 1.89).
+- **Removed custom `floor_char_boundary`**: Uses `str::floor_char_boundary()` from std (stable since Rust 1.91).
+- **MSRV CI job**: New CI check validates compilation on the minimum supported Rust version.
+
 ## [0.9.8] - 2026-02-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.9.8"
+version = "0.9.9"
 edition = "2021"
 rust-version = "1.93"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML, MCP server."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -48,7 +48,7 @@
 
 ## Architecture
 
-- Version: 0.9.8
+- Version: 0.9.9
 - MSRV: 1.93
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)


### PR DESCRIPTION
## Summary
- Bump version to 0.9.9
- Changelog for #348 (HNSW staleness fix) and #349 (MSRV bump to 1.93, fs4 removed)

## Changes since v0.9.8
- **Fixed**: HNSW staleness in watch mode and MCP server (#236)
- **Changed**: MSRV 1.88 -> 1.93, removed `fs4` dependency, removed custom `floor_char_boundary`, added MSRV CI job

## Test plan
- CI passes (no code changes in this PR, just version bump + changelog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
