### PR TITLE
feat: add cqs blame + cqs chat commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,8 @@ Fall back to Grep/Glob only for exact string matches or when semantic search ret
 - `cqs notes list --check` — verify note mentions still exist (files on disk, symbols in index).
 - `cqs gc` — report/clean stale index entries.
 - `cqs notes add/update/remove` — manage project notes.
+- `cqs blame <function>` — semantic git blame: who changed a function, when, and why. `--callers` for affected callers.
+- `cqs chat` — interactive REPL with readline, history, tab completion. Same commands and pipelines as batch.
 - `cqs audit-mode on/off` — toggle audit mode.
 - `cqs convert <path> [--output dir]` — convert PDF/HTML/CHM/MD to cleaned Markdown with sensible filenames.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,8 @@ src/
   cli/          - Command-line interface (clap)
     mod.rs      - Argument parsing, command dispatch
     commands/   - Command implementations
-      mod.rs, query.rs, index.rs, stats.rs, graph.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, drift.rs, trace.rs, impact.rs, impact_diff.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs, audit_mode.rs, read.rs, stale.rs, related.rs, where_cmd.rs, scout.rs, onboard.rs, convert.rs, review.rs, ci.rs, health.rs, suggest.rs, deps.rs, task.rs
+      mod.rs, query.rs, index.rs, stats.rs, graph.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, drift.rs, trace.rs, impact.rs, impact_diff.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs, audit_mode.rs, read.rs, stale.rs, related.rs, where_cmd.rs, scout.rs, onboard.rs, convert.rs, review.rs, ci.rs, health.rs, suggest.rs, deps.rs, task.rs, blame.rs
+    chat.rs     - Interactive REPL (wraps batch mode with rustyline)
     batch/      - Batch mode: persistent Store + Embedder, stdin commands, JSONL output, pipeline syntax
       mod.rs      - BatchContext, vector index builder, main loop
       commands.rs - BatchInput/BatchCmd parsing, dispatch router

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +663,7 @@ dependencies = [
  "rand 0.10.0",
  "rayon",
  "regex",
+ "rustyline",
  "self_cell",
  "serde",
  "serde_json",
@@ -1040,6 +1050,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1152,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1505,6 +1538,15 @@ dependencies = [
  "rand 0.9.2",
  "rayon",
  "serde",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2253,6 +2295,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2263,6 +2314,18 @@ dependencies = [
  "libc",
  "memoffset",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2798,6 +2861,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3089,6 +3162,28 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "rustyline"
+version = "17.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.30.1",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ tempfile = "3"
 fast_html2md = { version = "0.0", optional = true }
 walkdir = { version = "2", optional = true }
 self_cell = "1"
+rustyline = "17"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ Key commands (all support `--json`):
 - `cqs onboard "concept"` - guided tour: entry point, call chain, callers, key types, tests
 - `cqs review` - diff review: impact-diff + notes + risk scoring. `--base`, `--json`
 - `cqs ci` - CI pipeline: review + dead code in diff + gate. `--base`, `--gate`, `--json`
+- `cqs blame <function>` - semantic git blame: who changed a function, when, and why. `--callers` for affected callers
+- `cqs chat` - interactive REPL with readline, history, tab completion. Same commands as batch
 - `cqs batch` - batch mode: stdin commands, JSONL output. Pipeline syntax: `search "error" | callers | test-map`
 - `cqs dead` - find functions/methods never called by indexed code
 - `cqs health` - codebase quality snapshot: dead code, staleness, hotspots, untested functions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,8 @@ All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 20 lan
 
 ### Next — Commands
 
-- [ ] `cqs blame` — semantic git blame. Given a function, show who last changed it, when, and the commit message. Combines call graph with git log.
-- [ ] `cqs chat` — interactive REPL for chained queries. Batch mode + pipeline syntax done; REPL deferred (agents use batch).
+- [x] `cqs blame` — semantic git blame. Given a function, show who last changed it, when, and the commit message. Combines call graph with git log.
+- [x] `cqs chat` — interactive REPL for chained queries. Readline, history, tab completion. Wraps batch mode.
 
 ### Next — Performance
 

--- a/src/cli/batch/handlers.rs
+++ b/src/cli/batch/handlers.rs
@@ -12,6 +12,23 @@ use cqs::normalize_path;
 
 // ─── Handlers ────────────────────────────────────────────────────────────────
 
+pub(super) fn dispatch_blame(
+    ctx: &BatchContext,
+    target: &str,
+    depth: usize,
+    show_callers: bool,
+) -> Result<serde_json::Value> {
+    let _span = tracing::info_span!("batch_blame", target).entered();
+    let data = crate::cli::commands::blame::build_blame_data(
+        &ctx.store,
+        &ctx.root,
+        target,
+        depth,
+        show_callers,
+    )?;
+    Ok(crate::cli::commands::blame::blame_to_json(&data, &ctx.root))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn dispatch_search(
     ctx: &BatchContext,

--- a/src/cli/batch/pipeline.rs
+++ b/src/cli/batch/pipeline.rs
@@ -33,6 +33,14 @@ fn pipeable_command_names() -> String {
     use super::commands::BatchCmd;
     let all = [
         (
+            "blame",
+            BatchCmd::Blame {
+                name: String::new(),
+                depth: 10,
+                callers: false,
+            },
+        ),
+        (
             "callers",
             BatchCmd::Callers {
                 name: String::new(),
@@ -218,7 +226,7 @@ fn split_tokens_by_pipe(tokens: &[String]) -> Vec<Vec<String>> {
 }
 
 /// Execute a pipeline: chain commands where upstream names feed downstream.
-pub(super) fn execute_pipeline(
+pub(crate) fn execute_pipeline(
     ctx: &BatchContext,
     tokens: &[String],
     raw_line: &str,
@@ -416,7 +424,7 @@ fn build_pipeline_result(
 }
 
 /// Check if a token list contains a pipeline (standalone `|` token).
-pub(super) fn has_pipe_token(tokens: &[String]) -> bool {
+pub(crate) fn has_pipe_token(tokens: &[String]) -> bool {
     tokens.iter().any(|t| t == "|")
 }
 
@@ -642,8 +650,8 @@ mod tests {
     #[test]
     fn test_pipeable_commands_parse_with_name_arg() {
         let pipeable = [
-            "callers", "callees", "deps", "explain", "similar", "impact", "test-map", "related",
-            "scout",
+            "blame", "callers", "callees", "deps", "explain", "similar", "impact", "test-map",
+            "related", "scout",
         ];
         for cmd in pipeable {
             let result = BatchInput::try_parse_from([cmd, "test_function"]);

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -1,0 +1,255 @@
+//! Chat command — interactive REPL wrapping batch mode
+//!
+//! Same commands and pipeline syntax as `cqs batch`, with readline editing,
+//! history, and tab completion.
+
+use anyhow::Result;
+use clap::Parser;
+use rustyline::completion::{Completer, Pair};
+use rustyline::error::ReadlineError;
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::validate::Validator;
+use rustyline::{Editor, Helper};
+
+use super::batch;
+
+// ─── Completer ───────────────────────────────────────────────────────────────
+
+struct ChatHelper {
+    commands: Vec<String>,
+}
+
+impl Completer for ChatHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &rustyline::Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        // Only complete the first token (command name)
+        let prefix = &line[..pos];
+        if prefix.contains(' ') {
+            return Ok((pos, vec![]));
+        }
+
+        let matches: Vec<Pair> = self
+            .commands
+            .iter()
+            .filter(|cmd| cmd.starts_with(prefix))
+            .map(|cmd| Pair {
+                display: cmd.clone(),
+                replacement: cmd.clone(),
+            })
+            .collect();
+
+        Ok((0, matches))
+    }
+}
+
+impl Hinter for ChatHelper {
+    type Hint = String;
+}
+impl Highlighter for ChatHelper {}
+impl Validator for ChatHelper {}
+impl Helper for ChatHelper {}
+
+// ─── Meta-commands ───────────────────────────────────────────────────────────
+
+/// Handle meta-commands (help, exit, quit, clear).
+/// Returns Some(true) for exit/quit, Some(false) for other meta-commands, None if not a meta-command.
+fn handle_meta(line: &str) -> Option<bool> {
+    match line.to_ascii_lowercase().as_str() {
+        "exit" | "quit" => Some(true),
+        "help" => {
+            println!(
+                "Available commands: search, blame, callers, callees, deps, explain, similar,"
+            );
+            println!("  gather, impact, test-map, trace, dead, related, context, stats, onboard,");
+            println!("  scout, where, read, stale, health, drift, notes, task, help");
+            println!();
+            println!("Pipeline: search \"query\" | callers | test-map");
+            println!("Meta: help, exit, quit, clear");
+            Some(false)
+        }
+        "clear" => {
+            // ANSI clear screen
+            print!("\x1b[2J\x1b[H");
+            Some(false)
+        }
+        _ => None,
+    }
+}
+
+/// Build the sorted list of batch command names.
+fn command_names() -> Vec<String> {
+    let mut names = vec![
+        "search", "blame", "callers", "callees", "deps", "explain", "similar", "gather", "impact",
+        "test-map", "trace", "dead", "related", "context", "stats", "onboard", "scout", "where",
+        "read", "stale", "health", "drift", "notes", "task", "help", // meta-commands
+        "exit", "quit", "clear",
+    ];
+    names.sort();
+    names.into_iter().map(String::from).collect()
+}
+
+// ─── REPL ────────────────────────────────────────────────────────────────────
+
+pub(crate) fn cmd_chat(_cli: &super::Cli) -> Result<()> {
+    let _span = tracing::info_span!("cmd_chat").entered();
+
+    let ctx = batch::create_context()?;
+    let history_path = ctx.cqs_dir.join("chat_history");
+
+    let helper = ChatHelper {
+        commands: command_names(),
+    };
+
+    let config = rustyline::Config::builder()
+        .max_history_size(1000)
+        .expect("valid history size")
+        .build();
+    let mut editor = Editor::with_config(config)?;
+    editor.set_helper(Some(helper));
+
+    // Load history (ignore if missing)
+    let _ = editor.load_history(&history_path);
+
+    println!("cqs interactive mode. Type 'help' for commands, 'exit' to quit.");
+
+    loop {
+        match editor.readline("cqs> ") {
+            Ok(line) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() || trimmed.starts_with('#') {
+                    continue;
+                }
+
+                // Check meta-commands
+                if let Some(should_exit) = handle_meta(trimmed) {
+                    if should_exit {
+                        break;
+                    }
+                    continue;
+                }
+
+                let _ = editor.add_history_entry(trimmed);
+
+                // Tokenize
+                let tokens = match shell_words::split(trimmed) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        eprintln!("Parse error: {}", e);
+                        continue;
+                    }
+                };
+
+                if tokens.is_empty() {
+                    continue;
+                }
+
+                // Check idle timeout
+                ctx.check_idle_timeout();
+
+                // Execute: pipeline or single command
+                let result = if batch::has_pipe_token(&tokens) {
+                    batch::execute_pipeline(&ctx, &tokens, trimmed)
+                } else {
+                    match batch::BatchInput::try_parse_from(&tokens) {
+                        Ok(input) => match batch::dispatch(&ctx, input.cmd) {
+                            Ok(value) => value,
+                            Err(e) => {
+                                tracing::warn!(error = %e, command = trimmed, "Command failed");
+                                eprintln!("Error: {}", e);
+                                continue;
+                            }
+                        },
+                        Err(e) => {
+                            eprintln!("{}", e);
+                            continue;
+                        }
+                    }
+                };
+
+                // Pretty-print result
+                match serde_json::to_string_pretty(&result) {
+                    Ok(s) => println!("{}", s),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Failed to format result");
+                        eprintln!("Error formatting output: {}", e);
+                    }
+                }
+            }
+            Err(ReadlineError::Interrupted) => {
+                // Ctrl+C — just show new prompt
+                continue;
+            }
+            Err(ReadlineError::Eof) => {
+                // Ctrl+D — exit
+                break;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Readline error");
+                eprintln!("Error: {}", e);
+                break;
+            }
+        }
+    }
+
+    // Save history
+    if let Err(e) = editor.save_history(&history_path) {
+        tracing::warn!(error = %e, "Failed to save chat history");
+    }
+
+    Ok(())
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_names_complete() {
+        let names = command_names();
+        assert!(names.contains(&"search".to_string()));
+        assert!(names.contains(&"callers".to_string()));
+        assert!(names.contains(&"blame".to_string()));
+        assert!(names.contains(&"explain".to_string()));
+        assert!(names.contains(&"help".to_string()));
+        assert!(names.contains(&"exit".to_string()));
+    }
+
+    #[test]
+    fn test_command_names_sorted() {
+        let names = command_names();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+
+    #[test]
+    fn test_handle_meta_help() {
+        assert_eq!(handle_meta("help"), Some(false));
+        assert_eq!(handle_meta("HELP"), Some(false));
+        assert_eq!(handle_meta("Help"), Some(false));
+    }
+
+    #[test]
+    fn test_handle_meta_exit() {
+        assert_eq!(handle_meta("exit"), Some(true));
+        assert_eq!(handle_meta("quit"), Some(true));
+        assert_eq!(handle_meta("EXIT"), Some(true));
+        assert_eq!(handle_meta("Quit"), Some(true));
+    }
+
+    #[test]
+    fn test_handle_meta_not_meta() {
+        assert_eq!(handle_meta("search foo"), None);
+        assert_eq!(handle_meta("callers bar"), None);
+        assert_eq!(handle_meta(""), None);
+    }
+}

--- a/src/cli/commands/blame.rs
+++ b/src/cli/commands/blame.rs
@@ -1,0 +1,393 @@
+//! Blame command — semantic git blame for a function
+//!
+//! Core logic is in `build_blame_data()` so batch mode can reuse it.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+
+use cqs::store::{CallerInfo, ChunkSummary, Store};
+use cqs::{normalize_path, rel_display, resolve_target};
+
+use crate::cli::Cli;
+
+// ─── Data structures ─────────────────────────────────────────────────────────
+
+/// A single git commit that touched the function's line range.
+pub(crate) struct BlameEntry {
+    pub hash: String,
+    pub author: String,
+    pub date: String,
+    pub message: String,
+}
+
+/// All data needed to render blame output (JSON or terminal).
+pub(crate) struct BlameData {
+    pub chunk: ChunkSummary,
+    pub commits: Vec<BlameEntry>,
+    pub callers: Vec<CallerInfo>,
+}
+
+// ─── Core logic ──────────────────────────────────────────────────────────────
+
+/// Build blame data: resolve target, run git log -L, parse commits, optionally
+/// fetch callers.
+pub(crate) fn build_blame_data(
+    store: &Store,
+    root: &Path,
+    target: &str,
+    depth: usize,
+    show_callers: bool,
+) -> Result<BlameData> {
+    let _span = tracing::info_span!("build_blame_data", target, depth).entered();
+
+    let resolved = resolve_target(store, target)
+        .map_err(|e| anyhow::anyhow!("{}", e))
+        .context("Failed to resolve blame target")?;
+
+    let chunk = resolved.chunk;
+    let rel_file = rel_display(&chunk.file, root);
+
+    let output = run_git_log_line_range(root, &rel_file, chunk.line_start, chunk.line_end, depth)?;
+    let commits = parse_git_log_output(&output);
+
+    let callers = if show_callers {
+        store.get_callers_full(&chunk.name).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, name = %chunk.name, "Failed to fetch callers");
+            Vec::new()
+        })
+    } else {
+        Vec::new()
+    };
+
+    Ok(BlameData {
+        chunk,
+        commits,
+        callers,
+    })
+}
+
+/// Run `git log -L` for a specific line range and return raw output.
+fn run_git_log_line_range(
+    root: &Path,
+    rel_file: &str,
+    start: u32,
+    end: u32,
+    depth: usize,
+) -> Result<String> {
+    let _span =
+        tracing::info_span!("run_git_log_line_range", file = rel_file, start, end).entered();
+
+    if rel_file.starts_with('-') {
+        anyhow::bail!("Invalid file path '{}': must not start with '-'", rel_file);
+    }
+
+    let line_range = format!("{},{}:{}", start, end, rel_file);
+    let depth_str = depth.to_string();
+
+    let output = std::process::Command::new("git")
+        .args(["--no-pager", "log", "--no-patch"])
+        .args(["--format=%h%x00%aN%x00%ai%x00%s"])
+        .args(["-L", &line_range])
+        .args(["-n", &depth_str])
+        .current_dir(root)
+        .output()
+        .context("Failed to run 'git log'. Is git installed?")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+
+        if stderr.contains("not a git repository") {
+            anyhow::bail!("Not a git repository: {}", root.display());
+        }
+        if stderr.contains("no path") || stderr.contains("There is no path") {
+            anyhow::bail!("File '{}' not found in git history", rel_file);
+        }
+        if stderr.contains("has only") {
+            tracing::warn!(stderr, "Line range may exceed file length");
+            // Return empty — no commits touch those lines
+            return Ok(String::new());
+        }
+
+        anyhow::bail!("git log failed: {}", stderr);
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Parse NUL-delimited git log output into BlameEntry list.
+///
+/// Expected format per line: `hash\0author\0date\0message`
+pub(crate) fn parse_git_log_output(output: &str) -> Vec<BlameEntry> {
+    let mut entries = Vec::new();
+
+    for line in output.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let parts: Vec<&str> = line.splitn(4, '\0').collect();
+        if parts.len() != 4 {
+            tracing::warn!(
+                line,
+                "Skipping malformed git log line (expected 4 NUL-separated fields)"
+            );
+            continue;
+        }
+
+        entries.push(BlameEntry {
+            hash: parts[0].to_string(),
+            author: parts[1].to_string(),
+            date: parts[2].to_string(),
+            message: parts[3].to_string(),
+        });
+    }
+
+    entries
+}
+
+// ─── JSON output ─────────────────────────────────────────────────────────────
+
+/// Build JSON output from BlameData.
+pub(crate) fn blame_to_json(data: &BlameData, root: &Path) -> serde_json::Value {
+    let commits: Vec<serde_json::Value> = data
+        .commits
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "hash": c.hash,
+                "author": c.author,
+                "date": c.date,
+                "message": c.message,
+            })
+        })
+        .collect();
+
+    let mut result = serde_json::json!({
+        "function": data.chunk.name,
+        "file": normalize_path(&data.chunk.file),
+        "lines": [data.chunk.line_start, data.chunk.line_end],
+        "signature": data.chunk.signature,
+        "commits": commits,
+        "total_commits": commits.len(),
+    });
+
+    if !data.callers.is_empty() {
+        let callers: Vec<serde_json::Value> = data
+            .callers
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "name": c.name,
+                    "file": rel_display(&c.file, root),
+                    "line": c.line,
+                })
+            })
+            .collect();
+        result["callers"] = serde_json::Value::Array(callers);
+    }
+
+    result
+}
+
+// ─── Terminal output ─────────────────────────────────────────────────────────
+
+fn print_blame_terminal(data: &BlameData, root: &Path) {
+    let file = rel_display(&data.chunk.file, root);
+    println!(
+        "{} {} ({}:{}-{})",
+        "●".bright_blue(),
+        data.chunk.name.bold(),
+        file.dimmed(),
+        data.chunk.line_start,
+        data.chunk.line_end,
+    );
+    println!("  {}", data.chunk.signature.dimmed());
+    println!();
+
+    if data.commits.is_empty() {
+        println!("  {}", "No git history for this line range.".dimmed());
+    } else {
+        for entry in &data.commits {
+            // Truncate date to just date portion (YYYY-MM-DD)
+            let short_date = entry.date.split(' ').next().unwrap_or(&entry.date);
+            println!(
+                "  {} {} {} {}",
+                entry.hash.yellow(),
+                short_date.dimmed(),
+                entry.author.cyan(),
+                entry.message,
+            );
+        }
+    }
+
+    if !data.callers.is_empty() {
+        println!();
+        println!("  {} ({}):", "Callers".bold(), data.callers.len());
+        for caller in &data.callers {
+            let caller_file = rel_display(&caller.file, root);
+            println!(
+                "    {} ({}:{})",
+                caller.name.green(),
+                caller_file.dimmed(),
+                caller.line,
+            );
+        }
+    }
+}
+
+// ─── CLI command ─────────────────────────────────────────────────────────────
+
+pub(crate) fn cmd_blame(
+    _cli: &Cli,
+    target: &str,
+    json: bool,
+    depth: usize,
+    show_callers: bool,
+) -> Result<()> {
+    let _span = tracing::info_span!("cmd_blame", target).entered();
+
+    let (store, root, _cqs_dir) = crate::cli::open_project_store()?;
+    let data = build_blame_data(&store, &root, target, depth, show_callers)?;
+
+    if json {
+        let value = blame_to_json(&data, &root);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&value).context("Failed to serialize blame output")?
+        );
+    } else {
+        print_blame_terminal(&data, &root);
+    }
+
+    Ok(())
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_parse_git_log_output_single() {
+        let output = "abc1234\0Alice\02026-02-20 14:30:00 -0500\0fix: some bug\n";
+        let entries = parse_git_log_output(output);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].hash, "abc1234");
+        assert_eq!(entries[0].author, "Alice");
+        assert_eq!(entries[0].date, "2026-02-20 14:30:00 -0500");
+        assert_eq!(entries[0].message, "fix: some bug");
+    }
+
+    #[test]
+    fn test_parse_git_log_output_multiple() {
+        let output = "abc1234\0Alice\02026-02-20\0first commit\n\
+                       def5678\0Bob\02026-02-19\0second commit\n\
+                       ghi9012\0Charlie\02026-02-18\0third commit\n";
+        let entries = parse_git_log_output(output);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].hash, "abc1234");
+        assert_eq!(entries[2].author, "Charlie");
+    }
+
+    #[test]
+    fn test_parse_git_log_output_empty() {
+        let entries = parse_git_log_output("");
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_parse_git_log_output_malformed() {
+        // Lines without exactly 4 NUL-separated fields are skipped
+        let output = "just-a-hash\n\
+                       abc1234\0Alice\02026-02-20\0valid line\n\
+                       incomplete\0two-parts\n";
+        let entries = parse_git_log_output(output);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].hash, "abc1234");
+    }
+
+    #[test]
+    fn test_parse_git_log_output_message_with_pipe() {
+        // Pipe in commit message should not break parsing (NUL separator handles it)
+        let output = "abc1234\0Alice\02026-02-20\0fix: search | callers pipeline\n";
+        let entries = parse_git_log_output(output);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].message, "fix: search | callers pipeline");
+    }
+
+    #[test]
+    fn test_blame_to_json_shape() {
+        let data = BlameData {
+            chunk: ChunkSummary {
+                id: "test-id".to_string(),
+                file: PathBuf::from("src/search.rs"),
+                language: cqs::language::Language::Rust,
+                chunk_type: cqs::language::ChunkType::Function,
+                name: "resolve_target".to_string(),
+                signature: "pub fn resolve_target(store: &Store, target: &str)".to_string(),
+                content: String::new(),
+                doc: None,
+                line_start: 23,
+                line_end: 96,
+                parent_id: None,
+            },
+            commits: vec![BlameEntry {
+                hash: "abc1234".to_string(),
+                author: "Alice".to_string(),
+                date: "2026-02-20".to_string(),
+                message: "fix: something".to_string(),
+            }],
+            callers: vec![CallerInfo {
+                name: "cmd_explain".to_string(),
+                file: PathBuf::from("src/cli/commands/explain.rs"),
+                line: 52,
+            }],
+        };
+
+        let root = Path::new("");
+        let json = blame_to_json(&data, root);
+
+        assert_eq!(json["function"], "resolve_target");
+        assert_eq!(json["file"], "src/search.rs");
+        assert_eq!(json["lines"][0], 23);
+        assert_eq!(json["lines"][1], 96);
+        assert_eq!(json["commits"].as_array().unwrap().len(), 1);
+        assert_eq!(json["commits"][0]["hash"], "abc1234");
+        assert_eq!(json["total_commits"], 1);
+        assert_eq!(json["callers"].as_array().unwrap().len(), 1);
+        assert_eq!(json["callers"][0]["name"], "cmd_explain");
+    }
+
+    #[test]
+    fn test_blame_to_json_no_callers() {
+        let data = BlameData {
+            chunk: ChunkSummary {
+                id: "test-id".to_string(),
+                file: PathBuf::from("src/lib.rs"),
+                language: cqs::language::Language::Rust,
+                chunk_type: cqs::language::ChunkType::Function,
+                name: "foo".to_string(),
+                signature: "fn foo()".to_string(),
+                content: String::new(),
+                doc: None,
+                line_start: 1,
+                line_end: 5,
+                parent_id: None,
+            },
+            commits: vec![],
+            callers: vec![],
+        };
+
+        let root = Path::new("");
+        let json = blame_to_json(&data, root);
+
+        assert!(json.get("callers").is_none());
+        assert_eq!(json["total_commits"], 0);
+    }
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -3,6 +3,7 @@
 //! Each submodule handles one CLI subcommand.
 
 mod audit_mode;
