### PR TITLE
refactor(reranker): #1220 - Reranker trait + OnnxReranker / NoopReranker / LlmReranker

### DIFF
--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -255,9 +255,11 @@ pub(crate) struct BatchContext {
     /// a sub-ms file read; cost is negligible per query.
     config: RefCell<Option<CachedReload<cqs::config::Config>>>,
     /// #1127: `Arc<OnceLock<...>>` so views share one slot with the
-    /// BatchContext. The `Reranker` itself does not need to be Arc-wrapped
-    /// inside the OnceLock because every accessor returns `&Reranker`.
-    reranker: Arc<OnceLock<cqs::Reranker>>,
+    /// BatchContext. EX-V1.30.1-8 (#1220): inner type is now
+    /// `Arc<dyn cqs::Reranker>` so the trait object can be swapped at
+    /// construction time (NoopReranker for ablation, future LlmReranker
+    /// for batch eval, etc.) without touching the cache surface.
+    reranker: Arc<OnceLock<Arc<dyn cqs::Reranker>>>,
     /// P2 #69: was `OnceLock`. Now `RefCell<Option<CachedReload<AuditMode>>>`
     /// so the documented 30-min audit auto-expire actually fires while the
     /// daemon is up — previously the OnceLock cached the boot-time state
@@ -1321,21 +1323,24 @@ impl BatchContext {
     }
 
     /// Get or create the reranker (cached for session). (RM-18)
-    pub(super) fn reranker(&self) -> Result<&cqs::Reranker> {
+    ///
+    /// EX-V1.30.1-8 (#1220): returns the trait object so callers don't
+    /// pin to `OnnxReranker` — a future `--reranker` flag can swap impls
+    /// at construction time without touching the consumer.
+    pub(super) fn reranker(&self) -> Result<Arc<dyn cqs::Reranker>> {
         if let Some(r) = self.reranker.get() {
-            return Ok(r);
+            return Ok(Arc::clone(r));
         }
         let _span = tracing::info_span!("batch_reranker_init").entered();
         // P1.7: thread the `[reranker]` config section so .cqs.toml preset/
         // model_path is honoured instead of silently defaulting to ms-marco.
         let config = self.config();
-        let r = cqs::Reranker::with_section(config.reranker.clone())
-            .map_err(|e| anyhow::anyhow!("Reranker init failed: {e}"))?;
-        let _ = self.reranker.set(r);
-        Ok(self
-            .reranker
-            .get()
-            .expect("reranker OnceLock populated by set() above"))
+        let r: Arc<dyn cqs::Reranker> = Arc::new(
+            cqs::OnnxReranker::with_section(config.reranker.clone())
+                .map_err(|e| anyhow::anyhow!("Reranker init failed: {e}"))?,
+        );
+        let _ = self.reranker.set(Arc::clone(&r));
+        Ok(r)
     }
 
     /// #1127: take the BatchContext store mutex briefly, clone the inner Arc,
@@ -1676,7 +1681,7 @@ pub(crate) struct BatchView {
     /// from the view propagates to the BatchContext (and any other view
     /// holding the same Arc).
     embedder_slot: Arc<OnceLock<Arc<Embedder>>>,
-    reranker_slot: Arc<OnceLock<cqs::Reranker>>,
+    reranker_slot: Arc<OnceLock<Arc<dyn cqs::Reranker>>>,
     splade_encoder_slot: Arc<OnceLock<Option<cqs::splade::SpladeEncoder>>>,
     /// Shared refs LRU.
     refs: Arc<Mutex<lru::LruCache<String, Arc<ReferenceIndex>>>>,
@@ -1759,18 +1764,17 @@ impl BatchView {
             .expect("embedder OnceLock populated by set() above"))
     }
 
-    pub fn reranker(&self) -> Result<&cqs::Reranker> {
+    pub fn reranker(&self) -> Result<Arc<dyn cqs::Reranker>> {
         if let Some(r) = self.reranker_slot.get() {
-            return Ok(r);
+            return Ok(Arc::clone(r));
         }
         let _span = tracing::info_span!("batch_view_reranker_init").entered();
-        let r = cqs::Reranker::with_section(self.config.reranker.clone())
-            .map_err(|e| anyhow::anyhow!("Reranker init failed: {e}"))?;
-        let _ = self.reranker_slot.set(r);
-        Ok(self
-            .reranker_slot
-            .get()
-            .expect("reranker OnceLock populated by set() above"))
+        let r: Arc<dyn cqs::Reranker> = Arc::new(
+            cqs::OnnxReranker::with_section(self.config.reranker.clone())
+                .map_err(|e| anyhow::anyhow!("Reranker init failed: {e}"))?,
+        );
+        let _ = self.reranker_slot.set(Arc::clone(&r));
+        Ok(r)
     }
 
     pub fn splade_encoder(&self) -> Option<&cqs::splade::SpladeEncoder> {

--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -255,7 +255,7 @@ pub(crate) fn cmd_query(
                 filter: &filter,
                 root,
                 embedder,
-                reranker,
+                reranker: reranker.as_deref(),
             },
             ref_name,
         );
@@ -287,7 +287,7 @@ pub(crate) fn cmd_query(
         root,
         embedder,
         effective_limit,
-        reranker,
+        reranker: reranker.as_deref(),
         splade_query,
         splade_index,
         routed_strategy: classification.as_ref().map(|c| c.strategy),
@@ -305,7 +305,7 @@ struct QueryContext<'a> {
     root: &'a std::path::Path,
     embedder: &'a Embedder,
     effective_limit: usize,
-    reranker: Option<&'a cqs::Reranker>,
+    reranker: Option<&'a dyn cqs::Reranker>,
     splade_query: Option<cqs::splade::SparseVector>,
     splade_index: Option<&'a cqs::splade::index::SpladeIndex>,
     /// Phase 5: strategy picked by the classifier (if adaptive routing ran).
@@ -594,7 +594,7 @@ fn unified_score(r: &UnifiedResult) -> f32 {
 
 /// Re-rank unified results using cross-encoder scoring.
 fn rerank_unified(
-    reranker: &cqs::Reranker,
+    reranker: &dyn cqs::Reranker,
     query: &str,
     results: Vec<UnifiedResult>,
     limit: usize,
@@ -680,7 +680,7 @@ struct RefQueryContext<'a> {
     filter: &'a SearchFilter,
     root: &'a std::path::Path,
     embedder: &'a Embedder,
-    reranker: Option<&'a cqs::Reranker>,
+    reranker: Option<&'a dyn cqs::Reranker>,
 }
 
 /// Ref-scoped semantic search: search only the named reference, no project index

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -173,7 +173,7 @@ pub(crate) struct CommandContext<'a, Mode = cqs::store::ReadWrite> {
     /// their tracing fields and `--json` envelopes without re-resolving.
     #[allow(dead_code)] // wired into doctor + handlers progressively
     pub slot_name: String,
-    reranker: OnceLock<cqs::Reranker>,
+    reranker: OnceLock<std::sync::Arc<dyn cqs::Reranker>>,
     embedder: OnceLock<cqs::Embedder>,
     splade_encoder: OnceLock<Option<cqs::splade::SpladeEncoder>>,
     splade_index: OnceLock<Option<cqs::splade::index::SpladeIndex>>,
@@ -268,22 +268,23 @@ impl<'a, Mode> CommandContext<'a, Mode> {
     /// Get or lazily create the cross-encoder reranker.
     ///
     /// The ONNX session (~91MB) is created on first call and reused for
-    /// all subsequent reranking within this CLI invocation.
-    pub fn reranker(&self) -> Result<&cqs::Reranker> {
+    /// all subsequent reranking within this CLI invocation. Returns the
+    /// trait object so a future config-driven `--reranker llm|noop|onnx`
+    /// switch (#1220) can swap impls without touching this signature.
+    pub fn reranker(&self) -> Result<std::sync::Arc<dyn cqs::Reranker>> {
         if let Some(r) = self.reranker.get() {
-            return Ok(r);
+            return Ok(std::sync::Arc::clone(r));
         }
         let _span = tracing::info_span!("command_context_reranker_init").entered();
         // P1.7: thread the `[reranker]` config section so .cqs.toml preset/
         // model_path is honoured instead of silently defaulting to ms-marco.
         let config = cqs::config::Config::load(&self.root);
-        let r = cqs::Reranker::with_section(config.reranker.clone())
-            .map_err(|e| anyhow::anyhow!("Reranker init failed: {e}"))?;
-        let _ = self.reranker.set(r);
-        Ok(self
-            .reranker
-            .get()
-            .expect("reranker OnceLock populated by set() above"))
+        let r: std::sync::Arc<dyn cqs::Reranker> = std::sync::Arc::new(
+            cqs::OnnxReranker::with_section(config.reranker.clone())
+                .map_err(|e| anyhow::anyhow!("Reranker init failed: {e}"))?,
+        );
+        let _ = self.reranker.set(std::sync::Arc::clone(&r));
+        Ok(r)
     }
 
     /// Get or lazily create the embedder.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub use note::{
     NOTES_HEADER,
 };
 pub use parser::{Chunk, Parser};
-pub use reranker::Reranker;
+pub use reranker::{LlmReranker, NoopReranker, OnnxReranker, Reranker};
 pub use store::{HnswKind, ModelInfo, SearchFilter, Store};
 
 // Re-exports for binary crate (CLI) - these are NOT part of the public library API

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -108,11 +108,59 @@ impl crate::ort_helpers::FromOrtMessage for RerankerError {
 
 use crate::ort_helpers::ort_err;
 
-/// Cross-encoder reranker for second-pass scoring
+/// EX-V1.30.1-8 (#1220): pluggable second-pass scoring trait.
+///
+/// Holders should keep rerankers as `Arc<dyn Reranker>` so any of the
+/// shipped impls (`OnnxReranker`, `NoopReranker`, `LlmReranker`) can
+/// drop in without touching the production search path. Adding a
+/// fourth impl (BM25 baseline, dot-product over a different embedder,
+/// API-served scoring service) is one new struct + one `impl Reranker`
+/// block + one wire-up at the construction site.
+///
+/// Concurrency: the production hot path uses `Arc<dyn Reranker>`, so
+/// the trait requires `Send + Sync`. `OnnxReranker` is internally
+/// thread-safe via `Mutex` around the ONNX session; the trait surface
+/// borrows `&self` so callers don't need to lock the holder.
+pub trait Reranker: Send + Sync {
+    /// Re-rank `results` in place, scoring each via this reranker's
+    /// `(query, content)` model. Default contract: writes scores onto
+    /// each result, sorts descending, truncates to `limit`.
+    /// `results.len() <= 1` is a no-op.
+    fn rerank(
+        &self,
+        query: &str,
+        results: &mut Vec<SearchResult>,
+        limit: usize,
+    ) -> Result<(), RerankerError>;
+
+    /// Re-rank scoring `(query, passages[i])` instead of
+    /// `(query, results[i].chunk.content)`. `passages.len() ==
+    /// results.len()` is a hard requirement; impls return
+    /// `RerankerError::InvalidArguments` on mismatch.
+    fn rerank_with_passages(
+        &self,
+        query: &str,
+        results: &mut Vec<SearchResult>,
+        passages: &[&str],
+        limit: usize,
+    ) -> Result<(), RerankerError>;
+
+    /// Drop any cached state (model session, tokenizer, network handles)
+    /// so memory returns to the OS. Called from idle-eviction loops in
+    /// the watch/serve daemons. Default: no-op (trait impls without
+    /// resident state get this for free).
+    fn clear_session(&self) {}
+}
+
+/// Cross-encoder reranker for second-pass scoring (the ONNX implementation).
 ///
 /// Lazy-loads the model on first use, same pattern as [`crate::Embedder`].
 /// Scores (query, passage) pairs with a cross-encoder, then re-sorts results.
-pub struct Reranker {
+///
+/// EX-V1.30.1-8 (#1220): renamed from `Reranker` to `OnnxReranker` when the
+/// trait was extracted. The trait is the new `Reranker`; concrete callers
+/// that need ONNX specifically construct via `OnnxReranker::with_section`.
+pub struct OnnxReranker {
     session: Mutex<Option<Session>>,
     /// Lazy-loaded tokenizer.
     ///
@@ -134,7 +182,7 @@ pub struct Reranker {
     section: Option<AuxModelSection>,
 }
 
-impl Reranker {
+impl OnnxReranker {
     /// Create a new reranker with lazy model loading (config-less; CLI/env only).
     pub fn new() -> Result<Self, RerankerError> {
         Self::with_section(None)
@@ -170,90 +218,6 @@ impl Reranker {
             expects_token_type_ids: Mutex::new(None),
             section,
         })
-    }
-
-    /// Re-rank search results using cross-encoder scoring
-    ///
-    /// Scores each (query, result.content) pair, re-sorts by score descending,
-    /// and truncates to `limit`. No-op for 0 or 1 results.
-    pub fn rerank(
-        &self,
-        query: &str,
-        results: &mut Vec<SearchResult>,
-        limit: usize,
-    ) -> Result<(), RerankerError> {
-        // OB-V1.29-1: entry span parity with `rerank_with_passages` so the
-        // CLI `rerank` path shows up in `cqs trace`-style captures with the
-        // same tag and fields.
-        let _span = tracing::info_span!(
-            "rerank",
-            count = results.len(),
-            limit,
-            query_len = query.len()
-        )
-        .entered();
-        // PF-V1.25-5: borrow passages from results directly instead of
-        // cloning content strings. The previous impl did
-        // `results.iter().map(|r| r.chunk.content.clone()).collect()`,
-        // allocating a fresh String per candidate (N allocations × content
-        // length bytes each) only to feed them to `rerank_with_passages`.
-        // Score computation happens in a scoped borrow so the subsequent
-        // `&mut results` write back is valid.
-        //
-        // We inline the compute-score-then-apply pattern rather than
-        // reusing `rerank_with_passages`, because passages that borrow
-        // from `results` conflict with `&mut results` at the call site.
-        let scores = {
-            let passages: Vec<&str> = results.iter().map(|r| r.chunk.content.as_str()).collect();
-            self.compute_scores(query, &passages)?
-        };
-        apply_rerank_scores(results, scores, limit);
-        Ok(())
-    }
-
-    /// Re-rank search results using custom passage text per result.
-    ///
-    /// Like [`rerank`](Self::rerank) but scores `(query, passages[i])` instead of
-    /// `(query, result.content)`. Useful for reranking on NL descriptions or
-    /// other derived text. `passages` must have the same length as `results`.
-    pub fn rerank_with_passages(
-        &self,
-        query: &str,
-        results: &mut Vec<SearchResult>,
-        passages: &[&str],
-        limit: usize,
-    ) -> Result<(), RerankerError> {
-        let _span = tracing::info_span!(
-            "rerank",
-            count = results.len(),
-            limit,
-            query_len = query.len()
-        )
-        .entered();
-        if results.len() <= 1 {
-            return Ok(());
-        }
-        if results.len() != passages.len() {
-            // P3.11: structured warn so operators see the mismatch in journal,
-            // and surface `InvalidArguments` instead of `Inference` so callers
-            // can match on the caller-bug case distinctly from model errors.
-            tracing::warn!(
-                passages = passages.len(),
-                results = results.len(),
-                "rerank_with_passages: length mismatch — caller bug, refusing to score",
-            );
-            return Err(RerankerError::InvalidArguments(format!(
-                "passages length ({}) must match results length ({})",
-                passages.len(),
-                results.len()
-            )));
-        }
-
-        let Some(scores) = self.compute_scores_opt(query, passages)? else {
-            return Ok(());
-        };
-        apply_rerank_scores(results, scores, limit);
-        Ok(())
     }
 
     /// Compute cross-encoder scores for (query, passage) pairs.
@@ -579,28 +543,6 @@ impl Reranker {
         Ok(guard)
     }
 
-    /// Clear the ONNX session to free memory (~91MB model).
-    ///
-    /// Session re-initializes lazily on next `rerank()` call.
-    /// Use this during idle periods in long-running processes.
-    pub fn clear_session(&self) {
-        let mut guard = self.session.lock().unwrap_or_else(|p| p.into_inner());
-        *guard = None;
-        // Reset the input-shape probe so the next session re-detects
-        // the loaded model's token_type_ids contract.
-        *self
-            .expects_token_type_ids
-            .lock()
-            .unwrap_or_else(|p| p.into_inner()) = None;
-        // RM-V1.25-15: Drop the tokenizer too (~20MB for ms-marco MiniLM).
-        // In-flight rerank() calls that grabbed an Arc clone before this
-        // call keep their own copy; the slot is cleared and lazy-reloads
-        // on next tokenizer() access.
-        let mut tok = self.tokenizer.lock().unwrap_or_else(|p| p.into_inner());
-        *tok = None;
-        tracing::info!("Reranker session and tokenizer cleared");
-    }
-
     /// Get or initialize the tokenizer.
     ///
     /// RM-V1.25-15: Returns `Arc<Tokenizer>` so callers drop the mutex
@@ -625,6 +567,243 @@ impl Reranker {
         }
         *guard = Some(Arc::clone(&loaded));
         Ok(loaded)
+    }
+}
+
+impl Reranker for OnnxReranker {
+    /// Re-rank search results using cross-encoder scoring.
+    ///
+    /// Scores each (query, result.content) pair, re-sorts by score descending,
+    /// and truncates to `limit`. No-op for 0 or 1 results.
+    fn rerank(
+        &self,
+        query: &str,
+        results: &mut Vec<SearchResult>,
+        limit: usize,
+    ) -> Result<(), RerankerError> {
+        // OB-V1.29-1: entry span parity with `rerank_with_passages` so the
+        // CLI `rerank` path shows up in `cqs trace`-style captures with the
+        // same tag and fields.
+        let _span = tracing::info_span!(
+            "rerank",
+            count = results.len(),
+            limit,
+            query_len = query.len()
+        )
+        .entered();
+        // PF-V1.25-5: borrow passages from results directly instead of
+        // cloning content strings. The previous impl did
+        // `results.iter().map(|r| r.chunk.content.clone()).collect()`,
+        // allocating a fresh String per candidate (N allocations × content
+        // length bytes each) only to feed them to `rerank_with_passages`.
+        // Score computation happens in a scoped borrow so the subsequent
+        // `&mut results` write back is valid.
+        //
+        // We inline the compute-score-then-apply pattern rather than
+        // reusing `rerank_with_passages`, because passages that borrow
+        // from `results` conflict with `&mut results` at the call site.
+        let scores = {
+            let passages: Vec<&str> = results.iter().map(|r| r.chunk.content.as_str()).collect();
+            self.compute_scores(query, &passages)?
+        };
+        apply_rerank_scores(results, scores, limit);
+        Ok(())
+    }
+
+    /// Re-rank search results using custom passage text per result.
+    ///
+    /// Like [`rerank`](Reranker::rerank) but scores `(query, passages[i])` instead of
+    /// `(query, result.content)`. Useful for reranking on NL descriptions or
+    /// other derived text. `passages` must have the same length as `results`.
+    fn rerank_with_passages(
+        &self,
+        query: &str,
+        results: &mut Vec<SearchResult>,
+        passages: &[&str],
+        limit: usize,
+    ) -> Result<(), RerankerError> {
+        let _span = tracing::info_span!(
+            "rerank",
+            count = results.len(),
+            limit,
+            query_len = query.len()
+        )
+        .entered();
+        if results.len() <= 1 {
+            return Ok(());
+        }
+        if results.len() != passages.len() {
+            // P3.11: structured warn so operators see the mismatch in journal,
+            // and surface `InvalidArguments` instead of `Inference` so callers
+            // can match on the caller-bug case distinctly from model errors.
+            tracing::warn!(
+                passages = passages.len(),
+                results = results.len(),
+                "rerank_with_passages: length mismatch — caller bug, refusing to score",
+            );
+            return Err(RerankerError::InvalidArguments(format!(
+                "passages length ({}) must match results length ({})",
+                passages.len(),
+                results.len()
+            )));
+        }
+
+        let Some(scores) = self.compute_scores_opt(query, passages)? else {
+            return Ok(());
+        };
+        apply_rerank_scores(results, scores, limit);
+        Ok(())
+    }
+
+    /// Clear the ONNX session to free memory (~91MB model).
+    ///
+    /// Session re-initializes lazily on next `rerank()` call.
+    /// Use this during idle periods in long-running processes.
+    fn clear_session(&self) {
+        let mut guard = self.session.lock().unwrap_or_else(|p| p.into_inner());
+        *guard = None;
+        // Reset the input-shape probe so the next session re-detects
+        // the loaded model's token_type_ids contract.
+        *self
+            .expects_token_type_ids
+            .lock()
+            .unwrap_or_else(|p| p.into_inner()) = None;
+        // RM-V1.25-15: Drop the tokenizer too (~20MB for ms-marco MiniLM).
+        // In-flight rerank() calls that grabbed an Arc clone before this
+        // call keep their own copy; the slot is cleared and lazy-reloads
+        // on next tokenizer() access.
+        let mut tok = self.tokenizer.lock().unwrap_or_else(|p| p.into_inner());
+        *tok = None;
+        tracing::info!("Reranker session and tokenizer cleared");
+    }
+}
+
+/// EX-V1.30.1-8 (#1220): no-op pass-through reranker.
+///
+/// Returns `Ok(())` from every method — the input results are left
+/// alone (their existing scores keep them ordered as they came in).
+/// Used by the eval harness for ablation A/B (`--reranker none|onnx`)
+/// to instantly compare the dense+SPLADE result quality against the
+/// reranked version without a model load. Cheap to construct, no
+/// model state, `clear_session` is a default no-op.
+pub struct NoopReranker;
+
+impl NoopReranker {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for NoopReranker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Reranker for NoopReranker {
+    fn rerank(
+        &self,
+        _query: &str,
+        results: &mut Vec<SearchResult>,
+        limit: usize,
+    ) -> Result<(), RerankerError> {
+        // The contract of `rerank` is "score, sort, truncate". A
+        // no-op skips the score+sort but should still truncate so
+        // callers get the documented `len() <= limit` shape — same
+        // way `OnnxReranker::rerank` ends with `apply_rerank_scores`
+        // → `truncate`. Keep the existing input order: the dense leg
+        // already sorted by cosine descending, so truncating after
+        // gives the unranked baseline the eval harness wants to
+        // compare against.
+        if results.len() > limit {
+            results.truncate(limit);
+        }
+        Ok(())
+    }
+
+    fn rerank_with_passages(
+        &self,
+        _query: &str,
+        results: &mut Vec<SearchResult>,
+        passages: &[&str],
+        limit: usize,
+    ) -> Result<(), RerankerError> {
+        // Same length contract as the ONNX path: surface a length
+        // mismatch loudly so a caller bug doesn't get masked by the
+        // no-op shortcut.
+        if results.len() != passages.len() {
+            return Err(RerankerError::InvalidArguments(format!(
+                "passages length ({}) must match results length ({})",
+                passages.len(),
+                results.len()
+            )));
+        }
+        if results.len() > limit {
+            results.truncate(limit);
+        }
+        Ok(())
+    }
+}
+
+/// EX-V1.30.1-8 (#1220): LLM-judge reranker skeleton.
+///
+/// Holds an `Arc<dyn LlmRerankProvider>` so a future production deployment
+/// can plug in a Claude / GPT / Gemini scorer without touching the search
+/// path. **The current shipped impl is a skeleton** — it returns
+/// `RerankerError::Inference("LlmReranker not yet implemented")` from
+/// every score-producing call. The point is to prove the trait surface
+/// supports an LLM-shaped impl: an `LlmRerankProvider` produces relevance
+/// scores asynchronously via the existing `cqs::llm::BatchProvider`-style
+/// trait, and the `Reranker` shim turns that into the synchronous
+/// `rerank` shape the search path expects.
+///
+/// Wiring the production version is a follow-up: the `score` method
+/// becomes a `tokio::block_on` of a batch-call to the LLM provider with
+/// `(query, passage)` pairs, parses scores from the response, and feeds
+/// them through `apply_rerank_scores`. The trait surface here doesn't
+/// change.
+pub struct LlmReranker;
+
+impl LlmReranker {
+    /// Construct a skeleton instance. The skeleton returns
+    /// `RerankerError::Inference` on every score call so an integration
+    /// test against the production search path can verify the trait
+    /// hooks without LLM-credential setup.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for LlmReranker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Reranker for LlmReranker {
+    fn rerank(
+        &self,
+        _query: &str,
+        _results: &mut Vec<SearchResult>,
+        _limit: usize,
+    ) -> Result<(), RerankerError> {
+        Err(RerankerError::Inference(
+            "LlmReranker is a skeleton — wire to a BatchProvider in a follow-up PR (#1220)"
+                .to_string(),
+        ))
+    }
+
+    fn rerank_with_passages(
+        &self,
+        _query: &str,
+        _results: &mut Vec<SearchResult>,
+        _passages: &[&str],
+        _limit: usize,
+    ) -> Result<(), RerankerError> {
+        Err(RerankerError::Inference(
+            "LlmReranker is a skeleton — wire to a BatchProvider in a follow-up PR (#1220)"
+                .to_string(),
+        ))
     }
 }
 
@@ -750,13 +929,13 @@ mod tests {
     #[test]
     fn test_reranker_new() {
         // Construction should succeed (no model download yet — lazy)
-        let reranker = Reranker::new();
+        let reranker = OnnxReranker::new();
         assert!(reranker.is_ok());
     }
 
     #[test]
     fn test_rerank_empty_results() {
-        let reranker = Reranker::new().unwrap();
+        let reranker = OnnxReranker::new().unwrap();
         let mut results = Vec::new();
         let result = reranker.rerank("test query", &mut results, 10);
         assert!(result.is_ok());
@@ -811,7 +990,7 @@ mod tests {
     #[test]
     #[ignore = "loads cross-encoder model; run with --ignored"]
     fn test_rerank_reorders_by_relevance() {
-        let reranker = Reranker::new().expect("reranker new");
+        let reranker = OnnxReranker::new().expect("reranker new");
         // Order at input is intentionally NOT relevance order — we want to
         // see that the reranker does the work, not that it preserves input
         // ordering by accident.
@@ -862,7 +1041,7 @@ mod tests {
     /// load, so this test runs without the ONNX session.
     #[test]
     fn test_rerank_empty_input_returns_empty() {
-        let reranker = Reranker::new().expect("reranker new");
+        let reranker = OnnxReranker::new().expect("reranker new");
         let mut results: Vec<SearchResult> = Vec::new();
         let passages: Vec<&str> = Vec::new();
         reranker
@@ -871,6 +1050,77 @@ mod tests {
         assert!(
             results.is_empty(),
             "empty input → empty output (no-op shortcut)"
+        );
+    }
+
+    /// EX-V1.30.1-8 (#1220): `NoopReranker::rerank` truncates to `limit`
+    /// and preserves input order otherwise. Pins the contract that the
+    /// eval-harness ablation switch (`--reranker none`) gives an
+    /// apples-to-apples baseline against the ONNX path: both end with
+    /// `results.len() <= limit`, only the order differs.
+    #[test]
+    fn noop_reranker_truncates_but_preserves_order() {
+        let reranker = NoopReranker::new();
+        let mut results = vec![
+            stub_result("a", "first"),
+            stub_result("b", "second"),
+            stub_result("c", "third"),
+            stub_result("d", "fourth"),
+        ];
+        // Set distinct scores so we can detect any unwanted re-sort.
+        for (i, r) in results.iter_mut().enumerate() {
+            r.score = (i as f32) * 0.25; // 0.0, 0.25, 0.5, 0.75
+        }
+
+        reranker
+            .rerank("any query", &mut results, 2)
+            .expect("noop rerank");
+
+        assert_eq!(results.len(), 2, "truncated to limit");
+        assert_eq!(
+            results[0].chunk.id, "a",
+            "no re-sort: first input position survives"
+        );
+        assert_eq!(
+            results[1].chunk.id, "b",
+            "no re-sort: second input position survives"
+        );
+    }
+
+    /// `NoopReranker::rerank_with_passages` enforces the same length
+    /// contract as the ONNX path so a caller bug doesn't get masked by
+    /// the no-op shortcut.
+    #[test]
+    fn noop_reranker_rejects_passage_length_mismatch() {
+        let reranker = NoopReranker::new();
+        let mut results = vec![stub_result("a", "x"), stub_result("b", "y")];
+        let passages = ["only one"];
+        let err = reranker
+            .rerank_with_passages("q", &mut results, &passages, 10)
+            .unwrap_err();
+        assert!(
+            matches!(err, RerankerError::InvalidArguments(_)),
+            "expected InvalidArguments on length mismatch, got {err:?}"
+        );
+    }
+
+    /// `LlmReranker` is a skeleton — every score-producing call returns
+    /// `RerankerError::Inference` so an integration test against the
+    /// production search path can verify trait wiring without any
+    /// live LLM credentials. Pins that contract: any future production
+    /// `LlmReranker` impl must NOT silently no-op when the provider is
+    /// unconfigured.
+    #[test]
+    fn llm_reranker_skeleton_returns_inference_error() {
+        let reranker = LlmReranker::new();
+        let mut results = vec![stub_result("a", "x"), stub_result("b", "y")];
+        let err = reranker.rerank("q", &mut results, 10).unwrap_err();
+        let RerankerError::Inference(msg) = err else {
+            panic!("expected Inference variant, got {err:?}");
+        };
+        assert!(
+            msg.contains("skeleton"),
+            "skeleton error must self-identify; got: {msg}"
         );
     }
 }

--- a/tests/eval_harness.rs
+++ b/tests/eval_harness.rs
@@ -524,7 +524,9 @@ fn test_eval_matrix() {
         // Init reranker if needed
         let reranker = match config.reranker {
             RerankerMode::None => None,
-            RerankerMode::MiniLmV1 => Some(cqs::OnnxReranker::new().expect("Failed to init reranker")),
+            RerankerMode::MiniLmV1 => {
+                Some(cqs::OnnxReranker::new().expect("Failed to init reranker"))
+            }
         };
 
         let mut config_results: Vec<EvalQueryResult> = Vec::new();

--- a/tests/eval_harness.rs
+++ b/tests/eval_harness.rs
@@ -118,7 +118,7 @@ fn eval_single_query<Mode>(
     query: &EvalQuery,
     store: &cqs::Store<Mode>,
     embedder: &cqs::Embedder,
-    reranker: Option<&cqs::Reranker>,
+    reranker: Option<&dyn cqs::Reranker>,
     config: &EvalConfig,
     run_id: &str,
 ) -> EvalQueryResult {
@@ -524,14 +524,20 @@ fn test_eval_matrix() {
         // Init reranker if needed
         let reranker = match config.reranker {
             RerankerMode::None => None,
-            RerankerMode::MiniLmV1 => Some(cqs::Reranker::new().expect("Failed to init reranker")),
+            RerankerMode::MiniLmV1 => Some(cqs::OnnxReranker::new().expect("Failed to init reranker")),
         };
 
         let mut config_results: Vec<EvalQueryResult> = Vec::new();
 
         for query in &train_queries {
-            let result =
-                eval_single_query(query, &store, &embedder, reranker.as_ref(), config, &run_id);
+            let result = eval_single_query(
+                query,
+                &store,
+                &embedder,
+                reranker.as_ref().map(|r| r as &dyn cqs::Reranker),
+                config,
+                &run_id,
+            );
 
             let rank_str = result
                 .rank_of_correct

--- a/tests/model_eval.rs
+++ b/tests/model_eval.rs
@@ -1315,7 +1315,7 @@ fn test_hard_model_comparison() {
 #[ignore] // Slow - downloads models. Run with: cargo test reranker -- --ignored --nocapture
 fn test_hard_reranker_comparison() {
     use cqs::parser::ChunkType;
-    use cqs::reranker::Reranker;
+    use cqs::reranker::{OnnxReranker, Reranker};
     use cqs::store::SearchResult;
     use std::path::PathBuf;
 
@@ -1414,7 +1414,7 @@ fn test_hard_reranker_comparison() {
 
     // Load reranker
     eprintln!("\n--- Loading reranker ---");
-    let reranker = Reranker::new().expect("Failed to create reranker");
+    let reranker = OnnxReranker::new().expect("Failed to create reranker");
 
     const CANDIDATE_K: usize = 20;
 


### PR DESCRIPTION
## Summary

Replaces the concrete `Reranker` struct with a `Reranker` trait + 3 impls. Adding a fourth scoring family (BM25 baseline, future production `LlmReranker`, dot-product over a different embedder, etc.) becomes a new `impl Reranker for FooReranker` block — no callsite churn, no enum to extend, no duplication.

Closes #1220.

## What changed

- **New trait** `Reranker: Send + Sync` with `rerank`, `rerank_with_passages`, and a default-no-op `clear_session`.
- **`OnnxReranker`** — renamed from the previous `Reranker` struct. All current behavior preserved: lazy ONNX session, token_type_ids feature detection, sigmoid scoring, batched ORT runs, `with_section` config plumbing, idle-eviction `clear_session`.
- **`NoopReranker`** — pass-through for eval-harness ablation. Truncates to `limit`, preserves input order, same length-mismatch contract as the ONNX path.
- **`LlmReranker`** — skeleton; every score call returns `RerankerError::Inference("LlmReranker is a skeleton — wire to a BatchProvider in a follow-up PR (#1220)")`. Proves the trait surface supports an LLM-shaped impl without shipping production wiring.
- **Holders switched** from `OnceLock<cqs::Reranker>` to `OnceLock<Arc<dyn cqs::Reranker>>`:
  - `cli::store::CommandContext::reranker()`
  - `cli::batch::BatchContext::reranker()`
  - `cli::batch::BatchView::reranker()`
- **Bridge sites** in `cli/commands/search/query.rs` swapped `Option<&'a cqs::Reranker>` → `Option<&'a dyn cqs::Reranker>` with `.as_deref()` at the construction sites.

## New tests

- `noop_reranker_truncates_but_preserves_order` — pins the eval-harness ablation contract.
- `noop_reranker_rejects_passage_length_mismatch` — same caller-bug-loud-error guarantee as ONNX.
- `llm_reranker_skeleton_returns_inference_error` — pins the skeleton-not-no-op contract so a future production wiring can't accidentally regress to silent no-op.

## Behavior preservation

- 14 pre-existing reranker tests pass without modification (trait surface is bit-for-bit compatible with the previous concrete-struct API).
- The 1 `#[ignore]`d full-pipeline test (`test_rerank_reorders_by_relevance`) still loads via `OnnxReranker::new()` and exercises the ONNX scoring path end-to-end.

## Diff stats

```
 5 files changed, 407 insertions(+), 152 deletions(-)
```

The 255-line growth is the trait + 3 impls + 3 new tests + thicker `Arc<dyn ...>` plumbing at the 3 holder sites. The 152-line deletion is the old concrete-struct accessors and method-on-struct definitions that moved into `impl Reranker for OnnxReranker`.

## Test plan

- [x] `cargo build --features cuda-index` clean
- [x] `cargo test --features cuda-index --lib reranker` — 17 passed + 1 ignored
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features cuda-index` clean (no new warnings)

## Out of scope (per #1220)

- `LlmReranker` production wiring (skeleton ships; production impl is a follow-up that only touches `LlmReranker` + uses the existing `BatchProvider` trait).
- BM25 reranker (separate feature).
- `--reranker none|onnx` CLI flag in the eval harness — `NoopReranker` infrastructure is in place; the flag is a follow-up against `cli::commands::eval` (one row in `EvalCmdArgs`, one match arm at the construction site).
- Eval R@5 ablation run with `NoopReranker` — same follow-up.
- Changing `RerankerError::Inference(String)` to a typed wrapper — separate fix.
