### PR TITLE
chore: update tears for A6000 switch

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,52 +2,39 @@
 
 ## Right Now
 
-**SQ-6 metrics testing (2026-03-16).** Batches API merged (#605), stress eval running.
+**Clean main, moving to A6000 machine for SQ-7 (2026-03-17).** Build artifacts cleaned.
 
-### Done this session
-- v1.0.11: RT-DATA-2/4/6 data integrity fixes + #555 where_to_add 43-language coverage
+### Done this session (2026-03-16)
+- v1.0.11: RT-DATA-2/4/6 data integrity fixes + #555 where_to_add 43 languages
 - v1.0.12: `cqs plan` command — 11 task-type templates
-- v1.0.13: SQ-6 LLM summaries (schema v14, llm_summaries table)
-- PR #605: Batches API + llm-summaries in default features (merged)
-- Live test: 1465 summaries via batch ($0.59), 669 doc-comment, 2637 cached
-- Fixture eval baseline: 85.5% R@1, 0.914 MRR (ceiling-bound)
-- Stress eval running: baseline (no summaries) against cqs+Flask+Zod+Express+Chi
+- v1.0.13: SQ-6 LLM summaries (schema v14, Batches API, cached by content_hash)
+- PR #605: Batches API + llm-summaries in default features
+- PR #606: Stress eval A/B results
 
-### Stress eval baseline (no summaries, 3727 chunks)
-- R@1: 58.0%, MRR: 0.653, R@5: 73.4%
-- Rust MRR: 0.000, Python: 0.457, TS: 0.925, JS: 0.888, Go: 0.948
-- name_boost has no effect (0.0 = 0.2 = same results)
-
-### Stress eval WITH summaries (3727 chunks, 143 queries)
-- R@1: 55.9% (baseline 58.0%, **-2.1pp**)
-- MRR: 0.630 (baseline 0.653, **-0.023**)
-- Python MRR: 0.300 (baseline 0.457, **-0.157**)
-- TS/JS improved slightly (+0.023/+0.055), Rust still 0.000
-- **Verdict: SQ-6 doesn't help with E5-base-v2.** Model treats summaries same as prose.
-- SQ-7 (LoRA) remains the real fix — teach model that summaries > prose.
-
-### Still needs to happen
-- Decision: keep SQ-6 available for SQ-7 or shelve?
-- Docs review (README, CONTRIBUTING)
-- Release decision
+### SQ-6 eval results (CRITICAL for SQ-7 planning)
+- Fixture eval baseline: 85.5% R@1, 0.914 MRR (ceiling-bound, no room)
+- Stress eval baseline (no summaries, 3727 chunks): R@1 58.0%, MRR 0.653
+- Stress eval WITH SQ-6 (3727 chunks): R@1 55.9%, MRR 0.630 (**-2.1pp, -0.023**)
+- Python MRR: 0.457 → 0.300 (-0.157). TS/JS improved slightly.
+- Rust MRR: 0.000 in both cases
+- **Verdict: E5-base-v2 treats summaries same as prose. SQ-7 (LoRA) is the fix.**
+- SQ-6 + SQ-7 expected to outperform SQ-7 alone (richer NL + trained discrimination)
 
 ### Key decisions made
-- Batches API over sequential calls (no RPM limit, 50% discount, Tier 1 50 RPM was too low)
-- llm-summaries now default feature
-- Deduplicate batch items by content_hash
-- Doc comment shortcut: first sentence as summary, skip API
-- enrichment_hash extended to include summary text (no new column)
-- Enrichment pass loads summaries internally (no signature change)
-- ChunkSummary extended with content_hash + window_idx fields
+- Dirty flag over generation counter for RT-DATA-6
+- Batches API over sequential calls for SQ-6 (Tier 1 = 50 RPM, too low for sequential)
+- Doc comment shortcut: skip API for documented functions
+- enrichment_hash extended to include summary (no new column)
+- llm-summaries is default feature now (reqwest always compiled)
 
 ## Pending Changes
 
-None (PR #605 merged, no release yet).
+None. Clean main.
 
 ## Parked
 
 - **SQ-3: Code-specific embedding model** — UniXcoder, CodeBERT
-- **SQ-7: LoRA fine-tune E5 on A6000** — the real fix for code-vs-doc ranking
+- **SQ-7: LoRA fine-tune E5 on A6000** — NEXT. Training data: hard eval + holdout + synthetic pairs
 - **Post-index name matching** — fuzzy cross-doc references
 - **ref install** — #255
 
@@ -69,7 +56,7 @@ None (PR #605 merged, no release yet).
 
 ## Architecture
 
-- Version: 1.0.13 (v1.0.14 pending after metrics)
+- Version: 1.0.13
 - MSRV: 1.93
 - Schema: v14 (llm_summaries table)
 - 769-dim embeddings (768 E5-base-v2 + 1 sentiment)
@@ -77,6 +64,7 @@ None (PR #605 merged, no release yet).
 - 51 languages, 16 ChunkType variants
 - Tests: 1095 lib pass
 - SQ-6: LLM summaries via Claude Batches API, cached by content_hash
+- `cqs plan` command: 11 task-type templates
 - CUDA: 13 (cuVS) + 12 (ORT) symlinked into conda lib dir
 - Release targets: Linux x86_64, macOS ARM64, Windows x86_64
 - Notes: 122 indexed


### PR DESCRIPTION
## Summary
- Update tears for machine switch to A6000 (SQ-7 LoRA training)
- SQ-6 eval results captured for next session

## Test plan
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)
