### PR TITLE
chore: release v1.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.11] - 2026-03-16
+
+### Fixed
+- **RT-DATA-4**: Notes file lock vs rename race — use separate `.lock` file that survives atomic renames (#599)
+- **RT-DATA-2**: Enrichment idempotency — store blake3 hash of call context per chunk, skip re-enrichment when unchanged (#599)
+- **RT-DATA-6**: HNSW crash desync — dirty flag in SQLite metadata detects interrupted writes, falls back to brute-force until rebuild (#599)
+
+### Added
+- `where_to_add` pattern coverage for 43 languages across 10 family groups: C-like, JVM, .NET, dynamic, functional, data science, systems, Solidity, shell (#555, #599)
+- Schema v13 migration: `enrichment_hash` column + `hnsw_dirty` metadata key
+
+### Changed
+- Roadmap refreshed: v1.0.10 header, 51 languages, schema v12→v13, red team accepted findings section, missing injection entries
+
 ## [1.0.10] - 2026-03-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.0.10"
+version = "1.0.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "1.0.10"
+version = "1.0.11"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 51 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -57,9 +57,9 @@ None (notes.toml edited but not git-tracked).
 
 ## Architecture
 
-- Version: 1.0.10
+- Version: 1.0.11
 - MSRV: 1.93
-- Schema: v12
+- Schema: v13
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
 - HNSW index: chunks only
 - 51 languages, 16 ChunkType variants

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current: v1.0.10
+## Current: v1.0.11
 
 First stable release. All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 51 languages. Two full audits complete (v0.12.3 + v0.19.2). Recursive multi-grammar injection framework.
 


### PR DESCRIPTION
## Summary

- Version bump to 1.0.11
- Changelog entry for RT-DATA-2/4/6 fixes, #555, schema v13

## Test plan

- [ ] CI green
- [ ] Release workflow triggers on merge

Generated with [Claude Code](https://claude.com/claude-code)
