### PR TITLE
chore: release v0.12.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.11] - 2026-02-15
+
 ### Added
-- **Type edge storage and `cqs deps` command** (Phase 2b Step 2) — schema v11 adds `type_edges` table with FK CASCADE. 10 store methods (upsert, query, batch, stats, graph, prune). `cqs deps <type>` shows who uses a type; `cqs deps --reverse <fn>` shows what types a function uses. Batch mode support with pipeline compatibility. GC prunes orphan type edges. Stats includes type graph counts. 17 new tests.
+- **Type extraction parser** (Phase 1a Step 1) — tree-sitter type queries for 6 languages (Rust, Python, TypeScript, Go, Java, C). Extracts struct/enum/class/interface/typedef definitions and function parameter/return type references. `TypeEdgeKind` enum (Uses, Returns, Field, Impl, Bound, Alias). `parse_file_relationships()` returns both call sites and type refs. 19 new tests.
+- **Type edge storage and `cqs deps` command** (Phase 1a Step 2) — schema v11 adds `type_edges` table with FK CASCADE. 10 store methods (upsert, query, batch, stats, graph, prune). `cqs deps <type>` shows who uses a type; `cqs deps --reverse <fn>` shows what types a function uses. Batch mode support with pipeline compatibility. GC prunes orphan type edges. Stats includes type graph counts. 17 new tests.
+
+### Fixed
+- **Removed 100-line chunk limit** — `parse_file()` silently dropped any chunk over 100 lines, causing 52 functions (including `cmd_index`, `search_filtered`, `cmd_query`) to be entirely absent from the index. Large chunks are now handled by token-based windowing (480 tokens, 64 overlap) in the pipeline instead.
+- **Added windowing to watch mode** — `cqs watch` sent raw chunks directly to the embedder without windowing, silently truncating functions exceeding 480 tokens. Now uses the same `apply_windowing()` as the full indexing pipeline.
 
 ## [0.12.10] - 2026-02-14
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ src/
 - 769-dim embeddings (768 from E5-base-v2 + 1 sentiment dimension)
 - HNSW index is chunk-only; notes use brute-force SQLite search (always fresh)
 - Streaming HNSW build via `build_batched()` for memory efficiency
-- Chunks capped at 100 lines, notes capped at 10k entries
+- Large chunks split by windowing (480 tokens, 64 overlap); notes capped at 10k entries
 - Schema migrations allow upgrading indexes without full rebuild
 - Skills in `.claude/skills/*/SKILL.md` are auto-discovered by Claude Code
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.12.10"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.12.10"
+version = "0.12.11"
 edition = "2021"
 rust-version = "1.93"
 description = "Semantic code search and code intelligence for AI agents. Find functions by concept, trace call chains, assess impact — in single tool calls. Local ML embeddings."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -46,9 +46,9 @@ Unstaged on main (from prior sessions, not type extraction):
 
 ## Architecture
 
-- Version: 0.12.10
+- Version: 0.12.11
 - MSRV: 1.93
-- Schema: v10
+- Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cargo install cqs
 
 **Upgrading?** Schema changes require rebuilding the index:
 ```bash
-cqs index --force  # Run after upgrading from older versions (current schema: v10)
+cqs index --force  # Run after upgrading from older versions (current schema: v11)
 ```
 
 ## Quick Start

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current: v0.12.10
+## Current: v0.12.11
 
 All agent experience features shipped. CLI-only (MCP removed in v0.10.0).
 


### PR DESCRIPTION
## Summary

- Version bump 0.12.10 → 0.12.11
- Changelog: type extraction parser (Phase 1a Step 1), type edge storage + `cqs deps` (Phase 1a Step 2), removed 100-line chunk limit, added windowing to watcher
- Docs: schema v10 → v11 references, removed stale 100-line chunk limit mention from CONTRIBUTING.md

## Changes since v0.12.10

- #440: Type extraction parser (Phase 1a Step 1)
- #442: Type edge storage + `cqs deps` CLI (Phase 1a Step 2)
- #443: Ecosystem updates for deps command
- #444: Moonshot phase reorganization (docs)
- #445: Remove 100-line chunk limit + watcher windowing fix

## Test plan

- [x] `cargo test --features gpu-search` — all pass
- [x] `cargo clippy --features gpu-search` — clean
- [ ] CI passes on this PR
- [ ] Tag + publish after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
