### PR TITLE
feat: add type extraction to parser — Phase 2b Step 1

### DIFF
--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -35,6 +35,32 @@ const CALL_QUERY: &str = r#"
     field: (field_identifier) @callee))
 "#;
 
+/// Tree-sitter query for extracting type references
+const TYPE_QUERY: &str = r#"
+;; Param
+(parameter_declaration type: (type_identifier) @param_type)
+(parameter_declaration type: (struct_specifier name: (type_identifier) @param_type))
+(parameter_declaration type: (enum_specifier name: (type_identifier) @param_type))
+
+;; Return
+(function_definition type: (type_identifier) @return_type)
+(function_definition type: (struct_specifier name: (type_identifier) @return_type))
+(function_definition type: (enum_specifier name: (type_identifier) @return_type))
+
+;; Field
+(field_declaration type: (type_identifier) @field_type)
+(field_declaration type: (struct_specifier name: (type_identifier) @field_type))
+(field_declaration type: (enum_specifier name: (type_identifier) @field_type))
+
+;; Alias (typedef)
+(type_definition type: (type_identifier) @alias_type)
+(type_definition type: (struct_specifier name: (type_identifier) @alias_type))
+(type_definition type: (enum_specifier name: (type_identifier) @alias_type))
+
+;; Catch-all
+(type_identifier) @type_ref
+"#;
+
 /// Doc comment node types
 const DOC_NODES: &[&str] = &["comment"];
 
@@ -83,6 +109,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
     test_file_suggestion: None,
+    type_query: Some(TYPE_QUERY),
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/go.rs
+++ b/src/language/go.rs
@@ -35,6 +35,45 @@ const CALL_QUERY: &str = r#"
     field: (field_identifier) @callee))
 "#;
 
+/// Tree-sitter query for extracting type references
+const TYPE_QUERY: &str = r#"
+;; Param
+(parameter_declaration type: (type_identifier) @param_type)
+(parameter_declaration type: (pointer_type (type_identifier) @param_type))
+(parameter_declaration type: (qualified_type name: (type_identifier) @param_type))
+(parameter_declaration type: (generic_type type: (type_identifier) @param_type))
+(parameter_declaration type: (slice_type element: (type_identifier) @param_type))
+
+;; Return
+(function_declaration result: (type_identifier) @return_type)
+(function_declaration result: (pointer_type (type_identifier) @return_type))
+(function_declaration result: (qualified_type name: (type_identifier) @return_type))
+(function_declaration result: (generic_type type: (type_identifier) @return_type))
+(method_declaration result: (type_identifier) @return_type)
+(method_declaration result: (pointer_type (type_identifier) @return_type))
+(method_declaration result: (qualified_type name: (type_identifier) @return_type))
+(method_declaration result: (generic_type type: (type_identifier) @return_type))
+
+;; Field
+(field_declaration type: (type_identifier) @field_type)
+(field_declaration type: (pointer_type (type_identifier) @field_type))
+(field_declaration type: (qualified_type name: (type_identifier) @field_type))
+(field_declaration type: (generic_type type: (type_identifier) @field_type))
+(field_declaration type: (slice_type element: (type_identifier) @field_type))
+
+;; Impl (interface embedding — embedded types wrapped in type_elem)
+(interface_type (type_elem (type_identifier) @impl_type))
+(interface_type (type_elem (qualified_type name: (type_identifier) @impl_type)))
+
+;; Alias (type definitions and type aliases)
+(type_spec type: (type_identifier) @alias_type)
+(type_spec type: (generic_type type: (type_identifier) @alias_type))
+(type_alias type: (type_identifier) @alias_type)
+
+;; Catch-all
+(type_identifier) @type_ref
+"#;
+
 /// Doc comment node types
 const DOC_NODES: &[&str] = &["comment"];
 
@@ -106,6 +145,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
     test_file_suggestion: Some(|stem, parent| format!("{parent}/{stem}_test.go")),
+    type_query: Some(TYPE_QUERY),
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/java.rs
+++ b/src/language/java.rs
@@ -32,6 +32,39 @@ const CALL_QUERY: &str = r#"
   type: (type_identifier) @callee)
 "#;
 
