### PR TITLE
fix(serve+watch+fs): P3 bundle 7 — platform cleanups (PB-V1.30.1-2/4/6, PF-V1.30.1-2, RM-1)

### DIFF
--- a/src/cli/commands/infra/model.rs
+++ b/src/cli/commands/infra/model.rs
@@ -707,32 +707,95 @@ fn restart_daemon_if_needed(was_running: bool, quiet: bool) {
     }
     #[cfg(target_os = "linux")]
     {
-        let status = std::process::Command::new("systemctl")
-            .args(["--user", "start", "cqs-watch"])
+        // PB-V1.30.1-10: probe whether the systemd user unit is loaded
+        // before invoking `systemctl --user start`. On distros without
+        // systemd-user (or on hosts where the user never ran the
+        // installer), the unit doesn't exist and `start` returns a
+        // confusing "Failed to start cqs-watch.service: Unit not found"
+        // error. Fall back to spawning `cqs watch --serve` directly,
+        // mirroring the macOS branch below.
+        let probe = std::process::Command::new("systemctl")
+            .args(["--user", "is-enabled", "cqs-watch"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
             .status();
-        match status {
-            Ok(s) if s.success() => {
-                if !quiet {
-                    eprintln!("restarted cqs-watch daemon");
+        let unit_loaded = matches!(&probe, Ok(s) if s.success());
+        if unit_loaded {
+            let status = std::process::Command::new("systemctl")
+                .args(["--user", "start", "cqs-watch"])
+                .status();
+            match status {
+                Ok(s) if s.success() => {
+                    if !quiet {
+                        eprintln!("restarted cqs-watch daemon");
+                    }
+                }
+                Ok(s) => {
+                    tracing::warn!(code = ?s.code(), "systemctl --user start cqs-watch returned non-zero");
+                    if !quiet {
+                        eprintln!(
+                            "warning: failed to restart cqs-watch daemon (systemctl exited {:?}). \
+                             Run `systemctl --user start cqs-watch` manually.",
+                            s.code()
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to invoke systemctl on restart");
+                    if !quiet {
+                        eprintln!(
+                            "warning: failed to restart cqs-watch daemon ({e}). \
+                             Run `systemctl --user start cqs-watch` manually."
+                        );
+                    }
                 }
             }
-            Ok(s) => {
-                tracing::warn!(code = ?s.code(), "systemctl --user start cqs-watch returned non-zero");
-                if !quiet {
-                    eprintln!(
-                        "warning: failed to restart cqs-watch daemon (systemctl exited {:?}). \
-                         Run `systemctl --user start cqs-watch` manually.",
-                        s.code()
-                    );
+        } else {
+            // No systemd unit — spawn `cqs watch --serve` directly,
+            // mirroring the macOS branch. SEC-V1.25-7: resolve our own
+            // binary path so a malicious `cqs` earlier in PATH can't
+            // hijack the restart.
+            tracing::info!("cqs-watch.service not loaded; spawning `cqs watch --serve` directly");
+            match std::env::current_exe() {
+                Ok(cqs_path) => {
+                    let spawn_result = std::process::Command::new(&cqs_path)
+                        .args(["watch", "--serve"])
+                        .stdin(std::process::Stdio::null())
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .spawn();
+                    match spawn_result {
+                        Ok(child) => {
+                            tracing::info!(
+                                pid = child.id(),
+                                "Restarted cqs watch --serve on Linux (no systemd unit)"
+                            );
+                            if !quiet {
+                                eprintln!("restarted cqs-watch daemon (pid {})", child.id());
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "Failed to spawn cqs watch --serve");
+                            if !quiet {
+                                eprintln!(
+                                    "warning: failed to restart cqs-watch daemon ({e}). \
+                                     Run `cqs watch --serve &` manually."
+                                );
+                            }
+                        }
+                    }
                 }
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to invoke systemctl on restart");
-                if !quiet {
-                    eprintln!(
-                        "warning: failed to restart cqs-watch daemon ({e}). \
-                         Run `systemctl --user start cqs-watch` manually."
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "current_exe() failed; cannot restart daemon"
                     );
+                    if !quiet {
+                        eprintln!(
+                            "warning: failed to resolve cqs binary path ({e}). \
+                             Run `cqs watch --serve &` manually."
+                        );
+                    }
                 }
             }
         }

--- a/src/cli/commands/serve.rs
+++ b/src/cli/commands/serve.rs
@@ -58,9 +58,18 @@ pub(crate) fn cmd_serve(port: u16, bind: String, open: bool, no_auth: bool) -> R
         );
     }
 
-    let bind_addr: SocketAddr = format!("{bind}:{port}")
+    // PB-V1.30.1-2: resolve "localhost" to 127.0.0.1 before parse, since
+    // `SocketAddr::parse` only accepts numeric IPs. The CLI docs (and the
+    // loopback warning above) treat "localhost" as a valid bind value;
+    // without this resolution the literal hostname would always fail.
+    let bind_str: &str = if bind == "localhost" {
+        "127.0.0.1"
+    } else {
+        bind.as_str()
+    };
+    let bind_addr: SocketAddr = format!("{bind_str}:{port}")
         .parse()
-        .with_context(|| format!("Failed to parse {bind}:{port} as a SocketAddr"))?;
+        .with_context(|| format!("Failed to parse {bind_str}:{port} as a SocketAddr"))?;
 
     let root = find_project_root();
     let cqs_dir = cqs::resolve_index_dir(&root);

--- a/src/cli/watch/socket.rs
+++ b/src/cli/watch/socket.rs
@@ -10,7 +10,6 @@
 
 #![cfg(unix)]
 
-use std::cell::RefCell;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -88,15 +87,14 @@ pub(super) fn handle_socket_client(
         );
     }
 
-    // RM-V1.29-10 (#1116): per-thread scratch buffer for the request line.
-    // `handle_socket_client` runs on a Tokio blocking-pool thread that
-    // services many connections in succession. Allocating a fresh `String`
-    // (and its grow-during-`read_line` churn) per accept is ~80% of the
-    // allocator pressure on this path under high-QPS agent workloads. The
-    // 8 KiB initial capacity covers typical JSON requests in one allocation.
-    thread_local! {
-        static REQ_LINE: RefCell<String> = RefCell::new(String::with_capacity(8192));
-    }
+    // RM-1 (post-v1.30.1 audit): the original thread_local! REQ_LINE
+    // was a no-op. The accept loop in `daemon.rs:189-205` spawns a
+    // fresh `cqs-daemon-client` thread per connection, not a Tokio
+    // blocking-pool worker — so the thread_local never gets reused
+    // across calls and the "amortize the buffer" rationale was wrong.
+    // A plain stack-local `String::with_capacity(8192)` has the same
+    // single-allocation cost without the dead amortization story.
+    let mut line = String::with_capacity(8192);
 
     // Read request (max 1MB). Wrap reader in .take() so allocation is
     // bounded *before* we accept a giant line — the post-hoc size check
@@ -111,18 +109,15 @@ pub(super) fn handle_socket_client(
         IoError(String),
         JsonError(String),
     }
-    let parse_outcome = REQ_LINE.with_borrow_mut(|line| {
-        line.clear();
-        match std::io::BufRead::read_line(&mut reader, line) {
-            Ok(0) => ParseOutcome::Empty,
-            Ok(n) if n > 1_048_576 => ParseOutcome::TooLarge,
-            Err(e) => ParseOutcome::IoError(e.to_string()),
-            Ok(_) => match serde_json::from_str(line.trim()) {
-                Ok(v) => ParseOutcome::Ok(v),
-                Err(e) => ParseOutcome::JsonError(e.to_string()),
-            },
-        }
-    });
+    let parse_outcome = match std::io::BufRead::read_line(&mut reader, &mut line) {
+        Ok(0) => ParseOutcome::Empty,
+        Ok(n) if n > 1_048_576 => ParseOutcome::TooLarge,
+        Err(e) => ParseOutcome::IoError(e.to_string()),
+        Ok(_) => match serde_json::from_str(line.trim()) {
+            Ok(v) => ParseOutcome::Ok(v),
+            Err(e) => ParseOutcome::JsonError(e.to_string()),
+        },
+    };
     let request: serde_json::Value = match parse_outcome {
         ParseOutcome::Ok(v) => v,
         ParseOutcome::Empty => return,

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -87,6 +87,14 @@ pub fn atomic_replace(tmp_path: &Path, final_path: &Path) -> io::Result<()> {
     // Step 3: fsync the parent directory so the rename is durable. Best
     // effort — some filesystems do not support opening a directory for
     // fsync; we log at debug and continue.
+    //
+    // PB-V1.30.1-6: skip on Windows. NTFS journals the rename as part of
+    // its own metadata update, and `File::open(directory)` always fails
+    // on Windows (different file model — directories aren't opened the
+    // same way). The doc comment at the top of this fn already promises
+    // this is a no-op on Windows; this `cfg` makes that promise real
+    // instead of generating a debug log on every persisted file.
+    #[cfg(unix)]
     if let Some(parent) = final_path.parent() {
         match std::fs::File::open(parent) {
             Ok(dir) => {

--- a/src/serve/data.rs
+++ b/src/serve/data.rs
@@ -1102,27 +1102,28 @@ pub(crate) fn build_cluster(
 
 /// Pull richer stats than the `Store::base_embedding_count` shortcut.
 /// One query for total chunks + files + call edges + type edges.
+///
+/// PF-V1.30.1-5: collapsed from four sequential `fetch_one` round-trips
+/// into a single SELECT with subqueries. SQLite plans these as parallel
+/// COUNT scans and we save three pool round-trips per `/stats` request.
 pub(crate) fn build_stats(store: &Store<ReadOnly>) -> Result<StatsResponse, StoreError> {
     let _span = tracing::info_span!("build_stats").entered();
 
     store.rt.block_on(async {
-        let chunks_row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM chunks")
-            .fetch_one(&store.pool)
-            .await?;
-        let files_row: (i64,) = sqlx::query_as("SELECT COUNT(DISTINCT origin) FROM chunks")
-            .fetch_one(&store.pool)
-            .await?;
-        let call_row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM function_calls")
-            .fetch_one(&store.pool)
-            .await?;
-        let type_row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM type_edges")
-            .fetch_one(&store.pool)
-            .await?;
+        let row: (i64, i64, i64, i64) = sqlx::query_as(
+            "SELECT \
+                (SELECT COUNT(*) FROM chunks), \
+                (SELECT COUNT(DISTINCT origin) FROM chunks), \
+                (SELECT COUNT(*) FROM function_calls), \
+                (SELECT COUNT(*) FROM type_edges)",
+        )
+        .fetch_one(&store.pool)
+        .await?;
         Ok(StatsResponse {
-            total_chunks: chunks_row.0.max(0) as u64,
-            total_files: files_row.0.max(0) as u64,
-            call_edges: call_row.0.max(0) as u64,
-            type_edges: type_row.0.max(0) as u64,
+            total_chunks: row.0.max(0) as u64,
+            total_files: row.1.max(0) as u64,
+            call_edges: row.2.max(0) as u64,
+            type_edges: row.3.max(0) as u64,
         })
     })
 }


### PR DESCRIPTION
## Summary

P3 Bundle 7 — five platform-behavior cleanups from the v1.30.1 audit (Windows / WSL / Linux daemon-restart).

| ID | What |
|----|------|
| PB-V1.30.1-2 | `--bind localhost` resolution: map `"localhost"` → `"127.0.0.1"` before `parse::<SocketAddr>()` so the documented form works. (Used substring approach over `lookup_host` — DNS at startup would change behavior on disconnected hosts.) |
| PB-V1.30.1-4 | `atomic_replace` parent-dir fsync now `#[cfg(unix)]`-gated. The doc comment already promised "unix only"; now matches reality. |
| PB-V1.30.1-6 | Linux daemon-restart fallback: probe `systemctl --user is-enabled cqs-watch` first; if the unit isn't installed, spawn `cqs watch --serve` directly via `std::env::current_exe()` (preserves SEC-V1.25-7 PATH-hijack guard). Mirrors the macOS branch. stdio nulled on the probe so missing-unit noise doesn't reach the user. |
| PF-V1.30.1-2 | `build_stats` collapses 4 sequential `fetch_one` round-trips into a single `(i64,i64,i64,i64)` query with four `(SELECT ...)` subqueries. |
| RM-1 | Drop `thread_local! REQ_LINE` in `cli/watch/socket.rs`. The premise was wrong — daemon spawns a fresh thread per accept, so the thread_local never reused anything. Replaced with a local `String::with_capacity(8192)`. |

## Test plan

- [x] `cargo check --features cuda-index` — clean
- [x] `cargo clippy --features cuda-index --lib --bin cqs -- -D warnings` — clean
- [x] `cargo fmt` — clean (one cosmetic line-collapse in `model.rs`; no semantic change)
- [x] Targeted tests: 236 pass, 0 fail, 3 ignored (heavy BGE model loads — pre-existing)
  - `serve` lib (91)
  - `fs::` (31)
  - `cli::commands::serve` bin (10 — loopback warning matrix)
  - `cli::watch` bin (69 + 3 ignored)
  - `cli::commands::infra::model` bin (7)
  - `daemon_translate` lib (28)

Built in `CARGO_TARGET_DIR=/home/user001/.cargo-target/cqs-p3-b7` to avoid blocking the parent's target dir.
