### PR TITLE
fix: audit P3 — 24 fixes (observability, perf, security, tests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Vue language support (50 languages total)
+- 91 audit fixes across P1-P3 priority tiers
+
+### Changed
+- FTS indexing now uses batch INSERT for better performance
+- `count_stale_files` delegates to `list_stale_files` (dedup)
+- `SearchResult`/`NoteSearchResult` use `#[serde(flatten)]` for consistent serialization
+- Added tracing spans to 12+ hot-path functions (markdown, HNSW, CAGRA, notes, references)
+- Named constants for search scoring thresholds
+
+### Fixed
+- `is_webhelp_dir` now rejects symlinks (security hardening)
+- Token budget warning messages clarify min-1 guarantee
+
 ## [0.28.1] - 2026-03-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,10 @@ Project skills in `.claude/skills/`. Use `/skill-name` to invoke:
 - `/cqs-bootstrap` -- set up tears infrastructure for new projects
 - `/cqs-plan` -- task planning with scout data + task-type templates
 - `/reindex` -- rebuild index with before/after stats
+- `/docs-review` -- check docs for staleness, fix drift
+- `/cqs-batch` -- batch cqs queries in persistent session
+- `/migrate` -- handle schema version upgrades
+- `/troubleshoot` -- diagnose common cqs issues
 
 ## Code Search
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,8 @@ cqs is a **local code search tool** for developers. It runs on your machine, ind
 |----------|-------------|-------|
 | **Local user** | Trusted | You run cqs, you control it |
 | **Project files** | Trusted | Your code, indexed by your choice |
+| **External documents** | Semi-trusted | PDF/HTML/CHM files converted via `cqs convert` — parsed but not executed |
+| **Reference sources** | Semi-trusted | Indexed via `cqs ref add` — search results blended with project code |
 
 ### What We Protect Against
 

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -54,40 +54,40 @@ Date: 2026-03-06
 
 | # | Finding | Category | Location | Status |
 |---|---------|----------|----------|--------|
-| 1 | OB-5: `parse_markdown_chunks`/`parse_markdown_references` missing spans | Observability | markdown.rs | |
-| 2 | OB-6: `parse_notes`/`rewrite_notes_file` missing spans | Observability | note.rs | |
-| 3 | OB-7: HNSW build/save/load missing spans | Observability | hnsw/ | |
-| 4 | OB-8: CAGRA build/search missing spans | Observability | cagra.rs | |
-| 5 | OB-9: `load_references` missing span | Observability | reference.rs | |
-| 6 | OB-10: `enumerate_files` missing span | Observability | files.rs | |
-| 7 | OB-11: `extract_fenced_blocks` missing span | Observability | markdown.rs | |
-| 8 | CQ-5: 3 near-identical Chunk constructions in markdown | Code Quality | markdown.rs | |
-| 9 | DOC-4: CLAUDE.md skills list missing 5 skills | Documentation | CLAUDE.md | |
-| 10 | DOC-5: CHANGELOG [Unreleased] empty | Documentation | CHANGELOG.md | |
-| 11 | DOC-6: ROADMAP says 49 languages | Documentation | ROADMAP.md | |
-| 12 | PB-1: Markdown parsers don't normalize CRLF | Platform | markdown.rs | |
-| 13 | EX-6: `name_match_score` magic numbers | Extensibility | search.rs:130 | |
-| 14 | EX-7: `chunk_importance` magic numbers | Extensibility | search.rs:398 | |
-| 15 | EX-1: `Pattern` enum 4 manual-sync representations | Extensibility | structural.rs | |
-| 16 | PB-4: `ensure_ort_provider_libs` misleading stub comment | Platform | embedder.rs | |
-| 17 | SEC-2: `is_webhelp_dir` follows symlinks in detection | Security | webhelp.rs:19 | |
-| 18 | SEC-3: SECURITY.md threat model understates trust levels | Security | SECURITY.md | |
-| 19 | DS-12: Second-precision mtime — sub-second edits missed | Data Safety | notes.rs:234 | |
-| 20 | DS-13: `count_vectors` reads HNSW IDs without lock | Data Safety | persist.rs:442 | |
-| 21 | PF-5: FTS INSERT per-row despite bulk DELETE | Performance | chunks.rs:290 | |
-| 22 | PF-6: `count_stale_files`/`list_stale_files` duplicate SQL | Performance | chunks.rs:546 | |
-| 23 | TC-3: `extract_fenced_blocks` missing edge case tests | Test Coverage | markdown.rs | |
-| 24 | TC-4: `build_risk_summary` never directly tested | Test Coverage | review.rs | |
-| 25 | TC-5: `match_notes` only one happy path test | Test Coverage | review.rs | |
-| 26 | TC-8: `run_ci_analysis` dead code path untested edge cases | Test Coverage | ci.rs | |
-| 27 | AD-2: `SearchResult` dual serialization shapes | API Design | helpers.rs | |
-| 28 | AC-2: `apply_token_budget` `.max(1)` exceeds budget | Algorithm | review.rs:97 | |
-| 29 | AC-4: `index_pack`/`token_pack` first-item guarantee — by design | Algorithm | task.rs:62 | |
-| 30 | PB-6: Path traversal check case-sensitivity — doc gap | Platform | read.rs:35 | |
-| 31 | RM-4: `index_notes_from_file` creates separate Embedder | Resource | index.rs:269 | |
-| 32 | RM-6: `HnswIndex::build` 2x memory (test-only) | Resource | build.rs:67 | |
-| 33 | RM-7: `last_indexed_mtime` unbounded growth | Resource | watch.rs:119 | |
-| 34 | RM-8: SQLite 64MB page cache potential | Resource | mod.rs:217 | |
+| 1 | OB-5: `parse_markdown_chunks`/`parse_markdown_references` missing spans | Observability | markdown.rs | fixed |
+| 2 | OB-6: `parse_notes`/`rewrite_notes_file` missing spans | Observability | note.rs | fixed |
+| 3 | OB-7: HNSW build/save/load missing spans | Observability | hnsw/ | fixed |
+| 4 | OB-8: CAGRA build/search missing spans | Observability | cagra.rs | fixed |
+| 5 | OB-9: `load_references` missing span | Observability | reference.rs | fixed |
+| 6 | OB-10: `enumerate_files` missing span | Observability | files.rs | fixed |
+| 7 | OB-11: `extract_fenced_blocks` missing span | Observability | markdown.rs | fixed |
+| 8 | CQ-5: 3 near-identical Chunk constructions in markdown | Code Quality | markdown.rs | fixed |
+| 9 | DOC-4: CLAUDE.md skills list missing 5 skills | Documentation | CLAUDE.md | fixed |
+| 10 | DOC-5: CHANGELOG [Unreleased] empty | Documentation | CHANGELOG.md | fixed |
+| 11 | DOC-6: ROADMAP says 49 languages | Documentation | ROADMAP.md | non-issue (already says 50) |
+| 12 | PB-1: Markdown parsers don't normalize CRLF | Platform | markdown.rs | fixed (doc comment) |
+| 13 | EX-6: `name_match_score` magic numbers | Extensibility | search.rs:130 | fixed |
+| 14 | EX-7: `chunk_importance` magic numbers | Extensibility | search.rs:398 | fixed |
+| 15 | EX-1: `Pattern` enum 4 manual-sync representations | Extensibility | structural.rs | non-issue (existing tests adequate) |
+| 16 | PB-4: `ensure_ort_provider_libs` misleading stub comment | Platform | embedder.rs | fixed |
+| 17 | SEC-2: `is_webhelp_dir` follows symlinks in detection | Security | webhelp.rs:19 | fixed |
+| 18 | SEC-3: SECURITY.md threat model understates trust levels | Security | SECURITY.md | fixed |
+| 19 | DS-12: Second-precision mtime — sub-second edits missed | Data Safety | notes.rs:234 | non-issue (acceptable limitation) |
+| 20 | DS-13: `count_vectors` reads HNSW IDs without lock | Data Safety | persist.rs:442 | fixed |
+| 21 | PF-5: FTS INSERT per-row despite bulk DELETE | Performance | chunks.rs:290 | fixed |
+| 22 | PF-6: `count_stale_files`/`list_stale_files` duplicate SQL | Performance | chunks.rs:546 | fixed |
+| 23 | TC-3: `extract_fenced_blocks` missing edge case tests | Test Coverage | markdown.rs | fixed (4 tests) |
+| 24 | TC-4: `build_risk_summary` never directly tested | Test Coverage | review.rs | fixed (3 tests) |
+| 25 | TC-5: `match_notes` only one happy path test | Test Coverage | review.rs | deferred (needs Store, integration test exists) |
+| 26 | TC-8: `run_ci_analysis` dead code path untested edge cases | Test Coverage | ci.rs | deferred (CLI handler, low value) |
+| 27 | AD-2: `SearchResult` dual serialization shapes | API Design | helpers.rs | fixed |
+| 28 | AC-2: `apply_token_budget` `.max(1)` exceeds budget | Algorithm | review.rs:97 | fixed (warning message) |
+| 29 | AC-4: `index_pack`/`token_pack` first-item guarantee — by design | Algorithm | task.rs:62 | non-issue (by design) |
+| 30 | PB-6: Path traversal check case-sensitivity — doc gap | Platform | read.rs:35 | fixed (doc comment) |
+| 31 | RM-4: `index_notes_from_file` creates separate Embedder | Resource | index.rs:269 | non-issue (low impact, shared Embedder complicates API) |
+| 32 | RM-6: `HnswIndex::build` 2x memory (test-only) | Resource | build.rs:67 | non-issue (test-only path) |
+| 33 | RM-7: `last_indexed_mtime` unbounded growth | Resource | watch.rs:119 | fixed (comment + with_capacity) |
+| 34 | RM-8: SQLite 64MB page cache potential | Resource | mod.rs:217 | non-issue (typical usage fine) |
 
 ## P4: Hard or Low Impact — Defer / Create Issues
 

--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -77,6 +77,7 @@ impl CagraIndex {
 
     /// Build a CAGRA index from embeddings
     pub fn build(embeddings: Vec<(String, Embedding)>) -> Result<Self, CagraError> {
+        let _span = tracing::debug_span!("cagra_build").entered();
         let (id_map, flat_data, n_vectors) = crate::hnsw::prepare_index_data(embeddings)
             .map_err(|e| CagraError::Build(e.to_string()))?;
 
@@ -150,6 +151,7 @@ impl CagraIndex {
 
     /// Search for nearest neighbors
     pub fn search(&self, query: &Embedding, k: usize) -> Vec<IndexResult> {
+        let _span = tracing::debug_span!("cagra_search", k).entered();
         if self.id_map.is_empty() {
             return Vec::new();
         }
@@ -404,6 +406,7 @@ impl CagraIndex {
     /// Notes are excluded — they use brute-force search from SQLite so that
     /// notes are immediately searchable without rebuild.
     pub fn build_from_store(store: &crate::Store) -> Result<Self, CagraError> {
+        let _span = tracing::debug_span!("cagra_build_from_store").entered();
         let chunk_count = store
             .chunk_count()
             .map_err(|e| CagraError::Cuvs(format!("Failed to count chunks: {}", e)))?

--- a/src/cli/commands/ci.rs
+++ b/src/cli/commands/ci.rs
@@ -120,7 +120,7 @@ fn apply_token_budget(review: &mut ReviewResult, budget: usize, json: bool) -> u
             "Token-budgeted CI review"
         );
         review.warnings.push(format!(
-            "Output truncated to ~{} tokens (budget: {}). {} callers, {} tests omitted.",
+            "Output truncated to ~{} tokens (budget: {}). {} callers, {} tests omitted (min 1 caller + 1 test guaranteed).",
             used, budget, truncated_callers, truncated_tests
         ));
     }

--- a/src/cli/commands/read.rs
+++ b/src/cli/commands/read.rs
@@ -31,7 +31,9 @@ pub(crate) fn validate_and_read_file(root: &Path, path: &str) -> Result<(PathBuf
         bail!("File not found: {}", path);
     }
 
-    // Path traversal protection (dunce strips Windows UNC prefix automatically)
+    // Path traversal protection: canonicalize resolves to filesystem-stored case,
+    // so starts_with is correct even on case-insensitive filesystems (NTFS, APFS).
+    // dunce strips Windows UNC prefix automatically.
     let canonical = dunce::canonicalize(&file_path)
         .with_context(|| format!("Failed to canonicalize path: {}", path))?;
     let project_canonical =

--- a/src/cli/commands/review.rs
+++ b/src/cli/commands/review.rs
@@ -121,7 +121,7 @@ fn apply_token_budget(review: &mut ReviewResult, budget: usize, json: bool) -> u
             "Token-budgeted review"
         );
         review.warnings.push(format!(
-            "Output truncated to ~{} tokens (budget: {}). {} callers, {} tests omitted.",
+            "Output truncated to ~{} tokens (budget: {}). {} callers, {} tests omitted (min 1 caller + 1 test guaranteed).",
             used, budget, truncated_callers, truncated_tests
         ));
     }

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -126,7 +126,8 @@ pub fn cmd_watch(cli: &Cli, debounce_ms: u64, no_ignore: bool, poll: bool) -> Re
 
     // Track last-indexed mtime per file to skip duplicate WSL/NTFS events.
     // On WSL, inotify over 9P delivers repeated events for the same file change.
-    let mut last_indexed_mtime: HashMap<PathBuf, SystemTime> = HashMap::new();
+    // Bounded: pruned when >10k entries or >1k entries on single-file reindex.
+    let mut last_indexed_mtime: HashMap<PathBuf, SystemTime> = HashMap::with_capacity(1024);
 
     let mut cycles_since_clear: u32 = 0;
 

--- a/src/convert/webhelp.rs
+++ b/src/convert/webhelp.rs
@@ -17,6 +17,10 @@ const WEBHELP_CONTENT_DIR: &str = "content";
 ///
 /// Heuristic: has a `content/` subdirectory containing at least one `.html` file.
 pub fn is_webhelp_dir(dir: &Path) -> bool {
+    // Reject symlinks to prevent traversal outside trusted directories
+    if dir.symlink_metadata().is_ok_and(|m| m.is_symlink()) {
+        return false;
+    }
     let content_dir = dir.join(WEBHELP_CONTENT_DIR);
     if !content_dir.is_dir() {
         return false;

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -734,7 +734,9 @@ fn ensure_ort_provider_libs() {
 /// No-op on non-Unix platforms (CUDA provider libs handled differently)
 #[cfg(not(unix))]
 fn ensure_ort_provider_libs() {
-    // Windows/other platforms: CUDA libraries are typically in PATH already
+    // No-op: Windows and other platforms find CUDA/TensorRT provider libraries
+    // via PATH, so no symlinking is needed. The Unix version symlinks .so files
+    // into ort's search directory because LD_LIBRARY_PATH may not include them.
 }
 
 /// Cached GPU provider detection result

--- a/src/hnsw/build.rs
+++ b/src/hnsw/build.rs
@@ -41,6 +41,7 @@ impl HnswIndex {
     /// # Arguments
     /// * `embeddings` - Vector of (chunk_id, embedding) pairs
     pub fn build(embeddings: Vec<(String, Embedding)>) -> Result<Self, HnswError> {
+        let _span = tracing::debug_span!("hnsw_build").entered();
         if embeddings.is_empty() {
             // Create empty index
             let hnsw = Hnsw::new(MAX_NB_CONNECTION, 1, MAX_LAYER, EF_CONSTRUCTION, DistCosine);
@@ -110,6 +111,7 @@ impl HnswIndex {
         I: Iterator<Item = Result<Vec<(String, Embedding)>, E>>,
         E: std::fmt::Display,
     {
+        let _span = tracing::debug_span!("hnsw_build_batched", estimated_total).entered();
         let capacity = estimated_total.max(1);
         tracing::info!(
             "Building HNSW index incrementally (estimated {} vectors)",

--- a/src/hnsw/persist.rs
+++ b/src/hnsw/persist.rs
@@ -115,6 +115,7 @@ impl HnswIndex {
     /// Note: The underlying library writes graph/data non-atomically. However, the
     /// checksum verification on load ensures we never use a corrupted index.
     pub fn save(&self, dir: &Path, basename: &str) -> Result<(), HnswError> {
+        let _span = tracing::debug_span!("hnsw_save", dir = %dir.display(), basename).entered();
         tracing::info!("Saving HNSW index to {}/{}", dir.display(), basename);
 
         // Verify ID map matches HNSW vector count before saving
@@ -303,6 +304,7 @@ impl HnswIndex {
     /// Verifies blake3 checksums before loading to mitigate bincode deserialization risks.
     /// Memory is properly freed when the HnswIndex is dropped.
     pub fn load(dir: &Path, basename: &str) -> Result<Self, HnswError> {
+        let _span = tracing::debug_span!("hnsw_load", dir = %dir.display(), basename).entered();
         // Clean up stale temp dir from interrupted save (before anything else)
         let temp_dir = dir.join(format!(".{}.tmp", basename));
         if temp_dir.exists() {
@@ -452,6 +454,11 @@ impl HnswIndex {
                 return None;
             }
         };
+        // Acquire shared lock for consistency with load()
+        if let Err(e) = file.lock_shared() {
+            tracing::debug!("Could not lock HNSW id map: {}", e);
+            return None;
+        }
         // Guard against oversized id map files
         const MAX_ID_MAP_SIZE: u64 = 100 * 1024 * 1024; // 100MB
         match file.metadata() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,6 +339,7 @@ pub fn enumerate_files(
     extensions: &[&str],
     no_ignore: bool,
 ) -> anyhow::Result<Vec<PathBuf>> {
+    let _span = tracing::debug_span!("enumerate_files", root = %root.display()).entered();
     use anyhow::Context;
     use ignore::WalkBuilder;
 

--- a/src/note.rs
+++ b/src/note.rs
@@ -131,6 +131,7 @@ pub const NOTES_HEADER: &str = "\
 
 /// Parse notes from a notes.toml file
 pub fn parse_notes(path: &Path) -> Result<Vec<Note>, NoteError> {
+    let _span = tracing::debug_span!("parse_notes", path = %path.display()).entered();
     // Acquire shared lock and read from the locked handle directly
     use std::io::Read;
     let mut lock_file = std::fs::OpenOptions::new()
@@ -184,6 +185,7 @@ pub fn rewrite_notes_file(
     notes_path: &Path,
     mutate: impl FnOnce(&mut Vec<NoteEntry>) -> Result<(), NoteError>,
 ) -> Result<Vec<NoteEntry>, NoteError> {
+    let _span = tracing::debug_span!("rewrite_notes_file", path = %notes_path.display()).entered();
     // Acquire exclusive lock before the read-modify-write cycle.
     // Open with read+write so the exclusive lock covers both operations across all platforms.
     let mut lock_file = std::fs::OpenOptions::new()

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -19,6 +19,37 @@ static LINK_RE: LazyLock<Regex> =
 static FUNC_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"`([\w.:]+)\([^)]*\)`").expect("valid regex"));
 
+/// Build a markdown Chunk with common fields pre-filled.
+#[allow(clippy::too_many_arguments)]
+fn make_markdown_chunk(
+    path: &Path,
+    id: String,
+    name: String,
+    signature: String,
+    content: String,
+    line_start: u32,
+    line_end: u32,
+    content_hash: String,
+    parent_id: Option<String>,
+) -> Chunk {
+    Chunk {
+        id,
+        file: path.to_path_buf(),
+        language: Language::Markdown,
+        chunk_type: ChunkType::Section,
+        name,
+        signature,
+        content,
+        doc: None,
+        line_start,
+        line_end,
+        content_hash,
+        parent_id,
+        window_idx: None,
+        parent_type_name: None,
+    }
+}
+
 /// Minimum section size (lines) — smaller sections merge with next
 const MIN_SECTION_LINES: usize = 30;
 /// Maximum section size (lines) before attempting overflow split
@@ -36,7 +67,13 @@ struct Heading {
 ///
 /// Adaptive heading detection handles both standard (H1 → H2 → H3) and
 /// inverted (H2 title → H1 chapters → H3 subsections) hierarchies.
+///
+/// **Precondition:** `source` should use LF line endings. CRLF input works
+/// (Rust's `.lines()` handles both), but content hashes will differ from
+/// LF-normalized versions of the same file. The parser pipeline normalizes
+/// line endings before calling this function.
 pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, ParserError> {
+    let _span = tracing::debug_span!("parse_markdown_chunks", path = %path.display()).entered();
     let lines: Vec<&str> = source.lines().collect();
     let headings = extract_headings(&lines);
 
@@ -52,22 +89,17 @@ pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, Pa
         let hash_prefix = content_hash.get(..8).unwrap_or(&content_hash);
         let id = format!("{}:1:{}", path.display(), hash_prefix);
 
-        let mut chunks = vec![Chunk {
-            id: id.clone(),
-            file: path.to_path_buf(),
-            language: Language::Markdown,
-            chunk_type: ChunkType::Section,
-            name: name.clone(),
-            signature: name.clone(),
+        let mut chunks = vec![make_markdown_chunk(
+            path,
+            id.clone(),
+            name.clone(),
+            name.clone(),
             content,
-            doc: None,
-            line_start: 1,
-            line_end: lines.len() as u32,
+            1,
+            lines.len() as u32,
             content_hash,
-            parent_id: None,
-            window_idx: None,
-            parent_type_name: None,
-        }];
+            None,
+        )];
         extract_table_chunks(&lines, 0, lines.len(), &name, &name, &id, path, &mut chunks);
         return Ok(chunks);
     }
@@ -82,22 +114,17 @@ pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, Pa
         let line_end = lines.len() as u32;
         let id = format!("{}:{}:{}", path.display(), line_start, hash_prefix);
 
-        let mut chunks = vec![Chunk {
-            id: id.clone(),
-            file: path.to_path_buf(),
-            language: Language::Markdown,
-            chunk_type: ChunkType::Section,
-            name: h.text.clone(),
-            signature: h.text.clone(),
+        let mut chunks = vec![make_markdown_chunk(
+            path,
+            id.clone(),
+            h.text.clone(),
+            h.text.clone(),
             content,
-            doc: None,
             line_start,
             line_end,
             content_hash,
-            parent_id: None,
-            window_idx: None,
-            parent_type_name: None,
-        }];
+            None,
+        )];
         extract_table_chunks(
             &lines,
             0,
@@ -141,22 +168,17 @@ pub fn parse_markdown_chunks(source: &str, path: &Path) -> Result<Vec<Chunk>, Pa
         // Build breadcrumb signature
         let signature = build_breadcrumb(title_text, &section.heading_stack);
 
-        chunks.push(Chunk {
-            id: id.clone(),
-            file: path.to_path_buf(),
-            language: Language::Markdown,
-            chunk_type: ChunkType::Section,
-            name: section.name.clone(),
-            signature: signature.clone(),
+        chunks.push(make_markdown_chunk(
+            path,
+            id.clone(),
+            section.name.clone(),
+            signature.clone(),
             content,
-            doc: None,
             line_start,
             line_end,
             content_hash,
-            parent_id: None,
-            window_idx: None,
-            parent_type_name: None,
-        });
+            None,
+        ));
 
         // Extract tables as additional chunks with parent_id = section chunk
         extract_table_chunks(
@@ -179,6 +201,7 @@ pub fn parse_markdown_references(
     source: &str,
     path: &Path,
 ) -> Result<Vec<FunctionCalls>, ParserError> {
+    let _span = tracing::debug_span!("parse_markdown_references", path = %path.display()).entered();
     let lines: Vec<&str> = source.lines().collect();
     let headings = extract_headings(&lines);
 
@@ -1017,6 +1040,7 @@ fn normalize_lang(lang: &str) -> Option<&'static str> {
 /// recognized language identifiers. Blocks without a language tag or with
 /// unrecognized languages are skipped.
 pub fn extract_fenced_blocks(source: &str) -> Vec<FencedBlock> {
+    let _span = tracing::debug_span!("extract_fenced_blocks").entered();
     let lines: Vec<&str> = source.lines().collect();
     let mut blocks = Vec::new();
     let mut i = 0;
@@ -1816,7 +1840,6 @@ mod tests {
         assert_eq!(blocks[0].line_end, 5); // 1-indexed line of closing fence
     }
 
-    #[test]
     /// Verify normalize_lang covers all Language variants that have grammars.
     /// If this fails after adding a new language, add a mapping in normalize_lang().
     #[test]
@@ -1960,5 +1983,46 @@ mod tests {
             js_chunks.iter().any(|c| c.name == "add"),
             "Expected JavaScript function 'add'"
         );
+    }
+
+    // TC-3: extract_fenced_blocks edge case tests
+
+    #[test]
+    fn test_extract_fenced_blocks_unclosed() {
+        let source = "```rust\nfn foo() {}\n";
+        let blocks = extract_fenced_blocks(source);
+        // Unclosed fences are skipped (no matching closing fence)
+        assert_eq!(blocks.len(), 0);
+    }
+
+    #[test]
+    fn test_extract_fenced_blocks_nested_longer_fence() {
+        // 4-backtick fence containing a 3-backtick fence
+        let source = "````rust\nfn outer() {\n```\ninner\n```\n}\n````\n";
+        let blocks = extract_fenced_blocks(source);
+        assert_eq!(
+            blocks.len(),
+            1,
+            "Nested shorter fence should not close outer"
+        );
+        assert!(blocks[0].content.contains("inner"));
+    }
+
+    #[test]
+    fn test_extract_fenced_blocks_mixed_fence_types() {
+        // Backtick open + tilde close should NOT close
+        let source = "```rust\nfn foo() {}\n~~~\nmore\n```\n";
+        let blocks = extract_fenced_blocks(source);
+        assert_eq!(blocks.len(), 1);
+        // Tilde line should be included in content (doesn't close backtick fence)
+        assert!(blocks[0].content.contains("~~~"));
+    }
+
+    #[test]
+    fn test_extract_fenced_blocks_indented() {
+        let source = "  ```python\n  def foo(): pass\n  ```\n";
+        let blocks = extract_fenced_blocks(source);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].lang, "python");
     }
 }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -40,6 +40,7 @@ pub struct TaggedResult {
 /// HnswIndex::try_load is independent I/O (10-50ms each). Both Store and
 /// HnswIndex are Send + Sync.
 pub fn load_references(configs: &[ReferenceConfig]) -> Vec<ReferenceIndex> {
+    let _span = tracing::debug_span!("load_references", count = configs.len()).entered();
     let refs: Vec<ReferenceIndex> = configs
         .par_iter()
         .filter_map(|cfg| {

--- a/src/review.rs
+++ b/src/review.rs
@@ -241,3 +241,61 @@ fn build_risk_summary(functions: &[ReviewedFunction]) -> RiskSummary {
         overall,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::impact::RiskScore;
+
+    fn mock_reviewed(name: &str, level: RiskLevel) -> ReviewedFunction {
+        ReviewedFunction {
+            name: name.to_string(),
+            file: "src/lib.rs".to_string(),
+            line_start: 1,
+            risk: RiskScore {
+                risk_level: level,
+                blast_radius: level,
+                caller_count: 0,
+                test_count: 0,
+                coverage: 0.0,
+                score: 0.0,
+            },
+        }
+    }
+
+    // TC-4: build_risk_summary tests
+
+    #[test]
+    fn test_risk_summary_empty() {
+        let summary = build_risk_summary(&[]);
+        assert_eq!(summary.high, 0);
+        assert_eq!(summary.medium, 0);
+        assert_eq!(summary.low, 0);
+        assert!(matches!(summary.overall, RiskLevel::Low));
+    }
+
+    #[test]
+    fn test_risk_summary_all_high() {
+        let funcs = vec![
+            mock_reviewed("a", RiskLevel::High),
+            mock_reviewed("b", RiskLevel::High),
+        ];
+        let summary = build_risk_summary(&funcs);
+        assert_eq!(summary.high, 2);
+        assert!(matches!(summary.overall, RiskLevel::High));
+    }
+
+    #[test]
+    fn test_risk_summary_mixed() {
+        let funcs = vec![
+            mock_reviewed("a", RiskLevel::Low),
+            mock_reviewed("b", RiskLevel::Medium),
+            mock_reviewed("c", RiskLevel::Low),
+        ];
+        let summary = build_risk_summary(&funcs);
+        assert_eq!(summary.high, 0);
+        assert_eq!(summary.medium, 1);
+        assert_eq!(summary.low, 2);
+        assert!(matches!(summary.overall, RiskLevel::Medium));
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -126,23 +126,29 @@ impl NameMatcher {
         }
     }
 
+    // Name match score tiers
+    const SCORE_EXACT: f32 = 1.0;
+    const SCORE_CONTAINS: f32 = 0.8;
+    const SCORE_CONTAINED_BY: f32 = 0.6;
+    const SCORE_MAX_OVERLAP: f32 = 0.5;
+
     /// Compute name match score against pre-tokenized query
     pub fn score(&self, name: &str) -> f32 {
         let name_lower = name.to_lowercase();
 
         // Exact match
         if name_lower == self.query_lower {
-            return 1.0;
+            return Self::SCORE_EXACT;
         }
 
         // Name contains query as substring
         if name_lower.contains(&self.query_lower) {
-            return 0.8;
+            return Self::SCORE_CONTAINS;
         }
 
         // Query contains name as substring
         if self.query_lower.contains(&name_lower) {
-            return 0.6;
+            return Self::SCORE_CONTAINED_BY;
         }
 
         // Word overlap scoring
@@ -193,7 +199,7 @@ impl NameMatcher {
             .count() as f32;
         let total = self.query_words.len().max(1) as f32;
 
-        (overlap / total) * 0.5 // Max 0.5 for partial word overlap
+        (overlap / total) * Self::SCORE_MAX_OVERLAP
     }
 }
 
@@ -395,17 +401,20 @@ impl<'a> NoteBoostIndex<'a> {
 /// and monorepo layouts.
 ///
 /// Returns 1.0 (no change) when demotion doesn't apply.
+const IMPORTANCE_TEST: f32 = 0.90;
+const IMPORTANCE_PRIVATE: f32 = 0.95;
+
 fn chunk_importance(name: &str, file_path: &str) -> f32 {
-    // Name-based: test function → 0.90
+    // Name-based: test function
     if name.starts_with("test_")
         || name.starts_with("Test")
         || name.starts_with("spec_")
         || name.ends_with("_test")
         || name.ends_with("_spec")
     {
-        return 0.90;
+        return IMPORTANCE_TEST;
     }
-    // File-based: test file (by filename, not full path) → 0.90
+    // File-based: test file (by filename, not full path)
     let filename = file_path.rsplit('/').next().unwrap_or(file_path);
     if filename.contains("_test.")
         || filename.contains(".test.")
@@ -413,15 +422,15 @@ fn chunk_importance(name: &str, file_path: &str) -> f32 {
         || filename.contains("_spec.")
         || filename.starts_with("test_")
     {
-        return 0.90;
+        return IMPORTANCE_TEST;
     }
-    // Path-based: tests/ directory → 0.90
+    // Path-based: tests/ directory
     if file_path.contains("/tests/") || file_path.starts_with("tests/") {
-        return 0.90;
+        return IMPORTANCE_TEST;
     }
-    // Underscore-prefixed private (but not dunder like __init__) → 0.95
+    // Underscore-prefixed private (but not dunder like __init__)
     if name.starts_with('_') && !name.starts_with("__") {
-        return 0.95;
+        return IMPORTANCE_PRIVATE;
     }
     1.0
 }
@@ -1735,12 +1744,18 @@ mod tests {
     #[test]
     fn test_chunk_importance_test_upper() {
         // Go convention: TestFoo
-        assert_eq!(chunk_importance("TestParseConfig", "src/lib.go"), 0.90);
+        assert_eq!(
+            chunk_importance("TestParseConfig", "src/lib.go"),
+            IMPORTANCE_TEST
+        );
     }
 
     #[test]
     fn test_chunk_importance_underscore() {
-        assert_eq!(chunk_importance("_helper", "src/lib.rs"), 0.95);
+        assert_eq!(
+            chunk_importance("_helper", "src/lib.rs"),
+            IMPORTANCE_PRIVATE
+        );
     }
 
     #[test]
@@ -1752,19 +1767,25 @@ mod tests {
     #[test]
     fn test_chunk_importance_test_file() {
         // File named foo_test.rs → demotion via filename
-        assert_eq!(chunk_importance("helper_fn", "src/foo_test.rs"), 0.90);
+        assert_eq!(
+            chunk_importance("helper_fn", "src/foo_test.rs"),
+            IMPORTANCE_TEST
+        );
     }
 
     #[test]
     fn test_chunk_importance_test_dir_demoted() {
         // Files in tests/ directory are test infrastructure → demoted
-        assert_eq!(chunk_importance("real_fn", "tests/fixtures/eval.rs"), 0.90);
+        assert_eq!(
+            chunk_importance("real_fn", "tests/fixtures/eval.rs"),
+            IMPORTANCE_TEST
+        );
     }
 
     #[test]
     fn test_chunk_importance_test_name_beats_path() {
         // test_ name triggers demotion even in normal directory
-        assert_eq!(chunk_importance("test_foo", "src/lib.rs"), 0.90);
+        assert_eq!(chunk_importance("test_foo", "src/lib.rs"), IMPORTANCE_TEST);
     }
 
     // ===== build_filter_sql tests =====

--- a/src/store/chunks.rs
+++ b/src/store/chunks.rs
@@ -287,27 +287,34 @@ impl Store {
                 qb.build().execute(&mut *tx).await?;
             }
 
-            // FTS per-row (bulk DELETE above already cleared all FTS for this origin)
-            for (chunk, _) in chunks {
-                let fts_name = normalize_for_fts(&chunk.name);
-                let fts_sig = normalize_for_fts(&chunk.signature);
-                let fts_content = normalize_for_fts(&chunk.content);
-                let fts_doc = chunk
-                    .doc
-                    .as_ref()
-                    .map(|d| normalize_for_fts(d))
-                    .unwrap_or_default();
-
-                sqlx::query(
-                    "INSERT INTO chunks_fts (id, name, signature, content, doc) VALUES (?1, ?2, ?3, ?4, ?5)",
-                )
-                .bind(&chunk.id)
-                .bind(&fts_name)
-                .bind(&fts_sig)
-                .bind(&fts_content)
-                .bind(&fts_doc)
-                .execute(&mut *tx)
-                .await?;
+            // FTS batch INSERT (bulk DELETE above already cleared all FTS for this origin)
+            // Batch size: 190 rows × 5 columns = 950 params (< SQLite 999 limit)
+            let fts_data: Vec<_> = chunks
+                .iter()
+                .map(|(chunk, _)| {
+                    let fts_name = normalize_for_fts(&chunk.name);
+                    let fts_sig = normalize_for_fts(&chunk.signature);
+                    let fts_content = normalize_for_fts(&chunk.content);
+                    let fts_doc = chunk
+                        .doc
+                        .as_ref()
+                        .map(|d| normalize_for_fts(d))
+                        .unwrap_or_default();
+                    (chunk.id.clone(), fts_name, fts_sig, fts_content, fts_doc)
+                })
+                .collect();
+            for fts_batch in fts_data.chunks(190) {
+                let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+                    "INSERT INTO chunks_fts (id, name, signature, content, doc) ",
+                );
+                qb.push_values(fts_batch, |mut b, (id, name, sig, content, doc)| {
+                    b.push_bind(id)
+                        .push_bind(name)
+                        .push_bind(sig)
+                        .push_bind(content)
+                        .push_bind(doc);
+                });
+                qb.build().execute(&mut *tx).await?;
             }
 
             tx.commit().await?;
@@ -547,42 +554,8 @@ impl Store {
         &self,
         existing_files: &HashSet<PathBuf>,
     ) -> Result<(u64, u64), StoreError> {
-        self.rt.block_on(async {
-            let rows: Vec<(String, Option<i64>)> = sqlx::query_as(
-                "SELECT DISTINCT origin, source_mtime FROM chunks WHERE source_type = 'file'",
-            )
-            .fetch_all(&self.pool)
-            .await?;
-
-            let mut stale = 0u64;
-            let mut missing = 0u64;
-
-            for (origin, stored_mtime) in rows {
-                let path = PathBuf::from(&origin);
-                if !existing_files.contains(&path) {
-                    missing += 1;
-                    continue;
-                }
-
-                // Check mtime
-                if let Some(stored) = stored_mtime {
-                    let current_mtime = path
-                        .metadata()
-                        .and_then(|m| m.modified())
-                        .ok()
-                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                        .map(|d| d.as_secs() as i64);
-
-                    if let Some(current) = current_mtime {
-                        if current > stored {
-                            stale += 1;
-                        }
-                    }
-                }
-            }
-
-            Ok((stale, missing))
-        })
+        let report = self.list_stale_files(existing_files)?;
+        Ok((report.stale.len() as u64, report.missing.len() as u64))
     }
 
     /// List files that are stale (mtime changed) or missing from disk.

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -194,6 +194,7 @@ impl From<ChunkRow> for ChunkSummary {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SearchResult {
     /// The matching chunk
+    #[serde(flatten)]
     pub chunk: ChunkSummary,
     /// Similarity score (0.0 to 1.0, higher is better)
     pub score: f32,
@@ -335,6 +336,7 @@ pub struct NoteSummary {
 #[derive(Debug, serde::Serialize)]
 pub struct NoteSearchResult {
     /// The matching note
+    #[serde(flatten)]
     pub note: NoteSummary,
     /// Similarity score (0.0 to 1.0)
     pub score: f32,


### PR DESCRIPTION
## Summary

- 24 P3 audit fixes across 21 files
- 7 observability: `debug_span!` on 12+ hot-path functions
- 2 performance: batch FTS INSERT (190/batch), `count_stale_files` dedup
- 2 security: symlink check on `is_webhelp_dir`, SECURITY.md trust levels
- 2 test coverage: 4 fenced block edge case tests, 3 risk summary tests
- 2 extensibility: named constants for search scoring
- 1 code quality: `make_markdown_chunk` helper
- 1 API design: `#[serde(flatten)]` on `SearchResult`
- 1 algorithm: clarified token budget warning
- 1 data safety: shared lock in `count_vectors`
- 3 documentation: CLAUDE.md skills, CHANGELOG, SECURITY.md
- 6 non-issues closed, 2 deferred (TC-5, TC-8)

## Test plan

- [x] `cargo test --features lang-all` — 1533 pass, 0 fail
- [x] `cargo clippy --features lang-all -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
