### PR TITLE
feat: add pre-built release binaries via GitHub Actions

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -48,8 +48,8 @@ Release a new version of cqs.
    - Sync main: `git checkout main && git pull`
    - Tag: `git tag vX.Y.Z`
    - Push tag via PowerShell: `powershell.exe -Command 'cd C:\Projects\cqs; git push origin vX.Y.Z'`
-   - Publish: `cargo publish`
-   - Create GitHub release via PowerShell with `--body-file`
+   - GitHub Release with pre-built binaries is created automatically by `.github/workflows/release.yml`
+   - Publish to crates.io (manual): `cargo publish`
 
 7. **Post-release**:
    - Update PROJECT_CONTINUITY.md with new version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-22.04
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            archive: zip
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package archive
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          STAGING="cqs-${VERSION}-${{ matrix.target }}"
+          mkdir -p "${STAGING}"
+
+          if [ "${{ matrix.runner }}" = "windows-latest" ]; then
+            cp "target/${{ matrix.target }}/release/cqs.exe" "${STAGING}/cqs.exe"
+          else
+            cp "target/${{ matrix.target }}/release/cqs" "${STAGING}/cqs"
+          fi
+
+          for f in README.md LICENSE; do
+            [ -f "$f" ] && cp "$f" "${STAGING}/"
+          done
+
+          ARCHIVE="cqs-${VERSION}-${{ matrix.target }}.${{ matrix.archive }}"
+          if [ "${{ matrix.archive }}" = "zip" ]; then
+            7z a "${ARCHIVE}" "${STAGING}"
+          else
+            tar czf "${ARCHIVE}" "${STAGING}"
+          fi
+
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cqs-${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cqs-*
+          merge-multiple: true
+          path: artifacts
+
+      - name: Generate checksums
+        working-directory: artifacts
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          sha256sum cqs-${VERSION}-* > "cqs-${VERSION}-checksums-sha256.txt"
+          echo "## SHA256 Checksums"
+          cat "cqs-${VERSION}-checksums-sha256.txt"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+          files: artifacts/*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 50 lan
 
 ### Next — Expansion
 
-- [ ] Pre-built release binaries (GitHub Actions) — adoption friction
+- [x] Pre-built release binaries (GitHub Actions) — adoption friction
 
 ### Future Languages — Priority Order
 
@@ -71,7 +71,7 @@ Injection framework shipped in v0.27.0 (PRs #540, #544). `InjectionRule` on `Lan
 - [x] HCL → Bash — `heredoc_template` with shell identifiers (EOT, BASH, SHELL, etc.). `detect_heredoc_language` checks heredoc identifier.
 
 **Next — New grammars required:**
-- [ ] Vue (.vue) → JS/TS, CSS, HTML — needs `tree-sitter-vue` grammar. `<script>`, `<style>`, `<template>` identical to HTML injection pattern.
+- [x] Vue (.vue) → JS/TS, CSS, HTML — `tree-sitter-vue-next`. Identical injection pattern to HTML/Svelte. Post-processing: headings, landmarks, setup script detection.
 
 **Next — Medium value (narrower scope):**
 - [ ] Markdown → fenced code blocks — custom parser, not tree-sitter. Needs different approach (parse ` ```lang ` content with target grammar).


### PR DESCRIPTION
## Summary

- Add GitHub Actions release workflow (`.github/workflows/release.yml`) triggered on `v*` tag push
- Builds pre-built binaries for 4 targets: Linux x86_64, macOS x86_64, macOS aarch64, Windows x86_64
- Creates GitHub Release with archives and SHA256 checksums automatically
- Update release SKILL.md to note automated GitHub Release creation
- Check off "Pre-built release binaries" in ROADMAP.md

## Test plan

- [ ] Push a test tag (e.g. `v0.28.3-rc.1`) to trigger the workflow
- [ ] Verify all 4 platform builds succeed
- [ ] Verify GitHub Release is created with all assets and checksums
- [ ] Download Linux binary on a fresh machine, run `cqs --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
