### PR TITLE
fix: centralize normalize_path — 31 sites across 22 files (PB-3)

### DIFF
--- a/src/cli/batch/handlers.rs
+++ b/src/cli/batch/handlers.rs
@@ -5,9 +5,10 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 
 use super::commands::BatchInput;
-use super::types::{normalize_path, ChunkOutput};
+use super::types::ChunkOutput;
 use super::BatchContext;
 use crate::cli::{validate_finite_f32, DeadConfidenceLevel};
+use cqs::normalize_path;
 
 // ─── Handlers ────────────────────────────────────────────────────────────────
 

--- a/src/cli/batch/types.rs
+++ b/src/cli/batch/types.rs
@@ -3,14 +3,9 @@
 //! Replaces manual `serde_json::json!` assembly with `#[derive(Serialize)]` structs
 //! for chunk-shaped output. Ensures consistent field names and path normalization.
 
-use std::path::Path;
-
 use serde::Serialize;
 
-/// Normalize a path for JSON output: forward slashes, no backslashes.
-pub(super) fn normalize_path(p: &Path) -> String {
-    p.to_string_lossy().replace('\\', "/")
-}
+use cqs::normalize_path;
 
 /// Common chunk output shape used by search, similar, and other handlers.
 ///

--- a/src/cli/commands/explain.rs
+++ b/src/cli/commands/explain.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 
 use cqs::index::VectorIndex;
 use cqs::store::{CallerInfo, ChunkSummary, SearchResult, Store};
-use cqs::{compute_hints, FunctionHints, HnswIndex, SearchFilter};
+use cqs::{compute_hints, normalize_path, FunctionHints, HnswIndex, SearchFilter};
 
 use crate::cli::staleness;
 
@@ -185,7 +185,7 @@ pub(crate) fn explain_to_json(data: &ExplainData, root: &Path) -> serde_json::Va
         .map(|c| {
             serde_json::json!({
                 "name": c.name,
-                "file": c.file.to_string_lossy().replace('\\', "/"),
+                "file": normalize_path(&c.file),
                 "line": c.line,
             })
         })
