### PR TITLE
feat(read+context): emit trust_level + injection_flags so SECURITY.md stops lying — P1.6

### DIFF
--- a/src/cli/commands/io/context.rs
+++ b/src/cli/commands/io/context.rs
@@ -65,6 +65,13 @@ pub(crate) struct CompactChunkEntry {
     pub line_end: u32,
     pub caller_count: u64,
     pub callee_count: u64,
+    /// SEC-V1.30.1-1: every chunk-returning JSON output must carry a
+    /// trust_level. `cqs context --compact` reads from the project store
+    /// only; always "user-code".
+    pub trust_level: &'static str,
+    /// SEC-V1.30.1-1: per-chunk injection-heuristic flags. Empty for now;
+    /// schema-stability contract requires the field be present.
+    pub injection_flags: Vec<String>,
 }
 
 /// Serialize compact data to JSON.
@@ -89,6 +96,8 @@ pub(crate) fn compact_to_json(
                 line_end: c.line_end,
                 caller_count: cc,
                 callee_count: ce,
+                trust_level: "user-code",
+                injection_flags: Vec::new(),
             }
         })
         .collect();
@@ -245,6 +254,15 @@ pub(crate) struct FullChunkEntry {
     pub doc: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+    /// SEC-V1.30.1-1: every chunk-returning JSON output must carry a
+    /// trust_level. `cqs context` reads from the project store only;
+    /// always "user-code". SECURITY.md mitigation contract.
+    pub trust_level: &'static str,
+    /// SEC-V1.30.1-1: per-chunk injection-heuristic flags. The full
+    /// per-content-scan integration is #1181 follow-up; for now the
+    /// schema-stability contract requires the field be present and an
+    /// empty `Vec<String>` reflects "no heuristics fired".
+    pub injection_flags: Vec<String>,
 }
 
 /// An external caller in full context output.
@@ -286,6 +304,8 @@ pub(crate) fn full_to_json(
                 line_end: c.line_end,
                 doc: c.doc.clone(),
                 content,
+                trust_level: "user-code",
+                injection_flags: Vec::new(),
             }
         })
         .collect();
@@ -474,6 +494,12 @@ pub(crate) struct SummaryChunkEntry {
     pub chunk_type: String,
     pub line_start: u32,
     pub line_end: u32,
+    /// SEC-V1.30.1-1: every chunk-returning JSON output must carry a
+    /// trust_level. `cqs context --summary` reads from the project store
+    /// only; always "user-code".
+    pub trust_level: &'static str,
+    /// SEC-V1.30.1-1: per-chunk injection-heuristic flags.
+    pub injection_flags: Vec<String>,
 }
 
 pub(crate) fn summary_to_json(
@@ -488,6 +514,8 @@ pub(crate) fn summary_to_json(
             chunk_type: c.chunk_type.to_string(),
             line_start: c.line_start,
             line_end: c.line_end,
+            trust_level: "user-code",
+            injection_flags: Vec::new(),
         })
         .collect();
     let mut dep_files: Vec<String> = data.dependent_files.iter().cloned().collect();
@@ -901,5 +929,62 @@ mod tests {
             count_field, arr_len as u64,
             "chunk_count field must equal chunks array length"
         );
