### PR TITLE
feat(serve): step 2 — hierarchy 3D view (Y axis = call depth from root)

### DIFF
--- a/src/serve/assets.rs
+++ b/src/serve/assets.rs
@@ -18,9 +18,11 @@ const APP_JS: &str = include_str!("assets/app.js");
 
 // View modules — one per renderer. The router (app.js) dispatches
 // between them based on the URL `?view=` parameter. See
-// `docs/plans/2026-04-22-cqs-serve-3d-progressive.md` step 1.
+// `docs/plans/2026-04-22-cqs-serve-3d-progressive.md` (step 1 added
+// the renderer abstraction; step 2 added the hierarchy view).
 const CALLGRAPH_2D_JS: &str = include_str!("assets/views/callgraph-2d.js");
 const CALLGRAPH_3D_JS: &str = include_str!("assets/views/callgraph-3d.js");
+const HIERARCHY_3D_JS: &str = include_str!("assets/views/hierarchy-3d.js");
 
 // Embedded vendor bundles. See assets/vendor/LICENSES.md for sources +
 // versions. Total ~2.4 MB — noise vs the ~150 MB cqs binary.
@@ -58,6 +60,7 @@ pub(crate) async fn static_asset(Path(path): Path<String>) -> Result<Response, S
         "app.js" => (APP_JS, "application/javascript; charset=utf-8"),
         "views/callgraph-2d.js" => (CALLGRAPH_2D_JS, "application/javascript; charset=utf-8"),
         "views/callgraph-3d.js" => (CALLGRAPH_3D_JS, "application/javascript; charset=utf-8"),
+        "views/hierarchy-3d.js" => (HIERARCHY_3D_JS, "application/javascript; charset=utf-8"),
         "vendor/cytoscape.min.js" => (CYTOSCAPE_JS, "application/javascript; charset=utf-8"),
         "vendor/dagre.min.js" => (DAGRE_JS, "application/javascript; charset=utf-8"),
         "vendor/cytoscape-dagre.min.js" => {

--- a/src/serve/assets/app.css
+++ b/src/serve/assets/app.css
@@ -49,6 +49,62 @@ body { display: flex; flex-direction: column; }
   color: #fff;
 }
 
