### PR TITLE
refactor(rrf): #1130 phase 1 — generalize rrf_fuse to N lists

### DIFF
--- a/src/store/search.rs
+++ b/src/store/search.rs
@@ -158,61 +158,66 @@ impl<Mode> Store<Mode> {
         })
     }
 
-    /// Compute RRF (Reciprocal Rank Fusion) scores for combining two ranked lists.
+    /// Compute RRF (Reciprocal Rank Fusion) scores for combining N ranked lists.
     ///
-    /// Pre-allocates the HashMap with capacity for both input lists (PERF-28).
-    /// Input size varies (limit*3 semantic + limit*3 FTS) but is always known upfront.
+    /// Generalizes the historical 2-list `rrf_fuse(semantic, fts, ...)` so any
+    /// number of ranked sources can contribute on a single, uniform pipeline
+    /// (semantic embedding + FTS keyword + SPLADE sparse + name-fingerprint +
+    /// future signals all become slice elements). Each list is deduped
+    /// independently — duplicates within a list collapse to first-occurrence
+    /// rank, but a chunk that appears in multiple lists still accumulates one
+    /// RRF contribution per list, which is the desired "rewards overlap"
+    /// property that #1130 phase 1 preserves bit-for-bit.
     ///
-    /// PF-V1.25-2: uses `BoundedScoreHeap` for the final top-`limit` extraction
-    /// instead of full-sorting every candidate. Asymptotic: O(n log n) → O(n log limit),
-    /// which saves meaningful work on large candidate pools (100k returned for top-100).
-    pub(crate) fn rrf_fuse(
-        semantic_ids: &[&str],
-        fts_ids: &[String],
-        limit: usize,
-    ) -> Vec<(String, f32)> {
-        // K=60 is the standard RRF constant from the Cormack et al. (2009) paper,
-        // originally tuned for web search. For code search with smaller corpora
-        // (10k-100k chunks), the optimal K may differ. Empirically, K=60 performs
-        // well on our eval set (90.9% R@1). Override via CQS_RRF_K env var.
+    /// Pre-allocates the HashMap with the total candidate budget across all
+    /// inputs (PERF-28). PF-V1.25-2: uses `BoundedScoreHeap` for the final
+    /// top-`limit` extraction instead of full-sorting every candidate, with
+    /// the id tie-breaker for deterministic ordering.
+    pub(crate) fn rrf_fuse_n(ranked_lists: &[&[&str]], limit: usize) -> Vec<(String, f32)> {
+        // K=60 is the standard RRF constant from the Cormack et al. (2009)
+        // paper, originally tuned for web search. For code search with smaller
+        // corpora (10k-100k chunks), the optimal K may differ. Empirically,
+        // K=60 performs well on our eval set (90.9% R@1). Override via
+        // CQS_RRF_K env var.
         let k = rrf_k();
 
-        let mut scores: HashMap<&str, f32> =
-            HashMap::with_capacity(semantic_ids.len() + fts_ids.len());
+        let total_capacity: usize = ranked_lists.iter().map(|l| l.len()).sum();
+        let mut scores: HashMap<&str, f32> = HashMap::with_capacity(total_capacity);
 
-        // Deduplicate semantic_ids — keep first occurrence (best rank) only.
-        // Duplicates would get RRF contributions at multiple ranks, inflating score.
-        let mut seen_semantic = std::collections::HashSet::with_capacity(semantic_ids.len());
-        for (rank, id) in semantic_ids.iter().enumerate() {
-            if !seen_semantic.insert(*id) {
-                continue; // skip duplicate
+        for list in ranked_lists {
+            // AC-9: per-list dedup — duplicates within a list collapse to
+            // first-occurrence rank (best score). Cross-list overlap is
+            // intentional and gets the "rewards overlap" boost.
+            let mut seen = std::collections::HashSet::with_capacity(list.len());
+            for (rank, id) in list.iter().enumerate() {
+                if !seen.insert(*id) {
+                    continue;
+                }
+                // RRF formula: 1 / (K + rank). The + 1.0 converts the
+                // 0-indexed `enumerate()` to 1-indexed ranks (first result
+                // = rank 1, not rank 0).
+                let contribution = 1.0 / (k + rank as f32 + 1.0);
+                *scores.entry(*id).or_insert(0.0) += contribution;
             }
-            // RRF formula: 1 / (K + rank). The + 1.0 converts 0-indexed enumerate()
-            // to 1-indexed ranks (first result = rank 1, not rank 0).
-            let contribution = 1.0 / (k + rank as f32 + 1.0);
-            *scores.entry(id).or_insert(0.0) += contribution;
         }
 
-        // AC-9: Deduplicate fts_ids — symmetric with semantic_ids dedup above.
-        let mut seen_fts = std::collections::HashSet::with_capacity(fts_ids.len());
-        for (rank, id) in fts_ids.iter().enumerate() {
-            if !seen_fts.insert(id.as_str()) {
-                continue; // skip duplicate
-            }
-            // Same conversion: enumerate's 0-index -> RRF's 1-indexed rank
-            let contribution = 1.0 / (k + rank as f32 + 1.0);
-            *scores.entry(id.as_str()).or_insert(0.0) += contribution;
-        }
-
-        // Bounded heap keeps top-`limit` in O(n log limit) instead of the full
-        // O(n log n) sort+truncate. `BoundedScoreHeap::into_sorted_vec` applies
-        // the id tie-breaker so results are deterministic across process
-        // invocations (the HashMap above iterates in random order).
         let mut heap = crate::search::scoring::BoundedScoreHeap::new(limit);
         for (id, score) in scores {
             heap.push(id.to_string(), score);
         }
         heap.into_sorted_vec()
+    }
+
+    /// Backward-compatible 2-list wrapper for the historical semantic + FTS
+    /// pairing. New call sites should target [`rrf_fuse_n`] directly so they
+    /// can plug additional signals without touching this signature.
+    pub(crate) fn rrf_fuse(
+        semantic_ids: &[&str],
+        fts_ids: &[String],
+        limit: usize,
+    ) -> Vec<(String, f32)> {
+        let fts_refs: Vec<&str> = fts_ids.iter().map(|s| s.as_str()).collect();
+        Self::rrf_fuse_n(&[semantic_ids, &fts_refs], limit)
     }
 
     /// Exposed for property testing only
@@ -429,5 +434,88 @@ mod tests {
                 common_score, max_single
             );
         }
+    }
+
+    // ===== Direct rrf_fuse_n tests (#1130 phase 1) =====
+    //
+    // The 2-list rrf_fuse path is already exhaustively covered by the
+    // proptests above (it now delegates to rrf_fuse_n). These tests exercise
+    // the new generic surface with shapes the wrapper doesn't reach: empty
+    // input list, a single list, three lists, and "rewards overlap" across
+    // 3+ sources.
+
+    #[test]
+    fn rrf_fuse_n_empty_input_returns_empty() {
+        let r = Store::<ReadOnly>::rrf_fuse_n(&[], 10);
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn rrf_fuse_n_each_list_independently_dedupes() {
+        // A list with the same id at rank 1 and rank 5 should contribute
+        // exactly the rank-1 score, not their sum.
+        let list: &[&str] = &["a", "b", "c", "d", "a", "e"];
+        let r = Store::<ReadOnly>::rrf_fuse_n(&[list], 10);
+        let a_score = r.iter().find(|(id, _)| id == "a").map(|(_, s)| *s).unwrap();
+        // RRF formula: 1 / (K + 1) where K = rrf_k() (default 60). Should NOT
+        // include the second occurrence's contribution.
+        let k = rrf_k();
+        let expected = 1.0 / (k + 1.0);
+        assert!(
+            (a_score - expected).abs() < 1e-6,
+            "a should score {} (rank-1 only, dedup wins), got {}",
+            expected,
+            a_score
+        );
+    }
+
+    #[test]
+    fn rrf_fuse_n_three_lists_cumulative_overlap() {
+        // A chunk that appears at rank 1 in all three lists should score
+        // 3× the rank-1 contribution. Single-list participants score 1×.
+        let l_sem: &[&str] = &["common", "x", "y"];
+        let l_fts: &[&str] = &["common", "z"];
+        let l_splade: &[&str] = &["common", "w"];
+
+        let r = Store::<ReadOnly>::rrf_fuse_n(&[l_sem, l_fts, l_splade], 10);
+        let k = rrf_k();
+        let single = 1.0 / (k + 1.0);
+        let triple = 3.0 * single;
+
+        let common_score = r
+            .iter()
+            .find(|(id, _)| id == "common")
+            .map(|(_, s)| *s)
+            .unwrap();
+        let x_score = r.iter().find(|(id, _)| id == "x").map(|(_, s)| *s).unwrap();
+
+        assert!(
+            (common_score - triple).abs() < 1e-6,
+            "common at rank 1 in 3 lists should score {} (3× single), got {}",
+            triple,
+            common_score
+        );
+        assert!(
+            (x_score - 1.0 / (k + 2.0)).abs() < 1e-6,
+            "x at rank 2 in semantic-only should score {}, got {}",
+            1.0 / (k + 2.0),
+            x_score
+        );
+        // Common must outrank single-list participants — preserves the
+        // "rewards overlap" property at N=3.
+        assert!(common_score > x_score);
+    }
+
+    #[test]
+    fn rrf_fuse_n_respects_limit_with_many_lists() {
+        let l1: &[&str] = &["a", "b"];
+        let l2: &[&str] = &["c", "d"];
+        let l3: &[&str] = &["e", "f"];
+        let l4: &[&str] = &["g", "h"];
+        let r = Store::<ReadOnly>::rrf_fuse_n(&[l1, l2, l3, l4], 3);
+        assert_eq!(r.len(), 3);
+        // Sorted descending — first ≥ second ≥ third.
+        assert!(r[0].1 >= r[1].1);
+        assert!(r[1].1 >= r[2].1);
     }
 }


### PR DESCRIPTION
## Summary

- Replace the 2-list `Store::rrf_fuse(semantic_ids, fts_ids, limit)` with `rrf_fuse_n(ranked_lists: &[&[&str]], limit) -> Vec<(String, f32)>` taking any number of ranked input lists
- Keep the 2-list signature as a thin compat wrapper so the single existing call site (`src/search/query.rs:356`) and the existing proptest suite stay unchanged
- This is the foundation half of #1130 — phase 1 of 2

## Eval impact

**None.** The math is byte-identical:
- Same `K = rrf_k()` (default 60, env override `CQS_RRF_K`, config override via `[scoring]`)
- Same `1 / (K + rank + 1)` formula
- Same per-list dedup (first occurrence wins)
- Same cumulative cross-list scoring ("rewards overlap" property)
- Same `BoundedScoreHeap` top-`limit` extraction with id tie-breaker

No A/B required at this stage. Phase 2 will plug SPLADE + type-boost into the new fusion path; that's where scoring genuinely moves and gets the eval gate.

## What this unblocks

Phase 2 of #1130 — adding SPLADE / type-boost / future signals as additional `&[&str]` slices in the call site, no further changes to `rrf_fuse_n`. Each new signal becomes one slice element, not one branch in a hand-coded fusion function.

## Tests

- 4 new direct `rrf_fuse_n` tests covering shapes the wrapper proptests don't reach: empty input list, single-list per-list dedup, 3-list cumulative overlap, 4-list limit-respect
- Existing 5 RRF property tests (positive scores, bounded, sorted, respects limit, rewards overlap) continue passing through the wrapper

## Test plan

- [x] `cargo test --lib --features cuda-index store::search::` — 11/11 pass (7 existing + 4 new)
- [x] `cargo test --lib --features cuda-index` — 1825 pass / 16 ignored (`hnsw::build::tests::test_build_batched_vs_regular_equivalence` is a known recall flake from #1106; passes on rerun)
- [x] `cargo clippy --features cuda-index -- -D warnings` clean
- [x] `cargo clippy -- -D warnings` clean (cuda-index off)
- [x] `cargo fmt --check` clean
- [ ] CI green

## Phase 2 outline (not in this PR)

Once this lands:
- `search_hybrid` (linear-α dense + sparse) collapses into `rrf_fuse_n` — SPLADE becomes a third ranked-list input
- Type-boost (`query.rs:449-454`) folds in as a fourth signal rather than a post-hoc multiplier
- A/B eval on v3.v2: gate is **±3pp test R@5** AND **±3pp test R@20** (matches observed corpus-drift bound at N=109; ±1pp would be below the binomial noise floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
