### PR TITLE
docs: update tears — Phase 2a complete, add notes

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,21 +2,20 @@
 
 ## Right Now
 
-**Phase 1b complete.** 2026-02-15. PR #447 merged.
+**Moonshot Phase 2a complete.** 2026-02-17.
 
-Moonshot Phase 1 (type system) is done:
 - Phase 1a: Parser type extraction + schema v11 + `cqs deps` (PRs #440, #442)
 - Phase 1b: Wire type_edges into related, impact, read --focus, dead (PR #447)
+- Phase 1c: Note-boosted search ranking (PR #452)
+- Phase 2a: Batch completeness — 6 new commands (PR #453)
 
-Next: Phase 2 per MOONSHOT.md, or pick from roadmap (onboard, blame, drift, C#).
+Also merged 4 dependabot bumps: simsimd 6.5.13, toml 1.0.1, ctrlc 3.5.2, indicatif 0.18.4 (#448-#451).
+
+Next: Phase 2b+ per MOONSHOT.md (onboard, drift, auto-stale notes) or Phase 1d (embedding model eval — research).
 
 ## Pending Changes
 
-Unstaged on main (from prior sessions):
-- `Cargo.lock`, `Cargo.toml` — dependency updates
-- `docs/notes.toml` — note changes
-- `docs/MOONSHOT.md` — untracked, moonshot roadmap
-- `src/language/markdown.rs`, `src/language/mod.rs`, `src/parser/calls.rs` — stale diffs (check if merge artifacts)
+Uncommitted notes in `docs/notes.toml` (Phase 1c + OnceLock notes). `PROJECT_CONTINUITY.md` updated.
 
 ## Parked
 

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -771,3 +771,19 @@ mentions = [
     "COMMON_TYPES",
     "type_edges",
 ]
+
+[[note]]
+sentiment = 0.5
+text = "Note-boosted search ranking: note_boost() in search.rs applies ±15% score adjustment when note mentions match a chunk's file or name. Strongest absolute sentiment wins across multiple matches. Wired into both brute-force and HNSW-guided paths. Loads notes once per search via list_notes_summaries()."
+mentions = [
+    "src/search.rs",
+    "note_boost",
+]
+
+[[note]]
+sentiment = -0.5
+text = "OnceLock::get_or_try_init is still unstable (nightly-only). For fallible lazy init, use manual pattern: check get(), compute Result, set(), get().unwrap(). See BatchContext::file_set() for the pattern."
+mentions = [
+    "src/cli/batch.rs",
+    "OnceLock",
+]


### PR DESCRIPTION
## Summary
- Update PROJECT_CONTINUITY.md to reflect Phase 2a complete
- Add 2 notes: note-boosted search ranking pattern, OnceLock unstable API gotcha
- Clean up stale pending changes section

## Test plan
- [x] Docs-only change, no code modified
