### PR TITLE
chore: release v1.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.12] - 2026-03-16
+
+### Added
+- `cqs plan` command: classify tasks into 11 templates (language, bug fix, CLI flag, injection, etc.) via keyword scoring, run scout, output actionable checklist (#601)
+
+### Fixed
+- cqs-plan skill: stale file references (schema.rs → helpers.rs/migrations.rs, PRAGMA → metadata table)
+
 ## [1.0.11] - 2026-03-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "1.0.11"
+version = "1.0.12"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 51 languages, 90.9% Recall@1, 0.951 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -51,7 +51,7 @@ None.
 
 ## Architecture
 
-- Version: 1.0.11
+- Version: 1.0.12
 - MSRV: 1.93
 - Schema: v13
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current: v1.0.11
+## Current: v1.0.12
 
 First stable release. All agent experience features shipped. CLI-only (MCP removed in v0.10.0). 51 languages. Two full audits complete (v0.12.3 + v0.19.2). Recursive multi-grammar injection framework.
 


### PR DESCRIPTION
## Summary
- Version bump to 1.0.12
- Changelog for `cqs plan` command

## Test plan
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)
