### PR TITLE
feat: table-aware chunking and parent retrieval (--expand)

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,11 +2,9 @@
 
 ## Right Now
 
-**v0.10.1 released.** 2026-02-10.
+**v0.10.2 + Markdown RAG improvements.** 2026-02-11.
 
-All clean. Pipeline plan complete — 5 phases done, 7 issues closed (#256, #257, #269, #300, #302, #303, #344). Security hardening (10 fixes) merged. Published to crates.io and GitHub. Binary updated, cqs-watch running.
-
-Notes groomed (57 notes, 3 stale fixed, 1 removed, 3 added).
+Markdown RAG merged (PR #360): richer NL descriptions (1800 chars, was 200), cross-document link graph (file stem + anchor callees, bridge edges). 18 new tests. Release binary updated, index rebuilt with `--force`, cqs-watch running.
 
 ### Pending
 - `docs/notes.toml` — modified, not committed (groom changes)
@@ -38,7 +36,7 @@ Notes groomed (57 notes, 3 stale fixed, 1 removed, 3 added).
 
 ## Architecture
 
-- Version: 0.10.1
+- Version: 0.10.2
 - MSRV: 1.93
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)

--- a/src/cli/commands/similar.rs
+++ b/src/cli/commands/similar.rs
@@ -128,7 +128,7 @@ pub(crate) fn cmd_similar(
             .into_iter()
             .map(cqs::store::UnifiedResult::Code)
             .collect();
-        display::display_unified_results(&unified, &root, cli.no_content, cli.context)?;
+        display::display_unified_results(&unified, &root, cli.no_content, cli.context, None)?;
     }
 
     Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -92,6 +92,10 @@ pub struct Cli {
     #[arg(short = 'C', long)]
     context: Option<usize>,
 
+    /// Expand results with parent context (small-to-big retrieval)
+    #[arg(long)]
+    expand: bool,
+
     /// Suppress progress output
     #[arg(short, long)]
     quiet: bool,

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -52,13 +52,13 @@ pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, Pa
         let hash_prefix = content_hash.get(..8).unwrap_or(&content_hash);
         let id = format!("{}:1:{}", path.display(), hash_prefix);
 
-        return Ok(vec![Chunk {
-            id,
+        let mut chunks = vec![Chunk {
+            id: id.clone(),
             file: path.to_path_buf(),
             language: Language::Markdown,
             chunk_type: ChunkType::Section,
             name: name.clone(),
-            signature: name,
+            signature: name.clone(),
             content,
             doc: None,
             line_start: 1,
@@ -66,7 +66,9 @@ pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, Pa
             content_hash,
             parent_id: None,
             window_idx: None,
-        }]);
+        }];
+        extract_table_chunks(&lines, 0, lines.len(), &name, &name, &id, path, &mut chunks);
+        return Ok(chunks);
     }
 
     // Only one heading → title-only file, one chunk
@@ -79,8 +81,8 @@ pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, Pa
         let line_end = lines.len() as u32;
         let id = format!("{}:{}:{}", path.display(), line_start, hash_prefix);
 
-        return Ok(vec![Chunk {
-            id,
+        let mut chunks = vec![Chunk {
+            id: id.clone(),
             file: path.to_path_buf(),
             language: Language::Markdown,
             chunk_type: ChunkType::Section,
@@ -93,7 +95,18 @@ pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, Pa
             content_hash,
             parent_id: None,
             window_idx: None,
-        }]);
+        }];
+        extract_table_chunks(
+            &lines,
+            0,
+            lines.len(),
+            &h.text,
+            &h.text,
+            &id,
+            path,
+            &mut chunks,
+        );
+        return Ok(chunks);
     }
 
     // Adaptive heading detection
@@ -127,12 +140,12 @@ pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, Pa
         let signature = build_breadcrumb(title_text, &section.heading_stack);
 
         chunks.push(Chunk {
-            id,
+            id: id.clone(),
             file: path.to_path_buf(),
             language: Language::Markdown,
             chunk_type: ChunkType::Section,
             name: section.name.clone(),
-            signature,
+            signature: signature.clone(),
             content,
             doc: None,
             line_start,
@@ -141,6 +154,18 @@ pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, Pa
             parent_id: None,
             window_idx: None,
         });
