### PR TITLE
feat: add C++ language support (15 languages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **C++ language support** — 15th language. Tree-sitter parsing for classes, structs, unions, enums (including `enum class`), namespaces, functions, inline methods, out-of-class methods (`Class::method`), destructors, concepts (C++20), type aliases (`using`/`typedef`), preprocessor macros and constants. Call graph extraction (direct, member, qualified, template function calls, `new` expressions). Type dependency extraction (parameters, return types, fields, base classes, template arguments). Out-of-class method inference via `extract_qualified_method` infrastructure. Behind `lang-cpp` feature flag (enabled by default).
+- **`extract_qualified_method` on LanguageDef** — new optional field for languages where methods can be defined outside their class body (C++ `void Foo::bar() {}`). Infers `ChunkType::Method` + `parent_type_name` from the function's own declarator before parent-walking.
+
+### Dependencies
+- tree-sitter-cpp 0.23 (new)
+
 ## [0.17.0] - 2026-02-26
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ src/
     watch.rs    - File watcher for incremental reindexing
   language/     - Tree-sitter language support
     mod.rs      - Language enum, LanguageRegistry, LanguageDef, ChunkType
-    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, sql.rs, markdown.rs
+    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, sql.rs, markdown.rs
   source/       - Source abstraction layer
     mod.rs      - Source trait
     filesystem.rs - File-based source implementation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
+ "tree-sitter-cpp",
  "tree-sitter-fsharp",
  "tree-sitter-go",
  "tree-sitter-java",
@@ -3955,6 +3956,16 @@ name = "tree-sitter-c-sharp"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67f06accca7b45351758663b8215089e643d53bd9a660ce0349314263737fcb0"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tree-sitter-typescript = { version = "0.23", optional = true }
 tree-sitter-javascript = { version = "0.25", optional = true }
 tree-sitter-go = { version = "0.25", optional = true }
 tree-sitter-c = { version = "0.24", optional = true }
+tree-sitter-cpp = { version = "0.23", optional = true }
 tree-sitter-java = { version = "0.23", optional = true }
 tree-sitter-c-sharp = { version = "0.23", optional = true }
 tree-sitter-fsharp = { version = "0.1", optional = true }
@@ -105,7 +106,7 @@ self_cell = "1"
 libc = "0.2"
 
 [features]
-default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-sql", "lang-markdown", "convert"]
+default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-sql", "lang-markdown", "convert"]
 
 # Language support (opt-in, all enabled by default)
 lang-rust = ["dep:tree-sitter-rust"]
@@ -114,6 +115,7 @@ lang-typescript = ["dep:tree-sitter-typescript"]
 lang-javascript = ["dep:tree-sitter-javascript"]
 lang-go = ["dep:tree-sitter-go"]
 lang-c = ["dep:tree-sitter-c"]
+lang-cpp = ["dep:tree-sitter-cpp"]
 lang-java = ["dep:tree-sitter-java"]
 lang-csharp = ["dep:tree-sitter-c-sharp"]
 lang-fsharp = ["dep:tree-sitter-fsharp"]
@@ -122,7 +124,7 @@ lang-scala = ["dep:tree-sitter-scala"]
 lang-ruby = ["dep:tree-sitter-ruby"]
 lang-sql = ["dep:tree-sitter-sql"]
 lang-markdown = []  # No external deps — custom parser
-lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-sql", "lang-markdown"]
+lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-sql", "lang-markdown"]
 
 # Document conversion
 convert = ["dep:fast_html2md", "dep:walkdir"]

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,13 +2,13 @@
 
 ## Right Now
 
-**Releasing v0.17.0.** 2026-02-26.
+**C++ language support (15th language).** 2026-02-26. Branch: `feat/cpp-language-support`.
 
-Scala + Ruby language support shipped (PR #490). TypeAlias backfill across 5 languages. Capture gap fixes in C, SQL, Java, TypeScript, Ruby. 1150 tests, 0 failures.
+All 16 C++ tests pass + full suite green (1166 pass + 35 ignored). Docs updated. Ready for commit + PR.
 
 ## Pending Changes
 
-None — releasing v0.17.0.
+C++ language support on `feat/cpp-language-support` branch, uncommitted.
 
 ## Parked
 
@@ -41,9 +41,9 @@ None — releasing v0.17.0.
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
-- 14 languages (Rust, Python, TypeScript, JavaScript, Go, C, Java, C#, F#, PowerShell, Scala, Ruby, SQL, Markdown)
+- 15 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, SQL, Markdown)
 - 16 ChunkType variants (Function, Method, Struct, Class, Interface, Enum, Trait, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias)
-- Tests: 1150 pass, 0 failures
+- Tests: 1166 pass + 35 ignored, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag

--- a/README.md
+++ b/README.md
@@ -412,10 +412,13 @@ Keep index fresh: run `cqs watch` in a background terminal, or `cqs index` after
 - JavaScript (JSDoc `@param`/`@returns` tags improve search quality)
 - Go
 - C
+- C++ (classes, structs, namespaces, concepts, templates, out-of-class methods, preprocessor macros)
 - Java
 - C# (classes, structs, records, interfaces, enums, properties, delegates, events)
 - F# (functions, records, discriminated unions, classes, interfaces, modules, members)
 - PowerShell (functions, classes, methods, properties, enums, command calls)
+- Scala (classes, objects, traits, enums, functions, val/var bindings, type aliases)
+- Ruby (classes, modules, methods, singleton methods)
 - SQL (T-SQL, PostgreSQL)
 - Markdown (.md, .mdx — heading-based chunking with cross-reference extraction)
 
@@ -434,7 +437,7 @@ cqs index --dry-run    # Show what would be indexed
 
 **Parse → Embed → Index → Reason**
 
-1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 14 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
+1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 15 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
 2. **Describe** — Each code element gets a natural language description incorporating doc comments, parameter types, return types, and parent type context (e.g., methods include their struct/class name). This bridges the gap between how developers describe code and how it's written.
 3. **Embed** — E5-base-v2 generates 769-dimensional embeddings (768 semantic + 1 sentiment) locally. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval — outperforms code-specific models because NL descriptions play to general-purpose model strengths.
 4. **Index** — SQLite stores chunks, embeddings, call graph edges, and type dependency edges. HNSW provides fast approximate nearest-neighbor search. FTS5 enables keyword matching.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current: v0.17.0
 
-All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 14 languages.
+All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 15 languages.
 
 ### Recently Completed
 
@@ -71,7 +71,7 @@ Priority order based on competitive gap analysis (Feb 2026).
 
 **Tier 1 — High value, easy mapping:**
 - [ ] **Shell/Bash** — Function only. Every project has scripts, nobody indexes them semantically. `tree-sitter-bash` mature. Easiest win.
-- [ ] **C++** — Biggest gap by dev population. All variants mapped: namespace → Module, concept → Trait, `#define` → Macro/Constant, union → Struct, typedef/using → TypeAlias. `tree-sitter-cpp` mature.
+- [x] **C++** — Biggest gap by dev population. All variants mapped: namespace → Module, concept → Trait, `#define` → Macro/Constant, union → Struct, typedef/using → TypeAlias. `tree-sitter-cpp` mature.
 
 **Tier 2 — Structured schemas (better RAG, not just code search):**
 - [ ] **Terraform/HCL** — resource/data → Struct, module → Module, variable/output → Constant. Huge market. People search Terraform the same way they search docs.

--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -129,6 +129,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     ],
     container_body_kinds: &[],
     extract_container_name: None,
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/cpp.rs
+++ b/src/language/cpp.rs
@@ -1,0 +1,530 @@
+//! C++ language definition
+
+use super::{LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting C++ code chunks
+const CHUNK_QUERY: &str = r#"
+;; Free functions
+(function_definition
+  declarator: (function_declarator
+    declarator: (identifier) @name)) @function
+
+;; Inline methods (field_identifier inside class body)
+(function_definition
+  declarator: (function_declarator
+    declarator: (field_identifier) @name)) @function
+
+;; Out-of-class methods (Class::method)
+(function_definition
+  declarator: (function_declarator
+    declarator: (qualified_identifier
+      name: (identifier) @name))) @function
+
+;; Destructors (inline)
+(function_definition
+  declarator: (function_declarator
+    declarator: (destructor_name) @name)) @function
+
+;; Destructors (out-of-class, Class::~Class)
+(function_definition
+  declarator: (function_declarator
+    declarator: (qualified_identifier
+      name: (destructor_name) @name))) @function
+
+;; Forward declarations with function body (rare)
+(declaration
+  declarator: (init_declarator
+    declarator: (function_declarator
+      declarator: (identifier) @name))) @function
+
+;; Classes
+(class_specifier
+  name: (type_identifier) @name
+  body: (field_declaration_list)) @class
+
+;; Structs
+(struct_specifier
+  name: (type_identifier) @name
+  body: (field_declaration_list)) @struct
+
+;; Enums (including enum class)
+(enum_specifier
+  name: (type_identifier) @name
+  body: (enumerator_list)) @enum
+
+;; Namespaces
+(namespace_definition
+  name: (namespace_identifier) @name) @module
+
+;; Concepts (C++20)
+(concept_definition
+  name: (identifier) @name) @trait
+
+;; Type aliases — using X = Y (C++11)
+(alias_declaration
+  name: (type_identifier) @name) @typealias
+
+;; Typedefs (C-style)
+(type_definition
+  declarator: (type_identifier) @name) @typealias
+
+;; Unions
+(union_specifier
+  name: (type_identifier) @name
+  body: (field_declaration_list)) @struct
+
+;; Preprocessor constants
+(preproc_def
+  name: (identifier) @name) @const
+
+;; Preprocessor function macros
+(preproc_function_def
+  name: (identifier) @name) @macro
+"#;
+
+/// Tree-sitter query for extracting function calls
+const CALL_QUERY: &str = r#"
+;; Direct function call
+(call_expression
+  function: (identifier) @callee)
+
+;; Qualified call (Class::method or ns::func)
+(call_expression
+  function: (qualified_identifier
+    name: (identifier) @callee))
+
+;; Member call (obj.method or ptr->method)
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @callee))
+
+;; Template function call (make_shared<T>())
+(call_expression
+  function: (template_function
+    name: (identifier) @callee))
+
+;; Qualified template call (std::make_shared<T>())
+(call_expression
+  function: (qualified_identifier
+    name: (template_function
+      name: (identifier) @callee)))
+
+;; new expression
+(new_expression
+  type: (type_identifier) @callee)
+"#;
+
+/// Tree-sitter query for extracting type references
+const TYPE_QUERY: &str = r#"
+;; Parameter types
+(parameter_declaration type: (type_identifier) @param_type)
+(parameter_declaration type: (qualified_identifier name: (type_identifier) @param_type))
+
+;; Return types
+(function_definition type: (type_identifier) @return_type)
+(function_definition type: (qualified_identifier name: (type_identifier) @return_type))
+
+;; Field types
+(field_declaration type: (type_identifier) @field_type)
+(field_declaration type: (qualified_identifier name: (type_identifier) @field_type))
+
+;; Base class / inheritance
+(base_class_clause (type_identifier) @impl_type)
+(base_class_clause (qualified_identifier name: (type_identifier) @impl_type))
+(base_class_clause (template_type name: (type_identifier) @impl_type))
+
+;; Template arguments
+(template_argument_list (type_identifier) @type_ref)
+
+;; Using alias source type (alias_declaration wraps in type_descriptor)
+(alias_declaration type: (type_descriptor type: (type_identifier) @alias_type))
+
+;; Catch-all
+(type_identifier) @type_ref
+"#;
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    "if", "else", "for", "while", "do", "switch", "case", "break", "continue", "return",
+    "class", "struct", "enum", "namespace", "template", "typename", "using", "typedef",
+    "virtual", "override", "final", "const", "static", "inline", "explicit", "extern", "friend",
+    "public", "private", "protected", "void", "int", "char", "float", "double", "long", "short",
+    "unsigned", "signed", "auto", "new", "delete", "this", "true", "false", "nullptr", "sizeof",
+    "dynamic_cast", "static_cast", "reinterpret_cast", "const_cast", "throw", "try", "catch",
+    "noexcept", "operator", "concept", "requires", "constexpr", "consteval", "constinit",
+    "mutable", "volatile", "co_await", "co_yield", "co_return", "decltype",
+];
+
+const COMMON_TYPES: &[&str] = &[
+    "string", "wstring", "string_view", "vector", "map", "unordered_map", "set", "unordered_set",
+    "multimap", "multiset", "list", "deque", "array", "forward_list", "pair", "tuple", "optional",
+    "variant", "any", "expected", "shared_ptr", "unique_ptr", "weak_ptr", "function", "size_t",
+    "ptrdiff_t", "int8_t", "int16_t", "int32_t", "int64_t", "uint8_t", "uint16_t", "uint32_t",
+    "uint64_t", "nullptr_t", "span", "basic_string", "iterator", "const_iterator",
+    "reverse_iterator", "ostream", "istream", "iostream", "fstream", "ifstream", "ofstream",
+    "stringstream", "istringstream", "ostringstream", "thread", "mutex", "recursive_mutex",
+    "condition_variable", "atomic", "future", "promise", "exception", "runtime_error",
+    "logic_error", "invalid_argument", "out_of_range", "overflow_error", "bad_alloc", "type_info",
+    "initializer_list", "allocator", "hash", "equal_to", "less", "greater", "reference_wrapper",
+    "bitset", "complex", "regex", "chrono",
+];
+
+/// Extract parent type from a function's own declarator.
+/// For out-of-class methods: `void MyClass::method()` → Some("MyClass").
+fn extract_qualified_method(node: tree_sitter::Node, source: &str) -> Option<String> {
+    // function_definition > declarator: function_declarator > declarator: qualified_identifier
+    let func_decl = node.child_by_field_name("declarator")?;
+    let inner_decl = func_decl.child_by_field_name("declarator")?;
+    if inner_decl.kind() != "qualified_identifier" {
+        return None;
+    }
+    let scope = inner_decl.child_by_field_name("scope")?;
+    Some(source[scope.byte_range()].to_string())
+}
+
+fn extract_return(signature: &str) -> Option<String> {
+    // Check for trailing return type: auto foo() -> ReturnType
+    if let Some(paren) = signature.rfind(')') {
+        let after = &signature[paren + 1..];
+        if let Some(arrow) = after.find("->") {
+            let ret_part = after[arrow + 2..].trim();
+            // Take until '{' or end
+            let end = ret_part.find('{').unwrap_or(ret_part.len());
+            let ret_type = ret_part[..end].trim();
+            if !ret_type.is_empty() {
+                let ret_words = crate::nl::tokenize_identifier(ret_type).join(" ");
+                return Some(format!("Returns {}", ret_words));
+            }
+        }
+    }
+
+    // C-style prefix extraction: return type before function name
+    if let Some(paren) = signature.find('(') {
+        let before = signature[..paren].trim();
+        let words: Vec<&str> = before.split_whitespace().collect();
+        if words.len() >= 2 {
+            let type_words: Vec<&str> = words[..words.len() - 1]
+                .iter()
+                .filter(|w| {
+                    !matches!(
+                        **w,
+                        "static"
+                            | "inline"
+                            | "extern"
+                            | "const"
+                            | "volatile"
+                            | "virtual"
+                            | "explicit"
+                            | "friend"
+                            | "constexpr"
+                            | "consteval"
+                            | "constinit"
+                            | "auto"
+                    )
+                })
+                .copied()
+                .collect();
+            if !type_words.is_empty() && type_words != ["void"] {
+                let ret = type_words.join(" ");
+                let ret_words = crate::nl::tokenize_identifier(&ret).join(" ");
+                return Some(format!("Returns {}", ret_words));
+            }
+        }
+    }
+    None
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "cpp",
+    grammar: Some(|| tree_sitter_cpp::LANGUAGE.into()),
+    extensions: &["cpp", "cxx", "cc", "hpp", "hxx", "hh", "ipp"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &["class_specifier", "struct_specifier"],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/tests/{stem}_test.cpp")),
+    type_query: Some(TYPE_QUERY),
+    common_types: COMMON_TYPES,
+    container_body_kinds: &["field_declaration_list"],
+    extract_container_name: None,
+    extract_qualified_method: Some(extract_qualified_method),
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn test_extract_return_cpp() {
+        // Prefix return type
+        assert_eq!(
+            extract_return("int add(int a, int b)"),
+            Some("Returns int".to_string())
+        );
+        // Trailing return type
+        assert_eq!(
+            extract_return("auto add(int a, int b) -> int"),
+            Some("Returns int".to_string())
+        );
+        // auto deduction (no ->)
+        assert_eq!(extract_return("auto foo()"), None);
+        // void
+        assert_eq!(extract_return("void doSomething()"), None);
+        // With specifiers
+        assert_eq!(
+            extract_return("static inline int getValue()"),
+            Some("Returns int".to_string())
+        );
+        // virtual with qualified type (tokenize_identifier preserves ::)
+        assert_eq!(
+            extract_return("virtual std::string getName()"),
+            Some("Returns std::string".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_cpp_free_function() {
+        let content = "void foo() {\n  // body\n}\n";
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "foo").unwrap();
+        assert_eq!(func.chunk_type, ChunkType::Function);
+        assert!(func.parent_type_name.is_none());
+    }
+
+    #[test]
+    fn parse_cpp_class() {
+        let content = r#"
+class Calculator {
+public:
+    int add(int a, int b) {
+        return a + b;
+    }
+};
+"#;
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let class = chunks.iter().find(|c| c.name == "Calculator").unwrap();
+        assert_eq!(class.chunk_type, ChunkType::Class);
+    }
+
+    #[test]
+    fn parse_cpp_struct() {
+        let content = "struct Point {\n  double x;\n  double y;\n};\n";
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let s = chunks.iter().find(|c| c.name == "Point").unwrap();
+        assert_eq!(s.chunk_type, ChunkType::Struct);
+    }
+
+    #[test]
+    fn parse_cpp_namespace() {
+        let content = r#"
+namespace utils {
+    void helper() {}
+}
+"#;
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let ns = chunks.iter().find(|c| c.name == "utils").unwrap();
+        assert_eq!(ns.chunk_type, ChunkType::Module);
+    }
+
+    #[test]
+    fn parse_cpp_concept() {
+        let content = r#"
+template<typename T>
+concept Printable = requires(T t) {
+    { t.print() } -> std::same_as<void>;
+};
+"#;
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let concept = chunks.iter().find(|c| c.name == "Printable").unwrap();
+        assert_eq!(concept.chunk_type, ChunkType::Trait);
+    }
+
+    #[test]
+    fn parse_cpp_using_alias() {
+        let content = "using StringVec = std::vector<std::string>;\n";
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let ta = chunks.iter().find(|c| c.name == "StringVec").unwrap();
+        assert_eq!(ta.chunk_type, ChunkType::TypeAlias);
+    }
+
+    #[test]
+    fn parse_cpp_typedef() {
+        let content = "typedef unsigned long size_type;\n";
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let ta = chunks.iter().find(|c| c.name == "size_type").unwrap();
+        assert_eq!(ta.chunk_type, ChunkType::TypeAlias);
+    }
+
+    #[test]
+    fn parse_cpp_method_in_class() {
+        let content = r#"
+class Calculator {
+public:
+    int add(int a, int b) {
+        return a + b;
+    }
+};
+"#;
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let names: Vec<_> = chunks.iter().map(|c| format!("{}:{:?}", c.name, c.chunk_type)).collect();
+        let method = chunks.iter().find(|c| c.name == "add").unwrap_or_else(|| panic!("Expected 'add', found: {:?}", names));
+        assert_eq!(method.chunk_type, ChunkType::Method);
+        assert_eq!(method.parent_type_name.as_deref(), Some("Calculator"));
+    }
+
+    #[test]
+    fn parse_cpp_out_of_class_method() {
+        let content = r#"
+class Foo {
+public:
+    void bar();
+};
+
+void Foo::bar() {
+    // implementation
+}
+"#;
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        // Find the out-of-class definition (the one with a body)
+        let methods: Vec<_> = chunks.iter().filter(|c| c.name == "bar").collect();
+        let impl_method = methods.iter().find(|c| c.chunk_type == ChunkType::Method);
+        assert!(impl_method.is_some(), "Expected out-of-class method, got: {:?}", methods.iter().map(|c| (&c.name, &c.chunk_type)).collect::<Vec<_>>());
+        assert_eq!(impl_method.unwrap().parent_type_name.as_deref(), Some("Foo"));
+    }
+
+    #[test]
+    fn parse_cpp_destructor_inline() {
+        let content = r#"
+class Resource {
+public:
+    ~Resource() {
+        cleanup();
+    }
+};
+"#;
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let dtor = chunks.iter().find(|c| c.name.contains("Resource") && c.name.contains("~"));
+        assert!(dtor.is_some(), "Expected destructor, got: {:?}", chunks.iter().map(|c| &c.name).collect::<Vec<_>>());
+        // Destructor inside class body should be Method
+        assert_eq!(dtor.unwrap().chunk_type, ChunkType::Method);
+    }
+
+    #[test]
+    fn parse_cpp_destructor_out_of_class() {
+        let content = r#"
+class Foo {
+public:
+    ~Foo();
+};
+
+Foo::~Foo() {
+    // cleanup
+}
+"#;
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let dtors: Vec<_> = chunks.iter().filter(|c| c.name.contains("~")).collect();
+        assert!(!dtors.is_empty(), "Expected destructor, got: {:?}", chunks.iter().map(|c| &c.name).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn parse_cpp_enum_class() {
+        let content = "enum class Color { Red, Green, Blue };\n";
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let e = chunks.iter().find(|c| c.name == "Color").unwrap();
+        assert_eq!(e.chunk_type, ChunkType::Enum);
+    }
+
+    #[test]
+    fn parse_cpp_union() {
+        let content = "union Data {\n  int i;\n  float f;\n};\n";
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let u = chunks.iter().find(|c| c.name == "Data").unwrap();
+        assert_eq!(u.chunk_type, ChunkType::Struct);
+    }
+
+    #[test]
+    fn parse_cpp_template_class() {
+        let content = r#"
+template<typename T>
+class Container {
+public:
+    void add(T item) {}
+};
+"#;
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let class = chunks.iter().find(|c| c.name == "Container").unwrap();
+        assert_eq!(class.chunk_type, ChunkType::Class);
+    }
+
+    #[test]
+    fn parse_cpp_calls() {
+        let content = r#"
+void process() {
+    auto x = transform(input);
+    obj.method();
+    ptr->cleanup();
+    auto p = std::make_shared<Foo>(42);
+    auto w = new Widget();
+}
+"#;
+        let file = write_temp_file(content, "cpp");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "process").unwrap();
+        let calls = parser.extract_calls_from_chunk(func);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(names.contains(&"transform"), "Expected transform, got: {:?}", names);
+        assert!(names.contains(&"method"), "Expected method, got: {:?}", names);
+        assert!(names.contains(&"cleanup"), "Expected cleanup, got: {:?}", names);
+    }
+}

--- a/src/language/csharp.rs
+++ b/src/language/csharp.rs
@@ -159,6 +159,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     common_types: COMMON_TYPES,
     container_body_kinds: &["declaration_list"],
     extract_container_name: None,
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/fsharp.rs
+++ b/src/language/fsharp.rs
@@ -200,6 +200,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     common_types: COMMON_TYPES,
     container_body_kinds: &[],
     extract_container_name: Some(extract_container_name_fsharp),
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/go.rs
+++ b/src/language/go.rs
@@ -206,6 +206,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     ],
     container_body_kinds: &[],
     extract_container_name: None,
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/java.rs
+++ b/src/language/java.rs
@@ -135,6 +135,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     ],
     container_body_kinds: &["class_body"],
     extract_container_name: None,
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -72,6 +72,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     ],
     container_body_kinds: &["class_body"],
     extract_container_name: None,
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/markdown.rs
+++ b/src/language/markdown.rs
@@ -31,6 +31,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     common_types: &[],
     container_body_kinds: &[],
     extract_container_name: None,
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/powershell.rs
+++ b/src/language/powershell.rs
@@ -93,6 +93,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     common_types: COMMON_TYPES,
     container_body_kinds: &[],
     extract_container_name: Some(extract_container_name_ps),
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -91,6 +91,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     ],
     container_body_kinds: &[],
     extract_container_name: None,
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/ruby.rs
+++ b/src/language/ruby.rs
@@ -58,6 +58,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     common_types: &[],
     container_body_kinds: &[],
     extract_container_name: None,
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -163,6 +163,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     common_types: COMMON_TYPES,
     container_body_kinds: &[],
     extract_container_name: Some(extract_container_name_rust),
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/scala.rs
+++ b/src/language/scala.rs
@@ -140,6 +140,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     common_types: COMMON_TYPES,
     container_body_kinds: &["template_body"],
     extract_container_name: None,
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/sql.rs
+++ b/src/language/sql.rs
@@ -84,6 +84,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     common_types: &[],
     container_body_kinds: &[],
     extract_container_name: None,
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -132,6 +132,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     ],
     container_body_kinds: &["class_body"],
     extract_container_name: None,
