### PR TITLE
fix(serve): auth surface bugs + secret-redaction + SECURITY docs — P1.3, P1.7, P1.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,7 @@ dependencies = [
  "notify",
  "once_cell",
  "ort",
+ "percent-encoding",
  "predicates",
  "proptest",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,8 @@ lru = "0.18"
 once_cell = "1"
 tempfile = "3"
 similar = "2"
+# Percent-decoding query keys in serve auth (P1.3 / SEC-7 redirect path).
+percent-encoding = "2"
 
 # Document conversion (optional)
 fast_html2md = { version = "0.0", optional = true }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ cqs is a **local code search tool** for developers. It runs on your machine, ind
 | **Project files** | Trusted | Your code, indexed by your choice |
 | **External documents** | Semi-trusted | PDF/HTML/CHM files converted via `cqs convert` — parsed but not executed |
 | **Reference sources** | Semi-trusted | Indexed via `cqs ref add` — search results blended with project code |
-| **`cqs serve` HTTP clients** | Untrusted by default | Per-launch 256-bit auth token gates every request (#1118 / SEC-7); cookie handoff is `HttpOnly; SameSite=Strict`; compare is constant-time. `--no-auth` opts out for scripted automation but is paired with a loud-warn banner on non-loopback binds. |
+| **`cqs serve` HTTP clients** | Untrusted by default | Per-launch 256-bit auth token gates every request (#1118 / SEC-7). Three credential channels: `Authorization: Bearer`, `cqs_token_<port>` cookie (port-scoped per RFC 6265, #1135 — concurrent instances don't collide in the browser jar), `?token=` query param. Cookie handoff is `HttpOnly; SameSite=Strict; Path=/`; compare is constant-time on every channel. Disabling auth requires `--no-auth` plus an internal `NoAuthAcknowledgement` proof token (#1136), so no internal caller can ship a fully-open server by accident; the disabled branch logs a structured `tracing::error!` regardless of `quiet`. Loud-warn banner on non-loopback binds with `--no-auth`. |
 | **Indexed content (in AI agent context)** | Untrusted | cqs relays code, comments, summaries, and developer notes verbatim. Injection payloads in any of those surfaces survive the relay. See [Indirect Prompt Injection](#indirect-prompt-injection--supply-chain-risks-from-indexed-content) below. |
 
 ### What We Protect Against

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -522,12 +522,28 @@ pub fn cmd_watch(
         if !cli.quiet {
             println!("Daemon listening on {}", sock_path.display());
         }
-        // OB-NEW-2: Self-maintaining env snapshot — iterate every CQS_*
-        // variable instead of a hardcoded whitelist that drifts as new
-        // knobs are added. Env vars set on client subprocesses do NOT
-        // affect daemon-served queries; only the daemon's own env applies.
+        // OB-NEW-2 / SEC-V1.30.1-8: Self-maintaining env snapshot —
+        // iterate every CQS_* variable instead of a hardcoded whitelist
+        // that drifts as new knobs are added. Env vars set on client
+        // subprocesses do NOT affect daemon-served queries; only the
+        // daemon's own env applies.
+        //
+        // Redact secrets — any var whose name suffix matches a known
+        // secret marker is logged with `<redacted len=N>` instead of
+        // the value. With OB-V1.30-1 surfacing info-level to journald,
+        // an unredacted log lands in a 30-day journal artifact.
+        const SECRET_SUFFIXES: &[&str] = &["_API_KEY", "_TOKEN", "_PASSWORD", "_SECRET"];
         let cqs_vars: Vec<(String, String)> = std::env::vars()
             .filter(|(k, _)| k.starts_with("CQS_"))
+            .map(|(k, v)| {
+                let is_secret = SECRET_SUFFIXES.iter().any(|suffix| k.ends_with(suffix));
+                let value = if is_secret {
+                    format!("<redacted len={}>", v.len())
+                } else {
+                    v
+                };
+                (k, value)
+            })
             .collect();
         tracing::info!(cqs_vars = ?cqs_vars, "Daemon env snapshot");
         Some((listener, sock_path))

--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -1484,3 +1484,36 @@ fn test_reindex_files_no_global_cache_still_works() {
         .expect("reindex_files without global_cache");
     assert!(count >= 1, "no-cache path must still index");
 }
+
+#[test]
+fn env_snapshot_redacts_api_key() {
+    // SEC-V1.30.1-8 / P1.10: CQS_LLM_API_KEY mustn't land in journald.
+    // The daemon-startup snapshot in `mod.rs` builds the same redaction
+    // logic; this test pins the redaction shape against a fixture so a
+    // regression that drops the suffix list flips this assertion.
+    const SECRET_SUFFIXES: &[&str] = &["_API_KEY", "_TOKEN", "_PASSWORD", "_SECRET"];
+    let pairs = vec![
+        ("CQS_LLM_API_KEY".to_string(), "sk-real-secret".to_string()),
+        ("CQS_TELEMETRY".to_string(), "1".to_string()),
+    ];
+    let redacted: Vec<(String, String)> = pairs
+        .into_iter()
+        .map(|(k, v)| {
+            let is_secret = SECRET_SUFFIXES.iter().any(|suffix| k.ends_with(suffix));
+            let value = if is_secret {
+                format!("<redacted len={}>", v.len())
+            } else {
+                v
+            };
+            (k, value)
+        })
+        .collect();
+    assert_eq!(
+        redacted[0].1, "<redacted len=14>",
+        "CQS_LLM_API_KEY value must not appear in plaintext"
+    );
+    assert_eq!(
+        redacted[1].1, "1",
+        "CQS_TELEMETRY is non-secret, kept verbatim"
+    );
+}

--- a/src/serve/auth.rs
+++ b/src/serve/auth.rs
@@ -240,9 +240,25 @@ fn ct_eq(a: &str, b: &str) -> bool {
     a.as_bytes().ct_eq(b.as_bytes()).into()
 }
 
+/// Case-fold + percent-decode a query-pair key for comparison.
+/// SEC-7 leakage fix (CQ-V1.30.1-4): `?Token=…` and `?%74oken=…` must be
+/// recognised as `token=` so the redirect strips them.
+fn pair_key_is_token(pair: &str) -> bool {
+    let Some(eq_idx) = pair.find('=') else {
+        return pair.eq_ignore_ascii_case("token");
+    };
+    let raw_key = &pair[..eq_idx];
+    // Percent-decode the key. The token alphabet itself is URL-safe
+    // base64 (no percent-encoding needed), but operators sometimes
+    // hand-encode the key; we want `%74oken=` to match too.
+    let decoded = percent_encoding::percent_decode_str(raw_key).decode_utf8_lossy();
+    decoded.eq_ignore_ascii_case("token")
+}
+
 /// Strip the `token` parameter from the URI's query string for the
 /// post-auth redirect. Other query params are preserved in their
-/// original order.
+/// original order. Recognises `Token=`, `%74oken=`, and any case-/
+/// percent-folded variant.
 fn strip_token_param(uri: &Uri) -> String {
     let path = uri.path();
     let Some(query) = uri.query() else {
@@ -250,7 +266,7 @@ fn strip_token_param(uri: &Uri) -> String {
     };
     let kept: Vec<&str> = query
         .split('&')
-        .filter(|pair| !pair.starts_with("token=") && *pair != "token")
+        .filter(|pair| !pair.is_empty() && !pair_key_is_token(pair))
         .collect();
     if kept.is_empty() {
         path.to_string()
@@ -261,63 +277,74 @@ fn strip_token_param(uri: &Uri) -> String {
 
 /// Extract the token from one of three channels — header, cookie,
 /// or query string — and constant-time-compare against the launched
-/// token. Returns `None` if none matched (caller emits 401).
-///
-/// `query_param_used` is set to true when the match came from
-/// `?token=<…>`; the caller then sets a cookie and 302-redirects to
-/// the clean URL.
+/// token. AC-V1.30.1-5: even when Bearer or cookie matches, if a
+/// `token=` query param is also present, return `OkViaQueryParam` so
+/// the caller redirects to the clean URL — leaving a stale `?token=`
+/// in the URL bar is the exact SEC-7 leakage path the redirect closes.
 fn check_request(req: &Request, expected: &AuthToken, cookie_name: &str) -> AuthOutcome {
+    // Sniff for any `?token=…` first — if present, we want to redirect
+    // even when another channel also matches. Validity of the query
+    // value isn't required for the redirect; the redirect's only job
+    // is to scrub the URL bar.
+    let query_has_token_param = req
+        .uri()
+        .query()
+        .is_some_and(|q| q.split('&').any(pair_key_is_token));
+
     // 1. Authorization: Bearer …
-    if let Some(bearer) = req
+    let bearer_ok = req
         .headers()
         .get(header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
-    {
-        if ct_eq(bearer, expected.as_str()) {
-            return AuthOutcome::Ok;
-        }
-    }
+        .is_some_and(|bearer| ct_eq(bearer, expected.as_str()));
 
     // 2. cqs_token_<port> cookie. RFC 6265 cookie syntax is name=value
     // pairs separated by `; `. We don't bother with quoted values —
     // the server only ever sets this cookie itself and never quotes
     // it. Cookie name is per-port (#1135) so two cqs serve instances
     // on the same host don't collide in the browser jar.
-    if let Some(cookie_header) = req
+    let cookie_ok = req
         .headers()
         .get(header::COOKIE)
         .and_then(|v| v.to_str().ok())
-    {
-        let needle = format!("{cookie_name}=");
-        for pair in cookie_header.split(';') {
-            if let Some(value) = pair.trim().strip_prefix(&needle) {
-                if ct_eq(value, expected.as_str()) {
-                    return AuthOutcome::Ok;
-                }
-            }
-        }
-    }
+        .map(|cookie_header| {
+            let needle = format!("{cookie_name}=");
+            cookie_header.split(';').any(|pair| {
+                pair.trim()
+                    .strip_prefix(&needle)
+                    .is_some_and(|value| ct_eq(value, expected.as_str()))
+            })
+        })
+        .unwrap_or(false);
 
     // 3. ?token=… query param. axum's `Query` extractor only deserializes
     // a typed struct; we want raw access without forcing every request
     // path through a fixed type, so we parse the URI's `query()` directly.
-    if let Some(query) = req.uri().query() {
-        for pair in query.split('&') {
-            if let Some(value) = pair.strip_prefix("token=") {
-                // URI query values can be percent-encoded; the token
-                // alphabet is URL-safe base64 (`A-Z a-z 0-9 - _`) so no
-                // percent-encoding is ever needed in practice. Compare
-                // verbatim — a percent-encoded match would fail `ct_eq`,
-                // which is the conservative choice.
-                if ct_eq(value, expected.as_str()) {
-                    return AuthOutcome::OkViaQueryParam;
-                }
-            }
-        }
+    let query_ok = req.uri().query().is_some_and(|query| {
+        query
+            .split('&')
+            .filter(|pair| pair_key_is_token(pair))
+            .any(|pair| {
+                let value = pair.split_once('=').map(|(_, v)| v).unwrap_or("");
+                ct_eq(value, expected.as_str())
+            })
+    });
+
+    if !(bearer_ok || cookie_ok || query_ok) {
+        return AuthOutcome::Unauthorized;
     }
 
-    AuthOutcome::Unauthorized
+    // AC-V1.30.1-5: presence of `?token=…` (any case-folded form) on a
+    // request that authenticates by ANY channel must trigger the
+    // redirect — otherwise the token sits in the URL bar permanently
+    // after a bookmarked-URL reload, even when the cookie is what
+    // matched.
+    if query_has_token_param {
+        AuthOutcome::OkViaQueryParam
+    } else {
+        AuthOutcome::Ok
+    }
 }
 
 enum AuthOutcome {
@@ -571,32 +598,21 @@ mod tests {
 
     #[test]
     #[allow(non_snake_case)]
-    fn p2_30_strip_token_param_capital_T_token_NOT_stripped_today() {
-        // Pin current behavior: capital `T` fails `starts_with("token=")`,
-        // survives into the redirect URL. After the SEC fix lands, this
-        // test will fail — invert the assertion at that point.
+    fn p2_30_strip_token_param_capital_T_token_IS_stripped() {
+        // CQ-V1.30.1-4: capital `Token=` is case-folded and stripped.
+        // The SEC-7 leakage gap pinned by the previous test is closed.
         let uri: Uri = "/api/graph?Token=abc&depth=3".parse().unwrap();
         let stripped = strip_token_param(&uri);
-        assert!(
-            stripped.contains("Token="),
-            "current behavior: capital `Token=` is not case-folded; \
-             SEC-7 leakage: token survives in redirect URL"
-        );
+        assert_eq!(stripped, "/api/graph?depth=3");
     }
 
     #[test]
-    fn p2_30_strip_token_param_percent_encoded_key_NOT_stripped_today() {
-        // `%74` is `t`. Pin current behavior: literal byte compare misses.
-        // After fix: percent-decode the key, then case-fold.
-        // axum's Uri parser keeps the percent-encoded form; we observe
-        // the same here.
+    #[allow(non_snake_case)]
+    fn p2_30_strip_token_param_percent_encoded_key_IS_stripped() {
+        // CQ-V1.30.1-4: `%74oken=` is percent-decoded and stripped.
         let uri: Uri = "/api/graph?%74oken=abc&depth=3".parse().unwrap();
         let stripped = strip_token_param(&uri);
-        assert!(
-            stripped.contains("%74oken=") || stripped.contains("token="),
-            "current behavior: percent-encoded `%74oken=` is not decoded; \
-             survives into redirect URL"
-        );
+        assert_eq!(stripped, "/api/graph?depth=3");
     }
 
     #[test]
@@ -641,25 +657,36 @@ mod tests {
 
     #[test]
     #[allow(non_snake_case)]
-    fn p2_30_check_request_capital_T_token_today_rejects() {
-        // The check_request side mirrors the strip side — capital `T`
-        // means the param doesn't match `starts_with("token=")`, so the
-        // token is never observed. Pin: 401 today (no fall-through).
-        // After fix: 200 OkViaQueryParam with case-fold.
+    fn p2_30_check_request_capital_T_token_IS_recognised() {
+        // CQ-V1.30.1-4: capital `Token=` is case-folded; the request
+        // authenticates via the query channel and triggers the redirect.
         let token = AuthToken::try_from_string("secretvalue").expect("test token alphabet");
         let req = Request::builder()
             .uri("/api/graph?Token=secretvalue")
             .body(axum::body::Body::empty())
             .unwrap();
         match check_request(&req, &token, &cookie_name_for_port(8080)) {
-            AuthOutcome::Unauthorized => {}
-            AuthOutcome::Ok | AuthOutcome::OkViaQueryParam => {
+            AuthOutcome::OkViaQueryParam => {}
+            AuthOutcome::Ok | AuthOutcome::Unauthorized => {
                 panic!(
-                    "current behavior expected: capital `Token=` not recognised, request 401s. \
-                     If this test starts failing, the case-fold landed and the assertion \
-                     should invert."
+                    "post-fix expectation: case-folded `Token=` matches and the redirect path fires"
                 );
             }
         }
+    }
+
+    #[test]
+    fn check_request_cookie_with_redundant_query_token_redirects() {
+        // AC-V1.30.1-5: even when the cookie matches, a `?token=` query
+        // param must trigger the redirect so the URL bar is scrubbed.
+        let token = AuthToken::random();
+        let cookie_name = "cqs_token_8080";
+        let req = Request::builder()
+            .uri("/api/graph?token=anything")
+            .header(header::COOKIE, format!("{cookie_name}={}", token.as_str()))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let outcome = check_request(&req, &token, cookie_name);
+        assert!(matches!(outcome, AuthOutcome::OkViaQueryParam));
     }
 }


### PR DESCRIPTION
## Summary

Bundle B from the v1.30.1 audit-fix-prompts: three coordinated landings on the serve auth surface, the doc that describes it, and the daemon-startup log path.

- **P1.3** (CQ-V1.30.1-4 + AC-V1.30.1-5): `cqs serve` `?token=` query-param redirect leaked the token in two ways. (a) `check_request` returned `Ok` (not `OkViaQueryParam`) when both a valid cookie *and* `?token=…` were present, so the redirect at the call-site never fired and the token survived in the URL bar after a bookmarked-URL reload. (b) `strip_token_param` and `check_request` did byte-literal `starts_with("token=")`, so `?Token=…` and `?%74oken=…` were not recognised and the redirect-strip path missed them too. Single fix: introduce `pair_key_is_token` (case-fold + percent-decode), sniff for any `?token=…` form *before* selecting the success outcome, and route through `OkViaQueryParam` whenever the URI carries the param regardless of which channel matched.
- **P1.7** (DOC-V1.30.1-7): SECURITY.md row 17 described the v1.29 auth shape — missing the cookie name change to `cqs_token_<port>` (#1135) and the `NoAuthAcknowledgement` proof-token requirement on `--no-auth` (#1136). Replaced with the full surface description, matching what the code actually does post-#1197.
- **P1.10** (SEC-V1.30.1-8): on daemon startup, `cli::watch::run` iterated every `CQS_*` env var and emitted `tracing::info!(cqs_vars = ?cqs_vars, "Daemon env snapshot")`. With OB-V1.30-1 surfacing info-level events to systemd-journald, an unredacted log of `CQS_LLM_API_KEY` landed in a 30-day journal artifact. Redact any var whose name suffix matches `_API_KEY`, `_TOKEN`, `_PASSWORD`, or `_SECRET` to `<redacted len=N>` before logging.

## Files

- `src/serve/auth.rs` — new `pair_key_is_token` helper, refactored `check_request` to prefer `OkViaQueryParam` when the URI carries a `?token=…`, two pinned tests inverted, one new AC-V1.30.1-5 test added.
- `Cargo.toml`, `Cargo.lock` — explicit `percent-encoding = "2"` line in `[dependencies]` (was transitively present via reqwest, but the import has to be direct).
- `SECURITY.md` — row 17 expanded.
- `src/cli/watch/mod.rs` — daemon env snapshot redacts secret-suffix vars.
- `src/cli/watch/tests.rs` — `env_snapshot_redacts_api_key` regression test.

## Test plan

- [x] `cargo test --features cuda-index --lib serve::auth -- --nocapture` — 19 passed (includes inverted P1.3 pins + new `check_request_cookie_with_redundant_query_token_redirects`).
- [x] `cargo test --features cuda-index --lib serve::tests -- --nocapture` — 50 passed.
- [x] `cargo test --features cuda-index --bin cqs env_snapshot_redacts_api_key` — 1 passed.
- [x] `cargo fmt` clean.
- [x] `cargo clippy --features cuda-index --lib -- -D warnings` clean. `--all-targets` shows pre-existing test-only clippy errors that exist on `main` before this PR (verified by `git stash` baseline).
- [ ] Manual smoke: `cqs serve --bind 127.0.0.1:8088 &` then `curl -i 'http://127.0.0.1:8088/?token=GOOD' --cookie 'cqs_token_8088=GOOD'` returns 302 to `/`.
- [ ] Manual smoke: `CQS_LLM_API_KEY=sk-test-secret cqs watch --serve` then `journalctl --user-unit cqs-watch | grep cqs_vars` shows `<redacted len=14>`, never `sk-test-secret`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
