### PR TITLE
refactor(batch): #1137 lift BatchCmd::is_pipeable into a registry table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`cqs index --improve-docs` is now review-gated by default** (#1166). Generated doc comments are written as `git apply`-compatible unified-diff patches under `.cqs/proposed-docs/<rel>.patch`; the source tree is not mutated. Apply with `git apply .cqs/proposed-docs/**/*.patch`. Pass `--apply` to opt back into direct write-back (the previous behaviour); the run prints a warning when it does. This closes the indirect-prompt-injection vector where an LLM-authored doc comment could land in the working tree without human review. New public API: `cqs::doc_writer::rewriter::compute_rewrite()` (parse + resolve, no IO) and `write_proposed_patch()` (writes the patch).
 
+### Internal
+
+- **`BatchCmd::is_pipeable` driven from a registry table** (#1137 — audit finding EX-V1.30-1). Pipeability classification was a hand-maintained match arm decoupled from the variant declaration; adding a new `BatchCmd` variant required a coordinated edit in two places. Replaced with a `for_each_batch_cmd_pipeability!` table macro paired with a `gen_is_pipeable_impl!` emitter that produces an exhaustive match. Adding a new variant is now a single row; missing rows fail to compile via the same exhaustiveness invariant the previous match relied on.
+
 ## [1.30.0] - 2026-04-25
 
 Minor release: closes the v1.29.0 audit umbrella (#1095), ships the cache+slots infrastructure, adds a code-specialised embedder preset, hardens `cqs serve` with per-launch auth, and scaffolds non-NVIDIA `ExecutionProvider` backends. Schema unchanged from v1.29.x; no reindex required for the audit-fix changes (cache+slots auto-migrates the legacy `.cqs/index.db` on first command).

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -322,59 +322,96 @@ pub(crate) enum BatchCmd {
     },
 }
 
-impl BatchCmd {
-    /// Whether this command accepts a piped function name as its first positional arg.
-    /// Used by pipeline execution to validate downstream segments. Commands that
-    /// take a function name as their primary input are pipeable; commands that
-    /// take queries, paths, or no arguments are not.
-    ///
-    /// API-V1.25-6: `match` is intentionally exhaustive (no wildcard arm) so
-    /// adding a new `BatchCmd` variant forces a classification decision here.
-    /// The `test_is_pipeable_exhaustive` test below pins this behavior —
-    /// removing the exhaustiveness makes the test fail to compile.
-    pub(crate) fn is_pipeable(&self) -> bool {
-        match self {
-            // Pipeable: primary input is a function name.
-            BatchCmd::Blame { .. }
-            | BatchCmd::Callers { .. }
-            | BatchCmd::Callees { .. }
-            | BatchCmd::Deps { .. }
-            | BatchCmd::Explain { .. }
-            | BatchCmd::Similar { .. }
-            | BatchCmd::Impact { .. }
-            | BatchCmd::TestMap { .. }
-            | BatchCmd::Related { .. }
-            | BatchCmd::Scout { .. } => true,
-            // Not pipeable: queries, paths, git refs, or no positional arg.
-            BatchCmd::Search { .. }
-            | BatchCmd::Gather { .. }
-            | BatchCmd::Trace { .. }
-            | BatchCmd::Dead { .. }
-            | BatchCmd::Context { .. }
-            | BatchCmd::Stats { .. }
-            | BatchCmd::Onboard { .. }
-            | BatchCmd::Where { .. }
-            | BatchCmd::Read { .. }
-            | BatchCmd::Stale { .. }
-            | BatchCmd::Health { .. }
-            | BatchCmd::Drift { .. }
-            | BatchCmd::Notes { .. }
-            | BatchCmd::Task { .. }
-            | BatchCmd::Review { .. }
-            | BatchCmd::Ci { .. }
-            | BatchCmd::Diff { .. }
-            | BatchCmd::ImpactDiff { .. }
-            | BatchCmd::Plan { .. }
-            | BatchCmd::Suggest { .. }
-            | BatchCmd::Gc { .. }
-            | BatchCmd::Refresh
-            | BatchCmd::Ping
-            | BatchCmd::Help => false,
-            #[cfg(test)]
-            BatchCmd::TestSleep { .. } => false,
+/// Per-variant pipeability table — single source of truth for `BatchCmd::is_pipeable`.
+///
+/// Issue #1137 (audit finding EX-V1.30-1): the pipeability classification used
+/// to live in a hand-maintained match arm, decoupled from the variant declaration.
+/// Adding a new `BatchCmd` variant required a coordinated edit in two places.
+/// This macro folds the classification into the variant list itself: each row is
+/// `(variant_name, is_pipeable)`. The `gen_is_pipeable_impl` emitter expands the
+/// table into an exhaustive match — adding a new variant without a row is a
+/// compile-time error (the match is non-exhaustive).
+///
+/// Struct variants and unit variants are listed in two named blocks so the
+/// macro emitter can build the right pattern shape (`Variant { .. }` vs `Variant`)
+/// without ambiguity.
+///
+/// Pipeable: primary input is a function name (so a previous segment's output
+/// can be piped in). Not pipeable: queries, paths, git refs, or no positional arg.
+macro_rules! for_each_batch_cmd_pipeability {
+    ($emit:ident) => {
+        $emit! {
+            struct_variants: {
+                // Pipeable — primary input is a function name.
+                (Blame, true)
+                (Callers, true)
+                (Callees, true)
+                (Deps, true)
+                (Explain, true)
+                (Similar, true)
+                (Impact, true)
+                (TestMap, true)
+                (Related, true)
+                (Scout, true)
+
+                // Not pipeable — queries, paths, git refs, or no positional arg.
+                (Search, false)
+                (Gather, false)
+                (Trace, false)
+                (Dead, false)
+                (Context, false)
+                (Stats, false)
+                (Onboard, false)
+                (Where, false)
+                (Read, false)
+                (Stale, false)
+                (Health, false)
+                (Drift, false)
+                (Notes, false)
+                (Task, false)
+                (Review, false)
+                (Ci, false)
+                (Diff, false)
+                (ImpactDiff, false)
+                (Plan, false)
+                (Suggest, false)
+                (Gc, false)
+            }
+            unit_variants: {
+                (Refresh, false)
+                (Ping, false)
+                (Help, false)
+            }
         }
-    }
+    };
 }
+
+/// Emits `BatchCmd::is_pipeable` from the table above.
+///
+/// API-V1.25-6: the generated `match` is intentionally exhaustive (no wildcard
+/// arm), so a new `BatchCmd` variant without a pipeability row fails to compile.
+/// `test_is_pipeable_exhaustive` below double-pins this behaviour.
+macro_rules! gen_is_pipeable_impl {
+    (
+        struct_variants: { $(($svar:ident, $sp:expr))* }
+        unit_variants:   { $(($uvar:ident, $up:expr))* }
+    ) => {
+        impl BatchCmd {
+            /// Whether this command accepts a piped function name as its first positional arg.
+            /// Used by pipeline execution to validate downstream segments.
+            pub(crate) fn is_pipeable(&self) -> bool {
+                match self {
+                    $(BatchCmd::$svar { .. } => $sp,)*
+                    $(BatchCmd::$uvar => $up,)*
+                    #[cfg(test)]
+                    BatchCmd::TestSleep { .. } => false,
+                }
+            }
+        }
+    };
+}
+
+for_each_batch_cmd_pipeability!(gen_is_pipeable_impl);
 
 // ─── Query logging ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #1137 (audit finding EX-V1.30-1 / P3.26). Lifts `BatchCmd::is_pipeable` from a hand-maintained match arm into a registry-driven table macro pair (`for_each_batch_cmd_pipeability!` + `gen_is_pipeable_impl!`). Adding a new `BatchCmd` variant now requires a single row instead of a coordinated 2-edit. Compile-time exhaustiveness preserved — a missing row fails to compile, same invariant the manual match relied on. Eval-neutral; behavior identical for every existing variant.

## Test plan

- [x] `cargo check --features cuda-index` — clean
- [x] `cargo test --features cuda-index --bin cqs is_pipeable` — 8/8 pass (including the canonical `test_is_pipeable_exhaustive_classification`)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --features cuda-index` — no new warnings
- [ ] CI fmt / clippy / msrv / test green

## Why this design

`BatchCmd` and the `Commands` registry enum overlap but aren't the same — `BatchCmd` has variants without `Commands` analogues (`Refresh`, `Ping`, `Help`, `TestSleep`). Folding `BatchCmd` into `for_each_command!` would expand to a P2 refactor (folding `BatchCmd` into the registry entirely). The targeted fix here keeps `BatchCmd` separate but applies the same registry-table pattern in a parallel macro pair, scoped to pipeability.

Struct variants (`Variant { .. }`) and unit variants (`Variant`) are listed in two named blocks (`struct_variants:` and `unit_variants:`) inside the table so the emitter can build the right pattern shape without macro-rule ambiguity. The audit issue's hint about reusing `for_each_command!` directly didn't account for that mismatch; this is the smallest scope-correct fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
