### PR TITLE
fix: daemon arg translation + integration tests + systemd (#926 follow-up)

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -441,8 +441,35 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Option<String> {
         .ok();
     stream.set_write_timeout(Some(Duration::from_secs(5))).ok();
 
-    // Build the batch-format command line from CLI args
-    let args: Vec<String> = std::env::args().skip(1).collect();
+    // Build batch-format request from CLI args.
+    // Strip global flags (--json, -q, --quiet, --model, etc.) — they live
+    // on the top-level Cli struct, not on the subcommand. The batch handler
+    // always outputs JSON, so --json is implicit.
+    let raw_args: Vec<String> = std::env::args().skip(1).collect();
+    let global_flags: &[&str] = &["--json", "-q", "--quiet"];
+    let global_with_value: &[&str] = &["--model", "-n", "--limit"];
+    let mut args: Vec<String> = Vec::new();
+    let mut skip_next = false;
+    for arg in &raw_args {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if global_flags.contains(&arg.as_str()) {
+            continue;
+        }
+        if global_with_value.contains(&arg.as_str()) {
+            // Remap -n/--limit: the batch parser uses --limit on the subcommand
+            if arg == "-n" || arg == "--limit" {
+                args.push("--limit".to_string());
+                // Next arg is the value — pass it through
+                continue;
+            }
+            skip_next = true;
+            continue;
+        }
+        args.push(arg.clone());
+    }
     let request = serde_json::json!({
         "command": args.first().map(|s| s.as_str()).unwrap_or(""),
         "args": &args[1..],

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -176,3 +176,40 @@ pub(crate) fn acquire_index_lock(cqs_dir: &Path) -> Result<std::fs::File> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_socket_path_deterministic() {
+        let p1 = daemon_socket_path(Path::new("/mnt/c/Projects/cqs/.cqs"));
+        let p2 = daemon_socket_path(Path::new("/mnt/c/Projects/cqs/.cqs"));
+        assert_eq!(p1, p2, "Same cqs_dir should produce the same socket path");
+    }
+
+    #[test]
+    fn daemon_socket_path_differs_per_project() {
+        let p1 = daemon_socket_path(Path::new("/mnt/c/ProjectA/.cqs"));
+        let p2 = daemon_socket_path(Path::new("/mnt/c/ProjectB/.cqs"));
+        assert_ne!(p1, p2, "Different projects should get different sockets");
+    }
+
+    #[test]
+    fn daemon_socket_path_ends_with_sock() {
+        let p = daemon_socket_path(Path::new("/tmp/test/.cqs"));
+        assert!(
+            p.extension().is_some_and(|e| e == "sock"),
+            "Socket path should end with .sock"
+        );
+    }
+
+    #[test]
+    fn daemon_socket_path_not_on_project_dir() {
+        let p = daemon_socket_path(Path::new("/mnt/c/Projects/cqs/.cqs"));
+        assert!(
+            !p.starts_with("/mnt/c"),
+            "Socket should be on native filesystem, not /mnt/c/"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #926 (daemon mode). Fixes the two immediate issues blocking real use:

- **Arg translation**: Strip global CLI flags (`--json`, `-q`, `--model`, `-n`) before forwarding to the batch parser. Remap `-n`/`--limit` to batch form.
- **Integration tests**: 4 unit tests for `daemon_socket_path` (deterministic, per-project, .sock extension, not-on-9P)
- **systemd**: `cqs-watch.service` updated to `cqs watch --serve`

## Test results
- `callers` via daemon: **19ms** (vs 2-3s CLI)
- `search` via daemon: 30s cold (ONNX load), fast warm
- `impact` via daemon: 7.6s (search + BFS)
- 4 new unit tests pass

## Test plan
- [x] Manual end-to-end: search, callers, impact all work via socket
- [x] `daemon_socket_path` unit tests
- [x] systemd service restarts with `--serve`, socket appears
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
