### PR TITLE
feat: add Bash + HCL/Terraform language support (17 languages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Bash/Shell language support** — 16th language. Tree-sitter parsing for functions and command calls. Behind `lang-bash` feature flag (enabled by default).
+- **HCL/Terraform language support** — 17th language. Tree-sitter parsing for resources, data sources, variables, outputs, modules, and providers. Qualified naming support (e.g., `aws_instance.web`). Call graph extraction (HCL built-in function calls like `lookup`, `format`, `toset`). Behind `lang-hcl` feature flag (enabled by default).
+- **`post_process_chunk` hook on LanguageDef** — optional field for language-specific chunk reclassification (used by HCL for qualified naming).
+
 ## [0.18.0] - 2026-02-26
 
 ### Added
@@ -1073,7 +1078,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI commands: init, doctor, index, stats, serve
 - Filter by language (`-l`) and path pattern (`-p`)
 
-[Unreleased]: https://github.com/jamie8johnson/cqs/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/jamie8johnson/cqs/compare/v0.18.0...HEAD
 [0.13.0]: https://github.com/jamie8johnson/cqs/compare/v0.12.12...v0.13.0
 [0.12.12]: https://github.com/jamie8johnson/cqs/compare/v0.12.11...v0.12.12
 [0.12.11]: https://github.com/jamie8johnson/cqs/compare/v0.12.10...v0.12.11

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ src/
     watch.rs    - File watcher for incremental reindexing
   language/     - Tree-sitter language support
     mod.rs      - Language enum, LanguageRegistry, LanguageDef, ChunkType
-    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, sql.rs, markdown.rs
+    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, sql.rs, markdown.rs
   source/       - Source abstraction layer
     mod.rs      - Source trait
     filesystem.rs - File-based source implementation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,11 +669,13 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tree-sitter",
+ "tree-sitter-bash",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
  "tree-sitter-fsharp",
  "tree-sitter-go",
+ "tree-sitter-hcl",
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-powershell",
@@ -3942,6 +3944,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-bash"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-c"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3986,6 +3998,16 @@ name = "tree-sitter-go"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-hcl"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7b2cc3d7121553b84309fab9d11b3ff3d420403eef9ae50f9fd1cd9d9cf012"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cqs"
 version = "0.18.0"
 edition = "2021"
 rust-version = "1.93"
-description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."
+description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 17 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."
 license = "MIT"
 repository = "https://github.com/jamie8johnson/cqs"
 homepage = "https://github.com/jamie8johnson/cqs"
@@ -41,6 +41,8 @@ tree-sitter-fsharp = { version = "0.1", optional = true }
 tree-sitter-powershell = { version = "0.26", optional = true }
 tree-sitter-scala = { version = "0.24", optional = true }
 tree-sitter-ruby = { version = "0.23", optional = true }
+tree-sitter-bash = { version = "0.23", optional = true }
+tree-sitter-hcl = { version = "1.1", optional = true }
 tree-sitter-sql = { version = "0.4", package = "tree-sitter-sequel-tsql", optional = true }
 
 # ML
@@ -106,7 +108,7 @@ self_cell = "1"
 libc = "0.2"
 
 [features]
-default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-sql", "lang-markdown", "convert"]
+default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-sql", "lang-markdown", "convert"]
 
 # Language support (opt-in, all enabled by default)
 lang-rust = ["dep:tree-sitter-rust"]
@@ -122,9 +124,11 @@ lang-fsharp = ["dep:tree-sitter-fsharp"]
 lang-powershell = ["dep:tree-sitter-powershell"]
 lang-scala = ["dep:tree-sitter-scala"]
 lang-ruby = ["dep:tree-sitter-ruby"]
+lang-bash = ["dep:tree-sitter-bash"]
+lang-hcl = ["dep:tree-sitter-hcl"]
 lang-sql = ["dep:tree-sitter-sql"]
 lang-markdown = []  # No external deps — custom parser
-lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-sql", "lang-markdown"]
+lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-sql", "lang-markdown"]
 
 # Document conversion
 convert = ["dep:fast_html2md", "dep:walkdir"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code intelligence and RAG for AI agents. Semantic search, call graph analysis, impact tracing, type dependencies, and smart context assembly — all in single tool calls. Local ML embeddings, GPU-accelerated.
 
-**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval.
+**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval. 17 languages, GPU-accelerated.
 
 [![Crates.io](https://img.shields.io/crates/v/cqs.svg)](https://crates.io/crates/cqs)
 [![CI](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml/badge.svg)](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml)
@@ -419,6 +419,8 @@ Keep index fresh: run `cqs watch` in a background terminal, or `cqs index` after
 - PowerShell (functions, classes, methods, properties, enums, command calls)
 - Scala (classes, objects, traits, enums, functions, val/var bindings, type aliases)
 - Ruby (classes, modules, methods, singleton methods)
+- Bash (functions, command calls)
+- HCL (resources, data sources, variables, outputs, modules, providers with qualified naming)
 - SQL (T-SQL, PostgreSQL)
 - Markdown (.md, .mdx — heading-based chunking with cross-reference extraction)
 
@@ -437,7 +439,7 @@ cqs index --dry-run    # Show what would be indexed
 
 **Parse → Embed → Index → Reason**
 
-1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 15 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
+1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 17 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
 2. **Describe** — Each code element gets a natural language description incorporating doc comments, parameter types, return types, and parent type context (e.g., methods include their struct/class name). This bridges the gap between how developers describe code and how it's written.
 3. **Embed** — E5-base-v2 generates 769-dimensional embeddings (768 semantic + 1 sentiment) locally. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval — outperforms code-specific models because NL descriptions play to general-purpose model strengths.
 4. **Index** — SQLite stores chunks, embeddings, call graph edges, and type dependency edges. HNSW provides fast approximate nearest-neighbor search. FTS5 enables keyword matching.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current: v0.18.0
 
-All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 15 languages.
+All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 17 languages.
 
 ### Recently Completed
 
@@ -70,11 +70,11 @@ Priority order based on competitive gap analysis (Feb 2026).
 ### Future Languages — Priority Order
 
 **Tier 1 — High value, easy mapping:**
-- [ ] **Shell/Bash** — Function only. Every project has scripts, nobody indexes them semantically. `tree-sitter-bash` mature. Easiest win.
-- [x] **C++** — Biggest gap by dev population. All variants mapped: namespace → Module, concept → Trait, `#define` → Macro/Constant, union → Struct, typedef/using → TypeAlias. `tree-sitter-cpp` mature.
+- [x] **Shell/Bash** — 16th language. Function only. Every project has scripts, nobody indexes them semantically. `tree-sitter-bash` mature.
+- [x] **C++** — 15th language. Biggest gap by dev population. All variants mapped: namespace → Module, concept → Trait, `#define` → Macro/Constant, union → Struct, typedef/using → TypeAlias. `tree-sitter-cpp` mature.
 
 **Tier 2 — Structured schemas (better RAG, not just code search):**
-- [ ] **Terraform/HCL** — resource/data → Struct, module → Module, variable/output → Constant. Huge market. People search Terraform the same way they search docs.
+- [x] **Terraform/HCL** — 17th language. resource/data → Struct, module → Module, variable/output → Constant. Huge market. People search Terraform the same way they search docs. Qualified naming (aws_instance.web).
 - [ ] **Protobuf** — message → Struct, service → Interface, rpc → Function, enum → Enum. Every microservices shop has `.proto` files.
 - [ ] **GraphQL** — type/input → Struct, query/mutation/subscription → Function, interface → Interface, enum → Enum. Every web API shop has these.
 

--- a/src/language/bash.rs
+++ b/src/language/bash.rs
@@ -1,0 +1,211 @@
+//! Bash/Shell language definition
+
+use super::{LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting Bash function definitions
+const CHUNK_QUERY: &str = r#"
+;; Function definitions (both `function foo() {}` and `foo() {}` syntaxes)
+(function_definition
+  name: (word) @name) @function
+"#;
+
+/// Tree-sitter query for extracting command invocations
+const CALL_QUERY: &str = r#"
+;; Command invocations (function calls, builtins, externals)
+(command
+  name: (command_name) @callee)
+"#;
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    "if", "then", "else", "elif", "fi", "for", "do", "done", "while", "until", "case", "esac",
+    "in", "function", "return", "exit", "export", "local", "declare", "readonly", "unset", "shift",
+    "set", "eval", "exec", "source", "true", "false", "echo", "printf", "read", "test",
+];
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "bash",
+    grammar: Some(|| tree_sitter_bash::LANGUAGE.into()),
+    extensions: &["sh", "bash"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &[],
+    stopwords: STOPWORDS,
+    extract_return_nl: |_| None,
+    test_file_suggestion: None,
+    type_query: None,
+    common_types: &[],
+    container_body_kinds: &[],
+    extract_container_name: None,
+    extract_qualified_method: None,
+    post_process_chunk: None,
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_bash_function() {
+        let content = r#"
+function foo() {
+    echo "hello"
+}
+"#;
+        let file = write_temp_file(content, "sh");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].name, "foo");
+        assert_eq!(chunks[0].chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_bash_function_short() {
+        let content = r#"
+foo() {
+    echo "hello"
+}
+"#;
+        let file = write_temp_file(content, "sh");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].name, "foo");
+        assert_eq!(chunks[0].chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_bash_calls() {
+        let content = r#"
+function deploy() {
+    echo "deploying..."
+    grep -r "TODO" src/
+    run_tests
+}
+"#;
+        let file = write_temp_file(content, "sh");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "deploy").unwrap();
+        let calls = parser.extract_calls_from_chunk(func);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(names.contains(&"echo"), "Expected echo, got: {:?}", names);
+        assert!(names.contains(&"grep"), "Expected grep, got: {:?}", names);
+        assert!(
+            names.contains(&"run_tests"),
+            "Expected run_tests, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn parse_bash_multiline() {
+        let content = r#"
+function setup_env() {
+    local env_name="$1"
+    if [ -z "$env_name" ]; then
+        echo "Usage: setup_env <name>"
+        return 1
+    fi
+    export ENV_NAME="$env_name"
+    echo "Environment set to $env_name"
+}
+"#;
+        let file = write_temp_file(content, "sh");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].name, "setup_env");
+        assert!(chunks[0].content.contains("local env_name"));
+    }
+
+    #[test]
+    fn parse_bash_nested_calls() {
+        let content = r#"
+function build() {
+    compile_sources
+    run_tests
+    package_artifacts
+}
+
+function compile_sources() {
+    gcc -o main main.c
+}
+"#;
+        let file = write_temp_file(content, "sh");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert_eq!(chunks.len(), 2);
+        let build = chunks.iter().find(|c| c.name == "build").unwrap();
+        let calls = parser.extract_calls_from_chunk(build);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(
+            names.contains(&"compile_sources"),
+            "Expected compile_sources, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"run_tests"),
+            "Expected run_tests, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn parse_bash_no_chunks_outside_function() {
+        let content = r#"
+#!/bin/bash
+echo "standalone command"
+ls -la
+# This is a comment
+"#;
+        let file = write_temp_file(content, "sh");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert!(
+            chunks.is_empty(),
+            "Expected no chunks for bare commands, got: {:?}",
+            chunks.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn parse_bash_doc_comment() {
+        let content = r#"
+# Deploy the application to production
+function deploy() {
+    echo "deploying"
+}
+"#;
+        let file = write_temp_file(content, "sh");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "deploy").unwrap();
+        assert!(
+            func.doc.as_ref().map_or(false, |d| d.contains("Deploy")),
+            "Expected doc comment, got: {:?}",
+            func.doc
+        );
+    }
+}

--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -130,6 +130,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &[],
     extract_container_name: None,
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/cpp.rs
+++ b/src/language/cpp.rs
@@ -254,6 +254,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &["field_declaration_list"],
     extract_container_name: None,
     extract_qualified_method: Some(extract_qualified_method),
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/csharp.rs
+++ b/src/language/csharp.rs
@@ -160,6 +160,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &["declaration_list"],
     extract_container_name: None,
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/fsharp.rs
+++ b/src/language/fsharp.rs
@@ -201,6 +201,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &[],
     extract_container_name: Some(extract_container_name_fsharp),
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/go.rs
+++ b/src/language/go.rs
@@ -207,6 +207,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &[],
     extract_container_name: None,
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/hcl.rs
+++ b/src/language/hcl.rs
@@ -1,0 +1,379 @@
+//! HCL/Terraform language definition
+
+use super::{ChunkType, LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting HCL blocks.
+///
+/// All HCL blocks are generic `block` nodes. The `post_process_chunk` hook
+/// determines the actual name and ChunkType based on the block's first identifier
+/// (resource/variable/module/etc.) and string labels.
+const CHUNK_QUERY: &str = r#"
+;; All blocks — post_process_chunk determines name and type
+(block
+  (identifier) @name) @struct
+"#;
+
+/// Tree-sitter query for extracting HCL function calls
+const CALL_QUERY: &str = r#"
+;; HCL built-in function calls (lookup, format, toset, file, etc.)
+(function_call
+  (identifier) @callee)
+"#;
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    "resource",
+    "data",
+    "variable",
+    "output",
+    "module",
+    "provider",
+    "terraform",
+    "locals",
+    "backend",
+    "required_providers",
+    "required_version",
+    "count",
+    "for_each",
+    "depends_on",
+    "lifecycle",
+    "provisioner",
+    "connection",
+    "source",
+    "version",
+    "type",
+    "default",
+    "description",
+    "sensitive",
+    "validation",
+    "condition",
+    "error_message",
+    "true",
+    "false",
+    "null",
+    "each",
+    "self",
+    "var",
+    "local",
+    "path",
+];
+
+/// Post-process HCL blocks to determine correct name and ChunkType.
+///
+/// HCL's tree-sitter grammar represents all blocks as generic `block` nodes.
+/// This hook walks the block's children to extract the block type (first identifier)
+/// and string labels, then assigns the correct ChunkType and qualified name.
+///
+/// Filters out:
+/// - Nested blocks (provisioner/lifecycle inside resources)
+/// - Blocks with no labels (locals, terraform, required_providers)
+fn post_process_hcl(
+    name: &mut String,
+    chunk_type: &mut ChunkType,
+    node: tree_sitter::Node,
+    source: &str,
+) -> bool {
+    let _span = tracing::debug_span!("post_process_hcl", name = %name).entered();
+
+    // Filter nested blocks: if parent is a body whose parent is another block, skip.
+    // This prevents provisioner/lifecycle/connection inside resources from becoming chunks.
+    if let Some(parent) = node.parent() {
+        if parent.kind() == "body" {
+            if let Some(grandparent) = parent.parent() {
+                if grandparent.kind() == "block" {
+                    tracing::debug!("Skipping nested block inside parent block");
+                    return false;
+                }
+            }
+        }
+    }
+
+    let mut block_type = None;
+    let mut labels: Vec<String> = Vec::new();
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "identifier" if block_type.is_none() => {
+                block_type = Some(source[child.byte_range()].to_string());
+            }
+            "string_lit" => {
+                // Extract template_literal content (quote-free)
+                let mut inner = child.walk();
+                let mut found = false;
+                for c in child.children(&mut inner) {
+                    if c.kind() == "template_literal" {
+                        labels.push(source[c.byte_range()].to_string());
+                        found = true;
+                    }
+                }
+                if !found {
+                    // string_lit with no template_literal (empty string or interpolation-only)
+                    tracing::trace!("string_lit with no template_literal child, skipping label");
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let bt = block_type.as_deref().unwrap_or("");
+
+    // Skip blocks with no labels (locals, terraform, required_providers)
+    if labels.is_empty() {
+        tracing::debug!(block_type = bt, "Skipping block with no labels");
+        return false;
+    }
+
+    // Safe label access — guaranteed non-empty after check above
+    let last_label = &labels[labels.len() - 1];
+
+    match bt {
+        "resource" | "data" => {
+            *chunk_type = ChunkType::Struct;
+            *name = if labels.len() >= 2 {
+                format!("{}.{}", labels[0], labels[1])
+            } else {
+                last_label.clone()
+            };
+        }
+        "variable" | "output" => {
+            *chunk_type = ChunkType::Constant;
+            *name = last_label.clone();
+        }
+        "module" => {
+            *chunk_type = ChunkType::Module;
+            *name = last_label.clone();
+        }
+        _ => {
+            // provider, backend, unknown block types → Struct
+            *chunk_type = ChunkType::Struct;
+            *name = last_label.clone();
+        }
+    }
+
+    tracing::debug!(
+        block_type = bt,
+        name = %name,
+        chunk_type = ?chunk_type,
+        "Reclassified HCL block"
+    );
+    true
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "hcl",
+    grammar: Some(|| tree_sitter_hcl::LANGUAGE.into()),
+    extensions: &["tf", "tfvars", "hcl"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &[],
+    stopwords: STOPWORDS,
+    extract_return_nl: |_| None,
+    test_file_suggestion: None,
+    type_query: None,
+    common_types: &[],
+    container_body_kinds: &[],
+    extract_container_name: None,
+    extract_qualified_method: None,
+    post_process_chunk: Some(post_process_hcl),
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_hcl_resource() {
+        let content = r#"
+resource "aws_instance" "web" {
+  ami           = "ami-12345"
+  instance_type = "t2.micro"
+}
+"#;
+        let file = write_temp_file(content, "tf");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].name, "aws_instance.web");
+        assert_eq!(chunks[0].chunk_type, ChunkType::Struct);
+    }
+
+    #[test]
+    fn parse_hcl_data() {
+        let content = r#"
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]
+}
+"#;
+        let file = write_temp_file(content, "tf");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].name, "aws_ami.ubuntu");
+        assert_eq!(chunks[0].chunk_type, ChunkType::Struct);
+    }
+
+    #[test]
+    fn parse_hcl_variable() {
+        let content = r#"
+variable "name" {
+  type    = string
+  default = "world"
+}
+"#;
+        let file = write_temp_file(content, "tf");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].name, "name");
+        assert_eq!(chunks[0].chunk_type, ChunkType::Constant);
+    }
+
+    #[test]
+    fn parse_hcl_output() {
+        let content = r#"
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+"#;
+        let file = write_temp_file(content, "tf");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].name, "vpc_id");
+        assert_eq!(chunks[0].chunk_type, ChunkType::Constant);
+    }
+
+    #[test]
+    fn parse_hcl_module() {
+        let content = r#"
+module "vpc" {
+  source = "./modules/vpc"
+  cidr   = "10.0.0.0/16"
+}
+"#;
+        let file = write_temp_file(content, "tf");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].name, "vpc");
+        assert_eq!(chunks[0].chunk_type, ChunkType::Module);
+    }
+
+    #[test]
+    fn parse_hcl_locals_skipped() {
+        let content = r#"
+locals {
+  common_tags = {
+    Environment = "dev"
+  }
+}
+"#;
+        let file = write_temp_file(content, "tf");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert!(
+            chunks.is_empty(),
+            "locals block should be filtered out, got: {:?}",
+            chunks.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn parse_hcl_calls() {
+        let content = r#"
+variable "tags" {
+  default = lookup(var.base_tags, "env", "dev")
+}
+"#;
+        let file = write_temp_file(content, "tf");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let var = chunks.iter().find(|c| c.name == "tags").unwrap();
+        let calls = parser.extract_calls_from_chunk(var);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(
+            names.contains(&"lookup"),
+            "Expected lookup call, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn parse_hcl_provider() {
+        let content = r#"
+provider "aws" {
+  region = "us-east-1"
+}
+"#;
+        let file = write_temp_file(content, "tf");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].name, "aws");
+        assert_eq!(chunks[0].chunk_type, ChunkType::Struct);
+    }
+
+    #[test]
+    fn parse_hcl_empty_body() {
+        let content = r#"
+variable "x" {}
+"#;
+        let file = write_temp_file(content, "tf");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].name, "x");
+        assert_eq!(chunks[0].chunk_type, ChunkType::Constant);
+    }
+
+    #[test]
+    fn parse_hcl_nested_blocks() {
+        let content = r#"
+resource "aws_instance" "web" {
+  ami           = "ami-12345"
+  instance_type = "t2.micro"
+
+  provisioner "local-exec" {
+    command = "echo hello"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+"#;
+        let file = write_temp_file(content, "tf");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        // Only the top-level resource should be captured, not provisioner or lifecycle
+        assert_eq!(
+            chunks.len(),
+            1,
+            "Expected only resource, got: {:?}",
+            chunks.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+        assert_eq!(chunks[0].name, "aws_instance.web");
+    }
+}

--- a/src/language/java.rs
+++ b/src/language/java.rs
@@ -136,6 +136,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &["class_body"],
     extract_container_name: None,
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -73,6 +73,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &["class_body"],
     extract_container_name: None,
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/markdown.rs
+++ b/src/language/markdown.rs
@@ -32,6 +32,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &[],
     extract_container_name: None,
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/powershell.rs
+++ b/src/language/powershell.rs
@@ -94,6 +94,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &[],
     extract_container_name: Some(extract_container_name_ps),
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -92,6 +92,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &[],
     extract_container_name: None,
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/ruby.rs
+++ b/src/language/ruby.rs
@@ -59,6 +59,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &[],
     extract_container_name: None,
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -164,6 +164,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &[],
     extract_container_name: Some(extract_container_name_rust),
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/scala.rs
+++ b/src/language/scala.rs
@@ -141,6 +141,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &["template_body"],
     extract_container_name: None,
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/sql.rs
+++ b/src/language/sql.rs
@@ -85,6 +85,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &[],
     extract_container_name: None,
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -133,6 +133,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     container_body_kinds: &["class_body"],
     extract_container_name: None,
     extract_qualified_method: None,
+    post_process_chunk: None,
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - **Semantic search**: Uses E5-base-v2 embeddings (769-dim: 768 model + sentiment)
 //! - **Notes with sentiment**: Unified memory system for AI collaborators
-//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, SQL, Markdown
+//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, SQL, Markdown (17 languages)
 //! - **GPU acceleration**: CUDA/TensorRT with CPU fallback
 //! - **CLI tools**: Call graph, impact analysis, test mapping, dead code detection
 //! - **Document conversion**: PDF, HTML, CHM → cleaned Markdown (optional `convert` feature)

--- a/tests/eval_common.rs
+++ b/tests/eval_common.rs
@@ -37,6 +37,10 @@ pub fn fixture_path(lang: Language) -> PathBuf {
         Language::Scala => "scala",
         #[cfg(feature = "lang-ruby")]
         Language::Ruby => "rb",
+        #[cfg(feature = "lang-bash")]
+        Language::Bash => "sh",
+        #[cfg(feature = "lang-hcl")]
+        Language::Hcl => "tf",
         Language::Sql => "sql",
         Language::Markdown => "md",
     };
@@ -69,6 +73,10 @@ pub fn hard_fixture_path(lang: Language) -> PathBuf {
         Language::Scala => "scala",
         #[cfg(feature = "lang-ruby")]
         Language::Ruby => "rb",
+        #[cfg(feature = "lang-bash")]
+        Language::Bash => "sh",
+        #[cfg(feature = "lang-hcl")]
+        Language::Hcl => "tf",
         Language::Sql => "sql",
         Language::Markdown => "md",
     };


### PR DESCRIPTION
## Summary

- **Bash/Shell language support** (16th language) — tree-sitter parsing for function definitions (both `function foo() {}` and `foo() {}` syntaxes), command call extraction, stopwords, doc comments. 7 tests.
- **HCL/Terraform language support** (17th language) — tree-sitter parsing for resources, data sources, variables, outputs, modules, and providers. Qualified naming (e.g., `aws_instance.web`). HCL built-in function call extraction (`lookup`, `format`, `toset`). Nested block filtering (provisioner/lifecycle blocks excluded). 10 tests.
- **`post_process_chunk` hook** — new `PostProcessChunkFn` field on `LanguageDef` for language-specific chunk reclassification after tree-sitter extraction. All 15 existing languages set `None`. HCL uses it to determine block types and qualified names from generic `block` nodes.
- **`extract_definition_node` helper** — shared utility in `parser/mod.rs` used by both `parse_file()` and `parse_file_relationships()` hook call sites.

## Test plan

- [x] `cargo test --features gpu-index` — 1183 pass, 0 fail, 35 ignored (+17 new tests)
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Bash: both function syntaxes, command calls, multiline, nested calls, bare commands filtered, doc comments
- [x] HCL: resource/data qualified naming, variable/output as Constant, module as Module, locals filtered, function calls, provider, empty body, nested blocks filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
