### PR TITLE
docs(readme): refresh Performance table for v1.27.0 (#951)

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,28 +791,30 @@ Token budgeting works across all context commands: `--tokens N` packs results by
 
 ## Performance
 
-Benchmarked on a 4,110-chunk Rust project (202 files, 12 languages) with CUDA GPU (RTX A6000):
+Measured 2026-04-16 on the cqs codebase itself (562 files, 15,516 chunks) with CUDA GPU (NVIDIA RTX A6000, 48 GB) on WSL2 Ubuntu. Embedder: BGE-large (1024-dim). SPLADE: ensembledistil (110M, off-the-shelf). Raw measurements: [`evals/performance-v1.27.0.json`](evals/performance-v1.27.0.json).
 
 | Metric | Value |
 |--------|-------|
-| **Daemon query (graph ops)** | 3–19ms |
-| **Daemon query (search, warm)** | ~500ms |
-| **CLI search (hot, p50)** | 45ms |
-| **CLI search (cold, p50)** | 1,767ms |
-| **Throughput (batch mode)** | 22 queries/sec |
-| **Index build (203 files)** | 36 sec |
-| **Index size** | ~8 KB/chunk (31 MB for 4,110 chunks) |
+| **Daemon query (graph ops, p50)** | 99 ms |
+| **Daemon query (search, warm p50)** | 200 ms |
+| **Daemon query (impact, p50)** | 199 ms |
+| **Daemon query (search, first call after idle)** | 1.7–12 s (lazy ONNX init) |
+| **CLI cold (no daemon, p50)** | 10.5 s |
+| **Batch throughput (50 mixed ops)** | 2 ops/sec |
+| **Index size** | 2.4 GB DB (~157 KB/chunk, dominated by LLM enrichments) + 73 MB HNSW (~4.7 KB/chunk) |
 
-**Daemon mode** (`cqs watch --serve`) keeps the store, HNSW index, and embedder loaded. Graph queries (`callers`, `callees`, `impact`) run in 3–19ms. Embedding queries (`search`) pay ONNX inference on first run (~500ms), then hit the persistent query cache on repeats.
+**Daemon mode** (`cqs watch --serve`) keeps the store, HNSW index, embedder, SPLADE, and reranker loaded across queries — agents pay startup once and amortize over thousands of calls. Graph operations (`callers`, `callees`, `impact`) hit the in-memory call graph; search adds ONNX dense + SPLADE sparse retrieval and RRF fusion.
 
-CLI cold latency includes process startup, model init, and DB open. Batch mode (`cqs batch`) amortizes startup across queries.
+CLI cold latency includes process spawn, ONNX model load, DB open, and HNSW load. The 10× gap vs daemon is the cost of doing all of that per query — `cqs batch` amortizes startup across queries when the daemon isn't running.
+
+Mixed-batch throughput (~2 ops/sec) is dominated by search operations (~200 ms each via daemon). Pure call-graph throughput is much higher — `callers` alone runs at ~10 ops/sec via daemon.
 
 **Embedding latency (GPU vs CPU):**
 
 | Mode | Single Query | Batch (50 docs) |
 |------|--------------|-----------------|
-| CPU  | ~20ms        | ~15ms/doc       |
-| CUDA | ~3ms         | ~0.3ms/doc      |
+| CPU  | ~20 ms       | ~15 ms/doc      |
+| CUDA | ~3 ms        | ~0.3 ms/doc     |
 
 <details>
 <summary><h2>GPU Acceleration (Optional)</h2></summary>

--- a/evals/performance-v1.27.0.json
+++ b/evals/performance-v1.27.0.json
@@ -1,0 +1,62 @@
+{
+  "measured_on": "2026-04-16",
+  "cqs_version": "1.26.1+post (Phase-1 through Phase-5b on main; Phase-5c PR #1020 + Phase-5d pending)",
+  "git_revision": "3a5ef5c",
+  "hardware": {
+    "gpu": "NVIDIA RTX A6000 (48 GB)",
+    "secondary_gpu": "Quadro RTX 4000 (8 GB, idle during measurement)",
+    "platform": "WSL2 Ubuntu on Windows host"
+  },
+  "models": {
+    "embedder": "BAAI/bge-large-en-v1.5 (1024-dim)",
+    "splade": "naver/splade-cocondenser-ensembledistil (110M, off-the-shelf)",
+    "reranker": "cross-encoder/ms-marco-MiniLM-L-6-v2 (22M)"
+  },
+  "corpus": {
+    "name": "cqs codebase",
+    "files": 562,
+    "chunks": 15516,
+    "chunks_per_file": 27.6,
+    "languages": "rust + python (eval scripts) + markdown + a few stragglers"
+  },
+  "index_size": {
+    "index_db_bytes": 2430783488,
+    "index_db_human": "2.4 GB (includes content, summaries, hyde, embeddings as BLOBs)",
+    "hnsw_enriched_data_bytes": 64559472,
+    "hnsw_enriched_graph_bytes": 8084767,
+    "hnsw_enriched_ids_bytes": 698875,
+    "hnsw_base_data_bytes": 63793896,
+    "cagra_bytes": 67527348,
+    "cagra_meta_bytes": 693113,
+    "bytes_per_chunk_db": 156661,
+    "bytes_per_chunk_hnsw_only": 4727,
+    "notes": "DB dominated by enrichments (LLM summaries + HyDE). HNSW alone is ~4.7 KB/chunk. Pre-enrichment indexes are far smaller."
+  },
+  "latency_ms": {
+    "daemon_callers_p50": 99,
+    "daemon_callers_range": "86-100",
+    "daemon_callers_samples": 10,
+    "daemon_search_warm_p50": 200,
+    "daemon_search_warm_range": "137-219",
+    "daemon_search_warm_samples": 9,
+    "daemon_search_first_call_after_idle": "1700-12000 (lazy ONNX init in daemon)",
+    "daemon_impact_p50": 199,
+    "daemon_impact_range": "120-279",
+    "daemon_impact_samples": 5,
+    "cli_cold_no_daemon_p50": 10500,
+    "cli_cold_no_daemon_range": "10396-10649",
+    "cli_cold_no_daemon_samples": 3,
+    "notes": "CLI cold = full process spawn + ONNX init + DB open + HNSW load. Daemon mode amortizes all of this."
+  },
+  "throughput": {
+    "batch_mixed_50_ops_seconds": 25.0,
+    "batch_mixed_ops_per_sec": 2.0,
+    "batch_composition": "20 search + 10 callers + 5 callees + 6 impact + 4 explain + 4 scout + 1 misc",
+    "notes": "Throughput dominated by search ops (200ms each). Pure graph-op throughput is much higher — callers alone runs at ~10 ops/sec via daemon."
+  },
+  "post_v1_26_1_perf_changes": [
+    "#917 streaming SPLADE serialize — eliminates ~5-10 MB peak memory duplication on default ensembledistil model (~60-100 MB on SPLADE-Code 0.6B)",
+    "#966 stream-hash enrichment — drops ~100 MB allocator pressure on a 100k-chunk reindex",
+    "#969 recency-based last_indexed_mtime prune — eliminates O(n) stat() syscalls on WSL watch path"
+  ]
+}


### PR DESCRIPTION
## Summary

Phase 6 of the tier-1 audit wave. Refreshes the README Performance section with measurements taken 2026-04-16 on the cqs codebase itself (562 files, 15,516 chunks) using the post-Phase-5b binary.

The previous table was stamped to a 4,110-chunk Rust project from the v1.22.x era and had drifted noticeably:

| Metric | Old claim | Measured (v1.27.0-equivalent) |
|--------|-----------|-------------------------------|
| Daemon graph ops | 3–19 ms | **99 ms p50** |
| Daemon search (warm) | ~500 ms | **200 ms p50** |
| CLI cold (no daemon) | 1,767 ms | **10.5 s** (larger corpus) |
| Mixed-batch throughput | 22 ops/sec | **2 ops/sec** (search-heavy mix) |
| Index size | ~8 KB/chunk | **2.4 GB DB + 73 MB HNSW** (LLM enrichments dominate) |

Raw measurements + hardware spec + model versions + git revision pinned to [`evals/performance-v1.27.0.json`](evals/performance-v1.27.0.json) so future drift detection has a reference baseline.

Includes acknowledgements of the post-v1.26.1 perf changes that contribute: #917 streaming SPLADE, #966 stream-hash enrichment, #969 recency-based mtime prune.

## Test plan

- [x] All measurements taken from a freshly-installed `cqs 1.26.1` binary (post-Phase-5b main) against the cqs index at `.cqs/`.
- [x] Daemon restarted after binary install before warm measurements began (cold first-call shown separately).
- [x] Per-op sample counts and ranges recorded in the JSON sidecar.
- [x] `cargo fmt --check` n/a (docs only).

Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)
