### PR TITLE
fix(daemon+status): wait_for_fresh papercut bundle — RB-9, EH-V1.30.1-2, OB-V1.30.1-8, AC-V1.30.1-9, API-V1.30.1-1, API-V1.30.1-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,6 +765,7 @@ Both splits are ±2-3pp noisy on a single trial; quote both when comparing confi
 | `CQS_EVAL_TIMEOUT_SECS` | `300` | Per-query timeout in seconds inside `evals/run_ablation.py` |
 | `CQS_FILE_BATCH_SIZE` | `5000` | Files per parse batch in pipeline |
 | `CQS_FORCE_BASE_INDEX` | (none) | Set to `1` to force search via the base (non-enriched) HNSW index |
+| `CQS_FRESHNESS_POLL_MS` | `100` | Initial poll interval (ms) for `wait_for_fresh` exponential backoff before the eval freshness gate fires. Clamped to `[25, 5000]`. Bump on slow filesystems (WSL `/mnt/c/`) where the daemon's first snapshot is rarely under 100 ms. |
 | `CQS_FTS_NORMALIZE_MAX` | `16384` | Max bytes of `normalize_for_fts` output per chunk. Truncation is emitted at warn level; bump if FTS recall on long chunks (large generated tables, monolithic functions) is degraded. |
 | `CQS_GATHER_MAX_NODES` | `200` | Max BFS nodes in `gather` context assembly |
 | `CQS_HNSW_EF_CONSTRUCTION` | `200` | HNSW construction-time search width |

--- a/src/cli/commands/eval/mod.rs
+++ b/src/cli/commands/eval/mod.rs
@@ -292,7 +292,45 @@ fn require_fresh_gate(no_require_fresh_flag: &bool, wait_secs: u64) -> Result<()
                      Eval --require-fresh requires a running `cqs watch --serve`. Either:\n  \
                        - start the daemon (`systemctl --user start cqs-watch` or `cqs watch --serve`)\n  \
                        - rerun with `--no-require-fresh` for an offline check\n  \
-                       - export `CQS_EVAL_REQUIRE_FRESH=0` to disable the gate for this shell"
+                       - export `CQS_EVAL_REQUIRE_FRESH=0` to disable the gate for this shell\n\n\
+                     NOTE: if you upgraded from <v1.30.1, the daemon socket name changed (BLAKE3); \
+                     run `systemctl --user restart cqs-watch` so the daemon binds the new path."
+                )
+            }
+            // EH-V1.30.1-2: Transport — socket exists but daemon isn't
+            // responding (hung, crashed mid-call, or set_*_timeout failed).
+            FreshnessWait::Transport(msg) => {
+                tracing::info!(
+                    outcome = "transport",
+                    elapsed_ms,
+                    "require_fresh_gate: resolved",
+                );
+                anyhow::bail!(
+                    "watch daemon transport error: {msg}\n\
+                     \n\
+                     The daemon socket exists but isn't responding. The daemon may be \
+                     hung or crashed mid-call. Try:\n  \
+                       - check the daemon log (`journalctl --user -u cqs-watch -n 50`)\n  \
+                       - restart the daemon (`systemctl --user restart cqs-watch`)\n  \
+                       - rerun with `--no-require-fresh` to skip the gate"
+                )
+            }
+            // EH-V1.30.1-2: BadResponse — daemon replied but the envelope
+            // was unparseable. Most often a CLI/daemon version skew.
+            FreshnessWait::BadResponse(msg) => {
+                tracing::info!(
+                    outcome = "bad_response",
+                    elapsed_ms,
+                    "require_fresh_gate: resolved",
+                );
+                anyhow::bail!(
+                    "watch daemon returned a malformed response: {msg}\n\
+                     \n\
+                     The daemon answered but the response was unparseable — likely a \
+                     CLI/daemon version skew. Restart the daemon after rebuilding so it \
+                     speaks the same protocol as this CLI:\n  \
+                       - `systemctl --user stop cqs-watch && cargo install --path . && systemctl --user start cqs-watch`\n  \
+                       - rerun with `--no-require-fresh` to skip the gate"
                 )
             }
         }

--- a/src/cli/commands/infra/hook.rs
+++ b/src/cli/commands/infra/hook.rs
@@ -331,7 +331,7 @@ fn do_fire(cqs_dir: &Path, name: &str, args: Vec<String>, try_daemon: bool) -> R
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, "daemon_reconcile failed — touching .cqs/.dirty");
-                    report.daemon_error = Some(e);
+                    report.daemon_error = Some(e.as_message());
                 }
             }
         } else {

--- a/src/cli/commands/infra/ping.rs
+++ b/src/cli/commands/infra/ping.rs
@@ -179,12 +179,13 @@ pub(crate) fn cmd_ping(json: bool) -> Result<()> {
                 }
                 Ok(())
             }
-            Err(msg) => {
+            Err(err) => {
                 // Spec: "no daemon running" → exit 1. PR #1038 envelope contract
                 // requires `{data:null, error:{code,message}, version:1}` on JSON
                 // failure paths so health-monitor scripts get a single uniform
                 // shape. IO_ERROR is the right code: socket connection failures
                 // and timeouts both fall under filesystem/socket I/O.
+                let msg = err.as_message();
                 if json {
                     crate::cli::json_envelope::emit_json_error(
                         crate::cli::json_envelope::error_codes::IO_ERROR,

--- a/src/cli/commands/infra/status.rs
+++ b/src/cli/commands/infra/status.rs
@@ -70,7 +70,7 @@ pub(crate) fn cmd_status(json: bool, watch_fresh: bool, wait: bool, wait_secs: u
                     emit_snapshot(&snap, json)?;
                     Ok(())
                 }
-                Err(msg) => emit_no_daemon(&msg, json),
+                Err(err) => emit_no_daemon(&err.as_message(), json),
             };
         }
 
@@ -83,13 +83,35 @@ pub(crate) fn cmd_status(json: bool, watch_fresh: bool, wait: bool, wait_secs: u
                 Ok(())
             }
             cqs::daemon_translate::FreshnessWait::Timeout(snap) => {
-                emit_snapshot(&snap, json)?;
+                if json {
+                    // API-V1.30.1-1: error envelope so JSON consumers see
+                    // `error.code="timeout"` alongside the non-zero exit
+                    // code. Embedding the snapshot in `data` keeps the
+                    // counter information for callers that surface them.
+                    let payload = serde_json::json!({
+                        "snapshot": snap,
+                        "wait_secs": budget_secs,
+                    });
+                    crate::cli::json_envelope::emit_json_error_with_data(
+                        crate::cli::json_envelope::error_codes::TIMEOUT,
+                        &format!("watch index still stale after {budget_secs}s"),
+                        Some(payload),
+                    )?;
+                } else {
+                    print_text(&snap);
+                    eprintln!("cqs: watch index still stale after {budget_secs}s wait");
+                }
                 // Budget expired before fresh — surface as exit 1
                 // so scripts can distinguish "fresh" from "timed
                 // out still stale".
                 std::process::exit(1);
             }
             cqs::daemon_translate::FreshnessWait::NoDaemon(msg) => emit_no_daemon(&msg, json),
+            // Transport / BadResponse fold into the same exit-1 path as
+            // NoDaemon — the operator-side detail (which class fired) is
+            // in the message verbatim.
+            cqs::daemon_translate::FreshnessWait::Transport(msg)
+            | cqs::daemon_translate::FreshnessWait::BadResponse(msg) => emit_no_daemon(&msg, json),
         }
     }
 

--- a/src/cli/json_envelope.rs
+++ b/src/cli/json_envelope.rs
@@ -90,6 +90,10 @@ pub enum ErrorCode {
     /// Catch-all for unexpected internal errors. Carries the anyhow chain
     /// in `message` so the root cause stays visible.
     Internal,
+    /// Operation exceeded its time budget. Used by `cqs status --wait`
+    /// timeout (API-V1.30.1-1) and any future time-bounded operation that
+    /// times out before producing a result.
+    Timeout,
 }
 
 impl ErrorCode {
@@ -102,6 +106,7 @@ impl ErrorCode {
             ErrorCode::ParseError => "parse_error",
             ErrorCode::IoError => "io_error",
             ErrorCode::Internal => "internal",
+            ErrorCode::Timeout => "timeout",
         }
     }
 }
@@ -136,6 +141,10 @@ pub mod error_codes {
     /// Catch-all for unexpected internal errors. Carries the anyhow chain
     /// in `message` so the root cause stays visible.
     pub const INTERNAL: &str = ErrorCode::Internal.as_str();
+    /// Operation exceeded its time budget. Used by `cqs status --wait`
+    /// timeout and any future time-bounded operation that times out
+    /// before producing a result. (API-V1.30.1-1)
+    pub const TIMEOUT: &str = ErrorCode::Timeout.as_str();
 }
 
 /// Standard envelope for all JSON-emitting commands.
