### PR TITLE
feat: enrich method NL with parent type context (Phase 1d)

### DIFF
--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -65,6 +65,7 @@ pub(crate) fn apply_windowing(chunks: Vec<Chunk>, embedder: &Embedder) -> Vec<Ch
                         content_hash: window_hash,
                         parent_id: Some(parent_id.clone()),
                         window_idx: Some(window_idx),
+                        parent_type_name: chunk.parent_type_name.clone(),
                     });
                 }
             }
@@ -705,6 +706,7 @@ mod tests {
             content_hash: blake3::hash(content.as_bytes()).to_hex().to_string(),
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         }
     }
 

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -66,6 +66,7 @@ pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, Pa
             content_hash,
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         }];
         extract_table_chunks(&lines, 0, lines.len(), &name, &name, &id, path, &mut chunks);
         return Ok(chunks);
@@ -95,6 +96,7 @@ pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, Pa
             content_hash,
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         }];
         extract_table_chunks(
             &lines,
@@ -153,6 +155,7 @@ pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, Pa
             content_hash,
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         });
 
         // Extract tables as additional chunks with parent_id = section chunk
@@ -748,6 +751,7 @@ fn extract_table_chunks(
                 content_hash: table_hash,
                 parent_id: Some(section_id.to_string()),
                 window_idx: None,
+                parent_type_name: None,
             });
         } else {
             // Split row-wise with headers preserved
@@ -844,6 +848,7 @@ fn emit_table_window(
         content_hash: whash,
         parent_id: Some(parent_id.to_string()),
         window_idx: Some(window_idx),
+        parent_type_name: None,
     });
 }
 

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -55,6 +55,8 @@ pub struct Chunk {
     pub parent_id: Option<String>,
     /// Window index (0, 1, 2...) if this is a windowed portion
     pub window_idx: Option<u32>,
+    /// Parent type name for methods (e.g., "CircuitBreaker" for `impl CircuitBreaker { ... }`)
+    pub parent_type_name: Option<String>,
 }
 
 /// A function call site extracted from code

--- a/src/search.rs
+++ b/src/search.rs
@@ -1147,6 +1147,7 @@ mod tests {
                 content_hash: hash,
                 parent_id: None,
                 window_idx: None,
+                parent_type_name: None,
             }
         }
 

--- a/src/store/calls.rs
+++ b/src/store/calls.rs
@@ -1388,6 +1388,7 @@ mod tests {
                 content_hash: format!("{name}_hash"),
                 parent_id: None,
                 window_idx: None,
+                parent_type_name: None,
             };
             store.upsert_chunk(&chunk, &emb, Some(12345)).unwrap();
         }
@@ -1430,6 +1431,7 @@ mod tests {
             content_hash: "func_hash".to_string(),
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         };
         store.upsert_chunk(&func_chunk, &emb, Some(12345)).unwrap();
 
@@ -1447,6 +1449,7 @@ mod tests {
             content_hash: "meth_hash".to_string(),
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         };
         store
             .upsert_chunk(&method_chunk, &emb, Some(12345))

--- a/src/store/chunks.rs
+++ b/src/store/chunks.rs
@@ -1420,6 +1420,7 @@ mod tests {
             content_hash: hash,
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         }
     }
 
@@ -1716,6 +1717,7 @@ mod tests {
             content_hash: "abc".to_string(),
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         };
 
         // Get current mtime
@@ -1763,6 +1765,7 @@ mod tests {
             content_hash: "abc".to_string(),
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         };
 
         // Store with an old mtime (before the file was created)
@@ -1820,6 +1823,7 @@ mod tests {
             content_hash: "abc".to_string(),
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         };
 
         // Store with None mtime (will be NULL in DB)
@@ -1871,6 +1875,7 @@ mod tests {
             content_hash: "abc".to_string(),
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         };
 
         let mtime = file_path
@@ -1914,6 +1919,7 @@ mod tests {
             content_hash: "fresh".to_string(),
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         };
 
         let fresh_mtime = fresh_path
@@ -1948,6 +1954,7 @@ mod tests {
             content_hash: "stale".to_string(),
             parent_id: None,
             window_idx: None,
+            parent_type_name: None,
         };
 
         store

--- a/tests/ci_test.rs
+++ b/tests/ci_test.rs
@@ -28,6 +28,7 @@ fn chunk_at(name: &str, file: &str, line_start: u32, line_end: u32) -> Chunk {
         content_hash: hash,
         parent_id: None,
         window_idx: None,
+        parent_type_name: None,
     }
 }
 
@@ -49,6 +50,7 @@ fn test_chunk_at(name: &str, file: &str, line_start: u32, line_end: u32) -> Chun
         content_hash: hash,
         parent_id: None,
         window_idx: None,
+        parent_type_name: None,
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -78,6 +78,7 @@ pub fn test_chunk(name: &str, content: &str) -> Chunk {
         content_hash: hash,
         parent_id: None,
         window_idx: None,
+        parent_type_name: None,
     }
 }
 

