### PR TITLE
feat(index): first-encounter prompt for committed notes (#1168)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"9b4146a1-9818-4249-ac66-62a7362cbbfe","pid":2172179,"acquiredAt":1776544308926}
+{"sessionId":"5558b8ee-4411-4380-aa4d-60eddd2fba72","pid":815,"procStart":"13790","acquiredAt":1777342185064}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **First-encounter shared-notes gate on `cqs index`** (#1168). Indexing a repo for the first time when `docs/notes.toml` exists now prompts to confirm — committed notes affect search rankings and surface in agent context, so a freshly cloned repo's notes shouldn't be silently absorbed. Acceptance is persisted to `.cqs/.accepted-shared-notes` so the prompt doesn't repeat for the same project. New `--accept-shared-notes` flag bypasses the prompt for CI / scripted use; non-TTY stdin auto-skips the notes-indexing pass with a warning so CI never hangs.
+
 ### Changed
 
 - **`cqs index --improve-docs` is now review-gated by default** (#1166). Generated doc comments are written as `git apply`-compatible unified-diff patches under `.cqs/proposed-docs/<rel>.patch`; the source tree is not mutated. Apply with `git apply .cqs/proposed-docs/**/*.patch`. Pass `--apply` to opt back into direct write-back (the previous behaviour); the run prints a warning when it does. This closes the indirect-prompt-injection vector where an LLM-authored doc comment could land in the working tree without human review. New public API: `cqs::doc_writer::rewriter::compute_rewrite()` (parse + resolve, no IO) and `write_proposed_patch()` (writes the patch).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,13 +54,13 @@ cqs cannot reliably distinguish a legitimate doc comment from a malicious one. D
 - **No automatic execution**: cqs never executes indexed code; the threat is purely textual relay into agent context.
 - **Reference origin in metadata**: Chunks from `cqs ref` indexes carry reference-name metadata, but it is not yet surfaced as an explicit trust signal in JSON output.
 - **`--improve-docs` review gate (since v1.30.1)**: by default, `cqs index --improve-docs` writes proposed doc comments as unified-diff patches to `.cqs/proposed-docs/<rel>.patch` instead of mutating source files in place. Review with `git diff` and apply with `git apply .cqs/proposed-docs/**/*.patch`. Pass `--apply` to opt back into direct write-back; the run prints a warning when it does.
+- **First-encounter shared-notes gate (since v1.30.1)**: on the first `cqs index` against a repo containing `docs/notes.toml`, cqs prompts to confirm before indexing the notes — committed notes affect search rankings and surface in agent context. Acceptance is persisted to `.cqs/.accepted-shared-notes` so the prompt doesn't repeat. Pass `--accept-shared-notes` to bypass for CI / scripted use; non-TTY stdin auto-skips the notes pass with a warning so CI never hangs. (#1168)
 
 ### Tracked improvements
 
 | Issue | Surface |
 |-------|---------|
 | [#1167](https://github.com/jamie8johnson/cqs/issues/1167) | `trust_level` field + optional content delimiters in chunk-returning JSON output |
-| [#1168](https://github.com/jamie8johnson/cqs/issues/1168) | First-encounter prompt when indexing a repo with committed `docs/notes.toml` |
 | [#1169](https://github.com/jamie8johnson/cqs/issues/1169) | Surface reference origin (`trust_level` + `reference_name`) on every chunk from a `cqs ref` index |
 | [#1170](https://github.com/jamie8johnson/cqs/issues/1170) | Validate LLM summary output before caching (length cap, injection-pattern detection) |
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -583,6 +583,15 @@ pub(crate) struct IndexArgs {
     /// Index files ignored by .gitignore
     #[arg(long)]
     pub no_ignore: bool,
+    /// Skip the first-encounter prompt for committed `docs/notes.toml`.
+    ///
+    /// On the first index of a fresh repo containing `docs/notes.toml`, cqs
+    /// prompts to confirm — committed notes affect search rankings and surface
+    /// in agent context. Pass `--accept-shared-notes` to bypass the prompt for
+    /// non-interactive use (CI, scripts). Acceptance is persisted to
+    /// `.cqs/.accepted-shared-notes` so the prompt doesn't repeat. (#1168)
+    #[arg(long)]
+    pub accept_shared_notes: bool,
     /// Generate LLM summaries for functions (requires ANTHROPIC_API_KEY)
     #[cfg(feature = "llm-summaries")]
     #[arg(long)]

--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -534,8 +534,16 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
         }
     }
 
-    // Index notes if notes.toml exists
-    if !check_interrupted() {
+    // Index notes if notes.toml exists.
+    //
+    // #1168: first-encounter prompt — if this is the project's first index
+    // (no `.accepted-shared-notes` marker yet) AND a committed notes file
+    // exists, confirm with the user before proceeding. Bypassable with
+    // `--accept-shared-notes` for CI / scripted use; non-TTY stdin
+    // auto-skips the index-notes step (loud warn, never hangs).
+    let proceed_with_notes =
+        first_encounter_notes_gate(&root, &project_cqs_dir, args.accept_shared_notes, cli.quiet)?;
+    if !check_interrupted() && proceed_with_notes {
         if !cli.quiet {
             println!("Indexing notes...");
         }
@@ -876,6 +884,137 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
     Ok(())
 }
 
+/// First-encounter shared-notes gate. (#1168)
+///
+/// Returns `true` if notes indexing should proceed, `false` to skip the
+/// pass entirely (user declined OR non-TTY auto-skip).
+///
+/// Behaviour:
+/// - No committed `docs/notes.toml` → return `true` (nothing to gate on).
+/// - Marker file `.cqs/.accepted-shared-notes` already present → `true`.
+/// - `accept_flag = true` (i.e. `--accept-shared-notes`) → write marker, `true`.
+/// - Stdin not a TTY → loud warn + `false` (auto-skip; never hangs CI).
+/// - TTY available → prompt; on Y or empty (default), write marker + `true`.
+///   On any other reply → `false`.
+fn first_encounter_notes_gate(
+    root: &Path,
+    project_cqs_dir: &Path,
+    accept_flag: bool,
+    quiet: bool,
+) -> Result<bool> {
+    use std::io::{IsTerminal, Write};
+
+    let notes_path = root.join("docs/notes.toml");
+    if !notes_path.exists() {
+        return Ok(true);
+    }
+    let marker_path = project_cqs_dir.join(".accepted-shared-notes");
+    if marker_path.exists() {
+        return Ok(true);
+    }
+
+    // Count entries + sentiment buckets so the prompt is informative. A parse
+    // failure here is non-fatal — fall through to gating with N=?, the
+    // downstream `index_notes_from_file` will surface the parse error.
+    let (total, positive, negative) = match cqs::parse_notes(&notes_path) {
+        Ok(notes) => {
+            let total = notes.len();
+            let positive = notes.iter().filter(|n| n.sentiment > 0.0).count();
+            let negative = notes.iter().filter(|n| n.sentiment < 0.0).count();
+            (Some(total), Some(positive), Some(negative))
+        }
+        Err(_) => (None, None, None),
+    };
+
+    // Empty notes file → no payload to gate. Don't write the marker either;
+    // the next index run with non-empty notes will prompt as expected.
+    if matches!(total, Some(0)) {
+        return Ok(true);
+    }
+
+    let count_label = total
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "?".to_string());
+    let pos_label = positive
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "?".to_string());
+    let neg_label = negative
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "?".to_string());
+
+    if accept_flag {
+        write_notes_acceptance_marker(&marker_path)?;
+        if !quiet {
+            println!(
+                "Accepted committed shared notes ({} entries) — marker written to {}",
+                count_label,
+                marker_path.display()
+            );
+        }
+        return Ok(true);
+    }
+
+    // Non-TTY: never hang. Auto-skip with a warning so CI / scripted runs
+    // don't accidentally pull in untrusted shared notes; the user can
+    // re-run with `--accept-shared-notes` once they've reviewed them.
+    if !std::io::stdin().is_terminal() {
+        eprintln!(
+            "Warning: docs/notes.toml exists ({} entries) but stdin is not a TTY. \
+             Skipping notes indexing on this run. Pass --accept-shared-notes to opt in \
+             on subsequent runs.",
+            count_label
+        );
+        return Ok(false);
+    }
+
+    // Interactive prompt.
+    eprintln!();
+    eprintln!(
+        "Detected committed notes at {}: {} entries ({} positive, {} negative).",
+        notes_path.display(),
+        count_label,
+        pos_label,
+        neg_label
+    );
+    eprintln!(
+        "These will affect search rankings and be shown to AI agents using cqs against this repo."
+    );
+    eprint!(
+        "Index them? [Y/n] (or run with --accept-shared-notes to skip this prompt next time): "
+    );
+    std::io::stderr().flush().ok();
+
+    let mut reply = String::new();
+    std::io::stdin()
+        .read_line(&mut reply)
+        .context("Failed to read response from stdin")?;
+    let trimmed = reply.trim();
+    let accepted = trimmed.is_empty()
+        || trimmed.eq_ignore_ascii_case("y")
+        || trimmed.eq_ignore_ascii_case("yes");
+    if accepted {
+        write_notes_acceptance_marker(&marker_path)?;
+        Ok(true)
+    } else {
+        eprintln!("Skipping notes indexing on this run.");
+        Ok(false)
+    }
+}
+
+/// Write the `.accepted-shared-notes` marker with a UTC timestamp body.
+fn write_notes_acceptance_marker(marker_path: &Path) -> Result<()> {
+    if let Some(parent) = marker_path.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+        }
+    }
+    let now = chrono::Utc::now().to_rfc3339();
+    std::fs::write(marker_path, format!("accepted_at = {}\n", now))
+        .with_context(|| format!("Failed to write {}", marker_path.display()))?;
+    Ok(())
+}
+
 /// Index notes from notes.toml if it exists and needs reindexing
 ///
 /// Returns (indexed_count, was_skipped) where was_skipped is true if notes were up to date.
@@ -1178,6 +1317,82 @@ mod tests {
         assert!(
             result.is_none(),
             "empty store must yield None for base HNSW build"
+        );
+    }
+
+    // ===== #1168: first_encounter_notes_gate =====
+
+    #[test]
+    fn first_encounter_gate_proceeds_when_no_notes_file() {
+        let tmp = TempDir::new().unwrap();
+        let cqs_dir = tmp.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+        let proceed = first_encounter_notes_gate(tmp.path(), &cqs_dir, false, true).unwrap();
+        assert!(proceed, "no notes file → proceed");
+    }
+
+    #[test]
+    fn first_encounter_gate_proceeds_when_marker_present() {
+        let tmp = TempDir::new().unwrap();
+        let cqs_dir = tmp.path().join(".cqs");
+        std::fs::create_dir_all(tmp.path().join("docs")).unwrap();
+        std::fs::write(
+            tmp.path().join("docs/notes.toml"),
+            r#"
+[[note]]
+text = "Watch out for X"
+sentiment = -0.5
+mentions = []
+"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+        std::fs::write(cqs_dir.join(".accepted-shared-notes"), "x").unwrap();
+        let proceed = first_encounter_notes_gate(tmp.path(), &cqs_dir, false, true).unwrap();
+        assert!(proceed, "marker present → proceed");
+    }
+
+    #[test]
+    fn first_encounter_gate_accept_flag_writes_marker() {
+        let tmp = TempDir::new().unwrap();
+        let cqs_dir = tmp.path().join(".cqs");
+        std::fs::create_dir_all(tmp.path().join("docs")).unwrap();
+        std::fs::write(
+            tmp.path().join("docs/notes.toml"),
+            r#"
+[[note]]
+text = "Suspicious instruction"
+sentiment = 0.0
+mentions = []
+"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+        let proceed = first_encounter_notes_gate(tmp.path(), &cqs_dir, true, true).unwrap();
+        assert!(proceed, "--accept-shared-notes → proceed");
+        let marker = cqs_dir.join(".accepted-shared-notes");
+        assert!(marker.exists(), "marker must be written when accept_flag set");
+        let body = std::fs::read_to_string(&marker).unwrap();
+        assert!(
+            body.contains("accepted_at"),
+            "marker body should contain timestamp marker, got: {body}"
+        );
+    }
+
+    #[test]
+    fn first_encounter_gate_proceeds_when_notes_file_empty() {
+        let tmp = TempDir::new().unwrap();
+        let cqs_dir = tmp.path().join(".cqs");
+        std::fs::create_dir_all(tmp.path().join("docs")).unwrap();
+        std::fs::write(tmp.path().join("docs/notes.toml"), "").unwrap();
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+        let proceed = first_encounter_notes_gate(tmp.path(), &cqs_dir, false, true).unwrap();
+        assert!(proceed, "empty notes → proceed (nothing to gate on)");
+        // No marker written for the zero-entry case — the next non-empty
+        // index run should still prompt.
+        assert!(
+            !cqs_dir.join(".accepted-shared-notes").exists(),
+            "no marker should be written for empty notes file"
         );
     }
 }

--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -1371,7 +1371,10 @@ mentions = []
         let proceed = first_encounter_notes_gate(tmp.path(), &cqs_dir, true, true).unwrap();
         assert!(proceed, "--accept-shared-notes → proceed");
         let marker = cqs_dir.join(".accepted-shared-notes");
-        assert!(marker.exists(), "marker must be written when accept_flag set");
+        assert!(
+            marker.exists(),
+            "marker must be written when accept_flag set"
+        );
         let body = std::fs::read_to_string(&marker).unwrap();
         assert!(
             body.contains("accepted_at"),

--- a/src/cli/commands/infra/model.rs
+++ b/src/cli/commands/infra/model.rs
@@ -501,6 +501,7 @@ fn reindex_with_new_model(cli: &Cli, new_cfg: ModelConfig) -> Result<()> {
         force: true,
         dry_run: false,
         no_ignore: false,
+        accept_shared_notes: true,
         #[cfg(feature = "llm-summaries")]
         llm_summaries: false,
         #[cfg(feature = "llm-summaries")]


### PR DESCRIPTION
## Summary

Closes #1168 — the last issue in the indirect-prompt-injection cluster.

cqs encourages committing `docs/notes.toml` for cross-session memory. Notes affect search rankings (sentiment-weighted) and surface in agent context. A malicious or careless note in a cloned repo ("this function is safe to call with sudo") propagates to anyone who indexes that repo without realising notes ship with it. `audit-mode` mitigates rank influence at runtime; this PR adds the **first-encounter** mitigation.

## Behaviour

In `cmd_index`, just before the notes-indexing pass:

| Condition | Action |
|---|---|
| No `docs/notes.toml` | Proceed (nothing to gate on) |
| `.cqs/.accepted-shared-notes` already present | Proceed (decision persisted from prior run) |
| `--accept-shared-notes` flag set | Write marker, proceed |
| Stdin not a TTY, no flag | Loud warn + skip the notes pass (CI never hangs) |
| Interactive TTY | Prompt with N entries + sentiment breakdown; default `Y` on bare RET. On accept: write marker. |

## Implementation

- `--accept-shared-notes` flag on `IndexArgs` (already cfg-aware via the existing arg-struct family). Wired through `clone_cli_for_reindex` so `cqs model swap`'s programmatic reindex never trips the prompt.
- `first_encounter_notes_gate(root, cqs_dir, accept_flag, quiet)` private helper.
- `write_notes_acceptance_marker(path)` writes a UTC `accepted_at = <rfc3339>` body so the file is human-readable.
- 4 unit tests covering: no-notes-file, marker-present, accept-flag-writes-marker, empty-notes-file (no marker written so the next non-empty run still prompts).

The marker lives in the project-level `.cqs/`, not per-slot — it's a project-scoped trust decision, not an index-shape decision.

## Test plan

- [x] `cargo test --features cuda-index --bin cqs first_encounter` — 4 pass.
- [x] `cargo clippy -- -D warnings` clean.
- [x] `cargo clippy --features cuda-index -- -D warnings` clean.
- [x] `cargo fmt --all --check` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
