### PR TITLE
chore: release v0.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.5] - 2026-02-13
+
+### Fixed
+- **Eliminated unsafe transmute in HNSW index loading** (#270): Replaced raw pointer + `transmute` + `ManuallyDrop` + manual `Drop` with `self_cell` crate for safe self-referential ownership. Zero transmute, zero ManuallyDrop, zero Box::from_raw remaining in `src/hnsw/`.
+
+### Added
+- 4 `--ref` CLI integration tests (TC-6): `query --ref`, `gather --ref`, ref-not-found error path, `ref list` verification.
+- `self_cell` dependency (v1) for safe self-referential HNSW index management.
+
 ## [0.12.4] - 2026-02-13
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ src/
   search.rs     - Search algorithms, name matching, HNSW-guided search
   math.rs       - Vector math utilities (cosine similarity, SIMD)
   hnsw/         - HNSW index with batched build, atomic writes
-    mod.rs      - HnswIndex, HnswInner, HnswError, VectorIndex impl
+    mod.rs      - HnswIndex, LoadedHnsw (self_cell), HnswError, VectorIndex impl
     build.rs    - build(), build_batched() construction
     search.rs   - Nearest-neighbor search
     persist.rs  - save(), load(), checksum verification

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2021"
 rust-version = "1.93"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML embeddings."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,16 +2,13 @@
 
 ## Right Now
 
-**v0.12.3 released, clean state.** 2026-02-12.
+**Post-merge clean state.** 2026-02-13.
 
-v0.12.3 released to crates.io + GitHub. Post-release: split `impact.rs` monolith into `src/impact/` directory (PR #402). Added Code Quality section to roadmap.
-
-Next on roadmap: `cqs ci` (Phase 5 in plan), `cqs health` (Phase 3), re-ranking (Phase 4).
+PR #405 merged — eliminated unsafe transmute in HNSW load (`self_cell`), added 4 `--ref` CLI integration tests. Closed #270.
 
 ## Pending Changes
 
-- `PROJECT_CONTINUITY.md` — updated tears (this file)
-- `docs/notes.toml` — 2 new notes added (review composition, risk entry-point exception), uncommitted
+ROADMAP.md, docs/notes.toml, PROJECT_CONTINUITY.md — uncommitted tears updates.
 
 ## Parked
 
@@ -23,6 +20,7 @@ Next on roadmap: `cqs ci` (Phase 5 in plan), `cqs health` (Phase 3), re-ranking 
 - **Phase 8**: Security (index encryption)
 - **ref install** — deferred, tracked in #255
 - **Query-intent routing** — auto-boost ref weight when query mentions product names
+- **P4 audit findings** — 14 deferred items in `docs/audit-triage.md` (reverse BFS depth, risk scoring edge cases, convert TOCTOU, cross-index bridge perf, test gaps)
 
 ## Open Issues
 
@@ -34,19 +32,19 @@ Next on roadmap: `cqs ci` (Phase 5 in plan), `cqs health` (Phase 3), re-ranking 
 - #255: Pre-built reference packages
 
 ### Audit
-- #270: HNSW LoadedHnsw uses unsafe transmute (upstream hnsw_rs)
+- #270: HNSW LoadedHnsw unsafe transmute — closed (PR #405)
 - #389: CAGRA GPU memory — needs disk persistence layer
 
 ## Architecture
 
-- Version: 0.12.3
+- Version: 0.12.5
 - MSRV: 1.93
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 9 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, Markdown)
-- Tests: 808 total (470 lib + ~318 integration + 12 doc + 8 doc-tests)
+- Tests: 732 total (480 lib + 244 integration + 8 doc)
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/ are directories (impact split in PR #402)
 - convert/ module (7 files) behind `convert` feature flag

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current: v0.12.3
+## Current: v0.12.4
 
 All agent experience features shipped. CLI-only (MCP removed in v0.10.0).
 
@@ -36,7 +36,7 @@ Priority order based on competitive gap analysis (Feb 2026).
 
 ### Next — Retrieval Quality
 
-- [ ] Re-ranking — cross-encoder or second-pass scoring on top-N retrieval results. Biggest retrieval quality win.
+- [ ] Re-ranking — cross-encoder `--rerank` flag. Second-pass scoring on top-N retrieval results. Biggest retrieval quality win remaining.
 - [ ] Embedding model eval — benchmark current E5-base-v2 against CodeSage, UniXcoder, Nomic Code on existing eval harness. Quantify gap before committing to upgrade.
 
 ### Next — Code Quality
@@ -44,6 +44,9 @@ Priority order based on competitive gap analysis (Feb 2026).
 - [ ] Extract `read_stdin()` / `run_git_diff()` to shared CLI helper — duplicated in impact_diff.rs, review.rs, will multiply with ci
 - [ ] `store.search()` safety — rename or deprecate to prevent direct use. All user-facing paths should use `search_filtered()`.
 - [ ] `ChunkSummary` type consistency — some paths use stringly-typed fields, others use `Language`/`ChunkType` enums. Unify.
+- [ ] `reverse_bfs_multi` depth accuracy (P4 AC-15) — BFS ordering means depth depends on which changed function reaches a node first, not which is closest. Needs per-source BFS or Dijkstra.
+- [ ] `--ref` CLI integration tests (P4 TC-6) — zero end-to-end tests for the --ref flag across query and gather. Lib-level tests exist but the CLI flow is untested.
+- [ ] Eliminate unsafe transmute in HNSW load (#270) — lifetime transmute in LoadedHnsw. Evaluate: rebuild-from-embeddings, `self_cell`, or switch to safe HNSW crate.
 
 ### Next — Expansion
 

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -452,14 +452,6 @@ mentions = [
 ]
 
 [[note]]
-sentiment = -0.5
-text = "cuvs Rust crate passes CI without GPU feature, but gpu-search build requires matching libcuvs conda package version"
-mentions = [
-    "cuvs",
-    "gpu-search",
-]
-
-[[note]]
 sentiment = 0.5
 text = "cuDNN via conda (conda-forge) keeps libcudnn.so.9 in miniforge3/lib which is already on LD_LIBRARY_PATH — no path changes needed"
 mentions = [
@@ -537,7 +529,7 @@ mentions = [
 sentiment = -0.5
 text = "Half-open vs inclusive interval overlap: hunk [start, start+count) vs chunk [line_start, line_end]. Correct: start <= end_inclusive && exclusive_end > start_inclusive. Using >= with exclusive end is the classic off-by-one."
 mentions = [
-    "src/impact.rs",
+    "src/impact/diff.rs",
     "map_hunks_to_functions",
 ]
 
@@ -545,7 +537,7 @@ mentions = [
 sentiment = 0.5
 text = "compute_hints accepts prefetched_caller_count to avoid duplicate get_callers_full() when caller already has the data. Pattern: pass Optional<precomputed> to helper functions that would otherwise re-query."
 mentions = [
-    "src/impact.rs",
+    "src/impact/hints.rs",
     "compute_hints",
 ]
 
@@ -604,12 +596,15 @@ mentions = [
 [[note]]
 sentiment = -0.5
 text = "Sonnet agents produce shoddy work on audit fixes — ownership bugs (moved Vec used after for loop), missed tracing spans on files they owned. Always use opus agents for code changes. Haiku acceptable only for doc-only edits."
-mentions = ["src/impact.rs"]
+mentions = [
+    "src/impact/",
+    "audit",
+]
 
 [[note]]
 sentiment = 0.5
 text = "P2 audit: analyze_diff_impact changed from &[ChangedFunction] to Vec<ChangedFunction> — callers pass owned vec, return struct populates changed_functions directly instead of leaving empty for caller to fill."
-mentions = ["src/impact.rs"]
+mentions = ["src/impact/diff.rs"]
 
 [[note]]
 sentiment = -0.5
@@ -660,10 +655,11 @@ mentions = [
 
 [[note]]
 sentiment = 0.5
-text = "Token budgeting greedy knapsack pattern ships cleanly across 5 commands. Shared count_tokens helper. Lazy Embedder for commands that dont normally need it. Pattern: sort by score, walk items, accumulate token count, stop at budget."
+text = "Token budgeting greedy knapsack pattern ships cleanly across 5 commands. Generic token_pack<T>() in cli/commands/mod.rs replaces per-command loops. Batch tokenization via Embedder::token_counts_batch(). Pattern: sort by score, walk items, accumulate token count, stop at budget."
 mentions = [
-    "count_tokens",
+    "src/cli/commands/mod.rs",
     "token_pack",
+    "src/embedder.rs",
 ]
 
 [[note]]
@@ -676,10 +672,10 @@ mentions = [
 
 [[note]]
 sentiment = 0.5
-text = "Reference-scoped search via --ref flag reuses multi-index infrastructure but calls search_reference_unweighted() to avoid double-attenuating. Pattern works across query, gather, and diff commands with per-command ref loading."
+text = "Reference-scoped search via --ref flag reuses multi-index infrastructure. search_reference() with apply_weight=false avoids double-attenuating. Pattern works across query, gather, and diff commands with per-command ref loading."
 mentions = [
     "src/reference.rs",
-    "search_reference_unweighted",
+    "search_reference",
 ]
 
 [[note]]
@@ -687,14 +683,14 @@ sentiment = 0.5
 text = "review_diff() composes 5 primitives (parse_unified_diff, map_hunks_to_functions, analyze_diff_impact, compute_risk_batch, match_notes + staleness) into a single structured payload. Pattern for composition commands: load shared data once (call graph, test chunks), pass to multiple analyses, merge results. Avoids N separate CLI calls."
 mentions = [
     "src/review.rs",
-    "src/impact.rs",
+    "src/impact/",
 ]
 
 [[note]]
 sentiment = 0.5
 text = "Risk scoring entry-point exception: functions with 0 callers AND 0 tests get Medium risk, not Low. Score formula (caller_count * (1 - coverage)) gives 0 for these, which would be Low, but they're likely entry points that need tests. Special-case prevents silent coverage gaps."
 mentions = [
-    "src/impact.rs",
+    "src/impact/hints.rs",
     "compute_risk_batch",
 ]
 
@@ -704,4 +700,29 @@ text = "impact.rs monolith split into src/impact/ directory — types, bfs, hint
 mentions = [
     "src/impact/mod.rs",
     "src/impact/analysis.rs",
+]
+
+[[note]]
+sentiment = 1.0
+text = "v0.12.4 audit release: 61 fixes across 14 categories. Subagent-driven development with opus agents worked well — 11 tasks, each with spec + quality review. Key lesson: design tasks with exclusive file ownership to avoid parallel agent conflicts."
+mentions = [
+    "audit-triage.md",
+    "review.rs",
+    "impact",
+]
+
+[[note]]
+sentiment = -0.5
+text = "SQLite 999 variable limit hit in batch inserts — use INSERT_BATCH constants (999/bind_count) and chunk iterations. Applies to calls.rs and chunks.rs batch methods."
+mentions = [
+    "calls.rs",
+    "chunks.rs",
+]
+
+[[note]]
+sentiment = 0.5
+text = "self_cell with #[not_covariant] is the right pattern for hnsw_rs Hnsw<'a> — it's invariant over the lifetime, so covariant access won't compile. Use with_dependent() closure API, not borrow_dependent()."
+mentions = [
+    "src/hnsw/mod.rs",
+    "self_cell",
 ]


### PR DESCRIPTION
## Summary

- Bump version to 0.12.5
- Update CHANGELOG with v0.12.5 entry
- Update CONTRIBUTING.md architecture (self_cell reference)
- Update PROJECT_CONTINUITY.md, ROADMAP.md, notes.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)
