### PR TITLE
feat: add Macro ChunkType for Rust macro_rules\! definitions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,7 +81,7 @@ Languages that would likely need new ChunkType variants:
 | Variant | Languages | Rationale |
 |---------|-----------|-----------|
 | `Module` | Ruby, Elixir, ~~F#~~, OCaml | Namespace + mixin container. Ruby `module` is callable (included/extended), distinct from Class. F# shipped in v0.15.0. |
-| `Macro` | Elixir (`defmacro`), Rust (currently skipped) | Compile-time code gen, callable-like but different semantics. |
+| `Macro` | Elixir (`defmacro`), ~~Rust~~ (shipped v0.17.0) | Compile-time code gen, callable-like but different semantics. Rust `macro_rules!` indexed. |
 | `TypeAlias` | Haskell (`type`), Scala (`type`), Kotlin (`typealias`) | Creates type edges but isn't a container or callable. |
 | `Object` | Scala (`object`), Kotlin (`object`) | Singleton — neither class nor instance. Has members, is callable. |
 

--- a/src/cli/commands/query.rs
+++ b/src/cli/commands/query.rs
@@ -51,7 +51,7 @@ pub(crate) fn cmd_query(cli: &Cli, query: &str) -> Result<()> {
         Some(types) => {
             let parsed: Result<Vec<ChunkType>, _> = types.iter().map(|t| t.parse()).collect();
             Some(parsed.context(
-                "Invalid chunk type. Valid: function, method, class, struct, enum, trait, interface, constant, section, property, delegate, event",
+                "Invalid chunk type. Valid: function, method, class, struct, enum, trait, interface, constant, section, property, delegate, event, module, macro",
             )?)
         }
         None => None,

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -21,6 +21,9 @@ const CHUNK_QUERY: &str = r#"
 
 (static_item
   name: (identifier) @name) @const
+
+(macro_definition
+  name: (identifier) @name) @macro
 "#;
 
 /// Tree-sitter query for extracting function calls

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -349,6 +349,7 @@ pub fn generate_nl_with_template(chunk: &Chunk, template: NlTemplate) -> String 
         ChunkType::Delegate => "delegate",
         ChunkType::Event => "event",
         ChunkType::Module => "module",
+        ChunkType::Macro => "macro",
     };
 
     // DocFirst: minimal metadata when doc exists

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -282,6 +282,10 @@ impl Parser {
                         | "interface"
                         | "const"
                         | "module"
+                        | "macro"
+                        | "property"
+                        | "delegate"
+                        | "event"
                 )
             });
 

--- a/src/parser/chunk.rs
+++ b/src/parser/chunk.rs
@@ -27,6 +27,7 @@ impl Parser {
             ("delegate", ChunkType::Delegate),
             ("event", ChunkType::Event),
             ("module", ChunkType::Module),
+            ("macro", ChunkType::Macro),
         ];
 
         // Find which definition capture matched and get its node
@@ -701,6 +702,25 @@ public class Foo {
             let chunks = parser.parse_file(file.path()).unwrap();
 
             assert!(chunks.iter().any(|c| c.name == "Helper"));
+        }
+
+        #[test]
+        fn test_parse_rust_macro() {
+            let content = r#"
+macro_rules! my_macro {
+    ($x:expr) => {
+        println!("{}", $x);
+    };
+}
+"#;
+            let file = write_temp_file(content, "rs");
+            let parser = Parser::new().unwrap();
+            let chunks = parser.parse_file(file.path()).unwrap();
+
+            assert_eq!(chunks.len(), 1);
+            assert_eq!(chunks[0].name, "my_macro");
+            assert_eq!(chunks[0].chunk_type, ChunkType::Macro);
+            assert!(chunks[0].signature.contains("macro_rules! my_macro"));
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `Macro` ChunkType so Rust `macro_rules!` definitions are indexed as chunks
- Macro invocations were already tracked in the call graph, but definitions had no chunk — `cqs callers my_macro` returned nothing
- Fix pre-existing gap: `property`, `delegate`, `event` captures were missing from the `parse_file_relationships` definition filter in `calls.rs`
- Fix hardcoded valid types string in `query.rs` (was missing `module` and `macro`)

## Test plan

- [x] New `test_parse_rust_macro` confirms `macro_rules!` extraction produces a `Macro` chunk
- [x] Updated `test_chunk_type_from_str_valid`, `test_chunk_type_display_roundtrip`, `test_callable_sql_list`
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] Full test suite passes (1 pre-existing flaky HNSW test unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
