### PR TITLE
feat: add pipeline syntax to cqs batch

### DIFF
--- a/.claude/skills/cqs-batch/SKILL.md
+++ b/.claude/skills/cqs-batch/SKILL.md
@@ -7,7 +7,7 @@ argument-hint: "<commands>"
 
 # Batch Mode
 
-`cqs batch` reads commands from stdin, outputs compact JSONL. Persistent Store + lazy Embedder — amortizes startup cost across N commands.
+`cqs batch` reads commands from stdin, outputs compact JSONL. Persistent Store + lazy Embedder — amortizes startup cost across N commands. Supports pipeline syntax for chaining commands.
 
 ## Usage
 
@@ -18,9 +18,36 @@ echo 'callers search_filtered' | cqs batch
 # Multiple commands
 printf 'callers gather\nexplain gather\nstats\n' | cqs batch
 
+# Pipeline — chain commands via |
+echo 'callees dispatch | callers | test-map' | cqs batch
+
 # From file
 cqs batch < commands.txt
 ```
+
+## Pipeline Syntax
+
+Chain commands with `|` — upstream names feed downstream commands via fan-out:
+
+```bash
+# Search → get callers of each result
+echo 'search "error handling" --limit 5 | callers' | cqs batch
+
+# 3-stage: callees → callers of each → test coverage
+echo 'callees main | callers | test-map' | cqs batch
+
+# Dead code → explain each
+echo 'dead --min-confidence high | explain' | cqs batch
+```
+
+**Pipeable downstream commands:** callers, callees, explain, similar, impact, test-map, related.
+
+Pipeline output is a JSON envelope:
+```json
+{"pipeline": "...", "stages": N, "results": [{"_input": "name", "data": ...}], "errors": [...], "total_inputs": N, "truncated": false}
+```
+
+**Limits:** Max 50 names per stage (prevents fan-out explosion). Quoted pipes (`search "foo | bar"`) are not treated as separators.
 
 ## Supported Commands
 
@@ -46,7 +73,8 @@ cqs batch < commands.txt
 - `#` comments and empty lines are skipped
 - `quit` or `exit` stops processing
 - Quoted strings supported: `search "multi word query"`
+- `|` chains commands (pipeline syntax)
 
 ## Output
 
-Compact JSONL — one JSON object per line, flushed after each command. Errors: `{"error":"message"}`.
+Compact JSONL — one JSON object per line, flushed after each command. Pipelines produce a single envelope per pipeline. Errors: `{"error":"message"}`.

--- a/.claude/skills/cqs-bootstrap/SKILL.md
+++ b/.claude/skills/cqs-bootstrap/SKILL.md
@@ -105,7 +105,7 @@ None.
    - `cqs-impact` — what breaks if you change X
    - `cqs-impact-diff` — diff-aware impact: changed functions, callers, tests to re-run
    - `cqs-test-map` — map functions to their tests
-   - `cqs-batch` — batch mode: persistent Store + Embedder, stdin commands, JSONL output
+   - `cqs-batch` — batch mode: persistent Store + Embedder, stdin commands, JSONL output, pipeline syntax
    - `cqs-context` — module-level file overview
    - `cqs-gather` — smart context assembly (seed search + call graph BFS)
    - `cqs-dead` — find dead code (functions with no callers)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Fall back to Grep/Glob only for exact string matches or when semantic search ret
 - `cqs callers <function>` / `cqs callees <function>` — call graph navigation.
 - `cqs impact <function>` — what breaks if you change it. Callers + affected tests.
 - `cqs impact-diff [--base REF]` — diff-aware impact: changed functions, callers, tests to re-run.
-- `cqs batch` — batch mode: reads commands from stdin, outputs JSONL. Persistent Store + lazy Embedder. For scripting and chained queries.
+- `cqs batch` — batch mode: reads commands from stdin, outputs JSONL. Persistent Store + lazy Embedder. Supports pipeline syntax: `search "error" | callers | test-map` chains commands via fan-out.
 - `cqs ci [--base REF] [--gate high|medium|off]` — CI pipeline: review + dead code + gate. Exit 3 on gate fail.
 - `cqs test-map <function>` — map function to tests that exercise it.
 - `cqs trace <source> <target>` — shortest call path between two functions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ src/
     mod.rs      - Argument parsing, command dispatch
     commands/   - Command implementations
       mod.rs, query.rs, index.rs, stats.rs, graph.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, trace.rs, impact.rs, impact_diff.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs, audit_mode.rs, read.rs, stale.rs, related.rs, where_cmd.rs, scout.rs, convert.rs, review.rs, ci.rs