+.hierarchy-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.hierarchy-controls .btn-group {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+  overflow: hidden;
+}
+.hierarchy-controls .btn-group-label {
+  font-size: 11px;
+  color: #888;
+  padding: 0 6px;
+  border-right: 1px solid #d0d0d0;
+  background: #f5f5f5;
+}
+.hierarchy-controls .btn-group button {
+  background: #fff;
+  border: none;
+  padding: 5px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #555;
+  cursor: pointer;
+  border-right: 1px solid #d0d0d0;
+}
+.hierarchy-controls .btn-group button:last-child { border-right: none; }
+.hierarchy-controls .btn-group button:hover { background: #f5f5f5; }
+.hierarchy-controls .btn-group button.active {
+  background: #4a86e8;
+  color: #fff;
+}
+
+.sidebar-actions {
+  margin: 8px 0 12px 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.sidebar-actions .btn-link {
+  background: #eef3fb;
+  border: 1px solid #c5d4ed;
+  color: #2855a3;
+  padding: 4px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+}
+.sidebar-actions .btn-link:hover {
+  background: #dde7f7;
+}
+
 #search {
   width: 280px;
   padding: 6px 10px;

--- a/src/serve/assets/app.js
+++ b/src/serve/assets/app.js
@@ -18,11 +18,15 @@
   const $cy = document.getElementById("cy");
   const $toggle2D = document.getElementById("view-2d");
   const $toggle3D = document.getElementById("view-3d");
+  const $hierarchyControls = document.getElementById("hierarchy-controls");
+  const $directionGroup = document.getElementById("hierarchy-direction");
+  const $depthGroup = document.getElementById("hierarchy-depth");
 
   // --- View registry ---
   const VIEWS = {
     "2d": () => window.CqsCallgraph2D,
     "3d": () => window.CqsCallgraph3D,
+    hierarchy: () => window.CqsHierarchy3D,
   };
 
   let currentView = null;
@@ -34,8 +38,12 @@
   // browser responsive. User can broaden via URL ?max=NNN.
   const url = new URL(window.location.href);
   const MAX_NODES = parseInt(url.searchParams.get("max") || "1500", 10);
-  const INITIAL_VIEW =
-    url.searchParams.get("view") === "3d" ? "3d" : "2d";
+  function pickInitialView() {
+    const v = url.searchParams.get("view");
+    if (v === "3d" || v === "hierarchy") return v;
+    return "2d";
+  }
+  const INITIAL_VIEW = pickInitialView();
 
   function setStatus(s) {
     $status.textContent = s || "";
@@ -56,14 +64,52 @@
     $toggle3D.classList.toggle("active", viewName === "3d");
   }
 
+  function showHierarchyControls(show) {
+    if (!$hierarchyControls) return;
+    $hierarchyControls.style.display = show ? "inline-flex" : "none";
+  }
+
   function syncUrlView(viewName) {
     const u = new URL(window.location.href);
     if (viewName === "2d") {
       u.searchParams.delete("view");
+      // Hierarchy-only params are stale once we leave the view.
+      u.searchParams.delete("root");
+      u.searchParams.delete("direction");
+      u.searchParams.delete("depth");
+    } else if (viewName === "3d") {
+      u.searchParams.set("view", "3d");
+      u.searchParams.delete("root");
+      u.searchParams.delete("direction");
+      u.searchParams.delete("depth");
     } else {
       u.searchParams.set("view", viewName);
     }
     window.history.replaceState({}, "", u.toString());
+  }
+
+  function syncHierarchyControls() {
+    if (!$directionGroup || !$depthGroup) return;
+    const u = new URL(window.location.href);
+    const dir = u.searchParams.get("direction") || "callees";
+    const depth = u.searchParams.get("depth") || "5";
+    $directionGroup.querySelectorAll("button").forEach((btn) => {
+      btn.classList.toggle("active", btn.getAttribute("data-direction") === dir);
+    });
+    $depthGroup.querySelectorAll("button").forEach((btn) => {
+      btn.classList.toggle("active", btn.getAttribute("data-depth") === depth);
+    });
+  }
+
+  function setHierarchyParam(key, value) {
+    const u = new URL(window.location.href);
+    u.searchParams.set("view", "hierarchy");
+    u.searchParams.set(key, value);
+    window.history.replaceState({}, "", u.toString());
+    syncHierarchyControls();
+    // Force re-fetch of hierarchy data on re-activate.
+    currentGraphData = null;
+    activateView("hierarchy");
   }
 
   // --- Shared callbacks the view modules dispatch into ---
@@ -131,6 +177,8 @@
     currentView = newView;
     currentViewName = viewName;
     setActiveToggle(viewName);
+    showHierarchyControls(viewName === "hierarchy");
+    if (viewName === "hierarchy") syncHierarchyControls();
     syncUrlView(viewName);
 
     setStatus(`booting ${viewName}…`);
@@ -142,19 +190,43 @@
       return;
     }
 
-    if (!currentGraphData) {
-      currentGraphData = await loadGraph();
-      if (!currentGraphData) return;
+    // Two data-loading paths:
+    //   1. Views with their own loadData() (hierarchy, future cluster) —
+    //      router calls it with the URL context and renders the result.
+    //   2. Default views (2D/3D callgraph) — share /api/graph payload.
+    let dataForRender;
+    if (typeof currentView.loadData === "function") {
+      setStatus(`loading data for ${viewName}…`);
+      try {
+        dataForRender = await currentView.loadData({
+          url: new URL(window.location.href),
+          maxNodes: MAX_NODES,
+        });
+      } catch (e) {
+        setStatus(`loadData error: ${e.message}`);
+        console.error("view loadData failed:", e);
+        return;
+      }
+      if (!dataForRender) {
+        setStatus(`${viewName}: no data`);
+        return;
+      }
+    } else {
+      if (!currentGraphData) {
+        currentGraphData = await loadGraph();
+        if (!currentGraphData) return;
+      }
+      dataForRender = currentGraphData;
     }
 
     setStatus(
-      `rendering ${currentGraphData.nodes.length.toLocaleString()} nodes / ` +
-        `${currentGraphData.edges.length.toLocaleString()} edges…`,
+      `rendering ${dataForRender.nodes.length.toLocaleString()} nodes / ` +
+        `${dataForRender.edges.length.toLocaleString()} edges…`,
     );
     try {
-      await currentView.render(currentGraphData);
+      await currentView.render(dataForRender);
       setStatus(
-        `${currentGraphData.nodes.length.toLocaleString()} nodes · ${viewName} · click any`,
+        `${dataForRender.nodes.length.toLocaleString()} nodes · ${viewName} · click any`,
       );
     } catch (e) {
       setStatus(`render error: ${e.message}`);
@@ -196,6 +268,10 @@
           <code>${escapeHtml(c.file)}:${c.line_start}</code>
         </div>
         ${c.signature ? `<div><code>${escapeHtml(c.signature)}</code></div>` : ""}
+        <div class="sidebar-actions">
+          <button type="button" class="btn-link" data-action="hierarchy-callees" data-id="${escapeHtml(c.id)}">view callees as hierarchy ↓</button>
+          <button type="button" class="btn-link" data-action="hierarchy-callers" data-id="${escapeHtml(c.id)}">view callers as hierarchy ↑</button>
+        </div>
         ${c.doc ? `<h4>doc</h4><pre>${escapeHtml(c.doc)}</pre>` : ""}
         <h4>source preview</h4>
         <pre>${escapeHtml(c.content_preview)}</pre>
@@ -210,6 +286,14 @@
             currentView.onNodeFocus(targetId);
           }
           loadChunkDetail(targetId);
+        });
+      });
+      $sidebar.querySelectorAll("button[data-action^='hierarchy-']").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const action = btn.getAttribute("data-action");
+          const targetId = btn.getAttribute("data-id");
+          const direction = action === "hierarchy-callers" ? "callers" : "callees";
+          openHierarchy(targetId, direction);
         });
       });
     } catch (e) {
@@ -248,12 +332,43 @@
     }
   }
 
+  function openHierarchy(rootId, direction) {
+    const u = new URL(window.location.href);
+    u.searchParams.set("view", "hierarchy");
+    u.searchParams.set("root", rootId);
+    u.searchParams.set("direction", direction || "callees");
+    if (!u.searchParams.get("depth")) {
+      u.searchParams.set("depth", "5");
+    }
+    window.history.replaceState({}, "", u.toString());
+    currentGraphData = null; // hierarchy uses its own loadData
+    activateView("hierarchy");
+  }
+
   // Wire toggle buttons + search input
   if ($toggle2D) {
     $toggle2D.addEventListener("click", () => activateView("2d"));
   }
   if ($toggle3D) {
     $toggle3D.addEventListener("click", () => activateView("3d"));
+  }
+  // Hierarchy controls (depth + direction). Buttons carry data-attrs
+  // that map to URL params; clicking re-activates the view to refetch.
+  if ($directionGroup) {
+    $directionGroup.querySelectorAll("button").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const v = btn.getAttribute("data-direction");
+        if (v) setHierarchyParam("direction", v);
+      });
+    });
+  }
+  if ($depthGroup) {
+    $depthGroup.querySelectorAll("button").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const v = btn.getAttribute("data-depth");
+        if (v) setHierarchyParam("depth", v);
+      });
+    });
   }
   $search.addEventListener("input", onSearchInput);
 

