### PR TITLE
docs(plans): Phase 3 cross-encoder + sequenced ColBERT-XM (post-Phase 2)

### DIFF
--- a/docs/plans/2026-04-17-colbert-jina-v2.md
+++ b/docs/plans/2026-04-17-colbert-jina-v2.md
@@ -1,0 +1,120 @@
+# ColBERT Integration — Jina-ColBERT-v2 as 2-stage Reranker
+
+**Created:** 2026-04-17  
+**Sequencing:** runs after Phase 3 reranker training lands or fails (`docs/plans/2026-04-17-phase3-reranker-training.md`).  
+**Why now:** literature survey (2026-04-17) found WARP engine (41x faster than ColBERT reference) and Jina-ColBERT-v2 (multilingual, 50% smaller). Original "1-3 month architectural lift" estimate in the strategy doc is wrong — off-the-shelf 2-stage path is ~3-5 days.
+
+## Goal
+
+Add ColBERT-style late-interaction reranking as a `Reranker` trait implementation alongside the cross-encoder. Run it as the **last** stage of retrieval (after dense+SPLADE+RRF + cross-encoder), starting with no per-token index — pure inference cost only. A/B against the Phase 3 cross-encoder result.
+
+Decision gate: ColBERT 2-stage rerank wins by ≥2pp R@5 over the cross-encoder. If yes, then plan the per-token index build (separate, larger work). If no, parked.
+
+## Why 2-stage, not full late-interaction index
+
+The full ColBERT setup requires per-token indexes (~50× the storage of dense embeddings). Off-the-shelf inference only needs:
+- Query encoding (one forward pass, ~30ms on RTX 4000)
+- Per-candidate document encoding (top-50 candidates × ~30ms each = ~1.5s overhead)
+
+The 1.5s is acceptable for a final-stage reranker on a small candidate pool. If results are good, then the per-token index becomes a latency optimization, not a correctness requirement.
+
+This staging matches the "Reranker V2 first, ColBERT as confirmation" sequencing.
+
+## Off-the-shelf path
+
+- **Model:** `jinaai/jina-colbert-v2` from HuggingFace
+  - Multilingual (89 languages), but the 9 we care about (rust, python, js, ts, go, java, cpp, ruby, php) are all in-distribution for Jina's training mix
+  - 137M params, fp16 fits in <12GB → RTX 4000 (8GB) at fp16/int8, or A6000 if convenient
+  - Released under Apache-2.0
+- **Engine:** PyLate or sentence-transformers integration. Skip WARP for the first pass — it's a latency optimization that only matters once we have a per-token index.
+- **Inference shape:** `MaxSim(query_tokens, doc_tokens)` for each (query, candidate) pair. Sum over query token max-similarities to a doc token. The "late interaction" is that token-level matching happens at scoring time, not at index time.
+
+## Hardware decision
+
+- Phase 3 cross-encoder runs on A6000 (needs ~6GB)
+- Jina-ColBERT-v2 inference fits on RTX 4000 (8GB) at fp16
+- Could run BOTH simultaneously if Phase 3 sequential A/B is going on
+
+Practical: run Phase 3 first (A6000 free of vLLM after labeling), land it, THEN bring up ColBERT on RTX 4000 for the confirmation A/B.
+
+## Wiring change scope
+
+Bigger than Phase 3, because we need a `Reranker` trait abstraction:
+
+```rust
+// src/reranker/mod.rs (new trait)
+pub trait Reranker: Send + Sync {
+    fn rerank(&self, query: &str, candidates: &[Candidate], top_k: usize)
+        -> Result<Vec<RerankedResult>, RerankerError>;
+    fn name(&self) -> &str;
+    fn model_id(&self) -> &str;
+}
+
+// src/reranker/cross_encoder.rs — existing implementation refactored to trait
+pub struct CrossEncoderReranker { ... }
+impl Reranker for CrossEncoderReranker { ... }
+
+// src/reranker/colbert.rs — new
+pub struct ColbertReranker { /* ONNX session for jina-colbert-v2 */ }
+impl Reranker for ColbertReranker { ... }
+```
+
+CLI flag changes:
+- `--rerank` (existing) → defaults to cross-encoder
+- `--rerank colbert` → uses ColBERT
+- `--rerank both` → cross-encoder THEN ColBERT (ensemble — cross-encoder pool of top-50 → ColBERT top-K)
+- `CQS_RERANKER_KIND` env var: `cross_encoder` | `colbert` | `cross_then_colbert`
+
+## ONNX export
+
+Jina-ColBERT-v2 doesn't ship an ONNX file by default. Two options:
+
+1. **Use sentence-transformers Python inference via subprocess.** Slower per-query (Python startup), simpler to wire. Acceptable for proof-of-value.
+2. **Export to ONNX with `optimum`** (`optimum-cli export onnx --model jinaai/jina-colbert-v2 --task feature-extraction colbert.onnx`). Fast-path for production. Requires manual MaxSim implementation in Rust (not trivial — token-level outputs need to be summed over query maxes).
+
+Decision: start with option 1 for the A/B (cheaper to abandon if R@5 doesn't move). Move to option 2 only if we ship.
+
+## Eval protocol
+
+Same as Phase 3:
+
+```bash
+# A/B against Phase 3 baseline
+export CQS_RERANKER_KIND=cross_then_colbert
+cqs eval --baseline evals/baseline-post-reranker-v2.json --tolerance 1.0
+```
+
+Decision gate:
+1. **R@5 +2pp over cross-encoder alone** → ship 2-stage. Plan per-token index work as a latency follow-up.
+2. **R@5 within ±1pp** → don't ship. Document negative result.
+3. **R@5 worse** → ColBERT is fighting cross-encoder; the multilingual training mix may not match our code distribution well enough. Revisit only after exhausting cross-encoder retraining.
+
+## Wall-time estimate
+
+- ONNX/sentence-transformers inference setup: ~0.5 day
+- `Reranker` trait refactor: ~0.5 day
+- ColBERT impl wiring: ~0.5 day
+- A/B eval + report: ~0.5 day
+- Total: **~2 days** if option 1 (Python subprocess); **~3-5 days** if ONNX export + Rust MaxSim
+
+## Files this plan creates
+
+- `src/reranker/mod.rs` — Reranker trait (refactor existing)
+- `src/reranker/cross_encoder.rs` — existing impl refactored
+- `src/reranker/colbert.rs` — new
+- `evals/colbert_inference_smoke.py` — sentence-transformers inference smoke test
+- `models/colbert-jina-v2/` — downloaded model artifacts (gitignored — track via cqs model swap)
+- `docs/colbert-rerank-results.md` — A/B writeup
+
+## Stopping conditions
+
+- ColBERT inference >2s/query at top-50 candidates → drop top-K to 20 and re-A/B; if still slow, drop the plan
+- Per-language R@5 regresses on rust/cpp (lower-resource in Jina's mix) → restrict ColBERT to high-resource languages (python/java/js)
+- Cross-encoder + ColBERT ensemble is no better than cross-encoder alone → ship cross-encoder, mark ColBERT as parked-with-evidence
+
+## What's NOT in scope here
+
+- Per-token index (only if 2-stage proves out)
+- WARP engine integration (latency optimization, post-shipping)
+- Training a custom ColBERT on our 200k corpus (much bigger work; only if off-the-shelf wins enough to justify)
+- Replacing dense+SPLADE+RRF entirely with ColBERT (that's the per-token index path)

--- a/docs/plans/2026-04-17-colbert-xm.md
+++ b/docs/plans/2026-04-17-colbert-xm.md
@@ -1,4 +1,12 @@
-# ColBERT Integration — Jina-ColBERT-v2 as 2-stage Reranker
+# ColBERT Integration — ColBERT-XM as 2-stage Reranker
+
+> **License correction (2026-04-17):** the original draft of this plan
+> targeted `jinaai/jina-colbert-v2`. That model is CC-BY-NC-4.0 — non-
+> commercial only — which makes it unsuitable as a default for cqs (an
+> open-source project users can deploy commercially). Switched to
+> `antoinelouis/colbert-xm` (MIT, 81-language XMOD-based late
+> interaction). Jina is still on the table as an internal-research-only
+> ceiling reference, never as a shipped default.
 
 **Created:** 2026-04-17  
 **Sequencing:** runs after Phase 3 reranker training lands or fails (`docs/plans/2026-04-17-phase3-reranker-training.md`).  
@@ -22,20 +30,39 @@ This staging matches the "Reranker V2 first, ColBERT as confirmation" sequencing
 
 ## Off-the-shelf path
 
-- **Model:** `jinaai/jina-colbert-v2` from HuggingFace
-  - Multilingual (89 languages), but the 9 we care about (rust, python, js, ts, go, java, cpp, ruby, php) are all in-distribution for Jina's training mix
-  - 137M params, fp16 fits in <12GB → RTX 4000 (8GB) at fp16/int8, or A6000 if convenient
-  - Released under Apache-2.0
-- **Engine:** PyLate or sentence-transformers integration. Skip WARP for the first pass — it's a latency optimization that only matters once we have a per-token index.
-- **Inference shape:** `MaxSim(query_tokens, doc_tokens)` for each (query, candidate) pair. Sum over query token max-similarities to a doc token. The "late interaction" is that token-level matching happens at scoring time, not at index time.
+- **Model:** `antoinelouis/colbert-xm` from HuggingFace
+  - **MIT licensed** — safe to ship as cqs default; users can deploy
+    commercially without license friction
+  - Backbone: XMOD (cross-lingual modular). Fine-tuned on English
+    MS-MARCO; XMOD adapters give zero-shot transfer to 81 languages
+  - 14 languages explicitly evaluated on mMARCO; programming-language
+    natural language headers ("function", "returns", "param", etc.)
+    are well-covered. Code identifier handling untested — that's our
+    A/B job
+  - ~270M params (XLM-R-base + XMOD adapters); fp16 fits in <8GB
+    → RTX 4000 viable
+- **Alternate (research-only):** `jinaai/jina-colbert-v2` (CC-BY-NC-4.0)
+  - 137M params, 89 languages, generally stronger multilingual numbers
+    than ColBERT-XM in the paper
+  - Use ONLY as a ceiling reference in internal eval; never ship as
+    default. If it's a much higher ceiling than ColBERT-XM, that's
+    motivation to either license-clear or train our own permissive
+    multilingual ColBERT
+- **Engine:** PyLate or sentence-transformers integration. Skip WARP for
+  the first pass — it's a latency optimization that only matters once we
+  have a per-token index.
+- **Inference shape:** `MaxSim(query_tokens, doc_tokens)` for each
+  (query, candidate) pair. Sum over query token max-similarities to a
+  doc token. The "late interaction" is that token-level matching happens
+  at scoring time, not at index time.
 
 ## Hardware decision
 
 - Phase 3 cross-encoder runs on A6000 (needs ~6GB)
-- Jina-ColBERT-v2 inference fits on RTX 4000 (8GB) at fp16
+- ColBERT-XM inference fits on RTX 4000 (8GB) at fp16
 - Could run BOTH simultaneously if Phase 3 sequential A/B is going on
 
-Practical: run Phase 3 first (A6000 free of vLLM after labeling), land it, THEN bring up ColBERT on RTX 4000 for the confirmation A/B.
+Practical: run Phase 3 first (A6000 free of vLLM after labeling), land it, THEN bring up ColBERT-XM on RTX 4000 for the confirmation A/B.
 
 ## Wiring change scope
 
@@ -55,7 +82,7 @@ pub struct CrossEncoderReranker { ... }
 impl Reranker for CrossEncoderReranker { ... }
 
 // src/reranker/colbert.rs — new
-pub struct ColbertReranker { /* ONNX session for jina-colbert-v2 */ }
+pub struct ColbertReranker { /* ONNX session for colbert-xm */ }
 impl Reranker for ColbertReranker { ... }
 ```
 
@@ -67,10 +94,10 @@ CLI flag changes:
 
 ## ONNX export
 
-Jina-ColBERT-v2 doesn't ship an ONNX file by default. Two options:
+ColBERT-XM doesn't ship an ONNX file by default. Two options:
 
-1. **Use sentence-transformers Python inference via subprocess.** Slower per-query (Python startup), simpler to wire. Acceptable for proof-of-value.
-2. **Export to ONNX with `optimum`** (`optimum-cli export onnx --model jinaai/jina-colbert-v2 --task feature-extraction colbert.onnx`). Fast-path for production. Requires manual MaxSim implementation in Rust (not trivial — token-level outputs need to be summed over query maxes).
+1. **Use sentence-transformers / PyLate Python inference via subprocess.** Slower per-query (Python startup), simpler to wire. Acceptable for proof-of-value.
+2. **Export to ONNX with `optimum`** (`optimum-cli export onnx --model antoinelouis/colbert-xm --task feature-extraction colbert.onnx`). Fast-path for production. Requires manual MaxSim implementation in Rust (not trivial — token-level outputs need to be summed over query maxes). XMOD adapters add a wrinkle: language-specific adapter routing happens in the forward pass; check that ONNX export captures it correctly before assuming feature parity with the PyTorch reference.
 
 Decision: start with option 1 for the A/B (cheaper to abandon if R@5 doesn't move). Move to option 2 only if we ship.
 
@@ -103,13 +130,13 @@ Decision gate:
 - `src/reranker/cross_encoder.rs` — existing impl refactored
 - `src/reranker/colbert.rs` — new
 - `evals/colbert_inference_smoke.py` — sentence-transformers inference smoke test
-- `models/colbert-jina-v2/` — downloaded model artifacts (gitignored — track via cqs model swap)
+- `models/colbert-xm/` — downloaded model artifacts (gitignored — track via cqs model swap)
 - `docs/colbert-rerank-results.md` — A/B writeup
 
 ## Stopping conditions
 
 - ColBERT inference >2s/query at top-50 candidates → drop top-K to 20 and re-A/B; if still slow, drop the plan
-- Per-language R@5 regresses on rust/cpp (lower-resource in Jina's mix) → restrict ColBERT to high-resource languages (python/java/js)
+- Per-language R@5 regresses on rust/cpp (lower-resource in XMOD's adapter coverage) → restrict ColBERT to high-resource languages (python/java/js)
 - Cross-encoder + ColBERT ensemble is no better than cross-encoder alone → ship cross-encoder, mark ColBERT as parked-with-evidence
 
 ## What's NOT in scope here

--- a/docs/plans/2026-04-17-phase3-reranker-training.md
+++ b/docs/plans/2026-04-17-phase3-reranker-training.md
@@ -1,7 +1,7 @@
 # Phase 3 — Reranker V2 Cross-Encoder Training
 
 **Created:** 2026-04-17  
-**Sequencing:** runs after Phase 2 labeling completes (~16:20 CDT 2026-04-17). ColBERT path (`docs/plans/2026-04-17-colbert-jina-v2.md`) runs after this lands or fails.  
+**Sequencing:** runs after Phase 2 labeling completes (~16:20 CDT 2026-04-17). ColBERT path (`docs/plans/2026-04-17-colbert-xm.md`) runs after this lands or fails.  
 **Owner:** human-driven; literature-informed defaults below.
 
 ## Goal
@@ -137,7 +137,7 @@ Existing reranker integration:
 
 ## What's NOT in scope here
 
-- ColBERT integration (separate plan: `docs/plans/2026-04-17-colbert-jina-v2.md`)
+- ColBERT integration (separate plan: `docs/plans/2026-04-17-colbert-xm.md`)
 - Multi-reranker ensemble (deferred until both single-model paths are scored)
 - Per-category reranker gating (decision gate #3 above considers it conditionally)
 - Pairwise loss training (literature consensus is pointwise wins; not running pairwise unless BiXSE result fails to replicate)

--- a/docs/plans/2026-04-17-phase3-reranker-training.md
+++ b/docs/plans/2026-04-17-phase3-reranker-training.md
@@ -1,0 +1,143 @@
+# Phase 3 — Reranker V2 Cross-Encoder Training
+
+**Created:** 2026-04-17  
+**Sequencing:** runs after Phase 2 labeling completes (~16:20 CDT 2026-04-17). ColBERT path (`docs/plans/2026-04-17-colbert-jina-v2.md`) runs after this lands or fails.  
+**Owner:** human-driven; literature-informed defaults below.
+
+## Goal
+
+Train a code-aware cross-encoder reranker on the 200k Gemma-labeled corpus from Phase 2. Ship as a `--rerank` model swap; A/B against the v1.27.0 baseline on `v3_test.v2.json`. Decision gate: ≥3pp R@5 lift OR drop.
+
+## Prereq sanity check (before training starts)
+
+```bash
+# Phase 2 deliverables expected at the worktree
+WORKTREE=/mnt/c/Projects/cqs/.claude/worktrees/agent-a499dc70
+ls -la $WORKTREE/evals/reranker_v2_train_200k.jsonl              # pairwise A/B/TIE
+ls -la $WORKTREE/evals/reranker_v2_train_200k_pointwise.jsonl    # graded relevance
+ls -la $WORKTREE/evals/queries/reranker_v2_corpus_quality.json   # final quality report
+cat /tmp/post_labeling_final_report.txt                          # chain-monitor summary
+```
+
+Validation gates before training:
+- Pointwise file has ≥190k rows (allow ~5% to drop in pairwise→pointwise conversion)
+- Per-language balance: each of {rust, python, js, ts, go, java, cpp, ruby, php} ≥15k samples
+- Overall corpus agreement ≥95% (Phase 1 calibration target was 85% so this is comfortable)
+- Label distribution within {A: 35-50%, B: 35-50%, TIE: 5-15%}
+
+If any gate fails: investigate before training. Don't auto-proceed.
+
+## Loss + data format decision
+
+**Use BiXSE pointwise (BCE on graded relevance), not pairwise loss.** Literature signal:
+- BiXSE (2508.06781, Aug 2025): pointwise BCE with LLM-graded relevance outperforms pairwise/contrastive on dense retrieval
+- Instruction Distillation (2311.01555): distilling pairwise → pointwise gives 10-100x inference efficiency without quality loss
+
+Phase 2 already produced the pointwise file via the chain monitor's `pairwise_to_pointwise.py` step. Use it directly.
+
+Pointwise format expected:
+```jsonl
+{"query": "...", "passage": "...", "label": 0.0|0.5|1.0}
+```
+(0.0 = labeled losing chunk, 0.5 = TIE chunk, 1.0 = labeled winning chunk; verify by reading first 5 lines)
+
+## Base model decision tree
+
+Strategy doc requires "code-pretrained base, NOT MS-MARCO." Three candidates ranked:
+
+1. **`microsoft/unixcoder-base`** (125M) — code-pretrained, well-supported, fast on A6000. Cheapest first pass; default unless evidence pushes elsewhere.
+2. **`Salesforce/codet5p-110m-embedding`** (110M) — code-pretrained-from-scratch encoder, contrastive-trained. Better dense-retrieval prior than UniXcoder.
+3. **`DeepSoftwareAnalytics/CoCoSoDa`** (CoCoSoDa fine-tuned over CodeBERT, 125M) — strongest CSN baseline (+10.5% vs GraphCodeBERT) but bi-encoder pretrain; cross-encoder fine-tune may not transfer all the gains.
+
+Approach: ship UniXcoder run first. If it underperforms baseline OR is +/-1pp, run CodeT5+ as the second config. Don't sweep base models in parallel — sequenced runs use the A6000 cleaner.
+
+## Training hyperparameters (UniXcoder default)
+
+```python
+# evals/train_reranker_v2.py — to be written
+model = "microsoft/unixcoder-base"
+loss = "BCE"  # graded labels in [0.0, 1.0]
+max_seq_length = 512
+batch_size = 32           # A6000 has headroom; raise if VRAM allows
+learning_rate = 2e-5      # standard cross-encoder fine-tune LR
+warmup_ratio = 0.1
+epochs = 3
+weight_decay = 0.01
+gradient_accumulation = 1
+fp16 = True               # ~2x speedup, A6000 supports
+seed = 42                 # reproducible
+```
+
+**One-shot, no sweep.** If first run misses the 3pp gate, then sweep LR ∈ {1e-5, 5e-5} and epochs ∈ {2, 4}.
+
+## Wall-time estimate (A6000)
+
+- 200k pointwise rows × 3 epochs / batch 32 = ~18.75k steps
+- Step time UniXcoder cross-encoder fp16 seq 512: ~50-80ms
+- Total: ~25 minutes per epoch × 3 = **~1h20m** wall time
+- Plus eval pass: ~10min
+- Total: **~1.5h end-to-end** for the default config
+
+CodeT5+ second pass adds another ~1.5h if needed. Single LR/epoch sweep adds ~6h.
+
+## GPU contention with vLLM
+
+vLLM Gemma 4 31B AWQ uses ~48GB on A6000 during Phase 2 labeling. **Cannot train while vLLM is up.** Bring vLLM down BEFORE training:
+
+```bash
+# Find vLLM PID and stop it cleanly
+pkill -f 'vllm serve cyankiwi/gemma'
+# Wait for shutdown; verify
+nvidia-smi --query-gpu=memory.used --format=csv,noheader
+```
+
+After Phase 3 training: restart vLLM if any further labeling work is queued (currently none).
+
+## Eval protocol
+
+Use the new `cqs eval --baseline X --tolerance N` from PR #1030 against the regenerated `v3_test.v2.json` fixture (Tier 1.1).
+
+```bash
+# Save current baseline
+cqs eval --json > evals/baseline-pre-reranker-v2.json
+
+# After training, swap reranker model
+export CQS_RERANKER_MODEL=/path/to/reranker-v2-unixcoder
+cqs eval --baseline evals/baseline-pre-reranker-v2.json --tolerance 1.0
+# Exit 0 = no per-category regression past 1.0pp; exit 1 = regression
+```
+
+Decision gate (apply in order):
+1. **R@5 +3pp or more** → ship. Update `CQS_RERANKER_MODEL` default in `cqs model show`. Bump version.
+2. **R@5 within ±1pp** → run CodeT5+ second config. If still flat, mark Phase 3 done with no swap.
+3. **R@5 −1pp or worse** → triage by category. If improvement on `unexplained` queries (the audit's biggest reranker target) but regression elsewhere, consider category-gated reranker. Otherwise mark training data quality issue and revisit.
+
+## Wiring change scope
+
+Existing reranker integration:
+- `src/reranker/` (cross-encoder loader, ms-marco-MiniLM by default)
+- `--rerank` CLI flag and `args.rerank` in batch handler
+- `CQS_RERANKER_MODEL` env override (already supports local paths per PR ec0e62 from main session)
+
+**No new wiring needed.** Just point `CQS_RERANKER_MODEL` at the trained directory. The existing `populate token_type_ids` fix from main session means UniXcoder/CodeT5+ tokenizers work without further code change.
+
+## Files this plan creates
+
+- `evals/train_reranker_v2.py` — training script (sentence-transformers `CrossEncoder` + BCEWithLogitsLoss on graded labels)
+- `evals/reranker_v2_train_run.json` — per-run config + metrics (one per training attempt; numbered)
+- `models/reranker-v2-unixcoder/` — trained model directory (ONNX export for production)
+- `evals/baseline-pre-reranker-v2.json` — frozen baseline for the regression gate
+- `docs/reranker-v2-results.md` — final A/B writeup post-eval
+
+## Stopping conditions
+
+- Training perplexity NaN at step >100 → halve LR, restart
+- Eval R@5 regresses ≥3pp on default config → don't auto-proceed to CodeT5+; investigate corpus quality first (per-language label distribution, sample 20 random pairs and human-spot-check)
+- Phase 2 chain monitor produced an empty pointwise file → bug in `pairwise_to_pointwise.py`; fix that before training
+
+## What's NOT in scope here
+
+- ColBERT integration (separate plan: `docs/plans/2026-04-17-colbert-jina-v2.md`)
+- Multi-reranker ensemble (deferred until both single-model paths are scored)
+- Per-category reranker gating (decision gate #3 above considers it conditionally)
+- Pairwise loss training (literature consensus is pointwise wins; not running pairwise unless BiXSE result fails to replicate)


### PR DESCRIPTION
## Summary

Two execution plan documents for the work that runs after Phase 2 labeling completes (~16:20 CDT today):

1. **Phase 3 cross-encoder training** (`docs/plans/2026-04-17-phase3-reranker-training.md`) — UniXcoder + BiXSE pointwise BCE on graded labels. ~1.5h on A6000. Decision gate: ≥3pp R@5 lift on `v3_test.v2`.
2. **ColBERT 2-stage rerank** (`docs/plans/2026-04-17-colbert-xm.md`) — sequenced after Phase 3. `antoinelouis/colbert-xm` (MIT, 81 languages). Off-the-shelf path; no per-token index initially.

## Why this and why now

- HF papers semantic-search survey (2026-04-17) found WARP (41x faster ColBERT engine) and multiple permissive ColBERT-style models — original "1-3 month architectural lift" estimate in `docs/r5-strategy-2026-04-17.md` was wrong; off-the-shelf 2-stage path is ~3-5 days.
- Literature consensus is **pointwise BCE on graded labels beats pairwise contrastive** for cross-encoder reranker training (BiXSE 2508.06781 + Instruction Distillation 2311.01555).

## License audit catch

First draft of the ColBERT plan targeted `jinaai/jina-colbert-v2`. License check found it is **CC-BY-NC-4.0** (non-commercial only), not Apache-2.0. Switched to `antoinelouis/colbert-xm` (MIT). Jina kept as internal-research-only ceiling reference.

Permissive licenses confirmed for the Phase 3 base-model candidates:
- `microsoft/unixcoder-base` — Apache-2.0
- `Salesforce/codet5p-110m-embedding` — BSD-3-Clause
- `DeepSoftwareAnalytics/CoCoSoDa` — no license shown; would need author clarification before any use

## Test plan

- [x] Plan docs structurally complete (entry points, decision gates, stopping conditions, file lists, scope cuts)
- [ ] Phase 2 labeling completes and chain monitor produces final report
- [ ] Phase 3 plan executed against the resulting pointwise file
- [ ] ColBERT plan executed against the Phase 3 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
