### PR TITLE
fix: route notes mutations around daemon batch handler

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,66 +2,76 @@
 
 ## Right Now
 
-**v1.25.0 staged. Classifier is the bottleneck, not alphas. (2026-04-14 ~12:35 CDT)**
+**v1.25.0 shipped. Classifier is the next bottleneck. (2026-04-14 ~13:00 CDT)**
 
 ### Where we landed today
 
-Three PRs on top of v1.24.0:
+Three merged PRs on top of v1.24.0:
 
-1. **#943 merged** — `run_ablation.py` now writes eval results to `~/.cache/cqs/evals/` instead of `evals/runs/*/results.json`. Fixes the watch-reindex contamination that corrupted every prior alpha measurement.
-2. **Clean 21-point alpha re-sweep** — first truly deterministic sweep. Back-to-back runs bit-exact.
-3. **New per-category defaults** in `resolve_splade_alpha()` — structural 0.60 (was 0.9, wrong), conceptual 0.85 (was 0.95), identifier 0.90 (was 1.0), behavioral 0.05 (confirmed), rest 1.0 (confirmed).
-4. **Router fix** — dropped `query.contains("how does")` from `is_behavioral_query`. That pattern caught 100% of multi_step eval queries and routed them to α=0.05. Now multi_step falls to MultiStep/Unknown (both α=1.0). +0.7pp overall.
+1. **#943** — eval output moved to `~/.cache/cqs/evals/` (fixes watch-reindex contamination that corrupted every prior alpha measurement).
+2. **Clean 21-point alpha re-sweep** — first truly deterministic sweep; back-to-back runs are bit-exact.
+3. **#944 / v1.25.0** — new per-category defaults (`identifier 0.90, structural 0.60, conceptual 0.85, behavioral 0.05, rest 1.0`) + dropped the over-broad `"how does"` pattern from `is_behavioral_query` that was catching 100% of multi_step queries and routing them to α=0.05. Transitive `rand 0.9.2 → 0.9.4` bump (GHSA-cq8v-f236-94qc alert dismissed as `not_used`).
+
+### Release status
+
+- Tag `v1.25.0` pushed
+- Crates.io: **published** as `cqs 1.25.0` (default features; `[patch.crates-io]` cuvs git dep prevents publishing with `--features gpu-index`)
+- GitHub Release workflow: running (background task `bsyim32pp`, watched via `gh run watch`). Will auto-create the GitHub Release with Linux/macOS/Windows binaries on success.
+- Local binary + daemon: on v1.25.0, daemon active.
 
 ### Numbers
 
-- Best uniform α from clean sweep: **α=0.95 → 44.9%** (not α=1.0 — that was a corruption artifact)
+- Best uniform α from clean sweep: **α=0.95 → 44.9%** R@1
 - Per-category oracle ceiling: **49.4%** (131/265)
-- Deployed per-category routing after fixes: **44.9%** — ties uniform α=0.95
+- Deployed per-category routing (v1.25.0): **44.9%** — ties uniform α=0.95
 - The 4.5pp oracle gap is **entirely classifier accuracy**, not alpha choice
 
 ### The classifier is the bottleneck
 
-Confusion matrix (eval label vs `classify_query()` output):
+Confusion matrix (eval label vs `classify_query()` output) from today's check:
 
-| eval_label | N | correctly classified |
-|---|---|---|
-| negation | 29 | 100% |
-| identifier | 50 | 84% |
-| structural | 27 | 19% |
-| type_filtered | 24 | 4% |
-| behavioral | 44 | 5% |
-| conceptual | 36 | 3% |
-| cross_language | 21 | 0% |
-| multi_step | 34 | 0% → fixed today via "how does" removal |
+| eval_label | N | correctly classified | dominant misroute |
+|---|---|---|---|
+| negation | 29 | 100% | — |
+| identifier | 50 | 84% | 5 → Unknown |
+| structural | 27 | 19% | 18 → Unknown |
+| type_filtered | 24 | 4% | 11 → Structural (starts with "struct "/"enum "/"trait ") |
+| behavioral | 44 | 5% | 24 → Unknown |
+| conceptual | 36 | 3% | 24 → Unknown |
+| cross_language | 21 | 0% | 11 → Unknown, 5 → Structural |
+| multi_step | 34 | 0% → fixed | was 100% → Behavioral; now split MultiStep/Unknown (both α=1.0) |
 
