### PR TITLE
fix(serve+auth+ref): P3 bundle 3 — auth + serve hardening

### DIFF
--- a/src/cli/commands/infra/reference.rs
+++ b/src/cli/commands/infra/reference.rs
@@ -131,7 +131,14 @@ fn cmd_ref_add(
     let source = dunce::canonicalize(source)
         .map_err(|e| anyhow::anyhow!("Source path '{}' not found: {}", source.display(), e))?;
 
-    // Create reference directory with restrictive permissions
+    // Create reference directory with restrictive permissions.
+    // SEC-V1.30.1-9: walk every parent that `create_dir_all` may have
+    // freshly created and chmod each to 0o700. Without this, the
+    // `~/.local/share/cqs/refs/` chain inherits the user's umask
+    // (typically 0o022 → 0o755), so `~/.local/share/cqs/refs/` itself
+    // is world-readable and a co-located user can `ls` the names of
+    // every reference index. The leaf `ref_dir` was already chmod-ed;
+    // this extends the same guarantee one level up.
     let ref_dir = reference::ref_path(name)
         .ok_or_else(|| anyhow::anyhow!("Could not determine reference storage directory"))?;
     std::fs::create_dir_all(&ref_dir)
@@ -141,6 +148,20 @@ fn cmd_ref_add(
         use std::os::unix::fs::PermissionsExt;
         if let Err(e) = std::fs::set_permissions(&ref_dir, std::fs::Permissions::from_mode(0o700)) {
             tracing::debug!(path = %ref_dir.display(), error = %e, "Failed to set file permissions");
+        }
+        // SEC-V1.30.1-9: also chmod `~/.local/share/cqs/refs/` so the
+        // index *names* (one per ref subdir) aren't readable by other
+        // users on a multi-user host.
+        if let Some(refs_root) = ref_dir.parent() {
+            if let Err(e) =
+                std::fs::set_permissions(refs_root, std::fs::Permissions::from_mode(0o700))
+            {
+                tracing::debug!(
+                    path = %refs_root.display(),
+                    error = %e,
+                    "Failed to chmod refs root to 0o700",
+                );
+            }
         }
     }
     let db_path = ref_dir.join(cqs::INDEX_DB_FILENAME);
@@ -185,6 +206,34 @@ fn cmd_ref_add(
     if let Some(count) = build_hnsw_index(&store, &ref_dir)? {
         if !cli.quiet && !json {
             println!("  HNSW: {} vectors", count);
+        }
+    }
+
+    // SEC-V1.30.1-10: chmod 0o600 on every file in `ref_dir` (DB, WAL,
+    // SHM, HNSW snapshot). Mirrors the `cqs export-model` pattern for
+    // `model.toml`. Without this, the per-user umask leaks the index
+    // contents to other users on a multi-user host. Best-effort —
+    // failures are logged at debug, not surfaced; the directory is
+    // already 0o700 from the parent block, so file-mode failures
+    // can't widen exposure beyond the per-user default.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for entry in std::fs::read_dir(&ref_dir).into_iter().flatten().flatten() {
+            if let Ok(meta) = entry.metadata() {
+                if meta.is_file() {
+                    let path = entry.path();
+                    if let Err(e) =
+                        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                    {
+                        tracing::debug!(
+                            path = %path.display(),
+                            error = %e,
+                            "Failed to chmod reference file to 0o600",
+                        );
+                    }
+                }
+            }
         }
     }
 

--- a/src/cli/commands/serve.rs
+++ b/src/cli/commands/serve.rs
@@ -3,28 +3,11 @@
 //! Thin CLI wrapper around `cqs::serve::run_server`. Resolves the
 //! project's read-only store and binds the requested address.
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
 
 use crate::cli::find_project_root;
-
-/// Decide whether `cqs serve --no-auth --bind <bind>` should emit the
-/// "non-loopback exposure" warning.
-///
-/// PB-V1.30.1-1: returns `true` when `bind` resolves to anything that
-/// is NOT a loopback address. Subsumes `0.0.0.0` and `::`
-/// (IPv4/IPv6 UNSPECIFIED — the most exposed bind targets), concrete
-/// LAN IPs, and hostnames that don't loop back. Parse-failure
-/// (e.g. "localhost") falls through to the explicit name check so the
-/// previous behavior on the literal hostname is preserved.
-pub(crate) fn serve_warn_no_auth_exposure(bind: &str) -> bool {
-    let is_loopback = match bind.parse::<IpAddr>() {
-        Ok(ip) => ip.is_loopback(),
-        Err(_) => matches!(bind, "localhost"),
-    };
-    !is_loopback
-}
 
 /// Entry point for `cqs serve`. Dispatched from `src/cli/dispatch.rs`.
 ///
