### PR TITLE
fix(test): hoist ENV_LOCK to module level in llm::validation::tests

### DIFF
--- a/src/llm/validation.rs
+++ b/src/llm/validation.rs
@@ -325,11 +325,18 @@ mod tests {
         let _ = SummaryValidationMode::Loose;
     }
 
+    /// Shared mutex for env-mutating tests in this module. Per-test
+    /// `static ENV_LOCK` declarations are independent Mutex instances
+    /// and don't actually serialize against each other — same race
+    /// trap fixed in `src/embedder/provider.rs::tests` via #1260. CI
+    /// caught the flake on v1.32.0 release commit when
+    /// `from_env_strict` raced with `from_env_unknown_falls_back_to_loose`
+    /// and read each other's `CQS_SUMMARY_VALIDATION` writes.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn from_env_strict() {
-        use std::sync::Mutex;
-        static ENV_LOCK: Mutex<()> = Mutex::new(());
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_SUMMARY_VALIDATION", "strict");
         let mode = SummaryValidationMode::from_env();
         std::env::remove_var("CQS_SUMMARY_VALIDATION");
@@ -338,9 +345,7 @@ mod tests {
 
     #[test]
     fn from_env_unknown_falls_back_to_loose() {
-        use std::sync::Mutex;
-        static ENV_LOCK: Mutex<()> = Mutex::new(());
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_SUMMARY_VALIDATION", "extreme");
         let mode = SummaryValidationMode::from_env();
         std::env::remove_var("CQS_SUMMARY_VALIDATION");


### PR DESCRIPTION
## Summary

`src/llm/validation.rs::tests` had two env-mutating tests (`from_env_strict` + `from_env_unknown_falls_back_to_loose`) that each declared their **own** function-local `static ENV_LOCK: Mutex<()>`. Function-local statics are still module-level memory, but each `static` declaration creates a *separate* Mutex instance — they didn't serialize against each other.

Caught by CI on the v1.32.0 release commit (`5a577a30`): the two tests raced, one set `CQS_SUMMARY_VALIDATION=strict` between the other's `set_var(extreme)` → `from_env()` → `remove_var()` sequence, producing:

```
assertion `left == right` failed
  left: Loose
 right: Strict
```

Main has been red on v1.32.0 since the release merged.

## Fix

Hoist `static ENV_LOCK: Mutex<()>` to module level so both tests share **one** mutex. Same pattern fix already shipped in `src/embedder/provider.rs::tests` via #1260.

Plus switched the panic-recovery shape from `.lock().unwrap()` to `.lock().unwrap_or_else(|e| e.into_inner())` so a panicked test holding the lock doesn't poison subsequent tests.

## Test plan

- [x] `cargo test --features cuda-index --lib -- llm::validation::tests::from_env` — both tests pass
- [ ] CI green
- [ ] Main green again

🤖 Generated with [Claude Code](https://claude.com/claude-code)
