### PR TITLE
wave A: post-audit quick wins (#961, #962, #963)

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,10 @@ Best production config: **BGE-large** (`cqs index`). LLM summaries provide margi
 | `CQS_BATCH_IDLE_MINUTES` | `5` | Minutes of inactivity before `cqs batch` / `cqs chat` clears ONNX sessions (`0` disables eviction). |
 | `CQS_BUSY_TIMEOUT_MS` | `5000` | SQLite busy timeout in milliseconds |
 | `CQS_CACHE_MAX_SIZE` | `1073741824` (1 GB) | Global embedding cache size limit |
+| `CQS_CAGRA_GRAPH_DEGREE` | `64` | CAGRA output graph degree at build time (cuVS default 64; higher → better recall, longer build) |
+| `CQS_CAGRA_INTERMEDIATE_GRAPH_DEGREE` | `128` | CAGRA pruned-input graph degree at build time (cuVS default 128) |
+| `CQS_CAGRA_ITOPK_MAX` | (log₂(n)·32 clamped 128-4096) | Upper clamp on CAGRA `itopk_size`. Default scales with corpus size (1k→320, 100k→532, 1M→640). Raise for better recall on large indexes at the cost of search latency. |
+| `CQS_CAGRA_ITOPK_MIN` | `128` | Lower clamp on CAGRA `itopk_size`. `itopk_size = (k*2).clamp(min, max)`. |
 | `CQS_CAGRA_MAX_BYTES` | (auto) | Max GPU memory for CAGRA index |
 | `CQS_CAGRA_THRESHOLD` | `50000` | Min chunks to trigger CAGRA over HNSW |
 | `CQS_DAEMON_TIMEOUT_MS` | `2000` | Daemon client connect/read timeout in milliseconds (CLI → daemon) |

--- a/README.md
+++ b/README.md
@@ -706,6 +706,7 @@ Best production config: **BGE-large** (`cqs index`). LLM summaries provide margi
 | `CQS_QUERY_CACHE_SIZE` | `128` | Embedding query cache entries |
 | `CQS_RAYON_THREADS` | (auto) | Rayon thread pool size for parallel operations |
 | `CQS_REFS_LRU_SIZE` | `2` | Slots in the batch-mode reference-index LRU cache (sibling projects loaded via `@name`). |
+| `CQS_RERANKER_BATCH` | `32` | Cross-encoder batch size per ORT run (reduce if reranker OOMs on large `--rerank-k`) |
 | `CQS_RERANKER_MAX_LENGTH` | `512` | Max input length for cross-encoder reranker |
 | `CQS_RERANKER_MODEL` | `cross-encoder/ms-marco-MiniLM-L-6-v2` | Cross-encoder model for `--rerank` |
 | `CQS_RRF_K` | `60` | RRF fusion constant (higher = more weight to top results) |

--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -58,6 +58,47 @@ fn cagra_max_bytes() -> usize {
     })
 }
 