@@ -357,6 +366,39 @@ pub fn emit_json_error(code: &str, message: &str) -> Result<()> {
     Ok(())
 }
 
+/// Like [`emit_json_error`] but carries an optional `data` payload alongside
+/// the error so consumers can still surface counters (snapshot, wait_secs,
+/// etc.) in the failure shape. Used by `cqs status --wait` timeout
+/// (API-V1.30.1-1) to embed the stale snapshot in the error envelope —
+/// JSON consumers see `error.code="timeout"` AND keep the
+/// `data.snapshot` for diagnostic display, all in one envelope.
+///
+/// Same retry-on-NaN guarantee as [`emit_json`].
+pub fn emit_json_error_with_data(
+    code: &str,
+    message: &str,
+    data: Option<serde_json::Value>,
+) -> Result<()> {
+    let mut env = serde_json::Map::with_capacity(4);
+    env.insert("data".to_string(), data.unwrap_or(serde_json::Value::Null));
+    env.insert(
+        "error".to_string(),
+        serde_json::json!({"code": code, "message": message}),
+    );
+    env.insert(
+        "version".to_string(),
+        serde_json::Value::Number(JSON_OUTPUT_VERSION.into()),
+    );
+    env.insert(
+        "_meta".to_string(),
+        serde_json::to_value(EnvelopeMeta::new())?,
+    );
+    let buf = serde_json::Value::Object(env);
+    let s = format_envelope_to_string(&buf)?;
+    println!("{s}");
+    Ok(())
+}
+
 /// Redact an error chain to a stable `(code, message)` pair safe to surface
 /// over the daemon socket or to JSON consumers. P2 #33.
 ///
