### PR TITLE
fix: remove 100-line chunk limit, add windowing to watcher

### DIFF
--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -24,12 +24,12 @@ use super::check_interrupted;
 // These values balance quality with memory/time constraints:
 // - MAX_TOKENS_PER_WINDOW: E5-base-v2 has 512 token limit; we use 480 for safety
 // - WINDOW_OVERLAP_TOKENS: 64 tokens overlap provides context continuity
-const MAX_TOKENS_PER_WINDOW: usize = 480;
-const WINDOW_OVERLAP_TOKENS: usize = 64;
+pub(crate) const MAX_TOKENS_PER_WINDOW: usize = 480;
+pub(crate) const WINDOW_OVERLAP_TOKENS: usize = 64;
 
 /// Apply windowing to chunks that exceed the token limit.
 /// Long chunks are split into overlapping windows; short chunks pass through unchanged.
-fn apply_windowing(chunks: Vec<Chunk>, embedder: &Embedder) -> Vec<Chunk> {
+pub(crate) fn apply_windowing(chunks: Vec<Chunk>, embedder: &Embedder) -> Vec<Chunk> {
     let mut result = Vec::with_capacity(chunks.len());
 
     for chunk in chunks {

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -314,6 +314,9 @@ fn reindex_files(
         })
         .collect();
 
+    // Apply windowing to split long chunks into overlapping windows
+    let chunks = crate::cli::pipeline::apply_windowing(chunks, embedder);
+
     if chunks.is_empty() {
         return Ok((0, Vec::new()));
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -193,13 +193,8 @@ impl Parser {
         while let Some(m) = matches.next() {
             match self.extract_chunk(&source, m, query, language, path) {
                 Ok(chunk) => {
-                    // Skip chunks over 100 lines or 100KB
-                    let lines = chunk.line_end - chunk.line_start;
+                    // Skip chunks over 100KB (large functions are handled by windowing in the pipeline)
                     const MAX_CHUNK_BYTES: usize = 100_000;
-                    if lines > 100 {
-                        tracing::debug!("Skipping {} ({} lines > 100 max)", chunk.id, lines);
-                        continue;
-                    }
                     if chunk.content.len() > MAX_CHUNK_BYTES {
                         tracing::debug!(
                             "Skipping {} ({} bytes > {} max)",


### PR DESCRIPTION
## Summary

- Remove hardcoded 100-line chunk limit from `parse_file()` that dropped important functions entirely
- Add token-based windowing to `watch.rs` (was missing — chunks exceeding 480 tokens were silently truncated)
- Make `apply_windowing()` pub(crate) for shared use between pipeline and watcher

**Before:** 52 functions absent from index (cmd_index, search_filtered, cmd_query, etc.)
**After:** +243 chunks, +409 type edges, 0 chunk resolution failures

## Test plan

- [x] `cargo build --features gpu-search` — clean
- [x] `cargo test --features gpu-search` — 957 pass, 0 fail
- [x] `cargo clippy --features gpu-search` — no warnings
- [x] `cqs index --force` with tracing — 0 "Chunk not found" warnings (was 52)
- [x] `cqs deps --reverse cmd_index` — returns 4 types (was 0)
- [x] `cqs deps --reverse search_filtered` — returns 11 types (was 0)
- [x] `cqs "cmd_index" --name-only` — now finds the function

🤖 Generated with [Claude Code](https://claude.com/claude-code)
