### PR TITLE
chore: Release v1.28.1 — recover 8 P2 audit fixes lost in v1.28.0 wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.28.1] - 2026-04-19
+
+Recovery patch — lands 8 P2 audit fixes that were silently lost in the v1.28.0 wave's parallel-agent dispatch. The v1.28.0 CHANGELOG advertised them as landed; they were stubbed with `TODO(P2 #N)` markers (and in three cases, only existed in the in-memory `Chunk` struct without the corresponding store/schema half). Audit caught the gaps post-release. No data loss for users on v1.28.0 — schema migration is automatic on first open.
+
+### Fixed
+
+- **Schema v21 migration** with `parser_version` column on chunks (P2 #29). Closes the silent-skip-on-incremental-reindex regression class — chunks with new parser-version output now refresh on `cqs index` instead of being passed-through by the content-hash UPSERT filter. `batch_insert_chunks` and `upsert_fts_conditional` UPDATE-WHERE clauses now refresh on either `content_hash != excluded` OR `parser_version != excluded`.
+- **HNSW backup `?` propagation** (P2 #30). `std::fs::rename` failure during the backup pass no longer warn-and-continues — the atomic_replace pass never starts on a missing-backup file, so the rollback path can always restore the original.
+- **`prune_all` Phase 1 TOCTOU** (P2 #32). The distinct-origin scan moved INSIDE the Phase 2 write transaction. Closes the race against concurrent `cqs watch` reindex.
+- **`default_readonly_pooled_config` helper** (P2 #42). Both `Store::open_readonly_pooled` variants now delegate to one shared config builder — no more drift on `mmap_size` / `cache_size` / `max_connections` defaults.
+- **`Store::upsert_function_calls_for_files`** batched writes (P2 #64). Indexing pipeline now batches all per-file `function_calls` writes into one transaction (was N transactions for N files).
+- **`get_type_users` / `get_types_used_by` SQL `LIMIT`** (P2 #65). Both queries now `LIMIT ?` at SQL instead of fetching all rows and truncating at the CLI. CLI consumers in `cli/commands/graph/deps.rs` pass the user limit through.
+- **`LanguageDef::line_comment_prefixes`** field (P2 #53). `line_looks_comment_like` now consults the per-language prefix list (was a hardcoded global union with `lang` arg ignored). Adding a language with new comment syntax now wires up the chunker doc fallback automatically.
+- **`LanguageDef::aliases`** field (P2 #55). `parser/markdown/code_blocks.rs::FENCED_LANG_ALIASES` now derives from `REGISTRY.all()` (was a 75-line hand-maintained static table). Adding a new fenced-block alias is one row in `languages.rs` instead of two.
+
+### Migration notes
+
+- Users on v1.28.0 will see schema migrate v20 → v21 on first open. Migration is in-place, adds `parser_version INTEGER NOT NULL DEFAULT 0` to the `chunks` table. No reindex required, but a follow-up `cqs index --force` will let the chunker doc-fallback fix from PR #1040 / v1.28.0 actually take effect on previously-indexed short chunks (since their `parser_version` is now 0 and any future bump would force re-extraction).
+
 ## [1.28.0] - 2026-04-19
 
 The "post-audit" release — closes the post-v1.27.0 16-category audit (150 findings landed across PRs #1041 / #1045 / #1046; 6 hard-deferred items filed as issues #1042-#1044, #1047-#1049). Plus the chunker doc-fallback retrieval lift, uniform JSON envelope across all CLI/batch/daemon-socket commands, and a v21 schema migration.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.28.0"
+version = "1.28.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "1.28.0"
+version = "1.28.1"
 edition = "2021"
 rust-version = "1.95"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 91% R@1 on 296-query fixtures, 42% R@1 / 64% R@5 / 79% R@20 on v3 real code-search (544 dual-judge queries). Daemon mode (3-19ms queries). Local-first, GPU-accelerated."

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -37,13 +37,12 @@ pub(in crate::cli::batch) fn dispatch_deps(
     let limit = limit.clamp(1, 100);
 
     if reverse {
-        let mut types = ctx.store().get_types_used_by(name)?;
-        types.truncate(limit);
+        // P2 #65: bind the limit at SQL time.
+        let types = ctx.store().get_types_used_by(name, limit)?;
         let output = crate::cli::commands::build_deps_reverse(name, &types);
         Ok(serde_json::to_value(&output)?)
     } else {
-        let mut users = ctx.store().get_type_users(name)?;
-        users.truncate(limit);
+        let users = ctx.store().get_type_users(name, limit)?;
         let output = crate::cli::commands::build_deps_forward(&users, &ctx.root);
         Ok(serde_json::to_value(&output)?)
     }

--- a/src/cli/commands/graph/deps.rs
+++ b/src/cli/commands/graph/deps.rs
@@ -89,10 +89,11 @@ pub(crate) fn cmd_deps(
     let limit = limit.clamp(1, 100);
 
     if reverse {
-        let mut types = store
-            .get_types_used_by(name)
+        // P2 #65: limit at SQL time so we don't fetch every edge of a popular
+        // function just to drop the tail.
+        let types = store
+            .get_types_used_by(name, limit)
             .context("Failed to load type dependencies")?;
-        types.truncate(limit);
         if json {
             let output = build_deps_reverse(name, &types);
             crate::cli::json_envelope::emit_json(&output)?;
@@ -112,10 +113,10 @@ pub(crate) fn cmd_deps(
             println!("Total: {} type(s)", types.len());
         }
     } else {
-        let mut users = store
-            .get_type_users(name)
+        // P2 #65: limit at SQL time. Same shape as the reverse branch above.
+        let users = store
+            .get_type_users(name, limit)
             .context("Failed to load type users")?;
-        users.truncate(limit);
         if json {
             let output = build_deps_forward(&users, root);
             crate::cli::json_envelope::emit_json(&output)?;

--- a/src/cli/commands/io/blame.rs
+++ b/src/cli/commands/io/blame.rs
@@ -388,6 +388,7 @@ mod tests {
                 parent_type_name: None,
                 content_hash: String::new(),
                 window_idx: None,
+                parser_version: 0,
             },
             commits: vec![BlameEntry {
                 hash: "abc1234".to_string(),
@@ -435,6 +436,7 @@ mod tests {
                 parent_type_name: None,
                 content_hash: String::new(),
                 window_idx: None,
+                parser_version: 0,
             },
             commits: vec![],
             callers: vec![],

--- a/src/cli/commands/io/context.rs
+++ b/src/cli/commands/io/context.rs
@@ -599,6 +599,7 @@ mod tests {
             window_idx: None,
             parent_id: None,
             parent_type_name: None,
+            parser_version: 0,
         }
     }
 

--- a/src/cli/commands/io/read.rs
+++ b/src/cli/commands/io/read.rs
@@ -200,8 +200,11 @@ pub(crate) fn build_focused_output<Mode>(
     output.push_str(&chunk.content);
     output.push('\n');
 
-    // Type dependencies
-    let type_deps = match store.get_types_used_by(&chunk.name) {
+    // Type dependencies.
+    // P2 #65: usize::MAX preserves existing "all rows" behaviour. The display
+    // path filters by COMMON_TYPES then truncates inline downstream.
+    // TODO: cap at e.g. 50 once we measure typical edge count per chunk.
+    let type_deps = match store.get_types_used_by(&chunk.name, usize::MAX) {
         Ok(pairs) => pairs,
         Err(e) => {
             tracing::warn!(function = %chunk.name, error = %e, "Failed to query type deps");

--- a/src/cli/commands/io/reconstruct.rs
+++ b/src/cli/commands/io/reconstruct.rs
@@ -109,6 +109,7 @@ mod tests {
             parent_type_name: None,
             content_hash: String::new(),
             window_idx: None,
+            parser_version: 0,
         }
     }
 

--- a/src/cli/commands/train/train_pairs.rs
+++ b/src/cli/commands/train/train_pairs.rs
@@ -191,6 +191,7 @@ mod tests {
             parent_type_name: None,
             content_hash: format!("hash_{}", name),
             window_idx: None,
+            parser_version: 0,
         }
     }
 

--- a/src/cli/display.rs
+++ b/src/cli/display.rs
@@ -671,6 +671,7 @@ mod tests {
                 parent_type_name: None,
                 content_hash: String::new(),
                 window_idx: None,
+                parser_version: 0,
             },
             score,
         }

--- a/src/cli/pipeline/upsert.rs
+++ b/src/cli/pipeline/upsert.rs
@@ -148,16 +148,27 @@ pub(super) fn store_stage(
             }
         }
 
-        // Store function calls extracted during parsing (for the `function_calls` table)
-        for (file, function_calls) in &batch.relationships.function_calls {
-            for fc in function_calls {
+        // Store function calls extracted during parsing (for the `function_calls` table).
+        //
+        // P2 #64 (recovery wave): defer-and-batch like type edges. The previous
+        // per-file `upsert_function_calls` opened one transaction per file —
+        // 2,500 BEGIN/COMMIT round-trips on a typical wire. Collect every
+        // (file, calls) tuple first, then a single batched call writes them
+        // all in one transaction.
+        let mut function_call_entries: Vec<(PathBuf, Vec<cqs::parser::FunctionCalls>)> =
+            Vec::with_capacity(batch.relationships.function_calls.len());
+        for (file, function_calls) in batch.relationships.function_calls {
+            for fc in &function_calls {
                 total_calls += fc.calls.len();
             }
-            if let Err(e) = store.upsert_function_calls(file, function_calls) {
+            function_call_entries.push((file, function_calls));
+        }
+        if !function_call_entries.is_empty() {
+            if let Err(e) = store.upsert_function_calls_for_files(&function_call_entries) {
                 tracing::warn!(
-                    file = %file.display(),
+                    files = function_call_entries.len(),
                     error = %e,
-                    "Failed to store function calls"
+                    "Failed to store batched function calls"
                 );
             }
         }

--- a/src/hnsw/persist.rs
+++ b/src/hnsw/persist.rs
@@ -403,18 +403,26 @@ impl HnswIndex {
         let mut moved_exts: Vec<&str> = Vec::new();
 
         let rename_result: Result<(), HnswError> = (|| {
-            // Back up existing files before overwriting so rollback can restore them
+            // Back up existing files before overwriting so rollback can restore them.
+            //
+            // P2 #30: propagate the rename error instead of warning-and-continuing.
+            // If the backup never landed, the rollback path further down can't
+            // restore the original file when atomic_replace later fails — we'd
+            // delete the (newly promoted) file in `moved_exts` then look for a
+            // `.bak` that was never created and silently lose the prior index.
+            // Better to bail BEFORE the atomic_replace pass touches anything.
             for ext in &all_exts {
                 let final_path = dir.join(format!("{}.{}", basename, ext));
                 let bak_path = dir.join(format!("{}.{}.bak", basename, ext));
                 if final_path.exists() {
-                    if let Err(e) = std::fs::rename(&final_path, &bak_path) {
-                        tracing::warn!(
-                            path = %final_path.display(),
-                            error = %e,
-                            "Failed to back up existing HNSW file before save"
-                        );
-                    }
+                    std::fs::rename(&final_path, &bak_path).map_err(|e| {
+                        HnswError::Internal(format!(
+                            "Failed to back up {} -> {} before save: {}",
+                            final_path.display(),
+                            bak_path.display(),
+                            e
+                        ))
+                    })?;
                 }
             }
 
@@ -1200,6 +1208,69 @@ mod tests {
         assert!(
             enriched.is_none(),
             "enriched should return None when only index_base files exist"
+        );
+    }
+
+    /// P2 #30 (recovery wave): a backup-rename failure during save MUST bubble
+    /// up rather than being warning-and-continued. The previous behaviour swallowed
+    /// the error, then the rollback path couldn't restore the original file because
+    /// no `.bak` had ever been created — silently losing the prior index.
+    ///
+    /// Force the failure by pre-creating a `.bak` path as a non-empty directory
+    /// (Linux `rename(file, dir)` returns EISDIR / ENOTDIR depending on kernel,
+    /// either way an error). The save must surface that error and leave the
+    /// original `index.hnsw.*` files untouched.
+    #[cfg(unix)]
+    #[test]
+    fn test_save_propagates_backup_rename_failure() {
+        let tmp = TempDir::new().unwrap();
+
+        // Build + save a valid index so the directory has the v1 files.
+        let embeddings: Vec<(String, crate::embedder::Embedding)> = (1..=5)
+            .map(|i| (format!("vec{}", i), make_embedding(i)))
+            .collect();
+        let v1 = HnswIndex::build_with_dim(embeddings.clone(), crate::EMBEDDING_DIM).unwrap();
+        v1.save(tmp.path(), "index").unwrap();
+
+        // Snapshot the v1 graph file size so we can detect post-failure damage.
+        let graph_path = tmp.path().join("index.hnsw.graph");
+        let v1_graph_size = std::fs::metadata(&graph_path).unwrap().len();
+        assert!(
+            v1_graph_size > 0,
+            "v1 graph file should be non-empty after first save"
+        );
+
+        // Pre-create a non-empty directory at the `.bak` path for one of the
+        // extensions. `std::fs::rename(file, non_empty_dir)` fails with
+        // ENOTDIR/EISDIR on Linux, exercising the backup-rename error branch.
+        let bak_blocker = tmp.path().join("index.hnsw.graph.bak");
+        std::fs::create_dir(&bak_blocker).unwrap();
+        // Put a file inside so the rename can't succeed by replacing an empty dir.
+        std::fs::write(bak_blocker.join("blocker"), b"x").unwrap();
+
+        // Attempt a second save with a different (still valid) embeddings set.
+        let v2_embeddings: Vec<(String, crate::embedder::Embedding)> = (1..=8)
+            .map(|i| (format!("vec{}", i + 100), make_embedding(i + 100)))
+            .collect();
+        let v2 = HnswIndex::build_with_dim(v2_embeddings, crate::EMBEDDING_DIM).unwrap();
+
+        let result = v2.save(tmp.path(), "index");
+        assert!(
+            result.is_err(),
+            "save MUST surface the backup-rename failure (P2 #30)"
+        );
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("back up") || err_msg.contains("backup"),
+            "error should mention backup failure, got: {}",
+            err_msg
+        );
+
+        // Original v1 graph file MUST still be intact and the same size.
+        let post_size = std::fs::metadata(&graph_path).unwrap().len();
+        assert_eq!(
+            post_size, v1_graph_size,
+            "original index file must not be touched when save bails on backup failure"
         );
     }
 }

--- a/src/impact/analysis.rs
+++ b/src/impact/analysis.rs
@@ -423,7 +423,12 @@ fn find_type_impacted<Mode>(
 ) -> Result<Vec<TypeImpacted>, StoreError> {
     let _span = tracing::info_span!("find_type_impacted", target = target_name).entered();
 
-    let type_pairs = store.get_types_used_by(target_name)?;
+    // P2 #65: usize::MAX to preserve existing semantics. The type set is
+    // filtered by COMMON_TYPES + deduped, then drives a fan-out type-users
+    // query — capping here would silently truncate the impact graph.
+    // TODO: consider a per-target ceiling (~200) once we measure typical
+    // edge counts at the impact-target level.
+    let type_pairs = store.get_types_used_by(target_name, usize::MAX)?;
     let type_names: Vec<String> = type_pairs
         .into_iter()
         .map(|t| t.type_name)
@@ -566,6 +571,7 @@ mod tests {
                 parent_type_name: None,
                 content_hash: String::new(),
                 window_idx: None,
+                parser_version: 0,
             },
             ChunkSummary {
                 id: "2".into(),
@@ -582,6 +588,7 @@ mod tests {
                 parent_type_name: None,
                 content_hash: String::new(),
                 window_idx: None,
+                parser_version: 0,
             },
         ];
 

--- a/src/impact/diff.rs
+++ b/src/impact/diff.rs
@@ -330,6 +330,7 @@ mod tests {
             parent_type_name: None,
             content_hash: String::new(),
             window_idx: None,
+            parser_version: 0,
         }
     }
 

--- a/src/impact/hints.rs
+++ b/src/impact/hints.rs
@@ -313,6 +313,7 @@ mod tests {
             parent_type_name: None,
             content_hash: String::new(),
             window_idx: None,
+            parser_version: 0,
         }];
         let hints = compute_hints_with_graph(&graph, &test_chunks, "target", None);
         assert_eq!(hints.test_count, 0, "Unreachable test should not count");
@@ -375,6 +376,7 @@ mod tests {
             parent_type_name: None,
             content_hash: String::new(),
             window_idx: None,
+            parser_version: 0,
         }];
         let scores = compute_risk_batch(&["target"], &graph, &test_chunks);
         assert_eq!(scores[0].risk_level, RiskLevel::Low);
@@ -425,6 +427,7 @@ mod tests {
                 parent_type_name: None,
                 content_hash: String::new(),
                 window_idx: None,
+                parser_version: 0,
             },
             crate::store::ChunkSummary {
                 id: "t2".to_string(),
@@ -441,6 +444,7 @@ mod tests {
                 parent_type_name: None,
                 content_hash: String::new(),
                 window_idx: None,
+                parser_version: 0,
             },
             crate::store::ChunkSummary {
                 id: "t3".to_string(),
@@ -457,6 +461,7 @@ mod tests {
                 parent_type_name: None,
                 content_hash: String::new(),
                 window_idx: None,
+                parser_version: 0,
             },
         ];
         let scores = compute_risk_batch(&["target"], &graph, &test_chunks);
@@ -535,6 +540,7 @@ mod tests {
             parent_type_name: None,
             content_hash: String::new(),
             window_idx: None,
+            parser_version: 0,
         }];
 
         let scores = compute_risk_batch(&["target"], &graph, &test_chunks);
@@ -633,6 +639,7 @@ mod tests {
             parent_type_name: None,
             content_hash: String::new(),
             window_idx: None,
+            parser_version: 0,
         }];
         let scores = compute_risk_batch(&["target"], &graph, &test_chunks);
         assert_eq!(scores[0].risk_level, RiskLevel::Low);

--- a/src/impact/test_map.rs
+++ b/src/impact/test_map.rs
@@ -114,6 +114,7 @@ mod tests {
             window_idx: None,
             parent_id: None,
             parent_type_name: None,
+            parser_version: 0,
         }
     }
 

--- a/src/language/languages.rs
+++ b/src/language/languages.rs
@@ -62,6 +62,8 @@ const DEFAULTS: LanguageDef = LanguageDef {
     function_keywords: &[],
     receiver_strip: None,
     patterns: None,
+    line_comment_prefixes: &[],
+    aliases: &[],
 };
 
 /// Strip a Go method receiver from the line tail after `func ` has been consumed.
@@ -97,6 +99,8 @@ static LANG_BASH: LanguageDef = LanguageDef {
     post_process_chunk: Some(post_process_bash_bash as PostProcessChunkFn),
     function_keywords: &["function"],
     patterns: Some(&patterns_data::BASH),
+    line_comment_prefixes: &["#"],
+    aliases: &["sh", "shell", "zsh"],
     ..DEFAULTS
 };
 
@@ -199,6 +203,7 @@ static LANG_C: LanguageDef = LanguageDef {
     unsafe_markers: &["memcpy", "strcpy", "sprintf", "gets("],
     // C uses `returnType name()` syntax — no fixed function-introducer keyword.
     patterns: Some(&patterns_data::C),
+    line_comment_prefixes: &["//", "/*"],
     ..DEFAULTS
 };
 
@@ -495,6 +500,8 @@ static LANG_CPP: LanguageDef = LanguageDef {
     skip_line_prefixes: &["class ", "struct ", "union ", "enum ", "template"],
     // C++ uses `returnType name()` syntax — no fixed function-introducer keyword.
     patterns: Some(&patterns_data::CPP_LIKE),
+    line_comment_prefixes: &["//", "/*"],
+    aliases: &["c++", "cxx"],
     ..DEFAULTS
 };
 
@@ -745,6 +752,8 @@ static LANG_CSHARP: LanguageDef = LanguageDef {
     skip_line_prefixes: &["class ", "struct ", "interface ", "enum ", "record "],
     // C# uses `returnType name()` syntax — no fixed function-introducer keyword.
     patterns: Some(&patterns_data::DOTNET),
+    line_comment_prefixes: &["//", "/*"],
+    aliases: &["cs", "c#"],
     ..DEFAULTS
 };
 
@@ -844,6 +853,7 @@ static LANG_CSS: LanguageDef = LanguageDef {
     ],
     extract_return_nl: extract_return_css,
     post_process_chunk: Some(post_process_css_css as PostProcessChunkFn),
+    line_comment_prefixes: &["/*"],
     ..DEFAULTS
 };
 
@@ -1043,6 +1053,8 @@ static LANG_CUDA: LanguageDef = LanguageDef {
     post_process_chunk: Some(post_process_cuda_cuda as PostProcessChunkFn),
     // CUDA uses C++ syntax — no fixed function-introducer keyword.
     patterns: Some(&patterns_data::CPP_LIKE),
+    line_comment_prefixes: &["//", "/*"],
+    aliases: &["cu"],
     ..DEFAULTS
 };
 
@@ -1154,6 +1166,7 @@ static LANG_DART: LanguageDef = LanguageDef {
     },
     extract_return_nl: extract_return_dart,
     post_process_chunk: Some(post_process_dart_dart as PostProcessChunkFn),
+    line_comment_prefixes: &["//", "/*"],
     ..DEFAULTS
 };
 
@@ -1403,6 +1416,8 @@ static LANG_ELIXIR: LanguageDef = LanguageDef {
     skip_line_prefixes: &["defmodule", "defstruct"],
     function_keywords: &["def", "defp", "defmacro", "defmacrop"],
     patterns: Some(&patterns_data::ELIXIR),
+    line_comment_prefixes: &["#"],
+    aliases: &["ex"],
     ..DEFAULTS
 };
 
@@ -1425,6 +1440,7 @@ static LANG_ELM: LanguageDef = LanguageDef {
         "module", "import", "exposing", "type", "alias", "port", "let", "in", "case", "of", "if",
         "then", "else", "as", "where",
     ],
+    line_comment_prefixes: &["--"],
     ..DEFAULTS
 };
 
@@ -1559,6 +1575,8 @@ static LANG_ERLANG: LanguageDef = LanguageDef {
     skip_line_prefixes: &["-record"],
     // Erlang functions: `name(Args) -> ...` — no introducer keyword.
     patterns: Some(&patterns_data::ERLANG),
+    line_comment_prefixes: &["%"],
+    aliases: &["erl"],
     ..DEFAULTS
 };
 
@@ -1737,6 +1755,8 @@ static LANG_FSHARP: LanguageDef = LanguageDef {
     post_process_chunk: Some(post_process_fsharp_fsharp as PostProcessChunkFn),
     function_keywords: &["let", "member"],
     patterns: Some(&patterns_data::DOTNET),
+    line_comment_prefixes: &["//", "(*"],
+    aliases: &["fs", "f#"],
     ..DEFAULTS
 };
 
@@ -1868,6 +1888,7 @@ static LANG_GLEAM: LanguageDef = LanguageDef {
     skip_line_prefixes: &["type ", "pub type"],
     function_keywords: &["fn"],
     patterns: Some(&patterns_data::GLEAM),
+    line_comment_prefixes: &["//"],
     ..DEFAULTS
 };
 
@@ -2034,6 +2055,7 @@ static LANG_GLSL: LanguageDef = LanguageDef {
     skip_line_prefixes: &["struct "],
     // GLSL uses C-style `returnType name()` syntax — no introducer keyword.
     patterns: Some(&patterns_data::CPP_LIKE),
+    line_comment_prefixes: &["//", "/*"],
     ..DEFAULTS
 };
 
@@ -2214,6 +2236,8 @@ static LANG_GO: LanguageDef = LanguageDef {
     receiver_strip: Some(strip_go_receiver),
     // Go has custom logic in `where_to_add::extract_patterns`
     // (uppercase-name = exported), so `patterns` is None.
+    line_comment_prefixes: &["//", "/*"],
+    aliases: &["golang"],
     ..DEFAULTS
 };
 
@@ -2259,6 +2283,8 @@ static LANG_GRAPHQL: LanguageDef = LanguageDef {
         strip_prefixes: "",
     },
     skip_line_prefixes: &["type ", "input ", "interface ", "enum "],
+    line_comment_prefixes: &["#"],
+    aliases: &["gql"],
     ..DEFAULTS
 };
 
@@ -2427,6 +2453,8 @@ static LANG_HASKELL: LanguageDef = LanguageDef {
     // the line prefix. The C-family heuristic also doesn't fit (no parens
     // for nullary), but a `where` block can have indented function defs.
     patterns: Some(&patterns_data::HASKELL),
+    line_comment_prefixes: &["--"],
+    aliases: &["hs"],
     ..DEFAULTS
 };
 
@@ -2632,6 +2660,8 @@ static LANG_HCL: LanguageDef = LanguageDef {
             content_scoped_lines: false,
         },
     ],
+    line_comment_prefixes: &["#", "//", "/*"],
+    aliases: &["terraform", "tf"],
     ..DEFAULTS
 };
 
@@ -2947,6 +2977,7 @@ static LANG_HTML: LanguageDef = LanguageDef {
             content_scoped_lines: false,
         },
     ],
+    line_comment_prefixes: &["<!--"],
     ..DEFAULTS
 };
 
@@ -2977,6 +3008,7 @@ static LANG_INI: LanguageDef = LanguageDef {
     doc_nodes: &["comment"],
     stopwords: &["true", "false", "yes", "no", "on", "off"],
     extract_return_nl: extract_return_ini,
+    line_comment_prefixes: &[";", "#"],
     ..DEFAULTS
 };
 
@@ -3193,6 +3225,7 @@ static LANG_JAVA: LanguageDef = LanguageDef {
     ],
     // Java uses `returnType name()` syntax — no introducer keyword.
     patterns: Some(&patterns_data::JAVA),
+    line_comment_prefixes: &["//", "/*"],
     ..DEFAULTS
 };
 
@@ -3337,6 +3370,8 @@ static LANG_JAVASCRIPT: LanguageDef = LanguageDef {
     // both use the same surface syntax for async / catch / await.
     error_swallow_patterns: &["catch (e) {}", "catch {}", "// ignore"],
     async_markers: &["async ", "await "],
+    line_comment_prefixes: &["//", "/*"],
+    aliases: &["js"],
     ..DEFAULTS
 };
 
@@ -3387,6 +3422,8 @@ static LANG_JSON: LanguageDef = LanguageDef {
     stopwords: &["true", "false", "null"],
     extract_return_nl: extract_return_json,
     post_process_chunk: Some(post_process_json_json),
+    line_comment_prefixes: &["//", "/*"],
+    aliases: &["jsonc"],
     ..DEFAULTS
 };
 
@@ -3555,6 +3592,8 @@ static LANG_JULIA: LanguageDef = LanguageDef {
     skip_line_prefixes: &["struct ", "mutable struct"],
     function_keywords: &["function"],
     patterns: Some(&patterns_data::JULIA),
+    line_comment_prefixes: &["#"],
+    aliases: &["jl"],
     ..DEFAULTS
 };
 
@@ -3795,6 +3834,8 @@ static LANG_KOTLIN: LanguageDef = LanguageDef {
     ],
     function_keywords: &["fun"],
     patterns: Some(&patterns_data::JVM),
+    line_comment_prefixes: &["//", "/*"],
+    aliases: &["kt"],
     ..DEFAULTS
 };
 
@@ -3974,6 +4015,8 @@ static LANG_LATEX: LanguageDef = LanguageDef {
             content_scoped_lines: false,
         },
     ],
+    line_comment_prefixes: &["%"],
+    aliases: &["tex"],
     ..DEFAULTS
 };
 
@@ -4139,6 +4182,7 @@ static LANG_LUA: LanguageDef = LanguageDef {
     },
     function_keywords: &["function"],
     patterns: Some(&patterns_data::LUA),
+    line_comment_prefixes: &["--"],
     ..DEFAULTS
 };
 
@@ -4204,6 +4248,8 @@ static LANG_MAKE: LanguageDef = LanguageDef {
         detect_language: None,
         content_scoped_lines: false,
     }],
+    line_comment_prefixes: &["#"],
+    aliases: &["makefile"],
     ..DEFAULTS
 };
 
