### PR TITLE
chore: release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2026-02-10
+
+### Fixed
+- **Stale MCP documentation**: Removed references to `cqs serve`, HTTP transport, and MCP setup from README, CONTRIBUTING, and PRIVACY. MCP server was removed in v0.10.0.
+
 ## [0.10.1] - 2026-02-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 rust-version = "1.93"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML embeddings."


### PR DESCRIPTION
## Summary
- Version bump to 0.10.2
- Changelog for PR #358 (stale MCP docs removal)

## Test plan
- No code changes