@@ -34,34 +17,25 @@ pub(crate) fn serve_warn_no_auth_exposure(bind: &str) -> bool {
 /// * `open` — open the system browser on start (token-aware URL)
 /// * `no_auth` — disable per-launch auth (#1096); back-compat opt-out
 ///   for scripted automation, with loud-warning banner on boot
+///
+/// CQ-V1.30.1-6: the CLI-side "non-loopback + --no-auth" warning was
+/// removed; `serve/mod.rs::run_server` already emits an unconditional
+/// `WARN: --no-auth in use` on the listening banner. Carrying both
+/// surfaces was redundant and the CLI-side variant masked the most
+/// common footgun (localhost + --no-auth) by staying silent.
 pub(crate) fn cmd_serve(port: u16, bind: String, open: bool, no_auth: bool) -> Result<()> {
     let _span = tracing::info_span!("cmd_serve", port, bind = %bind, open, no_auth).entered();
 
-    // #1096 + PB-V1.30.1-1: warn loudly only when --no-auth is paired
-    // with a non-loopback bind. With auth on, non-loopback binds are
-    // fine — every request is gated by the token. The legacy
-    // unconditional warning misled operators into thinking any LAN
-    // bind was insecure. The substring check it replaced silently
-    // accepted `0.0.0.0` and `::` (UNSPECIFIED — the most exposed
-    // bind targets of all); `serve_warn_no_auth_exposure` parses the
-    // bind once with `IpAddr::is_loopback()` so wildcard binds now
-    // trigger the warning explicitly.
-    if no_auth && serve_warn_no_auth_exposure(&bind) {
-        tracing::warn!(
-            bind = %bind,
-            "binding cqs serve to non-localhost without auth — anyone with network \
-             access to this address can read the index"
-        );
-        eprintln!(
-            "WARN: --bind {bind} with --no-auth exposes cqs serve beyond localhost \
-             with no authentication"
-        );
-    }
+    // CQ-V1.30.1-6: CLI-side `--no-auth` warning dropped — `serve/mod.rs::run_server`
+    // emits an unconditional `WARN: --no-auth in use` on the listening banner, plus
+    // a structured `tracing::error!` regardless of `quiet`, plus loud-warn for the
+    // non-loopback case (#1118 / SEC-7 + PB-V1.30.1-1 in #1206). Carrying both
+    // surfaces was redundant.
 
     // PB-V1.30.1-2: resolve "localhost" to 127.0.0.1 before parse, since
-    // `SocketAddr::parse` only accepts numeric IPs. The CLI docs (and the
-    // loopback warning above) treat "localhost" as a valid bind value;
-    // without this resolution the literal hostname would always fail.
+    // `SocketAddr::parse` only accepts numeric IPs. CLI docs treat "localhost"
+    // as a valid bind value; without this resolution the literal hostname
+    // would always fail.
     let bind_str: &str = if bind == "localhost" {
         "127.0.0.1"
     } else {
@@ -160,75 +134,4 @@ fn open_browser(url: &str) -> Result<()> {
             .with_context(|| format!("Failed to spawn {cmd} {url}"))?;
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // PB-V1.30.1-1: loopback IPv4 — no warning.
-    #[test]
-    fn no_warn_on_ipv4_loopback() {
-        assert!(!serve_warn_no_auth_exposure("127.0.0.1"));
-    }
-
-    // PB-V1.30.1-1: arbitrary loopback IPv4 (127.0.0.0/8) — no warning.
-    #[test]
-    fn no_warn_on_ipv4_loopback_range() {
-        assert!(!serve_warn_no_auth_exposure("127.1.2.3"));
-    }
-
-    // PB-V1.30.1-1: loopback IPv6 — no warning.
-    #[test]
-    fn no_warn_on_ipv6_loopback() {
-        assert!(!serve_warn_no_auth_exposure("::1"));
-    }
-
-    // PB-V1.30.1-1: literal hostname "localhost" — no warning.
-    // Resolves to 127.0.0.1 in practice, parse falls through to the
-    // explicit name check so we preserve the legacy behavior.
-    #[test]
-    fn no_warn_on_localhost_name() {
-        assert!(!serve_warn_no_auth_exposure("localhost"));
-    }
-
-    // PB-V1.30.1-1 (regression): IPv4 wildcard (0.0.0.0) — warning fires.
-    // The legacy substring check silently accepted this string.
-    #[test]
-    fn warn_on_ipv4_wildcard() {
-        assert!(serve_warn_no_auth_exposure("0.0.0.0"));
-    }
-
-    // PB-V1.30.1-1 (regression): IPv6 unspecified (::) — warning fires.
-    #[test]
-    fn warn_on_ipv6_unspecified_short() {
-        assert!(serve_warn_no_auth_exposure("::"));
-    }
-
-    // PB-V1.30.1-1 (regression): IPv6 unspecified (::0) — warning fires.
-    #[test]
-    fn warn_on_ipv6_unspecified_explicit() {
-        assert!(serve_warn_no_auth_exposure("::0"));
-    }
-
-    // PB-V1.30.1-1: concrete LAN IP — warning fires (existing behavior).
-    #[test]
-    fn warn_on_lan_ip() {
-        assert!(serve_warn_no_auth_exposure("192.168.1.5"));
-    }
-
-    // PB-V1.30.1-1: arbitrary hostname that's not "localhost" —
-    // warning fires (we can't resolve at warn-time, conservative is fail-closed).
-    #[test]
-    fn warn_on_arbitrary_hostname() {
-        assert!(serve_warn_no_auth_exposure("server.lan"));
-    }
-
-    // PB-V1.30.1-1: empty bind — falls through, warns. Defensive
-    // behavior: an empty string can't be a loopback, so don't suppress
-    // the warning.
-    #[test]
-    fn warn_on_empty_bind() {
-        assert!(serve_warn_no_auth_exposure(""));
-    }
 }

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -1837,4 +1837,167 @@ mod tests {
         // DefaultHasher's variable-length unpadded output.
         assert_eq!(expected_hex.len(), 16, "BLAKE3 truncation must be 8 bytes");
     }
+
+    // ===== TC-ADV-1.30.1: daemon-side adversarial pins =====
+    //
+    // Each test pins CURRENT behavior so a future fix produces a clear
+    // inversion target. The two `daemon_status_handles_err_envelope_*`
+    // tests pin the somewhat-ugly "daemon error: daemon error" doubled
+    // string that today's fallback produces; future work should
+    // surface the raw envelope in the error message.
+
+    /// TC-ADV-1.30.1-8: `{"status":"err"}` with no `message` field. The
+    /// fallback path uses the literal `"daemon error"` string for the
+    /// missing message, then thiserror's `Display` prefixes with
+    /// `"daemon error: "` — yielding the awkward doubled
+    /// `"daemon error: daemon error"`. Pin so a future fix that
+    /// surfaces the raw envelope (or a less-confusing fallback) trips
+    /// this test.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(daemon_socket_xdg)]
+    fn daemon_status_handles_err_envelope_with_no_message() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        // SAFETY: see daemon_status_mock_round_trip.
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", dir.path());
+        }
+
+        let sock_path = daemon_socket_path(&cqs_dir);
+        let listener = UnixListener::bind(&sock_path).unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut req = String::new();
+            BufReader::new(&stream).read_line(&mut req).unwrap();
+            // Err envelope with no `message` field at all.
+            writeln!(stream, r#"{{"status":"err"}}"#).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let result = daemon_status(&cqs_dir);
+        handle.join().unwrap();
+        let _ = std::fs::remove_file(&sock_path);
+
+        // SAFETY: see above.
+        unsafe {
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+
+        match result {
+            Err(DaemonRpcError::DaemonError(msg)) => {
+                // CURRENT behavior: bare "daemon error" placeholder.
+                assert_eq!(
+                    msg, "daemon error",
+                    "today's fallback uses the literal placeholder; future fix should \
+                     surface the raw envelope or upgrade to a BadResponse variant",
+                );
+                // The full as_message() string today is the doubled form.
+                let rendered = DaemonRpcError::DaemonError(msg).as_message();
+                assert_eq!(
+                    rendered, "daemon error: daemon error",
+                    "today's wire-format string is the doubled fallback — \
+                     future fix should produce a less-confusing rendering",
+                );
+            }
+            other => panic!("expected DaemonError(\"daemon error\") today, got: {other:?}",),
+        }
+    }
+
+    /// TC-ADV-1.30.1-9: `{"status":"err","message": 42}` (non-string
+    /// message). `as_str()` returns None → falls back to the same
+    /// `"daemon error"` placeholder as the no-message case. Pin both
+    /// the variant and the fact that the integer payload is silently
+    /// dropped, so future work that surfaces the type mismatch
+    /// has a clear inversion target.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(daemon_socket_xdg)]
+    fn daemon_status_handles_err_envelope_with_non_string_message() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        // SAFETY: see daemon_status_mock_round_trip.
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", dir.path());
+        }
+
+        let sock_path = daemon_socket_path(&cqs_dir);
+        let listener = UnixListener::bind(&sock_path).unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut req = String::new();
+            BufReader::new(&stream).read_line(&mut req).unwrap();
+            // Non-string message: integer 42.
+            writeln!(stream, r#"{{"status":"err","message":42}}"#).unwrap();
+            stream.flush().unwrap();
+        });
+
+        let result = daemon_status(&cqs_dir);
+        handle.join().unwrap();
+        let _ = std::fs::remove_file(&sock_path);
+
+        // SAFETY: see above.
+        unsafe {
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+
+        match result {
+            Err(DaemonRpcError::DaemonError(msg)) => {
+                // CURRENT behavior: silent fallback. The 42 is dropped.
+                assert_eq!(
+                    msg, "daemon error",
+                    "non-string message payload is silently dropped by `as_str()`; \
+                     future fix should surface the shape mismatch as a BadResponse",
+                );
+            }
+            other => panic!("expected DaemonError(\"daemon error\") today, got: {other:?}",),
+        }
+    }
+
+    /// TC-ADV-1.30.1-10: `unwrap_dispatch_payload` does NOT distinguish
+    /// envelope-with-`data:null`-and-error from a bare-payload null. The
+    /// current code only checks for the *presence* of a `data` key and
+    /// returns whatever it finds, so an envelope advertising
+    /// `{"data": null, "error": "internal"}` round-trips as
+    /// `Ok(Value::Null)` rather than surfacing the `error` field. Pin
+    /// today's behavior — future work that propagates `error` from the
+    /// envelope has a clear inversion target.
+    #[test]
+    fn unwrap_dispatch_payload_distinguishes_envelope_no_data_from_bare_form() {
+        let v = serde_json::json!({"data": null, "error": "internal", "version": 1});
+        let result = unwrap_dispatch_payload(&v, "TestType");
+        // CURRENT behavior: returns Ok(Null), silently dropping `error`.
+        // The future fix should surface `error` as `Err(_)` — when it
+        // lands, this assertion inverts to `assert!(result.is_err())`.
+        assert!(
+            result.is_ok(),
+            "today's helper passes through `data: null` even when an `error` field \
+             is present alongside; future fix should surface that as Err",
+        );
+        assert_eq!(
+            result.unwrap(),
+            serde_json::Value::Null,
+            "the data:null payload is returned verbatim; the error field is dropped",
+        );
+    }
 }

