### PR TITLE
fix: wire rrf_k config + delete dead --semantic-only (CQ-1, API-10)

### DIFF
--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -178,10 +178,6 @@ pub struct Cli {
     #[arg(long)]
     pub name_only: bool,
 
-    /// Pure semantic similarity, disable RRF hybrid search (deprecated — RRF now off by default)
-    #[arg(long)]
-    pub semantic_only: bool,
-
     /// Enable RRF hybrid search (keyword + semantic fusion). Off by default — pure cosine is faster and scores higher on expanded eval.
     #[arg(long)]
     pub rrf: bool,

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -31,6 +31,14 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
     let config = cqs::config::Config::load(&find_project_root());
     apply_config_defaults(&mut cli, &config);
 
+    // v1.22.0 audit CQ-1: wire the [scoring] config section to the
+    // RRF K override. Previously `set_rrf_k_from_config` existed but
+    // nothing called it — a user writing `[scoring] rrf_k = 40` in
+    // `.cqs.toml` had their value silently ignored.
+    if let Some(ref scoring) = config.scoring {
+        cqs::store::set_rrf_k_from_config(scoring);
+    }
+
     // Resolve embedding model config once (CLI > env > config > default),
     // then apply env var overrides (CQS_MAX_SEQ_LENGTH, CQS_EMBEDDING_DIM)
     cli.resolved_model = Some(


### PR DESCRIPTION
Two P1 flag fixes from the v1.22.0 audit. set_rrf_k_from_config was dead (config value silently ignored); --semantic-only had zero readers. 1345/0 pass.