### PR TITLE
fix: skip integrity_check on read-only opens (86s → 6.9s per query)

### DIFF
--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -408,16 +408,37 @@ impl Store {
             "Database connected"
         );
 
-        // Quick integrity check — catches B-tree corruption early
-        rt.block_on(async {
-            let result: (String,) = sqlx::query_as("PRAGMA integrity_check(1)")
-                .fetch_one(&pool)
-                .await?;
-            if result.0 != "ok" {
-                return Err(StoreError::Corruption(result.0));
-            }
-            Ok::<_, StoreError>(())
-        })?;
+        // Cheap B-tree sanity check — write opens only.
+        //
+        // The previous `PRAGMA integrity_check(1)` walked every page and took
+        // 85s+ on a 1.1GB database over WSL /mnt/c, dominating every CLI
+        // invocation and blocking the eval harness (each `cqs search` shelled
+        // out, each open re-paid the cost). Two changes fix that:
+        //
+        // 1. Skip the check entirely on read-only opens. Reads cannot
+        //    introduce corruption, and if a read encounters corrupt pages the
+        //    query will fail naturally — an upfront walk of the whole file
+        //    just to pre-discover that is not earning its cost for a
+        //    rebuildable search index.
+        // 2. On write opens, use `PRAGMA quick_check` instead of
+        //    `integrity_check`. quick_check validates the B-tree structure
+        //    without the slower cross-checks of index content vs table
+        //    content, which is the right tradeoff for a startup canary.
+        //
+        // Opt-out for either path is available via CQS_SKIP_INTEGRITY_CHECK=1
+        // if the quick_check itself becomes a problem on huge write opens.
+        let skip_integrity = std::env::var("CQS_SKIP_INTEGRITY_CHECK").as_deref() == Ok("1");
+        if !config.read_only && !skip_integrity {
+            rt.block_on(async {
+                let result: (String,) = sqlx::query_as("PRAGMA quick_check(1)")
+                    .fetch_one(&pool)
+                    .await?;
+                if result.0 != "ok" {
+                    return Err(StoreError::Corruption(result.0));
+                }
+                Ok::<_, StoreError>(())
+            })?;
+        }
 
         // Read dim from metadata before constructing Store (avoid unsafe mutation).
         // Defaults to EMBEDDING_DIM for fresh/pre-v15 databases without dimensions key.


### PR DESCRIPTION
## Summary

- `PRAGMA integrity_check(1)` on every `Store::open_with_config` was taking **85 s** per CLI invocation on the 1.1 GB production index over WSL `/mnt/c`. Every `cqs search` paid it, and the eval harness (shells out per query) was unusable.
- Skip the check entirely on read-only opens. Reads cannot corrupt; an upfront full-page walk to pre-discover corruption is not earning its cost on a rebuildable search index.
- On write opens, downgrade to `PRAGMA quick_check(1)` — validates B-tree structure without the slower cross-checks between index and table content.
- `CQS_SKIP_INTEGRITY_CHECK=1` escape hatch preserved for write opens.

## Measured impact

On the production cqs project store (1.1 GB, SPLADE-Code 0.6B corpus, WSL `/mnt/c`):

| Path | Before | After |
|---|---|---|
| `cqs search` (read-only open) | 86 s | **6.9 s** |
| Eval harness (165 queries) | unusable (60 s subprocess timeout tripped) | runs to completion |

The 12× speedup is dominated by skipping the read-only walk; the remaining 6.9 s is HNSW load + embedding + search.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo fmt --check` clean
- [x] Verified a single `cqs search` on the production 1.1 GB DB drops from 86 s to 6.9 s
- [x] Eval harness (`evals/run_ablation.py`) now completes 165q without subprocess timeouts
- [ ] Existing Store tests — the read-only path previously paid the check on every test setup; tests should speed up slightly

## Notes

Follow-up item on the roadmap: `PRAGMA quick_check` on write opens still costs 40 s on a 1.1 GB DB over WSL. That hits `cqs notes add`, `cqs index`, and the `cqs-watch` service. Next step is probably making it opt-in entirely via `CQS_INTEGRITY_CHECK=1` rather than the current opt-out, since corruption detection on a rebuildable index doesn't justify the per-write cost. Tracked in the CPU lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
