### PR TITLE
feat(embedder,gc): index-aware embedder + proactive GC (#6, #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,9 @@ Best production config: **BGE-large** (`cqs index`). LLM summaries provide margi
 | `CQS_CENTROID_ALPHA_FLOOR` | `0.7` | Minimum α when the centroid classifier overrides the rule-based classifier. Caps downside of wrong-category alpha routing. Only active when `CQS_CENTROID_CLASSIFIER=1`. |
 | `CQS_CENTROID_CLASSIFIER` | `0` | Set to `1` to enable the embedding-centroid query classifier (experimental; disabled because 76% accuracy still hurts R@1 by −4.6pp on v3 dev). Set to `0` to explicitly disable when a centroid file is present. |
 | `CQS_CENTROID_THRESHOLD` | `0.01` | Minimum cosine margin (top1 − top2) for the centroid classifier to commit to a category. Below this, falls back to the rule-based classifier. |
+| `CQS_DAEMON_PERIODIC_GC` | `1` | Set to `0` to disable the daemon's idle-time periodic GC (#1024). When on, every 30 min of idle the daemon prunes a bounded batch of missing-file and gitignored chunks so the index stays close to a fresh `cqs index --force` over long sessions. |
+| `CQS_DAEMON_PERIODIC_GC_CAP` | `1000` | Max distinct origins examined per periodic-GC tick. Lower = shorter write transactions; higher = faster convergence on a polluted index. |
+| `CQS_DAEMON_STARTUP_GC` | `1` | Set to `0` to skip the daemon's startup GC pass (#1024). The startup pass drops chunks for files no longer on disk and chunks whose path is now matched by `.gitignore`. Synchronous, runs once when `cqs watch --serve` starts. |
 | `CQS_DAEMON_TIMEOUT_MS` | `2000` | Daemon client connect/read timeout in milliseconds (CLI → daemon) |
 | `CQS_DEFERRED_FLUSH_INTERVAL` | `50` | Chunks between deferred flushes during indexing |
 | `CQS_DISABLE_BASE_INDEX` | (none) | Set to `1` to skip the base (non-enriched) HNSW at query time (eval A/B) |

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -1052,6 +1052,21 @@ pub(crate) fn create_context_with_runtime(
         tracing::debug!("Could not stat index.db — staleness detection will be skipped until first successful stat");
     }
 
+    // Index-aware model resolution: prefer the model recorded in the store
+    // metadata over CQS_EMBEDDING_MODEL / config / default. Without this,
+    // running `CQS_EMBEDDING_MODEL=foo` against a `bar`-model index gives
+    // silent zero-result queries (the dim mismatch only surfaces as a
+    // tracing::warn! deep in the index backend). See ROADMAP.md "Embedder
+    // swap workflow".
+    let stored_model = store.stored_model_name();
+    let project_config = cqs::config::Config::load(&root);
+    let model_config = ModelConfig::resolve_for_query(
+        stored_model.as_deref(),
+        None,
+        project_config.embedding.as_ref(),
+    )
+    .apply_env_overrides();
+
     Ok(BatchContext {
         store: RefCell::new(store),
         runtime,
@@ -1070,7 +1085,7 @@ pub(crate) fn create_context_with_runtime(
         refs: RefCell::new(lru::LruCache::new(refs_lru_size())),
         root,
         cqs_dir,
-        model_config: ModelConfig::resolve(None, None).apply_env_overrides(),
+        model_config,
         index_id: Cell::new(index_id),
         // PF-V1.25-10: None means the first check runs unconditionally; the
         // 100ms rate-limit kicks in only after the first successful stat.

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -276,17 +276,6 @@ impl Cli {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("ModelConfig not resolved — call resolve_model() first"))
     }
-
-    /// Get the resolved model config. Panics if called before dispatch resolves it.
-    ///
-    /// **Deprecated:** Use [`try_model_config`] instead — it returns `Result`
-    /// rather than panicking on unresolved config.
-    #[deprecated(note = "use try_model_config() which returns Result instead of panicking")]
-    pub fn model_config(&self) -> &cqs::embedder::ModelConfig {
-        self.resolved_model
-            .as_ref()
-            .expect("BUG: ModelConfig not resolved — dispatch() must call resolve_model() first")
-    }
 }
 
 #[derive(Subcommand)]

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -69,6 +69,11 @@ pub(crate) struct CommandContext<'a, Mode = cqs::store::ReadWrite> {
     embedder: OnceLock<cqs::Embedder>,
     splade_encoder: OnceLock<Option<cqs::splade::SpladeEncoder>>,
     splade_index: OnceLock<Option<cqs::splade::index::SpladeIndex>>,
+    /// Index-aware ModelConfig override: if `Store::stored_model_name()` is
+    /// a known preset, that wins over CLI/env/config. Computed lazily on
+    /// first `model_config()` call. See
+    /// [`cqs::embedder::ModelConfig::resolve_for_query`].
+    index_aware_model: OnceLock<cqs::embedder::ModelConfig>,
 }
 
 impl<'a> CommandContext<'a, cqs::store::ReadOnly> {
@@ -84,6 +89,7 @@ impl<'a> CommandContext<'a, cqs::store::ReadOnly> {
             embedder: OnceLock::new(),
             splade_encoder: OnceLock::new(),
             splade_index: OnceLock::new(),
+            index_aware_model: OnceLock::new(),
         })
     }
 }
@@ -105,15 +111,46 @@ impl<'a> CommandContext<'a, cqs::store::ReadWrite> {
             embedder: OnceLock::new(),
             splade_encoder: OnceLock::new(),
             splade_index: OnceLock::new(),
+            index_aware_model: OnceLock::new(),
         })
     }
 }
 
 impl<'a, Mode> CommandContext<'a, Mode> {
-    /// Get the resolved model config from the CLI.
-    #[allow(deprecated)]
+    /// Get the resolved model config, preferring the model recorded in the
+    /// open store's metadata over CLI flag / env var / config / default.
+    ///
+    /// Index-time callers (`cqs index --force`) MUST NOT use this — they
+    /// should consult [`cqs::embedder::ModelConfig::resolve`] directly via
+    /// `cli.try_model_config()`. At index time the user's intent is to
+    /// install a new embedder; honouring the stored name would refuse to
+    /// switch models.
+    ///
+    /// Query-time commands (search, scout, gather, impact, ...) flow through
+    /// `CommandContext` and pick up the index-aware override here. This
+    /// closes the long-standing footgun where `CQS_EMBEDDING_MODEL=foo` set
+    /// in a shell would silently search a `bar`-model index with a wrong-dim
+    /// embedder and return zero results.
     pub fn model_config(&self) -> &cqs::embedder::ModelConfig {
-        self.cli.model_config()
+        self.index_aware_model.get_or_init(|| {
+            let stored = self.store.stored_model_name();
+            // Build a fresh resolution chain matching dispatch.rs logic.
+            // We re-load config because we don't carry it on the Cli.
+            let config = cqs::config::Config::load(&self.root);
+            let resolved = cqs::embedder::ModelConfig::resolve_for_query(
+                stored.as_deref(),
+                self.cli.model.as_deref(),
+                config.embedding.as_ref(),
+            )
+            .apply_env_overrides();
+            tracing::debug!(
+                stored_model = stored.as_deref().unwrap_or("<none>"),
+                resolved_model = %resolved.name,
+                resolved_dim = resolved.dim,
+                "CommandContext resolved index-aware model config"
+            );
+            resolved
+        })
     }
 
     /// Get or lazily create the cross-encoder reranker.

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -565,6 +565,51 @@ fn try_init_embedder<'a>(
     }
 }
 