--- a/src/serve/auth.rs
+++ b/src/serve/auth.rs
@@ -275,13 +275,42 @@ fn strip_token_param(uri: &Uri) -> String {
     }
 }
 
+/// Low-cardinality classification for a 401 rejection. Surfaced on the
+/// `enforce_auth` rejection warn (OB-V1.30.1-5) so operators can
+/// distinguish "client sent nothing" from "client sent a stale or
+/// wrong-channel credential" without logging the actual material.
+///
+/// Cardinality is fixed at four — the variants cover every channel
+/// `check_request` inspects, so the journal's reason-cardinality stays
+/// bounded regardless of traffic shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UnauthorizedReason {
+    /// No `Authorization`, no cookie, no `?token=…` query param. The
+    /// request sent zero auth channels — most often a fresh tab hitting
+    /// the bind address with no token.
+    MissingAll,
+    /// `Authorization: Bearer <…>` header present but the value didn't
+    /// match (after the strict `"Bearer "` prefix strip).
+    BearerMismatch,
+    /// `Cookie: cqs_token_<port>=<…>` present but the value didn't
+    /// match. Typically a stale cookie from a previous launch — the
+    /// per-launch token rotates on every `cqs serve` restart.
+    CookieMismatch,
+    /// `?token=<…>` query param present but the value didn't match.
+    QueryParamMismatch,
+}
+
 /// Extract the token from one of three channels — header, cookie,
 /// or query string — and constant-time-compare against the launched
 /// token. AC-V1.30.1-5: even when Bearer or cookie matches, if a
 /// `token=` query param is also present, return `OkViaQueryParam` so
 /// the caller redirects to the clean URL — leaving a stale `?token=`
 /// in the URL bar is the exact SEC-7 leakage path the redirect closes.
