### PR TITLE
fix: P3 audit findings — docs, observability, API design, robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -980,7 +980,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI commands: init, doctor, index, stats, serve
 - Filter by language (`-l`) and path pattern (`-p`)
 
-[Unreleased]: https://github.com/jamie8johnson/cqs/compare/v0.12.9...HEAD
+[Unreleased]: https://github.com/jamie8johnson/cqs/compare/v0.12.12...HEAD
+[0.12.12]: https://github.com/jamie8johnson/cqs/compare/v0.12.11...v0.12.12
+[0.12.11]: https://github.com/jamie8johnson/cqs/compare/v0.12.10...v0.12.11
 [0.12.10]: https://github.com/jamie8johnson/cqs/compare/v0.12.9...v0.12.10
 [0.12.9]: https://github.com/jamie8johnson/cqs/compare/v0.12.8...v0.12.9
 [0.12.8]: https://github.com/jamie8johnson/cqs/compare/v0.12.7...v0.12.8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ src/
   cli/          - Command-line interface (clap)
     mod.rs      - Argument parsing, command dispatch
     commands/   - Command implementations
-      mod.rs, query.rs, index.rs, stats.rs, graph.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, drift.rs, trace.rs, impact.rs, impact_diff.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs, audit_mode.rs, read.rs, stale.rs, related.rs, where_cmd.rs, scout.rs, onboard.rs, convert.rs, review.rs, ci.rs
+      mod.rs, query.rs, index.rs, stats.rs, graph.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, drift.rs, trace.rs, impact.rs, impact_diff.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs, audit_mode.rs, read.rs, stale.rs, related.rs, where_cmd.rs, scout.rs, onboard.rs, convert.rs, review.rs, ci.rs, health.rs, suggest.rs, deps.rs
     batch.rs    - Batch mode: persistent Store + Embedder, stdin commands, JSONL output, pipeline syntax
     config.rs   - Configuration file loading
     display.rs  - Output formatting, result display
@@ -159,6 +159,9 @@ src/
   ci.rs           - CI pipeline (review + dead code + gate logic)
   where_to_add.rs - Placement suggestion (semantic search + pattern extraction)
   diff_parse.rs   - Unified diff parser for impact-diff
+  health.rs     - Codebase quality snapshot (dead code, staleness, hotspots)
+  suggest.rs    - Auto-suggest notes from code patterns
+  deps.rs       - Type-level dependency impact analysis
   config.rs     - Configuration file support
   index.rs      - VectorIndex trait (HNSW, CAGRA)
   lib.rs        - Public API

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,17 +2,16 @@
 
 ## Right Now
 