+/// Resolve the embedding model for the watch / daemon path, preferring the
+/// model recorded in the open store's metadata over CLI flag / env / config.
+///
+/// Quick standalone read of `Store::stored_model_name()` — opened in
+/// read-only mode and dropped before the caller's main store handle is built,
+/// so this does not interfere with the watch loop's read-write store. The
+/// extra open is cheap (a single SELECT against the `metadata` table) and
+/// runs at most twice per `cmd_watch` invocation (once for the daemon
+/// thread's `daemon_model_config`, once for the watch loop's
+/// `cli.try_model_config()` override below).
+///
+/// See [`cqs::embedder::ModelConfig::resolve_for_query`] for the resolution
+/// chain when no stored name is present (CLI > env > config > default).
+fn resolve_index_aware_model_for_watch(
+    index_path: &std::path::Path,
+    root: &std::path::Path,
+    cli_model: Option<&str>,
+) -> Result<ModelConfig> {
+    let stored = match cqs::Store::open_readonly(index_path) {
+        Ok(s) => s.stored_model_name(),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "Quick read-only open for stored_model_name() failed; \
+                 falling back to CLI/env/config resolution"
+            );
+            None
+        }
+    };
+    let project_config = cqs::config::Config::load(root);
+    let resolved = ModelConfig::resolve_for_query(
+        stored.as_deref(),
+        cli_model,
+        project_config.embedding.as_ref(),
+    )
+    .apply_env_overrides();
+    tracing::info!(
+        stored = stored.as_deref().unwrap_or("<none>"),
+        resolved = %resolved.name,
+        dim = resolved.dim,
+        "Watch resolved index-aware model config"
+    );
+    Ok(resolved)
+}
+
 /// PB-3: Check if a path is under a WSL DrvFS automount root.
 ///
 /// Default automount root is `/mnt/`, but users can customize it via `automount.root`
@@ -721,6 +766,191 @@ fn build_splade_encoder_for_watch() -> Option<cqs::splade::SpladeEncoder> {
                  coverage will drift until manual 'cqs index'"
             );
             None
