### PR TITLE
chore: release v0.13.1 — batch.rs split + P4 audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-02-21
+
+### Changed
+- **Split `batch.rs` into `batch/` directory** — 2844-line monolith split into 4 focused files: `mod.rs` (BatchContext, main loop), `commands.rs` (parsing, dispatch), `handlers.rs` (23 handler functions), `pipeline.rs` (pipe chaining, fan-out). No behavior change.
+
+### Fixed
+- **P4 audit: 18 test + extensibility + resource management fixes** (#463) — 6 test improvements (edge cases, property-based tests for health/suggest/onboard), 9 extensibility enhancements (language registry, parser config), 3 resource management fixes (drop ordering, cleanup).
+- **CQ-8/CQ-9 read dedup** — extracted shared read logic (`validate_and_read_file`, `build_file_note_header`, `build_focused_output`) into `commands/read.rs`. Both CLI and batch read paths call shared core, eliminating ~200 lines of duplicated code.
+- **SECURITY.md** — path traversal code snippet updated to reflect `dunce::canonicalize` usage.
+
 ## [0.13.0] - 2026-02-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 90.9% Recall@1. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,22 +2,17 @@
 
 ## Right Now
 
-**batch.rs split + P4 audit.** 2026-02-21.
+**v0.13.0 audit + batch split complete.** 2026-02-21.
 
-- P1-P3 merged (#459, #460, #461)
-- P4: 18 fixes on branch `fix/p4-audit-findings`
-- batch.rs split: 2844-line monolith → batch/ directory (4 files) + CQ-8/CQ-9 read dedup
-- Ready to commit split work, then PR
+- P1-P4 all merged (#459, #460, #461, #463)
+- batch.rs split merged in #463: 2844-line monolith → batch/ directory (4 files) + CQ-8/CQ-9 read dedup
+- Binary updated, main clean
 
 Audit triage: `docs/audit-triage.md`
 
 ## Pending Changes
 
-Uncommitted on `fix/p4-audit-findings`:
-- `src/cli/batch.rs` deleted → `src/cli/batch/{mod,commands,handlers,pipeline}.rs`
-- `src/cli/commands/read.rs` rewritten with shared core functions
-- `src/health.rs` cosmetic comment fix
-- `CONTRIBUTING.md` architecture section updated
+None.
 
 ## Parked
 
@@ -28,7 +23,6 @@ Uncommitted on `fix/p4-audit-findings`:
 - **Phase 8**: Security (index encryption)
 - **ref install** — deferred, tracked in #255
 - **Query-intent routing** — auto-boost ref weight when query mentions product names
-- **P4 audit findings** — 18 findings fixed on `fix/p4-audit-findings`
 - **resolve_target test bias** — ambiguous names resolve to test functions over production code. Not blocking, but `cqs related foo` may pick `test_foo_bar` instead of `foo`. Fix: prefer non-test chunks in resolve_target.
 
 ## Open Issues
@@ -52,9 +46,9 @@ Uncommitted on `fix/p4-audit-findings`:
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 9 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, Markdown)
-- Tests: 1037 pass + 31 ignored
+- Tests: 1039 pass + 31 ignored
 - CLI-only (MCP server removed in PR #352)
-- Source layout: parser/, hnsw/, impact/ are directories (impact split in PR #402)
+- Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag
 - Build target: `~/.cargo-target/cqs/` (Linux FS)
 - NVIDIA env: CUDA 13.1, Driver 582.16, libcuvs 26.02 (conda/rapidsai), cuDNN 9.19.0 (conda/conda-forge)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -100,9 +100,10 @@ The convert module spawns external processes for format conversion:
 The `cqs read` command validates paths:
 
 ```rust
-let canonical = file_path.canonicalize()?;
-if !canonical.starts_with(&project_root) {
-    return Err("Path traversal not allowed");
+let canonical = dunce::canonicalize(&file_path)?;
+let project_canonical = dunce::canonicalize(root)?;
+if !canonical.starts_with(&project_canonical) {
+    bail!("Path traversal not allowed: {}", path);
 }
 ```
 


### PR DESCRIPTION
## Summary

Release v0.13.1 — batch.rs split + P4 audit fixes.

- Version bump: 0.13.0 → 0.13.1
- CHANGELOG updated
- SECURITY.md path traversal snippet updated to reflect `dunce::canonicalize` usage
- PROJECT_CONTINUITY.md test count updated

## Test plan

- [x] `cargo test --features gpu-index` — 1039 pass, 31 ignored
- [x] `cargo clippy --features gpu-index` — clean
- [x] Docs review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
