### PR TITLE
feat(index): add .cqsignore for cqs-only exclusions

### DIFF
--- a/.cqsignore
+++ b/.cqsignore
@@ -1,0 +1,21 @@
+# cqs-specific exclusions for the indexer.
+#
+# Same syntax as .gitignore. Layered on top of .gitignore — these files are
+# committed to git (binaries need them via include_str! / include_bytes!) but
+# contribute zero useful semantic search content.
+#
+# Respected by `cqs index` and `cqs watch`. Disable with `cqs index --no-ignore`.
+
+# Vendored minified bundles. Each is a single ~hundreds-of-KB line, well over
+# the parser's per-chunk byte cap; indexing them produces noise warnings and
+# meaningless embeddings (everything matches everything).
+src/serve/assets/vendor/*.min.js
+
+# Eval query fixtures — single-line JSON, hundreds of KB to multi-MB. Same
+# story as vendor bundles: too big to chunk usefully, no semantic signal.
+evals/queries/*.json
+evals/reranker_v3/**
+
+# Build artefact / pyc caches that occasionally slip past .gitignore.
+**/__pycache__/
+*.pyc

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -763,31 +763,45 @@ fn build_gitignore_matcher(root: &Path) -> Option<ignore::gitignore::Gitignore> 
     }
 
     let root_gitignore = root.join(".gitignore");
