### PR TITLE
refactor: unify ChunkSummary type consistency

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ Priority order based on competitive gap analysis (Feb 2026).
 - [ ] `cqs drift` — detect semantic drift between reference snapshots. Embedding distance, not just text diff. Surface functions that changed behavior.
 - [x] `cqs suggest` — auto-generate notes from code patterns. Scan for anti-patterns (unwrap in non-test code, high-caller untested functions, dead code clusters).
 - [ ] `cqs deps` — type-level dependency impact. Trace struct/enum usage through functions and tests. Deeper than caller-only analysis.
-- [ ] `cqs chat` — interactive REPL for chained queries. Keep store open across commands, pipeline syntax (`search | callers | test-map`).
+- [ ] `cqs chat` — interactive REPL for chained queries. Build order: (1) `ChunkSummary` unification, (2) batch mode `--batch` (persistent store, stdin commands), (3) REPL (readline), (4) pipeline syntax (`search | callers | test-map`).
 
 ### Next — Retrieval Quality
 
@@ -52,7 +52,7 @@ Priority order based on competitive gap analysis (Feb 2026).
 
 - [x] `store.search()` safety — renamed to `search_embedding_only()` to prevent direct use. All user-facing paths should use `search_filtered()`.
 - [x] `DocFormat` registry table (#412) — static FORMAT_TABLE replaces 4 match blocks, 6→3 changes per new variant.
-- [ ] `ChunkSummary` type consistency — some paths use stringly-typed fields, others use `Language`/`ChunkType` enums. Unify.
+- [x] `ChunkSummary` type consistency — `ChunkIdentity`, `LightChunk`, `GatheredChunk` now use `Language`/`ChunkType` enums. Parse boundary at SQL read.
 - [ ] `reverse_bfs_multi` depth accuracy (#407) — BFS ordering means depth depends on which changed function reaches a node first, not which is closest. Needs per-source BFS or Dijkstra.
 - [x] Convert filename TOCTOU race (#410) — atomic `create_new` instead of check-then-write.
 - [x] `gather_cross_index` tests (#414) — 4 integration tests added.

--- a/src/cli/commands/gather.rs
+++ b/src/cli/commands/gather.rs
@@ -131,6 +131,8 @@ pub(crate) fn cmd_gather(
                     "file": c.file.to_string_lossy().replace('\\', "/"),
                     "line_start": c.line_start,
                     "line_end": c.line_end,
+                    "language": c.language.to_string(),
+                    "chunk_type": c.chunk_type.to_string(),
                     "signature": c.signature,
                     "score": c.score,
                     "depth": c.depth,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -56,7 +56,7 @@ impl From<&ChunkIdentity> for ChunkKey {
         ChunkKey {
             origin: c.origin.clone(),
             name: c.name.clone(),
-            chunk_type: c.chunk_type.parse().unwrap_or(ChunkType::Function),
+            chunk_type: c.chunk_type,
         }
     }
 }
@@ -77,20 +77,13 @@ pub fn semantic_diff(
     let target_ids = target_store.all_chunk_identities_filtered(language_filter)?;
 
     // Collapse windowed chunks: keep only window_idx=0 (or None)
-    // When language filter is active, also exclude "unknown" chunk types
     let source_ids: Vec<_> = source_ids
         .into_iter()
-        .filter(|c| {
-            c.window_idx.is_none_or(|i| i == 0)
-                && (language_filter.is_none() || c.chunk_type != "unknown")
-        })
+        .filter(|c| c.window_idx.is_none_or(|i| i == 0))
         .collect();
     let target_ids: Vec<_> = target_ids
         .into_iter()
-        .filter(|c| {
-            c.window_idx.is_none_or(|i| i == 0)
-                && (language_filter.is_none() || c.chunk_type != "unknown")
-        })
+        .filter(|c| c.window_idx.is_none_or(|i| i == 0))
         .collect();
 
     tracing::debug!(
@@ -120,10 +113,7 @@ pub fn semantic_diff(
             added.push(DiffEntry {
                 name: target_chunk.name.clone(),
                 file: target_chunk.origin.clone(),
-                chunk_type: target_chunk
-                    .chunk_type
-                    .parse()
-                    .unwrap_or(ChunkType::Function),
+                chunk_type: target_chunk.chunk_type,
                 similarity: None,
             });
         }
@@ -135,10 +125,7 @@ pub fn semantic_diff(
             removed.push(DiffEntry {
                 name: source_chunk.name.clone(),
                 file: source_chunk.origin.clone(),
-                chunk_type: source_chunk
-                    .chunk_type
-                    .parse()
-                    .unwrap_or(ChunkType::Function),
+                chunk_type: source_chunk.chunk_type,
                 similarity: None,
             });
         }
@@ -163,10 +150,7 @@ pub fn semantic_diff(
                     modified.push(DiffEntry {
                         name: target_chunk.name.clone(),
                         file: target_chunk.origin.clone(),
-                        chunk_type: target_chunk
-                            .chunk_type
-                            .parse()
-                            .unwrap_or(ChunkType::Function),
+                        chunk_type: target_chunk.chunk_type,
                         similarity: Some(sim),
                     });
                 } else {
@@ -178,10 +162,7 @@ pub fn semantic_diff(
                 modified.push(DiffEntry {
                     name: target_chunk.name.clone(),
                     file: target_chunk.origin.clone(),
-                    chunk_type: target_chunk
-                        .chunk_type
-                        .parse()
-                        .unwrap_or(ChunkType::Function),
+                    chunk_type: target_chunk.chunk_type,
                     similarity: None,
                 });
             }

--- a/src/gather.rs
+++ b/src/gather.rs
@@ -13,6 +13,8 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use rayon::prelude::*;
 
+use crate::parser::{ChunkType, Language};
+
 use crate::store::helpers::{CallGraph, SearchFilter};
 use crate::store::SearchResult;
 use crate::Store;
@@ -113,6 +115,8 @@ pub struct GatheredChunk {
     pub file: PathBuf,
     pub line_start: u32,
     pub line_end: u32,
+    pub language: Language,
+    pub chunk_type: ChunkType,
     pub signature: String,
     pub content: String,
     pub score: f32,
@@ -226,6 +230,8 @@ fn fetch_and_assemble(
                         .to_path_buf(),
                     line_start: r.chunk.line_start,
                     line_end: r.chunk.line_end,
+                    language: r.chunk.language,
+                    chunk_type: r.chunk.chunk_type,
                     signature: r.chunk.signature.clone(),
                     content: r.chunk.content.clone(),
                     score: *score,
@@ -415,6 +421,8 @@ pub fn gather_cross_index(
             file: r.chunk.file.clone(),
             line_start: r.chunk.line_start,
             line_end: r.chunk.line_end,
+            language: r.chunk.language,
+            chunk_type: r.chunk.chunk_type,
             signature: r.chunk.signature.clone(),
             content: r.chunk.content.clone(),
             score: r.score,

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -252,12 +252,12 @@ pub struct ChunkIdentity {
     pub origin: String,
     /// Function/class/etc. name
     pub name: String,
-    /// Type of code element (e.g., "function", "class")
-    pub chunk_type: String,
+    /// Type of code element
+    pub chunk_type: ChunkType,
     /// Starting line number (1-indexed)
     pub line_start: u32,
     /// Programming language
-    pub language: String,
+    pub language: Language,
     /// Parent chunk ID (for windowed chunks)
     pub parent_id: Option<String>,
     /// Window index within parent (for long functions split into windows)

--- a/tests/cli_graph_test.rs
+++ b/tests/cli_graph_test.rs
@@ -510,6 +510,20 @@ fn test_gather_json() {
 
     assert_eq!(parsed["query"], "process data");
     assert!(parsed["chunks"].is_array(), "Should have chunks array");
+
+    // Verify language/chunk_type in JSON output
+    if let Some(chunks) = parsed["chunks"].as_array() {
+        for chunk_json in chunks {
+            assert!(
+                chunk_json.get("language").is_some(),
+                "JSON should include language"
+            );
+            assert!(
+                chunk_json.get("chunk_type").is_some(),
+                "JSON should include chunk_type"
+            );
+        }
+    }
 }
 
 #[test]

--- a/tests/gather_test.rs
+++ b/tests/gather_test.rs
@@ -6,7 +6,7 @@
 mod common;
 
 use common::{mock_embedding, test_chunk, TestStore};
-use cqs::parser::{CallSite, FunctionCalls};
+use cqs::parser::{CallSite, ChunkType, FunctionCalls, Language};
 use cqs::reference::ReferenceIndex;
 use cqs::{GatherDirection, GatherOptions};
 use std::path::PathBuf;
@@ -73,6 +73,16 @@ fn test_gather_basic() {
         assert!(
             chunk.depth <= 1,
             "With expand_depth=1, max depth should be 1"
+        );
+        assert_eq!(
+            chunk.language,
+            Language::Rust,
+            "Gathered chunk should have language"
+        );
+        assert_eq!(
+            chunk.chunk_type,
+            ChunkType::Function,
+            "Gathered chunk should have chunk_type"
         );
     }
 }

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -794,7 +794,7 @@ fn test_all_chunk_identities() {
     // Find chunk1 identity
     let id1 = identities.iter().find(|i| i.name == "fn1").unwrap();
     assert_eq!(id1.origin, "test.rs");
-    assert_eq!(id1.language, "rust");
+    assert_eq!(id1.language, Language::Rust);
     assert_eq!(id1.line_start, 1);
 
     // Find chunk2 identity


### PR DESCRIPTION
## Summary

- `ChunkIdentity`, `LightChunk`, and `GatheredChunk` now use `Language`/`ChunkType` enums instead of `String` fields
- Parse boundary centralized at SQL read layer with `tracing::warn` fallback for unknown values
- Removes 6 scattered `.parse().unwrap_or()` calls and 2 `"unknown"` string predicates from `diff.rs`
- `GatheredChunk` gains `language`/`chunk_type` fields, exposed in `gather --json` output
- Step 1 of the `cqs chat` build path (ChunkSummary unification)

## Test plan

- [x] `cargo build --features gpu-search` — zero warnings
- [x] `cargo test --features gpu-search` — all pass
- [x] `cargo clippy --features gpu-search` — clean
- [x] New assertions in `test_gather_basic` verify `language`/`chunk_type` on gathered chunks
- [x] `test_gather_json` verifies new JSON fields present
- [x] `test_all_chunk_identities` assertions updated from string to enum comparisons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
