### PR TITLE
chore: release v0.23.0 — 36 languages, mass language expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,49 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.23.0] - 2026-03-04
+## [0.23.0] - 2026-03-05
+
+Mass language expansion — 20 → 36 languages (+16). Four batches (#527–#531).
 
 ### Added
-- CSS language support (`.css`) — rule sets, keyframes, media queries
-- Perl language support (`.pl`, `.pm`) — subroutines, packages, method/function calls
-
-## [0.22.0] - 2026-03-04
-
-OCaml, Julia, and Gleam language support — 31 → 34 languages.
-
-### Added
-- **OCaml language support** (`.ml`, `.mli`) — let bindings, type definitions, modules, function application
+- **Protobuf language support** (`.proto`) — messages (Struct), services (Interface), RPCs (Method), enums, type references via `message_or_enum_type`
+- **GraphQL language support** (`.graphql`) — object types, interfaces, enums, unions (TypeAlias), input types, scalars, directives (Macro), operations, fragments, type references via `named_type`
+- **PHP language support** (`.php`) — classes, interfaces, traits, enums, functions, methods, properties, constants, call extraction (function/method/static/constructor), type references, return type extraction
+- **Lua language support** (`.lua`) — functions, local functions, method definitions, table constructors, call extraction
+- **Zig language support** (`.zig`) — functions, structs, enums, unions, error sets, test declarations
+- **R language support** (`.r`, `.R`) — functions, S4 classes/generics/methods, R6 classes, formula assignments
+- **YAML language support** (`.yaml`, `.yml`) — mapping keys, sequences, documents
+- **TOML language support** (`.toml`) — tables, arrays of tables, key-value pairs
+- **Elixir language support** (`.ex`, `.exs`) — functions (def/defp), modules (defmodule), protocols (Interface), implementations (Object), macros, guards, delegates, pipe call extraction
+- **Erlang language support** (`.erl`, `.hrl`) — functions, modules, records (Struct), type aliases, opaque types, behaviours (Interface), callbacks, local and remote call extraction
+- **Haskell language support** (`.hs`) — functions, data types (Enum), newtypes (Struct), type synonyms (TypeAlias), typeclasses (Trait), instances (Object), return type extraction, function application call extraction
+- **OCaml language support** (`.ml`, `.mli`) — let bindings, type definitions (variant/record/alias), modules, function application via value_path
 - **Julia language support** (`.jl`) — functions, structs, abstract types, modules, macros
 - **Gleam language support** (`.gleam`) — functions, type definitions, type aliases, constants
-
-## [0.21.0] - 2026-03-04
-
-Elixir, Erlang, and Haskell language support — 28 → 31 languages.
-
-### Added
-- **Elixir language support** — functions (def/defp), modules (defmodule), protocols (defprotocol → Interface), implementations (defimpl → Object), macros (defmacro), guards, delegates, pipe call extraction
-- **Erlang language support** — functions (fun_decl), modules, records (Struct), type aliases, opaque types, behaviours (Interface), callbacks, local and remote call extraction
-- **Haskell language support** — functions, data types (Enum), newtypes (Struct), type synonyms (TypeAlias), typeclasses (Trait), instances (Object), return type extraction from type signatures, function application call extraction
-
-## [0.21.0] - 2026-03-04
-
-Lua, Zig, R, YAML, and TOML language support — 23 → 28 languages.
-
-### Added
-- **Lua language support** — functions, local functions, method definitions, table constructors, call extraction
-- **Zig language support** — functions, structs, enums, unions, error sets, test declarations
-- **R language support** — functions, S4 classes/generics/methods, R6 classes, formula assignments
-- **YAML language support** — mapping keys, sequences, documents
-- **TOML language support** — tables, arrays of tables, key-value pairs
-
-## [0.20.0] - 2026-03-04
-
-Protobuf, GraphQL, and PHP language support — 20 → 23 languages.
-
-### Added
-- **Protobuf language support** — messages (Struct), services (Interface), RPCs (Method), enums, type references via `message_or_enum_type`
-- **GraphQL language support** — object types, interfaces, enums, unions (TypeAlias), input types, scalars, directives (Macro), operations, fragments, type references via `named_type`
-- **PHP language support** — classes, interfaces, traits, enums, functions, methods, properties, constants, call extraction (function/method/static/constructor), type references (params, returns, fields, extends, implements), return type extraction
+- **CSS language support** (`.css`) — rule sets (Property), keyframes and media queries (Section)
+- **Perl language support** (`.pl`, `.pm`) — subroutines, packages (Module), function/method calls
 
 ## [0.19.5] - 2026-03-04
 

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,15 +2,19 @@
 
 ## Right Now
 
-**Mass language expansion.** 2026-03-04.
+**Mass language expansion complete.** 2026-03-04.
 
-Batch 2 complete (Elixir, Erlang, Haskell). 28 → 31 languages.
-- Clojure blocked: `tree-sitter-clojure` 0.1.0 requires tree-sitter ^0.25, incompatible with 0.26
-- PR pending for Batch 2 (branch `feat/lang-elixir-erlang-haskell`)
+All 4 batches merged:
+- Batch 1: Lua, Zig, R, YAML, TOML (PR #528, 23→28)
+- Batch 2: Elixir, Erlang, Haskell (PR #529, 28→31) — Clojure blocked (tree-sitter ^0.25)
+- Batch 3: OCaml, Julia, Gleam (PR #530, 31→34)
+- Batch 4: CSS, Perl (PR #531, 34→36)
+
+36 languages total. Plan called for 37 (14 new) but Clojure was blocked.
 
 ## Pending Changes
 
-Batch 2 language files + fixtures + tests ready for commit.
+None.
 
 ## Parked
 
@@ -37,15 +41,15 @@ Batch 2 language files + fixtures + tests ready for commit.
 
 ## Architecture
 
-- Version: 0.21.0
+- Version: 0.23.0
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
-- 31 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Haskell, Markdown)
+- 36 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Haskell, OCaml, Julia, Gleam, CSS, Perl, Markdown)
 - 16 ChunkType variants (Function, Method, Struct, Class, Interface, Enum, Trait, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias)
-- Tests: 1371 pass, 0 failures
+- Tests: 1402 pass, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag


### PR DESCRIPTION
## Summary

Release v0.23.0 — mass language expansion from 20 to 36 languages.

16 new languages in 4 batches:
- **Batch 1** (#527): Protobuf, GraphQL, PHP (20→23)
- **Batch 2** (#528): Lua, Zig, R, YAML, TOML (23→28)
- **Batch 3** (#529): Elixir, Erlang, Haskell (28→31)
- **Batch 4** (#530): OCaml, Julia, Gleam (31→34)
- **Batch 5** (#531): CSS, Perl (34→36)

This PR consolidates the changelog and updates PROJECT_CONTINUITY.md.

## Test plan

- [x] 1402 tests pass
- [x] Zero clippy warnings
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
