### PR TITLE
docs: tighten OpenRCT2 dual-trail spec

### DIFF
--- a/docs/plans/2026-04-10-openrct2-rust-port-dual-trail.md
+++ b/docs/plans/2026-04-10-openrct2-rust-port-dual-trail.md
@@ -2,77 +2,72 @@
 
 ## Thesis
 
-A faithful Rust port of OpenRCT2 (a 25-year-old C/C++ codebase reverse-engineered from x86 assembly) is the substrate. **The publishable result is the dual-trail experiment**: two parallel translation efforts on the same upstream commit using the same agent stack, with one trail using cqs for code intelligence augmentation and the other using only the agent's built-in tools. Pre-registered metrics. Result published regardless of direction.
+Two parallel Rust translation efforts of OpenRCT2, same pinned upstream commit, same agent stack, same operator. Trail A uses cqs for code intelligence augmentation. Trail B uses the agent's built-in tools only. Pre-registered hypotheses, pre-committed metrics, result published in whichever direction the numbers point.
 
-The full port is the largest container the experiment fits inside. **The experiment is publishable after a single shared module completes in both trails**, not after the full port. If the full port never finishes, the experiment still produces an answer to the question that motivates building cqs in the first place: does code intelligence augmentation measurably improve agent-directed code translation?
+The full port is the container the experiment fits inside. The publishable dual-trail comparison is a function of the metrics recorded per module, not a function of the port ever shipping. If the port ships, the paper has a bigger story. If only Phase 1 ships, the paper still has its result.
 
-## Why this question matters
+## Pre-registered hypotheses
 
-cqs's design rests on the bet that structural code intelligence — typed chunks, call graphs, impact tracing, per-category retrieval — produces meaningfully better outcomes for agents working on code than unstructured search. That bet has been validated indirectly (telemetry, eval R@1, internal use) but never head-to-head against an unaugmented agent on a sustained, observable, multi-thousand-decision task. OpenRCT2 → Rust is the first task large enough, mechanical enough, and verifiable enough to make the comparison rigorous.
+**H1 — Regression bugs per merged module.** Trail A produces ≥30% fewer regression bugs (validation failures in previously-passing modules after a new module merges) than Trail B.
 
-If the cqs trail wins on the pre-registered metrics, that validates the entire research lane and produces a paper that justifies further investment in code intelligence as a category. If the unaugmented trail wins or ties, that's also a finding worth publishing — cqs's actual leverage is narrower than claimed and the architecture should be re-examined.
+**H2 — Tokens per validated module.** Trail A consumes ≥20% fewer agent tokens per validated module than Trail B, measured cache-adjusted.
 
-## Pre-registered hypothesis
+**H3 — Wall-clock per validated module.** Trail A completes modules in ≥25% less wall-clock time than Trail B, measured from "module started" to "module passes validation."
 
-**H1 (cqs trail produces fewer regression bugs per ported function.)** Code intelligence makes the agent aware of caller/callee context before editing, so cross-module breakage is caught earlier. Predicted effect: ≥30% reduction in regression bugs in the cqs trail vs the control trail, measured per merged module.
+**H0 — Null.** Both trails land within ±10% on all three metrics.
 
-**H2 (cqs trail consumes fewer agent tokens per validated module.)** Structural retrieval reduces the amount of file content the agent has to read into context to understand a function. Predicted effect: ≥20% token reduction per validated module.
-
-**H3 (cqs trail completes modules in less wall-clock time.)** Faster context assembly + fewer regression cycles. Predicted effect: ≥25% wall-clock reduction (measured per-module from "module started" to "module passes validation").
-
-**H0 (no significant difference.)** Both trails perform within ±10% on all three metrics. This would be a meaningful negative result — the structural advantages don't manifest at translation-task scale.
-
-The metrics are tracked from Phase 1 module 1 onward. The experiment publishes after **at least three modules** have completed in both trails, regardless of whether the full Phase 1 ever finishes. Three modules is the minimum for a non-trivial sample.
+Metrics are tracked from Phase 1 module 1 onward. Both trails must complete each module before the next begins (lockstep comparison, not racing).
 
 ## Source
 
 - Upstream: https://github.com/OpenRCT2/OpenRCT2
-- Pin target: latest tagged release at Phase 0 start. Both trails use the **identical pinned commit**. Upstream is treated as immutable spec for the duration of the experiment.
-- Required runtime assets: original RCT2 or RCT Classic data files from a legal copy (GOG sells RCT2 for ~$10).
+- Pin target: latest tagged release at Phase 0 start. Both trails use the identical pinned commit. Upstream is treated as immutable spec for the duration.
+- Required runtime assets: original RCT2 or RCT Classic data files from a legal copy.
 
 ## Trail definitions
 
