### PR TITLE
chore: ecosystem updates for cqs deps command

### DIFF
--- a/.claude/skills/cqs-batch/SKILL.md
+++ b/.claude/skills/cqs-batch/SKILL.md
@@ -40,7 +40,7 @@ echo 'callees main | callers | test-map' | cqs batch
 echo 'dead --min-confidence high | explain' | cqs batch
 ```
 
-**Pipeable downstream commands:** callers, callees, explain, similar, impact, test-map, related.
+**Pipeable downstream commands:** callers, callees, deps, explain, similar, impact, test-map, related.
 
 Pipeline output is a JSON envelope:
 ```json
@@ -56,6 +56,7 @@ Pipeline output is a JSON envelope:
 | `search <query>` | `search "error handling" --limit 3` |
 | `callers <name>` | `callers search_filtered` |
 | `callees <name>` | `callees gather` |
+| `deps <name>` | `deps Store` or `deps --reverse search_filtered` |
 | `explain <name>` | `explain search_filtered` |
 | `similar <name>` | `similar gather --limit 3` |
 | `gather <query>` | `gather "retry logic" --expand 2` |

--- a/.claude/skills/cqs-bootstrap/SKILL.md
+++ b/.claude/skills/cqs-bootstrap/SKILL.md
@@ -112,6 +112,7 @@ None.
    - `cqs-gc` — report index staleness
    - `cqs-stale` — check index freshness (files changed since last index)
    - `cqs-related` — find functions related by shared callers, callees, or types
+   - `cqs-deps` — type dependencies: who uses a type, or what types a function uses
    - `cqs-where` — suggest where to add new code based on semantic similarity
    - `cqs-scout` — pre-investigation dashboard (search + callers + tests + staleness + notes)
    - `cqs-plan` — task planning with scout data + task-type templates

--- a/.claude/skills/cqs-deps/SKILL.md
+++ b/.claude/skills/cqs-deps/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: cqs-deps
+description: Show type dependencies — who uses a type, or what types a function uses.
+disable-model-invocation: false
+argument-hint: "<type_or_function_name> [--reverse]"
+---
+
+# Type Dependencies
+
+Parse arguments:
+- First positional arg = type name (forward) or function name (with --reverse)
+- `--reverse` flag = show types used by a function instead of type users
+
+Forward (default): `cqs deps "<name>" --json -q` — who uses this type?
+Reverse: `cqs deps --reverse "<name>" --json -q` — what types does this function use?
+
+Present the results to the user. Forward mode shows chunks that reference the type. Reverse mode shows types a function depends on, with edge kinds (Param, Return, Field, Impl, Bound, Alias).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Type edge storage and `cqs deps` command** (Phase 2b Step 2) — schema v11 adds `type_edges` table with FK CASCADE. 10 store methods (upsert, query, batch, stats, graph, prune). `cqs deps <type>` shows who uses a type; `cqs deps --reverse <fn>` shows what types a function uses. Batch mode support with pipeline compatibility. GC prunes orphan type edges. Stats includes type graph counts. 17 new tests.
+
 ## [0.12.10] - 2026-02-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ Fall back to Grep/Glob only for exact string matches or when semantic search ret
 - `cqs where "description"` — placement suggestion: where to add new code, with local patterns.
 - `cqs scout "task"` — pre-investigation dashboard: search + callers/tests + staleness + notes in one call.
 - `cqs callers <function>` / `cqs callees <function>` — call graph navigation.
+- `cqs deps <type>` — type dependencies: who uses this type? `--reverse` for what types a function uses.
 - `cqs impact <function>` — what breaks if you change it. Callers + affected tests.
 - `cqs impact-diff [--base REF]` — diff-aware impact: changed functions, callers, tests to re-run.
 - `cqs batch` — batch mode: reads commands from stdin, outputs JSONL. Persistent Store + lazy Embedder. Supports pipeline syntax: `search "error" | callers | test-map` chains commands via fan-out.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,7 @@ src/
     chunks.rs   - Chunk CRUD, embedding_batches() for streaming
     notes.rs    - Note CRUD, note_embeddings(), brute-force search
     calls.rs    - Call graph storage and queries
+    types.rs    - Type edge storage and queries (Phase 2b)
     helpers.rs  - Types, embedding conversion functions
     migrations.rs - Schema migration framework
   parser/       - Code parsing (tree-sitter + custom parsers, delegates to language/ registry)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Find function call relationships:
 ```bash
 cqs callers <name>   # Functions that call <name>
 cqs callees <name>   # Functions called by <name>
+cqs deps <type>      # Who uses this type?
+cqs deps --reverse <fn>  # What types does this function use?
 cqs callers <name> --format mermaid  # Mermaid graph output
 ```
 
@@ -357,6 +359,7 @@ Key commands (all support `--json`):
 - `cqs stats` - index stats, chunk counts, HNSW index status
 - `cqs callers <function>` - find functions that call a given function
 - `cqs callees <function>` - find functions called by a given function
+- `cqs deps <type>` - type dependencies: who uses this type? `--reverse` for what types a function uses
 - `cqs notes add/update/remove` - manage project memory notes
 - `cqs audit-mode on/off` - toggle audit mode (exclude notes from search/read)
 - `cqs similar <function>` - find functions similar to a given function

--- a/docs/MOONSHOT.md
+++ b/docs/MOONSHOT.md
@@ -10,9 +10,9 @@ cqs has 35 CLI commands, 14 in batch mode, pipeline syntax, token budgeting, and
 
 **35 commands.** 14 available in batch mode. Pipeline syntax chains them. Token budgeting on 7 commands. Scout, gather, and impact exist independently but share nothing — each loads its own call graph, test chunks, and staleness data. Where is search-only (no call graph).
 
-**Parser extracts:** Functions, methods, classes, structs, enums, traits, interfaces, constants (+ markdown sections). Call sites (callee name + line). Signatures as raw strings. **Does not extract:** parameter types, return types, field types, trait bounds, generic parameters. No type-reference queries in tree-sitter.
+**Parser extracts:** Functions, methods, classes, structs, enums, traits, interfaces, constants (+ markdown sections). Call sites (callee name + line). Signatures as raw strings. **Type references** (Phase 2b Step 1): parameter types, return types, field types, trait bounds, generic parameters via tree-sitter queries across 7 languages (Rust, Python, TypeScript, Go, Java, C, SQL).
 
-**Schema v10:** `chunks`, `calls`, `function_calls`, `notes` tables. No `type_edges` table. No type-level dependency tracking.
+**Schema v11:** `chunks`, `calls`, `function_calls`, `notes`, `type_edges` tables. Type-level dependency tracking via `type_edges` (Phase 2b Step 2): source_chunk_id → target_type_name with edge_kind classification (Param, Return, Field, Impl, Bound, Alias). `cqs deps` command for forward/reverse queries.
 
 **Search pipeline:** FTS5 keyword → semantic embedding → RRF fusion → HNSW acceleration → unified (code + notes). Notes are separate results merged by score — they don't influence code ranking.
 


### PR DESCRIPTION
## Summary

Ecosystem updates for the `cqs deps` command added in PR #442 (Phase 2b Step 2):

- New `.claude/skills/cqs-deps/SKILL.md`
- Added to bootstrap portable skills list
- Added `deps` to batch skill's supported commands table and pipeable list
- Added `cqs deps` to CLAUDE.md, README.md, CONTRIBUTING.md (architecture: `types.rs`)
- Unreleased changelog entry for Phase 2b Step 2
- Updated MOONSHOT.md "Where We Are" to reflect schema v11 + type edges

## Test plan

- [x] Docs-only changes, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