+pub(crate) mod blame;
 mod ci;
 pub(crate) mod context;
 #[cfg(feature = "convert")]
@@ -41,6 +42,7 @@ mod trace;
 mod where_cmd;
 
 pub(crate) use audit_mode::cmd_audit_mode;
+pub(crate) use blame::cmd_blame;
 pub(crate) use ci::cmd_ci;
 pub(crate) use context::cmd_context;
 #[cfg(feature = "convert")]


### PR DESCRIPTION
## Summary

- **`cqs blame <function>`** — semantic git blame via `git log -L` on a function's line range. Shows who changed it, when, and why. Supports `--callers`, `--json`, `-n <depth>`. Works in CLI, batch, and pipeline modes.
- **`cqs chat`** — interactive REPL wrapping batch mode with rustyline. Tab completion, history persistence, meta-commands (help/exit/clear). Same commands and pipeline syntax as `cqs batch`.
- Batch infrastructure: factored `create_context()` for shared BatchContext init, promoted visibility of pipeline/dispatch re-exports.
- 16 new tests (9 blame, 5 chat, 2 batch parse). Total: 1275 pass, 0 fail.

## Test plan

- [x] `cargo test --features gpu-index` — 1275 pass, 0 fail
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `cqs blame resolve_target` — shows commit history
- [x] `cqs blame resolve_target --callers --json` — JSON with callers
- [x] `echo 'blame resolve_target' | cqs batch` — batch mode works
- [x] Fresh-eyes review complete (1 fix: added blame to pipeline command list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
