### PR TITLE
feat: note-boosted search ranking — Phase 1c

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,24 +2,21 @@
 
 ## Right Now
 
-**Phase 2b Step 1 merged.** 2026-02-15. PR #440.
+**Phase 1b complete.** 2026-02-15. PR #447 merged.
 
-Parser type extraction landed on main. Next session picks up Phase 2b Step 2:
-- Schema v11 migration (type_edges table)
-- Store methods (upsert_type_edges, get_type_users)
-- Pipeline wiring (index.rs/watch.rs call parse_file_relationships())
-- CLI `cqs deps` command
-- Batch mode + integration test upgrades
+Moonshot Phase 1 (type system) is done:
+- Phase 1a: Parser type extraction + schema v11 + `cqs deps` (PRs #440, #442)
+- Phase 1b: Wire type_edges into related, impact, read --focus, dead (PR #447)
 
-Plan file: `/home/user001/.claude/plans/goofy-wishing-sphinx.md`
+Next: Phase 2 per MOONSHOT.md, or pick from roadmap (onboard, blame, drift, C#).
 
 ## Pending Changes
 
-Unstaged on main (from prior sessions, not type extraction):
-- `Cargo.lock`, `Cargo.toml` — dependency updates from prior session
-- `docs/notes.toml` — note changes from prior session
+Unstaged on main (from prior sessions):
+- `Cargo.lock`, `Cargo.toml` — dependency updates
+- `docs/notes.toml` — note changes
 - `docs/MOONSHOT.md` — untracked, moonshot roadmap
-- `src/language/markdown.rs`, `src/language/mod.rs`, `src/parser/calls.rs` — stale diffs (check if these are merge artifacts)
+- `src/language/markdown.rs`, `src/language/mod.rs`, `src/parser/calls.rs` — stale diffs (check if merge artifacts)
 
 ## Parked
 
@@ -31,6 +28,7 @@ Unstaged on main (from prior sessions, not type extraction):
 - **ref install** — deferred, tracked in #255
 - **Query-intent routing** — auto-boost ref weight when query mentions product names
 - **P4 audit findings** — 1 remaining (#407 reverse BFS depth)
+- **resolve_target test bias** — ambiguous names resolve to test functions over production code. Not blocking, but `cqs related foo` may pick `test_foo_bar` instead of `foo`. Fix: prefer non-test chunks in resolve_target.
 
 ## Open Issues
 
@@ -53,10 +51,11 @@ Unstaged on main (from prior sessions, not type extraction):
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 9 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, Markdown)
-- Tests: 953 total (926 pass + 27 ignored)
+- Tests: 991 total (964 pass + 27 ignored)
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/ are directories (impact split in PR #402)
 - convert/ module (7 files) behind `convert` feature flag
 - Build target: `~/.cargo-target/cq/` (Linux FS)
 - NVIDIA env: CUDA 13.1, Driver 582.16, libcuvs 26.02 (conda/rapidsai), cuDNN 9.19.0 (conda/conda-forge)
 - Reference: `aveva` → `samples/converted/aveva-docs/` (10,482 chunks, 76 files)
+- type_edges: 3901 edges, 321 unique types (Phase 1a+1b complete)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@ Priority order based on competitive gap analysis (Feb 2026).
 - [ ] `cqs blame` — semantic git blame. Given a function, show who last changed it, when, and the commit message. Combines call graph with git log.
 - [ ] `cqs drift` — detect semantic drift between reference snapshots. Embedding distance, not just text diff. Surface functions that changed behavior.
 - [x] `cqs suggest` — auto-generate notes from code patterns. Scan for anti-patterns (unwrap in non-test code, high-caller untested functions, dead code clusters).
-- [ ] `cqs deps` — type-level dependency impact. Trace struct/enum usage through functions and tests. Deeper than caller-only analysis.
+- [x] `cqs deps` — type-level dependency impact. Trace struct/enum usage through functions and tests (PR #442). Wired into related, impact, read, dead (PR #447).
 - [ ] `cqs chat` — interactive REPL for chained queries. Build order: (1) ~~`ChunkSummary` unification~~, (2) ~~batch mode `cqs batch`~~, (3) ~~REPL~~ (deferred — agents use batch), (4) ~~pipeline syntax~~ (`search | callers | test-map` in `cqs batch`).
 
 ### Next — Retrieval Quality
@@ -83,7 +83,7 @@ Priority order based on competitive gap analysis (Feb 2026).
 
 ## 1.0 Release Criteria
 
-- [ ] Schema stable for 1+ week of daily use (currently v10)
+- [ ] Schema stable for 1+ week of daily use (currently v11)
 - [ ] Used on 2+ different codebases without issues
 - [ ] No known correctness bugs
 

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -29,16 +29,6 @@ mentions = [
 ]
 
 [[note]]
-sentiment = 0.0
-text = "hnsw_rs uses bincode 1.3.3 (unmaintained, RUSTSEC-2025-0141). Mitigated with blake3 checksums on save/load. verify_hnsw_checksums validates extension allowlist to prevent path traversal."
-mentions = [
-    "src/hnsw/persist.rs",
-    "hnsw_rs",
-    "bincode",
-    "blake3",
-]
-
-[[note]]
 sentiment = 0.5
 text = "769th embedding dimension can encode explicit sentiment. Similarity search then weights by feeling automatically. Breaking schema change but enables sentiment-aware retrieval."
 mentions = [
@@ -453,14 +443,6 @@ mentions = [
 
 [[note]]
 sentiment = 0.5
-text = "cuDNN via conda (conda-forge) keeps libcudnn.so.9 in miniforge3/lib which is already on LD_LIBRARY_PATH — no path changes needed"
-mentions = [
-    "cudnn",
-    "LD_LIBRARY_PATH",
-]
-
-[[note]]
-sentiment = 0.5
 text = "SQLite integrity check on every Store::open via PRAGMA quick_check. Catches B-tree corruption early with StoreError::Corruption. Added in PR #343 (DS12)."
 mentions = [
     "src/store/mod.rs",
@@ -495,7 +477,7 @@ mentions = [
 
 [[note]]
 sentiment = -0.5
-text = "HNSW checksum file is now mandatory — missing checksum returns error, not warning. Bincode deserializes unverified bytes, so loading without checksum = trusting arbitrary data. Always regenerate with cqs index --force if checksum missing."
+text = "HNSW checksum is mandatory — missing checksum returns error, not warning. hnsw_rs uses bincode 1.3.3 (unmaintained, RUSTSEC-2025-0141) which deserializes unverified bytes. Blake3 checksums on save/load mitigate this. verify_hnsw_checksums validates extension allowlist to prevent path traversal. Always regenerate with cqs index --force if checksum missing."
 mentions = [
     "src/hnsw/persist.rs",
     "blake3",
@@ -581,11 +563,6 @@ mentions = [
     "src/scout.rs",
     "cqs plan",
 ]
-
-[[note]]
-sentiment = 0.5
-text = "P2 audit: analyze_diff_impact changed from &[ChangedFunction] to Vec<ChangedFunction> — callers pass owned vec, return struct populates changed_functions directly instead of leaving empty for caller to fill."
-mentions = ["src/impact/diff.rs"]
 
 [[note]]
 sentiment = 0.5
@@ -737,15 +714,6 @@ mentions = [
 ]
 
 [[note]]
-sentiment = -0.5
-text = "gather and scout subcommands don't accept -q/--quiet flag. Skills referenced it but CLI rejects it. Progress output already goes to stderr, so -q isn't needed — just don't use it in skill definitions."
-mentions = [
-    "src/cli/commands/mod.rs",
-    ".claude/skills/cqs-gather/SKILL.md",
-    ".claude/skills/cqs-scout/SKILL.md",
-]
-
-[[note]]
 sentiment = 0.5
 text = "OnceLock pattern for lazy-init in long-running sessions (batch/REPL): Embedder and HNSW/CAGRA index built on first use, cached for session lifetime. Avoids 500ms+ ONNX init per command. Pattern: OnceLock<T> + get_or_init(|| build()). Used in BatchContext."
 mentions = [
@@ -777,4 +745,29 @@ mentions = [
     "src/language/rust.rs",
     "src/language/go.rs",
     "src/parser/calls.rs",
+]
+
+[[note]]
+sentiment = -0.5
+text = "pub(crate) items can't be re-exported as pub from lib.rs — compiler error E0364. If a constant/type needs to cross the lib→binary crate boundary, it must be pub. COMMON_TYPES hit this in Phase 1b."
+mentions = [
+    "src/focused_read.rs",
+    "src/lib.rs",
+]
+
+[[note]]
+sentiment = -0.5
+text = "resolve_target picks test functions over production code for ambiguous names. search_filtered resolves to test_search_filtered_empty_store, not Store::search_filtered. Phase 1b trials all showed zero type_impacted until using unique names like open_project_store or cmd_impact_diff."
+mentions = [
+    "src/search.rs",
+    "resolve_target",
+]
+
+[[note]]
+sentiment = 0.5
+text = "Always filter COMMON_TYPES before get_type_users_batch(). Without it, querying users of String/Vec/Result returns most of the codebase. COMMON_TYPES set in focused_read.rs (~35 stdlib types), re-exported from lib.rs."
+mentions = [
+    "src/focused_read.rs",
+    "COMMON_TYPES",
+    "type_edges",
 ]


### PR DESCRIPTION
## Summary

- Notes now influence code search ranking via sentiment-based score boosting (±15%)
- `note_boost()` checks note mentions against chunk file path and function name
- Strongest absolute sentiment wins when multiple notes match the same chunk
- Wired into both brute-force (`search_filtered`) and HNSW-guided (`search_by_candidate_ids`) paths
- 7 unit tests for boost logic, all 34 search tests pass

Moonshot Phase 1c complete.

## Test plan

- [x] `cargo test --features gpu-search --lib search::tests` — all 34 tests pass
- [x] `cargo build --features gpu-search` — zero warnings
- [ ] Manual: search with notes mentioning specific files, verify ranking shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
