### PR TITLE
fix: pin cuvs to =26.2 (CUDA 13 incompatibility)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "cuvs"
-version = "26.4.0"
+version = "26.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc05a465fc106bc0782fb975009ff38f50faedca6adf4dfecea08932be2f3fc"
+checksum = "9778fa1e16f42539772496e9adba2a29c67dca84bcb0d247795f9cb3135ba87d"
 dependencies = [
  "cuvs-sys",
  "ndarray 0.15.6",
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "cuvs-sys"
-version = "26.4.0"
+version = "26.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c41a89bdfe3960aae8746c43016f0909ada1c9efc933d9e26006223aeeb51"
+checksum = "d4cad121da7a7ac908965352ffeac029a93fb0e3a1278a271f7204098b8724e9"
 dependencies = [
  "bindgen",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ keyring = { version = "3", optional = true }
 # Vector search (HNSW default, cuVS optional)
 hnsw_rs = "0.3"
 simsimd = "6"
-cuvs = { version = "26.4", optional = true }
+cuvs = { version = "=26.2", optional = true }  # pinned — 26.4 requires CUDA <13, we run CUDA 13.1
 
 # Text processing
 regex = "1"


### PR DESCRIPTION
## Summary

- Pin `cuvs` back to `=26.2` (dependabot PR #871 bumped to 26.4, which requires CUDA <13 and breaks our CUDA 13.1 workstation)
- Add inline comment so future dependabot bumps get rejected by the constraint rather than silently breaking local builds

## Context

`libcuvs 26.04.00` from rapidsai ships with `cuda-version >=12,<13.0a0`. We run CUDA 13.1, and conda refuses to install the 26.04 libcuvs at all. Build fails at `cuvs-sys` CMake discovery with:

```
Could not find a configuration file for package "cuvs" that is compatible with requested version "26.04.00".
The following configuration files were considered but not accepted:
  /home/user001/miniforge3/lib/cmake/cuvs/cuvs-config.cmake, version: 26.02.0
```

## Test plan

- [x] `cargo build --features gpu-index` succeeds locally with 26.2 pin
- [x] `cargo fmt --check` clean
- [ ] CI green
