### PR TITLE
docs: audit 20 open issues post-v1.26.1 + refresh ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,18 +101,44 @@ Historical split (2026-04-09, 16,731 invocations): **main conversation** uses `s
 
 ---
 
-## Open Issues (pre-audit)
+## Open Issues
 
-| # | Finding | Difficulty |
-|---|---------|-----------|
-| #853 | DS-5: DEFERRED transactions → SQLITE_BUSY | medium |
-| #854 | SEC-4: Reference path containment | medium |
-| #855 | SHL-25: 25 env vars undocumented in README | easy |
-| #856 | PB-5: atexit Mutex UB | hard |
-| #848 | RM-1: Reduce tokio threads | easy |
-| #847 | EXT-2: CLI/batch parity test | easy (subsumed by [#947](https://github.com/jamie8johnson/cqs/issues/947)) |
+Audited 2026-04-16 post-v1.26.1 — see [`docs/audit-open-issues-2026-04-16.md`](docs/audit-open-issues-2026-04-16.md) for full findings + fix prompts amended onto each issue body.
 
-Audit-era issues under the `audit-v1.25.0` label: `gh issue list --label audit-v1.25.0`. Wave G backlog: #955, #958, #959, #960, #966, #969, #971, #974, #975.
+**Tier 1 (ship next, HIGH or MEDIUM/EASY):**
+
+| # | Finding | Impact | Difficulty |
+|---|---------|--------|-----------|
+| [#917](https://github.com/jamie8johnson/cqs/issues/917) | Streaming SPLADE serialize (~60-100MB peak drop) | HIGH | MEDIUM |
+| [#974](https://github.com/jamie8johnson/cqs/issues/974) | onboard + where: assert retrieval content | HIGH | MEDIUM |
+| [#975](https://github.com/jamie8johnson/cqs/issues/975) | Always-on recall + staleness mtime semantics | HIGH | MEDIUM |
+| [#954](https://github.com/jamie8johnson/cqs/issues/954) | Grammar-less parser dispatch via LanguageDef | MEDIUM | EASY |
+| [#959](https://github.com/jamie8johnson/cqs/issues/959) | Collapse notes dispatch into single handler | MEDIUM | EASY |
+| [#966](https://github.com/jamie8johnson/cqs/issues/966) | Stream-hash enrichment (blake3) | MEDIUM | EASY |
+| [#969](https://github.com/jamie8johnson/cqs/issues/969) | Recency-based `last_indexed_mtime` prune | MEDIUM | EASY |
+| [#971](https://github.com/jamie8johnson/cqs/issues/971) | HNSW self-heal dirty-flag integration test | MEDIUM | EASY |
+| [#951](https://github.com/jamie8johnson/cqs/issues/951) | Re-benchmark README Performance table | MEDIUM | EASY |
+
+**Tier 2 (bundle into audit-v1.26.0 wave, MEDIUM/MEDIUM):**
+
+| # | Finding |
+|---|---------|
+| [#955](https://github.com/jamie8johnson/cqs/issues/955) | Compile-enforced ChunkType type-hint patterns |
+| [#958](https://github.com/jamie8johnson/cqs/issues/958) | `define_query_categories!` macro — single source of truth |
+| [#960](https://github.com/jamie8johnson/cqs/issues/960) | Per-LanguageDef structural pattern matchers |
+| [#957](https://github.com/jamie8johnson/cqs/issues/957) | SPLADE/reranker preset registry |
+
+**Tier 3 (deferred / blocked):**
+
+| # | Finding | Blocker |
+|---|---------|---------|
+| [#956](https://github.com/jamie8johnson/cqs/issues/956) | ExecutionProvider: CoreML/ROCm decouple | needs non-Linux CI |
+| [#255](https://github.com/jamie8johnson/cqs/issues/255) | Pre-built reference packages | signing/registry design |
+| [#717](https://github.com/jamie8johnson/cqs/issues/717) | HNSW mmap | needs lib swap |
+| [#916](https://github.com/jamie8johnson/cqs/issues/916) | mmap SPLADE body | smaller win than claimed; depriorotized behind #917 |
+| [#106](https://github.com/jamie8johnson/cqs/issues/106) | ort 2.0-rc.12 stable release | upstream (pykeio) |
+
+**Closed during this audit:** #63 (audit.toml ignore already in place), #921 (watch-loop claim invalid; subsumed by #917).
 
 ---
 

--- a/docs/audit-open-issues-2026-04-16.md
+++ b/docs/audit-open-issues-2026-04-16.md
@@ -1,0 +1,70 @@
+# Open-issue audit — 2026-04-16 (post-v1.26.1)
+
+Audit pass on all 20 open GitHub issues after v1.26.1 shipped. Each has been code-verified; fix prompts are amended onto the issue bodies. This document is the cross-cutting ledger.
+
+## Summary
+
+| # | Title | Impact | Difficulty | Verdict |
+|---|-------|--------|-----------|---------|
+| #63 | deps: paste unmaintained (RUSTSEC-2024-0436) | LOW | EASY | **close** — audit.toml ignore already in place |
+| #106 | ort 2.0-rc.12 (no stable released) | MEDIUM | EASY | keep — blocked on upstream |
+| #255 | Pre-built reference packages | HIGH | HARD | keep — update model/schema specifics before spec work |
+| #717 | HNSW fully loaded into RAM (RM-40) | MEDIUM | HARD | keep — doc workaround (daemon), mmap needs lib swap |
+| #916 | mmap SPLADE index body (PF-11) | LOW | MEDIUM | keep — wins smaller than claimed |
+| #917 | Streaming SPLADE serialize (RM-5) | **HIGH** | MEDIUM | **prioritize** — ~60-100MB peak drop, contained scope |
+| #921 | SPLADE save blocks watch on WSL 9P | LOW | MEDIUM | **rescope** — "blocks watch" claim invalid; watch never calls `idx.save` |
+| #951 | Re-benchmark README Performance table | MEDIUM | EASY | fix — table is v1.22.x-era, cite v1.26.1 + 14,882 chunks |
+| #954 | Grammar-less parser dispatch via LanguageDef | MEDIUM | EASY | fix — cheapest refactor-lane win |
+| #955 | Compile-enforced ChunkType type-hint patterns | MEDIUM | MEDIUM | fix — extend `define_chunk_types!` with `hints = [...]` |
+| #956 | ExecutionProvider: CoreML/ROCm decouple | **HIGH** | HARD | keep — unlocks Apple Silicon + AMD, needs non-Linux CI |
+| #957 | SPLADE/reranker preset registry | MEDIUM | MEDIUM | keep — enables SPLADE-Code A/B without env flips |
+| #958 | `define_query_categories!` macro | MEDIUM | MEDIUM | fix — closes silent `_ => 1.0` fallback class |
+| #959 | Collapse notes dispatch | MEDIUM | EASY | fix — body text says `unreachable!()` but code is `bail!()` (stale) |
+| #960 | Per-LanguageDef structural patterns | MEDIUM | MEDIUM | fix — 4 pattern lists, 6 languages, data-driven |
+| #966 | Stream-hash enrichment (blake3) | MEDIUM | EASY | fix — ~100MB allocator pressure drop on 100k-chunk reindex |
+| #969 | Recency-based `last_indexed_mtime` prune | MEDIUM | EASY | fix — drop O(n) stat syscalls on WSL watch path |
+| #971 | HNSW self-heal dirty-flag integration test | MEDIUM | EASY | fix — pins rebuild-loop prevention |
+| #974 | onboard + where retrieval-content assertions | **HIGH** | MEDIUM | fix — guards agent-facing retrieval regression |
+| #975 | Always-on recall + staleness mtime semantics | **HIGH** | MEDIUM | fix — prevents silent retrieval regressions + backup-restore corruption |
+
+## Recommended priority order
+
+**Tier 1 (ship next):**
+1. **#917** streaming SPLADE serialize (HIGH/MEDIUM — user-visible peak-memory win)
+2. **#974** onboard/where content assertions (HIGH/MEDIUM — prevents agent-facing regressions)
+3. **#975** always-on recall + mtime semantics (HIGH/MEDIUM — CI recall ceiling)
+4. **#954** grammar-less parser dispatch (MEDIUM/EASY — closes a silent-routing class)
+5. **#959** collapse notes dispatch (MEDIUM/EASY — eliminates a bug class that already hit us once in PR #945)
+6. **#966** stream-hash enrichment (MEDIUM/EASY — allocator pressure)
+7. **#969** recency-based mtime prune (MEDIUM/EASY — WSL watch responsiveness)
+8. **#971** HNSW self-heal test (MEDIUM/EASY — pins invariant)
+9. **#951** README perf table refresh (MEDIUM/EASY — pure measurement)
+
+**Tier 2 (bundle into audit-v1.26.0 wave):**
+10. **#955** ChunkType hints compile-enforced (MEDIUM/MEDIUM)
+11. **#958** `define_query_categories!` macro (MEDIUM/MEDIUM)
+12. **#960** per-LanguageDef structural patterns (MEDIUM/MEDIUM)
+13. **#957** SPLADE/reranker preset registry (MEDIUM/MEDIUM)
+
+**Tier 3 (deferred / blocked):**
+14. **#956** ExecutionProvider CoreML/ROCm (HIGH/HARD — needs non-Linux CI)
+15. **#255** pre-built reference packages (HIGH/HARD — open design question)
+16. **#717** HNSW mmap (MEDIUM/HARD — needs hnsw lib swap)
+
+**Stale / close:**
+17. **#63** paste unmaintained — close, audit.toml already ignores it
+18. **#921** SPLADE save blocks watch — rescope to "streaming save perf" or close; watch-loop claim not reproducible
+
+**Tracking-only:**
+19. **#106** ort RC — keep open, no upstream stable available
+20. **#916** mmap SPLADE body — keep but depriorotize; owned-parse dominates residency
+
+## Appendix: impact × difficulty grid
+
+|  | EASY | MEDIUM | HARD |
+|---|---|---|---|
+| **HIGH** | — | #917, #974, #975 | #956, #255 |
+| **MEDIUM** | #106, #951, #954, #959, #966, #969, #971 | #955, #957, #958, #960 | #717 |
+| **LOW** | #63 | #916, #921 | — |
+
+Nine items land in HIGH or MEDIUM-impact × EASY difficulty — high-ROI candidates for the next sprint. The tier-3 HARD items (#956, #255, #717) are blocked on external dependencies (ORT providers, signing infrastructure, hnsw library) and should not absorb main-thread effort until unblocked.


### PR DESCRIPTION
## Summary

Systematic audit of all 20 open issues post-v1.26.1. Each issue's body now has an amended `## Audit 2026-04-16` section with a self-contained fix prompt, impact rating, and difficulty rating. This PR adds the cross-cutting ledger and refreshes the ROADMAP.

