### PR TITLE
fix: eval harness -- separator + per-query timeout handling

### DIFF
--- a/evals/run_ablation.py
+++ b/evals/run_ablation.py
@@ -51,12 +51,35 @@ def parse_args():
     return args
 
 
+# Per-query timeout. SPLADE queries pay the full SpladeIndex build cost on
+# every invocation (load all sparse rows → HashMap → inverted index). With
+# SPLADE-Code 0.6B at threshold 1.6 (7.58M rows), this is ~45s per query.
+# Non-SPLADE queries settle around 7s. 300s leaves headroom for worst-case
+# queries without letting genuine hangs wedge the eval.
+CQS_TIMEOUT_SECS = int(os.environ.get("CQS_EVAL_TIMEOUT_SECS", "300"))
+
+
 def run_search(query, n=20, splade=False):
     """Run a cqs search and return list of result names."""
-    cmd = ["cqs", query, "--json", "-n", str(n)]
+    # Put all flags before `--`, then the query as a positional arg. Without
+    # the separator, a single-token query that looks like a subcommand name
+    # (e.g. "prepare_for_embedding") makes clap try to parse it as an unknown
+    # subcommand and the search never runs.
+    cmd = ["cqs", "--json", "-n", str(n)]
     if splade:
         cmd.append("--splade")
-    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=60)
+    cmd.extend(["--", query])
+    try:
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=CQS_TIMEOUT_SECS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(f"[timeout {CQS_TIMEOUT_SECS}s] {query!r}\n")
+        return []
     try:
         data = json.loads(result.stdout)
         return [(r["name"], r.get("score", 0)) for r in data.get("results", [])]


### PR DESCRIPTION
## Summary

Two bugs in `evals/run_ablation.py` tripped by the SPLADE-Code 0.6B re-eval.

1. **Query as positional was parsed as subcommand.** `["cqs", query, "--json", ...]` made clap try to interpret single-token queries like `prepare_for_embedding` as unknown subcommands. The search silently returned `[]` via the JSON-decode fallback and the query scored as zero hits. Fixed with `cqs --json -n 20 -- <query>` — all flags first, then the `--` separator, then the positional.

2. **60 s per-query timeout was too tight and too fatal.** The integrity-check path (pre-#893) took 85 s per open. Even after that fix, the cold first SPLADE query takes ~45 s to build the in-memory `SpladeIndex` from SQLite before on-disk persistence lands. The old harness crashed the entire run on the first timeout.

   Fixed: default timeout raised to 300 s, `CQS_EVAL_TIMEOUT_SECS` env override, `subprocess.TimeoutExpired` caught per-query so one slow query logs and returns `[]` instead of taking down the whole ablation.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('evals/run_ablation.py').read())"` clean
- [x] Ran 165q ablation to completion after the fix — previously crashed on first query
- [x] Confirmed single-token queries (e.g. `prepare_for_embedding`) now dispatch correctly

## Related

- #893 (integrity check skip) — the other half of the eval unblock
- Next: a SPLADE persistence PR that removes the cold-rebuild cost entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
