### PR TITLE
fix(cli): cqs index --force fails fast when daemon holds HNSW lock

### DIFF
--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -81,6 +81,54 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
         }
     }
 
+    // Detect a running cqs-watch --serve daemon BEFORE we touch anything.
+    // The daemon holds a shared file lock on `index.hnsw.lock` for the
+    // lifetime of its in-memory HNSW. A subsequent `cqs index --force` then
+    // blocks indefinitely in `locks_lock_inode_wait` waiting for an
+    // exclusive write lock the daemon will never release. On WSL/NTFS the
+    // "advisory-only" warning fires but the wait still happens. Fail-fast
+    // here with clear instructions instead of hanging for 60+ minutes.
+    //
+    // We use a connect-only probe (not the typed `daemon_ping`) so a daemon
+    // running an older `PingResponse` schema still gets detected — schema
+    // drift would otherwise let the deserialize error fall through and
+    // silently restore the old hang behavior on version mismatches.
+    #[cfg(unix)]
+    if !dry_run {
+        let sock_path = cqs::daemon_translate::daemon_socket_path(&cqs_dir);
+        if sock_path.exists() {
+            use std::os::unix::net::UnixStream;
+            use std::time::Duration;
+            match UnixStream::connect(&sock_path) {
+                Ok(stream) => {
+                    // Connected — daemon is alive enough to hold the HNSW
+                    // lock. Drop the stream immediately and bail.
+                    let _ = stream.set_read_timeout(Some(Duration::from_millis(100)));
+                    drop(stream);
+                    anyhow::bail!(
+                        "A cqs-watch --serve daemon is currently running ({}). It holds a shared lock on \
+                         the HNSW index, so this reindex would block indefinitely in locks_lock_inode_wait. \
+                         Stop the daemon before reindexing:\n\n  \
+                         systemctl --user stop cqs-watch && cqs index{} && systemctl --user start cqs-watch\n\n\
+                         (If you launched the daemon manually, kill that process instead.)",
+                        sock_path.display(),
+                        if force { " --force" } else { "" }
+                    );
+                }
+                Err(e) => {
+                    // Socket file exists but connect failed → stale socket
+                    // (kill -9, OOM, power loss left the file behind). Safe
+                    // to proceed; the next daemon start will replace it.
+                    tracing::debug!(
+                        path = %sock_path.display(),
+                        error = %e,
+                        "stale daemon socket present; proceeding with reindex"
+                    );
+                }
+            }
+        }
+    }
+
     // Acquire lock (unless dry run)
     let _lock = if !dry_run {
         Some(acquire_index_lock(&cqs_dir)?)


### PR DESCRIPTION
## Summary

`cqs index --force` now fails fast when a `cqs-watch --serve` daemon is already running, instead of hanging for 60+ minutes in `locks_lock_inode_wait`.

### The footgun

The daemon holds a shared file lock on `.cqs/index.hnsw.lock` for the lifetime of its in-memory HNSW. A subsequent `cqs index --force` then blocks waiting for an exclusive write lock the daemon will never release. On WSL/NTFS the existing "advisory-only" warning fires but the wait still happens — observed in the wild during the Reranker V2 retrain reindex (1+ hour wedge before manual diagnosis).

### The fix

At the start of `cmd_index`, check whether the daemon socket exists and accepts a TCP connection. If yes, `bail!` with the exact stop/restart command:

```
A cqs-watch --serve daemon is currently running (/run/user/1000/cqs-21cca92c6f05112d.sock).
It holds a shared lock on the HNSW index, so this reindex would block
indefinitely in locks_lock_inode_wait. Stop the daemon before reindexing:

  systemctl --user stop cqs-watch && cqs index --force && systemctl --user start cqs-watch

(If you launched the daemon manually, kill that process instead.)
```

### Why connect-only, not `daemon_ping`

`daemon_ping` deserializes a typed `PingResponse`. If the daemon is running an older schema (e.g. you upgraded the binary but haven't restarted the service), the deserialize fails and `daemon_ping` returns `Err`. Treating that as "dead daemon" silently restores the hang on every version mismatch. The connect-only probe just verifies "something is holding the socket" — which is what actually causes the lock contention.

### Edge case: stale socket files

If the daemon was killed (kill -9, OOM, power loss) and `SocketCleanupGuard` couldn't remove the socket file, `UnixStream::connect` will fail. We log at debug and proceed — no daemon = no lock holder.

### Followup not in this PR

A proper fix would have the daemon expose a `shutdown` socket command and let `cqs index --force --auto-stop-daemon` orchestrate stop → reindex → restart. That needs a new IPC verb and graceful handle release on the daemon side. Out of scope for this fast-fail patch.

## Test plan

- [x] `cargo build --bin cqs --features gpu-index` clean
- [x] Manual: with daemon active, `cqs index` errors immediately (verified above)
- [x] Manual: with daemon stopped, `cqs index --dry-run` proceeds normally
- [x] Existing `cli::tests::test_cmd_index*` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
