### PR TITLE
chore: release v0.19.5 — full 75-finding audit + dep bumps (#526)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.5] - 2026-03-04
+
+Full 75-finding code audit completed (14 categories, 3 batches). All findings addressed — 62 fixed, 13 triaged as acceptable/informational/by-design.
+
+### Changed
+- **Lightweight HNSW candidate fetch (PF-5)** — two-phase search: fetch only IDs+scores from HNSW, then batch-load full chunks from SQLite. Reduces memory during search.
+- **Pipeline channel tuning (RM-4)** — separate depths for parse (512, lightweight) vs embed (64, heavy vector data) channels. Was uniform 256.
+- **Watch mtime pruning (RM-5)** — threshold-based pruning (1K/10K entries) instead of per-cycle `exists()` calls on every file.
+- **Generic token packing (CQ-3)** — unified `token_pack_unified`/`token_pack_tagged` into single generic `token_pack_results`.
+- **SearchParams struct (AD-5)** — `dispatch_search` takes a struct instead of 9 individual parameters.
+- **Pipeline name extraction (EX-4)** — `extract_from_scout_groups` folded into `extract_from_standard_fields` with automatic nested extraction.
+
+### Fixed
+- **SQLite 999-param limit (RB-1)** — `fetch_candidates_by_ids_async`/`fetch_chunks_by_ids_async` batched to stay under SQLite bind limit.
+- **JSON injection in empty results (AC-1)** — `emit_empty_results` now uses `serde_json::json!` instead of raw `format!`.
+- **Index lock race (DS-2)** — `acquire_index_lock` truncate+write is now atomic via temp file rename.
+- **Force-index data loss (DS-7)** — `cmd_index --force` now writes new DB before removing old.
+- **FTS debug_assert in release (SEC-2)** — query safety validation promoted from `debug_assert` to runtime check.
+- **Dead source/ module (CQ-1)** — removed ~250 lines of unused code.
+- **HNSW save rollback (DS-1)** — partial rename during save now rolls back already-moved files.
+- **Blame path separators (PB-3)** — backslash paths normalized to forward-slash for Windows git compatibility.
+- **PATH search validation (SEC-5)** — `find_7z`/`find_python` now validate exit status, not just executability.
+- 43 additional P3 fixes: tracing spans, error context, Serialize derives, filter tests, CHM/webhelp memory, file size guards, and more.
+
+### Added
+- Parser integration tests for Bash, HCL, Kotlin, Swift, and Objective-C (TC-1).
+- 7 `NoteBoostIndex` unit tests (TC-2).
+- 7 search filter set tests (TC-3).
+- 4 `ChatHelper::complete` tests (TC-4).
+- 6 pipeline tests (TC-6).
+
+### Dependencies
+- `hnsw_rs` 0.3.3 → 0.3.4
+- `tree-sitter` 0.26.5 → 0.26.6
+- `tree-sitter-bash` 0.23.3 → 0.25.1
+- `serial_test` 3.3.1 → 3.4.0
+
 ## [0.19.4] - 2026-02-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.19.4"
+version = "0.19.5"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 20 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,11 +2,14 @@
 
 ## Right Now
 
-**PF-5 shipped.** 2026-03-02.
+**Audit complete.** 2026-03-04.
 
-Lightweight HNSW candidate fetch (#510, PR #515). Two-phase search:
-score 500+ candidates using `CandidateRow` (6 SQL columns), load full
-content only for ~20 survivors. All roadmap performance items complete.
+v0.19.5 release in progress. Full 75-finding audit resolved:
+- P1: 6 fixes (PR #522)
+- P2: 4 fixes (PR #523)
+- P3: 43/50 fixed, 7 acceptable/moot (PR #524)
+- P4: 9/19 fixed, 10 triaged (PR #525)
+- 4 dep bumps merged (#516-#520)
 
 ## Pending Changes
 
@@ -37,7 +40,7 @@ None — clean working tree on main.
 
 ## Architecture
 
-- Version: 0.19.4
+- Version: 0.19.5
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
@@ -45,7 +48,7 @@ None — clean working tree on main.
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 20 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Markdown)
 - 16 ChunkType variants (Function, Method, Struct, Class, Interface, Enum, Trait, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias)
-- Tests: 1275 pass, 0 failures
+- Tests: 1296 pass, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag


### PR DESCRIPTION
## Summary

Release v0.19.5 — full 75-finding audit resolved + dependency bumps + PF-5 performance improvement.

**Audit (75 findings, 14 categories):**
- P1: 6 fixes (#522)
- P2: 4 fixes (#523)
- P3: 43 fixes + 7 acceptable (#524)
- P4: 9 fixes + 10 triaged (#525)

**Performance:**
- PF-5: Lightweight HNSW candidate fetch — two-phase search reduces memory (#515)
- Pipeline channel tuning: 512 parse / 64 embed (was uniform 256)

**Dependencies:**
- hnsw_rs 0.3.3 → 0.3.4
- tree-sitter 0.26.5 → 0.26.6
- tree-sitter-bash 0.23.3 → 0.25.1
- serial_test 3.3.1 → 3.4.0

## Test plan

- [x] 1296 tests pass, 0 fail
- [x] clippy clean
- [x] fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
