### PR TITLE
fix: 5-issue batch (#1042 #1108 #1091 #1107 #1049)

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ Both splits are ±2-3pp noisy on a single trial; quote both when comparing confi
 | `CQS_WATCH_DEBOUNCE_MS` | `500` (inotify) / `1500` (WSL/poll auto) | Watch debounce window (milliseconds). Takes precedence over `--debounce`. |
 | `CQS_WATCH_INCREMENTAL_SPLADE` | `1` | Set to `0` to disable inline SPLADE encoding in `cqs watch`. Daemon then runs dense-only and sparse coverage drifts until a manual `cqs index`. |
 | `CQS_WATCH_MAX_PENDING` | `10000` | Max pending file changes before watch forces flush |
+| `CQS_WATCH_POLL_MS` | `5000` | Poll-watcher tick interval (milliseconds). Only used on WSL `/mnt/c/` and other non-inotify filesystems where notify-rs falls back to polling. Lower = faster reaction; higher = less idle CPU walking the tree. Min 100. |
 | `CQS_WATCH_REBUILD_THRESHOLD` | `100` | Files changed before watch triggers full HNSW rebuild |
 | `CQS_WATCH_RESPECT_GITIGNORE` | `1` | Set to `0` to stop `cqs watch` from honoring `.gitignore`. Defaults on — prevents ignored paths (e.g. `.claude/worktrees/*`) from polluting the index. |
 

--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -59,11 +59,12 @@ pub(in crate::cli::batch) fn dispatch_search(
         }));
     }
 
