### PR TITLE
chore: update tears + groom notes after v0.15.0 release

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,13 +2,15 @@
 
 ## Right Now
 
-**Releasing v0.15.0 — C# language support.** 2026-02-25.
+**v0.15.0 released.** 2026-02-25.
 
-C# merged via PR #484. Release PR in progress.
+C# language support shipped. crates.io published, GitHub release tagged, binary installed.
+
+No active task.
 
 ## Pending Changes
 
-Release branch `release/v0.15.0` — version bump + changelog.
+None.
 
 ## Parked
 
@@ -49,5 +51,5 @@ Release branch `release/v0.15.0` — version bump + changelog.
 - Build target: `~/.cargo-target/cqs/` (Linux FS)
 - NVIDIA env: CUDA 13.1, Driver 582.16, libcuvs 26.02 (conda/rapidsai), cuDNN 9.19.0 (conda/conda-forge)
 - Reference: `aveva` → `samples/converted/aveva-docs/` (10,482 chunks, 76 files)
-- type_edges: 4276 edges (Phase 1a+1b complete)
+- type_edges: 4567 edges
 - Eval: E5-base-v2 90.9% Recall@1, 0.951 NDCG@10, 0.941 MRR on 55-query hard eval

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -372,15 +372,6 @@ mentions = [
 ]
 
 [[note]]
-sentiment = 0.5
-text = "Adding a new language to cqs requires: (1) tree-sitter grammar crate, (2) one-liner in define_languages! macro, (3) LanguageDef with chunk_query + call_query, (4) test fixture + parser tests, (5) match arms in eval_test.rs and model_eval.rs. The define_languages! macro (PR #307) reduced this from 13 scattered changes."
-mentions = [
-    "src/language/mod.rs",
-    "define_languages",
-    "src/language/sql.rs",
-]
-
-[[note]]
 sentiment = -0.5
 text = "extract_name_fallback() in chunk.rs searches for SQL keywords (PROCEDURE, FUNCTION, VIEW, TRIGGER) but lives in generic parser code. Harmless for non-SQL languages (returns None) but couples generic parsing to SQL-specific knowledge."
 mentions = [
@@ -828,4 +819,20 @@ mentions = [
     "CLAUDE.md",
     ".claude/skills/audit/SKILL.md",
     ".claude/skills/cqs-bootstrap/SKILL.md",
+]
+
+[[note]]
+sentiment = 1.0
+text = "C# language support shipped in v0.15.0. 10th language. New ChunkType variants: Property, Delegate, Event. Per-language common_types on LanguageDef. Data-driven container extraction. tree-sitter-c-sharp 0.23 behind lang-csharp feature flag."
+mentions = [
+    "src/language/csharp.rs",
+    "src/language/mod.rs",
+]
+
+[[note]]
+sentiment = 0.5
+text = "Adding a new language is now data-driven: one-line define_languages! entry, fill LanguageDef struct (queries, stopwords, common_types, container_body_kinds), done. No parser dispatch edits needed. Property/Delegate/Event ChunkType variants ready for reuse."
+mentions = [
+    "src/language/mod.rs",
+    "src/parser/chunk.rs",
 ]


### PR DESCRIPTION
## Summary

Post-release housekeeping — tears and notes grooming after v0.15.0.

- PROJECT_CONTINUITY.md: v0.15.0 released, no active task, type_edges 4567
- notes.toml: removed outdated language-extensibility note, added C# shipped + data-driven language infrastructure notes

## Test plan

- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