+/// Tree-sitter query for extracting type references
+const TYPE_QUERY: &str = r#"
+;; Param
+(formal_parameter type: (type_identifier) @param_type)
+(formal_parameter type: (generic_type (type_identifier) @param_type))
+(formal_parameter type: (scoped_type_identifier (type_identifier) @param_type))
+(formal_parameter type: (array_type element: (type_identifier) @param_type))
+(spread_parameter (type_identifier) @param_type)
+(spread_parameter (generic_type (type_identifier) @param_type))
+
+;; Return
+(method_declaration type: (type_identifier) @return_type)
+(method_declaration type: (generic_type (type_identifier) @return_type))
+(method_declaration type: (scoped_type_identifier (type_identifier) @return_type))
+(method_declaration type: (array_type element: (type_identifier) @return_type))
+
+;; Field
+(field_declaration type: (type_identifier) @field_type)
+(field_declaration type: (generic_type (type_identifier) @field_type))
+(field_declaration type: (scoped_type_identifier (type_identifier) @field_type))
+(field_declaration type: (array_type element: (type_identifier) @field_type))
+
+;; Impl (extends/implements)
+(superclass (type_identifier) @impl_type)
+(super_interfaces (type_list (type_identifier) @impl_type))
+
+;; Bound (type parameter bounds)
+(type_bound (type_identifier) @bound_type)
+
+;; Catch-all
+(type_identifier) @type_ref
+"#;
+
 /// Doc comment node types (Javadoc /** ... */ and regular comments)
 const DOC_NODES: &[&str] = &["line_comment", "block_comment"];
 
@@ -84,6 +117,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
     test_file_suggestion: Some(|stem, parent| format!("{parent}/{stem}Test.java")),
+    type_query: Some(TYPE_QUERY),
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -65,6 +65,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
     test_file_suggestion: Some(|stem, parent| format!("{parent}/{stem}.test.js")),
+    type_query: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/markdown.rs
+++ b/src/language/markdown.rs
@@ -27,6 +27,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     stopwords: STOPWORDS,
     extract_return_nl: |_| None,
     test_file_suggestion: None,
+    type_query: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -145,6 +145,10 @@ pub struct LanguageDef {
     /// Receives `(stem, parent_dir)` and returns a suggested test path.
     /// `None` uses the fallback pattern `{parent}/tests/{stem}_test.{ext}`.
     pub test_file_suggestion: Option<fn(&str, &str) -> String>,
+    /// Tree-sitter query for extracting type references (optional).
+    /// Uses classified capture names: `@param_type`, `@return_type`, `@field_type`,
+    /// `@impl_type`, `@bound_type`, `@alias_type`, `@type_ref` (catch-all).
+    pub type_query: Option<&'static str>,
 }
 
 /// How to extract function signatures
@@ -375,6 +379,11 @@ impl Language {
     /// Get the call extraction query pattern
     pub fn call_query_pattern(&self) -> &'static str {
         self.def().call_query.unwrap_or("")
+    }
+
+    /// Get the type extraction query pattern
+    pub fn type_query_pattern(&self) -> &'static str {
+        self.def().type_query.unwrap_or("")
     }
 }
 

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -21,6 +21,32 @@ const CALL_QUERY: &str = r#"
     attribute: (identifier) @callee))
 "#;
 
+/// Tree-sitter query for extracting type references
+const TYPE_QUERY: &str = r#"
+;; Param
+(typed_parameter type: (type (identifier) @param_type))
+(typed_parameter type: (type (generic_type (identifier) @param_type)))
+(typed_default_parameter type: (type (identifier) @param_type))
+(typed_default_parameter type: (type (generic_type (identifier) @param_type)))
+
+;; Return
+(function_definition return_type: (type (identifier) @return_type))
+(function_definition return_type: (type (generic_type (identifier) @return_type)))
+
+;; Field
+(assignment type: (type (identifier) @field_type))
+(assignment type: (type (generic_type (identifier) @field_type)))
+
+;; Impl (class inheritance)
+(class_definition superclasses: (argument_list (identifier) @impl_type))
+
+;; Alias (PEP 695)
+(type_alias_statement (type (identifier) @alias_type))
+
+;; Catch-all (scoped to type positions)
+(type (identifier) @type_ref)
+"#;
+
 /// Doc comment node types (sibling comments and standalone strings before a definition)
 const DOC_NODES: &[&str] = &["string", "comment"];
 
@@ -56,6 +82,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
     test_file_suggestion: Some(|stem, parent| format!("{parent}/test_{stem}.py")),
+    type_query: Some(TYPE_QUERY),
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -40,6 +40,50 @@ const CALL_QUERY: &str = r#"
   macro: (identifier) @callee)
 "#;
 
