### PR TITLE
feat: score improvements moonshot — pipeline eval, demotion, NL templates

### DIFF
--- a/src/cli/batch/handlers.rs
+++ b/src/cli/batch/handlers.rs
@@ -65,13 +65,11 @@ pub(super) fn dispatch_search(
 
     let filter = cqs::SearchFilter {
         languages,
-        chunk_types: None,
         path_pattern: path,
         name_boost: 0.2,
         query_text: query.to_string(),
         enable_rrf: !semantic_only,
-        note_weight: 1.0,
-        note_only: false,
+        ..Default::default()
     };
 
     // Check audit mode (cached per session)
@@ -279,14 +277,8 @@ pub(super) fn dispatch_explain(
     let similar = match ctx.store.get_chunk_with_embedding(&chunk.id)? {
         Some((_, embedding)) => {
             let filter = cqs::SearchFilter {
-                languages: None,
-                chunk_types: None,
-                path_pattern: None,
-                name_boost: 0.0,
-                query_text: String::new(),
-                enable_rrf: false,
                 note_weight: 0.0,
-                note_only: false,
+                ..Default::default()
             };
             let index = ctx.vector_index()?;
             let sim_results = ctx
@@ -407,14 +399,8 @@ pub(super) fn dispatch_similar(
         .ok_or_else(|| anyhow::anyhow!("Could not load embedding for '{}'", chunk.name))?;
 
     let filter = cqs::SearchFilter {
-        languages: None,
-        chunk_types: None,
-        path_pattern: None,
-        name_boost: 0.0,
-        query_text: String::new(),
-        enable_rrf: false,
         note_weight: 0.0,
-        note_only: false,
+        ..Default::default()
     };
 
     let index = ctx.vector_index()?;

--- a/src/cli/commands/explain.rs
+++ b/src/cli/commands/explain.rs
@@ -70,14 +70,8 @@ pub(crate) fn cmd_explain(
     let similar = match store.get_chunk_with_embedding(&chunk.id)? {
         Some((_, embedding)) => {
             let filter = SearchFilter {
-                languages: None,
-                chunk_types: None,
-                path_pattern: None,
-                name_boost: 0.0,
-                query_text: String::new(),
-                enable_rrf: false,
                 note_weight: 0.0,
-                note_only: false,
+                ..Default::default()
             };
             let index = HnswIndex::try_load(&cqs_dir);
             let sim_results = store.search_filtered_with_index(

--- a/src/cli/commands/query.rs
+++ b/src/cli/commands/query.rs
@@ -57,6 +57,7 @@ pub(crate) fn cmd_query(cli: &Cli, query: &str) -> Result<()> {
         None => None,
     };
 
+    #[allow(clippy::needless_update)]
     let filter = SearchFilter {
         languages,
         chunk_types,
@@ -66,6 +67,8 @@ pub(crate) fn cmd_query(cli: &Cli, query: &str) -> Result<()> {
         enable_rrf: !cli.semantic_only, // RRF on by default, disable with --semantic-only
         note_weight: cli.note_weight,
         note_only: cli.note_only,
+        enable_demotion: !cli.no_demote,
+        ..Default::default()
     };
     filter.validate().map_err(|e| anyhow::anyhow!(e))?;
 

--- a/src/cli/commands/similar.rs
+++ b/src/cli/commands/similar.rs
@@ -70,13 +70,9 @@ pub(crate) fn cmd_similar(
 
     let filter = SearchFilter {
         languages,
-        chunk_types: None,
         path_pattern: cli.path.clone(),
-        name_boost: 0.0, // Pure embedding similarity
-        query_text: String::new(),
-        enable_rrf: false, // No RRF — direct embedding comparison
-        note_weight: 0.0,  // Code only
-        note_only: false,
+        note_weight: 0.0, // Code only, no notes
+        ..Default::default()
     };
 
     // Load vector index

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -203,6 +203,10 @@ pub struct Cli {
     #[arg(long)]
     no_stale_check: bool,
 
+    /// Disable search-time demotion of test functions and underscore-prefixed names
+    #[arg(long)]
+    no_demote: bool,
+
     /// Show debug info (sets RUST_LOG=debug)
     #[arg(short, long)]
     pub verbose: bool,

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -432,6 +432,12 @@ pub struct SearchFilter {
     pub note_weight: f32,
     /// When true, return only notes (skip code search entirely)
     pub note_only: bool,
+    /// Apply search-time demotion for test functions and underscore-prefixed names.
+    ///
+    /// Test functions (`test_*`, `Test*`) get 0.90x multiplier.
+    /// Underscore-prefixed private names (`_foo` but not `__dunder__`) get 0.95x.
+    /// Disable with `--no-demote` CLI flag.
+    pub enable_demotion: bool,
 }
 
 impl Default for SearchFilter {
@@ -445,6 +451,7 @@ impl Default for SearchFilter {
             enable_rrf: false,
             note_weight: 1.0, // Notes weighted equally by default
             note_only: false,
+            enable_demotion: true, // Demote test functions by default
         }
     }
 }

--- a/tests/eval_common.rs
+++ b/tests/eval_common.rs
@@ -1,0 +1,604 @@
+//! Shared evaluation infrastructure — types, test cases, and fixture paths.
+//!
+//! Used by eval_test.rs, model_eval.rs, and pipeline_eval.rs.
+
+#![allow(dead_code)]
+
+use cqs::parser::Language;
+use std::path::PathBuf;
+
+/// A single evaluation case: semantic query -> expected function name
+pub struct EvalCase {
+    pub query: &'static str,
+    pub expected_name: &'static str,
+    pub language: Language,
+}
+
+/// Get fixture path for a language (original fixtures for basic eval)
+pub fn fixture_path(lang: Language) -> PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    let ext = match lang {
+        Language::Rust => "rs",
+        Language::Python => "py",
+        Language::TypeScript => "ts",
+        Language::JavaScript => "js",
+        Language::Go => "go",
+        Language::C => "c",
+        Language::Java => "java",
+        Language::Sql => "sql",
+        Language::Markdown => "md",
+    };
+    PathBuf::from(manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join(format!("eval_{}.{}", lang.to_string().to_lowercase(), ext))
+}
+
+/// Get fixture path for hard eval fixtures (confusable functions)
+pub fn hard_fixture_path(lang: Language) -> PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    let ext = match lang {
+        Language::Rust => "rs",
+        Language::Python => "py",
+        Language::TypeScript => "ts",
+        Language::JavaScript => "js",
+        Language::Go => "go",
+        Language::C => "c",
+        Language::Java => "java",
+        Language::Sql => "sql",
+        Language::Markdown => "md",
+    };
+    PathBuf::from(manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join(format!(
+            "eval_hard_{}.{}",
+            lang.to_string().to_lowercase(),
+            ext
+        ))
+}
+
+/// Eval cases: 10 per language = 50 total
+/// Queries are semantic descriptions, expected_name is the function that should match
+pub const EVAL_CASES: &[EvalCase] = &[
+    // Rust (10)
+    EvalCase {
+        query: "retry with exponential backoff",
+        expected_name: "retry_with_backoff",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "validate email address format",
+        expected_name: "validate_email",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "parse JSON configuration file",
+        expected_name: "parse_json_config",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "compute SHA256 hash",
+        expected_name: "hash_sha256",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "format number as currency with commas",
+        expected_name: "format_currency",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "convert camelCase to snake_case",
+        expected_name: "camel_to_snake",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "truncate string with ellipsis",
+        expected_name: "truncate_string",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "check if string is valid UUID",
+        expected_name: "is_valid_uuid",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "sort array with quicksort algorithm",
+        expected_name: "quicksort",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "memoize function results",
+        expected_name: "get_or_compute",
+        language: Language::Rust,
+    },
+    // Python (10)
+    EvalCase {
+        query: "retry with exponential backoff",
+        expected_name: "retry_with_backoff",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "validate email address format",
+        expected_name: "validate_email",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "parse JSON config from file",
+        expected_name: "parse_json_config",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "compute SHA256 hash of bytes",
+        expected_name: "hash_sha256",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "format currency with dollar sign",
+        expected_name: "format_currency",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "convert camelCase to snake_case",
+        expected_name: "camel_to_snake",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "truncate string with ellipsis",
+        expected_name: "truncate_string",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "check UUID format validity",
+        expected_name: "is_valid_uuid",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "quicksort sorting algorithm",
+        expected_name: "quicksort",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "cache function results decorator",
+        expected_name: "memoize",
+        language: Language::Python,
+    },
+    // TypeScript (10)
+    EvalCase {
+        query: "retry operation with exponential backoff",
+        expected_name: "retryWithBackoff",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "validate email address",
+        expected_name: "validateEmail",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "parse JSON config string",
+        expected_name: "parseJsonConfig",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "SHA256 hash computation",
+        expected_name: "hashSha256",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "format money with commas",
+        expected_name: "formatCurrency",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "camelCase to snake_case conversion",
+        expected_name: "camelToSnake",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "truncate long string with dots",
+        expected_name: "truncateString",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "UUID format validation",
+        expected_name: "isValidUuid",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "quicksort implementation",
+        expected_name: "quicksort",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "memoization cache wrapper",
+        expected_name: "memoize",
+        language: Language::TypeScript,
+    },
+    // JavaScript (10)
+    EvalCase {
+        query: "retry with exponential backoff delay",
+        expected_name: "retryWithBackoff",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "email validation regex",
+        expected_name: "validateEmail",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "JSON configuration parser",
+        expected_name: "parseJsonConfig",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "SHA256 cryptographic hash",
+        expected_name: "hashSha256",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "currency formatter",
+        expected_name: "formatCurrency",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "convert camel case to snake case",
+        expected_name: "camelToSnake",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "string truncation with ellipsis",
+        expected_name: "truncateString",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "UUID validation check",
+        expected_name: "isValidUuid",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "quicksort divide and conquer",
+        expected_name: "quicksort",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "function result memoization",
+        expected_name: "memoize",
+        language: Language::JavaScript,
+    },
+    // Go (10)
+    EvalCase {
+        query: "retry with exponential backoff",
+        expected_name: "RetryWithBackoff",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "email address validation",
+        expected_name: "ValidateEmail",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "parse JSON config file",
+        expected_name: "ParseJsonConfig",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "compute SHA256 hash",
+        expected_name: "HashSha256",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "format currency with commas",
+        expected_name: "FormatCurrency",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "camelCase to snake_case",
+        expected_name: "CamelToSnake",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "truncate string ellipsis",
+        expected_name: "TruncateString",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "validate UUID format",
+        expected_name: "IsValidUuid",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "quicksort algorithm",
+        expected_name: "Quicksort",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "memoization get or compute",
+        expected_name: "GetOrCompute",
+        language: Language::Go,
+    },
+];
+
+/// Hard eval cases - confusable queries where multiple similar functions exist
+/// 11 per language = 55 total
+pub const HARD_EVAL_CASES: &[EvalCase] = &[
+    // Rust (11) - must distinguish between 6 sort variants, 4 validators, etc.
+    EvalCase {
+        query: "stable sort preserving relative order of equal elements",
+        expected_name: "merge_sort",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "sort using binary max-heap data structure",
+        expected_name: "heap_sort",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "simple sort efficient for small nearly sorted arrays",
+        expected_name: "insertion_sort",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "non-comparison integer sort processing digits",
+        expected_name: "radix_sort",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "validate phone number with international country code",
+        expected_name: "validate_phone",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "check if URL has valid protocol and hostname",
+        expected_name: "validate_url",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "pad string to fixed width with fill character",
+        expected_name: "pad_string",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "count number of words in text",
+        expected_name: "count_words",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "extract numeric values from mixed text string",
+        expected_name: "extract_numbers",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "stop calling service after consecutive failures",
+        expected_name: "CircuitBreaker",
+        language: Language::Rust,
+    },
+    EvalCase {
+        query: "check whether circuit allows request through",
+        expected_name: "should_allow",
+        language: Language::Rust,
+    },
+    // Python (11)
+    EvalCase {
+        query: "stable sort preserving relative order of equal elements",
+        expected_name: "merge_sort",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "sort using binary max-heap data structure",
+        expected_name: "heap_sort",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "simple sort efficient for small nearly sorted arrays",
+        expected_name: "insertion_sort",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "non-comparison integer sort processing digits",
+        expected_name: "radix_sort",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "validate phone number with international country code",
+        expected_name: "validate_phone",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "check if URL has valid protocol and hostname",
+        expected_name: "validate_url",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "pad string to fixed width with fill character",
+        expected_name: "pad_string",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "count number of words in text",
+        expected_name: "count_words",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "extract numeric values from mixed text string",
+        expected_name: "extract_numbers",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "stop calling service after consecutive failures",
+        expected_name: "CircuitBreaker",
+        language: Language::Python,
+    },
+    EvalCase {
+        query: "check whether circuit allows request through",
+        expected_name: "should_allow",
+        language: Language::Python,
+    },
+    // TypeScript (11)
+    EvalCase {
+        query: "stable sort preserving relative order of equal elements",
+        expected_name: "mergeSort",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "sort using binary max-heap data structure",
+        expected_name: "heapSort",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "simple sort efficient for small nearly sorted arrays",
+        expected_name: "insertionSort",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "non-comparison integer sort processing digits",
+        expected_name: "radixSort",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "validate phone number with international country code",
+        expected_name: "validatePhone",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "check if URL has valid protocol and hostname",
+        expected_name: "validateUrl",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "pad string to fixed width with fill character",
+        expected_name: "padString",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "count number of words in text",
+        expected_name: "countWords",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "extract numeric values from mixed text string",
+        expected_name: "extractNumbers",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "stop calling service after consecutive failures",
+        expected_name: "CircuitBreaker",
+        language: Language::TypeScript,
+    },
+    EvalCase {
+        query: "check whether circuit allows request through",
+        expected_name: "shouldAllow",
+        language: Language::TypeScript,
+    },
+    // JavaScript (11)
+    EvalCase {
+        query: "stable sort preserving relative order of equal elements",
+        expected_name: "mergeSort",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "sort using binary max-heap data structure",
+        expected_name: "heapSort",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "simple sort efficient for small nearly sorted arrays",
+        expected_name: "insertionSort",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "non-comparison integer sort processing digits",
+        expected_name: "radixSort",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "validate phone number with international country code",
+        expected_name: "validatePhone",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "check if URL has valid protocol and hostname",
+        expected_name: "validateUrl",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "pad string to fixed width with fill character",
+        expected_name: "padString",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "count number of words in text",
+        expected_name: "countWords",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "extract numeric values from mixed text string",
+        expected_name: "extractNumbers",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "stop calling service after consecutive failures",
+        expected_name: "CircuitBreaker",
+        language: Language::JavaScript,
+    },
+    EvalCase {
+        query: "check whether circuit allows request through",
+        expected_name: "shouldAllow",
+        language: Language::JavaScript,
+    },
+    // Go (11)
+    EvalCase {
+        query: "stable sort preserving relative order of equal elements",
+        expected_name: "MergeSort",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "sort using binary max-heap data structure",
+        expected_name: "HeapSort",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "simple sort efficient for small nearly sorted arrays",
+        expected_name: "InsertionSort",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "non-comparison integer sort processing digits",
+        expected_name: "RadixSort",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "validate phone number with international country code",
+        expected_name: "ValidatePhone",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "check if URL has valid protocol and hostname",
+        expected_name: "ValidateUrl",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "pad string to fixed width with fill character",
+        expected_name: "PadString",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "count number of words in text",
+        expected_name: "CountWords",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "extract numeric values from mixed text string",
+        expected_name: "ExtractNumbers",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "stop calling service after consecutive failures",
+        expected_name: "CircuitBreakerGo",
+        language: Language::Go,
+    },
+    EvalCase {
+        query: "check whether circuit allows request through",
+        expected_name: "ShouldAllow",
+        language: Language::Go,
+    },
+];

--- a/tests/eval_test.rs
+++ b/tests/eval_test.rs
@@ -3,300 +3,15 @@
 //! Run with: cargo test eval -- --ignored --nocapture
 //! (Ignored by default because embedding generation is slow)
 
+mod eval_common;
+
 use cqs::embedder::Embedder;
 use cqs::generate_nl_description;
-use cqs::parser::{Language, Parser};
+use cqs::parser::Language;
 use cqs::store::{ModelInfo, SearchFilter, Store};
+use eval_common::{fixture_path, EVAL_CASES};
 use std::collections::HashMap;
-use std::path::PathBuf;
 use tempfile::TempDir;
-
-/// An eval test case: query -> expected function name
-struct EvalCase {
-    query: &'static str,
-    expected_name: &'static str,
-    language: Language,
-}
-
-/// Eval cases: 10 per language = 50 total
-/// Queries are semantic descriptions, expected_name is the function that should match
-const EVAL_CASES: &[EvalCase] = &[
-    // Rust (10)
-    EvalCase {
-        query: "retry with exponential backoff",
-        expected_name: "retry_with_backoff",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "validate email address format",
-        expected_name: "validate_email",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "parse JSON configuration file",
-        expected_name: "parse_json_config",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "compute SHA256 hash",
-        expected_name: "hash_sha256",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "format number as currency with commas",
-        expected_name: "format_currency",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "convert camelCase to snake_case",
-        expected_name: "camel_to_snake",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "truncate string with ellipsis",
-        expected_name: "truncate_string",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "check if string is valid UUID",
-        expected_name: "is_valid_uuid",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "sort array with quicksort algorithm",
-        expected_name: "quicksort",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "memoize function results",
-        expected_name: "get_or_compute",
-        language: Language::Rust,
-    },
-    // Python (10)
-    EvalCase {
-        query: "retry with exponential backoff",
-        expected_name: "retry_with_backoff",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "validate email address format",
-        expected_name: "validate_email",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "parse JSON config from file",
-        expected_name: "parse_json_config",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "compute SHA256 hash of bytes",
-        expected_name: "hash_sha256",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "format currency with dollar sign",
-        expected_name: "format_currency",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "convert camelCase to snake_case",
-        expected_name: "camel_to_snake",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "truncate string with ellipsis",
-        expected_name: "truncate_string",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "check UUID format validity",
-        expected_name: "is_valid_uuid",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "quicksort sorting algorithm",
-        expected_name: "quicksort",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "cache function results decorator",
-        expected_name: "memoize",
-        language: Language::Python,
-    },
-    // TypeScript (10)
-    EvalCase {
-        query: "retry operation with exponential backoff",
-        expected_name: "retryWithBackoff",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "validate email address",
-        expected_name: "validateEmail",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "parse JSON config string",
-        expected_name: "parseJsonConfig",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "SHA256 hash computation",
-        expected_name: "hashSha256",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "format money with commas",
-        expected_name: "formatCurrency",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "camelCase to snake_case conversion",
-        expected_name: "camelToSnake",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "truncate long string with dots",
-        expected_name: "truncateString",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "UUID format validation",
-        expected_name: "isValidUuid",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "quicksort implementation",
-        expected_name: "quicksort",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "memoization cache wrapper",
-        expected_name: "memoize",
-        language: Language::TypeScript,
-    },
-    // JavaScript (10)
-    EvalCase {
-        query: "retry with exponential backoff delay",
-        expected_name: "retryWithBackoff",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "email validation regex",
-        expected_name: "validateEmail",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "JSON configuration parser",
-        expected_name: "parseJsonConfig",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "SHA256 cryptographic hash",
-        expected_name: "hashSha256",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "currency formatter",
-        expected_name: "formatCurrency",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "convert camel case to snake case",
-        expected_name: "camelToSnake",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "string truncation with ellipsis",
-        expected_name: "truncateString",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "UUID validation check",
-        expected_name: "isValidUuid",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "quicksort divide and conquer",
-        expected_name: "quicksort",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "function result memoization",
-        expected_name: "memoize",
-        language: Language::JavaScript,
-    },
-    // Go (10)
-    EvalCase {
-        query: "retry with exponential backoff",
-        expected_name: "RetryWithBackoff",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "email address validation",
-        expected_name: "ValidateEmail",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "parse JSON config file",
-        expected_name: "ParseJsonConfig",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "compute SHA256 hash",
-        expected_name: "HashSha256",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "format currency with commas",
-        expected_name: "FormatCurrency",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "camelCase to snake_case",
-        expected_name: "CamelToSnake",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "truncate string ellipsis",
-        expected_name: "TruncateString",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "validate UUID format",
-        expected_name: "IsValidUuid",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "quicksort algorithm",
-        expected_name: "Quicksort",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "memoization get or compute",
-        expected_name: "GetOrCompute",
-        language: Language::Go,
-    },
-];
-
-/// Get fixture path for a language
-fn fixture_path(lang: Language) -> PathBuf {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
-    let ext = match lang {
-        Language::Rust => "rs",
-        Language::Python => "py",
-        Language::TypeScript => "ts",
-        Language::JavaScript => "js",
-        Language::Go => "go",
-        Language::C => "c",
-        Language::Java => "java",
-        Language::Sql => "sql",
-        Language::Markdown => "md",
-    };
-    PathBuf::from(manifest_dir)
-        .join("tests")
-        .join("fixtures")
-        .join(format!("eval_{}.{}", lang.to_string().to_lowercase(), ext))
-}
 
 #[test]
 #[ignore] // Slow test - run with: cargo test eval -- --ignored --nocapture
@@ -306,7 +21,7 @@ fn test_recall_at_5() {
     let embedder = Embedder::new().expect("Failed to initialize embedder");
 
     // Initialize parser
-    let parser = Parser::new().expect("Failed to initialize parser");
+    let parser = cqs::parser::Parser::new().expect("Failed to initialize parser");
 
     // Create temporary store
     let dir = TempDir::new().unwrap();
@@ -336,11 +51,11 @@ fn test_recall_at_5() {
             let embeddings = embedder
                 .embed_documents(&[&text])
                 .expect("Failed to embed chunk");
-            let embedding = &embeddings[0];
+            let embedding = embeddings.into_iter().next().unwrap().with_sentiment(0.0);
 
             // Store chunk (no mtime since these are test fixtures)
             store
-                .upsert_chunk(chunk, embedding, None)
+                .upsert_chunk(chunk, &embedding, None)
                 .expect("Failed to store chunk");
             chunk_count += 1;
         }
@@ -363,7 +78,6 @@ fn test_recall_at_5() {
         // Search with language filter
         let filter = SearchFilter {
             languages: Some(vec![case.language]),
-            path_pattern: None,
             ..Default::default()
         };
         let results = store
@@ -383,7 +97,7 @@ fn test_recall_at_5() {
         total_cases += 1;
 
         // Print result
-        let status = if found { "✓" } else { "✗" };
+        let status = if found { "+" } else { "-" };
         let top_names: Vec<_> = results
             .iter()
             .take(3)

--- a/tests/fixtures/eval_hard_go.go
+++ b/tests/fixtures/eval_hard_go.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 )
 
@@ -326,4 +327,83 @@ func (cb *CircuitBreakerGo) RecordSuccess() {
 	defer cb.mu.Unlock()
 	cb.failureCount = 0
 	cb.state = "closed"
+}
+
+// Test functions
+func TestMergeSort(t *testing.T) {
+	data := []int{5, 3, 8, 1, 2}
+	result := MergeSort(data)
+	expected := []int{1, 2, 3, 5, 8}
+	for i := range expected {
+		if result[i] != expected[i] {
+			t.Errorf("MergeSort failed at index %d: got %d, want %d", i, result[i], expected[i])
+		}
+	}
+}
+
+func TestHeapSort(t *testing.T) {
+	data := []int{9, 4, 7, 1, 3}
+	result := HeapSort(data)
+	expected := []int{1, 3, 4, 7, 9}
+	for i := range expected {
+		if result[i] != expected[i] {
+			t.Errorf("HeapSort failed at index %d: got %d, want %d", i, result[i], expected[i])
+		}
+	}
+}
+
+func TestValidateEmail(t *testing.T) {
+	if !ValidateEmail("user@example.com") {
+		t.Error("Expected valid email")
+	}
+	if ValidateEmail("not-an-email") {
+		t.Error("Expected invalid email")
+	}
+}
+
+func TestValidatePhone(t *testing.T) {
+	if !ValidatePhone("+1-555-0100") {
+		t.Error("Expected valid phone")
+	}
+	if ValidatePhone("abc") {
+		t.Error("Expected invalid phone")
+	}
+}
+
+func TestCircuitBreaker(t *testing.T) {
+	cb := NewCircuitBreaker(3, 30)
+	if !cb.ShouldAllow() {
+		t.Error("Expected circuit breaker to allow")
+	}
+}
+
+// mergeSorted is an internal merge helper — merges two sorted slices
+func mergeSorted(left, right []int) []int {
+	result := make([]int, 0, len(left)+len(right))
+	i, j := 0, 0
+	for i < len(left) && j < len(right) {
+		if left[i] <= right[j] {
+			result = append(result, left[i])
+			i++
+		} else {
+			result = append(result, right[j])
+			j++
+		}
+	}
+	result = append(result, left[i:]...)
+	result = append(result, right[j:]...)
+	return result
+}
+
+// insertionSortSmall is an internal sort helper for small partitions
+func insertionSortSmall(arr []int) {
+	for i := 1; i < len(arr); i++ {
+		key := arr[i]
+		j := i
+		for j > 0 && arr[j-1] > key {
+			arr[j] = arr[j-1]
+			j--
+		}
+		arr[j] = key
+	}
 }

--- a/tests/fixtures/eval_hard_javascript.js
+++ b/tests/fixtures/eval_hard_javascript.js
@@ -212,3 +212,56 @@ class CircuitBreaker {
         this.state = 'closed';
     }
 }
+
+// Test functions
+function testMergeSort() {
+    const data = [5, 3, 8, 1, 2];
+    const result = mergeSort(data);
+    console.assert(JSON.stringify(result) === JSON.stringify([1, 2, 3, 5, 8]));
+}
+
+function testHeapSort() {
+    const data = [9, 4, 7, 1, 3];
+    const result = heapSort(data);
+    console.assert(JSON.stringify(result) === JSON.stringify([1, 3, 4, 7, 9]));
+}
+
+function testValidateEmail() {
+    console.assert(validateEmail("user@example.com"));
+    console.assert(!validateEmail("not-an-email"));
+}
+
+function testValidatePhone() {
+    console.assert(validatePhone("+1-555-0100"));
+    console.assert(!validatePhone("abc"));
+}
+
+function testCircuitBreaker() {
+    const cb = new CircuitBreaker(3, 30000);
+    console.assert(cb.shouldAllow());
+}
+
+function _mergeSorted(left, right) {
+    const result = [];
+    let i = 0, j = 0;
+    while (i < left.length && j < right.length) {
+        if (left[i] <= right[j]) {
+            result.push(left[i++]);
+        } else {
+            result.push(right[j++]);
+        }
+    }
+    return result.concat(left.slice(i), right.slice(j));
+}
+
+function _insertionSortSmall(arr) {
+    for (let i = 1; i < arr.length; i++) {
+        const key = arr[i];
+        let j = i;
+        while (j > 0 && arr[j - 1] > key) {
+            arr[j] = arr[j - 1];
+            j--;
+        }
+        arr[j] = key;
+    }
+}

--- a/tests/fixtures/eval_hard_python.py
+++ b/tests/fixtures/eval_hard_python.py
@@ -232,3 +232,50 @@ class CircuitBreaker:
         """Record a success - resets failure count and closes circuit."""
         self.failure_count = 0
         self.state = 'closed'
+
+
+# Test functions for sort algorithms
+def test_merge_sort():
+    data = [5, 3, 8, 1, 2]
+    assert merge_sort(data) == [1, 2, 3, 5, 8]
+
+def test_heap_sort():
+    data = [9, 4, 7, 1, 3]
+    assert heap_sort(data) == [1, 3, 4, 7, 9]
+
+def test_validate_email():
+    assert validate_email("user@example.com")
+    assert not validate_email("not-an-email")
+
+def test_validate_phone():
+    assert validate_phone("+1-555-0100")
+    assert not validate_phone("abc")
+
+def test_circuit_breaker():
+    cb = CircuitBreaker(3, 30)
+    assert cb.should_allow()
+
+def _merge_sorted(left, right):
+    """Internal merge helper — merges two sorted lists."""
+    result = []
+    i = j = 0
+    while i < len(left) and j < len(right):
+        if left[i] <= right[j]:
+            result.append(left[i])
+            i += 1
+        else:
+            result.append(right[j])
+            j += 1
+    result.extend(left[i:])
+    result.extend(right[j:])
+    return result
+
+def _insertion_sort_small(arr):
+    """Internal sort helper for small partitions."""
+    for i in range(1, len(arr)):
+        key = arr[i]
+        j = i
+        while j > 0 and arr[j - 1] > key:
+            arr[j] = arr[j - 1]
+            j -= 1
+        arr[j] = key

--- a/tests/fixtures/eval_hard_rust.rs
+++ b/tests/fixtures/eval_hard_rust.rs
@@ -334,3 +334,66 @@ impl CircuitBreaker {
         self.state = CircuitState::Closed;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_merge_sort() {
+        let mut data = vec![5, 3, 8, 1, 2];
+        let result = merge_sort(&mut data);
+        assert_eq!(result, vec![1, 2, 3, 5, 8]);
+    }
+
+    fn test_heap_sort() {
+        let mut data = vec![9, 4, 7, 1, 3];
+        let result = heap_sort(&mut data);
+        assert_eq!(result, vec![1, 3, 4, 7, 9]);
+    }
+
+    fn test_validate_email() {
+        assert!(validate_email("user@example.com"));
+        assert!(!validate_email("not-an-email"));
+    }
+
+    fn test_validate_phone() {
+        assert!(validate_phone("+1-555-0100"));
+        assert!(!validate_phone("abc"));
+    }
+
+    fn test_circuit_breaker() {
+        let mut cb = CircuitBreaker::new(3, 30);
+        assert!(cb.should_allow());
+    }
+}
+
+/// Internal merge helper — merges two sorted slices
+fn _merge_sorted(left: &[i32], right: &[i32]) -> Vec<i32> {
+    let mut result = Vec::with_capacity(left.len() + right.len());
+    let (mut i, mut j) = (0, 0);
+    while i < left.len() && j < right.len() {
+        if left[i] <= right[j] {
+            result.push(left[i]);
+            i += 1;
+        } else {
+            result.push(right[j]);
+            j += 1;
+        }
+    }
+    result.extend_from_slice(&left[i..]);
+    result.extend_from_slice(&right[j..]);
+    result
+}
+
+/// Internal sort helper for small partitions
+fn _insertion_sort_small(arr: &mut [i32]) {
+    for i in 1..arr.len() {
+        let key = arr[i];
+        let mut j = i;
+        while j > 0 && arr[j - 1] > key {
+            arr[j] = arr[j - 1];
+            j -= 1;
+        }
+        arr[j] = key;
+    }
+}

--- a/tests/fixtures/eval_hard_typescript.ts
+++ b/tests/fixtures/eval_hard_typescript.ts
@@ -219,3 +219,56 @@ export class CircuitBreaker {
         this.state = 'closed';
     }
 }
+
+// Test functions
+function testMergeSort(): void {
+    const data = [5, 3, 8, 1, 2];
+    const result = mergeSort(data);
+    console.assert(JSON.stringify(result) === JSON.stringify([1, 2, 3, 5, 8]));
+}
+
+function testHeapSort(): void {
+    const data = [9, 4, 7, 1, 3];
+    const result = heapSort(data);
+    console.assert(JSON.stringify(result) === JSON.stringify([1, 3, 4, 7, 9]));
+}
+
+function testValidateEmail(): void {
+    console.assert(validateEmail("user@example.com"));
+    console.assert(!validateEmail("not-an-email"));
+}
+
+function testValidatePhone(): void {
+    console.assert(validatePhone("+1-555-0100"));
+    console.assert(!validatePhone("abc"));
+}
+
+function testCircuitBreaker(): void {
+    const cb = new CircuitBreaker(3, 30000);
+    console.assert(cb.shouldAllow());
+}
+
+function _mergeSorted(left: number[], right: number[]): number[] {
+    const result: number[] = [];
+    let i = 0, j = 0;
+    while (i < left.length && j < right.length) {
+        if (left[i] <= right[j]) {
+            result.push(left[i++]);
+        } else {
+            result.push(right[j++]);
+        }
+    }
+    return result.concat(left.slice(i), right.slice(j));
+}
+
+function _insertionSortSmall(arr: number[]): void {
+    for (let i = 1; i < arr.length; i++) {
+        const key = arr[i];
+        let j = i;
+        while (j > 0 && arr[j - 1] > key) {
+            arr[j] = arr[j - 1];
+            j--;
+        }
+        arr[j] = key;
+    }
+}

--- a/tests/model_eval.rs
+++ b/tests/model_eval.rs
@@ -9,13 +9,15 @@
 //! CUDA gate: only BERT-style models (absolute position embeddings) are candidates.
 //! Models with rotary embeddings (nomic, Qwen3) cause ort CPU fallback thrashing.
 
+mod eval_common;
+
 use cqs::parser::{Language, Parser};
 use cqs::{generate_nl_description, generate_nl_with_template, NlTemplate};
+use eval_common::{fixture_path, hard_fixture_path, EvalCase, EVAL_CASES, HARD_EVAL_CASES};
 use ndarray::Array2;
 use ort::session::Session;
 use ort::value::Tensor;
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 /// Per-model evaluation results: (name, per-language hits/total, total hits, total queries)
 type EvalResults<'a> = Vec<(&'a str, HashMap<Language, (usize, usize)>, usize, usize)>;
@@ -106,271 +108,7 @@ const MODELS: &[ModelConfig] = &[
     },
 ];
 
-// ===== Eval Cases (same as eval_test.rs) =====
-
-struct EvalCase {
-    query: &'static str,
-    expected_name: &'static str,
-    language: Language,
-}
-
-const EVAL_CASES: &[EvalCase] = &[
-    // Rust (10)
-    EvalCase {
-        query: "retry with exponential backoff",
-        expected_name: "retry_with_backoff",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "validate email address format",
-        expected_name: "validate_email",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "parse JSON configuration file",
-        expected_name: "parse_json_config",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "compute SHA256 hash",
-        expected_name: "hash_sha256",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "format number as currency with commas",
-        expected_name: "format_currency",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "convert camelCase to snake_case",
-        expected_name: "camel_to_snake",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "truncate string with ellipsis",
-        expected_name: "truncate_string",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "check if string is valid UUID",
-        expected_name: "is_valid_uuid",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "sort array with quicksort algorithm",
-        expected_name: "quicksort",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "memoize function results",
-        expected_name: "get_or_compute",
-        language: Language::Rust,
-    },
-    // Python (10)
-    EvalCase {
-        query: "retry with exponential backoff",
-        expected_name: "retry_with_backoff",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "validate email address format",
-        expected_name: "validate_email",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "parse JSON config from file",
-        expected_name: "parse_json_config",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "compute SHA256 hash of bytes",
-        expected_name: "hash_sha256",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "format currency with dollar sign",
-        expected_name: "format_currency",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "convert camelCase to snake_case",
-        expected_name: "camel_to_snake",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "truncate string with ellipsis",
-        expected_name: "truncate_string",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "check UUID format validity",
-        expected_name: "is_valid_uuid",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "quicksort sorting algorithm",
-        expected_name: "quicksort",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "cache function results decorator",
-        expected_name: "memoize",
-        language: Language::Python,
-    },
-    // TypeScript (10)
-    EvalCase {
-        query: "retry operation with exponential backoff",
-        expected_name: "retryWithBackoff",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "validate email address",
-        expected_name: "validateEmail",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "parse JSON config string",
-        expected_name: "parseJsonConfig",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "SHA256 hash computation",
-        expected_name: "hashSha256",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "format money with commas",
-        expected_name: "formatCurrency",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "camelCase to snake_case conversion",
-        expected_name: "camelToSnake",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "truncate long string with dots",
-        expected_name: "truncateString",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "UUID format validation",
-        expected_name: "isValidUuid",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "quicksort implementation",
-        expected_name: "quicksort",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "memoization cache wrapper",
-        expected_name: "memoize",
-        language: Language::TypeScript,
-    },
-    // JavaScript (10)
-    EvalCase {
-        query: "retry with exponential backoff delay",
-        expected_name: "retryWithBackoff",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "email validation regex",
-        expected_name: "validateEmail",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "JSON configuration parser",
-        expected_name: "parseJsonConfig",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "SHA256 cryptographic hash",
-        expected_name: "hashSha256",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "currency formatter",
-        expected_name: "formatCurrency",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "convert camel case to snake case",
-        expected_name: "camelToSnake",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "string truncation with ellipsis",
-        expected_name: "truncateString",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "UUID validation check",
-        expected_name: "isValidUuid",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "quicksort divide and conquer",
-        expected_name: "quicksort",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "function result memoization",
-        expected_name: "memoize",
-        language: Language::JavaScript,
-    },
-    // Go (10)
-    EvalCase {
-        query: "retry with exponential backoff",
-        expected_name: "RetryWithBackoff",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "email address validation",
-        expected_name: "ValidateEmail",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "parse JSON config file",
-        expected_name: "ParseJsonConfig",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "compute SHA256 hash",
-        expected_name: "HashSha256",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "format currency with commas",
-        expected_name: "FormatCurrency",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "camelCase to snake_case",
-        expected_name: "CamelToSnake",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "truncate string ellipsis",
-        expected_name: "TruncateString",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "validate UUID format",
-        expected_name: "IsValidUuid",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "quicksort algorithm",
-        expected_name: "Quicksort",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "memoization get or compute",
-        expected_name: "GetOrCompute",
-        language: Language::Go,
-    },
-];
+// EvalCase, EVAL_CASES, HARD_EVAL_CASES, fixture_path, hard_fixture_path imported from eval_common
 
 // ===== Eval Embedder (model-agnostic) =====
 
@@ -552,25 +290,6 @@ fn normalize_l2(mut v: Vec<f32>) -> Vec<f32> {
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     // Both are L2-normalized, so cosine similarity = dot product
     a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
-}
-
-fn fixture_path(lang: Language) -> PathBuf {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
-    let ext = match lang {
-        Language::Rust => "rs",
-        Language::Python => "py",
-        Language::TypeScript => "ts",
-        Language::JavaScript => "js",
-        Language::Go => "go",
-        Language::C => "c",
-        Language::Java => "java",
-        Language::Sql => "sql",
-        Language::Markdown => "md",
-    };
-    PathBuf::from(manifest_dir)
-        .join("tests")
-        .join("fixtures")
-        .join(format!("eval_{}.{}", lang.to_string().to_lowercase(), ext))
 }
 
 // ===== Chunk with embedding =====
@@ -794,6 +513,10 @@ fn test_template_comparison() {
         ("BodyKeywords", NlTemplate::BodyKeywords),
         ("Compact", NlTemplate::Compact),
         ("DocFirst", NlTemplate::DocFirst),
+        ("V2 NoPrefix", NlTemplate::StandardV2NoPrefix),
+        ("V2 Fields", NlTemplate::StandardV2Fields),
+        ("V2 Keywords", NlTemplate::StandardV2Keywords),
+        ("V2 TruncDoc", NlTemplate::StandardV2TruncDoc),
     ];
 
     let mut all_results: EvalResults = Vec::new();
@@ -931,314 +654,178 @@ fn test_template_comparison() {
     eprintln!();
 }
 
-// ===== Hard eval - confusable functions =====
+// ===== Hard template comparison =====
 
-fn hard_fixture_path(lang: Language) -> PathBuf {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
-    let ext = match lang {
-        Language::Rust => "rs",
-        Language::Python => "py",
-        Language::TypeScript => "ts",
-        Language::JavaScript => "js",
-        Language::Go => "go",
-        Language::C => "c",
-        Language::Java => "java",
-        Language::Sql => "sql",
-        Language::Markdown => "md",
-    };
-    PathBuf::from(manifest_dir)
-        .join("tests")
-        .join("fixtures")
-        .join(format!(
-            "eval_hard_{}.{}",
-            lang.to_string().to_lowercase(),
-            ext
-        ))
+#[test]
+#[ignore] // Slow - embeds 9x on hard corpus. Run with: cargo test hard_template -- --ignored --nocapture
+fn test_hard_template_comparison() {
+    let parser = Parser::new().expect("Failed to initialize parser");
+    let e5_config = &MODELS[0]; // E5-base-v2
+    let mut embedder = EvalEmbedder::new(e5_config).expect("Failed to load E5-base-v2");
+
+    let languages = [
+        Language::Rust,
+        Language::Python,
+        Language::TypeScript,
+        Language::JavaScript,
+        Language::Go,
+    ];
+
+    // Parse BOTH original and hard fixtures — combined corpus
+    let mut chunks: Vec<cqs::parser::Chunk> = Vec::new();
+    for lang in &languages {
+        let path = fixture_path(*lang);
+        let parsed = parser
+            .parse_file(&path)
+            .expect("Failed to parse original fixture");
+        chunks.extend(parsed);
+        let hard_path = hard_fixture_path(*lang);
+        if hard_path.exists() {
+            let parsed = parser
+                .parse_file(&hard_path)
+                .expect("Failed to parse hard fixture");
+            chunks.extend(parsed);
+        }
+    }
+    eprintln!(
+        "Parsed {} chunks from original + hard fixtures\n",
+        chunks.len()
+    );
+
+    let templates = [
+        ("Standard (baseline)", NlTemplate::Standard),
+        ("NoPrefix", NlTemplate::NoPrefix),
+        ("BodyKeywords", NlTemplate::BodyKeywords),
+        ("Compact", NlTemplate::Compact),
+        ("DocFirst", NlTemplate::DocFirst),
+        ("V2 NoPrefix", NlTemplate::StandardV2NoPrefix),
+        ("V2 Fields", NlTemplate::StandardV2Fields),
+        ("V2 Keywords", NlTemplate::StandardV2Keywords),
+        ("V2 TruncDoc", NlTemplate::StandardV2TruncDoc),
+    ];
+
+    // Store results: (name, recall@1, recall@5, mrr, ndcg@10)
+    let mut all_results: Vec<(&str, f64, f64, f64, f64)> = Vec::new();
+
+    for (template_name, template) in &templates {
+        eprintln!("--- {} ---", template_name);
+
+        // Generate NL descriptions with this template
+        let nl_texts: Vec<String> = chunks
+            .iter()
+            .map(|c| generate_nl_with_template(c, *template))
+            .collect();
+
+        if let Some(first) = nl_texts.first() {
+            eprintln!("  Sample: {}", &first[..first.len().min(120)]);
+        }
+
+        // Embed all descriptions
+        let text_refs: Vec<&str> = nl_texts.iter().map(|s| s.as_str()).collect();
+        let mut all_embeddings: Vec<Vec<f32>> = Vec::new();
+        for batch in text_refs.chunks(16) {
+            match embedder.embed_documents(batch) {
+                Ok(embs) => all_embeddings.extend(embs),
+                Err(e) => {
+                    eprintln!("  SKIP: Embedding failed: {}\n", e);
+                    continue;
+                }
+            }
+        }
+
+        if all_embeddings.len() != chunks.len() {
+            eprintln!("  SKIP: Embedding count mismatch\n");
+            continue;
+        }
+
+        let indexed: Vec<IndexedChunk> = chunks
+            .iter()
+            .zip(all_embeddings.into_iter())
+            .map(|(chunk, emb)| IndexedChunk {
+                name: chunk.name.clone(),
+                language: chunk.language,
+                embedding: emb,
+            })
+            .collect();
+
+        // Pre-embed all queries
+        let query_embeddings: Vec<Vec<f32>> = HARD_EVAL_CASES
+            .iter()
+            .map(|case| {
+                embedder
+                    .embed_query(case.query)
+                    .expect("Query embed failed")
+            })
+            .collect();
+
+        // Compute metrics
+        let (r1_hits, r1_total) =
+            compute_recall_at_k(&indexed, HARD_EVAL_CASES, &query_embeddings, 1);
+        let (r5_hits, r5_total) =
+            compute_recall_at_k(&indexed, HARD_EVAL_CASES, &query_embeddings, 5);
+        let (mrr, per_lang_mrr) = compute_mrr(&indexed, HARD_EVAL_CASES, &query_embeddings);
+        let ndcg_10 = compute_ndcg_at_k(&indexed, HARD_EVAL_CASES, &query_embeddings, 10);
+
+        let recall_1 = r1_hits as f64 / r1_total as f64;
+        let recall_5 = r5_hits as f64 / r5_total as f64;
+
+        eprintln!("  R@1: {}/{} ({:.1}%)", r1_hits, r1_total, recall_1 * 100.0);
+        eprintln!("  R@5: {}/{} ({:.1}%)", r5_hits, r5_total, recall_5 * 100.0);
+        eprintln!("  MRR: {:.4}", mrr);
+        eprintln!("  NDCG@10: {:.4}", ndcg_10);
+
+        // Per-language detail
+        for (lang, lang_mrr, count) in &per_lang_mrr {
+            eprintln!("    {:?}: MRR {:.4} ({} queries)", lang, lang_mrr, count);
+        }
+        eprintln!();
+
+        all_results.push((template_name, recall_1, recall_5, mrr, ndcg_10));
+    }
+
+    // Print comparison table
+    eprintln!("=== Hard Template Comparison (55 queries, confusable corpus) ===\n");
+    eprintln!(
+        "{:<25} {:>10} {:>10} {:>10} {:>10}",
+        "Template", "Recall@1", "Recall@5", "MRR", "NDCG@10"
+    );
+    eprintln!("{}", "-".repeat(70));
+    for (name, r1, r5, mrr, ndcg) in &all_results {
+        eprintln!(
+            "{:<25} {:>9.1}% {:>9.1}% {:>10.4} {:>10.4}",
+            name,
+            r1 * 100.0,
+            r5 * 100.0,
+            mrr,
+            ndcg
+        );
+    }
+    eprintln!();
+
+    // Delta from baseline
+    if let Some((_, baseline_r1, _, baseline_mrr, baseline_ndcg)) = all_results.first() {
+        eprintln!("=== Delta from Standard baseline ===\n");
+        eprintln!(
+            "{:<25} {:>10} {:>10} {:>10}",
+            "Template", "dR@1", "dMRR", "dNDCG@10"
+        );
+        eprintln!("{}", "-".repeat(60));
+        for (name, r1, _, mrr, ndcg) in &all_results[1..] {
+            let dr1 = (r1 - baseline_r1) * 100.0;
+            let dmrr = mrr - baseline_mrr;
+            let dndcg = ndcg - baseline_ndcg;
+            eprintln!(
+                "{:<25} {:>+9.1}% {:>+10.4} {:>+10.4}",
+                name, dr1, dmrr, dndcg
+            );
+        }
+        eprintln!();
+    }
 }
 
-/// Hard eval cases - confusable queries where multiple similar functions exist
-const HARD_EVAL_CASES: &[EvalCase] = &[
-    // Rust (11) - must distinguish between 6 sort variants, 4 validators, etc.
-    EvalCase {
-        query: "stable sort preserving relative order of equal elements",
-        expected_name: "merge_sort",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "sort using binary max-heap data structure",
-        expected_name: "heap_sort",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "simple sort efficient for small nearly sorted arrays",
-        expected_name: "insertion_sort",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "non-comparison integer sort processing digits",
-        expected_name: "radix_sort",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "validate phone number with international country code",
-        expected_name: "validate_phone",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "check if URL has valid protocol and hostname",
-        expected_name: "validate_url",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "pad string to fixed width with fill character",
-        expected_name: "pad_string",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "count number of words in text",
-        expected_name: "count_words",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "extract numeric values from mixed text string",
-        expected_name: "extract_numbers",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "stop calling service after consecutive failures",
-        expected_name: "CircuitBreaker",
-        language: Language::Rust,
-    },
-    EvalCase {
-        query: "check whether circuit allows request through",
-        expected_name: "should_allow",
-        language: Language::Rust,
-    },
-    // Python (11)
-    EvalCase {
-        query: "stable sort preserving relative order of equal elements",
-        expected_name: "merge_sort",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "sort using binary max-heap data structure",
-        expected_name: "heap_sort",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "simple sort efficient for small nearly sorted arrays",
-        expected_name: "insertion_sort",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "non-comparison integer sort processing digits",
-        expected_name: "radix_sort",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "validate phone number with international country code",
-        expected_name: "validate_phone",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "check if URL has valid protocol and hostname",
-        expected_name: "validate_url",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "pad string to fixed width with fill character",
-        expected_name: "pad_string",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "count number of words in text",
-        expected_name: "count_words",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "extract numeric values from mixed text string",
-        expected_name: "extract_numbers",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "stop calling service after consecutive failures",
-        expected_name: "CircuitBreaker",
-        language: Language::Python,
-    },
-    EvalCase {
-        query: "check whether circuit allows request through",
-        expected_name: "should_allow",
-        language: Language::Python,
-    },
-    // TypeScript (11)
-    EvalCase {
-        query: "stable sort preserving relative order of equal elements",
-        expected_name: "mergeSort",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "sort using binary max-heap data structure",
-        expected_name: "heapSort",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "simple sort efficient for small nearly sorted arrays",
-        expected_name: "insertionSort",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "non-comparison integer sort processing digits",
-        expected_name: "radixSort",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "validate phone number with international country code",
-        expected_name: "validatePhone",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "check if URL has valid protocol and hostname",
-        expected_name: "validateUrl",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "pad string to fixed width with fill character",
-        expected_name: "padString",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "count number of words in text",
-        expected_name: "countWords",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "extract numeric values from mixed text string",
-        expected_name: "extractNumbers",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "stop calling service after consecutive failures",
-        expected_name: "CircuitBreaker",
-        language: Language::TypeScript,
-    },
-    EvalCase {
-        query: "check whether circuit allows request through",
-        expected_name: "shouldAllow",
-        language: Language::TypeScript,
-    },
-    // JavaScript (11)
-    EvalCase {
-        query: "stable sort preserving relative order of equal elements",
-        expected_name: "mergeSort",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "sort using binary max-heap data structure",
-        expected_name: "heapSort",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "simple sort efficient for small nearly sorted arrays",
-        expected_name: "insertionSort",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "non-comparison integer sort processing digits",
-        expected_name: "radixSort",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "validate phone number with international country code",
-        expected_name: "validatePhone",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "check if URL has valid protocol and hostname",
-        expected_name: "validateUrl",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "pad string to fixed width with fill character",
-        expected_name: "padString",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "count number of words in text",
-        expected_name: "countWords",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "extract numeric values from mixed text string",
-        expected_name: "extractNumbers",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "stop calling service after consecutive failures",
-        expected_name: "CircuitBreaker",
-        language: Language::JavaScript,
-    },
-    EvalCase {
-        query: "check whether circuit allows request through",
-        expected_name: "shouldAllow",
-        language: Language::JavaScript,
-    },
-    // Go (11)
-    EvalCase {
-        query: "stable sort preserving relative order of equal elements",
-        expected_name: "MergeSort",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "sort using binary max-heap data structure",
-        expected_name: "HeapSort",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "simple sort efficient for small nearly sorted arrays",
-        expected_name: "InsertionSort",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "non-comparison integer sort processing digits",
-        expected_name: "RadixSort",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "validate phone number with international country code",
-        expected_name: "ValidatePhone",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "check if URL has valid protocol and hostname",
-        expected_name: "ValidateUrl",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "pad string to fixed width with fill character",
-        expected_name: "PadString",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "count number of words in text",
-        expected_name: "CountWords",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "extract numeric values from mixed text string",
-        expected_name: "ExtractNumbers",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "stop calling service after consecutive failures",
-        expected_name: "CircuitBreakerGo",
-        language: Language::Go,
-    },
-    EvalCase {
-        query: "check whether circuit allows request through",
-        expected_name: "ShouldAllow",
-        language: Language::Go,
-    },
-];
+// ===== Hard eval - confusable functions =====
+
+/// Hard eval cases imported from eval_common — see eval_common::HARD_EVAL_CASES
 
 /// Compute Mean Reciprocal Rank from ranked results using pre-computed query embeddings
 fn compute_mrr(

--- a/tests/pipeline_eval.rs
+++ b/tests/pipeline_eval.rs
@@ -1,0 +1,570 @@
+//! Pipeline evaluation — tests the full search scoring pipeline.
+//!
+//! Unlike model_eval (in-memory cosine only), this tests:
+//! - Store-based search (search_filtered)
+//! - HNSW-guided search (search_filtered_with_index)
+//! - RRF fusion (keyword + semantic)
+//! - Name boost blending
+//!
+//! Run with: cargo test pipeline_eval -- --ignored --nocapture
+
+mod eval_common;
+
+use cqs::embedder::Embedder;
+use cqs::generate_nl_description;
+use cqs::hnsw::HnswIndex;
+use cqs::parser::{Language, Parser};
+use cqs::store::{ModelInfo, SearchFilter, Store};
+use cqs::VectorIndex;
+use eval_common::{fixture_path, hard_fixture_path, EvalCase, HARD_EVAL_CASES};
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+/// Languages tested in the pipeline eval
+const LANGUAGES: [Language; 5] = [
+    Language::Rust,
+    Language::Python,
+    Language::TypeScript,
+    Language::JavaScript,
+    Language::Go,
+];
+
+/// Metrics for a single scoring configuration
+struct ConfigMetrics {
+    name: &'static str,
+    recall_at_1: f64,
+    recall_at_5: f64,
+    mrr: f64,
+    per_lang_mrr: HashMap<Language, f64>,
+}
+
+/// Compute metrics from search results for a set of eval cases.
+///
+/// For each case, finds the rank of `expected_name` in results (1-indexed).
+/// Returns (recall@1, recall@5, MRR, per-language MRR).
+fn compute_metrics(
+    results_per_case: &[(usize, Option<usize>)], // (case_index, rank_of_expected)
+    cases: &[EvalCase],
+) -> (f64, f64, f64, HashMap<Language, f64>) {
+    let total = results_per_case.len() as f64;
+    if total == 0.0 {
+        return (0.0, 0.0, 0.0, HashMap::new());
+    }
+
+    let mut hits_at_1 = 0usize;
+    let mut hits_at_5 = 0usize;
+    let mut total_rr = 0.0f64;
+    let mut lang_rr: HashMap<Language, (f64, usize)> = HashMap::new();
+
+    for &(case_idx, rank) in results_per_case {
+        let lang = cases[case_idx].language;
+        let entry = lang_rr.entry(lang).or_insert((0.0, 0));
+        entry.1 += 1;
+
+        if let Some(r) = rank {
+            if r == 1 {
+                hits_at_1 += 1;
+            }
+            if r <= 5 {
+                hits_at_5 += 1;
+            }
+            let rr = 1.0 / r as f64;
+            total_rr += rr;
+            entry.0 += rr;
+        }
+    }
+
+    let recall_1 = hits_at_1 as f64 / total;
+    let recall_5 = hits_at_5 as f64 / total;
+    let mrr = total_rr / total;
+
+    let per_lang: HashMap<Language, f64> = lang_rr
+        .into_iter()
+        .map(|(lang, (rr_sum, count))| {
+            let lang_mrr = if count > 0 {
+                rr_sum / count as f64
+            } else {
+                0.0
+            };
+            (lang, lang_mrr)
+        })
+        .collect();
+
+    (recall_1, recall_5, mrr, per_lang)
+}
+
+#[test]
+#[ignore] // Slow - needs embedding. Run with: cargo test pipeline_eval -- --ignored --nocapture
+fn test_pipeline_scoring() {
+    // === Setup ===
+    eprintln!("Initializing embedder...");
+    let embedder = Embedder::new().expect("Failed to initialize embedder");
+    let parser = Parser::new().expect("Failed to initialize parser");
+
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("pipeline_eval.db");
+    let store = Store::open(&db_path).unwrap();
+    store.init(&ModelInfo::default()).unwrap();
+
+    // Parse and index both original AND hard fixtures for all 5 languages
+    eprintln!("Parsing and indexing fixtures...");
+    let mut chunk_count = 0;
+
+    for lang in LANGUAGES {
+        // Original fixtures
+        let path = fixture_path(lang);
+        eprintln!("  Parsing {:?}...", path);
+        let chunks = parser.parse_file(&path).expect("Failed to parse fixture");
+        eprintln!("    Found {} chunks", chunks.len());
+
+        for chunk in &chunks {
+            let text = generate_nl_description(chunk);
+            let embeddings = embedder
+                .embed_documents(&[&text])
+                .expect("Failed to embed chunk");
+            let embedding = embeddings.into_iter().next().unwrap().with_sentiment(0.0);
+            store
+                .upsert_chunk(chunk, &embedding, None)
+                .expect("Failed to store chunk");
+            chunk_count += 1;
+        }
+
+        // Hard fixtures (confusable functions)
+        let hard_path = hard_fixture_path(lang);
+        if hard_path.exists() {
+            eprintln!("  Parsing {:?}...", hard_path);
+            let chunks = parser
+                .parse_file(&hard_path)
+                .expect("Failed to parse hard fixture");
+            eprintln!("    Found {} chunks", chunks.len());
+
+            for chunk in &chunks {
+                let text = generate_nl_description(chunk);
+                let embeddings = embedder
+                    .embed_documents(&[&text])
+                    .expect("Failed to embed chunk");
+                let embedding = embeddings.into_iter().next().unwrap().with_sentiment(0.0);
+                store
+                    .upsert_chunk(chunk, &embedding, None)
+                    .expect("Failed to store chunk");
+                chunk_count += 1;
+            }
+        }
+    }
+    eprintln!("Indexed {} total chunks\n", chunk_count);
+
+    // Build HNSW index from the store
+    eprintln!("Building HNSW index...");
+    let chunk_total = store.chunk_count().unwrap() as usize;
+    let hnsw = HnswIndex::build_batched(store.embedding_batches(10_000), chunk_total)
+        .expect("Failed to build HNSW index");
+    eprintln!("  HNSW index: {} vectors\n", hnsw.len());
+
+    // Pre-embed all queries
+    eprintln!("Embedding {} queries...", HARD_EVAL_CASES.len());
+    let query_embeddings: Vec<_> = HARD_EVAL_CASES
+        .iter()
+        .map(|case| {
+            embedder
+                .embed_query(case.query)
+                .expect("Failed to embed query")
+        })
+        .collect();
+    eprintln!("  Done.\n");
+
+    // === Run 4 scoring configs ===
+
+    let mut all_metrics: Vec<ConfigMetrics> = Vec::new();
+
+    // Config A: Cosine-only (brute-force, baseline)
+    {
+        eprintln!("--- Config A: Cosine-only ---");
+        let mut results_per_case = Vec::new();
+
+        for (i, case) in HARD_EVAL_CASES.iter().enumerate() {
+            let filter = SearchFilter {
+                languages: Some(vec![case.language]),
+                ..Default::default()
+            };
+            let results = store
+                .search_filtered(&query_embeddings[i], &filter, 10, 0.0)
+                .expect("Search failed");
+
+            let rank = results
+                .iter()
+                .position(|r| r.chunk.name == case.expected_name)
+                .map(|pos| pos + 1);
+
+            let status = match rank {
+                Some(1) => "+",
+                Some(r) if r <= 5 => "~",
+                _ => "-",
+            };
+            let top3: Vec<&str> = results
+                .iter()
+                .take(3)
+                .map(|r| r.chunk.name.as_str())
+                .collect();
+            eprintln!(
+                "  {} [{:?}] \"{}\" -> exp: {} (rank: {}), top3: {:?}",
+                status,
+                case.language,
+                case.query,
+                case.expected_name,
+                rank.map(|r| r.to_string()).unwrap_or("miss".to_string()),
+                top3
+            );
+
+            results_per_case.push((i, rank));
+        }
+
+        let (r1, r5, mrr, per_lang) = compute_metrics(&results_per_case, HARD_EVAL_CASES);
+        all_metrics.push(ConfigMetrics {
+            name: "A: Cosine-only",
+            recall_at_1: r1,
+            recall_at_5: r5,
+            mrr,
+            per_lang_mrr: per_lang,
+        });
+    }
+
+    // Config B: RRF (brute-force + keyword fusion)
+    {
+        eprintln!("\n--- Config B: RRF ---");
+        let mut results_per_case = Vec::new();
+
+        for (i, case) in HARD_EVAL_CASES.iter().enumerate() {
+            let filter = SearchFilter {
+                languages: Some(vec![case.language]),
+                enable_rrf: true,
+                query_text: case.query.to_string(),
+                ..Default::default()
+            };
+            let results = store
+                .search_filtered(&query_embeddings[i], &filter, 10, 0.0)
+                .expect("Search failed");
+
+            let rank = results
+                .iter()
+                .position(|r| r.chunk.name == case.expected_name)
+                .map(|pos| pos + 1);
+
+            let status = match rank {
+                Some(1) => "+",
+                Some(r) if r <= 5 => "~",
+                _ => "-",
+            };
+            let top3: Vec<&str> = results
+                .iter()
+                .take(3)
+                .map(|r| r.chunk.name.as_str())
+                .collect();
+            eprintln!(
+                "  {} [{:?}] \"{}\" -> exp: {} (rank: {}), top3: {:?}",
+                status,
+                case.language,
+                case.query,
+                case.expected_name,
+                rank.map(|r| r.to_string()).unwrap_or("miss".to_string()),
+                top3
+            );
+
+            results_per_case.push((i, rank));
+        }
+
+        let (r1, r5, mrr, per_lang) = compute_metrics(&results_per_case, HARD_EVAL_CASES);
+        all_metrics.push(ConfigMetrics {
+            name: "B: RRF",
+            recall_at_1: r1,
+            recall_at_5: r5,
+            mrr,
+            per_lang_mrr: per_lang,
+        });
+    }
+
+    // Config C: RRF + name_boost (full brute-force pipeline)
+    {
+        eprintln!("\n--- Config C: RRF + name_boost ---");
+        let mut results_per_case = Vec::new();
+
+        for (i, case) in HARD_EVAL_CASES.iter().enumerate() {
+            let filter = SearchFilter {
+                languages: Some(vec![case.language]),
+                enable_rrf: true,
+                name_boost: 0.2,
+                query_text: case.query.to_string(),
+                ..Default::default()
+            };
+            let results = store
+                .search_filtered(&query_embeddings[i], &filter, 10, 0.0)
+                .expect("Search failed");
+
+            let rank = results
+                .iter()
+                .position(|r| r.chunk.name == case.expected_name)
+                .map(|pos| pos + 1);
+
+            let status = match rank {
+                Some(1) => "+",
+                Some(r) if r <= 5 => "~",
+                _ => "-",
+            };
+            let top3: Vec<&str> = results
+                .iter()
+                .take(3)
+                .map(|r| r.chunk.name.as_str())
+                .collect();
+            eprintln!(
+                "  {} [{:?}] \"{}\" -> exp: {} (rank: {}), top3: {:?}",
+                status,
+                case.language,
+                case.query,
+                case.expected_name,
+                rank.map(|r| r.to_string()).unwrap_or("miss".to_string()),
+                top3
+            );
+
+            results_per_case.push((i, rank));
+        }
+
+        let (r1, r5, mrr, per_lang) = compute_metrics(&results_per_case, HARD_EVAL_CASES);
+        all_metrics.push(ConfigMetrics {
+            name: "C: RRF + name_boost",
+            recall_at_1: r1,
+            recall_at_5: r5,
+            mrr,
+            per_lang_mrr: per_lang,
+        });
+    }
+
+    // Config D: HNSW-guided + name_boost (production path)
+    {
+        eprintln!("\n--- Config D: HNSW + name_boost ---");
+        let mut results_per_case = Vec::new();
+
+        for (i, case) in HARD_EVAL_CASES.iter().enumerate() {
+            let filter = SearchFilter {
+                languages: Some(vec![case.language]),
+                name_boost: 0.2,
+                query_text: case.query.to_string(),
+                ..Default::default()
+            };
+            let results = store
+                .search_filtered_with_index(
+                    &query_embeddings[i],
+                    &filter,
+                    10,
+                    0.0,
+                    Some(&hnsw as &dyn VectorIndex),
+                )
+                .expect("Search failed");
+
+            let rank = results
+                .iter()
+                .position(|r| r.chunk.name == case.expected_name)
+                .map(|pos| pos + 1);
+
+            let status = match rank {
+                Some(1) => "+",
+                Some(r) if r <= 5 => "~",
+                _ => "-",
+            };
+            let top3: Vec<&str> = results
+                .iter()
+                .take(3)
+                .map(|r| r.chunk.name.as_str())
+                .collect();
+            eprintln!(
+                "  {} [{:?}] \"{}\" -> exp: {} (rank: {}), top3: {:?}",
+                status,
+                case.language,
+                case.query,
+                case.expected_name,
+                rank.map(|r| r.to_string()).unwrap_or("miss".to_string()),
+                top3
+            );
+
+            results_per_case.push((i, rank));
+        }
+
+        let (r1, r5, mrr, per_lang) = compute_metrics(&results_per_case, HARD_EVAL_CASES);
+        all_metrics.push(ConfigMetrics {
+            name: "D: HNSW + name_boost",
+            recall_at_1: r1,
+            recall_at_5: r5,
+            mrr,
+            per_lang_mrr: per_lang,
+        });
+    }
+
+    // Config E: Cosine + demotion (measures demotion effect on cosine baseline)
+    {
+        eprintln!("\n--- Config E: Cosine + demotion ---");
+        let mut results_per_case = Vec::new();
+
+        for (i, case) in HARD_EVAL_CASES.iter().enumerate() {
+            let filter = SearchFilter {
+                languages: Some(vec![case.language]),
+                enable_demotion: true,
+                ..Default::default()
+            };
+            let results = store
+                .search_filtered(&query_embeddings[i], &filter, 10, 0.0)
+                .expect("Search failed");
+
+            let rank = results
+                .iter()
+                .position(|r| r.chunk.name == case.expected_name)
+                .map(|pos| pos + 1);
+
+            let status = match rank {
+                Some(1) => "+",
+                Some(r) if r <= 5 => "~",
+                _ => "-",
+            };
+            let top3: Vec<&str> = results
+                .iter()
+                .take(3)
+                .map(|r| r.chunk.name.as_str())
+                .collect();
+            eprintln!(
+                "  {} [{:?}] \"{}\" -> exp: {} (rank: {}), top3: {:?}",
+                status,
+                case.language,
+                case.query,
+                case.expected_name,
+                rank.map(|r| r.to_string()).unwrap_or("miss".to_string()),
+                top3
+            );
+
+            results_per_case.push((i, rank));
+        }
+
+        let (r1, r5, mrr, per_lang) = compute_metrics(&results_per_case, HARD_EVAL_CASES);
+        all_metrics.push(ConfigMetrics {
+            name: "E: Cosine + demotion",
+            recall_at_1: r1,
+            recall_at_5: r5,
+            mrr,
+            per_lang_mrr: per_lang,
+        });
+    }
+
+    // Config F: HNSW + name_boost + demotion (production path with demotion)
+    {
+        eprintln!("\n--- Config F: HNSW + name_boost + demote ---");
+        let mut results_per_case = Vec::new();
+
+        for (i, case) in HARD_EVAL_CASES.iter().enumerate() {
+            let filter = SearchFilter {
+                languages: Some(vec![case.language]),
+                name_boost: 0.2,
+                query_text: case.query.to_string(),
+                enable_demotion: true,
+                ..Default::default()
+            };
+            let results = store
+                .search_filtered_with_index(
+                    &query_embeddings[i],
+                    &filter,
+                    10,
+                    0.0,
+                    Some(&hnsw as &dyn VectorIndex),
+                )
+                .expect("Search failed");
+
+            let rank = results
+                .iter()
+                .position(|r| r.chunk.name == case.expected_name)
+                .map(|pos| pos + 1);
+
+            let status = match rank {
+                Some(1) => "+",
+                Some(r) if r <= 5 => "~",
+                _ => "-",
+            };
+            let top3: Vec<&str> = results
+                .iter()
+                .take(3)
+                .map(|r| r.chunk.name.as_str())
+                .collect();
+            eprintln!(
+                "  {} [{:?}] \"{}\" -> exp: {} (rank: {}), top3: {:?}",
+                status,
+                case.language,
+                case.query,
+                case.expected_name,
+                rank.map(|r| r.to_string()).unwrap_or("miss".to_string()),
+                top3
+            );
+
+            results_per_case.push((i, rank));
+        }
+
+        let (r1, r5, mrr, per_lang) = compute_metrics(&results_per_case, HARD_EVAL_CASES);
+        all_metrics.push(ConfigMetrics {
+            name: "F: HNSW + boost + demote",
+            recall_at_1: r1,
+            recall_at_5: r5,
+            mrr,
+            per_lang_mrr: per_lang,
+        });
+    }
+
+    // === Print comparison table ===
+    eprintln!(
+        "\n=== Pipeline Scoring Comparison ({} hard eval queries) ===\n",
+        HARD_EVAL_CASES.len()
+    );
+    eprintln!(
+        "{:<25} {:>10} {:>10} {:>10}",
+        "Config", "Recall@1", "Recall@5", "MRR"
+    );
+    eprintln!("{}", "-".repeat(55));
+    for m in &all_metrics {
+        eprintln!(
+            "{:<25} {:>9.1}% {:>9.1}% {:>10.4}",
+            m.name,
+            m.recall_at_1 * 100.0,
+            m.recall_at_5 * 100.0,
+            m.mrr,
+        );
+    }
+
+    // Per-language MRR table
+    eprintln!("\n=== Per-Language MRR ===\n");
+    eprintln!(
+        "{:<25} {:>8} {:>8} {:>8} {:>8} {:>8}",
+        "Config", "Rust", "Py", "TS", "JS", "Go"
+    );
+    eprintln!("{}", "-".repeat(70));
+    for m in &all_metrics {
+        let mut row = format!("{:<25}", m.name);
+        for lang in &LANGUAGES {
+            let lang_mrr = m.per_lang_mrr.get(lang).copied().unwrap_or(0.0);
+            row += &format!(" {:>7.4}", lang_mrr);
+        }
+        eprintln!("{}", row);
+    }
+    eprintln!();
+
+    // === Assertions ===
+    let config_a = &all_metrics[0];
+    assert!(
+        config_a.recall_at_1 >= 0.85,
+        "Config A (Cosine-only) Recall@1 below 85% threshold: {:.1}%",
+        config_a.recall_at_1 * 100.0,
+    );
+
+    // No config should be dramatically worse than cosine baseline
+    let baseline_mrr = config_a.mrr;
+    for m in &all_metrics[1..] {
+        assert!(
+            m.mrr >= baseline_mrr * 0.90,
+            "Config '{}' MRR ({:.4}) is >10% worse than cosine baseline ({:.4})",
+            m.name,
+            m.mrr,
+            baseline_mrr,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Score improvements moonshot — 4 phases of search quality work:

- **Phase 0: SearchFilter cleanup** — migrated all 15 explicit `SearchFilter` construction sites to use `..Default::default()` for forward compatibility when adding new fields
- **Phase 1: Pipeline eval** — new `tests/pipeline_eval.rs` that tests the full scoring pipeline (RRF, name_boost, HNSW) through `Store`, not just cosine similarity. Shared eval infrastructure extracted to `tests/eval_common.rs`, deduplicating ~660 lines across 3 eval files
- **Phase 2: Sub-function demotion** — `chunk_importance()` search-time multiplier demotes test functions (0.90x) and underscore-prefixed names (0.95x). Wired into both brute-force and HNSW paths. `--no-demote` CLI flag
- **Phase 3: NL template experiments** — 4 new `StandardV2*` variants tested against 55-query hard eval corpus with confusable test/helper fixtures

### Template eval results (hard corpus, 55 queries)

| Template | Recall@1 | MRR | NDCG@10 |
|----------|----------|-----|---------|
| **Compact** | **92.7%** | **0.949** | **0.961** |
| DocFirst | 90.9% | 0.940 | 0.950 |
| Standard (baseline) | 89.1% | 0.931 | 0.943 |
| V2 Fields | 89.1% | 0.935 | 0.951 |
| BodyKeywords | 89.1% | 0.925 | 0.943 |
| V2 TruncDoc | 89.1% | 0.931 | 0.943 |
| NoPrefix | 87.3% | 0.921 | 0.940 |
| V2 NoPrefix | 87.3% | 0.921 | 0.940 |
| V2 Keywords | 85.5% | 0.902 | 0.926 |

**Compact wins across every metric** (+3.6% R@1 over Standard). Production default unchanged — switching requires reindex.

## Test plan

- [x] `cargo test --features gpu-index` — 1092 passed, 0 failed
- [x] `cargo clippy --features gpu-index` — no new warnings
- [x] `cargo test --test pipeline_eval -- --ignored --nocapture` — 6 scoring configs measured
- [x] `cargo test --test model_eval test_hard_template_comparison -- --ignored --nocapture` — 9 templates compared on hard corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