-fn check_request(req: &Request, expected: &AuthToken, cookie_name: &str) -> AuthOutcome {
+///
+/// PF-V1.30.1-6: `cookie_lookup_needle` is the pre-built `cqs_token_<port>=`
+/// string from [`AuthMiddlewareState`]. Passed in by reference so the
+/// happy path doesn't `format!()` per request.
+fn check_request(req: &Request, expected: &AuthToken, cookie_lookup_needle: &str) -> AuthOutcome {
     // Sniff for any `?token=…` first — if present, we want to redirect
     // even when another channel also matches. Validity of the query
     // value isn't required for the redirect; the redirect's only job
@@ -292,6 +321,13 @@ fn check_request(req: &Request, expected: &AuthToken, cookie_name: &str) -> Auth
         .is_some_and(|q| q.split('&').any(pair_key_is_token));
 
     // 1. Authorization: Bearer …
+    // OB-V1.30.1-5: track presence + match separately so the 401 path
+    // can attribute the failure to the specific channel the client used.
+    let bearer_attempted = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.starts_with("Bearer "));
     let bearer_ok = req
         .headers()
         .get(header::AUTHORIZATION)
@@ -303,16 +339,25 @@ fn check_request(req: &Request, expected: &AuthToken, cookie_name: &str) -> Auth
     // pairs separated by `; `. We don't bother with quoted values —
     // the server only ever sets this cookie itself and never quotes
     // it. Cookie name is per-port (#1135) so two cqs serve instances
-    // on the same host don't collide in the browser jar.
-    let cookie_ok = req
+    // on the same host don't collide in the browser jar. PF-V1.30.1-6:
+    // `cookie_lookup_needle` is pre-built (`cqs_token_<port>=`) so the
+    // scan never allocates.
+    let cookie_header_str = req
         .headers()
         .get(header::COOKIE)
-        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.to_str().ok());
+    let cookie_attempted = cookie_header_str
         .map(|cookie_header| {
-            let needle = format!("{cookie_name}=");
+            cookie_header
+                .split(';')
+                .any(|pair| pair.trim().starts_with(cookie_lookup_needle))
+        })
+        .unwrap_or(false);
+    let cookie_ok = cookie_header_str
+        .map(|cookie_header| {
             cookie_header.split(';').any(|pair| {
                 pair.trim()
-                    .strip_prefix(&needle)
+                    .strip_prefix(cookie_lookup_needle)
                     .is_some_and(|value| ct_eq(value, expected.as_str()))
             })
         })
@@ -332,7 +377,23 @@ fn check_request(req: &Request, expected: &AuthToken, cookie_name: &str) -> Auth
     });
 
     if !(bearer_ok || cookie_ok || query_ok) {
-        return AuthOutcome::Unauthorized;
+        // OB-V1.30.1-5: pick the most-specific reason. Priority: if
+        // *any* channel was attempted, attribute to the strongest one
+        // first (Bearer > Cookie > Query) — operators chasing a
+        // misconfigured automation client see the channel they were
+        // pointing at. If no channel was attempted, fall through to
+        // MissingAll so the journal distinguishes "fresh tab without
+        // token" from "client sent stale credentials".
+        let reason = if bearer_attempted {
+            UnauthorizedReason::BearerMismatch
+        } else if cookie_attempted {
+            UnauthorizedReason::CookieMismatch
+        } else if query_has_token_param {
+            UnauthorizedReason::QueryParamMismatch
+        } else {
+            UnauthorizedReason::MissingAll
+        };
+        return AuthOutcome::Unauthorized(reason);
     }
 
     // AC-V1.30.1-5: presence of `?token=…` (any case-folded form) on a