+/// Tree-sitter query for extracting type references
+///
+/// Classified captures: @param_type, @return_type, @field_type, @impl_type, @bound_type, @alias_type
+/// Catch-all: @type_ref (for types inside generics not reached by classified patterns)
+const TYPE_QUERY: &str = r#"
+;; Param
+(parameter type: (type_identifier) @param_type)
+(parameter type: (generic_type type: (type_identifier) @param_type))
+(parameter type: (reference_type type: (type_identifier) @param_type))
+(parameter type: (reference_type type: (generic_type type: (type_identifier) @param_type)))
+(parameter type: (scoped_type_identifier name: (type_identifier) @param_type))
+
+;; Return
+(function_item return_type: (type_identifier) @return_type)
+(function_item return_type: (generic_type type: (type_identifier) @return_type))
+(function_item return_type: (reference_type type: (type_identifier) @return_type))
+(function_item return_type: (reference_type type: (generic_type type: (type_identifier) @return_type)))
+(function_item return_type: (scoped_type_identifier name: (type_identifier) @return_type))
+
+;; Field
+(field_declaration type: (type_identifier) @field_type)
+(field_declaration type: (generic_type type: (type_identifier) @field_type))
+(field_declaration type: (reference_type type: (type_identifier) @field_type))
+(field_declaration type: (reference_type type: (generic_type type: (type_identifier) @field_type)))
+(field_declaration type: (scoped_type_identifier name: (type_identifier) @field_type))
+
+;; Impl
+(impl_item type: (type_identifier) @impl_type)
+(impl_item type: (generic_type type: (type_identifier) @impl_type))
+(impl_item trait: (type_identifier) @impl_type)
+(impl_item trait: (scoped_type_identifier name: (type_identifier) @impl_type))
+
+;; Bound
+(trait_bounds (type_identifier) @bound_type)
+(trait_bounds (scoped_type_identifier name: (type_identifier) @bound_type))
+
+;; Alias
+(type_item type: (type_identifier) @alias_type)
+(type_item type: (generic_type type: (type_identifier) @alias_type))
+
+;; Catch-all (captures types inside generics, type_arguments, etc.)
+(type_identifier) @type_ref
+"#;
+
 /// Doc comment node types
 const DOC_NODES: &[&str] = &["line_comment", "block_comment"];
 
@@ -75,6 +119,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
     test_file_suggestion: Some(|stem, parent| format!("{parent}/tests/{stem}_test.rs")),
+    type_query: Some(TYPE_QUERY),
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/sql.rs
+++ b/src/language/sql.rs
@@ -72,6 +72,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
     test_file_suggestion: None,
+    type_query: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -42,6 +42,44 @@ const CALL_QUERY: &str = r#"
     property: (property_identifier) @callee))
 "#;
 
+/// Tree-sitter query for extracting type references
+const TYPE_QUERY: &str = r#"
+;; Param
+(required_parameter type: (type_annotation (type_identifier) @param_type))
+(required_parameter type: (type_annotation (generic_type name: (type_identifier) @param_type)))
+(optional_parameter type: (type_annotation (type_identifier) @param_type))
+(optional_parameter type: (type_annotation (generic_type name: (type_identifier) @param_type)))
+
+;; Return
+(function_declaration return_type: (type_annotation (type_identifier) @return_type))
+(function_declaration return_type: (type_annotation (generic_type name: (type_identifier) @return_type)))
+(method_definition return_type: (type_annotation (type_identifier) @return_type))
+(method_definition return_type: (type_annotation (generic_type name: (type_identifier) @return_type)))
+(arrow_function return_type: (type_annotation (type_identifier) @return_type))
+(arrow_function return_type: (type_annotation (generic_type name: (type_identifier) @return_type)))
+
+;; Field
+(public_field_definition type: (type_annotation (type_identifier) @field_type))
+(public_field_definition type: (type_annotation (generic_type name: (type_identifier) @field_type)))
+(property_signature type: (type_annotation (type_identifier) @field_type))
+(property_signature type: (type_annotation (generic_type name: (type_identifier) @field_type)))
+
+;; Impl (extends/implements)
+(class_heritage (extends_clause value: (identifier) @impl_type))
+(class_heritage (implements_clause (type_identifier) @impl_type))
+(extends_type_clause (type_identifier) @impl_type)
+
+;; Bound (type parameter constraints)
+(constraint (type_identifier) @bound_type)
+
+;; Alias
+(type_alias_declaration value: (type_identifier) @alias_type)
+(type_alias_declaration value: (generic_type name: (type_identifier) @alias_type))
+
+;; Catch-all
+(type_identifier) @type_ref
+"#;
+
 /// Doc comment node types
 const DOC_NODES: &[&str] = &["comment"];
 
@@ -78,6 +116,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     stopwords: STOPWORDS,
     extract_return_nl: extract_return,
     test_file_suggestion: Some(|stem, parent| format!("{parent}/{stem}.test.ts")),
+    type_query: Some(TYPE_QUERY),
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -3,7 +3,9 @@
 use std::path::Path;
 use tree_sitter::StreamingIterator;
 
-use super::types::{CallSite, FunctionCalls, Language, ParserError};
+use super::types::{
+    CallSite, ChunkTypeRefs, FunctionCalls, Language, ParserError, TypeEdgeKind, TypeRef,
+};
 use super::Parser;
 
 impl Parser {
@@ -93,11 +95,117 @@ impl Parser {
         )
     }
 