@@ -4291,6 +4337,8 @@ static LANG_MARKDOWN: LanguageDef = LanguageDef {
         "figure",
         "table",
     ],
+    line_comment_prefixes: &["<!--"],
+    aliases: &["md"],
     ..DEFAULTS
 };
 
@@ -4401,6 +4449,7 @@ static LANG_NIX: LanguageDef = LanguageDef {
             content_scoped_lines: false,
         },
     ],
+    line_comment_prefixes: &["#", "/*"],
     ..DEFAULTS
 };
 
@@ -4553,6 +4602,8 @@ static LANG_OBJC: LanguageDef = LanguageDef {
     // Objective-C method declarations use `- (Type)name:`. The C-family
     // `name(` heuristic doesn't fit cleanly; leave function_keywords empty.
     patterns: Some(&patterns_data::CPP_LIKE),
+    line_comment_prefixes: &["//", "/*"],
+    aliases: &["objective-c", "objectivec"],
     ..DEFAULTS
 };
 
@@ -4715,6 +4766,8 @@ static LANG_OCAML: LanguageDef = LanguageDef {
     skip_line_prefixes: &["type "],
     function_keywords: &["let"],
     patterns: Some(&patterns_data::OCAML),
+    line_comment_prefixes: &["(*"],
+    aliases: &["ml"],
     ..DEFAULTS
 };
 
