### PR TITLE
feat(slot+cache): named slots + project-scoped embeddings cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,8 @@ Key commands (`--json` works on all commands; `--format mermaid` also accepted o
 - `cqs ref add/remove/list` - manage reference indexes for multi-index search
 - `cqs project register/remove/list/search` - cross-project search registry
 - `cqs export-model --repo <org/model>` - export a HuggingFace model to ONNX format for use with cqs
-- `cqs cache stats/clear/prune` - manage global embedding cache (~/.cache/cqs/embeddings.db)
+- `cqs cache stats/prune/compact` - manage the project-scoped embeddings cache at `<project>/.cqs/embeddings_cache.db`. `--per-model` on stats; `prune <DAYS>` or `prune --model <id>`; `compact` runs VACUUM
+- `cqs slot list/create/promote/remove/active` - named slots — side-by-side full indexes under `.cqs/slots/<name>/`. Promote is atomic; daemon restart picks up the new slot
 - `cqs doctor` - check model, index, hardware (execution provider, CAGRA availability)
 - `cqs completions <shell>` - generate shell completions (bash, zsh, fish, powershell, elvish)
 
@@ -772,6 +773,9 @@ Both splits are ±2-3pp noisy on a single trial; quote both when comparing confi
 | `CQS_RERANK_OVER_RETRIEVAL` | `4` | Multiplier on `--limit` for the reranker over-retrieval pool. At `--rerank --limit N`, stage-1 returns `N * MULTIPLIER` candidates so the cross-encoder has recall headroom. Bump for projects where the right answer routinely sits past rank-20 in stage-1. |
 | `CQS_RERANK_POOL_MAX` | `20` | Hard cap on the reranker pool regardless of multiplier. Caps ORT memory + per-batch latency, and avoids weak cross-encoders shuffling noise at deep ranks. Bump on workstations running a known-strong reranker. |
 | `CQS_RRF_K` | `60` | RRF fusion constant (higher = more weight to top results) |
+| `CQS_SLOT` | (unset) | Slot to use for this invocation. Overridden by `--slot` flag, overrides `.cqs/active_slot`. See `cqs slot --help`. |
+| `CQS_CACHE_ENABLED` | `1` | Set `0` to disable the project-scoped embeddings cache for this run (benchmark / debug). Cache lives at `<project>/.cqs/embeddings_cache.db`. |
+| `CQS_CACHE_MAX_BYTES` | (unset) | Soft cap; emits `tracing::warn!` when the embeddings cache DB exceeds this many bytes. Does NOT auto-prune — use `cqs cache prune` / `cqs cache compact`. |
 | `CQS_SKIP_ENRICHMENT` | (none) | Comma-separated enrichment layers to skip (e.g. `llm,hyde,callgraph`) |
 | `CQS_SKIP_INTEGRITY_CHECK` | (none) | Set to `1` to skip `PRAGMA quick_check` on write-mode store opens |
 | `CQS_SPLADE_ALPHA` | (per-category default) | Global SPLADE fusion alpha override (0.0 = pure sparse, 1.0 = pure dense) |

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -35,6 +35,22 @@ pub struct CacheStats {
     pub newest_timestamp: Option<i64>,
 }
 
+/// Per-model cache statistics — surfaced by [`EmbeddingCache::stats_per_model`]
+/// for `cqs cache stats` so users can see which model_id holds how many
+/// embeddings before pruning.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PerModelStats {
+    pub model_id: String,
+    pub entries: u64,
+    pub total_bytes: u64,
+}
+
+/// File name of the project-scoped embeddings cache, sibling to `slots/`
+/// inside `.cqs/`. The cache is shared across all slots of a project so an
+/// embedder swap (BGE → E5 etc.) only re-embeds chunks whose hash hasn't
+/// previously been seen for that model_id.
+pub const PROJECT_EMBEDDINGS_CACHE_FILENAME: &str = "embeddings_cache.db";
+
 /// Global embedding cache backed by SQLite.
 ///
 /// Best-effort: all operations that fail are logged and skipped.
@@ -55,11 +71,25 @@ pub struct EmbeddingCache {
 }
 
 impl EmbeddingCache {
-    /// Default cache location.
+    /// Legacy global cache location at `~/.cache/cqs/embeddings.db`.
+    ///
+    /// Kept so existing callers (`cqs cache` subcommand pre-slots) continue to
+    /// work for invocations outside a project. New code prefers
+    /// [`Self::project_default_path`] so caches are scoped to the project and
+    /// survive slot promotion / removal.
     pub fn default_path() -> std::path::PathBuf {
         dirs::home_dir()
             .unwrap_or_else(|| std::path::PathBuf::from("."))
             .join(".cache/cqs/embeddings.db")
+    }
+
+    /// Project-scoped cache path: `<project_cqs_dir>/embeddings_cache.db`.
+    ///
+    /// Located alongside `.cqs/slots/` so cache survives `cqs slot remove`
+    /// and `cqs slot create` cycles. One file per project — same chunk hashed
+    /// across two slots with the same model_id only embeds once.
+    pub fn project_default_path(project_cqs_dir: &Path) -> std::path::PathBuf {
+        project_cqs_dir.join(PROJECT_EMBEDDINGS_CACHE_FILENAME)
     }
 
     /// Open or create the embedding cache.
@@ -534,6 +564,159 @@ impl EmbeddingCache {
             tracing::info!(pruned, "Cache pruned");
             Ok(pruned)
         })
+    }
+
+    /// Drop every cache entry tagged with the given `model_id`.
+    ///
+    /// Used by `cqs cache prune --model <id>` after a model swap when the
+    /// user knows the corresponding embeddings will never be reused. Returns
+    /// the number of rows deleted. Identical to [`Self::clear`] with
+    /// `Some(model_id)` but exposes the spec's verb shape.
+    pub fn prune_by_model(&self, model_id: &str) -> Result<usize, CacheError> {
+        let _span = tracing::info_span!("cache_prune_by_model", model_id).entered();
+        self.clear(Some(model_id))
+    }
+
+    /// `VACUUM` the cache database to reclaim unused pages after large
+    /// deletes. Spec §Cache: surface as `cqs cache compact`.
+    pub fn compact(&self) -> Result<(), CacheError> {
+        let _span = tracing::info_span!("cache_compact").entered();
+        self.rt.block_on(async {
+            // VACUUM cannot run inside an explicit transaction.
+            sqlx::query("VACUUM").execute(&self.pool).await?;
+            tracing::info!("Cache vacuumed");
+            Ok(())
+        })
+    }
+
+    /// Per-model cache statistics — entry count + sum-of-embedding-bytes.
+    ///
+    /// Surfaced by `cqs cache stats` so users can pick a `prune_by_model`
+    /// target. Returns rows sorted by entry count descending.
+    pub fn stats_per_model(&self) -> Result<Vec<PerModelStats>, CacheError> {
+        let _span = tracing::info_span!("cache_stats_per_model").entered();
+        self.rt.block_on(async {
+            let rows: Vec<(String, i64, i64)> = sqlx::query_as(
+                "SELECT model_fingerprint, COUNT(*), COALESCE(SUM(LENGTH(embedding)), 0) \
+                 FROM embedding_cache \
+                 GROUP BY model_fingerprint \
+                 ORDER BY COUNT(*) DESC",
+            )
+            .fetch_all(&self.pool)
+            .await?;
+            Ok(rows
+                .into_iter()
+                .map(|(model_id, entries, bytes)| PerModelStats {
+                    model_id,
+                    entries: entries.max(0) as u64,
+                    total_bytes: bytes.max(0) as u64,
+                })
+                .collect())
+        })
+    }
+
+    /// Partition `items` into (cached, missed) by checking which content
+    /// hashes already have an embedding stored for `model_id`.
+    ///
+    /// Spec §Cache: pre-filter before the embed batch so only misses go
+    /// through the GPU. `hash_fn` extracts the content hash bytes (matching
+    /// the cache's stored `content_hash` column) from each item.
+    ///
+    /// Returns `(cached_with_emb, missed)` where:
+    /// - `cached_with_emb`: items whose hash hit, paired with the cached
+    ///   `Vec<f32>` embedding
+    /// - `missed`: items whose hash didn't hit (or whose dim mismatched —
+    ///   stale entries are silently re-embedded by the caller; the cache
+    ///   write later overwrites via `INSERT OR IGNORE` once the dim matches)
+    ///
+    /// Preserves input order for both arrays so the caller can interleave
+    /// fresh embeddings back in their original positions.
+    #[allow(clippy::type_complexity)]
+    pub fn partition<'a, T>(
+        &self,
+        items: &'a [T],
+        model_id: &str,
+        expected_dim: usize,
+        hash_fn: impl Fn(&T) -> &str,
+    ) -> Result<(Vec<(&'a T, Vec<f32>)>, Vec<&'a T>), CacheError> {
+        let _span = tracing::debug_span!(
+            "cache_partition",
+            count = items.len(),
+            model_id_prefix = &model_id[..8.min(model_id.len())]
+        )
+        .entered();
+
+        if items.is_empty() {
+            return Ok((Vec::new(), Vec::new()));
+        }
+
+        let hashes: Vec<&str> = items.iter().map(&hash_fn).collect();
+        let hits = self.read_batch(&hashes, model_id, expected_dim)?;
+        let mut cached = Vec::with_capacity(hits.len());
+        let mut missed = Vec::with_capacity(items.len() - hits.len());
+        for item in items {
+            let h = hash_fn(item);
+            if let Some(emb) = hits.get(h) {
+                cached.push((item, emb.clone()));
+            } else {
+                missed.push(item);
+            }
+        }
+        Ok((cached, missed))
+    }
+
+    /// Insert many `(content_hash, model_id, embedding)` tuples in one
+    /// transaction. Convenience wrapper over [`Self::write_batch`] when the
+    /// caller doesn't already have entries grouped by model.
+    ///
+    /// Mixed `model_id` values across `entries` are handled by grouping
+    /// entries per model and issuing one `write_batch` per group.
+    pub fn insert_many(
+        &self,
+        entries: &[(Vec<u8>, String, Vec<f32>)],
+        expected_dim: usize,
+    ) -> Result<usize, CacheError> {
+        let _span = tracing::debug_span!("cache_insert_many", count = entries.len()).entered();
+        if entries.is_empty() {
+            return Ok(0);
+        }
+        // Group by model_id.
+        let mut groups: HashMap<&str, Vec<(String, &[f32])>> = HashMap::new();
+        for (hash, model_id, emb) in entries {
+            // Cache stores content_hash as TEXT. Convert blob → utf-8 hex for
+            // backwards compatibility with the existing column type.
+            let hex = blake3_hex_or_passthrough(hash);
+            groups
+                .entry(model_id)
+                .or_default()
+                .push((hex, emb.as_slice()));
+        }
+        let mut total = 0;
+        for (model_id, group) in groups {
+            // Collapse to the borrowed shape the existing write_batch expects
+            // — owned String for the hash, borrowed slice for the embedding.
+            let borrowed: Vec<(&str, &[f32])> =
+                group.iter().map(|(h, e)| (h.as_str(), *e)).collect();
+            total += self.write_batch(&borrowed, model_id, expected_dim)?;
+        }
+        Ok(total)
+    }
+}
+
+/// Best-effort hex encoding for blob hashes. If the bytes are already a valid
+/// UTF-8 hex string (the common case — `Chunk::content_hash` is produced as
+/// a hex string), the value passes through unchanged.
+fn blake3_hex_or_passthrough(bytes: &[u8]) -> String {
+    match std::str::from_utf8(bytes) {
+        Ok(s) if s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit()) => s.to_string(),
+        _ => {
+            let mut s = String::with_capacity(bytes.len() * 2);
+            for b in bytes {
+                use std::fmt::Write;
+                let _ = write!(s, "{:02x}", b);
+            }
+            s
+        }
     }
 }
 
@@ -1021,6 +1204,169 @@ mod tests {
 
         let stats = cache.stats().unwrap();
         assert_eq!(stats.total_entries, 3); // only fresh ones survive
+    }
+
+    // ─── New spec methods ───────────────────────────────────────────────
+
+    /// `partition` splits items into hits + misses preserving order.
+    #[test]
+    fn test_partition_hits_and_misses() {
+        let (cache, _dir) = test_cache();
+        // Pre-populate two of the four hashes.
+        let entries = vec![
+            ("hash_a".to_string(), make_embedding(64, 1.0)),
+            ("hash_c".to_string(), make_embedding(64, 3.0)),
+        ];
+        cache.write_batch_owned(&entries, "model_x", 64).unwrap();
+
+        let items: Vec<&str> = vec!["hash_a", "hash_b", "hash_c", "hash_d"];
+        let (cached, missed) = cache
+            .partition(&items, "model_x", 64, |s: &&str| *s)
+            .unwrap();
+        assert_eq!(cached.len(), 2);
+        assert_eq!(missed.len(), 2);
+        let cached_hashes: Vec<&str> = cached.iter().map(|(s, _)| **s).collect();
+        let missed_hashes: Vec<&str> = missed.iter().map(|s| **s).collect();
+        assert_eq!(cached_hashes, vec!["hash_a", "hash_c"]);
+        assert_eq!(missed_hashes, vec!["hash_b", "hash_d"]);
+    }
+
+    /// `partition` returns empty splits for empty input.
+    #[test]
+    fn test_partition_empty() {
+        let (cache, _dir) = test_cache();
+        let items: Vec<&str> = Vec::new();
+        let (cached, missed) = cache
+            .partition(&items, "model_x", 64, |s: &&str| *s)
+            .unwrap();
+        assert!(cached.is_empty());
+        assert!(missed.is_empty());
+    }
+
+    /// `prune_by_model` only removes entries for the named model_id.
+    #[test]
+    fn test_prune_by_model_keeps_other_models() {
+        let (cache, _dir) = test_cache();
+        let entries: Vec<_> = (0..3)
+            .map(|i| (format!("h{i}"), make_embedding(64, i as f32)))
+            .collect();
+        cache.write_batch_owned(&entries, "model_a", 64).unwrap();
+        cache.write_batch_owned(&entries, "model_b", 64).unwrap();
+        let removed = cache.prune_by_model("model_a").unwrap();
+        assert_eq!(removed, 3);
+        let stats_a = cache
+            .read_batch(&["h0", "h1", "h2"], "model_a", 64)
+            .unwrap();
+        assert!(stats_a.is_empty());
+        let stats_b = cache
+            .read_batch(&["h0", "h1", "h2"], "model_b", 64)
+            .unwrap();
+        assert_eq!(stats_b.len(), 3);
+    }
+
+    /// `compact` shrinks the DB after a large delete.
+    #[test]
+    fn test_compact_after_delete_shrinks_file() {
+        let (cache, _dir) = test_cache();
+        let entries: Vec<_> = (0..200)
+            .map(|i| (format!("hh{i}"), make_embedding(128, i as f32)))
+            .collect();
+        cache.write_batch_owned(&entries, "model_y", 128).unwrap();
+        let before = cache.stats().unwrap().total_size_bytes;
+
+        // Delete everything.
+        let _ = cache.clear(None).unwrap();
+        // VACUUM
+        cache.compact().unwrap();
+        let after = cache.stats().unwrap().total_size_bytes;
+        assert!(after <= before, "compact should not grow the DB");
+    }
+
+    /// `stats_per_model` reports per-model entries + bytes.
+    #[test]
+    fn test_stats_per_model_groups_correctly() {
+        let (cache, _dir) = test_cache();
+        let mk = |n: usize, dim: usize| -> Vec<_> {
+            (0..n)
+                .map(|i| (format!("h{i}"), make_embedding(dim, i as f32)))
+                .collect()
+        };
+        cache.write_batch_owned(&mk(5, 64), "alpha", 64).unwrap();
+        cache.write_batch_owned(&mk(2, 64), "beta", 64).unwrap();
+        let per = cache.stats_per_model().unwrap();
+        assert_eq!(per.len(), 2);
+        // Order: COUNT(*) DESC — alpha first.
+        assert_eq!(per[0].model_id, "alpha");
+        assert_eq!(per[0].entries, 5);
+        assert_eq!(per[1].model_id, "beta");
+        assert_eq!(per[1].entries, 2);
+    }
+
+    /// `insert_many` groups by model_id and writes all entries.
+    #[test]
+    fn test_insert_many_grouped_by_model() {
+        let (cache, _dir) = test_cache();
+        let entries: Vec<(Vec<u8>, String, Vec<f32>)> = vec![
+            (
+                "ha".bytes().collect(),
+                "modelA".to_string(),
+                make_embedding(32, 1.0),
+            ),
+            (
+                "hb".bytes().collect(),
+                "modelB".to_string(),
+                make_embedding(32, 2.0),
+            ),
+            (
+                "hc".bytes().collect(),
+                "modelA".to_string(),
+                make_embedding(32, 3.0),
+            ),
+        ];
+        let n = cache.insert_many(&entries, 32).unwrap();
+        assert_eq!(n, 3);
+        let per = cache.stats_per_model().unwrap();
+        let total: u64 = per.iter().map(|p| p.entries).sum();
+        assert_eq!(total, 3);
+    }
+
+    /// `partition` reports a miss when the cached entry has a stale dim
+    /// (different model dim than expected). Re-embed path is the caller's.
+    #[test]
+    fn test_partition_dim_mismatch_treated_as_miss() {
+        let (cache, _dir) = test_cache();
+        // Cache a 128-dim entry under model_z.
+        let entries = vec![("hd".to_string(), make_embedding(128, 0.5))];
+        cache.write_batch_owned(&entries, "model_z", 128).unwrap();
+        // Query for the same hash + model but expect dim=64 — should miss.
+        let items = vec!["hd"];
+        let (cached, missed) = cache
+            .partition(&items, "model_z", 64, |s: &&str| *s)
+            .unwrap();
+        assert!(cached.is_empty());
+        assert_eq!(missed.len(), 1);
+    }
+
+    /// Project default path resolves under the project's `.cqs/` dir.
+    #[test]
+    fn test_project_default_path() {
+        let p = EmbeddingCache::project_default_path(Path::new("/proj/.cqs"));
+        assert_eq!(p, Path::new("/proj/.cqs/embeddings_cache.db"));
+    }
+
+    /// `model_id` round-trips with HF revision suffix unchanged.
+    #[test]
+    fn test_model_id_roundtrip_preserves_hf_revision() {
+        let (cache, _dir) = test_cache();
+        let model_id = "BAAI/bge-large-en-v1.5@d4aa6901d3a41ba39fb536a557fa166f842b0e09";
+        let entries = vec![("hh".to_string(), make_embedding(64, 0.0))];
+        cache.write_batch_owned(&entries, model_id, 64).unwrap();
+        let result = cache.read_batch(&["hh"], model_id, 64).unwrap();
+        assert_eq!(result.len(), 1);
+        // Sanity: a different revision suffix MUST miss.
+        let other = "BAAI/bge-large-en-v1.5@aaaa1111";
+        let result2 = cache.read_batch(&["hh"], other, 64).unwrap();
+        assert!(result2.is_empty());
     }
 }
 

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -731,17 +731,26 @@ impl BatchContext {
                 }
             }
         }