-Structural/conceptual/behavioral detectors rely on narrow phrase and word lists that miss most natural-language queries. Those queries fall to Unknown → α=1.0. type_filtered queries starting with "struct"/"enum"/"trait" hit the Structural rule first. Cross-language detection requires explicit language names.
-
-Classifier investigation is the next high-value CPU-lane item. Added to ROADMAP.
+Structural/conceptual/behavioral detectors use narrow phrase/word lists that miss natural-language queries. Those fall to Unknown → α=1.0. Cross-language detection requires explicit language names, which the eval queries don't use.
 
 ### Next session priorities
 
-1. Ship v1.25.0: commit router changes, new defaults, bump version, changelog, release.
-2. Classifier accuracy investigation — expand rule set / learned classifier / LLM-first-query-cached. Worth +4.5pp if done well.
-3. Eval expansion: grow small categories (N=21 cross_language, N=24 type_filtered) to N≥40.
-4. Rename `v2_300q.json` to actual count (265).
+1. **Classifier accuracy investigation** — expand rule set with phrasings mined from eval queries, or a small learned classifier, or LLM-first-query-cached. Worth +4.5pp if done well. Full ROADMAP entry exists.
+2. **Eval expansion** — grow small categories (N=21 cross_language, N=24 type_filtered) to N≥40 so per-category decisions aren't dominated by single-query noise.
+3. **Rename `evals/queries/v2_300q.json`** to its actual count (265 queries).
 
 ### Residual puzzles
 
-- Identifier dropped 1 query (98% → 96%) and structural dropped 1 query (51.9% → 48.1%) between v1 and v2 eval today, with only the `is_behavioral_query` change between them. Likely SPLADE ONNX GPU non-determinism on the sparse vector output — the previously-noted residual.
+- Identifier dropped 1 query (98% → 96%) and structural dropped 1 query between v1 and v2 router-fix evals with only `is_behavioral_query` changed between them. Likely SPLADE ONNX GPU non-determinism on the sparse vector output — a known residual drift source worth verifying once.
+
+## Parked
+
+- **CAGRA filtering regression on enriched index** (v1.24.0 investigation) — conceptual −5.5pp, structural −3.8pp, identifier −2pp vs pre-release baseline when CAGRA bitset filtering is on with the enriched graph. Options: HNSW-for-enriched + CAGRA-for-base, or bumped itopk_size, or per-filter CAGRA graphs. Blocks further R@1 gains but orthogonal to the classifier work.
+- **Query-time HyDE for structural queries** — old data shows +14pp structural / +12pp type_filtered / −22pp conceptual. Needs a fresh eval with SPLADE active.
+- **Reranker V2** (code-trained cross-encoder; ms-marco was catastrophic).
 
 ## PR status
-- #939, #940, #941, #942, #943 all merged
-- Router + defaults changes: uncommitted on local main (needs branch + PR for v1.25.0)
+- All recent PRs merged: #939, #940, #941, #942, #943, #944.
+- No open PRs from this session.
 
 ## Architecture
