### PR TITLE
chore: exclude evals/, samples/, tools/ from published crate (fixes v1.27.0 413)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,14 @@ exclude = [
     "docs/AUDIT_*",
     "docs/DESIGN_SPEC_*",
     "docs/notes.toml",
+    # Eval datasets, internal tools, and vendored forks live in the repo
+    # for development and CI but are not user-facing crate content. v1.27.0
+    # added v3 eval JSON (~136MB total) which pushed the package past
+    # crates.io's 10MB compressed limit.
+    "evals/",
+    "samples/",
+    "tools/",
+    "cuvs-fork-push/",
 ]
 
 [dependencies]


### PR DESCRIPTION
## Summary

Unblocks the v1.27.0 publish to crates.io. The v3 eval JSON datasets added in v1.26.1 → v1.27.0 (~136 MB across `evals/queries/v3_*.json`) were being bundled into the package. Combined with `samples/` (323 MB), `tools/` (25 MB), and `cuvs-fork-push/` (17 MB), the package went from 10.0 MiB compressed (right at the limit) to over → HTTP 413.

**After exclude:** 580 files, 9.6 MiB raw, **2.5 MiB compressed**. Comfortable headroom.

These directories are dev/CI-only — `cargo install cqs` users don't need them.

## Test plan

- [x] `cargo package --list --allow-dirty | wc -l` → 580 files
- [x] `cargo package --allow-dirty` → "Packaged 580 files, 9.6MiB (2.5MiB compressed)"
- [x] No source-code changes; existing tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
