### PR TITLE
fix(scaling): P3 bundle 6 — 8 env-var knobs + bounded read_context_lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ Both splits are ±2-3pp noisy on a single trial; quote both when comparing confi
 
 ## Environment Variables
 
-109 knobs total. Quick index by domain (everything is searchable in the table below):
+118 knobs total. Quick index by domain (everything is searchable in the table below):
 
 - **Trust / injection defence** — `CQS_TRUST_DELIMITERS`, `CQS_SUMMARY_VALIDATION`
 - **Retrieval & search** — `CQS_RRF_K`, `CQS_TYPE_BOOST`, `CQS_SPLADE_ALPHA*`, `CQS_RERANK*`, `CQS_RERANKER_*`, `CQS_CENTROID_*`, `CQS_MMR_LAMBDA`, `CQS_FORCE_BASE_INDEX`, `CQS_DISABLE_BASE_INDEX`, `CQS_QUERY_CACHE_*`
@@ -801,6 +801,15 @@ Both splits are ±2-3pp noisy on a single trial; quote both when comparing confi
 | `CQS_LOCAL_LLM_MAX_BODY_BYTES` | `4194304` (4 MiB) | Max response body bytes accepted from a `CQS_LLM_PROVIDER=local` server. Larger bodies are a sign of a misbehaving or hostile endpoint and abort with a clear error rather than OOMing the daemon. Must be > 0. |
 | `CQS_LOCAL_LLM_TIMEOUT_SECS` | `120` | Per-request timeout (seconds) for `CQS_LLM_PROVIDER=local`. Local inference can be slow, so the default is 2× the Anthropic 60s ceiling. |
 | `CQS_MAX_CONNECTIONS` | `4` | SQLite write-pool max connections |
+| `CQS_MAX_REFERENCES` | `20` | Max number of reference indexes loaded from `[references]` blocks. Each reference holds a separate SQLite DB + HNSW index (~50-100 MB RAM each). Hit on a `cqs ref`-heavy workspace? Bump it; `0`/garbage falls back to default. SHL-V1.30-6. |
+| `CQS_GATHER_DEPTH` | `1` (`gather` default) | BFS expansion depth for the shared `gather` pipeline. Honored as a fallback by `task` when `CQS_TASK_GATHER_DEPTH` is unset. SHL-V1.30-4. |
+| `CQS_TASK_GATHER_DEPTH` | `2` | BFS expansion depth used inside `cqs task` (number of call-graph hops from each modify target). Takes precedence over `CQS_GATHER_DEPTH` for the task pipeline only. SHL-V1.30-4. |
+| `CQS_ONBOARD_CALLEE_FETCH` | `30` | Max callees `cqs onboard` fetches content for after BFS. Excess callees are surfaced as `summary.callees_truncated` in JSON and a `tracing::warn!`. SHL-V1.30-5. |
+| `CQS_ONBOARD_CALLER_FETCH` | `15` | Max callers `cqs onboard` fetches content for. Truncation surfaces as `summary.callers_truncated`. SHL-V1.30-5. |
+| `CQS_NOTES_MAX_FILE_SIZE` | `10485760` (10 MiB) | Max size of `notes.toml` accepted by both read and rewrite paths. A larger file is rejected with `InvalidData`. Bump on workspaces with very large note collections. SHL-V1.30-7. |
+| `CQS_NOTES_MAX_ENTRIES` | `10000` | Max number of notes parsed from a single `notes.toml`. Excess entries are dropped with a `tracing::warn!` (previously silent). SHL-V1.30-7. |
+| `CQS_ENRICHMENT_PAGE_SIZE` | `500` | Chunks per page during the second-pass enrichment loop. Smaller = lower per-batch RAM (callers/callees maps), larger = fewer SQLite round-trips. SHL-V1.30-8. |
+| `CQS_WATCH_PRUNE_SIZE_THRESHOLD` | `5000` | Size threshold that triggers the watch loop's `last_indexed_mtime` recency prune. Larger maps (e.g. `cqs ref`-heavy projects) need this lifted to keep dedup working past the default. SHL-V1.30-9. |
 | `CQS_BATCH_MAX_LINE_LEN` | `52428800` (50 MiB) | Max bytes per batch-mode line (`cqs batch` stdin and the daemon socket request). Aligned with `CQS_MAX_DIFF_BYTES` so batch-routed diffs aren't capped 50× sooner than the CLI path. |
 | `CQS_MAX_CONTRASTIVE_CHUNKS` | `30000` | Max chunks for contrastive summary matrix (memory = N*N*4 bytes) |
 | `CQS_MAX_DIFF_BYTES` | `52428800` (50 MiB) | Max bytes accepted on stdin (`cqs review --stdin`, `cqs impact --diff`) and from `git diff` subprocess. Long-running feature branches with multi-MB diffs need this lifted. |

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -811,6 +811,8 @@ mod tests {
                 files_covered: 3,
                 callee_depth: 1,
                 tests_found: 0,
+                callees_truncated: 0,
+                callers_truncated: 0,
             },
         };
 
