### PR TITLE
chore: release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-02-11
+
+### Added
+- **`--no-stale-check` flag**: Skip per-file staleness checks on slow filesystems (NFS, network mounts). Also configurable via `stale_check = false` in `.cqs.toml`.
+
+### Fixed
+- **Scout note matching precision**: `find_relevant_notes()` no longer produces false matches from reverse suffix comparison. Now requires path-component boundary matching (e.g., mention "search.rs" matches "src/search.rs" but not "nosearch.rs").
+
+### Removed
+- **`type_map` dead code**: Removed `LanguageDef.type_map` field and all per-language `TYPE_MAP` constants (never read, zero call sites).
+
 ## [0.12.0] - 2026-02-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 rust-version = "1.93"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML embeddings."


### PR DESCRIPTION
## Summary

Release v0.12.1 — cleanup + staleness opt-out.

- **Added**: `--no-stale-check` flag / `stale_check` config for slow filesystems
- **Fixed**: Scout note matching precision (path-component boundary check)
- **Removed**: `type_map` dead code from all 9 language definitions

## Test plan

- [x] `cargo clippy --features gpu-search -- -D warnings` — clean
- [x] All tests pass
- [ ] CI passes
