### PR TITLE
feat: add Solidity, CUDA, and GLSL language support (46 languages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-03-05
+
+Language expansion Phase 2, Batch 3 — Solidity, CUDA, GLSL (43 → 46 languages).
+
+### Added
+- **Solidity language support** (`.sol`) — contracts (Class), interfaces, libraries (Module), structs, enums, functions, modifiers, events (Property), state variables, call graph
+- **CUDA language support** (`.cu`, `.cuh`) — reuses C++ grammar with CUDA qualifier filtering (__global__, __device__, __host__). Full call graph, out-of-class methods, kernel launches
+- **GLSL language support** (`.glsl`, `.vert`, `.frag`, `.geom`, `.comp`, `.tesc`, `.tese`) — reuses C grammar with GLSL qualifier filtering (uniform, varying, precision). Shader function extraction and call graph
+
+### Fixed
+- Unused variable warning in embedding batch iterator (newer Rust versions)
+
 ## [0.25.0] - 2026-03-05
 
 Language expansion Phase 2, Batch 2 — Nix, Make, LaTeX (40 → 43 languages).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Thank you for your interest in contributing to cqs!
 
 ### Feature Ideas
 
-- Additional language support (see `src/language/` for current list — 43 languages supported)
+- Additional language support (see `src/language/` for current list — 46 languages supported)
 - Non-CUDA GPU support (ROCm for AMD, Metal for Apple Silicon)
 - VS Code extension
 - Performance improvements
@@ -105,7 +105,7 @@ src/
     watch.rs    - File watcher for incremental reindexing
   language/     - Tree-sitter language support
     mod.rs      - Language enum, LanguageRegistry, LanguageDef, ChunkType
-    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, kotlin.rs, swift.rs, objc.rs, sql.rs, protobuf.rs, graphql.rs, php.rs, lua.rs, zig.rs, r.rs, yaml.rs, toml_lang.rs, elixir.rs, erlang.rs, gleam.rs, haskell.rs, julia.rs, ocaml.rs, css.rs, perl.rs, html.rs, json.rs, xml.rs, ini.rs, nix.rs, make.rs, latex.rs, markdown.rs
+    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, kotlin.rs, swift.rs, objc.rs, sql.rs, protobuf.rs, graphql.rs, php.rs, lua.rs, zig.rs, r.rs, yaml.rs, toml_lang.rs, elixir.rs, erlang.rs, gleam.rs, haskell.rs, julia.rs, ocaml.rs, css.rs, perl.rs, html.rs, json.rs, xml.rs, ini.rs, nix.rs, make.rs, latex.rs, solidity.rs, cuda.rs, glsl.rs, markdown.rs
   store/        - SQLite storage layer (Schema v11, WAL mode)
     mod.rs      - Store struct, open/init, FTS5, RRF fusion
     chunks.rs   - Chunk CRUD, embedding_batches() for streaming

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -695,10 +695,12 @@ dependencies = [
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
  "tree-sitter-css",
+ "tree-sitter-cuda",
  "tree-sitter-elixir",
  "tree-sitter-erlang",
  "tree-sitter-fsharp",
  "tree-sitter-gleam",
+ "tree-sitter-glsl",
  "tree-sitter-go",
  "tree-sitter-graphql",
  "tree-sitter-haskell",
@@ -725,6 +727,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-scala",
  "tree-sitter-sequel-tsql",
+ "tree-sitter-solidity",
  "tree-sitter-swift",
  "tree-sitter-toml-ng",
  "tree-sitter-typescript",
@@ -4103,6 +4106,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-cuda"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715eecfee69b15991de5b9f78009c6d4cb34e18d20d028304a75d38528cddb45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-elixir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4137,6 +4150,16 @@ name = "tree-sitter-gleam"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0175c53793bda5d444360dd5add25463d18d66afb7f521d6791e2fc61bf2fb3"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-glsl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0ee57cbf4c2b35d3a7f17a01bf33c0ef2e85987cb85e516ac8c6904c4e62ac"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4404,6 +4427,16 @@ name = "tree-sitter-sequel-tsql"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d02793ddf858f2fc6376c7c12d50a4a29797c834b8ddbafe752290d9cbdb59"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-solidity"
+version = "1.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eacf8875b70879f0cb670c60b233ad0b68752d9e1474e6c3ef168eea8a90b25"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "cqs"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 rust-version = "1.93"
-description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 43 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."
+description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 46 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."
 license = "MIT"
 repository = "https://github.com/jamie8johnson/cqs"
 homepage = "https://github.com/jamie8johnson/cqs"
@@ -71,6 +71,9 @@ tree-sitter-ini = { version = "1.4", optional = true }
 tree-sitter-nix = { version = "0.3", optional = true }
 tree-sitter-make = { version = "1.1", optional = true }
 tree-sitter-latex = { version = "0.6", package = "codebook-tree-sitter-latex", optional = true }
+tree-sitter-solidity = { version = "1.2", optional = true }
+tree-sitter-cuda = { version = "0.21", optional = true }
+tree-sitter-glsl = { version = "0.2", optional = true }
 
 # ML
 ort = { version = "2.0.0-rc.11", features = ["cuda", "tensorrt"] }
@@ -136,7 +139,7 @@ rustyline = "17"
 libc = "0.2"
 
 [features]
-default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-lua", "lang-zig", "lang-r", "lang-yaml", "lang-toml", "lang-elixir", "lang-erlang", "lang-haskell", "lang-ocaml", "lang-julia", "lang-gleam", "lang-css", "lang-perl", "lang-html", "lang-json", "lang-xml", "lang-ini", "lang-nix", "lang-make", "lang-latex", "lang-markdown", "convert"]
+default = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-lua", "lang-zig", "lang-r", "lang-yaml", "lang-toml", "lang-elixir", "lang-erlang", "lang-haskell", "lang-ocaml", "lang-julia", "lang-gleam", "lang-css", "lang-perl", "lang-html", "lang-json", "lang-xml", "lang-ini", "lang-nix", "lang-make", "lang-latex", "lang-solidity", "lang-cuda", "lang-glsl", "lang-markdown", "convert"]
 
 # Language support (opt-in, all enabled by default)
 lang-rust = ["dep:tree-sitter-rust"]
@@ -181,8 +184,11 @@ lang-ini = ["dep:tree-sitter-ini"]
 lang-nix = ["dep:tree-sitter-nix"]
 lang-make = ["dep:tree-sitter-make"]
 lang-latex = ["dep:tree-sitter-latex"]
+lang-solidity = ["dep:tree-sitter-solidity"]
+lang-cuda = ["dep:tree-sitter-cuda"]
+lang-glsl = ["dep:tree-sitter-glsl"]
 lang-markdown = []  # No external deps — custom parser
-lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-lua", "lang-zig", "lang-r", "lang-yaml", "lang-toml", "lang-elixir", "lang-erlang", "lang-haskell", "lang-ocaml", "lang-julia", "lang-gleam", "lang-css", "lang-perl", "lang-html", "lang-json", "lang-xml", "lang-ini", "lang-nix", "lang-make", "lang-latex", "lang-markdown"]
+lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "lang-go", "lang-c", "lang-cpp", "lang-java", "lang-csharp", "lang-fsharp", "lang-powershell", "lang-scala", "lang-ruby", "lang-bash", "lang-hcl", "lang-kotlin", "lang-swift", "lang-objc", "lang-sql", "lang-protobuf", "lang-graphql", "lang-php", "lang-lua", "lang-zig", "lang-r", "lang-yaml", "lang-toml", "lang-elixir", "lang-erlang", "lang-haskell", "lang-ocaml", "lang-julia", "lang-gleam", "lang-css", "lang-perl", "lang-html", "lang-json", "lang-xml", "lang-ini", "lang-nix", "lang-make", "lang-latex", "lang-solidity", "lang-cuda", "lang-glsl", "lang-markdown"]
 
 # Document conversion
 convert = ["dep:fast_html2md", "dep:walkdir"]

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,20 +2,19 @@
 
 ## Right Now
 
-**Phase 2 language expansion — Batch 2.** 2026-03-05.
+**Phase 2 language expansion — Batch 3.** 2026-03-05.
 
-Nix, Make, LaTeX done. v0.25.0. Uncommitted — ready for branch + PR.
+Solidity, CUDA, GLSL done. v0.26.0. Ready for branch + PR.
 
+Batch 2 (Nix, Make, LaTeX) in PR #537 — waiting for CI + merge.
 Batch 1 (HTML, JSON, XML, INI) merged as PR #535.
 
-Key fixes during Batch 2:
-- `tree-sitter-latex` 0.1.0 broken (missing scanner.c) → switched to `codebook-tree-sitter-latex` 0.6.1
-- `@section` capture was missing from `chunk.rs:capture_types` and `mod.rs:DEF_CAPTURES` — no prior tree-sitter language used it (Markdown uses custom parser)
-- Nix needed `apply_expression` pattern for function-application bindings
+Key fix in Batch 3:
+- Solidity grammar uses `expression` supertype for `call_expression.function` field — tree-sitter queries can't match through supertypes with `function: (identifier)`. Solved with `member_expression property:` for member calls + `function: (_)` wildcard for direct calls.
 
 ## Pending Changes
 
-Batch 2 language files (nix.rs, make.rs, latex.rs), fixtures, parser fixes (@section capture), mod.rs/eval_common/parser_test updates, doc updates. All tests pass (1440). Ready for branch + PR.
+Batch 3 language files (solidity.rs, cuda.rs, glsl.rs), fixtures, mod.rs/eval_common/parser_test updates, doc updates. All tests pass (1456). Ready for branch + PR once Batch 2 merges.
 
 ## Parked
 
@@ -42,15 +41,15 @@ Batch 2 language files (nix.rs, make.rs, latex.rs), fixtures, parser fixes (@sec
 
 ## Architecture
 
-- Version: 0.25.0
+- Version: 0.26.0
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
-- 43 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Haskell, OCaml, Julia, Gleam, CSS, Perl, HTML, JSON, XML, INI, Nix, Make, LaTeX, Markdown)
+- 46 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Haskell, OCaml, Julia, Gleam, CSS, Perl, HTML, JSON, XML, INI, Nix, Make, LaTeX, Solidity, CUDA, GLSL, Markdown)
 - 16 ChunkType variants (Function, Method, Struct, Class, Interface, Enum, Trait, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias)
