### PR TITLE
test(watch): #1230 - process_file_changes zero-files no-op coverage

### DIFF
--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -1656,3 +1656,44 @@ fn dropped_this_cycle_resets_after_successful_drain() {
          snapshot reflects fresh state"
     );
 }
+
+/// TC-HAP-1.30.1-6 (#1230): empty `pending_files` plus a blocked embedder
+/// backoff is a no-op — no panic, no state mutation, no embedder init.
+/// This is the smallest possible exercise of `process_file_changes` and
+/// pins the contract that the function tolerates the "nothing to do"
+/// case even when the embedder is currently unavailable. Companion to
+/// `dropped_this_cycle_survives_embedder_init_early_return` (which seeds
+/// `pending_files` and `dropped_this_cycle` to test the early-return
+/// path's preservation guarantee).
+#[test]
+fn process_file_changes_zero_files_is_noop_when_embedder_blocked() {
+    let fix = drain_test_fixture(4);
+    let cfg = test_watch_config(
+        fix.tmp.path(),
+        fix.tmp.path(),
+        &fix.notes_path,
+        &fix.supported_ext,
+    );
+
+    let mut state = test_watch_state();
+    // Block embedder retry without loading any model. Mirrors the trick
+    // from `dropped_this_cycle_survives_embedder_init_early_return`:
+    // `record_failure()` advances `next_retry` to ~2 s in the future,
+    // which is well past this test's runtime.
+    state.embedder_backoff.record_failure();
+    assert!(
+        !state.embedder_backoff.should_retry(),
+        "test setup: backoff must block retry so try_init_embedder returns None"
+    );
+    assert!(state.pending_files.is_empty());
+    assert_eq!(state.dropped_this_cycle, 0);
+
+    // Should not panic, should not mutate state.
+    process_file_changes(&cfg, &fix.store, &mut state);
+
+    assert!(state.pending_files.is_empty(), "still empty after no-op");
+    assert_eq!(
+        state.dropped_this_cycle, 0,
+        "no work was attempted, no counter to clear or preserve"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the smallest direct test of `process_file_changes` that #1230 asked for: empty `pending_files` plus a blocked embedder backoff is a no-op — no panic, no state mutation, no embedder init. Pins the contract for the "nothing to do, embedder unavailable" quadrant.

## Coverage status against #1230's four proposed tests

| # | Case | Status |
|---|------|--------|
| 1 | `zero_files_is_noop` | **Added in this PR** |
| 2 | `single_file_drains_into_index` | Covered by existing `dropped_this_cycle_resets_after_successful_drain` (`#[ignore]`d, requires real CPU embedder) |
| 3 | `reports_dropped_warn_once_then_resets` | Same — the reset arm is exercised by the `#[ignore]`d success-path test |
| 4 | `handles_embedder_init_error` | Already covered by existing `dropped_this_cycle_survives_embedder_init_early_return` |

The two `#[ignore]`d tests exist because the success branch of `process_file_changes` calls into `reindex_files` which loads an Embedder. Without an Embedder trait + test impl (out of scope for #1230), the load-bearing assertion is the early-return path — that's where the regression risk lives, and we cover it. The success-path tests are kept `#[ignore]`d so `cargo test --ignored` still runs them in CI's optional lane.

## Test runtime

`cargo test --bin cqs process_file_changes_zero_files_is_noop` → 0.04s. Meets the <1s budget the issue specifies.

## What changed

- `src/cli/watch/tests.rs` — one new `#[test]` at the end of the file, mirroring the existing `dropped_this_cycle_survives_embedder_init_early_return` setup pattern (`record_failure()` to block backoff retry → `try_init_embedder` returns None).

## Test plan

- [x] `cargo test --features cuda-index --bin cqs process_file_changes` (1 passed, 0 failed)
- [x] `cargo test --features cuda-index --bin cqs dropped_this_cycle` (existing tests still green: 1 passed, 1 ignored)
- [x] `cargo fmt --check` clean

Closes #1230.
