### PR TITLE
refactor: DocFormat registry table (#412)

### DIFF
--- a/src/convert/html.rs
+++ b/src/convert/html.rs
@@ -1,5 +1,7 @@
 //! HTML to Markdown conversion using `fast_html2md`.
 
+use std::path::Path;
+
 use anyhow::Result;
 
 /// Convert HTML source to Markdown.
@@ -18,4 +20,16 @@ pub fn html_to_markdown(source: &str) -> Result<String> {
 
     tracing::info!(bytes = markdown.len(), "HTML converted to markdown");
     Ok(markdown)
+}
+
+/// Convert an HTML file to Markdown.
+///
+/// Reads the file at `path` and converts its HTML content to Markdown.
+/// This is the path-based wrapper used by `FORMAT_TABLE`; the string-based
+/// [`html_to_markdown`] is still used directly by `chm` and `webhelp`.
+pub fn html_file_to_markdown(path: &Path) -> Result<String> {
+    let _span = tracing::info_span!("html_file_to_markdown", path = %path.display()).entered();
+    let source = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", path.display(), e))?;
+    html_to_markdown(&source)
 }


### PR DESCRIPTION
## Summary

Closes #412. Replace 4 separate match blocks on `DocFormat` with a static `FORMAT_TABLE` array.

- **Before:** Adding a new format requires 6 changes (enum variant, Display arm, detect_format arm, convert_file arm, pub mod, test assertion)
- **After:** 3 changes (enum variant, FORMAT_TABLE row, pub mod)

Changes:
- `FormatEntry` struct + `FORMAT_TABLE` static array with variant, display name, extensions, converter fn
- `html_file_to_markdown(Path)` wrapper normalizes all converters to same signature
- `markdown_passthrough()` replaces inline `read_to_string` in dispatch
- Display, detect_format, convert_file dispatch all driven from the table
- Table-driven tests replace manual test assertions (completeness + roundtrip + case-insensitivity)

## Test plan

- [x] All 27 convert module tests pass
- [x] Full suite passes (500+ tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