-- Tests: 1440 pass, 0 failures
+- Tests: 1456 pass, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code intelligence and RAG for AI agents. Semantic search, call graph analysis, impact tracing, type dependencies, and smart context assembly — all in single tool calls. Local ML embeddings, GPU-accelerated.
 
-**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval. 43 languages, GPU-accelerated.
+**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval. 46 languages, GPU-accelerated.
 
 [![Crates.io](https://img.shields.io/crates/v/cqs.svg)](https://crates.io/crates/cqs)
 [![CI](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml/badge.svg)](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml)
@@ -414,10 +414,12 @@ Keep index fresh: run `cqs watch` in a background terminal, or `cqs index` after
 - C++ (classes, structs, namespaces, concepts, templates, out-of-class methods, preprocessor macros)
 - C# (classes, structs, records, interfaces, enums, properties, delegates, events)
 - CSS (rule sets, keyframes, media queries)
+- CUDA (reuses C++ grammar — kernels, classes, structs, device/host functions)
 - Elixir (functions, modules, protocols, implementations, macros, pipe calls)
 - Erlang (functions, modules, records, type aliases, behaviours, callbacks)
 - F# (functions, records, discriminated unions, classes, interfaces, modules, members)
 - Gleam (functions, type definitions, type aliases, constants)
+- GLSL (reuses C grammar — vertex/fragment/compute shaders, structs, built-in function calls)
 - Go (functions, structs, interfaces)
 - GraphQL (types, interfaces, enums, unions, inputs, scalars, directives, operations, fragments)
 - Haskell (functions, data types, newtypes, type synonyms, typeclasses, instances)
@@ -445,6 +447,7 @@ Keep index fresh: run `cqs watch` in a background terminal, or `cqs index` after
 - Ruby (classes, modules, methods, singleton methods)
 - Rust (functions, structs, enums, traits, impls, macros)
 - Scala (classes, objects, traits, enums, functions, val/var bindings, type aliases)
+- Solidity (contracts, interfaces, libraries, structs, enums, functions, modifiers, events, state variables)
 - SQL (T-SQL, PostgreSQL)
 - Swift (classes, structs, enums, actors, protocols, extensions, functions, type aliases)
 - TOML (tables, arrays of tables, key-value pairs)
@@ -468,7 +471,7 @@ cqs index --dry-run    # Show what would be indexed
 
 **Parse → Embed → Index → Reason**
 
-1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 43 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
+1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 46 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
 2. **Describe** — Each code element gets a natural language description incorporating doc comments, parameter types, return types, and parent type context (e.g., methods include their struct/class name). This bridges the gap between how developers describe code and how it's written.
 3. **Embed** — E5-base-v2 generates 769-dimensional embeddings (768 semantic + 1 sentiment) locally. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval — outperforms code-specific models because NL descriptions play to general-purpose model strengths.
 4. **Index** — SQLite stores chunks, embeddings, call graph edges, and type dependency edges. HNSW provides fast approximate nearest-neighbor search. FTS5 enables keyword matching.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Roadmap
 
-## Current: v0.25.0
+## Current: v0.26.0
 
-All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 43 languages. Two full audits complete (v0.12.3 + v0.19.2).
+All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 46 languages. Two full audits complete (v0.12.3 + v0.19.2).
 
 ### Next — Commands
 
@@ -22,12 +22,22 @@ All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 43 lan
 - [x] **Elixir** — Module + Macro exist. defprotocol → Interface, defimpl → Object. Clean mapping.
 - [x] **Erlang** — FP + modules, behaviour → Interface, record → Struct.
 - [x] **Haskell** — data → Enum, newtype → Struct, type synonym → TypeAlias, class → Trait, instance → Object.
+- [x] **OCaml** — FP + modules. Uses `LANGUAGE_OCAML` export.
+- [x] **Julia** — Scientific + types.
+- [x] **Gleam** — FP + types.
+- [x] **CSS** — Selectors + rules. Rule sets → Section.
+- [x] **Perl** — Subs + packages. OOP via bless.
+- [x] **HTML** — Semantic elements, script/style modules, landmark sections.
+- [x] **JSON** — Top-level key-value pairs as Property.
+- [x] **XML** — Top-level elements as Struct.
+- [x] **INI** — Sections as Module, settings as Property.
+- [x] **Nix** — Bindings with function/attrset expressions. Call graph via apply_expression.
+- [x] **Make** — Targets as Function, variable assignments as Property.
+- [x] **LaTeX** — Sections, commands, environments.
+- [x] **Solidity** — Contracts, interfaces, libraries, call graph. Expression supertype workaround.
+- [x] **CUDA** — Reuses C++ queries. Kernel-specific stopwords.
+- [x] **GLSL** — Reuses C queries. Shader-specific stopwords.
 - [ ] **Clojure** — Blocked: `tree-sitter-clojure` 0.1.0 requires tree-sitter ^0.25, incompatible with 0.26.
-- [ ] **OCaml** — FP + modules. Uses `LANGUAGE_OCAML` export.
-- [ ] **Julia** — Scientific + types.
-- [ ] **Gleam** — FP + types.
-- [ ] **CSS** — Selectors + rules. Rule sets → Section.
-- [ ] **Perl** — Subs + packages. OOP via bless.
 - [ ] **Dart** — Blocked: old tree-sitter API (pre-0.24). Property covers properties, mixin → Trait.
 - [ ] **ArchestrA QuickScript** — No tree-sitter grammar exists. Needs custom grammar from scratch (VB-like syntax).
 
@@ -43,6 +53,30 @@ All 16 variants shipped and used across languages. Only one potential new varian
 | `Object` | v0.17.0 | Scala |
 
 Infrastructure for adding variants is now cheap: per-language LanguageDef fields, data-driven container extraction, dynamic callable SQL. New variant = enum arm + Display/FromStr + is_callable decision + nl.rs + capture_types.
+
+### Multi-Grammar Parsing (Architectural)
+
+Parse files containing multiple embedded languages. Requires:
+- Outer grammar parses document structure, identifies embedded regions
+- Inner grammars re-parse each region with correct byte offsets
+- Merged results preserve original file positions
+
+**Languages it would unlock:**
+- **Svelte** (.svelte) — JS/TS in `<script>`, CSS in `<style>`, HTML template
+- **Vue** (.vue) — same pattern as Svelte
+- **Astro** (.astro) — JS/TS frontmatter + HTML template
+- **ERB** (.erb) — Ruby embedded in HTML
+- **EEx/HEEx** (.eex, .heex) — Elixir embedded in HTML
+- **PHP-in-HTML** — our PHP support parses PHP blocks; multi-grammar adds HTML context
+
+**Embedded language extraction (lower priority):**
+- SQL in string literals (Rust, Python, Go, Java)
+- GraphQL in tagged templates (JS/TS)
+- Regex literals (via tree-sitter-regex, compatible)
+- Shell in Makefile recipes (both grammars compatible)
+- CSS-in-JS (styled-components, emotion)
+
+**Not yet designed.** Requires parser framework changes — current architecture is one grammar per file.
 
 ### Parked
 

--- a/src/language/cuda.rs
+++ b/src/language/cuda.rs
@@ -1,0 +1,312 @@
+//! CUDA language definition
+//!
+//! CUDA extends C++ grammar with kernel launch syntax and device qualifiers.
+//! Reuses C++ chunk and call queries — all C++ node types are present.
+
+use super::{LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting CUDA code chunks (reuses C++ patterns)
+const CHUNK_QUERY: &str = r#"
+;; Free functions
+(function_definition
+  declarator: (function_declarator
+    declarator: (identifier) @name)) @function
+
+;; Inline methods (field_identifier inside class body)
+(function_definition
+  declarator: (function_declarator
+    declarator: (field_identifier) @name)) @function
+
+;; Out-of-class methods (Class::method)
+(function_definition
+  declarator: (function_declarator
+    declarator: (qualified_identifier
+      name: (identifier) @name))) @function
+
+;; Destructors (inline)
+(function_definition
+  declarator: (function_declarator
+    declarator: (destructor_name) @name)) @function
+
+;; Destructors (out-of-class, Class::~Class)
+(function_definition
+  declarator: (function_declarator
+    declarator: (qualified_identifier
+      name: (destructor_name) @name))) @function
+
+;; Forward declarations with function body
+(declaration
+  declarator: (init_declarator
+    declarator: (function_declarator
+      declarator: (identifier) @name))) @function
+
+;; Classes
+(class_specifier
+  name: (type_identifier) @name
+  body: (field_declaration_list)) @class
+
+;; Structs
+(struct_specifier
+  name: (type_identifier) @name
+  body: (field_declaration_list)) @struct
+
+;; Enums (including enum class)
+(enum_specifier
+  name: (type_identifier) @name
+  body: (enumerator_list)) @enum
+
+;; Namespaces
+(namespace_definition
+  name: (namespace_identifier) @name) @module
+
+;; Type aliases — using X = Y (C++11)
+(alias_declaration
+  name: (type_identifier) @name) @typealias
+
+;; Typedefs (C-style)
+(type_definition
+  declarator: (type_identifier) @name) @typealias
+
+;; Unions
+(union_specifier
+  name: (type_identifier) @name
+  body: (field_declaration_list)) @struct
+
+;; Preprocessor constants
+(preproc_def
+  name: (identifier) @name) @const
+
+;; Preprocessor function macros
+(preproc_function_def
+  name: (identifier) @name) @macro
+"#;
+
+/// Tree-sitter query for extracting function calls (reuses C++ patterns)
+const CALL_QUERY: &str = r#"
+;; Direct function call
+(call_expression
+  function: (identifier) @callee)
+
+;; Qualified call (Class::method or ns::func)
+(call_expression
+  function: (qualified_identifier
+    name: (identifier) @callee))
+
+;; Member call (obj.method or ptr->method)
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @callee))
+
+;; Template function call (make_shared<T>())
+(call_expression
+  function: (template_function
+    name: (identifier) @callee))
+
+;; Qualified template call (std::make_shared<T>())
+(call_expression
+  function: (qualified_identifier
+    name: (template_function
+      name: (identifier) @callee)))
+
+;; new expression
+(new_expression
+  type: (type_identifier) @callee)
+"#;
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    // C++ stopwords
+    "if", "else", "for", "while", "do", "switch", "case", "break", "continue", "return",
+    "class", "struct", "enum", "namespace", "template", "typename", "using", "typedef",
+    "virtual", "override", "final", "const", "static", "inline", "explicit", "extern", "friend",
+    "public", "private", "protected", "void", "int", "char", "float", "double", "long", "short",
+    "unsigned", "signed", "auto", "new", "delete", "this", "true", "false", "nullptr", "sizeof",
+    // CUDA-specific qualifiers
+    "__global__", "__device__", "__host__", "__shared__", "__constant__",
+    "__managed__", "__restrict__", "__noinline__", "__forceinline__",
+    "dim3", "blockIdx", "threadIdx", "blockDim", "gridDim", "warpSize",
+    "cudaMalloc", "cudaFree", "cudaMemcpy",
+];
+
+fn extract_return(signature: &str) -> Option<String> {
+    // Reuse C++ trailing return type logic
+    if let Some(paren) = signature.rfind(')') {
+        let after = &signature[paren + 1..];
+        if let Some(arrow) = after.find("->") {
+            let ret_part = after[arrow + 2..].trim();
+            let end = ret_part.find('{').unwrap_or(ret_part.len());
+            let ret_type = ret_part[..end].trim();
+            if !ret_type.is_empty() {
+                let ret_words = crate::nl::tokenize_identifier(ret_type).join(" ");
+                return Some(format!("Returns {}", ret_words));
+            }
+        }
+    }
+
+    // C-style prefix extraction
+    if let Some(paren) = signature.find('(') {
+        let before = signature[..paren].trim();
+        let words: Vec<&str> = before.split_whitespace().collect();
+        if words.len() >= 2 {
+            let type_words: Vec<&str> = words[..words.len() - 1]
+                .iter()
+                .filter(|w| {
+                    !matches!(
+                        **w,
+                        "static"
+                            | "inline"
+                            | "extern"
+                            | "const"
+                            | "volatile"
+                            | "virtual"
+                            | "explicit"
+                            | "__global__"
+                            | "__device__"
+                            | "__host__"
+                            | "__forceinline__"
+                            | "__noinline__"
+                            | "auto"
+                    )
+                })
+                .copied()
+                .collect();
+            if !type_words.is_empty() && type_words != ["void"] {
+                let ret = type_words.join(" ");
+                let ret_words = crate::nl::tokenize_identifier(&ret).join(" ");
+                return Some(format!("Returns {}", ret_words));
+            }
+        }
+    }
+    None
+}
+
+/// Extract parent type from out-of-class method: `void MyClass::method()` → Some("MyClass")
+fn extract_qualified_method(node: tree_sitter::Node, source: &str) -> Option<String> {
+    let func_decl = node.child_by_field_name("declarator")?;
+    let inner_decl = func_decl.child_by_field_name("declarator")?;
+    if inner_decl.kind() != "qualified_identifier" {
+        return None;
+    }
+    let scope = inner_decl.child_by_field_name("scope")?;
+    Some(source[scope.byte_range()].to_string())
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "cuda",
+    grammar: Some(|| tree_sitter_cuda::LANGUAGE.into()),
+    extensions: &["cu", "cuh"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &["class_specifier", "struct_specifier"],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+    test_file_suggestion: None,
+    type_query: None,
+    common_types: &[
+        "int", "char", "float", "double", "void", "long", "short", "unsigned", "size_t",
+        "dim3", "cudaError_t", "cudaStream_t", "cudaEvent_t",
+        "float2", "float3", "float4", "int2", "int3", "int4",
+        "uint2", "uint3", "uint4", "half", "__half", "__half2",
+    ],
+    container_body_kinds: &["field_declaration_list"],
+    extract_container_name: None,
+    extract_qualified_method: Some(extract_qualified_method),
+    post_process_chunk: None,
+    test_markers: &["TEST(", "TEST_F(", "EXPECT_", "ASSERT_"],
+    test_path_patterns: &["%/tests/%", "%\\_test.cu"],
+    structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[],
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_cuda_kernel() {
+        let content = r#"
+__global__ void vectorAdd(float *a, float *b, float *c, int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        c[idx] = a[idx] + b[idx];
+    }
+}
+"#;
+        let file = write_temp_file(content, "cu");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let kernel = chunks.iter().find(|c| c.name == "vectorAdd").unwrap();
+        assert_eq!(kernel.chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_cuda_struct() {
+        let content = r#"
+struct DeviceConfig {
+    int numBlocks;
+    int threadsPerBlock;
+    cudaStream_t stream;
+};
+"#;
+        let file = write_temp_file(content, "cu");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let s = chunks.iter().find(|c| c.name == "DeviceConfig").unwrap();
+        assert_eq!(s.chunk_type, ChunkType::Struct);
+    }
+
+    #[test]
+    fn parse_cuda_calls() {
+        let content = r#"
+void launch() {
+    float *d_a;
+    cudaMalloc(&d_a, size);
+    vectorAdd<<<numBlocks, blockSize>>>(d_a, d_b, d_c, n);
+    cudaDeviceSynchronize();
+    cudaFree(d_a);
+}
+"#;
+        let file = write_temp_file(content, "cu");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "launch").unwrap();
+        let calls = parser.extract_calls_from_chunk(func);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(names.contains(&"cudaMalloc"), "Expected cudaMalloc, got: {:?}", names);
+        assert!(names.contains(&"cudaFree"), "Expected cudaFree, got: {:?}", names);
+    }
+
+    #[test]
+    fn test_extract_return_cuda() {
+        assert_eq!(
+            extract_return("__global__ void vectorAdd(float *a)"),
+            None
+        );
+        assert_eq!(
+            extract_return("__device__ float computeForce(float mass)"),
+            Some("Returns float".to_string())
+        );
+    }
+}

--- a/src/language/glsl.rs
+++ b/src/language/glsl.rs
@@ -1,0 +1,222 @@
+//! GLSL language definition
+//!
+//! GLSL extends C grammar. Reuses C chunk and call queries.
+//! Uses `LANGUAGE_GLSL` (non-standard export, like OCaml's `LANGUAGE_OCAML`).
+
+use super::{LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting GLSL code chunks (reuses C patterns)
+const CHUNK_QUERY: &str = r#"
+(function_definition
+  declarator: (function_declarator
+    declarator: (identifier) @name)) @function
+
+(struct_specifier
+  name: (type_identifier) @name
+  body: (field_declaration_list)) @struct
+
+(enum_specifier
+  name: (type_identifier) @name
+  body: (enumerator_list)) @enum
+
+(type_definition
+  declarator: (type_identifier) @name) @typealias
+
+(declaration
+  declarator: (init_declarator
+    declarator: (function_declarator
+      declarator: (identifier) @name))) @function
+
+;; Union definitions
+(union_specifier
+  name: (type_identifier) @name
+  body: (field_declaration_list)) @struct
+
+;; Preprocessor constants (#define FOO 42)
+(preproc_def
+  name: (identifier) @name) @const
+
+;; Preprocessor function macros (#define FOO(x) ...)
+(preproc_function_def
+  name: (identifier) @name) @macro
+"#;
+
+/// Tree-sitter query for extracting function calls
+const CALL_QUERY: &str = r#"
+(call_expression
+  function: (identifier) @callee)
+
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @callee))
+"#;
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    // C stopwords
+    "if", "else", "for", "while", "do", "switch", "case", "break", "continue", "return",
+    "typedef", "struct", "enum", "union", "void", "int", "char", "float", "double",
+    "const", "static", "sizeof", "true", "false",
+    // GLSL-specific qualifiers and types
+    "uniform", "varying", "attribute", "in", "out", "inout", "flat", "smooth",
+    "noperspective", "centroid", "sample", "patch",
+    "layout", "location", "binding", "set", "push_constant",
+    "precision", "lowp", "mediump", "highp",
+    "vec2", "vec3", "vec4", "ivec2", "ivec3", "ivec4",
+    "uvec2", "uvec3", "uvec4", "bvec2", "bvec3", "bvec4",
+    "mat2", "mat3", "mat4", "mat2x3", "mat3x4",
+    "sampler2D", "sampler3D", "samplerCube", "sampler2DShadow",
+    "texture", "discard", "gl_Position", "gl_FragColor",
+];
+
+fn extract_return(signature: &str) -> Option<String> {
+    // C-style: return type before function name
+    if let Some(paren) = signature.find('(') {
+        let before = signature[..paren].trim();
+        let words: Vec<&str> = before.split_whitespace().collect();
+        if words.len() >= 2 {
+            let type_words: Vec<&str> = words[..words.len() - 1]
+                .iter()
+                .filter(|w| {
+                    !matches!(
+                        **w,
+                        "static" | "inline" | "const" | "volatile"
+                            | "highp" | "mediump" | "lowp"
+                    )
+                })
+                .copied()
+                .collect();
+            if !type_words.is_empty() && type_words != ["void"] {
+                let ret = type_words.join(" ");
+                let ret_words = crate::nl::tokenize_identifier(&ret).join(" ");
+                return Some(format!("Returns {}", ret_words));
+            }
+        }
+    }
+    None
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "glsl",
+    grammar: Some(|| tree_sitter_glsl::LANGUAGE_GLSL.into()),
+    extensions: &["glsl", "vert", "frag", "geom", "comp", "tesc", "tese"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &[],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+    test_file_suggestion: None,
+    type_query: None,
+    common_types: &[
+        "int", "float", "double", "void", "bool",
+        "vec2", "vec3", "vec4", "ivec2", "ivec3", "ivec4",
+        "uvec2", "uvec3", "uvec4", "bvec2", "bvec3", "bvec4",
+        "mat2", "mat3", "mat4", "mat2x3", "mat2x4", "mat3x2", "mat3x4", "mat4x2", "mat4x3",
+        "sampler2D", "sampler3D", "samplerCube", "sampler2DShadow",
+    ],
+    container_body_kinds: &[],
+    extract_container_name: None,
+    extract_qualified_method: None,
+    post_process_chunk: None,
+    test_markers: &[],
+    test_path_patterns: &[],
+    structural_matchers: None,
+    entry_point_names: &["main"],
+    trait_method_names: &[],
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_glsl_vertex_shader() {
+        let content = r#"
+#version 450
+
+layout(location = 0) in vec3 aPosition;
+layout(location = 1) in vec2 aTexCoord;
+
+layout(location = 0) out vec2 vTexCoord;
+
+uniform mat4 uModelViewProjection;
+
+void main() {
+    gl_Position = uModelViewProjection * vec4(aPosition, 1.0);
+    vTexCoord = aTexCoord;
+}
+"#;
+        let file = write_temp_file(content, "vert");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let main_fn = chunks.iter().find(|c| c.name == "main").unwrap();
+        assert_eq!(main_fn.chunk_type, ChunkType::Function);
+    }
+
+    #[test]
+    fn parse_glsl_struct() {
+        let content = r#"
+struct Light {
+    vec3 position;
+    vec3 color;
+    float intensity;
+};
+"#;
+        let file = write_temp_file(content, "glsl");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let s = chunks.iter().find(|c| c.name == "Light").unwrap();
+        assert_eq!(s.chunk_type, ChunkType::Struct);
+    }
+
+    #[test]
+    fn parse_glsl_calls() {
+        let content = r#"
+vec4 applyLighting(vec3 normal, vec3 lightDir) {
+    float diff = max(dot(normal, lightDir), 0.0);
+    vec3 color = mix(ambient, diffuse, diff);
+    return vec4(normalize(color), 1.0);
+}
+"#;
+        let file = write_temp_file(content, "frag");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "applyLighting").unwrap();
+        let calls = parser.extract_calls_from_chunk(func);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(names.contains(&"max"), "Expected max, got: {:?}", names);
+        assert!(names.contains(&"dot"), "Expected dot, got: {:?}", names);
+        assert!(names.contains(&"mix"), "Expected mix, got: {:?}", names);
+        assert!(names.contains(&"normalize"), "Expected normalize, got: {:?}", names);
+    }
+
+    #[test]
+    fn test_extract_return_glsl() {
+        assert_eq!(
+            extract_return("vec4 applyLighting(vec3 normal)"),
+            Some("Returns vec4".to_string())
+        );
+        assert_eq!(extract_return("void main()"), None);
+    }
+}

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -45,6 +45,9 @@
 //! - `lang-nix` - Nix support (enabled by default)
 //! - `lang-make` - Makefile support (enabled by default)
 //! - `lang-latex` - LaTeX support (enabled by default)
+//! - `lang-solidity` - Solidity support (enabled by default)
+//! - `lang-cuda` - CUDA support (enabled by default)
+//! - `lang-glsl` - GLSL support (enabled by default)
 //! - `lang-all` - All languages
 
 use std::collections::HashMap;
@@ -594,6 +597,12 @@ define_languages! {
     Make => "make", feature = "lang-make", module = make;
     /// LaTeX (.tex, .sty, .cls files)
     Latex => "latex", feature = "lang-latex", module = latex;
+    /// Solidity (.sol files)
+    Solidity => "solidity", feature = "lang-solidity", module = solidity;
+    /// CUDA (.cu, .cuh files)
+    Cuda => "cuda", feature = "lang-cuda", module = cuda;
+    /// GLSL (.glsl, .vert, .frag, .geom, .comp, .tesc, .tese files)
+    Glsl => "glsl", feature = "lang-glsl", module = glsl;
     /// Markdown (.md, .mdx files)
     Markdown => "markdown", feature = "lang-markdown", module = markdown;
 }
@@ -829,6 +838,20 @@ mod tests {
             assert!(REGISTRY.from_extension("sty").is_some());
             assert!(REGISTRY.from_extension("cls").is_some());
         }
+        #[cfg(feature = "lang-solidity")]
+        assert!(REGISTRY.from_extension("sol").is_some());
+        #[cfg(feature = "lang-cuda")]
+        {
+            assert!(REGISTRY.from_extension("cu").is_some());
+            assert!(REGISTRY.from_extension("cuh").is_some());
+        }
+        #[cfg(feature = "lang-glsl")]
+        {
+            assert!(REGISTRY.from_extension("glsl").is_some());
+            assert!(REGISTRY.from_extension("vert").is_some());
+            assert!(REGISTRY.from_extension("frag").is_some());
+            assert!(REGISTRY.from_extension("comp").is_some());
+        }
         #[cfg(feature = "lang-markdown")]
         {
             assert!(REGISTRY.from_extension("md").is_some());
@@ -1010,6 +1033,18 @@ mod tests {
         {
             expected += 1;
         }
+        #[cfg(feature = "lang-solidity")]
+        {
+            expected += 1;
+        }
+        #[cfg(feature = "lang-cuda")]
+        {
+            expected += 1;
+        }
+        #[cfg(feature = "lang-glsl")]
+        {
+            expected += 1;
+        }
         #[cfg(feature = "lang-markdown")]
         {
             expected += 1;
@@ -1119,6 +1154,16 @@ mod tests {
         assert_eq!(Language::from_extension("tex"), Some(Language::Latex));
         assert_eq!(Language::from_extension("sty"), Some(Language::Latex));
         assert_eq!(Language::from_extension("cls"), Some(Language::Latex));
+        assert_eq!(Language::from_extension("sol"), Some(Language::Solidity));
+        assert_eq!(Language::from_extension("cu"), Some(Language::Cuda));
+        assert_eq!(Language::from_extension("cuh"), Some(Language::Cuda));
+        assert_eq!(Language::from_extension("glsl"), Some(Language::Glsl));
+        assert_eq!(Language::from_extension("vert"), Some(Language::Glsl));
+        assert_eq!(Language::from_extension("frag"), Some(Language::Glsl));
+        assert_eq!(Language::from_extension("geom"), Some(Language::Glsl));
+        assert_eq!(Language::from_extension("comp"), Some(Language::Glsl));
+        assert_eq!(Language::from_extension("tesc"), Some(Language::Glsl));
+        assert_eq!(Language::from_extension("tese"), Some(Language::Glsl));
         assert_eq!(Language::from_extension("md"), Some(Language::Markdown));
         assert_eq!(Language::from_extension("mdx"), Some(Language::Markdown));
         assert_eq!(Language::from_extension("unknown"), None);
@@ -1172,6 +1217,9 @@ mod tests {
         assert_eq!("nix".parse::<Language>().unwrap(), Language::Nix);
         assert_eq!("make".parse::<Language>().unwrap(), Language::Make);
         assert_eq!("latex".parse::<Language>().unwrap(), Language::Latex);
+        assert_eq!("solidity".parse::<Language>().unwrap(), Language::Solidity);
+        assert_eq!("cuda".parse::<Language>().unwrap(), Language::Cuda);
+        assert_eq!("glsl".parse::<Language>().unwrap(), Language::Glsl);
         assert_eq!("markdown".parse::<Language>().unwrap(), Language::Markdown);
         assert!("invalid".parse::<Language>().is_err());
     }
@@ -1220,6 +1268,9 @@ mod tests {
         assert_eq!(Language::Nix.to_string(), "nix");
         assert_eq!(Language::Make.to_string(), "make");
         assert_eq!(Language::Latex.to_string(), "latex");
+        assert_eq!(Language::Solidity.to_string(), "solidity");
+        assert_eq!(Language::Cuda.to_string(), "cuda");
+        assert_eq!(Language::Glsl.to_string(), "glsl");
         assert_eq!(Language::Markdown.to_string(), "markdown");
     }
 
@@ -1502,6 +1553,35 @@ mod tests {
         // LaTeX — no return types
         assert_eq!(
             (Language::Latex.def().extract_return_nl)("\\section{Intro}"),
+            None
+        );
+        // Solidity — returns keyword
+        assert_eq!(
+            (Language::Solidity.def().extract_return_nl)(
+                "function add(uint a, uint b) public pure returns (uint)"
+            ),
+            Some("Returns uint".to_string())
+        );
+        assert_eq!(
+            (Language::Solidity.def().extract_return_nl)("function doSomething() public"),
+            None
+        );
+        // CUDA — C++ style
+        assert_eq!(
+            (Language::Cuda.def().extract_return_nl)("__device__ float compute(float x)"),
+            Some("Returns float".to_string())
+        );
+        assert_eq!(
+            (Language::Cuda.def().extract_return_nl)("__global__ void kernel(int n)"),
+            None
+        );
+        // GLSL — C style
+        assert_eq!(
+            (Language::Glsl.def().extract_return_nl)("vec4 applyLighting(vec3 normal)"),
+            Some("Returns vec4".to_string())
+        );
+        assert_eq!(
+            (Language::Glsl.def().extract_return_nl)("void main()"),
             None
         );
     }

--- a/src/language/solidity.rs
+++ b/src/language/solidity.rs
@@ -1,0 +1,247 @@
+//! Solidity language definition
+
+use super::{LanguageDef, SignatureStyle};
+
+/// Tree-sitter query for extracting Solidity code chunks
+const CHUNK_QUERY: &str = r#"
+;; Contracts
+(contract_declaration
+  name: (identifier) @name
+  body: (contract_body)) @class
+
+;; Interfaces
+(interface_declaration
+  name: (identifier) @name
+  body: (contract_body)) @interface
+
+;; Libraries
+(library_declaration
+  name: (identifier) @name
+  body: (contract_body)) @module
+
+;; Structs
+(struct_declaration
+  name: (identifier) @name
+  body: (struct_body)) @struct
+
+;; Enums
+(enum_declaration
+  name: (identifier) @name
+  body: (enum_body)) @enum
+
+;; Functions
+(function_definition
+  name: (identifier) @name) @function
+
+;; Modifiers
+(modifier_definition
+  name: (identifier) @name) @function
+
+;; Events
+(event_definition
+  name: (identifier) @name) @property
+
+;; State variables
+(state_variable_declaration
+  name: (identifier) @name) @property
+
+;; Errors (custom error types)
+(error_declaration
+  name: (identifier) @name) @struct
+"#;
+
+/// Tree-sitter query for extracting function calls
+///
+/// Note: Solidity grammar uses supertype `expression` for the `function` field
+/// in `call_expression`, so `function: (identifier)` and `function: (member_expression)`
+/// fail with Structure errors. We use two patterns:
+/// 1. member_expression → capture just the property (method name)
+/// 2. call_expression function: (_) → capture whole callee (works for direct calls;
+///    member calls captured above get the whole `obj.method` text, but dedup
+///    means the first pattern's clean capture wins)
+const CALL_QUERY: &str = r#"
+;; Member function call — token.transfer() → captures "transfer"
+(member_expression
+  property: (identifier) @callee)
+
+;; All function calls — captures the full callee expression
+;; For direct calls like require(), this captures "require"
+;; For member calls, this captures "token.transfer" (deduped with above)
+(call_expression
+  function: (_) @callee)
+"#;
+
+/// Doc comment node types
+const DOC_NODES: &[&str] = &["comment"];
+
+const STOPWORDS: &[&str] = &[
+    "if", "else", "for", "while", "do", "return", "break", "continue",
+    "contract", "interface", "library", "struct", "enum", "function", "modifier",
+    "event", "error", "mapping", "address", "bool", "string", "bytes", "uint",
+    "int", "uint256", "int256", "uint8", "bytes32", "public", "private",
+    "internal", "external", "view", "pure", "payable", "memory", "storage",
+    "calldata", "indexed", "virtual", "override", "abstract", "immutable",
+    "constant", "emit", "require", "assert", "revert", "this", "super",
+    "true", "false", "msg", "block", "tx",
+];
+
+fn extract_return(signature: &str) -> Option<String> {
+    // Solidity: returns (...) at end of function signature
+    // e.g., "function add(uint a, uint b) public pure returns (uint)"
+    if let Some(ret_idx) = signature.find("returns") {
+        let after = signature[ret_idx + 7..].trim();
+        // Strip parens
+        let inner = after
+            .trim_start_matches('(')
+            .trim_end_matches(')')
+            .trim_end_matches('{')
+            .trim();
+        if !inner.is_empty() {
+            let ret_words = crate::nl::tokenize_identifier(inner).join(" ");
+            return Some(format!("Returns {}", ret_words));
+        }
+    }
+    None
+}
+
+static DEFINITION: LanguageDef = LanguageDef {
+    name: "solidity",
+    grammar: Some(|| tree_sitter_solidity::LANGUAGE.into()),
+    extensions: &["sol"],
+    chunk_query: CHUNK_QUERY,
+    call_query: Some(CALL_QUERY),
+    signature_style: SignatureStyle::UntilBrace,
+    doc_nodes: DOC_NODES,
+    method_node_kinds: &[],
+    method_containers: &["contract_body"],
+    stopwords: STOPWORDS,
+    extract_return_nl: extract_return,
+    test_file_suggestion: None,
+    type_query: None,
+    common_types: &[
+        "address", "bool", "string", "bytes", "uint256", "int256", "uint8", "uint16",
+        "uint32", "uint64", "uint128", "int8", "int16", "int32", "int64", "int128",
+        "bytes32", "bytes4", "bytes20",
+    ],
+    container_body_kinds: &["contract_body"],
+    extract_container_name: None,
+    extract_qualified_method: None,
+    post_process_chunk: None,
+    test_markers: &[],
+    test_path_patterns: &["%/test/%", "%.t.sol"],
+    structural_matchers: None,
+    entry_point_names: &["constructor", "receive", "fallback"],
+    trait_method_names: &[],
+};
+
+pub fn definition() -> &'static LanguageDef {
+    &DEFINITION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ChunkType, Parser};
+    use std::io::Write;
+
+    fn write_temp_file(content: &str, ext: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new()
+            .suffix(&format!(".{}", ext))
+            .tempfile()
+            .unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn parse_solidity_contract() {
+        let content = r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Token {
+    string public name;
+    uint256 public totalSupply;
+
+    function transfer(address to, uint256 amount) public returns (bool) {
+        return true;
+    }
+}
+"#;
+        let file = write_temp_file(content, "sol");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let contract = chunks.iter().find(|c| c.name == "Token").unwrap();
+        assert_eq!(contract.chunk_type, ChunkType::Class);
+        let func = chunks.iter().find(|c| c.name == "transfer").unwrap();
+        assert_eq!(func.chunk_type, ChunkType::Method);
+        assert_eq!(func.parent_type_name.as_deref(), Some("Token"));
+    }
+
+    #[test]
+    fn parse_solidity_interface() {
+        let content = r#"
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+}
+"#;
+        let file = write_temp_file(content, "sol");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let iface = chunks.iter().find(|c| c.name == "IERC20").unwrap();
+        assert_eq!(iface.chunk_type, ChunkType::Interface);
+    }
+
+    #[test]
+    fn parse_solidity_calls() {
+        let content = r#"
+contract Caller {
+    function doWork() public {
+        token.transfer(msg.sender, 100);
+        require(true, "failed");
+    }
+}
+"#;
+        let file = write_temp_file(content, "sol");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let func = chunks.iter().find(|c| c.name == "doWork").unwrap();
+        let calls = parser.extract_calls_from_chunk(func);
+        let names: Vec<_> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(names.contains(&"transfer"), "Expected transfer, got: {:?}", names);
+        assert!(names.contains(&"require"), "Expected require, got: {:?}", names);
+    }
+
+    #[test]
+    fn parse_solidity_struct_and_enum() {
+        let content = r#"
+struct Position {
+    uint256 x;
+    uint256 y;
+}
+
+enum Status { Active, Paused, Stopped }
+"#;
+        let file = write_temp_file(content, "sol");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        let s = chunks.iter().find(|c| c.name == "Position").unwrap();
+        assert_eq!(s.chunk_type, ChunkType::Struct);
+        let e = chunks.iter().find(|c| c.name == "Status").unwrap();
+        assert_eq!(e.chunk_type, ChunkType::Enum);
+    }
+
+    #[test]
+    fn test_extract_return_solidity() {
+        assert_eq!(
+            extract_return("function add(uint a, uint b) public pure returns (uint)"),
+            Some("Returns uint".to_string())
+        );
+        assert_eq!(
+            extract_return("function doSomething() public"),
+            None
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - **Semantic search**: Uses E5-base-v2 embeddings (769-dim: 768 model + sentiment)
 //! - **Notes with sentiment**: Unified memory system for AI collaborators
-//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Gleam, Haskell, Julia, OCaml, CSS, Perl, HTML, JSON, XML, INI, Nix, Make, LaTeX, Markdown (43 languages)
+//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Gleam, Haskell, Julia, OCaml, CSS, Perl, HTML, JSON, XML, INI, Nix, Make, LaTeX, Solidity, CUDA, GLSL, Markdown (46 languages)
 //! - **GPU acceleration**: CUDA/TensorRT with CPU fallback
 //! - **CLI tools**: Call graph, impact analysis, test mapping, dead code detection
 //! - **Document conversion**: PDF, HTML, CHM, Web Help → cleaned Markdown (optional `convert` feature)

--- a/tests/eval_common.rs
+++ b/tests/eval_common.rs
@@ -94,6 +94,12 @@ pub fn fixture_path(lang: Language) -> PathBuf {
         Language::Make => "mk",
         #[cfg(feature = "lang-latex")]
         Language::Latex => "tex",
+        #[cfg(feature = "lang-solidity")]
+        Language::Solidity => "sol",
+        #[cfg(feature = "lang-cuda")]
+        Language::Cuda => "cu",
+        #[cfg(feature = "lang-glsl")]
+        Language::Glsl => "vert",
         Language::Markdown => "md",
     };
     PathBuf::from(manifest_dir)
@@ -182,6 +188,12 @@ pub fn hard_fixture_path(lang: Language) -> PathBuf {
         Language::Make => "mk",
         #[cfg(feature = "lang-latex")]
         Language::Latex => "tex",
+        #[cfg(feature = "lang-solidity")]
+        Language::Solidity => "sol",
+        #[cfg(feature = "lang-cuda")]
+        Language::Cuda => "cu",
+        #[cfg(feature = "lang-glsl")]
+        Language::Glsl => "vert",
         Language::Markdown => "md",
     };
     PathBuf::from(manifest_dir)

--- a/tests/fixtures/sample.cu
+++ b/tests/fixtures/sample.cu
@@ -1,0 +1,104 @@
+#include <cuda_runtime.h>
+#include <stdio.h>
+
+// Device configuration
+struct DeviceConfig {
+    int numBlocks;
+    int threadsPerBlock;
+    size_t sharedMemSize;
+};
+
+// Enum for reduction operations
+enum class ReductionOp { Sum, Max, Min };
+
+typedef float (*ActivationFn)(float);
+
+#define BLOCK_SIZE 256
+#define WARP_SIZE 32
+#define CHECK_CUDA(call) do { cudaError_t err = (call); if (err != cudaSuccess) { printf("CUDA error: %s\n", cudaGetErrorString(err)); exit(1); } } while(0)
+
+namespace gpu {
+
+/// Vector addition kernel
+__global__ void vectorAdd(const float *a, const float *b, float *c, int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        c[idx] = a[idx] + b[idx];
+    }
+}
+
+/// Matrix multiply kernel with shared memory
+__global__ void matMul(const float *A, const float *B, float *C, int N) {
+    __shared__ float tileA[BLOCK_SIZE][BLOCK_SIZE];
+    __shared__ float tileB[BLOCK_SIZE][BLOCK_SIZE];
+
+    int row = blockIdx.y * blockDim.y + threadIdx.y;
+    int col = blockIdx.x * blockDim.x + threadIdx.x;
+    float sum = 0.0f;
+
+    for (int t = 0; t < (N + BLOCK_SIZE - 1) / BLOCK_SIZE; t++) {
+        tileA[threadIdx.y][threadIdx.x] = A[row * N + t * BLOCK_SIZE + threadIdx.x];
+        tileB[threadIdx.y][threadIdx.x] = B[(t * BLOCK_SIZE + threadIdx.y) * N + col];
+        __syncthreads();
+
+        for (int k = 0; k < BLOCK_SIZE; k++) {
+            sum += tileA[threadIdx.y][k] * tileB[k][threadIdx.x];
+        }
+        __syncthreads();
+    }
+
+    C[row * N + col] = sum;
+}
+
+/// Device helper function
+__device__ float sigmoid(float x) {
+    return 1.0f / (1.0f + expf(-x));
+}
+
+/// Activation kernel using function pointer
+__global__ void applyActivation(float *data, int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        data[idx] = sigmoid(data[idx]);
+    }
+}
+
+} // namespace gpu
+
+/// Host function to launch vector addition
+void launchVectorAdd(const float *h_a, const float *h_b, float *h_c, int n) {
+    float *d_a, *d_b, *d_c;
+    size_t size = n * sizeof(float);
+
+    CHECK_CUDA(cudaMalloc(&d_a, size));
+    CHECK_CUDA(cudaMalloc(&d_b, size));
+    CHECK_CUDA(cudaMalloc(&d_c, size));
+
+    cudaMemcpy(d_a, h_a, size, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_b, h_b, size, cudaMemcpyHostToDevice);
+
+    int blockSize = BLOCK_SIZE;
+    int numBlocks = (n + blockSize - 1) / blockSize;
+    gpu::vectorAdd<<<numBlocks, blockSize>>>(d_a, d_b, d_c, n);
+
+    cudaMemcpy(h_c, d_c, size, cudaMemcpyDeviceToHost);
+
+    cudaFree(d_a);
+    cudaFree(d_b);
+    cudaFree(d_c);
+}
+
+int main() {
+    const int N = 1024;
+    float a[N], b[N], c[N];
+
+    for (int i = 0; i < N; i++) {
+        a[i] = static_cast<float>(i);
+        b[i] = static_cast<float>(i * 2);
+    }
+
+    launchVectorAdd(a, b, c, N);
+
+    printf("c[0] = %f, c[N-1] = %f\n", c[0], c[N - 1]);
+    return 0;
+}

--- a/tests/fixtures/sample.sol
+++ b/tests/fixtures/sample.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/// @title Simple ERC20 Token
+/// @notice A basic token implementation for testing
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 amount) external returns (bool);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+}
+
+library SafeMath {
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: overflow");
+        return c;
+    }
+
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b <= a, "SafeMath: underflow");
+        return a - b;
+    }
+}
+
+struct TokenInfo {
+    string name;
+    string symbol;
+    uint8 decimals;
+}
+
+enum Status { Active, Paused, Stopped }
+
+error InsufficientBalance(uint256 available, uint256 required);
+
+contract Token is IERC20 {
+    using SafeMath for uint256;
+
+    string public name;
+    string public symbol;
+    uint256 public totalSupply;
+    mapping(address => uint256) private balances;
+
+    event Mint(address indexed to, uint256 amount);
+
+    modifier onlyPositive(uint256 amount) {
+        require(amount > 0, "Amount must be positive");
+        _;
+    }
+
+    constructor(string memory _name, string memory _symbol, uint256 _initialSupply) {
+        name = _name;
+        symbol = _symbol;
+        totalSupply = _initialSupply;
+        balances[msg.sender] = _initialSupply;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return balances[account];
+    }
+
+    function transfer(address to, uint256 amount) external onlyPositive(amount) returns (bool) {
+        if (balances[msg.sender] < amount) {
+            revert InsufficientBalance(balances[msg.sender], amount);
+        }
+        balances[msg.sender] = balances[msg.sender].sub(amount);
+        balances[to] = balances[to].add(amount);
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function mint(address to, uint256 amount) external {
+        totalSupply = totalSupply.add(amount);
+        balances[to] = balances[to].add(amount);
+        emit Mint(to, amount);
+    }
+}

--- a/tests/fixtures/sample.vert
+++ b/tests/fixtures/sample.vert
@@ -1,0 +1,75 @@
+#version 450 core
+
+// Vertex attribute inputs
+layout(location = 0) in vec3 aPosition;
+layout(location = 1) in vec3 aNormal;
+layout(location = 2) in vec2 aTexCoord;
+
+// Outputs to fragment shader
+layout(location = 0) out vec3 vWorldPos;
+layout(location = 1) out vec3 vNormal;
+layout(location = 2) out vec2 vTexCoord;
+layout(location = 3) out vec4 vShadowCoord;
+
+// Uniform buffer for transform matrices
+layout(std140, binding = 0) uniform Matrices {
+    mat4 model;
+    mat4 view;
+    mat4 projection;
+    mat4 lightSpaceMatrix;
+};
+
+// Material properties
+struct Material {
+    vec3 ambient;
+    vec3 diffuse;
+    vec3 specular;
+    float shininess;
+};
+
+// Point light
+struct PointLight {
+    vec3 position;
+    vec3 color;
+    float intensity;
+    float radius;
+};
+
+#define MAX_LIGHTS 8
+#define PI 3.14159265359
+
+/// Transform normal from object to world space
+vec3 transformNormal(vec3 normal, mat4 modelMatrix) {
+    mat3 normalMatrix = transpose(inverse(mat3(modelMatrix)));
+    return normalize(normalMatrix * normal);
+}
+
+/// Compute fresnel factor using Schlick approximation
+float fresnelSchlick(float cosTheta, float F0) {
+    return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+}
+
+/// Compute distance attenuation for point lights
+float attenuate(float distance, float radius) {
+    float d = max(distance, 0.001);
+    float attenuation = 1.0 / (d * d);
+    float falloff = clamp(1.0 - pow(d / radius, 4.0), 0.0, 1.0);
+    return attenuation * falloff;
+}
+
+/// Apply fog effect based on distance
+vec4 applyFog(vec4 color, float distance, vec3 fogColor, float fogDensity) {
+    float fogFactor = exp(-fogDensity * distance);
+    fogFactor = clamp(fogFactor, 0.0, 1.0);
+    return mix(vec4(fogColor, 1.0), color, fogFactor);
+}
+
+void main() {
+    vec4 worldPos = model * vec4(aPosition, 1.0);
+    vWorldPos = worldPos.xyz;
+    vNormal = transformNormal(aNormal, model);
+    vTexCoord = aTexCoord;
+    vShadowCoord = lightSpaceMatrix * worldPos;
+
+    gl_Position = projection * view * worldPos;
+}

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1480,3 +1480,123 @@ fn test_latex_section_and_command_extraction() {
             .collect::<Vec<_>>()
     );
 }