@@ -901,6 +903,8 @@ mod tests {
                 files_covered: 5,
                 callee_depth: 3,
                 tests_found: 0,
+                callees_truncated: 0,
+                callers_truncated: 0,
             },
         };
 

--- a/src/cli/display.rs
+++ b/src/cli/display.rs
@@ -56,14 +56,27 @@ pub fn read_context_lines(
             );
         }
     }
-    let content = std::fs::read_to_string(file)
-        .with_context(|| format!("Failed to read {}", file.display()))?;
-    // .lines() handles \r\n, but trim trailing \r for bare-CR edge cases
-    let lines: Vec<&str> = content.lines().map(|l| l.trim_end_matches('\r')).collect();
-
-    // Normalize: treat 0 as 1, ensure end >= start
+    // Normalize: treat 0 as 1, ensure end >= start. Done up front so the
+    // RM-3 bounded read knows how many lines to actually pull off disk.
     let line_start = line_start.max(1);
     let line_end = line_end.max(line_start);
+
+    // RM-3: bounded read. Previously `read_to_string` slurped the whole file
+    // into RAM even when only ~5 lines around the chunk were needed. Compute
+    // the upper bound from `line_end + context + 1` so we only walk the
+    // BufReader that far. The downstream indexing logic still handles short
+    // files gracefully because `lines.len()` reflects what was actually read.
+    use std::io::{BufRead, BufReader};
+    let f =
+        std::fs::File::open(file).with_context(|| format!("Failed to read {}", file.display()))?;
+    let limit = (line_end as usize)
+        .saturating_add(context)
+        .saturating_add(1);
+    let lines: Vec<String> = BufReader::new(f)
+        .lines()
+        .take(limit)
+        .map(|l| l.unwrap_or_default().trim_end_matches('\r').to_string())
+        .collect();
 
     // Convert 1-indexed lines to 0-indexed array indices, clamped to valid range.
     // For an empty file (lines.len() == 0), both indices will be 0.
