### PR TITLE
feat: cqs where — placement suggestion for new code

### DIFF
--- a/.claude/skills/cqs-bootstrap/SKILL.md
+++ b/.claude/skills/cqs-bootstrap/SKILL.md
@@ -110,6 +110,7 @@ None.
    - `cqs-gc` — report index staleness
    - `cqs-stale` — check index freshness (files changed since last index)
    - `cqs-related` — find functions related by shared callers, callees, or types
+   - `cqs-where` — suggest where to add new code based on semantic similarity
    - `troubleshoot` — diagnose common cqs issues
    - `migrate` — handle schema version upgrades
 

--- a/.claude/skills/cqs-where/SKILL.md
+++ b/.claude/skills/cqs-where/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: cqs-where
+description: Suggest where to add new code based on semantic similarity and local patterns.
+disable-model-invocation: false
+argument-hint: "<description>"
+---
+
+# Where
+
+Parse arguments:
+- First positional arg = description of the code to add (required)
+
+Run via Bash: `cqs where "<description>" --json -q`
+
+Returns file suggestions ranked by relevance. Each suggestion includes:
+- File path and insertion line
+- Nearest similar function
+- Local patterns (imports, error handling, naming convention, visibility, inline tests)
+
+Use this to decide where to place new code before starting implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`cqs context --compact`**: Signatures-only TOC with caller/callee counts per chunk. One command to see what's in a file and how connected each piece is. Uses batch SQL queries (no N+1).
 - **`cqs related <function>`**: Co-occurrence analysis — find functions that share callers, callees, or custom types with a target. Three dimensions for understanding what else needs review when touching code.
 - **`cqs impact --suggest-tests`**: For each untested caller in impact analysis, suggests test name, file location (inline or new file), and naming pattern. Language-aware for Rust, Python, JS/TS, Java, Go.
+- **`cqs where "description"`**: Placement suggestion — find the best file and insertion point for new code. Extracts local patterns (imports, error handling, naming convention, visibility, inline tests) for each suggested file.
 
 ## [0.11.0] - 2026-02-11
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Fall back to Grep/Glob only for exact string matches or when semantic search ret
 - `cqs dead` — find dead code: functions/methods with no callers in the index.
 - `cqs stale` — check index freshness: files modified since last index.
 - `cqs related <function>` — co-occurrence: shared callers, callees, types. What else to review.
+- `cqs where "description"` — placement suggestion: where to add new code, with local patterns.
 - `cqs callers <function>` / `cqs callees <function>` — call graph navigation.
 - `cqs impact <function>` — what breaks if you change it. Callers + affected tests.
 - `cqs impact-diff [--base REF]` — diff-aware impact: changed functions, callers, tests to re-run.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ src/
   cli/          - Command-line interface (clap)
     mod.rs      - Argument parsing, command dispatch
     commands/   - Command implementations
-      mod.rs, query.rs, index.rs, stats.rs, graph.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, trace.rs, impact.rs, impact_diff.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs, audit_mode.rs, read.rs, stale.rs, related.rs
+      mod.rs, query.rs, index.rs, stats.rs, graph.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, trace.rs, impact.rs, impact_diff.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs, audit_mode.rs, read.rs, stale.rs, related.rs, where_cmd.rs
     config.rs   - Configuration file loading
     display.rs  - Output formatting, result display
     files.rs    - File enumeration, lock files, path utilities
@@ -134,6 +134,7 @@ src/
   focused_read.rs - Focused read logic (extract type dependencies)
   impact.rs       - Impact analysis (callers + affected tests + diff-aware)
   related.rs      - Co-occurrence analysis (shared callers, callees, types)
+  where_to_add.rs - Placement suggestion (semantic search + pattern extraction)
   diff_parse.rs   - Unified diff parser for impact-diff
   config.rs     - Configuration file support
   index.rs      - VectorIndex trait (HNSW, CAGRA)

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -27,6 +27,7 @@ mod stale;
 mod stats;
 mod test_map;
 mod trace;
+mod where_cmd;
 
 pub(crate) use audit_mode::cmd_audit_mode;
 pub(crate) use context::cmd_context;
