### PR TITLE
fix(watch): #1124 — content-hash-aware drain replays mid-rebuild re-embeddings

### DIFF
--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -870,18 +870,28 @@ fn hnsw_batch_size() -> usize {
 /// Notes are excluded from HNSW — they use brute-force search from SQLite
 /// so that notes are immediately searchable without rebuild.
 pub(crate) fn build_hnsw_index(store: &Store, cqs_dir: &Path) -> Result<Option<usize>> {
-    Ok(build_hnsw_index_owned(store, cqs_dir)?.map(|h| h.len()))
+    Ok(build_hnsw_index_owned(store, cqs_dir)?.map(|(h, _)| h.len()))
 }
 
-/// Build HNSW index and return the Owned index for continued incremental use.
+/// Build HNSW index and return the Owned index plus a per-id `content_hash`
+/// snapshot for continued incremental use.
 ///
 /// Builds from all chunk embeddings in the store, saves to disk, and returns
-/// the `HnswIndex` (Owned variant). Used by watch mode to keep a mutable index
-/// in memory for `insert_batch` calls on subsequent file changes.
+/// `(HnswIndex, snapshot_hashes)` where `snapshot_hashes[id]` is the
+/// `content_hash` the embedding was generated from. Used by watch mode to
+/// keep a mutable index in memory for `insert_batch` calls and (on the
+/// background-rebuild path, #1124) to detect entries that were re-embedded
+/// mid-rebuild — the swap-time drain replays them with the fresh vector
+/// instead of dedup'ing them by id-only and silently dropping the update.
+///
+/// Both the embeddings and the hashes come from a single SQL pass via
+/// [`Store::embedding_and_hash_batches`] so they're consistent under
+/// concurrent writers (WAL snapshot isolation only holds within a
+/// transaction).
 pub(crate) fn build_hnsw_index_owned<M>(
     store: &cqs::store::Store<M>,
     cqs_dir: &Path,
-) -> Result<Option<HnswIndex>> {
+) -> Result<Option<(HnswIndex, std::collections::HashMap<String, String>)>> {
     let chunk_count = store.chunk_count().context("Failed to read chunk count")? as usize;
     let _span = tracing::info_span!("build_hnsw_index_owned", chunk_count).entered();
 
@@ -891,12 +901,27 @@ pub(crate) fn build_hnsw_index_owned<M>(
 
     let batch_size = hnsw_batch_size();
 
-    let chunk_batches = store.embedding_batches(batch_size);
+    // Tee the (id, embedding, hash) stream: HNSW build consumes
+    // (id, embedding) pairs while we accumulate (id, hash) into a side map.
+    // Single SQL pass — no second query, no risk of the hash drifting from
+    // the embedding under concurrent writers.
+    let mut snapshot_hashes: std::collections::HashMap<String, String> =
+        std::collections::HashMap::with_capacity(chunk_count);
+    let chunk_batches = store.embedding_and_hash_batches(batch_size).map(|batch| {
+        batch.map(|triples| {
+            let mut pairs = Vec::with_capacity(triples.len());
+            for (id, emb, hash) in triples {
+                snapshot_hashes.insert(id.clone(), hash);
+                pairs.push((id, emb));
+            }
+            pairs
+        })
+    });
 
     let hnsw = HnswIndex::build_batched_with_dim(chunk_batches, chunk_count, store.dim())?;
     hnsw.save(cqs_dir, "index")?;
 
-    Ok(Some(hnsw))
+    Ok(Some((hnsw, snapshot_hashes)))
 }
 
 /// Build the Phase 5 base HNSW index from `embedding_base` and save as
@@ -1022,10 +1047,24 @@ mod tests {
         let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
         let store = Store::open_readonly_after_init(&index_path, |_| Ok(())).expect("ro store");
 
-        let idx = build_hnsw_index_owned(&store, &cqs_dir)
+        let (idx, snapshot_hashes) = build_hnsw_index_owned(&store, &cqs_dir)
             .expect("build_hnsw_index_owned must succeed")
             .expect("non-empty store must produce an index");
         assert_eq!(idx.len(), n, "index len must equal seeded chunk count");
+        // P1.17 (#1124): snapshot must carry one (id, content_hash) entry
+        // per built vector so the rebuild-window drain can detect stale
+        // entries.
+        assert_eq!(
+            snapshot_hashes.len(),
+            n,
+            "snapshot_hashes must contain one entry per chunk"
+        );
+        for id in idx.ids() {
+            assert!(
+                snapshot_hashes.contains_key(id),
+                "snapshot_hashes missing id {id}"
+            );
+        }
         // The hnsw save side-effect should land at `<cqs_dir>/index.hnsw.*`.
         // We can't easily round-trip-load without exposing private save
         // path constants, so just verify the in-memory state is correct.

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -652,7 +652,14 @@ struct WatchState {
 /// closing the TOCTOU between the rebuild thread's snapshot and `recv`.
 struct PendingRebuild {
     rx: std::sync::mpsc::Receiver<RebuildOutcome>,
-    delta: Vec<(String, Embedding)>,
+    /// P1.17 / #1124: each entry carries the chunk's `content_hash` alongside
+    /// (id, embedding) so the swap-time drain can compare against the
+    /// rebuild thread's snapshot. An id-only dedup would silently drop the
+    /// fresh embedding for any chunk that was re-embedded mid-rebuild
+    /// (snapshot has the OLD vector under the same id; delta has the NEW
+    /// one) — the HNSW would carry the stale vector until the next
+    /// threshold rebuild.
+    delta: Vec<(String, Embedding, String)>,
     started_at: std::time::Instant,
     /// P2.71: held so daemon shutdown can `join` (or detect the thread is
     /// finished) instead of leaking a detached worker. `None` if the spawn
@@ -665,6 +672,17 @@ struct PendingRebuild {
     delta_saturated: bool,
 }
 
+/// P1.17 / #1124: the rebuild thread reports both the freshly-built
+/// `HnswIndex` AND the per-id `content_hash` snapshot the build consumed.
+/// The drain path needs the snapshot map to detect mid-rebuild
+/// re-embeddings — without it, a hash-aware dedup would have to issue a
+/// second SQL query (and lose snapshot consistency under concurrent
+/// writers).
+pub(crate) struct RebuildResult {
+    pub index: HnswIndex,
+    pub snapshot_hashes: std::collections::HashMap<String, String>,
+}
+
 /// P2.72: cap on per-rebuild delta size. A stale-rebuild that runs longer
 /// than expected (very large index, slow disk) accumulates one entry per
 /// chunk re-embedded by the watch loop. Without a cap a multi-GB embedding
@@ -673,7 +691,7 @@ struct PendingRebuild {
 /// next threshold rebuild's fresh SQLite scan.
 const MAX_PENDING_REBUILD_DELTA: usize = 5_000;
 
-type RebuildOutcome = Result<Option<HnswIndex>, anyhow::Error>;
+type RebuildOutcome = Result<Option<RebuildResult>, anyhow::Error>;
 
 /// Track exponential backoff state for embedder initialization retries.
 ///
@@ -1050,12 +1068,17 @@ fn spawn_hnsw_rebuild(
                         "base HNSW rebuild failed in background; router falls back to enriched-only"
                     ),
                 }
-                Ok(enriched)
+                // P1.17 / #1124: package the (index, snapshot_hashes) pair
+                // so the drain can detect mid-rebuild re-embeddings.
+                Ok(enriched.map(|(index, snapshot_hashes)| RebuildResult {
+                    index,
+                    snapshot_hashes,
+                }))
             })();
             let elapsed_ms = started_at.elapsed().as_millis();
             match &result {
-                Ok(Some(idx)) => tracing::info!(
-                    vectors = idx.len(),
+                Ok(Some(r)) => tracing::info!(
+                    vectors = r.index.len(),
                     elapsed_ms,
                     context,
                     "background HNSW rebuild complete"
@@ -1127,7 +1150,10 @@ fn drain_pending_rebuild(cfg: &WatchConfig, store: &Store, state: &mut WatchStat
         .expect("pending_rebuild was Some when we held a borrow");
 
     match outcome {
-        Ok(Some(mut new_index)) => {
+        Ok(Some(RebuildResult {
+            index: mut new_index,
+            snapshot_hashes,
+        })) => {
             // P2.72: if the delta saturated, the rebuilt index is missing
             // events that we dropped on the floor; swapping it in would
             // silently lose those chunks. Discard instead — the next
@@ -1148,18 +1174,28 @@ fn drain_pending_rebuild(cfg: &WatchConfig, store: &Store, state: &mut WatchStat
                 }
                 return;
             }
-            // Replay captured delta — but skip ids the rebuild thread already
-            // saw via its store snapshot, so we don't double-insert. (hnsw_rs
-            // has no dedup; duplicate ids would create twin vectors that bloat
-            // the graph until the next threshold cleans them up.)
-            let known: std::collections::HashSet<&str> =
-                new_index.ids().iter().map(String::as_str).collect();
+            // P1.17 / #1124: replay captured delta — skip only entries
+            // whose (id, content_hash) match the snapshot. An id that was
+            // re-embedded mid-rebuild has a NEW hash in delta but the
+            // snapshot baked in the OLD vector; the entry must replay so
+            // the fresh embedding lands in the swapped HNSW. Pure id-only
+            // dedup (the pre-fix shape) silently dropped these and left
+            // the HNSW serving stale vectors until the next threshold
+            // rebuild.
+            //
+            // Trade-off when an id IS re-embedded: `insert_batch` on
+            // hnsw_rs adds a duplicate node (no deletion API). That's the
+            // same orphan situation as the existing fast-incremental path
+            // — search post-filters by SQLite, so the orphan is invisible
+            // to callers. The next threshold rebuild cleans it up.
             let to_replay: Vec<(String, Embedding)> = pending
                 .delta
                 .into_iter()
-                .filter(|(id, _)| !known.contains(id.as_str()))
+                .filter(|(id, _, hash)| {
+                    snapshot_hashes.get(id.as_str()).is_none_or(|sh| sh != hash)
+                })
+                .map(|(id, emb, _)| (id, emb))
                 .collect();
-            drop(known);
             if !to_replay.is_empty() {
                 let items: Vec<(String, &[f32])> = to_replay
                     .iter()
@@ -2886,9 +2922,13 @@ fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut WatchState
                             // in the HNSW graph (hnsw_rs has no deletion). Orphans are
                             // harmless: search post-filters against live SQLite chunk
                             // IDs. They're cleaned on the next threshold rebuild.
+                            //
+                            // P1.17 / #1124: `pairs` carries content_hash as the
+                            // third tuple slot for the rebuild-window path; the
+                            // incremental insert only needs (id, embedding).
                             let items: Vec<(String, &[f32])> = pairs
                                 .iter()
-                                .map(|(id, emb)| (id.clone(), emb.as_slice()))
+                                .map(|(id, emb, _hash)| (id.clone(), emb.as_slice()))
                                 .collect();
                             match index.insert_batch(&items) {
                                 Ok(n) => {
@@ -4224,15 +4264,28 @@ mod tests {
         assert_eq!(new_idx.len(), 3);
 
         let (tx, rx) = std::sync::mpsc::channel();
-        tx.send(Ok(Some(new_idx))).unwrap();
+        tx.send(Ok(Some(RebuildResult {
+            index: new_idx,
+            // No overlap between delta ids and snapshot — all replay.
+            snapshot_hashes: std::collections::HashMap::new(),
+        })))
+        .unwrap();
         drop(tx);
 
         let mut state = test_watch_state();
         state.pending_rebuild = Some(PendingRebuild {
             rx,
             delta: vec![
-                ("delta_a".to_string(), cqs::Embedding::new(vec![1.0; dim])),
-                ("delta_b".to_string(), cqs::Embedding::new(vec![0.5; dim])),
+                (
+                    "delta_a".to_string(),
+                    cqs::Embedding::new(vec![1.0; dim]),
+                    "h_delta_a".to_string(),
+                ),
+                (
+                    "delta_b".to_string(),
+                    cqs::Embedding::new(vec![0.5; dim]),
+                    "h_delta_b".to_string(),
+                ),
             ],
             started_at: std::time::Instant::now(),
             handle: None,
@@ -4258,25 +4311,159 @@ mod tests {
         assert!(state.pending_rebuild.is_none());
     }
 
+    /// P1.17 / #1124: when a chunk is re-embedded mid-rebuild, the snapshot
+    /// has the OLD vector under the same id while delta has the NEW vector
+    /// + new content_hash. The drain must REPLAY the delta entry so the
+    /// fresh embedding lands in the swapped HNSW. The pre-fix code dedup'd
+    /// by id-only and silently dropped these updates.
+    ///
+    /// We can't query hnsw_rs for "give me the embedding stored under id X"
+    /// (it's a graph, not a kv store) and there's no deletion API, so we
+    /// assert the side-effect: the swapped index contains MORE entries
+    /// than the snapshot alone (orphan + replayed vector both present),
+    /// and a search by the FRESH embedding returns id "a" with cosine ≈ 1.0.
+    #[test]
+    fn test_rebuild_window_re_embedding_replays_fresh_vector() {
+        let dim = 4;
+
+        // Snapshot has id "a" baked in with hash h_v1 (and an unrelated id "z"
+        // so the index isn't trivially empty).
+        let snapshot_batch: Vec<(String, cqs::Embedding)> = vec![
+            (
+                "a".to_string(),
+                cqs::Embedding::new(vec![1.0, 0.0, 0.0, 0.0]),
+            ),
+            (
+                "z".to_string(),
+                cqs::Embedding::new(vec![0.0, 0.0, 0.0, 1.0]),
+            ),
+        ];
+        let snapshot_iter = std::iter::once(Ok::<_, cqs::store::StoreError>(snapshot_batch));
+        let new_idx = cqs::hnsw::HnswIndex::build_batched_with_dim(snapshot_iter, 2, dim)
+            .expect("build snapshot index");
+        assert_eq!(new_idx.len(), 2, "snapshot starts with 2 entries");
+
+        let mut snapshot_hashes = std::collections::HashMap::new();
+        snapshot_hashes.insert("a".to_string(), "h_v1".to_string());
+        snapshot_hashes.insert("z".to_string(), "h_z".to_string());
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        tx.send(Ok(Some(RebuildResult {
+            index: new_idx,
+            snapshot_hashes,
+        })))
+        .unwrap();
+        drop(tx);
+
+        // Delta has "a" again, but with a NEW embedding and a NEW content_hash —
+        // i.e. the file was re-embedded between the snapshot and the swap.
+        // The fresh vector points along axis 1, distinct from the snapshot's
+        // axis-0 vector, so we can tell them apart by search.
+        let fresh_embedding = cqs::Embedding::new(vec![0.0, 1.0, 0.0, 0.0]);
+
+        let mut state = test_watch_state();
+        state.pending_rebuild = Some(PendingRebuild {
+            rx,
+            delta: vec![(
+                "a".to_string(),
+                fresh_embedding.clone(),
+                "h_v2".to_string(), // hash differs from snapshot's "h_v1"
+            )],
+            started_at: std::time::Instant::now(),
+            handle: None,
+            delta_saturated: false,
+        });
+
+        let fix = drain_test_fixture(dim);
+        let cfg = test_watch_config(
+            fix.tmp.path(),
+            fix.tmp.path(),
+            &fix.notes_path,
+            &fix.supported_ext,
+        );
+
+        drain_pending_rebuild(&cfg, &fix.store, &mut state);
+
+        let idx = state.hnsw_index.expect("rebuild was swapped in");
+        // The fresh vector was REPLAYED — index now contains 3 nodes
+        // (snapshot's "a" + "z" + replayed "a"). hnsw_rs has no deletion,
+        // so both vectors for "a" coexist as duplicate-id orphans; that's
+        // the same trade-off as the fast-incremental path. Search
+        // post-filters via SQLite in production, which collapses the
+        // duplicates into one logical hit.
+        assert_eq!(
+            idx.len(),
+            3,
+            "fresh re-embedding must be replayed (snapshot 2 + 1 replay)"
+        );
+
+        // Crucial assertion: searching by the FRESH embedding returns id "a".
+        // Pre-fix, the replay was skipped, so the only "a" in the index was
+        // the snapshot's axis-0 vector, and querying the axis-1 fresh vector
+        // would surface "z" or "a" with poor cosine. After the fix, the
+        // axis-1 vector is in the index under "a" with cosine ≈ 1.0.
+        let hits = idx.search(&fresh_embedding, 1);
+        assert!(!hits.is_empty(), "search must return at least one hit");
+        let top = &hits[0];
+        assert_eq!(
+            top.id, "a",
+            "top hit for fresh embedding must be the re-embedded chunk \"a\""
+        );
+        assert!(
+            top.score > 0.99,
+            "top hit cosine must be near 1.0 (fresh vector is in the index); got {}",
+            top.score
+        );
+
+        assert!(state.pending_rebuild.is_none());
+    }
+
     #[test]
     fn drain_pending_rebuild_dedups_against_known_ids() {
-        // The rebuild thread already includes c0..c2 in its snapshot. Replaying
-        // those same ids would double-insert (hnsw_rs has no dedup) — drain
-        // must filter them against `new_index.ids()` first.
+        // P1.17 / #1124: dedup is now (id, content_hash)-aware, not id-only.
+        // The rebuild thread snapshotted c0/c1/c2 with hashes h0/h1/h2.
+        // Delta replays c0 with the SAME hash h0 (true duplicate — must be
+        // skipped), c1 with the same hash h1 (skipped), and c_new with a
+        // brand-new id (must replay). c0/c1 with matching hashes would
+        // double-insert under the pre-fix code; the new dedup uses the
+        // snapshot hashes the rebuild produced.
         let dim = 4;
         let new_idx = synthetic_owned_index(3, dim); // ids: c0, c1, c2
 
+        let mut snapshot_hashes = std::collections::HashMap::new();
+        snapshot_hashes.insert("c0".to_string(), "h0".to_string());
+        snapshot_hashes.insert("c1".to_string(), "h1".to_string());
+        snapshot_hashes.insert("c2".to_string(), "h2".to_string());
+
         let (tx, rx) = std::sync::mpsc::channel();
-        tx.send(Ok(Some(new_idx))).unwrap();
+        tx.send(Ok(Some(RebuildResult {
+            index: new_idx,
+            snapshot_hashes,
+        })))
+        .unwrap();
         drop(tx);
 
         let mut state = test_watch_state();
         state.pending_rebuild = Some(PendingRebuild {
             rx,
             delta: vec![
-                ("c0".to_string(), cqs::Embedding::new(vec![9.0; dim])),
-                ("c1".to_string(), cqs::Embedding::new(vec![9.0; dim])),
-                ("c_new".to_string(), cqs::Embedding::new(vec![9.0; dim])),
+                // Same id + same hash → genuine duplicate, skip.
+                (
+                    "c0".to_string(),
+                    cqs::Embedding::new(vec![9.0; dim]),
+                    "h0".to_string(),
+                ),
+                (
+                    "c1".to_string(),
+                    cqs::Embedding::new(vec![9.0; dim]),
+                    "h1".to_string(),
+                ),
+                // Brand-new id → snapshot didn't see it, must replay.
+                (
+                    "c_new".to_string(),
+                    cqs::Embedding::new(vec![9.0; dim]),
+                    "h_new".to_string(),
+                ),
             ],
             started_at: std::time::Instant::now(),
             handle: None,
@@ -4298,7 +4485,7 @@ mod tests {
         assert_eq!(
             idx.len(),
             4,
-            "3 from new_idx + 1 genuinely-new delta entry — duplicates skipped"
+            "3 from new_idx + 1 genuinely-new delta entry — same-hash duplicates skipped"
         );
         assert!(idx.ids().iter().any(|id| id == "c_new"));
     }

--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -186,6 +186,36 @@ impl<Mode> Store<Mode> {
         }
     }
 
+    /// Stream `(id, embedding, content_hash)` triples in batches.
+    ///
+    /// Same cursor-paginated single-pass shape as [`Store::embedding_batches`],
+    /// but each row also carries the chunk's `content_hash`. This is the
+    /// snapshot path used by the background HNSW rebuild thread (see #1124):
+    /// the rebuild needs both the vector (to feed HNSW build) and the hash
+    /// it was built from (so the swap-time drain can detect entries that
+    /// were re-embedded mid-rebuild and replay the fresh vector instead of
+    /// dropping it as a "duplicate id").
+    ///
+    /// Single SQL pass — `embedding` and `content_hash` come from the same
+    /// row read so they're consistent under concurrent writers (WAL snapshot
+    /// isolation only holds within a transaction).
+    ///
+    /// Sync-only: internally uses `block_on`. Call from the same context as
+    /// [`Store::embedding_batches`].
+    pub fn embedding_and_hash_batches(
+        &self,
+        batch_size: usize,
+    ) -> impl Iterator<Item = Result<Vec<(String, Embedding, String)>, StoreError>> + '_ {
+        let _span =
+            tracing::debug_span!("embedding_and_hash_batches", batch_size = batch_size).entered();
+        EmbeddingHashBatchIterator {
+            store: self,
+            batch_size,
+            last_rowid: 0,
+            done: false,
+        }
+    }
+
     /// Stream `embedding_base` rows in batches for the Phase 5 dual HNSW build.
     ///
     /// Rows with NULL `embedding_base` are skipped — that happens after the
@@ -558,6 +588,89 @@ impl<'a, Mode> Iterator for EmbeddingBatchIterator<'a, Mode> {
 // This is guaranteed by the check at the start of `next()`.
 impl<'a, Mode> std::iter::FusedIterator for EmbeddingBatchIterator<'a, Mode> {}
 
+/// Iterator for streaming `(id, embedding, content_hash)` triples.
+///
+/// Mirrors [`EmbeddingBatchIterator`]'s cursor pagination but reads the
+/// `content_hash` column in the same SQL pass so the hash is consistent
+/// with the embedding bytes the snapshot returned (#1124). Used only for
+/// the background-rebuild snapshot path; the regular `embedding` column
+/// (no hash) flows through [`EmbeddingBatchIterator`].
+struct EmbeddingHashBatchIterator<'a, Mode> {
+    store: &'a Store<Mode>,
+    batch_size: usize,
+    last_rowid: i64,
+    done: bool,
+}
+
+impl<'a, Mode> Iterator for EmbeddingHashBatchIterator<'a, Mode> {
+    type Item = Result<Vec<(String, Embedding, String)>, StoreError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.done {
+                return None;
+            }
+
+            let result = self.store.rt.block_on(async {
+                let sql = "SELECT rowid, id, embedding, content_hash FROM chunks \
+                           WHERE rowid > ?1 AND embedding IS NOT NULL \
+                           ORDER BY rowid ASC LIMIT ?2";
+                let rows: Vec<_> = sqlx::query(sql)
+                    .bind(self.last_rowid)
+                    .bind(self.batch_size as i64)
+                    .fetch_all(&self.store.pool)
+                    .await?;
+
+                let rows_fetched = rows.len();
+                let mut max_rowid = self.last_rowid;
+
+                let batch: Vec<(String, Embedding, String)> = rows
+                    .into_iter()
+                    .filter_map(|row| {
+                        let rowid: i64 = row.get(0);
+                        let id: String = row.get(1);
+                        let bytes: Vec<u8> = row.get(2);
+                        let hash: String = row.get(3);
+                        if rowid > max_rowid {
+                            max_rowid = rowid;
+                        }
+                        match bytes_to_embedding(&bytes, self.store.dim) {
+                            Ok(emb) => Some((id, Embedding::new(emb), hash)),
+                            Err(e) => {
+                                tracing::warn!(chunk_id = %id, error = %e, "Skipping corrupt embedding in hash-batch iterator");
+                                None
+                            }
+                        }
+                    })
+                    .collect();
+
+                Ok::<_, StoreError>((batch, rows_fetched, max_rowid))
+            });
+
+            match result {
+                Ok((batch, rows_fetched, _)) if batch.is_empty() && rows_fetched == 0 => {
+                    self.done = true;
+                    return None;
+                }
+                Ok((batch, _, max_rowid)) => {
+                    self.last_rowid = max_rowid;
+                    if batch.is_empty() {
+                        continue;
+                    } else {
+                        return Some(Ok(batch));
+                    }
+                }
+                Err(e) => {
+                    self.done = true;
+                    return Some(Err(e));
+                }
+            }
+        }
+    }
+}
+
+impl<'a, Mode> std::iter::FusedIterator for EmbeddingHashBatchIterator<'a, Mode> {}
+
 #[cfg(test)]
 mod tests {
     use super::super::test_utils::make_chunk;
@@ -609,6 +722,48 @@ mod tests {
     fn test_embedding_batches_empty_store() {
         let (store, _dir) = setup_store();
         let batches: Vec<_> = store.embedding_batches(10).collect();
+        assert!(batches.is_empty());
+    }
+
+    /// P1.17 / #1124: `embedding_and_hash_batches` must yield each chunk's
+    /// `(id, embedding, content_hash)` together from a single SQL pass —
+    /// the rebuild snapshot relies on hash↔embedding consistency.
+    #[test]
+    fn test_embedding_and_hash_batches_pairs_id_and_hash_per_row() {
+        let (store, _dir) = setup_store();
+
+        let chunks: Vec<_> = (0..6)
+            .map(|i| make_chunk(&format!("fn_{}", i), &format!("src/{}.rs", i)))
+            .collect();
+        let expected_hashes: std::collections::HashMap<String, String> = chunks
+            .iter()
+            .map(|c| (c.id.clone(), c.content_hash.clone()))
+            .collect();
+        let pairs: Vec<_> = chunks
+            .iter()
+            .enumerate()
+            .map(|(i, c)| (c.clone(), mock_embedding(i as f32)))
+            .collect();
+        store.upsert_chunks_batch(&pairs, Some(100)).unwrap();
+
+        let triples: Vec<_> = store
+            .embedding_and_hash_batches(4)
+            .filter_map(|b| b.ok())
+            .flatten()
+            .collect();
+        assert_eq!(triples.len(), 6);
+        for (id, _emb, hash) in &triples {
+            let want = expected_hashes
+                .get(id)
+                .unwrap_or_else(|| panic!("unexpected id from iterator: {id}"));
+            assert_eq!(hash, want, "hash for id {id} must match upsert hash");
+        }
+    }
+
+    #[test]
+    fn test_embedding_and_hash_batches_empty_store() {
+        let (store, _dir) = setup_store();
+        let batches: Vec<_> = store.embedding_and_hash_batches(10).collect();
         assert!(batches.is_empty());
     }
 

--- a/src/store/chunks/embeddings.rs
+++ b/src/store/chunks/embeddings.rs
@@ -74,14 +74,23 @@ impl<Mode> Store<Mode> {
         })
     }
 
-    /// Get (chunk_id, embedding) pairs for chunks with matching content hashes.
-    /// Unlike `get_embeddings_by_hashes` (which keys by content_hash), this returns
-    /// the chunk ID alongside the embedding — exactly what HNSW `insert_batch` needs.
-    /// Batches queries in groups of 500 to stay within SQLite's parameter limit (~999).
+    /// Get `(chunk_id, embedding, content_hash)` triples for chunks with
+    /// matching content hashes.
+    ///
+    /// Unlike `get_embeddings_by_hashes` (which keys by content_hash), this
+    /// returns the chunk ID alongside the embedding — exactly what HNSW
+    /// `insert_batch` needs. The `content_hash` is also returned so callers
+    /// (e.g. the watch reindex path that pushes into `pending.delta`) can
+    /// pair each fresh embedding with the hash it was generated from
+    /// (#1124). The hash is read from the same row, so it's consistent
+    /// with the embedding bytes returned.
+    ///
+    /// Batches queries in groups of 500 to stay within SQLite's parameter
+    /// limit (~999).
     pub fn get_chunk_ids_and_embeddings_by_hashes(
         &self,
         hashes: &[&str],
-    ) -> Result<Vec<(String, Embedding)>, StoreError> {
+    ) -> Result<Vec<(String, Embedding, String)>, StoreError> {
         let _span = tracing::debug_span!(
             "get_chunk_ids_and_embeddings_by_hashes",
             count = hashes.len()
@@ -99,7 +108,7 @@ impl<Mode> Store<Mode> {
             for batch in hashes.chunks(BATCH_SIZE) {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
                 let sql = format!(
-                    "SELECT id, embedding FROM chunks WHERE content_hash IN ({})",
+                    "SELECT id, embedding, content_hash FROM chunks WHERE content_hash IN ({})",
                     placeholders
                 );
 
@@ -114,6 +123,7 @@ impl<Mode> Store<Mode> {
                 for row in rows {
                     let id: String = row.get(0);
                     let bytes: Vec<u8> = row.get(1);
+                    let hash: String = row.get(2);
                     match bytes_to_embedding(&bytes, dim) {
                         // TC-ADV-1: same finiteness guard as
                         // `get_embeddings_by_hashes`. NaN/Inf values would
@@ -122,7 +132,7 @@ impl<Mode> Store<Mode> {
                         // warn instead.
                         Ok(embedding) => match Embedding::try_new(embedding) {
                             Ok(e) => {
-                                result.push((id, e));
+                                result.push((id, e, hash));
                             }
                             Err(e) => {
                                 tracing::warn!(
@@ -302,17 +312,23 @@ mod tests {
             .unwrap();
 
         // Good chunk present, bad chunk absent.
-        let ids: Vec<&str> = result.iter().map(|(id, _)| id.as_str()).collect();
+        let ids: Vec<&str> = result.iter().map(|(id, _, _)| id.as_str()).collect();
         assert!(ids.contains(&good.id.as_str()), "good id missing: {ids:?}");
         assert!(
             !ids.contains(&bad_id.as_str()),
             "NaN-containing chunk id must be filtered out: {ids:?}"
         );
-        // All returned embeddings are finite.
-        for (id, emb) in &result {
+        // All returned embeddings are finite, and content_hash threaded
+        // through is the chunk's stored hash (paired with the same row).
+        for (id, emb, hash) in &result {
             assert!(
                 emb.as_slice().iter().all(|v| v.is_finite()),
                 "embedding for id={id} must be finite"
+            );
+            assert_eq!(
+                hash.len(),
+                64,
+                "content_hash for id={id} must be a 64-char hex string"
             );
         }
     }
@@ -345,8 +361,10 @@ mod tests {
         assert_eq!(result.len(), 3, "Should return all 3 inserted chunks");
 
         // Build a lookup by chunk id for order-independent assertions
-        let by_id: std::collections::HashMap<&str, &Embedding> =
-            result.iter().map(|(id, emb)| (id.as_str(), emb)).collect();
+        let by_id: std::collections::HashMap<&str, (&Embedding, &str)> = result
+            .iter()
+            .map(|(id, emb, hash)| (id.as_str(), (emb, hash.as_str())))
+            .collect();
 
         assert!(by_id.contains_key(chunk1.id.as_str()));
         assert!(by_id.contains_key(chunk2.id.as_str()));
@@ -354,16 +372,22 @@ mod tests {
 
         // Verify embeddings match (cosine similarity ~1.0 with themselves)
         let cos1 =
-            crate::math::cosine_similarity(by_id[chunk1.id.as_str()].as_slice(), emb1.as_slice())
+            crate::math::cosine_similarity(by_id[chunk1.id.as_str()].0.as_slice(), emb1.as_slice())
                 .unwrap();
         let cos2 =
-            crate::math::cosine_similarity(by_id[chunk2.id.as_str()].as_slice(), emb2.as_slice())
+            crate::math::cosine_similarity(by_id[chunk2.id.as_str()].0.as_slice(), emb2.as_slice())
                 .unwrap();
         let cos3 =
-            crate::math::cosine_similarity(by_id[chunk3.id.as_str()].as_slice(), emb3.as_slice())
+            crate::math::cosine_similarity(by_id[chunk3.id.as_str()].0.as_slice(), emb3.as_slice())
                 .unwrap();
         assert!(cos1 > 0.99, "emb1 round-trip similarity: {cos1}");
         assert!(cos2 > 0.99, "emb2 round-trip similarity: {cos2}");
         assert!(cos3 > 0.99, "emb3 round-trip similarity: {cos3}");
+
+        // Each row's content_hash is paired with its own chunk's hash
+        // (single SQL pass — no cross-row mixing).
+        assert_eq!(by_id[chunk1.id.as_str()].1, chunk1.content_hash);
+        assert_eq!(by_id[chunk2.id.as_str()].1, chunk2.content_hash);
+        assert_eq!(by_id[chunk3.id.as_str()].1, chunk3.content_hash);
     }
 }


### PR DESCRIPTION
## Summary

Fixes **#1124** (P1.17 from the v1.30.0 audit). The non-blocking HNSW rebuild (#1113) had two concurrent producers — the rebuild thread snapshotting `(id, embedding)` from the store, and the watch loop pushing `(id, embedding)` into `pending.delta` for chunks re-embedded mid-rebuild. The swap-time drain dedup'd by **id only**: a chunk re-embedded mid-rebuild had the OLD vector under that id in the snapshot and the FRESH vector in delta — the filter threw away the fresh one. The HNSW served the stale vector until the next threshold rebuild.

**The fix is content-hash-aware dedup.**

- New `Store::embedding_and_hash_batches` reads `(id, embedding, content_hash)` in a single SQL pass — WAL snapshot consistency requires one transaction.
- `build_hnsw_index_owned` returns `(HnswIndex, HashMap<id, hash>)`; `build_hnsw_index` discards the map.
- `RebuildResult { index, snapshot_hashes }` packages both across the rebuild channel.
- `PendingRebuild::delta` carries `(id, embedding, hash)` triples.
- `get_chunk_ids_and_embeddings_by_hashes` returns triples (single SQL pass, single in-tree caller — `cqs watch` reindex path).
- Drain replaces the id-only `HashSet` filter with `snapshot_hashes.get(id).is_none_or(|sh| sh != hash)` — replay when id is new OR hash differs.

When an id is replayed because the hash differs, `hnsw_rs` adds a duplicate node (no deletion API) — same orphan situation as the fast-incremental path. Search post-filters by SQLite chunk ids, so the orphan is invisible to callers; next threshold rebuild cleans it up. This trade-off is documented inline at the filter site.

## Files changed

- `src/store/chunks/async_helpers.rs` — new `embedding_and_hash_batches` iterator + 2 tests (+155).
- `src/store/chunks/embeddings.rs` — `get_chunk_ids_and_embeddings_by_hashes` returns triples; in-tree tests updated.
- `src/cli/commands/index/build.rs` — `build_hnsw_index_owned` returns `(HnswIndex, HashMap<…>)`; in-tree test asserts the snapshot map.
- `src/cli/watch.rs` — `RebuildResult` struct, `PendingRebuild::delta` triples, hash-aware drain, regression test.

Total: +454 / −49 across 4 files.

## Regression test

`src/cli/watch.rs::tests::test_rebuild_window_re_embedding_replays_fresh_vector`

Constructs a snapshot with id `"a"` at axis-0 with hash `h_v1`, pushes a delta entry with axis-1 + hash `h_v2`, drains, asserts:

1. Swapped HNSW has `len() == 3` — snapshot's 2 entries plus the 1 replay (proves the hash mismatch triggered replay).
2. `idx.search(fresh_embedding, 1)` returns id `"a"` with cosine > 0.99 (proves the fresh axis-1 vector is in the graph under "a").

Pre-fix, the replay was skipped; the axis-1 query would surface "z" or "a" with poor cosine.

## Test plan

- [ ] `cargo test --features gpu-index --bin cqs cli::watch::tests::test_rebuild_window` (new test passes)
- [ ] `cargo test --features gpu-index --bin cqs cli::watch::tests::drain_pending_rebuild` (existing 4 rebuild tests pass)
- [ ] `cargo test --features gpu-index --bin cqs cli::watch::tests::spawn_hnsw_rebuild` (existing 2 spawn tests pass)
- [ ] `cargo test --features gpu-index --lib embedding_and_hash_batches` (2 new iterator tests pass)
- [ ] `cargo test --features gpu-index --lib get_chunk_ids_and_embeddings_by_hashes` (2 updated tests pass)
- [ ] `cargo clippy --features gpu-index -- -D warnings` clean
- [ ] CI green on PR

## Follow-on observations (not addressed here)

- `MAX_PENDING_REBUILD_DELTA = 5_000` worst-case memory now ~20.3 MB (vs 20 MB pre-fix) due to the added 64-byte hash per entry. Negligible — flagging only because the doc-comment line still reads "20 MB worst case".
- Phase 5 `build_hnsw_base_index` is not snapshot-tracked. The base HNSW reload path goes through disk only (no in-memory mutable swap), so the rebuild-window bug doesn't manifest. If a future change adds in-memory mutation to the base index, the same fix shape would need to apply there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
