### PR TITLE
feat: add Scala + Ruby language support, TypeAlias backfill, capture gap fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Scala language support** — 13th language. Tree-sitter parsing for classes, objects, traits, enums (Scala 3), functions, val/var bindings, and type aliases. Call graph extraction (function calls + field expression calls). Type dependency extraction (parameter types, return types, field types, extends clauses, generic type arguments). Behind `lang-scala` feature flag (enabled by default).
+- **Ruby language support** — 14th language. Tree-sitter parsing for classes, modules, methods, and singleton methods. Call graph extraction. Behind `lang-ruby` feature flag (enabled by default).
+- **ChunkType variants: Object, TypeAlias** — `Object` for Scala singleton objects, `TypeAlias` for Scala `type X = Y` definitions. Neither is callable.
+- **SignatureStyle::FirstLine** — new signature extraction mode for Ruby (no `{` or `:` delimiter, extracts up to first newline).
+- **TypeAlias backfill** — added TypeAlias capture to 5 existing languages: Rust (`type Foo = Bar`), TypeScript (`type Foo = ...`), Go (`type MyInt int`, `type Foo = int`), C (`typedef` — was incorrectly captured as Constant), F# (`type Foo = int -> string`).
+- **C capture gaps filled** — `#define` constants (→ Constant), `#define(...)` function macros (→ Macro), `union` (→ Struct).
+- **SQL capture gaps filled** — `CREATE TABLE` (→ Struct), `CREATE TYPE` (→ TypeAlias), `CREATE VIEW` reclassified from Constant to Function (named query).
+- **Java capture gaps filled** — annotation types `@interface` (→ Interface), class fields (→ Property).
+- **TypeScript namespace** — `namespace Foo { }` now captured as Module.
+- **Ruby constants** — `CONSTANT = value` assignments now captured as Constant.
+
+### Dependencies
+- tree-sitter-scala 0.24 (new), tree-sitter-ruby 0.23 (new)
+
 ## [0.16.0] - 2026-02-26
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Thank you for your interest in contributing to cqs!
 
 ### Feature Ideas
 
-- Additional language support (tree-sitter grammars: C++, Ruby, and more)
+- Additional language support (tree-sitter grammars: C++, Kotlin, Swift, and more)
 - Non-CUDA GPU support (ROCm for AMD, Metal for Apple Silicon)
 - VS Code extension
 - Performance improvements
@@ -103,7 +103,7 @@ src/
     watch.rs    - File watcher for incremental reindexing
   language/     - Tree-sitter language support
     mod.rs      - Language enum, LanguageRegistry, LanguageDef, ChunkType
