### PR TITLE
chore: release v0.28.0 — Svelte, Razor, VB.NET language support (49 languages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-03-07
+
+Recursive injection framework expansion — Svelte, Razor/CSHTML, VB.NET language support, plus PHP→HTML→JS/CSS recursive injection and Nix/HCL/LaTeX→code injection rules (46 → 49 languages).
+
+### Added
+- **Svelte language support** (`.svelte`) — `tree-sitter-svelte-next` grammar. JS/TS + CSS injection from `<script>` and `<style>` blocks. TypeScript detection via `lang`/`type` attributes. Reuses HTML's `detect_script_language` (PR #546)
+- **Razor/CSHTML language support** (`.cshtml`, `.razor`) — `tris203/tree-sitter-razor` fork. Monolithic grammar parses C#, HTML, and Razor directives in a single tree. C# chunks from `@code`/`@functions` blocks, HTML heading/landmark extraction, JS/CSS injection via `_inner` content mode (PR #546)
+- **VB.NET language support** (`.vb`) — `CodeAnt-AI/tree-sitter-vb-dotnet` fork. Classes, modules, structures, interfaces, enums, methods, properties, events, delegates. Full call graph and type references (PR #546)
+- **`_inner` content mode** — injection framework extension for grammars where container nodes have no named content child (e.g., Razor's generic `element` node). Extracts bytes between first `>` and last `</` in source text (PR #546)
+- **PHP→HTML→JS/CSS recursive injection** — depth limit 3. Two injection rules: `program/text` (leading HTML) + `text_interpolation/text` (HTML after `?>`). `content_scoped_lines` prevents container-spans-file problem (PR #546)
+- **Nix→Bash injection** — `indented_string_expression` in shell contexts (buildPhase, installPhase, shellHook). `detect_nix_shell_context` checks parent binding name (PR #546)
+- **HCL→Bash injection** — `heredoc_template` with shell identifiers (EOT, BASH, SHELL). `detect_heredoc_language` checks heredoc identifier (PR #546)
+- **LaTeX→code injection** — `minted_environment` + `listing_environment`. Language detection from `\begin{minted}{python}` and `[language=Rust]` options (PR #546)
+- `byte_offset_to_point()` helper for `_inner` content mode range calculation
+
 ## [0.27.0] - 2026-03-06
 
 Multi-grammar parsing — HTML files extract real JS/CSS chunks from embedded `<script>` and `<style>` blocks. Full 14-category audit with 57 findings resolved.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ src/
     watch.rs    - File watcher for incremental reindexing
   language/     - Tree-sitter language support
     mod.rs      - Language enum, LanguageRegistry, LanguageDef, ChunkType
-    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, kotlin.rs, swift.rs, objc.rs, sql.rs, protobuf.rs, graphql.rs, php.rs, lua.rs, zig.rs, r.rs, yaml.rs, toml_lang.rs, elixir.rs, erlang.rs, gleam.rs, haskell.rs, julia.rs, ocaml.rs, css.rs, perl.rs, html.rs, json.rs, xml.rs, ini.rs, nix.rs, make.rs, latex.rs, solidity.rs, cuda.rs, glsl.rs, markdown.rs
+    rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, kotlin.rs, swift.rs, objc.rs, sql.rs, protobuf.rs, graphql.rs, php.rs, lua.rs, zig.rs, r.rs, yaml.rs, toml_lang.rs, elixir.rs, erlang.rs, gleam.rs, haskell.rs, julia.rs, ocaml.rs, css.rs, perl.rs, html.rs, json.rs, xml.rs, ini.rs, nix.rs, make.rs, latex.rs, solidity.rs, cuda.rs, glsl.rs, svelte.rs, razor.rs, vbnet.rs, markdown.rs
   store/        - SQLite storage layer (Schema v11, WAL mode)
     mod.rs      - Store struct, open/init, FTS5, RRF fusion
     chunks.rs   - Chunk CRUD, embedding_batches() for streaming

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 49 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -35,7 +35,7 @@ None.
 
 ## Architecture
 
-- Version: 0.27.0
+- Version: 0.28.0
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Roadmap
 
-## Current: v0.27.0
+## Current: v0.28.0
 
-All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 47 languages. Two full audits complete (v0.12.3 + v0.19.2). Recursive multi-grammar injection framework.
+All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 49 languages. Two full audits complete (v0.12.3 + v0.19.2). Recursive multi-grammar injection framework.
 
 ### Next — Commands
 


### PR DESCRIPTION
## Summary

- Version bump 0.27.0 → 0.28.0
- Changelog for v0.28.0: Svelte, Razor/CSHTML, VB.NET language support + recursive injection framework expansion (49 languages)
- Docs review fixes: CONTRIBUTING.md file listing, ROADMAP.md version/count, PROJECT_CONTINUITY.md version

## Test plan

- [x] 1529 tests pass
- [x] Clippy clean
- [x] Docs reviewed and updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
