### PR TITLE
fix: audit P3/P4 cleanup — docs + router + dim + security + resource (13 findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **SPLADE index persistence** — on-disk `splade.index.bin` with blake3 integrity, generation-counter invalidation, and lazy rebuild. Warm SPLADE query: 45s → 9.7s (#895).
+- **v19 migration** — `sparse_vectors` gains FK `ON DELETE CASCADE` to `chunks`. Orphan sparse rows from chunk deletion are structurally impossible (#898).
+- **v20 migration** — `AFTER DELETE` trigger on `chunks` auto-bumps `splade_generation`, closing the watch-mode SPLADE drift (#899).
+- `CQS_SKIP_INTEGRITY_CHECK` env var — opt-out from `PRAGMA quick_check` on write opens.
+- `CQS_SPLADE_MAX_INDEX_BYTES` env var — cap on persisted SPLADE index file size (default 2 GB).
+- `CQS_EVAL_TIMEOUT_SECS` env var — per-query timeout for the eval harness (default 300s).
+
+### Fixed
+- **86s → 6.9s per search query** — `PRAGMA integrity_check(1)` on every `Store::open` was walking the full 1.1 GB database. Read-only opens now skip the check entirely; write opens use `quick_check` (#893).
+- **Eval harness query-as-subcommand** — single-token queries like `prepare_for_embedding` were parsed as unknown subcommands. Fixed with `cqs --json -n 20 -- <query>` form (#894).
+- **OpenRCT2 dual-trail spec revision** — removed time estimates, off-ramps, and substrate grading per session feedback (#896).
+
+### Performance
+- SPLADE persistence: 45s cold → 9.7s warm per SPLADE query (on-disk load instead of rebuild from SQLite) (#895).
+- Sparse DELETE batch size: `chunks(333)` → derived from SQLite variable limit (SHL-31 fix in #898).
+- SPLADE body `Vec::new()` → `Vec::with_capacity(body_len)` from file metadata (PF-4 fix in #898).
+
 ## [1.22.0] - 2026-04-09
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,10 +158,12 @@ src/
     queries/    - Tree-sitter queries (.scm files, loaded via include_str!())
       <lang>.chunks.scm, <lang>.calls.scm, <lang>.types.scm
   test_helpers.rs - Shared test fixtures module
-  store/        - SQLite storage layer (Schema v16, WAL mode)
-    mod.rs      - Store struct, open/init, FTS5
+  store/        - SQLite storage layer (Schema v20, WAL mode)
+    mod.rs      - Store struct, open/init, FTS5, split_sql_statements (BEGIN/END-aware)
     metadata.rs - Chunk metadata queries, file-level operations
     search.rs   - RRF fusion, search_filtered, search_unified_with_index
+    sparse.rs   - Sparse vector CRUD (SPLADE), upsert_sparse_vectors, prune_orphan,
+                  bump_splade_generation_tx, splade_generation()
     chunks/     - Chunk storage and retrieval
       mod.rs, crud.rs, staleness.rs, embeddings.rs, query.rs, async_helpers.rs
     notes.rs    - Note CRUD, note_embeddings(), brute-force search
@@ -170,7 +172,7 @@ src/
     types.rs    - Type edge storage and queries
     helpers/    - Types, embedding conversion, scoring, SQL utilities
       mod.rs, embeddings.rs, error.rs, rows.rs, scoring.rs, search_filter.rs, sql.rs, types.rs
-    migrations.rs - Schema migration framework
+    migrations.rs - Schema migration framework (v10-v20, including v19 FK cascade + v20 trigger)
   parser/       - Code parsing (tree-sitter + custom parsers, delegates to language/ registry)
     mod.rs      - Parser struct, parse_file(), parse_file_all(), supported_extensions()
     types.rs    - Chunk (incl. parent_type_name), CallSite, FunctionCalls, TypeRef, ParserError
@@ -191,7 +193,12 @@ src/
     scoring/    - ScoringConfig, score normalization, RRF fusion constants
       mod.rs, candidate.rs, config.rs, filter.rs, name_match.rs, note_boost.rs
     query.rs    - Query parsing, filter extraction
+    router.rs   - Query classifier (QueryCategory + SearchStrategy), adaptive routing for
+                  identifier/structural/behavioral/conceptual/multi_step/negation/type_filtered/cross_language
     synonyms.rs - Query synonym expansion
+  splade/       - SPLADE sparse encoder + persisted inverted index
+    mod.rs      - SpladeEncoder, SparseVector type, encode()/encode_batch(), resolve_splade_model_dir()
+    index.rs    - SpladeIndex with persist/load (splade.index.bin + metadata.splade_generation)
   math.rs       - Vector math utilities (cosine similarity, SIMD)
   hnsw/         - HNSW index with batched build, atomic writes
     mod.rs      - HnswIndex, LoadedHnsw (self_cell), HnswError, VectorIndex impl

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -4,7 +4,7 @@
 
 cqs processes your code locally by default. With `--llm-summaries`, function code is sent to Anthropic's API for one-sentence summary generation. With `--improve-docs`, LLM-generated doc comments are written back to your source files. With `--hyde-queries`, function descriptions are sent to Anthropic's API for synthetic search query generation. See [Anthropic's privacy policy](https://www.anthropic.com/privacy). Without these flags, nothing is transmitted externally and no source files are modified.
 
-- **No telemetry by default**: Optional local-only command logging when `CQS_TELEMETRY=1` is set. Stored in `.cqs/telemetry.jsonl`, never transmitted
+- **No telemetry by default**: Optional local-only command logging when `CQS_TELEMETRY=1` is set OR when `.cqs/telemetry.jsonl` already exists (persists opt-in across shells/subprocesses). Stored in `.cqs/telemetry.jsonl`, never transmitted. Delete the file and unset the env var to opt out
 - **No analytics**: No tracking of any kind
 - **No cloud sync**: Index stays in your project directory
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cargo install cqs
 
 **Upgrading?** Schema changes require rebuilding the index:
 ```bash
-cqs index --force  # Run after upgrading from older versions (current schema: v16)
+cqs index --force  # Run after upgrading from older versions (current schema: v20)
 ```
 
 ## Quick Start
@@ -686,7 +686,7 @@ Best production config: **BGE-large** (`cqs index`). LLM summaries provide margi
 | `CQS_TELEMETRY` | `0` | Set to `1` to enable command usage telemetry |
 | `CQS_TEST_MAP_MAX_NODES` | `10000` | Max BFS nodes in test-map traversal |
 | `CQS_TRACE_MAX_NODES` | `10000` | Max nodes in call chain trace |
-| `CQS_WATCH_MAX_PENDING` | `1000` | Max pending file changes before watch forces flush |
+| `CQS_WATCH_MAX_PENDING` | `10000` | Max pending file changes before watch forces flush |
 | `CQS_WATCH_REBUILD_THRESHOLD` | `100` | Files changed before watch triggers full HNSW rebuild |
 
 ## RAG Efficiency

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ cqs is a **local code search tool** for developers. It runs on your machine, ind
 
 1. **Path traversal**: Commands cannot read files outside project root
 2. **FTS injection**: Search queries sanitized before SQLite FTS5 MATCH operations
-3. **Database corruption**: `PRAGMA integrity_check(1)` on every database open
+3. **Database corruption**: `PRAGMA quick_check(1)` on write-mode opens (opt-out via `CQS_SKIP_INTEGRITY_CHECK=1`). Read-only opens skip the check entirely — reads cannot introduce corruption and the index is rebuildable via `cqs index --force`
 4. **Reference config trust**: Warnings logged when reference configs override project settings
 
 ### What We Don't Protect Against
@@ -68,7 +68,9 @@ No other network requests are made. Without `--llm-summaries` or `export-model`,
 |------|---------|------|
 | Project source files | Parsing and embedding | `cqs index`, `cqs watch` |
 | `.cqs/index.db` | SQLite database | All operations |
-| `.cqs/index.hnsw.*` | Vector index files | Search operations |
+| `.cqs/index.hnsw.*` | HNSW vector index files | Search operations |
+| `.cqs/index_base.hnsw.*` | Base (non-enriched) HNSW index | Search operations (Phase 5 dual routing) |
+| `.cqs/splade.index.bin` | SPLADE sparse inverted index | Search operations (`--splade` or routed cross-language) |
 | `docs/notes.toml` | Developer notes | Search, `cqs read` |
 | `~/.cache/huggingface/` | ML model cache | Embedding operations |
 | `~/.config/cqs/` | Config file (user-level defaults) | All operations |
@@ -81,7 +83,9 @@ No other network requests are made. Without `--llm-summaries` or `export-model`,
 |------|---------|------|
 | `.cqs/` directory | Index storage | `cqs init` |
 | `.cqs/index.db` | SQLite database | `cqs index`, note operations |
-| `.cqs/index.hnsw.*` | Vector index + checksums | `cqs index` |
+| `.cqs/index.hnsw.*` | HNSW vector index + checksums | `cqs index` |
+| `.cqs/index_base.hnsw.*` | Base HNSW index + checksums | `cqs index` |
+| `.cqs/splade.index.bin` | SPLADE sparse inverted index | `cqs index` (with `CQS_SPLADE_MODEL` set), lazy rebuild on first `--splade` query |
 | `.cqs/index.lock` | Process lock file | `cqs watch` |
 | `.cqs/audit-mode.json` | Audit mode state (on/off, expiry) | `cqs audit-mode on`, `cqs audit-mode off` |
 | `.cqs/telemetry*.jsonl` | Command usage logs (opt-in, persists via file presence) | `CQS_TELEMETRY=1` or file exists, delete to opt out |

--- a/src/cli/commands/io/blame.rs
+++ b/src/cli/commands/io/blame.rs
@@ -88,6 +88,21 @@ fn run_git_log_line_range(
         );
     }
 
+    // v1.22.0 audit SEC-NEW-3: reject absolute paths and `..` components.
+    // Store-indexed chunks always have project-relative file paths, but this
+    // is defense-in-depth for any future path where the store gets content
+    // from an untrusted source (reference-index merge, imported chunks).
+    let p = std::path::Path::new(rel_file);
+    if p.is_absolute()
+        || p.components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        anyhow::bail!(
+            "Invalid file path '{}': must be project-relative (no absolute paths or '..')",
+            rel_file
+        );
+    }
+
     // Ensure valid line range (start <= end); swap if inverted
     let (start, end) = if start > end {
         tracing::warn!(start, end, "Inverted line range, swapping");

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -339,20 +339,36 @@ impl Embedder {
                             fp
                         }
                         _ => {
-                            // Hash the ONNX file
-                            match std::fs::read(model_path) {
-                                Ok(bytes) => {
-                                    let hash = blake3::hash(&bytes).to_hex().to_string();
-                                    tracing::info!(
-                                        hash = &hash[..16],
-                                        "Model fingerprint computed"
-                                    );
-                                    hash
+                            // v1.22.0 audit RM-1: previously `std::fs::read`
+                            // loaded the entire ONNX into heap (~1.3 GB for
+                            // BGE-large) just to hash it. Use streaming
+                            // `update_reader` (same pattern as HNSW checksum
+                            // at hnsw/persist.rs:298-306) — constant memory.
+                            match std::fs::File::open(model_path) {
+                                Ok(file) => {
+                                    let mut hasher = blake3::Hasher::new();
+                                    match hasher.update_reader(file) {
+                                        Ok(_) => {
+                                            let hash =
+                                                hasher.finalize().to_hex().to_string();
+                                            tracing::info!(
+                                                hash = &hash[..16],
+                                                "Model fingerprint computed (streaming)"
+                                            );
+                                            hash
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!(error = %e, "Failed to stream-hash model, using repo+timestamp fallback");
+                                            let ts = std::time::SystemTime::now()
+                                                .duration_since(std::time::UNIX_EPOCH)
+                                                .unwrap_or_default()
+                                                .as_secs();
+                                            format!("{}:{}", self.model_config.repo, ts)
+                                        }
+                                    }
                                 }
                                 Err(e) => {
-                                    tracing::warn!(error = %e, "Failed to read model for fingerprint, using repo+timestamp fallback");
-                                    // DS-45: append timestamp to prevent cache key collisions
-                                    // between different model files with the same repo name
+                                    tracing::warn!(error = %e, "Failed to open model for fingerprint, using repo+timestamp fallback");
                                     let ts = std::time::SystemTime::now()
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .unwrap_or_default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,9 +236,17 @@ pub const EMBEDDING_DIM: usize = embedder::DEFAULT_DIM;
 /// detection (`TEST_NAME_PATTERNS`, `TEST_CONTENT_MARKERS`, `TEST_PATH_PATTERNS`)
 /// that also checks content markers like `#[test]` and `@Test`.
 pub fn is_test_chunk(name: &str, file: &str) -> bool {
-    // Name-based patterns (language-agnostic)
+    // Name-based patterns (language-agnostic).
+    //
+    // v1.22.0 audit AC-4: previously `name.starts_with("Test")` demoted
+    // production types like TestRegistry, TestHarness, TestContext by 30%.
+    // Tightened to require `Test` followed by underscore or end-of-name
+    // (catches `test_foo`, `Test_bar`, but not `TestHarness`). The xUnit
+    // `TestFoo` naming convention would still be caught but Go's and
+    // Rust's `test_` prefix is the dominant pattern in practice.
     let name_match = name.starts_with("test_")
-        || name.starts_with("Test")
+        || name.starts_with("Test_")
+        || name == "Test"
         || name.starts_with("spec_")
         || name.ends_with("_test")
         || name.ends_with("_spec")
@@ -467,11 +475,19 @@ mod tests {
     fn test_is_test_chunk_name_patterns() {
         // Positive: name-based
         assert!(is_test_chunk("test_foo", "src/lib.rs"));
-        assert!(is_test_chunk("TestSuite", "src/lib.rs"));
+        assert!(is_test_chunk("Test_suite", "src/lib.rs"));
+        assert!(is_test_chunk("Test", "src/lib.rs")); // bare "Test" name
         assert!(is_test_chunk("foo_test", "src/lib.rs"));
         assert!(is_test_chunk("foo_test_bar", "src/lib.rs"));
         assert!(is_test_chunk("foo.test", "src/lib.rs"));
         // Negative: name-based
+        // v1.22.0 audit AC-4: "TestSuite", "TestHarness", "TestRegistry" etc.
+        // are NOT tests — they're test-framework API types that should not be
+        // demoted 30% in search results. Only `test_` and `Test_` prefixes
+        // (with underscore) are treated as test chunks by name.
+        assert!(!is_test_chunk("TestSuite", "src/lib.rs"));
+        assert!(!is_test_chunk("TestHarness", "src/lib.rs"));
+        assert!(!is_test_chunk("TestRegistry", "src/lib.rs"));
         assert!(!is_test_chunk("search_filtered", "src/lib.rs"));
         assert!(!is_test_chunk("testing_util", "src/lib.rs"));
     }

--- a/src/project.rs
+++ b/src/project.rs
@@ -319,7 +319,7 @@ fn search_single_project(
 
     let store = crate::Store::open_readonly(&index_path)?;
     let cqs_dir = index_path.parent().unwrap_or(entry.path.as_path());
-    let index = crate::hnsw::HnswIndex::try_load_with_ef(cqs_dir, None, None);
+    let index = crate::hnsw::HnswIndex::try_load_with_ef(cqs_dir, None, Some(store.dim()));
     let filter = crate::store::helpers::SearchFilter {
         query_text: query_text.to_string(),
         enable_rrf: false, // RRF off by default — pure cosine is faster + higher R@1 on expanded eval

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -103,7 +103,11 @@ fn load_single_reference(cfg: &ReferenceConfig) -> Option<ReferenceIndex> {
         }
     };
 
-    let index = HnswIndex::try_load_with_ef(&cfg.path, None, None);
+    // v1.22.0 audit CQ-5: previously passed `dim=None` which defaulted to
+    // `EMBEDDING_DIM` (1024 for BGE-large). A reference built with a 768-dim
+    // model (E5-base or v9-200k) would load as 1024-dim garbage. Pass the
+    // store's actual dim so the HNSW loader trusts the right byte layout.
+    let index = HnswIndex::try_load_with_ef(&cfg.path, None, Some(store.dim()));
 
     Some(ReferenceIndex {
         name: cfg.name.clone(),

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -493,8 +493,16 @@ mod tests {
             classify_role(0.3, "test_helper", "src/lib.rs", 0.5),
             ChunkRole::TestToUpdate
         );
+        // v1.22.0 audit AC-4: `TestSuite` in non-test paths is a production
+        // type, not a test. After the `is_test_chunk` fix, this correctly
+        // classifies as a modification target, not a test to update.
         assert_eq!(
             classify_role(0.8, "TestSuite", "src/lib.rs", 0.5),
+            ChunkRole::ModifyTarget
+        );
+        // But `TestSuite` in an actual test path IS a test:
+        assert_eq!(
+            classify_role(0.8, "TestSuite", "tests/lib.rs", 0.5),
             ChunkRole::TestToUpdate
         );
         // File-based test detection

--- a/src/search/router.rs
+++ b/src/search/router.rs
@@ -189,18 +189,23 @@ const CONCEPTUAL_NOUNS: &[&str] = &[
     "methodology",
 ];
 
-/// Negation words (must include trailing space to avoid matching prefixes)
-const NEGATION_WORDS: &[&str] = &[
-    "not ",
-    "without ",
-    "except ",
-    "never ",
-    "avoid ",
-    "no ",
-    "don't ",
-    "doesn't ",
-    "shouldn't ",
-    "exclude ",
+/// Negation tokens matched against word-split query tokens (not substrings).
+///
+/// v1.22.0 audit AC-2: the previous pattern used trailing-space substring
+/// matching (`query.contains("not ")`) which false-fired on words like
+/// `cannot`, `piano`, `nano`, `volcano`, `casino`. Switched to exact
+/// word-token matching against the `words` vec already computed upstream.
+const NEGATION_TOKENS: &[&str] = &[
+    "not",
+    "without",
+    "except",
+    "never",
+    "avoid",
+    "no",
+    "don't",
+    "doesn't",
+    "shouldn't",
+    "exclude",
 ];
 
 /// Structural keywords from programming languages
@@ -285,7 +290,7 @@ pub fn classify_query(query: &str) -> Classification {
     // 1. Negation trumps everything — "sort without allocating".
     //    Phase 5: enriched summaries inject positive vocabulary ("allocates",
     //    "uses heap") that fights the negation, so route to the base index.
-    if NEGATION_WORDS.iter().any(|w| query_lower.contains(w)) {
+    if words.iter().any(|w| NEGATION_TOKENS.contains(w)) {
         return Classification {
             category: QueryCategory::Negation,
             confidence: Confidence::High,

--- a/src/search/scoring/candidate.rs
+++ b/src/search/scoring/candidate.rs
@@ -457,9 +457,17 @@ mod tests {
 
     #[test]
     fn test_chunk_importance_test_upper() {
-        // Go convention: TestFoo
+        // v1.22.0 audit AC-4: `TestParseConfig` in `src/lib.go` is NOT a Go
+        // test — Go tests live in `_test.go` files, not regular `.go` files.
+        // The previous assertion (importance_test = 0.70) was wrong: it
+        // demoted production helpers named `TestFoo` in non-test Go files.
+        // After the fix, `TestParseConfig` in `src/lib.go` gets normal
+        // importance (1.0), but `TestParseConfig` in `src/lib_test.go`
+        // gets the test demotion via path-based detection.
+        assert_eq!(chunk_importance("TestParseConfig", "src/lib.go"), 1.0);
+        // In an actual _test.go file, the path pattern catches it.
         assert_eq!(
-            chunk_importance("TestParseConfig", "src/lib.go"),
+            chunk_importance("TestParseConfig", "src/lib_test.go"),
             ScoringConfig::DEFAULT.importance_test
         );
     }


### PR DESCRIPTION
Batch of easy P1/P3/P4 fixes from the v1.22.0 audit. 13 files, 142 insertions, 41 deletions. See commit message for full breakdown. Addresses: Doc-1/2/3/4/6/7/8/9/11, AC-2, AC-4, CQ-5, SEC-NEW-3, RM-1. 1341/0 tests pass, clippy/fmt clean.