### PR TITLE
fix: eliminate unsafe transmute in HNSW load + add --ref integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,7 @@ dependencies = [
  "rand 0.10.0",
  "rayon",
  "regex",
+ "self_cell",
  "serde",
  "serde_json",
  "serial_test",
@@ -3154,6 +3155,12 @@ dependencies = [
  "servo_arc",
  "smallvec",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ tempfile = "3"
 # Document conversion (optional)
 fast_html2md = { version = "0.0", optional = true }
 walkdir = { version = "2", optional = true }
+self_cell = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/hnsw/search.rs
+++ b/src/hnsw/search.rs
@@ -37,8 +37,7 @@ impl HnswIndex {
 
         let neighbors = self
             .inner
-            .hnsw()
-            .search_neighbours(query.as_slice(), k, EF_SEARCH);
+            .with_hnsw(|h| h.search_neighbours(query.as_slice(), k, EF_SEARCH));
 
         neighbors
             .into_iter()


### PR DESCRIPTION
Closes #270

## Summary

- Replace unsafe `transmute` + raw pointer + `ManuallyDrop` + manual `Drop` in HNSW index loading with `self_cell` crate for safe self-referential ownership (#270)
- Add 4 CLI integration tests for `--ref` flag: `query --ref`, `gather --ref`, ref-not-found error, `ref list` (TC-6)

**Unsafe reduction:** 0 transmute, 0 ManuallyDrop, 0 Box::from_raw/into_raw remaining in `src/hnsw/`. Only 5 `unsafe` lines remain (4 Send+Sync trait impls + 1 UnsafeCell access during construction).

## Test plan

- [x] All 831 tests pass (480 lib + 343 integration + 8 doc)
- [x] All 23 HNSW tests pass (safety, search, persist, build, insert_batch, send_sync)
- [x] 4 new --ref integration tests pass
- [x] `cargo clippy --features gpu-search` clean
- [x] `grep -rn "transmute" src/hnsw/` returns 0 code matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
