### PR TITLE
refactor(#986): open_readonly_after_init + drop unsafe into_readonly

### DIFF
--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -1052,21 +1052,27 @@ pub(crate) fn create_context_with_runtime(
 /// Visibility: `pub(in crate::cli::batch)` under `#[cfg(test)]` so submodule
 /// tests (handlers/search.rs tests for issue #973) can reuse the same fixture
 /// wiring as the in-file `mod tests`.
+///
+/// The store is opened RO at the SQLite connection level via
+/// [`Store::open_readonly_after_init`] (#986) — the DB is expected to be
+/// pre-initialized by `setup_test_store` so the closure is a no-op, but
+/// the constructor path matches production code that may need fixture setup.
 #[cfg(test)]
 pub(in crate::cli::batch) fn create_test_context(
     cqs_dir: &std::path::Path,
 ) -> Result<BatchContext> {
     let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
-    let store =
-        Store::open(&index_path).map_err(|e| anyhow::anyhow!("Failed to open test store: {e}"))?;
+    // #986: open_readonly_after_init returns Store<ReadOnly> directly —
+    // the unsafe into_readonly() type-erasure is gone.
+    let store = Store::<ReadOnly>::open_readonly_after_init(&index_path, |_| Ok(()))
+        .map_err(|e| anyhow::anyhow!("Failed to open test store: {e}"))?;
     let root = cqs_dir.parent().unwrap_or(cqs_dir).to_path_buf();
     let index_id = DbFileIdentity::from_path(&index_path);
-    let store_ro = store.into_readonly();
     // #968: cache the runtime Arc so test contexts re-open on the same pool.
-    let runtime = std::sync::Arc::clone(store_ro.runtime());
+    let runtime = std::sync::Arc::clone(store.runtime());
 
     Ok(BatchContext {
-        store: RefCell::new(store_ro),
+        store: RefCell::new(store),
         runtime,
         embedder: OnceLock::new(),
         config: OnceLock::new(),

--- a/src/impact/cross_project.rs
+++ b/src/impact/cross_project.rs
@@ -284,32 +284,33 @@ mod tests {
     use super::*;
     use crate::store::calls::cross_project::NamedStore;
     use crate::Store;
-    use std::collections::HashMap as StdMap;
 
     /// Helper: build a NamedStore backed by a temp Store with synthetic call edges.
     // NOTE: similar helper exists in store/calls/cross_project.rs
     fn make_named_store(name: &str, forward_edges: Vec<(&str, &str)>) -> NamedStore {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
-        let store = Store::open(&db_path).unwrap();
         let model_info = crate::store::helpers::ModelInfo::default();
-        store.init(&model_info).unwrap();
 
-        for (caller, callee) in &forward_edges {
-            store
-                .rt
-                .block_on(async {
-                    sqlx::query(
-                        "INSERT OR IGNORE INTO function_calls (file, caller_name, callee_name, caller_line, call_line)
-                         VALUES ('test.rs', ?1, ?2, 1, 1)",
-                    )
-                    .bind(caller)
-                    .bind(callee)
-                    .execute(&store.pool)
-                    .await
-                })
-                .unwrap();
-        }
+        let store = Store::<crate::store::ReadOnly>::open_readonly_after_init(&db_path, |store| {
+            store.init(&model_info)?;
+            for (caller, callee) in &forward_edges {
+                store
+                    .rt
+                    .block_on(async {
+                        sqlx::query(
+                            "INSERT OR IGNORE INTO function_calls (file, caller_name, callee_name, caller_line, call_line)
+                             VALUES ('test.rs', ?1, ?2, 1, 1)",
+                        )
+                        .bind(caller)
+                        .bind(callee)
+                        .execute(&store.pool)
+                        .await
+                    })?;
+            }
+            Ok(())
+        })
+        .unwrap();
 
         // Keep the tempdir alive so the db file survives for the test duration.
         // `into_path` disables automatic cleanup; tests are short-lived so this is fine.
@@ -317,7 +318,7 @@ mod tests {
 
         NamedStore {
             name: name.to_string(),
-            store: store.into_readonly(),
+            store,
         }
     }
 

--- a/src/store/calls/cross_project.rs
+++ b/src/store/calls/cross_project.rs
@@ -284,47 +284,49 @@ mod tests {
     ) -> NamedStore {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
-        let store = Store::open(&db_path).unwrap();
         let model_info = crate::store::helpers::ModelInfo::default();
-        store.init(&model_info).unwrap();
 
-        // Insert function_calls rows so get_call_graph() builds the graph.
-        // We need to insert into function_calls table for each edge.
-        for (caller, callees) in &forward {
-            for callee in callees {
-                store
-                    .rt
-                    .block_on(async {
-                        sqlx::query(
-                            "INSERT OR IGNORE INTO function_calls (file, caller_name, callee_name, caller_line, call_line)
-                             VALUES ('test.rs', ?1, ?2, 1, 1)",
-                        )
-                        .bind(caller)
-                        .bind(callee)
-                        .execute(&store.pool)
-                        .await
-                    })
-                    .unwrap();
+        let store = Store::<crate::store::ReadOnly>::open_readonly_after_init(&db_path, |store| {
+            store.init(&model_info)?;
+
+            // Insert function_calls rows so get_call_graph() builds the graph.
+            // We need to insert into function_calls table for each edge.
+            for (caller, callees) in &forward {
+                for callee in callees {
+                    store
+                        .rt
+                        .block_on(async {
+                            sqlx::query(
+                                "INSERT OR IGNORE INTO function_calls (file, caller_name, callee_name, caller_line, call_line)
+                                 VALUES ('test.rs', ?1, ?2, 1, 1)",
+                            )
+                            .bind(caller)
+                            .bind(callee)
+                            .execute(&store.pool)
+                            .await
+                        })?;
+                }
             }
-        }
-        // Also insert reverse edges that aren't covered by forward
-        for (callee, callers) in &reverse {
-            for caller in callers {
-                store
-                    .rt
-                    .block_on(async {
-                        sqlx::query(
-                            "INSERT OR IGNORE INTO function_calls (file, caller_name, callee_name, caller_line, call_line)
-                             VALUES ('test.rs', ?1, ?2, 1, 1)",
-                        )
-                        .bind(caller)
-                        .bind(callee)
-                        .execute(&store.pool)
-                        .await
-                    })
-                    .unwrap();
+            // Also insert reverse edges that aren't covered by forward
+            for (callee, callers) in &reverse {
+                for caller in callers {
+                    store
+                        .rt
+                        .block_on(async {
+                            sqlx::query(
+                                "INSERT OR IGNORE INTO function_calls (file, caller_name, callee_name, caller_line, call_line)
+                                 VALUES ('test.rs', ?1, ?2, 1, 1)",
+                            )
+                            .bind(caller)
+                            .bind(callee)
+                            .execute(&store.pool)
+                            .await
+                        })?;
+                }
             }
-        }
+            Ok(())
+        })
+        .unwrap();
 
         // Keep the tempdir alive so the db file survives for the test duration.
         // `into_path` disables automatic cleanup; tests are short-lived so this is fine.
@@ -332,7 +334,7 @@ mod tests {
 
         NamedStore {
             name: name.to_string(),
-            store: store.into_readonly(),
+            store,
         }
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -644,35 +644,6 @@ impl<Mode> Store<Mode> {
 }
 
 impl Store<ReadWrite> {
-    /// Erase the write capability at the type level. No SQLite-level change —
-    /// the connection stays open in read-write mode but the `ReadOnly` marker
-    /// blocks `Store<ReadWrite>`-gated methods at compile time. Used by tests
-    /// that build fixture data under `ReadWrite` before handing the store to
-    /// an API that accepts only `Store<ReadOnly>` (e.g. `ReferenceIndex`,
-    /// `NamedStore`). Production code should prefer `Store::open_readonly`.
-    pub fn into_readonly(self) -> Store<ReadOnly> {
-        // `Store<Mode>` implements `Drop`, so we cannot move fields out with
-        // normal assignment. Use `ManuallyDrop` + `ptr::read` to transfer
-        // ownership field-by-field; the source is forgotten so its Drop
-        // doesn't run twice. Safe because we initialize every field of the
-        // returned `Store<ReadOnly>` exactly once.
-        let me = std::mem::ManuallyDrop::new(self);
-        unsafe {
-            Store {
-                pool: std::ptr::read(&me.pool),
-                rt: std::ptr::read(&me.rt),
-                dim: me.dim,
-                closed: std::ptr::read(&me.closed),
-                notes_summaries_cache: std::ptr::read(&me.notes_summaries_cache),
-                note_boost_cache: std::ptr::read(&me.note_boost_cache),
-                call_graph_cache: std::ptr::read(&me.call_graph_cache),
-                test_chunks_cache: std::ptr::read(&me.test_chunks_cache),
-                chunk_type_map_cache: std::ptr::read(&me.chunk_type_map_cache),
-                _mode: PhantomData,
-            }
-        }
-    }
-
     /// Open an existing index with connection pooling
     pub fn open(path: &Path) -> Result<Self, StoreError> {
         Self::open_with_config(path, Self::default_open_config(path, None))
@@ -737,6 +708,9 @@ impl Store<ReadOnly> {
     /// Open an existing index in read-only mode with reduced resources.
     /// Uses minimal connection pool, smaller cache, and single-threaded runtime.
     /// Suitable for reference stores and background builds that only read data.
+    ///
+    /// For test fixture setup where you need to write data before exposing a
+    /// read-only handle, see [`Store::open_readonly_after_init`].
     pub fn open_readonly(path: &Path) -> Result<Self, StoreError> {
         open_with_config_impl::<ReadOnly>(
             path,
@@ -801,6 +775,47 @@ impl Store<ReadOnly> {
                 runtime: None,
             },
         )
+    }
+
+    /// Open the store read-write, run `init` for fixture setup, drop the
+    /// read-write handle (flushing the WAL via the [`Drop`] impl), then
+    /// reopen read-only via [`Store::open_readonly`]. The returned store is
+    /// read-only at both the type system level and the SQLite connection
+    /// level — unlike the phantom-typestate erasure used internally by tests.
+    ///
+    /// Intended for test fixture setup where code under test accepts only
+    /// [`Store<ReadOnly>`] (e.g. `ReferenceIndex`, `NamedStore`) but the
+    /// fixture builder needs to populate tables first.
+    ///
+    /// The closure receives `&Store<ReadWrite>` (not `&mut`) because every
+    /// write method on `Store` already goes through the pool via `&self`.
+    /// If the closure returns `Err`, the read-write handle is dropped
+    /// immediately and the error is propagated — no partially-initialized
+    /// store is returned.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use cqs::Store;
+    /// use cqs::store::ModelInfo;
+    /// use std::path::Path;
+    /// let store = Store::open_readonly_after_init(Path::new(".cqs/index.db"), |s| {
+    ///     s.init(&ModelInfo::default())?;
+    ///     // populate fixtures via &Store<ReadWrite> methods here
+    ///     Ok(())
+    /// })?;
+    /// // `store` is Store<ReadOnly>, safe to pass to read-only-only APIs.
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn open_readonly_after_init<F>(path: &Path, init: F) -> Result<Self, StoreError>
+    where
+        F: FnOnce(&Store<ReadWrite>) -> Result<(), StoreError>,
+    {
+        let rw = Store::<ReadWrite>::open(path)?;
+        init(&rw)?;
+        // Dropping the RW handle runs the WAL checkpoint (see `impl Drop for
+        // Store`), ensuring the reopened RO handle sees all writes.
+        drop(rw);
+        Store::<ReadOnly>::open_readonly(path)
     }
 }
 
@@ -1569,6 +1584,7 @@ mod tests {
             .expect("second init() should be idempotent but failed");
     }
 
+<<<<<<< HEAD
     #[test]
     fn open_readonly_small_roundtrip() {
         // #970: open_readonly_small right-sizes the mmap/cache for reference
@@ -1629,5 +1645,79 @@ mod tests {
             .expect("get_chunks_by_origin should work on small-mode store");
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].name, "small");
+    }
+
+    // ===== open_readonly_after_init tests (#986) =====
+
+    #[test]
+    fn open_readonly_after_init_happy_path() {
+        // Closure writes fixtures under RW; reopened RO handle must read
+        // them back. Verifies that the WAL checkpoint triggered by dropping
+        // the RW handle flushes writes to the main DB file before the RO
+        // handle opens.
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("index.db");
+
+        let store = Store::<ReadOnly>::open_readonly_after_init(&db_path, |s| {
+            s.init(&ModelInfo::default())?;
+            // Write a call-graph edge so we have something to query back.
+            s.rt.block_on(async {
+                sqlx::query(
+                    "INSERT INTO function_calls (file, caller_name, callee_name, caller_line, call_line)
+                     VALUES ('test.rs', 'caller_fn', 'callee_fn', 1, 2)",
+                )
+                .execute(&s.pool)
+                .await
+            })?;
+            Ok(())
+        })
+        .expect("open_readonly_after_init happy path failed");
+
+        // Query the RO handle to confirm the write landed on disk.
+        let count: i64 = store
+            .rt
+            .block_on(async {
+                sqlx::query_scalar::<_, i64>(
+                    "SELECT COUNT(*) FROM function_calls WHERE caller_name = 'caller_fn'",
+                )
+                .fetch_one(&store.pool)
+                .await
+            })
+            .expect("query after reopen failed");
+        assert_eq!(count, 1, "RO handle did not see the fixture write");
+    }
+
+    #[test]
+    fn open_readonly_after_init_closure_error_propagates() {
+        // If the closure returns Err, the constructor must return Err and
+        // not leave a half-initialized read-only handle hanging around.
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("index.db");
+
+        // Can't use `expect_err` — `Store<ReadOnly>` doesn't implement
+        // `Debug`, so its formatter can't render the Ok case. Match directly.
+        match Store::<ReadOnly>::open_readonly_after_init(&db_path, |_s| {
+            Err(StoreError::Runtime("closure rejected the init".to_string()))
+        }) {
+            Ok(_) => panic!("constructor should have surfaced closure error"),
+            Err(StoreError::Runtime(msg)) => assert_eq!(msg, "closure rejected the init"),
+            Err(other) => panic!("expected Runtime error, got {other:?}"),
+        }
+
+        // The RW handle opened internally created the DB file (since
+        // `Store::open` uses `create_if_missing=true`). That's acceptable:
+        // the contract is "no half-initialized RO handle is returned", not
+        // "no bytes touch disk". The DB on disk may be either pre-init
+        // (empty) or post-init, but the caller holds no `Store` handle.
+        // Verify that a subsequent successful open_readonly_after_init can
+        // still use this path (i.e., the previous error didn't corrupt
+        // anything or leak a lock).
+        let recovered = Store::<ReadOnly>::open_readonly_after_init(&db_path, |s| {
+            s.init(&ModelInfo::default())?;
+            Ok(())
+        })
+        .expect("second attempt after closure error should succeed");
+        // Sanity: the recovered handle can run a read query.
+        assert!(recovered.check_model_version().is_ok());
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1584,7 +1584,6 @@ mod tests {
             .expect("second init() should be idempotent but failed");
     }
 
-<<<<<<< HEAD
     #[test]
     fn open_readonly_small_roundtrip() {
         // #970: open_readonly_small right-sizes the mmap/cache for reference

--- a/tests/cross_project_test.rs
+++ b/tests/cross_project_test.rs
@@ -4,18 +4,31 @@ use std::path::PathBuf;
 
 use cqs::cross_project::{CrossProjectContext, NamedStore};
 use cqs::parser::{ChunkType, Language};
-use cqs::store::ModelInfo;
+use cqs::store::{ModelInfo, ReadOnly, ReadWrite, StoreError};
 use cqs::Store;
 use tempfile::TempDir;
 
-fn create_project(dir: &TempDir) -> Store {
+/// Build a read-only `Store` at `dir/index.db`, initializing it and running
+/// `populate` for fixture setup. Wraps [`Store::open_readonly_after_init`]
+/// so tests don't have to repeat the init boilerplate.
+fn build_readonly_store<F>(dir: &TempDir, populate: F) -> Store<ReadOnly>
+where
+    F: FnOnce(&Store<ReadWrite>) -> Result<(), StoreError>,
+{
     let db_path = dir.path().join(cqs::INDEX_DB_FILENAME);
-    let store = Store::open(&db_path).expect("open store");
-    store.init(&ModelInfo::default()).expect("init store");
-    store
+    Store::<ReadOnly>::open_readonly_after_init(&db_path, |store| {
+        store.init(&ModelInfo::default())?;
+        populate(store)
+    })
+    .expect("open_readonly_after_init")
 }
 
-fn insert_chunk_and_call(store: &Store, caller: &str, callee: &str, file: &str) {
+fn insert_chunk_and_call(
+    store: &Store<ReadWrite>,
+    caller: &str,
+    callee: &str,
+    file: &str,
+) -> Result<(), StoreError> {
     // Use the public API: upsert_chunks + upsert_function_calls
     let chunk = cqs::Chunk {
         id: format!("{}:1:hash_{}", file, caller),
@@ -34,9 +47,7 @@ fn insert_chunk_and_call(store: &Store, caller: &str, callee: &str, file: &str) 
         parent_type_name: None,
     };
     let embedding = cqs::Embedding::new(vec![0.0f32; store.dim()]);
-    store
-        .upsert_chunks_batch(&[(chunk, embedding)], None)
-        .expect("upsert chunk");
+    store.upsert_chunks_batch(&[(chunk, embedding)], None)?;
 
     let calls = vec![cqs::parser::FunctionCalls {
         name: caller.to_string(),
@@ -46,29 +57,29 @@ fn insert_chunk_and_call(store: &Store, caller: &str, callee: &str, file: &str) 
             line_number: 3,
         }],
     }];
-    store
-        .upsert_function_calls(&PathBuf::from(file), &calls)
-        .expect("upsert calls");
+    store.upsert_function_calls(&PathBuf::from(file), &calls)?;
+    Ok(())
 }
 
 #[test]
 fn test_cross_project_callers_finds_both() {
     let dir_a = TempDir::new().unwrap();
     let dir_b = TempDir::new().unwrap();
-    let store_a = create_project(&dir_a);
-    let store_b = create_project(&dir_b);
-
-    insert_chunk_and_call(&store_a, "foo", "target", "a.rs");
-    insert_chunk_and_call(&store_b, "bar", "target", "b.rs");
+    let store_a = build_readonly_store(&dir_a, |s| {
+        insert_chunk_and_call(s, "foo", "target", "a.rs")
+    });
+    let store_b = build_readonly_store(&dir_b, |s| {
+        insert_chunk_and_call(s, "bar", "target", "b.rs")
+    });
 
     let mut ctx = CrossProjectContext::new(vec![
         NamedStore {
             name: "local".into(),
-            store: store_a.into_readonly(),
+            store: store_a,
         },
         NamedStore {
             name: "project_b".into(),
-            store: store_b.into_readonly(),
+            store: store_b,
         },
     ]);
 
@@ -87,20 +98,21 @@ fn test_cross_project_callers_finds_both() {
 fn test_cross_project_callees_finds_both() {
     let dir_a = TempDir::new().unwrap();
     let dir_b = TempDir::new().unwrap();
-    let store_a = create_project(&dir_a);
-    let store_b = create_project(&dir_b);
-
-    insert_chunk_and_call(&store_a, "source", "foo", "a.rs");
-    insert_chunk_and_call(&store_b, "source", "bar", "b.rs");
+    let store_a = build_readonly_store(&dir_a, |s| {
+        insert_chunk_and_call(s, "source", "foo", "a.rs")
+    });
+    let store_b = build_readonly_store(&dir_b, |s| {
+        insert_chunk_and_call(s, "source", "bar", "b.rs")
+    });
 
     let mut ctx = CrossProjectContext::new(vec![
         NamedStore {
             name: "local".into(),
-            store: store_a.into_readonly(),
+            store: store_a,
         },
         NamedStore {
             name: "project_b".into(),
-            store: store_b.into_readonly(),
+            store: store_b,
         },
     ]);
 
@@ -115,12 +127,11 @@ fn test_cross_project_callees_finds_both() {
 #[test]
 fn test_cross_project_no_references_local_only() {
     let dir = TempDir::new().unwrap();
-    let store = create_project(&dir);
-    insert_chunk_and_call(&store, "foo", "target", "a.rs");
+    let store = build_readonly_store(&dir, |s| insert_chunk_and_call(s, "foo", "target", "a.rs"));
 
     let mut ctx = CrossProjectContext::new(vec![NamedStore {
         name: "local".into(),
-        store: store.into_readonly(),
+        store,
     }]);
 
     let callers = ctx.get_callers_cross("target").unwrap();
@@ -131,11 +142,11 @@ fn test_cross_project_no_references_local_only() {
 #[test]
 fn test_cross_project_function_not_found() {
     let dir = TempDir::new().unwrap();
-    let store = create_project(&dir);
+    let store = build_readonly_store(&dir, |_s| Ok(()));
 
     let mut ctx = CrossProjectContext::new(vec![NamedStore {
         name: "local".into(),
-        store: store.into_readonly(),
+        store,
     }]);
 
     let callers = ctx.get_callers_cross("nonexistent").unwrap();
@@ -146,20 +157,21 @@ fn test_cross_project_function_not_found() {
 fn test_cross_project_same_name_different_sources() {
     let dir_a = TempDir::new().unwrap();
     let dir_b = TempDir::new().unwrap();
-    let store_a = create_project(&dir_a);
-    let store_b = create_project(&dir_b);
-
-    insert_chunk_and_call(&store_a, "init", "target", "a.rs");
-    insert_chunk_and_call(&store_b, "init", "target", "b.rs");
+    let store_a = build_readonly_store(&dir_a, |s| {
+        insert_chunk_and_call(s, "init", "target", "a.rs")
+    });
+    let store_b = build_readonly_store(&dir_b, |s| {
+        insert_chunk_and_call(s, "init", "target", "b.rs")
+    });
 
     let mut ctx = CrossProjectContext::new(vec![
         NamedStore {
             name: "local".into(),
-            store: store_a.into_readonly(),
+            store: store_a,
         },
         NamedStore {
             name: "project_b".into(),
-            store: store_b.into_readonly(),
+            store: store_b,
         },
     ]);
 


### PR DESCRIPTION
## Summary

Closes #986. Adds `Store::open_readonly_after_init<F>` — closure-based constructor that opens RW for fixture setup, drops the RW handle (flushing the WAL), and reopens RO. The returned `Store<ReadOnly>` is RO at both the type-system level *and* the SQLite connection level, closing the soft-RO footgun that `into_readonly()` left behind.

**`into_readonly()` is removed entirely.** No migration site justified the `#[cfg(test)]` escape hatch — every call site fit the closure pattern cleanly.

## Changes

| Location | Change |
|---|---|
| `src/store/mod.rs:739-749` | New `Store::<ReadOnly>::open_readonly_after_init<F>` at the bottom of `impl Store<ReadOnly>` (merge-safe placement per #968/#970 guidance) |
| `src/store/mod.rs:674-676` | Existing `open_readonly` doc updated to cross-reference the new constructor |
| `src/store/mod.rs:1510-1546` | Happy-path test: closure writes `function_calls` row, reopened RO reads it (verifies WAL flush) |
| `src/store/mod.rs:1548-1580` | Negative-path test: closure returns `Err`, constructor propagates; recovery-after-error check confirms no lock leak |
| `src/store/mod.rs` | `into_readonly` + its `ManuallyDrop`/`ptr::read` body removed |

## Migrated call sites (9 across 4 files)

- `tests/cross_project_test.rs` — 6 sites (4× `store_a.into_readonly()` + 2× `store.into_readonly()`), consolidated through a new `build_readonly_store` helper
- `src/store/calls/cross_project.rs` tests — 1 (`make_named_store` helper)
- `src/impact/cross_project.rs` tests — 1 (parallel `make_named_store` helper)
- `src/cli/batch/mod.rs` — 1 (`create_test_context`, `#[cfg(test)]`)

## Why the removal is safe

The `into_readonly` body used `ManuallyDrop` + `ptr::read` over every `Store` field. Adding a field later without updating the method would silently introduce UB (leak or UAF). Removing the unsafe body closes that foot-gun entirely — the only remaining RW→RO transition is the closure API, which is safe by construction (the RW handle is dropped, a fresh RO handle is opened).

## Test plan
- [x] `cargo test --lib -- store::tests::` — 16/16 (14 pre-existing + 2 new)
- [x] `cargo test --test cross_project_test` — 5/5
- [x] `cargo test --bin cqs -- batch` — 70/70 (exercises migrated `create_test_context`)
- [x] `cargo test --lib -- cross_project` — 12/12 (exercises both migrated `make_named_store` helpers)
- [x] `cargo test --doc -- open_readonly_after_init` — 1/1 (doctest compile-only)
- [x] `cargo clippy --lib --features gpu-index -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
