### PR TITLE
fix: RT-DATA-2/4/6 data integrity + #555 where_to_add coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ proptest-regressions/
 .env.local
 .env.*.local
 credentials.toml
+*.toml.lock
 .cqs/
 .cq/
 .cqs.toml

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -43,6 +43,7 @@ None (notes.toml edited but not git-tracked).
 
 ### Feature
 - #255: Pre-built reference packages
+- #555: EX-4 where_to_add catch-all for 44 languages
 
 ### Audit
 - #389: CAGRA CPU-side dataset retention

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,17 @@
 # Roadmap
 
-## Current: v1.0.0
+## Current: v1.0.10
 
-First stable release. All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 50 languages. Two full audits complete (v0.12.3 + v0.19.2). Recursive multi-grammar injection framework.
+First stable release. All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 51 languages. Two full audits complete (v0.12.3 + v0.19.2). Recursive multi-grammar injection framework.
+
+### 1.0.x Highlights
+
+- v1.0.5: ASP.NET Web Forms (51st language), Make → Bash injection, schema v12 (`parent_type_name`)
+- v1.0.6: SQ-2 richer NL descriptions (+3.7pp R@1 on hard eval)
+- v1.0.7: SQ-4 call-graph-enriched embeddings (two-pass, IDF callee filtering)
+- v1.0.8: 14-category audit — 14 findings fixed
+- v1.0.9: SQ-5 module-level context (filename stems with generic filter)
+- v1.0.10: Red team audit — 7 findings fixed (HNSW ID desync, PDF script injection, path traversal)
 
 ### Next — Commands
 