+        }
+    }
+}
+
+/// #1024: Default cap on the number of distinct origins examined per
+/// idle-time periodic GC tick. Keeps each tick short — at ~10k origins the
+/// matcher walk is microseconds-scale, but capping keeps the write
+/// transaction's lock window small even on much larger indexes. Override
+/// with `CQS_DAEMON_PERIODIC_GC_CAP` (parsed at first read).
+const DAEMON_PERIODIC_GC_CAP_DEFAULT: usize = 1000;
+
+/// #1024: Idle-time periodic GC interval. The daemon checks for a tick
+/// every loop iteration via `Instant::elapsed()`; the actual prune only
+/// fires when the last event was more than `DAEMON_PERIODIC_GC_IDLE_SECS`
+/// ago, so a long burst of file changes never triggers GC mid-burst.
+const DAEMON_PERIODIC_GC_INTERVAL_SECS: u64 = 1800; // 30 minutes
+const DAEMON_PERIODIC_GC_IDLE_SECS: u64 = 60;
+
+/// #1024: Read `CQS_DAEMON_PERIODIC_GC_CAP` once and cache. Keeps the
+/// hot path free of repeated env lookups on every tick.
+fn daemon_periodic_gc_cap() -> usize {
+    static CACHE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::env::var("CQS_DAEMON_PERIODIC_GC_CAP")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DAEMON_PERIODIC_GC_CAP_DEFAULT)
+    })
+}
+
+/// #1024: Run the daemon's startup GC sweep — Pass 1 (drop chunks for
+/// files no longer on disk) and Pass 2 (drop chunks for paths now matched
+/// by `.gitignore`). Runs once when `cqs watch --serve` starts, before
+/// the first request is served. Both passes are best-effort: failures are
+/// logged at warn and the daemon proceeds with whatever rows survived.
+///
+/// The eval-reliability motivating case: a `cqs index --force` on a
+/// long-running index dropped chunk count by 30 % (15 517 → 10 748). The
+/// extra 4 769 rows were a mix of deleted files and gitignored worktree
+/// pollution that accumulated before v1.26.0 added gitignore-respect to
+/// `cqs watch`. The startup pass closes that gap incrementally so the
+/// daemon converges to the same state a `--force` reindex would produce,
+/// without paying the embed cost.
+///
+/// Disable with `CQS_DAEMON_STARTUP_GC=0`.
+fn run_daemon_startup_gc(
+    store: &Store,
+    root: &Path,
+    parser: &CqParser,
+    matcher: Option<&ignore::gitignore::Gitignore>,
+) {
+    let _span = tracing::info_span!("daemon_startup_gc").entered();
+
+    if std::env::var("CQS_DAEMON_STARTUP_GC").as_deref() == Ok("0") {
+        tracing::info!("CQS_DAEMON_STARTUP_GC=0 — daemon startup GC disabled");
+        return;
+    }
+
+    // before/after counts are best-effort; if `stats()` fails we still run
+    // the prunes (the alternative is silent skip on a transient SQLite
+    // hiccup, which defeats the purpose of having a startup sweep).
+    let before = store.stats().map(|s| s.total_chunks).unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "Failed to read stats() before startup GC");
+        0
+    });
+
+    // Pass 1: prune chunks for files no longer on disk. Re-uses the same
+    // `prune_missing` path that `cqs gc` and `cqs index` call.
+    let exts = parser.supported_extensions();
+    let after_missing = match cqs::enumerate_files(root, &exts, false) {
+        Ok(files) => {
+            let file_set: std::collections::HashSet<_> = files.into_iter().collect();
+            match store.prune_missing(&file_set, root) {
+                Ok(n) => {
+                    if n > 0 {
+                        tracing::info!(pruned = n, "Daemon startup GC: pruned missing-file chunks");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Daemon startup GC: prune_missing failed — continuing");
+                }
+            }
+            store.stats().map(|s| s.total_chunks).unwrap_or(before)
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Daemon startup GC: enumerate_files failed — skipping prune_missing");
+            before
+        }
+    };
+
+    // Pass 2: retroactive gitignore prune. v1.26.0 only filters new events;
+    // pre-v1.26.0 rows (or rows added by `cqs index` before the
+    // gitignore-respect change) need this sweep to disappear.
+    let after = if let Some(gi) = matcher {
+        match store.prune_gitignored(gi, root, None) {
+            Ok(n) => {
+                if n > 0 {
+                    tracing::info!(pruned = n, "Daemon startup GC: pruned gitignored chunks");
+                }
+                store
+                    .stats()
+                    .map(|s| s.total_chunks)
+                    .unwrap_or(after_missing)
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Daemon startup GC: prune_gitignored failed — continuing");
+                after_missing
+            }
+        }
+    } else {
+        tracing::debug!("No gitignore matcher available — skipping retroactive gitignore prune");
+        after_missing
+    };
+
+    let pruned_missing = before.saturating_sub(after_missing);
+    let pruned_ignored = after_missing.saturating_sub(after);
+
+    tracing::info!(
+        before,
+        after_missing,
+        after,
+        pruned_missing,
+        pruned_ignored,
+        "Daemon startup GC complete"
+    );
+}
+
+/// #1024: Run the periodic idle-time GC sweep. Called from the main loop
+/// when `last_event` is older than `DAEMON_PERIODIC_GC_IDLE_SECS` and
+/// the previous GC ran more than `DAEMON_PERIODIC_GC_INTERVAL_SECS` ago.
+///
+/// Bounded: examines at most `daemon_periodic_gc_cap()` distinct origins
+/// per pass so a single tick never holds the write transaction longer
+/// than necessary. The cap means a deeply-polluted index converges over
+/// many ticks rather than one big stop-the-world prune.
+///
+/// Disable with `CQS_DAEMON_PERIODIC_GC=0`.
+fn run_daemon_periodic_gc(
+    store: &Store,
+    root: &Path,
+    parser: &CqParser,
+    matcher: Option<&ignore::gitignore::Gitignore>,
+) {
+    let _span = tracing::info_span!("daemon_periodic_gc").entered();
+
+    let cap = daemon_periodic_gc_cap();
+
+    // Pass 1: missing-file prune. `enumerate_files` is the heavier call
+    // here (one full walk of the tree); running it on idle is fine —
+    // by definition there is no contention.
+    let exts = parser.supported_extensions();
+    match cqs::enumerate_files(root, &exts, false) {
+        Ok(files) => {
+            let file_set: std::collections::HashSet<_> = files.into_iter().collect();
+            match store.prune_missing(&file_set, root) {
+                Ok(n) if n > 0 => {
+                    tracing::info!(pruned = n, "Periodic GC: pruned missing-file chunks");
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!(error = %e, "Periodic GC: prune_missing failed");
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Periodic GC: enumerate_files failed");
+        }
+    }
+
+    // Pass 2: bounded gitignore prune. `cap` limits how many origins this
+    // tick examines, so a deeply-polluted index converges over many ticks
+    // rather than one giant batch.
+    if let Some(gi) = matcher {
+        match store.prune_gitignored(gi, root, Some(cap)) {
+            Ok(n) if n > 0 => {
+                tracing::info!(
+                    pruned = n,
+                    cap,
+                    "Periodic GC: pruned gitignored chunks (capped batch)"
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(error = %e, "Periodic GC: prune_gitignored failed");
+            }
         }
     }
 }
@@ -1063,7 +1293,13 @@ pub fn cmd_watch(
             // so both the outer watch loop and BatchContext see the same
             // Arc<Embedder>.
             let daemon_embedder = std::sync::Arc::clone(&shared_embedder);
-            let daemon_model_config = cli.try_model_config()?.clone();
+            // Index-aware model resolution for the daemon's embedder. Prefer
+            // the model recorded in the store metadata so a wrong-model
+            // CQS_EMBEDDING_MODEL doesn't silently produce zero-result queries
+            // (the dim mismatch otherwise only surfaces as a tracing::warn!).
+            // See ROADMAP.md "Embedder swap workflow" for the longer story.
+            let daemon_model_config =
+                resolve_index_aware_model_for_watch(&index_path, &root, cli.model.as_deref())?;
             // #968: Clone the shared runtime handle into the daemon closure so
             // its BatchContext opens its Store/EmbeddingCache/QueryCache on
             // the same multi-thread pool as the outer watch loop.
@@ -1316,7 +1552,26 @@ pub fn cmd_watch(
             }
         };
 
-    let model_config = cli.try_model_config()?;
+    // Index-aware model resolution: prefer the model recorded in the open
+    // store metadata over CLI flag / env / config / default. Without this,
+    // running `cqs watch` with `CQS_EMBEDDING_MODEL=wrong-model` would embed
+    // new chunks with a different dim than the index, corrupting
+    // incremental reindex.
+    let stored_model_for_watch = store.stored_model_name();
+    let project_config_for_watch = cqs::config::Config::load(&root);
+    let model_config_owned = ModelConfig::resolve_for_query(
+        stored_model_for_watch.as_deref(),
+        cli.model.as_deref(),
+        project_config_for_watch.embedding.as_ref(),
+    )
+    .apply_env_overrides();
+    tracing::info!(
+        stored = stored_model_for_watch.as_deref().unwrap_or("<none>"),
+        resolved = %model_config_owned.name,
+        dim = model_config_owned.dim,
+        "Watch loop resolved index-aware model config"
+    );
+    let model_config = &model_config_owned;
 
     // #1002: build the gitignore matcher once at startup. `no_ignore` (CLI)
     // and `CQS_WATCH_RESPECT_GITIGNORE=0` (env) both disable it. Held in
@@ -1328,6 +1583,47 @@ pub fn cmd_watch(
     } else {
         build_gitignore_matcher(&root)
     });
+
+    // #1024: Daemon startup GC. Two-pass sweep — drop chunks whose origin
+    // is gone from disk (Pass 1) and drop chunks whose path is now matched
+    // by `.gitignore` (Pass 2, retroactive cleanup of pre-v1.26.0 worktree
+    // pollution). Only runs in `--serve` mode (the systemd unit) and is
+    // disabled by `CQS_DAEMON_STARTUP_GC=0`. Synchronous on the main
+    // thread so the daemon socket sees a clean index from the first
+    // accepted connection.
+    //
+    // Acquires the index lock non-blockingly via `try_acquire_index_lock`
+    // — if a concurrent `cqs index` already holds the lock, we skip the
+    // startup pass and let the next periodic-GC tick catch up. Blocking
+    // here would defeat `cqs index`'s expectation that the daemon
+    // releases the lock between reindex cycles.
+    if serve {
+        match try_acquire_index_lock(&cqs_dir) {
+            Ok(Some(gc_lock)) => {
+                let matcher_guard = gitignore.read().ok();
+                let matcher_ref = matcher_guard.as_ref().and_then(|g| g.as_ref());
+                run_daemon_startup_gc(&store, &root, &parser, matcher_ref);
+                // Explicit drop so the read lock is released before the watch
+                // loop starts taking it on every event.
+                drop(matcher_guard);
+                drop(gc_lock);
+                // Clear caches so subsequent queries observe the pruned rows.
+                store.clear_caches();
+                db_id = db_file_identity(&index_path);
+            }
+            Ok(None) => {
+                tracing::info!(
+                    "Daemon startup GC: index lock held by another process — skipping (periodic GC will catch up)"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Daemon startup GC: failed to acquire index lock — skipping"
+                );
+            }
+        }
+    }
 
     // #1004: build the SPLADE encoder once at startup. `None` means
     // incremental SPLADE is disabled for this daemon lifetime — either
@@ -1370,6 +1666,18 @@ pub fn cmd_watch(
     // the reindex path only trims once per hour, keeping the WAL file
     // from churning on every micro-edit.
     let mut last_cache_evict = std::time::Instant::now();
+
+    // #1024: Track last periodic GC tick. Initialised to "now" so the
+    // first periodic sweep doesn't fire until DAEMON_PERIODIC_GC_INTERVAL_SECS
+    // after startup — the startup pass already covered the initial state.
+    // Disabled when --serve is off (this is a daemon-only feature) or
+    // when CQS_DAEMON_PERIODIC_GC=0.
+    let periodic_gc_enabled =
+        serve && std::env::var("CQS_DAEMON_PERIODIC_GC").as_deref() != Ok("0");
+    if !periodic_gc_enabled && serve {
+        tracing::info!("CQS_DAEMON_PERIODIC_GC=0 — periodic idle-time GC disabled");
+    }
+    let mut last_periodic_gc = std::time::Instant::now();
 
     loop {
         match rx.recv_timeout(Duration::from_millis(100)) {
@@ -1476,6 +1784,52 @@ pub fn cmd_watch(
                         state.hnsw_index = None;
                         state.incremental_count = 0;
                         cycles_since_clear = 0;
+                    }
+
+                    // #1024: Idle-time periodic GC. Only fires when
+                    //   (a) `--serve` is on AND `CQS_DAEMON_PERIODIC_GC` != "0",
+                    //   (b) the last actual file event was more than
+                    //       DAEMON_PERIODIC_GC_IDLE_SECS ago (so a long burst
+                    //       of edits never triggers GC mid-burst), AND
+                    //   (c) the previous tick was more than
+                    //       DAEMON_PERIODIC_GC_INTERVAL_SECS ago.
+                    // The bounded sweep (cap = daemon_periodic_gc_cap()) keeps
+                    // each tick's write transaction short.
+                    //
+                    // Acquires the same `acquire_index_lock` semantics by
+                    // calling `try_acquire_index_lock` — if `cqs index` or
+                    // `cqs gc` is running, the GC tick skips and tries again
+                    // on the next interval.
+                    if periodic_gc_enabled
+                        && state.last_event.elapsed()
+                            >= Duration::from_secs(DAEMON_PERIODIC_GC_IDLE_SECS)
+                        && last_periodic_gc.elapsed()
+                            >= Duration::from_secs(DAEMON_PERIODIC_GC_INTERVAL_SECS)
+                    {
+                        match try_acquire_index_lock(&cqs_dir) {
+                            Ok(Some(gc_lock)) => {
+                                let matcher_guard = gitignore.read().ok();
+                                let matcher_ref = matcher_guard.as_ref().and_then(|g| g.as_ref());
+                                run_daemon_periodic_gc(&store, &root, &parser, matcher_ref);
+                                drop(matcher_guard);
+                                drop(gc_lock);
+                                // Clear caches so the next query observes the pruned rows.
+                                store.clear_caches();
+                                db_id = db_file_identity(&index_path);
+                            }
+                            Ok(None) => {
+                                tracing::debug!("Periodic GC: index lock held, skipping this tick");
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    "Periodic GC: failed to acquire index lock — skipping tick"
+                                );
+                            }
+                        }
+                        // Always advance the timer so a wedged lock or
+                        // failed enumerate doesn't make us retry every loop.
+                        last_periodic_gc = std::time::Instant::now();
                     }
                 }
 

--- a/src/embedder/models.rs
+++ b/src/embedder/models.rs
@@ -228,6 +228,51 @@ impl ModelConfig {
         }
     }
 
+    /// Resolve model config for a **query path** against an existing index.
+    ///
+    /// When the index records a model name (`Store::stored_model_name()`), that
+    /// name wins over CLI flag / env / config / default. The reasoning:
+    /// the index was built with a specific embedder, and the only useful
+    /// embedder for querying it is the one whose dim matches. Honouring a CLI
+    /// flag or `CQS_EMBEDDING_MODEL` that points at a different model leads to
+    /// the silent "0 results, only a tracing::warn!" failure mode this method
+    /// was added to prevent (see ROADMAP.md "Embedder swap workflow").
+    ///
+    /// Index time (`cqs index --force`) must keep using [`resolve`] — there
+    /// the user's intent is precisely to install a new embedder, and the
+    /// stored name (if any) is about to be overwritten.
+    ///
+    /// Falls through to [`resolve`] when:
+    /// - `stored_model` is `None` (fresh project, or pre-model-name index)
+    /// - the stored name is not a known preset (custom config — caller's
+    ///   chain still matches)
+    pub fn resolve_for_query(
+        stored_model: Option<&str>,
+        cli_model: Option<&str>,
+        config_embedding: Option<&EmbeddingConfig>,
+    ) -> Self {
+        let _span = tracing::info_span!("resolve_model_config_for_query").entered();
+        if let Some(name) = stored_model {
+            if let Some(cfg) = Self::from_preset(name) {
+                tracing::info!(
+                    model = %cfg.name,
+                    source = "index",
+                    "Resolved model config from indexed model name"
+                );
+                return cfg;
+            }
+            // Stored name not a known preset — fall through. The caller's
+            // resolution chain (CLI / env / config / default) is the next
+            // best signal. The defensive `Store::check_query_dim` guard will
+            // still catch a dim mismatch with an actionable error.
+            tracing::debug!(
+                stored = %name,
+                "Stored model name is not a known preset, falling back to CLI/env/config resolution"
+            );
+        }
+        Self::resolve(cli_model, config_embedding)
+    }
+
     /// Resolve model config from (in priority order): CLI flag, env var, config file, default.
     ///
     /// Unknown preset names log a warning and fall back to default.

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -83,6 +83,43 @@ pub(crate) fn type_boost_factor() -> f32 {
 }
 
 impl<Mode> Store<Mode> {
+    /// Defensive guard for query-time embedder/index dim mismatch.
+    ///
+    /// Returns [`StoreError::QueryDimMismatch`] when the query embedding's
+    /// dimension differs from the index's recorded dimension.
+    ///
+    /// # Why this exists
+    ///
+    /// Without this guard, a query against an index built with a different
+    /// model silently returns zero results: the dim mismatch surfaces as a
+    /// `tracing::warn!` deep inside the index backend (HNSW or CAGRA) and the
+    /// caller sees an empty result set with no actionable signal. Hours of
+    /// debugging followed (see ROADMAP.md "Embedder swap workflow").
+    ///
+    /// With index-aware embedder resolution in place
+    /// (`ModelConfig::resolve_for_query`), this case is rare — but the guard
+    /// remains as a defensive net for the "no recorded model" / corrupt-meta
+    /// edge case.
+    pub(crate) fn check_query_dim(&self, query: &Embedding) -> Result<(), StoreError> {
+        if query.len() == self.dim {
+            return Ok(());
+        }
+        let index_model = self
+            .stored_model_name()
+            .unwrap_or_else(|| "<unknown>".to_string());
+        // We do not have the embedder here, so we can only describe the query
+        // dim. The error template still gives the user enough information to
+        // fix the situation (rebuild against current model, or set
+        // CQS_EMBEDDING_MODEL to the indexed model).
+        let query_model = format!("{}-dim embedder", query.len());
+        Err(StoreError::QueryDimMismatch {
+            index_dim: self.dim,
+            query_dim: query.len(),
+            index_model,
+            query_model,
+        })
+    }
+
     /// Raw embedding-only cosine similarity search (no RRF, no keyword matching).
     ///
     /// **You almost certainly want `search_filtered()` instead.** This method skips
@@ -124,6 +161,12 @@ impl<Mode> Store<Mode> {
         let _span =
             tracing::info_span!("search_filtered", limit, threshold, rrf = filter.enable_rrf)
                 .entered();
+        // Defensive guard: surface query/index dim mismatch as a structured
+        // error instead of returning empty results from a downstream
+        // tracing::warn!. With Fix 1 (index-aware embedder resolution) in
+        // place this should rarely trigger, but it remains a safety net for
+        // missing-stored-model / corrupt-meta edges.
+        self.check_query_dim(query)?;
         // Load notes once for note-boosted ranking (cheap — no embeddings)
         let notes = match self.cached_notes_summaries() {
             Ok(n) => n,
@@ -623,6 +666,10 @@ impl<Mode> Store<Mode> {
         threshold: f32,
         index: Option<&dyn VectorIndex>,
     ) -> Result<Vec<SearchResult>, StoreError> {
+        // Defensive guard for query/index dim mismatch — see `check_query_dim`
+        // for rationale. Index backends (HNSW, CAGRA) used to swallow this
+        // case as a `tracing::warn!` and return zero candidates.
+        self.check_query_dim(query)?;
         // PERF-44: Load notes once for all search paths
         let notes = match self.cached_notes_summaries() {
             Ok(n) => n,
@@ -693,6 +740,8 @@ impl<Mode> Store<Mode> {
         limit: usize,
         threshold: f32,
     ) -> Result<Vec<SearchResult>, StoreError> {
+        // Defensive guard for query/index dim mismatch — see `check_query_dim`.
+        self.check_query_dim(query)?;
         // Load notes once for note-boosted ranking
         let notes = match self.cached_notes_summaries() {
             Ok(n) => n,

--- a/src/store/chunks/staleness.rs
+++ b/src/store/chunks/staleness.rs
@@ -260,6 +260,135 @@ impl Store<ReadWrite> {
             })
         })
     }
+
+    /// Delete chunks for files whose path is now matched by a `.gitignore`
+    /// matcher. Used by the daemon's startup GC pass to clean up rows that
+    /// were indexed before v1.26.0 added gitignore-respect to `cqs watch`,
+    /// or that pre-date a `.gitignore` change.
+    ///
+    /// Walks each distinct origin in `chunks` (with `source_type='file'`),
+    /// resolves it against `root` to obtain an absolute path, and asks the
+    /// matcher whether the path or any parent is ignored. Matching paths are
+    /// deleted in batches of 100 in a single transaction (same shape as
+    /// `prune_missing`). Notes and other non-file source types are
+    /// untouched.
+    ///
+    /// `max_paths` caps how many distinct origins this call examines per
+    /// invocation. Pass `None` for "no cap" (startup-time full sweep);
+    /// the periodic idle-time GC passes a small bound (e.g. 1000) so a
+    /// single tick never holds the write transaction longer than necessary.
+    /// Returns the number of chunk rows actually deleted.
+    pub fn prune_gitignored(
+        &self,
+        matcher: &ignore::gitignore::Gitignore,
+        root: &Path,
+        max_paths: Option<usize>,
+    ) -> Result<u32, StoreError> {
+        let _span = tracing::info_span!("prune_gitignored", max_paths = ?max_paths).entered();
+        self.rt.block_on(async {
+            // Phase 1: collect distinct origins (Rust-side filter, outside tx
+            // so the matcher walk doesn't hold the write lock).
+            let rows: Vec<(String,)> = sqlx::query_as(
+                "SELECT DISTINCT origin FROM chunks WHERE source_type = 'file'",
+            )
+            .fetch_all(&self.pool)
+            .await?;
+
+            let cap = max_paths.unwrap_or(usize::MAX);
+            let mut ignored: Vec<String> = Vec::new();
+            for (origin,) in rows.into_iter() {
+                if ignored.len() >= cap {
+                    break;
+                }
+                let origin_path = PathBuf::from(&origin);
+                let absolute = if origin_path.is_absolute() {
+                    origin_path
+                } else {
+                    root.join(&origin_path)
+                };
+                // `matched_path_or_any_parents` walks up the path's parents
+                // so that `.claude/worktrees/agent-x/src/lib.rs` is treated
+                // as ignored when `.claude/` is in `.gitignore`. The
+                // leaf-only `matched()` would miss this case — same logic
+                // as `collect_events` in `cli/watch.rs`.
+                if matcher
+                    .matched_path_or_any_parents(&absolute, false)
+                    .is_ignore()
+                {
+                    ignored.push(origin);
+                }
+            }
+
+            if ignored.is_empty() {
+                return Ok(0);
+            }
+
+            // Phase 2: batched delete in a single transaction. Same shape as
+            // `prune_missing` so a partial prune on crash leaves the index
+            // consistent with the remaining rows in `chunks`.
+            const BATCH_SIZE: usize = 100;
+            let mut deleted = 0u32;
+
+            let (_guard, mut tx) = self.begin_write().await?;
+
+            for batch in ignored.chunks(BATCH_SIZE) {
+                let placeholder_str = crate::store::helpers::make_placeholders(batch.len());
+
+                // Delete from FTS first
+                let fts_query = format!(
+                    "DELETE FROM chunks_fts WHERE id IN (SELECT id FROM chunks WHERE origin IN ({}))",
+                    placeholder_str
+                );
+                let mut fts_stmt = sqlx::query(&fts_query);
+                for origin in batch {
+                    fts_stmt = fts_stmt.bind(origin);
+                }
+                fts_stmt.execute(&mut *tx).await?;
+
+                // Delete from chunks
+                let chunks_query =
+                    format!("DELETE FROM chunks WHERE origin IN ({})", placeholder_str);
+                let mut chunks_stmt = sqlx::query(&chunks_query);
+                for origin in batch {
+                    chunks_stmt = chunks_stmt.bind(origin);
+                }
+                let result = chunks_stmt.execute(&mut *tx).await?;
+                deleted += result.rows_affected() as u32;
+            }
+
+            // Sweep orphan sparse_vectors inside the same transaction so a
+            // crash between DELETE chunks and DELETE sparse_vectors doesn't
+            // leave the SPLADE index over-counted (same fix as DS-1/DS-6 in
+            // `prune_missing`).
+            if deleted > 0 {
+                let sparse_result = sqlx::query(
+                    "DELETE FROM sparse_vectors WHERE chunk_id NOT IN \
+                     (SELECT id FROM chunks)",
+                )
+                .execute(&mut *tx)
+                .await?;
+                let pruned_sparse = sparse_result.rows_affected();
+                if pruned_sparse > 0 {
+                    tracing::debug!(
+                        pruned_sparse,
+                        "Pruned orphan sparse vectors in prune_gitignored tx"
+                    );
+                }
+            }
+
+            tx.commit().await?;
+
+            if deleted > 0 {
+                tracing::info!(
+                    deleted,
+                    paths = ignored.len(),
+                    "Pruned chunks for gitignored paths"
+                );
+            }
+
+            Ok(deleted)
+        })
+    }
 }
 
 impl<Mode> Store<Mode> {
@@ -1156,5 +1285,241 @@ mod tests {
         );
         assert!(report.missing.is_empty());
         assert_eq!(report.total_indexed, 1);
+    }
+
+    // ===== Daemon startup GC tests (#1024) =====
+    //
+    // These four tests pin the contract for the two prune passes the
+    // `cqs watch --serve` startup hook calls:
+    //
+    //   1. `prune_missing` — drop chunks whose origin no longer exists on
+    //      disk (e.g. file deleted while the daemon was down).
+    //   2. `prune_gitignored` — drop chunks whose path is now matched by
+    //      `.gitignore` (retroactive cleanup of pre-v1.26.0 pollution
+    //      that accumulated before `cqs watch` started honoring
+    //      `.gitignore`).
+    //
+    // Together they let the daemon idempotently reach the same chunk-count
+    // a fresh `cqs index --force` would produce, without rebuilding from
+    // scratch.
+
+    /// Build an `ignore::gitignore::Gitignore` matcher rooted at `root`
+    /// from the supplied pattern lines. Mirrors the `gitignore_from_lines`
+    /// helper in `src/cli/watch.rs::tests` so the staleness tests can build
+    /// matchers without importing from the binary crate.
+    fn matcher_from_lines(root: &std::path::Path, lines: &[&str]) -> ignore::gitignore::Gitignore {
+        let mut b = ignore::gitignore::GitignoreBuilder::new(root);
+        for line in lines {
+            b.add_line(None, line).expect("add_line");
+        }
+        b.build().expect("build gitignore")
+    }
+
+    /// Pass 1 — when the source file is gone from disk and absent from
+    /// `existing_files`, `prune_missing` must drop its chunks. Mirrors the
+    /// "deleted file" half of the daemon-startup pollution motivating
+    /// case (worktrees + deleted files).
+    #[test]
+    fn test_prune_missing_drops_chunks_for_deleted_files() {
+        let (store, dir) = setup_store();
+
+        // Seed two chunks: one for an actually-present file, one for a
+        // path the test never creates.
+        let kept_path = dir.path().join("src/keep.rs");
+        std::fs::create_dir_all(kept_path.parent().unwrap()).unwrap();
+        std::fs::write(&kept_path, "fn keep() {}").unwrap();
+        let kept_origin = kept_path.to_string_lossy().to_string();
+        let kept_chunk = Chunk {
+            id: format!("{}:1:keep", kept_origin),
+            file: kept_path.clone(),
+            language: Language::Rust,
+            chunk_type: ChunkType::Function,
+            name: "keep".to_string(),
+            signature: "fn keep()".to_string(),
+            content: "fn keep() {}".to_string(),
+            doc: None,
+            line_start: 1,
+            line_end: 1,
+            content_hash: "keep".to_string(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+        };
+
+        let gone = make_chunk("gone", "/no/such/file.rs");
+
+        store
+            .upsert_chunks_batch(
+                &[
+                    (kept_chunk, mock_embedding(1.0)),
+                    (gone, mock_embedding(2.0)),
+                ],
+                Some(1000),
+            )
+            .unwrap();
+
+        // Existing files contains only the kept path; the deleted file is
+        // omitted. `prune_missing` must drop the orphan chunk.
+        let mut existing = HashSet::new();
+        existing.insert(kept_path);
+        let pruned = store.prune_missing(&existing, dir.path()).unwrap();
+        assert_eq!(
+            pruned, 1,
+            "Should prune exactly 1 chunk for the deleted file"
+        );
+
+        let stats = store.stats().unwrap();
+        assert_eq!(stats.total_chunks, 1, "Kept chunk must survive");
+    }
+
+    /// Pass 1 baseline — when every chunk's source file is still on disk,
+    /// `prune_missing` must return 0 and leave the index untouched.
+    /// Regression guard: a refactor that flips the existence check would
+    /// silently delete the entire index on the next daemon startup.
+    #[test]
+    fn test_prune_missing_keeps_chunks_for_present_files() {
+        let (store, dir) = setup_store();
+
+        // Two real files on disk, two chunks indexed.
+        let p1 = dir.path().join("src/a.rs");
+        let p2 = dir.path().join("src/b.rs");
+        std::fs::create_dir_all(p1.parent().unwrap()).unwrap();
+        std::fs::write(&p1, "fn a() {}").unwrap();
+        std::fs::write(&p2, "fn b() {}").unwrap();
+
+        let mk = |path: &std::path::Path, name: &str, hash: &str| {
+            let origin = path.to_string_lossy().to_string();
+            Chunk {
+                id: format!("{}:1:{}", origin, hash),
+                file: path.to_path_buf(),
+                language: Language::Rust,
+                chunk_type: ChunkType::Function,
+                name: name.to_string(),
+                signature: format!("fn {}()", name),
+                content: format!("fn {}() {{}}", name),
+                doc: None,
+                line_start: 1,
+                line_end: 1,
+                content_hash: hash.to_string(),
+                parent_id: None,
+                window_idx: None,
+                parent_type_name: None,
+            }
+        };
+        let c1 = mk(&p1, "a", "ahash");
+        let c2 = mk(&p2, "b", "bhash");
+
+        store
+            .upsert_chunks_batch(
+                &[(c1, mock_embedding(1.0)), (c2, mock_embedding(2.0))],
+                Some(1000),
+            )
+            .unwrap();
+
+        let existing: HashSet<_> = vec![p1, p2].into_iter().collect();
+        let pruned = store.prune_missing(&existing, dir.path()).unwrap();
+        assert_eq!(
+            pruned, 0,
+            "No files are missing — prune_missing must return 0"
+        );
+
+        let stats = store.stats().unwrap();
+        assert_eq!(stats.total_chunks, 2, "Both chunks must survive");
+    }
+
+    /// Pass 2 — when `.gitignore` ignores `target/`, a chunk whose origin
+    /// is `target/cache.rs` must be pruned. Models the canonical
+    /// pre-v1.26.0 pollution case (worktrees, build artifacts, etc.).
+    #[test]
+    fn test_prune_gitignored_drops_chunks_in_ignored_paths() {
+        let (store, dir) = setup_store();
+
+        // Build an "indexed-before-gitignore" chunk under `target/`. The
+        // file does not need to exist on disk for this test — the gitignore
+        // matcher walks the path string, not the filesystem.
+        let target_chunk = make_chunk("cache", "target/cache.rs");
+        let kept_path = dir.path().join("src/lib.rs");
+        std::fs::create_dir_all(kept_path.parent().unwrap()).unwrap();
+        std::fs::write(&kept_path, "pub fn lib() {}").unwrap();
+        let kept_origin = kept_path.to_string_lossy().to_string();
+        let kept_chunk = Chunk {
+            id: format!("{}:1:lib", kept_origin),
+            file: kept_path.clone(),
+            language: Language::Rust,
+            chunk_type: ChunkType::Function,
+            name: "lib".to_string(),
+            signature: "pub fn lib()".to_string(),
+            content: "pub fn lib() {}".to_string(),
+            doc: None,
+            line_start: 1,
+            line_end: 1,
+            content_hash: "lib".to_string(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+        };
+
+        store
+            .upsert_chunks_batch(
+                &[
+                    (target_chunk, mock_embedding(1.0)),
+                    (kept_chunk, mock_embedding(2.0)),
+                ],
+                Some(1000),
+            )
+            .unwrap();
+
+        let matcher = matcher_from_lines(dir.path(), &["target/", ".claude/"]);
+        let pruned = store.prune_gitignored(&matcher, dir.path(), None).unwrap();
+        assert_eq!(
+            pruned, 1,
+            "target/cache.rs is now gitignored — must be pruned"
+        );
+
+        // The src/lib.rs chunk survives.
+        let stats = store.stats().unwrap();
+        assert_eq!(stats.total_chunks, 1);
+    }
+
+    /// Pass 2 baseline — when `.gitignore` only matches `target/`, a chunk
+    /// for `src/lib.rs` must survive. Regression guard: a refactor that
+    /// inverts the matcher result (or accidentally treats `Whitelist` as
+    /// "ignore") would wipe the entire tracked source tree on first
+    /// daemon startup.
+    #[test]
+    fn test_prune_gitignored_keeps_chunks_in_tracked_paths() {
+        let (store, dir) = setup_store();
+
+        let kept_path = dir.path().join("src/lib.rs");
+        std::fs::create_dir_all(kept_path.parent().unwrap()).unwrap();
+        std::fs::write(&kept_path, "pub fn lib() {}").unwrap();
+        let kept_origin = kept_path.to_string_lossy().to_string();
+        let kept_chunk = Chunk {
+            id: format!("{}:1:lib", kept_origin),
+            file: kept_path.clone(),
+            language: Language::Rust,
+            chunk_type: ChunkType::Function,
+            name: "lib".to_string(),
+            signature: "pub fn lib()".to_string(),
+            content: "pub fn lib() {}".to_string(),
+            doc: None,
+            line_start: 1,
+            line_end: 1,
+            content_hash: "lib".to_string(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+        };
+
+        store
+            .upsert_chunks_batch(&[(kept_chunk, mock_embedding(1.0))], Some(1000))
+            .unwrap();
+
+        let matcher = matcher_from_lines(dir.path(), &["target/"]);
+        let pruned = store.prune_gitignored(&matcher, dir.path(), None).unwrap();
+        assert_eq!(pruned, 0, "src/lib.rs is not gitignored — must be kept");
+
+        let stats = store.stats().unwrap();
+        assert_eq!(stats.total_chunks, 1);
     }
 }

--- a/src/store/helpers/error.rs
+++ b/src/store/helpers/error.rs
@@ -34,6 +34,21 @@ pub enum StoreError {
         "Dimension mismatch: index has {0}-dim embeddings, current model expects {1}. Run 'cqs index --force' to rebuild."
     )]
     DimensionMismatch(u32, u32),
+    /// Query-time embedder dim does not match the index dim.
+    /// Distinct from [`StoreError::DimensionMismatch`] (storage-blob shape) so the CLI
+    /// can print a model-aware hint instead of the generic "rebuild" message.
+    /// `index_model` / `query_model` are best-effort short names ("v9-200k",
+    /// "BAAI/bge-large-en-v1.5", or `<unknown>` when the store predates model-name
+    /// metadata).
+    #[error(
+        "embedder dim mismatch — index built with {index_model} ({index_dim}-dim) but query embedder is {query_model} ({query_dim}-dim).\n       Run `cqs index --force --model {index_model}` to rebuild against the current embedder, or set CQS_EMBEDDING_MODEL={index_model} to query with the indexed model."
+    )]
+    QueryDimMismatch {
+        index_dim: usize,
+        query_dim: usize,
+        index_model: String,
+        query_model: String,
+    },
     #[error("Database integrity check failed: {0}")]
     Corruption(String),
     #[error("Embedding blob dimension mismatch: expected {expected}-dim ({expected_bytes} bytes), got {actual_bytes} bytes")]

--- a/tests/embedder_dim_mismatch_test.rs
+++ b/tests/embedder_dim_mismatch_test.rs
@@ -1,0 +1,213 @@
+//! Tests for embedder/index dim-mismatch error handling.
+//!
+//! Two related guarantees are exercised:
+//!
+//! 1. **Fix 1 — index-aware embedder resolution.** Given a store recorded
+//!    with model X, `ModelConfig::resolve_for_query` returns X regardless of
+//!    `CQS_EMBEDDING_MODEL`, CLI flag, or config-file selection. Falls
+//!    through to the legacy resolution chain when no stored model is
+//!    present.
+//!
+//! 2. **Fix 2 — hard error on dim mismatch.** When a query embedding's dim
+//!    differs from the index's recorded dim, `Store::search_filtered` and
+//!    `Store::search_filtered_with_index` return
+//!    [`StoreError::QueryDimMismatch`] with an actionable message. This is
+//!    the defensive net for when Fix 1 doesn't apply (corrupt meta, custom
+//!    config, etc.).
+
+mod common;
+
+use cqs::embedder::{Embedding, EmbeddingConfig, ModelConfig};
+use cqs::store::{ModelInfo, SearchFilter, Store, StoreError};
+use std::sync::Mutex;
+use tempfile::TempDir;
+
+/// Mutex to serialize tests that manipulate `CQS_EMBEDDING_MODEL`. Env vars
+/// are process-global so concurrent test threads race on set/remove. Mirrors
+/// the same pattern used in `src/embedder/models.rs`'s test mod.
+static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Build a unit-norm `Embedding` of the requested dimension. Caller picks
+/// `dim` (cannot rely on `EMBEDDING_DIM` because the whole point of these
+/// tests is exercising mismatched dims).
+fn mock_embedding_dim(dim: usize, seed: f32) -> Embedding {
+    let mut v = vec![seed; dim];
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in &mut v {
+            *x /= norm;
+        }
+    }
+    Embedding::new(v)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Fix 1 — resolve_for_query
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn resolve_for_query_prefers_stored_model_over_env() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    std::env::set_var("CQS_EMBEDDING_MODEL", "v9-200k");
+    let resolved = ModelConfig::resolve_for_query(Some("bge-large"), None, None);
+    std::env::remove_var("CQS_EMBEDDING_MODEL");
+    assert_eq!(resolved.name, "bge-large");
+    assert_eq!(resolved.dim, 1024);
+}
+
+#[test]
+fn resolve_for_query_prefers_stored_model_over_cli_flag() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    std::env::remove_var("CQS_EMBEDDING_MODEL");
+    let resolved = ModelConfig::resolve_for_query(Some("bge-large"), Some("v9-200k"), None);
+    assert_eq!(resolved.name, "bge-large");
+    assert_eq!(resolved.dim, 1024);
+}
+
+#[test]
+fn resolve_for_query_accepts_repo_id_as_stored_name() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    std::env::remove_var("CQS_EMBEDDING_MODEL");
+    let resolved =
+        ModelConfig::resolve_for_query(Some("BAAI/bge-large-en-v1.5"), Some("v9-200k"), None);
+    assert_eq!(resolved.name, "bge-large");
+    assert_eq!(resolved.dim, 1024);
+}
+
+#[test]
+fn resolve_for_query_falls_through_when_no_stored_model() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    std::env::remove_var("CQS_EMBEDDING_MODEL");
+    let resolved = ModelConfig::resolve_for_query(None, Some("v9-200k"), None);
+    assert_eq!(resolved.name, "v9-200k");
+    assert_eq!(resolved.dim, 768);
+}
+
+#[test]
+fn resolve_for_query_falls_through_when_stored_unknown() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    std::env::remove_var("CQS_EMBEDDING_MODEL");
+    let resolved = ModelConfig::resolve_for_query(
+        Some("unknown-future-model"),
+        Some("v9-200k"),
+        Some(&EmbeddingConfig::default()),
+    );
+    assert_eq!(resolved.name, "v9-200k");
+}
+
+#[test]
+fn resolve_for_query_falls_through_to_default_when_chain_empty() {
+    let _lock = ENV_MUTEX.lock().unwrap();
+    std::env::remove_var("CQS_EMBEDDING_MODEL");
+    let resolved = ModelConfig::resolve_for_query(None, None, None);
+    assert_eq!(resolved.name, "bge-large");
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Fix 2 — Store guards search paths against query/index dim mismatch
+// ────────────────────────────────────────────────────────────────────────────
+
+fn store_with_dim(model_name: &str, dim: usize) -> (Store, TempDir) {
+    let dir = TempDir::new().expect("temp dir");
+    let db_path = dir.path().join(cqs::INDEX_DB_FILENAME);
+    let store = Store::open(&db_path).expect("open store");
+    store
+        .init(&ModelInfo::new(model_name, dim))
+        .expect("init store");
+    drop(store);
+    let store = Store::open(&db_path).expect("reopen store");
+    (store, dir)
+}
+
+#[test]
+fn search_filtered_errors_on_dim_mismatch() {
+    let (store, _dir) = store_with_dim("test/v9-200k", 768);
+    assert_eq!(store.dim(), 768);
+    let bad_query = mock_embedding_dim(1024, 0.5);
+    let result = store.search_filtered(&bad_query, &SearchFilter::default(), 10, 0.0);
+    let err = result.expect_err("dim mismatch must error, not return empty Ok");
+    match err {
+        StoreError::QueryDimMismatch {
+            index_dim,
+            query_dim,
+            index_model,
+            ..
+        } => {
+            assert_eq!(index_dim, 768);
+            assert_eq!(query_dim, 1024);
+            assert_eq!(index_model, "test/v9-200k");
+        }
+        other => panic!("expected QueryDimMismatch, got: {other:?}"),
+    }
+}
+
+#[test]
+fn search_filtered_with_index_errors_on_dim_mismatch() {
+    let (store, _dir) = store_with_dim("test/v9-200k", 768);
+    let bad_query = mock_embedding_dim(1024, 0.5);
+    let err = store
+        .search_filtered_with_index(&bad_query, &SearchFilter::default(), 10, 0.0, None)
+        .expect_err("dim mismatch must error");
+    assert!(matches!(err, StoreError::QueryDimMismatch { .. }));
+}
+
+#[test]
+fn search_by_candidate_ids_errors_on_dim_mismatch() {
+    let (store, _dir) = store_with_dim("test/v9-200k", 768);
+    let bad_query = mock_embedding_dim(1024, 0.5);
+    let candidate_ids: Vec<&str> = vec!["fake_chunk_id"];
+    let err = store
+        .search_by_candidate_ids(
+            &candidate_ids,
+            &bad_query,
+            &SearchFilter::default(),
+            10,
+            0.0,
+        )
+        .expect_err("dim mismatch must error");
+    assert!(matches!(err, StoreError::QueryDimMismatch { .. }));
+}
+
+#[test]
+fn search_filtered_passes_with_matching_dim() {
+    let (store, _dir) = store_with_dim("test/v9-200k", 768);
+    let good_query = mock_embedding_dim(768, 0.5);
+    let result = store
+        .search_filtered(&good_query, &SearchFilter::default(), 10, 0.0)
+        .expect("matching dim must succeed");
+    assert!(result.is_empty(), "no chunks indexed → empty results");
+}
+
+#[test]
+fn dim_mismatch_error_message_is_actionable() {
+    let (store, _dir) = store_with_dim("test/v9-200k", 768);
+    let bad_query = mock_embedding_dim(1024, 0.5);
+    let err = store
+        .search_filtered(&bad_query, &SearchFilter::default(), 10, 0.0)
+        .expect_err("dim mismatch must error");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("test/v9-200k"),
+        "error message must name the index model: {msg}"
+    );
+    assert!(
+        msg.contains("768") && msg.contains("1024"),
+        "error message must include both dims: {msg}"
+    );
+    assert!(
+        msg.contains("--force") || msg.contains("CQS_EMBEDDING_MODEL"),
+        "error message must point at a fix: {msg}"
+    );
+}
+
+#[test]
+fn search_filtered_message_handles_repo_id_format() {
+    let (store, _dir) = store_with_dim("BAAI/bge-large-en-v1.5", 1024);
+    let bad_query = mock_embedding_dim(768, 0.5);
+    let err = store
+        .search_filtered(&bad_query, &SearchFilter::default(), 10, 0.0)
+        .expect_err("must error");
+    let msg = format!("{err}");
+    assert!(msg.contains("BAAI/bge-large-en-v1.5"), "{msg}");
+    assert!(msg.contains("1024") && msg.contains("768"), "{msg}");
+}


