### PR TITLE
refactor(#923): INDEX_DB_FILENAME constant replaces 56 literals

### DIFF
--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -304,7 +304,7 @@ impl BatchContext {
         }
         self.last_staleness_check.set(Some(now));
 
-        let index_path = self.cqs_dir.join("index.db");
+        let index_path = self.cqs_dir.join(cqs::INDEX_DB_FILENAME);
         let current_id = match DbFileIdentity::from_path(&index_path) {
             Some(id) => id,
             None => {
@@ -377,7 +377,7 @@ impl BatchContext {
         let _span = tracing::info_span!("batch_manual_invalidation").entered();
         self.invalidate_mutable_caches();
 
-        let index_path = self.cqs_dir.join("index.db");
+        let index_path = self.cqs_dir.join(cqs::INDEX_DB_FILENAME);
         let new_store = Store::open_readonly_pooled(&index_path)
             .map_err(|e| anyhow::anyhow!("Failed to re-open Store: {e}"))?;
         *self.store.borrow_mut() = new_store;
@@ -954,7 +954,7 @@ pub(crate) fn create_context() -> Result<BatchContext> {
     // Capture initial index.db identity (inode/size/mtime on unix).
     // DS-V1.25-6: previously this was mtime alone, which sub-second
     // replacements on WSL NTFS could miss.
-    let index_id = DbFileIdentity::from_path(&cqs_dir.join("index.db"));
+    let index_id = DbFileIdentity::from_path(&cqs_dir.join(cqs::INDEX_DB_FILENAME));
     if index_id.is_none() {
         tracing::debug!("Could not stat index.db — staleness detection will be skipped until first successful stat");
     }
@@ -989,7 +989,7 @@ pub(crate) fn create_context() -> Result<BatchContext> {
 /// Create a BatchContext for testing with a temporary store.
 #[cfg(test)]
 fn create_test_context(cqs_dir: &std::path::Path) -> Result<BatchContext> {
-    let index_path = cqs_dir.join("index.db");
+    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
     let store =
         Store::open(&index_path).map_err(|e| anyhow::anyhow!("Failed to open test store: {e}"))?;
     let root = cqs_dir.parent().unwrap_or(cqs_dir).to_path_buf();
@@ -1172,7 +1172,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cqs_dir = dir.path().join(".cqs");
         std::fs::create_dir_all(&cqs_dir).unwrap();
-        let index_path = cqs_dir.join("index.db");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
         let store = Store::open(&index_path).unwrap();
         store.init(&ModelInfo::default()).unwrap();
         drop(store);
@@ -1228,7 +1228,7 @@ mod tests {
         // Touch index.db to simulate concurrent `cqs index`
         // Sleep to ensure mtime changes (filesystem granularity is ~1s on some FS)
         thread::sleep(Duration::from_secs(2));
-        let index_path = cqs_dir.join("index.db");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
         // Append a byte to force mtime change
         {
             use std::io::Write;
@@ -1270,7 +1270,7 @@ mod tests {
             "First check should not invalidate"
         );
 
-        let index_path = cqs_dir.join("index.db");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
         let original_mtime = std::fs::metadata(&index_path).unwrap().modified().unwrap();
         let original_ino = std::fs::metadata(&index_path).unwrap().ino();
 

--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -64,7 +64,7 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
 
     let root = find_project_root();
     let cqs_dir = cqs::resolve_index_dir(&root);
-    let index_path = cqs_dir.join("index.db");
+    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
 
     // Ensure .cqs directory exists with restrictive permissions
     if !cqs_dir.exists() {

--- a/src/cli/commands/infra/doctor.rs
+++ b/src/cli/commands/infra/doctor.rs
@@ -89,7 +89,7 @@ pub(crate) fn cmd_doctor(model_override: Option<&str>, fix: bool) -> Result<()> 
     let _span = tracing::info_span!("cmd_doctor", fix).entered();
     let root = find_project_root();
     let cqs_dir = cqs::resolve_index_dir(&root);
-    let index_path = cqs_dir.join("index.db");
+    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
     let mut any_failed = false;
     let mut issues: Vec<DoctorIssue> = Vec::new();
 
@@ -235,7 +235,7 @@ pub(crate) fn cmd_doctor(model_override: Option<&str>, fix: bool) -> Result<()> 
         println!();
         println!("References:");
         for r in &config.references {
-            let db_path = r.path.join("index.db");
+            let db_path = r.path.join(cqs::INDEX_DB_FILENAME);
             if !r.path.exists() {
                 println!(
                     "  {} {}: path missing ({})",

--- a/src/cli/commands/infra/reference.rs
+++ b/src/cli/commands/infra/reference.rs
@@ -122,7 +122,7 @@ fn cmd_ref_add(cli: &Cli, name: &str, source: &std::path::Path, weight: f32) -> 
             tracing::debug!(path = %ref_dir.display(), error = %e, "Failed to set file permissions");
         }
     }
-    let db_path = ref_dir.join("index.db");
+    let db_path = ref_dir.join(cqs::INDEX_DB_FILENAME);
 
     // Enumerate files
     let parser = CqParser::new()?;
@@ -197,7 +197,7 @@ fn cmd_ref_list(cli: &Cli, json: bool) -> Result<()> {
             .references
             .iter()
             .map(|r| {
-                let chunks = Store::open_readonly(&r.path.join("index.db"))
+                let chunks = Store::open_readonly(&r.path.join(cqs::INDEX_DB_FILENAME))
                     .map_err(|e| {
                         tracing::warn!(
                             name = %r.name,
@@ -231,7 +231,7 @@ fn cmd_ref_list(cli: &Cli, json: bool) -> Result<()> {
     println!("{}", "─".repeat(60));
 
     for r in &config.references {
-        let chunks = Store::open(&r.path.join("index.db"))
+        let chunks = Store::open(&r.path.join(cqs::INDEX_DB_FILENAME))
             .map_err(|e| {
                 tracing::warn!(
                     name = %r.name,
@@ -322,7 +322,7 @@ fn cmd_ref_update(cli: &Cli, name: &str) -> Result<()> {
         );
     }
 
-    let db_path = ref_config.path.join("index.db");
+    let db_path = ref_config.path.join(cqs::INDEX_DB_FILENAME);
     let ref_dir = &ref_config.path;
 
     // Get current chunk count before modifying anything

--- a/src/cli/commands/io/diff.rs
+++ b/src/cli/commands/io/diff.rs
@@ -96,7 +96,7 @@ pub(crate) fn cmd_diff(
     // Resolve target store
     let target_label = target.unwrap_or("project");
     let target_store = if target_label == "project" {
-        let index_path = cqs_dir.join("index.db");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
         if !index_path.exists() {
             bail!("Project index not found. Run 'cqs init && cqs index' first.");
         }

--- a/src/cli/commands/io/drift.rs
+++ b/src/cli/commands/io/drift.rs
@@ -91,7 +91,7 @@ pub(crate) fn cmd_drift(
     let ref_store =
         crate::cli::commands::resolve::resolve_reference_store_readonly(&root, reference)?;
 
-    let index_path = cqs_dir.join("index.db");
+    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
     if !index_path.exists() {
         bail!("Project index not found. Run 'cqs init && cqs index' first.");
     }

--- a/src/cli/commands/io/notes.rs
+++ b/src/cli/commands/io/notes.rs
@@ -167,7 +167,7 @@ fn reindex_notes(root: &std::path::Path, store: &cqs::Store) -> (usize, Option<S
 
 /// Open a read-write store for notes mutations that need to reindex.
 fn open_rw_store(root: &std::path::Path) -> Result<cqs::Store> {
-    let index_path = cqs::resolve_index_dir(root).join("index.db");
+    let index_path = cqs::resolve_index_dir(root).join(cqs::INDEX_DB_FILENAME);
     cqs::Store::open(&index_path)
         .map_err(|e| anyhow::anyhow!("Failed to open index at {}: {}", index_path.display(), e))
 }

--- a/src/cli/commands/resolve.rs
+++ b/src/cli/commands/resolve.rs
@@ -58,7 +58,7 @@ fn resolve_reference_db(root: &Path, ref_name: &str) -> Result<std::path::PathBu
             )
         })?;
 
-    let ref_db = ref_cfg.path.join("index.db");
+    let ref_db = ref_cfg.path.join(cqs::INDEX_DB_FILENAME);
     if !ref_db.exists() {
         bail!(
             "Reference '{}' has no index at {}. Run 'cqs ref update {}' first.",

--- a/src/cli/commands/review/suggest.rs
+++ b/src/cli/commands/review/suggest.rs
@@ -153,7 +153,7 @@ fn apply_suggestions(
     // Re-index notes. Opens a read-write store for the mutation — the
     // CLI already holds a read-only handle via CommandContext, but the
     // #946 typestate won't let us use it here.
-    let index_path = cqs_dir.join("index.db");
+    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
     let rw_store = cqs::Store::open(&index_path)?;
     let notes = cqs::parse_notes(&notes_path)?;
     cqs::index_notes(&notes, &notes_path, &rw_store)?;

--- a/src/cli/staleness.rs
+++ b/src/cli/staleness.rs
@@ -53,7 +53,7 @@ mod tests {
     fn test_warn_stale_results_empty_origins() {
         // Create a temp store
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(cqs::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
         store.init(&cqs::store::ModelInfo::default()).unwrap();
 
@@ -68,7 +68,7 @@ mod tests {
     #[test]
     fn test_warn_stale_results_nonexistent_origins() {
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(cqs::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
         store.init(&cqs::store::ModelInfo::default()).unwrap();
 

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -20,7 +20,7 @@ fn open_store_with<Mode>(
 ) -> Result<(cqs::Store<Mode>, PathBuf, PathBuf)> {
     let root = find_project_root();
     let cqs_dir = cqs::resolve_index_dir(&root);
-    let index_path = cqs_dir.join("index.db");
+    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
 
     if !index_path.exists() {
         anyhow::bail!("Index not found. Run 'cqs init && cqs index' first.");
@@ -554,7 +554,7 @@ mod base_index_tests {
         // Set up a real Store + a real index_base.hnsw.* fixture so we
         // exercise the actual file-load path, not just the early return.
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(cqs::INDEX_DB_FILENAME);
         let store = cqs::Store::open(&db_path).unwrap();
         store.init(&cqs::store::ModelInfo::default()).unwrap();
         // Mark the store as clean so we don't get filtered out by the
@@ -606,7 +606,7 @@ mod base_index_tests {
         let _guard = ENV_LOCK.lock().unwrap();
 
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(cqs::INDEX_DB_FILENAME);
         let store = cqs::Store::open(&db_path).unwrap();
         store.init(&cqs::store::ModelInfo::default()).unwrap();
         store.set_hnsw_dirty(cqs::HnswKind::Base, false).unwrap();

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -607,7 +607,7 @@ pub fn cmd_watch(
     };
 
     let cqs_dir = cqs::resolve_index_dir(&root);
-    let index_path = cqs_dir.join("index.db");
+    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
 
     if !index_path.exists() {
         bail!("No index found. Run 'cqs index' first.");

--- a/src/drift.rs
+++ b/src/drift.rs
@@ -130,7 +130,7 @@ mod tests {
     /// Panics if temporary directory creation, database opening, or store initialization fails.
     fn make_store() -> (Store, TempDir) {
         let dir = TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
         store.init(&crate::store::ModelInfo::default()).unwrap();
         (store, dir)

--- a/src/health.rs
+++ b/src/health.rs
@@ -152,7 +152,7 @@ mod tests {
 
     fn make_store() -> (Store, TempDir) {
         let dir = TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
         store.init(&crate::store::ModelInfo::default()).unwrap();
         (store, dir)

--- a/src/impact/cross_project.rs
+++ b/src/impact/cross_project.rs
@@ -290,7 +290,7 @@ mod tests {
     // NOTE: similar helper exists in store/calls/cross_project.rs
     fn make_named_store(name: &str, forward_edges: Vec<(&str, &str)>) -> NamedStore {
         let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
         let model_info = crate::store::helpers::ModelInfo::default();
         store.init(&model_info).unwrap();

--- a/src/impact/diff.rs
+++ b/src/impact/diff.rs
@@ -300,7 +300,7 @@ mod tests {
     /// Panics if temporary directory creation fails, if opening the Store fails, or if Store initialization fails.
     fn make_test_store() -> (crate::Store, tempfile::TempDir) {
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = crate::Store::open(&db_path).unwrap();
         store.init(&crate::store::ModelInfo::default()).unwrap();
         (store, dir)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,9 @@ pub enum AnalysisError {
 /// Name of the per-project index directory (created by `cqs init`).
 pub const INDEX_DIR: &str = ".cqs";
 
+/// Filename of the SQLite index database inside [`INDEX_DIR`].
+pub const INDEX_DB_FILENAME: &str = "index.db";
+
 /// Legacy index directory name (pre-v0.9.7). Used for auto-migration.
 const LEGACY_INDEX_DIR: &str = ".cq";
 

--- a/src/llm/summary.rs
+++ b/src/llm/summary.rs
@@ -456,7 +456,7 @@ mod tests {
     #[test]
     fn contrastive_neighbors_empty_store() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = crate::Store::open(&dir.path().join("index.db")).unwrap();
+        let store = crate::Store::open(&dir.path().join(crate::INDEX_DB_FILENAME)).unwrap();
         store.init(&crate::store::ModelInfo::default()).unwrap();
         let result = find_contrastive_neighbors(&store, 3);
         assert!(result.is_ok(), "Expected Ok, got {:?}", result);
@@ -470,7 +470,7 @@ mod tests {
     #[test]
     fn contrastive_neighbors_limit_zero() {
         let dir = tempfile::TempDir::new().unwrap();
-        let store = crate::Store::open(&dir.path().join("index.db")).unwrap();
+        let store = crate::Store::open(&dir.path().join(crate::INDEX_DB_FILENAME)).unwrap();
         store.init(&crate::store::ModelInfo::default()).unwrap();
         let result = find_contrastive_neighbors(&store, 0);
         assert!(result.is_ok(), "Expected Ok, got {:?}", result);

--- a/src/project.rs
+++ b/src/project.rs
@@ -494,7 +494,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cqs_dir = dir.path().join(".cqs");
         std::fs::create_dir_all(&cqs_dir).unwrap();
-        let db_path = cqs_dir.join("index.db");
+        let db_path = cqs_dir.join(crate::INDEX_DB_FILENAME);
 
         let store = crate::Store::open(&db_path).unwrap();
         store.init(&ModelInfo::default()).unwrap();

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -102,7 +102,7 @@ fn load_single_reference(cfg: &ReferenceConfig) -> Option<ReferenceIndex> {
         }
     }
 
-    let db_path = cfg.path.join("index.db");
+    let db_path = cfg.path.join(crate::INDEX_DB_FILENAME);
     let store = match Store::open_readonly(&db_path) {
         Ok(s) => s,
         Err(e) => {

--- a/src/review.rs
+++ b/src/review.rs
@@ -367,7 +367,7 @@ mod tests {
         use tempfile::TempDir;
 
         let dir = TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = crate::Store::open(&db_path).unwrap();
         store.init(&ModelInfo::default()).unwrap();
 
@@ -431,7 +431,7 @@ mod tests {
         use tempfile::TempDir;
 
         let dir = TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = crate::Store::open(&db_path).unwrap();
         store.init(&ModelInfo::default()).unwrap();
 
@@ -471,7 +471,7 @@ mod tests {
         use tempfile::TempDir;
 
         let dir = TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = crate::Store::open(&db_path).unwrap();
         store.init(&ModelInfo::default()).unwrap();
 

--- a/src/store/calls/cross_project.rs
+++ b/src/store/calls/cross_project.rs
@@ -92,7 +92,7 @@ impl CrossProjectContext {
         }];
 
         for ref_cfg in &config.references {
-            let db_path = ref_cfg.path.join("index.db");
+            let db_path = ref_cfg.path.join(crate::INDEX_DB_FILENAME);
             match Store::open_readonly(&db_path) {
                 Ok(store) => {
                     tracing::debug!(name = %ref_cfg.name, "Reference store opened");
@@ -283,7 +283,7 @@ mod tests {
         reverse: StdMap<String, Vec<String>>,
     ) -> NamedStore {
         let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
         let model_info = crate::store::helpers::ModelInfo::default();
         store.init(&model_info).unwrap();

--- a/src/store/chunks/embeddings.rs
+++ b/src/store/chunks/embeddings.rs
@@ -185,7 +185,7 @@ mod tests {
 
     fn make_store() -> (Store, TempDir) {
         let dir = TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
         store.init(&ModelInfo::default()).unwrap();
         (store, dir)

--- a/src/store/metadata.rs
+++ b/src/store/metadata.rs
@@ -606,7 +606,7 @@ mod tests {
 
     fn make_test_store_initialized() -> (Store, tempfile::TempDir) {
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
         store.init(&ModelInfo::default()).unwrap();
         (store, dir)
@@ -640,7 +640,7 @@ mod tests {
         // Corrupt dimension string is silently ignored (defaults to EMBEDDING_DIM).
         // This matches open_with_config behavior: parse failure -> default.
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         {
             let store = Store::open(&db_path).unwrap();
             store.init(&ModelInfo::default()).unwrap();
@@ -768,7 +768,7 @@ mod tests {
         // TC-31.1: init writes dim to metadata, verifiable via get_metadata_opt.
         // Note: store.dim() reflects the value read at open() time, not post-init.
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
         store
             .init(&ModelInfo::new("test/model-1024", 1024))
@@ -787,7 +787,7 @@ mod tests {
         // Note: Store::dim is set at open() time, not updated by init().
         // The metadata write is what matters for future reopens.
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
         store
             .init(&ModelInfo::new("test/model-1024", 1024))
@@ -807,7 +807,7 @@ mod tests {
         // (This was the AD-43/DS-30 bug: model validation on open rejected
         // non-default models. Fixed by skipping model validation on open.)
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         {
             let store = Store::open(&db_path).unwrap();
             store
@@ -828,7 +828,7 @@ mod tests {
     fn tc31_store_dim_zero_defaults_to_embedding_dim() {
         // TC-31.7: Set dimensions metadata to "0", reopen — should default to EMBEDDING_DIM.
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         {
             let store = Store::open(&db_path).unwrap();
             store.init(&ModelInfo::default()).unwrap();

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1401,7 +1401,7 @@ mod tests {
 
     fn make_test_store_initialized() -> (Store, tempfile::TempDir) {
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
         store.init(&ModelInfo::default()).unwrap();
         (store, dir)
@@ -1412,7 +1412,7 @@ mod tests {
         // Two readonly stores opened against the same DB should both succeed (WAL allows
         // multiple readers).
         let (_writer, dir) = make_test_store_initialized();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
 
         let ro1 = Store::open_readonly(&db_path).expect("first readonly open failed");
         let ro2 = Store::open_readonly(&db_path).expect("second readonly open failed");
@@ -1427,7 +1427,7 @@ mod tests {
         // A readonly store opened while a writer Store is alive should succeed.
         // SQLite WAL mode permits concurrent readers alongside a writer.
         let (writer, dir) = make_test_store_initialized();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
 
         let ro = Store::open_readonly(&db_path).expect("readonly open failed while writer active");
         assert!(ro.check_model_version().is_ok());
@@ -1479,7 +1479,7 @@ mod tests {
         // Schema uses INSERT OR REPLACE / CREATE TABLE IF NOT EXISTS, so a second
         // init() must be a no-op rather than a conflict.
         let dir = tempfile::TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
 
         store

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -284,7 +284,7 @@ mod tests {
 
     fn make_store() -> (Store, TempDir) {
         let dir = TempDir::new().unwrap();
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).unwrap();
         store.init(&crate::store::ModelInfo::default()).unwrap();
         (store, dir)

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -8,7 +8,7 @@ use tempfile::TempDir;
 /// Create a temporary Store for testing.
 pub fn setup_store() -> (Store, TempDir) {
     let dir = TempDir::new().unwrap();
-    let db_path = dir.path().join("index.db");
+    let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
     let store = Store::open(&db_path).unwrap();
     store.init(&ModelInfo::default()).unwrap();
     (store, dir)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -27,7 +27,7 @@ impl TestStore {
     /// Create an initialized test store in a temporary directory
     pub fn new() -> Self {
         let dir = TempDir::new().expect("Failed to create temp dir");
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(cqs::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).expect("Failed to open store");
         store
             .init(&ModelInfo::default())
@@ -38,14 +38,14 @@ impl TestStore {
     /// Get the database path for this test store
     #[allow(dead_code)]
     pub fn db_path(&self) -> PathBuf {
-        self._dir.path().join("index.db")
+        self._dir.path().join(cqs::INDEX_DB_FILENAME)
     }
 
     /// Create a test store with custom model info
     #[allow(dead_code)]
     pub fn with_model(model: &ModelInfo) -> Self {
         let dir = TempDir::new().expect("Failed to create temp dir");
-        let db_path = dir.path().join("index.db");
+        let db_path = dir.path().join(cqs::INDEX_DB_FILENAME);
         let store = Store::open(&db_path).expect("Failed to open store");
         store.init(model).expect("Failed to init store");
         Self { store, _dir: dir }

--- a/tests/cross_project_test.rs
+++ b/tests/cross_project_test.rs
@@ -9,7 +9,7 @@ use cqs::Store;
 use tempfile::TempDir;
 
 fn create_project(dir: &TempDir) -> Store {
-    let db_path = dir.path().join("index.db");
+    let db_path = dir.path().join(cqs::INDEX_DB_FILENAME);
     let store = Store::open(&db_path).expect("open store");
     store.init(&ModelInfo::default()).expect("init store");
     store

--- a/tests/eval_harness.rs
+++ b/tests/eval_harness.rs
@@ -494,7 +494,7 @@ fn test_eval_matrix() {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
     let root = PathBuf::from(&manifest_dir);
     let cqs_dir = cqs::resolve_index_dir(&root);
-    let db_path = cqs_dir.join("index.db");
+    let db_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
     let store = cqs::Store::open_readonly_pooled(&db_path).expect("Failed to open store");
     let model_config = cqs::embedder::ModelConfig::resolve(None, None);
     let embedder = cqs::Embedder::new_cpu(model_config).expect("Failed to init embedder");


### PR DESCRIPTION
## Summary

Closes #923 (audit EXT-12). Centralizes the `"index.db"` filename as `pub const INDEX_DB_FILENAME: &str = "index.db"` in `src/lib.rs`, next to the existing `INDEX_DIR` constant. Replaces 56 bare literal sites across 29 files.

## Scope

- Only **bare** `"index.db"` string literals that refer to the DB filename. Left untouched:
  - Substring occurrences inside larger path literals (`.cqs/index.db`, `.cq/index.db`, `index.db.bak`, `index.db.tmp`, `index.db{suffix}`)
  - Occurrences in doc comments, error messages, log strings, and the `.gitignore` template

Rationale for the exclusion: those are conceptually different strings (paths, user-facing text, sidecar filenames) that happen to contain `index.db`. A find-and-replace there would obscure intent.

## Commit layout

Commits are module-grouped so the refactor cherry-picks cleanly when it conflicts with concurrent Wave D/E/F work — the rebase reduces to re-running the literal → constant substitution at whichever line got introduced in the conflicting commit.

| Commit | Scope |
|---|---|
| `4497bec` | Introduce `INDEX_DB_FILENAME` constant in `src/lib.rs` |
| `9b09b6d` | Replace in lib modules (14 files, 26 sites — uses `crate::INDEX_DB_FILENAME`) |
| `20e0f2b` | Replace in CLI + tests (15 files, 30 sites — uses `cqs::INDEX_DB_FILENAME` since `src/cli/*` is part of the bin crate and `tests/*` are external) |

`pub` rather than `pub(crate)` because integration tests reference it as `cqs::INDEX_DB_FILENAME`.

## Test plan
- [x] `cargo build --features gpu-index` clean
- [x] `cargo clippy --features gpu-index -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] 61 affected tests pass (15 `store`/`health`/`suggest`/`metadata` + 41 `review`/`impact`/`cross_project`/etc. + 5 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
