### PR TITLE
chore(tears+roadmap): mark v1.30.0 released

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,7 +2,7 @@
 
 ## Right Now
 
-**v1.29.1 still tagged on crates.io.** Main now ~13 PRs ahead — release worthy of a v1.29.2 (or v1.30.0) bump after a docs-review pass. Today's session (2026-04-25) closed out the remaining v1.29.0 audit umbrella (#1095), shipped #956 Phase A scaffolding, and landed two infra PRs (cache+slots #1105, fixture refresh #1109, nomic-coderank preset #1110).
+**v1.30.0 released 2026-04-25.** Tag pushed (`68bfaca5`), GitHub release workflow building binaries, `cqs 1.30.0` published to crates.io, local `~/.cargo/bin/cqs` rebuilt and `cqs-watch` daemon restarted. Today's session (2026-04-25) closed out the remaining v1.29.0 audit umbrella (#1095), shipped #956 Phase A scaffolding, landed cache+slots (#1105) + fixture refresh (#1109) + nomic-coderank preset (#1110), and cut the v1.30.0 release.
 
 **This session's merged PRs** (newest first):
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Roadmap
 
-## Post-v1.29.1 (release candidate, no tag yet)
+## Current: v1.30.0 (released 2026-04-25)
 
-Main is now ~13 PRs ahead of the v1.29.1 tag — bump-worthy after a docs-review pass. Four arcs landed since the v1.29.1 release:
+Tag `v1.30.0` pushed; `cqs 1.30.0` published to crates.io; GitHub release workflow building prebuilt binaries. Four arcs landed since the v1.29.1 tag:
 
 - **Cache+slots infrastructure (#1105)** — `.cqs/embeddings_cache.db` (content_hash, model_id) + `.cqs/slots/<name>/` directories + per-slot `cqs slot {list,create,promote,remove,active}` and `cqs cache {stats,prune,compact}` commands. One-shot migration of legacy `.cqs/index.db` → `.cqs/slots/default/`.
 - **Three-way embedder A/B (#1109 #1110)** — fixture refresh absorbed v1.29.x line-start drift; BGE-large stays default; CodeRankEmbed-137M added as opt-in preset; v9-200k retired from production candidacy on the v3.v2 distribution.


### PR DESCRIPTION
Three-line update: PROJECT_CONTINUITY.md "Right Now" flips to v1.30.0 released; ROADMAP.md "Post-v1.29.1" header becomes "Current: v1.30.0". Tag, crates.io publish, local binary install all done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
