### PR TITLE
chore: release v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6] - 2026-03-14
+
+### Added
+- NL description enrichment (SQ-2): struct/enum/class field names and directory-path context improve embedding discrimination in large corpora (+3.7pp R@1 on hard eval) (#588)
+- Holdout eval infrastructure: 143-query eval set with stress eval against real codebases (3970 chunks) (#588)
+- `rerank_with_passages` method on reranker for scoring against custom passage text (#588)
+
+### Fixed
+- Dead code warning in Make language definition (#588)
+
 ## [1.0.5] - 2026-03-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 51 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."


### PR DESCRIPTION
## Summary
- NL description enrichment (SQ-2): field names + directory-path context for better search in large corpora
- Holdout eval infrastructure (143 queries) + stress eval against real codebases
- `rerank_with_passages` method on reranker
- Dead code warning fix in Make language

## Test plan
- [x] All tests pass (1562 pass, 0 fail)
- [x] Clippy clean
- [x] CI green
