### PR TITLE
feat: wire type_edges into related, impact, read, dead — Phase 1b

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -334,6 +334,9 @@ enum Commands {
         /// Suggest tests for untested callers
         #[arg(long)]
         suggest_tests: bool,
+        /// Include type-impacted functions (via shared type dependencies)
+        #[arg(long)]
+        include_types: bool,
     },
     /// Impact analysis from a git diff — what callers and tests are affected
     #[command(name = "impact-diff")]
@@ -640,9 +643,10 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
             ref format,
             json,
             suggest_tests,
+            include_types,
         }) => {
             let fmt = if json { &OutputFormat::Json } else { format };
-            cmd_impact(&cli, name, depth, fmt, suggest_tests)
+            cmd_impact(&cli, name, depth, fmt, suggest_tests, include_types)
         }
         Some(Commands::ImpactDiff {
             ref base,

--- a/src/focused_read.rs
+++ b/src/focused_read.rs
@@ -1,15 +1,17 @@
-//! Focused-read shared logic
+//! Common type filtering for type-edge consumers
 //!
-//! Extracts type names from function signatures for dependency resolution
-//! in focused-read mode. Used by the CLI read command.
+//! Provides the `COMMON_TYPES` set used to filter out standard library types
+//! from type-edge queries. Without this filter, queries like `get_type_users_batch("String")`
+//! would return most of the codebase.
 
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
-static TYPE_NAME_RE: LazyLock<regex::Regex> =
-    LazyLock::new(|| regex::Regex::new(r"\b([A-Z][a-zA-Z0-9_]+)\b").expect("hardcoded regex"));
-
-static COMMON_TYPES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+/// Standard library types to exclude from type-edge analysis.
+///
+/// Used by `related`, `impact --include-types`, and `read --focus` to prevent
+/// common types like `String`, `Vec`, `Result` from dominating results.
+pub static COMMON_TYPES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     [
         "String",
         "Vec",
@@ -62,49 +64,3 @@ static COMMON_TYPES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     .into_iter()
     .collect()
 });
-
-/// Extract non-standard type names from a function signature.
-///
-/// Finds capitalized identifiers (e.g., `ChunkSummary`, `SearchResult`)
-/// and filters out common standard library types. Returns sorted, deduplicated names.
-pub fn extract_type_names(signature: &str) -> Vec<String> {
-    let mut names: Vec<String> = TYPE_NAME_RE
-        .find_iter(signature)
-        .map(|m| m.as_str().to_string())
-        .filter(|name| !COMMON_TYPES.contains(name.as_str()))
-        .collect::<HashSet<_>>()
-        .into_iter()
-        .collect();
-    names.sort();
-    names
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_extract_type_names_filters_common() {
-        let sig = "fn foo(s: String, v: Vec<ChunkSummary>) -> Result<SearchResult>";
-        let names = extract_type_names(sig);
-        assert!(names.contains(&"ChunkSummary".to_string()));
-        assert!(names.contains(&"SearchResult".to_string()));
-        assert!(!names.contains(&"String".to_string()));
-        assert!(!names.contains(&"Vec".to_string()));
-        assert!(!names.contains(&"Result".to_string()));
-    }
-
-    #[test]
-    fn test_extract_type_names_empty() {
-        let names = extract_type_names("fn bar(x: i32) -> bool");
-        assert!(names.is_empty());
-    }
-
-    #[test]
-    fn test_extract_type_names_deduplicates() {
-        let sig = "fn baz(a: Foo, b: Foo) -> Foo";
-        let names = extract_type_names(sig);
-        assert_eq!(names.len(), 1);
-        assert_eq!(names[0], "Foo");
-    }
-}

--- a/src/impact/mod.rs
+++ b/src/impact/mod.rs
@@ -14,6 +14,7 @@ mod types;
 pub use types::{
     CallerDetail, ChangedFunction, DiffImpactResult, DiffImpactSummary, DiffTestInfo,
     FunctionHints, ImpactResult, RiskLevel, RiskScore, TestInfo, TestSuggestion, TransitiveCaller,
+    TypeImpacted,
 };
 
 // Re-export public functions

--- a/src/impact/types.rs
+++ b/src/impact/types.rs
@@ -34,6 +34,15 @@ pub struct TransitiveCaller {
     pub depth: usize,
 }
 
+/// A function impacted via shared type dependencies (one-hop type expansion).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TypeImpacted {
+    pub name: String,
+    pub file: PathBuf,
+    pub line: u32,
+    pub shared_types: Vec<String>,
+}
+
 /// Complete impact analysis result
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ImpactResult {
@@ -41,6 +50,7 @@ pub struct ImpactResult {
     pub callers: Vec<CallerDetail>,
     pub tests: Vec<TestInfo>,
     pub transitive_callers: Vec<TransitiveCaller>,
+    pub type_impacted: Vec<TypeImpacted>,
 }
 
 /// Lightweight caller + test coverage hints for a function.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub use store::{ModelInfo, SearchFilter, Store};
 // Re-exports for binary crate (CLI) - these are NOT part of the public library API
 // but need to be accessible to src/cli/* and tests/
 pub use diff::{semantic_diff, DiffResult};
-pub use focused_read::extract_type_names;
+pub use focused_read::COMMON_TYPES;
 pub use gather::{
     gather, gather_cross_index, GatherDirection, GatherOptions, DEFAULT_MAX_EXPANDED_NODES,
 };
@@ -102,7 +102,7 @@ pub use impact::{
     compute_hints_with_graph_depth, compute_risk_batch, diff_impact_to_json, find_hotspots,
     impact_to_json, impact_to_mermaid, map_hunks_to_functions, suggest_tests, CallerDetail,
     ChangedFunction, DiffImpactResult, DiffImpactSummary, DiffTestInfo, FunctionHints,
-    ImpactResult, RiskLevel, RiskScore, TestInfo, TestSuggestion, TransitiveCaller,
+    ImpactResult, RiskLevel, RiskScore, TestInfo, TestSuggestion, TransitiveCaller, TypeImpacted,
     DEFAULT_MAX_TEST_SEARCH_DEPTH,
 };
 pub use nl::{generate_nl_description, generate_nl_with_template, normalize_for_fts, NlTemplate};


### PR DESCRIPTION
## Summary

- **related**: Replace regex `extract_type_names` + LIKE-based `search_chunks_by_signatures_batch` with exact `get_types_used_by` + `get_type_users_batch` from `type_edges` table
- **impact --include-types**: One-hop type expansion via type_edges — new `TypeImpacted` struct with JSON/mermaid/text output
- **read --focus**: Type dependencies from `type_edges` with edge_kind labels (e.g., `[Param]`, `[Return]`)
- **dead**: `files_with_type_activity` merged into `file_is_active` heuristic for confidence scoring
- **Cleanup**: Remove `extract_type_names`, `TYPE_NAME_RE`, `search_chunks_by_signatures_batch` (no remaining callers)

Phase 1b of Moonshot — wires the `type_edges` table (shipped in Phase 1a, PRs #440/#442) into four existing commands that previously used regex/LIKE heuristics.

## Test plan

- [x] All 955+ tests pass (`cargo test --features gpu-search`)
- [x] Clean clippy (`cargo clippy --features gpu-search`)
- [x] Fresh-eyes review completed (2 findings fixed: deduplicated type names in `find_type_impacted`, consistent `type_impacted` in JSON output)
- [ ] CI passes
- [ ] Manual: `cqs related search_filtered --json` shows `shared_types` from type_edges
- [ ] Manual: `cqs impact Store --include-types --json` shows `type_impacted` array
- [ ] Manual: `cqs read --focus search_filtered` shows type deps with edge_kind labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
