### PR TITLE
refactor(#946): Store<ReadOnly>/Store<ReadWrite> typestate

### DIFF
--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -493,7 +493,10 @@ impl CagraIndex {
     /// so we can't stream incrementally like HNSW. However, we stream from
     /// SQLite to avoid double-buffering in memory.
     /// Notes are excluded — they use brute-force search from SQLite.
-    pub fn build_from_store(store: &crate::Store, dim: usize) -> Result<Self, CagraError> {
+    pub fn build_from_store<Mode>(
+        store: &crate::Store<Mode>,
+        dim: usize,
+    ) -> Result<Self, CagraError> {
         let _span = tracing::debug_span!("cagra_build_from_store").entered();
         let chunk_count = store
             .chunk_count()

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -64,8 +64,8 @@ pub struct CiReport {
 /// 1. `review_diff()` — impact analysis + risk scoring + notes + staleness
 /// 2. `find_dead_code()` — filtered to files touched by the diff
 /// 3. Gate evaluation — configurable threshold
-pub fn run_ci_analysis(
-    store: &Store,
+pub fn run_ci_analysis<Mode>(
+    store: &Store<Mode>,
     diff_text: &str,
     root: &Path,
     threshold: GateThreshold,

--- a/src/cli/batch/handlers/analysis.rs
+++ b/src/cli/batch/handlers/analysis.rs
@@ -96,32 +96,31 @@ pub(in crate::cli::batch) fn dispatch_health(ctx: &BatchContext) -> Result<serde
     Ok(serde_json::to_value(&report)?)
 }
 
-/// Suggests notes from codebase patterns and optionally applies them.
+/// Suggests notes from codebase patterns. `--apply` is rejected on the
+/// daemon path.
+///
+/// The daemon holds a `Store<ReadOnly>`, so the reindex half of
+/// `--apply` (which goes through `index_notes` → `replace_notes_for_file`)
+/// cannot compile here. `Commands::Suggest` is classified as
+/// `BatchSupport::Cli` precisely because of this — a user who runs
+/// `cqs suggest --apply` falls through to the CLI path, which opens a
+/// `Store<ReadWrite>`. Bailing when `apply=true` documents that
+/// invariant instead of silently producing a stale (unapplied) result.
 pub(in crate::cli::batch) fn dispatch_suggest(
     ctx: &BatchContext,
     apply: bool,
 ) -> Result<serde_json::Value> {
     let _span = tracing::info_span!("batch_suggest", apply).entered();
 
-    let suggestions = cqs::suggest::suggest_notes(&ctx.store(), &ctx.root)?;
-
-    if apply && !suggestions.is_empty() {
-        let notes_path = ctx.root.join("docs/notes.toml");
-        let entries: Vec<cqs::NoteEntry> = suggestions
-            .iter()
-            .map(|s| cqs::NoteEntry {
-                sentiment: s.sentiment,
-                text: s.text.clone(),
-                mentions: s.mentions.clone(),
-            })
-            .collect();
-        cqs::rewrite_notes_file(&notes_path, |notes| {
-            notes.extend(entries);
-            Ok(())
-        })?;
-        let notes = cqs::parse_notes(&notes_path)?;
-        cqs::index_notes(&notes, &notes_path, &ctx.store())?;
+    if apply {
+        anyhow::bail!(
+            "suggest --apply requires a writable store; run `cqs suggest --apply` outside \
+             the daemon. (Commands::Suggest is BatchSupport::Cli; reaching this branch \
+             means a classifier regressed — see #946.)"
+        );
     }
+
+    let suggestions = cqs::suggest::suggest_notes(&ctx.store(), &ctx.root)?;
 
     let json_val: Vec<_> = suggestions
         .iter()
@@ -138,7 +137,7 @@ pub(in crate::cli::batch) fn dispatch_suggest(
     Ok(serde_json::json!({
         "suggestions": json_val,
         "total": suggestions.len(),
-        "applied": apply,
+        "applied": false,
     }))
 }
 

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -417,36 +417,24 @@ pub(in crate::cli::batch) fn dispatch_plan(
 }
 
 /// Runs garbage collection on the index.
-/// In batch mode, GC skips HNSW rebuild (the batch session holds the index)
-/// and reports what was pruned.
-pub(in crate::cli::batch) fn dispatch_gc(ctx: &BatchContext) -> Result<serde_json::Value> {
+///
+/// **Not available via the daemon path.** GC mutates the DB
+/// (chunks/calls/type_edges/summaries/sparse_vectors pruning), but the
+/// daemon only opens a `Store<ReadOnly>`. The typestate refactor in
+/// GitHub #946 makes this a compile-time invariant: `prune_all` is on
+/// `impl Store<ReadWrite>` so the daemon path cannot accidentally
+/// call it. Returns an error instructing the user to run `cqs gc`
+/// directly; the dispatcher in `cli/dispatch.rs` already classifies
+/// `Commands::Gc` as `BatchSupport::Cli` so this branch is unreachable
+/// in practice, but the stub exists to keep the batch command surface
+/// complete and to document the invariant.
+pub(in crate::cli::batch) fn dispatch_gc(_ctx: &BatchContext) -> Result<serde_json::Value> {
     let _span = tracing::info_span!("batch_gc").entered();
-
-    let file_set = ctx.file_set()?;
-    let (stale_count, missing_count) = match ctx.store().count_stale_files(&file_set, &ctx.root) {
-        Ok(counts) => counts,
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to count stale files");
-            (0, 0)
-        }
-    };
-
-    let prune = ctx
-        .store()
-        .prune_all(&file_set, &ctx.root)
-        .context("Failed to prune stale entries from index")?;
-
-    let output = crate::cli::commands::GcOutput {
-        stale_files: stale_count as usize,
-        missing_files: missing_count as usize,
-        pruned_chunks: prune.pruned_chunks as usize,
-        pruned_calls: prune.pruned_calls as usize,
-        pruned_type_edges: prune.pruned_type_edges as usize,
-        pruned_summaries: prune.pruned_summaries,
-        hnsw_rebuilt: false,
-        hnsw_vectors: None,
-    };
-    Ok(serde_json::to_value(&output)?)
+    anyhow::bail!(
+        "gc requires a writable store; run `cqs gc` outside the daemon. \
+         (Commands::Gc is BatchSupport::Cli in dispatch.rs; reaching this \
+         branch means a daemon classifier regressed — see #946.)"
+    )
 }
 
 /// Manually invalidates all mutable caches and re-opens the Store.

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -1394,7 +1394,7 @@ mod tests {
     // TC-7: sanitize_json_floats is no-op on clean values
     #[test]
     fn test_sanitize_json_floats_clean_passthrough() {
-        let mut val = serde_json::json!({"a": 1, "b": "text", "c": [true, null, 3.14]});
+        let mut val = serde_json::json!({"a": 1, "b": "text", "c": [true, null, 2.5]});
         let expected = val.clone();
         sanitize_json_floats(&mut val);
         assert_eq!(val, expected);

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -29,7 +29,7 @@ use clap::Parser;
 use cqs::embedder::ModelConfig;
 use cqs::index::VectorIndex;
 use cqs::reference::ReferenceIndex;
-use cqs::store::Store;
+use cqs::store::{ReadOnly, Store};
 use cqs::Embedder;
 
 use super::open_project_store_readonly;
@@ -170,7 +170,13 @@ const STALENESS_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_
 pub(crate) struct BatchContext {
     // Wrapped in RefCell so we can re-open it when the index changes.
     // Access via store() method which checks staleness first.
-    store: RefCell<Store>,
+    //
+    // #946 typestate: BatchContext is the daemon's shared store, which only
+    // ever dispatches read-only queries (daemon handlers never mutate). The
+    // compiler refuses to call a write method on a `Store<ReadOnly>`, so
+    // the class of runtime errors from PR #945 / #944 / dispatch_gc is
+    // structurally impossible on this path.
+    store: RefCell<Store<ReadOnly>>,
     // Stable caches — keep OnceLock (not index-derived)
     //
     // RM-V1.25-28: `OnceLock<Arc<Embedder>>` so the watch outer scope
@@ -428,7 +434,7 @@ impl BatchContext {
     }
 
     /// Borrow the Store, checking for index staleness first.
-    pub fn store(&self) -> std::cell::Ref<'_, Store> {
+    pub fn store(&self) -> std::cell::Ref<'_, Store<ReadOnly>> {
         self.check_index_staleness();
         self.store.borrow()
     }
@@ -839,8 +845,8 @@ impl BatchContext {
 }
 
 /// Build the best available vector index for the store.
-fn build_vector_index(
-    store: &Store,
+fn build_vector_index<Mode: crate::cli::store::ClearHnswDirty>(
+    store: &Store<Mode>,
     cqs_dir: &std::path::Path,
     ef_search: Option<usize>,
 ) -> Result<Option<Box<dyn VectorIndex>>> {
@@ -990,7 +996,7 @@ fn create_test_context(cqs_dir: &std::path::Path) -> Result<BatchContext> {
     let index_id = DbFileIdentity::from_path(&index_path);
 
     Ok(BatchContext {
-        store: RefCell::new(store),
+        store: RefCell::new(store.into_readonly()),
         embedder: OnceLock::new(),
         config: OnceLock::new(),
         reranker: OnceLock::new(),

--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -65,7 +65,7 @@ pub(crate) fn build_callees(name: &str, callees: &[(String, u32)]) -> CalleesOut
 
 /// Find functions that call the specified function
 pub(crate) fn cmd_callers(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     name: &str,
     cross_project: bool,
     json: bool,
@@ -145,7 +145,7 @@ pub(crate) fn cmd_callers(
 
 /// Find functions called by the specified function
 pub(crate) fn cmd_callees(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     name: &str,
     cross_project: bool,
     json: bool,

--- a/src/cli/commands/graph/deps.rs
+++ b/src/cli/commands/graph/deps.rs
@@ -72,7 +72,7 @@ pub(crate) fn build_deps_forward(users: &[ChunkSummary], root: &Path) -> Vec<Dep
 /// Forward (default): `cqs deps Config` -- who uses this type?
 /// Reverse: `cqs deps --reverse func_name` -- what types does this function use?
 pub(crate) fn cmd_deps(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     name: &str,
     reverse: bool,
     cross_project: bool,

--- a/src/cli/commands/graph/explain.rs
+++ b/src/cli/commands/graph/explain.rs
@@ -39,8 +39,8 @@ pub(crate) struct ExplainData {
 ///   to load fresh).
 /// * `embedder` — required only when `max_tokens` is `Some`. Batch passes its cached one;
 ///   CLI passes `None` to create a fresh one internally.
-pub(crate) fn build_explain_data(
-    store: &Store,
+pub(crate) fn build_explain_data<Mode>(
+    store: &Store<Mode>,
     cqs_dir: &Path,
     target: &str,
     max_tokens: Option<usize>,
@@ -301,7 +301,7 @@ pub(crate) fn build_explain_output(data: &ExplainData, root: &Path) -> ExplainOu
 // ─── CLI command ────────────────────────────────────────────────────────────
 
 pub(crate) fn cmd_explain(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     target: &str,
     json: bool,
     max_tokens: Option<usize>,

--- a/src/cli/commands/graph/impact.rs
+++ b/src/cli/commands/graph/impact.rs
@@ -11,7 +11,7 @@ use crate::cli::commands::resolve::resolve_target;
 use crate::cli::OutputFormat;
 
 pub(crate) fn cmd_impact(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     name: &str,
     depth: usize,
     format: &OutputFormat,

--- a/src/cli/commands/graph/impact_diff.rs
+++ b/src/cli/commands/graph/impact_diff.rs
@@ -19,7 +19,7 @@ fn empty_impact_json() -> serde_json::Value {
 }
 
 pub(crate) fn cmd_impact_diff(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     base: Option<&str>,
     from_stdin: bool,
     json: bool,

--- a/src/cli/commands/graph/test_map.rs
+++ b/src/cli/commands/graph/test_map.rs
@@ -178,7 +178,7 @@ pub(crate) fn build_test_map_output(target_name: &str, matches: &[TestMatch]) ->
 // ─── CLI command ────────────────────────────────────────────────────────────
 
 pub(crate) fn cmd_test_map(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     name: &str,
     max_depth: usize,
     cross_project: bool,

--- a/src/cli/commands/graph/trace.rs
+++ b/src/cli/commands/graph/trace.rs
@@ -39,8 +39,8 @@ pub(crate) struct TraceOutput {
 ///
 /// Shared between CLI (`cmd_trace --json`) and batch (`dispatch_trace`).
 /// Takes the BFS path (or None) and resolves chunk metadata via batch lookup.
-pub(crate) fn build_trace_output(
-    store: &Store,
+pub(crate) fn build_trace_output<Mode>(
+    store: &Store<Mode>,
     source_name: &str,
     target_name: &str,
     path: Option<&[String]>,
@@ -97,7 +97,7 @@ pub(crate) fn build_trace_output(
 // ─── CLI command ────────────────────────────────────────────────────────────
 
 pub(crate) fn cmd_trace(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     source: &str,
     target: &str,
     max_depth: usize,
@@ -288,7 +288,11 @@ pub(crate) fn cmd_trace(
 }
 
 /// Format trace path as Mermaid graph TD diagram
-fn format_mermaid(store: &Store, root: &std::path::Path, names: &[String]) -> Result<()> {
+fn format_mermaid<Mode>(
+    store: &Store<Mode>,
+    root: &std::path::Path,
+    names: &[String],
+) -> Result<()> {
     println!("graph TD");
 
     // CQ-5: Batch lookup instead of N individual search_by_name calls

--- a/src/cli/commands/index/mod.rs
+++ b/src/cli/commands/index/mod.rs
@@ -8,6 +8,6 @@ mod stats;
 pub(crate) use build::{
     build_hnsw_base_index, build_hnsw_index, build_hnsw_index_owned, cmd_index,
 };
-pub(crate) use gc::{cmd_gc, GcOutput};
+pub(crate) use gc::cmd_gc;
 pub(crate) use stale::{build_stale, cmd_stale};
 pub(crate) use stats::{build_stats, cmd_stats};

--- a/src/cli/commands/index/stale.rs
+++ b/src/cli/commands/index/stale.rs
@@ -71,7 +71,7 @@ pub(crate) fn build_stale(report: &StaleReport) -> StaleOutput {
 
 /// Report stale (modified) and missing files in the index
 pub(crate) fn cmd_stale(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     json: bool,
     count_only: bool,
 ) -> Result<()> {

--- a/src/cli/commands/index/stats.rs
+++ b/src/cli/commands/index/stats.rs
@@ -63,7 +63,7 @@ pub(crate) struct StatsOutput {
 /// Contains: total_chunks, total_files, notes, call_graph, type_graph,
 /// by_language, by_type, model, schema_version.
 /// Callers add context-specific fields (stale_files, errors, etc.).
-pub(crate) fn build_stats(store: &cqs::Store) -> Result<StatsOutput> {
+pub(crate) fn build_stats<Mode>(store: &cqs::Store<Mode>) -> Result<StatsOutput> {
     let _span = tracing::info_span!("build_stats").entered();
     let stats = store.stats().context("Failed to read index statistics")?;
     let note_count = store.note_count()?;
@@ -195,7 +195,10 @@ fn print_stats_text(output: &StatsOutput) {
 // ---------------------------------------------------------------------------
 
 /// Display index statistics (chunk counts, languages, types)
-pub(crate) fn cmd_stats(ctx: &crate::cli::CommandContext, json: bool) -> Result<()> {
+pub(crate) fn cmd_stats(
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
+    json: bool,
+) -> Result<()> {
     let _span = tracing::info_span!("cmd_stats").entered();
     let store = &ctx.store;
     let root = &ctx.root;

--- a/src/cli/commands/io/blame.rs
+++ b/src/cli/commands/io/blame.rs
@@ -32,8 +32,8 @@ pub(crate) struct BlameData {
 
 /// Build blame data: resolve target, run git log -L, parse commits, optionally
 /// fetch callers.
-pub(crate) fn build_blame_data(
-    store: &Store,
+pub(crate) fn build_blame_data<Mode>(
+    store: &Store<Mode>,
     root: &Path,
     target: &str,
     depth: usize,
@@ -286,7 +286,7 @@ fn print_blame_terminal(data: &BlameData, root: &Path) {
 // ─── CLI command ─────────────────────────────────────────────────────────────
 
 pub(crate) fn cmd_blame(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     target: &str,
     depth: usize,
     show_callers: bool,
@@ -375,7 +375,7 @@ mod tests {
                 language: cqs::language::Language::Rust,
                 chunk_type: cqs::language::ChunkType::Function,
                 name: "resolve_target".to_string(),
-                signature: "pub fn resolve_target(store: &Store, target: &str)".to_string(),
+                signature: "pub fn resolve_target(store: &Store<Mode>, target: &str)".to_string(),
                 content: String::new(),
                 doc: None,
                 line_start: 23,

--- a/src/cli/commands/io/brief.rs
+++ b/src/cli/commands/io/brief.rs
@@ -34,7 +34,7 @@ struct BriefData {
 }
 
 /// Build brief data for a file: load chunks, count callers and test coverage.
-fn build_brief_data(store: &Store, path: &str) -> Result<BriefData> {
+fn build_brief_data<Mode>(store: &Store<Mode>, path: &str) -> Result<BriefData> {
     let _span = tracing::info_span!("build_brief_data", path).entered();
 
     let chunks = store
@@ -109,7 +109,11 @@ fn build_brief_data(store: &Store, path: &str) -> Result<BriefData> {
     })
 }
 
-pub(crate) fn cmd_brief(ctx: &crate::cli::CommandContext, path: &str, json: bool) -> Result<()> {
+pub(crate) fn cmd_brief(
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
+    path: &str,
+    json: bool,
+) -> Result<()> {
     let _span = tracing::info_span!("cmd_brief", path).entered();
     let store = &ctx.store;
     let root = &ctx.root;

--- a/src/cli/commands/io/context.rs
+++ b/src/cli/commands/io/context.rs
@@ -22,7 +22,7 @@ pub(crate) struct CompactData {
 }
 
 /// Build compact-mode data: chunks with caller/callee counts.
-pub(crate) fn build_compact_data(store: &Store, path: &str) -> Result<CompactData> {
+pub(crate) fn build_compact_data<Mode>(store: &Store<Mode>, path: &str) -> Result<CompactData> {
     let _span = tracing::info_span!("build_compact_data", path).entered();
     let chunks = store
         .get_chunks_by_origin(path)
@@ -105,7 +105,11 @@ pub(crate) struct FullData {
 
 /// Build full-mode data: chunks with external callers/callees/dependent files.
 /// Shared between CLI summary mode (uses counts) and full mode (uses details).
-pub(crate) fn build_full_data(store: &Store, path: &str, root: &Path) -> Result<FullData> {
+pub(crate) fn build_full_data<Mode>(
+    store: &Store<Mode>,
+    path: &str,
+    root: &Path,
+) -> Result<FullData> {
     let _span = tracing::info_span!("build_full_data", path).entered();
     let chunks = store
         .get_chunks_by_origin(path)
@@ -323,7 +327,7 @@ pub(crate) fn pack_by_relevance(
 // ─── CLI command ────────────────────────────────────────────────────────────
 
 pub(crate) fn cmd_context(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     path: &str,
     json: bool,
     summary: bool,
@@ -388,8 +392,8 @@ pub(crate) fn cmd_context(
 
 /// Build token-packed content set if max_tokens is requested.
 #[allow(clippy::type_complexity)]
-fn build_token_pack(
-    store: &Store,
+fn build_token_pack<Mode>(
+    store: &Store<Mode>,
     chunks: &[ChunkSummary],
     max_tokens: Option<usize>,
     model_config: &cqs::embedder::ModelConfig,

--- a/src/cli/commands/io/notes.rs
+++ b/src/cli/commands/io/notes.rs
@@ -103,7 +103,10 @@ pub(crate) enum NotesCommand {
 }
 
 /// Handle `notes list` — requires a readonly CommandContext for staleness checks.
-pub(crate) fn cmd_notes(ctx: &crate::cli::CommandContext, subcmd: &NotesCommand) -> Result<()> {
+pub(crate) fn cmd_notes(
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
+    subcmd: &NotesCommand,
+) -> Result<()> {
     let _span = tracing::info_span!("cmd_notes").entered();
     match subcmd {
         NotesCommand::List {
@@ -448,7 +451,7 @@ fn cmd_notes_remove(cli: &Cli, text: &str, no_reindex: bool) -> Result<()> {
 
 /// List notes from docs/notes.toml
 fn cmd_notes_list(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     warnings_only: bool,
     patterns_only: bool,
     json: bool,

--- a/src/cli/commands/io/read.rs
+++ b/src/cli/commands/io/read.rs
@@ -109,8 +109,8 @@ pub(crate) struct FocusedReadResult {
 
 /// Build focused-read output: header + hints + notes + target + type deps.
 /// Shared between CLI `cmd_read --focus` and batch `dispatch_read --focus`.
-pub(crate) fn build_focused_output(
-    store: &Store,
+pub(crate) fn build_focused_output<Mode>(
+    store: &Store<Mode>,
     focus: &str,
     root: &Path,
     audit_state: &cqs::audit::AuditMode,
@@ -290,7 +290,7 @@ struct FocusedReadJsonOutput {
 // ─── CLI commands ───────────────────────────────────────────────────────────
 
 pub(crate) fn cmd_read(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     path: &str,
     focus: Option<&str>,
     json: bool,
@@ -339,7 +339,11 @@ pub(crate) fn cmd_read(
     Ok(())
 }
 
-fn cmd_read_focused(ctx: &crate::cli::CommandContext, focus: &str, json: bool) -> Result<()> {
+fn cmd_read_focused(
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
+    focus: &str,
+    json: bool,
+) -> Result<()> {
     let _span = tracing::info_span!("cmd_read_focused", %focus).entered();
 
     let store = &ctx.store;

--- a/src/cli/commands/io/reconstruct.rs
+++ b/src/cli/commands/io/reconstruct.rs
@@ -20,7 +20,7 @@ struct ReconstructOutput {
 }
 
 pub(crate) fn cmd_reconstruct(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     path: &str,
     json: bool,
 ) -> Result<()> {

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -76,7 +76,6 @@ pub(crate) use index::cmd_gc;
 pub(crate) use index::cmd_index;
 pub(crate) use index::cmd_stale;
 pub(crate) use index::cmd_stats;
-pub(crate) use index::GcOutput;
 
 // -- io --
 pub(crate) use io::cmd_blame;

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -123,8 +123,8 @@ pub(crate) use train::cmd_train_pairs;
 ///
 /// `named_items` is a list of `(name, score)` pairs. Content is fetched from `store` via
 /// `get_chunks_by_names_batch`. Items without content in the store are silently dropped.
-pub(crate) fn fetch_and_pack_content(
-    store: &cqs::Store,
+pub(crate) fn fetch_and_pack_content<Mode>(
+    store: &cqs::Store<Mode>,
     embedder: &cqs::Embedder,
     named_items: &[(String, f32)],
     budget: usize,

--- a/src/cli/commands/resolve.rs
+++ b/src/cli/commands/resolve.rs
@@ -9,13 +9,14 @@ use std::path::Path;
 use anyhow::Result;
 use cqs::config::Config;
 use cqs::reference::{self, ReferenceIndex};
-use cqs::store::Store;
+use cqs::store::{ReadOnly, Store};
 use cqs::ResolvedTarget;
 
 /// Resolve a target string to a [`ResolvedTarget`] (CLI wrapper).
 ///
 /// Wraps the library's `resolve_target` with anyhow error conversion.
-pub fn resolve_target(store: &Store, target: &str) -> Result<ResolvedTarget> {
+/// Generic over the store's typestate — resolution is a pure query.
+pub fn resolve_target<Mode>(store: &Store<Mode>, target: &str) -> Result<ResolvedTarget> {
     let _span = tracing::info_span!("resolve_target", target).entered();
     Ok(cqs::resolve_target(store, target)?)
 }
@@ -81,7 +82,10 @@ pub(crate) fn resolve_reference_store(root: &Path, ref_name: &str) -> Result<Sto
 }
 
 /// Like [`resolve_reference_store`] but opens the store in read-only mode.
-pub(crate) fn resolve_reference_store_readonly(root: &Path, ref_name: &str) -> Result<Store> {
+pub(crate) fn resolve_reference_store_readonly(
+    root: &Path,
+    ref_name: &str,
+) -> Result<Store<ReadOnly>> {
     use anyhow::Context;
     let ref_db = resolve_reference_db(root, ref_name)?;
     Store::open_readonly(&ref_db)

--- a/src/cli/commands/review/affected.rs
+++ b/src/cli/commands/review/affected.rs
@@ -23,7 +23,7 @@ fn risk_label(level: &RiskLevel) -> colored::ColoredString {
 }
 
 pub(crate) fn cmd_affected(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     base: Option<&str>,
     json: bool,
 ) -> Result<()> {

--- a/src/cli/commands/review/ci.rs
+++ b/src/cli/commands/review/ci.rs
@@ -7,7 +7,7 @@ use cqs::ReviewResult;
 use cqs::RiskLevel;
 
 pub(crate) fn cmd_ci(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     base: Option<&str>,
     from_stdin: bool,
     format: &crate::cli::OutputFormat,

--- a/src/cli/commands/review/dead.rs
+++ b/src/cli/commands/review/dead.rs
@@ -74,7 +74,7 @@ pub(crate) fn build_dead_output(
 
 /// Find functions/methods with no callers in the indexed codebase
 pub(crate) fn cmd_dead(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     json: bool,
     include_pub: bool,
     min_level: DeadConfidence,

--- a/src/cli/commands/review/diff_review.rs
+++ b/src/cli/commands/review/diff_review.rs
@@ -6,7 +6,7 @@ use cqs::ReviewResult;
 use cqs::RiskLevel;
 
 pub(crate) fn cmd_review(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     base: Option<&str>,
     from_stdin: bool,
     format: &crate::cli::OutputFormat,

--- a/src/cli/commands/review/health.rs
+++ b/src/cli/commands/review/health.rs
@@ -7,7 +7,10 @@ use colored::Colorize;
 
 use cqs::Parser;
 
-pub(crate) fn cmd_health(ctx: &crate::cli::CommandContext, json: bool) -> Result<()> {
+pub(crate) fn cmd_health(
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
+    json: bool,
+) -> Result<()> {
     let _span = tracing::info_span!("cmd_health").entered();
 
     let store = &ctx.store;

--- a/src/cli/commands/review/suggest.rs
+++ b/src/cli/commands/review/suggest.rs
@@ -65,7 +65,11 @@ pub(crate) fn build_suggest_output(
 // CLI command
 // ---------------------------------------------------------------------------
 
-pub(crate) fn cmd_suggest(ctx: &crate::cli::CommandContext, json: bool, apply: bool) -> Result<()> {
+pub(crate) fn cmd_suggest(
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
+    json: bool,
+    apply: bool,
+) -> Result<()> {
     let _span = tracing::info_span!("cmd_suggest", apply).entered();
 
     let store = &ctx.store;
@@ -84,12 +88,12 @@ pub(crate) fn cmd_suggest(ctx: &crate::cli::CommandContext, json: bool, apply: b
 
     if json {
         if apply {
-            apply_suggestions(&suggestions, root, store)?;
+            apply_suggestions(&suggestions, root, &ctx.cqs_dir)?;
         }
         let output = build_suggest_output(&suggestions, apply);
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else if apply {
-        apply_suggestions(&suggestions, root, store)?;
+        apply_suggestions(&suggestions, root, &ctx.cqs_dir)?;
         println!(
             "Applied {} suggestion{}.",
             suggestions.len(),
@@ -117,11 +121,19 @@ pub(crate) fn cmd_suggest(ctx: &crate::cli::CommandContext, json: bool, apply: b
     Ok(())
 }
 
-/// Applies suggested notes to the notes file and re-indexes them in the store.
+/// Applies suggested notes to the notes file and re-indexes them.
+///
+/// The `CommandContext` holds a `Store<ReadOnly>` (suggest is a Group B
+/// read-only command), but `--apply` needs to write. This helper opens
+/// a scoped `Store<ReadWrite>` just for the reindex, mirroring the
+/// pattern used by `cmd_gc` and `cmd_notes_mutate`. The typestate
+/// enforces that the write path compiles only when we explicitly
+/// promote the store; an accidental call to a write method on `ctx.store`
+/// is now a compile error.
 fn apply_suggestions(
     suggestions: &[cqs::suggest::SuggestedNote],
     root: &std::path::Path,
-    store: &cqs::Store,
+    cqs_dir: &std::path::Path,
 ) -> Result<()> {
     let notes_path = root.join("docs/notes.toml");
 
@@ -138,9 +150,13 @@ fn apply_suggestions(
         Ok(())
     })?;
 
-    // Re-index notes
+    // Re-index notes. Opens a read-write store for the mutation — the
+    // CLI already holds a read-only handle via CommandContext, but the
+    // #946 typestate won't let us use it here.
+    let index_path = cqs_dir.join("index.db");
+    let rw_store = cqs::Store::open(&index_path)?;
     let notes = cqs::parse_notes(&notes_path)?;
-    cqs::index_notes(&notes, &notes_path, store)?;
+    cqs::index_notes(&notes, &notes_path, &rw_store)?;
 
     Ok(())
 }

--- a/src/cli/commands/search/gather.rs
+++ b/src/cli/commands/search/gather.rs
@@ -64,7 +64,7 @@ pub(crate) fn build_gather_output(
 
 /// Infrastructure context for gather commands.
 pub(crate) struct GatherContext<'a> {
-    pub ctx: &'a crate::cli::CommandContext<'a>,
+    pub ctx: &'a crate::cli::CommandContext<'a, cqs::store::ReadOnly>,
     pub query: &'a str,
     pub expand: usize,
     pub direction: GatherDirection,

--- a/src/cli/commands/search/neighbors.rs
+++ b/src/cli/commands/search/neighbors.rs
@@ -70,8 +70,8 @@ fn dot(a: &[f32], b: &[f32]) -> f32 {
 }
 
 /// Find top-K nearest neighbors by brute-force cosine similarity.
-fn find_neighbors(
-    store: &Store,
+fn find_neighbors<Mode>(
+    store: &Store<Mode>,
     target: &ChunkSummary,
     limit: usize,
 ) -> Result<Vec<(ChunkSummary, f32)>> {
@@ -127,8 +127,8 @@ fn find_neighbors(
 }
 
 /// Fetch ChunkSummary for a set of chunk IDs.
-fn fetch_chunk_summaries(
-    store: &Store,
+fn fetch_chunk_summaries<Mode>(
+    store: &Store<Mode>,
     ids: &[&str],
 ) -> Result<std::collections::HashMap<String, ChunkSummary>> {
     // Group IDs by origin (file) and fetch per-file, then filter
@@ -153,7 +153,7 @@ fn fetch_chunk_summaries(
 // ─── CLI command ───────────────────────────────────────────────────────────
 
 pub(crate) fn cmd_neighbors(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     name: &str,
     limit: usize,
     json: bool,

--- a/src/cli/commands/search/onboard.rs
+++ b/src/cli/commands/search/onboard.rs
@@ -6,7 +6,7 @@ use colored::Colorize;
 use cqs::onboard;
 
 pub(crate) fn cmd_onboard(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     concept: &str,
     depth: usize,
     json: bool,

--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -41,7 +41,10 @@ fn emit_empty_results(query: &str, json: bool, context: Option<&str>) -> ! {
 }
 
 /// Execute a semantic search query and display results
-pub(crate) fn cmd_query(ctx: &crate::cli::CommandContext, query: &str) -> Result<()> {
+pub(crate) fn cmd_query(
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
+    query: &str,
+) -> Result<()> {
     let query_preview = if query.len() > 200 {
         // Find a valid UTF-8 boundary near 200 bytes
         let mut end = 200;
@@ -268,7 +271,7 @@ struct QueryContext<'a> {
     query: &'a str,
     query_embedding: &'a Embedding,
     filter: &'a SearchFilter,
-    store: &'a Store,
+    store: &'a Store<cqs::store::ReadOnly>,
     cqs_dir: &'a std::path::Path,
     root: &'a std::path::Path,
     embedder: &'a Embedder,
@@ -580,9 +583,9 @@ fn rerank_unified(
 }
 
 /// Name-only search: find by function/struct name, no embedding needed
-fn cmd_query_name_only(
+fn cmd_query_name_only<Mode>(
     cli: &Cli,
-    store: &Store,
+    store: &Store<Mode>,
     query: &str,
     root: &std::path::Path,
 ) -> Result<()> {
@@ -771,9 +774,9 @@ fn cmd_query_ref_name_only(
 ///
 /// For table chunks: parent is a stored section chunk → fetch from DB.
 /// For windowed chunks: parent was never stored → read source file at line range.
-fn resolve_parent_context(
+fn resolve_parent_context<Mode>(
     results: &[UnifiedResult],
-    store: &Store,
+    store: &Store<Mode>,
     root: &std::path::Path,
 ) -> HashMap<String, ParentContext> {
     let mut parents = HashMap::new();

--- a/src/cli/commands/search/related.rs
+++ b/src/cli/commands/search/related.rs
@@ -59,7 +59,7 @@ pub(crate) fn build_related_output(result: &cqs::RelatedResult, root: &Path) -> 
 // ─── CLI command ────────────────────────────────────────────────────────────
 
 pub(crate) fn cmd_related(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     name: &str,
     limit: usize,
     json: bool,

--- a/src/cli/commands/search/scout.rs
+++ b/src/cli/commands/search/scout.rs
@@ -174,7 +174,7 @@ mod tests {
 }
 
 pub(crate) fn cmd_scout(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     task: &str,
     limit: usize,
     json: bool,

--- a/src/cli/commands/search/similar.rs
+++ b/src/cli/commands/search/similar.rs
@@ -13,7 +13,7 @@ use crate::cli::display;
 use crate::cli::commands::resolve::parse_target;
 
 /// Resolve a name to a chunk ID by searching by name and optionally filtering by file
-fn resolve_target(store: &Store, name: &str) -> Result<(String, String)> {
+fn resolve_target<Mode>(store: &Store<Mode>, name: &str) -> Result<(String, String)> {
     let (file_filter, func_name) = parse_target(name);
 
     let results = store.search_by_name(func_name, 20)?;
@@ -39,7 +39,7 @@ fn resolve_target(store: &Store, name: &str) -> Result<(String, String)> {
 }
 
 pub(crate) fn cmd_similar(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     name: &str,
     limit: usize,
     threshold: f32,

--- a/src/cli/commands/search/where_cmd.rs
+++ b/src/cli/commands/search/where_cmd.rs
@@ -79,7 +79,7 @@ pub(crate) fn build_where_output(
 // ─── CLI command ───────────────────────────────────────────────────────────
 
 pub(crate) fn cmd_where(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     description: &str,
     limit: usize,
     json: bool,

--- a/src/cli/commands/train/plan.rs
+++ b/src/cli/commands/train/plan.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use cqs::plan::plan;
 
 pub(crate) fn cmd_plan(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     description: &str,
     limit: usize,
     json: bool,

--- a/src/cli/commands/train/task.rs
+++ b/src/cli/commands/train/task.rs
@@ -276,7 +276,7 @@ const WATERFALL_PLACEMENT: f64 = 0.10;
 // Notes section takes whatever budget remains (no explicit constant needed).
 
 pub(crate) fn cmd_task(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     description: &str,
     limit: usize,
     json: bool,

--- a/src/cli/commands/train/train_pairs.rs
+++ b/src/cli/commands/train/train_pairs.rs
@@ -50,7 +50,7 @@ fn build_nl_description(chunk: &ChunkSummary, contrastive_prefix: Option<&str>) 
 }
 
 /// Build contrastive prefix from callees: "Unlike X and Y, ..."
-fn build_contrastive_prefix(store: &Store, chunk: &ChunkSummary) -> Option<String> {
+fn build_contrastive_prefix<Mode>(store: &Store<Mode>, chunk: &ChunkSummary) -> Option<String> {
     let _span = tracing::debug_span!("build_contrastive_prefix", name = %chunk.name).entered();
 
     let callees = store
@@ -84,7 +84,7 @@ fn build_contrastive_prefix(store: &Store, chunk: &ChunkSummary) -> Option<Strin
 }
 
 pub(crate) fn cmd_train_pairs(
-    ctx: &crate::cli::CommandContext,
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     output: &str,
     limit: Option<usize>,
     language: Option<&str>,

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -762,16 +762,32 @@ impl Commands {
             | Commands::Context { .. }
             | Commands::Dead { .. }
             | Commands::Gather { .. }
-            | Commands::Gc { .. }
             | Commands::Health { .. }
             | Commands::Stale { .. }
-            | Commands::Suggest { .. }
             | Commands::Read { .. }
             | Commands::Related { .. }
             | Commands::Where { .. }
             | Commands::Scout { .. }
             | Commands::Plan { .. }
             | Commands::Task { .. } => BatchSupport::Daemon,
+
+            // #946 typestate: Gc mutates the DB (prune_all + HNSW rebuild).
+            // Daemon holds `Store<ReadOnly>`, so `prune_all` is literally
+            // not callable there. Must go through the CLI path, which
+            // opens `Store<ReadWrite>` via `CommandContext::open_readwrite`.
+            Commands::Gc { .. } => BatchSupport::Cli,
+
+            // #946 typestate: Suggest with --apply rewrites notes.toml and
+            // calls `index_notes` → `replace_notes_for_file` (a write).
+            // Classify on the `apply` flag: read-only dry-run is daemon-
+            // dispatchable; the write variant must hit CLI.
+            Commands::Suggest { ref args, .. } => {
+                if args.apply {
+                    BatchSupport::Cli
+                } else {
+                    BatchSupport::Daemon
+                }
+            }
         }
     }
 }

--- a/src/cli/staleness.rs
+++ b/src/cli/staleness.rs
@@ -15,7 +15,11 @@ use cqs::Store;
 /// Check result origins for staleness and print warning to stderr.
 /// Returns the set of stale origins for callers that want to annotate results.
 /// Errors are logged and swallowed — staleness check should never break a query.
-pub fn warn_stale_results(store: &Store, origins: &[&str], root: &Path) -> HashSet<String> {
+pub fn warn_stale_results<Mode>(
+    store: &Store<Mode>,
+    origins: &[&str],
+    root: &Path,
+) -> HashSet<String> {
     let _span = tracing::info_span!("warn_stale_results", count = origins.len()).entered();
     match store.check_origins_stale(origins, root) {
         Ok(stale) => {

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -11,9 +11,13 @@ use super::config::find_project_root;
 use super::definitions;
 
 /// Shared helper: locate project root and index, open store with the given opener.
-fn open_store_with(
-    opener: fn(&Path) -> std::result::Result<cqs::Store, cqs::store::StoreError>,
-) -> Result<(cqs::Store, PathBuf, PathBuf)> {
+///
+/// Generic over the typestate returned by `opener`, so both `Store::open`
+/// (→ `Store<ReadWrite>`) and `Store::open_readonly_pooled`
+/// (→ `Store<ReadOnly>`) compose through the same helper.
+fn open_store_with<Mode>(
+    opener: fn(&Path) -> std::result::Result<cqs::Store<Mode>, cqs::store::StoreError>,
+) -> Result<(cqs::Store<Mode>, PathBuf, PathBuf)> {
     let root = find_project_root();
     let cqs_dir = cqs::resolve_index_dir(&root);
     let index_path = cqs_dir.join("index.db");
@@ -37,16 +41,28 @@ pub(crate) fn open_project_store() -> Result<(cqs::Store, PathBuf, PathBuf)> {
 /// Same as [`open_project_store`] but uses `Store::open_readonly_pooled()` which creates a
 /// `current_thread` tokio runtime (1 OS thread) instead of `multi_thread` (4 OS threads).
 /// Keeps full 256MB mmap and 16MB cache for search performance.
-pub(crate) fn open_project_store_readonly() -> Result<(cqs::Store, PathBuf, PathBuf)> {
+pub(crate) fn open_project_store_readonly(
+) -> Result<(cqs::Store<cqs::store::ReadOnly>, PathBuf, PathBuf)> {
     open_store_with(cqs::Store::open_readonly_pooled)
 }
 
 /// Shared context for CLI commands that need an open store.
 /// Created once in dispatch, passed to all store-using handlers.
 /// Eliminates per-handler `open_project_store_readonly()` calls.
-pub(crate) struct CommandContext<'a> {
+///
+/// The `Mode` type parameter records whether the store was opened read-only
+/// or read-write. Commands that only read (search, explain, etc.) take
+/// `&CommandContext<'_, ReadOnly>`; commands that mutate (gc, suggest
+/// --apply, notes add) take `&CommandContext<'_, ReadWrite>`. This makes
+/// GitHub #946 structurally impossible: a read-only command cannot
+/// accidentally call a write method at compile time.
+///
+/// `Mode` defaults to `ReadWrite` so pre-typestate call sites keep
+/// compiling. New code that only needs reads should prefer
+/// `CommandContext<'_, ReadOnly>`.
+pub(crate) struct CommandContext<'a, Mode = cqs::store::ReadWrite> {
     pub cli: &'a definitions::Cli,
-    pub store: cqs::Store,
+    pub store: cqs::Store<Mode>,
     pub root: PathBuf,
     pub cqs_dir: PathBuf,
     reranker: OnceLock<cqs::Reranker>,
@@ -55,7 +71,7 @@ pub(crate) struct CommandContext<'a> {
     splade_index: OnceLock<Option<cqs::splade::index::SpladeIndex>>,
 }
 
-impl<'a> CommandContext<'a> {
+impl<'a> CommandContext<'a, cqs::store::ReadOnly> {
     /// Open the project store in read-only mode and build a command context.
     pub fn open_readonly(cli: &'a definitions::Cli) -> Result<Self> {
         let (store, root, cqs_dir) = open_project_store_readonly()?;
@@ -70,7 +86,9 @@ impl<'a> CommandContext<'a> {
             splade_index: OnceLock::new(),
         })
     }
+}
 
+impl<'a> CommandContext<'a, cqs::store::ReadWrite> {
     /// Open the project store in read-write mode and build a command context.
     ///
     /// Used by write commands (gc, etc.) that need the lazy embedder/reranker
@@ -89,7 +107,9 @@ impl<'a> CommandContext<'a> {
             splade_index: OnceLock::new(),
         })
     }
+}
 
+impl<'a, Mode> CommandContext<'a, Mode> {
     /// Get the resolved model config from the CLI.
     #[allow(deprecated)]
     pub fn model_config(&self) -> &cqs::embedder::ModelConfig {
@@ -227,8 +247,8 @@ impl<'a> CommandContext<'a> {
 /// CAGRA rebuilds index each CLI invocation (~1s for 474 vectors).
 /// Only worth it when search time savings exceed rebuild cost.
 /// Threshold: 5000 vectors (where CAGRA search is ~10x faster than HNSW).
-pub(crate) fn build_vector_index(
-    store: &cqs::Store,
+pub(crate) fn build_vector_index<Mode: ClearHnswDirty>(
+    store: &cqs::Store<Mode>,
     cqs_dir: &Path,
 ) -> Result<Option<Box<dyn cqs::index::VectorIndex>>> {
     build_vector_index_with_config(store, cqs_dir, None)
@@ -244,8 +264,16 @@ pub(crate) fn build_vector_index(
 /// Returns `Ok(Some(index))` with a boxed vector index implementation if indexing succeeds, or `Ok(None)` if the index is stale or unavailable.
 /// # Errors
 /// Returns an error if the HNSW index building fails or store operations encounter errors.
-pub(crate) fn build_vector_index_with_config(
-    store: &cqs::Store,
+///
+/// Generic over the store's typestate. The self-heal write (clearing the
+/// `hnsw_dirty` flag after a successful checksum verify) is gated to
+/// `Store<ReadWrite>` via [`try_clear_hnsw_dirty`]; a daemon with a
+/// `Store<ReadOnly>` will still observe the verify result but cannot
+/// persist the cleared flag. That's intentional — the daemon never
+/// mutates the DB, and the next writable open (`cqs index`, `cqs gc`)
+/// re-runs this path and performs the clear.
+pub(crate) fn build_vector_index_with_config<Mode: ClearHnswDirty>(
+    store: &cqs::Store<Mode>,
     cqs_dir: &Path,
     ef_search: Option<usize>,
 ) -> Result<Option<Box<dyn cqs::index::VectorIndex>>> {
@@ -328,9 +356,7 @@ pub(crate) fn build_vector_index_with_config(
                 tracing::info!(
                     "HNSW dirty flag set but checksums pass — clearing flag (self-heal)"
                 );
-                if let Err(e) = store.set_hnsw_dirty(cqs::HnswKind::Enriched, false) {
-                    tracing::warn!(error = %e, "Failed to clear dirty flag");
-                }
+                Mode::try_clear_hnsw_dirty(store, cqs::HnswKind::Enriched);
             }
             Err(e) => {
                 tracing::warn!(
@@ -349,6 +375,35 @@ pub(crate) fn build_vector_index_with_config(
     ))
 }
 
+/// Typestate bridge for self-heal operations that conditionally clear the
+/// `hnsw_dirty` flag. `ReadWrite` performs the write; `ReadOnly` is a
+/// no-op that logs a debug trace. Keeps [`build_vector_index_with_config`]
+/// generic over `Mode` without per-site feature flags or match arms.
+pub(crate) trait ClearHnswDirty: 'static {
+    /// Clear the dirty flag for `kind` if this typestate supports writes,
+    /// or no-op otherwise.
+    fn try_clear_hnsw_dirty(store: &cqs::Store<Self>, kind: cqs::HnswKind)
+    where
+        Self: Sized;
+}
+
+impl ClearHnswDirty for cqs::store::ReadWrite {
+    fn try_clear_hnsw_dirty(store: &cqs::Store<Self>, kind: cqs::HnswKind) {
+        if let Err(e) = store.set_hnsw_dirty(kind, false) {
+            tracing::warn!(error = %e, "Failed to clear dirty flag");
+        }
+    }
+}
+
+impl ClearHnswDirty for cqs::store::ReadOnly {
+    fn try_clear_hnsw_dirty(_store: &cqs::Store<Self>, kind: cqs::HnswKind) {
+        tracing::debug!(
+            ?kind,
+            "HNSW self-heal skipped on read-only store; next writable open will clear the flag"
+        );
+    }
+}
+
 /// Phase 5: load the base (non-enriched) HNSW index for adaptive routing.
 ///
 /// Returns `Ok(None)` when:
@@ -360,8 +415,8 @@ pub(crate) fn build_vector_index_with_config(
 ///   plain HNSW is sufficient
 ///
 /// The router falls back to the enriched index when this returns `None`.
-pub(crate) fn build_base_vector_index(
-    store: &cqs::Store,
+pub(crate) fn build_base_vector_index<Mode: ClearHnswDirty>(
+    store: &cqs::Store<Mode>,
     cqs_dir: &Path,
 ) -> Result<Option<Box<dyn cqs::index::VectorIndex>>> {
     let _span = tracing::info_span!("build_base_vector_index").entered();
@@ -395,9 +450,7 @@ pub(crate) fn build_base_vector_index(
                 tracing::info!(
                     "Base HNSW dirty flag set but checksums pass — clearing flag (self-heal)"
                 );
-                if let Err(e) = store.set_hnsw_dirty(cqs::HnswKind::Base, false) {
-                    tracing::warn!(error = %e, "Failed to clear dirty flag");
-                }
+                Mode::try_clear_hnsw_dirty(store, cqs::HnswKind::Base);
             }
             Err(e) => {
                 tracing::warn!(

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -80,9 +80,9 @@ impl From<&ChunkIdentity> for ChunkKey {
 /// Loads `ChunkIdentity` (no content/embeddings) for all chunks in both stores.
 /// At ~500 bytes per identity, a 100k-chunk codebase uses ~50 MB — well within
 /// normal process memory. The `language_filter` param pushes filtering into SQL.
-pub fn semantic_diff(
-    source_store: &Store,
-    target_store: &Store,
+pub fn semantic_diff<Mode1, Mode2>(
+    source_store: &Store<Mode1>,
+    target_store: &Store<Mode2>,
     source_label: &str,
     target_label: &str,
     threshold: f32,

--- a/src/drift.rs
+++ b/src/drift.rs
@@ -44,9 +44,13 @@ pub struct DriftResult {
 /// Detect semantic drift between a reference and the project.
 /// Uses `semantic_diff()` internally, filtering to only the "modified" entries
 /// and presenting them as drift (1.0 - similarity).
-pub fn detect_drift(
-    ref_store: &Store,
-    project_store: &Store,
+///
+/// Generic over the typestate of both stores (`Mode1`, `Mode2`) — drift
+/// detection only reads, so a `Store<ReadOnly>` reference and a
+/// `Store<ReadWrite>` project compose freely.
+pub fn detect_drift<Mode1, Mode2>(
+    ref_store: &Store<Mode1>,
+    project_store: &Store<Mode2>,
     ref_name: &str,
     threshold: f32,
     min_drift: f32,

--- a/src/gather.rs
+++ b/src/gather.rs
@@ -367,8 +367,8 @@ pub(crate) fn bfs_expand(
 /// Batch-fetch chunks for expanded names, deduplicate by id, assemble `GatheredChunk`s.
 ///
 /// Returns `(chunks, search_degraded)`.
-pub(crate) fn fetch_and_assemble(
-    store: &Store,
+pub(crate) fn fetch_and_assemble<Mode>(
+    store: &Store<Mode>,
     name_scores: &HashMap<String, (f32, usize)>,
     root: &Path,
 ) -> (Vec<GatheredChunk>, bool) {
@@ -429,8 +429,8 @@ pub(crate) fn sort_and_truncate(chunks: &mut Vec<GatheredChunk>, limit: usize) {
 ///
 /// Embeds the query internally (or uses `opts.query_embedding` if pre-computed).
 /// Loads the call graph internally. For pre-loaded graph, use [`gather_with_graph`].
-pub fn gather(
-    store: &Store,
+pub fn gather<Mode>(
+    store: &Store<Mode>,
     embedder: &Embedder,
     description: &str,
     opts: &GatherOptions,
@@ -448,8 +448,8 @@ pub fn gather(
 ///
 /// Use when the caller already has the graph (e.g., batch mode or `task()`
 /// which shares the graph across phases).
-pub fn gather_with_graph(
-    store: &Store,
+pub fn gather_with_graph<Mode>(
+    store: &Store<Mode>,
     query_embedding: &crate::Embedding,
     query_text: &str,
     opts: &GatherOptions,
@@ -522,8 +522,8 @@ pub fn gather_with_graph(
 /// 3. For each seed embedding, search the project store for similar code (bridge)
 /// 4. BFS expand project-side bridges via the project call graph
 /// 5. Return both reference seeds (context) and expanded project chunks
-pub fn gather_cross_index(
-    project_store: &Store,
+pub fn gather_cross_index<Mode: Sync>(
+    project_store: &Store<Mode>,
     ref_idx: &crate::reference::ReferenceIndex,
     query_embedding: &crate::Embedding,
     query_text: &str,
@@ -543,8 +543,8 @@ pub fn gather_cross_index(
 
 /// Like [`gather_cross_index`] but accepts an optional HNSW index for O(log n)
 /// bridge searches instead of brute-force scans per reference seed.
-pub fn gather_cross_index_with_index(
-    project_store: &Store,
+pub fn gather_cross_index_with_index<Mode: Sync>(
+    project_store: &Store<Mode>,
     ref_idx: &crate::reference::ReferenceIndex,
     query_embedding: &crate::Embedding,
     query_text: &str,

--- a/src/health.rs
+++ b/src/health.rs
@@ -44,8 +44,8 @@ pub struct HealthReport {
 /// Run a comprehensive health check on the index.
 /// Only `store.stats()` is fatal. All other sub-queries degrade gracefully,
 /// populating defaults and adding warnings.
-pub fn health_check(
-    store: &Store,
+pub fn health_check<Mode>(
+    store: &Store<Mode>,
     existing_files: &HashSet<PathBuf>,
     cqs_dir: &Path,
     root: &Path,

--- a/src/impact/analysis.rs
+++ b/src/impact/analysis.rs
@@ -42,8 +42,8 @@ impl Default for ImpactOptions {
 /// Paths in the returned result are relative to `root`.
 /// When `opts.include_types` is true, also performs one-hop type expansion: finds
 /// other functions that share type dependencies with the target via `type_edges`.
-pub fn analyze_impact(
-    store: &Store,
+pub fn analyze_impact<Mode>(
+    store: &Store<Mode>,
     target_name: &str,
     root: &Path,
     opts: &ImpactOptions,
@@ -104,8 +104,8 @@ pub fn analyze_impact(
 /// to avoid N+1 per-caller `search_by_name` calls.
 /// Returns `(callers, degraded)` — `degraded` is true when the batch name search
 /// failed and caller snippets may be incomplete.
-fn build_caller_info(
-    store: &Store,
+fn build_caller_info<Mode>(
+    store: &Store<Mode>,
     target_name: &str,
     root: &Path,
 ) -> Result<(Vec<CallerDetail>, bool), StoreError> {
@@ -218,8 +218,8 @@ pub(crate) fn find_affected_tests_with_chunks(
 /// Find transitive callers up to the given depth.
 /// Uses `reverse_bfs` to discover all ancestor names in a single graph traversal,
 /// then batch-fetches chunk locations with `search_by_names_batch` to avoid N+1 queries.
-fn find_transitive_callers(
-    store: &Store,
+fn find_transitive_callers<Mode>(
+    store: &Store<Mode>,
     graph: &crate::store::CallGraph,
     target_name: &str,
     depth: usize,
@@ -267,7 +267,11 @@ fn find_transitive_callers(
 /// Suggest tests for untested callers in an impact result.
 /// Loads its own call graph and test chunks — only called when `--suggest-tests`
 /// is set, so the normal path pays zero overhead.
-pub fn suggest_tests(store: &Store, impact: &ImpactResult, root: &Path) -> Vec<TestSuggestion> {
+pub fn suggest_tests<Mode>(
+    store: &Store<Mode>,
+    impact: &ImpactResult,
+    root: &Path,
+) -> Vec<TestSuggestion> {
     let _span = tracing::info_span!("suggest_tests", function = %impact.function_name).entered();
     let graph = match store.get_call_graph() {
         Ok(g) => g,
@@ -412,8 +416,8 @@ fn suggest_test_file(source: &str) -> String {
 /// 2. Filter out common types (String, Vec, etc.)
 /// 3. For each remaining type, find other users via `get_type_users_batch`
 /// 4. Aggregate by function name, track which types are shared
-fn find_type_impacted(
-    store: &Store,
+fn find_type_impacted<Mode>(
+    store: &Store<Mode>,
     target_name: &str,
     root: &Path,
 ) -> Result<Vec<TypeImpacted>, StoreError> {

--- a/src/impact/cross_project.rs
+++ b/src/impact/cross_project.rs
@@ -317,7 +317,7 @@ mod tests {
 
         NamedStore {
             name: name.to_string(),
-            store,
+            store: store.into_readonly(),
         }
     }
 

--- a/src/impact/diff.rs
+++ b/src/impact/diff.rs
@@ -35,8 +35,8 @@ fn max_changed_functions() -> usize {
 /// Map diff hunks to function names using the index.
 /// For each hunk, finds chunks whose line range overlaps the hunk's range.
 /// Returns deduplicated function names.
-pub fn map_hunks_to_functions(
-    store: &Store,
+pub fn map_hunks_to_functions<Mode>(
+    store: &Store<Mode>,
     hunks: &[crate::diff_parse::DiffHunk],
 ) -> Vec<ChangedFunction> {
     let _span = tracing::info_span!("map_hunks_to_functions", hunk_count = hunks.len()).entered();
@@ -108,8 +108,8 @@ pub fn map_hunks_to_functions(
 /// Run impact analysis across all changed functions from a diff.
 /// Fetches call graph and test chunks once, then analyzes each function.
 /// Results are deduplicated by name.
-pub fn analyze_diff_impact(
-    store: &Store,
+pub fn analyze_diff_impact<Mode>(
+    store: &Store<Mode>,
     changed: Vec<ChangedFunction>,
     root: &Path,
 ) -> Result<DiffImpactResult, AnalysisError> {
@@ -122,8 +122,8 @@ pub fn analyze_diff_impact(
 /// Paths in the returned result are relative to `root`.
 /// Use when the caller already has the graph/test_chunks (e.g., `review_diff`
 /// which also needs them for risk scoring).
-pub fn analyze_diff_impact_with_graph(
-    store: &Store,
+pub fn analyze_diff_impact_with_graph<Mode>(
+    store: &Store<Mode>,
     changed: Vec<ChangedFunction>,
     graph: &crate::store::CallGraph,
     test_chunks: &[crate::store::ChunkSummary],

--- a/src/impact/hints.rs
+++ b/src/impact/hints.rs
@@ -52,8 +52,8 @@ pub fn compute_hints_with_graph(
 /// Convenience wrapper that loads graph internally. Pass `prefetched_caller_count`
 /// to avoid re-querying callers when the caller already has them (e.g., `explain`
 /// fetches callers before this).
-pub fn compute_hints(
-    store: &Store,
+pub fn compute_hints<Mode>(
+    store: &Store<Mode>,
     function_name: &str,
     prefetched_caller_count: Option<usize>,
 ) -> Result<FunctionHints, StoreError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,7 @@ pub fn rel_display(path: &Path, root: &Path) -> String {
 pub fn index_notes(
     notes: &[note::Note],
     notes_path: &Path,
-    store: &Store,
+    store: &Store<store::ReadWrite>,
 ) -> anyhow::Result<usize> {
     let _span =
         tracing::info_span!("index_notes", path = %notes_path.display(), count = notes.len())

--- a/src/onboard.rs
+++ b/src/onboard.rs
@@ -90,8 +90,8 @@ pub struct OnboardSummary {
 /// Produce a guided tour of a concept in the codebase.
 ///
 /// Returns an ordered reading list: entry point → callees → callers → types → tests.
-pub fn onboard(
-    store: &Store,
+pub fn onboard<Mode>(
+    store: &Store<Mode>,
     embedder: &Embedder,
     concept: &str,
     root: &Path,
@@ -315,8 +315,8 @@ fn gathered_to_onboard(c: GatheredChunk) -> OnboardEntry {
 /// `fetch_and_assemble` uses FTS which can fuzzy-match (e.g., "search" → "test_is_pipeable_search").
 /// This function does a direct `search_by_name` with multiple results, then picks the one
 /// with an exact name match, preferring the file from scout.
-fn fetch_entry_point(
-    store: &Store,
+fn fetch_entry_point<Mode>(
+    store: &Store<Mode>,
     entry_name: &str,
     entry_file: &Path,
     root: &Path,

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -375,8 +375,8 @@ pub fn template_names() -> Vec<&'static str> {
 ///
 /// Classifies the task, runs scout, and returns a structured plan
 /// combining the template checklist with scout results.
-pub fn plan(
-    store: &Store,
+pub fn plan<Mode>(
+    store: &Store<Mode>,
     embedder: &Embedder,
     description: &str,
     root: &Path,

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 use crate::config::ReferenceConfig;
 use crate::hnsw::HnswIndex;
 use crate::index::VectorIndex;
-use crate::store::{SearchFilter, SearchResult, Store, StoreError, UnifiedResult};
+use crate::store::{ReadOnly, SearchFilter, SearchResult, Store, StoreError, UnifiedResult};
 use crate::Embedding;
 
 /// A loaded reference index ready for searching
@@ -19,8 +19,12 @@ use crate::Embedding;
 pub struct ReferenceIndex {
     /// Display name
     pub name: String,
-    /// The reference's store (separate DB + connection pool)
-    pub store: Store,
+    /// The reference's store (separate DB + connection pool).
+    ///
+    /// Always `Store<ReadOnly>` — references are loaded from external
+    /// codebases and only exposed through search/caller queries. The
+    /// typestate (#946) turns any accidental write into a compile error.
+    pub store: Store<ReadOnly>,
     /// Optional HNSW index for O(log n) search
     pub index: Option<Box<dyn VectorIndex>>,
     /// Score multiplier (0.0-1.0)

--- a/src/related.rs
+++ b/src/related.rs
@@ -31,8 +31,8 @@ pub struct RelatedResult {
 /// 1. Shared callers — called by the same functions as target
 /// 2. Shared callees — calls the same functions as target
 /// 3. Shared types — uses the same types (via type_edges)
-pub fn find_related(
-    store: &Store,
+pub fn find_related<Mode>(
+    store: &Store<Mode>,
     target_name: &str,
     limit: usize,
 ) -> Result<RelatedResult, AnalysisError> {
@@ -74,7 +74,7 @@ pub fn find_related(
 
 /// Resolve (name, overlap_count) pairs to RelatedFunction by batch-looking up chunks.
 /// Uses a single batch query instead of N individual `get_chunks_by_name` calls.
-fn resolve_to_related(store: &Store, pairs: &[(String, u32)]) -> Vec<RelatedFunction> {
+fn resolve_to_related<Mode>(store: &Store<Mode>, pairs: &[(String, u32)]) -> Vec<RelatedFunction> {
     if pairs.is_empty() {
         return Vec::new();
     }
@@ -106,8 +106,8 @@ fn resolve_to_related(store: &Store, pairs: &[(String, u32)]) -> Vec<RelatedFunc
 
 /// Find functions that share types with the target via type_edges.
 /// Uses batch type-edge queries instead of LIKE-based signature scanning.
-fn find_type_overlap(
-    store: &Store,
+fn find_type_overlap<Mode>(
+    store: &Store<Mode>,
     target_name: &str,
     type_names: &[String],
     limit: usize,

--- a/src/review.rs
+++ b/src/review.rs
@@ -73,8 +73,8 @@ pub struct RiskSummary {
 /// 4. Risk scoring -> per-function risk
 /// 5. Note matching -> relevant notes for changed files (non-fatal)
 /// 6. Staleness check -> warn if changed files are stale (non-fatal)
-pub fn review_diff(
-    store: &Store,
+pub fn review_diff<Mode>(
+    store: &Store<Mode>,
     diff_text: &str,
     root: &Path,
 ) -> Result<Option<ReviewResult>, AnalysisError> {
@@ -184,8 +184,8 @@ pub fn review_diff(
 
 /// Match notes to a set of changed file paths.
 /// Returns an error if notes cannot be loaded (caller decides how to handle).
-fn match_notes(
-    store: &Store,
+fn match_notes<Mode>(
+    store: &Store<Mode>,
     changed_files: &HashSet<&str>,
 ) -> Result<Vec<ReviewNoteEntry>, AnalysisError> {
     let _span = tracing::info_span!("match_notes").entered();

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -126,8 +126,8 @@ impl Default for ScoutOptions {
 /// Run scout analysis for a task description.
 ///
 /// Uses default search parameters. For custom parameters, use [`scout_with_options`].
-pub fn scout(
-    store: &Store,
+pub fn scout<Mode>(
+    store: &Store<Mode>,
     embedder: &Embedder,
     task: &str,
     root: &Path,
@@ -137,8 +137,8 @@ pub fn scout(
 }
 
 /// Run scout analysis with configurable search parameters.
-pub fn scout_with_options(
-    store: &Store,
+pub fn scout_with_options<Mode>(
+    store: &Store<Mode>,
     embedder: &Embedder,
     task: &str,
     root: &Path,
@@ -168,8 +168,8 @@ pub fn scout_with_options(
 }
 
 /// Pre-loaded resources for scout_core, avoiding repeated lookups.
-pub(crate) struct ScoutResources<'a> {
-    pub store: &'a Store,
+pub(crate) struct ScoutResources<'a, Mode> {
+    pub store: &'a Store<Mode>,
     pub query_embedding: &'a crate::Embedding,
     pub task: &'a str,
     pub root: &'a Path,
@@ -183,7 +183,9 @@ pub(crate) struct ScoutResources<'a> {
 ///
 /// Use this when you already have the call graph and test chunks loaded
 /// (e.g., from `cqs task` which shares them across phases).
-pub(crate) fn scout_core(res: &ScoutResources<'_>) -> Result<ScoutResult, AnalysisError> {
+pub(crate) fn scout_core<Mode>(
+    res: &ScoutResources<'_, Mode>,
+) -> Result<ScoutResult, AnalysisError> {
     let store = res.store;
     let query_embedding = res.query_embedding;
     let task = res.task;
@@ -426,7 +428,10 @@ fn classify_role(score: f32, name: &str, file: &str, modify_threshold: f32) -> C
 /// Matches when a mention is a suffix of a result file path (e.g., mention "search.rs"
 /// matches result "src/search.rs") at a path-component boundary.
 /// This avoids false matches from short concept words like "audit" or "security".
-fn find_relevant_notes(store: &Store, result_files: &HashSet<String>) -> Vec<NoteSummary> {
+fn find_relevant_notes<Mode>(
+    store: &Store<Mode>,
+    result_files: &HashSet<String>,
+) -> Vec<NoteSummary> {
     let all_notes = match store.list_notes_summaries() {
         Ok(n) => n,
         Err(e) => {

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -42,7 +42,11 @@ pub fn parse_target(target: &str) -> (Option<&str>, &str) {
 /// Resolve a target string to a [`ResolvedTarget`].
 /// Uses search_by_name with optional file filtering.
 /// Returns the best-matching chunk and alternatives, or an error if none found.
-pub fn resolve_target(store: &Store, target: &str) -> Result<ResolvedTarget, StoreError> {
+/// Generic over store typestate — pure read path.
+pub fn resolve_target<Mode>(
+    store: &Store<Mode>,
+    target: &str,
+) -> Result<ResolvedTarget, StoreError> {
     let _span = tracing::info_span!("resolve_target", target).entered();
     let (file_filter, name) = parse_target(target);
     let results = store.search_by_name(name, 20)?;

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -82,7 +82,7 @@ pub(crate) fn type_boost_factor() -> f32 {
     }
 }
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Raw embedding-only cosine similarity search (no RRF, no keyword matching).
     ///
     /// **You almost certainly want `search_filtered()` instead.** This method skips

--- a/src/store/calls/cross_project.rs
+++ b/src/store/calls/cross_project.rs
@@ -10,11 +10,16 @@ use crate::store::helpers::{CallGraph, CallerInfo, ChunkSummary, StoreError};
 use crate::Store;
 
 /// A named store for cross-project context.
+///
+/// `CrossProjectContext` only issues read queries (callers, callees,
+/// test chunks), so the handle is `Store<ReadOnly>` — the typestate
+/// refactor (GitHub #946) makes it a compile-time error to accidentally
+/// call a write method on a cross-project reference store.
 pub struct NamedStore {
     /// Human-readable project name (e.g. "cqs", "openclaw").
     pub name: String,
     /// The open Store handle.
-    pub store: Store,
+    pub store: Store<crate::store::ReadOnly>,
 }
 
 impl std::fmt::Debug for NamedStore {
@@ -77,13 +82,10 @@ impl CrossProjectContext {
         let config = crate::config::Config::load(root);
 
         let db_path = root.join(".cqs/index.db");
-        let local_store = match Store::open_readonly(&db_path) {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::warn!(error = %e, "open_readonly failed, trying writable");
-                Store::open(&db_path)?
-            }
-        };
+        // #946 typestate: cross-project reads only — open read-only. If the DB
+        // doesn't exist yet, propagate the error; creating it here would
+        // corrupt the invariant that cross-project queries never mutate.
+        let local_store = Store::open_readonly(&db_path)?;
         let mut stores = vec![NamedStore {
             name: "local".to_string(),
             store: local_store,
@@ -330,7 +332,7 @@ mod tests {
 
         NamedStore {
             name: name.to_string(),
-            store,
+            store: store.into_readonly(),
         }
     }
 

--- a/src/store/calls/crud.rs
+++ b/src/store/calls/crud.rs
@@ -7,9 +7,9 @@ use std::path::Path;
 
 use super::CallStats;
 use crate::store::helpers::StoreError;
-use crate::store::Store;
+use crate::store::{ReadWrite, Store};
 
-impl<Mode> Store<Mode> {
+impl Store<ReadWrite> {
     /// Insert or replace call sites for a chunk
     pub fn upsert_calls(
         &self,
@@ -95,7 +95,9 @@ impl<Mode> Store<Mode> {
             Ok(())
         })
     }
+}
 
+impl<Mode> Store<Mode> {
     /// Check which chunk IDs from a set actually exist in the database.
     /// Used by periodic deferred-flush to filter calls whose FK targets are present.
     pub fn existing_chunk_ids(
@@ -171,7 +173,9 @@ impl<Mode> Store<Mode> {
             })
         })
     }
+}
 
+impl Store<ReadWrite> {
     // ============ Full Call Graph Methods (v5) ============
 
     /// Insert function calls for a file (full call graph, no size limits)

--- a/src/store/calls/crud.rs
+++ b/src/store/calls/crud.rs
@@ -9,7 +9,7 @@ use super::CallStats;
 use crate::store::helpers::StoreError;
 use crate::store::Store;
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Insert or replace call sites for a chunk
     pub fn upsert_calls(
         &self,

--- a/src/store/calls/dead_code.rs
+++ b/src/store/calls/dead_code.rs
@@ -13,7 +13,7 @@ use crate::parser::{ChunkType, Language};
 use crate::store::helpers::{clamp_line_number, ChunkRow, ChunkSummary, StoreError};
 use crate::store::Store;
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Find functions/methods never called by indexed code (dead code detection).
     /// Returns two lists:
     /// - `confident`: Functions with no callers that are likely dead (with confidence scores)

--- a/src/store/calls/query.rs
+++ b/src/store/calls/query.rs
@@ -9,7 +9,7 @@ use crate::store::helpers::{
 };
 use crate::store::Store;
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Find all callers of a function (from full call graph)
     pub fn get_callers_full(&self, callee_name: &str) -> Result<Vec<CallerInfo>, StoreError> {
         let _span = tracing::debug_span!("get_callers_full", function = %callee_name).entered();

--- a/src/store/calls/related.rs
+++ b/src/store/calls/related.rs
@@ -6,7 +6,7 @@ use super::FunctionCallStats;
 use crate::store::helpers::StoreError;
 use crate::store::Store;
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Batch count query for call graph columns.
     /// Shared implementation for caller/callee count queries. Filters by `filter_column`
     /// and groups by `group_column` to count edges.

--- a/src/store/calls/test_map.rs
+++ b/src/store/calls/test_map.rs
@@ -2,7 +2,7 @@
 
 use super::{TEST_CHUNKS_SQL, TEST_CHUNK_NAMES_SQL};
 use crate::store::helpers::{ChunkRow, ChunkSummary, StoreError};
-use crate::store::Store;
+use crate::store::{ReadWrite, Store};
 
 impl<Mode> Store<Mode> {
     /// Async helper for find_test_chunks (reused by find_dead_code)
@@ -35,24 +35,6 @@ impl<Mode> Store<Mode> {
         Ok(rows.into_iter().map(|(name,)| name).collect())
     }
 
-    /// Delete function_calls for files no longer in the chunks table.
-    /// Used by GC to clean up orphaned call graph entries after pruning chunks.
-    pub fn prune_stale_calls(&self) -> Result<u64, StoreError> {
-        let _span = tracing::info_span!("prune_stale_calls").entered();
-        self.rt.block_on(async {
-            let result = sqlx::query(
-                "DELETE FROM function_calls WHERE file NOT IN (SELECT DISTINCT origin FROM chunks)",
-            )
-            .execute(&self.pool)
-            .await?;
-            let count = result.rows_affected();
-            if count > 0 {
-                tracing::info!(pruned = count, "Pruned stale call graph entries");
-            }
-            Ok(count)
-        })
-    }
-
     /// Find test chunks using language-specific heuristics.
     /// Identifies test functions across all supported languages by:
     /// - Name patterns: `test_*` (Rust/Python), `Test*` (Go)
@@ -75,5 +57,25 @@ impl<Mode> Store<Mode> {
         let arc = std::sync::Arc::new(chunks);
         let _ = self.test_chunks_cache.set(std::sync::Arc::clone(&arc));
         Ok(arc)
+    }
+}
+
+impl Store<ReadWrite> {
+    /// Delete function_calls for files no longer in the chunks table.
+    /// Used by GC to clean up orphaned call graph entries after pruning chunks.
+    pub fn prune_stale_calls(&self) -> Result<u64, StoreError> {
+        let _span = tracing::info_span!("prune_stale_calls").entered();
+        self.rt.block_on(async {
+            let result = sqlx::query(
+                "DELETE FROM function_calls WHERE file NOT IN (SELECT DISTINCT origin FROM chunks)",
+            )
+            .execute(&self.pool)
+            .await?;
+            let count = result.rows_affected();
+            if count > 0 {
+                tracing::info!(pruned = count, "Pruned stale call graph entries");
+            }
+            Ok(count)
+        })
     }
 }

--- a/src/store/calls/test_map.rs
+++ b/src/store/calls/test_map.rs
@@ -4,7 +4,7 @@ use super::{TEST_CHUNKS_SQL, TEST_CHUNK_NAMES_SQL};
 use crate::store::helpers::{ChunkRow, ChunkSummary, StoreError};
 use crate::store::Store;
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Async helper for find_test_chunks (reused by find_dead_code)
     /// Loads only lightweight columns (no content/doc) since callers only need
     /// name, file, and line_start. The SQL WHERE clause still filters on content

--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -10,7 +10,7 @@ use crate::parser::Chunk;
 use crate::store::helpers::{bytes_to_embedding, CandidateRow, ChunkRow, StoreError};
 use crate::store::Store;
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Fetch chunks by IDs (without embeddings) — async version.
     ///
     /// Returns a map of chunk ID → ChunkRow for the given IDs.
@@ -398,8 +398,8 @@ pub(super) async fn upsert_fts_conditional(
 /// default) or `"embedding_base"` (Phase 5 dual index). Rows where the
 /// selected column is NULL are silently skipped — NULL is valid state for
 /// `embedding_base` between the v17→v18 migration and the next index pass.
-struct EmbeddingBatchIterator<'a> {
-    store: &'a Store,
+struct EmbeddingBatchIterator<'a, Mode> {
+    store: &'a Store<Mode>,
     batch_size: usize,
     /// Last seen rowid for cursor-based pagination
     last_rowid: i64,
@@ -407,7 +407,7 @@ struct EmbeddingBatchIterator<'a> {
     column: &'static str,
 }
 
-impl<'a> Iterator for EmbeddingBatchIterator<'a> {
+impl<'a, Mode> Iterator for EmbeddingBatchIterator<'a, Mode> {
     type Item = Result<Vec<(String, Embedding)>, StoreError>;
 
     /// Advances the iterator to the next batch of embedding records from the database.
@@ -501,7 +501,7 @@ impl<'a> Iterator for EmbeddingBatchIterator<'a> {
 
 // SAFETY: Once `done` is set to true, `next()` always returns None.
 // This is guaranteed by the check at the start of `next()`.
-impl<'a> std::iter::FusedIterator for EmbeddingBatchIterator<'a> {}
+impl<'a, Mode> std::iter::FusedIterator for EmbeddingBatchIterator<'a, Mode> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use crate::embedder::Embedding;
 use crate::parser::Chunk;
 use crate::store::helpers::{embedding_to_bytes, StoreError};
-use crate::store::Store;
+use crate::store::{ReadWrite, Store};
 
 use super::async_helpers::{batch_insert_chunks, snapshot_content_hashes, upsert_fts_conditional};
 
@@ -30,6 +30,179 @@ impl<Mode> Store<Mode> {
         })
     }
 
+    /// Get enrichment hashes for a batch of chunk IDs.
+    ///
+    /// Returns a map from chunk_id to enrichment_hash (only for chunks that have one).
+    pub fn get_enrichment_hashes_batch(
+        &self,
+        chunk_ids: &[&str],
+    ) -> Result<std::collections::HashMap<String, String>, StoreError> {
+        let _span =
+            tracing::debug_span!("get_enrichment_hashes_batch", count = chunk_ids.len()).entered();
+        if chunk_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        self.rt.block_on(async {
+            let mut result = std::collections::HashMap::new();
+            use crate::store::helpers::sql::max_rows_per_statement;
+            for batch in chunk_ids.chunks(max_rows_per_statement(1)) {
+                let placeholders = crate::store::helpers::make_placeholders(batch.len());
+                let sql = format!(
+                    "SELECT id, enrichment_hash FROM chunks WHERE id IN ({}) AND enrichment_hash IS NOT NULL",
+                    placeholders
+                );
+                let mut query = sqlx::query_as::<_, (String, String)>(&sql);
+                for id in batch {
+                    query = query.bind(*id);
+                }
+                let rows = query.fetch_all(&self.pool).await?;
+                for (id, hash) in rows {
+                    result.insert(id, hash);
+                }
+            }
+            Ok(result)
+        })
+    }
+
+    /// Fetch all enrichment hashes in a single query.
+    ///
+    /// Returns a map from chunk_id to enrichment_hash for all chunks that have one.
+    /// Used by the enrichment pass to avoid per-page hash fetches (PERF-29).
+    pub fn get_all_enrichment_hashes(
+        &self,
+    ) -> Result<std::collections::HashMap<String, String>, StoreError> {
+        let _span = tracing::debug_span!("get_all_enrichment_hashes").entered();
+        self.rt.block_on(async {
+            let rows: Vec<(String, String)> = sqlx::query_as(
+                "SELECT id, enrichment_hash FROM chunks WHERE enrichment_hash IS NOT NULL",
+            )
+            .fetch_all(&self.pool)
+            .await?;
+            Ok(rows.into_iter().collect())
+        })
+    }
+
+    /// Get LLM summaries for a batch of content hashes.
+    ///
+    /// Returns a map from content_hash to summary text. Only includes hashes
+    /// that have summaries in the llm_summaries table matching the given purpose.
+    pub fn get_summaries_by_hashes(
+        &self,
+        content_hashes: &[&str],
+        purpose: &str,
+    ) -> Result<std::collections::HashMap<String, String>, StoreError> {
+        let _span = tracing::debug_span!(
+            "get_summaries_by_hashes",
+            count = content_hashes.len(),
+            purpose
+        )
+        .entered();
+        if content_hashes.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        self.rt.block_on(async {
+            let mut result = std::collections::HashMap::new();
+            use crate::store::helpers::sql::max_rows_per_statement;
+            // Reserve one param for the purpose bind, so (limit - 1) per batch
+            for batch in content_hashes.chunks(max_rows_per_statement(1) - 1) {
+                let placeholders = crate::store::helpers::make_placeholders(batch.len());
+                let sql = format!(
+                    "SELECT content_hash, summary FROM llm_summaries WHERE content_hash IN ({}) AND purpose = ?{}",
+                    placeholders,
+                    batch.len() + 1
+                );
+                let mut query = sqlx::query_as::<_, (String, String)>(&sql);
+                for hash in batch {
+                    query = query.bind(*hash);
+                }
+                query = query.bind(purpose);
+                let rows = query.fetch_all(&self.pool).await?;
+                for (hash, summary) in rows {
+                    result.insert(hash, summary);
+                }
+            }
+            Ok(result)
+        })
+    }
+
+    /// Fetch all LLM summaries as a map from content_hash to summary text.
+    ///
+    /// Single query, no batching needed (reads entire table). Used by the
+    /// enrichment pass to avoid per-page summary fetches.
+    pub fn get_all_summaries(
+        &self,
+        purpose: &str,
+    ) -> Result<std::collections::HashMap<String, String>, StoreError> {
+        let _span = tracing::debug_span!("get_all_summaries", purpose).entered();
+        self.rt.block_on(async {
+            let rows: Vec<(String, String)> = sqlx::query_as(
+                "SELECT content_hash, summary FROM llm_summaries WHERE purpose = ?1",
+            )
+            .bind(purpose)
+            .fetch_all(&self.pool)
+            .await?;
+            Ok(rows.into_iter().collect())
+        })
+    }
+
+    /// Get all distinct content hashes currently in the chunks table.
+    /// Used to validate batch results against the current index (DS-20).
+    pub fn get_all_content_hashes(&self) -> Result<Vec<String>, StoreError> {
+        let _span = tracing::debug_span!("get_all_content_hashes").entered();
+        self.rt.block_on(async {
+            let rows: Vec<(String,)> = sqlx::query_as("SELECT DISTINCT content_hash FROM chunks")
+                .fetch_all(&self.pool)
+                .await?;
+            Ok(rows.into_iter().map(|(h,)| h).collect())
+        })
+    }
+
+    /// Get all summaries with full metadata for backup/restore.
+    /// Returns Vec of (content_hash, summary, model, purpose).
+    pub fn get_all_summaries_full(
+        &self,
+    ) -> Result<Vec<(String, String, String, String)>, StoreError> {
+        let _span = tracing::debug_span!("get_all_summaries_full").entered();
+        self.rt.block_on(async {
+            let rows: Vec<(String, String, String, String)> =
+                sqlx::query_as("SELECT content_hash, summary, model, purpose FROM llm_summaries")
+                    .fetch_all(&self.pool)
+                    .await?;
+            Ok(rows)
+        })
+    }
+
+    /// Check if a file needs reindexing based on mtime.
+    ///
+    /// Returns `Ok(Some(mtime))` if reindex needed (with the file's current mtime),
+    /// or `Ok(None)` if no reindex needed. This avoids reading file metadata twice.
+    pub fn needs_reindex(&self, path: &Path) -> Result<Option<i64>, StoreError> {
+        let _span = tracing::debug_span!("needs_reindex", path = %path.display()).entered();
+        let current_mtime = path
+            .metadata()?
+            .modified()?
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|_| StoreError::SystemTime)?
+            .as_millis() as i64;
+
+        self.rt.block_on(async {
+            let row: Option<(Option<i64>,)> =
+                sqlx::query_as("SELECT source_mtime FROM chunks WHERE origin = ?1 LIMIT 1")
+                    .bind(crate::normalize_path(path))
+                    .fetch_optional(&self.pool)
+                    .await?;
+
+            match row {
+                Some((Some(stored_mtime),)) if stored_mtime >= current_mtime => Ok(None),
+                _ => Ok(Some(current_mtime)),
+            }
+        })
+    }
+}
+
+// Write methods live on `impl Store<ReadWrite>` — the compiler refuses to
+// call them on a `Store<ReadOnly>`. Closes the bug class in GitHub #946.
+impl Store<ReadWrite> {
     /// Insert or update chunks in batch using multi-row INSERT.
     ///
     /// Chunks are inserted in batches of 52 rows (52 * 19 params = 988 < SQLite's 999 limit).
@@ -198,101 +371,6 @@ impl<Mode> Store<Mode> {
         })
     }
 
-    /// Get enrichment hashes for a batch of chunk IDs.
-    ///
-    /// Returns a map from chunk_id to enrichment_hash (only for chunks that have one).
-    pub fn get_enrichment_hashes_batch(
-        &self,
-        chunk_ids: &[&str],
-    ) -> Result<std::collections::HashMap<String, String>, StoreError> {
-        let _span =
-            tracing::debug_span!("get_enrichment_hashes_batch", count = chunk_ids.len()).entered();
-        if chunk_ids.is_empty() {
-            return Ok(std::collections::HashMap::new());
-        }
-        self.rt.block_on(async {
-            let mut result = std::collections::HashMap::new();
-            use crate::store::helpers::sql::max_rows_per_statement;
-            for batch in chunk_ids.chunks(max_rows_per_statement(1)) {
-                let placeholders = crate::store::helpers::make_placeholders(batch.len());
-                let sql = format!(
-                    "SELECT id, enrichment_hash FROM chunks WHERE id IN ({}) AND enrichment_hash IS NOT NULL",
-                    placeholders
-                );
-                let mut query = sqlx::query_as::<_, (String, String)>(&sql);
-                for id in batch {
-                    query = query.bind(*id);
-                }
-                let rows = query.fetch_all(&self.pool).await?;
-                for (id, hash) in rows {
-                    result.insert(id, hash);
-                }
-            }
-            Ok(result)
-        })
-    }
-
-    /// Fetch all enrichment hashes in a single query.
-    ///
-    /// Returns a map from chunk_id to enrichment_hash for all chunks that have one.
-    /// Used by the enrichment pass to avoid per-page hash fetches (PERF-29).
-    pub fn get_all_enrichment_hashes(
-        &self,
-    ) -> Result<std::collections::HashMap<String, String>, StoreError> {
-        let _span = tracing::debug_span!("get_all_enrichment_hashes").entered();
-        self.rt.block_on(async {
-            let rows: Vec<(String, String)> = sqlx::query_as(
-                "SELECT id, enrichment_hash FROM chunks WHERE enrichment_hash IS NOT NULL",
-            )
-            .fetch_all(&self.pool)
-            .await?;
-            Ok(rows.into_iter().collect())
-        })
-    }
-
-    /// Get LLM summaries for a batch of content hashes.
-    ///
-    /// Returns a map from content_hash to summary text. Only includes hashes
-    /// that have summaries in the llm_summaries table matching the given purpose.
-    pub fn get_summaries_by_hashes(
-        &self,
-        content_hashes: &[&str],
-        purpose: &str,
-    ) -> Result<std::collections::HashMap<String, String>, StoreError> {
-        let _span = tracing::debug_span!(
-            "get_summaries_by_hashes",
-            count = content_hashes.len(),
-            purpose
-        )
-        .entered();
-        if content_hashes.is_empty() {
-            return Ok(std::collections::HashMap::new());
-        }
-        self.rt.block_on(async {
-            let mut result = std::collections::HashMap::new();
-            use crate::store::helpers::sql::max_rows_per_statement;
-            // Reserve one param for the purpose bind, so (limit - 1) per batch
-            for batch in content_hashes.chunks(max_rows_per_statement(1) - 1) {
-                let placeholders = crate::store::helpers::make_placeholders(batch.len());
-                let sql = format!(
-                    "SELECT content_hash, summary FROM llm_summaries WHERE content_hash IN ({}) AND purpose = ?{}",
-                    placeholders,
-                    batch.len() + 1
-                );
-                let mut query = sqlx::query_as::<_, (String, String)>(&sql);
-                for hash in batch {
-                    query = query.bind(*hash);
-                }
-                query = query.bind(purpose);
-                let rows = query.fetch_all(&self.pool).await?;
-                for (hash, summary) in rows {
-                    result.insert(hash, summary);
-                }
-            }
-            Ok(result)
-        })
-    }
-
     /// Insert or update LLM summaries in batch.
     ///
     /// Each entry is (content_hash, summary, model, purpose).
@@ -331,38 +409,6 @@ impl<Mode> Store<Mode> {
         })
     }
 
-    /// Fetch all LLM summaries as a map from content_hash to summary text.
-    ///
-    /// Single query, no batching needed (reads entire table). Used by the
-    /// enrichment pass to avoid per-page summary fetches.
-    pub fn get_all_summaries(
-        &self,
-        purpose: &str,
-    ) -> Result<std::collections::HashMap<String, String>, StoreError> {
-        let _span = tracing::debug_span!("get_all_summaries", purpose).entered();
-        self.rt.block_on(async {
-            let rows: Vec<(String, String)> = sqlx::query_as(
-                "SELECT content_hash, summary FROM llm_summaries WHERE purpose = ?1",
-            )
-            .bind(purpose)
-            .fetch_all(&self.pool)
-            .await?;
-            Ok(rows.into_iter().collect())
-        })
-    }
-
-    /// Get all distinct content hashes currently in the chunks table.
-    /// Used to validate batch results against the current index (DS-20).
-    pub fn get_all_content_hashes(&self) -> Result<Vec<String>, StoreError> {
-        let _span = tracing::debug_span!("get_all_content_hashes").entered();
-        self.rt.block_on(async {
-            let rows: Vec<(String,)> = sqlx::query_as("SELECT DISTINCT content_hash FROM chunks")
-                .fetch_all(&self.pool)
-                .await?;
-            Ok(rows.into_iter().map(|(h,)| h).collect())
-        })
-    }
-
     /// Delete orphan LLM summaries whose content_hash doesn't exist in any chunk.
     pub fn prune_orphan_summaries(&self) -> Result<usize, StoreError> {
         let _span = tracing::debug_span!("prune_orphan_summaries").entered();
@@ -374,48 +420,6 @@ impl<Mode> Store<Mode> {
             .execute(&self.pool)
             .await?;
             Ok(result.rows_affected() as usize)
-        })
-    }
-
-    /// Get all summaries with full metadata for backup/restore.
-    /// Returns Vec of (content_hash, summary, model, purpose).
-    pub fn get_all_summaries_full(
-        &self,
-    ) -> Result<Vec<(String, String, String, String)>, StoreError> {
-        let _span = tracing::debug_span!("get_all_summaries_full").entered();
-        self.rt.block_on(async {
-            let rows: Vec<(String, String, String, String)> =
-                sqlx::query_as("SELECT content_hash, summary, model, purpose FROM llm_summaries")
-                    .fetch_all(&self.pool)
-                    .await?;
-            Ok(rows)
-        })
-    }
-
-    /// Check if a file needs reindexing based on mtime.
-    ///
-    /// Returns `Ok(Some(mtime))` if reindex needed (with the file's current mtime),
-    /// or `Ok(None)` if no reindex needed. This avoids reading file metadata twice.
-    pub fn needs_reindex(&self, path: &Path) -> Result<Option<i64>, StoreError> {
-        let _span = tracing::debug_span!("needs_reindex", path = %path.display()).entered();
-        let current_mtime = path
-            .metadata()?
-            .modified()?
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_err(|_| StoreError::SystemTime)?
-            .as_millis() as i64;
-
-        self.rt.block_on(async {
-            let row: Option<(Option<i64>,)> =
-                sqlx::query_as("SELECT source_mtime FROM chunks WHERE origin = ?1 LIMIT 1")
-                    .bind(crate::normalize_path(path))
-                    .fetch_optional(&self.pool)
-                    .await?;
-
-            match row {
-                Some((Some(stored_mtime),)) if stored_mtime >= current_mtime => Ok(None),
-                _ => Ok(Some(current_mtime)),
-            }
         })
     }
 
@@ -560,8 +564,11 @@ impl<Mode> Store<Mode> {
                 .await?;
 
             for batch in live_ids.chunks(crate::store::helpers::sql::max_rows_per_statement(1)) {
-                let placeholders: Vec<String> =
-                    batch.iter().enumerate().map(|(i, _)| format!("(?{})", i + 1)).collect();
+                let placeholders: Vec<String> = batch
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| format!("(?{})", i + 1))
+                    .collect();
                 let insert_sql = format!(
                     "INSERT OR IGNORE INTO _live_ids (id) VALUES {}",
                     placeholders.join(",")

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -12,7 +12,7 @@ use crate::store::Store;
 
 use super::async_helpers::{batch_insert_chunks, snapshot_content_hashes, upsert_fts_conditional};
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Retrieve a single metadata value by key.
     ///
     /// Returns `Ok(value)` if the key exists, or `Err` if not found or on DB error.

--- a/src/store/chunks/embeddings.rs
+++ b/src/store/chunks/embeddings.rs
@@ -8,7 +8,7 @@ use crate::embedder::Embedding;
 use crate::store::helpers::{bytes_to_embedding, StoreError};
 use crate::store::Store;
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Get embeddings for chunks with matching content hashes (batch lookup).
     /// Batches queries in groups of 500 to stay within SQLite's parameter limit (~999).
     pub fn get_embeddings_by_hashes(

--- a/src/store/chunks/query.rs
+++ b/src/store/chunks/query.rs
@@ -14,7 +14,7 @@ use crate::store::helpers::{
 };
 use crate::store::Store;
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Get the number of chunks in the index
     pub fn chunk_count(&self) -> Result<u64, StoreError> {
         let _span = tracing::debug_span!("chunk_count").entered();

--- a/src/store/chunks/staleness.rs
+++ b/src/store/chunks/staleness.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use crate::store::helpers::{StaleFile, StaleReport, StoreError};
-use crate::store::Store;
+use crate::store::{ReadWrite, Store};
 
 /// Decide whether a chunk origin refers to a file that exists.
 ///
@@ -46,7 +46,7 @@ pub struct PruneAllResult {
     pub pruned_summaries: usize,
 }
 
-impl<Mode> Store<Mode> {
+impl Store<ReadWrite> {
     /// Delete chunks for files that no longer exist
     /// Batches deletes in groups of 100 to balance memory usage and query efficiency.
     /// Uses Rust HashSet for existence check rather than SQL WHERE NOT IN because:
@@ -260,7 +260,9 @@ impl<Mode> Store<Mode> {
             })
         })
     }
+}
 
+impl<Mode> Store<Mode> {
     /// Count files that are stale (mtime changed) or missing from disk.
     /// Compares stored source_mtime against current filesystem state.
     /// Only checks files with source_type='file' (not notes or other sources).

--- a/src/store/chunks/staleness.rs
+++ b/src/store/chunks/staleness.rs
@@ -46,7 +46,7 @@ pub struct PruneAllResult {
     pub pruned_summaries: usize,
 }
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Delete chunks for files that no longer exist
     /// Batches deletes in groups of 100 to balance memory usage and query efficiency.
     /// Uses Rust HashSet for existence check rather than SQL WHERE NOT IN because:

--- a/src/store/metadata.rs
+++ b/src/store/metadata.rs
@@ -35,7 +35,7 @@ impl HnswKind {
     }
 }
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Validates and optionally migrates the database schema version to match the current expected version.
     /// Queries the metadata table for the stored schema version and compares it against the current version. If the stored version is older, attempts to migrate the schema. Returns an error if the stored version is newer than the current version (indicating the database is incompatible), if the schema is corrupted, or if migration fails without a supported migration path.
     /// # Arguments

--- a/src/store/metadata.rs
+++ b/src/store/metadata.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 #[cfg(test)]
 use super::helpers::DEFAULT_MODEL_NAME;
 use super::migrations;
-use super::{NoteSummary, Store, StoreError, CURRENT_SCHEMA_VERSION};
+use super::{NoteSummary, ReadWrite, Store, StoreError, CURRENT_SCHEMA_VERSION};
 
 /// Which HNSW index a dirty-flag operation applies to.
 ///
@@ -192,51 +192,6 @@ impl<Mode> Store<Mode> {
         }
     }
 
-    /// Update the `updated_at` metadata timestamp to now.
-    /// Call after indexing operations complete (pipeline, watch reindex, note sync)
-    /// to track when the index was last modified.
-    pub fn touch_updated_at(&self) -> Result<(), StoreError> {
-        let now = chrono::Utc::now().to_rfc3339();
-        self.rt.block_on(async {
-            sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES ('updated_at', ?1)")
-                .bind(&now)
-                .execute(&self.pool)
-                .await?;
-            Ok(())
-        })
-    }
-
-    /// Mark the given HNSW index as dirty (out of sync with SQLite).
-    /// Call before writing chunks to SQLite. Clear after successful HNSW save.
-    /// On load, a dirty flag means a crash occurred between SQLite commit and
-    /// HNSW save — the affected HNSW index should not be trusted.
-    ///
-    /// AC-V1.25-8: tracked per-kind so that clearing after an enriched rebuild
-    /// does not mask a still-stale base index.
-    ///
-    /// DS-V1.25-3: the flag update goes through `begin_write`, which acquires
-    /// `WRITE_LOCK` before opening the SQLite transaction. Previously this
-    /// ran as a bare pool write and could race with a concurrent chunks
-    /// mutation: if thread A was mid-write of new chunks while thread B
-    /// cleared the dirty flag, the on-disk state could briefly advertise a
-    /// clean HNSW that didn't yet reflect the in-flight chunks. The daemon
-    /// is read-only today so the hazard isn't exploited in practice, but
-    /// the invariant is now enforced instead of documented.
-    pub fn set_hnsw_dirty(&self, kind: HnswKind, dirty: bool) -> Result<(), StoreError> {
-        let val = if dirty { "1" } else { "0" };
-        let key = kind.metadata_key();
-        self.rt.block_on(async {
-            let (_guard, mut tx) = self.begin_write().await?;
-            sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES (?1, ?2)")
-                .bind(key)
-                .bind(val)
-                .execute(&mut *tx)
-                .await?;
-            tx.commit().await?;
-            Ok(())
-        })
-    }
-
     /// Check if the given HNSW index is marked as dirty (potentially stale).
     ///
     /// Returns `false` when the per-kind key doesn't exist. For backward
@@ -265,32 +220,6 @@ impl<Mode> Store<Mode> {
         })
     }
 
-    /// Set a metadata key/value pair, or delete it if `value` is `None`.
-    pub(crate) fn set_metadata_opt(
-        &self,
-        key: &str,
-        value: Option<&str>,
-    ) -> Result<(), StoreError> {
-        self.rt.block_on(async {
-            match value {
-                Some(v) => {
-                    sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES (?1, ?2)")
-                        .bind(key)
-                        .bind(v)
-                        .execute(&self.pool)
-                        .await?;
-                }
-                None => {
-                    sqlx::query("DELETE FROM metadata WHERE key = ?1")
-                        .bind(key)
-                        .execute(&self.pool)
-                        .await?;
-                }
-            }
-            Ok(())
-        })
-    }
-
     /// Get a metadata value by key, returning `None` if the key doesn't exist.
     pub(crate) fn get_metadata_opt(&self, key: &str) -> Result<Option<String>, StoreError> {
         self.rt.block_on(async {
@@ -303,29 +232,14 @@ impl<Mode> Store<Mode> {
         })
     }
 
-    /// Store a pending LLM batch ID so interrupted processes can resume polling.
-    pub fn set_pending_batch_id(&self, batch_id: Option<&str>) -> Result<(), StoreError> {
-        self.set_metadata_opt("pending_llm_batch", batch_id)
-    }
-
     /// Get the pending LLM batch ID, if any.
     pub fn get_pending_batch_id(&self) -> Result<Option<String>, StoreError> {
         self.get_metadata_opt("pending_llm_batch")
     }
 
-    /// Store a pending doc-comment batch ID so interrupted processes can resume polling.
-    pub fn set_pending_doc_batch_id(&self, batch_id: Option<&str>) -> Result<(), StoreError> {
-        self.set_metadata_opt("pending_doc_batch", batch_id)
-    }
-
     /// Get the pending doc-comment batch ID, if any.
     pub fn get_pending_doc_batch_id(&self) -> Result<Option<String>, StoreError> {
         self.get_metadata_opt("pending_doc_batch")
-    }
-
-    /// Store a pending HyDE batch ID so interrupted processes can resume polling.
-    pub fn set_pending_hyde_batch_id(&self, batch_id: Option<&str>) -> Result<(), StoreError> {
-        self.set_metadata_opt("pending_hyde_batch", batch_id)
     }
 
     /// Get the pending HyDE batch ID, if any.
@@ -428,6 +342,96 @@ impl<Mode> Store<Mode> {
         }
         *guard = Some(Arc::clone(&built));
         Ok(built)
+    }
+}
+
+// Write methods live on `impl Store<ReadWrite>` — the compiler refuses to
+// call them on a `Store<ReadOnly>`. Closes the bug class in GitHub #946.
+impl Store<ReadWrite> {
+    /// Update the `updated_at` metadata timestamp to now.
+    /// Call after indexing operations complete (pipeline, watch reindex, note sync)
+    /// to track when the index was last modified.
+    pub fn touch_updated_at(&self) -> Result<(), StoreError> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.rt.block_on(async {
+            sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES ('updated_at', ?1)")
+                .bind(&now)
+                .execute(&self.pool)
+                .await?;
+            Ok(())
+        })
+    }
+
+    /// Mark the given HNSW index as dirty (out of sync with SQLite).
+    /// Call before writing chunks to SQLite. Clear after successful HNSW save.
+    /// On load, a dirty flag means a crash occurred between SQLite commit and
+    /// HNSW save — the affected HNSW index should not be trusted.
+    ///
+    /// AC-V1.25-8: tracked per-kind so that clearing after an enriched rebuild
+    /// does not mask a still-stale base index.
+    ///
+    /// DS-V1.25-3: the flag update goes through `begin_write`, which acquires
+    /// `WRITE_LOCK` before opening the SQLite transaction. Previously this
+    /// ran as a bare pool write and could race with a concurrent chunks
+    /// mutation: if thread A was mid-write of new chunks while thread B
+    /// cleared the dirty flag, the on-disk state could briefly advertise a
+    /// clean HNSW that didn't yet reflect the in-flight chunks. The daemon
+    /// is read-only today so the hazard isn't exploited in practice, but
+    /// the invariant is now enforced instead of documented.
+    pub fn set_hnsw_dirty(&self, kind: HnswKind, dirty: bool) -> Result<(), StoreError> {
+        let val = if dirty { "1" } else { "0" };
+        let key = kind.metadata_key();
+        self.rt.block_on(async {
+            let (_guard, mut tx) = self.begin_write().await?;
+            sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES (?1, ?2)")
+                .bind(key)
+                .bind(val)
+                .execute(&mut *tx)
+                .await?;
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    /// Set a metadata key/value pair, or delete it if `value` is `None`.
+    pub(crate) fn set_metadata_opt(
+        &self,
+        key: &str,
+        value: Option<&str>,
+    ) -> Result<(), StoreError> {
+        self.rt.block_on(async {
+            match value {
+                Some(v) => {
+                    sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES (?1, ?2)")
+                        .bind(key)
+                        .bind(v)
+                        .execute(&self.pool)
+                        .await?;
+                }
+                None => {
+                    sqlx::query("DELETE FROM metadata WHERE key = ?1")
+                        .bind(key)
+                        .execute(&self.pool)
+                        .await?;
+                }
+            }
+            Ok(())
+        })
+    }
+
+    /// Store a pending LLM batch ID so interrupted processes can resume polling.
+    pub fn set_pending_batch_id(&self, batch_id: Option<&str>) -> Result<(), StoreError> {
+        self.set_metadata_opt("pending_llm_batch", batch_id)
+    }
+
+    /// Store a pending doc-comment batch ID so interrupted processes can resume polling.
+    pub fn set_pending_doc_batch_id(&self, batch_id: Option<&str>) -> Result<(), StoreError> {
+        self.set_metadata_opt("pending_doc_batch", batch_id)
+    }
+
+    /// Store a pending HyDE batch ID so interrupted processes can resume polling.
+    pub fn set_pending_hyde_batch_id(&self, batch_id: Option<&str>) -> Result<(), StoreError> {
+        self.set_metadata_opt("pending_hyde_batch", batch_id)
     }
 }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -31,6 +31,7 @@ mod types;
 /// types from `cqs::store` instead of accessing `cqs::store::helpers` directly.
 pub(crate) mod helpers;
 
+use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
@@ -200,10 +201,38 @@ pub(crate) fn sanitize_fts_query(s: &str) -> String {
     trimmed.to_string()
 }
 
+/// Typestate marker for a store opened in read-only mode.
+///
+/// A [`Store<ReadOnly>`] exposes only query methods. Write methods
+/// (`upsert_*`, `set_*`, `delete_*`, `prune_*`, etc.) live exclusively
+/// on `impl Store<ReadWrite>`, so the compiler refuses to call them on
+/// a read-only store. This converts a class of runtime errors into
+/// compile-time errors — see the closed-bug examples in GitHub #946.
+#[derive(Debug, Clone, Copy)]
+pub struct ReadOnly;
+
+/// Typestate marker for a store opened in read-write mode.
+///
+/// A [`Store<ReadWrite>`] exposes the full surface: both query and
+/// mutation methods. This is the default type parameter of `Store`, so
+/// bare `Store` in legacy code is equivalent to `Store<ReadWrite>`.
+#[derive(Debug, Clone, Copy)]
+pub struct ReadWrite;
+
 /// Thread-safe SQLite store for chunks and embeddings
 /// Uses sqlx connection pooling for concurrent reads and WAL mode
 /// for crash safety. All methods are synchronous but internally use
 /// an async runtime to execute sqlx operations.
+///
+/// # Typestate
+///
+/// The `Mode` type parameter records whether the store was opened
+/// read-only or read-write. Read methods live on `impl<Mode> Store<Mode>`
+/// and are available to both. Write methods live on `impl Store<ReadWrite>`
+/// only — the compiler refuses any attempt to call a mutating method on
+/// a `Store<ReadOnly>` handle (GitHub #946). `Mode` defaults to
+/// [`ReadWrite`] so bare `Store` keeps working for legacy call sites.
+///
 /// # Memory-mapped I/O
 /// `open()` sets `PRAGMA mmap_size = 256MB` per connection with a 4-connection pool,
 /// reserving up to 1GB of virtual address space. `open_readonly()` uses 64MB × 1.
@@ -219,7 +248,7 @@ pub(crate) fn sanitize_fts_query(s: &str) -> String {
 /// println!("Indexed {} chunks", stats.total_chunks);
 /// # Ok::<(), anyhow::Error>(())
 /// ```
-pub struct Store {
+pub struct Store<Mode = ReadWrite> {
     pub(crate) pool: SqlitePool,
     pub(crate) rt: Runtime,
     /// Embedding dimension for this store (read from metadata on open, default `EMBEDDING_DIM`).
@@ -237,6 +266,8 @@ pub struct Store {
     call_graph_cache: std::sync::OnceLock<std::sync::Arc<CallGraph>>,
     test_chunks_cache: std::sync::OnceLock<std::sync::Arc<Vec<ChunkSummary>>>,
     chunk_type_map_cache: std::sync::OnceLock<std::sync::Arc<ChunkTypeMap>>,
+    /// Typestate marker — `ReadOnly` or `ReadWrite`. Zero-sized.
+    _mode: PhantomData<Mode>,
 }
 
 /// Map from chunk ID to (ChunkType, Language) — used by HNSW traversal-time filtering.
@@ -578,7 +609,7 @@ fn cache_size_from_env(default_kib: &str) -> String {
         .unwrap_or_else(|| default_kib.to_string())
 }
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Embedding dimension for vectors in this store.
     pub fn dim(&self) -> usize {
         self.dim
@@ -590,7 +621,9 @@ impl Store {
     pub fn set_dim(&mut self, dim: usize) {
         self.dim = dim;
     }
+}
 
+impl Store<ReadWrite> {
     /// Open an existing index with connection pooling
     pub fn open(path: &Path) -> Result<Self, StoreError> {
         let max_connections = std::env::var("CQS_MAX_CONNECTIONS")
@@ -844,6 +877,7 @@ impl Store {
             call_graph_cache: std::sync::OnceLock::new(),
             test_chunks_cache: std::sync::OnceLock::new(),
             chunk_type_map_cache: std::sync::OnceLock::new(),
+            _mode: PhantomData,
         };
 
         // Skip model name validation on open — dimension is validated at embed time,
@@ -854,7 +888,9 @@ impl Store {
 
         Ok(store)
     }
+}
 
+impl<Mode> Store<Mode> {
     /// Begin a write transaction with in-process serialization (DS-5).
     ///
     /// Acquires `WRITE_LOCK` before calling `pool.begin()`, preventing two
@@ -1113,7 +1149,7 @@ CREATE TABLE baz (id INTEGER);
     }
 }
 
-impl Drop for Store {
+impl<Mode> Drop for Store<Mode> {
     /// Performs a best-effort WAL (Write-Ahead Logging) checkpoint when the Store is dropped to prevent accumulation of large WAL files.
     /// # Arguments
     /// * `&mut self` - A mutable reference to the Store instance being dropped

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -624,6 +624,35 @@ impl<Mode> Store<Mode> {
 }
 
 impl Store<ReadWrite> {
+    /// Erase the write capability at the type level. No SQLite-level change —
+    /// the connection stays open in read-write mode but the `ReadOnly` marker
+    /// blocks `Store<ReadWrite>`-gated methods at compile time. Used by tests
+    /// that build fixture data under `ReadWrite` before handing the store to
+    /// an API that accepts only `Store<ReadOnly>` (e.g. `ReferenceIndex`,
+    /// `NamedStore`). Production code should prefer `Store::open_readonly`.
+    pub fn into_readonly(self) -> Store<ReadOnly> {
+        // `Store<Mode>` implements `Drop`, so we cannot move fields out with
+        // normal assignment. Use `ManuallyDrop` + `ptr::read` to transfer
+        // ownership field-by-field; the source is forgotten so its Drop
+        // doesn't run twice. Safe because we initialize every field of the
+        // returned `Store<ReadOnly>` exactly once.
+        let me = std::mem::ManuallyDrop::new(self);
+        unsafe {
+            Store {
+                pool: std::ptr::read(&me.pool),
+                rt: std::ptr::read(&me.rt),
+                dim: me.dim,
+                closed: std::ptr::read(&me.closed),
+                notes_summaries_cache: std::ptr::read(&me.notes_summaries_cache),
+                note_boost_cache: std::ptr::read(&me.note_boost_cache),
+                call_graph_cache: std::ptr::read(&me.call_graph_cache),
+                test_chunks_cache: std::ptr::read(&me.test_chunks_cache),
+                chunk_type_map_cache: std::ptr::read(&me.chunk_type_map_cache),
+                _mode: PhantomData,
+            }
+        }
+    }
+
     /// Open an existing index with connection pooling
     pub fn open(path: &Path) -> Result<Self, StoreError> {
         let max_connections = std::env::var("CQS_MAX_CONNECTIONS")
@@ -642,7 +671,9 @@ impl Store<ReadWrite> {
             },
         )
     }
+}
 
+impl Store<ReadOnly> {
     /// Open an existing index in read-only mode with single-threaded runtime
     /// but full memory. Uses `current_thread` tokio runtime (1 OS thread
     /// instead of 4) while keeping the full 256MB mmap and 16MB cache of
@@ -653,7 +684,7 @@ impl Store<ReadWrite> {
     /// AD-1: Renamed from `open_light` to clarify semantics — this is a
     /// read-only pooled connection, not a "light" store.
     pub fn open_readonly_pooled(path: &Path) -> Result<Self, StoreError> {
-        Self::open_with_config(
+        open_with_config_impl::<ReadOnly>(
             path,
             StoreOpenConfig {
                 read_only: true,
@@ -670,7 +701,7 @@ impl Store<ReadWrite> {
     /// Uses minimal connection pool, smaller cache, and single-threaded runtime.
     /// Suitable for reference stores and background builds that only read data.
     pub fn open_readonly(path: &Path) -> Result<Self, StoreError> {
-        Self::open_with_config(
+        open_with_config_impl::<ReadOnly>(
             path,
             StoreOpenConfig {
                 read_only: true,
@@ -689,7 +720,7 @@ impl Store<ReadWrite> {
         path: &Path,
         runtime: Runtime,
     ) -> Result<Self, StoreError> {
-        Self::open_with_config(
+        open_with_config_impl::<ReadOnly>(
             path,
             StoreOpenConfig {
                 read_only: true,
@@ -701,193 +732,207 @@ impl Store<ReadWrite> {
             },
         )
     }
+}
 
-    /// Shared open logic for both read-write and read-only modes.
+impl Store<ReadWrite> {
+    /// Shared open logic for read-write mode (delegates to
+    /// `open_with_config_impl`). See that free function for shared logic.
     fn open_with_config(path: &Path, config: StoreOpenConfig) -> Result<Self, StoreError> {
-        let mode = if config.read_only { "readonly" } else { "open" };
-        let _span = tracing::info_span!("store_open", %mode, path = %path.display()).entered();
-
-        // Reuse provided runtime or build a new one.
-        let rt = if let Some(rt) = config.runtime {
-            rt
-        } else if config.use_current_thread {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()?
-        } else {
-            tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(config.max_connections as usize)
-                .enable_all()
-                .build()?
-        };
-
-        // Use SqliteConnectOptions::filename() to avoid URL parsing issues with
-        // special characters in paths (spaces, #, ?, %, unicode).
-        let mut connect_opts = SqliteConnectOptions::new()
-            .filename(path)
-            .foreign_keys(true)
-            .journal_mode(SqliteJournalMode::Wal)
-            .busy_timeout(helpers::sql::busy_timeout_from_env(5000))
-            // NORMAL synchronous in WAL mode: fsync on checkpoint, not every commit.
-            // Trade-off: a crash can lose the last few committed transactions (WAL
-            // tail not yet fsynced), but the database remains consistent. Acceptable
-            // for a rebuildable search index — `cqs index --force` recovers fully.
-            // FULL would fsync every commit, ~2x slower on spinning disk / WSL-NTFS.
-            .synchronous(SqliteSynchronous::Normal)
-            .pragma("mmap_size", config.mmap_size)
-            .log_slow_statements(log::LevelFilter::Warn, std::time::Duration::from_secs(5));
-
-        if config.read_only {
-            connect_opts = connect_opts.read_only(true);
-        } else {
-            connect_opts = connect_opts.create_if_missing(true);
-        }
-
-        // Build cache_size PRAGMA string once for the after_connect closure.
-        let cache_pragma = format!("PRAGMA cache_size = {}", config.cache_size);
-
-        let pool = rt.block_on(async {
-            SqlitePoolOptions::new()
-                .max_connections(config.max_connections)
-                .idle_timeout(std::time::Duration::from_secs(
-                    std::env::var("CQS_IDLE_TIMEOUT_SECS")
-                        .ok()
-                        .and_then(|v| v.parse::<u64>().ok())
-                        .unwrap_or(30), // PB-2: shorter timeout to release WAL locks
-                ))
-                .after_connect(move |conn, _meta| {
-                    let pragma = cache_pragma.clone();
-                    Box::pin(async move {
-                        sqlx::query(&pragma).execute(&mut *conn).await?;
-                        sqlx::query("PRAGMA temp_store = MEMORY")
-                            .execute(&mut *conn)
-                            .await?;
-                        Ok(())
-                    })
-                })
-                .connect_with(connect_opts)
-                .await
-        })?;
-
-        // Set restrictive permissions on database files (Unix only, write mode only)
-        #[cfg(unix)]
-        if !config.read_only {
-            use std::os::unix::fs::PermissionsExt;
-            let restrictive = std::fs::Permissions::from_mode(0o600);
-            if let Err(e) = std::fs::set_permissions(path, restrictive.clone()) {
-                tracing::debug!(path = %path.display(), error = %e, "Failed to set permissions");
-            }
-            let wal_path = path.with_extension("db-wal");
-            let shm_path = path.with_extension("db-shm");
-            if let Err(e) = std::fs::set_permissions(&wal_path, restrictive.clone()) {
-                tracing::debug!(path = %wal_path.display(), error = %e, "Failed to set permissions");
-            }
-            if let Err(e) = std::fs::set_permissions(&shm_path, restrictive) {
-                tracing::debug!(path = %shm_path.display(), error = %e, "Failed to set permissions");
-            }
-        }
-
-        tracing::info!(
-            path = %path.display(),
-            read_only = config.read_only,
-            "Database connected"
-        );
-
-        // Cheap B-tree sanity check — write opens only.
-        //
-        // The previous `PRAGMA integrity_check(1)` walked every page and took
-        // 85s+ on a 1.1GB database over WSL /mnt/c, dominating every CLI
-        // invocation and blocking the eval harness (each `cqs search` shelled
-        // out, each open re-paid the cost). Two changes fix that:
-        //
-        // 1. Skip the check entirely on read-only opens. Reads cannot
-        //    introduce corruption, and if a read encounters corrupt pages the
-        //    query will fail naturally — an upfront walk of the whole file
-        //    just to pre-discover that is not earning its cost for a
-        //    rebuildable search index.
-        // 2. On write opens, use `PRAGMA quick_check` instead of
-        //    `integrity_check`. quick_check validates the B-tree structure
-        //    without the slower cross-checks of index content vs table
-        //    content, which is the right tradeoff for a startup canary.
-        //
-        // Opt-in via CQS_INTEGRITY_CHECK=1. The quick_check takes ~40s on
-        // WSL /mnt/c (NTFS over 9P) which dominated every write-open. For a
-        // rebuildable search index the risk/cost tradeoff favors skipping by
-        // default. Legacy CQS_SKIP_INTEGRITY_CHECK=1 still works (forces skip
-        // even when CQS_INTEGRITY_CHECK=1 is set).
-        let opt_in = std::env::var("CQS_INTEGRITY_CHECK").as_deref() == Ok("1");
-        let force_skip = std::env::var("CQS_SKIP_INTEGRITY_CHECK").as_deref() == Ok("1");
-        let run_check = opt_in && !force_skip && !config.read_only;
-        if config.read_only {
-            tracing::debug!("Skipping integrity check (read-only open)");
-        } else if !run_check {
-            tracing::debug!("Integrity check skipped (set CQS_INTEGRITY_CHECK=1 to enable)");
-        }
-        if run_check {
-            rt.block_on(async {
-                let result: (String,) = sqlx::query_as("PRAGMA quick_check(1)")
-                    .fetch_one(&pool)
-                    .await?;
-                if result.0 != "ok" {
-                    return Err(StoreError::Corruption(result.0));
-                }
-                Ok::<_, StoreError>(())
-            })?;
-        }
-
-        // Read dim from metadata before constructing Store (avoid unsafe mutation).
-        // Defaults to EMBEDDING_DIM for fresh/pre-v15 databases without dimensions key.
-        let dim = rt
-            .block_on(async {
-                let row: Option<(String,)> =
-                    match sqlx::query_as("SELECT value FROM metadata WHERE key = 'dimensions'")
-                        .fetch_optional(&pool)
-                        .await
-                    {
-                        Ok(r) => r,
-                        Err(sqlx::Error::Database(e)) if e.message().contains("no such table") => {
-                            return Ok::<_, StoreError>(None);
-                        }
-                        Err(e) => return Err(e.into()),
-                    };
-                Ok(match row {
-                    Some((s,)) => match s.parse::<u32>() {
-                        Ok(0) => {
-                            tracing::warn!(raw = %s, "dimensions metadata is 0 — invalid, using default");
-                            None
-                        }
-                        Ok(d) => Some(d as usize),
-                        Err(e) => {
-                            tracing::warn!(raw = %s, error = %e, "dimensions metadata is not a valid integer, using default");
-                            None
-                        }
-                    },
-                    None => None,
-                })
-            })?
-            .unwrap_or(crate::EMBEDDING_DIM);
-
-        let store = Self {
-            pool,
-            rt,
-            dim,
-            closed: AtomicBool::new(false),
-            notes_summaries_cache: RwLock::new(None),
-            note_boost_cache: RwLock::new(None),
-            call_graph_cache: std::sync::OnceLock::new(),
-            test_chunks_cache: std::sync::OnceLock::new(),
-            chunk_type_map_cache: std::sync::OnceLock::new(),
-            _mode: PhantomData,
-        };
-
-        // Skip model name validation on open — dimension is validated at embed time,
-        // and configurable models (v1.7.0) can legitimately use any model name.
-        // Model mismatch is checked at index time via check_model_version_with().
-        store.check_schema_version(path)?;
-        store.check_cq_version();
-
-        Ok(store)
+        open_with_config_impl::<ReadWrite>(path, config)
     }
+}
+
+/// Shared open implementation used by `Store<ReadWrite>::open_with_config` and
+/// `Store<ReadOnly>::open_with_config`. Lives as a free function so both
+/// typestate-specific impl blocks can materialize `Store<Mode>` from the same
+/// connection/pool/validation logic.
+fn open_with_config_impl<Mode>(
+    path: &Path,
+    config: StoreOpenConfig,
+) -> Result<Store<Mode>, StoreError> {
+    let mode = if config.read_only { "readonly" } else { "open" };
+    let _span = tracing::info_span!("store_open", %mode, path = %path.display()).entered();
+
+    // Reuse provided runtime or build a new one.
+    let rt = if let Some(rt) = config.runtime {
+        rt
+    } else if config.use_current_thread {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?
+    } else {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(config.max_connections as usize)
+            .enable_all()
+            .build()?
+    };
+
+    // Use SqliteConnectOptions::filename() to avoid URL parsing issues with
+    // special characters in paths (spaces, #, ?, %, unicode).
+    let mut connect_opts = SqliteConnectOptions::new()
+        .filename(path)
+        .foreign_keys(true)
+        .journal_mode(SqliteJournalMode::Wal)
+        .busy_timeout(helpers::sql::busy_timeout_from_env(5000))
+        // NORMAL synchronous in WAL mode: fsync on checkpoint, not every commit.
+        // Trade-off: a crash can lose the last few committed transactions (WAL
+        // tail not yet fsynced), but the database remains consistent. Acceptable
+        // for a rebuildable search index — `cqs index --force` recovers fully.
+        // FULL would fsync every commit, ~2x slower on spinning disk / WSL-NTFS.
+        .synchronous(SqliteSynchronous::Normal)
+        .pragma("mmap_size", config.mmap_size)
+        .log_slow_statements(log::LevelFilter::Warn, std::time::Duration::from_secs(5));
+
+    if config.read_only {
+        connect_opts = connect_opts.read_only(true);
+    } else {
+        connect_opts = connect_opts.create_if_missing(true);
+    }
+
+    // Build cache_size PRAGMA string once for the after_connect closure.
+    let cache_pragma = format!("PRAGMA cache_size = {}", config.cache_size);
+
+    let pool = rt.block_on(async {
+        SqlitePoolOptions::new()
+            .max_connections(config.max_connections)
+            .idle_timeout(std::time::Duration::from_secs(
+                std::env::var("CQS_IDLE_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok())
+                    .unwrap_or(30), // PB-2: shorter timeout to release WAL locks
+            ))
+            .after_connect(move |conn, _meta| {
+                let pragma = cache_pragma.clone();
+                Box::pin(async move {
+                    sqlx::query(&pragma).execute(&mut *conn).await?;
+                    sqlx::query("PRAGMA temp_store = MEMORY")
+                        .execute(&mut *conn)
+                        .await?;
+                    Ok(())
+                })
+            })
+            .connect_with(connect_opts)
+            .await
+    })?;
+
+    // Set restrictive permissions on database files (Unix only, write mode only)
+    #[cfg(unix)]
+    if !config.read_only {
+        use std::os::unix::fs::PermissionsExt;
+        let restrictive = std::fs::Permissions::from_mode(0o600);
+        if let Err(e) = std::fs::set_permissions(path, restrictive.clone()) {
+            tracing::debug!(path = %path.display(), error = %e, "Failed to set permissions");
+        }
+        let wal_path = path.with_extension("db-wal");
+        let shm_path = path.with_extension("db-shm");
+        if let Err(e) = std::fs::set_permissions(&wal_path, restrictive.clone()) {
+            tracing::debug!(path = %wal_path.display(), error = %e, "Failed to set permissions");
+        }
+        if let Err(e) = std::fs::set_permissions(&shm_path, restrictive) {
+            tracing::debug!(path = %shm_path.display(), error = %e, "Failed to set permissions");
+        }
+    }
+
+    tracing::info!(
+        path = %path.display(),
+        read_only = config.read_only,
+        "Database connected"
+    );
+
+    // Cheap B-tree sanity check — write opens only.
+    //
+    // The previous `PRAGMA integrity_check(1)` walked every page and took
+    // 85s+ on a 1.1GB database over WSL /mnt/c, dominating every CLI
+    // invocation and blocking the eval harness (each `cqs search` shelled
+    // out, each open re-paid the cost). Two changes fix that:
+    //
+    // 1. Skip the check entirely on read-only opens. Reads cannot
+    //    introduce corruption, and if a read encounters corrupt pages the
+    //    query will fail naturally — an upfront walk of the whole file
+    //    just to pre-discover that is not earning its cost for a
+    //    rebuildable search index.
+    // 2. On write opens, use `PRAGMA quick_check` instead of
+    //    `integrity_check`. quick_check validates the B-tree structure
+    //    without the slower cross-checks of index content vs table
+    //    content, which is the right tradeoff for a startup canary.
+    //
+    // Opt-in via CQS_INTEGRITY_CHECK=1. The quick_check takes ~40s on
+    // WSL /mnt/c (NTFS over 9P) which dominated every write-open. For a
+    // rebuildable search index the risk/cost tradeoff favors skipping by
+    // default. Legacy CQS_SKIP_INTEGRITY_CHECK=1 still works (forces skip
+    // even when CQS_INTEGRITY_CHECK=1 is set).
+    let opt_in = std::env::var("CQS_INTEGRITY_CHECK").as_deref() == Ok("1");
+    let force_skip = std::env::var("CQS_SKIP_INTEGRITY_CHECK").as_deref() == Ok("1");
+    let run_check = opt_in && !force_skip && !config.read_only;
+    if config.read_only {
+        tracing::debug!("Skipping integrity check (read-only open)");
+    } else if !run_check {
+        tracing::debug!("Integrity check skipped (set CQS_INTEGRITY_CHECK=1 to enable)");
+    }
+    if run_check {
+        rt.block_on(async {
+            let result: (String,) = sqlx::query_as("PRAGMA quick_check(1)")
+                .fetch_one(&pool)
+                .await?;
+            if result.0 != "ok" {
+                return Err(StoreError::Corruption(result.0));
+            }
+            Ok::<_, StoreError>(())
+        })?;
+    }
+
+    // Read dim from metadata before constructing Store (avoid unsafe mutation).
+    // Defaults to EMBEDDING_DIM for fresh/pre-v15 databases without dimensions key.
+    let dim = rt
+        .block_on(async {
+            let row: Option<(String,)> =
+                match sqlx::query_as("SELECT value FROM metadata WHERE key = 'dimensions'")
+                    .fetch_optional(&pool)
+                    .await
+                {
+                    Ok(r) => r,
+                    Err(sqlx::Error::Database(e)) if e.message().contains("no such table") => {
+                        return Ok::<_, StoreError>(None);
+                    }
+                    Err(e) => return Err(e.into()),
+                };
+            Ok(match row {
+                Some((s,)) => match s.parse::<u32>() {
+                    Ok(0) => {
+                        tracing::warn!(raw = %s, "dimensions metadata is 0 — invalid, using default");
+                        None
+                    }
+                    Ok(d) => Some(d as usize),
+                    Err(e) => {
+                        tracing::warn!(raw = %s, error = %e, "dimensions metadata is not a valid integer, using default");
+                        None
+                    }
+                },
+                None => None,
+            })
+        })?
+        .unwrap_or(crate::EMBEDDING_DIM);
+
+    let store: Store<Mode> = Store {
+        pool,
+        rt,
+        dim,
+        closed: AtomicBool::new(false),
+        notes_summaries_cache: RwLock::new(None),
+        note_boost_cache: RwLock::new(None),
+        call_graph_cache: std::sync::OnceLock::new(),
+        test_chunks_cache: std::sync::OnceLock::new(),
+        chunk_type_map_cache: std::sync::OnceLock::new(),
+        _mode: PhantomData,
+    };
+
+    // Skip model name validation on open — dimension is validated at embed time,
+    // and configurable models (v1.7.0) can legitimately use any model name.
+    // Model mismatch is checked at index time via check_model_version_with().
+    store.check_schema_version(path)?;
+    store.check_cq_version();
+
+    Ok(store)
 }
 
 impl Store<ReadWrite> {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -890,7 +890,7 @@ impl Store<ReadWrite> {
     }
 }
 
-impl<Mode> Store<Mode> {
+impl Store<ReadWrite> {
     /// Begin a write transaction with in-process serialization (DS-5).
     ///
     /// Acquires `WRITE_LOCK` before calling `pool.begin()`, preventing two
@@ -916,33 +916,6 @@ impl<Mode> Store<Mode> {
         let guard = WRITE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tx = self.pool.begin().await?;
         Ok((guard, tx))
-    }
-
-    /// Reset all in-memory caches without closing the connection pool.
-    ///
-    /// Cheaper than `drop` + `open`: avoids pool teardown, runtime creation,
-    /// PRAGMA setup, and integrity check. Designed for long-lived Store
-    /// instances (watch mode, future daemon) that need to pick up index
-    /// changes without paying full re-open cost.
-    ///
-    /// Requires `&mut self` — exclusive access guarantees no concurrent
-    /// readers see a half-cleared state.
-    pub fn clear_caches(&mut self) {
-        let _span = tracing::debug_span!("store_clear_caches").entered();
-        *self
-            .notes_summaries_cache
-            .write()
-            .unwrap_or_else(|e| e.into_inner()) = None;
-        // PF-V1.25-4: note_boost_cache is derived from notes_summaries_cache;
-        // clear alongside it so a reset doesn't leave stale boost data.
-        *self
-            .note_boost_cache
-            .write()
-            .unwrap_or_else(|e| e.into_inner()) = None;
-        self.call_graph_cache = std::sync::OnceLock::new();
-        self.test_chunks_cache = std::sync::OnceLock::new();
-        self.chunk_type_map_cache = std::sync::OnceLock::new();
-        tracing::debug!("Store caches cleared");
     }
 
     /// Create a new index
@@ -1004,6 +977,35 @@ impl<Mode> Store<Mode> {
 
             Ok(())
         })
+    }
+}
+
+impl<Mode> Store<Mode> {
+    /// Reset all in-memory caches without closing the connection pool.
+    ///
+    /// Cheaper than `drop` + `open`: avoids pool teardown, runtime creation,
+    /// PRAGMA setup, and integrity check. Designed for long-lived Store
+    /// instances (watch mode, future daemon) that need to pick up index
+    /// changes without paying full re-open cost.
+    ///
+    /// Requires `&mut self` — exclusive access guarantees no concurrent
+    /// readers see a half-cleared state.
+    pub fn clear_caches(&mut self) {
+        let _span = tracing::debug_span!("store_clear_caches").entered();
+        *self
+            .notes_summaries_cache
+            .write()
+            .unwrap_or_else(|e| e.into_inner()) = None;
+        // PF-V1.25-4: note_boost_cache is derived from notes_summaries_cache;
+        // clear alongside it so a reset doesn't leave stale boost data.
+        *self
+            .note_boost_cache
+            .write()
+            .unwrap_or_else(|e| e.into_inner()) = None;
+        self.call_graph_cache = std::sync::OnceLock::new();
+        self.test_chunks_cache = std::sync::OnceLock::new();
+        self.chunk_type_map_cache = std::sync::OnceLock::new();
+        tracing::debug!("Store caches cleared");
     }
 
     /// Gracefully close the store, performing WAL checkpoint.

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -57,7 +57,7 @@ async fn insert_note_with_fts(
     Ok(())
 }
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Insert or update notes in batch
     pub fn upsert_notes_batch(
         &self,

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use sqlx::Row;
 
 use super::helpers::{NoteStats, NoteSummary, StoreError};
-use super::Store;
+use super::{ReadWrite, Store};
 use crate::nl::normalize_for_fts;
 use crate::note::Note;
 use crate::note::{SENTIMENT_NEGATIVE_THRESHOLD, SENTIMENT_POSITIVE_THRESHOLD};
@@ -57,7 +57,7 @@ async fn insert_note_with_fts(
     Ok(())
 }
 
-impl<Mode> Store<Mode> {
+impl Store<ReadWrite> {
     /// Insert or update notes in batch
     pub fn upsert_notes_batch(
         &self,
@@ -133,7 +133,9 @@ impl<Mode> Store<Mode> {
             Ok(notes.len())
         })
     }
+}
 
+impl<Mode> Store<Mode> {
     /// Check if notes file needs reindexing based on mtime.
     /// Returns `Ok(Some(mtime))` if reindex needed (with the file's current mtime),
     /// or `Ok(None)` if no reindex needed. This avoids reading file metadata twice.

--- a/src/store/search.rs
+++ b/src/store/search.rs
@@ -34,7 +34,7 @@ fn rrf_k() -> f32 {
     })
 }
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Search FTS5 index for keyword matches.
     ///
     /// # Search Method Overview

--- a/src/store/search.rs
+++ b/src/store/search.rs
@@ -220,6 +220,7 @@ impl<Mode> Store<Mode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::store::ReadOnly;
     use proptest::prelude::*;
 
     // ===== Property-based tests for RRF =====
@@ -232,7 +233,7 @@ mod tests {
             fts in prop::collection::vec("[a-z]{1,5}", 0..20),
             limit in 1usize..50
         ) {
-            let result = Store::rrf_fuse_test(&semantic, &fts, limit);
+            let result = Store::<ReadOnly>::rrf_fuse_test(&semantic, &fts, limit);
             for (_, score) in &result {
                 prop_assert!(*score > 0.0, "RRF score should be positive: {}", score);
             }
@@ -247,7 +248,7 @@ mod tests {
             fts in prop::collection::vec("[a-z]{1,5}", 0..20),
             limit in 1usize..50
         ) {
-            let result = Store::rrf_fuse_test(&semantic, &fts, limit);
+            let result = Store::<ReadOnly>::rrf_fuse_test(&semantic, &fts, limit);
             // Conservative upper bound: sum of first N terms of 1/(K+r+1) for both lists
             // where N is max list length (20). With duplicates, actual max is ~0.3
             let max_possible = 0.5; // generous bound accounting for duplicates
@@ -267,7 +268,7 @@ mod tests {
             fts in prop::collection::vec("[a-z]{1,5}", 0..30),
             limit in 1usize..20
         ) {
-            let result = Store::rrf_fuse_test(&semantic, &fts, limit);
+            let result = Store::<ReadOnly>::rrf_fuse_test(&semantic, &fts, limit);
             prop_assert!(
                 result.len() <= limit,
                 "Result length {} exceeds limit {}",
@@ -282,7 +283,7 @@ mod tests {
             fts in prop::collection::vec("[a-z]{1,5}", 1..20),
             limit in 1usize..50
         ) {
-            let result = Store::rrf_fuse_test(&semantic, &fts, limit);
+            let result = Store::<ReadOnly>::rrf_fuse_test(&semantic, &fts, limit);
             for window in result.windows(2) {
                 prop_assert!(
                     window[0].1 >= window[1].1,
@@ -306,7 +307,7 @@ mod tests {
             let mut fts = vec![common_id.clone()];
             fts.extend(only_fts);
 
-            let result = Store::rrf_fuse_test(&semantic, &fts, 100);
+            let result = Store::<ReadOnly>::rrf_fuse_test(&semantic, &fts, 100);
 
             let common_score = result.iter()
                 .find(|(id, _)| id == &common_id)

--- a/src/store/sparse.rs
+++ b/src/store/sparse.rs
@@ -76,7 +76,7 @@ pub(crate) async fn bump_splade_generation_tx(
     Ok(())
 }
 
-impl Store {
+impl<Mode> Store<Mode> {
     /// Upsert sparse vectors for a batch of chunks.
     /// Replaces existing vectors for the same chunk_id.
     ///

--- a/src/store/sparse.rs
+++ b/src/store/sparse.rs
@@ -19,7 +19,7 @@
 //! DS-W4, EH-1/2/3/4, API-14) apply here. Do not add a fourth write site
 //! without wiring the bump.
 
-use super::Store;
+use super::{ReadWrite, Store};
 use crate::splade::SparseVector;
 use crate::store::StoreError;
 
@@ -76,7 +76,7 @@ pub(crate) async fn bump_splade_generation_tx(
     Ok(())
 }
 
-impl<Mode> Store<Mode> {
+impl Store<ReadWrite> {
     /// Upsert sparse vectors for a batch of chunks.
     /// Replaces existing vectors for the same chunk_id.
     ///
@@ -210,7 +210,9 @@ impl<Mode> Store<Mode> {
             Ok(total)
         })
     }
+}
 
+impl<Mode> Store<Mode> {
     /// Load all sparse vectors for building the in-memory SpladeIndex.
     /// Returns Vec of (chunk_id, sparse_vector).
     ///
@@ -352,7 +354,9 @@ impl<Mode> Store<Mode> {
             Ok(result)
         })
     }
+}
 
+impl Store<ReadWrite> {
     /// Delete sparse vectors for chunks that no longer exist.
     ///
     /// **As of v19 this is a no-op on clean data** — the `sparse_vectors` →
@@ -395,7 +399,9 @@ impl<Mode> Store<Mode> {
             Ok(affected as usize)
         })
     }
+}
 
+impl<Mode> Store<Mode> {
     /// Read the current SPLADE generation counter from the metadata table.
     ///
     /// Returns `0` when the key is missing (fresh DB, no sparse vectors ever

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -138,7 +138,7 @@ async fn upsert_type_edges_one_file(
     Ok(edges.len())
 }
 
-impl Store {
+impl<Mode> Store<Mode> {
     // ============ Type Edge Upsert Methods ============
 
     /// Upsert type edges for a single chunk.

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 
 use super::helpers::sql::max_rows_per_statement;
 use super::helpers::{clamp_line_number, ChunkRow, StoreError};
-use super::Store;
+use super::{ReadWrite, Store};
 use crate::store::helpers::ChunkSummary;
 
 /// Statistics about type dependency edges
@@ -138,7 +138,7 @@ async fn upsert_type_edges_one_file(
     Ok(edges.len())
 }
 
-impl<Mode> Store<Mode> {
+impl Store<ReadWrite> {
     // ============ Type Edge Upsert Methods ============
 
     /// Upsert type edges for a single chunk.
@@ -273,7 +273,9 @@ impl<Mode> Store<Mode> {
             Ok(())
         })
     }
+}
 
+impl<Mode> Store<Mode> {
     // ============ Type Edge Query Methods ============
 
     /// Get chunks that reference a given type name.
@@ -524,7 +526,9 @@ impl<Mode> Store<Mode> {
                 .collect())
         })
     }
+}
 
+impl Store<ReadWrite> {
     // ============ Type Edge Maintenance ============
 
     /// Delete type_edges for chunks no longer in the chunks table (GC).

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -30,34 +30,29 @@ pub struct SuggestedNote {
     pub reason: String,
 }
 
-/// A detector function that scans for a specific anti-pattern.
-/// Takes a store and project root, returns suggested notes or an error.
-/// Errors are non-fatal — other detectors still run.
-type Detector = fn(&Store, &Path) -> Result<Vec<SuggestedNote>, StoreError>;
-
-/// Registry of all active detectors, run in order by `suggest_notes`.
-/// To add a new detector: define a `fn(&Store, &Path) -> Result<Vec<SuggestedNote>>`
-/// and append it here.
-const DETECTORS: &[(&str, Detector)] = &[
-    ("detect_dead_clusters", |store, _root| {
-        detect_dead_clusters(store)
-    }),
-    ("detect_risk_patterns", |store, _root| {
-        detect_risk_patterns(store)
-    }),
-    ("detect_stale_mentions", detect_stale_mentions),
-];
-
 /// Scan the index for anti-patterns and suggest notes.
 /// Each detector runs independently — if one fails, the others still produce results.
-pub fn suggest_notes(store: &Store, root: &Path) -> Result<Vec<SuggestedNote>, StoreError> {
+///
+/// Previously a `fn(&Store, &Path) -> ...` registry; the #946 typestate
+/// refactor made `Store` generic over `Mode`, so fn pointer registries
+/// that pin a concrete `Mode` don't compose. Inlining the sequence keeps
+/// the "each detector independent, errors non-fatal" contract while
+/// letting callers pass either `Store<ReadOnly>` or `Store<ReadWrite>`.
+pub fn suggest_notes<Mode>(
+    store: &Store<Mode>,
+    root: &Path,
+) -> Result<Vec<SuggestedNote>, StoreError> {
     let _span = tracing::info_span!("suggest_notes").entered();
 
     let mut suggestions = Vec::new();
 
-    for (name, detector) in DETECTORS {
+    for (name, result) in [
+        ("detect_dead_clusters", detect_dead_clusters(store)),
+        ("detect_risk_patterns", detect_risk_patterns(store)),
+        ("detect_stale_mentions", detect_stale_mentions(store, root)),
+    ] {
         let _span = tracing::info_span!("detector", name).entered();
-        match detector(store, root) {
+        match result {
             Ok(mut s) => suggestions.append(&mut s),
             Err(e) => tracing::warn!(error = %e, detector = name, "Detector failed"),
         }
@@ -82,7 +77,7 @@ pub fn suggest_notes(store: &Store, root: &Path) -> Result<Vec<SuggestedNote>, S
 }
 
 /// Detect files with 5+ dead (uncalled) functions.
-fn detect_dead_clusters(store: &Store) -> Result<Vec<SuggestedNote>, StoreError> {
+fn detect_dead_clusters<Mode>(store: &Store<Mode>) -> Result<Vec<SuggestedNote>, StoreError> {
     let (confident, _) = store.find_dead_code(true)?;
 
     // Group by file
@@ -105,7 +100,7 @@ fn detect_dead_clusters(store: &Store) -> Result<Vec<SuggestedNote>, StoreError>
 }
 
 /// Detect untested hotspots and high-risk functions.
-fn detect_risk_patterns(store: &Store) -> Result<Vec<SuggestedNote>, StoreError> {
+fn detect_risk_patterns<Mode>(store: &Store<Mode>) -> Result<Vec<SuggestedNote>, StoreError> {
     let graph = store.get_call_graph()?;
     let test_chunks = store.find_test_chunks()?;
     let hotspots = find_hotspots(&graph, SUGGEST_HOTSPOT_POOL);
@@ -184,8 +179,8 @@ pub(crate) fn is_pascal_case(s: &str) -> bool {
 /// Core logic: find stale mentions across all notes.
 /// Returns `(note_text, stale_mentions)` pairs for each note with at least one
 /// stale mention. Shared by `detect_stale_mentions` and `check_note_staleness`.
-fn find_stale_mentions(
-    store: &Store,
+fn find_stale_mentions<Mode>(
+    store: &Store<Mode>,
     root: &Path,
 ) -> Result<Vec<(String, Vec<String>)>, StoreError> {
     let notes = store.list_notes_summaries()?;
@@ -241,7 +236,10 @@ fn find_stale_mentions(
 }
 
 /// Detect notes with stale mentions (deleted files, removed functions).
-fn detect_stale_mentions(store: &Store, root: &Path) -> Result<Vec<SuggestedNote>, StoreError> {
+fn detect_stale_mentions<Mode>(
+    store: &Store<Mode>,
+    root: &Path,
+) -> Result<Vec<SuggestedNote>, StoreError> {
     let stale_pairs = find_stale_mentions(store, root)?;
 
     Ok(stale_pairs
@@ -269,8 +267,8 @@ fn detect_stale_mentions(store: &Store, root: &Path) -> Result<Vec<SuggestedNote
 /// Check all notes for stale mentions.
 /// Returns `(note_text, stale_mentions)` pairs for each note that has at least
 /// one stale mention. Reusable by `notes list --check` and future `health` integration.
-pub fn check_note_staleness(
-    store: &Store,
+pub fn check_note_staleness<Mode>(
+    store: &Store<Mode>,
     root: &Path,
 ) -> Result<Vec<(String, Vec<String>)>, StoreError> {
     let _span = tracing::info_span!("check_note_staleness").entered();

--- a/src/task.rs
+++ b/src/task.rs
@@ -67,8 +67,8 @@ pub struct TaskSummary {
 ///
 /// Loads the call graph and test chunks once, then runs scout → gather → impact →
 /// placement in sequence, sharing resources across phases.
-pub fn task(
-    store: &Store,
+pub fn task<Mode>(
+    store: &Store<Mode>,
     embedder: &Embedder,
     description: &str,
     root: &Path,
@@ -97,8 +97,8 @@ pub fn task(
 ///
 /// Use this in batch mode where `BatchContext` caches these resources across
 /// commands, avoiding repeated loading per pipeline stage.
-pub fn task_with_resources(
-    store: &Store,
+pub fn task_with_resources<Mode>(
+    store: &Store<Mode>,
     embedder: &Embedder,
     description: &str,
     root: &Path,

--- a/src/where_to_add.rs
+++ b/src/where_to_add.rs
@@ -92,8 +92,8 @@ impl Default for PlacementOptions {
 
 /// Suggest where to place new code matching a description.
 /// Uses default search parameters. For custom parameters, use [`suggest_placement_with_options`].
-pub fn suggest_placement(
-    store: &Store,
+pub fn suggest_placement<Mode>(
+    store: &Store<Mode>,
     embedder: &Embedder,
     description: &str,
     limit: usize,
@@ -114,8 +114,8 @@ pub fn suggest_placement(
 /// 2. Groups results by file, ranks by aggregate score
 /// 3. Extracts local patterns from each file
 /// 4. Suggests insertion point after the most similar function
-pub fn suggest_placement_with_options(
-    store: &Store,
+pub fn suggest_placement_with_options<Mode>(
+    store: &Store<Mode>,
     embedder: &Embedder,
     description: &str,
     limit: usize,
@@ -131,8 +131,8 @@ pub fn suggest_placement_with_options(
 }
 
 /// Core placement logic. Requires `opts.query_embedding` to be set.
-fn suggest_placement_with_options_core(
-    store: &Store,
+fn suggest_placement_with_options_core<Mode>(
+    store: &Store<Mode>,
     description: &str,
     limit: usize,
     opts: &PlacementOptions,

--- a/tests/cross_project_test.rs
+++ b/tests/cross_project_test.rs
@@ -64,11 +64,11 @@ fn test_cross_project_callers_finds_both() {
     let mut ctx = CrossProjectContext::new(vec![
         NamedStore {
             name: "local".into(),
-            store: store_a,
+            store: store_a.into_readonly(),
         },
         NamedStore {
             name: "project_b".into(),
-            store: store_b,
+            store: store_b.into_readonly(),
         },
     ]);
 
@@ -96,11 +96,11 @@ fn test_cross_project_callees_finds_both() {
     let mut ctx = CrossProjectContext::new(vec![
         NamedStore {
             name: "local".into(),
-            store: store_a,
+            store: store_a.into_readonly(),
         },
         NamedStore {
             name: "project_b".into(),
-            store: store_b,
+            store: store_b.into_readonly(),
         },
     ]);
 
@@ -120,7 +120,7 @@ fn test_cross_project_no_references_local_only() {
 
     let mut ctx = CrossProjectContext::new(vec![NamedStore {
         name: "local".into(),
-        store,
+        store: store.into_readonly(),
     }]);
 
     let callers = ctx.get_callers_cross("target").unwrap();
@@ -135,7 +135,7 @@ fn test_cross_project_function_not_found() {
 
     let mut ctx = CrossProjectContext::new(vec![NamedStore {
         name: "local".into(),
-        store,
+        store: store.into_readonly(),
     }]);
 
     let callers = ctx.get_callers_cross("nonexistent").unwrap();
@@ -155,11 +155,11 @@ fn test_cross_project_same_name_different_sources() {
     let mut ctx = CrossProjectContext::new(vec![
         NamedStore {
             name: "local".into(),
-            store: store_a,
+            store: store_a.into_readonly(),
         },
         NamedStore {
             name: "project_b".into(),
-            store: store_b,
+            store: store_b.into_readonly(),
         },
     ]);
 

--- a/tests/eval_harness.rs
+++ b/tests/eval_harness.rs
@@ -116,9 +116,9 @@ fn find_rank(results: &[cqs::store::SearchResult], query: &EvalQuery) -> (Option
 }
 
 /// Run a single query against a configuration, return per-query result
-fn eval_single_query(
+fn eval_single_query<Mode>(
     query: &EvalQuery,
-    store: &cqs::Store,
+    store: &cqs::Store<Mode>,
     embedder: &cqs::Embedder,
     reranker: Option<&cqs::Reranker>,
     config: &EvalConfig,

--- a/tests/gather_test.rs
+++ b/tests/gather_test.rs
@@ -235,7 +235,7 @@ fn test_gather_callees_only() {
 
 /// Helper: build a ReferenceIndex from a TestStore
 fn make_ref_index(store: &TestStore, name: &str) -> ReferenceIndex {
-    let ref_store = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
     ReferenceIndex {
         name: name.to_string(),
         store: ref_store,

--- a/tests/reference_test.rs
+++ b/tests/reference_test.rs
@@ -124,7 +124,7 @@ fn test_search_reference_applies_weight() {
     let c1 = test_chunk("weighted_fn", "fn weighted_fn() { test }");
     insert_chunks(&store, &[c1], 1.0);
 
-    let ref_store = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
     let ref_idx = ReferenceIndex {
         name: "test-ref".to_string(),
         store: ref_store,
@@ -156,7 +156,7 @@ fn test_search_reference_weight_filters_below_threshold() {
     let c1 = test_chunk("fn_a", "fn fn_a() { test }");
     insert_chunks(&store, &[c1], 1.0);
 
-    let ref_store = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
     let ref_idx = ReferenceIndex {
         name: "test-ref".to_string(),
         store: ref_store,
@@ -183,7 +183,7 @@ fn test_search_reference_by_name_weight() {
     let c1 = test_chunk("lookup_fn", "fn lookup_fn() { lookup }");
     insert_chunks(&store, &[c1], 1.0);
 
-    let ref_store = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
     let ref_idx = ReferenceIndex {
         name: "test-ref".to_string(),
         store: ref_store,
@@ -235,7 +235,7 @@ fn test_search_reference_unweighted_returns_raw_scores() {
     let c1 = test_chunk("unweighted_fn", "fn unweighted_fn() { test }");
     insert_chunks(&store, &[c1], 1.0);
 
-    let ref_store = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
     let ref_idx = ReferenceIndex {
         name: "test-ref".to_string(),
         store: ref_store,
@@ -268,8 +268,8 @@ fn test_search_reference_unweighted_vs_weighted() {
     let c1 = test_chunk("compare_fn", "fn compare_fn() { compare }");
     insert_chunks(&store, &[c1], 1.0);
 
-    let ref_store_w = cqs::Store::open(&store.db_path()).unwrap();
-    let ref_store_u = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_store_w = cqs::Store::open_readonly(&store.db_path()).unwrap();
+    let ref_store_u = cqs::Store::open_readonly(&store.db_path()).unwrap();
 
     let weight = 0.6;
     let ref_idx_w = ReferenceIndex {
@@ -328,7 +328,7 @@ fn test_search_reference_by_name_unweighted() {
     let c1 = test_chunk("name_search_fn", "fn name_search_fn() { test }");
     insert_chunks(&store, &[c1], 1.0);
 
-    let ref_store = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
     let ref_idx = ReferenceIndex {
         name: "test-ref".to_string(),
         store: ref_store,
@@ -358,7 +358,7 @@ fn test_search_reference_by_name_unweighted_threshold() {
     let c1 = test_chunk("threshold_fn", "fn threshold_fn() { test }");
     insert_chunks(&store, &[c1], 1.0);
 
-    let ref_store = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
     let ref_idx = ReferenceIndex {
         name: "test-ref".to_string(),
         store: ref_store,

--- a/tests/search_test.rs
+++ b/tests/search_test.rs
@@ -356,7 +356,7 @@ fn test_search_reference_by_name() {
     insert_chunks(&store, &[c1, c2], 1.0);
 
     // Create a reference index (open separate Store to same DB)
-    let ref_store = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
     let ref_idx = ReferenceIndex {
         name: "test-ref".to_string(),
         store: ref_store,
@@ -389,7 +389,7 @@ fn test_search_reference_by_name_threshold() {
     let c1 = test_chunk("test_fn", "fn test_fn() {}");
     insert_chunks(&store, &[c1], 1.0);
 
-    let ref_store = cqs::Store::open(&store.db_path()).unwrap();
+    let ref_store = cqs::Store::open_readonly(&store.db_path()).unwrap();
     let ref_idx = ReferenceIndex {
         name: "test-ref".to_string(),
         store: ref_store,

--- a/tests/task_test.rs
+++ b/tests/task_test.rs
@@ -323,5 +323,5 @@ fn test_task_with_resources_end_to_end() {
     let task_result = result.unwrap();
     // Verify the pipeline ran — even if search returns no results, structure should be valid
     assert_eq!(task_result.description, "validate user input");
-    assert!(task_result.summary.total_files >= 0);
+    let _ = task_result.summary.total_files;
 }


### PR DESCRIPTION
## Summary

Closes #946. Introduces `ReadOnly`/`ReadWrite` phantom type parameters on `Store` and partitions write methods to `impl Store<ReadWrite>`. Daemon, reference, and CLI read paths now hold `Store<ReadOnly>`; attempting to call a mutating method on one fails to compile.

## Changes

- 3 commits:
  1. Add `ReadOnly`/`ReadWrite` marker types + `PhantomData<Mode>` on `Store` (default `Mode = ReadWrite` keeps all call sites compiling unchanged).
  2. Relocate ~40 write methods (upserts, prunes, metadata setters, `begin_write`, `init`) to `impl Store<ReadWrite>`. Constructors still return `Store<ReadWrite>` at this commit.
  3. Cascade `Store<ReadOnly>` through the CLI command tree, `CrossProjectContext`/`NamedStore`, `ReferenceIndex`, `QueryContext`, and batch handlers. Switch `open_readonly*` constructors to return `Store<ReadOnly>`.

- Adds `Store::into_readonly()` — type-level erasure used by tests that build fixtures under `ReadWrite` and hand off to `ReadOnly` consumers. `ManuallyDrop` + `ptr::read` because `Store<Mode>` implements `Drop`.
- Rewrites `cqs::Store::open` in three integration tests to `open_readonly` where the store is consumed as a reference.

## Test plan
- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib` → 1415 passed
- [x] `cargo test --features gpu-index --test reference_test --test cross_project_test --test search_test --test gather_test` → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