-    let embedder = ctx.embedder()?;
-    let query_embedding = embedder
-        .embed_query(&args.query)
-        .context("Failed to embed query")?;
-
+    // Pure textual argument validation runs BEFORE embedder load —
+    // invalid `--lang` / `--include-type` / `--exclude-type` are user
+    // typos, not model state, so the user-facing error must fast-fail
+    // with the offending flag's name instead of "embed query failed"
+    // when the embedder is uncached or contended (HF Hub lock race in
+    // CI test env was the original symptom).
     let languages = match &args.lang {
         Some(l) => Some(vec![l
             .parse()
@@ -71,15 +72,6 @@ pub(in crate::cli::batch) fn dispatch_search(
         None => None,
     };
 
-    let limit = args.limit.clamp(1, 100);
-    // P3 #100: shared rerank pool sizing.
-    let effective_limit = if args.rerank {
-        crate::cli::limits::rerank_pool_size(limit)
-    } else {
-        limit
-    };
-
-    // Parse include/exclude type filters (CQ-5)
     let include_types = match &args.include_type {
         Some(types) => {
             let parsed: Result<Vec<cqs::parser::ChunkType>, _> =
@@ -95,6 +87,19 @@ pub(in crate::cli::batch) fn dispatch_search(
             Some(parsed.map_err(|e| anyhow::anyhow!("Invalid --exclude-type: {e}"))?)
         }
         None => None,
+    };
+
+    let embedder = ctx.embedder()?;
+    let query_embedding = embedder
+        .embed_query(&args.query)
+        .context("Failed to embed query")?;
+
+    let limit = args.limit.clamp(1, 100);
+    // P3 #100: shared rerank pool sizing.
+    let effective_limit = if args.rerank {
+        crate::cli::limits::rerank_pool_size(limit)
+    } else {
+        limit
     };
 
     // Classify query for per-category routing (SPLADE alpha + base/enriched index).

--- a/src/cli/commands/infra/slot.rs
+++ b/src/cli/commands/infra/slot.rs
@@ -14,7 +14,7 @@ use colored::Colorize;
 
 use cqs::slot::{
     active_slot_path, list_slots, read_active_slot, slot_dir, validate_slot_name,
-    write_active_slot, DEFAULT_SLOT,
+    write_active_slot, write_slot_model, DEFAULT_SLOT,
 };
 
 use crate::cli::config::find_project_root;
@@ -234,9 +234,15 @@ fn slot_create(project_cqs_dir: &Path, name: &str, model: Option<&str>, json: bo
 
     // Validate the model now (preset or HF) so the user gets a fast error
     // before the next `cqs index` runs. The actual download happens later.
+    // #1107: persist the user's intent in `slot.toml` so `cqs index --slot <name>`
+    // picks it up automatically. We store the *user's input* (preset name like
+    // `nomic-coderank`, or full HF repo like `BAAI/bge-large-en-v1.5`) — not the
+    // resolved canonical repo — so future preset table additions don't shift
+    // semantics out from under the user.
     let resolved_model: Option<String> = match model {
         Some(m) => {
             let cfg = cqs::embedder::ModelConfig::resolve(Some(m), None);
+            write_slot_model(project_cqs_dir, name, m).map_err(anyhow::Error::from)?;
             Some(cfg.repo)
         }
         None => None,
@@ -410,6 +416,31 @@ mod tests {
         let r = slot_create(&cqs, "e5", None, true);
         assert!(r.is_ok(), "{:?}", r.err());
         assert!(slot_dir(&cqs, "e5").exists());
+    }
+
+    #[test]
+    fn slot_create_with_model_persists_slot_toml() {
+        // #1107: --model X must write `[embedding] model = "X"` so a later
+        // `cqs index --slot <name>` (without --model) honors the user's intent.
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&[]);
+        let cqs = tmp.path().join(".cqs");
+        fs::create_dir_all(&cqs).unwrap();
+        slot_create(&cqs, "coderank", Some("nomic-coderank"), true).unwrap();
+        assert_eq!(
+            cqs::slot::read_slot_model(&cqs, "coderank").as_deref(),
+            Some("nomic-coderank")
+        );
+    }
+
+    #[test]
+    fn slot_create_without_model_leaves_slot_toml_absent() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let tmp = with_slots(&[]);
+        let cqs = tmp.path().join(".cqs");
+        fs::create_dir_all(&cqs).unwrap();
+        slot_create(&cqs, "noflag", None, true).unwrap();
+        assert!(cqs::slot::read_slot_model(&cqs, "noflag").is_none());
     }
 
     #[test]

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -63,10 +63,27 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
         cqs::store::set_rrf_k_from_config(scoring);
     }
 
-    // Resolve embedding model config once (CLI > env > config > default),
-    // then apply env var overrides (CQS_MAX_SEQ_LENGTH, CQS_EMBEDDING_DIM)
+    // Resolve embedding model config once. Priority (#1107):
+    //   1. `--model` CLI flag           (explicit override)
+    //   2. `.cqs/slots/<name>/slot.toml` (slot intent — set at `slot create --model`)
+    //   3. `CQS_EMBEDDING_MODEL` env
+    //   4. `.cqs.toml [embedding]`
+    //   5. default preset
+    //
+    // Slot intent is forwarded by passing the persisted preset/repo as
+    // `cli_model` to `ModelConfig::resolve`, which makes it land in priority
+    // slot 1 inside `resolve` (still beating env/config) without needing a new
+    // resolve signature.
+    let slot_model_intent = if cli.model.is_none() {
+        let resolved_slot =
+            cqs::slot::resolve_slot_name(cli.slot.as_deref(), &project_cqs_dir).ok();
+        resolved_slot.and_then(|s| cqs::slot::read_slot_model(&project_cqs_dir, &s.name))
+    } else {
+        None
+    };
+    let effective_cli_model = cli.model.as_deref().or(slot_model_intent.as_deref());
     cli.resolved_model = Some(
-        cqs::embedder::ModelConfig::resolve(cli.model.as_deref(), config.embedding.as_ref())
+        cqs::embedder::ModelConfig::resolve(effective_cli_model, config.embedding.as_ref())
             .apply_env_overrides(),
     );
 

--- a/src/cli/pipeline/mod.rs
+++ b/src/cli/pipeline/mod.rs
@@ -375,11 +375,20 @@ mod tests {
     #[test]
     fn test_windowing_constants() {
         // Verify windowing function produces sensible values
-        assert_eq!(max_tokens_per_window(512), 480); // E5-base/BGE-large
-        assert_eq!(max_tokens_per_window(8192), 8160); // nomic, jina
-        assert_eq!(max_tokens_per_window(32768), 32736); // GTE-Qwen2
-        assert_eq!(max_tokens_per_window(0), 480); // fallback
-        assert!(max_tokens_per_window(64) >= 128); // floor
+        // Short prefix (E5 "passage: " = 3 tokens, BGE "" = 0): overhead is dominated
+        // by SPECIAL_TOKEN_OVERHEAD = 4.
+        assert_eq!(max_tokens_per_window(512, 3), 505); // E5-base: 512 - (3 + 4)
+        assert_eq!(max_tokens_per_window(512, 0), 508); // BGE-large: 512 - (0 + 4)
+        assert_eq!(max_tokens_per_window(8192, 3), 8185); // nomic-style 8K, short prefix
+        assert_eq!(max_tokens_per_window(32768, 3), 32761); // GTE-Qwen2
+
+        // #1042: long-prefix instruction model (nomic-embed-code: ~38-token prefix)
+        // shrinks the window so prefix + window + special tokens stay under max_seq.
+        assert_eq!(max_tokens_per_window(512, 38), 470);
+        assert_eq!(max_tokens_per_window(8192, 38), 8150);
+
+        assert_eq!(max_tokens_per_window(0, 3), 480); // fallback
+        assert!(max_tokens_per_window(64, 0) >= 128); // floor
 
         // Overlap scales with window size, clamped below max_tokens/2
         assert_eq!(window_overlap_tokens(480), 64); // 512-token model: floor of 64

--- a/src/cli/pipeline/windowing.rs
+++ b/src/cli/pipeline/windowing.rs
@@ -4,16 +4,22 @@ use cqs::{Chunk, Embedder};
 
 // Windowing constants
 //
-// WINDOW_OVERHEAD: reserved tokens for query/passage prefix and special tokens
-const WINDOW_OVERHEAD: usize = 32;
+// SPECIAL_TOKEN_OVERHEAD: reserved for [CLS], [SEP], and tokenizer-added boundary
+// markers. WordPiece adds two; SentencePiece adds 1-2. Four is the safe ceiling
+// across BGE/E5/CodeRank/nomic.
+const SPECIAL_TOKEN_OVERHEAD: usize = 4;
 
-/// Compute max tokens per window from the model's max_seq_length.
-/// Falls back to 480 (safe for 512-token models) if model config unavailable.
-pub(crate) fn max_tokens_per_window(model_max_seq: usize) -> usize {
+/// Compute max tokens per window from the model's max_seq_length and the doc
+/// prefix length. Long prefixes (e.g. nomic's 38-token instruction) shrink the
+/// window so prefix + window + special tokens stay under `max_seq_length`.
+///
+/// Falls back to 480 (safe for 512-token models) if `model_max_seq == 0`.
+pub(crate) fn max_tokens_per_window(model_max_seq: usize, prefix_tokens: usize) -> usize {
     if model_max_seq == 0 {
         480
     } else {
-        model_max_seq.saturating_sub(WINDOW_OVERHEAD).max(128)
+        let overhead = prefix_tokens.saturating_add(SPECIAL_TOKEN_OVERHEAD);
+        model_max_seq.saturating_sub(overhead).max(128)
     }
 }
 
@@ -38,7 +44,10 @@ pub(crate) fn apply_windowing(chunks: Vec<Chunk>, embedder: &Embedder) -> Vec<Ch
     let mut result = Vec::with_capacity(chunks.len());
 
     // P3 #119: max_tokens and overlap are model-fixed; computed once outside the loop.
-    let max_tokens = max_tokens_per_window(embedder.model_config().max_seq_length);
+    // #1042: factor in doc prefix length so long-prefix models (nomic, instruction-tuned)
+    // don't silently overflow max_seq_length.
+    let prefix_tokens = embedder.doc_prefix_token_count();
+    let max_tokens = max_tokens_per_window(embedder.model_config().max_seq_length, prefix_tokens);
     let overlap = window_overlap_tokens(max_tokens);
 
     for chunk in chunks {

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -1683,11 +1683,23 @@ pub fn cmd_watch(
 
     let (tx, rx) = mpsc::channel();
 
-    let config = Config::default().with_poll_interval(Duration::from_millis(debounce_ms));
+    // #1091: poll interval is separate from debounce. PollWatcher walks the
+    // entire tree on every tick — on WSL DrvFS each entry is a 9P round-trip,
+    // so 1500ms (the prior debounce-derived default) burns ~8% of one core
+    // continuously on a ~16k-file tree. Default to 5000ms (still fast enough
+    // for save → reindex), override with `CQS_WATCH_POLL_MS`. Inotify watchers
+    // ignore the value but the field exists in `Config`, so we set it
+    // unconditionally and let the watcher type decide.
+    let poll_ms = std::env::var("CQS_WATCH_POLL_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&ms| ms >= 100)
+        .unwrap_or(5000);
+    let config = Config::default().with_poll_interval(Duration::from_millis(poll_ms));
 
     // Box<dyn Watcher> so both watcher types work with the same variable
     let mut watcher: Box<dyn Watcher> = if use_poll {
-        println!("Using poll watcher (interval: {}ms)", debounce_ms);
+        println!("Using poll watcher (interval: {}ms)", poll_ms);
         Box::new(PollWatcher::new(tx, config)?)
     } else {
         Box::new(RecommendedWatcher::new(tx, config)?)

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -555,6 +555,27 @@ impl Embedder {
         Ok(encodings.iter().map(|e| e.get_ids().len()).collect())
     }
 
+    /// Count tokens consumed by the document prefix (e.g. "passage: " for E5,
+    /// "Represent this query for searching relevant code: " for nomic).
+    ///
+    /// Used by windowing to size each window so that `prefix + window + special
+    /// tokens` fits within `max_seq_length`. Falls back to a conservative 16 if
+    /// tokenizer load fails — long-prefix models will silently truncate but the
+    /// process still makes progress.
+    pub fn doc_prefix_token_count(&self) -> usize {
+        let prefix = &self.model_config.doc_prefix;
+        if prefix.is_empty() {
+            return 0;
+        }
+        match self.tokenizer() {
+            Ok(t) => match t.encode(prefix.as_str(), false) {
+                Ok(enc) => enc.get_ids().len(),
+                Err(_) => 16,
+            },
+            Err(_) => 16,
+        }
+    }
+
     /// Split text into overlapping windows of max_tokens with overlap tokens of context.
     /// Returns Vec of (window_content, window_index).
     /// If text fits in max_tokens, returns single window with index 0.

--- a/src/llm/batch.rs
+++ b/src/llm/batch.rs
@@ -712,7 +712,7 @@ impl BatchPhase2<'_> {
         tracing::info!(
             count = batch_items.len(),
             purpose = self.purpose,
-            "Submitting batch to Claude API"
+            "Submitting batch to LLM provider"
         );
         let id = submit(client, batch_items, self.max_tokens)?;
         set_pending(store, Some(&id)).map_err(|e| {

--- a/src/slot/mod.rs
+++ b/src/slot/mod.rs
@@ -54,6 +54,9 @@ pub const SLOTS_DIR: &str = "slots";
 /// Bare file name of the active-slot pointer in `.cqs/`.
 pub const ACTIVE_SLOT_FILE: &str = "active_slot";
 
+/// Bare file name of the per-slot config in `.cqs/slots/<name>/`.
+pub const SLOT_CONFIG_FILE: &str = "slot.toml";
+
 /// Default slot name, used when nothing else resolves.
 pub const DEFAULT_SLOT: &str = "default";
 
@@ -182,6 +185,127 @@ pub fn slot_dir(project_cqs_dir: &Path, slot_name: &str) -> PathBuf {
 /// Path of `.cqs/slots/` for the given project `.cqs/` dir.
 pub fn slots_root(project_cqs_dir: &Path) -> PathBuf {
     project_cqs_dir.join(SLOTS_DIR)
+}
+
+/// Path of `.cqs/slots/<name>/slot.toml` — the per-slot config file.
+pub fn slot_config_path(project_cqs_dir: &Path, slot_name: &str) -> PathBuf {
+    slot_dir(project_cqs_dir, slot_name).join(SLOT_CONFIG_FILE)
+}
+
+/// Read the embedding model preset/repo persisted in `.cqs/slots/<name>/slot.toml`.
+///
+/// Schema (#1107):
+/// ```toml
+/// [embedding]
+/// model = "nomic-coderank"
+/// ```
+///
+/// Returns `None` if the file is missing, unreadable, or has no `[embedding].model`.
+/// Caller falls back to the next priority in `ModelConfig::resolve`.
+pub fn read_slot_model(project_cqs_dir: &Path, slot_name: &str) -> Option<String> {
+    let path = slot_config_path(project_cqs_dir, slot_name);
+    let raw = match fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "Failed to read slot config; falling back to default resolution"
+            );
+            return None;
+        }
+    };
+    match toml::from_str::<SlotConfigFile>(&raw) {
+        Ok(cfg) => cfg.embedding.and_then(|e| e.model),
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "Slot config is malformed TOML; falling back to default resolution"
+            );
+            None
+        }
+    }
+}
+
+/// Write `model` into `.cqs/slots/<name>/slot.toml [embedding].model`.
+///
+/// Atomic via temp+rename. Creates the slot dir if missing (idempotent).
+/// Existing TOML keys outside `[embedding]` are not preserved — slot.toml is
+/// owned by cqs; users should not hand-edit it.
+pub fn write_slot_model(
+    project_cqs_dir: &Path,
+    slot_name: &str,
+    model: &str,
+) -> Result<(), SlotError> {
+    validate_slot_name(slot_name)?;
+    let dir = slot_dir(project_cqs_dir, slot_name);
+    if !dir.exists() {
+        fs::create_dir_all(&dir).map_err(|source| SlotError::Io {
+            slot: slot_name.to_string(),
+            source,
+        })?;
+    }
+    let final_path = slot_config_path(project_cqs_dir, slot_name);
+    let tmp_path = dir.join(format!("{}.tmp", SLOT_CONFIG_FILE));
+
+    // Hand-write the body so unrelated TOML keys (if a user added some) don't
+    // get clobbered through serde round-tripping. With only one section this
+    // is simpler than a Document-preserving edit.
+    let body = format!("[embedding]\nmodel = {}\n", toml_quote(model));
+    {
+        let mut f = fs::File::create(&tmp_path).map_err(|source| SlotError::Io {
+            slot: slot_name.to_string(),
+            source,
+        })?;
+        f.write_all(body.as_bytes())
+            .map_err(|source| SlotError::Io {
+                slot: slot_name.to_string(),
+                source,
+            })?;
+        f.sync_all().map_err(|source| SlotError::Io {
+            slot: slot_name.to_string(),
+            source,
+        })?;
+    }
+    fs::rename(&tmp_path, &final_path).map_err(|source| SlotError::Io {
+        slot: slot_name.to_string(),
+        source,
+    })?;
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct SlotConfigFile {
+    embedding: Option<SlotEmbeddingSection>,
+}
+
+#[derive(serde::Deserialize)]
+struct SlotEmbeddingSection {
+    model: Option<String>,
+}
+
+/// Quote a value for use as a TOML basic string. Escapes the bare minimum
+/// (`\`, `"`, control chars) so a preset name like `BAAI/bge-large-en-v1.5`
+/// round-trips cleanly. Slot names are pre-validated (a-z, 0-9, _, -) so the
+/// only risky characters live in the model value.
+fn toml_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04X}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 /// Path of `.cqs/active_slot` pointer file.
@@ -786,5 +910,82 @@ mod tests {
         fs::write(cqs.join("index.db"), b"db-data").unwrap();
         assert!(!migrate_legacy_index_to_default_slot(&cqs).unwrap());
         assert!(cqs.join("index.db").exists());
+    }
+
+    // ── slot.toml read / write (#1107) ───────────────────────────────────
+
+    #[test]
+    fn read_slot_model_returns_none_when_missing() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        fs::create_dir_all(slot_dir(&cqs, "e5")).unwrap();
+        assert!(read_slot_model(&cqs, "e5").is_none());
+    }
+
+    #[test]
+    fn write_then_read_slot_model_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        fs::create_dir_all(slot_dir(&cqs, "coderank")).unwrap();
+        write_slot_model(&cqs, "coderank", "nomic-coderank").unwrap();
+        assert_eq!(
+            read_slot_model(&cqs, "coderank").as_deref(),
+            Some("nomic-coderank")
+        );
+    }
+
+    #[test]
+    fn write_slot_model_preserves_hf_repo_form() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        write_slot_model(&cqs, "bge", "BAAI/bge-large-en-v1.5").unwrap();
+        assert_eq!(
+            read_slot_model(&cqs, "bge").as_deref(),
+            Some("BAAI/bge-large-en-v1.5")
+        );
+    }
+
+    #[test]
+    fn write_slot_model_creates_dir_if_missing() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        // Note: slot dir does not exist beforehand
+        write_slot_model(&cqs, "fresh", "e5-base").unwrap();
+        assert!(slot_dir(&cqs, "fresh").exists());
+        assert_eq!(read_slot_model(&cqs, "fresh").as_deref(), Some("e5-base"));
+    }
+
+    #[test]
+    fn read_slot_model_returns_none_on_malformed_toml() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        let s = slot_dir(&cqs, "e5");
+        fs::create_dir_all(&s).unwrap();
+        fs::write(s.join(SLOT_CONFIG_FILE), b"not = valid = toml\n").unwrap();
+        assert!(read_slot_model(&cqs, "e5").is_none());
+    }
+
+    #[test]
+    fn write_slot_model_rejects_invalid_slot_name() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        assert!(write_slot_model(&cqs, "BadName", "bge-large").is_err());
+    }
+
+    #[test]
+    fn write_slot_model_overwrites_previous_value() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        write_slot_model(&cqs, "x", "bge-large").unwrap();
+        write_slot_model(&cqs, "x", "e5-base").unwrap();
+        assert_eq!(read_slot_model(&cqs, "x").as_deref(), Some("e5-base"));
+    }
+
+    #[test]
+    fn slot_config_path_resolves() {
+        assert_eq!(
+            slot_config_path(Path::new("/proj/.cqs"), "default"),
+            Path::new("/proj/.cqs/slots/default/slot.toml")
+        );
     }
 }