### PR DESCRIPTION
## Summary

Two coordinated fixes that close the eval-flakiness class hit during the v9-200k experiment. Aggregated from two parallel implementer worktrees; clean 3-way merge in `src/cli/watch.rs` (no overlap, both agents touched different line ranges).

## Embedder hygiene — the silent-zero-results bug

**Before:** `cqs "query"` against an index built with model X, with `CQS_EMBEDDING_MODEL=Y` set in the shell, produced a 1024-dim query against a 768-dim index → empty results + only a deep `tracing::warn!` for diagnostic. Invisible to the calling agent.

**After:**
- `Store::stored_model_name()` (already in metadata) wins over CLI/env/config at query time. New `ModelConfig::resolve_for_query()` performs index-aware resolution.
- Wired into `CommandContext::model_config()`, `BatchContext` (daemon), and the `cqs watch` daemon path via `resolve_index_aware_model_for_watch`.
- Defensive net: `Store::check_query_dim()` runs at the entry of `search_filtered`, `search_filtered_with_index`, and `search_by_candidate_ids`. On dim mismatch returns a structured `StoreError::QueryDimMismatch { index_dim, query_dim, index_model, query_model }` instead of empty results:

```
embedder dim mismatch — index built with v9-200k (768-dim) but query
embedder is 1024-dim embedder (1024-dim).
       Run `cqs index --force --model v9-200k` to rebuild against the
       current embedder, or set CQS_EMBEDDING_MODEL=v9-200k to query
       with the indexed model.
```