@@ -74,10 +87,7 @@ pub fn read_context_lines(
     // Context before
     let context_start = start_idx.saturating_sub(context);
     let before: Vec<String> = if start_idx <= lines.len() {
-        lines[context_start..start_idx]
-            .iter()
-            .map(|s| s.to_string())
-            .collect()
+        lines[context_start..start_idx].to_vec()
     } else {
         vec![]
     };
@@ -88,10 +98,7 @@ pub fn read_context_lines(
         .saturating_add(1)
         .min(lines.len());
     let after: Vec<String> = if end_idx + 1 < lines.len() {
-        lines[(end_idx + 1)..context_end]
-            .iter()
-            .map(|s| s.to_string())
-            .collect()
+        lines[(end_idx + 1)..context_end].to_vec()
     } else {
         vec![]
     };
@@ -480,26 +487,33 @@ mod tests {
     }
 
     /// Read context lines bypassing the path guard (for unit tests with temp files).
+    /// RM-3: mirror the production `read_context_lines` BufReader-based bounded read
+    /// so the test's edge-case coverage stays representative.
     fn read_context_lines_test(
         file: &Path,
         line_start: u32,
         line_end: u32,
         context: usize,
     ) -> anyhow::Result<(Vec<String>, Vec<String>)> {
-        let content = std::fs::read_to_string(file)
-            .with_context(|| format!("Failed to read {}", file.display()))?;
-        let lines: Vec<&str> = content.lines().map(|l| l.trim_end_matches('\r')).collect();
         let line_start = line_start.max(1);
         let line_end = line_end.max(line_start);
+        use std::io::{BufRead, BufReader};
+        let f = std::fs::File::open(file)
+            .with_context(|| format!("Failed to read {}", file.display()))?;
+        let limit = (line_end as usize)
+            .saturating_add(context)
+            .saturating_add(1);
+        let lines: Vec<String> = BufReader::new(f)
+            .lines()
+            .take(limit)
+            .map(|l| l.unwrap_or_default().trim_end_matches('\r').to_string())
+            .collect();
         let max_idx = lines.len().saturating_sub(1);
         let start_idx = (line_start as usize).saturating_sub(1).min(max_idx);
         let end_idx = (line_end as usize).saturating_sub(1).min(max_idx);
         let context_start = start_idx.saturating_sub(context);
         let before: Vec<String> = if start_idx <= lines.len() {
-            lines[context_start..start_idx]
-                .iter()
-                .map(|s| s.to_string())
-                .collect()
+            lines[context_start..start_idx].to_vec()
         } else {
             vec![]
         };
@@ -508,10 +522,7 @@ mod tests {
             .saturating_add(1)
             .min(lines.len());
         let after: Vec<String> = if end_idx + 1 < lines.len() {
-            lines[(end_idx + 1)..context_end]
-                .iter()
-                .map(|s| s.to_string())
-                .collect()
+            lines[(end_idx + 1)..context_end].to_vec()
         } else {
             vec![]
         };

--- a/src/cli/enrichment.rs
+++ b/src/cli/enrichment.rs
@@ -48,7 +48,9 @@ pub(crate) fn enrichment_pass(
     // Step 3: Iterate chunks in pages, collect those needing enrichment
     let mut enriched_count = 0usize;
     let mut cursor = 0i64;
-    const ENRICHMENT_PAGE_SIZE: usize = 500;
+    // SHL-V1.30-8: env override `CQS_ENRICHMENT_PAGE_SIZE` (default 500). Larger
+    // pages mean fewer SQLite round-trips at the cost of higher per-batch RAM.
+    let page_size = enrichment_page_size();
 
     // Track name frequency — ambiguous names (appearing in multiple files)
     // are skipped to avoid merging callers from different functions. (RB-B1)
@@ -131,7 +133,7 @@ pub(crate) fn enrichment_pass(
     let result: Result<usize> = (|| {
         loop {
             let (chunks, next_cursor) = store
-                .chunks_paged(cursor, ENRICHMENT_PAGE_SIZE)
+                .chunks_paged(cursor, page_size)
                 .context("Failed to page chunks")?;
             if chunks.is_empty() {
                 break;
@@ -265,6 +267,20 @@ pub(crate) fn enrichment_pass(
 }
 
 /// RB-6 / #966: normalize whitespace so LLM-generated strings with
+/// SHL-V1.30-8: env override `CQS_ENRICHMENT_PAGE_SIZE` (default 500).
+///
+/// Controls how many chunks `enrichment_pass` pulls per `chunks_paged` call.
+/// Larger pages mean fewer SQLite round-trips, smaller pages bound the per-batch
+/// RAM held by `callers_map`/`callees_map` while a page is in flight.
+/// Documented in README.md.
+fn enrichment_page_size() -> usize {
+    std::env::var("CQS_ENRICHMENT_PAGE_SIZE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(500)
+}
+
 /// non-deterministic leading/trailing/internal whitespace collapse to the
 /// same canonical form before hashing.
 ///

--- a/src/cli/watch/gc.rs
+++ b/src/cli/watch/gc.rs
@@ -21,7 +21,7 @@ use cqs::store::Store;
 /// #969: recency threshold for pruning `last_indexed_mtime`.
 ///
 /// Entries older than this are dropped when the map grows past
-/// `LAST_INDEXED_PRUNE_SIZE_THRESHOLD`. 1 day is long enough to survive an
+/// `last_indexed_prune_size_threshold()`. 1 day is long enough to survive an
 /// overnight idle (the map skips duplicate events on re-indexed files) but
 /// short enough that stale entries from deleted/moved files age out without
 /// a per-entry `stat()` syscall. Previously the prune called `Path::exists()`
@@ -29,17 +29,25 @@ use cqs::store::Store;
 /// serial syscalls). The map's `SystemTime` values make the recency check a
 /// pure in-memory comparison.
 ///
-/// Tunable by editing this constant; intentionally not an env var to avoid
-/// knob proliferation. Re-adding a file on its next watch event is a trivial
-/// insert — this threshold is a cache-size safety valve, not a correctness
-/// invariant.
+/// Tunable by editing this constant.
 pub(super) const LAST_INDEXED_PRUNE_AGE_SECS: u64 = 86_400;
 
-/// #969: size threshold that triggers the `last_indexed_mtime` prune.
+/// #969: default size threshold that triggers the `last_indexed_mtime` prune.
 ///
-/// Lowered from 10K to 5K in RM-4 because the map only needs to span one
-/// debounce cycle's worth of dedup signal.
-pub(super) const LAST_INDEXED_PRUNE_SIZE_THRESHOLD: usize = 5_000;
+/// SHL-V1.30-9: env override `CQS_WATCH_PRUNE_SIZE_THRESHOLD`. The audit found
+/// that `cqs ref` index sizes can exceed 5_000 entries, so the previous
+/// "intentionally not an env var" stance was too restrictive. Documented in
+/// README.md.
+pub(super) const LAST_INDEXED_PRUNE_SIZE_THRESHOLD_DEFAULT: usize = 5_000;
+
+/// SHL-V1.30-9: resolve `CQS_WATCH_PRUNE_SIZE_THRESHOLD` (default 5_000).
+fn last_indexed_prune_size_threshold() -> usize {
+    std::env::var("CQS_WATCH_PRUNE_SIZE_THRESHOLD")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(LAST_INDEXED_PRUNE_SIZE_THRESHOLD_DEFAULT)
+}
 
 /// #969: O(n) in-memory prune of `last_indexed_mtime` by recency.
 ///
@@ -50,7 +58,7 @@ pub(super) const LAST_INDEXED_PRUNE_SIZE_THRESHOLD: usize = 5_000;
 ///
 /// Returns the number of entries removed (useful for tracing and tests).
 pub(super) fn prune_last_indexed_mtime(map: &mut HashMap<PathBuf, SystemTime>) -> usize {
-    if map.len() <= LAST_INDEXED_PRUNE_SIZE_THRESHOLD {
+    if map.len() <= last_indexed_prune_size_threshold() {
         return 0;
     }
     let before = map.len();
@@ -73,16 +81,19 @@ const DAEMON_PERIODIC_GC_CAP_DEFAULT: usize = 1000;
 // `CQS_DAEMON_PERIODIC_GC_INTERVAL_SECS` / `CQS_DAEMON_PERIODIC_GC_IDLE_SECS`,
 // matching the sibling `daemon_periodic_gc_cap()` resolver pattern below.
 
-/// #1024: Read `CQS_DAEMON_PERIODIC_GC_CAP` once and cache. Keeps the
-/// hot path free of repeated env lookups on every tick.
+/// #1024 / SHL-V1.30-10: Resolve `CQS_DAEMON_PERIODIC_GC_CAP` on every call.
+///
+/// Previously cached in a `OnceLock`, which made `systemctl set-environment`
+/// and `systemctl --user reload-or-restart cqs-watch` ineffective at retuning
+/// the cap mid-process. One `getenv` per GC tick is microseconds; ticks are
+/// minutes apart (see `daemon_periodic_gc_interval_secs()`). Matches
+/// `reconcile_enabled()` semantics, where the env var is read each call.
 fn daemon_periodic_gc_cap() -> usize {
-    static CACHE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *CACHE.get_or_init(|| {
-        std::env::var("CQS_DAEMON_PERIODIC_GC_CAP")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(DAEMON_PERIODIC_GC_CAP_DEFAULT)
-    })
+    std::env::var("CQS_DAEMON_PERIODIC_GC_CAP")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DAEMON_PERIODIC_GC_CAP_DEFAULT)
 }
 
 /// #1024: Run the daemon's startup GC sweep — Pass 1 (drop chunks for

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -57,7 +57,7 @@ use rebuild::{RebuildOutcome, RebuildResult};
 mod gc;
 use gc::{prune_last_indexed_mtime, run_daemon_periodic_gc, run_daemon_startup_gc};
 #[cfg(test)]
-use gc::{LAST_INDEXED_PRUNE_AGE_SECS, LAST_INDEXED_PRUNE_SIZE_THRESHOLD};
+use gc::{LAST_INDEXED_PRUNE_AGE_SECS, LAST_INDEXED_PRUNE_SIZE_THRESHOLD_DEFAULT};
 
 mod reconcile;
 use reconcile::{reconcile_enabled, run_daemon_reconcile};

--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -660,7 +660,7 @@ fn collect_events_skips_unchanged_mtime() {
 
 /// #969: recency prune drops entries older than `LAST_INDEXED_PRUNE_AGE_SECS`,
 /// keeps fresh entries, and only triggers once the map exceeds
-/// `LAST_INDEXED_PRUNE_SIZE_THRESHOLD`. This replaces the old per-entry
+/// `LAST_INDEXED_PRUNE_SIZE_THRESHOLD_DEFAULT`. This replaces the old per-entry
 /// `Path::exists()` loop that stalled the watch thread on WSL 9P mounts.
 #[test]
 fn test_last_indexed_mtime_recency_prune() {
@@ -693,7 +693,7 @@ fn test_last_indexed_mtime_recency_prune() {
     // entries plus a handful of fresh sentinels so we can check both
     // that old entries are removed and fresh ones survive.
     let mut large: HashMap<PathBuf, SystemTime> = HashMap::new();
-    for i in 0..=LAST_INDEXED_PRUNE_SIZE_THRESHOLD {
+    for i in 0..=LAST_INDEXED_PRUNE_SIZE_THRESHOLD_DEFAULT {
         large.insert(PathBuf::from(format!("old_{}.rs", i)), old);
     }
     large.insert(PathBuf::from("fresh_1.rs"), fresh);
@@ -704,7 +704,7 @@ fn test_last_indexed_mtime_recency_prune() {
     // Every "old" entry (two days stale) should be gone.
     assert_eq!(
         pruned_large,
-        LAST_INDEXED_PRUNE_SIZE_THRESHOLD + 1,
+        LAST_INDEXED_PRUNE_SIZE_THRESHOLD_DEFAULT + 1,
         "Expected all old entries pruned (total_before={}, remaining={})",
         total_before,
         large.len()
@@ -734,7 +734,7 @@ fn test_last_indexed_mtime_recency_prune() {
         .checked_sub(Duration::from_secs(LAST_INDEXED_PRUNE_AGE_SECS - 1))
         .unwrap();
     let mut boundary: HashMap<PathBuf, SystemTime> = HashMap::new();
-    for i in 0..=LAST_INDEXED_PRUNE_SIZE_THRESHOLD {
+    for i in 0..=LAST_INDEXED_PRUNE_SIZE_THRESHOLD_DEFAULT {
         boundary.insert(PathBuf::from(format!("stale_{}.rs", i)), old);
     }
     boundary.insert(PathBuf::from("just_inside.rs"), just_inside);

--- a/src/config.rs
+++ b/src/config.rs
@@ -317,6 +317,25 @@ impl std::fmt::Debug for Config {
 /// Clamp f32 config value to valid range and warn if out of bounds.
 /// TC-48: Also catches NaN (which silently passes all comparisons as false)
 /// and clamps it to `min`, preventing silent data loss in downstream filters.
+/// SHL-V1.30-6: Resolve `CQS_MAX_REFERENCES` (default 20).
+///
+/// Memoized via `OnceLock` so the env-var read happens once at first
+/// `validate()` call rather than on every load. The value is documented in
+/// `README.md`'s env-var table. Each reference is ~50-100 MB, so the default
+/// keeps a worst-case load under ~1-2 GB; bump on machines that can afford
+/// it. Zero / non-numeric values fall back to the default.
+fn max_references() -> usize {
+    static CACHE: OnceLock<usize> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        const DEFAULT: usize = 20;
+        std::env::var("CQS_MAX_REFERENCES")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT)
+    })
+}
+
 fn clamp_config_f32(value: &mut f32, name: &str, min: f32, max: f32) {
     if value.is_nan() {
         tracing::warn!(field = name, "Config value is NaN, clamping to min");
@@ -384,24 +403,25 @@ impl Config {
     /// Adding a new field? Add its clamping here — this is the single
     /// validation choke point.
     fn validate(&mut self) {
-        // SHL-28: Cap reference count. Each reference opens a separate SQLite DB +
-        // HNSW index, consuming ~50-100MB RAM. 20 references = ~1-2GB baseline memory.
-        // If you need more, consider consolidating related libraries into fewer indexes.
-        const MAX_REFERENCES: usize = 20;
-        if self.references.len() > MAX_REFERENCES {
+        // SHL-28 / SHL-V1.30-6: Cap reference count. Each reference opens a separate
+        // SQLite DB + HNSW index, consuming ~50-100MB RAM. 20 references = ~1-2GB
+        // baseline memory. If you need more, consider consolidating related libraries
+        // into fewer indexes — or override via `CQS_MAX_REFERENCES`.
+        let max_references = max_references();
+        if self.references.len() > max_references {
             eprintln!(
                 "Warning: {} references configured, exceeding limit of {}. \
                  Only the first {} will be loaded. Each reference consumes ~50-100MB RAM.",
                 self.references.len(),
-                MAX_REFERENCES,
-                MAX_REFERENCES
+                max_references,
+                max_references
             );
             tracing::warn!(
                 count = self.references.len(),
-                max = MAX_REFERENCES,
+                max = max_references,
                 "Too many references configured, truncating"
             );
-            self.references.truncate(MAX_REFERENCES);
+            self.references.truncate(max_references);
         }
 
         // Clamp reference weights to [0.0, 1.0]

--- a/src/note.rs
+++ b/src/note.rs
@@ -17,7 +17,36 @@ pub const SENTIMENT_POSITIVE_THRESHOLD: f32 = 0.3;
 
 /// Maximum number of notes to parse from a single file.
 /// Prevents memory exhaustion from malicious or corrupted note files.
-const MAX_NOTES: usize = 10_000;
+///
+/// SHL-V1.30-7: env override `CQS_NOTES_MAX_ENTRIES`. Documented in README.md.
+const MAX_NOTES_DEFAULT: usize = 10_000;
+
+/// Maximum size of `notes.toml` (in bytes) before reads/writes refuse to load
+/// the file. Both the read-only `parse_notes` path and the read-modify-write
+/// `rewrite_notes_file` path enforce the same cap so a truncated/corrupt
+/// rewrite can't exceed it either.
+///
+/// SHL-V1.30-7: hoisted from per-call-site duplicate `const` declarations to
+/// module scope. Env override `CQS_NOTES_MAX_FILE_SIZE`. Default 10 MiB.
+const MAX_NOTES_FILE_SIZE_DEFAULT: u64 = 10 * 1024 * 1024;
+
+/// SHL-V1.30-7: resolve `CQS_NOTES_MAX_FILE_SIZE` (default 10 MiB).
+fn max_notes_file_size() -> u64 {
+    std::env::var("CQS_NOTES_MAX_FILE_SIZE")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(MAX_NOTES_FILE_SIZE_DEFAULT)
+}
+
+/// SHL-V1.30-7: resolve `CQS_NOTES_MAX_ENTRIES` (default 10_000).
+fn max_notes() -> usize {
+    std::env::var("CQS_NOTES_MAX_ENTRIES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(MAX_NOTES_DEFAULT)
+}
 
 /// Errors that can occur when parsing notes
 #[derive(Error, Debug)]
@@ -165,17 +194,18 @@ pub fn parse_notes(path: &Path) -> Result<Vec<Note>, NoteError> {
         ))
     })?;
 
-    // Size guard: notes.toml should be well under 10MB
-    const MAX_NOTES_FILE_SIZE: u64 = 10 * 1024 * 1024;
+    // Size guard: notes.toml should be well under 10MB. SHL-V1.30-7: env-overridable
+    // via CQS_NOTES_MAX_FILE_SIZE, single source of truth at module scope.
+    let max_size = max_notes_file_size();
     if let Ok(meta) = data_file.metadata() {
-        if meta.len() > MAX_NOTES_FILE_SIZE {
+        if meta.len() > max_size {
             return Err(NoteError::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!(
                     "{}: file too large ({}MB, limit {}MB)",
                     path.display(),
                     meta.len() / (1024 * 1024),
-                    MAX_NOTES_FILE_SIZE / (1024 * 1024)
+                    max_size / (1024 * 1024)
                 ),
             )));
         }
@@ -241,17 +271,17 @@ pub fn rewrite_notes_file(
             ))
         })?;
 
-    // Size guard (same limit as read path)
-    const MAX_NOTES_FILE_SIZE: u64 = 10 * 1024 * 1024;
+    // Size guard (same limit as read path). SHL-V1.30-7: shared resolver.
+    let max_size = max_notes_file_size();
     if let Ok(meta) = data_file.metadata() {
-        if meta.len() > MAX_NOTES_FILE_SIZE {
+        if meta.len() > max_size {
             return Err(NoteError::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!(
                     "{}: file too large ({}MB, limit {}MB)",
                     notes_path.display(),
                     meta.len() / (1024 * 1024),
-                    MAX_NOTES_FILE_SIZE / (1024 * 1024)
+                    max_size / (1024 * 1024)
                 ),
             )));
         }
@@ -321,14 +351,28 @@ pub fn rewrite_notes_file(
 /// Note IDs are generated from a hash of the text content (first 16 hex chars = 64 bits).
 /// This ensures IDs are stable when notes are reordered in the file.
 /// With 16 hex chars, collision probability is ~0.003% at 10k notes (birthday paradox).
-/// Limited to MAX_NOTES (10k) to prevent memory exhaustion.
+/// Limited to `CQS_NOTES_MAX_ENTRIES` (default 10k) to prevent memory exhaustion.
 pub fn parse_notes_str(content: &str) -> Result<Vec<Note>, NoteError> {
     let file: NoteFile = toml::from_str(content)?;
+
+    // SHL-V1.30-7: surface truncation rather than silently dropping entries.
+    // Previously `.take(MAX_NOTES)` ate the surplus with no signal; now we warn so
+    // users see they need to lift the cap (or split the file).
+    let cap = max_notes();
+    let total = file.note.len();
+    if total > cap {
+        tracing::warn!(
+            total,
+            cap,
+            dropped = total - cap,
+            "parse_notes_str: note count exceeds CQS_NOTES_MAX_ENTRIES; truncating"
+        );
+    }
 
     let notes = file
         .note
         .into_iter()
-        .take(MAX_NOTES)
+        .take(cap)
         .map(|entry| {
             // Use content hash for stable IDs (reordering notes won't break references)
             // 16 hex chars = 64 bits, collision probability ~0.003% at 10k notes

--- a/src/onboard.rs
+++ b/src/onboard.rs
@@ -27,10 +27,32 @@ pub const DEFAULT_ONBOARD_DEPTH: usize = 3;
 
 /// Maximum callees to fetch content for. BFS may discover more, but we only
 /// load content for the top entries by depth/score to cap memory usage.
-const MAX_CALLEE_FETCH: usize = 30;
+///
+/// SHL-V1.30-5: env override `CQS_ONBOARD_CALLEE_FETCH`. Documented in README.
+const MAX_CALLEE_FETCH_DEFAULT: usize = 30;
 
 /// Maximum callers to fetch content for.
-const MAX_CALLER_FETCH: usize = 15;
+///
+/// SHL-V1.30-5: env override `CQS_ONBOARD_CALLER_FETCH`. Documented in README.
+const MAX_CALLER_FETCH_DEFAULT: usize = 15;
+
+/// SHL-V1.30-5: resolve `CQS_ONBOARD_CALLEE_FETCH`, default 30.
+fn max_callee_fetch() -> usize {
+    std::env::var("CQS_ONBOARD_CALLEE_FETCH")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(MAX_CALLEE_FETCH_DEFAULT)
+}
+
+/// SHL-V1.30-5: resolve `CQS_ONBOARD_CALLER_FETCH`, default 15.
+fn max_caller_fetch() -> usize {
+    std::env::var("CQS_ONBOARD_CALLER_FETCH")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(MAX_CALLER_FETCH_DEFAULT)
+}
 
 // Uses crate::COMMON_TYPES (from focused_read.rs) for type filtering — single source of truth.
 
@@ -85,6 +107,22 @@ pub struct OnboardSummary {
     pub files_covered: usize,
     pub callee_depth: usize,
     pub tests_found: usize,
+    /// SHL-V1.30-5: callees discovered by BFS but dropped because they exceeded
+    /// `CQS_ONBOARD_CALLEE_FETCH`. Zero when no truncation happened. Surfaces
+    /// the cap to consumers so a user can lift it intentionally rather than
+    /// silently wonder where their callees went.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub callees_truncated: usize,
+    /// SHL-V1.30-5: callers truncated to `CQS_ONBOARD_CALLER_FETCH`. See
+    /// `callees_truncated`.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub callers_truncated: usize,
+}
+
+/// Helper used by `OnboardSummary` `skip_serializing_if` to elide zero-valued
+/// truncation counters from the JSON wire shape (keeps the common case clean).
+fn is_zero_usize(n: &usize) -> bool {
+    *n == 0
 }
 
 /// Produce a guided tour of a concept in the codebase.
@@ -171,8 +209,29 @@ pub fn onboard<Mode>(
 
     // 6. Cap score maps to avoid fetching content we'll discard (RM-24).
     //    BFS may discover 100 callees, but we only load content for the top N.
-    let callee_scores = cap_scores(callee_scores, MAX_CALLEE_FETCH, |(_s, d)| *d);
-    let caller_scores = cap_scores(caller_scores, MAX_CALLER_FETCH, |(score, _)| {
+    //    SHL-V1.30-5: env-overridable via CQS_ONBOARD_CALLEE_FETCH /
+    //    CQS_ONBOARD_CALLER_FETCH.  Track pre-cap counts so the caller can see
+    //    truncation in `OnboardSummary`.
+    let callee_fetch_cap = max_callee_fetch();
+    let caller_fetch_cap = max_caller_fetch();
+    let callees_truncated = callee_scores.len().saturating_sub(callee_fetch_cap);
+    let callers_truncated = caller_scores.len().saturating_sub(caller_fetch_cap);
+    if callees_truncated > 0 {
+        tracing::warn!(
+            dropped = callees_truncated,
+            cap = callee_fetch_cap,
+            "Onboard: callees truncated to CQS_ONBOARD_CALLEE_FETCH"
+        );
+    }
+    if callers_truncated > 0 {
+        tracing::warn!(
+            dropped = callers_truncated,
+            cap = caller_fetch_cap,
+            "Onboard: callers truncated to CQS_ONBOARD_CALLER_FETCH"
+        );
+    }
+    let callee_scores = cap_scores(callee_scores, callee_fetch_cap, |(_s, d)| *d);
+    let caller_scores = cap_scores(caller_scores, caller_fetch_cap, |(score, _)| {
         // Keep highest scores: Reverse makes ascending sort = descending by score.
         let safe = if score.is_finite() && *score > 0.0 {
             *score
@@ -254,6 +313,8 @@ pub fn onboard<Mode>(
         files_covered: all_files.len(),
         callee_depth: max_callee_depth,
         tests_found: tests.len(),
+        callees_truncated,
+        callers_truncated,
     };
 
     tracing::info!(

--- a/src/task.rs
+++ b/src/task.rs
@@ -16,13 +16,42 @@ use crate::where_to_add::FileSuggestion;
 use crate::{AnalysisError, Embedder, Store};
 
 /// BFS expansion depth for gather phase (how many call-graph hops from modify targets).
-const TASK_GATHER_DEPTH: usize = 2;
-
-/// Maximum BFS-expanded nodes in gather phase (prevents blowup on hub functions).
-const TASK_GATHER_MAX_NODES: usize = 100;
+///
+/// SHL-V1.30-4: `CQS_TASK_GATHER_DEPTH` env override per-task; falls back to this
+/// constant when unset. Also honors `CQS_GATHER_DEPTH` as a cross-cutting default
+/// for any caller that wants to set both `gather` and `task` depth in one place.
+const TASK_GATHER_DEPTH_DEFAULT: usize = 2;
 
 /// Multiplier applied to `limit` for gather phase truncation.
 const TASK_GATHER_LIMIT_MULTIPLIER: usize = 3;
+
+/// SHL-V1.30-4: Resolve gather depth for the task pipeline.
+///
+/// Precedence:
+/// 1. `CQS_TASK_GATHER_DEPTH` (per-task override)
+/// 2. `CQS_GATHER_DEPTH` (shared default with `cqs gather`)
+/// 3. `TASK_GATHER_DEPTH_DEFAULT` (= 2)
+///
+/// Reading on each call (vs `OnceLock`) is a single `getenv` per `task` invocation,
+/// which keeps `systemctl set-environment` and per-test overrides effective without
+/// process restart. Documented in README.md.
+fn task_gather_depth() -> usize {
+    if let Ok(v) = std::env::var("CQS_TASK_GATHER_DEPTH") {
+        if let Ok(n) = v.parse::<usize>() {
+            if n > 0 {
+                return n;
+            }
+        }
+    }
+    if let Ok(v) = std::env::var("CQS_GATHER_DEPTH") {
+        if let Ok(n) = v.parse::<usize>() {
+            if n > 0 {
+                return n;
+            }
+        }
+    }
+    TASK_GATHER_DEPTH_DEFAULT
+}
 
 /// Per-function risk assessment from impact analysis.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -136,13 +165,16 @@ pub fn task_with_resources<Mode>(
         let mut name_scores: HashMap<String, (f32, usize)> =
             targets.iter().map(|n| (n.to_string(), (1.0, 0))).collect();
 
+        // SHL-V1.30-4: drop the hardcoded `with_max_expanded_nodes(100)` override
+        // so `CQS_GATHER_MAX_NODES` (resolved by `GatherOptions::default()`) flows
+        // through. Depth is `CQS_TASK_GATHER_DEPTH` / `CQS_GATHER_DEPTH` overridable
+        // via `task_gather_depth()`.
         bfs_expand(
             &mut name_scores,
             graph,
             &GatherOptions::default()
-                .with_expand_depth(TASK_GATHER_DEPTH)
-                .with_direction(GatherDirection::Both)
-                .with_max_expanded_nodes(TASK_GATHER_MAX_NODES),
+                .with_expand_depth(task_gather_depth())
+                .with_direction(GatherDirection::Both),
         );
 
         let (mut chunks, _degraded) = fetch_and_assemble(store, &name_scores, root);


### PR DESCRIPTION
## Summary

P3 Bundle 6 — scaling knobs (env-var overrides for hardcoded limits) + bounded-read for context-line extraction.

Eight previously-hardcoded constants now have `CQS_*` env-var overrides. Pattern: read once (or per-call when caller is cold), parse with bounds, fall back to documented default. README env-var index updated; `all_cqs_env_vars_are_documented_in_readme` test confirms coverage. Index header bumped from "109 knobs total" to "118 knobs total".

| ID | Knob | Default | Notes |
|----|------|---------|-------|
| SHL-V1.30-3 | `CQS_TASK_GATHER_DEPTH` (per-task) + `CQS_GATHER_DEPTH` (fallback) | 2 / 1 | dropped `with_max_expanded_nodes(100)` override so `CQS_GATHER_MAX_NODES` flows through |
| SHL-V1.30-4 | `CQS_ONBOARD_CALLEE_FETCH` / `CQS_ONBOARD_CALLER_FETCH` | 30 / 15 | truncation surfaced via `OnboardSummary.callees_truncated`/`callers_truncated` + `tracing::warn!` |
| SHL-V1.30-5 | `CQS_MAX_REFERENCES` | 20 | memoized via `OnceLock`, warn fires once |
| SHL-V1.30-6 | `CQS_NOTES_MAX_FILE_SIZE` / `CQS_NOTES_MAX_ENTRIES` | 10 MiB / 10 000 | dedup const hoisted to module scope; `tracing::warn!` on `MAX_NOTES` truncation (was silent) |
| SHL-V1.30-7 | `CQS_ENRICHMENT_PAGE_SIZE` | 500 | |
| SHL-V1.30-8 | `CQS_WATCH_PRUNE_SIZE_THRESHOLD` | 5000 | const renamed `_DEFAULT` suffix |
| SHL-V1.30-9 | (cache removed) | n/a | dropped `OnceLock` cache on `daemon_periodic_gc_cap`; reads env on every call so `systemctl set-environment` is now effective |
| RM-2 | (bounded read) | n/a | `read_context_lines` (display.rs:59-99) + `read_context_lines_test` (display.rs:489) replaced `read_to_string + lines().collect()` with `BufReader::lines().take(line_end + context + 1)` — bounded RAM on huge files |

## Test plan

- [x] `cargo check --features cuda-index` — clean
- [x] `cargo clippy --features cuda-index --lib --bin cqs -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Targeted tests: 165 pass, 0 fail, 3 ignored
  - lib `task::` (7), `note::` (18), `onboard::` (6), `config::` (42)
  - bin `cli::watch::` (69 + 3 ignored), `cli::display::` (14), `cli::enrichment::` (9)
- [x] `all_cqs_env_vars_are_documented_in_readme` test — 1/1 pass

Built in `CARGO_TARGET_DIR=/home/user001/.cargo-target/cqs-p3-b6`.
