### PR TITLE
fix(telemetry): real subcommand resolution + completion event

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -123,13 +123,40 @@ macro_rules! gen_dispatch_group_b {
 }
 
 /// Run CLI with pre-parsed arguments (used when main.rs needs to inspect args first)
-pub fn run_with(mut cli: Cli) -> Result<()> {
+pub fn run_with(cli: Cli) -> Result<()> {
     // Log command for telemetry (opt-in via CQS_TELEMETRY=1)
     let project_cqs_dir = cqs::resolve_index_dir(&find_project_root());
     let telem_args: Vec<String> = std::env::args().collect();
     let (telem_cmd, telem_query) = telemetry::describe_command(&telem_args);
     telemetry::log_command(&project_cqs_dir, &telem_cmd, telem_query.as_deref(), None);
+    let started = std::time::Instant::now();
 
+    // Inner function carries the multiple early-return paths (daemon
+    // forwarding, group-A subcommands' `return $body;`, group-B tail) and
+    // funnels them into a single Result we can attach the completion-event
+    // telemetry to. Without this, half the invocations would never get a
+    // duration/ok event recorded.
+    let result = run_with_dispatch(cli, &project_cqs_dir, &telem_cmd);
+
+    telemetry::log_command_complete(
+        &project_cqs_dir,
+        &telem_cmd,
+        started.elapsed().as_millis() as u64,
+        result.is_ok(),
+        result.as_ref().err().map(|e| e.to_string()).as_deref(),
+    );
+    result
+}
+
+/// Inner dispatch body — separated from [`run_with`] so the outer can
+/// uniformly observe the completion outcome via [`telemetry::log_command_complete`].
+/// All early returns from the body land back here as the inner function's
+/// return value, which the outer wraps with timing + ok/err telemetry.
+fn run_with_dispatch(
+    mut cli: Cli,
+    project_cqs_dir: &std::path::Path,
+    telem_cmd: &str,
+) -> Result<()> {
     // v1.22.0 audit OB-14: root span so all per-command logs have a parent.
     let _root = tracing::info_span!("cqs", cmd = %telem_cmd).entered();
 
@@ -138,7 +165,7 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
     // subsequent run observes `.cqs/slots/` and skips. Safe to call on
     // never-indexed projects (returns false, no-op).
     if project_cqs_dir.exists() {
-        if let Err(e) = cqs::slot::migrate_legacy_index_to_default_slot(&project_cqs_dir) {
+        if let Err(e) = cqs::slot::migrate_legacy_index_to_default_slot(project_cqs_dir) {
             tracing::warn!(error = %e, "slot migration failed; continuing without it");
         }
     }
@@ -176,9 +203,8 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
     // slot 1 inside `resolve` (still beating env/config) without needing a new
     // resolve signature.
     let slot_model_intent = if cli.model.is_none() {
-        let resolved_slot =
-            cqs::slot::resolve_slot_name(cli.slot.as_deref(), &project_cqs_dir).ok();
-        resolved_slot.and_then(|s| cqs::slot::read_slot_model(&project_cqs_dir, &s.name))
+        let resolved_slot = cqs::slot::resolve_slot_name(cli.slot.as_deref(), project_cqs_dir).ok();
+        resolved_slot.and_then(|s| cqs::slot::read_slot_model(project_cqs_dir, &s.name))
     } else {
         None
     };
@@ -200,7 +226,7 @@ pub fn run_with(mut cli: Cli) -> Result<()> {
         // P2.17: daemon protocol errors now surface as `Err` instead of being
         // logged-and-fall-through. Transport-level failures still return
         // `Ok(None)` so CLI fallback works for those.
-        if let Some(output) = try_daemon_query(&project_cqs_dir, &cli)? {
+        if let Some(output) = try_daemon_query(project_cqs_dir, &cli)? {
             print!("{}", output);
             return Ok(());
         }

--- a/src/cli/telemetry.rs
+++ b/src/cli/telemetry.rs
@@ -160,6 +160,106 @@ pub fn log_command(
     }
 }
 
+/// Log the completion of a previously-invoked command — duration and
+/// success/failure outcome.
+///
+/// Pairs with [`log_command`] as a two-event model. The invoke event lands
+/// at dispatch entry so it survives mid-run crashes; the complete event
+/// lands once the dispatch returns. Pair against the invoke by `(cmd, ts)`
+/// proximity (within ~seconds for any single invocation).
+///
+/// Schema: `{event: "complete", cmd, ok, duration_ms, error?, ts}`. The
+/// `error` field is only set when `ok = false`; the message is truncated
+/// to 240 chars and never includes raw query text (anyhow `Display` already
+/// gives the `Result::Err`'s `Display` rather than the search args).
+///
+/// Activation rules and write semantics mirror [`log_command`].
+pub fn log_command_complete(
+    cqs_dir: &Path,
+    command: &str,
+    duration_ms: u64,
+    ok: bool,
+    error: Option<&str>,
+) {
+    let path = cqs_dir.join("telemetry.jsonl");
+    match std::env::var("CQS_TELEMETRY") {
+        Ok(v) if v == "1" => {}
+        Ok(_) => return,
+        Err(_) => {
+            if !path.exists() {
+                return;
+            }
+        }
+    }
+
+    let timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let error_field = error.map(|s| {
+        if s.len() > 240 {
+            let mut out = s.chars().take(240).collect::<String>();
+            out.push('…');
+            out
+        } else {
+            s.to_string()
+        }
+    });
+
+    let entry = serde_json::json!({
+        "ts": timestamp,
+        "event": "complete",
+        "cmd": command,
+        "ok": ok,
+        "duration_ms": duration_ms,
+        "error": error_field,
+    });
+
+    let result: std::io::Result<()> = (|| -> std::io::Result<()> {
+        // Same single-writer + non-blocking flock + auto-archive contract
+        // as `log_command`. See its inline doc for the rationale.
+        let lock_path = cqs_dir.join("telemetry.lock");
+        let lock_file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)?;
+        if lock_file.try_lock().is_err() {
+            return Ok(());
+        }
+
+        if let Ok(meta) = fs::metadata(&path) {
+            if meta.len() > MAX_TELEMETRY_BYTES {
+                let archive_name = format!("telemetry_{timestamp}.jsonl");
+                let archive_path = cqs_dir.join(&archive_name);
+                if let Err(e) = fs::rename(&path, &archive_path) {
+                    tracing::warn!(error = %e, "Failed to auto-archive telemetry file");
+                } else {
+                    tracing::info!(archived = %archive_name, "Auto-archived telemetry file (exceeded 10 MB)");
+                }
+            }
+        }
+
+        let mut opts = OpenOptions::new();
+        opts.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut file = opts.open(&path)?;
+        if let Err(e) = writeln!(file, "{}", entry) {
+            tracing::warn!(error = %e, "Failed to write telemetry completion entry");
+        }
+        Ok(())
+    })();
+    if let Err(e) = result {
+        tracing::debug!(error = %e, "Telemetry completion write skipped");
+    }
+}
+
 /// Log a search command with adaptive routing classification.
 ///
 /// Extends the standard telemetry entry with category, confidence, strategy,
@@ -268,30 +368,234 @@ pub fn log_routed(
 
 /// Extract command name and query from CLI args for telemetry.
 ///
-/// Derives known subcommands from `Cli`'s clap definition at runtime,
-/// so new commands are recognized automatically without maintaining a list.
+/// Walks past leading flags so global options (`--json`, `--slot <name>`,
+/// `--model <id>`, `-q`, etc.) don't get recorded as the command name.
+/// The first non-flag, non-flag-value token is matched against clap's
+/// subcommand registry; if it's a known subcommand we record that, else
+/// we treat it as a bare query (`cqs <query>` short form) and record
+/// `cmd = "search"`.
+///
+/// Pre-fix behavior: `cqs --json search "foo"` was logged as `cmd =
+/// "--json"`. The archived 44k-record telemetry file shows this
+/// happened to ~80% of all invocations. Post-fix it's recorded as
+/// `cmd = "search"` with `query = "foo"` (or its blake3 prefix when
+/// `CQS_TELEMETRY_REDACT_QUERY` is on).
+///
+/// Derives known subcommands from `Cli`'s clap definition at runtime
+/// so new commands are recognized automatically without maintaining
+/// a list. The set of known clap value-flags (those that take a
+/// following value, like `--slot foo` or `--model bar`) is also derived
+/// at runtime so we know which `--key value` pairs to skip past.
 pub fn describe_command(args: &[String]) -> (String, Option<String>) {
     use clap::CommandFactory;
 
-    // args[0] is the binary name
-    let cmd = args.get(1).map(|s| s.as_str()).unwrap_or("unknown");
+    let clap_app = super::definitions::Cli::command();
 
-    // If it's a bare query (no subcommand), it's a search
-    if !cmd.starts_with('-') && !cmd.is_empty() {
-        // Check if it's a known subcommand by querying clap's registry.
-        // Also recognizes "help" which clap adds automatically.
-        let clap_app = super::definitions::Cli::command();
-        let is_subcommand = clap_app.get_subcommands().any(|sc| sc.get_name() == cmd);
-
-        if is_subcommand {
-            // It's a subcommand -- look for query in remaining args
-            let query = args.iter().skip(2).find(|a| !a.starts_with('-')).cloned();
-            return (cmd.to_string(), query);
+    // Collect long+short flag forms that consume a following value.
+    // `--slot value`, `-q value`, etc. — we step past these as a pair so
+    // the value isn't mistaken for a subcommand or query. Top-level only;
+    // subcommand-local args are handled inside clap's parser, not here.
+    let mut value_flags: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for arg in clap_app.get_arguments() {
+        if matches!(
+            arg.get_action(),
+            clap::ArgAction::Set | clap::ArgAction::Append
+        ) {
+            if let Some(long) = arg.get_long() {
+                value_flags.insert(format!("--{long}"));
+            }
+            if let Some(short) = arg.get_short() {
+                value_flags.insert(format!("-{short}"));
+            }
         }
-
-        // Bare query -- it's a search
-        return ("search".to_string(), Some(cmd.to_string()));
     }
 
-    (cmd.to_string(), None)
+    let known_subcommands: std::collections::HashSet<String> = clap_app
+        .get_subcommands()
+        .map(|sc| sc.get_name().to_string())
+        .collect();
+
+    // args[0] is the binary name; start scanning at args[1].
+    let mut i = 1;
+    while i < args.len() {
+        let a = &args[i];
+        if a.starts_with('-') {
+            // `--key=value` is a single token regardless of value-flag-ness.
+            // `--key value` consumes the next arg only when `--key` is a
+            // value-flag (else it's a boolean / count flag and the next
+            // arg is unrelated). Short flags follow the same rule.
+            if a.contains('=') {
+                i += 1;
+            } else if value_flags.contains(a) {
+                i += 2;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+        // First non-flag token: subcommand, or bare-query short form.
+        if known_subcommands.contains(a) {
+            // Look for the first non-flag arg after the subcommand as the query.
+            let query = args[i + 1..].iter().find(|x| !x.starts_with('-')).cloned();
+            return (a.clone(), query);
+        }
+        // Bare query — `cqs "find me a thing"` short form.
+        return ("search".to_string(), Some(a.clone()));
+    }
+
+    // No bare token at all (e.g. `cqs --help`, `cqs --version`, or no args).
+    ("unknown".to_string(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(parts: &[&str]) -> Vec<String> {
+        std::iter::once("cqs")
+            .chain(parts.iter().copied())
+            .map(String::from)
+            .collect()
+    }
+
+    #[test]
+    fn describe_command_skips_leading_global_flag_for_subcommand() {
+        // The pre-fix bug: `cqs --json impact my_fn` was logged as
+        // cmd="--json" because args[1] was returned verbatim. 80% of the
+        // archived telemetry file hit this path. Fix walks past the flag
+        // to the real subcommand.
+        let (cmd, query) = describe_command(&args(&["--json", "impact", "my_fn"]));
+        assert_eq!(cmd, "impact");
+        assert_eq!(query.as_deref(), Some("my_fn"));
+    }
+
+    #[test]
+    fn describe_command_skips_leading_global_flag_for_bare_query() {
+        // `cqs --json "find authentication"` — there is no `search`
+        // subcommand; bare query is the search shorthand. We should still
+        // skip past the flag.
+        let (cmd, query) = describe_command(&args(&["--json", "find authentication"]));
+        assert_eq!(cmd, "search");
+        assert_eq!(query.as_deref(), Some("find authentication"));
+    }
+
+    #[test]
+    fn describe_command_skips_value_flag_pair() {
+        // `--slot <name>` is a value-flag; the value should not be mistaken
+        // for the subcommand.
+        let (cmd, query) = describe_command(&args(&["--slot", "default", "impact", "my_fn"]));
+        assert_eq!(cmd, "impact");
+        assert_eq!(query.as_deref(), Some("my_fn"));
+    }
+
+    #[test]
+    fn describe_command_handles_eq_form_value_flag() {
+        // `--slot=foo` is a single token; we don't double-skip after it.
+        let (cmd, query) = describe_command(&args(&["--slot=default", "impact", "my_fn"]));
+        assert_eq!(cmd, "impact");
+        assert_eq!(query.as_deref(), Some("my_fn"));
+    }
+
+    #[test]
+    fn describe_command_chained_global_flags() {
+        // Multiple leading flags should all get skipped.
+        let (cmd, query) =
+            describe_command(&args(&["--json", "--slot", "alt", "scout", "do thing"]));
+        assert_eq!(cmd, "scout");
+        assert_eq!(query.as_deref(), Some("do thing"));
+    }
+
+    #[test]
+    fn describe_command_bare_query_short_form() {
+        // `cqs "find me a thing"` (no subcommand) is the search shorthand.
+        let (cmd, query) = describe_command(&args(&["find me a thing"]));
+        assert_eq!(cmd, "search");
+        assert_eq!(query.as_deref(), Some("find me a thing"));
+    }
+
+    #[test]
+    fn describe_command_no_subcommand_only_flags() {
+        // `cqs --help` / `cqs --version` should land as "unknown" rather than
+        // recording the flag itself as the command.
+        let (cmd, query) = describe_command(&args(&["--help"]));
+        assert_eq!(cmd, "unknown");
+        assert!(query.is_none());
+
+        let (cmd, query) = describe_command(&args(&["--version"]));
+        assert_eq!(cmd, "unknown");
+        assert!(query.is_none());
+    }
+
+    #[test]
+    fn describe_command_subcommand_with_trailing_flags() {
+        // Flags after the subcommand should not be picked up as the query.
+        let (cmd, query) = describe_command(&args(&["impact", "some_fn", "--json"]));
+        assert_eq!(cmd, "impact");
+        assert_eq!(query.as_deref(), Some("some_fn"));
+    }
+
+    #[test]
+    fn describe_command_empty_args_after_binary_name() {
+        // `cqs` alone — no args after binary name.
+        let (cmd, query) = describe_command(&args(&[]));
+        assert_eq!(cmd, "unknown");
+        assert!(query.is_none());
+    }
+
+    #[test]
+    fn log_command_complete_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cqs_dir = tmp.path();
+        // Activate telemetry by pre-creating the file.
+        std::fs::write(cqs_dir.join("telemetry.jsonl"), "").unwrap();
+        std::env::set_var("CQS_TELEMETRY", "1");
+
+        log_command_complete(cqs_dir, "impact", 42, true, None);
+        log_command_complete(
+            cqs_dir,
+            "search",
+            17,
+            false,
+            Some("Database error: table missing"),
+        );
+
+        std::env::remove_var("CQS_TELEMETRY");
+
+        let body = std::fs::read_to_string(cqs_dir.join("telemetry.jsonl")).unwrap();
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 2, "expected exactly 2 completion lines");
+
+        let r0: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(r0["event"], "complete");
+        assert_eq!(r0["cmd"], "impact");
+        assert_eq!(r0["ok"], true);
+        assert_eq!(r0["duration_ms"], 42);
+        assert!(r0["error"].is_null());
+
+        let r1: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(r1["cmd"], "search");
+        assert_eq!(r1["ok"], false);
+        assert_eq!(r1["duration_ms"], 17);
+        assert!(r1["error"].as_str().unwrap().contains("Database error"));
+    }
+
+    #[test]
+    fn log_command_complete_truncates_long_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cqs_dir = tmp.path();
+        std::fs::write(cqs_dir.join("telemetry.jsonl"), "").unwrap();
+        std::env::set_var("CQS_TELEMETRY", "1");
+
+        let long_err: String = "x".repeat(500);
+        log_command_complete(cqs_dir, "search", 1, false, Some(&long_err));
+
+        std::env::remove_var("CQS_TELEMETRY");
+
+        let body = std::fs::read_to_string(cqs_dir.join("telemetry.jsonl")).unwrap();
+        let r: serde_json::Value = serde_json::from_str(body.trim()).unwrap();
+        let err_field = r["error"].as_str().unwrap();
+        assert!(err_field.ends_with('…'));
+        // 240 'x's plus the ellipsis.
+        assert_eq!(err_field.chars().count(), 241);
+    }
 }


### PR DESCRIPTION
## Summary

- `src/cli/telemetry.rs::describe_command` returned `args[1]` verbatim when it started with `-`, so any invocation through a global flag (`cqs --json impact my_fn`) was logged as `cmd="--json"`. Archived 44k-record telemetry file shows this hit 80% of invocations. Rewrite the resolver to walk past leading flags (skipping `--key value` pairs for clap value-flags, single tokens for booleans and `--key=value`) and match the first non-flag token against clap's subcommand registry
- Add `log_command_complete(cqs_dir, cmd, duration_ms, ok, error)` as the two-event companion to `log_command`. Schema: `{event: "complete", cmd, ok, duration_ms, error?, ts}`. Pair against the invoke event by `(cmd, ts)` proximity. Two events because the invoke record lands at dispatch entry — survives mid-run crashes — while the complete record carries the outcome
- Wire the new event into `cli::dispatch::run_with` by splitting the body into `run_with_dispatch` so the multiple early-return paths (daemon forwarding, group-A subcommand `return $body`, group-B tail expression) all funnel through a single Result that the outer attaches timing + ok/err to

## Why this matters

Pre-fix, telemetry could answer "what command was run" — and even that was wrong 80% of the time when global flags shifted the captured token. Post-fix it can answer "what command was run, did it succeed, how long did it take, what was the error class." The next round of `cqs review` / regression triage can use this directly.

## Tests (11 new)

- `describe_command_skips_leading_global_flag_for_subcommand` — the headline bug case
- `describe_command_skips_leading_global_flag_for_bare_query`
- `describe_command_skips_value_flag_pair` — `--slot <name>` etc.
- `describe_command_handles_eq_form_value_flag` — `--slot=name`
- `describe_command_chained_global_flags`
- `describe_command_bare_query_short_form` — `cqs "find me a thing"`
- `describe_command_no_subcommand_only_flags` — `cqs --help`, `cqs --version`
- `describe_command_subcommand_with_trailing_flags`
- `describe_command_empty_args_after_binary_name`
- `log_command_complete_roundtrip` — both ok=true and ok=false events round-trip through file IO
- `log_command_complete_truncates_long_error` — 500-char error → 240-char + ellipsis

## Test plan

- [x] `cargo test --features cuda-index --bin cqs cli::telemetry::tests` — 11/11 pass
- [x] `cargo test --lib --features cuda-index` — 1822/1822 pass / 16 ignored
- [x] `cargo clippy --features cuda-index -- -D warnings` clean
- [x] `cargo clippy -- -D warnings` clean (cuda-index off)
- [x] `cargo fmt --check` clean
- [ ] CI green
- [ ] After merge: `cqs telemetry reset --reason "post-fix-schema-cleanup"` to freeze the buggy archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