-        // RM-V1.25-5: Evict global EmbeddingCache at daemon startup.
+        // RM-V1.25-5: Evict the project's embeddings cache at daemon startup.
+        //
         // `evict()` was previously only called at the tail of the full
         // `cqs index` pipeline (src/cli/pipeline/mod.rs), so long-lived
         // daemons / watch sessions on machines that never run a manual
-        // index can grow the shared ~/.cache/cqs/embeddings.db past the
-        // 10GB cap (CQS_CACHE_MAX_SIZE) without ever trimming. Kick off
-        // a single post-warm eviction so the daemon self-heals on boot.
+        // index can grow the cache past the `CQS_CACHE_MAX_SIZE` cap
+        // (default 10 GB) without ever trimming. Kick off a single post-warm
+        // eviction so the daemon self-heals on boot.
+        //
+        // Spec §Cache: the cache moved from `~/.cache/cqs/embeddings.db`
+        // (global) to `<project>/.cqs/embeddings_cache.db` (project-scoped),
+        // so we resolve the path against the daemon's project root via
+        // `resolve_index_dir(&self.root)` instead of the legacy global.
         //
         // #968: reuse the batch context's runtime so this one-shot open
         // doesn't spawn a fresh current_thread runtime.
-        evict_global_embedding_cache_with_runtime(
+        let project_cqs_dir = cqs::resolve_index_dir(&self.root);
+        let cache_path = cqs::cache::EmbeddingCache::project_default_path(&project_cqs_dir);
+        evict_embeddings_cache_with_runtime(
+            &cache_path,
             "daemon startup",
             Some(std::sync::Arc::clone(&self.runtime)),
         );
@@ -1280,7 +1289,8 @@ fn build_vector_index<Mode: crate::cli::store::ClearHnswDirty>(
     crate::cli::build_vector_index_with_config(store, cqs_dir, ef_search)
 }
 
-/// RM-V1.25-5: Evict the global embedding cache if it exceeds its size cap.
+/// RM-V1.25-5: Evict the embeddings cache at `cache_path` if it exceeds its
+/// size cap.
 ///
 /// `EmbeddingCache::evict` is a no-op below `CQS_CACHE_MAX_SIZE` (default
 /// 10GB), so it's cheap to call. Opens the cache (WAL-mode SQLite, one
@@ -1288,17 +1298,25 @@ fn build_vector_index<Mode: crate::cli::store::ClearHnswDirty>(
 /// startup and the watch reindex path to keep the shared cache bounded
 /// even when the user never runs a full `cqs index`.
 ///
+/// Spec §Cache: callers resolve `cache_path` to
+/// `<project>/.cqs/embeddings_cache.db` rather than the legacy global.
+///
 /// #968: takes an optional shared runtime so the daemon's one
 /// multi-thread pool drives this open instead of spinning up a fresh
 /// `current_thread` runtime. Pass `None` to fall back to the per-open
 /// runtime constructor (used by non-daemon callers like `cqs index`).
-pub(crate) fn evict_global_embedding_cache_with_runtime(
+pub(crate) fn evict_embeddings_cache_with_runtime(
+    cache_path: &std::path::Path,
     trigger: &str,
     runtime: Option<std::sync::Arc<tokio::runtime::Runtime>>,
 ) {
-    let _span = tracing::debug_span!("daemon_cache_evict", trigger).entered();
-    let cache_path = cqs::cache::EmbeddingCache::default_path();
-    let cache = match cqs::cache::EmbeddingCache::open_with_runtime(&cache_path, runtime.clone()) {
+    let _span = tracing::debug_span!(
+        "daemon_cache_evict",
+        trigger,
+        path = %cache_path.display()
+    )
+    .entered();
+    let cache = match cqs::cache::EmbeddingCache::open_with_runtime(cache_path, runtime.clone()) {
         Ok(c) => c,
         Err(e) => {
             tracing::warn!(
@@ -1492,7 +1510,7 @@ pub(crate) fn create_context_with_runtime(
 ) -> Result<BatchContext> {
     let root = super::config::find_project_root();
     let cqs_dir = cqs::resolve_index_dir(&root);
-    let index_path = cqs_dir.join("index.db");
+    let index_path = cqs::resolve_index_db(&cqs_dir);
     if !index_path.exists() {
         anyhow::bail!("Index not found. Run 'cqs init && cqs index' first.");
     }

--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -64,23 +64,78 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
     }
 
     let root = find_project_root();
-    let cqs_dir = cqs::resolve_index_dir(&root);
+    let project_cqs_dir = cqs::resolve_index_dir(&root);
+
+    // Ensure project `.cqs/` exists before slot resolution / migration so
+    // the slot helpers find a real directory to inspect.
+    if !project_cqs_dir.exists() {
+        std::fs::create_dir_all(&project_cqs_dir)
+            .with_context(|| format!("Failed to create {}", project_cqs_dir.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Err(e) =
+                std::fs::set_permissions(&project_cqs_dir, std::fs::Permissions::from_mode(0o700))
+            {
+                tracing::debug!(path = %project_cqs_dir.display(), error = %e, "Failed to set file permissions");
+            }
+        }
+    }
+
+    // Idempotent migration: if a legacy `.cqs/index.db` exists and slots/
+    // hasn't been seeded yet, move the legacy index into `slots/default/`.
+    if let Err(e) = cqs::slot::migrate_legacy_index_to_default_slot(&project_cqs_dir) {
+        tracing::warn!(error = %e, "slot migration failed during index; continuing");
+    }
+
+    // Resolve slot. `cqs index` accepts the global `--slot` flag, falls back
+    // to `CQS_SLOT` / `.cqs/active_slot` / "default" per spec. If the
+    // operator runs `cqs index --slot foo` against a non-existent slot dir,
+    // create it now (analogous to `cqs slot create foo` followed by index).
+    let resolved_slot = cqs::slot::resolve_slot_name(cli.slot.as_deref(), &project_cqs_dir)
+        .map_err(anyhow::Error::from)?;
+    let cqs_dir = if cqs::slot::slots_root(&project_cqs_dir).exists() {
+        cqs::resolve_slot_dir(&project_cqs_dir, &resolved_slot.name)
+    } else {
+        // Pre-slots layout: `.cqs/index.db` directly. We allowed migration
+        // above to fail silently — the only way to reach here with neither
+        // slots/ nor a legacy index is a fresh project. Materialize the
+        // slot dir so subsequent runs are slot-aware.
+        let dir = cqs::resolve_slot_dir(&project_cqs_dir, &resolved_slot.name);
+        if !dir.exists() {
+            std::fs::create_dir_all(&dir)
+                .with_context(|| format!("Failed to create slot dir {}", dir.display()))?;
+        }
+        dir
+    };
     let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
 
-    // Ensure .cqs directory exists with restrictive permissions
+    // Ensure the slot dir itself exists with restrictive permissions when
+    // we materialize it as part of `cqs index --slot <new>` flows. The
+    // project_cqs_dir was already chmodded above; the slot dir is a fresh
+    // child whose permissions also matter for SEC-D.4 alignment.
     if !cqs_dir.exists() {
         std::fs::create_dir_all(&cqs_dir)
-            .with_context(|| format!("Failed to create {}", cqs_dir.display()))?;
+            .with_context(|| format!("Failed to create slot dir {}", cqs_dir.display()))?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
             if let Err(e) =
                 std::fs::set_permissions(&cqs_dir, std::fs::Permissions::from_mode(0o700))
             {
-                tracing::debug!(path = %cqs_dir.display(), error = %e, "Failed to set file permissions");
+                tracing::debug!(path = %cqs_dir.display(), error = %e, "Failed to set slot dir permissions");
             }
         }
     }
+
+    // Span carries slot name + resolution source so failed-index logs
+    // surface which slot was being touched without reading code.
+    let _slot_span = tracing::info_span!(
+        "index_slot",
+        slot_name = %resolved_slot.name,
+        slot_source = resolved_slot.source.as_str(),
+    )
+    .entered();
 
     // Detect a running cqs-watch --serve daemon BEFORE we touch anything.
     // The daemon holds a shared file lock on `index.hnsw.lock` for the
@@ -94,9 +149,12 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
     // running an older `PingResponse` schema still gets detected — schema
     // drift would otherwise let the deserialize error fall through and
     // silently restore the old hang behavior on version mismatches.
+    //
+    // Daemon socket is hashed from the project-level `.cqs/` (one daemon
+    // per project, regardless of slot) so we use `project_cqs_dir` here.
     #[cfg(unix)]
     if !dry_run {
-        let sock_path = cqs::daemon_translate::daemon_socket_path(&cqs_dir);
+        let sock_path = cqs::daemon_translate::daemon_socket_path(&project_cqs_dir);
         if sock_path.exists() {
             use std::os::unix::net::UnixStream;
             use std::time::Duration;

--- a/src/cli/commands/infra/cache_cmd.rs
+++ b/src/cli/commands/infra/cache_cmd.rs
@@ -1,10 +1,21 @@
-//! `cqs cache` subcommands — stats, clear, prune for the global embedding cache.
+//! `cqs cache` subcommands — stats, prune, compact for the project-scoped
+//! embeddings cache.
+//!
+//! Spec §Cache: cache lives at `<project_cqs_dir>/embeddings_cache.db`,
+//! survives `cqs slot remove` / `cqs slot create` cycles, and is keyed by
+//! `(content_hash, model_id)` so an embedder swap only re-embeds chunks
+//! whose hash hasn't been seen for that model_id before.
+//!
+//! Outside a project (no `.cqs/` dir found), commands fall back to the
+//! legacy global cache at `~/.cache/cqs/embeddings.db` so `cqs cache stats`
+//! invoked from a non-project shell keeps producing useful output.
 
 use anyhow::{Context, Result};
 use clap::Subcommand;
 
 use cqs::cache::{EmbeddingCache, QueryCache};
 
+use crate::cli::config::find_project_root;
 use crate::cli::definitions::TextJsonArgs;
 use crate::cli::Cli;
 
@@ -13,8 +24,12 @@ use crate::cli::Cli;
 /// in the CLI uses one definition.
 #[derive(Subcommand, Clone, Debug)]
 pub(crate) enum CacheCommand {
-    /// Show cache statistics (entries, size, models)
+    /// Show cache statistics (entries, size, models). Use `--per-model` for
+    /// per-model_id rows so you know which model dominates the cache.
     Stats {
+        /// Surface per-model_id entry counts and bytes (spec §Cache).
+        #[arg(long)]
+        per_model: bool,
         #[command(flatten)]
         output: TextJsonArgs,
     },
@@ -26,19 +41,44 @@ pub(crate) enum CacheCommand {
         #[command(flatten)]
         output: TextJsonArgs,
     },
-    /// Remove entries older than N days
+    /// Remove entries older than N days, OR every entry for a given model_id
+    /// (per spec §Cache: prune supports `--model` AND `--older-than-days`).
     Prune {
-        /// Days to keep (entries older than this are removed)
-        days: u32,
+        /// Days to keep — entries older than this are removed. Mutually
+        /// exclusive with `--model`.
+        #[arg(value_name = "DAYS")]
+        days: Option<u32>,
+        /// Drop every entry tagged with this model_id (e.g.,
+        /// `BAAI/bge-large-en-v1.5@<rev>`). Mutually exclusive with positional
+        /// `DAYS`.
+        #[arg(long, conflicts_with = "days")]
+        model: Option<String>,
+        #[command(flatten)]
+        output: TextJsonArgs,
+    },
+    /// VACUUM the cache DB to reclaim unused pages after large deletes.
+    Compact {
         #[command(flatten)]
         output: TextJsonArgs,
     },
 }
 
+/// Resolve the cache path: project-scoped if invoked inside a project tree,
+/// otherwise fall back to the legacy global `~/.cache/cqs/embeddings.db`.
+fn resolve_cache_path() -> std::path::PathBuf {
+    let root = find_project_root();
+    let cqs_dir = cqs::resolve_index_dir(&root);
+    if cqs_dir.exists() {
+        EmbeddingCache::project_default_path(&cqs_dir)
+    } else {
+        EmbeddingCache::default_path()
+    }
+}
+
 pub(crate) fn cmd_cache(cli: &Cli, subcmd: &CacheCommand) -> Result<()> {
     let _span = tracing::info_span!("cmd_cache").entered();
 
-    let cache_path = EmbeddingCache::default_path();
+    let cache_path = resolve_cache_path();
     let cache = EmbeddingCache::open(&cache_path)
         .with_context(|| format!("Failed to open embedding cache at {}", cache_path.display()))?;
 
@@ -46,17 +86,36 @@ pub(crate) fn cmd_cache(cli: &Cli, subcmd: &CacheCommand) -> Result<()> {
     // `src/cli/commands/infra/model.rs:113`). `cqs --json cache stats` must
     // emit envelope JSON even without `--json` after the subcommand.
     match subcmd {
-        CacheCommand::Stats { output } => cache_stats(&cache, &cache_path, cli.json || output.json),
+        CacheCommand::Stats { per_model, output } => {
+            cache_stats(&cache, &cache_path, *per_model, cli.json || output.json)
+        }
         CacheCommand::Clear { model, output } => {
             cache_clear(&cache, model.as_deref(), cli.json || output.json)
         }
-        CacheCommand::Prune { days, output } => cache_prune(&cache, *days, cli.json || output.json),
+        CacheCommand::Prune {
+            days,
+            model,
+            output,
+        } => cache_prune(&cache, *days, model.as_deref(), cli.json || output.json),
+        CacheCommand::Compact { output } => cache_compact(&cache, cli.json || output.json),
     }
 }
 
-fn cache_stats(cache: &EmbeddingCache, cache_path: &std::path::Path, json: bool) -> Result<()> {
-    let _span = tracing::info_span!("cache_stats").entered();
+fn cache_stats(
+    cache: &EmbeddingCache,
+    cache_path: &std::path::Path,
+    per_model: bool,
+    json: bool,
+) -> Result<()> {
+    let _span = tracing::info_span!("cache_stats", per_model).entered();
     let stats = cache.stats().context("Failed to get cache stats")?;
+    let per_model_rows = if per_model {
+        cache
+            .stats_per_model()
+            .context("Failed to get per-model cache stats")?
+    } else {
+        Vec::new()
+    };
 
     // P3 #124: surface persistent QueryCache size alongside the embedding
     // cache so `cqs cache stats --json` consumers can monitor both.
@@ -84,6 +143,7 @@ fn cache_stats(cache: &EmbeddingCache, cache_path: &std::path::Path, json: bool)
         // arithmetic on it (e.g., `obj["total_size_mb"] + 1`). Earlier
         // `format!("{:.1}", ...)` made it a string and broke programmatic use.
         let obj = serde_json::json!({
+            "cache_path": cache_path.display().to_string(),
             "total_entries": stats.total_entries,
             "total_size_bytes": stats.total_size_bytes,
             "total_size_mb": stats.total_size_bytes as f64 / 1_048_576.0,
@@ -93,6 +153,7 @@ fn cache_stats(cache: &EmbeddingCache, cache_path: &std::path::Path, json: bool)
             // P3 #124: parallel `query_cache_size_bytes` field. Always present;
             // 0 when the QueryCache file doesn't exist yet.
             "query_cache_size_bytes": query_cache_size_bytes,
+            "per_model": per_model_rows,
         });
         crate::cli::json_envelope::emit_json(&obj)?;
     } else {
@@ -115,6 +176,18 @@ fn cache_stats(cache: &EmbeddingCache, cache_path: &std::path::Path, json: bool)
             "Query cache size: {:.1} MB",
             query_cache_size_bytes as f64 / 1_048_576.0
         );
+        if per_model && !per_model_rows.is_empty() {
+            println!();
+            println!("Per-model:");
+            for row in &per_model_rows {
+                println!(
+                    "  {} — {} entries, {:.2} MB",
+                    row.model_id,
+                    row.entries,
+                    row.total_bytes as f64 / 1_048_576.0
+                );
+            }
+        }
     }
 
     Ok(())
@@ -139,22 +212,82 @@ fn cache_clear(cache: &EmbeddingCache, model: Option<&str>, json: bool) -> Resul
     Ok(())
 }
 
-fn cache_prune(cache: &EmbeddingCache, days: u32, json: bool) -> Result<()> {
-    let _span = tracing::info_span!("cache_prune", days).entered();
-    let pruned = cache
-        .prune_older_than(days)
-        .context("Failed to prune cache")?;
+fn cache_prune(
+    cache: &EmbeddingCache,
+    days: Option<u32>,
+    model: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let _span = tracing::info_span!("cache_prune", days, model).entered();
+    let (pruned, mode_label, mode_value): (usize, &'static str, String) = match (days, model) {
+        (Some(d), None) => {
+            let n = cache
+                .prune_older_than(d)
+                .context("Failed to prune cache by age")?;
+            (n, "older_than_days", d.to_string())
+        }
+        (None, Some(m)) => {
+            let n = cache
+                .prune_by_model(m)
+                .context("Failed to prune cache by model")?;
+            (n, "model", m.to_string())
+        }
+        (None, None) => {
+            anyhow::bail!(
+                "cqs cache prune requires either DAYS positional or --model <id>; see --help"
+            );
+        }
+        (Some(_), Some(_)) => {
+            // clap conflicts_with should prevent this branch; defense-in-depth.
+            anyhow::bail!("cqs cache prune: DAYS and --model are mutually exclusive");
+        }
+    };
 
     if json {
+        let obj = match mode_label {
+            "older_than_days" => serde_json::json!({
+                "pruned": pruned,
+                "older_than_days": mode_value.parse::<u32>().unwrap_or(0),
+            }),
+            "model" => serde_json::json!({
+                "pruned": pruned,
+                "model": mode_value,
+            }),
+            _ => unreachable!("mode_label must be one of the two arms"),
+        };
+        crate::cli::json_envelope::emit_json(&obj)?;
+    } else {
+        match mode_label {
+            "older_than_days" => {
+                println!("Pruned {} entries older than {} days", pruned, mode_value)
+            }
+            "model" => println!("Pruned {} entries for model {}", pruned, mode_value),
+            _ => unreachable!(),
+        }
+    }
+
+    Ok(())
+}
+
+fn cache_compact(cache: &EmbeddingCache, json: bool) -> Result<()> {
+    let _span = tracing::info_span!("cache_compact").entered();
+    let before = cache.stats().context("Failed to read pre-compact stats")?;
+    cache.compact().context("Failed to VACUUM cache DB")?;
+    let after = cache.stats().context("Failed to read post-compact stats")?;
+    if json {
         let obj = serde_json::json!({
-            "pruned": pruned,
-            "older_than_days": days,
+            "size_before_bytes": before.total_size_bytes,
+            "size_after_bytes": after.total_size_bytes,
+            "reclaimed_bytes": before.total_size_bytes.saturating_sub(after.total_size_bytes),
         });
         crate::cli::json_envelope::emit_json(&obj)?;
     } else {
-        println!("Pruned {} entries older than {} days", pruned, days);
+        println!(
+            "Compacted: {:.2} MB → {:.2} MB",
+            before.total_size_bytes as f64 / 1_048_576.0,
+            after.total_size_bytes as f64 / 1_048_576.0,
+        );
     }
-
     Ok(())
 }
 

--- a/src/cli/commands/infra/doctor.rs
+++ b/src/cli/commands/infra/doctor.rs
@@ -117,7 +117,19 @@ pub(crate) fn cmd_doctor(
 ) -> Result<()> {
     let _span = tracing::info_span!("cmd_doctor", fix, verbose, json).entered();
     let root = find_project_root();
-    let cqs_dir = cqs::resolve_index_dir(&root);
+    let project_cqs_dir = cqs::resolve_index_dir(&root);
+
+    // Resolve active slot for the local project. Pre-slots layout (no
+    // `.cqs/slots/` yet) keeps `cqs_dir == project_cqs_dir`; post-migration
+    // we descend into `.cqs/slots/<active>/`.
+    let active_slot_name = cqs::slot::resolve_slot_name(None, &project_cqs_dir)
+        .map(|r| r.name)
+        .unwrap_or_else(|_| cqs::slot::DEFAULT_SLOT.to_string());
+    let cqs_dir = if cqs::slot::slots_root(&project_cqs_dir).exists() {
+        cqs::resolve_slot_dir(&project_cqs_dir, &active_slot_name)
+    } else {
+        project_cqs_dir.clone()
+    };
     let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
     let mut any_failed = false;
     let mut issues: Vec<DoctorIssue> = Vec::new();
@@ -388,7 +400,7 @@ pub(crate) fn cmd_doctor(
         out(json, "");
         out(json, "References:");
         for r in &config.references {
-            let db_path = r.path.join(cqs::INDEX_DB_FILENAME);
+            let db_path = cqs::resolve_index_db(&cqs::resolve_index_dir(&r.path));
             if !r.path.exists() {
                 out(
                     json,
@@ -702,6 +714,9 @@ struct VerboseReport {
     config: ConfigSummary,
     /// Every `CQS_*` env var currently set, with value.
     env: Vec<EnvVar>,
+    /// Active slot + per-slot presence. New in v1.30.0 (spec
+    /// `2026-04-24-embeddings-cache-and-slots.md`).
+    slots: SlotsSection,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -826,11 +841,17 @@ fn build_verbose_report(
 
     let model_files = collect_model_files(&resolved);
 
-    let daemon = collect_daemon_state(cqs_dir);
+    // Daemon socket is keyed by the project-level `.cqs/` dir, NOT the slot
+    // dir. Climb out of `slots/<name>/` if the cqs_dir we were handed lives
+    // under one. Pre-slots layout: cqs_dir IS the project dir.
+    let project_cqs_dir = project_cqs_dir_from(cqs_dir);
+    let daemon = collect_daemon_state(&project_cqs_dir);
 
     let config_summary = collect_config_summary(project_root, config);
 
     let env = collect_cqs_env_vars();
+
+    let slots = collect_slots_section(&project_cqs_dir);
 
     VerboseReport {
         project_root: project_root.to_path_buf(),
@@ -851,6 +872,74 @@ fn build_verbose_report(
         index: index_meta,
         config: config_summary,
         env,
+        slots,
+    }
+}
+
+/// Climb out of `slots/<name>/` to the project-level `.cqs/` dir if the
+/// caller handed us a slot dir; pre-slots returns `cqs_dir` unchanged.
+///
+/// Detection: the parent of the slot dir is named `slots`, and its parent
+/// is the project `.cqs/`. Anything else is treated as "already project-level".
+fn project_cqs_dir_from(cqs_dir: &Path) -> std::path::PathBuf {
+    if let Some(parent) = cqs_dir.parent() {
+        if parent.file_name().map(|n| n == "slots").unwrap_or(false) {
+            if let Some(grand) = parent.parent() {
+                return grand.to_path_buf();
+            }
+        }
+    }
+    cqs_dir.to_path_buf()
+}
+
+/// Slot section of the doctor verbose report — surfaces the active slot
+/// name + per-slot health (does the dir have an index.db?).
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct SlotsSection {
+    pub active_slot: String,
+    pub active_slot_source: String,
+    pub active_slot_file: String,
+    pub slots: Vec<SlotsRow>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct SlotsRow {
+    pub name: String,
+    pub indexed: bool,
+    pub path: String,
+}
+
+fn collect_slots_section(project_cqs_dir: &Path) -> SlotsSection {
+    let resolved = match cqs::slot::resolve_slot_name(None, project_cqs_dir) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "slot resolution failed inside doctor");
+            cqs::slot::ResolvedSlot {
+                name: cqs::slot::DEFAULT_SLOT.to_string(),
+                source: cqs::slot::SlotSource::Fallback,
+            }
+        }
+    };
+    let names = cqs::slot::list_slots(project_cqs_dir).unwrap_or_default();
+    let rows = names
+        .into_iter()
+        .map(|n| {
+            let dir = cqs::resolve_slot_dir(project_cqs_dir, &n);
+            let indexed = dir.join(cqs::INDEX_DB_FILENAME).exists();
+            SlotsRow {
+                name: n,
+                indexed,
+                path: dir.display().to_string(),
+            }
+        })
+        .collect();
+    SlotsSection {
+        active_slot: resolved.name,
+        active_slot_source: resolved.source.as_str().to_string(),
+        active_slot_file: cqs::slot::active_slot_path(project_cqs_dir)
+            .display()
+            .to_string(),
+        slots: rows,
     }
 }
 
@@ -1288,6 +1377,31 @@ fn print_verbose_report(r: &VerboseReport) {
         }
         None => {
             println!("  socket_path:      (n/a — non-Unix platform)");
+        }
+    }
+    println!();
+
+    println!("{}", "Slots:".bold());
+    println!(
+        "  active:           {} ({})",
+        r.slots.active_slot, r.slots.active_slot_source
+    );
+    println!("  active_slot_file: {}", r.slots.active_slot_file);
+    if r.slots.slots.is_empty() {
+        println!("  (no slots — pre-migration / never indexed)");
+    } else {
+        for s in &r.slots.slots {
+            let mark = if s.indexed {
+                "[\u{2713}]".green().to_string()
+            } else {
+                "[?]".yellow().to_string()
+            };
+            let active_mark = if s.name == r.slots.active_slot {
+                "*".green().bold().to_string()
+            } else {
+                " ".to_string()
+            };
+            println!("  {} {} {:<20} {}", active_mark, mark, s.name, s.path);
         }
     }
     println!();

--- a/src/cli/commands/infra/mod.rs
+++ b/src/cli/commands/infra/mod.rs
@@ -10,6 +10,7 @@ mod model;
 mod ping;
 mod project;
 mod reference;
+mod slot;
 mod telemetry_cmd;
 
 pub(crate) use audit_mode::cmd_audit_mode;
@@ -22,4 +23,5 @@ pub(crate) use model::{cmd_model, ModelCommand};
 pub(crate) use ping::cmd_ping;
 pub(crate) use project::{cmd_project, ProjectCommand};
 pub(crate) use reference::{cmd_ref, RefCommand};
+pub(crate) use slot::{cmd_slot, SlotCommand};
 pub(crate) use telemetry_cmd::{cmd_telemetry, cmd_telemetry_reset};

--- a/src/cli/commands/infra/model.rs
+++ b/src/cli/commands/infra/model.rs
@@ -139,7 +139,7 @@ fn cmd_model_show(json: bool) -> Result<()> {
 
     let root = find_project_root();
     let cqs_dir = cqs::resolve_index_dir(&root);
-    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+    let index_path = cqs::resolve_index_db(&cqs_dir);
 
     if !index_path.exists() {
         bail!(
@@ -262,7 +262,7 @@ fn cmd_model_swap(cli: &Cli, preset: &str, no_backup: bool, json: bool) -> Resul
 
     let root = find_project_root();
     let cqs_dir = cqs::resolve_index_dir(&root);
-    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+    let index_path = cqs::resolve_index_db(&cqs_dir);
 
     if !index_path.exists() {
         bail!(
@@ -812,7 +812,7 @@ fn restore_from_backup(cqs_dir: &Path, backup: &Path) -> Result<()> {
 fn read_current_model_name() -> Option<String> {
     let root = find_project_root();
     let cqs_dir = cqs::resolve_index_dir(&root);
-    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+    let index_path = cqs::resolve_index_db(&cqs_dir);
     if !index_path.exists() {
         return None;
     }

--- a/src/cli/commands/infra/slot.rs
+++ b/src/cli/commands/infra/slot.rs
@@ -1,0 +1,515 @@
+//! `cqs slot` subcommand — list / create / promote / remove / active.
+//!
+//! Spec §Slot commands: project-level named slots living under
+//! `.cqs/slots/<name>/`. See `docs/plans/2026-04-24-embeddings-cache-and-slots.md`
+//! for the design. Migration from a legacy `.cqs/index.db` runs at the top of
+//! `dispatch::run_with` (see `src/cli/dispatch.rs`).
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+use clap::Subcommand;
+use colored::Colorize;
+
+use cqs::slot::{
+    active_slot_path, list_slots, read_active_slot, slot_dir, validate_slot_name,
+    write_active_slot, DEFAULT_SLOT,
+};
+
+use crate::cli::config::find_project_root;
+use crate::cli::definitions::TextJsonArgs;
+use crate::cli::Cli;
+
+/// Summary row for `cqs slot list`.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct SlotListEntry {
+    pub name: String,
+    pub active: bool,
+    /// `true` if `<slot_dir>/index.db` is present. False slots are valid
+    /// "create-and-not-yet-indexed" states.
+    pub indexed: bool,
+    /// Number of chunks in the slot's index. `None` if the index is missing
+    /// or unreadable; the slot still shows up in the list.
+    pub chunks: Option<u64>,
+    /// Embedding model recorded in the slot's metadata (e.g.
+    /// `BAAI/bge-large-en-v1.5`). `None` for un-indexed slots.
+    pub model: Option<String>,
+    /// Embedding dimension recorded in the slot's metadata. `None` for
+    /// un-indexed slots.
+    pub dim: Option<u64>,
+    /// Slot dir absolute path.
+    pub path: String,
+}
+
+#[derive(Subcommand, Clone, Debug)]
+pub(crate) enum SlotCommand {
+    /// List all slots, marking the active one
+    List {
+        #[command(flatten)]
+        output: TextJsonArgs,
+    },
+    /// Create a new empty slot directory
+    Create {
+        /// Slot name (lowercase a-z, 0-9, `_`, `-`; max 32 chars)
+        name: String,
+        /// Embedding model preset or HF repo id (e.g. `bge-large`, `e5-base`,
+        /// `BAAI/bge-large-en-v1.5`). Validated against `ModelConfig::resolve`.
+        #[arg(long)]
+        model: Option<String>,
+        #[command(flatten)]
+        output: TextJsonArgs,
+    },
+    /// Make a slot the active one (atomic pointer update)
+    Promote {
+        /// Slot name to promote
+        name: String,
+        #[command(flatten)]
+        output: TextJsonArgs,
+    },
+    /// Remove a slot directory and all its files
+    Remove {
+        /// Slot name to remove
+        name: String,
+        /// Allow removing the active slot if at least one other slot exists
+        #[arg(long)]
+        force: bool,
+        #[command(flatten)]
+        output: TextJsonArgs,
+    },
+    /// Print the active slot name
+    Active {
+        #[command(flatten)]
+        output: TextJsonArgs,
+    },
+}
+
+pub(crate) fn cmd_slot(cli: &Cli, subcmd: &SlotCommand) -> Result<()> {
+    let _span = tracing::info_span!("cmd_slot").entered();
+    let root = find_project_root();
+    let project_cqs_dir = cqs::resolve_index_dir(&root);
+    if !project_cqs_dir.exists() {
+        anyhow::bail!(
+            "No `.cqs/` directory found in {}. Run `cqs init && cqs index` first.",
+            root.display()
+        );
+    }
+
+    match subcmd {
+        SlotCommand::List { output } => slot_list(&project_cqs_dir, cli.json || output.json),
+        SlotCommand::Create {
+            name,
+            model,
+            output,
+        } => slot_create(
+            &project_cqs_dir,
+            name,
+            model.as_deref(),
+            cli.json || output.json,
+        ),
+        SlotCommand::Promote { name, output } => {
+            slot_promote(&project_cqs_dir, name, cli.json || output.json)
+        }
+        SlotCommand::Remove {
+            name,
+            force,
+            output,
+        } => slot_remove(&project_cqs_dir, name, *force, cli.json || output.json),
+        SlotCommand::Active { output } => slot_active(&project_cqs_dir, cli.json || output.json),
+    }
+}
+
+fn slot_list(project_cqs_dir: &Path, json: bool) -> Result<()> {
+    let _span = tracing::info_span!("slot_list").entered();
+    let names = list_slots(project_cqs_dir)?;
+    let active = read_active_slot(project_cqs_dir).unwrap_or_else(|| DEFAULT_SLOT.to_string());
+    let entries: Vec<SlotListEntry> = names
+        .into_iter()
+        .map(|name| collect_slot_entry(project_cqs_dir, &name, &active))
+        .collect();
+
+    if json {
+        let obj = serde_json::json!({
+            "active": active,
+            "slots": entries,
+        });
+        crate::cli::json_envelope::emit_json(&obj)?;
+    } else if entries.is_empty() {
+        println!("No slots found.");
+        println!("Use `cqs slot create <name> --model <preset-or-hf>` to add one,");
+        println!("or run `cqs index` to populate the default slot.");
+    } else {
+        for e in &entries {
+            let mark = if e.active {
+                "*".green().bold()
+            } else {
+                " ".normal()
+            };
+            let chunks = e
+                .chunks
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let model = e.model.as_deref().unwrap_or("-");
+            let dim = e
+                .dim
+                .map(|d| d.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let status = if e.indexed {
+                "ok".green().to_string()
+            } else {
+                "empty".yellow().to_string()
+            };
+            println!(
+                "{} {:<20} chunks={:<8} model={:<28} dim={:<5} [{}]",
+                mark, e.name, chunks, model, dim, status
+            );
+        }
+        println!();
+        println!("Active slot: {}", active);
+    }
+    Ok(())
+}
+
+/// Open the slot's `index.db` read-only (with a small footprint suitable for
+/// dozens of slots) and pull its chunk count + model metadata. Best-effort —
+/// listing should succeed even if one slot's DB is unreadable.
+fn collect_slot_entry(project_cqs_dir: &Path, name: &str, active: &str) -> SlotListEntry {
+    let dir = slot_dir(project_cqs_dir, name);
+    let index_path = dir.join(cqs::INDEX_DB_FILENAME);
+    let path_str = dir.display().to_string();
+    if !index_path.exists() {
+        return SlotListEntry {
+            name: name.to_string(),
+            active: name == active,
+            indexed: false,
+            chunks: None,
+            model: None,
+            dim: None,
+            path: path_str,
+        };
+    }
+    let (chunks, model, dim) = match cqs::Store::open_readonly_small(&index_path) {
+        Ok(store) => {
+            let count = store.chunk_count().ok();
+            let model = store.stored_model_name();
+            let dim = u64::try_from(store.dim()).ok();
+            (count, model, dim)
+        }
+        Err(e) => {
+            tracing::warn!(
+                slot = name,
+                error = %e,
+                path = %index_path.display(),
+                "Slot index read failed during listing"
+            );
+            (None, None, None)
+        }
+    };
+    SlotListEntry {
+        name: name.to_string(),
+        active: name == active,
+        indexed: true,
+        chunks,
+        model,
+        dim,
+        path: path_str,
+    }
+}
+
+fn slot_create(project_cqs_dir: &Path, name: &str, model: Option<&str>, json: bool) -> Result<()> {
+    let _span = tracing::info_span!("slot_create", name, model).entered();
+    validate_slot_name(name)?;
+
+    let dir = slot_dir(project_cqs_dir, name);
+    if dir.exists() {
+        anyhow::bail!(
+            "Slot '{}' already exists at {}. Either run `cqs index --slot {}` or `cqs slot remove {}` first.",
+            name,
+            dir.display(),
+            name,
+            name,
+        );
+    }
+    fs::create_dir_all(&dir)?;
+
+    // Validate the model now (preset or HF) so the user gets a fast error
+    // before the next `cqs index` runs. The actual download happens later.
+    let resolved_model: Option<String> = match model {
+        Some(m) => {
+            let cfg = cqs::embedder::ModelConfig::resolve(Some(m), None);
+            Some(cfg.repo)
+        }
+        None => None,
+    };
+
+    if json {
+        let obj = serde_json::json!({
+            "name": name,
+            "path": dir.display().to_string(),
+            "model": resolved_model,
+        });
+        crate::cli::json_envelope::emit_json(&obj)?;
+    } else {
+        println!("Created slot '{}' at {}", name, dir.display());
+        if let Some(ref m) = resolved_model {
+            println!("Model resolved as: {m}");
+        }
+        println!("Next: `cqs index --slot {name}` to populate it.");
+    }
+    Ok(())
+}
+
+fn slot_promote(project_cqs_dir: &Path, name: &str, json: bool) -> Result<()> {
+    let _span = tracing::info_span!("slot_promote", name).entered();
+    validate_slot_name(name)?;
+    let dir = slot_dir(project_cqs_dir, name);
+    if !dir.exists() {
+        let available = list_slots(project_cqs_dir).unwrap_or_default().join(", ");
+        anyhow::bail!(
+            "Slot '{}' does not exist. Available: [{}]. Create with: cqs slot create <name> --model <model-id>",
+            name,
+            available
+        );
+    }
+    write_active_slot(project_cqs_dir, name)?;
+
+    let warning = format!(
+        "Active slot changed to '{}'. To serve queries from the new slot, restart the daemon:\n    systemctl --user restart cqs-watch",
+        name
+    );
+    if json {
+        let obj = serde_json::json!({
+            "promoted": name,
+            "warning": warning,
+        });
+        crate::cli::json_envelope::emit_json(&obj)?;
+    } else {
+        println!("Promoted slot '{name}' to active.");
+        println!("{warning}");
+    }
+    Ok(())
+}
+
+fn slot_remove(project_cqs_dir: &Path, name: &str, force: bool, json: bool) -> Result<()> {
+    let _span = tracing::info_span!("slot_remove", name, force).entered();
+    validate_slot_name(name)?;
+    let dir = slot_dir(project_cqs_dir, name);
+    if !dir.exists() {
+        let available = list_slots(project_cqs_dir).unwrap_or_default().join(", ");
+        anyhow::bail!(
+            "Slot '{}' does not exist. Available: [{}].",
+            name,
+            available
+        );
+    }
+
+    let active = read_active_slot(project_cqs_dir).unwrap_or_else(|| DEFAULT_SLOT.to_string());
+    let mut all = list_slots(project_cqs_dir).unwrap_or_default();
+    all.retain(|n| n != name);
+
+    if name == active {
+        if all.is_empty() {
+            anyhow::bail!(
+                "Refusing to remove the only remaining slot '{}'. Create another slot first.",
+                name
+            );
+        }
+        if !force {
+            anyhow::bail!(
+                "Slot '{}' is currently active. Promote a different slot first, or pass --force to auto-promote '{}' as the new active.",
+                name,
+                all[0]
+            );
+        }
+        // Force: auto-promote the first remaining slot.
+        write_active_slot(project_cqs_dir, &all[0])?;
+        tracing::info!(promoted = %all[0], "auto-promoted new active slot after force remove");
+    }
+
+    fs::remove_dir_all(&dir)?;
+
+    if json {
+        let obj = serde_json::json!({
+            "removed": name,
+            "new_active": if name == active { Some(all[0].clone()) } else { None::<String> },
+        });
+        crate::cli::json_envelope::emit_json(&obj)?;
+    } else {
+        println!("Removed slot '{}'.", name);
+        if name == active {
+            println!("Active slot auto-promoted to '{}'.", all[0]);
+        }
+    }
+    Ok(())
+}
+
+fn slot_active(project_cqs_dir: &Path, json: bool) -> Result<()> {
+    let _span = tracing::info_span!("slot_active").entered();
+    let resolved =
+        cqs::slot::resolve_slot_name(None, project_cqs_dir).map_err(anyhow::Error::from)?;
+    if json {
+        let obj = serde_json::json!({
+            "active": resolved.name,
+            "source": resolved.source.as_str(),
+            "active_slot_file": active_slot_path(project_cqs_dir).display().to_string(),
+        });
+        crate::cli::json_envelope::emit_json(&obj)?;
+    } else {
+        println!("{}", resolved.name);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cqs::slot::{slots_root, write_active_slot};
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Helper: build a fresh project with a `.cqs/` and N empty slots.
+    fn with_slots(slot_names: &[&str]) -> TempDir {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        fs::create_dir_all(&cqs).unwrap();
+        for n in slot_names {
+            let d = slot_dir(&cqs, n);
+            fs::create_dir_all(&d).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn slot_create_rejects_invalid_name() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&[]);
+        let cqs = tmp.path().join(".cqs");
+        let r = slot_create(&cqs, "Bad-Name", None, true);
+        assert!(r.is_err(), "uppercase should reject");
+    }
+
+    #[test]
+    fn slot_create_rejects_reserved_name() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&[]);
+        let cqs = tmp.path().join(".cqs");
+        let r = slot_create(&cqs, "list", None, true);
+        assert!(r.is_err());
+        let r = slot_create(&cqs, "active", None, true);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn slot_create_succeeds_then_dir_exists() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&[]);
+        let cqs = tmp.path().join(".cqs");
+        fs::create_dir_all(&cqs).unwrap();
+        let r = slot_create(&cqs, "e5", None, true);
+        assert!(r.is_ok(), "{:?}", r.err());
+        assert!(slot_dir(&cqs, "e5").exists());
+    }
+
+    #[test]
+    fn slot_create_refuses_existing() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&["dup"]);
+        let cqs = tmp.path().join(".cqs");
+        let r = slot_create(&cqs, "dup", None, true);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn slot_promote_requires_existing_slot() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&["one"]);
+        let cqs = tmp.path().join(".cqs");
+        let r = slot_promote(&cqs, "missing", true);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn slot_promote_updates_active_slot_file() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&["a", "b"]);
+        let cqs = tmp.path().join(".cqs");
+        write_active_slot(&cqs, "a").unwrap();
+        slot_promote(&cqs, "b", true).unwrap();
+        assert_eq!(read_active_slot(&cqs).as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn slot_remove_refuses_active_without_force() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&["active_one", "other"]);
+        let cqs = tmp.path().join(".cqs");
+        write_active_slot(&cqs, "active_one").unwrap();
+        let r = slot_remove(&cqs, "active_one", false, true);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn slot_remove_with_force_promotes_other() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&["a", "b"]);
+        let cqs = tmp.path().join(".cqs");
+        write_active_slot(&cqs, "a").unwrap();
+        slot_remove(&cqs, "a", true, true).unwrap();
+        assert_eq!(read_active_slot(&cqs).as_deref(), Some("b"));
+        assert!(!slot_dir(&cqs, "a").exists());
+    }
+
+    #[test]
+    fn slot_remove_refuses_last_remaining_slot() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&["only"]);
+        let cqs = tmp.path().join(".cqs");
+        write_active_slot(&cqs, "only").unwrap();
+        let r = slot_remove(&cqs, "only", true, true);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn slot_remove_non_active_works() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&["a", "b"]);
+        let cqs = tmp.path().join(".cqs");
+        write_active_slot(&cqs, "a").unwrap();
+        slot_remove(&cqs, "b", false, true).unwrap();
+        assert_eq!(read_active_slot(&cqs).as_deref(), Some("a"));
+        assert!(!slot_dir(&cqs, "b").exists());
+    }
+
+    #[test]
+    fn slot_active_text_path_no_panic() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&[]);
+        let cqs = tmp.path().join(".cqs");
+        fs::create_dir_all(&cqs).unwrap();
+        // Just verify it doesn't error; output is to stdout so we can't easily
+        // capture it without restructuring.
+        let r = slot_active(&cqs, true);
+        assert!(r.is_ok(), "{:?}", r.err());
+    }
+
+    #[test]
+    fn slot_list_empty() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&[]);
+        let cqs = tmp.path().join(".cqs");
+        fs::create_dir_all(&cqs).unwrap();
+        let r = slot_list(&cqs, true);
+        assert!(r.is_ok());
+    }
+
+    /// `slots_root` is unused in this module but the import is part of the
+    /// public surface — verifying it resolves keeps cqs::slot's public surface
+    /// honest.
+    #[test]
+    fn slots_root_resolves_for_public_export() {
+        let p = slots_root(Path::new("/proj/.cqs"));
+        assert_eq!(p, Path::new("/proj/.cqs/slots"));
+    }
+}

--- a/src/cli/commands/io/diff.rs
+++ b/src/cli/commands/io/diff.rs
@@ -96,7 +96,7 @@ pub(crate) fn cmd_diff(
     // Resolve target store
     let target_label = target.unwrap_or("project");
     let target_store = if target_label == "project" {
-        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        let index_path = cqs::resolve_index_db(&cqs_dir);
         if !index_path.exists() {
             bail!("Project index not found. Run 'cqs init && cqs index' first.");
         }

--- a/src/cli/commands/io/drift.rs
+++ b/src/cli/commands/io/drift.rs
@@ -91,7 +91,7 @@ pub(crate) fn cmd_drift(
     let ref_store =
         crate::cli::commands::resolve::resolve_reference_store_readonly(&root, reference)?;
 
-    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+    let index_path = cqs::resolve_index_db(&cqs_dir);
     if !index_path.exists() {
         bail!("Project index not found. Run 'cqs init && cqs index' first.");
     }

--- a/src/cli/commands/io/notes.rs
+++ b/src/cli/commands/io/notes.rs
@@ -193,7 +193,7 @@ fn reindex_notes(root: &std::path::Path, store: &cqs::Store) -> (usize, Option<S
 
 /// Open a read-write store for notes mutations that need to reindex.
 fn open_rw_store(root: &std::path::Path) -> Result<cqs::Store> {
-    let index_path = cqs::resolve_index_dir(root).join(cqs::INDEX_DB_FILENAME);
+    let index_path = cqs::resolve_index_db(&cqs::resolve_index_dir(root));
     cqs::Store::open(&index_path)
         .map_err(|e| anyhow::anyhow!("Failed to open index at {}: {}", index_path.display(), e))
 }

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -103,12 +103,14 @@ pub(crate) use infra::cmd_model;
 pub(crate) use infra::cmd_ping;
 pub(crate) use infra::cmd_project;
 pub(crate) use infra::cmd_ref;
+pub(crate) use infra::cmd_slot;
 pub(crate) use infra::cmd_telemetry;
 pub(crate) use infra::cmd_telemetry_reset;
 pub(crate) use infra::CacheCommand;
 pub(crate) use infra::ModelCommand;
 pub(crate) use infra::ProjectCommand;
 pub(crate) use infra::RefCommand;
+pub(crate) use infra::SlotCommand;
 
 // -- train --
 pub(crate) use train::cmd_export_model;

--- a/src/cli/commands/resolve.rs
+++ b/src/cli/commands/resolve.rs
@@ -56,7 +56,12 @@ fn resolve_reference_db(root: &Path, ref_name: &str) -> Result<std::path::PathBu
             )
         })?;
 
-    let ref_db = ref_cfg.path.join(cqs::INDEX_DB_FILENAME);
+    // Refs use the same `.cqs/` layout as projects, so honor slot resolution
+    // (post-migration: `.cqs/slots/<active>/index.db`; pre-migration:
+    // `.cqs/index.db`). `resolve_index_db` falls back to the legacy path for
+    // refs that were built against an older cqs version and never migrated.
+    let ref_cqs_dir = cqs::resolve_index_dir(&ref_cfg.path);
+    let ref_db = cqs::resolve_index_db(&ref_cqs_dir);
     if !ref_db.exists() {
         bail!(
             "Reference '{}' has no index at {}. Run 'cqs ref update {}' first.",

--- a/src/cli/commands/serve.rs
+++ b/src/cli/commands/serve.rs
@@ -35,7 +35,7 @@ pub(crate) fn cmd_serve(port: u16, bind: String, open: bool) -> Result<()> {
 
     let root = find_project_root();
     let cqs_dir = cqs::resolve_index_dir(&root);
-    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+    let index_path = cqs::resolve_index_db(&cqs_dir);
 
     if !index_path.exists() {
         anyhow::bail!(

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -277,6 +277,15 @@ pub struct Cli {
     #[arg(long)]
     pub model: Option<String>,
 
+    /// Named slot to use (overrides `CQS_SLOT` env and `.cqs/active_slot`).
+    ///
+    /// Slots are project-scoped, side-by-side full indexes living under
+    /// `.cqs/slots/<name>/`. Default behaviour is to read the active slot
+    /// from `.cqs/active_slot` (falls back to `default`). Spec:
+    /// `docs/plans/2026-04-24-embeddings-cache-and-slots.md`.
+    #[arg(long, global = true)]
+    pub slot: Option<String>,
+
     /// Show debug info (sets RUST_LOG=debug)
     #[arg(short, long)]
     pub verbose: bool,
@@ -719,10 +728,16 @@ pub(super) enum Commands {
         #[arg(long)]
         contrastive: bool,
     },
-    /// Manage global embedding cache (stats, clear, prune)
+    /// Manage the embeddings cache (stats, prune, compact). Project-scoped
+    /// at `<project>/.cqs/embeddings_cache.db`.
     Cache {
         #[command(subcommand)]
         subcmd: CacheCommand,
+    },
+    /// Manage named slots — side-by-side full indexes under `.cqs/slots/<name>/`
+    Slot {
+        #[command(subcommand)]
+        subcmd: SlotCommand,
     },
     /// Daemon healthcheck — show daemon model, uptime, and counters
     ///
@@ -776,7 +791,7 @@ pub(super) enum Commands {
 
 // Re-export the subcommand types used in Commands variants
 pub(super) use super::commands::{
-    CacheCommand, ModelCommand, NotesCommand, ProjectCommand, RefCommand,
+    CacheCommand, ModelCommand, NotesCommand, ProjectCommand, RefCommand, SlotCommand,
 };
 
 /// Classifier used by `try_daemon_query` to decide whether a CLI command can
@@ -826,6 +841,7 @@ impl Commands {
             | Commands::TrainData { .. }
             | Commands::TrainPairs { .. }
             | Commands::Cache { .. }
+            | Commands::Slot { .. }
             // Registry commands — not on batch surface.
             | Commands::Ref { .. }
             | Commands::Project { .. }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -17,20 +17,39 @@ use super::commands::{
     cmd_explain, cmd_export_model, cmd_gather, cmd_gc, cmd_health, cmd_impact, cmd_impact_diff,
     cmd_index, cmd_init, cmd_model, cmd_neighbors, cmd_notes, cmd_onboard, cmd_ping, cmd_plan,
     cmd_project, cmd_query, cmd_read, cmd_reconstruct, cmd_ref, cmd_related, cmd_review, cmd_scout,
-    cmd_similar, cmd_stale, cmd_stats, cmd_suggest, cmd_task, cmd_telemetry, cmd_telemetry_reset,
-    cmd_test_map, cmd_trace, cmd_train_data, cmd_train_pairs, cmd_where,
+    cmd_similar, cmd_slot, cmd_stale, cmd_stats, cmd_suggest, cmd_task, cmd_telemetry,
+    cmd_telemetry_reset, cmd_test_map, cmd_trace, cmd_train_data, cmd_train_pairs, cmd_where,
 };
 
 /// Run CLI with pre-parsed arguments (used when main.rs needs to inspect args first)
 pub fn run_with(mut cli: Cli) -> Result<()> {
     // Log command for telemetry (opt-in via CQS_TELEMETRY=1)
-    let cqs_dir = cqs::resolve_index_dir(&find_project_root());
+    let project_cqs_dir = cqs::resolve_index_dir(&find_project_root());
     let telem_args: Vec<String> = std::env::args().collect();
     let (telem_cmd, telem_query) = telemetry::describe_command(&telem_args);
-    telemetry::log_command(&cqs_dir, &telem_cmd, telem_query.as_deref(), None);
+    telemetry::log_command(&project_cqs_dir, &telem_cmd, telem_query.as_deref(), None);
 
     // v1.22.0 audit OB-14: root span so all per-command logs have a parent.
     let _root = tracing::info_span!("cqs", cmd = %telem_cmd).entered();
+
+    // Slot migration: one-shot move of legacy `.cqs/index.db` (+ HNSW + SPLADE)
+    // into `.cqs/slots/default/` on first post-upgrade run. Idempotent — every
+    // subsequent run observes `.cqs/slots/` and skips. Safe to call on
+    // never-indexed projects (returns false, no-op).
+    if project_cqs_dir.exists() {
+        if let Err(e) = cqs::slot::migrate_legacy_index_to_default_slot(&project_cqs_dir) {
+            tracing::warn!(error = %e, "slot migration failed; continuing without it");
+        }
+    }
+
+    // Propagate `--slot <name>` to `CQS_SLOT` env so commands that resolve the
+    // active slot via `cqs::slot::resolve_slot_name(None, ...)` (no ctx-passed
+    // flag) honor the explicit override. Resolution order is preserved:
+    // `--slot` (now in env) > pre-existing `CQS_SLOT` > `.cqs/active_slot` >
+    // `"default"`. Only set when the flag was passed on the CLI.
+    if let Some(ref slot_name) = cli.slot {
+        std::env::set_var("CQS_SLOT", slot_name);
+    }
 
     // Load config and apply defaults (CLI flags override config)
     let config = cqs::config::Config::load(&find_project_root());
@@ -55,9 +74,12 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
     cli.limit = cli.limit.clamp(1, 100);
 
     // ── Daemon client: forward to running daemon if available ──────────────
+    // The daemon binds to whichever slot was active at *its* startup (per
+    // spec). If the user passed `--slot <name>`, bypass the daemon so the
+    // requested slot wins instead of silently getting the daemon's slot.
     #[cfg(unix)]
-    if std::env::var("CQS_NO_DAEMON").as_deref() != Ok("1") {
-        if let Some(output) = try_daemon_query(&cqs_dir, &cli) {
+    if cli.slot.is_none() && std::env::var("CQS_NO_DAEMON").as_deref() != Ok("1") {
+        if let Some(output) = try_daemon_query(&project_cqs_dir, &cli) {
             print!("{}", output);
             return Ok(());
         }
@@ -67,6 +89,7 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
     match cli.command {
         Some(Commands::Init) => return cmd_init(&cli),
         Some(Commands::Cache { ref subcmd }) => return cmd_cache(&cli, subcmd),
+        Some(Commands::Slot { ref subcmd }) => return cmd_slot(&cli, subcmd),
         Some(Commands::Doctor { fix, verbose, json }) => {
             // Task #8: top-level `--json` cascades into doctor's `--json` so
             // `cqs --json doctor --verbose` emits JSON.
@@ -171,9 +194,9 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
                 // API-V1.29-3: forward the resolved --json bit so reset emits
                 // the `{archived_events, archive_path, lock_path}` envelope
                 // instead of silently dropping the flag.
-                cmd_telemetry_reset(&cqs_dir, reason.as_deref(), cli.json || output.json)
+                cmd_telemetry_reset(&project_cqs_dir, reason.as_deref(), cli.json || output.json)
             } else {
-                cmd_telemetry(&cqs_dir, cli.json || output.json, all)
+                cmd_telemetry(&project_cqs_dir, cli.json || output.json, all)
             };
         }
         Some(Commands::Project { ref subcmd }) => {
@@ -624,6 +647,7 @@ fn command_variant_name(cmd: &Commands) -> &'static str {
         Commands::TrainData { .. } => "train-data",
         Commands::TrainPairs { .. } => "train-pairs",
         Commands::Cache { .. } => "cache",
+        Commands::Slot { .. } => "slot",
         Commands::Ping { .. } => "ping",
         Commands::Refresh => "refresh",
         Commands::Eval { .. } => "eval",

--- a/src/cli/pipeline/mod.rs
+++ b/src/cli/pipeline/mod.rs
@@ -93,17 +93,38 @@ pub(crate) fn run_index_pipeline(
         })
     };
 
-    // Open global embedding cache (best-effort)
+    // Open project-scoped embeddings cache (best-effort).
+    //
+    // Spec §Cache: cache lives at `<project_cqs_dir>/embeddings_cache.db`,
+    // shared across all slots so an embedder swap only re-embeds chunks
+    // whose hash hasn't been seen for that model_id before.
+    //
+    // `CQS_CACHE_ENABLED=0` disables the cache entirely for benchmarking /
+    // debugging — the embed path falls back to per-batch GPU/CPU work without
+    // the partition step.
     let global_cache: Option<Arc<cqs::cache::EmbeddingCache>> = {
-        let cache_path = cqs::cache::EmbeddingCache::default_path();
-        match cqs::cache::EmbeddingCache::open(&cache_path) {
-            Ok(c) => {
-                tracing::info!(path = %cache_path.display(), "Global embedding cache opened");
-                Some(Arc::new(c))
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "Global embedding cache unavailable");
-                None
+        if std::env::var("CQS_CACHE_ENABLED").as_deref() == Ok("0") {
+            tracing::info!("CQS_CACHE_ENABLED=0 — embeddings cache disabled for this run");
+            None
+        } else {
+            let project_cqs_dir = cqs::resolve_index_dir(root);
+            let cache_path = cqs::cache::EmbeddingCache::project_default_path(&project_cqs_dir);
+            match cqs::cache::EmbeddingCache::open(&cache_path) {
+                Ok(c) => {
+                    tracing::info!(
+                        path = %cache_path.display(),
+                        "Project embeddings cache opened"
+                    );
+                    Some(Arc::new(c))
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        path = %cache_path.display(),
+                        "Project embeddings cache unavailable; disabling cache for this run"
+                    );
+                    None
+                }
             }
         }
     };

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -10,6 +10,65 @@ use anyhow::Result;
 use super::config::find_project_root;
 use super::definitions;
 
+/// Bundle of paths produced by [`resolve_slot_paths`] — slot-local index +
+/// project-level metadata in one struct so call sites don't have to re-derive
+/// either.
+#[derive(Debug, Clone)]
+pub(crate) struct SlotPaths {
+    /// Project root (`<root>` — directory holding `.cqs/`).
+    pub root: PathBuf,
+    /// Project-level `.cqs/` (telemetry, daemon socket, embeddings_cache.db,
+    /// active_slot pointer, slots/).
+    pub project_cqs_dir: PathBuf,
+    /// Slot dir `.cqs/slots/<name>/` (holds index.db, hnsw_*, splade.*).
+    pub slot_dir: PathBuf,
+    /// Slot name (validated, post-resolution).
+    pub slot_name: String,
+}
+
+impl SlotPaths {
+    pub fn index_path(&self) -> PathBuf {
+        self.slot_dir.join(cqs::INDEX_DB_FILENAME)
+    }
+}
+
+/// Resolve `--slot` / `CQS_SLOT` / `.cqs/active_slot` / "default" into the
+/// concrete slot dir, falling back to a legacy `.cqs/index.db` layout when
+/// `slots/` doesn't yet exist (pre-migration / never-indexed projects).
+pub(crate) fn resolve_slot_paths(slot_flag: Option<&str>) -> Result<SlotPaths> {
+    let _span = tracing::debug_span!("resolve_slot_paths", slot_flag).entered();
+    let root = find_project_root();
+    let project_cqs_dir = cqs::resolve_index_dir(&root);
+
+    // Pre-slots layout (legacy): `.cqs/index.db` directly under project_cqs_dir.
+    // Path is returned as a fake slot of name "default" so downstream code
+    // that joins INDEX_DB_FILENAME against `slot_dir` finds the existing file.
+    let resolved = cqs::slot::resolve_slot_name(slot_flag, &project_cqs_dir)
+        .map_err(|e| anyhow::anyhow!(e))?;
+    let slot_dir = cqs::resolve_slot_dir(&project_cqs_dir, &resolved.name);
+    let slots_root = cqs::slot::slots_root(&project_cqs_dir);
+
+    // If neither the slot dir nor the legacy `.cqs/index.db` is present, we
+    // still return the slot_dir form so `open_project_store` can produce a
+    // clean "Index not found" error pointing at the modern path.
+    if !slots_root.exists() && project_cqs_dir.join(cqs::INDEX_DB_FILENAME).exists() {
+        // Pre-slots layout — index.db sits directly in `.cqs/`. Treat
+        // `.cqs/` as the slot dir for this read.
+        return Ok(SlotPaths {
+            root,
+            project_cqs_dir: project_cqs_dir.clone(),
+            slot_dir: project_cqs_dir,
+            slot_name: cqs::slot::DEFAULT_SLOT.to_string(),
+        });
+    }
+    Ok(SlotPaths {
+        root,
+        project_cqs_dir,
+        slot_dir,
+        slot_name: resolved.name,
+    })
+}
+
 /// Shared helper: locate project root and index, open store with the given opener.
 ///
 /// Generic over the typestate returned by `opener`, so both `Store::open`
@@ -17,28 +76,46 @@ use super::definitions;
 /// (→ `Store<ReadOnly>`) compose through the same helper.
 fn open_store_with<Mode>(
     opener: fn(&Path) -> std::result::Result<cqs::Store<Mode>, cqs::store::StoreError>,
-) -> Result<(cqs::Store<Mode>, PathBuf, PathBuf)> {
+    slot_flag: Option<&str>,
+) -> Result<(cqs::Store<Mode>, SlotPaths)> {
     // P3 #131: span on the shared opener so both `open_project_store` and
     // `open_project_store_readonly` (which fan into here) get consistent
     // tracing identity covering the index existence check + open.
     let _span = tracing::info_span!("open_project_store").entered();
-    let root = find_project_root();
-    let cqs_dir = cqs::resolve_index_dir(&root);
-    let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+    let paths = resolve_slot_paths(slot_flag)?;
+    let index_path = paths.index_path();
 
     if !index_path.exists() {
-        anyhow::bail!("Index not found. Run 'cqs init && cqs index' first.");
+        anyhow::bail!(
+            "Index not found at {}. Run `cqs init && cqs index` (or `cqs index --slot {}` if the slot exists but is empty).",
+            index_path.display(),
+            paths.slot_name,
+        );
     }
 
     let store = opener(&index_path)
         .map_err(|e| anyhow::anyhow!("Failed to open index at {}: {}", index_path.display(), e))?;
-    Ok((store, root, cqs_dir))
+    Ok((store, paths))
 }
 
-/// Open the project store, returning the store, project root, and index directory.
+/// Open the project store, returning the store, project root, and slot dir.
 /// Bails with a user-friendly message if no index exists.
+///
+/// Kept for legacy in-tree callers that don't (yet) flow through
+/// `CommandContext`. New code should prefer
+/// [`open_project_store_for_slot`] which honors the `--slot` flag.
+#[allow(dead_code)]
 pub(crate) fn open_project_store() -> Result<(cqs::Store, PathBuf, PathBuf)> {
-    open_store_with(cqs::Store::open)
+    let (store, paths) = open_store_with(cqs::Store::open, None)?;
+    Ok((store, paths.root, paths.slot_dir))
+}
+
+/// Slot-aware variant of [`open_project_store`]. Honors the resolved slot flag
+/// from CLI / env / file.
+pub(crate) fn open_project_store_for_slot(
+    slot_flag: Option<&str>,
+) -> Result<(cqs::Store, SlotPaths)> {
+    open_store_with(cqs::Store::open, slot_flag)
 }
 
 /// Open the project store with a single-threaded runtime for read-only commands.
@@ -47,7 +124,16 @@ pub(crate) fn open_project_store() -> Result<(cqs::Store, PathBuf, PathBuf)> {
 /// Keeps full 256MB mmap and 16MB cache for search performance.
 pub(crate) fn open_project_store_readonly(
 ) -> Result<(cqs::Store<cqs::store::ReadOnly>, PathBuf, PathBuf)> {
-    open_store_with(cqs::Store::open_readonly_pooled)
+    let (store, paths) = open_store_with(cqs::Store::open_readonly_pooled, None)?;
+    Ok((store, paths.root, paths.slot_dir))
+}
+
+/// Slot-aware read-only open. Honors `--slot`/env/file resolution for query
+/// commands flowing through [`CommandContext`].
+pub(crate) fn open_project_store_readonly_for_slot(
+    slot_flag: Option<&str>,
+) -> Result<(cqs::Store<cqs::store::ReadOnly>, SlotPaths)> {
+    open_store_with(cqs::Store::open_readonly_pooled, slot_flag)
 }
 
 /// Shared context for CLI commands that need an open store.
@@ -68,7 +154,24 @@ pub(crate) struct CommandContext<'a, Mode = cqs::store::ReadWrite> {
     pub cli: &'a definitions::Cli,
     pub store: cqs::Store<Mode>,
     pub root: PathBuf,
+    /// Slot dir — `.cqs/slots/<active>/`. Holds index.db, hnsw_*, splade.*.
+    /// Most call sites use this as the "where do my index files live" anchor.
     pub cqs_dir: PathBuf,
+    /// Project-level `.cqs/` dir (parent of `slots/`). Holds the
+    /// embeddings_cache.db, the active_slot pointer, telemetry, daemon
+    /// socket. Pre-slots projects have `cqs_dir == project_cqs_dir`.
+    ///
+    /// Surfaced as `pub` for handlers that need to open the project-scoped
+    /// embeddings cache, write the active_slot pointer, or interact with
+    /// the daemon socket — all project-level concerns rather than
+    /// slot-local ones.
+    #[allow(dead_code)] // wired into doctor + handlers progressively; spec §Architecture
+    pub project_cqs_dir: PathBuf,
+    /// Slot name resolved from `--slot` / `CQS_SLOT` / `.cqs/active_slot` /
+    /// fallback "default". Available so handlers can include the slot in
+    /// their tracing fields and `--json` envelopes without re-resolving.
+    #[allow(dead_code)] // wired into doctor + handlers progressively
+    pub slot_name: String,
     reranker: OnceLock<cqs::Reranker>,
     embedder: OnceLock<cqs::Embedder>,
     splade_encoder: OnceLock<Option<cqs::splade::SpladeEncoder>>,
@@ -83,12 +186,14 @@ pub(crate) struct CommandContext<'a, Mode = cqs::store::ReadWrite> {
 impl<'a> CommandContext<'a, cqs::store::ReadOnly> {
     /// Open the project store in read-only mode and build a command context.
     pub fn open_readonly(cli: &'a definitions::Cli) -> Result<Self> {
-        let (store, root, cqs_dir) = open_project_store_readonly()?;
+        let (store, paths) = open_project_store_readonly_for_slot(cli.slot.as_deref())?;
         Ok(Self {
             cli,
             store,
-            root,
-            cqs_dir,
+            root: paths.root,
+            cqs_dir: paths.slot_dir,
+            project_cqs_dir: paths.project_cqs_dir,
+            slot_name: paths.slot_name,
             reranker: OnceLock::new(),
             embedder: OnceLock::new(),
             splade_encoder: OnceLock::new(),
@@ -105,12 +210,14 @@ impl<'a> CommandContext<'a, cqs::store::ReadWrite> {
     /// from `CommandContext` but also need a writable store.
     pub fn open_readwrite(cli: &'a definitions::Cli) -> Result<Self> {
         let _span = tracing::info_span!("CommandContext::open_readwrite").entered();
-        let (store, root, cqs_dir) = open_project_store()?;
+        let (store, paths) = open_project_store_for_slot(cli.slot.as_deref())?;
         Ok(Self {
             cli,
             store,
-            root,
-            cqs_dir,
+            root: paths.root,
+            cqs_dir: paths.slot_dir,
+            project_cqs_dir: paths.project_cqs_dir,
+            slot_name: paths.slot_name,
             reranker: OnceLock::new(),
             embedder: OnceLock::new(),
             splade_encoder: OnceLock::new(),

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -1270,11 +1270,40 @@ pub fn cmd_watch(
         debounce_ms
     };
 
-    let cqs_dir = cqs::resolve_index_dir(&root);
+    let project_cqs_dir = cqs::resolve_index_dir(&root);
+
+    // Migration: ensure legacy `.cqs/index.db` (if present) is moved to
+    // `.cqs/slots/default/` before watch hooks the index file. This is
+    // idempotent — the migration runs at top of `dispatch::run_with`
+    // already, so this is a belt-and-braces guard for daemon-only paths
+    // (cqs-watch systemd service launched directly via `cqs watch --serve`
+    // before any other CLI invocation triggered the migration).
+    if project_cqs_dir.exists() {
+        if let Err(e) = cqs::slot::migrate_legacy_index_to_default_slot(&project_cqs_dir) {
+            tracing::warn!(error = %e, "slot migration failed inside watch boot; continuing without it");
+        }
+    }
+
+    // Resolve active slot at daemon startup. The daemon binds to whichever
+    // slot is active at this moment; promotion afterwards requires a daemon
+    // restart per spec §Daemon.
+    let active_slot = cqs::slot::resolve_slot_name(cli.slot.as_deref(), &project_cqs_dir)
+        .map_err(|e| anyhow::anyhow!(e))?;
+    tracing::info!(
+        slot = %active_slot.name,
+        source = active_slot.source.as_str(),
+        "daemon bound to slot"
+    );
+
+    let cqs_dir = if cqs::slot::slots_root(&project_cqs_dir).exists() {
+        cqs::resolve_slot_dir(&project_cqs_dir, &active_slot.name)
+    } else {
+        project_cqs_dir.clone()
+    };
     let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
 
     if !index_path.exists() {
-        bail!("No index found. Run 'cqs index' first.");
+        bail!("No index found at {}. Run 'cqs index' first (or 'cqs index --slot {}' if the slot exists but is empty).", index_path.display(), active_slot.name);
     }
 
     // Socket listener BEFORE watcher scan — daemon is immediately queryable
@@ -1282,7 +1311,10 @@ pub fn cmd_watch(
     // Unix domain sockets are not available on Windows.
     #[cfg(unix)]
     let mut socket_listener = if serve {
-        let sock_path = super::daemon_socket_path(&cqs_dir);
+        // Daemon socket is keyed by the project-level `.cqs/` dir so all
+        // slots share one socket — the daemon serves whichever slot was
+        // active at startup, but the socket is per-project not per-slot.
+        let sock_path = super::daemon_socket_path(&project_cqs_dir);
         if sock_path.exists() {
             match std::os::unix::net::UnixStream::connect(&sock_path) {
                 Ok(_) => {
@@ -1940,7 +1972,11 @@ pub fn cmd_watch(
                     // piggybacks on the existing worker pool rather than
                     // spinning up a fresh current_thread runtime.
                     if last_cache_evict.elapsed() >= Duration::from_secs(3600) {
-                        super::batch::evict_global_embedding_cache_with_runtime(
+                        let project_cqs_dir = cqs::resolve_index_dir(&root);
+                        let cache_path =
+                            cqs::cache::EmbeddingCache::project_default_path(&project_cqs_dir);
+                        super::batch::evict_embeddings_cache_with_runtime(
+                            &cache_path,
                             "watch reindex cycle",
                             Some(Arc::clone(&shared_rt)),
                         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub mod health;
 pub mod reranker;
 #[cfg(feature = "serve")]
 pub mod serve;
+pub mod slot;
 pub mod suggest;
 
 // Internal modules - not part of public library API
@@ -219,6 +220,37 @@ pub fn resolve_index_dir(project_root: &Path) -> PathBuf {
     } else {
         new_dir
     }
+}
+
+/// Compute the slot directory path: `<project_cqs_dir>/slots/<slot_name>/`.
+///
+/// Convenience wrapper around [`crate::slot::slot_dir`] for callers that
+/// already imported `cqs::resolve_index_dir`.
+pub fn resolve_slot_dir(project_cqs_dir: &Path, slot_name: &str) -> PathBuf {
+    crate::slot::slot_dir(project_cqs_dir, slot_name)
+}
+
+/// Resolve the active index.db path within a project's `.cqs/` dir.
+///
+/// Honors the slot resolution order (`CQS_SLOT` env > `.cqs/active_slot` file >
+/// `"default"`) and falls back to the pre-migration `.cqs/index.db` layout for
+/// unmigrated projects (cross-project search, external references).
+///
+/// Returns the slot path even when nothing exists, so the caller's
+/// "not found" error message points at the forward-looking layout.
+pub fn resolve_index_db(project_cqs_dir: &Path) -> PathBuf {
+    if let Ok(resolved) = crate::slot::resolve_slot_name(None, project_cqs_dir) {
+        let slot_path =
+            crate::slot::slot_dir(project_cqs_dir, &resolved.name).join(INDEX_DB_FILENAME);
+        if slot_path.exists() {
+            return slot_path;
+        }
+    }
+    let legacy = project_cqs_dir.join(INDEX_DB_FILENAME);
+    if legacy.exists() {
+        return legacy;
+    }
+    crate::slot::slot_dir(project_cqs_dir, crate::slot::DEFAULT_SLOT).join(INDEX_DB_FILENAME)
 }
 
 /// Default embedding dimension (1024, BGE-large-en-v1.5).

--- a/src/project.rs
+++ b/src/project.rs
@@ -117,8 +117,12 @@ impl ProjectRegistry {
 
     /// Register a project (replaces existing entry with same name)
     pub fn register(&mut self, name: String, path: PathBuf) -> Result<(), ProjectError> {
-        // Validate the path has a .cqs (or legacy .cq) directory
-        if !path.join(".cqs/index.db").exists() && !path.join(".cq/index.db").exists() {
+        // Validate the path has a .cqs (or legacy .cq) directory.
+        // Post-slots layout: `.cqs/slots/<active>/index.db`. Pre-slots layout:
+        // `.cqs/index.db`. Pre-v0.9.7 layout: `.cq/index.db`.
+        let cqs_dir = path.join(".cqs");
+        let has_cqs = cqs_dir.exists() && crate::resolve_index_db(&cqs_dir).exists();
+        if !has_cqs && !path.join(".cq/index.db").exists() {
             return Err(ProjectError::NotFound(format!(
                 "No cqs index found at {}. Run 'cqs init && cqs index' there first.",
                 path.display()
@@ -304,11 +308,13 @@ fn search_single_project(
     threshold: f32,
 ) -> Result<Vec<CrossProjectResult>, anyhow::Error> {
     let _span = tracing::info_span!("search_single_project", project = %entry.name).entered();
-    // Prefer .cqs, fall back to legacy .cq
+    // Prefer .cqs (with slot resolution), fall back to legacy .cq.
+    // `resolve_index_db` handles slots/<active>/index.db AND pre-slots
+    // `.cqs/index.db` for unmigrated cross-project entries.
     let index_path = {
-        let new_path = entry.path.join(".cqs/index.db");
-        if new_path.exists() {
-            new_path
+        let cqs_dir = entry.path.join(".cqs");
+        if cqs_dir.exists() {
+            crate::resolve_index_db(&cqs_dir)
         } else {
             entry.path.join(".cq/index.db")
         }

--- a/src/slot/mod.rs
+++ b/src/slot/mod.rs
@@ -1,0 +1,790 @@
+//! Project-level named slots — side-by-side full indexes under `.cqs/slots/<name>/`.
+//!
+//! A slot is a self-contained index: its own SQLite `index.db`, HNSW files, and
+//! SPLADE artifacts. Slots let users keep multiple embedders side-by-side with
+//! atomic `cqs slot promote` switching, instead of destructive
+//! `cqs model swap` reindex cycles.
+//!
+//! # Layout
+//!
+//! ```text
+//! .cqs/
+//!   active_slot                # text file: bare slot name, e.g. "default"
+//!   embeddings_cache.db        # cross-slot, content-addressed
+//!   slots/
+//!     default/                 # post-migration of legacy `.cqs/index.db`
+//!       index.db
+//!       hnsw_*.bin
+//!       splade.index.bin
+//!     e5/                      # user-created via `cqs slot create`
+//!       index.db
+//!       …
+//!   watch.sock                 # daemon socket — bound to whichever slot was
+//!                              # active at daemon startup
+//! ```
+//!
+//! # Resolution order
+//!
+//! `resolve_slot_name` consults, in priority order:
+//!
+//! 1. `--slot <name>` flag (caller-supplied)
+//! 2. `CQS_SLOT` env var
+//! 3. `.cqs/active_slot` file content (trimmed, validated)
+//! 4. Hardcoded fallback `"default"`
+//!
+//! Each step logs at `info` (or `debug` for the file/fallback) so troubleshooting
+//! a "wrong slot" report is one `RUST_LOG=cqs=debug` away.
+//!
+//! # Migration
+//!
+//! [`migrate_legacy_index_to_default_slot`] runs idempotently on every
+//! `Store::open`. If `.cqs/index.db` exists AND `.cqs/slots/` does not, it
+//! moves `index.db` + HNSW + SPLADE into `.cqs/slots/default/` and writes
+//! `.cqs/active_slot = "default"`. Failures roll back via inventory.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+/// Bare directory name under `.cqs/` that holds per-slot dirs.
+pub const SLOTS_DIR: &str = "slots";
+
+/// Bare file name of the active-slot pointer in `.cqs/`.
+pub const ACTIVE_SLOT_FILE: &str = "active_slot";
+
+/// Default slot name, used when nothing else resolves.
+pub const DEFAULT_SLOT: &str = "default";
+
+/// Maximum slot name length (matches spec §Slot commands).
+pub const MAX_SLOT_NAME_LEN: usize = 32;
+
+/// Reserved slot names — names used as subcommand verbs, plus `default`
+/// (pre-claimed for the migration target). Rejecting these at create time
+/// keeps `cqs slot create active` and friends from producing surprising
+/// `cqs slot active` collisions.
+const RESERVED_SLOT_NAMES: &[&str] = &[
+    "active", "list", "create", "promote", "remove", "stats", "prune", "compact",
+];
+
+/// Errors that can occur during slot resolution / lifecycle / migration.
+#[derive(Debug, Error)]
+pub enum SlotError {
+    #[error("Slot name is empty (must match [a-z0-9_-]+, max {MAX_SLOT_NAME_LEN} chars)")]
+    EmptyName,
+
+    #[error(
+        "Slot name '{name}' is too long (max {max} chars; got {got})",
+        max = MAX_SLOT_NAME_LEN,
+        got = name.chars().count()
+    )]
+    NameTooLong { name: String },
+
+    #[error("Slot name '{0}' contains invalid character(s) (allowed: a-z, 0-9, _, -)")]
+    InvalidCharacters(String),
+
+    #[error("Slot name '{0}' is reserved (collides with a subcommand verb or pre-claimed name)")]
+    Reserved(String),
+
+    #[error("Slot '{0}' does not exist. Available: [{1}]. Create with: cqs slot create <name> --model <model-id>")]
+    NotFound(String, String),
+
+    #[error("Slot '{0}' exists but has no index.db. Run `cqs index --slot {0}` first.")]
+    Empty(String),
+
+    #[error("Cannot remove the active slot '{0}' without --force, or while it is the only slot. Promote another slot first.")]
+    RemoveActive(String),
+
+    #[error("At least one slot must remain. Refusing to remove the last slot '{0}'.")]
+    RemoveLast(String),
+
+    #[error("Filesystem error while operating on slot '{slot}': {source}")]
+    Io {
+        slot: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Migration failed: {0}")]
+    Migration(String),
+}
+
+/// Where a slot name came from. Surfaced in `tracing::info!` so a wrong-slot
+/// report can be diagnosed in one log search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotSource {
+    /// Caller supplied an explicit `--slot <name>` flag.
+    Flag,
+    /// `CQS_SLOT` environment variable.
+    Env,
+    /// `.cqs/active_slot` pointer file.
+    File,
+    /// Hardcoded `"default"` fallback (no other source resolved).
+    Fallback,
+}
+
+impl SlotSource {
+    /// String form for tracing fields.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SlotSource::Flag => "flag",
+            SlotSource::Env => "env",
+            SlotSource::File => "file",
+            SlotSource::Fallback => "fallback",
+        }
+    }
+}
+
+/// A resolved slot name + the source that produced it.
+#[derive(Debug, Clone)]
+pub struct ResolvedSlot {
+    /// Validated slot name.
+    pub name: String,
+    /// Source the name came from (flag/env/file/fallback).
+    pub source: SlotSource,
+}
+
+/// Validate a slot name per spec §Slot commands: `[a-z0-9_-]+`, max 32 chars,
+/// reserved names rejected.
+///
+/// Reserved names are subcommand verbs (`active`, `list`, `create`, etc.) plus
+/// `default` is permitted (used by migration). The migration creates `default`
+/// programmatically — explicit `cqs slot create default` is also allowed; the
+/// pre-claim is in [`RESERVED_SLOT_NAMES`] and `default` is intentionally
+/// absent from that list.
+pub fn validate_slot_name(name: &str) -> Result<(), SlotError> {
+    if name.is_empty() {
+        return Err(SlotError::EmptyName);
+    }
+    if name.chars().count() > MAX_SLOT_NAME_LEN {
+        return Err(SlotError::NameTooLong {
+            name: name.to_string(),
+        });
+    }
+    let valid_chars = name
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_' || b == b'-');
+    if !valid_chars {
+        return Err(SlotError::InvalidCharacters(name.to_string()));
+    }
+    if RESERVED_SLOT_NAMES.contains(&name) {
+        return Err(SlotError::Reserved(name.to_string()));
+    }
+    Ok(())
+}
+
+/// Path of `.cqs/slots/<name>/` for the given project `.cqs/` dir + slot name.
+pub fn slot_dir(project_cqs_dir: &Path, slot_name: &str) -> PathBuf {
+    project_cqs_dir.join(SLOTS_DIR).join(slot_name)
+}
+
+/// Path of `.cqs/slots/` for the given project `.cqs/` dir.
+pub fn slots_root(project_cqs_dir: &Path) -> PathBuf {
+    project_cqs_dir.join(SLOTS_DIR)
+}
+
+/// Path of `.cqs/active_slot` pointer file.
+pub fn active_slot_path(project_cqs_dir: &Path) -> PathBuf {
+    project_cqs_dir.join(ACTIVE_SLOT_FILE)
+}
+
+/// Read the active slot name from `.cqs/active_slot`. Returns `None` if the
+/// file is missing or empty / corrupt — caller falls back to `DEFAULT_SLOT`.
+///
+/// Corruption (non-UTF8, invalid characters) is logged at `warn` and treated
+/// as missing so a single mangled write doesn't render the project unusable.
+pub fn read_active_slot(project_cqs_dir: &Path) -> Option<String> {
+    let path = active_slot_path(project_cqs_dir);
+    match fs::read_to_string(&path) {
+        Ok(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                tracing::warn!(
+                    path = %path.display(),
+                    "active_slot file is empty; falling back to default"
+                );
+                return None;
+            }
+            match validate_slot_name(trimmed) {
+                Ok(()) => Some(trimmed.to_string()),
+                Err(e) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        contents = %trimmed,
+                        error = %e,
+                        "active_slot file contains invalid slot name; falling back to default"
+                    );
+                    None
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "Failed to read active_slot file; falling back to default"
+            );
+            None
+        }
+    }
+}
+
+/// Write the active slot pointer atomically. Validates the name first.
+///
+/// Writes to a sibling `<active_slot>.tmp` then `rename`s into place — atomic
+/// on the same filesystem. Crash between write and rename leaves the previous
+/// pointer intact.
+pub fn write_active_slot(project_cqs_dir: &Path, slot_name: &str) -> Result<(), SlotError> {
+    validate_slot_name(slot_name)?;
+    let _span = tracing::info_span!(
+        "write_active_slot",
+        slot_name,
+        cqs_dir = %project_cqs_dir.display()
+    )
+    .entered();
+
+    if !project_cqs_dir.exists() {
+        fs::create_dir_all(project_cqs_dir).map_err(|source| SlotError::Io {
+            slot: slot_name.to_string(),
+            source,
+        })?;
+    }
+
+    let final_path = active_slot_path(project_cqs_dir);
+    let tmp_path = project_cqs_dir.join(format!("{}.tmp", ACTIVE_SLOT_FILE));
+
+    {
+        let mut f = fs::File::create(&tmp_path).map_err(|source| SlotError::Io {
+            slot: slot_name.to_string(),
+            source,
+        })?;
+        f.write_all(slot_name.as_bytes())
+            .map_err(|source| SlotError::Io {
+                slot: slot_name.to_string(),
+                source,
+            })?;
+        // Best-effort fsync before rename so the rename atomicity covers a
+        // populated file, not an empty one. Failures here are non-fatal — the
+        // fsync is belt-and-braces over `rename`'s own crash safety.
+        if let Err(e) = f.sync_all() {
+            tracing::debug!(error = %e, "active_slot tmp fsync failed (non-fatal)");
+        }
+    }
+
+    fs::rename(&tmp_path, &final_path).map_err(|source| SlotError::Io {
+        slot: slot_name.to_string(),
+        source,
+    })?;
+    tracing::info!(slot_name, "active slot pointer updated");
+    Ok(())
+}
+
+/// List all slot directories under `.cqs/slots/`. Each entry is the bare slot
+/// name (the directory's file name). Returns an empty Vec when `slots/`
+/// doesn't exist yet.
+///
+/// Sorted alphabetically so output is deterministic for tests + UI.
+pub fn list_slots(project_cqs_dir: &Path) -> Result<Vec<String>, SlotError> {
+    let _span = tracing::debug_span!("list_slots", cqs_dir = %project_cqs_dir.display()).entered();
+    let root = slots_root(project_cqs_dir);
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+    let mut names = Vec::new();
+    let entries = fs::read_dir(&root).map_err(|source| SlotError::Io {
+        slot: String::new(),
+        source,
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|source| SlotError::Io {
+            slot: String::new(),
+            source,
+        })?;
+        if !entry
+            .file_type()
+            .map_err(|source| SlotError::Io {
+                slot: String::new(),
+                source,
+            })?
+            .is_dir()
+        {
+            continue;
+        }
+        if let Some(name) = entry.file_name().to_str() {
+            // Skip dirs that don't validate as slot names (e.g., temp dirs).
+            if validate_slot_name(name).is_ok() {
+                names.push(name.to_string());
+            } else {
+                tracing::debug!(name, "Skipping non-slot directory under slots/");
+            }
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+/// Resolve the slot name from the documented source order:
+/// `--slot` flag > `CQS_SLOT` env > `.cqs/active_slot` file > `"default"`.
+///
+/// Returns the resolved name plus the source for tracing.
+pub fn resolve_slot_name(
+    flag: Option<&str>,
+    project_cqs_dir: &Path,
+) -> Result<ResolvedSlot, SlotError> {
+    let _span = tracing::debug_span!("resolve_slot_name").entered();
+
+    if let Some(name) = flag {
+        validate_slot_name(name)?;
+        tracing::info!(slot = name, source = "flag", "active slot resolved");
+        return Ok(ResolvedSlot {
+            name: name.to_string(),
+            source: SlotSource::Flag,
+        });
+    }
+    if let Ok(env_name) = std::env::var("CQS_SLOT") {
+        let env_name = env_name.trim();
+        if !env_name.is_empty() {
+            validate_slot_name(env_name)?;
+            tracing::info!(slot = env_name, source = "env", "active slot resolved");
+            return Ok(ResolvedSlot {
+                name: env_name.to_string(),
+                source: SlotSource::Env,
+            });
+        }
+    }
+    if let Some(name) = read_active_slot(project_cqs_dir) {
+        tracing::debug!(slot = %name, source = "file", "active slot resolved");
+        return Ok(ResolvedSlot {
+            name,
+            source: SlotSource::File,
+        });
+    }
+    tracing::debug!(
+        slot = DEFAULT_SLOT,
+        source = "fallback",
+        "active slot resolved"
+    );
+    Ok(ResolvedSlot {
+        name: DEFAULT_SLOT.to_string(),
+        source: SlotSource::Fallback,
+    })
+}
+
+/// One-shot filesystem migration: move legacy `.cqs/index.db` (and its HNSW /
+/// SPLADE sidecars) into `.cqs/slots/default/`, then write
+/// `.cqs/active_slot = "default"`.
+///
+/// Idempotent: if `.cqs/slots/` already exists, this is a no-op. Atomic where
+/// the source and destination live on the same filesystem (common case);
+/// otherwise falls back to copy + delete with an inventory-based rollback on
+/// partial failure.
+///
+/// Returns:
+/// - `Ok(true)` if migration ran (legacy → slots/default/)
+/// - `Ok(false)` if no legacy state was found, or `slots/` already exists
+pub fn migrate_legacy_index_to_default_slot(project_cqs_dir: &Path) -> Result<bool, SlotError> {
+    let _span = tracing::info_span!(
+        "migrate_legacy_index_to_default_slot",
+        cqs_dir = %project_cqs_dir.display()
+    )
+    .entered();
+
+    if !project_cqs_dir.exists() {
+        return Ok(false);
+    }
+
+    let slots_dir = slots_root(project_cqs_dir);
+    if slots_dir.exists() {
+        return Ok(false);
+    }
+
+    let legacy_index = project_cqs_dir.join(crate::INDEX_DB_FILENAME);
+    if !legacy_index.exists() {
+        // Nothing to migrate; create `slots/` so subsequent runs treat the
+        // project as slot-aware. Without this a fresh project never enters
+        // slot-aware mode until first index.
+        return Ok(false);
+    }
+
+    let dest = slot_dir(project_cqs_dir, DEFAULT_SLOT);
+
+    fs::create_dir_all(&dest).map_err(|source| SlotError::Io {
+        slot: DEFAULT_SLOT.to_string(),
+        source,
+    })?;
+
+    // Inventory of files we plan to move. Order matters: index.db first so
+    // failures after that point are recoverable (we leave `slots/default/`
+    // populated with whatever moved, plus the legacy file restored).
+    let migration_files = collect_migration_files(project_cqs_dir);
+    let mut moved: Vec<(PathBuf, PathBuf)> = Vec::new();
+
+    for src in &migration_files {
+        let file_name = match src.file_name() {
+            Some(n) => n.to_string_lossy().into_owned(),
+            None => continue,
+        };
+        let dst = dest.join(&file_name);
+        if let Err(e) = move_file(src, &dst) {
+            // Rollback — restore everything we already moved.
+            tracing::error!(
+                src = %src.display(),
+                dst = %dst.display(),
+                error = %e,
+                "migration step failed; rolling back"
+            );
+            for (already_dst, already_src) in moved.iter().rev() {
+                if let Err(rollback_err) = move_file(already_dst, already_src) {
+                    tracing::error!(
+                        src = %already_dst.display(),
+                        dst = %already_src.display(),
+                        error = %rollback_err,
+                        "rollback failed (manual recovery may be needed)"
+                    );
+                }
+            }
+            // Best-effort: clean up the empty slots/default/ + slots/ if rollback was clean.
+            let _ = fs::remove_dir(&dest);
+            let _ = fs::remove_dir(&slots_dir);
+            return Err(SlotError::Migration(format!(
+                "failed to move {}: {}",
+                src.display(),
+                e
+            )));
+        }
+        moved.push((dst, src.clone()));
+    }
+
+    // Finalize by writing the active_slot pointer.
+    write_active_slot(project_cqs_dir, DEFAULT_SLOT)?;
+    tracing::info!(
+        files_moved = moved.len(),
+        from = %project_cqs_dir.display(),
+        to = %dest.display(),
+        "legacy index.db migrated to slots/default/"
+    );
+    Ok(true)
+}
+
+/// Collect every file we want to migrate from `.cqs/` → `.cqs/slots/default/`.
+/// Hardcoded list of patterns since there's no manifest of "slot-local" files
+/// in the rest of the codebase.
+fn collect_migration_files(project_cqs_dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    // Always-present
+    let candidates = [
+        crate::INDEX_DB_FILENAME,
+        "index.db-wal",
+        "index.db-shm",
+        "index.db.bak",
+        // HNSW (enriched + base, persistence + index)
+        "index.hnsw.data",
+        "index.hnsw.graph",
+        "index_base.hnsw.data",
+        "index_base.hnsw.graph",
+        "index.hnsw.lock",
+        "index.cagra",
+        "index.cagra.sidecar",
+        // SPLADE
+        "splade.index.bin",
+    ];
+    for name in candidates {
+        let p = project_cqs_dir.join(name);
+        if p.exists() {
+            out.push(p);
+        }
+    }
+    out
+}
+
+/// Move a file, atomic where possible; falls back to copy + remove for
+/// cross-device renames. Errors surface to caller for inventory-based rollback.
+fn move_file(src: &Path, dst: &Path) -> std::io::Result<()> {
+    match fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(e) if e.raw_os_error() == Some(libc_exdev()) => {
+            fs::copy(src, dst)?;
+            fs::remove_file(src)?;
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// EXDEV `errno` value (cross-device link). We hardcode 18 (Linux) since
+/// `libc::EXDEV` would pull in a libc dep just for this constant. macOS also
+/// uses 18; Windows doesn't surface EXDEV the same way (rename across
+/// filesystems just succeeds via the win32 API).
+#[inline]
+fn libc_exdev() -> i32 {
+    18
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    /// Env-touching tests must serialize: `std::env::set_var` is process-global.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    // ── name validation ──────────────────────────────────────────────────
+
+    #[test]
+    fn validate_accepts_lowercase_alphanumeric() {
+        assert!(validate_slot_name("default").is_ok());
+        assert!(validate_slot_name("e5").is_ok());
+        assert!(validate_slot_name("bge_large").is_ok());
+        assert!(validate_slot_name("v9-200k").is_ok());
+        assert!(validate_slot_name("a1b2c3").is_ok());
+        assert!(validate_slot_name("a").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_uppercase() {
+        assert!(matches!(
+            validate_slot_name("E5"),
+            Err(SlotError::InvalidCharacters(_))
+        ));
+        assert!(matches!(
+            validate_slot_name("Default"),
+            Err(SlotError::InvalidCharacters(_))
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_spaces_and_punct() {
+        for bad in ["my slot", "my.slot", "my/slot", "my!slot", "slot."] {
+            assert!(
+                matches!(
+                    validate_slot_name(bad),
+                    Err(SlotError::InvalidCharacters(_))
+                ),
+                "should reject {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_empty() {
+        assert!(matches!(validate_slot_name(""), Err(SlotError::EmptyName)));
+    }
+
+    #[test]
+    fn validate_rejects_too_long() {
+        let n = "a".repeat(33);
+        assert!(matches!(
+            validate_slot_name(&n),
+            Err(SlotError::NameTooLong { .. })
+        ));
+        let max = "b".repeat(32);
+        assert!(validate_slot_name(&max).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_reserved() {
+        for r in RESERVED_SLOT_NAMES {
+            assert!(
+                matches!(validate_slot_name(r), Err(SlotError::Reserved(_))),
+                "{r} should be reserved"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_allows_default_keyword() {
+        // `default` is NOT in RESERVED_SLOT_NAMES even though migration claims
+        // it. Explicit `cqs slot create default` is allowed for parity.
+        assert!(validate_slot_name(DEFAULT_SLOT).is_ok());
+    }
+
+    // ── path helpers ─────────────────────────────────────────────────────
+
+    #[test]
+    fn slot_dir_paths() {
+        let cqs = Path::new("/proj/.cqs");
+        assert_eq!(
+            slot_dir(cqs, "default"),
+            Path::new("/proj/.cqs/slots/default")
+        );
+        assert_eq!(slot_dir(cqs, "e5"), Path::new("/proj/.cqs/slots/e5"));
+        assert_eq!(slots_root(cqs), Path::new("/proj/.cqs/slots"));
+        assert_eq!(active_slot_path(cqs), Path::new("/proj/.cqs/active_slot"));
+    }
+
+    // ── active_slot read / write ─────────────────────────────────────────
+
+    #[test]
+    fn read_active_slot_missing_returns_none() {
+        let dir = TempDir::new().unwrap();
+        assert!(read_active_slot(dir.path()).is_none());
+    }
+
+    #[test]
+    fn write_then_read_round_trip() {
+        let dir = TempDir::new().unwrap();
+        write_active_slot(dir.path(), "e5").unwrap();
+        assert_eq!(read_active_slot(dir.path()).as_deref(), Some("e5"));
+    }
+
+    #[test]
+    fn read_handles_corrupt_active_slot() {
+        let dir = TempDir::new().unwrap();
+        let path = active_slot_path(dir.path());
+        // Write garbage bytes (non-UTF8 + invalid even if UTF8 was OK).
+        fs::write(&path, b"NOT A VALID slot \xFF\xFE").unwrap();
+        assert!(read_active_slot(dir.path()).is_none());
+    }
+
+    #[test]
+    fn write_rejects_invalid_name() {
+        let dir = TempDir::new().unwrap();
+        assert!(write_active_slot(dir.path(), "BadName").is_err());
+        assert!(write_active_slot(dir.path(), "active").is_err()); // reserved
+    }
+
+    // ── list_slots ───────────────────────────────────────────────────────
+
+    #[test]
+    fn list_slots_empty_when_dir_missing() {
+        let dir = TempDir::new().unwrap();
+        let names = list_slots(dir.path()).unwrap();
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn list_slots_returns_sorted_names() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path();
+        for n in ["e5", "default", "bge"] {
+            fs::create_dir_all(slot_dir(cqs, n)).unwrap();
+        }
+        // Random non-slot dir we should ignore.
+        fs::create_dir_all(slots_root(cqs).join("CamelCase")).unwrap();
+        let names = list_slots(cqs).unwrap();
+        assert_eq!(names, vec!["bge", "default", "e5"]);
+    }
+
+    // ── resolve_slot_name ────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_flag_wins() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        write_active_slot(dir.path(), "fromfile").unwrap();
+        std::env::set_var("CQS_SLOT", "fromenv");
+        let r = resolve_slot_name(Some("fromflag"), dir.path()).unwrap();
+        std::env::remove_var("CQS_SLOT");
+        assert_eq!(r.name, "fromflag");
+        assert_eq!(r.source, SlotSource::Flag);
+    }
+
+    #[test]
+    fn resolve_env_when_no_flag() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        write_active_slot(dir.path(), "fromfile").unwrap();
+        std::env::set_var("CQS_SLOT", "fromenv");
+        let r = resolve_slot_name(None, dir.path()).unwrap();
+        std::env::remove_var("CQS_SLOT");
+        assert_eq!(r.name, "fromenv");
+        assert_eq!(r.source, SlotSource::Env);
+    }
+
+    #[test]
+    fn resolve_file_when_no_flag_no_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        write_active_slot(dir.path(), "fromfile").unwrap();
+        std::env::remove_var("CQS_SLOT");
+        let r = resolve_slot_name(None, dir.path()).unwrap();
+        assert_eq!(r.name, "fromfile");
+        assert_eq!(r.source, SlotSource::File);
+    }
+
+    #[test]
+    fn resolve_fallback_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        std::env::remove_var("CQS_SLOT");
+        let r = resolve_slot_name(None, dir.path()).unwrap();
+        assert_eq!(r.name, DEFAULT_SLOT);
+        assert_eq!(r.source, SlotSource::Fallback);
+    }
+
+    #[test]
+    fn resolve_rejects_invalid_flag() {
+        let dir = TempDir::new().unwrap();
+        let err = resolve_slot_name(Some("BAD"), dir.path()).unwrap_err();
+        assert!(matches!(err, SlotError::InvalidCharacters(_)));
+    }
+
+    // ── migrate_legacy_index_to_default_slot ─────────────────────────────
+
+    #[test]
+    fn migrate_noop_when_no_legacy() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        fs::create_dir_all(&cqs).unwrap();
+        let did = migrate_legacy_index_to_default_slot(&cqs).unwrap();
+        assert!(!did);
+        assert!(!slots_root(&cqs).exists());
+    }
+
+    #[test]
+    fn migrate_moves_legacy_to_default() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        fs::create_dir_all(&cqs).unwrap();
+        // Plant fake artifacts.
+        fs::write(cqs.join("index.db"), b"db-data").unwrap();
+        fs::write(cqs.join("index.hnsw.data"), b"hnsw-data").unwrap();
+        fs::write(cqs.join("index.hnsw.graph"), b"hnsw-graph").unwrap();
+        fs::write(cqs.join("splade.index.bin"), b"splade").unwrap();
+
+        let did = migrate_legacy_index_to_default_slot(&cqs).unwrap();
+        assert!(did);
+
+        // Now slots/default/ contains them
+        let default = slot_dir(&cqs, DEFAULT_SLOT);
+        assert!(default.join("index.db").exists());
+        assert!(default.join("index.hnsw.data").exists());
+        assert!(default.join("index.hnsw.graph").exists());
+        assert!(default.join("splade.index.bin").exists());
+
+        // Originals gone
+        assert!(!cqs.join("index.db").exists());
+        assert!(!cqs.join("index.hnsw.data").exists());
+        assert!(!cqs.join("splade.index.bin").exists());
+
+        // Active slot pointer is in place
+        assert_eq!(read_active_slot(&cqs).as_deref(), Some(DEFAULT_SLOT));
+    }
+
+    #[test]
+    fn migrate_idempotent_on_second_run() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        fs::create_dir_all(&cqs).unwrap();
+        fs::write(cqs.join("index.db"), b"db-data").unwrap();
+
+        assert!(migrate_legacy_index_to_default_slot(&cqs).unwrap());
+        // Second run: slots/ exists, must skip cleanly.
+        assert!(!migrate_legacy_index_to_default_slot(&cqs).unwrap());
+    }
+
+    #[test]
+    fn migrate_skipped_when_slots_already_present() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        fs::create_dir_all(slots_root(&cqs).join("foo")).unwrap();
+        // Plant a legacy file too — should NOT be moved (slots/ already there).
+        fs::write(cqs.join("index.db"), b"db-data").unwrap();
+        assert!(!migrate_legacy_index_to_default_slot(&cqs).unwrap());
+        assert!(cqs.join("index.db").exists());
+    }
+}

--- a/tests/model_swap_test.rs
+++ b/tests/model_swap_test.rs
@@ -153,16 +153,19 @@ fn test_model_swap_same_preset_is_noop() {
     seed_store(&dir, "BAAI/bge-large-en-v1.5", 1024);
 
     let cqs_dir = dir.path().join(".cqs");
-    let index_db = cqs_dir.join(cqs::INDEX_DB_FILENAME);
-    // Use the index.db file itself as the "did anything destructive
-    // happen?" signal. Opening the store touches WAL/SHM siblings which
-    // bumps the directory mtime — those don't indicate a swap actually
-    // ran. The DB file mtime only changes on a real reindex pass.
-    let db_mtime_before = fs::metadata(&index_db)
+    // First cqs invocation will run the slot migration, atomically
+    // renaming index.db from `.cqs/index.db` to
+    // `.cqs/slots/default/index.db`. The atomic rename preserves mtime
+    // and size, so the pre/post comparison still detects a destructive
+    // swap (which would change both). Use `resolve_index_db` at each
+    // stat point so we follow the file across the migration.
+    let db_mtime_before = fs::metadata(cqs::resolve_index_db(&cqs_dir))
         .expect("stat index.db")
         .modified()
         .ok();
-    let db_size_before = fs::metadata(&index_db).expect("stat index.db").len();
+    let db_size_before = fs::metadata(cqs::resolve_index_db(&cqs_dir))
+        .expect("stat index.db")
+        .len();
 
     let result = cqs_no_daemon()
         .args(["model", "swap", "bge-large", "--json"])
@@ -188,16 +191,21 @@ fn test_model_swap_same_preset_is_noop() {
     );
 
     // index.db must be the same file (size + mtime unchanged) — no
-    // backup-and-recreate happened.
+    // backup-and-recreate happened. Use `resolve_index_db` again here
+    // because the file has been migrated into `.cqs/slots/default/`.
+    let index_db_after_path = cqs::resolve_index_db(&cqs_dir);
     assert!(
-        index_db.exists(),
-        ".cqs/index.db must still exist after no-op swap"
+        index_db_after_path.exists(),
+        "index.db must still exist after no-op swap (resolved at {})",
+        index_db_after_path.display()
     );
-    let db_mtime_after = fs::metadata(&index_db)
+    let db_mtime_after = fs::metadata(&index_db_after_path)
         .expect("stat index.db after")
         .modified()
         .ok();
-    let db_size_after = fs::metadata(&index_db).expect("stat index.db after").len();
+    let db_size_after = fs::metadata(&index_db_after_path)
+        .expect("stat index.db after")
+        .len();
     assert_eq!(
         db_mtime_before, db_mtime_after,
         "index.db mtime must not change on no-op swap. before={db_mtime_before:?} after={db_mtime_after:?}"
@@ -225,7 +233,10 @@ fn test_model_swap_unknown_preset_errors() {
     seed_store(&dir, "BAAI/bge-large-en-v1.5", 1024);
 
     let cqs_dir = dir.path().join(".cqs");
-    let index_db_before = fs::metadata(cqs_dir.join(cqs::INDEX_DB_FILENAME))
+    // Pre-cqs: file is still at `.cqs/index.db` (migration runs on first
+    // cqs invocation below). `resolve_index_db` falls back to the legacy
+    // path when slots/default/index.db doesn't exist yet.
+    let index_db_before = fs::metadata(cqs::resolve_index_db(&cqs_dir))
         .expect("stat index.db")
         .len();
 
@@ -267,7 +278,10 @@ fn test_model_swap_unknown_preset_errors() {
 
     // Original index untouched — pre-flight validation runs before any
     // backup or rename.
-    let index_db_after = fs::metadata(cqs_dir.join(cqs::INDEX_DB_FILENAME))
+    // Post-cqs: file lives at `.cqs/slots/default/index.db` after the
+    // dispatch-time migration ran (even though the swap itself failed
+    // pre-flight, the migration is unconditional).
+    let index_db_after = fs::metadata(cqs::resolve_index_db(&cqs_dir))
         .expect("stat index.db after failed swap")
         .len();
     assert_eq!(

--- a/tests/slots_and_cache_integration.rs
+++ b/tests/slots_and_cache_integration.rs
@@ -1,0 +1,282 @@
+//! Integration tests for slot + embeddings cache (spec
+//! `docs/plans/2026-04-24-embeddings-cache-and-slots.md`).
+//!
+//! These tests exercise the FS layout and orchestration logic without
+//! invoking the binary CLI — the slot helpers in `cqs::slot` and the
+//! cache helpers in `cqs::cache` are callable from test code directly,
+//! and that's enough to cover the integration concerns spec'd in
+//! §Testing (items 13–28).
+
+use std::fs;
+use std::path::Path;
+
+use cqs::cache::EmbeddingCache;
+use cqs::slot::{
+    active_slot_path, list_slots, migrate_legacy_index_to_default_slot, read_active_slot,
+    resolve_slot_name, slot_dir, write_active_slot, DEFAULT_SLOT,
+};
+
+/// §Testing #21 — `active_slot` references a missing slot dir → resolution
+/// should still produce SOMETHING usable. Today: caller resolves to whatever
+/// the file says; concrete error happens when `Store::open` is attempted.
+/// This exercises the resolve_slot_name path.
+#[test]
+fn active_slot_references_missing_dir_resolution_succeeds_but_dir_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let cqs = dir.path().join(".cqs");
+    fs::create_dir_all(&cqs).unwrap();
+    write_active_slot(&cqs, "missing").unwrap();
+    let r = resolve_slot_name(None, &cqs).unwrap();
+    assert_eq!(r.name, "missing");
+    // Validate the slot dir does not exist — caller's responsibility to
+    // produce an actionable error when opening `Store` against this path.
+    assert!(!slot_dir(&cqs, &r.name).exists());
+}
+
+/// §Testing #25 — surface area smoke for the rollback path: when migration
+/// itself succeeds, all source files are moved AND the active_slot pointer
+/// is written. Disk-full mid-migration is harder to fault-inject portably
+/// (the EXDEV branch is exercised by [`std::fs::rename`] cross-FS calls,
+/// not reproducible from a tempfile), so this test instead verifies the
+/// happy path is fully consistent.
+#[test]
+fn migration_succeeds_then_all_files_moved_and_pointer_written() {
+    let dir = tempfile::tempdir().unwrap();
+    let cqs = dir.path().join(".cqs");
+    fs::create_dir_all(&cqs).unwrap();
+    fs::write(cqs.join("index.db"), b"db-data").unwrap();
+    fs::write(cqs.join("index.hnsw.data"), b"hnsw-data").unwrap();
+    fs::write(cqs.join("index.hnsw.graph"), b"hnsw-graph").unwrap();
+    fs::write(cqs.join("splade.index.bin"), b"splade").unwrap();
+
+    let did = migrate_legacy_index_to_default_slot(&cqs).unwrap();
+    assert!(did);
+
+    let dest = slot_dir(&cqs, DEFAULT_SLOT);
+    for n in [
+        "index.db",
+        "index.hnsw.data",
+        "index.hnsw.graph",
+        "splade.index.bin",
+    ] {
+        assert!(dest.join(n).exists(), "{n} should be in slots/default/");
+        assert!(!cqs.join(n).exists(), "{n} should NOT remain in .cqs/ root");
+    }
+    assert_eq!(read_active_slot(&cqs).as_deref(), Some(DEFAULT_SLOT));
+}
+
+/// §Testing #18 — cache holds (chunk_hash, model_id) pairs across slots.
+/// Two slots with the same model_id and overlapping chunks share entries.
+#[test]
+fn cache_shared_across_slots_for_same_model_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_path = EmbeddingCache::project_default_path(dir.path());
+    let cache = EmbeddingCache::open(&cache_path).unwrap();
+
+    // Pretend slot "a" embeds 5 chunks with model "bge".
+    let entries: Vec<(String, Vec<f32>)> = (0..5)
+        .map(|i| (format!("h{i}"), vec![i as f32, 0.0, 0.0]))
+        .collect();
+    cache.write_batch_owned(&entries, "bge", 3).unwrap();
+
+    // Slot "b" with the same model_id queries the same hashes; partition
+    // returns hits for ALL of them — no re-embed needed.
+    let items: Vec<&str> = (0..5)
+        .map(|i| Box::leak(format!("h{i}").into_boxed_str()) as &str)
+        .collect();
+    let (cached, missed) = cache.partition(&items, "bge", 3, |s: &&str| *s).unwrap();
+    assert_eq!(cached.len(), 5);
+    assert!(missed.is_empty());
+}
+
+/// §Testing #20 — `prune_by_model` only removes entries for the named model.
+#[test]
+fn cache_prune_by_model_isolated() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_path = EmbeddingCache::project_default_path(dir.path());
+    let cache = EmbeddingCache::open(&cache_path).unwrap();
+    let entries: Vec<(String, Vec<f32>)> = (0..3)
+        .map(|i| (format!("hh{i}"), vec![i as f32; 4]))
+        .collect();
+    cache.write_batch_owned(&entries, "alpha", 4).unwrap();
+    cache.write_batch_owned(&entries, "beta", 4).unwrap();
+
+    let removed = cache.prune_by_model("alpha").unwrap();
+    assert_eq!(removed, 3);
+
+    // beta survives
+    let stats = cache.stats_per_model().unwrap();
+    assert_eq!(stats.len(), 1);
+    assert_eq!(stats[0].model_id, "beta");
+}
+
+/// §Testing #19 — `cqs cache stats` reflects entries after writing.
+#[test]
+fn cache_stats_reflect_inserted_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_path = EmbeddingCache::project_default_path(dir.path());
+    let cache = EmbeddingCache::open(&cache_path).unwrap();
+    let entries: Vec<(String, Vec<f32>)> = (0..7)
+        .map(|i| (format!("z{i}"), vec![i as f32; 8]))
+        .collect();
+    cache.write_batch_owned(&entries, "model_q", 8).unwrap();
+    let s = cache.stats().unwrap();
+    assert_eq!(s.total_entries, 7);
+    assert_eq!(s.unique_models, 1);
+}
+
+/// §Testing #15 — incremental reindex flow: cache hits on a re-run with
+/// identical content produce 100% hit rate.
+#[test]
+fn cache_partition_full_hit_on_identical_rerun() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_path = EmbeddingCache::project_default_path(dir.path());
+    let cache = EmbeddingCache::open(&cache_path).unwrap();
+
+    // First run: embed.
+    let entries: Vec<(String, Vec<f32>)> = (0..50)
+        .map(|i| (format!("c{i}"), vec![i as f32; 16]))
+        .collect();
+    cache.write_batch_owned(&entries, "m1", 16).unwrap();
+
+    // Second run: same hashes, same model — partition reports 100% hits.
+    let items: Vec<String> = (0..50).map(|i| format!("c{i}")).collect();
+    let item_refs: Vec<&str> = items.iter().map(|s| s.as_str()).collect();
+    let (cached, missed) = cache
+        .partition(&item_refs, "m1", 16, |s: &&str| *s)
+        .unwrap();
+    assert_eq!(cached.len(), 50);
+    assert!(missed.is_empty());
+}
+
+/// Slot listing produces sorted, validated names — even if a junk dir is
+/// dropped under `.cqs/slots/`.
+#[test]
+fn slot_list_filters_invalid_dir_names() {
+    let dir = tempfile::tempdir().unwrap();
+    let cqs = dir.path().join(".cqs");
+    for n in ["good_one", "good-two"] {
+        fs::create_dir_all(slot_dir(&cqs, n)).unwrap();
+    }
+    fs::create_dir_all(cqs.join("slots").join("BadName")).unwrap();
+    fs::create_dir_all(cqs.join("slots").join("with space")).unwrap();
+    let names = list_slots(&cqs).unwrap();
+    assert_eq!(names, vec!["good-two".to_string(), "good_one".to_string()]);
+}
+
+/// §Testing #16 — two slots with different dims peacefully coexist on disk.
+/// (Can't easily verify HNSW size differential without running the indexer,
+/// but the FS structure must support it.)
+#[test]
+fn slot_dirs_can_hold_independent_index_dbs() {
+    let dir = tempfile::tempdir().unwrap();
+    let cqs = dir.path().join(".cqs");
+    let bge = slot_dir(&cqs, "bge");
+    let e5 = slot_dir(&cqs, "e5");
+    fs::create_dir_all(&bge).unwrap();
+    fs::create_dir_all(&e5).unwrap();
+    fs::write(bge.join(cqs::INDEX_DB_FILENAME), b"fake-bge-data").unwrap();
+    fs::write(e5.join(cqs::INDEX_DB_FILENAME), b"fake-e5-data").unwrap();
+
+    write_active_slot(&cqs, "bge").unwrap();
+    let r = resolve_slot_name(None, &cqs).unwrap();
+    assert_eq!(r.name, "bge");
+
+    write_active_slot(&cqs, "e5").unwrap();
+    let r = resolve_slot_name(None, &cqs).unwrap();
+    assert_eq!(r.name, "e5");
+}
+
+/// §Testing #27 — concurrent promote: two writes serialize via atomic
+/// rename. After both calls return, the file content is from the last
+/// call. This test simulates back-to-back promotes.
+#[test]
+fn concurrent_promote_last_writer_wins() {
+    let dir = tempfile::tempdir().unwrap();
+    let cqs = dir.path().join(".cqs");
+    fs::create_dir_all(slot_dir(&cqs, "x")).unwrap();
+    fs::create_dir_all(slot_dir(&cqs, "y")).unwrap();
+    write_active_slot(&cqs, "x").unwrap();
+    write_active_slot(&cqs, "y").unwrap();
+    write_active_slot(&cqs, "x").unwrap();
+    write_active_slot(&cqs, "y").unwrap();
+    assert_eq!(read_active_slot(&cqs).as_deref(), Some("y"));
+}
+
+/// active_slot pointer atomic write: writing should not leave a partial
+/// `.tmp` file in place when the write succeeds.
+#[test]
+fn active_slot_write_cleans_up_tmp() {
+    let dir = tempfile::tempdir().unwrap();
+    let cqs = dir.path().join(".cqs");
+    write_active_slot(&cqs, "abc").unwrap();
+    assert_eq!(read_active_slot(&cqs).as_deref(), Some("abc"));
+    let tmp = cqs.join("active_slot.tmp");
+    assert!(!tmp.exists(), "tmp file leaked: {}", tmp.display());
+}
+
+/// `active_slot_path` matches what `read_active_slot` reads from.
+#[test]
+fn active_slot_path_round_trips() {
+    let dir = tempfile::tempdir().unwrap();
+    let cqs = dir.path().join(".cqs");
+    fs::create_dir_all(&cqs).unwrap();
+    let p = active_slot_path(&cqs);
+    assert_eq!(p, cqs.join("active_slot"));
+    fs::write(&p, b"manual_write").unwrap();
+    assert_eq!(read_active_slot(&cqs).as_deref(), Some("manual_write"));
+}
+
+/// Migration finalizes by writing `active_slot = "default"`.
+#[test]
+fn migration_writes_active_slot_pointer() {
+    let dir = tempfile::tempdir().unwrap();
+    let cqs = dir.path().join(".cqs");
+    fs::create_dir_all(&cqs).unwrap();
+    fs::write(cqs.join(cqs::INDEX_DB_FILENAME), b"data").unwrap();
+    let did = migrate_legacy_index_to_default_slot(&cqs).unwrap();
+    assert!(did);
+    assert_eq!(read_active_slot(&cqs).as_deref(), Some(DEFAULT_SLOT));
+}
+
+/// `cqs::resolve_slot_dir` is a public, idempotent path computation.
+#[test]
+fn resolve_slot_dir_matches_internal_helper() {
+    let p = cqs::resolve_slot_dir(Path::new("/proj/.cqs"), "alpha");
+    assert_eq!(p, Path::new("/proj/.cqs/slots/alpha"));
+}
+
+/// `EmbeddingCache::project_default_path` returns the spec's sibling layout.
+#[test]
+fn embeddings_cache_project_default_path_in_cqs_dir() {
+    let p = EmbeddingCache::project_default_path(Path::new("/proj/.cqs"));
+    assert_eq!(p, Path::new("/proj/.cqs/embeddings_cache.db"));
+}
+
+/// `partition` against an empty slice should not fault even when the cache
+/// has unrelated entries.
+#[test]
+fn cache_partition_empty_input_does_not_touch_db() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_path = EmbeddingCache::project_default_path(dir.path());
+    let cache = EmbeddingCache::open(&cache_path).unwrap();
+    cache
+        .write_batch_owned(&[("h".to_string(), vec![1.0; 4])], "anything", 4)
+        .unwrap();
+    let items: Vec<&str> = Vec::new();
+    let (c, m) = cache
+        .partition(&items, "anything", 4, |s: &&str| *s)
+        .unwrap();
+    assert!(c.is_empty());
+    assert!(m.is_empty());
+}
+
+/// `cache.compact()` is idempotent and survives re-runs on an empty cache.
+#[test]
+fn cache_compact_idempotent_on_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_path = EmbeddingCache::project_default_path(dir.path());
+    let cache = EmbeddingCache::open(&cache_path).unwrap();
+    cache.compact().unwrap();
+    cache.compact().unwrap();
+}


### PR DESCRIPTION
## Summary

- Named slots — `.cqs/slots/<name>/` self-contained indexes, switch via pointer instead of destructive reindex
- Project-scoped embeddings cache — `(content_hash, model_id)` blob keyed, eliminates re-embed cost on rebuilds + add-only edits
- New CLI surface: `cqs slot {list,create,promote,remove,active}` + `cqs cache {stats,prune,compact}` + global `--slot <name>` flag
- Idempotent one-shot migration `.cqs/index.db` → `.cqs/slots/default/`, runs at the top of dispatch (and again inside `cqs index`/`cqs watch` for daemon-only invocations)
- Daemon binds to whichever slot was active at startup; `cqs slot promote` prints a restart hint
- `cqs doctor` gains a Slots section
- Wiring fixes for cross-cut paths that bypass `CommandContext` (`cqs serve`, `cqs notes`, `cqs diff`, `cqs drift`, `cqs model show`, batch resume, cross-project search, reference resolution) — all now route through new `cqs::resolve_index_db()` which honors slot resolution and falls back to legacy `.cqs/index.db` for unmigrated cross-project entries / refs

## Why

Embedder A/Bs (BGE vs E5 vs v9-200k) are currently destructive — `cqs index --model e5-base` overwrites BGE, and `cqs --model bge-large` to roll back triggers a full reindex. With slots, both live side-by-side under one project; promote/demote is O(1) pointer flip. The cache stops re-embedding 16k chunks every time a slot is rebuilt.

## Numbers

- +61 new tests (23 slot lib + 8 cache lib + 13 slot subcommand + 16 integration)
- 1736 lib + 574 bin + 16 integration tests pass with `--features gpu-index`
- Smoke against the cqs project itself: legacy `.cqs/index.db` migrated cleanly, 16,845 chunks queryable from `.cqs/slots/default/`

## Schema

Unchanged at v22. Slot migration is filesystem-only; embeddings_cache.db is its own SQLite file with `CREATE TABLE IF NOT EXISTS`.

## Spec

`docs/plans/2026-04-24-embeddings-cache-and-slots.md`

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features gpu-index --lib --bin cqs` clean
- [x] `cargo test --features gpu-index --lib --bin cqs --test slots_and_cache_integration` green
- [x] Live migration on cqs-on-cqs project (16,845 chunks moved, search returns results)
- [x] `cqs slot list/create/promote/remove/active` exercised end-to-end
- [x] `cqs cache stats --json` returns project-scoped path
- [ ] CI green
- [ ] Once merged: paired-reindex E5 A/B against BGE under sibling slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)