+
+        // Extract tables as additional chunks with parent_id = section chunk
+        extract_table_chunks(
+            &lines,
+            section.line_start,
+            section.line_end,
+            &section.name,
+            &signature,
+            &id,
+            path,
+            &mut chunks,
+        );
     }
 
     Ok(chunks)
@@ -669,6 +694,245 @@ fn extract_references_from_text(text: &str) -> Vec<CallSite> {
     calls
 }
 
+/// Maximum chars per table chunk before row-wise splitting
+const MAX_TABLE_CHARS: usize = 1500;
+
+/// Extract table chunks from a section's line range and append to `chunks`.
+///
+/// For each detected table, creates an additional chunk with `parent_id` set to
+/// the containing section. Large tables are split row-wise with headers preserved.
+#[allow(clippy::too_many_arguments)]
+fn extract_table_chunks(
+    lines: &[&str],
+    section_start: usize,
+    section_end: usize,
+    section_name: &str,
+    signature: &str,
+    section_id: &str,
+    path: &Path,
+    chunks: &mut Vec<Chunk>,
+) {
+    let section_lines = &lines[section_start..section_end];
+    let table_spans = detect_tables(section_lines);
+
+    for (table_idx, span) in table_spans.iter().enumerate() {
+        let table_lines = &section_lines[span.start..span.end];
+        let table_content = table_lines.join("\n");
+
+        // Disambiguate multiple tables: single = "(table)", multiple = "(table L{line})"
+        let abs_table_start = section_start + span.start;
+        let table_name = if table_spans.len() == 1 {
+            format!("{} (table)", section_name)
+        } else {
+            format!("{} (table L{})", section_name, abs_table_start + 1)
+        };
+
+        let table_line_start = abs_table_start as u32 + 1; // 1-indexed
+        let table_line_end = (section_start + span.end) as u32; // 1-indexed
+
+        if table_content.len() <= MAX_TABLE_CHARS {
+            let table_hash = blake3::hash(table_content.as_bytes()).to_hex().to_string();
+            let thash_prefix = table_hash.get(..8).unwrap_or(&table_hash);
+            let table_id = format!("{}:{}:{}", path.display(), table_line_start, thash_prefix);
+            chunks.push(Chunk {
+                id: table_id,
+                file: path.to_path_buf(),
+                language: Language::Markdown,
+                chunk_type: ChunkType::Section,
+                name: table_name,
+                signature: signature.to_string(),
+                content: table_content,
+                doc: None,
+                line_start: table_line_start,
+                line_end: table_line_end,
+                content_hash: table_hash,
+                parent_id: Some(section_id.to_string()),
+                window_idx: None,
+            });
+        } else {
+            // Split row-wise with headers preserved
+            let header_count = span.header_end - span.start;
+            let header_lines = &table_lines[..header_count];
+            let header_prefix = header_lines.join("\n");
+            let data_lines = &table_lines[header_count..];
+
+            let mut window: Vec<&str> = Vec::new();
+            let mut window_chars = header_prefix.len();
+            let mut widx: u32 = 0;
+
+            for row in data_lines {
+                if window_chars + row.len() + 1 > MAX_TABLE_CHARS && !window.is_empty() {
+                    emit_table_window(
+                        &header_prefix,
+                        &window,
+                        &table_name,
+                        signature,
+                        section_id,
+                        table_line_start,
+                        table_line_end,
+                        table_idx,
+                        widx,
+                        path,
+                        chunks,
+                    );
+                    window.clear();
+                    window_chars = header_prefix.len();
+                    widx += 1;
+                }
+                window.push(row);
+                window_chars += row.len() + 1;
+            }
+            // Emit remaining rows
+            if !window.is_empty() {
+                emit_table_window(
+                    &header_prefix,
+                    &window,
+                    &table_name,
+                    signature,
+                    section_id,
+                    table_line_start,
+                    table_line_end,
+                    table_idx,
+                    widx,
+                    path,
+                    chunks,
+                );
+            }
+        }
+    }
+}
+
+/// Emit a single row-wise table window chunk.
+#[allow(clippy::too_many_arguments)]
+fn emit_table_window(
+    header_prefix: &str,
+    rows: &[&str],
+    name: &str,
+    signature: &str,
+    parent_id: &str,
+    line_start: u32,
+    line_end: u32,
+    table_idx: usize,
+    window_idx: u32,
+    path: &Path,
+    chunks: &mut Vec<Chunk>,
+) {
+    let mut content = header_prefix.to_string();
+    content.push('\n');
+    content.push_str(&rows.join("\n"));
+    let whash = blake3::hash(content.as_bytes()).to_hex().to_string();
+    let whash_prefix = whash.get(..8).unwrap_or(&whash);
+    let wid = format!(
+        "{}:{}:{}:t{}w{}",
+        path.display(),
+        line_start,
+        whash_prefix,
+        table_idx,
+        window_idx
+    );
+    chunks.push(Chunk {
+        id: wid,
+        file: path.to_path_buf(),
+        language: Language::Markdown,
+        chunk_type: ChunkType::Section,
+        name: name.to_string(),
+        signature: signature.to_string(),
+        content,
+        doc: None,
+        line_start,
+        line_end,
+        content_hash: whash,
+        parent_id: Some(parent_id.to_string()),
+        window_idx: Some(window_idx),
+    });
+}
+
+/// A detected table span within a section
+#[derive(Debug, Clone)]
+struct TableSpan {
+    /// 0-indexed line, inclusive (header row)
+    start: usize,
+    /// 0-indexed line, exclusive (first non-table line)
+    end: usize,
+    /// Line index after separator (start of data rows, for row-wise splitting)
+    header_end: usize,
+}
+
+/// Pre-compiled regex for table separator rows: |---|---|  or  :---:|---:  etc.
+static TABLE_SEP_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)*\|?\s*$").expect("valid regex")
+});
+
+/// Detect markdown tables within a slice of lines.
+///
+/// Tables are identified by their separator row (the `|---|---|` line).
+/// The header row is the line immediately above the separator, and data rows
+/// follow below. Tables inside fenced code blocks are ignored.
+fn detect_tables(lines: &[&str]) -> Vec<TableSpan> {
+    let mut tables = Vec::new();
+    let mut in_code_block = false;
+
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+
+        // Track fenced code blocks
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_code_block = !in_code_block;
+            continue;
+        }
+        if in_code_block {
+            continue;
+        }
+
+        // Look for separator rows
+        if !TABLE_SEP_RE.is_match(trimmed) {
+            continue;
+        }
+
+        // Separator found — check header row above
+        if i == 0 {
+            continue; // No header row above
+        }
+        let header_line = lines[i - 1].trim();
+        if !header_line.contains('|') {
+            continue; // Header must contain pipes
+        }
+
+        // Check at least one data row below
+        let data_start = i + 1;
+        if data_start >= lines.len() {
+            continue; // No data rows
+        }
+        let first_data = lines[data_start].trim();
+        if !first_data.contains('|') {
+            continue; // First data row must contain pipes
+        }
+
+        // Find extent of data rows (contiguous pipe-containing lines)
+        let mut data_end = data_start + 1;
+        while data_end < lines.len() {
+            let row = lines[data_end].trim();
+            if row.is_empty() || !row.contains('|') {
+                break;
+            }
+            // Stop at headings
+            if atx_heading_level(row).is_some() {
+                break;
+            }
+            data_end += 1;
+        }
+
+        let span = TableSpan {
+            start: i - 1,      // header row
+            end: data_end,     // exclusive
+            header_end: i + 1, // first data row
+        };
+        tables.push(span);
+    }
+
+    tables
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1115,5 +1379,267 @@ mod tests {
         assert_eq!(title_idx, Some(0));
         assert_eq!(primary, 1);
         assert_eq!(overflow, Some(3));
+    }
+
+    // ── Table detection tests ──
+
+    #[test]
+    fn test_table_detection_basic() {
+        let lines = vec![
+            "Some text before",
+            "| Name | Type | Default |",
+            "|------|------|---------|",
+            "| port | int  | 8080    |",
+            "| host | str  | 0.0.0.0 |",
+            "",
+            "Some text after",
+        ];
+        let tables = detect_tables(&lines);
+        assert_eq!(tables.len(), 1);
+        assert_eq!(tables[0].start, 1); // header row
+        assert_eq!(tables[0].end, 5); // exclusive (empty line)
+        assert_eq!(tables[0].header_end, 3); // first data row
+    }
+
+    #[test]
+    fn test_table_detection_without_leading_pipes() {
+        let lines = vec![
+            "Name | Type | Default",
+            "------|------|--------",
+            "port | int  | 8080",
+            "host | str  | 0.0.0.0",
+        ];
+        let tables = detect_tables(&lines);
+        assert_eq!(tables.len(), 1);
+        assert_eq!(tables[0].start, 0);
+        assert_eq!(tables[0].end, 4);
+    }
+
+    #[test]
+    fn test_table_detection_alignment() {
+        let lines = vec![
+            "| Left | Center | Right |",
+            "|:-----|:------:|------:|",
+            "| a    | b      | c     |",
+        ];
+        let tables = detect_tables(&lines);
+        assert_eq!(tables.len(), 1);
+    }
+
+    #[test]
+    fn test_table_detection_in_code_block() {
+        let lines = vec![
+            "```",
+            "| Name | Type |",
+            "|------|------|",
+            "| a    | b    |",
+            "```",
+        ];
+        let tables = detect_tables(&lines);
+        assert_eq!(tables.len(), 0, "Tables in code blocks should be ignored");
+    }
+
+    #[test]
+    fn test_table_detection_multiple() {
+        let lines = vec![
+            "| A | B |",
+            "|---|---|",
+            "| 1 | 2 |",
+            "",
+            "Some text",
+            "",
+            "| X | Y |",
+            "|---|---|",
+            "| 3 | 4 |",
+        ];
+        let tables = detect_tables(&lines);
+        assert_eq!(tables.len(), 2);
+        assert_eq!(tables[0].start, 0);
+        assert_eq!(tables[0].end, 3);
+        assert_eq!(tables[1].start, 6);
+        assert_eq!(tables[1].end, 9);
+    }
+
+    #[test]
+    fn test_table_detection_no_separator() {
+        let lines = vec!["| Name | Type |", "| port | int  |", "| host | str  |"];
+        let tables = detect_tables(&lines);
+        assert_eq!(
+            tables.len(),
+            0,
+            "Pipes without separator row should not be a table"
+        );
+    }
+
+    #[test]
+    fn test_table_detection_min_size() {
+        // Exactly 3 lines (header + sep + 1 data) = detected
+        let lines = vec!["| A |", "|---|", "| 1 |"];
+        let tables = detect_tables(&lines);
+        assert_eq!(tables.len(), 1);
+
+        // Only 2 lines (header + sep, no data) = not detected
+        let lines2 = vec!["| A |", "|---|"];
+        let tables2 = detect_tables(&lines2);
+        assert_eq!(tables2.len(), 0);
+    }
+
+    // ── Table chunk creation tests ──
+
+    #[test]
+    fn test_table_chunk_created() {
+        let source = "# Doc Title\n\n\
+            ## Configuration\n\n\
+            Some intro text about configuration.\n\n\
+            | Option | Default | Description |\n\
+            |--------|---------|-------------|\n\
+            | port   | 8080    | Server port |\n\
+            | host   | 0.0.0.0 | Bind address|\n\n\
+            More text after the table.\n";
+        let chunks = parse_markdown_chunks(source, &test_path()).unwrap();
+        // Should have section chunk + table chunk
+        let table_chunks: Vec<_> = chunks
+            .iter()
+            .filter(|c| c.name.contains("(table)"))
+            .collect();
+        assert_eq!(
+            table_chunks.len(),
+            1,
+            "Should create one table chunk, got chunks: {:?}",
+            chunks.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+        assert!(table_chunks[0].content.contains("| Option"));
+        assert!(table_chunks[0].content.contains("| port"));
+    }
+
+    #[test]
+    fn test_table_chunk_has_parent_id() {
+        let source = "# Doc\n\n\
+            ## Settings\n\n\
+            | Key | Val |\n\
+            |-----|-----|\n\
+            | a   | 1   |\n";
+        let chunks = parse_markdown_chunks(source, &test_path()).unwrap();
+        let table_chunk = chunks.iter().find(|c| c.name.contains("(table)")).unwrap();
+        // Find the section chunk (the one without parent_id that contains the table)
+        let section_chunk = chunks.iter().find(|c| c.parent_id.is_none()).unwrap();
+        assert_eq!(
+            table_chunk.parent_id.as_ref().unwrap(),
+            &section_chunk.id,
+            "Table chunk parent_id should match section chunk id"
+        );
+    }
+
+    #[test]
+    fn test_table_chunk_name() {
+        // Single table → "(table)" — section name comes from the section after merge
+        let source = "# Doc\n\n## Sec\n\n| A |\n|---|\n| 1 |\n";
+        let chunks = parse_markdown_chunks(source, &test_path()).unwrap();
+        let table = chunks.iter().find(|c| c.name.contains("(table)")).unwrap();
+        // Small sections get merged — name may be "Doc" or "Sec" depending on merge
+        assert!(
+            table.name.ends_with("(table)"),
+            "Single table should end with '(table)': {}",
+            table.name
+        );
+
+        // Multiple tables → "(table L{line})"
+        let source2 = "# Doc\n\n## Sec\n\n\
+            | A |\n|---|\n| 1 |\n\n\
+            Some text.\n\n\
+            | B |\n|---|\n| 2 |\n";
+        let chunks2 = parse_markdown_chunks(source2, &test_path()).unwrap();
+        let tables: Vec<_> = chunks2
+            .iter()
+            .filter(|c| c.name.contains("(table"))
+            .collect();
+        assert_eq!(tables.len(), 2, "Should have two table chunks");
+        assert!(
+            tables[0].name.contains("(table L"),
+            "Should include line number: {}",
+            tables[0].name
+        );
+    }
+
+    #[test]
+    fn test_table_chunk_line_numbers() {
+        let source = "# Doc\n\n## Config\n\nIntro text.\n\n\
+            | Name | Type |\n\
+            |------|------|\n\
+            | port | int  |\n\n\
+            More text.\n";
+        let chunks = parse_markdown_chunks(source, &test_path()).unwrap();
+        let table = chunks.iter().find(|c| c.name.contains("(table)")).unwrap();
+        // Table starts at line 7 (1-indexed), ends at line 9
+        assert_eq!(table.line_start, 7, "Table should start at line 7");
+        assert_eq!(table.line_end, 9, "Table should end at line 9");
+    }
+
+    #[test]
+    fn test_large_table_split_row_wise() {
+        // Build a table with 50 rows to exceed 1500 chars
+        let mut source = String::from("# Doc\n\n## Data\n\n");
+        source.push_str("| Column A | Column B | Column C | Column D | Column E |\n");
+        source.push_str("|----------|----------|----------|----------|----------|\n");
+        for i in 0..50 {
+            source.push_str(&format!(
+                "| value_{}_a | value_{}_b | value_{}_c | value_{}_d | value_{}_e |\n",
+                i, i, i, i, i
+            ));
+        }
+        let chunks = parse_markdown_chunks(&source, &test_path()).unwrap();
+        let table_chunks: Vec<_> = chunks
+            .iter()
+            .filter(|c| c.name.contains("(table)"))
+            .collect();
+        assert!(
+            table_chunks.len() > 1,
+            "Large table should be split into multiple chunks, got {}",
+            table_chunks.len()
+        );
+        // Each split should start with header rows
+        for tc in &table_chunks {
+            assert!(
+                tc.content.starts_with("| Column A"),
+                "Each split should start with header: {}",
+                &tc.content[..50.min(tc.content.len())]
+            );
+            assert!(
+                tc.content.contains("|-------"),
+                "Each split should contain separator"
+            );
+        }
+        // All should have parent_id
+        for tc in &table_chunks {
+            assert!(
+                tc.parent_id.is_some(),
+                "Split table chunks should have parent_id"
+            );
+        }
+        // All should have window_idx
+        for tc in &table_chunks {
+            assert!(
+                tc.window_idx.is_some(),
+                "Split table chunks should have window_idx"
+            );
+        }
+    }
+
+    #[test]
+    fn test_table_at_file_start() {
+        // Table before any heading — file gets a single chunk from file_stem
+        let source = "| A | B |\n|---|---|\n| 1 | 2 |\n";
+        let chunks = parse_markdown_chunks(source, &test_path()).unwrap();
+        // No headings → whole file is one chunk + table chunk
+        let table_chunks: Vec<_> = chunks
+            .iter()
+            .filter(|c| c.name.contains("(table)"))
+            .collect();
+        assert_eq!(
+            table_chunks.len(),
+            1,
+            "Should detect table even with no headings: {:?}",
+            chunks.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
     }
 }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -227,6 +227,7 @@ mod tests {
                 doc: None,
                 line_start: 1,
                 line_end: 1,
+                parent_id: None,
             },
             score,
         }
