### PR TITLE
chore: release v0.14.1 — audit fixes + doc sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-02-22
+
+### Fixed
+- **61-finding audit: P1-P4 fixes across 3 PRs** (#470, #471, #472) — 14-category code audit with red team adversarial review. P1+P2: 18 fixes (task CLI hardening, HNSW search bounds, impact format safety, gather depth guards). P3: 25 fixes (scout gap detection refactor, search edge cases, note locking, reference validation). P4: 18 fixes (batch pipeline fan-out cap, GC HNSW cleanup, embedding dimension warning, extensibility constants).
+- **Flaky HNSW tests** — relaxed exact top-1 assertions to top-k contains for approximate nearest neighbor tests (#473).
+- **`Embedding::new()` false positive** — dimension warning no longer fires on 768-dim pre-sentiment intermediate embeddings (#473).
+- **Command listing sync** — added missing commands (task, health, suggest, convert, ref, project, review) across README, CLAUDE.md, audit skill, red-team skill, and bootstrap skill (#473).
+
+### Added
+- **Red team audit skill** (`.claude/skills/red-team/`) — reusable `/red-team` skill for adversarial security audits with 4 categories: input injection, filesystem boundary violations, adversarial robustness, silent data corruption (#472).
+
 ## [0.14.0] - 2026-02-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."


### PR DESCRIPTION
## Summary
- Bump version to v0.14.1
- Changelog for 4 PRs since v0.14.0: 61-finding audit (P1-P4), flaky HNSW fixes, embedding dimension fix, command listing sync, red team skill

## What's in v0.14.1
- 61 audit findings fixed across P1-P4 (PRs #470, #471, #472)
- Command listings synced across all docs and skills (#473)
- Flaky HNSW tests fixed (#473)
- Embedding::new() false positive fixed (#473)
- Red team audit skill added (#472)

## Test plan
- [x] 1116 tests (1083 pass, 33 ignored)
- [x] Clippy clean
- [x] Docs review passed
- [x] End-to-end validation of 12 cqs commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
