### PR TITLE
chore(evals): refresh v3.v2 fixture line_starts after v1.29.x audits

### DIFF
--- a/evals/queries/v3_dev.v2.json
+++ b/evals/queries/v3_dev.v2.json
@@ -148,8 +148,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 24,
-        "line_end": 27
+        "line_start": 27,
+        "line_end": 30
       },
       "gold_chunk_source": "consensus"
     },
@@ -205,8 +205,8 @@
         "origin": "src/cagra.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 471,
-        "line_end": 580
+        "line_start": 490,
+        "line_end": 599
       },
       "gold_chunk_source": "consensus"
     },
@@ -273,8 +273,8 @@
         "origin": "src/cache.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 51,
-        "line_end": 506
+        "line_start": 57,
+        "line_end": 538
       },
       "gold_chunk_source": "consensus"
     },
@@ -405,8 +405,8 @@
         "origin": "src/cli/args.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 518,
-        "line_end": 525
+        "line_start": 534,
+        "line_end": 541
       },
       "gold_chunk_source": "consensus"
     },
@@ -473,8 +473,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 175,
-        "line_end": 182
+        "line_start": 180,
+        "line_end": 187
       },
       "gold_chunk_source": "consensus"
     },
@@ -590,8 +590,8 @@
         "origin": "src/cli/store.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 247,
-        "line_end": 402
+        "line_start": 316,
+        "line_end": 469
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -1133,8 +1133,8 @@
         "origin": "src/hnsw/persist.rs",
         "language": "rust",
         "chunk_type": "typealias",
-        "line_start": 753,
-        "line_end": 753
+        "line_start": 849,
+        "line_end": 849
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -1259,8 +1259,8 @@
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 4655,
-        "line_end": 4674
+        "line_start": 4662,
+        "line_end": 4681
       },
       "gold_chunk_source": "consensus"
     },
@@ -1320,8 +1320,8 @@
         "origin": "evals/generate_from_chunks.py",
         "language": "python",
         "chunk_type": "function",
-        "line_start": 210,
-        "line_end": 274
+        "line_start": 216,
+        "line_end": 286
       },
       "gold_chunk_source": "consensus"
     },
@@ -1585,8 +1585,8 @@
         "origin": "src/cache.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 982,
-        "line_end": 986
+        "line_start": 1052,
+        "line_end": 1056
       },
       "gold_chunk_source": "consensus"
     },
@@ -1649,8 +1649,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 131,
-        "line_end": 135
+        "line_start": 136,
+        "line_end": 140
       },
       "gold_chunk_source": "consensus"
     },
@@ -1783,8 +1783,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 64,
-        "line_end": 71
+        "line_start": 69,
+        "line_end": 76
       },
       "gold_chunk_source": "consensus"
     },
@@ -2151,8 +2151,8 @@
         "origin": "evals/run_ablation.py",
         "language": "python",
         "chunk_type": "function",
-        "line_start": 155,
-        "line_end": 183
+        "line_start": 153,
+        "line_end": 181
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -2644,8 +2644,8 @@
         "origin": "src/hnsw/persist.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 172,
-        "line_end": 860
+        "line_start": 191,
+        "line_end": 956
       },
       "gold_chunk_source": "consensus"
     },
@@ -2890,8 +2890,8 @@
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 4092,
-        "line_end": 4113
+        "line_start": 4099,
+        "line_end": 4120
       },
       "gold_chunk_source": "consensus"
     },
@@ -3076,8 +3076,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 64,
-        "line_end": 71
+        "line_start": 69,
+        "line_end": 76
       },
       "gold_chunk_source": "consensus"
     },
@@ -3262,8 +3262,8 @@
         "origin": "src/cli/watch.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 2022,
-        "line_end": 2112
+        "line_start": 2096,
+        "line_end": 2186
       },
       "gold_chunk_source": "consensus"
     },
@@ -3330,8 +3330,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 64,
-        "line_end": 71
+        "line_start": 69,
+        "line_end": 76
       },
       "gold_chunk_source": "consensus"
     },
@@ -3457,8 +3457,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 64,
-        "line_end": 71
+        "line_start": 69,
+        "line_end": 76
       },
       "gold_chunk_source": "consensus"
     },
