### PR TITLE
feat(embedder): add nomic-coderank preset (CodeRankEmbed-137M)

### DIFF
--- a/src/embedder/models.rs
+++ b/src/embedder/models.rs
@@ -351,6 +351,28 @@ define_embedder_presets! {
         approx_download_bytes = Some(1_300 * 1024 * 1024),
         pad_id = 0,
         default = true;
+
+    /// CodeRankEmbed: 768-dim, 2048 tokens. Code-specialized fine-tune of
+    /// Snowflake Arctic Embed M Long, trained on CoRNStack (~21M code pairs).
+    /// Headline: 77.9 MRR on CodeSearchNet, 60.1 NDCG@10 on CoIR.
+    ///
+    /// Architecture is NomicBERT (custom: SwiGLU activation, RoPE, fused ops);
+    /// the ONNX export packages those into standard ONNX ops. Two inputs only
+    /// (`input_ids` + `attention_mask`, no `token_type_ids`); CLS pooling per
+    /// the model's `1_Pooling/config.json`. The official repo ships
+    /// safetensors only — this preset points at a re-exported ONNX bundle.
+    nomic_coderank => name = "nomic-coderank", repo = "jamie8johnson/CodeRankEmbed-onnx",
+        onnx_path = "onnx/model.onnx", tokenizer_path = "tokenizer.json",
+        dim = 768, max_seq_length = 2048,
+        query_prefix = "Represent this query for searching relevant code: ", doc_prefix = "",
+        // The sentence-transformers ONNX export exposes `token_embeddings`
+        // (3D `[batch, seq, dim]`) plus a pre-pooled `sentence_embedding`
+        // (2D). cqs's pooling expects a 3D tensor, so we read
+        // `token_embeddings` and CLS-pool ourselves.
+        input_names = InputNames::bert_no_token_types(), output_name = "token_embeddings".to_string(), pooling = PoolingStrategy::Cls,
+        // ONNX bundle: 522 MiB model + 712 KiB tokenizer.
+        approx_download_bytes = Some(523 * 1024 * 1024),
+        pad_id = 0;
 }
 
 impl ModelConfig {


### PR DESCRIPTION
## Why

Adds a preset for **CodeRankEmbed** (137M params, 768-dim, 2048 tokens) — a code-specialized fine-tune of Snowflake Arctic Embed M Long trained on CoRNStack (~21M code pairs). Reported headline metrics: 77.9 MRR on CodeSearchNet, 60.1 NDCG@10 on CoIR.

The official repo ships safetensors only; this preset points at a re-exported ONNX bundle at `jamie8johnson/CodeRankEmbed-onnx` (522 MiB model + 712 KiB tokenizer).

## A/B vs BGE-large on v3.v2 fixtures

Both slots fully enriched with LLM summaries (coderank summaries copied from default by content_hash, then `cqs index --llm-summaries` pass — 894 new summaries generated, the rest cache-hit).

| Metric | BGE-large (1024-dim) | CodeRankEmbed (768-dim) | Δ |
|---|---:|---:|---:|
| dev R@1 | 42.2% | **45.0%** | +2.8pp |
| dev R@5 | **74.3%** | 69.7% | -4.6pp |
| dev R@20 | **87.2%** | 79.8% | -7.4pp |
| test R@1 | 36.7% | **37.6%** | +0.9pp |
| test R@5 | 63.3% | **67.0%** | +3.7pp |
| test R@20 | **80.7%** | 78.9% | -1.8pp |

Per-category dev R@5 (large effects):
- multi_step: BGE 78.6% → coderank **92.9%** (+14.3pp)
- structural_search: BGE 75.0% → coderank 37.5% (-37.5pp)
- cross_language: BGE 63.6% → coderank 54.5% (-9.1pp)

Coderank is sharper at top-1 / R@5 on test, weaker on long-tail R@20 and structural keyword queries. BGE remains the better default for blanket recall; coderank is interesting for top-1-precision use cases.

Not promoting coderank to default — adding the preset for opt-in use via `cqs --model nomic-coderank`.

## Architecture notes

- NomicBERT-based (custom: SwiGLU, RoPE, fused ops) — the ONNX export packages those into standard ONNX ops, so cqs's existing inference path handles it
- Two inputs only: `input_ids` + `attention_mask` (no `token_type_ids`) → `InputNames::bert_no_token_types()`
- CLS pooling per `1_Pooling/config.json`
- The sentence-transformers ONNX export exposes both `token_embeddings` (3D) and `sentence_embedding` (2D, pre-pooled). cqs's pooling code expects 3D, so we read `token_embeddings` and CLS-pool ourselves
- Query prefix: `"Represent this query for searching relevant code: "` (per the model card); empty doc prefix

## Test plan

- [x] `cargo build --features gpu-index`
- [x] `cqs slot create coderank --model nomic-coderank` + `cqs --model nomic-coderank --slot coderank index --llm-summaries`
- [x] Eval on refreshed v3.v2 fixtures (numbers above)
- [ ] No new unit tests — `define_embedder_presets!` macro already covers preset wiring; eval was the validation

## Related

- #1107 — `cqs slot create --model` doesn't persist the model (must pass `--model` globally on every invocation; will need to keep doing so until #1107 ships)
- #1109 — fixture line_start refresh (this A/B used the refreshed fixtures)
