### PR TITLE
fix: P3 audit fixes — 29 items across API, robustness, observability, security, extensibility (#504)

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -9,6 +9,7 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::hash::{BuildHasher, Hasher};
 use std::path::Path;
 
 /// Audit mode state - excludes notes from search/read during audits
@@ -111,14 +112,10 @@ pub fn save_audit_state(cqs_dir: &Path, mode: &AuditMode) -> Result<()> {
     let content = serde_json::to_string_pretty(&file).context("Failed to serialize audit mode")?;
 
     // Atomic write: temp file + rename
-    let tmp_path = path.with_extension(format!(
-        "json.tmp.{}.{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos()
-    ));
+    let suffix = std::collections::hash_map::RandomState::new()
+        .build_hasher()
+        .finish();
+    let tmp_path = path.with_extension(format!("json.{:016x}.tmp", suffix));
     std::fs::write(&tmp_path, &content).context("Failed to write temp audit-mode file")?;
     if let Err(rename_err) = std::fs::rename(&tmp_path, &path) {
         if let Err(copy_err) = std::fs::copy(&tmp_path, &path) {

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -255,6 +255,28 @@ pub(crate) enum BatchCmd {
     Help,
 }
 
+impl BatchCmd {
+    /// Whether this command accepts a piped function name as its first positional arg.
+    ///
+    /// Used by pipeline execution to validate downstream segments. Commands that
+    /// take a function name as their primary input are pipeable; commands that
+    /// take queries, paths, or no arguments are not.
+    pub(crate) fn is_pipeable(&self) -> bool {
+        matches!(
+            self,
+            BatchCmd::Callers { .. }
+                | BatchCmd::Callees { .. }
+                | BatchCmd::Deps { .. }
+                | BatchCmd::Explain { .. }
+                | BatchCmd::Similar { .. }
+                | BatchCmd::Impact { .. }
+                | BatchCmd::TestMap { .. }
+                | BatchCmd::Related { .. }
+                | BatchCmd::Scout { .. }
+        )
+    }
+}
+
 // ─── Dispatch ────────────────────────────────────────────────────────────────
 
 /// Execute a batch command and return a JSON value.

--- a/src/cli/commands/ci.rs
+++ b/src/cli/commands/ci.rs
@@ -7,7 +7,6 @@ use cqs::review::ReviewResult;
 use cqs::RiskLevel;
 
 pub(crate) fn cmd_ci(
-    _cli: &crate::cli::Cli,
     base: Option<&str>,
     from_stdin: bool,
     format: &crate::cli::OutputFormat,

--- a/src/cli/commands/deps.rs
+++ b/src/cli/commands/deps.rs
@@ -5,13 +5,11 @@
 use anyhow::{Context as _, Result};
 use colored::Colorize;
 
-use crate::cli::Cli;
-
 /// Show type dependencies.
 ///
 /// Forward (default): `cqs deps Config` — who uses this type?
 /// Reverse: `cqs deps --reverse func_name` — what types does this function use?
-pub(crate) fn cmd_deps(_cli: &Cli, name: &str, reverse: bool, json: bool) -> Result<()> {
+pub(crate) fn cmd_deps(name: &str, reverse: bool, json: bool) -> Result<()> {
     let _span = tracing::info_span!("cmd_deps", name, reverse).entered();
     let (store, root, _) = crate::cli::open_project_store()?;
 

--- a/src/cli/commands/doctor.rs
+++ b/src/cli/commands/doctor.rs
@@ -7,12 +7,12 @@ use colored::Colorize;
 
 use cqs::{Embedder, Parser as CqParser, Store};
 
-use crate::cli::{find_project_root, Cli};
+use crate::cli::find_project_root;
 
 /// Run diagnostic checks on cqs installation and index
 ///
 /// Reports runtime info, embedding provider, model status, and index statistics.
-pub(crate) fn cmd_doctor(_cli: &Cli) -> Result<()> {
+pub(crate) fn cmd_doctor() -> Result<()> {
     let _span = tracing::info_span!("cmd_doctor").entered();
     let root = find_project_root();
     let cqs_dir = cqs::resolve_index_dir(&root);

--- a/src/cli/commands/graph.rs
+++ b/src/cli/commands/graph.rs
@@ -5,10 +5,8 @@
 use anyhow::{Context as _, Result};
 use colored::Colorize;
 
-use crate::cli::Cli;
-
 /// Find functions that call the specified function
-pub(crate) fn cmd_callers(_cli: &Cli, name: &str, json: bool) -> Result<()> {
+pub(crate) fn cmd_callers(name: &str, json: bool) -> Result<()> {
     let _span = tracing::info_span!("cmd_callers", name).entered();
     let (store, _, _) = crate::cli::open_project_store()?;
     // Use full call graph (includes large functions)
@@ -56,7 +54,7 @@ pub(crate) fn cmd_callers(_cli: &Cli, name: &str, json: bool) -> Result<()> {
 }
 
 /// Find functions called by the specified function
-pub(crate) fn cmd_callees(_cli: &Cli, name: &str, json: bool) -> Result<()> {
+pub(crate) fn cmd_callees(name: &str, json: bool) -> Result<()> {
     let _span = tracing::info_span!("cmd_callees", name).entered();
     let (store, _, _) = crate::cli::open_project_store()?;
     // Use full call graph (includes large functions)

--- a/src/cli/commands/impact.rs
+++ b/src/cli/commands/impact.rs
@@ -8,7 +8,6 @@ use super::resolve::resolve_target;
 use crate::cli::OutputFormat;
 
 pub(crate) fn cmd_impact(
-    _cli: &crate::cli::Cli,
     name: &str,
     depth: usize,
     format: &OutputFormat,

--- a/src/cli/commands/project.rs
+++ b/src/cli/commands/project.rs
@@ -8,8 +8,6 @@ use colored::Colorize;
 use cqs::Embedder;
 use cqs::{search_across_projects, ProjectRegistry};
 
-use crate::cli::Cli;
-
 /// Project subcommands
 #[derive(clap::Subcommand)]
 pub(crate) enum ProjectCommand {
@@ -43,7 +41,7 @@ pub(crate) enum ProjectCommand {
     },
 }
 
-pub(crate) fn cmd_project(_cli: &Cli, subcmd: &ProjectCommand) -> Result<()> {
+pub(crate) fn cmd_project(subcmd: &ProjectCommand) -> Result<()> {
     let _span = tracing::info_span!("cmd_project").entered();
     match subcmd {
         ProjectCommand::Register { name, path } => {

--- a/src/cli/commands/review.rs
+++ b/src/cli/commands/review.rs
@@ -6,7 +6,6 @@ use cqs::review::ReviewResult;
 use cqs::RiskLevel;
 
 pub(crate) fn cmd_review(
-    _cli: &crate::cli::Cli,
     base: Option<&str>,
     from_stdin: bool,
     format: &crate::cli::OutputFormat,

--- a/src/cli/commands/trace.rs
+++ b/src/cli/commands/trace.rs
@@ -11,7 +11,6 @@ use super::resolve::resolve_target;
 use crate::cli::OutputFormat;
 
 pub(crate) fn cmd_trace(
-    _cli: &crate::cli::Cli,
     source: &str,
     target: &str,
     max_depth: usize,

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -188,7 +188,7 @@ fn convert_file(path: &Path, opts: &ConvertOptions) -> anyhow::Result<ConvertRes
     let entry = FORMAT_TABLE
         .iter()
         .find(|e| e.variant == format)
-        .expect("FORMAT_TABLE must cover all DocFormat variants");
+        .unwrap_or_else(|| panic!("FORMAT_TABLE missing entry for {:?}", format));
 
     let raw_markdown = match entry.converter {
         Some(convert_fn) => convert_fn(path)?,

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -520,7 +520,9 @@ impl Embedder {
 
         // Run inference (lazy init session)
         let mut guard = self.session()?;
-        let session = guard.as_mut().unwrap(); // Safe: session() guarantees Some after init
+        let session = guard
+            .as_mut()
+            .expect("session() guarantees initialized after Ok return");
         let _inference = tracing::debug_span!("inference", max_len).entered();
         let outputs = session.run(ort::inputs![
             "input_ids" => input_ids_tensor,

--- a/src/gather.rs
+++ b/src/gather.rs
@@ -369,9 +369,9 @@ pub fn gather_with_graph(
 
     // 2. BFS expand
     let expansion_capped = bfs_expand(&mut name_scores, graph, opts);
-    tracing::debug!(
-        expanded_nodes = name_scores.len(),
-        expansion_capped,
+    tracing::info!(
+        expanded = name_scores.len(),
+        capped = expansion_capped,
         "BFS expansion complete"
     );
 
@@ -380,6 +380,8 @@ pub fn gather_with_graph(
 
     // 4. Sort by score desc, truncate to limit, re-sort to reading order
     sort_and_truncate(&mut chunks, opts.limit);
+
+    tracing::info!(final_chunks = chunks.len(), "Gather complete");
 
     Ok(GatherResult {
         chunks,

--- a/src/impact/format.rs
+++ b/src/impact/format.rs
@@ -50,6 +50,12 @@ pub fn impact_to_json(result: &ImpactResult, root: &Path) -> serde_json::Value {
         }
     }
 
+    if result.degraded {
+        if let Some(obj) = output.as_object_mut() {
+            obj.insert("degraded".into(), serde_json::json!(true));
+        }
+    }
+
     // Always include type_impacted for consistent JSON structure
     let type_json: Vec<_> = result
         .type_impacted
@@ -280,6 +286,7 @@ mod tests {
             }],
             transitive_callers: Vec::new(),
             type_impacted: Vec::new(),
+            degraded: false,
         };
         let root = Path::new("/project");
         let json = impact_to_json(&result, root);
@@ -313,6 +320,7 @@ mod tests {
                 depth: 2,
             }],
             type_impacted: Vec::new(),
+            degraded: false,
         };
         let root = Path::new("/project");
         let json = impact_to_json(&result, root);
@@ -332,6 +340,7 @@ mod tests {
             tests: Vec::new(),
             transitive_callers: Vec::new(),
             type_impacted: Vec::new(),
+            degraded: false,
         };
         let root = Path::new("/project");
         let json = impact_to_json(&result, root);

--- a/src/impact/types.rs
+++ b/src/impact/types.rs
@@ -63,6 +63,10 @@ pub struct ImpactResult {
     pub tests: Vec<TestInfo>,
     pub transitive_callers: Vec<TransitiveCaller>,
     pub type_impacted: Vec<TypeImpacted>,
+    /// True when batch name search failed and caller snippets may be incomplete.
+    /// CLI handlers can display a warning when this is set.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub degraded: bool,
 }
 
 /// Lightweight caller + test coverage hints for a function.

--- a/src/language/bash.rs
+++ b/src/language/bash.rs
@@ -47,6 +47,8 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &[],
     test_path_patterns: &["%/tests/%", "%\\_test.sh", "%.bats"],
     structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -134,6 +134,8 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &[],
     test_path_patterns: &["%/tests/%", "%\\_test.c"],
     structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/cpp.rs
+++ b/src/language/cpp.rs
@@ -258,6 +258,8 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["TEST(", "TEST_F(", "EXPECT_", "ASSERT_"],
     test_path_patterns: &["%/tests/%", "%\\_test.cpp", "%\\_test.cc"],
     structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/csharp.rs
+++ b/src/language/csharp.rs
@@ -164,6 +164,11 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["[Test]", "[Fact]", "[Theory]", "[TestMethod]"],
     test_path_patterns: &["%/Tests/%", "%/tests/%", "%Tests.cs"],
     structural_matchers: None,
+    entry_point_names: &["Main"],
+    trait_method_names: &[
+        "Equals", "GetHashCode", "ToString", "CompareTo", "Dispose",
+        "GetEnumerator", "MoveNext",
+    ],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/fsharp.rs
+++ b/src/language/fsharp.rs
@@ -205,6 +205,10 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["[<Test>]", "[<Fact>]", "[<Theory>]"],
     test_path_patterns: &["%/Tests/%", "%/tests/%", "%Tests.fs"],
     structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[
+        "Equals", "GetHashCode", "ToString", "CompareTo", "Dispose",
+    ],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/go.rs
+++ b/src/language/go.rs
@@ -211,6 +211,11 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &[],
     test_path_patterns: &["%\\_test.go"],
     structural_matchers: None,
+    entry_point_names: &["main", "init"],
+    trait_method_names: &[
+        "String", "Error", "Close", "Read", "Write", "ServeHTTP",
+        "Len", "Less", "Swap", "MarshalJSON", "UnmarshalJSON",
+    ],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/hcl.rs
+++ b/src/language/hcl.rs
@@ -184,6 +184,8 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &[],
     test_path_patterns: &[],
     structural_matchers: None,
+    entry_point_names: &[],
+    trait_method_names: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/java.rs
+++ b/src/language/java.rs
@@ -140,6 +140,11 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["@Test", "@ParameterizedTest", "@RepeatedTest"],
     test_path_patterns: &["%/test/%", "%/tests/%", "%Test.java"],
     structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[
+        "equals", "hashCode", "toString", "compareTo", "clone",
+        "iterator", "run", "call", "close", "accept", "apply", "get",
+    ],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -77,6 +77,8 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["describe(", "it(", "test("],
     test_path_patterns: &["%.test.%", "%.spec.%", "%/tests/%"],
     structural_matchers: None,
+    entry_point_names: &["handler", "middleware", "beforeEach", "afterEach", "beforeAll", "afterAll"],
+    trait_method_names: &["toString", "valueOf", "toJSON"],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/kotlin.rs
+++ b/src/language/kotlin.rs
@@ -186,6 +186,10 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["@Test", "@ParameterizedTest"],
     test_path_patterns: &["%/test/%", "%/tests/%", "%Test.kt"],
     structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[
+        "equals", "hashCode", "toString", "compareTo", "iterator",
+    ],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/markdown.rs
+++ b/src/language/markdown.rs
@@ -36,6 +36,8 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &[],
     test_path_patterns: &[],
     structural_matchers: None,
+    entry_point_names: &[],
+    trait_method_names: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/objc.rs
+++ b/src/language/objc.rs
@@ -91,6 +91,11 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["- (void)test"],
     test_path_patterns: &["%/Tests/%", "%Tests.m"],
     structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[
+        "init", "dealloc", "description", "hash", "isEqual",
+        "copyWithZone", "encodeWithCoder", "initWithCoder",
+    ],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/powershell.rs
+++ b/src/language/powershell.rs
@@ -98,6 +98,8 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["Describe ", "It ", "Context "],
     test_path_patterns: &["%/Tests/%", "%/tests/%", "%.Tests.ps1"],
     structural_matchers: None,
+    entry_point_names: &[],
+    trait_method_names: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -96,6 +96,13 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["def test_", "pytest"],
     test_path_patterns: &["%/tests/%", "%\\_test.py", "%/test\\_%"],
     structural_matchers: None,
+    entry_point_names: &["__init__", "setup", "teardown"],
+    trait_method_names: &[
+        "__str__", "__repr__", "__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__",
+        "__hash__", "__bool__", "__len__", "__iter__", "__next__", "__contains__",
+        "__getitem__", "__setitem__", "__delitem__", "__call__", "__enter__", "__exit__",
+        "__del__", "__new__", "__init_subclass__", "__class_getitem__",
+    ],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/ruby.rs
+++ b/src/language/ruby.rs
@@ -63,6 +63,11 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["describe ", "it ", "context "],
     test_path_patterns: &["%/spec/%", "%/test/%", "%\\_spec.rb", "%\\_test.rb"],
     structural_matchers: None,
+    entry_point_names: &[],
+    trait_method_names: &[
+        "to_s", "to_i", "to_f", "to_a", "to_h", "inspect",
+        "hash", "eql?", "==", "<=>", "each", "initialize",
+    ],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -168,6 +168,39 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["#[test]", "#[cfg(test)]"],
     test_path_patterns: &["%/tests/%", "%\\_test.rs"],
     structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[
+        // std::fmt
+        "fmt",
+        // std::convert
+        "from", "into", "try_from", "try_into",
+        // std::ops
+        "deref", "deref_mut", "drop", "index", "index_mut",
+        "add", "sub", "mul", "div", "rem", "neg", "not",
+        "bitor", "bitand", "bitxor", "shl", "shr",
+        // std::cmp
+        "eq", "ne", "partial_cmp", "cmp",
+        // std::hash
+        "hash",
+        // std::clone
+        "clone", "clone_from",
+        // std::default
+        "default",
+        // std::iter
+        "next", "into_iter",
+        // std::io
+        "read", "write", "flush",
+        // std::str
+        "from_str",
+        // std::convert / std::borrow
+        "as_ref", "as_mut", "borrow", "borrow_mut",
+        // serde
+        "serialize", "deserialize",
+        // std::error
+        "source",
+        // std::future
+        "poll",
+    ],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/scala.rs
+++ b/src/language/scala.rs
@@ -145,6 +145,10 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["@Test", "\"should", "it should"],
     test_path_patterns: &["%/test/%", "%/tests/%", "%Spec.scala", "%Test.scala"],
     structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[
+        "equals", "hashCode", "toString", "compare", "apply", "unapply",
+    ],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/sql.rs
+++ b/src/language/sql.rs
@@ -89,6 +89,8 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &[],
     test_path_patterns: &[],
     structural_matchers: None,
+    entry_point_names: &[],
+    trait_method_names: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/swift.rs
+++ b/src/language/swift.rs
@@ -202,6 +202,10 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["func test"],
     test_path_patterns: &["%/Tests/%", "%Tests.swift"],
     structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[
+        "hash", "encode", "init", "deinit", "description",
+    ],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -137,6 +137,8 @@ static DEFINITION: LanguageDef = LanguageDef {
     test_markers: &["describe(", "it(", "test("],
     test_path_patterns: &["%.test.%", "%.spec.%", "%/tests/%"],
     structural_matchers: None,
+    entry_point_names: &["handler", "middleware", "beforeEach", "afterEach", "beforeAll", "afterAll"],
+    trait_method_names: &["toString", "valueOf", "toJSON"],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/onboard.rs
+++ b/src/onboard.rs
@@ -127,7 +127,7 @@ pub fn onboard(
         .iter()
         .find(|r| is_callable_type(r.chunk.chunk_type))
         .or(results.first())
-        .unwrap();
+        .expect("results guaranteed non-empty by early return above");
     let entry_name = entry.chunk.name.clone();
     let entry_file = entry
         .chunk

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -125,7 +125,9 @@ impl Reranker {
 
         // 3. Run inference
         let mut session_guard = self.session()?;
-        let session = session_guard.as_mut().unwrap(); // Safe: session() guarantees Some
+        let session = session_guard
+            .as_mut()
+            .expect("session() guarantees initialized after Ok return");
         let outputs = session.run(ort::inputs![
             "input_ids" => ids_tensor,
             "attention_mask" => mask_tensor,

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -99,7 +99,11 @@ impl ChunkRow {
 pub struct ChunkSummary {
     /// Unique identifier
     pub id: String,
-    /// Source file path (typically absolute, as stored during indexing)
+    /// Source file path (always forward-slash normalized, not OS-native).
+    ///
+    /// Paths are normalized by `normalize_origin()` during indexing: backslashes
+    /// are converted to forward slashes for consistent cross-platform storage and
+    /// querying. The path itself is typically absolute.
     pub file: PathBuf,
     /// Programming language
     pub language: Language,

--- a/tests/impact_test.rs
+++ b/tests/impact_test.rs
@@ -299,6 +299,7 @@ fn test_suggest_tests_empty_impact() {
         tests: Vec::new(),
         transitive_callers: Vec::new(),
         type_impacted: Vec::new(),
+        degraded: false,
     };
     let suggestions = suggest_tests(&store, &impact);
     assert!(suggestions.is_empty(), "No callers means no suggestions");

--- a/tests/where_test.rs
+++ b/tests/where_test.rs
@@ -1,0 +1,96 @@
+//! Tests for suggest_placement (TC-6)
+//!
+//! Integration test that seeds a Store with real chunks and verifies
+//! suggest_placement returns meaningful results.
+
+#[allow(unused)]
+mod common;
+
+use common::TestStore;
+use cqs::parser::{Chunk, ChunkType, Language};
+use cqs::suggest_placement;
+use cqs::Embedder;
+use std::path::PathBuf;
+
+/// Create a chunk with a specific file, name, and content
+fn placement_chunk(name: &str, file: &str, content: &str, line_start: u32) -> Chunk {
+    let hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+    Chunk {
+        id: format!("{}:{}:{}", file, line_start, &hash[..8]),
+        file: PathBuf::from(file),
+        language: Language::Rust,
+        chunk_type: ChunkType::Function,
+        name: name.to_string(),
+        signature: format!("fn {}()", name),
+        content: content.to_string(),
+        doc: None,
+        line_start,
+        line_end: line_start + 5,
+        content_hash: hash,
+        parent_id: None,
+        window_idx: None,
+        parent_type_name: None,
+    }
+}
+
+#[test]
+fn test_suggest_placement_returns_results_for_similar_code() {
+    let store = TestStore::new();
+    let embedder = Embedder::new().unwrap();
+
+    // Seed store with chunks from multiple files that have known themes
+    let chunks = vec![
+        placement_chunk(
+            "parse_config",
+            "src/config.rs",
+            "fn parse_config(path: &Path) -> Result<Config, Error> { let data = std::fs::read_to_string(path)?; toml::from_str(&data) }",
+            1,
+        ),
+        placement_chunk(
+            "validate_config",
+            "src/config.rs",
+            "fn validate_config(cfg: &Config) -> Result<(), ValidationError> { if cfg.name.is_empty() { return Err(ValidationError::MissingName); } Ok(()) }",
+            10,
+        ),
+        placement_chunk(
+            "render_page",
+            "src/render.rs",
+            "fn render_page(template: &str, data: &Context) -> String { handlebars.render(template, data).unwrap() }",
+            1,
+        ),
+        placement_chunk(
+            "handle_request",
+            "src/server.rs",
+            "fn handle_request(req: Request) -> Response { let body = process(req.body()); Response::ok(body) }",
+            1,
+        ),
+    ];
+
+    // Embed each chunk with the real embedder for realistic similarity.
+    // embed_documents returns 768-dim; add neutral sentiment for 769-dim.
+    let contents: Vec<&str> = chunks.iter().map(|c| c.content.as_str()).collect();
+    let embeddings = embedder.embed_documents(&contents).unwrap();
+    let pairs: Vec<_> = chunks
+        .iter()
+        .cloned()
+        .zip(embeddings.into_iter().map(|e| e.with_sentiment(0.0)))
+        .collect();
+    store.upsert_chunks_batch(&pairs, Some(12345)).unwrap();
+
+    // Ask for placement of a config-related function
+    let result = suggest_placement(&store, &embedder, "load configuration from file", 3).unwrap();
+
+    // PlacementResult should be non-empty — config.rs should rank high
+    assert!(
+        !result.suggestions.is_empty(),
+        "suggest_placement should return at least one suggestion for a seeded store"
+    );
+
+    // The top suggestion should reference config.rs (most similar to "load configuration")
+    let top_file = result.suggestions[0].file.to_string_lossy().to_string();
+    assert!(
+        top_file.contains("config"),
+        "Top suggestion should be config.rs for config-related query, got: {}",
+        top_file
+    );
+}


### PR DESCRIPTION
## Summary

- **29 P3 audit fixes** across 57 files (+1459/-865 lines)
- API Design: standardized positional arg naming, removed duplicate `--json` flags, removed unused `_cli` params, collapsed `suggest_placement` variants
- Robustness: bare `.unwrap()` → `.expect()` with documented invariants (6 sites)
- Observability: timing spans on Store::open, search_across_projects, gather BFS, HNSW build_batched
- Security: RandomState-based temp file entropy (5 sites), FTS sanitization safety docs + debug_assert
- Extensibility: `entry_point_names`/`trait_method_names` on `LanguageDef` (all 20 languages), `is_pipeable()` on `BatchCmd`, key-agnostic pipeline name extraction
- Error Handling: `ImpactResult.degraded` flag for batch name search failures
- Performance: hoisted SQL template out of cursor loop
- Resource Management: `BufReader` for count_vectors, lightweight `find_test_chunk_names` query
- Test Coverage: +8 new tests (batch boundary, migration, placement, review notes, enumerate_files)
- Platform: `ChunkSummary.file` path semantics doc comment

## Test plan

- [x] 1247 tests pass, 0 failures
- [x] Clippy clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