+    }
+
+    /// SEC-V1.30.1-1: SECURITY.md:57 lists `cqs context` (all three shapes)
+    /// as JSON outputs that carry `trust_level` and `injection_flags` per
+    /// chunk. Before this fix, none of `CompactChunkEntry` /
+    /// `FullChunkEntry` / `SummaryChunkEntry` had the fields — the doc was
+    /// lying. This regression-pin keeps SECURITY.md honest across all three
+    /// shapes; future field removal would re-break the contract silently.
+    #[test]
+    fn context_chunks_emit_sec_trust_level_and_injection_flags() {
+        // Compact shape.
+        let compact_data = CompactData {
+            chunks: vec![make_chunk("a", 1, 5)],
+            caller_counts: HashMap::new(),
+            callee_counts: HashMap::new(),
+        };
+        let compact_json = compact_to_json(&compact_data, "src/lib.rs").unwrap();
+        let c = &compact_json["chunks"][0];
+        assert_eq!(
+            c["trust_level"], "user-code",
+            "SECURITY.md:57 promises trust_level on context --compact chunks"
+        );
+        let cf = c["injection_flags"]
+            .as_array()
+            .expect("SECURITY.md:57 promises injection_flags on context --compact chunks");
+        assert!(cf.is_empty());
+
+        // Full shape.
+        let full_data = FullData {
+            chunks: vec![make_chunk("b", 1, 5)],
+            external_callers: vec![],
+            external_callees: vec![],
+            dependent_files: HashSet::new(),
+            warnings: Vec::new(),
+        };
+        let full_json = full_to_json(&full_data, "src/lib.rs", None, None).unwrap();
+        let f = &full_json["chunks"][0];
+        assert_eq!(
+            f["trust_level"], "user-code",
+            "SECURITY.md:57 promises trust_level on context --full chunks"
+        );
+        let ff = f["injection_flags"]
+            .as_array()
+            .expect("SECURITY.md:57 promises injection_flags on context --full chunks");
+        assert!(ff.is_empty());
+
+        // Summary shape.
+        let summary_json = summary_to_json(&full_data, "src/lib.rs").unwrap();
+        let s = &summary_json["chunks"][0];
+        assert_eq!(
+            s["trust_level"], "user-code",
+            "SECURITY.md:57 promises trust_level on context --summary chunks"
+        );
+        let sf = s["injection_flags"]
+            .as_array()
+            .expect("SECURITY.md:57 promises injection_flags on context --summary chunks");
+        assert!(sf.is_empty());
     }
 }