@@ -3591,8 +3591,8 @@
         "origin": "src/parser/mod.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 257,
-        "line_end": 409
+        "line_start": 265,
+        "line_end": 417
       },
       "gold_chunk_source": "consensus"
     },
@@ -3659,8 +3659,8 @@
         "origin": "src/search/router.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 549,
-        "line_end": 691
+        "line_start": 561,
+        "line_end": 576
       },
       "gold_chunk_source": "consensus"
     },
@@ -3720,8 +3720,8 @@
         "origin": "src/store/sparse.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 230,
-        "line_end": 317
+        "line_start": 294,
+        "line_end": 381
       },
       "gold_chunk_source": "consensus"
     },
@@ -4106,8 +4106,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 103,
-        "line_end": 110
+        "line_start": 108,
+        "line_end": 115
       },
       "gold_chunk_source": "consensus"
     },
@@ -4174,8 +4174,8 @@
         "origin": "src/store/migrations.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 291,
-        "line_end": 305
+        "line_start": 295,
+        "line_end": 309
       },
       "gold_chunk_source": "consensus"
     },
@@ -4310,8 +4310,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 131,
-        "line_end": 135
+        "line_start": 136,
+        "line_end": 140
       },
       "gold_chunk_source": "consensus"
     },
@@ -4374,8 +4374,8 @@
         "origin": "src/cagra.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 471,
-        "line_end": 580
+        "line_start": 490,
+        "line_end": 599
       },
       "gold_chunk_source": "consensus"
     },
@@ -4440,8 +4440,8 @@
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 8217,
-        "line_end": 8237
+        "line_start": 8230,
+        "line_end": 8250
       },
       "gold_chunk_source": "consensus"
     },
@@ -4814,8 +4814,8 @@
         "origin": "src/impact/analysis.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 419,
-        "line_end": 496
+        "line_start": 433,
+        "line_end": 515
       },
       "gold_chunk_source": "consensus"
     },
@@ -4989,8 +4989,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 22,
-        "line_end": 45
+        "line_start": 32,
+        "line_end": 58
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -5119,8 +5119,8 @@
         "origin": "src/store/sparse.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 321,
-        "line_end": 323
+        "line_start": 385,
+        "line_end": 387
       },
       "gold_chunk_source": "consensus"
     },
@@ -5244,8 +5244,8 @@
         "origin": "src/cli/commands/resolve.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 28,
-        "line_end": 41
+        "line_start": 26,
+        "line_end": 39
       },
       "gold_chunk_source": "consensus"
     },
@@ -5310,8 +5310,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 74,
-        "line_end": 80
+        "line_start": 79,
+        "line_end": 85
       },
       "gold_chunk_source": "consensus"
     },
@@ -5376,8 +5376,8 @@
         "origin": "src/search/router.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 367,
-        "line_end": 369
+        "line_start": 379,
+        "line_end": 381
       },
       "gold_chunk_source": "consensus"
     },
@@ -5562,8 +5562,8 @@
         "origin": "src/cagra.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 471,
-        "line_end": 580
+        "line_start": 490,
+        "line_end": 599
       },
       "gold_chunk_source": "consensus"
     },
@@ -5685,8 +5685,8 @@
         "origin": "src/cli/watch.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 1170,
-        "line_end": 2019
+        "line_start": 1216,
+        "line_end": 2093
       },
       "gold_chunk_source": "consensus"
     },
@@ -5812,8 +5812,8 @@
         "origin": "src/cli/watch.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 2118,
-        "line_end": 2358
+        "line_start": 2192,
+        "line_end": 2434
       },
       "gold_chunk_source": "consensus"
     },
@@ -5932,8 +5932,8 @@
         "origin": "src/embedder/mod.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 349,
-        "line_end": 423
+        "line_start": 372,
+        "line_end": 446
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -6001,8 +6001,8 @@
         "origin": "src/reranker.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 487,
-        "line_end": 512
+        "line_start": 514,
+        "line_end": 539
       },
       "gold_chunk_source": "consensus"
     },
@@ -6198,8 +6198,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 142,
-        "line_end": 148
+        "line_start": 147,
+        "line_end": 153
       },
       "gold_chunk_source": "consensus"
     },
