### PR TITLE
fix(embedder,cli): raw-source windowing + reranker pool cap 100->20 + retrain tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,9 @@ cuvs-fork-push
 # directory. Their `.git` is a file, not a directory; the file walker also
 # skips them at runtime to prevent indexing duplicated source trees.
 .claude/worktrees/
+
+# Reranker V2 retrain artifacts (large jsonl, train weights live in ~/training-data/)
+evals/reranker_v3/
+evals/reranker_v2_train.jsonl
+evals/reranker_v2_dev.jsonl
+evals/reranker_v2_test.jsonl

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -17,11 +17,45 @@ v1.28.0 shipped 2026-04-19 (post-audit release, 150 findings closed across PRs #
 
 Both splits show consistent positive lifts. The asymmetry from the v1.28.0 wave (test gain didn't replicate on dev) was fixture drift — `evals/regenerate_v3_test.py` had a bug reading the post-#1038 envelope shape (`out["data"]["results"]` instead of `out["results"]`) so it returned 100% unresolved on first attempt; fixed in `evals/regenerate_v3_test.py:155-159` (kept inline, not yet PR'd).
 
-**Right Now:** v1.28.1 binary installed; daemon restarted; index at 15,603 chunks / schema v21 / 7,675 LLM summaries (49% coverage). v3.v2 fixture regenerated against current corpus (test: 41 strict / 1 basename / 57 name-fallback / 10 unresolved; dev: 49 / 1 / 52 / 7). Audit dossier at `docs/audit-{findings,triage}.md`; next strategic step is **Reranker V2 retrain with post-mortem fixes** per the user's chained direction.
+**Right Now:** **Reranker V2 retrain done (2026-04-20) — net negative again, weights stay local. Two related cqs fixes ARE shippable.**
 
-**Branch:** main.
+### A/B results on v3.v2 (post-windowing-fix reindex, pool cap 20, UniXcoder graded weights)
 
-**Pending uncommitted:** `evals/regenerate_v3_test.py` (envelope-aware fix), `evals/queries/v3_{test,dev}.{v2,diff}.json` (fresh fixture from current corpus). Worth one PR.
+| Split | Metric | Baseline (stage-1) | Rerank | Δ |
+|---|---|---|---|---|
+| test | R@1 | 42.2% | 28.4% | **−13.8pp** |
+| test | R@5 | 63.3% | 56.9% | **−6.4pp** |
+| test | R@20 | 81.7% | 81.7% | ±0 |
+| dev | R@1 | 41.3% | 32.1% | **−9.2pp** |
+| dev | R@5 | 75.2% | 67.9% | **−7.3pp** |
+| dev | R@20 | 88.1% | 88.1% | ±0 |
+
+**Diagnosis:** R@20 unchanged on both splits → gold IS in pool=20 → reranker just demotes it within the top 20. ~17pp R@5 improvement over Phase 3 (Stack v2 + binary) but ship gate (R@5 ≥ 0) still fails. Likely cause: severe class imbalance in training data (77% label=0.0, 14% A, 10% TIE) compresses score-head range. Future fix: class-weighted BCE or pairwise margin loss; possibly bigger base model (bge-reranker-large).
+
+**Weights:** `~/training-data/reranker-v2-cqs-graded/` (504MB safetensors + ONNX via optimum-cli in fresh `onnx-export` conda env). Daemon override at `~/.config/systemd/user/cqs-watch.service.d/override.conf` points `CQS_RERANKER_MODEL` here — disable to revert.
+
+### Shippable wins from this arc
+
+1. **Windowing-fix** at `src/embedder/mod.rs:564`. Windowed chunks (7228/15616) were being stored with lossy WordPiece `tokenizer.decode()` output as `chunks.content` (lowercased, space-separated subwords like "pub fn save ( & self )"). Fix uses `encoding.get_offsets()` to slice raw source text. Regression test in integration mod. Requires reindex (already done).
+
+2. **Pool cap default lowered** in `src/cli/limits.rs`: `RERANK_POOL_MAX 100 → 20` per post-mortem #3 + Drowning-in-Documents (arXiv 2411.11767). Env override `CQS_RERANK_POOL_MAX` still honored. Test updated.
+
+3. **Eval tooling**: `evals/label_reranker_v3.py` (Gemma 3-way pointwise labeling, observable+resumable), `evals/rerank_ab_eval.py` (envelope-aware A/B harness for `--rerank` toggle).
+
+### Pending uncommitted
+
+- `src/embedder/mod.rs` (windowing fix + regression test in integration mod)
+- `src/cli/limits.rs` (pool cap default 100→20 + test update)
+- `evals/label_reranker_v3.py` (new)
+- `evals/rerank_ab_eval.py` (new)
+- `evals/regenerate_v3_test.py` (envelope-aware payload, already in)
+- `evals/queries/v3_{test,dev}.{v2,diff}.json` (fresh fixtures)
+
+**Branch:** main. Worth one PR for the windowing fix + pool cap + eval tooling. The trained weights are deferred (stay local).
+
+### Daemon/reindex lock conflict
+
+Found while running `cqs index --force` with `cqs-watch --serve` active: both hold fd on `.cqs/index.hnsw.lock`, reindex blocks for 60+ minutes in `locks_lock_inode_wait`. WSL/NTFS shows "advisory-only" warning but the wait still happens. Workaround: stop daemon before reindex. Proper fix: `cqs index --force` should SIGTERM daemon or fail loudly. Note saved.
 
 ### Lever-by-lever results
 

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -1412,3 +1412,38 @@ mentions = ["evals/colbert_rerank_eval.py"]
 sentiment = -0.5
 text = "cqs gc had a latent bug: origin_exists fell through to Path::exists(), keeping any chunk whose file was on disk regardless of whether enumerate_files (worktree-skip + gitignore filter) actually owned it. Fix: drop the exists() fallback, canonicalize via dunce, require strict membership in existing_files. Pruned 522 worktree+gitignored chunks from production index. Watch for this pattern when adding new schema-prune logic."
 mentions = ["src/store/chunks/staleness.rs"]
+
+[[note]]
+sentiment = -1.0
+text = "Windowing bug in src/embedder/mod.rs:564 was storing lossy tokenizer.decode() output as chunks.content for windowed chunks (7228 of 15616). WordPiece decode lowercases + space-separates subwords so stored content looked like 'pub fn save ( & self )' instead of raw source. Fix: slice original text by encoding.get_offsets() character ranges. Regression test added in integration mod. Requires reindex."
+mentions = [
+    "src/embedder/mod.rs",
+    "src/cli/pipeline/windowing.rs",
+    "windowing",
+]
+
+[[note]]
+sentiment = 0.5
+text = "Reranker V2 post-mortem fix #3 (pool cap at 20) landed by lowering RERANK_POOL_MAX default from 100 to 20 in src/cli/limits.rs. At --limit 5 --rerank, pool was already 20 (5*4=20, under 100 cap). At --limit 20 --rerank it was 80; now 20. Env override CQS_RERANK_POOL_MAX still honored. Per 'Drowning in Documents' arXiv 2411.11767 + Phase 3 brittleness analysis."
+mentions = [
+    "src/cli/limits.rs",
+    "reranker",
+]
+
+[[note]]
+sentiment = -1.0
+text = "cqs index --force blocks indefinitely if cqs-watch --serve is running. Both hold fd on .cqs/index.hnsw.lock (daemon: shared R, reindex: exclusive W). Reindex waits in locks_lock_inode_wait. On WSL/NTFS the 'advisory-only' warning fires but the wait still happens. Workaround: systemctl --user stop cqs-watch before reindex, start after. Proper fix: index --force should SIGTERM daemon or fail loudly with instructions."
+mentions = [
+    "src/hnsw/persist.rs",
+    "src/cli/watch.rs",
+    "index",
+]
+
+[[note]]
+sentiment = -0.5
+text = "Reranker V2 retrain (graded labels + cqs domain) recovered ~17pp R@5 vs Phase 3 (Stack v2 + binary) but is still net negative: -6.4pp R@5 test, -7.3pp R@5 dev. R@20 unchanged on both splits — gold IS in the pool, reranker just demotes it. Root cause is likely severe class imbalance (77% label=0.0 vs 14% A vs 10% TIE) compressing the score head's range. Weights stay local at ~/training-data/reranker-v2-cqs-graded; ship gate (R@5 ≥ 0) failed. Future: class-weighted BCE or pairwise margin loss."
+mentions = [
+    "evals/train_reranker_v2.py",
+    "evals/label_reranker_v3.py",
+    "reranker",
+]

--- a/evals/label_reranker_v3.py
+++ b/evals/label_reranker_v3.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Label cqs-domain reranker candidates via Gemma 4 31B for graded pointwise training.
+
+Reads v3_{train,dev,test}.json and v3_pools.json, pulls raw chunk content
+straight from source files (bypassing the tokenized-content bug in some
+cqs stored rows), and asks Gemma to score each (query, candidate) pair
+on a 3-way scale:
+
+    relevant   -> label 1.0
+    partial    -> label 0.5
+    not_relevant -> label 0.0
+
+Output (JSONL, one per line):
+    {"query": str, "content": str, "label": float,
+     "query_idx": int, "gold": bool, "chunk_name": str, "chunk_file": str,
+     "split": "train"|"dev"|"test"}
+
+Three contracts (per feedback_orr_default.md):
+
+  Observable
+    - Heartbeat to stderr every ~20 items (rows/sec, eta, pct done)
+    - Events append to evals/label_reranker_v3.events.jsonl: start/row/resume/done
+
+  Robust
+    - Skips candidates whose content file is missing or line range is invalid
+    - Skips raw LLM replies that don't match one of the three verdicts
+    - Falls back to 0.0 (not_relevant) if the LLM reply is non-parseable but
+      only AFTER logging + counting; never silently invents a label
+
+  Resumable
+    - Uses LLMClient's blake3→SQLite cache: re-running is a no-op on already-labeled pairs
+    - Output JSONL is append-only; on resume we re-read existing rows and skip them
+    - A fresh --output directory starts from scratch; an existing one continues
+
+Run:
+    python3 evals/label_reranker_v3.py \\
+        --output evals/reranker_v3 \\
+        --concurrency 16
+
+Smoke (first 20 rows per split):
+    python3 evals/label_reranker_v3.py --limit-per-split 20 --output /tmp/rr3-smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from llm_client import LLMClient
+
+QUERIES_DIR = Path(__file__).parent / "queries"
+POOLS_PATH = QUERIES_DIR / "v3_pools.json"
+SPLITS = [
+    ("train", QUERIES_DIR / "v3_train.json"),
+    ("dev", QUERIES_DIR / "v3_dev.v2.json"),
+    ("test", QUERIES_DIR / "v3_test.v2.json"),
+]
+
+VERDICT_TO_LABEL = {"relevant": 1.0, "partial": 0.5, "not_relevant": 0.0}
+
+# Gemma has an 8192-token context. System prompt + query + instructions eat
+# ~400 tokens; leave a safe margin and cap content at ~28k chars (~7k tokens
+# at a conservative 4 chars/token). Longer chunks are truncated with a
+# marker so the LLM sees the signal-rich head, not a hard 400 error.
+MAX_CONTENT_CHARS = 28_000
+
+
+SYSTEM_PROMPT = (
+    "You judge whether a code chunk is relevant to a search query in a "
+    "code-retrieval system. You reply with EXACTLY one of three tokens:\n"
+    "\n"
+    "  relevant       — the chunk is a direct match for what the query asks; "
+    "a developer seeing this chunk first would say 'yes, this is what I wanted'.\n"
+    "  partial        — the chunk is related (same module, mentions the concept, "
+    "similar signature) but is not the primary answer. A developer might click "
+    "through but would prefer something more specific.\n"
+    "  not_relevant   — the chunk does not answer the query. Wrong function, "
+    "wrong concept, or only surface-level word overlap.\n"
+    "\n"
+    "Be strict. Only return 'relevant' for a clear primary answer. When in "
+    "doubt between partial and not_relevant, pick not_relevant.\n"
+    "\n"
+    "Reply with ONLY the verdict word — no quotes, no markdown, no prose."
+)
+
+
+def load_source_content(repo_root: Path, origin: str, line_start: int, line_end: int) -> str | None:
+    """Read raw source content from the repo for the given chunk span.
+
+    Returns None if the file is missing or the line range is out of bounds.
+    We use 1-indexed inclusive line ranges, matching cqs conventions.
+    """
+    if not origin or line_start is None or line_end is None:
+        return None
+    p = repo_root / origin
+    if not p.exists() or not p.is_file():
+        return None
+    try:
+        lines = p.read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)
+    except OSError:
+        return None
+    if line_start < 1 or line_end > len(lines) or line_start > line_end:
+        return None
+    return "".join(lines[line_start - 1 : line_end])
+
+
+def build_work_items(repo_root: Path, limit_per_split: int | None) -> list[dict]:
+    """Flatten train+dev+test × pool into a list of labeling work items."""
+    pools_data = json.loads(POOLS_PATH.read_text())
+    pools_by_query: dict[str, dict] = {p["query"]: p for p in pools_data["pools"]}
+
+    items: list[dict] = []
+    missing_file = 0
+    missing_pool = 0
+
+    for split_name, split_path in SPLITS:
+        if not split_path.exists():
+            print(f"[skip] {split_name}: {split_path} missing", file=sys.stderr)
+            continue
+        rows = json.loads(split_path.read_text())["queries"]
+        if limit_per_split:
+            rows = rows[:limit_per_split]
+
+        for q_idx, entry in enumerate(rows):
+            query = entry["query"]
+            gold = entry.get("gold_chunk") or {}
+            gold_key = (gold.get("origin"), gold.get("name"), gold.get("line_start"))
+            pool_entry = pools_by_query.get(query)
+            if not pool_entry:
+                missing_pool += 1
+                continue
+            for cand in pool_entry.get("pool", []):
+                r = cand["result"]
+                origin = r.get("file") or r.get("origin")
+                line_start = r.get("line_start")
+                line_end = r.get("line_end")
+                name = r.get("name")
+                content = load_source_content(repo_root, origin, line_start, line_end)
+                if content is None:
+                    missing_file += 1
+                    continue
+                is_gold = (origin, name, line_start) == gold_key
+                items.append({
+                    "split": split_name,
+                    "query": query,
+                    "query_idx": q_idx,
+                    "content": content,
+                    "chunk_name": name,
+                    "chunk_file": origin,
+                    "line_start": line_start,
+                    "line_end": line_end,
+                    "gold": is_gold,
+                })
+    print(
+        f"[load] {len(items)} work items (missing_pool={missing_pool}, "
+        f"missing_file={missing_file})",
+        file=sys.stderr,
+    )
+    return items
+
+
+def load_completed(out_dir: Path) -> set[tuple]:
+    """Keys of rows already written, so we can resume without re-calling the LLM.
+
+    Key = (split, query, chunk_file, chunk_name, line_start).
+    """
+    completed: set[tuple] = set()
+    for split, _ in SPLITS:
+        path = out_dir / f"reranker_v3_{split}.graded.jsonl"
+        if not path.exists():
+            continue
+        with path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    r = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                completed.add((
+                    r.get("split"),
+                    r.get("query"),
+                    r.get("chunk_file"),
+                    r.get("chunk_name"),
+                    r.get("line_start"),
+                ))
+    return completed
+
+
+async def label_one(
+    client: LLMClient,
+    query: str,
+    content: str,
+) -> tuple[str, str]:
+    """Return (verdict, raw_reply). Verdict is one of relevant/partial/not_relevant, or 'invalid'."""
+    if len(content) > MAX_CONTENT_CHARS:
+        content = content[:MAX_CONTENT_CHARS] + "\n… [truncated]"
+    user = (
+        f"Query: {query}\n"
+        f"\n"
+        f"Code chunk:\n"
+        f"```\n{content}\n```\n"
+        f"\n"
+        f"Verdict (one word):"
+    )
+    raw = await client._chat(
+        SYSTEM_PROMPT, user, role="rerank_v3_pointwise", max_tokens=8, temperature=0.0
+    )
+    tok = raw.strip().lower().split()[0] if raw.strip() else ""
+    if tok in VERDICT_TO_LABEL:
+        return tok, raw
+    # Second-chance: exact-word match in the reply
+    low = raw.lower()
+    for key in VERDICT_TO_LABEL:
+        if key in low:
+            return key, raw
+    return "invalid", raw
+
+
+class EventLog:
+    def __init__(self, path: Path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.path = path
+
+    def emit(self, kind: str, **fields) -> None:
+        rec = {"ts": time.strftime("%Y-%m-%dT%H:%M:%S"), "kind": kind, **fields}
+        with self.path.open("a") as f:
+            f.write(json.dumps(rec, default=str) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+
+
+async def main_async():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--output", type=Path, required=True,
+                    help="Output directory. Creates {train,dev,test}.graded.jsonl here.")
+    ap.add_argument("--repo-root", type=Path, default=Path("/mnt/c/Projects/cqs"))
+    ap.add_argument("--concurrency", type=int, default=16)
+    ap.add_argument("--limit-per-split", type=int, default=None,
+                    help="Truncate each split to first N queries (smoke test).")
+    args = ap.parse_args()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    events = EventLog(args.output / "events.jsonl")
+    events.emit("start", argv=sys.argv, args=vars(args))
+
+    items = build_work_items(args.repo_root, args.limit_per_split)
+    completed = load_completed(args.output)
+    if completed:
+        print(f"[resume] {len(completed)} rows already labeled — skipping them",
+              file=sys.stderr)
+        events.emit("resume", completed=len(completed))
+
+    remaining = [
+        it for it in items
+        if (it["split"], it["query"], it["chunk_file"], it["chunk_name"], it["line_start"])
+        not in completed
+    ]
+    n_total = len(remaining)
+    print(f"[plan] {n_total} items to label (already done: {len(items) - n_total})",
+          file=sys.stderr)
+    if n_total == 0:
+        print("[done] nothing to do", file=sys.stderr)
+        return 0
+
+    client = LLMClient()
+    sem = asyncio.Semaphore(args.concurrency)
+
+    writers: dict[str, object] = {}
+    for split, _ in SPLITS:
+        writers[split] = (args.output / f"reranker_v3_{split}.graded.jsonl").open("a")
+
+    counts = {"relevant": 0, "partial": 0, "not_relevant": 0, "invalid": 0}
+    t0 = time.monotonic()
+    done = 0
+    write_lock = asyncio.Lock()
+
+    async def worker(item):
+        nonlocal done
+        async with sem:
+            verdict, raw = await label_one(client, item["query"], item["content"])
+        counts[verdict] += 1
+        label = VERDICT_TO_LABEL.get(verdict, 0.0)  # invalid → 0.0 per contract
+        row = {
+            "query": item["query"],
+            "content": item["content"],
+            "label": label,
+            "query_idx": item["query_idx"],
+            "gold": item["gold"],
+            "chunk_name": item["chunk_name"],
+            "chunk_file": item["chunk_file"],
+            "line_start": item["line_start"],
+            "split": item["split"],
+            "verdict": verdict,
+        }
+        async with write_lock:
+            f = writers[item["split"]]
+            f.write(json.dumps(row) + "\n")
+            f.flush()
+            done += 1
+            if done % 20 == 0 or done == n_total:
+                elapsed = time.monotonic() - t0
+                rate = done / max(elapsed, 0.001)
+                eta_s = (n_total - done) / max(rate, 0.001)
+                print(
+                    f"  {done}/{n_total} ({100 * done / n_total:.1f}%) "
+                    f"{rate:.2f} rows/s eta {eta_s / 60:.1f}m "
+                    f"rel={counts['relevant']} par={counts['partial']} "
+                    f"not={counts['not_relevant']} inv={counts['invalid']}",
+                    file=sys.stderr, flush=True,
+                )
+                events.emit(
+                    "progress", done=done, total=n_total, rate=round(rate, 2),
+                    counts=dict(counts),
+                )
+
+    try:
+        tasks = [asyncio.create_task(worker(it)) for it in remaining]
+        await asyncio.gather(*tasks)
+    finally:
+        for f in writers.values():
+            f.close()
+        await client.aclose()
+
+    wall = time.monotonic() - t0
+    events.emit("done", wall_secs=round(wall, 1), counts=dict(counts), done=done)
+    print(
+        f"\n[done] {done} rows in {wall / 60:.1f}m "
+        f"rel={counts['relevant']} par={counts['partial']} "
+        f"not={counts['not_relevant']} inv={counts['invalid']}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def main():
+    sys.exit(asyncio.run(main_async()))
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/rerank_ab_eval.py
+++ b/evals/rerank_ab_eval.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""A/B eval: baseline (stage-1 only) vs baseline + `--rerank` on v3.v2 splits.
+
+Computes R@1/R@5/R@20 per config against the v3_{split}.v2.json gold. Runs
+both configs for every query so the diff is apples-to-apples on the same
+index state (i.e. same reindex, same SPLADE alpha, same SQLite content).
+
+Output (JSON to --save and printed markdown table):
+    {
+        "split": "test",
+        "n_queries": 109,
+        "baseline":  {"r1": 45, "r5": 72, "r20": 93, ...},
+        "rerank":    {"r1": ..., "r5": ..., "r20": ..., ...},
+        "delta":     {"r1": +4, "r5": +3, "r20": -1},
+        "per_query": [ { query, match_baseline, match_rerank }, ... ],
+    }
+
+The reranker model is selected via `CQS_RERANKER_MODEL_DIR` or whatever the
+default rerank wiring uses. This script doesn't pick the model — it just
+toggles --rerank on/off and compares.
+
+Run:
+    python3 evals/rerank_ab_eval.py --split test --save /tmp/ab-test.json
+    python3 evals/rerank_ab_eval.py --split dev  --save /tmp/ab-dev.json
+
+Robustness:
+    - Per-query timeout (default 120s). Timed-out queries are counted as miss
+      for both configs so the diff is still meaningful.
+    - Resumes via --save: if the file exists, rows with `rerank` already
+      filled are skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+QUERIES_DIR = Path(__file__).parent / "queries"
+
+
+def gold_key(g: dict) -> tuple:
+    return (g.get("origin"), g.get("name"), g.get("line_start"))
+
+
+def match_gold(gold: dict, results: list[dict], k: int) -> int | None:
+    """Return the 1-indexed rank of the gold within the top-k, else None."""
+    gold_k = gold_key(gold)
+    for i, r in enumerate(results[:k]):
+        rk = (r.get("file"), r.get("name"), r.get("line_start"))
+        if rk == gold_k:
+            return i + 1
+    return None
+
+
+def run_batch(queries: list[str], rerank: bool, limit: int = 20, timeout_s: int = 120) -> list[list[dict]]:
+    """Run a batch of queries through `cqs batch`. Returns per-query result lists."""
+    env = {**os.environ, "CQS_CENTROID_CLASSIFIER": "0"}
+    proc = subprocess.Popen(
+        ["cqs", "batch"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=open("/tmp/ab-eval.stderr", "ab"),
+        text=True,
+        bufsize=1,
+        env=env,
+    )
+
+    out = []
+    t0 = time.monotonic()
+    try:
+        for i, q in enumerate(queries):
+            flags = f"--limit {limit} --splade"
+            if rerank:
+                flags += " --rerank"
+            cmd = f"search {shlex.quote(q)} {flags}"
+            try:
+                proc.stdin.write(cmd + "\n")
+                proc.stdin.flush()
+            except (BrokenPipeError, OSError) as e:
+                print(f"batch died: {e}", file=sys.stderr)
+                break
+
+            line = proc.stdout.readline()
+            if not line:
+                print(f"batch EOF at q={i}", file=sys.stderr)
+                break
+            try:
+                envelope = json.loads(line)
+                payload = envelope.get("data") if isinstance(envelope.get("data"), dict) else envelope
+                out.append(payload.get("results", []))
+            except json.JSONDecodeError:
+                out.append([])
+
+            if (i + 1) % 20 == 0 or i + 1 == len(queries):
+                rate = (i + 1) / (time.monotonic() - t0)
+                print(f"  {'rerank' if rerank else 'base'}: {i+1}/{len(queries)} ({rate:.1f} qps)",
+                      file=sys.stderr, flush=True)
+    finally:
+        try:
+            proc.stdin.close()
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
+    return out
+
+
+def recall_at_k(rows: list[dict], results: list[list[dict]], k_list=(1, 5, 20)) -> dict:
+    """Compute R@k for each k in k_list. Returns {f"r{k}": count, "n": n}."""
+    counts = {f"r{k}": 0 for k in k_list}
+    misses = []
+    for row, results_i in zip(rows, results):
+        gold = row.get("gold_chunk") or {}
+        best = None
+        for k in k_list:
+            rank = match_gold(gold, results_i, k)
+            if rank is not None:
+                counts[f"r{k}"] += 1
+                if best is None:
+                    best = rank
+        if best is None:
+            misses.append(row["query"])
+    counts["n"] = len(rows)
+    counts["misses"] = misses[:20]  # first 20 misses for eyeballing
+    return counts
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--split", default="test", choices=["test", "dev"])
+    ap.add_argument("--limit", type=int, default=20,
+                    help="Depth for R@K denominator; also passed to `cqs search`")
+    ap.add_argument("--save", type=Path,
+                    help="Save the structured A/B result here (JSON).")
+    args = ap.parse_args()
+
+    src = QUERIES_DIR / f"v3_{args.split}.v2.json"
+    data = json.loads(src.read_text())
+    rows = data["queries"]
+    print(f"[eval] {len(rows)} queries from {src}", file=sys.stderr)
+
+    queries = [r["query"] for r in rows]
+
+    print(f"[cell] baseline (stage-1 only, --splade)", file=sys.stderr)
+    base_results = run_batch(queries, rerank=False, limit=args.limit)
+    base = recall_at_k(rows, base_results)
+
+    print(f"[cell] rerank (--rerank, pool cap 20)", file=sys.stderr)
+    rr_results = run_batch(queries, rerank=True, limit=args.limit)
+    rr = recall_at_k(rows, rr_results)
+
+    delta = {k: rr[k] - base[k] for k in ("r1", "r5", "r20")}
+
+    report = {
+        "split": args.split,
+        "n_queries": len(rows),
+        "baseline": base,
+        "rerank": rr,
+        "delta": delta,
+    }
+
+    print("\n" + "=" * 72)
+    print(f"A/B Rerank Eval — {args.split}.v2 ({len(rows)} queries)")
+    print("=" * 72)
+    hdr = f"| {'Config':20s} | {'R@1':>7s} | {'R@5':>7s} | {'R@20':>7s} |"
+    sep = "|" + "-" * 22 + "|" + "-" * 9 + "|" + "-" * 9 + "|" + "-" * 9 + "|"
+    print(hdr)
+    print(sep)
+    for label, c in (("baseline", base), ("rerank", rr)):
+        print(f"| {label:20s} | {100*c['r1']/c['n']:6.1f}% | "
+              f"{100*c['r5']/c['n']:6.1f}% | {100*c['r20']/c['n']:6.1f}% |")
+    print(sep)
+    n = base["n"]
+    print(f"| {'delta (pp)':20s} | "
+          f"{100*delta['r1']/n:+6.1f} | "
+          f"{100*delta['r5']/n:+6.1f} | "
+          f"{100*delta['r20']/n:+6.1f} |")
+
+    if args.save:
+        args.save.write_text(json.dumps(report, indent=2))
+        print(f"\nSaved {args.save}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cli/limits.rs
+++ b/src/cli/limits.rs
@@ -47,8 +47,15 @@ pub(crate) const RERANK_OVER_RETRIEVAL_MULTIPLIER: usize = 4;
 /// Default hard cap on the reranker pool, regardless of multiplier.
 /// At `--limit 50 --rerank` the multiplier alone would yield 200 — the
 /// cap keeps ORT memory and per-batch latency bounded on small GPUs.
+///
+/// The Reranker V2 post-mortem (2026-04-17) found that weak cross-encoders
+/// degrade monotonically with pool size — at 80 candidates they're just
+/// shuffling noise. "Drowning in Documents" (arXiv 2411.11767) reports
+/// similar behavior for off-the-shelf cross-encoders; small pools
+/// (~20) consistently beat large ones on recall@k. We cap here.
+///
 /// Honored by [`rerank_pool_size`].
-pub(crate) const RERANK_POOL_MAX: usize = 100;
+pub(crate) const RERANK_POOL_MAX: usize = 20;
 
 /// Resolve the over-retrieval multiplier honoring `CQS_RERANK_OVER_RETRIEVAL`.
 /// Falls back to [`RERANK_OVER_RETRIEVAL_MULTIPLIER`] when the env var is
@@ -155,10 +162,12 @@ mod tests {
         // default. We unset before/after to keep tests independent.
         std::env::remove_var("CQS_RERANK_OVER_RETRIEVAL");
         std::env::remove_var("CQS_RERANK_POOL_MAX");
-        // limit=5, default mult=4, default cap=100 → 20
+        // limit=5, default mult=4, default cap=20 → min(20, 20) = 20
         assert_eq!(rerank_pool_size(5), 20);
+        // limit=10 would be 40, but cap=20 holds
+        assert_eq!(rerank_pool_size(10), 20);
         // limit=50 hits the cap
-        assert_eq!(rerank_pool_size(50), 100);
+        assert_eq!(rerank_pool_size(50), 20);
 
         std::env::set_var("CQS_RERANK_OVER_RETRIEVAL", "8");
         std::env::set_var("CQS_RERANK_POOL_MAX", "200");

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -549,6 +549,16 @@ impl Embedder {
             return Ok(vec![(text.to_string(), 0)]);
         }
 
+        // Slice the original `text` by each window's character offsets rather
+        // than decoding token IDs. Decoding a WordPiece tokenizer (BGE) is
+        // lossy — it lowercases, drops original whitespace, and inserts a
+        // space between every subword — so stored chunk content would be
+        // unreadable ("pub fn save ( & self, path : & path )") and useless
+        // for cross-encoder reranking, result display, and NL generation.
+        // `encoding.get_offsets()` maps each token to (start_char, end_char)
+        // in the original input, which lets us return exact source slices.
+        let offsets = encoding.get_offsets();
+
         let mut windows = Vec::new();
         // Step size: tokens per window minus overlap.
         // The assertion above guarantees step > max_tokens/2, ensuring linear window count.
@@ -558,12 +568,16 @@ impl Embedder {
 
         while start < ids.len() {
             let end = (start + max_tokens).min(ids.len());
-            let window_ids: Vec<u32> = ids[start..end].to_vec();
-
-            // Decode back to text
-            let window_text = tokenizer
-                .decode(&window_ids, true)
-                .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
+            let char_start = offsets[start].0;
+            let char_end = offsets[end - 1].1;
+            // Some tokens (added special tokens, BOS/EOS with add_special_tokens=false
+            // unset, padding) have offsets (0, 0) which would collapse the slice.
+            // Fall back to the previous known-good offset in that case.
+            let window_text = if char_end <= char_start {
+                text.to_string()
+            } else {
+                text[char_start..char_end].to_string()
+            };
 
             windows.push((window_text, window_idx));
             window_idx += 1;
@@ -1519,6 +1533,52 @@ mod tests {
             let count = embedder.token_count(text).expect("token_count failed");
             // Unicode text may tokenize differently
             assert!(count > 0, "Expected >0 tokens for unicode, got {}", count);
+        }
+
+        /// Windowing must preserve raw source formatting — decoding token IDs
+        /// back to text is lossy on WordPiece tokenizers (lowercases, inserts
+        /// spaces between subwords), which would corrupt stored chunk content.
+        /// Regression check for the 2026-04-20 windowing fix.
+        #[test]
+        #[ignore]
+        fn split_into_windows_preserves_original_text() {
+            let embedder =
+                Embedder::new(ModelConfig::e5_base()).expect("Failed to create embedder");
+            // Mix of casing, punctuation, multi-space indentation — WordPiece
+            // decode would collapse `pub fn` to `pub fn`, strip mixed-case
+            // identifiers like `CagraError`, and pad every punctuation char
+            // with spaces. Raw slicing keeps all of it.
+            let source = "pub fn save(&self, path: &Path) -> Result<(), CagraError> {\n"
+                .to_string()
+                + &"    let _span = tracing::info_span!(\"cagra_save\").entered();\n".repeat(200);
+            let windows = embedder
+                .split_into_windows(&source, 128, 16)
+                .expect("split_into_windows");
+            assert!(windows.len() > 1, "text must be long enough to window");
+
+            // Each window should be a substring of the original text (modulo
+            // whitespace boundaries where the tokenizer split mid-character-class).
+            for (w, idx) in &windows {
+                assert!(
+                    source.contains(w.trim()),
+                    "window {idx} is not a substring of the source — tokenizer decode leaked"
+                );
+                // WordPiece decode inserts ' ( ' with surrounding spaces. Raw
+                // slicing keeps the exact `(` without spaces.
+                if w.contains('(') {
+                    assert!(
+                        !w.contains(" ( "),
+                        "window {idx} shows WordPiece-decoded punctuation: {w:?}"
+                    );
+                }
+                // WordPiece decode lowercases — raw slicing preserves `CagraError`.
+                // We only check the CagraError part appears in at least one window.
+            }
+            let any_has_camel = windows.iter().any(|(w, _)| w.contains("CagraError"));
+            assert!(
+                any_has_camel,
+                "no window contains `CagraError` — decoding lowercased the text"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Two production fixes from the Reranker V2 retrain arc, plus the eval scaffolding the retrain produced.

### 1. Windowing — `chunks.content` was lossy WordPiece-decoded text

7228 of 15616 chunks were storing `tokenizer.decode(window_ids)` in `chunks.content`. BGE WordPiece lowercases on decode and inserts spaces between subwords, so:

```
pub fn save(&self, path: &Path) -> Result<(), CagraError>
```

was persisted as:

```
pub fn save ( & self, path : & path ) - > result < ( ), cagraerror >
```

This corrupted any consumer of `chunk.content`: `cqs read --focus`, cross-encoder rerank input, search result display.

Fix slices the original `text` by `encoding.get_offsets()` character ranges, returning exact source substrings. Falls back to the full text on degenerate `(0, 0)` offsets so added special tokens can't collapse the slice. Regression test in `embedder::tests::integration::split_into_windows_preserves_original_text` asserts:
- mixed case survives (`CagraError` doesn't get lowercased)
- punctuation has no spaces injected (no `( ` / ` )` decoration)

**Reindex required.** Already done locally — verified raw content via `cqs read --focus save src/cagra.rs`.

### 2. Reranker pool cap default 100→20

Per Phase 3 reranker post-mortem fix #3 + Drowning in Documents (arXiv 2411.11767): weak cross-encoders degrade monotonically with pool size — at 80 candidates they're shuffling noise. Lower `RERANK_POOL_MAX` default from 100 to 20. `CQS_RERANK_POOL_MAX` env override still honored. Test updated.

### 3. Reranker-V2 retrain tooling

- `evals/label_reranker_v3.py`: Gemma 3-way pointwise labeling (`relevant`/`partial`/`not_relevant` → 1.0/0.5/0.0). Pulls chunk content from source files via `(origin, line_start, line_end)` to bypass any stored-content drift. Observable + resumable (per `feedback_orr_default.md`).
- `evals/rerank_ab_eval.py`: envelope-aware A/B harness toggling `--rerank` on a single index state.

### Why no trained weights ship in this PR

A/B on v3.v2 (post-windowing-fix reindex, pool cap 20, UniXcoder graded weights):

| Split | Metric | Baseline | Rerank | Δ |
|---|---|---|---|---|
| test | R@1 | 42.2% | 28.4% | **−13.8pp** |
| test | R@5 | 63.3% | 56.9% | **−6.4pp** |
| test | R@20 | 81.7% | 81.7% | ±0 |
| dev | R@1 | 41.3% | 32.1% | **−9.2pp** |
| dev | R@5 | 75.2% | 67.9% | **−7.3pp** |
| dev | R@20 | 88.1% | 88.1% | ±0 |

R@20 unchanged on both → gold IS in the pool, the weak score head just demotes it. ~17pp R@5 better than Phase 3 (Stack v2 + binary) but still misses the ship gate (R@5 ≥ 0). Weights stay local at `~/training-data/reranker-v2-cqs-graded/`. Future direction: class-weighted BCE or pairwise margin loss to handle the 77% B / 14% A / 10% TIE imbalance from natural pool ratios.

## Test plan

- [x] `cargo test --bin cqs rerank_pool` passes (cap default updated)
- [x] `cargo test --lib split_into_windows -- --ignored` passes (raw-text regression test)
- [x] `cargo fmt --check` clean
- [x] Reindex completed locally (15637 chunks, raw content verified)
- [x] A/B eval ran end-to-end on test+dev splits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
