### PR TITLE
chore: release v0.19.4 — blame + chat commands, normalize_path fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.4] - 2026-02-28
+
+### Added
+- **`cqs blame <function>`** — semantic git blame via `git log -L` on a function's line range. Shows who changed it, when, and why. Supports `--callers`, `--json`, `-n <depth>`. Works in CLI, batch, and pipeline modes.
+- **`cqs chat`** — interactive REPL wrapping batch mode with rustyline. Tab completion, history persistence, meta-commands (help/exit/clear). Same commands and pipeline syntax as `cqs batch`.
+
+### Fixed
+- **normalize_path centralization** — consolidated 31 inline `normalize_path` call sites into a single `cqs::normalize_path()` in lib.rs (PB-3 audit item).
+
 ## [0.19.3] - 2026-02-28
 
 Second 14-category audit completed (117 findings). 107 of 109 actionable findings fixed across 4 priority tiers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.19.3"
+version = "0.19.4"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 20 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current: v0.19.3
+## Current: v0.19.4
 
 All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 20 languages. Two full audits complete (v0.12.3 + v0.19.2).
 


### PR DESCRIPTION
## Summary

Release v0.19.4

### Added
- `cqs blame <function>` — semantic git blame via `git log -L`
- `cqs chat` — interactive REPL with tab completion, history, pipeline support

### Fixed
- normalize_path centralization — 31 inline sites consolidated (PB-3)

### Checks
- 1275 tests pass, 0 fail
- clippy clean
- docs reviewed — all current
