### PR TITLE
feat: add --rerank cross-encoder re-ranking for query results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **`cqs ci` command** — CI pipeline analysis composing review_diff + dead code detection + gate evaluation. `--gate high|medium|off` controls failure threshold (exit code 3 on fail). `--base`, `--stdin`, `--json`, `--tokens` supported.
+- **`--rerank` flag** — Cross-encoder re-ranking for query results. Second-pass scoring with `cross-encoder/ms-marco-MiniLM-L-6-v2` reorders top results for higher accuracy. Over-retrieves 4x then re-scores. Works with no-ref and `--ref` scoped queries. Warns and skips for multi-index search (incompatible score scales).
 
 ## [0.12.6] - 2026-02-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Project skills in `.claude/skills/`. Use `/skill-name` to invoke:
 cqs "search query" --json              # semantic search (default: hybrid RRF)
 cqs "function_name" --name-only --json # definition lookup (fast, no embedding)
 cqs "query" --semantic-only --json     # pure vector similarity, no keyword RRF
+cqs "query" --rerank --json            # cross-encoder re-ranking (slower, more accurate)
 cqs "query" --lang rust --path "src/cli/**" --json  # scoped search
 cqs "query" --ref aveva --json         # search only a named reference (skip project)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,7 @@ src/
     calls.rs    - Call graph extraction, callee filtering
     markdown.rs - Heading-based markdown parser, cross-reference extraction
   embedder.rs   - ONNX model (E5-base-v2), 769-dim embeddings
+  reranker.rs   - Cross-encoder re-ranking (ms-marco-MiniLM-L-6-v2)
   search.rs     - Search algorithms, name matching, HNSW-guided search
   math.rs       - Vector math utilities (cosine similarity, SIMD)
   hnsw/         - HNSW index with batched build, atomic writes

--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Key commands (all support `--json`):
 - `cqs "query"` - semantic search (hybrid RRF by default)
 - `cqs "name" --name-only` - definition lookup (fast, no embedding)
 - `cqs "query" --semantic-only` - pure vector similarity, no keyword RRF
