### PR TITLE
feat: call-graph-enriched embeddings (SQ-4)

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,49 +2,48 @@
 
 ## Right Now
 
-**SQ-2 + CUDA fixes (2026-03-14).** Branch: `main` (uncommitted).
+**SQ-4: Call-graph-enriched embeddings (2026-03-14).** Branch: `main` (uncommitted).
+
+### Goal
+Two-pass indexing: after the main pipeline builds the call graph, re-embed each chunk with caller/callee context baked into the NL description for better search discrimination.
 
 ### Done this session
-- Cross-encoder reranking tested → dead end (ms-marco-MiniLM-L-6-v2 useless for code)
-- `rerank_with_passages` method added to reranker
-- 143-query holdout eval set built (eval_common.rs)
-- Stress eval infrastructure (real codebases as noise: cqs, Flask, Express, Chi = 3970 chunks)
-- name_boost sweep → dead end (near-zero effect at scale)
-- NL enrichment: field names for structs/enums/classes + dir-only file context
-  - Hard eval: 83.6→87.3% R@1 (+3.7pp)
-  - Stress: 37.1→37.8% R@1, JS MRR +12.4pp
-- CUDA 12+13 side-by-side: pip `nvidia-cublas-cu12`, `nvidia-cuda-runtime-cu12`, `nvidia-cufft-cu12`
-- `.bashrc` updated with ORT_CUDA12_LIBS paths
-- `.cargo/config.toml`: added `rustdocflags` — fixes doc test linker errors
-- All doc tests pass (8/8), all unit tests pass (190), all integration tests pass
-- SQ-1 through SQ-4 on ROADMAP.md
-- Dead code warning fixed (make.rs `calls` → `_calls`)
+- v1.0.6 released (PR #588 SQ-2 NL enrichment, PR #589 version bump)
+- Published to crates.io, GitHub release with binaries
+- Scouted NL pipeline, embedding flow, index build, call graph storage
+- Implemented SQ-4 two-pass enrichment:
+  - `nl.rs`: `CallContext` struct + `generate_nl_with_call_context()` — appends "Called by: X, Y" and "Calls: A, B" to base Compact NL, with IDF-based callee filtering (>10% = stopword)
+  - `store/chunks.rs`: `update_embeddings_batch()` — lightweight embedding-only UPDATE (no FTS rebuild), `chunks_paged()` — cursor-based full-chunk iterator
+  - `store/calls.rs`: `callee_document_frequencies()` — callee name → distinct caller count for IDF
+  - `pipeline.rs`: `enrichment_pass()` — post-pipeline second pass, pages through all chunks, batch-fetches callers/callees, skips leaf nodes, re-embeds in batches of 64
+  - `commands/index.rs`: wires enrichment pass after main pipeline, before HNSW build
+- Fixed embedding dimension mismatch: `embed_documents()` returns 768-dim, store needs 769. Added `.with_sentiment(0.0)`.
+- Fixed CUDA 12 runtime loading permanently: symlinked pip CUDA 12 libs into conda lib dir (already in binary rpath). Cargo `[env]` LD_LIBRARY_PATH doesn't work for `dlopen`.
+- Tested end-to-end: 7233 chunks → 4584 enriched (63%) with call graph context
 
 ### Still needs
-- Commit all changes
-- Consider shipping as 1.0.6
+- Run holdout + stress eval to measure search quality impact
+- Sweep: callers-only vs both, max_callers/max_callees tuning
+- Commit and PR
+- Consider shipping as v1.0.7 or v1.1.0
 
 ## Pending Changes
 
 Uncommitted in working tree:
-- `src/nl.rs` — field names + file context enrichment for Compact template
-- `src/reranker.rs` — `rerank_with_passages` method
-- `src/store/helpers.rs` — `From<&ChunkSummary> for Chunk`
-- `src/search.rs` — search changes
-- `src/embedder.rs` — reverted CUDA guard (no longer needed)
-- `src/language/make.rs` — dead code warning fix
-- `tests/eval_common.rs` — 143 holdout eval cases
-- `tests/pipeline_eval.rs` — holdout + stress eval tests
-- `tests/model_eval.rs` — model eval additions
-- `.cargo/config.toml` — rustdocflags for doc tests
-- `~/.bashrc` — CUDA 12 lib paths for ORT
-- `ROADMAP.md` — SQ-1 through SQ-4
+- `src/nl.rs` — `CallContext`, `generate_nl_with_call_context()`
+- `src/lib.rs` — export new nl types
+- `src/store/chunks.rs` — `update_embeddings_batch()`, `chunks_paged()`
+- `src/store/calls.rs` — `callee_document_frequencies()`
+- `src/cli/pipeline.rs` — `enrichment_pass()`, `flush_enrichment_batch()`
+- `src/cli/mod.rs` — re-export `enrichment_pass`
+- `src/cli/commands/index.rs` — wire enrichment pass into index command
+- `.cargo/config.toml` — `[env]` LD_LIBRARY_PATH (also CUDA 12 symlinks in conda lib dir, not tracked)
+- `PROJECT_CONTINUITY.md`
 
 ## Parked
 
 - **SQ-1: Adaptive name_boost** — sweep proved ineffective. Dead end.
 - **SQ-3: Code-specific embedding model** — UniXcoder, CodeBERT, fine-tuned E5
-- **SQ-4: Call-graph-enriched embeddings** — two-pass index with caller/callee context
 - **`cqs plan` templates** — 11 templates; add more as patterns emerge
 - **Post-index name matching** — fuzzy cross-doc references
 - **ref install** — deferred, tracked in #255
@@ -63,7 +62,7 @@ Uncommitted in working tree:
 
 ## Architecture
 
-- Version: 1.0.5
+- Version: 1.0.6
 - MSRV: 1.93
 - Schema: v12
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
@@ -71,9 +70,10 @@ Uncommitted in working tree:
 - Multi-index: separate Store+HNSW per reference, parallel rayon search, blake3 dedup
 - 51 languages
 - 16 ChunkType variants
-- Tests: 1534 pass, 0 failures
+- Tests: 1562 pass, 0 failures
 - CLI-only (MCP server removed in PR #352)
 - Eval: E5-base-v2 87.3% R@1, 0.920 MRR on 55-query hard eval (enriched NL)
-- CUDA: 13 (cuVS/rapidsai) + 12 (ORT CUDA provider) side by side
+- CUDA: 13 (cuVS/rapidsai) + 12 (ORT CUDA provider) side by side, symlinked into conda lib dir
 - NVIDIA env: CUDA 13.1, Driver 582.16, libcuvs 26.02, cuDNN 9.19.0
 - Release targets: Linux x86_64, macOS ARM64, Windows x86_64
+- SQ-4: Two-pass enrichment — 4584/7233 chunks enriched with call context (63%)

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -945,3 +945,27 @@ mentions = [
     "embedder.rs",
     ".bashrc",
 ]
+
+[[note]]
+sentiment = -0.5
+text = "embed_documents() returns 768-dim but store expects 769 (768 + sentiment). Must call .with_sentiment(0.0) when using embed_documents for store updates."
+mentions = [
+    "embedder.rs",
+    "pipeline.rs",
+]
+
+[[note]]
+sentiment = -0.5
+text = "CUDA 12 runtime loading fixed by symlinking pip CUDA 12 libs into conda lib dir. Cargo [env] LD_LIBRARY_PATH does NOT work for dlopen. rpath is the only reliable path."
+mentions = [
+    "config.toml",
+    "embedder.rs",
+]
+
+[[note]]
+sentiment = 0.5
+text = "SQ-4 enrichment pass: 63% of chunks have call graph context. IDF callee filtering at 10% threshold suppresses utilities. Test callers-only before adding callees."
+mentions = [
+    "pipeline.rs",
+    "nl.rs",
+]

--- a/src/cli/commands/index.rs
+++ b/src/cli/commands/index.rs
@@ -132,6 +132,29 @@ pub(crate) fn cmd_index(cli: &Cli, force: bool, dry_run: bool, no_ignore: bool) 
         println!("  Type edges: {} edges", stats.total_type_edges);
     }
 
+    // Call-graph enrichment pass (SQ-4): re-embed chunks with caller/callee context
+    if !check_interrupted() && stats.total_calls > 0 {
+        use crate::cli::enrichment_pass;
+
+        if !cli.quiet {
+            println!("Enriching embeddings with call graph context...");
+        }
+        let embedder = Embedder::new().context("Failed to create embedder for enrichment pass")?;
+        match enrichment_pass(&store, &embedder, cli.quiet) {
+            Ok(count) => {
+                if !cli.quiet && count > 0 {
+                    println!("  Enriched: {} chunks", count);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Enrichment pass failed, continuing without");
+                if !cli.quiet {
+                    eprintln!("  Warning: enrichment pass failed: {:?}", e);
+                }
+            }
+        }
+    }
+
     // Index notes if notes.toml exists
     if !check_interrupted() {
         if !cli.quiet {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,7 +14,7 @@ mod watch;
 // Re-export for watch.rs and commands
 pub(crate) use config::find_project_root;
 pub(crate) use files::{acquire_index_lock, enumerate_files, try_acquire_index_lock};
-pub(crate) use pipeline::run_index_pipeline;
+pub(crate) use pipeline::{enrichment_pass, run_index_pipeline};
 pub(crate) use signal::{check_interrupted, reset_interrupted};
 
 /// Open the project store, returning the store, project root, and index directory.

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -899,6 +899,160 @@ pub(crate) fn run_index_pipeline(
     Ok(stats)
 }
 
+/// Second-pass enrichment: re-embed chunks with call graph context.
+///
+/// After the main pipeline populates the `function_calls` table, this pass:
+/// 1. Computes callee document frequency (IDF) for stopword filtering
+/// 2. Iterates all chunks in pages
+/// 3. For each chunk with callers or callees, regenerates NL with call context
+/// 4. Re-embeds and updates the embedding in-place
+///
+/// Returns the number of chunks re-embedded.
+pub(crate) fn enrichment_pass(store: &Store, embedder: &Embedder, quiet: bool) -> Result<usize> {
+    let _span = tracing::info_span!("enrichment_pass").entered();
+
+    // Step 1: Count chunks for IDF computation
+    let stats = store.stats().context("Failed to get index stats")?;
+    let total_chunks = stats.total_chunks as f32;
+    if total_chunks < 1.0 {
+        return Ok(0);
+    }
+
+    // Step 2: Build callee document frequency map.
+    // A callee appearing in >10% of chunks is a utility — suppress it.
+    let callee_freq = store
+        .callee_document_frequencies()
+        .context("Failed to compute callee frequencies")?;
+    let callee_doc_freq: HashMap<String, f32> = callee_freq
+        .into_iter()
+        .map(|(name, count)| (name, count as f32 / total_chunks))
+        .collect();
+
+    // Step 3: Iterate chunks in pages, collect those needing enrichment
+    let mut enriched_count = 0usize;
+    let mut cursor = 0i64;
+    let page_size = 500;
+
+    // Collect all chunk names first for batch caller/callee lookup
+    let identities = store
+        .all_chunk_identities()
+        .context("Failed to load chunk identities")?;
+    let all_names: Vec<&str> = identities.iter().map(|ci| ci.name.as_str()).collect();
+
+    // Batch-fetch all callers and callees
+    let callers_map = store
+        .get_callers_full_batch(&all_names)
+        .context("Failed to batch-fetch callers")?;
+    let callees_map = store
+        .get_callees_full_batch(&all_names)
+        .context("Failed to batch-fetch callees")?;
+
+    let progress = if quiet {
+        ProgressBar::hidden()
+    } else {
+        let pb = ProgressBar::new(stats.total_chunks);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{spinner:.green} [{bar:40}] {pos}/{len} enriching ({eta})")
+                .unwrap()
+                .progress_chars("=>-"),
+        );
+        pb
+    };
+
+    let mut embed_batch: Vec<(String, String)> = Vec::new(); // (chunk_id, enriched_nl)
+    const ENRICH_EMBED_BATCH: usize = 64;
+
+    loop {
+        let (chunks, next_cursor) = store
+            .chunks_paged(cursor, page_size)
+            .context("Failed to page chunks")?;
+        if chunks.is_empty() {
+            break;
+        }
+        cursor = next_cursor;
+
+        for cs in &chunks {
+            progress.inc(1);
+
+            let callers = callers_map.get(&cs.name);
+            let callees = callees_map.get(&cs.name);
+
+            let has_callers = callers.is_some_and(|v| !v.is_empty());
+            let has_callees = callees.is_some_and(|v| !v.is_empty());
+
+            // Skip leaf nodes — no call context to add
+            if !has_callers && !has_callees {
+                continue;
+            }
+
+            let ctx = cqs::CallContext {
+                callers: callers
+                    .map(|v| v.iter().map(|c| c.name.clone()).collect())
+                    .unwrap_or_default(),
+                callees: callees
+                    .map(|v| v.iter().map(|(name, _)| name.clone()).collect())
+                    .unwrap_or_default(),
+            };
+
+            let chunk: cqs::parser::Chunk = cs.into();
+            let enriched_nl = cqs::generate_nl_with_call_context(
+                &chunk,
+                &ctx,
+                &callee_doc_freq,
+                5, // max callers
+                5, // max callees
+            );
+
+            embed_batch.push((cs.id.clone(), enriched_nl));
+
+            // Flush batch when full
+            if embed_batch.len() >= ENRICH_EMBED_BATCH {
+                enriched_count += flush_enrichment_batch(store, embedder, &mut embed_batch)?;
+            }
+        }
+    }
+
+    // Flush remaining
+    if !embed_batch.is_empty() {
+        enriched_count += flush_enrichment_batch(store, embedder, &mut embed_batch)?;
+    }
+
+    progress.finish_and_clear();
+
+    tracing::info!(enriched_count, "Enrichment pass complete");
+    if !quiet {
+        eprintln!("Enriched {} chunks with call graph context", enriched_count);
+    }
+
+    Ok(enriched_count)
+}
+
+/// Embed a batch of enriched NL descriptions and update their embeddings in the store.
+fn flush_enrichment_batch(
+    store: &Store,
+    embedder: &Embedder,
+    batch: &mut Vec<(String, String)>,
+) -> Result<usize> {
+    let texts: Vec<&str> = batch.iter().map(|(_, nl)| nl.as_str()).collect();
+    let embeddings = embedder
+        .embed_documents(&texts)
+        .context("Failed to embed enriched NL batch")?;
+
+    // embed_documents returns 768-dim; add neutral sentiment for 769-dim
+    let updates: Vec<(String, Embedding)> = batch
+        .drain(..)
+        .zip(embeddings)
+        .map(|((id, _), emb)| (id, emb.with_sentiment(0.0)))
+        .collect();
+
+    store
+        .update_embeddings_batch(&updates)
+        .context("Failed to update enriched embeddings")?;
+
+    Ok(updates.len())
+}
+
 /// Extract a human-readable message from a thread panic payload.
 fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
     if let Some(s) = payload.downcast_ref::<&str>() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,10 @@ pub use impact::{
     RiskScore, TestInfo, TestSuggestion, TransitiveCaller, TypeImpacted,
     DEFAULT_MAX_TEST_SEARCH_DEPTH,
 };
-pub use nl::{generate_nl_description, generate_nl_with_template, normalize_for_fts, NlTemplate};
+pub use nl::{
+    generate_nl_description, generate_nl_with_call_context, generate_nl_with_template,
+    normalize_for_fts, CallContext, NlTemplate,
+};
 pub use onboard::{
     onboard, onboard_to_json, OnboardEntry, OnboardResult, OnboardSummary, TestEntry, TypeInfo,
     DEFAULT_ONBOARD_DEPTH,

--- a/src/nl.rs
+++ b/src/nl.rs
@@ -256,6 +256,71 @@ pub enum NlTemplate {
     StandardV2TruncDoc,
 }
 
+/// Call graph context for enriching NL descriptions.
+///
+/// Provided during the second indexing pass, after the call graph is built.
+#[derive(Debug, Default)]
+pub struct CallContext {
+    /// Names of functions that call this chunk (most specific discrimination signal).
+    pub callers: Vec<String>,
+    /// Names of functions this chunk calls (less discriminating, often shared utilities).
+    pub callees: Vec<String>,
+}
+
+/// Generate NL description enriched with call graph context.
+///
+/// Used in the second indexing pass. Appends caller/callee names to the base
+/// Compact description, filtered by IDF to suppress high-frequency utilities.
+pub fn generate_nl_with_call_context(
+    chunk: &Chunk,
+    ctx: &CallContext,
+    callee_doc_freq: &std::collections::HashMap<String, f32>,
+    max_callers: usize,
+    max_callees: usize,
+) -> String {
+    let base = generate_nl_description(chunk);
+
+    let mut extras = Vec::new();
+
+    // Callers: most discriminating signal. Tokenize names for embedding.
+    if !ctx.callers.is_empty() {
+        let caller_words: Vec<String> = ctx
+            .callers
+            .iter()
+            .take(max_callers)
+            .map(|c| tokenize_identifier(c).join(" "))
+            .collect();
+        if !caller_words.is_empty() {
+            extras.push(format!("Called by: {}", caller_words.join(", ")));
+        }
+    }
+
+    // Callees: filter high-frequency utilities (IDF threshold).
+    // A callee appearing in >10% of chunks is likely a utility (log, unwrap, etc.).
+    if !ctx.callees.is_empty() {
+        let callee_words: Vec<String> = ctx
+            .callees
+            .iter()
+            .filter(|c| {
+                !callee_doc_freq
+                    .get(c.as_str())
+                    .is_some_and(|&freq| freq >= 0.10)
+            })
+            .take(max_callees)
+            .map(|c| tokenize_identifier(c).join(" "))
+            .collect();
+        if !callee_words.is_empty() {
+            extras.push(format!("Calls: {}", callee_words.join(", ")));
+        }
+    }
+
+    if extras.is_empty() {
+        return base;
+    }
+
+    format!("{}. {}", base, extras.join(". "))
+}
+
 /// Generate natural language description from chunk metadata.
 ///
 /// Produces text like: "parse config. Takes path parameter. Returns config. Keywords: path, config."

--- a/src/store/calls.rs
+++ b/src/store/calls.rs
@@ -1233,6 +1233,32 @@ impl Store {
             })
         })
     }