-    if !root_gitignore.exists() {
+    let root_cqsignore = root.join(".cqsignore");
+    if !root_gitignore.exists() && !root_cqsignore.exists() {
         tracing::info!(
             root = %root.display(),
-            "no .gitignore at project root — watch will not filter by gitignore"
+            "no .gitignore or .cqsignore at project root — watch will not filter"
         );
         return None;
     }
 
     let mut builder = ignore::gitignore::GitignoreBuilder::new(root);
 
-    if let Some(err) = builder.add(&root_gitignore) {
-        tracing::warn!(
-            path = %root_gitignore.display(),
-            error = %err,
-            "root .gitignore unreadable or malformed — falling back to empty matcher"
-        );
-        return None;
+    // Order matters for negation: later `add()` calls win on conflict.
+    // .gitignore first, then .cqsignore so cqs-specific overrides apply last.
+    if root_gitignore.exists() {
+        if let Some(err) = builder.add(&root_gitignore) {
+            tracing::warn!(
+                path = %root_gitignore.display(),
+                error = %err,
+                "root .gitignore unreadable or malformed — falling back to empty matcher"
+            );
+            return None;
+        }
+    }
+    if root_cqsignore.exists() {
+        if let Some(err) = builder.add(&root_cqsignore) {
+            tracing::warn!(
+                path = %root_cqsignore.display(),
+                error = %err,
+                "root .cqsignore unreadable or malformed — skipping it"
+            );
+        }
     }
 
-    // Root-only .gitignore in v1. Nested .gitignore files are not yet
-    // discovered — tracked as follow-up. `cqs index` uses the full `ignore`
-    // crate walk which supports nesting; the watch loop uses a per-event
-    // point query against a pre-built matcher and compile-time nesting
-    // would require rebuilding on every subdir change. Root-level covers
-    // the worktree-pollution motivating case.
+    // Root-only .gitignore / .cqsignore in v1. Nested ignore files are not
+    // yet discovered — tracked as follow-up. `cqs index` uses the full
+    // `ignore` crate walk which supports nesting; the watch loop uses a
+    // per-event point query against a pre-built matcher and compile-time
+    // nesting would require rebuilding on every subdir change. Root-level
+    // covers the worktree-pollution + vendor-bundle motivating cases.
 
     match builder.build() {
         Ok(gi) => {
@@ -2975,12 +2989,12 @@ mod tests {
 
     #[test]
     fn build_gitignore_matcher_missing_returns_none() {
-        // A project with no .gitignore at the root should produce a
-        // `None` matcher — the watch loop indexes everything.
+        // A project with neither .gitignore nor .cqsignore should produce
+        // a `None` matcher — the watch loop indexes everything.
         let tmp = tempfile::TempDir::new().unwrap();
         assert!(
             build_gitignore_matcher(tmp.path()).is_none(),
-            "missing .gitignore should yield None matcher"
+            "missing .gitignore + .cqsignore should yield None matcher"
         );
     }
 
@@ -3025,6 +3039,50 @@ mod tests {
             .matched_path_or_any_parents(tmp.path().join("target/debug/foo.rs"), false)
             .is_ignore();
         assert!(hit, "target/ should match");
+    }
+
+    #[test]
+    fn build_gitignore_matcher_loads_cqsignore() {
+        // The watch matcher must layer .cqsignore on top of .gitignore so
+        // cqs-specific exclusions (vendor bundles etc.) are respected at
+        // event time, mirroring the indexer behaviour.
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".gitignore"), "target/\n").unwrap();
+        std::fs::write(tmp.path().join(".cqsignore"), "**/*.min.js\n").unwrap();
+
+        let matcher =
+            build_gitignore_matcher(tmp.path()).expect("matcher should build with cqsignore");
+        assert!(matcher.num_ignores() >= 2, "expected rules from both files");
+
+        let vendor_hit = matcher
+            .matched_path_or_any_parents(
+                tmp.path().join("src/serve/assets/vendor/three.min.js"),
+                false,
+            )
+            .is_ignore();
+        assert!(
+            vendor_hit,
+            ".cqsignore *.min.js rule should match vendor JS"
+        );
+
+        let regular_miss = matcher
+            .matched_path_or_any_parents(tmp.path().join("src/main.rs"), false)
+            .is_ignore();
+        assert!(!regular_miss, "regular source files must not match");
+    }
+
+    #[test]
+    fn build_gitignore_matcher_cqsignore_only() {
+        // .cqsignore alone (no .gitignore) should still build the matcher.
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".cqsignore"), "secret.txt\n").unwrap();
+
+        let matcher =
+            build_gitignore_matcher(tmp.path()).expect("matcher should build with cqsignore alone");
+        let hit = matcher
+            .matched_path_or_any_parents(tmp.path().join("secret.txt"), false)
+            .is_ignore();
+        assert!(hit, "cqsignore-only rule should match");
     }
 
     // ===== #1004 SPLADE builder / batch-size tests =====

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,7 +496,17 @@ pub fn enumerate_files(
 
     let root = dunce::canonicalize(root).context("Failed to canonicalize root")?;
 
-    let walker = WalkBuilder::new(&root)
+    // `.cqsignore` layers on top of `.gitignore` for cqs-specific exclusions
+    // (vendored minified JS, large data fixtures, etc.) — files we want
+    // committed to git but don't want indexed. Same gitignore syntax,
+    // hierarchical (per-directory), and respected by both `cqs index` (here)
+    // and `cqs watch` (see `cli/watch.rs::build_gitignore_matcher`).
+    // `--no-ignore` disables it alongside .gitignore.
+    let mut wb = WalkBuilder::new(&root);
+    if !no_ignore {
+        wb.add_custom_ignore_filename(".cqsignore");
+    }
+    let walker = wb
         .git_ignore(!no_ignore)
         .git_global(!no_ignore)
         .git_exclude(!no_ignore)
@@ -894,6 +904,43 @@ mentions = ["store.rs"]
             .collect();
         assert!(names.contains(&"main.rs".to_string()));
         assert!(names.contains(&"lib.rs".to_string()));
+    }
+
+    #[test]
+    fn test_enumerate_files_respects_cqsignore() {
+        // .cqsignore should exclude matching paths from indexing, layered on
+        // top of .gitignore. Verifies the indexer respects the cqs-specific
+        // ignore mechanism added for vendored bundles + similar artefacts.
+        let dir = tempfile::TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        let vendor = src.join("assets").join("vendor");
+        std::fs::create_dir_all(&vendor).unwrap();
+
+        std::fs::write(src.join("main.rs"), "fn main() {}").unwrap();
+        std::fs::write(vendor.join("three.min.js"), "/* huge minified */").unwrap();
+        std::fs::write(vendor.join("regular.js"), "console.log('ok');").unwrap();
+
+        // Without .cqsignore: both .js files are visible.
+        let before = enumerate_files(dir.path(), &["js"], false).unwrap();
+        assert_eq!(
+            before.len(),
+            2,
+            "expected both js files visible pre-cqsignore"
+        );
+
+        // With .cqsignore excluding *.min.js, only regular.js survives.
+        std::fs::write(dir.path().join(".cqsignore"), "**/*.min.js\n").unwrap();
+        let after = enumerate_files(dir.path(), &["js"], false).unwrap();
+        let names: Vec<String> = after
+            .iter()
+            .map(|f| f.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(after.len(), 1, "*.min.js should be filtered: got {names:?}");
+        assert!(names.contains(&"regular.js".to_string()));
+
+        // --no-ignore disables .cqsignore (same semantics as .gitignore).
+        let bypassed = enumerate_files(dir.path(), &["js"], true).unwrap();
+        assert_eq!(bypassed.len(), 2, "--no-ignore must also bypass .cqsignore");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a `.cqsignore` file (gitignore-style syntax) that layers on top of `.gitignore` for files we want committed to git but never indexed. Motivated by the parser warnings recently introduced by the vendored 3D bundles:

```
WARN cqs::parser: Dropped oversized chunks; bump CQS_PARSER_MAX_CHUNK_BYTES if needed
  path=/mnt/c/Projects/cqs/src/serve/assets/vendor/three.min.js dropped=1 cap_bytes=100000
```

`three.min.js`, `3d-force-graph.min.js`, `cytoscape.min.js`, `dagre.min.js`, and the eval JSON fixtures (`evals/queries/*.json`) are all single-line minified blobs hundreds of KB long. Indexing them produces noise warnings and meaningless embeddings (everything matches everything). They need to stay in git — the binary `include_str!`s them — but they shouldn't be in the search index.

`.gitignore` is the wrong layer for this; hence `.cqsignore`.

## What changed

**Library** (`src/lib.rs::enumerate_files`): adds `.add_custom_ignore_filename(".cqsignore")` to the `WalkBuilder`. The `ignore` crate handles the rest — same gitignore syntax, hierarchical per-directory, `--no-ignore` disables it alongside `.gitignore`.

**Watch** (`src/cli/watch.rs::build_gitignore_matcher`): now layers `.gitignore` + `.cqsignore` into a single matcher (`.gitignore` added first, `.cqsignore` second so cqs-specific overrides win on conflict). Either file alone is enough; both missing yields `None` as before.

**Root `.cqsignore`** excludes:
- `src/serve/assets/vendor/*.min.js` — the four vendored bundles
- `evals/queries/*.json` + `evals/reranker_v3/**` — single-line eval fixtures
- `**/__pycache__/` + `*.pyc` — build cruft that occasionally slips past `.gitignore`

## Tests

- `test_enumerate_files_respects_cqsignore` — pre/post `.cqsignore` visibility, plus `--no-ignore` bypass semantics
- `build_gitignore_matcher_loads_cqsignore` — watch matcher merges both files; vendor JS path matches, source files don't
- `build_gitignore_matcher_cqsignore_only` — `.cqsignore` alone (no `.gitignore`) still builds a matcher
- Existing `build_gitignore_matcher_missing_returns_none` updated to assert the both-missing case

## Smoke (full cqs corpus, --release)

| Metric | Before | After |
|---|---|---|
| Total chunks indexed | ~19,000 | 15,504 |
| `Dropped oversized chunks` warnings per `cqs index` | ~12 | 0 |

The 3.5k removed chunks are exclusively from minified vendor JS + single-line JSON fixtures — no useful search content lost.

## Test plan

- [x] `cargo build --features gpu-index --release` clean
- [x] `cargo test --features gpu-index test_enumerate_files_respects_cqsignore build_gitignore_matcher` — all green (5/5)
- [x] End-to-end: `cqs index` against the cqs corpus produces zero "Dropped oversized" warnings
- [x] Index size dropped as expected; nothing useful was filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
