### PR TITLE
fix: wire --tokens in batch handlers (#465)

### DIFF
--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -324,8 +324,8 @@ pub(crate) fn dispatch(ctx: &BatchContext, cmd: BatchCmd) -> Result<serde_json::
         BatchCmd::Onboard {
             query,
             depth,
-            tokens: _tokens,
-        } => handlers::dispatch_onboard(ctx, &query, depth),
+            tokens,
+        } => handlers::dispatch_onboard(ctx, &query, depth, tokens),
         BatchCmd::Scout {
             query,
             limit,


### PR DESCRIPTION
## Summary

- Wire `--tokens` token budgeting into 6 batch handlers that previously silently ignored it (CQ-14/TC-19 audit finding)
- Each handler uses `count_tokens_batch` + `token_pack` (greedy knapsack by score) to fit results within the budget
- Fix onboard dispatch in `commands.rs` where `tokens` was dropped at the call site

### Per-handler behavior

| Handler | Score function | Notes |
|---------|---------------|-------|
| search | result score | Skips for `--name-only` (no content) |
| explain | target always included; similar by similarity score | Similar packed into remaining budget after target |
| gather | `GatheredChunk.score` | |
| context | caller count | Skips for `--summary`/`--compact` (no content) |
| scout | `relevance_score * search_score` | Batch-fetches content, injects into JSON |
| onboard | depth-based (entry=1.0, chain=1/(d+2), callers=0.3) | Batch-fetches content, injects into JSON |

All responses include `token_count` and `token_budget` fields when `--tokens` is specified.

## Test plan

- [x] `cargo clippy --features gpu-index` — clean
- [x] `cargo test --features gpu-index` — 1039 pass, 31 ignored
- [x] Manual: `echo 'search "error handling" --tokens 500' | cqs batch` — token fields present, results pruned
- [x] Manual: `echo 'gather "error handling" --tokens 500' | cqs batch` — token fields present
- [x] Manual: `echo 'explain cmd_batch --tokens 1000' | cqs batch` — target + similar content included
- [x] Manual: `echo 'context src/cli/batch/handlers.rs --tokens 2000' | cqs batch` — chunks pruned by caller count
- [x] Manual: `echo 'scout "batch token budgeting" --tokens 1000' | cqs batch` — content injected for packed chunks
- [x] Manual: `echo 'onboard "token packing" --tokens 1000' | cqs batch` — content injected for packed entries
- [x] Manual: search without `--tokens` — no `token_count`/`token_budget` in output (no regression)
- [x] Fresh-eyes review: fixed 2 `unwrap_or_default()` calls → `tracing::warn!` per convention

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)