- Removed deprecated `Cli::model_config()`; `try_model_config()` is the only path now.
- 12 new tests in `tests/embedder_dim_mismatch_test.rs`.

## Proactive GC — the eval-flakiness root cause

**Before:** indexes accumulated stale rows over time. Bulk git operations (checkout, rebase, worktree add/remove) on WSL `/mnt/c/` silently miss file-delete events. Pre-v1.26.0 paths like `.claude/worktrees/agent-*` stayed indexed even after the v1.26.0 gitignore-respect work. Net: the v1.26.1-shipped index had ~30% pollution (4,769 stale rows out of 15,517), inflating R@1 baselines.

**After (`cqs watch --serve` runs three GC passes):**

| Pass | When | Default | Env gate |
|------|------|---------|----------|
| Startup `prune_missing` | once on daemon start | on | `CQS_DAEMON_STARTUP_GC` |
| Startup `prune_gitignored` | once on daemon start | on | `CQS_DAEMON_STARTUP_GC` |
| Idle-time periodic | every 30 min when 60s+ idle | on | `CQS_DAEMON_PERIODIC_GC` (cap: `CQS_DAEMON_PERIODIC_GC_CAP`, default 1000 origins/tick) |

- New `Store::prune_gitignored` method in `src/store/chunks/staleness.rs`.
- Periodic GC acquires `try_acquire_index_lock` non-blockingly — a concurrent `cqs index` skips a tick rather than wedging the loop.
- Timer always advances even on lock-acquisition failure (no hammering).
- 4 new unit tests covering both prune flavors.
- 3 new env vars documented in README.

## Test plan

- [x] `cargo test --release --features gpu-index --test embedder_dim_mismatch_test` — **12/12 pass** (12 new).
- [x] `cargo test --release --features gpu-index --lib -- store::chunks::staleness::tests::test_prune` — **9/9 pass** (4 new + 5 existing).
- [x] `cargo test --release --features gpu-index --bin cqs cli::watch::tests` — **27/27 pass** (1 new + 26 existing).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --release --features gpu-index -- -D warnings` clean.

Closes #6 (embedder hygiene)
Closes #7 (proactive GC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
