### PR TITLE
fix: resolve 13 P1 audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Multi-grammar injection parsing** — HTML `<script>` blocks now extract real JS/TS function chunks; `<style>` blocks extract CSS rule chunks. Powered by tree-sitter's `set_included_ranges()`. `InjectionRule` on `LanguageDef` makes this extensible to other host languages (PR #540)
+
 ## [0.26.0] - 2026-03-05
 
 Language expansion Phase 2, Batch 3 — Solidity, CUDA, GLSL (43 → 46 languages).

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,21 +2,13 @@
 
 ## Right Now
 
-**Multi-grammar parsing — implemented.** 2026-03-05.
+**Multi-grammar parsing — merged.** 2026-03-05. PR #540.
 
-HTML files now extract real JS/CSS chunks from `<script>` and `<style>` blocks using tree-sitter `set_included_ranges()`. Two-phase parsing: outer HTML grammar, then inner JS/CSS grammars.
-
-Key additions:
-- `InjectionRule` struct on `LanguageDef` (all 46 languages default to `&[]`)
-- `src/parser/injection.rs` — find_injection_ranges, parse_injected_chunks, parse_injected_relationships
-- HTML injection rules: script→JS (with TS detection via `lang`/`type` attrs), style→CSS
-- 9 new tests (JS extraction, CSS, TypeScript detection, empty script, multiple scripts, whitespace-only, regression, call graph, non-injection language)
-- `sample.html` fixture enhanced with inline `<script>` functions
-- Total: 1465 tests pass, 0 fail
+HTML files extract real JS/CSS chunks from `<script>` and `<style>` blocks using tree-sitter `set_included_ranges()`. Two-phase parsing: outer HTML grammar, then inner JS/CSS grammars. Extensible via `InjectionRule` on `LanguageDef`.
 
 ## Pending Changes
 
-Uncommitted multi-grammar changes. Ready for branch + PR.
+None.
 
 ## Parked
 
@@ -51,7 +43,7 @@ Uncommitted multi-grammar changes. Ready for branch + PR.
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 46 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Haskell, OCaml, Julia, Gleam, CSS, Perl, HTML, JSON, XML, INI, Nix, Make, LaTeX, Solidity, CUDA, GLSL, Markdown)
 - 16 ChunkType variants (Function, Method, Struct, Class, Interface, Enum, Trait, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias)
-- Tests: 1456 pass, 0 failures
+- Tests: 1465 pass, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Keep index fresh: run `cqs watch` in a background terminal, or `cqs index` after
 - GraphQL (types, interfaces, enums, unions, inputs, scalars, directives, operations, fragments)
 - Haskell (functions, data types, newtypes, type synonyms, typeclasses, instances)
 - HCL (resources, data sources, variables, outputs, modules, providers with qualified naming)
