### PR TITLE
docs: end-of-session continuity update

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,35 +2,46 @@
 
 ## Right Now
 
-**Phase 5 dual embeddings draft PR #876 up. Eval running. (2026-04-10 11:01 CDT)**
+**Phase 5 + summary expansion shipped. Routing null at N=27. SPLADE-Code 0.6B re-eval blocked on encoding perf. (2026-04-10 19:00 CDT)**
 
-### Recent wins
-- v1.21.0 + v1.22.0 released
-- v1.22.0: adaptive retrieval v1 (classifier, routing, SPLADE pre-pooled, telemetry)
-- SPLADE v2: NULL. SPLADE-Code 0.6B (Naver): **+1.2pp R@1, +20pp cross-language**
-- Full audit cleared, chunk types in 19 languages, dependabots merged
-- PR #874 merged (eval script field name + --config flag fix)
-- PR #875 merged (cuvs pinned to =26.2 — CUDA 13 incompatibility with 26.4)
+### This session shipped (10 PRs to main)
+- #876 Phase 5 dual embeddings + DenseBase routing
+- #877 CQS_DISABLE_BASE_INDEX env var (eval A/B)
+- #878 summary eligibility expanded from is_callable() → is_code()
+- #879 roadmap updates (selective SPLADE routing tracked)
+- #880 bypass test coverage
+- #881 CQS_SPLADE_MODEL env var + vocab-mismatch probe
+- #882 CQS_TYPE_BOOST env var (sweep infra)
+- #883 evals/run_sweep.py harness
+- #884 SPLADE vocab probe accepts benign lm_head padding
+- #885 routing fix: conceptual back to enriched (later showed as null)
+- #886 real batched encode_batch (5-10x speedup ceiling)
+- #887 (open) CQS_SPLADE_BATCH env var + adaptive halving
 
-### Phase 5 status (PR #876, draft)
-- Schema v17→v18 done, embedding_base column wired through pipeline
-- Dual HNSW build (`index_base.hnsw.*`) and DenseBase router strategy live
-- 14 new tests, 1316 lib tests pass total
-- Smoke test: behavioral/conceptual queries route to base index, structural stays on enriched
-- Eval running (~165 q × ~12s/q ≈ 33min); waiting on results
-- Hook drive-by: replaced verbose pre-edit-context.py with focused pre-edit-impact.py (function-targeted, no jq dep)
+### Eval matrix findings (50% coverage, BGE-large)
+- Phase 5 dual-routing: **null at N=27 per category** — all category swings within ±1 query
+- Total R@1: 43.0% with or without routing (within noise)
+- The "−3.7pp on conceptual from routing" earlier in the day was a misread (one query out of 27 = 3.7pp)
+- The historical research finding "summaries hurt conceptual −15pp" was for a different corpus shape
+
+### Pending blockers
+- **SPLADE-Code 0.6B encoding** (task #16) — encoder leaks GPU memory (7.4 → 30GB over 1h) with no progress regardless of batch size. Likely needs ORT arena reset / IO bindings / per-batch session refresh. Until fixed, the SPLADE-Code 0.6B re-eval (the only experiment with above-noise predicted effect) is blocked.
 
 ### What's next
-1. Eval results → flip PR #876 from draft → merge
-2. Paper polish with SPLADE-Code + dual embedding results
-3. Phase 6: explainable search (depends on SPLADE-Code integration)
+1. Debug the SPLADE encoding GPU memory leak (task #16) — biggest unblock
+2. Once unblocked: re-run the 4-cell matrix with proper SPLADE-Code 0.6B
+3. Decide what ships in v1.23.0 based on real SPLADE-Code 0.6B numbers
+4. Larger eval set (165q is too small to discriminate ±3pp effects)
 
 ## Open Issues
 - #856, #717, #389, #255, #106, #63
 
 ## Architecture
-- Version: 1.22.0, Tests: 1316 lib (+5 Phase 5), Chunk types: 29
-- Adaptive retrieval Phases 1-5 implemented (5 in flight on PR #876)
-- Schema: v18 (embedding_base column for dual HNSW indexes)
-- SPLADE-Code 0.6B: +1.2pp R@1, +20pp cross-language
+- Version: 1.22.0
+- Schema: v18 (embedding_base column for dual HNSW)
+- Tests: 1330 lib pass
+- Adaptive retrieval Phases 1-5 implemented
 - Two HNSW indexes per project: enriched (`index.hnsw.*`) + base (`index_base.hnsw.*`)
+- SPLADE-Code 0.6B model files at `~/training-data/splade-code-naver/onnx/`
+  - Set `CQS_SPLADE_MODEL` env var to use it (vocab probe verifies tokenizer/model match)
+  - Encoding currently broken (task #16)


### PR DESCRIPTION
## Summary

End-of-session continuity update. Captures the full session arc:

**Shipped to main this session (12 PRs):**
- #876 Phase 5 dual embeddings + DenseBase routing
- #877 `CQS_DISABLE_BASE_INDEX` env var (eval A/B testing)
- #878 summary eligibility expanded `is_callable() → is_code()`
- #879 roadmap updates (selective SPLADE routing tracked)
- #880 bypass test coverage
- #881 `CQS_SPLADE_MODEL` env var + vocab-mismatch construction probe
- #882 `CQS_TYPE_BOOST` env var (sweep infra)
- #883 `evals/run_sweep.py` parameter sweep harness
- #884 SPLADE vocab probe accepts benign lm_head padding
- #885 routing fix: conceptual back to enriched (later showed null)
- #886 real batched `encode_batch` (5–10x speedup ceiling)
- #887 (open) `CQS_SPLADE_BATCH` env var + adaptive halving

**Key findings:**
- **Phase 5 dual-routing is null at N=27 per category.** All category swings on the 165q v2 train split are within ±1 query (3.7pp). The "−3.7pp on conceptual" earlier in the day was a misread of single-query noise. Total R@1 = 43.0% with or without routing.
- The historical research finding "summaries hurt conceptual −15pp" was for a different corpus shape (only callables summarized). After PR #878 expanded summaries to type definitions, the per-category summary effects shifted.
- **SPLADE-Code 0.6B encoding is broken** — encoder leaks GPU memory (7.4 → 30GB over 1h) regardless of batch size, no measurable progress. Tracked as task #16.

**Pending blockers for v1.23.0:**
1. SPLADE-Code 0.6B encoding perf bug (task #16) — biggest unblock
2. Re-run the eval matrix with proper SPLADE once #16 is fixed
3. Larger eval set — 165q is too small to discriminate ±3pp effects

## Test plan

- [x] Docs only, no code changes
- [ ] CI green (trivial doc path)