-**Phase 1d complete + v0.12.12 release.** 2026-02-18.
+**v0.12.12 audit: P1 merged (#459), P2 merged (#460), P3 ready for PR.** 2026-02-21.
 
-- Phase 1d: Parent type context enrichment + embedding model eval (PR #455)
-  - E5-base-v2 confirmed: 90.9% Recall@1, 0.941 MRR (beats jina 80.0%, 0.863)
-  - Method NL descriptions now include parent type ("circuit breaker method")
-  - Hard eval: 55 confusable queries across 5 languages
-- Docs overhaul: repositioned as code intelligence + RAG (not just search)
+- P1: 12 findings fixed — security, correctness, data safety, error handling
+- P2: 18 findings fixed — BatchContext caching (6), N+1 queries (2), code quality (2), API design (4), robustness (4)
+- P2 also renamed `gpu-search` feature flag to `gpu-index`
+- P3: 31 code fixes + 8 non-issues across 20 files — docs (9), error handling (5), observability (4), API design (5), robustness (5), algorithm/platform/perf (5), test coverage (2), documentation comments (3)
+- P3 on branch `fix/p3-audit-findings-v0.12.12`, ready to commit+push+PR
+- P4: 18 findings deferred (tests, extensibility, design)
 
-Previous phases: 1a (type extraction), 1b (type wiring), 1c (note-boosted search), 2a (batch completeness).
-
-Next: Phase 2b+ per MOONSHOT.md (onboard, drift, auto-stale notes) or C# language support.
+Audit triage: `docs/audit-triage.md`
 
 ## Pending Changes
 
@@ -27,7 +26,7 @@ None.
 - **Phase 8**: Security (index encryption)
 - **ref install** — deferred, tracked in #255
 - **Query-intent routing** — auto-boost ref weight when query mentions product names
-- **P4 audit findings** — 1 remaining (#407 reverse BFS depth)
+- **P4 audit findings** — 18 findings deferred (issues TBD)
 - **resolve_target test bias** — ambiguous names resolve to test functions over production code. Not blocking, but `cqs related foo` may pick `test_foo_bar` instead of `foo`. Fix: prefer non-test chunks in resolve_target.
 
 ## Open Issues
@@ -51,7 +50,7 @@ None.
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 9 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, Markdown)
-- Tests: 1026 total (998 pass + 28 ignored)
+- Tests: 1019 pass + 28 ignored
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/ are directories (impact split in PR #402)
 - convert/ module (7 files) behind `convert` feature flag

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cqs --lang rust --chunk-type function --pattern async "database query"
 # Hybrid search tuning
 cqs --name-boost 0.2 "retry logic"   # Semantic-heavy (default)
 cqs --name-boost 0.8 "parse_config"  # Name-heavy for known identifiers
-cqs "query" --expand 2                # Expand results via call graph
+cqs "query" --expand                  # Expand results via call graph
 
 # Show surrounding context
 cqs -C 3 "error handling"       # 3 lines before/after each result
@@ -211,6 +211,7 @@ cqs trace cmd_query search_filtered --max-depth 5
 cqs impact search_filtered                # direct callers + affected tests
 cqs impact search_filtered --depth 3      # transitive callers
 cqs impact search_filtered --suggest-tests  # suggest tests for untested callers
+cqs impact search_filtered --include-types  # include type-level dependencies in impact
 
 # Map functions to their tests
 cqs test-map search_filtered
@@ -246,6 +247,10 @@ cqs dead --json             # JSON output
 
 # Garbage collection (remove stale index entries)
 cqs gc                      # Prune deleted files, rebuild HNSW
+
+# Codebase quality snapshot
+cqs health                  # Codebase quality snapshot — dead code, staleness, hotspots, untested hotspots, notes
+cqs suggest                 # Auto-suggest notes from patterns (dead clusters, untested hotspots, high-risk, stale mentions). `--apply` to add
 
 # Cross-project search
 cqs project register mylib /path/to/lib   # Register a project

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,9 +36,9 @@ Priority order based on competitive gap analysis (Feb 2026).
 
 - [x] `cqs ci` — CI pipeline mode. Impact analysis on PR diff, suggested test targets, dead code introduced, risk score. Exit codes for CI gates.
 - [x] `cqs health` — codebase quality snapshot. Dead code count, stale files, untested high-impact functions, hotspots, note warnings.
-- [ ] `cqs onboard "concept"` — guided codebase tour. Entry point → call chain → key types → tests. Ordered reading list from gather + trace + explain.
+- [x] `cqs onboard "concept"` — guided codebase tour. Entry point → call chain → key types → tests. Ordered reading list from gather + trace + explain.
 - [ ] `cqs blame` — semantic git blame. Given a function, show who last changed it, when, and the commit message. Combines call graph with git log.
-- [ ] `cqs drift` — detect semantic drift between reference snapshots. Embedding distance, not just text diff. Surface functions that changed behavior.
+- [x] `cqs drift` — detect semantic drift between reference snapshots. Embedding distance, not just text diff. Surface functions that changed behavior.
 - [x] `cqs suggest` — auto-generate notes from code patterns. Scan for anti-patterns (unwrap in non-test code, high-caller untested functions, dead code clusters).
 - [x] `cqs deps` — type-level dependency impact. Trace struct/enum usage through functions and tests (PR #442). Wired into related, impact, read, dead (PR #447).
 - [ ] `cqs chat` — interactive REPL for chained queries. Build order: (1) ~~`ChunkSummary` unification~~, (2) ~~batch mode `cqs batch`~~, (3) ~~REPL~~ (deferred — agents use batch), (4) ~~pipeline syntax~~ (`search | callers | test-map` in `cqs batch`).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,10 @@ The only network activity is:
   - Source: `huggingface.co/intfloat/e5-base-v2`
   - One-time download, cached in `~/.cache/huggingface/`
 
+- **Reranker model download** (first `--rerank` use): Downloads cross-encoder model from HuggingFace Hub
+  - Model: `ms-marco-MiniLM-L-6-v2` (cross-encoder)
+  - One-time download, cached in `~/.cache/huggingface/`
+
 No other network requests are made. Search, indexing, and all other operations are offline.
 
 ## Filesystem Access

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -130,92 +130,92 @@ After de-duplication: **~88 unique findings**
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 1 | README `--expand 2` example wrong — flag is boolean | DOC-10 | easy | |
-| 2 | README missing `cqs health` command | DOC-11 | easy | |
-| 3 | README missing `cqs suggest` command | DOC-12 | easy | |
-| 4 | CONTRIBUTING.md missing `health.rs`, `suggest.rs`, `deps.rs` from commands | DOC-13 | easy | |
-| 5 | CONTRIBUTING.md missing library-level files | DOC-14 | easy | |
-| 6 | CHANGELOG missing comparison URLs for v0.12.11/v0.12.12 | DOC-15 | easy | |
-| 7 | ROADMAP shows onboard/drift as unchecked | DOC-16 | easy | |
-| 8 | SECURITY.md missing reranker model download | DOC-17 | easy | |
-| 9 | README missing `--include-types` on impact | DOC-18 | easy | |
+| 1 | README `--expand 2` example wrong — flag is boolean | DOC-10 | easy | ✅ fixed |
+| 2 | README missing `cqs health` command | DOC-11 | easy | ✅ fixed |
+| 3 | README missing `cqs suggest` command | DOC-12 | easy | ✅ fixed |
+| 4 | CONTRIBUTING.md missing `health.rs`, `suggest.rs`, `deps.rs` from commands | DOC-13 | easy | ✅ fixed |
+| 5 | CONTRIBUTING.md missing library-level files | DOC-14 | easy | ✅ fixed |
+| 6 | CHANGELOG missing comparison URLs for v0.12.11/v0.12.12 | DOC-15 | easy | ✅ fixed |
+| 7 | ROADMAP shows onboard/drift as unchecked | DOC-16 | easy | ✅ fixed |
+| 8 | SECURITY.md missing reranker model download | DOC-17 | easy | ✅ fixed |
+| 9 | README missing `--include-types` on impact | DOC-18 | easy | ✅ fixed |
 
 ### Error Handling
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 10 | `serde_json::to_string().unwrap()` in batch JSONL loop | EH-25 | easy | |
-| 11 | `Store::open` without `.context()` in drift commands | EH-27/EH-28 | easy | |
-| 12 | `pick_entry_point` returns sentinel instead of error | EH-29 | easy | |
-| 13 | Missing `.context()` on embed_query in batch handlers | EH-31 | easy | |
-| 14 | `staleness.rs` `warn_stale_results` logs error at debug instead of warn | EH-32 | easy | |
+| 10 | `serde_json::to_string().unwrap()` in batch JSONL loop | EH-25 | easy | ✅ documented (infallible) |
+| 11 | `Store::open` without `.context()` in drift commands | EH-27/EH-28 | easy | ✅ fixed |
+| 12 | `pick_entry_point` returns sentinel instead of error | EH-29 | easy | ✅ n/a (deleted in P2) |
+| 13 | Missing `.context()` on embed_query in batch handlers | EH-31 | easy | ✅ fixed |
+| 14 | `staleness.rs` `warn_stale_results` logs error at debug instead of warn | EH-32 | easy | ✅ fixed |
 
 ### Observability
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 15 | `run_index_pipeline` missing entry tracing span | OB-15 | easy | |
-| 16 | `apply_windowing` missing tracing span | OB-16 | easy | |
-| 17 | Pipeline GPU/CPU embedder threads lack thread-level spans | OB-18 | medium | |
-| 18 | Batch pipeline errors not counted in summary | OB-19 | easy | |
+| 15 | `run_index_pipeline` missing entry tracing span | OB-15 | easy | ✅ fixed |
+| 16 | `apply_windowing` missing tracing span | OB-16 | easy | ✅ fixed |
+| 17 | Pipeline GPU/CPU embedder threads lack thread-level spans | OB-18 | medium | ✅ fixed |
+| 18 | Batch pipeline errors not counted in summary | OB-19 | easy | ✅ fixed |
 
 ### API Design
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 19 | TypeGraph missing Debug, Clone derives | AD-22 | easy | |
-| 20 | ResolvedTarget missing Debug, Clone derives | AD-23 | easy | |
-| 21 | Note missing Serialize derive — hand-rolled JSON | AD-24 | easy | |
-| 22 | Drift types not re-exported from lib.rs | AD-25 | easy | |
-| 23 | OnboardEntry.edge_kind stringly-typed — TypeEdgeKind exists | AD-26 | easy | |
+| 19 | TypeGraph missing Debug, Clone derives | AD-22 | easy | ✅ fixed |
+| 20 | ResolvedTarget missing Debug, Clone derives | AD-23 | easy | ✅ fixed |
+| 21 | Note missing Serialize derive — hand-rolled JSON | AD-24 | easy | ✅ fixed |
+| 22 | Drift types not re-exported from lib.rs | AD-25 | easy | ✅ fixed |
+| 23 | OnboardEntry.edge_kind stringly-typed — TypeEdgeKind exists | AD-26 | easy | ✅ fixed |
 
 ### Robustness
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 24 | `onboard` depth unbounded in library function | RB-26 | easy | |
-| 25 | BFS chain reconstruction lacks iteration bound | RB-25 | easy | |
-| 26 | `get_type_graph` cast uses `as i64` unnecessarily | RB-27 | easy | |
-| 27 | `search_by_name` limit not clamped | RB-29 | easy | |
-| 28 | `dispatch_trace` BFS no early-exit on target found | RB-30 | easy | |
+| 24 | `onboard` depth unbounded in library function | RB-26 | easy | ✅ fixed |
+| 25 | BFS chain reconstruction lacks iteration bound | RB-25 | easy | ✅ n/a (has max_depth + early exit) |
+| 26 | `get_type_graph` cast uses `as i64` unnecessarily | RB-27 | easy | ✅ fixed |
+| 27 | `search_by_name` limit not clamped | RB-29 | easy | ✅ fixed |
+| 28 | `dispatch_trace` BFS no early-exit on target found | RB-30 | easy | ✅ n/a (has early exit) |
 
 ### Algorithm Correctness
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 29 | `onboard` total_items excludes key_types | AC-23 | easy | |
-| 30 | Pipeline stage numbering off-by-one in logs | AC-27 | easy | |
+| 29 | `onboard` total_items excludes key_types | AC-23 | easy | ✅ fixed |
+| 30 | Pipeline stage numbering off-by-one in logs | AC-27 | easy | ✅ n/a (numbering correct: 1, 2a, 2b, 3) |
 
 ### Platform Behavior
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 31 | `onboard_to_json` PathBuf without backslash normalization | PB-14 | easy | |
+| 31 | `onboard_to_json` PathBuf without backslash normalization | PB-14 | easy | ✅ fixed |
 
 ### Data Safety
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 32 | `upsert_type_edges_for_file` deletes ALL file chunks, not just updated | DS-16 | easy | |
-| 33 | `BatchContext::refs` uses RefCell — blocks future parallelization | DS-17 | easy | |
-| 34 | Batch notes/audit cache never invalidated during session | DS-15 | easy (document) | |
+| 32 | `upsert_type_edges_for_file` deletes ALL file chunks, not just updated | DS-16 | easy | ✅ n/a (correctly scoped by chunk IDs) |
+| 33 | `BatchContext::refs` uses RefCell — blocks future parallelization | DS-17 | easy | ✅ documented (single-threaded by design) |
+| 34 | Batch notes/audit cache never invalidated during session | DS-15 | easy (document) | ✅ documented (intentional) |
 
 ### Performance
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 35 | `strip_markdown_noise` chains 8 intermediate Strings | PERF-24 | medium | |
-| 36 | `suggest_notes` dedup uses O(n*m) substring matching | PERF-26 | easy | |
+| 35 | `strip_markdown_noise` chains 8 intermediate Strings | PERF-24 | medium | ✅ fixed (Cow<str>) |
+| 36 | `suggest_notes` dedup uses O(n*m) substring matching | PERF-26 | easy | ✅ n/a (already sort+dedup) |
 
 ### Test Coverage
 
 | # | Finding | Source | Difficulty | Status |
 |---|---------|--------|------------|--------|
-| 37 | TypeEdgeKind::from_str() round-trip untested | TC-16 | easy | |
-| 38 | `warn_stale_results()` test discards return value | TC-17 | easy | |
-| 39 | `onboard.rs` tests test std library, not project code | TC-20 | easy | |
+| 37 | TypeEdgeKind::from_str() round-trip untested | TC-16 | easy | ✅ fixed |
+| 38 | `warn_stale_results()` test discards return value | TC-17 | easy | ✅ fixed |
+| 39 | `onboard.rs` tests test std library, not project code | TC-20 | easy | ✅ n/a (deleted in P2) |
 
-**P3 Total: 39 findings**
+**P3 Total: 39 findings (31 fixed, 8 non-issues/already-fixed)**
 
 ---
 

--- a/src/cli/commands/drift.rs
+++ b/src/cli/commands/drift.rs
@@ -1,6 +1,6 @@
 //! Drift command — semantic change detection between reference snapshots
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use colored::Colorize;
 
 use cqs::Store;
@@ -45,13 +45,13 @@ pub(crate) fn cmd_drift(
             reference
         );
     }
-    let ref_store = Store::open_readonly(&ref_db)?;
+    let ref_store = Store::open_readonly(&ref_db).context("Failed to open reference store")?;
 
     let index_path = cqs_dir.join("index.db");
     if !index_path.exists() {
         bail!("Project index not found. Run 'cqs init && cqs index' first.");
     }
-    let project_store = Store::open(&index_path)?;
+    let project_store = Store::open(&index_path).context("Failed to open project store")?;
 
     let result = cqs::drift::detect_drift(
         &ref_store,

--- a/src/cli/staleness.rs
+++ b/src/cli/staleness.rs
@@ -34,7 +34,7 @@ pub fn warn_stale_results(store: &Store, origins: &[&str], root: &Path) -> HashS
             stale
         }
         Err(e) => {
-            tracing::debug!(error = %e, "Failed to check staleness");
+            tracing::warn!(error = %e, "Failed to check staleness");
             HashSet::new()
         }
     }
@@ -71,6 +71,9 @@ mod tests {
         let result = warn_stale_results(&store, &["nonexistent.rs", "ghost.py"], dir.path());
         // Should return empty or the nonexistent files — depends on implementation.
         // Key: it must not panic.
-        let _ = result;
+        assert!(
+            result.is_empty(),
+            "Nonexistent origins should produce empty stale set"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub mod suggest;
 pub(crate) mod diff;
 pub mod diff_parse;
 pub mod drift;
+pub use drift::{detect_drift, DriftEntry, DriftResult};
 pub(crate) mod focused_read;
 pub(crate) mod gather;
 pub(crate) mod impact;

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -470,35 +470,19 @@ static MULTI_NEWLINE_RE: LazyLock<Regex> =
 /// strips bold/italic markers, HTML tags, and collapses whitespace.
 /// Keeps inline code content (strips backticks but preserves text).
 pub fn strip_markdown_noise(content: &str) -> String {
-    let mut result = content.to_string();
-
-    // Remove heading prefixes (## Foo → Foo)
-    result = MD_HEADING_RE.replace_all(&result, "").to_string();
-
-    // Remove image syntax entirely (![alt](url) → "")
-    result = MD_IMAGE_RE.replace_all(&result, "").to_string();
-
-    // Simplify links: [text](url) → text
-    result = MD_LINK_RE.replace_all(&result, "$1").to_string();
-
-    // Strip HTML tags
-    result = HTML_TAG_RE.replace_all(&result, "").to_string();
-
-    // Strip bold/italic markers
+    use std::borrow::Cow;
+    let result: Cow<str> = MD_HEADING_RE.replace_all(content, "");
+    let result: Cow<str> = MD_IMAGE_RE.replace_all(&result, "");
+    let result: Cow<str> = MD_LINK_RE.replace_all(&result, "$1");
+    let result: Cow<str> = HTML_TAG_RE.replace_all(&result, "");
+    let mut result = result.into_owned();
     result = result.replace("***", "");
     result = result.replace("**", "");
     result = result.replace('*', "");
-
-    // Strip backticks but keep content
     result = result.replace("```", "");
     result = result.replace('`', "");
-
-    // Collapse multiple spaces/tabs
-    result = MULTI_WHITESPACE_RE.replace_all(&result, " ").to_string();
-
-    // Collapse multiple newlines
-    result = MULTI_NEWLINE_RE.replace_all(&result, "\n\n").to_string();
-
+    let result: Cow<str> = MULTI_WHITESPACE_RE.replace_all(&result, " ");
+    let result: Cow<str> = MULTI_NEWLINE_RE.replace_all(&result, "\n\n");
     result.trim().to_string()
 }
 

--- a/src/note.rs
+++ b/src/note.rs
@@ -58,7 +58,7 @@ pub struct NoteFile {
 }
 
 /// A parsed note entry
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Note {
     /// Unique identifier: "note:{index}"
     pub id: String,

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -1,5 +1,6 @@
 //! Data types for the parser module
 
+use serde::Serialize;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -83,7 +84,7 @@ pub struct FunctionCalls {
 ///
 /// Used for type-level dependency tracking (Phase 2b of moonshot).
 /// Stored as string in SQLite `type_edges.edge_kind` column.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub enum TypeEdgeKind {
     /// Function/method parameter type: `fn foo(x: Config)`
     Param,
@@ -160,4 +161,25 @@ pub struct ChunkTypeRefs {
     pub line_start: u32,
     /// Type references used by this chunk
     pub type_refs: Vec<TypeRef>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn type_edge_kind_round_trip() {
+        for kind in [
+            TypeEdgeKind::Param,
+            TypeEdgeKind::Return,
+            TypeEdgeKind::Field,
+            TypeEdgeKind::Impl,
+            TypeEdgeKind::Bound,
+            TypeEdgeKind::Alias,
+        ] {
+            let s = kind.to_string();
+            let parsed: TypeEdgeKind = s.parse().unwrap();
+            assert_eq!(kind, parsed, "Round-trip failed for {s}");
+        }
+    }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -24,6 +24,7 @@ use crate::store::{Store, StoreError, UnifiedResult};
 ///
 /// Contains the best-matching chunk and any alternative matches
 /// found during resolution (useful for disambiguation UIs).
+#[derive(Debug, Clone)]
 pub struct ResolvedTarget {
     /// The resolved chunk (best match for the target name)
     pub chunk: ChunkSummary,

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -152,7 +152,7 @@ impl From<ChunkRow> for ChunkSummary {
 }
 
 /// A search result with similarity score
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SearchResult {
     /// The matching chunk
     pub chunk: ChunkSummary,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -587,6 +587,7 @@ impl Store {
         name: &str,
         limit: usize,
     ) -> Result<Vec<SearchResult>, StoreError> {
+        let limit = limit.min(100);
         let normalized = sanitize_fts_query(&normalize_for_fts(name));
         if normalized.is_empty() {
             return Ok(vec![]);

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -191,7 +191,7 @@ fn find_stale_mentions(store: &Store, project_root: &Path) -> Result<Vec<(String
         }
     }
     symbol_mentions.sort_unstable();
-    symbol_mentions.dedup();
+    symbol_mentions.dedup(); // dedup requires sorted input — sort_unstable above ensures this
 
     let symbol_results = if symbol_mentions.is_empty() {
         HashMap::new()


### PR DESCRIPTION
## Summary

P3 tier of the v0.12.12 audit — 31 fixes across 20 files, 8 non-issues documented.

- **Documentation (9):** README `--expand` flag, missing commands (health, suggest, --include-types), CONTRIBUTING file listings, CHANGELOG comparison URLs, ROADMAP checkmarks, SECURITY reranker model
- **Error handling (5):** `.context()` on Store::open in drift, embed_query in batch, debug→warn in staleness, EH-25/EH-29 documented or n/a
- **Observability (4):** tracing spans for pipeline, windowing, GPU/CPU embed threads; AtomicU64 error counter in batch stats
- **API design (5):** Debug+Clone on TypeGraph/ResolvedTarget, Serialize on Note, re-export drift types, TypeEdgeKind enum replaces stringly-typed edge_kind
- **Robustness (5):** onboard depth clamped to 10, search_by_name limit clamped to 100, MAX_EDGES as usize, RB-25/RB-30 verified correct
- **Algorithm/platform/perf (5):** onboard total_items includes key_types, PathBuf forward-slash serialization, Cow<str> in strip_markdown_noise, PERF-26/AC-27 verified correct
- **Test coverage (2):** TypeEdgeKind round-trip test, staleness test assertion

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index` — all pass
- [x] `cargo clippy --features gpu-index` — no warnings
- [x] Fresh-eyes review — no issues found
- [x] `docs/audit-triage.md` updated with status marks
