### PR TITLE
fix: sparse_vectors bulk insert batch size derived from SQLite limit

### DIFF
--- a/src/store/sparse.rs
+++ b/src/store/sparse.rs
@@ -37,22 +37,58 @@ impl Store {
                 qb.build().execute(&mut *tx).await?;
             }
 
+            // Insert in batches sized to the SQLite variable limit.
+            //
+            // SQLite caps the number of bind variables per statement.
+            // SQLITE_MAX_VARIABLE_NUMBER was 999 before v3.32 (2020) and
+            // is 32766 in current SQLite. The previous BATCH_SIZE constant
+            // was tuned for the old 999 limit and produced ~10x more INSERT
+            // statements than necessary with the modern limit. With
+            // SPLADE-Code 0.6B's denser sparse vectors (~1000+ tokens per
+            // chunk vs ~134 for BERT 110M), the per-statement sqlx overhead
+            // compounded into 30+ minute upserts that looked like a hang.
+            //
+            // The new batch size is derived from the constraint, not picked:
+            // each row uses VARS_PER_ROW bind variables, the maximum rows
+            // per statement is therefore (limit / VARS_PER_ROW), and we
+            // leave a safety margin for any future schema addition that
+            // adds another bound column to the row tuple.
+            //
+            // Iterate across chunks AND rows together so each batch fills
+            // close to capacity, instead of starting a fresh batch per chunk
+            // and producing tiny INSERTs for chunks with few tokens.
+            const SQLITE_MAX_VARIABLES: usize = 32766; // SQLite default since v3.32
+            const VARS_PER_ROW: usize = 3; // chunk_id, token_id, weight
+            const SAFETY_MARGIN_VARS: usize = 300; // headroom for one extra column on a max-size batch
+            const ROWS_PER_INSERT: usize =
+                (SQLITE_MAX_VARIABLES - SAFETY_MARGIN_VARS) / VARS_PER_ROW;
+            let mut pending: Vec<(&str, u32, f32)> = Vec::with_capacity(ROWS_PER_INSERT);
             for (chunk_id, sparse) in vectors {
-                // Insert new entries in batches
-                // 3 params per row, batch of 333 = 999 < SQLite 999 limit
-                const BATCH_SIZE: usize = 333;
-                for batch in sparse.chunks(BATCH_SIZE) {
-                    let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
-                        "INSERT INTO sparse_vectors (chunk_id, token_id, weight)",
-                    );
-                    qb.push_values(batch.iter(), |mut b, &(token_id, weight)| {
-                        b.push_bind(chunk_id)
-                            .push_bind(token_id as i64)
-                            .push_bind(weight);
-                    });
-                    qb.build().execute(&mut *tx).await?;
-                    total += batch.len();
+                for &(token_id, weight) in sparse {
+                    pending.push((chunk_id.as_str(), token_id, weight));
+                    if pending.len() >= ROWS_PER_INSERT {
+                        let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+                            "INSERT INTO sparse_vectors (chunk_id, token_id, weight)",
+                        );
+                        qb.push_values(pending.iter(), |mut b, &(cid, tid, w)| {
+                            b.push_bind(cid).push_bind(tid as i64).push_bind(w);
+                        });
+                        qb.build().execute(&mut *tx).await?;
+                        total += pending.len();
+                        pending.clear();
+                    }
                 }
+            }
+            // Flush remaining rows
+            if !pending.is_empty() {
+                let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+                    "INSERT INTO sparse_vectors (chunk_id, token_id, weight)",
+                );
+                qb.push_values(pending.iter(), |mut b, &(cid, tid, w)| {
+                    b.push_bind(cid).push_bind(tid as i64).push_bind(w);
+                });
+                qb.build().execute(&mut *tx).await?;
+                total += pending.len();
             }
 
             tx.commit().await?;


### PR DESCRIPTION
## Summary

`upsert_sparse_vectors` had `BATCH_SIZE = 333` hardcoded, with a comment claiming "999 < SQLite 999 limit." That comment has been wrong since SQLite 3.32 (2020) bumped `SQLITE_MAX_VARIABLE_NUMBER` from 999 to 32766. The constant was ~30x smaller than the modern constraint allows, and the resulting per-statement overhead compounded with sqlx async machinery into a real-world hang.

## How it manifested

For the BERT-110M SPLADE encoder (avg ~134 tokens per chunk), the over-batching was a minor inefficiency — a few extra INSERT statements per chunk, lost in the noise.

For SPLADE-Code 0.6B (denser sparse vectors, ~1000+ tokens per chunk on a corpus this size), the inner loop produced **tens of thousands of small INSERT statements** in a single transaction. Each statement went through sqlx's parameter binding + plan + execute path, awaited individually through the tokio runtime. The encoding phase finished correctly; the bulk-insert phase silently sat for 30+ minutes and looked like a process hang. I almost shipped a "SPLADE encoding leaks GPU memory" diagnosis before finding the actual cause was downstream of encoding entirely.

## The fix

Derive the batch size from the actual constraint instead of picking a number:

```rust
const SQLITE_MAX_VARIABLES: usize = 32766; // SQLite default since v3.32
const VARS_PER_ROW: usize = 3; // chunk_id, token_id, weight
const SAFETY_MARGIN_VARS: usize = 300;     // headroom for one extra column
const ROWS_PER_INSERT: usize =
    (SQLITE_MAX_VARIABLES - SAFETY_MARGIN_VARS) / VARS_PER_ROW;
```

That's **10,822 rows per INSERT statement**, ~32x larger than the old value, and explicitly derived from the constraint with a small safety margin for any future schema addition that adds another bound column.

The constant is no longer a magic number — its value is forced by the math.

## Restructured loop

The old code started a fresh batch per chunk. Chunks with few tokens triggered many tiny INSERTs because each chunk's encoding path immediately flushed its sub-batch. The new code accumulates into a single pending buffer that flushes whenever it crosses `ROWS_PER_INSERT`, then a final flush after the outer loop drains anything remaining.

So a chunk with 50 tokens no longer triggers a 50-row INSERT all by itself — its rows accumulate with adjacent chunks until the buffer fills. This is the optimization that actually matters for typical sparse-token distributions.

## Verified

SPLADE-Code 0.6B reindex of the cqs corpus (~12k chunks) now completes the bulk-insert phase in seconds instead of stalling for 30+ minutes. The encoding loop reaches 100% and the upsert returns promptly.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --features gpu-index --lib -- store::sparse` — all 3 existing tests pass (`test_sparse_roundtrip`, `test_sparse_upsert_replaces`, `test_sparse_empty`)
- [x] Live verification: SPLADE-Code 0.6B reindex completes the upsert phase fast
- [ ] CI green
