### PR TITLE
fix: deferred audit findings (9 groups, #382-#391)

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,14 +2,25 @@
 
 ## Right Now
 
-**v0.12.1 audit complete.** 2026-02-12.
+**Deferred audit findings complete.** 2026-02-12. Branch: `fix/audit-deferred`. Ready to commit + PR.
 
-- P1: 26 fixes merged (PR #360)
-- P2: 41 fixes merged (PR #380)
-- P3: 40 fixes merged (PR #381), 3 deferred (#390, #391), 3 non-issues
-- P4: 10 findings → 8 issues created (#382-#391), 1 inherent, 1 positive
-- Total: 107 fixes across 3 PRs, 10 issues for deferred work
-- 727 tests pass (up from 632)
+All 9 groups implemented. 747 tests pass, clippy clean, fresh-eyes complete.
+
+- Group A: Unified `is_test_chunk()` in lib.rs, replaced 3 divergent call sites
+- Group B: `DeadFunction` + `DeadConfidence` scoring, `ENTRY_POINT_NAMES`, `--min-confidence` CLI
+- Group C: Embedder `clear_session(&self)` via `Mutex<Option<Session>>`, watch idle clearing (5min)
+- Group D: Pipeline `file_batch_size` 100K → 5K
+- Group E: Improved HNSW checksum error messages + stale temp cleanup
+- Group F: HNSW file locking (exclusive save, shared load)
+- Group G: `HnswIndex::insert_batch()` for incremental HNSW
+- Group I: `extract_imports()` helper + C/SQL/Markdown support in `where_to_add`
+- Group J: Doc comment on `LocalPatterns` explaining string-based design
+
+**Descoped:** Group H (#389) — CAGRA GPU memory, requires new disk persistence layer
+
+**Prior audit totals:**
+- P1: 26 fixes (PR #360), P2: 41 fixes (PR #380), P3: 40 fixes (PR #381)
+- Total: 107 fixes + this deferred PR = ~116 fixes across 4 PRs
 
 ## Parked
 
@@ -42,7 +53,7 @@
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 9 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, Markdown)
-- Tests: 423 lib + 297 integration + 7 doc (727 total)
+- Tests: 441 lib + 297 integration + 7 doc (747 total)
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/ and hnsw/ are directories (split from monoliths in v0.9.0)
 - SQL grammar: tree-sitter-sequel-tsql v0.4.2 (crates.io)

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -637,3 +637,25 @@ mentions = [
     "impact.rs",
     "impact_diff.rs",
 ]
+
+[[note]]
+sentiment = -0.5
+text = "Fresh-eyes review of audit plan caught 3 blockers: File::unlock() doesn't exist (drop releases locks), hnsw_mut() on LoadedHnsw is unsound (unsafe transmute), CAGRA disk persistence is a new feature not a fix. Plans need scrutiny before execution."
+mentions = [
+    "hnsw/persist.rs",
+    "hnsw/mod.rs",
+    "cagra.rs",
+]
+
+[[note]]
+sentiment = 0.5
+text = "HNSW save is already crash-safe: blake3 checksums catch all partial-write states, try_load falls back to brute-force. Backup-dir approach would WIDEN crash window (8 renames vs 4). Don't over-engineer crash recovery when detection+rebuild is sufficient."
+mentions = ["hnsw/persist.rs"]
+
+[[note]]
+sentiment = -0.5
+text = "Embedder session clearing: 50 cycles at 100ms = 5 seconds is way too aggressive for clearing a 500MB ONNX session. Use 3000 cycles (5 minutes) to match SQLite idle timeout. Always check loop timing before setting cycle thresholds."
+mentions = [
+    "cli/watch.rs",
+    "embedder.rs",
+]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -305,6 +305,9 @@ enum Commands {
         /// Include public API functions in the main list
         #[arg(long)]
         include_pub: bool,
+        /// Minimum confidence level to report (low, medium, high)
+        #[arg(long, default_value = "low")]
+        min_confidence: String,
     },
     /// Gather minimal code context to answer a question
     Gather {
@@ -481,7 +484,11 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
             summary,
             compact,
         }) => cmd_context(&cli, path, json, summary, compact),
-        Some(Commands::Dead { json, include_pub }) => cmd_dead(&cli, json, include_pub),
+        Some(Commands::Dead {
+            json,
+            include_pub,
+            ref min_confidence,
+        }) => cmd_dead(&cli, json, include_pub, min_confidence),
         Some(Commands::Gather {
             ref query,
             expand,

--- a/src/hnsw/mod.rs
+++ b/src/hnsw/mod.rs
@@ -39,12 +39,14 @@ mod search;
 use std::mem::ManuallyDrop;
 
 use hnsw_rs::anndists::dist::distances::DistCosine;
+use hnsw_rs::api::AnnT;
 use hnsw_rs::hnsw::Hnsw;
 use hnsw_rs::hnswio::HnswIo;
 use thiserror::Error;
 
 use crate::embedder::Embedding;
 use crate::index::{IndexResult, VectorIndex};
+use crate::EMBEDDING_DIM;
 
 // HNSW tuning parameters
 //
@@ -162,6 +164,65 @@ impl HnswIndex {
     pub fn is_empty(&self) -> bool {
         self.id_map.is_empty()
     }
+
+    /// Incrementally insert vectors into an Owned HNSW index.
+    ///
+    /// Returns the number of items inserted, or an error if called on a Loaded
+    /// index (which is immutable — use a full rebuild instead).
+    ///
+    /// This enables watch mode to add new embeddings without rebuilding the
+    /// entire graph from scratch.
+    pub fn insert_batch(&mut self, items: &[(String, &[f32])]) -> Result<usize, HnswError> {
+        let _span = tracing::info_span!("hnsw_insert_batch", count = items.len()).entered();
+        if items.is_empty() {
+            return Ok(0);
+        }
+
+        // Only works on Owned variant — Loaded is immutable (unsafe transmute)
+        let hnsw = match &mut self.inner {
+            HnswInner::Owned(h) => h,
+            HnswInner::Loaded(_) => {
+                return Err(HnswError::Internal(
+                    "Cannot incrementally insert into loaded index; rebuild required".into(),
+                ));
+            }
+        };
+
+        // Validate dimensions
+        for (id, emb) in items {
+            if emb.len() != EMBEDDING_DIM {
+                return Err(HnswError::DimensionMismatch {
+                    expected: EMBEDDING_DIM,
+                    actual: emb.len(),
+                });
+            }
+            tracing::trace!("Inserting {} into HNSW index", id);
+        }
+
+        // Assign sequential IDs starting from current id_map length.
+        // Convert &[f32] → Vec<f32> so we can pass &Vec<f32> to hnsw_rs
+        // (which expects T: Sized + Send + Sync for parallel insert).
+        let base_idx = self.id_map.len();
+        let owned_vecs: Vec<Vec<f32>> = items.iter().map(|(_, emb)| emb.to_vec()).collect();
+        let data_for_insert: Vec<(&Vec<f32>, usize)> = owned_vecs
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (v, base_idx + i))
+            .collect();
+
+        hnsw.parallel_insert_data(&data_for_insert);
+
+        for (id, _) in items {
+            self.id_map.push(id.clone());
+        }
+
+        tracing::info!(
+            inserted = items.len(),
+            total = self.id_map.len(),
+            "HNSW batch insert complete"
+        );
+        Ok(items.len())
+    }
 }
 
 impl VectorIndex for HnswIndex {
@@ -216,5 +277,110 @@ mod send_sync_tests {
     fn test_loaded_hnsw_is_send_sync() {
         assert_send::<LoadedHnsw>();
         assert_sync::<LoadedHnsw>();
+    }
+}
+
+#[cfg(test)]
+mod insert_batch_tests {
+    use super::*;
+
+    use crate::hnsw::make_test_embedding;
+
+    #[test]
+    fn test_insert_batch_on_owned() {
+        // Build a small Owned HNSW index
+        let embeddings: Vec<(String, Embedding)> = (0..5)
+            .map(|i| (format!("chunk_{}", i), make_test_embedding(i)))
+            .collect();
+
+        let mut index = HnswIndex::build(embeddings).unwrap();
+        let initial_len = index.len();
+        assert_eq!(initial_len, 5);
+
+        // Insert new items
+        let new_embeddings: Vec<(String, Embedding)> = (5..8)
+            .map(|i| (format!("chunk_{}", i), make_test_embedding(i)))
+            .collect();
+        let refs: Vec<(String, &[f32])> = new_embeddings
+            .iter()
+            .map(|(id, emb)| (id.clone(), emb.as_slice()))
+            .collect();
+
+        let inserted = index.insert_batch(&refs).unwrap();
+        assert_eq!(inserted, 3);
+        assert_eq!(index.len(), initial_len + 3);
+
+        // Search should find both original and newly inserted items
+        let query = make_test_embedding(6);
+        let results = index.search(&query, 3);
+        assert!(!results.is_empty());
+        // chunk_6 should be in top results
+        assert!(results.iter().any(|r| r.id == "chunk_6"));
+    }
+
+    #[test]
+    fn test_insert_batch_empty() {
+        let embeddings: Vec<(String, Embedding)> = (0..3)
+            .map(|i| (format!("chunk_{}", i), make_test_embedding(i)))
+            .collect();
+
+        let mut index = HnswIndex::build(embeddings).unwrap();
+        let initial_len = index.len();
+
+        let inserted = index.insert_batch(&[]).unwrap();
+        assert_eq!(inserted, 0);
+        assert_eq!(index.len(), initial_len);
+    }
+
+    #[test]
+    fn test_insert_batch_on_loaded_fails() {
+        // Build, save, load, then try insert_batch — should fail
+        let embeddings: Vec<(String, Embedding)> = (0..3)
+            .map(|i| (format!("chunk_{}", i), make_test_embedding(i)))
+            .collect();
+
+        let index = HnswIndex::build(embeddings).unwrap();
+
+        // Save to temp dir
+        let dir = tempfile::tempdir().unwrap();
+        index.save(dir.path(), "test").unwrap();
+
+        // Load back (creates a Loaded variant)
+        let mut loaded = HnswIndex::load(dir.path(), "test").unwrap();
+
+        let new_emb = make_test_embedding(10);
+        let items = vec![("new_chunk".to_string(), new_emb.as_slice())];
+        let result = loaded.insert_batch(&items);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Cannot incrementally insert"),
+            "Expected 'Cannot incrementally insert' error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_insert_batch_dimension_mismatch() {
+        let embeddings: Vec<(String, Embedding)> = (0..3)
+            .map(|i| (format!("chunk_{}", i), make_test_embedding(i)))
+            .collect();
+
+        let mut index = HnswIndex::build(embeddings).unwrap();
+
+        // Try to insert with wrong dimension
+        let bad_vec = vec![1.0f32; 10]; // wrong dimension
+        let items = vec![("bad".to_string(), bad_vec.as_slice())];
+        let result = index.insert_batch(&items);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            HnswError::DimensionMismatch { expected, actual } => {
+                assert_eq!(expected, EMBEDDING_DIM);
+                assert_eq!(actual, 10);
+            }
+            other => panic!("Expected DimensionMismatch, got: {}", other),
+        }
     }
 }

--- a/src/impact.rs
+++ b/src/impact.rs
@@ -804,16 +804,16 @@ pub fn suggest_tests(store: &Store, impact: &ImpactResult) -> Vec<TestSuggestion
             }
         };
 
-        let is_test_chunk = |c: &crate::store::ChunkSummary| {
-            c.name.starts_with("test_") || c.name.starts_with("Test")
+        let chunk_is_test = |c: &crate::store::ChunkSummary| {
+            crate::is_test_chunk(&c.name, &c.file.to_string_lossy())
         };
 
-        let has_inline_tests = file_chunks.iter().any(is_test_chunk);
+        let has_inline_tests = file_chunks.iter().any(chunk_is_test);
 
         let pattern_source = if has_inline_tests {
             file_chunks
                 .iter()
-                .find(|c| is_test_chunk(c))
+                .find(|c| chunk_is_test(c))
                 .map(|c| c.name.clone())
                 .unwrap_or_default()
         } else {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -96,6 +96,12 @@ pub use helpers::score_name_match;
 /// Statistics about call graph entries (chunk-level calls table).
 pub use calls::CallStats;
 
+/// A dead function with confidence scoring.
+pub use calls::DeadFunction;
+
+/// Confidence level for dead code detection.
+pub use calls::DeadConfidence;
+
 /// Detailed function call statistics (function_calls table).
 pub use calls::FunctionCallStats;
 

--- a/tests/dead_code_test.rs
+++ b/tests/dead_code_test.rs
@@ -37,7 +37,7 @@ fn test_find_dead_code_basic() {
 
     // A and C should be in the list (no one calls them)
     // B should NOT be in the list (A calls it)
-    let dead_names: Vec<&str> = confident.iter().map(|c| c.name.as_str()).collect();
+    let dead_names: Vec<&str> = confident.iter().map(|d| d.chunk.name.as_str()).collect();
 
     assert!(
         dead_names.contains(&"func_a"),
@@ -66,7 +66,7 @@ fn test_find_dead_code_excludes_main() {
     let (confident, _) = store.find_dead_code(false).unwrap();
 
     // main should not be in the dead code list
-    let dead_names: Vec<&str> = confident.iter().map(|c| c.name.as_str()).collect();
+    let dead_names: Vec<&str> = confident.iter().map(|d| d.chunk.name.as_str()).collect();
     assert!(
         !dead_names.contains(&"main"),
         "main entry point should not be flagged as dead"
@@ -88,8 +88,11 @@ fn test_find_dead_code_pub_functions() {
     // include_pub=false: public functions go to possibly_dead_pub
     let (confident, possibly_dead_pub) = store.find_dead_code(false).unwrap();
 
-    let confident_names: Vec<&str> = confident.iter().map(|c| c.name.as_str()).collect();
-    let pub_names: Vec<&str> = possibly_dead_pub.iter().map(|c| c.name.as_str()).collect();
+    let confident_names: Vec<&str> = confident.iter().map(|d| d.chunk.name.as_str()).collect();
+    let pub_names: Vec<&str> = possibly_dead_pub
+        .iter()
+        .map(|d| d.chunk.name.as_str())
+        .collect();
 
     assert!(
         confident_names.contains(&"priv_fn"),
@@ -103,7 +106,7 @@ fn test_find_dead_code_pub_functions() {
     // include_pub=true: both should be in confident
     let (confident, possibly_dead_pub) = store.find_dead_code(true).unwrap();
 
-    let confident_names: Vec<&str> = confident.iter().map(|c| c.name.as_str()).collect();
+    let confident_names: Vec<&str> = confident.iter().map(|d| d.chunk.name.as_str()).collect();
 
     assert!(
         confident_names.contains(&"priv_fn"),
@@ -135,7 +138,7 @@ fn test_find_dead_code_excludes_test_files() {
     let (confident, _) = store.find_dead_code(false).unwrap();
 
     // Functions in test files should not be flagged as dead
-    let dead_names: Vec<&str> = confident.iter().map(|c| c.name.as_str()).collect();
+    let dead_names: Vec<&str> = confident.iter().map(|d| d.chunk.name.as_str()).collect();
     assert!(
         !dead_names.contains(&"test_helper"),
         "Functions in test files should be excluded from dead code detection"


### PR DESCRIPTION
## Summary

Fixes 9 of 10 deferred P4/P3 audit findings from the v0.12.1 audit.

- **Group A** (#390): Unified `is_test_chunk()` — replaces 3 divergent test detection implementations
- **Group B** (#385): Dead code false positive reduction — confidence scoring, entry point exclusions, `--min-confidence` CLI
- **Group C** (#391): Embedder `clear_session(&self)` — `Mutex<Option<Session>>` enables immutable clear, watch mode frees ~500MB after 5min idle
- **Group D** (#388): Pipeline batch size 100K → 5K (bounded peak memory)
- **Group E** (#383): HNSW error messages with actionable guidance + stale temp cleanup
- **Group F** (#384): HNSW file locking (exclusive save, shared load) via Rust 1.93 std API
- **Group G** (#382): `HnswIndex::insert_batch()` for incremental HNSW on Owned variant
- **Group I** (#386): `extract_imports()` helper + C/SQL/Markdown language arms in `where_to_add`
- **Group J** (#387): Doc comment on `LocalPatterns` — closed as non-issue

**Descoped:** Group H (#389) — CAGRA GPU memory requires new disk persistence layer.

16 files changed, +1247 -424. 747 tests pass, clippy clean.

Closes #382, #383, #384, #385, #386, #388, #390, #391.

## Test plan

- [x] `cargo test --features gpu-search` — 747 passed, 0 failed
- [x] `cargo clippy --features gpu-search -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Fresh-eyes review — no blocking issues
- [ ] Verify `cqs dead --min-confidence high` filters correctly
- [ ] Verify `cqs dead --json` includes confidence field

Generated with [Claude Code](https://claude.com/claude-code)
