### PR TITLE
chore: groom notes — remove 2 stale, update 1 renamed method

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,15 +2,12 @@
 
 ## Right Now
 
-**v0.12.7 post-release cleanup complete.** 2026-02-13.
+**v0.12.8 released + DocFormat registry refactor.** 2026-02-14.
 
-All shipped in PR #428:
-- Skills synced with v0.12.7 CLI flags (created `cqs-review`, updated 8 skills, updated bootstrap)
-- Added `--json` to `stats`, `notes list`, `ref list` (code existed, clap routing was broken)
-- Stale warnings moved from stdout to stderr (stats, gc, ci, review)
-- Fixed `-q` references in gather/scout skills
-- Notes groomed (90→91: removed 2 MEMORY.md duplicates, added 3 from trial run)
-- Comprehensive 56-command CLI trial run verified all functionality
+This session:
+- v0.12.8 released (PR #430, #431): `cqs health`, `cqs suggest`, search safety, TOCTOU fix, gather tests
+- DocFormat registry refactor (PR #432): static FORMAT_TABLE replaces 4 match blocks, 6→3 changes per variant
+- Issues closed: #410, #412, #414
 
 ## Pending Changes
 
@@ -25,7 +22,7 @@ None.
 - **Phase 8**: Security (index encryption)
 - **ref install** — deferred, tracked in #255
 - **Query-intent routing** — auto-boost ref weight when query mentions product names
-- **P4 audit findings** — 3 remaining in `docs/audit-triage.md` (#407 reverse BFS depth, #410 convert TOCTOU, #414 cross-index tests)
+- **P4 audit findings** — 1 remaining (#407 reverse BFS depth)
 
 ## Open Issues
 
@@ -41,7 +38,7 @@ None.
 
 ## Architecture
 
-- Version: 0.12.7
+- Version: 0.12.8
 - MSRV: 1.93
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -345,7 +345,7 @@ mentions = [
 
 [[note]]
 sentiment = -1.0
-text = "Never call store.search() directly in production code — raw embedding cosine only, no RRF hybrid or keyword matching. Always use search_filtered() or search_unified_with_index(). gather() and search_across_projects() both had this bug, fixed in PR #305."
+text = "Never call search_embedding_only() directly in production code — raw embedding cosine only, no RRF hybrid or keyword matching. Method was originally store.search(), renamed in PR #430 to make misuse obvious. Always use search_filtered() or search_unified_with_index(). gather() and search_across_projects() both had this bug, fixed in PR #305."
 mentions = [
     "src/gather.rs",
     "src/project.rs",
@@ -743,21 +743,4 @@ mentions = [
     "src/cli/commands/mod.rs",
     ".claude/skills/cqs-gather/SKILL.md",
     ".claude/skills/cqs-scout/SKILL.md",
-]
-
-[[note]]
-sentiment = -0.5
-text = "notes list, ref list, and stats don't support --json. Every other command that produces structured data has it. Inconsistency found during comprehensive CLI trial run."
-mentions = [
-    "src/cli/commands/notes.rs",
-    "src/cli/commands/reference.rs",
-    "src/cli/mod.rs",
-]
-
-[[note]]
-sentiment = -0.5
-text = "Stale file warnings print to stdout before JSON output, breaking JSON parsers. Commands like explain emit 'warning: N result files changed...' to stdout. Should go to stderr. Workaround: pipe stderr to /dev/null when parsing JSON."
-mentions = [
-    "src/cli/mod.rs",
-    "src/cli/commands/mod.rs",
 ]


### PR DESCRIPTION
## Summary

- Remove 2 stale notes (--json support fixed in PR #428, stale warnings to stderr fixed in PR #428)
- Update 1 note: `store.search()` renamed to `search_embedding_only()` in PR #430

93 → 91 notes.

## Test plan

- [x] `cqs notes list` shows 91 notes
- [x] No broken mentions (all file paths verified via glob)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
