### PR TITLE
chore: release v0.15.0 — C# language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-02-25
+
 ### Added
-- **C# language support** — 10th language. Tree-sitter parsing for classes, structs, records, interfaces, enums, methods, constructors, properties, delegates, events, and local functions. Call graph extraction (invocations + object creation). Type dependency extraction (base types, generic args, parameter/return types, property types). Behind `lang-csharp` feature flag (enabled by default).
+- **C# language support** (#484) — 10th language. Tree-sitter parsing for classes, structs, records, interfaces, enums, methods, constructors, properties, delegates, events, and local functions. Call graph extraction (invocations + object creation). Type dependency extraction (base types, generic args, parameter/return types, property types). Behind `lang-csharp` feature flag (enabled by default).
 - **ChunkType variants: Property, Delegate, Event** — new chunk types for C# (and future languages). `callable_sql_list()` replaces hardcoded SQL `IN` clauses. `is_callable()` method for type-safe callable checks.
 - **Per-language `common_types`** — each LanguageDef now carries its own common type set. Runtime union replaces global hardcoded list. Enables language-specific type filtering in focused reads.
 - **Data-driven container extraction** — `container_body_kinds` and `extract_container_name` on LanguageDef replace per-language match arms. Adding a language no longer requires editing the container extraction logic.
+- **Score improvements moonshot** (#480) — pipeline eval harness, sub-function demotion in NL descriptions, NL template experiments. Production template switched Standard → Compact (+3.6% R@1 on hard eval).
+
+### Changed
+- **Skill consolidation** (#482) — consolidated 35 thin cqs-* skill wrappers into unified `/cqs` dispatcher (48 → 14 skills).
+
+### Fixed
+- **hf-hub reverted to 0.4.3** (#483) — 0.5.0 broke model downloads.
+
+### Dependencies
+- clap 4.5.58 → 4.5.60, toml 1.0.1 → 1.0.3, anyhow 1.0.101 → 1.0.102, chrono 0.4.43 → 0.4.44
 
 ## [0.14.1] - 2026-02-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,29 +2,13 @@
 
 ## Right Now
 
-**C# language support — implementation complete, ready for PR.** 2026-02-25.
+**Releasing v0.15.0 — C# language support.** 2026-02-25.
 
-Branch: `feat/csharp-language-support` (7 commits ahead of main).
-
-Design: `docs/plans/2026-02-25-csharp-language-support-design.md`
-Plan: `docs/plans/2026-02-25-csharp-implementation-plan.md`
-
-### All tasks complete:
-
-1. **Task 1: ChunkType variants** — Property, Delegate, Event. `callable_sql_list()`. `is_callable()`.
-2. **Task 2: Dynamic callable SQL** — 3 hardcoded queries replaced.
-3. **Tasks 3+4: Infrastructure + backfill** — Per-language common_types, container_body_kinds, extract_container_name. Data-driven container extraction. All 9 existing languages backfilled.
-4. **Tasks 5+6: tree-sitter-c-sharp + C# module** — Full csharp.rs with chunk/call/type queries, stopwords, common types, extract_return. Registered in define_languages! macro.
-5. **Task 7: C# unit tests** — 8 parse tests (class, method, property, delegate, event, interface, enum, record→struct, constructor, local function). eval_common.rs CSharp arm added.
-6. **Task 8: Registry tests** — folded into Task 6.
-7. **Task 9: Documentation** — README (10 languages, C# in list), CHANGELOG, CONTRIBUTING, ROADMAP all updated.
-8. **Task 10: Final verification** — clippy clean, release build clean, 1101 tests pass (0 failures, 35 ignored).
-
-### Next: Push branch and create PR.
+C# merged via PR #484. Release PR in progress.
 
 ## Pending Changes
 
-Branch `feat/csharp-language-support` — not yet pushed. 7 local commits.
+Release branch `release/v0.15.0` — version bump + changelog.
 
 ## Parked
 
@@ -51,7 +35,7 @@ Branch `feat/csharp-language-support` — not yet pushed. 7 local commits.
 
 ## Architecture
 
-- Version: 0.14.1
+- Version: 0.15.0
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Roadmap
 
-## Current: v0.12.12
+## Current: v0.15.0
 
-All agent experience features shipped. CLI-only (MCP removed in v0.10.0).
+All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 10 languages.
 
 ### Recently Completed
 


### PR DESCRIPTION
## Summary

Release v0.15.0 — C# language support + score improvements moonshot + skill consolidation.

- Version bump 0.14.1 → 0.15.0
- Changelog updated with all changes since 0.14.1
- PROJECT_CONTINUITY.md and ROADMAP.md version refs updated

## Changes in this release

See CHANGELOG.md for full details. Highlights:
- **C# language support** (#484) — 10th language
- **Score improvements moonshot** (#480) — +3.6% R@1
- **Skill consolidation** (#482) — 48 → 14 skills
- **hf-hub fix** (#483) — reverted to 0.4.3

## Test plan

- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `cargo build --release --features gpu-index` — clean
- [x] CI passes on #484 (feature PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
