### PR TITLE
feat: batch completeness — Phase 2a

### DIFF
--- a/.claude/skills/cqs-batch/SKILL.md
+++ b/.claude/skills/cqs-batch/SKILL.md
@@ -40,7 +40,7 @@ echo 'callees main | callers | test-map' | cqs batch
 echo 'dead --min-confidence high | explain' | cqs batch
 ```
 
-**Pipeable downstream commands:** callers, callees, deps, explain, similar, impact, test-map, related.
+**Pipeable downstream commands:** callers, callees, deps, explain, similar, impact, test-map, related, scout.
 
 Pipeline output is a JSON envelope:
 ```json
@@ -67,6 +67,12 @@ Pipeline output is a JSON envelope:
 | `related <name>` | `related gather --limit 3` |
 | `context <path>` | `context src/lib.rs --compact` |
 | `stats` | `stats` |
+| `scout <query>` | `scout "error handling" --limit 10` |
+| `where <desc>` | `where "new CLI command"` |
+| `read <path>` | `read src/lib.rs --focus enumerate_files` |
+| `stale` | `stale` |
+| `health` | `health` |
+| `notes` | `notes --warnings` or `notes --patterns` |
 
 ## Input Format
 

--- a/src/cli/commands/gc.rs
+++ b/src/cli/commands/gc.rs
@@ -24,7 +24,8 @@ pub(crate) fn cmd_gc(json: bool) -> Result<()> {
 
     // Enumerate current files
     let parser = Parser::new()?;
-    let files = cqs::enumerate_files(&root, &parser, false)?;
+    let exts = parser.supported_extensions();
+    let files = cqs::enumerate_files(&root, &exts, false)?;
     let file_set: HashSet<_> = files.into_iter().collect();
 
     // Count what we'll clean before doing it

--- a/src/cli/commands/stale.rs
+++ b/src/cli/commands/stale.rs
@@ -18,7 +18,8 @@ pub(crate) fn cmd_stale(cli: &Cli, json: bool, count_only: bool) -> Result<()> {
 
     // Enumerate current files on disk
     let parser = Parser::new()?;
-    let files = cqs::enumerate_files(&root, &parser, false)?;
+    let exts = parser.supported_extensions();
+    let files = cqs::enumerate_files(&root, &exts, false)?;
     let file_set: HashSet<_> = files.into_iter().collect();
 
     let report = store.list_stale_files(&file_set)?;

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -12,7 +12,8 @@ pub(crate) fn enumerate_files(
     parser: &cqs::Parser,
     no_ignore: bool,
 ) -> Result<Vec<PathBuf>> {
-    cqs::enumerate_files(root, parser, no_ignore)
+    let exts = parser.supported_extensions();
+    cqs::enumerate_files(root, &exts, no_ignore)
 }
 
 /// Check if a process with the given PID exists

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ const MAX_FILE_SIZE: u64 = 1_048_576;
 /// Shared file enumeration for consistent indexing.
 pub fn enumerate_files(
     root: &Path,
-    parser: &Parser,
+    extensions: &[&str],
     no_ignore: bool,
 ) -> anyhow::Result<Vec<PathBuf>> {
     use anyhow::Context;
@@ -324,7 +324,7 @@ pub fn enumerate_files(
             e.path()
                 .extension()
                 .and_then(|ext| ext.to_str())
-                .map(|ext| parser.supported_extensions().contains(&ext))
+                .map(|ext| extensions.contains(&ext))
                 .unwrap_or(false)
         })
         .filter_map({


### PR DESCRIPTION
## Summary

- Adds 6 missing commands to `cqs batch`: **scout**, **where**, **read**, **stale**, **health**, **notes**
- Batch mode now has complete command coverage (21 commands) — agents never need to exit batch mode
- Each batch exit previously cost ~500ms (ONNX re-init) + Store re-open overhead
- Refactors `enumerate_files` to accept `&[&str]` instead of `&Parser`, decoupling it for batch use
- Adds 3 lazy-cached fields to `BatchContext`: file_set, audit_state, notes_cache
- `read` replicates full security chain: path traversal protection (dunce + starts_with), 10MB limit, note injection, focused read with type deps
- `scout` added to `PIPEABLE_COMMANDS` with nested `file_groups[].chunks[]` extraction
- 13 new tests (parse, extract_names, pipeline)

## Test plan

- [x] `cargo build --features gpu-search` — zero warnings
- [x] `cargo clippy --features gpu-search` — zero warnings
- [x] `cargo test --features gpu-search` — 983 pass, 0 fail, 27 ignored
- [x] Manual smoke test all 6 commands against live index
- [x] Pipeline test: `scout "search" | callers` — 13 results, 0 errors
- [x] Security test: `read ../../etc/passwd` — blocked with error
- [x] Help shows all 21 commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
