### PR TITLE
fix(slot): refuse remove if daemon is actively serving the slot

### DIFF
--- a/src/cli/commands/infra/slot.rs
+++ b/src/cli/commands/infra/slot.rs
@@ -338,6 +338,20 @@ fn slot_remove(project_cqs_dir: &Path, name: &str, force: bool, json: bool) -> R
         );
     }
 
+    // DS-V1.30.1-D4 (#1232): refuse if a daemon is currently serving
+    // this slot. The slots lock above pins out concurrent CLI promote /
+    // remove calls but doesn't bind a long-lived `cqs watch --serve`
+    // process — its `Store::open` against `slots/<name>/index.db`
+    // holds open file descriptors that survive `fs::remove_dir_all`
+    // on Linux, leaving WAL checkpoints persisting into a detached
+    // directory tree that's reaped on daemon exit. Operators see no
+    // error, lose hours of incremental rebuild work, and on WSL or
+    // any non-overlay FS the unlink can partially fail and leave the
+    // slot dir half-removed. Probe the daemon before unlinking; if
+    // it's serving this slot, refuse (or downgrade to a warn under
+    // `--force`).
+    guard_against_active_daemon(project_cqs_dir, name, force)?;
+
     let active = read_active_slot(project_cqs_dir).unwrap_or_else(|| DEFAULT_SLOT.to_string());
     // P2.21: don't mask `list_slots` failure as "only slot remaining" — that
     // would falsely error on a transient FS hiccup. Surface the real cause so
@@ -379,6 +393,57 @@ fn slot_remove(project_cqs_dir: &Path, name: &str, force: bool, json: bool) -> R
         if name == active {
             println!("Active slot auto-promoted to '{}'.", all[0]);
         }
+    }
+    Ok(())
+}
+
+/// DS-V1.30.1-D4 (#1232): probe the daemon and refuse if it's serving
+/// the slot the user is about to remove. Mirrors the existing
+/// "this is the active slot" `--force` semantics: refusal becomes a
+/// `tracing::warn!` when `force` is true.
+///
+/// Probe failure (no daemon, transport error, missing slot field) is
+/// treated as "no daemon serving this slot" — the worst case is the
+/// historical behavior, never a false positive. Probe takes ~5 ms when
+/// the daemon is up and ~1 ms when the socket is missing, so the
+/// extra round trip is invisible relative to the index-rebuild path.
+///
+/// Windows has no daemon today (`daemon_status` is unix-gated), so the
+/// guard is a no-op there.
+fn guard_against_active_daemon(project_cqs_dir: &Path, name: &str, force: bool) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let snap = match cqs::daemon_translate::daemon_status(project_cqs_dir) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "daemon probe failed during slot remove; assuming no daemon serving this slot"
+                );
+                return Ok(());
+            }
+        };
+        if snap.active_slot.as_deref() != Some(name) {
+            return Ok(());
+        }
+        if !force {
+            anyhow::bail!(
+                "daemon is currently serving slot '{name}'. \
+                 Stop it first (e.g. `systemctl --user stop cqs-watch`, or kill the \
+                 `cqs watch --serve` process) and re-run, or pass --force to override."
+            );
+        }
+        tracing::warn!(
+            slot = name,
+            "removing slot while daemon is actively serving it (--force); \
+             daemon will hold open file descriptors against the unlinked slot dir \
+             until it exits — incremental rebuild work persisted after this point \
+             may be silently lost"
+        );
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (project_cqs_dir, name, force);
     }
     Ok(())
 }
