### PR TITLE
feat: add Protobuf, GraphQL, PHP language support (20 to 23 languages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-03-04
+
+Protobuf, GraphQL, and PHP language support — 20 → 23 languages.
+
+### Added
+- **Protobuf language support** — messages (Struct), services (Interface), RPCs (Method), enums, type references via `message_or_enum_type`
+- **GraphQL language support** — object types, interfaces, enums, unions (TypeAlias), input types, scalars, directives (Macro), operations, fragments, type references via `named_type`
+- **PHP language support** — classes, interfaces, traits, enums, functions, methods, properties, constants, call extraction (function/method/static/constructor), type references (params, returns, fields, extends, implements), return type extraction
+
 ## [0.19.5] - 2026-03-04
 
 Full 75-finding code audit completed (14 categories, 3 batches). All findings addressed — 62 fixed, 13 triaged as acceptable/informational/by-design.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Thank you for your interest in contributing to cqs!
 
 ### Feature Ideas
 
-- Additional language support (see `src/language/` for current list — 20 languages supported)
+- Additional language support (see `src/language/` for current list — 23 languages supported)
 - Non-CUDA GPU support (ROCm for AMD, Metal for Apple Silicon)
 - VS Code extension
 - Performance improvements
@@ -105,7 +105,7 @@ src/
     watch.rs    - File watcher for incremental reindexing
   language/     - Tree-sitter language support
     mod.rs      - Language enum, LanguageRegistry, LanguageDef, ChunkType
-    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, kotlin.rs, swift.rs, objc.rs, sql.rs, markdown.rs
+    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, kotlin.rs, swift.rs, objc.rs, sql.rs, protobuf.rs, graphql.rs, php.rs, markdown.rs
   store/        - SQLite storage layer (Schema v11, WAL mode)
     mod.rs      - Store struct, open/init, FTS5, RRF fusion
     chunks.rs   - Chunk CRUD, embedding_batches() for streaming

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.19.5"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -685,12 +685,15 @@ dependencies = [
  "tree-sitter-cpp",
  "tree-sitter-fsharp",
  "tree-sitter-go",
+ "tree-sitter-graphql",
  "tree-sitter-hcl",
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-kotlin-ng",
  "tree-sitter-objc",
+ "tree-sitter-php",
  "tree-sitter-powershell",
+ "tree-sitter-proto",
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
@@ -4080,6 +4083,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-graphql"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efedc4cac157161cc23a0adc4553a2cedc908e1cd754b6cd033a919bb81ce5d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-hcl"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4136,10 +4149,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-php"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-powershell"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff5d1c86d8b1625585fd18e05fff47e38c36564e45ec4f38fd0de4ecbf08e2c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-proto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e410ccb5fa3cbd6bf7b8e512ecf7ad9d5254395b822bfe9f751b50fa978f31c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "cqs"
-version = "0.19.5"
+version = "0.20.0"
 edition = "2021"
 rust-version = "1.93"
-description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 20 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."
+description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 23 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."
 license = "MIT"
 repository = "https://github.com/jamie8johnson/cqs"
 homepage = "https://github.com/jamie8johnson/cqs"
@@ -47,6 +47,9 @@ tree-sitter-kotlin = { version = "1.1", package = "tree-sitter-kotlin-ng", optio
 tree-sitter-swift = { version = "0.7", optional = true }
 tree-sitter-objc = { version = "3.0", optional = true }
 tree-sitter-sql = { version = "0.4", package = "tree-sitter-sequel-tsql", optional = true }
+tree-sitter-proto = { version = "0.4", optional = true }
+tree-sitter-graphql = { version = "0.1", optional = true }
+tree-sitter-php = { version = "0.24", optional = true }
 
 # ML
 ort = { version = "2.0.0-rc.11", features = ["cuda", "tensorrt"] }
@@ -112,7 +115,7 @@ rustyline = "17"
 libc = "0.2"
 
 [features]
-default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-markdown", "convert"]
+default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-markdown", "convert"]
 
 # Language support (opt-in, all enabled by default)
 lang-rust = ["dep:tree-sitter-rust"]
@@ -134,8 +137,11 @@ lang-kotlin = ["dep:tree-sitter-kotlin"]
 lang-swift = ["dep:tree-sitter-swift"]
 lang-objc = ["dep:tree-sitter-objc"]
 lang-sql = ["dep:tree-sitter-sql"]
+lang-protobuf = ["dep:tree-sitter-proto"]
+lang-graphql = ["dep:tree-sitter-graphql"]
+lang-php = ["dep:tree-sitter-php"]
 lang-markdown = []  # No external deps — custom parser
-lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-markdown"]
+lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-markdown"]
 
 # Document conversion
 convert = ["dep:fast_html2md", "dep:walkdir"]

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -46,9 +46,9 @@ None — clean working tree on main.
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
-- 20 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Markdown)
+- 23 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Markdown)
 - 16 ChunkType variants (Function, Method, Struct, Class, Interface, Enum, Trait, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias)
-- Tests: 1296 pass, 0 failures
+- Tests: 1324 pass, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code intelligence and RAG for AI agents. Semantic search, call graph analysis, impact tracing, type dependencies, and smart context assembly — all in single tool calls. Local ML embeddings, GPU-accelerated.
 
