### PR TITLE
fix(test): stabilize hnsw::test_build_batched (top-5 → top-10)

### DIFF
--- a/src/hnsw/build.rs
+++ b/src/hnsw/build.rs
@@ -301,11 +301,16 @@ mod tests {
                 .unwrap();
         assert_eq!(index.len(), 25);
 
-        // Search should work correctly
+        // Search should work correctly. Top-10 (not top-5) for the same
+        // reason `test_build_batched_vs_regular_equivalence` uses top-10:
+        // HNSW batched builds on small N (25 here) have suboptimal recall —
+        // the unseeded random projections occasionally bump the matching
+        // chunk out of a top-5 window. Issue #1104 surfaced this as a CI
+        // flake; the test exists to verify batched-build wiring round-trips
+        // the right item, not to assert perfect recall.
         let query = make_embedding(1);
-        let results = index.search(&query, 5);
+        let results = index.search(&query, 10);
         assert!(!results.is_empty());
-        // chunk1 should be in top results
         assert!(results.iter().any(|r| r.id == "chunk1"));
     }
 


### PR DESCRIPTION
## Summary

- Loosens `hnsw::build::tests::test_build_batched` from top-5 to top-10 of 25 items
- Aligns with sibling `test_build_batched_vs_regular_equivalence` (already top-10 of 20)
- 30/30 local runs green with the new bound (prior top-5 flaked ~1/20)

## Root cause

HNSW batched builds on small N have suboptimal recall — `hnsw_rs`'s unseeded random projections occasionally bump the matching chunk out of a top-5 window. The test exists to verify batched-build wiring round-trips the right item, not to assert perfect recall — top-10 of 25 is a faithful window for that.

## Reference

- CI flake: https://github.com/jamie8johnson/cqs/actions/runs/24914810819/job/72964547701
- Issue: #1104

Closes #1104.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo test --lib hnsw::` green (50 passed)
- [x] 30 consecutive runs of `hnsw::build::tests::test_build_batched` all green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
