### PR TITLE
docs: mark P4 audit items fixed (PR #506)

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,17 +2,17 @@
 
 ## Right Now
 
-**v0.19.2 P1+P2+P3 audit fixes complete.** 2026-02-27.
+**v0.19.2 full audit complete.** 2026-02-28.
 
 Second 14-category audit completed (117 findings across 3 batches). All priority tiers fixed:
 - P1 (46 items) → PR #501
 - P2 (29 of 31 items) → PR #502
 - P3 (29 items) → PR #504
+- P4 (3 items) → PR #506
 
-Total: 104 of 109 actionable findings fixed. 1247 tests pass.
+Total: 107 of 109 actionable findings fixed. 1261 tests pass.
 
 Deferred P2: PB-3 (normalize_path centralization, 15+ files), PF-5 (lightweight HNSW fetch).
-P4 (3 items) remain in docs/audit-triage.md — hard/low-impact, deferred by design.
 
 ## Pending Changes
 

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -129,9 +129,9 @@ Informational/well-designed: 3 (RM-7, RM-9, RM-10) — no action needed
 
 | # | Finding | Category | Location | Status |
 |---|---------|----------|----------|--------|
-| 1 | **CQ-2**: `run_index_pipeline` 458 lines — 6 concerns, 5 threads | Code Quality | pipeline.rs:238 | |
-| 2 | **CQ-8**: `search_filtered` 219 lines mixing SQL, scoring, RRF, fetch | Code Quality | search.rs:414 | |
-| 3 | **RM-4**: Store mmap 256MB×4 = 1GB virtual — benign, needs doc | Resource Mgmt | store/mod.rs:214 | |
+| 1 | **CQ-2**: `run_index_pipeline` 458 lines — 6 concerns, 5 threads | Code Quality | pipeline.rs:238 | ✅ PR #506 |
+| 2 | **CQ-8**: `search_filtered` 219 lines mixing SQL, scoring, RRF, fetch | Code Quality | search.rs:414 | ✅ PR #506 |
+| 3 | **RM-4**: Store mmap 256MB×4 = 1GB virtual — benign, needs doc | Resource Mgmt | store/mod.rs:214 | ✅ PR #506 |
 
 ## Cross-References
 


### PR DESCRIPTION
## Summary
- Mark all 3 P4 audit items as fixed (PR #506) in `docs/audit-triage.md`
- Update `PROJECT_CONTINUITY.md` with final audit stats (107/109 fixed, 1261 tests)

Completes the v0.19.2 audit triage documentation.
