### PR TITLE
fix(api+codequality): P3 bundle 2 — API papercuts + ort_err dedup + Display + total_cmp + macros

### DIFF
--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -448,6 +448,55 @@ for_each_batch_cmd_pipeability!(gen_is_pipeable_impl);
 
 // ─── Query logging ───────────────────────────────────────────────────────────
 
+/// Per-variant table for the eval-capture query log.
+///
+/// EX-V1.30.1-3 (P3-EX-1): the `log_query("search", &args.query)` calls
+/// used to live at six hand-sprinkled sites in `dispatch`. Each site had
+/// to remember the right command-name string and the right field name
+/// (`args.query` vs `args.description` vs ...). Centralised here so
+/// adding a new logged variant is one row in this table instead of a
+/// new sprinkled call inside `dispatch`.
+///
+/// The `gen_log_query_dispatch` emitter expands the table into one
+/// `log_query_for(cmd: &BatchCmd)` function that pattern-matches the
+/// variant and pulls the field by name. Variants that aren't listed
+/// here fall through (no log line emitted) — most batch commands take
+/// a function name or a path, not a query, and those don't go in the
+/// eval-replay log.
+macro_rules! for_each_logged_batch_cmd {
+    ($emit:ident) => {
+        $emit! {
+            // (BatchCmd variant, log-name, field accessor on the variant's `args`)
+            (Search,  "search",  query)
+            (Gather,  "gather",  query)
+            (Onboard, "onboard", query)
+            (Scout,   "scout",   query)
+            (Where,   "where",   description)
+            (Task,    "task",    description)
+        }
+    };
+}
+
+/// Emit `fn log_query_for(cmd: &BatchCmd)` from the table above.
+///
+/// Each row produces a `BatchCmd::$variant { args, .. } => log_query(...)`
+/// arm; a final `_ => {}` arm covers the un-logged variants. Adding a
+/// new logged variant is one new row in `for_each_logged_batch_cmd!`.
+macro_rules! gen_log_query_dispatch {
+    ( $( ($var:ident, $log_name:literal, $field:ident) )* ) => {
+        fn log_query_for(cmd: &BatchCmd) {
+            match cmd {
+                $(
+                    BatchCmd::$var { args, .. } => log_query($log_name, &args.$field),
+                )*
+                _ => {}
+            }
+        }
+    };
+}
+
+for_each_logged_batch_cmd!(gen_log_query_dispatch);
+
 /// Append a query to the query log for eval workflow capture.
 /// Best-effort: failures are silently ignored (never blocks batch mode).
 fn log_query(command: &str, query: &str) {
@@ -495,6 +544,11 @@ fn log_query(command: &str, query: &str) {
 /// dispatch, so concurrent reads no longer serialize through one lock.
 pub(crate) fn dispatch(ctx: &BatchView, cmd: BatchCmd) -> Result<serde_json::Value> {
     let _span = tracing::debug_span!("batch_dispatch").entered();
+    // EX-V1.30.1-3 (P3-EX-1): single table-driven query-log call replaces
+    // six hand-sprinkled `log_query(...)` invocations inside the match arms.
+    // The `for_each_logged_batch_cmd!` table at the top of this module
+    // owns the variant → log-name + field-accessor mapping.
+    log_query_for(&cmd);
     // Task #8: every variant now also carries `output` (TextJsonArgs or
     // OutputArgs) for CLI flag parity, but batch always emits JSON via the
     // socket framer / stdout JSONL — the output field is intentionally
@@ -504,10 +558,7 @@ pub(crate) fn dispatch(ctx: &BatchView, cmd: BatchCmd) -> Result<serde_json::Val
         BatchCmd::Blame { args, .. } => {
             handlers::dispatch_blame(ctx, &args.name, args.commits, args.callers)
         }
-        BatchCmd::Search { args, .. } => {
-            log_query("search", &args.query);
-            handlers::dispatch_search(ctx, &args)
-        }
+        BatchCmd::Search { args, .. } => handlers::dispatch_search(ctx, &args),
         BatchCmd::Deps { args, .. } => handlers::dispatch_deps(
             ctx,
             &args.name,
@@ -527,10 +578,7 @@ pub(crate) fn dispatch(ctx: &BatchView, cmd: BatchCmd) -> Result<serde_json::Val
         BatchCmd::Similar { args, .. } => {
             handlers::dispatch_similar(ctx, &args.name, args.limit, args.threshold)
         }
-        BatchCmd::Gather { args, .. } => {
-            log_query("gather", &args.query);
-            handlers::dispatch_gather(ctx, &args)
-        }
+        BatchCmd::Gather { args, .. } => handlers::dispatch_gather(ctx, &args),
         BatchCmd::Impact { args, .. } => handlers::dispatch_impact(
             ctx,
             &args.name,
@@ -563,22 +611,17 @@ pub(crate) fn dispatch(ctx: &BatchView, cmd: BatchCmd) -> Result<serde_json::Val
             handlers::dispatch_context(ctx, &args.path, args.summary, args.compact, args.tokens)
         }
         BatchCmd::Stats { .. } => handlers::dispatch_stats(ctx),
-        BatchCmd::Onboard { args, .. } => {
-            log_query("onboard", &args.query);
-            handlers::dispatch_onboard(
-                ctx,
-                &args.query,
-                args.depth,
-                args.limit_arg.limit,
-                args.tokens,
-            )
-        }
+        BatchCmd::Onboard { args, .. } => handlers::dispatch_onboard(
+            ctx,
+            &args.query,
+            args.depth,
+            args.limit_arg.limit,
+            args.tokens,
+        ),
         BatchCmd::Scout { args, .. } => {
-            log_query("scout", &args.query);
             handlers::dispatch_scout(ctx, &args.query, args.limit, args.tokens)
         }
         BatchCmd::Where { args, .. } => {
-            log_query("where", &args.description);
             handlers::dispatch_where(ctx, &args.description, args.limit)
         }
         BatchCmd::Read { args, .. } => {
@@ -600,7 +643,6 @@ pub(crate) fn dispatch(ctx: &BatchView, cmd: BatchCmd) -> Result<serde_json::Val
             handlers::dispatch_notes(ctx, args.warnings, args.patterns, args.check)
         }
         BatchCmd::Task { args, .. } => {
-            log_query("task", &args.description);
             handlers::dispatch_task(ctx, &args.description, args.limit, args.tokens)
         }
         BatchCmd::Review { args, .. } => {

--- a/src/cli/commands/eval/mod.rs
+++ b/src/cli/commands/eval/mod.rs
@@ -82,6 +82,9 @@ pub(crate) struct EvalCmdArgs {
     /// How long `--require-fresh` waits for the daemon to reach
     /// `state == fresh` before erroring out. Capped at 600 (10 min)
     /// inside the wait helper so a runaway agent can't pin the socket.
+    ///
+    /// Note: `cqs status --wait-secs` has the same semantics; default
+    /// differs by use case (eval default = 600, status = 30).
     #[arg(long = "require-fresh-secs", default_value_t = 600u64)]
     pub require_fresh_secs: u64,
 }
@@ -356,14 +359,14 @@ fn require_fresh_gate(no_require_fresh_flag: &bool, wait_secs: u64) -> Result<()
 /// of falsy strings mirrors the convention used by other env-var knobs
 /// (`CQS_NO_DAEMON`, etc.) so an operator who knows one knob's spelling
 /// gets the other for free.
+///
+/// EX-V1.30.1-7 (P3-EX-2): falsy-string parsing now lives in
+/// [`cqs::env_falsy`] so the next migration pass can move the other
+/// ~30 hand-rolled call sites without re-debating the spelling list.
 fn env_disables_freshness_gate() -> bool {
-    match std::env::var("CQS_EVAL_REQUIRE_FRESH") {
-        Ok(v) => matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "0" | "false" | "no" | "off"
-        ),
-        Err(_) => false,
-    }
+    std::env::var("CQS_EVAL_REQUIRE_FRESH")
+        .map(|v| cqs::env_falsy(&v))
+        .unwrap_or(false)
 }
 
 /// Print the eval report in human-readable text.

--- a/src/cli/commands/infra/status.rs
+++ b/src/cli/commands/infra/status.rs
@@ -41,7 +41,11 @@ pub(crate) fn cmd_status(json: bool, watch_fresh: bool, wait: bool, wait_secs: u
     if !watch_fresh {
         // Reserve room for future sibling modes by gating the entire
         // command on at least one explicit "what to report" flag.
-        let msg = "cqs status: pass --watch-fresh to query daemon freshness";
+        // API-V1.30.1-8: nudge the user toward the canonical no-flag combo
+        // (`--watch-fresh --wait`) instead of just naming the flag they
+        // missed — agents and operators who hit the bare `cqs status`
+        // probably want to wait for fresh, not poll once.
+        let msg = "cqs status: hint: try --watch-fresh --wait";
         if json {
             crate::cli::json_envelope::emit_json_error(
                 crate::cli::json_envelope::error_codes::INVALID_INPUT,

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -789,6 +789,9 @@ pub(super) enum Commands {
         wait: bool,
         /// Maximum seconds `--wait` polls before giving up. Capped at 600
         /// so a runaway agent loop can't pin the daemon socket forever.
+        ///
+        /// Note: `cqs eval --require-fresh-secs` has the same semantics;
+        /// default differs by use case (eval default = 600, status = 30).
         #[arg(long, default_value_t = 30)]
         wait_secs: u64,
     },

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -161,17 +161,17 @@ fn publish_watch_snapshot(
         .as_ref()
         .map(|p| p.delta_saturated)
         .unwrap_or(false);
-    let snap = cqs::watch_status::WatchSnapshot::compute(cqs::watch_status::WatchSnapshotInput {
-        pending_files_count: state.pending_files.len(),
-        pending_notes: state.pending_notes,
-        rebuild_in_flight: state.pending_rebuild.is_some(),
-        delta_saturated,
-        incremental_count: state.incremental_count,
-        dropped_this_cycle: state.dropped_this_cycle,
-        last_event: state.last_event,
-        last_synced_at,
-        _marker: std::marker::PhantomData,
-    });
+    let snap =
+        cqs::watch_status::WatchSnapshot::compute(cqs::watch_status::WatchSnapshotInput::new(
+            state.pending_files.len(),
+            state.pending_notes,
+            state.pending_rebuild.is_some(),
+            delta_saturated,
+            state.incremental_count,
+            state.dropped_this_cycle,
+            state.last_event,
+            last_synced_at,
+        ));
     // Poison-recovery: another writer panicking shouldn't silently stop
     // freshness publishing. Recover and overwrite.
     //

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -16,7 +16,7 @@ pub const DEFAULT_DIM: usize = ModelConfig::DEFAULT_DIM;
 /// want a `&'static str` rather than `default_model().repo` (a `String`).
 pub const DEFAULT_MODEL_REPO: &str = ModelConfig::DEFAULT_REPO;
 
-use provider::ort_err;
+use crate::ort_helpers::ort_err;
 pub(crate) use provider::{create_session, select_provider};
 
 use lru::LruCache;
@@ -59,7 +59,17 @@ pub enum EmbedderError {
     HfHub(String),
 }
 
-// `ort_err` is defined in `provider.rs` (pub(super)) and imported above.
+/// CQ-V1.30.1-5 (P3-CQ-2): route a stringified ORT message into
+/// [`InferenceFailed`](EmbedderError::InferenceFailed) so the shared
+/// [`crate::ort_helpers::ort_err`] helper can hand back the right
+/// variant for embedder call sites. Sealed trait, not `From<String>`,
+/// so `.map_err(ort_err)` type inference isn't ambiguous against the
+/// reflexive `From<T> for T` impl.
+impl crate::ort_helpers::FromOrtMessage for EmbedderError {
+    fn from_ort_message(msg: String) -> Self {
+        Self::InferenceFailed(msg)
+    }
+}
 
 /// An L2-normalized embedding vector.
 ///

--- a/src/embedder/provider.rs
+++ b/src/embedder/provider.rs
@@ -9,11 +9,7 @@ use ort::session::Session;
 use std::path::{Path, PathBuf};
 
 use super::{EmbedderError, ExecutionProvider};
-
-/// Convert any ort error to [`EmbedderError::InferenceFailed`] via `.to_string()`.
-pub(super) fn ort_err<T>(e: ort::Error<T>) -> EmbedderError {
-    EmbedderError::InferenceFailed(e.to_string())
-}
+use crate::ort_helpers::ort_err;
 
 /// Ensure ORT CUDA provider libraries are findable (Unix only)
 /// ORT's C++ runtime resolves provider paths via `dladdr` -> `argv[0]`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub(crate) mod limits;
 pub(crate) mod math;
 pub(crate) mod nl;
 pub(crate) mod onboard;
+pub(crate) mod ort_helpers;
 pub(crate) mod project;
 pub(crate) mod related;
 pub(crate) mod review;
@@ -273,6 +274,26 @@ pub fn resolve_index_db(project_cqs_dir: &Path) -> PathBuf {
 /// Use `Embedder::embedding_dim()` for the runtime value.
 /// Derived from `ModelConfig::default_model().dim`.
 pub const EMBEDDING_DIM: usize = embedder::DEFAULT_DIM;
+
+/// EX-V1.30.1-7 (P3-EX-2): test whether a string is one of the canonical
+/// "off" tokens the cqs CLI accepts in `CQS_*` env vars.
+///
+/// Mirrors the dispatch the audit found duplicated across ~30 sites:
+/// `"0"`, `"false"`, `"no"`, `"off"` — case-insensitive, whitespace-trimmed.
+/// Centralised here so the next migration pass can swap a hand-rolled
+/// match for a single call without re-debating the spelling list.
+///
+/// Companion `env_truthy` is intentionally not added today — the audit's
+/// 30-site backlog only matters once we start migrating the rest, and
+/// the truthy spelling list (e.g. should `"y"` work?) deserves its own
+/// pass.
+#[inline]
+pub fn env_falsy(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
 
 /// DS2-10: Convert a [`std::time::Duration`] to milliseconds as `i64` for
 /// storage in SQLite `INTEGER` mtime columns.

--- a/src/ort_helpers.rs
+++ b/src/ort_helpers.rs
@@ -1,0 +1,37 @@
+//! Shared ORT error mapping for the embedder, reranker, and SPLADE backends.
+//!
+//! Three near-identical `fn ort_err` helpers used to live in
+//! [`crate::embedder::provider`], [`crate::reranker`], and
+//! [`crate::splade`]; each wrapped `ort::Error` into the calling module's
+//! `*Error::Inference{,Failed}` variant via `.to_string()`. Audit finding
+//! CQ-V1.30.1-5 (P3-CQ-2): consolidated here as a single helper backed by
+//! a private trait.
+//!
+//! The trait approach (rather than `E: From<String>`) avoids the
+//! reflexive `From<T> for T` ambiguity that breaks `.map_err(ort_err)`
+//! type inference: a generic `ort_err<E: From<String>>(e: ...)` can't
+//! decide whether the closure's output should be `String` or the
+//! enclosing `*Error` — both satisfy `From<String>`. A bespoke trait
+//! has only the three target impls, so inference is unambiguous from
+//! the call site's surrounding `Result<_, *Error>` return type.
+
+/// Implemented by error types that can carry a stringified ORT error
+/// in their `Inference{,Failed}` variant. Sealed inside the crate;
+/// adding a new ORT-using error type means one new impl in its module.
+pub(crate) trait FromOrtMessage {
+    fn from_ort_message(msg: String) -> Self;
+}
+
+/// Convert any ORT error into the caller's error type via `.to_string()`.
+///
+/// Accepts anything `Display` so `ort::Error`, `ort::Error<T>`, or any
+/// other ort error wrapper resolve through the same call. The
+/// surrounding `Result<_, *Error>` return type is enough for the
+/// compiler to pick the right `FromOrtMessage` impl when used as
+/// `.map_err(ort_err)`.
+pub(crate) fn ort_err<E>(e: impl std::fmt::Display) -> E
+where
+    E: FromOrtMessage,
+{
+    E::from_ort_message(e.to_string())
+}

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -94,12 +94,19 @@ pub enum RerankerError {
     InvalidArguments(String),
 }
 
-/// Convert any ort error to [`RerankerError::Inference`] via `.to_string()`.
-///
-/// Function instead of `From` impl — see [`crate::embedder::ort_err`] for rationale.
-fn ort_err<T>(e: ort::Error<T>) -> RerankerError {
-    RerankerError::Inference(e.to_string())
+/// CQ-V1.30.1-5 (P3-CQ-2): route a stringified ORT message into
+/// [`Inference`](RerankerError::Inference) so the shared
+/// [`crate::ort_helpers::ort_err`] helper can hand back the right
+/// variant for reranker call sites. Sealed trait, not `From<String>`,
+/// so `.map_err(ort_err)` type inference isn't ambiguous against the
+/// reflexive `From<T> for T` impl.
+impl crate::ort_helpers::FromOrtMessage for RerankerError {
+    fn from_ort_message(msg: String) -> Self {
+        Self::Inference(msg)
+    }
 }
+
+use crate::ort_helpers::ort_err;
 
 /// Cross-encoder reranker for second-pass scoring
 ///

--- a/src/search/router.rs
+++ b/src/search/router.rs
@@ -466,7 +466,11 @@ pub fn resolve_splade_alpha(category: &QueryCategory) -> f32 {
         Ok(val) if let Ok(alpha) = val.parse::<f32>() => {
             if alpha.is_finite() {
                 let alpha = alpha.clamp(0.0, 1.0);
-                tracing::info!(
+                // OB-V1.30.1-1 / P3-OB-1: per-search routing fires on every
+                // query — keep the entry `info_span!` for traceability and
+                // demote the inner event to debug so the operator default
+                // log level isn't flooded.
+                tracing::debug!(
                     category = %category,
                     alpha,
                     source = "per_cat_env",
@@ -488,7 +492,8 @@ pub fn resolve_splade_alpha(category: &QueryCategory) -> f32 {
         Ok(val) if let Ok(alpha) = val.parse::<f32>() => {
             if alpha.is_finite() {
                 let alpha = alpha.clamp(0.0, 1.0);
-                tracing::info!(
+                // OB-V1.30.1-1 / P3-OB-1: see comment above on per-cat env.
+                tracing::debug!(
                     category = %category,
                     alpha,
                     source = "global_env",
@@ -546,7 +551,9 @@ pub fn resolve_splade_alpha(category: &QueryCategory) -> f32 {
     // no longer slip through under a `_ => 1.0` catch-all.
     let alpha = category.default_alpha();
 
-    tracing::info!(
+    // OB-V1.30.1-1 / P3-OB-1: demote per-search routing to debug — see
+    // top of `resolve_splade_alpha` for the rationale.
+    tracing::debug!(
         category = %category,
         alpha,
         source = "default",
@@ -804,6 +811,14 @@ fn is_cross_language_query(query: &str, words: &[&str]) -> bool {
 /// keyword at end-of-query silently misrouted to Conceptual α=0.70 instead
 /// of Structural α=0.90.
 fn is_structural_query(query: &str) -> bool {
+    // AC-V1.30.1-2 (P3-AC-1): line 643 already passes `&query_lower`, but
+    // the other call sites (lines 900, 1265, 1275-1276) pass raw query
+    // strings, so a query like `"Class Foo"` would miss the `class`
+    // keyword match. Lowercase here once so every caller is correct
+    // without per-site discipline; the AC pattern set is keyed on
+    // lowercase forms anyway.
+    let query_lower = query.to_ascii_lowercase();
+    let query = query_lower.as_str();
     // Structural patterns like "functions that return"
     if STRUCTURAL_PATTERNS_AC.is_match(query) {
         return true;
@@ -1143,7 +1158,10 @@ pub fn reclassify_with_centroid(
     let classifier = CENTROID_CLASSIFIER.get_or_init(CentroidClassifier::load);
     if let Some(cls) = classifier {
         if let Some((cat, margin)) = cls.classify(embedding) {
-            tracing::info!(
+            // OB-V1.30.1-2 / P3-OB-1: per-search event — demote to debug
+            // so the operator default log level isn't flooded; the
+            // surrounding `info_span!`s still carry the trace context.
+            tracing::debug!(
                 centroid_category = %cat,
                 margin = format!("{margin:.4}"),
                 "centroid filled Unknown gap"
@@ -1274,6 +1292,24 @@ mod tests {
     fn test_p2_44_structural_keyword_as_substring_does_not_match() {
         assert!(!is_structural_query("training pipeline"));
         assert!(!is_structural_query("classifier"));
+    }
+
+    /// AC-V1.30.1-2 (P3-AC-1) regression-pin: case-folding inside
+    /// `is_structural_query` so callers that pass raw queries (line 900
+    /// in `is_conceptual_query`, the centroid path, and external test
+    /// callers) classify uppercase or mixed-case structural keywords
+    /// correctly. The pre-fix path only worked when callers had already
+    /// lowercased — `"Class Foo"` and `"FIND ALL STRUCT"` would miss.
+    /// Note: `STRUCTURAL_KEYWORDS` is singular-only (`struct`, not
+    /// `structs`); the case-fold pin tracks the uppercase axis only.
+    #[test]
+    fn test_ac_v1_30_1_2_is_structural_query_case_folds() {
+        assert!(is_structural_query("Class Foo"));
+        assert!(is_structural_query("Trait Iterator"));
+        assert!(is_structural_query("FIND ALL STRUCT"));
+        assert!(is_structural_query("Find Every Enum"));
+        // negative pin: substring + uppercase still must not false-fire
+        assert!(!is_structural_query("Training Pipeline"));
     }
 
     #[test]

--- a/src/search/scoring/candidate.rs
+++ b/src/search/scoring/candidate.rs
@@ -228,7 +228,23 @@ impl BoundedScoreHeap {
         // eviction boundary we break score ties on id ascending so the
         // surviving set is deterministic.
         if let Some(Reverse((OrderedFloat(worst_score), Reverse(worst_id)))) = self.heap.peek() {
-            let better = score > *worst_score || (score == *worst_score && id < *worst_id);
+            // AC-V1.30.1-7 (P3-AC-3): use `total_cmp` instead of `==` /
+            // `>` on raw `f32`. `==` is incorrect for NaN (panics on
+            // some payloads via the wrapping `OrderedFloat`'s ordering
+            // contract), and the upstream non-finite filter at the top
+            // of this function should already have rejected NaN/Inf;
+            // pin that invariant with a debug assertion. `total_cmp` is
+            // a total order so the eviction decision is well-defined
+            // for every finite-or-NaN bit pattern that could leak past.
+            debug_assert!(
+                score.is_finite(),
+                "BoundedScoreHeap::push: non-finite scores must be filtered above"
+            );
+            let better = match score.total_cmp(worst_score) {
+                std::cmp::Ordering::Greater => true,
+                std::cmp::Ordering::Equal => id < *worst_id,
+                std::cmp::Ordering::Less => false,
+            };
             if better {
                 self.heap.pop();
                 self.heap.push(Reverse((OrderedFloat(score), Reverse(id))));

--- a/src/splade/mod.rs
+++ b/src/splade/mod.rs
@@ -22,11 +22,7 @@ use thiserror::Error;
 use crate::aux_model::{self, AuxModelKind};
 use crate::config::AuxModelSection;
 use crate::embedder::{create_session, select_provider};
-
-/// Convert ORT errors to SpladeError
-fn ort_err(e: ort::Error) -> SpladeError {
-    SpladeError::InferenceFailed(e.to_string())
-}
+use crate::ort_helpers::ort_err;
 
 /// RB-V1.29-9: Convert an ORT-reported tensor dimension (`i64`) to `usize`
 /// with a negative-value guard. ORT shape entries are nominally
@@ -73,6 +69,18 @@ pub enum SpladeError {
         tokenizer_vocab: usize,
         model_vocab: usize,
     },
+}
+
+/// CQ-V1.30.1-5 (P3-CQ-2): route a stringified ORT message into
+/// [`InferenceFailed`](SpladeError::InferenceFailed) so the shared
+/// [`crate::ort_helpers::ort_err`] helper can hand back the right
+/// variant for SPLADE call sites. Sealed trait, not `From<String>`,
+/// so `.map_err(ort_err)` type inference isn't ambiguous against the
+/// reflexive `From<T> for T` impl.
+impl crate::ort_helpers::FromOrtMessage for SpladeError {
+    fn from_ort_message(msg: String) -> Self {
+        Self::InferenceFailed(msg)
+    }
 }
 
 /// SPLADE encoder using ONNX Runtime.

--- a/src/watch_status.rs
+++ b/src/watch_status.rs
@@ -59,6 +59,17 @@ impl FreshnessState {
     }
 }
 
+/// API-V1.30.1-9: implement `Display` so `tracing::info!(state = %snap.state)`
+/// works without callers having to reach for `.as_str()` everywhere. Delegates
+/// to `as_str()` so the wire-shape lowercase strings stay the single source of
+/// truth — JSON consumers, structured logs, and human-readable text all see
+/// the same spelling.
+impl std::fmt::Display for FreshnessState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Snapshot of the watch loop's view of "how fresh is the index?". The
 /// wire shape returned by `cqs status --watch-fresh --json`.
 ///
@@ -197,6 +208,37 @@ pub struct WatchSnapshotInput<'a> {
     /// Phantom keeps the API future-proof if we add borrow-only fields
     /// (e.g. last-error string). No-op today.
     pub _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> WatchSnapshotInput<'a> {
+    /// API-V1.30.1-7: named-field constructor so callers don't have to
+    /// remember to set `_marker: PhantomData` themselves. The lifetime
+    /// parameter remains in case future additions take borrowed fields
+    /// (e.g. `last_error: Option<&str>`); today the marker is the only
+    /// reason `'a` exists.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        pending_files_count: usize,
+        pending_notes: bool,
+        rebuild_in_flight: bool,
+        delta_saturated: bool,
+        incremental_count: usize,
+        dropped_this_cycle: usize,
+        last_event: std::time::Instant,
+        last_synced_at: Option<i64>,
+    ) -> Self {
+        Self {
+            pending_files_count,
+            pending_notes,
+            rebuild_in_flight,
+            delta_saturated,
+            incremental_count,
+            dropped_this_cycle,
+            last_event,
+            last_synced_at,
+            _marker: std::marker::PhantomData,
+        }
+    }
 }
 
 impl WatchSnapshot {


### PR DESCRIPTION
## Summary

P3 Bundle 2 — API papercuts + code-quality cleanups. 6 applied, 1 skipped (already done in #1208).

| ID | Status | Notes |
|----|--------|-------|
| API-V1.30.1-7 | ✅ applied | Added `WatchSnapshotInput::new(...)` constructor at `watch_status.rs`. Migrated the one production caller at `cli/watch/mod.rs:164`. |
| API-V1.30.1-9 | ✅ applied | Added `impl Display for FreshnessState` delegating to `as_str()`. |
| API-V1.30.1-10 | ⏭ skipped — already done in #1208 | Field renamed to `last_event_unix_secs`; doc-comment caveat already in place. |
| API-V1.30.1-8 | ✅ applied | Stderr message: `cqs status: hint: try --watch-fresh --wait`. |
| API-V1.30.1-2 | ✅ applied | Cross-reference doc lines on `--wait-secs` (`definitions.rs`) and `--require-fresh-secs` (`eval/mod.rs`). |
| CQ-V1.30.1-5 | ✅ applied | New `src/ort_helpers.rs` with **sealed `FromOrtMessage` trait** + generic `ort_err`. Used the sealed trait instead of `From<String>` because the latter collides with the reflexive `From<T> for T` impl and breaks `.map_err(ort_err)` type inference at all 27 call sites. Each of `EmbedderError` / `RerankerError` / `SpladeError` got an `impl FromOrtMessage`. The three duplicate `fn ort_err` are gone. |
| OB-V1.30.1-1 | ✅ applied | Demoted four `tracing::info!` → `tracing::debug!` at `search/router.rs` (per-cat env, global env, default-alpha, centroid Unknown gap). |
| AC-V1.30.1-2 | ✅ applied | `is_structural_query` now lowercases query once at function entry. New regression-pin test `test_ac_v1_30_1_2_is_structural_query_case_folds`. **Note**: the prompt's example `"FIND ALL STRUCTS"` is plural and won't match (`STRUCTURAL_KEYWORDS` is singular-only). Test uses `"FIND ALL STRUCT"` + `"Find Every Enum"` instead — documented inline. |
| AC-V1.30.1-7 | ✅ applied | `BoundedScoreHeap::push` score-equality at `search/scoring/candidate.rs:231` — replaced `==` with `total_cmp`. Added `debug_assert!(score.is_finite())` to pin the upstream filter invariant. |
| EX-V1.30.1-3 | ✅ applied | Added `for_each_logged_batch_cmd!` table + `gen_log_query_dispatch!` emitter macro at `cli/batch/commands.rs:451-498`. Single `log_query_for(&cmd)` at dispatch entry replaces 6 hand-sprinkled call sites. The table preserves the `query`/`description` field-name divergence per-row. |
| EX-V1.30.1-7 | ✅ applied | `pub fn cqs::env_falsy(value: &str) -> bool` at `lib.rs`. Migrated the one site in `eval/mod.rs:env_disables_freshness_gate()`. The other ~30 sites are reserved for a follow-up — per prompt. |

## Test plan

- [x] `cargo check --features cuda-index` — clean
- [x] `cargo clippy --features cuda-index --lib --bin cqs -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Targeted tests — 694 pass, 0 fail across watch_status, search::router, search::scoring, batch, eval, status, watch, embedder, reranker, splade

14 files changed (1 new module, 13 edits). Built in `CARGO_TARGET_DIR=/home/user001/.cargo-target/cqs-p3-b2`.
