### PR TITLE
fix: P3 audit findings for v0.14.0 (25 fixes)

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -40,31 +40,31 @@ Generated: 2026-02-22
 
 | # | Finding | Difficulty | Location | Status |
 |---|---------|-----------|----------|--------|
-| 1 | **AD-1**: TaskResult/TaskSummary missing Debug/Clone derives | easy | task.rs:20-45 | |
-| 2 | **AD-2**: ScoutChunk/FileGroup/ScoutSummary/ScoutResult missing derives | easy | scout.rs:26-70 | |
-| 3 | **AD-3**: PlacementResult/FileSuggestion etc missing derives | easy | where_to_add.rs:21-53, scout.rs:84 | |
-| 4 | **AD-5**: ScoutChunk u64 vs usize for counts | easy | scout.rs:38-40 | |
-| 5 | **OB-1**: compute_modify_threshold result not logged | easy | scout.rs:308 | |
-| 6 | **OB-2**: scout_core missing search result count in logs | easy | scout.rs:154-299 | |
-| 7 | **OB-3**: dispatch_task batch token budgeting not logged | easy | batch/handlers.rs:1460-1493 | |
-| 8 | **EH-2**: dispatch_test_map unwrap_or_default without tracing | easy | batch/handlers.rs:644-647 | |
-| 9 | **EH-4/PB-2**: scout_core to_str().unwrap_or("") — empty string for non-UTF8 | easy | scout.rs:202,223 | |
-| 10 | **AC-3**: index_pack includes first item with budget=0 | easy | cli/commands/task.rs:56 | |
-| 11 | **AC-5**: compute_modify_threshold doc inaccuracy (tied scores) | easy | scout.rs:336-337 | |
-| 12 | **CQ-5**: print_code_section_idx double-iterates content lines | easy | cli/commands/task.rs:554-559 | |
-| 13 | **PF-4**: Waterfall budgeting clones code content strings unnecessarily | easy | cli/commands/task.rs:107 | |
-| 14 | **PF-6**: dispatch_task serializes all code then overwrites with budgeted subset | easy | batch/handlers.rs:1457,1490 | |
-| 15 | **EX-3**: ChunkRole string serialization duplicated in 4 match arms | easy | scout.rs:411, cli/commands/task.rs:297,515, cli/commands/scout.rs:132 | |
-| 16 | **RT-DATA-6**: partial_cmp unwrap_or(Equal) — use f32::total_cmp instead | easy | store/mod.rs:674, store/notes.rs:164, diff.rs:181, search.rs:714 | |
-| 17 | **RT-INJ-9**: cmd_ref_add validates name late — confusing error | easy | cli/commands/reference.rs:64-89 | |
-| 18 | **RT-RES-3**: --tokens 0 emits content despite zero budget | easy | cli/commands/task.rs:56 | |
-| 19 | **RT-RES-8**: dispatch_test_map chain loop lacks iteration bound | easy | batch/handlers.rs:638-648 | |
-| 20 | **TC-4**: compute_modify_threshold untested with all-test-chunk inputs | easy | scout.rs:308-341 | |
-| 21 | **TC-6**: classify_role untested at exact threshold with test names | easy | scout.rs:344-352 | |
-| 22 | **TC-8**: index_pack untested with zero budget | easy | cli/commands/task.rs:36-64 | |
-| 23 | **TC-10**: note_mention_matches_file untested with empty strings | easy | scout.rs:383-391 | |
-| 24 | **RT-INJ-4**: validate_ref_name doesn't reject null bytes | easy | reference.rs:209-220 | |
-| 25 | **RT-DATA-7**: rewrite_notes_file reads from separate fd while holding lock | easy | note.rs:185-222 | |
+| 1 | **AD-1**: TaskResult/TaskSummary missing Debug/Clone derives | easy | task.rs:20-45 | ✅ fixed |
+| 2 | **AD-2**: ScoutChunk/FileGroup/ScoutSummary/ScoutResult missing derives | easy | scout.rs:26-70 | ✅ fixed |
+| 3 | **AD-3**: PlacementResult/FileSuggestion etc missing derives | easy | where_to_add.rs:21-53, scout.rs:84 | ✅ fixed |
+| 4 | **AD-5**: ScoutChunk u64 vs usize for counts | easy | scout.rs:38-40 | ✅ fixed |
+| 5 | **OB-1**: compute_modify_threshold result not logged | easy | scout.rs:308 | ✅ fixed |
+| 6 | **OB-2**: scout_core missing search result count in logs | easy | scout.rs:154-299 | ✅ fixed |
+| 7 | **OB-3**: dispatch_task batch token budgeting not logged | easy | batch/handlers.rs:1460-1493 | ✅ fixed (P2) |
+| 8 | **EH-2**: dispatch_test_map unwrap_or_default without tracing | easy | batch/handlers.rs:644-647 | ✅ fixed |
+| 9 | **EH-4/PB-2**: scout_core to_str().unwrap_or("") — empty string for non-UTF8 | easy | scout.rs:202,223 | ✅ fixed |
+| 10 | **AC-3**: index_pack includes first item with budget=0 | easy | cli/commands/task.rs:56 | ✅ fixed |
+| 11 | **AC-5**: compute_modify_threshold doc inaccuracy (tied scores) | easy | scout.rs:336-337 | ✅ fixed |
+| 12 | **CQ-5**: print_code_section_idx double-iterates content lines | easy | cli/commands/task.rs:554-559 | ✅ fixed |
+| 13 | **PF-4**: Waterfall budgeting clones code content strings unnecessarily | easy | cli/commands/task.rs:107 | ✅ fixed |
+| 14 | **PF-6**: dispatch_task serializes all code then overwrites with budgeted subset | easy | batch/handlers.rs:1457,1490 | ✅ fixed (P2) |
+| 15 | **EX-3**: ChunkRole string serialization duplicated in 4 match arms | easy | scout.rs:411, cli/commands/task.rs:297,515, cli/commands/scout.rs:132 | ✅ fixed |
+| 16 | **RT-DATA-6**: partial_cmp unwrap_or(Equal) — use f32::total_cmp instead | easy | store/mod.rs:674, store/notes.rs:164, diff.rs:181, search.rs:714 | ✅ fixed |
+| 17 | **RT-INJ-9**: cmd_ref_add validates name late — confusing error | easy | cli/commands/reference.rs:64-89 | ✅ fixed |
+| 18 | **RT-RES-3**: --tokens 0 emits content despite zero budget | easy | cli/commands/task.rs:56 | ✅ fixed |
+| 19 | **RT-RES-8**: dispatch_test_map chain loop lacks iteration bound | easy | batch/handlers.rs:638-648 | ✅ fixed |
+| 20 | **TC-4**: compute_modify_threshold untested with all-test-chunk inputs | easy | scout.rs:308-341 | ✅ fixed |
+| 21 | **TC-6**: classify_role untested at exact threshold with test names | easy | scout.rs:344-352 | ✅ fixed |
+| 22 | **TC-8**: index_pack untested with zero budget | easy | cli/commands/task.rs:36-64 | ✅ fixed |
+| 23 | **TC-10**: note_mention_matches_file untested with empty strings | easy | scout.rs:383-391 | ✅ fixed |
+| 24 | **RT-INJ-4**: validate_ref_name doesn't reject null bytes | easy | reference.rs:209-220 | ✅ fixed |
+| 25 | **RT-DATA-7**: rewrite_notes_file reads from separate fd while holding lock | easy | note.rs:185-222 | ✅ fixed |
 
 ## P4: Hard or Low Impact — Create Issues
 

