### PR TITLE
test: phase 1 of slow-tests elimination — InProcessFixture harness

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,15 +1,34 @@
 //! Common test fixtures and helpers
 //!
+//! Two fixture tiers:
+//!
+//! - [`TestStore`] — bare `Store` + tempdir. Use when the test only
+//!   exercises the storage layer (chunk CRUD, FTS, call graph rows,
+//!   etc.) and you don't need a parser or embedder.
+//!
+//! - [`InProcessFixture`] — `TestStore` + [`Parser`] + an embedder.
+//!   Use when the test needs to "act like the indexer": parse source
+//!   files, produce embeddings, upsert them, then assert. Replaces the
+//!   subprocess pattern used by the gated `slow-tests` binaries — see
+//!   `docs/plans/2026-04-22-cqs-slow-tests-elimination.md`.
+//!
+//!   By default the fixture uses [`MockEmbedder`], which hashes content
+//!   into deterministic vectors so retrieval works without loading any
+//!   ML model (~ms per test). For the handful of tests that need *real*
+//!   semantic behaviour, `with_real_embedder()` swaps in a shared,
+//!   lazily-cold-loaded `cqs::Embedder` (one per test binary).
+//!
 //! Usage in test files:
 //! ```ignore
 //! mod common;
-//! use common::TestStore;
+//! use common::{InProcessFixture, TestStore};
 //! ```
 
-use cqs::embedder::Embedding;
-use cqs::parser::{Chunk, ChunkType, Language};
+use cqs::embedder::{Embedder, Embedding, ModelConfig};
+use cqs::parser::{Chunk, ChunkType, Language, Parser};
 use cqs::store::{ModelInfo, Store};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
 use tempfile::TempDir;
 
 /// Test store with automatic cleanup
@@ -84,14 +103,16 @@ pub fn test_chunk(name: &str, content: &str) -> Chunk {
     }
 }
 
-/// Create a mock 768-dim embedding (E5-base-v2)
+/// Create a mock embedding from a scalar seed.
 ///
 /// The seed value determines the direction of the embedding vector.
 /// Same seed = same direction = high similarity.
 /// Different seeds = different directions = lower similarity.
