### PR TITLE
fix: deferred P2 audit fixes — 10 items (#499)

### DIFF
--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -10,6 +10,7 @@
 mod commands;
 mod handlers;
 mod pipeline;
+mod types;
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};

--- a/src/cli/batch/types.rs
+++ b/src/cli/batch/types.rs
@@ -1,0 +1,52 @@
+//! Typed output structs for batch JSON responses.
+//!
+//! Replaces manual `serde_json::json!` assembly with `#[derive(Serialize)]` structs
+//! for chunk-shaped output. Ensures consistent field names and path normalization.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+/// Normalize a path for JSON output: forward slashes, no backslashes.
+pub(super) fn normalize_path(p: &Path) -> String {
+    p.to_string_lossy().replace('\\', "/")
+}
+
+/// Common chunk output shape used by search, similar, and other handlers.
+///
+/// Fields match the existing JSON output exactly — this is a refactor, not a schema change.
+#[derive(Serialize)]
+pub(super) struct ChunkOutput {
+    pub name: String,
+    pub file: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub language: String,
+    pub chunk_type: String,
+    pub score: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+}
+
+impl ChunkOutput {
+    /// Build from a SearchResult (search, name-only search).
+    pub fn from_search_result(r: &cqs::store::SearchResult, include_content: bool) -> Self {
+        Self {
+            name: r.chunk.name.clone(),
+            file: normalize_path(&r.chunk.file),
+            line_start: r.chunk.line_start,
+            line_end: r.chunk.line_end,
+            language: r.chunk.language.to_string(),
+            chunk_type: r.chunk.chunk_type.to_string(),
+            score: r.score,
+            signature: Some(r.chunk.signature.clone()),
+            content: if include_content {
+                Some(r.chunk.content.clone())
+            } else {
+                None
+            },
+        }
+    }
+}

