### PR TITLE
test+perf: TC-ADV reconcile coverage + TRT engine cache persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,11 +720,11 @@ Both splits are ±2-3pp noisy on a single trial; quote both when comparing confi
 
 ## Environment Variables
 
-118 knobs total. Quick index by domain (everything is searchable in the table below):
+119 knobs total. Quick index by domain (everything is searchable in the table below):
 
 - **Trust / injection defence** — `CQS_TRUST_DELIMITERS`, `CQS_SUMMARY_VALIDATION`
 - **Retrieval & search** — `CQS_RRF_K`, `CQS_TYPE_BOOST`, `CQS_SPLADE_ALPHA*`, `CQS_RERANK*`, `CQS_RERANKER_*`, `CQS_CENTROID_*`, `CQS_MMR_LAMBDA`, `CQS_FORCE_BASE_INDEX`, `CQS_DISABLE_BASE_INDEX`, `CQS_QUERY_CACHE_*`
-- **Indexing & embedding** — `CQS_EMBEDDING_*`, `CQS_EMBED_*`, `CQS_ONNX_DIR`, `CQS_HNSW_*`, `CQS_CAGRA_*`, `CQS_SPARSE_CHUNKS_PER_TX`, `CQS_SPLADE_BATCH/MAX_*/MODEL/THRESHOLD/RESET_EVERY`, `CQS_PARSER_MAX_*`, `CQS_PARSE_CHANNEL_DEPTH`, `CQS_FILE_BATCH_SIZE`, `CQS_DEFERRED_FLUSH_INTERVAL`, `CQS_FTS_NORMALIZE_MAX`, `CQS_MAX_FILE_SIZE`, `CQS_MAX_QUERY_BYTES`, `CQS_MAX_SEQ_LENGTH`, `CQS_MAX_CONTRASTIVE_CHUNKS`, `CQS_MD_*`, `CQS_SKIP_ENRICHMENT`, `CQS_HYDE_MAX_TOKENS`, `CQS_RAYON_THREADS`
+- **Indexing & embedding** — `CQS_EMBEDDING_*`, `CQS_EMBED_*`, `CQS_ONNX_DIR`, `CQS_HNSW_*`, `CQS_CAGRA_*`, `CQS_TRT_ENGINE_CACHE`, `CQS_SPARSE_CHUNKS_PER_TX`, `CQS_SPLADE_BATCH/MAX_*/MODEL/THRESHOLD/RESET_EVERY`, `CQS_PARSER_MAX_*`, `CQS_PARSE_CHANNEL_DEPTH`, `CQS_FILE_BATCH_SIZE`, `CQS_DEFERRED_FLUSH_INTERVAL`, `CQS_FTS_NORMALIZE_MAX`, `CQS_MAX_FILE_SIZE`, `CQS_MAX_QUERY_BYTES`, `CQS_MAX_SEQ_LENGTH`, `CQS_MAX_CONTRASTIVE_CHUNKS`, `CQS_MD_*`, `CQS_SKIP_ENRICHMENT`, `CQS_HYDE_MAX_TOKENS`, `CQS_RAYON_THREADS`
 - **Daemon, watch, batch** — `CQS_NO_DAEMON`, `CQS_DAEMON_*`, `CQS_MAX_DAEMON_CLIENTS`, `CQS_BATCH_*IDLE_MINUTES`, `CQS_REFS_LRU_SIZE`, `CQS_WATCH_*`, `CQS_CHAT_HISTORY`
 - **Graph & impact** — `CQS_CALL_GRAPH_MAX_EDGES`, `CQS_TYPE_GRAPH_MAX_EDGES`, `CQS_GATHER_MAX_NODES`, `CQS_IMPACT_MAX_*`, `CQS_TRACE_MAX_NODES`, `CQS_TEST_MAP_MAX_NODES`
 - **SQLite storage** — `CQS_BUSY_TIMEOUT_MS`, `CQS_IDLE_TIMEOUT_SECS`, `CQS_MAX_CONNECTIONS`, `CQS_MMAP_SIZE`, `CQS_SQLITE_CACHE_SIZE`, `CQS_CACHE_MAX_SIZE`, `CQS_INTEGRITY_CHECK`, `CQS_SKIP_INTEGRITY_CHECK`, `CQS_MIGRATE_REQUIRE_BACKUP`
