### PR TITLE
refactor(watch): #1226 - share enumerate_files walk between gc + reconcile

### DIFF
--- a/src/cli/watch/gc.rs
+++ b/src/cli/watch/gc.rs
@@ -208,12 +208,19 @@ pub(super) fn run_daemon_startup_gc(
 /// than necessary. The cap means a deeply-polluted index converges over
 /// many ticks rather than one big stop-the-world prune.
 ///
+/// PF-V1.30.1-3 (#1226): when the caller has already enumerated the
+/// working tree (e.g. because reconcile is also firing on the same
+/// idle tick), pass `disk_files: Some(&shared_set)` to skip the
+/// internal walk. `disk_files: None` falls back to the original
+/// `cqs::enumerate_files` call.
+///
 /// Disable with `CQS_DAEMON_PERIODIC_GC=0`.
 pub(super) fn run_daemon_periodic_gc(
     store: &Store,
     root: &Path,
     parser: &CqParser,
     matcher: Option<&ignore::gitignore::Gitignore>,
+    disk_files: Option<&std::collections::HashSet<PathBuf>>,
 ) {
     let _span = tracing::info_span!("daemon_periodic_gc").entered();
     // OB-V1.30.1-7: capture elapsed time so operators can spot a
@@ -226,22 +233,35 @@ pub(super) fn run_daemon_periodic_gc(
     // Pass 1: missing-file prune. `enumerate_files` is the heavier call
     // here (one full walk of the tree); running it on idle is fine —
     // by definition there is no contention.
+    //
+    // PF-V1.30.1-3 (#1226): reuse the caller-supplied walk when present,
+    // so a tick that fires both gc and reconcile only walks the tree
+    // once. The fallback path keeps the function self-contained for
+    // callers that haven't pre-walked (today: no one in production —
+    // mod.rs always pre-walks when either gate fires — but the option
+    // keeps the function testable in isolation).
     let exts = parser.supported_extensions();
-    match cqs::enumerate_files(root, &exts, false) {
-        Ok(files) => {
-            let file_set: std::collections::HashSet<_> = files.into_iter().collect();
-            match store.prune_missing(&file_set, root) {
-                Ok(n) if n > 0 => {
-                    tracing::info!(pruned = n, "Periodic GC: pruned missing-file chunks");
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!(error = %e, "Periodic GC: prune_missing failed");
-                }
+    let walked: Option<std::collections::HashSet<PathBuf>> = if disk_files.is_none() {
+        match cqs::enumerate_files(root, &exts, false) {
+            Ok(files) => Some(files.into_iter().collect()),
+            Err(e) => {
+                tracing::warn!(error = %e, "Periodic GC: enumerate_files failed");
+                None
             }
         }
-        Err(e) => {
-            tracing::warn!(error = %e, "Periodic GC: enumerate_files failed");
+    } else {
+        None
+    };
+    let file_set: Option<&std::collections::HashSet<PathBuf>> = disk_files.or(walked.as_ref());
+    if let Some(file_set) = file_set {
+        match store.prune_missing(file_set, root) {
+            Ok(n) if n > 0 => {
+                tracing::info!(pruned = n, "Periodic GC: pruned missing-file chunks");
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!(error = %e, "Periodic GC: prune_missing failed");
+            }
         }
     }
 

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -1328,16 +1328,45 @@ pub fn cmd_watch(
                     // The bounded sweep (cap = daemon_periodic_gc_cap()) keeps
                     // each tick's write transaction short.
                     //
+                    // PF-V1.30.1-3 (#1226): when both gc and reconcile gates
+                    // fire on the same idle tick, do one disk walk and pass
+                    // it to both consumers. The two intervals share the
+                    // idle gate (`daemon_periodic_gc_idle_secs`), so on
+                    // long-quiet ticks at the gc cadence boundary, both
+                    // would otherwise walk the tree back-to-back.
+                    let gc_due = periodic_gc_enabled
+                        && state.last_event.elapsed()
+                            >= Duration::from_secs(super::limits::daemon_periodic_gc_idle_secs())
+                        && last_periodic_gc.elapsed()
+                            >= Duration::from_secs(
+                                super::limits::daemon_periodic_gc_interval_secs(),
+                            );
+                    let reconcile_due = reconcile_enabled_flag
+                        && state.last_event.elapsed()
+                            >= Duration::from_secs(super::limits::daemon_periodic_gc_idle_secs())
+                        && last_reconcile.elapsed()
+                            >= Duration::from_secs(super::limits::daemon_reconcile_interval_secs());
+                    let shared_disk_files: Option<HashSet<PathBuf>> = if gc_due && reconcile_due {
+                        let exts = parser.supported_extensions();
+                        match cqs::enumerate_files(&root, &exts, no_ignore) {
+                            Ok(v) => Some(v.into_iter().collect()),
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    "Shared idle-tick walk failed; gc and reconcile fall back to per-callsite walks",
+                                );
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
                     // Acquires the same `acquire_index_lock` semantics by
                     // calling `try_acquire_index_lock` — if `cqs index` or
                     // `cqs gc` is running, the GC tick skips and tries again
                     // on the next interval.
-                    if periodic_gc_enabled
-                        && state.last_event.elapsed()
-                            >= Duration::from_secs(super::limits::daemon_periodic_gc_idle_secs())
-                        && last_periodic_gc.elapsed()
-                            >= Duration::from_secs(super::limits::daemon_periodic_gc_interval_secs())
-                    {
+                    if gc_due {
                         match try_acquire_index_lock(&cqs_dir) {
                             Ok(Some(gc_lock)) => {
                                 // EH-V1.29-8: Same poison-recovery as startup
@@ -1355,7 +1384,13 @@ pub fn cmd_watch(
                                     }
                                 };
                                 let matcher_ref = matcher_guard.as_ref().and_then(|g| g.as_ref());
-                                run_daemon_periodic_gc(&store, &root, &parser, matcher_ref);
+                                run_daemon_periodic_gc(
+                                    &store,
+                                    &root,
+                                    &parser,
+                                    matcher_ref,
+                                    shared_disk_files.as_ref(),
+                                );
                                 drop(matcher_guard);
                                 drop(gc_lock);
                                 // Clear caches so the next query observes the pruned rows.
@@ -1396,12 +1431,7 @@ pub fn cmd_watch(
                     // Reads only — no write transaction, no index lock
                     // needed. The `process_file_changes` drain on the next
                     // tick takes its own lock per its existing contract.
-                    if reconcile_enabled_flag
-                        && state.last_event.elapsed()
-                            >= Duration::from_secs(super::limits::daemon_periodic_gc_idle_secs())
-                        && last_reconcile.elapsed()
-                            >= Duration::from_secs(super::limits::daemon_reconcile_interval_secs())
-                    {
+                    if reconcile_due {
                         // #1231: detect a `cqs index --force` rotation that
                         // happened between idle ticks — the inotify branch
                         // at line 1191 only fires on actual filesystem
@@ -1438,13 +1468,14 @@ pub fn cmd_watch(
                             }
                             last_reconcile = std::time::Instant::now();
                         } else {
-                            let queued = run_daemon_reconcile(
+                            let queued = reconcile::run_daemon_reconcile_with_walk(
                                 &store,
                                 &root,
                                 &parser,
                                 no_ignore,
                                 &mut state.pending_files,
                                 max_pending_files(),
+                                shared_disk_files.as_ref(),
                             );
                             if queued > 0 {
                                 // Reset `last_event` so `process_file_changes`

--- a/src/cli/watch/reconcile.rs
+++ b/src/cli/watch/reconcile.rs
@@ -90,21 +90,60 @@ pub(super) fn run_daemon_reconcile(
     pending_files: &mut HashSet<PathBuf>,
     max_pending: usize,
 ) -> usize {
+    run_daemon_reconcile_with_walk(
+        store,
+        root,
+        parser,
+        no_ignore,
+        pending_files,
+        max_pending,
+        None,
+    )
+}
+
+/// PF-V1.30.1-3 (#1226): reconcile variant that accepts a pre-computed
+/// disk walk. When the caller has already enumerated the tree (e.g.
+/// because periodic GC is also firing on the same idle tick),
+/// `disk_files: Some(&shared_set)` skips the internal walk.
+/// `disk_files: None` falls back to the original `enumerate_files`
+/// call. The legacy [`run_daemon_reconcile`] entry point delegates here
+/// with `None` for backward compatibility with existing call sites
+/// (the daemon idle-tick path is the one site that pre-walks).
+pub(super) fn run_daemon_reconcile_with_walk(
+    store: &Store,
+    root: &Path,
+    parser: &CqParser,
+    no_ignore: bool,
+    pending_files: &mut HashSet<PathBuf>,
+    max_pending: usize,
+    disk_files: Option<&HashSet<PathBuf>>,
+) -> usize {
     let _span = tracing::info_span!("daemon_reconcile", max_pending).entered();
     // OB-V1.30.1-7: capture elapsed time for the terminal log lines so
     // operators can correlate reconcile cadence with GC overhead in
     // journalctl. Pattern matches the HNSW build sites already in tree.
     let start = std::time::Instant::now();
 
-    // Walk disk → set of relative paths visible to indexing.
+    // Walk disk → set of relative paths visible to indexing. PF-V1.30.1-3:
+    // reuse the caller-supplied walk when present (saves one full
+    // `enumerate_files` pass on ticks that fire both gc and reconcile).
     let exts = parser.supported_extensions();
-    let disk_files = match cqs::enumerate_files(root, &exts, no_ignore) {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!(error = %e, "Reconcile: enumerate_files failed");
-            return 0;
+    let walked: Option<HashSet<PathBuf>> = if disk_files.is_none() {
+        match cqs::enumerate_files(root, &exts, no_ignore) {
+            Ok(v) => Some(v.into_iter().collect()),
+            Err(e) => {
+                tracing::warn!(error = %e, "Reconcile: enumerate_files failed");
+                return 0;
+            }
         }
+    } else {
+        None
     };
+    let disk_files: &HashSet<PathBuf> = disk_files.unwrap_or_else(|| {
+        walked
+            .as_ref()
+            .expect("walked is Some when disk_files was None and walk succeeded")
+    });
 
     // One SELECT pulls every indexed source-file origin + its stored
     // mtime. Map keyed by origin string for cheap lookups in the loop.
@@ -164,7 +203,7 @@ pub(super) fn run_daemon_reconcile(
                 // slash-normalized form the chunks table uses, so a
                 // Windows-side reconcile and a WSL-side watcher don't
                 // double-queue the same file under both separators.
-                let normalized = normalize_pending_path(&rel);
+                let normalized = normalize_pending_path(rel);
                 if pending_files.insert(normalized) {
                     added += 1;
                     queued += 1;
@@ -178,7 +217,7 @@ pub(super) fn run_daemon_reconcile(
                 let lookup_path: PathBuf = if rel.is_absolute() {
                     rel.clone()
                 } else {
-                    root.join(&rel)
+                    root.join(rel)
                 };
                 let needs_reindex = match FileFingerprint::read_disk(
                     &lookup_path,
@@ -200,7 +239,7 @@ pub(super) fn run_daemon_reconcile(
                     Some(disk_fp) => !stored_fp.matches(&disk_fp, FingerprintPolicy::MtimeOrHash),
                 };
                 if needs_reindex {
-                    let normalized = normalize_pending_path(&rel);
+                    let normalized = normalize_pending_path(rel);
                     if pending_files.insert(normalized) {
                         modified += 1;
                         queued += 1;
@@ -583,6 +622,57 @@ mod tests {
     /// git-checkout doesn't drown the next process_file_changes
     /// cycle. Tests the strict pre-queue clamp: files we'd otherwise
     /// queue are skipped once `pending_files.len() >= max_pending`.
+    /// PF-V1.30.1-3 (#1226): when the caller supplies `disk_files`,
+    /// reconcile uses that set verbatim instead of walking the tree.
+    /// Verify by passing a `disk_files` that doesn't match what's on
+    /// disk: a non-existent path. If reconcile honored the supplied
+    /// set, it queues that path (the index doesn't have it). If it
+    /// silently fell back to its own walk, the supplied path would be
+    /// skipped and the actual files would be queued instead.
+    #[test]
+    fn run_daemon_reconcile_with_walk_uses_supplied_disk_files() {
+        let dir = TempDir::new().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        fs::create_dir_all(&cqs_dir).unwrap();
+        let src_dir = dir.path().join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+        // Real disk file that the *internal* walk would discover.
+        fs::write(src_dir.join("on_disk.rs"), "fn a() {}").unwrap();
+
+        let store = open_store(&cqs_dir);
+
+        // Synthetic disk_files set that does NOT include `on_disk.rs`.
+        // If reconcile honors this set, only `synthetic.rs` is queued;
+        // if it falls back to its own walk, `on_disk.rs` is queued
+        // instead (and the synthetic path is missed entirely).
+        let mut supplied: HashSet<PathBuf> = HashSet::new();
+        supplied.insert(PathBuf::from("src/synthetic.rs"));
+
+        let mut pending: HashSet<PathBuf> = HashSet::new();
+        let queued = run_daemon_reconcile_with_walk(
+            &store,
+            dir.path(),
+            &parser(),
+            false,
+            &mut pending,
+            usize::MAX,
+            Some(&supplied),
+        );
+        assert_eq!(queued, 1, "supplied set has one entry → one queued");
+        let pending_strs: Vec<String> = pending
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+        assert!(
+            pending_strs.iter().any(|s| s.contains("synthetic.rs")),
+            "must queue the supplied path, not the real disk file. got: {pending_strs:?}"
+        );
+        assert!(
+            !pending_strs.iter().any(|s| s.contains("on_disk.rs")),
+            "must NOT walk the real tree when disk_files was supplied. got: {pending_strs:?}"
+        );
+    }
+
     #[test]
     fn run_daemon_reconcile_respects_max_pending_cap() {
         let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Lifts the working-tree walk out of `run_daemon_periodic_gc` and `run_daemon_reconcile` and threads it through the watch loop's idle-tick dispatcher. When both periodic-GC and periodic-reconcile gates fire on the same idle tick (every ~30 min on default settings — both share the `daemon_periodic_gc_idle_secs` idle gate), the daemon now does **one** disk walk instead of two back-to-back ones.

Closes #1226.

## What changed

- **`run_daemon_reconcile_with_walk(...)`** — new entry point that accepts `disk_files: Option<&HashSet<PathBuf>>`. The legacy `run_daemon_reconcile` delegates to it with `None`, so existing callers (test suite, the prior idle-tick site) work unchanged.
- **`run_daemon_periodic_gc(...)`** — gains the same `disk_files` parameter. `Some(set)` skips the internal walk; `None` falls back to `cqs::enumerate_files` as before.
- **`cli/watch/mod.rs` idle-tick block** — computes `gc_due` and `reconcile_due` upfront. When both fire, it does one walk and threads the resulting `HashSet<PathBuf>` to both consumers. When only one fires, the consumer falls back to its internal walk.

## Cost / win

The win is bounded — only every-~30-min coincident ticks save a walk. The motivation is as much architectural cleanup as raw perf: the walk belongs in the dispatcher that knows about both consumers, not duplicated inside each.

A typical 17k-chunk WSL `/mnt/c/` repo: ~1 s saved per 30-min coincident tick. Linux SSD: sub-second.

## New test

`run_daemon_reconcile_with_walk_uses_supplied_disk_files` — passes a synthetic `disk_files` set that doesn't match what's on disk. Asserts the synthetic path is queued (proving the supplied set was used) and the real disk file is NOT (proving the internal walk didn't run as a fallback).

## Test plan

- [x] `cargo build --features cuda-index` clean
- [x] `cargo test --features cuda-index --bin cqs run_daemon_reconcile` — 8 passed (7 existing + 1 new)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean (matches CI's clippy step)

## Out of scope (per #1226)

- Streaming the walk (RM-5 / #1229).
- Changing the interval defaults.
- Eliminating per-file `dunce::canonicalize` cost.
