### PR TITLE
chore(tears+roadmap+docs): post-batch state refresh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ src/
     queries/    - Tree-sitter queries (.scm files, loaded via include_str!())
       <lang>.chunks.scm, <lang>.calls.scm, <lang>.types.scm
   test_helpers.rs - Shared test fixtures module
-  store/        - SQLite storage layer (Schema v20, WAL mode)
+  store/        - SQLite storage layer (Schema v22, WAL mode)
     mod.rs      - Store struct, open/init, FTS5, split_sql_statements (BEGIN/END-aware)
     metadata.rs - Chunk metadata queries, file-level operations
     search.rs   - RRF fusion, search_filtered, search_unified_with_index
@@ -204,7 +204,7 @@ src/
     types.rs    - Type edge storage and queries
     helpers/    - Types, embedding conversion, scoring, SQL utilities
       mod.rs, embeddings.rs, error.rs, rows.rs, scoring.rs, search_filter.rs, sql.rs, types.rs
-    migrations.rs - Schema migration framework (v10-v20, including v19 FK cascade + v20 trigger)
+    migrations.rs - Schema migration framework (v10-v22, including v19 FK cascade, v20 trigger, v21 splade tokens, v22 chunks.umap_x/y)
   parser/       - Code parsing (tree-sitter + custom parsers, delegates to language/ registry)
     mod.rs      - Parser struct, parse_file(), parse_file_all(), supported_extensions()
     types.rs    - Chunk (incl. parent_type_name), CallSite, FunctionCalls, TypeRef, ParserError
@@ -215,10 +215,10 @@ src/
     l5x.rs      - Rockwell PLC exports (L5X XML + L5K ASCII) → Structured Text extraction
     markdown/   - Heading-based markdown parser
       mod.rs, headings.rs, code_blocks.rs, tables.rs
