### PR TITLE
feat: impact --suggest-tests — test suggestions for untested callers

### DIFF
--- a/.claude/skills/cqs-impact/SKILL.md
+++ b/.claude/skills/cqs-impact/SKILL.md
@@ -11,6 +11,11 @@ Parse arguments:
 - First positional arg = function name to analyze (required)
 - `--depth <n>` — caller depth, 1 = direct only (default 1)
 
-Run via Bash: `cqs impact "<name>" [--depth N] --json -q`
+Run via Bash: `cqs impact "<name>" [--depth N] [--suggest-tests] --json -q`
 
 Present the results to the user. Returns callers with call-site snippets and affected tests via reverse BFS.
+
+## Flags
+
+- `--depth <n>` — caller depth, 1 = direct only (default 1)
+- `--suggest-tests` — for each untested caller, suggest a test name, file location (inline or new file), and naming pattern. Language-aware (Rust, Python, JS/TS, Java, Go).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`cqs-stale` skill**: Agent skill for index freshness checks.
 - **`cqs context --compact`**: Signatures-only TOC with caller/callee counts per chunk. One command to see what's in a file and how connected each piece is. Uses batch SQL queries (no N+1).
 - **`cqs related <function>`**: Co-occurrence analysis — find functions that share callers, callees, or custom types with a target. Three dimensions for understanding what else needs review when touching code.
+- **`cqs impact --suggest-tests`**: For each untested caller in impact analysis, suggests test name, file location (inline or new file), and naming pattern. Language-aware for Rust, Python, JS/TS, Java, Go.
 
 ## [0.11.0] - 2026-02-11
 

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,14 +2,19 @@
 
 ## Right Now
 
-**Releasing v0.11.0.** 2026-02-11.
+**7 agent experience features.** 2026-02-11.
 
-Features since v0.10.2:
-1. **Proactive hints** (PR #362) — `cqs explain` and `cqs read --focus` show caller/test counts.
-2. **`cqs impact-diff`** (PR #362) — diff-aware impact analysis in one call.
-3. **Table-aware Markdown chunking** (PR #361) — row-wise table splitting, `--expand` parent retrieval.
-4. **Markdown RAG improvements** (PR #360) — richer embeddings, cross-doc links.
-5. **Suppress ort warning** (PR #363) — filter benign ONNX Runtime log noise.
+Plan at `/home/user001/.claude/plans/linear-brewing-flame.md`. Build order: 2→6→5→3→4→1→7.
+
+### Done
+- PR #365: `cqs stale` + proactive staleness warnings (Features 2+6). Merged.
+- PR #366: `cqs context --compact` (Feature 5). Merged.
+- PR #367: `cqs related` (Feature 3). Merged.
+
+### Next
+- Feature 4: `cqs impact --suggest-tests` — test suggestions for untested callers
+- Feature 1: `cqs where` — placement suggestion for new code
+- Feature 7: `cqs scout` — pre-investigation dashboard (capstone)
 
 ### Known limitations
 - T-SQL triggers (`CREATE TRIGGER ON table AFTER INSERT`) not supported by grammar
@@ -22,6 +27,7 @@ Features since v0.10.2:
 - **Post-index name matching** — follow-up PR for fuzzy cross-doc references
 - **Phase 8**: Security (index encryption)
 - **ref install** — deferred from Phase 6, tracked in #255
+- **Speculative R&D: `cqs plan`** — strong AI planning. Agent reasoning between sequential calls is load-bearing; collapsing it risks removing valuable intermediate decisions. Revisit when `scout` proves sufficient.
 
 ## Open Issues
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -218,6 +218,9 @@ enum Commands {
         /// Output as JSON (alias for --format json)
         #[arg(long)]
         json: bool,
+        /// Suggest tests for untested callers
+        #[arg(long)]
+        suggest_tests: bool,
     },
     /// Impact analysis from a git diff — what callers and tests are affected
     #[command(name = "impact-diff")]
@@ -404,9 +407,10 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
             depth,
             ref format,
             json,
+            suggest_tests,
         }) => {
             let fmt = if json { "json" } else { format.as_str() };
-            cmd_impact(&cli, name, depth, fmt)
+            cmd_impact(&cli, name, depth, fmt, suggest_tests)
         }
         Some(Commands::ImpactDiff {
             ref base,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,8 @@ pub use focused_read::extract_type_names;
 pub use gather::{gather, GatherDirection, GatherOptions};
 pub use impact::{
     analyze_diff_impact, analyze_impact, compute_hints, diff_impact_to_json, impact_to_json,
-    impact_to_mermaid, map_hunks_to_functions, ChangedFunction, DiffImpactResult, FunctionHints,
-    ImpactResult,
+    impact_to_mermaid, map_hunks_to_functions, suggest_tests, ChangedFunction, DiffImpactResult,
+    FunctionHints, ImpactResult, TestSuggestion,
 };
 pub use nl::{generate_nl_description, generate_nl_with_template, normalize_for_fts, NlTemplate};
 pub use project::{search_across_projects, ProjectRegistry};


### PR DESCRIPTION
## Summary

- Adds `--suggest-tests` flag to `cqs impact` command
- For each untested caller, suggests test name, file location (inline or new file), and naming pattern
- Language-aware: Rust/Python/Go `test_*`, JS/TS `test('...', ...)`, Java `testMethodName`
- Loads call graph and test chunks only when flag is set (zero overhead on normal path)
- 10 new unit tests (suggest_test_file, reverse_bfs, edge cases)

## Test plan

- [x] `cargo build --features gpu-search`
- [x] `cargo clippy --features gpu-search -- -D warnings`
- [x] `cargo test --features gpu-search` — all pass
- [x] Manual test: `cqs impact analyze_impact --suggest-tests --json`
- [x] Manual test: `cqs impact analyze_impact --suggest-tests` (text output)
- [x] Fresh-eyes review: 3 issues found and fixed (empty string panic, redundant DB calls, redundant `.to_string()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
