### PR TITLE
fix(hnsw): release load-phase shared flock before returning HnswIndex

### DIFF
--- a/src/hnsw/mod.rs
+++ b/src/hnsw/mod.rs
@@ -181,9 +181,20 @@ pub struct HnswIndex {
     pub(crate) ef_search: usize,
     /// Embedding dimension of vectors in this index
     pub(crate) dim: usize,
-    /// Shared lock held for the lifetime of a disk-loaded index (DS-NEW-1).
-    /// Prevents concurrent `save()` from overwriting files while this index is in use.
-    /// `None` for in-memory-only indexes that were never loaded from disk.
+    /// Vestigial. Always `None`.
+    ///
+    /// Pre-fix this held a shared `flock(2)` for the lifetime of a
+    /// disk-loaded index, intended to block concurrent `save()` from
+    /// overwriting files while this index was in use. In practice the
+    /// lifetime-held shared lock self-deadlocked the daemon's rebuild
+    /// thread on its next `save()` (Linux flock's exclusive lock waits
+    /// for *all* shared holders, including ones held by the same
+    /// process via a different open description). The lock is now
+    /// released at the end of `load_with_dim` after the data is in
+    /// memory; this field is kept on the struct so existing call sites
+    /// (in-memory-built indexes via `build.rs`) continue to compile
+    /// without churn, and so a future per-process-aware locking
+    /// strategy can repopulate it without re-introducing the field.
     pub(crate) _lock_file: Option<std::fs::File>,
 }
 

--- a/src/hnsw/persist.rs
+++ b/src/hnsw/persist.rs
@@ -679,10 +679,29 @@ impl HnswIndex {
             return Err(HnswError::NotFound(dir.display().to_string()));
         }
 
-        // Acquire shared lock for load (allows concurrent reads)
-        // NOTE: File locking is advisory only on WSL over 9P.
-        // This prevents concurrent cqs processes from corrupting the index,
-        // but cannot protect against external Windows process modifications.
+        // Acquire shared lock for the read phase only (released before
+        // return). Protects the on-disk graph/data/ids/checksum files
+        // from being overwritten by a concurrent `save()` while this
+        // function is reading them — once the data is in memory the
+        // copy is independent and the lock is no longer needed.
+        //
+        // NOTE: File locking is advisory only on WSL over 9P. The lock
+        // is best-effort cross-process; an external Windows tool can
+        // still modify the files.
+        //
+        // **Why the lock must NOT outlive the read phase**: prior to
+        // this PR, `_lock_file: Some(lock_file)` was stored on the
+        // returned `HnswIndex`, keeping the shared lock alive for the
+        // index's entire lifetime. The same daemon process's HNSW
+        // rebuild thread then called `save()` from a *second* file
+        // descriptor on the same lock path; Linux `flock(2)`'s
+        // exclusive-waits-for-shared-even-self semantics deadlocked
+        // the rebuild thread permanently. With the lock dropped at
+        // the bottom of this function, the load and save paths use
+        // disjoint open descriptions and the in-process self-deadlock
+        // can't form. Cross-process exclusion during runtime was
+        // theoretical anyway — concurrent writers race on the SQLite
+        // writer lock first.
         let lock_path = dir.join(format!("{}.hnsw.lock", basename));
         let lock_file = std::fs::OpenOptions::new()
             .read(true)
