### PR TITLE
fix: watch + SPLADE via v20 AFTER DELETE trigger on chunks (audit PR-B)

### DIFF
--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -263,6 +263,28 @@ pub fn cmd_watch(cli: &Cli, debounce_ms: u64, no_ignore: bool, poll: bool) -> Re
     );
     println!("Also watching: docs/notes.toml");
 
+    // v1.22.0 audit DS-W2 / OB-22 / PB-NEW-6: watch does not run SPLADE
+    // encoding on new chunks. The v20 trigger on `chunks` DELETE ensures
+    // sparse correctness (the persisted splade.index.bin gets invalidated
+    // when chunks are removed), but newly-added chunks have no sparse
+    // vectors until a manual `cqs index` runs. If a user has
+    // CQS_SPLADE_MODEL set expecting full SPLADE coverage to be
+    // maintained live, tell them up front that they still need to rerun
+    // `cqs index` for fresh coverage on new chunks.
+    if cqs::splade::resolve_splade_model_dir().is_some() {
+        println!(
+            "⚠ SPLADE model configured but watch mode does not refresh sparse vectors for \
+             newly-added chunks. Run 'cqs index' after a stable edit session to restore \
+             full SPLADE coverage. Sparse correctness for removed chunks is maintained \
+             automatically via the v20 schema trigger."
+        );
+        tracing::warn!(
+            "Watch mode does not re-run SPLADE encoding — new chunks will have no sparse \
+             vectors until manual 'cqs index'. Removals are handled via the v20 chunks-delete \
+             trigger."
+        );
+    }
+
     let (tx, rx) = mpsc::channel();
 
     let config = Config::default().with_poll_interval(Duration::from_millis(debounce_ms));

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -134,6 +134,26 @@ CREATE TABLE IF NOT EXISTS sparse_vectors (
 
 CREATE INDEX IF NOT EXISTS idx_sparse_token ON sparse_vectors(token_id);
 
+-- v20 (v1.22.0 audit DS-W2 / OB-22 / PB-NEW-6): trigger that bumps the
+-- SPLADE generation counter whenever a chunk is deleted. Fires per-row on
+-- explicit DELETE FROM chunks AND on CASCADE delete (which actually comes
+-- from type_edges.source_chunk_id, calls.source_chunk_id, and now
+-- sparse_vectors.chunk_id since v19). This makes the persisted
+-- `splade.index.bin` file invalidation structural instead of instrumented —
+-- `cqs watch` no longer needs to call `bump_splade_generation` explicitly
+-- because every delete_phantom_chunks / delete_by_origin statement bumps
+-- the counter automatically. Scoped to deletion specifically because
+-- chunks INSERT doesn't invalidate existing sparse data (new chunks have
+-- no sparse rows yet) and UPDATE-without-ID-change doesn't affect
+-- sparse_vectors at all.
+CREATE TRIGGER IF NOT EXISTS bump_splade_on_chunks_delete
+AFTER DELETE ON chunks
+BEGIN
+    INSERT INTO metadata (key, value) VALUES ('splade_generation', '1')
+    ON CONFLICT(key) DO UPDATE SET
+        value = CAST((CAST(value AS INTEGER) + 1) AS TEXT);
+END;
+
 -- LLM-generated summaries cache (SQ-6, v16: composite PK)
 -- Keyed by (content_hash, purpose) so the same code can have multiple summary types
 -- (e.g., 'summary', 'doc-comment'). Summaries survive chunk deletion and --force rebuilds.

--- a/src/store/helpers/mod.rs
+++ b/src/store/helpers/mod.rs
@@ -57,6 +57,12 @@ pub use embeddings::{bytes_to_embedding, embedding_slice, embedding_to_bytes};
 ///
 /// History:
 /// - v18: embedding_base column for dual embeddings (adaptive retrieval Phase 5)
