### PR TITLE
chore(deps): bump rustls-webpki 0.103.10 → 0.103.12 (Dependabot #7, #8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3394,9 +3394,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- Patch-bump `rustls-webpki` 0.103.10 → 0.103.12 to close two low-severity Dependabot advisories.

Closes Dependabot alerts #7 (GHSA-rxgw-pgv5-h3p8) and #8 (GHSA-c5q8-7m6g-8ggh).

## Context

Both advisories cover name-constraint bugs in `rustls-webpki`'s certificate validation:
- URI names were incorrectly accepted past the constraint
- Wildcard name constraints were accepted

`rustls-webpki` is transitive only in cqs — pulled in by `reqwest` (HTTPS to HuggingFace for model downloads) and `hf-hub`. The practical impact is bounded to model-download TLS chains, where the risk is MITM on `huggingface.co`. No direct cert-validation surface in user code.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `Cargo.lock` is the only file changed (2 lines)
- [ ] CI clippy/fmt/test/CodeQL pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
