### PR TITLE
chore: release v0.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.2] - 2026-03-08
+
 ### Added
 - Vue language support (50 languages total)
-- 91 audit fixes across P1-P3 priority tiers
+- Parser integration tests for 9 languages: C#, F#, PowerShell, Scala, Ruby, Vue, Svelte, Razor, VB.NET
+- Fenced block call-graph test (documents known limitation)
+- 100 audit fixes across P1-P4 tiers (91 P1-P3 + 9 P4)
+- Tracing spans for 49 store functions across calls.rs, types.rs, notes.rs, chunks.rs
 
 ### Changed
 - FTS indexing now uses batch INSERT for better performance
 - `count_stale_files` delegates to `list_stale_files` (dedup)
 - `SearchResult`/`NoteSearchResult` use `#[serde(flatten)]` for consistent serialization
-- Added tracing spans to 12+ hot-path functions (markdown, HNSW, CAGRA, notes, references)
 - Named constants for search scoring thresholds
+- `search_across_projects` now uses rayon parallel iteration
 
 ### Fixed
+- Replace panicking positional `row.get(N)` with safe `ChunkRow::from_row()` in search_by_names_batch
+- `find_project_root` now has depth limit (20) to avoid walking to filesystem root
 - `is_webhelp_dir` now rejects symlinks (security hardening)
 - Token budget warning messages clarify min-1 guarantee
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 50 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,7 +2,7 @@
 
 ## Right Now
 
-**P4 audit fixes in progress.** 2026-03-08. 9 of 20 P4 findings fixed (OB-1-4, TC-1, TC-6, RB-6, PB-3, PF-4). 11 deferred. Branch: `fix/p4-audit-fixes`.
+**v0.28.2 release in progress.** 2026-03-08. P4 audit fixes merged (#553). 9 of 20 findings fixed, 11 deferred with issues.
 
 ## Pending Changes
 
@@ -32,7 +32,7 @@ None.
 
 ## Architecture
 
-- Version: 0.28.1
+- Version: 0.28.2
 - MSRV: 1.93
 - Schema: v11
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)


### PR DESCRIPTION
## Summary

Release v0.28.2 — P4 audit fixes.

- Version bump 0.28.1 → 0.28.2
- Changelog updated
- PROJECT_CONTINUITY.md updated

See PR #553 for the actual changes.