-### Trail A (cqs-augmented)
+### Trail A — cqs-augmented
 
-- Agent stack: Claude Code with cqs MCP server enabled
-- Pre-edit hook: cqs impact runs before every Edit, injecting caller/test/risk context
-- Translation workflow uses: `cqs scout`, `cqs gather`, `cqs impact`, `cqs callers`, `cqs test-map`, `cqs context` for cross-language tracing across the C++/Rust boundary
-- Indexes both upstream OpenRCT2 (C++) and the in-progress Rust port simultaneously
-- Cross-language call tracing identifies untouched-but-affected Rust code when an upstream C++ function is re-translated
+- Claude Code with cqs MCP server enabled
+- Pre-edit hook runs `cqs impact` before every Edit, injecting caller/test/risk context
+- Uses `cqs scout`, `cqs gather`, `cqs impact`, `cqs callers`, `cqs test-map`, `cqs context`
+- Indexes upstream OpenRCT2 (C++) and the in-progress Rust port in parallel so cross-language call tracing works across the translation boundary
 
-### Trail B (control)
+### Trail B — control
 
-- Agent stack: Claude Code with default tools only (Read, Edit, Glob, Grep, Bash)
+- Claude Code with default tools only (Read, Edit, Glob, Grep, Bash)
 - No cqs, no MCP code intelligence server, no pre-edit hook
-- Translation workflow uses standard exploration: grep, file reads, manual context assembly
-- Indexes nothing — context comes from agent's own search tools session-by-session
+- Standard exploration: grep, file reads, manual context assembly
+- Tool list is frozen at Phase 0 end and does not change during the experiment
 
 ### Identical between trails
 
-- Same Anthropic model (whatever is current at Phase 0 start, then frozen for the duration)
-- Same upstream pinned commit
-- Same module ordering
-- Same validation harness (Phase 0c output)
+- Same Anthropic model, frozen at Phase 0 start for the duration
+- Same pinned upstream commit
+- Same module ordering (defined by Phase 1)
+- Same validation harness (produced by Phase 0c)
 - Same RNG seeds in test fixtures
-- Same operator (single human directing both trails, alternating sessions)
-- Same time-of-day distribution (agent state may vary across the day; alternating prevents lopsided sampling)
+- Same operator, alternating sessions between trails to avoid time-of-day bias
+- Same definition of "module done"
 
-### Tracked per session
+### Tracked per session (both trails)
 
-- Tokens consumed (input + output, separated)
+Written to `metrics.tsv` after every session. A session without a metrics row does not count toward the experiment. This is a hard rule.
+
+- Tokens consumed, input and output separate, cache-adjusted and raw
 - Wall-clock duration