-    batch.rs    - Batch mode: persistent Store + Embedder, stdin commands, JSONL output
+    batch.rs    - Batch mode: persistent Store + Embedder, stdin commands, JSONL output, pipeline syntax
     config.rs   - Configuration file loading
     display.rs  - Output formatting, result display
     files.rs    - File enumeration, lock files, path utilities

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ Priority order based on competitive gap analysis (Feb 2026).
 - [ ] `cqs drift` — detect semantic drift between reference snapshots. Embedding distance, not just text diff. Surface functions that changed behavior.
 - [x] `cqs suggest` — auto-generate notes from code patterns. Scan for anti-patterns (unwrap in non-test code, high-caller untested functions, dead code clusters).
 - [ ] `cqs deps` — type-level dependency impact. Trace struct/enum usage through functions and tests. Deeper than caller-only analysis.
-- [ ] `cqs chat` — interactive REPL for chained queries. Build order: (1) ~~`ChunkSummary` unification~~, (2) ~~batch mode `cqs batch`~~, (3) REPL (readline), (4) pipeline syntax (`search | callers | test-map`).
+- [ ] `cqs chat` — interactive REPL for chained queries. Build order: (1) ~~`ChunkSummary` unification~~, (2) ~~batch mode `cqs batch`~~, (3) ~~REPL~~ (deferred — agents use batch), (4) ~~pipeline syntax~~ (`search | callers | test-map` in `cqs batch`).
 
 ### Next — Retrieval Quality
 

--- a/src/cli/batch.rs
+++ b/src/cli/batch.rs
@@ -4,11 +4,11 @@
 //! Embedder, outputs compact JSON per line. Amortizes ~100ms Store open and
 //! ~500ms Embedder ONNX init across N commands.
 //!
-//! This is step 2 of the `cqs chat` build path. Step 3 (REPL) wraps
-//! `BatchContext` + `dispatch()` with readline.
+//! Supports pipeline syntax: `search "error" | callers | test-map` chains
+//! commands where upstream names feed downstream commands via fan-out.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, Write};
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -1198,6 +1198,297 @@ fn dispatch_help() -> Result<serde_json::Value> {
     Ok(serde_json::json!({"help": help_text}))
 }
 
