### PR TITLE
chore: release v0.19.3 — second 14-category audit (107/109 findings fixed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.19.2"
+version = "0.19.3"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 20 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."


### PR DESCRIPTION
## Summary
- Bump version 0.19.2 → 0.19.3
- Add changelog for second 14-category audit: 107 of 109 actionable findings fixed
- PRs #501 (P1, 46 items), #502 (P2, 29 items), #504 (P3, 29 items), #506 (P4, 3 items)
- 2 deferred: PB-3 (normalize_path centralization), PF-5 (lightweight HNSW fetch)

## Test plan
- [ ] CI passes (tests, clippy, fmt, msrv)
- [ ] `cargo publish --dry-run` succeeds
