### PR TITLE
fix: SPLADE encoding GPU memory leak — constant padding + arena reset

### DIFF
--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -404,11 +404,48 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
                     let mut encoded = 0usize;
                     let mut failed = 0usize;
 
-                    // PF-5: batch encode instead of per-chunk
-                    const SPLADE_BATCH: usize = 64;
-                    for batch in chunk_texts.chunks(SPLADE_BATCH) {
+                    // PF-5: batch encode instead of per-chunk.
+                    //
+                    // CQS_SPLADE_BATCH overrides the initial batch size
+                    // (default 64). Larger SPLADE models (SPLADE-Code 0.6B
+                    // at 5.5x params) overflow GPU memory at 64. The inner
+                    // loop is also adaptive: on OOM, halve and retry.
+                    //
+                    // CQS_SPLADE_RESET_EVERY (default 0 = disabled) triggers
+                    // a session.clear() every N batches. This frees the ORT
+                    // BFC arena which can accumulate cached allocations even
+                    // with constant-shape inputs. Set to 32-64 if encoding
+                    // a large corpus through a large model leaks memory.
+                    let initial_batch: usize = std::env::var("CQS_SPLADE_BATCH")
+                        .ok()
+                        .and_then(|v| v.parse().ok())
+                        .filter(|&n: &usize| n >= 1)
+                        .unwrap_or(64);
+                    let reset_every: usize = std::env::var("CQS_SPLADE_RESET_EVERY")
+                        .ok()
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0);
+
+                    let total_chunks = chunk_texts.len();
+                    let progress_step = (total_chunks / 20).max(1);
+                    let mut next_progress_threshold = progress_step;
+
+                    tracing::info!(
+                        initial_batch,
+                        reset_every,
+                        total_chunks,
+                        "SPLADE encoding starting"
+                    );
+
+                    let mut current_batch_size = initial_batch;
+                    let mut idx = 0;
+                    let mut batches_done = 0usize;
+                    while idx < total_chunks {
+                        let end = (idx + current_batch_size).min(total_chunks);
+                        let batch = &chunk_texts[idx..end];
                         let ids: Vec<&str> = batch.iter().map(|(id, _)| id.as_str()).collect();
                         let texts: Vec<&str> = batch.iter().map(|(_, t)| t.as_str()).collect();
+
                         match encoder.encode_batch(&texts) {
                             Ok(svs) => {
                                 for (id, sv) in ids.into_iter().zip(svs) {
@@ -417,24 +454,58 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
                                         encoded += 1;
                                     }
                                 }
+                                idx = end;
+                                batches_done += 1;
+
+                                // Periodic arena reset
+                                if reset_every > 0 && batches_done % reset_every == 0 {
+                                    encoder.clear_session();
+                                    tracing::debug!(batches_done, "SPLADE periodic session reset");
+                                }
+
+                                // Progress logging at ~5% milestones
+                                if encoded >= next_progress_threshold {
+                                    let pct = encoded * 100 / total_chunks.max(1);
+                                    tracing::info!(
+                                        encoded,
+                                        total = total_chunks,
+                                        pct,
+                                        batch_size = current_batch_size,
+                                        "SPLADE encoding progress"
+                                    );
+                                    if !cli.quiet {
+                                        eprintln!(
+                                            "  SPLADE: {}/{} ({}%) batch={}",
+                                            encoded, total_chunks, pct, current_batch_size
+                                        );
+                                    }
+                                    next_progress_threshold += progress_step;
+                                }
+                            }
+                            Err(e) if current_batch_size > 1 => {
+                                let new_size = (current_batch_size / 2).max(1);
+                                tracing::warn!(
+                                    old_batch = current_batch_size,
+                                    new_batch = new_size,
+                                    error = %e,
+                                    "SPLADE batch failed (likely OOM) — halving batch size and retrying"
+                                );
+                                // Clear the session on OOM to free leaked memory
+                                // before retrying at the smaller size.
+                                encoder.clear_session();
+                                current_batch_size = new_size;
+                                // Don't advance idx — retry the same range.
                             }
                             Err(e) => {
-                                // Fallback: encode individually to isolate failures
-                                if failed == 0 {
-                                    tracing::warn!(error = %e, "SPLADE batch failed, falling back to per-chunk");
-                                }
-                                for (id, text) in batch {
-                                    match encoder.encode(text) {
-                                        Ok(sv) if !sv.is_empty() => {
-                                            sparse_vecs.push((id.clone(), sv));
-                                            encoded += 1;
-                                        }
-                                        Ok(_) => {}
-                                        Err(_) => {
-                                            failed += 1;
-                                        }
-                                    }
-                                }
+                                // batch_size already at 1: this chunk truly
+                                // can't be encoded. Skip it and move on.
+                                tracing::warn!(
+                                    chunk_id = ?ids[0],
+                                    error = %e,
+                                    "SPLADE encoding failed at batch_size=1, skipping chunk"
+                                );
+                                failed += 1;
+                                idx += 1;
                             }
                         }
                     }