+/// - v20: AFTER DELETE trigger on chunks bumps splade_generation in metadata
+///   (v1.22.0 audit DS-W2 / OB-22 / PB-NEW-6 — `cqs watch` never touched
+///   SPLADE, so deletes that cascade to sparse_vectors left the persisted
+///   `splade.index.bin` stale. The trigger fires once per deleted chunk
+///   (1-200 fires per watch cycle, tolerable) and invalidates the cached
+///   index without requiring instrumentation at every chunks-delete site.)
 /// - v19: sparse_vectors gains FK(chunk_id) → chunks(id) ON DELETE CASCADE
 ///   (v1.22.0 audit DS-W3 — orphan sparse rows previously leaked on every
 ///   chunks-delete path; CASCADE makes the invariant structural)
@@ -69,7 +75,7 @@ pub use embeddings::{bytes_to_embedding, embedding_slice, embedding_to_bytes};
 /// - v12: parent_type_name column for method->class association
 /// - v11: type_edges table for type-level dependency tracking
 /// - v10: sentiment in embeddings, call graph, notes
-pub const CURRENT_SCHEMA_VERSION: i32 = 19;
+pub const CURRENT_SCHEMA_VERSION: i32 = 20;
 
 /// Default model name for metadata checks (used by test-only `check_model_version`).
 /// Canonical definition is `embedder::DEFAULT_MODEL_REPO`.

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -73,6 +73,7 @@ async fn run_migration(
         (16, 17) => migrate_v16_to_v17(conn).await,
         (17, 18) => migrate_v17_to_v18(conn).await,
         (18, 19) => migrate_v18_to_v19(conn).await,
+        (19, 20) => migrate_v19_to_v20(conn).await,
         _ => Err(StoreError::MigrationNotSupported(from, to)),
     }
 }
@@ -409,6 +410,65 @@ async fn migrate_v18_to_v19(conn: &mut sqlx::SqliteConnection) -> Result<(), Sto
     Ok(())
 }
 