-- Number of agent tool calls, broken down by tool
-- Number of validation iterations (cycles of port → harness fail → fix → retry)
-- Lines of Rust produced (added) and modified
-- Regression bugs introduced (count of validation failures in already-passing modules after a new module's port begins)
+- Agent tool call count, broken down by tool
+- Validation iteration count (port → harness fail → fix → retry cycles)
+- Lines of Rust added and modified
+- Regression bugs introduced (validation failures in already-passing modules after this session)
 
 ## Validation harness
 
-The experiment cannot run without a working harness. Phase 0c is the gate.
+Phase 0c produces the harness. Phase 1 cannot begin without one.
 
-**Strategy 1 (preferred): state-dump diff.** Patch upstream OpenRCT2 to emit a deterministic JSON dump of simulation state every N ticks. Run the same save through upstream and the Rust port for N ticks. Diff the dumps. If they match for the slice owned by the module under test, the module passes.
+**Strategy 1 — state-dump diff.** Patch upstream OpenRCT2 to emit a deterministic JSON dump of simulation state every N ticks. Run the same save through upstream and the Rust port for N ticks. Diff the dumps. If they match for the state slice owned by the module under test, the module passes.
 
-**Strategy 2 (fallback): behavioral equivalence.** If state-dump determinism cannot be achieved (because of float ordering, uninitialized memory, OS-specific behavior, or RNG re-seeding), validation switches to invariant-checking with numeric thresholds. Phase 1 metrics adjust accordingly:
+**Strategy 2 — behavioral equivalence.** If state-dump determinism cannot be achieved (float ordering, uninitialized memory, OS-specific scheduling, RNG re-seeding), validation falls back to invariant checking with numeric thresholds:
 
 - Park rating tracks within ±5% over 10,000 ticks
 - Guest count converges within ±2% by tick 10,000
@@ -80,127 +75,122 @@ The experiment cannot run without a working harness. Phase 0c is the gate.
 - No ride breakdowns occur in the port that didn't occur in upstream
 - No guest type appears in the port that didn't exist in upstream
 
-The fallback is weaker but still rigorous enough to detect translation errors that produce qualitatively different behavior.
+**Strategy 3 — user-acceptance.** If neither state-dump nor behavioral equivalence works, validation is "the port produces a playable scenario indistinguishable from upstream by an experienced player." This weakens the experiment's rigor significantly; document what made 1 and 2 unreachable and proceed.
 
-**Strategy 3 (hard fallback): user-acceptance only.** If neither state-dump nor behavioral equivalence can be made to work, validation degrades to "the port produces a playable scenario indistinguishable from upstream by an experienced player." This is the weakest bar and changes the experiment's scope substantially. Document and re-spec if reached.
+The fallback chain is technical contingency, not a permission slip. Strategy 1 is the target. Strategy 2 is what gets used when 1 provably can't be made to work. Strategy 3 is what gets used when 2 also can't. Which strategy is in use is fixed at Phase 0c and does not change mid-experiment.
 
-The choice between Strategy 1 and Strategy 2 is decided in Phase 0c. **Do not begin Phase 1 without a working strategy.**
+## Phase 0 — Recon and validation gate
 
-## Phase 0 — Reconnaissance and validation gate
-
-Phase 0 deliverables are the go/no-go gate. Do not write any Rust until all five are complete.
+Phase 0 deliverables are the technical gate to Phase 1. No Rust gets written until all five are complete.
 
 ### 0a — Prior art check
 
-Search GitHub, crates.io, GitLab, Codeberg, and the web for existing Rust ports of OpenRCT2 or RCT2. Document findings:
+Search GitHub, crates.io, GitLab, Codeberg, and the web for existing Rust ports of OpenRCT2 or RCT2. Document:
 - Any prior attempt at any completion level
 - Active maintainers, last commit, license
 - Whether the prior attempt is joinable or fork-able
-- Whether the prior attempt's design decisions match this spec's
+- Whether its design decisions match this spec
 
-If a viable prior attempt exists at meaningful completion, **stop** and re-evaluate: join, fork, or proceed knowing the comparison's external validity is reduced.
+A viable prior attempt at meaningful completion changes the experiment's external validity. Decide whether to join, fork, or proceed with the comparison noted as a limitation.
 
 ### 0b — Codebase recon
 
-- Pin upstream to the latest tagged release. Record the commit hash.
-- Build OpenRCT2 from the pinned commit, verify it runs with legal asset files.
-- Index the pinned C++ codebase with cqs (Trail A's first use of the tool).
-- Generate `RECON.md` containing:
-  - File counts and line counts per module
-  - Module dependency graph (cqs gather output)
-  - Inventory of every file-scope variable, extern, singleton, and global state holder
+- Pin upstream to the latest tagged release, record commit hash
+- Build from the pinned commit, verify it runs with legal assets
+- Index the pinned C++ codebase with cqs (Trail A's first use of the tool)
+- Generate `RECON.md`:
+  - File and line counts per module
+  - Module dependency graph (from `cqs gather`)
+  - Inventory of every file-scope variable, extern, singleton, global state holder
   - Inventory of every RNG call site
   - Save file format reference
   - Game action system reference
-  - Multiplayer sync hash extraction location (used in 0c)
+  - Multiplayer sync hash extraction location (used by 0c)
 
 ### 0c — Validation harness verification
 
-- **First** verify Strategy 1 (state-dump diff). Patch upstream to emit deterministic state dumps. Run two upstream instances from the same save for 10,000 ticks. Diff the dumps. **They must be byte-identical.** If yes, Strategy 1 is the validation strategy and Phase 1 can begin.
-- If Strategy 1 fails, identify why (float ordering? uninitialized memory? OS scheduler?). Document. Verify Strategy 2 (behavioral equivalence) by running two upstream instances and confirming the invariant thresholds hold. If yes, Phase 1 begins with Strategy 2 validation.
-- If Strategy 2 fails, escalate to Strategy 3 and re-evaluate whether the project should continue at all.
+- Verify Strategy 1 first. Patch upstream to emit deterministic state dumps. Run two upstream instances from the same save for 10,000 ticks. Diff the dumps. They must be byte-identical. If yes, Strategy 1 is the validation strategy.
+- If Strategy 1 fails, identify why (float ordering, uninitialized memory, OS scheduler) and document. Then verify Strategy 2 by running two upstream instances and confirming the invariant thresholds hold. If yes, Phase 1 begins with Strategy 2.
+- If Strategy 2 also fails, use Strategy 3 and document which failure modes forced it.
 
 ### 0d — RNG verification
 
-- Locate the upstream RNG. Document algorithm and seeding.
-- Implement the RNG in Rust (the smallest possible standalone test).
-- Run both with identical seeds for 10,000 iterations.
-- Sequences must match exactly (Strategy 1) or produce statistically equivalent distributions (Strategy 2).
+- Locate the upstream RNG, document algorithm and seeding
+- Implement the RNG in Rust as the smallest possible standalone test
+- Run both with identical seeds for 10,000 iterations
+- Sequences match exactly (Strategy 1) or produce statistically equivalent distributions (Strategy 2)
 
-### 0e — Architectural decision: global state
+### 0e — Global state architectural decision
 
-OpenRCT2's heritage from x86 assembly means it's full of file-scope and global mutable state. Choose the Rust mapping based on the inventory from 0b:
+OpenRCT2's heritage from x86 assembly means it's full of file-scope and global mutable state. Choose the Rust mapping based on the 0b inventory:
 
-- **Single `World` struct passed to every function** — most idiomatic, biggest API surface change, easiest to reason about
-- **Thread-locals matching C++ globals** — least idiomatic, smallest API surface change, easiest to keep validation harness comparing apples-to-apples
-- **`Arc<Mutex<…>>` per subsystem** — middle ground, allows future parallelism, adds locking overhead and complexity
+- **Single `World` struct passed to every function.** Most idiomatic, largest API surface change, easiest to reason about
+- **Thread-locals matching C++ globals.** Least idiomatic, smallest API surface change, easiest to keep validation comparing apples-to-apples
+- **`Arc<Mutex<…>>` per subsystem.** Middle ground, allows future parallelism, adds locking overhead
 
-Document the decision and rationale in `RECON.md`. Both trails must use the same mapping (otherwise they're not comparing the same task).
+Both trails must use the same mapping. Document the decision and rationale in `RECON.md`. Revisit after module 1.4 if the chosen mapping isn't fitting upstream's actual structure; a mid-Phase-1 refactor is preferable to cementing a wrong choice.
 
-### Phase 0 deliverable
+### Phase 0 exit
 
-`RECON.md` containing all five outputs, the validation strategy choice, the global state decision, the pinned commit hash, and a sign-off section the operator initials before Phase 1 begins.
+`RECON.md` contains all five outputs, the validation strategy, the global state decision, the pinned commit hash, and an operator sign-off section. Phase 1 begins when `RECON.md` is complete and signed off.
 
-## Phase 1 — Simulation core port
+## Phase 1 — Simulation core
 
-Port modules in dependency order. Each module must pass the validation harness for its state slice before the next module begins.
+Modules port in dependency order. Each module must pass validation for its state slice before the next begins. Both trails port the same module in parallel before advancing to the next.
 
-### Module sizing — not equal
+| Module | Description |
+|---|---|
+| 1.1 | Foundational types: coordinates, fixed-point math, RNG, tile data, entity IDs |
+| 1.2 | Map and terrain: grid, tile types, height data, footpath network |
+| 1.3 | Minimum viable ride: one stationary flat ride (e.g. observation tower) |
+| 1.4 | Minimum viable guest: one guest spawned, walking on a path |
+| 1.5 | Vehicles and tracked rides: coasters, gentle rides, thrill rides, trains, station logic, track pieces |
+| 1.6 | Full guest AI: needs system, decision making, pathfinding at scale |
+| 1.7 | Staff: mechanics, handymen, security, entertainers |
+| 1.8 | Park economics, ratings, loans, scenarios, win conditions |
 
-Modules 1.5 and 1.6 are dramatically larger than the others. Acknowledged up front so the spec doesn't read like eight equal milestones.
-
-| Module | Description | Estimated effort share |
-|---|---|---|
-| 1.1 | Foundational types: coordinates, fixed-point math, RNG, tile data, entity IDs | ~5% |
-| 1.2 | Map and terrain: grid, tile types, height data, footpath network | ~10% |
-| 1.3 | Minimum viable ride: one stationary flat ride (e.g. observation tower) | ~5% |
-| 1.4 | Minimum viable guest: one guest spawned, walking on a path | ~5% |
-| **1.5** | **Vehicles and tracked rides** (coasters, gentle rides, thrill rides, trains, station logic, track pieces) | **~30%** |
-| **1.6** | **Full guest AI** (needs system, decision making, pathfinding at scale) | **~30%** |
-| 1.7 | Staff (mechanics, handymen, security, entertainers) | ~10% |
-| 1.8 | Park economics, ratings, loans, scenarios, win conditions | ~5% |
-
-Modules 1.5 and 1.6 together are roughly 60% of Phase 1's total work. Each will likely require its own internal milestone breakdown. The spec deliberately does not break them into sub-modules at this stage because the right decomposition depends on what 0b's recon reveals about upstream's actual structure.
+Modules 1.5 and 1.6 are substantially larger than the others and will each require an internal breakdown before they start. The right decomposition depends on what 0b's recon reveals about upstream's actual structure, so the sub-module list is defined when the module begins, not now.
 
 ### Per-module workflow (both trails)
 
-1. Read the module's upstream C++ scope (Trail A uses cqs scout/gather/context; Trail B uses Read/Glob/Grep).
-2. Identify the state slice this module owns (Trail A reads from RECON.md's inventory; Trail B builds the slice list manually).
+1. Read the module's upstream C++ scope. Trail A uses `cqs scout`, `cqs gather`, `cqs context`. Trail B uses Read, Glob, Grep.
+2. Identify the state slice this module owns. Trail A reads from `RECON.md`. Trail B builds the slice list manually.
 3. Build a fixture: load a known save in upstream, run N ticks, dump the state slice using the Phase 0c harness.
-4. Translate the C++ to Rust function-by-function. Reproduce behavior, including bugs that the pinned commit has. **The pinned commit is the spec, not "what the code should do."**
-5. Run the same fixture through the Rust port. Dump the same slice.
-6. Diff the two dumps (Strategy 1) or check invariant thresholds (Strategy 2).
-7. If the diff is empty / invariants hold: module passes. Otherwise iterate.
-8. Record session metrics (tokens, wall clock, tool calls, iteration count, lines, regressions) in `metrics.tsv`.
-9. After both trails complete the module, snapshot metrics for the experiment writeup.
+4. Translate the C++ to Rust function by function. Reproduce behavior, including bugs the pinned commit has. The pinned commit is the spec, not "what the code should do."
+5. Run the same fixture through the Rust port and dump the same slice.
+6. Diff the dumps (Strategy 1) or check invariant thresholds (Strategy 2).
+7. If the diff is empty or invariants hold, the module passes. Otherwise iterate.
+8. Record session metrics (tokens, wall clock, tool calls, iterations, lines, regressions) to `metrics.tsv`.
+9. Once both trails complete the module, snapshot metrics and advance to the next module.
 
 ### Module exit criteria
 
-A module is "done" when:
-- Validation harness reports zero divergence (Strategy 1) or all invariants hold (Strategy 2)
-- Both trails have ported the same module with the same pinned upstream
-- Per-trail metrics are recorded
+A module is done when:
+
+- Validation reports zero divergence (Strategy 1) or all invariants hold (Strategy 2)
+- Both trails have ported the same module against the same pinned upstream
+- Per-trail metrics are recorded in each trail's `metrics.tsv`
 - The Rust crate compiles cleanly with no warnings
 - All previously-passing modules still pass (regression check)
-- A snapshot tag is created in both trail repos for reproducibility
+- A snapshot tag is created in both trail repos
 
 ## Phase 2 — Rendering, input, audio, UI
 
-**Phase 2 has effort parity with Phase 1.** Do not scope it down to "bolt rendering on top of the simulation." Rendering, asset loading, audio, and UI together represent a body of work comparable to Phase 1 in scope.
+Phase 2 has effort parity with Phase 1. Rendering, asset loading, audio, and UI together are a body of work comparable in scope to the simulation core. Do not treat it as a thin layer on top.
 
-Sub-components (each is its own substantial sub-project):
+Sub-components, each substantial on its own:
 
-- **DAT format asset loader**: Port from upstream. The DAT format is a 25-year-old binary asset bundle that took the OpenRCT2 community years to fully reverse-engineer. The port reuses upstream's loader logic, not the original Sawyer asset format work.
-- **Sprite renderer (wgpu)**: Match upstream's software renderer pixel-for-pixel where possible; document any GPU-specific divergence.
-- **Audio playback**: Original sound effects and music from RCT2 asset files.
-- **Input handling (winit)**: Mouse, keyboard, gamepad if upstream supports it.
-- **In-game UI**: Menus, ride construction interface, park management dialogs, finance reports, scenario editor. Decision deferred to Phase 2 start: pixel-exact reproduction (much more work) vs egui-based reimplementation (more work to design, less work to implement, breaks the "faithful port" thesis).
+- **DAT format asset loader.** Port from upstream. The DAT format is a 25-year-old binary asset bundle that took the community years to reverse-engineer. Reuse upstream's loader logic.
+- **Sprite renderer (wgpu).** Match upstream's software renderer pixel-for-pixel where possible; document any GPU-specific divergence.
+- **Audio playback.** Original sound effects and music from RCT2 asset files.
+- **Input handling (winit).** Mouse, keyboard, gamepad if upstream supports it.
+- **In-game UI.** Menus, ride construction interface, park management dialogs, finance reports, scenario editor. Decision at Phase 2 start: pixel-exact reproduction (more implementation work) vs egui-based reimplementation (more design work, but diverges from "faithful port").
 
-Phase 2 begins only after Phase 1 is complete. The experiment publishes after Phase 1 if Phase 2 is too large a commitment to make.
+Phase 2 begins when Phase 1 is complete.
 
 ## Phase 3 — Library extraction
 
-Refactor Phase 1's simulation core into a standalone crate `rct-sim` exposing:
+Refactor Phase 1's simulation core into a standalone crate `rct-sim`:
 
 ```rust
 fn load(path: &Path) -> Result<Simulation>
@@ -212,65 +202,52 @@ impl Simulation {
 }
 ```
 
-This is a refactor, not a rewrite. The validation harness must continue to pass after the refactor with no behavioral change.
+This is a refactor, not a rewrite. The validation harness must continue to pass with no behavioral change.
 
-## Phase 4 — Optional follow-ups
+## Phase 4 — Downstream projects
 
-Each is a separate project gated on Phase 3 completion, with its own spec when reached:
+Each is a separate project gated on Phase 3, specced when reached:
 
-- **ML testbed**: gym-style RL environment wrapping `rct-sim`. Park management is a constrained economic simulation with clear metrics — perfect for RL benchmarking.
-- **WASM mod API**: user-written plugins in any WASM-targeting language for rides, scenarios, and AI guests.
-- **Replay and diff tooling**: record inputs, replay deterministically, diff simulation states between versions. Useful for regression testing the rewrite, also useful for speedrunning and competitive play.
-- **Parallel simulation harness**: run thousands of parks concurrently for optimization studies.
-
-None of these are part of the core experiment. They exist to make the spec's "this is worth doing" argument bigger, and to attract contributors after publication.
+- **ML testbed.** Gym-style RL environment wrapping `rct-sim`. Park management is a constrained economic simulation with clear metrics.
+- **WASM mod API.** User plugins in any WASM-targeting language for rides, scenarios, AI guests.
+- **Replay and diff tooling.** Record inputs, replay deterministically, diff simulation states between versions.
+- **Parallel simulation harness.** Run thousands of parks concurrently for optimization studies.
 
 ## Phase ordering and exit criteria
 
-The experiment is gated on deliverables, not durations. A phase is "done" when its exit criteria are satisfied, not when a time budget elapses.
+The experiment is gated on deliverables, not durations.
 
-- **Phase 0**: All five 0a–0e deliverables complete. Validation strategy verified (Strategy 1, 2, or 3 chosen and proven to work on a real diff). Gate to Phase 1.
-- **Phase 1**: All eight modules pass validation in both trails. An interim writeup based on the first three modules is a valid milestone (see "First publishable milestone" below) but is not a substitute for completing Phase 1.
-- **Phase 2**: Playable scenario indistinguishable from upstream by an experienced player.
-- **Phase 3**: `rct-sim` crate compiles cleanly, validation harness still passes after the refactor.
-- **Phase 4**: Per-project specs.
+- **Phase 0.** All five 0a–0e deliverables complete, validation strategy verified on a real diff, `RECON.md` signed off. Gate to Phase 1.
+- **Phase 1.** All eight modules pass validation in both trails, regression checks clean, metrics recorded.
+- **Phase 2.** Playable scenario indistinguishable from upstream by an experienced player.
+- **Phase 3.** `rct-sim` crate compiles cleanly, validation passes after the refactor.
+- **Phase 4.** Per-project specs.
 
-## Calibration as a deliverable
+## Metrics are the deliverable
 
-The dual-trail experiment produces real per-module measurements: tokens consumed, agent invocations, validation iterations, regression bugs, lines of Rust generated. These measurements are the primary outputs of the experiment, and they're also the only credible answer to "how long does agent-directed translation actually take."
+The dual-trail comparison produces per-module measurements: tokens consumed, agent invocations, validation iterations, regression bugs, lines of Rust generated. These measurements are the primary output of the experiment. Every session produces a `metrics.tsv` row or the session does not count. Every module produces a snapshot or the module is not done. Gaps in the metrics invalidate the corresponding comparison, which is the single thing the experiment exists to produce.
 
-Treat the first three modules as the calibration run. Whatever throughput numbers come out of those modules are the basis for any future estimate of the work remaining. Do not write estimates into this spec; record measured numbers in `metrics.tsv` and update the writeup when the data exists.
-
-## First publishable milestone
-
-The dual-trail comparison is meaningful as soon as three modules are complete in both trails. After Phase 0 + modules 1.1–1.3, the operator can publish an interim writeup containing:
-
-- A working subset of the Rust port (foundational types, map, one stationary ride)
-- A pre-registered head-to-head comparison of cqs-augmented vs unaugmented agent-directed translation
-- Per-module numbers on tokens, agent invocations, validation iterations, regression bugs
-- The first calibration-grade evidence on whether code intelligence augmentation measurably helps agents on a sustained, real-world translation task
-
-This is a milestone, not a stopping point. The full Phase 1, Phase 2, and Phase 3 are still the deliverables. The interim writeup exists to start gathering external feedback on the methodology while the rest of the work continues.
+No predicted throughput numbers appear in this spec. Actual throughput comes from running the work and measuring it.
 
 ## Risks
 
-1. **Validation strategy fails** (0c). Mitigation: three-tier fallback chain (state-dump → behavioral → user-acceptance). If all three fail, the project is not feasible as specified and must be rescoped or abandoned.
+1. **Validation strategy cannot be built.** Technical contingency: three-tier fallback (state-dump → behavioral → user-acceptance). If Strategy 3 also fails, the harness has a deeper problem than the fallback chain addresses and Phase 0c needs a different approach before Phase 1 can begin.
 
-2. **RNG cannot be reproduced bit-exact**. Same as above, mitigated by Strategy 2 fallback.
+2. **RNG cannot be reproduced bit-exact.** Handled by Strategy 2 fallback. Documented in 0d.
 
-3. **Global state translation intractable**. Decided in 0e. Worst case: the chosen mapping doesn't fit the upstream architecture and the Rust port has to refactor partway through. Mitigation: revisit the 0e decision after module 1.4 completes, when enough Rust exists to test the assumption.
+3. **Global state mapping doesn't fit upstream.** The 0e decision is revisited after module 1.4, when enough Rust exists to test the assumption. A mid-Phase-1 refactor is the expected response if the original mapping is wrong.
 
-4. **Upstream changes invalidate the harness**. Mitigation: pin to a tagged release and treat as immutable. Do not chase upstream changes during Phase 1 or Phase 2.
+4. **Upstream changes invalidate the harness.** Pin to a tagged release and treat as immutable. Do not chase upstream changes during Phase 1 or Phase 2.
 
-5. **Single-operator confound**. The same human directs both trails. Operator priors, time of day, and recent context affect both trails. Acknowledged as a limitation; alternating between trails reduces but doesn't eliminate the bias. Independent replication would strengthen external validity.
+5. **Single-operator confound.** The same human directs both trails. Operator priors and recent context affect both. Alternating between trails reduces but doesn't eliminate the bias. Independent replication would strengthen external validity and is noted as a limitation in the writeup.
 
-6. **Trail B advantage from cqs design lessons**. The operator built cqs and has strong priors about what code intelligence should provide. Trail B might benefit from those priors even without the tool. Mitigation: pre-commit to Trail B's tool list before Phase 1 and do not modify it during the experiment.
+6. **Trail B advantage from cqs design priors.** The operator built cqs and has strong priors about what code intelligence should provide. Trail B may benefit from those priors even without the tool. Trail B's tool list and workflow are frozen at Phase 0 end and not modified during the experiment.
 
-7. **Trail A disadvantage from cqs maintenance overhead**. Time spent debugging cqs itself counts as Trail A overhead even though it's not translation work. Mitigation: track cqs maintenance time separately so it can be excluded or included in the analysis as appropriate.
+7. **Trail A overhead from cqs maintenance.** Time spent debugging cqs counts against Trail A. Track cqs maintenance time in a separate column so it can be analyzed with and without it.
 
-8. **Token measurement noise**. Anthropic API token counts include cache reads, which behave differently across sessions. Mitigation: report both raw and cache-adjusted token counts. The cache-adjusted number is the better proxy for agent work done.
+8. **Token measurement noise.** Anthropic API token counts include cache reads which behave differently across sessions. Report both raw and cache-adjusted numbers. The cache-adjusted number is the primary metric.
 
-9. **Metric tracking lapses**. The dual-trail comparison requires `metrics.tsv` updates after every module in both trails. If tracking lapses, the experiment loses its publishable result even though the port keeps progressing. Mitigation: sessions without a corresponding metrics row do not count toward the experiment, period. This is a hard rule, not a soft preference.
+9. **Metrics tracking lapses.** Sessions without `metrics.tsv` rows do not count. This is the experiment's hard rule.
 
 ## Repository layout
 
@@ -295,7 +272,7 @@ openrct2-rust-port/
 
 ## First concrete step
 
-Execute Phase 0a. One command:
+Execute Phase 0a.
 
 ```sh
 mkdir -p ~/openrct2-rust-port && cd ~/openrct2-rust-port && \
@@ -303,4 +280,4 @@ mkdir -p ~/openrct2-rust-port && cd ~/openrct2-rust-port && \
   date >> RECON-0a.md
 ```
 
-Then web search for existing Rust ports of OpenRCT2 or RCT2. Document findings in `RECON-0a.md`. **Do not proceed to 0b until 0a is complete and the findings have been reviewed.**
+Web search for existing Rust ports of OpenRCT2 or RCT2. Document findings in `RECON-0a.md`. Phase 0b begins when 0a is complete.


### PR DESCRIPTION
## Summary

Follow-up to #890 (the original OpenRCT2 → Rust dual-trail experiment spec). The original had accumulated three classes of content that the session feedback called out as disguised failure authorization dressed up as helpfulness:

1. **Time/effort estimates** — the Phase 1 module table had an "Estimated effort share" column (1.1 = ~5%, 1.5 = ~30%, …) that was guesses dressed up as percentages. Rule: don't put time estimates in specs; the model is structurally bad at producing them, they get ignored, and generating them anchors thinking on the wrong scale.

2. **Psychological off-ramps** — "First publishable milestone" section framed three-module interim results as a respectable stopping point. Phase 2 contained "the experiment publishes after Phase 1 if Phase 2 is too large a commitment to make." Risk 1 ended with "must be rescoped or abandoned." All pre-authorized giving up at points where the work could technically continue. Rule: keep technical fallback chains (state-dump → behavioral → user-acceptance is real contingency engineering); cut anything that reads like "future-me doesn't have to finish this."

3. **Substrate grading** — a "Why this question matters" section justified the experiment's importance, and Phase 4 described downstream projects as existing "to make the spec's 'this is worth doing' argument bigger." Both editorialized about whether the substrate deserves to exist. Rule: when the user picks a project, spec it well, don't filter through taste.

## Changes

- Removed "Why this question matters" section entirely
- Removed "Estimated effort share" column from the Phase 1 module table (the observation that 1.5 and 1.6 are substantially larger stays as a structural note about scope, not as a percentage budget)
- Removed "First publishable milestone" section
- Removed Phase 2 "publishes after Phase 1 if Phase 2 is too large a commitment" language
- Removed Phase 4 "exist to make the spec's 'this is worth doing' argument bigger" framing
- Risk 1 no longer ends with "must be rescoped or abandoned" — now says the harness needs a different Phase 0c approach before Phase 1 can begin (technical contingency, not psychological exit)
- Explicit **lockstep between trails**: both trails complete each module before the next begins
- Trail B tool list freeze promoted from risk footnote to structural property of the trail definition
- New "Metrics are the deliverable" section replaces "Calibration as a deliverable" with a harder rule: sessions without a `metrics.tsv` row do not count toward the experiment, period

## Bottom line

306 → 283 lines. Tighter, no merit selling, no time budgets, no bail-out hatches. Technical fallback chain stays because that's real contingency engineering.

## Test plan

- [x] Spec compiles (markdown — no build step)
- [x] Word count / line count check (306 → 283)
- [x] All three feedback rules (no time estimates, no off-ramps, don't grade substrate) verified against the revised text
- [x] Technical fallback chain (state-dump → behavioral → user-acceptance) preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