--- a/tests/fixtures/eval_hard_go.go
+++ b/tests/fixtures/eval_hard_go.go
@@ -1,0 +1,329 @@
+package evalhard
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MergeSort sorts a slice using merge sort - stable divide and conquer algorithm.
+// Preserves relative order of equal elements unlike quicksort.
+func MergeSort(arr []int) []int {
+	if len(arr) <= 1 {
+		return arr
+	}
+	mid := len(arr) / 2
+	left := MergeSort(arr[:mid])
+	right := MergeSort(arr[mid:])
+	result := make([]int, 0, len(arr))
+	i, j := 0, 0
+	for i < len(left) && j < len(right) {
+		if left[i] <= right[j] {
+			result = append(result, left[i])
+			i++
+		} else {
+			result = append(result, right[j])
+			j++
+		}
+	}
+	result = append(result, left[i:]...)
+	result = append(result, right[j:]...)
+	return result
+}
+
+// HeapSort sorts a slice using heap sort with binary max-heap.
+// Builds a max heap then repeatedly extracts the maximum element.
+func HeapSort(arr []int) {
+	n := len(arr)
+	for i := n/2 - 1; i >= 0; i-- {
+		heapify(arr, n, i)
+	}
+	for i := n - 1; i > 0; i-- {
+		arr[0], arr[i] = arr[i], arr[0]
+		heapify(arr, i, 0)
+	}
+}
+
+func heapify(arr []int, n, i int) {
+	largest := i
+	left := 2*i + 1
+	right := 2*i + 2
+	if left < n && arr[left] > arr[largest] {
+		largest = left
+	}
+	if right < n && arr[right] > arr[largest] {
+		largest = right
+	}
+	if largest != i {
+		arr[i], arr[largest] = arr[largest], arr[i]
+		heapify(arr, n, largest)
+	}
+}
+
+// InsertionSort sorts a slice using insertion sort - efficient for small or nearly sorted arrays.
+// Shifts elements to make room for each new element in sorted position.
+func InsertionSort(arr []int) {
+	for i := 1; i < len(arr); i++ {
+		key := arr[i]
+		j := i - 1
+		for j >= 0 && arr[j] > key {
+			arr[j+1] = arr[j]
+			j--
+		}
+		arr[j+1] = key
+	}
+}
+
+// BubbleSort sorts a slice using bubble sort with early termination.
+// Repeatedly swaps adjacent elements, stops when no swaps needed.
+func BubbleSort(arr []int) {
+	n := len(arr)
+	for i := 0; i < n; i++ {
+		swapped := false
+		for j := 0; j < n-1-i; j++ {
+			if arr[j] > arr[j+1] {
+				arr[j], arr[j+1] = arr[j+1], arr[j]
+				swapped = true
+			}
+		}
+		if !swapped {
+			break
+		}
+	}
+}
+
+// RadixSort sorts non-negative integers using radix sort - processes digits from least significant.
+// Non-comparison sort with O(d*n) time where d is digit count.
+func RadixSort(arr []int) {
+	if len(arr) == 0 {
+		return
+	}
+	maxVal := arr[0]
+	for _, v := range arr {
+		if v > maxVal {
+			maxVal = v
+		}
+	}
+	for exp := 1; maxVal/exp > 0; exp *= 10 {
+		countingSortByDigit(arr, exp)
+	}
+}
+
+func countingSortByDigit(arr []int, exp int) {
+	n := len(arr)
+	output := make([]int, n)
+	count := make([]int, 10)
+	for _, v := range arr {
+		count[(v/exp)%10]++
+	}
+	for i := 1; i < 10; i++ {
+		count[i] += count[i-1]
+	}
+	for i := n - 1; i >= 0; i-- {
+		digit := (arr[i] / exp) % 10
+		count[digit]--
+		output[count[digit]] = arr[i]
+	}
+	copy(arr, output)
+}
+
+// PadString pads string to fixed width with a fill character.
+// If string is shorter than width, pads on the left with fill char.
+func PadString(s string, width int, fill rune) string {
+	if len(s) >= width {
+		return s
+	}
+	return strings.Repeat(string(fill), width-len(s)) + s
+}
+
+// ReverseString reverses the characters in a string.
+func ReverseString(s string) string {
+	runes := []rune(s)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes)
+}
+
+// CountWords counts the number of words in text separated by whitespace.
+func CountWords(text string) int {
+	return len(strings.Fields(text))
+}
+
+// ExtractNumbers extracts all numeric values from a mixed text string.
+// Returns integers and floating point numbers found in the text.
+func ExtractNumbers(text string) []float64 {
+	re := regexp.MustCompile(`-?\d+\.?\d*`)
+	matches := re.FindAllString(text, -1)
+	numbers := make([]float64, 0, len(matches))
+	for _, m := range matches {
+		if n, err := strconv.ParseFloat(m, 64); err == nil {
+			numbers = append(numbers, n)
+		}
+	}
+	return numbers
+}
+
+// ValidateUrl validates URL format - checks for valid scheme and hostname.
+func ValidateUrl(url string) bool {
+	for _, prefix := range []string{"http://", "https://"} {
+		if strings.HasPrefix(url, prefix) {
+			rest := url[len(prefix):]
+			host := strings.SplitN(rest, "/", 2)[0]
+			return len(host) > 0 && strings.Contains(host, ".")
+		}
+	}
+	return false
+}
+
+// ValidateIpAddress validates IP address - supports both IPv4 and IPv6 formats.
+func ValidateIpAddress(addr string) bool {
+	// IPv4
+	parts := strings.Split(addr, ".")
+	if len(parts) == 4 {
+		for _, p := range parts {
+			n, err := strconv.Atoi(p)
+			if err != nil || n < 0 || n > 255 {
+				return false
+			}
+		}
+		return true
+	}
+	// IPv6
+	groups := strings.Split(addr, ":")
+	if len(groups) != 8 {
+		return false
+	}
+	for _, g := range groups {
+		if len(g) > 4 {
+			return false
+		}
+		for _, c := range g {
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// ValidatePhone validates phone number with international country code prefix.
+// Accepts formats like +1-555-123-4567 or +44 20 7946 0958.
+func ValidatePhone(phone string) bool {
+	digits := regexp.MustCompile(`\d`).FindAllString(phone, -1)
+	return strings.HasPrefix(phone, "+") && len(digits) >= 10 && len(digits) <= 15
+}
+
+// HashCrc32 computes CRC32 checksum of byte data.
+// Simple polynomial division checksum for error detection.
+func HashCrc32(data []byte) uint32 {
+	crc := uint32(0xFFFFFFFF)
+	for _, b := range data {
+		crc ^= uint32(b)
+		for i := 0; i < 8; i++ {
+			if crc&1 != 0 {
+				crc = (crc >> 1) ^ 0xEDB88320
+			} else {
+				crc >>= 1
+			}
+		}
+	}
+	return crc ^ 0xFFFFFFFF
+}
+
+// RateLimiterGo implements rate limiting using token bucket algorithm.
+// Allows N calls per time window, rejects excess calls.
+type RateLimiterGo struct {
+	mu          sync.Mutex
+	tokens      int
+	maxTokens   int
+	lastRefill  time.Time
+}
+
+// NewRateLimiter creates a rate limiter allowing maxPerSecond calls per second.
+func NewRateLimiter(maxPerSecond int) *RateLimiterGo {
+	return &RateLimiterGo{
+		tokens:     maxPerSecond,
+		maxTokens:  maxPerSecond,
+		lastRefill: time.Now(),
+	}
+}
+
+// Allow checks if a call is allowed under the rate limit.
+func (r *RateLimiterGo) Allow() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refill()
+	if r.tokens > 0 {
+		r.tokens--
+		return true
+	}
+	return false
+}
+
+func (r *RateLimiterGo) refill() {
+	if time.Since(r.lastRefill) >= time.Second {
+		r.tokens = r.maxTokens
+		r.lastRefill = time.Now()
+	}
+}
+
+// CircuitBreakerGo stops calling after consecutive failures.
+// Transitions: Closed -> Open (after threshold) -> HalfOpen (after timeout) -> Closed.
+type CircuitBreakerGo struct {
+	mu           sync.Mutex
+	failureCount int
+	threshold    int
+	state        string
+	lastFailure  time.Time
+	resetTimeout time.Duration
+}
+
+// NewCircuitBreaker creates a circuit breaker with failure threshold and reset timeout.
+func NewCircuitBreaker(threshold int, resetTimeout time.Duration) *CircuitBreakerGo {
+	return &CircuitBreakerGo{
+		threshold:    threshold,
+		state:        "closed",
+		resetTimeout: resetTimeout,
+	}
+}
+
+// ShouldAllow checks if calls should be allowed through the circuit.
+func (cb *CircuitBreakerGo) ShouldAllow() bool {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	switch cb.state {
+	case "closed":
+		return true
+	case "open":
+		if time.Since(cb.lastFailure) >= cb.resetTimeout {
+			cb.state = "half_open"
+			return true
+		}
+		return false
+	case "half_open":
+		return true
+	}
+	return false
+}
+
+// RecordFailure records a failure - may trip the circuit to open state.
+func (cb *CircuitBreakerGo) RecordFailure() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.failureCount++
+	cb.lastFailure = time.Now()
+	if cb.failureCount >= cb.threshold {
+		cb.state = "open"
+	}
+}
+
+// RecordSuccess records a success - resets failure count and closes circuit.
+func (cb *CircuitBreakerGo) RecordSuccess() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.failureCount = 0
+	cb.state = "closed"
+}

