### PR TITLE
chore: release v0.18.0 — C++ language support (#492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-02-26
+
 ### Added
-- **C++ language support** — 15th language. Tree-sitter parsing for classes, structs, unions, enums (including `enum class`), namespaces, functions, inline methods, out-of-class methods (`Class::method`), destructors, concepts (C++20), type aliases (`using`/`typedef`), preprocessor macros and constants. Call graph extraction (direct, member, qualified, template function calls, `new` expressions). Type dependency extraction (parameters, return types, fields, base classes, template arguments). Out-of-class method inference via `extract_qualified_method` infrastructure. Behind `lang-cpp` feature flag (enabled by default).
+- **C++ language support** (#492) — 15th language. Tree-sitter parsing for classes, structs, unions, enums (including `enum class`), namespaces, functions, inline methods, out-of-class methods (`Class::method`), destructors, concepts (C++20), type aliases (`using`/`typedef`), preprocessor macros and constants. Call graph extraction (direct, member, qualified, template function calls, `new` expressions). Type dependency extraction (parameters, return types, fields, base classes, template arguments). Out-of-class method inference via `extract_qualified_method` infrastructure. Behind `lang-cpp` feature flag (enabled by default).
 - **`extract_qualified_method` on LanguageDef** — new optional field for languages where methods can be defined outside their class body (C++ `void Foo::bar() {}`). Infers `ChunkType::Method` + `parent_type_name` from the function's own declarator before parent-walking.
 
 ### Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,13 +2,13 @@
 
 ## Right Now
 
-**C++ language support (15th language).** 2026-02-26. Branch: `feat/cpp-language-support`.
+**Releasing v0.18.0.** 2026-02-26.
 
-All 16 C++ tests pass + full suite green (1166 pass + 35 ignored). Docs updated. Ready for commit + PR.
+C++ language support shipped (PR #492). 15th language. 1166 tests, 0 failures.
 
 ## Pending Changes
 
-C++ language support on `feat/cpp-language-support` branch, uncommitted.
+None — releasing v0.18.0.
 
 ## Parked
 
@@ -35,7 +35,7 @@ C++ language support on `feat/cpp-language-support` branch, uncommitted.
 
 ## Architecture
 
-- Version: 0.17.0
+- Version: 0.18.0
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current: v0.17.0
+## Current: v0.18.0
 
 All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 15 languages.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - **Semantic search**: Uses E5-base-v2 embeddings (769-dim: 768 model + sentiment)
 //! - **Notes with sentiment**: Unified memory system for AI collaborators
-//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, Markdown
+//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, SQL, Markdown
 //! - **GPU acceleration**: CUDA/TensorRT with CPU fallback
 //! - **CLI tools**: Call graph, impact analysis, test mapping, dead code detection
 //! - **Document conversion**: PDF, HTML, CHM → cleaned Markdown (optional `convert` feature)


### PR DESCRIPTION
## Summary

- Version bump 0.17.0 → 0.18.0
- Changelog finalized with C++ language support (#492)
- Docs review: fixed stale language list in lib.rs (9 → 15 languages)
- ROADMAP version header updated
- PROJECT_CONTINUITY updated for release
