### PR TITLE
feat: add cqs gather --ref for cross-index context assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **`--ref` scoped search**: `cqs "query" --ref aveva` searches only the named reference index, skipping the project index. Returns raw scores (no weight attenuation). Works with `--name-only` and `--json`. Error on missing ref with `cqs ref list` hint.
+- **`cqs gather --ref`**: Cross-index gather — seeds from a reference index, bridges into project code via embedding similarity, then BFS-expands via the project call graph. Returns both reference context and related project code in a single call.
 - **`--tokens` token budgeting**: Greedy knapsack packing by score within a token budget, across 5 commands:
   - `cqs "query" --tokens 4000` — pack highest-scoring search results into budget
   - `cqs gather "query" --tokens 4000` — pack gathered chunks into budget

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Fall back to Grep/Glob only for exact string matches or when semantic search ret
 - `cqs similar <function>` — find code similar to a given function. Refactoring discovery, duplicates.
 - `cqs explain <function>` — function card: signature, callers, callees, similar. Collapses 4+ lookups into 1.
 - `cqs diff --source <ref>` — semantic diff between indexed snapshots. Requires references (`cqs ref add`).
-- `cqs gather "query"` — smart context assembly: seed search + BFS call graph expansion.
+- `cqs gather "query"` — smart context assembly: seed search + BFS call graph expansion. `--ref name` for cross-index: seeds from reference, bridges into project code.
 - `cqs dead` — find dead code: functions/methods with no callers in the index.
 - `cqs stale` — check index freshness: files modified since last index.
 - `cqs related <function>` — co-occurrence: shared callers, callees, types. What else to review.

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,25 +2,19 @@
 
 ## Right Now
 
-**Token budgeting (`--tokens`) shipped across 5 commands.** 2026-02-12.
+**`cqs gather --ref` cross-index gather shipped.** 2026-02-12.
 
-Implemented `--tokens N` greedy knapsack packing on:
-- `cqs "query" --tokens N` — pack search results into budget
-- `cqs gather --tokens N` — pack gathered chunks into budget
-- `cqs context file --tokens N` — include chunk content within budget
-- `cqs explain func --tokens N` — include target + similar content
-- `cqs scout "task" --tokens N` — fetch and include chunk content
+Seeds from a reference index, retrieves seed embeddings, bridges into project code via embedding similarity, BFS-expands via project call graph. Returns both reference chunks (tagged with source) and expanded project chunks.
 
-Also shipped in same session (PR #398, already merged):
-- `--ref` scoped search — `cqs "query" --ref aveva` skips project index
-- `cqs convert` — document-to-Markdown conversion (PDF, HTML, CHM, web help)
+Files changed: `src/gather.rs` (new `gather_cross_index()`), `src/cli/commands/gather.rs` (--ref handling, cross-index text/JSON display), `src/cli/mod.rs` (--ref flag on Gather + 3 tests), `src/lib.rs` (re-export), `CHANGELOG.md`, `CLAUDE.md`.
 
-Changes uncommitted on `feat/rag-strengthen` branch, ready to commit + PR.
+Also in this session: saved "always do things properly" memory.
+
+Previously shipped (PR #398, merged): `--tokens` on 5 commands, `--ref` scoped search, `cqs convert`.
 
 ## Pending Changes
 
-- Token budgeting across 5 commands (uncommitted on `feat/rag-strengthen`)
-- `PROJECT_CONTINUITY.md` and `docs/notes.toml` — session state
+- `gather --ref` cross-index feature — 6 files, uncommitted on main, needs branch + PR
 
 ## Parked
 
@@ -55,7 +49,7 @@ Changes uncommitted on `feat/rag-strengthen` branch, ready to commit + PR.
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 9 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, Markdown)
-- Tests: 757 total (465 lib + ~280 integration + 12 doc)
+- Tests: 760 total (465 lib + ~283 integration + 12 doc)
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/ and hnsw/ are directories (split from monoliths in v0.9.0)
 - convert/ module (7 files) behind `convert` feature flag

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,7 @@ All agent experience features shipped. CLI-only (MCP removed in v0.10.0).
 
 - [x] Web help ingestion — multi-page HTML sites (AuthorIT, MadCap Flare) auto-detected and merged (PR #397)
 - [x] Token-budgeted output — `--tokens N` on query, gather, context, explain, scout. Greedy knapsack packing by score.
+- [x] Cross-index gather — `cqs gather --ref name` seeds from reference, bridges into project code via embeddings, BFS-expands via project call graph.
 - [ ] Re-ranking — cross-encoder or second-pass scoring on top-N retrieval results. Biggest retrieval quality win.
 
 ### Next — Infrastructure

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,9 @@ pub use store::{ModelInfo, SearchFilter, Store};
 // but need to be accessible to src/cli/* and tests/
 pub use diff::{semantic_diff, DiffResult};
 pub use focused_read::extract_type_names;
-pub use gather::{gather, GatherDirection, GatherOptions, DEFAULT_MAX_EXPANDED_NODES};
+pub use gather::{
+    gather, gather_cross_index, GatherDirection, GatherOptions, DEFAULT_MAX_EXPANDED_NODES,
+};
 pub use impact::{
     analyze_diff_impact, analyze_impact, compute_hints, compute_hints_with_graph,
     compute_hints_with_graph_depth, diff_impact_to_json, impact_to_json, impact_to_mermaid,


### PR DESCRIPTION
## Summary

- **`cqs gather --ref <name>`**: Cross-index gather — seeds from a reference index, retrieves seed embeddings via `get_embeddings_by_ids()`, bridges into project code by searching the project store with each seed's embedding, then BFS-expands via the project call graph
- Returns both reference chunks (tagged `source: <ref_name>`) and expanded project chunks (`source: null`) in a single call
- Text output shows `=== Reference: name ===` / `=== Project ===` section headers with "ref seed" and "bridge" depth labels
- JSON output adds `source` field to chunks when present
- Works with `--tokens` for token-budgeted cross-index gather
- 3 new CLI parsing tests, all 760 existing tests pass

## Test plan

- [x] `cargo build --features gpu-search` — clean
- [x] `cargo clippy --features gpu-search` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --features gpu-search` — 760 pass, 0 fail
- [x] E2E: `cqs gather "Galaxy Database Manager" --ref aveva --json` — 5 ref seeds + 1 project bridge
- [x] E2E: `cqs gather "Galaxy Database Manager" --ref aveva --tokens 4000 --json` — token budgeting works
- [x] E2E: `cqs gather "search implementation"` — normal (non-ref) path unchanged
- [x] E2E: `cqs gather "test" --ref nonexistent` — clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
