### PR TITLE
docs: pre-release review for v1.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ Fall back to Grep/Glob only for exact string matches or when semantic search ret
 - `cqs chat` — interactive REPL with readline, history, tab completion. Same commands and pipelines as batch.
 - `cqs audit-mode on/off` — toggle audit mode.
 - `cqs convert <path> [--output dir]` — convert PDF/HTML/CHM/MD to cleaned Markdown with sensible filenames.
+- `cqs train-data` — generate fine-tuning training data from git history.
 
 **Token budgeting** — `--tokens N` on `query`, `gather`, `context`, `explain`, `scout`, `onboard`, and `task` packs results into a token budget (greedy knapsack by score). Commands that don't normally output content (`context`, `explain`, `scout`) include source code within the budget. `task` uses waterfall budgeting across sections (scout 15%, code 50%, impact 15%, placement 10%, notes 10%). JSON output adds `token_count` and `token_budget` fields.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ src/
   cli/          - Command-line interface (clap)
     mod.rs      - Argument parsing, command dispatch
     commands/   - Command implementations
-      mod.rs, query.rs, index.rs, stats.rs, graph.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, drift.rs, trace.rs, impact.rs, impact_diff.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs, audit_mode.rs, read.rs, stale.rs, related.rs, where_cmd.rs, scout.rs, onboard.rs, convert.rs, review.rs, ci.rs, health.rs, suggest.rs, deps.rs, task.rs, blame.rs, plan.rs
+      mod.rs, query.rs, index.rs, stats.rs, graph.rs, init.rs, doctor.rs, notes.rs, reference.rs, similar.rs, explain.rs, diff.rs, drift.rs, trace.rs, impact.rs, impact_diff.rs, test_map.rs, context.rs, resolve.rs, dead.rs, gc.rs, gather.rs, project.rs, audit_mode.rs, read.rs, stale.rs, related.rs, where_cmd.rs, scout.rs, onboard.rs, convert.rs, review.rs, ci.rs, health.rs, suggest.rs, deps.rs, task.rs, blame.rs, plan.rs, train_data.rs
     chat.rs     - Interactive REPL (wraps batch mode with rustyline)
     batch/      - Batch mode: persistent Store + Embedder, stdin commands, JSONL output, pipeline syntax
       mod.rs      - BatchContext, vector index builder, main loop
@@ -125,7 +125,7 @@ src/
     mod.rs      - Language enum, LanguageRegistry, LanguageDef, ChunkType
     rust.rs, python.rs, typescript.rs, javascript.rs, go.rs, c.rs, cpp.rs, java.rs, csharp.rs, fsharp.rs, powershell.rs, scala.rs, ruby.rs, bash.rs, hcl.rs, kotlin.rs, swift.rs, objc.rs, sql.rs, protobuf.rs, graphql.rs, php.rs, lua.rs, zig.rs, r.rs, yaml.rs, toml_lang.rs, elixir.rs, erlang.rs, gleam.rs, haskell.rs, julia.rs, ocaml.rs, css.rs, perl.rs, html.rs, json.rs, xml.rs, ini.rs, nix.rs, make.rs, latex.rs, solidity.rs, cuda.rs, glsl.rs, svelte.rs, razor.rs, vbnet.rs, vue.rs, aspx.rs, markdown.rs
   test_helpers.rs - Shared test fixtures module
-  store/        - SQLite storage layer (Schema v15, WAL mode)
+  store/        - SQLite storage layer (Schema v16, WAL mode)
     mod.rs      - Store struct, open/init, FTS5, RRF fusion
     chunks.rs   - Chunk CRUD, embedding_batches() for streaming
     notes.rs    - Note CRUD, note_embeddings(), brute-force search
@@ -195,7 +195,18 @@ src/
   suggest.rs    - Auto-suggest notes from code patterns
   config.rs     - Configuration file support
   index.rs      - VectorIndex trait (HNSW, CAGRA)
-  llm.rs        - LLM summary generation via Anthropic Batches API
+  llm.rs        - LLM summary generation, HyDE query predictions via Anthropic Batches API
+  doc_writer/   - Doc comment generation and source file rewriting (SQ-8, optional "llm-summaries" feature)
+    mod.rs      - DocCommentResult, module exports
+    formats.rs  - Per-language doc comment formatting (prefix, position, wrapping)
+    rewriter.rs - Source file rewriter: find insertion point, apply edits bottom-up, atomic write
+  train_data/   - Fine-tuning training data generation from git history
+    mod.rs      - TrainDataConfig, generate_training_data(), Triplet types
+    bm25.rs     - BM25 index for hard negative mining
+    checkpoint.rs - Resume support for long generation runs
+    diff.rs     - Git diff parsing for function-level changes
+    git.rs      - Git history traversal (log, show, diff-tree)
+    query.rs    - Query normalization for training pairs
   lib.rs        - Public API
 .claude/
   skills/       - Claude Code skills (auto-discovered)

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 ## Data Stays Local
 
