### PR TITLE
chore(deps): bump locked rand 0.8.5 -> 0.8.6 (security alert #9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,7 +2887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3164,9 +3164,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]


### PR DESCRIPTION
## Summary

Closes the last open Dependabot security alert (#9, low severity): "Rand is unsound with a custom logger using `rand::rng()`". Patched in `rand 0.8.6`.

## Provenance

The vulnerable `rand 0.8.5` is pulled in only as a build helper for phf perfect-hash generation:

```
cqs (convert feature)
└── fast_html2md
    └── auto_encoder
        └── phf_generator 0.11.3
            └── rand 0.8.5  ← vulnerable
```

The other `rand` versions in the dependency tree (`0.9.4`, `0.10.1`) are unaffected — different majors.

## What changed

`cargo update -p rand@0.8.5 --precise 0.8.6` — lockfile-only, no `Cargo.toml` change needed.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [ ] After merge: confirm Dependabot alert #9 auto-closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
