### PR TITLE
chore: release v0.11.0

### DIFF
--- a/.claude/skills/cqs-bootstrap/SKILL.md
+++ b/.claude/skills/cqs-bootstrap/SKILL.md
@@ -101,6 +101,7 @@ None.
    - `cqs-watch` — start file watcher for live index updates
    - `cqs-trace` — follow call chain between two functions
    - `cqs-impact` — what breaks if you change X
+   - `cqs-impact-diff` — diff-aware impact: changed functions, callers, tests to re-run
    - `cqs-test-map` — map functions to their tests
    - `cqs-batch` — execute multiple queries in one call
    - `cqs-context` — module-level file overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-02-11
+
+### Added
+- **Proactive hints** (#362): `cqs explain` and `cqs read --focus` now show caller count and test count for function/method chunks. JSON output includes `hints` object with `caller_count`, `test_count`, `no_callers`, `no_tests`.
+- **`cqs impact-diff`** (#362): New command maps git diff hunks to indexed functions and runs aggregated impact analysis. Shows changed functions, affected callers, and tests to re-run. Supports `--base`, `--stdin`, `--json`.
+- **Table-aware Markdown chunking** (#361): Markdown tables are chunked row-wise when exceeding 1500 characters. Parent retrieval via `--expand` flag.
+- **Markdown RAG improvements** (#360): Richer embeddings with cross-document reference linking and heading hierarchy preservation.
+- **`cqs-impact-diff` skill**: Agent skill for diff-aware impact analysis.
+
+### Fixed
+- **Suppress ort warning** (#363): Filter benign "nodes not assigned to preferred execution providers" warning from ONNX Runtime.
+- **Double compute_hints in read.rs**: JSON mode was calling `compute_hints()` twice; now stores result and reuses.
+
 ## [0.10.2] - 2026-02-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Fall back to Grep/Glob only for exact string matches or when semantic search ret
 - `cqs dead` — find dead code: functions/methods with no callers in the index.
 - `cqs callers <function>` / `cqs callees <function>` — call graph navigation.
 - `cqs impact <function>` — what breaks if you change it. Callers + affected tests.
+- `cqs impact-diff [--base REF]` — diff-aware impact: changed functions, callers, tests to re-run.
 - `cqs test-map <function>` — map function to tests that exercise it.
 - `cqs trace <source> <target>` — shortest call path between two functions.
 - `cqs context <file>` — module-level overview: chunks, callers, callees, notes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ src/
   cli/          - Command-line interface (clap)
     mod.rs      - Argument parsing, command dispatch
     commands/   - Command implementations
-      mod.rs, query.rs, index.rs, stats.rs, graph.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, trace.rs, impact.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs, audit_mode.rs, read.rs
+      mod.rs, query.rs, index.rs, stats.rs, graph.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, trace.rs, impact.rs, impact_diff.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs, audit_mode.rs, read.rs
     config.rs   - Configuration file loading
     display.rs  - Output formatting, result display
     files.rs    - File enumeration, lock files, path utilities
@@ -131,7 +131,8 @@ src/
   project.rs    - Cross-project search registry
   audit.rs    - Audit mode persistence and duration parsing
   focused_read.rs - Focused read logic (extract type dependencies)
-  impact.rs       - Impact analysis (callers + affected tests)
+  impact.rs       - Impact analysis (callers + affected tests + diff-aware)
+  diff_parse.rs   - Unified diff parser for impact-diff
   config.rs     - Configuration file support
   index.rs      - VectorIndex trait (HNSW, CAGRA)
   lib.rs        - Public API

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.93"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML embeddings."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,22 +2,14 @@
 
 ## Right Now
 
-**v0.10.2 + Proactive hints & diff-aware impact.** 2026-02-11.
+**Releasing v0.11.0.** 2026-02-11.
 
-Branch `feat/proactive-hints-diff-impact` — two features implemented, all tests passing, ready for PR:
-
-1. **Proactive hints** — `cqs explain` and `cqs read --focus` now show caller count + test count for functions. Skipped for non-function chunk types. JSON output includes `hints` object with `caller_count`, `test_count`, `no_callers`, `no_tests`.
-
-2. **`cqs impact-diff`** — new subcommand. Parses unified diff (from stdin or `git diff`), maps hunks to indexed functions, runs aggregated impact analysis. Shows changed functions, affected callers, and tests to re-run. Supports `--base`, `--stdin`, `--json`.
-
-New files: `src/diff_parse.rs`, `src/cli/commands/impact_diff.rs`, `tests/hints_test.rs`, `tests/impact_diff_test.rs`. Modified: `src/impact.rs`, `src/lib.rs`, `src/cli/mod.rs`, `src/cli/commands/mod.rs`, `src/cli/commands/explain.rs`, `src/cli/commands/read.rs`.
-
-Previous: PR #361 (table chunking + parent retrieval), PR #360 (Markdown RAG).
-
-### Pending
-- `docs/notes.toml` — modified, not committed (groom changes)
-- `.cqs.toml` — untracked, has aveva-docs reference config
-- Need `cqs-impact-diff` skill file (optional)
+Features since v0.10.2:
+1. **Proactive hints** (PR #362) — `cqs explain` and `cqs read --focus` show caller/test counts.
+2. **`cqs impact-diff`** (PR #362) — diff-aware impact analysis in one call.
+3. **Table-aware Markdown chunking** (PR #361) — row-wise table splitting, `--expand` parent retrieval.
+4. **Markdown RAG improvements** (PR #360) — richer embeddings, cross-doc links.
+5. **Suppress ort warning** (PR #363) — filter benign ONNX Runtime log noise.
 
 ### Known limitations
 - T-SQL triggers (`CREATE TRIGGER ON table AFTER INSERT`) not supported by grammar
@@ -45,7 +37,7 @@ Previous: PR #361 (table chunking + parent retrieval), PR #360 (Markdown RAG).
 
 ## Architecture
 
-- Version: 0.10.2
+- Version: 0.11.0
 - MSRV: 1.93
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Key commands (all support `--json`):
 - `cqs diff --source <ref>` - semantic diff between indexed snapshots
 - `cqs trace <source> <target>` - follow call chain (BFS shortest path)
 - `cqs impact <function>` - what breaks if you change X? Callers + affected tests
+- `cqs impact-diff [--base REF]` - diff-aware impact: changed functions, callers, tests to re-run
 - `cqs test-map <function>` - map functions to tests that exercise them
 - `cqs context <file>` - module-level: chunks, callers, callees, notes
 - `cqs gather "query"` - smart context assembly: seed search + call graph BFS


### PR DESCRIPTION
## Summary

Release v0.11.0 with 3 new features, 2 fixes, and documentation updates.

### Added
- Proactive hints in `cqs explain` and `cqs read --focus` (caller/test counts)
- `cqs impact-diff` command (diff-aware impact analysis)
- Table-aware Markdown chunking with `--expand` parent retrieval
- Markdown RAG improvements (cross-doc links, richer embeddings)
- `cqs-impact-diff` skill

### Fixed
- Suppress benign ort execution provider warning
- Double compute_hints call in read.rs JSON mode

### Docs
- CHANGELOG, README, CONTRIBUTING, CLAUDE.md, PROJECT_CONTINUITY updated
- Bootstrap skill includes impact-diff

## Test plan

- [x] All CI checks pass on PRs #360-#363
- [x] cargo test --features gpu-search (all pass)
- [x] cargo clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