-- HTML (headings, semantic landmarks, script/style blocks, id'd elements)
+- HTML (headings, semantic landmarks, id'd elements; inline `<script>` extracts JS/TS functions, `<style>` extracts CSS rules via multi-grammar injection)
 - INI (sections, settings)
 - Java (classes, interfaces, enums, methods)
 - JavaScript (JSDoc `@param`/`@returns` tags improve search quality)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,29 +54,36 @@ All 16 variants shipped and used across languages. Only one potential new varian
 
 Infrastructure for adding variants is now cheap: per-language LanguageDef fields, data-driven container extraction, dynamic callable SQL. New variant = enum arm + Display/FromStr + is_callable decision + nl.rs + capture_types.
 
-### Multi-Grammar Parsing (Architectural)
+### Multi-Grammar Parsing
 
-Parse files containing multiple embedded languages. Requires:
-- Outer grammar parses document structure, identifies embedded regions
-- Inner grammars re-parse each region with correct byte offsets
-- Merged results preserve original file positions
+Injection framework shipped in v0.26.0 (PR #540). `InjectionRule` on `LanguageDef`, two-phase `parse_file`/`parse_file_relationships` via `set_included_ranges()`.
 
-**Languages it would unlock:**
-- **Svelte** (.svelte) — JS/TS in `<script>`, CSS in `<style>`, HTML template
-- **Vue** (.vue) — same pattern as Svelte
-- **Astro** (.astro) — JS/TS frontmatter + HTML template
-- **ERB** (.erb) — Ruby embedded in HTML
-- **EEx/HEEx** (.eex, .heex) — Elixir embedded in HTML
-- **PHP-in-HTML** — our PHP support parses PHP blocks; multi-grammar adds HTML context
+**Done:**
+- [x] HTML → JavaScript (with TypeScript detection via `lang`/`type` attrs)
+- [x] HTML → CSS
 
-**Embedded language extraction (lower priority):**
-- SQL in string literals (Rust, Python, Go, Java)
-- GraphQL in tagged templates (JS/TS)
-- Regex literals (via tree-sitter-regex, compatible)
-- Shell in Makefile recipes (both grammars compatible)
-- CSS-in-JS (styled-components, emotion)
+**Next — High value (both grammars already exist):**
+- [ ] PHP → HTML → JS/CSS — chained injection. PHP `text` nodes contain HTML, then HTML's existing rules extract JS/CSS. Three-layer extraction.
 
-**Not yet designed.** Requires parser framework changes — current architecture is one grammar per file.
+**Next — New grammars required:**
+- [ ] Vue (.vue) → JS/TS, CSS, HTML — needs `tree-sitter-vue` grammar. `<script>`, `<style>`, `<template>` identical to HTML injection pattern.
+- [ ] Svelte (.svelte) → JS/TS, CSS — needs `tree-sitter-svelte` grammar. Same pattern as Vue.
+
+**Medium value (narrower scope):**
+- [ ] Markdown → fenced code blocks — custom parser, not tree-sitter. Needs different approach (parse ` ```lang ` content with target grammar).
+- [ ] LaTeX → code listings — `\begin{lstlisting}` / minted blocks → target language.
+- [ ] Nix → Bash — shell scripts in `writeShellScript`, derivation phase strings.
+- [ ] HCL → Bash — `provisioner "local-exec"` command blocks.
+- [ ] YAML → Bash — GitHub Actions `run:` blocks. Detection fragile (not all strings are scripts).
+
+**Lower priority (niche or fragile):**
+- [ ] Astro (.astro) → JS/TS + HTML — needs grammar
+- [ ] ERB (.erb) → Ruby in HTML — needs grammar
+- [ ] EEx/HEEx (.eex, .heex) → Elixir in HTML — needs grammar
+- [ ] SQL in string literals (Rust, Python, Go, Java) — fragile detection
+- [ ] GraphQL in tagged templates (JS/TS) — fragile detection
+- [ ] Shell in Makefile recipes — both grammars compatible
+- [ ] CSS-in-JS (styled-components, emotion) — template literal detection
 
 ### Parked
 

--- a/docs/audit-findings-v0.26.0-pre.md
+++ b/docs/audit-findings-v0.26.0-pre.md
@@ -1,0 +1,519 @@
+# Audit Findings — v0.19.4+
+
+Audit started 2026-03-02. Covers all code on main after PF-5 (#515).
+
+## Observability
+
+#### OB-1: `resolve_target` — public entry point has no tracing span
+- **Difficulty:** easy
+- **Location:** src/search.rs:57
+- **Description:** `resolve_target()` is the shared entry point used by `blame`, `explain`, `similar`, `callers`, `callees`, `deps`, `trace`, and `test-map`. It calls `store.search_by_name()` and applies file filtering. No span means failures (name not found, ambiguous file filter) are invisible in traces — you only see the outer command span with no insight into why lookup failed or how long it took.
+- **Suggested fix:** Add `let _span = tracing::info_span!("resolve_target", target).entered();` at the top of the function.
+
+#### OB-2: `delete_by_origin` and `replace_file_chunks` — no tracing spans on mutation operations
+- **Difficulty:** easy
+- **Location:** src/store/chunks.rs:194, 222
+- **Description:** `delete_by_origin()` deletes all chunks for a file path. `replace_file_chunks()` atomically replaces them. Both are called from the index pipeline and watch mode. Neither has a tracing span, so bulk delete/replace operations are invisible in traces. When a pipeline run is slow, there's no way to distinguish indexing latency from deletion latency.
+- **Suggested fix:** Add `info_span!("delete_by_origin", origin = %origin.display())` and `info_span!("replace_file_chunks", origin = %origin.display(), chunks = chunks.len())`.
+
+#### OB-3: `search_filtered` exits without logging result count
+- **Difficulty:** easy
+- **Location:** src/search.rs:793-795
+- **Description:** `search_filtered()` has an entry span but never logs how many results it returns. The span captures `limit` and `rrf` at entry but a caller observing a trace has no way to know whether the search returned 0, 5, or 20 results without reading the span's return value separately. This matters when debugging "why did gather find nothing?" — the seed search returning 0 vs the BFS finding nothing are different problems.
+- **Suggested fix:** Add `tracing::debug!(results = results.len(), "search_filtered complete");` before `Ok(results)` at line 795.
+
+#### OB-4: `Store::init` — schema initialization has no span
+- **Difficulty:** easy
+- **Location:** src/store/mod.rs:355
+- **Description:** `Store::init()` creates all tables, inserts metadata, and sets schema version. Called on every `cqs index` run on a fresh database. No span means a slow init (e.g., large schema, pragma tuning) is invisible. Also missing: no log of which schema version was initialized.
+- **Suggested fix:** Add `let _span = tracing::info_span!("store_init").entered();` and `tracing::info!(schema_version = CURRENT_SCHEMA_VERSION, "Store initialized");` after the commit.
+
+#### OB-5: `warn_stale_results` — missing entry span
+- **Difficulty:** easy
+- **Location:** src/cli/staleness.rs:19
+- **Description:** `warn_stale_results()` is called after every query command to check if result files changed since last index. It calls `store.check_origins_stale()` which can be non-trivial for large result sets. No span means staleness check latency is hidden in parent command spans. The function already has a `tracing::info!` call inside (line 24) but no enclosing span to correlate it with the originating command.
+- **Suggested fix:** Add `let _span = tracing::info_span!("warn_stale_results", origins = origins.len()).entered();` at the top.
+
+#### OB-6: `cmd_watch` — no entry span
+- **Difficulty:** easy
+- **Location:** src/cli/watch.rs:54
+- **Description:** `cmd_watch()` is the main watch loop. It has various `tracing::warn!` calls inside but no entry span. Watch mode can run for hours — without a span, there's no parent context to correlate reindex events or WSL inotify warnings back to a session.
+- **Suggested fix:** Add `let _span = tracing::info_span!("cmd_watch", debounce_ms).entered();` at the top of `cmd_watch`.
+
+#### OB-7: `get_caller_counts_batch` / `get_callee_counts_batch` — no spans on batch count queries
+- **Difficulty:** easy
+- **Location:** src/store/calls.rs:1147, 1163
+- **Description:** Both batch count functions delegate through `batch_count_query()` with no span. These are called by `find_dead_code` to identify functions with zero callers. When dead code analysis is slow (common on large indexes with `NOT IN` subqueries), there's no way to attribute latency to the counting phase vs. the filtering phase.
+- **Suggested fix:** Add spans: `tracing::info_span!("get_caller_counts_batch", count = names.len())` and `tracing::info_span!("get_callee_counts_batch", count = names.len())`.
+
+## API Design
+
+#### AD-1: BatchCmd::Gather `direction` is stringly-typed — should use GatherDirection enum
+- **Difficulty:** easy
+- **Location:** src/cli/batch/commands.rs:109, src/cli/batch/handlers.rs:349
+- **Description:** The CLI's `Gather` command uses `GatherDirection` as a typed `ValueEnum` (fixed in prior audit AD-1, PR #501), but `BatchCmd::Gather` still declares `direction: String`. The handler (`dispatch_gather`) manually parses it with `.parse().map_err(...)` on line 361. This means batch mode gets no clap validation — invalid directions produce a runtime error instead of a parse-time error.
+- **Suggested fix:** Change `BatchCmd::Gather` to use `GatherDirection` directly (it already has `FromStr` and could derive `ValueEnum`). Update `dispatch_gather` signature to accept `GatherDirection` instead of `&str`.
+
+#### AD-2: `get_callers()` is dead public API — zero callers
+- **Difficulty:** easy
+- **Location:** src/store/calls.rs:252
+- **Description:** `Store::get_callers()` returns `Vec<ChunkSummary>` from the chunks table. All production code uses `get_callers_full()` (returns `CallerInfo` from function_calls table) or `get_callers_with_context()` instead. The method has zero call sites outside its own doc comment. Dead public API surface that could confuse callers about which method to use.
+- **Suggested fix:** Remove `get_callers()`. If the chunk-level caller lookup is needed in the future, it can be re-added.
+
+#### AD-3: Core store types lack `Serialize` — manual `to_json()` everywhere
+- **Difficulty:** medium
+- **Location:** src/store/helpers.rs:128 (ChunkSummary), :192 (SearchResult), :243 (CallerInfo), :317 (NoteSummary), :330 (NoteSearchResult)
+- **Description:** The five most-used public types in the store API all lack `#[derive(Serialize)]`. Instead, they have manual `to_json()` / `to_json_relative()` methods using `serde_json::json!()` macros. This forces every consumer (CLI commands, batch handlers, `ChunkOutput` batch type) to either call these manual methods or re-serialize fields by hand. The prior audit (AD-6, PR #502) added Serialize to higher-level types (`ScoutResult`, `TaskResult`, `GatherResult`, etc.) but left these foundational types untouched.
+- **Suggested fix:** Add `#[derive(serde::Serialize)]` to `ChunkSummary`, `SearchResult`, `CallerInfo`, `NoteSummary`, `NoteSearchResult`. For `ChunkSummary::file` (PathBuf), use `#[serde(serialize_with = "crate::serialize_path_normalized")]` which already exists. The manual `to_json()` methods can remain as convenience wrappers or be deprecated.
+
+#### AD-4: `BlameEntry` and `BlameData` use manual JSON assembly
+- **Difficulty:** easy
+- **Location:** src/cli/commands/blame.rs:18,26,155
+- **Description:** `BlameEntry` and `BlameData` lack `Serialize` derive. `blame_to_json()` manually constructs JSON with `serde_json::json!()` for each field. This is the same pattern fixed in prior audits for other result types (AD-6/CQ-6).
+- **Suggested fix:** Add `#[derive(serde::Serialize)]` to `BlameEntry` and `BlameData`. Replace `blame_to_json()` with direct serialization. `BlameData.chunk` is `ChunkSummary` which would need Serialize first (see AD-3).
+
+#### AD-5: `dispatch_search` takes 9 individual parameters instead of a struct
+- **Difficulty:** medium
+- **Location:** src/cli/batch/handlers.rs:33-42
+- **Description:** `dispatch_search(ctx, query, limit, name_only, semantic_only, rerank, lang, path, tokens)` takes 9 parameters. The CLI side avoids this by passing the `Cli` struct which bundles all search options. Batch mode destructures `BatchCmd::Search` into 8 individual args then passes them through. This makes the handler signature fragile — adding a search option requires touching 3 call sites (BatchCmd fields, dispatch match arm, handler signature).
+- **Suggested fix:** Extract a `BatchSearchOptions` struct or pass the `BatchCmd::Search` variant directly to the handler, destructuring inside.
+
+#### AD-6: 9 CLI command handlers accept unused `_cli: &Cli` parameter
+- **Difficulty:** easy
+- **Location:** src/cli/commands/blame.rs:245, where_cmd.rs:8, test_map.rs:9, task.rs:19, scout.rs:9, related.rs:24, impact_diff.rs:18, onboard.rs:9, convert.rs:10
+- **Description:** These handlers accept `_cli: &Cli` but never read any field from it. This was reported in the prior audit (AD-5, PR #504, marked fixed) but 9 instances remain — either the fix regressed or new commands were added without removing the parameter. Unused parameters obscure the actual data dependencies and make signatures wider than needed.
+- **Suggested fix:** Remove the `_cli` parameter from these 9 handlers and update their call sites in `run_with()`.
+
+## Error Handling
+
+#### EH-1: `build_blame_data` discards StoreError chain via `.map_err(|e| anyhow::anyhow!("{}", e))`
+- **Difficulty:** easy
+- **Location:** src/cli/commands/blame.rs:46
+- **Description:** `resolve_target()` returns `Result<ResolvedTarget, StoreError>`. The blame handler converts the error via `.map_err(|e| anyhow::anyhow!("{}", e))`, which stringifies through `Display` and loses the full error chain. If the underlying cause is `StoreError::Database(sqlx::Error::...)`, the inner sqlx source chain is flattened to a single string. Since `StoreError` implements `std::error::Error` with proper `#[from]` chains, `?` alone would preserve the chain (anyhow auto-converts via `From`).
+- **Suggested fix:** Replace `.map_err(|e| anyhow::anyhow!("{}", e)).context("Failed to resolve blame target")` with just `.context("Failed to resolve blame target")?`. The `?` operator on `Result<_, StoreError>` auto-converts to `anyhow::Error` preserving the error source chain.
+
+#### EH-2: 7 bare `Store::open()` calls without path context in CLI commands
+- **Difficulty:** easy
+- **Location:** src/cli/commands/diff.rs:32, drift.rs:31, index.rs:66, index.rs:73, reference.rs:134, reference.rs:314, cli/watch.rs:113
+- **Description:** These `Store::open(&path)?` calls use bare `?` without `.context()` or `.with_context()`. When the store fails to open (e.g., corrupted DB, permission denied, locked), the error says "Database error: ..." without identifying which path failed. The prior audit EH-5 (PR #499) swept 10 CLI command files, and EH-4/EH-5 in v0.19.2 (PR #501) fixed 3 more. These survived because diff.rs/drift.rs were refactored after the fix, and index.rs/watch.rs/reference.rs open stores in contexts where the path was just computed but is still absent from the error.
+- **Suggested fix:** Add `.with_context(|| format!("Failed to open store at {}", path.display()))` to each site. The `open_project_store()` helper and `resolve_reference_store()` already do this correctly.
+
+#### EH-3: `SearchFilter::validate()` returns `Result<(), &'static str>` — not a proper error type
+- **Difficulty:** easy
+- **Location:** src/store/helpers.rs:513
+- **Description:** `SearchFilter::validate()` returns `Result<(), &'static str>` where the error is a plain string. Callers must convert with `.map_err(|e| anyhow::anyhow!(e))` (query.rs:96). This bypasses the project's `thiserror`-based error hierarchy. The method checks 4 conditions (name_boost range, note_weight range, contradictory note_only, missing query_text) but returns the same opaque type for all. Callers cannot distinguish or match on specific validation failures.
+- **Suggested fix:** Change the return type to `Result<(), StoreError>` using `StoreError::Runtime(msg.to_string())` for each check. Callers in query.rs and batch handlers would then use plain `?`.
+
+#### EH-4: `dispatch_onboard` swallows `get_chunks_by_names_batch` error with fallback to empty HashMap
+- **Difficulty:** easy
+- **Location:** src/cli/batch/handlers.rs:912-918
+- **Description:** In `dispatch_onboard`, when `get_chunks_by_names_batch()` fails, the error is logged via `tracing::warn!` and an empty `HashMap` is returned as fallback. This is the token-packing branch (`Some(budget)`) — returning empty content means the onboard command silently produces an incomplete result with no content for any entry. The `gather` command has a similar degradation pattern but signals it via `"search_degraded": true` in the JSON output. The onboard handler does neither — it silently drops content without any signal to the caller.
+- **Suggested fix:** Either propagate the error with `?` (since empty content defeats the purpose of token packing), or add a `"degraded": true` field to the JSON output like `gather` does.
+
+#### EH-5: `GatherDirection::FromStr` uses `String` error type — inconsistent with project conventions
+- **Difficulty:** easy
+- **Location:** src/gather.rs:97
+- **Description:** `GatherDirection`'s `FromStr` impl uses `type Err = String`. This is the only `FromStr` impl in the codebase that returns `String` — all `ChunkType` and `Language` `FromStr` impls return proper typed errors. The batch handler must do `.parse::<GatherDirection>().map_err(|e: String| anyhow::anyhow!("{e}"))` to convert. This is moot if AD-1 (make BatchCmd::Gather accept `GatherDirection` directly) is fixed.
+- **Suggested fix:** Fix AD-1 first (use `GatherDirection` as clap `ValueEnum` in `BatchCmd`). If `FromStr` is still needed, change `Err` to a proper error type.
+
+#### EH-6: `schema_version` in `IndexStats` silently defaults to 0 on parse failure
+- **Difficulty:** easy
+- **Location:** src/store/chunks.rs:873-876
+- **Description:** When loading `IndexStats`, the schema_version is parsed from a string metadata value via `.and_then(|s| s.parse().ok()).unwrap_or(0)`. If the stored value is non-numeric (e.g., corrupted), this silently returns schema version 0 with no log. A corrupt schema_version could cause downstream code to behave as if the index is unversioned. Other metadata fields (model_name, created_at) default to empty strings on missing, which is correct, but version 0 is actively misleading.
+- **Suggested fix:** Log a `tracing::warn!` when `.parse()` fails (i.e., when the value exists but is non-numeric): `Err(e) => { tracing::warn!(value = %s, error = %e, "Non-numeric schema_version"); 0 }`.
+
+## Documentation
+
+#### DOC-1: `source/` listed in CONTRIBUTING.md architecture but module is entirely dead
+- **Difficulty:** easy
+- **Location:** CONTRIBUTING.md:109-111
+- **Description:** CONTRIBUTING.md documents `source/` as "Source abstraction layer (reserved — not yet wired into indexing pipeline)" and lists `filesystem.rs` as an active file. The module is declared in `lib.rs:81` as `pub(crate) mod source` but has zero callers — `use crate::source` and `source::` appear nowhere outside the module itself. The prior audit (v0.19.2 DOC-7, PR #501) noted CONTRIBUTING.md listed it as active but only updated the description to "reserved"; neither the module nor the CONTRIBUTING entry was removed. This mismatch causes confusion about whether `source/` is a development direction or dead scaffolding.
+- **Suggested fix:** Remove `src/source/` directory entirely (2 files, ~250 lines), remove `pub(crate) mod source;` from `lib.rs`, and remove the `source/` entry from CONTRIBUTING.md's architecture section. (Duplicate of CQ-1 in this audit — fix code, then update CONTRIBUTING.md.)
+
+#### DOC-2: PRIVACY.md deletion instructions miss `~/.config/cqs/config.toml`
+- **Difficulty:** easy
+- **Location:** PRIVACY.md:46-51
+- **Description:** The "Deleting Your Data" section lists 6 paths to delete. It includes `~/.config/cqs/projects.toml` (the project registry) but omits `~/.config/cqs/config.toml` (the user config file at the same path, confirmed by `src/config.rs:4,120`). A user following these instructions to fully remove cqs data would leave behind their configuration.
+- **Suggested fix:** Add `rm -f ~/.config/cqs/config.toml  # User config` to the deletion block. Also change `rm -rf ~/.config/cqs/projects.toml` → `rm -f ~/.config/cqs/projects.toml` (using `-rf` on a file is inconsistent with `-f` used for the other files on lines 49-50).
+
+#### DOC-3: SECURITY.md symlink mitigation description is inaccurate
+- **Difficulty:** easy
+- **Location:** SECURITY.md:94
+- **Description:** SECURITY.md states "Symlinks in extracted archives are skipped" under the convert module mitigations. The actual implementation skips symlinks during **all directory walks** — both CHM-extracted archives (`src/convert/chm.rs:91`) and regular directory traversal (`src/convert/mod.rs:347`) and web help directories (`src/convert/webhelp.rs:60`). The phrase "in extracted archives" implies the protection only applies to CHM/archive extraction, underselling its actual scope.
+- **Suggested fix:** Change "Symlinks in extracted archives are skipped" → "Symlinks are skipped in all directory walks (file input, CHM extraction, web help traversal)".
+
+#### DOC-4: lib.rs doc comment omits Web Help format from convert feature description
+- **Difficulty:** easy
+- **Location:** src/lib.rs:13
+- **Description:** The crate-level doc says `- **Document conversion**: PDF, HTML, CHM → cleaned Markdown (optional `convert` feature)`. The convert module also handles Web Help sites (multi-page HTML sites with a structured nav, detected by `src/convert/webhelp.rs`). Web Help is distinct enough from generic HTML to have its own dedicated module and is listed in the README's supported formats table. The lib.rs doc is the first thing library users see and it understates the format support.
+- **Suggested fix:** Change to `PDF, HTML, CHM, Web Help → cleaned Markdown`.
+
+#### DOC-5: `cqs dead --min-confidence` undocumented in README and CLAUDE.md
+- **Difficulty:** easy
+- **Location:** README.md:243-246, CLAUDE.md:71
+- **Description:** `cqs dead --help` shows three options: `--json`, `--include-pub`, and `--min-confidence <MIN_CONFIDENCE>` (values: low, medium, high; default: low). README documents `--json` and `--include-pub` but not `--min-confidence`. CLAUDE.md only says `cqs dead — find dead code: functions/methods with no callers in the index` with no options listed. The `--min-confidence` flag is the primary way to reduce false positives in dead code analysis (filtering out low-confidence candidates) and is a meaningful option to document.
+- **Suggested fix:** Add `cqs dead --min-confidence medium  # Filter to medium+ confidence` example to README's Maintenance section. Update CLAUDE.md description to include `--min-confidence`.
+
+## Code Quality
+
+#### CQ-1: `source/` module is dead code — never wired into indexing pipeline
+- **Difficulty:** easy
+- **Location:** src/source/mod.rs, src/source/filesystem.rs (declared at src/lib.rs:81)
+- **Difficulty:** easy
+- **Description:** The entire `source/` module (~250 lines across 2 files) is dead code. It declares a `Source` trait and `FileSystemSource` implementation but is never used anywhere — `mod source` is declared in `lib.rs` but zero `use crate::source` or `source::` references exist in the codebase. The module header says "Not yet wired into the indexing pipeline — reserved for future use" and has `#![allow(dead_code)]` to suppress warnings. Prior audit DOC-7 (PR #501) noted CONTRIBUTING.md listed it as active, but the module itself was never removed.
+- **Suggested fix:** Delete `src/source/mod.rs` and `src/source/filesystem.rs`, remove `pub(crate) mod source;` from `lib.rs`. If the abstraction is needed later, it can be rebuilt from git history.
+
+#### CQ-2: Gather JSON assembly duplicated between CLI command and batch handler
+- **Difficulty:** easy
+- **Location:** src/cli/commands/gather.rs:114-145, src/cli/batch/handlers.rs:406-438
+- **Description:** `GatheredChunk` JSON serialization is written out identically in two places: `cmd_gather` (CLI command) and `dispatch_gather` (batch handler). Both construct the same `serde_json::json!()` with identical field lists (name, file, line_start, line_end, language, chunk_type, signature, score, depth, content) and the same conditional `source` field. Meanwhile, `GatheredChunk` already has both a `#[derive(serde::Serialize)]` and a manual `to_json(&self, root)` method — three different serialization paths for the same struct, none of which are used by these two callers.
+- **Suggested fix:** Use `GatheredChunk`'s existing `Serialize` derive or `to_json()` method in both cmd_gather and dispatch_gather. If `normalize_path` is needed (it is), ensure `GatheredChunk.file` is already normalized before serialization, or add a `#[serde(serialize_with = ...)]` attribute.
+
+#### CQ-3: `token_pack_unified` and `token_pack_tagged` are near-identical functions
+- **Difficulty:** easy
+- **Location:** src/cli/commands/query.rs:333-398
+- **Description:** `token_pack_unified()` and `token_pack_tagged()` are structurally identical 30-line functions that differ only in: (1) the input type (`Vec<UnifiedResult>` vs `Vec<TaggedResult>`), (2) how to extract text content (`.match r` vs `.match &r.result`), and (3) how to extract score (same match depth difference). Both call the same `super::token_pack()` generic function and log the same tracing info. The duplication exists because there's no trait to abstract "something that contains a UnifiedResult".
+- **Suggested fix:** Add a trait (e.g., `HasUnifiedResult`) with `fn unified(&self) -> &UnifiedResult` on both `UnifiedResult` (returning `self`) and `TaggedResult` (returning `&self.result`). Then a single generic `token_pack_results<T: HasUnifiedResult>()` replaces both functions.
+
+#### CQ-4: `cmd_query` at 287 lines — multiple concerns in one function body
+- **Difficulty:** medium
+- **Location:** src/cli/commands/query.rs:39-325
+- **Description:** `cmd_query` handles 5 different search modes (name-only, name-only+ref, semantic, semantic+ref, multi-index) with inline branching. It's already been partially decomposed into helper functions (`cmd_query_name_only`, `cmd_query_ref_only`, `cmd_query_ref_name_only`) but the main body still mixes: (1) embedder creation, (2) filter construction, (3) CAGRA/HNSW index loading (30 lines of cfg-gated code), (4) audit mode checks, (5) search execution, (6) reference search + merge, (7) token packing, (8) parent context resolution, (9) staleness warning, and (10) result display. The early returns at lines 50-52 for name-only mode mean the rest of the function is implicitly the "semantic search" path, but this isn't clear from the structure.
+- **Suggested fix:** Extract the CAGRA/HNSW index loading block (lines 115-153) into `load_vector_index(store, cqs_dir)`. Extract the staleness check (lines 240-253) into a helper. This would bring cmd_query under 200 lines and make the search mode flow clearer.
+
+#### CQ-5: 11 functions suppress `clippy::too_many_arguments` — parameter struct opportunities
+- **Difficulty:** medium
+- **Location:** src/cli/commands/gather.rs:11, src/cli/batch/handlers.rs:32,344, src/search.rs:554, src/scout.rs:169,198, src/cli/watch.rs:209,264, src/cli/pipeline.rs:235, src/parser/markdown.rs:707,810
+- **Description:** 11 `#[allow(clippy::too_many_arguments)]` annotations across the codebase. The worst offenders are `dispatch_search` (9 params), `dispatch_gather` (7 params), `cmd_gather` (8 params), and `scout_core` (8 params). Many of these pass CLI-extracted fields that were already bundled in a struct (`Cli` or `BatchCmd`) but destructured before the call. This pattern makes signatures fragile — adding a new option requires touching every call site in the chain.
+- **Suggested fix:** For the batch handlers, pass `&BatchCmd` variants directly instead of destructuring. For `cmd_gather`, accept a struct (e.g., `GatherArgs { expand, direction, limit, tokens, ref_name, json }`). Not all 11 need fixing — pipeline.rs and markdown.rs take contextual state that doesn't naturally bundle.
+
+## Extensibility
+
+#### EX-1: `pipeable_command_names()` manually duplicates all pipeable `BatchCmd` variants — silently stale on new commands
+- **Difficulty:** easy
+- **Location:** src/cli/batch/pipeline.rs:31-113
+- **Description:** `pipeable_command_names()` builds a static array of `(name, BatchCmd::Variant { .. })` pairs to find which commands are pipeable via `is_pipeable()`. Every pipeable `BatchCmd` variant must be listed twice: once in `is_pipeable()` (line 275 of commands.rs) and once in this array. When a new pipeable command is added, forgetting to update `pipeable_command_names()` silently omits it from the pipeline error message — the pipeline still works, the omission is invisible to tests, and it's easy to miss in review. The comment says "kept in sync via is_pipeable()" but there is no compiler enforcement of that sync.
+- **Suggested fix:** Remove the static array in `pipeable_command_names()`. Instead, generate the list by using `BatchInput::command().get_subcommands()` to iterate over all subcommand names and check each via `is_pipeable_command(&[name.to_string()])`. This derives the error message list from the actual `is_pipeable()` implementation rather than a separately maintained copy.
+
+#### EX-2: `name_boost: 0.2` hardcoded in `dispatch_search` — no shared constant with CLI default
+- **Difficulty:** easy
+- **Location:** src/cli/batch/handlers.rs:83
+- **Description:** `dispatch_search` hardcodes `name_boost: 0.2` as a bare literal. The CLI default is also `0.2` (via `#[arg(long, default_value = "0.2")]` in `src/cli/mod.rs:146`) and the config file template shows `name_boost = 0.2` (`src/config.rs:53`). These three values are in sync by coincidence — no shared constant exists. If the default changes, one of the three sites is likely to be missed. `SearchFilter::default()` correctly uses `0.0` (no name boosting when unspecified), so the batch handler is intentionally setting a non-default value — but the value should come from a named constant.
+- **Suggested fix:** Define `pub const DEFAULT_NAME_BOOST: f32 = 0.2;` in `src/store/helpers.rs` or `src/lib.rs`. Use it in `cli/mod.rs` default, `batch/handlers.rs` dispatch_search, and the config template string.
+
+#### EX-3: `HNSW_EXTENSIONS` and `HNSW_ALL_EXTENSIONS` are two overlapping constants manually kept in sync
+- **Difficulty:** easy
+- **Location:** src/hnsw/persist.rs:31,34
+- **Description:** `HNSW_EXTENSIONS = &["hnsw.graph", "hnsw.data", "hnsw.ids"]` and `HNSW_ALL_EXTENSIONS = &["hnsw.graph", "hnsw.data", "hnsw.ids", "hnsw.checksum"]` share three entries that are duplicated verbatim. The split is intentional: `HNSW_EXTENSIONS` excludes the checksum file (used in checksum verification), while `HNSW_ALL_EXTENSIONS` includes it (used for cleanup/deletion). Adding a new HNSW file component requires updating both constants and maintaining the correct split, with no compiler help.
+- **Suggested fix:** Add a compile-time assertion that `HNSW_ALL_EXTENSIONS` contains all elements of `HNSW_EXTENSIONS`: `const _: () = assert!(/* all HNSW_EXTENSIONS entries are in HNSW_ALL_EXTENSIONS */);`. Or restructure: `const HNSW_DATA_EXTENSIONS: &[&str] = &["hnsw.graph", "hnsw.data", "hnsw.ids"];` and derive both constants from it with a comment making the relationship explicit.
+
+#### EX-4: `extract_from_scout_groups` is a bespoke extractor for scout's nested JSON shape — new non-standard output shapes each need a new extractor
+- **Difficulty:** medium
+- **Location:** src/cli/batch/pipeline.rs:116-210
+- **Description:** The pipeline name extractor uses three strategies: bare array, a generic field walk (`extract_from_standard_fields`), and a bespoke `extract_from_scout_groups` for scout's `file_groups[].chunks[].name` nesting. `extract_from_standard_fields` was made key-agnostic (EX-6 fix, PR #504) to avoid hardcoding field names, but scout's two-level nesting required its own special case. Any new command with a non-standard output shape (e.g., `sections[].functions[].name`) would need another bespoke extractor added to `extract_names()`. The pipeline has no specification of what JSON structure makes a command's output pipeable.
+- **Suggested fix:** Define a `"_names"` convention: pipeable command handlers include a top-level `"_names": ["fn1", "fn2"]` field in their JSON output. The pipeline extractor checks `_names` first — zero structural parsing logic. Scout already assembles the output; adding `_names` extraction there is simpler than structural inference at the pipeline level. This also makes pipeability testable without structural knowledge.
+
+#### EX-5: Note/code slot ratio `(limit * 3) / 5` is an inline formula with no named constant — repeated in tests
+- **Difficulty:** easy
+- **Location:** src/search.rs:1061, :1216, :1223
+- **Description:** The 60%/40% note-to-code slot allocation is expressed as `(limit * 3) / 5` (60% minimum code slots). This formula appears three times: once in production (line 1061) and twice re-derived independently in tests (lines 1216, 1223). The policy is documented only in a comment. If the ratio changes, all three sites must be updated manually, and stale tests would not catch a mismatch between production and test formulas.
+- **Suggested fix:** Extract a `fn min_code_slots(limit: usize) -> usize { ((limit * 3) / 5).max(1) }` private helper. Both production code and tests call it. The ratio numerator/denominator becomes a single change point. Optionally name the constants: `const MIN_CODE_RATIO_NUM: usize = 3; const MIN_CODE_RATIO_DEN: usize = 5;`.
+
+## Robustness
+
+#### RB-1: `fetch_candidates_by_ids_async` and `fetch_chunks_by_ids_async` unbatched — exceed SQLite 999-param limit with high `--limit`
+- **Difficulty:** easy
+- **Location:** src/store/chunks.rs:1366, 1326
+- **Description:** Both functions build a single `IN(?)` placeholder list from all IDs passed in. The HNSW search path computes `candidate_count = (limit * 5).max(100)` (search.rs:811,1030), so `--limit 200` produces 1000 candidate IDs — exceeding SQLite's 999-parameter limit. `check_origins_stale` had the same bug (DS-8, fixed in v0.19.0) and `get_chunks_by_names_batch` already batches in groups of 500. These two functions were added later in PF-5 and missed the batching pattern.
+- **Suggested fix:** Batch IDs in groups of 900 (same constant used by `check_origins_stale`). Collect results across batches: `fetch_candidates_by_ids_async` extends a Vec, `fetch_chunks_by_ids_async` merges HashMaps.
+
+#### RB-2: `CandidateRow::from_row` and `ChunkRow::from_row` use panicking `row.get()` — no column-missing resilience
+- **Difficulty:** medium
+- **Location:** src/store/helpers.rs:75-84, 106-121
+- **Description:** Both `from_row` methods use `row.get("column_name")` which panics if the column is absent. The callers control the SQL query, so missing columns indicate a programmer bug rather than corrupt data. However, this means a schema migration that drops or renames a column would cause a panic rather than a descriptive error. Other store code (e.g., `IndexStats`, `metadata`) uses `row.get::<Option<_>, _>()` or `.fetch_optional()` which handle missing data gracefully. The `from_row` pattern is consistent across both structs — 16 panicking `.get()` calls total.
+- **Suggested fix:** This is acceptable as-is since the SQL queries are co-located with the from_row calls (programmer invariant). If defensive coding is desired, use `row.try_get()` which returns `Result` instead of panicking. Low priority — leave as informational unless schema migrations are planned.
+
+#### RB-3: `where_to_add.rs` — `suggest_placement_with_options_core` panics via `.expect()` on `query_embedding`
+- **Difficulty:** easy
+- **Location:** src/where_to_add.rs:170
+- **Description:** `suggest_placement_with_options_core` calls `.expect()` on `opts.query_embedding`, relying on the caller (`suggest_placement_with_options`) to always set it. The invariant is enforced by the public entry point: it either passes through when `is_some()` or sets it before calling `_core`. But `_core` is `fn` (not `pub`), so only the one caller can reach it. If a future refactor adds another call path that forgets to set the embedding, this panics at runtime with no compile-time guard.
+- **Suggested fix:** Change `_core` to take `query_embedding: &Embedding` as a direct parameter instead of extracting it from `opts`. This makes the requirement compile-time enforced rather than runtime-asserted.
+
+#### RB-4: `blame` — `run_git_log_line_range` passes `u32` line numbers to format string without overflow check on `start > end`
+- **Difficulty:** easy
+- **Location:** src/cli/commands/blame.rs:86
+- **Description:** The function formats `"{},{}:{}"` from `start` and `end` line numbers. If a chunk's `line_start > line_end` (corrupt index data, or a parser bug where an empty node produces inverted ranges), git receives a reversed line range like `100,50:file.rs`. Git handles this gracefully (returns empty output), so this doesn't crash. However, the user gets silent empty results with no explanation. A `line_end >= line_start` assertion or swap would make the failure mode visible.
+- **Suggested fix:** Add a check at the top: `if end < start { tracing::warn!(start, end, file = rel_file, "Inverted line range — possible corrupt index"); std::mem::swap(&mut start, &mut end); }`. This self-heals and logs the anomaly.
+
+#### RB-5: `reranker.rs` — `outputs[0]` index access panics if ONNX model returns empty output
+- **Difficulty:** easy
+- **Location:** src/reranker.rs:140
+- **Description:** After `session.run()`, the code accesses `outputs[0]` with direct indexing. If the ONNX model returns zero outputs (malformed model, version mismatch), this panics. The embedder has the same pattern at embedder.rs:528 (`outputs[0]`). Both are ONNX runtime calls on bundled models, so the risk is low — but a model update or file corruption would produce a panic instead of a descriptive error.
+- **Suggested fix:** Replace `outputs[0]` with `outputs.first().ok_or(RerankerError::Inference("Model returned no outputs".into()))?` (and similarly for embedder).
+
+#### RB-6: `Language::def()` and `Language::grammar()` panic on disabled feature flags — no graceful path
+- **Difficulty:** easy
+- **Location:** src/language/mod.rs:549, 570
+- **Description:** `Language::def()` panics if the language's feature flag is disabled, and `Language::grammar()` panics if the language has no tree-sitter grammar. Both are documented with `# Panics` doc sections. The `try_def()` alternative exists but callers (parser, search) almost universally use `def()`. In the current codebase all 20 languages are always enabled, so this is theoretical. But it means feature-flag subsetting (e.g., a minimal build with only Rust+Python) would hit panics instead of skip-and-warn behavior.
+- **Suggested fix:** Low priority since all languages are always enabled. If feature-flag subsetting is planned, replace panics with `Result` returns. Otherwise, leave as-is with the documented `# Panics` sections.
+
+#### RB-7: `Parser::new()` panics on registry/enum mismatch — fails at construction not usage
+- **Difficulty:** easy
+- **Location:** src/parser/mod.rs:62-67
+- **Description:** `Parser::new()` iterates the language registry and panics if any registered language name can't parse to a `Language` enum variant. This is a compile-time invariant (the registry and enum are defined in the same module), so the panic can only fire if someone adds a registry entry without a matching enum variant. The panic message is descriptive ("Language registry/enum mismatch: 'X' is registered but has no Language variant"). However, it runs at `Parser::new()` which is called during indexing — a panic here kills the entire index pipeline.
+- **Suggested fix:** Low priority — this is a developer-facing invariant violation. Could add a `#[cfg(test)]` consistency test instead, which catches the mismatch at test time rather than at runtime.
+
+## Algorithm Correctness
+
+#### AC-1: `emit_empty_results` produces malformed JSON — query string not escaped
+- **Difficulty:** easy
+- **Location:** src/cli/commands/query.rs:29, src/cli/commands/similar.rs:99
+- **Description:** `emit_empty_results` uses raw `format!`-style interpolation to embed the query string into a JSON string literal: `println!(r#"{{"results":[],"query":"{}","total":0}}"#, query)`. If the query contains `"`, `\`, or control characters, the output is invalid JSON. Example: query `foo"bar` produces `{"results":[],"query":"foo"bar","total":0}` which any JSON parser rejects. The same pattern exists in `cmd_similar` (similar.rs:99) with `chunk_name` — chunk names from the DB are unlikely to contain special chars but C++ operator overloads could trigger it.
+- **Suggested fix:** Use `serde_json::json!()` to build the object, which properly escapes all string values: `let obj = serde_json::json!({"results": [], "query": query, "total": 0}); println!("{}", obj);`. Apply the same fix in similar.rs:99.
+
+#### AC-2: `search_by_candidate_ids` FTS runs against full index, not scoped to HNSW candidates
+- **Difficulty:** medium
+- **Location:** src/search.rs:934-942
+- **Description:** In the HNSW-guided path (`search_by_candidate_ids`), semantic scoring only considers the ~500 HNSW candidate IDs. But the FTS keyword search runs against the full `chunks_fts` index with `LIMIT limit*3` (line 938). When `rrf_fuse` merges these two lists, FTS-only results that were NOT in the HNSW candidate set enter the final results. These FTS-only results appear in the output with a pure-FTS RRF score (no semantic component). This is a design tension: the HNSW path was designed to narrow the search space for performance (PF-5), but the unscoped FTS re-expands it. In practice this often improves recall (FTS catches keyword matches HNSW misses), but it means the HNSW candidate count doesn't actually bound the work — it's O(FTS_matches) + O(candidate_count), not O(candidate_count) alone.
+- **Suggested fix:** Document the behavior rather than restricting it: "HNSW narrows embedding search; FTS still scans the full index for keyword matches." The FTS scan is fast (SQLite FTS5 is O(matching_docs), not O(total_docs)) and improves recall. If strict bounding is needed, scope FTS with `WHERE id IN (...)` but this reduces recall for keyword-heavy queries.
+
+#### AC-3: `token_pack` has O(n^2) `keep.iter().any()` scan in greedy packing loop
+- **Difficulty:** easy
+- **Location:** src/cli/commands/mod.rs:134
+- **Description:** In the greedy packing loop, `keep.iter().any(|&k| k)` scans the entire `keep` boolean array on every iteration to check if at least one item has been packed. This check implements the "always include at least one item" guarantee. For N items, total scan work is O(N^2). In practice N is small (search results capped at ~20-100), so this isn't a measurable bottleneck. But it's an unnecessary quadratic pattern that could be replaced with a constant-time check.
+- **Suggested fix:** Replace with a `bool` flag: add `let mut has_any = false;` before the loop, change the condition to `if used + tokens > budget && has_any { break; }`, and set `has_any = true;` after each `keep[idx] = true;`.
+
+#### AC-4: `cap_scores` in onboard uses `u64::MAX - x` inversion trick — correct but fragile
+- **Difficulty:** easy
+- **Location:** src/onboard.rs:175-183
+- **Description:** The `cap_scores` function sorts ascending by key and truncates to `max`. For caller_scores, the key function inverts scores via `u64::MAX - ((safe * 1e6) as u64)` so highest scores map to lowest keys. This is mathematically correct — ascending sort + truncate keeps highest scores. But the inversion trick is non-obvious: a reader seeing ascending sort + truncate expects "keep lowest values." The callee_scores path uses `|(_s, d)| *d` (keep shallowest depth) which reads naturally. The `f32 * 1e6 as u64` cast is safe since scores are cosine similarities (0.0-1.0), producing values up to 1,000,000 — well within u64 range.
+- **Suggested fix:** Replace the inversion trick with a reverse sort: change `entries.sort_by(|a, b| key_fn(&a.1).cmp(&key_fn(&b.1)));` to `entries.sort_by(|a, b| key_fn(&b.1).cmp(&key_fn(&a.1)));` for the caller case, and pass `|(score, _)| { let safe = ...; (safe * 1e6) as u64 }` without inversion. This eliminates the mental gymnastics while preserving the same result.
+
+#### AC-5: `bfs_shortest_path` uses empty-string sentinel instead of `Option` for predecessor tracking
+- **Difficulty:** easy
+- **Location:** src/cli/commands/trace.rs:203-221
+- **Description:** The BFS shortest path stores predecessors in `HashMap<String, String>` where the source node's predecessor is `String::new()`. Path reconstruction walks predecessors until finding an empty string. This relies on no real function name being empty. The parser never produces empty names, so this works in practice. But the sentinel value makes the invariant implicit rather than type-enforced.
+- **Suggested fix:** Informational — no practical bug. Could use `HashMap<String, Option<String>>` for cleaner semantics, but the current code works given the parser invariant.
+
+## Test Coverage
+
+#### TC-1: 5 newest languages have no parser integration tests — Bash, HCL, Kotlin, Swift, Objective-C
+- **Difficulty:** medium
+- **Location:** tests/parser_test.rs (missing), tests/fixtures/ (missing .sh, .tf, .kt, .swift, .m)
+- **Description:** The parser integration tests in `tests/parser_test.rs` cover Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, and Markdown with fixture files. The 5 languages added in v0.19.0 (Bash, HCL, Kotlin, Swift, Objective-C) have no fixture files and no integration tests. Kotlin and Swift have 1 inline unit test each (return type extraction only). Bash, HCL, and Objective-C have zero tests anywhere — neither inline nor integration. The inline language tests only cover `extract_return_type()`, not the full tree-sitter parsing pipeline (`parse_file` -> chunks with correct names, signatures, call extraction, parent_id wiring). A tree-sitter query regression in any of these 5 languages would be invisible to CI.
+- **Suggested fix:** Add fixture files (`sample.sh`, `sample.tf`, `sample.kt`, `sample.swift`, `sample.m`) with representative code (functions, classes/structs, nested constructs). Add `test_parse_*_fixture()` integration tests following the existing C/Java/SQL pattern: parse fixture, assert non-empty, verify language tag, check function count.
+
+#### TC-2: `NoteBoostIndex` has zero tests — search scoring hot path
+- **Difficulty:** easy
+- **Location:** src/search.rs:300-371
+- **Description:** `NoteBoostIndex` is the search-time note-based score boosting component used in every search call. It has non-trivial logic: classifying mentions as name-like vs path-like (line 317-319), taking strongest absolute sentiment (line 323), and computing a `1.0 + sentiment * NOTE_BOOST_FACTOR` multiplier (line 368). Zero direct tests. The `test_score_candidate_name_boost` test exercises name boost through `NameMatcher` but not through `NoteBoostIndex`. The path-mention matching logic (suffix/prefix matching via `path_matches_mention`) is tested separately but the `NoteBoostIndex::boost()` composition — multiple notes, mixed name/path mentions, sentiment priority — is never tested in isolation.
+- **Suggested fix:** Add tests: (1) empty notes -> boost returns 1.0, (2) name mention with positive sentiment -> boost > 1.0, (3) path mention with negative sentiment -> boost < 1.0, (4) competing name and path mentions -> strongest absolute wins, (5) multiple notes for same mention -> strongest sentiment preserved.
+
+#### TC-3: `search_by_candidate_ids` language and chunk_type filter branches untested
+- **Difficulty:** easy
+- **Location:** src/search.rs:883-905
+- **Description:** The PF-5 `search_by_candidate_ids` function has filter_map branches for `filter.languages` (lines 883-893) and `filter.chunk_types` (lines 895-905) that parse candidate row strings into `Language`/`ChunkType` enums and filter non-matching candidates. These branches are unique to the candidate path — the brute-force `search_filtered` path filters differently (in SQL WHERE clauses). The existing `test_search_by_candidate_ids_with_glob_filter` tests the `path_pattern` filter but not language or chunk_type filters. A regression where string->enum parsing fails (e.g., case mismatch after a ChunkType rename) would silently drop all candidates in the candidate path while the brute-force path continues working.
+- **Suggested fix:** Add tests: (1) `filter.languages = Some(vec![Language::Rust])` with mixed-language candidates — only Rust survivors, (2) `filter.chunk_types = Some(vec![ChunkType::Function])` — methods/structs filtered out.
+
+#### TC-4: `ChatHelper::complete` — untested tab-completion logic
+- **Difficulty:** easy
+- **Location:** src/cli/chat.rs:26-49
+- **Description:** `ChatHelper::complete()` implements tab completion with specific behaviors: (1) only completes the first token (returns empty after a space), (2) filters commands by prefix, (3) returns `(0, matches)` — the 0 indicates replacement starts at position 0. The chat.rs test module only tests `handle_meta` and `command_names` — the `Completer` impl is never tested. Tab completion is a user-facing UX feature and the `pos` vs prefix slicing logic (`&line[..pos]`) could regress silently. The test would be trivial since `ChatHelper` is `struct { commands: Vec<String> }` with no external dependencies.
+- **Suggested fix:** Add tests: (1) prefix "se" at pos=2 -> returns ["search"], (2) prefix "cal" at pos=3 -> returns ["callers", "callees"], (3) "search fo" at pos=9 -> returns [] (space in prefix, no completion), (4) empty prefix at pos=0 -> returns all commands.
+
+#### TC-5: `build_blame_data` only tested through JSON shape — no end-to-end path with mock git
+- **Difficulty:** medium
+- **Location:** src/cli/commands/blame.rs:36-68
+- **Description:** `build_blame_data` is the core blame logic that wires `resolve_target` -> `run_git_log_line_range` -> `parse_git_log_output` -> `get_callers_full`. The existing tests cover `parse_git_log_output` (5 tests) and `blame_to_json` (2 tests) individually, but `build_blame_data` itself is never tested — its callers (`cmd_blame` and `dispatch_blame`) both need a live git repo and an indexed store, so integration tests would be needed. The function has 3 error paths: resolve_target failure (line 45-47), git log failure (line 52), and callers failure (line 56-59, silently falls back). The callers fallback path in particular — `unwrap_or_else` returning empty Vec on store error — is never exercised by any test.
+- **Suggested fix:** Create an integration test that sets up a temp git repo (init + commit), indexes it, then calls `build_blame_data`. This would cover the full pipeline. Lower priority than TC-1 through TC-4 since blame is a thin git wrapper and the individual components are tested.
+
+#### TC-6: Batch pipeline error propagation — malformed mid-pipeline input never tested
+- **Difficulty:** easy
+- **Location:** src/cli/batch/pipeline.rs
+- **Description:** The pipeline integration tests cover: valid 2-stage, valid 3-stage, empty upstream, ineligible downstream, quoted pipe, and mixed pipeline+single commands. However, no test exercises error propagation when a **middle** stage fails — e.g., `callers process | explain | callers` where the middle `explain` returns a result that the downstream `callers` can't extract names from (non-array explain output). The `extract_names` function at pipeline.rs handles various JSON shapes but the interaction between an explain output (object with `callers`/`callees` arrays) being fed into a downstream callers stage is untested. The pipeline should degrade gracefully (0 names extracted -> empty result), but this specific shape interaction isn't verified.
+- **Suggested fix:** Add a test: `explain process | callers` — verify the pipeline extracts names from explain's callers/callees arrays and feeds them downstream correctly. Also test a deliberately incompatible pipeline like `stats | callers` (stats returns object with no name fields) to verify graceful degradation.
+
+## Platform Behavior
+
+#### PB-1: `cmd_watch` — `RecommendedWatcher` uses inotify on WSL; `Config::with_poll_interval` has no effect on inotify backend
+- **Difficulty:** medium
+- **Location:** src/cli/watch.rs:61-63, 87-89
+- **Description:** On WSL over `/mnt/c/` NTFS-backed paths, inotify events are unreliable (missed or duplicated). The code emits a warning at startup but still creates a `RecommendedWatcher` which uses inotify on Linux. `Config::default().with_poll_interval(Duration::from_millis(debounce_ms))` configures the polling interval for `notify::PollWatcher` — it has no effect on the inotify backend. The result: users see the warning but the watcher continues using inotify, silently missing changes on `/mnt/` paths. The `last_indexed_mtime` deduplication guard mitigates duplicate events but doesn't address missed ones.
+- **Suggested fix:** When `is_wsl() && root.to_str().map_or(false, |p| p.starts_with("/mnt/"))`, use `notify::PollWatcher::new(tx, config)?` instead of `RecommendedWatcher`. Both implement the `Watcher` trait, enabling a conditional dispatch. Alternatively, document that `cqs watch` is unsupported on WSL `/mnt/` paths and upgrade the startup warning to a bail with a suggestion to use the `cqs-watch` systemd service configured with `cqs index` instead.
+
+#### PB-2: `collect_events` — `notes_path` silently falls back to non-canonical path if `docs/notes.toml` doesn't exist at watch start
+- **Difficulty:** easy
+- **Location:** src/cli/watch.rs:97-105, 232
+- **Description:** `dunce::canonicalize(&notes_path)` is called at watch startup (line 102), but fails if `docs/notes.toml` doesn't exist — valid for projects without notes. On failure, the fallback at line 103 preserves the un-canonicalized path. Inotify delivers event paths in canonicalized form. The comparison `path == notes_path` (line 232) then compares a canonical event path against a possibly non-canonical stored path. On WSL with symlinked project directories or when the project root itself is a symlink, the paths diverge and notes changes are silently ignored even after the file is created.
+- **Suggested fix:** Re-attempt canonicalization each cycle when `notes_path` remains non-canonical: `if !notes_canonical { if let Ok(c) = dunce::canonicalize(&notes_path) { notes_path = c; notes_canonical = true; } }`. Or compare both forms in the equality check.
+
+#### PB-3: `run_git_log_line_range` — forward-slash path in `-L` spec latently incompatible with native Windows git
+- **Difficulty:** easy
+- **Location:** src/cli/commands/blame.rs:50, 86
+- **Description:** `rel_file` is produced by `rel_display(&chunk.file, root)`, which normalizes to forward slashes. The `-L start,end:path` argument format requires the path to match the working tree path as git sees it. On native Windows git (not WSL), git expects Windows-native path separators; forward-slash paths fail the `-L` spec lookup and git returns "no path found in git history" for otherwise valid files. Currently WSL-only, so this is latent — but any future Windows-native deployment would hit this silently.
+- **Suggested fix:** Add a code comment at line 86 noting the platform assumption (`// git on WSL handles forward slashes; native Windows git requires MAIN_SEPARATOR`). If Windows native support is added, conditionally replace slashes: `if cfg!(windows) { rel_file.replace('/', "\\") } else { rel_file }`.
+
+#### PB-4: `acquire_index_lock` and `try_acquire_index_lock` duplicate lock-file open code; NTFS ignores `0o600` silently
+- **Difficulty:** easy
+- **Location:** src/cli/files.rs:52-71, 95-115, 46-81
+- **Description:** Both lock functions contain nearly identical `#[cfg(unix)]` / `#[cfg(not(unix))]` file-creation blocks. `acquire_index_lock` duplicates the block a second time in its retry-after-stale-lock path (lines 96-115). On WSL over `/mnt/c/`, the `#[cfg(unix)]` branch applies (WSL is Linux), so `0o600` mode is requested — but NTFS ignores Unix permission bits. The `set_permissions` call succeeds silently, making the lock file world-readable to any user with filesystem access. No warning is emitted.
+- **Suggested fix:** Extract `open_lock_file(path) -> Result<File>` helper to eliminate duplication. Add a `tracing::debug!` when `is_wsl() && path.starts_with("/mnt/")` noting the NTFS permission caveat. The PID leak is low severity since `.cqs/` already requires project directory access.
+
+#### PB-5: `is_wsl()` has no `#[cfg(unix)]` guard — non-Unix builds rely on I/O failure for correct behavior
+- **Difficulty:** easy
+- **Location:** src/config.rs:15-25
+- **Description:** `is_wsl()` reads `/proc/version` and returns `false` on I/O error. On a native Windows binary, `/proc/version` doesn't exist, so the function returns `false` — correct, but the correctness depends on `read_to_string` failing rather than on explicit platform conditioning. The callers (`warn_wsl_advisory_locking` at hnsw/persist.rs:21, config permission check at config.rs:206) pair `is_wsl()` with `path.starts_with("/mnt/")` — a Unix-only path prefix that is meaningless on Windows. The code is functionally correct for the current WSL-only deployment but is structurally confusing for any future Windows-native port.
+- **Suggested fix:** Add `#[cfg(unix)]` to the real implementation and `#[cfg(not(unix))] pub fn is_wsl() -> bool { false }` as the stub. This makes the platform conditionality explicit at the declaration rather than relying on I/O failure semantics.
+
+## Security
+
+#### SEC-1: `CQS_PDF_SCRIPT` env var allows arbitrary script execution with no path validation
+- **Difficulty:** easy
+- **Location:** src/convert/pdf.rs:56-68
+- **Description:** `find_pdf_script()` checks the `CQS_PDF_SCRIPT` env var first. If set, the value is used as a script path passed directly to `Command::new(&python).args([&script, ...])`. The only validation is a non-blocking warning if the extension isn't `.py`. An attacker who can set environment variables (e.g., via `.env` file, shell rc injection, or CI env manipulation) can point this to any script, which is then executed with the Python interpreter. The prior audit SEC-6 finding (v0.19.2, PR #504) addressed the log level but not the fundamental issue: user-controlled env var -> script execution with no guardrails beyond extension sniffing.
+- **Suggested fix:** (1) Require `.py` extension and abort (not just warn) on mismatch. (2) Validate the script resolves inside the project root or a known cqs directory. (3) Document in SECURITY.md. Low practical risk given the threat model (local tool, no external users), but violates defense-in-depth.
+
+#### SEC-2: `search_by_name` FTS query safety depends on `debug_assert` — compiled out in release builds
+- **Difficulty:** easy
+- **Location:** src/store/mod.rs:609-613, src/store/chunks.rs:1199-1203
+- **Description:** `search_by_name` and `search_by_names_batch` build FTS5 queries via `format!("name:\"{}\" OR name:\"{}\"*", normalized, normalized)`. Safety depends on `sanitize_fts_query` stripping all double quotes. A `debug_assert!(!normalized.contains('"'))` verifies this — but is compiled out in release builds. If `sanitize_fts_query` is ever refactored to miss the `"` character, release builds would have no runtime check and the format string would produce malformed FTS5 queries that could alter search semantics. The `sanitize_fts_query` function does currently strip `"` (mod.rs:144) and has fuzz coverage (mod.rs:916), so this is safe today. But the invariant is enforced by convention rather than by runtime check.
+- **Suggested fix:** Change `debug_assert!` to `assert!` at both sites. The assertion runs once per search call on an already-constructed short string — negligible cost. This makes the safety invariant enforceable even if `sanitize_fts_query` is accidentally weakened.
+
+#### SEC-3: `convert_directory` walk has no depth limit — deeply nested directories can exhaust resources
+- **Difficulty:** easy
+- **Location:** src/convert/mod.rs:345
+- **Description:** `convert_directory` uses `walkdir::WalkDir::new(dir)` with no `.max_depth()` limit. CHM extraction (chm.rs:61) and webhelp (webhelp.rs:58) also use unbounded walks but are bounded by temp directory (CHM) or `content/` subdirectory (webhelp), and both have `MAX_PAGES = 1000` as a backstop. `convert_directory` has no equivalent file count limit — it processes all matching files in an arbitrary directory tree. A directory with extreme nesting or a large number of supported files (e.g., 100K HTML files) would produce unbounded memory use and processing time.
+- **Suggested fix:** Add `.max_depth(50)` to the `WalkDir` in `convert_directory`. Add a `MAX_FILES` constant (e.g., 10000) and truncate with a warning, matching the `MAX_PAGES` pattern in CHM and webhelp.
+
+#### SEC-4: HNSW index files written with no permission restriction — inconsistent with SQLite database protection
+- **Difficulty:** easy
+- **Location:** src/hnsw/persist.rs (save functions)
+- **Description:** `Store::open()` (mod.rs:237-254) explicitly sets `0o600` permissions on SQLite database and WAL/SHM files as defense-in-depth. However, HNSW index files (`*.hnsw.graph`, `*.hnsw.data`, `*.hnsw.ids`, `*.hnsw.checksum`) are written by the HNSW persist module without any permission setting. These files contain the same embedding vectors that are in the database. On a shared system, HNSW files would be world-readable (subject to umask) while the database is owner-only. The `.cqs/` directory provides parent-level protection, but the file-level inconsistency is a gap.
+- **Suggested fix:** After writing HNSW files in `save_to_directory()` and `atomic_save()`, set `0o600` permissions on each file with `#[cfg(unix)]` guard, same pattern as `Store::open`. Apply after the final rename in `atomic_save()`.
+
+#### SEC-5: `find_7z` and `find_python` search `PATH` for executables without validation
+- **Difficulty:** medium
+- **Location:** src/convert/chm.rs:168-183, src/convert/pdf.rs:95-110
+- **Description:** Both functions iterate hardcoded names (`["7z", "7za", "p7zip"]` and `["python3", "python"]`) and probe via `Command::new(name)`, which resolves via the system `PATH`. If an attacker can prepend a directory to `PATH`, a malicious binary would be executed instead. Standard PATH poisoning — mitigated in most environments by OS protections, but relevant in CI pipelines or shared systems where `PATH` is not fully trusted.
+- **Suggested fix:** Low priority given the threat model. Document in SECURITY.md that `cqs convert` trusts the system PATH. For hardening: prefer absolute paths when available, or validate the found executable is in a trusted directory.
+
+#### SEC-6: No size limit on git diff output — `run_git_diff` can allocate unbounded memory
+- **Difficulty:** easy
+- **Location:** src/cli/commands/mod.rs:166-188
+- **Description:** `run_git_diff` calls `cmd.output()` which reads the entire stdout into memory. `git diff` output is unbounded — a large binary change, mass reformatting, or diff against an unrelated branch can produce hundreds of megabytes. The `read_stdin` function (mod.rs:153-162) has a 50MB limit, but `run_git_diff` has none. The output is then passed to `parse_diff_output` and `impact_diff` which process it in-memory. A pathological diff could cause OOM. The `run_git_log_line_range` (blame.rs) is naturally bounded by the `-n depth` flag, so it doesn't have this issue.
+- **Suggested fix:** Add a size check after `cmd.output()`: if `output.stdout.len() > MAX_DIFF_SIZE` (e.g., 50MB, matching the stdin limit), bail with an error message suggesting `--base` to narrow the diff scope. Alternatively, stream the output through a length-limited reader.
+
+## Data Safety
+
+#### DS-1: HNSW save — partial file rename leaves inconsistent index on mid-loop failure
+- **Difficulty:** medium
+- **Location:** src/hnsw/persist.rs:241-272
+- **Description:** `HnswIndex::save()` renames files from the temp directory to the final location in a sequential loop over `["hnsw.graph", "hnsw.data", "hnsw.ids", "hnsw.checksum"]`. If the rename succeeds for `hnsw.graph` and `hnsw.data` but fails for `hnsw.ids` (e.g., disk full, permissions), the method returns `Err` but the final directory now contains new graph+data files with the old (or missing) id map. The checksum file is renamed last, so a crash before that step means `load()` will fail checksum verification — which is the intended safety net. However, the specific failure mode where rename #3 (`hnsw.ids`) fails but #1 and #2 succeeded leaves new graph+data alongside the old id map from a previous save. On next `load()`, checksums from the old checksum file won't match the new graph/data, so load fails. But the old id map is now permanently desynchronized — a subsequent successful save would need to happen to recover. The recovery path works (next `cqs index` rebuilds everything), but the intermediate state is confusing and could mislead debugging.
+- **Suggested fix:** Rename files in reverse dependency order: checksum last (already done), but also track which renames succeeded. On failure mid-loop, attempt to roll back already-renamed files by renaming them back from final to temp. If rollback also fails, log a warning with explicit recovery instructions ("run `cqs index --force`").
+
+#### DS-2: `acquire_index_lock` — truncate(true) races with concurrent read of PID
+- **Difficulty:** easy
+- **Location:** src/cli/files.rs:57, 99, 104
+- **Description:** Both `acquire_index_lock` and `try_acquire_index_lock` open the lock file with `.truncate(true)` before calling `try_lock()`. If process A holds the lock and process B opens with `truncate(true)`, B truncates the lock file's content (clearing A's PID) before attempting the lock. The `try_lock()` call will fail (A still holds the OS lock), but A's PID is now gone from the file. If A crashes while the file is truncated, the stale lock detection in `acquire_index_lock` reads an empty file, fails to parse a PID (`content.trim().parse::<u32>()` fails on empty string), and falls through to the "lock held" error without cleaning up the stale lock. The user gets "Another cqs process is indexing" with no way to detect the stale state. Next attempt also fails because `retried` is only set when a PID is found and the process is dead.
+- **Suggested fix:** Open without `.truncate(true)`. Only write the PID after successfully acquiring the lock. This prevents any process from clearing another's PID metadata.
+
+#### DS-3: `extract_relationships` not atomic with chunk upserts — crash between pipeline and relationships leaves index with chunks but no call graph
+- **Difficulty:** easy
+- **Location:** src/cli/commands/index.rs:120-133
+- **Description:** `cmd_index` runs the pipeline (which upserts chunks+calls per file via `upsert_chunks_and_calls`), then separately calls `extract_relationships()` which overwrites the call graph with `upsert_function_calls` (per file, each in its own transaction). The pipeline's chunk-level `calls` table and the relationship-level `function_calls` table are updated at different times. If `cqs index` is interrupted (Ctrl+C) between the pipeline completing and `extract_relationships` finishing, the `function_calls` table contains stale data from the previous index run. Queries using `function_calls` (blame, callers with line-level precision) return stale call sites that don't match current chunk content. The `calls` table (chunk-level) is correct since the pipeline updates it atomically with chunks, but `function_calls` (line-level) is stale. No staleness indicator exists for this case.
+- **Suggested fix:** Add a metadata flag (`"relationships_stale" = "true"`) set before `extract_relationships` starts and cleared after it finishes. Commands using `function_calls` (blame, callers with context) can check this flag and warn. Alternatively, clear `function_calls` at the start of pipeline (before chunks are written) so stale data is never returned — only "no data" during the window.
+
+#### DS-4: `prune_stale_calls` and `prune_stale_type_edges` execute outside GC's index lock scope after chunk pruning
+- **Difficulty:** easy
+- **Location:** src/cli/commands/gc.rs:44-59
+- **Description:** `cmd_gc` acquires the index lock at line 23, then runs `prune_missing` (chunks), `prune_stale_calls`, and `prune_stale_type_edges` sequentially. Each operates in its own transaction. Between `prune_missing` (which deletes chunks) and `prune_stale_calls` (which deletes orphan call entries), a concurrent `cqs watch` process could insert new function_calls referencing chunks that were just pruned. The watch process checks `try_acquire_index_lock` and skips if locked — so normally this doesn't happen. But on WSL where advisory locking is unreliable (documented in PB-4), watch mode could proceed with a reindex cycle that inserts new rows into `function_calls` for a file that GC just pruned, creating orphan call entries. Self-heals on next GC run, but the window exists.
+- **Suggested fix:** Wrap all three prune operations in a single transaction. `prune_missing` already uses a transaction internally, so either: (a) expose a `prune_all()` that combines all three in one tx, or (b) accept the self-healing property and document the WSL advisory locking limitation as the root cause (not this code).
+
+#### DS-5: `notes_summaries_cache` invalidation is caller-responsibility — easy to miss on new mutation paths
+- **Difficulty:** easy
+- **Location:** src/store/mod.rs:746-754, src/store/notes.rs:122,224
+- **Description:** The `notes_summaries_cache` (RwLock<Option<Vec<NoteSummary>>>) is manually invalidated via `self.invalidate_notes_cache()` after note mutations. Currently called at two sites: `upsert_notes_batch` (line 122) and `replace_notes_for_file` (line 224). If a future mutation path is added to notes (e.g., `delete_note_by_id`, `update_note_sentiment`) without calling `invalidate_notes_cache()`, the cache returns stale data. The pattern is fragile because: (1) the cache lives on `Store` not `notes.rs`, so the relationship is non-local, (2) there's no compile-time enforcement. Prior audit DS-3 (v0.19.2) fixed `OnceLock` → `RwLock` for cache invalidation, but the caller-responsibility pattern remains.
+- **Suggested fix:** Add a `/// IMPORTANT: Call `invalidate_notes_cache()` after any note mutation` doc comment on the `notes_summaries_cache` field. Or, make all note mutations go through a single `fn mutate_notes(&self, f: impl FnOnce(&mut Transaction)) -> Result<()>` that automatically invalidates the cache post-commit.
+
+#### DS-6: `bytes_to_embedding` and `embedding_slice` silently skip corrupted embeddings — no aggregate corruption signal
+- **Difficulty:** easy
+- **Location:** src/store/helpers.rs:696-706, 714-725
+- **Description:** `bytes_to_embedding` and `embedding_slice` return `None` when the byte length doesn't match expected dimensions, with only `tracing::trace!` logging. Callers use `.filter_map()` to silently skip these entries. In `search_notes` (notes.rs:163), `note_embeddings` (notes.rs:338), and multiple search paths, corrupted embeddings are individually skipped with no aggregation. If a schema migration or embedder bug produces widespread dimension mismatches, the user sees degraded search quality (fewer results, missing notes) with no visible error. The per-entry trace-level logging requires `RUST_LOG=trace` to see, and even then doesn't aggregate (100 skips = 100 individual trace lines, no summary).
+- **Suggested fix:** Add a counter to search paths that tracks skipped-due-to-dimension-mismatch entries. If the count exceeds a threshold (e.g., >5% of scanned entries), emit a `tracing::warn!` with the count and a "run `cqs index --force` to re-embed" suggestion. This surfaces systematic corruption without impacting the common case (zero skips).
+
+## Resource Management
+
+#### RM-1: `chm_to_markdown` and `webhelp_to_markdown` accumulate all page content in memory then `join()` — peak is 2× output size
+- **Difficulty:** easy
+- **Location:** src/convert/chm.rs:119-157, src/convert/webhelp.rs:93-128
+- **Description:** Both converters collect all converted Markdown pages into a `Vec<String>` (`all_markdown`) and then call `.join("\n\n---\n\n")`. The `join` call allocates a new contiguous string equal to the total of all pages, while the `Vec<String>` holding the original pages is still alive. Peak memory = `all_markdown` Vec + `merged` String ≈ 2× output size. With `MAX_PAGES = 1000` pages and typical API reference pages converting to 50–150 KB each, average peak is ~100–300 MB; worst case with dense HTML is ~500 MB + 500 MB = ~1 GB before `all_markdown` is dropped. There is no guard on cumulative output size — only a page count guard (`MAX_PAGES = 1000`). A single 100 MB HTML page would produce a 100 MB string and pass the page-count check.
+- **Suggested fix:** Two independent fixes: (1) Add a cumulative byte guard: after `all_markdown.push(md)`, check `all_markdown.iter().map(|s| s.len()).sum::<usize>() > MAX_TOTAL_BYTES` (e.g., 200 MB) and `break` with a warning. (2) Write to a `String` with `push_str` instead of collecting into a Vec then joining, so only one copy exists at a time. Example: `let mut merged = String::new(); for md in all_markdown { if !merged.is_empty() { merged.push_str("\n\n---\n\n"); } merged.push_str(&md); }`.
+
+#### RM-2: `html_file_to_markdown` and `markdown_passthrough` load entire file into memory with no size guard
+- **Difficulty:** easy
+- **Location:** src/convert/html.rs:32, src/convert/mod.rs:113
+- **Description:** `html_file_to_markdown` reads the entire HTML file into a `String` with `std::fs::read_to_string(path)`, then passes it to `html_to_markdown`. `markdown_passthrough` does the same. Neither checks file size before reading. A 500 MB HTML file would allocate a 500 MB `String`, and after conversion the original string and the Markdown output both exist simultaneously in memory. The CHM and Web Help converters guard against page count but not per-page size — individual pages can be arbitrarily large. The `run_git_diff` finding (SEC-6) already identifies the same pattern for git output.
+- **Suggested fix:** Check `path.metadata()?.len()` before reading. If greater than a configurable limit (e.g., 100 MB), bail with a descriptive error: `"File too large to convert ({}MB > 100MB limit): {}"`. Match the limit used for the git diff guard in SEC-6.
+
+#### RM-3: `BatchContext::refs` — loaded reference indexes accumulate for the session lifetime with no eviction
+- **Difficulty:** easy
+- **Location:** src/cli/batch/mod.rs:60, 139-168
+- **Description:** `BatchContext::refs` is a `RefCell<HashMap<String, ReferenceIndex>>` that is populated on first access via `get_ref()` and never evicted. Each `ReferenceIndex` holds a full `Store` (SQLite pool with up to 1 read-only connection at 64 MB mmap + 4 MB cache) and an optional `HnswIndex` (loaded HNSW graph for the reference). A batch session referencing all configured references accumulates all of them simultaneously. With 5 references of 100k chunks each, each HNSW graph is ~300 MB; 5 loaded simultaneously = ~1.5 GB HNSW + 5 × 68 MB SQLite = ~1.9 GB. The RM-16 fix (PR #502) correctly limits to loading only the target reference per `get_ref` call, but all previously loaded references remain in memory for the full session.
+- **Suggested fix:** This is largely acceptable as-is — references are loaded on demand and the common case is 1-2 references. Add a tracing note at load time: `tracing::info!(name, total_loaded = refs.len(), "Reference loaded; {} references in memory", refs.len())` so users can see accumulation in traces. If eviction is needed, switch to an LRU map bounded at N references.
+
+#### RM-4: Pipeline `PIPELINE_CHANNEL_DEPTH = 256` uses the same depth for both `ParsedBatch` (chunks only) and `EmbeddedBatch` (chunks + embeddings) — embed channel can hold ~40 MB
+- **Difficulty:** easy
+- **Location:** src/cli/pipeline.rs:37, 652-657
+- **Description:** All three pipeline channels (`parse_tx/rx`, `embed_tx/rx`, `fail_tx/rx`) use `bounded(PIPELINE_CHANNEL_DEPTH)` with depth 256. `ParsedBatch` holds chunks with content strings — roughly 15 MB at full depth. `EmbeddedBatch` also holds chunk content *plus* 769-dim f32 embeddings (~3 KB each) — roughly 40 MB at full depth. If the writer (SQLite insert) stalls (e.g., fsync, WAL checkpoint), backpressure fills the embed channel before the parse channel, holding ~40 MB of embedded but unwritten chunks. This is bounded and not catastrophic, but using a single depth constant for payloads that differ 2.6× in size is suboptimal. The constant's comment says "Files to parse per batch (bounded memory)" which applies to `FILE_BATCH_SIZE`, not `PIPELINE_CHANNEL_DEPTH`.
+- **Suggested fix:** Use separate depth constants: `const PARSE_CHANNEL_DEPTH: usize = 256` (lightweight) and `const EMBED_CHANNEL_DEPTH: usize = 64` (heavy payloads). The embed channel at depth 64 would hold ~10 MB — more proportionate to the payload difference. Also fix the misleading comment on line 36 which describes `FILE_BATCH_SIZE`, not `PIPELINE_CHANNEL_DEPTH`.
+
+#### RM-5: Watch mode `last_indexed_mtime` grows to cover all indexed files and is only pruned on successful reindex — deleted-file cleanup depends on expensive `root.join(f).exists()` per entry
+- **Difficulty:** easy
+- **Location:** src/cli/watch.rs:117, 307-311
+- **Description:** `last_indexed_mtime: HashMap<PathBuf, SystemTime>` accumulates an entry for every file ever indexed in the watch session. The `retain(|f, _| root.join(f).exists())` call (line 311) prunes deleted files, but only runs in the success branch of `reindex_files`. If reindexing fails (e.g., embedder error), the prune is skipped — deleted files stay in the map indefinitely. On a large project with 50k source files, the map holds 50k `PathBuf`+`SystemTime` pairs (~50k × ~100 bytes ≈ 5 MB), which is tolerable. The `exists()` check on every entry on every reindex cycle is O(file_count) filesystem calls. For 50k files that's 50k `stat()` calls per reindex event, which adds latency to otherwise fast incremental reindexes. The `retain` runs every cycle regardless of how many files changed.
+- **Suggested fix:** Move the `retain` outside the `Ok` branch — run it after every reindex attempt (success or failure). For the `exists()` cost, consider only pruning when a delete event is detected: add `pending_deletes: HashSet<PathBuf>` alongside `pending_files`, and in `collect_events` when a `Remove` event fires, add to `pending_deletes`. Then in `process_file_changes`, only call `last_indexed_mtime.remove()` for the deleted entries rather than scanning all.
+
+#### DS-7: `cmd_index --force` removes old database before creating the new one — interruption loses entire index
+- **Difficulty:** easy
+- **Location:** src/cli/commands/index.rs:69-76
+- **Description:** When `--force` is passed, `cmd_index` removes the existing `index.db` at line 71, then opens a new empty store at line 73 and calls `init()`. If the process is killed between the `remove_file` and the completion of `run_index_pipeline`, the user has no index at all — neither old nor new. For a large codebase, the pipeline can take minutes, so this window is significant. The HNSW save uses temp-dir-then-rename for crash safety, but the SQLite database itself gets no such protection.
+- **Suggested fix:** Instead of removing the old index first, build the new index to a temp path (e.g., `index.db.new`), then atomically rename over the old one after the pipeline completes successfully. If interrupted, the old index remains intact. This is the same pattern used for HNSW save and note file rewrites.
+
+
+## Performance
+
+#### PF-1: `search_by_candidate_ids` parses language/chunk_type strings to enums per candidate when filters are active
+- **Difficulty:** easy
+- **Location:** src/search.rs:884-905
+- **Description:** In the HNSW-guided search path (`search_by_candidate_ids`), when `filter.languages` or `filter.chunk_types` is set, the scoring loop calls `candidate.language.parse::<Language>()` and `candidate.chunk_type.parse::<ChunkType>()` for every candidate (up to 500). Parsing enum from a string on every iteration is O(candidates) string comparisons plus allocation for the parse error path. Since the filter sets are fixed before the loop, a pre-built `HashSet<&str>` (or even `HashSet<String>`) of the allowed language/type string representations would reduce this to a single hash lookup per candidate, and avoids the parse entirely.
+- **Suggested fix:** Before the loop, compute `let lang_strs: Option<HashSet<String>> = filter.languages.as_ref().map(|ls| ls.iter().map(|l| l.to_string()).collect())` and similarly for chunk_types. Inside the loop, replace `candidate.language.parse()` + `langs.contains(&lang)` with `!lang_strs.contains(&candidate.language)`.
+
+#### PF-2: `search_filtered` clones all semantic IDs to `Vec<String>` solely to pass to `rrf_fuse`
+- **Difficulty:** easy
+- **Location:** src/search.rs:757, src/store/mod.rs:661
+- **Description:** After the brute-force scoring loop, `scored: Vec<(String, f32)>` contains the top embedding-scored candidates. When RRF is enabled, line 757 creates `semantic_ids: Vec<String>` by cloning every ID string from `scored`, then passes it to `rrf_fuse(&semantic_ids, ...)`. Inside `rrf_fuse`, these Strings are immediately borrowed as `&str` for the HashMap (line 670). After the call, the cloned `semantic_ids` Vec is dropped. For a typical `semantic_limit` of 30-60 results, this is 30-60 unnecessary String heap allocations per search. `rrf_fuse` signature could accept `&[(String, f32)]` (the scored Vec directly) and extract IDs as `id.as_str()` internally, or take `impl IntoIterator<Item = &str>`.
+- **Suggested fix:** Change `rrf_fuse` to accept `semantic_ids: &[(String, f32)]` and let it iterate `semantic_ids.iter().map(|(id, _)| id.as_str())` internally. Remove the intermediate `Vec<String>` at line 757. Same pattern applies to `search_by_candidate_ids` line 943.
+
+#### PF-3: `search_by_name` re-lowercases the query string for every result in the post-fetch scoring loop
+- **Difficulty:** easy
+- **Location:** src/store/mod.rs:646
+- **Description:** `search_by_name` fetches FTS-matched chunks then rescores each with `score_name_match(&chunk.name, name)`. Inside `score_name_match`, `name.to_lowercase()` is called on every invocation — it allocates a new `String` each time. For a limit-20 name lookup (the default from `resolve_target`), this means 20 identical `to_lowercase()` allocations for the same query string. `score_name_match_pre_lower` already exists for exactly this pattern (pre-lowercased strings, inline doc says "use when calling in a loop").
+- **Suggested fix:** Before the result iterator, compute `let name_lower = name.to_lowercase();` and call `score_name_match_pre_lower(&chunk.name.to_lowercase(), &name_lower)` (or pre-lower `chunk.name` too). The `score_name_match_pre_lower` function is at `src/store/helpers.rs:648`.
+
+#### PF-4: `score_confidence` clones all candidate IDs to a separate `Vec<String>` before chunking
+- **Difficulty:** easy
+- **Location:** src/store/calls.rs:881
+- **Description:** `score_confidence` takes `candidates: Vec<LightChunk>` and immediately creates `candidate_ids: Vec<String>` by cloning `c.id` for every element. This Vec is used only for `candidate_ids.chunks(BATCH_SIZE)` in the SQL batch loop. For large codebases with many dead-code candidates (hundreds to thousands), this is an O(N) string clone with the only purpose being that the `.chunks()` slice iterator works. The original `candidates` Vec has the same length and can be chunked directly.
+- **Suggested fix:** Replace `candidate_ids.chunks(BATCH_SIZE)` with `candidates.chunks(BATCH_SIZE)`, extracting IDs inline: `for id in batch { q = q.bind(&id.id); }`. This eliminates the ID clone Vec entirely.
+
+#### PF-5: `fetch_active_files` uses `IN (subquery)` where a JOIN is more efficient
+- **Difficulty:** easy
+- **Location:** src/store/calls.rs:841-843
+- **Description:** `fetch_active_files` runs `WHERE c.name IN (SELECT DISTINCT callee_name FROM function_calls)` to find files containing called functions. SQLite must first materialize the inner SELECT (all distinct callee_names) then check each chunk name against that set. With an index on `function_calls.callee_name` and `chunks.name`, a JOIN is equivalent and SQLite's query planner typically handles it more efficiently: `JOIN function_calls fc ON c.name = fc.callee_name`. The `DISTINCT` on callee_name in the subquery also forces a sort/dedup step that a `SELECT DISTINCT c.origin` with JOIN avoids.
+- **Suggested fix:** Replace the correlated subquery with a direct JOIN: `SELECT DISTINCT c.origin FROM chunks c JOIN function_calls fc ON c.name = fc.callee_name`. SQLite's query planner can use `idx_fcalls_callee` (on `callee_name`) and `idx_chunks_name` (on `name`) for a nested-loop join.
+
+#### PF-6: `build_batched` makes two passes over each batch — separate validation loop then data collection
+- **Difficulty:** easy
+- **Location:** src/hnsw/build.rs:140-157
+- **Description:** For each batch, the code first iterates all `(id, emb)` pairs to validate dimensions and emit `tracing::trace!` per item (lines 140-148), then immediately iterates the same batch again to build `data_for_insert` (lines 155-157). With 10K-row batches (the production default), this is 20K iterations per batch when a single combined loop would do 10K. The trace log is at `trace` level so it's typically inactive in production, making the first loop almost entirely wasted work.
+- **Suggested fix:** Combine the validation and collection into one loop. Move dimension checking inside the collection loop: validate `emb.len()` before pushing to `data_for_insert`. Move `tracing::trace!("Adding {} to HNSW index", id)` inside the combined loop too. This halves the iteration count per batch.

--- a/docs/audit-findings.md
+++ b/docs/audit-findings.md
@@ -1,519 +1,415 @@
-# Audit Findings — v0.19.4+
-
-Audit started 2026-03-02. Covers all code on main after PF-5 (#515).
-
-## Observability
-
-#### OB-1: `resolve_target` — public entry point has no tracing span
-- **Difficulty:** easy
-- **Location:** src/search.rs:57
-- **Description:** `resolve_target()` is the shared entry point used by `blame`, `explain`, `similar`, `callers`, `callees`, `deps`, `trace`, and `test-map`. It calls `store.search_by_name()` and applies file filtering. No span means failures (name not found, ambiguous file filter) are invisible in traces — you only see the outer command span with no insight into why lookup failed or how long it took.
-- **Suggested fix:** Add `let _span = tracing::info_span!("resolve_target", target).entered();` at the top of the function.
-
-#### OB-2: `delete_by_origin` and `replace_file_chunks` — no tracing spans on mutation operations
-- **Difficulty:** easy
-- **Location:** src/store/chunks.rs:194, 222
-- **Description:** `delete_by_origin()` deletes all chunks for a file path. `replace_file_chunks()` atomically replaces them. Both are called from the index pipeline and watch mode. Neither has a tracing span, so bulk delete/replace operations are invisible in traces. When a pipeline run is slow, there's no way to distinguish indexing latency from deletion latency.
-- **Suggested fix:** Add `info_span!("delete_by_origin", origin = %origin.display())` and `info_span!("replace_file_chunks", origin = %origin.display(), chunks = chunks.len())`.
-
-#### OB-3: `search_filtered` exits without logging result count
-- **Difficulty:** easy
-- **Location:** src/search.rs:793-795
-- **Description:** `search_filtered()` has an entry span but never logs how many results it returns. The span captures `limit` and `rrf` at entry but a caller observing a trace has no way to know whether the search returned 0, 5, or 20 results without reading the span's return value separately. This matters when debugging "why did gather find nothing?" — the seed search returning 0 vs the BFS finding nothing are different problems.
-- **Suggested fix:** Add `tracing::debug!(results = results.len(), "search_filtered complete");` before `Ok(results)` at line 795.
-
-#### OB-4: `Store::init` — schema initialization has no span
-- **Difficulty:** easy
-- **Location:** src/store/mod.rs:355
-- **Description:** `Store::init()` creates all tables, inserts metadata, and sets schema version. Called on every `cqs index` run on a fresh database. No span means a slow init (e.g., large schema, pragma tuning) is invisible. Also missing: no log of which schema version was initialized.
-- **Suggested fix:** Add `let _span = tracing::info_span!("store_init").entered();` and `tracing::info!(schema_version = CURRENT_SCHEMA_VERSION, "Store initialized");` after the commit.
-
-#### OB-5: `warn_stale_results` — missing entry span
-- **Difficulty:** easy
-- **Location:** src/cli/staleness.rs:19
-- **Description:** `warn_stale_results()` is called after every query command to check if result files changed since last index. It calls `store.check_origins_stale()` which can be non-trivial for large result sets. No span means staleness check latency is hidden in parent command spans. The function already has a `tracing::info!` call inside (line 24) but no enclosing span to correlate it with the originating command.
-- **Suggested fix:** Add `let _span = tracing::info_span!("warn_stale_results", origins = origins.len()).entered();` at the top.
-
-#### OB-6: `cmd_watch` — no entry span
-- **Difficulty:** easy
-- **Location:** src/cli/watch.rs:54
-- **Description:** `cmd_watch()` is the main watch loop. It has various `tracing::warn!` calls inside but no entry span. Watch mode can run for hours — without a span, there's no parent context to correlate reindex events or WSL inotify warnings back to a session.
-- **Suggested fix:** Add `let _span = tracing::info_span!("cmd_watch", debounce_ms).entered();` at the top of `cmd_watch`.
-
-#### OB-7: `get_caller_counts_batch` / `get_callee_counts_batch` — no spans on batch count queries
-- **Difficulty:** easy
-- **Location:** src/store/calls.rs:1147, 1163
-- **Description:** Both batch count functions delegate through `batch_count_query()` with no span. These are called by `find_dead_code` to identify functions with zero callers. When dead code analysis is slow (common on large indexes with `NOT IN` subqueries), there's no way to attribute latency to the counting phase vs. the filtering phase.
-- **Suggested fix:** Add spans: `tracing::info_span!("get_caller_counts_batch", count = names.len())` and `tracing::info_span!("get_callee_counts_batch", count = names.len())`.
-
-## API Design
-
-#### AD-1: BatchCmd::Gather `direction` is stringly-typed — should use GatherDirection enum
-- **Difficulty:** easy
-- **Location:** src/cli/batch/commands.rs:109, src/cli/batch/handlers.rs:349
-- **Description:** The CLI's `Gather` command uses `GatherDirection` as a typed `ValueEnum` (fixed in prior audit AD-1, PR #501), but `BatchCmd::Gather` still declares `direction: String`. The handler (`dispatch_gather`) manually parses it with `.parse().map_err(...)` on line 361. This means batch mode gets no clap validation — invalid directions produce a runtime error instead of a parse-time error.
-- **Suggested fix:** Change `BatchCmd::Gather` to use `GatherDirection` directly (it already has `FromStr` and could derive `ValueEnum`). Update `dispatch_gather` signature to accept `GatherDirection` instead of `&str`.
-
-#### AD-2: `get_callers()` is dead public API — zero callers
-- **Difficulty:** easy
-- **Location:** src/store/calls.rs:252
-- **Description:** `Store::get_callers()` returns `Vec<ChunkSummary>` from the chunks table. All production code uses `get_callers_full()` (returns `CallerInfo` from function_calls table) or `get_callers_with_context()` instead. The method has zero call sites outside its own doc comment. Dead public API surface that could confuse callers about which method to use.
-- **Suggested fix:** Remove `get_callers()`. If the chunk-level caller lookup is needed in the future, it can be re-added.
-
-#### AD-3: Core store types lack `Serialize` — manual `to_json()` everywhere
-- **Difficulty:** medium
-- **Location:** src/store/helpers.rs:128 (ChunkSummary), :192 (SearchResult), :243 (CallerInfo), :317 (NoteSummary), :330 (NoteSearchResult)
-- **Description:** The five most-used public types in the store API all lack `#[derive(Serialize)]`. Instead, they have manual `to_json()` / `to_json_relative()` methods using `serde_json::json!()` macros. This forces every consumer (CLI commands, batch handlers, `ChunkOutput` batch type) to either call these manual methods or re-serialize fields by hand. The prior audit (AD-6, PR #502) added Serialize to higher-level types (`ScoutResult`, `TaskResult`, `GatherResult`, etc.) but left these foundational types untouched.
-- **Suggested fix:** Add `#[derive(serde::Serialize)]` to `ChunkSummary`, `SearchResult`, `CallerInfo`, `NoteSummary`, `NoteSearchResult`. For `ChunkSummary::file` (PathBuf), use `#[serde(serialize_with = "crate::serialize_path_normalized")]` which already exists. The manual `to_json()` methods can remain as convenience wrappers or be deprecated.
-
-#### AD-4: `BlameEntry` and `BlameData` use manual JSON assembly
-- **Difficulty:** easy
-- **Location:** src/cli/commands/blame.rs:18,26,155
-- **Description:** `BlameEntry` and `BlameData` lack `Serialize` derive. `blame_to_json()` manually constructs JSON with `serde_json::json!()` for each field. This is the same pattern fixed in prior audits for other result types (AD-6/CQ-6).
-- **Suggested fix:** Add `#[derive(serde::Serialize)]` to `BlameEntry` and `BlameData`. Replace `blame_to_json()` with direct serialization. `BlameData.chunk` is `ChunkSummary` which would need Serialize first (see AD-3).
-
-#### AD-5: `dispatch_search` takes 9 individual parameters instead of a struct
-- **Difficulty:** medium
-- **Location:** src/cli/batch/handlers.rs:33-42
-- **Description:** `dispatch_search(ctx, query, limit, name_only, semantic_only, rerank, lang, path, tokens)` takes 9 parameters. The CLI side avoids this by passing the `Cli` struct which bundles all search options. Batch mode destructures `BatchCmd::Search` into 8 individual args then passes them through. This makes the handler signature fragile — adding a search option requires touching 3 call sites (BatchCmd fields, dispatch match arm, handler signature).
-- **Suggested fix:** Extract a `BatchSearchOptions` struct or pass the `BatchCmd::Search` variant directly to the handler, destructuring inside.
-
-#### AD-6: 9 CLI command handlers accept unused `_cli: &Cli` parameter
-- **Difficulty:** easy
-- **Location:** src/cli/commands/blame.rs:245, where_cmd.rs:8, test_map.rs:9, task.rs:19, scout.rs:9, related.rs:24, impact_diff.rs:18, onboard.rs:9, convert.rs:10
-- **Description:** These handlers accept `_cli: &Cli` but never read any field from it. This was reported in the prior audit (AD-5, PR #504, marked fixed) but 9 instances remain — either the fix regressed or new commands were added without removing the parameter. Unused parameters obscure the actual data dependencies and make signatures wider than needed.
-- **Suggested fix:** Remove the `_cli` parameter from these 9 handlers and update their call sites in `run_with()`.
-
-## Error Handling
-
-#### EH-1: `build_blame_data` discards StoreError chain via `.map_err(|e| anyhow::anyhow!("{}", e))`
-- **Difficulty:** easy
-- **Location:** src/cli/commands/blame.rs:46
-- **Description:** `resolve_target()` returns `Result<ResolvedTarget, StoreError>`. The blame handler converts the error via `.map_err(|e| anyhow::anyhow!("{}", e))`, which stringifies through `Display` and loses the full error chain. If the underlying cause is `StoreError::Database(sqlx::Error::...)`, the inner sqlx source chain is flattened to a single string. Since `StoreError` implements `std::error::Error` with proper `#[from]` chains, `?` alone would preserve the chain (anyhow auto-converts via `From`).
-- **Suggested fix:** Replace `.map_err(|e| anyhow::anyhow!("{}", e)).context("Failed to resolve blame target")` with just `.context("Failed to resolve blame target")?`. The `?` operator on `Result<_, StoreError>` auto-converts to `anyhow::Error` preserving the error source chain.
-
-#### EH-2: 7 bare `Store::open()` calls without path context in CLI commands
-- **Difficulty:** easy
-- **Location:** src/cli/commands/diff.rs:32, drift.rs:31, index.rs:66, index.rs:73, reference.rs:134, reference.rs:314, cli/watch.rs:113
-- **Description:** These `Store::open(&path)?` calls use bare `?` without `.context()` or `.with_context()`. When the store fails to open (e.g., corrupted DB, permission denied, locked), the error says "Database error: ..." without identifying which path failed. The prior audit EH-5 (PR #499) swept 10 CLI command files, and EH-4/EH-5 in v0.19.2 (PR #501) fixed 3 more. These survived because diff.rs/drift.rs were refactored after the fix, and index.rs/watch.rs/reference.rs open stores in contexts where the path was just computed but is still absent from the error.
-- **Suggested fix:** Add `.with_context(|| format!("Failed to open store at {}", path.display()))` to each site. The `open_project_store()` helper and `resolve_reference_store()` already do this correctly.
-
-#### EH-3: `SearchFilter::validate()` returns `Result<(), &'static str>` — not a proper error type
-- **Difficulty:** easy
-- **Location:** src/store/helpers.rs:513
-- **Description:** `SearchFilter::validate()` returns `Result<(), &'static str>` where the error is a plain string. Callers must convert with `.map_err(|e| anyhow::anyhow!(e))` (query.rs:96). This bypasses the project's `thiserror`-based error hierarchy. The method checks 4 conditions (name_boost range, note_weight range, contradictory note_only, missing query_text) but returns the same opaque type for all. Callers cannot distinguish or match on specific validation failures.
-- **Suggested fix:** Change the return type to `Result<(), StoreError>` using `StoreError::Runtime(msg.to_string())` for each check. Callers in query.rs and batch handlers would then use plain `?`.
-
-#### EH-4: `dispatch_onboard` swallows `get_chunks_by_names_batch` error with fallback to empty HashMap
-- **Difficulty:** easy
-- **Location:** src/cli/batch/handlers.rs:912-918
-- **Description:** In `dispatch_onboard`, when `get_chunks_by_names_batch()` fails, the error is logged via `tracing::warn!` and an empty `HashMap` is returned as fallback. This is the token-packing branch (`Some(budget)`) — returning empty content means the onboard command silently produces an incomplete result with no content for any entry. The `gather` command has a similar degradation pattern but signals it via `"search_degraded": true` in the JSON output. The onboard handler does neither — it silently drops content without any signal to the caller.
-- **Suggested fix:** Either propagate the error with `?` (since empty content defeats the purpose of token packing), or add a `"degraded": true` field to the JSON output like `gather` does.
-
-#### EH-5: `GatherDirection::FromStr` uses `String` error type — inconsistent with project conventions
-- **Difficulty:** easy
-- **Location:** src/gather.rs:97
-- **Description:** `GatherDirection`'s `FromStr` impl uses `type Err = String`. This is the only `FromStr` impl in the codebase that returns `String` — all `ChunkType` and `Language` `FromStr` impls return proper typed errors. The batch handler must do `.parse::<GatherDirection>().map_err(|e: String| anyhow::anyhow!("{e}"))` to convert. This is moot if AD-1 (make BatchCmd::Gather accept `GatherDirection` directly) is fixed.
-- **Suggested fix:** Fix AD-1 first (use `GatherDirection` as clap `ValueEnum` in `BatchCmd`). If `FromStr` is still needed, change `Err` to a proper error type.
-
-#### EH-6: `schema_version` in `IndexStats` silently defaults to 0 on parse failure
-- **Difficulty:** easy
-- **Location:** src/store/chunks.rs:873-876
-- **Description:** When loading `IndexStats`, the schema_version is parsed from a string metadata value via `.and_then(|s| s.parse().ok()).unwrap_or(0)`. If the stored value is non-numeric (e.g., corrupted), this silently returns schema version 0 with no log. A corrupt schema_version could cause downstream code to behave as if the index is unversioned. Other metadata fields (model_name, created_at) default to empty strings on missing, which is correct, but version 0 is actively misleading.
-- **Suggested fix:** Log a `tracing::warn!` when `.parse()` fails (i.e., when the value exists but is non-numeric): `Err(e) => { tracing::warn!(value = %s, error = %e, "Non-numeric schema_version"); 0 }`.
-
-## Documentation
-
-#### DOC-1: `source/` listed in CONTRIBUTING.md architecture but module is entirely dead
-- **Difficulty:** easy
-- **Location:** CONTRIBUTING.md:109-111
-- **Description:** CONTRIBUTING.md documents `source/` as "Source abstraction layer (reserved — not yet wired into indexing pipeline)" and lists `filesystem.rs` as an active file. The module is declared in `lib.rs:81` as `pub(crate) mod source` but has zero callers — `use crate::source` and `source::` appear nowhere outside the module itself. The prior audit (v0.19.2 DOC-7, PR #501) noted CONTRIBUTING.md listed it as active but only updated the description to "reserved"; neither the module nor the CONTRIBUTING entry was removed. This mismatch causes confusion about whether `source/` is a development direction or dead scaffolding.
-- **Suggested fix:** Remove `src/source/` directory entirely (2 files, ~250 lines), remove `pub(crate) mod source;` from `lib.rs`, and remove the `source/` entry from CONTRIBUTING.md's architecture section. (Duplicate of CQ-1 in this audit — fix code, then update CONTRIBUTING.md.)
-
-#### DOC-2: PRIVACY.md deletion instructions miss `~/.config/cqs/config.toml`
-- **Difficulty:** easy
-- **Location:** PRIVACY.md:46-51
-- **Description:** The "Deleting Your Data" section lists 6 paths to delete. It includes `~/.config/cqs/projects.toml` (the project registry) but omits `~/.config/cqs/config.toml` (the user config file at the same path, confirmed by `src/config.rs:4,120`). A user following these instructions to fully remove cqs data would leave behind their configuration.
-- **Suggested fix:** Add `rm -f ~/.config/cqs/config.toml  # User config` to the deletion block. Also change `rm -rf ~/.config/cqs/projects.toml` → `rm -f ~/.config/cqs/projects.toml` (using `-rf` on a file is inconsistent with `-f` used for the other files on lines 49-50).
-
-#### DOC-3: SECURITY.md symlink mitigation description is inaccurate
-- **Difficulty:** easy
-- **Location:** SECURITY.md:94
-- **Description:** SECURITY.md states "Symlinks in extracted archives are skipped" under the convert module mitigations. The actual implementation skips symlinks during **all directory walks** — both CHM-extracted archives (`src/convert/chm.rs:91`) and regular directory traversal (`src/convert/mod.rs:347`) and web help directories (`src/convert/webhelp.rs:60`). The phrase "in extracted archives" implies the protection only applies to CHM/archive extraction, underselling its actual scope.
-- **Suggested fix:** Change "Symlinks in extracted archives are skipped" → "Symlinks are skipped in all directory walks (file input, CHM extraction, web help traversal)".
-
-#### DOC-4: lib.rs doc comment omits Web Help format from convert feature description
-- **Difficulty:** easy
-- **Location:** src/lib.rs:13
-- **Description:** The crate-level doc says `- **Document conversion**: PDF, HTML, CHM → cleaned Markdown (optional `convert` feature)`. The convert module also handles Web Help sites (multi-page HTML sites with a structured nav, detected by `src/convert/webhelp.rs`). Web Help is distinct enough from generic HTML to have its own dedicated module and is listed in the README's supported formats table. The lib.rs doc is the first thing library users see and it understates the format support.
-- **Suggested fix:** Change to `PDF, HTML, CHM, Web Help → cleaned Markdown`.
-
-#### DOC-5: `cqs dead --min-confidence` undocumented in README and CLAUDE.md
-- **Difficulty:** easy
-- **Location:** README.md:243-246, CLAUDE.md:71
-- **Description:** `cqs dead --help` shows three options: `--json`, `--include-pub`, and `--min-confidence <MIN_CONFIDENCE>` (values: low, medium, high; default: low). README documents `--json` and `--include-pub` but not `--min-confidence`. CLAUDE.md only says `cqs dead — find dead code: functions/methods with no callers in the index` with no options listed. The `--min-confidence` flag is the primary way to reduce false positives in dead code analysis (filtering out low-confidence candidates) and is a meaningful option to document.
-- **Suggested fix:** Add `cqs dead --min-confidence medium  # Filter to medium+ confidence` example to README's Maintenance section. Update CLAUDE.md description to include `--min-confidence`.
+# Audit Findings — v0.26.0
 
 ## Code Quality
 
-#### CQ-1: `source/` module is dead code — never wired into indexing pipeline
+#### `find_content_child` (injection.rs) and `find_child_by_kind` (html.rs) are identical functions in different modules
 - **Difficulty:** easy
-- **Location:** src/source/mod.rs, src/source/filesystem.rs (declared at src/lib.rs:81)
-- **Difficulty:** easy
-- **Description:** The entire `source/` module (~250 lines across 2 files) is dead code. It declares a `Source` trait and `FileSystemSource` implementation but is never used anywhere — `mod source` is declared in `lib.rs` but zero `use crate::source` or `source::` references exist in the codebase. The module header says "Not yet wired into the indexing pipeline — reserved for future use" and has `#![allow(dead_code)]` to suppress warnings. Prior audit DOC-7 (PR #501) noted CONTRIBUTING.md listed it as active, but the module itself was never removed.
-- **Suggested fix:** Delete `src/source/mod.rs` and `src/source/filesystem.rs`, remove `pub(crate) mod source;` from `lib.rs`. If the abstraction is needed later, it can be rebuilt from git history.
+- **Location:** src/parser/injection.rs:174, src/language/html.rs:127
+- **Description:** Both functions do exactly the same thing — iterate direct children of a tree-sitter node and return the first matching a given kind string. Different names, both with `#[allow(clippy::manual_find)]`, but structurally identical 10-line bodies. Because `html.rs` is a language definition module rather than a parser module, it can't import from `injection.rs` directly with the current structure, but the duplication will drift.
+- **Suggested fix:** Move to `parser/mod.rs` or `parser/types.rs` as `pub(crate) fn find_child_by_kind(node: Node, kind: &str) -> Option<Node>` and have `html.rs` import it via `use crate::parser::find_child_by_kind`.
 
-#### CQ-2: Gather JSON assembly duplicated between CLI command and batch handler
+#### `MAX_FILE_SIZE` and `MAX_CHUNK_BYTES` inline constants defined at multiple sites
 - **Difficulty:** easy
-- **Location:** src/cli/commands/gather.rs:114-145, src/cli/batch/handlers.rs:406-438
-- **Description:** `GatheredChunk` JSON serialization is written out identically in two places: `cmd_gather` (CLI command) and `dispatch_gather` (batch handler). Both construct the same `serde_json::json!()` with identical field lists (name, file, line_start, line_end, language, chunk_type, signature, score, depth, content) and the same conditional `source` field. Meanwhile, `GatheredChunk` already has both a `#[derive(serde::Serialize)]` and a manual `to_json(&self, root)` method — three different serialization paths for the same struct, none of which are used by these two callers.
-- **Suggested fix:** Use `GatheredChunk`'s existing `Serialize` derive or `to_json()` method in both cmd_gather and dispatch_gather. If `normalize_path` is needed (it is), ensure `GatheredChunk.file` is already normalized before serialization, or add a `#[serde(serialize_with = ...)]` attribute.
+- **Location:** src/parser/mod.rs:144, src/parser/mod.rs:203, src/parser/calls.rs:210, src/parser/injection.rs:253
+- **Description:** `MAX_FILE_SIZE` (50 MB) is a local `const` inside both `parse_file` (mod.rs:144) and `parse_file_relationships` (calls.rs:210). `MAX_CHUNK_BYTES` (100,000 bytes) is a local `const` inside `parse_file` (mod.rs:203) and `parse_injected_chunks` (injection.rs:253). Changing either limit requires finding and updating all sites manually with no compiler enforcement.
+- **Suggested fix:** Hoist to module-level `pub(crate) const` at the top of `src/parser/mod.rs` and reference from all four sites.
 
-#### CQ-3: `token_pack_unified` and `token_pack_tagged` are near-identical functions
+#### Capture-name-to-`ChunkType` `match` arm duplicated between `calls.rs` and `injection.rs`, diverges from `chunk.rs`
 - **Difficulty:** easy
-- **Location:** src/cli/commands/query.rs:333-398
-- **Description:** `token_pack_unified()` and `token_pack_tagged()` are structurally identical 30-line functions that differ only in: (1) the input type (`Vec<UnifiedResult>` vs `Vec<TaggedResult>`), (2) how to extract text content (`.match r` vs `.match &r.result`), and (3) how to extract score (same match depth difference). Both call the same `super::token_pack()` generic function and log the same tracing info. The duplication exists because there's no trait to abstract "something that contains a UnifiedResult".
-- **Suggested fix:** Add a trait (e.g., `HasUnifiedResult`) with `fn unified(&self) -> &UnifiedResult` on both `UnifiedResult` (returning `self`) and `TaggedResult` (returning `&self.result`). Then a single generic `token_pack_results<T: HasUnifiedResult>()` replaces both functions.
+- **Location:** src/parser/calls.rs:314-329, src/parser/injection.rs:400-415, src/parser/chunk.rs:18-34
+- **Description:** Three sites in the parser module define the mapping from tree-sitter capture name string to `ChunkType`. `chunk.rs` uses a `&[(&str, ChunkType)]` slice (the authoritative table). `calls.rs` and `injection.rs` each have a hand-written `match` arm. All three already diverge: `chunk.rs` includes `("section", ChunkType::Section)` but neither `calls.rs` nor `injection.rs` has `"section"` in their `matches!` filter or their `match` arm — meaning `@section` captures (used by LaTeX) are filtered out of call/type extraction, and the `_` fallback assigns `ChunkType::Function` instead of `ChunkType::Section`. LaTeX is not currently an injection target so there's no user-visible bug today, but the divergence will cause a latent bug when a future host language injects LaTeX (e.g., in a documentation system).
+- **Suggested fix:** Extract `pub(crate) fn capture_name_to_chunk_type(name: &str) -> Option<ChunkType>` in `parser/types.rs` or `parser/mod.rs` using the same table as `chunk.rs`. Replace all three sites. Fixes the `"section"` gap automatically.
 
-#### CQ-4: `cmd_query` at 287 lines — multiple concerns in one function body
+#### `parse_injected_chunks` and `parse_injected_relationships` duplicate identical tree-sitter parser setup boilerplate
+- **Difficulty:** easy
+- **Location:** src/parser/injection.rs:206-230 (chunks), src/parser/injection.rs:305-330 (relationships)
+- **Description:** Both methods execute identical 4-step setup: `tree_sitter::Parser::new()`, `.set_language(&grammar)` with the same error wrapping, `.set_included_ranges(&group.ranges)` with warn-and-empty return, `.parse(source, None)` with warn-and-empty return. The only difference is the `Ok(vec![])` vs `Ok((vec![], vec![]))` on failure. The warn messages diverge slightly ("for injection" vs "for injection relationships"), making them hard to search in logs. Additionally, since `parse_file` and `parse_file_relationships` are separate callers, the inner grammar is parsed **twice** for each injection group per file (once for chunks, once for call graph relationships).
+- **Suggested fix:** Extract `fn build_injection_tree(inner_language: Language, source: &str, ranges: &[tree_sitter::Range]) -> Option<tree_sitter::Tree>` returning `None` on any failure. Both methods call it, handle `None` with their respective empty return. Longer term: consider a combined `parse_injected_all` returning `(Vec<Chunk>, Vec<FunctionCalls>, Vec<ChunkTypeRefs>)` to eliminate the double parse.
+
+#### `walk_for_containers` duplicates the cursor-advance-or-walk-up idiom twice within itself
+- **Difficulty:** easy
+- **Location:** src/parser/injection.rs:138-168
+- **Description:** `walk_for_containers` contains two identical 8-line cursor-advancement loops: one at lines 138-148 (after processing a container, skip to next sibling without descending) and one at lines 160-168 (at a leaf, walk back up to find next sibling). Both do `loop { if !cursor.goto_parent() { return; } if cursor.goto_next_sibling() { break; } }`. The duplication makes the traversal logic harder to audit for correctness.
+- **Suggested fix:** Extract an `#[inline]` `fn advance_to_next_sibling(cursor: &mut TreeCursor) -> bool` returning `false` if the tree is exhausted. Reduces each 8-line block to a 1-line call.
+
+#### `InjectionGroup` grouping loop uses O(n) linear scan that will degrade with many injection rules
+- **Difficulty:** easy
+- **Location:** src/parser/injection.rs:83-94
+- **Description:** The loop collecting `InjectionGroup`s calls `groups.iter_mut().find(|g| g.language == language)` — O(existing_groups) per entry. Currently only HTML is a host language with 2 injection rules, so worst-case is 2 groups. But as Svelte, Vue, or Markdown code-fence injection is added (each potentially having many `<script>`-like blocks all targeting the same language), this becomes O(n × rules) where n is the number of injection entries found.
+- **Suggested fix:** Replace the `Vec<InjectionGroup>` accumulator with a `HashMap<Language, InjectionGroup>` keyed by language, collect into `Vec` at the end. Or add a comment explaining the bound.
+
+## API Design
+
+#### `"section"` capture missing from chunk-node-finder in `calls.rs` and `injection.rs`
+- **Difficulty:** easy
+- **Location:** src/parser/calls.rs:276-291, src/parser/injection.rs:363-378
+- **Description:** Three places in the parser module contain the list of "is this capture a chunk node?" — `DEF_CAPTURES` in `mod.rs` (line 279), the `matches!` filter in `calls.rs` (line 276), and the matching `matches!` in `injection.rs` (line 363). `mod.rs` includes `"section"` (used by LaTeX via `@section` captures in `latex.rs`). Both `calls.rs` and `injection.rs` omit it. Consequence: LaTeX section chunks are silently skipped when building the call graph and when parsing injected relationships — `parse_file_relationships` finds no chunk for LaTeX `@section` captures and emits no `FunctionCalls` or `ChunkTypeRefs` for them.
+- **Suggested fix:** Add `"section"` to both `matches!` patterns, and add `"section" => ChunkType::Section` to both `cap_name`→`ChunkType` match arms (currently the `_` arm maps it to `ChunkType::Function` which is wrong). Longer term: extract `DEF_CAPTURES` into a shared module-level constant and reference it from all three sites.
+
+#### `parse_injected_chunks` and `parse_injected_relationships` duplicate tree-sitter parser setup
+- **Difficulty:** easy
+- **Location:** src/parser/injection.rs:206-230 and 305-330
+- **Description:** Both methods repeat identical boilerplate: `tree_sitter::Parser::new()`, `set_language(&grammar)` with the same error message, `set_included_ranges(&group.ranges)` with warn-and-return-empty on failure, `parser.parse(source, None)` with warn-and-return-empty on None. The only difference is the `Ok(vec![])` vs `Ok((vec![], vec![]))` return type on failure. This violates DRY and the warn messages diverge slightly ("for injection" vs "for injection relationships"), making it harder to grep logs consistently.
+- **Suggested fix:** Extract `fn build_injection_tree(grammar: tree_sitter::Language, source: &str, group: &InjectionGroup) -> Option<tree_sitter::Tree>` that returns `None` on any failure (with logging). Both methods call it and return their respective empty values on `None`. The error-handling asymmetry disappears.
+
+#### `InjectionRule` lacks `Debug` derive — inconsistent with all other public types
+- **Difficulty:** easy
+- **Location:** src/language/mod.rs:164
+- **Description:** `InjectionRule` is the only `pub` struct in `src/language/mod.rs` without `#[derive(Debug)]`. Every other public type in the file derives `Debug`: `ParseLanguageError` (line 418), `ParseChunkTypeError` (line 327), `SignatureStyle` (line 261), `LanguageRegistry` has no `Debug` either but it's a registry singleton. `LanguageDef` also lacks `Debug` — but that's harder (it contains raw function pointers which don't impl `Debug`). `InjectionRule` contains only `&'static str` and `Option<fn(...)>` — the function pointer field prevents auto-derive, but a manual `Debug` impl showing the `container_kind`, `content_kind`, and `target_language` fields (omitting the function pointer) would be consistent and useful for logging injection rule mismatches.
+- **Suggested fix:** Add a manual `impl Debug for InjectionRule` that shows `container_kind`, `content_kind`, `target_language`, and `detect_language: detect_language.is_some()`. Or at minimum add `#[derive(Debug)]` once Rust stabilizes function pointer debug (it already works for `Option<fn(...)>` in recent versions — check if `Option<fn(tree_sitter::Node, &str) -> Option<&'static str>>` derives `Debug`).
+
+#### `capture_name`→`ChunkType` mapping duplicated three times without shared abstraction
 - **Difficulty:** medium
-- **Location:** src/cli/commands/query.rs:39-325
-- **Description:** `cmd_query` handles 5 different search modes (name-only, name-only+ref, semantic, semantic+ref, multi-index) with inline branching. It's already been partially decomposed into helper functions (`cmd_query_name_only`, `cmd_query_ref_only`, `cmd_query_ref_name_only`) but the main body still mixes: (1) embedder creation, (2) filter construction, (3) CAGRA/HNSW index loading (30 lines of cfg-gated code), (4) audit mode checks, (5) search execution, (6) reference search + merge, (7) token packing, (8) parent context resolution, (9) staleness warning, and (10) result display. The early returns at lines 50-52 for name-only mode mean the rest of the function is implicitly the "semantic search" path, but this isn't clear from the structure.
-- **Suggested fix:** Extract the CAGRA/HNSW index loading block (lines 115-153) into `load_vector_index(store, cqs_dir)`. Extract the staleness check (lines 240-253) into a helper. This would bring cmd_query under 200 lines and make the search mode flow clearer.
+- **Location:** src/parser/calls.rs:314-329, src/parser/injection.rs:400-415, src/parser/chunk.rs (implicit via ChunkType)
+- **Description:** The mapping from tree-sitter capture name string (`"function"`, `"struct"`, etc.) to `ChunkType` is written out as a `match` arm in both `calls.rs` and `injection.rs`. `mod.rs` has `DEF_CAPTURES` for filtering, and `language/mod.rs` has `define_chunk_types!` which already encodes the name→variant mapping for `Display`/`FromStr`. The capture name is the same as the `ChunkType` serialization name (lowercase). So `cap_name.parse::<ChunkType>()` would work — but neither site uses it, both use manual match arms instead. The manual arms diverge: `"const" => ChunkType::Constant` (correct) vs the `ChunkType::from_str("const")` path which expects `"constant"` (the display string). This mismatch means a future `FromStr`-based refactor must account for the discrepancy.
+- **Suggested fix:** Either (a) add a separate `from_capture_name(s: &str) -> Option<ChunkType>` method that maps capture names (not display names) to variants, or (b) note the discrepancy in a comment at both match sites so a future refactor doesn't accidentally use `FromStr` which expects different strings. Low priority since the code is correct, but the duplication will cause drift.
 
-#### CQ-5: 11 functions suppress `clippy::too_many_arguments` — parameter struct opportunities
+## Documentation
+
+#### CHANGELOG missing multi-grammar injection feature
+- **Difficulty:** easy
+- **Location:** CHANGELOG.md:8 (`[Unreleased]` section)
+- **Description:** The multi-grammar injection feature (commit `afcbed8`, PR #540) added `src/parser/injection.rs`, `InjectionRule` on `LanguageDef`, two-phase `parse_file` and `parse_file_relationships`, and HTML→JS/CSS script/style extraction. The `[Unreleased]` section is empty. This is the most significant feature addition since v0.26.0 and is completely undocumented in the CHANGELOG.
+- **Suggested fix:** Add to `[Unreleased]`: "Multi-grammar injection parsing — HTML `<script>` blocks now extract JS/TS function chunks; `<style>` blocks extract CSS chunks. Powered by tree-sitter's `set_included_ranges()`. `InjectionRule` on `LanguageDef` makes this extensible to other host languages."
+
+#### `html.rs` module comment claims Svelte/Vue/Astro support that doesn't exist
+- **Difficulty:** easy
+- **Location:** src/language/html.rs:4
+- **Description:** The module-level doc comment reads "the outer grammar for multi-grammar parsing (Svelte, Vue, Astro)". Svelte (`.svelte`), Vue (`.vue`), and Astro (`.astro`) file extensions are not registered anywhere in the codebase — no `Language` variant, no extensions in the registry, no injection rules. The comment implies these formats work, but they don't.
+- **Suggested fix:** Remove "(Svelte, Vue, Astro)" or replace with "(e.g., HTML with embedded `<script>` and `<style>` blocks)".
+
+#### `parser/mod.rs` module comment omits `injection` and `markdown` submodules
+- **Difficulty:** easy
+- **Location:** src/parser/mod.rs:1-7
+- **Description:** The module-level doc comment lists only three submodules: `types`, `chunk`, `calls`. The module has two additional submodules: `injection` (multi-grammar injection, added in the same PR) and `markdown` (custom heading-based parser). Both are `pub` or `pub(crate)` and important enough to document.
+- **Suggested fix:** Add to the module doc comment: "- `injection` — multi-grammar injection (HTML→JS/CSS via `set_included_ranges()`)" and "- `markdown` — heading-based Markdown parser with cross-reference extraction".
+
+#### README does not mention multi-grammar injection in HTML language description
+- **Difficulty:** easy
+- **Location:** README.md:427
+- **Description:** The Supported Languages section describes HTML as "headings, semantic landmarks, script/style blocks, id'd elements". The script/style description implies only `Module`-type chunks, but the actual behavior is that inline `<script>` blocks extract JavaScript (or TypeScript) function/class chunks, and `<style>` blocks extract CSS rule chunks. The brief description undersells the feature and is technically inaccurate for inline scripts.
+- **Suggested fix:** Change to: "HTML (headings, semantic landmarks, script/style blocks, id'd elements; inline `<script>` blocks extract JS/TS functions, `<style>` blocks extract CSS rules via multi-grammar injection)"
+
+#### CHANGELOG v0.24.0 HTML entry omits multi-grammar injection design (minor)
+- **Difficulty:** easy
+- **Location:** CHANGELOG.md:40
+- **Description:** v0.24.0 added HTML support and lists "script/style blocks (Module)" — which was the initial behavior before injection was added. This entry is not wrong (it was accurate at v0.24.0 time), but once the `[Unreleased]` entry is added, the v0.24.0 entry may confuse readers about when injection was introduced. Low severity since version history is linear.
+- **Suggested fix:** No change needed if `[Unreleased]` is updated correctly; the history is accurate for that version.
+
+## Error Handling
+
+#### EH-1: `extract_calls` silently discards `set_language` and parse failures without logging
+- **Difficulty:** easy
+- **Location:** src/parser/calls.rs:30-37
+- **Description:** `extract_calls` returns an empty `Vec` on two failures with zero observability: (1) `parser.set_language(&grammar).is_err()` at line 30 — no `tracing::warn!`, the caller sees an empty result indistinguishable from "language has no calls"; (2) `parser.parse(source, None)` returning `None` at line 36 — also silent. In both cases a call graph edge is silently dropped. The sibling method `parse_injected_chunks` logs both of these failure modes (`injection.rs:213-229`) — `extract_calls` is inconsistent.
+- **Suggested fix:** Add `tracing::warn!(language = %language, "set_language failed in extract_calls")` and `tracing::warn!(language = %language, "parse returned None in extract_calls")` to the respective arms.
+
+#### EH-2: `get_query` / `get_call_query` / `get_type_query` use `{:?}` (Debug) instead of `{}` (Display) for tree-sitter query compilation errors
+- **Difficulty:** easy
+- **Location:** src/parser/mod.rs:95, 113, 131
+- **Description:** All three query-get functions use `format!("{:?}", e)` when building the `QueryCompileFailed` error message. `tree_sitter::QueryError` implements `Display` with a human-readable message including the erroneous pattern text and byte offset; the `Debug` impl wraps it in a struct prefix that clutters the output. When a query compilation fails (e.g., due to a new language's malformed query string), the error message surfaced to the user or logs will be harder to read than necessary.
+- **Suggested fix:** Change `format!("{:?}", e)` to `format!("{e}")` at lines 95, 113, and 131 in `src/parser/mod.rs`.
+
+#### EH-3: `parse_injected_relationships` `get_call_query` `Err(_)` arm silently discards real errors with a misleading comment
+- **Difficulty:** easy
+- **Location:** src/parser/injection.rs:340-346
+- **Description:** The `Err(_)` arm drops the error with the comment "No call query is not unusual (some languages don't have one)". However, since injection already guards that the inner language has a grammar (`lang.def().grammar.is_some()` at `injection.rs:64`), and all grammar-having languages are populated into `call_queries` (`mod.rs:71`), the only real `Err` case here is a query compilation failure — a genuine bug, not a legitimately absent query. The comment misidentifies the error class and there is no warning logged. Contrast with the `get_chunk_query` arm directly above (lines 334-337), which correctly logs a warning.
+- **Suggested fix:** Change `Err(_) => { ... }` to `Err(e) => { tracing::warn!(error = %e, language = %inner_language, "Call query compilation failed for injection language"); return Ok((vec![], vec![])); }`.
+
+#### EH-4: `parse_file_relationships` relies on undocumented invariant that empty tree-sitter query patterns compile successfully
 - **Difficulty:** medium
-- **Location:** src/cli/commands/gather.rs:11, src/cli/batch/handlers.rs:32,344, src/search.rs:554, src/scout.rs:169,198, src/cli/watch.rs:209,264, src/cli/pipeline.rs:235, src/parser/markdown.rs:707,810
-- **Description:** 11 `#[allow(clippy::too_many_arguments)]` annotations across the codebase. The worst offenders are `dispatch_search` (9 params), `dispatch_gather` (7 params), `cmd_gather` (8 params), and `scout_core` (8 params). Many of these pass CLI-extracted fields that were already bundled in a struct (`Cli` or `BatchCmd`) but destructured before the call. This pattern makes signatures fragile — adding a new option requires touching every call site in the chain.
-- **Suggested fix:** For the batch handlers, pass `&BatchCmd` variants directly instead of destructuring. For `cmd_gather`, accept a struct (e.g., `GatherArgs { expand, direction, limit, tokens, ref_name, json }`). Not all 11 need fixing — pipeline.rs and markdown.rs take contextual state that doesn't naturally bundle.
+- **Location:** src/parser/calls.rs:258
+- **Description:** `parse_file_relationships` calls `self.get_call_query(language)?` for all grammar-having languages including those with `call_query: None` (e.g., HTML, `html.rs:225`). This works today because `call_query_pattern()` returns `""` for `None`, and empty tree-sitter patterns happen to compile without error. The invariant is nowhere documented. If a future tree-sitter version changes this behavior, or a new language has `grammar: Some(...)` with `call_query: None` where the empty pattern causes unexpected match behavior, this will silently break call graph extraction. The same implicit dependency exists in `parse_injected_relationships` (injection.rs:340). By contrast, `extract_calls` at line 24-26 explicitly short-circuits for grammar-less languages — the guard pattern was clearly intentional but was not extended to the newer paths.
+- **Suggested fix:** After language detection at line 238, add an explicit guard: `if language.def().call_query.is_none() { /* no call extraction for this language */ }` before the call-matches loop. This makes the skip-on-empty-query intent explicit and eliminates the undocumented invariant.
 
-## Extensibility
+## Observability
 
-#### EX-1: `pipeable_command_names()` manually duplicates all pipeable `BatchCmd` variants — silently stale on new commands
+#### OB-1: `parse_injected_chunks` span missing file path — can't identify which file's injection failed in logs
 - **Difficulty:** easy
-- **Location:** src/cli/batch/pipeline.rs:31-113
-- **Description:** `pipeable_command_names()` builds a static array of `(name, BatchCmd::Variant { .. })` pairs to find which commands are pipeable via `is_pipeable()`. Every pipeable `BatchCmd` variant must be listed twice: once in `is_pipeable()` (line 275 of commands.rs) and once in this array. When a new pipeable command is added, forgetting to update `pipeable_command_names()` silently omits it from the pipeline error message — the pipeline still works, the omission is invisible to tests, and it's easy to miss in review. The comment says "kept in sync via is_pipeable()" but there is no compiler enforcement of that sync.
-- **Suggested fix:** Remove the static array in `pipeable_command_names()`. Instead, generate the list by using `BatchInput::command().get_subcommands()` to iterate over all subcommand names and check each via `is_pipeable_command(&[name.to_string()])`. This derives the error message list from the actual `is_pipeable()` implementation rather than a separately maintained copy.
+- **Location:** src/parser/injection.rs:199-204
+- **Description:** The `parse_injected_chunks` span records `language` and `range_count` but not the file path. When a warning fires inside this function (e.g., "Failed to set included ranges for injection" at line 213, or "Failed to extract injected chunk" at line 272), the log entry has no file context. In a large index run, multiple HTML files may trigger injection parsing in parallel; without the path you can't correlate which file caused the failure. The parent `parse_file` span does record the path, but spans are only useful for correlation when a tracing subscriber that supports nested spans (e.g., `tracing-tree`) is active. Direct log events (via `tracing::warn!`) do not inherit parent span fields automatically.
+- **Suggested fix:** Add `path = %path.display()` to the span at `injection.rs:199`. `parse_injected_chunks` already receives `path: &Path` as a parameter, so this is a one-line change.
 
-#### EX-2: `name_boost: 0.2` hardcoded in `dispatch_search` — no shared constant with CLI default
+#### OB-2: Silent injection replacement — no log when injection actually substitutes outer chunks
 - **Difficulty:** easy
-- **Location:** src/cli/batch/handlers.rs:83
-- **Description:** `dispatch_search` hardcodes `name_boost: 0.2` as a bare literal. The CLI default is also `0.2` (via `#[arg(long, default_value = "0.2")]` in `src/cli/mod.rs:146`) and the config file template shows `name_boost = 0.2` (`src/config.rs:53`). These three values are in sync by coincidence — no shared constant exists. If the default changes, one of the three sites is likely to be missed. `SearchFilter::default()` correctly uses `0.0` (no name boosting when unspecified), so the batch handler is intentionally setting a non-default value — but the value should come from a named constant.
-- **Suggested fix:** Define `pub const DEFAULT_NAME_BOOST: f32 = 0.2;` in `src/store/helpers.rs` or `src/lib.rs`. Use it in `cli/mod.rs` default, `batch/handlers.rs` dispatch_search, and the config template string.
+- **Location:** src/parser/mod.rs:241-250
+- **Description:** When injection parsing succeeds (`inner_chunks.is_empty()` is false), the code silently removes outer chunks and extends with inner chunks. There is no `tracing::debug!` or `tracing::info!` recording that the replacement happened, how many outer chunks were removed, or how many inner chunks were added. This makes it impossible to diagnose unexpected injection behaviour (e.g., outer HTML chunks disappearing) without adding a debugger or temporarily adding prints. By contrast, the zero-inner-chunks fallback path in `parse_injected_chunks` logs `"Injection produced no chunks, keeping outer"` (line 282-286) — the success path has worse observability than the fallback path.
+- **Suggested fix:** Add inside the `Ok(inner_chunks) if !inner_chunks.is_empty()` arm: `tracing::debug!(language = %group.language, removed = before_count, added = inner_chunks.len(), "Injection replaced outer chunks");` where `before_count` is captured before `chunks.retain(...)`.
 
-#### EX-3: `HNSW_EXTENSIONS` and `HNSW_ALL_EXTENSIONS` are two overlapping constants manually kept in sync
+#### OB-3: `parse_injected_chunks` does not log chunk count on success
 - **Difficulty:** easy
-- **Location:** src/hnsw/persist.rs:31,34
-- **Description:** `HNSW_EXTENSIONS = &["hnsw.graph", "hnsw.data", "hnsw.ids"]` and `HNSW_ALL_EXTENSIONS = &["hnsw.graph", "hnsw.data", "hnsw.ids", "hnsw.checksum"]` share three entries that are duplicated verbatim. The split is intentional: `HNSW_EXTENSIONS` excludes the checksum file (used in checksum verification), while `HNSW_ALL_EXTENSIONS` includes it (used for cleanup/deletion). Adding a new HNSW file component requires updating both constants and maintaining the correct split, with no compiler help.
-- **Suggested fix:** Add a compile-time assertion that `HNSW_ALL_EXTENSIONS` contains all elements of `HNSW_EXTENSIONS`: `const _: () = assert!(/* all HNSW_EXTENSIONS entries are in HNSW_ALL_EXTENSIONS */);`. Or restructure: `const HNSW_DATA_EXTENSIONS: &[&str] = &["hnsw.graph", "hnsw.data", "hnsw.ids"];` and derive both constants from it with a comment making the relationship explicit.
+- **Location:** src/parser/injection.rs:288
+- **Description:** `parse_injected_chunks` logs only the empty case (`"Injection produced no chunks, keeping outer"`) but emits nothing when it successfully extracts chunks. The span exits silently with an `Ok(chunks)` where `chunks` may contain 0–N entries. The sibling `parse_injected_relationships` has the same gap (line 478). For debugging "why did my HTML file not produce JS function chunks?", you'd see zero log output even when the function ran successfully and returned chunks. The `gather_with_graph` function provides a useful counter-example with `tracing::info!(final_chunks = chunks.len(), "Gather complete")`.
+- **Suggested fix:** Before `Ok(chunks)` at line 288, add: `tracing::debug!(language = %inner_language, chunk_count = chunks.len(), "Injection chunks extracted");`. Similarly before line 478 add: `tracing::debug!(language = %inner_language, call_count = call_results.len(), type_count = type_results.len(), "Injection relationships extracted");`.
 
-#### EX-4: `extract_from_scout_groups` is a bespoke extractor for scout's nested JSON shape — new non-standard output shapes each need a new extractor
-- **Difficulty:** medium
-- **Location:** src/cli/batch/pipeline.rs:116-210
-- **Description:** The pipeline name extractor uses three strategies: bare array, a generic field walk (`extract_from_standard_fields`), and a bespoke `extract_from_scout_groups` for scout's `file_groups[].chunks[].name` nesting. `extract_from_standard_fields` was made key-agnostic (EX-6 fix, PR #504) to avoid hardcoding field names, but scout's two-level nesting required its own special case. Any new command with a non-standard output shape (e.g., `sections[].functions[].name`) would need another bespoke extractor added to `extract_names()`. The pipeline has no specification of what JSON structure makes a command's output pipeable.
-- **Suggested fix:** Define a `"_names"` convention: pipeable command handlers include a top-level `"_names": ["fn1", "fn2"]` field in their JSON output. The pipeline extractor checks `_names` first — zero structural parsing logic. Scout already assembles the output; adding `_names` extraction there is simpler than structural inference at the pipeline level. This also makes pipeability testable without structural knowledge.
-
-#### EX-5: Note/code slot ratio `(limit * 3) / 5` is an inline formula with no named constant — repeated in tests
+#### OB-4: `find_injection_ranges` uses `debug_span` while its callers use `info_span` — inconsistent span level for a hot parse path
 - **Difficulty:** easy
-- **Location:** src/search.rs:1061, :1216, :1223
-- **Description:** The 60%/40% note-to-code slot allocation is expressed as `(limit * 3) / 5` (60% minimum code slots). This formula appears three times: once in production (line 1061) and twice re-derived independently in tests (lines 1216, 1223). The policy is documented only in a comment. If the ratio changes, all three sites must be updated manually, and stale tests would not catch a mismatch between production and test formulas.
-- **Suggested fix:** Extract a `fn min_code_slots(limit: usize) -> usize { ((limit * 3) / 5).max(1) }` private helper. Both production code and tests call it. The ratio numerator/denominator becomes a single change point. Optionally name the constants: `const MIN_CODE_RATIO_NUM: usize = 3; const MIN_CODE_RATIO_DEN: usize = 5;`.
+- **Location:** src/parser/injection.rs:41
+- **Description:** `find_injection_ranges` uses `tracing::debug_span!` while every other parse-path function that's called per-file uses `tracing::info_span!` (e.g., `parse_file` at `mod.rs:141`, `parse_injected_chunks` at `injection.rs:199`, `parse_injected_relationships` at `injection.rs:298`, `parse_file_relationships` at `calls.rs:206`). This inconsistency means that at `RUST_LOG=info`, the span for the tree-scan phase disappears from tracing output even though all surrounding spans are visible. Since `find_injection_ranges` is called once per file with injections (currently all HTML files), it's not a hot-loop function — the debug level provides no performance benefit.
+- **Suggested fix:** Change `tracing::debug_span!("find_injection_ranges", ...)` to `tracing::info_span!(...)` at line 41 for consistency with adjacent parse-path spans.
+
+#### OB-5: `scout_core` — the actual scout computation function — has no entry span
+- **Difficulty:** easy
+- **Location:** src/scout.rs:199
+- **Description:** `scout_core` is the primary compute function for the `cqs scout` command: it does the search, caller count query, staleness check, and note retrieval. Its wrappers `scout_with_options` (line 135) and `scout_with_resources` (line 170) each have their own `info_span!`. But `scout_core` itself has no span, so when called from batch mode via `dispatch_scout` → `scout` → `scout_with_options` → `scout_core`, the per-result timing is invisible. At `RUST_LOG=cqs=debug`, you'd see the wrapper span but can't isolate which phase inside `scout_core` is slow (search vs. caller counts vs. staleness).
+- **Suggested fix:** Add `let _span = tracing::info_span!("scout_core", task_len = task.len(), limit).entered();` at the start of `scout_core`. The wrapper spans will still appear in the hierarchy; this adds a nested span for the actual computation.
+
+#### OB-6: `cmd_read_focused` has no entry span
+- **Difficulty:** easy
+- **Location:** src/cli/commands/read.rs:312
+- **Description:** `cmd_read_focused` is the implementation of `cqs read --focus <fn>` — a non-trivial operation that opens the project store, parses notes, builds focused output including caller hints and type dependencies. `cmd_read` (line 267) has `let _span = tracing::info_span!("cmd_read", path).entered()`, but `cmd_read_focused` — called from `cmd_read` when `--focus` is given — has no span of its own. All warnings emitted inside `cmd_read_focused` (e.g., "Failed to compute hints" at line 139, "Failed to query type deps" at line 202) are therefore not associated with any named span in tracing output.
+- **Suggested fix:** Add `let _span = tracing::info_span!("cmd_read_focused", focus).entered();` at the start of `cmd_read_focused` (line 312).
+
+#### OB-7: Oversized injected chunks skipped silently — no log matching `parse_file`'s own oversized-chunk debug log
+- **Difficulty:** easy
+- **Location:** src/parser/injection.rs:252-256
+- **Description:** `parse_injected_chunks` silently skips oversized chunks (`> 100_000` bytes) with a bare `continue` at line 255, no log. The regular `parse_file` path logs this at debug level: `tracing::debug!("Skipping {} ({} bytes > {} max)", chunk.id, ...)` (mod.rs:205-212). Users debugging why an injected JS function is missing from their HTML index would see nothing in logs. The inconsistency is especially notable because both paths use the same `MAX_CHUNK_BYTES` constant.
+- **Suggested fix:** Add `tracing::debug!(chunk_id = %chunk.id, size = chunk.content.len(), max = MAX_CHUNK_BYTES, "Skipping oversized injected chunk");` before `continue` at line 255.
 
 ## Robustness
 
-#### RB-1: `fetch_candidates_by_ids_async` and `fetch_chunks_by_ids_async` unbatched — exceed SQLite 999-param limit with high `--limit`
+#### RB-1: `parse_injected_relationships` early-returns on `get_call_query` failure, silently skipping type extraction for the same language
 - **Difficulty:** easy
-- **Location:** src/store/chunks.rs:1366, 1326
-- **Description:** Both functions build a single `IN(?)` placeholder list from all IDs passed in. The HNSW search path computes `candidate_count = (limit * 5).max(100)` (search.rs:811,1030), so `--limit 200` produces 1000 candidate IDs — exceeding SQLite's 999-parameter limit. `check_origins_stale` had the same bug (DS-8, fixed in v0.19.0) and `get_chunks_by_names_batch` already batches in groups of 500. These two functions were added later in PF-5 and missed the batching pattern.
-- **Suggested fix:** Batch IDs in groups of 900 (same constant used by `check_origins_stale`). Collect results across batches: `fetch_candidates_by_ids_async` extends a Vec, `fetch_chunks_by_ids_async` merges HashMaps.
+- **Location:** src/parser/injection.rs:340-346
+- **Description:** When `get_call_query(inner_language)` returns `Err`, the function immediately returns `Ok((vec![], vec![]))` — discarding not just call extraction but also type extraction. Call queries and type queries are independent operations (one uses `call_query_pattern()`, the other `type_query_pattern()`). If the inner language has `type_query: Some(...)` but `call_query: None`, the type extraction at injection.rs:459-475 is never reached. Today this doesn't cause a user-visible regression because CSS (the only injection target without a call_query) also has no type_query — so there is nothing to extract. But for any future injection language with types but no calls (e.g., a CSS preprocessor or DSL), this silently produces no `ChunkTypeRefs` even though the type query would succeed. The finding is distinct from EH-3 (which only requests a warning be added) — the structural bug is that the early return conflates two independent failure modes into one early exit.
+- **Suggested fix:** Split the call query handling from the early return: if `get_call_query` fails, assign an empty call result and continue to type extraction. Structure as:
+  ```rust
+  let has_call_query = match self.get_call_query(inner_language) {
+      Ok(q) => Some(q),
+      Err(e) => { tracing::warn!(...); None }
+  };
+  // ... then proceed to type extraction regardless
+  ```
+  Type extraction (lines 459-475) should run whether or not a call query exists.
 
-#### RB-2: `CandidateRow::from_row` and `ChunkRow::from_row` use panicking `row.get()` — no column-missing resilience
-- **Difficulty:** medium
-- **Location:** src/store/helpers.rs:75-84, 106-121
-- **Description:** Both `from_row` methods use `row.get("column_name")` which panics if the column is absent. The callers control the SQL query, so missing columns indicate a programmer bug rather than corrupt data. However, this means a schema migration that drops or renames a column would cause a panic rather than a descriptive error. Other store code (e.g., `IndexStats`, `metadata`) uses `row.get::<Option<_>, _>()` or `.fetch_optional()` which handle missing data gracefully. The `from_row` pattern is consistent across both structs — 16 panicking `.get()` calls total.
-- **Suggested fix:** This is acceptable as-is since the SQL queries are co-located with the from_row calls (programmer invariant). If defensive coding is desired, use `row.try_get()` which returns `Result` instead of panicking. Low priority — leave as informational unless schema migrations are planned.
-
-#### RB-3: `where_to_add.rs` — `suggest_placement_with_options_core` panics via `.expect()` on `query_embedding`
+#### RB-2: `walk_for_containers` leaves cursor state undefined if two rules share the same `container_kind` — future injection rules would add duplicate ranges
 - **Difficulty:** easy
-- **Location:** src/where_to_add.rs:170
-- **Description:** `suggest_placement_with_options_core` calls `.expect()` on `opts.query_embedding`, relying on the caller (`suggest_placement_with_options`) to always set it. The invariant is enforced by the public entry point: it either passes through when `is_some()` or sets it before calling `_core`. But `_core` is `fn` (not `pub`), so only the one caller can reach it. If a future refactor adds another call path that forgets to set the embedding, this panics at runtime with no compile-time guard.
-- **Suggested fix:** Change `_core` to take `query_embedding: &Embedding` as a direct parameter instead of extracting it from `opts`. This makes the requirement compile-time enforced rather than runtime-asserted.
+- **Location:** src/parser/injection.rs:49-53, 83-94
+- **Description:** `find_injection_ranges` calls `walk_for_containers` once per rule in a loop, resetting the cursor to root before each call (line 51). For two rules with the same `container_kind` but different `content_kind` (e.g., two rules targeting `"script_element"` but looking for different content children), both walks would find the same container nodes. Each walk would push the container's content range to `entries`. The grouping pass (lines 60-96) then groups by resolved language — if both rules resolve to the same language, the same byte range is added twice to one `InjectionGroup.ranges`. Calling `set_included_ranges` with duplicate ranges is not explicitly documented as safe in tree-sitter, and may cause duplicate chunk extraction (same JS function appearing twice in the output). No current HTML injection rule has this property (script and style have different container_kinds), but the constraint is not enforced or documented. The issue is especially subtle because it would be a silent data quality regression, not a crash.
+- **Suggested fix:** Add a deduplication step in the grouping pass: after `group.ranges.push(range)`, check `if group.ranges.iter().filter(|r| r.start_byte == range.start_byte).count() > 1 { tracing::warn!("duplicate injection range"); group.ranges.pop(); }`. Alternatively, document in `InjectionRule` that two rules must not produce overlapping byte ranges for the same language.
 
-#### RB-4: `blame` — `run_git_log_line_range` passes `u32` line numbers to format string without overflow check on `start > end`
+#### RB-3: `chunk_overlaps_container` does not handle the case where `chunk_start == 0` and `container_start == 0` — works, but relies on u32 arithmetic that wraps silently on empty files
 - **Difficulty:** easy
-- **Location:** src/cli/commands/blame.rs:86
-- **Description:** The function formats `"{},{}:{}"` from `start` and `end` line numbers. If a chunk's `line_start > line_end` (corrupt index data, or a parser bug where an empty node produces inverted ranges), git receives a reversed line range like `100,50:file.rs`. Git handles this gracefully (returns empty output), so this doesn't crash. However, the user gets silent empty results with no explanation. A `line_end >= line_start` assertion or swap would make the failure mode visible.
-- **Suggested fix:** Add a check at the top: `if end < start { tracing::warn!(start, end, file = rel_file, "Inverted line range — possible corrupt index"); std::mem::swap(&mut start, &mut end); }`. This self-heals and logs the anomaly.
+- **Location:** src/parser/injection.rs:486-494
+- **Description:** The containment check `chunk_start >= start && chunk_end <= end` is arithmetically sound for all valid inputs (line numbers are 1-indexed u32, container_start >= 1). However, if tree-sitter ever returns a node with `start_position().row == 0` (which happens for the root node of an empty parse), and `node.end_position().row as u32 + 1` overflows on a file with exactly u32::MAX lines (2^32 - 1 ≈ 4 billion lines), the `+ 1` wraps to 0 in release mode. This would cause `chunk_end(0) <= end(some_valid_u32)` to be true, spuriously removing chunks. This is purely theoretical — no file has 4 billion lines, and the 50 MB file size limit prevents it. However, the code at injection.rs:130-131 computes both `node.start_position().row as u32 + 1` and `node.end_position().row as u32 + 1` without overflow protection, while `parse_file` has an explicit 50 MB guard. The overflow is suppressed by the file size limit, but this is an undocumented dependency between the two limits.
+- **Suggested fix:** Informational — document with a comment at injection.rs:130 that the `+ 1` cannot overflow because `parse_file`'s 50 MB size limit prevents files with enough lines to reach u32::MAX. No code change required.
 
-#### RB-5: `reranker.rs` — `outputs[0]` index access panics if ONNX model returns empty output
+#### RB-4: `source[cap.node.byte_range()]` in `parse_injected_relationships` panics on invalid byte boundary — inconsistent with `html.rs` which uses `utf8_text` returning `Result`
 - **Difficulty:** easy
-- **Location:** src/reranker.rs:140
-- **Description:** After `session.run()`, the code accesses `outputs[0]` with direct indexing. If the ONNX model returns zero outputs (malformed model, version mismatch), this panics. The embedder has the same pattern at embedder.rs:528 (`outputs[0]`). Both are ONNX runtime calls on bundled models, so the risk is low — but a model update or file corruption would produce a panic instead of a descriptive error.
-- **Suggested fix:** Replace `outputs[0]` with `outputs.first().ok_or(RerankerError::Inference("Model returned no outputs".into()))?` (and similarly for embedder).
-
-#### RB-6: `Language::def()` and `Language::grammar()` panic on disabled feature flags — no graceful path
-- **Difficulty:** easy
-- **Location:** src/language/mod.rs:549, 570
-- **Description:** `Language::def()` panics if the language's feature flag is disabled, and `Language::grammar()` panics if the language has no tree-sitter grammar. Both are documented with `# Panics` doc sections. The `try_def()` alternative exists but callers (parser, search) almost universally use `def()`. In the current codebase all 20 languages are always enabled, so this is theoretical. But it means feature-flag subsetting (e.g., a minimal build with only Rust+Python) would hit panics instead of skip-and-warn behavior.
-- **Suggested fix:** Low priority since all languages are always enabled. If feature-flag subsetting is planned, replace panics with `Result` returns. Otherwise, leave as-is with the documented `# Panics` sections.
-
-#### RB-7: `Parser::new()` panics on registry/enum mismatch — fails at construction not usage
-- **Difficulty:** easy
-- **Location:** src/parser/mod.rs:62-67
-- **Description:** `Parser::new()` iterates the language registry and panics if any registered language name can't parse to a `Language` enum variant. This is a compile-time invariant (the registry and enum are defined in the same module), so the panic can only fire if someone adds a registry entry without a matching enum variant. The panic message is descriptive ("Language registry/enum mismatch: 'X' is registered but has no Language variant"). However, it runs at `Parser::new()` which is called during indexing — a panic here kills the entire index pipeline.
-- **Suggested fix:** Low priority — this is a developer-facing invariant violation. Could add a `#[cfg(test)]` consistency test instead, which catches the mismatch at test time rather than at runtime.
-
-## Algorithm Correctness
-
-#### AC-1: `emit_empty_results` produces malformed JSON — query string not escaped
-- **Difficulty:** easy
-- **Location:** src/cli/commands/query.rs:29, src/cli/commands/similar.rs:99
-- **Description:** `emit_empty_results` uses raw `format!`-style interpolation to embed the query string into a JSON string literal: `println!(r#"{{"results":[],"query":"{}","total":0}}"#, query)`. If the query contains `"`, `\`, or control characters, the output is invalid JSON. Example: query `foo"bar` produces `{"results":[],"query":"foo"bar","total":0}` which any JSON parser rejects. The same pattern exists in `cmd_similar` (similar.rs:99) with `chunk_name` — chunk names from the DB are unlikely to contain special chars but C++ operator overloads could trigger it.
-- **Suggested fix:** Use `serde_json::json!()` to build the object, which properly escapes all string values: `let obj = serde_json::json!({"results": [], "query": query, "total": 0}); println!("{}", obj);`. Apply the same fix in similar.rs:99.
-
-#### AC-2: `search_by_candidate_ids` FTS runs against full index, not scoped to HNSW candidates
-- **Difficulty:** medium
-- **Location:** src/search.rs:934-942
-- **Description:** In the HNSW-guided path (`search_by_candidate_ids`), semantic scoring only considers the ~500 HNSW candidate IDs. But the FTS keyword search runs against the full `chunks_fts` index with `LIMIT limit*3` (line 938). When `rrf_fuse` merges these two lists, FTS-only results that were NOT in the HNSW candidate set enter the final results. These FTS-only results appear in the output with a pure-FTS RRF score (no semantic component). This is a design tension: the HNSW path was designed to narrow the search space for performance (PF-5), but the unscoped FTS re-expands it. In practice this often improves recall (FTS catches keyword matches HNSW misses), but it means the HNSW candidate count doesn't actually bound the work — it's O(FTS_matches) + O(candidate_count), not O(candidate_count) alone.
-- **Suggested fix:** Document the behavior rather than restricting it: "HNSW narrows embedding search; FTS still scans the full index for keyword matches." The FTS scan is fast (SQLite FTS5 is O(matching_docs), not O(total_docs)) and improves recall. If strict bounding is needed, scope FTS with `WHERE id IN (...)` but this reduces recall for keyword-heavy queries.
-
-#### AC-3: `token_pack` has O(n^2) `keep.iter().any()` scan in greedy packing loop
-- **Difficulty:** easy
-- **Location:** src/cli/commands/mod.rs:134
-- **Description:** In the greedy packing loop, `keep.iter().any(|&k| k)` scans the entire `keep` boolean array on every iteration to check if at least one item has been packed. This check implements the "always include at least one item" guarantee. For N items, total scan work is O(N^2). In practice N is small (search results capped at ~20-100), so this isn't a measurable bottleneck. But it's an unnecessary quadratic pattern that could be replaced with a constant-time check.
-- **Suggested fix:** Replace with a `bool` flag: add `let mut has_any = false;` before the loop, change the condition to `if used + tokens > budget && has_any { break; }`, and set `has_any = true;` after each `keep[idx] = true;`.
-
-#### AC-4: `cap_scores` in onboard uses `u64::MAX - x` inversion trick — correct but fragile
-- **Difficulty:** easy
-- **Location:** src/onboard.rs:175-183
-- **Description:** The `cap_scores` function sorts ascending by key and truncates to `max`. For caller_scores, the key function inverts scores via `u64::MAX - ((safe * 1e6) as u64)` so highest scores map to lowest keys. This is mathematically correct — ascending sort + truncate keeps highest scores. But the inversion trick is non-obvious: a reader seeing ascending sort + truncate expects "keep lowest values." The callee_scores path uses `|(_s, d)| *d` (keep shallowest depth) which reads naturally. The `f32 * 1e6 as u64` cast is safe since scores are cosine similarities (0.0-1.0), producing values up to 1,000,000 — well within u64 range.
-- **Suggested fix:** Replace the inversion trick with a reverse sort: change `entries.sort_by(|a, b| key_fn(&a.1).cmp(&key_fn(&b.1)));` to `entries.sort_by(|a, b| key_fn(&b.1).cmp(&key_fn(&a.1)));` for the caller case, and pass `|(score, _)| { let safe = ...; (safe * 1e6) as u64 }` without inversion. This eliminates the mental gymnastics while preserving the same result.
-
-#### AC-5: `bfs_shortest_path` uses empty-string sentinel instead of `Option` for predecessor tracking
-- **Difficulty:** easy
-- **Location:** src/cli/commands/trace.rs:203-221
-- **Description:** The BFS shortest path stores predecessors in `HashMap<String, String>` where the source node's predecessor is `String::new()`. Path reconstruction walks predecessors until finding an empty string. This relies on no real function name being empty. The parser never produces empty names, so this works in practice. But the sentinel value makes the invariant implicit rather than type-enforced.
-- **Suggested fix:** Informational — no practical bug. Could use `HashMap<String, Option<String>>` for cleaner semantics, but the current code works given the parser invariant.
-
-## Test Coverage
-
-#### TC-1: 5 newest languages have no parser integration tests — Bash, HCL, Kotlin, Swift, Objective-C
-- **Difficulty:** medium
-- **Location:** tests/parser_test.rs (missing), tests/fixtures/ (missing .sh, .tf, .kt, .swift, .m)
-- **Description:** The parser integration tests in `tests/parser_test.rs` cover Rust, Python, TypeScript, JavaScript, Go, C, Java, SQL, and Markdown with fixture files. The 5 languages added in v0.19.0 (Bash, HCL, Kotlin, Swift, Objective-C) have no fixture files and no integration tests. Kotlin and Swift have 1 inline unit test each (return type extraction only). Bash, HCL, and Objective-C have zero tests anywhere — neither inline nor integration. The inline language tests only cover `extract_return_type()`, not the full tree-sitter parsing pipeline (`parse_file` -> chunks with correct names, signatures, call extraction, parent_id wiring). A tree-sitter query regression in any of these 5 languages would be invisible to CI.
-- **Suggested fix:** Add fixture files (`sample.sh`, `sample.tf`, `sample.kt`, `sample.swift`, `sample.m`) with representative code (functions, classes/structs, nested constructs). Add `test_parse_*_fixture()` integration tests following the existing C/Java/SQL pattern: parse fixture, assert non-empty, verify language tag, check function count.
-
-#### TC-2: `NoteBoostIndex` has zero tests — search scoring hot path
-- **Difficulty:** easy
-- **Location:** src/search.rs:300-371
-- **Description:** `NoteBoostIndex` is the search-time note-based score boosting component used in every search call. It has non-trivial logic: classifying mentions as name-like vs path-like (line 317-319), taking strongest absolute sentiment (line 323), and computing a `1.0 + sentiment * NOTE_BOOST_FACTOR` multiplier (line 368). Zero direct tests. The `test_score_candidate_name_boost` test exercises name boost through `NameMatcher` but not through `NoteBoostIndex`. The path-mention matching logic (suffix/prefix matching via `path_matches_mention`) is tested separately but the `NoteBoostIndex::boost()` composition — multiple notes, mixed name/path mentions, sentiment priority — is never tested in isolation.
-- **Suggested fix:** Add tests: (1) empty notes -> boost returns 1.0, (2) name mention with positive sentiment -> boost > 1.0, (3) path mention with negative sentiment -> boost < 1.0, (4) competing name and path mentions -> strongest absolute wins, (5) multiple notes for same mention -> strongest sentiment preserved.
-
-#### TC-3: `search_by_candidate_ids` language and chunk_type filter branches untested
-- **Difficulty:** easy
-- **Location:** src/search.rs:883-905
-- **Description:** The PF-5 `search_by_candidate_ids` function has filter_map branches for `filter.languages` (lines 883-893) and `filter.chunk_types` (lines 895-905) that parse candidate row strings into `Language`/`ChunkType` enums and filter non-matching candidates. These branches are unique to the candidate path — the brute-force `search_filtered` path filters differently (in SQL WHERE clauses). The existing `test_search_by_candidate_ids_with_glob_filter` tests the `path_pattern` filter but not language or chunk_type filters. A regression where string->enum parsing fails (e.g., case mismatch after a ChunkType rename) would silently drop all candidates in the candidate path while the brute-force path continues working.
-- **Suggested fix:** Add tests: (1) `filter.languages = Some(vec![Language::Rust])` with mixed-language candidates — only Rust survivors, (2) `filter.chunk_types = Some(vec![ChunkType::Function])` — methods/structs filtered out.
-
-#### TC-4: `ChatHelper::complete` — untested tab-completion logic
-- **Difficulty:** easy
-- **Location:** src/cli/chat.rs:26-49
-- **Description:** `ChatHelper::complete()` implements tab completion with specific behaviors: (1) only completes the first token (returns empty after a space), (2) filters commands by prefix, (3) returns `(0, matches)` — the 0 indicates replacement starts at position 0. The chat.rs test module only tests `handle_meta` and `command_names` — the `Completer` impl is never tested. Tab completion is a user-facing UX feature and the `pos` vs prefix slicing logic (`&line[..pos]`) could regress silently. The test would be trivial since `ChatHelper` is `struct { commands: Vec<String> }` with no external dependencies.
-- **Suggested fix:** Add tests: (1) prefix "se" at pos=2 -> returns ["search"], (2) prefix "cal" at pos=3 -> returns ["callers", "callees"], (3) "search fo" at pos=9 -> returns [] (space in prefix, no completion), (4) empty prefix at pos=0 -> returns all commands.
-
-#### TC-5: `build_blame_data` only tested through JSON shape — no end-to-end path with mock git
-- **Difficulty:** medium
-- **Location:** src/cli/commands/blame.rs:36-68
-- **Description:** `build_blame_data` is the core blame logic that wires `resolve_target` -> `run_git_log_line_range` -> `parse_git_log_output` -> `get_callers_full`. The existing tests cover `parse_git_log_output` (5 tests) and `blame_to_json` (2 tests) individually, but `build_blame_data` itself is never tested — its callers (`cmd_blame` and `dispatch_blame`) both need a live git repo and an indexed store, so integration tests would be needed. The function has 3 error paths: resolve_target failure (line 45-47), git log failure (line 52), and callers failure (line 56-59, silently falls back). The callers fallback path in particular — `unwrap_or_else` returning empty Vec on store error — is never exercised by any test.
-- **Suggested fix:** Create an integration test that sets up a temp git repo (init + commit), indexes it, then calls `build_blame_data`. This would cover the full pipeline. Lower priority than TC-1 through TC-4 since blame is a thin git wrapper and the individual components are tested.
-
-#### TC-6: Batch pipeline error propagation — malformed mid-pipeline input never tested
-- **Difficulty:** easy
-- **Location:** src/cli/batch/pipeline.rs
-- **Description:** The pipeline integration tests cover: valid 2-stage, valid 3-stage, empty upstream, ineligible downstream, quoted pipe, and mixed pipeline+single commands. However, no test exercises error propagation when a **middle** stage fails — e.g., `callers process | explain | callers` where the middle `explain` returns a result that the downstream `callers` can't extract names from (non-array explain output). The `extract_names` function at pipeline.rs handles various JSON shapes but the interaction between an explain output (object with `callers`/`callees` arrays) being fed into a downstream callers stage is untested. The pipeline should degrade gracefully (0 names extracted -> empty result), but this specific shape interaction isn't verified.
-- **Suggested fix:** Add a test: `explain process | callers` — verify the pipeline extracts names from explain's callers/callees arrays and feeds them downstream correctly. Also test a deliberately incompatible pipeline like `stats | callers` (stats returns object with no name fields) to verify graceful degradation.
+- **Location:** src/parser/injection.rs:391, 434
+- **Description:** Two sites in `parse_injected_relationships` use direct string indexing `source[c.node.byte_range()]` which panics (with an index-out-of-range or invalid-UTF8-boundary message) if tree-sitter reports a byte range that falls on a non-char boundary. By contrast, `html.rs` in `find_attribute_value` and `extract_element_text` uses `node.utf8_text(source.as_bytes()).unwrap_or("")`, which returns a `Result` and handles the error gracefully. The inconsistency is an auditor-visible code smell: the same tree-sitter API is used two different ways in the same PR. In practice, tree-sitter guarantees byte positions are on valid UTF-8 boundaries for valid UTF-8 input (and the source has already been validated by `read_to_string`), so this is not a practical panic risk. But a tree-sitter bug or a non-UTF-8-aligned grammar would cause a panic rather than a graceful fallback. The parallel code in `calls.rs` (lines 56, 152, 304, 348) also uses direct indexing — the pattern is consistent in `calls.rs` but `html.rs` breaks the pattern.
+- **Suggested fix:** Change the two injection.rs sites to use `utf8_text` with a fallback: `cap.node.utf8_text(source.as_bytes()).unwrap_or("<?>")`. Low priority since the panic path is unreachable with valid input, but it makes the injection code consistent with `html.rs` and eliminates a theoretical panic in the production path.
 
 ## Platform Behavior
 
-#### PB-1: `cmd_watch` — `RecommendedWatcher` uses inotify on WSL; `Config::with_poll_interval` has no effect on inotify backend
+#### PB-1: `parse_file` and `parse_file_relationships` don't lowercase file extension before language lookup — uppercase extensions (`.HTML`, `.RS`) silently fail
+- **Difficulty:** easy
+- **Location:** src/parser/mod.rs:171-174, src/parser/calls.rs:236-238, src/cli/watch.rs:241-242, src/lib.rs:373-374
+- **Description:** `parse_file` and `parse_file_relationships` extract the file extension via `path.extension().and_then(|e| e.to_str())` and pass it verbatim to `Language::from_extension()`. The registry `by_extension` map is keyed on lowercase `&'static str` keys (e.g., `"html"`, `"rs"`). On case-insensitive filesystems (macOS, Windows, Windows-mounted NTFS in WSL), a file named `index.HTML` or `main.RS` is readable but `Language::from_extension("HTML")` returns `None` and the file is treated as unsupported, producing an `UnsupportedFileType` error. The converter module at `src/convert/mod.rs:165` handles this correctly with `.to_ascii_lowercase()` — the parser paths don't. The same gap exists in the watch path (`watch.rs:241-242`) where `supported_ext.contains(ext)` fails for uppercase extensions, silently skipping the file. The file-walk at `src/lib.rs:373-374` also lacks lowercasing and skips uppercase-extension files during initial index. In practice on Linux (ext4/btrfs) this doesn't trigger since the OS filesystem is case-sensitive and file names are normally lowercase, but on WSL2 with NTFS-backed `/mnt/c/` this is a real user-visible failure for any file with uppercase extension.
+- **Suggested fix:** Add `.map(|s| s.to_ascii_lowercase())` after `.and_then(|e| e.to_str())` in all three parser extraction points (`mod.rs:171`, `calls.rs:236`), adjust `watch.rs:241` similarly, and lowercase `ext` before `extensions.contains` in `lib.rs:373`. The `supported_ext` HashSet in `watch.rs` already contains lowercase strings, so the consumer side is correct — only the producer side needs fixing.
+
+#### PB-2: `detect_script_language` returns lowercase `&'static str` but `InjectionRule::target_language` has no compile-time enforcement that it is lowercase — future mixed-case injection rules are silently accepted by `from_str` but produce inconsistent `Language::Display` output
+- **Difficulty:** easy
+- **Location:** src/language/mod.rs:172, src/parser/injection.rs:63-81
+- **Description:** `find_injection_ranges` resolves the injection target language with `lang_name.parse::<Language>()` which calls `s.to_lowercase()` (language/mod.rs:103), making it case-insensitive. So `InjectionRule::target_language = "JavaScript"` would resolve to the same `Language::JavaScript` as `"javascript"`. No bug today since all rules use lowercase. The risk is that future injection rules may set `target_language: "TypeScript"` or `"JavaScript"` (as the display name would suggest), relying on the case-insensitive parse. The `detect_script_language` function returns `"typescript"` (lowercase) — if it returned `"TypeScript"`, the parse would still work. The inconsistency means there's no single source of truth for what string format `target_language` expects. If the field were ever compared by string equality rather than going through `Language::from_str`, the bug would be silent.
+- **Suggested fix:** Add a `debug_assert!(rule.target_language == rule.target_language.to_ascii_lowercase(), ...)` in `find_injection_ranges` or in `LanguageDef`'s initialization. Or document in `InjectionRule`'s field doc that `target_language` must be the lowercase language name matching `Language::to_string()`.
+
+#### PB-3: `walk_for_containers` and injection parsing create per-call `tree_sitter::Parser` allocations in the rayon parallel stage — on HTML-heavy projects, memory amplification scales with parallelism
 - **Difficulty:** medium
-- **Location:** src/cli/watch.rs:61-63, 87-89
-- **Description:** On WSL over `/mnt/c/` NTFS-backed paths, inotify events are unreliable (missed or duplicated). The code emits a warning at startup but still creates a `RecommendedWatcher` which uses inotify on Linux. `Config::default().with_poll_interval(Duration::from_millis(debounce_ms))` configures the polling interval for `notify::PollWatcher` — it has no effect on the inotify backend. The result: users see the warning but the watcher continues using inotify, silently missing changes on `/mnt/` paths. The `last_indexed_mtime` deduplication guard mitigates duplicate events but doesn't address missed ones.
-- **Suggested fix:** When `is_wsl() && root.to_str().map_or(false, |p| p.starts_with("/mnt/"))`, use `notify::PollWatcher::new(tx, config)?` instead of `RecommendedWatcher`. Both implement the `Watcher` trait, enabling a conditional dispatch. Alternatively, document that `cqs watch` is unsupported on WSL `/mnt/` paths and upgrade the startup warning to a bail with a suggestion to use the `cqs-watch` systemd service configured with `cqs index` instead.
+- **Location:** src/parser/injection.rs:206-210, 305-310, src/cli/pipeline.rs:263-304
+- **Description:** `parse_injected_chunks` and `parse_injected_relationships` each call `tree_sitter::Parser::new()` to create a fresh parser for the inner language. This is correct for thread safety. However, in the rayon parallel map at `pipeline.rs:263`, every HTML file creates two additional `tree_sitter::Parser` instances (one per parse function). Under rayon's default parallelism (num_cpus threads), processing a batch of 5000 HTML files means dozens of live `tree_sitter::Parser` allocations simultaneously, each holding grammar-specific internal state. The outer `Parser` struct uses `OnceCell<tree_sitter::Query>` to amortize query compilation — injection bypasses this entirely and re-creates parsers on every file. On a project with thousands of HTML files (e.g., a documentation site or large web codebase), this is a meaningful memory regression compared to pre-injection behavior. This is particularly relevant on WSL where RAM is shared with Windows and memory pressure from rayon workers is more pronounced.
+- **Suggested fix:** Informational for now; document the tradeoff in `parse_injected_chunks`. If memory pressure is observed, cache injection parsers (not just queries) in `Parser` with `HashMap<Language, Mutex<tree_sitter::Parser>>` or use a per-thread pool. This is a precondition to the combined `parse_injected_all` optimization noted in Code Quality findings.
 
-#### PB-2: `collect_events` — `notes_path` silently falls back to non-canonical path if `docs/notes.toml` doesn't exist at watch start
+#### PB-4: `extract_calls` does not normalize CRLF — if called with un-normalized source, byte offsets from call-site captures may be wrong on Windows
 - **Difficulty:** easy
-- **Location:** src/cli/watch.rs:97-105, 232
-- **Description:** `dunce::canonicalize(&notes_path)` is called at watch startup (line 102), but fails if `docs/notes.toml` doesn't exist — valid for projects without notes. On failure, the fallback at line 103 preserves the un-canonicalized path. Inotify delivers event paths in canonicalized form. The comparison `path == notes_path` (line 232) then compares a canonical event path against a possibly non-canonical stored path. On WSL with symlinked project directories or when the project root itself is a symlink, the paths diverge and notes changes are silently ignored even after the file is created.
-- **Suggested fix:** Re-attempt canonicalization each cycle when `notes_path` remains non-canonical: `if !notes_canonical { if let Ok(c) = dunce::canonicalize(&notes_path) { notes_path = c; notes_canonical = true; } }`. Or compare both forms in the equality check.
+- **Location:** src/parser/calls.rs:15-78
+- **Description:** `parse_file` (mod.rs:169) and `parse_file_relationships` (calls.rs:234) both normalize CRLF → LF before parsing. `extract_calls` (calls.rs:15-78) does not normalize. All current callers pass already-normalized content: `extract_calls_from_chunk` passes `chunk.content` (normalized at parse time), and `parse_file_relationships` passes the already-normalized `source`. However, if a future caller passes raw file content (e.g., from `std::fs::read_to_string` on a Windows CRLF file without normalizing), tree-sitter will parse with CRLF and produce byte offsets that are correct for the CRLF string. But any downstream code that strips CRLF before comparing byte ranges would produce mismatches. The three other functions in the module guard against this by normalizing at the top; `extract_calls` is the only one that doesn't.
+- **Suggested fix:** Add `let source = if source.contains('\r') { std::borrow::Cow::Owned(source.replace("\r\n", "\n")) } else { std::borrow::Cow::Borrowed(source) };` at the top of `extract_calls`, matching the pattern in `diff_parse.rs:37-39`. Low priority since no current caller is affected, but defensive against future misuse.
 
-#### PB-3: `run_git_log_line_range` — forward-slash path in `-L` spec latently incompatible with native Windows git
+## Algorithm Correctness
+
+#### AC-1: `chunk_overlaps_container` implements containment, not overlap — misnamed and semantically incomplete
 - **Difficulty:** easy
-- **Location:** src/cli/commands/blame.rs:50, 86
-- **Description:** `rel_file` is produced by `rel_display(&chunk.file, root)`, which normalizes to forward slashes. The `-L start,end:path` argument format requires the path to match the working tree path as git sees it. On native Windows git (not WSL), git expects Windows-native path separators; forward-slash paths fail the `-L` spec lookup and git returns "no path found in git history" for otherwise valid files. Currently WSL-only, so this is latent — but any future Windows-native deployment would hit this silently.
-- **Suggested fix:** Add a code comment at line 86 noting the platform assumption (`// git on WSL handles forward slashes; native Windows git requires MAIN_SEPARATOR`). If Windows native support is added, conditionally replace slashes: `if cfg!(windows) { rel_file.replace('/', "\\") } else { rel_file }`.
+- **Location:** src/parser/injection.rs:486-494
+- **Description:** The function is named "overlaps" but implements strict containment: `chunk_start >= start && chunk_end <= end`. A true overlap (partial intersection) would be `chunk_start <= end && chunk_end >= start`. For the current HTML use case this works because the outer Module chunk for a `<script_element>` always has `line_start == container_start` and `line_end == container_end` (the chunk and container are the same node). But if any future host language produces an outer chunk that starts before the container and ends inside it — e.g., a preamble chunk that spans the injection boundary — the containment check yields `false` and the outer chunk is NOT removed, leaving both the outer and inner chunks for the same code region. The mismatch between name and implementation also makes the logic hard to audit: callers expect "does this chunk intersect a container?" but get "is this chunk fully inside a container?".
+- **Suggested fix:** Either (a) rename to `chunk_contained_by_container` and add a comment explaining why containment suffices for the current HTML case, or (b) change the predicate to a true overlap check: `chunk_start <= end && chunk_end >= start`. Option (b) is safer and handles future host languages without needing to reconsider this function.
 
-#### PB-4: `acquire_index_lock` and `try_acquire_index_lock` duplicate lock-file open code; NTFS ignores `0o600` silently
-- **Difficulty:** easy
-- **Location:** src/cli/files.rs:52-71, 95-115, 46-81
-- **Description:** Both lock functions contain nearly identical `#[cfg(unix)]` / `#[cfg(not(unix))]` file-creation blocks. `acquire_index_lock` duplicates the block a second time in its retry-after-stale-lock path (lines 96-115). On WSL over `/mnt/c/`, the `#[cfg(unix)]` branch applies (WSL is Linux), so `0o600` mode is requested — but NTFS ignores Unix permission bits. The `set_permissions` call succeeds silently, making the lock file world-readable to any user with filesystem access. No warning is emitted.
-- **Suggested fix:** Extract `open_lock_file(path) -> Result<File>` helper to eliminate duplication. Add a `tracing::debug!` when `is_wsl() && path.starts_with("/mnt/")` noting the NTFS permission caveat. The PID leak is low severity since `.cqs/` already requires project directory access.
-
-#### PB-5: `is_wsl()` has no `#[cfg(unix)]` guard — non-Unix builds rely on I/O failure for correct behavior
-- **Difficulty:** easy
-- **Location:** src/config.rs:15-25
-- **Description:** `is_wsl()` reads `/proc/version` and returns `false` on I/O error. On a native Windows binary, `/proc/version` doesn't exist, so the function returns `false` — correct, but the correctness depends on `read_to_string` failing rather than on explicit platform conditioning. The callers (`warn_wsl_advisory_locking` at hnsw/persist.rs:21, config permission check at config.rs:206) pair `is_wsl()` with `path.starts_with("/mnt/")` — a Unix-only path prefix that is meaningless on Windows. The code is functionally correct for the current WSL-only deployment but is structurally confusing for any future Windows-native port.
-- **Suggested fix:** Add `#[cfg(unix)]` to the real implementation and `#[cfg(not(unix))] pub fn is_wsl() -> bool { false }` as the stub. This makes the platform conditionality explicit at the declaration rather than relying on I/O failure semantics.
-
-## Security
-
-#### SEC-1: `CQS_PDF_SCRIPT` env var allows arbitrary script execution with no path validation
-- **Difficulty:** easy
-- **Location:** src/convert/pdf.rs:56-68
-- **Description:** `find_pdf_script()` checks the `CQS_PDF_SCRIPT` env var first. If set, the value is used as a script path passed directly to `Command::new(&python).args([&script, ...])`. The only validation is a non-blocking warning if the extension isn't `.py`. An attacker who can set environment variables (e.g., via `.env` file, shell rc injection, or CI env manipulation) can point this to any script, which is then executed with the Python interpreter. The prior audit SEC-6 finding (v0.19.2, PR #504) addressed the log level but not the fundamental issue: user-controlled env var -> script execution with no guardrails beyond extension sniffing.
-- **Suggested fix:** (1) Require `.py` extension and abort (not just warn) on mismatch. (2) Validate the script resolves inside the project root or a known cqs directory. (3) Document in SECURITY.md. Low practical risk given the threat model (local tool, no external users), but violates defense-in-depth.
-
-#### SEC-2: `search_by_name` FTS query safety depends on `debug_assert` — compiled out in release builds
-- **Difficulty:** easy
-- **Location:** src/store/mod.rs:609-613, src/store/chunks.rs:1199-1203
-- **Description:** `search_by_name` and `search_by_names_batch` build FTS5 queries via `format!("name:\"{}\" OR name:\"{}\"*", normalized, normalized)`. Safety depends on `sanitize_fts_query` stripping all double quotes. A `debug_assert!(!normalized.contains('"'))` verifies this — but is compiled out in release builds. If `sanitize_fts_query` is ever refactored to miss the `"` character, release builds would have no runtime check and the format string would produce malformed FTS5 queries that could alter search semantics. The `sanitize_fts_query` function does currently strip `"` (mod.rs:144) and has fuzz coverage (mod.rs:916), so this is safe today. But the invariant is enforced by convention rather than by runtime check.
-- **Suggested fix:** Change `debug_assert!` to `assert!` at both sites. The assertion runs once per search call on an already-constructed short string — negligible cost. This makes the safety invariant enforceable even if `sanitize_fts_query` is accidentally weakened.
-
-#### SEC-3: `convert_directory` walk has no depth limit — deeply nested directories can exhaust resources
-- **Difficulty:** easy
-- **Location:** src/convert/mod.rs:345
-- **Description:** `convert_directory` uses `walkdir::WalkDir::new(dir)` with no `.max_depth()` limit. CHM extraction (chm.rs:61) and webhelp (webhelp.rs:58) also use unbounded walks but are bounded by temp directory (CHM) or `content/` subdirectory (webhelp), and both have `MAX_PAGES = 1000` as a backstop. `convert_directory` has no equivalent file count limit — it processes all matching files in an arbitrary directory tree. A directory with extreme nesting or a large number of supported files (e.g., 100K HTML files) would produce unbounded memory use and processing time.
-- **Suggested fix:** Add `.max_depth(50)` to the `WalkDir` in `convert_directory`. Add a `MAX_FILES` constant (e.g., 10000) and truncate with a warning, matching the `MAX_PAGES` pattern in CHM and webhelp.
-
-#### SEC-4: HNSW index files written with no permission restriction — inconsistent with SQLite database protection
-- **Difficulty:** easy
-- **Location:** src/hnsw/persist.rs (save functions)
-- **Description:** `Store::open()` (mod.rs:237-254) explicitly sets `0o600` permissions on SQLite database and WAL/SHM files as defense-in-depth. However, HNSW index files (`*.hnsw.graph`, `*.hnsw.data`, `*.hnsw.ids`, `*.hnsw.checksum`) are written by the HNSW persist module without any permission setting. These files contain the same embedding vectors that are in the database. On a shared system, HNSW files would be world-readable (subject to umask) while the database is owner-only. The `.cqs/` directory provides parent-level protection, but the file-level inconsistency is a gap.
-- **Suggested fix:** After writing HNSW files in `save_to_directory()` and `atomic_save()`, set `0o600` permissions on each file with `#[cfg(unix)]` guard, same pattern as `Store::open`. Apply after the final rename in `atomic_save()`.
-
-#### SEC-5: `find_7z` and `find_python` search `PATH` for executables without validation
+#### AC-2: `walk_for_containers` visits the same node multiple times when two injection rules share a container ancestor
 - **Difficulty:** medium
-- **Location:** src/convert/chm.rs:168-183, src/convert/pdf.rs:95-110
-- **Description:** Both functions iterate hardcoded names (`["7z", "7za", "p7zip"]` and `["python3", "python"]`) and probe via `Command::new(name)`, which resolves via the system `PATH`. If an attacker can prepend a directory to `PATH`, a malicious binary would be executed instead. Standard PATH poisoning — mitigated in most environments by OS protections, but relevant in CI pipelines or shared systems where `PATH` is not fully trusted.
-- **Suggested fix:** Low priority given the threat model. Document in SECURITY.md that `cqs convert` trusts the system PATH. For hardening: prefer absolute paths when available, or validate the found executable is in a trusted directory.
+- **Location:** src/parser/injection.rs:49-53, 100-170
+- **Description:** `find_injection_ranges` iterates over all `rules` and calls `walk_for_containers` once per rule, resetting the cursor to root each time. For HTML's two rules (script and style), this means the entire tree is walked twice. Nodes that are ancestors of both script and style elements (e.g., `html`, `body`, `head`) are visited and checked against each rule on each pass. In the current implementation the cost is O(tree_nodes × rules), not O(tree_nodes). For HTML with 2 rules and a large file this is a 2× overhead. More importantly, the walk's correctness depends on `cursor.reset(root)` being called before each walk — this is done correctly at line 51. However, the reset shares the cursor object between calls, which means any call to `walk_for_containers` that returns via the inner `loop { if !cursor.goto_parent() { return; } ... }` at line 141 leaves the cursor in an intermediate position — the parent that failed `goto_next_sibling()`. When `reset(root)` is called next iteration, this is correctly overwritten. But if `walk_for_containers` is ever called without a preceding `reset`, the bug would silently skip nodes. The reset is in the calling loop (line 51), so the current code is correct; the fragility is the coupling between caller and callee.
+- **Suggested fix:** Move `cursor.reset(root)` inside `walk_for_containers` (first line of the function), making the function self-contained and eliminating the caller's responsibility. This also makes the code correct if `walk_for_containers` is ever called from a different context.
 
-#### SEC-6: No size limit on git diff output — `run_git_diff` can allocate unbounded memory
+#### AC-3: Injected call sites have absolute source line numbers but `FunctionCalls::line_start` is used as a relative anchor — callee line numbers may be wrong in store lookup
+- **Difficulty:** medium
+- **Location:** src/parser/injection.rs:422-455
+- **Description:** In `parse_injected_relationships`, `line_start` is computed as `node.start_position().row as u32 + 1` (line 422) — an absolute line number in the full HTML source. `CallSite::line_number` (line 435) is also `cap.node.start_position().row as u32 + 1` — also absolute. Both are consistent. However, the store matches `FunctionCalls` to existing chunks by name and `line_start`. When injected JS function chunks are indexed (from `parse_injected_chunks`), their `line_start` is also absolute (from the same inner tree). So the name+line_start key should match. The potential issue: if `parse_file` and `parse_file_relationships` are called separately (which they are — `parse_file` for indexing, `parse_file_relationships` for relationship extraction), the inner tree is parsed twice with `set_included_ranges`. If the two parses produce different `start_position().row` values for the same node (e.g., due to a different tree-sitter version or grammar update between runs), the `line_start` mismatch would silently orphan call graph edges. This is not a bug today, but it is a fragile assumption: the correctness of cross-phase name+line matching for injected functions depends on both parses producing identical row numbers. By contrast, non-injection languages share the same tree parse across both phases (`parse_file_relationships` uses one tree for everything). The injection path breaks this single-parse invariant.
+- **Suggested fix:** Add a comment at line 422 noting that `line_start` must match the value produced by `parse_injected_chunks` for the same function, and that both depend on tree-sitter's `set_included_ranges` producing deterministic absolute row numbers. No code change needed today; the comment documents the invariant for future maintainers.
+
+#### AC-4: `detect_script_language` returns `None` (falls through to JS) for `<script type="text/javascript">` and module scripts — fine — but also for `<script type="application/ld+json">` (JSON, not JS)
 - **Difficulty:** easy
-- **Location:** src/cli/commands/mod.rs:166-188
-- **Description:** `run_git_diff` calls `cmd.output()` which reads the entire stdout into memory. `git diff` output is unbounded — a large binary change, mass reformatting, or diff against an unrelated branch can produce hundreds of megabytes. The `read_stdin` function (mod.rs:153-162) has a 50MB limit, but `run_git_diff` has none. The output is then passed to `parse_diff_output` and `impact_diff` which process it in-memory. A pathological diff could cause OOM. The `run_git_log_line_range` (blame.rs) is naturally bounded by the `-n depth` flag, so it doesn't have this issue.
-- **Suggested fix:** Add a size check after `cmd.output()`: if `output.stdout.len() > MAX_DIFF_SIZE` (e.g., 50MB, matching the stdin limit), bail with an error message suggesting `--base` to narrow the diff scope. Alternatively, stream the output through a length-limited reader.
+- **Location:** src/language/html.rs:195-218
+- **Description:** `detect_script_language` only detects TypeScript variants (`lang="ts"`, `type` containing `"typescript"`). All other `<script>` elements fall through to `None`, which means they use the default `target_language = "javascript"`. This includes `<script type="application/ld+json">` (JSON-LD), `<script type="text/template">` (Mustache/Handlebars templates), and `<script type="x-shader/x-vertex">` (GLSL shaders). These are sent to the JavaScript parser, which will produce no function chunks (since JSON/template/GLSL top-level content isn't function declarations), so the practical effect is just a wasted parse — `inner_chunks` will be empty, and the fallback keeps the outer Module chunk. No incorrect chunks are indexed. The issue is: if cqs adds GLSL or JSON injection support later and adds those types to `target_language`, the `detect_script_language` function's ordering could return wrong results. This is a latent bug, not a current one.
+- **Suggested fix:** Add an early return for known non-JS types before the TypeScript detection: if `type_val` contains `"json"`, `"template"`, `"x-shader"`, or similar, return the appropriate language or a sentinel that `find_injection_ranges` can use to skip the entry entirely. The cleanest fix is a return type of `Option<Option<&'static str>>` where `None` means "no injection" and `Some(None)` means "use default". But that requires a signature change to `InjectionRule::detect_language`. Simpler short term: add a comment listing known non-JS types that will be silently passed to the JS parser.
+
+#### AC-5: `find_content_child` returns the FIRST matching child by kind — HTML grammar puts `raw_text` as the only content child, but if multiple children match, injection uses the wrong range
+- **Difficulty:** easy
+- **Location:** src/parser/injection.rs:172-185
+- **Description:** `find_content_child(node, rule.content_kind)` returns the first child of `node` with `child.kind() == content_kind`. For the HTML `script_element` → `raw_text` injection, tree-sitter's HTML grammar always produces exactly one `raw_text` child. But the function searches linearly and returns the first match, silently ignoring any subsequent matches. If a grammar produces multiple children with the same kind (which can happen in error-recovery scenarios — tree-sitter can produce duplicate-kind siblings when parsing malformed input), only the first range is used, and the remaining code regions are not injected. The more common and practical issue: for `<script>` elements with a missing closing `</script>`, tree-sitter may split the content into multiple `raw_text` nodes (one per "paragraph" of content), and only the first would be injected.
+- **Suggested fix:** Change `find_content_child` to return all matching children (iterator or `Vec`), and accumulate all their byte ranges into the `InjectionGroup`. Each `tree_sitter::Range` already handles individual byte ranges independently. This makes injection robust to multi-node content, which also future-proofs for languages where injection content may span multiple sibling nodes.
+
+## Extensibility
+
+#### EX-1: `InjectionRule::target_language` strings are never validated — a typo silently fails at every injection parse, not at startup
+- **Difficulty:** easy
+- **Location:** src/language/html.rs:248, 254; src/parser/injection.rs:62-81
+- **Description:** `InjectionRule::target_language` is a `&'static str` that is resolved to a `Language` variant at parse time via `lang_name.parse::<Language>()` in `find_injection_ranges`. If the string is invalid (e.g., `"javscript"` typo, or `"js"` instead of `"javascript"`), the error is silently logged as a `tracing::warn!` per injection entry found — meaning the warn fires for every `<script>` element in every HTML file indexed, but no injection happens and no JS chunks are extracted. There is no startup or test-time validation that injection rule target_language strings resolve to known, enabled languages. The existing registry test `test_registry_by_extension` (language/mod.rs:708) validates extensions, not injection targets. By contrast, the `Language::from_extension` path in `parse_file` returns a hard error (`UnsupportedFileType`) on unknown extensions — the injection path's failure is much softer.
+- **Suggested fix:** Add a test in `src/language/mod.rs` (near `test_registry_by_extension`) that iterates `REGISTRY.all()`, iterates each language's `injections`, and asserts `rule.target_language.parse::<Language>().is_ok()` for each rule. This makes the typo a test failure rather than a runtime warning storm.
+
+#### EX-2: Adding a new injection host language requires no code changes outside the language module — but CONTRIBUTING.md has no guidance on `InjectionRule` fields
+- **Difficulty:** easy
+- **Location:** CONTRIBUTING.md:107-122; src/language/mod.rs:160-173
+- **Description:** The injection framework is genuinely data-driven: adding injections to a new language (e.g., Svelte `.svelte` → JS/TS/CSS) requires only populating the `injections: &[InjectionRule { ... }]` field in that language's `definition()`. No parser code changes needed. However, CONTRIBUTING.md's Architecture Overview section lists `injection.rs` with a one-line description ("Multi-grammar injection (HTML→JS/CSS via set_included_ranges)") but gives no guidance on how to add injection rules for a new host language. A contributor adding Svelte/Vue/PHP (which embeds JS/CSS/HTML) would have to discover the `InjectionRule` fields by reading the HTML implementation directly. The `container_kind`/`content_kind` values are tree-sitter grammar node names — contributor needs to know to consult the grammar's `node-types.json`, which is undocumented. The optional `detect_language` callback (for attribute-based language detection like `<script lang="ts">`) is particularly non-obvious.
+- **Suggested fix:** Add a short "Adding injection support to a language" section to CONTRIBUTING.md after the Architecture Overview. Cover: (1) the four `InjectionRule` fields and where to find `container_kind`/`content_kind` values (grammar `node-types.json`), (2) `target_language` must be the lowercase `Language::to_string()` value, (3) `detect_language` callback for attribute-based detection, (4) point to `html.rs` as the canonical example. This is a docs-only change but directly enables the "extensible to other host languages" promise.
+
+#### EX-3: Chained injection (inner language with its own `injections` field) is silently ignored — PHP's inline HTML with JS is unindexable by the current design
+- **Difficulty:** medium
+- **Location:** src/parser/injection.rs:187-289 (`parse_injected_chunks`); src/language/mod.rs:257
+- **Description:** The injection framework currently supports one level of nesting: host language → inner language. `parse_injected_chunks` parses the inner language's tree and extracts chunks, but never checks `inner_language.def().injections`. If an inner language itself has injection rules (e.g., PHP with inline `<script>` blocks — PHP → HTML → JS), those rules are silently ignored. Currently no language has both `grammar.is_some()` and a non-empty `injections` field simultaneously; only HTML uses injections and it is never an injection target. But if PHP support is added with HTML injection (common: PHP templates contain `echo "<script>..."` patterns parsed as raw HTML string content), or if Svelte is added as a host language with both JS and CSS injections, the second level would silently fail. The issue is also relevant for Markdown code fences: if Markdown ever gains a tree-sitter grammar and injection rules for fenced code blocks, the inner language would not be recursively injected. This is a design gap, not a latent bug in current code, but it constrains which future languages can be modeled as injection targets.
+- **Suggested fix:** Document the single-level restriction in `InjectionRule`'s doc comment and in CONTRIBUTING.md: "Chained injection (inner language with its own injection rules) is not supported. If the inner language is also a host language, only its own top-level chunks are extracted." This prevents incorrect expectations. If chained injection is needed later, `parse_injected_chunks` would need to call `find_injection_ranges` on the inner parse tree and recursively call itself — a clear extension point, but currently unimplemented.
+
+#### EX-4: Grammar-less languages with non-empty `injections` field would silently produce no injections — no guard or assertion
+- **Difficulty:** easy
+- **Location:** src/parser/mod.rs:177-179, 235-264; src/parser/calls.rs:241-244, 388-407
+- **Description:** In both `parse_file` and `parse_file_relationships`, grammar-less languages (currently only Markdown) trigger an early return before Phase 2 (the injection phase). This means if a future grammar-less language defines `injections: &[...]`, those rules are silently never applied — no warning, no assertion, no test failure. The early return at `mod.rs:177` routes to `parse_markdown_chunks`, which returns directly without reaching the injection loop at line 235. Markdown code-fence injection (parsing fenced blocks as their respective languages) is a plausible future feature, and the current architecture would silently block it while appearing to support it via `LanguageDef::injections`. The same applies to `calls.rs:241` routing to `parse_markdown_references` before line 388. The `injections: &[]` on `markdown.rs` is currently correct, but there is no compile-time or test-time enforcement that the injection field remains vacuous for grammar-less languages.
+- **Suggested fix:** Add a `debug_assert!(language.def().grammar.is_some() || language.def().injections.is_empty(), "Grammar-less language {} has injection rules that will never fire", language)` before the early return in `parse_file` and `parse_file_relationships`. This turns a silent misconfiguration into an immediate assertion failure during development. Alternatively, add a registry validation test that iterates all languages and asserts grammar-less ones have empty injection lists.
+
+## Test Coverage
+
+#### TC-1: `chunk_overlaps_container` has zero unit tests — the sole filter that decides which outer chunks are removed on injection
+- **Difficulty:** easy
+- **Location:** src/parser/injection.rs:486-494
+- **Description:** `chunk_overlaps_container` is the predicate used in `parse_file` (mod.rs:243-248) to decide which outer HTML chunks to discard when injection succeeds. It implements strict containment (`chunk_start >= container_start && chunk_end <= container_end`), not overlap. No tests exercise the function directly. The boundary conditions — chunk that starts exactly at container start, chunk that ends exactly at container end, chunk that spans the container, chunk one line outside — are all untested. AC-1 (filed by Algorithm Correctness) notes the naming mismatch; the missing tests mean neither the current containment semantics nor the boundary behavior is verified.
+- **Suggested fix:** Add unit tests in `src/parser/injection.rs` covering: (1) exact containment — `assert!(chunk_overlaps_container(10, 20, &[(10, 20)]))`, (2) chunk one line before start — `assert!(!chunk_overlaps_container(9, 20, &[(10, 20)]))`, (3) chunk one line past end — `assert!(!chunk_overlaps_container(10, 21, &[(10, 20)]))`, (4) multiple container ranges with one match, (5) empty container list returns false.
+
+#### TC-2: CSS injection test (`parse_html_with_style_extracts_css_rules`) has a conditional assertion — passes vacuously when CSS produces no chunks
+- **Difficulty:** easy
+- **Location:** src/language/html.rs:459-499
+- **Description:** The test for CSS injection from HTML `<style>` blocks guards all CSS-specific assertions with `if !css_chunks.is_empty() { ... }`. If CSS injection fails silently or the CSS parser produces no chunks, the test exits with no failures. The CSS query (`css.rs:14-25`) has `(rule_set (selectors) @name) @property` which should match `.container { display: flex; gap: 1rem; }` — chunks should be produced. The conditional guard hides a potential regression: a broken CSS injection path would leave this test green. The `parse_html_with_style_extracts_css_rules` test can pass even with completely broken CSS injection.
+- **Suggested fix:** Remove the `if !css_chunks.is_empty()` guard and add an unconditional assertion: `assert!(!css_chunks.is_empty(), "Expected CSS chunks from inline <style>, got: {:?}", chunks...)`. Add a specific assertion for the `.container` selector chunk by name. This makes the test a real regression gate for CSS injection.
+
+#### TC-3: Injected type references (`ChunkTypeRefs`) are never asserted in any test — `_types` is silently discarded
+- **Difficulty:** easy
+- **Location:** src/language/html.rs:650
+- **Description:** The single test for HTML injection call graphs (`injection_call_graph`) calls `parser.parse_file_relationships(...)` and destructures as `(calls, _types)` — the type references return value is discarded. `parse_injected_relationships` extracts both `FunctionCalls` and `ChunkTypeRefs` (injection.rs:459-475). No test in the codebase asserts that injected functions with type usage produce `ChunkTypeRefs` entries. A regression in `extract_types` for injected code (e.g., the byte range scoping at injection.rs:459-465) would be completely invisible in the test suite.
+- **Suggested fix:** Add a test with TypeScript content in a `<script lang="ts">` block that uses a type annotation (e.g., `function foo(x: MyType): void {}`), then assert that `parse_file_relationships` returns a non-empty `types` vec containing a `ChunkTypeRefs` entry for `foo` referencing `MyType`.
+
+#### TC-4: No integration test for the parse_file → index → search roundtrip with HTML injection
+- **Difficulty:** medium
+- **Location:** tests/cli_test.rs
+- **Description:** The existing CLI integration tests index Rust/Python fixtures and search for functions. There is no integration test that: (1) creates an HTML file with inline `<script>`, (2) indexes it, (3) searches for the injected JS function by name or content. The unit tests in `html.rs` verify `parse_file` output, but the full pipeline — `parse_file` → chunk embedding → store upsert → `search_filtered` → result — for injected chunks is untested. A regression in how injected chunk `language` or `line_start` fields are stored/retrieved would not be caught by the existing test suite.
+- **Suggested fix:** Add an integration test in `tests/cli_test.rs` that creates a temp directory with an `index.html` containing `<script>function zq_unique_injection_fn() { return 42; }</script>`, runs `cqs index`, then runs `cqs "zq_unique_injection_fn" --json` and asserts the result contains `"zq_unique_injection_fn"` with language `"javascript"`.
+
+#### TC-5: `detect_script_language` type-attribute branch and None fallback have no test coverage
+- **Difficulty:** easy
+- **Location:** src/language/html.rs:195-218
+- **Description:** `detect_script_language` has three branches: (1) `lang` attribute is `"ts"` or `"typescript"` → `Some("typescript")`, (2) `type` attribute contains `"typescript"` → `Some("typescript")`, (3) neither → `None`. Only branch 1 is exercised by `parse_html_with_typescript_script` (via `lang="ts"`). Branch 2 (`type="text/typescript"`) and branch 3 (e.g., `<script type="application/ld+json">`) have no direct test. The `None` path for non-JS/TS types is particularly important: for JSON-LD scripts, the fallback to `"javascript"` means the JavaScript parser tries to parse JSON, produces no function chunks, and keeps the outer Module chunk — but none of this behavior is asserted. If the fallback behavior changes (e.g., a future `detect_script_language` returns `Some("json")` for JSON-LD), no test would catch the difference.
+- **Suggested fix:** Add tests via `parse_file` for: (1) `<script type="text/typescript">` — assert TypeScript language; (2) `<script lang="typescript">` — assert TypeScript language; (3) `<script type="application/ld+json">` — assert outer Module chunk is kept (no JSON-language injection occurs since JSON injection is not registered for HTML). All three are easy to add alongside the existing `parse_html_with_typescript_script` test.
+
+#### TC-6: No test for injection with malformed/unclosed `<script>` — error-recovery behavior unverified
+- **Difficulty:** medium
+- **Location:** src/parser/injection.rs:99-185, src/language/html.rs
+- **Description:** All injection tests use well-formed HTML. tree-sitter is an error-tolerant parser: for malformed input it produces a parse tree with error nodes, but the structure may differ from the well-formed case. Untested scenarios: (1) `<script>` with no closing `</script>` — tree-sitter may produce a truncated `raw_text` node or no content child; `find_content_child` returning `None` is the graceful path but is never exercised by a test; (2) empty `<style></style>` with no whitespace — the `byte_range.start < byte_range.end` guard at injection.rs:114 should skip it, but this is untested; (3) `<script>` body containing a JS syntax error (e.g., `function incomplete() {`) — JS parser's error recovery should still produce a function node for any well-formed function before the error. A `tree-sitter-html` grammar update could change error-recovery behavior, silently breaking injection for common malformed-HTML patterns.
+- **Suggested fix:** Add tests for: (1) HTML with unclosed `<script>` — assert `parse_file` completes without panic; (2) `<style></style>` (zero-byte content) — assert outer Module chunk is kept; (3) `<script>` with a JS syntax error followed by a valid function — assert the valid function chunk is extracted.
 
 ## Data Safety
 
-#### DS-1: HNSW save — partial file rename leaves inconsistent index on mid-loop failure
+#### DS-NEW-1: `parse_file_relationships` does not remove outer relationship entries when injection succeeds — call graph and type edges include both outer and inner entries for the same container region
 - **Difficulty:** medium
-- **Location:** src/hnsw/persist.rs:241-272
-- **Description:** `HnswIndex::save()` renames files from the temp directory to the final location in a sequential loop over `["hnsw.graph", "hnsw.data", "hnsw.ids", "hnsw.checksum"]`. If the rename succeeds for `hnsw.graph` and `hnsw.data` but fails for `hnsw.ids` (e.g., disk full, permissions), the method returns `Err` but the final directory now contains new graph+data files with the old (or missing) id map. The checksum file is renamed last, so a crash before that step means `load()` will fail checksum verification — which is the intended safety net. However, the specific failure mode where rename #3 (`hnsw.ids`) fails but #1 and #2 succeeded leaves new graph+data alongside the old id map from a previous save. On next `load()`, checksums from the old checksum file won't match the new graph/data, so load fails. But the old id map is now permanently desynchronized — a subsequent successful save would need to happen to recover. The recovery path works (next `cqs index` rebuilds everything), but the intermediate state is confusing and could mislead debugging.
-- **Suggested fix:** Rename files in reverse dependency order: checksum last (already done), but also track which renames succeeded. On failure mid-loop, attempt to roll back already-renamed files by renaming them back from final to temp. If rollback also fails, log a warning with explicit recovery instructions ("run `cqs index --force`").
+- **Location:** src/parser/calls.rs:388-407, src/parser/mod.rs:235-265
+- **Description:** `parse_file` (mod.rs:242-249) removes outer chunks that overlap with injection containers when inner parsing succeeds: `chunks.retain(|c| !injection::chunk_overlaps_container(...))`. This is the correct behavior — the outer HTML Module chunk that wraps a `<script>` block is replaced by the injected JS functions. But `parse_file_relationships` (calls.rs:388-407) has no analogous removal step: it appends injected `FunctionCalls` and `ChunkTypeRefs` via `.extend(inner_calls)` and `.extend(inner_types)` **without** removing the outer `FunctionCalls`/`ChunkTypeRefs` entries that the outer HTML parser already produced for the same container region. In practice, the HTML parser's chunk query only captures Module-level nodes (whole `<script>` blocks), so the outer call extraction for that node would be empty. But if the outer grammar produces a named chunk that contains the injection region (e.g., the Module chunk for `<script>`), and the outer call query captures any call sites within it (e.g., HTML event attributes), those calls would appear in the call graph alongside the injected JS calls, potentially doubling some entries. More critically, `upsert_function_calls` (calls.rs:300-303) does `DELETE FROM function_calls WHERE file = ?1` and re-inserts everything, so both outer and inner call entries are stored. The outer Module-level chunk is not stored in the chunks table (it was replaced), but its callers/callees may still appear in `function_calls` with a `caller_name` that no longer has a corresponding chunk, creating dangling function_calls entries.
+- **Suggested fix:** Mirror `parse_file`'s retain logic in `parse_file_relationships`: after computing `groups`, for each group that produces non-empty `(inner_calls, inner_types)`, remove from `call_results` and `type_results` any entry whose `name` and `line_start` correspond to an outer chunk that `chunk_overlaps_container` would remove (i.e., an outer chunk fully within the container line range). This requires computing `InjectionGroup.container_lines` in `parse_file_relationships`, which is already available since `find_injection_ranges` returns `InjectionGroup` with `container_lines` populated.
 
-#### DS-2: `acquire_index_lock` — truncate(true) races with concurrent read of PID
-- **Difficulty:** easy
-- **Location:** src/cli/files.rs:57, 99, 104
-- **Description:** Both `acquire_index_lock` and `try_acquire_index_lock` open the lock file with `.truncate(true)` before calling `try_lock()`. If process A holds the lock and process B opens with `truncate(true)`, B truncates the lock file's content (clearing A's PID) before attempting the lock. The `try_lock()` call will fail (A still holds the OS lock), but A's PID is now gone from the file. If A crashes while the file is truncated, the stale lock detection in `acquire_index_lock` reads an empty file, fails to parse a PID (`content.trim().parse::<u32>()` fails on empty string), and falls through to the "lock held" error without cleaning up the stale lock. The user gets "Another cqs process is indexing" with no way to detect the stale state. Next attempt also fails because `retried` is only set when a PID is found and the process is dead.
-- **Suggested fix:** Open without `.truncate(true)`. Only write the PID after successfully acquiring the lock. This prevents any process from clearing another's PID metadata.
+#### DS-NEW-2: `chunk_overlaps_container` uses strict containment (`>=`/`<=`) rather than overlap — outer chunks that straddle injection boundaries are silently kept alongside inner chunks
+- **Difficulty:** medium
+- **Location:** src/parser/injection.rs:486-494, src/parser/mod.rs:243-249
+- **Description:** `chunk_overlaps_container` returns true only when `chunk_start >= container_start && chunk_end <= container_end` — i.e., the outer chunk is fully enclosed by the container. If an outer parser chunk partially overlaps an injection container (e.g., a chunk whose start line is within the container but end line is outside it, or vice versa), it will NOT be removed by the `retain` filter. The result is both the partial outer chunk AND the injected inner chunks from that region are stored, creating duplicate/conflicting index entries for the same source lines. For HTML, the outer grammar captures Module chunks and inline event handlers, and it is plausible for tree-sitter's error recovery (on malformed HTML) to produce a chunk whose line range straddles a `<script>` boundary. The naming is also misleading: "overlaps" typically implies any intersection, but the implementation requires full containment. This was previously noted in the Algorithm Correctness category (naming mismatch), but the data safety consequence — duplicate chunks from the same line range — was not filed.
+- **Suggested fix:** Either (a) rename to `chunk_contained_by_any_container` to document the strict containment semantics, and verify that strict containment is correct for all expected outer grammar chunk kinds; or (b) change to an overlap check (`chunk_start <= container_end && chunk_end >= container_start`) to remove any outer chunk that shares any lines with an injection container, accepting more aggressive removal. Document which semantics are intended and add tests (already filed as TC-1).
 
-#### DS-3: `extract_relationships` not atomic with chunk upserts — crash between pipeline and relationships leaves index with chunks but no call graph
-- **Difficulty:** easy
-- **Location:** src/cli/commands/index.rs:120-133
-- **Description:** `cmd_index` runs the pipeline (which upserts chunks+calls per file via `upsert_chunks_and_calls`), then separately calls `extract_relationships()` which overwrites the call graph with `upsert_function_calls` (per file, each in its own transaction). The pipeline's chunk-level `calls` table and the relationship-level `function_calls` table are updated at different times. If `cqs index` is interrupted (Ctrl+C) between the pipeline completing and `extract_relationships` finishing, the `function_calls` table contains stale data from the previous index run. Queries using `function_calls` (blame, callers with line-level precision) return stale call sites that don't match current chunk content. The `calls` table (chunk-level) is correct since the pipeline updates it atomically with chunks, but `function_calls` (line-level) is stale. No staleness indicator exists for this case.
-- **Suggested fix:** Add a metadata flag (`"relationships_stale" = "true"`) set before `extract_relationships` starts and cleared after it finishes. Commands using `function_calls` (blame, callers with context) can check this flag and warn. Alternatively, clear `function_calls` at the start of pipeline (before chunks are written) so stale data is never returned — only "no data" during the window.
+#### DS-NEW-3: `upsert_chunks_and_calls` (store_stage) and `upsert_function_calls` (extract_relationships) write to overlapping tables for the same file without coordination — partial failure leaves calls table inconsistent
+- **Difficulty:** medium
+- **Location:** src/cli/pipeline.rs:577-621, src/cli/commands/index.rs:183-234, src/store/chunks.rs:434-464, src/store/calls.rs:283-343
+- **Description:** The index pipeline has two separate write passes: (1) `store_stage` calls `upsert_chunks_and_calls` which writes to both the `chunks` table and the `calls` table (chunk-level calls, extracted via `extract_calls_from_chunk`); (2) `extract_relationships` calls `upsert_function_calls` which writes to `function_calls` table and `upsert_type_edges_for_file` which writes to `type_edges`. These are three different tables updated in two separate transactions at different stages. If the process is interrupted between `store_stage` completing and `extract_relationships` completing, the `chunks` table is up to date but `function_calls` and `type_edges` are stale (still reflecting the previous version of the file). On the next `cqs index` run, files are only reindexed if their mtime changed. If the file was not modified, `needs_reindex` returns `None`, the file is skipped by `store_stage`, and `extract_relationships` is called for all files in `existing_files` regardless of mtime. So `function_calls` would be updated even without a mtime change — but `type_edges` uses the same unconditional loop. The risk is: a crash mid-run leaves `function_calls` stale for already-processed files, but a re-run with unchanged files fixes it. The more serious case is: `upsert_type_edges_for_file` queries `chunks WHERE origin = ?1` inside a transaction to resolve `(name, line_start)` → `chunk_id` (types.rs:129-146). If a chunk was replaced with different ID structure (different hash after a code change), the `name_to_id` lookup at types.rs:152-163 logs a `warn!` and silently skips, leaving no type edges for that chunk. There is no aggregate signal that edges were dropped.
+- **Suggested fix:** Add a counter for skipped type edges in `upsert_type_edges_for_file` and log a `warn!` with the count at the end (similar to how DS-6 was fixed). The skipped-chunks warning is already there (types.rs:158-164) but per-chunk; a summary log at function exit would surface systematic mismatches. Longer term: consider a single-pass write that combines chunk upsert, calls, and type edge updates in one transaction per file.
 
-#### DS-4: `prune_stale_calls` and `prune_stale_type_edges` execute outside GC's index lock scope after chunk pruning
-- **Difficulty:** easy
-- **Location:** src/cli/commands/gc.rs:44-59
-- **Description:** `cmd_gc` acquires the index lock at line 23, then runs `prune_missing` (chunks), `prune_stale_calls`, and `prune_stale_type_edges` sequentially. Each operates in its own transaction. Between `prune_missing` (which deletes chunks) and `prune_stale_calls` (which deletes orphan call entries), a concurrent `cqs watch` process could insert new function_calls referencing chunks that were just pruned. The watch process checks `try_acquire_index_lock` and skips if locked — so normally this doesn't happen. But on WSL where advisory locking is unreliable (documented in PB-4), watch mode could proceed with a reindex cycle that inserts new rows into `function_calls` for a file that GC just pruned, creating orphan call entries. Self-heals on next GC run, but the window exists.
-- **Suggested fix:** Wrap all three prune operations in a single transaction. `prune_missing` already uses a transaction internally, so either: (a) expose a `prune_all()` that combines all three in one tx, or (b) accept the self-healing property and document the WSL advisory locking limitation as the root cause (not this code).
-
-#### DS-5: `notes_summaries_cache` invalidation is caller-responsibility — easy to miss on new mutation paths
-- **Difficulty:** easy
-- **Location:** src/store/mod.rs:746-754, src/store/notes.rs:122,224
-- **Description:** The `notes_summaries_cache` (RwLock<Option<Vec<NoteSummary>>>) is manually invalidated via `self.invalidate_notes_cache()` after note mutations. Currently called at two sites: `upsert_notes_batch` (line 122) and `replace_notes_for_file` (line 224). If a future mutation path is added to notes (e.g., `delete_note_by_id`, `update_note_sentiment`) without calling `invalidate_notes_cache()`, the cache returns stale data. The pattern is fragile because: (1) the cache lives on `Store` not `notes.rs`, so the relationship is non-local, (2) there's no compile-time enforcement. Prior audit DS-3 (v0.19.2) fixed `OnceLock` → `RwLock` for cache invalidation, but the caller-responsibility pattern remains.
-- **Suggested fix:** Add a `/// IMPORTANT: Call `invalidate_notes_cache()` after any note mutation` doc comment on the `notes_summaries_cache` field. Or, make all note mutations go through a single `fn mutate_notes(&self, f: impl FnOnce(&mut Transaction)) -> Result<()>` that automatically invalidates the cache post-commit.
-
-#### DS-6: `bytes_to_embedding` and `embedding_slice` silently skip corrupted embeddings — no aggregate corruption signal
-- **Difficulty:** easy
-- **Location:** src/store/helpers.rs:696-706, 714-725
-- **Description:** `bytes_to_embedding` and `embedding_slice` return `None` when the byte length doesn't match expected dimensions, with only `tracing::trace!` logging. Callers use `.filter_map()` to silently skip these entries. In `search_notes` (notes.rs:163), `note_embeddings` (notes.rs:338), and multiple search paths, corrupted embeddings are individually skipped with no aggregation. If a schema migration or embedder bug produces widespread dimension mismatches, the user sees degraded search quality (fewer results, missing notes) with no visible error. The per-entry trace-level logging requires `RUST_LOG=trace` to see, and even then doesn't aggregate (100 skips = 100 individual trace lines, no summary).
-- **Suggested fix:** Add a counter to search paths that tracks skipped-due-to-dimension-mismatch entries. If the count exceeds a threshold (e.g., >5% of scanned entries), emit a `tracing::warn!` with the count and a "run `cqs index --force` to re-embed" suggestion. This surfaces systematic corruption without impacting the common case (zero skips).
-
-## Resource Management
-
-#### RM-1: `chm_to_markdown` and `webhelp_to_markdown` accumulate all page content in memory then `join()` — peak is 2× output size
-- **Difficulty:** easy
-- **Location:** src/convert/chm.rs:119-157, src/convert/webhelp.rs:93-128
-- **Description:** Both converters collect all converted Markdown pages into a `Vec<String>` (`all_markdown`) and then call `.join("\n\n---\n\n")`. The `join` call allocates a new contiguous string equal to the total of all pages, while the `Vec<String>` holding the original pages is still alive. Peak memory = `all_markdown` Vec + `merged` String ≈ 2× output size. With `MAX_PAGES = 1000` pages and typical API reference pages converting to 50–150 KB each, average peak is ~100–300 MB; worst case with dense HTML is ~500 MB + 500 MB = ~1 GB before `all_markdown` is dropped. There is no guard on cumulative output size — only a page count guard (`MAX_PAGES = 1000`). A single 100 MB HTML page would produce a 100 MB string and pass the page-count check.
-- **Suggested fix:** Two independent fixes: (1) Add a cumulative byte guard: after `all_markdown.push(md)`, check `all_markdown.iter().map(|s| s.len()).sum::<usize>() > MAX_TOTAL_BYTES` (e.g., 200 MB) and `break` with a warning. (2) Write to a `String` with `push_str` instead of collecting into a Vec then joining, so only one copy exists at a time. Example: `let mut merged = String::new(); for md in all_markdown { if !merged.is_empty() { merged.push_str("\n\n---\n\n"); } merged.push_str(&md); }`.
-
-#### RM-2: `html_file_to_markdown` and `markdown_passthrough` load entire file into memory with no size guard
-- **Difficulty:** easy
-- **Location:** src/convert/html.rs:32, src/convert/mod.rs:113
-- **Description:** `html_file_to_markdown` reads the entire HTML file into a `String` with `std::fs::read_to_string(path)`, then passes it to `html_to_markdown`. `markdown_passthrough` does the same. Neither checks file size before reading. A 500 MB HTML file would allocate a 500 MB `String`, and after conversion the original string and the Markdown output both exist simultaneously in memory. The CHM and Web Help converters guard against page count but not per-page size — individual pages can be arbitrarily large. The `run_git_diff` finding (SEC-6) already identifies the same pattern for git output.
-- **Suggested fix:** Check `path.metadata()?.len()` before reading. If greater than a configurable limit (e.g., 100 MB), bail with a descriptive error: `"File too large to convert ({}MB > 100MB limit): {}"`. Match the limit used for the git diff guard in SEC-6.
-
-#### RM-3: `BatchContext::refs` — loaded reference indexes accumulate for the session lifetime with no eviction
-- **Difficulty:** easy
-- **Location:** src/cli/batch/mod.rs:60, 139-168
-- **Description:** `BatchContext::refs` is a `RefCell<HashMap<String, ReferenceIndex>>` that is populated on first access via `get_ref()` and never evicted. Each `ReferenceIndex` holds a full `Store` (SQLite pool with up to 1 read-only connection at 64 MB mmap + 4 MB cache) and an optional `HnswIndex` (loaded HNSW graph for the reference). A batch session referencing all configured references accumulates all of them simultaneously. With 5 references of 100k chunks each, each HNSW graph is ~300 MB; 5 loaded simultaneously = ~1.5 GB HNSW + 5 × 68 MB SQLite = ~1.9 GB. The RM-16 fix (PR #502) correctly limits to loading only the target reference per `get_ref` call, but all previously loaded references remain in memory for the full session.
-- **Suggested fix:** This is largely acceptable as-is — references are loaded on demand and the common case is 1-2 references. Add a tracing note at load time: `tracing::info!(name, total_loaded = refs.len(), "Reference loaded; {} references in memory", refs.len())` so users can see accumulation in traces. If eviction is needed, switch to an LRU map bounded at N references.
-
-#### RM-4: Pipeline `PIPELINE_CHANNEL_DEPTH = 256` uses the same depth for both `ParsedBatch` (chunks only) and `EmbeddedBatch` (chunks + embeddings) — embed channel can hold ~40 MB
-- **Difficulty:** easy
-- **Location:** src/cli/pipeline.rs:37, 652-657
-- **Description:** All three pipeline channels (`parse_tx/rx`, `embed_tx/rx`, `fail_tx/rx`) use `bounded(PIPELINE_CHANNEL_DEPTH)` with depth 256. `ParsedBatch` holds chunks with content strings — roughly 15 MB at full depth. `EmbeddedBatch` also holds chunk content *plus* 769-dim f32 embeddings (~3 KB each) — roughly 40 MB at full depth. If the writer (SQLite insert) stalls (e.g., fsync, WAL checkpoint), backpressure fills the embed channel before the parse channel, holding ~40 MB of embedded but unwritten chunks. This is bounded and not catastrophic, but using a single depth constant for payloads that differ 2.6× in size is suboptimal. The constant's comment says "Files to parse per batch (bounded memory)" which applies to `FILE_BATCH_SIZE`, not `PIPELINE_CHANNEL_DEPTH`.
-- **Suggested fix:** Use separate depth constants: `const PARSE_CHANNEL_DEPTH: usize = 256` (lightweight) and `const EMBED_CHANNEL_DEPTH: usize = 64` (heavy payloads). The embed channel at depth 64 would hold ~10 MB — more proportionate to the payload difference. Also fix the misleading comment on line 36 which describes `FILE_BATCH_SIZE`, not `PIPELINE_CHANNEL_DEPTH`.
-
-#### RM-5: Watch mode `last_indexed_mtime` grows to cover all indexed files and is only pruned on successful reindex — deleted-file cleanup depends on expensive `root.join(f).exists()` per entry
-- **Difficulty:** easy
-- **Location:** src/cli/watch.rs:117, 307-311
-- **Description:** `last_indexed_mtime: HashMap<PathBuf, SystemTime>` accumulates an entry for every file ever indexed in the watch session. The `retain(|f, _| root.join(f).exists())` call (line 311) prunes deleted files, but only runs in the success branch of `reindex_files`. If reindexing fails (e.g., embedder error), the prune is skipped — deleted files stay in the map indefinitely. On a large project with 50k source files, the map holds 50k `PathBuf`+`SystemTime` pairs (~50k × ~100 bytes ≈ 5 MB), which is tolerable. The `exists()` check on every entry on every reindex cycle is O(file_count) filesystem calls. For 50k files that's 50k `stat()` calls per reindex event, which adds latency to otherwise fast incremental reindexes. The `retain` runs every cycle regardless of how many files changed.
-- **Suggested fix:** Move the `retain` outside the `Ok` branch — run it after every reindex attempt (success or failure). For the `exists()` cost, consider only pruning when a delete event is detected: add `pending_deletes: HashSet<PathBuf>` alongside `pending_files`, and in `collect_events` when a `Remove` event fires, add to `pending_deletes`. Then in `process_file_changes`, only call `last_indexed_mtime.remove()` for the deleted entries rather than scanning all.
-
-#### DS-7: `cmd_index --force` removes old database before creating the new one — interruption loses entire index
-- **Difficulty:** easy
-- **Location:** src/cli/commands/index.rs:69-76
-- **Description:** When `--force` is passed, `cmd_index` removes the existing `index.db` at line 71, then opens a new empty store at line 73 and calls `init()`. If the process is killed between the `remove_file` and the completion of `run_index_pipeline`, the user has no index at all — neither old nor new. For a large codebase, the pipeline can take minutes, so this window is significant. The HNSW save uses temp-dir-then-rename for crash safety, but the SQLite database itself gets no such protection.
-- **Suggested fix:** Instead of removing the old index first, build the new index to a temp path (e.g., `index.db.new`), then atomically rename over the old one after the pipeline completes successfully. If interrupted, the old index remains intact. This is the same pattern used for HNSW save and note file rewrites.
-
+#### DS-NEW-4: Injected chunk IDs are generated from the outer file path + inner `line_start` + content hash — a collision is possible if two injection groups produce a chunk at the same line with the same first 8 chars of BLAKE3 hash
+- **Difficulty:** hard
+- **Location:** src/parser/chunk.rs:101, src/parser/injection.rs:250
+- **Description:** Chunk IDs are `format!("{}:{}:{}", path, line_start, hash_prefix)` where `hash_prefix` is the first 8 hex chars (4 bytes) of the BLAKE3 hash of the chunk's content (chunk.rs:100-101). Two chunks in the same file at the same starting line with a hash collision in the first 8 hex digits would get the same ID. For non-injection files, two chunks at the same `line_start` would have to overlap substantially, which tree-sitter prevents (it produces non-overlapping captures for disjoint nodes). But with injection, the outer parser and inner parser both capture nodes that may start at the same line (e.g., the `<script>` tag starts at line 5, and the first JS function inside it also starts at line 5 before the outer chunks for line 5 are removed by `chunk_overlaps_container`). The 8-hex-char prefix means a birthday-attack collision requires only ~65,536 chunks, but a natural collision in a realistic codebase is extremely unlikely. If a collision occurs, `INSERT OR REPLACE INTO chunks` (chunks.rs:371) would silently overwrite the first chunk with the second. The real risk is not a random collision but a deterministic collision: if the outer HTML module chunk for a `<script>` block AND the inner JS function both start at line 5, the outer chunk is supposed to be removed by the `retain` filter — but if injection produces zero inner chunks (fallback path), the outer chunk is kept with a valid ID. When injection later succeeds (after a code edit), the injected chunk may get the same line_start as the outer chunk had, and `INSERT OR REPLACE` would silently replace it. This is actually correct behavior (replacement is desired), but there is no test asserting that re-indexing a file where injection transitions from "no inner chunks" to "has inner chunks" correctly replaces the outer chunk entry.
+- **Suggested fix:** Low priority for hash collision — 8 hex chars (32 bits) is sufficient for typical codebases. For the injection transition case: add a test that verifies re-indexing an HTML file after adding a JS function to an empty `<script>` block correctly replaces the outer Module chunk with the inner JS chunk (no duplicate entries in the chunks table).
 
 ## Performance
 
-#### PF-1: `search_by_candidate_ids` parses language/chunk_type strings to enums per candidate when filters are active
-- **Difficulty:** easy
-- **Location:** src/search.rs:884-905
-- **Description:** In the HNSW-guided search path (`search_by_candidate_ids`), when `filter.languages` or `filter.chunk_types` is set, the scoring loop calls `candidate.language.parse::<Language>()` and `candidate.chunk_type.parse::<ChunkType>()` for every candidate (up to 500). Parsing enum from a string on every iteration is O(candidates) string comparisons plus allocation for the parse error path. Since the filter sets are fixed before the loop, a pre-built `HashSet<&str>` (or even `HashSet<String>`) of the allowed language/type string representations would reduce this to a single hash lookup per candidate, and avoids the parse entirely.
-- **Suggested fix:** Before the loop, compute `let lang_strs: Option<HashSet<String>> = filter.languages.as_ref().map(|ls| ls.iter().map(|l| l.to_string()).collect())` and similarly for chunk_types. Inside the loop, replace `candidate.language.parse()` + `langs.contains(&lang)` with `!lang_strs.contains(&candidate.language)`.
+#### PF-NEW-1: `parse_file` + `parse_file_relationships` double-reads and double-parses every file during full index
+- **Difficulty:** hard
+- **Location:** src/cli/commands/index.rs:87,130-131; src/cli/watch.rs:395,512; src/cli/pipeline.rs:267
+- **Description:** The full index pipeline calls `run_index_pipeline` (which calls `parse_file` on every file) and then calls `extract_relationships` (which calls `parse_file_relationships` on every file). Each call reads the file from disk and runs tree-sitter parse. For a project with 1,000 source files, every `cqs index` run reads every file twice and runs two complete tree-sitter parses per file. For HTML files (the only language with injection rules), the outer tree is also built twice, and each injection group triggers an additional inner re-parse in both `parse_file` and `parse_file_relationships`. The watch incremental path (`reindex_files` in watch.rs:395,512) has the same double-parse: `parse_file` then `parse_file_relationships`. Additionally, `reindex_files` calls `extract_calls_from_chunk` for each chunk to build the call graph, which creates **yet another** tree-sitter parser and re-parses the chunk's content — so for the watch path, each file is parsed at least 3 times (once for chunks, once for relationships, once per chunk for calls). `parse_file_relationships` already returns both call sites and type refs in a single pass — the watch path uses it for type edges only and discards the call sites it already computed.
+- **Suggested fix:** Merge `parse_file` and `parse_file_relationships` into a combined `parse_file_all` that returns `(Vec<Chunk>, Vec<FunctionCalls>, Vec<ChunkTypeRefs>)` in a single read + single parse. The full-index pipeline already separates the two passes by design (pipeline stages), so the short-term fix for watch is to use the `function_calls` returned by `parse_file_relationships` instead of discarding them, eliminating `extract_calls_from_chunk` from the watch path.
 
-#### PF-2: `search_filtered` clones all semantic IDs to `Vec<String>` solely to pass to `rrf_fuse`
+#### PF-NEW-2: `capture_index_for_name("name")` called inside per-match hot loops — should be hoisted
 - **Difficulty:** easy
-- **Location:** src/search.rs:757, src/store/mod.rs:661
-- **Description:** After the brute-force scoring loop, `scored: Vec<(String, f32)>` contains the top embedding-scored candidates. When RRF is enabled, line 757 creates `semantic_ids: Vec<String>` by cloning every ID string from `scored`, then passes it to `rrf_fuse(&semantic_ids, ...)`. Inside `rrf_fuse`, these Strings are immediately borrowed as `&str` for the HashMap (line 670). After the call, the cloned `semantic_ids` Vec is dropped. For a typical `semantic_limit` of 30-60 results, this is 30-60 unnecessary String heap allocations per search. `rrf_fuse` signature could accept `&[(String, f32)]` (the scored Vec directly) and extract IDs as `id.as_str()` internally, or take `impl IntoIterator<Item = &str>`.
-- **Suggested fix:** Change `rrf_fuse` to accept `semantic_ids: &[(String, f32)]` and let it iterate `semantic_ids.iter().map(|(id, _)| id.as_str())` internally. Remove the intermediate `Vec<String>` at line 757. Same pattern applies to `search_by_candidate_ids` line 943.
+- **Location:** src/parser/calls.rs:301; src/parser/injection.rs:388; src/parser/chunk.rs:41,50
+- **Description:** `tree_sitter::Query::capture_index_for_name` performs a string search over the query's capture name list. It is called once per query match inside tight loops, but the result is invariant for a given `Query` object — the capture index for `"name"` never changes between matches. In `calls.rs:301` and `injection.rs:388`, `chunk_query.capture_index_for_name("name")` is inside `while let Some(m) = matches.next()`. In `chunk.rs`, `extract_chunk` is called once per match from `parse_file`'s inner loop, and calls `capture_index_for_name` up to 16 times (once per entry in `capture_types` + once for `"name"`). For a file with 100 functions, this is up to 1,700 redundant string lookups per parse.
+- **Suggested fix:** In `parse_file_relationships` (calls.rs) and `parse_injected_relationships` (injection.rs), hoist `let name_idx = chunk_query.capture_index_for_name("name")` outside the `while let Some(m)` loop. In `extract_chunk` (chunk.rs), pre-build a `HashMap<u32, ChunkType>` mapping capture index → `ChunkType` before the match loop and pass it in, or cache it in the `Parser` struct alongside the `OnceCell<Query>`.
 
-#### PF-3: `search_by_name` re-lowercases the query string for every result in the post-fetch scoring loop
+#### PF-NEW-3: `find_injection_groups` uses linear scan to group by language — O(n) per entry with O(groups) comparisons
 - **Difficulty:** easy
-- **Location:** src/store/mod.rs:646
-- **Description:** `search_by_name` fetches FTS-matched chunks then rescores each with `score_name_match(&chunk.name, name)`. Inside `score_name_match`, `name.to_lowercase()` is called on every invocation — it allocates a new `String` each time. For a limit-20 name lookup (the default from `resolve_target`), this means 20 identical `to_lowercase()` allocations for the same query string. `score_name_match_pre_lower` already exists for exactly this pattern (pre-lowercased strings, inline doc says "use when calling in a loop").
-- **Suggested fix:** Before the result iterator, compute `let name_lower = name.to_lowercase();` and call `score_name_match_pre_lower(&chunk.name.to_lowercase(), &name_lower)` (or pre-lower `chunk.name` too). The `score_name_match_pre_lower` function is at `src/store/helpers.rs:648`.
+- **Location:** src/parser/injection.rs:83-93
+- **Description:** After collecting all `(lang_name, range, container_lines)` entries, grouping uses `groups.iter_mut().find(|g| g.language == language)`. For each entry, this linearly scans all existing groups. In practice, HTML has 2 injection rules (script → JavaScript/TypeScript, style → CSS), so at most 2-3 groups — cost is negligible now. But if injection rules expand (e.g., PHP, Vue, Svelte with multiple embedded languages), this becomes O(entries × groups). The entries Vec is also created unnecessarily: the grouping could be done inline during the tree walk without the intermediate allocation.
+- **Suggested fix:** Use a `HashMap<Language, InjectionGroup>` indexed by language during collection, then convert to `Vec<InjectionGroup>` at the end. This also eliminates the intermediate `entries` Vec.
 
-#### PF-4: `score_confidence` clones all candidate IDs to a separate `Vec<String>` before chunking
-- **Difficulty:** easy
-- **Location:** src/store/calls.rs:881
-- **Description:** `score_confidence` takes `candidates: Vec<LightChunk>` and immediately creates `candidate_ids: Vec<String>` by cloning `c.id` for every element. This Vec is used only for `candidate_ids.chunks(BATCH_SIZE)` in the SQL batch loop. For large codebases with many dead-code candidates (hundreds to thousands), this is an O(N) string clone with the only purpose being that the `.chunks()` slice iterator works. The original `candidates` Vec has the same length and can be chunked directly.
-- **Suggested fix:** Replace `candidate_ids.chunks(BATCH_SIZE)` with `candidates.chunks(BATCH_SIZE)`, extracting IDs inline: `for id in batch { q = q.bind(&id.id); }`. This eliminates the ID clone Vec entirely.
+#### PF-NEW-4: `parse_injected_chunks` and `parse_injected_relationships` each create a fresh `tree_sitter::Parser` and re-parse the same byte ranges independently
+- **Difficulty:** medium
+- **Location:** src/parser/injection.rs:207-231, 306-329
+- **Description:** For HTML files with both `<script>` and `<style>` blocks, `parse_file` calls `parse_injected_chunks` once per `InjectionGroup` (one for JS/TS, one for CSS) — each creates a new `tree_sitter::Parser`, sets `set_included_ranges`, and calls `parser.parse(source, None)`. Then `parse_file_relationships` calls `parse_injected_relationships` for the same groups, repeating the same parser creation and `source` re-parse. The parsed `tree_sitter::Tree` from `parse_injected_chunks` cannot currently be reused in `parse_injected_relationships` because they're called in separate functions without sharing state. A tree-sitter `Parser` object itself is reusable (supports `reset_language` / `set_language`) — creating a fresh one per injection group foregoes this optimization.
+- **Suggested fix:** Share a single `tree_sitter::Parser` instance across injection group parses by passing it as `&mut tree_sitter::Parser` into `parse_injected_chunks` and `parse_injected_relationships`. If the combined `parse_file_all` from PF-NEW-1 is implemented, injection chunks and relationships can be extracted from a single shared tree per inner language.
 
-#### PF-5: `fetch_active_files` uses `IN (subquery)` where a JOIN is more efficient
+#### PF-NEW-5: `extract_types` builds `HashSet<String>` of classified names by cloning all type name strings — avoidable with `&str`
 - **Difficulty:** easy
-- **Location:** src/store/calls.rs:841-843
-- **Description:** `fetch_active_files` runs `WHERE c.name IN (SELECT DISTINCT callee_name FROM function_calls)` to find files containing called functions. SQLite must first materialize the inner SELECT (all distinct callee_names) then check each chunk name against that set. With an index on `function_calls.callee_name` and `chunks.name`, a JOIN is equivalent and SQLite's query planner typically handles it more efficiently: `JOIN function_calls fc ON c.name = fc.callee_name`. The `DISTINCT` on callee_name in the subquery also forces a sort/dedup step that a `SELECT DISTINCT c.origin` with JOIN avoids.
-- **Suggested fix:** Replace the correlated subquery with a direct JOIN: `SELECT DISTINCT c.origin FROM chunks c JOIN function_calls fc ON c.name = fc.callee_name`. SQLite's query planner can use `idx_fcalls_callee` (on `callee_name`) and `idx_chunks_name` (on `name`) for a nested-loop join.
+- **Location:** src/parser/calls.rs:170-178
+- **Description:** After collecting classified and catch-all type refs, the deduplication step at calls.rs:170 builds `classified_names: HashSet<String>` by cloning the `type_name` field from every classified entry. Since `classified` is already a `Vec<TypeRef>` alive for the remainder of the function, the `HashSet` can reference the existing strings as `&str` without allocating new `String` copies.
+- **Suggested fix:** Change to `let classified_names: HashSet<&str> = classified.iter().map(|t| t.type_name.as_str()).collect();` and update the containment check to `classified_names.contains(t.type_name.as_str())`.
 
-#### PF-6: `build_batched` makes two passes over each batch — separate validation loop then data collection
+## Resource Management
+
+#### RM-NEW-1: Outer tree-sitter `Parser` and `Tree` not dropped before injection inner-parse phase in `parse_file`
 - **Difficulty:** easy
-- **Location:** src/hnsw/build.rs:140-157
-- **Description:** For each batch, the code first iterates all `(id, emb)` pairs to validate dimensions and emit `tracing::trace!` per item (lines 140-148), then immediately iterates the same batch again to build `data_for_insert` (lines 155-157). With 10K-row batches (the production default), this is 20K iterations per batch when a single combined loop would do 10K. The trace log is at `trace` level so it's typically inactive in production, making the first loop almost entirely wasted work.
-- **Suggested fix:** Combine the validation and collection into one loop. Move dimension checking inside the collection loop: validate `emb.len()` before pushing to `data_for_insert`. Move `tracing::trace!("Adding {} to HNSW index", id)` inside the combined loop too. This halves the iteration count per batch.
+- **Location:** src/parser/mod.rs:182-266, src/parser/calls.rs:247-409
+- **Description:** In `parse_file` (mod.rs), the outer `tree_sitter::Parser` is created at line 182 and last used at line 188 (the `.parse()` call). The outer `tree_sitter::Tree` is last used at line 238 (`find_injection_ranges(&tree, ...)`). Neither is explicitly dropped: both remain live until end of scope at line 266. During the injection inner-parse loop (lines 239–263), each call to `parse_injected_chunks` creates an additional inner `Parser` and `Tree` — so the outer parser's internal reusable buffers (lookahead pool, subtree pool, held since the HTML parse) are retained idle while inner allocations happen. The outer tree for a large HTML file can be several MB. In the rayon parallel parsing stage (`pipeline.rs:263`), `num_cpus` threads may each hold an outer HTML tree + inner JS/CSS tree simultaneously, approximately doubling peak tree memory for HTML-heavy projects compared to what is necessary. The same pattern exists in `parse_file_relationships` (calls.rs:247–409): outer `parser` last used at line 254, outer `tree` last used at line 391, both live until line 409.
+- **Suggested fix:** In `parse_file` (mod.rs), add `drop(parser);` after line 189 and `drop(tree);` after line 238 — four lines total (two per function), each a one-liner. Rust's NLL extends borrows but does not insert early drops for owned values; explicit `drop()` is required to reclaim memory before end of scope. In `parse_file_relationships` (calls.rs), add `drop(parser);` after line 254 and `drop(tree);` after line 391. Note: in `parse_file_relationships`, `tree` is borrowed inside the while loop (passed to `extract_types` at line 357 and `call_cursor.matches(call_query, tree.root_node(), ...)` at line 354) so `drop(tree)` can only follow line 391, not be moved earlier.
+
+#### RM-NEW-2: Call-deduplication `HashSet` in injection and relationship extractors clones every callee name string unnecessarily
+- **Difficulty:** easy
+- **Location:** src/parser/injection.rs:447-448, src/parser/calls.rs:351-357
+- **Description:** `parse_injected_relationships` (injection.rs:447) and `parse_file_relationships` (calls.rs) deduplicate call sites with `calls.retain(|c| seen.insert(c.callee_name.clone()))`. The `seen: HashSet<String>` takes ownership of a fresh clone of every `callee_name` string, even though the original strings live in the `calls` Vec for the rest of the iteration. Since `seen.clear()` is called per function (injection.rs:447) or a new `seen` is created per iteration (calls.rs:352), these clones are discarded almost immediately. For a function with N distinct call sites, this allocates N `String` heap objects that are freed within the same loop iteration. For JavaScript React components or large generated files with many calls per function (50–100+), this is 50–100 redundant allocations per function during relationship extraction. The allocation pattern is correct (deduplication works) but wasteful.
+- **Suggested fix:** Replace `HashSet<String>` with `HashSet<&str>` referencing into the existing `calls` Vec: `calls.retain(|c| seen.insert(c.callee_name.as_str()));` where `seen: HashSet<&str>`. This avoids all clones for the deduplication check. Apply to both injection.rs:447 and calls.rs (the corresponding `retain` at line 352). The lifetime of `&str` references is valid as long as `calls` is in scope, which it is for both sites.
+
+## Security
+
+#### SEC-NEW-1: Unbounded injection range count in HTML parser enables DoS via crafted file
+- **Difficulty:** easy
+- **Location:** src/parser/injection.rs:83-94, src/parser/injection.rs:212
+- **Description:** `find_injection_ranges` collects one `tree_sitter::Range` per `<script>` or `<style>` block into a single `InjectionGroup.ranges` Vec (groups are per-language, so all JavaScript blocks share one group). There is no cap on how many ranges a group may contain. A crafted 50 MB HTML file with ~2.8 million minimal `<script>x</script>` blocks (18 bytes each) would produce a Vec of ~2.8 M `tree_sitter::Range` structs (~90 MB of range data), which is then passed wholesale to `parser.set_included_ranges(&group.ranges)`. tree-sitter processes this range array before parsing, and the subsequent parse covers all 2.8 M script regions in one pass. On a machine with limited RAM this can cause OOM; at minimum it causes multi-second stalls during indexing. The file-size limit (50 MB, `MAX_FILE_SIZE`) is the only existing guard but does not bound range count because each range can be very small.
+- **Suggested fix:** Add a `MAX_INJECTION_RANGES` constant (e.g. `10_000`) and truncate — with a `tracing::warn!` — if `group.ranges.len()` would exceed it before calling `set_included_ranges`. Since the ranges within a single language group are non-overlapping script blocks, truncation means the tail of the file is treated as plain HTML rather than injected JS/CSS, which is a graceful degradation.
+
+#### SEC-NEW-2: Temp files written with umask-derived permissions before `chmod 0o600` is applied
+- **Difficulty:** easy
+- **Location:** src/audit.rs:119-135, src/config.rs:332-349, src/note.rs:250-273
+- **Description:** All three atomic-write paths share the same pattern: `std::fs::write(&tmp_path, &content)` creates the temp file with the process umask (typically `0o644` = world-readable), then `std::fs::rename(&tmp_path, &final_path)` renames it. `audit.rs` and `config.rs` apply `set_permissions(0o600)` **after** the rename, leaving a window where the renamed file is world-readable. `note.rs` (`rewrite_notes_file`) never applies `chmod` at all. On a multi-user system or shared CI runner the content is transiently readable. `config.toml` is the most sensitive: it contains `[[reference]]` entries with `path` and `source` fields that disclose filesystem layout. `audit-mode.json` contains only timestamps (low sensitivity). `notes.toml` contains user-authored note text (medium sensitivity, no `chmod` ever applied).
+- **Suggested fix:** Replace `std::fs::write` with an `OpenOptions` that sets `mode(0o600)` before writing (Unix only): `OpenOptions::new().write(true).create(true).truncate(true).mode(0o600).open(&tmp_path)` followed by `file.write_all(...)`. This ensures the temp file is created private from the start. The post-rename `chmod` in `audit.rs`/`config.rs` then becomes defense-in-depth rather than the primary guard. For `note.rs`, add the same `chmod` after rename.
+
+#### SEC-NEW-3: `run_git_log_line_range` does not validate colons in the file path — git `-L` spec misparse
+- **Difficulty:** easy
+- **Location:** src/cli/commands/blame.rs:79-93
+- **Description:** `run_git_log_line_range` validates that `rel_file` does not start with `'-'` (prevents git option injection), but does not check for embedded colons. The `-L` spec format is `start,end:filepath`. If a file in the index has a relative path containing `:` (legal on Linux, e.g. `src/proto:generated/foo.rs`), `line_range = format!("{},{}", start, end, git_file)` produces `"1,5:src/proto:generated/foo.rs"`. Git parses the first `:` as the end of the line-range expression and attempts to use `src/proto` as the ref and `generated/foo.rs` as the path, silently producing empty output or a git error rather than blame for the intended file. The caller `build_blame_data` returns `Ok(BlameData { commits: [] })` (empty result from `parse_git_log_output("")`) rather than an error, so the user sees an empty blame result with no indication of failure.
+- **Suggested fix:** Before building `line_range`, validate that `git_file` contains no `:`: `if git_file.contains(':') { anyhow::bail!("File path contains ':' which is incompatible with git -L spec: {}", git_file); }`. Colons in source file paths are extremely rare but legal; a clear error is better than silent empty results.

--- a/docs/audit-triage-v0.26.0-pre.md
+++ b/docs/audit-triage-v0.26.0-pre.md
@@ -1,0 +1,113 @@
+# Audit Triage — v0.19.4+
+
+Triaged 2026-03-02. 75 findings across 14 categories, 3 batches.
+
+## P1 — Easy + High Impact (fix immediately)
+
+| # | Finding | Category | Location | Status |
+|---|---------|----------|----------|--------|
+| RB-1 | SQLite 999-param limit on `fetch_candidates_by_ids_async` / `fetch_chunks_by_ids_async` — PF-5 regression | Robustness | src/store/chunks.rs:1366, 1326 | ✅ fixed |
+| AC-1 | `emit_empty_results` JSON injection — query string not escaped via raw `format!` | Algorithm | src/cli/commands/query.rs:29, similar.rs:99 | ✅ fixed |
+| DS-2 | `acquire_index_lock` truncate(true) races with concurrent PID read — stale lock unrecoverable | Data Safety | src/cli/files.rs:57, 99 | ✅ fixed |
+| DS-7 | `cmd_index --force` removes old DB before pipeline completes — interruption loses entire index | Data Safety | src/cli/commands/index.rs:69-76 | ✅ fixed |
+| SEC-2 | FTS query safety depends on `debug_assert` — compiled out in release builds | Security | src/store/mod.rs:609, chunks.rs:1199 | ✅ fixed |
+| CQ-1 | Dead `source/` module (~250 lines, zero callers) + stale CONTRIBUTING.md entry (DOC-1) | Code Quality | src/source/, lib.rs:81, CONTRIBUTING.md:109 | ✅ fixed |
+
+## P2 — Medium Effort + High Impact (fix in batch)
+
+| # | Finding | Category | Location | Status |
+|---|---------|----------|----------|--------|
+| TC-1 | 5 newest languages (Bash, HCL, Kotlin, Swift, ObjC) have zero parser integration tests | Test Coverage | tests/parser_test.rs, tests/fixtures/ | ✅ fixed |
+| TC-2 | `NoteBoostIndex` has zero tests — search scoring hot path | Test Coverage | src/search.rs:300-371 | ✅ fixed |
+| TC-3 | PF-5 `search_by_candidate_ids` language/chunk_type filter branches untested | Test Coverage | src/search.rs:883-905 | ✅ fixed (7 filter set unit tests) |
+| AD-3 | Core store types (`ChunkSummary`, `SearchResult`, `CallerInfo`, etc.) lack `Serialize` — manual `to_json()` everywhere | API Design | src/store/helpers.rs:128-330 | ✅ fixed |
+
+## P3 — Easy + Low Impact (fix if time)
+
+| # | Finding | Category | Location | Status |
+|---|---------|----------|----------|--------|
+| OB-1 | `resolve_target` has no tracing span | Observability | src/search.rs:57 | ✅ fixed |
+| OB-2 | `delete_by_origin` / `replace_file_chunks` no tracing spans | Observability | src/store/chunks.rs:194, 222 | ✅ fixed |
+| OB-3 | `search_filtered` exits without logging result count | Observability | src/search.rs:793 | ✅ fixed |
+| OB-4 | `Store::init` — no span on schema initialization | Observability | src/store/mod.rs:355 | ✅ fixed |
+| OB-5 | `warn_stale_results` missing entry span | Observability | src/cli/staleness.rs:19 | ✅ fixed |
+| OB-6 | `cmd_watch` no entry span | Observability | src/cli/watch.rs:54 | ✅ fixed |
+| OB-7 | `get_caller_counts_batch` / `get_callee_counts_batch` no spans | Observability | src/store/calls.rs:1147, 1163 | ✅ fixed |
+| AD-1 | `BatchCmd::Gather` direction is stringly-typed — should use `GatherDirection` enum | API Design | src/cli/batch/commands.rs:109 | ✅ fixed |
+| AD-2 | `get_callers()` is dead public API — zero callers | API Design | src/store/calls.rs:252 | ✅ fixed (deleted, tests updated to get_callers_full) |
+| AD-4 | `BlameEntry` / `BlameData` use manual JSON assembly (depends on AD-3) | API Design | src/cli/commands/blame.rs:18-155 | ✅ fixed (Serialize derive) |
+| AD-6 | 9 CLI command handlers accept unused `_cli: &Cli` parameter | API Design | blame.rs, where_cmd.rs, test_map.rs, etc. | ✅ fixed (6 handlers) |
+| EH-1 | `build_blame_data` discards `StoreError` chain via `.map_err` stringify | Error Handling | src/cli/commands/blame.rs:46 | ✅ fixed |
+| EH-2 | 7 bare `Store::open()` calls without path context | Error Handling | diff.rs, drift.rs, index.rs, reference.rs, watch.rs | ✅ fixed |
+| EH-3 | `SearchFilter::validate()` returns `&'static str` not proper error type | Error Handling | src/store/helpers.rs:513 | ✅ fixed (returns String with values) |
+| EH-4 | `dispatch_onboard` swallows `get_chunks_by_names_batch` error silently | Error Handling | src/cli/batch/handlers.rs:912 | acceptable (has tracing::warn) |
+| EH-5 | `GatherDirection::FromStr` uses `String` error type (moot if AD-1 fixed) | Error Handling | src/gather.rs:97 | moot (AD-1 fixed) |
+| EH-6 | `schema_version` silently defaults to 0 on parse failure | Error Handling | src/store/chunks.rs:873 | ✅ fixed (tracing::warn) |
+| DOC-2 | PRIVACY.md deletion instructions miss `config.toml` | Documentation | PRIVACY.md:46-51 | ✅ fixed |
+| DOC-3 | SECURITY.md symlink mitigation description is inaccurate (understates scope) | Documentation | SECURITY.md:94 | ✅ fixed |
+| DOC-4 | lib.rs doc comment omits Web Help format | Documentation | src/lib.rs:13 | ✅ fixed |
+| DOC-5 | `cqs dead --min-confidence` undocumented in README and CLAUDE.md | Documentation | README.md:243, CLAUDE.md:71 | ✅ fixed |
+| CQ-2 | Gather JSON assembly duplicated between CLI and batch handler | Code Quality | gather.rs:114, handlers.rs:406 | ✅ fixed (serde Serialize, removed to_json) |
+| EX-1 | `pipeable_command_names()` manually duplicates pipeable variants — stale on new commands | Extensibility | src/cli/batch/pipeline.rs:31-113 | ✅ fixed (PIPEABLE_NAMES const + sync test) |
+| EX-2 | `name_boost: 0.2` hardcoded — no shared constant with CLI default | Extensibility | src/cli/batch/handlers.rs:83 | ✅ fixed (DEFAULT_NAME_BOOST const) |
+| EX-3 | `HNSW_EXTENSIONS` / `HNSW_ALL_EXTENSIONS` overlap with no sync enforcement | Extensibility | src/hnsw/persist.rs:31,34 | ✅ fixed |
+| EX-5 | Note/code slot ratio `(limit * 3) / 5` inline formula repeated in tests | Extensibility | src/search.rs:1061, 1216, 1223 | ✅ fixed (min_code_slot_count fn) |
+| RB-3 | `where_to_add` core panics via `.expect()` on `query_embedding` | Robustness | src/where_to_add.rs:170 | ✅ fixed (AnalysisError::Phase) |
+| RB-4 | Blame passes inverted line ranges to git silently | Robustness | src/cli/commands/blame.rs:86 | ✅ fixed (swap + warn) |
+| RB-5 | Reranker/embedder `outputs[0]` panics if ONNX returns empty | Robustness | src/reranker.rs:140 | informational (SessionOutputs API) |
+| AC-3 | `token_pack` O(n²) `keep.iter().any()` in packing loop | Algorithm | src/cli/commands/mod.rs:134 | ✅ fixed (kept_any bool) |
+| AC-4 | `cap_scores` uses `u64::MAX - x` inversion trick (correct but fragile) | Algorithm | src/onboard.rs:175 | ✅ fixed (std::cmp::Reverse) |
+| TC-4 | `ChatHelper::complete` tab-completion logic untested | Test Coverage | src/cli/chat.rs:26-49 | ✅ fixed (4 tests) |
+| TC-6 | Batch pipeline error propagation for malformed mid-pipeline input untested | Test Coverage | src/cli/batch/pipeline.rs | ✅ fixed (6 tests) |
+| PB-2 | `notes_path` falls back to non-canonical path if file missing at watch start | Platform | src/cli/watch.rs:97-105 | acceptable (canonical after first event) |
+| PB-4 | Lock file open code duplicated; NTFS ignores `0o600` silently | Platform | src/cli/files.rs:52-115 | acceptable (already extracted to open_lock_file) |
+| PB-5 | `is_wsl()` has no `#[cfg(unix)]` guard | Platform | src/config.rs:15-25 | ✅ fixed |
+| SEC-1 | `CQS_PDF_SCRIPT` env var allows arbitrary script execution (defense-in-depth) | Security | src/convert/pdf.rs:56-68 | acceptable (documented in SECURITY.md) |
+| SEC-3 | `convert_directory` walk has no depth/file count limit | Security | src/convert/mod.rs:345 | ✅ fixed (max_depth 50) |
+| SEC-4 | HNSW index files written with no permission restriction (inconsistent with DB) | Security | src/hnsw/persist.rs | acceptable (0o600 set in persist) |
+| SEC-6 | `run_git_diff` can allocate unbounded memory — no size limit | Security | src/cli/commands/mod.rs:166-188 | ✅ fixed (50 MB limit) |
+| DS-3 | `extract_relationships` not atomic with chunk upserts — crash leaves stale call graph | Data Safety | src/cli/commands/index.rs:120-133 | acceptable (reindex recovers) |
+| DS-5 | `notes_summaries_cache` invalidation is caller-responsibility — fragile | Data Safety | src/store/mod.rs:746, notes.rs:122,224 | non-issue (all paths call invalidate) |
+| DS-6 | `bytes_to_embedding` silently skips corrupted embeddings — no aggregate signal | Data Safety | src/store/helpers.rs:696-725 | ✅ fixed (warn level logging) |
+| PF-1 | `search_by_candidate_ids` parses language/chunk_type strings per candidate (pre-build HashSet) | Performance | src/search.rs:884-905 | ✅ fixed |
+| PF-2 | `search_filtered` clones all semantic IDs to separate Vec for `rrf_fuse` | Performance | src/search.rs:757 | ✅ fixed (Vec<&str>) |
+| PF-3 | `search_by_name` re-lowercases query per result (use `score_name_match_pre_lower`) | Performance | src/store/mod.rs:646 | ✅ fixed |
+| PF-4 | `score_confidence` clones all candidate IDs to separate Vec | Performance | src/store/calls.rs:881 | ✅ fixed (Vec<&str>) |
+| PF-5 | `fetch_active_files` uses `IN (subquery)` where JOIN is more efficient | Performance | src/store/calls.rs:841-843 | ✅ fixed (INNER JOIN) |
+| PF-6 | `build_batched` two-pass loop (validation then collection) | Performance | src/hnsw/build.rs:140-157 | ✅ fixed (single pass) |
+| RM-1 | CHM/webhelp converters accumulate all pages then `join()` — 2× peak memory | Resource Mgmt | src/convert/chm.rs:119, webhelp.rs:93 | ✅ fixed (incremental String) |
+| RM-2 | `html_file_to_markdown` / `markdown_passthrough` load entire file with no size guard | Resource Mgmt | src/convert/html.rs:32, mod.rs:113 | ✅ fixed (100 MB limit) |
+
+## P4 — Hard or Low Impact (create issues)
+
+| # | Finding | Category | Location | Status |
+|---|---------|----------|----------|--------|
+| AD-5 | `dispatch_search` takes 9 individual parameters instead of a struct | API Design | src/cli/batch/handlers.rs:33-42 | ✅ fixed (SearchParams struct) |
+| CQ-3 | `token_pack_unified` / `token_pack_tagged` near-identical functions | Code Quality | src/cli/commands/query.rs:333-398 | ✅ fixed (generic `token_pack_results`) |
+| CQ-4 | `cmd_query` at 287 lines — multiple concerns in one function | Code Quality | src/cli/commands/query.rs:39-325 | acceptable (helper fns extracted in CQ-3) |
+| CQ-5 | 11 functions suppress `clippy::too_many_arguments` | Code Quality | multiple files | reduced to 10 (AD-5); remainder are internal watch/pipeline state |
+| EX-4 | `extract_from_scout_groups` bespoke extractor — new output shapes need new extractors | Extensibility | src/cli/batch/pipeline.rs:116-210 | ✅ fixed (nested extraction in `extract_from_standard_fields`) |
+| RB-2 | `CandidateRow::from_row` / `ChunkRow::from_row` use panicking `row.get()` | Robustness | src/store/helpers.rs:75-121 | informational |
+| RB-6 | `Language::def()` panics on disabled feature flags | Robustness | src/language/mod.rs:549, 570 | informational |
+| RB-7 | `Parser::new()` panics on registry/enum mismatch | Robustness | src/parser/mod.rs:62-67 | informational |
+| AC-2 | FTS not scoped to HNSW candidates — design tension, improves recall | Algorithm | src/search.rs:934-942 | by-design |
+| AC-5 | `bfs_shortest_path` uses empty-string sentinel for predecessor tracking | Algorithm | src/cli/commands/trace.rs:203-221 | informational |
+| TC-5 | `build_blame_data` only tested through components — no end-to-end with mock git | Test Coverage | src/cli/commands/blame.rs:36-68 | acceptable (parser tests + integration cover components) |
+| PB-1 | `cmd_watch` uses inotify on WSL; PollWatcher would be more reliable on `/mnt/` | Platform | src/cli/watch.rs:61-89 | existing behavior |
+| PB-3 | Forward-slash path in blame `-L` spec latently incompatible with native Windows git | Platform | src/cli/commands/blame.rs:50, 86 | ✅ fixed (backslash → forward-slash normalize) |
+| SEC-5 | `find_7z` / `find_python` search PATH without validation | Security | src/convert/chm.rs:168, pdf.rs:95 | ✅ fixed (validate exit status) |
+| DS-1 | HNSW save partial rename leaves inconsistent index on mid-loop failure | Data Safety | src/hnsw/persist.rs:241-272 | ✅ fixed (rollback on partial failure) |
+| DS-4 | `prune_stale_calls` executes outside GC's index lock scope after chunk pruning | Data Safety | src/cli/commands/gc.rs:44-59 | non-issue (`_lock` held for entire function) |
+| RM-3 | `BatchContext::refs` loaded references accumulate with no eviction | Resource Mgmt | src/cli/batch/mod.rs:60 | acceptable |
+| RM-4 | Pipeline channel depth same for parse (light) and embed (heavy) payloads | Resource Mgmt | src/cli/pipeline.rs:37 | ✅ fixed (512 parse / 64 embed) |
+| RM-5 | Watch `last_indexed_mtime` grows unbounded; `retain` runs O(files) `exists()` calls | Resource Mgmt | src/cli/watch.rs:117, 307-311 | ✅ fixed (conditional pruning at 1K/10K thresholds) |
+
+## Summary
+
+| Priority | Count | Action |
+|----------|-------|--------|
+| P1 | 6 | Fix immediately |
+| P2 | 4 | Fix in batch |
+| P3 | 50 | Fix if time |
+| P4 | 19 | Create issues / informational |
+| **Total** | **75** | |

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -1,113 +1,88 @@
-# Audit Triage — v0.19.4+
+# Audit Triage — v0.26.0
 
-Triaged 2026-03-02. 75 findings across 14 categories, 3 batches.
+Audit date: 2026-03-06. 14 categories, 3 batches, ~50 unique findings (some overlap across categories).
 
-## P1 — Easy + High Impact (fix immediately)
-
-| # | Finding | Category | Location | Status |
-|---|---------|----------|----------|--------|
-| RB-1 | SQLite 999-param limit on `fetch_candidates_by_ids_async` / `fetch_chunks_by_ids_async` — PF-5 regression | Robustness | src/store/chunks.rs:1366, 1326 | ✅ fixed |
-| AC-1 | `emit_empty_results` JSON injection — query string not escaped via raw `format!` | Algorithm | src/cli/commands/query.rs:29, similar.rs:99 | ✅ fixed |
-| DS-2 | `acquire_index_lock` truncate(true) races with concurrent PID read — stale lock unrecoverable | Data Safety | src/cli/files.rs:57, 99 | ✅ fixed |
-| DS-7 | `cmd_index --force` removes old DB before pipeline completes — interruption loses entire index | Data Safety | src/cli/commands/index.rs:69-76 | ✅ fixed |
-| SEC-2 | FTS query safety depends on `debug_assert` — compiled out in release builds | Security | src/store/mod.rs:609, chunks.rs:1199 | ✅ fixed |
-| CQ-1 | Dead `source/` module (~250 lines, zero callers) + stale CONTRIBUTING.md entry (DOC-1) | Code Quality | src/source/, lib.rs:81, CONTRIBUTING.md:109 | ✅ fixed |
-
-## P2 — Medium Effort + High Impact (fix in batch)
+## P1: Easy + High Impact — Fix Immediately
 
 | # | Finding | Category | Location | Status |
 |---|---------|----------|----------|--------|
-| TC-1 | 5 newest languages (Bash, HCL, Kotlin, Swift, ObjC) have zero parser integration tests | Test Coverage | tests/parser_test.rs, tests/fixtures/ | ✅ fixed |
-| TC-2 | `NoteBoostIndex` has zero tests — search scoring hot path | Test Coverage | src/search.rs:300-371 | ✅ fixed |
-| TC-3 | PF-5 `search_by_candidate_ids` language/chunk_type filter branches untested | Test Coverage | src/search.rs:883-905 | ✅ fixed (7 filter set unit tests) |
-| AD-3 | Core store types (`ChunkSummary`, `SearchResult`, `CallerInfo`, etc.) lack `Serialize` — manual `to_json()` everywhere | API Design | src/store/helpers.rs:128-330 | ✅ fixed |
+| 1 | `"section"` capture missing from `calls.rs` and `injection.rs` — LaTeX sections get wrong ChunkType in call graph | API Design, Code Quality | calls.rs:276, injection.rs:363 | ✅ fixed |
+| 2 | Capture-name→ChunkType match duplicated 3x, diverges — extract shared `capture_name_to_chunk_type()` | Code Quality, API Design | calls.rs:314, injection.rs:400, chunk.rs:18 | ✅ fixed |
+| 3 | `parse_file_relationships` doesn't remove outer container call/type entries when injection succeeds — dangling `function_calls` rows | Data Safety | calls.rs:388-407 | ✅ fixed |
+| 4 | CSS injection test has vacuous `if !css_chunks.is_empty()` guard — passes even if CSS injection is broken | Test Coverage | html.rs tests | ✅ fixed |
+| 5 | `detect_script_language` parses non-JS types (application/ld+json, x-shader) as JavaScript — wasted inner parse | Algorithm Correctness | html.rs detect_script_language | ✅ fixed |
+| 6 | Uppercase file extensions (.HTML, .RS) silently rejected — real bug on case-insensitive FS | Platform Behavior | mod.rs:171, calls.rs:236, watch.rs:241 | ✅ fixed |
+| 7 | `find_content_child` / `find_child_by_kind` identical across injection.rs and html.rs — extract shared helper | Code Quality | injection.rs:174, html.rs:127 | ✅ fixed |
+| 8 | `MAX_FILE_SIZE` / `MAX_CHUNK_BYTES` inline constants at 4 sites — hoist to module-level | Code Quality | mod.rs:144, mod.rs:203, calls.rs:210, injection.rs:253 | ✅ fixed |
+| 9 | `parse_injected_chunks` + `parse_injected_relationships` duplicate parser setup boilerplate — extract `build_injection_tree()` | Code Quality, API Design | injection.rs:206-230, 305-330 | ✅ fixed |
+| 10 | `html.rs` module comment claims Svelte/Vue/Astro support that doesn't exist | Documentation | html.rs:4 | ✅ fixed |
+| 11 | `parser/mod.rs` module comment omits `injection` and `markdown` submodules | Documentation | mod.rs:1-7 | ✅ fixed |
+| 12 | CHANGELOG `[Unreleased]` empty — multi-grammar injection not documented | Documentation | CHANGELOG.md:8 | ✅ fixed |
+| 13 | README HTML entry doesn't mention multi-grammar injection | Documentation | README.md:427 | ✅ fixed |
 
-## P3 — Easy + Low Impact (fix if time)
-
-| # | Finding | Category | Location | Status |
-|---|---------|----------|----------|--------|
-| OB-1 | `resolve_target` has no tracing span | Observability | src/search.rs:57 | ✅ fixed |
-| OB-2 | `delete_by_origin` / `replace_file_chunks` no tracing spans | Observability | src/store/chunks.rs:194, 222 | ✅ fixed |
-| OB-3 | `search_filtered` exits without logging result count | Observability | src/search.rs:793 | ✅ fixed |
-| OB-4 | `Store::init` — no span on schema initialization | Observability | src/store/mod.rs:355 | ✅ fixed |
-| OB-5 | `warn_stale_results` missing entry span | Observability | src/cli/staleness.rs:19 | ✅ fixed |
-| OB-6 | `cmd_watch` no entry span | Observability | src/cli/watch.rs:54 | ✅ fixed |
-| OB-7 | `get_caller_counts_batch` / `get_callee_counts_batch` no spans | Observability | src/store/calls.rs:1147, 1163 | ✅ fixed |
-| AD-1 | `BatchCmd::Gather` direction is stringly-typed — should use `GatherDirection` enum | API Design | src/cli/batch/commands.rs:109 | ✅ fixed |
-| AD-2 | `get_callers()` is dead public API — zero callers | API Design | src/store/calls.rs:252 | ✅ fixed (deleted, tests updated to get_callers_full) |
-| AD-4 | `BlameEntry` / `BlameData` use manual JSON assembly (depends on AD-3) | API Design | src/cli/commands/blame.rs:18-155 | ✅ fixed (Serialize derive) |
-| AD-6 | 9 CLI command handlers accept unused `_cli: &Cli` parameter | API Design | blame.rs, where_cmd.rs, test_map.rs, etc. | ✅ fixed (6 handlers) |
-| EH-1 | `build_blame_data` discards `StoreError` chain via `.map_err` stringify | Error Handling | src/cli/commands/blame.rs:46 | ✅ fixed |
-| EH-2 | 7 bare `Store::open()` calls without path context | Error Handling | diff.rs, drift.rs, index.rs, reference.rs, watch.rs | ✅ fixed |
-| EH-3 | `SearchFilter::validate()` returns `&'static str` not proper error type | Error Handling | src/store/helpers.rs:513 | ✅ fixed (returns String with values) |
-| EH-4 | `dispatch_onboard` swallows `get_chunks_by_names_batch` error silently | Error Handling | src/cli/batch/handlers.rs:912 | acceptable (has tracing::warn) |
-| EH-5 | `GatherDirection::FromStr` uses `String` error type (moot if AD-1 fixed) | Error Handling | src/gather.rs:97 | moot (AD-1 fixed) |
-| EH-6 | `schema_version` silently defaults to 0 on parse failure | Error Handling | src/store/chunks.rs:873 | ✅ fixed (tracing::warn) |
-| DOC-2 | PRIVACY.md deletion instructions miss `config.toml` | Documentation | PRIVACY.md:46-51 | ✅ fixed |
-| DOC-3 | SECURITY.md symlink mitigation description is inaccurate (understates scope) | Documentation | SECURITY.md:94 | ✅ fixed |
-| DOC-4 | lib.rs doc comment omits Web Help format | Documentation | src/lib.rs:13 | ✅ fixed |
-| DOC-5 | `cqs dead --min-confidence` undocumented in README and CLAUDE.md | Documentation | README.md:243, CLAUDE.md:71 | ✅ fixed |
-| CQ-2 | Gather JSON assembly duplicated between CLI and batch handler | Code Quality | gather.rs:114, handlers.rs:406 | ✅ fixed (serde Serialize, removed to_json) |
-| EX-1 | `pipeable_command_names()` manually duplicates pipeable variants — stale on new commands | Extensibility | src/cli/batch/pipeline.rs:31-113 | ✅ fixed (PIPEABLE_NAMES const + sync test) |
-| EX-2 | `name_boost: 0.2` hardcoded — no shared constant with CLI default | Extensibility | src/cli/batch/handlers.rs:83 | ✅ fixed (DEFAULT_NAME_BOOST const) |
-| EX-3 | `HNSW_EXTENSIONS` / `HNSW_ALL_EXTENSIONS` overlap with no sync enforcement | Extensibility | src/hnsw/persist.rs:31,34 | ✅ fixed |
-| EX-5 | Note/code slot ratio `(limit * 3) / 5` inline formula repeated in tests | Extensibility | src/search.rs:1061, 1216, 1223 | ✅ fixed (min_code_slot_count fn) |
-| RB-3 | `where_to_add` core panics via `.expect()` on `query_embedding` | Robustness | src/where_to_add.rs:170 | ✅ fixed (AnalysisError::Phase) |
-| RB-4 | Blame passes inverted line ranges to git silently | Robustness | src/cli/commands/blame.rs:86 | ✅ fixed (swap + warn) |
-| RB-5 | Reranker/embedder `outputs[0]` panics if ONNX returns empty | Robustness | src/reranker.rs:140 | informational (SessionOutputs API) |
-| AC-3 | `token_pack` O(n²) `keep.iter().any()` in packing loop | Algorithm | src/cli/commands/mod.rs:134 | ✅ fixed (kept_any bool) |
-| AC-4 | `cap_scores` uses `u64::MAX - x` inversion trick (correct but fragile) | Algorithm | src/onboard.rs:175 | ✅ fixed (std::cmp::Reverse) |
-| TC-4 | `ChatHelper::complete` tab-completion logic untested | Test Coverage | src/cli/chat.rs:26-49 | ✅ fixed (4 tests) |
-| TC-6 | Batch pipeline error propagation for malformed mid-pipeline input untested | Test Coverage | src/cli/batch/pipeline.rs | ✅ fixed (6 tests) |
-| PB-2 | `notes_path` falls back to non-canonical path if file missing at watch start | Platform | src/cli/watch.rs:97-105 | acceptable (canonical after first event) |
-| PB-4 | Lock file open code duplicated; NTFS ignores `0o600` silently | Platform | src/cli/files.rs:52-115 | acceptable (already extracted to open_lock_file) |
-| PB-5 | `is_wsl()` has no `#[cfg(unix)]` guard | Platform | src/config.rs:15-25 | ✅ fixed |
-| SEC-1 | `CQS_PDF_SCRIPT` env var allows arbitrary script execution (defense-in-depth) | Security | src/convert/pdf.rs:56-68 | acceptable (documented in SECURITY.md) |
-| SEC-3 | `convert_directory` walk has no depth/file count limit | Security | src/convert/mod.rs:345 | ✅ fixed (max_depth 50) |
-| SEC-4 | HNSW index files written with no permission restriction (inconsistent with DB) | Security | src/hnsw/persist.rs | acceptable (0o600 set in persist) |
-| SEC-6 | `run_git_diff` can allocate unbounded memory — no size limit | Security | src/cli/commands/mod.rs:166-188 | ✅ fixed (50 MB limit) |
-| DS-3 | `extract_relationships` not atomic with chunk upserts — crash leaves stale call graph | Data Safety | src/cli/commands/index.rs:120-133 | acceptable (reindex recovers) |
-| DS-5 | `notes_summaries_cache` invalidation is caller-responsibility — fragile | Data Safety | src/store/mod.rs:746, notes.rs:122,224 | non-issue (all paths call invalidate) |
-| DS-6 | `bytes_to_embedding` silently skips corrupted embeddings — no aggregate signal | Data Safety | src/store/helpers.rs:696-725 | ✅ fixed (warn level logging) |
-| PF-1 | `search_by_candidate_ids` parses language/chunk_type strings per candidate (pre-build HashSet) | Performance | src/search.rs:884-905 | ✅ fixed |
-| PF-2 | `search_filtered` clones all semantic IDs to separate Vec for `rrf_fuse` | Performance | src/search.rs:757 | ✅ fixed (Vec<&str>) |
-| PF-3 | `search_by_name` re-lowercases query per result (use `score_name_match_pre_lower`) | Performance | src/store/mod.rs:646 | ✅ fixed |
-| PF-4 | `score_confidence` clones all candidate IDs to separate Vec | Performance | src/store/calls.rs:881 | ✅ fixed (Vec<&str>) |
-| PF-5 | `fetch_active_files` uses `IN (subquery)` where JOIN is more efficient | Performance | src/store/calls.rs:841-843 | ✅ fixed (INNER JOIN) |
-| PF-6 | `build_batched` two-pass loop (validation then collection) | Performance | src/hnsw/build.rs:140-157 | ✅ fixed (single pass) |
-| RM-1 | CHM/webhelp converters accumulate all pages then `join()` — 2× peak memory | Resource Mgmt | src/convert/chm.rs:119, webhelp.rs:93 | ✅ fixed (incremental String) |
-| RM-2 | `html_file_to_markdown` / `markdown_passthrough` load entire file with no size guard | Resource Mgmt | src/convert/html.rs:32, mod.rs:113 | ✅ fixed (100 MB limit) |
-
-## P4 — Hard or Low Impact (create issues)
+## P2: Medium Effort + High Impact — Fix in Batch
 
 | # | Finding | Category | Location | Status |
 |---|---------|----------|----------|--------|
-| AD-5 | `dispatch_search` takes 9 individual parameters instead of a struct | API Design | src/cli/batch/handlers.rs:33-42 | ✅ fixed (SearchParams struct) |
-| CQ-3 | `token_pack_unified` / `token_pack_tagged` near-identical functions | Code Quality | src/cli/commands/query.rs:333-398 | ✅ fixed (generic `token_pack_results`) |
-| CQ-4 | `cmd_query` at 287 lines — multiple concerns in one function | Code Quality | src/cli/commands/query.rs:39-325 | acceptable (helper fns extracted in CQ-3) |
-| CQ-5 | 11 functions suppress `clippy::too_many_arguments` | Code Quality | multiple files | reduced to 10 (AD-5); remainder are internal watch/pipeline state |
-| EX-4 | `extract_from_scout_groups` bespoke extractor — new output shapes need new extractors | Extensibility | src/cli/batch/pipeline.rs:116-210 | ✅ fixed (nested extraction in `extract_from_standard_fields`) |
-| RB-2 | `CandidateRow::from_row` / `ChunkRow::from_row` use panicking `row.get()` | Robustness | src/store/helpers.rs:75-121 | informational |
-| RB-6 | `Language::def()` panics on disabled feature flags | Robustness | src/language/mod.rs:549, 570 | informational |
-| RB-7 | `Parser::new()` panics on registry/enum mismatch | Robustness | src/parser/mod.rs:62-67 | informational |
-| AC-2 | FTS not scoped to HNSW candidates — design tension, improves recall | Algorithm | src/search.rs:934-942 | by-design |
-| AC-5 | `bfs_shortest_path` uses empty-string sentinel for predecessor tracking | Algorithm | src/cli/commands/trace.rs:203-221 | informational |
-| TC-5 | `build_blame_data` only tested through components — no end-to-end with mock git | Test Coverage | src/cli/commands/blame.rs:36-68 | acceptable (parser tests + integration cover components) |
-| PB-1 | `cmd_watch` uses inotify on WSL; PollWatcher would be more reliable on `/mnt/` | Platform | src/cli/watch.rs:61-89 | existing behavior |
-| PB-3 | Forward-slash path in blame `-L` spec latently incompatible with native Windows git | Platform | src/cli/commands/blame.rs:50, 86 | ✅ fixed (backslash → forward-slash normalize) |
-| SEC-5 | `find_7z` / `find_python` search PATH without validation | Security | src/convert/chm.rs:168, pdf.rs:95 | ✅ fixed (validate exit status) |
-| DS-1 | HNSW save partial rename leaves inconsistent index on mid-loop failure | Data Safety | src/hnsw/persist.rs:241-272 | ✅ fixed (rollback on partial failure) |
-| DS-4 | `prune_stale_calls` executes outside GC's index lock scope after chunk pruning | Data Safety | src/cli/commands/gc.rs:44-59 | non-issue (`_lock` held for entire function) |
-| RM-3 | `BatchContext::refs` loaded references accumulate with no eviction | Resource Mgmt | src/cli/batch/mod.rs:60 | acceptable |
-| RM-4 | Pipeline channel depth same for parse (light) and embed (heavy) payloads | Resource Mgmt | src/cli/pipeline.rs:37 | ✅ fixed (512 parse / 64 embed) |
-| RM-5 | Watch `last_indexed_mtime` grows unbounded; `retain` runs O(files) `exists()` calls | Resource Mgmt | src/cli/watch.rs:117, 307-311 | ✅ fixed (conditional pruning at 1K/10K thresholds) |
+| 14 | Unbounded injection range count — crafted HTML with millions of tiny `<script>` blocks causes OOM | Security | injection.rs:83-94 | |
+| 15 | `parse_injected_relationships` early-returns on call query failure, skipping independent type extraction | Robustness, Error Handling | injection.rs:340-346 | |
+| 16 | `chunk_overlaps_container` is strict containment, not overlap — misnamed and will cause double-coverage for future hosts | Algorithm Correctness, Data Safety | injection.rs:486-494 | |
+| 17 | Chained injection silently ignored — `parse_injected_chunks` never checks inner language's injections (blocks PHP→HTML→JS) | Extensibility | injection.rs | |
+| 18 | `extract_calls` silently discards `set_language` and parse failures without logging | Error Handling | calls.rs:30-37 | |
+| 19 | `get_query`/`get_call_query`/`get_type_query` use `{:?}` instead of `{}` for error formatting | Error Handling | mod.rs:95, 113, 131 | |
+| 20 | `parse_injected_relationships` `get_call_query` Err arm drops real errors with misleading comment | Error Handling | injection.rs:340-346 | |
+| 21 | `parse_file_relationships` relies on undocumented invariant that empty query patterns compile | Error Handling | calls.rs:258 | |
+| 22 | `find_content_child` returns only first matching child — split `raw_text` from error recovery skipped | Algorithm Correctness | injection.rs find_content_child | |
+| 23 | `chunk_overlaps_container` has no unit tests — boundary conditions untested | Test Coverage | injection.rs:486-494 | |
+| 24 | Injected type references (`ChunkTypeRefs`) never asserted in tests | Test Coverage | injection.rs tests | |
+| 25 | `detect_script_language` — `type="text/typescript"` branch untested | Test Coverage | html.rs tests | |
+| 26 | Temp files written with umask-derived permissions before `chmod` applied; `note.rs` never `chmod`s | Security | audit.rs:119, config.rs:332, note.rs:250 | |
 
-## Summary
+## P3: Easy + Low Impact — Fix if Time
 
-| Priority | Count | Action |
-|----------|-------|--------|
-| P1 | 6 | Fix immediately |
-| P2 | 4 | Fix in batch |
-| P3 | 50 | Fix if time |
-| P4 | 19 | Create issues / informational |
-| **Total** | **75** | |
+| # | Finding | Category | Location | Status |
+|---|---------|----------|----------|--------|
+| 27 | `InjectionRule` lacks `Debug` — only pub struct without it | API Design | mod.rs:164 | |
+| 28 | `walk_for_containers` cursor-advance idiom duplicated twice within itself | Code Quality | injection.rs:138-168 | |
+| 29 | `InjectionGroup` grouping uses O(n) linear scan (fine for 2 rules, won't scale) | Code Quality | injection.rs:83-94 | |
+| 30 | `parse_injected_chunks` span missing file path | Observability | injection.rs:199 | |
+| 31 | Silent injection replacement — no log when outer chunks replaced | Observability | mod.rs:241-250 | |
+| 32 | `parse_injected_chunks`/`parse_injected_relationships` don't log chunk/call count on success | Observability | injection.rs:288, 478 | |
+| 33 | `find_injection_ranges` uses `debug_span` while callers use `info_span` | Observability | injection.rs:41 | |
+| 34 | `scout_core` has no entry span | Observability | scout.rs:199 | |
+| 35 | `cmd_read_focused` has no entry span | Observability | read.rs:312 | |
+| 36 | Oversized injected chunks skipped silently — no debug log | Observability | injection.rs:252-256 | |
+| 37 | Outer tree-sitter Parser/Tree not dropped before injection inner-parse | Resource Management | mod.rs:182-266, calls.rs:247-409 | |
+| 38 | Call-dedup `HashSet<String>` should be `HashSet<&str>` — avoids clone per callee | Resource Management, Performance | injection.rs:447, calls.rs:352 | |
+| 39 | `extract_types` builds `HashSet<String>` — can use `HashSet<&str>` | Performance | extract_types | |
+| 40 | `capture_index_for_name("name")` called inside per-match hot loops — hoist out of loop | Performance | calls.rs:301, injection.rs:388, chunk.rs | |
+| 41 | `extract_calls` missing CRLF normalization (all callers pass normalized, but latent) | Platform Behavior | calls.rs:15-78 | |
+| 42 | `InjectionRule::target_language` convention unenforced (no compile/runtime validation) | Platform Behavior, Extensibility | mod.rs:172, injection.rs:63 | |
+| 43 | `source[byte_range()]` direct indexing vs `utf8_text` — inconsistent style | Robustness | injection.rs:391, 434 | |
+| 44 | `walk_for_containers` duplicate range risk if two rules share `container_kind` | Robustness | injection.rs:49-53 | |
+| 45 | Grammar-less languages with non-empty `injections` field would silently produce nothing | Extensibility | mod.rs, injection.rs | |
+| 46 | No contributor docs for adding new injection rules | Extensibility | CONTRIBUTING.md | |
+| 47 | `run_git_log_line_range` doesn't validate colons in file path — git `-L` misparse | Security | blame.rs:79-93 | |
+| 48 | No test for `type="text/typescript"` attribute detection | Test Coverage | html.rs tests | |
+
+## P4: Hard or Low Impact — Defer / Create Issues
+
+| # | Finding | Category | Location | Status |
+|---|---------|----------|----------|--------|
+| 49 | Double-read + double-parse of every file during full index (parse_file + parse_file_relationships) | Performance | mod.rs, calls.rs | |
+| 50 | Per-call Parser allocations in rayon parallel injection stage — memory amplification | Platform Behavior, Performance | injection.rs:206-210, 305-310 | |
+| 51 | Two-pass write architecture (store → relationships) — crash between passes leaves stale edges | Data Safety | store/types.rs:106-184 | |
+| 52 | Chunk ID collision between outer and injected chunks (theoretical, 32-bit hash) | Data Safety | chunk.rs:101 | |
+| 53 | u32 arithmetic overflow in container_lines (theoretical, prevented by 50MB file limit) | Robustness | injection.rs:130-131 | |
+| 54 | No end-to-end integration test (parse → embed → store → search for injected chunks) | Test Coverage | — | |
+| 55 | No tests for malformed/unclosed `<script>` tags | Test Coverage | — | |
+| 56 | Cross-phase line_start dependency between parse_file and parse_file_relationships undocumented | Algorithm Correctness | — | |
+| 57 | `cursor.reset(root)` responsibility in caller, not callee — fragile | Algorithm Correctness | injection.rs walk_for_containers | |
+
+## Overlap Notes
+
+- P1#1 + P1#2 are the same root cause — fix together via shared `capture_name_to_chunk_type()`
+- P2#15 + P2#20 are the same code location — fix together (split call/type error handling + add warning)
+- P2#16 + P2#23 — rename + add tests together
+- P3#38 + P3#39 — same pattern, fix together
+- P3#42 + P3#45 — validation concerns, can add registry test for both

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -238,8 +238,9 @@ fn collect_events(
         }
 
         // Skip if not a supported extension
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-        if !supported_ext.contains(ext) {
+        let ext_raw = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let ext = ext_raw.to_ascii_lowercase();
+        if !supported_ext.contains(ext.as_str()) {
             continue;
         }
 

--- a/src/language/html.rs
+++ b/src/language/html.rs
@@ -1,8 +1,9 @@
 //! HTML language definition
 //!
-//! HTML is the foundational markup language for the web and the outer grammar
-//! for multi-grammar parsing (Svelte, Vue, Astro). Chunks are semantic elements:
-//! headings, landmarks, script/style blocks, and id'd elements.
+//! HTML is the foundational markup language for the web. Chunks are semantic
+//! elements: headings, landmarks, and id'd elements. Inline `<script>` blocks
+//! extract JS/TS functions and `<style>` blocks extract CSS rules via
+//! multi-grammar injection.
 
 use super::{ChunkType, InjectionRule, LanguageDef, PostProcessChunkFn, SignatureStyle};
 
@@ -123,15 +124,11 @@ fn post_process_html(
 }
 
 /// Find a direct child node by kind.
-#[allow(clippy::manual_find)]
-fn find_child_by_kind<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == kind {
-            return Some(child);
-        }
-    }
-    None
+fn find_child_by_kind<'a>(
+    node: tree_sitter::Node<'a>,
+    kind: &str,
+) -> Option<tree_sitter::Node<'a>> {
+    crate::parser::find_child_by_kind(node, kind)
 }
 
 /// Find an attribute's value within a start_tag node.
@@ -211,6 +208,20 @@ fn detect_script_language(node: tree_sitter::Node, source: &str) -> Option<&'sta
         if lower.contains("typescript") {
             tracing::debug!("Detected TypeScript from type attribute");
             return Some("typescript");
+        }
+        // Skip non-JS script types (JSON-LD, templates, shaders, etc.)
+        if !lower.is_empty()
+            && !matches!(
+                lower.as_str(),
+                "text/javascript"
+                    | "application/javascript"
+                    | "module"
+                    | "text/ecmascript"
+                    | "application/ecmascript"
+            )
+        {
+            tracing::debug!(r#type = %type_val, "Skipping non-JS script type");
+            return Some("_skip"); // sentinel: caller will skip injection
         }
     }
 
@@ -480,16 +491,16 @@ function setupListeners() {
             .filter(|c| c.language == crate::parser::Language::Css)
             .collect();
 
-        // CSS language definition captures Section chunks for selectors
-        // Even if no CSS chunks extracted (depends on CSS query), the style Module
-        // chunk behavior should be correct
-        if !css_chunks.is_empty() {
-            // If CSS produces chunks, the style Module should be replaced
-            assert!(
-                !chunks.iter().any(|c| c.chunk_type == ChunkType::Module && c.name == "style"),
-                "Style Module chunk should be replaced by CSS chunks"
-            );
-        }
+        // CSS injection must produce chunks — if this fails, CSS injection is broken
+        assert!(
+            !css_chunks.is_empty(),
+            "CSS injection should extract chunks from <style> block"
+        );
+        // Style Module chunk should be replaced by CSS chunks
+        assert!(
+            !chunks.iter().any(|c| c.chunk_type == ChunkType::Module && c.name == "style"),
+            "Style Module chunk should be replaced by CSS chunks"
+        );
 
         // HTML heading should still be present
         assert!(

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -4,7 +4,8 @@ use std::path::Path;
 use tree_sitter::StreamingIterator;
 
 use super::types::{
-    CallSite, ChunkType, ChunkTypeRefs, FunctionCalls, Language, ParserError, TypeEdgeKind, TypeRef,
+    capture_name_to_chunk_type, CallSite, ChunkType, ChunkTypeRefs, FunctionCalls, Language,
+    ParserError, TypeEdgeKind, TypeRef, CHUNK_CAPTURE_NAMES,
 };
 use super::Parser;
 
@@ -207,9 +208,8 @@ impl Parser {
             tracing::info_span!("parse_file_relationships", path = %path.display()).entered();
 
         // Check file size (matching parse_file limit)
-        const MAX_FILE_SIZE: u64 = 50 * 1024 * 1024;
         match std::fs::metadata(path) {
-            Ok(meta) if meta.len() > MAX_FILE_SIZE => {
+            Ok(meta) if meta.len() > super::MAX_FILE_SIZE => {
                 tracing::warn!(
                     "Skipping large file ({}MB > 50MB limit): {}",
                     meta.len() / (1024 * 1024),
@@ -233,8 +233,9 @@ impl Parser {
         // Normalize line endings (CRLF -> LF) for consistency
         let source = source.replace("\r\n", "\n");
 
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-        let language = Language::from_extension(ext)
+        let ext_raw = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let ext = ext_raw.to_ascii_lowercase();
+        let language = Language::from_extension(&ext)
             .ok_or_else(|| ParserError::UnsupportedFileType(ext.to_string()))?;
 
         // Grammar-less languages (Markdown) use custom reference extraction
@@ -272,23 +273,7 @@ impl Parser {
             // Find chunk node
             let func_node = m.captures.iter().find(|c| {
                 let name = capture_names.get(c.index as usize).copied().unwrap_or("");
-                matches!(
-                    name,
-                    "function"
-                        | "struct"
-                        | "class"
-                        | "enum"
-                        | "trait"
-                        | "interface"
-                        | "const"
-                        | "module"
-                        | "macro"
-                        | "object"
-                        | "typealias"
-                        | "property"
-                        | "delegate"
-                        | "event"
-                )
+                CHUNK_CAPTURE_NAMES.contains(&name)
             });
 
             let Some(func_capture) = func_node else {
@@ -311,23 +296,7 @@ impl Parser {
                     .get(func_capture.index as usize)
                     .copied()
                     .unwrap_or("");
-                let mut ct = match cap_name {
-                    "function" => ChunkType::Function,
-                    "struct" => ChunkType::Struct,
-                    "class" => ChunkType::Class,
-                    "enum" => ChunkType::Enum,
-                    "trait" => ChunkType::Trait,
-                    "interface" => ChunkType::Interface,
-                    "const" => ChunkType::Constant,
-                    "module" => ChunkType::Module,
-                    "macro" => ChunkType::Macro,
-                    "object" => ChunkType::Object,
-                    "typealias" => ChunkType::TypeAlias,
-                    "property" => ChunkType::Property,
-                    "delegate" => ChunkType::Delegate,
-                    "event" => ChunkType::Event,
-                    _ => ChunkType::Function,
-                };
+                let mut ct = capture_name_to_chunk_type(cap_name).unwrap_or(ChunkType::Function);
                 if !post_process(&mut name, &mut ct, node, &source) {
                     continue; // Skip discarded chunks
                 }
@@ -391,9 +360,29 @@ impl Parser {
             let groups = super::injection::find_injection_ranges(&tree, &source, injections);
             for group in &groups {
                 match self.parse_injected_relationships(&source, group) {
-                    Ok((inner_calls, inner_types)) => {
+                    Ok((inner_calls, inner_types))
+                        if !inner_calls.is_empty() || !inner_types.is_empty() =>
+                    {
+                        // Remove outer container entries (matching parse_file's chunk removal)
+                        call_results.retain(|fc| {
+                            !super::injection::chunk_overlaps_container(
+                                fc.line_start,
+                                fc.line_start, // calls have no line_end, use start for containment
+                                &group.container_lines,
+                            )
+                        });
+                        type_results.retain(|tr| {
+                            !super::injection::chunk_overlaps_container(
+                                tr.line_start,
+                                tr.line_start,
+                                &group.container_lines,
+                            )
+                        });
                         call_results.extend(inner_calls);
                         type_results.extend(inner_types);
+                    }
+                    Ok(_) => {
+                        // Zero inner results — keep outer
                     }
                     Err(e) => {
                         tracing::warn!(

--- a/src/parser/injection.rs
+++ b/src/parser/injection.rs
@@ -11,7 +11,10 @@ use std::path::Path;
 
 use tree_sitter::StreamingIterator;
 
-use super::types::{Chunk, ChunkType, ChunkTypeRefs, FunctionCalls, Language, ParserError};
+use super::types::{
+    capture_name_to_chunk_type, Chunk, ChunkType, ChunkTypeRefs, FunctionCalls, Language,
+    ParserError, CHUNK_CAPTURE_NAMES,
+};
 use super::Parser;
 use crate::language::InjectionRule;
 
@@ -119,6 +122,11 @@ fn walk_for_containers(
                         rule.target_language
                     };
 
+                    // Skip non-parseable content (e.g., JSON-LD, shader scripts)
+                    if target == "_skip" {
+                        continue;
+                    }
+
                     let range = tree_sitter::Range {
                         start_byte: byte_range.start,
                         end_byte: byte_range.end,
@@ -170,18 +178,46 @@ fn walk_for_containers(
 }
 
 /// Find a direct child of `node` with the given kind.
-#[allow(clippy::manual_find)]
 fn find_content_child<'a>(
     node: tree_sitter::Node<'a>,
     content_kind: &str,
 ) -> Option<tree_sitter::Node<'a>> {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == content_kind {
-            return Some(child);
-        }
+    super::find_child_by_kind(node, content_kind)
+}
+
+/// Build an inner tree-sitter parse tree for injection ranges.
+///
+/// Returns `None` on any failure (with warnings logged).
+fn build_injection_tree(
+    language: Language,
+    source: &str,
+    ranges: &[tree_sitter::Range],
+) -> Option<tree_sitter::Tree> {
+    let grammar = language.grammar();
+    let mut parser = tree_sitter::Parser::new();
+    if let Err(e) = parser.set_language(&grammar) {
+        tracing::warn!(
+            error = ?e,
+            %language,
+            "Failed to set language for injection"
+        );
+        return None;
     }
-    None
+
+    if let Err(e) = parser.set_included_ranges(ranges) {
+        tracing::warn!(
+            error = %e,
+            %language,
+            "Failed to set included ranges for injection"
+        );
+        return None;
+    }
+
+    let tree = parser.parse(source, None);
+    if tree.is_none() {
+        tracing::warn!(%language, "Injection parse returned None");
+    }
+    tree
 }
 
 impl Parser {
@@ -203,30 +239,9 @@ impl Parser {
         )
         .entered();
 
-        let grammar = inner_language.grammar();
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(&grammar)
-            .map_err(|e| ParserError::ParseFailed(format!("injection set_language: {:?}", e)))?;
-
-        if let Err(e) = parser.set_included_ranges(&group.ranges) {
-            tracing::warn!(
-                error = %e,
-                language = %inner_language,
-                "Failed to set included ranges for injection"
-            );
-            return Ok(vec![]);
-        }
-
-        let tree = match parser.parse(source, None) {
+        let tree = match build_injection_tree(inner_language, source, &group.ranges) {
             Some(t) => t,
-            None => {
-                tracing::warn!(
-                    language = %inner_language,
-                    "Injection parse returned None"
-                );
-                return Ok(vec![]);
-            }
+            None => return Ok(vec![]),
         };
 
         let query = match self.get_query(inner_language) {
@@ -250,8 +265,7 @@ impl Parser {
             match self.extract_chunk(source, m, query, inner_language, path) {
                 Ok(mut chunk) => {
                     // Skip oversized chunks
-                    const MAX_CHUNK_BYTES: usize = 100_000;
-                    if chunk.content.len() > MAX_CHUNK_BYTES {
+                    if chunk.content.len() > super::MAX_CHUNK_BYTES {
                         continue;
                     }
 
@@ -302,30 +316,9 @@ impl Parser {
         )
         .entered();
 
-        let grammar = inner_language.grammar();
-        let mut parser = tree_sitter::Parser::new();
-        parser
-            .set_language(&grammar)
-            .map_err(|e| ParserError::ParseFailed(format!("injection set_language: {:?}", e)))?;
-
-        if let Err(e) = parser.set_included_ranges(&group.ranges) {
-            tracing::warn!(
-                error = %e,
-                language = %inner_language,
-                "Failed to set included ranges for injection relationships"
-            );
-            return Ok((vec![], vec![]));
-        }
-
-        let tree = match parser.parse(source, None) {
+        let tree = match build_injection_tree(inner_language, source, &group.ranges) {
             Some(t) => t,
-            None => {
-                tracing::warn!(
-                    language = %inner_language,
-                    "Injection parse returned None for relationships"
-                );
-                return Ok((vec![], vec![]));
-            }
+            None => return Ok((vec![], vec![])),
         };
 
         // Get queries
@@ -359,23 +352,7 @@ impl Parser {
             // Find chunk node (same logic as parse_file_relationships)
             let func_node = m.captures.iter().find(|c| {
                 let name = capture_names.get(c.index as usize).copied().unwrap_or("");
-                matches!(
-                    name,
-                    "function"
-                        | "struct"
-                        | "class"
-                        | "enum"
-                        | "trait"
-                        | "interface"
-                        | "const"
-                        | "module"
-                        | "macro"
-                        | "object"
-                        | "typealias"
-                        | "property"
-                        | "delegate"
-                        | "event"
-                )
+                CHUNK_CAPTURE_NAMES.contains(&name)
             });
 
             let Some(func_capture) = func_node else {
@@ -397,23 +374,7 @@ impl Parser {
                     .get(func_capture.index as usize)
                     .copied()
                     .unwrap_or("");
-                let mut ct = match cap_name {
-                    "function" => ChunkType::Function,
-                    "struct" => ChunkType::Struct,
-                    "class" => ChunkType::Class,
-                    "enum" => ChunkType::Enum,
-                    "trait" => ChunkType::Trait,
-                    "interface" => ChunkType::Interface,
-                    "const" => ChunkType::Constant,
-                    "module" => ChunkType::Module,
-                    "macro" => ChunkType::Macro,
-                    "object" => ChunkType::Object,
-                    "typealias" => ChunkType::TypeAlias,
-                    "property" => ChunkType::Property,
-                    "delegate" => ChunkType::Delegate,
-                    "event" => ChunkType::Event,
-                    _ => ChunkType::Function,
-                };
+                let mut ct = capture_name_to_chunk_type(cap_name).unwrap_or(ChunkType::Function);
                 if !post_process(&mut name, &mut ct, node, source) {
                     continue;
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4,6 +4,8 @@
 //! - `types` — data structures and error types
 //! - `chunk` — chunk extraction from parse trees
 //! - `calls` — call site extraction for call graph
+//! - `injection` — multi-grammar injection (HTML→JS/CSS via `set_included_ranges()`)
+//! - `markdown` — heading-based Markdown parser with cross-reference extraction
 
 mod calls;
 mod chunk;
@@ -20,6 +22,12 @@ use once_cell::sync::OnceCell;
 use std::collections::HashMap;
 use std::path::Path;
 use tree_sitter::StreamingIterator;
+
+/// Maximum file size for parsing (50 MB). Files larger than this are skipped.
+pub(crate) const MAX_FILE_SIZE: u64 = 50 * 1024 * 1024;
+
+/// Maximum chunk content size (100 KB). Larger chunks are skipped.
+pub(crate) const MAX_CHUNK_BYTES: usize = 100_000;
 
 /// Code parser using tree-sitter grammars
 ///
@@ -140,8 +148,7 @@ impl Parser {
     pub fn parse_file(&self, path: &Path) -> Result<Vec<Chunk>, ParserError> {
         let _span = tracing::info_span!("parse_file", path = %path.display()).entered();
 
-        // Check file size to prevent OOM on huge files (limit: 50MB)
-        const MAX_FILE_SIZE: u64 = 50 * 1024 * 1024;
+        // Check file size to prevent OOM on huge files
         match std::fs::metadata(path) {
             Ok(meta) if meta.len() > MAX_FILE_SIZE => {
                 tracing::warn!(
@@ -168,9 +175,10 @@ impl Parser {
         // Normalize line endings (CRLF -> LF) for consistent hashing across platforms
         let source = source.replace("\r\n", "\n");
 
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let ext_raw = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let ext = ext_raw.to_ascii_lowercase();
 
-        let language = Language::from_extension(ext)
+        let language = Language::from_extension(&ext)
             .ok_or_else(|| ParserError::UnsupportedFileType(ext.to_string()))?;
 
         // Grammar-less languages (Markdown) use custom parsers
@@ -200,7 +208,6 @@ impl Parser {
             match self.extract_chunk(&source, m, query, language, path) {
                 Ok(mut chunk) => {
                     // Skip chunks over 100KB (large functions are handled by windowing in the pipeline)
-                    const MAX_CHUNK_BYTES: usize = 100_000;
                     if chunk.content.len() > MAX_CHUNK_BYTES {
                         tracing::debug!(
                             "Skipping {} ({} bytes > {} max)",
@@ -269,6 +276,23 @@ impl Parser {
     pub fn supported_extensions(&self) -> Vec<&'static str> {
         crate::language::REGISTRY.supported_extensions().collect()
     }
+}
+
+/// Find a direct child of a tree-sitter node by kind.
+///
+/// Shared helper used by injection parsing and HTML language definition.
+#[allow(clippy::manual_find)]
+pub(crate) fn find_child_by_kind<'a>(
+    node: tree_sitter::Node<'a>,
+    kind: &str,
+) -> Option<tree_sitter::Node<'a>> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == kind {
+            return Some(child);
+        }
+    }
+    None
 }
 
 /// Find the definition node (function/struct/class/etc.) from a query match's captures.

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -7,6 +7,52 @@ use thiserror::Error;
 // Re-export from language module (source of truth)
 pub use crate::language::{ChunkType, Language, SignatureStyle};
 
+/// Map a tree-sitter capture name to a `ChunkType`.
+///
+/// Single source of truth — used by chunk extraction, call graph, and injection.
+/// Returns `None` for unknown capture names.
+pub fn capture_name_to_chunk_type(name: &str) -> Option<ChunkType> {
+    match name {
+        "function" => Some(ChunkType::Function),
+        "struct" => Some(ChunkType::Struct),
+        "class" => Some(ChunkType::Class),
+        "enum" => Some(ChunkType::Enum),
+        "trait" => Some(ChunkType::Trait),
+        "interface" => Some(ChunkType::Interface),
+        "const" => Some(ChunkType::Constant),
+        "section" => Some(ChunkType::Section),
+        "property" => Some(ChunkType::Property),
+        "delegate" => Some(ChunkType::Delegate),
+        "event" => Some(ChunkType::Event),
+        "module" => Some(ChunkType::Module),
+        "macro" => Some(ChunkType::Macro),
+        "object" => Some(ChunkType::Object),
+        "typealias" => Some(ChunkType::TypeAlias),
+        _ => None,
+    }
+}
+
+/// All tree-sitter capture names that correspond to chunk definitions.
+///
+/// Used for filtering captures in call/type extraction.
+pub const CHUNK_CAPTURE_NAMES: &[&str] = &[
+    "function",
+    "struct",
+    "class",
+    "enum",
+    "trait",
+    "interface",
+    "const",
+    "section",
+    "module",
+    "macro",
+    "object",
+    "typealias",
+    "property",
+    "delegate",
+    "event",
+];
+
 /// Errors that can occur during code parsing
 #[derive(Error, Debug)]
 pub enum ParserError {


### PR DESCRIPTION
## Summary

- Fix all 13 P1 (easy + high impact) findings from the v0.27.0-pre audit
- Extract shared `capture_name_to_chunk_type()` eliminating 3-way divergence across parser modules
- Fix dangling relationship entries when injection parsing succeeds
- Add case-insensitive file extension matching, non-JS script type skipping
- Deduplicate `find_child_by_kind`, `build_injection_tree()`, and module-level constants
- Fix stale documentation (html.rs, mod.rs, CHANGELOG, README)

## Test plan

- [x] `cargo test --features gpu-index --lib` — 920 pass, 0 fail
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] Integration tests pass
- [x] All 13 P1 items in `docs/audit-triage.md` marked fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
