### PR TITLE
chore: release v0.28.1 — crates.io deps fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.1] - 2026-03-07
+
+### Fixed
+- Switch `tree-sitter-razor` and `tree-sitter-vb-dotnet` from git deps to crates.io v0.1.0 — enables `cargo install cqs` without git access (PR #548)
+
 ## [0.28.0] - 2026-03-07
 
 Recursive injection framework expansion — Svelte, Razor/CSHTML, VB.NET language support, plus PHP→HTML→JS/CSS recursive injection and Nix/HCL/LaTeX→code injection rules (46 → 49 languages).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 49 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -35,7 +35,7 @@ None.
 
 ## Architecture
 
-- Version: 0.28.0
+- Version: 0.28.1
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current: v0.28.0
+## Current: v0.28.1
 
 All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 49 languages. Two full audits complete (v0.12.3 + v0.19.2). Recursive multi-grammar injection framework.
 


### PR DESCRIPTION
## Summary

- Version bump 0.28.0 → 0.28.1
- Changelog for crates.io deps fix (PR #548)

## Test plan

- [x] 1529 tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
