### PR TITLE
docs: openrct2 rust port + dual-trail experiment spec

### DIFF
--- a/docs/plans/2026-04-10-openrct2-rust-port-dual-trail.md
+++ b/docs/plans/2026-04-10-openrct2-rust-port-dual-trail.md
@@ -265,21 +265,19 @@ Ship it as soon as the criteria are satisfied. Re-evaluate whether to continue t
 
 2. **RNG cannot be reproduced bit-exact**. Same as above, mitigated by Strategy 2 fallback.
 
-3. **Global state translation intractable**. Decided in 0e. Worst case: the operator chooses a mapping that doesn't fit the upstream architecture and must refactor the Rust port partway through. Mitigation: revisit the 0e decision after module 1.4 completes, when enough Rust exists to test the assumption.
+3. **Global state translation intractable**. Decided in 0e. Worst case: the chosen mapping doesn't fit the upstream architecture and the Rust port has to refactor partway through. Mitigation: revisit the 0e decision after module 1.4 completes, when enough Rust exists to test the assumption.
 
 4. **Upstream changes invalidate the harness**. Mitigation: pin to a tagged release and treat as immutable. Do not chase upstream changes during Phase 1 or Phase 2.
 
-5. **Operator fatigue or interest drift**. The minimum publishable artifact (Phase 0 + three modules, see above) exists specifically to mitigate this. Even if the full port never finishes, the experiment publishes.
+5. **Single-operator confound**. The same human directs both trails. Operator priors, time of day, and recent context affect both trails. Acknowledged as a limitation; alternating between trails reduces but doesn't eliminate the bias. Independent replication would strengthen external validity.
 
-6. **Single-operator confound**. The same human directs both trails, which means operator skill, time of day, mood, and recent learning all affect both trails. This is acknowledged as a limitation of the experimental design. Alternating between trails session-to-session reduces but doesn't eliminate the bias. Future replication by independent operators would strengthen external validity.
+6. **Trail B advantage from cqs design lessons**. The operator built cqs and has strong priors about what code intelligence should provide. Trail B might benefit from those priors even without the tool. Mitigation: pre-commit to Trail B's tool list before Phase 1 and do not modify it during the experiment.
 
-7. **Trail B advantage from cqs design lessons**. The operator built cqs and has strong priors about what code intelligence should provide. Trail B might benefit from those priors (the operator knows what to look for even without the tool). Mitigation: pre-commit to Trail B's tool list before Phase 1 starts and do not modify it during the experiment.
+7. **Trail A disadvantage from cqs maintenance overhead**. Time spent debugging cqs itself counts as Trail A overhead even though it's not translation work. Mitigation: track cqs maintenance time separately so it can be excluded or included in the analysis as appropriate.
 
-8. **Trail A disadvantage from cqs maintenance overhead**. Time spent debugging cqs itself counts as Trail A overhead even though it's not "translation work." Mitigation: track cqs maintenance time separately so it can be excluded or included in the analysis as appropriate.
+8. **Token measurement noise**. Anthropic API token counts include cache reads, which behave differently across sessions. Mitigation: report both raw and cache-adjusted token counts. The cache-adjusted number is the better proxy for agent work done.
 
-9. **Token measurement noise**. Anthropic API token counts include cache reads, which behave differently across sessions. Mitigation: report both raw token counts and cache-adjusted token counts. The cache-adjusted number is the better proxy for "agent work done."
-
-10. **Project becomes more interesting than the experiment**. Easy failure mode: the operator starts caring about the port itself and stops tracking metrics rigorously. Mitigation: the spec mandates `metrics.tsv` updates per session. Sessions without metrics updates are not counted toward the experiment. This is the operator's main discipline-enforcement mechanism.
+9. **Metric tracking lapses**. The dual-trail comparison requires `metrics.tsv` updates after every module in both trails. If tracking lapses, the experiment loses its publishable result even though the port keeps progressing. Mitigation: sessions without a corresponding metrics row do not count toward the experiment, period. This is a hard rule, not a soft preference.
 
 ## Repository layout
 