--- a/src/serve/assets/index.html
+++ b/src/serve/assets/index.html
@@ -15,6 +15,19 @@
       <button id="view-2d" class="active" type="button" title="2D Cytoscape (default)">2D</button>
       <button id="view-3d" type="button" title="3D force-directed (Three.js)">3D</button>
     </div>
+    <div id="hierarchy-controls" class="hierarchy-controls" style="display:none;" aria-label="hierarchy controls">
+      <div id="hierarchy-direction" class="btn-group" role="group" aria-label="direction">
+        <button type="button" data-direction="callers" title="show transitive callers (BFS up)">↑ callers</button>
+        <button type="button" data-direction="callees" class="active" title="show transitive callees (BFS down)">↓ callees</button>
+      </div>
+      <div id="hierarchy-depth" class="btn-group" role="group" aria-label="depth">
+        <span class="btn-group-label">depth</span>
+        <button type="button" data-depth="3">3</button>
+        <button type="button" data-depth="5" class="active">5</button>
+        <button type="button" data-depth="7">7</button>
+        <button type="button" data-depth="10">10</button>
+      </div>
+    </div>
     <input id="search" type="text" placeholder="search by name…" autocomplete="off">
     <span id="status" class="status"></span>
   </header>
@@ -38,6 +51,7 @@
   <!-- View modules -->
   <script src="/static/views/callgraph-2d.js"></script>
   <script src="/static/views/callgraph-3d.js"></script>
+  <script src="/static/views/hierarchy-3d.js"></script>
 
   <!-- Router (must load last; depends on all view modules being registered on window) -->
   <script src="/static/app.js"></script>

