### PR TITLE
docs: update tears — PB-3 fixed, PF-5 tracked (#510)

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,17 +2,10 @@
 
 ## Right Now
 
-**v0.19.2 full audit complete.** 2026-02-28.
+**v0.19.3 released.** 2026-02-28.
 
-Second 14-category audit completed (117 findings across 3 batches). All priority tiers fixed:
-- P1 (46 items) → PR #501
-- P2 (29 of 31 items) → PR #502
-- P3 (29 items) → PR #504
-- P4 (3 items) → PR #506
-
-Total: 107 of 109 actionable findings fixed. 1261 tests pass.
-
-Deferred P2: PB-3 (normalize_path centralization, 15+ files), PF-5 (lightweight HNSW fetch).
+Patch release covering v0.19.2 audit (107/109 findings) + PB-3 fix (PR #509).
+Only deferred item: PF-5 (lightweight HNSW candidate fetch).
 
 ## Pending Changes
 
@@ -43,7 +36,7 @@ None — clean working tree on main.
 
 ## Architecture
 
-- Version: 0.19.2
+- Version: 0.19.3
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
@@ -51,7 +44,7 @@ None — clean working tree on main.
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 20 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Markdown)
 - 16 ChunkType variants (Function, Method, Struct, Class, Interface, Enum, Trait, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias)
-- Tests: 1247 pass, 0 failures
+- Tests: 1261 pass, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -71,7 +71,7 @@ Informational/well-designed: 3 (RM-7, RM-9, RM-10) — no action needed
 | 10 | **DS-3**: OnceLock notes cache never invalidated in long-lived Store | Data Safety | store/mod.rs:170 | ✅ PR #502 |
 | 11 | **DS-5**: HNSW copy fallback not atomic — crash loses index | Data Safety | persist.rs:225 | ✅ PR #502 |
 | 12 | **DS-6**: `prune_missing` per-batch transactions — partial prune on crash | Data Safety | chunks.rs:474 | ✅ PR #502 |
-| 13 | **PB-3**: 30+ sites manual `.replace('\\', "/")` — no centralized function | Platform | 15+ files | deferred |
+| 13 | **PB-3**: 30+ sites manual `.replace('\\', "/")` — no centralized function | Platform | 15+ files | ✅ PR #509 |
 | 14 | **PF-1**: N+1 SELECT for content hash snapshotting in upsert | Performance | chunks.rs:64 | ✅ PR #502 |
 | 15 | **PF-5**: HNSW search loads full content for all 500 candidates before scoring | Performance | chunks.rs:1235, search.rs:694 | deferred |
 | 16 | **PF-7**: `get_call_graph` called 15 times with no caching | Performance | calls.rs:469 | ✅ PR #502 |


### PR DESCRIPTION
## Summary
- Mark PB-3 as fixed (PR #509) in audit-triage.md
- Update PROJECT_CONTINUITY.md to v0.19.3, remove PB-3 from deferred list
- Only remaining deferred audit item: PF-5 (#510)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
