### PR TITLE
feat: cqs context --compact (batch caller/callee counts)

### DIFF
--- a/.claude/skills/cqs-context/SKILL.md
+++ b/.claude/skills/cqs-context/SKILL.md
@@ -9,8 +9,9 @@ argument-hint: "<file_path>"
 
 Parse arguments:
 - First positional arg = file path (required)
+- `--compact` — signatures-only TOC with caller/callee counts per chunk (no code bodies, no individual caller names). Best for quick "what's in this file?" before drilling in.
 - `--summary` — return counts only instead of full details
 
-Run via Bash: `cqs context "<path>" [--summary] --json -q`
+Run via Bash: `cqs context "<path>" [--compact] [--summary] --json -q`
 
-Present the results to the user. Returns a module overview: all chunks (signatures), external callers, external callees, dependent files, and related notes. Useful for understanding a file's role before making changes.
+Present the results to the user. Returns a module overview: all chunks (signatures), external callers, external callees, dependent files, and related notes. Useful for understanding a file's role before making changes. Use `--compact` when you just need the TOC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`cqs stale`**: New command to check index freshness. Lists files modified since last index and files in the index that no longer exist on disk. Supports `--json`, `--count-only`.
 - **Proactive staleness warnings**: Search, explain, gather, and context commands now warn on stderr when results come from stale files. Suppressed with `-q`.
 - **`cqs-stale` skill**: Agent skill for index freshness checks.
+- **`cqs context --compact`**: Signatures-only TOC with caller/callee counts per chunk. One command to see what's in a file and how connected each piece is. Uses batch SQL queries (no N+1).
 
 ## [0.11.0] - 2026-02-11
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -269,6 +269,9 @@ enum Commands {
         /// Return summary counts instead of full details
         #[arg(long)]
         summary: bool,
+        /// Signatures-only TOC with caller/callee counts (no code bodies)
+        #[arg(long)]
+        compact: bool,
     },
     /// Find functions with no callers (dead code detection)
     Dead {
@@ -418,7 +421,8 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
             ref path,
             json,
             summary,
-        }) => cmd_context(&cli, path, json, summary),
+            compact,
+        }) => cmd_context(&cli, path, json, summary, compact),
         Some(Commands::Dead { json, include_pub }) => cmd_dead(&cli, json, include_pub),
         Some(Commands::Gather {
             ref query,


### PR DESCRIPTION
## Summary
- Add `--compact` flag to `cqs context` for signatures-only TOC with caller/callee counts per chunk
- Two new batch SQL queries (`get_caller_counts_batch`, `get_callee_counts_batch`) avoid N+1 queries
- 6 unit tests for batch count methods (empty input, known names, unknown names)
- Updated cqs-context skill and changelog

## Test plan
- [x] `cargo build --features gpu-search` — clean
- [x] `cargo test --features gpu-search` — all pass
- [x] `cargo clippy --features gpu-search -- -D warnings` — clean
- [x] Manual test: `cqs context --compact src/store/calls.rs` — shows TOC with counts
- [x] Manual test: `cqs context --compact --json src/store/calls.rs` — valid JSON
- [x] Fresh-eyes review — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