--- a/src/serve/assets/views/hierarchy-3d.js
+++ b/src/serve/assets/views/hierarchy-3d.js
@@ -1,0 +1,276 @@
+// Hierarchy 3D view — 3d-force-graph with Y axis locked to BFS depth.
+//
+// Conforms to the renderer abstraction interface from step 1, plus an
+// optional `loadData(context)` hook the router calls instead of feeding
+// shared `/api/graph` data. Hierarchy fetches its own subgraph from
+// `/api/hierarchy/{root_id}` and arranges it as a tree.
+//
+// Conventions:
+//   - direction=callees → root at top, callees grow downward (fy negative)
+//   - direction=callers → root at bottom, callers grow upward  (fy positive)
+//   - X position from force layout (siblings spread)
+//   - Z stays free so dense layers can fan out into space
+
+(function (window) {
+  "use strict";
+
+  const TYPE_COLORS = {
+    function: "#4a86e8",
+    method: "#3d78d8",
+    impl: "#2e5fb0",
+    struct: "#43aa6b",
+    enum: "#5fbf85",
+    trait: "#3d8b5d",
+    interface: "#3d8b5d",
+    class: "#43aa6b",
+    test: "#e6a91c",
+    constant: "#888",
+    macro: "#a05ec5",
+    typealias: "#888",
+  };
+
+  const Y_SPACING = 80;
+
+  function nodeColor(kind) {
+    return TYPE_COLORS[kind] || "#999";
+  }
+
+  function nodeRadius(callers) {
+    return Math.max(1.5, Math.min(8, 1.5 + Math.sqrt(callers) * 0.6));
+  }
+
+  window.CqsHierarchy3D = {
+    graph: null,
+    container: null,
+    cb: null,
+    nodeIds: new Set(),
+    highlighted: new Set(),
+    selected: null,
+    nodeIndex: new Map(),
+    rootId: null,
+    direction: "callees",
+    depth: 5,
+
+    async init(container, options) {
+      this.container = container;
+      this.cb = options.callbacks || {};
+      container.innerHTML = "";
+
+      if (typeof ForceGraph3D === "undefined") {
+        container.innerHTML =
+          '<div class="error" style="margin:24px">3D renderer not loaded — check that ' +
+          "<code>/static/vendor/three.min.js</code> and " +
+          "<code>/static/vendor/3d-force-graph.min.js</code> served correctly.</div>";
+        throw new Error("ForceGraph3D global not present");
+      }
+    },
+
+    /// Router calls this before render() when the view module declares it.
+    /// Reads ?root, ?direction, ?depth from the URL and fetches the
+    /// hierarchy subgraph. Returns the response payload (with a
+    /// bfs_depth on each node) or null on missing root / HTTP failure.
+    async loadData(context) {
+      const url = context.url;
+      const root = url.searchParams.get("root");
+      if (!root) {
+        this.container.innerHTML =
+          '<div class="error" style="margin:24px">hierarchy view requires <code>?root=&lt;chunk_id&gt;</code> in the URL. ' +
+          'Click a node in the 2D or 3D view, then use "view as hierarchy" in the sidebar.</div>';
+        return null;
+      }
+      this.rootId = root;
+      this.direction = url.searchParams.get("direction") || "callees";
+      this.depth = parseInt(url.searchParams.get("depth") || "5", 10);
+      if (!Number.isFinite(this.depth) || this.depth < 1) this.depth = 5;
+      if (this.depth > 10) this.depth = 10;
+
+      const params = new URLSearchParams({
+        direction: this.direction,
+        depth: String(this.depth),
+      });
+      const apiUrl = `/api/hierarchy/${encodeURIComponent(root)}?${params}`;
+      try {
+        const resp = await fetch(apiUrl);
+        if (!resp.ok) {
+          const body = await resp.text();
+          this.container.innerHTML = `<div class="error" style="margin:24px">hierarchy HTTP ${resp.status}: ${body.slice(0, 200)}</div>`;
+          return null;
+        }
+        return await resp.json();
+      } catch (e) {
+        this.container.innerHTML = `<div class="error" style="margin:24px">hierarchy fetch error: ${e.message}</div>`;
+        return null;
+      }
+    },
+
+    async render(data) {
+      this.nodeIds = new Set(data.nodes.map((n) => n.id));
+      // For callers (BFS up the graph), depth grows upward on screen.
+      // For callees (BFS down), depth grows downward. Either way the
+      // root sits at fy = 0 so the camera centres on it naturally.
+      const sign = this.direction === "callers" ? 1 : -1;
+      const nodes = data.nodes.map((n) => ({
+        id: n.id,
+        name: n.name,
+        kind: n.type,
+        file: n.file,
+        line: n.line_start,
+        callers: n.n_callers,
+        callees: n.n_callees,
+        dead: n.dead,
+        depth: n.bfs_depth,
+        // fy locks Y to the BFS depth — 3d-force-graph honors fx/fy/fz
+        // and skips force-directed updates on those axes.
+        fy: sign * n.bfs_depth * Y_SPACING,
+      }));
+      this.nodeIndex = new Map(nodes.map((n) => [n.id, n]));
+
+      this.graph = ForceGraph3D()(this.container)
+        .graphData({
+          nodes,
+          links: data.edges.map((e) => ({
+            source: e.source,
+            target: e.target,
+          })),
+        })
+        .backgroundColor("#0d1117")
+        .nodeLabel(
+          (n) =>
+            `${n.name} · depth ${n.depth} · ${n.kind} · ${n.callers} callers`,
+        )
+        .nodeColor((n) => {
+          if (this.selected === n.id) return "#fc0";
+          if (this.highlighted.has(n.id)) return "#ff8c00";
+          if (n.id === this.rootId) return "#fff";
+          if (n.dead) return "#c33";
+          return nodeColor(n.kind);
+        })
+        .nodeVal((n) => Math.pow(nodeRadius(n.callers), 2))
+        .nodeOpacity(0.9)
+        .linkColor(() => "rgba(180,180,200,0.35)")
+        .linkOpacity(0.55)
+        .linkDirectionalArrowLength(2.5)
+        .linkDirectionalArrowRelPos(1)
+        .linkDirectionalArrowColor(() => "rgba(200,200,220,0.55)")
+        .cooldownTime(8000)
+        .warmupTicks(20)
+        .onNodeClick((node) => {
+          this.selected = node.id;
+          this.graph.refresh();
+          if (this.cb.onNodeClick) this.cb.onNodeClick(node.id);
+        })
+        .onNodeHover((node) => {
+          if (node && this.cb.onNodeHover) {
+            this.cb.onNodeHover(
+              `${node.name} · depth ${node.depth} · ${node.kind}`,
+            );
+          } else if (!node && this.cb.onNodeHover) {
+            this.cb.onNodeHover("");
+          }
+        });
+
+      // Side-on camera: position the camera off to the +X side so the
+      // depth axis (Y) reads vertically and the tree is unmistakable.
+      // Defer one frame so the graph has bounds to centre on.
+      const maxDepth = nodes.reduce(
+        (m, n) => Math.max(m, n.depth || 0),
+        0,
+      );
+      const span = Math.max(maxDepth, 1) * Y_SPACING;
+      window.requestAnimationFrame(() => {
+        if (!this.graph) return;
+        try {
+          this.graph.cameraPosition(
+            { x: span * 2.2 + 200, y: (sign * span) / 2, z: 200 },
+            { x: 0, y: (sign * span) / 2, z: 0 },
+            0,
+          );
+        } catch (e) {
+          console.warn("hierarchy: cameraPosition failed", e);
+        }
+      });
+    },
+
+    onSearchHighlight(matchedIds) {
+      if (!this.graph) return 0;
+      this.highlighted = new Set();
+      let inView = 0;
+      let firstMatch = null;
+      for (const id of matchedIds) {
+        if (this.nodeIds.has(id)) {
+          this.highlighted.add(id);
+          inView += 1;
+          if (!firstMatch) firstMatch = this.nodeIndex.get(id);
+        }
+      }
+      this.graph.refresh();
+      if (firstMatch) {
+        const distance = 100;
+        const distRatio =
+          1 +
+          distance /
+            Math.hypot(
+              firstMatch.x || 0,
+              firstMatch.y || 0,
+              firstMatch.z || 0,
+            );
+        this.graph.cameraPosition(
+          {
+            x: (firstMatch.x || 0) * distRatio,
+            y: (firstMatch.y || 0) * distRatio,
+            z: (firstMatch.z || 0) * distRatio,
+          },
+          firstMatch,
+          1000,
+        );
+      }
+      return inView;
+    },
+
+    onNodeFocus(chunkId) {
+      if (!this.graph || !this.nodeIds.has(chunkId)) return false;
+      const node = this.nodeIndex.get(chunkId);
+      if (!node) return false;
+      this.selected = chunkId;
+      this.graph.refresh();
+      const distance = 80;
+      const distRatio =
+        1 +
+        distance /
+          Math.hypot(node.x || 0, node.y || 0, node.z || 0);
+      this.graph.cameraPosition(
+        {
+          x: (node.x || 0) * distRatio,
+          y: (node.y || 0) * distRatio,
+          z: (node.z || 0) * distRatio,
+        },
+        node,
+        800,
+      );
+      return true;
+    },
+
+    dispose() {
+      if (this.graph) {
+        try {
+          if (typeof this.graph._destructor === "function") {
+            this.graph._destructor();
+          }
+        } catch (e) {
+          console.warn("CqsHierarchy3D.dispose: _destructor threw", e);
+        }
+        this.graph = null;
+      }
+      this.nodeIds = new Set();
+      this.highlighted = new Set();
+      this.selected = null;
+      this.nodeIndex = new Map();
+      this.rootId = null;
+      if (this.container) {
+        this.container.innerHTML = "";
+      }
+      this.container = null;
+      this.cb = null;
+    },
+  };
+})(window);