@@ -69,6 +78,8 @@ Injection framework shipped in v0.27.0 (PRs #540, #544). `InjectionRule` on `Lan
 - [x] LaTeX → code listings — `minted_environment` + `listing_environment`. Language detection from `\begin{minted}{python}` and `[language=Rust]` options.
 - [x] Nix → Bash — `indented_string_expression` in shell contexts (buildPhase, installPhase, shellHook, etc.). `detect_nix_shell_context` checks parent binding name.
 - [x] HCL → Bash — `heredoc_template` with shell identifiers (EOT, BASH, SHELL, etc.). `detect_heredoc_language` checks heredoc identifier.
+- [x] Make → Bash — `recipe/shell_text` injection. Extracts shell commands from recipe bodies.
+- [x] Razor → JS/CSS — `_inner` content mode for grammars without named content children. `detect_razor_element_language` for script/style elements.
 
 **Next — New grammars required:**
 - [x] Vue (.vue) → JS/TS, CSS, HTML — `tree-sitter-vue-next`. Identical injection pattern to HTML/Svelte. Post-processing: headings, landmarks, setup script detection.
@@ -83,7 +94,6 @@ Injection framework shipped in v0.27.0 (PRs #540, #544). `InjectionRule` on `Lan
 - [ ] EEx/HEEx (.eex, .heex) → Elixir in HTML — needs grammar
 - [ ] SQL in string literals (Rust, Python, Go, Java) — fragile detection
 - [ ] GraphQL in tagged templates (JS/TS) — fragile detection
-- [ ] Shell in Makefile recipes — both grammars compatible
 - [ ] CSS-in-JS (styled-components, emotion) — template literal detection
 
 ### Next — Search Quality (large corpus)
@@ -94,7 +104,7 @@ Stress eval against real codebases (cqs 2956 chunks, Flask, Express, Chi) showed
 - [x] SQ-2: Richer NL descriptions — field names, dir-only file context. +3.7pp R@1 on hard eval (v1.0.6).
 - [ ] SQ-3: Code-specific embedding model — evaluate UniXcoder, CodeBERT, or fine-tuned E5 as replacement for general-purpose E5-base-v2.
 - [x] SQ-4: Call-graph-enriched embeddings — two-pass index with IDF callee filtering. 63% of chunks enriched (v1.0.7).
-- [x] SQ-5: Module-level context in NL — tested: filename stems regress holdout R@1 by ~3pp (generic filenames add noise). Dead end with current approach. Would need smarter filtering (skip generic stems like sample/mod/index/lib).
+- [x] SQ-5: Module-level context in NL — filename stems with generic filter (11 stems: mod, index, lib, main, utils, helpers, common, types, config, constants, init). Regresses fixture eval ~3pp but improves real queries — shipped in v1.0.9.
 - [ ] SQ-6: LLM-generated function summaries — one-sentence purpose summary per function via small LLM at index time. Cached, regenerated on content change. Breaks local-only constraint; high accuracy.
 - [ ] SQ-7: Fine-tune E5-base-v2 with LoRA on code search pairs.
   - **Hardware:** A6000 (48GB VRAM), can fine-tune in hours
@@ -112,16 +122,32 @@ Stress eval against real codebases (cqs 2956 chunks, Flask, Express, Chi) showed
 - ~~**Pattern mining**~~ — closed: manual notes + `cqs suggest` cover practical needs. Automated AST pattern recognition is research-grade effort for uncertain payoff.
 - **Post-index name matching** — fuzzy cross-doc references
 
+### Red Team — Accepted/Deferred
+
+Findings from v1.0.10 red team audit. Accepted as trade-offs — each needs upstream API changes or schema work to fix.
+
+- RT-DATA-2: Enrichment no idempotency marker (medium — needs schema change)
+- RT-DATA-3: HNSW orphan accumulation in watch mode (medium — no deletion API)
+- RT-DATA-5: Batch OnceLock stale cache (medium — by design, restart to refresh)
+- RT-DATA-6: SQLite/HNSW crash desync (medium — needs generation counter)
+- RT-DATA-4: Notes file lock vs rename race (low)
+
 ### Open Issues
 
-- #389: CAGRA CPU-side dataset retention (~146MB at 50k chunks) — cuVS `search()` consumes the index, so `dataset` is needed for rebuild. Blocked on upstream API change.
-- #255: Pre-built reference packages
+**External/Waiting:**
 - #106: ort stable (currently 2.0.0-rc.12)
 - #63: paste dep unmaintained (RUSTSEC-2024-0436) — transitive via `tokenizers`, waiting on HuggingFace to switch to `pastey`
 
+**Feature:**
+- #255: Pre-built reference packages
+- #555: EX-4 `where_to_add` catch-all for 44 languages (P4, extensibility)
+
+**Infrastructure:**
+- #389: CAGRA CPU-side dataset retention (~146MB at 50k chunks) — cuVS `search()` consumes the index, so `dataset` is needed for rebuild. Blocked on upstream API change.
+
 ## 1.0 Release Criteria
 
-- [x] Schema stable for 1+ week of daily use (v11 since 2026-02-15)
+- [x] Schema stable for 1+ week of daily use (v12 since 2026-03-13)
 - [x] Used on 2+ different codebases without issues (cqs, aveva, rust)
 - [x] No known correctness bugs
 

--- a/src/cli/commands/gc.rs
+++ b/src/cli/commands/gc.rs
@@ -62,6 +62,7 @@ pub(crate) fn cmd_gc(json: bool) -> Result<()> {
     // concurrent searches fall back to brute-force during the rebuild window
     // rather than returning orphan IDs from the old index (RT-DATA-2).
     let hnsw_vectors = if pruned_chunks > 0 {
+        store.set_hnsw_dirty(true).ok(); // RT-DATA-6: mark before rebuild
         let hnsw_path = cqs_dir.join("index.hnsw.graph");
         if hnsw_path.exists() {
             for file_name in cqs::hnsw::HNSW_ALL_EXTENSIONS
@@ -81,7 +82,11 @@ pub(crate) fn cmd_gc(json: bool) -> Result<()> {
             }
             tracing::debug!("Deleted stale HNSW before rebuild");
         }
-        build_hnsw_index(&store, &cqs_dir)?
+        let result = build_hnsw_index(&store, &cqs_dir)?;
+        if result.is_some() {
+            store.set_hnsw_dirty(false).ok(); // RT-DATA-6
+        }
+        result
     } else {
         None
     };

--- a/src/cli/commands/index.rs
+++ b/src/cli/commands/index.rs
@@ -86,6 +86,11 @@ pub(crate) fn cmd_index(cli: &Cli, force: bool, dry_run: bool, no_ignore: bool) 
         println!("Indexing {} files (pipelined)...", files.len());
     }
 
+    // Mark HNSW as dirty before writing chunks — if we crash between SQLite
+    // commit and HNSW save, the dirty flag tells the next load to fall back
+    // to brute-force search until a full rebuild. (RT-DATA-6)
+    store.set_hnsw_dirty(true).ok();
+
     // Run the 3-stage pipeline: parse → embed → write
     // Pipeline shares the same Store via Arc (no duplicate DB connections)
     let stats = run_index_pipeline(&root, files.clone(), Arc::clone(&store), force, cli.quiet)?;
@@ -185,6 +190,8 @@ pub(crate) fn cmd_index(cli: &Cli, force: bool, dry_run: bool, no_ignore: bool) 
         }
 
         if let Some(total) = build_hnsw_index(&store, &cqs_dir)? {
+            // HNSW saved successfully — clear dirty flag (RT-DATA-6)
+            store.set_hnsw_dirty(false).ok();
             if !cli.quiet {
                 println!("  HNSW index: {} vectors", total);
             }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -78,6 +78,14 @@ pub(crate) fn build_vector_index_with_config(
             tracing::debug!("GPU not available, using HNSW");
         }
     }
+    // Check for crash between SQLite commit and HNSW save (RT-DATA-6)
+    if store.is_hnsw_dirty().unwrap_or(false) {
+        tracing::warn!(
+            "HNSW index may be stale (interrupted write detected). \
+             Falling back to brute-force search. Run 'cqs index' to rebuild."
+        );
+        return Ok(None);
+    }
     Ok(cqs::HnswIndex::try_load_with_ef(cqs_dir, ef_search))
 }
 

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -966,8 +966,10 @@ pub(crate) fn enrichment_pass(store: &Store, embedder: &Embedder, quiet: bool) -
         pb
     };
 
-    let mut embed_batch: Vec<(String, String)> = Vec::new(); // (chunk_id, enriched_nl)
+    // (chunk_id, enriched_nl, enrichment_hash)
+    let mut embed_batch: Vec<(String, String, String)> = Vec::new();
     const ENRICH_EMBED_BATCH: usize = 64;
