### PR TITLE
perf: derive all SQL batch sizes from modern SQLite limit — 15 sites (SHL-32/33)

### DIFF
--- a/src/store/calls/crud.rs
+++ b/src/store/calls/crud.rs
@@ -27,9 +27,9 @@ impl Store {
                 .execute(&mut *tx)
                 .await?;
 
-            // Batch insert calls (300 rows * 3 binds = 900 < SQLite's 999 limit)
             if !calls.is_empty() {
-                const INSERT_BATCH: usize = 300;
+                use crate::store::helpers::sql::max_rows_per_statement;
+                const INSERT_BATCH: usize = max_rows_per_statement(3);
                 for batch in calls.chunks(INSERT_BATCH) {
                     let mut query_builder: sqlx::QueryBuilder<sqlx::Sqlite> =
                         sqlx::QueryBuilder::new(
@@ -77,8 +77,8 @@ impl Store {
                 }
             }
 
-            // Batch insert all calls (300 rows * 3 binds = 900 < SQLite's 999 limit)
-            const INSERT_BATCH: usize = 300;
+            use crate::store::helpers::sql::max_rows_per_statement;
+            const INSERT_BATCH: usize = max_rows_per_statement(3);
             for batch in calls.chunks(INSERT_BATCH) {
                 let mut query_builder: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
                     "INSERT INTO calls (caller_id, callee_name, line_number) ",
@@ -109,8 +109,8 @@ impl Store {
         self.rt.block_on(async {
             let mut found = std::collections::HashSet::new();
             let id_vec: Vec<&str> = ids.iter().copied().collect();
-            // 200 per batch keeps bind count well under SQLite's 999 limit
-            for batch in id_vec.chunks(200) {
+            use crate::store::helpers::sql::max_rows_per_statement;
+            for batch in id_vec.chunks(max_rows_per_statement(1)) {
                 let placeholders: String = (0..batch.len())
                     .map(|i| format!("?{}", i + 1))
                     .collect::<Vec<_>>()
@@ -210,8 +210,8 @@ impl Store {
                 .collect();
 
             if !all_calls.is_empty() {
-                // 190 rows * 5 binds = 950 < SQLite's 999 limit
-                const INSERT_BATCH: usize = 190;
+                use crate::store::helpers::sql::max_rows_per_statement;
+                const INSERT_BATCH: usize = max_rows_per_statement(5);
                 for batch in all_calls.chunks(INSERT_BATCH) {
                     let mut query_builder: sqlx::QueryBuilder<sqlx::Sqlite> =
                         sqlx::QueryBuilder::new(

--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -217,7 +217,13 @@ pub(super) async fn snapshot_content_hashes(
     Ok(old_hashes)
 }
 
-/// Batch INSERT chunks (49 rows × 20 params = 980 < SQLite's 999 limit).
+/// Batch INSERT chunks — derived from the modern SQLite variable limit.
+///
+/// v1.22.0 audit SHL-32: the previous `CHUNK_INSERT_BATCH = 49` (49 × 20
+/// params = 980) was sized for the pre-3.32 SQLite 999-variable limit. On
+/// a 12k-chunk reindex this produced ~245 INSERT statements. The modern
+/// limit (32766) permits ~1622 rows per statement, reducing to ~8 INSERTs
+/// for the same corpus — a 30× reduction in SQL round-trips.
 ///
 /// Uses `ON CONFLICT(id) DO UPDATE` (upsert) instead of `INSERT OR REPLACE`
 /// to preserve `enrichment_hash` and `enrichment_version` columns that are
@@ -239,7 +245,8 @@ pub(super) async fn batch_insert_chunks(
     source_mtime: Option<i64>,
     now: &str,
 ) -> Result<(), StoreError> {
-    const CHUNK_INSERT_BATCH: usize = 49;
+    use crate::store::helpers::sql::max_rows_per_statement;
+    const CHUNK_INSERT_BATCH: usize = max_rows_per_statement(20);
     for (batch_idx, batch) in chunks.chunks(CHUNK_INSERT_BATCH).enumerate() {
         let emb_offset = batch_idx * CHUNK_INSERT_BATCH;
         let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
@@ -330,8 +337,9 @@ pub(super) async fn upsert_fts_conditional(
         return Ok(());
     }
 
+    use crate::store::helpers::sql::max_rows_per_statement;
     // Batch DELETE: remove old FTS entries for changed chunks (PF-8: reuse make_placeholders)
-    for batch in changed.chunks(500) {
+    for batch in changed.chunks(max_rows_per_statement(1)) {
         let placeholders = crate::store::helpers::make_placeholders(batch.len());
         let sql = format!("DELETE FROM chunks_fts WHERE id IN ({})", placeholders);
         let mut query = sqlx::query(&sql);
@@ -342,8 +350,7 @@ pub(super) async fn upsert_fts_conditional(
     }
 
     // Batch INSERT: add new FTS entries
-    for batch in changed.chunks(180) {
-        // 180 chunks × 5 bind params = 900, under SQLite 999 limit
+    for batch in changed.chunks(max_rows_per_statement(5)) {
         let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> =
             sqlx::QueryBuilder::new("INSERT INTO chunks_fts (id, name, signature, content, doc) ");
         qb.push_values(batch.iter(), |mut b, chunk| {

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -205,8 +205,8 @@ impl Store {
         }
         self.rt.block_on(async {
             let mut result = std::collections::HashMap::new();
-            // Process in batches to stay under SQLite parameter limit
-            for batch in chunk_ids.chunks(500) {
+            use crate::store::helpers::sql::max_rows_per_statement;
+            for batch in chunk_ids.chunks(max_rows_per_statement(1)) {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
                 let sql = format!(
                     "SELECT id, enrichment_hash FROM chunks WHERE id IN ({}) AND enrichment_hash IS NOT NULL",
@@ -263,8 +263,9 @@ impl Store {
         }
         self.rt.block_on(async {
             let mut result = std::collections::HashMap::new();
-            // Reserve one param slot for purpose, so 499 per batch
-            for batch in content_hashes.chunks(499) {
+            use crate::store::helpers::sql::max_rows_per_statement;
+            // Reserve one param for the purpose bind, so (limit - 1) per batch
+            for batch in content_hashes.chunks(max_rows_per_statement(1) - 1) {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
                 let sql = format!(
                     "SELECT content_hash, summary FROM llm_summaries WHERE content_hash IN ({}) AND purpose = ?{}",
@@ -300,7 +301,8 @@ impl Store {
         let now = chrono::Utc::now().to_rfc3339();
         self.rt.block_on(async {
             let (_guard, mut tx) = self.begin_write().await?;
-            const BATCH_SIZE: usize = 132; // 132 * 5 params = 660 < 999
+            use crate::store::helpers::sql::max_rows_per_statement;
+            const BATCH_SIZE: usize = max_rows_per_statement(5);
             for batch in summaries.chunks(BATCH_SIZE) {
                 let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
                     "INSERT OR REPLACE INTO llm_summaries (content_hash, summary, model, purpose, created_at)",
@@ -481,7 +483,9 @@ impl Store {
                         })
                         .collect()
                 };
-                for batch in unique_ids.chunks(500) {
+                for batch in
+                    unique_ids.chunks(crate::store::helpers::sql::max_rows_per_statement(1))
+                {
                     let placeholders: String = batch
                         .iter()
                         .enumerate()
@@ -548,8 +552,7 @@ impl Store {
                 .execute(&mut *tx)
                 .await?;
 
-            // Batch inserts into temp table at 500 to stay under SQLite limits.
-            for batch in live_ids.chunks(500) {
+            for batch in live_ids.chunks(crate::store::helpers::sql::max_rows_per_statement(1)) {
                 let placeholders: Vec<String> =
                     batch.iter().enumerate().map(|(i, _)| format!("(?{})", i + 1)).collect();
                 let insert_sql = format!(

--- a/src/store/chunks/staleness.rs
+++ b/src/store/chunks/staleness.rs
@@ -398,8 +398,8 @@ impl Store {
         self.rt.block_on(async {
             let mut stale = HashSet::new();
 
-            // Batch in groups of 900 to stay under SQLite's 999-parameter limit
-            const BATCH_SIZE: usize = 900;
+            use crate::store::helpers::sql::max_rows_per_statement;
+            const BATCH_SIZE: usize = max_rows_per_statement(1);
             for batch in origins.chunks(BATCH_SIZE) {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
                 let sql = format!(

--- a/src/store/helpers/mod.rs
+++ b/src/store/helpers/mod.rs
@@ -14,7 +14,7 @@ mod error;
 mod rows;
 mod scoring;
 mod search_filter;
-mod sql;
+pub(crate) mod sql;
 mod types;
 
 // ============ Re-exports ============

--- a/src/store/helpers/sql.rs
+++ b/src/store/helpers/sql.rs
@@ -1,8 +1,39 @@
-//! SQL placeholder generation and caching.
+//! SQL placeholder generation, caching, and batch-size derivation.
+//!
+//! ## SQLite variable limit
+//!
+//! `SQLITE_MAX_VARIABLE_NUMBER` was 999 before v3.32 (2020) and is 32766
+//! in current SQLite. cqs requires SQLite 3.35+ (for RETURNING) so the
+//! limit is always 32766. The v1.22.0 audit (SHL-31/32/33) found 15 call
+//! sites still using the old 999-derived batch sizes, producing 10-30×
+//! more SQL statements than necessary. The [`max_rows_per_statement`]
+//! helper centralizes the derivation so call sites don't need to
+//! re-derive the constant.
+
+/// SQLite's `SQLITE_MAX_VARIABLE_NUMBER` since v3.32 (2020).
+/// Single source of truth — all batch-size derivations reference this.
+pub const SQLITE_MAX_VARIABLES: usize = 32766;
+
+/// Generic headroom so a future caller adding one more bind variable
+/// doesn't instantly trip the limit. NOT sized to absorb a full extra
+/// column; adding a new column requires updating `vars_per_row` at the
+/// call site (SHL-41 audit rationale correction).
+pub const SAFETY_MARGIN_VARS: usize = 300;
+
+/// Derive the maximum rows per INSERT/DELETE statement given the number
+/// of bind variables per row. Centralizes the `(LIMIT - MARGIN) / N`
+/// derivation that was previously inlined (and wrong) at 15+ sites.
+///
+/// For single-bind queries (e.g. `WHERE id IN (?, ?, ...)`), pass
+/// `vars_per_row = 1`. For multi-column INSERTs, pass the column count.
+pub const fn max_rows_per_statement(vars_per_row: usize) -> usize {
+    (SQLITE_MAX_VARIABLES - SAFETY_MARGIN_VARS) / vars_per_row
+}
 
 /// Maximum batch size that is pre-built and cached at startup.
-/// All observed batch sizes (55, 100, 190, 200, 250, 300, 500, 900) fall within this range.
-const PLACEHOLDER_CACHE_MAX: usize = 999;
+/// Bumped from 999 to match the modern SQLite limit so cached
+/// placeholder strings cover the full useful range.
+const PLACEHOLDER_CACHE_MAX: usize = 10_000;
 
 /// Pre-built placeholder strings for n = 1..=PLACEHOLDER_CACHE_MAX.
 /// Index 0 is unused; index n holds the string for n placeholders.

--- a/src/store/sparse.rs
+++ b/src/store/sparse.rs
@@ -111,7 +111,8 @@ impl Store {
             // finding SHL-31: PR #891 fixed the sibling INSERT loop but left
             // the DELETE on the old constant, paying ~30x the statement
             // count. One bind variable per chunk_id, minus the safety margin.
-            const DELETE_BATCH: usize = SQLITE_MAX_VARIABLES - SAFETY_MARGIN_VARS;
+            use crate::store::helpers::sql::max_rows_per_statement;
+            const DELETE_BATCH: usize = max_rows_per_statement(1);
             let chunk_ids: Vec<&str> = vectors.iter().map(|(id, _)| id.as_str()).collect();
             for batch in chunk_ids.chunks(DELETE_BATCH) {
                 let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> =
@@ -147,9 +148,7 @@ impl Store {
             // Iterate across chunks AND rows together so each batch fills
             // close to capacity, instead of starting a fresh batch per chunk
             // and producing tiny INSERTs for chunks with few tokens.
-            const VARS_PER_ROW: usize = 3; // chunk_id, token_id, weight
-            const ROWS_PER_INSERT: usize =
-                (SQLITE_MAX_VARIABLES - SAFETY_MARGIN_VARS) / VARS_PER_ROW;
+            const ROWS_PER_INSERT: usize = max_rows_per_statement(3);
             let mut pending: Vec<(&str, u32, f32)> = Vec::with_capacity(ROWS_PER_INSERT);
             for (chunk_id, sparse) in vectors {
                 for &(token_id, weight) in sparse {
@@ -358,17 +357,6 @@ impl Store {
         })
     }
 }
-
-/// SQLite's `SQLITE_MAX_VARIABLE_NUMBER` since v3.32 (2020). The audit chain
-/// SHL-31/32/33 found 15 call sites still using the pre-3.32 999 assumption;
-/// this constant is the single source of truth we migrate them towards.
-const SQLITE_MAX_VARIABLES: usize = 32766;
-
-/// Generic headroom so one extra bind variable in a future caller doesn't
-/// instantly trip the SQLite limit. Does NOT absorb a full extra column;
-/// adding a new bind column requires increasing `VARS_PER_ROW` at the call
-/// site (SHL-41 audit rationale correction).
-const SAFETY_MARGIN_VARS: usize = 300;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Centralized max_rows_per_statement helper replaces 15 pre-3.32 hardcoded batch sizes. Chunk INSERT: 49→1622 rows/statement (30x fewer SQL round-trips on 12k-chunk reindex). 1351/0 pass.