### PR TITLE
feat(notes): cqs notes list --kind <kind> filter (#1133 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`cqs notes list --kind <kind>`** filter — column-level filter against the v25 `notes.kind` column (kebab-case lowercase, normalized). ANDs with `--warnings` / `--patterns`. CLI prints the kind tag inline (`[+0.5] [todo] note text…`); JSON adds `kind` field to every list entry, omitted on null. Same flag wired into the daemon batch path (`BatchCmd::Notes`) so `--kind` works through the socket too. Companion to the v25 schema landed in #1265 (#1133 follow-up).
+
 ## [1.32.0] - 2026-05-01
 
 Minor release. Schema bumps **v23 → v25** (chained auto-migration: v23→v24 adds `chunks.vendored`, v24→v25 adds `notes.kind`). Five themes:

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -561,6 +561,11 @@ pub(crate) struct NotesListArgs {
     /// Show only patterns (positive sentiment)
     #[arg(long)]
     pub patterns: bool,
+    /// Filter by kind tag (e.g. `todo`, `design-decision`, `known-bug`).
+    /// Matches against the v25 `notes.kind` column (kebab-case lowercase).
+    /// ANDs with `--warnings` / `--patterns` when combined.
+    #[arg(long)]
+    pub kind: Option<String>,
     /// Check mentions for staleness (verifies files exist and symbols are in index)
     #[arg(long)]
     pub check: bool,

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -640,7 +640,13 @@ pub(crate) fn dispatch(ctx: &BatchView, cmd: BatchCmd) -> Result<serde_json::Val
         BatchCmd::Notes { args, .. } => {
             // API-V1.29-4: pass `check` through so the daemon path matches
             // `cqs notes list --check` when routed via the socket.
-            handlers::dispatch_notes(ctx, args.warnings, args.patterns, args.check)
+            handlers::dispatch_notes(
+                ctx,
+                args.warnings,
+                args.patterns,
+                args.kind.as_deref(),
+                args.check,
+            )
         }
         BatchCmd::Task { args, .. } => {
             handlers::dispatch_task(ctx, &args.description, args.limit, args.tokens)
@@ -937,6 +943,17 @@ mod tests {
             BatchCmd::Notes { ref args, .. } => {
                 assert!(!args.warnings);
                 assert!(args.patterns);
+            }
+            _ => panic!("Expected Notes command"),
+        }
+    }
+
+    #[test]
+    fn test_parse_notes_kind() {
+        let input = BatchInput::try_parse_from(["notes", "--kind", "todo"]).unwrap();
+        match input.cmd {
+            BatchCmd::Notes { ref args, .. } => {
+                assert_eq!(args.kind.as_deref(), Some("todo"));
             }
             _ => panic!("Expected Notes command"),
         }

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -102,9 +102,10 @@ pub(in crate::cli::batch) fn dispatch_notes(
     ctx: &BatchView,
     warnings: bool,
     patterns: bool,
+    kind: Option<&str>,
     check: bool,
 ) -> Result<serde_json::Value> {
-    let _span = tracing::info_span!("batch_notes", warnings, patterns, check).entered();
+    let _span = tracing::info_span!("batch_notes", warnings, patterns, kind, check).entered();
 
     let notes = ctx.notes();
 
@@ -118,22 +119,37 @@ pub(in crate::cli::batch) fn dispatch_notes(
         std::collections::HashMap::new()
     };
 
+    let kind_norm = kind.and_then(|k| {
+        let trimmed = k.trim().to_lowercase();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    });
+
     let filtered: Vec<_> = notes
         .iter()
         .filter(|n| {
-            if warnings {
+            let sentiment_ok = if warnings {
                 n.is_warning()
             } else if patterns {
                 n.is_pattern()
             } else {
                 true
-            }
+            };
+            let kind_ok = match &kind_norm {
+                Some(k) => n.kind.as_deref() == Some(k.as_str()),
+                None => true,
+            };
+            sentiment_ok && kind_ok
         })
         .map(|n| {
             let mut entry = serde_json::json!({
                 "text": n.text,
                 "sentiment": n.sentiment,
                 "sentiment_label": n.sentiment_label(),
+                "kind": n.kind,
                 "mentions": n.mentions,
             });
             if check {

--- a/src/cli/commands/io/notes.rs
+++ b/src/cli/commands/io/notes.rs
@@ -38,6 +38,8 @@ struct NoteListEntry {
     sentiment: f32,
     #[serde(rename = "type")]
     note_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kind: Option<String>,
     text: String,
     mentions: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -148,6 +150,7 @@ pub(crate) fn cmd_notes(
                 ctx,
                 list.warnings,
                 list.patterns,
+                list.kind.as_deref(),
                 cli.json || output.json,
                 list.check,
             )
@@ -557,6 +560,7 @@ fn cmd_notes_list(
     ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     warnings_only: bool,
     patterns_only: bool,
+    kind_filter: Option<&str>,
     json: bool,
     check: bool,
 ) -> Result<()> {
@@ -583,17 +587,30 @@ fn cmd_notes_list(
         std::collections::HashMap::new()
     };
 
-    // Filter
+    // Filter — kind ANDs with sentiment filter (warnings/patterns).
+    let kind_norm = kind_filter.and_then(|k| {
+        let trimmed = k.trim().to_lowercase();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    });
     let filtered: Vec<_> = notes
         .iter()
         .filter(|n| {
-            if warnings_only {
+            let sentiment_ok = if warnings_only {
                 n.is_warning()
             } else if patterns_only {
                 n.is_pattern()
             } else {
                 true
-            }
+            };
+            let kind_ok = match &kind_norm {
+                Some(k) => n.kind.as_deref() == Some(k.as_str()),
+                None => true,
+            };
+            sentiment_ok && kind_ok
         })
         .collect();
 
@@ -617,6 +634,7 @@ fn cmd_notes_list(
                     id: n.id.clone(),
                     sentiment: n.sentiment,
                     note_type: note_type.into(),
+                    kind: n.kind.clone(),
                     text: n.text.clone(),
                     mentions: n.mentions.clone(),
                     stale_mentions,
@@ -640,6 +658,11 @@ fn cmd_notes_list(
 
     for note in &filtered {
         let sentiment_marker = format!("[{:+.1}]", note.sentiment);
+        let kind_marker = note
+            .kind
+            .as_deref()
+            .map(|k| format!(" [{}]", k))
+            .unwrap_or_default();
 
         // Truncate text for display (char-safe)
         let preview = if note.text.chars().count() > 120 {
@@ -660,7 +683,7 @@ fn cmd_notes_list(
             format!("  mentions: {}", note.mentions.join(", "))
         };
 
-        print!("  {} {}", sentiment_marker, preview);
+        print!("  {}{} {}", sentiment_marker, kind_marker, preview);
         if check {
             if let Some(stale) = staleness.get(&note.text) {
                 print!("  [STALE: {}]", stale.join(", "));
@@ -730,6 +753,7 @@ mod tests {
             id: "note:0".into(),
             sentiment: -1.0,
             note_type: "warning".into(),
+            kind: Some("known-bug".into()),
             text: "This is broken".into(),
             mentions: vec!["search.rs".into()],
             stale_mentions: Some(vec!["old_file.rs".into()]),
@@ -737,6 +761,7 @@ mod tests {
         let json = serde_json::to_value(&entry).unwrap();
         assert_eq!(json["id"], "note:0");
         assert_eq!(json["type"], "warning");
+        assert_eq!(json["kind"], "known-bug");
         assert_eq!(json["sentiment"], -1.0);
         assert_eq!(json["mentions"][0], "search.rs");
         assert_eq!(json["stale_mentions"][0], "old_file.rs");
@@ -748,11 +773,13 @@ mod tests {
             id: "note:1".into(),
             sentiment: 0.0,
             note_type: "neutral".into(),
+            kind: None,
             text: "just an observation".into(),
             mentions: vec![],
             stale_mentions: None,
         };
         let json = serde_json::to_value(&entry).unwrap();
         assert!(json.get("stale_mentions").is_none());
+        assert!(json.get("kind").is_none());
     }
 }


### PR DESCRIPTION
## Summary

The v25 schema (`notes.kind TEXT` + `idx_notes_kind`) and `cqs notes add --kind` shipped in #1265. This is the small follow-up that closes the retrieval side: `cqs notes list --kind todo` now filters the column directly instead of forcing a regex over `text`.

## What changed

- `NotesListArgs.kind: Option<String>` (CLI + daemon batch path).
- `cmd_notes_list` and `dispatch_notes` both gain a `kind` filter that **ANDs with `--warnings` / `--patterns`**.
- Kind input is trimmed + lowercased before compare, matching the same normalization `cqs notes add --kind` applies. Empty / whitespace-only kind is treated as absent.
- CLI prints the kind tag inline after the sentiment marker:
  ```
    [+0.5] [todo] note text…
  ```
  Unset → unchanged output.
- JSON list entry gains a `kind` field (`#[serde(skip_serializing_if = "Option::is_none")]`).

## What's still ahead (out of scope)

- `cqs notes update --kind` flag (small follow-up; currently you have to remove + re-add to retag).
- Pushing the column filter into `Store::list_notes_summaries` (today the filter is in-memory; the `idx_notes_kind` SQL index already covers a future SQL-side `WHERE kind = ?`).

## Test plan

- [x] `cargo build --features cuda-index` clean
- [x] `cargo test --bin cqs note_list_entry` — JSON shape covers `kind: Some` + `kind: None` (skip-on-null)
- [x] `cargo test --bin cqs parse_notes_kind` — clap parses `--kind todo` into `args.kind`
- [x] `cargo test --bin cqs notes` — full notes test surface (22 tests) green
- [x] `cargo fmt` clean; `cargo clippy --features cuda-index --all-targets` no new warnings

## Why now

#1133 is closed, but its scope listed `cqs notes list --kind <kind>` explicitly. Schema/index were already paid for in #1265 — the retrieval side is one filter pass. Picking it off before #1176 (SPLADE phase 2) so the kind taxonomy is end-to-end usable.