-    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, sql.rs, markdown.rs
+    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, sql.rs, markdown.rs
   source/       - Source abstraction layer
     mod.rs      - Source trait
     filesystem.rs - File-based source implementation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,9 @@ dependencies = [
  "tree-sitter-javascript",
  "tree-sitter-powershell",
  "tree-sitter-python",
+ "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-scala",
  "tree-sitter-sequel-tsql",
  "tree-sitter-typescript",
  "walkdir",
@@ -4025,10 +4027,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-rust"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b9b18034c684a2420722be8b2a91c9c44f2546b631c039edf575ccba8c61be1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-scala"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7516aeb3d1f40ede8e3045b163e86993b3434514dd06c34c0b75e782d9a0b251"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ tree-sitter-java = { version = "0.23", optional = true }
 tree-sitter-c-sharp = { version = "0.23", optional = true }
 tree-sitter-fsharp = { version = "0.1", optional = true }
 tree-sitter-powershell = { version = "0.26", optional = true }
+tree-sitter-scala = { version = "0.24", optional = true }
+tree-sitter-ruby = { version = "0.23", optional = true }
 tree-sitter-sql = { version = "0.4", package = "tree-sitter-sequel-tsql", optional = true }
 
 # ML
@@ -103,7 +105,7 @@ self_cell = "1"
 libc = "0.2"
 
 [features]
-default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-sql", "lang-markdown", "convert"]
+default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-sql", "lang-markdown", "convert"]
 
 # Language support (opt-in, all enabled by default)
 lang-rust = ["dep:tree-sitter-rust"]
@@ -116,9 +118,11 @@ lang-java = ["dep:tree-sitter-java"]
 lang-csharp = ["dep:tree-sitter-c-sharp"]
 lang-fsharp = ["dep:tree-sitter-fsharp"]
 lang-powershell = ["dep:tree-sitter-powershell"]
+lang-scala = ["dep:tree-sitter-scala"]
+lang-ruby = ["dep:tree-sitter-ruby"]
 lang-sql = ["dep:tree-sitter-sql"]
 lang-markdown = []  # No external deps — custom parser
-lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-sql", "lang-markdown"]
+lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-sql", "lang-markdown"]
 
 # Document conversion
 convert = ["dep:fast_html2md", "dep:walkdir"]

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,13 +2,23 @@
 
 ## Right Now
 
-**v0.16.0 releasing.** 2026-02-26.
+**Scala + Ruby language support.** 2026-02-26.
 
-F# (11th) and PowerShell (12th) languages. Module ChunkType. PR #487 merged.
+Adding languages 13 (Scala) and 14 (Ruby). New ChunkType variants: `Object`, `TypeAlias`. New SignatureStyle: `FirstLine`.
+
+Done:
+- Infrastructure: ChunkType::Object/TypeAlias, SignatureStyle::FirstLine in mod.rs, chunk.rs, calls.rs, nl.rs, query.rs
+- `src/language/scala.rs` — full module with TYPE_QUERY, 8 tests
+- `src/language/ruby.rs` — full module, 7 tests
+- `tests/eval_common.rs` — exhaustive match arms
+- Build/clippy/fmt clean, all tests pass (17 new)
+- Docs updated: README, ROADMAP, CHANGELOG, CONTRIBUTING
+
+Not committed yet — ready for commit + PR.
 
 ## Pending Changes
 
-None.
+Uncommitted: Scala + Ruby language support (all files listed above).
 
 ## Parked
 
@@ -41,7 +51,7 @@ None.
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
-- 12 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, C#, F#, PowerShell, SQL, Markdown)
+- 14 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, C#, F#, PowerShell, Scala, Ruby, SQL, Markdown)
 - Tests: 1115 pass + 34 ignored, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ cqs index --dry-run    # Show what would be indexed
 
 **Parse → Embed → Index → Reason**
 
-1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 12 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
+1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 14 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
 2. **Describe** — Each code element gets a natural language description incorporating doc comments, parameter types, return types, and parent type context (e.g., methods include their struct/class name). This bridges the gap between how developers describe code and how it's written.
 3. **Embed** — E5-base-v2 generates 769-dimensional embeddings (768 semantic + 1 sentiment) locally. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval — outperforms code-specific models because NL descriptions play to general-purpose model strengths.
 4. **Index** — SQLite stores chunks, embeddings, call graph edges, and type dependency edges. HNSW provides fast approximate nearest-neighbor search. FTS5 enables keyword matching.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current: v0.16.0
 
-All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 12 languages.
+All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 14 languages.
 
 ### Recently Completed
 
@@ -62,30 +62,43 @@ Priority order based on competitive gap analysis (Feb 2026).
 - [x] C# language support — 10th language. Property, Delegate, Event chunk types. Per-language common_types. Data-driven container extraction.
 - [x] F# language support — 11th language. Module ChunkType. Functions, records, discriminated unions, classes, interfaces, modules, members.
 - [x] PowerShell language support — 12th language. Functions, classes, methods, properties, enums, command/method calls.
+- [x] Scala language support — 13th language. Object, TypeAlias ChunkTypes. Functions, classes, objects, traits, enums, type aliases, vals/vars. Type dependency extraction.
+- [x] Ruby language support — 14th language. SignatureStyle::FirstLine. Functions, classes, modules, singleton methods. Call graph extraction.
 - [ ] Pre-built release binaries (GitHub Actions) — adoption friction
 - [x] Skill grouping — consolidated 35 thin cqs-* wrappers into unified `/cqs` dispatcher (48→14 skills)
 
-### Future Languages + ChunkType Variants
+### Future Languages — Priority Order
 
-Languages that map cleanly to existing variants (no new ChunkType needed):
-- **Kotlin** — Property covers properties, rest maps to Class/Interface/Enum/Function
-- **Swift** — Property covers properties, `protocol` → Interface
-- **PHP** — Property covers properties, `trait` → Trait
-- **Dart** — Property covers properties, `mixin` could map to Trait
-- **Objective-C** — Property covers `@property`, `@protocol` → Interface
-- **C++** — structs/classes/functions/enums cover it
-- **Zig** — maps cleanly
+**Tier 1 — High value, easy mapping:**
+- [ ] **Shell/Bash** — Function only. Every project has scripts, nobody indexes them semantically. `tree-sitter-bash` mature. Easiest win.
+- [ ] **C++** — Biggest gap by dev population. All variants mapped: namespace → Module, concept → Trait, `#define` → Macro/Constant, union → Struct, typedef/using → TypeAlias. `tree-sitter-cpp` mature.
 
-Languages that would likely need new ChunkType variants:
+**Tier 2 — Structured schemas (better RAG, not just code search):**
+- [ ] **Terraform/HCL** — resource/data → Struct, module → Module, variable/output → Constant. Huge market. People search Terraform the same way they search docs.
+- [ ] **Protobuf** — message → Struct, service → Interface, rpc → Function, enum → Enum. Every microservices shop has `.proto` files.
+- [ ] **GraphQL** — type/input → Struct, query/mutation/subscription → Function, interface → Interface, enum → Enum. Every web API shop has these.
 
-| Variant | Languages | Rationale |
-|---------|-----------|-----------|
-| `Module` | Ruby, Elixir, ~~F#~~, OCaml | Namespace + mixin container. Ruby `module` is callable (included/extended), distinct from Class. F# shipped in v0.15.0. |
-| `Macro` | Elixir (`defmacro`), ~~Rust~~ (shipped v0.17.0) | Compile-time code gen, callable-like but different semantics. Rust `macro_rules!` indexed. |
-| `TypeAlias` | Haskell (`type`), Scala (`type`), Kotlin (`typealias`) | Creates type edges but isn't a container or callable. |
-| `Object` | Scala (`object`), Kotlin (`object`) | Singleton — neither class nor instance. Has members, is callable. |
+**Tier 3 — Programming languages with clean mappings:**
+- [ ] **Kotlin** — Object (companion/singleton), TypeAlias, Property; data class → Struct, sealed class → Class
+- [ ] **Swift** — protocol → Trait, actor → Class, TypeAlias, Property. May need `Extension` variant (primary code org).
+- [ ] **Elixir** — Module + Macro exist. defprotocol → Trait, defrecord → Struct. Clean mapping.
+- [ ] **Lua** — Function-only. Game dev niche (Roblox, Neovim). Easy.
+- [ ] **Haskell** — TypeAlias exists. data → Enum, class → Trait. Niche but loved.
+- [ ] **PHP** — Property covers properties, trait → Trait
+- [ ] **Dart** — Property covers properties, mixin → Trait
+- [ ] **Objective-C** — Property covers `@property`, `@protocol` → Interface
+- [ ] **Zig** — maps cleanly
 
-Ruby would push hardest — `module` is a first-class concept that loses information mapped to either Class or Trait. Scala is the other interesting one with `object`, `trait`, `case class`, `sealed`, and `type` members all structurally distinct.
+### ChunkType Variant Status
+
+All 16 variants shipped and used across languages. Only one potential new variant remains: `Extension` for Swift.
+
+| Variant | Shipped in | Used by |
+|---------|-----------|---------|
+| `Module` | v0.16.0 | F#, Ruby, TS (namespace) |
+| `Macro` | v0.17.0 | Rust, C (`#define(...)`) |
+| `TypeAlias` | v0.17.0 | Scala, Rust, TypeScript, Go, C, F#, SQL |
+| `Object` | v0.17.0 | Scala |
 
 Infrastructure for adding variants is now cheap: per-language LanguageDef fields, data-driven container extraction, dynamic callable SQL. New variant = enum arm + Display/FromStr + is_callable decision + nl.rs + capture_types.
 

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -836,3 +836,12 @@ mentions = [
     "src/language/mod.rs",
     "src/parser/chunk.rs",
 ]
+
+[[note]]
+sentiment = 0.5
+text = "Macro ChunkType added for Rust macro_rules! definitions. Also fixed pre-existing gap: property/delegate/event missing from calls.rs definition filter — those chunk types had call extraction silently skipped in parse_file_relationships."
+mentions = [
+    "src/language/mod.rs",
+    "src/parser/calls.rs",
+    "ChunkType",
+]

--- a/src/cli/commands/query.rs
+++ b/src/cli/commands/query.rs
@@ -51,7 +51,7 @@ pub(crate) fn cmd_query(cli: &Cli, query: &str) -> Result<()> {
         Some(types) => {
             let parsed: Result<Vec<ChunkType>, _> = types.iter().map(|t| t.parse()).collect();
             Some(parsed.context(
-                "Invalid chunk type. Valid: function, method, class, struct, enum, trait, interface, constant, section, property, delegate, event, module, macro",
+                "Invalid chunk type. Valid: function, method, class, struct, enum, trait, interface, constant, section, property, delegate, event, module, macro, object, typealias",
             )?)
         }
         None => None,

--- a/src/language/ruby.rs
+++ b/src/language/ruby.rs
@@ -1,0 +1,206 @@
+//! Ruby language definition
+
+use super::{LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting Ruby code chunks
+const CHUNK_QUERY: &str = r#"
+;; Methods
+(method
+  name: (identifier) @name) @function
+
+;; Singleton methods (def self.foo)
+(singleton_method
+  name: (identifier) @name) @function
+
+;; Classes
+(class
+  name: (constant) @name) @class
+
+;; Modules
+(module
+  name: (constant) @name) @module
+
+;; Constants (UPPER_CASE = value)
+(assignment
+  left: (constant) @name) @const
+"#;
+
+/// Tree-sitter query for extracting Ruby function calls
+const CALL_QUERY: &str = r#"
+(call
+  method: (identifier) @callee)
+"#;
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    "def", "class", "module", "end", "if", "elsif", "else", "unless", "case", "when", "for",
+    "while", "until", "do", "begin", "rescue", "ensure", "raise", "return", "yield", "self",
+    "super", "true", "false", "nil", "and", "or", "not", "in", "include", "extend", "prepend",
+    "require", "private", "protected", "public", "attr_accessor", "attr_reader", "attr_writer",
+];
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "ruby",
+    grammar: Some(|| tree_sitter_ruby::LANGUAGE.into()),
+    extensions: &["rb", "rake", "gemspec"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::FirstLine,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &["singleton_method"],
+    method_containers: &["class", "module"],
+    stopwords: STOPWORDS,
+    extract_return_nl: |_| None,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/spec/{stem}_spec.rb")),
+    type_query: None,
+    common_types: &[],
+    container_body_kinds: &[],
+    extract_container_name: None,
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_ruby_class() {
+        let content = r#"
+class Calculator
+  def add(a, b)
+    a + b
+  end
+end
+"#;
+        let file = write_temp_file(content, "rb");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let class = chunks.iter().find(|c| c.name == "Calculator").unwrap();
+        assert_eq!(class.chunk_type, ChunkType::Class);
+    }
+
+    #[test]
+    fn parse_ruby_module() {
+        let content = r#"
+module Helpers
+  def helper
+    42
+  end
+end
+"#;
+        let file = write_temp_file(content, "rb");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let module = chunks.iter().find(|c| c.name == "Helpers").unwrap();
+        assert_eq!(module.chunk_type, ChunkType::Module);
+    }
+
+    #[test]
+    fn parse_ruby_method() {
+        let content = r#"
+def standalone_method(x)
+  x * 2
+end
+"#;
+        let file = write_temp_file(content, "rb");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "standalone_method").unwrap();
+        assert_eq!(func.chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_ruby_singleton_method() {
+        let content = r#"
+class Foo
+  def self.bar
+    "hello"
+  end
+end
+"#;
+        let file = write_temp_file(content, "rb");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let method = chunks.iter().find(|c| c.name == "bar").unwrap();
+        assert_eq!(method.chunk_type, ChunkType::Method);
+    }
+
+    #[test]
+    fn parse_ruby_method_in_class() {
+        let content = r#"
+class Calculator
+  def add(a, b)
+    a + b
+  end
+end
+"#;
+        let file = write_temp_file(content, "rb");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let method = chunks.iter().find(|c| c.name == "add").unwrap();
+        assert_eq!(method.chunk_type, ChunkType::Method);
+        assert_eq!(method.parent_type_name.as_deref(), Some("Calculator"));
+    }
+
+    #[test]
+    fn parse_ruby_method_in_module() {
+        let content = r#"
+module StringUtils
+  def capitalize_all(str)
+    str.upcase
+  end
+end
+"#;
+        let file = write_temp_file(content, "rb");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let method = chunks.iter().find(|c| c.name == "capitalize_all").unwrap();
+        assert_eq!(method.chunk_type, ChunkType::Method);
+        assert_eq!(method.parent_type_name.as_deref(), Some("StringUtils"));
+    }
+
+    #[test]
+    fn parse_ruby_constant() {
+        let content = "MAX_RETRIES = 3\n";
+        let file = write_temp_file(content, "rb");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let c = chunks.iter().find(|c| c.name == "MAX_RETRIES").unwrap();
+        assert_eq!(c.chunk_type, ChunkType::Constant);
+    }
+
+    #[test]
+    fn parse_ruby_calls() {
+        let content = r#"
+def process(input)
+  result = transform(input)
+  result.to_s
+  puts(result)
+end
+"#;
+        let file = write_temp_file(content, "rb");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "process").unwrap();
+        let calls = parser.extract_calls_from_chunk(func);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(names.contains(&"transform"), "Expected transform call, got: {:?}", names);
+        assert!(names.contains(&"puts"), "Expected puts call, got: {:?}", names);
+    }
+}

--- a/src/language/scala.rs
+++ b/src/language/scala.rs
@@ -1,0 +1,285 @@
+//! Scala language definition
+
+use super::{LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting Scala code chunks
+const CHUNK_QUERY: &str = r#"
+;; Functions
+(function_definition
+  name: (identifier) @name) @function
+
+;; Classes
+(class_definition
+  name: (identifier) @name) @class
+
+;; Objects (singletons)
+(object_definition
+  name: (identifier) @name) @object
+
+;; Traits
+(trait_definition
+  name: (identifier) @name) @trait
+
+;; Enums (Scala 3)
+(enum_definition
+  name: (identifier) @name) @enum
+
+;; Val bindings
+(val_definition
+  pattern: (identifier) @name) @const
+
+;; Var bindings
+(var_definition
+  pattern: (identifier) @name) @const
+
+;; Type aliases — name is type_identifier, not identifier
+(type_definition
+  name: (type_identifier) @name) @typealias
+"#;
+
+/// Tree-sitter query for extracting Scala function calls
+const CALL_QUERY: &str = r#"
+(call_expression
+  function: (identifier) @callee)
+
+(call_expression
+  function: (field_expression
+    field: (identifier) @callee))
+"#;
+
+/// Tree-sitter query for extracting Scala type references
+const TYPE_QUERY: &str = r#"
+;; Parameter types
+(parameter
+  type: (type_identifier) @param_type)
+(parameter
+  type: (generic_type (type_identifier) @param_type))
+
+;; Return types
+(function_definition
+  return_type: (type_identifier) @return_type)
+(function_definition
+  return_type: (generic_type (type_identifier) @return_type))
+
+;; Field types — val/var type annotations
+(val_definition
+  type: (type_identifier) @field_type)
+(val_definition
+  type: (generic_type (type_identifier) @field_type))
+(var_definition
+  type: (type_identifier) @field_type)
+(var_definition
+  type: (generic_type (type_identifier) @field_type))
+
+;; Extends clauses (class Foo extends Bar)
+(extends_clause
+  type: (type_identifier) @impl_type)
+(extends_clause
+  type: (generic_type (type_identifier) @impl_type))
+
+;; Catch-all — generic type arguments
+(type_arguments
+  (type_identifier) @type_ref)
+"#;
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment", "block_comment"];
+
+const STOPWORDS: &[&str] = &[
+    "def", "val", "var", "class", "object", "trait", "sealed", "case", "abstract", "override",
+    "implicit", "lazy", "extends", "with", "import", "package", "match", "if", "else", "for",
+    "while", "yield", "return", "throw", "try", "catch", "finally", "new", "this", "super",
+    "true", "false", "null",
+];
+
+const COMMON_TYPES: &[&str] = &[
+    "String", "Int", "Long", "Double", "Float", "Boolean", "Char", "Byte", "Short", "Unit",
+    "Any", "AnyRef", "AnyVal", "Nothing", "Null", "Option", "Some", "None", "List", "Map", "Set",
+    "Seq", "Vector", "Array", "Future", "Either", "Left", "Right", "Try", "Success", "Failure",
+    "Iterator", "Iterable", "Ordering",
+];
+
+fn extract_return(signature: &str) -> Option<String> {
+    // Scala: def foo(x: Int): String = ...
+    // Look for `: ReturnType` after last `)` and before `=` or `{`
+    let paren_pos = signature.rfind(')')?;
+    let after_paren = &signature[paren_pos + 1..];
+
+    // Find the terminator (= or {)
+    let end_pos = after_paren
+        .find('=')
+        .or_else(|| after_paren.find('{'))
+        .unwrap_or(after_paren.len());
+    let between = &after_paren[..end_pos];
+
+    // Look for colon
+    let colon_pos = between.find(':')?;
+    let ret_type = between[colon_pos + 1..].trim();
+    if ret_type.is_empty() {
+        return None;
+    }
+
+    let ret_words = crate::nl::tokenize_identifier(ret_type).join(" ");
+    Some(format!("Returns {}", ret_words))
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "scala",
+    grammar: Some(|| tree_sitter_scala::LANGUAGE.into()),
+    extensions: &["scala", "sc"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &["class_definition", "trait_definition", "object_definition"],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/src/test/scala/{stem}Spec.scala")),
+    type_query: Some(TYPE_QUERY),
+    common_types: COMMON_TYPES,
+    container_body_kinds: &["template_body"],
+    extract_container_name: None,
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn test_extract_return_scala() {
+        assert_eq!(
+            extract_return("def foo(x: Int): String ="),
+            Some("Returns string".to_string())
+        );
+        assert_eq!(extract_return("def bar() ="), None);
+        assert_eq!(
+            extract_return("def process(input: List[Int]): Boolean ="),
+            Some("Returns boolean".to_string())
+        );
+        assert_eq!(extract_return("def noReturn() {"), None);
+    }
+
+    #[test]
+    fn parse_scala_class() {
+        let content = r#"
+class Calculator {
+  def add(a: Int, b: Int): Int = {
+    a + b
+  }
+}
+"#;
+        let file = write_temp_file(content, "scala");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let class = chunks.iter().find(|c| c.name == "Calculator").unwrap();
+        assert_eq!(class.chunk_type, ChunkType::Class);
+    }
+
+    #[test]
+    fn parse_scala_object() {
+        let content = r#"
+object Main {
+  def run(): Unit = {
+    println("hello")
+  }
+}
+"#;
+        let file = write_temp_file(content, "scala");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let obj = chunks.iter().find(|c| c.name == "Main").unwrap();
+        assert_eq!(obj.chunk_type, ChunkType::Object);
+    }
+
+    #[test]
+    fn parse_scala_trait() {
+        let content = r#"
+trait Printable {
+  def print(): Unit
+}
+"#;
+        let file = write_temp_file(content, "scala");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let t = chunks.iter().find(|c| c.name == "Printable").unwrap();
+        assert_eq!(t.chunk_type, ChunkType::Trait);
+    }
+
+    #[test]
+    fn parse_scala_type_alias() {
+        let content = "type StringMap = Map[String, String]\n";
+        let file = write_temp_file(content, "scala");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let ta = chunks.iter().find(|c| c.name == "StringMap").unwrap();
+        assert_eq!(ta.chunk_type, ChunkType::TypeAlias);
+    }
+
+    #[test]
+    fn parse_scala_method_in_class() {
+        let content = r#"
+class Calculator {
+  def add(a: Int, b: Int): Int = {
+    a + b
+  }
+}
+"#;
+        let file = write_temp_file(content, "scala");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let method = chunks.iter().find(|c| c.name == "add").unwrap();
+        assert_eq!(method.chunk_type, ChunkType::Method);
+        assert_eq!(method.parent_type_name.as_deref(), Some("Calculator"));
+    }
+
+    #[test]
+    fn parse_scala_val_const() {
+        let content = r#"
+object Config {
+  val maxRetries: Int = 3
+}
+"#;
+        let file = write_temp_file(content, "scala");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let val_chunk = chunks.iter().find(|c| c.name == "maxRetries").unwrap();
+        assert_eq!(val_chunk.chunk_type, ChunkType::Constant);
+    }
+
+    #[test]
+    fn parse_scala_calls() {
+        let content = r#"
+object App {
+  def process(input: String): Unit = {
+    val result = transform(input)
+    println(result.toString)
+  }
+}
+"#;
+        let file = write_temp_file(content, "scala");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "process").unwrap();
+        let calls = parser.extract_calls_from_chunk(func);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(names.contains(&"transform"), "Expected transform, got: {:?}", names);
+        assert!(names.contains(&"println"), "Expected println, got: {:?}", names);
+    }
+}

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -30,6 +30,13 @@ const CHUNK_QUERY: &str = r#"
 
 (enum_declaration
   name: (identifier) @name) @enum
+
+(type_alias_declaration
+  name: (type_identifier) @name) @typealias
+
+;; Namespace/module declarations
+(internal_module
+  name: (identifier) @name) @module
 "#;
 
 /// Tree-sitter query for extracting function calls
@@ -129,4 +136,40 @@ static DEFINITION: LanguageDef = LanguageDef {
 
 pub fn definition() -> &'static LanguageDef {
     &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_typescript_namespace() {
+        let content = "namespace Validators {\n  export function check() {}\n}\n";
+        let file = write_temp_file(content, "ts");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let ns = chunks.iter().find(|c| c.name == "Validators").unwrap();
+        assert_eq!(ns.chunk_type, ChunkType::Module);
+    }
+
+    #[test]
+    fn parse_typescript_type_alias() {
+        let content = "type Result = Success | Failure;\n";
+        let file = write_temp_file(content, "ts");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let ta = chunks.iter().find(|c| c.name == "Result").unwrap();
+        assert_eq!(ta.chunk_type, ChunkType::TypeAlias);
+    }
 }

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -350,6 +350,8 @@ pub fn generate_nl_with_template(chunk: &Chunk, template: NlTemplate) -> String 
         ChunkType::Event => "event",
         ChunkType::Module => "module",
         ChunkType::Macro => "macro",
+        ChunkType::Object => "object",
+        ChunkType::TypeAlias => "type alias",
     };
 
     // DocFirst: minimal metadata when doc exists

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -283,6 +283,8 @@ impl Parser {
                         | "const"
                         | "module"
                         | "macro"
+                        | "object"
+                        | "typealias"
                         | "property"
                         | "delegate"
                         | "event"
@@ -977,6 +979,9 @@ fn another() {
             Language::Go,
             Language::Java,
             Language::C,
+            Language::CSharp,
+            // FSharp type query has pre-existing compile issues (#node-type mismatch)
+            Language::Scala,
         ];
         for lang in languages_with_types {
             let result = parser.get_type_query(lang);

--- a/src/parser/chunk.rs
+++ b/src/parser/chunk.rs
@@ -28,6 +28,8 @@ impl Parser {
             ("event", ChunkType::Event),
             ("module", ChunkType::Module),
             ("macro", ChunkType::Macro),
+            ("object", ChunkType::Object),
+            ("typealias", ChunkType::TypeAlias),
         ];
 
         // Find which definition capture matched and get its node
@@ -120,6 +122,7 @@ pub(crate) fn extract_signature(content: &str, language: Language) -> String {
     let sig_end = match language.def().signature_style {
         SignatureStyle::UntilBrace => content.find('{').unwrap_or(content.len()),
         SignatureStyle::UntilColon => content.find(':').unwrap_or(content.len()),
+        SignatureStyle::FirstLine => content.find('\n').unwrap_or(content.len()),
         SignatureStyle::UntilAs => {
             // Case-insensitive search for AS as a standalone word
             let upper = content.to_uppercase();
@@ -342,6 +345,13 @@ mod tests {
             let content = "function processData(input: string): Promise<Result> {\n  return ok;\n}";
             let sig = extract_signature(content, Language::TypeScript);
             assert_eq!(sig, "function processData(input: string): Promise<Result>");
+        }
+
+        #[test]
+        fn test_ruby_signature_stops_at_newline() {
+            let content = "def calculate(x, y)\n  x + y\nend";
+            let sig = extract_signature(content, Language::Ruby);
+            assert_eq!(sig, "def calculate(x, y)");
         }
 
         #[test]

--- a/tests/eval_common.rs
+++ b/tests/eval_common.rs
@@ -31,6 +31,10 @@ pub fn fixture_path(lang: Language) -> PathBuf {
         Language::FSharp => "fs",
         #[cfg(feature = "lang-powershell")]
         Language::PowerShell => "ps1",
+        #[cfg(feature = "lang-scala")]
+        Language::Scala => "scala",
+        #[cfg(feature = "lang-ruby")]
+        Language::Ruby => "rb",
         Language::Sql => "sql",
         Language::Markdown => "md",
     };
@@ -57,6 +61,10 @@ pub fn hard_fixture_path(lang: Language) -> PathBuf {
         Language::FSharp => "fs",
         #[cfg(feature = "lang-powershell")]
         Language::PowerShell => "ps1",
+        #[cfg(feature = "lang-scala")]
+        Language::Scala => "scala",
+        #[cfg(feature = "lang-ruby")]
+        Language::Ruby => "rb",
         Language::Sql => "sql",
         Language::Markdown => "md",
     };

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -345,7 +345,7 @@ fn test_parse_sql_fixture() {
         .iter()
         .find(|c| c.name.contains("vw_ActiveCustomers"));
     assert!(view.is_some(), "Should find vw_ActiveCustomers view");
-    assert_eq!(view.unwrap().chunk_type, ChunkType::Constant);
+    assert_eq!(view.unwrap().chunk_type, ChunkType::Function);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Scala language support** (13th) — classes, objects, traits, enums, functions, val/var, type aliases. Call graph + type dependency extraction. 8 tests.
- **Ruby language support** (14th) — classes, modules, methods, singleton methods. Call graph extraction. `SignatureStyle::FirstLine`. 8 tests.
- **ChunkType variants**: `Object` (Scala singleton), `TypeAlias` (Scala `type X = Y`)
- **TypeAlias backfill** across 5 existing languages: Rust, TypeScript, Go, C (was incorrectly Constant), F#
- **Capture gap fixes**: C (`#define`, `union`), SQL (`CREATE TABLE`, `CREATE TYPE`, `CREATE VIEW` reclassified), Java (`@interface`, fields), TypeScript (`namespace`), Ruby (constants)
- 35 new tests, 1150 total pass, 0 failures

## Test plan

- [x] `cargo test --features gpu-index` — 1150 pass, 0 fail
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New parse tests for every new capture pattern
- [x] Existing tests updated (SQL fixture view type, eval_common exhaustive match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
