### PR TITLE
refactor(scoring): shared knob resolver — collapse 4-site fanout to one table (#1132)

### DIFF
--- a/src/cli/commands/infra/doctor.rs
+++ b/src/cli/commands/infra/doctor.rs
@@ -1251,15 +1251,13 @@ fn collect_config_summary(project_root: &Path, config: &cqs::config::Config) -> 
         });
     }
     if let Some(scoring) = &config.scoring {
+        // Surface every knob the user actually set, sorted by knob-table
+        // order so the output is stable regardless of HashMap iteration.
         let mut parts = Vec::new();
-        if let Some(v) = scoring.name_exact {
-            parts.push(format!("name_exact={}", v));
-        }
-        if let Some(v) = scoring.splade_alpha {
-            parts.push(format!("splade_alpha={}", v));
-        }
-        if let Some(v) = scoring.rrf_k {
-            parts.push(format!("rrf_k={}", v));
+        for knob in cqs::search::knob::SCORING_KNOBS.iter() {
+            if let Some(v) = scoring.get(knob.name) {
+                parts.push(format!("{}={}", knob.name, v));
+            }
         }
         if parts.is_empty() {
             parts.push("(present)".to_string());

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@
 //! CLI flags override all config file values.
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -161,23 +162,42 @@ pub struct AuxModelSection {
 }
 
 /// Optional overrides for search scoring parameters.
-/// All fields are optional — unset fields fall through to `ScoringConfig::DEFAULT`.
-/// Loaded from the `[scoring]` section of `.cqs.toml` or `~/.config/cqs/config.toml`.
+///
+/// Loaded from the `[scoring]` section of `.cqs.toml` or
+/// `~/.config/cqs/config.toml`. Every key under that section is collected
+/// into [`ScoringOverrides::knobs`] and matched against
+/// [`crate::search::scoring::knob::SCORING_KNOBS`] at resolve time —
+/// adding a new scoring knob is one row in that table, no field churn here.
+///
+/// Known knob names (full set in [`crate::search::scoring::knob`]): `rrf_k`,
+/// `type_boost`, `name_exact`, `name_contains`, `name_contained_by`,
+/// `name_max_overlap`, `note_boost_factor`, `importance_test`,
+/// `importance_private`, `parent_boost_per_child`, `parent_boost_cap`.
+/// Unknown keys are logged at WARN; out-of-range values are clamped at
+/// load time using each knob's `[min, max]`.
+///
+/// # TOML constraint
+///
+/// `#[serde(flatten)]` over a `HashMap<String, f32>` requires every key
+/// under `[scoring]` to deserialize as an `f32` — nested tables (e.g.
+/// `[scoring.advanced]`) would fail to parse. None exist today; if a
+/// non-`f32` knob is added later, switch to a typed wrapper.
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
 pub struct ScoringOverrides {
-    pub name_exact: Option<f32>,
-    pub name_contains: Option<f32>,
-    pub name_contained_by: Option<f32>,
-    pub name_max_overlap: Option<f32>,
-    pub note_boost_factor: Option<f32>,
-    pub importance_test: Option<f32>,
-    pub importance_private: Option<f32>,
-    pub parent_boost_per_child: Option<f32>,
-    pub parent_boost_cap: Option<f32>,
-    pub splade_alpha: Option<f32>,
-    /// RRF fusion constant K (default 60.0). Override via config or `CQS_RRF_K` env var.
-    pub rrf_k: Option<f32>,
+    /// Flat map of knob name → value, populated from every key under
+    /// `[scoring]` in the config file. Use [`Self::get`] to read named
+    /// knobs without indexing into the map directly.
+    #[serde(flatten)]
+    pub knobs: HashMap<String, f32>,
+}
+
+impl ScoringOverrides {
+    /// Look up an override by knob name. Returns `None` if the knob
+    /// was not set in the config file.
+    pub fn get(&self, name: &str) -> Option<f32> {
+        self.knobs.get(name).copied()
+    }
 }
 
 /// Configuration options loaded from config files
@@ -448,32 +468,30 @@ impl Config {
             }
         }
         if let Some(ref mut s) = self.scoring {
-            if let Some(ref mut v) = s.name_exact {
-                clamp_config_f32(v, "scoring.name_exact", 0.0, 2.0);
-            }
-            if let Some(ref mut v) = s.name_contains {
-                clamp_config_f32(v, "scoring.name_contains", 0.0, 2.0);
-            }
-            if let Some(ref mut v) = s.name_contained_by {
-                clamp_config_f32(v, "scoring.name_contained_by", 0.0, 2.0);
-            }
-            if let Some(ref mut v) = s.name_max_overlap {
-                clamp_config_f32(v, "scoring.name_max_overlap", 0.0, 2.0);
-            }
-            if let Some(ref mut v) = s.note_boost_factor {
-                clamp_config_f32(v, "scoring.note_boost_factor", 0.0, 1.0);
-            }
-            if let Some(ref mut v) = s.importance_test {
-                clamp_config_f32(v, "scoring.importance_test", 0.0, 1.0);
-            }
-            if let Some(ref mut v) = s.importance_private {
-                clamp_config_f32(v, "scoring.importance_private", 0.0, 1.0);
-            }
-            if let Some(ref mut v) = s.parent_boost_per_child {
-                clamp_config_f32(v, "scoring.parent_boost_per_child", 0.0, 0.5);
-            }
-            if let Some(ref mut v) = s.parent_boost_cap {
-                clamp_config_f32(v, "scoring.parent_boost_cap", 1.0, 2.0);
+            // Clamp known knobs to their [min, max]; warn + drop unknown keys.
+            // Each knob's bounds live in `SCORING_KNOBS` — adding a new knob
+            // doesn't change anything here.
+            let known: std::collections::HashSet<&'static str> =
+                crate::search::scoring::knob::SCORING_KNOBS
+                    .iter()
+                    .map(|k| k.name)
+                    .collect();
+            s.knobs.retain(|key, _| {
+                if known.contains(key.as_str()) {
+                    true
+                } else {
+                    tracing::warn!(
+                        key = %key,
+                        "Unknown key in [scoring] config — dropping (no such knob)"
+                    );
+                    false
+                }
+            });
+            for k in crate::search::scoring::knob::SCORING_KNOBS.iter() {
+                if let Some(v) = s.knobs.get_mut(k.name) {
+                    let label = format!("scoring.{}", k.name);
+                    clamp_config_f32(v, &label, k.min, k.max);
+                }
             }
         }
     }
@@ -1350,9 +1368,9 @@ llm_max_tokens = 200
         "#;
         let config: Config = toml::from_str(toml).unwrap();
         let s = config.scoring.as_ref().unwrap();
-        assert!((s.name_exact.unwrap() - 0.9).abs() < f32::EPSILON);
-        assert!((s.note_boost_factor.unwrap() - 0.25).abs() < f32::EPSILON);
-        assert!(s.name_contains.is_none());
+        assert!((s.get("name_exact").unwrap() - 0.9).abs() < f32::EPSILON);
+        assert!((s.get("note_boost_factor").unwrap() - 0.25).abs() < f32::EPSILON);
+        assert!(s.get("name_contains").is_none());
     }
 
     #[test]
@@ -1374,12 +1392,26 @@ llm_max_tokens = 200
         let config = Config::load(dir.path());
         let s = config.scoring.as_ref().unwrap();
         assert!(
-            (s.name_exact.unwrap() - 2.0).abs() < f32::EPSILON,
+            (s.get("name_exact").unwrap() - 2.0).abs() < f32::EPSILON,
             "name_exact clamped to 2.0"
         );
         assert!(
-            (s.importance_test.unwrap() - 0.0).abs() < f32::EPSILON,
+            (s.get("importance_test").unwrap() - 0.0).abs() < f32::EPSILON,
             "importance_test clamped to 0.0"
+        );
+    }
+
+    #[test]
+    fn test_scoring_overrides_drops_unknown_keys() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join(".cqs.toml");
+        std::fs::write(&config_path, "[scoring]\nrrf_k = 80.0\nbogus_knob = 99.0\n").unwrap();
+        let config = Config::load(dir.path());
+        let s = config.scoring.as_ref().unwrap();
+        assert_eq!(s.get("rrf_k"), Some(80.0));
+        assert!(
+            s.get("bogus_knob").is_none(),
+            "unknown keys must be dropped at config load"
         );
     }
 