@@ -52,3 +53,4 @@ pub(crate) use stale::cmd_stale;
 pub(crate) use stats::cmd_stats;
 pub(crate) use test_map::cmd_test_map;
 pub(crate) use trace::cmd_trace;
+pub(crate) use where_cmd::cmd_where;

--- a/src/cli/commands/where_cmd.rs
+++ b/src/cli/commands/where_cmd.rs
@@ -1,0 +1,111 @@
+//! Where command — suggest placement for new code
+
+use anyhow::Result;
+
+use cqs::{suggest_placement, Embedder, Store};
+
+use crate::cli::find_project_root;
+
+pub(crate) fn cmd_where(
+    _cli: &crate::cli::Cli,
+    description: &str,
+    limit: usize,
+    json: bool,
+) -> Result<()> {
+    let root = find_project_root();
+    let cqs_dir = cqs::resolve_index_dir(&root);
+    let index_path = cqs_dir.join("index.db");
+
+    if !index_path.exists() {
+        anyhow::bail!("Index not found. Run 'cqs init && cqs index' first.");
+    }
+
+    let store = Store::open(&index_path)?;
+    let embedder = Embedder::new()?;
+    let limit = limit.clamp(1, 10);
+
+    let result = suggest_placement(&store, &embedder, description, &root, limit)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    if json {
+        let suggestions_json: Vec<_> = result
+            .suggestions
+            .iter()
+            .map(|s| {
+                let rel = s
+                    .file
+                    .strip_prefix(&root)
+                    .unwrap_or(&s.file)
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                serde_json::json!({
+                    "file": rel,
+                    "score": s.score,
+                    "insertion_line": s.insertion_line,
+                    "near_function": s.near_function,
+                    "reason": s.reason,
+                    "patterns": {
+                        "imports": s.patterns.imports,
+                        "error_handling": s.patterns.error_handling,
+                        "naming_convention": s.patterns.naming_convention,
+                        "visibility": s.patterns.visibility,
+                        "has_inline_tests": s.patterns.has_inline_tests,
+                    }
+                })
+            })
+            .collect();
+        let output = serde_json::json!({
+            "description": description,
+            "suggestions": suggestions_json,
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        use colored::Colorize;
+
+        println!("{} {}", "Where to add:".cyan(), description.bold());
+
+        if result.suggestions.is_empty() {
+            println!();
+            println!("{}", "No placement suggestions found.".dimmed());
+        } else {
+            for (i, s) in result.suggestions.iter().enumerate() {
+                let rel = s
+                    .file
+                    .strip_prefix(&root)
+                    .unwrap_or(&s.file)
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                println!();
+                println!(
+                    "{}. {} {}",
+                    i + 1,
+                    rel.bold(),
+                    format!("(score: {:.2})", s.score).dimmed()
+                );
+                println!(
+                    "   Insert after line {} (near {})",
+                    s.insertion_line, s.near_function
+                );
+                println!("   {}", s.reason.dimmed());
+
+                // Show patterns
+                if !s.patterns.visibility.is_empty() {
+                    println!(
+                        "   {} {} | {} | {} {}",
+                        "Patterns:".cyan(),
+                        s.patterns.visibility,
+                        s.patterns.naming_convention,
+                        s.patterns.error_handling,
+                        if s.patterns.has_inline_tests {
+                            "| inline tests"
+                        } else {
+                            ""
+                        }
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,7 +19,7 @@ use commands::{
     cmd_audit_mode, cmd_callees, cmd_callers, cmd_context, cmd_dead, cmd_diff, cmd_doctor,
     cmd_explain, cmd_gather, cmd_gc, cmd_impact, cmd_impact_diff, cmd_index, cmd_init, cmd_notes,
     cmd_project, cmd_query, cmd_read, cmd_ref, cmd_related, cmd_similar, cmd_stale, cmd_stats,
-    cmd_test_map, cmd_trace, NotesCommand, ProjectCommand, RefCommand,
+    cmd_test_map, cmd_trace, cmd_where, NotesCommand, ProjectCommand, RefCommand,
 };
 use config::apply_config_defaults;
 
@@ -356,6 +356,17 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Suggest where to add new code matching a description
+    Where {
+        /// Description of the code to add
+        description: String,
+        /// Max file suggestions
+        #[arg(short = 'n', long, default_value = "3")]
+        limit: usize,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// Run CLI with pre-parsed arguments (used when main.rs needs to inspect args first)
@@ -464,6 +475,11 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
             limit,
             json,
         }) => cmd_related(&cli, name, limit, json),
+        Some(Commands::Where {
+            ref description,
+            limit,
+            json,
+        }) => cmd_where(&cli, description, limit, json),
         None => match &cli.query {
             Some(q) => cmd_query(&cli, q),
             None => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub(crate) mod related;
 pub(crate) mod search;
 pub(crate) mod source;
 pub(crate) mod structural;
+pub(crate) mod where_to_add;
 
 #[cfg(feature = "gpu-search")]
 pub mod cagra;
@@ -92,6 +93,7 @@ pub use project::{search_across_projects, ProjectRegistry};
 pub use related::{find_related, RelatedFunction, RelatedResult};
 pub use search::{parse_target, resolve_target};
 pub use structural::Pattern;
+pub use where_to_add::{suggest_placement, FileSuggestion, LocalPatterns, PlacementResult};
 
 #[cfg(feature = "gpu-search")]
 pub use cagra::CagraIndex;

--- a/src/where_to_add.rs
+++ b/src/where_to_add.rs
@@ -1,0 +1,473 @@
+//! Placement suggestion for new code
+//!
+//! Given a description of what you want to add, finds the best file and
+//! insertion point based on semantic similarity + local pattern analysis.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::embedder::Embedder;
+use crate::parser::Language;
+use crate::store::{ChunkSummary, SearchFilter, StoreError};
+use crate::Store;
+
+/// Local patterns observed in a file
+pub struct LocalPatterns {
+    /// Common imports/use statements
+    pub imports: Vec<String>,
+    /// Dominant error handling style (e.g., "anyhow", "thiserror", "Result<>", "try/except")
+    pub error_handling: String,
+    /// Naming convention (e.g., "snake_case", "camelCase", "PascalCase")
+    pub naming_convention: String,
+    /// Dominant visibility (e.g., "pub", "pub(crate)", "private")
+    pub visibility: String,
+    /// Whether the file has inline test module
+    pub has_inline_tests: bool,
+}
+
+/// Suggestion for where to place new code
+pub struct FileSuggestion {
+    /// File path
+    pub file: PathBuf,
+    /// Aggregate relevance score
+    pub score: f32,
+    /// Suggested insertion line
+    pub insertion_line: u32,
+    /// Function nearest to insertion point
+    pub near_function: String,
+    /// Why this file was chosen
+    pub reason: String,
+    /// Local patterns to follow
+    pub patterns: LocalPatterns,
+}
+
+/// Result from placement analysis
+pub struct PlacementResult {
+    pub suggestions: Vec<FileSuggestion>,
+}
+
+/// Suggest where to place new code matching a description.
+///
+/// 1. Searches for semantically similar code
+/// 2. Groups results by file, ranks by aggregate score
+/// 3. Extracts local patterns from each file
+/// 4. Suggests insertion point after the most similar function
+pub fn suggest_placement(
+    store: &Store,
+    embedder: &Embedder,
+    description: &str,
+    _root: &Path,
+    limit: usize,
+) -> Result<PlacementResult, SuggestError> {
+    // Embed the description
+    let query_embedding = embedder
+        .embed_query(description)
+        .map_err(|e| SuggestError::Embedding(e.to_string()))?;
+
+    // Search with RRF hybrid
+    let filter = SearchFilter {
+        enable_rrf: true,
+        query_text: description.to_string(),
+        ..SearchFilter::default()
+    };
+
+    let results = store.search_filtered(&query_embedding, &filter, 10, 0.1)?;
+
+    if results.is_empty() {
+        return Ok(PlacementResult {
+            suggestions: Vec::new(),
+        });
+    }
+
+    // Group by file, compute aggregate score
+    let mut by_file: HashMap<PathBuf, Vec<(f32, &ChunkSummary)>> = HashMap::new();
+    for r in &results {
+        by_file
+            .entry(r.chunk.file.clone())
+            .or_default()
+            .push((r.score, &r.chunk));
+    }
+
+    // Rank files by aggregate score (sum of chunk scores)
+    let mut file_scores: Vec<_> = by_file
+        .into_iter()
+        .map(|(file, chunks)| {
+            let total_score: f32 = chunks.iter().map(|(s, _)| s).sum();
+            (file, total_score, chunks)
+        })
+        .collect();
+    file_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    file_scores.truncate(limit);
+
+    // Build suggestions
+    let mut suggestions = Vec::with_capacity(file_scores.len());
+
+    for (file, score, chunks) in &file_scores {
+        // Get all chunks from this file for pattern extraction
+        let all_file_chunks = store
+            .get_chunks_by_origin(&file.to_string_lossy())
+            .unwrap_or_default();
+
+        // Find the most similar chunk in this file (highest individual score)
+        let best_chunk = chunks
+            .iter()
+            .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+        let (near_function, insertion_line) = match best_chunk {
+            Some((_, chunk)) => (chunk.name.clone(), chunk.line_end + 1),
+            None => ("(top of file)".to_string(), 1),
+        };
+
+        // Detect language from first chunk
+        let language = all_file_chunks.first().map(|c| c.language);
+
+        // Extract patterns
+        let patterns = extract_patterns(&all_file_chunks, language);
+
+        let reason = format!(
+            "{} similar functions found (best match: {})",
+            chunks.len(),
+            near_function
+        );
+
+        suggestions.push(FileSuggestion {
+            file: file.clone(),
+            score: *score,
+            insertion_line,
+            near_function,
+            reason,
+            patterns,
+        });
+    }
+
+    Ok(PlacementResult { suggestions })
+}
+
+/// Extract local coding patterns from a file's chunks
+fn extract_patterns(chunks: &[ChunkSummary], language: Option<Language>) -> LocalPatterns {
+    let mut imports = Vec::new();
+    let mut error_style = String::new();
+    let mut has_inline_tests = false;
+
+    // Collect all content for analysis
+    let all_content: String = chunks
+        .iter()
+        .map(|c| c.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let visibility = match language {
+        Some(Language::Rust) => {
+            // Rust patterns
+            for line in all_content.lines() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("use ") && !imports.contains(&trimmed.to_string()) {
+                    imports.push(trimmed.to_string());
+                }
+            }
+            if all_content.contains("anyhow::") || all_content.contains("anyhow::Result") {
+                error_style = "anyhow".to_string();
+            } else if all_content.contains("thiserror") {
+                error_style = "thiserror".to_string();
+            } else if all_content.contains("Result<") {
+                error_style = "Result<>".to_string();
+            }
+            // Dominant visibility
+            let pub_crate = chunks
+                .iter()
+                .filter(|c| c.signature.contains("pub(crate)"))
+                .count();
+            let pub_count = chunks
+                .iter()
+                .filter(|c| c.signature.starts_with("pub ") || c.signature.starts_with("pub fn"))
+                .count();
+            let private = chunks
+                .iter()
+                .filter(|c| !c.signature.contains("pub"))
+                .count();
+            has_inline_tests = all_content.contains("#[cfg(test)]");
+            if pub_crate >= pub_count && pub_crate >= private {
+                "pub(crate)".to_string()
+            } else if pub_count >= private {
+                "pub".to_string()
+            } else {
+                "private".to_string()
+            }
+        }
+        Some(Language::Python) => {
+            for line in all_content.lines() {
+                let trimmed = line.trim();
+                if (trimmed.starts_with("import ") || trimmed.starts_with("from "))
+                    && !imports.contains(&trimmed.to_string())
+                {
+                    imports.push(trimmed.to_string());
+                }
+            }
+            if all_content.contains("raise ") {
+                error_style = "raise".to_string();
+            } else if all_content.contains("try:") {
+                error_style = "try/except".to_string();
+            }
+            "module-level".to_string()
+        }
+        Some(Language::TypeScript | Language::JavaScript) => {
+            for line in all_content.lines() {
+                let trimmed = line.trim();
+                if (trimmed.starts_with("import ")
+                    || (trimmed.starts_with("const ") && trimmed.contains("require(")))
+                    && !imports.contains(&trimmed.to_string())
+                {
+                    imports.push(trimmed.to_string());
+                }
+            }
+            if all_content.contains("throw ") {
+                error_style = "throw".to_string();
+            } else if all_content.contains(".catch(") || all_content.contains("try {") {
+                error_style = "try/catch".to_string();
+            }
+            let has_export = chunks.iter().any(|c| c.signature.contains("export"));
+            if has_export {
+                "export".to_string()
+            } else {
+                "module-private".to_string()
+            }
+        }
+        Some(Language::Go) => {
+            for line in all_content.lines() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("import ") && !imports.contains(&trimmed.to_string()) {
+                    imports.push(trimmed.to_string());
+                }
+            }
+            if all_content.contains("error") {
+                error_style = "error return".to_string();
+            }
+            // Go: capitalized = exported
+            let exported = chunks
+                .iter()
+                .filter(|c| c.name.starts_with(|ch: char| ch.is_uppercase()))
+                .count();
+            if exported > chunks.len() / 2 {
+                "exported".to_string()
+            } else {
+                "unexported".to_string()
+            }
+        }
+        Some(Language::Java) => {
+            for line in all_content.lines() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("import ") && !imports.contains(&trimmed.to_string()) {
+                    imports.push(trimmed.to_string());
+                }
+            }
+            if all_content.contains("throws ") {
+                error_style = "checked exceptions".to_string();
+            } else if all_content.contains("try {") {
+                error_style = "try/catch".to_string();
+            }
+            let public = chunks
+                .iter()
+                .filter(|c| c.signature.contains("public"))
+                .count();
+            if public > chunks.len() / 2 {
+                "public".to_string()
+            } else {
+                "package-private".to_string()
+            }
+        }
+        _ => "default".to_string(),
+    };
+
+    // Cap imports to top 5
+    imports.truncate(5);
+
+    LocalPatterns {
+        imports,
+        error_handling: error_style,
+        naming_convention: detect_naming_convention(chunks),
+        visibility,
+        has_inline_tests,
+    }
+}
+
+/// Detect naming convention from chunk names
+fn detect_naming_convention(chunks: &[ChunkSummary]) -> String {
+    let mut snake = 0usize;
+    let mut camel = 0usize;
+    let mut pascal = 0usize;
+
+    for c in chunks {
+        if c.name.starts_with("test_") || c.name.starts_with("Test") {
+            continue; // Skip test functions
+        }
+        if c.name.contains('_') {
+            snake += 1;
+        } else if c.name.starts_with(|ch: char| ch.is_lowercase())
+            && c.name.chars().any(|ch| ch.is_uppercase())
+        {
+            camel += 1;
+        } else if c.name.starts_with(|ch: char| ch.is_uppercase()) && c.name.len() > 1 {
+            pascal += 1;
+        }
+    }
+
+    if snake >= camel && snake >= pascal {
+        "snake_case".to_string()
+    } else if camel >= pascal {
+        "camelCase".to_string()
+    } else {
+        "PascalCase".to_string()
+    }
+}
+
+/// Error type for placement suggestions
+#[derive(Debug)]
+pub enum SuggestError {
+    Embedding(String),
+    Store(StoreError),
+}
+
+impl std::fmt::Display for SuggestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SuggestError::Embedding(e) => write!(f, "Embedding error: {e}"),
+            SuggestError::Store(e) => write!(f, "Store error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SuggestError {}
+
+impl From<StoreError> for SuggestError {
+    fn from(e: StoreError) -> Self {
+        SuggestError::Store(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::ChunkType;
+
+    fn make_chunk(name: &str, sig: &str, content: &str, lang: Language) -> ChunkSummary {
+        ChunkSummary {
+            id: format!("id-{name}"),
+            file: PathBuf::from("src/test.rs"),
+            language: lang,
+            chunk_type: ChunkType::Function,
+            name: name.to_string(),
+            signature: sig.to_string(),
+            content: content.to_string(),
+            doc: None,
+            line_start: 1,
+            line_end: 10,
+            parent_id: None,
+        }
+    }
+
+    #[test]
+    fn test_detect_naming_snake_case() {
+        let chunks = vec![
+            make_chunk("find_related", "fn find_related()", "", Language::Rust),
+            make_chunk(
+                "search_filtered",
+                "fn search_filtered()",
+                "",
+                Language::Rust,
+            ),
+        ];
+        assert_eq!(detect_naming_convention(&chunks), "snake_case");
+    }
+
+    #[test]
+    fn test_detect_naming_camel_case() {
+        let chunks = vec![
+            make_chunk(
+                "findRelated",
+                "function findRelated()",
+                "",
+                Language::JavaScript,
+            ),
+            make_chunk(
+                "searchFiltered",
+                "function searchFiltered()",
+                "",
+                Language::JavaScript,
+            ),
+        ];
+        assert_eq!(detect_naming_convention(&chunks), "camelCase");
+    }
+
+    #[test]
+    fn test_detect_naming_pascal_case() {
+        let chunks = vec![
+            make_chunk("FindRelated", "func FindRelated()", "", Language::Go),
+            make_chunk("SearchFiltered", "func SearchFiltered()", "", Language::Go),
+        ];
+        assert_eq!(detect_naming_convention(&chunks), "PascalCase");
+    }
+
+    #[test]
+    fn test_detect_naming_skips_tests() {
+        let chunks = vec![
+            make_chunk("test_something", "fn test_something()", "", Language::Rust),
+            make_chunk("TestSomething", "func TestSomething()", "", Language::Rust),
+            make_chunk("findRelated", "fn findRelated()", "", Language::Rust),
+        ];
+        assert_eq!(detect_naming_convention(&chunks), "camelCase");
+    }
+
+    #[test]
+    fn test_extract_patterns_rust() {
+        let chunks = vec![
+            make_chunk(
+                "search_filtered",
+                "pub(crate) fn search_filtered()",
+                "use crate::store::Store;\nuse anyhow::Result;\n#[cfg(test)]",
+                Language::Rust,
+            ),
+            make_chunk(
+                "search_by_name",
+                "pub(crate) fn search_by_name()",
+                "use crate::embedder::Embedder;",
+                Language::Rust,
+            ),
+        ];
+        let patterns = extract_patterns(&chunks, Some(Language::Rust));
+        assert_eq!(patterns.error_handling, "anyhow");
+        assert_eq!(patterns.visibility, "pub(crate)");
+        assert!(patterns.has_inline_tests);
+        assert!(!patterns.imports.is_empty());
+    }
+
+    #[test]
+    fn test_extract_patterns_python() {
+        let chunks = vec![make_chunk(
+            "find_items",
+            "def find_items()",
+            "import os\nfrom pathlib import Path\nraise ValueError('bad')",
+            Language::Python,
+        )];
+        let patterns = extract_patterns(&chunks, Some(Language::Python));
+        assert_eq!(patterns.error_handling, "raise");
+        assert_eq!(patterns.visibility, "module-level");
+        assert!(patterns.imports.iter().any(|i| i.contains("import os")));
+    }
+
+    #[test]
+    fn test_extract_patterns_empty() {
+        let patterns = extract_patterns(&[], None);
+        assert!(patterns.imports.is_empty());
+        assert_eq!(patterns.visibility, "default");
+        assert!(!patterns.has_inline_tests);
+    }
+
+    #[test]
+    fn test_placement_empty_result() {
+        // PlacementResult with empty suggestions is valid
+        let result = PlacementResult {
+            suggestions: Vec::new(),
+        };
+        assert!(result.suggestions.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- New `cqs where "description"` command for placement suggestions
- Searches semantically similar code, groups by file, ranks by aggregate score
- Extracts language-aware patterns: imports, error handling, naming convention, visibility, inline tests
- Suggests insertion point (line number) after the most similar function
- 8 unit tests for pattern extraction, naming detection, edge cases
- New `cqs-where` skill added to bootstrap

## Test plan

- [x] `cargo build --features gpu-search`
- [x] `cargo clippy --features gpu-search -- -D warnings`
- [x] `cargo test --features gpu-search` — all pass (1 pre-existing flaky test)
- [x] Manual test: `cqs where "parse TOML configuration" --json`
- [x] Manual test: `cqs where "search for functions by embedding similarity"`
- [x] Fresh-eyes review: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
