### PR TITLE
feat: multi-grammar parsing (HTML → JS/CSS injection)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,7 @@ src/
     types.rs    - Chunk (incl. parent_type_name), CallSite, FunctionCalls, TypeRef, ParserError
     chunk.rs    - Chunk extraction, signatures, doc comments, parent type extraction
     calls.rs    - Call graph extraction, callee filtering
+    injection.rs - Multi-grammar injection (HTML→JS/CSS via set_included_ranges)
     markdown.rs - Heading-based markdown parser, cross-reference extraction
   embedder.rs   - ONNX model (E5-base-v2), 769-dim embeddings
   reranker.rs   - Cross-encoder re-ranking (ms-marco-MiniLM-L-6-v2)

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,21 +2,21 @@
 
 ## Right Now
 
-**Phase 2 language expansion — complete.** 2026-03-05.
+**Multi-grammar parsing — implemented.** 2026-03-05.
 
-All 3 batches done. 46 languages total.
-- Batch 1 (HTML, JSON, XML, INI) — PR #535 merged
-- Batch 2 (Nix, Make, LaTeX) — PR #537 merged
-- Batch 3 (Solidity, CUDA, GLSL) — PR #538 open, CI running
+HTML files now extract real JS/CSS chunks from `<script>` and `<style>` blocks using tree-sitter `set_included_ranges()`. Two-phase parsing: outer HTML grammar, then inner JS/CSS grammars.
 
-Key fix in Batch 3:
-- Solidity grammar uses `expression` supertype for `call_expression.function` field — tree-sitter queries can't match through supertypes with `function: (identifier)`. Solved with `member_expression property:` for member calls + `function: (_)` wildcard for direct calls.
-
-Also added Multi-Grammar Parsing section to ROADMAP.md.
+Key additions:
+- `InjectionRule` struct on `LanguageDef` (all 46 languages default to `&[]`)
+- `src/parser/injection.rs` — find_injection_ranges, parse_injected_chunks, parse_injected_relationships
+- HTML injection rules: script→JS (with TS detection via `lang`/`type` attrs), style→CSS
+- 9 new tests (JS extraction, CSS, TypeScript detection, empty script, multiple scripts, whitespace-only, regression, call graph, non-injection language)
+- `sample.html` fixture enhanced with inline `<script>` functions
+- Total: 1465 tests pass, 0 fail
 
 ## Pending Changes
 
-PR #538 waiting for CI. No uncommitted work.
+Uncommitted multi-grammar changes. Ready for branch + PR.
 
 ## Parked
 