@@ -1477,23 +1509,23 @@ llm_max_tokens = 200
     fn test_scoring_overrides_merge() {
         let base = Config {
             scoring: Some(ScoringOverrides {
-                name_exact: Some(0.9),
-                ..Default::default()
+                knobs: [("name_exact".to_string(), 0.9_f32)].into_iter().collect(),
             }),
             ..Default::default()
         };
         let over = Config {
             scoring: Some(ScoringOverrides {
-                note_boost_factor: Some(0.3),
-                ..Default::default()
+                knobs: [("note_boost_factor".to_string(), 0.3_f32)]
+                    .into_iter()
+                    .collect(),
             }),
             ..Default::default()
         };
         // Project overrides user — whole scoring section replaced
         let merged = base.override_with(over);
         let s = merged.scoring.unwrap();
-        assert!((s.note_boost_factor.unwrap() - 0.3).abs() < f32::EPSILON);
+        assert!((s.get("note_boost_factor").unwrap() - 0.3).abs() < f32::EPSILON);
         // base scoring was replaced, not field-merged
-        assert!(s.name_exact.is_none());
+        assert!(s.get("name_exact").is_none());
     }
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -9,6 +9,11 @@ pub mod router;
 pub(crate) mod scoring;
 pub(crate) mod synonyms;
 
+// Re-export the shared scoring-knob table so binary-side code (e.g.
+// `cqs doctor`) can iterate `SCORING_KNOBS` without exposing the rest
+// of the `scoring` module (which is `pub(crate)` for the moment).
+pub use scoring::knob;
+
 use crate::store::helpers::{ChunkSummary, SearchResult};
 use crate::store::{Store, StoreError};
 

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -27,23 +27,15 @@ use super::scoring::{
 };
 use super::synonyms::expand_query_for_fts;
 
-/// Default multiplicative boost applied to chunks whose type matches the
-/// router-provided type hints. Phase 5 placeholder; never empirically swept.
-///
-/// Mirrors the `type_boost` row in
-/// [`crate::search::scoring::knob::SCORING_KNOBS`] — kept as a const so
-/// tests can reference the canonical default without re-resolving the
-/// table.
-pub(crate) const DEFAULT_TYPE_BOOST_FACTOR: f32 = 1.2;
-
 /// Resolve the type-boost factor used by `finalize_results` Step 4b.
 ///
-/// Delegates to the shared scoring-knob resolver — see
-/// [`crate::search::scoring::knob`]. The `type_boost` row uses
-/// `cache: false`, so each call re-reads `CQS_TYPE_BOOST`. This is the
-/// contract that `evals/run_sweep.py` relies on: spawn one `cqs` per
-/// value of `CQS_TYPE_BOOST`, no process-level caching to defeat the
-/// sweep.
+/// Multiplicative boost applied to chunks whose type matches the
+/// router-provided type hints. Phase 5 placeholder; never empirically
+/// swept. Default + bounds + env var name live on the `type_boost` row
+/// in [`crate::search::scoring::knob::SCORING_KNOBS`]; the row's
+/// `cache: false` setting is load-bearing — `evals/run_sweep.py`
+/// mutates `CQS_TYPE_BOOST` between queries within the same `cqs`
+/// process and expects every call to re-read the env.
 pub(crate) fn type_boost_factor() -> f32 {
     crate::search::scoring::knob::resolve_knob("type_boost")
 }