+///
+/// Dimension matches `cqs::EMBEDDING_DIM` (1024 with the default BGE-large
+/// preset).
 pub fn mock_embedding(seed: f32) -> Embedding {
     let mut v = vec![seed; cqs::EMBEDDING_DIM];
-    // Normalize to unit length
     let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
     if norm > 0.0 {
         for x in &mut v {
@@ -99,4 +120,210 @@ pub fn mock_embedding(seed: f32) -> Embedding {
         }
     }
     Embedding::new(v)
+}
+
+/// Content-deterministic mock embedding: same text → same vector.
+///
+/// Built by spreading a blake3 digest of `text` across the 1024
+/// dimensions. Useful for harness tests where we want
+/// `embed("foo")` and `embed("foo")` to match (so that `search("foo")`
+/// returns the chunk that contains "foo") *without* loading an ONNX
+/// model. Doesn't preserve real semantic similarity — synonyms won't
+/// cluster — so tests that rely on semantic behaviour should use
+/// `InProcessFixture::with_real_embedder()` instead.
+pub fn mock_embed_text(text: &str) -> Embedding {
+    let hash = blake3::hash(text.as_bytes());
+    let bytes = hash.as_bytes(); // 32 bytes
+    let mut v = vec![0f32; cqs::EMBEDDING_DIM];
+    for (i, slot) in v.iter_mut().enumerate() {
+        let byte = bytes[i % bytes.len()];
+        // Map [0, 256) → [-1, 1] then scatter slightly per-dim so two
+        // strings differing in one char don't collapse onto each other
+        // after normalisation.
+        let centred = (byte as f32 - 128.0) / 128.0;
+        *slot = centred + (i as f32) * 1e-4 * centred.signum();
+    }
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in &mut v {
+            *x /= norm;
+        }
+    }
+    Embedding::new(v)
+}
+
+/// Trait abstracting the production [`Embedder`] so tests can swap in
+/// a deterministic mock without paying the model cold-load cost.
+///
+/// Only the two methods cqs's indexer and search paths actually call
+/// are required; everything else can stay on the concrete `Embedder`.
+pub trait TestEmbedder: Send + Sync {
+    fn embed_documents(&self, texts: &[&str]) -> Vec<Embedding>;
+    fn embed_query(&self, text: &str) -> Embedding;
+}
+
+/// Mock embedder built on [`mock_embed_text`]. Zero model load,
+/// deterministic, sub-microsecond per embedding.
+pub struct MockEmbedder;
+
+impl TestEmbedder for MockEmbedder {
+    fn embed_documents(&self, texts: &[&str]) -> Vec<Embedding> {
+        texts.iter().map(|t| mock_embed_text(t)).collect()
+    }
+    fn embed_query(&self, text: &str) -> Embedding {
+        mock_embed_text(text)
+    }
+}
+
+/// Adapter so the production [`cqs::Embedder`] satisfies [`TestEmbedder`].
+/// The first call lazy-loads the ONNX session.
+impl TestEmbedder for Embedder {
+    fn embed_documents(&self, texts: &[&str]) -> Vec<Embedding> {
+        Embedder::embed_documents(self, texts).expect("real embedder embed_documents failed")
+    }
+    fn embed_query(&self, text: &str) -> Embedding {
+        Embedder::embed_query(self, text).expect("real embedder embed_query failed")
+    }
+}
+
+/// Shared real embedder, lazy-loaded once per test binary. Cold-load
+/// happens on first `with_real_embedder()` call; subsequent calls
+/// reuse the same `Arc` — saves ~2-5s per test on the binaries that
+/// genuinely need semantic embeddings.
+fn shared_real_embedder() -> Arc<Embedder> {
+    static REAL: OnceLock<Arc<Embedder>> = OnceLock::new();
+    REAL.get_or_init(|| {
+        let cfg = ModelConfig::resolve(None, None);
+        Arc::new(Embedder::new_cpu(cfg).expect("failed to construct shared test Embedder"))
+    })
+    .clone()
+}
+
+/// In-process integration fixture: store + parser + embedder, all
+/// living in a single tempdir. Replaces the subprocess pattern used
+/// by the gated `slow-tests` binaries.
+///
+/// Lifetime: drop the fixture and the tempdir is reaped (with the
+/// `.cqs/` index inside it). The shared real-embedder is *not*
+/// dropped — it's pinned by [`shared_real_embedder`]'s `OnceLock`
+/// for the lifetime of the test binary.
+pub struct InProcessFixture {
+    /// The store fixture (gives us `Store` + tempdir cleanup).
+    pub store: TestStore,
+    /// Configured tree-sitter parser. Cheap to construct; not shared
+    /// between fixtures because `Parser` isn't `Sync` in all configs.
+    pub parser: Parser,
+    /// Embedder behind the test trait — `MockEmbedder` by default,
+    /// real `cqs::Embedder` when constructed via `with_real_embedder()`.
+    pub embedder: Arc<dyn TestEmbedder>,
+    /// "Project root" inside the tempdir where source files live.
+    /// `with_corpus()` writes under `root/src/`; `write_file()` accepts
+    /// a name relative to `root/`.
+    pub root: PathBuf,
+}
+
+impl InProcessFixture {
+    /// Build a fixture with the [`MockEmbedder`]. No source files, no
+    /// indexed chunks — call `with_corpus`/`write_file` to populate.
+    pub fn new() -> Self {
+        let store = TestStore::new();
+        let root = store.db_path().parent().unwrap().to_path_buf();
+        let parser = Parser::new().expect("failed to construct test Parser");
+        Self {
+            store,
+            parser,
+            embedder: Arc::new(MockEmbedder),
+            root,
+        }
+    }
+
+    /// Build a fixture with the real shared `cqs::Embedder`. First
+    /// call per test binary cold-loads the ONNX model (~2-5s); later
+    /// calls reuse it. Use only for tests that depend on real semantic
+    /// similarity — most tests do fine with the mock.
+    pub fn with_real_embedder() -> Self {
+        let mut f = Self::new();
+        f.embedder = shared_real_embedder();
+        f
+    }
+
+    /// Convenience: build a fixture pre-populated with a sample
+    /// corpus. Each entry is `(relative_path_under_root, content)`.
+    /// The fixture writes the files, parses them, embeds the chunks,
+    /// and upserts into the store before returning.
+    pub fn with_corpus(files: &[(&str, &str)]) -> Self {
+        let mut f = Self::new();
+        for (path, content) in files {
+            f.write_file(path, content)
+                .expect("seed corpus write_file failed");
+        }
+        f.index().expect("seed corpus index failed");
+        f
+    }
+
+    /// Write a single file to the fixture root, creating parent
+    /// directories as needed.
+    pub fn write_file(&self, rel_path: &str, content: &str) -> std::io::Result<()> {
+        let p = self.root.join(rel_path);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(p, content)
+    }
+
+    /// Re-index every file currently under `root/` (recursively),
+    /// using the configured embedder. Mirrors what `cqs index` does
+    /// at the library level: parse → embed → upsert.
+    ///
+    /// `enumerate_files` returns paths relative to the root, so we join
+    /// each with `self.root` before handing it to the parser — without
+    /// that join the parser would resolve `src/lib.rs` against cargo's
+    /// CWD (the cqs project itself) and end up parsing cqs's own code
+    /// into the test store. Found that the hard way during phase 1
+    /// harness validation.
+    pub fn index(&mut self) -> Result<usize, Box<dyn std::error::Error>> {
+        let exts = self.parser.supported_extensions();
+        let files = cqs::enumerate_files(&self.root, &exts, false)?;
+        let mut total = 0usize;
+        for rel_path in files {
+            let abs_path = self.root.join(&rel_path);
+            let chunks = match self.parser.parse_file(&abs_path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            if chunks.is_empty() {
+                continue;
+            }
+            let texts: Vec<&str> = chunks.iter().map(|c| c.content.as_str()).collect();
+            let embeddings = self.embedder.embed_documents(&texts);
+            let pairs: Vec<(Chunk, Embedding)> = chunks.into_iter().zip(embeddings).collect();
+            total += self.store.upsert_chunks_batch(&pairs, None)?;
+        }
+        Ok(total)
+    }
+
+    /// Convenience: embed `query` via the configured embedder, then
+    /// search the store. Returns the raw `SearchResult`s; tests assert
+    /// on names / scores / counts as needed.
+    pub fn search(
+        &self,
+        query: &str,
+        n: usize,
+    ) -> Result<Vec<cqs::store::SearchResult>, Box<dyn std::error::Error>> {
+        let q_emb = self.embedder.embed_query(query);
+        let filter = cqs::store::SearchFilter::default();
+        let results = self.store.search_filtered(&q_emb, &filter, n, 0.0)?;
+        Ok(results)
+    }
+
+    /// Project root path (the parent of `.cqs/`).
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+}
+
+impl Default for InProcessFixture {
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/tests/common_fixture_test.rs
+++ b/tests/common_fixture_test.rs
@@ -1,0 +1,135 @@
+//! Self-tests for the in-process integration fixture.
+//!
+//! These verify the harness itself before any of the five `cli_*_test.rs`
+//! binaries are converted to use it (phase 1 of the slow-tests
+//! elimination — see `docs/plans/2026-04-22-cqs-slow-tests-elimination.md`).
+//!
+//! All tests use the `MockEmbedder` so they're hermetic and ~ms-fast.
+//! The `with_real_embedder()` path is exercised by the eventual converted
+//! tests; testing the cold-load here would re-introduce the cost we're
+//! trying to delete.
+
+mod common;
+
+use common::{mock_embed_text, InProcessFixture, MockEmbedder, TestEmbedder};
+
+#[test]
+fn empty_fixture_starts_clean() {
+    let f = InProcessFixture::new();
+    let stats = f.store.stats().expect("stats");
+    assert_eq!(stats.total_chunks, 0, "fresh fixture must have no chunks");
+    assert_eq!(stats.total_files, 0, "fresh fixture must have no files");
+}
+
+#[test]
+fn write_file_then_index_inserts_chunks() {
+    let mut f = InProcessFixture::new();
+    f.write_file(
+        "src/lib.rs",
+        "pub fn add(a: i32, b: i32) -> i32 { a + b }\n\
+         pub fn sub(a: i32, b: i32) -> i32 { a - b }\n",
+    )
+    .expect("write");
+    let inserted = f.index().expect("index");
+    assert!(
+        inserted >= 2,
+        "expected ≥2 chunks from a 2-fn file, got {inserted}"
+    );
+
+    let stats = f.store.stats().expect("stats");
+    assert!(
+        stats.total_chunks >= 2,
+        "store should report the inserted chunks, got {}",
+        stats.total_chunks
+    );
+}
+
+#[test]
+fn with_corpus_helper_round_trips() {
+    let f = InProcessFixture::with_corpus(&[
+        (
+            "src/math.rs",
+            "pub fn multiply(a: i32, b: i32) -> i32 { a * b }\n",
+        ),
+        (
+            "src/text.rs",
+            "pub fn greet(name: &str) -> String { format!(\"hello {name}\") }\n",
+        ),
+    ]);
+    let stats = f.store.stats().expect("stats");
+    assert!(
+        stats.total_chunks >= 2,
+        "expected at least one chunk per fixture file, got {}",
+        stats.total_chunks
+    );
+    assert!(
+        stats.total_files >= 2,
+        "expected the two fixture files to be tracked, got {}",
+        stats.total_files
+    );
+}
+
+#[test]
+fn search_returns_indexed_chunk_via_mock_embedder() {
+    // Mock embedder hashes content deterministically, so `search("foo")`
+    // matches the chunk that contains literal "foo" in its content.
+    // This is the property converted tests will rely on.
+    let f = InProcessFixture::with_corpus(&[(
+        "src/lib.rs",
+        "pub fn unique_marker_token() -> i32 { 42 }\n",
+    )]);
+
+    let hits = f.search("unique_marker_token", 5).expect("search");
+    assert!(
+        !hits.is_empty(),
+        "search by content token should return the indexed chunk"
+    );
+    let names: Vec<&str> = hits.iter().map(|r| r.chunk.name.as_str()).collect();
+    assert!(
+        names.contains(&"unique_marker_token"),
+        "expected unique_marker_token in results, got {names:?}"
+    );
+}
+
+#[test]
+fn fixture_isolation_per_instance() {
+    // Two fixtures must not share storage — each has its own tempdir.
+    let a = InProcessFixture::with_corpus(&[("src/a.rs", "pub fn fn_a() {}\n")]);
+    let b = InProcessFixture::with_corpus(&[("src/b.rs", "pub fn fn_b() {}\n")]);
+
+    let a_hits = a.search("fn_b", 5).expect("search a for b");
+    assert!(
+        a_hits.iter().all(|r| r.chunk.name != "fn_b"),
+        "fixture a must not see fixture b's chunks"
+    );
+
+    let b_hits = b.search("fn_a", 5).expect("search b for a");
+    assert!(
+        b_hits.iter().all(|r| r.chunk.name != "fn_a"),
+        "fixture b must not see fixture a's chunks"
+    );
+}
+
+#[test]
+fn mock_embedder_is_deterministic() {
+    let m = MockEmbedder;
+    let v1 = m.embed_query("hello world");
+    let v2 = m.embed_query("hello world");
+    assert_eq!(v1.as_slice(), v2.as_slice(), "same text → same vector");
+
+    let v3 = m.embed_query("totally different content");
+    assert_ne!(
+        v1.as_slice(),
+        v3.as_slice(),
+        "different text → different vector"
+    );
+}
+
+#[test]
+fn mock_embed_text_helper_matches_trait_impl() {
+    // The free function and the trait impl must agree so tests can use
+    // either form interchangeably.
+    let direct = mock_embed_text("for-the-trait");
+    let via_trait = MockEmbedder.embed_query("for-the-trait");
+    assert_eq!(direct.as_slice(), via_trait.as_slice());
+}


### PR DESCRIPTION
## Summary

Phase 1 of `docs/plans/2026-04-22-cqs-slow-tests-elimination.md`. Builds the in-process integration harness the per-binary conversion PRs (PR-1..PR-5) will use to retire the 5 subprocess-spawning slow-test binaries that anchor the nightly cron.

No production code changes. Pure test infrastructure.

## What changed

**New `InProcessFixture`** in `tests/common/mod.rs` alongside the existing `TestStore`. Bundles `Store` + `Parser` + a pluggable embedder so tests can act like the indexer in-process — no `cqs` subprocess, no per-test ONNX cold-load.

Embedder paths:
- **Default — `MockEmbedder`.** Hashes content via blake3 into deterministic 1024-dim vectors. ~ms-fast, hermetic, sufficient for "did this chunk get indexed and findable" tests (which is most of them).
- **Opt-in — `with_real_embedder()`.** Shared `Arc<Embedder>` constructed once per test binary via `OnceLock`. First call lazy-loads the ONNX session; subsequent calls reuse it. For the small subset of tests that depend on real semantic similarity.

Helpers: `new()`, `with_corpus(&[(name, content)])`, `write_file()`, `index()`, `search()`. The full `cqs index` pipeline (enumerate → parse → embed → upsert) collapsed to library calls.

## Why a `TestEmbedder` trait

Two reasons rather than just using `cqs::Embedder` directly:
1. The mock path can't be a real `Embedder` instance — it has no ONNX session.
2. The trait keeps the harness honest about what surface tests actually use (just `embed_documents` + `embed_query`).

## Pothole found during validation

`cqs::enumerate_files` returns paths relative to its `root` argument. The first `index()` implementation passed those straight to `parser.parse_file()`, which then resolved them against cargo's CWD — the cqs project root — and parsed cqs's own source into the test store. Caught immediately by `search_returns_indexed_chunk_via_mock_embedder` returning chunks named `test_normalize_path_*` instead of the test fixture's `unique_marker_token`.

Fix: join with `self.root` before handing to the parser. Comment in `index()` flags it for the next person to read this.

## Tests

7 self-tests in `tests/common_fixture_test.rs`, all green:
- `empty_fixture_starts_clean`
- `write_file_then_index_inserts_chunks`
- `with_corpus_helper_round_trips`
- `search_returns_indexed_chunk_via_mock_embedder`
- `fixture_isolation_per_instance`
- `mock_embedder_is_deterministic`
- `mock_embed_text_helper_matches_trait_impl`

Wall time for the entire `tests/common_fixture_test.rs` binary: **~30 seconds** (most of which is cargo build, not the tests themselves). Compare to the existing slow-tests binaries which take 25+ minutes each.

## Decision gate

Per the spec: harness LOC + ergonomics. If `with_corpus(&[...])` ergonomically beats the equivalent `cqs() init + cqs() index` subprocess pattern, scale to PR-1 (cli_health, smallest pilot at 6 tests). If not, redesign before going wide.

The harness API:
```rust
let f = InProcessFixture::with_corpus(&[
    ("src/lib.rs", "pub fn add(a: i32, b: i32) -> i32 { a + b }"),
]);
let hits = f.search("add", 5)?;
```

vs. the existing pattern:
```rust
let dir = setup_project();  // also writes src/lib.rs with two fns
cqs().args(["init"]).current_dir(dir.path()).assert().success();
cqs().args(["index"]).current_dir(dir.path()).assert().success();
let output = cqs().args(["search", "add"]).current_dir(dir.path()).output()?;
let json: Value = serde_json::from_slice(&output.stdout)?;
// then assert on json["results"]
```

Verdict: harness wins on terseness + speed. Greenlight to start phase 2.

## Test plan

- [x] `cargo build --features gpu-index --tests` clean
- [x] `cargo test --features gpu-index --test common_fixture_test` — 7/7 pass
- [x] `cargo clippy --features gpu-index --tests` — zero warnings on the new files
- [ ] After merge, start PR-1 (cli_health_test conversion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
