### PR TITLE
chore: release v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7] - 2026-03-14
+
+### Added
+- Call-graph-enriched embeddings (SQ-4): two-pass indexing re-embeds chunks with caller/callee context after call graph is built (#590)
+- IDF-based callee filtering suppresses high-frequency utility functions (>10% threshold) (#590)
+- `update_embeddings_batch()` for lightweight embedding-only updates (#590)
+- `chunks_paged()` cursor-based chunk iterator (#590)
+- `callee_document_frequencies()` for IDF computation (#590)
+
 ## [1.0.6] - 2026-03-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 51 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."


### PR DESCRIPTION
## Summary
- Version bump to 1.0.7
- Changelog for SQ-4 call-graph-enriched embeddings

## Test plan
- [x] `cargo check` passes
