### PR TITLE
chore: Release v1.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.29.1] - 2026-04-24
+
+Patch release: v1.29.0 audit close-out. 147 findings triaged; 142 fixed across #1093 and #1094. Remaining 5 items are architectural / micro-perf and live in #1095, #1096, #1097, #1098. No new commands, no behaviour changes by default; env-var additions are additive, JSON field additions are non-breaking.
+
+### Fixed
+
+- **Cagra GPU index SIGSEGV on drop** (`src/cagra.rs`). `impl Drop for GpuState` now calls `resources.sync_stream()` before fields drop; prior async CUDA kernels could be in-flight when `cuvsResourcesDestroy` fired, producing a segfault during test teardown. All 22 cagra tests now pass serially.
+- **HNSW persistence fsync gap** — parent-directory fsync after `persist()` write (DS2-6).
+- **Staleness + metadata writes honour `begin_write`** — `SELECT DISTINCT origin` and `touch_updated_at` / `set_metadata_opt` now land inside a transaction so concurrent readers see consistent state (DS2-1, DS2-2, DS2-3).
+- **Cache eviction single-tx + WAL checkpoint on drop** — `evict_lock` taken once, eviction runs under one transaction, `Cache::drop` runs `PRAGMA wal_checkpoint(TRUNCATE)` (DS2-5, RM-V1.29-7).
+- **RwLock poison recovery in `cqs watch`** — daemon recovers from a poisoned inner lock rather than aborting the dispatcher (EH-V1.29-8).
+- **`clear_hnsw_dirty` retries under SQLite contention** (DS2-7).
+- **`upsert_chunks_calls_and_prune` single tx** — prior implementation pruned in a second tx, briefly exposing partial graphs to readers (DS2-4).
+- **Migration backup required by default** — `CQS_MIGRATE_REQUIRE_BACKUP=1` is now default; orphan drop > 10% errors instead of silently landing (DS2-8).
+- **L5X parser panics on malformed regex match** — 4 `unwrap` sites replaced with `let-else` + `tracing::warn!+continue` (RB-V1.29-5).
+- **`is_wsl()` false positives** — detection now requires `WSL_INTEROP` env or `/proc/sys/fs/binfmt_misc/WSLInterop`, not just `microsoft` / `wsl` in `/proc/version` (PB-V1.29-10).
+
+### Security
+
+- **`cqs serve` host-header allowlist middleware** — rejects requests with a `Host` header outside the bind address (SEC-1).
+- **`cqs serve` SQL LIMIT caps** — `build_graph` / `build_cluster` bounded at 50k nodes + 500k edges and 50k cluster nodes; user-supplied `max_nodes` is clamped, not trusted (SEC-3).
+- **`cqs serve` asset HTML escaping** — `escapeHtml` helper wraps every `innerHTML` interpolation in `hierarchy-3d.js` and `cluster-3d.js` (SEC-2).
+- **`cqs serve --open` forces loopback** — `loopback_open_url` helper replaces user-supplied `bind_addr` with `127.0.0.1` / `::1` for the launched browser URL regardless of what `--bind` set the server to (SEC-6).
+- **`rustls-webpki` 0.103.12 → 0.103.13** (Dependabot #15, GHSA high — DoS via panic on malformed CRL BIT STRING).
+
+### Added
+
+- **Degraded / warnings signalling** — `ImpactResult` + `DiffImpactSummary` gain a `degraded` flag; context outputs gain `warnings: Vec<String>`. Callers surface partial-result state instead of silently short-circuiting (EH-V1.29-9).
+- **Env-var knobs for thresholds** — `CQS_HOTSPOT_MIN_CALLERS`, `CQS_DEAD_CLUSTER_MIN_SIZE`, `CQS_HEALTH_HOTSPOT_COUNT`, `CQS_SUGGEST_HOTSPOT_POOL`, `CQS_RISK_HIGH`, `CQS_RISK_MEDIUM`, `CQS_BLAST_LOW_MAX`, `CQS_BLAST_HIGH_MIN`, `CQS_CONVERT_MAX_FILE_SIZE`, `CQS_CONVERT_WEBHELP_BYTES`, `CQS_DAEMON_PERIODIC_GC_INTERVAL_SECS`, `CQS_DAEMON_PERIODIC_GC_IDLE_SECS`, `CQS_BATCH_MAX_LINE_LEN` (SHL-V1.29-7, SHL-V1.29-8, SHL-V1.29-9). Defaults preserved; these are escape hatches for users on corpora / projects with different thresholds.
+- **Startup self-test** — `test_every_language_has_nonempty_chunk_query` iterates `REGISTRY.all()` and asserts every language's chunk query is non-empty. Catches empty `queries/*.scm` files at build time (EX-V1.29-7).
+- **`trait ConfigSection`** — `.cqs.toml` sections now implement a common trait; `apply_config_defaults` uses clap's `ArgSource::DefaultValue` rather than `DEFAULT_*` const comparison to detect "user set it explicitly" (EX-V1.29-8).
+- **`define_aux_presets!` macro** — collapses 5 parallel matches in `AuxModelKind` preset registration into a single preset table (EX-V1.29-4).
+- **`VisibilityRule` variants** — `SigStartsTriage`, `RegexImportSet`, `NameCase` added to `where_to_add::VisibilityRule`; `LanguagePatternDef` gains `inline_test_markers`. Moves three custom Rust/TS-JS/Go arms into the pattern table (EX-V1.29-2).
+- **Daemon socket thread stack size** — `std::thread::Builder::new().stack_size(256 * 1024)` on spawned handlers; worst-case memory at `CQS_MAX_DAEMON_CLIENTS=128` drops from ~128 MB (default 1 MB stacks) to ~32 MB (RM-V1.29-9).
+- **Reranker happy-path tests** — `test_rerank_empty_input_returns_empty` (always runs) and `test_rerank_reorders_by_relevance` (`#[ignore]`-gated, requires model on disk). Pins the `rerank` / `rerank_with_passages` contract that was previously exercised only via the black-box eval loop (TC-HAP-1.29-3).
+- **`cqs project search` CLI integration test** — two registered projects, indexed separately, cross-project search asserts per-project tagging (TC-HAP-1.29-4).
+- **`cqs ref {add,list,remove,update}` CLI integration tests** — end-to-end happy paths, `slow-tests` gated (TC-HAP-1.29-5).
+- **Daemon socket happy-path round-trip test** — `{"command":"stats","args":[]}` through `handle_socket_client` via std `UnixStream::pair()`; asserts envelope shape + payload (TC-HAP-1.29-6).
+
+### Changed
+
+- **`is_wsl()` gating** — tightened to require `WSL_INTEROP` or WSLInterop binfmt as well as the `/proc/version` substring (PB-V1.29-10). Affects rendering heuristics only, not correctness.
+- **HNSW persist chunk size** — bumped from 100 MB to 1 GB (SHL-V1.29-3).
+
+### Internal
+
+- **`normalize_path` helper + `dispatch_tokens`** in `src/cli/watch.rs` (PB-V1.29-2, PF-V1.29-1).
+- **`LazyLock` migration** for daemon static state (RM-V1.29-8).
+- **`hf_cache_dir()` helper** centralizes the HF cache path resolution (PB-V1.29-8).
+
+### Migration notes
+
+- No schema bump; no reindex required.
+- JSON output on `cqs impact` / `cqs ci` / `cqs context` now carries `degraded: bool` and / or `warnings: Vec<String>` fields. Additive only — missing fields still deserialize as empty / false for prior consumers.
+- If you were relying on default hotspot / risk / blast thresholds and want them restored after editing `~/.config/cqs/cqs.toml`, clear the relevant `CQS_*` env vars.
+
 ## [1.29.0] - 2026-04-23
 
 Feature release. Three things land together: a new interactive web UI (`cqs serve`) with four call-graph / hierarchy / embedding-cluster views, a new opt-in cqs-specific ignore mechanism (`.cqsignore`), and the elimination of the ~130-minute nightly slow-tests cron (5 subprocess CLI test binaries → 4 in-process binaries running in regular PR CI in <2 min). Schema bumps v21 → v22 for the cluster view's UMAP coordinates; auto-applied on first daemon/CLI startup.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "1.29.0"
+version = "1.29.1"
 edition = "2021"
 rust-version = "1.95"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 91% R@1 on 296-query fixtures, 42% R@1 / 64% R@5 / 79% R@20 on v3 real code-search (544 dual-judge queries). Daemon mode (3-19ms queries). Local-first, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,13 +2,30 @@
 
 ## Right Now
 
-**v1.29.0 shipped 2026-04-23 (PR #1092 squashed at 22:57 UTC).** crates.io published, GitHub Release workflow building binaries (~13 min), local binary at 1.29.0. No active PRs.
+**v1.29.1 prepared 2026-04-24.** Audit close-out patch release. Working tree: CHANGELOG / PROJECT_CONTINUITY / ROADMAP updated, release build in progress, release via `/release` skill pending. Main is at `1a9215c7` (post-audit merge).
 
 ### Open PRs
 
-None.
+None. PR #1094 (91 P1-P3 fixes, cagra segfault root-caused, TC-HAP coverage) merged at 2026-04-24T19:55 UTC. PR #1093 (docs refresh for v1.29.0) merged at 2026-04-24T19:17 UTC.
 
-### v1.29.0 contents
+### v1.29.1 contents
+
+Patch release — audit close-out. 147 findings from the v1.29.0 audit triaged; 142 fixed across 3 commits to #1094 + #1093. No new commands, no schema bump, no reindex. Full list in `CHANGELOG.md`.
+
+Highlights:
+- **Cagra SIGSEGV root-caused + fixed** — `impl Drop for GpuState` now calls `resources.sync_stream()` before fields drop. Async CUDA kernels from prior tests were in-flight when `cuvsResourcesDestroy` fired, producing a teardown segfault. All 22 cagra tests pass serially post-fix.
+- **`cqs serve` security hardening** — Host header allowlist (SEC-1), SQL LIMIT caps on graph + cluster (SEC-3), HTML escaping on 3D asset innerHTML (SEC-2), `--open` forced to loopback (SEC-6).
+- **Transaction integrity** — staleness / metadata writes honour `begin_write`, cache eviction single-tx, HNSW persist parent-dir fsync, migration backup default-on with orphan-drop guard.
+- **Env-var knobs** — 13 new `CQS_*` vars for thresholds (hotspot/risk/blast/GC/etc). Additive; defaults preserved.
+- **Test coverage** — reranker happy paths, `cqs project search` / `cqs ref {add,list,remove,update}` CLI end-to-end, daemon socket round-trip.
+- **Security bump** — `rustls-webpki` 0.103.12 → 0.103.13 (Dependabot #15, GHSA high, DoS via malformed CRL).
+
+### Audit close-out remaining
+
+- **Umbrella**: issue #1095 (rewritten post-#1094; 2 micro-perf items kept: PF-V1.29-9 suggest_tests BFS, RM-V1.29-10 socket BufReader scratch).
+- **Split into tracking issues**: #1096 (SEC-7 serve auth), #1097 (EX-V1.29-1 Commands→trait), #1098 (EX-V1.29-3 LlmProvider trait + Local provider).
+
+### v1.29.0 contents (shipped 2026-04-23)
 
 Feature release bundling three arcs (23 commits since v1.28.3):
 - **`cqs serve`** with 4 views (2D / 3D / hierarchy / embedding cluster) + perf pass (~60s → ~3-4s first paint). Schema v22 (umap_x/umap_y); opt-in via `cqs index --umap`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,10 @@
 # Roadmap
 
-## Current: v1.29.0 (cqs serve + .cqsignore + slow-tests cron eliminated)
+## Current: v1.29.1 (v1.29.0 audit close-out)
 
 54 languages. 29 chunk types. v3 eval canonical, regenerated to v2 fixture 2026-04-17/20 (109 test / 109 dev). Daemon mode (`cqs watch --serve`, 99ms graph p50 / 200ms search-warm p50). Per-category SPLADE alpha routing — re-swept against R@5 in v1.28.3 (was R@1-tuned). **Centroid classifier active by default** (test R@5 +3.7pp from category-aware routing; opt-out via `CQS_CENTROID_CLASSIFIER=0`). GPU-native CAGRA bitset filtering (patched cuvs 26.4). Schema v22 (umap_x/umap_y, opt-in via `cqs index --umap`). MSRV 1.95.
+
+**v1.29.1** shipped 2026-04-24: patch release — v1.29.0 audit close-out. 147 findings triaged; 142 fixed. No new commands, no schema bump, no reindex. Cagra SIGSEGV root-caused (missing `Drop` on `GpuState`) + fixed; `cqs serve` security hardened (host allowlist, SQL caps, HTML escape, loopback `--open`); transaction integrity fixes (staleness / metadata / cache / HNSW persist); 13 new `CQS_*` env var knobs for thresholds (additive); `rustls-webpki` GHSA-high patch; reranker + daemon-socket + cross-project test coverage. Remaining 5 audit items (SEC-7 serve auth, EX-1 Commands trait, EX-3 LlmProvider trait, PF-9 suggest_tests BFS, RM-10 socket BufReader) split to issues #1096/#1097/#1098 + umbrella #1095. Full detail in `CHANGELOG.md`.
 
 **v1.29.0** shipped 2026-04-23: feature release bundling three arcs.
 


### PR DESCRIPTION
## Summary

- Patch release: v1.29.0 audit close-out.
- 147 findings triaged; 142 fixed across #1093 + #1094; remaining 5 items split into #1095, #1096, #1097, #1098.
- No new commands, no schema bump, no reindex required.

## What's included

- **Cagra SIGSEGV** root-caused + fixed — `impl Drop for GpuState` calls `resources.sync_stream()` before fields drop. All 22 cagra tests pass serially.
- **`cqs serve` security hardening** — host header allowlist, SQL LIMIT caps on graph + cluster, HTML escape on 3D asset innerHTML, `--open` forced to loopback, `rustls-webpki` 0.103.12 → 0.103.13 (GHSA high, DoS via malformed CRL).
- **Transaction integrity** — staleness / metadata writes honour `begin_write`, cache eviction single-tx, HNSW persist parent-dir fsync, migration backup default-on with orphan-drop guard.
- **13 new `CQS_*` env var knobs** for hotspot / risk / blast / GC thresholds. Additive, defaults preserved.
- **Test coverage** — reranker happy paths, daemon socket round-trip, cross-project CLI search, ref CLI end-to-end.

Full changelog: `CHANGELOG.md` § `[1.29.1]`.

## Test plan

- [x] `cargo build --release --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib -- --test-threads=1` — 1679 pass, 0 failed
- [x] Local binary installed and daemon restarted — `cqs index` reindexed cleanly (16,369 chunks)
- [ ] CI green (fmt / clippy / msrv / test / CodeQL / Analyze)