@@ -355,17 +416,49 @@ enum AuthOutcome {
     /// 302-redirect to the same URL with the token stripped.
     OkViaQueryParam,
     /// No token matched. Reject with 401.
-    Unauthorized,
+    /// OB-V1.30.1-5: carries a reason classification so the rejection
+    /// warn can distinguish "no auth at all" from "stale credential" /
+    /// "wrong channel" without logging the material itself.
+    Unauthorized(UnauthorizedReason),
 }
 
 /// State plumbed into the auth middleware. Holds the per-launch
-/// [`AuthToken`] **and** the bind port so the cookie name can be
-/// scoped per-instance (#1135). Cloned cheaply on every request —
-/// `AuthToken` is `Arc<String>` and `u16` is plain stack data.
+/// [`AuthToken`] and the pre-built cookie strings. Cloned cheaply on
+/// every request — `AuthToken` is `Arc<String>` and the cookie strings
+/// are `Arc<str>`.
+///
+/// PF-V1.30.1-6 (subsumes RM-6, RM-7): pre-build the cookie name
+/// (`cqs_token_<port>`) and the lookup needle (`cqs_token_<port>=`)
+/// at construction time. The auth happy path on every request is
+/// then zero-allocation — both forms are borrowed out of the state.
+/// `cookie_port` was dropped from the struct because it's only needed
+/// at construction time; persisting it forced [`enforce_auth`] to
+/// re-derive the cookie name on every request.
 #[derive(Clone, Debug)]
 pub(crate) struct AuthMiddlewareState {
     pub(crate) token: AuthToken,
-    pub(crate) cookie_port: u16,
+    /// Full cookie name, computed once: `cqs_token_<port>`.
+    pub(crate) cookie_name: Arc<str>,
+    /// Lookup needle, computed once: `cqs_token_<port>=`. Used by
+    /// [`check_request`] when scanning the `Cookie:` header for the
+    /// per-launch entry. Pre-formatted so the per-request hot path
+    /// doesn't allocate.
+    pub(crate) cookie_lookup_needle: Arc<str>,
+}
+
+impl AuthMiddlewareState {
+    /// Construct from a launched token + bind port. Builds the cookie
+    /// name and lookup needle once, so the per-request middleware path
+    /// is allocation-free.
+    pub(crate) fn new(token: AuthToken, cookie_port: u16) -> Self {
+        let cookie_name = cookie_name_for_port(cookie_port);
+        let cookie_lookup_needle = format!("{cookie_name}=");
+        Self {
+            token,
+            cookie_name: Arc::from(cookie_name.as_str()),
+            cookie_lookup_needle: Arc::from(cookie_lookup_needle.as_str()),
+        }
+    }
 }
 
 /// axum middleware: enforce per-launch token on every request.
