### PR TITLE
fix(watch): state machine observability + delta + clock safety — bundle-watch-status-machine, AC-V1.30.1-10, API-V1.30.1-10, OB-V1.30.1-9, RB-10, EH-V1.30.1-8

### DIFF
--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -638,6 +638,17 @@ mod tests {
             obj.contains_key("snapshot_at"),
             "snapshot must carry `snapshot_at` timestamp"
         );
+        // RB-10: snapshot_at is `Option<i64>` — serializes to a JSON number
+        // on a healthy clock, JSON null on a clock-before-epoch system. CI
+        // and dev workstations pass the healthy-clock path, so pin
+        // `is_number()` to catch a regression that flips the wire shape.
+        assert!(
+            obj.get("snapshot_at")
+                .map(|v| v.is_number())
+                .unwrap_or(false),
+            "snapshot_at must be a JSON number on a healthy clock; got: {:?}",
+            obj.get("snapshot_at")
+        );
     }
 
     /// #1182 — Layer 1: `dispatch_reconcile` flips the shared

--- a/src/cli/commands/infra/status.rs
+++ b/src/cli/commands/infra/status.rs
@@ -135,12 +135,12 @@ fn print_text(snap: &cqs::watch_status::WatchSnapshot) {
     // without parsing JSON. Counters that matter live on the second line.
     println!("state: {}", snap.state.as_str());
     println!(
-        "modified_files={} pending_notes={} rebuild_in_flight={} dropped_this_cycle={} idle_secs={}",
+        "modified_files={} pending_notes={} rebuild_in_flight={} dropped_this_cycle={} last_event_unix_secs={}",
         snap.modified_files,
         snap.pending_notes,
         snap.rebuild_in_flight,
         snap.dropped_this_cycle,
-        snap.idle_secs,
+        snap.last_event_unix_secs,
     );
 }
 

--- a/src/cli/watch/events.rs
+++ b/src/cli/watch/events.rs
@@ -150,12 +150,16 @@ pub(super) fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut
             "Watch event queue full this cycle; dropping events. Run `cqs index` to catch up"
         );
     }
-    if !cfg.quiet {
-        println!("\n{} file(s) changed, reindexing...", files.len());
-        for f in &files {
-            println!("  {}", f.display());
-        }
-    }
+    // OB-V1.30.1-9: replace stdout println with structured tracing.
+    // The daemon has no terminal — stdout goes to journald via the
+    // systemd unit which writes unstructured. Tracing routes through
+    // the configured subscriber (journald JSON or stderr text) and
+    // honours filter levels.
+    tracing::info!(
+        file_count = files.len(),
+        files = ?files,
+        "watch: reindexing changed files",
+    );
 
     let emb = match try_init_embedder(cfg.embedder, &mut state.embedder_backoff, cfg.model_config) {
         Some(e) => e,
@@ -430,6 +434,20 @@ pub(super) fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut
         }
         Err(e) => {
             warn!(error = %e, "Reindex error");
+            // EH-V1.30.1-8: the dirty flag was set above (lines 184/189)
+            // before the reindex attempt and the success path's
+            // `clear_hnsw_dirty_with_retry` is unreachable from this arm.
+            // Surface that the HNSW will be marked dirty on disk until a
+            // successful reindex cycle clears it — operators correlate
+            // this with the prior `Reindex error` to diagnose persistent
+            // dirty state (SQLite busy / OOM / etc.) and search may
+            // serve stale results in the meantime.
+            tracing::warn!(
+                hnsw_kinds = "enriched,base",
+                "HNSW dirty flag remains set after reindex failure; \
+                 search may serve stale results until next successful \
+                 reindex cycle clears it"
+            );
         }
     }
 }

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -174,12 +174,37 @@ fn publish_watch_snapshot(
     });
     // Poison-recovery: another writer panicking shouldn't silently stop
     // freshness publishing. Recover and overwrite.
+    //
+    // bundle-watch-status-machine / OB-V1.30.1-3: capture the previous
+    // state under the lock so we can emit a transition log line *after*
+    // releasing it. Operators see a journal trail for Fresh↔Stale↔
+    // Rebuilding flips; the loop wrote 100 ms updates with zero state
+    // observability before this. `WatchSnapshot` derives `Clone` and
+    // `FreshnessState` is `Copy`, so the clone-for-log cost is negligible.
+    let prev_state;
+    let next_snap = snap.clone();
     match handle.write() {
-        Ok(mut guard) => *guard = snap,
+        Ok(mut guard) => {
+            prev_state = guard.state;
+            *guard = snap;
+        }
         Err(poisoned) => {
             tracing::warn!("watch_snapshot RwLock poisoned — recovering and continuing to publish");
-            *poisoned.into_inner() = snap;
+            let mut guard = poisoned.into_inner();
+            prev_state = guard.state;
+            *guard = snap;
         }
+    }
+
+    if prev_state != next_snap.state {
+        tracing::info!(
+            prev = prev_state.as_str(),
+            next = next_snap.state.as_str(),
+            modified_files = next_snap.modified_files,
+            rebuild_in_flight = next_snap.rebuild_in_flight,
+            dropped_this_cycle = next_snap.dropped_this_cycle,
+            "watch state transition",
+        );
     }
 }
 