-**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval. 20 languages, GPU-accelerated.
+**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval. 23 languages, GPU-accelerated.
 
 [![Crates.io](https://img.shields.io/crates/v/cqs.svg)](https://crates.io/crates/cqs)
 [![CI](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml/badge.svg)](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml)
@@ -428,6 +428,9 @@ Keep index fresh: run `cqs watch` in a background terminal, or `cqs index` after
 - Swift (classes, structs, enums, actors, protocols, extensions, functions, type aliases)
 - Objective-C (class interfaces, protocols, methods, properties, C functions)
 - SQL (T-SQL, PostgreSQL)
+- Protobuf (messages, services, RPCs, enums, type references)
+- GraphQL (types, interfaces, enums, unions, inputs, scalars, directives, operations, fragments)
+- PHP (classes, interfaces, traits, enums, functions, methods, properties, constants, type references)
 - Markdown (.md, .mdx — heading-based chunking with cross-reference extraction)
 
 ## Indexing
@@ -445,7 +448,7 @@ cqs index --dry-run    # Show what would be indexed
 
 **Parse → Embed → Index → Reason**
 
-1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 20 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
+1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 23 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
 2. **Describe** — Each code element gets a natural language description incorporating doc comments, parameter types, return types, and parent type context (e.g., methods include their struct/class name). This bridges the gap between how developers describe code and how it's written.
 3. **Embed** — E5-base-v2 generates 769-dimensional embeddings (768 semantic + 1 sentiment) locally. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval — outperforms code-specific models because NL descriptions play to general-purpose model strengths.
 4. **Index** — SQLite stores chunks, embeddings, call graph edges, and type dependency edges. HNSW provides fast approximate nearest-neighbor search. FTS5 enables keyword matching.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Roadmap
 
-## Current: v0.19.4
+## Current: v0.20.0
 
-All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 20 languages. Two full audits complete (v0.12.3 + v0.19.2).
+All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 23 languages. Two full audits complete (v0.12.3 + v0.19.2).
 
 ### Next — Commands
 

--- a/src/language/graphql.rs
+++ b/src/language/graphql.rs
@@ -1,0 +1,259 @@
+//! GraphQL language definition
+
+use super::{LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting GraphQL definitions.
+///
+/// Object/Input types → Struct, Interfaces → Interface, Enums → Enum,
+/// Unions/Scalars → TypeAlias, Directives → Macro, Operations/Fragments → Function.
+const CHUNK_QUERY: &str = r#"
+;; Object types (type User { ... })
+(object_type_definition
+  (name) @name) @struct
+
+;; Interface types (interface Node { ... })
+(interface_type_definition
+  (name) @name) @interface
+
+;; Enum types (enum Status { ... })
+(enum_type_definition
+  (name) @name) @enum
+
+;; Union types (union SearchResult = User | Post)
+(union_type_definition
+  (name) @name) @typealias
+
+;; Input types (input CreateUserInput { ... })
+(input_object_type_definition
+  (name) @name) @struct
+
+;; Scalar types (scalar DateTime)
+(scalar_type_definition
+  (name) @name) @typealias
+
+;; Directive definitions (@directive ...)
+(directive_definition
+  (name) @name) @macro
+
+;; Operations (query GetUser { ... }, mutation CreateUser { ... })
+(operation_definition
+  (name) @name) @function
+
+;; Fragments (fragment UserFields on User { ... })
+(fragment_definition
+  (fragment_name
+    (name) @name)) @function
+"#;
+
+/// Tree-sitter query for extracting type references in GraphQL.
+///
+/// `named_type` appears in field types, argument types, and type conditions.
+const CALL_QUERY: &str = r#"
+;; Named type references
+(named_type
+  (name) @callee)
+"#;
+
+/// Doc comment node types — GraphQL uses `description` (triple-quoted strings)
+const DOC_NODES: &[&str] = &["description"];
+
+const STOPWORDS: &[&str] = &[
+    "type", "interface", "enum", "union", "input", "scalar", "directive", "query", "mutation",
+    "subscription", "fragment", "on", "extend", "implements", "schema", "true", "false", "null",
+    "repeatable",
+];
+
+const COMMON_TYPES: &[&str] = &["String", "Int", "Float", "Boolean", "ID"];
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "graphql",
+    grammar: Some(|| tree_sitter_graphql::LANGUAGE.into()),
+    extensions: &["graphql", "gql"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &[],
+    stopwords: STOPWORDS,
+    extract_return_nl: |_| None,
+    test_file_suggestion: None,
+    type_query: None,
+    common_types: COMMON_TYPES,
+    container_body_kinds: &[],
+    extract_container_name: None,
+    extract_qualified_method: None,
+    post_process_chunk: None,
+    test_markers: &[],
+    test_path_patterns: &[],
+    structural_matchers: None,
+    entry_point_names: &[],
+    trait_method_names: &[],
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_graphql_object_type() {
+        let content = r#"
+type User {
+  id: ID!
+  name: String!
+}
+"#;
+        let file = write_temp_file(content, "graphql");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let user = chunks.iter().find(|c| c.name == "User").unwrap();
+        assert_eq!(user.chunk_type, ChunkType::Struct);
+    }
+
+    #[test]
+    fn parse_graphql_interface() {
+        let content = r#"
+interface Node {
+  id: ID!
+}
+"#;
+        let file = write_temp_file(content, "graphql");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let node = chunks.iter().find(|c| c.name == "Node").unwrap();
+        assert_eq!(node.chunk_type, ChunkType::Interface);
+    }
+
+    #[test]
+    fn parse_graphql_enum() {
+        let content = r#"
+enum Status {
+  ACTIVE
+  INACTIVE
+}
+"#;
+        let file = write_temp_file(content, "graphql");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let e = chunks.iter().find(|c| c.name == "Status").unwrap();
+        assert_eq!(e.chunk_type, ChunkType::Enum);
+    }
+
+    #[test]
+    fn parse_graphql_union() {
+        let content = "union SearchResult = User | Post\n";
+        let file = write_temp_file(content, "graphql");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let u = chunks.iter().find(|c| c.name == "SearchResult").unwrap();
+        assert_eq!(u.chunk_type, ChunkType::TypeAlias);
+    }
+
+    #[test]
+    fn parse_graphql_input() {
+        let content = r#"
+input CreateUserInput {
+  name: String!
+  email: String!
+}
+"#;
+        let file = write_temp_file(content, "graphql");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let input = chunks.iter().find(|c| c.name == "CreateUserInput").unwrap();
+        assert_eq!(input.chunk_type, ChunkType::Struct);
+    }
+
+    #[test]
+    fn parse_graphql_scalar() {
+        let content = "scalar DateTime\n";
+        let file = write_temp_file(content, "graphql");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let s = chunks.iter().find(|c| c.name == "DateTime").unwrap();
+        assert_eq!(s.chunk_type, ChunkType::TypeAlias);
+    }
+
+    #[test]
+    fn parse_graphql_directive() {
+        let content = "directive @auth(requires: Role!) on FIELD_DEFINITION\n";
+        let file = write_temp_file(content, "graphql");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let d = chunks.iter().find(|c| c.name == "auth").unwrap();
+        assert_eq!(d.chunk_type, ChunkType::Macro);
+    }
+
+    #[test]
+    fn parse_graphql_operation() {
+        let content = r#"
+query GetUser($id: ID!) {
+  user(id: $id) {
+    name
+  }
+}
+"#;
+        let file = write_temp_file(content, "graphql");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let op = chunks.iter().find(|c| c.name == "GetUser").unwrap();
+        assert_eq!(op.chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_graphql_fragment() {
+        let content = r#"
+fragment UserFields on User {
+  name
+  email
+}
+"#;
+        let file = write_temp_file(content, "graphql");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let frag = chunks.iter().find(|c| c.name == "UserFields").unwrap();
+        assert_eq!(frag.chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_graphql_calls() {
+        let content = r#"
+type User {
+  id: ID!
+  posts: [Post!]!
+  address: Address
+}
+"#;
+        let file = write_temp_file(content, "graphql");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let user = chunks.iter().find(|c| c.name == "User").unwrap();
+        let calls = parser.extract_calls_from_chunk(user);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(
+            names.contains(&"Post"),
+            "Expected Post type reference, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"Address"),
+            "Expected Address type reference, got: {:?}",
+            names
+        );
+    }
+}

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -526,6 +526,12 @@ define_languages! {
     ObjC => "objc", feature = "lang-objc", module = objc;
     /// SQL (.sql files)
     Sql => "sql", feature = "lang-sql", module = sql;
+    /// Protobuf (.proto files)
+    Protobuf => "protobuf", feature = "lang-protobuf", module = protobuf;
+    /// GraphQL (.graphql, .gql files)
+    GraphQL => "graphql", feature = "lang-graphql", module = graphql;
+    /// PHP (.php files)
+    Php => "php", feature = "lang-php", module = php;
     /// Markdown (.md, .mdx files)
     Markdown => "markdown", feature = "lang-markdown", module = markdown;
 }
@@ -673,6 +679,15 @@ mod tests {
         }
         #[cfg(feature = "lang-sql")]
         assert!(REGISTRY.from_extension("sql").is_some());
+        #[cfg(feature = "lang-protobuf")]
+        assert!(REGISTRY.from_extension("proto").is_some());
+        #[cfg(feature = "lang-graphql")]
+        {
+            assert!(REGISTRY.from_extension("graphql").is_some());
+            assert!(REGISTRY.from_extension("gql").is_some());
+        }
+        #[cfg(feature = "lang-php")]
+        assert!(REGISTRY.from_extension("php").is_some());
         #[cfg(feature = "lang-markdown")]
         {
             assert!(REGISTRY.from_extension("md").is_some());
@@ -762,6 +777,18 @@ mod tests {
         {
             expected += 1;
         }
+        #[cfg(feature = "lang-protobuf")]
+        {
+            expected += 1;
+        }
+        #[cfg(feature = "lang-graphql")]
+        {
+            expected += 1;
+        }
+        #[cfg(feature = "lang-php")]
+        {
+            expected += 1;
+        }
         #[cfg(feature = "lang-markdown")]
         {
             expected += 1;
@@ -831,6 +858,10 @@ mod tests {
         assert_eq!(Language::from_extension("m"), Some(Language::ObjC));
         assert_eq!(Language::from_extension("mm"), Some(Language::ObjC));
         assert_eq!(Language::from_extension("sql"), Some(Language::Sql));
+        assert_eq!(Language::from_extension("proto"), Some(Language::Protobuf));
+        assert_eq!(Language::from_extension("graphql"), Some(Language::GraphQL));
+        assert_eq!(Language::from_extension("gql"), Some(Language::GraphQL));
+        assert_eq!(Language::from_extension("php"), Some(Language::Php));
         assert_eq!(Language::from_extension("md"), Some(Language::Markdown));
         assert_eq!(Language::from_extension("mdx"), Some(Language::Markdown));
         assert_eq!(Language::from_extension("unknown"), None);
@@ -861,6 +892,9 @@ mod tests {
         assert_eq!("swift".parse::<Language>().unwrap(), Language::Swift);
         assert_eq!("objc".parse::<Language>().unwrap(), Language::ObjC);
         assert_eq!("sql".parse::<Language>().unwrap(), Language::Sql);
+        assert_eq!("protobuf".parse::<Language>().unwrap(), Language::Protobuf);
+        assert_eq!("graphql".parse::<Language>().unwrap(), Language::GraphQL);
+        assert_eq!("php".parse::<Language>().unwrap(), Language::Php);
         assert_eq!("markdown".parse::<Language>().unwrap(), Language::Markdown);
         assert!("invalid".parse::<Language>().is_err());
     }
@@ -886,6 +920,9 @@ mod tests {
         assert_eq!(Language::Swift.to_string(), "swift");
         assert_eq!(Language::ObjC.to_string(), "objc");
         assert_eq!(Language::Sql.to_string(), "sql");
+        assert_eq!(Language::Protobuf.to_string(), "protobuf");
+        assert_eq!(Language::GraphQL.to_string(), "graphql");
+        assert_eq!(Language::Php.to_string(), "php");
         assert_eq!(Language::Markdown.to_string(), "markdown");
     }
 
@@ -1061,6 +1098,22 @@ mod tests {
         );
         assert_eq!(
             (Language::ObjC.def().extract_return_nl)("- (void)greet"),
+            None
+        );
+        assert_eq!(
+            (Language::Protobuf.def().extract_return_nl)("message User {"),
+            None
+        );
+        assert_eq!(
+            (Language::GraphQL.def().extract_return_nl)("type User {"),
+            None
+        );
+        assert_eq!(
+            (Language::Php.def().extract_return_nl)("function add(int $a, int $b): int {"),
+            Some("Returns int".to_string())
+        );
+        assert_eq!(
+            (Language::Php.def().extract_return_nl)("function doSomething(): void {"),
             None
         );
     }

--- a/src/language/php.rs
+++ b/src/language/php.rs
@@ -1,0 +1,382 @@
+//! PHP language definition
+
+use super::{ChunkType, LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting PHP code chunks.
+///
+/// Classes → Class, Interfaces → Interface, Traits → Trait, Enums → Enum,
+/// Functions → Function, Methods → Function (reclassified via method_containers),
+/// Constants → Constant, Properties → Property.
+const CHUNK_QUERY: &str = r#"
+;; Functions
+(function_definition
+  name: (name) @name) @function
+
+;; Classes
+(class_declaration
+  name: (name) @name) @class
+
+;; Interfaces
+(interface_declaration
+  name: (name) @name) @interface
+
+;; Traits
+(trait_declaration
+  name: (name) @name) @trait
+
+;; Enums (PHP 8.1+)
+(enum_declaration
+  name: (name) @name) @enum
+
+;; Methods (reclassified to Method via method_containers when inside declaration_list)
+(method_declaration
+  name: (name) @name) @function
+
+;; Constants
+(const_declaration
+  (const_element
+    (name) @name)) @const
+
+;; Properties
+(property_declaration
+  (property_element
+    (variable_name) @name)) @property
+"#;
+
+/// Tree-sitter query for extracting PHP function calls.
+const CALL_QUERY: &str = r#"
+;; Regular function calls
+(function_call_expression
+  function: (name) @callee)
+
+;; Method calls ($obj->method())
+(member_call_expression
+  name: (name) @callee)
+
+;; Static calls (Class::method())
+(scoped_call_expression
+  name: (name) @callee)
+
+;; Constructor calls (new ClassName)
+(object_creation_expression
+  (name) @callee)
+"#;
+
+/// Tree-sitter query for extracting PHP type references.
+const TYPE_QUERY: &str = r#"
+;; Parameter types (function foo(Type $param))
+(simple_parameter
+  type: (named_type (name) @param_type))
+
+;; Return types (function foo(): Type)
+(function_definition
+  return_type: (named_type (name) @return_type))
+(method_declaration
+  return_type: (named_type (name) @return_type))
+
+;; Property types (public Type $prop)
+(property_declaration
+  type: (named_type (name) @field_type))
+
+;; Extends (class Foo extends Bar)
+(base_clause
+  (name) @impl_type)
+
+;; Implements (class Foo implements Bar, Baz)
+(class_interface_clause
+  (name) @impl_type)
+
+;; Catch-all for named types
+(named_type (name) @type_ref)
+"#;
+
+/// Doc comment node types — PHPDoc uses `/** ... */` parsed as comment
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    "function", "class", "interface", "trait", "enum", "namespace", "use", "extends", "implements",
+    "abstract", "final", "static", "public", "protected", "private", "return", "if", "else",
+    "elseif", "for", "foreach", "while", "do", "switch", "case", "break", "continue", "new",
+    "try", "catch", "finally", "throw", "echo", "print", "var", "const", "true", "false", "null",
+    "self", "parent", "this", "array", "string", "int", "float", "bool", "void", "mixed", "never",
+    "callable", "iterable", "object", "isset", "unset", "empty",
+];
+
+const COMMON_TYPES: &[&str] = &[
+    "string", "int", "float", "bool", "array", "object", "callable", "iterable", "void", "null",
+    "mixed", "never", "self", "parent", "static", "false", "true", "Closure", "Iterator",
+    "Generator", "Traversable", "Countable", "Throwable", "Exception", "RuntimeException",
+    "InvalidArgumentException", "stdClass",
+];
+
+/// Strip `$` prefix from PHP property names.
+///
+/// PHP properties are declared as `$name`, but callers reference them without `$`.
+/// This hook strips the prefix so property names match call sites.
+fn post_process_php(
+    name: &mut String,
+    _chunk_type: &mut ChunkType,
+    _node: tree_sitter::Node,
+    _source: &str,
+) -> bool {
+    if let Some(stripped) = name.strip_prefix('$') {
+        *name = stripped.to_string();
+    }
+    true
+}
+
+fn extract_return(signature: &str) -> Option<String> {
+    // PHP: function name(params): ReturnType { ... }
+    // Look for ): ReturnType after last )
+    let paren_pos = signature.rfind(')')?;
+    let after_paren = &signature[paren_pos + 1..];
+    let colon_pos = after_paren.find(':')?;
+    let end_pos = after_paren.find('{').unwrap_or(after_paren.len());
+    // Colon must come before brace
+    if colon_pos + 1 >= end_pos {
+        return None;
+    }
+    let ret_type = after_paren[colon_pos + 1..end_pos].trim();
+    if ret_type.is_empty() || ret_type == "void" || ret_type == "mixed" {
+        return None;
+    }
+    // Strip nullable prefix
+    let ret_type = ret_type.strip_prefix('?').unwrap_or(ret_type);
+    let ret_words = crate::nl::tokenize_identifier(ret_type).join(" ");
+    Some(format!("Returns {}", ret_words))
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "php",
+    grammar: Some(|| tree_sitter_php::LANGUAGE_PHP.into()),
+    extensions: &["php"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &["declaration_list"],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, parent| format!("{parent}/{stem}Test.php")),
+    type_query: Some(TYPE_QUERY),
+    common_types: COMMON_TYPES,
+    container_body_kinds: &["declaration_list"],
+    extract_container_name: None,
+    extract_qualified_method: None,
+    post_process_chunk: Some(post_process_php),
+    test_markers: &["@test", "function test"],
+    test_path_patterns: &["%/tests/%", "%/Tests/%", "%Test.php"],
+    structural_matchers: None,
+    entry_point_names: &[],
+    trait_method_names: &[
+        "__construct",
+        "__destruct",
+        "__toString",
+        "__get",
+        "__set",
+        "__call",
+        "__isset",
+        "__unset",
+        "__sleep",
+        "__wakeup",
+        "__clone",
+        "__invoke",
+    ],
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_php_class() {
+        let content = r#"<?php
+class User {
+    private string $name;
+    public function getName(): string {
+        return $this->name;
+    }
+}
+"#;
+        let file = write_temp_file(content, "php");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let class = chunks.iter().find(|c| c.name == "User").unwrap();
+        assert_eq!(class.chunk_type, ChunkType::Class);
+    }
+
+    #[test]
+    fn parse_php_interface() {
+        let content = r#"<?php
+interface Printable {
+    public function print(): void;
+}
+"#;
+        let file = write_temp_file(content, "php");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let iface = chunks.iter().find(|c| c.name == "Printable").unwrap();
+        assert_eq!(iface.chunk_type, ChunkType::Interface);
+    }
+
+    #[test]
+    fn parse_php_trait() {
+        let content = r#"<?php
+trait Timestampable {
+    public function getCreatedAt(): string {
+        return date('Y-m-d');
+    }
+}
+"#;
+        let file = write_temp_file(content, "php");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let t = chunks.iter().find(|c| c.name == "Timestampable").unwrap();
+        assert_eq!(t.chunk_type, ChunkType::Trait);
+    }
+
+    #[test]
+    fn parse_php_enum() {
+        let content = r#"<?php
+enum Status: string {
+    case Active = 'active';
+    case Inactive = 'inactive';
+}
+"#;
+        let file = write_temp_file(content, "php");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let e = chunks.iter().find(|c| c.name == "Status").unwrap();
+        assert_eq!(e.chunk_type, ChunkType::Enum);
+    }
+
+    #[test]
+    fn parse_php_function() {
+        let content = r#"<?php
+function formatDuration(int $seconds): string {
+    $hours = intdiv($seconds, 3600);
+    return "{$hours}h";
+}
+"#;
+        let file = write_temp_file(content, "php");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "formatDuration").unwrap();
+        assert_eq!(func.chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_php_method_in_class() {
+        let content = r#"<?php
+class Calculator {
+    public function add(int $a, int $b): int {
+        return $a + $b;
+    }
+}
+"#;
+        let file = write_temp_file(content, "php");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let method = chunks.iter().find(|c| c.name == "add").unwrap();
+        assert_eq!(method.chunk_type, ChunkType::Method);
+        assert_eq!(method.parent_type_name.as_deref(), Some("Calculator"));
+    }
+
+    #[test]
+    fn parse_php_constructor() {
+        let content = r#"<?php
+class User {
+    public function __construct(private string $name) {}
+}
+"#;
+        let file = write_temp_file(content, "php");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let ctor = chunks.iter().find(|c| c.name == "__construct").unwrap();
+        assert_eq!(ctor.chunk_type, ChunkType::Method);
+        assert_eq!(ctor.parent_type_name.as_deref(), Some("User"));
+    }
+
+    #[test]
+    fn parse_php_calls() {
+        // NOTE: PHP grammar requires <?php tag, so extract_calls_from_chunk (which
+        // re-parses chunk content without the tag) won't work. Use parse_file_calls
+        // instead — this is the production path.
+        let content = r#"<?php
+function process(string $input): int {
+    $trimmed = trim($input);
+    $result = intval($trimmed);
+    echo $result;
+    return $result;
+}
+"#;
+        let file = write_temp_file(content, "php");
+        let parser = Parser::new().unwrap();
+        let function_calls = parser.parse_file_calls(file.path()).unwrap();
+        let func = function_calls
+            .iter()
+            .find(|fc| fc.name == "process")
+            .unwrap();
+        let names: Vec<_> = func.calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(
+            names.contains(&"trim"),
+            "Expected trim call, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"intval"),
+            "Expected intval call, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn parse_php_property_strips_dollar() {
+        let content = r#"<?php
+class Config {
+    public string $name = "default";
+}
+"#;
+        let file = write_temp_file(content, "php");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let prop = chunks.iter().find(|c| c.chunk_type == ChunkType::Property).unwrap();
+        assert_eq!(prop.name, "name", "Property name should have $ stripped");
+    }
+
+    #[test]
+    fn test_extract_return_php() {
+        assert_eq!(
+            extract_return("function add(int $a, int $b): int {"),
+            Some("Returns int".to_string())
+        );
+        assert_eq!(
+            extract_return("function getName(): string {"),
+            Some("Returns string".to_string())
+        );
+        assert_eq!(extract_return("function doSomething(): void {"), None);
+        assert_eq!(extract_return("function doSomething(): mixed {"), None);
+        assert_eq!(
+            extract_return("function getUser(): ?User {"),
+            Some("Returns user".to_string())
+        );
+        assert_eq!(extract_return("function doSomething() {"), None);
+    }
+}

--- a/src/language/protobuf.rs
+++ b/src/language/protobuf.rs
@@ -1,0 +1,207 @@
+//! Protobuf language definition
+
+use super::{LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting Protobuf code chunks.
+///
+/// Messages → Struct, Services → Interface, RPCs → Function (reclassified to Method
+/// when inside a service via `method_containers`), Enums → Enum.
+const CHUNK_QUERY: &str = r#"
+;; Messages
+(message
+  (message_name
+    (identifier) @name)) @struct
+
+;; Services
+(service
+  (service_name
+    (identifier) @name)) @interface
+
+;; RPCs (inside services → Method via method_containers)
+(rpc
+  (rpc_name
+    (identifier) @name)) @function
+
+;; Enums
+(enum
+  (enum_name
+    (identifier) @name)) @enum
+"#;
+
+/// Tree-sitter query for extracting type references in Protobuf.
+///
+/// `message_or_enum_type` appears in field types and RPC input/output types.
+const CALL_QUERY: &str = r#"
+;; Type references in fields and RPCs
+(message_or_enum_type) @callee
+"#;
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    "syntax", "package", "import", "option", "message", "service", "rpc", "enum", "oneof", "map",
+    "repeated", "optional", "required", "reserved", "returns", "stream", "extend", "true", "false",
+    "string", "bytes", "bool", "int32", "int64", "uint32", "uint64", "sint32", "sint64", "fixed32",
+    "fixed64", "sfixed32", "sfixed64", "float", "double", "google",
+];
+
+/// Extract service name from a service node.
+///
+/// The proto grammar uses `service_name` children (not a `name` field),
+/// so the default container name extractor won't work.
+fn extract_container_name(node: tree_sitter::Node, source: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "service_name" {
+            return Some(source[child.byte_range()].to_string());
+        }
+    }
+    None
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "protobuf",
+    grammar: Some(|| tree_sitter_proto::LANGUAGE.into()),
+    extensions: &["proto"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &["service"],
+    stopwords: STOPWORDS,
+    extract_return_nl: |_| None,
+    test_file_suggestion: None,
+    type_query: None,
+    common_types: &[],
+    container_body_kinds: &[],
+    extract_container_name: Some(extract_container_name),
+    extract_qualified_method: None,
+    post_process_chunk: None,
+    test_markers: &[],
+    test_path_patterns: &[],
+    structural_matchers: None,
+    entry_point_names: &[],
+    trait_method_names: &[],
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_proto_message() {
+        let content = r#"
+syntax = "proto3";
+
+message User {
+  string name = 1;
+  int32 age = 2;
+}
+"#;
+        let file = write_temp_file(content, "proto");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let msg = chunks.iter().find(|c| c.name == "User").unwrap();
+        assert_eq!(msg.chunk_type, ChunkType::Struct);
+    }
+
+    #[test]
+    fn parse_proto_service() {
+        let content = r#"
+syntax = "proto3";
+
+service UserService {
+  rpc GetUser (GetUserRequest) returns (GetUserResponse);
+}
+"#;
+        let file = write_temp_file(content, "proto");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let svc = chunks
+            .iter()
+            .find(|c| c.name == "UserService" && c.chunk_type == ChunkType::Interface);
+        assert!(svc.is_some(), "Should find 'UserService' as Interface");
+    }
+
+    #[test]
+    fn parse_proto_rpc() {
+        let content = r#"
+syntax = "proto3";
+
+service UserService {
+  rpc GetUser (GetUserRequest) returns (GetUserResponse);
+  rpc ListUsers (ListUsersRequest) returns (stream User);
+}
+"#;
+        let file = write_temp_file(content, "proto");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let rpc = chunks.iter().find(|c| c.name == "GetUser").unwrap();
+        assert_eq!(rpc.chunk_type, ChunkType::Method);
+        assert_eq!(rpc.parent_type_name.as_deref(), Some("UserService"));
+    }
+
+    #[test]
+    fn parse_proto_enum() {
+        let content = r#"
+syntax = "proto3";
+
+enum Status {
+  UNKNOWN = 0;
+  ACTIVE = 1;
+  INACTIVE = 2;
+}
+"#;
+        let file = write_temp_file(content, "proto");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let e = chunks
+            .iter()
+            .find(|c| c.name == "Status" && c.chunk_type == ChunkType::Enum);
+        assert!(e.is_some(), "Should find 'Status' as Enum");
+    }
+
+    #[test]
+    fn parse_proto_calls() {
+        let content = r#"
+syntax = "proto3";
+
+message User {
+  string name = 1;
+  Address address = 2;
+}
+
+message Address {
+  string street = 1;
+}
+"#;
+        let file = write_temp_file(content, "proto");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let user = chunks.iter().find(|c| c.name == "User").unwrap();
+        let calls = parser.extract_calls_from_chunk(user);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(
+            names.contains(&"Address"),
+            "Expected Address type reference, got: {:?}",
+            names
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - **Semantic search**: Uses E5-base-v2 embeddings (769-dim: 768 model + sentiment)
 //! - **Notes with sentiment**: Unified memory system for AI collaborators
-//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Markdown (20 languages)
+//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Markdown (23 languages)
 //! - **GPU acceleration**: CUDA/TensorRT with CPU fallback
 //! - **CLI tools**: Call graph, impact analysis, test mapping, dead code detection
 //! - **Document conversion**: PDF, HTML, CHM, Web Help → cleaned Markdown (optional `convert` feature)

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -1012,6 +1012,7 @@ fn another() {
             // FSharp type query has pre-existing compile issues (#node-type mismatch)
             Language::Scala,
             Language::Cpp,
+            Language::Php,
         ];
         for lang in languages_with_types {
             let result = parser.get_type_query(lang);

--- a/tests/eval_common.rs
+++ b/tests/eval_common.rs
@@ -48,6 +48,12 @@ pub fn fixture_path(lang: Language) -> PathBuf {
         #[cfg(feature = "lang-objc")]
         Language::ObjC => "m",
         Language::Sql => "sql",
+        #[cfg(feature = "lang-protobuf")]
+        Language::Protobuf => "proto",
+        #[cfg(feature = "lang-graphql")]
+        Language::GraphQL => "graphql",
+        #[cfg(feature = "lang-php")]
+        Language::Php => "php",
         Language::Markdown => "md",
     };
     PathBuf::from(manifest_dir)
@@ -90,6 +96,12 @@ pub fn hard_fixture_path(lang: Language) -> PathBuf {
         #[cfg(feature = "lang-objc")]
         Language::ObjC => "m",
         Language::Sql => "sql",
+        #[cfg(feature = "lang-protobuf")]
+        Language::Protobuf => "proto",
+        #[cfg(feature = "lang-graphql")]
+        Language::GraphQL => "graphql",
+        #[cfg(feature = "lang-php")]
+        Language::Php => "php",
         Language::Markdown => "md",
     };
     PathBuf::from(manifest_dir)

--- a/tests/fixtures/sample.graphql
+++ b/tests/fixtures/sample.graphql
@@ -1,0 +1,56 @@
+"""
+A user in the system.
+"""
+type User {
+  id: ID!
+  name: String!
+  email: String!
+  posts: [Post!]!
+  address: Address
+}
+
+type Post {
+  id: ID!
+  title: String!
+  body: String!
+  author: User!
+}
+
+input CreateUserInput {
+  name: String!
+  email: String!
+}
+
+interface Node {
+  id: ID!
+}
+
+enum Status {
+  ACTIVE
+  INACTIVE
+  SUSPENDED
+}
+
+union SearchResult = User | Post
+
+scalar DateTime
+
+directive @auth(requires: Role!) on FIELD_DEFINITION
+
+query GetUser($id: ID!) {
+  user(id: $id) {
+    name
+    email
+    posts {
+      title
+    }
+  }
+}
+
+fragment UserFields on User {
+  name
+  email
+  address {
+    city
+  }
+}

--- a/tests/fixtures/sample.php
+++ b/tests/fixtures/sample.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+/**
+ * Represents a user in the system.
+ */
+class User
+{
+    private string $name;
+    private int $age;
+
+    public function __construct(string $name, int $age)
+    {
+        $this->name = $name;
+        $this->age = $age;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function greet(): string
+    {
+        return "Hello, " . $this->name;
+    }
+}
+
+interface Printable
+{
+    public function print(): void;
+}
+
+trait Timestampable
+{
+    public function getCreatedAt(): string
+    {
+        return date('Y-m-d');
+    }
+}
+
+enum Status: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+    case Suspended = 'suspended';
+}
+
+function formatDuration(int $seconds): string
+{
+    $hours = intdiv($seconds, 3600);
+    $minutes = intdiv($seconds % 3600, 60);
+    return "{$hours}h {$minutes}m";
+}

--- a/tests/fixtures/sample.proto
+++ b/tests/fixtures/sample.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+package example;
+
+// User message definition
+message User {
+  string name = 1;
+  int32 age = 2;
+  repeated string emails = 3;
+  Address address = 4;
+}
+
+message Address {
+  string street = 1;
+  string city = 2;
+  string country = 3;
+}
+
+// Request and response for user service
+message GetUserRequest {
+  string user_id = 1;
+}
+
+message GetUserResponse {
+  User user = 1;
+}
+
+enum Status {
+  UNKNOWN = 0;
+  ACTIVE = 1;
+  INACTIVE = 2;
+}
+
+service UserService {
+  rpc GetUser (GetUserRequest) returns (GetUserResponse);
+  rpc ListUsers (ListUsersRequest) returns (stream User);
+}
+
+message ListUsersRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+}

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -767,3 +767,158 @@ fn test_objc_class_and_protocol_extraction() {
     let calc = chunks.iter().find(|c| c.name == "calculateDistance");
     assert!(calc.is_some(), "Should find 'calculateDistance' function");
 }
+
+// ===== Protobuf tests =====
+
+#[test]
+fn test_protobuf_message_and_service_extraction() {
+    let parser = Parser::new().unwrap();
+    let path = fixtures_path().join("sample.proto");
+    let chunks = parser.parse_file(&path).unwrap();
+
+    assert!(
+        chunks.len() >= 4,
+        "Expected at least 4 Protobuf chunks, got {}",
+        chunks.len()
+    );
+
+    // Message → Struct
+    let user = chunks
+        .iter()
+        .find(|c| c.name == "User" && c.chunk_type == ChunkType::Struct);
+    assert!(user.is_some(), "Should find 'User' message (as Struct)");
+    assert_eq!(user.unwrap().language, Language::Protobuf);
+
+    // Service → Interface
+    let svc = chunks
+        .iter()
+        .find(|c| c.name == "UserService" && c.chunk_type == ChunkType::Interface);
+    assert!(
+        svc.is_some(),
+        "Should find 'UserService' service (as Interface)"
+    );
+
+    // Enum
+    let status = chunks
+        .iter()
+        .find(|c| c.name == "Status" && c.chunk_type == ChunkType::Enum);
+    assert!(status.is_some(), "Should find 'Status' enum");
+
+    // RPC → Method (inside service)
+    let rpc = chunks
+        .iter()
+        .find(|c| c.name == "GetUser" && c.chunk_type == ChunkType::Method);
+    assert!(
+        rpc.is_some(),
+        "Should find 'GetUser' RPC (as Method). Types: {:?}",
+        chunks
+            .iter()
+            .map(|c| format!("{}:{}", c.name, c.chunk_type))
+            .collect::<Vec<_>>()
+    );
+}
+
+// ===== GraphQL tests =====
+
+#[test]
+fn test_graphql_type_extraction() {
+    let parser = Parser::new().unwrap();
+    let path = fixtures_path().join("sample.graphql");
+    let chunks = parser.parse_file(&path).unwrap();
+
+    assert!(
+        chunks.len() >= 6,
+        "Expected at least 6 GraphQL chunks, got {}",
+        chunks.len()
+    );
+
+    // Object type → Struct
+    let user = chunks
+        .iter()
+        .find(|c| c.name == "User" && c.chunk_type == ChunkType::Struct);
+    assert!(user.is_some(), "Should find 'User' type (as Struct)");
+    assert_eq!(user.unwrap().language, Language::GraphQL);
+
+    // Interface
+    let node = chunks
+        .iter()
+        .find(|c| c.name == "Node" && c.chunk_type == ChunkType::Interface);
+    assert!(node.is_some(), "Should find 'Node' interface");
+
+    // Enum
+    let status = chunks
+        .iter()
+        .find(|c| c.name == "Status" && c.chunk_type == ChunkType::Enum);
+    assert!(status.is_some(), "Should find 'Status' enum");
+
+    // Union → TypeAlias
+    let search = chunks
+        .iter()
+        .find(|c| c.name == "SearchResult" && c.chunk_type == ChunkType::TypeAlias);
+    assert!(
+        search.is_some(),
+        "Should find 'SearchResult' union (as TypeAlias)"
+    );
+
+    // Operation → Function
+    let query = chunks
+        .iter()
+        .find(|c| c.name == "GetUser" && c.chunk_type == ChunkType::Function);
+    assert!(
+        query.is_some(),
+        "Should find 'GetUser' operation (as Function)"
+    );
+
+    // Fragment → Function
+    let frag = chunks
+        .iter()
+        .find(|c| c.name == "UserFields" && c.chunk_type == ChunkType::Function);
+    assert!(
+        frag.is_some(),
+        "Should find 'UserFields' fragment (as Function)"
+    );
+}
+
+// ===== PHP tests =====
+
+#[test]
+fn test_php_class_and_function_extraction() {
+    let parser = Parser::new().unwrap();
+    let path = fixtures_path().join("sample.php");
+    let chunks = parser.parse_file(&path).unwrap();
+
+    assert!(
+        chunks.len() >= 5,
+        "Expected at least 5 PHP chunks, got {}",
+        chunks.len()
+    );
+
+    // Class
+    let user = chunks
+        .iter()
+        .find(|c| c.name == "User" && c.chunk_type == ChunkType::Class);
+    assert!(user.is_some(), "Should find 'User' class");
+    assert_eq!(user.unwrap().language, Language::Php);
+
+    // Interface
+    let printable = chunks
+        .iter()
+        .find(|c| c.name == "Printable" && c.chunk_type == ChunkType::Interface);
+    assert!(printable.is_some(), "Should find 'Printable' interface");
+
+    // Trait
+    let ts = chunks
+        .iter()
+        .find(|c| c.name == "Timestampable" && c.chunk_type == ChunkType::Trait);
+    assert!(ts.is_some(), "Should find 'Timestampable' trait");
+
+    // Enum
+    let status = chunks
+        .iter()
+        .find(|c| c.name == "Status" && c.chunk_type == ChunkType::Enum);
+    assert!(status.is_some(), "Should find 'Status' enum");
+
+    // Free function
+    let fmt = chunks.iter().find(|c| c.name == "formatDuration");
+    assert!(fmt.is_some(), "Should find 'formatDuration' function");
+}


### PR DESCRIPTION
## Summary

- **Protobuf** — messages (Struct), services (Interface), RPCs (Method via `extract_container_name`), enums, type references via `message_or_enum_type`. Crate: `tree-sitter-proto` v0.4
- **GraphQL** — 9 definition types: object types, interfaces, enums, unions (TypeAlias), input types, scalars, directives (Macro), operations, fragments. Type references via `named_type`. Crate: `tree-sitter-graphql` v0.1
- **PHP** — full OOP: classes, interfaces, traits, enums, functions, methods (via `declaration_list` container), properties (`$` stripped via `post_process_chunk`), constants. Call extraction (function/method/static/constructor), type references (params, returns, fields, extends, implements), return type parsing. Crate: `tree-sitter-php` v0.24

### Notable fixes during implementation
- PHP `extract_calls_from_chunk` doesn't work (LANGUAGE_PHP requires `<?php` tag, chunk content lacks it) — tests use `parse_file_calls` (production path) instead
- Fuzz test found panic in PHP `extract_return` on input `"){:"` — added colon-before-brace guard
- Protobuf has no `service_body` node — RPCs are direct children of `service`, solved with custom `extract_container_name`

### Test coverage
- 28 new tests (25 unit + 3 integration), 1324 total pass
- Zero clippy warnings, zero build warnings

### Version
0.19.5 → 0.20.0

## Test plan

- [x] `cargo test --features gpu-index` — 1324 pass, 0 fail
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --features gpu-index` — zero warnings
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