@@ -508,12 +550,86 @@ mod tests {
         assert_eq!(ErrorCode::ParseError.as_str(), error_codes::PARSE_ERROR);
         assert_eq!(ErrorCode::IoError.as_str(), error_codes::IO_ERROR);
         assert_eq!(ErrorCode::Internal.as_str(), error_codes::INTERNAL);
+        // API-V1.30.1-1: new Timeout variant.
+        assert_eq!(ErrorCode::Timeout.as_str(), error_codes::TIMEOUT);
+        assert_eq!(error_codes::TIMEOUT, "timeout");
     }
 
     #[test]
     fn error_code_into_static_str() {
         let code: &'static str = ErrorCode::ParseError.into();
         assert_eq!(code, "parse_error");
+    }
+
+    // API-V1.30.1-1: `emit_json_error_with_data` produces an envelope
+    // matching `{data: <payload>, error: {code, message}, version, _meta}`
+    // — same outer shape as `emit_json_error` but with a payload in the
+    // `data` slot (success-style) AND an error in the `error` slot.
+    // This dual-fill is intentional: timeout-class failures want to
+    // carry diagnostic counters (snapshot, wait_secs) in `data` while
+    // signalling failure via `error.code = "timeout"`.
+    //
+    // We exercise the helper indirectly by mirroring its construction
+    // logic (since println!-emitting functions are hard to assert
+    // against in a test harness without redirecting stdout).
+    #[test]
+    fn emit_json_error_with_data_envelope_shape() {
+        let payload = serde_json::json!({
+            "snapshot": {"state": "stale", "modified_files": 3},
+            "wait_secs": 5,
+        });
+        // Reconstruct what emit_json_error_with_data builds.
+        let mut env = serde_json::Map::with_capacity(4);
+        env.insert("data".to_string(), payload.clone());
+        env.insert(
+            "error".to_string(),
+            serde_json::json!({"code": error_codes::TIMEOUT, "message": "timed out"}),
+        );
+        env.insert(
+            "version".to_string(),
+            serde_json::Value::Number(JSON_OUTPUT_VERSION.into()),
+        );
+        env.insert(
+            "_meta".to_string(),
+            serde_json::to_value(EnvelopeMeta::new()).unwrap(),
+        );
+        let v = serde_json::Value::Object(env);
+        // Diagnostic data carried alongside the error.
+        assert_eq!(v["data"]["wait_secs"], 5);
+        assert_eq!(v["data"]["snapshot"]["state"], "stale");
+        assert_eq!(v["data"]["snapshot"]["modified_files"], 3);
+        // Error envelope semantics: code == "timeout".
+        assert_eq!(v["error"]["code"], "timeout");
+        assert_eq!(v["error"]["message"], "timed out");
+        assert_eq!(v["version"], JSON_OUTPUT_VERSION);
+        assert_eq!(v["_meta"]["handling_advice"], HANDLING_ADVICE);
+    }
+
+    // API-V1.30.1-1: `emit_json_error_with_data` accepts `None` data and
+    // emits `data: null` — i.e. degrades to the same shape as
+    // `emit_json_error` for callers that don't need a payload.
+    #[test]
+    fn emit_json_error_with_data_none_data_is_null() {
+        let mut env = serde_json::Map::with_capacity(4);
+        env.insert(
+            "data".to_string(),
+            (None as Option<serde_json::Value>).unwrap_or(serde_json::Value::Null),
+        );
+        env.insert(
+            "error".to_string(),
+            serde_json::json!({"code": error_codes::TIMEOUT, "message": "x"}),
+        );
+        env.insert(
+            "version".to_string(),
+            serde_json::Value::Number(JSON_OUTPUT_VERSION.into()),
+        );
+        env.insert(
+            "_meta".to_string(),
+            serde_json::to_value(EnvelopeMeta::new()).unwrap(),
+        );
+        let v = serde_json::Value::Object(env);
+        assert!(v["data"].is_null());
+        assert_eq!(v["error"]["code"], "timeout");
     }
 
     // P2 #40: wrap_value / wrap_error are now thin wrappers over the typed

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -170,10 +170,18 @@ pub fn stripped_model_value(raw: &[String]) -> Option<String> {
 /// bind a mock listener there. The hash is collision-avoidance only (per-
 /// project naming) — not a security property; access control relies on the
 /// filesystem permissions the real daemon sets (0o600).
+///
+/// AC-V1.30.1-9: hashes via [`blake3`] rather than `std::collections::hash_map::DefaultHasher`.
+/// `DefaultHasher` is Rust-version-dependent SipHash; a `cargo update` of
+/// std could change socket names and break systemd `cqs-watch` units that
+/// hardcode a specific path. BLAKE3 is stable across Rust versions and
+/// truncating the digest to 8 bytes keeps the socket name short while
+/// staying collision-safe (~1e-15 for 100 projects). Wire-format change:
+/// operators upgrading from <v1.30.1 must `systemctl --user restart cqs-watch`
+/// once so the daemon binds the new socket name; CLI auto-discovers via
+/// `XDG_RUNTIME_DIR` thereafter.
 #[cfg(unix)]
 pub fn daemon_socket_path(cqs_dir: &std::path::Path) -> std::path::PathBuf {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
     use std::path::PathBuf;
 
     let sock_dir = match std::env::var_os("XDG_RUNTIME_DIR") {
@@ -196,12 +204,67 @@ pub fn daemon_socket_path(cqs_dir: &std::path::Path) -> std::path::PathBuf {
             std::env::temp_dir()
         }
     };
-    let sock_name = format!("cqs-{:x}.sock", {
-        let mut h = DefaultHasher::new();
-        cqs_dir.hash(&mut h);
-        h.finish()
-    });
+    // AC-V1.30.1-9: BLAKE3 is stable across Rust versions — important
+    // because systemd unit files and operator scripts encode the socket
+    // path. Truncate to 8 hex bytes (16 chars) — collision probability
+    // for 100 projects is ~1e-15.
+    let canonical_path_bytes = cqs_dir.as_os_str().as_encoded_bytes();
+    let hash = blake3::hash(canonical_path_bytes);
+    let truncated = &hash.as_bytes()[..8];
+    let mut hex = String::with_capacity(16);
+    for b in truncated {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{:02x}", b);
+    }
+    let sock_name = format!("cqs-{}.sock", hex);
     sock_dir.join(sock_name)
+}
+
+/// Typed error returned by [`daemon_ping`], [`daemon_status`], and
+/// [`daemon_reconcile`].
+///
+/// API-V1.30.1-5: replaces the previous `Result<T, String>` shape so
+/// callers can distinguish "daemon never ran" (socket file missing) from
+/// "daemon crashed mid-call" (transport failure) from "daemon answered
+/// with garbage" (envelope/JSON parse failure) from "daemon answered
+/// with `status: \"err\"`" (handler-level error). The `wait_for_fresh`
+/// hot path branches on the variant to produce different bail messages
+/// per failure mode rather than collapsing every failure into "no
+/// daemon — start one" advice.
+#[cfg(unix)]
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum DaemonRpcError {
+    /// The daemon socket file does not exist — the daemon never started
+    /// (or was stopped). Operator action: start `cqs watch --serve`.
+    #[error("daemon socket missing: {0}")]
+    SocketMissing(String),
+    /// Connect / read / write / timeout / set_*_timeout failure. The
+    /// socket file exists but the daemon isn't responding. Operator
+    /// action: check `journalctl --user -u cqs-watch` and consider
+    /// restarting the unit.
+    #[error("daemon transport failure: {0}")]
+    Transport(String),
+    /// Envelope JSON parse, missing/non-string `status` field, or the
+    /// dispatch payload deserialize failed. The daemon answered but the
+    /// response is unparseable — most often a CLI/daemon version skew.
+    /// Operator action: rebuild and restart `cqs-watch`.
+    #[error("daemon returned malformed response: {0}")]
+    BadResponse(String),
+    /// The daemon returned `{"status": "err", "message": "..."}` — a
+    /// handler-level error. The `message` is the daemon's own description.
+    #[error("daemon error: {0}")]
+    DaemonError(String),
+}
+
+#[cfg(unix)]
+impl DaemonRpcError {
+    /// Render the daemon error as a stable wire-format string for
+    /// callers that still want to surface it as plain text (eg. the
+    /// `cqs hook fire` fallback that touches `.cqs/.dirty`). Equivalent
+    /// to the previous `Err(String)` payload.
+    pub fn as_message(&self) -> String {
+        self.to_string()
+    }
 }
 
 /// Daemon healthcheck response — the payload returned by `cqs ping`.
@@ -255,10 +318,9 @@ pub struct PingResponse {
 
 /// Connect to the running daemon and request a `PingResponse`.
 ///
-/// Task B2 helper: returns `Ok(PingResponse)` on success, `Err` if the
-/// socket is missing, the connection fails, the daemon returns a non-`ok`
-/// status, or the response payload doesn't deserialize. Errors are explicit
-/// strings the caller can present verbatim.
+/// Task B2 helper: returns `Ok(PingResponse)` on success or a typed
+/// [`DaemonRpcError`] on failure (socket missing, transport/connection
+/// failure, malformed response, or daemon-side error).
 ///
 /// Reusable from Task B1 (`cqs doctor --verbose`) and from any future tool
 /// that wants to ask the daemon "are you alive and serving the right
@@ -268,7 +330,7 @@ pub struct PingResponse {
 /// Note: this function is unix-only because the daemon socket is unix-only.
 /// On non-unix platforms the daemon never starts in the first place.
 #[cfg(unix)]
-pub fn daemon_ping(cqs_dir: &std::path::Path) -> Result<PingResponse, String> {
+pub fn daemon_ping(cqs_dir: &std::path::Path) -> Result<PingResponse, DaemonRpcError> {
     use std::io::{BufRead, Write};
     use std::os::unix::net::UnixStream;
     use std::time::Duration;
@@ -278,37 +340,45 @@ pub fn daemon_ping(cqs_dir: &std::path::Path) -> Result<PingResponse, String> {
     // multi-project agent loop can disambiguate which daemon failed.
     let _span = tracing::info_span!("daemon_ping", path = %sock_path.display()).entered();
     if !sock_path.exists() {
-        return Err(format!(
+        return Err(DaemonRpcError::SocketMissing(format!(
             "no daemon running (socket {} does not exist)",
             sock_path.display()
-        ));
+        )));
     }
 
     let mut stream = UnixStream::connect(&sock_path).map_err(|e| {
-        tracing::warn!(stage = "connect", error = %e, "daemon_ping failed");
-        format!("connect to {} failed: {e}", sock_path.display())
+        // OB-V1.30.1-8: demoted from warn to debug — `wait_for_fresh`
+        // polls this path during startup and a 250ms info-level cadence
+        // floods journalctl. Final-decision warns live in `wait_for_fresh`
+        // / the eval gate, not here.
+        tracing::debug!(stage = "connect", error = %e, "daemon_ping connect failed");
+        DaemonRpcError::Transport(format!("connect to {} failed: {e}", sock_path.display()))
     })?;
 
     // 5s is generous: the ping handler does no I/O — just snapshot reads
     // off atomic counters and a single `metadata()` on `index.db`.
     let timeout = Duration::from_secs(5);
     if let Err(e) = stream.set_read_timeout(Some(timeout)) {
-        tracing::warn!(stage = "set_read_timeout", error = %e, "daemon_ping failed");
-        return Err(format!("set_read_timeout failed: {e}"));
+        tracing::debug!(stage = "set_read_timeout", error = %e, "daemon_ping failed");
+        return Err(DaemonRpcError::Transport(format!(
+            "set_read_timeout failed: {e}"
+        )));
     }
     if let Err(e) = stream.set_write_timeout(Some(timeout)) {
-        tracing::warn!(stage = "set_write_timeout", error = %e, "daemon_ping failed");
-        return Err(format!("set_write_timeout failed: {e}"));
+        tracing::debug!(stage = "set_write_timeout", error = %e, "daemon_ping failed");
+        return Err(DaemonRpcError::Transport(format!(
+            "set_write_timeout failed: {e}"
+        )));
     }
 
     let request = serde_json::json!({"command": "ping", "args": []});
     writeln!(stream, "{}", request).map_err(|e| {
-        tracing::warn!(stage = "write", error = %e, "daemon_ping failed");
-        format!("write request failed: {e}")
+        tracing::debug!(stage = "write", error = %e, "daemon_ping failed");
+        DaemonRpcError::Transport(format!("write request failed: {e}"))
     })?;
     stream.flush().map_err(|e| {
-        tracing::warn!(stage = "flush", error = %e, "daemon_ping failed");
-        format!("flush failed: {e}")
+        tracing::debug!(stage = "flush", error = %e, "daemon_ping failed");
+        DaemonRpcError::Transport(format!("flush failed: {e}"))
     })?;
 
     // PingResponse is small (<1KB). Cap the read at 64KB to bound memory
@@ -318,13 +388,13 @@ pub fn daemon_ping(cqs_dir: &std::path::Path) -> Result<PingResponse, String> {
     let mut reader = std::io::BufReader::new(&stream).take(64 * 1024);
     let mut response_line = String::new();
     reader.read_line(&mut response_line).map_err(|e| {
-        tracing::warn!(stage = "read", error = %e, "daemon_ping failed");
-        format!("read response failed: {e}")
+        tracing::debug!(stage = "read", error = %e, "daemon_ping failed");
+        DaemonRpcError::Transport(format!("read response failed: {e}"))
     })?;
 
     let envelope: serde_json::Value = serde_json::from_str(response_line.trim()).map_err(|e| {
         tracing::warn!(stage = "parse", error = %e, "daemon_ping failed");
-        format!("parse envelope failed: {e}")
+        DaemonRpcError::BadResponse(format!("parse envelope failed: {e}"))
     })?;
 
     let status = envelope
@@ -332,7 +402,7 @@ pub fn daemon_ping(cqs_dir: &std::path::Path) -> Result<PingResponse, String> {
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
             tracing::warn!(stage = "parse", "daemon_ping failed: missing status field");
-            "missing 'status' field in daemon response".to_string()
+            DaemonRpcError::BadResponse("missing 'status' field in daemon response".to_string())
         })?;
     if status != "ok" {
         let msg = envelope
@@ -345,15 +415,17 @@ pub fn daemon_ping(cqs_dir: &std::path::Path) -> Result<PingResponse, String> {
             msg,
             "daemon_ping failed: non-ok status"
         );
-        return Err(format!("daemon error: {msg}"));
+        return Err(DaemonRpcError::DaemonError(msg.to_string()));
     }
 
     let output = envelope.get("output").ok_or_else(|| {
         tracing::warn!(stage = "parse", "daemon_ping failed: missing output field");
-        "missing 'output' field in daemon response".to_string()
+        DaemonRpcError::BadResponse("missing 'output' field in daemon response".to_string())
     })?;
-    let payload = unwrap_dispatch_payload(output, "PingResponse")?;
-    serde_json::from_value(payload).map_err(|e| format!("PingResponse deserialize failed: {e}"))
+    let payload =
+        unwrap_dispatch_payload(output, "PingResponse").map_err(DaemonRpcError::BadResponse)?;
+    serde_json::from_value(payload)
+        .map_err(|e| DaemonRpcError::BadResponse(format!("PingResponse deserialize failed: {e}")))
 }
 
 /// Pull the inner handler payload out of a daemon dispatch response.
@@ -411,9 +483,12 @@ fn unwrap_dispatch_payload(
 /// watch loop publishes from — the CLI-only path returns a default
 /// `unknown` snapshot, which would defeat the purpose.
 ///
-/// Returns explicit `Err(String)` on every failure (no socket, connect
-/// fail, non-`ok` status, malformed payload). Callers can fall back or
-/// surface verbatim.
+/// Returns a typed [`DaemonRpcError`] on failure. Callers can fall back
+/// or surface verbatim. The connect-stage `tracing::warn!` of the prior
+/// implementation was demoted to `tracing::debug!` because [`wait_for_fresh`]
+/// polls this in a tight loop during startup and the warn-cadence floods
+/// the journal at info level (OB-V1.30.1-8). Final-decision warns live
+/// in [`wait_for_fresh`] / the eval gate.
 ///
 /// Unix-only: the daemon socket is unix-only.
 ///
@@ -421,7 +496,7 @@ fn unwrap_dispatch_payload(
 #[cfg(unix)]
 pub fn daemon_status(
     cqs_dir: &std::path::Path,
-) -> Result<crate::watch_status::WatchSnapshot, String> {
+) -> Result<crate::watch_status::WatchSnapshot, DaemonRpcError> {
     use std::io::{BufRead, Write};
     use std::os::unix::net::UnixStream;
     use std::time::Duration;
@@ -429,49 +504,54 @@ pub fn daemon_status(
     let sock_path = daemon_socket_path(cqs_dir);
     let _span = tracing::info_span!("daemon_status", path = %sock_path.display()).entered();
     if !sock_path.exists() {
-        return Err(format!(
+        return Err(DaemonRpcError::SocketMissing(format!(
             "no daemon running (socket {} does not exist)",
             sock_path.display()
-        ));
+        )));
     }
 
     let mut stream = UnixStream::connect(&sock_path).map_err(|e| {
-        tracing::warn!(stage = "connect", error = %e, "daemon_status failed");
-        format!("connect to {} failed: {e}", sock_path.display())
+        // OB-V1.30.1-8: demoted from warn to debug. See type-level docs.
+        tracing::debug!(stage = "connect", error = %e, "daemon_status connect failed");
+        DaemonRpcError::Transport(format!("connect to {} failed: {e}", sock_path.display()))
     })?;
 
     // 5s is generous: the status handler does a single RwLock read + clone.
     let timeout = Duration::from_secs(5);
     if let Err(e) = stream.set_read_timeout(Some(timeout)) {
-        tracing::warn!(stage = "set_read_timeout", error = %e, "daemon_status failed");
-        return Err(format!("set_read_timeout failed: {e}"));
+        tracing::debug!(stage = "set_read_timeout", error = %e, "daemon_status failed");
+        return Err(DaemonRpcError::Transport(format!(
+            "set_read_timeout failed: {e}"
+        )));
     }
     if let Err(e) = stream.set_write_timeout(Some(timeout)) {
-        tracing::warn!(stage = "set_write_timeout", error = %e, "daemon_status failed");
-        return Err(format!("set_write_timeout failed: {e}"));
+        tracing::debug!(stage = "set_write_timeout", error = %e, "daemon_status failed");
+        return Err(DaemonRpcError::Transport(format!(
+            "set_write_timeout failed: {e}"
+        )));
     }
 
     let request = serde_json::json!({"command": "status", "args": []});
     writeln!(stream, "{}", request).map_err(|e| {
-        tracing::warn!(stage = "write", error = %e, "daemon_status failed");
-        format!("write request failed: {e}")
+        tracing::debug!(stage = "write", error = %e, "daemon_status failed");
+        DaemonRpcError::Transport(format!("write request failed: {e}"))
     })?;
     stream.flush().map_err(|e| {
-        tracing::warn!(stage = "flush", error = %e, "daemon_status failed");
-        format!("flush failed: {e}")
+        tracing::debug!(stage = "flush", error = %e, "daemon_status failed");
+        DaemonRpcError::Transport(format!("flush failed: {e}"))
     })?;
 
     use std::io::Read as _;
     let mut reader = std::io::BufReader::new(&stream).take(64 * 1024);
     let mut response_line = String::new();
     reader.read_line(&mut response_line).map_err(|e| {
-        tracing::warn!(stage = "read", error = %e, "daemon_status failed");
-        format!("read response failed: {e}")
+        tracing::debug!(stage = "read", error = %e, "daemon_status failed");
+        DaemonRpcError::Transport(format!("read response failed: {e}"))
     })?;
 
     let envelope: serde_json::Value = serde_json::from_str(response_line.trim()).map_err(|e| {
         tracing::warn!(stage = "parse", error = %e, "daemon_status failed");
-        format!("parse envelope failed: {e}")
+        DaemonRpcError::BadResponse(format!("parse envelope failed: {e}"))
     })?;
 
     let status = envelope
@@ -482,7 +562,7 @@ pub fn daemon_status(
                 stage = "parse",
                 "daemon_status failed: missing status field"
             );
-            "missing 'status' field in daemon response".to_string()
+            DaemonRpcError::BadResponse("missing 'status' field in daemon response".to_string())
         })?;
     if status != "ok" {
         let msg = envelope
@@ -495,7 +575,7 @@ pub fn daemon_status(
             msg,
             "daemon_status failed: non-ok status"
         );
-        return Err(format!("daemon error: {msg}"));
+        return Err(DaemonRpcError::DaemonError(msg.to_string()));
     }
 
     let output = envelope.get("output").ok_or_else(|| {
@@ -503,10 +583,12 @@ pub fn daemon_status(
             stage = "parse",
             "daemon_status failed: missing output field"
         );
-        "missing 'output' field in daemon response".to_string()
+        DaemonRpcError::BadResponse("missing 'output' field in daemon response".to_string())
     })?;
-    let payload = unwrap_dispatch_payload(output, "WatchSnapshot")?;
-    serde_json::from_value(payload).map_err(|e| format!("WatchSnapshot deserialize failed: {e}"))
+    let payload =
+        unwrap_dispatch_payload(output, "WatchSnapshot").map_err(DaemonRpcError::BadResponse)?;
+    serde_json::from_value(payload)
+        .map_err(|e| DaemonRpcError::BadResponse(format!("WatchSnapshot deserialize failed: {e}")))
 }
 
 /// #1182 — Layer 1: response shape for [`daemon_reconcile`]. Mirrors the
@@ -529,16 +611,16 @@ pub struct DaemonReconcileResponse {
 /// #1182 — Layer 1: post a `reconcile` socket message to the running
 /// daemon. Used by the `cqs hook fire` CLI surface.
 ///
-/// Returns the parsed [`DaemonReconcileResponse`] on success, or a
-/// descriptive error on socket / deserialize failure. The CLI surface
-/// downgrades a missing-socket error to the `.cqs/.dirty` fallback;
-/// every other error is surfaced verbatim so hooks fail loudly.
+/// Returns the parsed [`DaemonReconcileResponse`] on success, or a typed
+/// [`DaemonRpcError`] on failure. The CLI surface downgrades the
+/// `SocketMissing` variant to the `.cqs/.dirty` fallback; every other
+/// variant is surfaced verbatim so hooks fail loudly.
 #[cfg(unix)]
 pub fn daemon_reconcile(
     cqs_dir: &std::path::Path,
     hook: Option<&str>,
     args: &[String],
-) -> Result<DaemonReconcileResponse, String> {
+) -> Result<DaemonReconcileResponse, DaemonRpcError> {
     use std::io::{BufRead, Write};
     use std::os::unix::net::UnixStream;
     use std::time::Duration;
@@ -551,23 +633,27 @@ pub fn daemon_reconcile(
     )
     .entered();
     if !sock_path.exists() {
-        return Err(format!(
+        return Err(DaemonRpcError::SocketMissing(format!(
             "no daemon running (socket {} does not exist)",
             sock_path.display()
-        ));
+        )));
     }
 
     let mut stream = UnixStream::connect(&sock_path).map_err(|e| {
-        tracing::warn!(stage = "connect", error = %e, "daemon_reconcile failed");
-        format!("connect to {} failed: {e}", sock_path.display())
+        tracing::debug!(stage = "connect", error = %e, "daemon_reconcile connect failed");
+        DaemonRpcError::Transport(format!("connect to {} failed: {e}", sock_path.display()))
     })?;
 
     let timeout = Duration::from_secs(5);
     if let Err(e) = stream.set_read_timeout(Some(timeout)) {
-        return Err(format!("set_read_timeout failed: {e}"));
+        return Err(DaemonRpcError::Transport(format!(
+            "set_read_timeout failed: {e}"
+        )));
     }
     if let Err(e) = stream.set_write_timeout(Some(timeout)) {
-        return Err(format!("set_write_timeout failed: {e}"));
+        return Err(DaemonRpcError::Transport(format!(
+            "set_write_timeout failed: {e}"
+        )));
     }
 
     // Build the batch-arg vector: ["--hook", "<name>", "--arg", "v1",
@@ -585,95 +671,169 @@ pub fn daemon_reconcile(
 
     let request = serde_json::json!({"command": "reconcile", "args": batch_args});
     writeln!(stream, "{}", request).map_err(|e| {
-        tracing::warn!(stage = "write", error = %e, "daemon_reconcile failed");
-        format!("write request failed: {e}")
+        tracing::debug!(stage = "write", error = %e, "daemon_reconcile failed");
+        DaemonRpcError::Transport(format!("write request failed: {e}"))
     })?;
-    stream.flush().map_err(|e| format!("flush failed: {e}"))?;
+    stream
+        .flush()
+        .map_err(|e| DaemonRpcError::Transport(format!("flush failed: {e}")))?;
 
     use std::io::Read as _;
     let mut reader = std::io::BufReader::new(&stream).take(64 * 1024);
     let mut response_line = String::new();
     reader
         .read_line(&mut response_line)
-        .map_err(|e| format!("read response failed: {e}"))?;
+        .map_err(|e| DaemonRpcError::Transport(format!("read response failed: {e}")))?;
 
     let envelope: serde_json::Value = serde_json::from_str(response_line.trim())
-        .map_err(|e| format!("parse envelope failed: {e}"))?;
+        .map_err(|e| DaemonRpcError::BadResponse(format!("parse envelope failed: {e}")))?;
 
     let status = envelope
         .get("status")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| "missing 'status' field in daemon response".to_string())?;
+        .ok_or_else(|| {
+            DaemonRpcError::BadResponse("missing 'status' field in daemon response".to_string())
+        })?;
     if status != "ok" {
         let msg = envelope
             .get("message")
             .and_then(|v| v.as_str())
             .unwrap_or("daemon error");
-        return Err(format!("daemon error: {msg}"));
+        return Err(DaemonRpcError::DaemonError(msg.to_string()));
     }
 
-    let output = envelope
-        .get("output")
-        .ok_or_else(|| "missing 'output' field in daemon response".to_string())?;
-    let payload = unwrap_dispatch_payload(output, "DaemonReconcileResponse")?;
-    serde_json::from_value(payload)
-        .map_err(|e| format!("DaemonReconcileResponse deserialize failed: {e}"))
+    let output = envelope.get("output").ok_or_else(|| {
+        DaemonRpcError::BadResponse("missing 'output' field in daemon response".to_string())
+    })?;
+    let payload = unwrap_dispatch_payload(output, "DaemonReconcileResponse")
+        .map_err(DaemonRpcError::BadResponse)?;
+    serde_json::from_value(payload).map_err(|e| {
+        DaemonRpcError::BadResponse(format!("DaemonReconcileResponse deserialize failed: {e}"))
+    })
 }
 
 /// #1182 — Layer 4: outcome of [`wait_for_fresh`].
 ///
-/// Three cases callers need to distinguish:
+/// Five cases callers need to distinguish so the caller-side advice
+/// matches the actual failure mode (EH-V1.30.1-2):
 /// - `Fresh` — daemon reported `state == fresh` within the budget; safe to
 ///   proceed with the gated work.
 /// - `Timeout` — daemon was reachable but never became fresh in time. The
 ///   final snapshot is attached so callers can surface counters
 ///   (`modified_files`, `pending_notes`) in their error message.
-/// - `NoDaemon` — socket missing or transport error. The eval gate treats
-///   this as a hard fail by default; ceremony commands invoking this helper
-///   should advise the user to either start `cqs watch --serve` or pass
-///   `--no-require-fresh`.
+/// - `NoDaemon` — socket file does not exist. Operator action: start
+///   `cqs watch --serve`.
+/// - `Transport` — socket exists but the daemon isn't responding (connect /
+///   read / write / timeout). Operator action: check the daemon log,
+///   consider restarting the unit.
+/// - `BadResponse` — daemon answered but the response was unparseable.
+///   Most often a CLI/daemon version skew — restart `cqs-watch`.
 #[cfg(unix)]
 #[derive(Debug, Clone)]
 pub enum FreshnessWait {
     Fresh(crate::watch_status::WatchSnapshot),
     Timeout(crate::watch_status::WatchSnapshot),
+    /// Socket file missing — the daemon never started.
     NoDaemon(String),
+    /// Connect/read/write/timeout — daemon is gone or hung.
+    Transport(String),
+    /// Envelope/JSON/parse error — daemon answered but garbled.
+    BadResponse(String),
 }
 
 /// #1182 — Layer 4: shared client-side polling for `state == fresh`.
 ///
 /// Both `cqs status --watch-fresh --wait` and `cqs eval --require-fresh`
-/// route through this. Polls the daemon every 250 ms with a deadline of
-/// `wait_secs` (capped at 600 by the caller's clap default — caller is
-/// authoritative; we honour whatever they pass).
+/// route through this. Polls the daemon with exponential backoff (initial
+/// interval from [`crate::limits::freshness_poll_ms_initial`] doubling up
+/// to a 2 s ceiling) within a deadline of `wait_secs`. RB-2 caps the
+/// budget at 86,400 s (24 h) defensively so a misconfigured caller can't
+/// pass a value that overflows `Instant + Duration::from_secs`.
 ///
 /// The first successful poll that reports `fresh` returns immediately —
-/// callers don't pay 250 ms latency on an already-fresh tree.
+/// callers don't pay any latency on an already-fresh tree.
 ///
-/// Transport errors collapse into [`FreshnessWait::NoDaemon`]. We do not
-/// retry across socket-missing errors because (a) the watch daemon's socket
-/// is created at startup and persists; if it's gone, restarting it is the
-/// fix, not waiting; and (b) silently waiting through an outage masks the
-/// "you forgot to run `cqs watch --serve`" case the eval gate exists to
-/// catch.
+/// EH-V1.30.1-2: errors are surfaced per [`DaemonRpcError`] variant rather
+/// than collapsed into a single `NoDaemon` so the caller-side advice can
+/// distinguish "no daemon at all" (start one), "daemon hung" (restart),
+/// and "daemon answered with garbage" (version skew → restart).
+///
+/// OB-V1.30.1-8: the connect-stage `tracing::warn!` was demoted to debug
+/// at the [`daemon_status`] layer, so a 250 ms poll loop no longer floods
+/// journalctl during startup. Final-decision warns are emitted here, one
+/// per terminal outcome.
 #[cfg(unix)]
 pub fn wait_for_fresh(cqs_dir: &std::path::Path, wait_secs: u64) -> FreshnessWait {
     let _span = tracing::info_span!("wait_for_fresh", wait_secs).entered();
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_secs);
-    let poll_interval = std::time::Duration::from_millis(250);
+    let start = std::time::Instant::now();
+    // RB-2: defensive cap so a `pub fn` can't panic on
+    // `Instant + Duration::from_secs(u64::MAX)`. Caller should pass a
+    // sane budget but we bound it here regardless.
+    let bounded_secs = wait_secs.min(86_400);
+    let deadline = start + std::time::Duration::from_secs(bounded_secs);
+
+    let mut poll_interval =
+        std::time::Duration::from_millis(crate::limits::freshness_poll_ms_initial());
+    let max_interval = std::time::Duration::from_secs(2);
 
     loop {
+        // RB-9: deadline-first so a slow daemon timeout can't push us
+        // past the user's budget. If the deadline already passed before
+        // we got our first response, return Timeout with the unknown
+        // snapshot — the caller's bail message will explain.
+        if std::time::Instant::now() >= deadline {
+            tracing::info!(
+                elapsed_ms = start.elapsed().as_millis() as u64,
+                "wait_for_fresh: deadline reached before first fresh poll",
+            );
+            return FreshnessWait::Timeout(crate::watch_status::WatchSnapshot::unknown());
+        }
+
         match daemon_status(cqs_dir) {
             Ok(snap) => {
                 if snap.is_fresh() {
+                    tracing::info!(
+                        elapsed_ms = start.elapsed().as_millis() as u64,
+                        modified_files = snap.modified_files,
+                        "wait_for_fresh: index reached Fresh",
+                    );
                     return FreshnessWait::Fresh(snap);
                 }
                 if std::time::Instant::now() >= deadline {
+                    tracing::info!(
+                        elapsed_ms = start.elapsed().as_millis() as u64,
+                        modified_files = snap.modified_files,
+                        rebuild_in_flight = snap.rebuild_in_flight,
+                        "wait_for_fresh: timeout — index still stale",
+                    );
                     return FreshnessWait::Timeout(snap);
                 }
                 std::thread::sleep(poll_interval);
+                // Exponential backoff with a 2 s ceiling. Linearly
+                // doubling beats fixed cadence on long waits because the
+                // socket budget cost is per round-trip, not per second.
+                poll_interval = (poll_interval * 2).min(max_interval);
             }
-            Err(msg) => return FreshnessWait::NoDaemon(msg),
+            Err(DaemonRpcError::SocketMissing(msg)) => {
+                tracing::info!(error = %msg, "wait_for_fresh: daemon socket missing");
+                return FreshnessWait::NoDaemon(msg);
+            }
+            Err(DaemonRpcError::Transport(msg)) => {
+                tracing::info!(error = %msg, "wait_for_fresh: transport failure");
+                return FreshnessWait::Transport(msg);
+            }
+            Err(DaemonRpcError::BadResponse(msg)) => {
+                tracing::warn!(error = %msg, "wait_for_fresh: malformed daemon response");
+                return FreshnessWait::BadResponse(msg);
+            }
+            Err(DaemonRpcError::DaemonError(msg)) => {
+                // The daemon answered with `status: "err"`. From the
+                // freshness-poll perspective this is the daemon refusing
+                // to provide a snapshot — surface as transport-class so
+                // the caller's message points at the daemon log.
+                tracing::warn!(error = %msg, "wait_for_fresh: daemon-side error");
+                return FreshnessWait::Transport(msg);
+            }
         }
     }
 }
@@ -839,9 +999,15 @@ mod tests {
         let result = daemon_ping(&cqs_dir);
         assert!(result.is_err());
         let err = result.unwrap_err();
+        // API-V1.30.1-5: typed variant — SocketMissing is the no-daemon path.
         assert!(
-            err.contains("no daemon running"),
-            "expected friendly error, got: {err}"
+            matches!(err, DaemonRpcError::SocketMissing(_)),
+            "expected SocketMissing variant, got: {err:?}"
+        );
+        let msg = err.as_message();
+        assert!(
+            msg.contains("no daemon running"),
+            "expected friendly error, got: {msg}"
         );
     }
 
@@ -1086,9 +1252,15 @@ mod tests {
         let result = daemon_status(&cqs_dir);
         assert!(result.is_err());
         let err = result.unwrap_err();
+        // API-V1.30.1-5: typed variant.
         assert!(
-            err.contains("no daemon running"),
-            "expected friendly error, got: {err}"
+            matches!(err, DaemonRpcError::SocketMissing(_)),
+            "expected SocketMissing variant, got: {err:?}"
+        );
+        let msg = err.as_message();
+        assert!(
+            msg.contains("no daemon running"),
+            "expected friendly error, got: {msg}"
         );
     }
 
@@ -1195,9 +1367,15 @@ mod tests {
         let result = daemon_reconcile(&cqs_dir, Some("post-merge"), &args);
         assert!(result.is_err());
         let err = result.unwrap_err();
+        // API-V1.30.1-5: typed variant.
         assert!(
-            err.contains("no daemon running"),
-            "expected friendly error, got: {err}"
+            matches!(err, DaemonRpcError::SocketMissing(_)),
+            "expected SocketMissing variant, got: {err:?}"
+        );
+        let msg = err.as_message();
+        assert!(
+            msg.contains("no daemon running"),
+            "expected friendly error, got: {msg}"
         );
     }
 
@@ -1276,17 +1454,16 @@ mod tests {
         }
     }
 
-    /// PR 4 of #1182: `wait_for_fresh` reports `Timeout` when the deadline
-    /// expires while the daemon still reports stale. With `wait_secs = 0`
-    /// the helper polls once and immediately checks the deadline — no
-    /// 250 ms sleep, fast test.
+    /// PR 4 of #1182 (post-RB-9 refactor): `wait_for_fresh` reports
+    /// `Timeout` when the deadline expires before any successful poll.
+    /// With `wait_secs = 0` the deadline-first guard fires immediately,
+    /// returning `Timeout(unknown)` without a wasted round-trip. The
+    /// `unknown` snapshot signals "we never got a real status" so the
+    /// caller's bail message can adapt.
     #[cfg(unix)]
     #[test]
     #[serial_test::serial(daemon_socket_xdg)]
     fn wait_for_fresh_returns_timeout_when_budget_expires() {
-        use std::io::{BufRead, BufReader, Write};
-        use std::os::unix::net::UnixListener;
-
         let dir = tempfile::tempdir().unwrap();
         let cqs_dir = dir.path().join(".cqs");
         std::fs::create_dir_all(&cqs_dir).unwrap();
@@ -1297,42 +1474,13 @@ mod tests {
             std::env::set_var("XDG_RUNTIME_DIR", dir.path());
         }
 
+        // A bound socket so the helper sees a daemon socket file. We never
+        // actually accept — the deadline-first guard returns before the
+        // first daemon_status call.
         let sock_path = daemon_socket_path(&cqs_dir);
-        let listener = UnixListener::bind(&sock_path).unwrap();
-
-        let snap = crate::watch_status::WatchSnapshot {
-            state: crate::watch_status::FreshnessState::Stale,
-            modified_files: 7,
-            pending_notes: true,
-            rebuild_in_flight: false,
-            delta_saturated: false,
-            incremental_count: 17,
-            dropped_this_cycle: 0,
-            last_event_unix_secs: 1_734_120_488,
-            last_synced_at: Some(1_734_120_000),
-            snapshot_at: Some(1_734_120_500),
-        };
-        let inner_envelope = serde_json::json!({
-            "data": serde_json::to_value(&snap).unwrap(),
-            "error": null,
-            "version": 1,
-        });
-        let outer_envelope = serde_json::json!({"status": "ok", "output": inner_envelope});
-        let outer_str = outer_envelope.to_string();
-
-        let handle = std::thread::spawn(move || {
-            // wait_secs=0 → exactly one accept before the deadline trips.
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut request_line = String::new();
-            BufReader::new(&stream)
-                .read_line(&mut request_line)
-                .unwrap();
-            writeln!(stream, "{outer_str}").unwrap();
-            stream.flush().unwrap();
-        });
+        let _listener = std::os::unix::net::UnixListener::bind(&sock_path).unwrap();
 
         let result = wait_for_fresh(&cqs_dir, 0);
-        handle.join().unwrap();
         let _ = std::fs::remove_file(&sock_path);
 
         // SAFETY: see daemon_status_mock_round_trip.
@@ -1345,8 +1493,9 @@ mod tests {
 
         match result {
             FreshnessWait::Timeout(snap) => {
-                assert_eq!(snap.state, crate::watch_status::FreshnessState::Stale);
-                assert_eq!(snap.modified_files, 7);
+                // RB-9 deadline-first: budget=0 means we return without a
+                // round-trip, so the snapshot is the synthetic "unknown".
+                assert_eq!(snap.state, crate::watch_status::FreshnessState::Unknown);
             }
             other => panic!("expected Timeout, got: {other:?}"),
         }
@@ -1354,15 +1503,40 @@ mod tests {
 
     /// PR 4 of #1182: `wait_for_fresh` returns `NoDaemon` without a socket.
     /// No mock listener — the helper short-circuits on `daemon_status`'s
-    /// pre-flight existence check. No serial gate needed because we don't
-    /// touch `XDG_RUNTIME_DIR`.
+    /// pre-flight existence check. Must point XDG at a fresh tempdir so
+    /// the helper sees no socket regardless of any host daemon.
+    ///
+    /// `#[serial]` for the same XDG-race reason as
+    /// `daemon_status_mock_round_trip`.
+    ///
+    /// RB-9 reframe: post-deadline-first, we use `wait_secs = 5` so we
+    /// reach `daemon_status` and get the SocketMissing → NoDaemon path.
+    /// `wait_secs = 0` would short-circuit on the deadline-first guard
+    /// and return `Timeout(unknown)` without ever asking the daemon.
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial(daemon_socket_xdg)]
     fn wait_for_fresh_returns_no_daemon_without_socket() {
         let dir = tempfile::tempdir().unwrap();
         let cqs_dir = dir.path().join(".cqs");
         std::fs::create_dir_all(&cqs_dir).unwrap();
-        let result = wait_for_fresh(&cqs_dir, 0);
+
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        // SAFETY: see daemon_status_mock_round_trip.
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", dir.path());
+        }
+
+        let result = wait_for_fresh(&cqs_dir, 5);
+
+        // SAFETY: see above.
+        unsafe {
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+
         match result {
             FreshnessWait::NoDaemon(msg) => {
                 assert!(
@@ -1372,5 +1546,295 @@ mod tests {
             }
             other => panic!("expected NoDaemon, got: {other:?}"),
         }
+    }
+
+    /// TC-HAP-1.30.1-5: `wait_for_fresh` polls past stale snapshots and
+    /// returns `Fresh` once the daemon flips. Listener accepts three
+    /// connections: stale, stale, fresh. Pins both the polling loop AND
+    /// the exponential backoff (elapsed must be at least the initial
+    /// poll interval × 1 sleep — a fresh-on-first wouldn't sleep at all).
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(daemon_socket_xdg)]
+    fn wait_for_fresh_returns_fresh_after_two_stale_polls() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        // SAFETY: tests run sequentially within a process; this only races
+        // against parallel workers, and the temp_dir is unique per test.
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", dir.path());
+            // Fast-poll override so the test's two sleeps don't add a
+            // perceptible delay. 25ms is the floor.
+            std::env::set_var("CQS_FRESHNESS_POLL_MS", "25");
+        }
+
+        let sock_path = daemon_socket_path(&cqs_dir);
+        let listener = UnixListener::bind(&sock_path).unwrap();
+
+        // Helper: build the outer envelope wrapping a snapshot.
+        let envelope = |state: crate::watch_status::FreshnessState| -> String {
+            let snap = crate::watch_status::WatchSnapshot {
+                state,
+                modified_files: if matches!(state, crate::watch_status::FreshnessState::Fresh) {
+                    0
+                } else {
+                    3
+                },
+                pending_notes: false,
+                rebuild_in_flight: false,
+                delta_saturated: false,
+                incremental_count: 0,
+                dropped_this_cycle: 0,
+                last_event_unix_secs: 1_734_120_488,
+                last_synced_at: Some(1_734_120_000),
+                snapshot_at: Some(1_734_120_500),
+            };
+            let inner = serde_json::json!({
+                "data": serde_json::to_value(&snap).unwrap(),
+                "error": null,
+                "version": 1,
+            });
+            serde_json::json!({"status": "ok", "output": inner}).to_string()
+        };
+
+        let stale1 = envelope(crate::watch_status::FreshnessState::Stale);
+        let stale2 = envelope(crate::watch_status::FreshnessState::Stale);
+        let fresh = envelope(crate::watch_status::FreshnessState::Fresh);
+
+        let handle = std::thread::spawn(move || {
+            for body in [stale1, stale2, fresh] {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut req = String::new();
+                BufReader::new(&stream).read_line(&mut req).unwrap();
+                writeln!(stream, "{body}").unwrap();
+                stream.flush().unwrap();
+            }
+        });
+
+        let start = std::time::Instant::now();
+        let result = wait_for_fresh(&cqs_dir, 5);
+        let elapsed = start.elapsed();
+
+        handle.join().unwrap();
+        let _ = std::fs::remove_file(&sock_path);
+
+        // SAFETY: see above.
+        unsafe {
+            std::env::remove_var("CQS_FRESHNESS_POLL_MS");
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+
+        match result {
+            FreshnessWait::Fresh(snap) => {
+                assert_eq!(snap.state, crate::watch_status::FreshnessState::Fresh);
+                assert_eq!(snap.modified_files, 0);
+            }
+            other => panic!("expected Fresh after stale polls, got: {other:?}"),
+        }
+        // We slept at least once (after first stale poll). At a 25ms
+        // initial interval the test must take >= 25ms total. Use a loose
+        // 20ms floor to allow scheduler jitter.
+        assert!(
+            elapsed.as_millis() >= 20,
+            "expected at least one sleep cycle, got {}ms",
+            elapsed.as_millis()
+        );
+    }
+
+    /// TC-ADV-1.30.1-4: `wait_for_fresh` returns `Transport(_)` (not
+    /// `NoDaemon`) when the daemon socket file exists but the daemon
+    /// process has died — i.e. the listener was bound, accepted one
+    /// connection, then dropped. The socket file persists (until we
+    /// `remove_file`) but `UnixStream::connect` returns ECONNREFUSED
+    /// because no listener is bound to it.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(daemon_socket_xdg)]
+    fn wait_for_fresh_returns_transport_when_daemon_dies_mid_poll() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        // SAFETY: see above.
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", dir.path());
+            std::env::set_var("CQS_FRESHNESS_POLL_MS", "25");
+        }
+
+        let sock_path = daemon_socket_path(&cqs_dir);
+        let listener = UnixListener::bind(&sock_path).unwrap();
+
+        let stale_envelope = {
+            let snap = crate::watch_status::WatchSnapshot {
+                state: crate::watch_status::FreshnessState::Stale,
+                modified_files: 5,
+                pending_notes: false,
+                rebuild_in_flight: false,
+                delta_saturated: false,
+                incremental_count: 0,
+                dropped_this_cycle: 0,
+                last_event_unix_secs: 1_734_120_488,
+                last_synced_at: Some(1_734_120_000),
+                snapshot_at: Some(1_734_120_500),
+            };
+            let inner = serde_json::json!({
+                "data": serde_json::to_value(&snap).unwrap(),
+                "error": null,
+                "version": 1,
+            });
+            serde_json::json!({"status": "ok", "output": inner}).to_string()
+        };
+
+        // Listener thread: accept once, send Stale, drop listener. The
+        // socket file persists on disk so subsequent connects see the
+        // file but hit ECONNREFUSED (no listener bound) — exercises
+        // Transport, not SocketMissing.
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut req = String::new();
+            BufReader::new(&stream).read_line(&mut req).unwrap();
+            writeln!(stream, "{stale_envelope}").unwrap();
+            stream.flush().unwrap();
+            drop(stream);
+            drop(listener);
+        });
+
+        let result = wait_for_fresh(&cqs_dir, 5);
+        handle.join().unwrap();
+        let _ = std::fs::remove_file(&sock_path);
+
+        // SAFETY: see above.
+        unsafe {
+            std::env::remove_var("CQS_FRESHNESS_POLL_MS");
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+
+        // The socket file existed at every poll, but the daemon was
+        // gone for the second one — must surface as Transport, not
+        // NoDaemon, so the eval gate's advice points at journalctl
+        // rather than at "start the daemon".
+        match result {
+            FreshnessWait::Transport(_) => { /* expected */ }
+            other => panic!("expected Transport after daemon death, got: {other:?}"),
+        }
+    }
+
+    /// TC-ADV-1.30.1-4 (sibling): `daemon_status` distinguishes a
+    /// malformed envelope (`BadResponse`) from a missing socket
+    /// (`SocketMissing`). The mock listener writes a truncated JSON line
+    /// and closes — the helper must classify as BadResponse so callers
+    /// like `wait_for_fresh` can route to "version skew" advice rather
+    /// than "start a daemon".
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(daemon_socket_xdg)]
+    fn daemon_status_returns_bad_response_on_malformed_envelope() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        // SAFETY: see above.
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", dir.path());
+        }
+
+        let sock_path = daemon_socket_path(&cqs_dir);
+        let listener = UnixListener::bind(&sock_path).unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut req = String::new();
+            BufReader::new(&stream).read_line(&mut req).unwrap();
+            // Truncated envelope — opens an object then closes the line.
+            writeln!(stream, r#"{{"status":"ok","output":"#).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let result = daemon_status(&cqs_dir);
+        handle.join().unwrap();
+        let _ = std::fs::remove_file(&sock_path);
+
+        // SAFETY: see above.
+        unsafe {
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+
+        match result {
+            Err(DaemonRpcError::BadResponse(msg)) => {
+                assert!(
+                    msg.contains("parse")
+                        || msg.contains("envelope")
+                        || msg.contains("missing")
+                        || msg.contains("EOF")
+                        || msg.contains("trailing"),
+                    "expected envelope/parse-class message, got: {msg}"
+                );
+            }
+            other => panic!("expected BadResponse on malformed envelope, got: {other:?}"),
+        }
+    }
+
+    /// AC-V1.30.1-9: `daemon_socket_path` is deterministic across calls
+    /// (BLAKE3 of the cqs_dir bytes). Pin the exact hash for a known
+    /// input so a future drift in the truncation length or hex
+    /// formatting trips this test.
+    #[cfg(unix)]
+    #[test]
+    fn daemon_socket_path_blake3_pinned() {
+        use std::path::Path;
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        // SAFETY: see daemon_status_mock_round_trip.
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", "/tmp");
+        }
+        let p = daemon_socket_path(Path::new("/tmp/foo"));
+        // Restore env early so a panic doesn't poison neighbour tests.
+        // SAFETY: see above.
+        unsafe {
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+
+        // Compute the expected hex independently so the test pins both
+        // the algorithm choice (BLAKE3) and the truncation length (8 bytes
+        // → 16 hex chars). If anyone swaps to SHA256 / changes the
+        // truncation, this fails immediately.
+        let expected_hash = blake3::hash(b"/tmp/foo");
+        let expected_truncated = &expected_hash.as_bytes()[..8];
+        let mut expected_hex = String::with_capacity(16);
+        for b in expected_truncated {
+            use std::fmt::Write as _;
+            write!(expected_hex, "{:02x}", b).unwrap();
+        }
+        let expected = format!("/tmp/cqs-{expected_hex}.sock");
+        assert_eq!(p.to_string_lossy(), expected);
+        // Sanity: 16-char hex, fixed width — distinguishes from
+        // DefaultHasher's variable-length unpadded output.
+        assert_eq!(expected_hex.len(), 16, "BLAKE3 truncation must be 8 bytes");
     }
 }

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -341,6 +341,33 @@ pub fn parse_env_u64(key: &str, default: u64) -> u64 {
     }
 }
 
+// ============ #1182 wait_for_fresh poll cadence ============
+
+/// Default initial poll interval (milliseconds) for `wait_for_fresh`. The
+/// poll loop starts here and doubles up to a 2 s ceiling. 100 ms is fast
+/// enough that an already-fresh tree returns within a tick, slow enough
+/// that 600 s × 100 ms ≈ 6000 connect/parse round-trips can't pin a
+/// host's socket budget on a stuck-stale daemon.
+///
+/// SHL-V1.30-2: env override `CQS_FRESHNESS_POLL_MS` clamped to
+/// `[25, 5000]` so a misconfigured `=1` doesn't burn CPU and `=60000`
+/// doesn't masquerade as a hang.
+pub const FRESHNESS_POLL_MS_INITIAL_DEFAULT: u64 = 100;
+
+/// Resolve the initial poll interval honoring `CQS_FRESHNESS_POLL_MS`.
+/// Floor 25 ms, ceiling 5000 ms. See [`FRESHNESS_POLL_MS_INITIAL_DEFAULT`].
+pub fn freshness_poll_ms_initial() -> u64 {
+    match std::env::var("CQS_FRESHNESS_POLL_MS") {
+        Ok(v) => v
+            .parse::<u64>()
+            .ok()
+            .filter(|n| *n > 0)
+            .map(|n| n.clamp(25, 5000))
+            .unwrap_or(FRESHNESS_POLL_MS_INITIAL_DEFAULT),
+        Err(_) => FRESHNESS_POLL_MS_INITIAL_DEFAULT,
+    }
+}
+
 /// Parse a duration-in-seconds env var into a `std::time::Duration`,
 /// falling back to `default_secs` on missing/empty/garbage/zero values.
 /// P2.4: convenience wrapper for the common `parse_env_u64(...) -> from_secs`
@@ -383,5 +410,30 @@ mod tests {
         std::env::set_var("CQS_TEST_LIMITS_U64", "42");
         assert_eq!(parse_env_u64("CQS_TEST_LIMITS_U64", 99), 42);
         std::env::remove_var("CQS_TEST_LIMITS_U64");
+    }
+
+    /// SHL-V1.30-2: `freshness_poll_ms_initial` honors the env override and
+    /// clamps to `[25, 5000]`. Missing / garbage / zero falls back to the
+    /// 100 ms default.
+    #[test]
+    fn freshness_poll_ms_initial_default_and_clamp() {
+        // Default path
+        std::env::remove_var("CQS_FRESHNESS_POLL_MS");
+        assert_eq!(freshness_poll_ms_initial(), 100);
+        // Garbage / zero falls back to default
+        std::env::set_var("CQS_FRESHNESS_POLL_MS", "garbage");
+        assert_eq!(freshness_poll_ms_initial(), 100);
+        std::env::set_var("CQS_FRESHNESS_POLL_MS", "0");
+        assert_eq!(freshness_poll_ms_initial(), 100);
+        // Below floor → clamped to 25
+        std::env::set_var("CQS_FRESHNESS_POLL_MS", "1");
+        assert_eq!(freshness_poll_ms_initial(), 25);
+        // Above ceiling → clamped to 5000
+        std::env::set_var("CQS_FRESHNESS_POLL_MS", "60000");
+        assert_eq!(freshness_poll_ms_initial(), 5000);
+        // In-range value passes through
+        std::env::set_var("CQS_FRESHNESS_POLL_MS", "250");
+        assert_eq!(freshness_poll_ms_initial(), 250);
+        std::env::remove_var("CQS_FRESHNESS_POLL_MS");
     }
 }