@@ -4802,6 +4855,8 @@ static LANG_PERL: LanguageDef = LanguageDef {
     },
     function_keywords: &["sub"],
     patterns: Some(&patterns_data::PERL),
+    line_comment_prefixes: &["#"],
+    aliases: &["pl"],
     ..DEFAULTS
 };
 
@@ -5012,6 +5067,7 @@ static LANG_PHP: LanguageDef = LanguageDef {
     skip_line_prefixes: &["class ", "interface ", "trait ", "enum "],
     function_keywords: &["function"],
     patterns: Some(&patterns_data::PHP),
+    line_comment_prefixes: &["//", "#", "/*"],
     ..DEFAULTS
 };
 
@@ -5122,6 +5178,8 @@ static LANG_POWERSHELL: LanguageDef = LanguageDef {
     post_process_chunk: Some(post_process_powershell_powershell as PostProcessChunkFn),
     function_keywords: &["function"],
     patterns: Some(&patterns_data::POWERSHELL),
+    line_comment_prefixes: &["#", "<#"],
+    aliases: &["ps1", "pwsh"],
     ..DEFAULTS
 };
 
@@ -5182,6 +5240,8 @@ static LANG_PROTOBUF: LanguageDef = LanguageDef {
         strip_prefixes: "optional repeated required",
     },
     skip_line_prefixes: &["message ", "enum ", "service "],
+    line_comment_prefixes: &["//", "/*"],
+    aliases: &["proto"],
     ..DEFAULTS
 };
 
@@ -5399,6 +5459,8 @@ static LANG_PYTHON: LanguageDef = LanguageDef {
     mutex_markers: &["Lock()", "threading.Lock"],
     function_keywords: &["def"],
     patterns: Some(&patterns_data::PYTHON),
+    line_comment_prefixes: &["#"],
+    aliases: &["py"],
     ..DEFAULTS
 };
 
@@ -5609,6 +5671,7 @@ static LANG_R: LanguageDef = LanguageDef {
     // line prefix. Method names are extracted via the C-family heuristic
     // (which is loose for R) — leave function_keywords empty.
     patterns: Some(&patterns_data::R_LANG),
+    line_comment_prefixes: &["#"],
     ..DEFAULTS
 };
 
@@ -5981,6 +6044,8 @@ static LANG_RAZOR: LanguageDef = LanguageDef {
     ],
     // Razor uses C# syntax — no introducer keyword.
     patterns: Some(&patterns_data::DOTNET),
+    line_comment_prefixes: &["@*", "<!--", "//"],
+    aliases: &["cshtml"],
     ..DEFAULTS
 };
 
@@ -6070,6 +6135,8 @@ static LANG_RUBY: LanguageDef = LanguageDef {
     post_process_chunk: Some(post_process_ruby_ruby as PostProcessChunkFn),
     function_keywords: &["def"],
     patterns: Some(&patterns_data::RUBY),
+    line_comment_prefixes: &["#"],
+    aliases: &["rb"],
     ..DEFAULTS
 };
 
@@ -6357,6 +6424,7 @@ static LANG_RUST: LanguageDef = LanguageDef {
     function_keywords: &["fn"],
     // Rust has custom logic in `where_to_add::extract_patterns`
     // (3-way pub(crate)/pub/private + anyhow vs thiserror), so `patterns: None`.
+    line_comment_prefixes: &["//", "/*"],
     ..DEFAULTS
 };
 
@@ -6464,6 +6532,7 @@ static LANG_SCALA: LanguageDef = LanguageDef {
     post_process_chunk: Some(post_process_scala_scala as PostProcessChunkFn),
     function_keywords: &["def"],
     patterns: Some(&patterns_data::JVM),
+    line_comment_prefixes: &["//", "/*"],
     ..DEFAULTS
 };
 
@@ -6584,6 +6653,8 @@ static LANG_SOLIDITY: LanguageDef = LanguageDef {
     post_process_chunk: Some(post_process_solidity_solidity as PostProcessChunkFn),
     function_keywords: &["function"],
     patterns: Some(&patterns_data::SOLIDITY),
+    line_comment_prefixes: &["//", "/*"],
+    aliases: &["sol"],
     ..DEFAULTS
 };
 
@@ -6704,6 +6775,7 @@ static LANG_SQL: LanguageDef = LanguageDef {
         "replace",
     ],
     extract_return_nl: extract_return_sql,
+    line_comment_prefixes: &["--", "/*"],
     ..DEFAULTS
 };
 
@@ -6835,6 +6907,8 @@ static LANG_STRUCTURED_TEXT: LanguageDef = LanguageDef {
         "END_PROGRAM",
     ],
     function_keywords: &["FUNCTION", "FUNCTION_BLOCK", "METHOD"],
+    line_comment_prefixes: &["(*", "//"],
+    aliases: &["st", "stl", "iec61131", "iec-st"],
     ..DEFAULTS
 };
 
@@ -7054,6 +7128,7 @@ static LANG_SVELTE: LanguageDef = LanguageDef {
             content_scoped_lines: false,
         },
     ],
+    line_comment_prefixes: &["<!--"],
     ..DEFAULTS
 };
 
@@ -7283,6 +7358,7 @@ static LANG_SWIFT: LanguageDef = LanguageDef {
     skip_line_prefixes: &["class ", "struct ", "enum ", "protocol "],
     function_keywords: &["func"],
     patterns: Some(&patterns_data::SWIFT),
+    line_comment_prefixes: &["//", "/*"],
     ..DEFAULTS
 };
 
@@ -7338,6 +7414,7 @@ static LANG_TOML: LanguageDef = LanguageDef {
     stopwords: &["true", "false"],
     extract_return_nl: extract_return_toml,
     post_process_chunk: Some(post_process_toml_toml),
+    line_comment_prefixes: &["#"],
     ..DEFAULTS
 };
 
@@ -7523,6 +7600,8 @@ static LANG_TYPESCRIPT: LanguageDef = LanguageDef {
     // TS has custom logic in `where_to_add::extract_patterns` (require()
     // import match + module-private vs export). Methods are bare `name(`
     // — no introducer keyword.
+    line_comment_prefixes: &["//", "/*"],
+    aliases: &["ts"],
     ..DEFAULTS
 };
 
@@ -7798,6 +7877,8 @@ static LANG_VBNET: LanguageDef = LanguageDef {
     skip_line_prefixes: &["Class ", "Structure ", "Interface ", "Enum "],
     function_keywords: &["Sub", "Function"],
     patterns: Some(&patterns_data::DOTNET),
+    line_comment_prefixes: &["'", "REM "],
+    aliases: &["vb", "vb.net"],
     ..DEFAULTS
 };
 
@@ -8032,6 +8113,7 @@ static LANG_VUE: LanguageDef = LanguageDef {
             content_scoped_lines: false,
         },
     ],
+    line_comment_prefixes: &["<!--"],
     ..DEFAULTS
 };
 
@@ -8107,6 +8189,8 @@ static LANG_XML: LanguageDef = LanguageDef {
     ],
     extract_return_nl: extract_return_xml,
     post_process_chunk: Some(post_process_xml_xml),
+    line_comment_prefixes: &["<!--"],
+    aliases: &["svg", "xsl"],
     ..DEFAULTS
 };
 
@@ -8162,6 +8246,8 @@ static LANG_YAML: LanguageDef = LanguageDef {
     stopwords: &["true", "false", "null", "yes", "no", "on", "off"],
     extract_return_nl: extract_return_yaml,
     post_process_chunk: Some(post_process_yaml_yaml),
+    line_comment_prefixes: &["#"],
+    aliases: &["yml"],
     ..DEFAULTS
 };
 
@@ -8366,6 +8452,7 @@ static LANG_ZIG: LanguageDef = LanguageDef {
     skip_line_prefixes: &["const ", "pub const"],
     function_keywords: &["fn"],
     patterns: Some(&patterns_data::ZIG),
+    line_comment_prefixes: &["//"],
     ..DEFAULTS
 };
 
@@ -8410,6 +8497,8 @@ static LANG_ASPX: LanguageDef = LanguageDef {
     custom_all_parser: Some(crate::parser::aspx::parse_aspx_all),
     // ASPX wraps C# / VB.NET — dispatch to .NET pattern defaults.
     patterns: Some(&patterns_data::DOTNET),
+    line_comment_prefixes: &["<%--", "<!--", "//"],
+    aliases: &["ascx", "asmx", "webforms"],
     ..DEFAULTS
 };
 

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -431,6 +431,21 @@ pub struct LanguageDef {
     /// Adding `Some(&LANG_PATTERNS)` here exposes a new language to the
     /// data-driven pattern extractor automatically.
     pub patterns: Option<&'static crate::where_to_add::LanguagePatternDef>,
+    /// Per-language line-comment prefixes consumed by
+    /// `parser::chunk::line_looks_comment_like`. The first matching prefix
+    /// classifies a line as comment-like for the doc-fallback walk.
+    /// Empty `&[]` falls back to a conservative global union of common comment
+    /// sigils (`//`, `--`, `/*`, `*/`, `<!--`, `<%--`, `(*` plus `#` and `*`
+    /// when followed by a separator). Populate per-language to give precision
+    /// to languages with non-default comment syntax (Lisp `;`, Erlang `%`, …).
+    pub line_comment_prefixes: &'static [&'static str],
+    /// Markdown fenced code block aliases. Used by
+    /// `parser::markdown::code_blocks::normalize_lang` to map fence tags
+    /// (e.g., `py`, `golang`, `c++`) to canonical language names. Empty `&[]`
+    /// means the language is recognised only under its canonical `name`.
+    /// Populate per-language to teach the markdown parser which tags resolve
+    /// to this language.
+    pub aliases: &'static [&'static str],
 }
 
 /// Helper: PascalCase test name from a base function name with a given prefix.

