### PR TITLE
feat: expand summary eligibility from is_callable to is_code

### DIFF
--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -87,7 +87,20 @@ pub(crate) fn collect_eligible_chunks(
                 cached += 1;
                 continue;
             }
-            if !cs.chunk_type.is_callable() {
+            // Phase 5 follow-up: summarize all code chunk types, not just callable
+            // ones. Structs, enums, traits, impls, classes, constants etc. all
+            // benefit from a one-line summary because the dual-index router
+            // routes conceptual/behavioral queries to the base (non-summary)
+            // index — and that routing has zero effect when the gold answer is
+            // a struct that doesn't have a summary to strip in the first place.
+            //
+            // NOTE: this filter is shared with hyde_query_pass. The HyDE pass
+            // is currently disabled (--hyde-queries default is false) and
+            // research data (training-data/research/enrichment.md) shows HyDE
+            // is net-negative across most categories, so we don't worry about
+            // it here. If HyDE is ever re-enabled, split this gate per-purpose
+            // because HyDE should NOT broaden to type definitions.
+            if !cs.chunk_type.is_code() {
                 skipped += 1;
                 continue;
             }

--- a/src/llm/summary.rs
+++ b/src/llm/summary.rs
@@ -334,34 +334,44 @@ mod tests {
         );
     }
 
-    /// Condition 2: non-callable chunk types should be skipped.
+    /// Condition 2 (Phase 5 follow-up): the eligibility filter now uses
+    /// `is_code()` instead of `is_callable()`, so type-definition chunks
+    /// (struct, enum, trait, interface, class, constant, impl, etc.) are
+    /// summarizable. Only Section (markdown) and Module (file-level) and
+    /// ConfigKey/Object/Namespace are still skipped.
     #[test]
-    fn filter_skips_non_callable_chunks() {
-        let non_callable_types = [
-            ChunkType::Struct,
-            ChunkType::Enum,
-            ChunkType::Trait,
-            ChunkType::Interface,
-            ChunkType::Class,
-            ChunkType::Constant,
-            ChunkType::Section,
-            ChunkType::Module,
-            ChunkType::TypeAlias,
-        ];
-        for ct in non_callable_types {
-            assert!(!ct.is_callable(), "{:?} should not be callable", ct);
-        }
-        // Callable types should NOT be skipped
-        let callable_types = [
+    fn filter_accepts_code_chunk_types() {
+        // Code chunk types — should pass the filter
+        let code_types = [
             ChunkType::Function,
             ChunkType::Method,
             ChunkType::Constructor,
             ChunkType::Property,
             ChunkType::Macro,
             ChunkType::Extension,
+            ChunkType::Test,
+            ChunkType::Struct,
+            ChunkType::Enum,
+            ChunkType::Trait,
+            ChunkType::Interface,
+            ChunkType::Class,
+            ChunkType::Constant,
+            ChunkType::Impl,
+            ChunkType::TypeAlias,
+            ChunkType::Variable,
         ];
-        for ct in callable_types {
-            assert!(ct.is_callable(), "{:?} should be callable", ct);
+        for ct in code_types {
+            assert!(
+                ct.is_code(),
+                "{ct:?} should be considered a code chunk and eligible for summary"
+            );
+        }
+
+        // Non-code types — should be filtered out (markdown sections,
+        // file-level modules, raw config keys are not worth summarizing)
+        let non_code_types = [ChunkType::Section, ChunkType::Module, ChunkType::ConfigKey];
+        for ct in non_code_types {
+            assert!(!ct.is_code(), "{ct:?} should not be eligible for summary");
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 5 follow-up. Expands the LLM summary eligibility filter from `is_callable()` (Function / Method / Constructor / Property / Macro / Test / Endpoint / etc.) to `is_code()` (everything in `is_callable` PLUS Struct / Enum / Trait / Interface / Class / TypeAlias / Constant / Impl / Variable / Service / Extern).

## Why

A clean A/B on the same indexed corpus (PR #877's `CQS_DISABLE_BASE_INDEX=1` bypass vs unset) showed Phase 5 dual-index routing produces **0pp deltas** on conceptual, behavioral, and negation queries. The infrastructure works — telemetry confirms routing fires — but the gold-answer chunks for those queries are mostly structs and types, not functions. Structs aren't summarized, so their `embedding_base` and `embedding` columns are byte-identical, so swapping HNSW indexes is a no-op for them.

The fix: summarize structs / enums / impls / classes / traits etc. too. Then the dual index has actual divergence to bite on.

## Numbers

| Coverage | Before this PR | After this PR (estimated) |
|---|---|---|
| Total chunks | 11768 | 11768 |
| With LLM summary | 4652 (40%) | ~6300 (54%) including type defs |
| Routed to base index | 100% of base-routed queries | 100% of base-routed queries |
| **Routed-and-divergent** (where routing actually changes the answer) | **~40%** | **~54%** |

Sections (3618 markdown chunks) and ConfigKey (646) stay excluded — markdown is already natural language and config keys are usually self-descriptive.

## What's in this PR

Single change in `src/llm/mod.rs:90` — `is_callable()` → `is_code()` with an inline comment explaining the routing motivation and a NOTE that the filter is shared with `hyde_query_pass`. HyDE is currently disabled and research data shows it's net-negative across most categories, so we don't worry about HyDE broadening here. If HyDE is ever re-enabled, the filter should be split per-purpose.

`filter_skips_non_callable_chunks` test renamed to `filter_accepts_code_chunk_types` and updated to assert the new semantics: code types eligible, only `Section` / `Module` / `ConfigKey` skipped.

## Operational follow-up (not in this PR)

After this lands, the summary batch needs to actually run:
```
cqs index --llm-summaries
```
That submits a batch to Claude, polls for completion (~30 min for ~1700 chunks), then a force-reindex picks up the new summaries and refreshes both `embedding` and `embedding_base` columns.

After that, re-run the eval ablation matrix (PR #877's bypass + with/without SPLADE) to measure dual-index routing's effect with the broader summary coverage.

## Test plan

- [x] `cargo build --features gpu-index,llm-summaries` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --features gpu-index,llm-summaries --lib -- llm` — 154 pass
- [ ] CI green
