### PR TITLE
fix(signal): enable ctrlc termination feature for Windows watch shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ blake3 = "1"
 bytemuck = { version = "1", features = ["derive"] }
 ignore = "0.4"
 notify = { version = "8", features = ["serde"] }
-ctrlc = "3"
+ctrlc = { version = "3", features = ["termination"] }
 rayon = "1"
 crossbeam-channel = "0.5"
 chrono = "0.4"

--- a/README.md
+++ b/README.md
@@ -193,6 +193,19 @@ cqs watch --debounce 1000  # Custom debounce (ms)
 
 Watch mode respects `.gitignore` by default. Use `--no-ignore` to index ignored files.
 
+### Stopping `cqs watch` cleanly
+
+| Platform | Signal | Sender |
+|----------|--------|--------|
+| Linux / macOS / WSL | SIGINT | `Ctrl+C` from launching console |
+| Linux / macOS / WSL | SIGTERM | `systemctl --user stop cqs-watch`, `kill <pid>` |
+| Native Windows | `CTRL_C_EVENT` | `Ctrl+C` from launching console |
+| Native Windows | `CTRL_BREAK_EVENT` | `Stop-Process -Name cqs`, `taskkill /B` |
+| Native Windows | `CTRL_CLOSE_EVENT` | Console window closed |
+| Native Windows | `CTRL_LOGOFF_EVENT` / `CTRL_SHUTDOWN_EVENT` | User logout / system shutdown |
+
+Each of these triggers a clean drain — pending writes flush, the SQLite WAL checkpoints, and the daemon socket is removed. Avoid `taskkill /F` (`TerminateProcess`) on Windows or `kill -9` on Unix: those bypass the drain and risk leaving the index DB in a state that requires `cqs index --force` to recover.
+
 ### Three-layer reconciliation (#1182)
 
 `cqs watch --serve` is **always-recoverable, always-detectable** stale: any working-tree change is reflected within seconds, and you can synchronously query "is the index fresh?" before trusting it.

--- a/src/cli/signal.rs
+++ b/src/cli/signal.rs
@@ -20,19 +20,38 @@ pub enum ExitCode {
 /// Global flag indicating user requested interruption
 static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 
-/// Install Ctrl+C handler for graceful shutdown
+/// Install Ctrl+C handler for graceful shutdown.
 ///
-/// First Ctrl+C sets INTERRUPTED flag, allowing current batch to finish.
-/// Second Ctrl+C force-exits with code 130.
+/// First signal sets `INTERRUPTED`, allowing current batch to finish.
+/// Second signal force-exits with code 130.
+///
+/// DS-V1.30.2-D5 (#1044): with `ctrlc`'s `termination` feature, this
+/// handler catches more than just Ctrl+C:
+///
+/// - **Unix**: SIGINT, SIGTERM, SIGHUP. The watch loop already
+///   installs its own `libc::signal(SIGTERM, ...)` *after* this
+///   handler in `cmd_watch`, so our SIGTERM-specific path
+///   (`SHUTDOWN_REQUESTED`) wins on Unix as before — `ctrlc`'s
+///   coverage there is belt-and-braces for non-watch commands.
+/// - **Windows**: `CTRL_C_EVENT`, `CTRL_BREAK_EVENT` (sent by
+///   `Stop-Process` / `taskkill /B`), `CTRL_CLOSE_EVENT` (console
+///   window closed), `CTRL_LOGOFF_EVENT` (user logout),
+///   `CTRL_SHUTDOWN_EVENT` (system shutdown). This is the
+///   load-bearing change for #1044: native Windows `cqs watch`
+///   deployments can now drain cleanly on every interactive shutdown
+///   path instead of only Ctrl+C from the launching console. The
+///   only Windows path *not* covered is `SERVICE_CONTROL_STOP` from
+///   a Windows Service wrapper — there is no service wrapper shipped
+///   today, so that's out of scope until one ships.
 pub fn setup_signal_handler() {
     if let Err(e) = ctrlc::set_handler(|| {
         if INTERRUPTED.swap(true, Ordering::AcqRel) {
-            // Second Ctrl+C: force exit
+            // Second signal: force exit.
             std::process::exit(ExitCode::Interrupted as i32);
         }
         eprintln!("\nInterrupted. Finishing current batch...");
     }) {
-        tracing::warn!(error = %e, "Failed to set Ctrl+C handler");
+        tracing::warn!(error = %e, "Failed to set signal handler");
     }
 }
 

--- a/src/cli/watch/runtime.rs
+++ b/src/cli/watch/runtime.rs
@@ -11,9 +11,15 @@ use std::sync::Arc;
 
 /// RM-V1.25-9: Set on SIGTERM so the watch loop drains and exits
 /// cleanly instead of being hard-killed mid-write when systemd
-/// sends `stop`. `ctrlc` without the `termination` feature only
-/// traps SIGINT, and we don't want to grow a dep just for this
-/// one unix-only hook.
+/// sends `stop`. The cross-platform `ctrlc::set_handler` (with the
+/// `termination` feature, since #1044 / DS-V1.30.2-D5) also raises
+/// SIGTERM into our `INTERRUPTED` flag — we keep this dedicated
+/// libc::signal path because the daemon socket accept loop polls
+/// `daemon_should_exit` (the OR of `SHUTDOWN_REQUESTED` and
+/// `INTERRUPTED`) and the SIGTERM handler must be async-signal-safe
+/// in the strict POSIX sense; the `ctrlc` path runs the closure on
+/// a separate thread, which the daemon-shutdown protocol can't rely
+/// on for ordering.
 #[cfg(unix)]
 static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 


### PR DESCRIPTION
## Summary

Closes #1044. Bundle 6 of the post-v1.30.2 bug drain — native Windows watch shutdown.

DS-V1.30.2-D5: native Windows `cqs watch` deployments could not stop cleanly. The `ctrlc` crate was loaded without the `termination` feature, so `ctrlc::set_handler` only trapped `CTRL_C_EVENT`. Every non-Ctrl+C shutdown path on Windows either silently no-op'd (`taskkill <pid>`'s `WM_CLOSE` on a console-mode app) or hard-killed the process mid-write (`taskkill /F` → `TerminateProcess`), risking SQLite WAL corruption that requires `cqs index --force` to recover.