-  embedder/      - ONNX embedding models (configurable: BGE-large-en-v1.5 default, E5-base preset, custom ONNX)
-    mod.rs      - Embedder struct, embed(), batch embedding, runtime dimension detection
-    models.rs   - ModelConfig struct, built-in presets (e5-base, bge-large), resolution logic, EmbeddingConfig
-    provider.rs - ORT execution provider selection (CUDA/TensorRT/CPU)
+  embedder/      - ONNX embedding models (configurable: BGE-large-en-v1.5 default; E5-base, nomic-coderank-137M, custom ONNX presets)
+    mod.rs      - Embedder struct, embed(), batch embedding, runtime dimension detection, ExecutionProvider enum (CUDA/TensorRT/CPU; CoreML/ROCm cfg-gated per #956 Phase A)
+    models.rs   - ModelConfig struct, built-in presets (e5-base, bge-large, nomic-coderank), resolution logic, EmbeddingConfig
+    provider.rs - ORT execution provider selection — per-backend cfg-blocks; CUDA/TensorRT always-on, CoreML/ROCm scaffolded via `ep-coreml`/`ep-rocm` features (#956 Phase A)
   reranker.rs   - Cross-encoder re-ranking (ms-marco-MiniLM-L-6-v2)
   search/       - Search algorithms, name matching, HNSW-guided search
     mod.rs      - search_filtered(), search_unified_with_index(), hybrid RRF
@@ -247,7 +247,9 @@ src/
     naming.rs   - Title extraction, kebab-case filename generation
     cleaning.rs - Extensible tag-based cleaning rules (7 rules)
     webhelp.rs  - Web help site detection and multi-page merge
-  cache.rs      - Global embedding cache (SQLite, keyed by content_hash + model_fingerprint)
+  cache.rs      - Per-project embedding cache `.cqs/embeddings_cache.db` (SQLite, keyed by content_hash + model_id; #1105)
+  slot/         - Named slots — side-by-side full indexes under `.cqs/slots/<name>/` (#1105)
+    mod.rs      - slot_dir(), resolve_slot_name() (CQS_SLOT > .cqs/active_slot > "default"), one-shot legacy migration
   cagra.rs      - GPU-accelerated CAGRA index (optional), save/load via cuvsCagraSerialize
   nl/           - NL description generation, JSDoc parsing
     mod.rs      - Core NL generation, type-aware embeddings, call context
@@ -269,7 +271,7 @@ src/
     analysis.rs - suggest_tests, find_transitive_callers, extract_call_snippet_from_cache
     diff.rs     - analyze_diff_impact, map_hunks_to_functions
     cross_project.rs - Cross-project impact analysis and trace
-    bfs.rs      - Reverse BFS, reverse_bfs_multi_attributed, test_reachability
+    bfs.rs      - reverse_bfs, reverse_bfs_multi_attributed, test_reachability, forward_bfs_multi (used by suggest_tests, #1115)
     format.rs   - JSON/Mermaid formatting
     hints.rs    - compute_hints, compute_hints_batch, compute_risk_batch, risk scoring
     test_map.rs - Shared test-map algorithm (reverse BFS from function to test chunks)
@@ -299,6 +301,10 @@ src/
     diff.rs     - Git diff parsing for function-level changes
     git.rs      - Git history traversal (log, show, diff-tree)
     query.rs    - Query normalization for training pairs
+  serve/        - `cqs serve` web UI (gated on `serve` feature; axum + tower)
+    mod.rs      - run_server, build_router, route handlers (search, graph, hierarchy, cluster, chunk detail)
+    auth.rs     - Per-launch auth token: 256-bit URL-safe base64, constant-time compare, Bearer/cookie/?token= surfaces (#1118 / SEC-7)
+    tests.rs    - Router + auth integration tests (test_router_with_auth helper, host allowlist, gzip)
   lib.rs        - Public API
 .claude/
   skills/       - Claude Code skills (auto-discovered)
@@ -323,7 +329,7 @@ src/
 ```
 
 **Key design notes:**
-- Configurable embeddings (BGE-large 1024-dim default, E5-base 768-dim preset, custom ONNX)
+- Configurable embeddings (BGE-large 1024-dim default; E5-base 768-dim, nomic-coderank-137M 768-dim, custom ONNX presets)
 - HNSW index is chunk-only; notes use brute-force SQLite search (always fresh)
 - Streaming HNSW build via `build_batched()` for memory efficiency
 - Large chunks split by windowing (480 tokens, 64 overlap); notes capped at 10k entries

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -10,18 +10,16 @@ cqs processes your code locally by default. With `--llm-summaries`, function cod
 
 ## What Gets Stored
 
-When you run `cqs index`, the following is stored in `.cqs/index.db`:
+When you run `cqs index`, the following is stored under `.cqs/`:
 
-- Code chunks (functions, methods, documentation sections)
-- Embedding vectors (dimension depends on configured model; 1024 for BGE-large default, 768 for E5-base/v9-200k presets)
-- File paths and line numbers
-- File modification times
+- `.cqs/slots/<name>/index.db` — code chunks, embedding vectors (dim depends on configured model; 1024 for BGE-large default, 768 for E5-base / nomic-coderank presets), file paths, line numbers, modification times. Per-named-slot, side-by-side (#1105). Pre-migration projects may still see a legacy single-slot path at `.cqs/index.db`.
+- `.cqs/embeddings_cache.db` — per-project embedding cache, keyed by `(content_hash, model_id)` (#1105). Skips re-embedding chunks that haven't changed across reindexes / model swaps.
 
-Additional caches are kept under `~/.cache/cqs/`:
+A legacy global cache may also exist from older versions:
 
-- `embeddings.db` — content-addressed embedding cache, capped at 1 GB by default (configurable via `CQS_CACHE_MAX_SIZE`). Reused across projects to skip re-embedding identical chunks.
-- `query_cache.db` — recent query embeddings with a 7-day TTL. Speeds up repeated searches.
-- `query_log.jsonl` — opt-in query log, written only when `CQS_TELEMETRY=1` or the file already exists. Stays local.
+- `~/.cache/cqs/embeddings.db` — pre-#1105 cross-project embedding cache, capped at 1 GB by default (`CQS_CACHE_MAX_SIZE`). Still consulted when the per-project cache misses.
+- `~/.cache/cqs/query_cache.db` — recent query embeddings with a 7-day TTL. Speeds up repeated searches.
+- `~/.cache/cqs/query_log.jsonl` — opt-in query log, written only when `CQS_TELEMETRY=1` or the file already exists. Stays local.
 
 This data never leaves your machine.
 
@@ -31,7 +29,7 @@ The embedding model is downloaded once from HuggingFace:
 
 - Default: `BAAI/bge-large-en-v1.5` (BGE-large, ~1.2GB, 1024-dim)
 - Preset: `intfloat/e5-base-v2` (E5-base, ~438MB, 768-dim)
-- Preset: `jamie8johnson/e5-base-v2-code-search` (v9-200k LoRA, ~417MB, 768-dim)
+- Preset: `nomic-ai/CodeRankEmbed` (nomic-coderank, ~547MB, 768-dim) — code-specialised, opt-in via `CQS_EMBEDDING_MODEL=nomic-coderank` (#1110)
 - Custom: any HuggingFace repo via `[embedding]` config section, `--model` CLI flag, or `CQS_EMBEDDING_MODEL` env var
 - Size varies by model
 - Cached in: `~/.cache/huggingface/`

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,15 +2,24 @@
 
 ## Right Now
 
-**v1.29.1 still current (no new release).** Main at `df689741` post-#1105 merge. Cache+slots infrastructure shipped; three-way embedder A/B run on the new infra (BGE-large vs CodeRankEmbed-137M vs v9-200k); fixture line-start drift surfaced and fixed.
+**v1.29.1 still tagged on crates.io.** Main now ~13 PRs ahead — release worthy of a v1.29.2 (or v1.30.0) bump after a docs-review pass. Today's session (2026-04-25) closed out the remaining v1.29.0 audit umbrella (#1095), shipped #956 Phase A scaffolding, and landed two infra PRs (cache+slots #1105, fixture refresh #1109, nomic-coderank preset #1110).
 
-**Two PRs open awaiting CI/merge:**
-- **#1109 — `chore(evals): refresh v3.v2 fixture line_starts after v1.29.x audits`**. 42 dev + 44 test gold chunks re-pinned to current line numbers. Recovers dev R@5 51.4% → 74.3% (the apparent 25pp regression was 100% fixture drift, not a search bug).
-- **#1110 — `feat(embedder): add nomic-coderank preset (CodeRankEmbed-137M)`**. Opt-in preset with the A/B numbers in the PR body.
+**This session's merged PRs** (newest first):
 
-**Two issues outstanding from today's work:**
-- **#1107 — `cqs slot create --model: validates but does not persist`**. Currently `--model` must be passed globally on every `cqs index --slot X` invocation. Caught when first coderank reindex silently used BGE.
-- **#1108 — `Hot search SELECTs omit content_hash, producing 20 warnings/query in eval`**. 5 production SELECTs in `src/store/{search.rs, chunks/async_helpers.rs, chunks/query.rs}` build `ChunkRow` via `from_row` without selecting `content_hash` — `try_get` falls back silently and `reference.rs:333` recomputes blake3 per result. ~2,180 warnings per dev eval run.
+| PR | Closes | Title |
+|---|---|---|
+| **#1120** | — *(Phase A only)* | `refactor(embedder): ExecutionProvider feature split — Phase A (#956)` — `gpu-index` → `cuda-index` rename + alias, `ep-coreml`/`ep-rocm` cargo features, cfg-gated enum variants, per-backend probe blocks. CUDA path byte-identical. Phase B (CoreML/macOS runner) + Phase C (ROCm/AMD) deferred. |
+| **#1119** | #1115 #1116 | `perf: v1.29.0 audit micro-fixes` — `forward_bfs_multi` for `suggest_tests` (`O(callers × graph)` → `O(tests + edges)`); thread-local scratch buffer in daemon socket handler |
+| **#1118** | #1096 (SEC-7) | `fix(serve): per-launch auth token` — 256-bit URL-safe base64 token, constant-time compare, three credential surfaces (Bearer / cookie / `?token=`), HttpOnly+SameSite=Strict cookie handoff |
+| **#1117** | #1047 | `fix(language): macro-generated ChunkType::human_name` — exhaustive `define_chunk_types!` macro removes catch-all that silently fell through for new variants |
+| #1114 | #1097 (EX-1) | `refactor: single-registration command registry` — collapses 5+ exhaustive matches into one `for_each_command!` table |
+| #1113 | #1090 | `fix(watch): non-blocking HNSW rebuilds` |
+| #1112 | #1042 #1049 #1091 #1107 #1108 | `fix: 5-issue batch` — clears most of the v1.29.0 audit P4 backlog |
+| #1111 | — | `chore(tears+roadmap): post-#1105 / cache+slots / embedder A/B state` |
+| #1110 | — | `feat(embedder): add nomic-coderank preset (CodeRankEmbed-137M)` |
+| #1109 | — | `chore(evals): refresh v3.v2 fixture line_starts` |
+
+**Outstanding issues**: down to 9 open (was 19 yesterday). Two tier-2 (#956 EP-decouple — Phase A landed, B/C still open; #916 mmap SPLADE), one cosmetic (#1102 LLM provider log string), three Windows-specific tier-3 (#1043 #1044 — both need Windows test env), three external-blocked tier-3 (#717 hnsw_rs lib swap, #255 pre-built indexes infra, #106 ort 2.0 stable). See ROADMAP.md "Open Issues".
 
 ### Today's session (2026-04-25) — what landed
 
@@ -174,35 +183,17 @@ None. Working tree clean post-release.
 
 3.7-5.5pp gap between canonical and refreshed-current is real corpus-drift attrition (5,413 new chunks since 2026-04-20, ~30% of corpus). Not a search regression. The v3.v2 fixture is the canonical eval slate; v4 fixtures (1526/split, 14× v3 N) exist for any future A/B that needs tighter noise floors. Long-term inoculation against fixture drift would be relaxing eval gold-match to `(file, name, chunk_type)` only — out of scope for this round.
 
-## Open issues (19 open)
+## Open issues (9 open)
 
-**Filed today:**
+| # | Title | Tier | Status |
+|---|---|---|---|
+| 1102 | llm: batch.rs log says "Claude API" regardless of provider | cosmetic | open — small wording fix |
+| 1044 | Windows `cqs watch` can't stop cleanly — DB corruption risk | tier-3, bug | needs Windows test env |
+| 1043 | `is_slow_mmap_fs` ignores Windows network drives | tier-3, perf | needs Windows test env |
+| 956 | ExecutionProvider — decouple gpu-index from CUDA | tier-2, refactor | **PR #1120 in flight (Phase A scaffolding); Phase B/C blocked on macOS / AMD hardware** |
+| 916 | mmap SPLADE index (PF-11) | tier-2, perf | smaller win than originally claimed |
+| 717 | HNSW fully in RAM, no mmap (RM-40) | tier-3, perf | hnsw_rs lib limitation; would need lib swap |
+| 255 | Pre-built reference packages (downloadable indexes) | tier-3, infra | needs signing/registry design |
+| 106 | ort dependency is pre-release RC | tier-3, dep | blocked upstream (pykeio) |
 
-| # | Title | Tier |
-|---|---|---|
-| 1108 | Hot search SELECTs omit content_hash, ~2180 warnings/eval | bug |
-| 1107 | `cqs slot create --model` validates but does not persist | bug |
-
-**Existing (post-v1.29.0 audit / earlier):**
-
-| # | Title | Tier |
-|---|---|---|
-| 1102 | llm: batch.rs log says "Claude API" regardless of provider | bug, cosmetic |
-| 1097 | refactor: collapse Commands enum into trait Command | enhancement, refactor |
-| 1096 | serve: add per-launch auth token | enhancement, security |
-| 1095 | v1.29.0 audit — P4 backlog | audit, tier-2 |
-| 1091 | WSL poll-watcher 8% CPU | performance |
-| 1090 | HNSW rebuild every save (15-30s CUDA) | performance |
-| 1049 | Pin fallback_does_not_mix_comment_styles test | testing, tier-3 |
-| 1048 | try_daemon_query strict-string parsing | enhancement, tier-3 |
-| 1047 | ChunkType::human_name catch-all hides variants | enhancement, tier-3 |
-| 1044 | Windows cqs watch can't stop cleanly | bug, data-integrity, tier-3 |
-| 1043 | is_slow_mmap_fs ignores Windows network drives | performance, tier-3 |
-| 1042 | WINDOW_OVERHEAD doesn't scale with prefix length | enhancement, tier-3 |
-| 956 | ExecutionProvider — decouple gpu-index from CUDA | refactor, tier-2 |
-| 916 | mmap SPLADE index | tier-2 |
-| 717 | HNSW fully in RAM, no mmap | tier-3 |
-| 255 | Pre-built reference packages | enhancement, tier-3 |
-| 106 | ort dependency is pre-release RC | tier-3 |
-
-**Closed today:** #1104 (HNSW flake) → PR #1106.
+**Closed this session (2026-04-25 batch):** #1042, #1047, #1048, #1049, #1090, #1091, #1095 (umbrella, split + closed), #1096, #1097, #1104, #1107, #1108, #1115, #1116. #1115/#1116 were filed and closed in the same session (split from #1095, fixed in #1119).

--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ Two eval suites are run on every release:
 
 Both splits are ±2-3pp noisy on a single trial; quote both when comparing config changes.
 
-**Default config:** BGE-large dense + SPLADE sparse, RRF-fused with per-category α (set via offline sweep), centroid query classifier active by default for category routing. `CQS_EMBEDDING_MODEL=v9-200k` is a 1/3-size alternative for resource-constrained environments.
+**Default config:** BGE-large dense + SPLADE sparse, RRF-fused with per-category α (set via offline sweep), centroid query classifier active by default for category routing. `CQS_EMBEDDING_MODEL=nomic-coderank` is a 137M code-specialised opt-in preset (#1110) for resource-constrained environments — wins R@1 on the v3.v2 test split at ~⅓ the parameters of BGE-large.
 
 ## Environment Variables
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,13 @@
 # Roadmap
 
-## Post-v1.29.1 (in flight, no release yet)
+## Post-v1.29.1 (release candidate, no tag yet)
 
-Cache+slots infrastructure shipped on main (#1105). Three-way embedder A/B (BGE-large vs CodeRankEmbed-137M vs v9-200k) settled on the new infra: BGE-large stays default, CodeRankEmbed becomes opt-in preset, v9-200k retired from production candidacy on the v3.v2 distribution. Two PRs in flight, two issues outstanding from this work — see PROJECT_CONTINUITY.md "Right Now" for full state.
+Main is now ~13 PRs ahead of the v1.29.1 tag — bump-worthy after a docs-review pass. Four arcs landed since the v1.29.1 release:
+
+- **Cache+slots infrastructure (#1105)** — `.cqs/embeddings_cache.db` (content_hash, model_id) + `.cqs/slots/<name>/` directories + per-slot `cqs slot {list,create,promote,remove,active}` and `cqs cache {stats,prune,compact}` commands. One-shot migration of legacy `.cqs/index.db` → `.cqs/slots/default/`.
+- **Three-way embedder A/B (#1109 #1110)** — fixture refresh absorbed v1.29.x line-start drift; BGE-large stays default; CodeRankEmbed-137M added as opt-in preset; v9-200k retired from production candidacy on the v3.v2 distribution.
+- **v1.29.0 audit close-out batch (#1112 #1113 #1114 #1117 #1118 #1119)** — every umbrella finding from #1095 closed: SEC-7 serve auth (#1118), EX-1 command registry (#1114), `cqs watch` HNSW non-blocking (#1113), `ChunkType::human_name` macro (#1117), `forward_bfs_multi` for `suggest_tests` (#1119), thread-local socket scratch buffer (#1119), plus a 5-issue batch (#1112) clearing #1042/#1049/#1091/#1107/#1108.
+- **#956 Phase A scaffolding (#1120)** — `gpu-index` → `cuda-index` cargo feature rename (legacy alias preserved); `ep-coreml` / `ep-rocm` features added as scaffolding markers; `ExecutionProvider` enum gains cfg-gated `CoreML` and `ROCm { device_id }` variants; `detect_provider()` and `create_session()` restructured into per-backend cfg-blocks. CUDA path byte-identical at runtime. Phase B (CoreML, GHA macOS runner) and Phase C (ROCm, AMD hardware) both deferred — issue stays open.
 
 ## Current: v1.29.1 (v1.29.0 audit close-out)
 
@@ -139,31 +144,30 @@ Historical split (2026-04-09, 16,731 invocations): **main conversation** uses `s
 
 ## Open Issues
 
-Re-audited 2026-04-21 against actual GitHub state. **All Tier 1 + Tier 2 issues from the 2026-04-16 audit have shipped** (across PRs #1041, #1045, #1046 in the v1.27 → v1.28 audit-fix waves). Remaining work is the 6 P4 deferrals from the post-v1.27.0 audit + 5 hard-blocked Tier 3 items.
+Re-audited 2026-04-25 against actual GitHub state. **The v1.29.0 audit P4 backlog is now empty** — every numbered finding (1042/1047/1048/1049/1091/1107/1108) closed via PRs #1112, #1117, #1119 (the latter two from the post-v1.29.1 audit close-out batch). Remaining 9 open issues split into "small / opportunistic", "Windows-specific (need test env)", and "external-blocked".
 
-**P4 deferrals (small effort, low impact — opportunistic):**
+**Small / opportunistic:**
 
 | # | Finding | Notes |
 |---|---------|-------|
-| [#1107](https://github.com/jamie8johnson/cqs/issues/1107) | `cqs slot create --model` validates but does not persist | filed 2026-04-25 |
-| [#1108](https://github.com/jamie8johnson/cqs/issues/1108) | Hot search SELECTs omit `content_hash` (~2180 warnings/eval) | filed 2026-04-25 |
-| [#1102](https://github.com/jamie8johnson/cqs/issues/1102) | llm: batch.rs log says "Claude API" regardless of provider | cosmetic |
-| [#1042](https://github.com/jamie8johnson/cqs/issues/1042) | `WINDOW_OVERHEAD` doesn't scale with embedder prefix length | constant tuning |
-| [#1047](https://github.com/jamie8johnson/cqs/issues/1047) | `ChunkType::human_name` catch-all hides multi-word variant omissions | compile-time enforcement |
-| [#1048](https://github.com/jamie8johnson/cqs/issues/1048) | `try_daemon_query` strict-string output parsing | future-proof refactor |
-| [#1049](https://github.com/jamie8johnson/cqs/issues/1049) | Pin `fallback_does_not_mix_comment_styles` with explicit test | tiny test pin |
-| [#1043](https://github.com/jamie8johnson/cqs/issues/1043) | `is_slow_mmap_fs` ignores Windows network drives + reparse points | Windows-specific edge case |
-| [#1044](https://github.com/jamie8johnson/cqs/issues/1044) | Native Windows `cqs watch` cannot stop cleanly — DB corruption risk | Windows-specific signal handling |
+| [#1102](https://github.com/jamie8johnson/cqs/issues/1102) | llm: batch.rs log says "Claude API" regardless of provider | cosmetic wording fix |
 
-**Tier 3 (blocked on external factors):**
+**Windows-specific (need Windows test environment):**
 
 | # | Finding | Blocker |
 |---|---------|---------|
-| [#956](https://github.com/jamie8johnson/cqs/issues/956) | ExecutionProvider: CoreML/ROCm decouple | needs non-Linux CI |
-| [#255](https://github.com/jamie8johnson/cqs/issues/255) | Pre-built reference packages | signing/registry design |
-| [#717](https://github.com/jamie8johnson/cqs/issues/717) | HNSW mmap | needs lib swap to hnswlib-rs (nightly-only) |
-| [#916](https://github.com/jamie8johnson/cqs/issues/916) | mmap SPLADE body | smaller win than originally claimed |
-| [#106](https://github.com/jamie8johnson/cqs/issues/106) | ort 2.0-rc.12 stable release | upstream (pykeio) |
+| [#1043](https://github.com/jamie8johnson/cqs/issues/1043) | `is_slow_mmap_fs` ignores Windows network drives + reparse points | Linux/WSL unaffected; needs Windows runner |
+| [#1044](https://github.com/jamie8johnson/cqs/issues/1044) | Native Windows `cqs watch` cannot stop cleanly — DB corruption risk | Windows signal-handling edge case |
+
+**Tier 2 / 3 (external-blocked or scaffolding-only):**
+
+| # | Finding | Status |
+|---|---------|--------|
+| [#956](https://github.com/jamie8johnson/cqs/issues/956) | ExecutionProvider: CoreML/ROCm decouple | **Phase A in PR #1120** (cargo feature split + cfg-gated enum variants + restructured probe) — Phase B (CoreML, GHA macOS runner) and Phase C (ROCm, AMD hardware) both deferred to contributors with the matching test environment |
+| [#916](https://github.com/jamie8johnson/cqs/issues/916) | mmap SPLADE body (PF-11) | smaller win than originally claimed |
+| [#717](https://github.com/jamie8johnson/cqs/issues/717) | HNSW mmap (RM-40) | needs lib swap to hnswlib-rs (nightly-only) |
+| [#255](https://github.com/jamie8johnson/cqs/issues/255) | Pre-built reference packages | signing/registry design (infra, not code) |
+| [#106](https://github.com/jamie8johnson/cqs/issues/106) | ort 2.0-rc.12 stable release | blocked upstream (pykeio) |
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,7 @@ cqs is a **local code search tool** for developers. It runs on your machine, ind
 | **Project files** | Trusted | Your code, indexed by your choice |
 | **External documents** | Semi-trusted | PDF/HTML/CHM files converted via `cqs convert` — parsed but not executed |
 | **Reference sources** | Semi-trusted | Indexed via `cqs ref add` — search results blended with project code |
+| **`cqs serve` HTTP clients** | Untrusted by default | Per-launch 256-bit auth token gates every request (#1118 / SEC-7); cookie handoff is `HttpOnly; SameSite=Strict`; compare is constant-time. `--no-auth` opts out for scripted automation but is paired with a loud-warn banner on non-loopback binds. |
 
 ### What We Protect Against
 
@@ -39,7 +40,7 @@ The only network activity is:
 - **Model download** (`cqs init`): Downloads embedding model from HuggingFace Hub
   - Default: `huggingface.co/BAAI/bge-large-en-v1.5` (~1.2GB)
   - Preset: `e5-base` (`intfloat/e5-base-v2`, ~438MB)
-  - Preset: `v9-200k` (`jamie8johnson/e5-base-v2-code-search`, ~417MB) — fine-tuned E5-base LoRA
+  - Preset: `nomic-coderank` (`nomic-ai/CodeRankEmbed`, ~547MB) — code-specialised, opt-in via `CQS_EMBEDDING_MODEL=nomic-coderank` (#1110)
   - Custom: any HuggingFace repo via `[embedding]` config or `CQS_EMBEDDING_MODEL` env var. Custom model configs download ONNX files from the specified repo — only configure repos you trust.
   - One-time download per model, cached in `~/.cache/huggingface/`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Features
 //!
-//! - **Semantic search**: Hybrid RRF (keyword + vector) with configurable embedding models (BGE-large default, E5-base and v9-200k presets, custom ONNX). 90.9% Recall@1 on 296-query expanded eval.
+//! - **Semantic search**: Hybrid RRF (keyword + vector) with configurable embedding models (BGE-large default; E5-base, nomic-coderank-137M, and custom ONNX presets). 90.9% Recall@1 on 296-query expanded eval.
 //! - **Call graphs**: Callers, callees, transitive impact, shortest-path tracing between functions
 //! - **Impact analysis**: What breaks if you change X? Callers + affected tests + risk scoring
 //! - **Type dependencies**: Who uses this type? What types does this function use?
@@ -19,7 +19,7 @@
 //! - **Doc comment generation**: `--improve-docs` generates and writes doc comments to source files via LLM
 //! - **HyDE query predictions**: `--hyde-queries` generates synthetic search queries per function for improved recall
 //! - **Training data generation**: `train-data` command generates fine-tuning triplets from git history
-//! - **GPU acceleration**: CUDA/TensorRT with CPU fallback
+//! - **GPU acceleration**: CUDA/TensorRT with CPU fallback (CoreML and ROCm scaffolding present, wiring deferred per #956 Phase B/C)
 //! - **Document conversion**: PDF, HTML, CHM, Web Help → cleaned Markdown (optional `convert` feature)
 //!
 //! ## Quick Start
@@ -30,10 +30,13 @@
 //! use cqs::store::SearchFilter;
 //!
 //! # fn main() -> anyhow::Result<()> {
-//! // Initialize components
+//! // Initialize components. `resolve_index_db` honours the slot layout
+//! // (post-#1105: `.cqs/slots/<active>/index.db`) and falls back to the
+//! // pre-migration `.cqs/index.db` path on unmigrated projects.
 //! let parser = Parser::new()?;
 //! let embedder = Embedder::new(ModelConfig::resolve(None, None))?;
-//! let store = Store::open(std::path::Path::new(".cqs/index.db"))?;
+//! let cqs_dir = cqs::resolve_index_dir(std::path::Path::new("."));
+//! let store = Store::open(&cqs::resolve_index_db(&cqs_dir))?;
 //!
 //! // Parse and embed a file
 //! let chunks = parser.parse_file(std::path::Path::new("src/main.rs"))?;


### PR DESCRIPTION
## Summary

Two-part chore PR capturing the state of main after today's batch and refreshing project docs for accuracy.

### Commit 1 — `chore(tears+roadmap)`

Captures the state of main after today's batch lands:

- Four arcs since the v1.29.1 tag: cache+slots (#1105), three-way embedder A/B (#1109 #1110), v1.29.0 audit close-out (#1112 #1113 #1114 #1117 #1118 #1119), and #956 Phase A scaffolding (#1120)
- Outstanding issues tightened from 19 → 9 open
- ROADMAP "Open Issues" section reflects the empty audit P4 backlog

### Commit 2 — `docs: refresh project docs for post-v1.29.1 state`

Docs-review pass against everything landed since v1.29.1:

- **`src/lib.rs`** — feature list updated for nomic-coderank preset (replaces v9-200k mention) and #956 Phase A note. Quick Start example now uses `resolve_index_db()` so the doctest works on slot-migrated projects (#1105).
- **`CONTRIBUTING.md`** — Architecture Overview catches up: schema v22, `migrations.rs` v10-v22 range, embedder presets (nomic-coderank), `provider.rs` cfg-block restructure (#956 Phase A), `bfs.rs::forward_bfs_multi` (#1115), new `slot/` and `serve/` module trees (incl. `serve/auth.rs` from #1118).
- **`SECURITY.md`** — Trust Boundaries gains a row for `cqs serve` HTTP clients (per-launch auth token, HttpOnly+SameSite=Strict cookie, constant-time compare). Network-request preset list updated.
- **`PRIVACY.md`** — "What Gets Stored" reflects the slot layout and per-project `.cqs/embeddings_cache.db` from #1105; legacy global cache moved to "may also exist from older versions". Model download list updated.
- **`README.md`** — resource-constrained recommendation switches from `CQS_EMBEDDING_MODEL=v9-200k` to `nomic-coderank`. Eval tables left untouched (stable measurements; refresh is a separate decision).

No CHANGELOG entry — that goes in the release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