+    extract_qualified_method: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -982,6 +982,7 @@ fn another() {
             Language::CSharp,
             // FSharp type query has pre-existing compile issues (#node-type mismatch)
             Language::Scala,
+            Language::Cpp,
         ];
         for lang in languages_with_types {
             let result = parser.get_type_query(lang);

--- a/src/parser/chunk.rs
+++ b/src/parser/chunk.rs
@@ -228,6 +228,14 @@ fn infer_chunk_type(
         return (ChunkType::Method, parent_type);
     }
 
+    // Check if the function has a qualified name (e.g., C++ out-of-class methods)
+    if let Some(extractor) = def.extract_qualified_method {
+        if let Some(class_name) = extractor(node, source) {
+            tracing::debug!(class = %class_name, "Qualified method inference");
+            return (ChunkType::Method, Some(class_name));
+        }
+    }
+
     // Walk parents looking for method containers (e.g., impl blocks, class bodies)
     let mut current = node.parent();
     while let Some(parent) = current {

--- a/tests/eval_common.rs
+++ b/tests/eval_common.rs
@@ -24,6 +24,8 @@ pub fn fixture_path(lang: Language) -> PathBuf {
         Language::JavaScript => "js",
         Language::Go => "go",
         Language::C => "c",
+        #[cfg(feature = "lang-cpp")]
+        Language::Cpp => "cpp",
         Language::Java => "java",
         #[cfg(feature = "lang-csharp")]
         Language::CSharp => "cs",
@@ -54,6 +56,8 @@ pub fn hard_fixture_path(lang: Language) -> PathBuf {
         Language::JavaScript => "js",
         Language::Go => "go",
         Language::C => "c",
+        #[cfg(feature = "lang-cpp")]
+        Language::Cpp => "cpp",
         Language::Java => "java",
         #[cfg(feature = "lang-csharp")]
         Language::CSharp => "cs",


### PR DESCRIPTION
## Summary

- **C++ language support** — 15th language. Full tree-sitter parsing with 16 chunk query patterns covering classes, structs, unions, enums (`enum class`), namespaces, functions, inline methods, out-of-class methods (`Class::method`), destructors (inline + out-of-class), concepts (C++20), type aliases (`using`/`typedef`), preprocessor macros and constants.
- **Call graph extraction** — direct calls, member calls (`.` and `->`), qualified calls (`ns::func`), template function calls (`make_shared<T>()`), and `new` expressions.
- **Type dependency extraction** — parameter types, return types, field types, base class clauses (including template types), template arguments, and alias source types.
- **New `extract_qualified_method` infrastructure** on `LanguageDef` — enables out-of-class method inference for C++ `void Foo::bar() {}` patterns. Examines function_definition's declarator for `qualified_identifier`, extracts scope prefix as `parent_type_name`. All 14 existing languages set to `None`.

## Files Changed (26)

- `src/language/cpp.rs` — NEW: full C++ language module (CHUNK_QUERY, CALL_QUERY, TYPE_QUERY, extract_qualified_method, extract_return, 16 tests)
- `src/language/mod.rs` — `extract_qualified_method` field on LanguageDef, Cpp language registration, test updates
- `src/parser/chunk.rs` — `extract_qualified_method` call in `infer_chunk_type` with tracing
- `src/parser/calls.rs` — Cpp added to `test_type_queries_compile`
- `Cargo.toml` — tree-sitter-cpp 0.23, `lang-cpp` feature flag
- 14 existing language modules — `extract_qualified_method: None`
- `tests/eval_common.rs` — Cpp match arms
- Docs: README, CHANGELOG, CONTRIBUTING, ROADMAP, PROJECT_CONTINUITY

## Test plan

- [x] 16 new C++ tests (chunk parsing, calls, extract_return, all construct types)
- [x] Full test suite: 1166 pass + 35 ignored, 0 failures
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
