### PR TITLE
docs: update tears + groom notes after v0.19.4 release

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,10 +2,10 @@
 
 ## Right Now
 
-**v0.19.3 released.** 2026-02-28.
+**v0.19.4 released.** 2026-02-28.
 
-Patch release covering v0.19.2 audit (107/109 findings) + PB-3 fix (PR #509).
-Only deferred item: PF-5 (lightweight HNSW candidate fetch).
+Added `cqs blame` (semantic git blame) and `cqs chat` (interactive REPL).
+Only deferred item: PF-5 (lightweight HNSW candidate fetch, #510).
 
 ## Pending Changes
 
@@ -36,7 +36,7 @@ None — clean working tree on main.
 
 ## Architecture
 
-- Version: 0.19.3
+- Version: 0.19.4
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
@@ -44,7 +44,7 @@ None — clean working tree on main.
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 20 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Markdown)
 - 16 ChunkType variants (Function, Method, Struct, Class, Interface, Enum, Trait, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias)
-- Tests: 1261 pass, 0 failures
+- Tests: 1275 pass, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -861,3 +861,29 @@ mentions = [
     "audit",
     "agents",
 ]
+
+[[note]]
+sentiment = 0.5
+text = "git log %x00 (NUL byte) as field separator avoids ambiguity with | in commit messages. --no-pager must come before 'log' (git-level flag, not log flag). Pattern used in blame.rs for reliable parse_git_log_output."
+mentions = [
+    "src/cli/commands/blame.rs",
+    "git",
+]
+
+[[note]]
+sentiment = 0.5
+text = "Factor create_context() from batch module to share BatchContext between batch and chat REPL. OnceLock + lazy-init amortizes ~600ms Store+Embedder init. Visibility promotion (pub(super) to pub(crate)) for cross-module sharing. Re-export pattern: pub(crate) use commands::{dispatch, BatchInput}."
+mentions = [
+    "src/cli/batch/mod.rs",
+    "src/cli/chat.rs",
+    "BatchContext",
+]
+
+[[note]]
+sentiment = 1.0
+text = "Second 14-category audit (v0.19.2): 117 findings, 107 fixed across 4 priority tiers (P1: 46, P2: 29, P3: 29, P4: 3). Two deferred: PF-5 (HNSW candidate fetch #510) and PB-3 (normalize_path, fixed PR #509). Confirms 14-category / 3-batch structure works at scale. Total across both audits: ~200 findings fixed."
+mentions = [
+    "docs/audit-findings.md",
+    "docs/audit-triage.md",
+    "audit",
+]


### PR DESCRIPTION
## Summary

- Update PROJECT_CONTINUITY.md to v0.19.4, test count 1275
- Groom notes: 3 new notes (NUL separator pattern, BatchContext reuse, v0.19.2 audit scale)