+    let mut skipped_count = 0usize;
 
     // Wrap loop in closure so progress bar is always cleaned up on error
     let result: Result<usize> = (|| {
@@ -979,6 +981,12 @@ pub(crate) fn enrichment_pass(store: &Store, embedder: &Embedder, quiet: bool) -
                 break;
             }
             cursor = next_cursor;
+
+            // Pre-fetch enrichment hashes for this page (RT-DATA-2)
+            let page_ids: Vec<&str> = chunks.iter().map(|c| c.id.as_str()).collect();
+            let stored_hashes = store
+                .get_enrichment_hashes_batch(&page_ids)
+                .context("Failed to fetch enrichment hashes")?;
 
             for cs in &chunks {
                 progress.inc(1);
@@ -1010,6 +1018,19 @@ pub(crate) fn enrichment_pass(store: &Store, embedder: &Embedder, quiet: bool) -
                         .unwrap_or_default(),
                 };
 
+                // Compute enrichment hash from post-filtered call context (RT-DATA-2).
+                // This hash captures exactly what goes into generate_nl_with_call_context,
+                // so if the call graph hasn't changed, we skip re-enrichment.
+                let enrichment_hash = compute_enrichment_hash(&ctx, &callee_doc_freq);
+
+                // Skip if already enriched with the same call context
+                if let Some(stored) = stored_hashes.get(&cs.id) {
+                    if *stored == enrichment_hash {
+                        skipped_count += 1;
+                        continue;
+                    }
+                }
+
                 let chunk: cqs::parser::Chunk = cs.into();
                 let enriched_nl = cqs::generate_nl_with_call_context(
                     &chunk,
@@ -1019,7 +1040,7 @@ pub(crate) fn enrichment_pass(store: &Store, embedder: &Embedder, quiet: bool) -
                     5, // max callees
                 );
 
-                embed_batch.push((cs.id.clone(), enriched_nl));
+                embed_batch.push((cs.id.clone(), enriched_nl, enrichment_hash));
 
                 // Flush batch when full
                 if embed_batch.len() >= ENRICH_EMBED_BATCH {
@@ -1040,21 +1061,63 @@ pub(crate) fn enrichment_pass(store: &Store, embedder: &Embedder, quiet: bool) -
 
     let enriched_count = result?;
 
-    tracing::info!(enriched_count, "Enrichment pass complete");
+    tracing::info!(enriched_count, skipped_count, "Enrichment pass complete");
     if !quiet {
-        eprintln!("Enriched {} chunks with call graph context", enriched_count);
+        if skipped_count > 0 {
+            eprintln!(
+                "Enriched {} chunks with call graph context ({} already up-to-date)",
+                enriched_count, skipped_count
+            );
+        } else {
+            eprintln!("Enriched {} chunks with call graph context", enriched_count);
+        }
     }
 
     Ok(enriched_count)
+}
+
+/// Compute a hash of the call context that will be used for enrichment.
+///
+/// The hash captures the post-filtered caller/callee names — the same inputs
+/// that `generate_nl_with_call_context` uses. If the call graph hasn't changed,
+/// the hash matches and we skip re-enrichment. (RT-DATA-2)
+fn compute_enrichment_hash(
+    ctx: &cqs::CallContext,
+    callee_doc_freq: &HashMap<String, f32>,
+) -> String {
+    use std::fmt::Write;
+    let mut input = String::new();
+
+    // Sorted callers (same as what generate_nl_with_call_context sees)
+    let mut callers: Vec<&str> = ctx.callers.iter().map(|s| s.as_str()).collect();
+    callers.sort_unstable();
+    for c in &callers {
+        let _ = write!(input, "c:{c}|");
+    }
+
+    // Sorted callees, filtered by IDF (same threshold as generate_nl_with_call_context)
+    let mut callees: Vec<&str> = ctx
+        .callees
+        .iter()
+        .filter(|name| callee_doc_freq.get(name.as_str()).copied().unwrap_or(0.0) < 0.1)
+        .map(|s| s.as_str())
+        .collect();
+    callees.sort_unstable();
+    for c in &callees {
+        let _ = write!(input, "e:{c}|");
+    }
+
+    let hash = blake3::hash(input.as_bytes());
+    hash.to_hex()[..32].to_string()
 }
 
 /// Embed a batch of enriched NL descriptions and update their embeddings in the store.
 fn flush_enrichment_batch(
     store: &Store,
     embedder: &Embedder,
-    batch: &mut Vec<(String, String)>,
+    batch: &mut Vec<(String, String, String)>,
 ) -> Result<usize> {
-    let texts: Vec<&str> = batch.iter().map(|(_, nl)| nl.as_str()).collect();
+    let texts: Vec<&str> = batch.iter().map(|(_, nl, _)| nl.as_str()).collect();
     let expected = texts.len();
     let embeddings = embedder
         .embed_documents(&texts)
@@ -1069,14 +1132,14 @@ fn flush_enrichment_batch(
 
     // embed_documents returns 768-dim; add neutral sentiment for 769-dim
     // Build updates from batch without draining — only clear after successful write
-    let updates: Vec<(String, Embedding)> = batch
+    let updates: Vec<(String, Embedding, String)> = batch
         .iter()
         .zip(embeddings)
-        .map(|((id, _), emb)| (id.clone(), emb.with_sentiment(0.0)))
+        .map(|((id, _, hash), emb)| (id.clone(), emb.with_sentiment(0.0), hash.clone()))
         .collect();
 
     store
-        .update_embeddings_batch(&updates)
+        .update_embeddings_with_hashes_batch(&updates)
         .context("Failed to update enriched embeddings")?;
 
     let count = updates.len();

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -341,6 +341,9 @@ fn process_file_changes(
     // results (RT-DATA-3). Per-file transactions are atomic but the
     // batch is not — files indexed so far are visible, remaining are
     // stale. Self-heals after HNSW rebuild. Acceptable for a dev tool.
+    //
+    // Mark HNSW dirty before writing chunks (RT-DATA-6).
+    store.set_hnsw_dirty(true).ok();
     match reindex_files(root, store, &files, parser, emb, quiet) {
         Ok((count, content_hashes)) => {
             // Record mtimes to skip duplicate events
@@ -372,6 +375,7 @@ fn process_file_changes(
                         let n = index.len();
                         *hnsw_index = Some(index);
                         *incremental_count = 0;
+                        store.set_hnsw_dirty(false).ok(); // RT-DATA-6
                         info!(vectors = n, "HNSW index rebuilt (full)");
                         if !quiet {
                             println!("  HNSW index: {} vectors (full rebuild)", n);
@@ -411,6 +415,8 @@ fn process_file_changes(
                                     // Save updated index to disk for search processes
                                     if let Err(e) = index.save(cqs_dir, "index") {
                                         warn!(error = %e, "Failed to save HNSW after incremental insert");
+                                    } else {
+                                        store.set_hnsw_dirty(false).ok(); // RT-DATA-6
                                     }
                                     info!(
                                         inserted = n,

--- a/src/note.rs
+++ b/src/note.rs
@@ -131,27 +131,42 @@ pub const NOTES_HEADER: &str = "\
 /// Parse notes from a notes.toml file
 pub fn parse_notes(path: &Path) -> Result<Vec<Note>, NoteError> {
     let _span = tracing::debug_span!("parse_notes", path = %path.display()).entered();
-    // Acquire shared lock and read from the locked handle directly
-    use std::io::Read;
-    let mut lock_file = std::fs::OpenOptions::new()
+    // Lock a separate .lock file (shared) to coordinate with writers.
+    // Using a separate lock file avoids the inode-vs-rename race: if we locked
+    // the data file itself, a concurrent writer's atomic rename would orphan
+    // our lock onto the old inode, letting a third process read stale data.
+    let lock_path = path.with_extension("toml.lock");
+    let lock_file = std::fs::OpenOptions::new()
         .read(true)
-        .open(path)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
         .map_err(|e| {
             NoteError::Io(std::io::Error::new(
                 e.kind(),
-                format!("{}: {}", path.display(), e),
+                format!("{}: {}", lock_path.display(), e),
             ))
         })?;
     lock_file.lock_shared().map_err(|e| {
         NoteError::Io(std::io::Error::new(
             std::io::ErrorKind::WouldBlock,
-            format!("Could not lock {} for reading: {}", path.display(), e),
+            format!("Could not lock {} for reading: {}", lock_path.display(), e),
+        ))
+    })?;
+
+    // Now open and read the data file (protected by the lock file)
+    use std::io::Read;
+    let mut data_file = std::fs::File::open(path).map_err(|e| {
+        NoteError::Io(std::io::Error::new(
+            e.kind(),
+            format!("{}: {}", path.display(), e),
         ))
     })?;
 
     // Size guard: notes.toml should be well under 10MB
     const MAX_NOTES_FILE_SIZE: u64 = 10 * 1024 * 1024;
-    if let Ok(meta) = lock_file.metadata() {
+    if let Ok(meta) = data_file.metadata() {
         if meta.len() > MAX_NOTES_FILE_SIZE {
             return Err(NoteError::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -165,7 +180,7 @@ pub fn parse_notes(path: &Path) -> Result<Vec<Note>, NoteError> {
         }
     }
     let mut content = String::new();
-    lock_file.read_to_string(&mut content).map_err(|e| {
+    data_file.read_to_string(&mut content).map_err(|e| {
         NoteError::Io(std::io::Error::new(
             e.kind(),
             format!("{}: {}", path.display(), e),
@@ -185,11 +200,35 @@ pub fn rewrite_notes_file(
     mutate: impl FnOnce(&mut Vec<NoteEntry>) -> Result<(), NoteError>,
 ) -> Result<Vec<NoteEntry>, NoteError> {
     let _span = tracing::debug_span!("rewrite_notes_file", path = %notes_path.display()).entered();
-    // Acquire exclusive lock before the read-modify-write cycle.
-    // Open with read+write so the exclusive lock covers both operations across all platforms.
-    let mut lock_file = std::fs::OpenOptions::new()
+    // Lock a separate .lock file (exclusive) to coordinate with readers/writers.
+    // See parse_notes() for why we use a separate lock file instead of the data file.
+    let lock_path = notes_path.with_extension("toml.lock");
+    let _lock_file = {
+        let f = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|e| {
+                NoteError::Io(std::io::Error::new(
+                    e.kind(),
+                    format!("{}: {}", lock_path.display(), e),
+                ))
+            })?;
+        f.lock().map_err(|e| {
+            NoteError::Io(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                format!("Could not lock {} for writing: {}", lock_path.display(), e),
+            ))
+        })?;
+        f // held until end of function
+    };
+
+    // Now open and read the data file (protected by the lock file)
+    use std::io::Read;
+    let mut data_file = std::fs::OpenOptions::new()
         .read(true)
-        .write(true)
         .open(notes_path)
         .map_err(|e| {
             NoteError::Io(std::io::Error::new(
@@ -197,17 +236,10 @@ pub fn rewrite_notes_file(
                 format!("{}: {}", notes_path.display(), e),
             ))
         })?;
-    lock_file.lock().map_err(|e| {
-        NoteError::Io(std::io::Error::new(
-            std::io::ErrorKind::WouldBlock,
-            format!("Could not lock {} for writing: {}", notes_path.display(), e),
-        ))
-    })?;
-    // lock_file held until end of function (dropped automatically)
 
-    // Size guard (same limit as read path) — use locked fd, not a separate syscall
+    // Size guard (same limit as read path)
     const MAX_NOTES_FILE_SIZE: u64 = 10 * 1024 * 1024;
-    if let Ok(meta) = lock_file.metadata() {
+    if let Ok(meta) = data_file.metadata() {
         if meta.len() > MAX_NOTES_FILE_SIZE {
             return Err(NoteError::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -220,10 +252,8 @@ pub fn rewrite_notes_file(
             )));
         }
     }
-    // Read from the locked fd — avoids a separate open that could see different content
-    use std::io::Read;
     let mut content = String::new();
-    lock_file.read_to_string(&mut content).map_err(|e| {
+    data_file.read_to_string(&mut content).map_err(|e| {
         NoteError::Io(std::io::Error::new(
             e.kind(),
             format!("{}: {}", notes_path.display(), e),

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,4 +1,4 @@
--- cq index schema v12
+-- cq index schema v13
 -- v10: Generalized for multiple sources (filesystem, SQL Server, etc.)
 --   file → origin (unique identifier like "file:src/main.rs" or "mssql:server/db/dbo.MyProc")
 --   file_mtime → source_mtime (nullable for sources without mtime)
@@ -28,7 +28,8 @@ CREATE TABLE IF NOT EXISTS chunks (
     updated_at TEXT NOT NULL,
     parent_id TEXT,           -- if windowed: ID of the logical parent chunk
     window_idx INTEGER,       -- if windowed: 0, 1, 2... for each window
-    parent_type_name TEXT     -- for methods: name of enclosing class/struct/impl
+    parent_type_name TEXT,    -- for methods: name of enclosing class/struct/impl
+    enrichment_hash TEXT      -- blake3 hash of call context used for enrichment (NULL = not enriched)
 );
 
 CREATE INDEX IF NOT EXISTS idx_chunks_origin ON chunks(origin);

--- a/src/store/chunks.rs
+++ b/src/store/chunks.rs
@@ -114,6 +114,99 @@ impl Store {
         })
     }
 
+    /// Update embeddings and enrichment hashes in batch.
+    ///
+    /// Like `update_embeddings_batch` but also stores the enrichment hash
+    /// for idempotency detection. Used by the enrichment pass to record
+    /// which call context was used, so re-indexing can skip unchanged chunks.
+    pub fn update_embeddings_with_hashes_batch(
+        &self,
+        updates: &[(String, Embedding, String)],
+    ) -> Result<usize, StoreError> {
+        let _span =
+            tracing::info_span!("update_embeddings_with_hashes_batch", count = updates.len())
+                .entered();
+        if updates.is_empty() {
+            return Ok(0);
+        }
+
+        let embedding_bytes: Vec<Vec<u8>> = updates
+            .iter()
+            .map(|(_, emb, _)| embedding_to_bytes(emb))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        self.rt.block_on(async {
+            let mut tx = self.pool.begin().await?;
+            let mut updated = 0usize;
+            for (i, (id, _, hash)) in updates.iter().enumerate() {
+                let result = sqlx::query(
+                    "UPDATE chunks SET embedding = ?1, enrichment_hash = ?2 WHERE id = ?3",
+                )
+                .bind(&embedding_bytes[i])
+                .bind(hash)
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
+                if result.rows_affected() > 0 {
+                    updated += 1;
+                } else {
+                    tracing::debug!(chunk_id = %id, "Enrichment update found no row");
+                }
+            }
+            tx.commit().await?;
+            Ok(updated)
+        })
+    }
+
+    /// Get the enrichment hash for a chunk, if any.
+    pub fn get_enrichment_hash(&self, chunk_id: &str) -> Result<Option<String>, StoreError> {
+        self.rt.block_on(async {
+            let row: Option<(Option<String>,)> =
+                sqlx::query_as("SELECT enrichment_hash FROM chunks WHERE id = ?1")
+                    .bind(chunk_id)
+                    .fetch_optional(&self.pool)
+                    .await?;
+            Ok(row.and_then(|(h,)| h))
+        })
+    }
+
+    /// Get enrichment hashes for a batch of chunk IDs.
+    ///
+    /// Returns a map from chunk_id to enrichment_hash (only for chunks that have one).
+    pub fn get_enrichment_hashes_batch(
+        &self,
+        chunk_ids: &[&str],
+    ) -> Result<std::collections::HashMap<String, String>, StoreError> {
+        if chunk_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        self.rt.block_on(async {
+            let mut result = std::collections::HashMap::new();
+            // Process in batches to stay under SQLite parameter limit
+            for batch in chunk_ids.chunks(500) {
+                let placeholders: String = batch
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| format!("?{}", i + 1))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let sql = format!(
+                    "SELECT id, enrichment_hash FROM chunks WHERE id IN ({}) AND enrichment_hash IS NOT NULL",
+                    placeholders
+                );
+                let mut query = sqlx::query_as::<_, (String, String)>(&sql);
+                for id in batch {
+                    query = query.bind(*id);
+                }
+                let rows = query.fetch_all(&self.pool).await?;
+                for (id, hash) in rows {
+                    result.insert(id, hash);
+                }
+            }
+            Ok(result)
+        })
+    }
+
     /// Check if a file needs reindexing based on mtime.
     ///
     /// Returns `Ok(Some(mtime))` if reindex needed (with the file's current mtime),

--- a/src/store/helpers.rs
+++ b/src/store/helpers.rs
@@ -13,10 +13,11 @@ use crate::parser::{Chunk, ChunkType, Language};
 /// against the stored version and returns StoreError::SchemaMismatch if different.
 ///
 /// History:
-/// - v12: Current (parent_type_name column for method→class association)
+/// - v13: Current (enrichment_hash for idempotent enrichment, hnsw_dirty flag)
+/// - v12: parent_type_name column for method→class association
 /// - v11: type_edges table for type-level dependency tracking
 /// - v10: sentiment in embeddings, call graph, notes
-pub const CURRENT_SCHEMA_VERSION: i32 = 12;
+pub const CURRENT_SCHEMA_VERSION: i32 = 13;
 pub const MODEL_NAME: &str = "intfloat/e5-base-v2";
 /// Expected embedding dimensions — derived from crate::EMBEDDING_DIM
 pub const EXPECTED_DIMENSIONS: u32 = crate::EMBEDDING_DIM as u32;

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -66,6 +66,7 @@ async fn run_migration(
     match (from, to) {
         (10, 11) => migrate_v10_to_v11(conn).await,
         (11, 12) => migrate_v11_to_v12(conn).await,
+        (12, 13) => migrate_v12_to_v13(conn).await,
         _ => Err(StoreError::MigrationNotSupported(from, to)),
     }
 }
@@ -122,6 +123,29 @@ async fn migrate_v11_to_v12(conn: &mut sqlx::SqliteConnection) -> Result<(), Sto
     Ok(())
 }
 
+/// Migrate from v12 to v13: enrichment idempotency + HNSW dirty flag
+///
+/// - `enrichment_hash` column on chunks: blake3 hash of call context used during
+///   enrichment. NULL means not yet enriched. Allows skipping already-enriched
+///   chunks on re-index and detecting partial enrichment after crash.
+/// - `hnsw_dirty` metadata key: set to "1" before SQLite chunk writes, cleared
+///   to "0" after successful HNSW save. Detects crash between the two writes.
+async fn migrate_v12_to_v13(conn: &mut sqlx::SqliteConnection) -> Result<(), StoreError> {
+    sqlx::query("ALTER TABLE chunks ADD COLUMN enrichment_hash TEXT")
+        .execute(&mut *conn)
+        .await?;
+
+    sqlx::query("INSERT OR IGNORE INTO metadata (key, value) VALUES ('hnsw_dirty', '0')")
+        .execute(&mut *conn)
+        .await?;
+
+    tracing::info!(
+        "Added enrichment_hash column and hnsw_dirty flag. \
+         Run 'cqs index --force' to populate enrichment hashes."
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,7 +163,7 @@ mod tests {
     #[test]
     fn test_current_schema_version_documented() {
         // Ensure the current version matches what we document
-        assert_eq!(CURRENT_SCHEMA_VERSION, 12);
+        assert_eq!(CURRENT_SCHEMA_VERSION, 13);
     }
 
     #[test]
@@ -163,7 +187,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let result = migrate(&pool, 12, 12).await;
+            let result = migrate(&pool, 13, 13).await;
             assert!(result.is_ok(), "same-version migration should be no-op");
         });
     }
@@ -189,10 +213,10 @@ mod tests {
                 .await
                 .unwrap();
 
-            let result = migrate(&pool, 12, 11).await;
+            let result = migrate(&pool, 13, 12).await;
             assert!(result.is_err(), "downgrade should fail");
             match result.unwrap_err() {
-                StoreError::SchemaNewerThanCq(v) => assert_eq!(v, 12),
+                StoreError::SchemaNewerThanCq(v) => assert_eq!(v, 13),
                 other => panic!("Expected SchemaNewerThanCq, got: {:?}", other),
             }
         });

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -759,6 +759,35 @@ impl Store {
         })
     }
 
+    /// Mark the HNSW index as dirty (out of sync with SQLite).
+    ///
+    /// Call before writing chunks to SQLite. Clear after successful HNSW save.
+    /// On load, a dirty flag means a crash occurred between SQLite commit and
+    /// HNSW save — the HNSW index should not be trusted.
+    pub fn set_hnsw_dirty(&self, dirty: bool) -> Result<(), StoreError> {
+        let val = if dirty { "1" } else { "0" };
+        self.rt.block_on(async {
+            sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES ('hnsw_dirty', ?1)")
+                .bind(val)
+                .execute(&self.pool)
+                .await?;
+            Ok(())
+        })
+    }
+
+    /// Check if the HNSW index is marked as dirty (potentially stale).
+    ///
+    /// Returns `false` if the key doesn't exist (pre-v13 indexes).
+    pub fn is_hnsw_dirty(&self) -> Result<bool, StoreError> {
+        self.rt.block_on(async {
+            let row: Option<(String,)> =
+                sqlx::query_as("SELECT value FROM metadata WHERE key = 'hnsw_dirty'")
+                    .fetch_optional(&self.pool)
+                    .await?;
+            Ok(row.is_some_and(|(v,)| v == "1"))
+        })
+    }
+
     /// Get cached notes summaries (loaded on first call, invalidated on mutation).
     ///
     /// Returns a cloned Vec rather than a slice reference to avoid holding the

--- a/src/where_to_add.rs
+++ b/src/where_to_add.rs
@@ -422,14 +422,257 @@ fn extract_patterns(chunks: &[ChunkSummary], language: Option<Language>) -> Loca
             };
             (imports, vis.to_string())
         }
-        Some(Language::Sql) => {
-            // SQL has no imports or visibility conventions
-            (Vec::new(), "default".to_string())
+        // C-like: reuse C patterns (#include, static/extern)
+        Some(Language::Cpp | Language::ObjC | Language::Cuda | Language::Glsl) => {
+            let imports = extract_imports(chunks, &["#include"], MAX_IMPORT_COUNT);
+            error_style = detect_error_style(
+                chunks,
+                &[
+                    ("errno", "errno"),
+                    ("throw ", "throw"),
+                    ("try {", "try/catch"),
+                ],
+            );
+            let statics = chunks
+                .iter()
+                .filter(|c| c.signature.starts_with("static "))
+                .count();
+            let vis = if statics > chunks.len() / 2 {
+                "static"
+            } else {
+                "extern"
+            };
+            (imports, vis.to_string())
         }
-        Some(Language::Markdown) => {
-            // Markdown has no code patterns
-            (Vec::new(), "default".to_string())
+        // JVM: reuse Java patterns (import, public/package-private)
+        Some(Language::Scala | Language::Kotlin) => {
+            let imports = extract_imports(chunks, &["import "], MAX_IMPORT_COUNT);
+            error_style = detect_error_style(
+                chunks,
+                &[("throws ", "checked exceptions"), ("try {", "try/catch")],
+            );
+            let public = chunks
+                .iter()
+                .filter(|c| c.signature.contains("public"))
+                .count();
+            let vis = if public > chunks.len() / 2 {
+                "public"
+            } else {
+                "package-private"
+            };
+            (imports, vis.to_string())
         }
+        // .NET: using/open statements, public/internal visibility
+        Some(
+            Language::CSharp
+            | Language::FSharp
+            | Language::VbNet
+            | Language::Razor
+            | Language::Aspx,
+        ) => {
+            let imports = extract_imports(chunks, &["using ", "open "], MAX_IMPORT_COUNT);
+            error_style =
+                detect_error_style(chunks, &[("throw ", "throw"), ("try {", "try/catch")]);
+            let public = chunks
+                .iter()
+                .filter(|c| c.signature.contains("public"))
+                .count();
+            let internal = chunks
+                .iter()
+                .filter(|c| c.signature.contains("internal"))
+                .count();
+            let vis = if public >= internal {
+                "public"
+            } else {
+                "internal"
+            };
+            (imports, vis.to_string())
+        }
+        // Dynamic: require/use/include, mixed visibility
+        Some(Language::Ruby) => {
+            let imports =
+                extract_imports(chunks, &["require ", "require_relative "], MAX_IMPORT_COUNT);
+            error_style =
+                detect_error_style(chunks, &[("raise ", "raise"), ("rescue", "begin/rescue")]);
+            (imports, "module-level".to_string())
+        }
+        Some(Language::Php) => {
+            let imports = extract_imports(
+                chunks,
+                &["require ", "require_once ", "include ", "use "],
+                MAX_IMPORT_COUNT,
+            );
+            error_style =
+                detect_error_style(chunks, &[("throw ", "throw"), ("try {", "try/catch")]);
+            let public = chunks
+                .iter()
+                .filter(|c| c.signature.contains("public"))
+                .count();
+            let vis = if public > chunks.len() / 2 {
+                "public"
+            } else {
+                "default"
+            };
+            (imports, vis.to_string())
+        }
+        Some(Language::Perl) => {
+            let imports = extract_imports(chunks, &["use ", "require "], MAX_IMPORT_COUNT);
+            error_style = detect_error_style(chunks, &[("die ", "die"), ("croak", "croak")]);
+            (imports, "module-level".to_string())
+        }
+        Some(Language::Lua) => {
+            let imports = extract_imports(
+                chunks,
+                &["require(", "require \"", "require '"],
+                MAX_IMPORT_COUNT,
+            );
+            error_style = detect_error_style(chunks, &[("error(", "error"), ("pcall(", "pcall")]);
+            (imports, "module-level".to_string())
+        }
+        // Functional: import/use, module visibility
+        Some(Language::Haskell) => {
+            let imports = extract_imports(chunks, &["import "], MAX_IMPORT_COUNT);
+            error_style =
+                detect_error_style(chunks, &[("error ", "error"), ("throwIO", "throwIO")]);
+            (imports, "module-level".to_string())
+        }
+        Some(Language::OCaml) => {
+            let imports = extract_imports(chunks, &["open "], MAX_IMPORT_COUNT);
+            error_style = detect_error_style(chunks, &[("raise ", "raise"), ("Result.", "Result")]);
+            (imports, "module-level".to_string())
+        }
+        Some(Language::Elixir) => {
+            let imports = extract_imports(
+                chunks,
+                &["import ", "alias ", "use ", "require "],
+                MAX_IMPORT_COUNT,
+            );
+            error_style =
+                detect_error_style(chunks, &[("raise ", "raise"), ("{:error,", "{:error, _}")]);
+            let private = chunks
+                .iter()
+                .filter(|c| c.signature.starts_with("defp "))
+                .count();
+            let vis = if private > chunks.len() / 2 {
+                "private"
+            } else {
+                "public"
+            };
+            (imports, vis.to_string())
+        }
+        Some(Language::Erlang) => {
+            let imports = extract_imports(chunks, &["-include"], MAX_IMPORT_COUNT);
+            error_style =
+                detect_error_style(chunks, &[("throw(", "throw"), ("{error,", "{error, _}")]);
+            (imports, "module-level".to_string())
+        }
+        Some(Language::Gleam) => {
+            let imports = extract_imports(chunks, &["import "], MAX_IMPORT_COUNT);
+            error_style = detect_error_style(chunks, &[("Error(", "Error"), ("Result(", "Result")]);
+            let public = chunks
+                .iter()
+                .filter(|c| c.signature.starts_with("pub "))
+                .count();
+            let vis = if public > chunks.len() / 2 {
+                "pub"
+            } else {
+                "private"
+            };
+            (imports, vis.to_string())
+        }
+        // Data science: library/using
+        Some(Language::R) => {
+            let imports = extract_imports(chunks, &["library(", "require("], MAX_IMPORT_COUNT);
+            (imports, "default".to_string())
+        }
+        Some(Language::Julia) => {
+            let imports = extract_imports(chunks, &["using ", "import "], MAX_IMPORT_COUNT);
+            error_style = detect_error_style(chunks, &[("throw(", "throw"), ("error(", "error")]);
+            (imports, "module-level".to_string())
+        }
+        // Systems
+        Some(Language::Zig) => {
+            let imports = extract_imports(chunks, &["@import("], MAX_IMPORT_COUNT);
+            error_style =
+                detect_error_style(chunks, &[("error.", "error set"), ("catch", "catch")]);
+            let public = chunks
+                .iter()
+                .filter(|c| c.signature.starts_with("pub "))
+                .count();
+            let vis = if public > chunks.len() / 2 {
+                "pub"
+            } else {
+                "private"
+            };
+            (imports, vis.to_string())
+        }
+        Some(Language::Swift) => {
+            let imports = extract_imports(chunks, &["import "], MAX_IMPORT_COUNT);
+            error_style = detect_error_style(chunks, &[("throw ", "throw"), ("try ", "do/catch")]);
+            let public = chunks
+                .iter()
+                .filter(|c| c.signature.contains("public"))
+                .count();
+            let vis = if public > chunks.len() / 2 {
+                "public"
+            } else {
+                "internal"
+            };
+            (imports, vis.to_string())
+        }
+        // Solidity: contract visibility
+        Some(Language::Solidity) => {
+            let imports = extract_imports(chunks, &["import "], MAX_IMPORT_COUNT);
+            error_style =
+                detect_error_style(chunks, &[("revert ", "revert"), ("require(", "require")]);
+            let public = chunks
+                .iter()
+                .filter(|c| c.signature.contains("public") || c.signature.contains("external"))
+                .count();
+            let vis = if public > chunks.len() / 2 {
+                "public"
+            } else {
+                "internal"
+            };
+            (imports, vis.to_string())
+        }
+        // Shell: source/import
+        Some(Language::Bash) => {
+            let imports = extract_imports(chunks, &["source ", ". "], MAX_IMPORT_COUNT);
+            error_style =
+                detect_error_style(chunks, &[("exit ", "exit code"), ("set -e", "set -e")]);
+            (imports, "default".to_string())
+        }
+        Some(Language::PowerShell) => {
+            let imports = extract_imports(
+                chunks,
+                &["Import-Module ", "using module "],
+                MAX_IMPORT_COUNT,
+            );
+            error_style =
+                detect_error_style(chunks, &[("throw ", "throw"), ("try {", "try/catch")]);
+            (imports, "default".to_string())
+        }
+        // Non-code: no meaningful patterns
+        Some(
+            Language::Sql
+            | Language::Markdown
+            | Language::Json
+            | Language::Yaml
+            | Language::Toml
+            | Language::Xml
+            | Language::Ini
+            | Language::Css
+            | Language::Html
+            | Language::Svelte
+            | Language::Vue
+            | Language::Make
+            | Language::Nix
+            | Language::Latex
+            | Language::Protobuf
+            | Language::GraphQL
+            | Language::Hcl,
+        ) => (Vec::new(), "default".to_string()),
         _ => (Vec::new(), "default".to_string()),
     };
 

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -17,7 +17,7 @@ fn test_store_init() {
     let stats = store.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
     assert_eq!(stats.total_files, 0);
-    assert_eq!(stats.schema_version, 12); // v12: parent_type_name column
+    assert_eq!(stats.schema_version, 13); // v13: enrichment_hash + hnsw_dirty
     assert_eq!(stats.model_name, "intfloat/e5-base-v2");
 }
 


### PR DESCRIPTION
## Summary

- **RT-DATA-4**: Notes file lock vs rename race — separate `.lock` file that survives atomic renames
- **RT-DATA-2**: Enrichment idempotency — blake3 hash of call context, skip re-enrichment when unchanged (schema v13)
- **RT-DATA-6**: HNSW crash desync — dirty flag in SQLite metadata, set before chunk writes, cleared after HNSW save
- **#555**: `where_to_add` coverage for 43 languages — 10 family groups + explicit skip list for non-code languages
- Roadmap refresh: version, language count, schema version, red team section, missing injections

## Test plan

- [x] 1080 lib tests pass
- [x] All integration tests pass
- [x] cargo clippy clean
- [x] cargo fmt clean
- [ ] CI green
- [ ] Migration test: v12→v13 adds `enrichment_hash` column and `hnsw_dirty` metadata key
- [ ] Enrichment: `cqs index` then re-run shows skip count
- [ ] Dirty flag: set `hnsw_dirty=1` manually → search warns and falls back

Closes #555

Generated with [Claude Code](https://claude.com/claude-code)
