### PR TITLE
feat: contrastive LLM summaries + FTS path filter fix

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,35 +2,35 @@
 
 ## Right Now
 
-**v1.4.0 audit complete (2026-03-24). 70/74 findings fixed. Ready to merge.**
+**v1.4.1 released + contrastive summaries implemented (2026-03-24).**
 
-### Audit Results (v1.4.0)
-- 14-category audit, 3 batches, 74 unique findings
-- P1: 10/10 fixed (crashes, security, data loss)
-- P2: 15/15 fixed (correctness, performance, duplication)
-- P3: 37/37 fixed (docs, derives, spans, tests, small improvements)
-- P4: 8/12 fixed, 4 deferred (2 informational, 2 upstream-blocked)
-- Tests: 1916 pass (up from 1095 pre-audit), 0 failures, 0 warnings
-- Key fixes: Windows path separator bug, UTF-8 panic, API key exfiltration warning, LLM batch dedup (-215 lines), HNSW rollback safety, BFS batching, 29 new tests
+### Contrastive Summaries (SQ-10)
+- Brute-force cosine neighbors precomputed from embeddings during summary pass
+- Top-3 nearest neighbors passed to LLM prompt: "This function is similar to but different from: X, Y, Z"
+- Doc-comment shortcut removed — all callable chunks go through contrastive API path (~$0.38 one-time)
+- FTS path filter bug fixed — `--path` glob now applies to FTS keyword results too
+- Full-pipeline eval: **92.7% R@1, 96.3% R@5, 0.9478 NDCG@10** (55 queries, 5 languages)
+- 2 remaining misses: TS helper-function confusion (genuine hard cases)
 
 ### Uncommitted changes
-All audit fixes on `main` working tree — needs branch + PR + merge.
+- Contrastive summary implementation (`src/llm/summary.rs`, `src/llm/prompts.rs`, `src/llm/batch.rs`)
+- FTS path filter fix (`src/search/query.rs`)
+- Improved eval script (`tests/full_pipeline_eval.sh` — path scoping, R@1/R@5/R@10/NDCG metrics)
+- Audit skill update (mandatory `cqs health`/`cqs dead` first steps)
 
 ### Next experiments (prioritized)
-1. **Contrastive discriminating summaries** — plan at `docs/superpowers/plans/2026-03-24-contrastive-summaries.md`. ~1.5h implementation.
-2. **KeyDAC query augmentation** (free) — keyword-preserving training data augmentation
-3. **KD-LoRA distillation** — CodeSage-large (1.3B) → E5-base (110M). ~12h on A6000.
+1. **KeyDAC query augmentation** — plan at `docs/superpowers/plans/2026-03-24-keydac-augmentation.md`. ~1h code + 14-21h train.
+2. **KD-LoRA distillation** — CodeSage-large (1.3B) → E5-base (110M). ~12h on A6000.
 
 ### Next session
