### PR TITLE
fix: route conceptual queries to enriched index, not base

### DIFF
--- a/src/search/router.rs
+++ b/src/search/router.rs
@@ -341,6 +341,14 @@ pub fn classify_query(query: &str) -> Classification {
     //    Phase 5: behavioral queries use verbs the query author chose; enriched
     //    summaries standardize those verbs ("handles" → "processes"), which
     //    washes out the specific verb the user asked about. Route to base.
+    //
+    //    2026-04-10 update: same-corpus A/B at 50% summary coverage shows
+    //    behavioral routing produces 0pp delta — the routing fires but the
+    //    affected queries' gold answers are mostly callable types where
+    //    base ≈ enriched after enrichment_hash dedupe. Keeping the route on
+    //    base because the historical research data still says behavioral
+    //    is hurt by summaries; we just can't measure the effect on this
+    //    corpus shape. See research/enrichment.md for the data.
     if is_behavioral_query(&query_lower, &words) {
         return Classification {
             category: QueryCategory::Behavioral,
@@ -351,13 +359,31 @@ pub fn classify_query(query: &str) -> Classification {
     }
 
     // 7. Conceptual — abstract nouns, short non-identifier queries.
-    //    Phase 5: conceptual matches benefit from raw NL embeddings because
-    //    summaries flatten nuance into canonical phrasing. Route to base.
+    //
+    //    2026-04-10 update: ROUTING REVERSED. Phase 5 originally routed
+    //    conceptual to DenseBase based on the historical research finding
+    //    "summaries hurt conceptual −15pp". That finding was measured on a
+    //    corpus where only callable types were summarized.
+    //
+    //    After the eligibility expansion in PR #878 (summaries now cover
+    //    structs / enums / impls / traits / classes / etc.), conceptual
+    //    queries' gold answers are mostly type definitions where the
+    //    summary actively helps bridge code → concept ("a service container
+    //    that resolves dependencies" → "dependency injection"). Routing
+    //    those queries to the base index strips the helpful signal.
+    //
+    //    Same-corpus A/B at 50% coverage measured −3.7pp R@1 on conceptual
+    //    when routing was on. Keeping conceptual on the enriched index
+    //    until / unless the summary coverage shape changes again.
+    //
+    //    The lesson: routing rules are coupled to corpus shape, not to
+    //    a category-intrinsic property. They need to be re-validated any
+    //    time summary coverage changes meaningfully.
     if is_conceptual_query(&query_lower, &words) {
         return Classification {
             category: QueryCategory::Conceptual,
             confidence: Confidence::Medium,
-            strategy: SearchStrategy::DenseBase,
+            strategy: SearchStrategy::DenseDefault,
             type_hints: None,
         };
     }
@@ -571,11 +597,21 @@ mod tests {
     }
 
     #[test]
-    fn test_classify_conceptual_routes_to_base() {
-        // Phase 5: conceptual also routes to base for similar reasons.
+    fn test_classify_conceptual_routes_to_enriched() {
+        // 2026-04-10: ROUTING REVERSED. Originally Phase 5 routed conceptual
+        // to DenseBase based on the historical research finding "summaries
+        // hurt conceptual −15pp". Same-corpus A/B at 50% summary coverage
+        // measured −3.7pp R@1 from that routing — the historical finding
+        // was for a different corpus shape (only callables summarized).
+        // After PR #878 expanded summaries to type definitions, conceptual
+        // queries' gold answers benefit from the enrichment (the summary
+        // bridges code → concept on struct/enum chunks).
+        //
+        // See research/enrichment.md "Same-corpus A/B/C/D matrix (50% coverage)"
+        // for the data that drove this revision.
         let c = classify_query("dependency injection pattern");
         assert_eq!(c.category, QueryCategory::Conceptual);
-        assert_eq!(c.strategy, SearchStrategy::DenseBase);
+        assert_eq!(c.strategy, SearchStrategy::DenseDefault);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reverses the Phase 5 conceptual → DenseBase routing rule based on data from the same-corpus A/B at 50% summary coverage. Routing was costing us −3.7pp R@1 on conceptual_search, and that single category was the entire negative delta of the routing matrix.

## The data

Same binary, same `.cqs/`, only `CQS_DISABLE_BASE_INDEX` differs:

| Category | Cell A (bypass on, no routing) | Cell B (bypass off, routing on) | Δ R@1 |
|---|---|---|---|
| identifier_lookup | 96.8% | 96.8% | 0 |
| behavioral_search | 25.9% | 25.9% | 0 |
| **conceptual_search** | **25.9%** | **22.2%** | **−3.7pp** |
| multi_step | 40.9% | 40.9% | 0 |
| negation | 11.1% | 11.1% | 0 |
| structural_search | 57.1% | 57.1% | 0 |
| type_filtered | 31.2% | 31.2% | 0 |
| cross_language | 30.0% | 30.0% | 0 |
| **Total** | **43.0%** | **42.4%** | **−0.6pp** |

Conceptual is the entire negative delta. Reverting just that one routing rule should recover the loss.

## Why the original rule was wrong

The historical research finding that drove Phase 5 ("summaries hurt conceptual −15pp", in `research/enrichment.md`) was measured on a corpus where only callable types were summarized. After **PR #878** expanded summaries to type definitions, conceptual queries' gold answers are mostly structs / enums / impls — chunks where the LLM summary actively HELPS bridge code → concept ("a service container that resolves dependencies" → "dependency injection pattern"). Routing those queries to the un-summarized base index strips that helpful signal.

## Why behavioral and negation are NOT being changed

Both produced 0pp delta at 50% coverage in the same A/B. The routing fires (telemetry confirms), but the affected queries' gold answers happen to be on chunks where base ≈ enriched after enrichment_hash dedupe. We can't *measure* a benefit from routing them to base on this corpus shape — but the historical research data still says these categories are hurt by summaries, and the default-positive bias is on the side of "trust the historical finding when our own measurement is null."

If a future eval shows behavioral/negation routing is also 0pp or negative, those rules should be flipped too.

## The deeper lesson

Routing rules are coupled to **corpus shape**, not to category-intrinsic properties. The same routing rule can flip direction when summary coverage changes — adding or removing chunk types from the eligibility filter changes which chunks the gold answers fall on, which changes whether stripping summaries helps or hurts.

This is recorded in the inline comments at the call site so the next person revisiting the router knows to re-validate after any summary coverage change.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --features gpu-index --lib -- search::router` — 31 pass
- [x] Smoke test with `RUST_LOG`: `cqs "dependency injection pattern"` now logs `category=conceptual strategy=dense` (was `dense_base`)
- [ ] CI green
- [ ] Re-run cell B (bypass off, no splade) after this lands — should recover from 42.4% R@1 / 22.2% conceptual to ~43.0% R@1 / 25.9% conceptual (matching Cell A within rounding)