@@ -398,6 +399,7 @@ mod tests {
                 doc: None,
                 line_start: 1,
                 line_end: 1,
+                parent_id: None,
             },
             score: 0.9,
         })];
@@ -415,6 +417,7 @@ mod tests {
                     doc: None,
                     line_start: 1,
                     line_end: 1,
+                    parent_id: None,
                 },
                 score: 0.7,
             }],

--- a/src/store/chunks.rs
+++ b/src/store/chunks.rs
@@ -672,6 +672,23 @@ impl Store {
         })
     }
 
+    /// Batch-fetch chunks by IDs.
+    ///
+    /// Returns a map of chunk ID → ChunkSummary for all found IDs.
+    /// Used by `--expand` to fetch parent chunks for small-to-big retrieval.
+    pub fn get_chunks_by_ids(
+        &self,
+        ids: &[&str],
+    ) -> Result<HashMap<String, ChunkSummary>, StoreError> {
+        self.rt.block_on(async {
+            let rows = self.fetch_chunks_by_ids_async(ids).await?;
+            Ok(rows
+                .into_iter()
+                .map(|(id, row)| (id, ChunkSummary::from(row)))
+                .collect())
+        })
+    }
+
     /// Batch-fetch embeddings by chunk IDs.
     ///
     /// Returns a map of chunk ID → Embedding for all found IDs.

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -45,6 +45,9 @@ pub use helpers::ChunkIdentity;
 /// Summary of an indexed code chunk (function, class, etc.).
 pub use helpers::ChunkSummary;
 
