### PR TITLE
feat: daemon mode — cqs watch --serve (3ms queries)

### DIFF
--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -225,6 +225,42 @@ impl BatchContext {
         Ok(())
     }
 
+    /// Dispatch a single command line (e.g. "search foo -n 5 --json") and
+    /// write the JSON result to `out`. Used by the daemon socket handler.
+    pub(crate) fn dispatch_line(&self, line: &str, out: &mut impl std::io::Write) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        let tokens = match shell_words::split(trimmed) {
+            Ok(t) => t,
+            Err(e) => {
+                let err = serde_json::json!({"error": format!("Parse error: {e}")});
+                let _ = write_json_line(out, &err);
+                return;
+            }
+        };
+        if tokens.is_empty() {
+            return;
+        }
+        self.check_idle_timeout();
+        match commands::BatchInput::try_parse_from(&tokens) {
+            Ok(input) => match commands::dispatch(self, input.cmd) {
+                Ok(value) => {
+                    let _ = write_json_line(out, &value);
+                }
+                Err(e) => {
+                    let err = serde_json::json!({"error": format!("{e}")});
+                    let _ = write_json_line(out, &err);
+                }
+            },
+            Err(e) => {
+                let err = serde_json::json!({"error": format!("{e}")});
+                let _ = write_json_line(out, &err);
+            }
+        }
+    }
+
     /// Borrow the Store, checking for index staleness first.
     pub fn store(&self) -> std::cell::Ref<'_, Store> {
         self.check_index_staleness();

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -299,6 +299,9 @@ pub(super) enum Commands {
         /// Use polling instead of inotify (reliable on WSL /mnt/ paths)
         #[arg(long)]
         poll: bool,
+        /// Also listen on a Unix socket for query requests (daemon mode)
+        #[arg(long)]
+        serve: bool,
     },
     /// What functions, callers, and tests are affected by current diff
     Affected {

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -52,6 +52,14 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
     // Clamp limit to prevent usize::MAX wrapping to -1 in SQLite queries
     cli.limit = cli.limit.clamp(1, 100);
 
+    // ── Daemon client: forward to running daemon if available ──────────────
+    if std::env::var("CQS_NO_DAEMON").as_deref() != Ok("1") {
+        if let Some(output) = try_daemon_query(&cqs_dir, &cli) {
+            print!("{}", output);
+            return Ok(());
+        }
+    }
+
     // ── Group A: no-store commands (early return before CommandContext) ──────
     match cli.command {
         Some(Commands::Init) => return cmd_init(&cli),
@@ -62,7 +70,8 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
             debounce,
             no_ignore,
             poll,
-        }) => return watch::cmd_watch(&cli, debounce, no_ignore, poll),
+            serve,
+        }) => return watch::cmd_watch(&cli, debounce, no_ignore, poll, serve),
         Some(Commands::Batch) => return batch::cmd_batch(),
         Some(Commands::Chat) => return chat::cmd_chat(),
         Some(Commands::Completions { shell }) => {
@@ -382,4 +391,86 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
 fn cmd_completions(shell: clap_complete::Shell) {
     use clap::CommandFactory;
     clap_complete::generate(shell, &mut Cli::command(), "cqs", &mut std::io::stdout());
+}
+
+/// Try to forward the current command to a running daemon.
+/// Returns `Some(output)` if the daemon handled it, `None` if no daemon or
+/// the command is not daemon-dispatchable (index, watch, gc, init, etc.).
+fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Option<String> {
+    // Only forward commands that the batch handler can dispatch
+    match &cli.command {
+        Some(Commands::Init)
+        | Some(Commands::Index { .. })
+        | Some(Commands::Watch { .. })
+        | Some(Commands::Batch)
+        | Some(Commands::Chat)
+        | Some(Commands::Completions { .. })
+        | Some(Commands::TrainData { .. })
+        | Some(Commands::TrainPairs { .. })
+        | Some(Commands::Cache { .. })
+        | Some(Commands::Doctor { .. })
+        | None => return None,
+        _ => {}
+    }
+
+    let sock_path = super::daemon_socket_path(cqs_dir);
+    if !sock_path.exists() {
+        return None;
+    }
+
+    use std::io::{BufRead, Write};
+    use std::os::unix::net::UnixStream;
+    use std::time::Duration;
+
+    let stream = match UnixStream::connect(&sock_path) {
+        Ok(s) => s,
+        Err(_) => {
+            tracing::debug!(path = %sock_path.display(), "Daemon socket exists but connect failed");
+            return None;
+        }
+    };
+
+    stream
+        .set_read_timeout(Some(Duration::from_secs(
+            std::env::var("CQS_DAEMON_TIMEOUT_MS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(|ms| ms / 1000)
+                .unwrap_or(30),
+        )))
+        .ok();
+    stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
+
+    // Build the batch-format command line from CLI args
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let request = serde_json::json!({
+        "command": args.first().map(|s| s.as_str()).unwrap_or(""),
+        "args": &args[1..],
+    });
+
+    let mut stream = stream;
+    if writeln!(stream, "{}", request).is_err() {
+        return None;
+    }
+    if stream.flush().is_err() {
+        return None;
+    }
+
+    let mut reader = std::io::BufReader::new(&stream);
+    let mut response_line = String::new();
+    if reader.read_line(&mut response_line).is_err() {
+        return None;
+    }
+
+    let resp: serde_json::Value = serde_json::from_str(response_line.trim()).ok()?;
+    if resp.get("status")?.as_str()? == "ok" {
+        Some(resp.get("output")?.as_str()?.to_string())
+    } else {
+        let msg = resp
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("daemon error");
+        tracing::warn!(error = msg, "Daemon returned error, falling back to CLI");
+        None
+    }
 }

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -7,6 +7,25 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 
+/// Derive the daemon socket path for a given cqs_dir.
+///
+/// Unix domain sockets don't work on WSL 9P mounts (/mnt/c/), so the socket
+/// is placed on the native Linux filesystem ($XDG_RUNTIME_DIR or /tmp).
+/// The filename is derived from a hash of cqs_dir to support multiple projects.
+pub(crate) fn daemon_socket_path(cqs_dir: &Path) -> PathBuf {
+    let sock_dir = std::env::var("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir());
+    let sock_name = format!("cqs-{:x}.sock", {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut h = DefaultHasher::new();
+        cqs_dir.hash(&mut h);
+        h.finish()
+    });
+    sock_dir.join(sock_name)
+}
+
 /// Enumerate files to index (delegates to library implementation)
 pub(crate) fn enumerate_files(
     root: &Path,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,7 +29,9 @@ pub use dispatch::run_with;
 // Re-export for watch.rs and commands
 pub(crate) use config::find_project_root;
 pub(crate) use enrichment::enrichment_pass;
-pub(crate) use files::{acquire_index_lock, enumerate_files, try_acquire_index_lock};
+pub(crate) use files::{
+    acquire_index_lock, daemon_socket_path, enumerate_files, try_acquire_index_lock,
+};
 pub(crate) use pipeline::run_index_pipeline;
 pub(crate) use signal::{check_interrupted, reset_interrupted};
 
@@ -170,9 +172,11 @@ mod tests {
                 debounce,
                 no_ignore,
                 poll,
+                serve,
             }) => {
                 assert_eq!(debounce, 500); // default
                 assert!(!no_ignore);
+                assert!(!serve);
                 assert!(!poll);
             }
             _ => panic!("Expected Watch command"),

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -17,6 +17,7 @@
 
 use std::cell::OnceCell;
 use std::collections::{HashMap, HashSet};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::{Duration, SystemTime};
@@ -33,6 +34,122 @@ use cqs::parser::{ChunkTypeRefs, Parser as CqParser};
 use cqs::store::Store;
 
 use super::{check_interrupted, find_project_root, try_acquire_index_lock, Cli};
+
+/// RAII guard that removes the Unix socket file on drop.
+struct SocketCleanupGuard(PathBuf);
+
+impl Drop for SocketCleanupGuard {
+    fn drop(&mut self) {
+        if self.0.exists() {
+            if let Err(e) = std::fs::remove_file(&self.0) {
+                tracing::warn!(path = %self.0.display(), error = %e, "Failed to remove socket file");
+            } else {
+                tracing::info!(path = %self.0.display(), "Daemon socket removed");
+            }
+        }
+    }
+}
+
+/// Handle a single client connection on the daemon socket.
+/// Reads one JSON-line request, dispatches via the shared BatchContext, writes response.
+fn handle_socket_client(
+    mut stream: std::os::unix::net::UnixStream,
+    batch_ctx: &super::batch::BatchContext,
+) {
+    let _span = tracing::info_span!("daemon_query").entered();
+    let start = std::time::Instant::now();
+
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+    stream.set_write_timeout(Some(Duration::from_secs(30))).ok();
+
+    // Read request (max 1MB)
+    let mut reader = std::io::BufReader::new(&stream);
+    let mut line = String::new();
+    match std::io::BufRead::read_line(&mut reader, &mut line) {
+        Ok(0) => return,
+        Ok(n) if n > 1_048_576 => {
+            let _ = write_daemon_error(&mut stream, "request too large");
+            return;
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "Socket read failed");
+            return;
+        }
+        Ok(_) => {}
+    }
+
+    let request: serde_json::Value = match serde_json::from_str(line.trim()) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = write_daemon_error(&mut stream, &format!("invalid JSON: {e}"));
+            return;
+        }
+    };
+
+    let command = request
+        .get("command")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let args: Vec<String> = request
+        .get("args")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    tracing::debug!(command, args = ?args, "Daemon request");
+
+    if command.is_empty() {
+        let _ = write_daemon_error(&mut stream, "missing 'command' field");
+        return;
+    }
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let full_line = if args.is_empty() {
+            command.to_string()
+        } else {
+            format!("{} {}", command, shell_words::join(&args))
+        };
+        let mut output = Vec::new();
+        batch_ctx.dispatch_line(&full_line, &mut output);
+        String::from_utf8(output).map_err(|e| format!("non-UTF-8 output: {e}"))
+    }));
+
+    match result {
+        Ok(Ok(output)) => {
+            let resp = serde_json::json!({
+                "status": "ok",
+                "output": output.trim_end(),
+            });
+            let _ = writeln!(stream, "{}", resp);
+        }
+        Ok(Err(e)) => {
+            let _ = write_daemon_error(&mut stream, &e);
+        }
+        Err(_) => {
+            let _ = write_daemon_error(&mut stream, "internal error (panic in dispatch)");
+            tracing::error!("Daemon query panicked — daemon continues");
+        }
+    }
+
+    tracing::info!(
+        command,
+        latency_ms = start.elapsed().as_millis() as u64,
+        "Daemon query complete"
+    );
+}
+
+fn write_daemon_error(
+    stream: &mut std::os::unix::net::UnixStream,
+    message: &str,
+) -> std::io::Result<()> {
+    use std::io::Write;
+    let resp = serde_json::json!({ "status": "error", "message": message });
+    writeln!(stream, "{}", resp)
+}
 
 /// Opaque identity of a database file for detecting replacements (DS-W5).
 /// On Unix uses (device, inode) — survives renames that preserve the inode
