### PR TITLE
fix: remove misleading --format from TextJsonArgs — 25+ commands silently ignored it (API-1)

### DIFF
--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -17,20 +17,6 @@ pub enum OutputFormat {
 }
 
 /// Parse an `OutputFormat` that only allows text or json (rejects mermaid at parse time).
-///
-/// Used by `review` and `ci` commands which accept `--format` but don't support mermaid output.
-/// Catches the error at argument parsing rather than failing at runtime.
-fn parse_text_or_json_format(s: &str) -> std::result::Result<OutputFormat, String> {
-    match s.to_ascii_lowercase().as_str() {
-        "text" => Ok(OutputFormat::Text),
-        "json" => Ok(OutputFormat::Json),
-        "mermaid" => {
-            Err("mermaid output is not supported for this command — use text or json".into())
-        }
-        other => Err(format!("invalid format '{other}' — expected text or json")),
-    }
-}
-
 impl std::fmt::Display for OutputFormat {
     /// Formats the enum variant as a human-readable string representation.
     ///
@@ -72,24 +58,25 @@ impl OutputArgs {
     }
 }
 
-/// AD-49: Output format arguments for commands that only support text/json (no mermaid).
+/// AD-49 + v1.22.0 audit API-1: Output format for commands that only support
+/// text or JSON. Previously exposed `--format text|json` alongside `--json`,
+/// but 25+ command handlers read `output.json` directly and never checked
+/// `output.format`, so `--format json` was silently accepted and ignored.
+/// Removed `--format`; commands that genuinely support multiple output formats
+/// (e.g. `--format mermaid`) use [`OutputArgs`] instead.
 #[derive(Clone, Debug, clap::Args)]
 pub struct TextJsonArgs {
-    /// Output format: text, json (use --json as shorthand for --format json; mermaid not supported)
-    #[arg(long, default_value = "text", value_parser = parse_text_or_json_format)]
-    pub format: OutputFormat,
-    /// Shorthand for --format json
-    #[arg(long, conflicts_with = "format")]
+    /// Output as JSON
+    #[arg(long)]
     pub json: bool,
 }
 
 impl TextJsonArgs {
-    /// Resolve the effective format (--json overrides --format).
     pub fn effective_format(&self) -> OutputFormat {
         if self.json {
             OutputFormat::Json
         } else {
-            self.format.clone()
+            OutputFormat::Text
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -687,7 +687,6 @@ mod tests {
             }) => {
                 assert!(base.is_none());
                 assert!(!stdin);
-                assert!(matches!(output.format, OutputFormat::Text));
                 assert!(!output.json);
                 assert!(tokens.is_none());
             }
@@ -707,14 +706,15 @@ mod tests {
     }
 
     #[test]
-    fn test_cmd_review_stdin_format_json() {
-        let cli = Cli::try_parse_from(["cqs", "review", "--stdin", "--format", "json"]).unwrap();
+    fn test_cmd_review_stdin_json() {
+        // v1.22.0 audit API-1: --format removed from TextJsonArgs, use --json
+        let cli = Cli::try_parse_from(["cqs", "review", "--stdin", "--json"]).unwrap();
         match cli.command {
             Some(Commands::Review {
                 stdin, ref output, ..
             }) => {
                 assert!(stdin);
-                assert!(matches!(output.format, OutputFormat::Json));
+                assert!(output.json);
             }
             _ => panic!("Expected Review command"),
         }
@@ -784,7 +784,6 @@ mod tests {
         match cli.command {
             Some(Commands::Review { ref output, .. }) => {
                 assert!(output.json);
-                assert!(matches!(output.format, OutputFormat::Text));
             }
             _ => panic!("Expected Review command"),
         }
@@ -802,16 +801,9 @@ mod tests {
         match cli.command {
             Some(Commands::Ci { ref output, .. }) => {
                 assert!(output.json);
-                assert!(matches!(output.format, OutputFormat::Text));
             }
             _ => panic!("Expected Ci command"),
         }
-    }
-
-    #[test]
-    fn test_ci_json_conflicts_with_format() {
-        let result = Cli::try_parse_from(["cqs", "ci", "--json", "--format", "json"]);
-        assert!(result.is_err(), "--json and --format should conflict");
     }
 
     #[test]
@@ -965,7 +957,6 @@ mod tests {
             }) => {
                 assert!(base.is_none());
                 assert!(!stdin);
-                assert!(matches!(output.format, OutputFormat::Text));
                 assert!(!output.json);
                 assert!(matches!(gate, GateThreshold::High));
                 assert!(tokens.is_none());
@@ -997,11 +988,10 @@ mod tests {
     }
 
     #[test]
-    fn test_cmd_ci_stdin_format_json_tokens() {
-        let cli = Cli::try_parse_from([
-            "cqs", "ci", "--stdin", "--format", "json", "--tokens", "5000",
-        ])
-        .unwrap();
+    fn test_cmd_ci_stdin_json_tokens() {
+        // v1.22.0 audit API-1: --format removed from TextJsonArgs, use --json
+        let cli =
+            Cli::try_parse_from(["cqs", "ci", "--stdin", "--json", "--tokens", "5000"]).unwrap();
         match cli.command {
             Some(Commands::Ci {
                 stdin,
@@ -1010,7 +1000,7 @@ mod tests {
                 ..
             }) => {
                 assert!(stdin);
-                assert!(matches!(output.format, OutputFormat::Json));
+                assert!(output.json);
                 assert_eq!(tokens, Some(5000));
             }
             _ => panic!("Expected Ci command"),


### PR DESCRIPTION
TextJsonArgs exposed --format text|json but 25+ handlers read output.json directly. --format json was silently accepted and ignored. Removed the field; only --json remains. Commands that genuinely support --format mermaid keep OutputArgs.