### PR TITLE
chore: release v0.12.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.9] - 2026-02-14
+
+### Added
+- **`cqs batch` command** — persistent Store batch mode. Reads commands from stdin, outputs compact JSONL. Amortizes ~100ms Store open and ~500ms Embedder ONNX init across N commands. 13 commands supported: search, callers, callees, explain, similar, gather, impact, test-map, trace, dead, related, context, stats. Lazy Embedder and HNSW/CAGRA vector index via `OnceLock` — built on first use, cached for session. Reference indexes cached in `RefCell<HashMap>`. `dispatch()` function is the seam for step 3 (REPL).
+- `shell-words` dependency for batch command tokenization.
+- 10 unit tests (command parsing) + 9 integration tests (batch CLI pipeline).
+
+### Changed
+- **`ChunkSummary` type consistency** — `ChunkIdentity`, `LightChunk`, `GatheredChunk` now use `Language`/`ChunkType` enums instead of `String`. Parse boundary at SQL read layer.
+- **`DocFormat` registry table** — static `FORMAT_TABLE` replaces 4 match blocks; adding a new document format now requires 3 changes instead of 6.
+
 ## [0.12.8] - 2026-02-14
 
 ### Added
@@ -934,7 +945,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI commands: init, doctor, index, stats, serve
 - Filter by language (`-l`) and path pattern (`-p`)
 
-[Unreleased]: https://github.com/jamie8johnson/cqs/compare/v0.12.4...HEAD
+[Unreleased]: https://github.com/jamie8johnson/cqs/compare/v0.12.9...HEAD
+[0.12.9]: https://github.com/jamie8johnson/cqs/compare/v0.12.8...v0.12.9
+[0.12.8]: https://github.com/jamie8johnson/cqs/compare/v0.12.7...v0.12.8
+[0.12.7]: https://github.com/jamie8johnson/cqs/compare/v0.12.6...v0.12.7
+[0.12.6]: https://github.com/jamie8johnson/cqs/compare/v0.12.5...v0.12.6
+[0.12.5]: https://github.com/jamie8johnson/cqs/compare/v0.12.4...v0.12.5
 [0.12.4]: https://github.com/jamie8johnson/cqs/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/jamie8johnson/cqs/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/jamie8johnson/cqs/compare/v0.12.1...v0.12.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.12.8"
+version = "0.12.9"
 edition = "2021"
 rust-version = "1.93"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML embeddings."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,12 +2,14 @@
 
 ## Right Now
 
-**v0.12.8 released + DocFormat registry refactor.** 2026-02-14.
+**Releasing v0.12.9.** 2026-02-14.
 
 This session:
-- v0.12.8 released (PR #430, #431): `cqs health`, `cqs suggest`, search safety, TOCTOU fix, gather tests
-- DocFormat registry refactor (PR #432): static FORMAT_TABLE replaces 4 match blocks, 6→3 changes per variant
-- Issues closed: #410, #412, #414
+- `cqs batch` shipped (PR #436): persistent Store batch mode, 13 commands, JSONL output, lazy Embedder/HNSW via OnceLock, CAGRA amortization
+- Fresh-eyes review caught bare `.unwrap_or_default()` in `dispatch_explain` — fixed with tracing::warn
+- CI feature flag fix: `let _ = store;` for unused var without gpu-search
+
+Next in `cqs chat` build path: step 3 = REPL (readline wrapping `dispatch()`)
 
 ## Pending Changes
 
@@ -38,14 +40,14 @@ None.
 
 ## Architecture
 
-- Version: 0.12.8
+- Version: 0.12.9
 - MSRV: 1.93
 - Schema: v10
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 9 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, Markdown)
-- Tests: 875 total (499 lib + 115 bin + 253 integration + 8 doc)
+- Tests: 929 total
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/ are directories (impact split in PR #402)
 - convert/ module (7 files) behind `convert` feature flag

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current: v0.12.8
+## Current: v0.12.9
 
 All agent experience features shipped. CLI-only (MCP removed in v0.10.0).
 

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -744,3 +744,20 @@ mentions = [
     ".claude/skills/cqs-gather/SKILL.md",
     ".claude/skills/cqs-scout/SKILL.md",
 ]
+
+[[note]]
+sentiment = 0.5
+text = "OnceLock pattern for lazy-init in long-running sessions (batch/REPL): Embedder and HNSW/CAGRA index built on first use, cached for session lifetime. Avoids 500ms+ ONNX init per command. Pattern: OnceLock<T> + get_or_init(|| build()). Used in BatchContext."
+mentions = [
+    "src/cli/batch.rs",
+    "OnceLock",
+]
+
+[[note]]
+sentiment = -0.5
+text = 'CI runs without gpu-search feature — functions with params used only inside #[cfg(feature = "gpu-search")] need let _ = param; at top to avoid unused variable warnings in CI.'
+mentions = [
+    "src/cli/batch.rs",
+    "CI",
+    "gpu-search",
+]


### PR DESCRIPTION
## Summary

- **`cqs batch`** — persistent Store batch mode. 13 commands, JSONL output, lazy Embedder/HNSW via OnceLock. Amortizes ~100ms Store + ~500ms ONNX init across N commands.
- **ChunkSummary type consistency** — `Language`/`ChunkType` enums replace String in `ChunkIdentity`, `LightChunk`, `GatheredChunk`
- **DocFormat registry table** — static FORMAT_TABLE, 3 changes per new variant instead of 6
- Version bump 0.12.8 → 0.12.9, changelog, roadmap, tears, notes

## Test plan

- [x] `cargo build --features gpu-search` clean
- [x] All 929 tests pass
- [x] Clippy clean
- [x] Batch mode integration tests (9) pass
- [x] Batch mode unit tests (10) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
