### PR TITLE
fix: save_with_store generic over Store<Mode> (main broken after #982)

### DIFF
--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -796,7 +796,11 @@ impl CagraIndex {
     /// Persist with an explicit `splade_generation` stamp from the caller's
     /// `Store`. Preferred over [`save`](Self::save) because it records the
     /// deletion counter for coarse staleness checks on load.
-    pub fn save_with_store(&self, path: &Path, store: &crate::Store) -> Result<(), CagraError> {
+    pub fn save_with_store<Mode>(
+        &self,
+        path: &Path,
+        store: &crate::Store<Mode>,
+    ) -> Result<(), CagraError> {
         let _span = tracing::info_span!("cagra_save_with_store", path = %path.display()).entered();
         if !cagra_persist_enabled() {
             return Err(CagraError::Io(


### PR DESCRIPTION
## Summary

Main was broken at `f8b6e8d` (immediately after #982 merged) because of a merge-order artifact:

- #985 (CAGRA persistence) added `CagraIndex::save_with_store(store: &Store)` with the default `Mode = ReadWrite`.
- #982 (Store typestate) made `build_vector_index_with_config` generic over `Mode` and passes `&Store<Mode>` through.

The call site `idx.save_with_store(&cagra_path, store)` at `src/cli/store.rs:348` stopped unifying. One-line fix: lift `save_with_store` to `<Mode>(store: &Store<Mode>)`.

## Changes

`src/cagra.rs` — add `<Mode>` type parameter on `save_with_store`. No runtime change.

## Test plan
- [x] `cargo build --release --features gpu-index` — clean
- [x] Binary rebuilt + installed from this branch, daemon restarted, CLI responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
