### PR TITLE
feat: improve Markdown RAG with richer embeddings and cross-doc links

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -364,6 +364,9 @@
 - [ ] **Proactive hints in cqs_read/cqs_explain** — auto-surface "0 callers" (dead code) and "no tests" flags without requiring separate tool calls
 - [ ] **Refactor assistant** — "move function X from A to B" → checklist of import changes, visibility fixes, re-exports needed
 - [ ] **Batch UX** — common batch patterns (e.g., "callers for these N functions") as named shortcuts instead of raw JSON construction
+- [ ] **Table-aware Markdown chunking** — keep tables as atomic chunks or split row-wise with headers preserved. Prevents incoherent embedding of partial table data.
+- [ ] **Parent retrieval (small-to-big)** — when a small chunk matches, also surface its parent section for context. Flag in search results indicating a parent is available.
+- [ ] **Hypothetical question embedding** — generate "what question does this chunk answer?" and embed alongside content. Aligns query embeddings (questions) with chunk embeddings (answers). One extra embedding per chunk at index time.
 
 ## Parked
 


### PR DESCRIPTION
## Summary

Two features for better Markdown documentation RAG performance:

- **Richer NL descriptions**: Markdown sections now embed 1800 chars of stripped content (up from 200), filling E5-base-v2's 512-token window. New `strip_markdown_noise()` removes formatting noise (bold, headings, images, HTML, code fences) for cleaner embedding text.
- **Cross-document link graph**: Markdown links to `.md`/`.mdx` files now emit file stem and anchor as additional callees. Bridge edges (file stem → title heading) enable graph traversal across documents via `callers`/`callees`/`gather`/`trace`.
- **Roadmap**: Added 3 future items (table-aware chunking, parent retrieval, hypothetical question embedding).

## Details

### Feature 1: Richer NL Descriptions (`src/nl.rs`)

E5-base-v2 handles ~512 tokens (~2000 chars). Old code used only 200 chars of content preview for Markdown sections — wasting ~90% of embedding capacity. Markdown IS natural language, so we can embed much more content than code chunks.

Token budget: breadcrumb ~25 tokens + name ~12 tokens + 1800 chars ~450 tokens = ~487 tokens.

### Feature 2: Cross-Document Link Graph (`src/parser/markdown.rs`)

`[Configuration Guide](config.md#database)` now produces three call edges:
1. `"Configuration Guide"` — link text (existing)
2. `"config"` — file stem (new)
3. `"database"` — anchor fragment (new)

**Bridge edges** solve graph connectivity: file stems (e.g., "config") don't match section headings (e.g., "Configuration Guide") in the name-based call graph. Each Markdown file emits a synthetic edge from its file stem to its title heading, connecting the dots.

## Test plan

- [x] 18 new unit tests (4 bridge edge, 3 link extraction, 7 edge cases, 2 NL description, 2 strip noise)
- [x] All 575 tests pass (`cargo test --features gpu-search`)
- [x] `cargo clippy --features gpu-search` clean
- [x] Fresh-eyes review: 0 issues
- [x] Manual verification: search quality improved, bridge edges visible in `cqs callers`
- [ ] Reindex required after merge (`cqs index --force`) — NL descriptions changed, embeddings differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
