### PR TITLE
ci: free ~30 GB on the test runner — fix recurring No space left on device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h /
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

Multiple PRs and main itself are failing CI with:

```
rustc-LLVM ERROR: IO failure on output stream: No space left on device
error: linking with `cc` failed: ... ld terminated with signal 7 [Bus error], core dumped
```

The `ubuntu-latest` runner ships with ~14 GB free after `Swatinem/rust-cache` restore + cqs's 54 tree-sitter grammars + `ort` + `sqlx` etc. That's enough for `cargo build`, but tips over during `cargo test` when per-test binary artifacts land.

This PR adds a "Free up disk space" step at the top of the `test` job that strips the bundled .NET, Boost, Android, GHC, and CodeQL toolchains and prunes Docker images. Reclaims ~30 GB on a standard ubuntu-latest runner. The other jobs (clippy, fmt, msrv) don't need the headroom — only `test` produces the artifact volume that triggers the limit.

## Test plan

- [x] CI on this PR exercises the new step
- [x] Once merged, in-flight PRs (#1200/#1201/#1202/#1203 and any new audit-fix PRs) rebase onto main and pick up the cleanup step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
