### PR TITLE
chore: release v1.0.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,8 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-24.04
             archive: tar.gz
-          - target: x86_64-apple-darwin
-            runner: macos-14
-            archive: tar.gz
+          # x86_64-apple-darwin dropped: ort-sys has no prebuilt binaries for Intel Mac
+          # Intel Mac users can build from source: cargo install cqs
           - target: aarch64-apple-darwin
             runner: macos-latest
             archive: tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.3] - 2026-03-13
+## [1.0.4] - 2026-03-13
 
 ### Fixed
-- Release workflow: make ort CUDA/TensorRT features conditional on non-macOS targets (no prebuilt binaries for x86_64-apple-darwin)
-- Release workflow: upgrade macOS Intel runner from macos-13 (deprecated) to macos-14
+- Release workflow: make ort CUDA/TensorRT features conditional on non-macOS targets
+- Release workflow: drop x86_64-apple-darwin target (ort-sys has no prebuilt binaries; use `cargo install cqs`)
+- Release workflow: upgrade macOS runner from macos-13 (deprecated) to macos-14
 
 ## [1.0.1] - 2026-03-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 50 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."


### PR DESCRIPTION
## Summary
- Drop x86_64-apple-darwin release target (ort-sys has no prebuilt binaries for Intel Mac)
- Make ort CUDA/TensorRT features conditional on non-macOS targets
- Bump to v1.0.4

## Test plan
- [ ] CI passes
- [ ] All 3 release binaries (linux x86_64, macOS arm64, windows x86_64) build successfully