+- `cqs "query" --rerank` - cross-encoder re-ranking (slower, more accurate)
 - `cqs "query" --note-only` - search only notes (skip code results)
 - `cqs read <path>` - file with context notes injected as comments
 - `cqs read --focus <function>` - function + type dependencies only

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,7 @@ All agent experience features shipped. CLI-only (MCP removed in v0.10.0).
 - Eliminate unsafe transmute in HNSW load + `--ref` integration tests (PR #405, v0.12.5)
 - v0.12.3 audit: 73/76 findings fixed (P1-P3 complete, 11/14 P4 fixed) (PR #421, v0.12.6)
 - `cqs ci` — CI pipeline mode with gate logic and exit codes
+- Cross-encoder re-ranking — `--rerank` flag on query, ms-marco-MiniLM-L-6-v2
 
 ### Next — New Commands
 
@@ -39,7 +40,7 @@ Priority order based on competitive gap analysis (Feb 2026).
 
 ### Next — Retrieval Quality
 
-- [ ] Re-ranking — cross-encoder `--rerank` flag. Second-pass scoring on top-N retrieval results. Biggest retrieval quality win remaining.
+- [x] Re-ranking — cross-encoder `--rerank` flag. Second-pass scoring on top-N retrieval results. Biggest retrieval quality win remaining.
 - [ ] Embedding model eval — benchmark current E5-base-v2 against CodeSage, UniXcoder, Nomic Code on existing eval harness. Quantify gap before committing to upgrade.
 
 ### Next — Code Quality

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -157,6 +157,10 @@ pub struct Cli {
     #[arg(long)]
     semantic_only: bool,
 
+    /// Re-rank results with cross-encoder (slower, more accurate)
+    #[arg(long)]
+    rerank: bool,
+
     /// Output as JSON
     #[arg(long)]
     json: bool,
@@ -1137,6 +1141,34 @@ mod tests {
             Cli::try_parse_from(["cqs", "--ref", "aveva", "--name-only", "some_function"]).unwrap();
         assert_eq!(cli.ref_name, Some("aveva".to_string()));
         assert!(cli.name_only);
+    }
+
+    // ===== --rerank flag tests =====
+
+    #[test]
+    fn test_cli_rerank_flag() {
+        let cli = Cli::try_parse_from(["cqs", "--rerank", "search query"]).unwrap();
+        assert!(cli.rerank);
+    }
+
+    #[test]
+    fn test_cli_rerank_default_false() {
+        let cli = Cli::try_parse_from(["cqs", "search query"]).unwrap();
+        assert!(!cli.rerank);
+    }
+
+    #[test]
+    fn test_cli_rerank_with_ref() {
+        let cli = Cli::try_parse_from(["cqs", "--rerank", "--ref", "aveva", "query"]).unwrap();
+        assert!(cli.rerank);
+        assert_eq!(cli.ref_name, Some("aveva".to_string()));
+    }
+
+    #[test]
+    fn test_cli_rerank_with_limit() {
+        let cli = Cli::try_parse_from(["cqs", "--rerank", "-n", "20", "query"]).unwrap();
+        assert!(cli.rerank);
+        assert_eq!(cli.limit, 20);
     }
 
     // ===== --tokens flag tests =====

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -735,7 +735,7 @@ static CACHED_PROVIDER: OnceCell<ExecutionProvider> = OnceCell::new();
 ///
 /// Provider detection is expensive (checks CUDA/TensorRT availability).
 /// Result is cached in a static OnceCell for subsequent calls.
-fn select_provider() -> ExecutionProvider {
+pub(crate) fn select_provider() -> ExecutionProvider {
     *CACHED_PROVIDER.get_or_init(detect_provider)
 }
 
@@ -762,7 +762,7 @@ fn detect_provider() -> ExecutionProvider {
 }
 
 /// Create an ort session with the specified provider
-fn create_session(
+pub(crate) fn create_session(
     model_path: &Path,
     provider: ExecutionProvider,
 ) -> Result<Session, EmbedderError> {
@@ -790,7 +790,7 @@ fn create_session(
 }
 
 /// Pad 2D sequences to a fixed length
-fn pad_2d_i64(inputs: &[Vec<i64>], max_len: usize, pad_value: i64) -> Array2<i64> {
+pub(crate) fn pad_2d_i64(inputs: &[Vec<i64>], max_len: usize, pad_value: i64) -> Array2<i64> {
     let batch_size = inputs.len();
     let mut arr = Array2::from_elem((batch_size, max_len), pad_value);
     for (i, seq) in inputs.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub mod reference;
 pub mod store;
 
 pub mod ci;
+pub mod reranker;
 
 // Internal modules - not part of public library API
 // These are pub(crate) to hide implementation details, but specific items are
@@ -84,6 +85,7 @@ pub use note::{
     NOTES_HEADER,
 };
 pub use parser::{Chunk, Parser};
+pub use reranker::Reranker;
 pub use store::{ModelInfo, SearchFilter, Store};
 
 // Re-exports for binary crate (CLI) - these are NOT part of the public library API

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -1,0 +1,269 @@
+//! Cross-encoder re-ranking for second-pass scoring
+//!
+//! Reorders search results using a cross-encoder model that scores
+//! (query, passage) pairs directly, producing more accurate rankings
+//! than embedding cosine similarity alone.
+//!
+//! Uses `cross-encoder/ms-marco-MiniLM-L-6-v2` (~91MB ONNX, 22M params).
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use ndarray::Array2;
+use once_cell::sync::OnceCell;
+use ort::session::Session;
+
+use crate::embedder::{create_session, pad_2d_i64, select_provider, ExecutionProvider};
+use crate::store::SearchResult;
+
+const MODEL_REPO: &str = "cross-encoder/ms-marco-MiniLM-L-6-v2";
+const MODEL_FILE: &str = "onnx/model.onnx";
+const TOKENIZER_FILE: &str = "tokenizer.json";
+
+#[derive(Debug, thiserror::Error)]
+pub enum RerankerError {
+    #[error("Model download failed: {0}")]
+    ModelDownload(String),
+    #[error("Tokenizer error: {0}")]
+    Tokenizer(String),
+    #[error("Inference error: {0}")]
+    Inference(String),
+}
+
+impl From<ort::Error> for RerankerError {
+    fn from(e: ort::Error) -> Self {
+        RerankerError::Inference(e.to_string())
+    }
+}
+
+/// Cross-encoder reranker for second-pass scoring
+///
+/// Lazy-loads the model on first use, same pattern as [`crate::Embedder`].
+/// Scores (query, passage) pairs with a cross-encoder, then re-sorts results.
+pub struct Reranker {
+    session: Mutex<Option<Session>>,
+    tokenizer: OnceCell<tokenizers::Tokenizer>,
+    model_paths: OnceCell<(PathBuf, PathBuf)>,
+    provider: ExecutionProvider,
+    max_length: usize,
+}
+
+impl Reranker {
+    /// Create a new reranker with lazy model loading
+    pub fn new() -> Result<Self, RerankerError> {
+        let provider = select_provider();
+        Ok(Self {
+            session: Mutex::new(None),
+            tokenizer: OnceCell::new(),
+            model_paths: OnceCell::new(),
+            provider,
+            max_length: 512,
+        })
+    }
+
+    /// Re-rank search results using cross-encoder scoring
+    ///
+    /// Scores each (query, result.content) pair, re-sorts by score descending,
+    /// and truncates to `limit`. No-op for 0 or 1 results.
+    pub fn rerank(
+        &self,
+        query: &str,
+        results: &mut Vec<SearchResult>,
+        limit: usize,
+    ) -> Result<(), RerankerError> {
+        let _span = tracing::info_span!(
+            "rerank",
+            count = results.len(),
+            limit,
+            query_len = query.len()
+        )
+        .entered();
+        if results.len() <= 1 {
+            return Ok(());
+        }
+
+        let tokenizer = self.tokenizer()?;
+
+        // 1. Tokenize (query, passage) pairs
+        let encodings: Vec<tokenizers::Encoding> = results
+            .iter()
+            .map(|r| {
+                tokenizer
+                    .encode((query, r.chunk.content.as_str()), true)
+                    .map_err(|e| RerankerError::Tokenizer(e.to_string()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // 2. Build padded tensors
+        let input_ids: Vec<Vec<i64>> = encodings
+            .iter()
+            .map(|e| e.get_ids().iter().map(|&id| id as i64).collect())
+            .collect();
+        let attention_mask: Vec<Vec<i64>> = encodings
+            .iter()
+            .map(|e| e.get_attention_mask().iter().map(|&m| m as i64).collect())
+            .collect();
+        let max_len = input_ids
+            .iter()
+            .map(|v| v.len())
+            .max()
+            .unwrap_or(0)
+            .min(self.max_length);
+        if max_len == 0 {
+            return Ok(()); // Nothing to score — empty tokenization
+        }
+
+        let ids_arr = pad_2d_i64(&input_ids, max_len, 0);
+        let mask_arr = pad_2d_i64(&attention_mask, max_len, 0);
+        let type_arr = Array2::<i64>::zeros((results.len(), max_len));
+
+        // Create tensors (ort requires Value, not raw ndarray)
+        use ort::value::Tensor;
+        let ids_tensor = Tensor::from_array(ids_arr)?;
+        let mask_tensor = Tensor::from_array(mask_arr)?;
+        let type_tensor = Tensor::from_array(type_arr)?;
+
+        // 3. Run inference
+        let mut session_guard = self.session()?;
+        let session = session_guard.as_mut().unwrap(); // Safe: session() guarantees Some
+        let outputs = session.run(ort::inputs![
+            "input_ids" => ids_tensor,
+            "attention_mask" => mask_tensor,
+            "token_type_ids" => type_tensor,
+        ])?;
+
+        // 4. Extract logits, apply sigmoid
+        // Cross-encoder output is typically "logits" with shape [batch, 1] or [batch]
+        // ort rc.11 try_extract_tensor returns (Vec<i64>, Vec<f32>)
+        let (shape, data) = outputs[0].try_extract_tensor::<f32>()?;
+        let batch_size = results.len();
+
+        // Handle [batch, 1] → stride 1, or [batch] → stride 1
+        let stride = if shape.len() == 2 {
+            shape[1] as usize
+        } else {
+            1
+        };
+
+        let expected_len = batch_size * stride;
+        if data.len() < expected_len {
+            return Err(RerankerError::Inference(format!(
+                "Model output too short: expected {} elements, got {}",
+                expected_len,
+                data.len()
+            )));
+        }
+
+        for (i, result) in results.iter_mut().enumerate() {
+            let logit = data[i * stride];
+            result.score = sigmoid(logit);
+        }
+
+        // 5. Sort descending by score, truncate
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        results.truncate(limit);
+
+        tracing::info!(reranked = results.len(), batch_size, "Re-ranking complete");
+        Ok(())
+    }
+
+    /// Download model and tokenizer from HuggingFace Hub
+    fn model_paths(&self) -> Result<&(PathBuf, PathBuf), RerankerError> {
+        self.model_paths.get_or_try_init(|| {
+            let _span = tracing::info_span!("reranker_model_download").entered();
+            use hf_hub::api::sync::Api;
+
+            let api = Api::new().map_err(|e| RerankerError::ModelDownload(e.to_string()))?;
+            let repo = api.model(MODEL_REPO.to_string());
+
+            let model_path = repo
+                .get(MODEL_FILE)
+                .map_err(|e| RerankerError::ModelDownload(e.to_string()))?;
+            let tokenizer_path = repo
+                .get(TOKENIZER_FILE)
+                .map_err(|e| RerankerError::ModelDownload(e.to_string()))?;
+
+            tracing::info!(model = %model_path.display(), "Reranker model ready");
+            Ok((model_path, tokenizer_path))
+        })
+    }
+
+    /// Get or initialize the ONNX session
+    fn session(&self) -> Result<std::sync::MutexGuard<'_, Option<Session>>, RerankerError> {
+        let mut guard = self.session.lock().unwrap_or_else(|p| p.into_inner());
+        if guard.is_none() {
+            let _span = tracing::info_span!("reranker_session_init").entered();
+            let (model_path, _) = self.model_paths()?;
+            *guard = Some(
+                create_session(model_path, self.provider)
+                    .map_err(|e| RerankerError::Inference(e.to_string()))?,
+            );
+            tracing::info!("Reranker session initialized");
+        }
+        Ok(guard)
+    }
+
+    /// Get or initialize the tokenizer
+    fn tokenizer(&self) -> Result<&tokenizers::Tokenizer, RerankerError> {
+        let (_, tokenizer_path) = self.model_paths()?;
+        self.tokenizer.get_or_try_init(|| {
+            let _span = tracing::info_span!("reranker_tokenizer_init").entered();
+            tokenizers::Tokenizer::from_file(tokenizer_path)
+                .map_err(|e| RerankerError::Tokenizer(e.to_string()))
+        })
+    }
+}
+
+fn sigmoid(x: f32) -> f32 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sigmoid_zero() {
+        let result = sigmoid(0.0);
+        assert!((result - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_sigmoid_large_positive() {
+        let result = sigmoid(10.0);
+        assert!(result > 0.999);
+    }
+
+    #[test]
+    fn test_sigmoid_large_negative() {
+        let result = sigmoid(-10.0);
+        assert!(result < 0.001);
+    }
+
+    #[test]
+    fn test_sigmoid_extreme_negative() {
+        // Should not panic or produce NaN
+        let result = sigmoid(-100.0);
+        assert!(result >= 0.0 && result.is_finite());
+    }
+
+    #[test]
+    fn test_reranker_new() {
+        // Construction should succeed (no model download yet — lazy)
+        let reranker = Reranker::new();
+        assert!(reranker.is_ok());
+    }
+
+    #[test]
+    fn test_rerank_empty_results() {
+        let reranker = Reranker::new().unwrap();
+        let mut results = Vec::new();
+        let result = reranker.rerank("test query", &mut results, 10);
+        assert!(result.is_ok());
+        assert!(results.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `--rerank` flag for cross-encoder re-ranking of query results
- Second-pass scoring with `cross-encoder/ms-marco-MiniLM-L-6-v2` (~91MB ONNX, 22M params)
- Over-retrieves 4x candidates, then re-scores with sigmoid-normalized logits for higher accuracy
- Works with no-ref and `--ref` scoped queries; warns and skips for multi-index search (incompatible score scales)
- Incompatible with `--name-only` (requires embedding search)
- New `src/reranker.rs` module follows `Embedder` pattern: lazy ONNX session, HF Hub download, GPU detection
- Widens `select_provider()`, `create_session()`, `pad_2d_i64()` to `pub(crate)` in embedder for reuse

## Test plan

- [x] 6 unit tests: sigmoid edge cases, Reranker construction, empty results
- [x] 4 CLI parsing tests: flag presence, default, with --ref, with --limit
- [x] Full test suite passes (843 tests)
- [x] Clippy clean, no warnings
- [ ] Manual: `cqs "query" --rerank` produces reordered results
- [ ] Manual: `cqs "query" --rerank --name-only` shows error message
- [ ] Manual: multi-index search with `--rerank` shows warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
