### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-02-11
+
 ### Added
 - **`cqs stale`**: New command to check index freshness. Lists files modified since last index and files in the index that no longer exist on disk. Supports `--json`, `--count-only`.
 - **Proactive staleness warnings**: Search, explain, gather, and context commands now warn on stderr when results come from stale files. Suppressed with `-q`.
-- **`cqs-stale` skill**: Agent skill for index freshness checks.
 - **`cqs context --compact`**: Signatures-only TOC with caller/callee counts per chunk. One command to see what's in a file and how connected each piece is. Uses batch SQL queries (no N+1).
 - **`cqs related <function>`**: Co-occurrence analysis — find functions that share callers, callees, or custom types with a target. Three dimensions for understanding what else needs review when touching code.
 - **`cqs impact --suggest-tests`**: For each untested caller in impact analysis, suggests test name, file location (inline or new file), and naming pattern. Language-aware for Rust, Python, JS/TS, Java, Go.
 - **`cqs where "description"`**: Placement suggestion — find the best file and insertion point for new code. Extracts local patterns (imports, error handling, naming convention, visibility, inline tests) for each suggested file.
 - **`cqs scout "task"`**: Pre-investigation dashboard — single command replaces search → read → callers → tests → notes workflow. Groups results by file with signatures, caller/test counts, role classification, staleness, and relevant notes.
+- **Bootstrap agent skills propagation**: Bootstrap template now instructs spawned agents to include cqs tool instructions in their prompts.
 
 ## [0.11.0] - 2026-02-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.93"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML embeddings."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,19 +2,18 @@
 
 ## Right Now
 
-**7 agent experience features.** 2026-02-11.
+**All 7 agent experience features shipped.** 2026-02-11.
 
-Plan at `/home/user001/.claude/plans/linear-brewing-flame.md`. Build order: 2→6→5→3→4→1→7.
+All PRs merged:
+- PR #365: `cqs stale` + proactive staleness warnings (Features 2+6)
+- PR #366: `cqs context --compact` (Feature 5)
+- PR #367: `cqs related` (Feature 3)
+- PR #368: `cqs impact --suggest-tests` (Feature 4)
+- PR #369: `cqs where` (Feature 1)
+- PR #370: `cqs scout` (Feature 7 — capstone)
+- PR #371: Bootstrap agent skills propagation fix
 
-### Done
-- PR #365: `cqs stale` + proactive staleness warnings (Features 2+6). Merged.
-- PR #366: `cqs context --compact` (Feature 5). Merged.
-- PR #367: `cqs related` (Feature 3). Merged.
-
-### Next
-- Feature 4: `cqs impact --suggest-tests` — test suggestions for untested callers
-- Feature 1: `cqs where` — placement suggestion for new code
-- Feature 7: `cqs scout` — pre-investigation dashboard (capstone)
+Ready for v0.11.1 or v0.12.0 release.
 
 ### Known limitations
 - T-SQL triggers (`CREATE TRIGGER ON table AFTER INSERT`) not supported by grammar
@@ -43,7 +42,7 @@ Plan at `/home/user001/.claude/plans/linear-brewing-flame.md`. Build order: 2→
 
 ## Architecture
 
-- Version: 0.11.0
+- Version: 0.12.0
 - MSRV: 1.93
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ cqs trace cmd_query search_filtered --max-depth 5
 # Impact analysis: what breaks if I change this function?
 cqs impact search_filtered                # direct callers + affected tests
 cqs impact search_filtered --depth 3      # transitive callers
+cqs impact search_filtered --suggest-tests  # suggest tests for untested callers
 
 # Map functions to their tests
 cqs test-map search_filtered
@@ -190,7 +191,16 @@ cqs test-map search_filtered --depth 3 --json
 
 # Module overview: chunks, callers, callees, notes for a file
 cqs context src/search.rs