--- a/src/cli/commands/reference.rs
+++ b/src/cli/commands/reference.rs
@@ -62,13 +62,17 @@ pub(crate) fn cmd_ref(cli: &Cli, subcmd: &RefCommand) -> Result<()> {
 }
 
 fn cmd_ref_add(cli: &Cli, name: &str, source: &std::path::Path, weight: f32) -> Result<()> {
-    let root = find_project_root();
-    let config = cqs::config::Config::load(&root);
+    // Validate name first — fast-fail before any I/O
+    cqs::reference::validate_ref_name(name)
+        .map_err(|e| anyhow::anyhow!("Invalid reference name '{}': {}", name, e))?;
 
     // Validate weight
     if !(0.0..=1.0).contains(&weight) {
         bail!("Weight must be between 0.0 and 1.0 (got {})", weight);
     }
+
+    let root = find_project_root();
+    let config = cqs::config::Config::load(&root);
 
     // Check for duplicate
     if config.references.iter().any(|r| r.name == name) {

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -179,7 +179,7 @@ pub fn semantic_diff(
     // Entries with None similarity (missing embeddings) sort to the end
     // rather than being conflated with maximally-changed (similarity=0.0).
     modified.sort_by(|a, b| match (a.similarity, b.similarity) {
-        (Some(sa), Some(sb)) => sa.partial_cmp(&sb).unwrap_or(std::cmp::Ordering::Equal),
+        (Some(sa), Some(sb)) => sa.total_cmp(&sb),
         (Some(_), None) => std::cmp::Ordering::Less,
         (None, Some(_)) => std::cmp::Ordering::Greater,
         (None, None) => std::cmp::Ordering::Equal,
@@ -306,7 +306,7 @@ mod tests {
 
         // Apply the same sort as semantic_diff
         entries.sort_by(|a, b| match (a.similarity, b.similarity) {
-            (Some(sa), Some(sb)) => sa.partial_cmp(&sb).unwrap_or(std::cmp::Ordering::Equal),
+            (Some(sa), Some(sb)) => sa.total_cmp(&sb),
             (Some(_), None) => std::cmp::Ordering::Less,
             (None, Some(_)) => std::cmp::Ordering::Greater,
             (None, None) => std::cmp::Ordering::Equal,

--- a/src/gather.rs
+++ b/src/gather.rs
@@ -109,7 +109,7 @@ impl std::str::FromStr for GatherDirection {
 }
 
 /// A gathered code chunk with context
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GatheredChunk {
     pub name: String,
     pub file: PathBuf,

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -210,6 +210,9 @@ pub fn validate_ref_name(name: &str) -> Result<(), &'static str> {
     if name.is_empty() {
         return Err("Reference name cannot be empty");
     }
+    if name.contains('\0') {
+        return Err("Reference name cannot contain null bytes");
+    }
     if name.contains('/') || name.contains('\\') || name.contains("..") {
         return Err("Reference name cannot contain '/', '\\', or '..'");
     }
@@ -391,6 +394,7 @@ mod tests {
         assert!(validate_ref_name("..").is_err());
         assert!(validate_ref_name(".").is_err());
         assert!(validate_ref_name("").is_err());
+        assert!(validate_ref_name("foo\0bar").is_err());
     }
 
     #[test]

--- a/src/search.rs
+++ b/src/search.rs
@@ -356,7 +356,7 @@ impl BoundedScoreHeap {
             .into_iter()
             .map(|Reverse((OrderedFloat(score), id))| (id, score))
             .collect();
-        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| b.1.total_cmp(&a.1));
         results
     }
 }
@@ -723,7 +723,7 @@ impl Store {
                 })
                 .collect();
 
-            scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            scored.sort_by(|a, b| b.1.total_cmp(&a.1));
 
             let mut seen_parents: HashSet<String> = HashSet::new();
             let results: Vec<SearchResult> = scored

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -671,7 +671,7 @@ impl Store {
             .into_iter()
             .map(|(k, v)| (k.to_string(), v))
             .collect();
-        sorted.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        sorted.sort_by(|a, b| b.1.total_cmp(&a.1));
         sorted.truncate(limit);
         sorted
     }

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -161,7 +161,7 @@ impl Store {
                 .filter_map(|row| score_note_row(row, query, threshold))
                 .collect();
 
-            scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            scored.sort_by(|a, b| b.1.total_cmp(&a.1));
             scored.truncate(limit);
 
             if scanned == MAX_NOTES_SCAN as usize {

--- a/src/task.rs
+++ b/src/task.rs
@@ -16,6 +16,7 @@ use crate::where_to_add::FileSuggestion;
 use crate::{AnalysisError, Embedder, Store};
 
 /// Complete task analysis result.
+#[derive(Debug, Clone)]
 pub struct TaskResult {
     /// Original task description.
     pub description: String,
@@ -34,6 +35,7 @@ pub struct TaskResult {
 }
 
 /// Summary statistics for a task result.
+#[derive(Debug, Clone)]
 pub struct TaskSummary {
     pub total_files: usize,
     pub total_functions: usize,


### PR DESCRIPTION
## Summary

Fixes all 25 P3 findings from the v0.14.0 audit (easy + low impact tier). Two items (OB-3, PF-6) were already resolved by P2 changes in #470.

### Highlights

- **Debug/Clone derives** on all public result types (TaskResult, ScoutResult, FileSuggestion, etc.) — enables downstream cloning and debug formatting
- **f32::total_cmp everywhere** — replaced 9 `partial_cmp().unwrap_or(Equal)` sites across 5 files with `total_cmp`, eliminating NaN-related sort instability
- **ChunkRole::as_str()** — centralizes JSON serialization strings, eliminating 4 duplicated match arms
- **rewrite_notes_file reads from locked fd** — was opening a separate file descriptor for reading while holding the lock, creating a theoretical race window
- **validate_ref_name rejects null bytes** — closes the last input injection gap in reference name validation
- **index_pack returns empty for budget=0** — `--tokens 0` no longer emits content
- **4 new unit tests** for previously untested edge cases (all-test thresholds, exact threshold classification, zero budget packing, empty string mention matching)

## Test plan

- [x] `cargo build --features gpu-index` — zero warnings
- [x] `cargo clippy --features gpu-index` — zero warnings
- [x] `cargo test --features gpu-index` — 1081 passed, 0 failed, 33 ignored
- [x] All 25 P3 items marked fixed in `docs/audit-triage.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