--- a/src/cli/commands/io/read.rs
+++ b/src/cli/commands/io/read.rs
@@ -312,6 +312,17 @@ struct ReadHints {
 struct FocusedReadJsonOutput {
     focus: String,
     content: String,
+    /// SEC-V1.30.1-1: every chunk-returning JSON output must carry a
+    /// trust_level. `read --focus` reads from the project store only
+    /// (no reference-store fan-in), so this is always "user-code".
+    /// SECURITY.md's mitigation contract is that agents can branch
+    /// safely on this field; the `read --focus` path was missing it.
+    trust_level: &'static str,
+    /// SEC-V1.30.1-1: parallel field to chunk JSON. `read --focus`
+    /// content is delivered as a single concatenated string, not a
+    /// per-chunk list, so there is no per-chunk array — a single
+    /// empty array satisfies the schema-stability contract.
+    injection_flags: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hints: Option<ReadHints>,
     /// P2.23: warnings emitted by the underlying assembly (e.g.
@@ -408,6 +419,8 @@ fn cmd_read_focused(
         let output = FocusedReadJsonOutput {
             focus: focus.to_string(),
             content: result.output,
+            trust_level: "user-code",
+            injection_flags: Vec::new(),
             hints,
             warnings: result.warnings.clone(),
         };
@@ -447,6 +460,8 @@ mod tests {
         let output = FocusedReadJsonOutput {
             focus: "search".into(),
             content: "fn search() { ... }".into(),
+            trust_level: "user-code",
+            injection_flags: Vec::new(),
             hints: Some(ReadHints {
                 caller_count: 3,
                 test_count: 2,
@@ -470,6 +485,8 @@ mod tests {
         let output = FocusedReadJsonOutput {
             focus: "MyStruct".into(),
             content: "struct MyStruct {}".into(),
+            trust_level: "user-code",
+            injection_flags: Vec::new(),
             hints: None,
             warnings: Vec::new(),
         };
@@ -486,6 +503,8 @@ mod tests {
         let output = FocusedReadJsonOutput {
             focus: "MyStruct".into(),
             content: "struct MyStruct {}".into(),
+            trust_level: "user-code",
+            injection_flags: Vec::new(),
             hints: None,
             warnings: vec!["search_by_names_batch failed: db locked".into()],
         };
@@ -493,6 +512,33 @@ mod tests {
         let warns = json["warnings"].as_array().unwrap();
         assert_eq!(warns.len(), 1);
         assert!(warns[0].as_str().unwrap().contains("db locked"));
+    }
+
+    /// SEC-V1.30.1-1: SECURITY.md:57 promises `read --focus` JSON carries
+    /// `trust_level: "user-code" | "reference-code"` and `injection_flags: []`.
+    /// Before this fix, the doc was lying — `FocusedReadJsonOutput` had
+    /// neither field. This regression-pin keeps the contract honest: future
+    /// removal of these fields would silently break SECURITY.md again.
+    #[test]
+    fn focused_read_output_emits_sec_trust_level_and_injection_flags() {
+        let output = FocusedReadJsonOutput {
+            focus: "f".into(),
+            content: "fn f() {}".into(),
+            trust_level: "user-code",
+            injection_flags: Vec::new(),
+            hints: None,
+            warnings: Vec::new(),
+        };
+        let json = serde_json::to_value(&output).unwrap();
+        // Both fields must serialize (no skip_serializing_if on these).
+        assert_eq!(
+            json["trust_level"], "user-code",
+            "SECURITY.md:57 promises trust_level on read --focus JSON"
+        );
+        let flags = json["injection_flags"].as_array().expect(
+            "SECURITY.md:57 promises injection_flags on read --focus JSON; must serialize as array",
+        );
+        assert!(flags.is_empty(), "no per-content heuristics fired yet");
     }
 
     /// SEC-D.5: `validate_and_read_file` must produce identical error text


### PR DESCRIPTION
## Summary

Closes audit fix **P1.6 (SEC-V1.30.1-1)**: SECURITY.md:57 has been promising every chunk-returning JSON output carries `trust_level: "user-code" | "reference-code"` and per-chunk `injection_flags: []`. The doc has been lying since the surfaces were added — none of the `read --focus` or `cqs context` JSON shapes carried either field.

Per the **"Docs Lying Is P1"** memory: SECURITY/PRIVACY/README that promise behavior the code doesn't deliver are correctness bugs, not "just docs."

This PR brings the code in line with the doc. `read --focus` and `cqs context` always read from the project store (no reference-store fan-in), so the constant is `"user-code"` plus empty `injection_flags`. The full per-content-scan integration is #1181 follow-up; for now the schema-stability contract requires the field be present and an empty `Vec<String>` reflects "no heuristics fired."

### Surfaces fixed

- `cqs read --focus <fn> --json` → `FocusedReadJsonOutput`
- `cqs context <file> --full --json` → `FullChunkEntry`
- `cqs context <file> --compact --json` → `CompactChunkEntry`
- `cqs context <file> --summary --json` → `SummaryChunkEntry`

All four now serialize `trust_level: "user-code"` and `injection_flags: []`, matching what SECURITY.md:57 has been claiming all along.

### Changes

- `src/cli/commands/io/read.rs` — extended `FocusedReadJsonOutput` struct, updated production constructor + three test literals (`focused_read_output_with_hints`, `focused_read_output_no_hints`, `focused_read_output_with_warnings`), added regression-pin test `focused_read_output_emits_sec_trust_level_and_injection_flags`.
- `src/cli/commands/io/context.rs` — extended `CompactChunkEntry`, `FullChunkEntry`, `SummaryChunkEntry` structs, updated all three `_to_json` constructors, added regression-pin test `context_chunks_emit_sec_trust_level_and_injection_flags` covering all three shapes in one test.

The two regression-pin tests assert SECURITY.md's contract directly, so future field removal would silently re-break the doc — these tests would catch it instead.

No SECURITY.md edit needed once the code matches the doc.

## Test plan

- [x] `cargo build --features cuda-index` clean
- [x] `cargo test --features cuda-index --bin cqs cli::commands::io::read` — 6 passed (5 prior + 1 new SEC pin)
- [x] `cargo test --features cuda-index --bin cqs cli::commands::io::context` — 8 passed (7 prior + 1 new SEC pin covering all three shapes)
- [x] `cargo fmt` clean
- [x] `cargo clippy --features cuda-index --bin cqs` clean (other pre-existing clippy regressions in main are unrelated)
- [ ] Post-merge manual: `cqs read --focus some_function --json | jq '.trust_level, .injection_flags'` prints `"user-code"` and `[]`
- [ ] Post-merge manual: `cqs context some_file.rs --full --json | jq '.chunks[0].trust_level, .chunks[0].injection_flags'` prints `"user-code"` and `[]`
- [ ] Post-merge manual: `cqs context some_file.rs --compact --json | jq '.chunks[0].trust_level'` and `--summary --json | jq '.chunks[0].trust_level'` both print `"user-code"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
