### PR TITLE
fix: corrupt embedding warn + staleness log + plan tokens warn (OB-19, EH-8, API-11)

### DIFF
--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -141,7 +141,18 @@ impl BatchContext {
         let index_path = self.cqs_dir.join("index.db");
         let current_mtime = match std::fs::metadata(&index_path).and_then(|m| m.modified()) {
             Ok(t) => t,
-            Err(_) => return, // Can't stat — skip check
+            Err(e) => {
+                // v1.22.0 audit EH-8: previously silent return. If the DB
+                // becomes temporarily unstattable (permissions, concurrent
+                // rebuild, NFS glitch), every subsequent command in the batch
+                // session keeps using stale caches forever.
+                tracing::warn!(
+                    error = %e,
+                    path = %index_path.display(),
+                    "Cannot stat index.db for staleness check — caches may remain stale"
+                );
+                return;
+            }
         };
 
         let last = self.index_mtime.get();

--- a/src/cli/commands/train/plan.rs
+++ b/src/cli/commands/train/plan.rs
@@ -37,8 +37,16 @@ pub(crate) fn cmd_plan(
 fn display_plan_text(
     result: &cqs::plan::PlanResult,
     root: &std::path::Path,
-    _tokens: Option<usize>,
+    tokens: Option<usize>,
 ) {
+    // v1.22.0 audit API-11: --tokens was accepted and silently ignored in
+    // text mode. Warn so the user knows their budget isn't being applied.
+    if tokens.is_some() {
+        tracing::warn!(
+            tokens,
+            "--tokens is not yet applied in text mode (only JSON). Output may exceed budget."
+        );
+    }
     use colored::Colorize;
 
     println!("{}", format!("Plan: {}", result.template).bold());

--- a/src/store/chunks/embeddings.rs
+++ b/src/store/chunks/embeddings.rs
@@ -49,7 +49,7 @@ impl Store {
                             result.insert(hash, Embedding::new(embedding));
                         }
                         Err(e) => {
-                            tracing::trace!(hash = %hash, error = %e, "Skipping embedding");
+                            tracing::warn!(hash = %hash, error = %e, "Corrupt embedding blob, skipping — run 'cqs index --force' to rebuild");
                         }
                     }
                 }

--- a/src/store/chunks/query.rs
+++ b/src/store/chunks/query.rs
@@ -344,7 +344,7 @@ impl Store {
                             result.insert(id, Embedding::new(emb));
                         }
                         Err(e) => {
-                            tracing::trace!(chunk_id = %id, error = %e, "Skipping embedding");
+                            tracing::warn!(chunk_id = %id, error = %e, "Corrupt embedding blob, skipping — run 'cqs index --force' to rebuild");
                         }
                     }
                 }


### PR DESCRIPTION
Three small audit fixes: trace→warn on corrupt embeddings, staleness check silent-return logged, --tokens in text mode warns. 1351/0 pass.