### PR TITLE
fix: guard daemon code with cfg(unix) for Windows builds

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -53,6 +53,7 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
     cli.limit = cli.limit.clamp(1, 100);
 
     // ── Daemon client: forward to running daemon if available ──────────────
+    #[cfg(unix)]
     if std::env::var("CQS_NO_DAEMON").as_deref() != Ok("1") {
         if let Some(output) = try_daemon_query(&cqs_dir, &cli) {
             print!("{}", output);
@@ -396,6 +397,7 @@ fn cmd_completions(shell: clap_complete::Shell) {
 /// Try to forward the current command to a running daemon.
 /// Returns `Some(output)` if the daemon handled it, `None` if no daemon or
 /// the command is not daemon-dispatchable (index, watch, gc, init, etc.).
+#[cfg(unix)]
 fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Option<String> {
     // Only forward commands that the batch handler can dispatch.
     // None = default search (most common invocation: `cqs "query"`)

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 
+#[cfg(unix)]
 /// Derive the daemon socket path for a given cqs_dir.
 ///
 /// Unix domain sockets don't work on WSL 9P mounts (/mnt/c/), so the socket
@@ -181,6 +182,7 @@ pub(crate) fn acquire_index_lock(cqs_dir: &Path) -> Result<std::fs::File> {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     #[test]
     fn daemon_socket_path_deterministic() {
         let p1 = daemon_socket_path(Path::new("/mnt/c/Projects/cqs/.cqs"));
@@ -188,6 +190,7 @@ mod tests {
         assert_eq!(p1, p2, "Same cqs_dir should produce the same socket path");
     }
 
+    #[cfg(unix)]
     #[test]
     fn daemon_socket_path_differs_per_project() {
         let p1 = daemon_socket_path(Path::new("/mnt/c/ProjectA/.cqs"));
@@ -195,6 +198,7 @@ mod tests {
         assert_ne!(p1, p2, "Different projects should get different sockets");
     }
 
+    #[cfg(unix)]
     #[test]
     fn daemon_socket_path_ends_with_sock() {
         let p = daemon_socket_path(Path::new("/tmp/test/.cqs"));
@@ -204,6 +208,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn daemon_socket_path_not_on_project_dir() {
         let p = daemon_socket_path(Path::new("/mnt/c/Projects/cqs/.cqs"));

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,9 +29,9 @@ pub use dispatch::run_with;
 // Re-export for watch.rs and commands
 pub(crate) use config::find_project_root;
 pub(crate) use enrichment::enrichment_pass;
-pub(crate) use files::{
-    acquire_index_lock, daemon_socket_path, enumerate_files, try_acquire_index_lock,
-};
+#[cfg(unix)]
+pub(crate) use files::daemon_socket_path;
+pub(crate) use files::{acquire_index_lock, enumerate_files, try_acquire_index_lock};
 pub(crate) use pipeline::run_index_pipeline;
 pub(crate) use signal::{check_interrupted, reset_interrupted};
 

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -36,8 +36,10 @@ use cqs::store::Store;
 use super::{check_interrupted, find_project_root, try_acquire_index_lock, Cli};
 
 /// RAII guard that removes the Unix socket file on drop.
+#[cfg(unix)]
 struct SocketCleanupGuard(PathBuf);
 
+#[cfg(unix)]
 impl Drop for SocketCleanupGuard {
     fn drop(&mut self) {
         if self.0.exists() {
@@ -51,6 +53,7 @@ impl Drop for SocketCleanupGuard {
 }
 
 /// Handle a single client connection on the daemon socket.
+#[cfg(unix)]
 /// Reads one JSON-line request, dispatches via the shared BatchContext, writes response.
 fn handle_socket_client(
     mut stream: std::os::unix::net::UnixStream,
@@ -390,6 +393,8 @@ pub fn cmd_watch(
 
     // Socket listener BEFORE watcher scan — daemon is immediately queryable
     // while the (potentially slow) poll watcher initializes.
+    // Unix domain sockets are not available on Windows.
+    #[cfg(unix)]
     let mut socket_listener = if serve {
         let sock_path = super::daemon_socket_path(&cqs_dir);
         if sock_path.exists() {
@@ -409,7 +414,6 @@ pub fn cmd_watch(
         let listener = std::os::unix::net::UnixListener::bind(&sock_path)
             .with_context(|| format!("Failed to bind socket at {}", sock_path.display()))?;
         listener.set_nonblocking(true)?;
-        #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o600)).ok();
@@ -426,12 +430,18 @@ pub fn cmd_watch(
     } else {
         None
     };
+    #[cfg(unix)]
     let _socket_guard = socket_listener
         .as_ref()
         .map(|(_, path)| SocketCleanupGuard(path.clone()));
+    #[cfg(not(unix))]
+    if serve {
+        tracing::warn!("--serve is not supported on Windows (no Unix domain sockets)");
+    }
 
     // Spawn dedicated socket handler thread — runs independently of the file
     // watcher so queries are served immediately, even during the slow poll scan.
+    #[cfg(unix)]
     let _socket_thread = if serve {
         if let Some((listener, _)) = socket_listener.take() {
             listener.set_nonblocking(false)?;


### PR DESCRIPTION
## Summary
Windows release build failed — `std::os::unix::net::UnixStream` doesn't exist on Windows.

All daemon code now gated with `#[cfg(unix)]`:
- Socket listener, guard, handler, thread spawn in watch.rs
- Client `try_daemon_query` in dispatch.rs
- `daemon_socket_path` helper + tests in files.rs

On Windows, `--serve` logs a warning. Everything else works normally.

## Test plan
- [x] clippy clean on Linux
- [x] Windows build should now pass (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
