### PR TITLE
feat: CQS_SPLADE_MODEL env var + vocab-mismatch detection

### DIFF
--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -245,21 +245,25 @@ impl BatchContext {
     }
 
     /// Get or lazily load the SPLADE encoder. Returns None if model unavailable.
+    ///
+    /// Path resolution is delegated to [`cqs::splade::resolve_splade_model_dir`]
+    /// so the env-var override (`CQS_SPLADE_MODEL`) and vocab-mismatch probe
+    /// stay consistent across the interactive (`cqs query`) and batch
+    /// (`cqs search`) paths.
     pub fn splade_encoder(&self) -> Option<&cqs::splade::SpladeEncoder> {
         let opt = self.splade_encoder.get_or_init(|| {
-            let model_dir = dirs::home_dir()
-                .map(|h| h.join(".cache/huggingface/splade-onnx"))
-                .unwrap_or_default();
-            if !model_dir.join("model.onnx").exists() {
-                return None;
-            }
+            let model_dir = cqs::splade::resolve_splade_model_dir()?;
             match cqs::splade::SpladeEncoder::new(
                 &model_dir,
                 cqs::splade::SpladeEncoder::default_threshold(),
             ) {
                 Ok(enc) => Some(enc),
                 Err(e) => {
-                    tracing::warn!(error = %e, "SPLADE encoder unavailable in batch mode");
+                    tracing::warn!(
+                        path = %model_dir.display(),
+                        error = %e,
+                        "SPLADE encoder unavailable in batch mode"
+                    );
                     None
                 }
             }

--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -378,12 +378,16 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
         }
     }
 
-    // SPLADE sparse encoding (if model available)
+    // SPLADE sparse encoding (if model available).
+    //
+    // Path resolution is delegated to cqs::splade::resolve_splade_model_dir
+    // so the env var (CQS_SPLADE_MODEL) and vocab-mismatch probe stay
+    // consistent with the search-time encoder loaders. Critical for index
+    // correctness: if the index pass and search pass use different SPLADE
+    // models, the sparse vectors are token-incompatible and search-time
+    // queries return garbage. Single source of truth.
     if !check_interrupted() {
-        let splade_dir = dirs::home_dir()
-            .map(|h| h.join(".cache/huggingface/splade-onnx"))
-            .unwrap_or_default();
-        if splade_dir.join("model.onnx").exists() {
+        if let Some(splade_dir) = cqs::splade::resolve_splade_model_dir() {
             if !cli.quiet {
                 println!("Encoding SPLADE sparse vectors...");
             }

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -132,24 +132,30 @@ impl<'a> CommandContext<'a> {
     }
 
     /// Get or lazily load the SPLADE encoder.
-    /// Returns None if the SPLADE model is not available.
+    ///
+    /// Path resolution is delegated to [`cqs::splade::resolve_splade_model_dir`]
+    /// — see that function's docs for env-var override and fallback rules.
+    /// `SpladeEncoder::new` runs a vocab-mismatch probe at construction time,
+    /// so a hot-swapped `model.onnx` with a stale `tokenizer.json` will fail
+    /// fast here rather than silently producing garbage embeddings.
+    ///
+    /// Returns `None` when no usable model dir exists or the load fails —
+    /// callers fall back to dense-only.
     pub fn splade_encoder(&self) -> Option<&cqs::splade::SpladeEncoder> {
         let opt = self.splade_encoder.get_or_init(|| {
             let _span = tracing::debug_span!("command_context_splade_encoder_init").entered();
-            let model_dir = dirs::home_dir()
-                .map(|h| h.join(".cache/huggingface/splade-onnx"))
-                .unwrap_or_default();
-            if !model_dir.join("model.onnx").exists() {
-                tracing::warn!("SPLADE model not found, hybrid search unavailable");
-                return None;
-            }
+            let model_dir = cqs::splade::resolve_splade_model_dir()?;
             match cqs::splade::SpladeEncoder::new(
                 &model_dir,
                 cqs::splade::SpladeEncoder::default_threshold(),
             ) {
                 Ok(enc) => Some(enc),
                 Err(e) => {
-                    tracing::warn!(error = %e, "Failed to load SPLADE encoder");
+                    tracing::warn!(
+                        path = %model_dir.display(),
+                        error = %e,
+                        "Failed to load SPLADE encoder"
+                    );
                     None
                 }
             }

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -293,3 +293,113 @@ pub(crate) fn build_base_vector_index(
         Some(store.dim()),
     ))
 }
+
+#[cfg(test)]
+mod base_index_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Process-wide lock — env-touching tests must serialize so they don't
+    /// race against each other (env::set_var/remove_var are global state).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Build a deterministic L2-normalized embedding from a seed value.
+    /// Inlined here because cqs::test_helpers is `#[cfg(test)]`-gated in the
+    /// library crate and bin-crate test code can't reach it.
+    fn make_embedding(seed: f32, dim: usize) -> cqs::embedder::Embedding {
+        let mut v = vec![seed; dim];
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for x in &mut v {
+                *x /= norm;
+            }
+        }
+        cqs::embedder::Embedding::new(v)
+    }
+
+    /// Phase 5 invariant: `CQS_DISABLE_BASE_INDEX=1` short-circuits
+    /// `build_base_vector_index` to return `None` even when the
+    /// `index_base.hnsw.*` files exist on disk and the store is clean.
+    /// This is the load-bearing behavior for same-corpus A/B eval.
+    #[test]
+    fn test_disable_base_index_env_short_circuits_with_files_present() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        // Set up a real Store + a real index_base.hnsw.* fixture so we
+        // exercise the actual file-load path, not just the early return.
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("index.db");
+        let store = cqs::Store::open(&db_path).unwrap();
+        store.init(&cqs::store::ModelInfo::default()).unwrap();
+        // Mark the store as clean so we don't get filtered out by the
+        // hnsw_dirty branch — that branch fires before the file load but
+        // AFTER the env-var check, so we still test the early return.
+        store.set_hnsw_dirty(false).unwrap();
+
+        let dim = store.dim();
+        let embeddings: Vec<(String, cqs::embedder::Embedding)> = (0..10)
+            .map(|i| (format!("vec{i}"), make_embedding(i as f32 + 0.1, dim)))
+            .collect();
+        let index = cqs::HnswIndex::build_with_dim(embeddings, dim).unwrap();
+        index.save(dir.path(), "index_base").unwrap();
+
+        // ── Sanity: without the bypass, the function loads the base index ──
+        std::env::remove_var("CQS_DISABLE_BASE_INDEX");
+        let loaded = build_base_vector_index(&store, dir.path()).unwrap();
+        assert!(
+            loaded.is_some(),
+            "without bypass, base files present + store clean → should load"
+        );
+        assert_eq!(loaded.unwrap().len(), 10);
+
+        // ── With the bypass, the function returns None despite files existing ──
+        std::env::set_var("CQS_DISABLE_BASE_INDEX", "1");
+        let bypassed = build_base_vector_index(&store, dir.path()).unwrap();
+        assert!(
+            bypassed.is_none(),
+            "with CQS_DISABLE_BASE_INDEX=1, base files exist + store clean \
+             → must return None (this is the load-bearing A/B-eval behavior)"
+        );
+        std::env::remove_var("CQS_DISABLE_BASE_INDEX");
+
+        // ── And that the bypass is reset cleanly: removing it brings the
+        //    function back to its normal load behavior ──
+        let after_unset = build_base_vector_index(&store, dir.path()).unwrap();
+        assert!(
+            after_unset.is_some(),
+            "after env var unset, normal load path should resume"
+        );
+    }
+
+    /// `CQS_DISABLE_BASE_INDEX` only triggers for the literal value "1".
+    /// Any other value (including "true", "yes", "0", empty) must NOT activate
+    /// the bypass — we don't want a stray export accidentally suppressing
+    /// the base index.
+    #[test]
+    fn test_disable_base_index_env_strict_value_match() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("index.db");
+        let store = cqs::Store::open(&db_path).unwrap();
+        store.init(&cqs::store::ModelInfo::default()).unwrap();
+        store.set_hnsw_dirty(false).unwrap();
+
+        let dim = store.dim();
+        let embeddings: Vec<(String, cqs::embedder::Embedding)> = (0..5)
+            .map(|i| (format!("v{i}"), make_embedding(i as f32 + 0.1, dim)))
+            .collect();
+        let index = cqs::HnswIndex::build_with_dim(embeddings, dim).unwrap();
+        index.save(dir.path(), "index_base").unwrap();
+
+        for non_one in ["", "0", "true", "yes", "on", "TRUE", " 1", "1 ", "false"] {
+            std::env::set_var("CQS_DISABLE_BASE_INDEX", non_one);
+            let result = build_base_vector_index(&store, dir.path()).unwrap();
+            assert!(
+                result.is_some(),
+                "CQS_DISABLE_BASE_INDEX={non_one:?} must NOT activate bypass"
+            );
+        }
+        std::env::remove_var("CQS_DISABLE_BASE_INDEX");
+    }
+}

--- a/src/splade/mod.rs
+++ b/src/splade/mod.rs
@@ -38,6 +38,23 @@ pub enum SpladeError {
     InferenceFailed(String),
     #[error("SPLADE tokenization failed: {0}")]
     TokenizationFailed(String),
+    /// Tokenizer vocab size and model output vocab size don't match — the
+    /// directory contains a tokenizer for one model and weights for another.
+    /// Most commonly this happens when `model.onnx` was hot-swapped (e.g.
+    /// SPLADE-Code 0.6B replaced the off-the-shelf 110M BERT) without
+    /// updating `tokenizer.json`. Encoding would silently produce garbage —
+    /// fail fast at construction time so the eval doesn't waste a 30-minute
+    /// run on broken vectors.
+    #[error(
+        "SPLADE config mismatch: tokenizer vocab is {tokenizer_vocab}, model vocab is \
+         {model_vocab}. The tokenizer.json and model.onnx in {dir:?} are from different \
+         models — replace tokenizer.json with the one matching the model architecture."
+    )]
+    ConfigMismatch {
+        dir: std::path::PathBuf,
+        tokenizer_vocab: usize,
+        model_vocab: usize,
+    },
 }
 
 /// SPLADE encoder using ONNX Runtime.
