### PR TITLE
fix(embedder+watch): batch-size wiring + reconcile cap + mtime predicate -- P1.9, P1.11, P1.12

### DIFF
--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -517,9 +517,10 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
         if !cli.quiet {
             println!("Enriching embeddings with call graph context...");
         }
-        let embedder = Embedder::new(cli.try_model_config()?.clone())
+        let model_config = cli.try_model_config()?.clone();
+        let embedder = Embedder::new(model_config.clone())
             .context("Failed to create embedder for enrichment pass")?;
-        match enrichment_pass(&store, &embedder, cli.quiet) {
+        match enrichment_pass(&store, &embedder, &model_config, cli.quiet) {
             Ok(count) => {
                 if !cli.quiet && count > 0 {
                     println!("  Enriched: {} chunks", count);

--- a/src/cli/enrichment.rs
+++ b/src/cli/enrichment.rs
@@ -20,7 +20,12 @@ use cqs::{Embedder, Embedding, Store};
 /// 3. For each chunk with callers or callees, regenerates NL with call context
 /// 4. Re-embeds and updates the embedding in-place
 /// Returns the number of chunks re-embedded.
-pub(crate) fn enrichment_pass(store: &Store, embedder: &Embedder, quiet: bool) -> Result<usize> {
+pub(crate) fn enrichment_pass(
+    store: &Store,
+    embedder: &Embedder,
+    model_config: &cqs::embedder::ModelConfig,
+    quiet: bool,
+) -> Result<usize> {
     let _span = tracing::info_span!("enrichment_pass").entered();
 
     // Step 1: Count chunks for IDF computation
@@ -70,8 +75,10 @@ pub(crate) fn enrichment_pass(store: &Store, embedder: &Embedder, quiet: bool) -
 
     // (chunk_id, enriched_nl, enrichment_hash)
     let mut embed_batch: Vec<(String, String, String)> = Vec::new();
-    // SHL-27: Use shared embed_batch_size() so CQS_EMBED_BATCH_SIZE env var is respected
-    let enrich_embed_batch: usize = super::pipeline::embed_batch_size();
+    // SHL-V1.30-1: model-aware batch size so nomic-coderank (768 dim,
+    // 2048 seq) doesn't OOM at batch=64 on an 8 GB GPU. CQS_EMBED_BATCH_SIZE
+    // override is still honoured inside `embed_batch_size_for`.
+    let enrich_embed_batch: usize = super::pipeline::embed_batch_size_for(model_config);
     let mut skipped_count = 0usize;
 
     // Pre-fetch all LLM summaries once before the page loop (PERF-18).

--- a/src/cli/pipeline/mod.rs
+++ b/src/cli/pipeline/mod.rs
@@ -12,7 +12,7 @@ mod upsert;
 mod windowing;
 
 // Re-export public items
-pub(crate) use types::embed_batch_size;
+pub(crate) use types::embed_batch_size_for;
 pub(crate) use types::PipelineStats;
 pub(crate) use windowing::apply_windowing;
 
@@ -77,6 +77,7 @@ pub(crate) fn run_index_pipeline(
         let parsed_count = Arc::clone(&parsed_count);
         let parse_errors = Arc::clone(&parse_errors);
         let root = root.to_path_buf();
+        let model_config = model_config.clone();
         thread::spawn(move || {
             parser_stage(
                 files,
@@ -87,6 +88,7 @@ pub(crate) fn run_index_pipeline(
                     store,
                     parsed_count,
                     parse_errors,
+                    model_config,
                 },
                 parse_tx,
             )

--- a/src/cli/pipeline/parsing.rs
+++ b/src/cli/pipeline/parsing.rs
@@ -11,7 +11,7 @@ use rayon::prelude::*;
 
 use cqs::{normalize_path, Parser as CqParser, Store};
 
-use super::types::{embed_batch_size, file_batch_size, ParsedBatch, RelationshipData};
+use super::types::{embed_batch_size_for, file_batch_size, ParsedBatch, RelationshipData};
 use crate::cli::check_interrupted;
 
 /// CQ-39: Context struct for parser_stage to avoid too_many_arguments.
@@ -22,6 +22,10 @@ pub(super) struct ParserStageContext {
     pub store: Arc<Store>,
     pub parsed_count: Arc<AtomicUsize>,
     pub parse_errors: Arc<AtomicUsize>,
+    /// SHL-V1.30-1: model config so the per-batch send loop can pick a
+    /// dim/seq-scaled batch size. At batch=64 nomic-coderank (768 dim,
+    /// 2048 seq) OOMs an 8 GB GPU; the model-aware helper drops it to 16.
+    pub model_config: cqs::embedder::ModelConfig,
 }
 
 /// Stage 1: Parse files in parallel batches, filter by staleness, and send to embedder channels.
@@ -38,8 +42,9 @@ pub(super) fn parser_stage(
         store,
         parsed_count,
         parse_errors,
+        model_config,
     } = ctx;
-    let batch_size = embed_batch_size();
+    let batch_size = embed_batch_size_for(&model_config);
     let file_batch_size = file_batch_size();
 
     for (batch_idx, file_batch) in files.chunks(file_batch_size).enumerate() {
@@ -272,6 +277,7 @@ pub(super) fn parser_stage(
 
 #[cfg(test)]
 mod tests {
+    use super::super::types::embed_batch_size;
     use super::*;
     use crossbeam_channel::unbounded;
     use std::collections::HashSet;
@@ -348,6 +354,8 @@ mod tests {
             store: Arc::clone(&store),
             parsed_count: Arc::new(AtomicUsize::new(0)),
             parse_errors: Arc::new(AtomicUsize::new(0)),
+            // `resolve` returns `Self`, not Result/Option — no `.unwrap()`.
+            model_config: cqs::embedder::ModelConfig::resolve(None, None),
         };
         parser_stage(rel_paths, ctx, tx).unwrap();
 

--- a/src/cli/pipeline/types.rs
+++ b/src/cli/pipeline/types.rs
@@ -136,14 +136,15 @@ pub(super) fn embed_channel_depth() -> usize {
 #[cfg(test)]
 pub(super) static TEST_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// Embedding batch size. Was 32 (backed off from 64 after an undiagnosed crash at 2%).
-/// Restored to 64 with debug logging (PERF-45 investigation). If it crashes again,
-/// run with RUST_LOG=debug to capture batch_size/max_char_len/total_chars at failure.
-/// Configurable via `CQS_EMBED_BATCH_SIZE` environment variable.
+/// Legacy fixed-batch helper kept ONLY for callers without a `ModelConfig`
+/// in scope (currently: nothing in production, only the in-tree tests
+/// `pipeline::tests::test_embed_batch_size` and the parser-stage drain
+/// regression test). Production must use [`embed_batch_size_for`] which
+/// scales batch with the active model's dim & seq — at batch=64 the
+/// nomic-coderank preset (768 dim, 2048 seq) OOMs an 8 GB GPU.
 ///
-/// Legacy entry point — kept for callers that don't have a `ModelConfig`
-/// in scope. New sites should prefer [`embed_batch_size_for`] which scales
-/// with the active model's `dim` and `max_seq_length`.
+/// Returns 64 with `CQS_EMBED_BATCH_SIZE` env override.
+#[cfg(test)]
 pub(crate) fn embed_batch_size() -> usize {
     match std::env::var("CQS_EMBED_BATCH_SIZE") {
         Ok(val) => match val.parse::<usize>() {
@@ -163,7 +164,8 @@ pub(crate) fn embed_batch_size() -> usize {
     }
 }
 
-/// P2.41 — scale the embed batch size with the active model's dim & seq.
+/// SHL-V1.30-1 / P2.41 — scale the embed batch size with the active model's
+/// dim & seq.
 ///
 /// BGE-large (1024 dim, 512 seq) at batch=64 ≈ 130 MB per forward-pass tensor
 /// — the empirical sweet spot on RTX 4060 8 GB. Nomic-coderank (768 dim,
@@ -175,7 +177,6 @@ pub(crate) fn embed_batch_size() -> usize {
 /// → `batch_baseline * (1024/dim) * (512/seq)` rounded to a power of 2,
 /// clamped to `[2, 256]`. The env override `CQS_EMBED_BATCH_SIZE` takes
 /// priority — operators with workloads they understand can pin a value.
-#[allow(dead_code)] // P2.41: opt-in helper; pipeline migration is a follow-on PR.
 pub(crate) fn embed_batch_size_for(model: &cqs::embedder::ModelConfig) -> usize {
     if let Ok(val) = std::env::var("CQS_EMBED_BATCH_SIZE") {
         if let Ok(size) = val.parse::<usize>() {

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -63,7 +63,6 @@ mod reconcile;
 use reconcile::{reconcile_enabled, run_daemon_reconcile};
 
 mod events;
-#[cfg(test)]
 use events::max_pending_files;
 use events::{collect_events, process_file_changes, process_note_changes};
 
@@ -1074,6 +1073,7 @@ pub fn cmd_watch(
                         &parser,
                         no_ignore,
                         &mut state.pending_files,
+                        max_pending_files(),
                     );
                     tracing::info!(
                         queued,
@@ -1287,6 +1287,7 @@ pub fn cmd_watch(
                             &parser,
                             no_ignore,
                             &mut state.pending_files,
+                            max_pending_files(),
                         );
                         if queued > 0 {
                             // Reset `last_event` so `process_file_changes`

--- a/src/cli/watch/reconcile.rs
+++ b/src/cli/watch/reconcile.rs
@@ -60,14 +60,21 @@ use cqs::store::Store;
 /// inserted it gets reindexed on the next idle tick like any other event-
 /// driven change. The watch loop's existing dedup (`HashSet`) means
 /// queueing a file already in `pending_files` is free.
+///
+/// `max_pending` caps the total queue size — DS-V1.30.1-D2: respect the
+/// same backpressure ceiling the inotify path enforces (events.rs:108)
+/// so a bulk `git checkout` of 50k files doesn't drown the next
+/// `process_file_changes` cycle. Files skipped at the cap are picked up
+/// by the next reconcile pass — the walk is idempotent.
 pub(super) fn run_daemon_reconcile(
     store: &Store,
     root: &Path,
     parser: &CqParser,
     no_ignore: bool,
     pending_files: &mut HashSet<PathBuf>,
+    max_pending: usize,
 ) -> usize {
-    let _span = tracing::info_span!("daemon_reconcile").entered();
+    let _span = tracing::info_span!("daemon_reconcile", max_pending).entered();
 
     // Walk disk → set of relative paths visible to indexing.
     let exts = parser.supported_extensions();
@@ -92,7 +99,16 @@ pub(super) fn run_daemon_reconcile(
     let mut added = 0usize;
     let mut modified = 0usize;
     let mut queued = 0usize;
+    let mut skipped_at_cap = 0usize;
     for rel in disk_files {
+        // DS-V1.30.1-D2: respect the same cap as the inotify path so a
+        // bulk branch switch (50k files) doesn't drown the next
+        // `process_file_changes` cycle. Files we skip here are picked
+        // up by the next reconcile pass — the walk is idempotent.
+        if pending_files.len() >= max_pending {
+            skipped_at_cap += 1;
+            continue;
+        }
         // Stored origins are typically relative; normalize to forward
         // slashes for cross-platform matching parity with the rest of the
         // store layer.
@@ -106,8 +122,9 @@ pub(super) fn run_daemon_reconcile(
                 }
             }
             Some(stored_mtime) => {
-                // MODIFIED: same path indexed, but mtime moved forward.
-                // `None` stored mtime → treat as stale (legacy schema).
+                // MODIFIED: same path indexed, but disk content may have
+                // diverged. `None` stored mtime → treat as stale (legacy
+                // schema).
                 let lookup_path: PathBuf = if rel.is_absolute() {
                     rel.clone()
                 } else {
@@ -120,8 +137,17 @@ pub(super) fn run_daemon_reconcile(
                         .map(cqs::duration_to_mtime_millis),
                     Err(_) => None,
                 };
+                // AC-V1.30.1-1: use `!=` not `>` because `git checkout`
+                // restores commit-time mtimes, which can be *older* than
+                // the indexed `source_mtime`. The inotify path's
+                // `mtime <= last` mtime-equality skip is correct for
+                // single-file edits (where mtime always advances), but
+                // reconcile exists *specifically* for bulk git ops where
+                // mtime is non-monotonic. Any disk/stored mismatch is
+                // a queue trigger; the reindex itself is content-hashed
+                // so a no-op rewrite costs only the parse + cache-hit.
                 let needs_reindex = match (stored_mtime, disk_mtime) {
-                    (Some(stored), Some(disk)) => disk > *stored,
+                    (Some(stored), Some(disk)) => disk != *stored,
                     (None, _) => true,        // legacy/null stored mtime
                     (Some(_), None) => false, // can't read disk mtime → leave to GC
                 };
@@ -133,7 +159,14 @@ pub(super) fn run_daemon_reconcile(
         }
     }
 
-    if queued > 0 {
+    if skipped_at_cap > 0 {
+        tracing::warn!(
+            queued,
+            skipped_at_cap,
+            cap = max_pending,
+            "Reconcile: hit pending-files cap; skipped files will be picked up on next reconcile pass"
+        );
+    } else if queued > 0 {
         tracing::info!(
             queued,
             added,
@@ -187,7 +220,14 @@ mod tests {
 
         let store = open_store(&cqs_dir);
         let mut pending = HashSet::new();
-        let queued = run_daemon_reconcile(&store, dir.path(), &parser(), false, &mut pending);
+        let queued = run_daemon_reconcile(
+            &store,
+            dir.path(),
+            &parser(),
+            false,
+            &mut pending,
+            usize::MAX,
+        );
         assert_eq!(queued, 2);
         assert_eq!(pending.len(), 2);
     }
@@ -201,7 +241,14 @@ mod tests {
 
         let store = open_store(&cqs_dir);
         let mut pending = HashSet::new();
-        let queued = run_daemon_reconcile(&store, dir.path(), &parser(), false, &mut pending);
+        let queued = run_daemon_reconcile(
+            &store,
+            dir.path(),
+            &parser(),
+            false,
+            &mut pending,
+            usize::MAX,
+        );
         assert_eq!(queued, 0);
         assert!(pending.is_empty());
     }
@@ -222,7 +269,14 @@ mod tests {
         // Pre-seed the queue as if inotify already saw the file.
         pending.insert(PathBuf::from("src/a.rs"));
 
-        let queued = run_daemon_reconcile(&store, dir.path(), &parser(), false, &mut pending);
+        let queued = run_daemon_reconcile(
+            &store,
+            dir.path(),
+            &parser(),
+            false,
+            &mut pending,
+            usize::MAX,
+        );
         // The file was already pending — `insert` returned false, so
         // `queued` stays 0 even though the file was divergent.
         assert_eq!(queued, 0);
@@ -359,7 +413,14 @@ mod tests {
         // `stored_mtime_ms`. Reconcile must classify every file as
         // MODIFIED and queue it.
         let mut pending = HashSet::new();
-        let queued = run_daemon_reconcile(&store, dir.path(), &parser(), false, &mut pending);
+        let queued = run_daemon_reconcile(
+            &store,
+            dir.path(),
+            &parser(),
+            false,
+            &mut pending,
+            usize::MAX,
+        );
         assert_eq!(
             queued, N,
             "all {N} bulk-modified files must be queued (got {queued})"
@@ -404,8 +465,9 @@ mod tests {
 
         // Write a single file, then store its current disk mtime as the
         // index's `source_mtime` so reconcile sees `disk_mtime ==
-        // stored_mtime`. The needs_reindex predicate uses strict
-        // `disk > stored`, so equality keeps the file out of the queue.
+        // stored_mtime`. After AC-V1.30.1-1 the predicate is `disk !=
+        // stored`, so equality (the unchanged-file case) keeps the file
+        // out of the queue.
         let rel = "src/quiet.rs";
         let abs = dir.path().join(rel);
         fs::write(&abs, b"fn quiet() {}").unwrap();
@@ -447,11 +509,135 @@ mod tests {
             .expect("seed chunk at disk mtime");
 
         let mut pending = HashSet::new();
-        let queued = run_daemon_reconcile(&store, dir.path(), &parser(), false, &mut pending);
+        let queued = run_daemon_reconcile(
+            &store,
+            dir.path(),
+            &parser(),
+            false,
+            &mut pending,
+            usize::MAX,
+        );
         assert_eq!(
             queued, 0,
             "file with disk_mtime == stored_mtime must not requeue"
         );
         assert!(pending.is_empty());
+    }
+
+    /// DS-V1.30.1-D2: cap shared with the inotify path so a bulk
+    /// git-checkout doesn't drown the next process_file_changes
+    /// cycle. Tests the strict pre-queue clamp: files we'd otherwise
+    /// queue are skipped once `pending_files.len() >= max_pending`.
+    #[test]
+    fn run_daemon_reconcile_respects_max_pending_cap() {
+        let dir = TempDir::new().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        fs::create_dir_all(&cqs_dir).unwrap();
+        let store = open_store(&cqs_dir);
+
+        let mut pending: HashSet<PathBuf> = HashSet::new();
+        // Pre-fill 5 entries so `pending.len() >= cap=5` immediately.
+        for i in 0..5 {
+            pending.insert(PathBuf::from(format!("preexisting_{i}.rs")));
+        }
+        // Create 20 files on disk.
+        let src_dir = dir.path().join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+        for i in 0..20 {
+            fs::write(src_dir.join(format!("file_{i}.rs")), "fn x(){}").unwrap();
+        }
+        let queued = run_daemon_reconcile(
+            &store,
+            dir.path(),
+            &parser(),
+            false,
+            &mut pending,
+            5, // cap is already met
+        );
+        assert_eq!(queued, 0, "cap already met → no new entries queued");
+        assert_eq!(pending.len(), 5, "pending must not exceed cap");
+    }
+
+    /// AC-V1.30.1-1: `git checkout HEAD~5 -- foo.rs` restores the file
+    /// with its commit-time mtime, which is *older* than the indexed
+    /// `source_mtime`. The strict `disk > stored` predicate would skip
+    /// this file silently. Reconcile must use `disk != stored` so any
+    /// divergence — forward or backward in time — queues a reindex.
+    #[test]
+    fn run_daemon_reconcile_queues_older_disk_mtime() {
+        use cqs::parser::{Chunk, ChunkType, Language};
+        use std::time::{Duration, SystemTime};
+
+        let dir = TempDir::new().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        fs::create_dir_all(&cqs_dir).unwrap();
+        let src_dir = dir.path().join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+
+        // Write the file with new content (post-checkout state).
+        let rel = "src/foo.rs";
+        let abs = dir.path().join(rel);
+        fs::write(&abs, "fn rewound() {}").unwrap();
+
+        // Rewind the disk mtime to a week ago to simulate `git checkout`
+        // restoring a commit-time mtime older than what we'll seed as
+        // the stored mtime. `set_modified` is stable since Rust 1.75
+        // (cqs MSRV is 1.95) — same pattern used in
+        // `src/store/migrations.rs` and `src/cli/batch/mod.rs`.
+        let week_ago = SystemTime::now() - Duration::from_secs(7 * 24 * 60 * 60);
+        let f = std::fs::OpenOptions::new().write(true).open(&abs).unwrap();
+        f.set_modified(week_ago).unwrap();
+        drop(f);
+
+        // Seed the index with a HIGHER stored_mtime than the rewound
+        // disk mtime — simulates "indexed at HEAD (today), then file
+        // rewound by checkout to last week's commit". Use a "now" stored
+        // mtime in milliseconds; even if the test runs millis after the
+        // rewind, `now > week_ago` by a comfortable margin.
+        let stored_mtime_ms = cqs::duration_to_mtime_millis(
+            SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap(),
+        );
+        let content = "fn original() {}".to_string(); // any content; only mtime drives the predicate
+        let hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+        let chunk = Chunk {
+            id: format!("{rel}:1:{}", &hash[..8]),
+            file: PathBuf::from(rel),
+            language: Language::Rust,
+            chunk_type: ChunkType::Function,
+            name: "original".to_string(),
+            signature: "fn original()".to_string(),
+            content,
+            doc: None,
+            line_start: 1,
+            line_end: 1,
+            content_hash: hash,
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        };
+
+        let store = open_store(&cqs_dir);
+        store
+            .upsert_chunks_batch(
+                &[(chunk, placeholder_embedding(0.0))],
+                Some(stored_mtime_ms),
+            )
+            .expect("seed chunk at stored mtime");
+
+        let mut pending: HashSet<PathBuf> = HashSet::new();
+        let queued = run_daemon_reconcile(
+            &store,
+            dir.path(),
+            &parser(),
+            false,
+            &mut pending,
+            usize::MAX,
+        );
+
+        assert_eq!(queued, 1, "older-mtime divergent file must be queued");
+        assert!(pending.contains(&PathBuf::from(rel)));
     }
 }

--- a/src/store/helpers/types.rs
+++ b/src/store/helpers/types.rs
@@ -880,6 +880,15 @@ mod tests {
 
     #[test]
     fn test_to_json_with_origin_none_matches_default() {
+        // Both `to_json` and `to_json_with_origin(None)` call
+        // `maybe_wrap_content`, which reads the process-global
+        // `CQS_TRUST_DELIMITERS`. Tests that mutate that env var (e.g.
+        // `test_to_json_field_values`) take `TRUST_DELIM_ENV_LOCK`; this
+        // test must hold it too, or it sees a flipped value mid-call and
+        // the assertion races.
+        let _guard = TRUST_DELIM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let result = SearchResult {
             chunk: make_chunk("foo", None),
             score: 0.7,


### PR DESCRIPTION
## Summary

Bundle E of the v1.30.1 P1 audit — three correctness fixes touching the embedder pipeline and the watch reconcile path:

- **P1.9 (SHL-V1.30-1)** — Wire `embed_batch_size_for(model)` into the two production callers (`parser_stage`, `enrichment_pass`). The model-aware variant existed since v1.30.0 but was `#[allow(dead_code)]` with zero callers; both production sites still used the legacy `embed_batch_size()` returning a hardcoded 64. nomic-coderank (768 dim, 2048 seq) at batch=64 OOMs an 8 GB GPU. Same wiring-verification class as the configurable-models disaster — the convenience wrapper masked the bug. Legacy `embed_batch_size()` is now `#[cfg(test)]`-gated so any future production caller fails to compile.
- **P1.11 (DS-V1.30.1-D2)** — `run_daemon_reconcile` now respects `max_pending_files()`, the same backpressure ceiling the inotify path enforces. Bulk `git checkout` of 50k files no longer drowns the next `process_file_changes` cycle. Files skipped at the cap are picked up on the next reconcile pass — the walk is idempotent.
- **P1.12 (AC-V1.30.1-1)** — Reconcile predicate switches from `disk > stored` to `disk != stored` to catch non-monotonic mtimes. `git checkout HEAD~5 -- foo.rs` restores the file with its commit-time mtime (often *older* than the indexed `source_mtime`); the strict-greater predicate was silently dropping these. Reindex itself is content-hashed so a no-op rewrite costs only the parse + cache-hit.

## Files touched

- `src/cli/pipeline/types.rs` — drop `#[allow(dead_code)]` on `embed_batch_size_for`; gate legacy `embed_batch_size` to `#[cfg(test)]`
- `src/cli/pipeline/parsing.rs` — extend `ParserStageContext` with `model_config`; switch to `embed_batch_size_for`
- `src/cli/pipeline/mod.rs` — re-export `embed_batch_size_for`; thread `model_config` into the `parser_handle` spawn
- `src/cli/enrichment.rs` — add `model_config: &ModelConfig` to `enrichment_pass` signature; switch to `embed_batch_size_for`
- `src/cli/commands/index/build.rs` — pass `&model_config` to `enrichment_pass`
- `src/cli/watch/reconcile.rs` — add `max_pending: usize` parameter; cap pre-queue clamping; predicate `>` → `!=`; 2 new tests + 5 existing tests updated
- `src/cli/watch/mod.rs` — un-gate `max_pending_files` import (was `#[cfg(test)]`-only); pass `max_pending_files()` at both reconcile call sites

## Test plan

- [x] `cargo test --features cuda-index --bin cqs watch::reconcile` — 9/9 pass (2 new)
- [x] `cargo test --features cuda-index --bin cqs pipeline::` — 35/35 pass
- [x] `cargo test --features cuda-index --bin cqs commands::index::build` — 8/8 pass
- [x] `cargo build --features cuda-index` — clean, no dead-code warning on `embed_batch_size_for`
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --features cuda-index --bin cqs --lib` — clean (pre-existing `--all-targets` errors are unrelated to this diff: `src/search/scoring/candidate.rs:1033`, `src/serve/auth.rs:588`, `src/llm/local.rs` httpmock deprecation, `src/cli/batch/pipeline.rs:763`, etc.)
- [x] Wiring verification: `grep "embed_batch_size()" src/cli/ | grep -v cfg(test)` — zero non-test matches
- [ ] Manual on a real repo: `git checkout HEAD~5 -- src/lib.rs` then wait `CQS_WATCH_RECONCILE_SECS` seconds — `cqs status --watch-fresh --json` should flip `state: "stale"` (was `fresh` before the predicate fix)
- [ ] Manual: `RUST_LOG=cqs::cli::pipeline=debug cqs index --model nomic-coderank` should log `embed_batch_size_for: model-derived default rounded=16` (was 64)
- [ ] Manual: with `CQS_WATCH_MAX_PENDING=10`, `git checkout` of a 47-file diff should leave `pending_files.len() == 10` with `cap=10 skipped_at_cap=37` in journal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
