### PR TITLE
fix: preserve SPLADE fusion scores through scoring pipeline (AC-1)

### DIFF
--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -20,8 +20,9 @@ use crate::store::sanitize_fts_query;
 use crate::store::{NoteSummary, Store, StoreError};
 
 use super::scoring::{
-    apply_parent_boost, build_filter_sql, compile_glob_filter, extract_file_from_chunk_id,
-    score_candidate, BoundedScoreHeap, NameMatcher, NoteBoostIndex, ScoringContext,
+    apply_parent_boost, apply_scoring_pipeline, build_filter_sql, compile_glob_filter,
+    extract_file_from_chunk_id, score_candidate, BoundedScoreHeap, NameMatcher, NoteBoostIndex,
+    ScoringContext,
 };
 use super::synonyms::expand_query_for_fts;
 
@@ -528,6 +529,8 @@ impl Store {
 
         tracing::debug!(fused = fused.len(), alpha, "Hybrid fusion complete");
 
+        let fused_map: std::collections::HashMap<String, f32> =
+            fused.iter().map(|r| (r.id.clone(), r.score)).collect();
         let candidate_ids: Vec<&str> = fused.iter().map(|r| r.id.as_str()).collect();
         self.search_by_candidate_ids_with_notes(
             &candidate_ids,
@@ -536,6 +539,7 @@ impl Store {
             limit,
             threshold,
             &notes,
+            Some(&fused_map),
         )
     }
 
@@ -600,6 +604,7 @@ impl Store {
                 limit,
                 threshold,
                 &notes,
+                None,
             );
         }
 
@@ -630,10 +635,17 @@ impl Store {
             limit,
             threshold,
             &notes,
+            None,
         )
     }
 
-    /// Inner implementation of `search_by_candidate_ids` that accepts pre-loaded notes.
+    /// Inner implementation of `search_by_candidate_ids` that accepts pre-loaded notes
+    /// and optional pre-fused scores from hybrid search.
+    ///
+    /// When `fused_scores` is `Some`, candidates with a fused score entry use that
+    /// score as the base (replacing cosine similarity) while still applying name
+    /// boost, note boost, demotion, and threshold filtering.
+    #[allow(clippy::too_many_arguments)]
     fn search_by_candidate_ids_with_notes(
         &self,
         candidate_ids: &[&str],
@@ -642,6 +654,7 @@ impl Store {
         limit: usize,
         threshold: f32,
         notes: &[NoteSummary],
+        fused_scores: Option<&std::collections::HashMap<String, f32>>,
     ) -> Result<Vec<SearchResult>, StoreError> {
         let _span = tracing::info_span!(
             "search_by_candidates",
@@ -717,14 +730,23 @@ impl Store {
                         }
                     }
 
-                    let embedding = embedding_slice(&embedding_bytes, self.dim).ok()?;
-
-                    let score = score_candidate(
-                        embedding,
-                        Some(&candidate.name),
-                        &candidate.origin,
-                        &scoring_ctx,
-                    )?;
+                    let score =
+                        if let Some(&fused) = fused_scores.and_then(|fs| fs.get(&candidate.id)) {
+                            apply_scoring_pipeline(
+                                fused,
+                                Some(&candidate.name),
+                                &candidate.origin,
+                                &scoring_ctx,
+                            )?
+                        } else {
+                            let embedding = embedding_slice(&embedding_bytes, self.dim).ok()?;
+                            score_candidate(
+                                embedding,
+                                Some(&candidate.name),
+                                &candidate.origin,
+                                &scoring_ctx,
+                            )?
+                        };
 
                     Some((candidate, score))
                 })

--- a/src/search/scoring/candidate.rs
+++ b/src/search/scoring/candidate.rs
@@ -216,20 +216,17 @@ pub(crate) struct ScoringContext<'a> {
     pub threshold: f32,
 }
 
-/// Score a single candidate chunk against the query.
+/// Apply the scoring pipeline to a pre-computed base score (name boost, glob
+/// filter, note boost, test demotion, threshold).
 ///
-/// Pure function — no database access. Combines embedding similarity, optional
-/// name boosting, glob filtering, note boosting, and test-function demotion.
-///
-/// Returns `None` if the candidate is filtered out (glob mismatch or below threshold).
-pub(crate) fn score_candidate(
-    embedding: &[f32],
+/// Used by `score_candidate` (base = cosine) and the hybrid search path
+/// (base = alpha-weighted dense+sparse fusion).
+pub(crate) fn apply_scoring_pipeline(
+    embedding_score: f32,
     name: Option<&str>,
     file_part: &str,
     ctx: &ScoringContext<'_>,
 ) -> Option<f32> {
-    let embedding_score = cosine_similarity(ctx.query, embedding)?;
-
     let base_score = if let Some(matcher) = ctx.name_matcher {
         let n = name.unwrap_or("");
         let name_score = matcher.score(n);
@@ -244,13 +241,9 @@ pub(crate) fn score_candidate(
         }
     }
 
-    // Apply note-based boost: notes mentioning this chunk's file or name
-    // adjust its score by up to ±15%. Clamp base_score to non-negative first —
-    // negative cosine scores invert multiplicative boost/demotion semantics.
     let chunk_name = name.unwrap_or("");
     let mut score = base_score.max(0.0) * ctx.note_index.boost(file_part, chunk_name);
 
-    // Apply demotion for test functions and underscore-prefixed names
     if ctx.filter.enable_demotion {
         score *= chunk_importance(chunk_name, file_part);
     }
@@ -260,6 +253,22 @@ pub(crate) fn score_candidate(
     } else {
         None
     }
+}
+
+/// Score a single candidate chunk against the query.
+///
+/// Pure function — no database access. Combines embedding similarity, optional
+/// name boosting, glob filtering, note boosting, and test-function demotion.
+///
+/// Returns `None` if the candidate is filtered out (glob mismatch or below threshold).
+pub(crate) fn score_candidate(
+    embedding: &[f32],
+    name: Option<&str>,
+    file_part: &str,
+    ctx: &ScoringContext<'_>,
+) -> Option<f32> {
+    let base = cosine_similarity(ctx.query, embedding)?;
+    apply_scoring_pipeline(base, name, file_part, ctx)
 }
 
 #[cfg(test)]
@@ -895,5 +904,91 @@ mod tests {
                 "score_candidate with zero query must return finite score, got {v}"
             ),
         }