--- a/src/llm/doc_comments.rs
+++ b/src/llm/doc_comments.rs
@@ -356,6 +356,7 @@ mod tests {
             window_idx,
             parent_id: None,
             parent_type_name: None,
+            parser_version: 0,
         }
     }
 
@@ -375,6 +376,7 @@ mod tests {
             window_idx: None,
             parent_id: None,
             parent_type_name: None,
+            parser_version: 0,
         }
     }
 

--- a/src/llm/summary.rs
+++ b/src/llm/summary.rs
@@ -319,6 +319,7 @@ mod tests {
             parent_type_name: None,
             content_hash: content_hash.to_string(),
             window_idx,
+            parser_version: 0,
         }
     }
 

--- a/src/onboard.rs
+++ b/src/onboard.rs
@@ -212,7 +212,13 @@ pub fn onboard<Mode>(
     let callers: Vec<OnboardEntry> = caller_chunks.into_iter().map(gathered_to_onboard).collect();
 
     // 7. Type dependencies — filter common types
-    let key_types = match store.get_types_used_by(&entry_name) {
+    // P2 #65: pass usize::MAX to preserve existing "all rows" behaviour. The
+    // post-filter `filter_common_types` discards most of these anyway; if a
+    // future tightening wants to limit the entry-point's edges the value
+    // should land here.
+    // TODO: consider a sane cap (e.g. 100) once we've measured the typical
+    // edge count for entry-point chunks.
+    let key_types = match store.get_types_used_by(&entry_name, usize::MAX) {
         Ok(types) => filter_common_types(types),
         Err(e) => {
             tracing::warn!(error = %e, "Type dependency lookup failed, skipping key_types");

--- a/src/parser/chunk.rs
+++ b/src/parser/chunk.rs
@@ -292,13 +292,11 @@ const MAX_TOLERATED_BLANK_SIBLINGS: usize = 4;
 /// Returns true if a single source line looks like the start of a
 /// comment in the given language.
 ///
-/// TODO(P2 #53): This currently uses a hardcoded global union of comment
-/// sigils for backward compatibility. Once Agent I lands `pub
-/// line_comment_prefixes: &'static [&'static str]` on `LanguageDef`, switch
-/// to `lang.def().line_comment_prefixes` so adding a language with new
-/// comment syntax (Lisp `;`, Erlang/MATLAB `%`, Smalltalk `"..."`) wires the
-/// fallback automatically. The `lang` argument is wired through now so the
-/// signature is stable for the registry switchover.
+/// Consults `lang.def().line_comment_prefixes` first (per-language precision
+/// for languages with non-default comment syntax — Erlang `%`, Lua `--`, etc.).
+/// If the language declares no prefixes (default `&[]`), falls back to the
+/// conservative global union of common comment sigils so unknown / grammar-less
+/// languages still get reasonable behaviour.
 ///
 /// Trims the leading whitespace before checking; `*` alone is also accepted
 /// for the inner lines of a `/** ... */` block.
@@ -306,15 +304,52 @@ const MAX_TOLERATED_BLANK_SIBLINGS: usize = 4;
 /// The bare-`#` and bare-`*` arms are tightened to require a separator so
 /// `#[derive]` (Rust attribute), `#include`/`#define`/`#pragma` (C
 /// preprocessor), `#region` (C# pragma), `*ptr = 0` (C deref), and
-/// `*x = y` are NOT classified as comment-like.
-fn line_looks_comment_like(line: &str, _lang: Language) -> bool {
+/// `*x = y` are NOT classified as comment-like. This separator rule applies
+/// to ambiguous single-char prefixes regardless of whether they came from
+/// the per-language list or the global fallback (P1 #3 hardening).
+fn line_looks_comment_like(line: &str, lang: Language) -> bool {
     let t = line.trim_start();
     if t.is_empty() {
         return true;
     }
-    // TODO(P2 #53): replace fallback list with `lang.def().line_comment_prefixes`
-    // once Agent I lands the LanguageDef field.
-    // Multi-char comment introducers (unambiguous)
+
+    // Per-language prefixes take precedence. Empty `&[]` means "no
+    // language-specific list registered" — fall through to the global fallback.
+    let prefixes = lang.def().line_comment_prefixes;
+    if !prefixes.is_empty() {
+        for prefix in prefixes {
+            if !t.starts_with(prefix) {
+                continue;
+            }
+            // Apply separator rule for ambiguous single-char prefixes so
+            // attribute / preprocessor / pointer-deref lines stay rejected.
+            if matches!(*prefix, "#" | "*" | "'") {
+                let rest = &t[prefix.len()..];
+                if rest.is_empty() || rest.starts_with(' ') || rest.starts_with('\t') {
+                    return true;
+                }
+                continue;
+            }
+            return true;
+        }
+        // Block-comment continuation markers — accept if any per-language
+        // prefix included `/*`. Inner-`*` lines (` * doc`) and the closing
+        // `*/` line are part of a `/** ... */` block.
+        if prefixes.contains(&"/*") {
+            if t.starts_with("*/") {
+                return true;
+            }
+            if let Some(rest) = t.strip_prefix('*') {
+                if rest.is_empty() || rest.starts_with(' ') || rest.starts_with('\t') {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // Global fallback: conservative union for unknown languages and the
+    // grammar-less default routing path.
     if t.starts_with("//")
         || t.starts_with("--")
         || t.starts_with("/*")
@@ -325,13 +360,9 @@ fn line_looks_comment_like(line: &str, _lang: Language) -> bool {
     {
         return true;
     }
-    // Single-char `#` is comment in sh/python/ruby ONLY when followed by whitespace
-    // or alone. Reject `#[derive]`, `#include`, `#define`, `#pragma`, `#region`, `#!`.
     if let Some(rest) = t.strip_prefix('#') {
         return rest.is_empty() || rest.starts_with(' ') || rest.starts_with('\t');
     }
-    // Single-char `*` is the inner-line marker of /** ... */ blocks ONLY when
-    // followed by whitespace or alone. Reject `*ptr = 0`, `*x * y`, etc.
     if let Some(rest) = t.strip_prefix('*') {
         return rest.is_empty() || rest.starts_with(' ') || rest.starts_with('\t');
     }
@@ -1250,22 +1281,25 @@ public class Calculator {
 
         #[test]
         fn comment_like_accepts_common_prefixes() {
-            for line in [
-                "// rust",
-                "/// outer doc",
-                "//! inner doc",
-                "-- sql",
-                "# python",
-                "/* block",
-                " * inner of /** */ block",
-                "*/ block end",
-                "<!-- html -->",
-                "<%-- jsp --%>",
-                "(* fsharp",
+            // Each sigil tested under a language that legitimately uses it
+            // (per `lang.def().line_comment_prefixes`). Per-language precision
+            // means `--` belongs to SQL/Lua/Haskell, `#` to Python/Bash, etc.
+            for (line, lang) in [
+                ("// rust", Language::Rust),
+                ("/// outer doc", Language::Rust),
+                ("//! inner doc", Language::Rust),
+                ("-- sql", Language::Sql),
+                ("# python", Language::Python),
+                ("/* block", Language::Rust),
+                (" * inner of /** */ block", Language::Rust),
+                ("*/ block end", Language::Rust),
+                ("<!-- html -->", Language::Html),
+                ("<%-- jsp --%>", Language::Aspx),
+                ("(* fsharp", Language::FSharp),
             ] {
                 assert!(
-                    line_looks_comment_like(line, Language::Rust),
-                    "expected comment-like: {line:?}"
+                    line_looks_comment_like(line, lang),
+                    "expected comment-like: {line:?} (lang={lang})"
                 );
             }
         }
@@ -1487,10 +1521,9 @@ type WithDoc = u8;
 
         #[test]
         fn line_looks_comment_like_still_accepts_real_comment_prefixes() {
+            // Rust-specific real comment prefixes — per-language list is
+            // `&["//", "/*"]` plus inner-`*` of `/** */` blocks.
             for line in [
-                "# python comment",
-                "# ",
-                "#",
                 "// rust",
                 "/// outer doc",
                 "/* block",
@@ -1501,6 +1534,13 @@ type WithDoc = u8;
                 assert!(
                     line_looks_comment_like(line, Language::Rust),
                     "expected comment-like: {line:?}"
+                );
+            }
+            // `#` belongs to Python/Bash/Ruby, not Rust.
+            for line in ["# python comment", "# ", "#"] {
+                assert!(
+                    line_looks_comment_like(line, Language::Python),
+                    "expected comment-like in Python: {line:?}"
                 );
             }
         }
@@ -1535,6 +1575,46 @@ type WithDoc = u8;
                     chunk.doc
                 );
             }
+        }
+
+        // ─── P2 #53: per-language line_comment_prefixes ────────────────────
+
+        /// Pin that the registry-driven prefix list is populated for the
+        /// languages most likely to surface in eval data. A language landing
+        /// without prefixes silently falls back to the global heuristic; the
+        /// audit's intent is that common languages get precision.
+        #[test]
+        fn line_comment_prefixes_populated_for_common_languages() {
+            for lang in [
+                Language::Rust,
+                Language::Python,
+                Language::Sql,
+                Language::Java,
+                Language::Go,
+                Language::Bash,
+                Language::Yaml,
+            ] {
+                assert!(
+                    !lang.def().line_comment_prefixes.is_empty(),
+                    "expected {lang} to populate line_comment_prefixes",
+                );
+            }
+        }
+
+        /// Pinned decision: `#` is NOT comment-like in Rust. The audit's
+        /// per-language precision intent overrides the previous global
+        /// fallback. `#` belongs to Python/Bash/Ruby/Yaml; in Rust it is an
+        /// attribute (`#[derive]`) or shebang prefix.
+        #[test]
+        fn python_line_comment_does_not_match_in_rust_context() {
+            assert!(
+                !line_looks_comment_like("# python comment", Language::Rust),
+                "`#` must not classify as comment-like in Rust",
+            );
+            assert!(
+                line_looks_comment_like("# python comment", Language::Python),
+                "`#` must classify as comment-like in Python",
+            );
         }
 
         // ─── A.2: walk-back blank-line budget ──────────────────────────────
@@ -1694,19 +1774,17 @@ CREATE TABLE five_line (
             );
         }
 
-        /// Mixed-prefix walk: the current `line_looks_comment_like` accepts
-        /// `//`, `--`, `#`, etc. globally, so a chunk preceded by mixed
-        /// comment styles will see all of them concatenated. Pin the
-        /// chosen behavior — if a future tightening requires same-prefix-
-        /// family continuity (or per-language filtering once Agent I lands
-        /// the LanguageDef field), this test will fail loudly so the change
-        /// is deliberate.
+        /// Mixed-prefix walk: P2 #53 made `line_looks_comment_like` consult
+        /// `lang.def().line_comment_prefixes` instead of a global union, so
+        /// a Rust chunk preceded by SQL-style `--` comments no longer walks
+        /// past the `--` line. Pin this deliberate tightening so a future
+        /// regression (or a permissive rewrite) surfaces as a loud diff.
         #[test]
         fn fallback_does_not_mix_comment_styles() {
-            // `//` and `--` both pass the current global predicate. Today
-            // the walk-back collects both; we pin "current behavior is
-            // mixing styles is permitted" so that any future deliberate
-            // tightening shows up as a deliberate test diff.
+            // Under Rust (`line_comment_prefixes: &["//", "/*"]`), the `--`
+            // line is NOT comment-like — the walk stops there. The `//`
+            // sibling gap between the `//` header and `type` is not surfaced
+            // because the walk's contiguous comment run is broken.
             let content = "// rust-style header\n-- sql-style header\ntype Mixed = u8;\n";
             let file = write_temp_file(content, "rs");
             let parser = Parser::new().unwrap();
@@ -1717,12 +1795,8 @@ CREATE TABLE five_line (
                 .expect("Mixed chunk");
             let doc = chunk.doc.as_deref().unwrap_or("");
             assert!(
-                doc.contains("rust-style header"),
-                "expected `//` prefix to be captured, got: {doc:?}"
-            );
-            assert!(
-                doc.contains("sql-style header"),
-                "expected `--` prefix to be captured (current mixed-style behavior), got: {doc:?}"
+                !doc.contains("sql-style header"),
+                "per-language walk must NOT capture `--` line in Rust context, got: {doc:?}"
             );
         }
 

--- a/src/parser/markdown/code_blocks.rs
+++ b/src/parser/markdown/code_blocks.rs
@@ -19,83 +19,19 @@ pub struct FencedBlock {
     pub line_end: u32,
 }
 
-/// Plain-text fenced-block alias map.
+/// Plain-text fenced-block alias map, derived from the language registry.
 ///
-/// TODO(P2 #55): Once Agent I adds `pub aliases: &'static [&'static str]` to
-/// `LanguageDef`, replace this static table with an iteration over
-/// `crate::language::REGISTRY.all()`, populating `(alias → canonical name)`
-/// from `def.name + def.aliases`. The current static table is the
-/// transitional shim — it duplicates the language registry and will drift
-/// from `define_languages!` until the registry conversion lands.
-///
-/// Note: Dart IS a `Language` variant (see `languages.rs`), so its alias is
-/// retained here. An earlier pass removed it on the assumption that it
-/// wasn't registered — `test_normalize_lang_covers_all_languages` catches
-/// that class of drift.
+/// Iterates `crate::language::REGISTRY.all()`, inserting `(canonical_name →
+/// canonical_name)` plus `(alias → canonical_name)` for each `def.aliases`
+/// entry. Adding a `Language` variant with an `aliases: &["foo"]` row in
+/// `languages.rs` propagates here automatically — no parallel table to keep
+/// in sync.
 static FENCED_LANG_ALIASES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
     let mut m = HashMap::new();
-    let entries: &[(&str, &[&str])] = &[
-        ("rust", &["rust"]),
-        ("python", &["python", "py"]),
-        ("typescript", &["typescript", "ts"]),
-        ("javascript", &["javascript", "js"]),
-        ("go", &["go", "golang"]),
-        ("c", &["c"]),
-        ("cpp", &["cpp", "c++", "cxx"]),
-        ("java", &["java"]),
-        ("csharp", &["csharp", "cs", "c#"]),
-        ("fsharp", &["fsharp", "fs", "f#"]),
-        ("powershell", &["powershell", "ps1", "pwsh"]),
-        ("scala", &["scala"]),
-        ("ruby", &["ruby", "rb"]),
-        ("bash", &["bash", "sh", "shell", "zsh"]),
-        ("hcl", &["hcl", "terraform", "tf"]),
-        ("kotlin", &["kotlin", "kt"]),
-        ("swift", &["swift"]),
-        ("objc", &["objc", "objective-c", "objectivec"]),
-        ("sql", &["sql"]),
-        ("protobuf", &["protobuf", "proto"]),
-        ("graphql", &["graphql", "gql"]),
-        ("php", &["php"]),
-        ("lua", &["lua"]),
-        ("zig", &["zig"]),
-        ("r", &["r"]),
-        ("yaml", &["yaml", "yml"]),
-        ("toml", &["toml"]),
-        ("elixir", &["elixir", "ex"]),
-        ("elm", &["elm"]),
-        ("erlang", &["erlang", "erl"]),
-        ("haskell", &["haskell", "hs"]),
-        ("ocaml", &["ocaml", "ml"]),
-        ("julia", &["julia", "jl"]),
-        ("gleam", &["gleam"]),
-        ("css", &["css"]),
-        ("perl", &["perl", "pl"]),
-        ("html", &["html"]),
-        ("json", &["json", "jsonc"]),
-        ("xml", &["xml", "svg", "xsl"]),
-        ("nix", &["nix"]),
-        ("make", &["make", "makefile"]),
-        ("latex", &["latex", "tex"]),
-        ("solidity", &["solidity", "sol"]),
-        ("cuda", &["cuda", "cu"]),
-        ("glsl", &["glsl"]),
-        ("vue", &["vue"]),
-        ("svelte", &["svelte"]),
-        ("razor", &["razor", "cshtml"]),
-        ("vbnet", &["vb", "vbnet", "vb.net"]),
-        ("ini", &["ini"]),
-        ("markdown", &["markdown", "md"]),
-        ("aspx", &["aspx", "ascx", "asmx", "webforms"]),
-        (
-            "structured_text",
-            &["structured_text", "st", "stl", "iec61131", "iec-st"],
-        ),
-        ("dart", &["dart"]),
-    ];
-    for (canonical, aliases) in entries {
-        for alias in *aliases {
-            m.insert(*alias, *canonical);
+    for def in crate::language::REGISTRY.all() {
+        m.insert(def.name, def.name);
+        for alias in def.aliases {
+            m.insert(*alias, def.name);
         }
     }
     m
@@ -228,6 +164,60 @@ mod tests {
                 "normalize_lang({:?}) returned None -- add a mapping for Language::{}",
                 name_lower,
                 lang
+            );
+        }
+    }
+
+    /// Pin that the registry-driven alias list is populated for the languages
+    /// most likely to appear as fence tags. Without this, an alias regression
+    /// in `languages.rs` would only be caught if it dropped the canonical
+    /// name itself.
+    #[test]
+    fn aliases_populated_for_common_languages() {
+        use crate::parser::Language;
+        assert!(
+            Language::Python.def().aliases.contains(&"py"),
+            "Python must register the `py` alias",
+        );
+        assert!(
+            Language::Go.def().aliases.contains(&"golang"),
+            "Go must register the `golang` alias",
+        );
+        assert!(
+            Language::TypeScript.def().aliases.contains(&"ts"),
+            "TypeScript must register the `ts` alias",
+        );
+    }
+
+    /// Regression pin: `normalize_lang` resolves a representative alias subset
+    /// to the correct canonical name. If the registry conversion drifts (a
+    /// language drops an alias, or `normalize_lang` is rewired wrong), this
+    /// surfaces immediately.
+    #[test]
+    fn fenced_lang_aliases_match_legacy_table() {
+        for (alias, canonical) in [
+            ("py", "python"),
+            ("ts", "typescript"),
+            ("js", "javascript"),
+            ("golang", "go"),
+            ("c++", "cpp"),
+            ("cs", "csharp"),
+            ("kt", "kotlin"),
+            ("ml", "ocaml"),
+            ("rb", "ruby"),
+            ("yml", "yaml"),
+            ("md", "markdown"),
+            ("tf", "hcl"),
+            ("proto", "protobuf"),
+            ("gql", "graphql"),
+            ("hs", "haskell"),
+            ("sol", "solidity"),
+            ("cu", "cuda"),
+        ] {
+            assert_eq!(
+                normalize_lang(alias),
+                Some(canonical),
+                "alias `{alias}` must resolve to `{canonical}`",
             );
         }
     }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -411,6 +411,7 @@ mod tests {
                 parent_type_name: None,
                 content_hash: String::new(),
                 window_idx: None,
+                parser_version: 0,
             },
             score,
         }
@@ -560,6 +561,7 @@ mod tests {
                 parent_type_name: None,
                 content_hash: String::new(),
                 window_idx: None,
+                parser_version: 0,
             },
             score: 0.9,
         })];
@@ -581,6 +583,7 @@ mod tests {
                     parent_type_name: None,
                     content_hash: String::new(),
                     window_idx: None,
+                    parser_version: 0,
                 },
                 score: 0.7,
             }],

--- a/src/related.rs
+++ b/src/related.rs
@@ -49,8 +49,13 @@ pub fn find_related<Mode>(
     let shared_callee_pairs = store.find_shared_callees(&target, limit)?;
     let shared_callees = resolve_to_related(store, &shared_callee_pairs);
 
-    // 3. Shared types — query type_edges for target's types, find other functions using them
-    let type_pairs = store.get_types_used_by(&target)?;
+    // 3. Shared types — query type_edges for target's types, find other functions using them.
+    // P2 #65: pass usize::MAX to preserve existing "all rows" behaviour. This
+    // path filters down via COMMON_TYPES + dedupe, and downstream uses each
+    // type to drive a fan-out query, so capping here would change semantics.
+    // TODO: revisit if this becomes a hot path (currently O(types-per-target)
+    // which is bounded in practice by the chunk's surface area).
+    let type_pairs = store.get_types_used_by(&target, usize::MAX)?;
     let type_names: Vec<String> = type_pairs
         .into_iter()
         .map(|t| t.type_name)

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,4 +1,11 @@
--- cq index schema v20
+-- cq index schema v21
+-- v21: parser_version column on chunks so incremental UPSERT can refresh rows
+--      whose content_hash hasn't changed but whose parser-emitted fields (e.g.
+--      `doc` from extract_doc_fallback_for_short_chunk) would now differ. The
+--      WHERE clause in batch_insert_chunks's ON CONFLICT path additionally
+--      checks `OR parser_version != excluded.parser_version`, and
+--      upsert_fts_conditional uses the same OR filter when comparing the
+--      pre-INSERT snapshot.
 -- v20: AFTER DELETE trigger on chunks bumps splade_generation so any persisted
 --      splade.index.bin is invalidated when underlying chunks are removed
 --      (catches the race `delete_by_origin` left behind when CASCADE alone
@@ -41,7 +48,8 @@ CREATE TABLE IF NOT EXISTS chunks (
     window_idx INTEGER,       -- if windowed: 0, 1, 2... for each window
     parent_type_name TEXT,    -- for methods: name of enclosing class/struct/impl
     enrichment_hash TEXT,     -- blake3 hash of call context used for enrichment (NULL = not enriched)
-    enrichment_version INTEGER NOT NULL DEFAULT 0  -- RT-DATA-2: idempotency marker for enrichment passes
+    enrichment_version INTEGER NOT NULL DEFAULT 0,  -- RT-DATA-2: idempotency marker for enrichment passes
+    parser_version INTEGER NOT NULL DEFAULT 0  -- v21: parser stamp for content-hash-stable doc enrichment refresh (P2 #29)
 );
 
 CREATE INDEX IF NOT EXISTS idx_chunks_origin ON chunks(origin);

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -551,6 +551,7 @@ mod tests {
                 parent_type_name: None,
                 content_hash: String::new(),
                 window_idx: None,
+                parser_version: 0,
             },
             score,
         }

--- a/src/search/scoring/candidate.rs
+++ b/src/search/scoring/candidate.rs
@@ -435,6 +435,7 @@ mod tests {
                 parent_type_name: parent_type_name.map(|s| s.to_string()),
                 content_hash: String::new(),
                 window_idx: None,
+                parser_version: 0,
             },
             score,
         }

--- a/src/store/calls/crud.rs
+++ b/src/store/calls/crud.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::await_holding_lock)]
 //! Call graph upsert, delete, batch operations, and basic stats.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::CallStats;
 use crate::store::helpers::StoreError;
@@ -238,6 +238,103 @@ impl Store<ReadWrite> {
             }
 
             tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    /// Insert function calls for multiple files in a single transaction.
+    ///
+    /// P2 #64 (recovery wave): mirrors the existing `upsert_type_edges_for_files`
+    /// pattern. The previous CLI hot path (`pipeline/upsert.rs:152-163`) called
+    /// `upsert_function_calls(file, calls)` once per file, opening one
+    /// transaction per file. On a 2,500-file project this was 2,500 separate
+    /// `BEGIN ... COMMIT` round-trips; batching to one transaction is the same
+    /// shape we already use for type edges.
+    ///
+    /// Inside the single transaction:
+    /// - Batched DELETE WHERE file IN (?, ?, ?) for all files in the batch
+    ///   (chunked under the SQLite parameter limit).
+    /// - Batched multi-row INSERT for all rows from all files (5 binds per row,
+    ///   chunked under the same parameter limit).
+    pub fn upsert_function_calls_for_files(
+        &self,
+        entries: &[(PathBuf, Vec<crate::parser::FunctionCalls>)],
+    ) -> Result<(), StoreError> {
+        let total_files = entries.len();
+        let _span =
+            tracing::info_span!("upsert_function_calls_for_files", files = total_files).entered();
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        // Pre-normalize file paths so the borrow lives for the whole tx.
+        let file_strs: Vec<String> = entries
+            .iter()
+            .map(|(file, _)| crate::normalize_path(file))
+            .collect();
+
+        self.rt.block_on(async {
+            let (_guard, mut tx) = self.begin_write().await?;
+
+            use crate::store::helpers::sql::max_rows_per_statement;
+
+            // Phase 1: batched DELETE WHERE file IN (?, ?, ?) — one bind per
+            // file, chunked under the SQLite param limit.
+            const DELETE_PER_STMT: usize = max_rows_per_statement(1);
+            for chunk in file_strs.chunks(DELETE_PER_STMT) {
+                let placeholders = crate::store::helpers::make_placeholders(chunk.len());
+                let sql =
+                    format!("DELETE FROM function_calls WHERE file IN ({})", placeholders);
+                let mut q = sqlx::query(&sql);
+                for fs in chunk {
+                    q = q.bind(fs);
+                }
+                q.execute(&mut *tx).await?;
+            }
+
+            // Phase 2: collect all rows tagged with their file string, then
+            // batched multi-row INSERT.
+            let mut all_rows: Vec<(&str, &str, u32, &str, u32)> = Vec::new();
+            for ((_file, function_calls), file_str) in entries.iter().zip(file_strs.iter()) {
+                for fc in function_calls {
+                    for call in &fc.calls {
+                        all_rows.push((
+                            file_str.as_str(),
+                            fc.name.as_str(),
+                            fc.line_start,
+                            call.callee_name.as_str(),
+                            call.line_number,
+                        ));
+                    }
+                }
+            }
+
+            if !all_rows.is_empty() {
+                const INSERT_BATCH: usize = max_rows_per_statement(5);
+                for batch in all_rows.chunks(INSERT_BATCH) {
+                    let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+                        "INSERT INTO function_calls (file, caller_name, caller_line, callee_name, call_line) ",
+                    );
+                    qb.push_values(
+                        batch.iter(),
+                        |mut b, (file, caller_name, caller_line, callee_name, call_line)| {
+                            b.push_bind(*file)
+                                .push_bind(*caller_name)
+                                .push_bind(*caller_line as i64)
+                                .push_bind(*callee_name)
+                                .push_bind(*call_line as i64);
+                        },
+                    );
+                    qb.build().execute(&mut *tx).await?;
+                }
+            }
+
+            tx.commit().await?;
+            tracing::info!(
+                files = total_files,
+                rows = all_rows.len(),
+                "Batch-indexed function calls"
+            );
             Ok(())
         })
     }

--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -210,31 +210,53 @@ impl<Mode> Store<Mode> {
 
 // ── Shared async helpers for chunk upsert (PERF-3) ──────────────────────────
 
-/// Snapshot existing content hashes before INSERT overwrites them.
-/// Batched in groups of 500 to stay within SQLite's 999-param limit.
+/// Pre-INSERT snapshot of fields used by the `ON CONFLICT DO UPDATE WHERE`
+/// short-circuit and by `upsert_fts_conditional`'s "did anything actually
+/// change?" filter.
+///
+/// `content_hash` is the original PERF-3 / FTS skip key. `parser_version` was
+/// added in v1.28.0 audit P2 #29 so chunks whose source bytes are unchanged
+/// but whose parser logic moved on (e.g. `extract_doc_fallback_for_short_chunk`
+/// in PR #1040) still trigger a refresh.
+#[derive(Clone)]
+pub(super) struct ChunkSnapshot {
+    pub content_hash: String,
+    pub parser_version: u32,
+}
+
+/// Snapshot existing content_hash + parser_version before INSERT overwrites
+/// them. Batched in groups of 500 to stay within SQLite's 999-param limit.
 pub(super) async fn snapshot_content_hashes(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     chunks: &[(Chunk, Embedding)],
-) -> Result<HashMap<String, String>, StoreError> {
+) -> Result<HashMap<String, ChunkSnapshot>, StoreError> {
     const HASH_BATCH: usize = 500;
-    let mut old_hashes = HashMap::new();
+    let mut old: HashMap<String, ChunkSnapshot> = HashMap::new();
     let chunk_ids: Vec<&str> = chunks.iter().map(|(c, _)| c.id.as_str()).collect();
     for id_batch in chunk_ids.chunks(HASH_BATCH) {
         let placeholders = crate::store::helpers::make_placeholders(id_batch.len());
         let sql = format!(
-            "SELECT id, content_hash FROM chunks WHERE id IN ({})",
+            "SELECT id, content_hash, parser_version FROM chunks WHERE id IN ({})",
             placeholders
         );
-        let mut q = sqlx::query_as::<_, (String, String)>(&sql);
+        let mut q = sqlx::query_as::<_, (String, String, i64)>(&sql);
         for id in id_batch {
             q = q.bind(*id);
         }
         let rows = q.fetch_all(&mut **tx).await?;
-        for (id, hash) in rows {
-            old_hashes.insert(id, hash);
+        for (id, hash, pv) in rows {
+            old.insert(
+                id,
+                ChunkSnapshot {
+                    content_hash: hash,
+                    // Stored as INTEGER NOT NULL DEFAULT 0; cast back to u32.
+                    // Negative values shouldn't occur but clamp defensively.
+                    parser_version: pv.max(0).min(u32::MAX as i64) as u32,
+                },
+            );
         }
     }
-    Ok(old_hashes)
+    Ok(old)
 }
 
 /// Batch INSERT chunks — derived from the modern SQLite variable limit.
@@ -266,11 +288,12 @@ pub(super) async fn batch_insert_chunks(
     now: &str,
 ) -> Result<(), StoreError> {
     use crate::store::helpers::sql::max_rows_per_statement;
-    const CHUNK_INSERT_BATCH: usize = max_rows_per_statement(20);
+    // 21 binds per row (P2 #29: parser_version added).
+    const CHUNK_INSERT_BATCH: usize = max_rows_per_statement(21);
     for (batch_idx, batch) in chunks.chunks(CHUNK_INSERT_BATCH).enumerate() {
         let emb_offset = batch_idx * CHUNK_INSERT_BATCH;
         let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
-            "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name, signature, content, content_hash, doc, line_start, line_end, embedding, embedding_base, source_mtime, created_at, updated_at, parent_id, window_idx, parent_type_name)",
+            "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name, signature, content, content_hash, doc, line_start, line_end, embedding, embedding_base, source_mtime, created_at, updated_at, parent_id, window_idx, parent_type_name, parser_version)",
         );
         qb.push_values(batch.iter().enumerate(), |mut b, (i, (chunk, _))| {
             b.push_bind(&chunk.id)
@@ -296,10 +319,17 @@ pub(super) async fn batch_insert_chunks(
                 .push_bind(now)
                 .push_bind(&chunk.parent_id)
                 .push_bind(chunk.window_idx.map(|i| i as i64))
-                .push_bind(&chunk.parent_type_name);
+                .push_bind(&chunk.parent_type_name)
+                // P2 #29: stamp the parser version emitted with this chunk so
+                // a parser-logic bump (without source change) still refreshes.
+                .push_bind(chunk.parser_version as i64);
         });
         // DS-2: ON CONFLICT upsert preserves enrichment_hash and enrichment_version.
-        // Only update when content_hash changed (avoids write amplification for unchanged chunks).
+        //
+        // Skip the UPDATE only when BOTH content_hash and parser_version are
+        // identical to the existing row. P2 #29: a parser-logic bump (e.g.
+        // PR #1040's doc fallback) needs to refresh `doc` even though
+        // `content_hash` is unchanged. The OR clause handles that case.
         //
         // Phase 5: on content change, refresh embedding_base too — new content
         // means new NL text means new base embedding. Reindex sets both columns.
@@ -322,30 +352,43 @@ pub(super) async fn batch_insert_chunks(
              updated_at=excluded.updated_at, \
              parent_id=excluded.parent_id, \
              window_idx=excluded.window_idx, \
-             parent_type_name=excluded.parent_type_name \
-             WHERE chunks.content_hash != excluded.content_hash",
+             parent_type_name=excluded.parent_type_name, \
+             parser_version=excluded.parser_version \
+             WHERE chunks.content_hash != excluded.content_hash \
+                OR chunks.parser_version != excluded.parser_version",
         );
         qb.build().execute(&mut **tx).await?;
     }
     Ok(())
 }
 
-/// Conditional FTS upsert: skip if content_hash unchanged (compared to pre-INSERT snapshot).
+/// Conditional FTS upsert: skip if content_hash AND parser_version are
+/// unchanged (compared to pre-INSERT snapshot).
+///
+/// P2 #29: the parser_version OR mirrors the UPSERT WHERE filter in
+/// `batch_insert_chunks`. A parser bump that updates `doc` without touching
+/// source bytes still needs the FTS row refreshed — `normalize_for_fts` is
+/// applied to `doc` and the FTS would otherwise serve stale text.
+///
 /// Batches DELETE and INSERT for efficiency (PERF-2: was 2 SQL per chunk, now batched).
 pub(super) async fn upsert_fts_conditional(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     chunks: &[(Chunk, Embedding)],
-    old_hashes: &HashMap<String, String>,
+    old: &HashMap<String, ChunkSnapshot>,
 ) -> Result<(), StoreError> {
-    // Collect changed chunks
+    // Collect changed chunks (content OR parser_version differs vs. snapshot)
     let changed: Vec<&Chunk> = chunks
         .iter()
         .filter_map(|(chunk, _)| {
-            let content_changed = old_hashes
+            let chunk_changed = old
                 .get(&chunk.id)
-                .map(|old_hash| old_hash != &chunk.content_hash)
+                .map(|snap| {
+                    snap.content_hash != chunk.content_hash
+                        || snap.parser_version != chunk.parser_version
+                })
+                // No snapshot → row is brand-new → always insert.
                 .unwrap_or(true);
-            if content_changed {
+            if chunk_changed {
                 Some(chunk)
             } else {
                 None

--- a/src/store/chunks/staleness.rs
+++ b/src/store/chunks/staleness.rs
@@ -172,9 +172,15 @@ impl Store<ReadWrite> {
     /// are deleted but orphan call graph / type edge / summary entries remain.
     /// Without this, the window between `prune_missing` and `prune_stale_calls`
     /// exposes stale `function_calls` rows referencing deleted chunks.
-    // Note: This has a theoretical TOCTOU race between the Phase 1 file-existence
-    // check and the Phase 2 transaction, but acquire_index_lock in cmd_index
-    // prevents concurrent writers in practice.
+    //
+    // P2 #32 (recovery wave): the previous Phase 1 ran the SELECT DISTINCT
+    // outside the write transaction. If `cqs watch` (which only takes
+    // `try_acquire_index_lock`) interleaved an `upsert_chunks_and_calls` call
+    // for a freshly-added file between Phase 1 and Phase 2, that file's origin
+    // was missing from `existing_files` (caller-passed snapshot) yet present in
+    // `chunks` — the Phase 2 DELETE would wipe the just-added rows. Closed by
+    // snapshotting inside the write transaction so we observe a post-watch-
+    // reindex-consistent view.
     pub fn prune_all(
         &self,
         existing_files: &HashSet<PathBuf>,
@@ -182,11 +188,20 @@ impl Store<ReadWrite> {
     ) -> Result<PruneAllResult, StoreError> {
         let _span = tracing::info_span!("prune_all", existing = existing_files.len()).entered();
         self.rt.block_on(async {
-            // Phase 1: identify missing origins (Rust-side HashSet check, outside tx)
+            // Phase 2 begins immediately: take the write lock first so the
+            // distinct-origin scan happens against the same snapshot the
+            // DELETEs will operate on (P2 #32 TOCTOU close).
+            let (_guard, mut tx) = self.begin_write().await?;
+
+            // Phase 1 (now inside the tx): identify missing origins via the
+            // tx's read snapshot. Any concurrent watch reindex that committed
+            // *before* our begin_write is reflected here; any reindex that
+            // committed *after* will be queued behind our write lock. Either
+            // way the missing-set lines up with what's actually deletable.
             let rows: Vec<(String,)> = sqlx::query_as(
                 "SELECT DISTINCT origin FROM chunks WHERE source_type = 'file'",
             )
-            .fetch_all(&self.pool)
+            .fetch_all(&mut *tx)
             .await?;
 
             // Same filesystem-existence reconciliation as `prune_missing`.
@@ -195,9 +210,6 @@ impl Store<ReadWrite> {
                 .filter(|(origin,)| !origin_exists(origin, existing_files, root))
                 .map(|(origin,)| origin)
                 .collect();
-
-            // Phase 2: single transaction for ALL mutations
-            let (_guard, mut tx) = self.begin_write().await?;
 
             // 2a. Delete chunks for missing files (batched for SQLite param limit)
             const BATCH_SIZE: usize = 100;

--- a/src/store/helpers/mod.rs
+++ b/src/store/helpers/mod.rs
@@ -56,7 +56,15 @@ pub use embeddings::{bytes_to_embedding, embedding_slice, embedding_to_bytes};
 /// against the stored version and returns StoreError::SchemaMismatch if different.
 ///
 /// History:
-/// - v18: embedding_base column for dual embeddings (adaptive retrieval Phase 5)
+/// - v21: parser_version column on chunks (v1.28.0 audit P2 #29 — incremental
+///   UPSERT now refreshes rows whose `content_hash` is unchanged but whose
+///   `parser_version` bumped, e.g. when `extract_doc_fallback_for_short_chunk`
+///   logic changes the value of `doc` for a previously-indexed chunk. Without
+///   this column the watch path's content-hash short-circuit silently
+///   discards the new `doc`. See `parser::chunk::PARSER_VERSION` for the
+///   in-memory value and `chunks/async_helpers.rs::batch_insert_chunks` for
+///   the corresponding `OR parser_version != excluded.parser_version` UPSERT
+///   filter.)
 /// - v20: AFTER DELETE trigger on chunks bumps splade_generation in metadata
 ///   (v1.22.0 audit DS-W2 / OB-22 / PB-NEW-6 — `cqs watch` never touched
 ///   SPLADE, so deletes that cascade to sparse_vectors left the persisted
@@ -75,7 +83,7 @@ pub use embeddings::{bytes_to_embedding, embedding_slice, embedding_to_bytes};
 /// - v12: parent_type_name column for method->class association
 /// - v11: type_edges table for type-level dependency tracking
 /// - v10: sentiment in embeddings, call graph, notes
-pub const CURRENT_SCHEMA_VERSION: i32 = 20;
+pub const CURRENT_SCHEMA_VERSION: i32 = 21;
 
 /// Default model name for metadata checks (used by test-only `check_model_version`).
 /// Canonical definition is `embedder::DEFAULT_MODEL_REPO`.

--- a/src/store/helpers/rows.rs
+++ b/src/store/helpers/rows.rs
@@ -56,11 +56,15 @@ pub(crate) struct ChunkRow {
     pub window_idx: Option<i32>,
     pub parent_id: Option<String>,
     pub parent_type_name: Option<String>,
+    /// Parser logic stamp (P2 #29). 0 means either pre-v21 or never written;
+    /// `try_get` keeps existing SELECTs that omit the column working.
+    pub parser_version: u32,
 }
 
 impl ChunkRow {
     /// Construct from a SQLite row containing columns:
     /// id, origin, language, chunk_type, name, signature, content, doc, line_start, line_end, parent_id, parent_type_name
+    /// (parser_version is read via `try_get` so SELECTs that omit it still work).
     pub(crate) fn from_row(row: &sqlx::sqlite::SqliteRow) -> Self {
         use sqlx::Row;
         ChunkRow {
@@ -81,6 +85,12 @@ impl ChunkRow {
             window_idx: row.try_get("window_idx").unwrap_or(None),
             parent_id: row.get("parent_id"),
             parent_type_name: row.get("parent_type_name"),
+            // try_get so SELECT lists that don't pull parser_version still
+            // construct a valid row — most search/read paths don't need it.
+            parser_version: row
+                .try_get::<i64, _>("parser_version")
+                .map(|v| v.max(0).min(u32::MAX as i64) as u32)
+                .unwrap_or(0),
         }
     }
 
@@ -106,6 +116,7 @@ impl ChunkRow {
             window_idx: None,
             parent_id: row.get("parent_id"),
             parent_type_name: row.get("parent_type_name"),
+            parser_version: 0,
         }
     }
 
@@ -133,6 +144,7 @@ impl ChunkRow {
             window_idx: None,
             parent_id: None,
             parent_type_name: None,
+            parser_version: 0,
         }
     }
 }

--- a/src/store/helpers/types.rs
+++ b/src/store/helpers/types.rs
@@ -46,6 +46,15 @@ pub struct ChunkSummary {
     pub parent_id: Option<String>,
     /// For methods: name of enclosing class/struct/impl
     pub parent_type_name: Option<String>,
+    /// Parser logic stamp (P2 #29). Defaults to 0 when the loading SELECT
+    /// didn't include the column or when the row predates v21.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub parser_version: u32,
+}
+
+#[inline]
+fn is_zero_u32(v: &u32) -> bool {
+    *v == 0
 }
 
 impl From<&ChunkSummary> for Chunk {
@@ -65,12 +74,10 @@ impl From<&ChunkSummary> for Chunk {
             parent_id: cs.parent_id.clone(),
             window_idx: cs.window_idx.map(|i| i as u32),
             parent_type_name: cs.parent_type_name.clone(),
-            // TODO(P2 #29 / Agent D): plumb `parser_version` through
-            // `ChunkSummary` and the store layer so this conversion preserves
-            // the original parser_version. Defaulting to 0 here means
-            // round-tripped chunks lose the version stamp; only the parser
-            // -emitted Chunks via `extract_chunk` carry the live value.
-            parser_version: 0,
+            // P2 #29: preserve the version stamp on round-trip. Falls back to
+            // 0 only when the source row was loaded by a SELECT that omitted
+            // `parser_version`, in which case the next reindex will rewrite it.
+            parser_version: cs.parser_version,
         }
     }
 }
@@ -108,6 +115,7 @@ impl From<ChunkRow> for ChunkSummary {
             window_idx: row.window_idx,
             parent_id: row.parent_id,
             parent_type_name: row.parent_type_name,
+            parser_version: row.parser_version,
         }
     }
 }
@@ -429,6 +437,7 @@ mod tests {
             parent_type_name: None,
             content_hash: String::new(),
             window_idx: None,
+            parser_version: 0,
         }
     }
 
@@ -494,6 +503,7 @@ mod tests {
                 parent_type_name: Some("SearchEngine".to_string()),
                 content_hash: "abc123".to_string(),
                 window_idx: None,
+                parser_version: 0,
             },
             score: 0.9375,
         }

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -224,6 +224,7 @@ async fn run_migration(
         (17, 18) => migrate_v17_to_v18(conn).await,
         (18, 19) => migrate_v18_to_v19(conn).await,
         (19, 20) => migrate_v19_to_v20(conn).await,
+        (20, 21) => migrate_v20_to_v21(conn).await,
         _ => Err(StoreError::MigrationNotSupported(from, to)),
     }
 }
@@ -619,6 +620,32 @@ async fn migrate_v19_to_v20(conn: &mut sqlx::SqliteConnection) -> Result<(), Sto
     Ok(())
 }
 
+/// Migrate from v20 to v21: add `parser_version` column to chunks
+///
+/// v1.28.0 audit P2 #29 (recovery wave): the watch path UPSERTs chunks with an
+/// `ON CONFLICT(id) DO UPDATE ... WHERE chunks.content_hash != excluded.content_hash`
+/// short-circuit, which is correct when the only thing that ever changes is the
+/// source bytes. But `extract_doc_fallback_for_short_chunk` (PR #1040) can
+/// change `doc` for a chunk whose source bytes are byte-identical to a
+/// previously-indexed version — and that change was being silently discarded
+/// on every incremental update. A `parser_version` stamp lets the UPSERT
+/// invalidate rows whose parser logic moved on, mirroring `splade_generation`.
+///
+/// Defaults to 0 for existing rows so the next `cqs index` (or watch reindex)
+/// will write the live PARSER_VERSION value and refresh the affected fields.
+async fn migrate_v20_to_v21(conn: &mut sqlx::SqliteConnection) -> Result<(), StoreError> {
+    let _span = tracing::info_span!("migrate_v20_to_v21").entered();
+
+    sqlx::query("ALTER TABLE chunks ADD COLUMN parser_version INTEGER NOT NULL DEFAULT 0")
+        .execute(&mut *conn)
+        .await?;
+
+    tracing::info!(
+        "Migrated to v21: parser_version column on chunks (P2 #29 — content-hash-stable doc refresh)"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -651,7 +678,7 @@ mod tests {
     #[test]
     fn test_current_schema_version_documented() {
         // Ensure the current version matches what we document
-        assert_eq!(CURRENT_SCHEMA_VERSION, 20);
+        assert_eq!(CURRENT_SCHEMA_VERSION, 21);
     }
 
     #[test]
@@ -2459,6 +2486,127 @@ mod tests {
                 post.map(|(v,)| v),
                 Some("11".to_string()),
                 "schema_version row must be created with the new version"
+            );
+        });
+    }
+
+    /// v1.28.0 audit P2 #29: v20→v21 adds a `parser_version` column that
+    /// defaults to 0 for existing rows. New rows can write any u32 value;
+    /// the UPSERT path uses `OR parser_version != excluded.parser_version`
+    /// to refresh chunks whose source bytes are unchanged but whose parser
+    /// emitted a different `doc` (or other non-content field).
+    ///
+    /// Round-trip:
+    /// - Pre-migration v20 chunk gets `parser_version = 0` after ALTER.
+    /// - Post-migration v21 INSERT can stamp any value (e.g. 5) and read it back.
+    #[test]
+    fn test_migrate_v20_to_v21_adds_parser_version_column() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        rt.block_on(async {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(
+                    sqlx::sqlite::SqliteConnectOptions::new()
+                        .filename(&db_path)
+                        .create_if_missing(true)
+                        .foreign_keys(true),
+                )
+                .await
+                .unwrap();
+
+            // Minimal v20 schema: chunks with the v20 column set, metadata.
+            // Notably no `parser_version` column — that's what v20→v21 adds.
+            sqlx::query("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+                .execute(&pool)
+                .await
+                .unwrap();
+            sqlx::query(
+                "CREATE TABLE chunks (
+                    id TEXT PRIMARY KEY,
+                    origin TEXT NOT NULL,
+                    source_type TEXT NOT NULL,
+                    language TEXT NOT NULL,
+                    chunk_type TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    signature TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    content_hash TEXT NOT NULL,
+                    line_start INTEGER NOT NULL,
+                    line_end INTEGER NOT NULL,
+                    embedding BLOB NOT NULL,
+                    embedding_base BLOB,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    enrichment_version INTEGER NOT NULL DEFAULT 0
+                )",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            sqlx::query("INSERT INTO metadata (key, value) VALUES ('schema_version', '20')")
+                .execute(&pool)
+                .await
+                .unwrap();
+
+            // Seed a pre-migration v20 chunk.
+            sqlx::query(
+                "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name, \
+                 signature, content, content_hash, line_start, line_end, embedding, \
+                 created_at, updated_at) \
+                 VALUES ('pre_v21', 'file:lib.rs', 'file', 'rust', 'function', 'pre_v21', \
+                 '', '', 'h', 1, 10, X'00', '2026-04-12', '2026-04-12')",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+
+            // Run v20 → v21 migration.
+            migrate(&pool, &db_path, 20, 21).await.unwrap();
+
+            // Schema version bumped.
+            let (v,): (String,) =
+                sqlx::query_as("SELECT value FROM metadata WHERE key = 'schema_version'")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert_eq!(v, "21");
+
+            // Pre-migration row has parser_version = 0 (default).
+            let (pre_pv,): (i64,) =
+                sqlx::query_as("SELECT parser_version FROM chunks WHERE id = 'pre_v21'")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                pre_pv, 0,
+                "v20 chunk after migration must default to parser_version = 0"
+            );
+
+            // New row written with parser_version = 5 round-trips correctly.
+            sqlx::query(
+                "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name, \
+                 signature, content, content_hash, line_start, line_end, embedding, \
+                 created_at, updated_at, parser_version) \
+                 VALUES ('post_v21', 'file:lib.rs', 'file', 'rust', 'function', 'post_v21', \
+                 '', '', 'h', 1, 10, X'00', '2026-04-12', '2026-04-12', 5)",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            let (post_pv,): (i64,) =
+                sqlx::query_as("SELECT parser_version FROM chunks WHERE id = 'post_v21'")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                post_pv, 5,
+                "v21 INSERT with parser_version = 5 must round-trip"
             );
         });
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -682,6 +682,25 @@ impl Store<ReadWrite> {
 }
 
 impl Store<ReadOnly> {
+    /// Shared config builder for `open_readonly_pooled` /
+    /// `open_readonly_pooled_with_runtime`. Mirrors `default_open_config` on
+    /// the read-write side so the runtime-sharing variant stays in lockstep
+    /// with the standalone version as pool / mmap / cache defaults evolve
+    /// (P2 #42).
+    fn default_readonly_pooled_config(
+        path: &Path,
+        runtime: Option<Arc<Runtime>>,
+    ) -> StoreOpenConfig {
+        StoreOpenConfig {
+            read_only: true,
+            use_current_thread: true,
+            max_connections: 1,
+            mmap_size: resolve_mmap_size("268435456", path), // 256MB default
+            cache_size: cache_size_from_env("-16384"),       // 16MB
+            runtime,
+        }
+    }
+
     /// Open an existing index in read-only mode with single-threaded runtime
     /// but full memory. Uses `current_thread` tokio runtime (1 OS thread
     /// instead of 4) while keeping the full 256MB mmap and 16MB cache of
@@ -692,17 +711,7 @@ impl Store<ReadOnly> {
     /// AD-1: Renamed from `open_light` to clarify semantics — this is a
     /// read-only pooled connection, not a "light" store.
     pub fn open_readonly_pooled(path: &Path) -> Result<Self, StoreError> {
-        open_with_config_impl::<ReadOnly>(
-            path,
-            StoreOpenConfig {
-                read_only: true,
-                use_current_thread: true,
-                max_connections: 1,
-                mmap_size: resolve_mmap_size("268435456", path),
-                cache_size: cache_size_from_env("-16384"),
-                runtime: None,
-            },
-        )
+        open_with_config_impl::<ReadOnly>(path, Self::default_readonly_pooled_config(path, None))
     }
 
     /// Open an existing index in read-only mode with reduced resources.
@@ -736,14 +745,7 @@ impl Store<ReadOnly> {
     ) -> Result<Self, StoreError> {
         open_with_config_impl::<ReadOnly>(
             path,
-            StoreOpenConfig {
-                read_only: true,
-                use_current_thread: true,
-                max_connections: 1,
-                mmap_size: resolve_mmap_size("268435456", path),
-                cache_size: cache_size_from_env("-16384"),
-                runtime: Some(runtime),
-            },
+            Self::default_readonly_pooled_config(path, Some(runtime)),
         )
     }
 

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -20,6 +20,21 @@ use super::helpers::{clamp_line_number, ChunkRow, StoreError};
 use super::{ReadWrite, Store};
 use crate::store::helpers::ChunkSummary;
 
+/// Convert a Rust `usize` limit into a SQLite-bindable `i64`.
+///
+/// P2 #65: callers that genuinely want all rows pass `usize::MAX`. SQLite
+/// caps `LIMIT ?` at i64::MAX (`LIMIT -1` is "unlimited" but doesn't
+/// round-trip through bind), so saturate to that. On 32-bit `usize` is
+/// already u32 → i64 round-trips losslessly.
+#[inline]
+fn limit_to_sql(limit: usize) -> i64 {
+    if limit > i64::MAX as usize {
+        i64::MAX
+    } else {
+        limit as i64
+    }
+}
+
 /// Statistics about type dependency edges
 #[derive(Debug, Clone, Default)]
 pub struct TypeEdgeStats {
@@ -281,8 +296,19 @@ impl<Mode> Store<Mode> {
     /// Get chunks that reference a given type name.
     /// Forward query: "who uses Config?" Returns chunks that have type edges
     /// pointing to the given type name.
-    pub fn get_type_users(&self, type_name: &str) -> Result<Vec<ChunkSummary>, StoreError> {
-        let _span = tracing::debug_span!("get_type_users", type_name).entered();
+    ///
+    /// P2 #65 (recovery wave): `limit` is now bound at SQL time so we don't
+    /// fetch every row of a popular type just to drop the tail in Rust. CLI
+    /// callers that previously called `users.truncate(limit)` after the fact
+    /// pass the same value here; loaders that genuinely want all rows pass
+    /// `usize::MAX` (SQLite caps `LIMIT ?` at i64::MAX, so usize::MAX -> i64
+    /// saturates to no-op).
+    pub fn get_type_users(
+        &self,
+        type_name: &str,
+        limit: usize,
+    ) -> Result<Vec<ChunkSummary>, StoreError> {
+        let _span = tracing::debug_span!("get_type_users", type_name, limit).entered();
         tracing::debug!("querying type users");
 
         self.rt.block_on(async {
@@ -292,9 +318,11 @@ impl<Mode> Store<Mode> {
                  FROM type_edges te
                  JOIN chunks c ON te.source_chunk_id = c.id
                  WHERE te.target_type_name = ?1
-                 ORDER BY c.origin, c.line_start",
+                 ORDER BY c.origin, c.line_start
+                 LIMIT ?2",
             )
             .bind(type_name)
+            .bind(limit_to_sql(limit))
             .fetch_all(&self.pool)
             .await?
             .iter()
@@ -308,8 +336,16 @@ impl<Mode> Store<Mode> {
     /// Get types used by a given chunk (by function name).
     /// Reverse query: "what types does parse_config use?" Returns [`TypeUsage`] structs
     /// where edge_kind is "" for catch-all types.
-    pub fn get_types_used_by(&self, chunk_name: &str) -> Result<Vec<TypeUsage>, StoreError> {
-        let _span = tracing::debug_span!("get_types_used_by", chunk_name).entered();
+    ///
+    /// P2 #65: `limit` mirrors `get_type_users`. Pass `usize::MAX` to disable
+    /// the cap (the SQL `LIMIT ?` will receive i64::MAX, which is effectively
+    /// no limit).
+    pub fn get_types_used_by(
+        &self,
+        chunk_name: &str,
+        limit: usize,
+    ) -> Result<Vec<TypeUsage>, StoreError> {
+        let _span = tracing::debug_span!("get_types_used_by", chunk_name, limit).entered();
         tracing::debug!("querying types used by chunk");
 
         self.rt.block_on(async {
@@ -318,9 +354,11 @@ impl<Mode> Store<Mode> {
                  FROM type_edges te
                  JOIN chunks c ON te.source_chunk_id = c.id
                  WHERE c.name = ?1
-                 ORDER BY te.edge_kind, te.target_type_name",
+                 ORDER BY te.edge_kind, te.target_type_name
+                 LIMIT ?2",
             )
             .bind(chunk_name)
+            .bind(limit_to_sql(limit))
             .fetch_all(&self.pool)
             .await?;
 
@@ -648,14 +686,14 @@ mod tests {
             .unwrap();
 
         // Query: who uses Config?
-        let users = store.get_type_users("Config").unwrap();
+        let users = store.get_type_users("Config", usize::MAX).unwrap();
         assert_eq!(users.len(), 2);
         let names: Vec<&str> = users.iter().map(|c| c.name.as_str()).collect();
         assert!(names.contains(&"func_a"));
         assert!(names.contains(&"func_b"));
 
         // Query: who uses Store?
-        let users = store.get_type_users("Store").unwrap();
+        let users = store.get_type_users("Store", usize::MAX).unwrap();
         assert_eq!(users.len(), 1);
         assert_eq!(users[0].name, "func_a");
     }
@@ -669,7 +707,7 @@ mod tests {
             .upsert_type_edges("chunk-a", &make_type_refs())
             .unwrap();
 
-        let types = store.get_types_used_by("func_a").unwrap();
+        let types = store.get_types_used_by("func_a", usize::MAX).unwrap();
         assert_eq!(types.len(), 3);
         let type_names: Vec<&str> = types.iter().map(|t| t.type_name.as_str()).collect();
         assert!(type_names.contains(&"Config"));
@@ -686,7 +724,7 @@ mod tests {
         store
             .upsert_type_edges("chunk-a", &make_type_refs())
             .unwrap();
-        let types = store.get_types_used_by("func_a").unwrap();
+        let types = store.get_types_used_by("func_a", usize::MAX).unwrap();
         assert_eq!(types.len(), 3);
 
         // Second upsert: only HashMap
@@ -700,7 +738,7 @@ mod tests {
                 }],
             )
             .unwrap();
-        let types = store.get_types_used_by("func_a").unwrap();
+        let types = store.get_types_used_by("func_a", usize::MAX).unwrap();
         assert_eq!(types.len(), 1);
         assert_eq!(types[0].type_name, "HashMap");
     }
@@ -708,14 +746,16 @@ mod tests {
     #[test]
     fn test_get_type_users_empty() {
         let (store, _dir) = setup_store();
-        let users = store.get_type_users("NonexistentType").unwrap();
+        let users = store.get_type_users("NonexistentType", usize::MAX).unwrap();
         assert!(users.is_empty());
     }
 
     #[test]
     fn test_get_types_used_by_empty() {
         let (store, _dir) = setup_store();
-        let types = store.get_types_used_by("nonexistent_func").unwrap();
+        let types = store
+            .get_types_used_by("nonexistent_func", usize::MAX)
+            .unwrap();
         assert!(types.is_empty());
     }
 
@@ -948,7 +988,7 @@ mod tests {
             )
             .unwrap();
 
-        let types = store.get_types_used_by("func_a").unwrap();
+        let types = store.get_types_used_by("func_a", usize::MAX).unwrap();
         let config = types.iter().find(|t| t.type_name == "Config").unwrap();
         assert_eq!(config.edge_kind, "Param");
 
@@ -988,11 +1028,11 @@ mod tests {
             .upsert_type_edges_for_file(Path::new("src/test.rs"), &chunk_type_refs)
             .unwrap();
 
-        let users = store.get_type_users("Config").unwrap();
+        let users = store.get_type_users("Config", usize::MAX).unwrap();
         assert_eq!(users.len(), 1);
         assert_eq!(users[0].name, "func_a");
 
-        let users = store.get_type_users("Store").unwrap();
+        let users = store.get_type_users("Store", usize::MAX).unwrap();
         assert_eq!(users.len(), 1);
         assert_eq!(users[0].name, "func_b");
     }
@@ -1029,10 +1069,10 @@ mod tests {
             .upsert_type_edges_for_file(Path::new("src/test.rs"), &chunk_type_refs)
             .unwrap();
 
-        let users = store.get_type_users("Config").unwrap();
+        let users = store.get_type_users("Config", usize::MAX).unwrap();
         assert_eq!(users.len(), 1);
         // Store type edge was NOT inserted (chunk not found)
-        let users = store.get_type_users("Store").unwrap();
+        let users = store.get_type_users("Store", usize::MAX).unwrap();
         assert!(users.is_empty());
     }
 

--- a/src/where_to_add.rs
+++ b/src/where_to_add.rs
@@ -786,6 +786,7 @@ mod tests {
             parent_type_name: None,
             content_hash: String::new(),
             window_idx: None,
+            parser_version: 0,
         }
     }
 

--- a/tests/model_eval.rs
+++ b/tests/model_eval.rs
@@ -1481,6 +1481,7 @@ fn test_hard_reranker_comparison() {
                             window_idx: None,
                             parent_id: None,
                             parent_type_name: None,
+                            parser_version: 0,
                         },
                         score: *score,
                     }

--- a/tests/reference_test.rs
+++ b/tests/reference_test.rs
@@ -30,6 +30,7 @@ fn make_code_result(name: &str, score: f32) -> SearchResult {
             parent_type_name: None,
             content_hash: String::new(),
             window_idx: None,
+            parser_version: 0,
         },
         score,
     }

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -17,7 +17,7 @@ fn test_store_init() {
     let stats = store.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
     assert_eq!(stats.total_files, 0);
-    assert_eq!(stats.schema_version, 20); // v20: AFTER DELETE trigger on chunks (DS-W2)
+    assert_eq!(stats.schema_version, 21); // v21: parser_version column on chunks (P2 #29 / v1.28.1)
     assert_eq!(stats.model_name, cqs::embedder::DEFAULT_MODEL_REPO);
 }
 
@@ -1107,7 +1107,7 @@ fn test_open_readonly_on_initialized_store() {
     let ro = cqs::store::Store::open_readonly(&db_path).unwrap();
     let stats = ro.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
-    assert_eq!(stats.schema_version, 20);
+    assert_eq!(stats.schema_version, 21);
     assert_eq!(stats.model_name, cqs::embedder::DEFAULT_MODEL_REPO);
 }
 

--- a/tests/task_test.rs
+++ b/tests/task_test.rs
@@ -250,6 +250,7 @@ fn test_compute_risk_and_tests_integration() {
         parent_type_name: None,
         content_hash: String::new(),
         window_idx: None,
+        parser_version: 0,
     }];
 
     let (scores, tests) =


### PR DESCRIPTION
## Summary

Recovery patch — **v1.28.1**. Lands 8 P2 audit fixes that were silently lost in the v1.28.0 wave's parallel-agent dispatch.

The v1.28.0 CHANGELOG advertised these as landed; the audit-mode follow-up caught them as `TODO(P2 #N)` stubs in code. No data loss for users on v1.28.0 — schema migration is automatic on first open.

## What was lost

| Cluster | Items | Cause |
|---|---|---|
| **Agent D's full scope** (6 items, `src/store/*` + `src/hnsw/`) | #29 schema v21 + `parser_version`; #30 HNSW backup `?`-prop; #32 `prune_all` Phase 1 TOCTOU; #42 `default_readonly_pooled_config`; #64 `upsert_function_calls_for_files` batch; #65 `get_type_users`/`get_types_used_by` SQL LIMIT | Agent D's report flagged "scope=risky, BLOCKED" — work was wiped twice by parallel-agent `git reset` events; never recovered. The Chunk struct had `parser_version: u32` (Agent A landed it) but the schema column + UPSERT WHERE plumbing never made it. |
| **Agent A/I coordination gap** (2 items) | #53 `LanguageDef::line_comment_prefixes`; #55 `LanguageDef::aliases` | Agent A stubbed for "Agent I to land", Agent I deferred to "Agent A". Both `TODO(P2 #N)` markers in code; `line_looks_comment_like` had `_lang: Language` (param ignored) with hardcoded global list. |

## Stats

- **42 files changed** (+931 / −234)
- **1,575 lib tests pass** (+6 vs v1.28.0; cagra SIGSEGV pre-existing)
- New tests: schema v21 round-trip, HNSW backup error propagation, `LanguageDef` field population checks, fenced-lang alias regression pins
- `cargo clippy --features gpu-index --lib -- -D warnings` clean

## Migration notes

- Users on v1.28.0 see schema migrate v20 → v21 on first open. Migration is in-place, adds `parser_version INTEGER NOT NULL DEFAULT 0` to `chunks`. No reindex required.
- Optional follow-up: `cqs index --force` lets the chunker doc-fallback fix from PR #1040 actually take effect on previously-indexed short chunks (since their `parser_version` is now 0; future bumps force re-extraction).

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib -- --skip cagra` → 1575 passed (was 1569)
- [x] Schema v21 round-trip test
- [x] HNSW backup propagation test
- [x] `LanguageDef::line_comment_prefixes` + `aliases` populated for common languages
- [x] `cargo clippy --features gpu-index --lib -- -D warnings` clean
- [x] `cargo fmt --check`
- [ ] CI green
- [ ] `cargo publish` (post-merge)

## Lessons learned

For the next audit / parallel-agent wave: **cross-cutting struct field additions need to be wave-0 prerequisites.** Agent A added `parser_version: u32` to the `Chunk` struct in parallel with Agent D adding the schema migration; when Agent D's work was wiped, the field existed in memory but had no on-disk persistence, and no caller raised an error because the UPSERT path silently dropped the unknown column. A pre-wave commit landing the schema first would have caught this in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
