### PR TITLE
test: Phase 5 — CQS_DISABLE_BASE_INDEX bypass coverage

### DIFF
--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -293,3 +293,113 @@ pub(crate) fn build_base_vector_index(
         Some(store.dim()),
     ))
 }
+
+#[cfg(test)]
+mod base_index_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Process-wide lock — env-touching tests must serialize so they don't
+    /// race against each other (env::set_var/remove_var are global state).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Build a deterministic L2-normalized embedding from a seed value.
+    /// Inlined here because cqs::test_helpers is `#[cfg(test)]`-gated in the
+    /// library crate and bin-crate test code can't reach it.
+    fn make_embedding(seed: f32, dim: usize) -> cqs::embedder::Embedding {
+        let mut v = vec![seed; dim];
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for x in &mut v {
+                *x /= norm;
+            }
+        }
+        cqs::embedder::Embedding::new(v)
+    }
+
+    /// Phase 5 invariant: `CQS_DISABLE_BASE_INDEX=1` short-circuits
+    /// `build_base_vector_index` to return `None` even when the
+    /// `index_base.hnsw.*` files exist on disk and the store is clean.
+    /// This is the load-bearing behavior for same-corpus A/B eval.
+    #[test]
+    fn test_disable_base_index_env_short_circuits_with_files_present() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        // Set up a real Store + a real index_base.hnsw.* fixture so we
+        // exercise the actual file-load path, not just the early return.
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("index.db");
+        let store = cqs::Store::open(&db_path).unwrap();
+        store.init(&cqs::store::ModelInfo::default()).unwrap();
+        // Mark the store as clean so we don't get filtered out by the
+        // hnsw_dirty branch — that branch fires before the file load but
+        // AFTER the env-var check, so we still test the early return.
+        store.set_hnsw_dirty(false).unwrap();
+
+        let dim = store.dim();
+        let embeddings: Vec<(String, cqs::embedder::Embedding)> = (0..10)
+            .map(|i| (format!("vec{i}"), make_embedding(i as f32 + 0.1, dim)))
+            .collect();
+        let index = cqs::HnswIndex::build_with_dim(embeddings, dim).unwrap();
+        index.save(dir.path(), "index_base").unwrap();
+
+        // ── Sanity: without the bypass, the function loads the base index ──
+        std::env::remove_var("CQS_DISABLE_BASE_INDEX");
+        let loaded = build_base_vector_index(&store, dir.path()).unwrap();
+        assert!(
+            loaded.is_some(),
+            "without bypass, base files present + store clean → should load"
+        );
+        assert_eq!(loaded.unwrap().len(), 10);
+
+        // ── With the bypass, the function returns None despite files existing ──
+        std::env::set_var("CQS_DISABLE_BASE_INDEX", "1");
+        let bypassed = build_base_vector_index(&store, dir.path()).unwrap();
+        assert!(
+            bypassed.is_none(),
+            "with CQS_DISABLE_BASE_INDEX=1, base files exist + store clean \
+             → must return None (this is the load-bearing A/B-eval behavior)"
+        );
+        std::env::remove_var("CQS_DISABLE_BASE_INDEX");
+
+        // ── And that the bypass is reset cleanly: removing it brings the
+        //    function back to its normal load behavior ──
+        let after_unset = build_base_vector_index(&store, dir.path()).unwrap();
+        assert!(
+            after_unset.is_some(),
+            "after env var unset, normal load path should resume"
+        );
+    }
+
+    /// `CQS_DISABLE_BASE_INDEX` only triggers for the literal value "1".
+    /// Any other value (including "true", "yes", "0", empty) must NOT activate
+    /// the bypass — we don't want a stray export accidentally suppressing
+    /// the base index.
+    #[test]
+    fn test_disable_base_index_env_strict_value_match() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("index.db");
+        let store = cqs::Store::open(&db_path).unwrap();
+        store.init(&cqs::store::ModelInfo::default()).unwrap();
+        store.set_hnsw_dirty(false).unwrap();
+
+        let dim = store.dim();
+        let embeddings: Vec<(String, cqs::embedder::Embedding)> = (0..5)
+            .map(|i| (format!("v{i}"), make_embedding(i as f32 + 0.1, dim)))
+            .collect();
+        let index = cqs::HnswIndex::build_with_dim(embeddings, dim).unwrap();
+        index.save(dir.path(), "index_base").unwrap();
+
+        for non_one in ["", "0", "true", "yes", "on", "TRUE", " 1", "1 ", "false"] {
+            std::env::set_var("CQS_DISABLE_BASE_INDEX", non_one);
+            let result = build_base_vector_index(&store, dir.path()).unwrap();
+            assert!(
+                result.is_some(),
+                "CQS_DISABLE_BASE_INDEX={non_one:?} must NOT activate bypass"
+            );
+        }
+        std::env::remove_var("CQS_DISABLE_BASE_INDEX");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the test gap I'd labeled "manual smoke" in the Phase 5 dual-index invariants table. `CQS_DISABLE_BASE_INDEX=1` is the load-bearing primitive for same-corpus A/B eval (PR #877), and until now it was only smoke-tested by hand.

## Two new tests

**`test_disable_base_index_env_short_circuits_with_files_present`** — sets up a real `Store` + a real `index_base.hnsw.*` fixture, marks the store clean (so we don't get filtered out by the `hnsw_dirty` branch that fires *after* the env-var check), and verifies the three states the A/B eval depends on:

1. **Without env var:** `build_base_vector_index` loads the index → `Some` (len = 10)
2. **With `CQS_DISABLE_BASE_INDEX=1`:** returns `None` despite files present and store clean — this is the load-bearing A/B-eval behavior
3. **After unsetting:** load path resumes normally

This is the exact contract the eval ablation script (`evals/run_ablation.py`) relies on when running same-corpus A/B with the bypass toggled between cells.

**`test_disable_base_index_env_strict_value_match`** — defensive coverage: only the literal string `"1"` triggers the bypass. Any other value (`""`, `"0"`, `"true"`, `"yes"`, `"on"`, `"TRUE"`, `" 1"`, `"1 "`, `"false"`) leaves the normal load path active. Prevents stray exports or typoed env values from accidentally suppressing the base index in production.

## Test parallelism

Both tests serialize on a `static Mutex<()>` (`ENV_LOCK`) because `env::set_var` and `env::remove_var` are process-global state. Without the lock they'd race against each other and against any other test that touches `CQS_DISABLE_BASE_INDEX` in the future.

## Helper inlining

I inlined a small `make_embedding(seed, dim) -> Embedding` helper rather than reaching for `cqs::test_helpers::mock_embedding`. The library's `test_helpers` module is `#[cfg(test)]`-gated, which means the bin crate's test compilation can't access it. Inlining is cleaner than promoting `test_helpers` to non-gated public API just for one bin-crate test.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --features gpu-index --bin cqs -- test_disable_base_index` — 2 pass
- [ ] CI green
