### PR TITLE
chore: release v0.17.0 — Scala + Ruby language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-02-26
+
 ### Added
 - **Scala language support** — 13th language. Tree-sitter parsing for classes, objects, traits, enums (Scala 3), functions, val/var bindings, and type aliases. Call graph extraction (function calls + field expression calls). Type dependency extraction (parameter types, return types, field types, extends clauses, generic type arguments). Behind `lang-scala` feature flag (enabled by default).
 - **Ruby language support** — 14th language. Tree-sitter parsing for classes, modules, methods, and singleton methods. Call graph extraction. Behind `lang-ruby` feature flag (enabled by default).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,23 +2,13 @@
 
 ## Right Now
 
-**Scala + Ruby language support.** 2026-02-26.
+**Releasing v0.17.0.** 2026-02-26.
 
-Adding languages 13 (Scala) and 14 (Ruby). New ChunkType variants: `Object`, `TypeAlias`. New SignatureStyle: `FirstLine`.
-
-Done:
-- Infrastructure: ChunkType::Object/TypeAlias, SignatureStyle::FirstLine in mod.rs, chunk.rs, calls.rs, nl.rs, query.rs
-- `src/language/scala.rs` — full module with TYPE_QUERY, 8 tests
-- `src/language/ruby.rs` — full module, 7 tests
-- `tests/eval_common.rs` — exhaustive match arms
-- Build/clippy/fmt clean, all tests pass (17 new)
-- Docs updated: README, ROADMAP, CHANGELOG, CONTRIBUTING
-
-Not committed yet — ready for commit + PR.
+Scala + Ruby language support shipped (PR #490). TypeAlias backfill across 5 languages. Capture gap fixes in C, SQL, Java, TypeScript, Ruby. 1150 tests, 0 failures.
 
 ## Pending Changes
 
-Uncommitted: Scala + Ruby language support (all files listed above).
+None — releasing v0.17.0.
 
 ## Parked
 
@@ -45,14 +35,15 @@ Uncommitted: Scala + Ruby language support (all files listed above).
 
 ## Architecture
 
-- Version: 0.16.0
+- Version: 0.17.0
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 14 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, C#, F#, PowerShell, Scala, Ruby, SQL, Markdown)
-- Tests: 1115 pass + 34 ignored, 0 failures
+- 16 ChunkType variants (Function, Method, Struct, Class, Interface, Enum, Trait, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias)
+- Tests: 1150 pass, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current: v0.16.0
+## Current: v0.17.0
 
 All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 14 languages.
 


### PR DESCRIPTION
## Summary

- Version bump 0.16.0 → 0.17.0
- Changelog finalized with release date
- ROADMAP/PROJECT_CONTINUITY updated

## Test plan

- [x] `cargo test --features gpu-index` — 1150 pass, 0 fail
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