+
+#[test]
+#[cfg(feature = "lang-solidity")]
+fn test_solidity_contract_and_function_extraction() {
+    let parser = Parser::new().unwrap();
+    let path = fixtures_path().join("sample.sol");
+    let chunks = parser.parse_file(&path).unwrap();
+    assert!(
+        !chunks.is_empty(),
+        "Should extract Solidity chunks from sample.sol"
+    );
+
+    let contract = chunks
+        .iter()
+        .find(|c| c.name == "Token" && c.chunk_type == ChunkType::Class);
+    assert!(
+        contract.is_some(),
+        "Should find 'Token' contract as Class, got: {:?}",
+        chunks
+            .iter()
+            .map(|c| (&c.name, &c.chunk_type))
+            .collect::<Vec<_>>()
+    );
+
+    let iface = chunks
+        .iter()
+        .find(|c| c.name == "IERC20" && c.chunk_type == ChunkType::Interface);
+    assert!(
+        iface.is_some(),
+        "Should find 'IERC20' interface, got: {:?}",
+        chunks
+            .iter()
+            .map(|c| (&c.name, &c.chunk_type))
+            .collect::<Vec<_>>()
+    );
+
+    let lib = chunks
+        .iter()
+        .find(|c| c.name == "SafeMath" && c.chunk_type == ChunkType::Module);
+    assert!(
+        lib.is_some(),
+        "Should find 'SafeMath' library as Module, got: {:?}",
+        chunks
+            .iter()
+            .map(|c| (&c.name, &c.chunk_type))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+#[cfg(feature = "lang-cuda")]
+fn test_cuda_kernel_and_struct_extraction() {
+    let parser = Parser::new().unwrap();
+    let path = fixtures_path().join("sample.cu");
+    let chunks = parser.parse_file(&path).unwrap();
+    assert!(
+        !chunks.is_empty(),
+        "Should extract CUDA chunks from sample.cu"
+    );
+
+    let kernel = chunks
+        .iter()
+        .find(|c| c.name == "vectorAdd" && c.chunk_type == ChunkType::Function);
+    assert!(
+        kernel.is_some(),
+        "Should find 'vectorAdd' kernel as Function, got: {:?}",
+        chunks
+            .iter()
+            .map(|c| (&c.name, &c.chunk_type))
+            .collect::<Vec<_>>()
+    );
+
+    let s = chunks
+        .iter()
+        .find(|c| c.name == "DeviceConfig" && c.chunk_type == ChunkType::Struct);
+    assert!(
+        s.is_some(),
+        "Should find 'DeviceConfig' struct, got: {:?}",
+        chunks
+            .iter()
+            .map(|c| (&c.name, &c.chunk_type))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+#[cfg(feature = "lang-glsl")]
+fn test_glsl_function_and_struct_extraction() {
+    let parser = Parser::new().unwrap();
+    let path = fixtures_path().join("sample.vert");
+    let chunks = parser.parse_file(&path).unwrap();
+    assert!(
+        !chunks.is_empty(),
+        "Should extract GLSL chunks from sample.vert"
+    );
+
+    let func = chunks
+        .iter()
+        .find(|c| c.name == "transformNormal" && c.chunk_type == ChunkType::Function);
+    assert!(
+        func.is_some(),
+        "Should find 'transformNormal' function, got: {:?}",
+        chunks
+            .iter()
+            .map(|c| (&c.name, &c.chunk_type))
+            .collect::<Vec<_>>()
+    );
+
+    let s = chunks
+        .iter()
+        .find(|c| c.name == "Material" && c.chunk_type == ChunkType::Struct);
+    assert!(
+        s.is_some(),
+        "Should find 'Material' struct, got: {:?}",
+        chunks
+            .iter()
+            .map(|c| (&c.name, &c.chunk_type))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Batch 3 of Phase 2 language expansion: adds Solidity, CUDA, and GLSL support (43 → 46 languages).

- **Solidity**: Full smart contract support — contracts, interfaces, libraries, structs, enums, functions, modifiers, events, state variables, errors, call graph. Workaround for tree-sitter supertype issue (`call_expression.function` uses `expression` supertype — can't match specific types through it).
- **CUDA**: Reuses C++ chunk/call queries verbatim. Adds CUDA-specific stopwords and qualifier filtering. Extensions: `.cu`, `.cuh`.
- **GLSL**: Reuses C chunk/call queries. Uses `LANGUAGE_GLSL` non-standard export. Adds shader-specific stopwords. Extensions: `.glsl`, `.vert`, `.frag`, `.geom`, `.comp`, `.tesc`, `.tese`.

All 1456 tests pass, clippy clean, fmt clean.

## Changes

- 3 new language modules: `solidity.rs`, `cuda.rs`, `glsl.rs` (with 13 unit tests)
- 3 new test fixtures: `sample.sol`, `sample.cu`, `sample.vert`
- 3 integration tests in `parser_test.rs`
- Updated `mod.rs`, `eval_common.rs`, `Cargo.toml` (deps + features)
- Docs: README, CONTRIBUTING, CHANGELOG, lib.rs, ROADMAP, PROJECT_CONTINUITY

## Test plan

- [x] `cargo test --features gpu-index` — 1456 pass, 0 fail
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