@@ -879,6 +879,7 @@ Both splits are ±2-3pp noisy on a single trial; quote both when comparing confi
 | `CQS_TEST_MAP_MAX_NODES` | `10000` | Max BFS nodes in test-map traversal |
 | `CQS_MMR_LAMBDA` | unset (disabled) | Maximum Marginal Relevance λ ∈ `[0.0, 1.0]` for opt-in result diversification. `1.0` = pure relevance (no-op), `0.0` = pure diversity. Disabled by default. |
 | `CQS_TRACE_MAX_NODES` | `10000` | Max nodes in call chain trace |
+| `CQS_TRT_ENGINE_CACHE` | `1` (on) | Persist compiled TensorRT engines + timing cache to `~/.cache/cqs/trt-engine-cache/` so daemon restarts reuse the engine instead of paying the 4–90 s per-model compile cost again. Set to `0` to opt out (forces re-compile every session — useful for validating that a driver upgrade invalidated the cache). Cache invalidates automatically when (model bytes, GPU SM, TRT version) changes. |
 | `CQS_TRUST_DELIMITERS` | `1` (on) | Wraps every chunk's `content` in `<<<chunk:{id}>>> ... <<</chunk:{id}>>>` markers so prompt-injection guards downstream of cqs detect content boundaries when the agent inlines the rendered string into a larger prompt. Set to `0` to opt out (raw text). Default flipped on in v1.30.2. (#1167, #1181) |
 | `CQS_TRAIN_GIT_SHOW_MAX_BYTES` | `52428800` (50 MiB) | Max bytes retrieved per file via `git show` during training-data extraction. Files above the cap are skipped; bump to capture larger generated files (schema dumps, vendored corpora). |
 | `CQS_TYPE_BOOST` | `1.2` | Multiplier applied to chunks whose type matches the query filter (e.g. `--include-type function`) |

--- a/src/cli/watch/reconcile.rs
+++ b/src/cli/watch/reconcile.rs
@@ -985,6 +985,102 @@ mod tests {
         assert_eq!(pending.len(), 1, "queue must contain exactly one entry");
     }
 
+    /// TC-ADV-1.30.1-5 / #1242: clock skew that lands `stored_mtime`
+    /// ahead of disk mtime (NTP step backward, system-clock change, VM
+    /// drift, file restored from a backup taken on a host with a
+    /// different clock) must NOT trigger a reindex storm when content
+    /// is unchanged. Pre-v23, the `disk_mtime != stored_mtime`
+    /// predicate would re-queue every file in the index until disk
+    /// caught up. The v23 BLAKE3 tiebreak under `MtimeOrHash` policy
+    /// short-circuits when the hash matches — regardless of which
+    /// side of the tie the mtime is on.
+    ///
+    /// Pinning this case alongside
+    /// `run_daemon_reconcile_blake3_skips_mtime_only_bump_with_identical_content`
+    /// (which tests the *forward* skew direction) protects against a
+    /// regression where someone reverts the predicate to `disk > stored`
+    /// — that would silently skip future-stored-mtime files even when
+    /// their content actually changed (different bug, same family).
+    #[test]
+    fn run_daemon_reconcile_blake3_skips_future_stored_mtime_with_identical_content() {
+        use cqs::parser::{Chunk, ChunkType, Language};
+        use cqs::store::FileFingerprint;
+        use std::time::{Duration, SystemTime};
+
+        let dir = TempDir::new().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        fs::create_dir_all(&cqs_dir).unwrap();
+        let src_dir = dir.path().join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+
+        let rel = "src/skewed.rs";
+        let abs = dir.path().join(rel);
+        let bytes = b"fn skewed() {}";
+        fs::write(&abs, bytes).unwrap();
+
+        // Stored mtime is 24 h in the FUTURE (clock skewed backward —
+        // index was written when system clock was a day ahead, then
+        // NTP step pulled it back). Current disk mtime is "now"; stored
+        // is now+24h. Both directions of skew should land on the same
+        // BLAKE3-tiebreak path because `MtimeOrHash` keys off `!=`, not
+        // `<` or `>`.
+        let stored_mtime_ms = cqs::duration_to_mtime_millis(
+            (SystemTime::now() + Duration::from_secs(24 * 60 * 60))
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap(),
+        );
+        let chunk_content = "fn skewed() {}".to_string();
+        let hash_str = blake3::hash(chunk_content.as_bytes()).to_hex().to_string();
+        let chunk = Chunk {
+            id: format!("{rel}:1:{}", &hash_str[..8]),
+            file: PathBuf::from(rel),
+            language: Language::Rust,
+            chunk_type: ChunkType::Function,
+            name: "skewed".to_string(),
+            signature: "fn skewed()".to_string(),
+            content: chunk_content,
+            doc: None,
+            line_start: 1,
+            line_end: 1,
+            content_hash: hash_str,
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        };
+
+        let store = open_store(&cqs_dir);
+        store
+            .upsert_chunks_batch(
+                &[(chunk, placeholder_embedding(0.0))],
+                Some(stored_mtime_ms),
+            )
+            .expect("seed chunk at future stored mtime");
+        let stored_fp = FileFingerprint {
+            mtime: Some(stored_mtime_ms),
+            size: Some(bytes.len() as u64),
+            content_hash: Some(*blake3::hash(bytes).as_bytes()),
+        };
+        store
+            .set_file_fingerprint(&PathBuf::from(rel), &stored_fp)
+            .expect("stamp v23 fingerprint with future mtime");
+
+        let mut pending: HashSet<PathBuf> = HashSet::new();
+        let queued = run_daemon_reconcile(
+            &store,
+            dir.path(),
+            &parser(),
+            false,
+            &mut pending,
+            usize::MAX,
+        );
+        assert_eq!(
+            queued, 0,
+            "future stored mtime + matching hash must keep the file out of the queue (clock-skew safety)"
+        );
+        assert!(pending.is_empty());
+    }
+
     /// #1245: `normalize_pending_path` directly — backslashes get rewritten,
     /// already-clean paths pass through. Pin the path-mangling rules so a
     /// future tweak doesn't silently change behavior.