+/// Parent context for expanded search results (small-to-big retrieval).
+pub use helpers::ParentContext;
+
 /// Statistics about the index (chunk counts, languages, etc.).
 pub use helpers::IndexStats;
 

--- a/tests/reference_test.rs
+++ b/tests/reference_test.rs
@@ -26,6 +26,7 @@ fn make_code_result(name: &str, score: f32) -> SearchResult {
             doc: None,
             line_start: 1,
             line_end: 1,
+            parent_id: None,
         },
         score,
     }


### PR DESCRIPTION
## Summary

- Extract markdown tables as separate chunks alongside section chunks, giving tables their own focused embeddings for better search quality
- Expose `has_parent` in search results (JSON + terminal) so consumers know broader context is available
- Add `--expand` flag for small-to-big retrieval: inlines parent section content for table and windowed chunks
- Fix pipeline bug where `parent_id` wasn't rewritten from absolute to relative paths alongside chunk IDs

## Details

**Table detection:** Identifies tables by separator rows (`|---|---|`), validates header above and data rows below, ignores tables inside fenced code blocks. Large tables (>1500 chars) split row-wise with headers preserved in each split.

**Parent retrieval:** `--expand` batch-fetches parent chunks from the store. For stored parents (table → section), returns the full section. For unstored parents (windowed chunks), reads the source file at the chunk's line range.

**Files changed:** 12 (parser, store, CLI, pipeline, display, tests)
**New tests:** 17 (13 table detection/creation + 4 parent_id exposure)

## Test plan

- [x] `cargo build --features gpu-search` — clean
- [x] `cargo test --features gpu-search` — all pass
- [x] `cargo clippy --features gpu-search` — no warnings
- [x] Reindex with `--force`, verify table chunks appear with correct parent_ids
- [x] `cqs "query" --json` shows `has_parent: true` for table chunks
- [x] `cqs "query" --json --expand` includes `parent_name` and `parent_content`
- [x] Fresh-eyes review — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
