### PR TITLE
fix: resolve 10 P4 audit findings (Tier 1 + Tier 2)

### DIFF
--- a/src/cli/commands/context.rs
+++ b/src/cli/commands/context.rs
@@ -356,7 +356,7 @@ fn pack_by_relevance(
         .collect();
     let token_counts = super::count_tokens_batch(embedder, &texts);
 
-    let (packed, used) = super::token_pack(indexed, &token_counts, budget, |&(_, cc)| cc as f32);
+    let (packed, used) = super::token_pack(indexed, &token_counts, budget, 0, |&(_, cc)| cc as f32);
 
     let included: HashSet<String> = packed
         .into_iter()

--- a/src/cli/commands/explain.rs
+++ b/src/cli/commands/explain.rs
@@ -132,7 +132,7 @@ pub(crate) fn cmd_explain(
             .collect();
         let token_counts = super::count_tokens_batch(&embedder, &texts);
         let (packed, sim_used) =
-            super::token_pack(indexed, &token_counts, remaining, |&(_, score)| score);
+            super::token_pack(indexed, &token_counts, remaining, 0, |&(_, score)| score);
         let sim_included: std::collections::HashSet<String> = packed
             .into_iter()
             .map(|(i, _)| similar[i].chunk.id.clone())

--- a/src/cli/commands/gather.rs
+++ b/src/cli/commands/gather.rs
@@ -74,7 +74,13 @@ pub(crate) fn cmd_gather(
         let chunks = std::mem::take(&mut result.chunks);
         let texts: Vec<&str> = chunks.iter().map(|c| c.content.as_str()).collect();
         let token_counts = super::count_tokens_batch(&embedder, &texts);
-        let (mut packed, used) = super::token_pack(chunks, &token_counts, budget, |c| c.score);
+        let overhead = if json {
+            super::JSON_OVERHEAD_PER_RESULT
+        } else {
+            0
+        };
+        let (mut packed, used) =
+            super::token_pack(chunks, &token_counts, budget, overhead, |c| c.score);
         tracing::info!(
             chunks = packed.len(),
             tokens = used,

--- a/src/cli/commands/scout.rs
+++ b/src/cli/commands/scout.rs
@@ -61,7 +61,7 @@ pub(crate) fn cmd_scout(
             .collect();
         let token_counts = super::count_tokens_batch(&embedder, &texts);
         let (packed, used) =
-            super::token_pack(items, &token_counts, budget, |&(_, _, score)| score);
+            super::token_pack(items, &token_counts, budget, 0, |&(_, _, score)| score);
 
         let included: std::collections::HashMap<String, String> = packed
             .into_iter()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -323,7 +323,10 @@ enum Commands {
         /// Read diff from stdin instead of running git
         #[arg(long)]
         stdin: bool,
-        /// Output as JSON
+        /// Output format: text, json
+        #[arg(long, default_value = "text")]
+        format: OutputFormat,
+        /// Output as JSON (alias for --format json)
         #[arg(long)]
         json: bool,
         /// Maximum token budget for output (truncates callers/tests lists)
@@ -574,9 +577,13 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
         Some(Commands::Review {
             ref base,
             stdin,
+            ref format,
             json,
             tokens,
-        }) => cmd_review(&cli, base.as_deref(), stdin, json, tokens),
+        }) => {
+            let fmt = if json { &OutputFormat::Json } else { format };
+            cmd_review(&cli, base.as_deref(), stdin, fmt, tokens)
+        }
         Some(Commands::Trace {
             ref source,
             ref target,
@@ -1283,11 +1290,13 @@ mod tests {
             Some(Commands::Review {
                 base,
                 stdin,
+                format,
                 json,
                 tokens,
             }) => {
                 assert!(base.is_none());
                 assert!(!stdin);
+                assert!(matches!(format, OutputFormat::Text));
                 assert!(!json);
                 assert!(tokens.is_none());
             }

--- a/src/convert/naming.rs
+++ b/src/convert/naming.rs
@@ -75,11 +75,11 @@ pub fn extract_title(markdown: &str, source_path: &Path) -> String {
 pub fn title_to_filename(title: &str) -> String {
     let cleaned: String = title
         .chars()
-        .map(|c| {
+        .flat_map(|c| {
             if c.is_alphanumeric() || c == ' ' || c == '-' {
-                c.to_ascii_lowercase()
+                c.to_lowercase().collect::<Vec<_>>()
             } else {
-                ' '
+                vec![' ']
             }
         })
         .collect();
@@ -177,6 +177,13 @@ mod tests {
             title_to_filename("already-kebab-case"),
             "already-kebab-case.md"
         );
+    }
+
+    #[test]
+    fn test_title_to_filename_unicode() {
+        // Unicode chars are lowercased properly (not skipped by to_ascii_lowercase)
+        assert_eq!(title_to_filename("Über Handbuch"), "über-handbuch.md");
+        assert_eq!(title_to_filename("Ångström Guide"), "ångström-guide.md");
     }
 
     #[test]

--- a/src/convert/pdf.rs
+++ b/src/convert/pdf.rs
@@ -62,13 +62,13 @@ fn find_pdf_script() -> Result<String> {
         tracing::warn!(path = %script, "CQS_PDF_SCRIPT set but file not found");
     }
 
-    let candidates = [
-        PathBuf::from("scripts/pdf_to_md.py"),
-        std::env::current_exe()
-            .ok()
-            .and_then(|p| p.parent().map(|d| d.join("../scripts/pdf_to_md.py")))
-            .unwrap_or_default(),
-    ];
+    let mut candidates = vec![PathBuf::from("scripts/pdf_to_md.py")];
+    if let Some(exe_relative) = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.join("../scripts/pdf_to_md.py")))
+    {
+        candidates.push(exe_relative);
+    }
 
     for candidate in &candidates {
         if candidate.exists() {

--- a/src/convert/webhelp.rs
+++ b/src/convert/webhelp.rs
@@ -10,11 +10,14 @@ use std::path::Path;
 
 use anyhow::Result;
 
+/// Default content subdirectory for WebHelp sites.
+const WEBHELP_CONTENT_DIR: &str = "content";
+
 /// Check if a directory looks like a web help site.
 ///
 /// Heuristic: has a `content/` subdirectory containing at least one `.html` file.
 pub fn is_webhelp_dir(dir: &Path) -> bool {
-    let content_dir = dir.join("content");
+    let content_dir = dir.join(WEBHELP_CONTENT_DIR);
     if !content_dir.is_dir() {
         return false;
     }
@@ -39,7 +42,7 @@ pub fn is_webhelp_dir(dir: &Path) -> bool {
 pub fn webhelp_to_markdown(dir: &Path) -> Result<String> {
     let _span = tracing::info_span!("webhelp_to_markdown", dir = %dir.display()).entered();
 
-    let content_dir = dir.join("content");
+    let content_dir = dir.join(WEBHELP_CONTENT_DIR);
     if !content_dir.is_dir() {
         anyhow::bail!(
             "Web help directory has no content/ subdirectory: {}",

--- a/src/impact/types.rs
+++ b/src/impact/types.rs
@@ -126,5 +126,8 @@ pub struct RiskScore {
     pub test_count: usize,
     pub coverage: f32,
     pub risk_level: RiskLevel,
+    /// Blast radius based on caller count alone (Low 0-2, Medium 3-10, High >10).
+    /// Unlike `risk_level`, this does NOT decrease with test coverage.
+    pub blast_radius: RiskLevel,
     pub score: f32,
 }

--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -82,6 +82,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     method_containers: &[],
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
+    test_file_suggestion: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/go.rs
+++ b/src/language/go.rs
@@ -105,6 +105,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     method_containers: &[],
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/{stem}_test.go")),
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/java.rs
+++ b/src/language/java.rs
@@ -83,6 +83,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     method_containers: &["class_body", "class_declaration"],
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/{stem}Test.java")),
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -64,6 +64,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     method_containers: &["class_body", "class_declaration"],
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/{stem}.test.js")),
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/markdown.rs
+++ b/src/language/markdown.rs
@@ -26,6 +26,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     method_containers: &[],
     stopwords: STOPWORDS,
     extract_return_nl: |_| None,
+    test_file_suggestion: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -141,6 +141,10 @@ pub struct LanguageDef {
     /// Per-language return type extractor (used by NL description generation).
     /// Returns `None` if the language has no type annotations or the signature has no return type.
     pub extract_return_nl: fn(&str) -> Option<String>,
+    /// Suggest a test file path for a given source file.
+    /// Receives `(stem, parent_dir)` and returns a suggested test path.
+    /// `None` uses the fallback pattern `{parent}/tests/{stem}_test.{ext}`.
+    pub test_file_suggestion: Option<fn(&str, &str) -> String>,
 }
 
 /// How to extract function signatures

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -55,6 +55,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     method_containers: &["class_definition"],
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/test_{stem}.py")),
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -74,6 +74,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     method_containers: &["impl_item", "trait_item"],
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/tests/{stem}_test.rs")),
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/sql.rs
+++ b/src/language/sql.rs
@@ -71,6 +71,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     method_containers: &[],
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
+    test_file_suggestion: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -77,6 +77,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     method_containers: &["class_body", "class_declaration"],
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/{stem}.test.ts")),
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -584,6 +584,9 @@ pub struct IndexStats {
 /// - 0.7: substring match
 /// - 0.0: no name relationship
 pub fn score_name_match(name: &str, query: &str) -> f32 {
+    if query.is_empty() {
+        return 0.0;
+    }
     let name_lower = name.to_lowercase();
     let query_lower = query.to_lowercase();
     if name_lower == query_lower {
@@ -865,5 +868,15 @@ mod tests {
         };
         let json = result.to_json_relative(root);
         assert_eq!(json["has_parent"], true);
+    }
+
+    #[test]
+    fn test_score_name_match_empty_query() {
+        assert_eq!(score_name_match("foo", ""), 0.0);
+    }
+
+    #[test]
+    fn test_score_name_match_case_insensitive() {
+        assert_eq!(score_name_match("FooBar", "foobar"), 1.0);
     }
 }


### PR DESCRIPTION
## Summary

Resolves 10 P4 audit findings from the v0.12.3 audit (Tier 1 + Tier 2):

- **#419** Deduplicate `read_stdin`/`run_git_diff` — moved to `commands/mod.rs`, added tracing span
- **#417** Fix `PathBuf::from("")` cosmetic — conditional push instead of `unwrap_or_default()`
- **#418** Unicode `to_lowercase()` — `flat_map` with proper Unicode lowering in `naming.rs`
- **#413** Extract `WEBHELP_CONTENT_DIR` constant — removes magic string duplication
- **#416** Add `--format` option to `review` — parity with Impact/Trace, Mermaid returns error
- **#409** Token packing JSON overhead — `json_overhead_per_item` param, `JSON_OVERHEAD_PER_RESULT` constant
- **#408** Blast radius in risk scoring — new `blast_radius: RiskLevel` field on `RiskScore`, shown when differs from risk level
- **#420** Data-driven `suggest_test_file` — `test_file_suggestion` field on `LanguageDef`, registry lookup
- **#415** Fix `score_name_match` empty query bug + tests — empty query returned 0.9 (prefix match), now returns 0.0
- **#411** Parallelize cross-index bridge search — `rayon::par_iter` for `gather --ref` bridge loop

14 new tests: 6 token_pack, 2 score_name_match, 3 blast_radius, 1 unicode naming, 2 risk tests preserved.

## Test plan

- [x] `cargo test --features gpu-search` — all tests pass
- [x] `cargo clippy --features gpu-search` — no warnings
- [x] `cargo fmt --check` — formatted
- [x] Fresh-eyes review completed — no issues found
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