@@ -52,6 +69,159 @@ pub struct SpladeEncoder {
     vocab_size: usize,
 }
 
+/// Probe a SPLADE model's output vocabulary by running one short inference.
+///
+/// Used at construction time to validate that the loaded `tokenizer.json` and
+/// `model.onnx` agree on vocab size. Returns the model's output vocab
+/// dimension extracted from the inference output shape.
+///
+/// Handles both output formats:
+/// - `sparse_vector` (2D `[batch, vocab]`) — pre-pooled SPLADE-Code 0.6B+
+/// - `logits` (3D `[batch, seq, vocab]`) — raw masked-LM logits, our v1/v2
+///
+/// The session is consumed by this function (ORT's `Session::run` requires
+/// `&mut`); the caller re-creates the session for the persistent encoder
+/// after probing succeeds.
+fn probe_model_vocab(
+    mut session: Session,
+    tokenizer: &tokenizers::Tokenizer,
+    onnx_path: &Path,
+) -> Result<usize, SpladeError> {
+    let _span = tracing::debug_span!("probe_model_vocab", path = %onnx_path.display()).entered();
+
+    // Tokenize a short fixed string. Content doesn't matter — we only care
+    // about the output tensor shape.
+    let encoding = tokenizer
+        .encode("test", true)
+        .map_err(|e| SpladeError::TokenizationFailed(format!("probe tokenization: {e}")))?;
+
+    let input_ids: Vec<i64> = encoding.get_ids().iter().map(|&id| id as i64).collect();
+    let attention_mask: Vec<i64> = encoding
+        .get_attention_mask()
+        .iter()
+        .map(|&m| m as i64)
+        .collect();
+    let seq_len = input_ids.len();
+
+    let ids_array = Array2::from_shape_vec((1, seq_len), input_ids)
+        .map_err(|e| SpladeError::InferenceFailed(format!("probe ids tensor: {e}")))?;
+    let mask_array = Array2::from_shape_vec((1, seq_len), attention_mask)
+        .map_err(|e| SpladeError::InferenceFailed(format!("probe mask tensor: {e}")))?;
+
+    let ids_tensor = Tensor::from_array(ids_array)
+        .map_err(|e| SpladeError::InferenceFailed(format!("probe ids: {e}")))?;
+    let mask_tensor = Tensor::from_array(mask_array)
+        .map_err(|e| SpladeError::InferenceFailed(format!("probe mask: {e}")))?;
+
+    let outputs = session
+        .run(ort::inputs![
+            "input_ids" => ids_tensor,
+            "attention_mask" => mask_tensor,
+        ])
+        .map_err(ort_err)?;
+
+    // Extract vocab dim from whichever output shape we get.
+    let vocab = if let Some(sv_output) = outputs.get("sparse_vector") {
+        let (shape, _data) = sv_output.try_extract_tensor::<f32>().map_err(ort_err)?;
+        if shape.len() != 2 {
+            return Err(SpladeError::InferenceFailed(format!(
+                "probe: pre-pooled sparse_vector expected 2D [batch, vocab], got {}D",
+                shape.len()
+            )));
+        }
+        shape[1] as usize
+    } else if let Some(logits_output) = outputs.get("logits") {
+        let (shape, _data) = logits_output.try_extract_tensor::<f32>().map_err(ort_err)?;
+        if shape.len() != 3 {
+            return Err(SpladeError::InferenceFailed(format!(
+                "probe: expected 3D logits [batch, seq, vocab], got {}D",
+                shape.len()
+            )));
+        }
+        shape[2] as usize
+    } else {
+        let names: Vec<&str> = outputs.keys().collect();
+        return Err(SpladeError::InferenceFailed(format!(
+            "probe: no recognized SPLADE output. Expected 'sparse_vector' or 'logits'. \
+             Available: {names:?}"
+        )));
+    };
+
+    tracing::debug!(model_vocab = vocab, "Probed SPLADE model vocab");
+    Ok(vocab)
+}
+
+/// Resolve the SPLADE model directory.
+///
+/// Resolution order:
+/// 1. `CQS_SPLADE_MODEL` env var (absolute or `~`-prefixed path) — overrides
+///    everything. The directory must contain `model.onnx` AND `tokenizer.json`.
+/// 2. `~/.cache/huggingface/splade-onnx/` (default location)
+///
+/// Returns `None` when neither location has both required files. Callers
+/// fall back to dense-only and emit a warning.
+///
+/// The env-var override exists so research can A/B between SPLADE models
+/// (e.g. SPLADE-Code 0.6B at `~/training-data/splade-code-naver/onnx/`
+/// vs the off-the-shelf 110M BERT model) without clobbering the default
+/// cache directory.
+///
+/// CRITICAL: this single helper is the *only* place SPLADE paths are
+/// resolved. Adding new SPLADE call sites must use this function — having
+/// multiple paths means the model and tokenizer can desync (which has
+/// happened: a stale BERT tokenizer was used with a SPLADE-Code model,
+/// silently producing garbage embeddings).
+pub fn resolve_splade_model_dir() -> Option<std::path::PathBuf> {
+    let _span = tracing::debug_span!("resolve_splade_model_dir").entered();
+
+    let dir = match std::env::var("CQS_SPLADE_MODEL") {
+        Ok(p) if !p.is_empty() => {
+            // Expand a leading "~/" using $HOME so users can write
+            // CQS_SPLADE_MODEL=~/training-data/splade-code-naver/onnx
+            let expanded = if let Some(stripped) = p.strip_prefix("~/") {
+                dirs::home_dir()
+                    .map(|h| h.join(stripped))
+                    .unwrap_or_else(|| p.into())
+            } else {
+                p.into()
+            };
+            tracing::info!(
+                source = "CQS_SPLADE_MODEL",
+                path = %expanded.display(),
+                "SPLADE model dir resolved from env var"
+            );
+            expanded
+        }
+        _ => {
+            let default = dirs::home_dir()
+                .map(|h| h.join(".cache/huggingface/splade-onnx"))
+                .unwrap_or_default();
+            tracing::debug!(path = %default.display(), "Using default SPLADE model dir");
+            default
+        }
+    };
+
+    let model = dir.join("model.onnx");
+    let tokenizer = dir.join("tokenizer.json");
+
+    if !model.exists() {
+        tracing::warn!(
+            path = %model.display(),
+            "SPLADE model.onnx not found — hybrid search will be disabled"
+        );
+        return None;
+    }
+    if !tokenizer.exists() {
+        tracing::warn!(
+            path = %tokenizer.display(),
+            "SPLADE tokenizer.json not found — hybrid search will be disabled"
+        );
+        return None;
+    }
+
+    Some(dir)
+}
+
 impl SpladeEncoder {
     /// Default SPLADE threshold, overridable via `CQS_SPLADE_THRESHOLD` env var.
     pub fn default_threshold() -> f32 {
@@ -62,6 +232,13 @@ impl SpladeEncoder {
     }
 
     /// Load SPLADE model from a directory containing model.onnx and tokenizer.json.
+    ///
+    /// At construction time runs a dummy inference to detect tokenizer/model
+    /// vocabulary mismatches. If the tokenizer vocab and the model output vocab
+    /// disagree, returns [`SpladeError::ConfigMismatch`] — encoding would
+    /// otherwise silently produce garbage. This catches the failure mode where
+    /// `model.onnx` is hot-swapped (e.g. SPLADE-Code 0.6B replaces BERT 110M)
+    /// without updating `tokenizer.json`.
     pub fn new(model_dir: &Path, threshold: f32) -> Result<Self, SpladeError> {
         let _span = tracing::info_span!("splade_encoder_new", dir = %model_dir.display()).entered();
 
@@ -88,17 +265,46 @@ impl SpladeEncoder {
         let tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path)
             .map_err(|e| SpladeError::TokenizationFailed(e.to_string()))?;
 
-        // BERT vocabulary is typically 30522
-        let vocab_size = tokenizer.get_vocab_size(true);
+        let tokenizer_vocab = tokenizer.get_vocab_size(true);
 
-        tracing::info!(threshold, vocab_size, "SPLADE encoder loaded");
+        // Probe the model's actual output vocab via a dummy inference.
+        // Mismatch with tokenizer vocab → silent garbage in production, so
+        // we fail fast here. The probe runs the same code path as `encode`,
+        // so it also surfaces ORT/runtime errors at construction time.
+        let model_vocab = probe_model_vocab(session, &tokenizer, &onnx_path)?;
+
+        if tokenizer_vocab != model_vocab {
+            tracing::error!(
+                tokenizer_vocab,
+                model_vocab,
+                dir = %model_dir.display(),
+                "SPLADE tokenizer/model vocab mismatch — refusing to load"
+            );
+            return Err(SpladeError::ConfigMismatch {
+                dir: model_dir.to_path_buf(),
+                tokenizer_vocab,
+                model_vocab,
+            });
+        }
+
+        // Re-create the session for the persistent encoder (the probe consumed
+        // the original via session.run mutability — cleaner to reload than to
+        // rebuild the API around split borrow).
+        let session = create_session(&onnx_path, provider)
+            .map_err(|e| SpladeError::InferenceFailed(format!("ORT session re-init: {e}")))?;
+
+        tracing::info!(
+            threshold,
+            vocab_size = tokenizer_vocab,
+            "SPLADE encoder loaded (vocab consistency verified)"
+        );
 
         Ok(Self {
             session: Mutex::new(Some(session)),
             model_path: onnx_path,
             tokenizer,
             threshold,
-            vocab_size,
+            vocab_size: tokenizer_vocab,
         })
     }
 
@@ -361,5 +567,183 @@ mod tests {
             ),
             Ok(_) => unreachable!(),
         }
+    }
+
+    // ===== resolve_splade_model_dir tests =====
+    //
+    // These touch the process-wide CQS_SPLADE_MODEL env var and serialize on
+    // a static Mutex so they don't race against each other or against any
+    // other test that touches the same var.
+
+    use std::sync::Mutex;
+    static SPLADE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Helper: write a stub directory with both required files so the
+    /// resolver believes a model lives there. Doesn't write a real ONNX
+    /// graph — that's only needed for tests that actually load the encoder.
+    fn write_stub_splade_dir(dir: &Path) {
+        std::fs::write(dir.join("model.onnx"), b"stub").unwrap();
+        std::fs::write(dir.join("tokenizer.json"), b"stub").unwrap();
+    }
+
+    /// `CQS_SPLADE_MODEL` set to a directory with both files → returned as-is.
+    #[test]
+    fn test_resolve_env_var_override() {
+        let _guard = SPLADE_ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        write_stub_splade_dir(tmp.path());
+
+        std::env::set_var("CQS_SPLADE_MODEL", tmp.path());
+        let resolved = resolve_splade_model_dir();
+        std::env::remove_var("CQS_SPLADE_MODEL");
+
+        assert_eq!(resolved.as_deref(), Some(tmp.path()));
+    }
+
+    /// `CQS_SPLADE_MODEL` set to a `~/...` path → expanded against $HOME.
+    #[test]
+    fn test_resolve_env_var_tilde_expansion() {
+        let _guard = SPLADE_ENV_LOCK.lock().unwrap();
+        // Build a stub dir under $HOME so a tilde-prefixed env var resolves
+        // to a real existing directory. Use a unique subdir to avoid colliding
+        // with other tests.
+        let home = dirs::home_dir().expect("HOME must be set in test env");
+        let stub_subdir = format!(".cqs-test-splade-{}", std::process::id());
+        let stub_dir = home.join(&stub_subdir);
+        std::fs::create_dir_all(&stub_dir).unwrap();
+        write_stub_splade_dir(&stub_dir);
+
+        std::env::set_var("CQS_SPLADE_MODEL", format!("~/{stub_subdir}"));
+        let resolved = resolve_splade_model_dir();
+        std::env::remove_var("CQS_SPLADE_MODEL");
+
+        // Cleanup before assertions so a failure doesn't strand the dir.
+        let _ = std::fs::remove_dir_all(&stub_dir);
+
+        assert_eq!(
+            resolved.as_deref(),
+            Some(stub_dir.as_path()),
+            "tilde-prefixed CQS_SPLADE_MODEL should expand against $HOME"
+        );
+    }
+
+    /// `CQS_SPLADE_MODEL` set but the directory has no `model.onnx` → None.
+    #[test]
+    fn test_resolve_env_var_missing_model_returns_none() {
+        let _guard = SPLADE_ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Only write tokenizer, no model.onnx
+        std::fs::write(tmp.path().join("tokenizer.json"), b"stub").unwrap();
+
+        std::env::set_var("CQS_SPLADE_MODEL", tmp.path());
+        let resolved = resolve_splade_model_dir();
+        std::env::remove_var("CQS_SPLADE_MODEL");
+
+        assert!(
+            resolved.is_none(),
+            "should return None when model.onnx is missing"
+        );
+    }
+
+    /// `CQS_SPLADE_MODEL` set but no `tokenizer.json` → None. Critical: this
+    /// is the failure mode the vocab-mismatch detection was added to catch,
+    /// so we want the resolver to also reject the missing-tokenizer case.
+    #[test]
+    fn test_resolve_env_var_missing_tokenizer_returns_none() {
+        let _guard = SPLADE_ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Only write model, no tokenizer.json
+        std::fs::write(tmp.path().join("model.onnx"), b"stub").unwrap();
+
+        std::env::set_var("CQS_SPLADE_MODEL", tmp.path());
+        let resolved = resolve_splade_model_dir();
+        std::env::remove_var("CQS_SPLADE_MODEL");
+
+        assert!(
+            resolved.is_none(),
+            "should return None when tokenizer.json is missing — \
+             a model+wrong-tokenizer dir must not silently fall through"
+        );
+    }
+
+    /// Empty `CQS_SPLADE_MODEL` value → falls back to default cache dir.
+    /// This is the bash gotcha where `export CQS_SPLADE_MODEL=` (no value)
+    /// would otherwise be treated as "the empty path" and resolve nowhere.
+    #[test]
+    fn test_resolve_env_var_empty_falls_back_to_default() {
+        let _guard = SPLADE_ENV_LOCK.lock().unwrap();
+        std::env::set_var("CQS_SPLADE_MODEL", "");
+        let resolved = resolve_splade_model_dir();
+        std::env::remove_var("CQS_SPLADE_MODEL");
+
+        // The default path may or may not actually exist on this machine —
+        // we only care that the empty-string env var didn't take precedence.
+        // If it had, the resolver would have inspected an empty PathBuf and
+        // returned None for "model.onnx not found at ".
+        let expected_default = dirs::home_dir()
+            .map(|h| h.join(".cache/huggingface/splade-onnx"))
+            .unwrap_or_default();
+        if expected_default.join("model.onnx").exists()
+            && expected_default.join("tokenizer.json").exists()
+        {
+            assert_eq!(
+                resolved.as_deref(),
+                Some(expected_default.as_path()),
+                "empty env var should fall back to default cache dir"
+            );
+        } else {
+            assert!(
+                resolved.is_none(),
+                "empty env var with no default model installed → None"
+            );
+        }
+    }
+
+    /// No env var set → falls back to default cache dir resolution.
+    #[test]
+    fn test_resolve_no_env_var() {
+        let _guard = SPLADE_ENV_LOCK.lock().unwrap();
+        std::env::remove_var("CQS_SPLADE_MODEL");
+        let resolved = resolve_splade_model_dir();
+
+        // Identical reasoning to the empty-string case — the result depends
+        // on whether a default model is installed on the test machine.
+        let expected_default = dirs::home_dir()
+            .map(|h| h.join(".cache/huggingface/splade-onnx"))
+            .unwrap_or_default();
+        if expected_default.join("model.onnx").exists()
+            && expected_default.join("tokenizer.json").exists()
+        {
+            assert_eq!(resolved.as_deref(), Some(expected_default.as_path()));
+        } else {
+            assert!(resolved.is_none());
+        }
+    }
+
+    /// SpladeError::ConfigMismatch renders a message that points the user at
+    /// the actionable fix (replace tokenizer.json). Verifies the message
+    /// stays useful — Display impl is the only place mismatched users see
+    /// guidance.
+    #[test]
+    fn test_config_mismatch_error_message_is_actionable() {
+        let err = SpladeError::ConfigMismatch {
+            dir: PathBuf::from("/some/where/splade-onnx"),
+            tokenizer_vocab: 30522,
+            model_vocab: 151936,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("30522"),
+            "should include tokenizer vocab: {msg}"
+        );
+        assert!(msg.contains("151936"), "should include model vocab: {msg}");
+        assert!(
+            msg.contains("/some/where/splade-onnx"),
+            "should include the directory: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("tokenizer"),
+            "should mention tokenizer.json as the fix-point: {msg}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds a single source of truth for SPLADE model path resolution and a construction-time vocab consistency probe. **Catches the failure mode that wasted today's eval matrix**: a hot-swapped `model.onnx` (532MB SPLADE-Code 0.6B) paired with a stale `tokenizer.json` (BERT WordPiece, 30522 vocab) at `~/.cache/huggingface/splade-onnx/`. Encoding produced syntactically valid but semantically meaningless sparse vectors, giving 0pp on cross_language where the previous SPLADE-Code eval got +20pp R@1.

The 110M-vs-600M-trained-on-different-vocab failure mode silently produced result lists that LOOKED like SPLADE was working — same number of results, scores in the right range, no crashes — until you compared cross_language R@1 between SPLADE-on and SPLADE-off cells and they were byte-identical.

## Changes

### `cqs::splade::resolve_splade_model_dir()` (new helper)

Single function that returns `Some(PathBuf)` when both `model.onnx` AND `tokenizer.json` exist at the resolved location, `None` otherwise.

Resolution order:
1. `CQS_SPLADE_MODEL` env var (absolute or `~/`-prefixed)
2. `~/.cache/huggingface/splade-onnx/` (default)

`~/`-expansion uses `$HOME` so users can write the env var with a tilde. All tracing emits the resolved path on every code path so misconfigurations are immediately visible in logs without needing `RUST_LOG=debug`.

### `cqs::splade::SpladeEncoder::new()` — vocab probe

Now runs `probe_model_vocab()` at construction time. Loads the tokenizer + ORT session, runs a dummy "test" inference, extracts the output vocab dimension from whichever output format the model emits (`sparse_vector` pre-pooled or `logits` raw), and compares to `tokenizer.get_vocab_size(true)`. Mismatch → returns the new `SpladeError::ConfigMismatch` with an actionable message naming the directory and both vocab sizes.

The probe re-creates the session afterwards because it consumes the original via ORT's `&mut Session::run`. Cleaner than fighting the borrow checker for a one-time-use API.

### Three call sites unified

Before this PR, the SPLADE model path was hardcoded inline in three places:
- `src/cli/store.rs` — interactive search (`cqs query`)
- `src/cli/batch/mod.rs` — batch search (`cqs search`)
- `src/cli/commands/index/build.rs` — index pass (`cqs index`)

All three now call `resolve_splade_model_dir()`. **This eliminates the divergence risk** where index-time and search-time encoders could resolve to different models, which would produce token-incompatible sparse vectors and silently break search results.

### `SpladeError::ConfigMismatch` (new variant)

```rust
ConfigMismatch {
    dir: PathBuf,
    tokenizer_vocab: usize,
    model_vocab: usize,
}
```

Renders as: *"SPLADE config mismatch: tokenizer vocab is 30522, model vocab is 151936. The tokenizer.json and model.onnx in /home/user/.cache/huggingface/splade-onnx are from different models — replace tokenizer.json with the one matching the model architecture."*

## Tests added (7)

Tests serialize on a static `SPLADE_ENV_LOCK` because process-wide env vars race against parallel test execution.

| Test | What it asserts |
|---|---|
| `test_resolve_env_var_override` | env var → resolver returns the directory |
| `test_resolve_env_var_tilde_expansion` | `CQS_SPLADE_MODEL=~/...` expands against `$HOME` |
| `test_resolve_env_var_missing_model_returns_none` | env var set to dir without `model.onnx` → `None` |
| `test_resolve_env_var_missing_tokenizer_returns_none` | env var set to dir without `tokenizer.json` → `None`. **The exact failure mode that produced today's bug** — a model+wrong-tokenizer dir must NOT silently fall through. Defense in depth alongside the construction-time vocab probe. |
| `test_resolve_env_var_empty_falls_back_to_default` | bash gotcha: `export CQS_SPLADE_MODEL=` (no value) must not take precedence over the default |
| `test_resolve_no_env_var` | unset env var → falls back to default cache dir |
| `test_config_mismatch_error_message_is_actionable` | verifies the `ConfigMismatch` error message includes the directory, both vocab sizes, and points the user at `tokenizer.json` as the fix-point |

The vocab-probe path itself (full ORT inference) requires a real model on disk and stays `#[ignore]`-d alongside the existing `test_encode_*` tests — it gets exercised in real eval runs once the model is properly installed.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --features gpu-index --lib` — 1323 pass (+7 from this PR)
- [ ] CI green
- [ ] After merge: install proper SPLADE-Code 0.6B model to `~/training-data/splade-code-naver/onnx/`, set `CQS_SPLADE_MODEL=~/training-data/splade-code-naver/onnx`, force reindex to re-encode sparse vectors with the right model, re-run eval matrix