@@ -230,8 +347,14 @@ fn parse_wsl_automount_root() -> Option<String> {
 ///
 /// * If the project index is not found (user should run `cqs index` first)
 /// * If setting up file system watching fails
-pub fn cmd_watch(cli: &Cli, debounce_ms: u64, no_ignore: bool, poll: bool) -> Result<()> {
-    let _span = tracing::info_span!("cmd_watch", debounce_ms, poll).entered();
+pub fn cmd_watch(
+    cli: &Cli,
+    debounce_ms: u64,
+    no_ignore: bool,
+    poll: bool,
+    serve: bool,
+) -> Result<()> {
+    let _span = tracing::info_span!("cmd_watch", debounce_ms, poll, serve).entered();
     if no_ignore {
         tracing::warn!("--no-ignore is not yet implemented for watch mode");
     }
@@ -264,6 +387,84 @@ pub fn cmd_watch(cli: &Cli, debounce_ms: u64, no_ignore: bool, poll: bool) -> Re
     if !index_path.exists() {
         bail!("No index found. Run 'cqs index' first.");
     }
+
+    // Socket listener BEFORE watcher scan — daemon is immediately queryable
+    // while the (potentially slow) poll watcher initializes.
+    let mut socket_listener = if serve {
+        let sock_path = super::daemon_socket_path(&cqs_dir);
+        if sock_path.exists() {
+            match std::os::unix::net::UnixStream::connect(&sock_path) {
+                Ok(_) => {
+                    anyhow::bail!(
+                        "Another daemon is already listening on {}",
+                        sock_path.display()
+                    );
+                }
+                Err(_) => {
+                    std::fs::remove_file(&sock_path).ok();
+                    tracing::debug!(path = %sock_path.display(), "Removed stale socket file");
+                }
+            }
+        }
+        let listener = std::os::unix::net::UnixListener::bind(&sock_path)
+            .with_context(|| format!("Failed to bind socket at {}", sock_path.display()))?;
+        listener.set_nonblocking(true)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o600)).ok();
+        }
+        tracing::info!(
+            socket = %sock_path.display(),
+            pid = std::process::id(),
+            "Daemon listening"
+        );
+        if !cli.quiet {
+            println!("Daemon listening on {}", sock_path.display());
+        }
+        Some((listener, sock_path))
+    } else {
+        None
+    };
+    let _socket_guard = socket_listener
+        .as_ref()
+        .map(|(_, path)| SocketCleanupGuard(path.clone()));
+
+    // Spawn dedicated socket handler thread — runs independently of the file
+    // watcher so queries are served immediately, even during the slow poll scan.
+    let _socket_thread = if serve {
+        if let Some((listener, _)) = socket_listener.take() {
+            listener.set_nonblocking(false)?;
+            let thread = std::thread::spawn(move || {
+                // BatchContext created inside the thread — RefCell is !Send
+                // but thread-local ownership is fine.
+                let ctx = match super::batch::create_context() {
+                    Ok(ctx) => {
+                        ctx.warm();
+                        ctx
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "Daemon BatchContext creation failed");
+                        return;
+                    }
+                };
+                tracing::info!("Daemon query thread ready");
+                for stream in listener.incoming() {
+                    match stream {
+                        Ok(s) => handle_socket_client(s, &ctx),
+                        Err(e) => {
+                            tracing::debug!(error = %e, "Socket accept error");
+                        }
+                    }
+                }
+            });
+            Some(thread)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
 
     let parser = CqParser::new()?;
     let supported_ext: HashSet<_> = parser.supported_extensions().iter().cloned().collect();
@@ -473,6 +674,8 @@ pub fn cmd_watch(cli: &Cli, debounce_ms: u64, no_ignore: bool, poll: bool) -> Re
                         cycles_since_clear = 0;
                     }
                 }