--- a/tests/fixtures/eval_hard_javascript.js
+++ b/tests/fixtures/eval_hard_javascript.js
@@ -1,0 +1,214 @@
+// Hard eval fixture for JavaScript - confusable functions for semantic search testing
+
+/** Sort array using merge sort - stable divide and conquer algorithm.
+ * Preserves relative order of equal elements unlike quicksort. */
+function mergeSort(arr) {
+    if (arr.length <= 1) return arr;
+    const mid = Math.floor(arr.length / 2);
+    const left = mergeSort(arr.slice(0, mid));
+    const right = mergeSort(arr.slice(mid));
+    const result = [];
+    let i = 0, j = 0;
+    while (i < left.length && j < right.length) {
+        if (left[i] <= right[j]) result.push(left[i++]);
+        else result.push(right[j++]);
+    }
+    return result.concat(left.slice(i), right.slice(j));
+}
+
+/** Sort array using heap sort with binary max-heap.
+ * Builds a max heap then repeatedly extracts the maximum element. */
+function heapSort(arr) {
+    function heapify(size, i) {
+        let largest = i;
+        const left = 2 * i + 1, right = 2 * i + 2;
+        if (left < size && arr[left] > arr[largest]) largest = left;
+        if (right < size && arr[right] > arr[largest]) largest = right;
+        if (largest !== i) {
+            [arr[i], arr[largest]] = [arr[largest], arr[i]];
+            heapify(size, largest);
+        }
+    }
+    const n = arr.length;
+    for (let i = Math.floor(n / 2) - 1; i >= 0; i--) heapify(n, i);
+    for (let i = n - 1; i > 0; i--) {
+        [arr[0], arr[i]] = [arr[i], arr[0]];
+        heapify(i, 0);
+    }
+    return arr;
+}
+
+/** Sort array using insertion sort - efficient for small or nearly sorted arrays.
+ * Shifts elements to make room for each new element in sorted position. */
+function insertionSort(arr) {
+    for (let i = 1; i < arr.length; i++) {
+        const key = arr[i];
+        let j = i - 1;
+        while (j >= 0 && arr[j] > key) {
+            arr[j + 1] = arr[j];
+            j--;
+        }
+        arr[j + 1] = key;
+    }
+    return arr;
+}
+
+/** Sort array using bubble sort with early termination.
+ * Repeatedly swaps adjacent elements, stops when no swaps needed. */
+function bubbleSort(arr) {
+    const n = arr.length;
+    for (let i = 0; i < n; i++) {
+        let swapped = false;
+        for (let j = 0; j < n - 1 - i; j++) {
+            if (arr[j] > arr[j + 1]) {
+                [arr[j], arr[j + 1]] = [arr[j + 1], arr[j]];
+                swapped = true;
+            }
+        }
+        if (!swapped) break;
+    }
+    return arr;
+}
+
+/** Sort non-negative integers using radix sort - processes digits from least significant.
+ * Non-comparison sort with O(d*n) time where d is digit count. */
+function radixSort(arr) {
+    if (arr.length === 0) return arr;
+    const maxVal = Math.max(...arr);
+    let exp = 1;
+    while (Math.floor(maxVal / exp) > 0) {
+        const output = new Array(arr.length);
+        const count = new Array(10).fill(0);
+        for (const val of arr) count[Math.floor(val / exp) % 10]++;
+        for (let i = 1; i < 10; i++) count[i] += count[i - 1];
+        for (let i = arr.length - 1; i >= 0; i--) {
+            const digit = Math.floor(arr[i] / exp) % 10;
+            output[--count[digit]] = arr[i];
+        }
+        arr.splice(0, arr.length, ...output);
+        exp *= 10;
+    }
+    return arr;
+}
+
+/** Pad string to fixed width with a fill character.
+ * If string is shorter than width, pads on the left with fill char. */
+function padString(s, width, fill = ' ') {
+    return s.length >= width ? s : fill.repeat(width - s.length) + s;
+}
+
+/** Reverse the characters in a string. */
+function reverseString(s) {
+    return s.split('').reverse().join('');
+}
+
+/** Count the number of words in text separated by whitespace. */
+function countWords(text) {
+    return text.trim().split(/\s+/).filter(w => w.length > 0).length;
+}
+
+/** Extract all numeric values from a mixed text string.
+ * Returns integers and floating point numbers found in the text. */
+function extractNumbers(text) {
+    const matches = text.match(/-?\d+\.?\d*/g);
+    return matches ? matches.map(Number) : [];
+}
+
+/** Validate URL format - checks for valid scheme and hostname. */
+function validateUrl(url) {
+    const match = url.match(/^https?:\/\/([^/]+)/);
+    if (!match) return false;
+    return match[1].length > 0 && match[1].includes('.');
+}
+
+/** Validate IP address - supports both IPv4 and IPv6 formats. */
+function validateIpAddress(addr) {
+    const v4parts = addr.split('.');
+    if (v4parts.length === 4) {
+        return v4parts.every(p => /^\d{1,3}$/.test(p) && parseInt(p) >= 0 && parseInt(p) <= 255);
+    }
+    const v6groups = addr.split(':');
+    return v6groups.length === 8 && v6groups.every(g => /^[0-9a-fA-F]{1,4}$/.test(g));
+}
+
+/** Validate phone number with international country code prefix.
+ * Accepts formats like +1-555-123-4567 or +44 20 7946 0958. */
+function validatePhone(phone) {
+    const digits = phone.replace(/\D/g, '');
+    return phone.startsWith('+') && digits.length >= 10 && digits.length <= 15;
+}
+
+/** Compute CRC32 checksum of string data.
+ * Simple polynomial division checksum for error detection. */
+function hashCrc32(data) {
+    let crc = 0xFFFFFFFF;
+    for (let i = 0; i < data.length; i++) {
+        crc ^= data.charCodeAt(i);
+        for (let j = 0; j < 8; j++) {
+            crc = (crc & 1) ? (crc >>> 1) ^ 0xEDB88320 : crc >>> 1;
+        }
+    }
+    return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
+/** Rate limiter using token bucket algorithm.
+ * Allows N calls per time window, rejects excess calls. */
+class RateLimiter {
+    constructor(maxPerSecond) {
+        this.tokens = maxPerSecond;
+        this.maxTokens = maxPerSecond;
+        this.lastRefill = Date.now();
+    }
+
+    allow() {
+        this.refill();
+        if (this.tokens > 0) {
+            this.tokens--;
+            return true;
+        }
+        return false;
+    }
+
+    refill() {
+        const now = Date.now();
+        if (now - this.lastRefill >= 1000) {
+            this.tokens = this.maxTokens;
+            this.lastRefill = now;
+        }
+    }
+}
+
+/** Circuit breaker - stops calling after consecutive failures.
+ * Transitions: Closed -> Open (after threshold) -> HalfOpen (after timeout) -> Closed. */
+class CircuitBreaker {
+    constructor(threshold, resetTimeoutMs = 30000) {
+        this.failureCount = 0;
+        this.threshold = threshold;
+        this.state = 'closed';
+        this.lastFailure = null;
+        this.resetTimeoutMs = resetTimeoutMs;
+    }
+
+    shouldAllow() {
+        if (this.state === 'closed') return true;
+        if (this.state === 'open' && this.lastFailure) {
+            if (Date.now() - this.lastFailure >= this.resetTimeoutMs) {
+                this.state = 'half_open';
+                return true;
+            }
+            return false;
+        }
+        return this.state === 'half_open';
+    }
+
+    recordFailure() {
+        this.failureCount++;
+        this.lastFailure = Date.now();
+        if (this.failureCount >= this.threshold) this.state = 'open';
+    }
+
+    recordSuccess() {
+        this.failureCount = 0;
+        this.state = 'closed';
+    }
+}

--- a/tests/fixtures/eval_hard_python.py
+++ b/tests/fixtures/eval_hard_python.py
@@ -1,0 +1,234 @@
+# Hard eval fixture for Python - confusable functions for semantic search testing
+
+import time
+import re
+from typing import List, Optional
+
+
+def merge_sort(arr: list) -> list:
+    """Sort list using merge sort - stable divide and conquer algorithm.
+    Preserves relative order of equal elements unlike quicksort."""
+    if len(arr) <= 1:
+        return arr
+    mid = len(arr) // 2
+    left = merge_sort(arr[:mid])
+    right = merge_sort(arr[mid:])
+    result = []
+    i = j = 0
+    while i < len(left) and j < len(right):
+        if left[i] <= right[j]:
+            result.append(left[i])
+            i += 1
+        else:
+            result.append(right[j])
+            j += 1
+    result.extend(left[i:])
+    result.extend(right[j:])
+    return result
+
+
+def heap_sort(arr: list) -> list:
+    """Sort list using heap sort with binary max-heap.
+    Builds a max heap then repeatedly extracts the maximum element."""
+    def heapify(arr, n, i):
+        largest = i
+        left = 2 * i + 1
+        right = 2 * i + 2
+        if left < n and arr[left] > arr[largest]:
+            largest = left
+        if right < n and arr[right] > arr[largest]:
+            largest = right
+        if largest != i:
+            arr[i], arr[largest] = arr[largest], arr[i]
+            heapify(arr, n, largest)
+
+    n = len(arr)
+    for i in range(n // 2 - 1, -1, -1):
+        heapify(arr, n, i)
+    for i in range(n - 1, 0, -1):
+        arr[0], arr[i] = arr[i], arr[0]
+        heapify(arr, i, 0)
+    return arr
+
+
+def insertion_sort(arr: list) -> list:
+    """Sort list using insertion sort - efficient for small or nearly sorted arrays.
+    Shifts elements to make room for each new element in sorted position."""
+    for i in range(1, len(arr)):
+        key = arr[i]
+        j = i - 1
+        while j >= 0 and arr[j] > key:
+            arr[j + 1] = arr[j]
+            j -= 1
+        arr[j + 1] = key
+    return arr
+
+
+def bubble_sort(arr: list) -> list:
+    """Sort list using bubble sort with early termination.
+    Repeatedly swaps adjacent elements, stops when no swaps needed."""
+    n = len(arr)
+    for i in range(n):
+        swapped = False
+        for j in range(0, n - i - 1):
+            if arr[j] > arr[j + 1]:
+                arr[j], arr[j + 1] = arr[j + 1], arr[j]
+                swapped = True
+        if not swapped:
+            break
+    return arr
+
+
+def radix_sort(arr: list) -> list:
+    """Sort non-negative integers using radix sort - processes digits from least significant.
+    Non-comparison sort with O(d*n) time where d is digit count."""
+    if not arr:
+        return arr
+    max_val = max(arr)
+    exp = 1
+    while max_val // exp > 0:
+        counting_sort_by_digit(arr, exp)
+        exp *= 10
+    return arr
+
+
+def counting_sort_by_digit(arr, exp):
+    n = len(arr)
+    output = [0] * n
+    count = [0] * 10
+    for val in arr:
+        index = (val // exp) % 10
+        count[index] += 1
+    for i in range(1, 10):
+        count[i] += count[i - 1]
+    for val in reversed(arr):
+        index = (val // exp) % 10
+        count[index] -= 1
+        output[count[index]] = val
+    arr[:] = output
+
+
+def pad_string(s: str, width: int, fill: str = ' ') -> str:
+    """Pad string to fixed width with a fill character.
+    If string is shorter than width, pads on the left with fill char."""
+    if len(s) >= width:
+        return s
+    return fill * (width - len(s)) + s
+
+
+def reverse_string(s: str) -> str:
+    """Reverse the characters in a string."""
+    return s[::-1]
+
+
+def count_words(text: str) -> int:
+    """Count the number of words in text separated by whitespace."""
+    return len(text.split())
+
+
+def extract_numbers(text: str) -> List[float]:
+    """Extract all numeric values from a mixed text string.
+    Returns integers and floating point numbers found in the text."""
+    return [float(m) for m in re.findall(r'-?\d+\.?\d*', text)]
+
+
+def validate_url(url: str) -> bool:
+    """Validate URL format - checks for valid scheme and hostname."""
+    if url.startswith('http://') or url.startswith('https://'):
+        rest = url.split('://', 1)[1]
+        host = rest.split('/')[0]
+        return bool(host) and '.' in host
+    return False
+
+
+def validate_ip_address(addr: str) -> bool:
+    """Validate IP address - supports both IPv4 and IPv6 formats."""
+    # Try IPv4
+    parts = addr.split('.')
+    if len(parts) == 4:
+        return all(p.isdigit() and 0 <= int(p) <= 255 for p in parts)
+    # Try IPv6
+    groups = addr.split(':')
+    if len(groups) == 8:
+        return all(len(g) <= 4 and all(c in '0123456789abcdefABCDEF' for c in g) for g in groups)
+    return False
+
+
+def validate_phone(phone: str) -> bool:
+    """Validate phone number with international country code prefix.
+    Accepts formats like +1-555-123-4567 or +44 20 7946 0958."""
+    digits = ''.join(c for c in phone if c.isdigit())
+    return phone.startswith('+') and 10 <= len(digits) <= 15
+
+
+def hash_crc32(data: bytes) -> int:
+    """Compute CRC32 checksum of byte data.
+    Simple polynomial division checksum for error detection."""
+    crc = 0xFFFFFFFF
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            if crc & 1:
+                crc = (crc >> 1) ^ 0xEDB88320
+            else:
+                crc >>= 1
+    return crc ^ 0xFFFFFFFF
+
+
+class RateLimiter:
+    """Rate limiter using token bucket algorithm.
+    Allows N calls per time window, rejects excess calls."""
+
+    def __init__(self, max_per_second: int):
+        self.tokens = max_per_second
+        self.max_tokens = max_per_second
+        self.last_refill = time.time()
+
+    def allow(self) -> bool:
+        """Check if a call is allowed under the rate limit."""
+        self._refill()
+        if self.tokens > 0:
+            self.tokens -= 1
+            return True
+        return False
+
+    def _refill(self):
+        now = time.time()
+        if now - self.last_refill >= 1.0:
+            self.tokens = self.max_tokens
+            self.last_refill = now
+
+
+class CircuitBreaker:
+    """Circuit breaker - stops calling after consecutive failures.
+    Transitions: Closed -> Open (after threshold) -> HalfOpen (after timeout) -> Closed."""
+
+    def __init__(self, threshold: int, reset_timeout: float = 30.0):
+        self.failure_count = 0
+        self.threshold = threshold
+        self.state = 'closed'
+        self.last_failure: Optional[float] = None
+        self.reset_timeout = reset_timeout
+
+    def should_allow(self) -> bool:
+        """Check if calls should be allowed through the circuit."""
+        if self.state == 'closed':
+            return True
+        if self.state == 'open' and self.last_failure:
+            if time.time() - self.last_failure >= self.reset_timeout:
+                self.state = 'half_open'
+                return True
+            return False
+        return self.state == 'half_open'
+
+    def record_failure(self):
+        """Record a failure - may trip the circuit to open state."""
+        self.failure_count += 1
+        self.last_failure = time.time()
+        if self.failure_count >= self.threshold:
+            self.state = 'open'
+
+    def record_success(self):
+        """Record a success - resets failure count and closes circuit."""
+        self.failure_count = 0
+        self.state = 'closed'

--- a/tests/fixtures/eval_hard_rust.rs
+++ b/tests/fixtures/eval_hard_rust.rs
@@ -1,0 +1,336 @@
+// Hard eval fixture for Rust - confusable functions that test fine-grained semantic distinction
+
+use std::collections::HashMap;
+
+/// Sort array using merge sort - stable divide and conquer algorithm
+/// Preserves relative order of equal elements unlike quicksort
+pub fn merge_sort<T: Ord + Clone>(arr: &mut [T]) {
+    if arr.len() <= 1 {
+        return;
+    }
+    let mid = arr.len() / 2;
+    let mut left = arr[..mid].to_vec();
+    let mut right = arr[mid..].to_vec();
+    merge_sort(&mut left);
+    merge_sort(&mut right);
+    let (mut i, mut j, mut k) = (0, 0, 0);
+    while i < left.len() && j < right.len() {
+        if left[i] <= right[j] {
+            arr[k] = left[i].clone();
+            i += 1;
+        } else {
+            arr[k] = right[j].clone();
+            j += 1;
+        }
+        k += 1;
+    }
+    while i < left.len() {
+        arr[k] = left[i].clone();
+        i += 1;
+        k += 1;
+    }
+    while j < right.len() {
+        arr[k] = right[j].clone();
+        j += 1;
+        k += 1;
+    }
+}
+
+/// Sort array using heap sort with binary max-heap
+/// Builds a max heap then repeatedly extracts the maximum element
+pub fn heap_sort(arr: &mut [i32]) {
+    let n = arr.len();
+    // Build max heap
+    for i in (0..n / 2).rev() {
+        heapify(arr, n, i);
+    }
+    // Extract elements from heap one by one
+    for i in (1..n).rev() {
+        arr.swap(0, i);
+        heapify(arr, i, 0);
+    }
+}
+
+fn heapify(arr: &mut [i32], n: usize, i: usize) {
+    let mut largest = i;
+    let left = 2 * i + 1;
+    let right = 2 * i + 2;
+    if left < n && arr[left] > arr[largest] {
+        largest = left;
+    }
+    if right < n && arr[right] > arr[largest] {
+        largest = right;
+    }
+    if largest != i {
+        arr.swap(i, largest);
+        heapify(arr, n, largest);
+    }
+}
+
+/// Sort array using insertion sort - efficient for small or nearly sorted arrays
+/// Shifts elements to make room for each new element in sorted position
+pub fn insertion_sort<T: Ord + Clone>(arr: &mut [T]) {
+    for i in 1..arr.len() {
+        let key = arr[i].clone();
+        let mut j = i;
+        while j > 0 && arr[j - 1] > key {
+            arr[j] = arr[j - 1].clone();
+            j -= 1;
+        }
+        arr[j] = key;
+    }
+}
+
+/// Sort array using bubble sort with early termination
+/// Repeatedly swaps adjacent elements, stops when no swaps needed
+pub fn bubble_sort<T: Ord>(arr: &mut [T]) {
+    let n = arr.len();
+    for i in 0..n {
+        let mut swapped = false;
+        for j in 0..n - 1 - i {
+            if arr[j] > arr[j + 1] {
+                arr.swap(j, j + 1);
+                swapped = true;
+            }
+        }
+        if !swapped {
+            break;
+        }
+    }
+}
+
+/// Sort non-negative integers using radix sort - processes digits from least significant
+/// Non-comparison sort with O(d*n) time where d is digit count
+pub fn radix_sort(arr: &mut [u32]) {
+    if arr.is_empty() {
+        return;
+    }
+    let max_val = *arr.iter().max().unwrap();
+    let mut exp = 1u32;
+    let mut output = vec![0u32; arr.len()];
+    while max_val / exp > 0 {
+        let mut count = [0usize; 10];
+        for &val in arr.iter() {
+            count[((val / exp) % 10) as usize] += 1;
+        }
+        for i in 1..10 {
+            count[i] += count[i - 1];
+        }
+        for &val in arr.iter().rev() {
+            let digit = ((val / exp) % 10) as usize;
+            count[digit] -= 1;
+            output[count[digit]] = val;
+        }
+        arr.copy_from_slice(&output);
+        exp *= 10;
+    }
+}
+
+/// Pad string to fixed width with a fill character
+/// If string is shorter than width, pads on the left with fill char
+pub fn pad_string(s: &str, width: usize, fill: char) -> String {
+    if s.len() >= width {
+        s.to_string()
+    } else {
+        let padding = width - s.len();
+        let pad: String = std::iter::repeat(fill).take(padding).collect();
+        format!("{}{}", pad, s)
+    }
+}
+
+/// Reverse the characters in a string
+pub fn reverse_string(s: &str) -> String {
+    s.chars().rev().collect()
+}
+
+/// Count the number of words in text separated by whitespace
+pub fn count_words(text: &str) -> usize {
+    text.split_whitespace().count()
+}
+
+/// Extract all numeric values from a mixed text string
+/// Returns integers and floating point numbers found in the text
+pub fn extract_numbers(text: &str) -> Vec<f64> {
+    let mut numbers = Vec::new();
+    let mut current = String::new();
+    let mut has_dot = false;
+    for c in text.chars() {
+        if c.is_ascii_digit() {
+            current.push(c);
+        } else if c == '.' && !has_dot && !current.is_empty() {
+            current.push(c);
+            has_dot = true;
+        } else if !current.is_empty() {
+            if let Ok(n) = current.parse::<f64>() {
+                numbers.push(n);
+            }
+            current.clear();
+            has_dot = false;
+        }
+    }
+    if !current.is_empty() {
+        if let Ok(n) = current.parse::<f64>() {
+            numbers.push(n);
+        }
+    }
+    numbers
+}
+
+/// Validate URL format - checks for valid scheme and hostname
+pub fn validate_url(url: &str) -> bool {
+    if let Some(rest) = url.strip_prefix("http://").or_else(|| url.strip_prefix("https://")) {
+        let host = rest.split('/').next().unwrap_or("");
+        !host.is_empty() && host.contains('.')
+    } else {
+        false
+    }
+}
+
+/// Validate IP address - supports both IPv4 and IPv6 formats
+pub fn validate_ip_address(addr: &str) -> bool {
+    // Try IPv4: four octets 0-255
+    if let Some(ipv4) = try_parse_ipv4(addr) {
+        return ipv4;
+    }
+    // Try IPv6: eight groups of hex
+    let groups: Vec<&str> = addr.split(':').collect();
+    groups.len() == 8 && groups.iter().all(|g| {
+        g.len() <= 4 && g.chars().all(|c| c.is_ascii_hexdigit())
+    })
+}
+
+fn try_parse_ipv4(addr: &str) -> Option<bool> {
+    let parts: Vec<&str> = addr.split('.').collect();
+    if parts.len() != 4 {
+        return None;
+    }
+    Some(parts.iter().all(|p| p.parse::<u8>().is_ok()))
+}
+
+/// Validate phone number with international country code prefix
+/// Accepts formats like +1-555-123-4567 or +44 20 7946 0958
+pub fn validate_phone(phone: &str) -> bool {
+    let digits: String = phone.chars().filter(|c| c.is_ascii_digit()).collect();
+    let has_plus = phone.starts_with('+');
+    has_plus && digits.len() >= 10 && digits.len() <= 15
+}
+
+/// Compute CRC32 checksum of byte data
+/// Simple polynomial division checksum for error detection
+pub fn hash_crc32(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFFFFFF;
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            if crc & 1 != 0 {
+                crc = (crc >> 1) ^ 0xEDB88320;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    !crc
+}
+
+/// Rate limiter using token bucket algorithm
+/// Allows N calls per time window, rejects excess calls
+pub struct RateLimiter {
+    tokens: u32,
+    max_tokens: u32,
+    last_refill: std::time::Instant,
+    refill_interval: std::time::Duration,
+}
+
+impl RateLimiter {
+    pub fn new(max_per_second: u32) -> Self {
+        Self {
+            tokens: max_per_second,
+            max_tokens: max_per_second,
+            last_refill: std::time::Instant::now(),
+            refill_interval: std::time::Duration::from_secs(1),
+        }
+    }
+
+    /// Check if a call is allowed under the rate limit
+    pub fn allow(&mut self) -> bool {
+        self.refill();
+        if self.tokens > 0 {
+            self.tokens -= 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn refill(&mut self) {
+        let now = std::time::Instant::now();
+        if now.duration_since(self.last_refill) >= self.refill_interval {
+            self.tokens = self.max_tokens;
+            self.last_refill = now;
+        }
+    }
+}
+
+/// Circuit breaker - stops calling after consecutive failures
+/// Transitions: Closed -> Open (after threshold failures) -> HalfOpen (after timeout) -> Closed
+pub struct CircuitBreaker {
+    failure_count: u32,
+    threshold: u32,
+    state: CircuitState,
+    last_failure: Option<std::time::Instant>,
+    reset_timeout: std::time::Duration,
+}
+
+#[derive(PartialEq)]
+enum CircuitState {
+    Closed,
+    Open,
+    HalfOpen,
+}
+
+impl CircuitBreaker {
+    pub fn new(threshold: u32, reset_timeout_ms: u64) -> Self {
+        Self {
+            failure_count: 0,
+            threshold,
+            state: CircuitState::Closed,
+            last_failure: None,
+            reset_timeout: std::time::Duration::from_millis(reset_timeout_ms),
+        }
+    }
+
+    /// Check if calls should be allowed through the circuit
+    pub fn should_allow(&mut self) -> bool {
+        match self.state {
+            CircuitState::Closed => true,
+            CircuitState::Open => {
+                if let Some(last) = self.last_failure {
+                    if std::time::Instant::now().duration_since(last) >= self.reset_timeout {
+                        self.state = CircuitState::HalfOpen;
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+            CircuitState::HalfOpen => true,
+        }
+    }
+
+    /// Record a failure - may trip the circuit to open state
+    pub fn record_failure(&mut self) {
+        self.failure_count += 1;
+        self.last_failure = Some(std::time::Instant::now());
+        if self.failure_count >= self.threshold {
+            self.state = CircuitState::Open;
+        }
+    }
+
+    /// Record a success - resets failure count and closes circuit
+    pub fn record_success(&mut self) {
+        self.failure_count = 0;
+        self.state = CircuitState::Closed;
+    }
+}

--- a/tests/fixtures/eval_hard_typescript.ts
+++ b/tests/fixtures/eval_hard_typescript.ts
@@ -1,0 +1,221 @@
+// Hard eval fixture for TypeScript - confusable functions for semantic search testing
+
+/** Sort array using merge sort - stable divide and conquer algorithm.
+ * Preserves relative order of equal elements unlike quicksort. */
+export function mergeSort<T>(arr: T[], compare: (a: T, b: T) => number = (a: any, b: any) => a - b): T[] {
+    if (arr.length <= 1) return arr;
+    const mid = Math.floor(arr.length / 2);
+    const left = mergeSort(arr.slice(0, mid), compare);
+    const right = mergeSort(arr.slice(mid), compare);
+    const result: T[] = [];
+    let i = 0, j = 0;
+    while (i < left.length && j < right.length) {
+        if (compare(left[i], right[j]) <= 0) {
+            result.push(left[i++]);
+        } else {
+            result.push(right[j++]);
+        }
+    }
+    return result.concat(left.slice(i), right.slice(j));
+}
+
+/** Sort array using heap sort with binary max-heap.
+ * Builds a max heap then repeatedly extracts the maximum element. */
+export function heapSort(arr: number[]): number[] {
+    const n = arr.length;
+    function heapify(size: number, i: number) {
+        let largest = i;
+        const left = 2 * i + 1;
+        const right = 2 * i + 2;
+        if (left < size && arr[left] > arr[largest]) largest = left;
+        if (right < size && arr[right] > arr[largest]) largest = right;
+        if (largest !== i) {
+            [arr[i], arr[largest]] = [arr[largest], arr[i]];
+            heapify(size, largest);
+        }
+    }
+    for (let i = Math.floor(n / 2) - 1; i >= 0; i--) heapify(n, i);
+    for (let i = n - 1; i > 0; i--) {
+        [arr[0], arr[i]] = [arr[i], arr[0]];
+        heapify(i, 0);
+    }
+    return arr;
+}
+
+/** Sort array using insertion sort - efficient for small or nearly sorted arrays.
+ * Shifts elements to make room for each new element in sorted position. */
+export function insertionSort<T>(arr: T[], compare: (a: T, b: T) => number = (a: any, b: any) => a - b): T[] {
+    for (let i = 1; i < arr.length; i++) {
+        const key = arr[i];
+        let j = i - 1;
+        while (j >= 0 && compare(arr[j], key) > 0) {
+            arr[j + 1] = arr[j];
+            j--;
+        }
+        arr[j + 1] = key;
+    }
+    return arr;
+}
+
+/** Sort array using bubble sort with early termination.
+ * Repeatedly swaps adjacent elements, stops when no swaps needed. */
+export function bubbleSort<T>(arr: T[], compare: (a: T, b: T) => number = (a: any, b: any) => a - b): T[] {
+    const n = arr.length;
+    for (let i = 0; i < n; i++) {
+        let swapped = false;
+        for (let j = 0; j < n - 1 - i; j++) {
+            if (compare(arr[j], arr[j + 1]) > 0) {
+                [arr[j], arr[j + 1]] = [arr[j + 1], arr[j]];
+                swapped = true;
+            }
+        }
+        if (!swapped) break;
+    }
+    return arr;
+}
+
+/** Sort non-negative integers using radix sort - processes digits from least significant.
+ * Non-comparison sort with O(d*n) time where d is digit count. */
+export function radixSort(arr: number[]): number[] {
+    if (arr.length === 0) return arr;
+    const maxVal = Math.max(...arr);
+    let exp = 1;
+    while (Math.floor(maxVal / exp) > 0) {
+        const output = new Array(arr.length);
+        const count = new Array(10).fill(0);
+        for (const val of arr) count[Math.floor(val / exp) % 10]++;
+        for (let i = 1; i < 10; i++) count[i] += count[i - 1];
+        for (let i = arr.length - 1; i >= 0; i--) {
+            const digit = Math.floor(arr[i] / exp) % 10;
+            output[--count[digit]] = arr[i];
+        }
+        arr.splice(0, arr.length, ...output);
+        exp *= 10;
+    }
+    return arr;
+}
+
+/** Pad string to fixed width with a fill character.
+ * If string is shorter than width, pads on the left with fill char. */
+export function padString(s: string, width: number, fill: string = ' '): string {
+    return s.length >= width ? s : fill.repeat(width - s.length) + s;
+}
+
+/** Reverse the characters in a string. */
+export function reverseString(s: string): string {
+    return s.split('').reverse().join('');
+}
+
+/** Count the number of words in text separated by whitespace. */
+export function countWords(text: string): number {
+    return text.trim().split(/\s+/).filter(w => w.length > 0).length;
+}
+
+/** Extract all numeric values from a mixed text string.
+ * Returns integers and floating point numbers found in the text. */
+export function extractNumbers(text: string): number[] {
+    const matches = text.match(/-?\d+\.?\d*/g);
+    return matches ? matches.map(Number) : [];
+}
+
+/** Validate URL format - checks for valid scheme and hostname. */
+export function validateUrl(url: string): boolean {
+    const match = url.match(/^https?:\/\/([^/]+)/);
+    if (!match) return false;
+    const host = match[1];
+    return host.length > 0 && host.includes('.');
+}
+
+/** Validate IP address - supports both IPv4 and IPv6 formats. */
+export function validateIpAddress(addr: string): boolean {
+    // IPv4
+    const v4parts = addr.split('.');
+    if (v4parts.length === 4) {
+        return v4parts.every(p => /^\d{1,3}$/.test(p) && parseInt(p) >= 0 && parseInt(p) <= 255);
+    }
+    // IPv6
+    const v6groups = addr.split(':');
+    return v6groups.length === 8 && v6groups.every(g => /^[0-9a-fA-F]{1,4}$/.test(g));
+}
+
+/** Validate phone number with international country code prefix.
+ * Accepts formats like +1-555-123-4567 or +44 20 7946 0958. */
+export function validatePhone(phone: string): boolean {
+    const digits = phone.replace(/\D/g, '');
+    return phone.startsWith('+') && digits.length >= 10 && digits.length <= 15;
+}
+
+/** Compute CRC32 checksum of string data.
+ * Simple polynomial division checksum for error detection. */
+export function hashCrc32(data: string): number {
+    let crc = 0xFFFFFFFF;
+    for (let i = 0; i < data.length; i++) {
+        crc ^= data.charCodeAt(i);
+        for (let j = 0; j < 8; j++) {
+            crc = (crc & 1) ? (crc >>> 1) ^ 0xEDB88320 : crc >>> 1;
+        }
+    }
+    return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
+/** Rate limiter using token bucket algorithm.
+ * Allows N calls per time window, rejects excess calls. */
+export class RateLimiter {
+    private tokens: number;
+    private lastRefill: number;
+
+    constructor(private maxPerSecond: number) {
+        this.tokens = maxPerSecond;
+        this.lastRefill = Date.now();
+    }
+
+    allow(): boolean {
+        this.refill();
+        if (this.tokens > 0) {
+            this.tokens--;
+            return true;
+        }
+        return false;
+    }
+
+    private refill(): void {
+        const now = Date.now();
+        if (now - this.lastRefill >= 1000) {
+            this.tokens = this.maxPerSecond;
+            this.lastRefill = now;
+        }
+    }
+}
+
+/** Circuit breaker - stops calling after consecutive failures.
+ * Transitions: Closed -> Open (after threshold) -> HalfOpen (after timeout) -> Closed. */
+export class CircuitBreaker {
+    private failureCount = 0;
+    private state: 'closed' | 'open' | 'half_open' = 'closed';
+    private lastFailure: number | null = null;
+
+    constructor(private threshold: number, private resetTimeoutMs: number = 30000) {}
+
+    shouldAllow(): boolean {
+        if (this.state === 'closed') return true;
+        if (this.state === 'open' && this.lastFailure) {
+            if (Date.now() - this.lastFailure >= this.resetTimeoutMs) {
+                this.state = 'half_open';
+                return true;
+            }
+            return false;
+        }
+        return this.state === 'half_open';
+    }
+
+    recordFailure(): void {
+        this.failureCount++;
+        this.lastFailure = Date.now();
+        if (this.failureCount >= this.threshold) this.state = 'open';
+    }
+
+    recordSuccess(): void {
+        this.failureCount = 0;
+        this.state = 'closed';
+    }
+}

--- a/tests/impact_diff_test.rs
+++ b/tests/impact_diff_test.rs
@@ -26,6 +26,7 @@ fn chunk_at(name: &str, file: &str, line_start: u32, line_end: u32) -> Chunk {
         content_hash: hash,
         parent_id: None,
         window_idx: None,
+        parent_type_name: None,
     }
 }
 
@@ -284,6 +285,7 @@ fn test_chunk_at(name: &str, file: &str, line_start: u32, line_end: u32) -> Chun
         content_hash: hash,
         parent_id: None,
         window_idx: None,
+        parent_type_name: None,
     }
 }
 

--- a/tests/impact_test.rs
+++ b/tests/impact_test.rs
@@ -25,6 +25,7 @@ fn chunk_at(name: &str, file: &str, line_start: u32, line_end: u32) -> Chunk {
         content_hash: hash,
         parent_id: None,
         window_idx: None,
+        parent_type_name: None,
     }
 }
 
@@ -46,6 +47,7 @@ fn test_chunk_at(name: &str, file: &str, line_start: u32, line_end: u32) -> Chun
         content_hash: hash,
         parent_id: None,
         window_idx: None,
+        parent_type_name: None,
     }
 }
 

--- a/tests/related_test.rs
+++ b/tests/related_test.rs
@@ -25,6 +25,7 @@ fn chunk_at(name: &str, file: &str, line_start: u32, line_end: u32, sig: &str) -
         content_hash: hash,
         parent_id: None,
         window_idx: None,
+        parent_type_name: None,
     }
 }
 

--- a/tests/review_test.rs
+++ b/tests/review_test.rs
@@ -29,6 +29,7 @@ fn chunk_at(name: &str, file: &str, line_start: u32, line_end: u32) -> Chunk {
         content_hash: hash,
         parent_id: None,
         window_idx: None,
+        parent_type_name: None,
     }
 }
 
@@ -50,6 +51,7 @@ fn test_chunk_at(name: &str, file: &str, line_start: u32, line_end: u32) -> Chun
         content_hash: hash,
         parent_id: None,
         window_idx: None,
+        parent_type_name: None,
     }
 }
 