+// ─── Pipeline ─────────────────────────────────────────────────────────────────
+
+/// Maximum names extracted per pipeline stage to prevent fan-out explosion.
+/// A 3-stage pipeline dispatches at most 1 + 50 + 50 = 101 calls.
+const PIPELINE_FAN_OUT_LIMIT: usize = 50;
+
+/// Commands that accept a piped function name as their first positional arg.
+const PIPEABLE_COMMANDS: &[&str] = &[
+    "callers", "callees", "explain", "similar", "impact", "test-map", "related",
+];
+
+/// Check if a command (first token) can receive piped names.
+fn is_pipeable_command(tokens: &[String]) -> bool {
+    tokens
+        .first()
+        .map(|cmd| PIPEABLE_COMMANDS.contains(&cmd.as_str()))
+        .unwrap_or(false)
+}
+
+/// Extract function/chunk names from a dispatch result JSON value.
+///
+/// Walks known array fields (results, chunks, callers, calls, tests, dead,
+/// possibly_dead_pub, path, shared_callers, shared_callees, shared_types)
+/// plus the top-level "name" field (explain). Deduplicates preserving order.
+fn extract_names(val: &serde_json::Value) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut names = Vec::new();
+
+    let mut push_name = |n: &str| {
+        if !n.is_empty() && seen.insert(n.to_string()) {
+            names.push(n.to_string());
+        }
+    };
+
+    // Top-level "name" (explain returns the target's own name)
+    if let Some(name) = val.get("name").and_then(|v| v.as_str()) {
+        push_name(name);
+    }
+
+    // Bare array (callers returns [...])
+    if let Some(arr) = val.as_array() {
+        for item in arr {
+            if let Some(name) = item.get("name").and_then(|v| v.as_str()) {
+                push_name(name);
+            }
+        }
+        return names;
+    }
+
+    // Known array fields in dispatch results
+    const NAME_ARRAY_FIELDS: &[&str] = &[
+        "results",           // search, similar
+        "chunks",            // gather, context
+        "callers",           // impact, explain
+        "calls",             // callees
+        "tests",             // impact, test-map
+        "dead",              // dead
+        "possibly_dead_pub", // dead
+        "path",              // trace
+        "shared_callers",    // related
+        "shared_callees",    // related
+        "shared_types",      // related
+        "similar",           // explain
+        "callees",           // explain
+    ];
+
+    for field in NAME_ARRAY_FIELDS {
+        if let Some(arr) = val.get(*field).and_then(|v| v.as_array()) {
+            for item in arr {
+                if let Some(name) = item.get("name").and_then(|v| v.as_str()) {
+                    push_name(name);
+                }
+            }
+        }
+    }
+
+    names
+}
+
+/// Split a token list by standalone `|` into pipeline segments.
+fn split_tokens_by_pipe(tokens: &[String]) -> Vec<Vec<String>> {
+    let mut segments: Vec<Vec<String>> = Vec::new();
+    let mut current: Vec<String> = Vec::new();
+
+    for token in tokens {
+        if token == "|" {
+            segments.push(std::mem::take(&mut current));
+        } else {
+            current.push(token.clone());
+        }
+    }
+    segments.push(current);
+    segments
+}
+
+/// Execute a pipeline: chain commands where upstream names feed downstream.
+fn execute_pipeline(ctx: &BatchContext, tokens: &[String], raw_line: &str) -> serde_json::Value {
+    let _span = tracing::info_span!("pipeline", input = raw_line).entered();
+
+    let segments = split_tokens_by_pipe(tokens);
+    let stage_count = segments.len();
+
+    // Validate: no empty segments
+    for (i, seg) in segments.iter().enumerate() {
+        if seg.is_empty() {
+            return serde_json::json!({"error": format!(
+                "Empty pipeline segment at position {}", i + 1
+            )});
+        }
+    }
+
+    // Validate: downstream segments (index 1+) must be pipeable
+    for seg in &segments[1..] {
+        if !is_pipeable_command(seg) {
+            let cmd = seg.first().map(|s| s.as_str()).unwrap_or("(empty)");
+            return serde_json::json!({"error": format!(
+                "Cannot pipe into '{}' \u{2014} it doesn't accept a function name. \
+                 Pipeable commands: {}",
+                cmd,
+                PIPEABLE_COMMANDS.join(", ")
+            )});
+        }
+    }
+
+    // Validate: quit/exit/help not allowed in pipelines
+    for seg in &segments {
+        if let Some(first) = seg.first() {
+            let lower = first.to_ascii_lowercase();
+            if lower == "quit" || lower == "exit" || lower == "help" {
+                return serde_json::json!({"error": format!(
+                    "'{}' cannot be used in a pipeline", first
+                )});
+            }
+        }
+    }
+
+    // Stage 0: execute first segment normally
+    let stage0_result = {
+        let _stage_span = tracing::info_span!(
+            "pipeline_stage",
+            stage = 0,
+            command = segments[0].first().map(|s| s.as_str()).unwrap_or("?"),
+        )
+        .entered();
+
+        match BatchInput::try_parse_from(&segments[0]) {
+            Ok(input) => match dispatch(ctx, input.cmd) {
+                Ok(val) => val,
+                Err(e) => {
+                    return serde_json::json!({"error": format!(
+                        "Pipeline stage 1 failed: {}", e
+                    )});
+                }
+            },
+            Err(e) => {
+                return serde_json::json!({"error": format!(
+                    "Pipeline stage 1 parse error: {}", e
+                )});
+            }
+        }
+    };
+
+    // Process remaining stages
+    let mut current_value = stage0_result;
+    let mut any_truncated = false;
+
+    for (stage_idx, segment) in segments[1..].iter().enumerate() {
+        let stage_num = stage_idx + 1; // 1-indexed for display (stage 0 already done)
+
+        // Extract names from current result
+        let mut names = extract_names(&current_value);
+        tracing::debug!(stage = stage_num, count = names.len(), "Names extracted");
+
+        if names.len() > PIPELINE_FAN_OUT_LIMIT {
+            any_truncated = true;
+            tracing::info!(
+                stage = stage_num,
+                original = names.len(),
+                limit = PIPELINE_FAN_OUT_LIMIT,
+                "Fan-out truncated"
+            );
+            names.truncate(PIPELINE_FAN_OUT_LIMIT);
+        }
+
+        let total_inputs = names.len();
+        let _stage_span = tracing::info_span!(
+            "pipeline_stage",
+            stage = stage_num + 1, // 1-based for user
+            command = segment.first().map(|s| s.as_str()).unwrap_or("?"),
+            fan_out = total_inputs,
+        )
+        .entered();
+
+        if names.is_empty() {
+            // No names to fan out — return empty pipeline result
+            return build_pipeline_result(raw_line, stage_count, vec![], vec![], 0, false);
+        }
+
+        let mut results: Vec<(String, serde_json::Value)> = Vec::new();
+        let mut errors: Vec<(String, String)> = Vec::new();
+
+        for name in &names {
+            // Build tokens: prepend name to downstream segment
+            let mut cmd_tokens = vec![segment[0].clone(), name.clone()];
+            cmd_tokens.extend_from_slice(&segment[1..]);
+
+            match BatchInput::try_parse_from(&cmd_tokens) {
+                Ok(input) => match dispatch(ctx, input.cmd) {
+                    Ok(val) => results.push((name.clone(), val)),
+                    Err(e) => {
+                        tracing::warn!(name = name, error = %e, "Per-name dispatch failed");
+                        errors.push((name.clone(), e.to_string()));
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(name = name, error = %e, "Per-name parse failed");
+                    errors.push((name.clone(), e.to_string()));
+                }
+            }
+        }
+
+        // If this is the last stage, build the pipeline result envelope
+        if stage_num == segments.len() - 1 {
+            return build_pipeline_result(
+                raw_line,
+                stage_count,
+                results,
+                errors,
+                total_inputs,
+                any_truncated,
+            );
+        }
+
+        // Intermediate stage: merge results for next stage's name extraction
+        // Collect all per-name results into a single object with all names
+        let mut merged_names: Vec<String> = Vec::new();
+        let mut merged_seen = HashSet::new();
+        for (_, val) in &results {
+            for n in extract_names(val) {
+                if merged_seen.insert(n.clone()) {
+                    merged_names.push(n);
+                }
+            }
+        }
+
+        // Build a synthetic value with a "results" array for extraction
+        let synthetic: Vec<serde_json::Value> = merged_names
+            .iter()
+            .map(|n| serde_json::json!({"name": n}))
+            .collect();
+        current_value = serde_json::json!({"results": synthetic});
+    }
+
+    // Should not reach here, but safety net
+    serde_json::json!({"error": "Pipeline execution ended unexpectedly"})
+}
+
+/// Build the final pipeline result envelope.
+fn build_pipeline_result(
+    pipeline_str: &str,
+    stages: usize,
+    results: Vec<(String, serde_json::Value)>,
+    errors: Vec<(String, String)>,
+    total_inputs: usize,
+    truncated: bool,
+) -> serde_json::Value {
+    let results_json: Vec<serde_json::Value> = results
+        .into_iter()
+        .map(|(input, data)| serde_json::json!({"_input": input, "data": data}))
+        .collect();
+
+    let errors_json: Vec<serde_json::Value> = errors
+        .into_iter()
+        .map(|(input, err)| serde_json::json!({"_input": input, "error": err}))
+        .collect();
+
+    serde_json::json!({
+        "pipeline": pipeline_str,
+        "stages": stages,
+        "results": results_json,
+        "errors": errors_json,
+        "total_inputs": total_inputs,
+        "truncated": truncated,
+    })
+}
+
+/// Check if a token list contains a pipeline (standalone `|` token).
+fn has_pipe_token(tokens: &[String]) -> bool {
+    tokens.iter().any(|t| t == "|")
+}
+
 // ─── Main loop ───────────────────────────────────────────────────────────────
 
 /// Entry point for `cqs batch`.
@@ -1253,20 +1544,26 @@ pub(crate) fn cmd_batch(_cli: &super::Cli) -> Result<()> {
             continue;
         }
 
-        // Parse and dispatch
-        match BatchInput::try_parse_from(&tokens) {
-            Ok(input) => match dispatch(&ctx, input.cmd) {
-                Ok(value) => {
-                    let _ = writeln!(stdout, "{}", serde_json::to_string(&value).unwrap());
-                }
+        // Pipeline detection: if tokens contain a standalone `|`, route to pipeline
+        if has_pipe_token(&tokens) {
+            let result = execute_pipeline(&ctx, &tokens, trimmed);
+            let _ = writeln!(stdout, "{}", serde_json::to_string(&result).unwrap());
+        } else {
+            // Single command — existing path
+            match BatchInput::try_parse_from(&tokens) {
+                Ok(input) => match dispatch(&ctx, input.cmd) {
+                    Ok(value) => {
+                        let _ = writeln!(stdout, "{}", serde_json::to_string(&value).unwrap());
+                    }
+                    Err(e) => {
+                        let error_json = serde_json::json!({"error": format!("{}", e)});
+                        let _ = writeln!(stdout, "{}", serde_json::to_string(&error_json).unwrap());
+                    }
+                },
                 Err(e) => {
                     let error_json = serde_json::json!({"error": format!("{}", e)});
                     let _ = writeln!(stdout, "{}", serde_json::to_string(&error_json).unwrap());
                 }
-            },
-            Err(e) => {
-                let error_json = serde_json::json!({"error": format!("{}", e)});
-                let _ = writeln!(stdout, "{}", serde_json::to_string(&error_json).unwrap());
             }
         }
 
@@ -1363,6 +1660,183 @@ mod tests {
     fn test_parse_unknown_command() {
         let result = BatchInput::try_parse_from(["bogus"]);
         assert!(result.is_err());
+    }
+
+    // ─── Pipeline unit tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_extract_names_search_result() {
+        let val = serde_json::json!({
+            "results": [{"name": "a", "file": "f.rs"}, {"name": "b", "file": "g.rs"}],
+            "query": "test",
+            "total": 2
+        });
+        assert_eq!(extract_names(&val), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_extract_names_callers_bare_array() {
+        let val = serde_json::json!([{"name": "a", "file": "f.rs"}, {"name": "b", "file": "g.rs"}]);
+        assert_eq!(extract_names(&val), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_extract_names_callees() {
+        let val = serde_json::json!({
+            "function": "f",
+            "calls": [{"name": "a", "line": 1}],
+            "count": 1
+        });
+        assert_eq!(extract_names(&val), vec!["a"]);
+    }
+
+    #[test]
+    fn test_extract_names_impact() {
+        let val = serde_json::json!({
+            "function": "f",
+            "callers": [{"name": "a"}],
+            "tests": [{"name": "b"}],
+            "caller_count": 1,
+            "test_count": 1
+        });
+        let names = extract_names(&val);
+        assert!(names.contains(&"a".to_string()));
+        assert!(names.contains(&"b".to_string()));
+    }
+
+    #[test]
+    fn test_extract_names_dead() {
+        let val = serde_json::json!({
+            "dead": [{"name": "a"}],
+            "possibly_dead_pub": [{"name": "b"}],
+            "total_dead": 1,
+            "total_possibly_dead_pub": 1
+        });
+        let names = extract_names(&val);
+        assert!(names.contains(&"a".to_string()));
+        assert!(names.contains(&"b".to_string()));
+    }
+
+    #[test]
+    fn test_extract_names_related() {
+        let val = serde_json::json!({
+            "target": "f",
+            "shared_callers": [{"name": "a"}],
+            "shared_callees": [{"name": "b"}],
+            "shared_types": [{"name": "c"}]
+        });
+        let names = extract_names(&val);
+        assert!(names.contains(&"a".to_string()));
+        assert!(names.contains(&"b".to_string()));
+        assert!(names.contains(&"c".to_string()));
+    }
+
+    #[test]
+    fn test_extract_names_trace() {
+        let val = serde_json::json!({
+            "source": "s",
+            "target": "t",
+            "path": [{"name": "a"}, {"name": "b"}],
+            "depth": 1
+        });
+        let names = extract_names(&val);
+        assert!(names.contains(&"a".to_string()));
+        assert!(names.contains(&"b".to_string()));
+    }
+
+    #[test]
+    fn test_extract_names_explain() {
+        let val = serde_json::json!({
+            "name": "target",
+            "callers": [{"name": "a"}],
+            "similar": [{"name": "b"}]
+        });
+        let names = extract_names(&val);
+        assert_eq!(names[0], "target"); // top-level name first
+        assert!(names.contains(&"a".to_string()));
+        assert!(names.contains(&"b".to_string()));
+    }
+
+    #[test]
+    fn test_extract_names_empty_results() {
+        let val = serde_json::json!({"results": [], "query": "x", "total": 0});
+        assert!(extract_names(&val).is_empty());
+    }
+
+    #[test]
+    fn test_extract_names_stats_no_names() {
+        let val = serde_json::json!({
+            "total_chunks": 100,
+            "total_files": 10,
+            "notes": 5
+        });
+        assert!(extract_names(&val).is_empty());
+    }
+
+    #[test]
+    fn test_extract_names_dedup() {
+        let val = serde_json::json!({
+            "results": [{"name": "a"}, {"name": "a"}, {"name": "b"}]
+        });
+        assert_eq!(extract_names(&val), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_is_pipeable_callers() {
+        assert!(is_pipeable_command(&["callers".to_string()]));
+    }
+
+    #[test]
+    fn test_is_pipeable_search() {
+        assert!(!is_pipeable_command(&[
+            "search".to_string(),
+            "foo".to_string()
+        ]));
+    }
+
+    #[test]
+    fn test_is_pipeable_stats() {
+        assert!(!is_pipeable_command(&["stats".to_string()]));
+    }
+
+    #[test]
+    fn test_split_tokens_by_pipe() {
+        let tokens: Vec<String> = vec!["search", "foo", "|", "callers"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let segments = split_tokens_by_pipe(&tokens);
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0], vec!["search", "foo"]);
+        assert_eq!(segments[1], vec!["callers"]);
+    }
+
+    #[test]
+    fn test_split_tokens_three_stages() {
+        let tokens: Vec<String> = vec!["search", "foo", "|", "callers", "|", "test-map"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let segments = split_tokens_by_pipe(&tokens);
+        assert_eq!(segments.len(), 3);
+        assert_eq!(segments[0], vec!["search", "foo"]);
+        assert_eq!(segments[1], vec!["callers"]);
+        assert_eq!(segments[2], vec!["test-map"]);
+    }
+
+    #[test]
+    fn test_has_pipe_token() {
+        let with_pipe: Vec<String> = vec!["search", "foo", "|", "callers"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert!(has_pipe_token(&with_pipe));
+
+        let without_pipe: Vec<String> = vec!["search", "foo|bar"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert!(!has_pipe_token(&without_pipe));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add pipeline syntax to `cqs batch` — chain commands where upstream names feed downstream via fan-out: `search "error" | callers | test-map`
- Quote-safe parsing: tokenize with `shell_words` first, split by standalone `|` token. Pipes inside quotes (`search "foo | bar"`) are not separators.
- 7 pipeable downstream commands: callers, callees, explain, similar, impact, test-map, related
- Fan-out capped at 50 names per stage (prevents explosion in multi-stage pipelines)
- Pipeline envelope output: `{"pipeline": "...", "stages": N, "results": [...], "errors": [...], "total_inputs": N, "truncated": bool}`
- No new dependencies, no dispatch handler changes, single-command batch lines work identically

## Test plan

- [x] 17 unit tests: name extraction (10 handlers), pipeable check, token splitting, pipe detection
- [x] 7 integration tests: 2-stage pipeline, 3-stage pipeline, empty upstream, ineligible downstream, regression (no pipe), quoted pipe, mixed pipeline + single
- [x] Full test suite: 926 passed, 0 failed (no regressions)
- [x] Manual verification: `callees dispatch | callers | test-map`, `callers process | stats` (error), `search "foo | bar"` (not pipeline)
- [x] Clippy clean, cargo fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
