### PR TITLE
fix: bootstrap tells agents to pass cqs skills to spawned agents

### DIFF
--- a/.claude/skills/cqs-bootstrap/SKILL.md
+++ b/.claude/skills/cqs-bootstrap/SKILL.md
@@ -182,6 +182,10 @@ After: `cqs audit-mode off` or let it auto-expire (30 min default).
 **Use `cqs notes add` to add notes** — it indexes immediately. Direct file edits require `cqs index` to become searchable.
 
 **Sentiment is DISCRETE** — only 5 valid values: -1, -0.5, 0, 0.5, 1
+
+## Agent Teams
+
+When spawning agents (via Task tool), always include cqs tool instructions in the agent prompt. Agents start with zero context — they can't use cqs unless told how. Include the key commands block (search, callers, callees, explain, similar, gather, impact, test-map, trace, context, dead, scout) in every agent prompt.
 ```
 
 ### Phase 6: Verify


### PR DESCRIPTION
## Summary

- Bootstrap's CLAUDE.md template now tells the bootstrapped instance to pass cqs tool instructions to spawned agents
- Without this, agents in bootstrapped projects fall back to grep/glob because they start with zero context

## Test plan

- [x] Verified SKILL.md renders correctly
- [x] No code changes — skill template only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