@@ -545,6 +610,189 @@ mod tests {
         slot_remove(&cqs, "b", false, true).unwrap();
         assert_eq!(read_active_slot(&cqs).as_deref(), Some("a"));
         assert!(!slot_dir(&cqs, "b").exists());
+    }
+
+    // DS-V1.30.1-D4 (#1232) — refuse to unlink a slot dir while a daemon
+    // is actively serving it. These tests stand up a `UnixListener` on
+    // the same socket path `daemon_status` probes and respond with a
+    // `WatchSnapshot` whose `active_slot` field decides the outcome.
+    //
+    // The XDG-shared-state warning from `daemon_translate::tests` applies
+    // here too: each test sets `XDG_RUNTIME_DIR` to a unique tempdir,
+    // and the `serial_test::serial(daemon_socket_xdg)` group keeps these
+    // from racing against the production-side mock-round-trip tests.
+
+    #[cfg(unix)]
+    fn make_snapshot_envelope(slot: Option<&str>) -> String {
+        let snap = cqs::watch_status::WatchSnapshot {
+            state: cqs::watch_status::FreshnessState::Fresh,
+            modified_files: 0,
+            pending_notes: false,
+            rebuild_in_flight: false,
+            delta_saturated: false,
+            incremental_count: 0,
+            dropped_this_cycle: 0,
+            last_event_unix_secs: 0,
+            last_synced_at: Some(0),
+            snapshot_at: Some(0),
+            active_slot: slot.map(|s| s.to_string()),
+        };
+        let inner = serde_json::json!({
+            "data": serde_json::to_value(&snap).unwrap(),
+            "error": null,
+            "version": 1,
+        });
+        let outer = serde_json::json!({
+            "status": "ok",
+            "output": inner,
+        });
+        outer.to_string()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(daemon_socket_xdg)]
+    fn slot_remove_refuses_when_daemon_serves_target() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let _g = ENV_LOCK.lock().unwrap();
+        let xdg = TempDir::new().unwrap();
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        // SAFETY: serial_test gates this; only one daemon-mock test runs at a time.
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", xdg.path());
+        }
+
+        let tmp = with_slots(&["foo", "bar"]);
+        let cqs = tmp.path().join(".cqs");
+        write_active_slot(&cqs, "bar").unwrap();
+
+        let sock_path = cqs::daemon_translate::daemon_socket_path(&cqs);
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let envelope = make_snapshot_envelope(Some("foo"));
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut req = String::new();
+            BufReader::new(&stream).read_line(&mut req).unwrap();
+            writeln!(stream, "{envelope}").unwrap();
+            stream.flush().unwrap();
+        });
+
+        let result = slot_remove(&cqs, "foo", false, true);
+        handle.join().unwrap();
+        let _ = fs::remove_file(&sock_path);
+
+        // SAFETY: paired with the set above.
+        unsafe {
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+
+        let err = result.expect_err("daemon serving 'foo' must block remove");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("daemon is currently serving slot 'foo'"),
+            "error should name the slot and the daemon: {msg}"
+        );
+        assert!(
+            slot_dir(&cqs, "foo").exists(),
+            "slot dir should still exist after refused remove"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(daemon_socket_xdg)]
+    fn slot_remove_with_force_proceeds_despite_daemon() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let _g = ENV_LOCK.lock().unwrap();
+        let xdg = TempDir::new().unwrap();
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", xdg.path());
+        }
+
+        let tmp = with_slots(&["foo", "bar"]);
+        let cqs = tmp.path().join(".cqs");
+        write_active_slot(&cqs, "bar").unwrap();
+
+        let sock_path = cqs::daemon_translate::daemon_socket_path(&cqs);
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let envelope = make_snapshot_envelope(Some("foo"));
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut req = String::new();
+            BufReader::new(&stream).read_line(&mut req).unwrap();
+            writeln!(stream, "{envelope}").unwrap();
+            stream.flush().unwrap();
+        });
+
+        let result = slot_remove(&cqs, "foo", true, true);
+        handle.join().unwrap();
+        let _ = fs::remove_file(&sock_path);
+
+        unsafe {
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+
+        result.expect("--force should override daemon guard");
+        assert!(
+            !slot_dir(&cqs, "foo").exists(),
+            "slot dir should be removed under --force"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(daemon_socket_xdg)]
+    fn slot_remove_allows_when_daemon_serves_different_slot() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let _g = ENV_LOCK.lock().unwrap();
+        let xdg = TempDir::new().unwrap();
+        let prev_xdg = std::env::var("XDG_RUNTIME_DIR").ok();
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", xdg.path());
+        }
+
+        let tmp = with_slots(&["foo", "bar"]);
+        let cqs = tmp.path().join(".cqs");
+        write_active_slot(&cqs, "bar").unwrap();
+
+        let sock_path = cqs::daemon_translate::daemon_socket_path(&cqs);
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        // Daemon claims it's serving "bar"; we want to remove "foo" — should work.
+        let envelope = make_snapshot_envelope(Some("bar"));
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut req = String::new();
+            BufReader::new(&stream).read_line(&mut req).unwrap();
+            writeln!(stream, "{envelope}").unwrap();
+            stream.flush().unwrap();
+        });
+
+        let result = slot_remove(&cqs, "foo", false, true);
+        handle.join().unwrap();
+        let _ = fs::remove_file(&sock_path);
+
+        unsafe {
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+                None => std::env::remove_var("XDG_RUNTIME_DIR"),
+            }
+        }
+
+        result.expect("removing a different slot must not be blocked");
+        assert!(!slot_dir(&cqs, "foo").exists());
     }
 
     #[test]

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -147,6 +147,13 @@ struct WatchState {
     /// throttled stat calls. `None` ⇒ index.db missing or mtime
     /// unreadable on the last stat.
     cached_last_synced_at: Option<i64>,
+    /// DS-V1.30.1-D4 (#1232): slot name resolved at startup. Cloned
+    /// into the watch snapshot every publish so `daemon_status`
+    /// callers (specifically `cqs slot remove`) can know which slot
+    /// the daemon is serving and refuse to unlink it. Owned String
+    /// rather than borrow because `WatchState` outlives the per-tick
+    /// `WatchSnapshotInput`.
+    active_slot: String,
 }
 
 /// PF-V1.30.1-1: how often the watch loop re-stats `index.db` for the