@@ -6450,8 +6450,8 @@
         "origin": "src/cache.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 404,
-        "line_end": 461
+        "line_start": 456,
+        "line_end": 493
       },
       "gold_chunk_source": "consensus"
     },
@@ -6516,8 +6516,8 @@
         "origin": "src/cli/batch/mod.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 222,
-        "line_end": 306
+        "line_start": 218,
+        "line_end": 307
       },
       "gold_chunk_source": "consensus"
     },
@@ -6709,8 +6709,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 86,
-        "line_end": 93
+        "line_start": 91,
+        "line_end": 98
       },
       "gold_chunk_source": "consensus"
     },

--- a/evals/queries/v3_test.v2.json
+++ b/evals/queries/v3_test.v2.json
@@ -80,8 +80,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 116,
-        "line_end": 126
+        "line_start": 121,
+        "line_end": 131
       },
       "gold_chunk_source": "consensus"
     },
@@ -216,8 +216,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 142,
-        "line_end": 148
+        "line_start": 147,
+        "line_end": 153
       },
       "gold_chunk_source": "consensus"
     },
@@ -280,8 +280,8 @@
         "origin": "src/hnsw/persist.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 533,
-        "line_end": 698
+        "line_start": 599,
+        "line_end": 780
       },
       "gold_chunk_source": "consensus"
     },
@@ -396,8 +396,8 @@
         "origin": "evals/generate_from_chunks.py",
         "language": "python",
         "chunk_type": "function",
-        "line_start": 109,
-        "line_end": 156
+        "line_start": 115,
+        "line_end": 162
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -461,8 +461,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 142,
-        "line_end": 148
+        "line_start": 147,
+        "line_end": 153
       },
       "gold_chunk_source": "consensus"
     },
@@ -529,8 +529,8 @@
         "origin": "src/cli/watch.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 601,
-        "line_end": 610
+        "line_start": 603,
+        "line_end": 612
       },
       "gold_chunk_source": "consensus"
     },
@@ -658,8 +658,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 142,
-        "line_end": 148
+        "line_start": 147,
+        "line_end": 153
       },
       "gold_chunk_source": "consensus"
     },
@@ -776,8 +776,8 @@
         "origin": "src/cli/batch/handlers/info.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 93,
-        "line_end": 148
+        "line_start": 100,
+        "line_end": 155
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -911,8 +911,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 74,
-        "line_end": 80
+        "line_start": 79,
+        "line_end": 85
       },
       "gold_chunk_source": "consensus"
     },
@@ -1106,8 +1106,8 @@
         "origin": "src/hnsw/persist.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 172,
-        "line_end": 860
+        "line_start": 191,
+        "line_end": 956
       },
       "gold_chunk_source": "consensus"
     },
@@ -1419,8 +1419,8 @@
         "origin": "evals/run_ablation.py",
         "language": "python",
         "chunk_type": "function",
-        "line_start": 193,
-        "line_end": 209
+        "line_start": 191,
+        "line_end": 207
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -1986,8 +1986,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 142,
-        "line_end": 148
+        "line_start": 147,
+        "line_end": 153
       },
       "gold_chunk_source": "consensus"
     },
@@ -2054,8 +2054,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 24,
-        "line_end": 27
+        "line_start": 27,
+        "line_end": 30
       },
       "gold_chunk_source": "consensus"
     },
@@ -2111,8 +2111,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 95,
-        "line_end": 102
+        "line_start": 108,
+        "line_end": 115
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -2180,8 +2180,8 @@
         "origin": "src/cache.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 980,
-        "line_end": 1265
+        "line_start": 1050,
+        "line_end": 1369
       },
       "gold_chunk_source": "consensus"
     },
@@ -2309,8 +2309,8 @@
         "origin": "src/cli/batch/mod.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 475,
-        "line_end": 518
+        "line_start": 480,
+        "line_end": 523
       },
       "gold_chunk_source": "consensus"
     },
@@ -2436,8 +2436,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 24,
-        "line_end": 27
+        "line_start": 27,
+        "line_end": 30
       },
       "gold_chunk_source": "consensus"
     },