--- a/tests/daemon_forward_test.rs
+++ b/tests/daemon_forward_test.rs
@@ -241,13 +241,20 @@ fn setup_project() -> (TempDir, PathBuf) {
 /// Mirror `cqs::daemon_translate::daemon_socket_path` but with an explicit
 /// runtime-dir override so the test doesn't need to mutate env vars in the
 /// current process. The mutation happens on the spawned CLI only.
+///
+/// AC-V1.30.1-9: must stay byte-equivalent to the production helper —
+/// production switched from `std::collections::hash_map::DefaultHasher`
+/// (Rust-version-dependent SipHash) to `blake3` truncated to 8 bytes.
 fn daemon_socket_path_with_runtime_dir(cqs_dir: &Path, runtime_dir: &Path) -> PathBuf {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    let mut h = DefaultHasher::new();
-    cqs_dir.hash(&mut h);
-    let sock_name = format!("cqs-{:x}.sock", h.finish());
+    let canonical_path_bytes = cqs_dir.as_os_str().as_encoded_bytes();
+    let hash = blake3::hash(canonical_path_bytes);
+    let truncated = &hash.as_bytes()[..8];
+    let mut hex = String::with_capacity(16);
+    for b in truncated {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{:02x}", b);
+    }
+    let sock_name = format!("cqs-{}.sock", hex);
     runtime_dir.join(sock_name)
 }
 


### PR DESCRIPTION
## Summary

P2 batch from v1.30.1 audit — `wait_for_fresh` hot path. 3 prompts, 1 commit, 8 files, 8 new tests.

| Finding | Fix |
|---------|-----|
| **bundle-wait-fresh** (RB-9, EH-V1.30.1-2, OB-V1.30.1-8, API-V1.30.1-5, TC-HAP-1.30.1-5, TC-ADV-1.30.1-4) | `DaemonRpcError` enum (`SocketMissing`/`Transport`/`BadResponse`/`DaemonError`/`Timeout(WatchSnapshot)`) replaces `Result<T, String>` on `daemon_ping`/`daemon_status`/`daemon_reconcile`. `wait_for_fresh` refactored deadline-first with exponential backoff. Connect-failure warn cadence widened so it doesn't spam at 250 ms during startup. |
| **AC-V1.30.1-9** | `daemon_socket_path` switched from Rust-version-dependent `DefaultHasher` to BLAKE3-truncated-to-8-bytes (16 hex chars). Deterministic across Rust versions and operators. **Migration:** existing `cqs-watch` services must restart so daemon binds new socket name and CLI clients connect to it. |
| **API-V1.30.1-1** | `cqs status --wait` timeout now emits error envelope (`error_codes::TIMEOUT`) and exits 1, matching the contract. New `Timeout` variant in `ErrorCode` + `error_codes::TIMEOUT` constant + `emit_json_error_with_data()` helper. |

## New helpers

- `crate::limits::freshness_poll_ms_initial()` — initial poll interval for exp backoff (default 250 ms, clamp-tested).
- `cli::json_envelope::emit_json_error_with_data()` — error envelope with optional `data` payload.
- `DaemonRpcError::as_message()` — adapter so existing string-based call sites (eval/ping/hook/status) keep working without a sweeping rewrite.

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean (8 pre-existing warnings in unrelated test code under `--tests`)
- [x] `daemon_translate.rs` — 28 pass (4 new: `wait_for_fresh_returns_fresh_after_two_stale_polls`, `wait_for_fresh_returns_transport_when_daemon_dies_mid_poll`, `daemon_status_returns_bad_response_on_malformed_envelope`, `daemon_socket_path_blake3_pinned`)
- [x] `json_envelope.rs` — 23 pass (2 new: `emit_json_error_with_data_envelope_shape`, `emit_json_error_with_data_none_data_is_null` + extended `error_code_str_round_trip` for Timeout)
- [x] `limits.rs` — 4 pass (1 new: `freshness_poll_ms_initial_default_and_clamp`)
- [x] `status.rs` — 4 pass (existing pinned, now exercising Timeout error envelope)
- [x] `daemon_forward_test.rs` — 9 pass (mirrored BLAKE3 hashing in test stub)
- [x] `cargo fmt --check` clean

## Migration note

This commit changes the Unix socket name (BLAKE3 vs `DefaultHasher`). After landing:

```bash
systemctl --user restart cqs-watch
```

CLI clients connecting via `daemon_translate::daemon_socket_path` automatically pick up the new name; CLI auto-fallback to direct mode catches the brief gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