--- a/src/serve/data.rs
+++ b/src/serve/data.rs
@@ -106,6 +106,51 @@ pub(crate) struct StatsResponse {
     pub type_edges: u64,
 }
 
+/// Direction of BFS expansion for the hierarchy view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HierarchyDirection {
+    /// BFS up the call graph (this function's transitive callers).
+    Callers,
+    /// BFS down the call graph (this function's transitive callees).
+    Callees,
+}
+
+impl HierarchyDirection {
+    pub(crate) fn parse(s: &str) -> Option<Self> {
+        match s {
+            "callers" => Some(Self::Callers),
+            "callees" => Some(Self::Callees),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Callers => "callers",
+            Self::Callees => "callees",
+        }
+    }
+}
+
+/// One node in the hierarchy view — same as a graph `Node` plus the
+/// BFS depth from the root (root itself is depth 0).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct HierarchyNode {
+    #[serde(flatten)]
+    pub base: Node,
+    pub bfs_depth: u32,
+}
+
+/// Top-level response for `GET /api/hierarchy/:id`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct HierarchyResponse {
+    pub root: String,
+    pub direction: String,
+    pub max_depth: u32,
+    pub nodes: Vec<HierarchyNode>,
+    pub edges: Vec<Edge>,
+}
+
 /// Build the full graph response from the store.
 ///
 /// Pulls every chunk + every resolved call edge in two SQL queries, then
@@ -401,6 +446,252 @@ pub(crate) fn build_chunk_detail(
             tests,
         }))
     })