-cqs processes your code locally by default. With `--llm-summaries`, function code is sent to Anthropic's API for one-sentence summary generation. See [Anthropic's privacy policy](https://www.anthropic.com/privacy). Without this flag, nothing is transmitted externally.
+cqs processes your code locally by default. With `--llm-summaries`, function code is sent to Anthropic's API for one-sentence summary generation. With `--improve-docs`, LLM-generated doc comments are written back to your source files. With `--hyde-queries`, function descriptions are sent to Anthropic's API for synthetic search query generation. See [Anthropic's privacy policy](https://www.anthropic.com/privacy). Without these flags, nothing is transmitted externally and no source files are modified.
 
 - **No telemetry**: We collect no usage data
 - **No analytics**: No tracking of any kind

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cargo install cqs
 
 **Upgrading?** Schema changes require rebuilding the index:
 ```bash
-cqs index --force  # Run after upgrading from older versions (current schema: v15)
+cqs index --force  # Run after upgrading from older versions (current schema: v16)
 ```
 
 ## Quick Start
@@ -120,17 +120,11 @@ threshold = 0.4
 # Name boost for hybrid search (0.0 = pure semantic, 1.0 = pure name)
 name_boost = 0.2
 
-# Note weight in search results (0.0-1.0, lower = notes rank below code)
-note_weight = 1.0
-
 # HNSW search width (higher = better recall, slower queries)
 ef_search = 100
 
 # Skip index staleness checks on every query (useful on NFS or slow disks)
 stale_check = true
-
-# Search only notes, skip code results (equivalent to --note-only flag)
-note_only = false
 
 # Output modes
 quiet = false
@@ -306,6 +300,26 @@ cqs gather "auth flow" --expand 2         # Deeper expansion
 cqs gather "config" --direction callers   # Only callers, not callees
 ```
 
+## Training Data Generation
+
+Generate fine-tuning training data from git history (LoRA fine-tuning triplets):
+
+```bash
+cqs train-data --repos /path/to/repo --output triplets.jsonl
+cqs train-data --repos /path/to/repo1 /path/to/repo2 --output data/triplets.jsonl
+cqs train-data --repos . --output out.jsonl --max-commits 500  # Limit commit history
+cqs train-data --repos . --output out.jsonl --resume           # Resume from checkpoint
+```
+
+## Reranker Configuration
+
+The cross-encoder reranker model can be overridden via environment variable:
+
+```bash
+export CQS_RERANKER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2  # default
+cqs "query" --rerank
+```
+
 ## Document Conversion
 
 Convert PDF, HTML, CHM, web help sites, and Markdown documents to cleaned, indexed Markdown:
@@ -403,7 +417,6 @@ Key commands (most support `--json`; `impact`, `review`, `ci`, and `trace` use `
 - `cqs "name" --name-only` - definition lookup (fast, no embedding)
 - `cqs "query" --semantic-only` - pure vector similarity, no keyword RRF
 - `cqs "query" --rerank` - cross-encoder re-ranking (slower, more accurate)
-- `cqs "query" --note-only` - search only notes (skip code results)
 - `cqs read <path>` - file with context notes injected as comments
 - `cqs read --focus <function>` - function + type dependencies only
 - `cqs stats` - index stats, chunk counts, HNSW index status
@@ -440,6 +453,7 @@ Key commands (most support `--json`; `impact`, `review`, `ci`, and `trace` use `
 - `cqs stale` - check index freshness (files changed since last index)
 - `cqs gc` - report/clean stale index entries
 - `cqs convert <path>` - convert PDF/HTML/CHM/Markdown to cleaned Markdown for indexing
+- `cqs train-data` - generate fine-tuning training data from git history
 - `cqs ref add/remove/list` - manage reference indexes for multi-index search
 - `cqs project register/remove/list/search` - cross-project search registry
 - `cqs completions <shell>` - generate shell completions (bash, zsh, fish, powershell, elvish)
@@ -511,6 +525,8 @@ cqs index --no-ignore      # Index everything
 cqs index --force          # Re-index all files
 cqs index --dry-run        # Show what would be indexed
 cqs index --llm-summaries  # Generate LLM summaries (requires ANTHROPIC_API_KEY)
+cqs index --llm-summaries --improve-docs  # Generate + write doc comments to source files
+cqs index --llm-summaries --hyde-queries  # Generate HyDE query predictions for better recall
 ```
 
 ## How It Works
@@ -518,9 +534,9 @@ cqs index --llm-summaries  # Generate LLM summaries (requires ANTHROPIC_API_KEY)
 **Parse → Describe → Embed → Enrich → Index → Search → Reason**
 
 1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 51 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
-2. **Describe** — Each code element gets a natural language description incorporating doc comments, parameter types, return types, and parent type context (e.g., methods include their struct/class name). Optionally enriched with LLM-generated one-sentence summaries via `--llm-summaries`. This bridges the gap between how developers describe code and how it's written.
-3. **Embed** — E5-base-v2 generates 768-dimensional embeddings locally. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval — outperforms code-specific models because NL descriptions play to general-purpose model strengths.
-4. **Enrich** — Call-graph-enriched embeddings prepend caller/callee context. Optional LLM summaries (via Claude Batches API) add one-sentence function purpose. Both cached by content_hash.
+2. **Describe** — Each code element gets a natural language description incorporating doc comments, parameter types, return types, and parent type context (e.g., methods include their struct/class name). Type-aware embeddings append full signatures for richer type discrimination (SQ-11). Optionally enriched with LLM-generated one-sentence summaries via `--llm-summaries`. This bridges the gap between how developers describe code and how it's written.
+3. **Embed** — E5-base-v2 generates 768-dimensional embeddings locally. 90.9% Recall@1, 0.951 NDCG@10 on confusable function retrieval — outperforms code-specific models because NL descriptions play to general-purpose model strengths. Optional HyDE query predictions (`--hyde-queries`) generate synthetic search queries per function for improved recall.
+4. **Enrich** — Call-graph-enriched embeddings prepend caller/callee context. Optional LLM summaries (via Claude Batches API) add one-sentence function purpose. `--improve-docs` generates and writes doc comments back to source files. Both cached by content_hash.
 5. **Index** — SQLite stores chunks, embeddings, call graph edges, and type dependency edges. HNSW provides fast approximate nearest-neighbor search. FTS5 enables keyword matching.
 6. **Search** — Hybrid RRF (Reciprocal Rank Fusion) combines semantic similarity with keyword matching. Optional cross-encoder re-ranking for highest accuracy.
 7. **Reason** — Call graph traversal, type dependency analysis, impact scoring, risk assessment, and smart context assembly build on the indexed data to answer questions like "what breaks if I change X?" in a single call.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,10 +45,13 @@ The only network activity is:
   - One-time download, cached in `~/.cache/huggingface/`
 
 - **LLM summaries** (`cqs index --llm-summaries`): Sends function code to the Anthropic API
+- **HyDE queries** (`cqs index --llm-summaries --hyde-queries`): Sends function descriptions to the Anthropic API for synthetic query generation
 
 | Flag | Endpoint | Data Sent | Notes |
 |------|----------|-----------|-------|
 | `--llm-summaries` | api.anthropic.com | Function bodies (up to 8000 chars), chunk type, language | Requires `ANTHROPIC_API_KEY`. Opt-in via `cqs index --llm-summaries` |
+| `--hyde-queries` | api.anthropic.com | Function NL descriptions, signatures | Requires `--llm-summaries`. Generates synthetic search queries per function |
+| `--improve-docs` | api.anthropic.com | Function bodies (for doc generation) | Requires `--llm-summaries`. Writes doc comments back to source files |
 
 No other network requests are made. Without `--llm-summaries`, all operations are offline.
 
@@ -79,6 +82,7 @@ No other network requests are made. Without `--llm-summaries`, all operations ar
 | `.cqs.toml` | Reference configuration | `cqs ref add`, `cqs ref remove` |
 | `~/.config/cqs/projects.toml` | Project registry | `cqs project register`, `cqs project remove` |
 | `~/.local/share/cqs/refs/*/` | Reference index creation and updates (write) | `cqs ref add`, `cqs ref update` |
+| Project source files | Doc comment insertion | `cqs index --llm-summaries --improve-docs` |
 
 ### Process Operations
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,10 @@
 //! - **Batch & chat modes**: Persistent session with pipeline syntax (`search "error" | callers | test-map`)
 //! - **Notes with sentiment**: Unified memory system for AI collaborators
 //! - **Multi-language**: 51 languages with multi-grammar injection (HTML→JS/CSS, Svelte, Vue, Razor, etc.)
+//! - **Type-aware embeddings**: Full signatures appended to NL descriptions for richer type discrimination
+//! - **Doc comment generation**: `--improve-docs` generates and writes doc comments to source files via LLM
+//! - **HyDE query predictions**: `--hyde-queries` generates synthetic search queries per function for improved recall
+//! - **Training data generation**: `train-data` command generates fine-tuning triplets from git history
 //! - **GPU acceleration**: CUDA/TensorRT with CPU fallback
 //! - **Document conversion**: PDF, HTML, CHM, Web Help → cleaned Markdown (optional `convert` feature)
 //!


### PR DESCRIPTION
## Summary
Pre-release docs review for v1.2.0. Fixes staleness from SQ-8/10/11/12 features.

- README: schema v16, remove stale note_weight/note_only, add new feature sections
- CONTRIBUTING: add doc_writer/ and train_data/ modules
- SECURITY: document --hyde-queries and --improve-docs network/file access
- PRIVACY: mention source file writes and API calls
- src/lib.rs: feature descriptions

## Test plan
- [x] Docs + lib.rs doc comment only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
