### PR TITLE
chore: release v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.9] - 2026-03-15
+
+### Changed
+- NL descriptions now include filename stem for module-level discrimination (SQ-5). Generic stems (mod, index, lib, utils, helpers) are filtered (#594)
+
 ## [1.0.8] - 2026-03-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "1.0.8"
+version = "1.0.9"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 51 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."


### PR DESCRIPTION
## Summary
- Version bump to 1.0.9
- Changelog for SQ-5 module-level context

## Test plan
- [x] `cargo check` passes
