### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0] - 2026-02-10
 
 ### Removed
 - MCP server (`src/mcp/`, `cqs serve` command). All functionality available via CLI + skills.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ src/
   gather.rs     - Smart context assembly (BFS call graph expansion)
   structural.rs - Structural pattern matching on code chunks
   project.rs    - Cross-project search registry
-  audit.rs    - Audit mode persistence (file-based, shared CLI/MCP)
+  audit.rs    - Audit mode persistence and duration parsing
   focused_read.rs - Focused read logic (extract type dependencies)
   impact.rs       - Impact analysis (callers + affected tests)
   config.rs     - Configuration file support
@@ -147,7 +147,7 @@ src/
     docs-review/  - Check project docs for staleness
     migrate/      - Schema version upgrades
     troubleshoot/ - Diagnose common cqs issues
-    cqs-*/        - MCP tool skill wrappers (search, read, callers, etc.)
+    cqs-*/        - CLI skill wrappers (search, read, callers, etc.)
 ```
 
 **Key design notes:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.9.9"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.9.9"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.93"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML embeddings."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,22 +2,9 @@
 
 ## Right Now
 
-**MCP server removed.** 2026-02-10.
+**Post-MCP cleanup and release.** 2026-02-10.
 
-Steps 1-13 complete. Remaining: close issues #345/#301, rebuild release binary, reindex.
-
-### Completed This Session
-- Moved `parse_duration()` from `src/mcp/validation.rs` → `src/audit.rs`
-- Deleted `src/mcp/` (27 files, ~4649 lines), `tests/mcp_test.rs` (~1565 lines), `src/cli/commands/serve.rs`
-- Removed 7 deps (axum, tower, tower-http, futures, tokio-stream, subtle, zeroize)
-- Slimmed tokio from 6 features to 2 (`rt-multi-thread`, `time`)
-- Fixed all MCP references across source, docs, notes, skills
-- Build clean, all tests pass, clippy clean
-
-### Completed Prior Sessions
-- v0.9.9 released
-- PR #348: HNSW staleness fix (#236)
-- PR #349: MSRV bump 1.88→1.93, dropped fs4
+MCP server removed in PR #352 (merged). Now: groom notes, review docs, release v0.10.0.
 
 ### Pending
 - `.cqs.toml` — untracked, has aveva-docs reference config
@@ -52,14 +39,14 @@ Steps 1-13 complete. Remaining: close issues #345/#301, rebuild release binary, 
 
 ## Architecture
 
-- Version: 0.9.9
+- Version: 0.10.0
 - MSRV: 1.93
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, score-based merge with weight
 - 9 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, Markdown)
-- CLI-only (MCP server removed)
+- CLI-only (MCP server removed in PR #352)
 - Source layout: parser/ and hnsw/ are directories (split from monoliths in v0.9.0)
 - SQL grammar: tree-sitter-sequel-tsql v0.4.2 (crates.io)
 - Build target: `~/.cargo-target/cq/` (Linux FS)

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -199,7 +199,7 @@ mentions = [
 
 [[note]]
 sentiment = 1.0
-text = "Hybrid CAGRA startup: HNSW loads in 30ms (server ready), CAGRA builds in background (~1.2s), auto-swaps via Arc<RwLock>. Eliminated blocking startup delay."
+text = "Hybrid CAGRA startup: HNSW loads in 30ms, CAGRA builds in background (~1.2s), auto-swaps via Arc<RwLock>. Non-blocking startup pattern for GPU index builds."
 mentions = [
     "src/cagra.rs",
     "src/hnsw/mod.rs",
@@ -208,28 +208,10 @@ mentions = [
 
 [[note]]
 sentiment = 0.5
-text = "HTTP server --bind flag with safety check. Non-localhost requires --dangerously-allow-network-bind + --api-key. API key uses constant-time comparison (subtle crate). --api-key-file for secure loading with zeroize."
-mentions = [
-    "src/cli/mod.rs",
-    "src/audit.rs",
-    "--bind",
-    "auth",
-]
-
-[[note]]
-sentiment = 0.5
 text = "sqlx migration complete: replaced rusqlite/r2d2 with sqlx async SQLite. Key design choice: sync wrappers via internal Runtime::block_on() preserve existing API. Schema init needed fix: split SQL by semicolons AND skip leading comment-only lines (not just statements that start with --)."
 mentions = [
     "src/store/mod.rs",
     "Cargo.toml",
-]
-
-[[note]]
-sentiment = 0.5
-text = "Inline validation code is hard to find via semantic search. Extract into named functions: validate_api_key, validate_origin_header, etc. 'validate bearer token' query now finds validate_api_key at 0.74 score."
-mentions = [
-    "src/audit.rs",
-    "discoverability",
 ]
 
 [[note]]
@@ -601,7 +583,7 @@ mentions = [
 
 [[note]]
 sentiment = 0.5
-text = "Embedder clear_session() releases ~500MB ONNX session memory for long-running processes. Session lazily re-initializes on next embed call. Use during idle periods in watch/serve."
+text = "Embedder clear_session() releases ~500MB ONNX session memory for long-running processes. Session lazily re-initializes on next embed call. Use during idle periods in watch mode."
 mentions = [
     "src/embedder.rs",
     "clear_session",
@@ -616,3 +598,11 @@ mentions = [
     "disk-space",
 ]
 
+[[note]]
+sentiment = 0.5
+text = "MCP removal was clean because all logic lived in library modules. The MCP layer was a pure JSON-RPC wrapper — deleting ~6200 lines required zero changes to core search/graph/impact code. Validates keeping business logic in src/*.rs with thin CLI wrappers."
+mentions = [
+    "src/lib.rs",
+    "src/audit.rs",
+    "PR #352",
+]


### PR DESCRIPTION
## Summary

- Bump version to 0.10.0
- Finalize CHANGELOG (move Unreleased to 0.10.0)
- Fix remaining MCP references in CONTRIBUTING.md
- Update GitHub repo description and topics
- Groom notes (remove 2 stale, update 2, add 1)
- Update tears

## Test plan

- [x] `cargo check --features gpu-search` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
