### PR TITLE
fix(llm+ref): same-origin redirect policy + symlink-redirect warning

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -228,6 +228,8 @@ When the user passes a path on the command line, cqs canonicalizes it (`dunce::c
 | `cqs read link` where `link → /etc/passwd` | Blocked (target outside project) |
 | `cqs read link` where `link → ../sibling/file` | Blocked (target outside project) |
 
+**`cqs ref add --source <path>` redirect surfacing (since v1.30.2, [#1222](https://github.com/jamie8johnson/cqs/issues/1222))**: when the user-supplied `--source` path resolves through a symlink to a different filesystem location, `cmd_ref_add` emits a `tracing::warn!` (and a `WARN:` line on stderr in non-`--quiet` text mode) naming both the user-supplied and resolved paths. JSON output gains a `warnings: ["source path '<input>' resolved via symlink to '<target>'"]` field. The reference is still indexed at the resolved path — the warning exists so an operator who ran `cqs ref add foo vendored-monorepo-pull/` against a symlink to `~/work/customer-A-private/` can see what they actually pulled in. Lexical normalization (`..`, `.`, repeated separators) is applied before comparison so purely syntactic differences in the input don't trigger false positives.
+
 **TOCTOU consideration**: A symlink could theoretically be changed between canonicalization and read. This is a standard filesystem race condition that affects all programs. Mitigation would require `O_NOFOLLOW` or similar, which would break legitimate symlink use cases on `cqs read`.
 
 **Recommendation**: If you don't trust symlinks in your project, remove them. The directory-walk path is already conservative.

--- a/src/cli/commands/infra/doctor.rs
+++ b/src/cli/commands/infra/doctor.rs
@@ -573,9 +573,15 @@ fn check_local_llm(json: bool, records: &mut Vec<CheckRecord>, any_failed: &mut 
     // timeout. We don't want doctor to hang if the user typo'd a URL.
     let base = api_base.unwrap();
     let probe_url = format!("{}/models", base.trim_end_matches('/'));
+    // SEC-V1.30.1-7 (#1223): same-origin policy matches the production
+    // submit path so doctor and the real `LocalProvider` agree on what
+    // counts as a "reachable" endpoint. The probe doesn't carry a
+    // bearer today, but pinning the same policy means a future probe
+    // that adds auth doesn't silently regain cross-origin redirect
+    // following.
     let client = match reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
-        .redirect(reqwest::redirect::Policy::limited(2))
+        .redirect(cqs::llm::redirect::same_origin_redirect_policy(2))
         .build()
     {
         Ok(c) => c,

--- a/src/cli/commands/infra/reference.rs
+++ b/src/cli/commands/infra/reference.rs
@@ -128,8 +128,45 @@ fn cmd_ref_add(
     }
 
     // Validate source
+    let source_input = source.to_path_buf();
     let source = dunce::canonicalize(source)
         .map_err(|e| anyhow::anyhow!("Source path '{}' not found: {}", source.display(), e))?;
+
+    // SEC-V1.30.1-6 (#1222): if `dunce::canonicalize` redirected the
+    // user-supplied path through a symlink, surface it. The submitted
+    // index will live at the *resolved* path; an operator who
+    // symlinks `vendored-monorepo-pull/` → `~/work/customer-A-private/`
+    // and runs `cqs ref add foo vendored-monorepo-pull/` deserves a
+    // loud notice that they just indexed customer-A-private content.
+    //
+    // Comparison strategy: lexically normalize the absolute form of
+    // the user input (resolve `..`, `.`, repeated separators without
+    // touching the filesystem) and compare to the canonical path. A
+    // mismatch means a symlink was followed somewhere in the chain.
+    // Lexical normalization is intentionally cheap and conservative
+    // — false positives are acceptable (the warning is informational)
+    // but false negatives (silent symlink redirect) are not.
+    let symlink_warning = match symlink_redirect_warning(&source_input, &source) {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::debug!(
+                source = %source_input.display(),
+                error = %e,
+                "Could not compute absolute form of --source; skipping symlink-redirect check"
+            );
+            None
+        }
+    };
+    if let Some(ref msg) = symlink_warning {
+        tracing::warn!(
+            user_source = %source_input.display(),
+            resolved = %source.display(),
+            "Source path resolved via symlink"
+        );
+        if !json && !cli.quiet {
+            eprintln!("WARN: {msg}");
+        }
+    }
 
     // Create reference directory with restrictive permissions.
     // SEC-V1.30.1-9: walk every parent that `create_dir_all` may have
@@ -248,15 +285,72 @@ fn cmd_ref_add(
     add_reference_to_config(&config_path, &ref_config)?;
 
     if json {
-        crate::cli::json_envelope::emit_json(&serde_json::json!({
+        let mut payload = serde_json::json!({
             "status": "added",
             "name": name,
             "weight": weight,
-        }))?;
+        });
+        if let Some(msg) = symlink_warning {
+            payload
+                .as_object_mut()
+                .expect("payload is an object literal above")
+                .insert("warnings".to_string(), serde_json::json!([msg]));
+        }
+        crate::cli::json_envelope::emit_json(&payload)?;
     } else if !cli.quiet {
         println!("Reference '{}' added.", name);
     }
     Ok(())
+}
+
+/// SEC-V1.30.1-6 (#1222): detect whether `dunce::canonicalize` redirected
+/// `source_input` through a symlink. Returns `Ok(Some(message))` on
+/// redirect, `Ok(None)` when the input lexically matches the canonical
+/// path, and `Err` only when the absolute form of `source_input` cannot
+/// be computed.
+///
+/// The lexical-normalize step resolves `..`, `.`, and duplicate
+/// separators without touching the filesystem so that user input like
+/// `/home/me/../me/projects/foo` doesn't trip a false positive. Symlink
+/// resolution still happens via `dunce::canonicalize` upstream — this
+/// helper only compares the result.
+fn symlink_redirect_warning(
+    source_input: &std::path::Path,
+    canonical: &std::path::Path,
+) -> std::io::Result<Option<String>> {
+    let absolute = std::path::absolute(source_input)?;
+    let normalized = lexical_normalize(&absolute);
+    if normalized == canonical {
+        Ok(None)
+    } else {
+        Ok(Some(format!(
+            "source path '{}' resolved via symlink to '{}'",
+            normalized.display(),
+            canonical.display()
+        )))
+    }
+}
+
+/// Lexically normalize a path by resolving `..` and `.` components
+/// without consulting the filesystem. Used by the symlink-redirect
+/// check so that purely-syntactic differences in the user's input
+/// (e.g. `./foo`, `bar/../foo`) do not look like symlink redirects.
+fn lexical_normalize(p: &std::path::Path) -> std::path::PathBuf {
+    let mut out = std::path::PathBuf::new();
+    for component in p.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                // Pop only if the result already has a non-root tail;
+                // popping at root keeps the path well-formed.
+                if !out.pop() {
+                    out.push(component);
+                }
+            }
+            std::path::Component::CurDir => {}
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 fn cmd_ref_list(cli: &Cli, json: bool) -> Result<()> {
@@ -590,5 +684,80 @@ mod tests {
         let json = serde_json::to_value(&entry).unwrap();
         assert!(json.get("source").is_none());
         assert_eq!(json["chunks"], 0);
+    }
+
+    // SEC-V1.30.1-6 (#1222) — symlink-redirect detection.
+
+    #[test]
+    fn lexical_normalize_resolves_dot_and_dotdot() {
+        let cases = [
+            ("/a/b/./c", "/a/b/c"),
+            ("/a/b/../c", "/a/c"),
+            ("/a/./b/../c", "/a/c"),
+            ("/a/b/c/../..", "/a"),
+            ("/a", "/a"),
+            ("/", "/"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                lexical_normalize(std::path::Path::new(input)),
+                std::path::PathBuf::from(expected),
+                "lexical_normalize({input}) should be {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn symlink_redirect_warning_returns_none_for_identity() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).expect("mkdir real");
+        let canonical = dunce::canonicalize(&real).expect("canonicalize real");
+
+        // User passed the real path; no redirect.
+        let warning = symlink_redirect_warning(&real, &canonical).expect("warn ok");
+        assert!(
+            warning.is_none(),
+            "no symlink → no warning, got {warning:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_redirect_warning_fires_on_symlinked_input() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).expect("mkdir real");
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        let canonical = dunce::canonicalize(&link).expect("canonicalize link");
+        let warning = symlink_redirect_warning(&link, &canonical).expect("warn ok");
+        let msg = warning.expect("symlink should produce a warning");
+        assert!(
+            msg.contains("symlink"),
+            "warning text should mention symlink: {msg}"
+        );
+        assert!(
+            msg.contains(real.to_str().unwrap()),
+            "warning should name the resolved target: {msg}"
+        );
+    }
+
+    #[test]
+    fn symlink_redirect_warning_ignores_purely_syntactic_dotdot() {
+        // User typed `<dir>/sub/../sub/` — lexically equivalent to
+        // `<dir>/sub`, no symlink involved. This must not warn.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real = dir.path().join("sub");
+        std::fs::create_dir(&real).expect("mkdir sub");
+        let weird_input = dir.path().join("sub").join("..").join("sub");
+        let canonical = dunce::canonicalize(&weird_input).expect("canonicalize");
+
+        let warning = symlink_redirect_warning(&weird_input, &canonical).expect("warn ok");
+        assert!(
+            warning.is_none(),
+            "purely syntactic `..` must not look like a symlink, got {warning:?}"
+        );
     }
 }

--- a/src/llm/local.rs
+++ b/src/llm/local.rs
@@ -111,10 +111,17 @@ impl LocalProvider {
             .ok()
             .filter(|s| !s.is_empty());
 
-        // P2.36: align production redirect policy with the doctor probe
-        // (`Policy::limited(2)`). Same-origin HTTP→HTTPS redirects on
-        // bind-localhost are benign; a strict `none()` here disagreed
-        // with what doctor reported reachable, surprising operators.
+        // SEC-V1.30.1-7 (#1223): same-origin redirect policy. Submit
+        // requests carry `Authorization: Bearer <key>` when
+        // CQS_LLM_API_KEY is set. The historical `Policy::limited(2)`
+        // followed redirects to *any* origin — a misconfigured load
+        // balancer that 302s `internal-llm/` → `attacker-host/v1/...`
+        // would surface as a silent 401 loop on the redirect target
+        // (because reqwest 0.12 strips Authorization cross-origin) but
+        // the strip is silent and depends on a default that could
+        // shift across versions. `same_origin_redirect_policy(2)`
+        // refuses cross-origin hops outright with a `tracing::warn!`,
+        // so the failure is loud and the bearer never travels.
         //
         // P3.48: cap idle pool to `concurrency` per-host with a 30s idle
         // timeout. The default reqwest pool is unbounded with a 90s idle
@@ -123,7 +130,7 @@ impl LocalProvider {
         // matching outbound traffic spike.
         let http = Client::builder()
             .timeout(timeout)
-            .redirect(reqwest::redirect::Policy::limited(2))
+            .redirect(crate::llm::redirect::same_origin_redirect_policy(2))
             .pool_max_idle_per_host(concurrency)
             .pool_idle_timeout(Duration::from_secs(30))
             .build()?;

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -19,6 +19,7 @@ mod hyde;
 pub mod local;
 mod prompts;
 pub mod provider;
+pub mod redirect;
 mod summary;
 pub mod validation;
 

--- a/src/llm/redirect.rs
+++ b/src/llm/redirect.rs
@@ -1,0 +1,183 @@
+//! Redirect policies for bearer-bearing HTTP clients.
+//!
+//! `LocalProvider` and the `cqs doctor` LLM probe both target the
+//! user-configured `CQS_LLM_API_BASE`. The submit path attaches an
+//! `Authorization: Bearer <key>` header on every request when
+//! `CQS_LLM_API_KEY` is set.
+//!
+//! reqwest's stock `Policy::limited(N)` follows redirects without
+//! checking the destination origin — and while reqwest 0.12 strips
+//! `Authorization` cross-origin by default, that strip is silent
+//! (operator sees a 401 loop on the redirect target instead of a
+//! clean fail-fast) and it depends on a default that could shift
+//! across versions. SEC-V1.30.1-7 (#1223) closed that gap by adding
+//! `same_origin_redirect_policy`, which:
+//!
+//! 1. Refuses any redirect whose target origin (scheme + host + port)
+//!    differs from the previous hop's origin, with a `tracing::warn!`
+//!    naming both URLs.
+//! 2. Caps the same-origin redirect chain at `max` hops so a
+//!    pathologically misconfigured load balancer can't loop us.
+//!
+//! Refusing the redirect causes `reqwest::send()` to return
+//! `Err(reqwest::Error)` whose `is_redirect()` is true — callers
+//! surface that as a regular request failure, which for `LocalProvider`
+//! flows through the existing retry/backoff path.
+
+use reqwest::redirect::Policy;
+
+/// Build a redirect policy that:
+///
+/// - Refuses cross-origin redirects (scheme / host / port must match
+///   the previous hop). Emits `tracing::warn!` naming the source and
+///   destination URLs and converts the redirect into a `reqwest::Error`
+///   with `is_redirect()=true` so the caller gets a loud fail-fast.
+/// - Caps the same-origin redirect chain at `max` hops by surfacing
+///   the same fail-fast error (matches the historical
+///   `Policy::limited(max)` behavior, which produced a `TooManyRedirects`
+///   error rather than returning the 3xx response).
+///
+/// `max` is the historical `Policy::limited(max)` cap — a value of `0`
+/// disables redirects entirely (any 3xx becomes an error on the first
+/// hop).
+///
+/// We pass error messages through `std::io::Error::new(Other, ..)` so
+/// the surfaced `reqwest::Error::source()` chain still names the
+/// reason without us having to add a public error type to the lib
+/// crate's surface.
+pub fn same_origin_redirect_policy(max: usize) -> Policy {
+    Policy::custom(move |attempt| {
+        if let Some(prev_url) = attempt.previous().last() {
+            if prev_url.origin() != attempt.url().origin() {
+                tracing::warn!(
+                    from = %prev_url,
+                    to = %attempt.url(),
+                    "Refusing cross-origin redirect on bearer-bearing request"
+                );
+                let msg = format!(
+                    "cross-origin redirect refused: {} -> {}",
+                    prev_url,
+                    attempt.url()
+                );
+                return attempt.error(std::io::Error::other(msg));
+            }
+        }
+        if attempt.previous().len() >= max {
+            let msg = format!("redirect chain exceeded {} hops at {}", max, attempt.url());
+            return attempt.error(std::io::Error::other(msg));
+        }
+        attempt.follow()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cross-origin 302 against a request that carries an `Authorization`
+    /// header. The redirect chain server A → server B has different
+    /// `host:port` (httpmock binds each `MockServer::start()` on a
+    /// distinct port), so the same-origin policy must refuse.
+    ///
+    /// We assert at the `reqwest::blocking::Client` level rather than
+    /// going through `LocalProvider::submit_batch_prebuilt` so the
+    /// failure mode is unambiguous: the test fails iff the policy
+    /// itself stops permitting the redirect.
+    #[test]
+    fn cross_origin_redirect_is_refused() {
+        let server_b = httpmock::MockServer::start();
+        let server_a = httpmock::MockServer::start();
+
+        let _redirect_mock = server_a.mock(|when, then| {
+            when.method("GET").path("/redirect");
+            then.status(302)
+                .header("Location", &format!("{}/target", server_b.base_url()));
+        });
+        let target_mock = server_b.mock(|when, then| {
+            when.method("GET").path("/target");
+            then.status(200).body("should never be reached");
+        });
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(3))
+            .redirect(same_origin_redirect_policy(2))
+            .build()
+            .unwrap();
+
+        let result = client
+            .get(format!("{}/redirect", server_a.base_url()))
+            .header("Authorization", "Bearer test-token")
+            .send();
+
+        assert!(
+            result.is_err(),
+            "expected cross-origin redirect to fail, got {result:?}"
+        );
+        let err = result.unwrap_err();
+        assert!(err.is_redirect(), "expected redirect error, got {err}");
+        // The target on server B must NOT have been hit.
+        assert_eq!(
+            target_mock.hits(),
+            0,
+            "cross-origin target was reached — bearer header would have leaked"
+        );
+    }
+
+    /// Same-origin 302 within `max` hops follows cleanly. This is the
+    /// case the original `Policy::limited(2)` covered (HTTP→HTTPS on
+    /// the same host:port, e.g. local TLS terminator) and we must not
+    /// regress it.
+    #[test]
+    fn same_origin_redirect_within_limit_follows() {
+        let server = httpmock::MockServer::start();
+        let _redirect_mock = server.mock(|when, then| {
+            when.method("GET").path("/redirect");
+            then.status(302).header("Location", "/target");
+        });
+        let target_mock = server.mock(|when, then| {
+            when.method("GET").path("/target");
+            then.status(200).body("ok");
+        });
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(3))
+            .redirect(same_origin_redirect_policy(2))
+            .build()
+            .unwrap();
+
+        let resp = client
+            .get(format!("{}/redirect", server.base_url()))
+            .send()
+            .expect("same-origin redirect should follow");
+        assert_eq!(resp.status(), 200);
+        assert_eq!(target_mock.hits(), 1);
+    }
+
+    /// Same-origin chain that exceeds `max` hops stops cleanly. Using
+    /// max=0 forces the very first redirect to stop.
+    #[test]
+    fn same_origin_redirect_chain_capped() {
+        let server = httpmock::MockServer::start();
+        let _redirect_mock = server.mock(|when, then| {
+            when.method("GET").path("/redirect");
+            then.status(302).header("Location", "/target");
+        });
+        let _target_mock = server.mock(|when, then| {
+            when.method("GET").path("/target");
+            then.status(200).body("ok");
+        });
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(3))
+            .redirect(same_origin_redirect_policy(0))
+            .build()
+            .unwrap();
+
+        let result = client.get(format!("{}/redirect", server.base_url())).send();
+        assert!(
+            result.is_err(),
+            "max=0 must stop on first redirect, got {result:?}"
+        );
+        assert!(result.unwrap_err().is_redirect());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1222, #1223. Bundle 4 of the post-v1.30.2 bug drain — security pair (SEC-V1.30.1-6 + SEC-V1.30.1-7).

### #1223 — same-origin redirect policy on bearer-bearing LLM requests

`LocalProvider`'s HTTP client previously used `Policy::limited(2)`, which follows redirects to *any* origin. A misconfigured load balancer that 302s `internal-llm/` → `attacker-host/v1/...` would surface as a silent 401 loop on the redirect target — reqwest 0.12 strips `Authorization` cross-origin by default, but the strip is silent and depends on a default that could shift across versions. The change-rationale comment claimed the policy enforced same-origin; it did not.

**New `cqs::llm::redirect::same_origin_redirect_policy(max)`** builds a `Policy::custom` that:

- Refuses cross-origin redirects (scheme + host + port match) with a `tracing::warn!` naming the source and destination URLs and converts the redirect into a `reqwest::Error` with `is_redirect()=true` so callers see a loud fail-fast instead of a silent strip.
- Caps the same-origin redirect chain at `max` hops via the same fail-fast error (matches historical `Policy::limited` semantics).

Wired into `src/llm/local.rs` (the actual bearer-sender) and the `cqs doctor` LLM probe at `src/cli/commands/infra/doctor.rs` for consistency. The misleading comment block at `LocalProvider::new` is replaced with text that matches what the code actually enforces.

### #1222 — surface symlink resolution in `cqs ref add`

`cmd_ref_add` canonicalizes `--source` via `dunce::canonicalize`, which silently follows symlinks. Operators who symlinked `vendored-monorepo-pull/ → ~/work/customer-A-private/` to "test cqs ref" silently ended up with a customer-content reference index. The persisted `source` in `.cqs.toml` shows the resolved path, so `cqs ref list` is technically truthful — but if the user's mental model is "I added /home/me/projects/foo," the reindex behavior is surprising.

**New `symlink_redirect_warning(source_input, canonical)`** lexically normalizes the absolute form of the user input (resolves `..`, `.`, duplicate separators without touching the FS) and compares against the canonical path. Mismatch → emit `tracing::warn!` naming both paths, plus a `WARN:` line on stderr in non-`--quiet` text mode, plus a `warnings: ["..."]` field on the JSON envelope. The reference is still indexed at the resolved path; the warning is informational only — option (1) from the issue, not the strict-fail option (2).

Lexical normalization avoids false positives on inputs like `/home/me/../me/projects/foo` (where `..` is purely syntactic — no FS lookup needed to flatten it).

`SECURITY.md` updated to document the new redirect surfacing.

## Test plan

- [x] `cargo test --features cuda-index --lib llm::redirect` → 3 pass
  - `cross_origin_redirect_is_refused` — server A 302s to server B (distinct httpmock port → distinct origin); request errors with `is_redirect()=true`, target is never hit
  - `same_origin_redirect_within_limit_follows` — 302 to same-origin path follows cleanly (no regression on HTTP→HTTPS local TLS terminator)
  - `same_origin_redirect_chain_capped` — `max=0` stops on first hop
- [x] `cargo test --features cuda-index --bin cqs reference` → 7 pass (4 new symlink-detection tests + 3 existing)
  - `lexical_normalize_resolves_dot_and_dotdot` — pins `..` / `.` / repeated-separator handling
  - `symlink_redirect_warning_returns_none_for_identity` — non-symlinked path → no warning
  - `symlink_redirect_warning_fires_on_symlinked_input` (unix-only) — real symlink fires the warning and names the resolved target
  - `symlink_redirect_warning_ignores_purely_syntactic_dotdot` — input with `..` that lexically resolves to a real dir → no false positive
- [ ] CI green
- [ ] Manual: `cqs ref add foo /path/to/symlink` (where `symlink → /elsewhere`) prints `WARN:` and the JSON envelope carries `warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
