### PR TITLE
chore(deps): raise dependabot open-pr cap from 5 to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary

- Raises `open-pull-requests-limit` from 5 to 10 in `.github/dependabot.yml`.

Today dependabot pushed exactly 5 cargo PRs (#1149-#1153) on the weekly Monday schedule, matching the configured cap. Raising to 10 gives 2× headroom for busy weeks without grouping — preference is per-dep granularity over a single weekly grouped PR.

## Test plan

- [ ] `fmt`, `clippy`, `msrv` checks pass (no code changes)
- [ ] No effect until next weekly dependabot run
