### PR TITLE
fix(search): default to project-only search, add --include-refs flag

### DIFF
--- a/src/cli/commands/query.rs
+++ b/src/cli/commands/query.rs
@@ -134,7 +134,7 @@ pub(crate) fn cmd_query(cli: &Cli, query: &str) -> Result<()> {
     )
 }
 
-/// Project search: search project index (+ references if configured), post-process, display.
+/// Project search: search project index, optionally include references (--include-refs).
 #[allow(clippy::too_many_arguments)]
 fn cmd_query_project(
     cli: &Cli,
@@ -249,9 +249,13 @@ fn cmd_query_project(
         }
     }
 
-    // Load references for multi-index search
-    let config = cqs::config::Config::load(root);
-    let references = reference::load_references(&config.references);
+    // Load references only when --include-refs is set (default: project only)
+    let references = if cli.include_refs {
+        let config = cqs::config::Config::load(root);
+        reference::load_references(&config.references)
+    } else {
+        Vec::new()
+    };
 
     if references.is_empty() {
         if results.is_empty() {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -239,6 +239,10 @@ pub struct Cli {
     #[arg(long = "ref")]
     ref_name: Option<String>,
 
+    /// Include reference indexes in search results (default: project only)
+    #[arg(long)]
+    include_refs: bool,
+
     /// Maximum token budget for results (packs highest-scoring into budget)
     #[arg(long, value_parser = parse_nonzero_usize)]
     tokens: Option<usize>,


### PR DESCRIPTION
## Summary

- Search defaults to project-only (no reference indexes)
- Add `--include-refs` flag to include configured references in search
- `--ref name` (single reference search) unchanged

Previously, references were included whenever configured, polluting results with dependency code.

## Test plan

- [x] 1702 tests pass, 0 fail
- [x] `cqs "query"` returns project results only
- [x] `cqs "query" --include-refs` includes reference results
- [x] `cqs "query" --ref name` searches single reference (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
