### PR TITLE
chore: release v0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 20 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."


### PR DESCRIPTION
## Summary

- Version bump 0.19.0 → 0.19.1
- Changelog for v0.19.1 audit fixes (12 P1 + 9 P2)

## Test plan

- [x] `cargo test --features gpu-index` — 1212 pass, 0 fail
- [x] `cargo clippy --features gpu-index` — clean
- [x] Docs review — all current

🤖 Generated with [Claude Code](https://claude.com/claude-code)