+    /// Extract type references from a chunk's byte range
+    ///
+    /// Returns classified type references with merge logic: if a type name
+    /// was captured by any classified pattern (Param/Return/Field/Impl/Bound/Alias),
+    /// the catch-all duplicate is dropped. Types found ONLY by the catch-all
+    /// get `kind = None`.
+    pub fn extract_types(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        language: Language,
+        start_byte: usize,
+        end_byte: usize,
+    ) -> Vec<TypeRef> {
+        let _span = tracing::info_span!("extract_types", %language).entered();
+
+        let query = match self.get_type_query(language) {
+            Ok(q) => q,
+            Err(_) => {
+                // Language has no type query (e.g., JavaScript) — not a warning
+                return vec![];
+            }
+        };
+
+        let capture_names = query.capture_names();
+        let mut cursor = tree_sitter::QueryCursor::new();
+        cursor.set_byte_range(start_byte..end_byte);
+
+        // Collect all (type_name, line_number, kind) entries
+        let mut classified: Vec<TypeRef> = Vec::new();
+        let mut catch_all: Vec<TypeRef> = Vec::new();
+
+        let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+        while let Some(m) = matches.next() {
+            for cap in m.captures {
+                let capture_name = match capture_names.get(cap.index as usize) {
+                    Some(name) => *name,
+                    None => continue,
+                };
+
+                let kind = match capture_name {
+                    "param_type" => Some(TypeEdgeKind::Param),
+                    "return_type" => Some(TypeEdgeKind::Return),
+                    "field_type" => Some(TypeEdgeKind::Field),
+                    "impl_type" => Some(TypeEdgeKind::Impl),
+                    "bound_type" => Some(TypeEdgeKind::Bound),
+                    "alias_type" => Some(TypeEdgeKind::Alias),
+                    "type_ref" => None,
+                    other => {
+                        tracing::debug!(capture = other, "Unknown type capture");
+                        continue;
+                    }
+                };
+
+                let type_name = source[cap.node.byte_range()].to_string();
+                let line_number = cap.node.start_position().row as u32 + 1;
+
+                let type_ref = TypeRef {
+                    type_name,
+                    line_number,
+                    kind,
+                };
+
+                if kind.is_some() {
+                    classified.push(type_ref);
+                } else {
+                    catch_all.push(type_ref);
+                }
+            }
+        }
+
+        // Build set of type names that have at least one classified entry
+        let classified_names: std::collections::HashSet<String> =
+            classified.iter().map(|t| t.type_name.clone()).collect();
+
+        // Keep catch-all entries only for types NOT already classified
+        for t in catch_all {
+            if !classified_names.contains(&t.type_name) {
+                classified.push(t);
+            }
+        }
+
+        // Dedup by (type_name, kind) — same type as Param twice → one entry,
+        // but same type as Param AND Return → two entries
+        let mut seen = std::collections::HashSet::new();
+        classified.retain(|t| seen.insert((t.type_name.clone(), t.kind)));
+
+        classified
+    }
+
     /// Extract all function calls from a file, ignoring size limits
     ///
     /// Returns calls for every function in the file, including those >100 lines
     /// that would normally be skipped during chunk extraction.