+
+                // Socket queries handled by dedicated thread (see _socket_thread above).
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 bail!(


### PR DESCRIPTION
## Summary
- `cqs watch --serve` binds a Unix domain socket and serves batch-format queries in a dedicated thread
- **3ms per query** (vs 2-3s CLI startup) — 1000x speedup for agent burst patterns
- Socket bound before the slow poll watcher scan, so daemon is queryable immediately
- Client side in `dispatch.rs` auto-forwards queries to daemon if available, falls back to CLI

## Architecture
- Dedicated query thread with pre-warmed `BatchContext`
- Socket on `$XDG_RUNTIME_DIR` (WSL 9P doesn't support AF_UNIX on `/mnt/c/`)
- RAII cleanup guard removes socket on shutdown
- Stale socket detection via connect probe on startup
- `CQS_NO_DAEMON=1` to force CLI mode

## Known limitation
Batch arg parser differs from CLI parser (e.g. no `--json` flag in batch mode). Client-side arg translation needed for full CLI parity. Tracked as follow-up.

## Test plan
- [x] Manual end-to-end: start daemon, query via Python socket client, verify 3ms latency
- [x] Stale socket cleanup verified
- [x] RAII guard removes socket on kill
- [x] `cargo clippy --features gpu-index -- -D warnings` clean
- [x] `cargo test --bin cqs -- test_cmd_watch` passes
- [ ] Integration tests for socket protocol (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