--- a/src/language/bash.rs
+++ b/src/language/bash.rs
@@ -49,6 +49,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &["main"],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/c.rs
+++ b/src/language/c.rs
@@ -136,6 +136,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &["main"],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/cpp.rs
+++ b/src/language/cpp.rs
@@ -260,6 +260,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &["main"],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/csharp.rs
+++ b/src/language/csharp.rs
@@ -169,6 +169,7 @@ static DEFINITION: LanguageDef = LanguageDef {
         "Equals", "GetHashCode", "ToString", "CompareTo", "Dispose",
         "GetEnumerator", "MoveNext",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/css.rs
+++ b/src/language/css.rs
@@ -95,6 +95,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/cuda.rs
+++ b/src/language/cuda.rs
@@ -222,6 +222,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &["main"],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/elixir.rs
+++ b/src/language/elixir.rs
@@ -198,6 +198,7 @@ static DEFINITION: LanguageDef = LanguageDef {
         "terminate",
         "code_change",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/erlang.rs
+++ b/src/language/erlang.rs
@@ -131,6 +131,7 @@ static DEFINITION: LanguageDef = LanguageDef {
         "terminate",
         "code_change",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/fsharp.rs
+++ b/src/language/fsharp.rs
@@ -209,6 +209,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     trait_method_names: &[
         "Equals", "GetHashCode", "ToString", "CompareTo", "Dispose",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/gleam.rs
+++ b/src/language/gleam.rs
@@ -125,6 +125,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &["main"],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/glsl.rs
+++ b/src/language/glsl.rs
@@ -128,6 +128,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &["main"],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/go.rs
+++ b/src/language/go.rs
@@ -216,6 +216,7 @@ static DEFINITION: LanguageDef = LanguageDef {
         "String", "Error", "Close", "Read", "Write", "ServeHTTP",
         "Len", "Less", "Swap", "MarshalJSON", "UnmarshalJSON",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/graphql.rs
+++ b/src/language/graphql.rs
@@ -89,6 +89,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/haskell.rs
+++ b/src/language/haskell.rs
@@ -159,6 +159,7 @@ static DEFINITION: LanguageDef = LanguageDef {
         "return",
         "fromInteger",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/hcl.rs
+++ b/src/language/hcl.rs
@@ -186,6 +186,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/html.rs
+++ b/src/language/html.rs
@@ -4,7 +4,7 @@
 //! for multi-grammar parsing (Svelte, Vue, Astro). Chunks are semantic elements:
 //! headings, landmarks, script/style blocks, and id'd elements.
 
-use super::{ChunkType, LanguageDef, PostProcessChunkFn, SignatureStyle};
+use super::{ChunkType, InjectionRule, LanguageDef, PostProcessChunkFn, SignatureStyle};
 
 /// Tree-sitter query for extracting HTML chunks.
 ///
@@ -188,6 +188,35 @@ fn extract_return(_signature: &str) -> Option<String> {
     None
 }
 
+/// Detect script language from `<script>` element attributes.
+///
+/// Checks for `lang="ts"`, `type="text/typescript"`, or similar attributes
+/// that indicate TypeScript instead of the default JavaScript.
+fn detect_script_language(node: tree_sitter::Node, source: &str) -> Option<&'static str> {
+    // Find the start_tag child
+    let start_tag = find_child_by_kind(node, "start_tag")?;
+
+    // Check lang attribute: <script lang="ts">
+    if let Some(lang_val) = find_attribute_value(start_tag, "lang", source) {
+        let lower = lang_val.to_lowercase();
+        if lower == "ts" || lower == "typescript" {
+            tracing::debug!("Detected TypeScript from lang attribute");
+            return Some("typescript");
+        }
+    }
+
+    // Check type attribute: <script type="text/typescript">
+    if let Some(type_val) = find_attribute_value(start_tag, "type", source) {
+        let lower = type_val.to_lowercase();
+        if lower.contains("typescript") {
+            tracing::debug!("Detected TypeScript from type attribute");
+            return Some("typescript");
+        }
+    }
+
+    None // Use default (javascript)
+}
+
 static DEFINITION: LanguageDef = LanguageDef {
     name: "html",
     grammar: Some(|| tree_sitter_html::LANGUAGE.into()),
@@ -212,6 +241,20 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[
+        InjectionRule {
+            container_kind: "script_element",
+            content_kind: "raw_text",
+            target_language: "javascript",
+            detect_language: Some(detect_script_language),
+        },
+        InjectionRule {
+            container_kind: "style_element",
+            content_kind: "raw_text",
+            target_language: "css",
+            detect_language: None,
+        },
+    ],
 };
 
 pub fn definition() -> &'static LanguageDef {
@@ -352,5 +395,292 @@ mod tests {
     fn test_extract_return_html() {
         assert_eq!(extract_return("<div>test</div>"), None);
         assert_eq!(extract_return(""), None);
+    }
+
+    // --- Multi-grammar injection tests ---
+
+    #[test]
+    fn parse_html_with_script_extracts_js_functions() {
+        let content = r#"<html>
+<body>
+<h1>Title</h1>
+<script>
+function handleClick(event) {
+    const el = document.getElementById('target');
+    el.classList.toggle('active');
+}
+
+function setupListeners() {
+    handleClick(null);
+}
+</script>
+</body>
+</html>
+"#;
+        let file = write_temp_file(content, "html");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+
+        // Should have JS function chunks
+        let js_funcs: Vec<_> = chunks
+            .iter()
+            .filter(|c| c.language == crate::parser::Language::JavaScript)
+            .collect();
+        assert!(
+            js_funcs.iter().any(|c| c.name == "handleClick"),
+            "Expected JS function 'handleClick', got: {:?}",
+            js_funcs.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+        assert!(
+            js_funcs.iter().any(|c| c.name == "setupListeners"),
+            "Expected JS function 'setupListeners', got: {:?}",
+            js_funcs.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+
+        // JS functions should have correct language
+        for f in &js_funcs {
+            assert_eq!(f.language, crate::parser::Language::JavaScript);
+            assert_eq!(f.chunk_type, ChunkType::Function);
+        }
+
+        // HTML heading should still be present
+        assert!(
+            chunks.iter().any(|c| c.name == "Title" && c.chunk_type == ChunkType::Section),
+            "Expected HTML heading 'Title'"
+        );
+
+        // The script Module chunk should have been replaced by JS functions
+        assert!(
+            !chunks.iter().any(|c| c.chunk_type == ChunkType::Module && c.name == "script"),
+            "Script Module chunk should be replaced by JS functions"
+        );
+    }
+
+    #[test]
+    fn parse_html_with_style_extracts_css_rules() {
+        let content = r#"<html>
+<head>
+<style>
+.container {
+    display: flex;
+    gap: 1rem;
+}
+</style>
+</head>
+<body><h1>Page</h1></body>
+</html>
+"#;
+        let file = write_temp_file(content, "html");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+
+        // CSS chunks should be extracted (if CSS query captures rules)
+        let css_chunks: Vec<_> = chunks
+            .iter()
+            .filter(|c| c.language == crate::parser::Language::Css)
+            .collect();
+
+        // CSS language definition captures Section chunks for selectors
+        // Even if no CSS chunks extracted (depends on CSS query), the style Module
+        // chunk behavior should be correct
+        if !css_chunks.is_empty() {
+            // If CSS produces chunks, the style Module should be replaced
+            assert!(
+                !chunks.iter().any(|c| c.chunk_type == ChunkType::Module && c.name == "style"),
+                "Style Module chunk should be replaced by CSS chunks"
+            );
+        }
+
+        // HTML heading should still be present
+        assert!(
+            chunks.iter().any(|c| c.name == "Page" && c.chunk_type == ChunkType::Section),
+            "Expected HTML heading 'Page'"
+        );
+    }
+
+    #[test]
+    fn parse_html_with_typescript_script() {
+        let content = r#"<html>
+<body>
+<script lang="ts">
+function typedFunction(x: number): string {
+    return x.toString();
+}
+</script>
+</body>
+</html>
+"#;
+        let file = write_temp_file(content, "html");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+
+        let ts_funcs: Vec<_> = chunks
+            .iter()
+            .filter(|c| c.language == crate::parser::Language::TypeScript)
+            .collect();
+        assert!(
+            ts_funcs.iter().any(|c| c.name == "typedFunction"),
+            "Expected TypeScript function, got: {:?}",
+            chunks.iter().map(|c| (&c.name, &c.language)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn parse_html_with_empty_script_keeps_module() {
+        // <script src="..."> has no raw_text child — should keep outer Module
+        let content = r#"<html>
+<body>
+<script src="app.js"></script>
+</body>
+</html>
+"#;
+        let file = write_temp_file(content, "html");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+
+        let module = chunks.iter().find(|c| c.chunk_type == ChunkType::Module);
+        assert!(
+            module.is_some(),
+            "Empty script should keep Module chunk, got: {:?}",
+            chunks.iter().map(|c| (&c.name, &c.chunk_type)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn parse_html_with_multiple_scripts() {
+        let content = r#"<html>
+<body>
+<script>
+function first() { return 1; }
+</script>
+<script>
+function second() { return 2; }
+</script>
+</body>
+</html>
+"#;
+        let file = write_temp_file(content, "html");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+
+        let js_names: Vec<_> = chunks
+            .iter()
+            .filter(|c| c.language == crate::parser::Language::JavaScript)
+            .map(|c| c.name.as_str())
+            .collect();
+        assert!(
+            js_names.contains(&"first"),
+            "Expected 'first' from first script, got: {:?}",
+            js_names
+        );
+        assert!(
+            js_names.contains(&"second"),
+            "Expected 'second' from second script, got: {:?}",
+            js_names
+        );
+    }
+
+    #[test]
+    fn parse_html_with_whitespace_only_script_keeps_module() {
+        let content = "<html><body>\n<script>  \n  </script>\n</body></html>\n";
+        let file = write_temp_file(content, "html");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+
+        // Whitespace-only script produces zero inner chunks — should keep outer
+        let has_module = chunks.iter().any(|c| c.chunk_type == ChunkType::Module);
+        assert!(
+            has_module,
+            "Whitespace-only script should keep Module chunk, got: {:?}",
+            chunks.iter().map(|c| (&c.name, &c.chunk_type)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn parse_html_without_script_unchanged() {
+        // HTML with only headings/nav — no injections should fire
+        let content = r#"<html>
+<body>
+<nav id="main-nav"><a href="/">Home</a></nav>
+<h1>Welcome</h1>
+<h2>About</h2>
+</body>
+</html>
+"#;
+        let file = write_temp_file(content, "html");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+
+        // Should have only HTML chunks
+        for chunk in &chunks {
+            assert_eq!(
+                chunk.language,
+                crate::parser::Language::Html,
+                "All chunks should be HTML, found {:?} for '{}'",
+                chunk.language,
+                chunk.name
+            );
+        }
+
+        // Verify expected chunks
+        assert!(chunks.iter().any(|c| c.name == "Welcome"));
+        assert!(chunks.iter().any(|c| c.name == "About"));
+        assert!(chunks.iter().any(|c| c.name.contains("main-nav")));
+    }
+
+    #[test]
+    fn injection_call_graph() {
+        let content = r#"<html>
+<body>
+<script>
+function caller() {
+    helper();
+    other();
+}
+
+function helper() {
+    return 42;
+}
+</script>
+</body>
+</html>
+"#;
+        let file = write_temp_file(content, "html");
+        let parser = Parser::new().unwrap();
+        let (calls, _types) = parser.parse_file_relationships(file.path()).unwrap();
+
+        let caller_calls = calls.iter().find(|c| c.name == "caller");
+        assert!(
+            caller_calls.is_some(),
+            "Expected call graph entry for 'caller', got: {:?}",
+            calls.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+        let call_names: Vec<_> = caller_calls
+            .unwrap()
+            .calls
+            .iter()
+            .map(|c| c.callee_name.as_str())
+            .collect();
+        assert!(
+            call_names.contains(&"helper"),
+            "Expected caller → helper, got: {:?}",
+            call_names
+        );
+        assert!(
+            call_names.contains(&"other"),
+            "Expected caller → other, got: {:?}",
+            call_names
+        );
+    }
+
+    #[test]
+    fn injection_ranges_empty_for_non_injection_language() {
+        // Rust files have no injection rules — should return empty
+        let content = "fn main() {}\n";
+        let file = write_temp_file(content, "rs");
+        let parser = Parser::new().unwrap();
+        let chunks = parser.parse_file(file.path()).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].language, crate::parser::Language::Rust);
     }
 }

--- a/src/language/ini.rs
+++ b/src/language/ini.rs
@@ -51,6 +51,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/java.rs
+++ b/src/language/java.rs
@@ -145,6 +145,7 @@ static DEFINITION: LanguageDef = LanguageDef {
         "equals", "hashCode", "toString", "compareTo", "clone",
         "iterator", "run", "call", "close", "accept", "apply", "get",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -79,6 +79,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &["handler", "middleware", "beforeEach", "afterEach", "beforeAll", "afterAll"],
     trait_method_names: &["toString", "valueOf", "toJSON"],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/json.rs
+++ b/src/language/json.rs
@@ -66,6 +66,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/julia.rs
+++ b/src/language/julia.rs
@@ -133,6 +133,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     trait_method_names: &[
         "show", "convert", "promote_rule", "iterate", "length", "getindex", "setindex!",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/kotlin.rs
+++ b/src/language/kotlin.rs
@@ -190,6 +190,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     trait_method_names: &[
         "equals", "hashCode", "toString", "compareTo", "iterator",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/latex.rs
+++ b/src/language/latex.rs
@@ -106,6 +106,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/lua.rs
+++ b/src/language/lua.rs
@@ -64,6 +64,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/make.rs
+++ b/src/language/make.rs
@@ -56,6 +56,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &["all", "default"],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/markdown.rs
+++ b/src/language/markdown.rs
@@ -38,6 +38,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -157,6 +157,21 @@ pub type PostProcessChunkFn = fn(&mut String, &mut ChunkType, tree_sitter::Node,
 /// Takes `(content, name)` and returns true if the pattern matches.
 pub type StructuralMatcherFn = fn(&str, &str) -> bool;
 
+/// An injection rule for multi-grammar parsing.
+///
+/// Defines how embedded language regions within a host grammar are identified
+/// and parsed. For example, `<script>` within HTML → JavaScript.
+pub struct InjectionRule {
+    /// Node kind of the container element (e.g., "script_element", "style_element")
+    pub container_kind: &'static str,
+    /// Node kind of the content node within the container (e.g., "raw_text")
+    pub content_kind: &'static str,
+    /// Default target language for the embedded content
+    pub target_language: &'static str,
+    /// Optional: detect language from container attributes (e.g., `<script lang="ts">`)
+    pub detect_language: Option<fn(tree_sitter::Node, &str) -> Option<&'static str>>,
+}
+
 /// A language definition with all parsing configuration
 #[non_exhaustive]
 pub struct LanguageDef {
@@ -236,6 +251,10 @@ pub struct LanguageDef {
     /// "clone", "default"]`, Java: `&["equals", "hashCode", "toString"]`.
     /// Cross-language names are in the global fallback constant.
     pub trait_method_names: &'static [&'static str],
+    /// Injection rules for multi-grammar parsing.
+    /// Empty by default. Only languages with embedded content (e.g., HTML with
+    /// `<script>` and `<style>`) define injection rules.
+    pub injections: &'static [InjectionRule],
 }
 
 /// How to extract function signatures

--- a/src/language/nix.rs
+++ b/src/language/nix.rs
@@ -80,6 +80,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/objc.rs
+++ b/src/language/objc.rs
@@ -96,6 +96,7 @@ static DEFINITION: LanguageDef = LanguageDef {
         "init", "dealloc", "description", "hash", "isEqual",
         "copyWithZone", "encodeWithCoder", "initWithCoder",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/ocaml.rs
+++ b/src/language/ocaml.rs
@@ -136,6 +136,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     trait_method_names: &[
         "compare", "equal", "hash", "pp", "show", "to_string", "of_string",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/perl.rs
+++ b/src/language/perl.rs
@@ -109,6 +109,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     trait_method_names: &[
         "new", "AUTOLOAD", "DESTROY", "import", "BEGIN", "END",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/php.rs
+++ b/src/language/php.rs
@@ -183,6 +183,7 @@ static DEFINITION: LanguageDef = LanguageDef {
         "__clone",
         "__invoke",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/powershell.rs
+++ b/src/language/powershell.rs
@@ -100,6 +100,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/protobuf.rs
+++ b/src/language/protobuf.rs
@@ -84,6 +84,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/python.rs
+++ b/src/language/python.rs
@@ -103,6 +103,7 @@ static DEFINITION: LanguageDef = LanguageDef {
         "__getitem__", "__setitem__", "__delitem__", "__call__", "__enter__", "__exit__",
         "__del__", "__new__", "__init_subclass__", "__class_getitem__",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/r.rs
+++ b/src/language/r.rs
@@ -67,6 +67,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/ruby.rs
+++ b/src/language/ruby.rs
@@ -68,6 +68,7 @@ static DEFINITION: LanguageDef = LanguageDef {
         "to_s", "to_i", "to_f", "to_a", "to_h", "inspect",
         "hash", "eql?", "==", "<=>", "each", "initialize",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/rust.rs
+++ b/src/language/rust.rs
@@ -201,6 +201,7 @@ static DEFINITION: LanguageDef = LanguageDef {
         // std::future
         "poll",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/scala.rs
+++ b/src/language/scala.rs
@@ -149,6 +149,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     trait_method_names: &[
         "equals", "hashCode", "toString", "compare", "apply", "unapply",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/solidity.rs
+++ b/src/language/solidity.rs
@@ -132,6 +132,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &["constructor", "receive", "fallback"],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/sql.rs
+++ b/src/language/sql.rs
@@ -91,6 +91,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/swift.rs
+++ b/src/language/swift.rs
@@ -206,6 +206,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     trait_method_names: &[
         "hash", "encode", "init", "deinit", "description",
     ],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/toml_lang.rs
+++ b/src/language/toml_lang.rs
@@ -99,6 +99,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -139,6 +139,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &["handler", "middleware", "beforeEach", "afterEach", "beforeAll", "afterAll"],
     trait_method_names: &["toString", "valueOf", "toJSON"],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/xml.rs
+++ b/src/language/xml.rs
@@ -93,6 +93,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/yaml.rs
+++ b/src/language/yaml.rs
@@ -74,6 +74,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &[],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/language/zig.rs
+++ b/src/language/zig.rs
@@ -148,6 +148,7 @@ static DEFINITION: LanguageDef = LanguageDef {
     structural_matchers: None,
     entry_point_names: &["main"],
     trait_method_names: &[],
+    injections: &[],
 };
 
 pub fn definition() -> &'static LanguageDef {

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -385,6 +385,27 @@ impl Parser {
             }
         }
 
+        // --- Phase 2: Injection relationships (multi-grammar) ---
+        let injections = language.def().injections;
+        if !injections.is_empty() {
+            let groups = super::injection::find_injection_ranges(&tree, &source, injections);
+            for group in &groups {
+                match self.parse_injected_relationships(&source, group) {
+                    Ok((inner_calls, inner_types)) => {
+                        call_results.extend(inner_calls);
+                        type_results.extend(inner_types);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            language = %group.language,
+                            "Injection relationship parsing failed"
+                        );
+                    }
+                }
+            }
+        }
+
         Ok((call_results, type_results))
     }
 }
@@ -397,7 +418,7 @@ impl Parser {
 /// - `toString`, `valueOf`: Ubiquitous JS/TS methods that add noise
 ///
 /// Case-sensitive to avoid false positives (e.g., "This" as a variable name).
-fn should_skip_callee(name: &str) -> bool {
+pub(crate) fn should_skip_callee(name: &str) -> bool {
     matches!(
         name,
         "self" | "this" | "super" | "Self" | "new" | "toString" | "valueOf"

--- a/src/parser/injection.rs
+++ b/src/parser/injection.rs
@@ -1,0 +1,494 @@
+//! Multi-grammar injection parsing
+//!
+//! Implements two-phase parsing for files containing embedded languages:
+//! 1. Parse the outer grammar (e.g., HTML)
+//! 2. Find injection regions (e.g., `<script>`, `<style>`)
+//! 3. Re-parse those regions with inner grammars (e.g., JavaScript, CSS)
+//!
+//! Uses tree-sitter's `set_included_ranges()` for byte-accurate inner parsing.
+
+use std::path::Path;
+
+use tree_sitter::StreamingIterator;
+
+use super::types::{Chunk, ChunkType, ChunkTypeRefs, FunctionCalls, Language, ParserError};
+use super::Parser;
+use crate::language::InjectionRule;
+
+/// Result of scanning an outer tree for injection regions.
+///
+/// Groups byte ranges by target language, plus tracks which outer chunk
+/// line ranges correspond to injection containers (for removal).
+pub(crate) struct InjectionGroup {
+    /// Resolved inner language
+    pub language: Language,
+    /// Byte ranges for `set_included_ranges()`
+    pub ranges: Vec<tree_sitter::Range>,
+    /// Line ranges of container nodes (start, end) — outer chunks overlapping
+    /// these should be replaced by inner chunks
+    pub container_lines: Vec<(u32, u32)>,
+}
+
+/// Scan an outer parse tree for injection regions defined by the given rules.
+///
+/// Returns injection groups — each group has a target language, byte ranges
+/// for inner parsing, and line ranges of the container nodes to replace.
+pub(crate) fn find_injection_ranges(
+    tree: &tree_sitter::Tree,
+    source: &str,
+    rules: &[InjectionRule],
+) -> Vec<InjectionGroup> {
+    let _span = tracing::debug_span!("find_injection_ranges", rules = rules.len()).entered();
+
+    // Collect (language_name, range, container_lines) tuples
+    let mut entries: Vec<(&str, tree_sitter::Range, (u32, u32))> = Vec::new();
+
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+
+    for rule in rules {
+        // Walk the tree to find container nodes
+        cursor.reset(root);
+        walk_for_containers(&mut cursor, rule, source, &mut entries);
+    }
+
+    if entries.is_empty() {
+        return vec![];
+    }
+
+    // Group by language name
+    let mut groups: Vec<InjectionGroup> = Vec::new();
+    for (lang_name, range, lines) in entries {
+        // Resolve language
+        let language = match lang_name.parse::<Language>() {
+            Ok(lang) if lang.is_enabled() && lang.def().grammar.is_some() => lang,
+            Ok(lang) => {
+                tracing::warn!(
+                    language = lang_name,
+                    "Injection target language '{}' not available (disabled or no grammar)",
+                    lang
+                );
+                continue;
+            }
+            Err(_) => {
+                tracing::warn!(
+                    language = lang_name,
+                    "Injection target language '{}' not recognized",
+                    lang_name
+                );
+                continue;
+            }
+        };
+
+        // Find existing group or create new one
+        if let Some(group) = groups.iter_mut().find(|g| g.language == language) {
+            group.ranges.push(range);
+            group.container_lines.push(lines);
+        } else {
+            groups.push(InjectionGroup {
+                language,
+                ranges: vec![range],
+                container_lines: vec![lines],
+            });
+        }
+    }
+
+    groups
+}
+
+/// Walk the tree using a cursor to find all nodes matching an injection rule's container_kind.
+fn walk_for_containers(
+    cursor: &mut tree_sitter::TreeCursor,
+    rule: &InjectionRule,
+    source: &str,
+    entries: &mut Vec<(&str, tree_sitter::Range, (u32, u32))>,
+) {
+    loop {
+        let node = cursor.node();
+
+        if node.kind() == rule.container_kind {
+            // Found a container — look for the content child
+            if let Some(content_node) = find_content_child(node, rule.content_kind) {
+                // Skip empty content
+                let byte_range = content_node.byte_range();
+                if byte_range.start < byte_range.end {
+                    // Determine target language
+                    let target = if let Some(detect) = rule.detect_language {
+                        detect(node, source).unwrap_or(rule.target_language)
+                    } else {
+                        rule.target_language
+                    };
+
+                    let range = tree_sitter::Range {
+                        start_byte: byte_range.start,
+                        end_byte: byte_range.end,
+                        start_point: content_node.start_position(),
+                        end_point: content_node.end_position(),
+                    };
+
+                    let container_lines = (
+                        node.start_position().row as u32 + 1,
+                        node.end_position().row as u32 + 1,
+                    );
+
+                    entries.push((target, range, container_lines));
+                }
+            }
+            // Don't descend into containers — skip to next sibling
+            if !cursor.goto_next_sibling() {
+                // Walk back up to find more siblings
+                loop {
+                    if !cursor.goto_parent() {
+                        return;
+                    }
+                    if cursor.goto_next_sibling() {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+
+        // Try to go deeper
+        if cursor.goto_first_child() {
+            continue;
+        }
+        // Try next sibling
+        if cursor.goto_next_sibling() {
+            continue;
+        }
+        // Walk back up
+        loop {
+            if !cursor.goto_parent() {
+                return;
+            }
+            if cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+/// Find a direct child of `node` with the given kind.
+#[allow(clippy::manual_find)]
+fn find_content_child<'a>(
+    node: tree_sitter::Node<'a>,
+    content_kind: &str,
+) -> Option<tree_sitter::Node<'a>> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == content_kind {
+            return Some(child);
+        }
+    }
+    None
+}
+
+impl Parser {
+    /// Parse injected chunks from byte ranges using an inner language grammar.
+    ///
+    /// Creates a new tree-sitter parser, sets included ranges, parses the source,
+    /// and extracts chunks using the inner language's query.
+    pub(crate) fn parse_injected_chunks(
+        &self,
+        source: &str,
+        path: &Path,
+        group: &InjectionGroup,
+    ) -> Result<Vec<Chunk>, ParserError> {
+        let inner_language = group.language;
+        let _span = tracing::info_span!(
+            "parse_injected_chunks",
+            language = %inner_language,
+            range_count = group.ranges.len()
+        )
+        .entered();
+
+        let grammar = inner_language.grammar();
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&grammar)
+            .map_err(|e| ParserError::ParseFailed(format!("injection set_language: {:?}", e)))?;
+
+        if let Err(e) = parser.set_included_ranges(&group.ranges) {
+            tracing::warn!(
+                error = %e,
+                language = %inner_language,
+                "Failed to set included ranges for injection"
+            );
+            return Ok(vec![]);
+        }
+
+        let tree = match parser.parse(source, None) {
+            Some(t) => t,
+            None => {
+                tracing::warn!(
+                    language = %inner_language,
+                    "Injection parse returned None"
+                );
+                return Ok(vec![]);
+            }
+        };
+
+        let query = match self.get_query(inner_language) {
+            Ok(q) => q,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    language = %inner_language,
+                    "Failed to get chunk query for injection language"
+                );
+                return Ok(vec![]);
+            }
+        };
+
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+
+        let mut chunks = Vec::new();
+
+        while let Some(m) = matches.next() {
+            match self.extract_chunk(source, m, query, inner_language, path) {
+                Ok(mut chunk) => {
+                    // Skip oversized chunks
+                    const MAX_CHUNK_BYTES: usize = 100_000;
+                    if chunk.content.len() > MAX_CHUNK_BYTES {
+                        continue;
+                    }
+
+                    // Apply post-process hook
+                    if let Some(post_process) = inner_language.def().post_process_chunk {
+                        if let Some(node) = super::extract_definition_node(m, query) {
+                            if !post_process(&mut chunk.name, &mut chunk.chunk_type, node, source) {
+                                continue;
+                            }
+                        }
+                    }
+
+                    // Ensure language is set to the inner language
+                    chunk.language = inner_language;
+                    chunks.push(chunk);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        language = %inner_language,
+                        "Failed to extract injected chunk"
+                    );
+                }
+            }
+        }
+
+        if chunks.is_empty() {
+            tracing::debug!(
+                language = %inner_language,
+                "Injection produced no chunks, keeping outer"
+            );
+        }
+
+        Ok(chunks)
+    }
+
+    /// Parse injected relationships (calls + types) from byte ranges.
+    pub(crate) fn parse_injected_relationships(
+        &self,
+        source: &str,
+        group: &InjectionGroup,
+    ) -> Result<(Vec<FunctionCalls>, Vec<ChunkTypeRefs>), ParserError> {
+        let inner_language = group.language;
+        let _span = tracing::info_span!(
+            "parse_injected_relationships",
+            language = %inner_language,
+            range_count = group.ranges.len()
+        )
+        .entered();
+
+        let grammar = inner_language.grammar();
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&grammar)
+            .map_err(|e| ParserError::ParseFailed(format!("injection set_language: {:?}", e)))?;
+
+        if let Err(e) = parser.set_included_ranges(&group.ranges) {
+            tracing::warn!(
+                error = %e,
+                language = %inner_language,
+                "Failed to set included ranges for injection relationships"
+            );
+            return Ok((vec![], vec![]));
+        }
+
+        let tree = match parser.parse(source, None) {
+            Some(t) => t,
+            None => {
+                tracing::warn!(
+                    language = %inner_language,
+                    "Injection parse returned None for relationships"
+                );
+                return Ok((vec![], vec![]));
+            }
+        };
+
+        // Get queries
+        let chunk_query = match self.get_query(inner_language) {
+            Ok(q) => q,
+            Err(e) => {
+                tracing::warn!(error = %e, "No chunk query for injection language");
+                return Ok((vec![], vec![]));
+            }
+        };
+
+        let call_query = match self.get_call_query(inner_language) {
+            Ok(q) => q,
+            Err(_) => {
+                // No call query is not unusual (some languages don't have one)
+                return Ok((vec![], vec![]));
+            }
+        };
+
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut matches = cursor.matches(chunk_query, tree.root_node(), source.as_bytes());
+
+        let capture_names = chunk_query.capture_names();
+        let mut call_results = Vec::new();
+        let mut type_results = Vec::new();
+        let mut call_cursor = tree_sitter::QueryCursor::new();
+        let mut calls = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+
+        while let Some(m) = matches.next() {
+            // Find chunk node (same logic as parse_file_relationships)
+            let func_node = m.captures.iter().find(|c| {
+                let name = capture_names.get(c.index as usize).copied().unwrap_or("");
+                matches!(
+                    name,
+                    "function"
+                        | "struct"
+                        | "class"
+                        | "enum"
+                        | "trait"
+                        | "interface"
+                        | "const"
+                        | "module"
+                        | "macro"
+                        | "object"
+                        | "typealias"
+                        | "property"
+                        | "delegate"
+                        | "event"
+                )
+            });
+
+            let Some(func_capture) = func_node else {
+                continue;
+            };
+
+            let node = func_capture.node;
+
+            // Get chunk name
+            let name_idx = chunk_query.capture_index_for_name("name");
+            let mut name = name_idx
+                .and_then(|idx| m.captures.iter().find(|c| c.index == idx))
+                .map(|c| source[c.node.byte_range()].to_string())
+                .unwrap_or_else(|| "<anonymous>".to_string());
+
+            // Apply post-process hook
+            if let Some(post_process) = inner_language.def().post_process_chunk {
+                let cap_name = capture_names
+                    .get(func_capture.index as usize)
+                    .copied()
+                    .unwrap_or("");
+                let mut ct = match cap_name {
+                    "function" => ChunkType::Function,
+                    "struct" => ChunkType::Struct,
+                    "class" => ChunkType::Class,
+                    "enum" => ChunkType::Enum,
+                    "trait" => ChunkType::Trait,
+                    "interface" => ChunkType::Interface,
+                    "const" => ChunkType::Constant,
+                    "module" => ChunkType::Module,
+                    "macro" => ChunkType::Macro,
+                    "object" => ChunkType::Object,
+                    "typealias" => ChunkType::TypeAlias,
+                    "property" => ChunkType::Property,
+                    "delegate" => ChunkType::Delegate,
+                    "event" => ChunkType::Event,
+                    _ => ChunkType::Function,
+                };
+                if !post_process(&mut name, &mut ct, node, source) {
+                    continue;
+                }
+            }
+
+            let line_start = node.start_position().row as u32 + 1;
+            let byte_range = node.byte_range();
+
+            // --- Call extraction ---
+            call_cursor.set_byte_range(byte_range.clone());
+            calls.clear();
+
+            let mut call_matches =
+                call_cursor.matches(call_query, tree.root_node(), source.as_bytes());
+
+            while let Some(cm) = call_matches.next() {
+                for cap in cm.captures {
+                    let callee_name = source[cap.node.byte_range()].to_string();
+                    let call_line = cap.node.start_position().row as u32 + 1;
+
+                    if !super::calls::should_skip_callee(&callee_name) {
+                        calls.push(super::types::CallSite {
+                            callee_name,
+                            line_number: call_line,
+                        });
+                    }
+                }
+            }
+
+            // Deduplicate calls
+            seen.clear();
+            calls.retain(|c| seen.insert(c.callee_name.clone()));
+
+            if !calls.is_empty() {
+                call_results.push(FunctionCalls {
+                    name: name.clone(),
+                    line_start,
+                    calls: std::mem::take(&mut calls),
+                });
+            }
+
+            // --- Type extraction ---
+            let mut type_refs = self.extract_types(
+                source,
+                &tree,
+                inner_language,
+                byte_range.start,
+                byte_range.end,
+            );
+
+            type_refs.retain(|t| t.type_name != name);
+
+            if !type_refs.is_empty() {
+                type_results.push(ChunkTypeRefs {
+                    name,
+                    line_start,
+                    type_refs,
+                });
+            }
+        }
+
+        Ok((call_results, type_results))
+    }
+}
+
+/// Check if an outer chunk overlaps with any injection container line range.
+///
+/// Used to identify outer chunks (e.g., HTML Module chunks for script/style)
+/// that should be replaced by inner chunks when injection parsing succeeds.
+pub(crate) fn chunk_overlaps_container(
+    chunk_start: u32,
+    chunk_end: u32,
+    container_lines: &[(u32, u32)],
+) -> bool {
+    container_lines
+        .iter()
+        .any(|&(start, end)| chunk_start >= start && chunk_end <= end)
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,6 +7,7 @@
 
 mod calls;
 mod chunk;
+pub(crate) mod injection;
 pub mod markdown;
 pub mod types;
 
@@ -227,6 +228,37 @@ impl Parser {
                 }
                 Err(e) => {
                     tracing::warn!("Failed to extract chunk from {}: {}", path.display(), e);
+                }
+            }
+        }
+
+        // --- Phase 2: Injection parsing (multi-grammar) ---
+        let injections = language.def().injections;
+        if !injections.is_empty() {
+            let groups = injection::find_injection_ranges(&tree, &source, injections);
+            for group in &groups {
+                match self.parse_injected_chunks(&source, path, group) {
+                    Ok(inner_chunks) if !inner_chunks.is_empty() => {
+                        // Remove outer chunks that overlap with injection containers
+                        chunks.retain(|c| {
+                            !injection::chunk_overlaps_container(
+                                c.line_start,
+                                c.line_end,
+                                &group.container_lines,
+                            )
+                        });
+                        chunks.extend(inner_chunks);
+                    }
+                    Ok(_) => {
+                        // Zero inner chunks — keep outer chunks as-is (fallback)
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            language = %group.language,
+                            "Injection parsing failed, keeping outer chunks"
+                        );
+                    }
                 }
             }
         }

--- a/tests/fixtures/sample.html
+++ b/tests/fixtures/sample.html
@@ -42,6 +42,16 @@
     </footer>
 
     <script src="main.js"></script>
+    <script>
+    function handleClick(event) {
+        const el = document.getElementById('target');
+        el.classList.toggle('active');
+    }
+
+    function setupListeners() {
+        document.querySelector('button').addEventListener('click', handleClick);
+    }
+    </script>
     <style>
         body { font-family: sans-serif; }
         .container { max-width: 1200px; }

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1270,7 +1270,7 @@ fn test_html_heading_and_landmark_extraction() {
         .find(|c| c.name == "Welcome to the Sample" && c.chunk_type == ChunkType::Section);
     assert!(h1.is_some(), "Should find h1 heading as Section");
 
-    // Script module
+    // Script module (external src — no raw_text, kept as Module)
     let script = chunks
         .iter()
         .find(|c| c.name.contains("main.js") && c.chunk_type == ChunkType::Module);
@@ -1281,6 +1281,22 @@ fn test_html_heading_and_landmark_extraction() {
             .iter()
             .map(|c| (&c.name, &c.chunk_type))
             .collect::<Vec<_>>()
+    );
+
+    // Injected JS functions from inline <script>
+    let js_funcs: Vec<_> = chunks
+        .iter()
+        .filter(|c| c.language == Language::JavaScript)
+        .collect();
+    assert!(
+        js_funcs.iter().any(|c| c.name == "handleClick"),
+        "Should find injected JS function 'handleClick', got: {:?}",
+        js_funcs.iter().map(|c| &c.name).collect::<Vec<_>>()
+    );
+    assert!(
+        js_funcs.iter().any(|c| c.name == "setupListeners"),
+        "Should find injected JS function 'setupListeners', got: {:?}",
+        js_funcs.iter().map(|c| &c.name).collect::<Vec<_>>()
     );
 }
 


### PR DESCRIPTION
## Summary

- **Multi-grammar parsing** for HTML files: `<script>` and `<style>` blocks are now parsed with their inner grammars (JavaScript/CSS) using tree-sitter's `set_included_ranges()`
- Adds `InjectionRule` struct to `LanguageDef` — extensible for future Svelte/Vue/Astro support
- Two-phase `parse_file` and `parse_file_relationships`: outer HTML parse → find injection regions → inner JS/CSS parse → merge chunks and call/type graphs
- TypeScript detection via `<script lang="ts">` or `type="text/typescript"` attributes
- All error paths are graceful fallbacks — injection failure never blocks outer parsing

## Details

| Component | Change |
|-----------|--------|
| `src/language/mod.rs` | `InjectionRule` struct, `injections` field on `LanguageDef` |
| `src/parser/injection.rs` | **New** — `find_injection_ranges`, `parse_injected_chunks`, `parse_injected_relationships` |
| `src/parser/mod.rs` | Two-phase `parse_file` with injection support |
| `src/parser/calls.rs` | Two-phase `parse_file_relationships` with injection support |
| `src/language/html.rs` | Injection rules (script→JS, style→CSS), `detect_script_language` |
| 45 other language files | `injections: &[]` (no-op default) |
| `tests/fixtures/sample.html` | Enhanced with inline `<script>` functions |
| `tests/parser_test.rs` | Integration test verifies injected JS chunks |

## Test plan

- [x] 9 new unit tests: JS extraction, CSS rules, TypeScript detection, empty script, multiple scripts, whitespace-only, regression, call graph, non-injection language
- [x] Integration test: `sample.html` fixture with inline script produces JS function chunks alongside HTML chunks
- [x] Full suite: 1465 pass, 0 fail
- [x] `cargo clippy -- -D warnings` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