+    /// Thin wrapper around `parse_file_relationships()`.
     pub fn parse_file_calls(&self, path: &Path) -> Result<Vec<FunctionCalls>, ParserError> {
+        let (calls, _types) = self.parse_file_relationships(path)?;
+        Ok(calls)
+    }
+
+    /// Extract all function calls AND type references from a file in a single parse pass
+    ///
+    /// Returns `(calls, type_refs)` for every chunk in the file. Single file read,
+    /// single tree-sitter parse, two query cursors on the same tree.
+    pub fn parse_file_relationships(
+        &self,
+        path: &Path,
+    ) -> Result<(Vec<FunctionCalls>, Vec<ChunkTypeRefs>), ParserError> {
+        let _span =
+            tracing::info_span!("parse_file_relationships", path = %path.display()).entered();
+
         // Check file size (matching parse_file limit)
         const MAX_FILE_SIZE: u64 = 50 * 1024 * 1024;
         match std::fs::metadata(path) {
@@ -107,7 +215,7 @@ impl Parser {
                     meta.len() / (1024 * 1024),
                     path.display()
                 );
-                return Ok(vec![]);
+                return Ok((vec![], vec![]));
             }
             Ok(_) => {}
             Err(e) => return Err(e.into()),
@@ -117,7 +225,7 @@ impl Parser {
         let source = match std::fs::read_to_string(path) {
             Ok(s) => s,
             Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
-                return Ok(vec![]);
+                return Ok((vec![], vec![]));
             }
             Err(e) => return Err(e.into()),
         };
@@ -131,7 +239,8 @@ impl Parser {
 
         // Grammar-less languages (Markdown) use custom reference extraction
         if language.def().grammar.is_none() {
-            return crate::parser::markdown::parse_markdown_references(&source, path);
+            let md_calls = crate::parser::markdown::parse_markdown_references(&source, path)?;
+            return Ok((md_calls, vec![]));
         }
 
         let grammar = language.grammar();
@@ -151,7 +260,8 @@ impl Parser {
         let mut cursor = tree_sitter::QueryCursor::new();
         let mut matches = cursor.matches(chunk_query, tree.root_node(), source.as_bytes());
 
-        let mut results = Vec::new();
+        let mut call_results = Vec::new();
+        let mut type_results = Vec::new();
         // Reuse these allocations across iterations
         let mut call_cursor = tree_sitter::QueryCursor::new();
         let mut calls = Vec::new();
@@ -159,7 +269,7 @@ impl Parser {
         let capture_names = chunk_query.capture_names();
 
         while let Some(m) = matches.next() {
-            // Find function node
+            // Find chunk node
             let func_node = m.captures.iter().find(|c| {
                 let name = capture_names.get(c.index as usize).copied().unwrap_or("");
                 matches!(
@@ -174,7 +284,7 @@ impl Parser {
 
             let node = func_capture.node;
 
-            // Get function name
+            // Get chunk name
             let name_idx = chunk_query.capture_index_for_name("name");
             let name = name_idx
                 .and_then(|idx| m.captures.iter().find(|c| c.index == idx))
@@ -182,9 +292,10 @@ impl Parser {
                 .unwrap_or_else(|| "<anonymous>".to_string());
 
             let line_start = node.start_position().row as u32 + 1;
+            let byte_range = node.byte_range();
 
-            // Extract calls within this function (no size limit!)
-            call_cursor.set_byte_range(node.byte_range());
+            // --- Call extraction ---
+            call_cursor.set_byte_range(byte_range.clone());
             calls.clear();
 
             let mut call_matches =
@@ -204,20 +315,35 @@ impl Parser {
                 }
             }
 
-            // Deduplicate
+            // Deduplicate calls
             seen.clear();
             calls.retain(|c| seen.insert(c.callee_name.clone()));
 
             if !calls.is_empty() {
-                results.push(FunctionCalls {
-                    name,
+                call_results.push(FunctionCalls {
+                    name: name.clone(),
                     line_start,
                     calls: std::mem::take(&mut calls),
                 });
             }
+
+            // --- Type extraction ---
+            let mut type_refs =
+                self.extract_types(&source, &tree, language, byte_range.start, byte_range.end);
+
+            // Filter self-referential types (e.g., struct Config shouldn't list Config as a dep)
+            type_refs.retain(|t| t.type_name != name);
+
+            if !type_refs.is_empty() {
+                type_results.push(ChunkTypeRefs {
+                    name,
+                    line_start,
+                    type_refs,
+                });
+            }
         }
 
-        Ok(results)
+        Ok((call_results, type_results))
     }
 }
 
@@ -405,6 +531,450 @@ fn another() {
             let parser = Parser::new().unwrap();
             let function_calls = parser.parse_file_calls(file.path()).unwrap();
             assert!(function_calls.is_empty());
+        }
+    }
+
+    mod type_extraction_tests {
+        use super::*;
+
+        /// Helper: check if type_refs contains (name, kind)
+        fn has_type(refs: &[TypeRef], name: &str, kind: Option<TypeEdgeKind>) -> bool {
+            refs.iter().any(|t| t.type_name == name && t.kind == kind)
+        }
+
+        /// Parse source with tree-sitter and run extract_types on full range.
+        /// Use for testing types on constructs that aren't chunks (impl blocks, type aliases).
+        fn extract_types_from_source(content: &str, ext: &str) -> Vec<TypeRef> {
+            let parser = Parser::new().unwrap();
+            let language = Language::from_extension(ext).unwrap();
+            let grammar = language.grammar();
+            let mut ts_parser = tree_sitter::Parser::new();
+            ts_parser.set_language(&grammar).unwrap();
+            let tree = ts_parser.parse(content, None).unwrap();
+            parser.extract_types(content, &tree, language, 0, content.len())
+        }
+
+        // --- Rust ---
+
+        #[test]
+        fn test_extract_types_rust_params_and_return() {
+            let content = "fn foo(x: Config, y: Store) -> StoreError { }\n";
+            let file = write_temp_file(content, "rs");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            assert_eq!(types.len(), 1);
+            let refs = &types[0].type_refs;
+            assert!(has_type(refs, "Config", Some(TypeEdgeKind::Param)));
+            assert!(has_type(refs, "Store", Some(TypeEdgeKind::Param)));
+            assert!(has_type(refs, "StoreError", Some(TypeEdgeKind::Return)));
+        }
+
+        #[test]
+        fn test_extract_types_rust_struct_fields() {
+            let content = "struct Foo {\n    config: Config,\n    pool: SqlitePool,\n}\n";
+            let file = write_temp_file(content, "rs");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            assert_eq!(types.len(), 1);
+            assert_eq!(types[0].name, "Foo");
+            let refs = &types[0].type_refs;
+            assert!(has_type(refs, "Config", Some(TypeEdgeKind::Field)));
+            assert!(has_type(refs, "SqlitePool", Some(TypeEdgeKind::Field)));
+        }
+
+        #[test]
+        fn test_extract_types_rust_impl() {
+            // impl blocks aren't chunks — test extract_types directly with full-file range
+            let content = "impl MyTrait for MyStruct {\n    fn foo(&self) { }\n}\n";
+            let types = extract_types_from_source(content, "rs");
+            assert!(
+                has_type(&types, "MyTrait", Some(TypeEdgeKind::Impl)),
+                "MyTrait should be Impl, got: {:?}",
+                types
+            );
+            assert!(
+                has_type(&types, "MyStruct", Some(TypeEdgeKind::Impl)),
+                "MyStruct should be Impl, got: {:?}",
+                types
+            );
+        }
+
+        #[test]
+        fn test_extract_types_rust_bounds() {
+            let content = "fn foo<T: Display + Clone>(x: T) { }\n";
+            let file = write_temp_file(content, "rs");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            // The function chunk includes its entire span including generic params
+            assert_eq!(types.len(), 1);
+            let refs = &types[0].type_refs;
+            assert!(has_type(refs, "Display", Some(TypeEdgeKind::Bound)));
+            assert!(has_type(refs, "Clone", Some(TypeEdgeKind::Bound)));
+        }
+
+        #[test]
+        fn test_extract_types_rust_no_primitives() {
+            let content = "fn foo(x: i32, y: bool) -> u64 { 0 }\n";
+            let file = write_temp_file(content, "rs");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            // Primitives are `primitive_type` in tree-sitter, not `type_identifier`
+            // So the function should have no type refs
+            assert!(types.is_empty());
+        }
+
+        #[test]
+        fn test_extract_types_rust_catch_all_merge() {
+            // Config appears as Param (classified) AND inside generic (catch-all)
+            // Error appears only inside generic (catch-all only)
+            let content = "fn foo(c: Config) -> Result<Config, MyError> { todo!() }\n";
+            let file = write_temp_file(content, "rs");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            assert_eq!(types.len(), 1);
+            let refs = &types[0].type_refs;
+
+            // Config should be Param (classified wins over catch-all)
+            assert!(has_type(refs, "Config", Some(TypeEdgeKind::Param)));
+            // Config should NOT also appear as None
+            assert!(!has_type(refs, "Config", None));
+
+            // Result should be Return (classified)
+            assert!(has_type(refs, "Result", Some(TypeEdgeKind::Return)));
+
+            // MyError should be None (catch-all only — inside generic)
+            assert!(has_type(refs, "MyError", None));
+        }
+
+        #[test]
+        fn test_extract_types_rust_reference_types() {
+            let content = "fn foo(x: &Config) -> &Store { todo!() }\n";
+            let file = write_temp_file(content, "rs");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            assert_eq!(types.len(), 1);
+            let refs = &types[0].type_refs;
+            assert!(has_type(refs, "Config", Some(TypeEdgeKind::Param)));
+            assert!(has_type(refs, "Store", Some(TypeEdgeKind::Return)));
+        }
+
+        #[test]
+        fn test_extract_types_rust_generic_param() {
+            let content = "fn foo(x: Vec<Config>) -> Option<Store> { todo!() }\n";
+            let file = write_temp_file(content, "rs");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            assert_eq!(types.len(), 1);
+            let refs = &types[0].type_refs;
+            // Vec and Option are the outer generic types → classified
+            assert!(has_type(refs, "Vec", Some(TypeEdgeKind::Param)));
+            assert!(has_type(refs, "Option", Some(TypeEdgeKind::Return)));
+            // Config and Store are inside generics → catch-all or classified depending on pattern
+            // Config is inside Vec<Config> which is a parameter → the generic_type pattern should match Vec
+            // Config itself is a type_identifier inside type_arguments → catch-all
+            assert!(
+                has_type(refs, "Config", None)
+                    || has_type(refs, "Config", Some(TypeEdgeKind::Param))
+            );
+            assert!(
+                has_type(refs, "Store", None)
+                    || has_type(refs, "Store", Some(TypeEdgeKind::Return))
+            );
+        }
+
+        #[test]
+        fn test_extract_types_rust_alias() {
+            // type_item isn't a chunk — test extract_types directly with full-file range
+            let content = "type MyResult = Result<Config, MyError>;\n";
+            let types = extract_types_from_source(content, "rs");
+            assert!(
+                has_type(&types, "Result", Some(TypeEdgeKind::Alias)),
+                "Result should be Alias, got: {:?}",
+                types
+            );
+            // Config and MyError inside generics — catch-all only
+            assert!(
+                has_type(&types, "Config", None),
+                "Config should be catch-all (None), got: {:?}",
+                types
+            );
+            assert!(
+                has_type(&types, "MyError", None),
+                "MyError should be catch-all (None), got: {:?}",
+                types
+            );
+        }
+
+        // --- TypeScript ---
+
+        #[test]
+        fn test_extract_types_typescript() {
+            let content =
+                "function foo(x: UserConfig): ResponseData {\n    return {} as ResponseData;\n}\n";
+            let file = write_temp_file(content, "ts");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            assert_eq!(types.len(), 1);
+            let refs = &types[0].type_refs;
+            assert!(has_type(refs, "UserConfig", Some(TypeEdgeKind::Param)));
+            assert!(has_type(refs, "ResponseData", Some(TypeEdgeKind::Return)));
+        }
+
+        // --- Python ---
+
+        #[test]
+        fn test_extract_types_python() {
+            let content = "def foo(x: MyType) -> ReturnType:\n    pass\n";
+            let file = write_temp_file(content, "py");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            assert_eq!(types.len(), 1);
+            let refs = &types[0].type_refs;
+            assert!(has_type(refs, "MyType", Some(TypeEdgeKind::Param)));
+            assert!(has_type(refs, "ReturnType", Some(TypeEdgeKind::Return)));
+        }
+
+        // --- Go ---
+
+        #[test]
+        fn test_extract_types_go() {
+            let content =
+                "package main\n\nfunc foo(cfg Config) Handler {\n    return Handler{}\n}\n";
+            let file = write_temp_file(content, "go");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            assert_eq!(types.len(), 1);
+            let refs = &types[0].type_refs;
+            assert!(has_type(refs, "Config", Some(TypeEdgeKind::Param)));
+            assert!(has_type(refs, "Handler", Some(TypeEdgeKind::Return)));
+        }
+
+        // --- Java ---
+
+        #[test]
+        fn test_extract_types_java() {
+            let content = "class Main {\n    public UserService getService(Config config) {\n        return null;\n    }\n}\n";
+            let file = write_temp_file(content, "java");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            // Java chunk query should capture the class or method
+            // method_definition captures getService
+            if !types.is_empty() {
+                let refs = &types[0].type_refs;
+                assert!(has_type(refs, "Config", Some(TypeEdgeKind::Param)));
+                assert!(has_type(refs, "UserService", Some(TypeEdgeKind::Return)));
+            }
+        }
+
+        // --- C ---
+
+        #[test]
+        fn test_extract_types_c() {
+            let content = "Config create_config(Pool pool) {\n    Config c;\n    return c;\n}\n";
+            let file = write_temp_file(content, "c");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            if !types.is_empty() {
+                let refs = &types[0].type_refs;
+                // C function_definition captures return type
+                assert!(has_type(refs, "Pool", Some(TypeEdgeKind::Param)));
+                // Config is both return type AND function name won't match (it's the type)
+                // Actually the function name is "create_config", Config is the return type
+                assert!(has_type(refs, "Config", Some(TypeEdgeKind::Return)));
+            }
+        }
+
+        // --- JavaScript (no types) ---
+
+        #[test]
+        fn test_extract_types_empty_for_js() {
+            let content = "function foo(x) {\n    return x + 1;\n}\n";
+            let file = write_temp_file(content, "js");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+            assert!(types.is_empty());
+        }
+
+        // --- Markdown (no types) ---
+
+        #[test]
+        fn test_extract_types_empty_for_markdown() {
+            let content = "# Hello\n\nSome text\n";
+            let file = write_temp_file(content, "md");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+            assert!(types.is_empty());
+        }
+
+        // --- Combined parse ---
+
+        #[test]
+        fn test_parse_file_relationships_returns_both() {
+            let content = r#"
+fn process(config: Config) -> StoreError {
+    helper();
+    store.save();
+}
+"#;
+            let file = write_temp_file(content, "rs");
+            let parser = Parser::new().unwrap();
+            let (calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            // Should have both calls and types
+            assert!(!calls.is_empty(), "Expected call results");
+            assert!(!types.is_empty(), "Expected type results");
+
+            let call_entry = calls.iter().find(|c| c.name == "process").unwrap();
+            let call_names: Vec<_> = call_entry
+                .calls
+                .iter()
+                .map(|c| c.callee_name.as_str())
+                .collect();
+            assert!(call_names.contains(&"helper"));
+            assert!(call_names.contains(&"save"));
+
+            let type_entry = types.iter().find(|t| t.name == "process").unwrap();
+            assert!(has_type(
+                &type_entry.type_refs,
+                "Config",
+                Some(TypeEdgeKind::Param)
+            ));
+            assert!(has_type(
+                &type_entry.type_refs,
+                "StoreError",
+                Some(TypeEdgeKind::Return)
+            ));
+        }
+
+        #[test]
+        fn test_parse_file_relationships_filters_self_referential() {
+            let content = "struct Config {\n    pool: SqlitePool,\n}\n";
+            let file = write_temp_file(content, "rs");
+            let parser = Parser::new().unwrap();
+            let (_calls, types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            if !types.is_empty() {
+                let config_refs = types.iter().find(|t| t.name == "Config").unwrap();
+                // Config should NOT appear in its own type_refs
+                assert!(
+                    !config_refs
+                        .type_refs
+                        .iter()
+                        .any(|t| t.type_name == "Config"),
+                    "Self-referential type should be filtered out"
+                );
+                assert!(has_type(
+                    &config_refs.type_refs,
+                    "SqlitePool",
+                    Some(TypeEdgeKind::Field)
+                ));
+            }
+        }
+
+        #[test]
+        fn test_parse_file_calls_unchanged() {
+            // Verify the thin wrapper returns same results as before
+            let content = r#"
+fn caller() {
+    helper();
+    other_func();
+}
+
+fn another() {
+    third();
+}
+"#;
+            let file = write_temp_file(content, "rs");
+            let parser = Parser::new().unwrap();
+            let calls_only = parser.parse_file_calls(file.path()).unwrap();
+            let (calls_combined, _types) = parser.parse_file_relationships(file.path()).unwrap();
+
+            assert_eq!(calls_only.len(), calls_combined.len());
+            for (a, b) in calls_only.iter().zip(calls_combined.iter()) {
+                assert_eq!(a.name, b.name);
+                assert_eq!(a.line_start, b.line_start);
+                assert_eq!(a.calls.len(), b.calls.len());
+            }
+        }
+
+        #[test]
+        fn test_parse_file_relationships_nonexistent() {
+            let parser = Parser::new().unwrap();
+            let result =
+                parser.parse_file_relationships(std::path::Path::new("/nonexistent/file.rs"));
+            assert!(result.is_err());
+        }
+    }
+
+    mod type_edge_kind_tests {
+        use super::*;
+
+        #[test]
+        fn test_roundtrip() {
+            let kinds = [
+                TypeEdgeKind::Param,
+                TypeEdgeKind::Return,
+                TypeEdgeKind::Field,
+                TypeEdgeKind::Impl,
+                TypeEdgeKind::Bound,
+                TypeEdgeKind::Alias,
+            ];
+            for kind in &kinds {
+                let s = kind.as_str();
+                let parsed: TypeEdgeKind = s.parse().unwrap();
+                assert_eq!(*kind, parsed);
+            }
+        }
+
+        #[test]
+        fn test_display() {
+            assert_eq!(TypeEdgeKind::Param.to_string(), "Param");
+            assert_eq!(TypeEdgeKind::Return.to_string(), "Return");
+            assert_eq!(TypeEdgeKind::Field.to_string(), "Field");
+            assert_eq!(TypeEdgeKind::Impl.to_string(), "Impl");
+            assert_eq!(TypeEdgeKind::Bound.to_string(), "Bound");
+            assert_eq!(TypeEdgeKind::Alias.to_string(), "Alias");
+        }
+
+        #[test]
+        fn test_unknown_from_str() {
+            let result: Result<TypeEdgeKind, _> = "Unknown".parse();
+            assert!(result.is_err());
+        }
+    }
+
+    /// Diagnostic: verify type queries compile for all languages with type_query defined
+    #[test]
+    fn test_type_queries_compile() {
+        let parser = Parser::new().unwrap();
+        let languages_with_types = [
+            Language::Rust,
+            Language::TypeScript,
+            Language::Python,
+            Language::Go,
+            Language::Java,
+            Language::C,
+        ];
+        for lang in languages_with_types {
+            let result = parser.get_type_query(lang);
+            assert!(
+                result.is_ok(),
+                "{} type query failed to compile: {:?}",
+                lang,
+                result.err()
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `parse_file_relationships()` — combined single-parse method returning both call sites and type references from one tree-sitter parse
- Add `extract_types()` with classified edge kinds (Param/Return/Field/Impl/Bound/Alias) and catch-all merge logic
- Add TYPE_QUERY for 6 typed languages (Rust, TypeScript, Go, Java, C, Python); JS/SQL/Markdown set to None
- Refactor `parse_file_calls()` as thin wrapper over `parse_file_relationships()` — zero API break
- Fix 3 tree-sitter query bugs found during testing: Rust `trait_bound`→`trait_bounds`, Go interface `type_elem` wrapper, Go `type_alias` pattern

Phase 2b Step 1 of the moonshot (`cqs deps`). Parser layer only — no schema, store, or CLI changes.

## Test plan

- [x] 24 new tests: type extraction per language, catch-all merge, combined parse, TypeEdgeKind roundtrip, query compilation regression
- [x] All 527 lib tests pass (0 failures)
- [x] All integration tests pass
- [x] `cargo clippy --features gpu-search` — 0 warnings
- [x] `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
