### PR TITLE
fix: streaming search, size guards, parallel refs, dedup, test harness

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,9 +2,9 @@
 
 ## Right Now
 
-**Post-MCP cleanup and release.** 2026-02-10.
+**v0.10.0 released.** 2026-02-10.
 
-MCP server removed in PR #352 (merged). Now: groom notes, review docs, release v0.10.0.
+MCP server removed (PR #352), v0.10.0 released (PR #353). Published to crates.io and GitHub.
 
 ### Pending
 - `.cqs.toml` — untracked, has aveva-docs reference config

--- a/tests/cli_graph_test.rs
+++ b/tests/cli_graph_test.rs
@@ -1,0 +1,629 @@
+//! CLI integration tests for call-graph and utility commands
+//!
+//! Tests commands that need inter-function call relationships (trace, impact,
+//! test-map, context, gather, explain, similar) and standalone commands
+//! (audit-mode, notes, project, read).
+//!
+//! Graph tests use a richer fixture with call chains:
+//!   src/lib.rs:  main() → process(), process() → validate(), process() → transform()
+//!   src/tests.rs: test_process() → process()
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serial_test::serial;
+use std::fs;
+use tempfile::TempDir;
+
+/// Get a Command for the cqs binary
+fn cqs() -> Command {
+    #[allow(deprecated)]
+    Command::cargo_bin("cqs").expect("Failed to find cqs binary")
+}
+
+/// Create a project with call relationships for graph command testing.
+fn setup_graph_project() -> TempDir {
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let src = dir.path().join("src");
+    fs::create_dir(&src).expect("Failed to create src dir");
+
+    fs::write(
+        src.join("lib.rs"),
+        r#"
+/// Entry point
+pub fn main() {
+    let data = process(42);
+    println!("{}", data);
+}
+
+/// Process input through validation and transformation
+pub fn process(input: i32) -> String {
+    let valid = validate(input);
+    if valid {
+        transform(input)
+    } else {
+        String::from("invalid")
+    }
+}
+
+/// Check if input is positive
+fn validate(input: i32) -> bool {
+    input > 0
+}
+
+/// Double and format the input
+fn transform(input: i32) -> String {
+    format!("result: {}", input * 2)
+}
+"#,
+    )
+    .expect("Failed to write lib.rs");
+
+    fs::write(
+        src.join("tests.rs"),
+        r#"
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_process() {
+        let result = process(5);
+        assert_eq!(result, "result: 10");
+    }
+}
+"#,
+    )
+    .expect("Failed to write tests.rs");
+
+    dir
+}
+
+/// Initialize and index a project, returning the TempDir.
+/// Must be called inside a #[serial] test.
+fn init_and_index(dir: &TempDir) {
+    cqs()
+        .args(["init"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    cqs()
+        .args(["index"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Index complete"));
+}
+
+// =============================================================================
+// Tier 1: No model needed — standalone commands
+// =============================================================================
+
+#[test]
+fn test_audit_mode_on() {
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let cqs_dir = dir.path().join(".cqs");
+    fs::create_dir(&cqs_dir).expect("Failed to create .cqs dir");
+
+    cqs()
+        .args(["audit-mode", "on", "--expires", "30m"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Audit mode enabled"));
+}
+
+#[test]
+fn test_audit_mode_off() {
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let cqs_dir = dir.path().join(".cqs");
+    fs::create_dir(&cqs_dir).expect("Failed to create .cqs dir");
+
+    // Turn on first
+    cqs()
+        .args(["audit-mode", "on", "--expires", "30m"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // Turn off
+    cqs()
+        .args(["audit-mode", "off"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Audit mode disabled"));
+}
+
+#[test]
+fn test_audit_mode_query_status() {
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let cqs_dir = dir.path().join(".cqs");
+    fs::create_dir(&cqs_dir).expect("Failed to create .cqs dir");
+
+    // Query when off
+    cqs()
+        .args(["audit-mode"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Audit mode: OFF"));
+}
+
+#[test]
+fn test_audit_mode_json() {
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let cqs_dir = dir.path().join(".cqs");
+    fs::create_dir(&cqs_dir).expect("Failed to create .cqs dir");
+
+    let output = cqs()
+        .args(["audit-mode", "on", "--expires", "1h", "--json"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("Invalid JSON: {} — raw: {}", e, stdout));
+    assert_eq!(parsed["audit_mode"], true);
+    assert!(parsed["expires_at"].is_string());
+}
+
+#[test]
+fn test_audit_mode_invalid_state() {
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let cqs_dir = dir.path().join(".cqs");
+    fs::create_dir(&cqs_dir).expect("Failed to create .cqs dir");
+
+    cqs()
+        .args(["audit-mode", "maybe"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid state"));
+}
+
+#[test]
+#[serial]
+fn test_project_register_list_remove() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    // Register
+    cqs()
+        .args([
+            "project",
+            "register",
+            "testproj",
+            dir.path().to_str().unwrap(),
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Registered 'testproj'"));
+
+    // List
+    cqs()
+        .args(["project", "list"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("testproj"));
+
+    // Remove
+    cqs()
+        .args(["project", "remove", "testproj"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed 'testproj'"));
+}
+
+#[test]
+#[serial]
+fn test_project_remove_nonexistent() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    cqs()
+        .args(["project", "remove", "nosuchproject"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("not found"));
+}
+
+// =============================================================================
+// Tier 2: Real init+index — graph and search commands
+// =============================================================================
+
+#[test]
+#[serial]
+fn test_trace_finds_path() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    let output = cqs()
+        .args(["trace", "main", "validate", "--format", "json"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("Invalid JSON: {} — raw: {}", e, stdout));
+
+    assert_eq!(parsed["source"], "main");
+    assert_eq!(parsed["target"], "validate");
+    let path = parsed["path"].as_array().expect("path should be array");
+    assert!(path.len() >= 2, "Path should have at least 2 hops");
+
+    // Verify path starts with main and ends with validate
+    assert_eq!(path[0]["name"], "main");
+    assert_eq!(path[path.len() - 1]["name"], "validate");
+}
+
+#[test]
+#[serial]
+fn test_trace_trivial_self() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    cqs()
+        .args(["trace", "main", "main"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("same function"));
+}
+
+#[test]
+#[serial]
+fn test_trace_no_path() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    // validate doesn't call main — no reverse path
+    cqs()
+        .args(["trace", "validate", "main"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No call path found"));
+}
+
+#[test]
+#[serial]
+fn test_impact_json() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    let output = cqs()
+        .args(["impact", "validate", "--format", "json"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("Invalid JSON: {} — raw: {}", e, stdout));
+
+    // validate is called by process, which is called by main
+    assert!(parsed["function"].is_string(), "Should have function field");
+}
+
+#[test]
+#[serial]
+fn test_impact_text_output() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    cqs()
+        .args(["impact", "validate"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("validate"));
+}
+
+#[test]
+#[serial]
+fn test_test_map_json() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    let output = cqs()
+        .args(["test-map", "process", "--json"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("Invalid JSON: {} — raw: {}", e, stdout));
+
+    assert!(parsed["function"].is_string(), "Should have function field");
+    assert!(parsed["tests"].is_array(), "Should have tests array");
+}
+
+#[test]
+#[serial]
+fn test_test_map_transitive() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    // validate is called by process, which is called by test_process
+    let output = cqs()
+        .args(["test-map", "validate", "--json"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("Invalid JSON: {} — raw: {}", e, stdout));
+
+    assert!(parsed["function"].is_string(), "Should have function field");
+}
+
+#[test]
+#[serial]
+fn test_context_json() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    let output = cqs()
+        .args(["context", "src/lib.rs", "--json"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("Invalid JSON: {} — raw: {}", e, stdout));
+
+    assert_eq!(parsed["file"], "src/lib.rs");
+    let chunks = parsed["chunks"]
+        .as_array()
+        .expect("Should have chunks array");
+    assert!(
+        chunks.len() >= 4,
+        "Should have at least 4 chunks (main, process, validate, transform)"
+    );
+}
+
+#[test]
+#[serial]
+fn test_context_summary() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    cqs()
+        .args(["context", "src/lib.rs", "--summary"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Chunks:"));
+}
+
+#[test]
+#[serial]
+fn test_context_nonexistent_file() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    cqs()
+        .args(["context", "src/nonexistent.rs"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No indexed chunks"));
+}
+
+#[test]
+#[serial]
+fn test_explain_text() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    cqs()
+        .args(["explain", "process"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("process")
+                .and(predicate::str::contains("Callers:").or(predicate::str::contains("Callees:"))),
+        );
+}
+
+#[test]
+#[serial]
+fn test_explain_json() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    let output = cqs()
+        .args(["explain", "process", "--json"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("Invalid JSON: {} — raw: {}", e, stdout));
+
+    assert!(parsed["name"].is_string(), "Should have name field");
+    assert!(parsed["callers"].is_array(), "Should have callers array");
+    assert!(parsed["callees"].is_array(), "Should have callees array");
+    assert!(parsed["signature"].is_string(), "Should have signature");
+}
+
+#[test]
+#[serial]
+fn test_explain_nonexistent() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    cqs()
+        .args(["explain", "nonexistent_function_xyz"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No function found"));
+}
+
+#[test]
+#[serial]
+fn test_similar_json() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    // similar to process — should find other functions
+    let output = cqs()
+        .args(["similar", "process", "--json"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    // Should be valid JSON (either results or empty)
+    let _parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("Invalid JSON: {} — raw: {}", e, stdout));
+}
+
+#[test]
+#[serial]
+fn test_gather_json() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    let output = cqs()
+        .args(["gather", "process data", "--json"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("Invalid JSON: {} — raw: {}", e, stdout));
+
+    assert_eq!(parsed["query"], "process data");
+    assert!(parsed["chunks"].is_array(), "Should have chunks array");
+}
+
+#[test]
+#[serial]
+fn test_read_file() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    cqs()
+        .args(["read", "src/lib.rs"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pub fn main()"));
+}
+
+#[test]
+#[serial]
+fn test_read_nonexistent() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    cqs()
+        .args(["read", "src/nope.rs"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("File not found"));
+}
+
+#[test]
+#[serial]
+fn test_read_focused() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    cqs()
+        .args(["read", "src/lib.rs", "--focus", "process"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Focused read:"));
+}
+
+#[test]
+#[serial]
+fn test_notes_add_list_remove() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    // Create docs directory for notes.toml
+    let docs_dir = dir.path().join("docs");
+    fs::create_dir_all(&docs_dir).expect("Failed to create docs dir");
+
+    // Add
+    cqs()
+        .args([
+            "notes",
+            "add",
+            "test note for CLI",
+            "--sentiment",
+            "0.5",
+            "--mentions",
+            "lib.rs",
+            "--no-reindex",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // List
+    cqs()
+        .args(["notes", "list"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("test note for CLI"));
+
+    // Remove
+    cqs()
+        .args(["notes", "remove", "test note for CLI", "--no-reindex"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+}
+
+#[test]
+#[serial]
+fn test_notes_warnings_filter() {
+    let dir = setup_graph_project();
+    init_and_index(&dir);
+
+    let docs_dir = dir.path().join("docs");
+    fs::create_dir_all(&docs_dir).expect("Failed to create docs dir");
+
+    // Add a warning note
+    cqs()
+        .args([
+            "notes",
+            "add",
+            "this is a warning",
+            "--sentiment",
+            "-0.5",
+            "--no-reindex",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // List with --warnings filter
+    cqs()
+        .args(["notes", "list", "--warnings"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("this is a warning"));
+}

--- a/tests/embedding_test.rs
+++ b/tests/embedding_test.rs
@@ -1,0 +1,155 @@
+//! Embedding pipeline integration tests
+//!
+//! Tests for `embed_documents` and `embed_query` that require the ONNX model.
+//! Run with: cargo test --features gpu-search --test embedding_test -- --ignored
+
+use cqs::embedder::{Embedder, EmbedderError};
+use cqs::EMBEDDING_DIM;
+
+/// Create a CPU embedder (avoids GPU context overhead for these tests)
+fn cpu_embedder() -> Embedder {
+    Embedder::new_cpu().expect("Failed to create CPU embedder")
+}
+
+#[test]
+#[ignore] // Requires ONNX model
+fn test_embed_single_document() {
+    let embedder = cpu_embedder();
+    let results = embedder
+        .embed_documents(&["fn main() { println!(\"hello\"); }"])
+        .expect("embed_documents failed");
+
+    assert_eq!(results.len(), 1);
+    // embed_documents returns 768-dim (no sentiment appended)
+    assert_eq!(results[0].len(), 768);
+
+    // Should be L2-normalized (magnitude ≈ 1.0)
+    let magnitude: f32 = results[0]
+        .as_slice()
+        .iter()
+        .map(|x| x * x)
+        .sum::<f32>()
+        .sqrt();
+    assert!(
+        (magnitude - 1.0).abs() < 1e-4,
+        "Expected unit vector, got magnitude {}",
+        magnitude
+    );
+}
+
+#[test]
+#[ignore]
+fn test_embed_batch_documents() {
+    let embedder = cpu_embedder();
+    let docs = vec![
+        "fn add(a: i32, b: i32) -> i32 { a + b }",
+        "def multiply(x, y): return x * y",
+        "function divide(a, b) { return a / b; }",
+        "public static int subtract(int a, int b) { return a - b; }",
+        "SELECT * FROM users WHERE id = 1",
+    ];
+    let results = embedder
+        .embed_documents(&docs)
+        .expect("embed_documents batch failed");
+
+    assert_eq!(results.len(), 5);
+    for (i, emb) in results.iter().enumerate() {
+        assert_eq!(emb.len(), 768, "Document {} has wrong dimension", i);
+        let magnitude: f32 = emb.as_slice().iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!(
+            (magnitude - 1.0).abs() < 1e-4,
+            "Document {} not normalized: magnitude {}",
+            i,
+            magnitude
+        );
+    }
+}
+
+#[test]
+#[ignore]
+fn test_embed_empty_batch() {
+    let embedder = cpu_embedder();
+    let results = embedder
+        .embed_documents(&[])
+        .expect("embed_documents empty failed");
+    assert!(results.is_empty());
+}
+
+#[test]
+#[ignore]
+fn test_embed_deterministic() {
+    let embedder = cpu_embedder();
+    let text = "pub fn process(data: &[u8]) -> Vec<u8>";
+
+    let result1 = embedder
+        .embed_documents(&[text])
+        .expect("first embed failed");
+    let result2 = embedder
+        .embed_documents(&[text])
+        .expect("second embed failed");
+
+    assert_eq!(result1[0].as_slice(), result2[0].as_slice());
+}
+
+#[test]
+#[ignore]
+fn test_query_vs_document_differ() {
+    let embedder = cpu_embedder();
+    let text = "parse configuration file";
+
+    let doc = embedder
+        .embed_documents(&[text])
+        .expect("embed_documents failed");
+    let query = embedder.embed_query(text).expect("embed_query failed");
+
+    // E5 uses "passage: " prefix for documents and "query: " for queries
+    // So the embeddings should differ
+    assert_ne!(
+        doc[0].as_slice(),
+        &query.as_slice()[..768],
+        "Query and document embeddings should differ due to E5 prefix"
+    );
+}
+
+#[test]
+#[ignore]
+fn test_embed_query_has_sentiment_dim() {
+    let embedder = cpu_embedder();
+    let query = embedder
+        .embed_query("search for functions")
+        .expect("embed_query failed");
+
+    // embed_query appends sentiment (0.0) as 769th dim
+    assert_eq!(query.len(), EMBEDDING_DIM);
+    assert_eq!(query.sentiment(), Some(0.0));
+}
+
+#[test]
+#[ignore]
+fn test_embed_query_empty_rejected() {
+    let embedder = cpu_embedder();
+    let err = embedder.embed_query("").unwrap_err();
+    assert!(matches!(err, EmbedderError::EmptyQuery));
+}
+
+#[test]
+#[ignore]
+fn test_embed_query_whitespace_only_rejected() {
+    let embedder = cpu_embedder();
+    let err = embedder.embed_query("   \t\n  ").unwrap_err();
+    assert!(matches!(err, EmbedderError::EmptyQuery));
+}
+
+#[test]
+#[ignore]
+fn test_embed_query_cached() {
+    let embedder = cpu_embedder();
+    let text = "test caching behavior";
+
+    // First call — cache miss
+    let result1 = embedder.embed_query(text).expect("first query failed");
+    // Second call — cache hit (should return identical result)
+    let result2 = embedder.embed_query(text).expect("second query failed");
+
+    assert_eq!(result1.as_slice(), result2.as_slice());
+}


### PR DESCRIPTION
## Summary

Five-phase pipeline addressing 9 deferred audit issues:

- **#269**: Stream brute-force search in batches of 5000 via cursor pagination instead of `fetch_all()` — bounds memory to O(batch_size) instead of O(total_chunks)
- **#303**: HNSW graph (500MB) and data (1GB) file size guards before deserialization
- **#302**: CAGRA OOM guard before `Vec::with_capacity` allocation (2GB limit with `saturating_mul`)
- **#257**: Parallel reference search with `rayon::par_iter` (was sequential loop)
- **#256**: Cross-store dedup by `blake3` content hash in `merge_results()` — keeps highest-scoring occurrence
- **#300**: 27 CLI integration tests for all previously untested commands (trace, impact, test-map, context, explain, similar, gather, read, notes, audit-mode, project)
- **#344**: 9 embedding pipeline integration tests (dimensions, normalization, determinism, query vs document, caching, error cases)

## Test plan

- [x] All 27 new CLI integration tests pass (`cargo test --test cli_graph_test`)
- [x] All 9 new embedding tests pass (`cargo test --test embedding_test -- --ignored`)
- [x] 3 new HNSW size guard unit tests pass
- [x] 1 new CAGRA OOM guard unit test passes
- [x] 2 new dedup unit tests pass
- [x] Full test suite passes (`cargo test --features gpu-search`)
- [x] Clippy clean (`cargo clippy --features gpu-search -- -D warnings`)
- [x] Fresh-eyes review completed — 0 issues

Closes #269, #300, #302, #303, #344, #256, #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)
