### PR TITLE
chore: release v0.16.0 — F# + PowerShell language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-02-26
+
 ### Added
-- **F# language support** — 11th language. Tree-sitter parsing for functions, records, discriminated unions, classes, interfaces, modules, and members. Call graph extraction (function application + dot access). Type dependency extraction (record fields, parameter types, inheritance, interface implementation). Behind `lang-fsharp` feature flag (enabled by default).
-- **PowerShell language support** — 12th language. Tree-sitter parsing for functions, classes, methods, properties, and enums. Call graph extraction (command calls, .NET method invocations, member access). Behind `lang-powershell` feature flag (enabled by default).
+- **F# language support** (#487) — 11th language. Tree-sitter parsing for functions, records, discriminated unions, classes, interfaces, modules, and members. Call graph extraction (function application + dot access). Type dependency extraction (record fields, parameter types, inheritance, interface implementation). Behind `lang-fsharp` feature flag (enabled by default).
+- **PowerShell language support** (#487) — 12th language. Tree-sitter parsing for functions, classes, methods, properties, and enums. Call graph extraction (command calls, .NET method invocations, member access). Behind `lang-powershell` feature flag (enabled by default).
 - **ChunkType variant: Module** — new chunk type for F# modules (not callable). Infrastructure for future Ruby/Elixir module support.
+
+### Dependencies
+- tree-sitter-fsharp 0.1.0 (new), tree-sitter-powershell 0.26.3 (new)
 
 ## [0.15.0] - 2026-02-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,9 +2,9 @@
 
 ## Right Now
 
-**F# + PowerShell language support** — 2026-02-25.
+**v0.16.0 releasing.** 2026-02-26.
 
-F# (11th) and PowerShell (12th) languages added. Module ChunkType variant added for F# modules. All tests pass. Needs branch + PR (main is protected).
+F# (11th) and PowerShell (12th) languages. Module ChunkType. PR #487 merged.
 
 ## Pending Changes
 
@@ -35,14 +35,14 @@ None.
 
 ## Architecture
 
-- Version: 0.15.0
+- Version: 0.16.0
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 12 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, C#, F#, PowerShell, SQL, Markdown)
-- Tests: 1101 pass + 35 ignored, 0 failures
+- Tests: 1115 pass + 34 ignored, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Token budgeting works across all context commands: `--tokens N` packs results by
 
 ## Performance
 
-Benchmarked on a 4,110-chunk Rust project (202 files, 10 languages) with CUDA GPU (RTX A6000):
+Benchmarked on a 4,110-chunk Rust project (202 files, 12 languages) with CUDA GPU (RTX A6000):
 
 | Metric | Value |
 |--------|-------|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current: v0.15.0
+## Current: v0.16.0
 
 All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 12 languages.
 


### PR DESCRIPTION
## Summary

- Version bump 0.15.0 → 0.16.0
- Changelog, roadmap, and docs updated for F# + PowerShell release
- Fix stale "10 languages" reference in README benchmarks section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