-- Version: 1.24.0 (1.25.0 staged), Schema: v20
+- Version: **1.25.0**, Schema: v20
 - Deterministic search path (PR #942) + deterministic eval pipeline (PR #943)
-- SPLADE always-on, alpha controls fusion weight only
-- Per-category defaults (staged for v1.25.0): identifier 0.90, structural 0.60, conceptual 0.85, type_filtered 1.0, behavioral 0.05, rest 1.0
+- SPLADE always-on, α controls fusion weight only
+- Per-category SPLADE defaults: identifier 0.90, structural 0.60, conceptual 0.85, type_filtered 1.0, behavioral 0.05, rest 1.0
 - HNSW dirty flag self-heals via checksum verification
-- cuVS 26.4 + patched with search_with_filter (upstream rapidsai/cuvs#2019)
+- cuVS 26.4 + patched with `search_with_filter` (upstream rapidsai/cuvs#2019 pending)
 - Eval results write to `~/.cache/cqs/evals/` (outside watched project dir)
+- Daemon: `cqs watch --serve`, systemd unit `cqs-watch`
 
 ## Open Issues
 - #909, #912-#925, #856, #717, #389, #255, #106, #63

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -1151,3 +1151,42 @@ mentions = ["agents"]
 sentiment = -0.5
 text = "GH Actions free tier queues test jobs 20+ minutes on Sunday afternoons — plan around this for CI-dependent workflows"
 mentions = ["ci"]
+
+[[note]]
+sentiment = -1.0
+text = "Watch-reindex on eval-output writes is the invisible determinism killer. Any .json/.md write inside watched dir triggers reindex + cache invalidation mid-session, drifting measurements ±15pp on small categories. Fix: write eval results to ~/.cache/cqs/evals/ outside the watched tree."
+mentions = [
+    "evals/run_ablation.py",
+    "watch",
+    "daemon",
+]
+
+[[note]]
+sentiment = -0.5
+text = "cargo publish fails with --features gpu-index because [patch.crates-io] cannot reference a git dep when publishing. Must publish default features only. Consumers with gpu-index apply the same patch in their own Cargo.toml."
+mentions = [
+    "Cargo.toml",
+    "cuvs",
+]
+
+[[note]]
+sentiment = 0.0
+text = "Dependabot alerts do not auto-close while any vulnerable transitive version remains in the lockfile — even if that transitive is build-time only. Dismiss manually with reason (not_used / tolerable_risk) when the advisory preconditions are structurally unreachable in our code."
+mentions = ["Cargo.lock"]
+
+[[note]]
+sentiment = 0.5
+text = "When adding daemon bypass for commands the batch handler can't dispatch, exclude them in try_daemon_query (src/cli/dispatch.rs). Mutations often belong in CLI path even if reads can daemon-serve. Fixed for notes {add,update,remove}."
+mentions = [
+    "src/cli/batch",
+    "notes",
+]
+
+[[note]]
+sentiment = 0.0
+text = "Per-category alpha routing caps at classifier accuracy, not alpha values. Oracle 49.4% on 2026-04-14 eval, deployed 44.9% — gap is entirely structural/conceptual/behavioral classifier missing 80%+ of queries (they fall to Unknown). Rule-list heuristics do not cover natural-language phrasings. Fix direction: broader rules / learned classifier / LLM-on-first-query cached."
+mentions = [
+    "src/search/router.rs",
+    "classifier",
+    "splade",
+]

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -412,6 +412,13 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Option<String> {
         | Some(Commands::TrainPairs { .. })
         | Some(Commands::Cache { .. })
         | Some(Commands::Doctor { .. }) => return None,
+        // notes add/update/remove are filesystem mutations on docs/notes.toml
+        // followed by a reindex. The batch handler only supports `notes --warnings`
+        // / `--patterns` (list modes) and rejects the subcommand tokens. Route
+        // mutations to the CLI handler at Group A instead.
+        Some(Commands::Notes { subcmd }) if !matches!(subcmd, NotesCommand::List { .. }) => {
+            return None;
+        }
         None | Some(_) => {}
     }
 


### PR DESCRIPTION
## Summary

`cqs notes {add, update, remove}` was broken when the daemon was running. The CLI forwarded the command to the daemon, which rejected it at the batch parser ("unexpected argument 'add'"). The CLI dispatch already had a proper handler for mutations (`cmd_notes_mutate` at `dispatch.rs:177`) — we just never reached it.

Fix: exclude notes mutations from `try_daemon_query`'s forward list. List mode still forwards (fast daemon read). Mutations route to the CLI handler as intended.

No more `CQS_NO_DAEMON=1` workaround for in-session note-taking.

Also picks up:
- `PROJECT_CONTINUITY.md` post-v1.25.0 state.
- Five session notes in `docs/notes.toml` (eval-output watch-reindex killer, `cargo publish --features gpu-index` limitation, dependabot close semantics, daemon parser gap now closed, classifier-as-bottleneck).

## Test plan

- [x] `cqs notes add "..."` works with daemon running (no `CQS_NO_DAEMON` needed)
- [x] `cqs notes remove "..."` works with daemon running
- [x] Daemon still active after the bypass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
