### PR TITLE
chore: Release v1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.32.0] - 2026-05-01
+
+Minor release. Schema bumps **v23 → v25** (chained auto-migration: v23→v24 adds `chunks.vendored`, v24→v25 adds `notes.kind`). Five themes:
+
+1. **Watch-mode self-deadlock fix** (the urgent one) — `HnswIndex.load_with_dim` no longer keeps the load-phase shared `flock(2)` alive for the loaded index's lifetime. Pre-fix, the rebuild thread's `save()` opened a second fd on `index.hnsw.lock` and called exclusive `lock()`; Linux flock waits for ALL shared holders, including the same process via a different open description, so the rebuild thread parked permanently in `locks_lock_inode_wait`. Diagnosis hit the exact reproduction in production: daemon stuck in `state == rebuilding` with delta queue accumulating until `delta_saturated` latched the recovery path.
+2. **Three-tier `trust_level`** (#1221, schema v24) — vendored content (`vendor/`, `node_modules/`, `third_party/`, `.cargo/`, `target/`, `dist/`, `build/` by default; override via `[index].vendored_paths`) gets `"vendored-code"` instead of the bare `"user-code"` claim. Closes the SEC-V1.30.1-5 doc-only stop-gap.
+3. **Worktree → main-index discovery** (#1254) — `cqs` running inside a `git worktree` without its own `.cqs/` auto-discovers main's index via `.git/commondir`. Every JSON envelope from that process carries `_meta.worktree_stale: true` + `_meta.worktree_name: "<name>"` so consuming agents know to fall back to absolute worktree paths for files they're about to edit. Closes the worktree-leakage class of bugs documented in `feedback_agent_worktrees.md`.
+4. **Note kind taxonomy** (#1133, schema v25) — `NoteEntry.kind: Option<String>` + TOML roundtrip + `cqs notes add --kind <kind>` flag + structured `kind` column + path-prefix index. Embedding-text prefix priority chain: kind > sentiment-Warning > sentiment-Pattern > no-prefix. Closes audit P2.91.
+5. **TC-ADV reconcile coverage + TRT engine cache** (#1260) — clock-skew test + read_disk metadata-Err test + persistent TRT engine cache at `~/.cache/cqs/trt-engine-cache/` (gated on `CQS_TRT_ENGINE_CACHE`, default on) so daemon restarts don't re-pay the 30-90s BGE-large compile cost.
+
+### Added
+
+- **`chunks.vendored INTEGER NOT NULL DEFAULT 0`** (#1221, schema v24). Index-pipeline path-segment matcher (`crate::vendored::is_vendored_origin`) + `Store::set_vendored_prefixes` + `cmd_index` / `cmd_watch` startup wiring. Override the default prefix list via `[index].vendored_paths` in `.cqs.toml`. Three-tier `trust_level` in `to_json_with_origin`: `reference-code` > `vendored-code` > `user-code`.
+- **`notes.kind TEXT`** (#1133, schema v25). `NoteEntry.kind` / `Note.kind` / `NoteSummary.kind`; TOML round-trip with serde-skip-when-default; CLI `cqs notes add --kind <kind>`; `idx_notes_kind` for future `--kind` filter. `embedding_text` honours kind prefix when set.
+- **`_meta.worktree_stale: bool` + `_meta.worktree_name: Option<String>`** on every JSON envelope (#1254). Skipped when not stale so the wire shape only grows for affected processes.
+- **`crate::worktree::resolve_main_project_dir`** + `lookup_main_cqs_dir` + `record_worktree_stale` / `is_worktree_stale` / `current_worktree_name`. Process-wide stale flag via `OnceLock`. Robust to malformed `.git` files — every failure mode returns `None` rather than panicking.
+- **`CQS_TRT_ENGINE_CACHE`** (#1260, default on). Persistent TRT engine + timing cache at `~/.cache/cqs/trt-engine-cache/`. Set to `0` to opt out.
+- **TC-ADV-1.30.1-5 / TC-ADV-1.30.1-6 tests** (#1260) — clock-skew (stored mtime in future, hash tiebreak) + `read_disk` metadata-Err (None-on-stat-failure contract).
+
+### Fixed
+
+- **HNSW load-phase shared flock self-deadlock** (#1261). `load_with_dim` drops the lock immediately after the read phase; constructor sets `_lock_file: None`. Regression test (`load_does_not_block_subsequent_save_in_same_process`) verified by reverting just the fix lines — fails at 5.05s timeout, passes in <100ms with the fix. Daemon's HNSW rebuild thread no longer parks indefinitely on `save()`.
+
+### Changed
+
+- **`EnvelopeMeta::new()` → `EnvelopeMeta::current()`** (no longer `const`). Reads process-wide worktree state at envelope-emit time. `meta_value()` and `meta_json_fragment()` rebuild on every call so streamed batch output gets correct flags. (#1254)
+
+### Internal
+
+- **`ENV_LOCK` hoisted to module-level** in `src/embedder/provider.rs::tests` so env-mutating tests actually serialize against each other (the previous per-test `static` pattern provided no real serialization). (#1260)
+- Schema migration framework gains `migrate_v23_to_v24` (chunks.vendored) and `migrate_v24_to_v25` (notes.kind). Both additive ALTER-only — fast, no row rewrite.
+
 ## [1.31.0] - 2026-04-30
 
 Minor release. Post-v1.30.2 bug drain across watch reconcile, sparse-vector index, LLM redirect policy, slot lifecycle, native-Windows shutdown, and coarse-mtime filesystems. Schema bumps v22 → v23 (auto-migrating; `source_size` + `source_content_hash` columns added to `FileFingerprint`). Reindex not required, but the v23 binary will refuse to open a v22 index until the auto-migration step runs on first start.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.31.0"
+version = "1.32.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cqs"
-version = "1.31.0"
+version = "1.32.0"
 edition = "2021"
 rust-version = "1.95"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 91% R@1 on 296-query fixtures, 42% R@1 / 64% R@5 / 79% R@20 on v3 real code-search (544 dual-judge queries). Daemon mode (3-19ms queries). Local-first, GPU-accelerated."


### PR DESCRIPTION
## Summary

Release v1.32.0. Minor bump because of the **schema v23 → v25 chain** (auto-migrating; v23→v24 adds `chunks.vendored`, v24→v25 adds `notes.kind`). Five themes, with the watch-mode fix being the urgent one.

### Pillars

| Theme | PR | Severity |
|---|---|---|
| **HNSW load-phase flock self-deadlock fix** | #1261 | high — daemon was stuck in `state == rebuilding` permanently, delta queue accumulating until `delta_saturated` latched recovery |
| **Three-tier `trust_level: vendored-code`** | #1221 | medium-high — closes SEC-V1.30.1-5 doc-only stop-gap. **Schema v24.** |
| **Worktree → main-index discovery** | #1254 | medium — closes worktree-leakage class via `_meta.worktree_stale` |
| **Note kind taxonomy** | #1133 | medium — `cqs notes add --kind`, structured tag column. **Schema v25.** |
| **TC-ADV reconcile tests + TRT engine cache** | #1260 | medium — clock-skew + read_disk-Err coverage; persistent `~/.cache/cqs/trt-engine-cache/` |

Full notes in `CHANGELOG.md`.

### Operator impact

- v23 → v25 chain runs automatically on first daemon start of v1.32.0 (two `ALTER TABLE ... ADD COLUMN` + one `CREATE INDEX`). Fast — no row rewrite.
- Reindex not required. Existing chunks default to `vendored = 0`; existing notes default to `kind = NULL`.
- New chunks indexed after upgrade get correct `vendored` flag based on `[index].vendored_paths` (default list: `vendor`, `node_modules`, `third_party`, `.cargo`, `target`, `dist`, `build`).
- New notes via `cqs notes add --kind <kind>` populate the column immediately.
- `_meta.worktree_stale: true` fires only when the calling process is in a worktree without its own `.cqs/` AND main has one — non-worktree responses unchanged.
- v1.32.0 binary refuses to open a v22 / v23 / v24 index until the chain auto-migrates on first start; pre-v1.32.0 binaries cannot read the v25 schema.

## Test plan

- [x] All PR CIs green
- [x] `cargo clippy --features cuda-index -- -D warnings` clean
- [x] `cargo fmt`
- [ ] CI green
- [ ] On merge: `git tag v1.32.0` + `git push origin v1.32.0` from main → release.yml builds prebuilts
- [ ] `cargo publish` to crates.io
- [ ] `PROJECT_CONTINUITY.md` version bumped post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