### Fix

Enable `ctrlc`'s `termination` feature so `set_handler` surfaces every interactive Windows shutdown event through the same `INTERRUPTED` flag the watch loop already polls (`check_interrupted` at the top of every cycle).

| Windows event | Sender | Was covered? | Now covered? |
|---------------|--------|--------------|--------------|
| `CTRL_C_EVENT` | Ctrl+C from launching console | ✓ | ✓ |
| `CTRL_BREAK_EVENT` | `Stop-Process -Name cqs`, `taskkill /B` | ✗ | ✓ |
| `CTRL_CLOSE_EVENT` | Console window closed | ✗ | ✓ |
| `CTRL_LOGOFF_EVENT` | User logout | ✗ | ✓ |
| `CTRL_SHUTDOWN_EVENT` | System shutdown | ✗ | ✓ |

Each of these now triggers a clean drain — pending writes flush, the SQLite WAL checkpoints, and the daemon socket is removed.

### What's still not covered (out of scope)

`SERVICE_CONTROL_STOP` from a Windows Service wrapper. There's no service wrapper shipped today; if one ever ships, that's option B in the issue (requires a `windows` crate dep + `SetConsoleCtrlHandler`).

### Unix interaction

On Unix, `ctrlc` with `termination` would also raise SIGTERM into `INTERRUPTED`. The existing `cmd_watch::install_sigterm_handler` runs *after* `setup_signal_handler` and re-installs `libc::signal(SIGTERM, ...)` directly, so the unix daemon's `SHUTDOWN_REQUESTED` path remains load-bearing — the daemon socket accept loop polls `daemon_should_exit`, the OR of `SHUTDOWN_REQUESTED` and `INTERRUPTED`. The ctrlc termination coverage is belt-and-braces on Unix for non-watch commands. Pre-existing comments in `runtime.rs` updated to reflect the new ctrlc behavior.

## Test plan

- [x] `cargo build --features cuda-index` clean
- [x] `cargo test --features cuda-index --lib signal` → 5 pass
- [x] `cargo test --features cuda-index --bin cqs cli::signal::tests` → 1 pass (existing test_reset_interrupted_clears_flag)
- [ ] CI green
- [ ] Manual on a native Windows host: start `cqs watch --serve`, then `Stop-Process -Name cqs` from another PowerShell — index DB should be clean on next `cqs status`. (Cannot validate from WSL.)

README documents the per-platform shutdown signal matrix so operators know the right tool for each OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
