### PR TITLE
chore: release v0.27.0 — multi-grammar parsing, 57 audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-03-06
+
+Multi-grammar parsing — HTML files extract real JS/CSS chunks from embedded `<script>` and `<style>` blocks. Full 14-category audit with 57 findings resolved.
+
 ### Added
-- **Multi-grammar injection parsing** — HTML `<script>` blocks now extract real JS/TS function chunks; `<style>` blocks extract CSS rule chunks. Powered by tree-sitter's `set_included_ranges()`. `InjectionRule` on `LanguageDef` makes this extensible to other host languages (PR #540)
+- **Multi-grammar injection parsing** — HTML `<script>` blocks extract real JS/TS function chunks; `<style>` blocks extract CSS rule chunks. Powered by tree-sitter's `set_included_ranges()`. `InjectionRule` on `LanguageDef` makes this extensible to other host languages (PR #540)
+- **`parse_file_all()` combined method** — single file read + tree-sitter parse returns chunks, calls, and type refs. Eliminates double-parse in watch mode incremental reindexing (PR #544)
+- **`ParseAllResult` type alias** for combined parse results
+- **`parse_injected_all()`** — combined injection method for chunks + relationships in one inner parse
+- **`detect_script_language()`** — detects TypeScript from `<script lang="ts">` or `<script type="text/typescript">` attributes
+- End-to-end integration test for HTML injection parsing
+- Tests for malformed/unclosed `<script>` tags, `type="text/typescript"` detection
+
+### Fixed
+- 57 audit findings resolved across 4 PRs (#541-#544): deduplication, correctness, security, observability, documentation
+- `capture_name_to_chunk_type()` shared helper eliminates duplicated capture-name-to-type mapping (P1)
+- `walk_for_containers()` now owns its cursor — takes `Node` instead of `&mut TreeCursor` (P4)
+- Injection range deduplication prevents duplicate chunks from shared container kinds (P3)
+- `run_git_log_line_range()` validates colons in file paths to prevent git `-L` misparse (P3)
+- Cross-phase coupling between `parse_file` and `parse_file_relationships` documented (P4)
+
+### Changed
+- Watch mode (`reindex_files`) uses `parse_file_all()` instead of separate `parse_file` + `parse_file_relationships` calls
 
 ## [0.26.0] - 2026-03-05
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ src/
     helpers.rs  - Types, embedding conversion functions
     migrations.rs - Schema migration framework
   parser/       - Code parsing (tree-sitter + custom parsers, delegates to language/ registry)
-    mod.rs      - Parser struct, parse_file(), supported_extensions()
+    mod.rs      - Parser struct, parse_file(), parse_file_all(), supported_extensions()
     types.rs    - Chunk (incl. parent_type_name), CallSite, FunctionCalls, TypeRef, ParserError
     chunk.rs    - Chunk extraction, signatures, doc comments, parent type extraction
     calls.rs    - Call graph extraction, callee filtering

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 46 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,9 +2,9 @@
 
 ## Right Now
 
-**Multi-grammar parsing — merged.** 2026-03-05. PR #540.
-
-HTML files extract real JS/CSS chunks from `<script>` and `<style>` blocks using tree-sitter `set_included_ranges()`. Two-phase parsing: outer HTML grammar, then inner JS/CSS grammars. Extensible via `InjectionRule` on `LanguageDef`.
+**Multi-grammar audit complete.** 2026-03-06. All 57 findings resolved across 4 PRs:
+- P1: #541 (13 fixes), P2: #542 (13 fixes), P3: #543 (18 fixes), P4: #544 (9 fixes)
+- Key P4 deliverable: `parse_file_all()` combined method eliminates double file read/parse in watch.rs
 
 ## Pending Changes
 
@@ -35,7 +35,7 @@ None.
 
 ## Architecture
 
-- Version: 0.26.0
+- Version: 0.27.0
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
@@ -43,7 +43,7 @@ None.
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 46 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Haskell, OCaml, Julia, Gleam, CSS, Perl, HTML, JSON, XML, INI, Nix, Make, LaTeX, Solidity, CUDA, GLSL, Markdown)
 - 16 ChunkType variants (Function, Method, Struct, Class, Interface, Enum, Trait, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias)
-- Tests: 1465 pass, 0 failures
+- Tests: 1480 pass, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Source layout: parser/, hnsw/, impact/, batch/ are directories
 - convert/ module (7 files) behind `convert` feature flag

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,7 +56,7 @@ Infrastructure for adding variants is now cheap: per-language LanguageDef fields
 
 ### Multi-Grammar Parsing
 
-Injection framework shipped in v0.26.0 (PR #540). `InjectionRule` on `LanguageDef`, two-phase `parse_file`/`parse_file_relationships` via `set_included_ranges()`.
+Injection framework shipped in v0.27.0 (PRs #540, #544). `InjectionRule` on `LanguageDef`, `parse_file_all()` combined method for single-pass chunk + relationship extraction via `set_included_ranges()`.
 
 **Done:**
 - [x] HTML → JavaScript (with TypeScript detection via `lang`/`type` attrs)


### PR DESCRIPTION
## Summary

Release v0.27.0 — multi-grammar parsing and full 14-category audit.

### Highlights

- **Multi-grammar injection parsing** (PR #540) — HTML `<script>` extracts real JS/TS function chunks, `<style>` extracts CSS rules. Extensible via `InjectionRule` on `LanguageDef`.
- **`parse_file_all()` combined method** (PR #544) — single file read + tree-sitter parse for chunks + calls + type refs. Watch mode uses it.
- **57 audit findings resolved** (PRs #541-#544) — dedup, correctness, security, observability, documentation, tests.

### Changes

- Version bump 0.26.0 → 0.27.0
- CHANGELOG entry
- CONTRIBUTING.md architecture update
- ROADMAP update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