--- a/src/embedder/provider.rs
+++ b/src/embedder/provider.rs
@@ -166,6 +166,38 @@ fn ensure_ort_provider_libs() {
     );
 }
 
+/// Resolve the on-disk cache directory for TensorRT engine binaries +
+/// timing tactic results, or return `None` when caching is opted out.
+///
+/// TRT compiles each ONNX graph into a hardware-specific engine on
+/// first use — 4-5 s for SPLADE-Code (33M params), 30-90 s for
+/// BGE-large (340M). Without persistent caching the daemon pays the
+/// compile cost on every restart. With caching, the engine is reused
+/// until any identity input (model bytes, GPU SM, TRT version) changes,
+/// at which point TRT silently re-compiles and overwrites the cached
+/// blob.
+///
+/// Cache layout under `~/.cache/cqs/trt-engine-cache/`:
+/// - `TensorrtExecutionProvider_TRTKernel_*.engine` — compiled engines
+/// - `TensorrtExecutionProvider.cache` — timing tactic results
+///
+/// Both are safe to delete; missing files cause TRT to re-compile
+/// transparently. Cache directory is created on demand.
+///
+/// Set `CQS_TRT_ENGINE_CACHE=0` to disable persistence — the helper
+/// returns `None` and `create_session` falls through to a no-cache
+/// TensorRT builder. Useful when validating that a driver upgrade
+/// invalidated the cache, or to force a clean compile after a known
+/// regression.
+fn trt_cache_dir() -> Option<PathBuf> {
+    if std::env::var("CQS_TRT_ENGINE_CACHE").as_deref() == Ok("0") {
+        return None;
+    }
+    let dir = dirs::cache_dir()?.join("cqs").join("trt-engine-cache");
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir)
+}
+
 /// Cached GPU provider detection result
 static CACHED_PROVIDER: OnceCell<ExecutionProvider> = OnceCell::new();
 
