### PR TITLE
chore(tears): v1.30.1 audit P1+P2 close-out — 45/45 done, P3+P4 next

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,6 +2,35 @@
 
 ## Right Now
 
+**v1.30.1 audit P1+P2 done; P3+P4 next (2026-04-29 ~01:15 UTC).** 144 findings from 16 parallel auditors. Tiers: P1=14, P2=31, P3=78, P4=23.
+
+**Status:**
+- **P1 14/14 ✅ merged**: #1199 (lying docs) · #1200 (trust_level wiring) · #1201 (auth surface) · #1202 (freshness gate) · #1203 (embedder/reconcile)
+- **#1205 ✅ merged**: audit artifacts (findings/triage/fix-prompts.md)
+- **P2 31/31 ✅ merged** (six PRs):
+  - #1206 — auth+serve hardening — PB-1, SEC-3/4, OB-10
+  - #1207 — reconcile+path correctness — EH-1/7, RB-1/6, PB-7
+  - #1208 — watch state machine + delta + clock safety — OB-3/9, AC-10, API-10, RB-10, EH-8 (wire-shape break: `idle_secs` → `last_event_unix_secs`)
+  - #1209 — tests+DS papercuts+misc — TC-HAP-2/3, DS-D1/D5/D7, AC-3, PB-3
+  - #1210 — eval gate observability — OB-6, TC-HAP-4/7
+  - #1211 — wait_for_fresh hot path — RB-9, EH-2, OB-8, AC-9 (BLAKE3 socket path replaces DefaultHasher — restart cqs-watch after binary install), API-1, API-5
+- **#1212 filed**: perf wart — `upsert_sparse_vectors` 1M-row DELETE holds SQLite write lock ~8s on bulk reindex. `sparse_vectors.rs` already does DROP/CREATE INDEX + batched ops; this is the inherent cost of the deletes. Follow-up tracker.
+- **Main** at `ade6f5c8` post-#1211 merge. Local binary rebuild in flight (background `b7wf9ik6d`); after it lands, `systemctl --user stop cqs-watch && cp ~/.cargo-target/cqs/release/cqs ~/.cargo/bin/cqs && systemctl --user start cqs-watch` (BLAKE3 socket path **requires** the daemon restart; old DefaultHasher socket name will be orphaned).
+
+**Up next:**
+- Tears+triage PR (this commit) → CI green → merge
+- P3 execution (78 findings → ~9 implementer bundles by area: docs / API-papercuts / wait_for_fresh-polish / auth-serve / watch-reconcile / scaling-knobs / refactor / platform / TC-coverage)
+- P4 trivials (23 findings; ~10 doc fixes, rest get tracking issues)
+- `cqs audit-mode off` final cleanup
+
+**Cross-cutting themes** (for context, not action): `delta_saturated` half-wired (fixed #1202), `dropped_this_cycle` reset-before-publish (fixed #1202), `wait_for_fresh` papercuts (in #1211), lying-docs cluster (fixed #1199-#1201), v0.12.1 swallow-error pattern recurrence (P2/P3), three-channel auth gaps (fixed #1201).
+
+**Path-discipline incident this session.** 2 of 6 P2 implementer agents (P2-B, P2-F) leaked writes to absolute parent paths despite running in worktrees. Both self-corrected after coordinator notice (saved diff in worktree, reverted parent, reapplied). Lesson reinforced: every parallel-agent prompt needs explicit "use $(git rev-parse --show-toplevel) prefix, never /mnt/c/Projects/cqs/" text per `feedback_agent_worktrees` memory.
+
+**Audit verification quality.** P1 had 5/12 NEEDS FIX (~42%) and P2 had 9/22 NEEDS FIX (~41%) on first verification pass — vs the audit skill's expected 20%. Pattern is consistent across phases: fictional API arities (atomic_replace), wrong function names (save vs save_owned), nonexistent constants (error_codes::TIMEOUT). Fix-prompt generation needs tighter source-grounding before agents are dispatched.
+
+**GPU load spike root-caused (2026-04-29 ~00:55 UTC).** Watch service held GPU/CPU load for ~1h after 11 sequential P1+P2 PR merges. Each `git pull` triggered a debounced inotify batch → reindex_files{file_count=179} → upsert_sparse_vectors{count=5614} → 1.04M-row DELETE in 7.7s + CREATE INDEX rebuild 7.7s. Legitimate work, but worth filing #1212 for. No watch-tuning knob change needed — this is the steady-state cost of a corpus-wide reindex over WSL NTFS.
+
 **v1.30.1 released 2026-04-28.** Post-release autopilot loop drained the queue across two arcs: #1182 perfect watch mode (Layers 1-4 + acceptance test) and the P4 auth-hardening cluster (#1197 closes #1134/#1135/#1136). Skipped #1139 / #1140 per autopilot directive.
 
 **Just landed (post-v1.30.1):**

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -38,37 +38,37 @@ Categorization: P1 14, P2 32, P3 78, P4 23 (duplicate entries cross-referenced r
 
 | ID | Title | Category | Location | Effort | Status |
 |----|-------|----------|----------|--------|--------|
-| EH-V1.30.1-1 | Parse failure leaves stale chunks AND no mtime update — reconciles forever | Error Handling | `src/cli/watch/reindex.rs:255-314` | medium | pending |
-| EH-V1.30.1-2 | `wait_for_fresh` collapses transport AND parse errors into `NoDaemon` — wrong advice | Error Handling | `src/daemon_translate.rs:660-678` | easy | pending |
-| EH-V1.30.1-7 | Reconcile mtime-stat error swallowed — file may oscillate as "always stale" | Error Handling | `src/cli/watch/reconcile.rs:116-127` + `reindex.rs:501-509` | medium | pending |
-| EH-V1.30.1-8 | `try_init_embedder` Err path strands HNSW dirty flag without observability | Error Handling | `src/cli/watch/events.rs:154-185` | medium | pending |
-| RB-1 | `to_string_lossy()` on path keys silently mangles non-UTF-8 paths into permanent reindex storms | Robustness | `src/cli/watch/reconcile.rs:99` + `staleness.rs:627-637` | medium | pending |
-| RB-9 | `wait_for_fresh` infinite poll loop on slow daemon — no exp backoff, 2400 socket connects/600s | Robustness | `src/daemon_translate.rs:665-678` | medium | pending |
-| RB-10 | `now_unix_secs()` swallows clock-before-epoch error as `0` — masks systemic bad-clock | Robustness | `src/watch_status.rs:226-231` | easy | pending |
-| RB-6 | `enumerate_files` `unwrap_or(&path)` on canonicalize-mismatch leaks abs paths into rel workflow | Robustness | `src/lib.rs:680-685` | medium | pending |
-| AC-V1.30.1-3 | BFS `bfs_expand` cap check skips score-bump for already-visited neighbors at boundary | Algorithm Correctness | `src/gather.rs:357-381` | medium | pending |
-| AC-V1.30.1-9 | `daemon_socket_path` uses `DefaultHasher` — Rust-version-dependent, breaks systemd unit naming | Algorithm Correctness | `src/daemon_translate.rs:174-200` | medium | pending |
-| AC-V1.30.1-10 | `incremental_count = 0` reset on idle-clear loses delta context — late HNSW rebuilds | Algorithm Correctness | `src/cli/watch/mod.rs:1180` | medium | pending |
-| API-V1.30.1-1 | `cqs status --wait` emits success envelope but exits 1 on timeout — contradicts contract | API Design | `src/cli/commands/infra/status.rs:85-90` | easy | pending |
-| API-V1.30.1-5 | `daemon_ping`/`status`/`reconcile` return `Result<T, String>` — stringly-typed errors on public API | API Design | `src/daemon_translate.rs:271,422,541` | medium | pending |
-| API-V1.30.1-10 | `WatchSnapshot.idle_secs` frozen at compute time — wire shape lies once snapshot served later | API Design | `src/watch_status.rs:101,219` | medium | pending |
-| OB-V1.30.1-3 | `WatchSnapshot` state transitions silent — Fresh↔Stale↔Rebuilding flips have no journal trail | Observability | `src/cli/watch/mod.rs:149-185`, `watch_status.rs:195-224` | medium | pending |
-| OB-V1.30.1-6 | `require_fresh_gate` lacks entry span + final-decision info — eval gate decisions invisible | Observability | `src/cli/commands/eval/mod.rs:219-275` | easy | pending |
-| OB-V1.30.1-8 | `daemon_status` connect-failure warns every 250 ms during startup race — 2400 lines/600s wait | Observability | `src/daemon_translate.rs:438-441` | medium | pending |
-| OB-V1.30.1-9 | `process_file_changes` uses `println!` in non-quiet — bypasses tracing infrastructure | Observability | `src/cli/watch/events.rs:147-152` | easy | pending |
-| OB-V1.30.1-10 | `serve::search` info logs full query at info — bypasses TraceLayer redaction | Observability | `src/serve/handlers.rs:189-232` | easy | pending |
-| PB-V1.30.1-1 | `cmd_serve` `--no-auth` warning misses `0.0.0.0` and `::` wildcard binds — most-exposed configs | Platform Behavior | `src/cli/commands/serve.rs:27` | easy | pending |
-| PB-V1.30.1-3 | `process_exists` (Windows) substring-matches `INFO:` against localized `tasklist` output | Platform Behavior | `src/cli/files.rs:59-72` | medium | pending |
-| PB-V1.30.1-7 | `cqs hook fire` on Windows-native: `.cqs/.dirty` written but no consumer ever reads it | Platform Behavior | `src/cli/commands/infra/hook.rs:309-335` | medium | pending |
-| SEC-V1.30.1-3 | `callgraph-3d.js` interpolates `e.message` into `innerHTML` without `escapeHtml` — XSS gap | Security | `src/serve/assets/views/callgraph-3d.js:55` | easy | pending |
-| SEC-V1.30.1-4 | `tag_user_code_trust_level` shape-coupled — silently no-ops on unknown JSON shapes | Security | `src/cli/commands/mod.rs:216-257` | medium | pending |
-| DS-V1.30.1-D1 | `cqs index --force` reopen leaves stale `pending_rebuild` against orphaned store handle | Data Safety | `src/cli/watch/mod.rs:1102-1122` | medium | pending |
-| DS-V1.30.1-D5 | `.cqs/.dirty` fallback marker write not atomic — crash drops the only signal daemon will see | Data Safety | `src/cli/commands/infra/hook.rs:329-332` | easy | pending |
-| DS-V1.30.1-D7 | HNSW rollback path leaves `.bak` files orphaned when restore-rename fails | Data Safety | `src/hnsw/persist.rs:509-553` | medium | pending |
-| TC-HAP-1.30.1-2 | `cmd_uninstall`, `cmd_fire`, `cmd_hook_status` — three CLI commands ship with zero tests | Test Coverage (happy) | `src/cli/commands/infra/hook.rs:262-373` | medium | pending |
-| TC-HAP-1.30.1-3 | `cmd_status` — 6-row behavior matrix promised, zero outcomes pinned | Test Coverage (happy) | `src/cli/commands/infra/status.rs:38-103` | medium | pending |
-| TC-HAP-1.30.1-4 | `require_fresh_gate` — function never called by any test; bypass logic re-implemented inline | Test Coverage (happy) | `src/cli/commands/eval/mod.rs:219-275` | easy | pending |
-| TC-HAP-1.30.1-7 | Eval freshness gate untested end-to-end — every test sets `CQS_EVAL_REQUIRE_FRESH=0` bypass | Test Coverage (happy) | `tests/eval_subcommand_test.rs:88-93` | medium | pending |
+| EH-V1.30.1-1 | Parse failure leaves stale chunks AND no mtime update — reconciles forever | Error Handling | `src/cli/watch/reindex.rs:255-314` | medium | ✅ PR #1207 |
+| EH-V1.30.1-2 | `wait_for_fresh` collapses transport AND parse errors into `NoDaemon` — wrong advice | Error Handling | `src/daemon_translate.rs:660-678` | easy | ⏳ PR #1211 |
+| EH-V1.30.1-7 | Reconcile mtime-stat error swallowed — file may oscillate as "always stale" | Error Handling | `src/cli/watch/reconcile.rs:116-127` + `reindex.rs:501-509` | medium | ✅ PR #1207 |
+| EH-V1.30.1-8 | `try_init_embedder` Err path strands HNSW dirty flag without observability | Error Handling | `src/cli/watch/events.rs:154-185` | medium | ✅ PR #1208 |
+| RB-1 | `to_string_lossy()` on path keys silently mangles non-UTF-8 paths into permanent reindex storms | Robustness | `src/cli/watch/reconcile.rs:99` + `staleness.rs:627-637` | medium | ✅ PR #1207 |
+| RB-9 | `wait_for_fresh` infinite poll loop on slow daemon — no exp backoff, 2400 socket connects/600s | Robustness | `src/daemon_translate.rs:665-678` | medium | ⏳ PR #1211 |
+| RB-10 | `now_unix_secs()` swallows clock-before-epoch error as `0` — masks systemic bad-clock | Robustness | `src/watch_status.rs:226-231` | easy | ✅ PR #1208 |
+| RB-6 | `enumerate_files` `unwrap_or(&path)` on canonicalize-mismatch leaks abs paths into rel workflow | Robustness | `src/lib.rs:680-685` | medium | ✅ PR #1207 |
+| AC-V1.30.1-3 | BFS `bfs_expand` cap check skips score-bump for already-visited neighbors at boundary | Algorithm Correctness | `src/gather.rs:357-381` | medium | ✅ PR #1209 |
+| AC-V1.30.1-9 | `daemon_socket_path` uses `DefaultHasher` — Rust-version-dependent, breaks systemd unit naming | Algorithm Correctness | `src/daemon_translate.rs:174-200` | medium | ⏳ PR #1211 |
+| AC-V1.30.1-10 | `incremental_count = 0` reset on idle-clear loses delta context — late HNSW rebuilds | Algorithm Correctness | `src/cli/watch/mod.rs:1180` | medium | ✅ PR #1208 |
+| API-V1.30.1-1 | `cqs status --wait` emits success envelope but exits 1 on timeout — contradicts contract | API Design | `src/cli/commands/infra/status.rs:85-90` | easy | ⏳ PR #1211 |
+| API-V1.30.1-5 | `daemon_ping`/`status`/`reconcile` return `Result<T, String>` — stringly-typed errors on public API | API Design | `src/daemon_translate.rs:271,422,541` | medium | ⏳ PR #1211 |
+| API-V1.30.1-10 | `WatchSnapshot.idle_secs` frozen at compute time — wire shape lies once snapshot served later | API Design | `src/watch_status.rs:101,219` | medium | ✅ PR #1208 |
+| OB-V1.30.1-3 | `WatchSnapshot` state transitions silent — Fresh↔Stale↔Rebuilding flips have no journal trail | Observability | `src/cli/watch/mod.rs:149-185`, `watch_status.rs:195-224` | medium | ✅ PR #1208 |
+| OB-V1.30.1-6 | `require_fresh_gate` lacks entry span + final-decision info — eval gate decisions invisible | Observability | `src/cli/commands/eval/mod.rs:219-275` | easy | ✅ PR #1210 |
+| OB-V1.30.1-8 | `daemon_status` connect-failure warns every 250 ms during startup race — 2400 lines/600s wait | Observability | `src/daemon_translate.rs:438-441` | medium | ⏳ PR #1211 |
+| OB-V1.30.1-9 | `process_file_changes` uses `println!` in non-quiet — bypasses tracing infrastructure | Observability | `src/cli/watch/events.rs:147-152` | easy | ✅ PR #1208 |
+| OB-V1.30.1-10 | `serve::search` info logs full query at info — bypasses TraceLayer redaction | Observability | `src/serve/handlers.rs:189-232` | easy | ✅ PR #1206 |
+| PB-V1.30.1-1 | `cmd_serve` `--no-auth` warning misses `0.0.0.0` and `::` wildcard binds — most-exposed configs | Platform Behavior | `src/cli/commands/serve.rs:27` | easy | ✅ PR #1206 |
+| PB-V1.30.1-3 | `process_exists` (Windows) substring-matches `INFO:` against localized `tasklist` output | Platform Behavior | `src/cli/files.rs:59-72` | medium | ✅ PR #1209 |
+| PB-V1.30.1-7 | `cqs hook fire` on Windows-native: `.cqs/.dirty` written but no consumer ever reads it | Platform Behavior | `src/cli/commands/infra/hook.rs:309-335` | medium | ✅ PR #1207 |
+| SEC-V1.30.1-3 | `callgraph-3d.js` interpolates `e.message` into `innerHTML` without `escapeHtml` — XSS gap | Security | `src/serve/assets/views/callgraph-3d.js:55` | easy | ✅ PR #1206 |
+| SEC-V1.30.1-4 | `tag_user_code_trust_level` shape-coupled — silently no-ops on unknown JSON shapes | Security | `src/cli/commands/mod.rs:216-257` | medium | ✅ PR #1206 |
+| DS-V1.30.1-D1 | `cqs index --force` reopen leaves stale `pending_rebuild` against orphaned store handle | Data Safety | `src/cli/watch/mod.rs:1102-1122` | medium | ✅ PR #1209 |
+| DS-V1.30.1-D5 | `.cqs/.dirty` fallback marker write not atomic — crash drops the only signal daemon will see | Data Safety | `src/cli/commands/infra/hook.rs:329-332` | easy | ✅ PR #1209 |
+| DS-V1.30.1-D7 | HNSW rollback path leaves `.bak` files orphaned when restore-rename fails | Data Safety | `src/hnsw/persist.rs:509-553` | medium | ✅ PR #1209 |
+| TC-HAP-1.30.1-2 | `cmd_uninstall`, `cmd_fire`, `cmd_hook_status` — three CLI commands ship with zero tests | Test Coverage (happy) | `src/cli/commands/infra/hook.rs:262-373` | medium | ✅ PR #1209 |
+| TC-HAP-1.30.1-3 | `cmd_status` — 6-row behavior matrix promised, zero outcomes pinned | Test Coverage (happy) | `src/cli/commands/infra/status.rs:38-103` | medium | ✅ PR #1209 |
+| TC-HAP-1.30.1-4 | `require_fresh_gate` — function never called by any test; bypass logic re-implemented inline | Test Coverage (happy) | `src/cli/commands/eval/mod.rs:219-275` | easy | ✅ PR #1210 |
+| TC-HAP-1.30.1-7 | Eval freshness gate untested end-to-end — every test sets `CQS_EVAL_REQUIRE_FRESH=0` bypass | Test Coverage (happy) | `tests/eval_subcommand_test.rs:88-93` | medium | ✅ PR #1210 |
 
 ## P3 — Easy + low impact (fix if time)
 

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -1665,3 +1665,35 @@ mentions = [
     "#1197",
     "#1135",
 ]
+
+[[note]]
+sentiment = -0.5
+text = "v1.30.1 audit P2: 9 of 22 prompts NEEDS FIX (~41%) vs skill expectation of 20%. Common errors: fictional API arities (atomic_replace), wrong function names (save vs save_owned), wrong error types (anyhow vs HnswError), nonexistent constants (error_codes::TIMEOUT). Fix-prompt generation needs tighter source-grounding — recurring across P1/P2/P3 phases of this audit."
+mentions = [
+    "audit-fix-prompts.md",
+    "verification",
+]
+
+[[note]]
+sentiment = -0.5
+text = "Verifier-found NEEDS FIX rate on audit fix-prompts: P1 42%, P2 41%, P3 16%. Audit skill expects ~20%. Common errors: fictional API arities, wrong function names (save vs save_owned), wrong error types (anyhow vs HnswError), nonexistent constants. Source-grounding step in fix-prompt generation needs tightening — generator produces plausible-shaped APIs without grepping for them. Verification agent is essential, not optional."
+mentions = [
+    "audit-fix-prompts.md",
+    "verification",
+]
+
+[[note]]
+sentiment = -0.5
+text = "Worktree-isolation failure mode: 2 of 6 implementer agents (P2-B, P2-F) leaked writes to /mnt/c/Projects/cqs/ instead of their worktree. Both self-corrected: saved diff via git diff > /tmp/X.patch, reverted parent files, applied patch in worktree, re-edited under worktree-rooted paths. Confirms feedback_agent_worktrees memory: every parallel-agent prompt MUST include explicit path-discipline text — isolation: worktree alone is not enough."
+mentions = [
+    "worktree",
+    "implementer",
+]
+
+[[note]]
+sentiment = 0.5
+text = "P2-B agent caught a self-duplicating prompt: DS-V1.30.1-D2 and AC-V1.30.1-1 were tagged P2 in the audit-fix-prompts but had already shipped in #1203 (P1 phase). Caller-side verification (cargo test on existing tests + 7-call-site grep) confirmed wiring was correct, agent dropped that part of the bundle. Lesson: when generating P2 prompts, verify against P1 PRs that shipped during the same audit cycle — not just main HEAD at audit time."
+mentions = [
+    "audit-triage.md",
+    "DS-V1.30.1-D2",
+]


### PR DESCRIPTION
## Summary

Tears + triage refresh after the v1.30.1 audit P1+P2 wave landed.

- **PROJECT_CONTINUITY.md** — "Right Now" updated to reflect all 31 P2 PRs merged (six bundles: #1206–#1211); binary rebuild in flight; BLAKE3-socket-path daemon-restart requirement noted (AC-V1.30.1-9 wire change); P3 plan sketched (~9 implementer bundles by area).
- **docs/audit-triage.md** — Status column for all 31 P2 rows marked with their PR reference (`✅ PR #N`).
- **docs/notes.toml** — Three new observations from the P2 wave:
  - Verifier NEEDS-FIX rate ~41% (well above the 20% the audit skill expects) → fix-prompt generation needs tighter source-grounding (-0.5)
  - Worktree-isolation path-discipline incident — 2 of 6 implementers leaked writes to absolute parent paths despite worktree isolation; reinforces the `feedback_agent_worktrees` memory (-0.5)
  - The P1↔P2 dedup catch in #1207 — DS-V1.30.1-D2 + AC-V1.30.1-1 had already shipped in the P1 #1203 prompt; agent self-corrected (+0.5)

Audit count corrected from 32→31 P2 (fix-prompts grouping had counted one ID twice).

#1212 (slow `upsert_sparse_vectors` DELETE on bulk reindex) filed as the perf-wart follow-up tracker.

## Test plan

- [x] Doc-only changes; no code touched
- [x] `cqs audit-mode` still on per skill flow; will toggle off after P3+P4 land
