### PR TITLE
fix: audit P3 fixes (18 of 22 findings)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,36 @@ src/
 - Schema migrations allow upgrading indexes without full rebuild
 - Skills in `.claude/skills/*/SKILL.md` are auto-discovered by Claude Code
 
+## Adding Injection Rules (Multi-Grammar)
+
+Files like HTML contain embedded languages (`<script>` → JS, `<style>` → CSS). cqs handles this via injection rules on `LanguageDef`.
+
+**To add injection rules for a new host language:**
+
+1. Define `InjectionRule` entries in the language's `LanguageDef` (`src/language/<lang>.rs`):
+   ```rust
+   injections: &[
+       InjectionRule {
+           container_kind: "script_element",  // outer tree node kind
+           content_kind: "raw_text",          // child node with embedded content
+           target_language: "javascript",     // must match a Language variant name
+           detect_language: Some(detect_fn),  // optional: inspect attributes for lang override
+       },
+   ],
+   ```
+
+2. `container_kind` / `content_kind` must match the host grammar's node kinds (inspect with `tree-sitter parse`).
+
+3. `target_language` must be a valid `Language` name with a grammar (validated at runtime in `find_injection_ranges`).
+
+4. `detect_language` receives the container node and source — return `Some("typescript")` to override the default, `Some("_skip")` to skip the container entirely, or `None` for the default.
+
+5. Injection is single-level only. Inner languages are not re-scanned for their own injections.
+
+6. The two-phase flow in `parse_file` and `parse_file_relationships` automatically handles injection when `injections` is non-empty. No changes needed outside the language definition.
+
+**Key files:** `src/language/mod.rs` (InjectionRule struct), `src/parser/injection.rs` (parsing logic), `src/language/html.rs` (reference implementation).
+
 ## Questions?
 
 Open an issue for questions or discussions.

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -42,28 +42,28 @@ Audit date: 2026-03-06. 14 categories, 3 batches, ~50 unique findings (some over
 
 | # | Finding | Category | Location | Status |
 |---|---------|----------|----------|--------|
-| 27 | `InjectionRule` lacks `Debug` — only pub struct without it | API Design | mod.rs:164 | |
-| 28 | `walk_for_containers` cursor-advance idiom duplicated twice within itself | Code Quality | injection.rs:138-168 | |
-| 29 | `InjectionGroup` grouping uses O(n) linear scan (fine for 2 rules, won't scale) | Code Quality | injection.rs:83-94 | |
-| 30 | `parse_injected_chunks` span missing file path | Observability | injection.rs:199 | |
-| 31 | Silent injection replacement — no log when outer chunks replaced | Observability | mod.rs:241-250 | |
-| 32 | `parse_injected_chunks`/`parse_injected_relationships` don't log chunk/call count on success | Observability | injection.rs:288, 478 | |
-| 33 | `find_injection_ranges` uses `debug_span` while callers use `info_span` | Observability | injection.rs:41 | |
-| 34 | `scout_core` has no entry span | Observability | scout.rs:199 | |
-| 35 | `cmd_read_focused` has no entry span | Observability | read.rs:312 | |
-| 36 | Oversized injected chunks skipped silently — no debug log | Observability | injection.rs:252-256 | |
-| 37 | Outer tree-sitter Parser/Tree not dropped before injection inner-parse | Resource Management | mod.rs:182-266, calls.rs:247-409 | |
-| 38 | Call-dedup `HashSet<String>` should be `HashSet<&str>` — avoids clone per callee | Resource Management, Performance | injection.rs:447, calls.rs:352 | |
-| 39 | `extract_types` builds `HashSet<String>` — can use `HashSet<&str>` | Performance | extract_types | |
-| 40 | `capture_index_for_name("name")` called inside per-match hot loops — hoist out of loop | Performance | calls.rs:301, injection.rs:388, chunk.rs | |
-| 41 | `extract_calls` missing CRLF normalization (all callers pass normalized, but latent) | Platform Behavior | calls.rs:15-78 | |
-| 42 | `InjectionRule::target_language` convention unenforced (no compile/runtime validation) | Platform Behavior, Extensibility | mod.rs:172, injection.rs:63 | |
-| 43 | `source[byte_range()]` direct indexing vs `utf8_text` — inconsistent style | Robustness | injection.rs:391, 434 | |
-| 44 | `walk_for_containers` duplicate range risk if two rules share `container_kind` | Robustness | injection.rs:49-53 | |
-| 45 | Grammar-less languages with non-empty `injections` field would silently produce nothing | Extensibility | mod.rs, injection.rs | |
-| 46 | No contributor docs for adding new injection rules | Extensibility | CONTRIBUTING.md | |
-| 47 | `run_git_log_line_range` doesn't validate colons in file path — git `-L` misparse | Security | blame.rs:79-93 | |
-| 48 | No test for `type="text/typescript"` attribute detection | Test Coverage | html.rs tests | |
+| 27 | `InjectionRule` lacks `Debug` — only pub struct without it | API Design | mod.rs:164 | ✅ fixed |
+| 28 | `walk_for_containers` cursor-advance idiom duplicated twice within itself | Code Quality | injection.rs:138-168 | ✅ fixed |
+| 29 | `InjectionGroup` grouping uses O(n) linear scan (fine for 2 rules, won't scale) | Code Quality | injection.rs:83-94 | ✅ fixed |
+| 30 | `parse_injected_chunks` span missing file path | Observability | injection.rs:199 | ✅ fixed |
+| 31 | Silent injection replacement — no log when outer chunks replaced | Observability | mod.rs:241-250 | ✅ fixed |
+| 32 | `parse_injected_chunks`/`parse_injected_relationships` don't log chunk/call count on success | Observability | injection.rs:288, 478 | ✅ fixed |
+| 33 | `find_injection_ranges` uses `debug_span` while callers use `info_span` | Observability | injection.rs:41 | ✅ fixed |
+| 34 | `scout_core` has no entry span | Observability | scout.rs:199 | ✅ fixed |
+| 35 | `cmd_read_focused` has no entry span | Observability | read.rs:312 | ✅ fixed |
+| 36 | Oversized injected chunks skipped silently — no debug log | Observability | injection.rs:252-256 | ✅ fixed |
+| 37 | Outer tree-sitter Parser/Tree not dropped before injection inner-parse | Resource Management | mod.rs:182-266, calls.rs:247-409 | ✅ fixed |
+| 38 | Call-dedup `HashSet<String>` should be `HashSet<&str>` — avoids clone per callee | Resource Management, Performance | injection.rs:447, calls.rs:352 | non-issue: `retain` borrows `&mut Vec`, can't store `&str` refs into it |
+| 39 | `extract_types` builds `HashSet<String>` — can use `HashSet<&str>` | Performance | extract_types | non-issue: `classified.push()` may reallocate, invalidating `&str` refs |
+| 40 | `capture_index_for_name("name")` called inside per-match hot loops — hoist out of loop | Performance | calls.rs:301, injection.rs:388, chunk.rs | ✅ fixed (calls.rs + injection.rs; chunk.rs requires API change, skipped) |
+| 41 | `extract_calls` missing CRLF normalization (all callers pass normalized, but latent) | Platform Behavior | calls.rs:15-78 | ✅ fixed |
+| 42 | `InjectionRule::target_language` convention unenforced (no compile/runtime validation) | Platform Behavior, Extensibility | mod.rs:172, injection.rs:63 | non-issue: already validated at runtime in `find_injection_ranges` |
+| 43 | `source[byte_range()]` direct indexing vs `utf8_text` — inconsistent style | Robustness | injection.rs:391, 434 | non-issue: `source[byte_range()]` is the consistent pattern across the codebase |
+| 44 | `walk_for_containers` duplicate range risk if two rules share `container_kind` | Robustness | injection.rs:49-53 | ✅ fixed |
+| 45 | Grammar-less languages with non-empty `injections` field would silently produce nothing | Extensibility | mod.rs, injection.rs | ✅ fixed |
+| 46 | No contributor docs for adding new injection rules | Extensibility | CONTRIBUTING.md | ✅ fixed |
+| 47 | `run_git_log_line_range` doesn't validate colons in file path — git `-L` misparse | Security | blame.rs:79-93 | ✅ fixed |
+| 48 | No test for `type="text/typescript"` attribute detection | Test Coverage | html.rs tests | ✅ fixed in P2 |
 
 ## P4: Hard or Low Impact — Defer / Create Issues
 

--- a/src/cli/commands/blame.rs
+++ b/src/cli/commands/blame.rs
@@ -80,6 +80,14 @@ fn run_git_log_line_range(
         anyhow::bail!("Invalid file path '{}': must not start with '-'", rel_file);
     }
 
+    // Reject embedded colons — git `-L start,end:file` would misparse
+    if rel_file.contains(':') {
+        anyhow::bail!(
+            "Invalid file path '{}': colons not supported (conflicts with git -L syntax)",
+            rel_file
+        );
+    }
+
     // Ensure valid line range (start <= end); swap if inverted
     let (start, end) = if start > end {
         tracing::warn!(start, end, "Inverted line range, swapping");

--- a/src/cli/commands/read.rs
+++ b/src/cli/commands/read.rs
@@ -310,6 +310,8 @@ pub(crate) fn cmd_read(path: &str, focus: Option<&str>, json: bool) -> Result<()
 }
 
 fn cmd_read_focused(focus: &str, json: bool) -> Result<()> {
+    let _span = tracing::info_span!("cmd_read_focused", %focus).entered();
+
     let (store, root, cqs_dir) = crate::cli::open_project_store()?;
 
     let audit_mode = load_audit_state(&cqs_dir);

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -161,6 +161,7 @@ pub type StructuralMatcherFn = fn(&str, &str) -> bool;
 ///
 /// Defines how embedded language regions within a host grammar are identified
 /// and parsed. For example, `<script>` within HTML → JavaScript.
+#[derive(Debug)]
 pub struct InjectionRule {
     /// Node kind of the container element (e.g., "script_element", "style_element")
     pub container_kind: &'static str,

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -26,6 +26,14 @@ impl Parser {
             return vec![];
         }
 
+        // Normalize CRLF → LF for consistency (callers typically pass normalized
+        // source, but standalone callers like extract_calls_from_chunk may not)
+        let source = if source.contains("\r\n") {
+            std::borrow::Cow::Owned(source.replace("\r\n", "\n"))
+        } else {
+            std::borrow::Cow::Borrowed(source)
+        };
+
         let grammar = language.grammar();
         let mut parser = tree_sitter::Parser::new();
         if let Err(e) = parser.set_language(&grammar) {
@@ -33,7 +41,7 @@ impl Parser {
             return vec![];
         }
 
-        let tree = match parser.parse(source, None) {
+        let tree = match parser.parse(source.as_ref(), None) {
             Some(t) => t,
             None => {
                 tracing::warn!(%language, "tree-sitter parse returned None in extract_calls");
@@ -274,6 +282,7 @@ impl Parser {
         let mut calls = Vec::new();
         let mut seen = std::collections::HashSet::new();
         let capture_names = chunk_query.capture_names();
+        let name_idx = chunk_query.capture_index_for_name("name");
 
         while let Some(m) = matches.next() {
             // Find chunk node
@@ -289,7 +298,6 @@ impl Parser {
             let node = func_capture.node;
 
             // Get chunk name
-            let name_idx = chunk_query.capture_index_for_name("name");
             let mut name = name_idx
                 .and_then(|idx| m.captures.iter().find(|c| c.index == idx))
                 .map(|c| source[c.node.byte_range()].to_string())
@@ -363,7 +371,15 @@ impl Parser {
         // --- Phase 2: Injection relationships (multi-grammar) ---
         let injections = language.def().injections;
         if !injections.is_empty() {
+            // Release borrows on the outer tree before injection phase
+            drop(matches);
+            drop(cursor);
+
             let groups = super::injection::find_injection_ranges(&tree, &source, injections);
+
+            // Free outer tree/parser memory before inner parse allocations
+            drop(tree);
+            drop(parser);
             for group in &groups {
                 match self.parse_injected_relationships(&source, group) {
                     Ok((inner_calls, inner_types))

--- a/src/parser/injection.rs
+++ b/src/parser/injection.rs
@@ -11,6 +11,7 @@
 //! checked for their own injection rules (e.g., PHP→HTML→JS would require
 //! recursive injection, which is not yet implemented).
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use tree_sitter::StreamingIterator;
@@ -49,7 +50,7 @@ pub(crate) fn find_injection_ranges(
     source: &str,
     rules: &[InjectionRule],
 ) -> Vec<InjectionGroup> {
-    let _span = tracing::debug_span!("find_injection_ranges", rules = rules.len()).entered();
+    let _span = tracing::info_span!("find_injection_ranges", rules = rules.len()).entered();
 
     // Collect (language_name, range, container_lines) tuples
     let mut entries: Vec<(&str, tree_sitter::Range, (u32, u32))> = Vec::new();
@@ -77,7 +78,11 @@ pub(crate) fn find_injection_ranges(
         entries.truncate(MAX_INJECTION_RANGES);
     }
 
-    // Group by language name
+    // Deduplicate by byte range (guards against two rules sharing a container_kind)
+    entries.dedup_by(|a, b| a.1.start_byte == b.1.start_byte && a.1.end_byte == b.1.end_byte);
+
+    // Group by resolved language using HashMap for O(1) lookup
+    let mut group_index: HashMap<Language, usize> = HashMap::new();
     let mut groups: Vec<InjectionGroup> = Vec::new();
     for (lang_name, range, lines) in entries {
         // Resolve language
@@ -101,11 +106,12 @@ pub(crate) fn find_injection_ranges(
             }
         };
 
-        // Find existing group or create new one
-        if let Some(group) = groups.iter_mut().find(|g| g.language == language) {
-            group.ranges.push(range);
-            group.container_lines.push(lines);
+        if let Some(&idx) = group_index.get(&language) {
+            groups[idx].ranges.push(range);
+            groups[idx].container_lines.push(lines);
         } else {
+            let idx = groups.len();
+            group_index.insert(language, idx);
             groups.push(InjectionGroup {
                 language,
                 ranges: vec![range],
@@ -115,6 +121,23 @@ pub(crate) fn find_injection_ranges(
     }
 
     groups
+}
+
+/// Advance a tree cursor to the next sibling, walking up parents as needed.
+///
+/// Returns `false` if the entire tree has been exhausted.
+fn advance_cursor(cursor: &mut tree_sitter::TreeCursor) -> bool {
+    if cursor.goto_next_sibling() {
+        return true;
+    }
+    loop {
+        if !cursor.goto_parent() {
+            return false;
+        }
+        if cursor.goto_next_sibling() {
+            return true;
+        }
+    }
 }
 
 /// Walk the tree using a cursor to find all nodes matching an injection rule's container_kind.
@@ -136,9 +159,7 @@ fn walk_for_containers(
             };
 
             // Skip non-parseable content (e.g., JSON-LD, shader scripts)
-            if target == "_skip" {
-                // Fall through to the sibling-advance logic below
-            } else {
+            if target != "_skip" {
                 // Collect ALL matching content children (error recovery may split
                 // raw_text into multiple nodes)
                 let mut child_cursor = node.walk();
@@ -164,16 +185,8 @@ fn walk_for_containers(
                 }
             }
             // Don't descend into containers — skip to next sibling
-            if !cursor.goto_next_sibling() {
-                // Walk back up to find more siblings
-                loop {
-                    if !cursor.goto_parent() {
-                        return;
-                    }
-                    if cursor.goto_next_sibling() {
-                        break;
-                    }
-                }
+            if !advance_cursor(cursor) {
+                return;
             }
             continue;
         }
@@ -182,18 +195,9 @@ fn walk_for_containers(
         if cursor.goto_first_child() {
             continue;
         }
-        // Try next sibling
-        if cursor.goto_next_sibling() {
-            continue;
-        }
-        // Walk back up
-        loop {
-            if !cursor.goto_parent() {
-                return;
-            }
-            if cursor.goto_next_sibling() {
-                break;
-            }
+        // Advance to next sibling or walk up
+        if !advance_cursor(cursor) {
+            return;
         }
     }
 }
@@ -248,7 +252,8 @@ impl Parser {
         let _span = tracing::info_span!(
             "parse_injected_chunks",
             language = %inner_language,
-            range_count = group.ranges.len()
+            range_count = group.ranges.len(),
+            path = %path.display()
         )
         .entered();
 
@@ -279,6 +284,11 @@ impl Parser {
                 Ok(mut chunk) => {
                     // Skip oversized chunks
                     if chunk.content.len() > super::MAX_CHUNK_BYTES {
+                        tracing::debug!(
+                            id = %chunk.id,
+                            bytes = chunk.content.len(),
+                            "Skipping oversized injected chunk"
+                        );
                         continue;
                     }
 
@@ -309,6 +319,12 @@ impl Parser {
             tracing::debug!(
                 language = %inner_language,
                 "Injection produced no chunks, keeping outer"
+            );
+        } else {
+            tracing::debug!(
+                language = %inner_language,
+                count = chunks.len(),
+                "Injection extracted chunks"
             );
         }
 
@@ -361,6 +377,7 @@ impl Parser {
         let mut matches = cursor.matches(chunk_query, tree.root_node(), source.as_bytes());
 
         let capture_names = chunk_query.capture_names();
+        let name_idx = chunk_query.capture_index_for_name("name");
         let mut call_results = Vec::new();
         let mut type_results = Vec::new();
         let mut call_cursor = tree_sitter::QueryCursor::new();
@@ -381,7 +398,6 @@ impl Parser {
             let node = func_capture.node;
 
             // Get chunk name
-            let name_idx = chunk_query.capture_index_for_name("name");
             let mut name = name_idx
                 .and_then(|idx| m.captures.iter().find(|c| c.index == idx))
                 .map(|c| source[c.node.byte_range()].to_string())
@@ -456,6 +472,13 @@ impl Parser {
                 });
             }
         }
+
+        tracing::debug!(
+            language = %inner_language,
+            calls = call_results.len(),
+            types = type_results.len(),
+            "Injection extracted relationships"
+        );
 
         Ok((call_results, type_results))
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -74,6 +74,12 @@ impl Parser {
                     def.name
                 )
             });
+            // Grammar-less languages must not define injections (they'd silently produce nothing)
+            debug_assert!(
+                def.grammar.is_some() || def.injections.is_empty(),
+                "Language '{}' has no grammar but defines injections — injections require tree-sitter",
+                def.name
+            );
             if def.grammar.is_some() {
                 queries.insert(lang, OnceCell::new());
                 call_queries.insert(lang, OnceCell::new());
@@ -242,10 +248,20 @@ impl Parser {
         // --- Phase 2: Injection parsing (multi-grammar) ---
         let injections = language.def().injections;
         if !injections.is_empty() {
+            // Release borrows on the outer tree before injection phase
+            drop(matches);
+            drop(cursor);
+
             let groups = injection::find_injection_ranges(&tree, &source, injections);
+
+            // Free outer tree/parser memory before inner parse allocations
+            drop(tree);
+            drop(parser);
+
             for group in &groups {
                 match self.parse_injected_chunks(&source, path, group) {
                     Ok(inner_chunks) if !inner_chunks.is_empty() => {
+                        let before = chunks.len();
                         // Remove outer chunks that overlap with injection containers
                         chunks.retain(|c| {
                             !injection::chunk_within_container(
@@ -254,6 +270,13 @@ impl Parser {
                                 &group.container_lines,
                             )
                         });
+                        let removed = before - chunks.len();
+                        tracing::debug!(
+                            language = %group.language,
+                            removed,
+                            added = inner_chunks.len(),
+                            "Replaced outer chunks with injection results"
+                        );
                         chunks.extend(inner_chunks);
                     }
                     Ok(_) => {

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -206,6 +206,8 @@ pub(crate) fn scout_core(
     graph: &crate::store::CallGraph,
     test_chunks: &[ChunkSummary],
 ) -> Result<ScoutResult, AnalysisError> {
+    let _span = tracing::info_span!("scout_core", %task, limit).entered();
+
     // 1. Search
     let filter = SearchFilter {
         enable_rrf: true,


### PR DESCRIPTION
## Summary

- Fix 18 of 22 P3 audit findings across 9 files
- 4 findings marked non-actionable with justification (HashSet<&str> incompatible with retain/push patterns, runtime validation already exists, source indexing style is consistent)
- #48 was already fixed in P2

**Key changes:**
- Injection parsing: Debug derive, advance_cursor helper, HashMap grouping, range dedup, success logging, path in spans
- Resource management: explicit drop of outer tree-sitter objects before injection inner-parse
- Performance: hoist capture_index_for_name out of per-match loops
- Platform: CRLF normalization in extract_calls, colon validation in blame paths
- Observability: tracing spans for scout_core and cmd_read_focused
- Docs: injection rules section in CONTRIBUTING.md

## Test plan

- [x] `cargo test --features gpu-index --lib` — 933 pass
- [x] `cargo test --features gpu-index --test parser_test` — 60 pass
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
