### PR TITLE
docs: continuity + roadmap update after SPLADE-Code unblock chain

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,36 +2,65 @@
 
 ## Right Now
 
-**Phase 5 + summary expansion shipped. Routing null at N=27. SPLADE-Code 0.6B re-eval blocked on encoding perf. (2026-04-10 19:00 CDT)**
+**SPLADE-Code 0.6B encoding cleared. v8 reindex bulk-inserting. Eval is the next concrete step. (2026-04-10 22:15 CDT)**
 
-### This session shipped (10 PRs to main)
+### Total this session: 14 PRs merged to main
+**Phase 5 dual embeddings**
 - #876 Phase 5 dual embeddings + DenseBase routing
-- #877 CQS_DISABLE_BASE_INDEX env var (eval A/B)
-- #878 summary eligibility expanded from is_callable() → is_code()
-- #879 roadmap updates (selective SPLADE routing tracked)
+- #877 `CQS_DISABLE_BASE_INDEX` env var (eval A/B)
+- #878 summary eligibility expanded from `is_callable()` → `is_code()`
 - #880 bypass test coverage
-- #881 CQS_SPLADE_MODEL env var + vocab-mismatch probe
-- #882 CQS_TYPE_BOOST env var (sweep infra)
-- #883 evals/run_sweep.py harness
-- #884 SPLADE vocab probe accepts benign lm_head padding
-- #885 routing fix: conceptual back to enriched (later showed as null)
-- #886 real batched encode_batch (5-10x speedup ceiling)
-- #887 (open) CQS_SPLADE_BATCH env var + adaptive halving
+- #885 routing fix: conceptual back to enriched (later showed as null at N=27)
 
-### Eval matrix findings (50% coverage, BGE-large)
+**SPLADE-Code 0.6B unblock chain**
+- #881 `CQS_SPLADE_MODEL` env var + vocab-mismatch probe
+- #884 vocab probe accepts benign lm_head padding (151669 → 151936)
+- #886 real batched `encode_batch` (replaces serial loop)
+- #889 SPLADE encoding GPU memory leak — constant max_seq_len padding + arena reset
+- #891 sparse_vectors bulk insert batch size derived from SQLite limit (was tuned for the pre-3.32 999-var limit, now derives from 32766)
+
+**Sweep infrastructure**
+- #882 `CQS_TYPE_BOOST` env var (research-side sweep knob)
+- #883 `evals/run_sweep.py` parameter sweep harness
+
+**Docs / process**
+- #879 roadmap updates (selective SPLADE routing tracked)
+- #888 end-of-(first-half-of-)session continuity
+- #890 OpenRCT2 Rust port + dual-trail experiment spec
+
+**Closed: #887** (CQS_SPLADE_BATCH env var) — superseded by #889 which has the env var inline with the encoding fix and avoids the same clippy issue.
+
+### Phase 5 eval finding (50% coverage, BGE-large)
 - Phase 5 dual-routing: **null at N=27 per category** — all category swings within ±1 query
 - Total R@1: 43.0% with or without routing (within noise)
 - The "−3.7pp on conceptual from routing" earlier in the day was a misread (one query out of 27 = 3.7pp)
-- The historical research finding "summaries hurt conceptual −15pp" was for a different corpus shape
+- The historical research finding "summaries hurt conceptual −15pp" was for a different corpus shape (only callables summarized); after PR #878 expanded summaries to type definitions, the per-category effects shifted enough that the original Phase 5 routing rules no longer apply cleanly
+- Phase 5 is shipped as infrastructure for further research, not as a measurable quality improvement at the current sample size
 