+    }
+
+    #[test]
+    fn apply_scoring_pipeline_preserves_fused_score() {
+        let filter = SearchFilter::default();
+        let query = test_embedding(1.0);
+        let note_index = NoteBoostIndex::new(&[]);
+        let ctx = ScoringContext {
+            query: &query,
+            filter: &filter,
+            name_matcher: None,
+            glob_matcher: None,
+            note_index: &note_index,
+            threshold: 0.0,
+        };
+
+        let fused = 0.75;
+        let result = apply_scoring_pipeline(fused, Some("my_fn"), "src/lib.rs", &ctx);
+        assert_eq!(result, Some(0.75));
+    }
+
+    #[test]
+    fn apply_scoring_pipeline_applies_name_boost_to_fused() {
+        let mut filter = SearchFilter::default();
+        filter.name_boost = 0.3;
+        filter.query_text = "my_fn".to_string();
+        let query = test_embedding(1.0);
+        let note_index = NoteBoostIndex::new(&[]);
+        let matcher = NameMatcher::new("my_fn");
+        let ctx = ScoringContext {
+            query: &query,
+            filter: &filter,
+            name_matcher: Some(&matcher),
+            glob_matcher: None,
+            note_index: &note_index,
+            threshold: 0.0,
+        };
+
+        let fused = 0.6;
+        let result = apply_scoring_pipeline(fused, Some("my_fn"), "src/lib.rs", &ctx).unwrap();
+        assert!(
+            result > fused,
+            "name boost should increase fused score for exact match"
+        );
+    }
+
+    #[test]
+    fn apply_scoring_pipeline_applies_demotion_to_fused() {
+        let mut filter = SearchFilter::default();
+        filter.enable_demotion = true;
+        let query = test_embedding(1.0);
+        let note_index = NoteBoostIndex::new(&[]);
+        let ctx = ScoringContext {
+            query: &query,
+            filter: &filter,
+            name_matcher: None,
+            glob_matcher: None,
+            note_index: &note_index,
+            threshold: 0.0,
+        };
+
+        let fused = 0.8;
+        let prod = apply_scoring_pipeline(fused, Some("real_fn"), "src/lib.rs", &ctx).unwrap();
+        let test = apply_scoring_pipeline(fused, Some("test_foo"), "src/lib.rs", &ctx).unwrap();
+        assert!(
+            test < prod,
+            "test function should be demoted even with fused score"
+        );
+    }
+
+    #[test]
+    fn apply_scoring_pipeline_respects_threshold() {
+        let filter = SearchFilter::default();
+        let query = test_embedding(1.0);
+        let note_index = NoteBoostIndex::new(&[]);
+        let ctx = ScoringContext {
+            query: &query,
+            filter: &filter,
+            name_matcher: None,
+            glob_matcher: None,
+            note_index: &note_index,
+            threshold: 0.9,
+        };
+
+        let result = apply_scoring_pipeline(0.5, Some("fn"), "src/lib.rs", &ctx);
+        assert!(result.is_none());
     }
 }

--- a/src/search/scoring/mod.rs
+++ b/src/search/scoring/mod.rs
@@ -13,7 +13,9 @@ mod filter;
 mod name_match;
 mod note_boost;
 
-pub(crate) use candidate::{apply_parent_boost, score_candidate, BoundedScoreHeap, ScoringContext};
+pub(crate) use candidate::{
+    apply_parent_boost, apply_scoring_pipeline, score_candidate, BoundedScoreHeap, ScoringContext,
+};
 pub(crate) use filter::{build_filter_sql, compile_glob_filter, extract_file_from_chunk_id};
 pub(crate) use name_match::NameMatcher;
 pub(crate) use note_boost::NoteBoostIndex;


### PR DESCRIPTION
## Summary
- **AC-1 fix**: `search_hybrid` computed alpha-weighted fused scores (dense×α + sparse×(1-α)) then discarded them — passing only candidate IDs to `search_by_candidate_ids_with_notes`, which recomputed pure cosine from raw embeddings. The alpha knob was a no-op on final ranking.
- Extract `apply_scoring_pipeline()` from `score_candidate()` so the hybrid path can inject pre-fused scores as the base while name boost, note boost, test demotion, and threshold filtering still apply.
- 4 new unit tests for `apply_scoring_pipeline` (score preservation, name boost, demotion, threshold).
- No signature changes for existing callers — `search_by_candidate_ids` and `search_filtered_with_index` pass `None` for fused scores.

## Impact
Every SPLADE evaluation to date was measuring candidate-set expansion, not fusion quality. With this fix, the alpha knob actually controls the dense/sparse blending that reaches the user.

## Test plan
- [x] 35 candidate scoring unit tests pass (31 existing + 4 new)
- [x] 16 search query unit tests pass
- [x] 236 total search-related tests pass across all binaries
- [x] `cargo clippy --features gpu-index -- -D warnings` clean
- [ ] Re-run SPLADE eval to measure actual fusion quality (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