@@ -275,9 +307,29 @@ pub(crate) fn create_session(
             .commit_from_file(model_path)
             .map_err(ort_err)?,
         ExecutionProvider::TensorRT { device_id } => {
+            // TRT compiles each ONNX model into an engine on first use,
+            // taking 5 s for SPLADE-Code (33M params) and 30-90 s for
+            // BGE-large (340M). Persisting the compiled engine + the
+            // optimization tactic timing cache to disk amortizes that
+            // cost to once-per-(model, GPU, TRT version) instead of
+            // once-per-daemon-restart. Cache is invalidated automatically
+            // when any of those identity inputs change.
+            //
+            // Set `CQS_TRT_ENGINE_CACHE=0` to opt out (forces re-compile
+            // every session — useful when validating that a driver
+            // upgrade did invalidate the cache).
+            let mut tensorrt = TensorRT::default().with_device_id(device_id);
+            if let Some(cache_dir) = trt_cache_dir() {
+                let cache_str = cache_dir.to_string_lossy().into_owned();
+                tensorrt = tensorrt
+                    .with_engine_cache(true)
+                    .with_engine_cache_path(cache_str.clone())
+                    .with_timing_cache(true)
+                    .with_timing_cache_path(cache_str);
+            }
             builder
                 .with_execution_providers([
-                    TensorRT::default().with_device_id(device_id).build(),
+                    tensorrt.build(),
                     // Fallback to CUDA for unsupported ops
                     CUDA::default().with_device_id(device_id).build(),
                 ])
@@ -320,6 +372,13 @@ mod tests {
     //! splits — pin them here.
     use super::*;
 
+    /// Shared mutex for tests that mutate process-global env vars
+    /// (`LD_LIBRARY_PATH`, `CQS_TRT_ENGINE_CACHE`). Each env-mutating
+    /// test takes this lock before any `env::set_var` / `env::remove_var`
+    /// and releases it after restoring the prior value, guaranteeing
+    /// linearization across parallel test threads.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// `select_provider` must be idempotent: subsequent calls return the
     /// same `ExecutionProvider` value (OnceCell semantics). Hardware-agnostic;
     /// only checks consistency, not which provider was selected.
@@ -345,9 +404,7 @@ mod tests {
     #[test]
     fn find_ld_library_dir_skips_empty_entries() {
         use std::env;
-        // Env-mutating tests must serialize: reuse a module-local mutex.
-        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev = env::var_os("LD_LIBRARY_PATH");
         // SAFETY: this test holds ENV_LOCK; no other test in this module
         // touches LD_LIBRARY_PATH concurrently.
@@ -374,8 +431,7 @@ mod tests {
     #[test]
     fn find_ld_library_dir_handles_unset() {
         use std::env;
-        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let prev = env::var_os("LD_LIBRARY_PATH");
         unsafe {
             env::remove_var("LD_LIBRARY_PATH");
@@ -430,5 +486,66 @@ mod tests {
         let p2 = p; // exercises Copy
         let _ = format!("{p:?}");
         let _ = format!("{p2:?}");
+    }
+
+    /// `trt_cache_dir` resolves to a writable directory under the user
+    /// cache root and creates it on demand. A `None` return would
+    /// silently disable engine caching — the helper guarantees `Some`
+    /// on a normal system, so pinning the contract here protects against
+    /// a future refactor that fails-open and erases the once-per-restart
+    /// compile-cost amortization.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn trt_cache_dir_creates_directory_under_user_cache() {
+        // Env-mutating tests serialize via the module-local mutex.
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("CQS_TRT_ENGINE_CACHE").ok();
+        // SAFETY: tests run sequentially within this guard; restored below.
+        unsafe { std::env::remove_var("CQS_TRT_ENGINE_CACHE") };
+
+        let path = trt_cache_dir().expect("trt_cache_dir must resolve on a normal system");
+        let is_dir = path.is_dir();
+        let suffix_ok = path.ends_with("cqs/trt-engine-cache");
+
+        // SAFETY: see above.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("CQS_TRT_ENGINE_CACHE", v),
+                None => std::env::remove_var("CQS_TRT_ENGINE_CACHE"),
+            }
+        }
+
+        assert!(is_dir, "expected directory at {}", path.display());
+        assert!(
+            suffix_ok,
+            "expected path to end with cqs/trt-engine-cache, got {}",
+            path.display()
+        );
+    }
+
+    /// `CQS_TRT_ENGINE_CACHE=0` opts out of engine caching. The helper
+    /// must return `None`, and `create_session` short-circuits to the
+    /// no-cache TRT builder. Pinning the opt-out path protects the
+    /// "force re-compile after driver upgrade" workflow from a
+    /// regression that would silently keep using the stale cache.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn trt_cache_dir_returns_none_when_opted_out() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("CQS_TRT_ENGINE_CACHE").ok();
+        // SAFETY: tests run sequentially within this guard; restored below.
+        unsafe { std::env::set_var("CQS_TRT_ENGINE_CACHE", "0") };
+
+        let result = trt_cache_dir();
+
+        // SAFETY: see above.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("CQS_TRT_ENGINE_CACHE", v),
+                None => std::env::remove_var("CQS_TRT_ENGINE_CACHE"),
+            }
+        }
+
+        assert!(result.is_none(), "opt-out must yield None");
     }
 }

--- a/src/store/chunks/staleness.rs
+++ b/src/store/chunks/staleness.rs
@@ -2015,4 +2015,37 @@ mod tests {
         let stats = store.stats().unwrap();
         assert_eq!(stats.total_chunks, 1);
     }
+
+    /// TC-ADV-1.30.1-6 / #1243: `FileFingerprint::read_disk` returns
+    /// `None` when `metadata()` fails. The `reconcile.rs:188` "leave
+    /// to GC" branch is keyed on this contract: if `metadata()` errs
+    /// (deleted-since-walk, permission flip on the parent dir,
+    /// transient AV scan), reconcile must skip the file rather than
+    /// queue it for reindex — otherwise every unreadable file would
+    /// re-queue every reconcile pass (default 30 s) until external
+    /// state changed.
+    ///
+    /// A nonexistent path is the cleanest reproduction of the failure
+    /// mode: deleted-since-walk, permission-denied on parent, and the
+    /// transient AV-scan window all surface the same way at line 133's
+    /// `metadata().ok()? -> None`. Pinning the contract here protects
+    /// against a future "helpful" refactor that defaults the
+    /// fingerprint fields and silently re-queues unreadable files.
+    #[test]
+    fn test_read_disk_returns_none_on_metadata_err() {
+        use crate::store::{FileFingerprint, FingerprintPolicy};
+        use std::path::PathBuf;
+        let nonexistent = PathBuf::from("/nonexistent/cqs-test-path-must-not-exist-87a4f1ec");
+        let stored = FileFingerprint {
+            mtime: Some(0),
+            size: Some(0),
+            content_hash: None,
+        };
+        let result =
+            FileFingerprint::read_disk(&nonexistent, &stored, FingerprintPolicy::MtimeOrHash);
+        assert!(
+            result.is_none(),
+            "metadata() failure must surface as None — the leave-to-GC signal that reconcile.rs:188 relies on"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Two adversarial test additions from the v1.30.1 audit P3 backlog plus a TensorRT engine-cache perf fix.

### Tests

| Issue | Test | File |
|---|---|---|
| #1242 (TC-ADV-1.30.1-5) | `run_daemon_reconcile_blake3_skips_future_stored_mtime_with_identical_content` — pins that clock skew landing `stored_mtime` *ahead* of disk mtime doesn't re-queue unchanged content. Companion to the existing `run_daemon_reconcile_blake3_skips_mtime_only_bump_with_identical_content` (forward direction). | `src/cli/watch/reconcile.rs::tests` |
| #1243 (TC-ADV-1.30.1-6) | `test_read_disk_returns_none_on_metadata_err` — pins that `FileFingerprint::read_disk` returns `None` when `metadata()` fails (deleted-since-walk, permission flip, transient AV scan). The `reconcile.rs:188` "leave to GC" branch depends on this contract. | `src/store/chunks/staleness.rs::tests` |

### TensorRT engine cache

- `create_session` now wires `with_engine_cache` + `with_engine_cache_path` + `with_timing_cache` + `with_timing_cache_path` on the TRT branch. Cache dir `~/.cache/cqs/trt-engine-cache/` (created on demand via new `trt_cache_dir()` helper).
- New `CQS_TRT_ENGINE_CACHE` env knob (default on, set to `0` to opt out — useful for forcing re-compile after a driver upgrade). Documented in README env-var table; count bumped 118 → 119.
- Two unit tests pin the helper's happy path + opt-out semantic.

Without the engine cache, every daemon restart pays the ~4 s SPLADE compile plus ~30–90 s BGE-large compile. With the cache, those costs amortize to once per `(model bytes, GPU SM, TRT version)` — TRT invalidates automatically when any identity input changes.

### Drive-by

Hoisted the per-test `ENV_LOCK` statics in `provider.rs::tests` to a module-level static so env-mutating tests actually serialize against each other. The previous pattern was independent locks per test, which provided no real serialization.

## Test plan

- [x] `cargo test --features cuda-index --lib -- run_daemon_reconcile_blake3_skips_future_stored_mtime test_read_disk_returns_none_on_metadata_err trt_cache_dir` — all 3 pass
- [x] `cargo test --features cuda-index --bin cqs -- run_daemon_reconcile_blake3_skips_future` — passes
- [x] `cargo clippy --features cuda-index -- -D warnings` clean
- [x] `cargo fmt`
- [ ] CI green
- [ ] Post-merge: verify `~/.cache/cqs/trt-engine-cache/` populates on first daemon restart with the new binary, and that the second restart is fast (no re-compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Closes #1242, closes #1243.