@@ -208,7 +208,7 @@ pub(crate) fn explain_to_json(data: &ExplainData, root: &Path) -> serde_json::Va
         .map(|r| {
             let mut obj = serde_json::json!({
                 "name": r.chunk.name,
-                "file": r.chunk.file.to_string_lossy().replace('\\', "/"),
+                "file": normalize_path(&r.chunk.file),
                 "score": r.score,
             });
             if let Some(ref set) = data.similar_content_ids {

--- a/src/cli/commands/gather.rs
+++ b/src/cli/commands/gather.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use colored::Colorize;
 
 use cqs::Embedder;
-use cqs::{gather, gather_cross_index, GatherDirection, GatherOptions};
+use cqs::{gather, gather_cross_index, normalize_path, GatherDirection, GatherOptions};
 
 use crate::cli::staleness;
 
@@ -117,7 +117,7 @@ pub(crate) fn cmd_gather(
             .map(|c| {
                 let mut chunk_json = serde_json::json!({
                     "name": c.name,
-                    "file": c.file.to_string_lossy().replace('\\', "/"),
+                    "file": normalize_path(&c.file),
                     "line_start": c.line_start,
                     "line_end": c.line_end,
                     "language": c.language.to_string(),
@@ -194,7 +194,7 @@ pub(crate) fn cmd_gather(
                 }
             }
 
-            let file_str = chunk.file.to_string_lossy().replace('\\', "/");
+            let file_str = normalize_path(&chunk.file);
             if file_str != current_file {
                 if !current_file.is_empty() {
                     println!();

--- a/src/cli/commands/graph.rs
+++ b/src/cli/commands/graph.rs
@@ -5,6 +5,8 @@
 use anyhow::{Context as _, Result};
 use colored::Colorize;
 
+use cqs::normalize_path;
+
 /// Find functions that call the specified function
 pub(crate) fn cmd_callers(name: &str, json: bool) -> Result<()> {
     let _span = tracing::info_span!("cmd_callers", name).entered();
@@ -29,7 +31,7 @@ pub(crate) fn cmd_callers(name: &str, json: bool) -> Result<()> {
             .map(|c| {
                 serde_json::json!({
                     "name": c.name,
-                    "file": c.file.to_string_lossy().replace('\\', "/"),
+                    "file": normalize_path(&c.file),
                     "line": c.line,
                 })
             })

--- a/src/cli/commands/project.rs
+++ b/src/cli/commands/project.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use colored::Colorize;
 
+use cqs::normalize_path;
 use cqs::Embedder;
 use cqs::{search_across_projects, ProjectRegistry};
 
@@ -104,7 +105,7 @@ pub(crate) fn cmd_project(subcmd: &ProjectCommand) -> Result<()> {
                         serde_json::json!({
                             "project": r.project_name,
                             "name": r.name,
-                            "file": r.file.to_string_lossy().replace('\\', "/"),
+                            "file": normalize_path(&r.file),
                             "line": r.line_start,
                             "signature": r.signature,
                             "score": r.score,

--- a/src/cli/commands/stale.rs
+++ b/src/cli/commands/stale.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 
+use cqs::normalize_slashes;
 use cqs::Parser;
 
 use crate::cli::Cli;
@@ -30,7 +31,7 @@ pub(crate) fn cmd_stale(cli: &Cli, json: bool, count_only: bool) -> Result<()> {
             .iter()
             .map(|f| {
                 serde_json::json!({
-                    "file": f.origin.replace('\\', "/"),
+                    "file": normalize_slashes(&f.origin),
                     "stored_mtime": f.stored_mtime,
                     "current_mtime": f.current_mtime,
                 })
@@ -40,7 +41,7 @@ pub(crate) fn cmd_stale(cli: &Cli, json: bool, count_only: bool) -> Result<()> {
         let missing_json: Vec<_> = report
             .missing
             .iter()
-            .map(|f| f.replace('\\', "/"))
+            .map(|f| normalize_slashes(f))
             .collect();
 
         let result = serde_json::json!({
@@ -82,13 +83,13 @@ pub(crate) fn cmd_stale(cli: &Cli, json: bool, count_only: bool) -> Result<()> {
             if !report.stale.is_empty() {
                 println!("\nStale:");
                 for f in &report.stale {
-                    println!("  {}", f.origin.replace('\\', "/"));
+                    println!("  {}", normalize_slashes(&f.origin));
                 }
             }
             if !report.missing.is_empty() {
                 println!("\nMissing:");
                 for f in &report.missing {
-                    println!("  {}", f.replace('\\', "/"));
+                    println!("  {}", normalize_slashes(f));
                 }
             }
             println!("\nRun 'cqs index' to update.");

--- a/src/cli/display.rs
+++ b/src/cli/display.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use colored::Colorize;
 
+use cqs::normalize_path;
 use cqs::reference::TaggedResult;
 use cqs::store::{ParentContext, UnifiedResult};
 
@@ -222,7 +223,7 @@ pub fn display_unified_results_json(
                 let mut obj = serde_json::json!({
                     "type": "code",
                     // Normalize to forward slashes for consistent JSON output across platforms
-                    "file": r.chunk.file.to_string_lossy().replace('\\', "/"),
+                    "file": normalize_path(&r.chunk.file),
                     "line_start": r.chunk.line_start,
                     "line_end": r.chunk.line_end,
                     "name": r.chunk.name,
@@ -416,7 +417,7 @@ pub fn display_similar_results_json(
         .iter()
         .map(|r| {
             serde_json::json!({
-                "file": r.chunk.file.to_string_lossy().replace('\\', "/"),
+                "file": normalize_path(&r.chunk.file),
                 "line_start": r.chunk.line_start,
                 "line_end": r.chunk.line_end,
                 "name": r.chunk.name,
@@ -453,7 +454,7 @@ pub fn display_tagged_results_json(
                 UnifiedResult::Code(r) => {
                     let mut obj = serde_json::json!({
                         "type": "code",
-                        "file": r.chunk.file.to_string_lossy().replace('\\', "/"),
+                        "file": normalize_path(&r.chunk.file),
                         "line_start": r.chunk.line_start,
                         "line_end": r.chunk.line_end,
                         "name": r.chunk.name,

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -16,7 +16,7 @@ use crossbeam_channel::{bounded, select, Receiver, Sender};
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
 
-use cqs::{Chunk, Embedder, Embedding, Parser as CqParser, Store};
+use cqs::{normalize_path, Chunk, Embedder, Embedding, Parser as CqParser, Store};
 
 use super::check_interrupted;
 
@@ -266,7 +266,7 @@ fn parser_stage(
                     Ok(mut chunks) => {
                         // Rewrite paths to be relative for storage
                         // Normalize path separators to forward slashes for cross-platform consistency
-                        let path_str = rel_path.to_string_lossy().replace('\\', "/");
+                        let path_str = normalize_path(rel_path);
                         // Build a map of old IDs → new IDs for parent_id fixup
                         let id_map: std::collections::HashMap<String, String> = chunks
                             .iter()

--- a/src/cli/staleness.rs
+++ b/src/cli/staleness.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use colored::Colorize;
 
+use cqs::normalize_slashes;
 use cqs::Store;
 
 /// Check result origins for staleness and print warning to stderr.
@@ -28,7 +29,7 @@ pub fn warn_stale_results(store: &Store, origins: &[&str], root: &Path) -> HashS
                     if count == 1 { "" } else { "s" }
                 );
                 for file in &stale {
-                    eprintln!("  {}", file.replace('\\', "/").dimmed());
+                    eprintln!("  {}", normalize_slashes(file).dimmed());
                 }
             }
             stale

--- a/src/impact/analysis.rs
+++ b/src/impact/analysis.rs
@@ -11,6 +11,8 @@ use super::types::{
 };
 use super::DEFAULT_MAX_TEST_SEARCH_DEPTH;
 
+use crate::{normalize_path, normalize_slashes};
+
 /// Run impact analysis: find callers, affected tests, and transitive callers.
 ///
 /// When `include_types` is true, also performs one-hop type expansion: finds
@@ -338,7 +340,7 @@ pub fn suggest_tests(store: &Store, impact: &ImpactResult) -> Vec<TestSuggestion
         };
 
         // Suggest file location
-        let caller_file_str = caller.file.to_string_lossy().replace('\\', "/");
+        let caller_file_str = normalize_path(&caller.file);
 
         let suggested_file = if has_inline_tests {
             caller_file_str.to_string()
@@ -369,11 +371,7 @@ fn suggest_test_file(source: &str) -> String {
         .and_then(|s| s.to_str())
         .unwrap_or("unknown");
     let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("rs");
-    let parent = path
-        .parent()
-        .and_then(|p| p.to_str())
-        .unwrap_or("tests")
-        .replace('\\', "/");
+    let parent = normalize_slashes(path.parent().and_then(|p| p.to_str()).unwrap_or("tests"));
 
     // Look up language-specific convention via registry
     if let Some(lang_def) = crate::language::REGISTRY.from_extension(ext) {

--- a/src/impact/diff.rs
+++ b/src/impact/diff.rs
@@ -12,6 +12,8 @@ use super::types::{
 };
 use super::DEFAULT_MAX_TEST_SEARCH_DEPTH;
 
+use crate::normalize_slashes;
+
 /// Map diff hunks to function names using the index.
 ///
 /// For each hunk, finds chunks whose line range overlaps the hunk's range.
@@ -31,7 +33,7 @@ pub fn map_hunks_to_functions(
     }
 
     for (file, file_hunks) in &by_file {
-        let normalized = file.replace('\\', "/");
+        let normalized = normalize_slashes(file);
         let chunks = match store.get_chunks_by_origin(&normalized) {
             Ok(c) => c,
             Err(e) => {

--- a/src/note.rs
+++ b/src/note.rs
@@ -8,6 +8,8 @@ use std::hash::{BuildHasher, Hasher};
 use std::path::Path;
 use thiserror::Error;
 
+use crate::normalize_slashes;
+
 /// Sentiment thresholds for classification
 ///
 /// 0.3 chosen to separate neutral observations from significant notes:
@@ -309,8 +311,8 @@ pub fn parse_notes_str(content: &str) -> Result<Vec<Note>, NoteError> {
 /// "src/store" matches "src/store/chunks.rs" but not "my_src/store.rs"
 pub fn path_matches_mention(path: &str, mention: &str) -> bool {
     // Normalize backslashes to forward slashes for cross-platform matching
-    let path = path.replace('\\', "/");
-    let mention = mention.replace('\\', "/");
+    let path = normalize_slashes(path);
+    let mention = normalize_slashes(mention);
 
     // Check if mention matches as a path suffix (component-aligned)
     if let Some(stripped) = path.strip_suffix(mention.as_str()) {

--- a/src/onboard.rs
+++ b/src/onboard.rs
@@ -32,13 +32,6 @@ const MAX_CALLEE_FETCH: usize = 30;
 /// Maximum callers to fetch content for.
 const MAX_CALLER_FETCH: usize = 15;
 
-fn serialize_path_forward_slash<S>(path: &std::path::Path, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.serialize_str(&path.to_string_lossy().replace('\\', "/"))
-}
-
 // Uses crate::COMMON_TYPES (from focused_read.rs) for type filtering — single source of truth.
 
 /// Result of an onboard analysis — ordered reading list for understanding a concept.
@@ -57,7 +50,7 @@ pub struct OnboardResult {
 #[derive(Debug, Clone, Serialize)]
 pub struct OnboardEntry {
     pub name: String,
-    #[serde(serialize_with = "serialize_path_forward_slash")]
+    #[serde(serialize_with = "crate::serialize_path_normalized")]
     pub file: PathBuf,
     pub line_start: u32,
     pub line_end: u32,
@@ -79,7 +72,7 @@ pub struct TypeInfo {
 #[derive(Debug, Clone, Serialize)]
 pub struct TestEntry {
     pub name: String,
-    #[serde(serialize_with = "serialize_path_forward_slash")]
+    #[serde(serialize_with = "crate::serialize_path_normalized")]
     pub file: PathBuf,
     pub line: u32,
     pub call_depth: usize,

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 
 use crate::impact::compute_hints_with_graph;
 use crate::store::{ChunkSummary, NoteSummary, SearchFilter};
-use crate::{AnalysisError, Embedder, Store};
+use crate::{normalize_slashes, AnalysisError, Embedder, Store};
 
 /// Role classification for chunks in scout results
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -440,8 +440,8 @@ fn find_relevant_notes(store: &Store, result_files: &HashSet<String>) -> Vec<Not
 /// Match requires the file path to end with the mention at a path-component
 /// boundary (preceded by '/' or at start of string).
 fn note_mention_matches_file(mention: &str, file: &str) -> bool {
-    let mention = mention.replace('\\', "/");
-    let file = file.replace('\\', "/");
+    let mention = normalize_slashes(mention);
+    let file = normalize_slashes(file);
     if !mention.contains('.') && !mention.contains('/') {
         return false;
     }

--- a/src/source/filesystem.rs
+++ b/src/source/filesystem.rs
@@ -129,7 +129,7 @@ impl Source for FileSystemSource {
             let rel_path = path.strip_prefix(&self.root).unwrap_or(&path).to_path_buf();
 
             items.push(SourceItem {
-                origin: rel_path.to_string_lossy().replace('\\', "/"),
+                origin: crate::normalize_path(&rel_path),
                 source_type: "file",
                 content,
                 language,

--- a/src/store/calls.rs
+++ b/src/store/calls.rs
@@ -332,7 +332,7 @@ impl Store {
         file: &Path,
         function_calls: &[crate::parser::FunctionCalls],
     ) -> Result<(), StoreError> {
-        let file_str = file.to_string_lossy().replace('\\', "/");
+        let file_str = crate::normalize_path(file);
         let total_calls: usize = function_calls.iter().map(|fc| fc.calls.len()).sum();
         tracing::trace!(
             file = %file_str,

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -175,7 +175,7 @@ impl SearchResult {
     /// Includes all chunk metadata plus score.
     pub fn to_json(&self) -> serde_json::Value {
         serde_json::json!({
-            "file": self.chunk.file.to_string_lossy().replace('\\', "/"),
+            "file": crate::normalize_path(&self.chunk.file),
             "line_start": self.chunk.line_start,
             "line_end": self.chunk.line_end,
             "name": self.chunk.name,

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -112,7 +112,7 @@ impl Store {
             return Ok(());
         }
 
-        let file_str = file.to_string_lossy().replace('\\', "/");
+        let file_str = crate::normalize_path(file);
         let total_refs: usize = chunk_type_refs.iter().map(|c| c.type_refs.len()).sum();
         tracing::trace!(
             file = %file_str,

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::impact::find_hotspots;
-use crate::{compute_risk_batch, RiskLevel, Store};
+use crate::{compute_risk_batch, normalize_slashes, RiskLevel, Store};
 
 /// Minimum dead functions in a single file to flag as a dead code cluster.
 const DEAD_CLUSTER_MIN_SIZE: usize = 5;
@@ -218,7 +218,7 @@ fn find_stale_mentions(store: &Store, project_root: &Path) -> Result<Vec<(String
             match classify_mention(mention) {
                 MentionKind::File => {
                     // Normalize backslashes to forward slashes for cross-platform path joining
-                    let normalized = mention.replace('\\', "/");
+                    let normalized = normalize_slashes(mention);
                     if !project_root.join(&normalized).exists() {
                         stale.push(mention.clone());
                     }


### PR DESCRIPTION
## Summary
- Add `normalize_path(&Path)`, `normalize_slashes(&str)`, `serialize_path_normalized` to `lib.rs`
- Delete 3 local duplicates: `batch/types.rs::normalize_path`, `chunks.rs::normalize_origin`, `onboard.rs::serialize_path_forward_slash`
- Replace all 31 inline `.replace('\\', "/")` sites across 22 files
- `rel_display` now delegates to `normalize_path` internally
- Closes audit finding PB-3

## Test plan
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `cargo test --features gpu-index` — 1261 pass, 0 fail
- [x] `grep -r "\.replace('\\\\', \"/\")" src/` — only 2 hits (function bodies in lib.rs)