-### Pending blockers
-- **SPLADE-Code 0.6B encoding** (task #16) — encoder leaks GPU memory (7.4 → 30GB over 1h) with no progress regardless of batch size. Likely needs ORT arena reset / IO bindings / per-batch session refresh. Until fixed, the SPLADE-Code 0.6B re-eval (the only experiment with above-noise predicted effect) is blocked.
+### SPLADE-Code 0.6B encoding journey (v1 → v8)
+The "SPLADE-Code re-eval is blocked on encoding perf" line from earlier in this doc turned out to be three stacked bugs, all now fixed:
+
+1. **Vocab mismatch (PR #881, #884)**: `~/.cache/huggingface/splade-onnx/` had a hot-swapped 532MB SPLADE-Code 0.6B `model.onnx` paired with the original BERT `tokenizer.json` (711KB). Encoder was feeding BERT-tokenized inputs (30522 vocab) to a Qwen3-trained model (151936 vocab) — semantically garbage but consistently garbage at both index time and search time, so search returned results without crashing. Construction-time vocab probe added.
+2. **Encoding GPU memory leak (PR #886, #889)**: `encode_batch` had no real batching (serial loop), and per-batch padding to varying `max_seq_len` made ORT's BFC arena allocate new slots for every batch and never free them. Memory grew 7.4 → 30 GB over an hour with no measurable progress. Fixed by adding real batching AND padding to a CONSTANT `max_seq_len` (configurable via `CQS_SPLADE_MAX_SEQ`, default 256) so ORT can reuse the same arena slots.
+3. **Sparse insert slow path (PR #891)**: `BATCH_SIZE = 333` in `upsert_sparse_vectors` was tuned for the pre-3.32 SQLite variable limit (999). The modern limit is 32766. With SPLADE-Code 0.6B's denser sparse vectors (~1000+ tokens per chunk), the per-statement sqlx overhead compounded into 30+ minute "hangs" on the bulk insert phase. Fixed by deriving `ROWS_PER_INSERT` from the actual variable limit (10822 vs the old 333). Restructured the loop to fill batches across chunk boundaries instead of starting fresh per chunk.
+
+The encoding pipeline now runs end-to-end with SPLADE-Code 0.6B. Reindex v8 (binary with all 3 fixes) is currently in the bulk insert phase — WAL is at 3.4 GB and growing, process alive at 20% CPU, work is genuinely happening.
 
 ### What's next
-1. Debug the SPLADE encoding GPU memory leak (task #16) — biggest unblock
-2. Once unblocked: re-run the 4-cell matrix with proper SPLADE-Code 0.6B
-3. Decide what ships in v1.23.0 based on real SPLADE-Code 0.6B numbers
-4. Larger eval set (165q is too small to discriminate ±3pp effects)
+1. Wait for v8 reindex to finish (bulk insert + dual HNSW rebuild)
+2. Run the SPLADE eval matrix with proper SPLADE-Code 0.6B (`CQS_SPLADE_MODEL` set)
+3. Compare results to the previous SPLADE-Code 0.6B finding (+1.2pp R@1, +20pp cross_language)
+4. Update `research/sparse.md` and `research/enrichment.md` with the actual numbers
+5. Decide whether SPLADE-Code 0.6B becomes the default for cqs (env var → bake into the path resolver)
+6. Larger eval set (165q is too small to discriminate ±3pp effects on most categories)
+
+### Lessons saved to memory this session
+- **Autopilot no pauses** — when user says "autopilot", don't stop at decision points, pick the most likely option and run it
+- **No time estimates** — never put time/effort estimates in specs; the model is structurally bad at it (off by 1–2 OOM)
+- **No off-ramps in specs** — distinguish technical fallback chains (keep) from psychological exit hatches (cut)
+- **Don't grade substrate** — when user picks a project, spec it well; don't editorialize about whether the substrate deserves to exist
+- **Knob count depends on consumer** — for human-facing tools, attack wrong defaults; for agent-facing tools (cqs, Monitor), more knobs are cheap
+- **Read before acting** (carried over) — always read files before editing, don't guess at contents
 
 ## Open Issues
 - #856, #717, #389, #255, #106, #63
@@ -39,9 +68,10 @@
 ## Architecture
 - Version: 1.22.0
 - Schema: v18 (embedding_base column for dual HNSW)
-- Tests: 1330 lib pass
-- Adaptive retrieval Phases 1-5 implemented
+- Tests: 1345 lib pass (+15 SPLADE/sparse from this session)
+- Adaptive retrieval Phases 1–5 implemented
 - Two HNSW indexes per project: enriched (`index.hnsw.*`) + base (`index_base.hnsw.*`)
 - SPLADE-Code 0.6B model files at `~/training-data/splade-code-naver/onnx/`
   - Set `CQS_SPLADE_MODEL` env var to use it (vocab probe verifies tokenizer/model match)
-  - Encoding currently broken (task #16)
+  - **Encoding now works end-to-end** (constant padding, batched encoder, fast bulk insert)
+- Env vars added this session: `CQS_DISABLE_BASE_INDEX`, `CQS_SPLADE_MODEL`, `CQS_SPLADE_MAX_SEQ`, `CQS_SPLADE_BATCH`, `CQS_SPLADE_RESET_EVERY`, `CQS_TYPE_BOOST`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,11 +20,11 @@
 
 ### GPU Lane
 - [x] ~~SPLADE v1~~ — **NULL**. 0pp R@1. Weak reg, wrong vocab, wrong negatives.
-- [x] ~~SPLADE v2 data mining~~ — 199,998 token-overlap pairs. Complete.
-- [x] ~~SPLADE v2 training~~ — Complete. Token-overlap negs + reg_weight 1e-3. Awaiting eval.
-- [ ] **SPLADE v2 eval** — ablation running now
-- [ ] **SPLADE-Code 0.6B** — Naver Labs code-specific SPLADE (arXiv 2603.22008). Export script ready. Eval after v2.
-- [ ] **SPLADE v3: reg sweep** — Only if v2 shows signal AND SPLADE-Code doesn't work.
+- [x] ~~SPLADE v2 data mining~~ — 199,998 token-overlap pairs.
+- [x] ~~SPLADE v2 training~~ — Token-overlap negs + reg_weight 1e-3.
+- [x] ~~SPLADE v2 eval~~ — **NULL**. 0pp R@1. 110M BERT capacity ceiling confirmed.
+- [x] ~~SPLADE v3 / v4 (reg sweep, CodeBERT vocab)~~ — Cancelled. Capacity is the bottleneck.
+- [ ] **SPLADE-Code 0.6B eval** — perf blockers cleared (PRs #881, #884, #886, #889, #891). Encoding pipeline now runs end-to-end with proper vocab probe, batched encoder, constant-padding arena reuse, and SQLite-limit-derived sparse insert batches. Reindex in flight; eval runs immediately after. Previous result on a different corpus state: +1.2pp R@1, +20pp cross_language. This eval reproduces or refutes that on the current corpus.
 - [ ] **Reranker V2** — code-trained cross-encoder (ms-marco was catastrophic)
 
 ### CPU Lane (next up)
@@ -37,6 +37,7 @@
   - Open: should the routed strategy compose with `DenseBase` for cross-language + negation queries? Probably not in v1 — keep enums mutually exclusive, revisit if data demands
   - Validate: same-corpus A/B on cross_language category specifically
 - [ ] **Phase 6: Explainable search** — depends on SPLADE-Code being the production default. Spec: `docs/plans/adaptive-retrieval.md`
+- [ ] **OpenRCT2 → Rust dual-trail experiment** — substrate for measuring whether structural code intelligence augmentation improves agent-directed translation in a sustained, real-world task. Two parallel translations on the same upstream commit, one with cqs in the loop, one without. Pre-registered metrics (regression bugs, tokens, wall clock). Publishable after three modules in both trails. Spec: `docs/plans/2026-04-10-openrct2-rust-port-dual-trail.md`
 - [ ] **Paper v1.0** — clean rewrite done, needs review/polish + adaptive retrieval results
 - [x] ~~**Cross-project: wire remaining commands**~~ — impact, trace, test-map wired in #864. Deps local-only.
 - [x] ~~**Agent adoption: telemetry analysis**~~ — mined 16,731 invocations across all sessions. Finding: main conversation uses search (60%) + context (28%). Subagents use the full toolkit (impact, callers, test-map). The gap is in the main conversation, not subagents.


### PR DESCRIPTION
## Summary

Two doc updates capturing the day's session.

**`PROJECT_CONTINUITY.md`** — full session arc:
- 14 PRs merged today, grouped by theme (Phase 5, SPLADE-Code unblock chain, sweep infra, docs/process)
- Phase 5 dual-routing finding: null at N=27 per category, "−3.7pp on conceptual" was a one-query misread
- The three-stacked-bug SPLADE-Code 0.6B unblock chain (vocab mismatch → encoding leak → sparse insert slow path) and how each was found and fixed
- All 6 memory rules saved this session listed
- Reindex v8 bulk-inserting now; eval is the next concrete step

**`ROADMAP.md`**:
- SPLADE v1/v2 marked definitively done as null results, v3/v4 cancelled (capacity is the bottleneck, not data)
- Old SPLADE-Code 0.6B item replaced with one that reflects the perf blockers being cleared (links the relevant PR numbers)
- OpenRCT2 → Rust dual-trail experiment added as a CPU-lane research item, links to `docs/plans/2026-04-10-openrct2-rust-port-dual-trail.md`

## Test plan

- [x] Docs only, no code changes
- [ ] CI green (trivial)
