### PR TITLE
chore: release v1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.10] - 2026-03-15
+
+### Fixed
+- **HNSW ID desync** on zero-vector skip — used `id_map.len()` instead of loop index (RT-DATA-1, high) (#596)
+- **CQS_PDF_SCRIPT** now rejects non-.py extensions to prevent arbitrary script execution (RT-INJ-1) (#596)
+- **Path traversal** in `read_context_lines` — validates paths containing `..` against project root (RT-FS-1/2) (#596)
+- **Chat input** length capped at 1MB to match batch mode (RT-RES-1) (#596)
+
 ## [1.0.9] - 2026-03-15
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "1.0.9"
+version = "1.0.10"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 51 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."


### PR DESCRIPTION
## Summary
- Version bump to 1.0.10
- Changelog for red team security fixes

## Test plan
- [x] `cargo check` passes
