### PR TITLE
fix(tests): cli_review_test passes --json not --format json (slow-tests red 2 days)

### DIFF
--- a/tests/cli_review_test.rs
+++ b/tests/cli_review_test.rs
@@ -88,7 +88,7 @@ diff --git a/src/unrelated.txt b/src/unrelated.txt
 ";
 
     let output = cqs()
-        .args(["review", "--stdin", "--format", "json"])
+        .args(["review", "--stdin", "--json"])
         .current_dir(dir.path())
         .write_stdin(diff)
         .output()
@@ -160,7 +160,7 @@ diff --git a/src/lib.rs b/src/lib.rs
 ";
 
     let output = cqs()
-        .args(["review", "--stdin", "--format", "json"])
+        .args(["review", "--stdin", "--json"])
         .current_dir(dir.path())
         .write_stdin(diff)
         .output()
@@ -226,7 +226,7 @@ diff --git a/src/lib.rs b/src/lib.rs
 ";
 
     let output = cqs()
-        .args(["review", "--stdin", "--format", "json", "--tokens", "100"])
+        .args(["review", "--stdin", "--json", "--tokens", "100"])
         .current_dir(dir.path())
         .write_stdin(diff)
         .output()


### PR DESCRIPTION
## Summary

`Slow Tests (nightly)` has been red two days running ([Apr 19](https://github.com/jamie8johnson/cqs/actions/runs/24625412612), [Apr 20](https://github.com/jamie8johnson/cqs/actions/runs/24660616362)). Three integration tests in `tests/cli_review_test.rs` panic on the same line:

```
review --stdin should succeed. stdout= stderr=error: unexpected argument '--format' found
Usage: cqs review --stdin
```

## Root cause

PR #1038 (uniform JSON envelope) collapsed `--format json` into the canonical `--json` boolean flag across the CLI. `cqs review --help` confirms only `--json` is accepted. Three integration tests were missed in the migration:

- `test_review_from_stdin_returns_envelope_with_changed_functions`
- `test_review_json_no_indexed_functions_emits_empty_envelope`
- `test_review_token_budget_adds_token_count_field`

PR CI doesn't catch them — these live in `cli_review_test`, gated by `--features slow-tests`, which only runs in `Slow Tests (nightly)` (08:00 UTC daily, ~2h wall).

## Fix

Replace `["--format", "json"]` with `["--json"]` at all three call sites.

## Test plan

- [x] `cargo test --features gpu-index,slow-tests --test cli_review_test` — 3/3 pass locally (197s wall)
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
