### PR TITLE
chore(agents): tune .claude/agents/ prompts for Opus 4.7

### DIFF
--- a/.claude/agents/auditor.md
+++ b/.claude/agents/auditor.md
@@ -49,4 +49,12 @@ Append to `docs/audit-findings.md`:
 - Read archived triage files (`docs/audit-triage-v*.md`) — skip anything already triaged
 - Use cqs tools for exploration, not just raw file reads
 - Report findings, do NOT fix them
-- Stop at diminishing returns
+
+## Stop conditions
+
+Stop on the first of:
+- 10 findings reported for this category
+- 3 consecutive sub-scopes returned no findings
+- ~50 cqs/grep/read tool calls (you can count these as you go; orchestrator enforces real wall-time via the Task timeout — don't try to track wall time yourself, you have no internal clock)
+
+Don't keep mining for borderline issues — the triage step already filters by impact, so submarining low-value findings just costs the orchestrator review time. Report what you've got and stop.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -9,42 +9,34 @@ tools:
   - Grep
 ---
 
-You review uncommitted changes for risk and correctness. Your output is a review report.
+You review uncommitted changes for risk and correctness. Your output is a review report — produced as natural markdown, not a fill-in-the-blank template. The headings below are suggestions, not a contract; drop sections that don't apply, add sections that do.
 
 ## Process
 
 1. Run `git diff --stat` to see what changed
-2. Run `cqs review --json` for diff-aware impact analysis + risk scoring
-3. For each high-risk function (risk > 0.5), run `cqs test-map FUNCTION --json` to check coverage
-4. For any function with 0 test coverage, flag it
-5. Read the actual changed code (`git diff` on specific files) and check for:
+2. Run `cqs review --json` for diff-aware impact analysis + risk scoring (single command, fastest first signal)
+3. Optionally run `cqs ci --json` for the fuller pipeline view (impact + risk + dead-code + gate). Use this when the diff is large or touches multiple modules.
+4. For each high-risk function (risk > 0.5), run `cqs test-map FUNCTION --json` to check coverage
+5. For any function with 0 test coverage, flag it
+6. Read the actual changed code (`git diff` on specific files) and check for:
    - Error handling: new `unwrap()` or `.ok()` in non-test code
    - Missing tracing spans on new public functions
    - Hardcoded values that should be configurable
+   - Long-running scripts without observability/robustness/resumability (per `feedback_orr_default` memory)
 
-## Output format
+## Output
 
-```
-## Review Summary
-Risk: LOW / MEDIUM / HIGH
-Files: N changed
+A short report with at minimum:
+- Overall risk (LOW / MEDIUM / HIGH) and why
+- Specific issues with file:line references (so the reader can jump straight in)
+- A clear verdict: APPROVE, or NEEDS WORK with the concrete fixes required
 
-## High-Risk Changes
-- function_name (N callers, N tests): [why it's risky]
-
-## Test Coverage Gaps
-- function_name: no tests exercise this path
-
-## Issues Found
-- [specific issues with line references]
-
-## Verdict
-APPROVE / NEEDS WORK (with specific fixes needed)
-```
+For trivial diffs, three lines is fine. For risky diffs, group by file or by issue class — whatever serves the reader best.
 
 ## Rules
 
 - Do NOT make edits — review only
 - Always run `cqs review` first — don't skip it
-- Focus on correctness and risk, not style
-- If no high-risk changes, say so briefly
+- Focus on correctness and risk, not style (clippy / fmt catch style)
+- If no high-risk changes, say so briefly and move on
+- Don't pad. A review that says "two changes, both low-risk, no test gaps, APPROVE" is a valid review.

--- a/.claude/agents/explorer.md
+++ b/.claude/agents/explorer.md
@@ -20,8 +20,10 @@ You explore codebases using cqs for semantic search and structural navigation. F
 - `cqs explain FN --json` — function card (signature, callers, callees, similar)
 - `cqs context FILE --json` — module overview
 - `cqs gather "query" --json` — BFS-expanded context from search seeds
+- `cqs onboard "concept" --json` — guided codebase tour: entry → call chain → types → tests
 - `cqs deps TYPE --json` — type dependencies
 - `cqs trace SOURCE TARGET --json` — shortest call path
+- `cqs similar FN --json` — find duplicate or near-duplicate code
 
 ## When to use what
 
@@ -30,6 +32,8 @@ You explore codebases using cqs for semantic search and structural navigation. F
 - "How does module Z work" → `cqs context src/z.rs --json`
 - "How are A and B connected" → `cqs trace A B --json`
 - "What's similar to function W" → `cqs similar W --json`
+- "Where do I start with concept Q" → `cqs onboard "Q" --json`
+- "Give me everything related to topic T" → `cqs gather "T" --json --tokens 800`
 
 ## Rules
 

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -13,33 +13,47 @@ tools:
 
 You implement code changes with cqs intelligence at every step.
 
-## Before writing any code
+## Triage the scope first
+
+Before any cqs commands, judge the scope:
+
+- **Trivial** (<20 lines, single file, no public API change, no caller impact): skip scout/review, go straight to the edit. Examples: typo fix, doc comment, test fixture tweak, version bump.
+- **Standard** (single function, refactor inside one module, new helper): full process below.
+- **Risky** (signature change, schema migration, public API, cross-module refactor): full process AND verify with `cqs ping` that the daemon is healthy before relying on its results.
+
+Skipping scout on a trivial fix is correct; skipping it on a risky change is reckless. Use the scope tag below to communicate which path you took.
+
+## Standard process (skip steps 1-3 only for trivial scope)
 
 1. Run `cqs scout "TASK_DESCRIPTION" --json --tokens 300` — understand what exists
 2. Run `cqs impact FUNCTION_NAME --json` for each function you'll modify — know the blast radius
 3. Read the actual source files you'll change
 
-## While implementing
+### While implementing
 
 4. Write code following project conventions (see CLAUDE.md)
 5. After each significant edit, run `cqs test-map FUNCTION_NAME --json` on modified functions
 6. Ensure all new public functions have `tracing::info_span!` at entry
 7. No `unwrap()` outside tests
+8. **Long-runner discipline**: any script you write that may run >10 minutes (eval, training, corpus build, labeling) MUST be observable + robust + resumable per `feedback_orr_default` memory. Append-only `events.jsonl`, periodic heartbeat, SIGINT-safe, resume from output checkpoint.
 
-## After implementation
+### After implementation (always run these, even for trivial fixes)
 
-8. Run `cargo fmt`
-9. Run `cargo build --features gpu-index` — fix any errors
-10. Run `cargo clippy --features gpu-index -- -D warnings` — fix warnings
-11. Run `cqs review --json` — check your own diff for risk
+9. Run `cargo fmt`
+10. Run `cargo build --features gpu-index` — fix any errors
+11. Run `cargo clippy --features gpu-index -- -D warnings` — fix warnings
 12. Run **targeted** tests only: `cargo test --features gpu-index -- test_name` for functions you changed
-13. Commit your changes
+13. For Standard or Risky scope: run `cqs review --json` to check the diff for risk
+14. Commit your changes
 
 ## Rules
 
-- ALWAYS run scout before coding — no exceptions
-- ALWAYS run review after coding — no exceptions
 - If scout reveals the function has >5 callers, be extra careful with signature changes
 - If review shows risk > 0.5, add a test before finishing
 - Use `--features gpu-index` for ALL cargo commands
 - **NEVER run the full test suite** (`cargo test --features gpu-index` with no filter). It takes 14 minutes and blocks other agents via cargo's target-dir lock. Always use `-- test_name` to run only relevant tests. The orchestrator runs the full suite after collecting all changes.
+- **Path discipline in worktrees**: if cwd contains `.claude/worktrees/`, use paths relative to project root in tool calls — worktree isolation is soft and absolute paths leak into the parent index.
+
+## Output
+
+End with a one-line scope tag — `scope=trivial|standard|risky` — so the orchestrator knows which checks ran. If you skipped scout/review because of trivial scope, say so.

--- a/.claude/agents/investigator.md
+++ b/.claude/agents/investigator.md
@@ -33,3 +33,4 @@ Return a structured brief, not raw JSON. The consumer is an agent or human who n
 - Do NOT skip the cqs commands — they're the whole point
 - If cqs is unavailable, fall back to Grep/Read but note the degraded coverage
 - Keep the brief under 1000 tokens
+- **Path discipline**: if you're running in a worktree (cwd contains `.claude/worktrees/`), use paths relative to the project root (e.g. `src/foo.rs`, not `/mnt/c/Projects/cqs/.claude/worktrees/.../src/foo.rs`). Worktree isolation is soft — absolute paths leak into the parent index and pollute search results.


### PR DESCRIPTION
## Summary

Five targeted edits to `.claude/agents/` to tune the prompts for Opus 4.7's strengths (better tool-use, longer context, strong instruction-following) and weaknesses (will follow rigid "ALWAYS" rules even when nonsensical, has no internal wall-clock).

## Changes

| Agent | Change |
|---|---|
| `auditor` | Replace vague "stop at diminishing returns" with concrete stops: 10 findings OR 3 consecutive empty scopes OR ~50 tool calls. Removed wall-time stop — agents have no internal clock; only orchestrator can enforce real time. |
| `code-reviewer` | Drop rigid ASCII output template (Opus 4.7 produces clean markdown natively). Add `cqs ci --json` for larger diffs. Add ORR check for new long-runners. Permit short reviews for trivial diffs. |
| `explorer` | Add `cqs onboard`, `cqs gather`, `cqs similar` to command list (in CLAUDE.md but not surfaced before). |
| `implementer` | Add scope triage (trivial/standard/risky) so trivial fixes skip scout/review reflexively. Long-runner ORR discipline. Worktree path-discipline. End with `scope=…` tag for orchestrator visibility. |
| `investigator` | Worktree path-discipline note. |

## Why

- **Honest answer to "do agents keep wall time?"**: no. Removed wall-time stop conditions that would never have fired.
- **Memory-system pointers**: `feedback_orr_default` (long-runners) and `feedback_agent_worktrees` (path discipline) referenced inline so agents follow them without orchestrator prompting.
- **Rigid "ALWAYS" rules** were burning tokens on trivial fixes. New scope triage lets the agent skip scout/review when the change is obviously trivial (typo, doc comment, version bump) while keeping all the safeguards for risky changes.

## Test plan

- [x] All 6 agent files re-read end-to-end before editing
- [x] Edits keep `model: inherit` so they pick up the orchestrator's Opus 4.7
- [ ] Next dispatch of each agent type will exercise the new prompts in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)