-1. **Merge audit PR** if not merged yet
-2. **Execute contrastive summaries** — Rust changes in `src/llm/summary.rs`
-3. **Execute KeyDAC augmentation** — plan at `docs/superpowers/plans/2026-03-24-keydac-augmentation.md`
+1. **Merge contrastive summaries PR** if not merged yet
+2. **Execute KeyDAC augmentation**
+3. **Re-run hard eval** with contrastive summaries in fixture embeddings (requires adding summary injection to eval test harness)
 
 ## Parked
 - Paper revision — after next training improvement
 - Verified HF eval results — needs CoIR benchmark registration
 - v7b epoch 2 — deprioritized (v7b didn't improve)
-- Full-pipeline hard eval with doc comments — costs API credits
 
 ## Open Issues
 - #665: RM-23 enrichment_pass ~105MB memory (deferred)
@@ -41,8 +41,9 @@ All audit fixes on `main` working tree — needs branch + PR + merge.
 - #63: paste crate warning (monitoring)
 
 ## Architecture
-- Version: 1.4.0 (released, tagged, published to crates.io)
-- Current model: LoRA v7 (200k 9-lang, GIST+Matryoshka, 0.707 CSN, 49.19 CoIR, 89.1% hard eval)
+- Version: 1.4.1 (released, tagged, published to crates.io)
+- Current model: LoRA v7 (200k 9-lang, GIST+Matryoshka, 0.707 CSN, 49.19 CoIR, 89.1% hard eval raw)
+- Full-pipeline: 92.7% R@1, 0.9478 NDCG@10 (with contrastive summaries + enrichment)
 - ChunkType: 20 variants (Extension: 4 langs, Constructor: 10 langs)
-- Tests: 1916 pass (post-audit)
+- Tests: 1916 pass
 - 5th full audit (v0.5.3, v0.12.3, v0.19.2, v1.0.13, v1.4.0)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Roadmap
 
-## Current: v1.4.0
+## Current: v1.4.1
 
-v1.4.0: Extension/Constructor ChunkTypes, batch cache invalidation, 4-file refactor split, R/Lua improvements. v1.4.0 audit: 70/74 findings fixed, 1916 tests. v1.3.0: `--improve-all` doc generation, LoRA v5 default model, Windows build fix, security deps, 75 audit fixes. 51 languages. Five full audits (v0.5.3, v0.12.3, v0.19.2, v1.0.13, v1.4.0). Usage telemetry. 9-language training data pipeline.
+v1.4.1: 70/74 audit findings fixed. Contrastive LLM summaries (embedding-neighbor context). FTS path filter fix. Full-pipeline eval: 92.7% R@1, 96.3% R@5, 0.9478 NDCG@10. v1.4.0: Extension/Constructor ChunkTypes, batch cache invalidation, 4-file refactor. 51 languages. Five full audits.
 
 ### 1.0.x Highlights
 

--- a/docs/research-log.md
+++ b/docs/research-log.md
@@ -662,3 +662,32 @@ Tested on 19 hard eval Rust functions. Both Haiku and Sonnet summaries **hurt** 
 **Summary augmentation (Dimension 4):** Script `~/training-data/augment_with_summaries.py` adds (discriminating_summary, code) pairs alongside (docstring, code) pairs. For our codebase, summaries are cached in cqs store. For CSN, would need ~$2 Haiku batch to generate. The discriminating summaries capture *what makes a function unique* — bridging abstract intent to concrete implementation. Free data augmentation for indexed codebases.
 
 **Note:** cqs users are always AI agents, not humans. Agent queries tend to be more precise and technical than human queries — "function that validates JWT tokens and checks expiration" rather than "JWT stuff." This affects which quality dimensions matter most: semantic depth (1) and abstraction level (4) over task breadth (2).
+
+### Exp 15: Contrastive Summaries (SQ-10b) — 2026-03-24
+
+**Implementation:** Brute-force pairwise cosine on all callable chunk embeddings (~12k chunks), extract top-3 nearest neighbors per chunk, pass neighbor names into LLM summary prompt. Prompt: "This function is similar to but different from: X, Y, Z. Describe what distinguishes it."
+
+**Key decisions:**
+- Removed doc-comment shortcut — all callable chunks go through contrastive API path (~$0.38 Haiku)
+- HNSW unavailable during summary pass (built after), so brute-force cosine on raw embeddings
+- Memory: 12k² × 4 = ~550MB brief allocation for similarity matrix
+- Summaries cached by content_hash — one-time cost per function
+
+**Bug found:** FTS keyword results in RRF fusion were NOT filtered by `--path` glob, causing eval fixture scaffolding (`HARD_EVAL_CASES` constant) to contaminate search results. Fixed by applying `compile_glob_filter` to FTS results in `finalize_results`.
+
+**Full-pipeline eval (55 queries, 5 languages, scoped to fixture files):**
+
+| Metric | Value |
+|--------|-------|
+| Recall@1 | 51/55 (92.7%) |
+| Recall@5 | 53/55 (96.3%) |
+| Recall@10 | 53/55 (96.3%) |
+| NDCG@10 | 0.9478 |
+
+**Misses (2):**
+- TS `mergeSort` — `_insertionSortSmall` helper ranked higher (semantically very close to "stable sort for small arrays")
+- TS `insertionSort` — `quicksort` ranked higher (both are comparison sorts)
+
+**Note:** Previous 65.4% R@1 baseline was measured with the FTS path filter bug — `HARD_EVAL_CASES` contaminated results. The 92.7% is the first clean full-pipeline measurement. Cannot directly compare to the buggy baseline.
+
+**Cost:** ~$0.38 one-time (2635 Haiku API calls × ~300 input tokens × ~50 output tokens). Incremental: $0.01-0.05 per session (only new/changed functions).

--- a/src/llm/batch.rs
+++ b/src/llm/batch.rs
@@ -76,17 +76,18 @@ impl Client {
         Ok(batch.id)
     }
 
-    /// Submit a batch of summary requests to the Batches API.
+    /// Submit a batch where prompts are already built (content field IS the prompt).
     ///
-    /// `items` is a list of (custom_id, content, chunk_type, language).
-    /// `max_tokens` controls the per-request token limit.
-    /// Returns the batch ID for polling.
-    pub(super) fn submit_batch(
+    /// Used by the contrastive summary path which pre-builds prompts with neighbor context.
+    pub(super) fn submit_batch_prebuilt(
         &self,
         items: &[(String, String, String, String)],
         max_tokens: u32,
     ) -> Result<String, LlmError> {
-        self.submit_batch_inner(items, max_tokens, "Batch", Self::build_prompt)
+        // Identity: content is already the full prompt, ignore field3/language
+        self.submit_batch_inner(items, max_tokens, "Batch", |content, _, _| {
+            content.to_string()
+        })
     }
 
     /// Submit a batch of doc-comment requests to the Batches API.

--- a/src/llm/prompts.rs
+++ b/src/llm/prompts.rs
@@ -3,7 +3,7 @@
 use super::{Client, MAX_CONTENT_CHARS};
 
 impl Client {
-    /// Build the prompt for a code chunk.
+    /// Build the discriminating prompt for a code chunk (no neighbor context).
     pub(super) fn build_prompt(content: &str, chunk_type: &str, language: &str) -> String {
         let truncated = if content.len() > MAX_CONTENT_CHARS {
             &content[..content.floor_char_boundary(MAX_CONTENT_CHARS)]
@@ -15,6 +15,42 @@ impl Client {
              Focus on the specific algorithm, approach, or behavioral characteristics \
              that distinguish it. One sentence only. Be specific, not generic.\n\n```{}\n{}\n```",
             chunk_type, chunk_type, language, truncated
+        )
+    }
+
+    /// Build a contrastive prompt with nearest-neighbor context.
+    ///
+    /// Tells the LLM about similar functions, producing summaries like
+    /// "unlike heap_sort, this function uses a divide-and-conquer merge strategy".
+    pub(super) fn build_contrastive_prompt(
+        content: &str,
+        chunk_type: &str,
+        language: &str,
+        neighbors: &[String],
+    ) -> String {
+        let truncated = if content.len() > MAX_CONTENT_CHARS {
+            &content[..content.floor_char_boundary(MAX_CONTENT_CHARS)]
+        } else {
+            content
+        };
+        let neighbor_list: String = neighbors
+            .iter()
+            .take(5)
+            .map(|n| {
+                if n.len() > 60 {
+                    &n[..n.floor_char_boundary(60)]
+                } else {
+                    n.as_str()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "This {} is similar to but different from: {}. \
+             Describe what specifically distinguishes this {} from those. \
+             Focus on the algorithm, data structure, or behavioral difference. \
+             One sentence only. Be concrete.\n\n```{}\n{}\n```",
+            chunk_type, neighbor_list, chunk_type, language, truncated
         )
     }
 
@@ -78,24 +114,37 @@ mod tests {
     #[test]
     fn test_build_prompt() {
         let prompt = Client::build_prompt("fn foo() {}", "function", "rust");
-        assert!(prompt.contains("function"));
+        assert!(prompt.contains("unique and distinguishable"));
         assert!(prompt.contains("```rust"));
         assert!(prompt.contains("fn foo()"));
+    }
+
+    #[test]
+    fn test_build_contrastive_prompt() {
+        let prompt = Client::build_contrastive_prompt(
+            "fn merge_sort() {}",
+            "function",
+            "rust",
+            &["heap_sort".into(), "quicksort".into()],
+        );
+        assert!(prompt.contains("heap_sort"));
+        assert!(prompt.contains("quicksort"));
+        assert!(prompt.contains("distinguishes"));
+        assert!(!prompt.contains("unique and distinguishable"));
     }
 
     #[test]
     fn test_build_prompt_truncation() {
         let long = "x".repeat(10000);
         let prompt = Client::build_prompt(&long, "function", "rust");
-        // Prompt should contain truncated content
-        assert!(prompt.len() < 10000 + 200); // prompt overhead + truncated
+        assert!(prompt.len() < 10000 + 200);
     }
 
     #[test]
     fn build_prompt_multibyte_no_panic() {
         let content: String = std::iter::repeat('あ').take(2667).collect();
         let prompt = Client::build_prompt(&content, "function", "rust");
-        assert!(prompt.len() <= 8300); // discriminating prompt is slightly longer
+        assert!(prompt.len() <= 8300);
     }
 
     // ===== build_doc_prompt tests =====

--- a/src/llm/summary.rs
+++ b/src/llm/summary.rs
@@ -1,7 +1,11 @@
 //! LLM summary pass orchestration — collects chunks, submits batches, stores results.
 
+use std::collections::HashMap;
+
+use ndarray::Array2;
+
 use super::batch::BatchPhase2;
-use super::{Client, LlmConfig, LlmError, MAX_BATCH_SIZE, MAX_CONTENT_CHARS, MIN_CONTENT_CHARS};
+use super::{Client, LlmConfig, LlmError, MAX_BATCH_SIZE, MIN_CONTENT_CHARS};
 use crate::Store;
 
 /// Run the LLM summary pass using the Batches API.
@@ -33,16 +37,22 @@ pub fn llm_summary_pass(
     })?;
     let client = Client::new(&api_key, llm_config)?;
 
-    let mut doc_extracted = 0usize;
     let mut cached = 0usize;
     let mut skipped = 0usize;
     let mut cursor = 0i64;
     const PAGE_SIZE: usize = 500;
 
+    // Phase 0: Precompute contrastive neighbors from embedding similarity
+    let neighbor_map = match find_contrastive_neighbors(store, 3) {
+        Ok(map) => map,
+        Err(e) => {
+            tracing::warn!(error = %e, "Contrastive neighbor computation failed, falling back to discriminating-only");
+            HashMap::new()
+        }
+    };
+
     // Phase 1: Collect chunks needing summaries
-    // Store doc-comment summaries immediately, collect API-needing chunks
-    let mut to_store: Vec<(String, String, String, String)> = Vec::new();
-    // (custom_id=content_hash, content, chunk_type, language) for batch API
+    // (custom_id=content_hash, prompt, chunk_type, language) for batch API
     let mut batch_items: Vec<(String, String, String, String)> = Vec::new();
     // Track content_hashes already queued to avoid duplicate custom_ids in batch
     let mut queued_hashes: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -82,32 +92,34 @@ pub fn llm_summary_pass(
                 continue;
             }
 
-            // Doc comment shortcut
-            if let Some(ref doc) = cs.doc {
-                if doc.len() > 10 {
-                    let first_sentence = extract_first_sentence(doc);
-                    if !first_sentence.is_empty() {
-                        to_store.push((
-                            cs.content_hash.clone(),
-                            first_sentence,
-                            "doc-comment".to_string(),
-                            "summary".to_string(),
-                        ));
-                        doc_extracted += 1;
-                        continue;
-                    }
-                }
-            }
+            // All chunks go through the contrastive API path (option 2).
+            // Doc-comment shortcut removed — contrastive summaries are more
+            // discriminating for retrieval than raw first-sentence extraction.
 
             // Queue for batch API (deduplicate by content_hash)
             if queued_hashes.insert(cs.content_hash.clone()) {
+                // Pre-build prompt with contrastive neighbor context if available
+                let neighbors = neighbor_map
+                    .get(&cs.content_hash)
+                    .cloned()
+                    .unwrap_or_default();
+                let prompt = if neighbors.is_empty() {
+                    Client::build_prompt(
+                        &cs.content,
+                        &cs.chunk_type.to_string(),
+                        &cs.language.to_string(),
+                    )
+                } else {
+                    Client::build_contrastive_prompt(
+                        &cs.content,
+                        &cs.chunk_type.to_string(),
+                        &cs.language.to_string(),
+                        &neighbors,
+                    )
+                };
                 batch_items.push((
                     cs.content_hash.clone(),
-                    if cs.content.len() > MAX_CONTENT_CHARS {
-                        cs.content[..cs.content.floor_char_boundary(MAX_CONTENT_CHARS)].to_string()
-                    } else {
-                        cs.content.clone()
-                    },
+                    prompt,
                     cs.chunk_type.to_string(),
                     cs.language.to_string(),
                 ));
@@ -126,16 +138,21 @@ pub fn llm_summary_pass(
         }
     }
 
-    // Store doc-comment summaries immediately
-    if !to_store.is_empty() {
-        store.upsert_summaries_batch(&to_store)?;
-    }
+    // Count how many batch items got contrastive neighbors
+    let with_neighbors = if neighbor_map.is_empty() {
+        0
+    } else {
+        batch_items
+            .iter()
+            .filter(|(hash, _, _, _)| neighbor_map.contains_key(hash))
+            .count()
+    };
 
     tracing::info!(
         cached,
-        doc_extracted,
         skipped,
         api_needed = batch_items.len(),
+        with_neighbors,
         "Summary scan complete"
     );
 
@@ -151,117 +168,127 @@ pub fn llm_summary_pass(
         &batch_items,
         &|s| s.get_pending_batch_id(),
         &|s, id| s.set_pending_batch_id(id),
-        &|c, items, max_tok| c.submit_batch(items, max_tok),
+        &|c, items, max_tok| c.submit_batch_prebuilt(items, max_tok),
     )?;
     let api_generated = api_results.len();
 
-    tracing::info!(
-        api_generated,
-        doc_extracted,
-        cached,
-        skipped,
-        "LLM summary pass complete"
-    );
+    tracing::info!(api_generated, cached, skipped, "LLM summary pass complete");
 
-    Ok(api_generated + doc_extracted)
+    Ok(api_generated)
 }
 
-/// Extract the first sentence from a doc comment.
-fn extract_first_sentence(doc: &str) -> String {
-    let trimmed = doc.trim();
-    if let Some(pos) = trimmed.find(['.', '!', '?']) {
-        let sentence = trimmed[..=pos].trim();
-        if sentence.len() > 10 {
-            return sentence.to_string();
+/// Precompute top-N nearest neighbors for all callable chunks by cosine similarity.
+///
+/// Loads all callable chunk embeddings from SQLite, builds a pairwise cosine similarity
+/// matrix via L2-normalized matrix multiply, and returns a map from content_hash to
+/// neighbor names. Used to generate contrastive LLM summaries ("unlike X, this does Y").
+///
+/// Runs during `llm_summary_pass` Phase 1, when embeddings are in SQLite but HNSW
+/// is not yet built. ~1.3s for 10k chunks.
+///
+/// Memory: N×N×4 bytes for the similarity matrix (~550MB at 12k callable chunks).
+/// The matrix is dropped after top-N extraction.
+fn find_contrastive_neighbors(
+    store: &Store,
+    limit: usize,
+) -> Result<HashMap<String, Vec<String>>, LlmError> {
+    let _span = tracing::info_span!("find_contrastive_neighbors", limit).entered();
+
+    // Collect callable chunk identities (content_hash, name)
+    let mut chunk_ids: Vec<(String, String)> = Vec::new(); // (content_hash, name)
+    let mut cursor = 0i64;
+    loop {
+        let (page, next) = store.chunks_paged(cursor, 500)?;
+        if page.is_empty() {
+            break;
+        }
+        cursor = next;
+        for cs in &page {
+            if !cs.chunk_type.is_callable() {
+                continue;
+            }
+            if cs.content.len() < MIN_CONTENT_CHARS {
+                continue;
+            }
+            if cs.window_idx.is_some_and(|idx| idx > 0) {
+                continue;
+            }
+            chunk_ids.push((cs.content_hash.clone(), cs.name.clone()));
         }
     }
-    let first_line = trimmed.lines().next().unwrap_or("").trim();
-    if first_line.len() > 10 {
-        first_line.to_string()
-    } else {
-        String::new()
+
+    if chunk_ids.len() < 2 {
+        tracing::info!(
+            count = chunk_ids.len(),
+            "Too few callable chunks for contrastive neighbors"
+        );
+        return Ok(HashMap::new());
     }
+
+    // Batch-fetch embeddings
+    let hashes: Vec<&str> = chunk_ids.iter().map(|(h, _)| h.as_str()).collect();
+    let embeddings = store.get_embeddings_by_hashes(&hashes)?;
+
+    // Filter to chunks with embeddings, build matrix
+    let mut valid: Vec<(&str, &str, &[f32])> = Vec::new(); // (hash, name, embedding)
+    for (hash, name) in &chunk_ids {
+        if let Some(emb) = embeddings.get(hash.as_str()) {
+            valid.push((hash, name, emb.as_slice()));
+        }
+    }
+
+    let n = valid.len();
+    if n < 2 {
+        return Ok(HashMap::new());
+    }
+
+    let dim = valid[0].2.len();
+    tracing::info!(chunks = n, dim, "Computing pairwise cosine similarity");
+
+    // Build L2-normalized ndarray matrix
+    let mut matrix = Array2::<f32>::zeros((n, dim));
+    for (i, (_, _, emb)) in valid.iter().enumerate() {
+        let mut row = matrix.row_mut(i);
+        for (j, &v) in emb.iter().enumerate() {
+            row[j] = v;
+        }
+        // L2-normalize
+        let norm = matrix.row(i).mapv(|x| x * x).sum().sqrt();
+        if norm > 0.0 {
+            matrix.row_mut(i).mapv_inplace(|x| x / norm);
+        }
+    }
+
+    // Pairwise cosine = normalized @ normalized.T
+    let sims = matrix.dot(&matrix.t());
+
+    // Extract top-N neighbors per chunk (excluding self)
+    let mut result: HashMap<String, Vec<String>> = HashMap::with_capacity(n);
+    for i in 0..n {
+        let row = sims.row(i);
+        // Partial sort: collect (index, score) pairs, sort desc, take top-N
+        let mut scored: Vec<(usize, f32)> =
+            (0..n).filter(|&j| j != i).map(|j| (j, row[j])).collect();
+        scored.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
+        let neighbors: Vec<String> = scored
+            .iter()
+            .take(limit)
+            .map(|(j, _)| valid[*j].1.to_string())
+            .collect();
+        if !neighbors.is_empty() {
+            result.insert(valid[i].0.to_string(), neighbors);
+        }
+    }
+
+    let with_neighbors = result.len();
+    tracing::info!(total = n, with_neighbors, "Contrastive neighbors computed");
+
+    Ok(result)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_extract_first_sentence_period() {
-        assert_eq!(
-            extract_first_sentence("Parse a config file. Returns validated settings."),
-            "Parse a config file."
-        );
-    }
-
-    #[test]
-    fn test_extract_first_sentence_no_period() {
-        assert_eq!(
-            extract_first_sentence("Parse a config file and return settings"),
-            "Parse a config file and return settings"
-        );
-    }
-
-    #[test]
-    fn test_extract_first_sentence_short() {
-        assert_eq!(extract_first_sentence("Hi."), "");
-    }
-
-    #[test]
-    fn test_extract_first_sentence_multiline() {
-        assert_eq!(
-            extract_first_sentence("Parse a config file.\n\nThis handles TOML and JSON."),
-            "Parse a config file."
-        );
-    }
-
-    #[test]
-    fn extract_first_sentence_url_with_period() {
-        // URL period — cuts at first period in domain (known behavior, not a bug)
-        let r = extract_first_sentence("See https://example.com. Usage guide.");
-        assert_eq!(r, "See https://example.");
-    }
-
-    #[test]
-    fn extract_first_sentence_short_falls_to_line() {
-        // "Short." is 6 chars <=10, falls to first line
-        let r = extract_first_sentence("Short. More text here.");
-        assert_eq!(r, "Short. More text here.");
-    }
-
-    #[test]
-    fn extract_first_sentence_exclamation() {
-        let r = extract_first_sentence("This is great! More.");
-        assert_eq!(r, "This is great!");
-    }
-
-    #[test]
-    fn extract_first_sentence_question() {
-        let r = extract_first_sentence("Is this working? Yes.");
-        assert_eq!(r, "Is this working?");
-    }
-
-    #[test]
-    fn extract_first_sentence_whitespace_only() {
-        assert_eq!(extract_first_sentence("   \n  \t  "), "");
-    }
-
-    #[test]
-    fn extract_first_sentence_empty_input() {
-        assert_eq!(extract_first_sentence(""), "");
-    }
-
-    #[test]
-    fn extract_first_sentence_boundary_11_chars() {
-        assert_eq!(extract_first_sentence("1234567890."), "1234567890.");
-    }
-
-    #[test]
-    fn extract_first_sentence_short_multiline() {
-        // Both sentence and first line too short
-        assert_eq!(extract_first_sentence("OK.\nMore"), "");
-    }
 
     // ===== TC-22: LLM pass chunk filtering condition tests =====
     //

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -172,7 +172,13 @@ impl Store {
             let scored = score_heap.into_sorted_vec();
 
             let results = self
-                .finalize_results(scored, &filter.query_text, fsql.use_rrf, limit)
+                .finalize_results(
+                    scored,
+                    &filter.query_text,
+                    fsql.use_rrf,
+                    limit,
+                    filter.path_pattern.as_deref(),
+                )
                 .await?;
 
             tracing::debug!(count = results.len(), "search_filtered complete");
@@ -195,6 +201,7 @@ impl Store {
         query_text: &str,
         use_rrf: bool,
         limit: usize,
+        path_pattern: Option<&str>,
     ) -> Result<Vec<SearchResult>, StoreError> {
         // Step 1: RRF fusion with FTS keyword search, or plain truncate
         let final_scored: Vec<(String, f32)> = if use_rrf {
@@ -210,7 +217,20 @@ impl Store {
                 .bind((limit * 3) as i64)
                 .fetch_all(&self.pool)
                 .await?;
-                fts_rows.into_iter().map(|(id,)| id).collect()
+                // Apply path filter to FTS results (FTS5 doesn't support JOIN filtering)
+                let fts_all: Vec<String> = fts_rows.into_iter().map(|(id,)| id).collect();
+                let path_owned = path_pattern.map(String::from);
+                if let Some(fts_glob) = compile_glob_filter(path_owned.as_ref()) {
+                    fts_all
+                        .into_iter()
+                        .filter(|id| {
+                            let file = extract_file_from_chunk_id(id);
+                            fts_glob.is_match(file)
+                        })
+                        .collect()
+                } else {
+                    fts_all
+                }
             };
             let semantic_ids: Vec<&str> = scored.iter().map(|(id, _)| id.as_str()).collect();
             // Request extra candidates from RRF to compensate for parent dedup
@@ -392,8 +412,14 @@ impl Store {
             let scored: Vec<(String, f32)> =
                 scored.into_iter().map(|(c, score)| (c.id, score)).collect();
 
-            self.finalize_results(scored, &filter.query_text, use_rrf, limit)
-                .await
+            self.finalize_results(
+                scored,
+                &filter.query_text,
+                use_rrf,
+                limit,
+                filter.path_pattern.as_deref(),
+            )
+            .await
         })
     }
 

--- a/tests/full_pipeline_eval.sh
+++ b/tests/full_pipeline_eval.sh
@@ -8,8 +8,11 @@
 set -euo pipefail
 
 HITS=0
+HITS5=0
+HITS10=0
 TOTAL=0
 MISSES=""
+RANKS=""
 
 eval_query() {
     local query="$1"
@@ -19,9 +22,9 @@ eval_query() {
 
     TOTAL=$((TOTAL + 1))
 
-    # Search with cqs, get top-5 results as JSON
+    # Search with cqs, scoped to fixture files (exclude production code and eval scaffolding)
     local results
-    results=$(cqs "$query" --lang "$lang" --json 2>/dev/null)
+    results=$(cqs "$query" --lang "$lang" --path "tests/fixtures/**" --json 2>/dev/null)
 
     # Extract top-5 names
     local top5
@@ -47,14 +50,27 @@ for i, n in enumerate(names):
 print('miss')
 " 2>/dev/null)
 
-    if [ "$rank1" = "1" ]; then
-        HITS=$((HITS + 1))
-        echo "  + [$lang] \"$query\" -> $expected (rank 1) top5: $top5"
-    elif [ "$rank1" != "miss" ] && [ "$rank1" -le 5 ] 2>/dev/null; then
-        echo "  ~ [$lang] \"$query\" -> $expected (rank $rank1) top5: $top5"
-    else
-        echo "  - [$lang] \"$query\" -> $expected (rank $rank1) top5: $top5"
+    if [ "$rank1" = "miss" ]; then
+        echo "  - [$lang] \"$query\" -> $expected (rank miss) top5: $top5"
         MISSES="$MISSES\n  [$lang] \"$query\" exp=$expected got=$top5"
+        RANKS="$RANKS 0"
+    else
+        RANKS="$RANKS $rank1"
+        if [ "$rank1" -le 1 ] 2>/dev/null; then
+            HITS=$((HITS + 1))
+            HITS5=$((HITS5 + 1))
+            HITS10=$((HITS10 + 1))
+            echo "  + [$lang] \"$query\" -> $expected (rank 1) top5: $top5"
+        elif [ "$rank1" -le 5 ] 2>/dev/null; then
+            HITS5=$((HITS5 + 1))
+            HITS10=$((HITS10 + 1))
+            echo "  ~ [$lang] \"$query\" -> $expected (rank $rank1) top5: $top5"
+        elif [ "$rank1" -le 10 ] 2>/dev/null; then
+            HITS10=$((HITS10 + 1))
+            echo "  . [$lang] \"$query\" -> $expected (rank $rank1) top5: $top5"
+        else
+            echo "  - [$lang] \"$query\" -> $expected (rank $rank1) top5: $top5"
+        fi
     fi
 }
 
@@ -120,7 +136,7 @@ eval_query "sort using binary max-heap data structure" "HeapSort" "go" ""
 eval_query "simple sort efficient for small nearly sorted arrays" "InsertionSort" "go" ""
 eval_query "non-comparison integer sort processing digits" "RadixSort" "go" ""
 eval_query "validate phone number with international country code" "ValidatePhone" "go" ""
-eval_query "check if URL has valid protocol and hostname" "ValidateURL" "go" ""
+eval_query "check if URL has valid protocol and hostname" "ValidateURL" "go" "ValidateUrl"
 eval_query "pad string to fixed width with fill character" "PadString" "go" ""
 eval_query "count number of words in text" "CountWords" "go" ""
 eval_query "extract numeric values from mixed text string" "ExtractNumbers" "go" ""
@@ -129,7 +145,20 @@ eval_query "check whether circuit allows request through" "ShouldAllow" "go" "Ci
 
 echo ""
 echo "=== Results ==="
-echo "Recall@1: $HITS/$TOTAL ($(echo "scale=1; $HITS * 100 / $TOTAL" | bc)%)"
+echo "Recall@1:  $HITS/$TOTAL ($(echo "scale=1; $HITS * 100 / $TOTAL" | bc)%)"
+echo "Recall@5:  $HITS5/$TOTAL ($(echo "scale=1; $HITS5 * 100 / $TOTAL" | bc)%)"
+echo "Recall@10: $HITS10/$TOTAL ($(echo "scale=1; $HITS10 * 100 / $TOTAL" | bc)%)"
+
+# Compute NDCG@10
+NDCG=$(echo "$RANKS" | python3 -c "
+import sys, math
+ranks = [int(x) for x in sys.stdin.read().split() if x]
+dcg = sum(1.0 / math.log2(r + 1) for r in ranks if r > 0)
+idcg = len(ranks) * 1.0  # ideal: all at rank 1 = 1/log2(2) = 1.0
+print(f'{dcg / idcg:.4f}' if idcg > 0 else '0.0000')
+")
+echo "NDCG@10:   $NDCG"
+
 if [ -n "$MISSES" ]; then
     echo ""
     echo "Misses:"


### PR DESCRIPTION
## Summary

- **Contrastive LLM summaries** — precompute top-3 embedding neighbors per chunk, pass to LLM prompt. Produces summaries like "unlike heap_sort, this uses divide-and-conquer merging" instead of generic descriptions.
- **FTS path filter fix** — `--path` glob now applies to FTS keyword results in RRF fusion. Previously only the semantic path was filtered, causing unscoped results to contaminate rankings.
- **Eval improvements** — `full_pipeline_eval.sh` scoped to fixture files, reports R@1/R@5/R@10/NDCG@10, accepts case variants.

Full-pipeline eval: **92.7% R@1, 96.3% R@5, 0.9478 NDCG@10** (55 queries, 5 languages).

## Test plan
- [x] `cargo test --features gpu-index` — 1361 lib tests pass
- [x] `cargo clippy --features gpu-index` — clean
- [x] `bash tests/full_pipeline_eval.sh` — 92.7% R@1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