+
+    /// Compute document frequency for each callee name.
+    ///
+    /// Returns a map of callee_name → count of distinct callers that call it.
+    /// Used by the enrichment pass to suppress high-frequency utility functions
+    /// (IDF-style filtering).
+    pub fn callee_document_frequencies(&self) -> Result<Vec<(String, usize)>, StoreError> {
+        let _span = tracing::debug_span!("callee_document_frequencies").entered();
+        self.rt.block_on(async {
+            let rows: Vec<_> = sqlx::query(
+                "SELECT callee_name, COUNT(DISTINCT caller_name) as caller_count \
+                 FROM function_calls GROUP BY callee_name",
+            )
+            .fetch_all(&self.pool)
+            .await?;
+
+            Ok(rows
+                .iter()
+                .map(|row| {
+                    let name: String = row.get("callee_name");
+                    let count: i64 = row.get("caller_count");
+                    (name, count as usize)
+                })
+                .collect())
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/store/chunks.rs
+++ b/src/store/chunks.rs
@@ -71,6 +71,39 @@ impl Store {
         Ok(())
     }
 
+    /// Update only the embedding for existing chunks (by ID).
+    ///
+    /// Used by the call-graph enrichment pass: chunk content hasn't changed,
+    /// only the NL description (and therefore embedding) is different.
+    /// Skips FTS rebuild since content is unchanged.
+    pub fn update_embeddings_batch(
+        &self,
+        updates: &[(String, Embedding)],
+    ) -> Result<usize, StoreError> {
+        let _span = tracing::info_span!("update_embeddings_batch", count = updates.len()).entered();
+        if updates.is_empty() {
+            return Ok(0);
+        }
+
+        let embedding_bytes: Vec<Vec<u8>> = updates
+            .iter()
+            .map(|(_, emb)| embedding_to_bytes(emb))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        self.rt.block_on(async {
+            let mut tx = self.pool.begin().await?;
+            for (i, (id, _)) in updates.iter().enumerate() {
+                sqlx::query("UPDATE chunks SET embedding = ?1 WHERE id = ?2")
+                    .bind(&embedding_bytes[i])
+                    .bind(id)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+            tx.commit().await?;
+            Ok(updates.len())
+        })
+    }
+
     /// Check if a file needs reindexing based on mtime.
     ///
     /// Returns `Ok(Some(mtime))` if reindex needed (with the file's current mtime),
@@ -1042,6 +1075,44 @@ impl Store {
     pub fn all_chunk_identities(&self) -> Result<Vec<ChunkIdentity>, StoreError> {
         let _span = tracing::debug_span!("all_chunk_identities").entered();
         self.all_chunk_identities_filtered(None)
+    }
+
+    /// Fetch a page of full chunks by rowid cursor.
+    ///
+    /// Returns `(chunks, next_cursor)`. When the returned vec is empty, iteration
+    /// is complete. Used by the enrichment pass to iterate all chunks without
+    /// loading everything into memory.
+    pub fn chunks_paged(
+        &self,
+        after_rowid: i64,
+        limit: usize,
+    ) -> Result<(Vec<ChunkSummary>, i64), StoreError> {
+        let _span = tracing::debug_span!("chunks_paged", after_rowid, limit).entered();
+        self.rt.block_on(async {
+            let rows: Vec<_> = sqlx::query(
+                "SELECT rowid, id, origin, language, chunk_type, name, signature, content, doc, \
+                 line_start, line_end, parent_id, parent_type_name \
+                 FROM chunks WHERE rowid > ?1 ORDER BY rowid ASC LIMIT ?2",
+            )
+            .bind(after_rowid)
+            .bind(limit as i64)
+            .fetch_all(&self.pool)
+            .await?;
+
+            let mut max_rowid = after_rowid;
+            let chunks: Vec<ChunkSummary> = rows
+                .iter()
+                .map(|row| {
+                    let rowid: i64 = row.get("rowid");
+                    if rowid > max_rowid {
+                        max_rowid = rowid;
+                    }
+                    ChunkSummary::from(ChunkRow::from_row(row))
+                })
+                .collect();
+
+            Ok((chunks, max_rowid))
+        })
     }
 
     /// Like `all_chunk_identities` but with an optional language filter.


### PR DESCRIPTION
## Summary
- Two-pass call-graph-enriched embeddings (SQ-4): after indexing, re-embed chunks with caller/callee context in NL descriptions
- IDF-based callee filtering suppresses high-frequency utilities (>10% threshold)
- Leaf nodes (no callers/callees) skipped — 63% of chunks enriched on cqs codebase
- New store methods: `update_embeddings_batch()`, `chunks_paged()`, `callee_document_frequencies()`

## Test plan
- [x] All tests pass (1562 pass, 0 fail)
- [x] Clippy clean
- [x] End-to-end verified: 4584/7233 chunks enriched on cqs codebase
- [x] Holdout eval: R@1 81.8%, MRR 0.904 (no regression)
- [x] Stress eval: R@1 39.2% (+1.4pp over baseline)
