### PR TITLE
feat: add type edge storage, queries, CLI and batch — Phase 2b Step 2

### DIFF
--- a/src/cli/commands/deps.rs
+++ b/src/cli/commands/deps.rs
@@ -1,0 +1,79 @@
+//! Type dependency command for cqs
+//!
+//! Shows which chunks reference a type (forward), or what types a function uses (reverse).
+
+use anyhow::Result;
+use colored::Colorize;
+
+use crate::cli::Cli;
+
+/// Show type dependencies.
+///
+/// Forward (default): `cqs deps Config` — who uses this type?
+/// Reverse: `cqs deps --reverse func_name` — what types does this function use?
+pub(crate) fn cmd_deps(_cli: &Cli, name: &str, reverse: bool, json: bool) -> Result<()> {
+    let _span = tracing::info_span!("cmd_deps", name, reverse).entered();
+    let (store, root, _) = crate::cli::open_project_store()?;
+
+    if reverse {
+        let types = store.get_types_used_by(name)?;
+        if json {
+            let json_types: Vec<serde_json::Value> = types
+                .iter()
+                .map(|(tn, kind)| serde_json::json!({"type_name": tn, "edge_kind": kind}))
+                .collect();
+            let output = serde_json::json!({
+                "function": name,
+                "types": json_types,
+                "count": json_types.len(),
+            });
+            println!("{}", serde_json::to_string_pretty(&output)?);
+        } else if types.is_empty() {
+            println!("No type dependencies found for '{}'", name);
+        } else {
+            println!("Types used by '{}':", name.cyan());
+            println!();
+            for (type_name, kind) in &types {
+                if kind.is_empty() {
+                    println!("  {}", type_name);
+                } else {
+                    println!("  {} ({})", type_name, kind.dimmed());
+                }
+            }
+            println!();
+            println!("Total: {} type(s)", types.len());
+        }
+    } else {
+        let users = store.get_type_users(name)?;
+        if json {
+            let json_users: Vec<serde_json::Value> = users
+                .iter()
+                .map(|c| {
+                    serde_json::json!({
+                        "name": c.name,
+                        "file": cqs::rel_display(&c.file, &root),
+                        "line_start": c.line_start,
+                        "chunk_type": c.chunk_type.to_string(),
+                    })
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&json_users)?);
+        } else if users.is_empty() {
+            println!("No users found for type '{}'", name);
+        } else {
+            println!("Chunks that use type '{}':", name.cyan());
+            println!();
+            for user in &users {
+                println!(
+                    "  {} ({}:{})",
+                    user.name.cyan(),
+                    cqs::rel_display(&user.file, &root),
+                    user.line_start
+                );
+            }
+            println!();
+            println!("Total: {} user(s)", users.len());
+        }
+    }
+    Ok(())
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -8,6 +8,7 @@ mod context;
 #[cfg(feature = "convert")]
 mod convert;
 mod dead;
+mod deps;
 mod diff;
 mod doctor;
 mod explain;
@@ -42,6 +43,7 @@ pub(crate) use context::cmd_context;
 #[cfg(feature = "convert")]
 pub(crate) use convert::cmd_convert;
 pub(crate) use dead::cmd_dead;
+pub(crate) use deps::cmd_deps;
 pub(crate) use diff::cmd_diff;
 pub(crate) use doctor::cmd_doctor;
 pub(crate) use explain::cmd_explain;

--- a/src/cli/commands/stats.rs
+++ b/src/cli/commands/stats.rs
@@ -31,6 +31,7 @@ pub(crate) fn cmd_stats(cli: &Cli, json: bool) -> Result<()> {
         fc_stats.unique_callers,
         fc_stats.unique_callees,
     );
+    let te_stats = store.type_edge_stats()?;
 
     if json || cli.json {
         let json = serde_json::json!({
@@ -43,6 +44,10 @@ pub(crate) fn cmd_stats(cli: &Cli, json: bool) -> Result<()> {
                 "total_calls": call_count,
                 "unique_callers": caller_count,
                 "unique_callees": callee_count,
+            },
+            "type_graph": {
+                "total_edges": te_stats.total_edges,
+                "unique_types": te_stats.unique_types,
             },
             "by_language": stats.chunks_by_language.iter()
                 .map(|(l, c)| (l.to_string(), c))
@@ -81,6 +86,10 @@ pub(crate) fn cmd_stats(cli: &Cli, json: bool) -> Result<()> {
         println!(
             "Call graph: {} calls ({} callers, {} callees)",
             call_count, caller_count, callee_count
+        );
+        println!(
+            "Type graph: {} edges ({} types)",
+            te_stats.total_edges, te_stats.unique_types
         );
 
         // HNSW index status (use count_vectors to avoid loading full index)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -36,11 +36,11 @@ pub(crate) fn open_project_store(
 #[cfg(feature = "convert")]
 use commands::cmd_convert;
 use commands::{
-    cmd_audit_mode, cmd_callees, cmd_callers, cmd_ci, cmd_context, cmd_dead, cmd_diff, cmd_doctor,
-    cmd_explain, cmd_gather, cmd_gc, cmd_health, cmd_impact, cmd_impact_diff, cmd_index, cmd_init,
-    cmd_notes, cmd_project, cmd_query, cmd_read, cmd_ref, cmd_related, cmd_review, cmd_scout,
-    cmd_similar, cmd_stale, cmd_stats, cmd_suggest, cmd_test_map, cmd_trace, cmd_where,
-    NotesCommand, ProjectCommand, RefCommand,
+    cmd_audit_mode, cmd_callees, cmd_callers, cmd_ci, cmd_context, cmd_dead, cmd_deps, cmd_diff,
+    cmd_doctor, cmd_explain, cmd_gather, cmd_gc, cmd_health, cmd_impact, cmd_impact_diff,
+    cmd_index, cmd_init, cmd_notes, cmd_project, cmd_query, cmd_read, cmd_ref, cmd_related,
+    cmd_review, cmd_scout, cmd_similar, cmd_stale, cmd_stats, cmd_suggest, cmd_test_map, cmd_trace,
+    cmd_where, NotesCommand, ProjectCommand, RefCommand,
 };
 use config::apply_config_defaults;
 
@@ -239,6 +239,17 @@ enum Commands {
         /// Shell to generate completions for
         #[arg(value_enum)]
         shell: clap_complete::Shell,
+    },
+    /// Show type dependencies: who uses a type, or what types a function uses
+    Deps {
+        /// Type name (forward) or function name (with --reverse)
+        name: String,
+        /// Reverse: show types used by a function instead of type users
+        #[arg(long)]
+        reverse: bool,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Find functions that call a given function
     Callers {
@@ -596,6 +607,11 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
             cmd_completions(shell);
             Ok(())
         }
+        Some(Commands::Deps {
+            ref name,
+            reverse,
+            json,
+        }) => cmd_deps(&cli, name, reverse, json),
         Some(Commands::Callers { ref name, json }) => cmd_callers(&cli, name, json),
         Some(Commands::Callees { ref name, json }) => cmd_callees(&cli, name, json),
         Some(Commands::Notes { ref subcmd }) => cmd_notes(&cli, subcmd),

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -13,8 +13,9 @@ use crate::parser::{ChunkType, Language};
 /// against the stored version and returns StoreError::SchemaMismatch if different.
 ///
 /// History:
-/// - v10: Current (sentiment in embeddings, call graph, notes)
-pub const CURRENT_SCHEMA_VERSION: i32 = 10;
+/// - v11: Current (type_edges table for type-level dependency tracking)
+/// - v10: sentiment in embeddings, call graph, notes
+pub const CURRENT_SCHEMA_VERSION: i32 = 11;
 pub const MODEL_NAME: &str = "intfloat/e5-base-v2";
 /// Expected embedding dimensions — derived from crate::EMBEDDING_DIM
 pub const EXPECTED_DIMENSIONS: u32 = crate::EMBEDDING_DIM as u32;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -14,6 +14,7 @@ mod calls;
 mod chunks;
 mod migrations;
 mod notes;
+mod types;
 
 /// Helper types and embedding conversion functions.
 ///
@@ -104,6 +105,12 @@ pub use calls::DeadConfidence;
 
 /// Detailed function call statistics (function_calls table).
 pub use calls::FunctionCallStats;
+
+/// Statistics about type dependency edges (type_edges table).
+pub use types::TypeEdgeStats;
+
+/// In-memory type graph (forward + reverse adjacency lists).
+pub use types::TypeGraph;
 
 // Internal use
 use helpers::{clamp_line_number, ChunkRow};

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -1,0 +1,992 @@
+//! Type edge storage and queries
+//!
+//! Stores type-level dependency edges extracted by the parser (Phase 2b).
+//! Each edge records which chunk references which type, with an edge_kind
+//! classification (Param, Return, Field, Impl, Bound, Alias) or empty string
+//! for catch-all types found only inside generics.
+//!
+//! Follows the same patterns as `calls.rs`: sync wrappers over async sqlx,
+//! batch-safe SQL (999 bind limit), tracing at appropriate levels.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use super::helpers::{clamp_line_number, ChunkRow, StoreError};
+use super::Store;
+use crate::store::helpers::ChunkSummary;
+
+/// Statistics about type dependency edges
+#[derive(Debug, Clone, Default)]
+pub struct TypeEdgeStats {
+    /// Total number of type edges
+    pub total_edges: u64,
+    /// Number of distinct target type names
+    pub unique_types: u64,
+}
+
+/// In-memory type graph for BFS traversal
+///
+/// Built from a single scan of the `type_edges` table joined with `chunks`.
+/// Forward: chunk_name -> Vec<type_name>, Reverse: type_name -> Vec<chunk_name>.
+/// Used by Phase 4 BFS traversal over type edges.
+pub struct TypeGraph {
+    /// Forward edges: chunk_name -> Vec<type_name>
+    pub forward: HashMap<String, Vec<String>>,
+    /// Reverse edges: type_name -> Vec<chunk_name>
+    pub reverse: HashMap<String, Vec<String>>,
+}
+
+impl Store {
+    // ============ Type Edge Upsert Methods ============
+
+    /// Upsert type edges for a single chunk.
+    ///
+    /// Deletes existing type edges for the chunk, then batch-inserts new ones.
+    /// 4 binds per row → 249 rows per batch (996 < 999 SQLite limit).
+    pub fn upsert_type_edges(
+        &self,
+        chunk_id: &str,
+        type_refs: &[crate::parser::TypeRef],
+    ) -> Result<(), StoreError> {
+        if type_refs.is_empty() {
+            return Ok(());
+        }
+
+        tracing::trace!(chunk_id, count = type_refs.len(), "upserting type edges");
+
+        self.rt.block_on(async {
+            let mut tx = self.pool.begin().await?;
+
+            sqlx::query("DELETE FROM type_edges WHERE source_chunk_id = ?1")
+                .bind(chunk_id)
+                .execute(&mut *tx)
+                .await?;
+
+            const INSERT_BATCH: usize = 249;
+            for batch in type_refs.chunks(INSERT_BATCH) {
+                let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+                    "INSERT INTO type_edges (source_chunk_id, target_type_name, edge_kind, line_number) ",
+                );
+                qb.push_values(batch.iter(), |mut b, tr| {
+                    let kind_str = tr
+                        .kind
+                        .as_ref()
+                        .map(|k| k.as_str())
+                        .unwrap_or("");
+                    b.push_bind(chunk_id)
+                        .push_bind(&tr.type_name)
+                        .push_bind(kind_str)
+                        .push_bind(tr.line_number as i64);
+                });
+                qb.build().execute(&mut *tx).await?;
+            }
+
+            tracing::debug!(chunk_id, count = type_refs.len(), "Inserted type edges");
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    /// Upsert type edges for all chunks in a file.
+    ///
+    /// Resolves chunk names to chunk IDs via the chunks table, then deletes old
+    /// type edges and batch-inserts new ones. Chunks not found in the database
+    /// are warned and skipped (not an error).
+    ///
+    /// For windowed chunks, associates type edges with the first window
+    /// (window_idx IS NULL or window_idx = 0).
+    pub fn upsert_type_edges_for_file(
+        &self,
+        file: &Path,
+        chunk_type_refs: &[crate::parser::ChunkTypeRefs],
+    ) -> Result<(), StoreError> {
+        if chunk_type_refs.is_empty() {
+            return Ok(());
+        }
+
+        let file_str = file.to_string_lossy().replace('\\', "/");
+        let total_refs: usize = chunk_type_refs.iter().map(|c| c.type_refs.len()).sum();
+        tracing::trace!(
+            file = %file_str,
+            chunks = chunk_type_refs.len(),
+            total_refs,
+            "upserting type edges for file"
+        );
+
+        self.rt.block_on(async {
+            // Resolve chunk names to IDs
+            let rows: Vec<(String, String, i64, Option<i64>)> = sqlx::query_as(
+                "SELECT id, name, line_start, window_idx FROM chunks WHERE origin = ?1",
+            )
+            .bind(&file_str)
+            .fetch_all(&self.pool)
+            .await?;
+
+            // Build lookup: (name, line_start) -> chunk_id
+            // For windowed chunks, prefer window_idx IS NULL or window_idx = 0
+            let mut name_to_id: HashMap<(String, u32), String> = HashMap::new();
+            for (id, name, line_start, window_idx) in &rows {
+                let key = (name.clone(), clamp_line_number(*line_start));
+                let is_primary = window_idx.is_none() || *window_idx == Some(0);
+                if is_primary || !name_to_id.contains_key(&key) {
+                    name_to_id.insert(key, id.clone());
+                }
+            }
+
+            // Collect (chunk_id, type_ref) pairs, skipping unresolved chunks
+            let mut edges: Vec<(&str, &crate::parser::TypeRef)> = Vec::new();
+            for ctr in chunk_type_refs {
+                let key = (ctr.name.clone(), ctr.line_start);
+                if let Some(chunk_id) = name_to_id.get(&key) {
+                    for tr in &ctr.type_refs {
+                        edges.push((chunk_id.as_str(), tr));
+                    }
+                } else {
+                    tracing::warn!(
+                        name = %ctr.name,
+                        line_start = ctr.line_start,
+                        file = %file_str,
+                        "Chunk not found for type edges, skipping"
+                    );
+                }
+            }
+
+            if edges.is_empty() {
+                return Ok(());
+            }
+
+            let mut tx = self.pool.begin().await?;
+
+            // Delete existing type edges for all resolved chunk IDs
+            let chunk_ids: Vec<&str> = name_to_id.values().map(|s| s.as_str()).collect();
+            for batch in chunk_ids.chunks(500) {
+                let placeholders: String = (1..=batch.len())
+                    .map(|i| format!("?{}", i))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let sql = format!(
+                    "DELETE FROM type_edges WHERE source_chunk_id IN ({})",
+                    placeholders
+                );
+                let mut q = sqlx::query(&sql);
+                for id in batch {
+                    q = q.bind(id);
+                }
+                q.execute(&mut *tx).await?;
+            }
+
+            // Batch insert new edges
+            const INSERT_BATCH: usize = 249;
+            for batch in edges.chunks(INSERT_BATCH) {
+                let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+                    "INSERT INTO type_edges (source_chunk_id, target_type_name, edge_kind, line_number) ",
+                );
+                qb.push_values(batch.iter(), |mut b, (chunk_id, tr)| {
+                    let kind_str = tr
+                        .kind
+                        .as_ref()
+                        .map(|k| k.as_str())
+                        .unwrap_or("");
+                    b.push_bind(*chunk_id)
+                        .push_bind(&tr.type_name)
+                        .push_bind(kind_str)
+                        .push_bind(tr.line_number as i64);
+                });
+                qb.build().execute(&mut *tx).await?;
+            }
+
+            tracing::info!(
+                file = %file_str,
+                chunks = chunk_type_refs.len(),
+                edges = edges.len(),
+                "Indexed type edges"
+            );
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    // ============ Type Edge Query Methods ============
+
+    /// Get chunks that reference a given type name.
+    ///
+    /// Forward query: "who uses Config?" Returns chunks that have type edges
+    /// pointing to the given type name.
+    pub fn get_type_users(&self, type_name: &str) -> Result<Vec<ChunkSummary>, StoreError> {
+        tracing::debug!(type_name, "querying type users");
+
+        self.rt.block_on(async {
+            let rows: Vec<ChunkRow> = sqlx::query(
+                "SELECT DISTINCT c.id, c.origin, c.language, c.chunk_type, c.name,
+                        c.signature, c.content, c.doc, c.line_start, c.line_end, c.parent_id
+                 FROM type_edges te
+                 JOIN chunks c ON te.source_chunk_id = c.id
+                 WHERE te.target_type_name = ?1
+                 ORDER BY c.origin, c.line_start",
+            )
+            .bind(type_name)
+            .fetch_all(&self.pool)
+            .await?
+            .iter()
+            .map(ChunkRow::from_row)
+            .collect();
+
+            Ok(rows.into_iter().map(ChunkSummary::from).collect())
+        })
+    }
+
+    /// Get types used by a given chunk (by function name).
+    ///
+    /// Reverse query: "what types does parse_config use?" Returns (type_name, edge_kind)
+    /// pairs where edge_kind is "" for catch-all types.
+    pub fn get_types_used_by(&self, chunk_name: &str) -> Result<Vec<(String, String)>, StoreError> {
+        tracing::debug!(chunk_name, "querying types used by chunk");
+
+        self.rt.block_on(async {
+            let rows: Vec<(String, String)> = sqlx::query_as(
+                "SELECT DISTINCT te.target_type_name, te.edge_kind
+                 FROM type_edges te
+                 JOIN chunks c ON te.source_chunk_id = c.id
+                 WHERE c.name = ?1
+                 ORDER BY te.edge_kind, te.target_type_name",
+            )
+            .bind(chunk_name)
+            .fetch_all(&self.pool)
+            .await?;
+
+            Ok(rows)
+        })
+    }
+
+    /// Batch-fetch type users for multiple type names.
+    ///
+    /// Returns type_name -> Vec<ChunkSummary>. Uses WHERE IN with 200 names per batch.
+    pub fn get_type_users_batch(
+        &self,
+        type_names: &[&str],
+    ) -> Result<HashMap<String, Vec<ChunkSummary>>, StoreError> {
+        if type_names.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        tracing::debug!(count = type_names.len(), "batch querying type users");
+
+        self.rt.block_on(async {
+            let mut result: HashMap<String, Vec<ChunkSummary>> = HashMap::new();
+
+            const BATCH_SIZE: usize = 200;
+            for batch in type_names.chunks(BATCH_SIZE) {
+                let placeholders: String = (1..=batch.len())
+                    .map(|i| format!("?{}", i))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let sql = format!(
+                    "SELECT te.target_type_name, c.id, c.origin, c.language, c.chunk_type, c.name,
+                            c.signature, c.content, c.doc, c.line_start, c.line_end, c.parent_id
+                     FROM type_edges te
+                     JOIN chunks c ON te.source_chunk_id = c.id
+                     WHERE te.target_type_name IN ({})
+                     ORDER BY te.target_type_name, c.origin, c.line_start",
+                    placeholders
+                );
+                let mut q = sqlx::query(&sql);
+                for name in batch {
+                    q = q.bind(name);
+                }
+                let rows: Vec<_> = q.fetch_all(&self.pool).await?;
+                for row in rows {
+                    use sqlx::Row;
+                    let type_name: String = row.get(0);
+                    // Build ChunkRow from remaining columns (offset by 1)
+                    let chunk = ChunkSummary::from(ChunkRow {
+                        id: row.get(1),
+                        origin: row.get(2),
+                        language: row.get(3),
+                        chunk_type: row.get(4),
+                        name: row.get(5),
+                        signature: row.get(6),
+                        content: row.get(7),
+                        doc: row.get(8),
+                        line_start: clamp_line_number(row.get::<i64, _>(9)),
+                        line_end: clamp_line_number(row.get::<i64, _>(10)),
+                        parent_id: row.get(11),
+                    });
+                    result.entry(type_name).or_default().push(chunk);
+                }
+            }
+
+            Ok(result)
+        })
+    }
+
+    /// Batch-fetch types used by multiple chunk names.
+    ///
+    /// Returns chunk_name -> Vec<(type_name, edge_kind)>. Uses WHERE IN with 200 names per batch.
+    pub fn get_types_used_by_batch(
+        &self,
+        chunk_names: &[&str],
+    ) -> Result<HashMap<String, Vec<(String, String)>>, StoreError> {
+        if chunk_names.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        tracing::debug!(count = chunk_names.len(), "batch querying types used by");
+
+        self.rt.block_on(async {
+            let mut result: HashMap<String, Vec<(String, String)>> = HashMap::new();
+
+            const BATCH_SIZE: usize = 200;
+            for batch in chunk_names.chunks(BATCH_SIZE) {
+                let placeholders: String = (1..=batch.len())
+                    .map(|i| format!("?{}", i))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let sql = format!(
+                    "SELECT c.name, te.target_type_name, te.edge_kind
+                     FROM type_edges te
+                     JOIN chunks c ON te.source_chunk_id = c.id
+                     WHERE c.name IN ({})
+                     ORDER BY c.name, te.edge_kind, te.target_type_name",
+                    placeholders
+                );
+                let mut q = sqlx::query(&sql);
+                for name in batch {
+                    q = q.bind(name);
+                }
+                let rows: Vec<_> = q.fetch_all(&self.pool).await?;
+                for row in rows {
+                    use sqlx::Row;
+                    let chunk_name: String = row.get(0);
+                    let type_name: String = row.get(1);
+                    let edge_kind: String = row.get(2);
+                    result
+                        .entry(chunk_name)
+                        .or_default()
+                        .push((type_name, edge_kind));
+                }
+            }
+
+            Ok(result)
+        })
+    }
+
+    // ============ Type Edge Statistics ============
+
+    /// Get type edge statistics.
+    pub fn type_edge_stats(&self) -> Result<TypeEdgeStats, StoreError> {
+        tracing::debug!("querying type edge stats");
+
+        self.rt.block_on(async {
+            let (total_edges, unique_types): (i64, i64) =
+                sqlx::query_as("SELECT COUNT(*), COUNT(DISTINCT target_type_name) FROM type_edges")
+                    .fetch_one(&self.pool)
+                    .await?;
+
+            Ok(TypeEdgeStats {
+                total_edges: total_edges as u64,
+                unique_types: unique_types as u64,
+            })
+        })
+    }
+
+    /// Load the type graph as forward + reverse adjacency lists.
+    ///
+    /// Single SQL scan of `type_edges` joined with `chunks`, capped at 500K edges.
+    /// Forward: chunk_name -> Vec<type_name>, Reverse: type_name -> Vec<chunk_name>.
+    pub fn get_type_graph(&self) -> Result<TypeGraph, StoreError> {
+        let _span = tracing::info_span!("get_type_graph").entered();
+
+        self.rt.block_on(async {
+            const MAX_TYPE_GRAPH_EDGES: i64 = 500_000;
+            let rows: Vec<(String, String)> = sqlx::query_as(
+                "SELECT c.name, te.target_type_name
+                 FROM type_edges te
+                 JOIN chunks c ON te.source_chunk_id = c.id
+                 LIMIT ?1",
+            )
+            .bind(MAX_TYPE_GRAPH_EDGES)
+            .fetch_all(&self.pool)
+            .await?;
+
+            if rows.len() as i64 >= MAX_TYPE_GRAPH_EDGES {
+                tracing::warn!(
+                    cap = MAX_TYPE_GRAPH_EDGES,
+                    "Type graph hit edge cap, results may be incomplete"
+                );
+            }
+
+            let mut forward: HashMap<String, Vec<String>> = HashMap::new();
+            let mut reverse: HashMap<String, Vec<String>> = HashMap::new();
+
+            for (chunk_name, type_name) in rows {
+                reverse
+                    .entry(type_name.clone())
+                    .or_default()
+                    .push(chunk_name.clone());
+                forward.entry(chunk_name).or_default().push(type_name);
+            }
+
+            Ok(TypeGraph { forward, reverse })
+        })
+    }
+
+    /// Find types that share users with target (co-occurrence).
+    ///
+    /// "Types commonly used alongside Config" → Vec<(type_name, overlap_count)>.
+    /// Uses self-join: find other types referenced by the same chunks that reference target.
+    pub fn find_shared_type_users(
+        &self,
+        target_type: &str,
+        limit: usize,
+    ) -> Result<Vec<(String, u32)>, StoreError> {
+        tracing::debug!(target_type, limit, "finding shared type users");
+
+        self.rt.block_on(async {
+            let rows: Vec<(String, i64)> = sqlx::query_as(
+                "SELECT te2.target_type_name, COUNT(DISTINCT te2.source_chunk_id) AS overlap
+                 FROM type_edges te1
+                 JOIN type_edges te2 ON te1.source_chunk_id = te2.source_chunk_id
+                 WHERE te1.target_type_name = ?1 AND te2.target_type_name != ?1
+                 GROUP BY te2.target_type_name
+                 ORDER BY overlap DESC
+                 LIMIT ?2",
+            )
+            .bind(target_type)
+            .bind(limit as i64)
+            .fetch_all(&self.pool)
+            .await?;
+
+            Ok(rows
+                .into_iter()
+                .map(|(name, count)| (name, count as u32))
+                .collect())
+        })
+    }
+
+    // ============ Type Edge Maintenance ============
+
+    /// Delete type_edges for chunks no longer in the chunks table (GC).
+    ///
+    /// Returns the number of pruned rows.
+    pub fn prune_stale_type_edges(&self) -> Result<u64, StoreError> {
+        self.rt.block_on(async {
+            let result = sqlx::query(
+                "DELETE FROM type_edges WHERE source_chunk_id NOT IN (SELECT id FROM chunks)",
+            )
+            .execute(&self.pool)
+            .await?;
+            let count = result.rows_affected();
+            if count > 0 {
+                tracing::info!(pruned = count, "Pruned stale type edges");
+            }
+            Ok(count)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{TypeEdgeKind, TypeRef};
+    use crate::store::helpers::ModelInfo;
+    use std::path::Path;
+
+    fn setup_store() -> (Store, tempfile::TempDir) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("index.db");
+        let store = Store::open(&db_path).unwrap();
+        store.init(&ModelInfo::default()).unwrap();
+        (store, dir)
+    }
+
+    /// Insert a minimal chunk into the store for testing type edges.
+    fn insert_test_chunk(store: &Store, id: &str, name: &str, file: &str) {
+        store.rt.block_on(async {
+            let embedding = crate::embedder::Embedding::new(vec![0.0f32; crate::EMBEDDING_DIM]);
+            let embedding_bytes = crate::store::helpers::embedding_to_bytes(&embedding).unwrap();
+            let now = chrono::Utc::now().to_rfc3339();
+            sqlx::query(
+                "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name,
+                     signature, content, content_hash, doc, line_start, line_end, embedding,
+                     source_mtime, created_at, updated_at)
+                     VALUES (?1, ?2, 'file', 'rust', 'function', ?3,
+                     '', '', '', NULL, 1, 10, ?4, 0, ?5, ?5)",
+            )
+            .bind(id)
+            .bind(file)
+            .bind(name)
+            .bind(&embedding_bytes)
+            .bind(&now)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        });
+    }
+
+    fn make_type_refs() -> Vec<TypeRef> {
+        vec![
+            TypeRef {
+                type_name: "Config".to_string(),
+                line_number: 5,
+                kind: Some(TypeEdgeKind::Param),
+            },
+            TypeRef {
+                type_name: "Store".to_string(),
+                line_number: 5,
+                kind: Some(TypeEdgeKind::Return),
+            },
+            TypeRef {
+                type_name: "SqlitePool".to_string(),
+                line_number: 8,
+                kind: Some(TypeEdgeKind::Field),
+            },
+        ]
+    }
+
+    #[test]
+    fn test_upsert_and_query_type_users() {
+        let (store, _dir) = setup_store();
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/a.rs");
+        insert_test_chunk(&store, "chunk-b", "func_b", "src/b.rs");
+
+        // func_a uses Config(Param) and Store(Return)
+        store
+            .upsert_type_edges(
+                "chunk-a",
+                &[
+                    TypeRef {
+                        type_name: "Config".to_string(),
+                        line_number: 5,
+                        kind: Some(TypeEdgeKind::Param),
+                    },
+                    TypeRef {
+                        type_name: "Store".to_string(),
+                        line_number: 6,
+                        kind: Some(TypeEdgeKind::Return),
+                    },
+                ],
+            )
+            .unwrap();
+
+        // func_b uses Config(Param)
+        store
+            .upsert_type_edges(
+                "chunk-b",
+                &[TypeRef {
+                    type_name: "Config".to_string(),
+                    line_number: 10,
+                    kind: Some(TypeEdgeKind::Param),
+                }],
+            )
+            .unwrap();
+
+        // Query: who uses Config?
+        let users = store.get_type_users("Config").unwrap();
+        assert_eq!(users.len(), 2);
+        let names: Vec<&str> = users.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"func_a"));
+        assert!(names.contains(&"func_b"));
+
+        // Query: who uses Store?
+        let users = store.get_type_users("Store").unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].name, "func_a");
+    }
+
+    #[test]
+    fn test_upsert_and_query_types_used_by() {
+        let (store, _dir) = setup_store();
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/a.rs");
+
+        store
+            .upsert_type_edges("chunk-a", &make_type_refs())
+            .unwrap();
+
+        let types = store.get_types_used_by("func_a").unwrap();
+        assert_eq!(types.len(), 3);
+        let type_names: Vec<&str> = types.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(type_names.contains(&"Config"));
+        assert!(type_names.contains(&"Store"));
+        assert!(type_names.contains(&"SqlitePool"));
+    }
+
+    #[test]
+    fn test_upsert_replaces_old() {
+        let (store, _dir) = setup_store();
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/a.rs");
+
+        // First upsert: Config + Store
+        store
+            .upsert_type_edges("chunk-a", &make_type_refs())
+            .unwrap();
+        let types = store.get_types_used_by("func_a").unwrap();
+        assert_eq!(types.len(), 3);
+
+        // Second upsert: only HashMap
+        store
+            .upsert_type_edges(
+                "chunk-a",
+                &[TypeRef {
+                    type_name: "HashMap".to_string(),
+                    line_number: 1,
+                    kind: Some(TypeEdgeKind::Return),
+                }],
+            )
+            .unwrap();
+        let types = store.get_types_used_by("func_a").unwrap();
+        assert_eq!(types.len(), 1);
+        assert_eq!(types[0].0, "HashMap");
+    }
+
+    #[test]
+    fn test_get_type_users_empty() {
+        let (store, _dir) = setup_store();
+        let users = store.get_type_users("NonexistentType").unwrap();
+        assert!(users.is_empty());
+    }
+
+    #[test]
+    fn test_get_types_used_by_empty() {
+        let (store, _dir) = setup_store();
+        let types = store.get_types_used_by("nonexistent_func").unwrap();
+        assert!(types.is_empty());
+    }
+
+    #[test]
+    fn test_type_users_batch() {
+        let (store, _dir) = setup_store();
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/a.rs");
+        insert_test_chunk(&store, "chunk-b", "func_b", "src/b.rs");
+
+        store
+            .upsert_type_edges(
+                "chunk-a",
+                &[TypeRef {
+                    type_name: "Config".to_string(),
+                    line_number: 5,
+                    kind: Some(TypeEdgeKind::Param),
+                }],
+            )
+            .unwrap();
+        store
+            .upsert_type_edges(
+                "chunk-b",
+                &[TypeRef {
+                    type_name: "Store".to_string(),
+                    line_number: 5,
+                    kind: Some(TypeEdgeKind::Param),
+                }],
+            )
+            .unwrap();
+
+        let result = store
+            .get_type_users_batch(&["Config", "Store", "Unknown"])
+            .unwrap();
+        assert_eq!(result.get("Config").map(|v| v.len()).unwrap_or(0), 1);
+        assert_eq!(result.get("Store").map(|v| v.len()).unwrap_or(0), 1);
+        assert!(result.get("Unknown").is_none());
+    }
+
+    #[test]
+    fn test_types_used_by_batch() {
+        let (store, _dir) = setup_store();
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/a.rs");
+        insert_test_chunk(&store, "chunk-b", "func_b", "src/b.rs");
+
+        store
+            .upsert_type_edges("chunk-a", &make_type_refs())
+            .unwrap();
+        store
+            .upsert_type_edges(
+                "chunk-b",
+                &[TypeRef {
+                    type_name: "HashMap".to_string(),
+                    line_number: 1,
+                    kind: None,
+                }],
+            )
+            .unwrap();
+
+        let result = store
+            .get_types_used_by_batch(&["func_a", "func_b"])
+            .unwrap();
+        assert_eq!(result.get("func_a").map(|v| v.len()).unwrap_or(0), 3);
+        assert_eq!(result.get("func_b").map(|v| v.len()).unwrap_or(0), 1);
+    }
+
+    #[test]
+    fn test_batch_empty_input() {
+        let (store, _dir) = setup_store();
+        let r1 = store.get_type_users_batch(&[]).unwrap();
+        assert!(r1.is_empty());
+        let r2 = store.get_types_used_by_batch(&[]).unwrap();
+        assert!(r2.is_empty());
+    }
+
+    #[test]
+    fn test_type_edge_stats() {
+        let (store, _dir) = setup_store();
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/a.rs");
+
+        store
+            .upsert_type_edges("chunk-a", &make_type_refs())
+            .unwrap();
+
+        let stats = store.type_edge_stats().unwrap();
+        assert_eq!(stats.total_edges, 3);
+        assert_eq!(stats.unique_types, 3); // Config, Store, SqlitePool
+    }
+
+    #[test]
+    fn test_get_type_graph() {
+        let (store, _dir) = setup_store();
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/a.rs");
+        insert_test_chunk(&store, "chunk-b", "func_b", "src/b.rs");
+
+        store
+            .upsert_type_edges(
+                "chunk-a",
+                &[TypeRef {
+                    type_name: "Config".to_string(),
+                    line_number: 5,
+                    kind: Some(TypeEdgeKind::Param),
+                }],
+            )
+            .unwrap();
+        store
+            .upsert_type_edges(
+                "chunk-b",
+                &[TypeRef {
+                    type_name: "Config".to_string(),
+                    line_number: 10,
+                    kind: Some(TypeEdgeKind::Return),
+                }],
+            )
+            .unwrap();
+
+        let graph = store.get_type_graph().unwrap();
+
+        // Forward: func_a -> [Config], func_b -> [Config]
+        assert!(graph
+            .forward
+            .get("func_a")
+            .unwrap()
+            .contains(&"Config".to_string()));
+        assert!(graph
+            .forward
+            .get("func_b")
+            .unwrap()
+            .contains(&"Config".to_string()));
+
+        // Reverse: Config -> [func_a, func_b]
+        let config_users = graph.reverse.get("Config").unwrap();
+        assert_eq!(config_users.len(), 2);
+    }
+
+    #[test]
+    fn test_find_shared_type_users() {
+        let (store, _dir) = setup_store();
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/a.rs");
+
+        // func_a uses Config and Store
+        store
+            .upsert_type_edges(
+                "chunk-a",
+                &[
+                    TypeRef {
+                        type_name: "Config".to_string(),
+                        line_number: 5,
+                        kind: Some(TypeEdgeKind::Param),
+                    },
+                    TypeRef {
+                        type_name: "Store".to_string(),
+                        line_number: 6,
+                        kind: Some(TypeEdgeKind::Return),
+                    },
+                ],
+            )
+            .unwrap();
+
+        // Types commonly used with Config = Store (overlap: 1 chunk)
+        let shared = store.find_shared_type_users("Config", 10).unwrap();
+        assert_eq!(shared.len(), 1);
+        assert_eq!(shared[0].0, "Store");
+        assert_eq!(shared[0].1, 1);
+    }
+
+    #[test]
+    fn test_prune_stale_type_edges() {
+        let (store, _dir) = setup_store();
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/a.rs");
+
+        store
+            .upsert_type_edges("chunk-a", &make_type_refs())
+            .unwrap();
+
+        // Delete the chunk — type edges become orphaned
+        store.rt.block_on(async {
+            sqlx::query("DELETE FROM chunks WHERE id = 'chunk-a'")
+                .execute(&store.pool)
+                .await
+                .unwrap();
+        });
+
+        // CASCADE should have already cleaned them, but prune catches non-FK orphans
+        let pruned = store.prune_stale_type_edges().unwrap();
+        // CASCADE already deleted them, so prune should find 0
+        assert_eq!(pruned, 0);
+    }
+
+    #[test]
+    fn test_cascade_delete() {
+        let (store, _dir) = setup_store();
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/a.rs");
+
+        store
+            .upsert_type_edges("chunk-a", &make_type_refs())
+            .unwrap();
+        assert_eq!(store.type_edge_stats().unwrap().total_edges, 3);
+
+        // Delete chunk — CASCADE should remove type edges
+        store.rt.block_on(async {
+            sqlx::query("DELETE FROM chunks WHERE id = 'chunk-a'")
+                .execute(&store.pool)
+                .await
+                .unwrap();
+        });
+
+        assert_eq!(store.type_edge_stats().unwrap().total_edges, 0);
+    }
+
+    #[test]
+    fn test_edge_kind_storage() {
+        let (store, _dir) = setup_store();
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/a.rs");
+
+        store
+            .upsert_type_edges(
+                "chunk-a",
+                &[
+                    TypeRef {
+                        type_name: "Config".to_string(),
+                        line_number: 5,
+                        kind: Some(TypeEdgeKind::Param),
+                    },
+                    TypeRef {
+                        type_name: "Generic".to_string(),
+                        line_number: 6,
+                        kind: None, // catch-all
+                    },
+                ],
+            )
+            .unwrap();
+
+        let types = store.get_types_used_by("func_a").unwrap();
+        let config = types.iter().find(|(n, _)| n == "Config").unwrap();
+        assert_eq!(config.1, "Param");
+
+        let generic = types.iter().find(|(n, _)| n == "Generic").unwrap();
+        assert_eq!(generic.1, ""); // empty string for catch-all
+    }
+
+    #[test]
+    fn test_upsert_type_edges_for_file() {
+        let (store, _dir) = setup_store();
+        // Insert chunks with matching origin
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/test.rs");
+        insert_test_chunk(&store, "chunk-b", "func_b", "src/test.rs");
+
+        let chunk_type_refs = vec![
+            crate::parser::ChunkTypeRefs {
+                name: "func_a".to_string(),
+                line_start: 1,
+                type_refs: vec![TypeRef {
+                    type_name: "Config".to_string(),
+                    line_number: 5,
+                    kind: Some(TypeEdgeKind::Param),
+                }],
+            },
+            crate::parser::ChunkTypeRefs {
+                name: "func_b".to_string(),
+                line_start: 1,
+                type_refs: vec![TypeRef {
+                    type_name: "Store".to_string(),
+                    line_number: 15,
+                    kind: Some(TypeEdgeKind::Return),
+                }],
+            },
+        ];
+
+        store
+            .upsert_type_edges_for_file(Path::new("src/test.rs"), &chunk_type_refs)
+            .unwrap();
+
+        let users = store.get_type_users("Config").unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].name, "func_a");
+
+        let users = store.get_type_users("Store").unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].name, "func_b");
+    }
+
+    #[test]
+    fn test_upsert_for_file_missing_chunk() {
+        let (store, _dir) = setup_store();
+        // Only insert one chunk, reference two
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/test.rs");
+
+        let chunk_type_refs = vec![
+            crate::parser::ChunkTypeRefs {
+                name: "func_a".to_string(),
+                line_start: 1,
+                type_refs: vec![TypeRef {
+                    type_name: "Config".to_string(),
+                    line_number: 5,
+                    kind: Some(TypeEdgeKind::Param),
+                }],
+            },
+            crate::parser::ChunkTypeRefs {
+                name: "nonexistent".to_string(), // not in DB
+                line_start: 20,
+                type_refs: vec![TypeRef {
+                    type_name: "Store".to_string(),
+                    line_number: 25,
+                    kind: Some(TypeEdgeKind::Return),
+                }],
+            },
+        ];
+
+        // Should succeed — skips nonexistent chunk with warning, stores func_a's edges
+        store
+            .upsert_type_edges_for_file(Path::new("src/test.rs"), &chunk_type_refs)
+            .unwrap();
+
+        let users = store.get_type_users("Config").unwrap();
+        assert_eq!(users.len(), 1);
+        // Store type edge was NOT inserted (chunk not found)
+        let users = store.get_type_users("Store").unwrap();
+        assert!(users.is_empty());
+    }
+
+    #[test]
+    fn test_large_batch_crossing_boundary() {
+        let (store, _dir) = setup_store();
+        insert_test_chunk(&store, "chunk-a", "func_a", "src/a.rs");
+
+        // Create 300 type refs — crosses the 249 batch boundary
+        let refs: Vec<TypeRef> = (0..300)
+            .map(|i| TypeRef {
+                type_name: format!("Type{}", i),
+                line_number: i as u32 + 1,
+                kind: Some(TypeEdgeKind::Param),
+            })
+            .collect();
+
+        store.upsert_type_edges("chunk-a", &refs).unwrap();
+
+        let stats = store.type_edge_stats().unwrap();
+        assert_eq!(stats.total_edges, 300);
+        assert_eq!(stats.unique_types, 300);
+    }
+}

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -17,7 +17,7 @@ fn test_store_init() {
     let stats = store.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
     assert_eq!(stats.total_files, 0);
-    assert_eq!(stats.schema_version, 10); // v10: Multi-source support
+    assert_eq!(stats.schema_version, 11); // v11: type_edges table
     assert_eq!(stats.model_name, "intfloat/e5-base-v2");
 }
 


### PR DESCRIPTION
## Summary

Phase 2b Step 2: Wire type dependencies through the full stack so parser type extraction (Step 1, PR #440) is stored and queryable.

- **Schema v11**: `type_edges` table with FK CASCADE to chunks, source + target indexes
- **Store** (`src/store/types.rs`): 10 methods — upsert, query (forward/reverse), batch, stats, graph, shared-type co-occurrence, prune — all with tracing + `?` propagation
- **Pipeline**: `extract_relationships()` stores both call graph and type edges; watch.rs wired with independent error isolation
- **CLI**: `cqs deps <name>` (forward: who uses this type?) and `cqs deps --reverse <name>` (what types does this function use?)
- **Batch**: `deps` command with pipeline support, `stats` includes `type_graph` section
- **GC**: prunes orphan type edges alongside stale calls
- **17 new tests** covering round-trip, batch boundary, cascade, edge kind storage, missing chunk handling

## Test plan

- [x] `cargo build --features gpu-search` — clean
- [x] `cargo test --features gpu-search` — 957 pass, 0 fail, 27 ignored
- [x] `cargo clippy --features gpu-search` — no warnings
- [ ] `cqs index --force` to populate type_edges on own codebase
- [ ] `cqs stats --json` shows `type_graph` section
- [ ] `cqs deps Store --json` returns type users
- [ ] `cqs deps --reverse search_filtered --json` returns types used
- [ ] `echo 'deps Store' | cqs batch` works in batch mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
