### PR TITLE
refactor(#948): atomic_replace helper for crash-safe file rotation

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -139,35 +139,12 @@ pub fn save_audit_state(cqs_dir: &Path, mode: &AuditMode) -> Result<()> {
         }
     }
 
-    if let Err(rename_err) = std::fs::rename(&tmp_path, &path) {
-        // Cross-device fallback: copy to same-dir temp, then rename (atomic)
-        let dest_dir = path.parent().unwrap_or(std::path::Path::new("."));
-        let dest_tmp = dest_dir.join(format!(".audit.{:016x}.tmp", suffix));
-        if let Err(copy_err) = std::fs::copy(&tmp_path, &dest_tmp) {
-            let _ = std::fs::remove_file(&tmp_path);
-            anyhow::bail!(
-                "rename failed ({}), copy fallback failed: {}",
-                rename_err,
-                copy_err
-            );
-        }
-        // SEC-2: Restrict permissions on copy fallback target
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&dest_tmp, std::fs::Permissions::from_mode(0o600));
-        }
-        if let Err(rename2_err) = std::fs::rename(&dest_tmp, &path) {
-            let _ = std::fs::remove_file(&dest_tmp);
-            let _ = std::fs::remove_file(&tmp_path);
-            anyhow::bail!(
-                "rename failed ({}), fallback rename failed: {}",
-                rename_err,
-                rename2_err
-            );
-        }
+    // atomic_replace: fsync tmp, rename with EXDEV fallback, fsync parent dir.
+    // SEC-1 perms preserved: tmp was opened with mode(0o600).
+    crate::fs::atomic_replace(&tmp_path, &path).map_err(|e| {
         let _ = std::fs::remove_file(&tmp_path);
-    }
+        anyhow::anyhow!("Failed to persist audit-mode file: {}", e)
+    })?;
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -560,31 +560,13 @@ pub fn add_reference_to_config(
         }
     }
 
-    if let Err(rename_err) = std::fs::rename(&tmp_path, config_path) {
-        // Cross-device fallback: copy to a same-dir temp, then rename
-        // PB-19: unpredictable suffix to prevent symlink TOCTOU
-        let fb_suffix = crate::temp_suffix();
-        let fallback_tmp =
-            config_path.with_extension(format!("toml.{:016x}.fallback.tmp", fb_suffix));
-        if let Err(copy_err) = std::fs::copy(&tmp_path, &fallback_tmp) {
-            let _ = std::fs::remove_file(&tmp_path);
-            return Err(ConfigError::Io(std::io::Error::other(format!(
-                "rename failed ({}), copy fallback failed: {}",
-                rename_err, copy_err
-            ))));
-        }
-        // SEC-2: Restrict permissions on copy fallback target
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&fallback_tmp, std::fs::Permissions::from_mode(0o600));
-        }
+    // atomic_replace: fsync tmp, rename with EXDEV fallback, fsync parent dir.
+    // SEC-1: the tmp file was opened with mode(0o600), which fs::copy
+    // preserves into the xdev fallback destination.
+    crate::fs::atomic_replace(&tmp_path, config_path).map_err(|e| {
         let _ = std::fs::remove_file(&tmp_path);
-        if let Err(e) = std::fs::rename(&fallback_tmp, config_path) {
-            let _ = std::fs::remove_file(&fallback_tmp);
-            return Err(ConfigError::Io(e));
-        }
-    }
+        ConfigError::Io(e)
+    })?;
 
     // lock_file dropped here, releasing exclusive lock
     Ok(())
@@ -658,32 +640,11 @@ pub fn remove_reference_from_config(config_path: &Path, name: &str) -> Result<bo
             }
         }
 
