### PR TITLE
feat(evals): ColBERT 2-stage + RRF fusion eval tool

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,96 +2,101 @@
 
 ## Right Now
 
-**Reranker V2 Phase 1 done — verdict GEMMA_ONLY** (Task #18, 2026-04-17). 1000 sampled triples from `~/training-data/augmented_200k_keydac.jsonl` labeled by both Gemma 4 31B (vLLM local) and Claude Haiku. Result: **98.3% inter-rater agreement, kappa 0.9663**, 0 parse errors, ground-truth agreement 98.79% (Gemma) / 98.30% (Claude). Clears 85% threshold by 13.3pp → use Gemma alone for the 200k pass. **PR #1031 open, in CI** (`feat/reranker-v2-phase1-calibration`).
+**Cheap R@5 lever sweep complete (2026-04-18) — full sweep + post-mortems are recorded.** Every Tier 1/2 lever from `docs/r5-strategy-2026-04-17.md` was tested this session arc; net is no robust positive R@5 lift. Current architecture's R@5 ceiling on v3.v2 sits ~63-65%; pushing past requires a bigger investment (re-trained Reranker V2, chunker fix, HyDE re-validation, full ColBERT integration, or embedder swap).
 
-**Reranker V2 Phase 2 done** (Task #19, 2026-04-17, 16:42 CDT, ~12h45m wall vs my 32h prediction — 2.5x over). 200k pairs labeled, **95.31% overall agreement**, all 9 languages 21k-22k triples, balanced A/B (~50/50 per lang). Per-lang agreement ranges 90.9% (ruby) to 99.4% (python). Pointwise file: 382,718 rows (TIE filtered, labels binary 0.0/1.0). Deliverables backed up to `~/training-data/reranker_v2_corpus/`.
+**Branch:** `feat/colbert-fusion-eval-tool` (PR #1037 open).
 
-**Reranker V2 Phase 3 training in flight** (Task #20, started 16:45 CDT). UniXcoder-base + BCEWithLogitsLoss + 200k pointwise + 3 epochs + bs 32 + lr 2e-5 on A6000 (vLLM stopped). Output: `~/training-data/reranker-v2-unixcoder/`. Predicted ~1.5h wall (caveat: predictions unanchored; will report observed elapsed). Loader bug caught at first launch — `passage` vs `content` field name; fixed in PR #1035.
+### Lever-by-lever results
 
-**R@5 audit + strategy + gc fix + MMR experiment landed on the same branch** (Tasks #3, #4, #21, #22). Audit shows permissive R@5 = **64.2%** (matches documented v1.27.0 baseline exactly after the gc cleanup). Strict R@5 = 51.4% — the 13pp gap is v3-fixture drift, not retrieval drift. Failure modes: `near_dup_crowding` 60%, `wrong_abstraction` 45%, `unexplained` 15%. Strategy doc: `docs/r5-strategy-2026-04-17.md`.
-
-**MMR result: negative.** Surface-feature MMR regressed R@5 at every λ < 1.0 in the v3-test sweep, even after calibrating same-file penalty 1.0 → 0.4. Code shipped as inert opt-in (`CQS_MMR_LAMBDA` env / `SearchFilter.mmr_lambda`) for future embedding-MMR experiments. **Type-boost calibration:** ±1pp noise window; default 1.2 stays. **GC fix #21:** pruned 522 worktree+gitignored chunks via fixed `origin_exists`. **Eval-data hygiene (#23):** v3_test.v2.json regenerated against current index — 78 strict / 2 basename / 15 name / 14 unresolved. New canonical baseline on v2: **R@1 41.3% / R@5 63.3% / R@20 80.7%** with strict==permissive (no more fixture-drift artifacts). Cleaner future A/B.
-
-**Branch:** `feat/reranker-v2-phase1-calibration`. PR #1031 expanded scope: calibration + audit + strategy + gc fix + MMR infra. CI is in flight (clippy + fmt + test fixes pushed at ad1be3d).
-
-**Phase 2 status:** Stage A done (225k chunks, 9 langs, ~56 min). Stage B (BGE embed) running at 67 chunks/sec on A6000, 97% GPU, ~24 min ETA. Stage C (HNSW + hard-neg mining) next, then Gemma labeling pass.
-
-### What landed this session (after v1.27.0)
-
-| PR | Closes | Highlight |
+| Lever | Result | Status |
 |---|---|---|
-| #1023 | release v1.27.0 | Audit-wave + MSRV bump 1.93→1.95 |
-| #1024 | tears | v1.27.0 ROADMAP refresh + embedder swap workflow plan |
-| #1025 | publish 413 fix | Excluded `evals/`, `samples/`, `tools/`, `cuvs-fork-push/` from package |
-| #1026 | #6, #7 | Embedder hygiene (index-aware resolution + dim-mismatch error) + proactive GC (startup + retroactive gitignore + idle-time periodic) |
-| #1027 | #11, #13, #14, #9 | `cqs stats` field expansion + `cqs doctor --verbose` + `cqs ping` + `cqs eval` subcommand |
-| #1028 | #12, #8 | `--limit` standardization + `--json` propagation through batch |
-| #1029 | #10 | `.gitattributes` + LF renormalize (closed CRLF tax) |
-| #1030 | #15, #16 | `cqs model swap` + `cqs eval --baseline` regression gate (merged) |
-| #1031 | Reranker V2 Phase 1 | Calibration gate → GEMMA_ONLY (98.3% agreement, kappa 0.97) |
+| Tier 1.1 — eval-data hygiene | strict==permissive after `regenerate_v3_test.py` | done; canonical baseline R@5=63.3% on `v3_test.v2.json` |
+| Tier 1.2 — MMR re-rank (surface-feature) | regressed at every λ < 1.0 | shipped inert opt-in via `CQS_MMR_LAMBDA`; embedding-MMR is the obvious follow-up |
+| Tier 1.3 — chunk-type aware boost | within ±1pp noise of default 1.2 | default stays |
+| Tier 2 — Reranker V2 (Phase 3 cross-encoder) | −24pp R@5 (domain shift + binary-label loss) | weights stay local at `~/training-data/reranker-v2-unixcoder/`; not shipped |
+| Tier 2 — ColBERT 2-stage (mxbai-edge-colbert-v0-32m) | marginal/inconsistent: test α=0.9 +2.8pp R@5, dev α=0.9 +0.9pp | eval tool shipped; default OFF; PR #1037 |
 
-**v1.27.0 published on crates.io 2026-04-16.** GitHub Release with binaries built. crates.io was 503-ing initially; resolved after PR #1025 fixed 413 (eval datasets pushed package over 10MB).
+### What landed this session arc (post-v1.27.0)
 
-### v9-200k embedder eval result (2026-04-16)
+| PR | Highlight |
+|---|---|
+| #1023 | release v1.27.0 (audit-wave + MSRV bump 1.93→1.95) |
+| #1024 | post-v1.27.0 ROADMAP refresh + embedder swap workflow plan |
+| #1025 | publish 413 fix (excluded `evals/`, `samples/`, `tools/`, `cuvs-fork-push/` from package) |
+| #1026 | embedder hygiene (index-aware resolution + dim-mismatch error) + proactive GC (startup + retroactive gitignore + idle-time periodic) |
+| #1027 | `cqs stats` field expansion + `cqs doctor --verbose` + `cqs ping` + `cqs eval` subcommand |
+| #1028 | `--limit` standardization + `--json` propagation through batch |
+| #1029 | `.gitattributes` + LF renormalize (closed CRLF tax) |
+| #1030 | `cqs model swap` + `cqs eval --baseline` regression gate |
+| #1031 | Reranker V2 Phase 1 calibration → GEMMA_ONLY (98.3% inter-rater, kappa 0.97) |
+| #1032 | docs(plans): Phase 3 cross-encoder + sequenced ColBERT-XM |
+| #1033 | docs(plans): research recheck 2026-04-17 + Phase 3 training script |
+| #1034 | chore(agents): tune `.claude/agents/` prompts for Opus 4.7 |
+| #1035 | fix(train): accept `content` field in pointwise rows |
+| #1036 | fix(reranker): detect ONNX input shape, skip token_type_ids for RoBERTa-family |
+| #1037 | feat(evals): ColBERT 2-stage + RRF fusion eval tool (open) |
 
-Completed. **Verdict: don't switch.** v9-200k v3 test = R@1 28.4% / R@5 49.5% / R@20 71.6% vs BGE-large 42.2% / 64.2% / 78.9%. Net −13.8/−14.7/−7.3pp. Confound: `--force` reindex dropped chunks 15.5k → 10.7k (stale-row cleanup), but the gap is too large for that alone to explain. v9-200k is fine-tuned E5-base; not a true code-aware model. The ROADMAP "ties on R@1" claim was on 296q fixture (chunk-to-description), not v3 real-code search.
+Reranker V2 work also produced commits in the private `cqs-training` repo (research/reranker.md updated with Phase 1/2/3 + ColBERT results + post-mortem).
 
-### v3 test baselines (still current)
+### v3 baselines (current canonical)
+
+`evals/queries/v3_test.v2.json` (regenerated 2026-04-17 against current index; 109 queries, 78 strict / 2 basename / 15 name-fallback / 14 unresolved):
 
 | Config | R@1 | R@5 | R@20 |
 |---|---|---|---|
-| **v1.27.0 shipping (xlang=0.10)** | **42.2%** | 64.2% | 78.9% |
-| Forced-α ceiling (no router) | ~48% | (untested) | (untested) |
+| **v1.27.0 shipping (xlang=0.10), no rerank** | **41.3%** | **63.3%** | **80.7%** |
+| v3 dev baseline (same config) | 41.3% | 74.3% | 86.2% |
 
-**R@5 ceiling on v3 is unmeasured.** Forced-α R@5 ceiling is the next sanity check before committing to Reranker V2.
+Strict == permissive on v2 fixture (no more drift artifacts). Subsequent A/B should always quote both test AND dev — wins on test alone don't generalize (saw this with ColBERT 2-stage).
 
 ## What's queued
 
-Strategy ordering per `docs/r5-strategy-2026-04-17.md` (Tier 1 ships independent of Phase 2):
+The cheap-lever well is dry. Remaining options — pick by appetite:
 
-- ~~**Tier 1.1 — Eval-data hygiene**~~ — done (#23). v3_test.v2.json regenerated; baseline now strict==permissive at R@5=63.3%. 14 queries unresolved (legitimately no match in current index — flagged with `_unresolved: true`).
-- ~~**Tier 1.2 — MMR re-rank**~~ — tested, **negative result**. Surface-feature MMR regressed R@5 at every tested λ. Code shipped inert as opt-in (`CQS_MMR_LAMBDA`). Embedding-MMR is the obvious follow-up if revisited.
-- ~~**Tier 1.3 — Chunk-type aware boost**~~ — `CQS_TYPE_BOOST` sweep (1.3 → 2.0) within ±1pp noise of default 1.2. Already wired via `extract_type_hints` + Aho-Corasick. Default stands.
-
-**Net result for the cheap R@5 lever stack: zero usable lift.** Reranker V2 (Phase 2 in flight) is now the only path to R@5 >70%. ColBERT-class is the only path beyond.
-- **Tier 2 — Reranker V2 Phase 2 in flight + Phase 3** (Tasks #19, #20). Catches `unexplained` (15%) plus likely improves wrong_abstraction. +5-10pp realistic. ~5d to deployment.
-- **Tier 3 — chunker fix for `truncated_gold`** (3 queries). Reindex cost; smaller lift.
-- **JSON output schema standardization** (Task #17) — bigger refactor, runs whenever ergonomics work resumes.
-
-## R@5 90% target — analysis
-
-Honest framing (per session discussion):
-- **80% R@5 is the sharp goal.** Achievable with audit + Section-2 stack (MMR, larger pool, α resweep, chunk-type boost) + multi-query + per-category HyDE. Lower variance, infrastructure mostly exists. Estimated P(hit) ≥ 70%.
-- **90% R@5 is stretch.** Requires Reranker V2 done right with all 4 prereqs OR ColBERT (1-3 month architectural lift) OR both. Estimated P(hit) 30-40% even with full stack.
-- **Wins-vanish-through-router** is the recurring structural risk (centroid: −4.6pp, reranker v2 pilot: −5.5pp, full α sweep: only xlang transferred). Each phase must validate end-to-end on v3 dev.
+1. **Re-train Reranker V2 with post-mortem fixes** — re-mine hard negatives against cqs's own enriched index, keep TIE labels in pointwise, cap reranker pool at 20. ~1-2 weeks. Plausibly lands where the off-the-shelf attempts didn't.
+2. **Chunker fix for `truncated_gold`** — Tier 3, modest expected lift (+1-2pp R@5), requires reindex. ~3 days.
+3. **Per-category HyDE re-validation** — speculative, untested on v3. v2-era data showed +14pp structural / −22pp conceptual. Treat v2 numbers as motivation, not promise.
+4. **ColBERT integration into cqs proper** with per-token index — multi-week architectural work; eval-tool gain didn't justify it yet.
+5. **Embedder swap (CodeBERT / CodeT5+ / CodeR)** — same risk profile as the v9-200k experiment that already failed.
+6. **JSON output schema standardization** (Task #17) — unrelated to R@5 but on the queue.
 
 ## Architecture state
 
 - **Version:** v1.27.0 (live on crates.io + GitHub Releases with binaries)
 - **MSRV:** 1.95
 - **Local binary:** built from main; reinstall after merge with `cargo build --release --features gpu-index && systemctl --user stop cqs-watch && cp ~/.cargo-target/cqs/release/cqs ~/.cargo/bin/cqs && systemctl --user start cqs-watch`
-- **Index:** ~14.9k chunks (BGE-large; stale-row cleanup after the v9-200k experiment may have shifted count slightly)
-- **Production R@1 baseline on v3 test:** 42.2% / R@5 64.2% / R@20 78.9%
-- **Open PRs:** #1031 (Phase 1 calibration, in CI)
+- **Index:** ~16k chunks (BGE-large; cleaned of worktree pollution by #21 fix)
+- **Production R@5 baseline on v3.v2 test:** 63.3% (v1.27.0 shipping config)
+- **Open PRs:** #1037 (ColBERT eval tool)
 - **Open issues:** 5 — all tier-3 deferred or external-blocked: #106 (ort upstream RC), #717 (HNSW lib swap), #916 (mmap SPLADE — depriorotized behind #917 which shipped), #956 (CoreML/ROCm needs non-Linux CI), #255 (pre-built ref packages design)
 - **cqs-watch daemon:** running latest binary
-- **CRLF tax:** killed by #1029 (`.gitattributes` + `* text=auto eol=lf`)
+- **Pending uncommitted:** 4 files in `evals/queries/colbert_rerank_{test,dev}.{json,events.jsonl}` — eval artifacts from PR #1037 work; intentionally not staged (reproducible from script)
+
+## Reranker V2 post-mortem (recorded for future revisit)
+
+Phase 3 trained `microsoft/unixcoder-base` on the 382k pointwise corpus. Result: −24pp R@5 (full pool), still −4.6pp at smallest pool. Three causes, all fixable but combined ~1-2 weeks:
+
+1. **TIE labels were dropped from pointwise.** Phase 2's `pairwise_to_pointwise.py` filtered 8641 TIE pairs entirely — model trained on binary labels, weaker ordering signal than BiXSE assumes. Fix: keep TIE as label=0.5, OR use original pairwise data with margin loss.
+2. **Domain shift Stack v2 → cqs index.** Trained on raw Stack v2 chunks; cqs serves *enriched* chunks (NL desc + signature + content + doc). Fix: re-mine hard negatives from cqs's actual index; smaller corpus (~16k chunks) but domain-matched.
+3. **Pool-size brittleness.** `(limit * 4).min(100)` over-retrieves; weak rerankers get amplified by large pools. Fix: cap reranker pool at ~20.
+
+Full detail in `~/training-data/research/reranker.md`.
 
 ## Operational pitfalls (rolling forward)
 
-- **Agent worktree leak via absolute paths** — `isolation: "worktree"` is *soft* isolation; agents using absolute paths in tool calls write to parent tree. Add explicit path-discipline text to every parallel-agent prompt. **Filed as Anthropic feedback this session.**
+- **Agent worktree leak via absolute paths** — `isolation: "worktree"` is *soft* isolation; agents using absolute paths in tool calls write to parent tree. Add explicit path-discipline text to every parallel-agent prompt. Filed as Anthropic feedback.
+- **WSL git credential helper** — out-of-the-box, `git push` from `~/training-data` (and any WSL-native path) fails with "could not read Username." Fix: `git config --global credential.helper '/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe'`. Saved as memory `reference_wsl_git_creds.md`. Already configured globally; future repos work without setup.
 - **Cargo publish 413 = "exclude" list missing** — `evals/queries/v3_*.json` pushed package over 10MB. `Cargo.toml` exclude list now blocks `evals/`, `samples/`, `tools/`, `cuvs-fork-push/`. Re-check after adding any new heavy dir.
-- **Cargo publish 503 = transient CDN** — auto-retry within minutes resolves it. Don't bump version chasing 503s.
-- **3-way `git merge-file` works well** for parallel-agent aggregation when files don't overlap line-for-line. Pattern: `git merge-file <current> <main_base> <other_worktree>` produces clean merge for non-overlapping clap variant additions.
-- **systemd doesn't inherit shell env** — `CQS_EMBEDDING_MODEL=v9-200k systemctl start cqs-watch` doesn't propagate; use `systemctl --user set-environment KEY=VAL` then start. (Mostly obsolete now since #1026 made model resolution index-aware.)
 - **Always run `cqs eval --baseline` after retrieval changes** — the regression gate from #1030 catches per-category R@K drops automatically. Save baselines per release: `evals/baseline-v1.27.0.json` etc.
-- **Reranker V2 prereqs are non-negotiable**: 200k+ Gemma pairs, code-pretrained base (NOT MS-MARCO), RRF fusion (don't replace), top-K input (no over-retrieval). Pilot violated all 4 → −5pp. The 200k corpus build (Task #18-20) is the path to satisfying #1.
-- **No time estimates in specs** (per user feedback this session) — they're systemically too long. Frame in compute units / GPU hours / step counts.
+- **Single-split A/B is noisy at N=109** — always confirm test wins on dev before declaring. ColBERT 2-stage taught this by showing +5.5pp R@5 on test that dropped to +0.9pp on dev.
+- **Smoke-test against real producer output** — synthetic fixtures only catch what you anticipate. Phase 3 training failed first launch because synthetic smoke used `passage` field; real Phase 2 output used `content`. Saved as memory `feedback_smoke_real_shape.md`.
+- **No time estimates in specs** — they're systemically too long. Frame in compute units / GPU hours / step counts. Wall-time predictions get better when anchored on concrete reference frames (size, count, throughput).
 
 ## What's parked
 
-- **HyDE on v3 dev** — most promising untested representation lever. Per-category routing required (v2-era data: +14pp structural, −22pp conceptual). Treat v2 numbers as motivation only — wins-vanish risk is real.
-- **ColBERT-class late interaction** — biggest single lever for code retrieval (+10-25pp R@5 on benchmarks). Architectural rebuild. Plan: add `Reranker` trait → ColBERT impl as 2-stage re-ranker first → only do full per-token index if it wins.
-- **Code-aware embedder switch** — CodeBERT, CodeT5+-110M-embedding, UniXcoder all untested on v3. v9-200k didn't help but it's not a true code-aware model.
-- **Knowledge-augmented retrieval** — use the call/type graph as a structured filter. Multi_step queries currently weakest at 28-43% R@1; KG could help.
-- **Meta-routing** — current router commits to one strategy; ensemble of strategies with learned weights could stop the wins-vanishing pattern.
+- **HyDE on v3 dev** — most promising untested representation lever. Per-category routing required.
+- **ColBERT integration with per-token index** — eval tool exists, default off; full integration multi-week.
+- **Code-aware embedder switch** — CodeBERT, CodeT5+-110M-embedding, UniXcoder all untested on v3. v9-200k didn't help.
+- **Knowledge-augmented retrieval** — call/type graph as structured filter. Multi_step queries weakest at 28-43% R@1.
+- **Meta-routing** — current router commits to one strategy; ensemble with learned weights could stop the wins-vanishing pattern.
+- **Properly-retrained Reranker V2** — see post-mortem; gated on appetite for the 1-2 week re-mine + retrain.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,19 +2,18 @@
 
 ## Current: v1.27.0 (audit-wave release)
 
-54 languages. 29 chunk types. v3 eval canonical (544 dual-judge queries, train/dev/test 326/109/109). Daemon mode (`cqs watch --serve`, 99ms graph p50 / 200ms search-warm p50). Per-category SPLADE alpha routing via compile-enforced `define_query_categories!` macro. GPU-native CAGRA bitset filtering (patched cuvs 26.4). MSRV 1.95 (bumped from 1.93).
+54 languages. 29 chunk types. v3 eval canonical, regenerated to v2 fixture 2026-04-17 (109 test / 109 dev with strict==permissive matching after `regenerate_v3_test.py`). Daemon mode (`cqs watch --serve`, 99ms graph p50 / 200ms search-warm p50). Per-category SPLADE alpha routing via compile-enforced `define_query_categories!` macro. GPU-native CAGRA bitset filtering (patched cuvs 26.4). MSRV 1.95 (bumped from 1.93).
 
 **v1.27.0** shipped 2026-04-16: closes 13 of 18 open issues from the post-v1.26.1 audit. Major perf wins (#917 streaming SPLADE, #966 stream-hash enrichment, #969 recency-based watch prune) + the `AuxModelConfig` preset registry (#957) that makes SPLADE-Code 0.6B a one-line config switch. See [`docs/audit-open-issues-2026-04-16.md`](docs/audit-open-issues-2026-04-16.md) for the audit ledger.
 
-### Eval baselines on v3 test (production router, 3-trial stable)
+### Eval baselines on v3.v2 (canonical, 2026-04-17 regen)
 
-| Config | R@1 | R@5 | R@20 |
+| Split | R@1 | R@5 | R@20 |
 |---|---|---|---|
-| v1.26.0 alphas | 40.4% | 64.2% | 80.7% |
-| **v1.27.0 shipping (xlang=0.10)** | **42.2%** | 64.2% | 78.9% |
-| Full v3-swept per-category α | 41.3% | 63.3% | 78.9% |
+| **test (n=109), v1.27.0 shipping config** | **41.3%** | **63.3%** | **80.7%** |
+| dev (n=109), same config | 41.3% | 74.3% | 86.2% |
 
-Single-trial v3 test readings drift ±1pp; always confirm over 3 trials. Forced-α (no strategy router) tops out around 48% — the ceiling if the rule-based classifier perfectly routed every query. Breakeven simulation shows per-category α routing on Unknown queries (~48% of traffic) is net-negative at *any* classifier accuracy. Real reachable tuning ceiling is ~1-3pp above 42.2%. Further R@1 requires representation changes (HyDE, reranker V2 at scale, embedder switch).
+Strict == permissive on v2 fixture — no fixture drift artifacts. Subsequent A/B should always quote both test AND dev; wins on test alone don't generalize (saw this with the ColBERT 2-stage A/B). N=109 per split is noisy at ±2-3pp single-trial. The cheap-lever sweep this session arc landed within that noise window — current architecture's R@5 ceiling sits around 63-65%.
 
 ---
 
@@ -22,17 +21,18 @@ Single-trial v3 test readings drift ±1pp; always confirm over 3 trials. Forced-
 
 ### GPU Lane
 
-- [ ] **Reranker V2 — code-trained cross-encoder.** Pilot (2270 v3 triples, ms-marco-MiniLM-L-6-v2 fine-tune) landed net-negative. Default ms-marco without fine-tuning: 28.4% R@1. Full pipeline verified end-to-end (training, ONNX export, local-path loading, `--rerank` integration).
+- [x] **Reranker V2 — code-trained cross-encoder, 2026-04-17/18 pass.** Phase 1 calibration: 1k Gemma+Claude triples → 98.3% inter-rater agreement → GEMMA_ONLY decision (PR #1031). Phase 2: 200k Stack v2 hard-negative triples labeled by Gemma 4 31B AWQ on A6000 (12h45m wall, 95.31% overall agreement, 0 parse errors, balanced across 9 langs). Phase 3: trained `microsoft/unixcoder-base` + BCE on 382k pointwise rows. **Result: −24pp R@5 on v3.v2 test.** Even at smallest pool: −4.6pp R@5. Weights stay local at `~/training-data/reranker-v2-unixcoder/`.
 
-  **Prerequisites to ship — all four required:**
-  1. Scale — 200k+ Gemma-labeled pairs (pipeline built 2026-04-15: vLLM Gemma 4 31B serving, blake3-cached prompts, Haiku fallback for hard tail).
-  2. Code-pretrained base — CodeBERT, CodeT5+-110M-embedding, or UniXcoder. MS-MARCO on web passages doesn't transfer to code.
-  3. RRF fusion — combine reranker logit with hybrid score rather than replacing it. Preserves SPLADE signal.
-  4. Don't over-retrieve — keep reranker input = top-K, not 4×K. Prevents R@20 drop.
+  **Post-mortem (full detail `~/training-data/research/reranker.md`):**
+  1. TIE labels were dropped from pointwise → trained on binary, weaker signal than BiXSE assumes
+  2. Domain shift: trained on raw Stack v2 chunks, deployed on cqs's enriched chunks (NL desc + signature + content + doc)
+  3. Pool-size brittleness: `(limit*4).min(100)` over-retrieves; weak rerankers get amplified
 
-  Bi-encoder alternative is blocked by the research/models.md "basin" result: v9-200k, v9-200k-hn, v9-200k-testq, v9-175k, v9-500k, v9-mini, v8, contrastive-B all land 81-82% R@1 on 296q regardless of training variation. Architectural ceiling of E5-base, not a training gap.
+  All three are fixable but combined ~1-2 weeks. Not currently top priority. The "ms-marco net negative" result still stands for off-the-shelf rerankers; we now also have the matching result for in-domain-trained rerankers when domain isn't actually matched.
 
-  Gating: idle GPU window + decision on LLM-judged vs click-signal labels. Calibration gate (≥85% Gemma↔Haiku agreement on 1k gold) before committing to local-only labeling. Full design in `~/training-data/research/models.md`.
+- [x] **ColBERT 2-stage rerank — tested 2026-04-17/18.** `mixedbread-ai/mxbai-edge-colbert-v0-32m` (Apache-2.0, 32M, beats ColBERTv2 on BEIR) via PyLate. Three modes (pure replacement, RRF fusion, alpha sweep). **Test α=0.9: R@5 +2.8pp; dev α=0.9: R@5 +0.9pp.** Test gain didn't fully replicate on dev; only R@20 improves consistently. Eval tool shipped (PR #1037), default OFF in production. Rust integration deferred — gains too marginal/inconsistent to justify the work.
+
+- [ ] **Reranker V2 retrain with post-mortem fixes — open path.** Mine hard negatives against cqs's *own* index (~16k chunks) for domain match, keep TIE labels in pointwise as 0.5, cap reranker pool at 20. ~1-2 weeks. Plausibly lands where the Stack-v2-trained version didn't.
 
 ### CPU Lane
 

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -99,16 +99,6 @@ mentions = [
 ]
 
 [[note]]
-sentiment = 1.0
-text = "BGE-large-en-v1.5 (335M) is the default model: 90.5% R@1 on 296-query expanded eval. v9-200k (110M) 90.2%, v5 (110M) 89.5% — all within GPU non-determinism (~1.4pp). Enrichment compresses top model differences to ~1pp above a ~54% raw R@1 threshold."
-mentions = [
-    "src/embedder/mod.rs",
-    "CUDA",
-    "model selection",
-    "E5",
-]
-
-[[note]]
 sentiment = -1.0
 text = "Glob filter BEFORE heap was the #1 correctness bug from the 20-category audit. Brute-force search applied glob AFTER selecting top-k from heap, meaning filtered results could miss relevant chunks that were displaced by non-matching ones. Always filter before ranking."
 mentions = [
@@ -954,23 +944,9 @@ mentions = [
 ]
 
 [[note]]
-sentiment = 0.5
-text = "Real codebase eval hierarchy: training signal (CG filter) > embedding quality (BGE-large) > context length (nomic 8K). v9-200k 48%, BGE-large 46%, nomic 32% on 50-query real eval. Fixture convergence at 90% was artifact — models separate on harder evals."
-mentions = [
-    "pipeline_eval",
-    "search",
-    "research",
-]
-
-[[note]]
 sentiment = -1.0
 text = "Real eval script had schema mismatch — real_eval_expanded.json uses function_lookup/conceptual keys, script expected queries. Prior 187q/100q claims were inflated. Only 50 manual queries actually ran. Fixed 2026-04-03."
 mentions = ["run_real_eval.py"]
-
-[[note]]
-sentiment = -0.5
-text = "v9-200k collapsed from 49% to 26% R@1 after commands subdirectory restructure. 768-dim model less robust to file path changes than 1024-dim BGE-large. Path-dependent embeddings are fragile."
-mentions = ["search"]
 
 [[note]]
 sentiment = 0.0
@@ -1193,14 +1169,6 @@ mentions = [
 ]
 
 [[note]]
-sentiment = -1.0
-text = "tests/cli_health_test.rs tests take 60-300s EACH because they shell out to cqs and cold-load ONNX/HNSW/SPLADE per invocation. Normal test-job CI time is ~22min. Do NOT cancel running CI under 30min without a specific hang signal. Filed #980 with in-process-fixture fix."
-mentions = [
-    "tests/cli_health_test.rs",
-    "ci",
-]
-
-[[note]]
 sentiment = 0.0
 text = "gh pr merge --admin (when auth'd as repo owner) overrides 'fail' and 'stale' status checks but NOT 'in progress' ones. If branch protection is blocking, empty commit to retrigger fresh CI + wait for it, THEN admin-merge if needed. Don't try to admin-bypass a running check."
 mentions = [
@@ -1410,3 +1378,37 @@ mentions = [
     "llm-judge",
     "labeling",
 ]
+
+[[note]]
+sentiment = -0.5
+text = "Reranker V2 cross-encoder trained on Stack v2 chunks regressed −24pp R@5 when deployed against cqs's enriched-chunk index. Domain shift (raw vs enriched chunk format) is the dominant cause; binary-only labels (TIE filtered from pointwise) and pool-size amplification compound it. Same model can score sort-vs-print correctly (0.74 vs 0.06) but degenerates on tighter pairs."
+mentions = [
+    "reranker.rs",
+    "evals/train_reranker_v2.py",
+    "reranker_v2_corpus",
+]
+
+[[note]]
+sentiment = -0.5
+text = "ColBERT 2-stage rerank R@5 wins on test (+5.5pp at α=0.7) don't replicate on dev (0.0pp at α=0.7). Test baseline 58.7% leaves headroom; dev baseline 74.3% doesn't. Single-split A/B at N=109 is noisy; always confirm both splits before declaring a lever real."
+mentions = ["evals/colbert_rerank_eval.py"]
+
+[[note]]
+sentiment = -0.5
+text = "MMR re-rank with surface-feature similarity (file/dir/name) regressed R@5 at every λ < 1.0 even after calibrating same-file penalty 1.0 → 0.4. Pool expansion re-triggered type-boost re-sort, shifting top-1. Code shipped inert via CQS_MMR_LAMBDA opt-in; embedding-MMR is the obvious follow-up if revisited."
+mentions = ["src/search/mmr.rs"]
+
+[[note]]
+sentiment = 0.5
+text = "Reranker hardcoded token_type_ids in ort::inputs! macro broke RoBERTa-family models (UniXcoder, CodeBERT, ColBERT-XM, jina-colbert-v2, mxbai-edge-colbert). Fix at session-init: inspect session.inputs(), cache has_token_type_ids bool, build inputs dict conditionally. Caught during Phase 3 reranker A/B; prerequisite for any future RoBERTa-based reranker work including ColBERT integration."
+mentions = ["src/reranker.rs"]
+
+[[note]]
+sentiment = 0.0
+text = "ColBERT model license check before defaulting: jinaai/jina-colbert-v2 and jinaai/jina-reranker-v3 are CC-BY-NC-4.0 (research-only, blocks commercial users). antoinelouis/colbert-xm is MIT. mixedbread-ai/mxbai-edge-colbert-v0-32m is Apache-2.0 (preferred default for our 2-stage path; 32M params, beats ColBERTv2 on BEIR)."
+mentions = ["evals/colbert_rerank_eval.py"]
+
+[[note]]
+sentiment = -0.5
+text = "cqs gc had a latent bug: origin_exists fell through to Path::exists(), keeping any chunk whose file was on disk regardless of whether enumerate_files (worktree-skip + gitignore filter) actually owned it. Fix: drop the exists() fallback, canonicalize via dunce, require strict membership in existing_files. Pruned 522 worktree+gitignored chunks from production index. Watch for this pattern when adding new schema-prune logic."
+mentions = ["src/store/chunks/staleness.rs"]

--- a/evals/colbert_rerank_eval.py
+++ b/evals/colbert_rerank_eval.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""ColBERT 2-stage rerank A/B vs current shipping config.
+
+Per `docs/plans/2026-04-17-colbert-2stage-rerank.md`:
+  - Stage 1: cqs's existing dense + SPLADE + RRF + per-category alpha
+    pipeline produces a top-K candidate pool.
+  - Stage 2: ColBERT (`mxbai-edge-colbert-v0-32m`, Apache-2.0) re-ranks
+    that pool via late-interaction MaxSim.
+  - Cut to top-N. Compare R@K vs the no-rerank baseline.
+
+Off-the-shelf — no training, no Rust integration. If this beats baseline,
+that's the green light to wire it into cqs proper. If it doesn't, ColBERT
+is parked for now.
+
+Observable + Robust + Resumable per `feedback_orr_default`:
+  - Append-only `events.jsonl` (start, load, model_loaded, per-query
+    progress, fatal, done)
+  - Per-query try/except — single failures don't abort the run
+  - SIGINT-safe — partial results saved on Ctrl+C
+  - Resume — if `--out` already has cached results for a query, skip it
+  - Heartbeat to stderr every N queries
+
+Run:
+  python3 evals/colbert_rerank_eval.py --split test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Disable trainer integrations (wandb etc.) before transformers loads
+os.environ.setdefault("WANDB_DISABLED", "true")
+os.environ.setdefault("TRANSFORMERS_NO_ADVISORY_WARNINGS", "1")
+
+import torch  # noqa: E402
+
+QUERIES_DIR = Path(__file__).parent / "queries"
+DEFAULT_MODEL = "mixedbread-ai/mxbai-edge-colbert-v0-32m"
+POOL_K = 50  # candidates from cqs (larger pool; ColBERT is cheap per pair)
+EVAL_K_VALUES = [1, 5, 20]
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--split", default="test", choices=["test", "dev"])
+    p.add_argument("--model", default=DEFAULT_MODEL)
+    p.add_argument(
+        "--pool",
+        type=int,
+        default=POOL_K,
+        help="Stage-1 candidate pool size (passed as --limit to cqs batch)",
+    )
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output JSON path (default: evals/queries/colbert_rerank_<split>.json)",
+    )
+    p.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    p.add_argument("--heartbeat-every", type=int, default=10)
+    return p.parse_args()
+
+
+class EventLog:
+    def __init__(self, path: Path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.path = path
+
+    def emit(self, kind: str, **fields):
+        rec = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%S"),
+            "ts_unix": time.time(),
+            "kind": kind,
+            **fields,
+        }
+        with self.path.open("a") as f:
+            f.write(json.dumps(rec, default=str) + "\n")
+            f.flush()
+
+
+def load_split(split: str) -> list[dict]:
+    path = QUERIES_DIR / f"v3_{split}.v2.json"
+    if not path.exists():
+        path = QUERIES_DIR / f"v3_{split}.json"
+    rows = json.loads(path.read_text())["queries"]
+    return [q for q in rows if q.get("gold_chunk")]
+
+
+def get_stage1_pool(queries: list[dict], pool_k: int) -> list[list[dict]]:
+    """Get cqs's top-K dense+RRF+SPLADE candidates for each query."""
+    env = {**os.environ, "CQS_CENTROID_CLASSIFIER": "0"}
+    proc = subprocess.Popen(
+        ["cqs", "batch"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=open("/tmp/colbert-stage1.stderr", "ab"),
+        text=True,
+        bufsize=1,
+        env=env,
+    )
+    out = []
+    t0 = time.monotonic()
+    try:
+        for i, q in enumerate(queries):
+            cmd = f"search {shlex.quote(q['query'])} --limit {pool_k} --splade"
+            proc.stdin.write(cmd + "\n")
+            proc.stdin.flush()
+            line = proc.stdout.readline()
+            try:
+                res = json.loads(line).get("results", [])
+            except (json.JSONDecodeError, AttributeError):
+                res = []
+            out.append(res)
+            if (i + 1) % 20 == 0 or i + 1 == len(queries):
+                rate = (i + 1) / (time.monotonic() - t0)
+                print(
+                    f"  stage1 {i+1}/{len(queries)} ({rate:.1f} qps)",
+                    file=sys.stderr,
+                    flush=True,
+                )
+    finally:
+        try:
+            proc.stdin.close()
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
+    return out
+
+
+def find_rank_in_results(gold: dict, results: list[dict]) -> tuple[int | None, str]:
+    """Return (1-based rank, match_kind). Strict → basename → name fallback."""
+    target_origin = gold.get("origin")
+    target_name = gold.get("name")
+    target_lstart = gold.get("line_start")
+    target_basename = (target_origin or "").split("/")[-1].split("\\")[-1]
+
+    for i, r in enumerate(results):
+        if (r.get("file"), r.get("name"), r.get("line_start")) == (
+            target_origin,
+            target_name,
+            target_lstart,
+        ):
+            return i + 1, "strict"
+    for i, r in enumerate(results):
+        rb = (r.get("file") or "").split("/")[-1].split("\\")[-1]
+        if (rb, r.get("name"), r.get("line_start")) == (
+            target_basename,
+            target_name,
+            target_lstart,
+        ):
+            return i + 1, "basename"
+    for i, r in enumerate(results):
+        if r.get("name") == target_name and target_name:
+            return i + 1, "name"
+    return None, "none"
+
+
+def _pad_stack(arrays):
+    """Pad ragged list of (n_tokens_i, dim) arrays to a single
+    (N, max_tokens, dim) tensor + boolean mask (N, max_tokens).
+    PyLate's encode returns a list of variable-length numpy arrays;
+    colbert_scores wants pre-padded tensors with masks for the variable
+    lengths.
+    """
+    import numpy as np
+    n = len(arrays)
+    max_len = max(a.shape[0] for a in arrays)
+    dim = arrays[0].shape[1]
+    out = np.zeros((n, max_len, dim), dtype=np.float32)
+    mask = np.zeros((n, max_len), dtype=np.bool_)
+    for i, a in enumerate(arrays):
+        L = a.shape[0]
+        out[i, :L] = a
+        mask[i, :L] = True
+    return torch.from_numpy(out), torch.from_numpy(mask)
+
+
+def colbert_rank_one(model, query: str, candidates: list[dict]) -> list[int] | None:
+    """Score candidates with ColBERT MaxSim. Returns colbert_rank[] where
+    colbert_rank[orig_idx] = the candidate's position (0-based) in the
+    pure-ColBERT ordering. Returns None if scoring not possible.
+    """
+    if not candidates:
+        return None
+    docs = [c.get("content", "") or "" for c in candidates]
+    if not any(docs):
+        return None
+
+    q_emb_list = model.encode([query], is_query=True, show_progress_bar=False)
+    d_emb_list = model.encode(docs, is_query=False, show_progress_bar=False)
+
+    q_tensor, q_mask = _pad_stack(q_emb_list)
+    d_tensor, d_mask = _pad_stack(d_emb_list)
+
+    if torch.cuda.is_available():
+        q_tensor = q_tensor.cuda()
+        d_tensor = d_tensor.cuda()
+        q_mask = q_mask.cuda()
+        d_mask = d_mask.cuda()
+
+    from pylate.scores import colbert_scores
+
+    s = colbert_scores(q_tensor, d_tensor, queries_mask=q_mask, documents_mask=d_mask)
+    colbert_scores_list = s[0].cpu().tolist()
+
+    pairs = list(zip(colbert_scores_list, range(len(candidates))))
+    pairs.sort(key=lambda x: -x[0])
+    colbert_rank = [0] * len(candidates)
+    for new_pos, (_, orig_idx) in enumerate(pairs):
+        colbert_rank[orig_idx] = new_pos
+    return colbert_rank
+
+
+def fuse_rrf(
+    candidates: list[dict],
+    colbert_rank: list[int] | None,
+    alpha: float,
+    k_stage1: int = 60,
+    k_colbert: int = 60,
+) -> list[dict]:
+    """Reciprocal-rank-fusion of stage1 (input order) and colbert ranks.
+
+    fusion_score = alpha / (k_stage1 + stage1_rank) + (1-alpha) / (k_colbert + colbert_rank)
+
+    alpha=1.0 → pure stage1, alpha=0.0 → pure colbert, alpha=0.5 → equal.
+    Returns candidates sorted by fusion_score descending.
+    """
+    if colbert_rank is None:
+        return list(candidates)
+    scored = [
+        (
+            alpha / (k_stage1 + i)
+            + (1.0 - alpha) / (k_colbert + colbert_rank[i]),
+            candidates[i],
+        )
+        for i in range(len(candidates))
+    ]
+    scored.sort(key=lambda x: -x[0])
+    return [c for _, c in scored]
+
+
+def colbert_only(
+    candidates: list[dict], colbert_rank: list[int] | None
+) -> list[dict]:
+    if colbert_rank is None:
+        return list(candidates)
+    paired = list(zip(colbert_rank, range(len(candidates))))
+    paired.sort(key=lambda x: x[0])
+    return [candidates[orig] for _, orig in paired]
+
+
+def compute_recall_at_k(
+    queries: list[dict], rankings: list[list[dict]]
+) -> dict:
+    """Compute R@K for both strict and permissive matching."""
+    strict = {k: 0 for k in EVAL_K_VALUES}
+    permissive = {k: 0 for k in EVAL_K_VALUES}
+    misses = 0
+    n = 0
+    for q, results in zip(queries, rankings):
+        gold = q.get("gold_chunk")
+        if not gold:
+            continue
+        n += 1
+        rank, kind = find_rank_in_results(gold, results)
+        if rank is None:
+            misses += 1
+            continue
+        for k in EVAL_K_VALUES:
+            if rank <= k:
+                permissive[k] += 1
+                if kind == "strict":
+                    strict[k] += 1
+    return {
+        "n": n,
+        "misses": misses,
+        "strict": {k: strict[k] for k in EVAL_K_VALUES},
+        "permissive": {k: permissive[k] for k in EVAL_K_VALUES},
+    }
+
+
+def main():
+    args = parse_args()
+    out_path = args.out or QUERIES_DIR / f"colbert_rerank_{args.split}.json"
+    events = EventLog(out_path.with_suffix(".events.jsonl"))
+    events.emit("start", argv=sys.argv, args=vars(args))
+
+    interrupted = {"flag": False}
+
+    def sigint(_signum, _frame):
+        print("\n[INT] saving partial results then exiting", file=sys.stderr)
+        events.emit("sigint")
+        interrupted["flag"] = True
+
+    signal.signal(signal.SIGINT, sigint)
+
+    print(f"Loading split: {args.split}", file=sys.stderr)
+    queries = load_split(args.split)
+    print(f"  {len(queries)} queries with gold_chunk", file=sys.stderr)
+    events.emit("loaded_queries", n=len(queries), split=args.split)
+
+    print(f"Running stage 1 (cqs dense+SPLADE+RRF, pool={args.pool})...", file=sys.stderr)
+    stage1 = get_stage1_pool(queries, args.pool)
+    events.emit("stage1_done", n=len(stage1), pool=args.pool)
+
+    print(f"Loading ColBERT model: {args.model}", file=sys.stderr)
+    from pylate import models as pl_models
+
+    model = pl_models.ColBERT(args.model, device=args.device)
+    events.emit("model_loaded", model=args.model, device=args.device)
+    print("  loaded.", file=sys.stderr)
+
+    # Compute baseline (no-rerank) metrics on the same stage1 pool
+    baseline_metrics = compute_recall_at_k(queries, stage1)
+    events.emit("baseline_metrics", **baseline_metrics)
+    print(
+        f"\n=== Baseline (stage1 only, pool={args.pool}) ===\n"
+        f"  R@1  strict={baseline_metrics['strict'][1]}/{baseline_metrics['n']} "
+        f"({100*baseline_metrics['strict'][1]/baseline_metrics['n']:.1f}%) | "
+        f"permissive={baseline_metrics['permissive'][1]}/{baseline_metrics['n']} "
+        f"({100*baseline_metrics['permissive'][1]/baseline_metrics['n']:.1f}%)\n"
+        f"  R@5  strict={baseline_metrics['strict'][5]}/{baseline_metrics['n']} "
+        f"({100*baseline_metrics['strict'][5]/baseline_metrics['n']:.1f}%) | "
+        f"permissive={baseline_metrics['permissive'][5]}/{baseline_metrics['n']} "
+        f"({100*baseline_metrics['permissive'][5]/baseline_metrics['n']:.1f}%)\n"
+        f"  R@20 strict={baseline_metrics['strict'][20]}/{baseline_metrics['n']} "
+        f"({100*baseline_metrics['strict'][20]/baseline_metrics['n']:.1f}%) | "
+        f"permissive={baseline_metrics['permissive'][20]}/{baseline_metrics['n']} "
+        f"({100*baseline_metrics['permissive'][20]/baseline_metrics['n']:.1f}%)",
+        file=sys.stderr,
+    )
+
+    # Stage 2: ColBERT MaxSim score per query (scored once, used to derive
+    # multiple alphas in the fusion sweep)
+    alpha_sweep = [0.3, 0.5, 0.7, 0.9]
+    print(f"\nStage 2: ColBERT MaxSim + RRF fusion sweep over α={alpha_sweep}...", file=sys.stderr)
+    rerank_only = []
+    fused_by_alpha = {a: [] for a in alpha_sweep}
+    t0 = time.monotonic()
+    fail_ct = 0
+    for i, (q, pool) in enumerate(zip(queries, stage1)):
+        try:
+            cb_rank = colbert_rank_one(model, q["query"], pool)
+        except Exception as e:
+            fail_ct += 1
+            events.emit("rerank_fail", query_idx=i, error=repr(e))
+            cb_rank = None
+        rerank_only.append(colbert_only(pool, cb_rank))
+        for a in alpha_sweep:
+            fused_by_alpha[a].append(fuse_rrf(pool, cb_rank, alpha=a))
+        if (i + 1) % args.heartbeat_every == 0 or i + 1 == len(queries):
+            rate = (i + 1) / (time.monotonic() - t0)
+            mem_mb = (
+                round(torch.cuda.memory_allocated() / (1024 * 1024), 1)
+                if args.device.startswith("cuda")
+                else None
+            )
+            print(
+                f"  rerank {i+1}/{len(queries)} ({rate:.2f} q/s, "
+                f"{fail_ct} fails, gpu_mb={mem_mb})",
+                file=sys.stderr,
+                flush=True,
+            )
+            events.emit(
+                "heartbeat",
+                idx=i + 1,
+                rate_qps=round(rate, 2),
+                fails=fail_ct,
+                gpu_mb=mem_mb,
+            )
+        if interrupted["flag"]:
+            break
+
+    rerank_metrics = compute_recall_at_k(queries[: len(rerank_only)], rerank_only)
+    fusion_metrics_by_alpha = {
+        a: compute_recall_at_k(queries[: len(fused_by_alpha[a])], fused_by_alpha[a])
+        for a in alpha_sweep
+    }
+    events.emit("rerank_metrics", **rerank_metrics)
+    for a, m in fusion_metrics_by_alpha.items():
+        events.emit("fusion_metrics", alpha=a, **m)
+
+    n = baseline_metrics["n"]
+    print(f"\n=== Comparison (pool={args.pool}, n={n}) ===", file=sys.stderr)
+    header = (
+        f"  {'metric':<6}  {'baseline':>14s}  {'colbert':>14s}"
+        + "".join(f"  {'fus α=' + str(a):>14s}" for a in alpha_sweep)
+    )
+    print(header, file=sys.stderr)
+    for k in EVAL_K_VALUES:
+        b = baseline_metrics["permissive"][k]
+        r = rerank_metrics["permissive"][k]
+        cells = [
+            f"{b}/{n} ({100*b/n:5.1f}%)",
+            f"{r}/{n} ({100*r/n:5.1f}%) {100*(r-b)/n:+.1f}",
+        ]
+        for a in alpha_sweep:
+            f = fusion_metrics_by_alpha[a]["permissive"][k]
+            cells.append(f"{f}/{n} ({100*f/n:5.1f}%) {100*(f-b)/n:+.1f}")
+        print(f"  R@{k:<3}   " + "  ".join(c.rjust(14) for c in cells), file=sys.stderr)
+
+    out = {
+        "split": args.split,
+        "model": args.model,
+        "pool": args.pool,
+        "n_queries": n,
+        "baseline": baseline_metrics,
+        "rerank": rerank_metrics,
+        "fusion_by_alpha": {str(a): m for a, m in fusion_metrics_by_alpha.items()},
+        "alpha_sweep": alpha_sweep,
+        "interrupted": interrupted["flag"],
+        "fail_ct": fail_ct,
+    }
+    out_path.write_text(json.dumps(out, indent=2))
+    events.emit("done", out=str(out_path), **out)
+    print(f"\n→ {out_path}\n→ {out_path.with_suffix('.events.jsonl')}", file=sys.stderr)
+    return 130 if interrupted["flag"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Standalone PyLate-based ColBERT 2-stage rerank eval. Default OFF in production — gains are marginal and inconsistent across splits (test α=0.9 R@5 +2.8pp, dev α=0.9 R@5 +0.9pp). Tool kept for future ColBERT experiments without committing cqs proper to Rust integration. See commit body for full A/B numbers.