### PR TITLE
chore: Release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-03-24
+
+### Added
+- **Extension ChunkType** — Swift extensions, Objective-C categories, F# type extensions, Scala 3 extension definitions. Parser infrastructure wired (`capture_types`, `DEF_CAPTURES`).
+- **Constructor ChunkType** — Detects constructors across 10 languages: Python `__init__`, Java/C#/Razor `constructor_declaration`, Kotlin `init`, Swift `init`, VB.NET `Sub New`, Rust `new`, Go `New*`, C++ (no return type), PHP `__construct`. NL: "constructor for {parent}".
+- **Python/JS/TS constant capture** — UPPER_CASE module-level assignments as `ChunkType::Constant` with `post_process` filtering.
+- **`--json` flag on impact/review/ci/trace** — alias for `--format json`. Backward-compatible with existing `--format` flag.
+- **Batch/chat cache auto-invalidation** — mutable caches (HNSW, call graph, file set, notes) invalidate on `index.db` mtime change. `refresh`/`invalidate` command added.
+- **`tests/full_pipeline_eval.sh`** — full-pipeline hard eval script (55 queries against live cqs index).
+
+### Changed
+- **Read-only commands use single-thread runtime** — `Store::open_light()` with `current_thread` tokio runtime for 27 read-only commands. Full 256MB mmap/16MB cache preserved.
+- **Solidity events use `Event` ChunkType** instead of `Property`.
+- **Java `static final` fields promoted to `Constant`** instead of `Property`.
+- **Erlang `-define()` macros captured as `Macro`**.
+- **Bash `readonly` declarations captured as `Constant`**.
+- **R parser improved** — S4 classes (`setClass`), R6 classes (`R6Class`), UPPER_CASE constants.
+- **Lua parser improved** — UPPER_CASE constants (local and global).
+
+### Refactored
+- **`llm.rs` (2245 lines)** split into 6 submodules: client, prompts, batch, summary, doc_comments, hyde.
+- **`store/calls.rs` (1570 lines)** split into 6 submodules: types, crud, query, dead_code, test_map, related.
+- **`cli/batch/handlers.rs` (2082 lines)** split into 6 submodules: search, graph, analysis, info, misc.
+- **`search/scoring.rs` (1748 lines)** split into 5 submodules: config, name_match, note_boost, filter, candidate.
+
+### Fixed
+- **`--json` conflicts with `--format`** — clap `conflicts_with` prevents ambiguous `--json --format mermaid`.
+
+### Dependencies
+- Bumped `tree-sitter-rust` 0.24.0 → 0.24.1
+- Bumped `tree-sitter-fsharp` 0.1.0 → 0.2.2
+- Bumped `tracing-subscriber` 0.3.22 → 0.3.23
+- Bumped `toml` 1.0.6 → 1.0.7
+- Bumped `clap_complete` 4.5.66 → 4.6.0
+
 ## [1.3.1] - 2026-03-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Use it for:
 
 Fall back to Grep/Glob only for exact string matches or when semantic search returns nothing.
 
-**Key commands** (most support `--json`; `impact`, `review`, `ci`, and `trace` use `--format json` instead). Search is project-only by default — use `--include-refs` for cross-index, or `--ref <name>` for a specific reference:
+**Key commands** (`--json` works on all commands; `--format mermaid` also accepted on impact/trace). Search is project-only by default — use `--include-refs` for cross-index, or `--ref <name>` for a specific reference:
 - `cqs read <path>` — file contents with notes injected as comments. Use instead of raw `Read` for indexed source files.
 - `cqs read --focus <function>` — focused read: function + type dependencies only. Saves tokens.
 - `cqs similar <function>` — find code similar to a given function. Refactoring discovery, duplicates.
@@ -85,8 +85,8 @@ Fall back to Grep/Glob only for exact string matches or when semantic search ret
 - `cqs impact <function>` — what breaks if you change it. Callers + affected tests.
 - `cqs impact-diff [--base REF]` — diff-aware impact: changed functions, callers, tests to re-run.
 - `cqs batch` — batch mode: reads commands from stdin, outputs JSONL. Persistent Store + lazy Embedder. Supports pipeline syntax: `search "error" | callers | test-map` chains commands via fan-out.
-- `cqs review` — comprehensive diff review: impact-diff + notes + risk scoring. `--base`, `--format json`.
-- `cqs ci [--base REF] [--gate high|medium|off]` — CI pipeline: review + dead code + gate. Exit 3 on gate fail. `--format json` for structured output.
+- `cqs review` — comprehensive diff review: impact-diff + notes + risk scoring. `--base`, `--json`.
+- `cqs ci [--base REF] [--gate high|medium|off]` — CI pipeline: review + dead code + gate. Exit 3 on gate fail. `--json` for structured output.
 - `cqs test-map <function>` — map function to tests that exercise it.
 - `cqs trace <source> <target>` — shortest call path between two functions.
 - `cqs context <file>` — module-level overview: chunks, callers, callees, notes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,8 @@ src/
     batch/      - Batch mode: persistent Store + Embedder, stdin commands, JSONL output, pipeline syntax
       mod.rs      - BatchContext, vector index builder, main loop
       commands.rs - BatchInput/BatchCmd parsing, dispatch router
-      handlers.rs - Handler functions (one per command)
+      handlers/ - Handler functions (one per command)
+        mod.rs, analysis.rs, graph.rs, info.rs, misc.rs, search.rs
       pipeline.rs - Pipeline execution (pipe chaining via `|`)
       types.rs    - Output types (ChunkOutput, normalize_path)
     args.rs     - Shared CLI/batch arg structs via #[command(flatten)]
@@ -127,9 +128,11 @@ src/
   test_helpers.rs - Shared test fixtures module
   store/        - SQLite storage layer (Schema v16, WAL mode)
     mod.rs      - Store struct, open/init, FTS5, RRF fusion
-    chunks.rs   - Chunk CRUD, embedding_batches() for streaming
+    chunks/     - Chunk storage and retrieval
+      mod.rs, crud.rs, staleness.rs, embeddings.rs, query.rs, async_helpers.rs
     notes.rs    - Note CRUD, note_embeddings(), brute-force search
-    calls.rs    - Call graph storage and queries
+    calls/      - Call graph storage and queries
+      mod.rs, crud.rs, dead_code.rs, query.rs, related.rs, test_map.rs
     types.rs    - Type edge storage and queries
     helpers.rs  - Types, embedding conversion functions
     migrations.rs - Schema migration framework
@@ -146,7 +149,8 @@ src/
   reranker.rs   - Cross-encoder re-ranking (ms-marco-MiniLM-L-6-v2)
   search/       - Search algorithms, name matching, HNSW-guided search
     mod.rs      - search_filtered(), search_unified_with_index(), hybrid RRF
-    scoring.rs  - ScoringConfig, score normalization, RRF fusion constants
+    scoring/    - ScoringConfig, score normalization, RRF fusion constants
+      mod.rs, candidate.rs, config.rs, filter.rs, name_match.rs, note_boost.rs
     query.rs    - Query parsing, filter extraction
   math.rs       - Vector math utilities (cosine similarity, SIMD)
   hnsw/         - HNSW index with batched build, atomic writes
@@ -195,7 +199,8 @@ src/
   suggest.rs    - Auto-suggest notes from code patterns
   config.rs     - Configuration file support
   index.rs      - VectorIndex trait (HNSW, CAGRA)
-  llm.rs        - LLM summary generation, HyDE query predictions via Anthropic Batches API
+  llm/          - LLM summary generation, HyDE query predictions via Anthropic Batches API
+    mod.rs, batch.rs, doc_comments.rs, hyde.rs, prompts.rs, summary.rs
   doc_writer/   - Doc comment generation and source file rewriting (SQ-8, optional "llm-summaries" feature)
     mod.rs      - DocCommentResult, module exports
     formats.rs  - Per-language doc comment formatting (prefix, position, wrapping)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "1.3.1"
+version = "1.4.0"
 edition = "2021"
 rust-version = "1.93"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 51 languages, 92.7% Recall@1, 0.965 NDCG@10. Local ML, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,52 +2,52 @@
 
 ## Right Now
 
-**v7 CoIR complete (2026-03-22). Mixed result: +2.4pp CSN, -5.5pp hard eval. Specialization trade-off partially resolved.**
+**All evals and refactoring complete (2026-03-24). Contrastive summaries plan written. Ready for next experiment.**
 
-### v7 Results (complete)
-- Training: 200k subsample, GIST + Matryoshka + hard negs, 1ep, 6h53m on A6000
-- **CoIR overall: 49.19** (v5: 48.67, base: 49.48) — +0.52pp vs v5, only -0.29pp vs base
-- CoIR CSN: **0.707** (v5: 0.683, base: 0.627) — +2.4pp vs v5, best ever
-- CoIR CCR: 0.508 (v5: 0.490, base: 0.569) — partially recovered (+1.8pp vs v5)
-- v7 wins 6/9 CoIR tasks, loses 3
-- Hard eval R@1: **81.8%** (v5: 85.5%, base: 87.3%) — worse on adversarial pairs
-- **Key insight:** GIST + hard negs fix generalist degradation on realistic benchmarks but not adversarial confusable-function pairs
+### Final Model Results
 
