### PR TITLE
feat: CQS_DISABLE_BASE_INDEX env var for Phase 5 A/B testing

### DIFF
--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -261,6 +261,7 @@ pub(crate) fn build_vector_index_with_config(
 /// Returns `Ok(None)` when:
 /// - The `index_base.hnsw.*` files don't exist (e.g. fresh v17→v18 migration)
 /// - The store is flagged `hnsw_dirty` (interrupted write)
+/// - `CQS_DISABLE_BASE_INDEX=1` is set in the environment (eval A/B testing)
 /// - CAGRA is preferred for the enriched index; we never build CAGRA for the
 ///   base — the base path is a narrow router decision, not a hot path, so
 ///   plain HNSW is sufficient
@@ -271,6 +272,15 @@ pub(crate) fn build_base_vector_index(
     cqs_dir: &Path,
 ) -> Result<Option<Box<dyn cqs::index::VectorIndex>>> {
     let _span = tracing::info_span!("build_base_vector_index").entered();
+
+    // Eval A/B bypass: forces fallback to enriched even when index_base exists.
+    // Lets us measure the marginal contribution of routing on the same corpus
+    // without rebuilding the index.
+    if std::env::var("CQS_DISABLE_BASE_INDEX").as_deref() == Ok("1") {
+        tracing::info!("CQS_DISABLE_BASE_INDEX=1 — base index bypass active");
+        return Ok(None);
+    }
+
     if store.is_hnsw_dirty().unwrap_or(true) {
         tracing::warn!(
             "Base HNSW index may be stale (dirty flag set) — router falls back to enriched"


### PR DESCRIPTION
## Summary

Adds `CQS_DISABLE_BASE_INDEX=1` runtime bypass so we can A/B-test Phase 5 dual-index routing on the same indexed corpus without re-indexing.

## Why

After PR #876 landed I needed to measure dual-routing's marginal effect. Running the eval twice — once with my normal Phase 5 binary, once against an older binary built without dual indexing — gives a *baseline drift* artifact: the chunk universe between runs isn't identical (re-index changes content hashes, ordering, summary cache hits). Categories that aren't even routed differently still swing ±10pp on N=27.

The clean way: same binary, same `.cqs/`, same indexed corpus. Just toggle whether `build_base_vector_index` returns the loaded base index or `None`. When the env var is set, the router falls back to enriched for every query — identical to pre-Phase-5 behavior on the exact same data.

## What

Single early-return at the top of `build_base_vector_index`:

```rust
if std::env::var("CQS_DISABLE_BASE_INDEX").as_deref() == Ok("1") {
    tracing::info!("CQS_DISABLE_BASE_INDEX=1 — base index bypass active");
    return Ok(None);
}
```

Documented in the function's doc comment alongside the other "returns None when..." conditions.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo fmt --check` clean
- [x] Smoke: `cqs "validates user input"` with bypass on logs `CQS_DISABLE_BASE_INDEX=1 — base index bypass active` and routes to `index.hnsw.*` instead of `index_base.hnsw.*`
- [ ] CI green