-cqs context src/search.rs --json
+cqs context src/search.rs --compact       # signatures + caller/callee counts only
+
+# Co-occurrence analysis: what else to review when touching a function
+cqs related search_filtered               # shared callers, callees, types
+
+# Placement suggestion: where to add new code
+cqs where "rate limiting middleware"       # best file, insertion point, local patterns
+
+# Pre-investigation dashboard: plan before you code
+cqs scout "add retry logic to search"     # search + callers + tests + staleness + notes
 ```
 
 ## Maintenance
@@ -294,7 +304,11 @@ Key commands (all support `--json`):
 - `cqs impact-diff [--base REF]` - diff-aware impact: changed functions, callers, tests to re-run
 - `cqs test-map <function>` - map functions to tests that exercise them
 - `cqs context <file>` - module-level: chunks, callers, callees, notes
+- `cqs context <file> --compact` - signatures + caller/callee counts only
 - `cqs gather "query"` - smart context assembly: seed search + call graph BFS
+- `cqs related <function>` - co-occurrence: shared callers, callees, types
+- `cqs where "description"` - suggest where to add new code
+- `cqs scout "task"` - pre-investigation dashboard: search + callers + tests + staleness + notes
 - `cqs dead` - find functions/methods never called by indexed code
 - `cqs stale` - check index freshness (files changed since last index)
 - `cqs gc` - report/clean stale index entries

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -361,10 +361,17 @@
 - [x] **Table-aware Markdown chunking** (PR #361) — tables extracted as separate chunks alongside sections. Row-wise splitting for large tables (>1500 chars) with headers preserved. Pipeline parent_id path normalization fix. 17 new tests.
 - [x] **Parent retrieval (small-to-big)** (PR #361) — `has_parent` field in search JSON/terminal output. `--expand` flag inlines parent section content for table and windowed chunks. Batch parent fetching via `get_chunks_by_ids()`.
 
-### Planned
+### Done (v0.11.0+)
 
-- [ ] **Proactive hints in cqs_read/cqs_explain** — auto-surface "0 callers" (dead code) and "no tests" flags without requiring separate tool calls. Saves 2 tool calls per function investigation.
-- [ ] **Diff-aware impact** — `cqs impact-diff` takes a git diff, returns affected callers + tests that need re-running. CI integration: run only relevant tests. Combines `git diff` parse → function extraction → call graph traversal.
+- [x] **Proactive hints in cqs_read/cqs_explain** — auto-surface "0 callers" (dead code) and "no tests" flags without requiring separate tool calls. Saves 2 tool calls per function investigation.
+- [x] **Diff-aware impact** — `cqs impact-diff` takes a git diff, returns affected callers + tests that need re-running. CI integration: run only relevant tests. Combines `git diff` parse → function extraction → call graph traversal.
+- [x] **`cqs stale`** — index freshness check, lists files modified since last index (PR #365)
+- [x] **Proactive staleness warnings** — query commands warn on stderr when results come from stale files (PR #365)
+- [x] **`cqs context --compact`** — signatures-only TOC with caller/callee counts (PR #366)
+- [x] **`cqs related`** — co-occurrence analysis: shared callers, callees, types (PR #367)
+- [x] **`cqs impact --suggest-tests`** — test suggestions for untested callers (PR #368)
+- [x] **`cqs where`** — placement suggestion for new code based on semantic similarity (PR #369)
+- [x] **`cqs scout`** — pre-investigation dashboard: search + file groups + caller/test counts + staleness + notes (PR #370)
 
 ## Parked
 


### PR DESCRIPTION
## Summary

- Bump version 0.11.0 → 0.12.0
- 7 new agent experience features: `stale`, `context --compact`, `related`, `impact --suggest-tests`, `where`, `scout`, proactive staleness warnings
- Bootstrap agent skills propagation fix
- Update README with new commands in Code Intelligence and Claude Code Integration sections
- Update CHANGELOG, PROJECT_CONTINUITY, ROADMAP

## Test plan

- [x] `cargo clippy --features gpu-search -- -D warnings` clean
- [x] `cargo test --features gpu-search` all passing
- [x] README documents all new commands
- [x] CHANGELOG has complete [0.12.0] section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