+/// Migrate from v19 to v20: AFTER DELETE trigger on chunks bumps splade_generation
+///
+/// v1.22.0 audit DS-W2 / OB-22 / PB-NEW-6 (triple-confirmed by three
+/// independent auditors): `cqs watch` never touched SPLADE. When watch
+/// detected a file edit and called `delete_phantom_chunks` or
+/// `delete_by_origin`, the v19 FK CASCADE correctly removed the orphan
+/// sparse rows, but nothing bumped `splade_generation`. The on-disk
+/// `splade.index.bin` still matched the unchanged counter, so readers
+/// trusted the stale file and served chunk_ids that no longer existed.
+///
+/// This trigger fires on every `DELETE FROM chunks` statement, once per
+/// deleted row, and bumps the generation via a single metadata UPDATE.
+/// For a watch cycle that touches 1-200 chunks, that's 1-200 metadata
+/// updates — negligible. For `cqs index --force`, the new DB is fresh
+/// and receives no DELETE statements at all, so the trigger cost is
+/// zero on the bulk-reindex path. The only concern is `delete_by_origin`
+/// during normal reindex when many chunks are displaced; even then the
+/// write amplification is ~1-5s per 10k deletions, vs. the minutes the
+/// actual rebuild takes.
+///
+/// The trigger is scoped to `chunks` deletions specifically. sparse_vectors
+/// writes are still bumped explicitly by `bump_splade_generation_tx` (one
+/// call per upsert transaction, not per row) because that's the only site
+/// the trigger-on-sparse_vectors alternative would have caught and it
+/// would have fired millions of times during a bulk upsert — row-level
+/// triggers on the high-cardinality table were the wrong design.
+async fn migrate_v19_to_v20(conn: &mut sqlx::SqliteConnection) -> Result<(), StoreError> {
+    let _span = tracing::info_span!("migrate_v19_to_v20").entered();
+
+    sqlx::query(
+        "CREATE TRIGGER IF NOT EXISTS bump_splade_on_chunks_delete \
+         AFTER DELETE ON chunks \
+         BEGIN \
+             INSERT INTO metadata (key, value) VALUES ('splade_generation', '1') \
+             ON CONFLICT(key) DO UPDATE SET \
+                 value = CAST((CAST(value AS INTEGER) + 1) AS TEXT); \
+         END",
+    )
+    .execute(&mut *conn)
+    .await?;
+
+    // Bump generation immediately so any pre-v20 persisted splade.index.bin
+    // (possibly already out of sync with sparse_vectors because watch-mode
+    // deletes since v19 landed never bumped the counter) gets invalidated
+    // on the next load.
+    sqlx::query(
+        "INSERT INTO metadata (key, value) VALUES ('splade_generation', '1')
+         ON CONFLICT(key) DO UPDATE SET
+             value = CAST((CAST(value AS INTEGER) + 1) AS TEXT)",
+    )
+    .execute(&mut *conn)
+    .await?;
+
+    tracing::info!(
+        "Migrated to v20: AFTER DELETE trigger on chunks bumps splade_generation (DS-W2/OB-22 fix)"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -426,7 +486,7 @@ mod tests {
     #[test]
     fn test_current_schema_version_documented() {
         // Ensure the current version matches what we document
-        assert_eq!(CURRENT_SCHEMA_VERSION, 19);
+        assert_eq!(CURRENT_SCHEMA_VERSION, 20);
     }
 
     #[test]
@@ -1518,6 +1578,194 @@ mod tests {
             assert_eq!(
                 remaining, 0,
                 "CASCADE should have removed chunk-also-live's sparse rows"
+            );
+        });
+    }
+
+    /// v1.22.0 audit DS-W2 / OB-22 / PB-NEW-6: v19→v20 adds a trigger on
+    /// chunks that bumps splade_generation on every DELETE. Test covers:
+    /// - Migration bumps the generation immediately
+    /// - The trigger fires on subsequent DELETE FROM chunks
+    /// - Multiple deletes produce multiple bumps (cardinality check)
+    /// - A no-op reindex (all INSERT no DELETE) does NOT bump via the trigger
+    #[test]
+    fn test_migrate_v19_to_v20_adds_trigger_that_bumps_on_chunks_delete() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        rt.block_on(async {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(
+                    sqlx::sqlite::SqliteConnectOptions::new()
+                        .filename(&db_path)
+                        .create_if_missing(true)
+                        .foreign_keys(true),
+                )
+                .await
+                .unwrap();
+
+            // Minimal v19 schema: chunks, sparse_vectors with v19 FK, metadata.
+            sqlx::query("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+                .execute(&pool)
+                .await
+                .unwrap();
+            sqlx::query(
+                "CREATE TABLE chunks (
+                    id TEXT PRIMARY KEY,
+                    origin TEXT NOT NULL,
+                    source_type TEXT NOT NULL,
+                    language TEXT NOT NULL,
+                    chunk_type TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    signature TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    content_hash TEXT NOT NULL,
+                    line_start INTEGER NOT NULL,
+                    line_end INTEGER NOT NULL,
+                    embedding BLOB NOT NULL,
+                    embedding_base BLOB,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    enrichment_version INTEGER NOT NULL DEFAULT 0
+                )",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "CREATE TABLE sparse_vectors (
+                    chunk_id TEXT NOT NULL,
+                    token_id INTEGER NOT NULL,
+                    weight REAL NOT NULL,
+                    PRIMARY KEY (chunk_id, token_id),
+                    FOREIGN KEY (chunk_id) REFERENCES chunks(id) ON DELETE CASCADE
+                )",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            sqlx::query("CREATE INDEX idx_sparse_token ON sparse_vectors(token_id)")
+                .execute(&pool)
+                .await
+                .unwrap();
+            sqlx::query(
+                "INSERT INTO metadata (key, value) VALUES ('schema_version', '19'),
+                                                          ('splade_generation', '10')",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+
+            // Seed a chunk so we have something to delete.
+            for id in ["c1", "c2", "c3"] {
+                sqlx::query(
+                    "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name, \
+                     signature, content, content_hash, line_start, line_end, embedding, \
+                     created_at, updated_at) \
+                     VALUES (?1, 'file:lib.rs', 'file', 'rust', 'function', ?1, \
+                     '', '', 'h', 1, 10, X'00', '2026-04-12', '2026-04-12')",
+                )
+                .bind(id)
+                .execute(&pool)
+                .await
+                .unwrap();
+            }
+
+            // Run v19 → v20 migration.
+            migrate(&pool, 19, 20).await.unwrap();
+
+            // Migration itself bumps the generation once.
+            let (gen_after_migration,): (String,) =
+                sqlx::query_as("SELECT value FROM metadata WHERE key = 'splade_generation'")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            let gen_after_migration: u64 = gen_after_migration.parse().unwrap();
+            assert!(
+                gen_after_migration > 10,
+                "migration should bump generation past starting value 10"
+            );
+
+            // Trigger exists.
+            let trigger: Option<(String,)> = sqlx::query_as(
+                "SELECT name FROM sqlite_master WHERE type='trigger' \
+                 AND name='bump_splade_on_chunks_delete'",
+            )
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+            assert!(trigger.is_some(), "v20 trigger must exist after migration");
+
+            // Schema version.
+            let (v,): (String,) =
+                sqlx::query_as("SELECT value FROM metadata WHERE key = 'schema_version'")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert_eq!(v, "20");
+
+            // Deleting a chunk fires the trigger once and bumps the
+            // generation.
+            let before_one_delete = gen_after_migration;
+            sqlx::query("DELETE FROM chunks WHERE id = 'c1'")
+                .execute(&pool)
+                .await
+                .unwrap();
+            let (gen_after_one_delete,): (String,) =
+                sqlx::query_as("SELECT value FROM metadata WHERE key = 'splade_generation'")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            let gen_after_one_delete: u64 = gen_after_one_delete.parse().unwrap();
+            assert_eq!(
+                gen_after_one_delete,
+                before_one_delete + 1,
+                "one chunk delete should bump generation by exactly one"
+            );
+
+            // Deleting two chunks bumps by two (trigger is row-level).
+            sqlx::query("DELETE FROM chunks WHERE id IN ('c2', 'c3')")
+                .execute(&pool)
+                .await
+                .unwrap();
+            let (gen_after_two_delete,): (String,) =
+                sqlx::query_as("SELECT value FROM metadata WHERE key = 'splade_generation'")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            let gen_after_two_delete: u64 = gen_after_two_delete.parse().unwrap();
+            assert_eq!(
+                gen_after_two_delete,
+                gen_after_one_delete + 2,
+                "two chunk deletes should bump generation by exactly two"
+            );
+
+            // INSERTs do NOT bump via this trigger (new chunks don't
+            // invalidate existing sparse data).
+            sqlx::query(
+                "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name, \
+                 signature, content, content_hash, line_start, line_end, embedding, \
+                 created_at, updated_at) \
+                 VALUES ('c4', 'file:lib.rs', 'file', 'rust', 'function', 'c4', \
+                 '', '', 'h', 1, 10, X'00', '2026-04-12', '2026-04-12')",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            let (gen_after_insert,): (String,) =
+                sqlx::query_as("SELECT value FROM metadata WHERE key = 'splade_generation'")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            let gen_after_insert: u64 = gen_after_insert.parse().unwrap();
+            assert_eq!(
+                gen_after_insert, gen_after_two_delete,
+                "INSERT should NOT bump the generation (no DELETE happened)"
             );
         });
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -525,22 +525,18 @@ impl Store {
         self.rt.block_on(async {
             let (_guard, mut tx) = self.begin_write().await?;
 
-            // Create tables - execute each statement separately
+            // Create tables + indexes + triggers. A naive `schema.split(';')`
+            // would cut trigger bodies in half because `CREATE TRIGGER ...
+            // BEGIN ... END` contains an embedded semicolon. The loop below
+            // tracks whether we're inside a BEGIN/END block (case-insensitive
+            // keyword match at word boundaries) and folds the body into a
+            // single statement.
             let schema = include_str!("../schema.sql");
-            for statement in schema.split(';') {
-                let stmt: String = statement
-                    .lines()
-                    .skip_while(|line| {
-                        let trimmed = line.trim();
-                        trimmed.is_empty() || trimmed.starts_with("--")
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                let stmt = stmt.trim();
+            for stmt in split_sql_statements(schema) {
                 if stmt.is_empty() {
                     continue;
                 }
-                sqlx::query(stmt).execute(&mut *tx).await?;
+                sqlx::query(&stmt).execute(&mut *tx).await?;
             }
 
             // Store metadata (OR REPLACE handles re-init after incomplete cleanup)
@@ -599,6 +595,129 @@ impl Store {
             self.pool.close().await;
             Ok(())
         })
+    }
+}
+
+/// Split a SQL script into individual statements, honoring `CREATE TRIGGER
+/// ... BEGIN ... END` blocks so embedded semicolons inside a trigger body
+/// don't cause the parser to cut the statement in half.
+///
+/// This is a minimal implementation — it doesn't handle quoted strings,
+/// nested parentheses, or comments beyond line-comments. It's only called
+/// on `src/schema.sql`, which is hand-written and trusted.
+///
+/// Rules:
+/// - Skip empty lines and `--` comments at the start of each statement
+/// - Semicolons outside a `BEGIN`/`END` block end the statement
+/// - Semicolons inside a `BEGIN`/`END` block are part of the body
+/// - Case-insensitive keyword matching at word boundaries
+fn split_sql_statements(sql: &str) -> Vec<String> {
+    let mut statements: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut in_trigger_body = false;
+    // Walk the text line-by-line. This is good enough for our schema, which
+    // places one statement per logical block with comments above.
+    for raw_line in sql.lines() {
+        let trimmed = raw_line.trim();
+        // Strip pure comment / empty lines at the start of a statement.
+        if current.trim().is_empty() && (trimmed.is_empty() || trimmed.starts_with("--")) {
+            continue;
+        }
+        // Detect entry into a trigger body via a standalone `BEGIN` token.
+        let upper = trimmed.to_ascii_uppercase();
+        if !in_trigger_body && (upper == "BEGIN" || upper.ends_with(" BEGIN")) {
+            in_trigger_body = true;
+        }
+        current.push_str(raw_line);
+        current.push('\n');
+        // Detect end of trigger body via a standalone `END` token (possibly
+        // followed by a trailing semicolon on the same line).
+        if in_trigger_body && (upper.starts_with("END;") || upper == "END" || upper == "END;") {
+            in_trigger_body = false;
+            // The trailing semicolon after END closes the whole CREATE
+            // TRIGGER statement. Flush.
+            statements.push(current.trim().trim_end_matches(';').trim().to_string());
+            current.clear();
+            continue;
+        }
+        // Outside a trigger body: split on `;` at end-of-line.
+        if !in_trigger_body && trimmed.ends_with(';') {
+            // Strip the trailing semicolon from the flushed statement.
+            let stmt = current.trim().trim_end_matches(';').trim().to_string();
+            if !stmt.is_empty() {
+                statements.push(stmt);
+            }
+            current.clear();
+        }
+    }
+    // Flush any trailing statement with no final semicolon.
+    let tail = current.trim().to_string();
+    if !tail.is_empty() {
+        statements.push(tail);
+    }
+    statements
+}
+
+#[cfg(test)]
+mod sql_split_tests {
+    use super::split_sql_statements;
+
+    #[test]
+    fn test_split_single_table() {
+        let sql = "CREATE TABLE foo (id INTEGER);";
+        let stmts = split_sql_statements(sql);
+        assert_eq!(stmts.len(), 1);
+        assert!(stmts[0].starts_with("CREATE TABLE foo"));
+    }
+
+    #[test]
+    fn test_split_multiple_statements() {
+        let sql = "CREATE TABLE foo (id INTEGER);\nCREATE INDEX idx_foo ON foo(id);";
+        let stmts = split_sql_statements(sql);
+        assert_eq!(stmts.len(), 2);
+    }
+
+    #[test]
+    fn test_split_trigger_body_preserved() {
+        // A trigger body contains an embedded `;` that would split naively.
+        let sql = "\
+CREATE TABLE foo (id INTEGER);
+
+CREATE TRIGGER bump_on_delete
+AFTER DELETE ON foo
+BEGIN
+    INSERT INTO bar (x) VALUES (1);
+END;
+
+CREATE TABLE baz (id INTEGER);
+";
+        let stmts = split_sql_statements(sql);
+        assert_eq!(
+            stmts.len(),
+            3,
+            "foo + trigger + baz — trigger body must not be cut"
+        );
+        assert!(stmts[1].contains("CREATE TRIGGER"));
+        assert!(
+            stmts[1].contains("INSERT INTO bar"),
+            "trigger body must be preserved intact"
+        );
+        assert!(stmts[1].contains("END"), "trigger END must be included");
+    }
+
+    #[test]
+    fn test_split_skips_leading_comments() {
+        let sql = "-- comment\n-- another\nCREATE TABLE foo (id INTEGER);";
+        let stmts = split_sql_statements(sql);
+        assert_eq!(stmts.len(), 1);
+        assert!(stmts[0].starts_with("CREATE TABLE"));
+    }
+
+    #[test]
+    fn test_split_empty_input() {
+        assert!(split_sql_statements("").is_empty());
+        assert!(split_sql_statements("-- just a comment\n").is_empty());
+        assert!(split_sql_statements("\n\n\n").is_empty());
     }
 }
 

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -17,7 +17,7 @@ fn test_store_init() {
     let stats = store.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
     assert_eq!(stats.total_files, 0);
-    assert_eq!(stats.schema_version, 19); // v19: sparse_vectors FK CASCADE (DS-W3)
+    assert_eq!(stats.schema_version, 20); // v20: AFTER DELETE trigger on chunks (DS-W2)
     assert_eq!(stats.model_name, cqs::embedder::DEFAULT_MODEL_REPO);
 }
 
@@ -1103,7 +1103,7 @@ fn test_open_readonly_on_initialized_store() {
     let ro = cqs::store::Store::open_readonly(&db_path).unwrap();
     let stats = ro.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
-    assert_eq!(stats.schema_version, 19);
+    assert_eq!(stats.schema_version, 20);
     assert_eq!(stats.model_name, cqs::embedder::DEFAULT_MODEL_REPO);
 }
 


### PR DESCRIPTION
## Summary

**PR-B of 10** from the v1.22.0 audit execution plan. Depends on #898 (PR-A: v19 FK CASCADE + generation bump).

Fixes the triple-confirmed watch + SPLADE drift (DS-W2, OB-22, PB-NEW-6) — three independent auditors landed on the same issue: `cqs watch` never touches SPLADE. When watch deletes phantom chunks, the v19 FK CASCADE (from #898) correctly removes orphan sparse_vectors rows, but nothing bumped `splade_generation`. The on-disk `splade.index.bin` still matched the unchanged counter, so readers trusted the stale file.

## The fix: v20 schema trigger

```sql
CREATE TRIGGER bump_splade_on_chunks_delete
AFTER DELETE ON chunks
BEGIN
    INSERT INTO metadata (key, value) VALUES ('splade_generation', '1')
    ON CONFLICT(key) DO UPDATE SET
        value = CAST((CAST(value AS INTEGER) + 1) AS TEXT);
END;
```

Fires once per deleted chunk — 1-200 fires per watch cycle (negligible). On `cqs index --force` the DB is rebuilt fresh, zero trigger fires. The trigger runs AFTER DELETE so the v19 FK CASCADE has already removed sparse_vectors rows by the time the generation bumps.

Also includes:
- `split_sql_statements()` helper for `schema.sql` init — the naive `split(';')` cut trigger bodies in half. 5 unit tests for the splitter.
- Watch startup warn when `CQS_SPLADE_MODEL` is set: tells the user watch doesn't refresh SPLADE for new chunks and to run `cqs index` for full coverage.

## Test plan

- [x] `test_migrate_v19_to_v20_adds_trigger_that_bumps_on_chunks_delete` — full migration path + trigger cardinality (1 delete = +1, 2 deletes = +2, INSERT = no change)
- [x] 5 SQL splitter unit tests
- [x] Full `cargo test --features gpu-index` all green (1351+ pass)
- [x] Integration tests: `test_store_init` + `test_open_readonly_on_initialized_store` updated for v20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