+}
+
+/// Build a BFS hierarchy rooted at `root_id` (a chunk_id), expanding
+/// either upward (callers) or downward (callees) up to `max_depth`.
+///
+/// Strategy:
+/// 1. Resolve `root_id` → root chunk row (must exist; 404 otherwise).
+/// 2. Borrow the cached `Store::get_call_graph()` (`Arc<CallGraph>`).
+/// 3. BFS by **name** (the call graph is name-keyed), tracking depth.
+/// 4. Resolve every visited name → chunk_id by `(file, name)` deterministic
+///    pick (same overload-disambiguation pattern as `build_graph`). When
+///    a name resolves to multiple chunks across files we keep the first
+///    (sorted by id) so renderings are stable.
+/// 5. Pull node metadata + per-node degree counts in one batched SQL query.
+/// 6. Emit only edges whose endpoints are both inside the BFS frontier.
+///
+/// `max_depth` is clamped to 1..=10 by the caller.
+pub(crate) fn build_hierarchy(
+    store: &Store<ReadOnly>,
+    root_id: &str,
+    direction: HierarchyDirection,
+    max_depth: u32,
+) -> Result<Option<HierarchyResponse>, StoreError> {
+    let _span = tracing::info_span!(
+        "build_hierarchy",
+        root_id = %root_id,
+        direction = direction.as_str(),
+        max_depth
+    )
+    .entered();
+
+    // 1. Resolve root chunk_id → name (and confirm it exists).
+    let root_name: Option<String> = store.rt.block_on(async {
+        let row = sqlx::query("SELECT name FROM chunks WHERE id = ?")
+            .bind(root_id)
+            .fetch_optional(&store.pool)
+            .await?;
+        Ok::<_, StoreError>(row.map(|r| r.get::<String, _>("name")))
+    })?;
+
+    let Some(root_name) = root_name else {
+        tracing::info!(root_id, "build_hierarchy: root chunk not found");
+        return Ok(None);
+    };
+
+    // 2. Cached call graph (Arc; cheap clone).
+    let call_graph = match store.get_call_graph() {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::warn!(error = %e, "build_hierarchy: get_call_graph failed");
+            return Err(e);
+        }
+    };
+
+    // 3. BFS by name with depth tracking. Visited holds the smallest
+    //    depth we've seen for each name (so a node visible at depth 2 via
+    //    one path stays at depth 2 even if also reachable at depth 4).
+    let mut depth_by_name: HashMap<std::sync::Arc<str>, u32> = HashMap::new();
+    let root_arc: std::sync::Arc<str> = std::sync::Arc::from(root_name.as_str());
+    depth_by_name.insert(root_arc.clone(), 0);
+    let mut frontier: Vec<std::sync::Arc<str>> = vec![root_arc.clone()];
+
+    for d in 0..max_depth {
+        let mut next: Vec<std::sync::Arc<str>> = Vec::new();
+        for name in &frontier {
+            let neighbors: Option<&Vec<std::sync::Arc<str>>> = match direction {
+                HierarchyDirection::Callees => call_graph.forward.get(name),
+                HierarchyDirection::Callers => call_graph.reverse.get(name),
+            };
+            let Some(neighbors) = neighbors else { continue };
+            for n in neighbors {
+                if !depth_by_name.contains_key(n) {
+                    depth_by_name.insert(n.clone(), d + 1);
+                    next.push(n.clone());
+                }
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        frontier = next;
+    }
+
+    let visited_names: Vec<String> = depth_by_name.keys().map(|s| s.to_string()).collect();
+    tracing::info!(
+        visited = visited_names.len(),
+        "build_hierarchy: BFS complete"
+    );
+
+    // 4 + 5. Pull chunk rows for every visited name. We need (file, name)
+    // tuples to disambiguate overloads. Use IN (?, ?, ...) with a sane cap.
+    if visited_names.is_empty() {
+        return Ok(Some(HierarchyResponse {
+            root: root_id.to_string(),
+            direction: direction.as_str().to_string(),
+            max_depth,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        }));
+    }
+
+    let response = store.rt.block_on(async {
+        let placeholders = vec!["?"; visited_names.len()].join(",");
+        let sql = format!(
+            "SELECT id, name, chunk_type, language, origin, line_start, line_end \
+             FROM chunks WHERE name IN ({placeholders}) ORDER BY id"
+        );
+        let mut q = sqlx::query(&sql);
+        for n in &visited_names {
+            q = q.bind(n);
+        }
+        let rows = q.fetch_all(&store.pool).await?;
+
+        // For each name, keep the deterministic-first chunk_id (sorted
+        // by id from the SQL ORDER BY). If a name has multiple chunks
+        // (overloads in different files), this is the first one.
+        let mut name_to_first_id: HashMap<String, String> = HashMap::new();
+        // Also keep all chunks so we can build node metadata for every
+        // unique chunk_id that we emit (we emit one per name).
+        let mut chunk_meta: HashMap<String, (String, String, String, String, i64, i64)> =
+            HashMap::new();
+
+        for row in rows {
+            let id: String = row.get("id");
+            let name: String = row.get("name");
+            let chunk_type: String = row.get("chunk_type");
+            let language: String = row.get("language");
+            let origin: String = row.get("origin");
+            let line_start: i64 = row.get("line_start");
+            let line_end: i64 = row.get("line_end");
+
+            // First-seen wins (rows already sorted by id).
+            name_to_first_id.entry(name.clone()).or_insert(id.clone());
+            chunk_meta.insert(
+                id,
+                (name, chunk_type, language, origin, line_start, line_end),
+            );
+        }
+
+        // Build the node set. For names that didn't resolve to a chunk
+        // (e.g. external std-lib calls), they're silently skipped — same
+        // behavior as build_graph.
+        let mut nodes: Vec<HierarchyNode> = Vec::new();
+        let mut emitted_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (name_arc, depth) in &depth_by_name {
+            let name = name_arc.as_ref();
+            let Some(chunk_id) = name_to_first_id.get(name) else {
+                continue;
+            };
+            let Some((cname, ckind, lang, origin, l_start, l_end)) = chunk_meta.get(chunk_id)
+            else {
+                continue;
+            };
+            emitted_ids.insert(chunk_id.clone());
+            nodes.push(HierarchyNode {
+                base: Node {
+                    id: chunk_id.clone(),
+                    name: cname.clone(),
+                    kind: ckind.clone(),
+                    language: lang.clone(),
+                    file: origin.clone(),
+                    line_start: (*l_start).max(0) as u32,
+                    line_end: (*l_end).max(0) as u32,
+                    n_callers: 0,
+                    n_callees: 0,
+                    dead: false,
+                },
+                bfs_depth: *depth,
+            });
+        }
+
+        // 6. Pull all edges where both endpoints are inside the visited
+        //    name set, then resolve each (caller, callee) name pair to
+        //    chunk IDs using the same name_to_first_id map.
+        let edge_sql = format!(
+            "SELECT DISTINCT caller_name, callee_name FROM function_calls \
+             WHERE caller_name IN ({placeholders}) AND callee_name IN ({placeholders})"
+        );
+        let mut eq = sqlx::query(&edge_sql);
+        for n in &visited_names {
+            eq = eq.bind(n);
+        }
+        for n in &visited_names {
+            eq = eq.bind(n);
+        }
+        let edge_rows = eq.fetch_all(&store.pool).await?;
+
+        let mut caller_count: HashMap<String, u32> = HashMap::new();
+        let mut callee_count: HashMap<String, u32> = HashMap::new();
+        let mut edges: Vec<Edge> = Vec::with_capacity(edge_rows.len());
+        for row in edge_rows {
+            let caller_name: String = row.get("caller_name");
+            let callee_name: String = row.get("callee_name");
+            let Some(caller_id) = name_to_first_id.get(&caller_name) else {
+                continue;
+            };
+            let Some(callee_id) = name_to_first_id.get(&callee_name) else {
+                continue;
+            };
+            // Skip self-loops; 3d-force-graph is not happy with them.
+            if caller_id == callee_id {
+                continue;
+            }
+            *caller_count.entry(callee_id.clone()).or_insert(0) += 1;
+            *callee_count.entry(caller_id.clone()).or_insert(0) += 1;
+            edges.push(Edge {
+                source: caller_id.clone(),
+                target: callee_id.clone(),
+                kind: "call".to_string(),
+            });
+        }
+
+        // Backfill per-node degrees + dead flags using only the edges
+        // visible inside this hierarchy. (Dead is uninteresting in a
+        // hierarchy view since the root is by definition reached, so we
+        // mostly just want the degree counts to drive node sizing.)
+        for node in nodes.iter_mut() {
+            node.base.n_callers = *caller_count.get(&node.base.id).unwrap_or(&0);
+            node.base.n_callees = *callee_count.get(&node.base.id).unwrap_or(&0);
+            node.base.dead = node.base.n_callers == 0 && node.base.kind != "test";
+        }
+
+        // Stable order: by depth then id, so frontend rendering is
+        // deterministic and reload-friendly.
+        nodes.sort_unstable_by(|a, b| {
+            a.bfs_depth
+                .cmp(&b.bfs_depth)
+                .then_with(|| a.base.id.cmp(&b.base.id))
+        });
+
+        tracing::info!(
+            nodes = nodes.len(),
+            edges = edges.len(),
+            "build_hierarchy: built response"
+        );
+
+        Ok::<_, StoreError>(HierarchyResponse {
+            root: root_id.to_string(),
+            direction: direction.as_str().to_string(),
+            max_depth,
+            nodes,
+            edges,
+        })
+    })?;
+
+    Ok(Some(response))
 }
 
 /// Pull richer stats than the `Store::base_embedding_count` shortcut.

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -13,7 +13,10 @@ use axum::{
 };
 use serde::Deserialize;
 
-use super::data::{ChunkDetail, GraphResponse, NodeRef, SearchResponse, StatsResponse};
+use super::data::{
+    ChunkDetail, GraphResponse, HierarchyDirection, HierarchyResponse, NodeRef, SearchResponse,
+    StatsResponse,
+};
 use super::error::ServeError;
 use super::AppState;
 
@@ -44,6 +47,19 @@ pub(crate) struct SearchQuery {
 fn default_search_limit() -> usize {
     20
 }
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct HierarchyQuery {
+    /// `callers` (BFS up) or `callees` (BFS down). Defaults to `callees`.
+    #[serde(default)]
+    pub direction: Option<String>,
+    /// BFS depth from root. Defaults to 5, clamped to 1..=10.
+    #[serde(default)]
+    pub depth: Option<u32>,
+}
+
+const DEFAULT_HIERARCHY_DEPTH: u32 = 5;
+const MAX_HIERARCHY_DEPTH: u32 = 10;
 
 /// `GET /health` — always returns 200. Used by orchestration / monitoring.
 pub(crate) async fn health() -> (StatusCode, &'static str) {
@@ -151,4 +167,47 @@ pub(crate) async fn search(
 
     tracing::info!(matches = matches.len(), "search returned");
     Ok(Json(SearchResponse { matches }))
+}
+
+/// `GET /api/hierarchy/{id}?direction={callers|callees}&depth=N`
+///
+/// BFS subgraph from a chunk. Returns nodes annotated with `bfs_depth`
+/// so the frontend can lock the Z axis to depth and render a tree-shaped
+/// 3D layout. Depth is clamped to 1..=10 to bound response size on
+/// densely-connected codebases.
+pub(crate) async fn hierarchy(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Query(params): Query<HierarchyQuery>,
+) -> Result<Json<HierarchyResponse>, ServeError> {
+    let direction_str = params.direction.as_deref().unwrap_or("callees").to_string();
+    let direction = HierarchyDirection::parse(&direction_str).ok_or_else(|| {
+        ServeError::BadRequest(format!(
+            "direction must be 'callers' or 'callees', got '{direction_str}'"
+        ))
+    })?;
+    let depth = params
+        .depth
+        .unwrap_or(DEFAULT_HIERARCHY_DEPTH)
+        .clamp(1, MAX_HIERARCHY_DEPTH);
+
+    tracing::info!(
+        chunk_id = %id,
+        direction = direction.as_str(),
+        depth,
+        "serve::hierarchy"
+    );
+
+    let store = state.store.clone();
+    let id_clone = id.clone();
+    let response = tokio::task::spawn_blocking(move || {
+        super::data::build_hierarchy(&store, &id_clone, direction, depth)
+    })
+    .await
+    .map_err(|e| ServeError::Internal(format!("hierarchy join: {e}")))?
+    .map_err(ServeError::from)?;
+
+    response
+        .map(Json)
+        .ok_or_else(|| ServeError::NotFound(format!("chunk: {id}")))
 }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -99,6 +99,7 @@ pub(crate) fn build_router(state: AppState) -> Router {
         .route("/api/stats", get(handlers::stats))
         .route("/api/graph", get(handlers::graph))
         .route("/api/chunk/{id}", get(handlers::chunk_detail))
+        .route("/api/hierarchy/{id}", get(handlers::hierarchy))
         .route("/api/search", get(handlers::search))
         .route("/", get(assets::index_html))
         .route("/static/{*path}", get(assets::static_asset))

--- a/src/serve/tests.rs
+++ b/src/serve/tests.rs
@@ -176,8 +176,8 @@ async fn static_asset_serves_js() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn view_modules_serve() {
-    // Both view modules (callgraph-2d.js, callgraph-3d.js) must be
-    // reachable so the router in app.js can dispatch to them.
+    // All view modules must be reachable so the router in app.js can
+    // dispatch to them.
     let fixture = fixture_state();
     let state = fixture.state();
     let app = build_router(state);
@@ -185,6 +185,7 @@ async fn view_modules_serve() {
     for path in &[
         "/static/views/callgraph-2d.js",
         "/static/views/callgraph-3d.js",
+        "/static/views/hierarchy-3d.js",
     ] {
         let resp = app
             .clone()
@@ -268,11 +269,15 @@ async fn index_html_loads_view_modules() {
     for needle in &[
         "/static/views/callgraph-2d.js",
         "/static/views/callgraph-3d.js",
+        "/static/views/hierarchy-3d.js",
         "/static/vendor/three.min.js",
         "/static/vendor/3d-force-graph.min.js",
         "view-toggle",
         "view-2d",
         "view-3d",
+        "hierarchy-controls",
+        "hierarchy-direction",
+        "hierarchy-depth",
     ] {
         assert!(
             body.contains(needle),
@@ -403,6 +408,103 @@ async fn chunk_detail_unknown_id_returns_404() {
         .oneshot(
             Request::builder()
                 .uri("/api/chunk/no-such-id")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn hierarchy_unknown_root_returns_404() {
+    // Empty fixture has no chunks, so any root id is unknown — we expect
+    // a 404 (not a 500 or empty 200) so the frontend can show a clear
+    // "no such root" message.
+    let fixture = fixture_state();
+    let state = fixture.state();
+    let app = build_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/hierarchy/no-such-id?direction=callees&depth=5")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn hierarchy_invalid_direction_returns_400() {
+    let fixture = fixture_state();
+    let state = fixture.state();
+    let app = build_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/hierarchy/anything?direction=sideways&depth=5")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+    assert_eq!(json["error"], "bad_request");
+    assert!(
+        json["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("direction"),
+        "detail should mention 'direction', got {}",
+        json["detail"]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn hierarchy_default_direction_is_callees() {
+    // Omitting direction should default to callees (still 404 because
+    // no chunks, but the request should be accepted not 400'd).
+    let fixture = fixture_state();
+    let state = fixture.state();
+    let app = build_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/hierarchy/some-id")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("oneshot");
+
+    // Direction defaults to "callees" → not BAD_REQUEST, should be 404 (no chunk).
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn hierarchy_extreme_depth_is_clamped() {
+    // depth=999 should be silently clamped to MAX_HIERARCHY_DEPTH (10),
+    // not error out. We can't observe the clamp directly without a
+    // populated store, but the request should still come back as 404
+    // (chunk not found) rather than 400 / 500.
+    let fixture = fixture_state();
+    let state = fixture.state();
+    let app = build_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/hierarchy/some-id?direction=callees&depth=999")
                 .body(Body::empty())
                 .unwrap(),
         )


### PR DESCRIPTION
## Summary

Step 2 of the 3D progressive rollout per `docs/plans/2026-04-22-cqs-serve-3d-progressive.md`:
**hierarchy view — Y axis locked to BFS depth from a chosen root**.

A third view appears at `?view=hierarchy&root=<chunk_id>&direction=callees|callers&depth=N`. It BFS-expands a subgraph from a root and pins each node's Y coordinate to its depth, so the result reads as a tree in 3D. X stays force-directed (siblings spread within each layer), Z stays free (depth-dense layers fan out into space). The camera defaults to a side-on shot so the depth axis reads vertically.

## What changed

**Backend** (`src/serve/data.rs`, `handlers.rs`, `mod.rs`):
- `HierarchyDirection` enum (`callers` / `callees`) + parse/as_str
- `HierarchyNode` (Node + `bfs_depth`) + `HierarchyResponse`
- `build_hierarchy(store, root_id, direction, depth)` uses cached `Store::get_call_graph()` (`Arc<CallGraph>`) for the BFS, resolves names → chunk_ids with the same overload-disambiguation pattern as `build_graph` (deterministic-first by id sort), then pulls per-node degrees from the visible edge subset
- `/api/hierarchy/{id}` route — depth clamped to 1..=10, direction defaulting to `callees`, structured tracing on entry + at completion, 400 on invalid direction, 404 on unknown root

**Frontend**:
- `views/hierarchy-3d.js` — new view module with `init/loadData/render/onSearchHighlight/onNodeFocus/dispose`. The router calls `loadData()` when a view declares it (versus the default shared-graph path), so this view fetches its own subgraph from `/api/hierarchy/...`. Uses `node.fy` to lock Y = ±bfs_depth × 80px (sign by direction). Root coloured white to stand out.
- `app.js` — `VIEWS` registry gains a `"hierarchy"` entry; `activateView` now dispatches to `loadData()` when the module declares it; URL state cleanup drops `root|direction|depth` when leaving hierarchy; `openHierarchy()` helper for the sidebar buttons; depth (3/5/7/10) and direction (↑callers / ↓callees) header buttons re-activate the view on click
- `index.html` — adds the hierarchy-controls cluster (hidden by default, shown only in hierarchy view) + new view-module script tag
- `app.css` — button-group styles for the controls + sidebar action buttons

## Tracing / error handling / tests

- `build_hierarchy` opens an `info_span!` and emits structured `info!` events on BFS completion + on response build. `get_call_graph()` failure surfaces as a `warn!` then propagates.
- Bad direction returns a JSON `bad_request` body (verified by test); unknown root returns 404; depth=999 is clamped silently.
- 4 new integration tests in `src/serve/tests.rs`:
  - `hierarchy_unknown_root_returns_404`
  - `hierarchy_invalid_direction_returns_400` (also asserts JSON error shape)
  - `hierarchy_default_direction_is_callees`
  - `hierarchy_extreme_depth_is_clamped`
  - existing `view_modules_serve` + `index_html_loads_view_modules` extended to cover the new view module + control elements
- Lib test count: **13 → 17**, all passing.

**Smoke against the full cqs corpus** (18954 chunks, 53265 call edges):
- `test_search_filtered_rrf_hybrid` callees `depth=3` → 115 nodes, 306 edges, 4 depth bins (0..3)
- `search_filtered_with_index_errors_on_dim_mismatch` callees `depth=1` → 5 nodes, 4 edges (root + 4 immediate)
- `depth=999` clamped to 10 transparently
- bad direction → 400 with JSON body
- unknown root → 404

## Decision gate

Per the spec: open `?view=hierarchy&root=<id>` (or click the new "view callees as hierarchy" button in the sidebar) on a few real chunks. Does the depth axis answer a real question — *what does this transitively reach?* If yes, green-light step 3 (UMAP cluster view). If gimmicky, ship and stop.

## Test plan

- [x] `cargo build --features gpu-index --release` clean
- [x] `cargo test --features gpu-index serve::tests` — 17/17 pass
- [x] Smoke `/api/hierarchy/...` against real corpus, both directions
- [ ] Manual browser test: click a node in 2D/3D, hit "view callees as hierarchy ↓", verify tree-shaped layout with depth axis vertical, change depth/direction with the header buttons, switch back to 2D/3D toggle and confirm hierarchy params drop from URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