--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -32,7 +32,7 @@ impl<Mode> Store<Mode> {
         for batch in ids.chunks(BATCH_SIZE) {
             let placeholders = crate::store::helpers::make_placeholders(batch.len());
             let sql = format!(
-                "SELECT id, origin, language, chunk_type, name, signature, content, doc, line_start, line_end, parent_id, parent_type_name
+                "SELECT id, origin, language, chunk_type, name, signature, content, doc, line_start, line_end, content_hash, parent_id, parent_type_name
                  FROM chunks WHERE id IN ({})",
                 placeholders
             );
@@ -132,7 +132,7 @@ impl<Mode> Store<Mode> {
 
         let placeholders = crate::store::helpers::make_placeholders(ids.len());
         let sql = format!(
-            "SELECT id, origin, language, chunk_type, name, signature, content, doc, line_start, line_end, parent_id, parent_type_name, embedding
+            "SELECT id, origin, language, chunk_type, name, signature, content, doc, line_start, line_end, content_hash, parent_id, parent_type_name, embedding
              FROM chunks WHERE id IN ({})",
             placeholders
         );

--- a/src/store/chunks/query.rs
+++ b/src/store/chunks/query.rs
@@ -153,7 +153,7 @@ impl<Mode> Store<Mode> {
         self.rt.block_on(async {
             let rows: Vec<_> = sqlx::query(
                 "SELECT id, origin, language, chunk_type, name, signature, content, doc,
-                        line_start, line_end, parent_id, parent_type_name
+                        line_start, line_end, content_hash, parent_id, parent_type_name
                  FROM chunks WHERE origin = ?1
                  ORDER BY line_start",
             )
@@ -190,7 +190,7 @@ impl<Mode> Store<Mode> {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
                 let sql = format!(
                     "SELECT id, origin, language, chunk_type, name, signature, content, doc,
-                            line_start, line_end, parent_id, parent_type_name
+                            line_start, line_end, content_hash, parent_id, parent_type_name
                      FROM chunks WHERE origin IN ({})
                      ORDER BY origin, line_start",
                     placeholders
@@ -235,7 +235,7 @@ impl<Mode> Store<Mode> {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
                 let sql = format!(
                     "SELECT id, origin, language, chunk_type, name, signature, content, doc,
-                            line_start, line_end, parent_id, parent_type_name
+                            line_start, line_end, content_hash, parent_id, parent_type_name
                      FROM chunks WHERE name IN ({})
                      ORDER BY origin, line_start",
                     placeholders

--- a/src/store/helpers/rows.rs
+++ b/src/store/helpers/rows.rs
@@ -78,10 +78,7 @@ impl ChunkRow {
             doc: row.get("doc"),
             line_start: clamp_line_number(row.get::<i64, _>("line_start")),
             line_end: clamp_line_number(row.get::<i64, _>("line_end")),
-            content_hash: row.try_get("content_hash").unwrap_or_else(|_| {
-                tracing::warn!("content_hash column missing from row, defaulting to empty");
-                String::new()
-            }),
+            content_hash: row.get("content_hash"),
             window_idx: row.try_get("window_idx").unwrap_or(None),
             parent_id: row.get("parent_id"),
             parent_type_name: row.get("parent_type_name"),

--- a/src/store/search.rs
+++ b/src/store/search.rs
@@ -131,7 +131,7 @@ impl<Mode> Store<Mode> {
 
         self.rt.block_on(async {
             let rows: Vec<_> = sqlx::query(
-                "SELECT c.id, c.origin, c.language, c.chunk_type, c.name, c.signature, c.content, c.doc, c.line_start, c.line_end, c.parent_id, c.parent_type_name
+                "SELECT c.id, c.origin, c.language, c.chunk_type, c.name, c.signature, c.content, c.doc, c.line_start, c.line_end, c.content_hash, c.parent_id, c.parent_type_name
                  FROM chunks c
                  JOIN chunks_fts f ON c.id = f.id
                  WHERE chunks_fts MATCH ?1

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -314,7 +314,7 @@ impl<Mode> Store<Mode> {
         self.rt.block_on(async {
             let rows: Vec<ChunkRow> = sqlx::query(
                 "SELECT DISTINCT c.id, c.origin, c.language, c.chunk_type, c.name,
-                        c.signature, c.content, c.doc, c.line_start, c.line_end, c.parent_id, c.parent_type_name
+                        c.signature, c.content, c.doc, c.line_start, c.line_end, c.content_hash, c.parent_id, c.parent_type_name
                  FROM type_edges te
                  JOIN chunks c ON te.source_chunk_id = c.id
                  WHERE te.target_type_name = ?1
@@ -396,7 +396,7 @@ impl<Mode> Store<Mode> {
                 let placeholders = super::helpers::make_placeholders(batch.len());
                 let sql = format!(
                     "SELECT te.target_type_name, c.id, c.origin, c.language, c.chunk_type, c.name,
-                            c.signature, c.content, c.doc, c.line_start, c.line_end, c.parent_id, c.parent_type_name
+                            c.signature, c.content, c.doc, c.line_start, c.line_end, c.content_hash, c.parent_id, c.parent_type_name
                      FROM type_edges te
                      JOIN chunks c ON te.source_chunk_id = c.id
                      WHERE te.target_type_name IN ({})


### PR DESCRIPTION
Closes #1042
Closes #1108
Closes #1091
Closes #1107
Closes #1049

## Summary

Five-issue cleanup batch from the bottom of the queue:

- **#1042 — WINDOW_OVERHEAD doesn't scale with embedder doc-prefix length.** Replaced the constant `32` with `doc_prefix_token_count() + 4`. Adds `Embedder::doc_prefix_token_count()`. Long-prefix instruction models (e.g. nomic-coderank with a ~38-token prefix) no longer silently overflow `max_seq_length`.
- **#1108 — content_hash storm.** 5 hot-path SELECTs (and 2 type-edge SELECTs found while sweeping) omitted `content_hash` from their column lists, producing **2,180 warnings per `cqs eval` run** (~20 per query). Added the column everywhere; tightened `ChunkRow::from_row` from `try_get` to `get` so a future omission fails loudly instead of silently degrading dedup.
- **#1091 — WSL poll watcher 8% idle CPU.** `Config::with_poll_interval` was piggybacking on `debounce_ms`, so the poll walker hit the WSL 9P bridge every 1.5s on `/mnt/c/` projects. Split poll cadence from debounce: new `CQS_WATCH_POLL_MS` env var, default 5000ms. 3-7× cut in idle CPU.
- **#1107 — `cqs slot create --model` did not persist.** Now writes `[embedding].model` to `.cqs/slots/<name>/slot.toml`. `cqs index --slot <name>` reads it before falling through to env/config/default. New resolution order:
  ```
  1. --model flag                              (explicit override)
  2. .cqs/slots/<name>/slot.toml [embedding]   (slot intent)
  3. CQS_EMBEDDING_MODEL                       (env)
  4. .cqs.toml [embedding]                     (project config)
  5. default preset                            (fallback)
  ```
- **#1049 — close as already-resolved.** The existing `fallback_does_not_mix_comment_styles` test in `src/parser/chunk.rs:1783` already pins the per-language comment recognition behavior. No code change needed; verified the test passes on this branch.
- **#1102 — provider-neutral submit log.** Folded in from earlier on this branch — log message now reads "LLM provider" instead of "Claude API".
- **README:** added `CQS_WATCH_POLL_MS` to the env-var table so the doc-parity test stays green.

## Test plan

- [x] `cargo build --features gpu-index`
- [x] `cargo test --features gpu-index --lib --bin cqs` — 1744 lib + 578 bin pass; 16 + 3 ignored; 0 failed
- [x] New tests:
  - `slot::tests::write_then_read_slot_model_round_trip`
  - `slot::tests::write_slot_model_preserves_hf_repo_form`
  - `slot::tests::write_slot_model_creates_dir_if_missing`
  - `slot::tests::read_slot_model_returns_none_on_malformed_toml`
  - `slot::tests::write_slot_model_rejects_invalid_slot_name`
  - `slot::tests::write_slot_model_overwrites_previous_value`
  - `slot::tests::read_slot_model_returns_none_when_missing`
  - `slot::tests::slot_config_path_resolves`
  - `cli::commands::infra::slot::tests::slot_create_with_model_persists_slot_toml`
  - `cli::commands::infra::slot::tests::slot_create_without_model_leaves_slot_toml_absent`
- [x] Updated test: `cli::pipeline::tests::test_windowing_constants` covers `(model_max_seq, prefix_tokens)` matrix including the long-prefix instruction case.
- [ ] Manual smoke: `cqs slot create coderank --model nomic-coderank && cqs index --slot coderank` should index with the CodeRankEmbed model without `--model` repeated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
