### PR TITLE
chore: release v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-03-13
+
+### Added
+- ASP.NET Web Forms support — 51st language. Parses C#/VB.NET in server script blocks and `<% %>` expressions (#584)
+- Makefile shell injection — extracts shell commands from recipe bodies via Bash grammar (#584)
+- Class NL enrichment — Class/Struct/Interface chunks include member method names in NL descriptions for better semantic search (#585)
+- `is_name_like_query()` — detects NL vs identifier queries, gates name_boost to prevent harmful re-ranking (#585)
+- `parent_type_name` column in chunks table — methods carry enclosing class/struct/impl name through to search results (#585)
+- Schema v11→v12 migration for `parent_type_name` (#585)
+
+### Changed
+- Test function demotion strengthened: `IMPORTANCE_TEST` 0.90→0.70, `IMPORTANCE_PRIVATE` 0.95→0.80 (#585)
+
+### Fixed
+- CUDA 13 compatibility via `--no-default-features` for ort build (#583)
+- sqlx slow statement threshold raised from 1s to 10s to reduce log noise (#583)
+- Flaky HNSW safety test — assertions now check memory safety, not approximate recall (#586)
+
 ## [1.0.4] - 2026-03-13
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Rules:
 
 ### Feature Ideas
 
-- Additional language support (see `src/language/` for current list — 50 languages supported)
+- Additional language support (see `src/language/` for current list — 51 languages supported)
 - Non-CUDA GPU support (ROCm for AMD, Metal for Apple Silicon)
 - VS Code extension
 - Performance improvements
@@ -122,7 +122,7 @@ src/
   language/     - Tree-sitter language support
     mod.rs      - Language enum, LanguageRegistry, LanguageDef, ChunkType
     rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, kotlin.rs, swift.rs, objc.rs, sql.rs, protobuf.rs, graphql.rs, php.rs, lua.rs, zig.rs, r.rs, yaml.rs, toml_lang.rs, elixir.rs, erlang.rs, gleam.rs, haskell.rs, julia.rs, ocaml.rs, css.rs, perl.rs, html.rs, json.rs, xml.rs, ini.rs, nix.rs, make.rs, latex.rs, solidity.rs, cuda.rs, glsl.rs, svelte.rs, razor.rs, vbnet.rs, markdown.rs
-  store/        - SQLite storage layer (Schema v11, WAL mode)
+  store/        - SQLite storage layer (Schema v12, WAL mode)
     mod.rs      - Store struct, open/init, FTS5, RRF fusion
     chunks.rs   - Chunk CRUD, embedding_batches() for streaming
     notes.rs    - Note CRUD, note_embeddings(), brute-force search

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 51 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,13 +2,7 @@
 
 ## Right Now
 
-**v1.0.4 released (2026-03-13).** Full v1.0.0 audit complete — 100 findings across 14 categories, 97 fixed, 2 documented, 1 existing (#389). Release binaries building successfully for 3 targets (Linux x86_64, macOS ARM64, Windows x86_64).
-
-Release workflow issues resolved across v1.0.1–v1.0.4:
-- ubuntu-22.04 → ubuntu-24.04 (glibc 2.38+ for ort prebuilt binaries)
-- macos-13 → macos-14 (macos-13 deprecated)
-- ort CUDA/TensorRT features made conditional on non-macOS targets
-- x86_64-apple-darwin dropped (ort-sys has no prebuilt binaries for Intel Mac)
+**v1.0.5 releasing (2026-03-13).** ASPX support (51 languages), search quality improvements (demotion, name_boost gating, parent_type_name, class NL), CUDA 13 fix, flaky HNSW test fix.
 
 ## Pending Changes
 
@@ -34,13 +28,13 @@ None.
 
 ## Architecture
 
-- Version: 1.0.4
+- Version: 1.0.5
 - MSRV: 1.93
-- Schema: v11
+- Schema: v12
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only (notes use brute-force SQLite search)
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
-- 50 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Haskell, OCaml, Julia, Gleam, CSS, Perl, HTML, JSON, XML, INI, Nix, Make, LaTeX, Solidity, CUDA, GLSL, Svelte, Razor, VB.NET, Vue, Markdown)
+- 51 languages (Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Haskell, OCaml, Julia, Gleam, CSS, Perl, HTML, JSON, XML, INI, Nix, Make, LaTeX, Solidity, CUDA, GLSL, Svelte, Razor, VB.NET, Vue, ASPX, Markdown)
 - 16 ChunkType variants (Function, Method, Struct, Class, Interface, Enum, Trait, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias)
 - Tests: 1534 pass, 0 failures
 - CLI-only (MCP server removed in PR #352)
@@ -50,5 +44,5 @@ None.
 - NVIDIA env: CUDA 13.1, Driver 582.16, libcuvs 26.02 (conda/rapidsai), cuDNN 9.19.0 (conda/conda-forge)
 - Reference: `aveva` → `samples/converted/aveva-docs/` (10,482 chunks, 76 files)
 - type_edges: 4567 edges
-- Eval: E5-base-v2 90.9% Recall@1, 0.951 NDCG@10, 0.941 MRR on 55-query hard eval
+- Eval: E5-base-v2 90.9% Recall@1, 0.936 MRR on 55-query hard eval (name_boost no longer harmful)
 - Release targets: Linux x86_64, macOS ARM64, Windows x86_64 (Intel Mac dropped — no ort prebuilt binaries)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code intelligence and RAG for AI agents. Semantic search, call graph analysis, impact tracing, type dependencies, and smart context assembly — all in single tool calls. Local ML embeddings, GPU-accelerated.
 
-**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval. 50 languages, GPU-accelerated.
+**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval. 51 languages, GPU-accelerated.
 
 [![Crates.io](https://img.shields.io/crates/v/cqs.svg)](https://crates.io/crates/cqs)
 [![CI](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml/badge.svg)](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml)
@@ -32,7 +32,7 @@ cargo install cqs
 
 **Upgrading?** Schema changes require rebuilding the index:
 ```bash
-cqs index --force  # Run after upgrading from older versions (current schema: v11)
+cqs index --force  # Run after upgrading from older versions (current schema: v12)
 ```
 
 ## Quick Start
@@ -420,6 +420,7 @@ Keep index fresh: run `cqs watch` in a background terminal, or `cqs index` after
 
 ## Supported Languages
 
+- ASP.NET Web Forms (ASPX/ASCX/ASMX — C#/VB.NET code-behind in server script blocks and `<% %>` expressions, delegates to C#/VB.NET grammars)
 - Bash (functions, command calls)
 - C (functions, structs, enums, macros)
 - C++ (classes, structs, namespaces, concepts, templates, out-of-class methods, preprocessor macros)
@@ -486,7 +487,7 @@ cqs index --dry-run    # Show what would be indexed
 
 **Parse → Embed → Index → Reason**
 
-1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 50 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
+1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 51 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
 2. **Describe** — Each code element gets a natural language description incorporating doc comments, parameter types, return types, and parent type context (e.g., methods include their struct/class name). This bridges the gap between how developers describe code and how it's written.
 3. **Embed** — E5-base-v2 generates 769-dimensional embeddings (768 semantic + 1 sentiment) locally. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval — outperforms code-specific models because NL descriptions play to general-purpose model strengths.
 4. **Index** — SQLite stores chunks, embeddings, call graph edges, and type dependency edges. HNSW provides fast approximate nearest-neighbor search. FTS5 enables keyword matching.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! - **Semantic search**: Uses E5-base-v2 embeddings (769-dim: 768 model + sentiment)
 //! - **Notes with sentiment**: Unified memory system for AI collaborators
-//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Gleam, Haskell, Julia, OCaml, CSS, Perl, HTML, JSON, XML, INI, Nix, Make, LaTeX, Solidity, CUDA, GLSL, Svelte, Razor, VB.NET, Vue, Markdown (50 languages)
+//! - **Multi-language**: Rust, Python, TypeScript, JavaScript, Go, C, C++, Java, C#, F#, PowerShell, Scala, Ruby, Bash, HCL, Kotlin, Swift, Objective-C, SQL, Protobuf, GraphQL, PHP, Lua, Zig, R, YAML, TOML, Elixir, Erlang, Gleam, Haskell, Julia, OCaml, CSS, Perl, HTML, JSON, XML, INI, Nix, Make, LaTeX, Solidity, CUDA, GLSL, Svelte, Razor, VB.NET, Vue, ASP.NET Web Forms, Markdown (51 languages)
 //! - **GPU acceleration**: CUDA/TensorRT with CPU fallback
 //! - **CLI tools**: Call graph, impact analysis, test mapping, dead code detection
 //! - **Document conversion**: PDF, HTML, CHM, Web Help → cleaned Markdown (optional `convert` feature)


### PR DESCRIPTION
## Summary

- Version bump 1.0.4 → 1.0.5
- Changelog for v1.0.5 (ASPX support, search quality, CUDA 13, flaky test fix)
- Docs updated: 50 → 51 languages, schema v11 → v12, ASPX in language list

## Test plan

- [x] All tests pass
- [x] Clippy clean
- [x] Docs reviewed for staleness

Generated with [Claude Code](https://claude.com/claude-code)