--- a/src/cli/commands/context.rs
+++ b/src/cli/commands/context.rs
@@ -4,7 +4,7 @@
 //! `compact_to_json`, `full_to_json`) so batch mode can reuse them without
 //! duplicating ~120 lines.
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context as _, Result};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
@@ -23,7 +23,9 @@ pub(crate) struct CompactData {
 
 /// Build compact-mode data: chunks with caller/callee counts.
 pub(crate) fn build_compact_data(store: &Store, path: &str) -> Result<CompactData> {
-    let chunks = store.get_chunks_by_origin(path)?;
+    let chunks = store
+        .get_chunks_by_origin(path)
+        .context("Failed to load chunks for file")?;
     if chunks.is_empty() {
         bail!(
             "No indexed chunks found for '{}'. Is the file indexed?",
@@ -79,7 +81,9 @@ pub(crate) struct FullData {
 ///
 /// Shared between CLI summary mode (uses counts) and full mode (uses details).
 pub(crate) fn build_full_data(store: &Store, path: &str, root: &Path) -> Result<FullData> {
-    let chunks = store.get_chunks_by_origin(path)?;
+    let chunks = store
+        .get_chunks_by_origin(path)
+        .context("Failed to load chunks for file")?;
     if chunks.is_empty() {
         bail!(
             "No indexed chunks found for '{}'. Is the file indexed?",

--- a/src/cli/commands/dead.rs
+++ b/src/cli/commands/dead.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use cqs::store::{DeadConfidence, DeadFunction};
 
 use crate::cli::Cli;
@@ -16,7 +16,9 @@ pub(crate) fn cmd_dead(
 ) -> Result<()> {
     let _span = tracing::info_span!("cmd_dead").entered();
     let (store, root, _) = crate::cli::open_project_store()?;
-    let (confident, possibly_pub) = store.find_dead_code(include_pub)?;
+    let (confident, possibly_pub) = store
+        .find_dead_code(include_pub)
+        .context("Failed to detect dead code")?;
 
     // Filter by minimum confidence
     let confident: Vec<_> = confident

--- a/src/cli/commands/deps.rs
+++ b/src/cli/commands/deps.rs
@@ -2,7 +2,7 @@
 //!
 //! Shows which chunks reference a type (forward), or what types a function uses (reverse).
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use colored::Colorize;
 
 use crate::cli::Cli;
@@ -16,7 +16,9 @@ pub(crate) fn cmd_deps(_cli: &Cli, name: &str, reverse: bool, json: bool) -> Res
     let (store, root, _) = crate::cli::open_project_store()?;
 
     if reverse {
-        let types = store.get_types_used_by(name)?;
+        let types = store
+            .get_types_used_by(name)
+            .context("Failed to load type dependencies")?;
         if json {
             let json_types: Vec<serde_json::Value> = types
                 .iter()
@@ -44,7 +46,9 @@ pub(crate) fn cmd_deps(_cli: &Cli, name: &str, reverse: bool, json: bool) -> Res
             println!("Total: {} type(s)", types.len());
         }
     } else {
-        let users = store.get_type_users(name)?;
+        let users = store
+            .get_type_users(name)
+            .context("Failed to load type users")?;
         if json {
             let json_users: Vec<serde_json::Value> = users
                 .iter()

--- a/src/cli/commands/gc.rs
+++ b/src/cli/commands/gc.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashSet;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 
 use cqs::Parser;
 
@@ -38,15 +38,21 @@ pub(crate) fn cmd_gc(json: bool) -> Result<()> {
     };
 
     // Count chunks to prune before deleting HNSW
-    let pruned_chunks = store.prune_missing(&file_set)?;
+    let pruned_chunks = store
+        .prune_missing(&file_set)
+        .context("Failed to prune deleted files from index")?;
     tracing::debug!(pruned_chunks, "Chunks pruned");
 
     // Prune orphan call graph entries
-    let pruned_calls = store.prune_stale_calls()?;
+    let pruned_calls = store
+        .prune_stale_calls()
+        .context("Failed to prune orphan call graph entries")?;
     tracing::debug!(pruned_calls, "Calls pruned");
 
     // Prune orphan type edges
-    let pruned_type_edges = store.prune_stale_type_edges()?;
+    let pruned_type_edges = store
+        .prune_stale_type_edges()
+        .context("Failed to prune orphan type edges")?;
     tracing::debug!(pruned_type_edges, "Type edges pruned");
 
     // Rebuild HNSW if we pruned chunks. Delete the stale HNSW first so

--- a/src/cli/commands/graph.rs
+++ b/src/cli/commands/graph.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides callers/callees analysis.
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use colored::Colorize;
 
 use crate::cli::Cli;
@@ -12,7 +12,9 @@ pub(crate) fn cmd_callers(_cli: &Cli, name: &str, json: bool) -> Result<()> {
     let _span = tracing::info_span!("cmd_callers", name).entered();
     let (store, _, _) = crate::cli::open_project_store()?;
     // Use full call graph (includes large functions)
-    let callers = store.get_callers_full(name)?;
+    let callers = store
+        .get_callers_full(name)
+        .context("Failed to load callers")?;
 
     if callers.is_empty() {
         if json {
@@ -59,7 +61,9 @@ pub(crate) fn cmd_callees(_cli: &Cli, name: &str, json: bool) -> Result<()> {
     let (store, _, _) = crate::cli::open_project_store()?;
     // Use full call graph (includes large functions)
     // No file context available from CLI input — pass None
-    let callees = store.get_callees_full(name, None)?;
+    let callees = store
+        .get_callees_full(name, None)
+        .context("Failed to load callees")?;
 
     if json {
         let json_output = serde_json::json!({

--- a/src/cli/commands/query.rs
+++ b/src/cli/commands/query.rs
@@ -428,7 +428,9 @@ fn cmd_query_name_only(
     root: &std::path::Path,
 ) -> Result<()> {
     let _span = tracing::info_span!("cmd_query_name_only", query).entered();
-    let results = store.search_by_name(query, cli.limit)?;
+    let results = store
+        .search_by_name(query, cli.limit)
+        .context("Failed to search by name")?;
 
     if results.is_empty() {
         if cli.json {

--- a/src/cli/commands/test_map.rs
+++ b/src/cli/commands/test_map.rs
@@ -1,6 +1,6 @@
 //! Test map command — find tests that exercise a function
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use super::resolve::resolve_target;
@@ -16,8 +16,12 @@ pub(crate) fn cmd_test_map(
     let resolved = resolve_target(&store, name)?;
     let target_name = resolved.chunk.name.clone();
 
-    let graph = store.get_call_graph()?;
-    let test_chunks = store.find_test_chunks()?;
+    let graph = store
+        .get_call_graph()
+        .context("Failed to load call graph")?;
+    let test_chunks = store
+        .find_test_chunks()
+        .context("Failed to find test chunks")?;
     let _test_names: HashSet<String> = test_chunks.iter().map(|t| t.name.clone()).collect();
 
     // Reverse BFS from target

--- a/src/cli/commands/trace.rs
+++ b/src/cli/commands/trace.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, VecDeque};
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use colored::Colorize;
 
 use cqs::Store;
@@ -57,7 +57,9 @@ pub(crate) fn cmd_trace(
     }
 
     // Load call graph and BFS
-    let graph = store.get_call_graph()?;
+    let graph = store
+        .get_call_graph()
+        .context("Failed to load call graph")?;
     let path = bfs_shortest_path(&graph.forward, &source_name, &target_name, max_depth);
 
     match path {

--- a/src/hnsw/search.rs
+++ b/src/hnsw/search.rs
@@ -35,9 +35,14 @@ impl HnswIndex {
             return Vec::new();
         }
 
+        // Adaptive ef_search: baseline EF_SEARCH or 2*k (whichever is larger),
+        // capped at index size (searching more than the index is pointless for small indexes).
+        let index_size = self.id_map.len();
+        let ef_search = EF_SEARCH.max(k * 2).min(index_size.max(EF_SEARCH));
+
         let neighbors = self
             .inner
-            .with_hnsw(|h| h.search_neighbours(query.as_slice(), k, EF_SEARCH));
+            .with_hnsw(|h| h.search_neighbours(query.as_slice(), k, ef_search));
 
         neighbors
             .into_iter()


### PR DESCRIPTION
## Summary

Fixes the 10 deferred P2 items from the v0.19.0 audit (AD-1 skipped — pure type refactor, no functional value).

- **AC-5**: BFS visited set in `gather` prevents duplicate node expansion with overlapping seeds
- **AC-8**: Adaptive `ef_search` scales with HNSW index size (`EF_SEARCH.max(k*2).min(index_size)`)
- **AD-5**: `search_reference()` returns typed `StoreError` instead of `anyhow::Error`
- **RM-8**: Parallel reference loading via `rayon::par_iter()` in `load_references()`
- **EX-6**: Consolidated config validation into `Config::validate()` method
- **PF-1**: Multi-row INSERT batching (55 rows × 18 params = 990 < SQLite 999 limit)
- **PF-9**: Skip FTS normalization when `content_hash` unchanged
- **CQ-5**: Pipeline `extract_names` refactored into 3 focused sub-functions
- **CQ-6**: Typed `ChunkOutput` struct replaces manual `serde_json::json!` assembly
- **EH-5**: `.context()` sweep across 10 CLI command files for better error messages

## Test plan

- [x] 1212 tests pass, 0 failures
- [x] No clippy warnings
- [x] Each agent tested independently, then verified combined build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