@@ -381,8 +474,7 @@ pub(crate) async fn enforce_auth(
     req: Request,
     next: Next,
 ) -> Response<Body> {
-    let cookie_name = cookie_name_for_port(state.cookie_port);
-    match check_request(&req, &state.token, &cookie_name) {
+    match check_request(&req, &state.token, &state.cookie_lookup_needle) {
         AuthOutcome::Ok => next.run(req).await,
         AuthOutcome::OkViaQueryParam => {
             let clean_uri = strip_token_param(req.uri());
@@ -396,7 +488,8 @@ pub(crate) async fn enforce_auth(
             // from sticking, defeating the handoff. Cookie name is
             // per-port (#1135) so concurrent instances don't collide.
             let cookie = format!(
-                "{cookie_name}={}; Path=/; HttpOnly; SameSite=Strict",
+                "{}={}; Path=/; HttpOnly; SameSite=Strict",
+                state.cookie_name,
                 state.token.as_str()
             );
             // The token alphabet is enforced at construction time
@@ -413,15 +506,17 @@ pub(crate) async fn enforce_auth(
             resp.headers_mut().insert(header::SET_COOKIE, value);
             resp
         }
-        AuthOutcome::Unauthorized => {
+        AuthOutcome::Unauthorized(reason) => {
             // Body intentionally minimal: no debug data, no token-
             // length leak. Tracing emits method + path (NOT query
-            // string — that may carry `?token=` candidates) so
-            // operators get a journal trail for 401s without
-            // logging token material. (P1.21 / OB-V1.30-2.)
+            // string — that may carry `?token=` candidates) plus the
+            // low-cardinality `reason` (OB-V1.30.1-5) so operators get
+            // a journal trail for 401s without logging token material.
+            // (P1.21 / OB-V1.30-2.)
             tracing::warn!(
                 method = %req.method(),
                 path = %req.uri().path(),
+                reason = ?reason,
                 "serve: rejected unauthenticated request",
             );
             (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
@@ -665,9 +760,11 @@ mod tests {
             .uri("/api/graph?Token=secretvalue")
             .body(axum::body::Body::empty())
             .unwrap();
-        match check_request(&req, &token, &cookie_name_for_port(8080)) {
+        // PF-V1.30.1-6: tests pass the pre-built lookup needle directly.
+        let needle = format!("{}=", cookie_name_for_port(8080));
+        match check_request(&req, &token, &needle) {
             AuthOutcome::OkViaQueryParam => {}
-            AuthOutcome::Ok | AuthOutcome::Unauthorized => {
+            AuthOutcome::Ok | AuthOutcome::Unauthorized(_) => {
                 panic!(
                     "post-fix expectation: case-folded `Token=` matches and the redirect path fires"
                 );
@@ -686,7 +783,222 @@ mod tests {
             .header(header::COOKIE, format!("{cookie_name}={}", token.as_str()))
             .body(axum::body::Body::empty())
             .unwrap();
-        let outcome = check_request(&req, &token, cookie_name);
+        // PF-V1.30.1-6: `check_request` takes the pre-built lookup needle
+        // (`<cookie_name>=`) instead of `cookie_name` itself.
+        let needle = format!("{cookie_name}=");
+        let outcome = check_request(&req, &token, &needle);
         assert!(matches!(outcome, AuthOutcome::OkViaQueryParam));
+    }
+
+    // ===== TC-ADV-1.30.1: adversarial pins for `try_from_string` length,
+    // cookie/query interaction, duplicate-cookie handling, and Bearer
+    // grammar strictness. Each test pins CURRENT behavior — the
+    // `*_today` suffix marks tests that should invert when the audit
+    // finding is closed.
+
+    /// TC-ADV-1.30.1-1: `try_from_string` accepts a 10K-char alphabet input
+    /// today. No `MAX_TOKEN_LEN` cap exists. Pin so a future cap addition
+    /// trips the test (then invert to expect `Err`).
+    #[test]
+    fn try_from_string_accepts_long_alphabet_input_today() {
+        let long = "a".repeat(10_240);
+        assert!(
+            AuthToken::try_from_string(long).is_ok(),
+            "no MAX_TOKEN_LEN cap exists today; long alphabet inputs accepted"
+        );
+    }
+
+    /// TC-ADV-1.30.1-2: when a `?token=…` query param is present alongside
+    /// a valid cookie, AC-V1.30.1-5 forces the redirect path (cookie does
+    /// NOT win — the redirect's job is to scrub the URL bar). Pin current
+    /// behavior. The prompt name in the audit fixture asserted the OLD
+    /// "cookie wins" semantics; the actual landed fix is "any `?token=`
+    /// triggers redirect", so the test name reflects the real shape.
+    #[test]
+    fn auth_query_present_cookie_right_redirects_to_scrub_url_bar() {
+        // Right cookie value, garbage `?token=…` value: still redirects.
+        // The redirect is the only path that strips the URL-bar token.
+        let token = AuthToken::try_from_string("rightvalue").expect("test alphabet");
+        let cookie_name = "cqs_token_8080";
+        let needle = format!("{cookie_name}=");
+        let req = Request::builder()
+            .uri("/api/graph?token=wrong")
+            .header(header::COOKIE, format!("{cookie_name}={}", token.as_str()))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        match check_request(&req, &token, &needle) {
+            AuthOutcome::OkViaQueryParam => { /* expected: redirect path */ }
+            AuthOutcome::Ok => panic!(
+                "expected OkViaQueryParam (any `?token=` triggers redirect, AC-V1.30.1-5), \
+                 got Ok"
+            ),
+            AuthOutcome::Unauthorized(reason) => {
+                panic!("expected OkViaQueryParam, got Unauthorized({reason:?})")
+            }
+        }
+    }
+
+    /// TC-ADV-1.30.1-3: wrong cookie value + right query token → redirect
+    /// (cookie value mismatch is irrelevant — the query channel
+    /// authenticates and the redirect overwrites the cookie). Pins
+    /// current behavior; if a future fix routes wrong-cookie+right-query
+    /// to a 401 (e.g. fail-closed instead of fail-into-redirect), this
+    /// test inverts.
+    #[test]
+    fn auth_query_right_cookie_wrong_redirects_and_overwrites_cookie() {
+        let token = AuthToken::try_from_string("rightvalue").expect("test alphabet");
+        let cookie_name = "cqs_token_8080";
+        let needle = format!("{cookie_name}=");
+        let req = Request::builder()
+            .uri(format!("/api/graph?token={}", token.as_str()))
+            .header(header::COOKIE, format!("{cookie_name}=wrongvalue"))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let outcome = check_request(&req, &token, &needle);
+        assert!(
+            matches!(outcome, AuthOutcome::OkViaQueryParam),
+            "right-query overrides wrong-cookie + redirects to scrub the URL bar"
+        );
+    }
+
+    /// TC-ADV-1.30.1-4: two cookies with the same name in one `Cookie:`
+    /// header. RFC 6265 says order is arbitrary; current code uses
+    /// `.any(...)`, so ANY matching pair authenticates regardless of
+    /// position. Pin actual behavior — the prompt's "first-wins"
+    /// framing was inverted.
+    #[test]
+    fn auth_two_cookies_with_same_name_any_match_authenticates() {
+        let token = AuthToken::try_from_string("rightvalue").expect("test alphabet");
+        let cookie_name = "cqs_token_8080";
+        let needle = format!("{cookie_name}=");
+        // Wrong-then-right ordering: `.any(...)` returns true on the
+        // second pair → request authenticates.
+        let req = Request::builder()
+            .uri("/api/graph")
+            .header(
+                header::COOKIE,
+                format!("{cookie_name}=wrong; {cookie_name}={}", token.as_str()),
+            )
+            .body(axum::body::Body::empty())
+            .unwrap();
+        match check_request(&req, &token, &needle) {
+            AuthOutcome::Ok => { /* any-match wins */ }
+            AuthOutcome::OkViaQueryParam => panic!(
+                "expected Ok — any matching duplicate cookie authenticates, got OkViaQueryParam"
+            ),
+            AuthOutcome::Unauthorized(reason) => {
+                panic!("expected Ok, got Unauthorized({reason:?})")
+            }
+        }
+        // Symmetric: right-then-wrong also authenticates (first pair wins).
+        let req = Request::builder()
+            .uri("/api/graph")
+            .header(
+                header::COOKIE,
+                format!("{cookie_name}={}; {cookie_name}=wrong", token.as_str()),
+            )
+            .body(axum::body::Body::empty())
+            .unwrap();
+        assert!(
+            matches!(check_request(&req, &token, &needle), AuthOutcome::Ok),
+            "right-then-wrong duplicate cookies still authenticate via the right one"
+        );
+    }
+
+    /// TC-ADV-1.30.1-5: lowercase `bearer` scheme returns 401 today.
+    /// RFC 6750 §2.1 says the scheme is case-insensitive; current code
+    /// is strict (`strip_prefix("Bearer ")`). Pin current 401 behavior;
+    /// invert when the grammar is relaxed.
+    #[test]
+    fn bearer_lowercase_scheme_returns_401_today() {
+        let token = AuthToken::try_from_string("rightvalue").expect("test alphabet");
+        let cookie_name = "cqs_token_8080";
+        let needle = format!("{cookie_name}=");
+        let req = Request::builder()
+            .uri("/api/graph")
+            .header(header::AUTHORIZATION, format!("bearer {}", token.as_str()))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        match check_request(&req, &token, &needle) {
+            AuthOutcome::Unauthorized(reason) => {
+                // OB-V1.30.1-5: lowercase scheme means `starts_with("Bearer ")`
+                // is false, so `bearer_attempted` is false too — falls
+                // through to MissingAll. Pin that.
+                assert_eq!(
+                    reason,
+                    UnauthorizedReason::MissingAll,
+                    "lowercase 'bearer ' fails the strict prefix check entirely; \
+                     pinning MissingAll today (when grammar is relaxed, this should \
+                     become BearerMismatch on a typo, or Bearer-success)",
+                );
+            }
+            AuthOutcome::Ok => panic!("expected Unauthorized today, got Ok"),
+            AuthOutcome::OkViaQueryParam => {
+                panic!("expected Unauthorized today, got OkViaQueryParam")
+            }
+        }
+    }
+
+    /// TC-ADV-1.30.1-6: `Authorization: Bearer  <token>` (double space)
+    /// returns 401 today. Strict separator check; the second space gets
+    /// included as the leading byte of the value, breaking ct_eq. Pin
+    /// current behavior so a future grammar relaxation has a clear
+    /// inversion target.
+    #[test]
+    fn bearer_double_space_returns_401_today() {
+        let token = AuthToken::try_from_string("rightvalue").expect("test alphabet");
+        let cookie_name = "cqs_token_8080";
+        let needle = format!("{cookie_name}=");
+        let req = Request::builder()
+            .uri("/api/graph")
+            .header(header::AUTHORIZATION, format!("Bearer  {}", token.as_str()))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        match check_request(&req, &token, &needle) {
+            AuthOutcome::Unauthorized(reason) => {
+                // `starts_with("Bearer ")` matches (one space prefix succeeds),
+                // so `bearer_attempted` IS true. The value starts with " "
+                // which mismatches → BearerMismatch.
+                assert_eq!(
+                    reason,
+                    UnauthorizedReason::BearerMismatch,
+                    "double-space 'Bearer  …' is bearer_attempted but value-mismatch",
+                );
+            }
+            AuthOutcome::Ok => panic!("expected Unauthorized today, got Ok"),
+            AuthOutcome::OkViaQueryParam => {
+                panic!("expected Unauthorized today, got OkViaQueryParam")
+            }
+        }
+    }
+
+    /// TC-ADV-1.30.1-7: `Authorization: Bearer<token>` (no separator)
+    /// returns 401 today. `starts_with("Bearer ")` requires the trailing
+    /// space; without it the prefix check fails and `bearer_attempted`
+    /// is false → MissingAll. Pin current behavior.
+    #[test]
+    fn bearer_no_separator_returns_401_today() {
+        let token = AuthToken::try_from_string("rightvalue").expect("test alphabet");
+        let cookie_name = "cqs_token_8080";
+        let needle = format!("{cookie_name}=");
+        let req = Request::builder()
+            .uri("/api/graph")
+            .header(header::AUTHORIZATION, format!("Bearer{}", token.as_str()))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        match check_request(&req, &token, &needle) {
+            AuthOutcome::Unauthorized(reason) => {
+                assert_eq!(
+                    reason,
+                    UnauthorizedReason::MissingAll,
+                    "no-separator 'Bearer<token>' fails starts_with(\"Bearer \"); \
+                     bearer_attempted is false → MissingAll today",
+                );
+            }
+            AuthOutcome::Ok => panic!("expected Unauthorized today, got Ok"),
+            AuthOutcome::OkViaQueryParam => {
+                panic!("expected Unauthorized today, got OkViaQueryParam")
+            }
+        }
     }
 }

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -214,7 +214,10 @@ pub(crate) fn build_router(state: AppState, allowed_hosts: AllowedHosts, auth: A
     // and traced).
     match auth {
         AuthMode::Required { token, cookie_port } => {
-            let middleware_state = auth::AuthMiddlewareState { token, cookie_port };
+            // PF-V1.30.1-6: `new()` pre-builds the cookie name and lookup
+            // needle once so the per-request middleware path doesn't
+            // allocate.
+            let middleware_state = auth::AuthMiddlewareState::new(token, cookie_port);
             app = app.layer(from_fn_with_state(middleware_state, auth::enforce_auth));
         }
         AuthMode::Disabled(_ack) => {


### PR DESCRIPTION
## Summary

P3 Bundle 3 — auth + serve hardening. 6 applied, 2 skipped (already shipped in #1206).

| ID | Status | Notes |
|----|--------|-------|
| CQ-V1.30.1-6 | ✅ applied | dropped CLI-side `serve_warn_no_auth_exposure` + its 10 tests; rely on `serve/mod.rs::run_server` unconditional warning (which already covers wildcard binds via #1206) |
| OB-V1.30.1-5 | ✅ applied | added 4-variant `UnauthorizedReason` enum (`MissingAll`, `BearerMismatch`, `CookieMismatch`, `QueryParamMismatch`); threaded through `check_request`; emit `reason = ?reason` on the 401 warn |
| PB-V1.30.1-1 | ⏭ skipped — already done in #1206 | `IpAddr::is_loopback()` was the substance of #1206's PB-1; CQ-V1.30.1-6 above subsumes the duplicate-warning angle |
| SEC-V1.30.1-9 | ✅ applied | `cqs ref add` now chmods `~/.local/share/cqs/refs/` to 0o700 (parent walk) |
| SEC-V1.30.1-10 | ✅ applied | after `build_hnsw_index`, walk ref_dir and chmod each file to 0o600 |
| SEC-V1.30.1-3 | ⏭ skipped — already done in #1206 | `escapeHtml` mirror in `callgraph-3d.js` already shipped (lines 14-21, 69) |
| PF-V1.30.1-6 | ✅ applied | `AuthMiddlewareState::new()` precomputes `cookie_name` + `cookie_lookup_needle` as `Arc<str>`; dropped now-unused `cookie_port` field |
| TC-ADV-V1.30.1-1/-2/-3/-9/-10 | ✅ applied | 10 new tests added (7 auth, 3 daemon) |

## Test additions (10)

In `src/serve/auth.rs::tests`:
- `try_from_string_accepts_long_alphabet_input_today`
- `auth_query_present_cookie_right_redirects_to_scrub_url_bar` (renamed from prompt's "no_redirect" framing — actual AC-V1.30.1-5 behavior is "any `?token=` triggers redirect")
- `auth_query_right_cookie_wrong_redirects_and_overwrites_cookie`
- `auth_two_cookies_with_same_name_any_match_authenticates` (renamed from prompt's "first occurrence" — actual `.any(...)` behavior is any-match wins)
- `bearer_lowercase_scheme_returns_401_today`
- `bearer_double_space_returns_401_today`
- `bearer_no_separator_returns_401_today`

In `src/daemon_translate.rs::tests`:
- `daemon_status_handles_err_envelope_with_no_message` (pins doubled `"daemon error: daemon error"` fallback)
- `daemon_status_handles_err_envelope_with_non_string_message` (pins silent drop of non-string `message`)
- `unwrap_dispatch_payload_distinguishes_envelope_no_data_from_bare_form` (pins current behavior — passes `Ok(Null)` even when an `error` field is present alongside; TODO commentary so the future fix that surfaces `error` has a clear inversion target)

## Notable inversions from prompt

- TC-ADV-1.30.1-2/-3/-4 — prompt names assumed pre-AC-V1.30.1-5 semantics ("cookie wins, no redirect" / "first cookie wins"). Landed code uses "any `?token=` triggers redirect" + `.any(...)` over duplicate cookies. Tests pin **actual** behavior with descriptive names.
- TC-ADV-1.30.1-10 — prompt expected `assert!(result.is_err())` but `unwrap_dispatch_payload` returns `Ok(Null)` for `{"data": null, "error": "internal"}`. Test pins `is_ok()` with TODO so the future fix that surfaces `error` has a clear inversion point.

## Test plan

- [x] `cargo check --features cuda-index` — clean
- [x] `cargo clippy --features cuda-index -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --lib serve::auth` — 26 pass / 0 fail (was 19, +7)
- [x] `cargo test --lib daemon_translate` — 31 pass / 0 fail (was 28, +3)
- [x] `cargo test --lib serve` (full module) — 98 pass / 0 fail / 1 ignored
- [x] `cargo test --lib auth_tests` (`serve::tests`) — 13 pass / 0 fail (`AuthMiddlewareState` constructor change didn't break end-to-end)

Built in `CARGO_TARGET_DIR=/home/user001/.cargo-target/cqs-p3-b3`.

5 files changed, +558 / -134.