+/// Issue #962: Scale `itopk_max` ceiling with corpus size. At 1k chunks we
+/// want the library default (~320); at 1M chunks we want ~640 or more.
+/// Logarithmic scaling based on chunk count:
+///   ceiling = (log2(n_vectors) * 32).clamp(128, 4096)
+/// 1k → 320, 13k → 447, 100k → 532, 1M → 640, 10M → 744
+/// Then `(k * 2).clamp(min, max)` narrows the actual `itopk_size` at
+/// query time. Overridable via `CQS_CAGRA_ITOPK_MAX`.
+#[cfg(feature = "gpu-index")]
+fn cagra_itopk_max_default(n_vectors: usize) -> usize {
+    let log2 = (n_vectors.max(1) as f64).log2();
+    let scaled = (log2 * 32.0) as usize;
+    scaled.clamp(128, 4096)
+}
+
+/// Issue #962: Build-time CAGRA graph degrees, overridable via env.
+/// `CQS_CAGRA_GRAPH_DEGREE` (default 64) is the output graph degree.
+/// `CQS_CAGRA_INTERMEDIATE_GRAPH_DEGREE` (default 128) is the pruned-input
+/// graph degree. Both map to the corresponding cuVS `IndexParams` setters.
+/// Returns `IndexParams` with those setters applied (and traces the choice).
+#[cfg(feature = "gpu-index")]
+fn cagra_build_params() -> Result<cuvs::cagra::IndexParams, CagraError> {
+    let graph_degree: usize = std::env::var("CQS_CAGRA_GRAPH_DEGREE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(64);
+    let intermediate_graph_degree: usize = std::env::var("CQS_CAGRA_INTERMEDIATE_GRAPH_DEGREE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(128);
+    let params = cuvs::cagra::IndexParams::new()
+        .map_err(|e| CagraError::Cuvs(e.to_string()))?
+        .set_graph_degree(graph_degree)
+        .set_intermediate_graph_degree(intermediate_graph_degree);
+    tracing::info!(
+        graph_degree,
+        intermediate_graph_degree,
+        "CAGRA build params"
+    );
+    Ok(params)
+}
+
 /// CAGRA GPU index for vector search.
 ///
 /// # Thread Safety
@@ -119,8 +160,7 @@ impl CagraIndex {
         let dataset = Array2::from_shape_vec((n_vectors, dim), flat_data)
             .map_err(|e| CagraError::Cuvs(format!("Failed to create array: {}", e)))?;
 
-        let build_params =
-            cuvs::cagra::IndexParams::new().map_err(|e| CagraError::Cuvs(e.to_string()))?;
+        let build_params = cagra_build_params()?;
 
         let index = cuvs::cagra::Index::build(&resources, &build_params, &dataset)
             .map_err(|e| CagraError::Cuvs(e.to_string()))?;
@@ -192,10 +232,23 @@ impl CagraIndex {
         k: usize,
         bitset_device: Option<&cuvs::ManagedTensor>,
     ) -> Vec<IndexResult> {
-        let itopk_size = (k * 2).clamp(128, 512);
-        if k * 2 > 512 {
-            tracing::debug!(k, "CAGRA itopk_size clamped to 512, recall may degrade");
-        }
+        let itopk_min = std::env::var("CQS_CAGRA_ITOPK_MIN")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(128);
+        let itopk_max = std::env::var("CQS_CAGRA_ITOPK_MAX")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_else(|| cagra_itopk_max_default(self.len()));
+        let itopk_size = (k * 2).clamp(itopk_min, itopk_max);
+        tracing::debug!(
+            itopk_size,
+            itopk_min,
+            itopk_max,
+            k,
+            n_vectors = self.len(),
+            "CAGRA itopk resolved"
+        );
 
         let search_params = match cuvs::cagra::SearchParams::new() {
             Ok(params) => params.set_itopk_size(itopk_size),
@@ -520,8 +573,7 @@ impl CagraIndex {
         let dataset = Array2::from_shape_vec((n_vectors, dim), flat_data)
             .map_err(|e| CagraError::Cuvs(format!("Failed to create array: {}", e)))?;
 
-        let build_params =
-            cuvs::cagra::IndexParams::new().map_err(|e| CagraError::Cuvs(e.to_string()))?;
+        let build_params = cagra_build_params()?;
 
         let index = cuvs::cagra::Index::build(&resources, &build_params, &dataset)
             .map_err(|e| CagraError::Cuvs(e.to_string()))?;

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -24,6 +24,28 @@ const TOKENIZER_FILE: &str = "tokenizer.json";
 const MODEL_BLAKE3: &str = "";
 const TOKENIZER_BLAKE3: &str = "";
 
+/// Default batch size for reranker ORT runs.
+///
+/// Caps the candidate set fed to each `session.run()` call so a large `k`
+/// (e.g. `--rerank-k 100` with `max_length=512`) doesn't allocate a single
+/// `[100, 512]` token tensor that OOMs on small GPUs or after SPLADE has
+/// claimed VRAM. Mirrors the `CQS_EMBED_BATCH_SIZE=64` pattern in the
+/// embed path; 32 is conservative because cross-encoder runs produce larger
+/// activations than plain encoder forward passes.
+const DEFAULT_RERANKER_BATCH: usize = 32;
+
+/// Maximum number of candidates per ORT `session.run()` in the reranker.
+///
+/// Reads `CQS_RERANKER_BATCH`; falls back to [`DEFAULT_RERANKER_BATCH`] when
+/// unset, unparseable, or zero.
+fn reranker_batch_size() -> usize {
+    std::env::var("CQS_RERANKER_BATCH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&n: &usize| n > 0)
+        .unwrap_or(DEFAULT_RERANKER_BATCH)
+}
+
 /// Retrieves the reranker model repository path from the environment or returns the default.
 ///
 /// # Returns
@@ -179,12 +201,19 @@ impl Reranker {
     /// Compute cross-encoder scores for (query, passage) pairs.
     ///
     /// Returns `Some(scores)` on success, or `None` when tokenization produced
-    /// zero-length encodings (nothing to score). `scores.len() == passages.len()`
-    /// on `Some(...)`.
+    /// zero-length encodings across all passages (nothing to score).
+    /// `scores.len() == passages.len()` on `Some(...)`.
     ///
     /// PF-V1.25-5: extracted so `rerank` can feed passages borrowed directly
     /// from `&Vec<SearchResult>` without cloning contents, then apply scores
     /// via `apply_rerank_scores` in a subsequent `&mut` scope.
+    ///
+    /// Issue #963: passages are chunked into `CQS_RERANKER_BATCH`-sized
+    /// groups (default 32) before feeding each chunk to `session.run()`. This
+    /// keeps the `[chunk_len, max_length]` token tensor bounded so large `k`
+    /// values don't OOM on small GPUs or after SPLADE has claimed VRAM.
+    /// Scoring semantics are preserved — each candidate gets the same
+    /// cross-encoder score, just computed in smaller ORT runs.
     fn compute_scores_opt(
         &self,
         query: &str,
@@ -192,7 +221,10 @@ impl Reranker {
     ) -> Result<Option<Vec<f32>>, RerankerError> {
         let tokenizer = self.tokenizer()?;
 
-        // 1. Tokenize (query, passage) pairs
+        // 1. Tokenize (query, passage) pairs once up front. Tokenization is
+        //    cheap relative to ORT inference and doing it here lets us
+        //    short-circuit (return None) when the entire input is degenerate,
+        //    matching the pre-#963 semantics.
         let encodings: Vec<tokenizers::Encoding> = passages
             .iter()
             .map(|passage| {
@@ -202,12 +234,42 @@ impl Reranker {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        // 2. Build padded tensors
-        let input_ids: Vec<Vec<i64>> = encodings
+        let overall_max = encodings
+            .iter()
+            .map(|e| e.get_ids().len())
+            .max()
+            .unwrap_or(0)
+            .min(self.max_length);
+        if overall_max == 0 {
+            return Ok(None); // Nothing to score — empty tokenization
+        }
+
+        let batch_cap = reranker_batch_size();
+        let mut scores = Vec::with_capacity(passages.len());
+        for chunk in encodings.chunks(batch_cap) {
+            scores.extend(self.run_chunk(chunk)?);
+        }
+        Ok(Some(scores))
+    }
+
+    /// Run one reranker batch: build tensors from `chunk` and score via ORT.
+    ///
+    /// `chunk` is a slice of tokenized (query, passage) encodings sized to at
+    /// most `CQS_RERANKER_BATCH`. The per-chunk `max_len` is the longest
+    /// encoding in this chunk capped at `self.max_length`, so shorter chunks
+    /// use smaller tensors.
+    ///
+    /// Returns one score per encoding in `chunk`.
+    fn run_chunk(&self, chunk: &[tokenizers::Encoding]) -> Result<Vec<f32>, RerankerError> {
+        let batch_size = chunk.len();
+        debug_assert!(batch_size > 0, "run_chunk called with empty chunk");
+
+        // Build per-chunk padded tensors.
+        let input_ids: Vec<Vec<i64>> = chunk
             .iter()
             .map(|e| e.get_ids().iter().map(|&id| id as i64).collect())
             .collect();
-        let attention_mask: Vec<Vec<i64>> = encodings
+        let attention_mask: Vec<Vec<i64>> = chunk
             .iter()
             .map(|e| e.get_attention_mask().iter().map(|&m| m as i64).collect())
             .collect();
@@ -218,10 +280,13 @@ impl Reranker {
             .unwrap_or(0)
             .min(self.max_length);
         if max_len == 0 {
-            return Ok(None); // Nothing to score — empty tokenization
+            // This chunk's passages all tokenized empty but the aggregate
+            // check in compute_scores_opt already guaranteed overall_max > 0.
+            // Return zero scores for this chunk; the non-empty chunks carry
+            // the ranking signal.
+            return Ok(vec![sigmoid(0.0); batch_size]);
         }
 
-        let batch_size = passages.len();
         let ids_arr = pad_2d_i64(&input_ids, max_len, 0);
         let mask_arr = pad_2d_i64(&attention_mask, max_len, 0);
         let type_arr = Array2::<i64>::zeros((batch_size, max_len));
@@ -232,7 +297,7 @@ impl Reranker {
         let mask_tensor = Tensor::from_array(mask_arr).map_err(ort_err)?;
         let type_tensor = Tensor::from_array(type_arr).map_err(ort_err)?;
 
-        // 3. Run inference
+        // Run inference on this chunk only.
         let mut session_guard = self.session()?;
         let session = session_guard
             .as_mut()
@@ -245,7 +310,7 @@ impl Reranker {
             ])
             .map_err(ort_err)?;
 
-        // 4. Extract logits, apply sigmoid
+        // Extract logits, apply sigmoid.
         if outputs.len() == 0 {
             return Err(RerankerError::Inference(
                 "ONNX model produced no outputs".to_string(),
@@ -273,7 +338,7 @@ impl Reranker {
         }
 
         let scores: Vec<f32> = (0..batch_size).map(|i| sigmoid(data[i * stride])).collect();
-        Ok(Some(scores))
+        Ok(scores)
     }
 
     /// Like [`compute_scores_opt`] but returns an empty vec instead of `None`

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -257,13 +257,313 @@ struct StoreOpenConfig {
     runtime: Option<Runtime>,
 }
 
-/// Read `CQS_MMAP_SIZE` env var, falling back to `default_bytes`.
-/// The env var is the raw byte count (e.g. `268435456` for 256 MB).
-fn mmap_size_from_env(default_bytes: &str) -> String {
+/// Filesystem types where SQLite `mmap_size > 0` hurts performance.
+///
+/// On these backends, mmap either falls back to per-page I/O (9P, NFS, SMB)
+/// or triggers synchronous flushes on unrelated writes. Setting `mmap_size=0`
+/// forces SQLite to use regular `pread`/`pwrite`, which is uniformly faster
+/// on these filesystems.
+///
+/// `drvfs` / `fuse.drvfs` cover legacy WSL1. `9p` is WSL2's DrvFS transport
+/// to the Windows host (paths under `/mnt/c/`, `/mnt/d/`, etc.). `cifs`,
+/// `smb3`, `smbfs` cover SMB shares. `nfs`, `nfs4` cover NFS mounts.
+/// `ntfs`, `ntfs3`, `fuseblk` cover native-Linux NTFS access (ntfs-3g).
+const SLOW_MMAP_FSTYPES: &[&str] = &[
+    "9p",
+    "cifs",
+    "smb3",
+    "smbfs",
+    "drvfs",
+    "fuse.drvfs",
+    "nfs",
+    "nfs4",
+    "ntfs",
+    "ntfs3",
+    "fuseblk",
+];
+
+/// Read `CQS_MMAP_SIZE` env var, returning `Some(value)` if explicitly set
+/// to a valid non-negative integer. Returns `None` if unset or unparseable,
+/// so callers can distinguish "user-requested" from "fell back to default".
+fn mmap_size_env_override() -> Option<String> {
     std::env::var("CQS_MMAP_SIZE")
         .ok()
-        .and_then(|v| v.parse::<u64>().ok().map(|n| n.to_string()))
-        .unwrap_or_else(|| default_bytes.to_string())
+        .and_then(|v| v.trim().parse::<u64>().ok().map(|n| n.to_string()))
+}
+
+/// Resolve the SQLite `mmap_size` PRAGMA value for a database at `db_path`.
+///
+/// Precedence (highest first):
+/// 1. `CQS_MMAP_SIZE` env var — explicit user override always wins.
+/// 2. Slow-FS auto-detection — if `db_path` is on 9P/NTFS/SMB/NFS, return `"0"`
+///    (disables mmap) and log an info message.
+/// 3. `default_bytes` — the mode-specific default (e.g. 256 MB pooled, 64 MB
+///    read-only).
+///
+/// The env var is the raw byte count (e.g. `268435456` for 256 MB).
+fn resolve_mmap_size(default_bytes: &str, db_path: &Path) -> String {
+    if let Some(explicit) = mmap_size_env_override() {
+        return explicit;
+    }
+    if is_slow_mmap_fs(db_path) {
+        tracing::info!(
+            path = %db_path.display(),
+            "Slow FS detected (WSL/9P/NTFS/SMB/NFS), disabling SQLite mmap (set CQS_MMAP_SIZE to override)"
+        );
+        return "0".to_string();
+    }
+    default_bytes.to_string()
+}
+
+/// Return `true` if `path` lives on a filesystem where SQLite `mmap_size > 0`
+/// degrades performance (WSL `/mnt/c/` 9P, NFS, SMB, NTFS-via-FUSE).
+///
+/// Implementation: on Unix, parses `/proc/self/mountinfo` and looks up the
+/// fstype of the mount containing `path`. On non-Unix, returns `false` (mmap
+/// behavior on Windows native / macOS APFS is fine with the default size).
+///
+/// Canonicalizes `path` first; if canonicalization fails (e.g., the DB file
+/// doesn't exist yet on first open), tries the parent directory.
+fn is_slow_mmap_fs(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        // Resolve to an absolute path. On fresh opens the DB file may not
+        // exist yet (create_if_missing=true), so fall back to the parent dir.
+        let canonical = dunce::canonicalize(path).or_else(|_| {
+            path.parent().map_or_else(
+                || {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "no parent",
+                    ))
+                },
+                dunce::canonicalize,
+            )
+        });
+        let abs = match canonical {
+            Ok(p) => p,
+            Err(_) => return false,
+        };
+        let mountinfo = match std::fs::read_to_string("/proc/self/mountinfo") {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+        match fstype_for_path(&mountinfo, &abs) {
+            Some(fstype) => SLOW_MMAP_FSTYPES.iter().any(|&s| s == fstype),
+            None => false,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        false
+    }
+}
+
+/// Parse `/proc/self/mountinfo` content and return the fstype of the mount
+/// point that contains `abs_path`.
+///
+/// mountinfo format (per `proc(5)`):
+/// ```text
+///   36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
+///   (1) (2) (3)   (4)   (5)      (6)    ...    -  (fstype)
+/// ```
+/// Field 5 is the mount point; after the `-` separator, the first field is
+/// the fstype. Optional fields (field 7+) vary, so split on `-`.
+///
+/// Picks the longest mount point that is a path-prefix of `abs_path`
+/// (so nested mounts like `/mnt/c/WINDOWS` inside `/mnt/c` win correctly).
+fn fstype_for_path(mountinfo: &str, abs_path: &Path) -> Option<String> {
+    let abs_str = abs_path.to_str()?;
+    let mut best: Option<(usize, String)> = None;
+    for line in mountinfo.lines() {
+        // Split on the ` - ` separator between variable-length and
+        // fixed fields. mountinfo guarantees the separator token is ` - `.
+        let (left, right) = match line.split_once(" - ") {
+            Some(parts) => parts,
+            None => continue,
+        };
+        let left_fields: Vec<&str> = left.split_whitespace().collect();
+        if left_fields.len() < 5 {
+            continue;
+        }
+        let mount_point = left_fields[4];
+        // mountinfo escapes space/tab/newline/backslash as \040, \011, \012, \134.
+        // For our purposes we only need to match exact prefixes; unescape \040
+        // since spaces in paths are the realistic case. Other escapes are rare
+        // enough to skip.
+        let mp = mount_point.replace("\\040", " ");
+        if !path_starts_with(abs_str, &mp) {
+            continue;
+        }
+        let right_fields: Vec<&str> = right.split_whitespace().collect();
+        let fstype = match right_fields.first() {
+            Some(t) => *t,
+            None => continue,
+        };
+        let len = mp.len();
+        if best.as_ref().is_none_or(|(blen, _)| len > *blen) {
+            best = Some((len, fstype.to_string()));
+        }
+    }
+    best.map(|(_, fs)| fs)
+}
+
+/// Check whether `path` begins with `prefix` at a path-component boundary.
+///
+/// A plain `str::starts_with` would match `/mnt/ca` against `/mnt/c` — wrong,
+/// since those are sibling mounts. The prefix matches only if `path == prefix`
+/// or `path` continues with `/` after the prefix. Also handles the special
+/// case where `prefix == "/"` (root mount) — always a prefix.
+fn path_starts_with(path: &str, prefix: &str) -> bool {
+    if prefix == "/" {
+        return path.starts_with('/');
+    }
+    if !path.starts_with(prefix) {
+        return false;
+    }
+    // Exact match or next char is a path separator.
+    path.len() == prefix.len() || path.as_bytes()[prefix.len()] == b'/'
+}
+
+#[cfg(test)]
+mod slow_fs_tests {
+    use super::{fstype_for_path, path_starts_with, SLOW_MMAP_FSTYPES};
+    use std::path::Path;
+
+    /// Realistic mountinfo snippet captured on WSL2 (Debian 13, kernel 6.6).
+    /// Rootfs is ext4, `/mnt/c` is 9P-over-drvfs, `/proc` and `/sys` are virtual.
+    const WSL_MOUNTINFO: &str = "\
+75 80 0:29 / /usr/lib/modules/6.6.87 rw,nosuid,nodev,noatime - overlay none rw,lowerdir=/modules
+80 65 8:48 / / rw,relatime - ext4 /dev/sdd rw,discard,errors=remount-ro
+111 80 0:22 / /sys rw,nosuid,nodev,noexec,noatime shared:15 - sysfs sysfs rw
+112 80 0:59 / /proc rw,nosuid,nodev,noexec,noatime shared:16 - proc proc rw
+135 80 0:73 / /mnt/c rw,noatime - 9p C:\\134 rw,aname=drvfs;path=C:\\
+136 80 0:74 / /mnt/d rw,noatime - 9p D:\\134 rw,aname=drvfs;path=D:\\
+";
+
+    #[test]
+    fn wsl_mnt_c_detected_as_9p() {
+        let fs = fstype_for_path(
+            WSL_MOUNTINFO,
+            Path::new("/mnt/c/Projects/cqs/.cqs/index.db"),
+        );
+        assert_eq!(fs.as_deref(), Some("9p"));
+        assert!(SLOW_MMAP_FSTYPES.contains(&"9p"));
+    }
+
+    #[test]
+    fn wsl_home_detected_as_ext4_not_slow() {
+        let fs = fstype_for_path(
+            WSL_MOUNTINFO,
+            Path::new("/home/user001/project/.cqs/index.db"),
+        );
+        assert_eq!(fs.as_deref(), Some("ext4"));
+        assert!(!SLOW_MMAP_FSTYPES.contains(&"ext4"));
+    }
+
+    #[test]
+    fn wsl_mnt_c_root_itself_matches() {
+        // Path exactly at mount point (edge case).
+        let fs = fstype_for_path(WSL_MOUNTINFO, Path::new("/mnt/c"));
+        assert_eq!(fs.as_deref(), Some("9p"));
+    }
+
+    #[test]
+    fn sibling_mount_not_matched() {
+        // `/mnt/ca` must not match mount `/mnt/c`. Without component-boundary
+        // checking, naive starts_with would incorrectly return "9p".
+        let info = "135 80 0:73 / /mnt/c rw,noatime - 9p C:\\134 rw\n80 65 8:48 / / rw - ext4 /dev/sdd rw\n";
+        let fs = fstype_for_path(info, Path::new("/mnt/ca/file"));
+        // Falls through to root ext4, not the /mnt/c 9p.
+        assert_eq!(fs.as_deref(), Some("ext4"));
+    }
+
+    #[test]
+    fn longest_prefix_wins_for_nested_mounts() {
+        // `/mnt/c/WINDOWS` nested inside `/mnt/c` — the nested mount fstype
+        // should win even though both are prefixes. Uses an artificial "cifs"
+        // for the nested mount to prove the longer match is picked.
+        let info = "\
+80 65 8:48 / / rw - ext4 /dev/sdd rw
+135 80 0:73 / /mnt/c rw - 9p C:\\134 rw
+200 135 0:99 / /mnt/c/WINDOWS rw - cifs //host/share rw
+";
+        let fs = fstype_for_path(info, Path::new("/mnt/c/WINDOWS/system32/a.db"));
+        assert_eq!(fs.as_deref(), Some("cifs"));
+    }
+
+    #[test]
+    fn handles_optional_fields_with_shared_tag() {
+        // mountinfo may have optional fields (shared:N, master:M) between
+        // mount opts and the `-` separator. Must still parse.
+        let info = "\
+76 80 0:32 / /some/mount rw,relatime shared:1 master:2 - 9p foo rw\n";
+        let fs = fstype_for_path(info, Path::new("/some/mount/file"));
+        assert_eq!(fs.as_deref(), Some("9p"));
+    }
+
+    #[test]
+    fn empty_or_garbage_mountinfo_returns_none() {
+        assert!(fstype_for_path("", Path::new("/any/path")).is_none());
+        assert!(fstype_for_path("not a mountinfo line\n", Path::new("/any/path")).is_none());
+        // Missing ` - ` separator.
+        assert!(fstype_for_path("80 65 8:48 / / rw ext4 /dev/sdd rw\n", Path::new("/")).is_none());
+    }
+
+    #[test]
+    fn native_linux_ext4_is_not_slow() {
+        // No WSL in sight — plain ext4 at root.
+        let info = "80 65 8:48 / / rw,relatime - ext4 /dev/sda1 rw\n";
+        let fs = fstype_for_path(info, Path::new("/home/alice/project/.cqs/index.db"));
+        assert_eq!(fs.as_deref(), Some("ext4"));
+        assert!(!SLOW_MMAP_FSTYPES.contains(&"ext4"));
+    }
+
+    #[test]
+    fn nfs_and_cifs_are_slow() {
+        let info = "\
+80 65 8:48 / / rw - ext4 /dev/sdd rw
+90 80 0:50 / /net/nfs rw - nfs server:/export rw
+91 80 0:51 / /net/smb rw - cifs //host/share rw
+";
+        assert_eq!(
+            fstype_for_path(info, Path::new("/net/nfs/index.db")).as_deref(),
+            Some("nfs")
+        );
+        assert_eq!(
+            fstype_for_path(info, Path::new("/net/smb/index.db")).as_deref(),
+            Some("cifs")
+        );
+        assert!(SLOW_MMAP_FSTYPES.contains(&"nfs"));
+        assert!(SLOW_MMAP_FSTYPES.contains(&"cifs"));
+    }
+
+    #[test]
+    fn path_starts_with_component_boundary() {
+        assert!(path_starts_with("/mnt/c/foo", "/mnt/c"));
+        assert!(path_starts_with("/mnt/c", "/mnt/c"));
+        assert!(!path_starts_with("/mnt/ca", "/mnt/c"));
+        assert!(!path_starts_with("/mnt", "/mnt/c"));
+        // Root is always a prefix of any absolute path.
+        assert!(path_starts_with("/anything", "/"));
+        assert!(path_starts_with("/", "/"));
+    }
+
+    #[test]
+    fn resolve_mmap_size_env_override_wins() {
+        // Env explicit set → returns that value, ignores slow-fs detection.
+        // Save/restore to stay neighbour-friendly with parallel tests that
+        // may inspect CQS_MMAP_SIZE.
+        let prev = std::env::var("CQS_MMAP_SIZE").ok();
+        std::env::set_var("CQS_MMAP_SIZE", "12345");
+        let got = super::resolve_mmap_size("268435456", Path::new("/mnt/c/any"));
+        assert_eq!(got, "12345");
+        match prev {
+            Some(v) => std::env::set_var("CQS_MMAP_SIZE", v),
+            None => std::env::remove_var("CQS_MMAP_SIZE"),
+        }
+    }
 }
 
 /// Read `CQS_SQLITE_CACHE_SIZE` env var, falling back to `default_kib`.
@@ -303,8 +603,8 @@ impl Store {
                 read_only: false,
                 use_current_thread: false,
                 max_connections,
-                mmap_size: mmap_size_from_env("268435456"), // 256MB default
-                cache_size: cache_size_from_env("-16384"),  // 16MB
+                mmap_size: resolve_mmap_size("268435456", path), // 256MB default
+                cache_size: cache_size_from_env("-16384"),       // 16MB
                 runtime: None,
             },
         )
@@ -326,7 +626,7 @@ impl Store {
                 read_only: true,
                 use_current_thread: true,
                 max_connections: 1,
-                mmap_size: mmap_size_from_env("268435456"),
+                mmap_size: resolve_mmap_size("268435456", path),
                 cache_size: cache_size_from_env("-16384"),
                 runtime: None,
             },
@@ -343,8 +643,8 @@ impl Store {
                 read_only: true,
                 use_current_thread: true,
                 max_connections: 1,
-                mmap_size: mmap_size_from_env("67108864"), // 64MB default
-                cache_size: cache_size_from_env("-4096"),  // 4MB
+                mmap_size: resolve_mmap_size("67108864", path), // 64MB default
+                cache_size: cache_size_from_env("-4096"),       // 4MB
                 runtime: None,
             },
         )
@@ -362,7 +662,7 @@ impl Store {
                 read_only: true,
                 use_current_thread: true,
                 max_connections: 1,
-                mmap_size: mmap_size_from_env("268435456"),
+                mmap_size: resolve_mmap_size("268435456", path),
                 cache_size: cache_size_from_env("-16384"),
                 runtime: Some(runtime),
             },


### PR DESCRIPTION
## Summary

Wave A of the post-audit pull list — 3 tier-1 quick wins, implemented by 3 parallel worktree-isolated opus agents.

### Closes

- **#961** — WSL 9P/NTFS mmap auto-detect
- **#963** — Reranker batch chunking
- **#962** — CAGRA itopk + graph_degree env overrides with corpus-size scaling

## #961 — WSL 9P/NTFS mmap auto-detect

**Problem:** On WSL `/mnt/c/...` (9P/DrvFS/NTFS), SQLite `mmap_size > 0` produces real performance degradation — every page fault crosses the 9P boundary. Daily slow-eval pain today is traceable to this.

**Fix:** At Store-open time, detect whether the DB path lives on a slow-mmap filesystem (9p, drvfs, fuse.drvfs, cifs, smb3, smbfs, nfs, nfs4, ntfs, ntfs3, fuseblk). If so, auto-set `mmap_size=0` unless the user explicitly set `CQS_MMAP_SIZE` (explicit wins).

- New `is_slow_mmap_fs(path)` reads `/proc/self/mountinfo`, finds the longest mount-point prefix, checks fstype.
- New `fstype_for_path(mountinfo, path)` is the pure string parser — testable without filesystem access.
- Log at `info` level on slow-FS detection with override hint.
- **11 unit tests** covering mount-boundary edge cases, sibling mounts, nested mounts, native Linux, NFS/CIFS.

## #963 — Reranker batch chunking

**Problem:** Reranker fed the whole candidate set to a single ORT `session.run()`. With `k=100`, `max_length=512`, that's a `[100, 512]` token tensor that OOMs on small GPUs or after SPLADE claims VRAM. No configurable cap existed (compare embed path's `CQS_EMBED_BATCH_SIZE`).

**Fix:** Tokenize all pairs up front, iterate `encodings.chunks(CQS_RERANKER_BATCH)` (default 32), run per-chunk. Per-chunk `max_len` = longest encoding in the chunk, capped at `self.max_length` — short chunks allocate smaller tensors. Mirrors `embed_documents`.

## #962 — CAGRA itopk + graph_degree env overrides with corpus-size scaling

**Problem:** CAGRA `itopk_size` hardcoded to `(k*2).clamp(128, 512)`. On a 500k-chunk index with `k=100`, only 200 candidates searched → recall collapses. This is the concrete proposal for the known v1.24.0 CAGRA filtering regression.

**Fix:** 4 env vars with corpus-aware defaults:
- `CQS_CAGRA_ITOPK_MIN` (default 128)
- `CQS_CAGRA_ITOPK_MAX` (default `(log2(n_vectors) * 32).clamp(128, 4096)` — scales from 320 @1k to 744 @10M)
- `CQS_CAGRA_GRAPH_DEGREE` (default 64)
- `CQS_CAGRA_INTERMEDIATE_GRAPH_DEGREE` (default 128)

Both `build()` and `build_from_flat()` now funnel through `cagra_build_params()` — no more bare `IndexParams::new()` in the build path.

## Test plan

- [x] `cargo build --release --features gpu-index` clean
- [x] `cargo fmt` clean
- [x] `cargo clippy --features gpu-index -- -D warnings` clean (each agent's worktree verified)
- [ ] Full `cargo test --lib` run (CI)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