@@ -2622,8 +2622,8 @@
         "origin": "src/store/migrations.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 439,
-        "line_end": 448
+        "line_start": 443,
+        "line_end": 452
       },
       "gold_chunk_source": "consensus"
     },
@@ -2749,8 +2749,8 @@
         "origin": "src/embedder/models.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 320,
-        "line_end": 518
+        "line_start": 356,
+        "line_end": 559
       },
       "gold_chunk_source": "consensus"
     },
@@ -2817,8 +2817,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 24,
-        "line_end": 27
+        "line_start": 27,
+        "line_end": 30
       },
       "gold_chunk_source": "consensus"
     },
@@ -2878,8 +2878,8 @@
         "origin": "src/store/chunks/crud.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 427,
-        "line_end": 449
+        "line_start": 506,
+        "line_end": 538
       },
       "gold_chunk_source": "consensus"
     },
@@ -3007,8 +3007,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 131,
-        "line_end": 135
+        "line_start": 136,
+        "line_end": 140
       },
       "gold_chunk_source": "consensus"
     },
@@ -3376,8 +3376,8 @@
         "origin": "src/embedder/mod.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 217,
-        "line_end": 249
+        "line_start": 225,
+        "line_end": 271
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -3504,8 +3504,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 116,
-        "line_end": 126
+        "line_start": 121,
+        "line_end": 131
       },
       "gold_chunk_source": "consensus"
     },
@@ -3568,8 +3568,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 116,
-        "line_end": 126
+        "line_start": 121,
+        "line_end": 131
       },
       "gold_chunk_source": "consensus"
     },
@@ -3695,8 +3695,8 @@
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "constant",
-        "line_start": 6060,
-        "line_end": 6141
+        "line_start": 6067,
+        "line_end": 6148
       },
       "gold_chunk_source": "consensus"
     },
@@ -3763,8 +3763,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 103,
-        "line_end": 110
+        "line_start": 108,
+        "line_end": 115
       },
       "gold_chunk_source": "consensus"
     },
@@ -4083,8 +4083,8 @@
         "origin": "src/search/router.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 911,
-        "line_end": 931
+        "line_start": 950,
+        "line_end": 970
       },
       "gold_chunk_source": "consensus"
     },
@@ -4217,8 +4217,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 175,
-        "line_end": 182
+        "line_start": 180,
+        "line_end": 187
       },
       "gold_chunk_source": "consensus"
     },
@@ -4285,8 +4285,8 @@
         "origin": "src/cache.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 1103,
-        "line_end": 1151
+        "line_start": 1189,
+        "line_end": 1255
       },
       "gold_chunk_source": "consensus"
     },
@@ -4410,8 +4410,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 103,
-        "line_end": 110
+        "line_start": 108,
+        "line_end": 115
       },
       "gold_chunk_source": "consensus"
     },
@@ -4476,8 +4476,8 @@
         "origin": "src/cagra.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 241,
-        "line_end": 468
+        "line_start": 250,
+        "line_end": 257
       },
       "gold_chunk_source": "consensus"
     },
@@ -4671,8 +4671,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 131,
-        "line_end": 135
+        "line_start": 136,
+        "line_end": 140
       },
       "gold_chunk_source": "consensus"
     },
@@ -4798,8 +4798,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 86,
-        "line_end": 93
+        "line_start": 91,
+        "line_end": 98
       },
       "gold_chunk_source": "consensus"
     },
@@ -5114,8 +5114,8 @@
         "origin": "src/hnsw/persist.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 189,
-        "line_end": 519
+        "line_start": 208,
+        "line_end": 593
       },
       "gold_chunk_source": "consensus"
     },
@@ -5543,8 +5543,8 @@
         "origin": "src/convert/html.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 43,
-        "line_end": 57
+        "line_start": 45,
+        "line_end": 60
       },
       "gold_chunk_source": "consensus"
     },
@@ -5609,8 +5609,8 @@
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 4655,
-        "line_end": 4674
+        "line_start": 4662,
+        "line_end": 4681
       },
       "gold_chunk_source": "consensus"
     },
@@ -5675,8 +5675,8 @@
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 6662,
-        "line_end": 6680
+        "line_start": 6672,
+        "line_end": 6690
       },
       "gold_chunk_source": "consensus"
     },