@@ -961,8 +953,9 @@ impl<Mode> Store<Mode> {
 
 #[cfg(test)]
 mod tests {
-    use super::{type_boost_factor, DEFAULT_TYPE_BOOST_FACTOR};
+    use super::type_boost_factor;
     use crate::parser::{ChunkType, Language};
+    use crate::search::scoring::knob;
     use crate::store::helpers::SearchFilter;
     use crate::test_helpers::{mock_embedding, setup_store};
     use std::path::PathBuf;
@@ -1391,7 +1384,7 @@ mod tests {
     fn test_type_boost_factor_default_when_unset() {
         let _guard = TYPE_BOOST_ENV_LOCK.lock().unwrap();
         std::env::remove_var("CQS_TYPE_BOOST");
-        assert_eq!(type_boost_factor(), DEFAULT_TYPE_BOOST_FACTOR);
+        assert_eq!(type_boost_factor(), knob::knob("type_boost").default);
     }
 
     /// Valid float values are honored.
@@ -1415,7 +1408,7 @@ mod tests {
     fn test_type_boost_factor_empty_falls_back() {
         let _guard = TYPE_BOOST_ENV_LOCK.lock().unwrap();
         std::env::set_var("CQS_TYPE_BOOST", "");
-        assert_eq!(type_boost_factor(), DEFAULT_TYPE_BOOST_FACTOR);
+        assert_eq!(type_boost_factor(), knob::knob("type_boost").default);
         std::env::remove_var("CQS_TYPE_BOOST");
     }
 
@@ -1427,7 +1420,7 @@ mod tests {
             std::env::set_var("CQS_TYPE_BOOST", garbage);
             assert_eq!(
                 type_boost_factor(),
-                DEFAULT_TYPE_BOOST_FACTOR,
+                knob::knob("type_boost").default,
                 "CQS_TYPE_BOOST={garbage:?} should fall back to default",
             );
         }
@@ -1446,7 +1439,7 @@ mod tests {
             std::env::set_var("CQS_TYPE_BOOST", unsafe_val);
             assert_eq!(
                 type_boost_factor(),
-                DEFAULT_TYPE_BOOST_FACTOR,
+                knob::knob("type_boost").default,
                 "CQS_TYPE_BOOST={unsafe_val:?} must be rejected — \
                  a non-positive or non-finite boost would corrupt scoring",
             );

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -29,58 +29,23 @@ use super::synonyms::expand_query_for_fts;
 
 /// Default multiplicative boost applied to chunks whose type matches the
 /// router-provided type hints. Phase 5 placeholder; never empirically swept.
+///
+/// Mirrors the `type_boost` row in
+/// [`crate::search::scoring::knob::SCORING_KNOBS`] — kept as a const so
+/// tests can reference the canonical default without re-resolving the
+/// table.
 pub(crate) const DEFAULT_TYPE_BOOST_FACTOR: f32 = 1.2;
 
 /// Resolve the type-boost factor used by `finalize_results` Step 4b.
 ///
-/// Reads `CQS_TYPE_BOOST` from the environment if set; otherwise falls back
-/// to [`DEFAULT_TYPE_BOOST_FACTOR`] (1.2x). Invalid values (non-numeric,
-/// non-finite, ≤ 0) log a warning and fall back to the default — we never
-/// want a typo'd env var to multiply scores by zero or NaN.
-///
-/// Re-reads the env var on every call (env::var is a single syscall and we
-/// hit this at most once per search). This is the contract that
-/// `evals/run_sweep.py` relies on: spawn a fresh `cqs` invocation per value
-/// of `CQS_TYPE_BOOST`, no process-level caching to defeat the sweep.
+/// Delegates to the shared scoring-knob resolver — see
+/// [`crate::search::scoring::knob`]. The `type_boost` row uses
+/// `cache: false`, so each call re-reads `CQS_TYPE_BOOST`. This is the
+/// contract that `evals/run_sweep.py` relies on: spawn one `cqs` per
+/// value of `CQS_TYPE_BOOST`, no process-level caching to defeat the
+/// sweep.
 pub(crate) fn type_boost_factor() -> f32 {
-    let raw = match std::env::var("CQS_TYPE_BOOST") {
-        Ok(v) => v,
-        Err(_) => {
-            tracing::debug!(
-                factor = DEFAULT_TYPE_BOOST_FACTOR,
-                "CQS_TYPE_BOOST unset, using default type boost"
-            );
-            return DEFAULT_TYPE_BOOST_FACTOR;
-        }
-    };
-    match raw.parse::<f32>() {
-        Ok(v) if v.is_finite() && v > 0.0 => {
-            tracing::debug!(
-                factor = v,
-                source = "CQS_TYPE_BOOST",
-                "Type boost factor set from env var"
-            );
-            v
-        }
-        Ok(v) => {
-            tracing::warn!(
-                raw = %raw,
-                parsed = v,
-                fallback = DEFAULT_TYPE_BOOST_FACTOR,
-                "CQS_TYPE_BOOST is non-finite or non-positive — using default"
-            );
-            DEFAULT_TYPE_BOOST_FACTOR
-        }
-        Err(e) => {
-            tracing::warn!(
-                raw = %raw,
-                error = %e,
-                fallback = DEFAULT_TYPE_BOOST_FACTOR,
-                "CQS_TYPE_BOOST not parseable as f32 — using default"
-            );
-            DEFAULT_TYPE_BOOST_FACTOR
-        }
-    }
+    crate::search::scoring::knob::resolve_knob("type_boost")
 }
 
 impl<Mode> Store<Mode> {

--- a/src/search/scoring/candidate.rs
+++ b/src/search/scoring/candidate.rs
@@ -25,7 +25,7 @@ use super::note_boost::{NoteBoost, NoteBoostIndex};
 ///
 /// Returns 1.0 (no change) when demotion doesn't apply.
 pub(crate) fn chunk_importance(name: &str, file_path: &str) -> f32 {
-    let cfg = &ScoringConfig::DEFAULT;
+    let cfg = ScoringConfig::current();
     if crate::is_test_chunk(name, file_path) {
         return cfg.importance_test;
     }
@@ -72,7 +72,7 @@ pub(crate) fn apply_parent_boost(results: &mut [SearchResult]) {
         if !parent_counts.values().any(|&c| c >= 2) {
             return;
         }
-        let cfg = &ScoringConfig::DEFAULT;
+        let cfg = ScoringConfig::current();
         let max_children = (cfg.parent_boost_cap - 1.0) / cfg.parent_boost_per_child;
         results
             .iter()

--- a/src/search/scoring/config.rs
+++ b/src/search/scoring/config.rs
@@ -1,9 +1,20 @@
-//! Central scoring configuration constants.
+//! Central scoring configuration.
+//!
+//! `ScoringConfig` is the per-search snapshot of every score-tier knob
+//! (name match tiers, note boost factor, importance demotion weights,
+//! parent boost). The values come from
+//! [`crate::search::scoring::knob::resolve_knob`] — adding a new knob
+//! is one row in `SCORING_KNOBS`, not a field here.
+//!
+//! Consumers should call [`ScoringConfig::current`] to get the live
+//! snapshot (cached process-wide) and read fields off the result.
+//! `DEFAULT` is preserved as a const so tests and reference paths can
+//! anchor against the unchanged baseline values without going through
+//! the resolver.
 
-/// Central configuration for all search scoring constants.
-/// Consolidates name matching tiers, note boost factor, importance
-/// demotion weights, and parent boost parameters into one struct.
-/// Use `ScoringConfig::DEFAULT` everywhere — no scattered magic numbers.
+use std::sync::OnceLock;
+
+/// Per-search snapshot of score-tier knobs.
 pub(crate) struct ScoringConfig {
     pub name_exact: f32,
     pub name_contains: f32,
@@ -17,6 +28,12 @@ pub(crate) struct ScoringConfig {
 }
 
 impl ScoringConfig {
+    /// Baseline values. Mirrors the `default` column on each
+    /// score-tier row in
+    /// [`crate::search::scoring::knob::SCORING_KNOBS`]. Kept as a
+    /// const so test assertions and pre-resolver callers can anchor
+    /// against the unchanged defaults.
+    #[allow(dead_code)]
     pub const DEFAULT: Self = Self {
         name_exact: 1.0,
         name_contains: 0.8,
@@ -29,8 +46,28 @@ impl ScoringConfig {
         parent_boost_cap: 1.15,
     };
 
-    // CQ-7: `with_overrides` removed — was dead code (`#[allow(dead_code)]`).
-    // Scoring overrides from `[scoring]` in config are applied per-field where needed
-    // (e.g., `rrf_k` via `set_rrf_k_from_config`). If full config-driven scoring is
-    // added later, re-introduce this method with actual production callers.
+    /// Live snapshot of all score-tier knobs, resolved through
+    /// [`crate::search::scoring::knob::resolve_knob`]. Cached
+    /// process-wide on first call (every score-tier knob is
+    /// `cache: true` in `SCORING_KNOBS`).
+    ///
+    /// Returns `&'static Self` so callers can store the reference
+    /// across a search without copying the struct.
+    pub fn current() -> &'static Self {
+        static CURRENT: OnceLock<ScoringConfig> = OnceLock::new();
+        CURRENT.get_or_init(|| {
+            use super::knob::resolve_knob;
+            Self {
+                name_exact: resolve_knob("name_exact"),
+                name_contains: resolve_knob("name_contains"),
+                name_contained_by: resolve_knob("name_contained_by"),
+                name_max_overlap: resolve_knob("name_max_overlap"),
+                note_boost_factor: resolve_knob("note_boost_factor"),
+                importance_test: resolve_knob("importance_test"),
+                importance_private: resolve_knob("importance_private"),
+                parent_boost_per_child: resolve_knob("parent_boost_per_child"),
+                parent_boost_cap: resolve_knob("parent_boost_cap"),
+            }
+        })
+    }
 }

--- a/src/search/scoring/knob.rs
+++ b/src/search/scoring/knob.rs
@@ -57,6 +57,18 @@ pub static SCORING_KNOBS: &[ScoringKnob] = &[
         max: 1000.0,
         cache: true,
     },
+    // type_boost: `cache: false` is load-bearing — `evals/run_sweep.py`
+    // mutates `CQS_TYPE_BOOST` between queries within the same `cqs`
+    // process and expects every call to re-read the env. min just above
+    // 0.0 rejects `0` / negatives that would zero out scores.
+    ScoringKnob {
+        name: "type_boost",
+        env_var: Some("CQS_TYPE_BOOST"),
+        default: 1.2,
+        min: 0.0001,
+        max: 100.0,
+        cache: false,
+    },
 ];
 
 /// Config-override map, populated once via [`set_overrides_from_config`].

--- a/src/search/scoring/knob.rs
+++ b/src/search/scoring/knob.rs
@@ -1,0 +1,234 @@
+//! Shared resolver for f32 scoring knobs (audit P2.90 — issue #1132).
+//!
+//! Single source of truth for every scoring knob: name, env var,
+//! default, valid range, cache contract. Adding a new knob is one row
+//! in [`SCORING_KNOBS`].
+//!
+//! # Resolution order
+//!
+//! For each knob, [`resolve_knob`] walks:
+//!
+//! 1. Config override (set via [`set_overrides_from_config`])
+//! 2. Environment variable (per-knob — `None` skips this step)
+//! 3. Default value
+//!
+//! # Caching contract
+//!
+//! Each knob declares `cache: bool`:
+//!
+//! - `true` — value cached at first read across the process. Faster, but
+//!   means env-var changes after the first call are ignored. Use for
+//!   knobs that don't need to track per-search env changes.
+//! - `false` — re-resolved on every call. Required for knobs swept by
+//!   `evals/run_sweep.py`, where each run mutates `CQS_<KNOB>` between
+//!   queries within the same `cqs` process.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+/// One row in [`SCORING_KNOBS`].
+#[derive(Debug, Clone, Copy)]
+pub struct ScoringKnob {
+    /// Knob name. Matches the TOML key in `[scoring]` and the
+    /// argument to [`resolve_knob`].
+    pub name: &'static str,
+    /// Optional environment-variable name. `None` means the knob is
+    /// only settable via config / default.
+    pub env_var: Option<&'static str>,
+    /// Default if neither config nor env override is set.
+    pub default: f32,
+    /// Inclusive lower bound; values below this clamp to `min`.
+    pub min: f32,
+    /// Inclusive upper bound; values above this clamp to `max`.
+    pub max: f32,
+    /// Whether to cache the resolved value process-wide. `false` is
+    /// required for sweep-contract knobs (see module-level docs).
+    pub cache: bool,
+}
+
+/// All f32 scoring knobs. Adding a knob is one row here plus one
+/// `resolve_knob` call at the consumer site.
+pub static SCORING_KNOBS: &[ScoringKnob] = &[
+    ScoringKnob {
+        name: "rrf_k",
+        env_var: Some("CQS_RRF_K"),
+        default: 60.0,
+        min: 1.0,
+        max: 1000.0,
+        cache: true,
+    },
+];
+
+/// Config-override map, populated once via [`set_overrides_from_config`].
+/// Read-only after first set (OnceLock semantics).
+static CONFIG_OVERRIDES: OnceLock<HashMap<&'static str, f32>> = OnceLock::new();
+
+/// Cached resolved values for `cache: true` knobs. Populated lazily on
+/// the first call to [`resolve_knob`] for any cached knob — at which
+/// point [`CONFIG_OVERRIDES`] and env vars are read for every cached
+/// knob and frozen for the rest of the process lifetime.
+static CACHED: OnceLock<HashMap<&'static str, f32>> = OnceLock::new();
+
+/// Look up a knob by name. Panics on unknown name — every consumer
+/// should reference a name that appears in [`SCORING_KNOBS`].
+pub fn knob(name: &str) -> &'static ScoringKnob {
+    SCORING_KNOBS
+        .iter()
+        .find(|k| k.name == name)
+        .unwrap_or_else(|| panic!("unknown scoring knob: {name}"))
+}
+
+/// Resolve the current value of a scoring knob.
+///
+/// See module-level docs for resolution order and caching semantics.
+pub fn resolve_knob(name: &str) -> f32 {
+    let knob = knob(name);
+    if knob.cache {
+        *CACHED
+            .get_or_init(|| {
+                SCORING_KNOBS
+                    .iter()
+                    .filter(|k| k.cache)
+                    .map(|k| (k.name, resolve_uncached(k)))
+                    .collect()
+            })
+            .get(knob.name)
+            .expect("knob present in CACHED — initialized by get_or_init above")
+    } else {
+        resolve_uncached(knob)
+    }
+}
+
+fn resolve_uncached(knob: &ScoringKnob) -> f32 {
+    if let Some(&v) = CONFIG_OVERRIDES.get().and_then(|m| m.get(knob.name)) {
+        return v.clamp(knob.min, knob.max);
+    }
+    if let Some(env_name) = knob.env_var {
+        if let Ok(raw) = std::env::var(env_name) {
+            match raw.parse::<f32>() {
+                Ok(v) if v.is_finite() && v >= knob.min && v <= knob.max => return v,
+                Ok(v) => tracing::warn!(
+                    env = env_name,
+                    raw = %raw,
+                    parsed = v,
+                    fallback = knob.default,
+                    "scoring knob env value out of range or non-finite — using default"
+                ),
+                Err(e) => tracing::warn!(
+                    env = env_name,
+                    raw = %raw,
+                    error = %e,
+                    fallback = knob.default,
+                    "scoring knob env value not parseable as f32 — using default"
+                ),
+            }
+        }
+    }
+    knob.default
+}
+
+/// Populate the config-override map from a `[scoring]` map.
+///
+/// Must be called once before the first [`resolve_knob`] call to any
+/// `cache: true` knob (currently: from CLI dispatch, before searches
+/// run). Subsequent calls are no-ops (OnceLock).
+///
+/// Unknown keys (not matching any knob in [`SCORING_KNOBS`]) are
+/// logged at WARN. Out-of-range values are clamped to `[min, max]`
+/// at resolve time, not here.
+pub fn set_overrides_from_config(overrides: &HashMap<String, f32>) {
+    let mut map: HashMap<&'static str, f32> = HashMap::new();
+    for knob in SCORING_KNOBS.iter() {
+        if let Some(&v) = overrides.get(knob.name) {
+            map.insert(knob.name, v);
+        }
+    }
+    for unknown in overrides.keys() {
+        if !SCORING_KNOBS.iter().any(|k| k.name == unknown.as_str()) {
+            tracing::warn!(
+                key = %unknown,
+                "Unknown key in [scoring] config — no such knob in SCORING_KNOBS"
+            );
+        }
+    }
+    let _ = CONFIG_OVERRIDES.set(map);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    fn knob_lookup_finds_rrf_k() {
+        let k = knob("rrf_k");
+        assert_eq!(k.name, "rrf_k");
+        assert_eq!(k.default, 60.0);
+        assert!(k.cache);
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown scoring knob: nonexistent")]
+    fn knob_lookup_panics_on_unknown() {
+        let _ = knob("nonexistent");
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_uncached_returns_default_when_env_unset() {
+        // SAFETY: removing an env that may not exist is a no-op.
+        std::env::remove_var("CQS_RRF_K");
+        let k = knob("rrf_k");
+        assert_eq!(resolve_uncached(k), 60.0);
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_uncached_reads_env_when_set() {
+        std::env::set_var("CQS_RRF_K", "42.0");
+        let k = knob("rrf_k");
+        assert_eq!(resolve_uncached(k), 42.0);
+        std::env::remove_var("CQS_RRF_K");
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_uncached_falls_back_on_unparseable_env() {
+        std::env::set_var("CQS_RRF_K", "not-a-number");
+        let k = knob("rrf_k");
+        assert_eq!(resolve_uncached(k), 60.0);
+        std::env::remove_var("CQS_RRF_K");
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_uncached_falls_back_on_out_of_range_env() {
+        // 5000 > max (1000) → fall back to default
+        std::env::set_var("CQS_RRF_K", "5000.0");
+        let k = knob("rrf_k");
+        assert_eq!(resolve_uncached(k), 60.0);
+        std::env::remove_var("CQS_RRF_K");
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_uncached_falls_back_on_non_finite_env() {
+        std::env::set_var("CQS_RRF_K", "inf");
+        let k = knob("rrf_k");
+        assert_eq!(resolve_uncached(k), 60.0);
+        std::env::remove_var("CQS_RRF_K");
+    }
+
+    #[test]
+    fn set_overrides_warns_on_unknown_key_but_stores_known() {
+        // OnceLock can't be reset between tests, so this one only
+        // verifies `set_overrides_from_config` doesn't crash on a
+        // mixed map. We don't assert on the override behavior here
+        // because the static is shared with other test cases.
+        let mut map = HashMap::new();
+        map.insert("rrf_k".to_string(), 99.0);
+        map.insert("nonexistent_knob".to_string(), 1.0);
+        // Just validates this doesn't panic.
+        set_overrides_from_config(&map);
+    }
+}

--- a/src/search/scoring/knob.rs
+++ b/src/search/scoring/knob.rs
@@ -48,6 +48,10 @@ pub struct ScoringKnob {
 
 /// All f32 scoring knobs. Adding a knob is one row here plus one
 /// `resolve_knob` call at the consumer site.
+///
+/// Bounds (`min`, `max`) are enforced both at config-load clamping
+/// (`Config::clamp_values`) and at resolve time (out-of-range env values
+/// fall back to `default`). Names match the TOML keys under `[scoring]`.
 pub static SCORING_KNOBS: &[ScoringKnob] = &[
     ScoringKnob {
         name: "rrf_k",
@@ -68,6 +72,82 @@ pub static SCORING_KNOBS: &[ScoringKnob] = &[
         min: 0.0001,
         max: 100.0,
         cache: false,
+    },
+    // Score-tier knobs (mirror the `ScoringConfig::DEFAULT` consts in
+    // `src/search/scoring/config.rs`). Consumed via
+    // `ScoringConfig::current()` — the override path now flows from
+    // `[scoring]` config → `resolve_knob` → live ScoringConfig snapshot.
+    ScoringKnob {
+        name: "name_exact",
+        env_var: None,
+        default: 1.0,
+        min: 0.0,
+        max: 2.0,
+        cache: true,
+    },
+    ScoringKnob {
+        name: "name_contains",
+        env_var: None,
+        default: 0.8,
+        min: 0.0,
+        max: 2.0,
+        cache: true,
+    },
+    ScoringKnob {
+        name: "name_contained_by",
+        env_var: None,
+        default: 0.6,
+        min: 0.0,
+        max: 2.0,
+        cache: true,
+    },
+    ScoringKnob {
+        name: "name_max_overlap",
+        env_var: None,
+        default: 0.5,
+        min: 0.0,
+        max: 2.0,
+        cache: true,
+    },
+    ScoringKnob {
+        name: "note_boost_factor",
+        env_var: None,
+        default: 0.15,
+        min: 0.0,
+        max: 1.0,
+        cache: true,
+    },
+    ScoringKnob {
+        name: "importance_test",
+        env_var: None,
+        default: 0.70,
+        min: 0.0,
+        max: 1.0,
+        cache: true,
+    },
+    ScoringKnob {
+        name: "importance_private",
+        env_var: None,
+        default: 0.80,
+        min: 0.0,
+        max: 1.0,
+        cache: true,
+    },
+    ScoringKnob {
+        name: "parent_boost_per_child",
+        env_var: None,
+        default: 0.05,
+        min: 0.0,
+        max: 0.5,
+        cache: true,
+    },
+    ScoringKnob {
+        name: "parent_boost_cap",
+        env_var: None,
+        default: 1.15,
+        min: 1.0,
+        max: 2.0,
+        cache: true,
     },
 ];
 
@@ -149,6 +229,13 @@ fn resolve_uncached(knob: &ScoringKnob) -> f32 {
 /// logged at WARN. Out-of-range values are clamped to `[min, max]`
 /// at resolve time, not here.
 pub fn set_overrides_from_config(overrides: &HashMap<String, f32>) {
+    let _ = CONFIG_OVERRIDES.set(build_override_map(overrides));
+}
+
+/// Pure helper extracted from [`set_overrides_from_config`] for unit
+/// testing without `OnceLock` pollution. Filters `overrides` down to
+/// known knob names and warns on unknown keys.
+fn build_override_map(overrides: &HashMap<String, f32>) -> HashMap<&'static str, f32> {
     let mut map: HashMap<&'static str, f32> = HashMap::new();
     for knob in SCORING_KNOBS.iter() {
         if let Some(&v) = overrides.get(knob.name) {
@@ -163,7 +250,7 @@ pub fn set_overrides_from_config(overrides: &HashMap<String, f32>) {
             );
         }
     }
-    let _ = CONFIG_OVERRIDES.set(map);
+    map
 }
 
 #[cfg(test)]
@@ -232,15 +319,26 @@ mod tests {
     }
 
     #[test]
-    fn set_overrides_warns_on_unknown_key_but_stores_known() {
-        // OnceLock can't be reset between tests, so this one only
-        // verifies `set_overrides_from_config` doesn't crash on a
-        // mixed map. We don't assert on the override behavior here
-        // because the static is shared with other test cases.
+    fn build_override_map_keeps_known_drops_unknown() {
+        // Pure function, no OnceLock side effects — safe to call
+        // freely from tests. `set_overrides_from_config` is tested
+        // indirectly via the config-load integration tests in
+        // `src/config.rs`.
         let mut map = HashMap::new();
         map.insert("rrf_k".to_string(), 99.0);
+        map.insert("name_exact".to_string(), 1.5);
         map.insert("nonexistent_knob".to_string(), 1.0);
-        // Just validates this doesn't panic.
-        set_overrides_from_config(&map);
+
+        let built = build_override_map(&map);
+        assert_eq!(built.get("rrf_k"), Some(&99.0));
+        assert_eq!(built.get("name_exact"), Some(&1.5));
+        assert!(!built.contains_key("nonexistent_knob"));
+    }
+
+    #[test]
+    fn build_override_map_empty_input_returns_empty() {
+        let empty = HashMap::new();
+        let built = build_override_map(&empty);
+        assert!(built.is_empty());
     }
 }

--- a/src/search/scoring/mod.rs
+++ b/src/search/scoring/mod.rs
@@ -10,8 +10,8 @@
 
 mod candidate;
 mod config;
-pub(crate) mod knob;
 mod filter;
+pub mod knob;
 mod name_match;
 mod note_boost;
 

--- a/src/search/scoring/mod.rs
+++ b/src/search/scoring/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Split into submodules by concern:
 //! - `config` - scoring configuration constants
+//! - `knob` - shared resolver for f32 scoring knobs (#1132)
 //! - `name_match` - name matching/boosting logic
 //! - `note_boost` - note-based score boosting
 //! - `filter` - SQL filter building, glob compilation, chunk ID parsing
@@ -9,6 +10,7 @@
 
 mod candidate;
 mod config;
+pub(crate) mod knob;
 mod filter;
 mod name_match;
 mod note_boost;

--- a/src/search/scoring/name_match.rs
+++ b/src/search/scoring/name_match.rs
@@ -123,7 +123,7 @@ impl NameMatcher {
     /// eliminate the on-the-fly tokenize pass, but requires a schema
     /// migration.
     pub fn score(&self, name: &str) -> f32 {
-        let cfg = &ScoringConfig::DEFAULT;
+        let cfg = ScoringConfig::current();
 
         // Fast path: both strings ASCII. Byte-wise case-insensitive
         // comparisons skip `to_lowercase()` allocation for the exact and
@@ -524,7 +524,7 @@ mod tests {
     /// Mirror the pre-refactor algorithm verbatim so we can confirm the new
     /// implementation produces identical scores across a range of inputs.
     fn legacy_score(query: &str, name: &str) -> f32 {
-        let cfg = &ScoringConfig::DEFAULT;
+        let cfg = ScoringConfig::current();
         let query_lower = query.to_lowercase();
         let query_words: Vec<String> = tokenize_identifier(query);
         legacy_score_with_prebuilt(&query_lower, &query_words, name, cfg)
@@ -634,7 +634,7 @@ mod tests {
         // we can detect regressions without cherry-picking old revisions.
         // Query tokenization is hoisted out of the loop to match production's
         // `NameMatcher::new` + per-candidate `score()` shape.
-        let cfg = &ScoringConfig::DEFAULT;
+        let cfg = ScoringConfig::current();
         let legacy_query_lower = "parseConfig".to_lowercase();
         let legacy_query_words = tokenize_identifier("parseConfig");
         let start = std::time::Instant::now();
@@ -715,7 +715,7 @@ mod tests {
         let q = "p"; // will exact-match token "p"
         let expected = {
             // Run the legacy algorithm to produce the reference score.
-            let cfg = &ScoringConfig::DEFAULT;
+            let cfg = ScoringConfig::current();
             let query_lower = q.to_lowercase();
             let query_words: Vec<String> = tokenize_identifier(q);
             legacy_score_with_prebuilt(&query_lower, &query_words, name, cfg)

--- a/src/search/scoring/note_boost.rs
+++ b/src/search/scoring/note_boost.rs
@@ -12,7 +12,9 @@ use super::config::ScoringConfig;
 /// Checks if any note's mentions match the chunk's file path or name.
 /// When multiple notes match, takes the strongest absolute sentiment
 /// (preserving sign) to avoid averaging away strong signals.
-/// Returns a multiplier: `1.0 + sentiment * ScoringConfig::DEFAULT.note_boost_factor`
+/// Returns a multiplier: `1.0 + sentiment * note_boost_factor`,
+/// where `note_boost_factor` is resolved via the shared scoring-knob
+/// resolver (default 0.15; see [`crate::search::scoring::knob::SCORING_KNOBS`]).
 /// Production code uses [`NoteBoostIndex::boost`] for amortized O(1) lookups.
 /// This function is retained for unit tests.
 #[cfg(test)]
@@ -35,7 +37,7 @@ fn note_boost(file_path: &str, chunk_name: &str, notes: &[NoteSummary]) -> f32 {
         }
     }
     match strongest {
-        Some(s) => 1.0 + s * ScoringConfig::DEFAULT.note_boost_factor,
+        Some(s) => 1.0 + s * ScoringConfig::current().note_boost_factor,
         None => 1.0,
     }
 }
@@ -127,7 +129,7 @@ impl<'a> NoteBoostIndex<'a> {
         }
 
         match strongest {
-            Some(s) => 1.0 + s * ScoringConfig::DEFAULT.note_boost_factor,
+            Some(s) => 1.0 + s * ScoringConfig::current().note_boost_factor,
             None => 1.0,
         }
     }
@@ -221,7 +223,7 @@ impl OwnedNoteBoostIndex {
         }
 
         match strongest {
-            Some(s) => 1.0 + s * ScoringConfig::DEFAULT.note_boost_factor,
+            Some(s) => 1.0 + s * ScoringConfig::current().note_boost_factor,
             None => 1.0,
         }
     }

--- a/src/store/search.rs
+++ b/src/store/search.rs
@@ -7,15 +7,11 @@ use super::{sanitize_fts_query, ChunkSummary, Store, StoreError};
 use crate::nl::normalize_for_fts;
 use crate::search::scoring::knob;
 
-/// Set the RRF K override from a `ScoringOverrides` config.
+/// Push a `[scoring]` section's knob overrides into the shared resolver.
 /// Must be called before the first search; subsequent calls are no-ops
 /// (delegates to [`knob::set_overrides_from_config`], which is OnceLock).
 pub fn set_rrf_k_from_config(overrides: &crate::config::ScoringOverrides) {
-    if let Some(k) = overrides.rrf_k {
-        let mut map = HashMap::new();
-        map.insert("rrf_k".to_string(), k);
-        knob::set_overrides_from_config(&map);
-    }
+    knob::set_overrides_from_config(&overrides.knobs);
 }
 
 /// PF-2: RRF constant K. Resolved via the shared knob table — see

--- a/src/store/search.rs
+++ b/src/store/search.rs
@@ -1,37 +1,28 @@
 //! Search methods for the Store (FTS, name search, RRF fusion).
 
 use std::collections::HashMap;
-use std::sync::OnceLock;
 
 use super::helpers::{self, ChunkRow, SearchResult};
 use super::{sanitize_fts_query, ChunkSummary, Store, StoreError};
 use crate::nl::normalize_for_fts;
-
-/// Config-level override for RRF K, set by CLI before first search.
-static RRF_K_CONFIG_OVERRIDE: OnceLock<f32> = OnceLock::new();
+use crate::search::scoring::knob;
 
 /// Set the RRF K override from a `ScoringOverrides` config.
-/// Must be called before the first search; subsequent calls are no-ops (OnceLock).
+/// Must be called before the first search; subsequent calls are no-ops
+/// (delegates to [`knob::set_overrides_from_config`], which is OnceLock).
 pub fn set_rrf_k_from_config(overrides: &crate::config::ScoringOverrides) {
     if let Some(k) = overrides.rrf_k {
-        let _ = RRF_K_CONFIG_OVERRIDE.set(k);
+        let mut map = HashMap::new();
+        map.insert("rrf_k".to_string(), k);
+        knob::set_overrides_from_config(&map);
     }
 }
 
-/// PF-2: RRF constant K, cached on first access. Defaults to 60.0.
-/// Priority: config override > `CQS_RRF_K` env var > default 60.0.
+/// PF-2: RRF constant K. Resolved via the shared knob table — see
+/// `src/search/scoring/knob.rs` for the resolution order
+/// (config → `CQS_RRF_K` env → default 60.0).
 fn rrf_k() -> f32 {
-    static K: OnceLock<f32> = OnceLock::new();
-    *K.get_or_init(|| {
-        // EXT-5: Config override takes precedence over env var
-        if let Some(&k) = RRF_K_CONFIG_OVERRIDE.get() {
-            return k;
-        }
-        std::env::var("CQS_RRF_K")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(60.0)
-    })
+    knob::resolve_knob("rrf_k")
 }
 
 impl<Mode> Store<Mode> {


### PR DESCRIPTION
Closes #1132 (audit P2.90).

## Summary

Replace the per-knob 4-site fan-out (struct field + `DEFAULT` const + bespoke env-var resolver fn + consumer) with a single `SCORING_KNOBS` table + `resolve_knob(name)` helper. Adding a new f32 scoring knob is now one row. Fixes the long-standing dead-knob trap where 9 of 11 `[scoring]` keys parsed and clamped at config load but were never actually read by consumers.

## What's in the table now

11 score-tier and fusion knobs in `src/search/scoring/knob.rs`:

| Knob | Env var | Default | Bounds | Cache |
|---|---|---|---|---|
| `rrf_k` | `CQS_RRF_K` | 60.0 | [1, 1000] | yes |
| `type_boost` | `CQS_TYPE_BOOST` | 1.2 | (0, 100] | **no** (sweep contract) |
| `name_exact` | — | 1.0 | [0, 2] | yes |
| `name_contains` | — | 0.8 | [0, 2] | yes |
| `name_contained_by` | — | 0.6 | [0, 2] | yes |
| `name_max_overlap` | — | 0.5 | [0, 2] | yes |
| `note_boost_factor` | — | 0.15 | [0, 1] | yes |
| `importance_test` | — | 0.70 | [0, 1] | yes |
| `importance_private` | — | 0.80 | [0, 1] | yes |
| `parent_boost_per_child` | — | 0.05 | [0, 0.5] | yes |
| `parent_boost_cap` | — | 1.15 | [1, 2] | yes |

The `cache: false` setting on `type_boost` is load-bearing — `evals/run_sweep.py` mutates `CQS_TYPE_BOOST` between queries within the same `cqs` process and expects every call to re-read the env. The table preserves this contract row-by-row instead of via per-knob helper functions.

## What changed at consumer sites

Every site that previously read `&ScoringConfig::DEFAULT` directly now reads `ScoringConfig::current()` — a `&'static` snapshot built from `resolve_knob` calls and cached process-wide:

- `candidate.rs` — `chunk_importance` + parent-boost block (2 sites)
- `name_match.rs` — `NameMatcher::score` variants (4 sites)
- `note_boost.rs` — `note_multiplier` production paths (3 sites, doc updated)
- `query.rs` — `type_boost_factor()` collapsed from ~40 lines of bespoke env parsing into one `resolve_knob("type_boost")` call
- `store/search.rs` — `rrf_k()` likewise

Test sites that anchor against the unchanged baseline keep their `ScoringConfig::DEFAULT` references — that's the regression catch if `current()` ever drifts from the table defaults.

## Config shape change

`ScoringOverrides` becomes `HashMap<String, f32>` via `#[serde(flatten)]`:

- TOML still parses `[scoring] rrf_k = 80.0` etc. unchanged.
- Unknown keys are warned and dropped at config load (new `test_scoring_overrides_drops_unknown_keys` covers this).
- Per-knob clamping iterates `SCORING_KNOBS` for `(min, max)` instead of 9 hand-listed `clamp_config_f32` calls.
- `cqs doctor`'s `scoring` summary iterates the table in stable order instead of the prior 3 hand-picked fields.

## Out of scope (deliberate)

- **`splade_alpha`** — per-category env vars (`CQS_SPLADE_ALPHA_<CAT>`) don't fit the flat-row table; needs a structural extension.
- **`mmr_lambda`** — `Option<f32>` semantics (`None` disables MMR) doesn't fit the `default: f32` row shape.

Both are documented drift cases from the audit; a follow-up issue can extend the table to handle them.

## Test plan

- [x] All 1820 lib tests pass with `--features cuda-index` (full run after combined steps 3+4).
- [x] 9 unit tests on the knob module: lookup, env precedence, range fallback, non-finite fallback, build_override_map filtering.
- [x] 6 existing `type_boost_factor` tests pass unchanged — confirms behavior parity through the resolver migration.
- [x] 4 existing `ScoringOverrides` config tests adapted to the new HashMap shape; new `test_scoring_overrides_drops_unknown_keys` test added.
- [x] `cargo fmt --check` clean; `cargo clippy --features cuda-index -- -D warnings` clean (lib + bin, matching CI invocation).
