### PR TITLE
fix: upgrade macOS Intel runner to macos-14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             runner: ubuntu-24.04
             archive: tar.gz
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-14
             archive: tar.gz
           - target: aarch64-apple-darwin
             runner: macos-latest


### PR DESCRIPTION
## Summary

- `macos-13` runner is deprecated/unavailable on GitHub Actions
- Switch to `macos-14` (arm64) which cross-compiles to x86_64 via `--target`

## Test plan

- [x] Will verify on next release tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
