### PR TITLE
feat: add Elixir, Erlang, Haskell language support (31 languages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Elixir, Erlang, and Haskell language support — 28 → 31 languages.
+
+### Added
+- **Elixir language support** — functions (def/defp), modules (defmodule), protocols (defprotocol → Interface), implementations (defimpl → Object), macros (defmacro), guards, delegates, pipe call extraction
+- **Erlang language support** — functions (fun_decl), modules, records (Struct), type aliases, opaque types, behaviours (Interface), callbacks, local and remote call extraction
+- **Haskell language support** — functions, data types (Enum), newtypes (Struct), type synonyms (TypeAlias), typeclasses (Trait), instances (Object), return type extraction from type signatures, function application call extraction
+
 ## [0.21.0] - 2026-03-04
 
 Lua, Zig, R, YAML, and TOML language support — 23 → 28 languages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Thank you for your interest in contributing to cqs!
 
 ### Feature Ideas
 
-- Additional language support (see `src/language/` for current list — 28 languages supported)
+- Additional language support (see `src/language/` for current list — 31 languages supported)
 - Non-CUDA GPU support (ROCm for AMD, Metal for Apple Silicon)
 - VS Code extension
 - Performance improvements
@@ -105,7 +105,7 @@ src/
     watch.rs    - File watcher for incremental reindexing
   language/     - Tree-sitter language support
     mod.rs      - Language enum, LanguageRegistry, LanguageDef, ChunkType
-    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, kotlin.rs, swift.rs, objc.rs, sql.rs, protobuf.rs, graphql.rs, php.rs, lua.rs, zig.rs, r.rs, yaml.rs, toml_lang.rs, markdown.rs
+    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, kotlin.rs, swift.rs, objc.rs, sql.rs, protobuf.rs, graphql.rs, php.rs, lua.rs, zig.rs, r.rs, yaml.rs, toml_lang.rs, elixir.rs, erlang.rs, haskell.rs, markdown.rs
   store/        - SQLite storage layer (Schema v11, WAL mode)
     mod.rs      - Store struct, open/init, FTS5, RRF fusion
     chunks.rs   - Chunk CRUD, embedding_batches() for streaming

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,9 +683,12 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
+ "tree-sitter-elixir",
+ "tree-sitter-erlang",
  "tree-sitter-fsharp",
  "tree-sitter-go",
  "tree-sitter-graphql",
+ "tree-sitter-haskell",
  "tree-sitter-hcl",
  "tree-sitter-java",
  "tree-sitter-javascript",
@@ -4068,6 +4071,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-elixir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-erlang"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2091cce4eda19c03d77928c608ac6617445a6a25691dde1e93ac0102467a6be"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-fsharp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4092,6 +4115,16 @@ name = "tree-sitter-graphql"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efedc4cac157161cc23a0adc4553a2cedc908e1cd754b6cd033a919bb81ce5d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-haskell"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977c51e504548cba13fc27cb5a2edab2124cf6716a1934915d07ab99523b05a4"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cqs"
 version = "0.21.0"
 edition = "2021"
 rust-version = "1.93"
-description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 28 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."
+description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 31 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."
 license = "MIT"
 repository = "https://github.com/jamie8johnson/cqs"
 homepage = "https://github.com/jamie8johnson/cqs"
@@ -55,6 +55,10 @@ tree-sitter-zig = { version = "1.1", optional = true }
 tree-sitter-r = { version = "1.2", optional = true }
 tree-sitter-yaml = { version = "0.7", optional = true }
 tree-sitter-toml = { version = "0.7", package = "tree-sitter-toml-ng", optional = true }
+tree-sitter-elixir = { version = "0.3", optional = true }
+tree-sitter-erlang = { version = "0.15", optional = true }
+tree-sitter-haskell = { version = "0.23", optional = true }
+# tree-sitter-clojure blocked: 0.1.0 requires tree-sitter ^0.25, incompatible with 0.26
 
 # ML
 ort = { version = "2.0.0-rc.11", features = ["cuda", "tensorrt"] }
@@ -120,7 +124,7 @@ rustyline = "17"
 libc = "0.2"
 
 [features]
-default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-lua", "lang-zig", "lang-r", "lang-yaml", "lang-toml", "lang-markdown", "convert"]
+default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-lua", "lang-zig", "lang-r", "lang-yaml", "lang-toml", "lang-elixir", "lang-erlang", "lang-haskell", "lang-markdown", "convert"]
 
 # Language support (opt-in, all enabled by default)
 lang-rust = ["dep:tree-sitter-rust"]
@@ -150,8 +154,11 @@ lang-zig = ["dep:tree-sitter-zig"]
 lang-r = ["dep:tree-sitter-r"]
 lang-yaml = ["dep:tree-sitter-yaml"]
 lang-toml = ["dep:tree-sitter-toml"]
+lang-elixir = ["dep:tree-sitter-elixir"]
+lang-erlang = ["dep:tree-sitter-erlang"]
+lang-haskell = ["dep:tree-sitter-haskell"]
 lang-markdown = []  # No external deps — custom parser
-lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-lua", "lang-zig", "lang-r", "lang-yaml", "lang-toml", "lang-markdown"]
+lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-lua", "lang-zig", "lang-r", "lang-yaml", "lang-toml", "lang-elixir", "lang-erlang", "lang-haskell", "lang-markdown"]
 
 # Document conversion
 convert = ["dep:fast_html2md", "dep:walkdir"]

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,18 +2,15 @@
 
 ## Right Now
 
-**Audit complete.** 2026-03-04.
+**Mass language expansion.** 2026-03-04.
 
-v0.19.5 release in progress. Full 75-finding audit resolved:
-- P1: 6 fixes (PR #522)
-- P2: 4 fixes (PR #523)
-- P3: 43/50 fixed, 7 acceptable/moot (PR #524)
-- P4: 9/19 fixed, 10 triaged (PR #525)
-- 4 dep bumps merged (#516-#520)
+Batch 2 complete (Elixir, Erlang, Haskell). 28 → 31 languages.
+- Clojure blocked: `tree-sitter-clojure` 0.1.0 requires tree-sitter ^0.25, incompatible with 0.26
+- PR pending for Batch 2 (branch `feat/lang-elixir-erlang-haskell`)
 
 ## Pending Changes
 
-None — clean working tree on main.
+Batch 2 language files + fixtures + tests ready for commit.
 
 ## Parked
 
@@ -46,9 +43,9 @@ None — clean working tree on main.
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
-- 28 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Markdown)
+- 31 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Haskell, Markdown)
 - 16 ChunkType variants (Function, Method, Struct, Class, Interface, Enum, Trait, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias)
-- Tests: 1351 pass, 0 failures
+- Tests: 1371 pass, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code intelligence and RAG for AI agents. Semantic search, call graph analysis, impact tracing, type dependencies, and smart context assembly — all in single tool calls. Local ML embeddings, GPU-accelerated.
 
-**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval. 28 languages, GPU-accelerated.
+**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval. 31 languages, GPU-accelerated.
 
 [![Crates.io](https://img.shields.io/crates/v/cqs.svg)](https://crates.io/crates/cqs)
 [![CI](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml/badge.svg)](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml)
@@ -436,6 +436,9 @@ Keep index fresh: run `cqs watch` in a background terminal, or `cqs index` after
 - TOML (tables, arrays of tables, key-value pairs)
 - YAML (mapping keys, sequences, documents)
 - Zig (functions, structs, enums, unions, error sets, test declarations)
+- Elixir (functions, modules, protocols, implementations, macros, pipe calls)
+- Erlang (functions, modules, records, type aliases, behaviours, callbacks)
+- Haskell (functions, data types, newtypes, type synonyms, typeclasses, instances)
 - Markdown (.md, .mdx — heading-based chunking with cross-reference extraction)
 
 ## Indexing
@@ -453,7 +456,7 @@ cqs index --dry-run    # Show what would be indexed
 
 **Parse → Embed → Index → Reason**
 
-1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 28 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
+1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 31 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
 2. **Describe** — Each code element gets a natural language description incorporating doc comments, parameter types, return types, and parent type context (e.g., methods include their struct/class name). This bridges the gap between how developers describe code and how it's written.
 3. **Embed** — E5-base-v2 generates 769-dimensional embeddings (768 semantic + 1 sentiment) locally. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval — outperforms code-specific models because NL descriptions play to general-purpose model strengths.
 4. **Index** — SQLite stores chunks, embeddings, call graph edges, and type dependency edges. HNSW provides fast approximate nearest-neighbor search. FTS5 enables keyword matching.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current: v0.21.0
 
-All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 28 languages. Two full audits complete (v0.12.3 + v0.19.2).
+All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 31 languages. Two full audits complete (v0.12.3 + v0.19.2).
 
 ### Next — Commands
 
@@ -19,9 +19,17 @@ All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 28 lan
 
 ### Future Languages — Priority Order
 
-- [ ] **Elixir** — Module + Macro exist. defprotocol → Trait, defrecord → Struct. Clean mapping.
-- [ ] **Haskell** — TypeAlias exists. data → Enum, class → Trait. Niche but loved.
-- [ ] **Dart** — Property covers properties, mixin → Trait
+- [x] **Elixir** — Module + Macro exist. defprotocol → Interface, defimpl → Object. Clean mapping.
+- [x] **Erlang** — FP + modules, behaviour → Interface, record → Struct.
+- [x] **Haskell** — data → Enum, newtype → Struct, type synonym → TypeAlias, class → Trait, instance → Object.
+- [ ] **Clojure** — Blocked: `tree-sitter-clojure` 0.1.0 requires tree-sitter ^0.25, incompatible with 0.26.
+- [ ] **OCaml** — FP + modules. Uses `LANGUAGE_OCAML` export.
+- [ ] **Julia** — Scientific + types.
+- [ ] **Gleam** — FP + types.
+- [ ] **CSS** — Selectors + rules. Rule sets → Section.
+- [ ] **Perl** — Subs + packages. OOP via bless.
+- [ ] **Dart** — Blocked: old tree-sitter API (pre-0.24). Property covers properties, mixin → Trait.
+- [ ] **ArchestrA QuickScript** — No tree-sitter grammar exists. Needs custom grammar from scratch (VB-like syntax).
 
 ### ChunkType Variant Status
 

--- a/src/language/elixir.rs
+++ b/src/language/elixir.rs
@@ -1,0 +1,328 @@
+//! Elixir language definition
+
+use super::{ChunkType, LanguageDef, PostProcessChunkFn, SignatureStyle};
+
+/// Tree-sitter query for extracting Elixir code chunks.
+///
+/// Elixir has no dedicated node types for `def`/`defmodule` etc. — everything
+/// is a generic `call` node. The keyword (`def`, `defmodule`, etc.) is just an
+/// `identifier` in the `target` field. We match the generic call structure and
+/// reclassify in `post_process_elixir` based on the target identifier text.
+///
+/// Patterns matched:
+///   - `def foo(args) do ... end` → Function
+///   - `defp foo(args) do ... end` → Function (private)
+///   - `defmodule Foo do ... end` → Module
+///   - `defprotocol Foo do ... end` → Interface
+///   - `defimpl Foo do ... end` → Object (protocol implementation)
+///   - `defmacro foo(args) do ... end` → Macro
+///   - `defstruct [...]` → Struct
+///   - `defguard foo(args)` → Function
+///   - `defdelegate foo(args)` → Function
+const CHUNK_QUERY: &str = r#"
+;; Function with arguments: def foo(args) do ... end
+(call
+  target: (identifier) @_keyword
+  (arguments
+    (call
+      target: (identifier) @name))
+  (#any-of? @_keyword "def" "defp" "defmacro" "defmacrop" "defguard" "defguardp" "defdelegate")) @function
+
+;; Function with guard: def foo(args) when guard do ... end
+(call
+  target: (identifier) @_keyword
+  (arguments
+    (binary_operator
+      left: (call
+        target: (identifier) @name)))
+  (#any-of? @_keyword "def" "defp" "defmacro" "defmacrop" "defguard" "defguardp")) @function
+
+;; Zero-arity function: def foo do ... end
+(call
+  target: (identifier) @_keyword
+  (arguments
+    (identifier) @name)
+  (#any-of? @_keyword "def" "defp" "defmacro" "defmacrop" "defguard" "defguardp" "defdelegate")) @function
+
+;; Module definition: defmodule MyApp.Foo do ... end
+(call
+  target: (identifier) @_keyword
+  (arguments
+    (alias) @name)
+  (#any-of? @_keyword "defmodule" "defprotocol")) @struct
+
+;; defimpl: defimpl Protocol, for: Type do ... end
+(call
+  target: (identifier) @_keyword
+  (arguments
+    (alias) @name)
+  (#eq? @_keyword "defimpl")) @struct
+
+;; defstruct: defstruct [:field1, :field2]
+(call
+  target: (identifier) @_keyword
+  (#eq? @_keyword "defstruct")) @struct
+"#;
+
+/// Tree-sitter query for extracting Elixir function calls.
+const CALL_QUERY: &str = r#"
+;; Local function call: foo(args)
+(call
+  target: (identifier) @callee
+  (#not-any-of? @callee "def" "defp" "defmodule" "defprotocol" "defimpl" "defmacro" "defmacrop" "defstruct" "defguard" "defguardp" "defdelegate" "defexception" "defoverridable" "use" "import" "require" "alias"))
+
+;; Remote function call: Module.function(args)
+(call
+  target: (dot
+    right: (identifier) @callee))
+
+;; Pipe into function: data |> function
+(binary_operator
+  operator: "|>"
+  right: (identifier) @callee)
+"#;
+
+/// Doc comment node types — Elixir uses `@doc` and `@moduledoc` (comments are generic)
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    "def", "defp", "defmodule", "defprotocol", "defimpl", "defmacro", "defmacrop", "defstruct",
+    "defguard", "defguardp", "defdelegate", "defexception", "defoverridable", "do", "end", "fn",
+    "case", "cond", "if", "else", "unless", "when", "with", "for", "receive", "try", "catch",
+    "rescue", "after", "raise", "throw", "import", "require", "use", "alias", "nil", "true",
+    "false", "and", "or", "not", "in", "is", "self", "super", "send", "spawn", "apply",
+    "Enum", "List", "Map", "String", "IO", "Kernel", "Agent", "Task", "GenServer",
+];
+
+/// Post-process Elixir chunks to set correct chunk types.
+fn post_process_elixir(
+    name: &mut String,
+    chunk_type: &mut ChunkType,
+    node: tree_sitter::Node,
+    source: &str,
+) -> bool {
+    // Get the keyword from the target identifier
+    let keyword = node
+        .child_by_field_name("target")
+        .and_then(|t| t.utf8_text(source.as_bytes()).ok())
+        .unwrap_or("");
+
+    match keyword {
+        "def" | "defp" | "defguard" | "defguardp" | "defdelegate" => {
+            *chunk_type = ChunkType::Function;
+        }
+        "defmacro" | "defmacrop" => {
+            *chunk_type = ChunkType::Macro;
+        }
+        "defmodule" => {
+            *chunk_type = ChunkType::Module;
+        }
+        "defprotocol" => {
+            *chunk_type = ChunkType::Interface;
+        }
+        "defimpl" => {
+            *chunk_type = ChunkType::Object;
+        }
+        "defstruct" => {
+            // defstruct has no name argument — use enclosing module name if possible
+            *chunk_type = ChunkType::Struct;
+            // Walk up to find enclosing defmodule call
+            let mut parent = node.parent();
+            while let Some(p) = parent {
+                if p.kind() == "call" {
+                    if let Some(target) = p.child_by_field_name("target") {
+                        if target.utf8_text(source.as_bytes()).ok() == Some("defmodule") {
+                            // Find alias in arguments by walking children
+                            let mut cursor = p.walk();
+                            for child in p.named_children(&mut cursor) {
+                                if child.kind() == "arguments" {
+                                    let mut inner_cursor = child.walk();
+                                    for arg in child.named_children(&mut inner_cursor) {
+                                        if arg.kind() == "alias" {
+                                            if let Ok(mod_name) =
+                                                arg.utf8_text(source.as_bytes())
+                                            {
+                                                *name = mod_name.to_string();
+                                                return true;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                parent = p.parent();
+            }
+            // If no enclosing module, discard
+            return false;
+        }
+        _ => {}
+    }
+    true
+}
+
+fn extract_return(_signature: &str) -> Option<String> {
+    // Elixir is dynamically typed — no return type annotations in signatures
+    None
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "elixir",
+    grammar: Some(|| tree_sitter_elixir::LANGUAGE.into()),
+    extensions: &["ex", "exs"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::FirstLine,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &[],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, _parent| format!("test/{stem}_test.exs")),
+    type_query: None,
+    common_types: &[],
+    container_body_kinds: &["do_block"],
+    extract_container_name: None,
+    extract_qualified_method: None,
+    post_process_chunk: Some(post_process_elixir as PostProcessChunkFn),
+    test_markers: &["test ", "describe "],
+    test_path_patterns: &["%/test/%", "%_test.exs"],
+    structural_matchers: None,
+    entry_point_names: &["start", "init", "handle_call", "handle_cast", "handle_info"],
+    trait_method_names: &[
+        "init",
+        "handle_call",
+        "handle_cast",
+        "handle_info",
+        "terminate",
+        "code_change",
+    ],
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_elixir_function() {
+        let content = r#"
+defmodule MyApp do
+  def greet(name) do
+    "Hello, #{name}"
+  end
+end
+"#;
+        let file = write_temp_file(content, "ex");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "greet").unwrap();
+        assert_eq!(func.chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_elixir_module() {
+        let content = r#"
+defmodule MyApp.Users do
+  def list_users do
+    []
+  end
+end
+"#;
+        let file = write_temp_file(content, "ex");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let module = chunks
+            .iter()
+            .find(|c| c.name == "MyApp.Users" && c.chunk_type == ChunkType::Module);
+        assert!(module.is_some(), "Should find 'MyApp.Users' module");
+    }
+
+    #[test]
+    fn parse_elixir_protocol() {
+        let content = r#"
+defprotocol Printable do
+  def to_string(data)
+end
+"#;
+        let file = write_temp_file(content, "ex");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let proto = chunks
+            .iter()
+            .find(|c| c.name == "Printable" && c.chunk_type == ChunkType::Interface);
+        assert!(proto.is_some(), "Should find 'Printable' protocol/interface");
+    }
+
+    #[test]
+    fn parse_elixir_macro() {
+        let content = r#"
+defmodule MyMacros do
+  defmacro my_if(condition, do: block) do
+    quote do
+      case unquote(condition) do
+        true -> unquote(block)
+        _ -> nil
+      end
+    end
+  end
+end
+"#;
+        let file = write_temp_file(content, "ex");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let mac = chunks
+            .iter()
+            .find(|c| c.name == "my_if" && c.chunk_type == ChunkType::Macro);
+        assert!(mac.is_some(), "Should find 'my_if' macro");
+    }
+
+    #[test]
+    fn parse_elixir_calls() {
+        let content = r#"
+defmodule Processor do
+  def process(data) do
+    data
+    |> String.trim()
+    |> transform()
+    |> IO.puts()
+  end
+
+  defp transform(data), do: data
+end
+"#;
+        let file = write_temp_file(content, "ex");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "process").unwrap();
+        let calls = parser.extract_calls_from_chunk(func);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(
+            names.contains(&"transform"),
+            "Expected transform, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn test_extract_return_elixir() {
+        assert_eq!(extract_return("def greet(name) do"), None);
+        assert_eq!(extract_return(""), None);
+    }
+}

--- a/src/language/erlang.rs
+++ b/src/language/erlang.rs
@@ -1,0 +1,237 @@
+//! Erlang language definition
+
+use super::{ChunkType, LanguageDef, PostProcessChunkFn, SignatureStyle};
+
+/// Tree-sitter query for extracting Erlang code chunks.
+///
+/// Erlang top-level forms:
+///   - `fun_decl` → Function (with `function_clause` children)
+///   - `module_attribute` → Module
+///   - `type_alias` / `opaque` → TypeAlias
+///   - `record_decl` → Struct
+///   - `behaviour_attribute` → Interface
+///   - `callback` → Interface
+///   - `spec` → skipped (attached to function, not standalone chunk)
+const CHUNK_QUERY: &str = r#"
+;; Function declaration (the outermost form wrapping function_clause(s))
+(fun_decl
+  clause: (function_clause
+    name: (atom) @name)) @function
+
+;; Module attribute: -module(name).
+(module_attribute
+  name: (atom) @name) @struct
+
+;; Type alias: -type name(...) :: ...
+(type_alias
+  name: (type_name
+    name: (atom) @name)) @struct
+
+;; Opaque type: -opaque name(...) :: ...
+(opaque
+  name: (type_name
+    name: (atom) @name)) @struct
+
+;; Record declaration: -record(name, {fields}).
+(record_decl
+  name: (atom) @name) @struct
+
+;; Behaviour attribute: -behaviour(name).
+(behaviour_attribute
+  name: (atom) @name) @interface
+
+;; Callback: -callback name(Args) -> Ret.
+(callback
+  fun: (atom) @name) @interface
+"#;
+
+/// Tree-sitter query for extracting Erlang function calls.
+const CALL_QUERY: &str = r#"
+;; Local function call: foo(args)
+(call
+  expr: (atom) @callee)
+
+;; Remote function call: module:function(args)
+(call
+  expr: (remote
+    fun: (atom) @callee))
+"#;
+
+/// Doc comment node types — Erlang uses %% comments
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    "module", "export", "import", "behaviour", "behavior", "callback", "spec", "type", "opaque",
+    "record", "define", "ifdef", "ifndef", "endif", "include", "include_lib", "fun", "end",
+    "case", "of", "if", "receive", "after", "when", "try", "catch", "throw", "begin", "and",
+    "or", "not", "band", "bor", "bxor", "bnot", "bsl", "bsr", "div", "rem", "true", "false",
+    "undefined", "ok", "error", "self", "lists", "maps", "io", "gen_server", "gen_statem",
+    "supervisor", "application", "ets", "mnesia", "erlang", "string", "binary",
+];
+
+/// Post-process Erlang chunks to set correct chunk types.
+fn post_process_erlang(
+    _name: &mut String,
+    chunk_type: &mut ChunkType,
+    node: tree_sitter::Node,
+    _source: &str,
+) -> bool {
+    match node.kind() {
+        "fun_decl" => *chunk_type = ChunkType::Function,
+        "module_attribute" => *chunk_type = ChunkType::Module,
+        "type_alias" | "opaque" => *chunk_type = ChunkType::TypeAlias,
+        "record_decl" => *chunk_type = ChunkType::Struct,
+        "behaviour_attribute" => *chunk_type = ChunkType::Interface,
+        "callback" => *chunk_type = ChunkType::Interface,
+        _ => {}
+    }
+    true
+}
+
+fn extract_return(_signature: &str) -> Option<String> {
+    // Erlang is dynamically typed — no return types in function heads
+    None
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "erlang",
+    grammar: Some(|| tree_sitter_erlang::LANGUAGE.into()),
+    extensions: &["erl", "hrl"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::FirstLine,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &[],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, _parent| format!("test/{stem}_SUITE.erl")),
+    type_query: None,
+    common_types: &[],
+    container_body_kinds: &[],
+    extract_container_name: None,
+    extract_qualified_method: None,
+    post_process_chunk: Some(post_process_erlang as PostProcessChunkFn),
+    test_markers: &[],
+    test_path_patterns: &["%/test/%", "%_SUITE.erl", "%_tests.erl"],
+    structural_matchers: None,
+    entry_point_names: &[
+        "start",
+        "start_link",
+        "init",
+        "handle_call",
+        "handle_cast",
+        "handle_info",
+    ],
+    trait_method_names: &[
+        "init",
+        "handle_call",
+        "handle_cast",
+        "handle_info",
+        "terminate",
+        "code_change",
+    ],
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_erlang_function() {
+        let content = r#"
+-module(mymod).
+-export([greet/1]).
+
+greet(Name) ->
+    io:format("Hello, ~s~n", [Name]).
+"#;
+        let file = write_temp_file(content, "erl");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "greet").unwrap();
+        assert_eq!(func.chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_erlang_module() {
+        let content = r#"
+-module(calculator).
+-export([add/2]).
+
+add(A, B) -> A + B.
+"#;
+        let file = write_temp_file(content, "erl");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let module = chunks
+            .iter()
+            .find(|c| c.name == "calculator" && c.chunk_type == ChunkType::Module);
+        assert!(module.is_some(), "Should find 'calculator' module");
+    }
+
+    #[test]
+    fn parse_erlang_record() {
+        let content = r#"
+-module(mymod).
+-record(state, {count = 0, name}).
+
+init() -> #state{count = 0, name = "test"}.
+"#;
+        let file = write_temp_file(content, "erl");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let record = chunks
+            .iter()
+            .find(|c| c.name == "state" && c.chunk_type == ChunkType::Struct);
+        assert!(record.is_some(), "Should find 'state' record/struct");
+    }
+
+    #[test]
+    fn parse_erlang_calls() {
+        let content = r#"
+-module(mymod).
+-export([process/1]).
+
+process(Data) ->
+    Trimmed = string:trim(Data),
+    io:format("~s~n", [Trimmed]),
+    helper(Trimmed).
+
+helper(X) -> X.
+"#;
+        let file = write_temp_file(content, "erl");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "process").unwrap();
+        let calls = parser.extract_calls_from_chunk(func);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(
+            names.contains(&"helper"),
+            "Expected helper, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn test_extract_return_erlang() {
+        assert_eq!(extract_return("greet(Name) ->"), None);
+        assert_eq!(extract_return(""), None);
+    }
+}

--- a/src/language/haskell.rs
+++ b/src/language/haskell.rs
@@ -1,0 +1,283 @@
+//! Haskell language definition
+
+use super::{ChunkType, LanguageDef, PostProcessChunkFn, SignatureStyle};
+
+/// Tree-sitter query for extracting Haskell code chunks.
+///
+/// Haskell constructs:
+///   - `function` → Function
+///   - `signature` → skipped (type signatures are associated with functions)
+///   - `data_type` → Struct or Enum (depending on constructor count)
+///   - `newtype` → Struct
+///   - `type_synomym` → TypeAlias (note: grammar has typo "synomym")
+///   - `class` → Trait
+///   - `instance` → Object (typeclass instance)
+const CHUNK_QUERY: &str = r#"
+;; Function definition: foo x y = ...
+(function
+  name: (variable) @name) @function
+
+;; Data type definition: data Foo = Bar | Baz
+(data_type
+  name: (name) @name) @struct
+
+;; Newtype definition: newtype Foo = Foo a
+(newtype
+  name: (name) @name) @struct
+
+;; Type synonym: type Foo = Bar
+(type_synomym
+  name: (name) @name) @struct
+
+;; Typeclass definition: class Foo a where ...
+(class
+  name: (name) @name) @trait
+
+;; Instance declaration: instance Foo Bar where ...
+(instance
+  name: (name) @name) @struct
+"#;
+
+/// Tree-sitter query for extracting Haskell calls.
+///
+/// Haskell uses `apply` for function application. We capture:
+///   - Direct application: `foo arg` → (apply function: (variable) ...)
+///   - Qualified application: `Data.Map.lookup key m`
+const CALL_QUERY: &str = r#"
+;; Direct function application: foo arg
+(apply
+  function: (variable) @callee)
+
+;; Qualified function call: Module.func arg
+(apply
+  function: (qualified
+    id: (variable) @callee))
+"#;
+
+/// Doc comment node types — Haskell uses `-- |` and `{- | -}` doc comments
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    "module", "where", "import", "qualified", "as", "hiding", "data", "type", "newtype", "class",
+    "instance", "deriving", "do", "let", "in", "case", "of", "if", "then", "else", "forall",
+    "infixl", "infixr", "infix", "default", "foreign", "True", "False", "Nothing", "Just",
+    "Maybe", "Either", "Left", "Right", "IO", "Int", "Integer", "Float", "Double", "Char",
+    "String", "Bool", "Show", "Read", "Eq", "Ord", "Num", "Monad", "Functor", "Applicative",
+    "Foldable", "Traversable", "return", "pure", "putStrLn", "print", "map", "filter", "fmap",
+];
+
+/// Post-process Haskell chunks to set correct chunk types.
+fn post_process_haskell(
+    _name: &mut String,
+    chunk_type: &mut ChunkType,
+    node: tree_sitter::Node,
+    _source: &str,
+) -> bool {
+    match node.kind() {
+        "function" => *chunk_type = ChunkType::Function,
+        "data_type" => *chunk_type = ChunkType::Enum,
+        "newtype" => *chunk_type = ChunkType::Struct,
+        "type_synomym" => *chunk_type = ChunkType::TypeAlias,
+        "class" => *chunk_type = ChunkType::Trait,
+        "instance" => *chunk_type = ChunkType::Object,
+        _ => {}
+    }
+    true
+}
+
+/// Extract return type from Haskell type signatures.
+///
+/// Haskell signatures: `foo :: Int -> Bool -> String`
+/// Return type is the last type after the final `->`.
+fn extract_return(signature: &str) -> Option<String> {
+    // Look for :: to find the type signature part
+    let type_part = signature.split("::").nth(1)?;
+
+    // The return type is after the last ->
+    let return_type = if type_part.contains("->") {
+        type_part.rsplit("->").next()?.trim()
+    } else {
+        // No arrows — single type (e.g., `foo :: Int`)
+        type_part.trim()
+    };
+
+    // Clean up: strip leading/trailing whitespace and "where" clauses
+    let return_type = return_type.split("where").next()?.trim();
+
+    if return_type.is_empty() {
+        return None;
+    }
+
+    // Skip IO/monadic wrappers — extract inner type if wrapped
+    let clean = return_type.strip_prefix("IO ").unwrap_or(return_type);
+
+    // Strip parentheses
+    let clean = clean.trim_start_matches('(').trim_end_matches(')').trim();
+
+    if clean.is_empty() || clean == "()" {
+        return None;
+    }
+
+    let ret_words = crate::nl::tokenize_identifier(clean).join(" ");
+    Some(format!("Returns {}", ret_words.to_lowercase()))
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "haskell",
+    grammar: Some(|| tree_sitter_haskell::LANGUAGE.into()),
+    extensions: &["hs"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::FirstLine,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &[],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+    test_file_suggestion: Some(|stem, _parent| format!("test/{stem}Spec.hs")),
+    type_query: None,
+    common_types: &[
+        "Int", "Integer", "Float", "Double", "Char", "String", "Bool", "IO", "Maybe", "Either",
+        "Show", "Read", "Eq", "Ord", "Num",
+    ],
+    container_body_kinds: &["class_declarations", "instance_declarations"],
+    extract_container_name: None,
+    extract_qualified_method: None,
+    post_process_chunk: Some(post_process_haskell as PostProcessChunkFn),
+    test_markers: &["hspec", "describe", "it ", "prop "],
+    test_path_patterns: &["%/test/%", "%Spec.hs", "%Test.hs"],
+    structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[
+        "show",
+        "read",
+        "readsPrec",
+        "showsPrec",
+        "compare",
+        "fmap",
+        "pure",
+        "return",
+        "fromInteger",
+    ],
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_haskell_function() {
+        let content = r#"
+greet :: String -> String
+greet name = "Hello, " ++ name
+"#;
+        let file = write_temp_file(content, "hs");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "greet").unwrap();
+        assert_eq!(func.chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_haskell_data_type() {
+        let content = r#"
+data Color = Red | Green | Blue
+"#;
+        let file = write_temp_file(content, "hs");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let dt = chunks
+            .iter()
+            .find(|c| c.name == "Color" && c.chunk_type == ChunkType::Enum);
+        assert!(dt.is_some(), "Should find 'Color' data type as Enum");
+    }
+
+    #[test]
+    fn parse_haskell_typeclass() {
+        let content = r#"
+class Printable a where
+  display :: a -> String
+"#;
+        let file = write_temp_file(content, "hs");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let tc = chunks
+            .iter()
+            .find(|c| c.name == "Printable" && c.chunk_type == ChunkType::Trait);
+        assert!(tc.is_some(), "Should find 'Printable' typeclass as Trait");
+    }
+
+    #[test]
+    fn parse_haskell_instance() {
+        let content = r#"
+data Color = Red | Green | Blue
+
+instance Show Color where
+  show Red = "Red"
+  show Green = "Green"
+  show Blue = "Blue"
+"#;
+        let file = write_temp_file(content, "hs");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let inst = chunks
+            .iter()
+            .find(|c| c.name == "Show" && c.chunk_type == ChunkType::Object);
+        assert!(inst.is_some(), "Should find 'Show' instance as Object");
+    }
+
+    #[test]
+    fn parse_haskell_calls() {
+        let content = r#"
+process :: String -> IO ()
+process text = do
+  let trimmed = trim text
+  putStrLn trimmed
+  validate trimmed
+"#;
+        let file = write_temp_file(content, "hs");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "process").unwrap();
+        let calls = parser.extract_calls_from_chunk(func);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(
+            names.contains(&"putStrLn"),
+            "Expected putStrLn, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn test_extract_return_haskell() {
+        assert_eq!(
+            extract_return("greet :: String -> String"),
+            Some("Returns string".to_string())
+        );
+        assert_eq!(
+            extract_return("add :: Int -> Int -> Int"),
+            Some("Returns int".to_string())
+        );
+        assert_eq!(
+            extract_return("main :: IO ()"),
+            None
+        );
+        assert_eq!(extract_return(""), None);
+    }
+}

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -34,6 +34,9 @@
 //! - `lang-r` - R support (enabled by default)
 //! - `lang-yaml` - YAML support (enabled by default)
 //! - `lang-toml` - TOML support (enabled by default)
+//! - `lang-elixir` - Elixir support (enabled by default)
+//! - `lang-erlang` - Erlang support (enabled by default)
+//! - `lang-haskell` - Haskell support (enabled by default)
 //! - `lang-all` - All languages
 
 use std::collections::HashMap;
@@ -553,6 +556,12 @@ define_languages! {
     Yaml => "yaml", feature = "lang-yaml", module = yaml;
     /// TOML (.toml files)
     Toml => "toml", feature = "lang-toml", module = toml_lang;
+    /// Elixir (.ex, .exs files)
+    Elixir => "elixir", feature = "lang-elixir", module = elixir;
+    /// Erlang (.erl, .hrl files)
+    Erlang => "erlang", feature = "lang-erlang", module = erlang;
+    /// Haskell (.hs files)
+    Haskell => "haskell", feature = "lang-haskell", module = haskell;
     /// Markdown (.md, .mdx files)
     Markdown => "markdown", feature = "lang-markdown", module = markdown;
 }
@@ -725,6 +734,18 @@ mod tests {
         }
         #[cfg(feature = "lang-toml")]
         assert!(REGISTRY.from_extension("toml").is_some());
+        #[cfg(feature = "lang-elixir")]
+        {
+            assert!(REGISTRY.from_extension("ex").is_some());
+            assert!(REGISTRY.from_extension("exs").is_some());
+        }
+        #[cfg(feature = "lang-erlang")]
+        {
+            assert!(REGISTRY.from_extension("erl").is_some());
+            assert!(REGISTRY.from_extension("hrl").is_some());
+        }
+        #[cfg(feature = "lang-haskell")]
+        assert!(REGISTRY.from_extension("hs").is_some());
         #[cfg(feature = "lang-markdown")]
         {
             assert!(REGISTRY.from_extension("md").is_some());
@@ -846,6 +867,18 @@ mod tests {
         {
             expected += 1;
         }
+        #[cfg(feature = "lang-elixir")]
+        {
+            expected += 1;
+        }
+        #[cfg(feature = "lang-erlang")]
+        {
+            expected += 1;
+        }
+        #[cfg(feature = "lang-haskell")]
+        {
+            expected += 1;
+        }
         #[cfg(feature = "lang-markdown")]
         {
             expected += 1;
@@ -926,6 +959,11 @@ mod tests {
         assert_eq!(Language::from_extension("yaml"), Some(Language::Yaml));
         assert_eq!(Language::from_extension("yml"), Some(Language::Yaml));
         assert_eq!(Language::from_extension("toml"), Some(Language::Toml));
+        assert_eq!(Language::from_extension("ex"), Some(Language::Elixir));
+        assert_eq!(Language::from_extension("exs"), Some(Language::Elixir));
+        assert_eq!(Language::from_extension("erl"), Some(Language::Erlang));
+        assert_eq!(Language::from_extension("hrl"), Some(Language::Erlang));
+        assert_eq!(Language::from_extension("hs"), Some(Language::Haskell));
         assert_eq!(Language::from_extension("md"), Some(Language::Markdown));
         assert_eq!(Language::from_extension("mdx"), Some(Language::Markdown));
         assert_eq!(Language::from_extension("unknown"), None);
@@ -964,6 +1002,9 @@ mod tests {
         assert_eq!("r".parse::<Language>().unwrap(), Language::R);
         assert_eq!("yaml".parse::<Language>().unwrap(), Language::Yaml);
         assert_eq!("toml".parse::<Language>().unwrap(), Language::Toml);
+        assert_eq!("elixir".parse::<Language>().unwrap(), Language::Elixir);
+        assert_eq!("erlang".parse::<Language>().unwrap(), Language::Erlang);
+        assert_eq!("haskell".parse::<Language>().unwrap(), Language::Haskell);
         assert_eq!("markdown".parse::<Language>().unwrap(), Language::Markdown);
         assert!("invalid".parse::<Language>().is_err());
     }
@@ -997,6 +1038,9 @@ mod tests {
         assert_eq!(Language::R.to_string(), "r");
         assert_eq!(Language::Yaml.to_string(), "yaml");
         assert_eq!(Language::Toml.to_string(), "toml");
+        assert_eq!(Language::Elixir.to_string(), "elixir");
+        assert_eq!(Language::Erlang.to_string(), "erlang");
+        assert_eq!(Language::Haskell.to_string(), "haskell");
         assert_eq!(Language::Markdown.to_string(), "markdown");
     }
 
@@ -1208,6 +1252,22 @@ mod tests {
         );
         assert_eq!((Language::Yaml.def().extract_return_nl)("key: value"), None);
         assert_eq!((Language::Toml.def().extract_return_nl)("[section]"), None);
+        assert_eq!(
+            (Language::Elixir.def().extract_return_nl)("def greet(name) do"),
+            None
+        );
+        assert_eq!(
+            (Language::Erlang.def().extract_return_nl)("greet(Name) ->"),
+            None
+        );
+        assert_eq!(
+            (Language::Haskell.def().extract_return_nl)("greet :: String -> String"),
+            Some("Returns string".to_string())
+        );
+        assert_eq!(
+            (Language::Haskell.def().extract_return_nl)("main :: IO ()"),
+            None
+        );
     }
 
     // ===== ChunkType tests =====

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - **Semantic search**: Uses E5-base-v2 embeddings (769-dim: 768 model + sentiment)
 //! - **Notes with sentiment**: Unified memory system for AI collaborators
-//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Markdown (28 languages)
+//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Haskell, Markdown (31 languages)
 //! - **GPU acceleration**: CUDA/TensorRT with CPU fallback
 //! - **CLI tools**: Call graph, impact analysis, test mapping, dead code detection
 //! - **Document conversion**: PDF, HTML, CHM, Web Help → cleaned Markdown (optional `convert` feature)

--- a/tests/eval_common.rs
+++ b/tests/eval_common.rs
@@ -64,6 +64,12 @@ pub fn fixture_path(lang: Language) -> PathBuf {
         Language::Yaml => "yaml",
         #[cfg(feature = "lang-toml")]
         Language::Toml => "toml",
+        #[cfg(feature = "lang-elixir")]
+        Language::Elixir => "ex",
+        #[cfg(feature = "lang-erlang")]
+        Language::Erlang => "erl",
+        #[cfg(feature = "lang-haskell")]
+        Language::Haskell => "hs",
         Language::Markdown => "md",
     };
     PathBuf::from(manifest_dir)
@@ -122,6 +128,12 @@ pub fn hard_fixture_path(lang: Language) -> PathBuf {
         Language::Yaml => "yaml",
         #[cfg(feature = "lang-toml")]
         Language::Toml => "toml",
+        #[cfg(feature = "lang-elixir")]
+        Language::Elixir => "ex",
+        #[cfg(feature = "lang-erlang")]
+        Language::Erlang => "erl",
+        #[cfg(feature = "lang-haskell")]
+        Language::Haskell => "hs",
         Language::Markdown => "md",
     };
     PathBuf::from(manifest_dir)

--- a/tests/fixtures/sample.erl
+++ b/tests/fixtures/sample.erl
@@ -1,0 +1,37 @@
+-module(calculator).
+-behaviour(gen_server).
+-export([start_link/0, add/2, subtract/2]).
+
+-type result() :: {ok, number()} | {error, term()}.
+
+-record(state, {
+    count = 0 :: non_neg_integer(),
+    name :: string()
+}).
+
+-callback init(Args :: term()) -> {ok, term()}.
+
+-spec add(number(), number()) -> number().
+add(A, B) ->
+    A + B.
+
+-spec subtract(number(), number()) -> number().
+subtract(A, B) ->
+    A - B.
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    {ok, #state{count = 0, name = "calc"}}.
+
+handle_call({add, A, B}, _From, State) ->
+    Result = add(A, B),
+    {reply, Result, State#state{count = State#state.count + 1}}.
+
+process(Data) ->
+    Trimmed = string:trim(Data),
+    io:format("~s~n", [Trimmed]),
+    helper(Trimmed).
+
+helper(X) -> X.

--- a/tests/fixtures/sample.ex
+++ b/tests/fixtures/sample.ex
@@ -1,0 +1,43 @@
+defmodule Calculator do
+  @moduledoc "A simple calculator module"
+
+  @doc "Add two numbers"
+  def add(a, b) do
+    a + b
+  end
+
+  @doc "Subtract two numbers"
+  def subtract(a, b) do
+    a - b
+  end
+
+  defp validate(n) when is_number(n), do: :ok
+  defp validate(_), do: {:error, :not_a_number}
+end
+
+defprotocol Printable do
+  @doc "Convert to printable string"
+  def to_string(data)
+end
+
+defimpl Printable, for: Integer do
+  def to_string(n), do: Integer.to_string(n)
+end
+
+defmodule Greeter do
+  defmacro say_hello(name) do
+    quote do
+      IO.puts("Hello, #{unquote(name)}")
+    end
+  end
+
+  def greet(name) do
+    name
+    |> String.trim()
+    |> format_greeting()
+  end
+
+  defp format_greeting(name) do
+    "Hello, #{name}!"
+  end
+end

--- a/tests/fixtures/sample.hs
+++ b/tests/fixtures/sample.hs
@@ -1,0 +1,45 @@
+module Sample where
+
+-- | A 2D point
+data Point = Point { x :: Double, y :: Double }
+
+-- | Color enumeration
+data Color = Red | Green | Blue deriving (Show, Eq)
+
+-- | Type alias for a name
+type Name = String
+
+-- | Printable typeclass
+class Printable a where
+  display :: a -> String
+
+-- | Instance of Printable for Color
+instance Printable Color where
+  display Red   = "Red"
+  display Green = "Green"
+  display Blue  = "Blue"
+
+-- | Add two integers
+add :: Int -> Int -> Int
+add a b = a + b
+
+-- | Greet a person
+greet :: String -> String
+greet name = "Hello, " ++ name
+
+-- | Process a list of items
+process :: [String] -> IO ()
+process items = do
+  let filtered = filter (not . null) items
+  mapM_ putStrLn filtered
+  print (length filtered)
+
+-- | Calculate distance between two points
+distance :: Point -> Point -> Double
+distance p1 p2 = sqrt (dx * dx + dy * dy)
+  where
+    dx = x p1 - x p2
+    dy = y p1 - y p2
+
+-- | A newtype wrapper
+newtype UserId = UserId Int

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1020,3 +1020,78 @@ fn test_toml_table_extraction() {
         names
     );
 }
+
+#[test]
+#[cfg(feature = "lang-elixir")]
+fn test_elixir_function_and_module_extraction() {
+    let parser = Parser::new().unwrap();
+    let path = fixtures_path().join("sample.ex");
+    let chunks = parser.parse_file(&path).unwrap();
+    assert!(
+        !chunks.is_empty(),
+        "Should extract Elixir chunks from sample.ex"
+    );
+
+    // Function
+    let add = chunks.iter().find(|c| c.name == "add");
+    assert!(add.is_some(), "Should find 'add' function");
+    assert_eq!(add.unwrap().chunk_type, ChunkType::Function);
+
+    // Module
+    let calc = chunks
+        .iter()
+        .find(|c| c.name == "Calculator" && c.chunk_type == ChunkType::Module);
+    assert!(calc.is_some(), "Should find 'Calculator' module");
+}
+
+#[test]
+#[cfg(feature = "lang-erlang")]
+fn test_erlang_function_and_module_extraction() {
+    let parser = Parser::new().unwrap();
+    let path = fixtures_path().join("sample.erl");
+    let chunks = parser.parse_file(&path).unwrap();
+    assert!(
+        !chunks.is_empty(),
+        "Should extract Erlang chunks from sample.erl"
+    );
+
+    // Function
+    let add = chunks.iter().find(|c| c.name == "add");
+    assert!(add.is_some(), "Should find 'add' function");
+    assert_eq!(add.unwrap().chunk_type, ChunkType::Function);
+
+    // Module
+    let module = chunks
+        .iter()
+        .find(|c| c.name == "calculator" && c.chunk_type == ChunkType::Module);
+    assert!(module.is_some(), "Should find 'calculator' module");
+}
+
+#[test]
+#[cfg(feature = "lang-haskell")]
+fn test_haskell_function_and_data_extraction() {
+    let parser = Parser::new().unwrap();
+    let path = fixtures_path().join("sample.hs");
+    let chunks = parser.parse_file(&path).unwrap();
+    assert!(
+        !chunks.is_empty(),
+        "Should extract Haskell chunks from sample.hs"
+    );
+
+    // Function
+    let add = chunks.iter().find(|c| c.name == "add");
+    assert!(add.is_some(), "Should find 'add' function");
+    assert_eq!(add.unwrap().chunk_type, ChunkType::Function);
+
+    // Data type (Enum)
+    let color = chunks
+        .iter()
+        .find(|c| c.name == "Color" && c.chunk_type == ChunkType::Enum);
+    assert!(color.is_some(), "Should find 'Color' data type");
+
+    // Typeclass (Trait)
+    let printable = chunks
+        .iter()
+        .find(|c| c.name == "Printable" && c.chunk_type == ChunkType::Trait);
+    assert!(printable.is_some(), "Should find 'Printable' typeclass");
+}


### PR DESCRIPTION
## Summary

- **Elixir** — functions (def/defp), modules (defmodule), protocols (defprotocol → Interface), implementations (defimpl → Object), macros (defmacro), guards, delegates, pipe call extraction. Post-process reclassifies generic `call` nodes by keyword text.
- **Erlang** — functions (fun_decl), modules, records (Struct), type aliases, opaque types, behaviours (Interface), callbacks, local and remote call extraction.
- **Haskell** — functions, data types (Enum), newtypes (Struct), type synonyms (TypeAlias), typeclasses (Trait), instances (Object). Return type extraction from type signatures. Note: grammar has intentional typo `type_synomym`.
- **Clojure deferred** — `tree-sitter-clojure` 0.1.0 requires tree-sitter ^0.25, incompatible with our 0.26.

28 → 31 languages. 1371 tests pass, 0 failures.

## Test plan

- [x] All new language unit tests pass (elixir.rs, erlang.rs, haskell.rs)
- [x] All integration tests pass (parser_test.rs)
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] mod.rs registry tests updated (extension, count, from_str, display, extract_return)
- [x] eval_common.rs match arms added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