@@ -195,8 +202,8 @@ fn publish_watch_snapshot(
         .as_ref()
         .map(|p| p.delta_saturated)
         .unwrap_or(false);
-    let snap =
-        cqs::watch_status::WatchSnapshot::compute(cqs::watch_status::WatchSnapshotInput::new(
+    let snap = cqs::watch_status::WatchSnapshot::compute(
+        cqs::watch_status::WatchSnapshotInput::new(
             state.pending_files.len(),
             state.pending_notes,
             state.pending_rebuild.is_some(),
@@ -205,7 +212,9 @@ fn publish_watch_snapshot(
             state.dropped_this_cycle,
             state.last_event,
             last_synced_at,
-        ));
+        )
+        .with_active_slot(&state.active_slot),
+    );
     // Poison-recovery: another writer panicking shouldn't silently stop
     // freshness publishing. Recover and overwrite.
     //
@@ -1078,6 +1087,7 @@ pub fn cmd_watch(
             .checked_sub(LAST_SYNCED_REFRESH)
             .unwrap_or_else(std::time::Instant::now),
         cached_last_synced_at: None,
+        active_slot: active_slot.name.clone(),
     };
 
     let mut cycles_since_clear: u32 = 0;

--- a/src/cli/watch/reconcile.rs
+++ b/src/cli/watch/reconcile.rs
@@ -489,6 +489,7 @@ mod tests {
             dropped_this_cycle: 0,
             last_event: std::time::Instant::now(),
             last_synced_at: None,
+            active_slot: None,
             _marker: PhantomData,
         });
         assert_eq!(snap.state, FreshnessState::Stale);

--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -104,6 +104,7 @@ fn test_watch_state() -> WatchState {
             .checked_sub(std::time::Duration::from_secs(60))
             .unwrap_or_else(std::time::Instant::now),
         cached_last_synced_at: None,
+        active_slot: cqs::slot::DEFAULT_SLOT.to_string(),
     }
 }
 

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -1209,6 +1209,7 @@ mod tests {
             last_event_unix_secs: 1_734_120_488,
             last_synced_at: Some(1_734_120_000),
             snapshot_at: Some(1_734_120_500),
+            active_slot: None,
         };
         let inner_envelope = serde_json::json!({
             "data": serde_json::to_value(&snap).unwrap(),
@@ -1523,6 +1524,7 @@ mod tests {
             last_event_unix_secs: 1_734_120_470,
             last_synced_at: Some(1_734_120_000),
             snapshot_at: Some(1_734_120_500),
+            active_slot: None,
         };
         let inner_envelope = serde_json::json!({
             "data": serde_json::to_value(&snap).unwrap(),
@@ -1704,6 +1706,7 @@ mod tests {
                 last_event_unix_secs: 1_734_120_488,
                 last_synced_at: Some(1_734_120_000),
                 snapshot_at: Some(1_734_120_500),
+                active_slot: None,
             };
             let inner = serde_json::json!({
                 "data": serde_json::to_value(&snap).unwrap(),
@@ -1799,6 +1802,7 @@ mod tests {
                 last_event_unix_secs: 1_734_120_488,
                 last_synced_at: Some(1_734_120_000),
                 snapshot_at: Some(1_734_120_500),
+                active_slot: None,
             };
             let inner = serde_json::json!({
                 "data": serde_json::to_value(&snap).unwrap(),

--- a/src/watch_status.rs
+++ b/src/watch_status.rs
@@ -124,6 +124,16 @@ pub struct WatchSnapshot {
     /// downstream freshness gates. Operators see a once-per-process
     /// warn from `now_unix_secs` when this happens.
     pub snapshot_at: Option<i64>,
+    /// DS-V1.30.1-D4 (#1232): name of the slot the daemon is currently
+    /// serving. Lets `cqs slot remove <name>` refuse to unlink a slot
+    /// directory while a long-lived daemon holds open file descriptors
+    /// against `slots/<name>/index.db` — on Linux the unlink succeeds
+    /// against the held inode and the daemon's WAL checkpoints persist
+    /// into a detached directory tree that gets reaped on daemon exit,
+    /// silently losing hours of incremental rebuild work. `None` ⇒
+    /// daemon hasn't published a snapshot yet (still ramping up).
+    #[serde(default)]
+    pub active_slot: Option<String>,
 }
 
 impl WatchSnapshot {
@@ -143,6 +153,7 @@ impl WatchSnapshot {
             last_event_unix_secs: 0,
             last_synced_at: None,
             snapshot_at: now_unix_secs(),
+            active_slot: None,
         }
     }
 
@@ -204,6 +215,12 @@ pub struct WatchSnapshotInput<'a> {
     pub dropped_this_cycle: usize,
     pub last_event: std::time::Instant,
     pub last_synced_at: Option<i64>,
+    /// DS-V1.30.1-D4 (#1232): borrowed slot name set once at watch
+    /// startup. Cloned into the snapshot's `active_slot: Option<String>`
+    /// each tick so the daemon's status response can name what it's
+    /// currently serving. The lifetime ties this borrow to the watch
+    /// loop's owned `WatchState` field.
+    pub active_slot: Option<&'a str>,
     /// Phantom keeps the API future-proof if we add borrow-only fields
     /// (e.g. last-error string). No-op today.
     pub _marker: std::marker::PhantomData<&'a ()>,
@@ -235,8 +252,19 @@ impl<'a> WatchSnapshotInput<'a> {
             dropped_this_cycle,
             last_event,
             last_synced_at,
+            active_slot: None,
             _marker: std::marker::PhantomData,
         }
+    }
+
+    /// DS-V1.30.1-D4 (#1232): builder-style chain for the slot name. The
+    /// watch loop calls `WatchSnapshotInput::new(...).with_active_slot(&s)`
+    /// each tick so the snapshot publishes the slot the daemon is
+    /// serving. Default is `None` to keep existing call sites that
+    /// don't care about slot tracking compiling unchanged.
+    pub fn with_active_slot(mut self, slot: &'a str) -> Self {
+        self.active_slot = Some(slot);
+        self
     }
 }
 
@@ -297,6 +325,7 @@ impl WatchSnapshot {
             last_event_unix_secs,
             last_synced_at: input.last_synced_at,
             snapshot_at: now_unix_secs(),
+            active_slot: input.active_slot.map(|s| s.to_string()),
         }
     }
 }
@@ -327,6 +356,7 @@ mod tests {
             dropped_this_cycle,
             last_event: std::time::Instant::now(),
             last_synced_at: None,
+            active_slot: None,
             _marker: std::marker::PhantomData,
         }
     }
@@ -404,6 +434,7 @@ mod tests {
             dropped_this_cycle: 0,
             last_event: std::time::Instant::now(),
             last_synced_at: None,
+            active_slot: None,
             _marker: std::marker::PhantomData,
         });
         assert_eq!(snap.state, FreshnessState::Stale);
@@ -424,6 +455,7 @@ mod tests {
             dropped_this_cycle: 0,
             last_event: std::time::Instant::now(),
             last_synced_at: None,
+            active_slot: None,
             _marker: std::marker::PhantomData,
         });
         assert_eq!(snap.state, FreshnessState::Rebuilding);


### PR DESCRIPTION
## Summary

Closes #1232. Bundle 5 of the post-v1.30.2 bug drain — slot-remove daemon safety.

`slot_remove` (`src/cli/commands/infra/slot.rs`) previously called `fs::remove_dir_all` on the slot directory without checking whether a long-lived `cqs watch --serve` process was already mmap'd against it. The slots lock prevents concurrent CLI promote/remove races, but doesn't bind the daemon — its `Store::open` against `slots/<name>/index.db` holds open file descriptors that survive `fs::remove_dir_all` on Linux, leaving WAL checkpoints persisting into a detached directory tree that's reaped on daemon exit. Operators see no error, lose hours of incremental rebuild work, and on WSL or any non-overlay FS the unlink can partially fail and leave the slot dir half-removed.

This wires the daemon's currently-served slot into `WatchSnapshot` so `daemon_status` callers know what to refuse.

### Three pieces

**1. `WatchSnapshot.active_slot: Option<String>`** — frozen at watch startup from the resolved slot name. Serializes alongside the existing freshness fields. `#[serde(default)] = None` for backward compat with pre-#1232 daemon snapshots.

**2. `WatchState.active_slot: String`** + `WatchSnapshotInput.active_slot: Option<&'a str>` + `with_active_slot(&str)` builder. The watch loop clones the slot name into the per-tick input via the builder; pure threading through, no new state.

**3. `guard_against_active_daemon` in `slot_remove`** — probes `daemon_status` before unlinking. Refuses if the daemon's `active_slot == name`, downgrades to `tracing::warn!` under `--force`. Probe failure (no daemon, transport error, missing field) is treated as "no daemon serving this slot" so the historical behavior is preserved on hosts without the watch service.

The error message points operators at the systemd unit name and the underlying `cqs watch --serve` process so they know how to stop it:

```
daemon is currently serving slot 'foo'. Stop it first
(e.g. `systemctl --user stop cqs-watch`, or kill the
`cqs watch --serve` process) and re-run, or pass --force to override.
```

Windows has no daemon today (`daemon_status` is unix-gated), so the guard is a no-op there.

## Test plan

- [x] 3 new unit tests in `cli/commands/infra/slot.rs` use a `UnixListener` mock daemon socket pinned to a per-test `XDG_RUNTIME_DIR`:
  - `slot_remove_refuses_when_daemon_serves_target` — daemon claims slot `foo`, `slot_remove("foo", false)` errors with the daemon message; slot dir still exists
  - `slot_remove_with_force_proceeds_despite_daemon` — same setup, `slot_remove("foo", true)` succeeds with a warn; slot dir gone
  - `slot_remove_allows_when_daemon_serves_different_slot` — daemon claims `bar`, `slot_remove("foo", false)` succeeds
- [x] All 7 existing slot_remove tests still pass (4 + 3 = 7 total)
- [x] `cargo test --features cuda-index --lib watch_status` → 12 pass
- [x] `cargo test --features cuda-index --lib daemon_status` → 5 pass (mock-round-trip tests updated for new field)
- [x] `cargo clippy --features cuda-index --bin cqs --lib -- -D warnings` clean
- [ ] CI green
- [ ] Manual: start `cqs watch --serve` against slot `foo`, run `cqs slot remove foo` — expect refusal; `cqs slot remove foo --force` — expect warn + removal

## Compat note

`WatchSnapshot.active_slot` uses `#[serde(default)]` so a daemon running an older binary (which doesn't set this field) still deserializes cleanly into the new shape — the field arrives as `None` and `guard_against_active_daemon` then no-ops, matching the historical behavior. New CLI against old daemon: safe. New CLI against new daemon: full guard. Old CLI against new daemon: ignores the field (forward-compatible serde).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
