### PR TITLE
chore: bump MSRV 1.93 → 1.95 + apply if-let guards + cold_path hints (Phase 5d)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
       - name: Check MSRV
         run: cargo check --verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to cqs!
 
 ## Development Setup
 
-**Requires Rust 1.93+** (check with `rustc --version`)
+**Requires Rust 1.95+** (check with `rustc --version`)
 
 1. Clone the repository:
    ```bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cqs"
 version = "1.26.1"
 edition = "2021"
-rust-version = "1.93"
+rust-version = "1.95"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 91% R@1 on 296-query fixtures, 42% R@1 / 64% R@5 / 79% R@20 on v3 real code-search (544 dual-judge queries). Daemon mode (3-19ms queries). Local-first, GPU-accelerated."
 license = "MIT"
 repository = "https://github.com/jamie8johnson/cqs"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Code intelligence and RAG for AI agents. Semantic search, call graph analysis, impact tracing, type dependencies, and smart context assembly — all in single tool calls. Local ML embeddings, GPU-accelerated.
 
-**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. 91.2% Recall@1 on fixtures; on a real 11k-chunk codebase (v1.25.0 clean post-GC index, 265-query V2 live eval) the router scores 37.4% R@1 / 55.8% R@5 / 77.4% R@20 (oracle ceiling 49.4% R@1). Identifier lookup is 50% R@1 / 73% R@5 on a 100-query slice — the agent-relevant metric. 54 languages + L5X/L5K PLC exports, GPU-accelerated.
+**TL;DR:** Code intelligence toolkit for Claude Code. Instead of grep + sequential file reads, cqs understands what code *does* — semantic search finds functions by concept, call graph commands trace dependencies, and `gather`/`impact`/`context` assemble the right context in one call. 17-41x token reduction vs full file reads. **91% R@1 on 296-query fixtures, 42% R@1 / 64% R@5 / 79% R@20 on the v3 dual-judge eval (544 real-code queries, 14.9k-chunk codebase, BGE-large + per-category SPLADE α routing).** Forced-α ceiling on v3 is ~48% R@1 — further headroom needs representation changes (HyDE, code-trained reranker), not tuning. 54 languages + L5X/L5K PLC exports, GPU-accelerated.
 
 [![Crates.io](https://img.shields.io/crates/v/cqs.svg)](https://crates.io/crates/cqs)
 [![CI](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml/badge.svg)](https://github.com/jamie8johnson/cqs/actions/workflows/ci.yml)
@@ -24,7 +24,7 @@ Code intelligence and RAG for AI agents. Semantic search, call graph analysis, i
 
 ## Install
 
-**Requires Rust 1.93+**
+**Requires Rust 1.95+**
 
 ```bash
 cargo install cqs

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -128,6 +128,10 @@ impl<Mode> Store<Mode> {
         let notes = match self.cached_notes_summaries() {
             Ok(n) => n,
             Err(e) => {
+                // Rust 1.95: hint that the notes-load failure path is cold so
+                // the optimizer keeps the happy path (Ok) inline in this
+                // per-query function.
+                core::hint::cold_path();
                 tracing::warn!(error = %e, "Failed to load notes for search boosting");
                 std::sync::Arc::new(Vec::new())
             }
@@ -173,6 +177,10 @@ impl<Mode> Store<Mode> {
             let note_boost = match self.cached_note_boost_index() {
                 Ok(arc) => NoteBoost::Owned(arc),
                 Err(e) => {
+                    // Rust 1.95: cache-fetch failure is the cold path; the
+                    // borrowed rebuild only fires when the cache layer has
+                    // already failed once.
+                    core::hint::cold_path();
                     tracing::warn!(error = %e, "note boost cache unavailable, rebuilding per-call");
                     NoteBoost::Borrowed(super::scoring::NoteBoostIndex::new(notes))
                 }
@@ -468,6 +476,10 @@ impl<Mode> Store<Mode> {
         let dense_results = if let Some(idx) = index {
             idx.search_with_filter(query, candidate_count, &predicate)
         } else {
+            // Rust 1.95: hybrid search without a vector index is a misconfig
+            // (build error or partial index load). Mark cold so the dense
+            // leg's normal path stays the predicted branch.
+            core::hint::cold_path();
             tracing::warn!("No vector index available for dense leg of hybrid search");
             Vec::new()
         };

--- a/src/search/router.rs
+++ b/src/search/router.rs
@@ -414,9 +414,19 @@ pub fn resolve_splade_alpha(category: &QueryCategory) -> f32 {
     let _span = tracing::debug_span!("resolve_splade_alpha", category = %category).entered();
 
     // Per-category env override: CQS_SPLADE_ALPHA_CONCEPTUAL_SEARCH etc.
+    //
+    // Rust 1.95 if-let guards collapse the previous nested
+    // `if let Ok(val) { if let Ok(alpha) { ... } else { warn } }` into a
+    // single match: each Ok-arm carries the env value straight into its
+    // tracing call without an extra `else` block. The happy-path arm keeps
+    // the inner `if alpha.is_finite()` so the non-finite warning can re-use
+    // the already-parsed `alpha` without a second `parse::<f32>()` round
+    // (clippy::collapsible_match would inline the predicate at the cost of
+    // re-parsing in the second arm — not worth it for a hot path).
     let cat_key = format!("CQS_SPLADE_ALPHA_{}", category.to_string().to_uppercase());
-    if let Ok(val) = std::env::var(&cat_key) {
-        if let Ok(alpha) = val.parse::<f32>() {
+    #[allow(clippy::collapsible_match)]
+    match std::env::var(&cat_key) {
+        Ok(val) if let Ok(alpha) = val.parse::<f32>() => {
             if alpha.is_finite() {
                 let alpha = alpha.clamp(0.0, 1.0);
                 tracing::info!(
@@ -428,14 +438,17 @@ pub fn resolve_splade_alpha(category: &QueryCategory) -> f32 {
                 return alpha;
             }
             tracing::warn!(var = %cat_key, value = %val, "Non-finite alpha, using default");
-        } else {
+        }
+        Ok(val) => {
             tracing::warn!(var = %cat_key, value = %val, "Invalid alpha, using default");
         }
+        Err(_) => {}
     }
 
     // Global env override: CQS_SPLADE_ALPHA
-    if let Ok(val) = std::env::var("CQS_SPLADE_ALPHA") {
-        if let Ok(alpha) = val.parse::<f32>() {
+    #[allow(clippy::collapsible_match)]
+    match std::env::var("CQS_SPLADE_ALPHA") {
+        Ok(val) if let Ok(alpha) = val.parse::<f32>() => {
             if alpha.is_finite() {
                 let alpha = alpha.clamp(0.0, 1.0);
                 tracing::info!(
@@ -447,6 +460,7 @@ pub fn resolve_splade_alpha(category: &QueryCategory) -> f32 {
                 return alpha;
             }
         }
+        _ => {}
     }
 
     // Per-category defaults from the 21-point alpha sweep on the genuinely


### PR DESCRIPTION
## Summary

Phase 5d of the tier-1 audit wave. Bumps MSRV from 1.93 → 1.95 and applies two surgical Rust 1.95 features that justify the bump.

## What changed

**MSRV bump (4 sites):**
- `Cargo.toml` — `rust-version = "1.95"`
- `.github/workflows/ci.yml` — `dtolnay/rust-toolchain@1.95.0`
- `README.md` — "Requires Rust 1.95+"
- `CONTRIBUTING.md` — "Requires Rust 1.95+"

**1.95 feature applications:**

1. **if-let guards in `match`** — `resolve_splade_alpha` (router.rs) replaces nested `if let Ok(val) = env::var() { if let Ok(alpha) = val.parse() { ... } else warn }` with `match` arms guarded by `if let Ok(alpha) = val.parse::<f32>()`. Cleaner control flow, single-parse semantics preserved.

   `classify_query` itself is a pure if-chain (no match ladder). The if-let-guard rewrite landed in the adjacent `resolve_splade_alpha` which sits in the same file and on every search path.

2. **`core::hint::cold_path()` on warn-fallback paths in hot loops** — three sites in `src/search/query.rs` (`search_filtered`, `search_filtered_with_notes`, `search_hybrid`). All three are per-query call paths where the `tracing::warn!` branch only fires on misconfig / transient errors. Optimizer gets real branch-prediction hints on production paths.

   Reranker `compute_scores` was scoped but skipped — its only `tracing::warn!` is in `Reranker::new()` (startup-only, hint wasted). Followed "if no clean candidate, skip" rule.

**README TL;DR refresh** bundled in (same "stale public-facing claim" theme): replaced v1.25.0 / v2 R@1 numbers (37.4% / 55.8% / 77.4%) with the shipped v3 eval (42.2% / 64.2% / 78.9% on 544 dual-judge queries). Added the architectural-ceiling note (forced-α ~48% R@1) so future drift detection has a concrete reference.

## Why the bump is overdue

1.93 was set when fs4 dropped (PR #349). 1.94 (2026-03-05) and 1.95 (2026-04-16) shipped while cqs's MSRV stayed put. Per the project's "no external users" principle, MSRV bumps cost ~zero externally.

Cargo.toml stays on **edition 2021**. Let-chains (`if let X && let Y`) require edition 2024 — out of scope. If-let guards work in edition 2021 + MSRV 1.95 and are what was applied.

## Test plan

- [x] `cargo +1.95.0 build --release --features gpu-index` — clean (proves MSRV is reachable).
- [x] `cargo build --release --features gpu-index` — clean (default toolchain).
- [x] `cargo test --release --features gpu-index --bin cqs router classify` — 40 router unit tests pass.
- [x] `cargo test --release --features gpu-index --test router_test` — 17 integration tests pass (every if-let-guard branch exercised: NaN, infinity, invalid string, per-cat override, global override, precedence).
- [x] `cargo test --release --features gpu-index --lib search::scoring` — 97 pass.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --release --features gpu-index -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
