### PR TITLE
chore(hooks): scope pre-edit-impact to cqs src/ and tests/ (skip vendored Rust)

### DIFF
--- a/.claude/hooks/pre-edit-impact.py
+++ b/.claude/hooks/pre-edit-impact.py
@@ -4,6 +4,14 @@
 Only fires when `old_string` contains a `fn foo` / `pub fn foo` declaration.
 Non-fn edits (schema, comments, match arms, string literals) produce no output,
 keeping context injection focused on risky function-targeted changes.
+
+Scope: ONLY fires for cqs's own `src/` and `tests/` trees. Vendored Rust
+subtrees (`cuvs-fork-push/rust/`, future bundled deps) are deliberately
+skipped — `cqs impact` runs against cqs's index, which doesn't contain
+foreign Cargo workspaces, so the lookup would be empty/wrong. Earlier
+versions of this script matched any path containing `/src/`, which fired
+on cuvs-fork-push edits and blocked them with a missing-file error
+during conflict resolution.
 """
 import json
 import os
@@ -15,8 +23,19 @@ inp = json.load(sys.stdin)
 file_path = inp.get("tool_input", {}).get("file_path", "")
 old_string = inp.get("tool_input", {}).get("old_string", "")
 
-# Only analyse Rust source files in src/
-if not file_path.endswith(".rs") or "/src/" not in file_path:
+if not file_path.endswith(".rs"):
+    sys.exit(0)
+
+# Derive cqs project root from the script's own location:
+# <cqs_root>/.claude/hooks/pre-edit-impact.py → ../../ = <cqs_root>
+CQS_ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+abs_path = os.path.realpath(file_path)
+allowed_roots = (
+    os.path.join(CQS_ROOT, "src") + os.sep,
+    os.path.join(CQS_ROOT, "tests") + os.sep,
+)
+if not abs_path.startswith(allowed_roots):
     sys.exit(0)
 
 # Look for a fn / pub fn / pub async fn / pub(crate) fn declaration in old_string.


### PR DESCRIPTION
## Summary

The PreToolUse hook for Edit (`pre-edit-impact.py`) was matching any path containing `/src/`, which included vendored Rust subtrees like `cuvs-fork-push/rust/cuvs/src/`. When an Edit fired against a cuvs file, the hook tried to invoke `python3 .claude/hooks/pre-edit-impact.py` with cwd=cuvs-fork-push, where that script doesn't exist — silently blocking the Edit with a `No such file` error.

Hit today during a rebase of [rapidsai/cuvs#2019](https://github.com/rapidsai/cuvs/pull/2019) to resolve a merge conflict — had to work around by writing the resolved file via a Python heredoc in Bash, which is brittle.

## Fix

Tighten the path predicate: derive cqs root from the script's own location (`<cqs_root>/.claude/hooks/pre-edit-impact.py` → `../../`), then accept only files under `<cqs_root>/src/` or `<cqs_root>/tests/`. Vendored Rust subtrees (cuvs-fork-push, future bundled deps), `evals/`, `samples/`, etc. all silently bail before the `cqs impact` lookup.

## Test plan

Smoke-tested four scenarios with synthetic hook input:

| Path | Expected | Got |
|---|---|---|
| `/mnt/c/Projects/cqs/cuvs-fork-push/rust/cuvs/src/cagra/index.rs` | silent exit 0 | ✓ |
| `/mnt/c/Projects/cqs/src/search/router.rs` | runs `cqs impact` | ✓ |
| `/mnt/c/Projects/cqs/tests/router_test.rs` | runs `cqs impact` | ✓ |
| `/mnt/c/Projects/cqs/evals/some.rs` | silent exit 0 | ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