### Verdicts

- **17 valid with fix prompts** — 3 HIGH-impact (#917, #974, #975), 11 MEDIUM, 3 LOW.
- **2 closed** in this pass: #63 (audit.toml ignore already in place), #921 ("blocks watch" claim doesn't match code; subsumed by #917).
- **1 kept with updated specifics**: #255 (design spec needs v20 schema + BGE-large update before code).

### Tier 1 priorities (ship next)

High-ROI: #917 (streaming SPLADE, HIGH/MEDIUM), #974 + #975 (retrieval test coverage, HIGH/MEDIUM), plus 6 MEDIUM/EASY items (#954, #959, #966, #969, #971, #951).

### ROADMAP refresh

The stale "Open Issues (pre-audit)" section listed 6 issues (#847, #848, #853, #854, #855, #856) — all already closed. Replaced with a tiered view mirroring the audit doc.

### What's in this PR

- `docs/audit-open-issues-2026-04-16.md` — master audit ledger with summary table, priority tiers, and impact×difficulty grid.
- `ROADMAP.md` — Open Issues section rewritten with tier 1/2/3 breakdown.

The 20 per-issue body edits and 2 closures were applied directly via `gh` and are not part of this diff.

## Test plan

- [x] All 20 issue bodies amended (verified via `gh issue view`)
- [x] #63 and #921 closed with reasons
- [x] ROADMAP tier tables link to the correct issue numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