--- a/tests/search_test.rs
+++ b/tests/search_test.rs
@@ -60,6 +60,7 @@ fn chunk_with_path(name: &str, file: &str, lang: Language) -> cqs::Chunk {
         content_hash: hash,
         parent_id: None,
         window_idx: None,
+        parent_type_name: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- **Enrich method NL descriptions with parent type context** — methods like `should_allow()` on `CircuitBreaker` now get "circuit breaker method" injected into their NL description, improving semantic search for pattern-level queries
- **Per-language parent type extraction** — Rust impl/trait, Python class, JS/TS/Java class body, Go method receiver — all covered with 11 parser tests
- **Harden hard eval suite** — fix circuit breaker expected answers (struct not method), add 5 method-targeting queries (50→55 total), deduplicate query embeddings (4x fewer ONNX inferences)

### Eval Results

| Metric | Before | After |
|--------|--------|-------|
| E5 Recall@1 | 86.0% | **90.9%** |
| E5 Recall@5 | 90.0% | **98.2%** |
| E5 MRR | 0.885 | **0.941** |

E5 achieves perfect MRR (1.0) on Rust, Python, and Go. TypeScript remains the weakest (0.75 MRR) due to class constructor interference.

### Files Changed (21)

| Area | Files | Changes |
|------|-------|---------|
| Parser | `types.rs`, `chunk.rs`, `markdown.rs` | New field + extraction logic + 11 tests |
| NL | `nl.rs` | Parent type injection + 4 tests |
| Pipeline | `cli/pipeline.rs` | Propagate through windowed chunks |
| Eval | `model_eval.rs`, 5 fixture files | Hard eval cases + dedup + fixtures |
| Plumbing | 10 test/src files | `parent_type_name: None` at Chunk construction sites |

## Test plan

- [x] All 15 new tests pass (11 parser + 4 NL)
- [x] Full test suite passes (926+)
- [x] Clippy clean
- [x] Hard eval run confirms improvement (90.9% R@1, 0.941 MRR)
- [ ] Reindex after merge (`cqs index --force`) to populate parent_type_name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