@@ -692,7 +711,7 @@ impl HnswIndex {
             .open(&lock_path)?;
         lock_file.lock_shared().map_err(HnswError::Io)?;
         warn_wsl_advisory_locking(dir);
-        tracing::debug!(lock_path = %lock_path.display(), "Acquired HNSW load lock (shared)");
+        tracing::debug!(lock_path = %lock_path.display(), "Acquired HNSW load lock (shared, released after read)");
 
         tracing::info!(dir = %dir.display(), basename, "Loading HNSW index");
         verify_hnsw_checksums(dir, basename)?;
@@ -829,12 +848,22 @@ impl HnswIndex {
 
         tracing::info!(count = id_map.len(), "HNSW index loaded");
 
+        // Release the load-phase shared lock before returning. The
+        // in-memory `Loaded(...)` variant is fully self-contained
+        // (vectors copied into rust-allocated buffers via `bincode`,
+        // not mmap'd), so the on-disk file can be modified or removed
+        // without affecting this instance. Keeping the lock alive
+        // across the return would self-deadlock the daemon's rebuild
+        // thread on its next `save()` (Linux flock; see comment at the
+        // lock acquisition site above).
+        drop(lock_file);
+
         Ok(Self {
             inner: HnswInner::Loaded(loaded),
             id_map,
             ef_search: super::ef_search(),
             dim,
-            _lock_file: Some(lock_file),
+            _lock_file: None,
         })
     }
 
@@ -1189,6 +1218,86 @@ mod tests {
         let loaded2 = HnswIndex::load_with_dim(tmp.path(), basename, crate::EMBEDDING_DIM).unwrap();
         assert_eq!(loaded1.len(), 2);
         assert_eq!(loaded2.len(), 2);
+    }
+
+    /// Regression for the in-process flock self-deadlock between
+    /// `load_with_dim`'s shared lock and a subsequent `save()`'s
+    /// exclusive lock. Pre-fix the load held a `shared` flock for the
+    /// entire lifetime of the returned `HnswIndex` via the
+    /// `_lock_file` field; the daemon's HNSW rebuild thread then opened
+    /// a *second* fd on the same lock path inside `save()` and called
+    /// `lock()` (exclusive), which blocks forever on Linux because
+    /// `flock(2)` exclusive-waits for *all* shared holders, including
+    /// ones held by the same process via a different open description.
+    /// In production this manifested as a permanently `state == rebuilding`
+    /// daemon with one `cqs-hnsw-rebuild` thread parked in
+    /// `locks_lock_inode_wait`.
+    ///
+    /// The fix releases the load lock at the end of `load_with_dim`
+    /// (the in-memory `Loaded(...)` is independent of the on-disk
+    /// files), so a same-process `save()` after a `load()` can proceed.
+    /// We model this by loading the on-disk index, then saving a *fresh*
+    /// `HnswIndex` (built in memory) to the same directory while the
+    /// loaded handle is still alive — pre-fix this hangs indefinitely.
+    /// We bound the save in a worker thread with a 5-second timeout so
+    /// the test fails fast on regression instead of hanging the suite.
+    #[test]
+    fn load_does_not_block_subsequent_save_in_same_process() {
+        use std::sync::mpsc::{channel, RecvTimeoutError};
+        use std::time::Duration;
+
+        let tmp = TempDir::new().unwrap();
+        let basename = "deadlock_repro";
+
+        let initial = HnswIndex::build_with_dim(
+            vec![
+                ("chunk1".to_string(), make_embedding(1)),
+                ("chunk2".to_string(), make_embedding(2)),
+            ],
+            crate::EMBEDDING_DIM,
+        )
+        .unwrap();
+        initial.save(tmp.path(), basename).unwrap();
+
+        // Step 2: load the on-disk HNSW. Pre-fix this stashes a shared
+        // flock in `_lock_file` that lives until `_loaded` drops at the
+        // end of the test scope.
+        let _loaded = HnswIndex::load_with_dim(tmp.path(), basename, crate::EMBEDDING_DIM)
+            .expect("load should succeed");
+
+        // Step 3: build a fresh HnswIndex in memory and save it to the
+        // same directory while the loaded handle is still alive. This
+        // re-enters `save()`, which opens a second fd on the same lock
+        // path and calls `lock()` (exclusive). Pre-fix this deadlocks.
+        let dir = tmp.path().to_path_buf();
+        let basename_owned = basename.to_string();
+        let (tx, rx) = channel();
+        std::thread::spawn(move || {
+            let new_index = HnswIndex::build_with_dim(
+                vec![("chunk3".to_string(), make_embedding(3))],
+                crate::EMBEDDING_DIM,
+            )
+            .unwrap();
+            // Save into a NEW basename so we don't trip the
+            // stale-`.bak` guard from a partial first save; the lock
+            // path is keyed on basename so we keep the original to
+            // exercise the deadlock surface.
+            let result = new_index.save(&dir, &basename_owned);
+            let _ = tx.send(result);
+        });
+
+        match rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(Ok(())) => { /* save completed cleanly — fix is in place */ }
+            Ok(Err(e)) => panic!("save failed: {e:?}"),
+            Err(RecvTimeoutError::Timeout) => panic!(
+                "save deadlocked — regression: load's shared flock is still held while save \
+                 tries to acquire exclusive. Verify `load_with_dim` drops `lock_file` before \
+                 returning."
+            ),
+            Err(RecvTimeoutError::Disconnected) => {
+                panic!("save thread panicked without sending a result")
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes an in-process self-deadlock between HNSW load and save in the watch daemon.

`HnswIndex.load_with_dim` previously stashed the shared `flock(2)` it acquired into `HnswIndex._lock_file`, keeping the lock alive for the entire lifetime of the loaded index. The daemon's HNSW rebuild thread then opened a *second* fd on the same `index.hnsw.lock` path inside `save()` and called exclusive `lock()`. Linux `flock(2)` exclusive-waits for ALL shared holders — including ones held by the same process via a different open description — so the rebuild thread parked forever in `locks_lock_inode_wait`.

In production this manifested as a daemon permanently in `state == rebuilding`, with the rebuild thread visible in `ps -L` as `cqs-hnsw-rebuil` blocked on `locks_lock_inode_wait`, the delta queue accumulating indefinitely until `delta_saturated` eventually latched the recovery path. Diagnosed by inspecting `/proc/<daemon>/fd/` and seeing two open descriptions on the same lock path (fd 21 rw from the loaded HnswIndex, fd 43 wo from the save thread).

## Fix

- `load_with_dim` drops the `lock_file` explicitly before returning. The shared lock's only purpose is protecting on-disk `graph`/`data`/`ids`/`checksum` files during the read phase. Once the data is in `Loaded(...)` (fully copied via `bincode`, not mmap'd), the in-memory copy is independent of the disk file.
- Constructor sets `_lock_file: None` instead of `Some(lock_file)`. The field is now vestigial — always `None`. Doc comment updated to explain why the lifetime-held lock was removed and to acknowledge the field is kept on the struct so existing in-memory-built call sites in `build.rs` continue to compile without churn.

Cross-process exclusion during runtime was theoretical anyway — concurrent writers race on the SQLite writer lock first, and the daemon socket lock prevents two daemons from running against the same slot.

## Regression test

`load_does_not_block_subsequent_save_in_same_process` loads a saved index, then spawns a thread that saves a fresh `HnswIndex` to the same dir while the loaded handle is still alive. Pre-fix this hangs (5 s `recv_timeout` panics the test); post-fix it completes in <100 ms.

Verified the test catches the bug by reverting just the `drop(lock_file)` + `_lock_file: None` change — test fails at 5.05 s with the deadlock-detection panic.

## Test plan

- [x] `cargo test --features cuda-index --lib -- hnsw::persist::tests` — all 4 tests pass (`test_save_creates_lock_file`, `test_concurrent_load_shared`, `test_save_and_load`, new `load_does_not_block_subsequent_save_in_same_process`)
- [x] `cargo clippy --features cuda-index -- -D warnings` clean
- [x] `cargo fmt`
- [x] Repro reverification: temporarily reverted just the fix lines → test fails at 5.05 s as expected → restored fix → test passes in <100 ms
- [ ] CI green
- [ ] Post-merge: rebuild local daemon binary and confirm `state` transitions out of `rebuilding` cleanly on next startup (no `cqs-hnsw-rebuil` thread parked in `locks_lock_inode_wait`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
