### PR TITLE
feat: add Kotlin, Swift, and Objective-C language support (20 languages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Bash/Shell language support** — 16th language. Tree-sitter parsing for functions and command calls. Behind `lang-bash` feature flag (enabled by default).
 - **HCL/Terraform language support** — 17th language. Tree-sitter parsing for resources, data sources, variables, outputs, modules, and providers. Qualified naming support (e.g., `aws_instance.web`). Call graph extraction (HCL built-in function calls like `lookup`, `format`, `toset`). Behind `lang-hcl` feature flag (enabled by default).
-- **`post_process_chunk` hook on LanguageDef** — optional field for language-specific chunk reclassification (used by HCL for qualified naming).
+- **Kotlin language support** — 18th language. Tree-sitter parsing for classes, interfaces, enum classes, objects, functions, properties, type aliases. Call graph extraction (function calls + property access). Type dependency extraction (parameter types, return types, property types, inheritance, interface implementation). Behind `lang-kotlin` feature flag (enabled by default).
+- **Swift language support** — 19th language. Tree-sitter parsing for classes, structs, enums, actors, protocols, extensions, functions, type aliases. Call graph extraction (function calls + property access + method calls). Type dependency extraction (parameter types, return types, property types, conformances). Behind `lang-swift` feature flag (enabled by default).
+- **Objective-C language support** — 20th language. Tree-sitter parsing for class interfaces, protocols, methods, properties, C functions. Call graph extraction (message sends + C function calls). Behind `lang-objc` feature flag (enabled by default).
+- **`post_process_chunk` hook on LanguageDef** — optional field for language-specific chunk reclassification (used by HCL for qualified naming; Kotlin for interface/enum reclassification; Swift for struct/enum/actor/extension reclassification).
 
 ## [0.18.0] - 2026-02-26
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ src/
     watch.rs    - File watcher for incremental reindexing
   language/     - Tree-sitter language support
     mod.rs      - Language enum, LanguageRegistry, LanguageDef, ChunkType
-    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, sql.rs, markdown.rs
+    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, kotlin.rs, swift.rs, objc.rs, sql.rs, markdown.rs
   source/       - Source abstraction layer
     mod.rs      - Source trait
     filesystem.rs - File-based source implementation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,12 +678,15 @@ dependencies = [
  "tree-sitter-hcl",
  "tree-sitter-java",
  "tree-sitter-javascript",
+ "tree-sitter-kotlin-ng",
+ "tree-sitter-objc",
  "tree-sitter-powershell",
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-scala",
  "tree-sitter-sequel-tsql",
+ "tree-sitter-swift",
  "tree-sitter-typescript",
  "walkdir",
 ]
@@ -4034,10 +4037,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-kotlin-ng"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e800ebbda938acfbf224f4d2c34947a31994b1295ee6e819b65226c7b51b4450"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-objc"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca8bb556423fc176f0535e79d525f783a6684d3c9da81bf9d905303c129e1d2"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-powershell"
@@ -4094,6 +4117,16 @@ name = "tree-sitter-sequel-tsql"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d02793ddf858f2fc6376c7c12d50a4a29797c834b8ddbafe752290d9cbdb59"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ef216011c3e3df4fa864736f347cb8d509b1066cf0c8549fb1fd81ac9832e59"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cqs"
 version = "0.18.0"
 edition = "2021"
 rust-version = "1.93"
-description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 17 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."
+description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 20 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."
 license = "MIT"
 repository = "https://github.com/jamie8johnson/cqs"
 homepage = "https://github.com/jamie8johnson/cqs"
@@ -43,6 +43,9 @@ tree-sitter-scala = { version = "0.24", optional = true }
 tree-sitter-ruby = { version = "0.23", optional = true }
 tree-sitter-bash = { version = "0.23", optional = true }
 tree-sitter-hcl = { version = "1.1", optional = true }
+tree-sitter-kotlin = { version = "1.1", package = "tree-sitter-kotlin-ng", optional = true }
+tree-sitter-swift = { version = "0.7", optional = true }
+tree-sitter-objc = { version = "3.0", optional = true }
 tree-sitter-sql = { version = "0.4", package = "tree-sitter-sequel-tsql", optional = true }
 
 # ML
@@ -108,7 +111,7 @@ self_cell = "1"
 libc = "0.2"
 
 [features]
-default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-sql", "lang-markdown", "convert"]
+default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-markdown", "convert"]
 
 # Language support (opt-in, all enabled by default)
 lang-rust = ["dep:tree-sitter-rust"]
@@ -126,9 +129,12 @@ lang-scala = ["dep:tree-sitter-scala"]
 lang-ruby = ["dep:tree-sitter-ruby"]
 lang-bash = ["dep:tree-sitter-bash"]
 lang-hcl = ["dep:tree-sitter-hcl"]
+lang-kotlin = ["dep:tree-sitter-kotlin"]
+lang-swift = ["dep:tree-sitter-swift"]
+lang-objc = ["dep:tree-sitter-objc"]
 lang-sql = ["dep:tree-sitter-sql"]
 lang-markdown = []  # No external deps — custom parser
-lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-sql", "lang-markdown"]
+lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-markdown"]
 
 # Document conversion
 convert = ["dep:fast_html2md", "dep:walkdir"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code intelligence and RAG for AI agents. Semantic search, call graph analysis, impact tracing, type dependencies, and smart context assembly — all in single tool calls. Local ML embeddings, GPU-accelerated.
 
-**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval. 17 languages, GPU-accelerated.
+**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval. 20 languages, GPU-accelerated.
 
 [![Crates.io](https://img.shields.io/crates/v/cqs.svg)](https://crates.io/crates/cqs)
 [![CI](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml/badge.svg)](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml)
@@ -421,6 +421,9 @@ Keep index fresh: run `cqs watch` in a background terminal, or `cqs index` after
 - Ruby (classes, modules, methods, singleton methods)
 - Bash (functions, command calls)
 - HCL (resources, data sources, variables, outputs, modules, providers with qualified naming)
+- Kotlin (classes, interfaces, enum classes, objects, functions, properties, type aliases)
+- Swift (classes, structs, enums, actors, protocols, extensions, functions, type aliases)
+- Objective-C (class interfaces, protocols, methods, properties, C functions)
 - SQL (T-SQL, PostgreSQL)
 - Markdown (.md, .mdx — heading-based chunking with cross-reference extraction)
 
@@ -439,7 +442,7 @@ cqs index --dry-run    # Show what would be indexed
 
 **Parse → Embed → Index → Reason**
 
-1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 17 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
+1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 20 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
 2. **Describe** — Each code element gets a natural language description incorporating doc comments, parameter types, return types, and parent type context (e.g., methods include their struct/class name). This bridges the gap between how developers describe code and how it's written.
 3. **Embed** — E5-base-v2 generates 769-dimensional embeddings (768 semantic + 1 sentiment) locally. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval — outperforms code-specific models because NL descriptions play to general-purpose model strengths.
 4. **Index** — SQLite stores chunks, embeddings, call graph edges, and type dependency edges. HNSW provides fast approximate nearest-neighbor search. FTS5 enables keyword matching.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current: v0.18.0
 
-All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 17 languages.
+All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 20 languages.
 
 ### Recently Completed
 
@@ -79,14 +79,14 @@ Priority order based on competitive gap analysis (Feb 2026).
 - [ ] **GraphQL** — type/input → Struct, query/mutation/subscription → Function, interface → Interface, enum → Enum. Every web API shop has these.
 
 **Tier 3 — Programming languages with clean mappings:**
-- [ ] **Kotlin** — Object (companion/singleton), TypeAlias, Property; data class → Struct, sealed class → Class
-- [ ] **Swift** — protocol → Trait, actor → Class, TypeAlias, Property. May need `Extension` variant (primary code org).
+- [x] **Kotlin** — 18th language. Classes, interfaces, enum classes, objects, functions, properties, type aliases. Call graph + type dependency extraction. post_process_chunk for interface/enum reclassification.
+- [x] **Swift** — 19th language. Classes, structs, enums, actors, protocols, extensions, functions, type aliases. Call graph + type dependency extraction. post_process_chunk for struct/enum/actor/extension reclassification.
+- [x] **Objective-C** — 20th language. Class interfaces, protocols, methods, properties, C functions. Call graph extraction (message sends + C calls). No type dependency extraction.
 - [ ] **Elixir** — Module + Macro exist. defprotocol → Trait, defrecord → Struct. Clean mapping.
 - [ ] **Lua** — Function-only. Game dev niche (Roblox, Neovim). Easy.
 - [ ] **Haskell** — TypeAlias exists. data → Enum, class → Trait. Niche but loved.
 - [ ] **PHP** — Property covers properties, trait → Trait
 - [ ] **Dart** — Property covers properties, mixin → Trait
-- [ ] **Objective-C** — Property covers `@property`, `@protocol` → Interface
 - [ ] **Zig** — maps cleanly
 
 ### ChunkType Variant Status

--- a/src/language/kotlin.rs
+++ b/src/language/kotlin.rs
@@ -1,0 +1,375 @@
+//! Kotlin language definition
+
+use super::{ChunkType, LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting Kotlin code chunks.
+///
+/// The kotlin-ng grammar uses `class_declaration` for both classes and interfaces,
+/// distinguished by an anonymous keyword child ("class" vs "interface").
+/// Enum classes have a `class_modifier` with text "enum" inside `modifiers`.
+/// The `post_process_chunk` hook reclassifies these after extraction.
+const CHUNK_QUERY: &str = r#"
+;; Classes (regular, data, sealed, abstract) and interfaces
+;; post_process_chunk reclassifies interfaces and enum classes
+(class_declaration
+  (identifier) @name) @class
+
+;; Object declarations (singletons)
+(object_declaration
+  (identifier) @name) @object
+
+;; Functions
+(function_declaration
+  (identifier) @name) @function
+
+;; Property declarations (val/var)
+(property_declaration
+  (variable_declaration
+    (identifier) @name)) @property
+
+;; Type aliases
+(type_alias
+  (identifier) @name) @typealias
+"#;
+
+/// Tree-sitter query for extracting Kotlin function calls
+const CALL_QUERY: &str = r#"
+;; Direct function calls
+(call_expression
+  (identifier) @callee)
+
+;; Method calls (object.method())
+(call_expression
+  (navigation_expression
+    (identifier) @callee))
+"#;
+
+/// Tree-sitter query for extracting Kotlin type references
+const TYPE_QUERY: &str = r#"
+;; Parameter types
+(parameter
+  (user_type (identifier) @param_type))
+
+;; Return types
+(function_declaration
+  (user_type (identifier) @return_type))
+
+;; Property types
+(property_declaration
+  (user_type (identifier) @field_type))
+
+;; Superclass / interface implementations
+(delegation_specifier
+  (user_type (identifier) @impl_type))
+
+;; Type alias right-hand side
+(type_alias
+  (user_type (identifier) @alias_type))
+
+;; Generic type arguments
+(type_arguments
+  (type_projection
+    (user_type (identifier) @type_ref)))
+
+;; Catch-all
+(user_type (identifier) @type_ref)
+"#;
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["line_comment", "multiline_comment"];
+
+const STOPWORDS: &[&str] = &[
+    "fun", "val", "var", "class", "interface", "object", "companion", "data", "sealed", "enum",
+    "abstract", "open", "override", "private", "protected", "public", "internal", "return", "if",
+    "else", "when", "for", "while", "do", "break", "continue", "this", "super", "import",
+    "package", "is", "as", "in", "null", "true", "false", "typealias", "const", "lateinit",
+    "suspend", "inline", "reified",
+];
+
+const COMMON_TYPES: &[&str] = &[
+    "String", "Int", "Long", "Double", "Float", "Boolean", "Byte", "Short", "Char", "Unit",
+    "Nothing", "Any", "List", "ArrayList", "Map", "HashMap", "Set", "HashSet", "Collection",
+    "MutableList", "MutableMap", "MutableSet", "Sequence", "Array", "Pair", "Triple", "Comparable",
+    "Iterable",
+];
+
+/// Post-process Kotlin chunks to reclassify `class_declaration` nodes.
+///
+/// The kotlin-ng grammar uses `class_declaration` for both classes and interfaces.
+/// This hook checks:
+/// 1. If an anonymous "interface" keyword child exists -> Interface
+/// 2. If `modifiers` contains a `class_modifier` with text "enum" -> Enum
+fn post_process_kotlin(
+    _name: &mut String,
+    chunk_type: &mut ChunkType,
+    node: tree_sitter::Node,
+    source: &str,
+) -> bool {
+    // Only reclassify class_declarations
+    if node.kind() != "class_declaration" {
+        return true;
+    }
+
+    let mut has_enum_modifier = false;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "modifiers" => {
+                let mut mod_cursor = child.walk();
+                for modifier in child.children(&mut mod_cursor) {
+                    if modifier.kind() == "class_modifier" {
+                        let text = &source[modifier.byte_range()];
+                        if text == "enum" {
+                            has_enum_modifier = true;
+                        }
+                    }
+                }
+            }
+            "interface" => {
+                *chunk_type = ChunkType::Interface;
+                return true;
+            }
+            _ => {}
+        }
+    }
+
+    if has_enum_modifier {
+        *chunk_type = ChunkType::Enum;
+    }
+    // else: stays as Class
+    true
+}
+
+fn extract_return(signature: &str) -> Option<String> {
+    // Kotlin: fun name(params): ReturnType { ... }
+    // Look for `: ReturnType` after last `)` and before `{` or `=`
+    let paren_pos = signature.rfind(')')?;
+    let after_paren = &signature[paren_pos + 1..];
+
+    // Find the terminator ({ or =)
+    let end_pos = after_paren
+        .find('{')
+        .or_else(|| after_paren.find('='))
+        .unwrap_or(after_paren.len());
+    let between = &after_paren[..end_pos];
+
+    // Look for colon
+    let colon_pos = between.find(':')?;
+    let ret_type = between[colon_pos + 1..].trim();
+    if ret_type.is_empty() || ret_type == "Unit" {
+        return None;
+    }
+
+    let ret_words = crate::nl::tokenize_identifier(ret_type).join(" ");
+    Some(format!("Returns {}", ret_words))
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "kotlin",
+    grammar: Some(|| tree_sitter_kotlin::LANGUAGE.into()),
+    extensions: &["kt", "kts"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &["class_body"],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/{stem}Test.kt")),
+    type_query: Some(TYPE_QUERY),
+    common_types: COMMON_TYPES,
+    container_body_kinds: &["class_body"],
+    extract_container_name: None,
+    extract_qualified_method: None,
+    post_process_chunk: Some(post_process_kotlin),
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn test_extract_return_kotlin() {
+        assert_eq!(
+            extract_return("fun add(a: Int, b: Int): Int {"),
+            Some("Returns int".to_string())
+        );
+        assert_eq!(extract_return("fun doSomething(): Unit {"), None);
+        assert_eq!(extract_return("fun doSomething() {"), None);
+        assert_eq!(
+            extract_return("fun getName(): String ="),
+            Some("Returns string".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_kotlin_data_class() {
+        let content = r#"
+data class Person(val name: String, val age: Int)
+"#;
+        let file = write_temp_file(content, "kt");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let class = chunks.iter().find(|c| c.name == "Person").unwrap();
+        assert_eq!(class.chunk_type, ChunkType::Class);
+    }
+
+    #[test]
+    fn parse_kotlin_interface() {
+        let content = r#"
+interface Printable {
+    fun print()
+    fun prettyPrint()
+}
+"#;
+        let file = write_temp_file(content, "kt");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let iface = chunks.iter().find(|c| c.name == "Printable").unwrap();
+        assert_eq!(iface.chunk_type, ChunkType::Interface);
+    }
+
+    #[test]
+    fn parse_kotlin_enum_class() {
+        let content = r#"
+enum class Color {
+    RED, GREEN, BLUE
+}
+"#;
+        let file = write_temp_file(content, "kt");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let e = chunks.iter().find(|c| c.name == "Color").unwrap();
+        assert_eq!(e.chunk_type, ChunkType::Enum);
+    }
+
+    #[test]
+    fn parse_kotlin_object() {
+        let content = r#"
+object Singleton {
+    fun greet(): String = "hello"
+}
+"#;
+        let file = write_temp_file(content, "kt");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let obj = chunks.iter().find(|c| c.name == "Singleton").unwrap();
+        assert_eq!(obj.chunk_type, ChunkType::Object);
+    }
+
+    #[test]
+    fn parse_kotlin_function() {
+        let content = r#"
+fun add(a: Int, b: Int): Int {
+    return a + b
+}
+"#;
+        let file = write_temp_file(content, "kt");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "add").unwrap();
+        assert_eq!(func.chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_kotlin_typealias() {
+        let content = "typealias StringMap = Map<String, String>\n";
+        let file = write_temp_file(content, "kt");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let ta = chunks.iter().find(|c| c.name == "StringMap").unwrap();
+        assert_eq!(ta.chunk_type, ChunkType::TypeAlias);
+    }
+
+    #[test]
+    fn parse_kotlin_calls() {
+        let content = r#"
+fun process(input: String): Int {
+    val trimmed = input.trim()
+    val result = parseInt(trimmed)
+    println(result)
+    return result
+}
+"#;
+        let file = write_temp_file(content, "kt");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "process").unwrap();
+        let calls = parser.extract_calls_from_chunk(func);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(
+            names.contains(&"parseInt"),
+            "Expected parseInt call, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"println"),
+            "Expected println call, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn parse_kotlin_property() {
+        let content = r#"
+val greeting: String = "hello"
+var counter: Int = 0
+"#;
+        let file = write_temp_file(content, "kt");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let val_chunk = chunks.iter().find(|c| c.name == "greeting").unwrap();
+        assert_eq!(val_chunk.chunk_type, ChunkType::Property);
+        let var_chunk = chunks.iter().find(|c| c.name == "counter").unwrap();
+        assert_eq!(var_chunk.chunk_type, ChunkType::Property);
+    }
+
+    #[test]
+    fn parse_kotlin_method_in_class() {
+        let content = r#"
+class Calculator {
+    fun add(a: Int, b: Int): Int {
+        return a + b
+    }
+}
+"#;
+        let file = write_temp_file(content, "kt");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let method = chunks.iter().find(|c| c.name == "add").unwrap();
+        assert_eq!(method.chunk_type, ChunkType::Method);
+        assert_eq!(method.parent_type_name.as_deref(), Some("Calculator"));
+    }
+
+    #[test]
+    fn parse_kotlin_sealed_class() {
+        let content = r#"
+sealed class Result {
+    data class Success(val data: String) : Result()
+    data class Error(val message: String) : Result()
+}
+"#;
+        let file = write_temp_file(content, "kt");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let sealed = chunks.iter().find(|c| c.name == "Result").unwrap();
+        assert_eq!(sealed.chunk_type, ChunkType::Class);
+    }
+}

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -22,6 +22,7 @@
 //! - `lang-ruby` - Ruby support (enabled by default)
 //! - `lang-bash` - Bash support (enabled by default)
 //! - `lang-hcl` - HCL/Terraform support (enabled by default)
+//! - `lang-kotlin` - Kotlin support (enabled by default)
 //! - `lang-all` - All languages
 
 use std::collections::HashMap;
@@ -423,6 +424,12 @@ define_languages! {
     Bash => "bash", feature = "lang-bash", module = bash;
     /// HCL/Terraform (.tf, .tfvars, .hcl files)
     Hcl => "hcl", feature = "lang-hcl", module = hcl;
+    /// Kotlin (.kt, .kts files)
+    Kotlin => "kotlin", feature = "lang-kotlin", module = kotlin;
+    /// Swift (.swift files)
+    Swift => "swift", feature = "lang-swift", module = swift;
+    /// Objective-C (.m, .mm files)
+    ObjC => "objc", feature = "lang-objc", module = objc;
     /// SQL (.sql files)
     Sql => "sql", feature = "lang-sql", module = sql;
     /// Markdown (.md, .mdx files)
@@ -558,6 +565,18 @@ mod tests {
             assert!(REGISTRY.from_extension("tfvars").is_some());
             assert!(REGISTRY.from_extension("hcl").is_some());
         }
+        #[cfg(feature = "lang-kotlin")]
+        {
+            assert!(REGISTRY.from_extension("kt").is_some());
+            assert!(REGISTRY.from_extension("kts").is_some());
+        }
+        #[cfg(feature = "lang-swift")]
+        assert!(REGISTRY.from_extension("swift").is_some());
+        #[cfg(feature = "lang-objc")]
+        {
+            assert!(REGISTRY.from_extension("m").is_some());
+            assert!(REGISTRY.from_extension("mm").is_some());
+        }
         #[cfg(feature = "lang-sql")]
         assert!(REGISTRY.from_extension("sql").is_some());
         #[cfg(feature = "lang-markdown")]
@@ -633,6 +652,18 @@ mod tests {
         {
             expected += 1;
         }
+        #[cfg(feature = "lang-kotlin")]
+        {
+            expected += 1;
+        }
+        #[cfg(feature = "lang-swift")]
+        {
+            expected += 1;
+        }
+        #[cfg(feature = "lang-objc")]
+        {
+            expected += 1;
+        }
         #[cfg(feature = "lang-sql")]
         {
             expected += 1;
@@ -700,6 +731,11 @@ mod tests {
         assert_eq!(Language::from_extension("tf"), Some(Language::Hcl));
         assert_eq!(Language::from_extension("tfvars"), Some(Language::Hcl));
         assert_eq!(Language::from_extension("hcl"), Some(Language::Hcl));
+        assert_eq!(Language::from_extension("kt"), Some(Language::Kotlin));
+        assert_eq!(Language::from_extension("kts"), Some(Language::Kotlin));
+        assert_eq!(Language::from_extension("swift"), Some(Language::Swift));
+        assert_eq!(Language::from_extension("m"), Some(Language::ObjC));
+        assert_eq!(Language::from_extension("mm"), Some(Language::ObjC));
         assert_eq!(Language::from_extension("sql"), Some(Language::Sql));
         assert_eq!(Language::from_extension("md"), Some(Language::Markdown));
         assert_eq!(Language::from_extension("mdx"), Some(Language::Markdown));
@@ -727,6 +763,9 @@ mod tests {
         assert_eq!("cpp".parse::<Language>().unwrap(), Language::Cpp);
         assert_eq!("bash".parse::<Language>().unwrap(), Language::Bash);
         assert_eq!("hcl".parse::<Language>().unwrap(), Language::Hcl);
+        assert_eq!("kotlin".parse::<Language>().unwrap(), Language::Kotlin);
+        assert_eq!("swift".parse::<Language>().unwrap(), Language::Swift);
+        assert_eq!("objc".parse::<Language>().unwrap(), Language::ObjC);
         assert_eq!("sql".parse::<Language>().unwrap(), Language::Sql);
         assert_eq!("markdown".parse::<Language>().unwrap(), Language::Markdown);
         assert!("invalid".parse::<Language>().is_err());
@@ -749,6 +788,9 @@ mod tests {
         assert_eq!(Language::Cpp.to_string(), "cpp");
         assert_eq!(Language::Bash.to_string(), "bash");
         assert_eq!(Language::Hcl.to_string(), "hcl");
+        assert_eq!(Language::Kotlin.to_string(), "kotlin");
+        assert_eq!(Language::Swift.to_string(), "swift");
+        assert_eq!(Language::ObjC.to_string(), "objc");
         assert_eq!(Language::Sql.to_string(), "sql");
         assert_eq!(Language::Markdown.to_string(), "markdown");
     }
@@ -905,6 +947,26 @@ mod tests {
         );
         assert_eq!(
             (Language::Hcl.def().extract_return_nl)("resource \"aws_instance\" \"web\""),
+            None
+        );
+        assert_eq!(
+            (Language::Kotlin.def().extract_return_nl)("fun add(a: Int, b: Int): Int {"),
+            Some("Returns int".to_string())
+        );
+        assert_eq!(
+            (Language::Kotlin.def().extract_return_nl)("fun doSomething(): Unit {"),
+            None
+        );
+        assert_eq!(
+            (Language::Swift.def().extract_return_nl)("func greet(name: String) -> String {"),
+            Some("Returns string".to_string())
+        );
+        assert_eq!(
+            (Language::Swift.def().extract_return_nl)("func doSomething() {"),
+            None
+        );
+        assert_eq!(
+            (Language::ObjC.def().extract_return_nl)("- (void)greet"),
             None
         );
     }

--- a/src/language/objc.rs
+++ b/src/language/objc.rs
@@ -1,0 +1,233 @@
+//! Objective-C language definition
+
+use super::{LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting Objective-C code chunks
+const CHUNK_QUERY: &str = r#"
+;; Class interfaces (@interface ... @end)
+(class_interface
+  (identifier) @name) @class
+
+;; Protocols (@protocol ... @end)
+(protocol_declaration
+  (identifier) @name) @interface
+
+;; Method declarations (in @interface or @protocol — no body)
+(method_declaration
+  (identifier) @name) @function
+
+;; Method definitions (in @implementation — with body)
+(method_definition
+  (identifier) @name) @function
+
+;; C-style free functions
+(function_definition
+  declarator: (function_declarator
+    declarator: (identifier) @name)) @function
+
+;; Properties with pointer types (@property NSString *name)
+(property_declaration
+  (struct_declaration
+    (struct_declarator
+      (pointer_declarator
+        (identifier) @name)))) @property
+
+;; Properties with value types (@property NSInteger age)
+(property_declaration
+  (struct_declaration
+    (struct_declarator
+      (identifier) @name))) @property
+"#;
+
+/// Tree-sitter query for extracting function calls
+const CALL_QUERY: &str = r#"
+;; Objective-C message sends [receiver method]
+(message_expression
+  (identifier) @callee)
+
+;; C function calls
+(call_expression
+  function: (identifier) @callee)
+"#;
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    "self", "super", "nil", "NULL", "YES", "NO", "true", "false", "if", "else", "for", "while",
+    "do", "switch", "case", "break", "continue", "return", "void", "int", "float", "double",
+    "char", "long", "short", "unsigned", "signed", "static", "extern", "const", "typedef",
+    "struct", "enum", "union", "id", "Class", "SEL", "IMP", "BOOL", "NSObject", "NSString",
+    "NSInteger", "NSUInteger", "CGFloat", "nonatomic", "strong", "weak", "copy", "assign",
+    "readonly", "readwrite", "atomic", "property", "synthesize", "dynamic", "interface",
+    "implementation", "protocol", "end", "optional", "required", "import", "include",
+];
+
+fn extract_return(_signature: &str) -> Option<String> {
+    // ObjC methods use `- (ReturnType)methodName` syntax which doesn't lend itself
+    // to simple text-based extraction. Return None.
+    None
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "objc",
+    grammar: Some(|| tree_sitter_objc::LANGUAGE.into()),
+    extensions: &["m", "mm"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &["class_interface", "implementation_definition", "protocol_declaration"],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/{stem}Tests.m")),
+    type_query: None,
+    common_types: &[],
+    container_body_kinds: &["implementation_definition"],
+    extract_container_name: None,
+    extract_qualified_method: None,
+    post_process_chunk: None,
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_objc_class_interface() {
+        let content = r#"
+@interface Person : NSObject
+@property (nonatomic) NSString *name;
+- (void)greet;
+@end
+"#;
+        let file = write_temp_file(content, "m");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let class = chunks.iter().find(|c| c.name == "Person").unwrap();
+        assert_eq!(class.chunk_type, ChunkType::Class);
+    }
+
+    #[test]
+    fn parse_objc_protocol() {
+        let content = r#"
+@protocol Drawable
+- (void)draw;
+@end
+"#;
+        let file = write_temp_file(content, "m");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let proto = chunks.iter().find(|c| c.name == "Drawable").unwrap();
+        assert_eq!(proto.chunk_type, ChunkType::Interface);
+    }
+
+    #[test]
+    fn parse_objc_method_declaration() {
+        let content = r#"
+@interface Calculator : NSObject
+- (int)add:(int)a to:(int)b;
++ (Calculator *)shared;
+@end
+"#;
+        let file = write_temp_file(content, "m");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let method = chunks.iter().find(|c| c.name == "add").unwrap();
+        assert_eq!(method.chunk_type, ChunkType::Method);
+        let class_method = chunks.iter().find(|c| c.name == "shared").unwrap();
+        assert_eq!(class_method.chunk_type, ChunkType::Method);
+    }
+
+    #[test]
+    fn parse_objc_method_definition() {
+        let content = r#"
+@implementation Person
+
+- (void)greet {
+    NSLog(@"Hello, %@", self.name);
+}
+
+@end
+"#;
+        let file = write_temp_file(content, "m");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let method = chunks.iter().find(|c| c.name == "greet").unwrap();
+        assert_eq!(method.chunk_type, ChunkType::Method);
+    }
+
+    #[test]
+    fn parse_objc_free_function() {
+        let content = "void freeFunc(int x) { }\n";
+        let file = write_temp_file(content, "m");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "freeFunc").unwrap();
+        assert_eq!(func.chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_objc_property() {
+        let content = r#"
+@interface Config : NSObject
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic) NSInteger count;
+@end
+"#;
+        let file = write_temp_file(content, "m");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let ptr_prop = chunks.iter().find(|c| c.name == "name").unwrap();
+        assert_eq!(ptr_prop.chunk_type, ChunkType::Property);
+        let val_prop = chunks.iter().find(|c| c.name == "count").unwrap();
+        assert_eq!(val_prop.chunk_type, ChunkType::Property);
+    }
+
+    #[test]
+    fn parse_objc_calls() {
+        let content = r#"
+@implementation Runner
+
+- (void)run {
+    [self greet];
+    NSLog(@"done");
+    free(ptr);
+}
+
+@end
+"#;
+        let parser = Parser::new().unwrap();
+        let lang = crate::parser::Language::ObjC;
+        let calls = parser.extract_calls(content, lang, 0, content.len(), 0);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        // Message sends
+        assert!(
+            names.contains(&"greet"),
+            "Expected greet call, got: {:?}",
+            names
+        );
+        // C function calls
+        assert!(
+            names.contains(&"free"),
+            "Expected free call, got: {:?}",
+            names
+        );
+    }
+}

--- a/src/language/swift.rs
+++ b/src/language/swift.rs
@@ -1,0 +1,424 @@
+//! Swift language definition
+
+use super::{ChunkType, LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting Swift code chunks.
+///
+/// Swift's tree-sitter grammar uses `class_declaration` for classes, structs,
+/// enums, actors, AND extensions. The `post_process_chunk` hook reclassifies
+/// based on keyword children and body type.
+const CHUNK_QUERY: &str = r#"
+;; Classes, structs, actors (all use class_declaration with direct type_identifier)
+;; post_process_chunk reclassifies based on keyword
+(class_declaration
+  (type_identifier) @name) @class
+
+;; Extensions — name comes from user_type, not direct type_identifier
+(class_declaration
+  (user_type
+    (type_identifier) @name)) @class
+
+;; Protocols
+(protocol_declaration
+  (type_identifier) @name) @trait
+
+;; Functions (top-level and methods)
+(function_declaration
+  (simple_identifier) @name) @function
+
+;; Protocol function declarations (signatures without body)
+(protocol_function_declaration
+  (simple_identifier) @name) @function
+
+;; Typealias
+(typealias_declaration
+  (type_identifier) @name) @typealias
+"#;
+
+/// Tree-sitter query for extracting Swift function calls
+const CALL_QUERY: &str = r#"
+;; Direct function calls
+(call_expression
+  (simple_identifier) @callee)
+
+;; Method calls via navigation
+(call_expression
+  (navigation_expression
+    (navigation_suffix
+      (simple_identifier) @callee)))
+"#;
+
+/// Tree-sitter query for extracting Swift type references
+const TYPE_QUERY: &str = r#"
+;; Parameter types
+(parameter
+  (user_type
+    (type_identifier) @param_type))
+
+;; Return types (after ->)
+(function_declaration
+  (user_type
+    (type_identifier) @return_type))
+
+;; Property types
+(property_declaration
+  (user_type
+    (type_identifier) @field_type))
+
+;; Protocol conformance / inheritance
+(inheritance_specifier
+  (user_type
+    (type_identifier) @impl_type))
+
+;; Catch-all
+(user_type
+  (type_identifier) @type_ref)
+"#;
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment", "multiline_comment"];
+
+const STOPWORDS: &[&str] = &[
+    "func", "var", "let", "class", "struct", "enum", "protocol", "extension", "actor", "import",
+    "return", "if", "else", "guard", "switch", "case", "for", "while", "repeat", "break",
+    "continue", "self", "super", "nil", "true", "false", "is", "as", "in", "try", "catch",
+    "throw", "throws", "async", "await", "public", "private", "internal", "open", "fileprivate",
+    "static", "final", "override", "mutating", "typealias", "where", "some", "any",
+];
+
+const COMMON_TYPES: &[&str] = &[
+    "String", "Int", "Double", "Float", "Bool", "Character", "UInt", "Int8", "Int16", "Int32",
+    "Int64", "UInt8", "UInt16", "UInt32", "UInt64", "Optional", "Array", "Dictionary", "Set",
+    "Any", "AnyObject", "Void", "Never", "Error", "Codable", "Equatable", "Hashable", "Comparable",
+    "Identifiable", "CustomStringConvertible",
+];
+
+fn extract_return(signature: &str) -> Option<String> {
+    // Swift: func name(params) -> ReturnType {
+    // Find "->" and extract the type between it and "{"
+    let arrow_pos = signature.find("->")?;
+    let after_arrow = &signature[arrow_pos + 2..];
+
+    let end_pos = after_arrow
+        .find('{')
+        .unwrap_or(after_arrow.len());
+    let ret_type = after_arrow[..end_pos].trim();
+
+    if ret_type.is_empty() || ret_type == "Void" {
+        return None;
+    }
+
+    let ret_words = crate::nl::tokenize_identifier(ret_type).join(" ");
+    Some(format!("Returns {}", ret_words))
+}
+
+/// Post-process Swift chunks to reclassify `class_declaration` into the correct type.
+///
+/// Swift's tree-sitter grammar uses `class_declaration` for all structural types:
+/// classes, structs, enums, actors, and extensions. We distinguish them by:
+/// - `enum_class_body` child → Enum
+/// - Anonymous "struct" keyword → Struct
+/// - Anonymous "actor" keyword → Class (actor treated as class)
+/// - Anonymous "extension" keyword → Class (extension treated as class)
+/// - Anonymous "class" keyword or default → Class
+fn post_process_swift(
+    _name: &mut String,
+    chunk_type: &mut ChunkType,
+    node: tree_sitter::Node,
+    source: &str,
+) -> bool {
+    if node.kind() != "class_declaration" {
+        return true;
+    }
+
+    let _span = tracing::debug_span!("post_process_swift", kind = node.kind()).entered();
+
+    let mut cursor = node.walk();
+    let mut has_enum_body = false;
+    let mut keyword = "";
+
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "enum_class_body" => has_enum_body = true,
+            _ if !child.is_named() => {
+                let text = &source[child.byte_range()];
+                match text {
+                    "struct" => keyword = "struct",
+                    "class" => keyword = "class",
+                    "actor" => keyword = "actor",
+                    "extension" => keyword = "extension",
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if has_enum_body {
+        *chunk_type = ChunkType::Enum;
+        tracing::debug!("Reclassified class_declaration as Enum (has enum_class_body)");
+    } else {
+        match keyword {
+            "struct" => {
+                *chunk_type = ChunkType::Struct;
+                tracing::debug!("Reclassified class_declaration as Struct");
+            }
+            "actor" => {
+                // Actor → Class (closest semantic match)
+                tracing::debug!("Reclassified class_declaration as Class (actor)");
+            }
+            "extension" => {
+                // Extension → Class (closest semantic match)
+                tracing::debug!("Reclassified class_declaration as Class (extension)");
+            }
+            _ => {
+                // "class" or unknown — default @class stays
+            }
+        }
+    }
+
+    true
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "swift",
+    grammar: Some(|| tree_sitter_swift::LANGUAGE.into()),
+    extensions: &["swift"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &["class_body"],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/{stem}Tests.swift")),
+    type_query: Some(TYPE_QUERY),
+    common_types: COMMON_TYPES,
+    container_body_kinds: &["class_body", "protocol_body"],
+    extract_container_name: None,
+    extract_qualified_method: None,
+    post_process_chunk: Some(post_process_swift),
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn test_extract_return_swift() {
+        assert_eq!(
+            extract_return("func greet(name: String) -> String {"),
+            Some("Returns string".to_string())
+        );
+        assert_eq!(extract_return("func doSomething() {"), None);
+        assert_eq!(
+            extract_return("func getCount() -> Int {"),
+            Some("Returns int".to_string())
+        );
+        assert_eq!(extract_return("func nothing() -> Void {"), None);
+    }
+
+    #[test]
+    fn parse_swift_class() {
+        let content = r#"
+class Shape {
+    var sides: Int = 0
+
+    func describe() -> String {
+        return "A shape with \(sides) sides"
+    }
+}
+"#;
+        let file = write_temp_file(content, "swift");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let class = chunks.iter().find(|c| c.name == "Shape").unwrap();
+        assert_eq!(class.chunk_type, ChunkType::Class);
+    }
+
+    #[test]
+    fn parse_swift_struct() {
+        let content = r#"
+struct Point {
+    var x: Double
+    var y: Double
+}
+"#;
+        let file = write_temp_file(content, "swift");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let s = chunks.iter().find(|c| c.name == "Point").unwrap();
+        assert_eq!(s.chunk_type, ChunkType::Struct);
+    }
+
+    #[test]
+    fn parse_swift_enum() {
+        let content = r#"
+enum Direction {
+    case north
+    case south
+    case east
+    case west
+}
+"#;
+        let file = write_temp_file(content, "swift");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let e = chunks.iter().find(|c| c.name == "Direction").unwrap();
+        assert_eq!(e.chunk_type, ChunkType::Enum);
+    }
+
+    #[test]
+    fn parse_swift_protocol() {
+        let content = r#"
+protocol Drawable {
+    func draw()
+}
+"#;
+        let file = write_temp_file(content, "swift");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let p = chunks.iter().find(|c| c.name == "Drawable").unwrap();
+        assert_eq!(p.chunk_type, ChunkType::Trait);
+    }
+
+    #[test]
+    fn parse_swift_function() {
+        let content = r#"
+func greet(name: String) -> String {
+    return "Hello, \(name)!"
+}
+"#;
+        let file = write_temp_file(content, "swift");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "greet").unwrap();
+        assert_eq!(func.chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_swift_actor() {
+        let content = r#"
+actor Counter {
+    var count: Int = 0
+
+    func increment() {
+        count += 1
+    }
+}
+"#;
+        let file = write_temp_file(content, "swift");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let a = chunks.iter().find(|c| c.name == "Counter").unwrap();
+        assert_eq!(a.chunk_type, ChunkType::Class);
+    }
+
+    #[test]
+    fn parse_swift_extension() {
+        let content = r#"
+struct Point {
+    var x: Double
+    var y: Double
+}
+
+extension Point {
+    func distance() -> Double {
+        return (x * x + y * y).squareRoot()
+    }
+}
+"#;
+        let file = write_temp_file(content, "swift");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        // Both the struct and the extension should have name "Point"
+        let point_chunks: Vec<_> = chunks.iter().filter(|c| c.name == "Point").collect();
+        assert!(
+            point_chunks.len() >= 2,
+            "Expected at least 2 Point chunks (struct + extension), got: {}",
+            point_chunks.len()
+        );
+        // The struct should be Struct type
+        assert!(
+            point_chunks.iter().any(|c| c.chunk_type == ChunkType::Struct),
+            "Expected one Point to be Struct"
+        );
+        // The extension should be Class type
+        assert!(
+            point_chunks.iter().any(|c| c.chunk_type == ChunkType::Class),
+            "Expected one Point to be Class (extension)"
+        );
+    }
+
+    #[test]
+    fn parse_swift_typealias() {
+        let content = "typealias StringMap = Dictionary<String, String>\n";
+        let file = write_temp_file(content, "swift");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let ta = chunks.iter().find(|c| c.name == "StringMap").unwrap();
+        assert_eq!(ta.chunk_type, ChunkType::TypeAlias);
+    }
+
+    #[test]
+    fn parse_swift_calls() {
+        let content = r#"
+func process(input: String) -> Int {
+    let trimmed = input.trimmingCharacters(in: .whitespaces)
+    let result = transform(trimmed)
+    print(result)
+    return result.count
+}
+"#;
+        let file = write_temp_file(content, "swift");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "process").unwrap();
+        let calls = parser.extract_calls_from_chunk(func);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(
+            names.contains(&"transform"),
+            "Expected transform call, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"print"),
+            "Expected print call, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn parse_swift_method_in_class() {
+        let content = r#"
+class Calculator {
+    func add(a: Int, b: Int) -> Int {
+        return a + b
+    }
+}
+"#;
+        let file = write_temp_file(content, "swift");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let method = chunks.iter().find(|c| c.name == "add").unwrap();
+        assert_eq!(method.chunk_type, ChunkType::Method);
+        assert_eq!(method.parent_type_name.as_deref(), Some("Calculator"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - **Semantic search**: Uses E5-base-v2 embeddings (769-dim: 768 model + sentiment)
 //! - **Notes with sentiment**: Unified memory system for AI collaborators
-//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, SQL, Markdown (17 languages)
+//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Markdown (20 languages)
 //! - **GPU acceleration**: CUDA/TensorRT with CPU fallback
 //! - **CLI tools**: Call graph, impact analysis, test mapping, dead code detection
 //! - **Document conversion**: PDF, HTML, CHM → cleaned Markdown (optional `convert` feature)

--- a/tests/eval_common.rs
+++ b/tests/eval_common.rs
@@ -41,6 +41,12 @@ pub fn fixture_path(lang: Language) -> PathBuf {
         Language::Bash => "sh",
         #[cfg(feature = "lang-hcl")]
         Language::Hcl => "tf",
+        #[cfg(feature = "lang-kotlin")]
+        Language::Kotlin => "kt",
+        #[cfg(feature = "lang-swift")]
+        Language::Swift => "swift",
+        #[cfg(feature = "lang-objc")]
+        Language::ObjC => "m",
         Language::Sql => "sql",
         Language::Markdown => "md",
     };
@@ -77,6 +83,12 @@ pub fn hard_fixture_path(lang: Language) -> PathBuf {
         Language::Bash => "sh",
         #[cfg(feature = "lang-hcl")]
         Language::Hcl => "tf",
+        #[cfg(feature = "lang-kotlin")]
+        Language::Kotlin => "kt",
+        #[cfg(feature = "lang-swift")]
+        Language::Swift => "swift",
+        #[cfg(feature = "lang-objc")]
+        Language::ObjC => "m",
         Language::Sql => "sql",
         Language::Markdown => "md",
     };


### PR DESCRIPTION
## Summary

- **Kotlin language support** (18th language) — tree-sitter-kotlin-ng 1.1. Classes, interfaces, enum classes, objects, functions, properties, type aliases. Call graph + type dependency extraction. `post_process_chunk` for interface/enum reclassification from generic `class_declaration`. 11 tests.
- **Swift language support** (19th language) — tree-sitter-swift 0.7. Classes, structs, enums, actors, protocols, extensions, functions, type aliases. Call graph + type dependency extraction. `post_process_chunk` for struct/enum/actor/extension reclassification (all share `class_declaration` node in tree-sitter-swift). 11 tests.
- **Objective-C language support** (20th language) — tree-sitter-objc 3.0. Class interfaces, protocols, methods (declaration + definition), properties, C functions. Call graph extraction (message sends + C calls). No type dependency extraction. 7 tests.

## Test plan

- [x] `cargo test --features gpu-index` — 1212 pass, 0 fail (+29 new tests)
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Kotlin: data class, interface, enum class, object, function, typealias, property, sealed class, method-in-class, calls
- [x] Swift: class, struct, enum, protocol, function, actor, extension, typealias, method-in-class, calls
- [x] ObjC: class interface, protocol, method declaration, method definition, free function, property, calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