-### Hard eval now supports local LoRA models
-- Modified `tests/model_eval.rs`: `EvalEmbedder` resolves local paths, `local_lora_models()` auto-discovers v5/v7
+| Eval | v7 | v7b | Base |
+|------|-----|------|------|
+| Hard eval (raw, 268 chunks) | 89.1% R@1 | 89.1% | 89.1% |
+| CoIR overall (9 tasks) | **49.19** | 49.03 | 49.48 |
+| CoIR CSN (6 langs) | **0.707** | 0.702 | 0.627 |
+| Full pipeline (6,867 chunks) | 65.4% R@1 | — | — |
 
-### Decision: ship v7 or stay on v5?
-- For cqs product (NL→code only): v7 is strictly better (0.707 vs 0.683 CSN)
-- For generalist: v7 nearly matches base (49.19 vs 49.48)
-- Hard eval regression means confusable functions (sorting variants, validators) get worse
-- v5 is safer; v7 is better for the primary use case
+**v7 unbalanced (200k) is the best model.** Shipped in v1.3.1. v7b balanced didn't improve.
 
-### Still possible: v7b balanced training
-- 46k/lang × 9 = 414k total — may further improve by fixing language imbalance
-- Language imbalance (82% in 3 langs) likely still dragging down results
+### What's merged since v1.3.1
+- PR #656: 5 issue fixes (--json alias, light runtime, chunks.rs split, batch cache invalidation)
+- PR #662: Extension ChunkType (Swift/ObjC/F#/Scala) + coverage gaps (7 langs)
+- PR #663: 4 file splits (llm/calls/handlers/scoring) + Constructor ChunkType (10 langs) + R/Lua improvements
+- 5 dependabot PRs (#657-661)
 
-## Session accomplishments
-- v1.3.0 released + 75 audit fixes (PRs #640-653)
-- Full 10-task CoIR controlled comparison: base 49.48, v5 48.67, v7 49.19
-- 9-language training data pipeline (extract → filter → mine)
-- Literature survey + paper draft v0.1
-- Novel ideas: call-graph false neg filtering, test-derived queries
-- All scripts quality-reviewed, backed up to github.com/jamie8johnson/cqs-training
-- v7 trained + evaluated — CoIR improved, hard eval degraded
-- Hard eval supports local LoRA models
+### Next experiments (prioritized)
+1. **Contrastive discriminating summaries** — plan written at `docs/superpowers/plans/2026-03-24-contrastive-summaries.md`. ~1.5h implementation. Brute-force cosine neighbors, contrastive prompt.
+2. **KeyDAC query augmentation** (free) — keyword-preserving training data augmentation
+3. **KD-LoRA distillation** — CodeSage-large (1.3B) → E5-base (110M). ~12h on A6000.
+
+### Pending Changes
+- `ROADMAP.md` — updated with ChunkType status, refactoring done, literature survey refs
+- `docs/superpowers/plans/2026-03-24-contrastive-summaries.md` — new plan
+- `tests/full_pipeline_eval.sh` — new eval script
 
 ## Parked
-- v7b balanced (46k/lang × 9 = 414k) — if imbalance is the remaining issue
-- Synthetic query augmentation, structural metadata — v8
-- Call-graph enriched training data — after balanced training proves concept
-- Language-specific LoRA adapters — if balanced training also fails
-- Paper revision — after shipping decision
-- Rebuild cqs binary + reindex + re-run --improve-all
+- Paper revision — after next training improvement
+- Verified HF eval results — needs CoIR benchmark registration
+- v7b epoch 2 — deprioritized (v7b didn't improve)
+- Full-pipeline hard eval with doc comments — costs API credits
+
+## Open Issues
+- #389: CAGRA memory retention (blocked on upstream cuVS)
+- #255: Pre-built reference packages (enhancement)
+- #106: ort pre-release RC
+- #63: paste crate warning (monitoring)
 
 ## Architecture
-- Version: 1.3.1, Schema: v16
-- Current model: LoRA v7 (200k 9-lang, GIST+Matryoshka, 0.707 CSN, 49.19 CoIR)
-- Hard eval: supports local LoRA models (tests/model_eval.rs)
-- Metrics: 92.7% R@1, 0.965 NDCG@10 (hard eval, DocFirst, with v5)
-- Tests: 1290 lib pass
+- Version: 1.4.0
+- Current model: LoRA v7 (200k 9-lang, GIST+Matryoshka, 0.707 CSN, 49.19 CoIR, 89.1% hard eval)
+- ChunkType: 20 variants (Extension: 4 langs, Constructor: 10 langs)
+- 4 large files split into submodules (llm, calls, handlers, scoring)
+- store/chunks.rs also split (PR #656)
+- Tests: 1867 pass
 - Telemetry: CQS_TELEMETRY=1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code intelligence and RAG for AI agents. Semantic search, call graph analysis, impact tracing, type dependencies, and smart context assembly — all in single tool calls. Local ML embeddings, GPU-accelerated.
 
-**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 92.7% Recall@1, 0.965 NDCG@10 on confusable function retrieval. 51 languages, GPU-accelerated.
+**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 89.1% Recall@1 on confusable function retrieval (92.7% with full enrichment pipeline). 51 languages, GPU-accelerated.
 
 [![Crates.io](https://img.shields.io/crates/v/cqs.svg)](https://crates.io/crates/cqs)
 [![CI](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml/badge.svg)](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml)
@@ -229,13 +229,13 @@ echo 'search "error handling" | callers | test-map' | cqs batch
 # Diff review: structured risk analysis of changes
 cqs review                                # review uncommitted changes
 cqs review --base main                    # review changes since main
-cqs review --format json                  # JSON output for CI integration
+cqs review --json                         # JSON output for CI integration
 
 # CI pipeline: review + dead code + gate (exit 3 on fail)
 cqs ci                                    # analyze uncommitted changes
 cqs ci --base main                        # analyze changes since main
 cqs ci --gate medium                      # fail on medium+ risk
-cqs ci --gate off --format json           # report only, JSON output
+cqs ci --gate off --json                  # report only, JSON output
 echo "$diff" | cqs ci --stdin             # pipe diff from CI system
 
 # Follow a call chain between two functions (BFS shortest path)
@@ -395,7 +395,7 @@ Without cqs, Claude uses grep/glob to find code and reads entire files for conte
 
 - **Fewer tool calls**: `gather`, `impact`, `trace`, `context`, `explain` each replace 5-10 sequential file reads with a single call
 - **Less context burn**: `cqs read --focus` returns a function + its type dependencies — not the whole file. Token budgeting (`--tokens N`) caps output across all commands.
-- **Find code by concept**: "function that retries with backoff" finds retry logic even if it's named `doWithAttempts`. 92.7% Recall@1, 0.965 NDCG@10 on confusable functions.
+- **Find code by concept**: "function that retries with backoff" finds retry logic even if it's named `doWithAttempts`. 89.1% Recall@1 on confusable functions (92.7% with full enrichment pipeline).
 - **Understand dependencies**: Call graphs, type dependencies, impact analysis, and risk scoring answer "what breaks if I change X?" without manual tracing
 - **Navigate unfamiliar codebases**: Semantic search + `cqs scout` + `cqs where` provide instant orientation without knowing project structure
 
@@ -411,7 +411,7 @@ Use `cqs` for semantic search, call graph analysis, and code intelligence instea
 - Trace dependencies and impact ("what breaks if I change X?")
 - Assemble context efficiently (one call instead of 5-10 file reads)
 
-Key commands (most support `--json`; `impact`, `review`, `ci`, and `trace` use `--format json` instead):
+Key commands (`--json` works on all commands; `--format mermaid` also accepted on impact/trace):
 - `cqs "query"` - semantic search (hybrid RRF by default, project-only)
 - `cqs "query" --include-refs` - also search configured reference indexes
 - `cqs "name" --name-only` - definition lookup (fast, no embedding)
@@ -442,8 +442,8 @@ Key commands (most support `--json`; `impact`, `review`, `ci`, and `trace` use `
 - `cqs plan "description"` - task planning: classify into 11 task-type templates + scout + checklist
 - `cqs task "description"` - implementation brief: scout + gather + impact + placement + notes in one call
 - `cqs onboard "concept"` - guided tour: entry point, call chain, callers, key types, tests
-- `cqs review` - diff review: impact-diff + notes + risk scoring. `--base`, `--format json`
-- `cqs ci` - CI pipeline: review + dead code in diff + gate. `--base`, `--gate`, `--format json`
+- `cqs review` - diff review: impact-diff + notes + risk scoring. `--base`, `--json`
+- `cqs ci` - CI pipeline: review + dead code in diff + gate. `--base`, `--gate`, `--json`
 - `cqs blame <function>` - semantic git blame: who changed a function, when, and why. `--callers` for affected callers
 - `cqs chat` - interactive REPL with readline, history, tab completion. Same commands as batch
 - `cqs batch` - batch mode: stdin commands, JSONL output. Pipeline syntax: `search "error" | callers | test-map`
@@ -538,7 +538,7 @@ cqs index --llm-summaries --max-hyde 200  # Limit HyDE query generation to N fun
 
 1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, constants, and documentation across 51 languages. Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
 2. **Describe** — Each code element gets a natural language description incorporating doc comments, parameter types, return types, and parent type context (e.g., methods include their struct/class name). Type-aware embeddings append full signatures for richer type discrimination (SQ-11). Optionally enriched with LLM-generated one-sentence summaries via `--llm-summaries`. This bridges the gap between how developers describe code and how it's written.
-3. **Embed** — E5-base-v2 generates 768-dimensional embeddings locally. 92.7% Recall@1, 0.965 NDCG@10 on confusable function retrieval — outperforms code-specific models because NL descriptions play to general-purpose model strengths. Optional HyDE query predictions (`--hyde-queries`) generate synthetic search queries per function for improved recall.
+3. **Embed** — E5-base-v2 generates 768-dimensional embeddings locally. 89.1% Recall@1 on confusable function retrieval (92.7% with full enrichment pipeline) — outperforms code-specific models because NL descriptions play to general-purpose model strengths. Optional HyDE query predictions (`--hyde-queries`) generate synthetic search queries per function for improved recall.
 4. **Enrich** — Call-graph-enriched embeddings prepend caller/callee context. Optional LLM summaries (via Claude Batches API) add one-sentence function purpose. `--improve-docs` generates and writes doc comments back to source files. Both cached by content_hash.
 5. **Index** — SQLite stores chunks, embeddings, call graph edges, and type dependency edges. HNSW provides fast approximate nearest-neighbor search. FTS5 enables keyword matching.
 6. **Search** — Hybrid RRF (Reciprocal Rank Fusion) combines semantic similarity with keyword matching. Optional cross-encoder re-ranking for highest accuracy.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,16 +55,20 @@ v1.3.0: `--improve-all` doc generation, LoRA v5 default model, Windows build fix
 
 ### ChunkType Variant Status
 
-All 16 variants shipped and used across languages. Only one potential new variant remains: `Extension` for Swift.
+20 variants shipped. Recent additions (PR #662, #663):
 
-| Variant | Shipped in | Used by |
-|---------|-----------|---------|
-| `Module` | v0.16.0 | F#, Ruby, TS (namespace) |
-| `Macro` | v0.17.0 | Rust, C (`#define(...)`) |
-| `TypeAlias` | v0.17.0 | Scala, Rust, TypeScript, Go, C, F#, SQL |
-| `Object` | v0.17.0 | Scala |
+| Variant | Used by |
+|---------|---------|
+| `Extension` | Swift, Objective-C (categories), F#, Scala 3 |
+| `Constructor` | Python, Java, C#, Kotlin, Swift, VB.NET, Rust, Go, C++, PHP, Razor |
+| `Constant` | Rust, Go, C, C++, Gleam, Ruby, PHP, GLSL, Python, JavaScript, TypeScript, Java, Erlang, Bash, R, Lua |
+| `Event` | C#, VB.NET, Solidity |
 
-Infrastructure for adding variants is now cheap: per-language LanguageDef fields, data-driven container extraction, dynamic callable SQL. New variant = enum arm + Display/FromStr + is_callable decision + nl.rs + capture_types.
+Infrastructure for adding variants is cheap: enum arm + Display/FromStr + is_callable + nl.rs + capture_types in parser.
+
+**Coverage gaps fixed (PR #662):** Python/JS/TS constants, Solidity events, Java static final → Constant, Erlang -define() → Macro, Bash readonly → Constant.
+
+**Language improvements (PR #663):** R: S4/R6 classes + UPPER_CASE constants. Lua: UPPER_CASE constants.
 
 ### Multi-Grammar Parsing
 
@@ -155,14 +159,22 @@ Ranked by difficulty / likely impact. 8 experiments + CoIR benchmark completed. 
 **Done (training improvements):**
 1. **Hard negative mining** — 1.89M pairs mined, 65% got hard negatives. GPU FAISS, CoRNStack recipe.
 2. **9-language training data** — CSN 6 + Stack Rust 56k, TS 58k, C++ 63k.
-3. **v7 (unbalanced, GIST+Matryoshka)** — Trained 200k subsample. **Result: degraded.** Hard eval R@1: 81.8% (v5: 85.5%, base: 87.3%). Language imbalance (82% in 3 langs) overwhelmed hard negatives.
+3. **v7 (unbalanced, GIST+Matryoshka)** — 200k subsample. **Best model.** CoIR 49.19, CSN 0.707, hard eval 89.1% (matches base). Shipped v1.3.1.
+4. **v7b balanced** — 414k (46k/lang × 9). **No improvement.** CSN -0.5pp vs v7. Balance doesn't help NL→code.
+5. **Resume-from-checkpoint** — `--resume-from-checkpoint` added to `train_lora.py`.
+6. **ONNX opset-11 export** — weight injection into base E5 graph. Integrated into `train_lora.py --export-onnx`.
 
-**Next:**
-4. **v7b balanced** — 46k/lang × 9 = 414k, equal language representation. Tests imbalance hypothesis. Quick — no new data.
-5. **Resume-from-checkpoint** — add `--resume-from-checkpoint` to `train_lora.py`. HF Trainer supports it natively. Enables multi-epoch training without restarting, checkpoint-and-eval at arbitrary points.
-6. **Language-specific LoRA adapters** — If balanced also fails. LoRACode showed per-language gains correlate with data size; we have 46-63k/lang.
-6. **Call-graph enriched training data** — Clone ~500 repos/lang, extract with structural context. Only after balanced training proves the concept.
-7. **Agent task eval** — telemetry (CQS_TELEMETRY=1) collecting data. Build eval from real agent usage patterns.
+**Next (training — plans written, ready to execute):**
+7. **KeyDAC query augmentation** ($0, ~1h code + 14-21h train) — keyword-preserving query rewrites. Preserve function name/param tokens, modify surrounding words (delete/swap/synonym). 200k pairs → ~600k augmented. Teaches phrasing robustness. Plan: `docs/superpowers/plans/2026-03-24-keydac-augmentation.md`. Python script in training-data repo.
+8. **Contrastive discriminating summaries** ($0, ~1.5h code) — brute-force cosine on embeddings to find top-3 neighbors, pass to LLM prompt: "unlike X, this function..." Index-time improvement in Rust cqs binary. Plan: `docs/superpowers/plans/2026-03-24-contrastive-summaries.md`.
+9. **LLM summary augmentation for training** (~$38) — generate discriminating summaries for 200k training pairs, add as additional (summary, code) query pairs. Enriches query side only. Script: `augment_with_summaries.py`.
+
+**Later:**
+10. **KD-LoRA distillation** (~12h on A6000) — distill CodeSage-large (1.3B, 64.18 CoIR) into E5-base (110M) via LoRA. Potentially largest single quality jump.
+11. **Language-specific LoRA adapters** — if improvements plateau. LoRACode approach.
+12. **Call-graph enriched training data** — clone repos, extract with structural context.
+13. **Publish training dataset to HuggingFace** — after confirming final dataset composition.
+14. **Agent task eval** — telemetry (CQS_TELEMETRY=1) collecting data.
 
 **Done:**
 - Sample size sweep (10k/50k/166k at 1ep) — 166k is optimal, more data at 1ep beats less data

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -1165,3 +1165,13 @@ mentions = [
     "research-log.md",
     "run_coir.py",
 ]
+
+[[note]]
+sentiment = 0.0
+text = "v7b balanced (414k, 46k/lang) did not improve over v7 unbalanced (200k). Natural language proportions beat equal representation for NL→code search. Balance only helps cross-language tasks (CCR, codetrans)."
+mentions = ["train_lora.py"]
+
+[[note]]
+sentiment = 0.5
+text = "Brute-force cosine for contrastive neighbors is fast enough: 1.3s for 10k chunks (768-dim matrix multiply). No need for HNSW or FTS approximation."
+mentions = ["llm/summary.rs"]

--- a/docs/superpowers/plans/2026-03-24-contrastive-summaries.md
+++ b/docs/superpowers/plans/2026-03-24-contrastive-summaries.md
@@ -1,0 +1,501 @@
+# Contrastive Discriminating Summaries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enhance LLM summary prompts with nearest-neighbor context so summaries say "unlike X, this function does Y" instead of generic descriptions. Exp 8 showed contrastive +18.2pp vs +16.3pp discriminating — a 1.9pp gain from neighbor context alone.
+
+**Architecture:** Within the existing `llm_summary_pass`, precompute a full pairwise cosine similarity matrix from chunk embeddings (already in SQLite at this pipeline stage), extract top-3 neighbors per chunk, pass neighbor names into `build_prompt` for contrastive prompting. No schema changes — summaries stored with existing `purpose = "summary"`.
+
+**Tech Stack:** Rust, ndarray, sqlx, Claude Batches API
+
+---
+
+## Constraints
+
+- **HNSW is NOT available during summary pass** — it's built after summaries (step 6 in pipeline). Embeddings ARE available (written in step 1).
+- **Brute-force cosine is fast** — benchmarked at 1.3s for 10k chunks (768-dim matrix multiply + top-3 extraction). Negligible vs 5-15 min API wait.
+- **ndarray** is already a dependency — used in HNSW and embedder.
+- **10,000 item batch cap** — neighbor precomputation is one-time, not per-item.
+- **`submit_doc_batch` and `submit_hyde_batch` are NOT affected** — they use separate prompt builders (`build_doc_prompt`, `build_hyde_prompt`) and keep their existing 4-tuple signatures.
+
+## Neighbor Strategy
+
+**Brute-force cosine on embeddings.** FTS name search was considered but rejected:
+- FTS phrase-prefix (`name:"merge sort"*`) only matches prefix variants of the same name — it will NOT find `heap_sort` from `merge_sort`.
+- Token-split OR (`name:sort`) is noisy and needs custom query logic.
+- Embedding cosine directly measures semantic similarity — exactly what we want.
+
+**Process:**
+1. Load all callable chunk embeddings from SQLite (one batch query)
+2. Build ndarray matrix (N × 768), L2-normalize rows
+3. Matrix multiply: `sims = embeddings @ embeddings.T` → N × N similarity matrix
+4. For each chunk, extract top-3 neighbors (excluding self, same language)
+5. Store as `HashMap<String, Vec<String>>` keyed by content_hash → neighbor names
+6. Look up neighbors per batch item during collection
+
+**Memory:** N × N × 4 bytes. At 10k chunks = 381 MB (brief, dropped after extraction). At 7k chunks (our index) = 187 MB.
+
+---
+
+### Task 1: Add `find_contrastive_neighbors` function
+
+**Files:**
+- Modify: `src/llm/summary.rs` — add neighbor computation function
+
+This is a standalone function (not a Store method) because it operates on in-memory embeddings, not the database.
+
+- [ ] **Step 1: Write tests**
+
+```rust
+#[cfg(test)]
+mod neighbor_tests {
+    #[test]
+    fn test_find_neighbors_basic() {
+        // 4 chunks: A (similar to B), C (similar to D), all Rust
+        // Verify A's neighbors include B, C's neighbors include D
+    }
+
+    #[test]
+    fn test_find_neighbors_excludes_self() {
+        // Verify chunk is never its own neighbor
+    }
+
+    #[test]
+    fn test_find_neighbors_respects_limit() {
+        // 10 similar chunks, limit=3, verify only 3 returned
+    }
+
+    #[test]
+    fn test_find_neighbors_empty_input() {
+        // Zero chunks → empty HashMap, no panic
+    }
+
+    #[test]
+    fn test_find_neighbors_single_chunk() {
+        // One chunk → no neighbors possible → empty vec
+    }
+}
+```
+
+- [ ] **Step 2: Implement `find_contrastive_neighbors`**
+
+```rust
+use ndarray::{Array2, Axis};
+
+/// Precompute top-N nearest neighbors for all chunks by cosine similarity.
+///
+/// Loads all callable chunk embeddings, builds a pairwise similarity matrix,
+/// and returns a map from content_hash to neighbor names.
+///
+/// This runs during `llm_summary_pass` Phase 1, when embeddings are in SQLite
+/// but HNSW is not yet built. Benchmarked at ~1.3s for 10k chunks.
+fn find_contrastive_neighbors(
+    store: &Store,
+    limit: usize,
+) -> Result<HashMap<String, Vec<String>>, LlmError> {
+    let _span = tracing::info_span!("find_contrastive_neighbors", limit).entered();
+
+    // Load all callable chunk identities + embeddings
+    // Use chunks_paged to iterate, filter callable, collect (content_hash, name, embedding)
+    let mut chunks: Vec<(String, String, Vec<f32>)> = Vec::new(); // (content_hash, name, embedding)
+
+    let mut cursor = 0i64;
+    loop {
+        let (page, next) = store.chunks_paged(cursor, 500)?;
+        if page.is_empty() { break; }
+        cursor = next;
+        for cs in &page {
+            if !cs.chunk_type.is_callable() { continue; }
+            if cs.content.len() < MIN_CONTENT_CHARS { continue; }
+            if cs.window_idx.is_some_and(|idx| idx > 0) { continue; }
+            // Fetch embedding for this chunk
+            // (batch this for efficiency)
+            chunks.push((cs.content_hash.clone(), cs.name.clone(), Vec::new())); // placeholder
+        }
+    }
+
+    if chunks.len() < 2 {
+        tracing::info!(count = chunks.len(), "Too few callable chunks for contrastive neighbors");
+        return Ok(HashMap::new());
+    }
+
+    // Batch-fetch embeddings by content_hash
+    let hashes: Vec<&str> = chunks.iter().map(|(h, _, _)| h.as_str()).collect();
+    let embeddings = store.get_embeddings_by_hashes(&hashes)?;
+
+    // Build matrix — only chunks with embeddings
+    let mut valid_chunks: Vec<(String, String, &[f32])> = Vec::new();
+    for (hash, name, _) in &chunks {
+        if let Some(emb) = embeddings.get(hash.as_str()) {
+            valid_chunks.push((hash.clone(), name.clone(), emb));
+        }
+    }
+
+    let n = valid_chunks.len();
+    if n < 2 {
+        return Ok(HashMap::new());
+    }
+
+    let dim = valid_chunks[0].2.len();
+    tracing::info!(chunks = n, dim, "Computing pairwise cosine similarity");
+
+    // Build ndarray matrix, L2-normalize
+    let mut matrix = Array2::<f32>::zeros((n, dim));
+    for (i, (_, _, emb)) in valid_chunks.iter().enumerate() {
+        for (j, &v) in emb.iter().enumerate() {
+            matrix[[i, j]] = v;
+        }
+        // L2-normalize row
+        let norm = matrix.row(i).mapv(|x| x * x).sum().sqrt();
+        if norm > 0.0 {
+            matrix.row_mut(i).mapv_inplace(|x| x / norm);
+        }
+    }
+
+    // Pairwise cosine = matrix @ matrix.T
+    let sims = matrix.dot(&matrix.t());
+
+    // Extract top-N neighbors per chunk (excluding self)
+    let mut result: HashMap<String, Vec<String>> = HashMap::new();
+    for i in 0..n {
+        let mut scored: Vec<(usize, f32)> = (0..n)
+            .filter(|&j| j != i)
+            .map(|j| (j, sims[[i, j]]))
+            .collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        let neighbors: Vec<String> = scored.iter()
+            .take(limit)
+            .map(|(j, _)| valid_chunks[*j].1.clone())
+            .collect();
+        if !neighbors.is_empty() {
+            result.insert(valid_chunks[i].0.clone(), neighbors);
+        }
+    }
+
+    let with_neighbors = result.len();
+    tracing::info!(total = n, with_neighbors, "Contrastive neighbors computed");
+
+    Ok(result)
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cargo test --lib -- llm::summary::neighbor_tests
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: brute-force cosine neighbor computation for contrastive summaries"
+```
+
+---
+
+### Task 2: Introduce `SummaryBatchItem` struct
+
+**Files:**
+- Modify: `src/llm/summary.rs` — define struct, use in batch collection
+- Modify: `src/llm/batch.rs` — update `submit_batch` signature
+
+Replace the 4-tuple with a named struct. This is cleaner than a 5-tuple and prevents positional confusion.
+
+- [ ] **Step 1: Define struct in `summary.rs`**
+
+```rust
+/// A chunk queued for LLM summary generation via the Batches API.
+pub(super) struct SummaryBatchItem {
+    pub content_hash: String,
+    pub content: String,
+    pub chunk_type: String,
+    pub language: String,
+    pub neighbors: Vec<String>,
+}
+```
+
+- [ ] **Step 2: Update `submit_batch` in `batch.rs`**
+
+```rust
+// Before:
+pub(super) fn submit_batch(&self, items: &[(String, String, String, String)], max_tokens: u32)
+// After:
+pub(super) fn submit_batch(&self, items: &[SummaryBatchItem], max_tokens: u32)
+```
+
+Map fields by name: `item.content_hash`, `item.content`, etc. Pass `&item.neighbors` to `build_prompt`.
+
+**Note:** `submit_doc_batch` and `submit_hyde_batch` keep their existing 4-tuple signatures — they use different prompt builders and don't need neighbors.
+
+- [ ] **Step 3: Update batch collection in `summary.rs`**
+
+Replace `batch_items.push((hash, content, type, lang))` with `batch_items.push(SummaryBatchItem { ... })`.
+
+- [ ] **Step 4: Update all 3 `submit_batch` call sites in `summary.rs`**
+
+These are at lines ~184, ~196, ~205 in `summary.rs`. All pass `&batch_items` — no change needed since the type changed.
+
+- [ ] **Step 5: Build and verify**
+
+```bash
+cargo build
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "refactor: replace batch item 4-tuple with SummaryBatchItem struct"
+```
+
+---
+
+### Task 3: Update `build_prompt` for contrastive mode
+
+**Files:**
+- Modify: `src/llm/prompts.rs`
+
+- [ ] **Step 1: Write tests**
+
+```rust
+#[test]
+fn test_build_prompt_no_neighbors_unchanged() {
+    let prompt = Client::build_prompt("fn foo() {}", "function", "rust", &[]);
+    assert!(prompt.contains("unique and distinguishable"));
+    assert!(!prompt.contains("similar to but different from"));
+}
+
+#[test]
+fn test_build_prompt_single_neighbor() {
+    let prompt = Client::build_prompt("fn merge_sort() {}", "function", "rust", &["heap_sort".into()]);
+    assert!(prompt.contains("heap_sort"));
+    assert!(prompt.contains("distinguishes"));
+}
+
+#[test]
+fn test_build_prompt_three_neighbors() {
+    let prompt = Client::build_prompt("fn merge_sort() {}", "function", "rust",
+        &["heap_sort".into(), "insertion_sort".into(), "quicksort".into()]);
+    assert!(prompt.contains("heap_sort"));
+    assert!(prompt.contains("insertion_sort"));
+    assert!(prompt.contains("quicksort"));
+}
+
+#[test]
+fn test_build_prompt_long_neighbor_names_within_budget() {
+    let long_name = "a".repeat(200);
+    let neighbors = vec![long_name.clone(), long_name.clone(), long_name.clone()];
+    let content = "x".repeat(7000);
+    let prompt = Client::build_prompt(&content, "function", "rust", &neighbors);
+    // Prompt should not exceed reasonable size (content is truncated to MAX_CONTENT_CHARS)
+    assert!(prompt.len() < 9000); // MAX_CONTENT_CHARS (8000) + prompt overhead + neighbor names
+}
+```
+
+- [ ] **Step 2: Add neighbors parameter to `build_prompt`**
+
+```rust
+fn build_prompt(content: &str, chunk_type: &str, language: &str, neighbors: &[String]) -> String {
+    let truncated = if content.len() > MAX_CONTENT_CHARS {
+        &content[..content.floor_char_boundary(MAX_CONTENT_CHARS)]
+    } else {
+        content
+    };
+    if neighbors.is_empty() {
+        // Existing discriminating prompt (unchanged)
+        format!(
+            "Describe what makes this {} unique and distinguishable from similar {}s. \
+             Focus on the specific algorithm, approach, or behavioral characteristics \
+             that distinguish it. One sentence only. Be specific, not generic.\n\n```{}\n{}\n```",
+            chunk_type, chunk_type, language, truncated
+        )
+    } else {
+        // Truncate neighbor list to avoid blowing prompt budget
+        let neighbor_list: String = neighbors.iter()
+            .take(5)
+            .map(|n| if n.len() > 60 { &n[..60] } else { n.as_str() })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "This {} is similar to but different from: {}. \
+             Describe what specifically distinguishes this {} from those. \
+             Focus on the algorithm, data structure, or behavioral difference. \
+             One sentence only. Be concrete.\n\n```{}\n{}\n```",
+            chunk_type, neighbor_list, chunk_type, language, truncated
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Update existing `build_prompt` tests (3 in prompts.rs)**
+
+Add `&[]` as 4th argument to the 3 existing test calls.
+
+- [ ] **Step 4: Update `submit_batch` call site in `batch.rs`**
+
+Pass `&item.neighbors` to `build_prompt`.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo test --lib -- llm::prompts
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat: contrastive prompt with embedding-based neighbor context"
+```
+
+---
+
+### Task 4: Wire neighbor precomputation into summary pass
+
+**Files:**
+- Modify: `src/llm/summary.rs`
+
+- [ ] **Step 1: Call `find_contrastive_neighbors` at start of Phase 1**
+
+Before the batch collection loop, compute all neighbors:
+
+```rust
+// Precompute contrastive neighbors from embedding similarity
+let neighbor_map = match find_contrastive_neighbors(store, 3) {
+    Ok(map) => map,
+    Err(e) => {
+        tracing::warn!(error = %e, "Contrastive neighbor computation failed, falling back to discriminating-only");
+        HashMap::new()
+    }
+};
+```
+
+**Design decision:** Neighbor computation failure is non-fatal. All chunks fall back to the existing discriminating prompt (empty neighbors).
+
+- [ ] **Step 2: Look up neighbors per batch item**
+
+In the batch collection loop, after building content/chunk_type/language:
+
+```rust
+let neighbors = neighbor_map
+    .get(&cs.content_hash)
+    .cloned()
+    .unwrap_or_default();
+
+batch_items.push(SummaryBatchItem {
+    content_hash: cs.content_hash.clone(),
+    content,
+    chunk_type: cs.chunk_type.to_string(),
+    language: cs.language.to_string(),
+    neighbors,
+});
+```
+
+- [ ] **Step 3: Add batch-level tracing**
+
+After the collection loop:
+
+```rust
+let with_neighbors = batch_items.iter().filter(|item| !item.neighbors.is_empty()).count();
+tracing::info!(
+    total = batch_items.len(),
+    with_neighbors,
+    without = batch_items.len() - with_neighbors,
+    "Summary batch items collected"
+);
+```
+
+- [ ] **Step 4: Build and test**
+
+```bash
+cargo build && cargo test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat: wire contrastive neighbors into LLM summary pass"
+```
+
+---
+
+### Task 5: Tests and documentation
+
+**Files:**
+- Modify: `src/llm/summary.rs` (tests)
+
+- [ ] **Step 1: Test neighbor failure fallback**
+
+```rust
+#[test]
+fn test_neighbor_failure_produces_empty_neighbors() {
+    // Verify that when neighbor_map is empty (simulating failure),
+    // batch items still get created with empty neighbors vec
+    let item = SummaryBatchItem {
+        content_hash: "abc".into(),
+        content: "fn foo() {}".into(),
+        chunk_type: "function".into(),
+        language: "rust".into(),
+        neighbors: Vec::new(),
+    };
+    // Prompt should be the non-contrastive variant
+    let prompt = Client::build_prompt(&item.content, &item.chunk_type, &item.language, &item.neighbors);
+    assert!(prompt.contains("unique and distinguishable"));
+}
+```
+
+- [ ] **Step 2: Manual smoke test**
+
+```bash
+# Delete existing summaries to force regeneration
+sqlite3 .cqs/index.db "DELETE FROM llm_summaries WHERE purpose = 'summary';"
+cqs index --llm-summaries 2>&1 | grep -E "neighbors|contrastive|Batch items"
+```
+
+Expected output:
+```
+Contrastive neighbors computed: total=2500, with_neighbors=2100
+Summary batch items collected: total=2500, with_neighbors=2100, without=400
+```
+
+- [ ] **Step 3: Add doc comment to `find_contrastive_neighbors`**
+
+Note the known limitations:
+- Neighbor names can become stale if chunks are added/removed (summaries cached by content_hash, not re-checked when neighbors change)
+- Functions with very common names (e.g., `new`, `init`) may get neighbors that are semantically unrelated — the embedding similarity handles this better than name matching would
+- Memory usage: N×N similarity matrix is brief (~200-400 MB for typical indexes)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "test: contrastive summary tests and documentation"
+```
+
+---
+
+## Estimated effort
+
+| Task | Time | Risk |
+|------|------|------|
+| 1. Neighbor computation | 30 min | Medium — ndarray matrix ops, embedding loading |
+| 2. Batch struct refactor | 15 min | Low — mechanical |
+| 3. Prompt update | 15 min | Low — string formatting |
+| 4. Wire into summary pass | 15 min | Low — map lookup |
+| 5. Tests + docs | 15 min | Low |
+| **Total** | **~1.5 hours** | |
+
+## Known limitations
+
+- **Neighbor staleness:** Contrastive summaries are cached by `content_hash`. If a neighbor is renamed or deleted, the summary still references the old name. Summaries only regenerate when the function's own content changes, not when its neighbors change. This is acceptable — summaries are approximations, and stale neighbor references don't break retrieval.
+- **Common names:** Functions named `new`, `init`, `test_*` may get semantically unrelated neighbors that happen to have similar embeddings. The contrastive prompt still improves over the non-contrastive version because the LLM sees the actual code, not just neighbor names.
+- **Memory:** The N×N similarity matrix uses N²×4 bytes. At 10k chunks = 381 MB, at 50k = 9.3 GB. For very large indexes, should switch to batched top-k (process chunks in groups, not full matrix). Current cqs indexes are <10k chunks.
+
+## What this does NOT include
+
+- **Training data augmentation** — this only affects index-time summaries. The `augment_with_summaries.py` script for training data is separate.
+- **Eval** — should re-run hard eval (both raw and full-pipeline) after deploying.
+
+## Dependencies
+
+- `ndarray` — already a dependency (used by HNSW, embedder).
+- `store.get_embeddings_by_hashes()` — exists in `src/store/chunks/embeddings.rs`.
+- `store.chunks_paged()` — exists in `src/store/chunks/query.rs`.
+- No schema changes. No new dependencies.

--- a/docs/superpowers/plans/2026-03-24-keydac-augmentation.md
+++ b/docs/superpowers/plans/2026-03-24-keydac-augmentation.md
@@ -1,0 +1,416 @@
+# KeyDAC-Style Query Augmentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Augment training data with keyword-preserving query rewrites. For each (query, code) pair, generate additional (augmented_query, code) pairs where important keywords are preserved but surrounding words are modified. This teaches the model robustness to query phrasing variations. Free — no API costs.
+
+**Architecture:** Python script that reads training JSONL, identifies keywords per query (via code component matching), applies augmentation operations while preserving keywords, outputs augmented JSONL. Run before `train_lora.py`.
+
+**Tech Stack:** Python, NLTK or simple tokenization
+
+**Reference:** KeyDAC (EACL 2023, Park et al.) — keyword-based data augmentation for contrastive code search.
+
+---
+
+## Background
+
+KeyDAC's core insight: when augmenting code search queries, don't modify the words that carry search intent. "sort array by key" — "sort" and "key" are important (they match the function name and parameter). "array" and "by" are less important and can be varied.
+
+**Keyword identification:** Match query tokens against code components:
+- Function name tokens (tokenized: `merge_sort` → `merge`, `sort`)
+- Parameter names (tokenized)
+- Doc comment tokens (if available)
+- Tokens that appear in the code but are not language stopwords
+
+**Augmentation operations** (applied to non-keyword tokens only):
+1. **Delete** — remove a non-keyword word: "sort array by key" → "sort by key"
+2. **Swap** — swap two adjacent non-keyword words: "find files matching pattern" → "find matching files pattern"
+3. **Synonym replace** — replace with a synonym: "check if valid" → "verify if valid"
+
+Each original pair generates 2-3 augmented pairs. Keywords are never modified.
+
+## Data Flow
+
+```
+combined_9lang_hard_negs.jsonl (1.89M pairs)
+  ↓ subsample (200k, seed 42 — same as v7)
+  ↓ augment_keydac.py (2-3x expansion)
+  ↓ augmented_200k.jsonl (~500k pairs)
+  ↓ train_lora.py --data augmented_200k.jsonl
+```
+
+---
+
+### Task 1: Write keyword extraction
+
+**Files:**
+- Create: `~/training-data/augment_keydac.py`
+
+- [ ] **Step 1: Implement `extract_keywords`**
+
+```python
+def extract_keywords(query: str, code: str) -> set[str]:
+    """Identify query tokens that match code components."""
+    query_tokens = set(tokenize(query.lower()))
+
+    # Extract code components
+    code_tokens = set()
+    # Function/method names (camelCase and snake_case split)
+    for token in re.findall(r'\b[a-zA-Z_]\w*\b', code):
+        code_tokens.update(split_identifier(token))
+
+    # Keywords = query tokens that appear in code components
+    # Plus: tokens that are nouns/verbs (content words) based on simple heuristic
+    keywords = query_tokens & code_tokens
+
+    # If no overlap found (rare), treat all content words as keywords
+    # to avoid destroying the query entirely
+    if not keywords:
+        keywords = {t for t in query_tokens if len(t) > 3}
+
+    return keywords
+```
+
+- [ ] **Step 2: Test keyword extraction**
+
+```python
+def test_extract_keywords():
+    assert "sort" in extract_keywords("sort array by key", "def sort_by_key(array, key):")
+    assert "key" in extract_keywords("sort array by key", "def sort_by_key(array, key):")
+    assert "array" in extract_keywords("sort array by key", "def sort_by_key(array, key):")
+    # "by" should NOT be a keyword (not in code identifiers)
+```
+
+- [ ] **Step 3: Implement `split_identifier`**
+
+```python
+def split_identifier(name: str) -> list[str]:
+    """Split camelCase and snake_case into tokens."""
+    # snake_case
+    if '_' in name:
+        return [t.lower() for t in name.split('_') if t]
+    # camelCase
+    tokens = re.sub(r'([A-Z])', r' \1', name).split()
+    return [t.lower() for t in tokens if t]
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: keyword extraction for KeyDAC augmentation"
+```
+
+---
+
+### Task 2: Write augmentation operations
+
+**Files:**
+- Modify: `~/training-data/augment_keydac.py`
+
+- [ ] **Step 1: Implement `augment_delete`**
+
+```python
+def augment_delete(tokens: list[str], keywords: set[str]) -> str | None:
+    """Remove one random non-keyword token."""
+    non_kw_indices = [i for i, t in enumerate(tokens) if t.lower() not in keywords]
+    if not non_kw_indices:
+        return None  # All tokens are keywords, can't delete
+    idx = random.choice(non_kw_indices)
+    result = tokens[:idx] + tokens[idx+1:]
+    return ' '.join(result) if result else None
+```
+
+- [ ] **Step 2: Implement `augment_swap`**
+
+```python
+def augment_swap(tokens: list[str], keywords: set[str]) -> str | None:
+    """Swap two adjacent non-keyword tokens."""
+    swappable = []
+    for i in range(len(tokens) - 1):
+        if tokens[i].lower() not in keywords and tokens[i+1].lower() not in keywords:
+            swappable.append(i)
+    if not swappable:
+        return None
+    idx = random.choice(swappable)
+    result = list(tokens)
+    result[idx], result[idx+1] = result[idx+1], result[idx]
+    return ' '.join(result)
+```
+
+- [ ] **Step 3: Implement `augment_synonym`**
+
+```python
+# Simple synonym table — no external dependency needed
+SYNONYMS = {
+    "find": ["search", "locate", "look up"],
+    "get": ["retrieve", "fetch", "obtain"],
+    "check": ["verify", "validate", "test"],
+    "create": ["make", "build", "generate"],
+    "remove": ["delete", "drop", "clear"],
+    "update": ["modify", "change", "set"],
+    "convert": ["transform", "parse", "map"],
+    "sort": ["order", "arrange", "rank"],
+    "filter": ["select", "extract", "pick"],
+    "count": ["tally", "enumerate", "total"],
+    "list": ["enumerate", "show", "display"],
+    "read": ["load", "parse", "open"],
+    "write": ["save", "store", "output"],
+    "split": ["divide", "separate", "partition"],
+    "merge": ["combine", "join", "concatenate"],
+    "compare": ["diff", "match", "contrast"],
+    # Add more as needed
+}
+
+def augment_synonym(tokens: list[str], keywords: set[str]) -> str | None:
+    """Replace one non-keyword token with a synonym."""
+    replaceable = [(i, t) for i, t in enumerate(tokens)
+                   if t.lower() not in keywords and t.lower() in SYNONYMS]
+    if not replaceable:
+        return None
+    idx, token = random.choice(replaceable)
+    syn = random.choice(SYNONYMS[token.lower()])
+    result = list(tokens)
+    result[idx] = syn
+    return ' '.join(result)
+```
+
+- [ ] **Step 4: Test augmentation operations**
+
+```python
+def test_augment_delete():
+    tokens = ["sort", "array", "by", "key"]
+    keywords = {"sort", "key"}
+    result = augment_delete(tokens, keywords)
+    assert "sort" in result and "key" in result
+    assert len(result.split()) == 3  # one token removed
+
+def test_augment_swap():
+    tokens = ["find", "all", "matching", "files"]
+    keywords = {"find", "files"}
+    result = augment_swap(tokens, keywords)
+    assert "find" in result and "files" in result
+
+def test_augment_all_keywords_returns_none():
+    tokens = ["sort", "key"]
+    keywords = {"sort", "key"}
+    assert augment_delete(tokens, keywords) is None
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat: KeyDAC augmentation operations (delete, swap, synonym)"
+```
+
+---
+
+### Task 3: Write the main augmentation pipeline
+
+**Files:**
+- Modify: `~/training-data/augment_keydac.py`
+
+- [ ] **Step 1: Implement main pipeline**
+
+```python
+def augment_pair(query: str, code: str, num_augments: int = 2) -> list[str]:
+    """Generate augmented queries for a (query, code) pair."""
+    keywords = extract_keywords(query, code)
+    tokens = query.split()
+
+    if len(tokens) < 3:
+        return []  # Too short to augment meaningfully
+
+    augmented = []
+    ops = [augment_delete, augment_swap, augment_synonym]
+
+    attempts = 0
+    while len(augmented) < num_augments and attempts < num_augments * 3:
+        op = random.choice(ops)
+        result = op(tokens, keywords)
+        if result and result != query and result not in augmented:
+            augmented.append(result)
+        attempts += 1
+
+    return augmented
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--max-samples", type=int, default=200000)
+    parser.add_argument("--augments-per-pair", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+
+    original = 0
+    augmented_count = 0
+
+    with open(args.input) as fin, open(args.output, 'w') as fout:
+        for line in fin:
+            d = json.loads(line)
+
+            # Write original pair
+            fout.write(line)
+            original += 1
+
+            # Generate augmented queries
+            aug_queries = augment_pair(d["query"], d["positive"], args.augments_per_pair)
+            for aug_q in aug_queries:
+                aug_record = dict(d)
+                aug_record["query"] = aug_q
+                fout.write(json.dumps(aug_record) + "\n")
+                augmented_count += 1
+
+            if original >= args.max_samples:
+                break
+
+    print(f"Original: {original}, Augmented: {augmented_count}")
+    print(f"Total: {original + augmented_count} pairs -> {args.output}")
+```
+
+- [ ] **Step 2: Test end-to-end**
+
+```bash
+# Quick test on 100 pairs
+python augment_keydac.py --input combined_9lang_hard_negs.jsonl --output test_aug.jsonl --max-samples 100
+wc -l test_aug.jsonl  # Should be ~300 (100 original + ~200 augmented)
+head -5 test_aug.jsonl  # Inspect quality
+```
+
+- [ ] **Step 3: Add progress reporting and stats**
+
+```python
+# Every 10k pairs, print progress
+# At end, print per-operation counts and keyword hit rate
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat: KeyDAC augmentation pipeline for training data"
+```
+
+---
+
+### Task 4: Generate augmented training data
+
+**Files:**
+- No code changes — run the script
+
+- [ ] **Step 1: Generate augmented dataset**
+
+```bash
+python augment_keydac.py \
+  --input combined_9lang_hard_negs.jsonl \
+  --output augmented_200k_keydac.jsonl \
+  --max-samples 200000 \
+  --augments-per-pair 2
+```
+
+Expected: ~600k pairs (200k original + ~400k augmented). Some pairs produce 0-1 augments (short queries, all keywords).
+
+- [ ] **Step 2: Inspect quality**
+
+```bash
+# Check augmented queries look reasonable
+python -c "
+import json, random
+lines = open('augmented_200k_keydac.jsonl').readlines()
+random.seed(42)
+for line in random.sample(lines, 10):
+    d = json.loads(line)
+    print(f'  {d[\"query\"][:80]}')
+"
+```
+
+- [ ] **Step 3: Push to cqs-training repo**
+
+```bash
+git add augment_keydac.py
+git commit -m "feat: KeyDAC query augmentation script"
+git push
+```
+
+---
+
+### Task 5: Train v8 with augmented data
+
+**Files:**
+- No new code — use existing `train_lora.py`
+
+- [ ] **Step 1: Train**
+
+```bash
+python train_lora.py \
+  --data augmented_200k_keydac.jsonl \
+  --output ./e5-code-search-lora-v8-keydac \
+  --epochs 1 --batch-size 32 \
+  --use-gist --matryoshka --export-onnx
+```
+
+ETA: ~14-21 hours on A6000 (600k pairs with GIST at ~3.5s/step).
+
+- [ ] **Step 2: Export opset-11 ONNX**
+
+The updated `train_lora.py --export-onnx` now handles this automatically (weight injection into opset-11 template).
+
+- [ ] **Step 3: Add v8-keydac to eval harness**
+
+Add `lora-v8-keydac` to `run_coir.py` and `local_lora_models()` in `model_eval.rs`.
+
+---
+
+### Task 6: Evaluate
+
+- [ ] **Step 1: Hard eval (raw)**
+
+```bash
+cargo test --features gpu-index --test model_eval --release -- test_hard_model_comparison --nocapture --ignored
+```
+
+Compare v8-keydac vs v7 vs base.
+
+- [ ] **Step 2: CoIR (full 9 tasks)**
+
+```bash
+python run_coir.py --model lora-v8-keydac --all
+```
+
+Compare overall, CSN, and CosQA transfer.
+
+- [ ] **Step 3: Update research log, roadmap, model card if improved**
+
+---
+
+## Estimated effort
+
+| Task | Time | Notes |
+|------|------|-------|
+| 1. Keyword extraction | 20 min | Simple token matching |
+| 2. Augmentation ops | 20 min | Delete/swap/synonym |
+| 3. Main pipeline | 15 min | JSONL reader/writer |
+| 4. Generate data | 5 min | ~200k pairs, fast |
+| 5. Train v8 | 14-21 hours | GPU time, unattended |
+| 6. Evaluate | 1-2 hours | Hard eval + CoIR |
+| **Total coding** | **~1 hour** | |
+| **Total wall time** | **~16-23 hours** | Dominated by training |
+
+## Expected impact
+
+- **CosQA transfer** — most likely to improve. CosQA queries are real web searches (terse, varied phrasing). Augmentation teaches robustness to phrasing variations.
+- **CSN** — moderate improvement. CSN queries are commit messages/docstrings (already well-formed). Less benefit from augmentation.
+- **Hard eval** — unlikely to change. Hard eval tests semantic discrimination, not query phrasing robustness.
+
+## Risks
+
+- **Quality degradation** — if augmentations are too aggressive (too many deletions, bad synonyms), the model learns noisy query→code mappings. Mitigation: preserve keywords, limit to 2 augments per pair, inspect sample quality.
+- **Training time increase** — 3x data = 3x training time with GIST. Could subsample augmented set to 200k total (66k original + 133k augmented) to keep training time constant.
+- **Synonym table gaps** — the hardcoded synonym table won't cover all code search vocabulary. Can expand iteratively. Missing synonyms just mean fewer augmentations, not wrong ones.
+
+## What this does NOT include
+
+- **Code-side augmentation** — only queries are augmented. Code passages stay unchanged (must match CoIR's raw-code evaluation).
+- **LLM-based augmentation** — KeyDAC is purely mechanical (no API costs). LLM discriminating summaries are a separate, complementary approach ($38).
+- **Contrastive neighbor context** — that's the separate contrastive summaries plan. KeyDAC and contrastive summaries are independent and can stack.

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,32 +1,22 @@
 ## Summary
-ChunkType coverage improvements across 11 languages:
+v1.4.0 release — ChunkType expansion, refactoring, and quality-of-life improvements.
 
-**Extension variant (4 languages):**
-- Swift: Extension for `extension Type { }` (already in main)
-- Objective-C: Extension for categories `@interface Type (Category)`
-- F#: Extension for type extensions `type MyType with ...`
-- Scala 3: Extension for `extension (x: Type) { ... }`
-- Infrastructure: wired `@extension` capture in parser chunk.rs and mod.rs
+**New ChunkTypes:**
+- Extension (Swift, ObjC, F#, Scala 3)
+- Constructor (10 languages)
+- Coverage gaps fixed: Python/JS/TS/Solidity/Java/Erlang/Bash/R/Lua
 
-**Coverage gaps fixed (7 languages):**
-- Python: UPPER_CASE module-level constants as Constant
-- JavaScript: `const` declarations (non-function) as Constant
-- TypeScript: `const` declarations (non-function) as Constant
-- Solidity: `event` declarations use Event ChunkType (was Property)
-- Java: `static final` fields promoted to Constant (was Property)
-- Erlang: `-define()` preprocessor macros as Macro
-- Bash: `readonly` declarations as Constant
+**Refactoring:**
+- 4 large files split into 23 submodules (7,645 lines reorganized)
 
-**Also:** Roadmap updates for contrastive summaries, algorithm detection, Constructor variant
+**Improvements:**
+- `--json` alias on impact/review/ci/trace
+- Single-thread runtime for 27 read-only commands
+- Batch/chat cache auto-invalidation on index change
 
 ## Test plan
-- [x] 1837 tests pass, 0 fail (+12 new tests)
+- [x] 1867 tests pass, 0 fail
+- [x] `cargo clippy` — clean
 - [x] `cargo fmt` — clean
-- [x] ObjC: 3 new tests (category interface, category implementation, regular class stays Class)
-- [x] F#: 1 new test (type extension)
-- [x] Scala: 1 new test (extension definition)
-- [x] Python: 1 new test (UPPER_CASE constants)
-- [x] JS/TS: 2 new tests (const declarations)
-- [x] Solidity/Java/Erlang/Bash: 4 new tests
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use thiserror::Error;
 
-// Model configuration - LoRA v3 fine-tuned E5-base-v2 for code search (SQ-7).
+// Model configuration - LoRA v7 fine-tuned E5-base-v2 for code search (SQ-7).
 // Override with CQS_EMBEDDING_MODEL env var to use a different model.
 const DEFAULT_MODEL_REPO: &str = "jamie8johnson/e5-base-v2-code-search";
 const MODEL_FILE: &str = "model.onnx";

--- a/tests/full_pipeline_eval.sh
+++ b/tests/full_pipeline_eval.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Full-pipeline hard eval — uses cqs search (enriched embeddings + RRF + FTS)
+# Run after: cqs index && cqs index --llm-summaries
+#
+# This tests the PRODUCTION search path, not raw embeddings like model_eval.rs.
+# Results are comparable to the 92.7% R@1 baseline (v5 + full pipeline).
+
+set -euo pipefail
+
+HITS=0
+TOTAL=0
+MISSES=""
+
+eval_query() {
+    local query="$1"
+    local expected="$2"
+    local lang="$3"
+    local also_accept="$4"  # comma-separated
+
+    TOTAL=$((TOTAL + 1))
+
+    # Search with cqs, get top-5 results as JSON
+    local results
+    results=$(cqs "$query" --lang "$lang" --json 2>/dev/null)
+
+    # Extract top-5 names
+    local top5
+    top5=$(echo "$results" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+names = [r['name'] for r in data.get('results', [])[:5]]
+print(' '.join(names))
+" 2>/dev/null)
+
+    local rank1
+    rank1=$(echo "$results" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+names = [r['name'] for r in data.get('results', [])[:10]]
+expected = '$expected'
+also = '$also_accept'.split(',') if '$also_accept' else []
+accept = [expected] + [a for a in also if a]
+for i, n in enumerate(names):
+    if n in accept:
+        print(i + 1)
+        sys.exit(0)
+print('miss')
+" 2>/dev/null)
+
+    if [ "$rank1" = "1" ]; then
+        HITS=$((HITS + 1))
+        echo "  + [$lang] \"$query\" -> $expected (rank 1) top5: $top5"
+    elif [ "$rank1" != "miss" ] && [ "$rank1" -le 5 ] 2>/dev/null; then
+        echo "  ~ [$lang] \"$query\" -> $expected (rank $rank1) top5: $top5"
+    else
+        echo "  - [$lang] \"$query\" -> $expected (rank $rank1) top5: $top5"
+        MISSES="$MISSES\n  [$lang] \"$query\" exp=$expected got=$top5"
+    fi
+}
+
+echo "=== Full Pipeline Hard Eval ==="
+echo "Model: $(cqs --version 2>&1)"
+echo ""
+
+# Rust (11)
+eval_query "stable sort preserving relative order of equal elements" "merge_sort" "rust" ""
+eval_query "sort using binary max-heap data structure" "heap_sort" "rust" ""
+eval_query "simple sort efficient for small nearly sorted arrays" "insertion_sort" "rust" ""
+eval_query "non-comparison integer sort processing digits" "radix_sort" "rust" ""
+eval_query "validate phone number with international country code" "validate_phone" "rust" ""
+eval_query "check if URL has valid protocol and hostname" "validate_url" "rust" ""
+eval_query "pad string to fixed width with fill character" "pad_string" "rust" ""
+eval_query "count number of words in text" "count_words" "rust" ""
+eval_query "extract numeric values from mixed text string" "extract_numbers" "rust" ""
+eval_query "stop calling service after consecutive failures" "CircuitBreaker" "rust" "should_allow,record_failure"
+eval_query "check whether circuit allows request through" "should_allow" "rust" "CircuitBreaker"
+
+# Python (11)
+eval_query "stable sort preserving relative order of equal elements" "merge_sort" "python" ""
+eval_query "sort using binary max-heap data structure" "heap_sort" "python" ""
+eval_query "simple sort efficient for small nearly sorted arrays" "insertion_sort" "python" ""
+eval_query "non-comparison integer sort processing digits" "radix_sort" "python" ""
+eval_query "validate phone number with international country code" "validate_phone" "python" ""
+eval_query "check if URL has valid protocol and hostname" "validate_url" "python" ""
+eval_query "pad string to fixed width with fill character" "pad_string" "python" ""
+eval_query "count number of words in text" "count_words" "python" ""
+eval_query "extract numeric values from mixed text string" "extract_numbers" "python" ""
+eval_query "stop calling service after consecutive failures" "CircuitBreaker" "python" "should_allow,record_failure"
+eval_query "check whether circuit allows request through" "should_allow" "python" "CircuitBreaker"
+
+# TypeScript (11)
+eval_query "stable sort preserving relative order of equal elements" "mergeSort" "typescript" ""
+eval_query "sort using binary max-heap data structure" "heapSort" "typescript" ""
+eval_query "simple sort efficient for small nearly sorted arrays" "insertionSort" "typescript" ""
+eval_query "non-comparison integer sort processing digits" "radixSort" "typescript" ""
+eval_query "validate phone number with international country code" "validatePhone" "typescript" ""
+eval_query "check if URL has valid protocol and hostname" "validateUrl" "typescript" ""
+eval_query "pad string to fixed width with fill character" "padString" "typescript" ""
+eval_query "count number of words in text" "countWords" "typescript" ""
+eval_query "extract numeric values from mixed text string" "extractNumbers" "typescript" ""
+eval_query "stop calling service after consecutive failures" "CircuitBreaker" "typescript" "shouldAllow,recordFailure"
+eval_query "check whether circuit allows request through" "shouldAllow" "typescript" "CircuitBreaker"
+
+# JavaScript (11)
+eval_query "stable sort preserving relative order of equal elements" "mergeSort" "javascript" ""
+eval_query "sort using binary max-heap data structure" "heapSort" "javascript" ""
+eval_query "simple sort efficient for small nearly sorted arrays" "insertionSort" "javascript" ""
+eval_query "non-comparison integer sort processing digits" "radixSort" "javascript" ""
+eval_query "validate phone number with international country code" "validatePhone" "javascript" ""
+eval_query "check if URL has valid protocol and hostname" "validateUrl" "javascript" ""
+eval_query "pad string to fixed width with fill character" "padString" "javascript" ""
+eval_query "count number of words in text" "countWords" "javascript" ""
+eval_query "extract numeric values from mixed text string" "extractNumbers" "javascript" ""
+eval_query "stop calling service after consecutive failures" "CircuitBreaker" "javascript" "shouldAllow,recordFailure"
+eval_query "check whether circuit allows request through" "shouldAllow" "javascript" "CircuitBreaker"
+
+# Go (11)
+eval_query "stable sort preserving relative order of equal elements" "MergeSort" "go" ""
+eval_query "sort using binary max-heap data structure" "HeapSort" "go" ""
+eval_query "simple sort efficient for small nearly sorted arrays" "InsertionSort" "go" ""
+eval_query "non-comparison integer sort processing digits" "RadixSort" "go" ""
+eval_query "validate phone number with international country code" "ValidatePhone" "go" ""
+eval_query "check if URL has valid protocol and hostname" "ValidateURL" "go" ""
+eval_query "pad string to fixed width with fill character" "PadString" "go" ""
+eval_query "count number of words in text" "CountWords" "go" ""
+eval_query "extract numeric values from mixed text string" "ExtractNumbers" "go" ""
+eval_query "stop calling service after consecutive failures" "CircuitBreakerGo" "go" "RecordFailure"
+eval_query "check whether circuit allows request through" "ShouldAllow" "go" "CircuitBreakerGo"
+
+echo ""
+echo "=== Results ==="
+echo "Recall@1: $HITS/$TOTAL ($(echo "scale=1; $HITS * 100 / $TOTAL" | bc)%)"
+if [ -n "$MISSES" ]; then
+    echo ""
+    echo "Misses:"
+    echo -e "$MISSES"
+fi


### PR DESCRIPTION
## Summary
v1.4.0 release — ChunkType expansion, refactoring, and quality-of-life improvements.

**New ChunkTypes:**
- Extension (Swift, ObjC, F#, Scala 3)
- Constructor (10 languages)
- Coverage gaps fixed: Python/JS/TS/Solidity/Java/Erlang/Bash/R/Lua

**Refactoring:**
- 4 large files split into 23 submodules (7,645 lines reorganized)

**Improvements:**
- `--json` alias on impact/review/ci/trace
- Single-thread runtime for 27 read-only commands
- Batch/chat cache auto-invalidation on index change

## Test plan
- [x] 1867 tests pass, 0 fail
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