@@ -442,7 +513,10 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
                         store.upsert_sparse_vectors(&sparse_vecs)?;
                     }
                     if !cli.quiet {
-                        println!("  SPLADE: {} chunks encoded", encoded);
+                        println!(
+                            "  SPLADE: {} chunks encoded (final batch={})",
+                            encoded, current_batch_size
+                        );
                         if failed > 0 {
                             println!("  SPLADE: {} chunks failed", failed);
                         }

--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -458,7 +458,7 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
                                 batches_done += 1;
 
                                 // Periodic arena reset
-                                if reset_every > 0 && batches_done % reset_every == 0 {
+                                if reset_every > 0 && batches_done.is_multiple_of(reset_every) {
                                     encoder.clear_session();
                                     tracing::debug!(batches_done, "SPLADE periodic session reset");
                                 }

--- a/src/splade/mod.rs
+++ b/src/splade/mod.rs
@@ -499,11 +499,22 @@ impl SpladeEncoder {
 
     /// Batch encode multiple texts in a single forward pass.
     ///
-    /// Tokenizes all inputs, pads to the longest sequence in the batch,
-    /// runs one ONNX inference call, and extracts per-example sparse vectors.
-    /// For SPLADE-Code 0.6B (600M parameters), this is the difference between
-    /// ~3-hour and ~10-minute corpus encoding — the per-call ORT overhead
-    /// dominates inference time on large models.
+    /// Tokenizes all inputs, pads to a CONSTANT max_seq_len (configurable
+    /// via `CQS_SPLADE_MAX_SEQ`, default 256), runs one ONNX inference call,
+    /// and extracts per-example sparse vectors.
+    ///
+    /// **Why constant padding (not per-batch max)?** ORT's BFC arena caches
+    /// allocations by tensor shape. If consecutive batches have different
+    /// shapes (which they would with per-batch-max padding), the arena
+    /// allocates new slots and never frees old ones — observed leak of
+    /// 7.4 → 30 GB GPU memory over 60 minutes encoding 11k chunks with
+    /// SPLADE-Code 0.6B. Padding to a fixed length keeps every input
+    /// tensor at the same shape so ORT can reuse the same arena slots.
+    ///
+    /// Tradeoff: short inputs get padded more (median chunk is ~16 tokens,
+    /// so padding to 256 is ~16x overhead). For SPLADE-Code 0.6B that's
+    /// fine — the activation memory at batch=8, seq=256 is ~600 MB which
+    /// fits comfortably and stays stable across all batches.
     ///
     /// Output handling matches the single-input `encode` path:
     /// - `sparse_vector` (pre-pooled, 2D): slice rows directly, threshold-filter
@@ -559,23 +570,33 @@ impl SpladeEncoder {
             .collect::<Result<_, _>>()?;
 
         let batch_size = encodings.len();
-        let max_seq_len = encodings
-            .iter()
-            .map(|e| e.get_ids().len())
-            .max()
-            .unwrap_or(0);
-        if max_seq_len == 0 {
-            return Ok(vec![Vec::new(); texts.len()]);
-        }
 
-        // Step 3: pad to [batch_size, max_seq_len]. Pad token is 0; mask is 0
-        // for padding positions so they don't influence attention.
+        // Step 3: pad to a CONSTANT max_seq_len (configurable via
+        // CQS_SPLADE_MAX_SEQ, default 256). Constant shape is critical for
+        // ORT BFC arena reuse — varying shapes leak GPU memory over time.
+        //
+        // Inputs longer than max_seq_len are truncated. The 256 default is
+        // larger than the cqs corpus p99 (180 tokens) so truncation is rare,
+        // but if a different corpus has many long chunks, bump CQS_SPLADE_MAX_SEQ.
+        let max_seq_len: usize = std::env::var("CQS_SPLADE_MAX_SEQ")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&n: &usize| n >= 8)
+            .unwrap_or(256);
+
+        // Pad token is 0; mask is 0 for padding positions so they don't
+        // influence attention. Truncation: if a real input is longer than
+        // max_seq_len, we keep only the first max_seq_len tokens.
         let mut input_ids: Vec<i64> = Vec::with_capacity(batch_size * max_seq_len);
         let mut attention_mask: Vec<i64> = Vec::with_capacity(batch_size * max_seq_len);
+        let mut truncations = 0usize;
         for enc in &encodings {
             let ids = enc.get_ids();
             let mask = enc.get_attention_mask();
             let n = ids.len();
+            if n > max_seq_len {
+                truncations += 1;
+            }
             for i in 0..max_seq_len {
                 if i < n {
                     input_ids.push(ids[i] as i64);
@@ -585,6 +606,14 @@ impl SpladeEncoder {
                     attention_mask.push(0);
                 }
             }
+        }
+        if truncations > 0 {
+            tracing::debug!(
+                truncations,
+                batch_size,
+                max_seq_len,
+                "SPLADE batch had truncated inputs"
+            );
         }
 
         let ids_array =
@@ -698,7 +727,9 @@ impl SpladeEncoder {
                         .expect("shape derived from data length");
 
                     // Build a -inf mask for padded positions so they can't win max-pool.
-                    let real_seq_len = encodings[b].get_ids().len();
+                    // Clamp real_seq_len to max_seq_len in case the input was
+                    // truncated to fit the constant padding length.
+                    let real_seq_len = encodings[b].get_ids().len().min(max_seq_len);
                     let pooled: Vec<f32> = (0..vocab)
                         .map(|v| {
                             let mut max_val = f32::NEG_INFINITY;


### PR DESCRIPTION
## Summary

Fixes the SPLADE-Code 0.6B encoding GPU memory leak that blocked the SPLADE re-eval (task #16). Three changes:

### 1. CONSTANT `max_seq_len` in `encode_batch` (was per-batch max)

**Root cause of the leak.** ORT's BFC arena caches allocations by tensor shape. With per-batch-max padding, each batch had a different `(batch_size, seq_len)` shape, so ORT allocated new arena slots for every batch and never freed the old ones. Observed growth: **7.4 → 30 GB** GPU memory over 60 minutes encoding 11k chunks with SPLADE-Code 0.6B, with no measurable progress.

**Fix:** pad to a CONSTANT `max_seq_len` (configurable via `CQS_SPLADE_MAX_SEQ`, default 256). Every batch now has identical shape and ORT reuses the same arena slots. Inputs longer than `max_seq_len` are truncated; the 256 default is well above the cqs corpus p99 (180 tokens) so truncation is rare.

**Verified:** SPLADE-Code 0.6B reindex of the cqs corpus (12k chunks) now progresses with stable GPU memory. Live trace from `/tmp/reindex_splade_v4.log` while this PR was being written:

```
SPLADE: 616/12246 (5%) batch=8
SPLADE: 1224/12246 (9%) batch=8
SPLADE: 1840/12246 (15%) batch=8
SPLADE: 2448/12246 (19%) batch=8
SPLADE: 3064/12246 (25%) batch=8
```

Where the previous attempt hung at 0% with no progress for 90+ minutes.

### 2. `CQS_SPLADE_RESET_EVERY` env var in `cmd_index` (default 0, disabled)

Belt-and-suspenders against any remaining arena growth. When set to N, calls `encoder.clear_session()` every N successful batches. The session is lazily re-created on the next encode call, which forces a fresh ORT arena. Set to 32-64 for very large corpora through very large models.

### 3. Adaptive batch halving + `clear_session()` on OOM

Previous fallback on a batch failure was "encode each chunk in that batch individually" which negated batching entirely. New behavior: halve current batch size, clear session to free leaked memory, retry the same range. Falls back to per-chunk only when `batch_size==1` AND single chunk still fails (truly unencodable).

### Plus (smaller fixes)

- Per-5%-progress logging so long encodes have something visible in the log instead of running silently for hours.
- `CQS_SPLADE_BATCH` env var (default 64) lets research override the initial batch size. SPLADE-Code 0.6B works at batch=8 on a 48GB GPU.
- Logits-output path's max-pool `real_seq_len` clamp: when an input is truncated to `max_seq_len`, the real seq length used for masking must be clamped to `max_seq_len` too, otherwise the mask loop indexes past the padded tensor.

## Supersedes

This PR supersedes **#887** (which had the env var + adaptive halving but hit clippy's `manual_is_multiple_of` lint and didn't fix the underlying leak). I'll close #887 once this is up.

## Test plan

- [x] `cargo build --release --features gpu-index,llm-summaries` clean
- [x] `cargo fmt --check` clean
- [x] Live verification: SPLADE-Code 0.6B encoding the cqs corpus is **actually progressing** at 5%, 9%, 15%, 19%, 25%... (was hung at 0%)
- [ ] Reindex completes in single-digit-minute range (was >90 min and didn't finish)
- [ ] CI green
- [ ] After merge: real SPLADE-Code 0.6B eval — should reproduce `+1.2pp R@1, +20pp cross_language` from the previous SPLADE-Code eval