@@ -1192,8 +1217,15 @@ pub fn cmd_watch(
                         if let Some(emb) = shared_embedder.get() {
                             emb.clear_session();
                         }
+                        // AC-V1.30.1-10: do NOT reset incremental_count on
+                        // idle-clear. The counter's contract is "incremental
+                        // inserts since last full rebuild"; a 5-minute idle
+                        // hasn't changed the on-disk delta. Resetting here
+                        // means the next file event starts the threshold
+                        // timer from scratch and understates delta size,
+                        // delaying the rebuild that should fire on
+                        // accumulated drift.
                         state.hnsw_index = None;
-                        state.incremental_count = 0;
                         cycles_since_clear = 0;
                     }
 

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -1027,9 +1027,9 @@ mod tests {
             delta_saturated: false,
             incremental_count: 17,
             dropped_this_cycle: 0,
-            idle_secs: 12,
+            last_event_unix_secs: 1_734_120_488,
             last_synced_at: Some(1_734_120_000),
-            snapshot_at: 1_734_120_500,
+            snapshot_at: Some(1_734_120_500),
         };
         let inner_envelope = serde_json::json!({
             "data": serde_json::to_value(&snap).unwrap(),
@@ -1232,9 +1232,9 @@ mod tests {
             delta_saturated: false,
             incremental_count: 1234,
             dropped_this_cycle: 0,
-            idle_secs: 30,
+            last_event_unix_secs: 1_734_120_470,
             last_synced_at: Some(1_734_120_000),
-            snapshot_at: 1_734_120_500,
+            snapshot_at: Some(1_734_120_500),
         };
         let inner_envelope = serde_json::json!({
             "data": serde_json::to_value(&snap).unwrap(),
@@ -1308,9 +1308,9 @@ mod tests {
             delta_saturated: false,
             incremental_count: 17,
             dropped_this_cycle: 0,
-            idle_secs: 12,
+            last_event_unix_secs: 1_734_120_488,
             last_synced_at: Some(1_734_120_000),
-            snapshot_at: 1_734_120_500,
+            snapshot_at: Some(1_734_120_500),
         };
         let inner_envelope = serde_json::json!({
             "data": serde_json::to_value(&snap).unwrap(),

--- a/src/watch_status.rs
+++ b/src/watch_status.rs
@@ -95,18 +95,25 @@ pub struct WatchSnapshot {
     /// next reconciliation pass) — non-zero is always cause for
     /// attention.
     pub dropped_this_cycle: u64,
-    /// Seconds since the watch loop last observed *any* filesystem
-    /// event. Useful for telling whether the daemon is genuinely idle
-    /// vs. mid-burst.
-    pub idle_secs: u64,
+    /// Unix timestamp (UTC seconds) when the watch loop last observed
+    /// *any* filesystem event. Lets clients compute fresh idle on
+    /// demand (`now - last_event_unix_secs`) without retransacting
+    /// through the daemon — the previous `idle_secs` field was frozen
+    /// at snapshot-publish time and lied once read N seconds later
+    /// (API-V1.30.1-10).
+    pub last_event_unix_secs: i64,
     /// Unix timestamp (UTC seconds) of the last completed reindex —
     /// the mtime of `index.db` after the most recent write. `None`
     /// when the file is missing or unreadable.
     pub last_synced_at: Option<i64>,
     /// Unix timestamp (UTC seconds) when this snapshot was published.
     /// Lets clients tell how stale the *snapshot itself* is (stale
-    /// snapshot ⇒ daemon hasn't ticked recently). Always populated.
-    pub snapshot_at: i64,
+    /// snapshot ⇒ daemon hasn't ticked recently). `None` only on a
+    /// clock-before-epoch system error (RB-10) — formerly silently `0`,
+    /// which made every snapshot look "56 years stale" and tripped
+    /// downstream freshness gates. Operators see a once-per-process
+    /// warn from `now_unix_secs` when this happens.
+    pub snapshot_at: Option<i64>,
 }
 
 impl WatchSnapshot {
@@ -123,7 +130,7 @@ impl WatchSnapshot {
             delta_saturated: false,
             incremental_count: 0,
             dropped_this_cycle: 0,
-            idle_secs: 0,
+            last_event_unix_secs: 0,
             last_synced_at: None,
             snapshot_at: now_unix_secs(),
         }
@@ -214,6 +221,21 @@ impl WatchSnapshot {
             FreshnessState::Fresh
         };
 
+        // API-V1.30.1-10: anchor the last-event timestamp to wall-clock so
+        // consumers can compute fresh idle (`now - last_event_unix_secs`)
+        // on read. `WatchState.last_event` is an `Instant` (monotonic, no
+        // wall-clock conversion), so reconstruct the wall-clock value as
+        // "now minus elapsed". Saturating arithmetic handles the (in
+        // practice unreachable) clock-before-epoch case symmetrically with
+        // `now_unix_secs`.
+        let last_event_unix_secs = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .ok()
+            .map(|d| {
+                (d.as_secs() as i64).saturating_sub(input.last_event.elapsed().as_secs() as i64)
+            })
+            .unwrap_or(0);
+
         Self {
             state,
             modified_files: input.pending_files_count as u64,
@@ -222,18 +244,32 @@ impl WatchSnapshot {
             delta_saturated: input.delta_saturated,
             incremental_count: input.incremental_count as u64,
             dropped_this_cycle: input.dropped_this_cycle as u64,
-            idle_secs: input.last_event.elapsed().as_secs(),
+            last_event_unix_secs,
             last_synced_at: input.last_synced_at,
             snapshot_at: now_unix_secs(),
         }
     }
 }
 
-fn now_unix_secs() -> i64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
+fn now_unix_secs() -> Option<i64> {
+    use std::sync::OnceLock;
+    static WARNED_BAD_CLOCK: OnceLock<()> = OnceLock::new();
+
+    match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(d) => i64::try_from(d.as_secs()).ok(),
+        Err(e) => {
+            // RB-10: surface the bad-clock condition once per process so
+            // journalctl operators can correlate stale snapshots with
+            // NTP-pre-sync boot.
+            WARNED_BAD_CLOCK.get_or_init(|| {
+                tracing::warn!(
+                    error = %e,
+                    "system clock is before UNIX_EPOCH — snapshot_at will be None until NTP sync; check `timedatectl` / `chronyc tracking`",
+                );
+            });
+            None
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

P2 batch from v1.30.1 audit — watch state machine + delta + clock safety. 6 prompts, 1 commit, 6 files changed.

| Finding | Fix |
|---------|-----|
| **bundle-watch-status-machine** (OB-V1.30.1-3) | `publish_watch_snapshot` clones the snap, captures `prev_state`, emits `tracing::info!("watch state transition", prev, next, modified_files, rebuild_in_flight, dropped_this_cycle)` on Fresh↔Stale↔Rebuilding flips. |
| **AC-V1.30.1-10** | Removed `state.incremental_count = 0` from idle-clear block in `watch/mod.rs`. Counter persists across 5-min idle so threshold-rebuild fires correctly on accumulated drift. |
| **API-V1.30.1-10** | Wire shape break: `idle_secs` removed, replaced with `last_event_unix_secs: i64` (computed via `now - last_event.elapsed()` workaround for `Instant`-vs-`SystemTime`). All consumers updated. |
| **OB-V1.30.1-9** | `process_file_changes` `println!` → `tracing::info!`. |
| **RB-10** | `now_unix_secs()` returns `Option<i64>` (was always-`0` on clock-before-epoch). `WatchSnapshot.snapshot_at: Option<i64>`. Once-per-process bad-clock warn. All 5 sites updated (watch_status, daemon_translate test fixtures, batch/handlers/misc). |
| **EH-V1.30.1-8** | Added `tracing::warn!` in `reindex_files` Err arm noting the HNSW dirty flag remains set. (Narrowed scope per cover prompt — no `consecutive_dirty_cycles` plumbing.) |

## Wire-shape break note

This commit deliberately breaks JSON wire shape on `WatchSnapshot`:
- `idle_secs: u64` → `last_event_unix_secs: i64`
- `snapshot_at: i64` → `snapshot_at: Option<i64>`

Per project memory ("no external users — can break JSON output schemas without migration concerns"), this is the cleaner choice over a deprecated-back-compat-keep-both. Operators reading the wire shape directly will need to update; `cqs status` output is rendered server-side.

## Test plan

- [x] `cargo build --features gpu-index` — clean, no warnings introduced
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `watch_status` — 11/11 pass
- [x] `daemon_translate` — 24/24 pass (snapshot fixtures still serialize correctly with Option<i64>)
- [x] `cli::watch` — 69 pass + 3 ignored (pre-existing CPU-embedder skips)
- [x] `cli::commands::infra::status` — 3/3 pass
- [x] `cli::batch::handlers::misc` — 6/6 pass (new `is_number()` assertion on healthy-clock `snapshot_at`)
- [x] `cargo fmt --check` — clean

## Notes for review

- `Instant::elapsed()` is monotonic from process start. The `now - last_event.elapsed()` reconstruction of wall-clock event time is correct as long as the wall clock isn't NTP-stepped between event capture and snapshot publish. Acceptable for daemon-side use.
- `OB-V1.30.1-9` scope was kept tight — only the `events.rs:147-152` block. Two adjacent `println!` sites (line ~230) left untouched per strict scope; flag for follow-up if broader scope was intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