-        if let Err(rename_err) = std::fs::rename(&tmp_path, config_path) {
-            // Cross-device fallback: copy to a same-dir temp, then rename
-            // PB-19: unpredictable suffix to prevent symlink TOCTOU
-            let fb_suffix = crate::temp_suffix();
-            let fallback_tmp =
-                config_path.with_extension(format!("toml.{:016x}.fallback.tmp", fb_suffix));
-            if let Err(copy_err) = std::fs::copy(&tmp_path, &fallback_tmp) {
-                let _ = std::fs::remove_file(&tmp_path);
-                return Err(ConfigError::Io(std::io::Error::other(format!(
-                    "rename failed ({}), copy fallback failed: {}",
-                    rename_err, copy_err
-                ))));
-            }
-            // SEC-2: Restrict permissions on copy fallback target
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let _ =
-                    std::fs::set_permissions(&fallback_tmp, std::fs::Permissions::from_mode(0o600));
-            }
+        // atomic_replace: fsync tmp, rename with EXDEV fallback, fsync parent dir.
+        crate::fs::atomic_replace(&tmp_path, config_path).map_err(|e| {
             let _ = std::fs::remove_file(&tmp_path);
-            if let Err(e) = std::fs::rename(&fallback_tmp, config_path) {
-                let _ = std::fs::remove_file(&fallback_tmp);
-                return Err(ConfigError::Io(e));
-            }
-        }
+            ConfigError::Io(e)
+        })?;
     }
     // lock_file dropped here, releasing exclusive lock
     Ok(removed)

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,0 +1,214 @@
+//! Shared filesystem primitives for durable, atomic file writes.
+//!
+//! The write-to-temp-then-rename pattern is repeated throughout cqs for
+//! persisting indexes, configuration, and notes. Historically each site
+//! evolved its own copy, and several audits (DS-V1.25-1 and DS-V1.25-4 in
+//! particular) caught sites that were missing `sync_all` on the temp file
+//! or on the parent directory. `atomic_replace` concentrates that logic in
+//! one place so new persistence sites inherit the correct durability
+//! semantics by default.
+
+use std::io;
+use std::path::Path;
+
+/// Atomically replace `final_path` with the contents of `tmp_path`.
+///
+/// Sequence:
+/// 1. `fsync` the temp file so its bytes are durable on disk before the rename.
+/// 2. `rename(tmp_path, final_path)` — atomic on the same filesystem. On
+///    cross-device failure (`EXDEV` → `io::ErrorKind::CrossesDevices`, seen
+///    on Docker overlayfs, NFS, WSL `/mnt/c`) we fall back to copy into a
+///    unique same-directory temp + fsync that copy + rename it into place,
+///    then best-effort remove the source temp.
+/// 3. Best-effort `fsync` the parent directory so the rename itself is
+///    durable against power loss. Some filesystems (tmpfs, certain network
+///    FSes) do not support this and return errors we log at debug level.
+///
+/// The caller is responsible for:
+/// - Setting correct permissions on the temp file before calling (the
+///   rename preserves them on unix).
+/// - Holding any locks required for serialization with concurrent writers.
+/// - Cleaning up `tmp_path` on error paths before `atomic_replace` was
+///   invoked (this helper only manages temps it creates internally for
+///   the cross-device fallback).
+///
+/// On Windows this helper still goes through `std::fs::rename` which uses
+/// `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING` under the hood, so
+/// rename-over-existing works. The cross-device fallback uses
+/// `ErrorKind::CrossesDevices` which is detected identically on Windows.
+/// The parent-dir fsync is a no-op on Windows because NTFS journals the
+/// rename as part of its own metadata update.
+pub fn atomic_replace(tmp_path: &Path, final_path: &Path) -> io::Result<()> {
+    // Step 1: fsync the temp file so the data is durable before the rename.
+    {
+        let f = std::fs::File::open(tmp_path)?;
+        f.sync_all()?;
+    }
+
+    // Step 2: try the cheap rename first.
+    match std::fs::rename(tmp_path, final_path) {
+        Ok(()) => {}
+        Err(e) if is_cross_device(&e) => {
+            // Cross-device: copy into a unique same-dir temp, fsync it,
+            // rename atomically, then best-effort clean up the source.
+            let dest_tmp = cross_device_tmp_path(final_path);
+            std::fs::copy(tmp_path, &dest_tmp)?;
+            // fsync the copied file before rename for durability.
+            match std::fs::File::open(&dest_tmp) {
+                Ok(f) => {
+                    if let Err(fsync_err) = f.sync_all() {
+                        tracing::debug!(
+                            error = %fsync_err,
+                            path = %dest_tmp.display(),
+                            "fsync of cross-device dest tmp failed (non-fatal)"
+                        );
+                    }
+                }
+                Err(open_err) => {
+                    tracing::debug!(
+                        error = %open_err,
+                        path = %dest_tmp.display(),
+                        "could not reopen cross-device dest tmp for fsync"
+                    );
+                }
+            }
+            if let Err(rn_err) = std::fs::rename(&dest_tmp, final_path) {
+                // Best-effort cleanup of both temps before returning error.
+                let _ = std::fs::remove_file(&dest_tmp);
+                let _ = std::fs::remove_file(tmp_path);
+                return Err(rn_err);
+            }
+            // Source temp is no longer needed.
+            let _ = std::fs::remove_file(tmp_path);
+        }
+        Err(e) => return Err(e),
+    }
+
+    // Step 3: fsync the parent directory so the rename is durable. Best
+    // effort — some filesystems do not support opening a directory for
+    // fsync; we log at debug and continue.
+    if let Some(parent) = final_path.parent() {
+        match std::fs::File::open(parent) {
+            Ok(dir) => {
+                if let Err(e) = dir.sync_all() {
+                    tracing::debug!(
+                        error = %e,
+                        parent = %parent.display(),
+                        "parent dir fsync failed after atomic_replace (non-fatal)"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    parent = %parent.display(),
+                    "could not open parent dir for fsync after atomic_replace (non-fatal)"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Detect a cross-device rename error.
+///
+/// On stable Rust 1.85+ the dedicated `ErrorKind::CrossesDevices` is the
+/// cleanest way to recognize `EXDEV` from Unix and `ERROR_NOT_SAME_DEVICE`
+/// from Windows. We also accept raw `EXDEV` as a belt-and-suspenders check
+/// in case the mapping ever regresses — historically some libc versions
+/// and Rust versions surfaced this as `Other`.
+fn is_cross_device(e: &io::Error) -> bool {
+    if matches!(e.kind(), io::ErrorKind::CrossesDevices) {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        // libc::EXDEV = 18 on Linux and BSDs.
+        if let Some(code) = e.raw_os_error() {
+            return code == libc::EXDEV;
+        }
+    }
+    false
+}
+
+/// Build a unique temp path in the same directory as `final_path` for the
+/// cross-device fallback. Uses the process id plus the shared random
+/// `temp_suffix` so two concurrent saves cannot collide.
+fn cross_device_tmp_path(final_path: &Path) -> std::path::PathBuf {
+    let dir = final_path.parent().unwrap_or(Path::new("."));
+    let name = final_path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "file".to_string());
+    let suffix = crate::temp_suffix();
+    let pid = std::process::id();
+    dir.join(format!(".{}.xdev.{}.{:016x}.tmp", name, pid, suffix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn atomic_replace_same_fs_moves_bytes_to_final_path() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let tmp = dir.path().join(".config.tmp");
+        let final_path = dir.path().join("config.toml");
+        let payload = b"hello = 1\n";
+
+        std::fs::write(&tmp, payload).unwrap();
+        atomic_replace(&tmp, &final_path).unwrap();
+
+        assert!(!tmp.exists(), "temp file should be gone after rename");
+        assert!(final_path.exists(), "final file should exist");
+        let got = std::fs::read(&final_path).unwrap();
+        assert_eq!(got, payload);
+    }
+
+    #[test]
+    fn atomic_replace_overwrites_existing_final_path() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let tmp = dir.path().join(".config.tmp");
+        let final_path = dir.path().join("config.toml");
+
+        std::fs::write(&final_path, b"old contents").unwrap();
+        std::fs::write(&tmp, b"new contents").unwrap();
+        atomic_replace(&tmp, &final_path).unwrap();
+
+        let got = std::fs::read(&final_path).unwrap();
+        assert_eq!(got, b"new contents");
+    }
+
+    #[test]
+    fn atomic_replace_missing_tmp_returns_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let tmp = dir.path().join("does_not_exist.tmp");
+        let final_path = dir.path().join("config.toml");
+
+        let err = atomic_replace(&tmp, &final_path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert!(!final_path.exists());
+    }
+
+    #[test]
+    fn atomic_replace_preserves_written_bytes_over_flush() {
+        // Regression guard for the DS-V1.25-4 shape: data written via
+        // BufWriter but never synced should still end up in the final
+        // file because atomic_replace fsyncs the temp before rename.
+        let dir = tempfile::TempDir::new().unwrap();
+        let tmp = dir.path().join(".ids.tmp");
+        let final_path = dir.path().join("ids");
+        {
+            let f = std::fs::File::create(&tmp).unwrap();
+            let mut w = std::io::BufWriter::new(f);
+            w.write_all(b"0:a\n1:b\n").unwrap();
+            w.flush().unwrap();
+            // No explicit sync_all — atomic_replace should do it.
+        }
+        atomic_replace(&tmp, &final_path).unwrap();
+        let got = std::fs::read_to_string(&final_path).unwrap();
+        assert_eq!(got, "0:a\n1:b\n");
+    }
+}

--- a/src/hnsw/persist.rs
+++ b/src/hnsw/persist.rs
@@ -422,40 +422,31 @@ impl HnswIndex {
                 let temp_path = temp_dir.join(format!("{}.{}", basename, ext));
                 let final_path = dir.join(format!("{}.{}", basename, ext));
                 if temp_path.exists() {
-                    if let Err(rename_err) = std::fs::rename(&temp_path, &final_path) {
-                        // Cross-device fallback (Docker overlayfs, NFS, etc.)
-                        // PB-20: unpredictable suffix
-                        let fb_suffix = crate::temp_suffix();
-                        let target_tmp =
-                            dir.join(format!(".{}.{}.{:016x}.tmp", basename, ext, fb_suffix));
-                        std::fs::copy(&temp_path, &target_tmp).map_err(|copy_err| {
-                            HnswError::Internal(format!(
-                                "Failed to rename {} -> {} ({}), copy fallback also failed: {}",
-                                temp_path.display(),
-                                final_path.display(),
-                                rename_err,
-                                copy_err
-                            ))
-                        })?;
-                        // SEC-2: Restrict permissions on copy fallback target
-                        #[cfg(unix)]
-                        {
-                            use std::os::unix::fs::PermissionsExt;
-                            let _ = std::fs::set_permissions(
-                                &target_tmp,
-                                std::fs::Permissions::from_mode(0o600),
-                            );
-                        }
-                        std::fs::rename(&target_tmp, &final_path).map_err(|e| {
-                            let _ = std::fs::remove_file(&target_tmp);
-                            HnswError::Internal(format!(
-                                "Failed to rename {} -> {} after cross-device copy: {}",
-                                target_tmp.display(),
-                                final_path.display(),
-                                e
-                            ))
-                        })?;
-                        let _ = std::fs::remove_file(&temp_path);
+                    // `atomic_replace` fsyncs the temp file, renames with
+                    // cross-device fallback (the in-process temp dir sits
+                    // on a different device from `dir` on Docker overlayfs
+                    // and WSL `/mnt/c`), and fsyncs the parent directory.
+                    // Unified replacement for the previous per-extension
+                    // rename + fs::copy fallback; see SEC-2 / PB-20 notes.
+                    crate::fs::atomic_replace(&temp_path, &final_path).map_err(|e| {
+                        HnswError::Internal(format!(
+                            "Failed to promote {} -> {}: {}",
+                            temp_path.display(),
+                            final_path.display(),
+                            e
+                        ))
+                    })?;
+                    // SEC-2: keep the restrictive mode on the promoted file
+                    // now that it lives in the final directory. The library
+                    // `file_dump` output uses the process umask; we want
+                    // 0o600 regardless.
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        let _ = std::fs::set_permissions(
+                            &final_path,
+                            std::fs::Permissions::from_mode(0o600),
+                        );
                     }
                     moved_exts.push(ext);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod cache;
 pub mod config;
 pub mod convert;
 pub mod embedder;
+pub mod fs;
 pub mod hnsw;
 pub mod index;
 pub mod language;

--- a/src/note.rs
+++ b/src/note.rs
@@ -297,33 +297,22 @@ pub fn rewrite_notes_file(
         }
     }
 
-    if let Err(rename_err) = std::fs::rename(&tmp_path, notes_path) {
-        // Rename can fail with EXDEV on cross-device (Docker overlayfs, some CI).
-        // Write a second temp in the destination directory (guaranteed same device),
-        // then rename atomically.
-        let dest_dir = notes_path.parent().unwrap_or(Path::new("."));
-        let dest_tmp = dest_dir.join(format!(".notes.{:016x}.tmp", suffix));
-        if let Err(copy_err) = std::fs::copy(&tmp_path, &dest_tmp) {
-            let _ = std::fs::remove_file(&tmp_path);
-            let _ = std::fs::remove_file(&dest_tmp);
-            return Err(NoteError::Io(std::io::Error::new(
-                copy_err.kind(),
-                format!(
-                    "rename {} -> {} failed ({}), copy fallback also failed: {}",
-                    tmp_path.display(),
-                    notes_path.display(),
-                    rename_err,
-                    copy_err
-                ),
-            )));
-        }
+    // atomic_replace: fsync tmp, rename with EXDEV fallback, fsync parent dir.
+    // Previously the notes path open-coded the rename + fs::copy fallback but
+    // never fsynced the tmp or the parent dir, so a power cut between write
+    // and rename could lose notes that appeared committed to the user.
+    crate::fs::atomic_replace(&tmp_path, notes_path).map_err(|e| {
         let _ = std::fs::remove_file(&tmp_path);
-        // Same-device rename is atomic
-        if let Err(e) = std::fs::rename(&dest_tmp, notes_path) {
-            let _ = std::fs::remove_file(&dest_tmp);
-            return Err(NoteError::Io(e));
-        }
-    }
+        NoteError::Io(std::io::Error::new(
+            e.kind(),
+            format!(
+                "Failed to persist {} -> {}: {}",
+                tmp_path.display(),
+                notes_path.display(),
+                e
+            ),
+        ))
+    })?;
 
     Ok(file.note)
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -96,27 +96,11 @@ impl ProjectRegistry {
         let suffix = crate::temp_suffix();
         let tmp = path.with_extension(format!("toml.{:016x}.tmp", suffix));
         std::fs::write(&tmp, &content)?;
-        if let Err(rename_err) = std::fs::rename(&tmp, &path) {
-            // Cross-device fallback: copy to dest dir temp, then same-device rename (atomic)
-            let dest_dir = path.parent().unwrap_or(Path::new("."));
-            let dest_tmp = dest_dir.join(format!(".projects.{:016x}.tmp", suffix));
-            if let Err(copy_err) = std::fs::copy(&tmp, &dest_tmp) {
-                let _ = std::fs::remove_file(&tmp);
-                let _ = std::fs::remove_file(&dest_tmp);
-                return Err(ProjectError::Io(std::io::Error::other(format!(
-                    "rename {} -> {} failed ({}), copy fallback failed: {}",
-                    tmp.display(),
-                    path.display(),
-                    rename_err,
-                    copy_err
-                ))));
-            }
+        // atomic_replace: fsync tmp, rename with EXDEV fallback, fsync parent dir.
+        crate::fs::atomic_replace(&tmp, &path).map_err(|e| {
             let _ = std::fs::remove_file(&tmp);
-            if let Err(e) = std::fs::rename(&dest_tmp, &path) {
-                let _ = std::fs::remove_file(&dest_tmp);
-                return Err(ProjectError::Io(e));
-            }
-        }
+            ProjectError::Io(e)
+        })?;
 
         #[cfg(unix)]
         {

--- a/src/splade/index.rs
+++ b/src/splade/index.rs
@@ -381,104 +381,24 @@ impl SpladeIndex {
             writer.get_ref().sync_all()?;
         }
 
-        // Atomic rename. Audit PB-NEW-3: the previous Windows branch did
-        // `remove_file` then `rename`, which was (a) redundant — Rust's
-        // `std::fs::rename` on Windows uses `MoveFileExW` with
-        // `MOVEFILE_REPLACE_EXISTING` since 1.46, so rename-over-existing
-        // works natively; (b) actively harmful — the remove+rename
-        // sequence opened a crash window where neither the old nor the new
-        // file existed, and a `SHARING_VIOLATION` on the remove (from
-        // another process mmapping the target) broke the save entirely.
-        // Deleted the whole `#[cfg(windows)]` block.
+        // Audit PB-NEW-3 / PB-NEW-4 / PB-NEW-5: atomic rename with
+        // cross-device fallback and parent-dir fsync. The full sequence
+        // (fsync tmp -> rename -> EXDEV fallback with fsync -> parent-dir
+        // fsync) now lives in `cqs::fs::atomic_replace`; the previous
+        // inline implementation was the fourth copy of this pattern and
+        // two siblings had shipped without one of the fsync calls
+        // (DS-V1.25-1, DS-V1.25-4).
         //
-        // Audit PB-NEW-4: cross-device rename fallback — on WSL 9P / Docker
-        // overlayfs / NFS the rename can fail with `CrossesDevices` or
-        // permission errors even within a single path. Mirror the
-        // `src/hnsw/persist.rs:412-445` pattern: try rename first, fall
-        // back to `fs::copy` + `set_permissions(0o600)` + remove(tmp) on
-        // error.
-        if let Err(rename_err) = std::fs::rename(&tmp_path, path) {
-            tracing::warn!(
-                error = %rename_err,
-                from = %tmp_path.display(),
-                to = %path.display(),
-                "SPLADE index rename failed, attempting fs::copy fallback"
-            );
-            // DS-V1.25-1: copy into a same-dir temp first, fsync it, then
-            // rename atomically. The previous implementation did
-            // `fs::copy(&tmp_path, path)` which writes directly into the
-            // final filename — if the process died mid-copy, a later load
-            // would read a truncated file. Mirrors the HNSW pattern in
-            // `src/hnsw/persist.rs:412-445`.
-            let dest_tmp = path.with_extension("splade.tmp");
-            std::fs::copy(&tmp_path, &dest_tmp).map_err(|copy_err| {
-                SpladeIndexPersistError::Io(std::io::Error::new(
-                    copy_err.kind(),
-                    format!(
-                        "rename failed ({}) AND copy fallback failed ({})",
-                        rename_err, copy_err
-                    ),
-                ))
-            })?;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let _ = std::fs::set_permissions(&dest_tmp, std::fs::Permissions::from_mode(0o600));
-            }
-            // fsync the dest-dir tmp file before the rename so the bytes are
-            // durable even on a power cut between copy and rename.
-            match std::fs::File::open(&dest_tmp) {
-                Ok(f) => {
-                    if let Err(e) = f.sync_all() {
-                        tracing::debug!(
-                            error = %e,
-                            path = %dest_tmp.display(),
-                            "fsync of SPLADE cross-device dest tmp failed (non-fatal)"
-                        );
-                    }
-                }
-                Err(e) => {
-                    tracing::debug!(
-                        error = %e,
-                        path = %dest_tmp.display(),
-                        "could not reopen SPLADE cross-device dest tmp for fsync"
-                    );
-                }
-            }
-            std::fs::rename(&dest_tmp, path).map_err(|rn_err| {
-                // Best-effort cleanup of the dest tmp; the original src tmp
-                // is cleaned below regardless.
-                let _ = std::fs::remove_file(&dest_tmp);
-                SpladeIndexPersistError::Io(std::io::Error::new(
-                    rn_err.kind(),
-                    format!(
-                        "rename failed ({}), copy fallback succeeded, final rename failed ({})",
-                        rename_err, rn_err
-                    ),
-                ))
-            })?;
-            // Best-effort source temp cleanup — we already got the target
-            // file in place, so a leftover tmp is non-fatal.
+        // The BufWriter above already flushed and sync_all'd the tmp
+        // file, but atomic_replace re-fsyncs the path it reopens — this
+        // is effectively free compared to the write itself and matches
+        // the invariant the helper advertises.
+        crate::fs::atomic_replace(&tmp_path, path).map_err(|e| {
+            // Best-effort cleanup of our own tmp on unexpected error
+            // before returning.
             let _ = std::fs::remove_file(&tmp_path);
-        }
-
-        // Audit PB-NEW-5: fsync the parent directory on unix so the rename
-        // is durable across a power cut. NTFS journals metadata with the
-        // rename itself, so Windows doesn't need this. Best-effort; logged
-        // on failure because the rebuild path handles lost persists.
-        #[cfg(unix)]
-        {
-            if let Ok(dir) = std::fs::File::open(parent) {
-                if let Err(e) = dir.sync_all() {
-                    tracing::debug!(
-                        error = %e,
-                        parent = %parent.display(),
-                        "parent dir fsync failed after SPLADE save — save is persisted but not \
-                         guaranteed durable across power loss (rebuildable, so low severity)"
-                    );
-                }
-            }
-        }
+            SpladeIndexPersistError::Io(e)
+        })?;
 
         tracing::info!(
             path = %path.display(),

--- a/src/train_data/checkpoint.rs
+++ b/src/train_data/checkpoint.rs
@@ -40,7 +40,14 @@ pub fn write_checkpoint(path: &Path, repo: &str, sha: &str) -> Result<(), TrainD
         content.push('\n');
     }
     fs::write(&tmp, &content)?;
-    fs::rename(&tmp, path)?;
+    // atomic_replace: picks up fsync-tmp + EXDEV fallback + fsync-parent
+    // that the previous bare `fs::rename` skipped. Checkpoints drive
+    // training-data resumption, so lost checkpoint writes = re-traversing
+    // thousands of commits on the next run.
+    crate::fs::atomic_replace(&tmp, path).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        TrainDataError::Io(e)
+    })?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Closes #948. Introduces `cqs::fs::atomic_replace(tmp, final)` — a crash-safe rename helper that fsyncs the tmp file, renames over the target, and fsyncs the parent directory (with EXDEV fallback for cross-filesystem writes). Migrates 7 persistent-file call sites.

## Changes

- New module `src/fs.rs` with `atomic_replace`.
- Migrates 7 write paths: HNSW save, SPLADE save, notes save, project registry save, config writes, audit-mode save, checkpoint write.

Every site that previously did `rename(tmp, final)` now goes through `atomic_replace`, closing the class of power-fail corruption where the tmp file's contents were still in the page cache at the moment of rename.

## Test plan
- [x] `cargo build --features gpu-index`
- [x] `cargo test --features gpu-index --lib`
- [ ] Kill-9 smoke test on HNSW save path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