--- a/docs/plans/2026-04-10-openrct2-rust-port-dual-trail.md
+++ b/docs/plans/2026-04-10-openrct2-rust-port-dual-trail.md
@@ -1,0 +1,334 @@
+# OpenRCT2 Rust Port — Dual-Trail Experiment
+
+## Thesis
+
+A faithful Rust port of OpenRCT2 (a 25-year-old C/C++ codebase reverse-engineered from x86 assembly) is the substrate. **The publishable result is the dual-trail experiment**: two parallel translation efforts on the same upstream commit using the same agent stack, with one trail using cqs for code intelligence augmentation and the other using only the agent's built-in tools. Pre-registered metrics. Result published regardless of direction.
+
+The full port is the largest container the experiment fits inside. **The experiment is publishable after a single shared module completes in both trails**, not after the full port. If the full port never finishes, the experiment still produces an answer to the question that motivates building cqs in the first place: does code intelligence augmentation measurably improve agent-directed code translation?
+
+## Why this question matters
+
+cqs's design rests on the bet that structural code intelligence — typed chunks, call graphs, impact tracing, per-category retrieval — produces meaningfully better outcomes for agents working on code than unstructured search. That bet has been validated indirectly (telemetry, eval R@1, internal use) but never head-to-head against an unaugmented agent on a sustained, observable, multi-thousand-decision task. OpenRCT2 → Rust is the first task large enough, mechanical enough, and verifiable enough to make the comparison rigorous.
+
+If the cqs trail wins on the pre-registered metrics, that validates the entire research lane and produces a paper that justifies further investment in code intelligence as a category. If the unaugmented trail wins or ties, that's also a finding worth publishing — cqs's actual leverage is narrower than claimed and the architecture should be re-examined.
+
+## Pre-registered hypothesis
+
+**H1 (cqs trail produces fewer regression bugs per ported function.)** Code intelligence makes the agent aware of caller/callee context before editing, so cross-module breakage is caught earlier. Predicted effect: ≥30% reduction in regression bugs in the cqs trail vs the control trail, measured per merged module.
+
+**H2 (cqs trail consumes fewer agent tokens per validated module.)** Structural retrieval reduces the amount of file content the agent has to read into context to understand a function. Predicted effect: ≥20% token reduction per validated module.
+
+**H3 (cqs trail completes modules in fewer wall-clock hours.)** Faster context assembly + fewer regression cycles. Predicted effect: ≥25% wall-clock reduction.
+
+**H0 (no significant difference.)** Both trails perform within ±10% on all three metrics. This would be a meaningful negative result — the structural advantages don't manifest at translation-task scale.
+
+The metrics are tracked from Phase 1 module 1 onward. The experiment publishes after **at least three modules** have completed in both trails, regardless of whether the full Phase 1 ever finishes. Three modules is the minimum for a non-trivial sample.
+
+## Source
+
+- Upstream: https://github.com/OpenRCT2/OpenRCT2
+- Pin target: latest tagged release at Phase 0 start. Both trails use the **identical pinned commit**. Upstream is treated as immutable spec for the duration of the experiment.
+- Required runtime assets: original RCT2 or RCT Classic data files from a legal copy (GOG sells RCT2 for ~$10).
+
+## Trail definitions
+
+### Trail A (cqs-augmented)
+
+- Agent stack: Claude Code with cqs MCP server enabled
+- Pre-edit hook: cqs impact runs before every Edit, injecting caller/test/risk context
+- Translation workflow uses: `cqs scout`, `cqs gather`, `cqs impact`, `cqs callers`, `cqs test-map`, `cqs context` for cross-language tracing across the C++/Rust boundary
+- Indexes both upstream OpenRCT2 (C++) and the in-progress Rust port simultaneously
+- Cross-language call tracing identifies untouched-but-affected Rust code when an upstream C++ function is re-translated
+
+### Trail B (control)
+
+- Agent stack: Claude Code with default tools only (Read, Edit, Glob, Grep, Bash)
+- No cqs, no MCP code intelligence server, no pre-edit hook
+- Translation workflow uses standard exploration: grep, file reads, manual context assembly
+- Indexes nothing — context comes from agent's own search tools session-by-session
+
+### Identical between trails
+
+- Same Anthropic model (whatever is current at Phase 0 start, then frozen for the duration)
+- Same upstream pinned commit
+- Same module ordering
+- Same validation harness (Phase 0c output)
+- Same RNG seeds in test fixtures
+- Same operator (single human directing both trails, alternating sessions)
+- Same time-of-day distribution (agent state may vary across the day; alternating prevents lopsided sampling)
+
+### Tracked per session
+
+- Tokens consumed (input + output, separated)
+- Wall-clock duration
+- Number of agent tool calls, broken down by tool
+- Number of validation iterations (cycles of port → harness fail → fix → retry)
+- Lines of Rust produced (added) and modified
+- Regression bugs introduced (count of validation failures in already-passing modules after a new module's port begins)
+
+## Validation harness
+
+The experiment cannot run without a working harness. Phase 0c is the gate.
+
+**Strategy 1 (preferred): state-dump diff.** Patch upstream OpenRCT2 to emit a deterministic JSON dump of simulation state every N ticks. Run the same save through upstream and the Rust port for N ticks. Diff the dumps. If they match for the slice owned by the module under test, the module passes.
+
+**Strategy 2 (fallback): behavioral equivalence.** If state-dump determinism cannot be achieved (because of float ordering, uninitialized memory, OS-specific behavior, or RNG re-seeding), validation switches to invariant-checking with numeric thresholds. Phase 1 metrics adjust accordingly:
+
+- Park rating tracks within ±5% over 10,000 ticks
+- Guest count converges within ±2% by tick 10,000
+- Total revenue tracks within ±5%
+- No ride breakdowns occur in the port that didn't occur in upstream
+- No guest type appears in the port that didn't exist in upstream
+
+The fallback is weaker but still rigorous enough to detect translation errors that produce qualitatively different behavior.
+
+**Strategy 3 (hard fallback): user-acceptance only.** If neither state-dump nor behavioral equivalence can be made to work, validation degrades to "the port produces a playable scenario indistinguishable from upstream by an experienced player." This is the weakest bar and changes the experiment's scope substantially. Document and re-spec if reached.
+
+The choice between Strategy 1 and Strategy 2 is decided in Phase 0c. **Do not begin Phase 1 without a working strategy.**
+
+## Phase 0 — Reconnaissance and validation gate
+
+Phase 0 deliverables are the go/no-go gate. Do not write any Rust until all five are complete.
+
+### 0a — Prior art check (1 day)
+
+Search GitHub, crates.io, GitLab, Codeberg, and the web for existing Rust ports of OpenRCT2 or RCT2. Document findings:
+- Any prior attempt at any completion level
+- Active maintainers, last commit, license
+- Whether the prior attempt is joinable or fork-able
+- Whether the prior attempt's design decisions match this spec's
+
+If a viable prior attempt exists at meaningful completion, **stop** and re-evaluate: join, fork, or proceed knowing the comparison's external validity is reduced.
+
+### 0b — Codebase recon (3–5 days)
+
+- Pin upstream to the latest tagged release. Record the commit hash.
+- Build OpenRCT2 from the pinned commit, verify it runs with legal asset files.
+- Index the pinned C++ codebase with cqs (Trail A's first use of the tool).
+- Generate `RECON.md` containing:
+  - File counts and line counts per module
+  - Module dependency graph (cqs gather output)
+  - Inventory of every file-scope variable, extern, singleton, and global state holder
+  - Inventory of every RNG call site
+  - Save file format reference
+  - Game action system reference
+  - Multiplayer sync hash extraction location (used in 0c)
+
+### 0c — Validation harness verification (3–7 days)
+
+- **First** verify Strategy 1 (state-dump diff). Patch upstream to emit deterministic state dumps. Run two upstream instances from the same save for 10,000 ticks. Diff the dumps. **They must be byte-identical.** If yes, Strategy 1 is the validation strategy and Phase 1 can begin.
+- If Strategy 1 fails, identify why (float ordering? uninitialized memory? OS scheduler?). Document. Verify Strategy 2 (behavioral equivalence) by running two upstream instances and confirming the invariant thresholds hold. If yes, Phase 1 begins with Strategy 2 validation.
+- If Strategy 2 fails, escalate to Strategy 3 and re-evaluate whether the project should continue at all.
+
+### 0d — RNG verification (1–2 days)
+
+- Locate the upstream RNG. Document algorithm and seeding.
+- Implement the RNG in Rust (the smallest possible standalone test).
+- Run both with identical seeds for 10,000 iterations.
+- Sequences must match exactly (Strategy 1) or produce statistically equivalent distributions (Strategy 2).
+
+### 0e — Architectural decision: global state (1 day)
+
+OpenRCT2's heritage from x86 assembly means it's full of file-scope and global mutable state. Choose the Rust mapping based on the inventory from 0b:
+
+- **Single `World` struct passed to every function** — most idiomatic, biggest API surface change, easiest to reason about
+- **Thread-locals matching C++ globals** — least idiomatic, smallest API surface change, easiest to keep validation harness comparing apples-to-apples
+- **`Arc<Mutex<…>>` per subsystem** — middle ground, allows future parallelism, adds locking overhead and complexity
+
+Document the decision and rationale in `RECON.md`. Both trails must use the same mapping (otherwise they're not comparing the same task).
+
+### Phase 0 deliverable
+
+`RECON.md` containing all five outputs, the validation strategy choice, the global state decision, the pinned commit hash, and a sign-off section the operator initials before Phase 1 begins. Estimated effort: **2–4 weeks** of evening work.
+
+## Phase 1 — Simulation core port
+
+Port modules in dependency order. Each module must pass the validation harness for its state slice before the next module begins.
+
+### Module sizing — not equal
+
+Modules 1.5 and 1.6 are dramatically larger than the others. Acknowledged up front so the spec doesn't read like eight equal milestones.
+
+| Module | Description | Estimated effort share |
+|---|---|---|
+| 1.1 | Foundational types: coordinates, fixed-point math, RNG, tile data, entity IDs | ~5% |
+| 1.2 | Map and terrain: grid, tile types, height data, footpath network | ~10% |
+| 1.3 | Minimum viable ride: one stationary flat ride (e.g. observation tower) | ~5% |
+| 1.4 | Minimum viable guest: one guest spawned, walking on a path | ~5% |
+| **1.5** | **Vehicles and tracked rides** (coasters, gentle rides, thrill rides, trains, station logic, track pieces) | **~30%** |
+| **1.6** | **Full guest AI** (needs system, decision making, pathfinding at scale) | **~30%** |
+| 1.7 | Staff (mechanics, handymen, security, entertainers) | ~10% |
+| 1.8 | Park economics, ratings, loans, scenarios, win conditions | ~5% |
+
+Modules 1.5 and 1.6 together are ~60% of Phase 1's total effort. Each is itself a multi-week project with sub-milestones. The spec deliberately does not break them into sub-modules at this stage because the right decomposition depends on what 0b's recon reveals about upstream's actual structure.
+
+### Per-module workflow (both trails)
+
+1. Read the module's upstream C++ scope (Trail A uses cqs scout/gather/context; Trail B uses Read/Glob/Grep).
+2. Identify the state slice this module owns (Trail A reads from RECON.md's inventory; Trail B builds the slice list manually).
+3. Build a fixture: load a known save in upstream, run N ticks, dump the state slice using the Phase 0c harness.
+4. Translate the C++ to Rust function-by-function. Reproduce behavior, including bugs that the pinned commit has. **The pinned commit is the spec, not "what the code should do."**
+5. Run the same fixture through the Rust port. Dump the same slice.
+6. Diff the two dumps (Strategy 1) or check invariant thresholds (Strategy 2).
+7. If the diff is empty / invariants hold: module passes. Otherwise iterate.
+8. Record session metrics (tokens, wall clock, tool calls, iteration count, lines, regressions) in `metrics.tsv`.
+9. After both trails complete the module, snapshot metrics for the experiment writeup.
+
+### Module exit criteria
+
+A module is "done" when:
+- Validation harness reports zero divergence (Strategy 1) or all invariants hold (Strategy 2)
+- Both trails have ported the same module with the same pinned upstream
+- Per-trail metrics are recorded
+- The Rust crate compiles cleanly with no warnings
+- All previously-passing modules still pass (regression check)
+- A snapshot tag is created in both trail repos for reproducibility
+
+## Phase 2 — Rendering, input, audio, UI
+
+**Phase 2 has effort parity with Phase 1.** Do not scope it down to "bolt rendering on top of the simulation." The rendering, asset loading, audio, and UI together represent another 12–18 months of evening work for one operator plus agent.
+
+Sub-components (each is itself a multi-week project):
+
+- **DAT format asset loader**: Port from upstream. The DAT format is a 25-year-old binary asset bundle that took the OpenRCT2 community years to fully reverse-engineer. The port reuses upstream's loader logic, not the original Sawyer asset format work.
+- **Sprite renderer (wgpu)**: Match upstream's software renderer pixel-for-pixel where possible; document any GPU-specific divergence.
+- **Audio playback**: Original sound effects and music from RCT2 asset files.
+- **Input handling (winit)**: Mouse, keyboard, gamepad if upstream supports it.
+- **In-game UI**: Menus, ride construction interface, park management dialogs, finance reports, scenario editor. Decision deferred to Phase 2 start: pixel-exact reproduction (much more work) vs egui-based reimplementation (more work to design, less work to implement, breaks the "faithful port" thesis).
+
+Phase 2 begins only after Phase 1 is complete. The experiment publishes after Phase 1 if Phase 2 is too large a commitment to make.
+
+## Phase 3 — Library extraction
+
+Refactor Phase 1's simulation core into a standalone crate `rct-sim` exposing:
+
+```rust
+fn load(path: &Path) -> Result<Simulation>
+impl Simulation {
+    fn step(&mut self, n_ticks: u32);
+    fn state(&self) -> StateSnapshot;
+    fn inject(&mut self, action: GameAction) -> Result<()>;
+    fn serialize(&self) -> Vec<u8>;
+}
+```
+
+This is a refactor, not a rewrite. The validation harness must continue to pass after the refactor with no behavioral change. Estimated effort: **2–6 weeks**.
+
+## Phase 4 — Optional follow-ups
+
+Each is a separate project gated on Phase 3 completion, with its own spec when reached:
+
+- **ML testbed**: gym-style RL environment wrapping `rct-sim`. Park management is a constrained economic simulation with clear metrics — perfect for RL benchmarking.
+- **WASM mod API**: user-written plugins in any WASM-targeting language for rides, scenarios, and AI guests.
+- **Replay and diff tooling**: record inputs, replay deterministically, diff simulation states between versions. Useful for regression testing the rewrite, also useful for speedrunning and competitive play.
+- **Parallel simulation harness**: run thousands of parks concurrently for optimization studies.
+
+None of these are part of the core experiment. They exist to make the spec's "this is worth doing" argument bigger, and to attract contributors after publication.
+
+## Effort estimate
+
+The author of this spec is a frontier LLM and is bad at predicting its own throughput. Earlier drafts of this estimate were off by 1–2 orders of magnitude in the slow direction, anchored on traditional team-of-humans timelines. **A core deliverable of the dual-trail experiment is a calibrated number for how wrong these estimates are.** Track the actual time spent per module and treat the spec's numbers as priors to update, not commitments.
+
+The estimates below are agent execution time. They do not include arbitrary calendar padding for review loops or session boundaries. The session is left running. The agent just does the work.
+
+| Phase | Estimate | Gate criterion |
+|---|---|---|
+| Phase 0 (recon + harness verification) | hours | All five 0a–0e deliverables complete; validation strategy verified |
+| Phase 1.1 (foundational types) | ≤1 hour | Types, RNG, fixed-point math compile and pass tests |
+| Phase 1.2–1.4 (map, one stationary ride, one walking guest) | a few hours | Minimum viable port runs and validates |
+| Phase 1.5 (vehicles & tracked rides) | ~1 day | All ride types pass validation |
+| Phase 1.6 (full guest AI) | ~1 day | Guest needs, decision making, pathfinding pass validation |
+| Phase 1.7–1.8 (staff, economics) | hours | Staff AI and park economics pass validation |
+| **Phase 1 total** | **3–7 days** | All eight modules pass validation in both trails |
+| Phase 2 (rendering, audio, UI) | 1–2 weeks | Playable scenario indistinguishable from upstream |
+| Phase 3 (library extraction refactor) | hours | `rct-sim` compiles, validation passes |
+| **Total to Phase 3** | **2–3 weeks** | Phase 1 + Phase 2 + Phase 3 done in both trails |
+
+**The experiment publishes after three modules in both trails.** That's Phase 0 + modules 1.1–1.3, which is **1–3 days** of work. That is the actual primary deliverable. Phases 2+ exist to make the substrate larger and more interesting, and to give the dual-trail metrics more sample size before the writeup ships.
+
+### Why the v1 estimate (24–48 months) was wrong
+
+OpenRCT2 → Rust translation is mechanical. The pinned upstream commit is the spec; the agent reads C++, writes Rust, the harness diffs the output, the agent fixes divergence. Each module is hundreds to a few thousand lines. Generation is bounded by the model's tokens-per-second, not by anything that takes weeks.
+
+The historical OpenRCT2 effort (12+ years of community work) is not a precedent. That work was reverse-engineering hand-written x86 assembly into readable C++ *without a spec*. This work is faithful translation between two memory-managed systems languages *with the C++ as the spec*. Different problem class. The dual-trail experiment will quantify how different.
+
+### What could make these numbers wrong (slower)
+
+- The validation harness cannot be made deterministic (Strategy 1 fails). Strategy 2 is weaker; every regression takes longer to isolate.
+- The cqs MCP integration breaks on the upstream codebase shape (cross-language, no Cargo.toml at the C++ root). Trail A loses its structural advantages until cqs is patched. Patching time counts against Trail A.
+- Modules 1.5 and 1.6 hide undocumented behavior in the original assembly that's faithfully reproduced in upstream C++ but not explained anywhere readable. Each undocumented edge case adds a debug cycle.
+- The dual-trail metric tracking adds friction. The spec mandates `metrics.tsv` updates per module — if the operator stops tracking, the experiment loses its publishable result even though the port keeps progressing.
+
+### What could make them wrong (faster)
+
+- Validation harness works first try. Iteration runs at full agent speed.
+- Many modules turn out to be smaller than anticipated because the upstream complexity is in UI and asset handling, not the simulation core.
+- Later modules go faster, not slower, as the agent (and the operator) accumulate context about the upstream codebase shape.
+
+## Scope-down: minimum publishable artifact
+
+**Minimum scope**: Phase 0 complete, Phase 1 modules 1.1–1.3 complete in both trails, `metrics.tsv` populated, writeup published as a technical report or blog post.
+
+This is **1–3 days of work** and produces:
+
+- A working subset of the Rust port (foundational types, map, one stationary ride)
+- A pre-registered head-to-head comparison of cqs-augmented vs unaugmented agent-directed translation
+- Concrete per-module numbers on tokens, agent invocations, validation iterations, regression bugs
+- A research finding on whether code intelligence augmentation measurably helps agents on a sustained, real-world translation task — with the smallest sample size that still produces a defensible result
+
+Ship it. Re-evaluate whether to continue to Phase 1.4+ based on what the metrics show and whether the experiment is still teaching new things.
+
+## Risks
+
+1. **Validation strategy fails** (0c). Mitigation: three-tier fallback chain (state-dump → behavioral → user-acceptance). If all three fail, the project is not feasible as specified and must be rescoped or abandoned.
+
+2. **RNG cannot be reproduced bit-exact**. Same as above, mitigated by Strategy 2 fallback.
+
+3. **Global state translation intractable**. Decided in 0e. Worst case: the operator chooses a mapping that doesn't fit the upstream architecture and must refactor the Rust port partway through. Mitigation: revisit the 0e decision after module 1.4 completes, when enough Rust exists to test the assumption.
+
+4. **Upstream changes invalidate the harness**. Mitigation: pin to a tagged release and treat as immutable. Do not chase upstream changes during Phase 1 or Phase 2.
+
+5. **Operator fatigue over multi-year timeline**. The minimum publishable artifact (3–6 months, three modules) exists specifically to mitigate this. Even if the full port never finishes, the experiment publishes.
+
+6. **Single-operator confound**. The same human directs both trails, which means operator skill, time of day, mood, and recent learning all affect both trails. This is acknowledged as a limitation of the experimental design. Alternating between trails session-to-session reduces but doesn't eliminate the bias. Future replication by independent operators would strengthen external validity.
+
+7. **Trail B advantage from cqs design lessons**. The operator built cqs and has strong priors about what code intelligence should provide. Trail B might benefit from those priors (the operator knows what to look for even without the tool). Mitigation: pre-commit to Trail B's tool list before Phase 1 starts and do not modify it during the experiment.
+
+8. **Trail A disadvantage from cqs maintenance overhead**. Time spent debugging cqs itself counts as Trail A overhead even though it's not "translation work." Mitigation: track cqs maintenance time separately so it can be excluded or included in the analysis as appropriate.
+
+9. **Token measurement noise**. Anthropic API token counts include cache reads, which behave differently across sessions. Mitigation: report both raw token counts and cache-adjusted token counts. The cache-adjusted number is the better proxy for "agent work done."
+
+10. **Project becomes more interesting than the experiment**. Easy failure mode: the operator starts caring about the port itself and stops tracking metrics rigorously. Mitigation: the spec mandates `metrics.tsv` updates per session. Sessions without metrics updates are not counted toward the experiment. This is the operator's main discipline-enforcement mechanism.
+
+## Repository layout
+
+```
+openrct2-rust-port/
+├── SPEC.md                      # this file
+├── RECON.md                     # Phase 0 output
+├── trail-a-cqs/                 # cqs-augmented Rust port
+│   ├── Cargo.toml
+│   ├── src/
+│   ├── tests/
+│   └── metrics.tsv              # per-session metrics for Trail A
+├── trail-b-control/             # control Rust port
+│   ├── Cargo.toml
+│   ├── src/
+│   ├── tests/
+│   └── metrics.tsv              # per-session metrics for Trail B
+├── upstream/                    # pinned OpenRCT2 fork (immutable spec)
+├── harness/                     # validation harness (state-dump tool, diff scripts)
+└── analysis/                    # comparison scripts, plots, writeup
+```
+
+## First concrete step
+
+Execute Phase 0a. One command:
+
+```sh
+mkdir -p ~/openrct2-rust-port && cd ~/openrct2-rust-port && \
+  echo "# Phase 0a: Prior Art Check" > RECON-0a.md && \
+  date >> RECON-0a.md
+```
+
+Then web search for existing Rust ports of OpenRCT2 or RCT2. Document findings in `RECON-0a.md`. Estimated effort: 1 day. **Do not proceed to 0b until 0a is complete and the findings have been reviewed.**

--- a/docs/plans/2026-04-10-openrct2-rust-port-dual-trail.md
+++ b/docs/plans/2026-04-10-openrct2-rust-port-dual-trail.md
@@ -230,7 +230,7 @@ None of these are part of the core experiment. They exist to make the spec's "th
 The experiment is gated on deliverables, not durations. A phase is "done" when its exit criteria are satisfied, not when a time budget elapses.
 
 - **Phase 0**: All five 0a–0e deliverables complete. Validation strategy verified (Strategy 1, 2, or 3 chosen and proven to work on a real diff). Gate to Phase 1.
-- **Phase 1**: All eight modules pass validation in both trails. The experiment can publish before Phase 1 is complete — see "minimum publishable artifact" below.
+- **Phase 1**: All eight modules pass validation in both trails. An interim writeup based on the first three modules is a valid milestone (see "First publishable milestone" below) but is not a substitute for completing Phase 1.
 - **Phase 2**: Playable scenario indistinguishable from upstream by an experienced player.
 - **Phase 3**: `rct-sim` crate compiles cleanly, validation harness still passes after the refactor.
 - **Phase 4**: Per-project specs.
@@ -241,23 +241,16 @@ The dual-trail experiment produces real per-module measurements: tokens consumed
 
 Treat the first three modules as the calibration run. Whatever throughput numbers come out of those modules are the basis for any future estimate of the work remaining. Do not write estimates into this spec; record measured numbers in `metrics.tsv` and update the writeup when the data exists.
 
-## Minimum publishable artifact
+## First publishable milestone
 
-The experiment publishes when these are all true:
-
-- Phase 0 complete (validation strategy verified)
-- Phase 1 modules 1.1–1.3 complete in both trails
-- `metrics.tsv` populated with per-module numbers for both trails
-- Writeup drafted as a technical report or blog post
-
-The publishable result contains:
+The dual-trail comparison is meaningful as soon as three modules are complete in both trails. After Phase 0 + modules 1.1–1.3, the operator can publish an interim writeup containing:
 
 - A working subset of the Rust port (foundational types, map, one stationary ride)
 - A pre-registered head-to-head comparison of cqs-augmented vs unaugmented agent-directed translation
 - Per-module numbers on tokens, agent invocations, validation iterations, regression bugs
-- A research finding on whether code intelligence augmentation measurably helps agents on a sustained, real-world translation task
+- The first calibration-grade evidence on whether code intelligence augmentation measurably helps agents on a sustained, real-world translation task
 
-Ship it as soon as the criteria are satisfied. Re-evaluate whether to continue to Phase 1.4+ based on what the metrics show.
+This is a milestone, not a stopping point. The full Phase 1, Phase 2, and Phase 3 are still the deliverables. The interim writeup exists to start gathering external feedback on the methodology while the rest of the work continues.
 
 ## Risks
 

--- a/docs/plans/2026-04-10-openrct2-rust-port-dual-trail.md
+++ b/docs/plans/2026-04-10-openrct2-rust-port-dual-trail.md
@@ -18,7 +18,7 @@ If the cqs trail wins on the pre-registered metrics, that validates the entire r
 
 **H2 (cqs trail consumes fewer agent tokens per validated module.)** Structural retrieval reduces the amount of file content the agent has to read into context to understand a function. Predicted effect: ≥20% token reduction per validated module.
 
-**H3 (cqs trail completes modules in fewer wall-clock hours.)** Faster context assembly + fewer regression cycles. Predicted effect: ≥25% wall-clock reduction.
+**H3 (cqs trail completes modules in less wall-clock time.)** Faster context assembly + fewer regression cycles. Predicted effect: ≥25% wall-clock reduction (measured per-module from "module started" to "module passes validation").
 
 **H0 (no significant difference.)** Both trails perform within ±10% on all three metrics. This would be a meaningful negative result — the structural advantages don't manifest at translation-task scale.
 
@@ -90,7 +90,7 @@ The choice between Strategy 1 and Strategy 2 is decided in Phase 0c. **Do not be
 
 Phase 0 deliverables are the go/no-go gate. Do not write any Rust until all five are complete.
 
-### 0a — Prior art check (1 day)
+### 0a — Prior art check
 
 Search GitHub, crates.io, GitLab, Codeberg, and the web for existing Rust ports of OpenRCT2 or RCT2. Document findings:
 - Any prior attempt at any completion level
@@ -100,7 +100,7 @@ Search GitHub, crates.io, GitLab, Codeberg, and the web for existing Rust ports 
 
 If a viable prior attempt exists at meaningful completion, **stop** and re-evaluate: join, fork, or proceed knowing the comparison's external validity is reduced.
 
-### 0b — Codebase recon (3–5 days)
+### 0b — Codebase recon
 
 - Pin upstream to the latest tagged release. Record the commit hash.
 - Build OpenRCT2 from the pinned commit, verify it runs with legal asset files.
@@ -114,20 +114,20 @@ If a viable prior attempt exists at meaningful completion, **stop** and re-evalu
   - Game action system reference
   - Multiplayer sync hash extraction location (used in 0c)
 
-### 0c — Validation harness verification (3–7 days)
+### 0c — Validation harness verification
 
 - **First** verify Strategy 1 (state-dump diff). Patch upstream to emit deterministic state dumps. Run two upstream instances from the same save for 10,000 ticks. Diff the dumps. **They must be byte-identical.** If yes, Strategy 1 is the validation strategy and Phase 1 can begin.
 - If Strategy 1 fails, identify why (float ordering? uninitialized memory? OS scheduler?). Document. Verify Strategy 2 (behavioral equivalence) by running two upstream instances and confirming the invariant thresholds hold. If yes, Phase 1 begins with Strategy 2 validation.
 - If Strategy 2 fails, escalate to Strategy 3 and re-evaluate whether the project should continue at all.
 
-### 0d — RNG verification (1–2 days)
+### 0d — RNG verification
 
 - Locate the upstream RNG. Document algorithm and seeding.
 - Implement the RNG in Rust (the smallest possible standalone test).
 - Run both with identical seeds for 10,000 iterations.
 - Sequences must match exactly (Strategy 1) or produce statistically equivalent distributions (Strategy 2).
 
-### 0e — Architectural decision: global state (1 day)
+### 0e — Architectural decision: global state
 
 OpenRCT2's heritage from x86 assembly means it's full of file-scope and global mutable state. Choose the Rust mapping based on the inventory from 0b:
 
@@ -139,7 +139,7 @@ Document the decision and rationale in `RECON.md`. Both trails must use the same
 
 ### Phase 0 deliverable
 
-`RECON.md` containing all five outputs, the validation strategy choice, the global state decision, the pinned commit hash, and a sign-off section the operator initials before Phase 1 begins. Estimated effort: **2–4 weeks** of evening work.
+`RECON.md` containing all five outputs, the validation strategy choice, the global state decision, the pinned commit hash, and a sign-off section the operator initials before Phase 1 begins.
 
 ## Phase 1 — Simulation core port
 
@@ -160,7 +160,7 @@ Modules 1.5 and 1.6 are dramatically larger than the others. Acknowledged up fro
 | 1.7 | Staff (mechanics, handymen, security, entertainers) | ~10% |
 | 1.8 | Park economics, ratings, loans, scenarios, win conditions | ~5% |
 
-Modules 1.5 and 1.6 together are ~60% of Phase 1's total effort. Each is itself a multi-week project with sub-milestones. The spec deliberately does not break them into sub-modules at this stage because the right decomposition depends on what 0b's recon reveals about upstream's actual structure.
+Modules 1.5 and 1.6 together are roughly 60% of Phase 1's total work. Each will likely require its own internal milestone breakdown. The spec deliberately does not break them into sub-modules at this stage because the right decomposition depends on what 0b's recon reveals about upstream's actual structure.
 
 ### Per-module workflow (both trails)
 
@@ -186,9 +186,9 @@ A module is "done" when:
 
 ## Phase 2 — Rendering, input, audio, UI
 
-**Phase 2 has effort parity with Phase 1.** Do not scope it down to "bolt rendering on top of the simulation." The rendering, asset loading, audio, and UI together represent another 12–18 months of evening work for one operator plus agent.
+**Phase 2 has effort parity with Phase 1.** Do not scope it down to "bolt rendering on top of the simulation." Rendering, asset loading, audio, and UI together represent a body of work comparable to Phase 1 in scope.
 
-Sub-components (each is itself a multi-week project):
+Sub-components (each is its own substantial sub-project):
 
 - **DAT format asset loader**: Port from upstream. The DAT format is a 25-year-old binary asset bundle that took the OpenRCT2 community years to fully reverse-engineer. The port reuses upstream's loader logic, not the original Sawyer asset format work.
 - **Sprite renderer (wgpu)**: Match upstream's software renderer pixel-for-pixel where possible; document any GPU-specific divergence.
@@ -212,7 +212,7 @@ impl Simulation {
 }
 ```
 
-This is a refactor, not a rewrite. The validation harness must continue to pass after the refactor with no behavioral change. Estimated effort: **2–6 weeks**.
+This is a refactor, not a rewrite. The validation harness must continue to pass after the refactor with no behavioral change.
 
 ## Phase 4 — Optional follow-ups
 
@@ -225,58 +225,39 @@ Each is a separate project gated on Phase 3 completion, with its own spec when r
 
 None of these are part of the core experiment. They exist to make the spec's "this is worth doing" argument bigger, and to attract contributors after publication.
 
-## Effort estimate
+## Phase ordering and exit criteria
 
-The author of this spec is a frontier LLM and is bad at predicting its own throughput. Earlier drafts of this estimate were off by 1–2 orders of magnitude in the slow direction, anchored on traditional team-of-humans timelines. **A core deliverable of the dual-trail experiment is a calibrated number for how wrong these estimates are.** Track the actual time spent per module and treat the spec's numbers as priors to update, not commitments.
+The experiment is gated on deliverables, not durations. A phase is "done" when its exit criteria are satisfied, not when a time budget elapses.
 
-The estimates below are agent execution time. They do not include arbitrary calendar padding for review loops or session boundaries. The session is left running. The agent just does the work.
+- **Phase 0**: All five 0a–0e deliverables complete. Validation strategy verified (Strategy 1, 2, or 3 chosen and proven to work on a real diff). Gate to Phase 1.
+- **Phase 1**: All eight modules pass validation in both trails. The experiment can publish before Phase 1 is complete — see "minimum publishable artifact" below.
+- **Phase 2**: Playable scenario indistinguishable from upstream by an experienced player.
+- **Phase 3**: `rct-sim` crate compiles cleanly, validation harness still passes after the refactor.
+- **Phase 4**: Per-project specs.
 
-| Phase | Estimate | Gate criterion |
-|---|---|---|
-| Phase 0 (recon + harness verification) | hours | All five 0a–0e deliverables complete; validation strategy verified |
-| Phase 1.1 (foundational types) | ≤1 hour | Types, RNG, fixed-point math compile and pass tests |
-| Phase 1.2–1.4 (map, one stationary ride, one walking guest) | a few hours | Minimum viable port runs and validates |
-| Phase 1.5 (vehicles & tracked rides) | ~1 day | All ride types pass validation |
-| Phase 1.6 (full guest AI) | ~1 day | Guest needs, decision making, pathfinding pass validation |
-| Phase 1.7–1.8 (staff, economics) | hours | Staff AI and park economics pass validation |
-| **Phase 1 total** | **3–7 days** | All eight modules pass validation in both trails |
-| Phase 2 (rendering, audio, UI) | 1–2 weeks | Playable scenario indistinguishable from upstream |
-| Phase 3 (library extraction refactor) | hours | `rct-sim` compiles, validation passes |
-| **Total to Phase 3** | **2–3 weeks** | Phase 1 + Phase 2 + Phase 3 done in both trails |
+## Calibration as a deliverable
 
-**The experiment publishes after three modules in both trails.** That's Phase 0 + modules 1.1–1.3, which is **1–3 days** of work. That is the actual primary deliverable. Phases 2+ exist to make the substrate larger and more interesting, and to give the dual-trail metrics more sample size before the writeup ships.
+The dual-trail experiment produces real per-module measurements: tokens consumed, agent invocations, validation iterations, regression bugs, lines of Rust generated. These measurements are the primary outputs of the experiment, and they're also the only credible answer to "how long does agent-directed translation actually take."
 
-### Why the v1 estimate (24–48 months) was wrong
+Treat the first three modules as the calibration run. Whatever throughput numbers come out of those modules are the basis for any future estimate of the work remaining. Do not write estimates into this spec; record measured numbers in `metrics.tsv` and update the writeup when the data exists.
 
-OpenRCT2 → Rust translation is mechanical. The pinned upstream commit is the spec; the agent reads C++, writes Rust, the harness diffs the output, the agent fixes divergence. Each module is hundreds to a few thousand lines. Generation is bounded by the model's tokens-per-second, not by anything that takes weeks.
+## Minimum publishable artifact
 
-The historical OpenRCT2 effort (12+ years of community work) is not a precedent. That work was reverse-engineering hand-written x86 assembly into readable C++ *without a spec*. This work is faithful translation between two memory-managed systems languages *with the C++ as the spec*. Different problem class. The dual-trail experiment will quantify how different.
+The experiment publishes when these are all true:
 
-### What could make these numbers wrong (slower)
+- Phase 0 complete (validation strategy verified)
+- Phase 1 modules 1.1–1.3 complete in both trails
+- `metrics.tsv` populated with per-module numbers for both trails
+- Writeup drafted as a technical report or blog post
 
-- The validation harness cannot be made deterministic (Strategy 1 fails). Strategy 2 is weaker; every regression takes longer to isolate.
-- The cqs MCP integration breaks on the upstream codebase shape (cross-language, no Cargo.toml at the C++ root). Trail A loses its structural advantages until cqs is patched. Patching time counts against Trail A.
-- Modules 1.5 and 1.6 hide undocumented behavior in the original assembly that's faithfully reproduced in upstream C++ but not explained anywhere readable. Each undocumented edge case adds a debug cycle.
-- The dual-trail metric tracking adds friction. The spec mandates `metrics.tsv` updates per module — if the operator stops tracking, the experiment loses its publishable result even though the port keeps progressing.
-
-### What could make them wrong (faster)
-
-- Validation harness works first try. Iteration runs at full agent speed.
-- Many modules turn out to be smaller than anticipated because the upstream complexity is in UI and asset handling, not the simulation core.
-- Later modules go faster, not slower, as the agent (and the operator) accumulate context about the upstream codebase shape.
-
-## Scope-down: minimum publishable artifact
-
-**Minimum scope**: Phase 0 complete, Phase 1 modules 1.1–1.3 complete in both trails, `metrics.tsv` populated, writeup published as a technical report or blog post.
-
-This is **1–3 days of work** and produces:
+The publishable result contains:
 
 - A working subset of the Rust port (foundational types, map, one stationary ride)
 - A pre-registered head-to-head comparison of cqs-augmented vs unaugmented agent-directed translation
-- Concrete per-module numbers on tokens, agent invocations, validation iterations, regression bugs
-- A research finding on whether code intelligence augmentation measurably helps agents on a sustained, real-world translation task — with the smallest sample size that still produces a defensible result
+- Per-module numbers on tokens, agent invocations, validation iterations, regression bugs
+- A research finding on whether code intelligence augmentation measurably helps agents on a sustained, real-world translation task
 
-Ship it. Re-evaluate whether to continue to Phase 1.4+ based on what the metrics show and whether the experiment is still teaching new things.
+Ship it as soon as the criteria are satisfied. Re-evaluate whether to continue to Phase 1.4+ based on what the metrics show.
 
 ## Risks
 
@@ -288,7 +269,7 @@ Ship it. Re-evaluate whether to continue to Phase 1.4+ based on what the metrics
 
 4. **Upstream changes invalidate the harness**. Mitigation: pin to a tagged release and treat as immutable. Do not chase upstream changes during Phase 1 or Phase 2.
 
-5. **Operator fatigue over multi-year timeline**. The minimum publishable artifact (3–6 months, three modules) exists specifically to mitigate this. Even if the full port never finishes, the experiment publishes.
+5. **Operator fatigue or interest drift**. The minimum publishable artifact (Phase 0 + three modules, see above) exists specifically to mitigate this. Even if the full port never finishes, the experiment publishes.
 
 6. **Single-operator confound**. The same human directs both trails, which means operator skill, time of day, mood, and recent learning all affect both trails. This is acknowledged as a limitation of the experimental design. Alternating between trails session-to-session reduces but doesn't eliminate the bias. Future replication by independent operators would strengthen external validity.
 
@@ -331,4 +312,4 @@ mkdir -p ~/openrct2-rust-port && cd ~/openrct2-rust-port && \
   date >> RECON-0a.md
 ```
 
-Then web search for existing Rust ports of OpenRCT2 or RCT2. Document findings in `RECON-0a.md`. Estimated effort: 1 day. **Do not proceed to 0b until 0a is complete and the findings have been reviewed.**
+Then web search for existing Rust ports of OpenRCT2 or RCT2. Document findings in `RECON-0a.md`. **Do not proceed to 0b until 0a is complete and the findings have been reviewed.**


### PR DESCRIPTION
## Summary

Spec for the OpenRCT2 → Rust port + dual-trail experiment.

The headline isn't the port — it's the experiment. cqs's design rests on the bet that structural code intelligence improves agent-directed work. That bet has been validated indirectly (telemetry, R@1, internal use) but never head-to-head against an unaugmented agent on a sustained translation task. OpenRCT2 → Rust is the first task large enough, mechanical enough, and verifiable enough to make the comparison rigorous.

## Pre-registered hypotheses

- **H1**: cqs trail produces ≥30% fewer regression bugs per ported function
- **H2**: cqs trail consumes ≥20% fewer agent tokens per validated module
- **H3**: cqs trail completes modules in ≥25% less wall-clock time
- **H0**: both trails perform within ±10% on all three metrics (meaningful negative result)

## Validation

Three-tier fallback chain:
1. **State-dump diff** — patch upstream OpenRCT2 to emit deterministic state dumps, run upstream and Rust port in parallel, diff per tick. Phase 0c verifies this works on two upstream instances first.
2. **Behavioral equivalence** — invariant thresholds (park rating ±5%, guest count ±2%, revenue ±5%, no spurious breakdowns/guest types) over 10,000 ticks if state-dump determinism fails.
3. **User-acceptance only** — playable scenario indistinguishable from upstream by an experienced player. Weakest bar; rescope if reached.

## Phase 0 deliverables (the gate)

Five sub-deliverables before any Rust gets written:
- **0a** prior art check (existing Rust ports of OpenRCT2 / RCT2)
- **0b** codebase recon (file/module map, global state inventory, RNG sites, save format)
- **0c** validation harness verification (Strategy 1 vs 2 vs 3 chosen and proven on real data)
- **0d** RNG verification (port to Rust, sequences match upstream)
- **0e** architectural decision: global state mapping (single `World` struct vs thread-locals vs `Arc<Mutex<…>>` per subsystem)

Output: `RECON.md`. **Do not write Rust until all five are complete.**

## Phase 1 module ordering

Foundational types → map → minimum viable ride → minimum viable guest → vehicles & tracked rides → full guest AI → staff → economics. Modules 1.5 (vehicles) and 1.6 (guest AI) together are roughly 60% of Phase 1's total work; the spec acknowledges this asymmetry up front rather than treating all eight modules as equal-sized milestones.

## What's intentionally NOT in this spec

Per several recent feedback rules saved this session:

- **No time/effort estimates.** The dual-trail experiment's first three modules ARE the calibration run for "how fast does agent-directed translation actually go." Predictions written into the spec ahead of measured data are unreliable.
- **No psychological off-ramps.** Technical fallback chains (Strategy 1 → 2 → 3) are real contingency engineering and stay. "Scope down to minimum viable artifact and call it a win" framing is gone — there's a "first publishable milestone" section that describes the three-module interim writeup as a milestone toward the full deliverable, not a stopping point.
- **No editorializing about the substrate's intrinsic merit.** OpenRCT2 → Rust is being chosen precisely because it's mechanical and verifiable. The spec's job is to spec it well, not to grade whether the port deserves to exist.

## Test plan

- [x] Spec is structurally complete
- [ ] CI green (docs only — should pass trivially)
- [ ] Phase 0 begins with `cqs index` of upstream OpenRCT2 once spec is approved
