### PR TITLE
feat: add --no-stale-check flag for slow filesystems

### DIFF
--- a/src/cli/commands/context.rs
+++ b/src/cli/commands/context.rs
@@ -39,7 +39,7 @@ pub(crate) fn cmd_context(
     }
 
     // Proactive staleness warning
-    if !cli.quiet {
+    if !cli.quiet && !cli.no_stale_check {
         staleness::warn_stale_results(&store, &[&origin]);
     }
 

--- a/src/cli/commands/explain.rs
+++ b/src/cli/commands/explain.rs
@@ -43,7 +43,7 @@ pub(crate) fn cmd_explain(cli: &crate::cli::Cli, target: &str, json: bool) -> Re
     let chunk = &source.chunk;
 
     // Proactive staleness warning
-    if !cli.quiet {
+    if !cli.quiet && !cli.no_stale_check {
         if let Some(file_str) = chunk.file.to_str() {
             staleness::warn_stale_results(&store, &[file_str]);
         }

--- a/src/cli/commands/gather.rs
+++ b/src/cli/commands/gather.rs
@@ -40,7 +40,7 @@ pub(crate) fn cmd_gather(
     let result = gather(&store, &query_embedding, query, &opts, &root)?;
 
     // Proactive staleness warning
-    if !cli.quiet && !result.chunks.is_empty() {
+    if !cli.quiet && !cli.no_stale_check && !result.chunks.is_empty() {
         let origins: Vec<&str> = result
             .chunks
             .iter()

--- a/src/cli/commands/query.rs
+++ b/src/cli/commands/query.rs
@@ -178,7 +178,7 @@ pub(crate) fn cmd_query(cli: &Cli, query: &str) -> Result<()> {
     let parents_ref = if cli.expand { Some(&parents) } else { None };
 
     // Proactive staleness warning (stderr, doesn't pollute JSON)
-    if !cli.quiet {
+    if !cli.quiet && !cli.no_stale_check {
         let origins: Vec<&str> = results
             .iter()
             .filter_map(|r| match r {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -126,6 +126,11 @@ pub(super) fn apply_config_defaults(cli: &mut Cli, config: &cqs::config::Config)
             cli.note_only = true;
         }
     }
+    if !cli.no_stale_check {
+        if let Some(false) = config.stale_check {
+            cli.no_stale_check = true;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -101,6 +101,10 @@ pub struct Cli {
     #[arg(short, long)]
     quiet: bool,
 
+    /// Disable staleness checks (skip per-file mtime comparison)
+    #[arg(long)]
+    no_stale_check: bool,
+
     /// Show debug info (sets RUST_LOG=debug)
     #[arg(short, long)]
     pub verbose: bool,
@@ -909,6 +913,7 @@ mod tests {
             references: vec![],
             note_weight: None,
             note_only: None,
+            stale_check: None,
         };
         apply_config_defaults(&mut cli, &config);
 
@@ -931,6 +936,7 @@ mod tests {
             references: vec![],
             note_weight: None,
             note_only: None,
+            stale_check: None,
         };
         apply_config_defaults(&mut cli, &config);
 


### PR DESCRIPTION
## Summary

- Add `--no-stale-check` CLI flag to skip per-file mtime comparison after queries
- Add `stale_check = false` config option in `.cqs.toml` for persistent opt-out
- Gates all 4 staleness warning call sites: query, gather, context, explain

Useful on NFS or slow filesystems where `fs::metadata()` per result file adds latency.

## Test plan

- [x] `cargo clippy --features gpu-search -- -D warnings` — clean
- [x] New `test_stale_check_config` — parses `stale_check = false/true/absent`
- [x] Existing `test_apply_config_defaults` tests pass with new field
- [ ] CI passes