@@ -5998,8 +5998,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 24,
-        "line_end": 27
+        "line_start": 27,
+        "line_end": 30
       },
       "gold_chunk_source": "consensus"
     },
@@ -6114,8 +6114,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 108,
-        "line_end": 118
+        "line_start": 121,
+        "line_end": 131
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -6183,8 +6183,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 74,
-        "line_end": 80
+        "line_start": 79,
+        "line_end": 85
       },
       "gold_chunk_source": "consensus"
     },
@@ -6249,8 +6249,8 @@
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 6553,
-        "line_end": 6570
+        "line_start": 6563,
+        "line_end": 6580
       },
       "gold_chunk_source": "consensus"
     },
@@ -6617,8 +6617,8 @@
         "origin": "src/impact/analysis.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 221,
-        "line_end": 265
+        "line_start": 232,
+        "line_end": 279
       },
       "gold_chunk_source": "consensus"
     },
@@ -6753,8 +6753,8 @@
         "origin": "src/hnsw/persist.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 806,
-        "line_end": 812
+        "line_start": 894,
+        "line_end": 900
       },
       "gold_chunk_source": "consensus"
     },


### PR DESCRIPTION
## Why

`cqs eval` matches gold chunks on `(file, name, line_start)` exactly. The v3.v2 fixtures were generated 2026-04-17/20; v1.29.0 (147 audit fixes) and v1.29.1 (91 P1+P2+P3 fixes) landed afterward and shifted line numbers in many files.

Re-running `cqs eval evals/queries/v3_dev.v2.json` against the current `main` index produced **R@5 = 51.4%** — down 26.6pp from the canonical 78.0%. The cause was entirely fixture drift:

- 42 of 109 dev gold chunks had `line_start` that no longer matched any chunk with the same `(name, origin, chunk_type)`
- 44 of 109 test gold chunks had the same problem
- The semantic search was retrieving the right code; the eval was rejecting hits because line numbers had shifted by 1–96 lines

After refreshing line numbers (and `line_end` for consistency) to the nearest current chunk with matching `(name, origin, chunk_type)`:

| Metric | Canonical (2026-04-20) | Refreshed (2026-04-25) | Δ |
|---|---:|---:|---:|
| dev R@1 | 45.0% | 42.2% | -2.8pp |
| dev R@5 | 78.0% | **74.3%** | -3.7pp |
| dev R@20 | 88.1% | 87.2% | -0.9pp |
| test R@5 | 68.8% | 63.3% | -5.5pp |

The 3.7-5.5pp residual is real: 5,413 of 17,778 chunks (30%) were created since the canonical baseline as audit fixes touched many files, slightly shifting chunk content and ranking. Not a search regression.

## How

Per gold chunk:

1. Look up `(name, origin, chunk_type)` in the current default-slot index
2. If `line_start` already matches a candidate → unchanged
3. If shifted, pick the candidate with `line_start` closest to the original; update `line_start` and `line_end`
4. Fall back to `(name, origin)` only when chunk_type drift exists (none observed)

Ambiguous shifts (multiple candidates of same `(name, origin, chunk_type)` with shifted lines): 10 in dev, 5 in test. The "closest line" heuristic picked nearest — most likely the same logical chunk, but a few may be subtly wrong. Acceptable for a re-baseline.

No queries were dropped. 1 test query had `name+origin` not present in the index (likely a chunk that was deleted in audit fixes); left untouched and counts as a miss.

## Future-proofing

Filed [#1108](https://github.com/jamie8johnson/cqs/issues/1108) separately for the `content_hash column missing` warning storm (~2,180 warnings/eval), unrelated to this fixture refresh.

Long-term: consider relaxing eval gold-match to `(file, name, chunk_type)` only, so future audits don't require fixture refreshes. Out of scope here.

## Test plan

- [x] `cargo build --features gpu-index` (no code changes, fixture-only)
- [x] `cqs --slot default eval evals/queries/v3_dev.v2.json` → R@5 = 74.3% (was 51.4% before refresh)
- [x] `cqs --slot default eval evals/queries/v3_test.v2.json` → R@5 = 63.3% (was 43.1% before refresh)
