### PR TITLE
fix: remove atexit Mutex UB from ORT provider setup (#856)

### DIFF
--- a/src/embedder/provider.rs
+++ b/src/embedder/provider.rs
@@ -21,8 +21,16 @@ pub(super) fn ort_err<T>(e: ort::Error<T>) -> EmbedderError {
 /// name (e.g., "cqs"), so ORT constructs `absolute("cqs").remove_filename()`
 /// = CWD. Providers must exist there for `dlopen` to succeed.
 /// Strategy: compute the same directory ORT will search (from argv[0]),
-/// and create symlinks from the ORT cache there. Symlinks are cleaned up
-/// on process exit.
+/// and create symlinks from the ORT cache there.
+///
+/// PB-5 / #856: we previously registered a libc::atexit handler to
+/// unlink the symlinks here, but that function called Mutex::lock()
+/// which is UB after the Rust allocator has been torn down (and panics
+/// on poisoned mutex → unwinding into C is also UB). The symlinks are
+/// now left in place on process exit; they get overwritten on the
+/// next run (ORT provider resolution is deterministic per cqs version).
+/// If stale-file accumulation becomes a concern, add a startup-time
+/// GC pass instead of a shutdown-time one.
 #[cfg(target_os = "linux")]
 fn ensure_ort_provider_libs() {
     let ort_lib_dir = match find_ort_provider_dir() {
@@ -47,20 +55,10 @@ fn ensure_ort_provider_libs() {
 
     symlink_providers(&ort_lib_dir, &ort_search_dir, &provider_libs);
 
-    // Collect all symlink paths for cleanup
-    let mut cleanup_paths: Vec<PathBuf> = provider_libs
-        .iter()
-        .map(|lib| ort_search_dir.join(lib))
-        .collect();
-
     // Also symlink into LD_LIBRARY_PATH for other search paths
     if let Some(ld_dir) = find_ld_library_dir(&ort_lib_dir) {
         symlink_providers(&ort_lib_dir, &ld_dir, &provider_libs);
-        cleanup_paths.extend(provider_libs.iter().map(|lib| ld_dir.join(lib)));
     }
-
-    // Register cleanup for ALL symlinked paths (both directories)
-    register_provider_cleanup(cleanup_paths);
 }
 
 /// Compute the directory ORT's GetRuntimePath() will resolve to.
@@ -151,41 +149,6 @@ fn symlink_providers(src_dir: &Path, target_dir: &Path, libs: &[&str]) {
             tracing::debug!("Failed to symlink {}: {}", lib, e);
         }
     }
-}
-
-/// Register atexit cleanup for provider symlinks.
-/// Uses Mutex to support paths from multiple directories.
-#[cfg(target_os = "linux")]
-fn register_provider_cleanup(paths: Vec<PathBuf>) {
-    use std::sync::Mutex;
-
-    static CLEANUP_PATHS: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
-
-    if let Ok(mut guard) = CLEANUP_PATHS.lock() {
-        guard.extend(paths);
-    }
-
-    // Register atexit handler only once
-    static REGISTERED: std::sync::Once = std::sync::Once::new();
-    REGISTERED.call_once(|| {
-        /// Cleans up temporary files and symlinks registered for deletion during program termination.
-        /// This function is registered as an exit handler and removes any files that were added to the cleanup list during execution. It safely iterates through registered paths, verifying each is a symlink before attempting deletion, and silently ignores any removal failures.
-        /// # Arguments
-        /// None. Accesses a global `CLEANUP_PATHS` collection to determine which files to remove.
-        /// # Returns
-        /// Nothing. This is an extern "C" function with no return value, suitable for use as an exit handler.
-        extern "C" fn cleanup() {
-            // Note: remove_file may allocate. Acceptable for CLI tool that exits normally.
-            if let Ok(paths) = CLEANUP_PATHS.lock() {
-                for path in paths.iter() {
-                    if path.symlink_metadata().is_ok() && std::fs::read_link(path).is_ok() {
-                        let _ = std::fs::remove_file(path);
-                    }
-                }
-            }
-        }
-        unsafe { libc::atexit(cleanup) };
-    });
 }
 
 /// No-op on non-Linux platforms (CUDA provider libs handled differently)


### PR DESCRIPTION
## Summary

Fixes #856 (PB-5: atexit Mutex UB).

`src/embedder/provider.rs` registered a `libc::atexit` cleanup handler that called `Mutex::lock()` to unlink ORT provider symlinks. Two soundness problems:

1. **Allocation in atexit handler is UB** once the Rust global allocator has been torn down. `Mutex::lock()` can allocate (poisoning metadata, internal spin/park state).
2. **Poisoned-mutex panics unwind into C code** — another UB, since `libc::atexit` handlers must not unwind.

Fires on every `cqs` CLI exit that loaded the ORT provider (Linux-only `#[cfg(target_os = "linux")]`), which is effectively every GPU-feature invocation.

## Fix

Removed the atexit registration and the `register_provider_cleanup` function entirely. The ORT provider symlinks are now left in place on process exit — they get overwritten idempotently on the next startup by `symlink_providers` (which already canonicalizes + read_links + replaces-if-wrong under the pre-existing PB-10 logic).

Added a doc comment explaining the tradeoff and pointing at the escape hatch: if stale-file accumulation ever becomes a concern, add a startup-time GC pass instead of a shutdown-time one.

Diff: `1 file changed, 10 insertions(+), 47 deletions(-)`.

## Verification

- `cargo fmt` — clean
- `cargo build --features gpu-index` — clean
- `cargo clippy --features gpu-index -- -D warnings` — clean
- No tests reference `register_provider_cleanup` / `CLEANUP_PATHS` / `atexit`
- `libc` crate still used elsewhere (`src/cli/files.rs`), dependency stays

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] No callers of the removed handler (`cqs callers register_provider_cleanup` → none)
- [ ] CI green
- [ ] Post-merge: rebuild + install, verify `cqs` exits cleanly with no stderr UB output

Closes #856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
