### PR TITLE
docs(continuity+roadmap): cleanup pass post-v1.32.0 sweep

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,229 +2,95 @@
 
 ## Right Now
 
-**v1.32.0 released 2026-05-01.** Tag `v1.32.0` pushed (`5a577a30`); `cqs 1.32.0` published to crates.io; release.yml building prebuilt binaries.
+**v1.32.0 released 2026-05-01.** Tag `v1.32.0` pushed (`5a577a30`); `cqs 1.32.0` published to crates.io. Schema v23 → v25 (chained, additive `ALTER TABLE … ADD COLUMN`); no reindex required.
 
-**Theme:** post-v1.31.0 structural-trust + watch-correctness bundle. **Schema v23 → v25** (chained auto-migration: v23→v24 adds `chunks.vendored`, v24→v25 adds `notes.kind`). Reindex not required; both migrations are additive `ALTER TABLE … ADD COLUMN`.
+Five themes (full detail in CHANGELOG.md):
 
-**Bundle table (all merged):**
+1. **HNSW load-phase flock self-deadlock fix** (#1261) — urgent watch-mode correctness.
+2. **Three-tier `trust_level: vendored-code`** (#1221, schema v24) — chunks under `vendor/`, `node_modules/`, `third_party/`, `.cargo/`, `target/`, `dist/`, `build/` get `vendored-code` instead of bare `user-code`. Override via `[index].vendored_paths`.
+3. **Worktree → main-index discovery** (#1254) — `cqs` from inside a `git worktree` without its own `.cqs/` auto-discovers main's index via `.git/commondir`; envelopes carry `_meta.worktree_stale` + `_meta.worktree_name`.
+4. **Note kind taxonomy** (#1133, schema v25) — `cqs notes add/list/update --kind` + structured `kind` column + `idx_notes_kind`. Full add/list/update lifecycle wired (kind taxonomy is end-to-end).
+5. **TC-ADV reconcile coverage + persistent TRT engine cache** (#1260).
 
-| PR | Closes | Theme |
-|---|---|---|
-| #1260 | #1242 #1243 | TC-ADV reconcile clock-skew + read_disk metadata-Err tests + persistent TRT engine cache (`~/.cache/cqs/trt-engine-cache/`, gated on `CQS_TRT_ENGINE_CACHE`). |
-| #1261 | — | **HNSW load-phase flock self-deadlock fix** (the urgent watch-mode correctness fix). Drop `_lock_file` after the read phase so the rebuild thread's `save()` doesn't park forever. Regression test pinned. |
-| #1262 | #1221 | Three-tier `trust_level: vendored-code` for chunks under `vendor/`, `node_modules/`, `third_party/`, `.cargo/`, `target/`, `dist/`, `build/` (default; override via `[index].vendored_paths`). **Schema v23→v24.** |
-| #1263 | #1254 | Worktree → main-`.cqs/` discovery via `.git/commondir`. Every JSON envelope from a worktree-without-own-`.cqs/` process carries `_meta.worktree_stale: true` + `_meta.worktree_name`. |
-| #1265 | #1133 | Note `kind` taxonomy (audit P2.91). `cqs notes add --kind <kind>`, structured tag column, `idx_notes_kind`. **Schema v24→v25.** |
-| #1266 | — | release. |
-
-**State:**
-- Main at `5a577a30`. Local at the same SHA.
-- v1.32.0 published to crates.io ✅. Release workflow run building prebuilts.
-- v23 → v24 → v25 migration verified clean on local daemon: both `Migrated to v24: vendored column on chunks` and `Migrated to v25: kind column on notes` log lines fired without panic.
-- HNSW flock fix (#1261) verified in production: post-restart daemon transitions out of `rebuilding` cleanly; no `cqs-hnsw-rebuild` thread parks in `locks_lock_inode_wait`.
-
-**Post-v1.32.0 follow-up sweep (2026-05-01, all merged on main):**
+### Post-v1.32.0 sweep (2026-05-01, all merged on main)
 
 | PR | Closes | Theme |
 |---|---|---|
-| #1268 | — | Fix flaky `llm::validation::tests::from_env_strict` race on main (ENV_LOCK hoisted to module level). Restored main green after v1.32.0 release. |
-| #1269 | — | `cqs notes list --kind <kind>` filter (#1133 follow-up; column-level filter using v25 `notes.kind` + `idx_notes_kind`). ANDs with `--warnings`/`--patterns`; daemon batch path wired too. |
-| #1270 | #1176 | SPLADE phase 2 A/B writeup: RRF on dense+sparse trails linear-α blend by ~1pp R@5/R@20 on test, ~4-5pp R@1/R@5 on dev. Closed without merging the impl swap. New file `research/models.md` is the inaugural retrieval-research log entry. |
-| #1271 | #1230 | `process_file_changes_zero_files_is_noop_when_embedder_blocked` test in `cli/watch/tests.rs` — pins the smallest no-op contract using the existing blocked-backoff trick from `dropped_this_cycle_survives_embedder_init_early_return`. |
-| #1272 | #1217 | `write_slot_model` now reads + round-trips through `SlotConfigFile` with `#[serde(flatten)] extra: toml::Table`, preserving unrelated top-level sections (e.g. hand-added `[notes].project_id`). Comments still lost (toml crate limitation); user-keys-survive contract delivered. |
-| #1273 | #1215 | Extract `daemon_request<T: DeserializeOwned>` helper from `daemon_translate.rs`; `daemon_ping`/`status`/`reconcile` collapse to thin shims. -110 net lines, single span carrying `command` field. |
-| #1274 | — | Continuity update for the post-v1.32.0 sweep itself. |
-| #1275 | #1218 | `AuthChannel` trait + `BearerHeaderChannel` / `CookieChannel<'a>` / `QueryParamChannel` impls for `cqs serve` auth. `check_request` collapses to a 3-channel registry walk. New `channel_priority_is_bearer_cookie_query` test pins the priority ordering. Adding mTLS / API-key / JWT / SSO becomes one new impl. |
-| #1276 | #1220 | `Reranker` trait + `OnnxReranker` (renamed from struct), `NoopReranker` (eval ablation), `LlmReranker` (BatchProvider skeleton). Holders switched from `OnceLock<Reranker>` to `OnceLock<Arc<dyn Reranker>>` at 3 sites. |
+| #1268 | — | Fix flaky `llm::validation::tests::from_env_strict` race (ENV_LOCK hoisted). Restored main green. |
+| #1269 | — | `cqs notes list --kind <kind>` filter (#1133 follow-up). |
+| #1270 | #1176 | SPLADE phase 2 negative-result A/B writeup → `research/models.md`. RRF dense+sparse trails linear-α by ~1pp R@5/R@20 on test, ~4-5pp R@1/R@5 on dev. Linear-α stays. |
+| #1271 | #1230 | `process_file_changes` zero-files no-op test. |
+| #1272 | #1217 | `write_slot_model` round-trips through `SlotConfigFile` with flatten extras — preserves unrelated TOML sections. |
+| #1273 | #1215 | `daemon_request<T>` helper extraction; `daemon_ping/status/reconcile` collapse to thin shims. -110 net lines. |
+| #1275 | #1218 | `AuthChannel` trait + 3 impls (`Bearer`/`Cookie<'a>`/`QueryParam`). `check_request` collapses to a registry walk. |
+| #1276 | #1220 | `Reranker` trait + `OnnxReranker` (renamed) / `NoopReranker` / `LlmReranker` (skeleton). Holders cache `Arc<dyn Reranker>`. |
+| #1278 | #1133 | `cqs notes update --new-kind <kind>` flag — closes the kind taxonomy lifecycle. |
+| #1279 | #1226 | `run_daemon_reconcile_with_walk(...)` accepts pre-computed disk walk; idle-tick dispatcher does one walk when both gc + reconcile fire. |
+| #1274 / #1277 | — | Continuity updates. |
 
-**Up next:**
-- Verify release.yml prebuilds completed for all three targets (Linux x86_64, Windows x86_64, macOS aarch64).
+**Eight issues closed by this sweep:** #1133 (already), #1176, #1217, #1218, #1220, #1226, #1230, #1215.
+
+**State:** main at `da4b79ff` (post-#1279). Local at the same SHA. Daemon up to date (rebuilt + reinstalled after each merge).
+
+**Conda/pip cleanup pass (2026-05-01):** safe-tier upgrades across base, cqs-train, onnx-export, vllm-serve. Bumped: `anthropic` 0.86→0.97 (used by SQ-6), `onnxruntime` 1.24.4→1.25.1, `onnx` 1.20→1.21, `sentence-transformers` 5.1→5.4, `peft` 0.18→0.19, `datasets` 4.8.4→4.8.5, `pip` 26.0.1→26.1, plus ~15 utility minors per env. Held: `transformers` 4→5, `protobuf` 6→7, `cudnn` 9.19→9.21, `cuda-version` 13.1→13.2, `vllm` 0.19→0.20, `torch` 2.9→2.11, all `nvidia-*` (torch-pinned). Rolled back: `mpmath` (sympy cap), `setuptools` (torch cap), `fsspec` (datasets cap), `flashinfer-cubin/python`/`lark` (vllm exact pins). Pre-existing latent conflicts surfaced (not caused by upgrades): `pylate` pins `st==5.1.1`/`ujson==5.10.0` in base; `optimum-onnx` pins `transformers<4.58` in cqs-train; `vllm 0.19` pins `transformers<5` but env has 5.6.0.dev0; `coir-eval` missing `faiss-cpu`.
+
+**Up next (no active task — user-direct):**
+- Verify release.yml prebuilds completed for all three targets.
 - v1.32.0 audit eligible (16-category audit).
-- Embedder eval queue: Phase 3 EmbeddingGemma-300m, ceiling probes Qwen3-Embedding-8B + NV-Embed-v2 — all queued in ROADMAP, all eval-required.
+- Embedder eval queue: Phase 3 EmbeddingGemma-300m, ceiling probes Qwen3-Embedding-8B + NV-Embed-v2.
 
-**Outstanding follow-ups (still small, no PRs yet):**
-- `cqs notes update --kind` flag (#1269 only added `add` and `list`; update path still needs the field).
-- #1107 (`cqs slot create --model` not persisted) — now a one-line `write_slot_model` call thanks to #1272.
-- `cqs eval --reranker none|onnx` flag (`NoopReranker` is in place from #1276; eval-runner construction site needs a one-line dispatch).
-- `LlmReranker` production wiring against `BatchProvider` (skeleton in `src/reranker.rs` from #1276).
+### Outstanding follow-ups (small, optional)
+
+- `cqs eval --reranker none|onnx` flag (`NoopReranker` infrastructure ready from #1276; eval-runner needs a one-line dispatch).
+- `LlmReranker` production wiring against `BatchProvider` (skeleton in `src/reranker.rs`).
 - Retroactive vendored / kind tagging for pre-v25 rows — operator can `cqs index --force` if they want immediate flagging.
-- cuvs crate update — upstream PRs #1840 (serialize/deserialize) + #2019 (search_with_filter) both merged into rapidsai/cuvs; `[patch.crates-io]` entry on `jamie8johnson/cuvs-patched` becomes redundant once a new cuvs crate publishes (RAPIDS ~2-month cadence).
+- `cuvs` crate update — upstream PRs #1840 (serialize/deserialize) + #2019 (search_with_filter) both merged into rapidsai/cuvs; `[patch.crates-io]` entry on `jamie8johnson/cuvs-patched` becomes redundant once a new cuvs crate publishes (RAPIDS ~2-month cadence).
 
-**Open Issues (post-v1.32.0 + this sweep):** ~11 remain. All P1/P2 closed. Refactor frontier (#1218 / #1215 / #1220) cleared. Remaining: #106 (ort RC, blocks on upstream), perf cluster #1244 / #1228 / #1229 / #1226 (RM/PF) which all have small wins per the audit but mostly need careful eval, #1216 (BatchCmd dispatch macro — 33-handler refactor), #1043 (needs Windows env), #916/#717 (mmap perf, eval-required), #255 (pre-built reference packages, feature). #1139 / #1140 explicitly skipped per autopilot directive.
+## Open issues (11 total)
+
+All P1/P2 closed. Refactor frontier (#1215, #1217, #1218, #1220, #1226) cleared. Remaining are tier-3 or have specific blockers.
+
+| # | Title | Why open |
+|---|---|---|
+| 106 | ort dependency is pre-release RC | Blocks on upstream pykeio cutting a stable 2.0 |
+| 255 | Pre-built reference packages | Signing/registry design (infra, not code) |
+| 717 | perf: HNSW fully loaded into RAM | Needs lib swap to hnswlib-rs (nightly-only) |
+| 916 | perf: mmap SPLADE index | Audit-deprioritized — 59 MB peak transient, dominated by parse-side allocations |
+| 1043 | `is_slow_mmap_fs` ignores Windows network drives | Linux/WSL unaffected; needs Windows test runner |
+| 1139 | EX-V1.30-3: structural_matchers shared library | Touches 50+ language modules; explicitly skipped per autopilot directive |
+| 1140 | EX-V1.30-4: Embedder preset extras map | Skipped per autopilot directive |
+| 1216 | EX-V1.30.1-2: BatchCmd dispatch macro table | 33-handler refactor; current dispatch already exhaustive |
+| 1228 | RM-2: wait_for_fresh persistent connection | Daemon side reads one request per connection — option (a) is bigger than the issue's "30-line" estimate |
+| 1229 | RM-5: stream enumerate_files walk | Real win at 1M-file repos; needs `enumerate_files_iter` API + batched SQL lookup |
+| 1244 | RM-4: HNSW snapshot 17 MB | Audit's "240×" claim assumed nonexistent u32 chunk_ids; actual win ~1 MB via `[u8; 32]` repr |
 
 ## Parked
 
-Strategic frontier candidates if the user redirects:
-- **#1130 / #1176** — phase 2 SPLADE → `rrf_fuse_n` (eval-required A/B)
-- **#1133** — `NoteEntry` kind/tag taxonomy
-- **#1131 follow-on** — wire USearch / SIMD brute-force as `IndexBackend` candidates (trait scaffolding from #1131 already in)
-- **#1212** — bulk `upsert_sparse_vectors` DELETE perf wart (1M-row delete holds SQLite write lock ~8s on bulk reindex)
-- P4 hard items #1215-#1232 — extensibility umbrellas (BatchCmd macro table, AuthChannel trait, Reranker trait, daemon_request<T> dedup) + data-safety (db_file_identity, schema v23 fingerprint with content_hash+size) + security (vendored chunks denylist + `vendored: bool` schema bump).
+Strategic frontier candidates if redirected:
 
-#1139 (structural_matchers shared library) + #1140 (Embedder preset extras map) explicitly skipped per autopilot directive.
-
-**Landed since v1.30.0 release:**
-- **#1146** — `fix(daemon): #1127 — short-hold mutex via BatchView snapshot dispatch`. Daemon BatchContext mutex now held only across `checkout_view_from_arc` (microseconds); handlers run outside the lock against a `BatchView`. Two slow queries (gather + task) now overlap on wall-clock instead of serializing.
-- **#1147** — `refactor(watch): split watch.rs into watch/ module`. 5,711-line `cli/watch.rs` carved into 10 submodules: `mod.rs` (1,206 lines) + `socket` / `runtime` / `rebuild` / `gc` / `events` / `reindex` / `daemon` / `tests` / `adversarial_socket_tests`. Agent-readable file sizes; CONTRIBUTING.md Architecture Overview updated.
-- **#1148** + **#1154** — roadmap docs: queue USearch + SIMD brute-force as IndexBackend candidates; queue 5 watch-mode improvements (adaptive debounce / `cqs status --watch` / whitespace-canonical hash / parallel reindex across slots / kill periodic rebuild).
-- **#1149-#1153** — 5 dependabot bumps merged: `lru` 0.17→0.18, `blake3` 1.8.4→1.8.5, `rayon` 1.11→1.12, `tokenizers` 0.22.2→0.23.1, `assert_cmd` 2.2.0→2.2.1.
-- **#1155** — raise `open-pull-requests-limit` from 5 to 10 in `.github/dependabot.yml`. Per-dep granularity preserved (no grouping).
-- **#1157-#1164** — 8 more dependabot bumps after the cap raise: misc minor/patch upgrades. **#1156** (tree-sitter-dart 0.2.0) closed: 0.2.0 grammar removed `function_signature` node; cqs Dart query references it. Migration deferred — staying on 0.1.0.
-- **#1165** — `refactor(scoring): #1132 shared `ScoringKnob` resolver`. Replaced 9-named-field `ScoringOverrides` with `HashMap<String,f32>` + `#[serde(flatten)]`; added `SCORING_KNOBS` static array (11 rows: name, env_var, default, min, max, cache flag) + `resolve_knob(name)` lookup. Single resolver path: config override → env var (finite + in-range) → default. `ScoringConfig::current()` reads via the resolver. Eval-neutral. Closes P2 task #1132.
-
-**This session's surface-broadening — indirect prompt injection threat model.** cqs faithfully relays indexed content (code comments, summaries, notes, reference content) into AI agent context. The relay carries injection payloads through any of those surfaces. Filed 5 tracking issues:
-
-- **#1166** — `--improve-docs` review gate (highest-impact: persists into git on `--improve-docs --apply`)
-- **#1167** — `trust_level` field + optional content delimiters in chunk-returning JSON output
-- **#1168** — first-encounter prompt when indexing a repo with committed `docs/notes.toml`
-- **#1169** — surface reference origin (`trust_level` + `reference_name`) in `cqs ref` chunk results
-- **#1170** — validate LLM summary output before caching (length cap, injection-pattern detection)
-
-**#1171** documents the threat model — adds top-level `## Indirect Prompt Injection / Supply-Chain Risks from Indexed Content` section to SECURITY.md with surface table, mitigations, and tracked-improvements list. CI in flight.
-
-
-### v1.30.0 release session (2026-04-25) — what landed
-
-**Merged (this session):**
-- **#1103 — `chore(tears): post-#1101 / #1100 session state`**. Updated PROJECT_CONTINUITY for the v1.29.1/cache+slots state.
-- **#1105 — `feat(slot+cache): named slots + project-scoped embeddings cache`**. Single-PR delivery of the spec from #1100. `.cqs/embeddings_cache.db` (content_hash, model_id) + `.cqs/slots/<name>/` directories + `cqs slot {list,create,promote,remove,active}` + `cqs cache {stats,prune,compact}` + `--slot`/`CQS_SLOT` on every major command + one-shot migration of `.cqs/index.db` → `.cqs/slots/default/`. Added `cqs::resolve_index_db()` helper after merge to fix 8 call sites that built `.cqs/index.db` paths directly (post-merge wiring fix). `model_swap_test.rs` updated to follow the slot migration.
-- **#1106 — `fix(test): loosen hnsw::test_build_batched recall window from top-5 to top-10`**. Closes #1104 (flake on top-5 of 25 unseeded HNSW). The failing assertion expected the gold chunk in top-5 of an unseeded HNSW build; loosening to top-10 keeps the recall guarantee while accepting random-graph variance.
-
-**Three-way embedder A/B (refreshed v3.v2, all slots fully enriched):**
-
-| Model | Params | dim | dev R@1 | dev R@5 | dev R@20 | test R@1 | test R@5 | test R@20 |
-|---|---:|---:|---:|---:|---:|---:|---:|---:|
-| **BGE-large** | 335M | 1024 | 42.2% | **74.3%** | **87.2%** | 36.7% | 63.3% | **80.7%** |
-| CodeRankEmbed | 137M | 768 | **45.0%** | 69.7% | 79.8% | **37.6%** | **67.0%** | 78.9% |
-| v9-200k (E5-LoRA) | 110M | 768 | 20.2% | 40.4% | 52.3% | 22.9% | 38.5% | 47.7% |
-
-Verdict: **BGE-large stays default.** CodeRankEmbed wins R@1 and test R@5 — added as opt-in preset (#1110). v9-200k underperforms by ~30pp R@5 on v3.v2; consistent with the prior "best 296q fixture R@1 / worst CoIR" finding — its CSN/Stack-curated representation doesn't generalize to LLM-generated + telemetry queries. Retired from production candidacy on this fixture distribution. Phase 2 (`nomic-embed-code` 7B) explicitly deferred — at 7B params, inference cost approaches an LLM call.
-
-**Methodology trick worth keeping:** copy `llm_summaries` rows cross-slot by content_hash before `cqs index --llm-summaries`. Summary text is model-independent (it's NL describing the chunk); only the embedding into the slot's HNSW changes. Coderank: 6,855 of 7,675 cached, 894 new generated. v9-200k: 7,749 cached, 0 new generated (overlap was 100% of eligible chunks below threshold). Saved ~$1-2 of API spend across both A/B prep cycles.
-
-**Fixture drift discovery:** running the canonical dev eval against current main produced R@5 = 51.4% — apparently down 26.6pp from canonical 78.0%. R@20 had crashed 88.1% → 54.1%. The cause was 100% fixture-side: 42 of 109 dev gold chunks had `line_start` shifted by 1-96 lines after v1.29.0 (147 fixes) + v1.29.1 (91 fixes), and the eval matches `(file, name, line_start)` strictly. After re-pinning to nearest current `(name, origin, chunk_type)` candidate, R@5 returned to 74.3% (3.7pp below canonical = real corpus-drift attrition, not a regression). PR #1109 commits the refresh.
-
-**Residual gap diagnosis:** 5,413 of 17,778 chunks (30%) created since the canonical 2026-04-20 baseline (audit-fix wave touched many files). Audit fixes shifted chunk content even where line numbers held → small embedding shifts → some borderline gold answers fall below R@20 threshold. CAGRA was ruled out as a cause (HNSW gives identical numbers at limit=20; CAGRA only fails at limit≥100 via `topk=500 > itopk_size=480` — separate operational gotcha). Real attrition, not a search-path regression.
-
-**Other operational findings (logged for posterity):**
-- Centroid classifier silently no-ops when query embedding dim ≠ centroid file dim. The shipped centroid file is 1024-dim BGE-prefixed; v9-200k queries (768-dim, E5 prefix) hit the dim guard and fall through to rule-based-only routing. ~0-3pp test-R@5 cost on v9-200k. If we ever swap default embedders, centroid file must be regenerated per-model.
-- `cqs slot create --model X` validates the model but doesn't write anything to the slot. The slot's actual model is resolved later from `--model` / `CQS_EMBEDDING_MODEL` / index metadata at first index pass. First attempt at coderank reindex silently used BGE (caught after a bad eval). #1107 filed.
-- Bare-vs-enriched on v9-200k gave **identical** R@5 numbers (40.4% dev, 38.5% test, both runs). Summaries can't rescue a dense channel that doesn't surface the right neighborhood. Useful diagnostic: if `--llm-summaries` doesn't move R@5 at all, the embedder is the bottleneck.
-
-### Research log updates (committed to `cqs-training` repo)
-
-- `c8b3953` — added v9-200k three-way to v3.v2 A/B section in `research/models.md`. Per-category collapse: every NL→code semantic category drops to 16-25% R@5 vs BGE's 50-69%; only identifier_lookup holds (FTS+name-boost path doesn't need strong dense semantics).
-- `284c4af` — original CodeRankEmbed A/B + fixture refresh writeup.
-- `ef8704b` — Reranker V2 Phase 4 notes (cqs-domain graded retrain, all three loss regimens net-negative) — committed today after surfacing as a leftover uncommitted change from a prior session.
-
-### v1.29.1 contents
-
-Patch release — audit close-out. 147 findings from the v1.29.0 audit triaged; 142 fixed across 3 commits to #1094 + #1093. No new commands, no schema bump, no reindex. Full list in `CHANGELOG.md`.
-
-Highlights:
-- **Cagra SIGSEGV root-caused + fixed** — `impl Drop for GpuState` now calls `resources.sync_stream()` before fields drop. Async CUDA kernels from prior tests were in-flight when `cuvsResourcesDestroy` fired, producing a teardown segfault. All 22 cagra tests pass serially post-fix.
-- **`cqs serve` security hardening** — Host header allowlist (SEC-1), SQL LIMIT caps on graph + cluster (SEC-3), HTML escaping on 3D asset innerHTML (SEC-2), `--open` forced to loopback (SEC-6).
-- **Transaction integrity** — staleness / metadata writes honour `begin_write`, cache eviction single-tx, HNSW persist parent-dir fsync, migration backup default-on with orphan-drop guard.
-- **Env-var knobs** — 13 new `CQS_*` vars for thresholds (hotspot/risk/blast/GC/etc). Additive; defaults preserved.
-- **Test coverage** — reranker happy paths, `cqs project search` / `cqs ref {add,list,remove,update}` CLI end-to-end, daemon socket round-trip.
-- **Security bump** — `rustls-webpki` 0.103.12 → 0.103.13 (Dependabot #15, GHSA high, DoS via malformed CRL).
-
-### Audit close-out remaining
-
-- **Umbrella**: issue #1095 (rewritten post-#1094; 2 micro-perf items kept: PF-V1.29-9 suggest_tests BFS, RM-V1.29-10 socket BufReader scratch).
-- **Split into tracking issues**: #1096 (SEC-7 serve auth), #1097 (EX-V1.29-1 Commands→trait), #1098 (EX-V1.29-3 LlmProvider trait + Local provider).
-
-### v1.29.0 contents (shipped 2026-04-23)
-
-Feature release bundling three arcs (23 commits since v1.28.3):
-- **`cqs serve`** with 4 views (2D / 3D / hierarchy / embedding cluster) + perf pass (~60s → ~3-4s first paint). Schema v22 (umap_x/umap_y); opt-in via `cqs index --umap`.
-- **`.cqsignore`** mechanism for cqs-only exclusions.
-- **Slow-tests cron killed**: 5 of 16 subprocess CLI test binaries converted to in-process; `slow-tests.yml` workflow deleted.
-- 2 Dependabot security bumps (openssl 0.10.78, rand 0.8.6).
-
-Spec docs:
-- `docs/plans/2026-04-22-cqs-serve-3d-progressive.md`
-- `docs/plans/2026-04-22-cqs-serve-perf.md`
-- `docs/plans/2026-04-22-cqs-slow-tests-elimination.md`
-
-### Pre-flight cleanups that landed alongside the release
-
-Things clippy 1.95 caught when running with `-D warnings`:
-- **Restored `slow-tests` Cargo feature gate** — 11 subprocess test files still reference `#![cfg(feature = "slow-tests")]` (not in original conversion scope): `cli_blame_test`, `cli_brief_test`, `cli_chat_completer_test`, `cli_chat_format_test`, `cli_doctor_fix_test`, `cli_drift_diff_test`, `cli_envelope_test`, `cli_neighbors_test`, `cli_reconstruct_test`, `cli_review_test`, `cli_train_review_test`. Feature kept alive (gate without an executor — the cron is gone). Convert opportunistically when re-touching their code.
-- **`tests/common/mod.rs`** — file-level `#![allow(dead_code, clippy::type_complexity)]` since harness items used by different test-binary subsets.
-- **`src/search/scoring/candidate.rs`** — `SearchFilter::default()` + field reassignment → struct literal.
-
-### Just-shipped arcs (2026-04-22 → 2026-04-23)
-
-**`cqs serve` 3D progressive rollout (#1077, #1078, #1079, #1081):**
-- Step 1: renderer abstraction + 2D/3D toggle (Three.js + 3d-force-graph, lazy-loaded)
-- Step 2: hierarchy view (Y axis = BFS depth from selected root)
-- Step 3: embedding cluster view (X/Z = UMAP, Y = caller count) — adds `cqs index --umap` flag, schema v22 (umap_x/umap_y columns), Python `scripts/run_umap.py` embedded in binary
-- Perf pass: SQL-side `max_nodes` cap, default 300 (was 1500), `cose` layout (was dagre), gzip middleware, lazy 3D bundle. **First paint ~60s → ~3-4s on cqs corpus.**
-- Spec: `docs/plans/2026-04-22-cqs-serve-3d-progressive.md` + `2026-04-22-cqs-serve-perf.md`
-
-**`.cqsignore` mechanism (#1080):** Layered on top of `.gitignore`. Excludes vendor minified JS + eval JSON fixtures. Index 18,954 → 15,488 chunks. Zero "Dropped oversized" parser warnings.
-
-**Slow-tests elimination (#1082-#1088, full sweep):** All 5 subprocess CLI test binaries (cli_health, cli_test, cli_graph, cli_commands, cli_batch — 113 tests, ~130 min nightly cron) converted to in-process `InProcessFixture`-based tests (60 tests across 4 binaries) + 15-test `cli_surface_test.rs` for things that genuinely need a binary. **`slow-tests.yml` workflow deleted, `slow-tests` Cargo feature removed.** Now ~2 min added to every PR instead of ~130 min nightly. Spec: `docs/plans/2026-04-22-cqs-slow-tests-elimination.md`. Issue #980 closed.
-
-**Dependabot security alerts: 12 → 0 open.**
-- #1086: openssl 0.10.75 → 0.10.78 (medium, several CVE-adjacent fixes) — merged
-- #1089: rand 0.8.5 → 0.8.6 (low, custom-logger soundness) — open, awaiting CI
-
-### Newly-filed issues (2026-04-23)
-
-- **#1090** — `cqs watch` does a full HNSW rebuild on every file change (~15-30s of CUDA churn per save). `hnsw_rs` doesn't support incremental insert into a loaded index. Four candidate fixes ranked.
-- **#1091** — WSL `cqs watch` poll-watcher walks entire tree at 1500ms intervals over the 9P bridge → 8% sustained CPU. Easy win: configurable `CQS_WATCH_POLL_MS` with longer default.
-
-### Architecture state
-
-- **Version:** v1.30.0 (crates.io published 2026-04-25; tag `v1.30.0` at commit `68bfaca5`). Unreleased on main: 4 indirect-injection mitigations (#1177, #1178, #1180; #1179 in flight). Next release tag will be v1.30.1.
-- **Local binary:** stale — pinned at v1.30.0 + dep-bumps. **Refresh deferred until #1179 merges**, then `cargo build --release --features cuda-index` → stop cqs-watch → cp → restart.
-- **Index:** 18,760 chunks, **schema v22** (umap_x/umap_y columns, opt-in via `cqs index --umap`). No schema change in cluster — no reindex required.
-- **Tests:** ~3015 pass + 51 ignored locally post-cluster on main (#1177 +3, #1178 +7, #1180 +4 new tests); ~3027 expected after #1179 merges (+12 validation tests). Full suite in CI ~2 min added per PR.
-- **Production R@5 on v3.v2 (refreshed 2026-04-25):** test 63.3% / dev 74.3% with default BGE-large; CodeRankEmbed opt-in preset gets test 67.0% / dev 69.7% (R@1 wins, R@20 loses)
-- **cqs-watch daemon:** running v1.30.0 release binary; daemon mutex now short-hold (post-#1146); BatchView snapshot dispatch lets concurrent slow queries overlap
-- **`cqs serve`:** 4 views — `2d` / `3d` / `hierarchy` / `cluster`. Run `cqs index --umap` first to populate the cluster view's coords.
-- **Watch module structure (post-#1147):** `src/cli/watch/{mod,socket,runtime,rebuild,gc,events,reindex,daemon,tests,adversarial_socket_tests}.rs` — `mod.rs` is orchestration (1,206 lines), submodules carry the I/O / lifecycle / per-event plumbing.
-
-### Roadmap parked (highest-value)
-
-- **`nomic-ai/CodeRankEmbed` + `nomic-ai/nomic-embed-code` A/B** — open-weight code-specialized embedders. CodeRankEmbed is 137M (smaller than BGE-large), MIT, 768-dim, 8192-token context, asymmetric prefix. nomic-embed-code is 7B (Apache, Qwen2.5-Coder-based), GGUF quantizations available. ~2-hour A/B against v9-200k on the v3 fixture would tell us if CodeRankEmbed earns the default slot.
-
-### Local cleanup pending
-
-None. Working tree clean post-release.
-
-### Roadmap follow-ups added during the release
-
-- **11 slow-test-binary stragglers** (cli_blame, cli_brief, cli_chat_completer, cli_chat_format, cli_doctor_fix, cli_drift_diff, cli_envelope, cli_neighbors, cli_reconstruct, cli_review, cli_train_review) still gated by `slow-tests` feature with no executor (cron is dead). Convert opportunistically when re-touching the code paths they cover. Pattern documented in `docs/plans/2026-04-22-cqs-slow-tests-elimination.md`.
-- **Issue #1090** — HNSW full rebuild on every save (15-30s CUDA churn per file change in `cqs watch`)
-- **Issue #1091** — WSL poll-watcher 8% sustained CPU (1500ms interval, walks entire tree over 9P)
-
-## What's parked
-
-- **#1182 — perfect watch mode (3-layer reconciliation).** Filed 2026-04-28. Closes the missed-event classes (bulk git ops, WSL 9P, external writes) via git hooks + periodic full-tree reconciliation + `cqs status --watch-fresh --wait` API. Promise: "the index is always either fresh or telling you it isn't." Supersedes the CLAUDE.md "always run `cqs index` after branch switches/merges" guidance once landed. **Positioning lever — biggest gap between cqs and similar tools is "easy to index, hard to keep indexed between turns"; closing it makes freshness a top-line property alongside semantic search + call graphs.** Prior-art survey 2026-04-28 (in #1182 comment): codeindex.cc has per-query stale flags; Cursor has Merkle-tree sync; CocoIndex has fast incremental updates. None has the blocking `--wait` API + git-hook integration + the "between turns" consumer-consistency-model framing. Honest pitch: "the only code search tool that lets your agent **wait** until it's fresh" (not "the only one that tells you when it's stale" — codeindex.cc does that too). README/marketing pass to follow.
-- **HyDE on v3 dev** — most promising untested representation lever. Per-category routing required. Killed at v1.28.3 attempt.
-- **Reranker V2 properly retrained** — Phase 3 attempt failed (-24pp R@5 full pool). Three fixes in post-mortem (TIE labels, domain-shifted hard negatives, pool cap), ~1-2 weeks work. Re-attempt only with 10x more queries OR bge-reranker-large.
-- **ColBERT integration with per-token index** — eval tool exists, default off; full integration multi-week.
-- **Knowledge-augmented retrieval** — call/type graph as structured filter. Multi_step queries weakest at 28-43% R@1.
-- **Code-aware embedder switch (older candidates)** — CodeBERT, CodeT5+-110M, UniXcoder all untested on v3. v9-200k didn't help. CodeRankEmbed (above) is the better bet now.
+- **#1131 follow-on** — wire USearch / SIMD brute-force as `IndexBackend` candidates (trait scaffolding from #1131 already in).
+- **EmbeddingGemma-300m, Qwen3-Embedding-8B, NV-Embed-v2** — embedder eval queue, all eval-required.
+- **HyDE on v3 dev** — most promising untested representation lever. Per-category routing required. Killed at v1.28.3 attempt; index-time variant never properly retested at v3 N.
+- **Reranker V2 properly retrained** — Phase 3 attempt failed (-24pp R@5 full pool). Three fixes in post-mortem (TIE labels, domain-shifted hard negatives, pool cap), ~1-2 weeks work. Re-attempt only with 10× more queries OR bge-reranker-large.
+- **Knowledge-augmented retrieval** — call/type graph as structured filter. multi_step queries weakest at 28-43% R@1.
 
 ## Operational pitfalls (rolling forward)
 
-- **WSL git credential helper** — out-of-the-box, `git push` from `~/training-data` fails with "could not read Username." Fix: `git config --global credential.helper '/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe'`. Already configured globally.
-- **Squash-merge + rebase trap** — when a PR is squash-merged and a follow-up branch was based off it, rebase fails because individual commits ≠ squash. Fix: cherry-pick the follow-up's commits onto a fresh branch from main. Hit this 4 times during the cqs serve arc.
+- **Main is protected** — `git push` to main is rejected. Always create a branch + PR. `git push origin main` wastes a round trip.
+- **Always use `--body-file` for `gh pr create`** — never inline heredocs (PowerShell mangles + Claude Code captures the whole multiline as a permission entry, corrupting `settings.local.json`).
+- **WSL git credential helper** — `git push` from `~/training-data` needs `git config --global credential.helper '/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe'`. Already configured globally for cqs.
+- **Squash-merge + rebase trap** — when a PR is squash-merged and a follow-up branch was based off it, rebase fails (commits ≠ squash). Cherry-pick the follow-up's commits onto a fresh branch from main.
 - **Auto-merge disabled on this repo** — `gh pr merge --auto` returns "auto merge is not allowed". Watch CI manually + merge when green.
-- **`gh pr create` requires `--head` + `--base`** when branch name on local differs from origin (rebased branches).
-- **Always use `--body-file` for PR/issue bodies** — never inline heredocs (PowerShell mangles + Claude Code captures whole multiline as a permission entry).
-- **Cargo publish 413 = "exclude" list missing** — `evals/` etc. now in `Cargo.toml` exclude list.
+- **Cargo publish 413** = "exclude" list missing. `evals/` etc. now in `Cargo.toml` exclude list.
 - **Always confirm test wins on dev before declaring** — single-split A/B is noisy at N=109. ColBERT 2-stage taught this.
 - **Smoke-test against real producer output** — synthetic fixtures only catch what you anticipate.
 - **No time estimates in specs** — wall-time predictions are unreliable. Use compute units / step counts / size anchors instead.
-- **`enumerate_files` returns relative paths** — joining with project root before `parse_file()` is mandatory; otherwise the parser resolves against cargo's CWD and parses the wrong tree. Caught during InProcessFixture phase 1.
+- **`enumerate_files` returns relative paths** — joining with project root before `parse_file()` is mandatory; otherwise the parser resolves against cargo's CWD and parses the wrong tree.
 - **`type_edges` parser tracks signature-level uses only** — params, returns, fields. Not expression-level (`let x = T::new()`). Test assertions on "who uses type T?" must check signature users.
-- **Audit-mode tests must `mkdir .cqs/` first** — `TestStore::new()` puts `index.db` in the tempdir root, not in a `.cqs/` subdirectory; `cqs::audit::save_audit_state` writes to `cqs_dir.join(...)` which 404s without the dir.
 - **Daemon GPU "activity" is misleading** — ORT keeps the CUDA context warm; A6000 sits at P2/1800MHz/84W with 0 actual compute work. True idle (P8) requires stopping the daemon.
+- **CI cqs test job runs ~30-40 min** serialised on a single GPU runner. Fixed-interval `/loop` heartbeats > 60min should go to cloud schedule (`/schedule`).
+- **vllm 0.19 has tight pins** on `flashinfer==0.6.6` and `lark==1.2.2`. Bumping these without bumping vllm itself breaks the Gemma server. The vllm-serve env runs a `transformers 5.6.0.dev0` build that vllm theoretically rejects — tolerated at runtime, fragile if vllm ever bumps.
+- **`pylate 1.4.0` pins `sentence-transformers==5.1.1` exactly** with no newer pylate available. Conflict is dormant unless ColBERT eval is run; cleanest fix would be a dedicated `colbert-eval` env.
 
 ## Collaboration calibration (still load-bearing)
 
@@ -241,53 +107,10 @@ None. Working tree clean post-release.
 | Config | test R@1 | test R@5 | test R@20 | dev R@1 | dev R@5 | dev R@20 |
 |---|---|---|---|---|---|---|
 | canonical (post-v1.28.3, 2026-04-20) | 41.3% | 68.8% | 85.3% | 45.0% | 78.0% | 88.1% |
-| **current (refreshed fixture, 2026-04-25, BGE-large)** | 36.7% | **63.3%** | **80.7%** | 42.2% | **74.3%** | **87.2%** |
+| **current (refreshed fixture, BGE-large)** | 36.7% | **63.3%** | **80.7%** | 42.2% | **74.3%** | **87.2%** |
 | current (CodeRankEmbed, opt-in via #1110) | 37.6% | **67.0%** | 78.9% | 45.0% | 69.7% | 79.8% |
 | current (v9-200k, retired) | 22.9% | 38.5% | 47.7% | 20.2% | 40.4% | 52.3% |
 
-3.7-5.5pp gap between canonical and refreshed-current is real corpus-drift attrition (5,413 new chunks since 2026-04-20, ~30% of corpus). Not a search regression. The v3.v2 fixture is the canonical eval slate; v4 fixtures (1526/split, 14× v3 N) exist for any future A/B that needs tighter noise floors. Long-term inoculation against fixture drift would be relaxing eval gold-match to `(file, name, chunk_type)` only — out of scope for this round.
+The 3.7-5.5pp gap between canonical and refreshed-current is real corpus-drift attrition (5,413 new chunks since 2026-04-20, ~30% of corpus). Not a search regression. The v3.v2 fixture is the canonical eval slate; v4 fixtures (1526/split, 14× v3 N) exist for any future A/B that needs tighter noise floors. Long-term inoculation against fixture drift would be relaxing eval gold-match to `(file, name, chunk_type)` only — out of scope for this round.
 
-## Open issues (20 open)
-
-**Indirect prompt injection cluster (filed 2026-04-27, mitigations landing 2026-04-28):**
-
-| # | Title | PR | Status |
-|---|---|---|---|
-| 1166 | feat(doc-writer): `--improve-docs` review gate | #1177 | merged — close after binary refresh |
-| 1167 | feat(search): `trust_level` + delimiters in chunk JSON | #1178 | merged — close after binary refresh |
-| 1168 | feat(notes): first-encounter shared-notes prompt | #1180 | merged — close after binary refresh |
-| 1169 | feat(reference): `trust_level` + `reference_name` on `cqs ref` chunks | #1178 | merged — close after binary refresh |
-| 1170 | feat(llm-summaries): validate summary output before caching | #1179 | CI in flight — merge then close |
-| **1181** | **feat(security): general mistrust posture (default-on delimiters + `_meta.handling_advice` + per-chunk `injection_flags`)** | — | filed 2026-04-28; blocked on cluster merging |
-
-**v1.30.0 audit cluster (P2/P3/P4 — filed post-release):**
-
-| # | Title | Bucket |
-|---|---|---|
-| 1176 | feat(search): #1130 phase 2 — migrate SPLADE blend to rrf_fuse_n (eval-required) | P2 follow-on |
-| 1140 | EX-V1.30-4: Embedder preset extras map | P3 ergonomics — **skip per autopilot directive** |
-| 1139 | EX-V1.30-3: structural_matchers shared library | P3 ergonomics — **skip per autopilot directive** |
-| 1133 | P2.91: NoteEntry has no kind/tag taxonomy | P2 enhancement |
-
-**P4 auth cluster — closed in #1197 (2026-04-28):** #1134 (AuthToken alphabet), #1135 (port-scoped cookie), #1136 (AuthMode enum + NoAuthAcknowledgement proof type). #1137 + #1138 already shipped in v1.30.1 (registry tables for batch + LLM provider).
-
-**Watch-mode infrastructure:**
-
-| # | Title | Status |
-|---|---|---|
-| 1182 | feat(watch): perfect watch mode — 3-layer reconciliation | **closed 2026-04-28** by #1189 + #1191 + #1193 + #1194 + #1195 + #1196 (all four layers + acceptance test) |
-
-**Closed since last tears update:** #1130 (phase 1 only — phase 2 = #1176), #1131 (#1173), #1132 (#1165), #1166-#1169 (PRs merged today; comment-close pending).
-
-**Pre-v1.30.0 backlog (still open):**
-
-| # | Title | Tier | Status |
-|---|---|---|---|
-| 1044 | Windows `cqs watch` can't stop cleanly — DB corruption risk | tier-3, bug | needs Windows test env |
-| 1043 | `is_slow_mmap_fs` ignores Windows network drives | tier-3, perf | needs Windows test env |
-| 916 | mmap SPLADE index (PF-11) | tier-2, perf | smaller win than originally claimed |
-| 717 | HNSW fully in RAM, no mmap (RM-40) | tier-3, perf | hnsw_rs lib limitation; would need lib swap |
-| 255 | Pre-built reference packages (downloadable indexes) | tier-3, infra | needs signing/registry design |
-| 106 | ort dependency is pre-release RC | tier-3, dep | blocked upstream (pykeio) |
-
-**Closed in v1.29.x → v1.30.0 release window:** #1042, #1047, #1048, #1049, #1090, #1091, #1095 (umbrella, split + closed), #1096, #1097, #1102, #1104, #1107, #1108, #1115, #1116, #956 Phase A scaffolding (Phase B/C still open as the umbrella). #1127 closed by #1146; #1132 closed by #1165 today.
+The `research/models.md` file (committed in #1270) is the inaugural retrieval-research log. Future A/B writeups append there.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,29 +12,24 @@ Tag `v1.32.0` pushed; `cqs 1.32.0` published to crates.io. Five themes:
 
 Schema v23 → v25 (chained, both additive `ALTER TABLE … ADD COLUMN`). No reindex required.
 
-## Previous: v1.31.0 (released 2026-04-30)
+### Post-v1.32.0 follow-up sweep (2026-05-01)
 
-Tag `v1.31.0` pushed; `cqs 1.31.0` published to crates.io; GitHub Release workflow building prebuilt binaries. Minor bump because of the **schema v22 → v23 migration** (auto-migrating; new `source_size` + `source_content_hash` columns on `FileFingerprint` for the reconcile cluster fix). Theme: post-v1.30.2 bug drain across watch reconcile, sparse-vector index, LLM redirect policy, slot lifecycle, native-Windows shutdown, and coarse-mtime filesystems. Reindex not required, but the v23 binary will refuse to open a v22 index until the auto-migration step runs on first start.
+13 PRs landed on top of v1.32.0 across two work blocks. Eight issues closed (#1133, #1176, #1217, #1218, #1220, #1226, #1230, #1215). Highlights:
 
-**Bundle table:**
+- **#1268** flaky `ENV_LOCK` test (restored main green post-release).
+- **#1269 + #1278** complete the `notes.kind` taxonomy (add/list/update lifecycle, closes #1133 follow-up).
+- **#1270** SPLADE phase 2 negative-result writeup; new `research/models.md` retrieval-research log.
+- **#1272** `write_slot_model` round-trips via `SlotConfigFile` flatten extras (#1217).
+- **#1273** `daemon_request<T>` helper extraction (#1215).
+- **#1275** `AuthChannel` trait + 3-impl registry (#1218).
+- **#1276** `Reranker` trait + Onnx/Noop/Llm impls (#1220).
+- **#1279** share `enumerate_files` walk between gc + reconcile when both ticks coincide (#1226).
 
-| PR | Closes | Theme |
-|---|---|---|
-| #1248 | #1219 #1245 #1231 #1227 | watch reconcile cluster — content-hash fingerprint + path dedup + force-rotation guard. **Schema v22→v23.** |
-| #1249 | #1212 | sparse-upsert chunked sub-transactions (`CQS_SPARSE_CHUNKS_PER_TX`, default 5000). |
-| #1250 | #1224 #1225 | coarse-mtime FS handling (HFS+, SMB, NFS, CIFS, FAT32 on plain Linux/macOS) + WSL `cqs serve --open` browser opener. |
-| #1251 | #1222 #1223 | reqwest same-origin redirect policy + `cqs ref add --source` symlink-redirect warning. |
-| #1252 | #1232 | `cqs slot remove` refuses if daemon is serving (probes `daemon_status`, matches `WatchSnapshot.active_slot`). |
-| #1253 | #1044 | native-Windows `cqs watch` clean shutdown via `ctrlc` termination feature. |
-| #1255 | tracks #1254 | agent definitions: worktree-leakage warning bullet across all 6 `.claude/agents/*.md` files. |
+No release tag yet for the sweep — these are unreleased increments on `main` past `v1.32.0` (`5a577a30`).
 
-**#1254 worktree leakage** — `git worktree add` doesn't create `.cqs/`; cqs errors; agents fall back to absolute paths under main's tree → edits leak into parent tree. Agent-side guard shipped via #1255; cqs-side fix (`.git/commondir` auto-discovery + `worktree_stale: bool` JSON envelope flag) deferred.
+**Skipped per autopilot directive:** #1139 (structural_matchers shared library) + #1140 (embedder preset extras map).
 
-**Deferred indefinitely:**
-
-- **#1134-#1136** — `cqs serve` P4 auth bugs from the v1.30.0 audit. Need shaping decisions; not blocking.
-- **#1139** — `structural_matchers` shared library. Touches 50+ language modules.
-- **#1140** — embedder preset extras map. Revisit when preset count pressures the current hand-rolled match.
+(Older release detail is in the Done table at the bottom + CHANGELOG.md.)
 
 ---
 
@@ -108,7 +103,7 @@ Core finding: R@5 is alpha-insensitive on this corpus state across [0, 1]. The O
 - [ ] **NV-Embed-v2 ceiling probe (NVIDIA, Aug 2024) — research, not production.** Companion to the Qwen3 ceiling probe. [`nvidia/NV-Embed-v2`](https://huggingface.co/nvidia/NV-Embed-v2) was MTEB #1 at release with **72.31 across 56 tasks** and **62.65 on the 15 retrieval tasks** — a hair above Qwen3-Embedding-8B's 70.58 on a different snapshot. 8B params, base = Mistral-7B-v0.1, 4096-dim, 32K context. Two caveats vs Qwen3 that change the engineering profile: (1) **non-standard Latent-Attention pooling head** — cqs's ONNX path assumes mean / CLS / EOS pooling, so wiring NV-Embed-v2 needs a custom pooling implementation OR running via PyTorch outside cqs and importing the per-chunk embeddings as a stored vector; (2) **no community ONNX exists** — would need our own `optimum-cli` export. License is **CC-BY-NC-4.0** which is a commercial-use blocker if cqs ever ships it as a default — not a problem for a measurement-only run on the local A6000 (the user has confirmed eval-only use is fine, since this never ships). The retrieval-specialized sibling [`nvidia/NV-Retriever-v1`](https://huggingface.co/nvidia/NV-Retriever-v1) (60.9 retrieval) and the multimodal [`nvidia/omni-embed-nemotron-3b`](https://huggingface.co/nvidia/omni-embed-nemotron-3b) (3B, vision+audio+text) are noted but lower priority — pick NV-Embed-v2 first since it's the strongest text-only scorer. Smaller commercial-OK NeMo Retriever option for the production lane: [`nvidia/llama-3.2-nv-embedqa-1b-v2`](https://huggingface.co/nvidia/llama-3.2-nv-embedqa-1b-v2) (1B, Matryoshka 384–2048-dim, 8K context, 26 langs, NVIDIA Open Model License + Llama 3.2 license, commercial-OK) — a plausible alternative to EmbeddingGemma if Phase 3 surfaces interesting tradeoffs.
 
 **Daemon:**
-- [ ] **Daemon: full CLI parity** — subsumed by [#947](https://github.com/jamie8johnson/cqs/issues/947) Commands/BatchCmd unification.
+- [x] **Daemon: full CLI parity** — closed via [#947](https://github.com/jamie8johnson/cqs/issues/947) Commands/BatchCmd unification (shipped in v1.30.x).
 
 **Watch mode:**
 
@@ -155,24 +150,38 @@ Historical split (2026-04-09, 16,731 invocations): **main conversation** uses `s
 
 ## Open Issues
 
-Re-audited 2026-04-25 against actual GitHub state. **The v1.29.0 audit P4 backlog is now empty** — every numbered finding (1042/1047/1048/1049/1091/1107/1108) closed via PRs #1112, #1117, #1119 (the latter two from the post-v1.29.1 audit close-out batch). Remaining open issues split into "Windows-specific (need test env)" and "external-blocked".
+Re-audited 2026-05-01 post-v1.32.0 follow-up sweep. **All P1/P2/P3 audit backlogs from v1.29.0 / v1.30.0 / v1.30.1 are now empty.** The v1.30.1 refactor frontier (#1215, #1217, #1218, #1220, #1226) cleared in the sweep. Remaining 11 issues split into perf tier-3, blocked-on-external, blocked-on-Windows, and explicitly-skipped.
 
-**Windows-specific (need Windows test environment):**
+**Perf tier-3 (real wins, but each ≥1hr):**
+
+| # | Finding | Status |
+|---|---------|--------|
+| [#1244](https://github.com/jamie8johnson/cqs/issues/1244) | RM-4: Reduce build_hnsw_index_owned 17 MB content_hash snapshot | Audit's "240×" claim assumed nonexistent u32 chunk_ids; actual win ~1 MB via `[u8; 32]` repr |
+| [#1229](https://github.com/jamie8johnson/cqs/issues/1229) | RM-5: Stream enumerate_files walk + per-file SQL lookup | Real win at 1M-file repos; needs `enumerate_files_iter` API + batched 1k-row SQL |
+| [#1228](https://github.com/jamie8johnson/cqs/issues/1228) | RM-2: wait_for_fresh persistent connection | Daemon-side reads one request per connection — option (a) needs daemon-side loop change too |
+| [#916](https://github.com/jamie8johnson/cqs/issues/916) | perf: mmap SPLADE body (PF-11) | Audit-deprioritized — 59 MB peak transient, dominated by parse-side allocations |
+| [#717](https://github.com/jamie8johnson/cqs/issues/717) | perf: HNSW fully loaded into RAM (RM-40) | Needs lib swap to hnswlib-rs (nightly-only) |
+
+**Refactor tier-3 (architectural debt, no user-visible impact):**
+
+| # | Finding | Status |
+|---|---------|--------|
+| [#1216](https://github.com/jamie8johnson/cqs/issues/1216) | EX: Drive BatchCmd dispatch from macro table (33-arm match) | Current dispatch already exhaustive; win is hypothetical-future-regression-prevention |
+| [#1140](https://github.com/jamie8johnson/cqs/issues/1140) | EX: Embedder preset extras map | Explicitly skipped per autopilot directive |
+| [#1139](https://github.com/jamie8johnson/cqs/issues/1139) | EX: structural_matchers shared library | Touches 50+ language modules; explicitly skipped |
+
+**Blocked on Windows test env or upstream:**
 
 | # | Finding | Blocker |
 |---|---------|---------|
 | [#1043](https://github.com/jamie8johnson/cqs/issues/1043) | `is_slow_mmap_fs` ignores Windows network drives + reparse points | Linux/WSL unaffected; needs Windows runner |
-| [#1044](https://github.com/jamie8johnson/cqs/issues/1044) | Native Windows `cqs watch` cannot stop cleanly — DB corruption risk | Closing via PR #1253 (`ctrlc` termination feature) |
+| [#106](https://github.com/jamie8johnson/cqs/issues/106) | ort 2.0-rc.12 stable release | Blocked upstream (pykeio); no stable release yet |
 
-**Tier 2 / 3 (external-blocked or scaffolding-only):**
+**Feature scaffolding deferred:**
 
 | # | Finding | Status |
 |---|---------|--------|
-| [#956](https://github.com/jamie8johnson/cqs/issues/956) | ExecutionProvider: CoreML/ROCm decouple | **Phase A in PR #1120** (cargo feature split + cfg-gated enum variants + restructured probe) — Phase B (CoreML, GHA macOS runner) and Phase C (ROCm, AMD hardware) both deferred to contributors with the matching test environment |
-| [#916](https://github.com/jamie8johnson/cqs/issues/916) | mmap SPLADE body (PF-11) | smaller win than originally claimed |
-| [#717](https://github.com/jamie8johnson/cqs/issues/717) | HNSW mmap (RM-40) | needs lib swap to hnswlib-rs (nightly-only) |
-| [#255](https://github.com/jamie8johnson/cqs/issues/255) | Pre-built reference packages | signing/registry design (infra, not code) |
-| [#106](https://github.com/jamie8johnson/cqs/issues/106) | ort 2.0-rc.12 stable release | blocked upstream (pykeio) |
+| [#255](https://github.com/jamie8johnson/cqs/issues/255) | Pre-built reference packages | Signing/registry design (infra, not code) |
 
 ---
 
@@ -198,6 +207,8 @@ Re-audited 2026-04-25 against actual GitHub state. **The v1.29.0 audit P4 backlo
 
 | Version | Highlights |
 |---------|-----------|
+| v1.32.0 | **HNSW load-phase flock self-deadlock fix + structural-trust + watch-correctness bundle.** Schema v23→v25 (chained, additive). Five themes: #1261 watch-mode flock fix, #1221 three-tier `trust_level: vendored-code`, #1254 worktree → main-index discovery, #1133 note kind taxonomy, #1260 TC-ADV reconcile coverage + persistent TRT engine cache. Post-release sweep landed 13 PRs closing 8 issues — refactor frontier (#1215/#1217/#1218/#1220/#1226) cleared, kind taxonomy fully wired (add/list/update). |
+| v1.31.0 | **Schema v22→v23 + watch reconcile cluster + post-v1.30.2 bug drain.** Bundle: #1248 reconcile content-hash fingerprint + path dedup + force-rotation guard, #1249 sparse-upsert chunked sub-transactions, #1250 coarse-mtime FS handling + WSL `cqs serve --open` browser opener, #1251 reqwest same-origin redirect policy, #1252 `cqs slot remove` daemon-aware, #1253 native-Windows `cqs watch` clean shutdown via `ctrlc`, #1255 agent worktree-leakage guard. |
 | v1.30.2 | **#1181 mistrust posture + #1182 perfect watch mode + v1.30.1 audit-fix wave.** Default-on `CQS_TRUST_DELIMITERS`, `_meta.handling_advice` on every JSON envelope, per-chunk `injection_flags`. Watch-mode Layers 1-4 closed: `cqs hook install` git hooks, periodic full-tree reconciliation, `cqs status --watch-fresh --wait` API, `cqs eval --require-fresh` gate. v1.30.1 audit-fix omnibus across 19 PRs (P1+P2+P3+P4 trivials, 121 of 144 findings; 18 hard P4s tracked). |
 | v1.30.1 | **Indirect-prompt-injection hardening + v1.30.0 audit-fix wave + watch-mode reliability.** Cluster #1166-#1170 + threat model #1171: trust labelling on chunk JSON, `CQS_TRUST_DELIMITERS` opt-in, first-encounter shared-notes prompt on `cqs index`, `CQS_SUMMARY_VALIDATION` for prose summaries before caching, `--improve-docs` review-gated by default, threat model in `SECURITY.md`. Audit-fix omnibus #1141 (152 of 170 P1+P2+P3 findings). Five watch-mode correctness fixes (#1124-#1129): content-hash-aware drain, restore_from_backup pool ordering, summary-write coalescing, daemon mutex hold-time, embedding-cache `purpose` plumbing. Plus four refactors enabling cleaner extension points (#1130 RRF generalize, #1131 IndexBackend trait, #1132 scoring-knob resolver, **#1137 + #1138** registry tables for batch / LLM provider) and 12 dependabot bumps. Schema unchanged from v1.30.0; no reindex required. |
 | v1.30.0 | **Cache+slots + three-way embedder A/B + v1.29.0 audit close-out + #956 Phase A scaffolding.** Cache+slots infra (#1105): `.cqs/embeddings_cache.db` keyed on (content_hash, model_id) + project-level `.cqs/slots/<name>/` directories + per-slot `cqs slot {list,create,promote,remove,active}` and `cqs cache {stats,clear,prune,compact}` commands. Three-way embedder A/B (#1109 #1110): fixture refresh absorbed v1.29.x line-start drift; BGE-large stays default; CodeRankEmbed-137M added as opt-in preset; v9-200k retired from production candidacy on the v3.v2 distribution. v1.29.0 audit close-out batch (#1112 #1113 #1114 #1117 #1118 #1119): every umbrella finding from #1095 closed. #956 Phase A scaffolding (#1120): `gpu-index` → `cuda-index` cargo feature rename (legacy alias preserved); `ep-coreml` / `ep-rocm` features added; `ExecutionProvider` enum gains cfg-gated `CoreML` and `ROCm { device_id }` variants. CUDA path byte-identical at runtime. |


### PR DESCRIPTION
## Summary

Cleanup pass on `PROJECT_CONTINUITY.md` and `ROADMAP.md` to absorb the post-v1.32.0 follow-up sweep and prune historical content already in `CHANGELOG.md` / git log.

## What changed

**PROJECT_CONTINUITY.md: 293 → 116 lines** (~60% trim).

- **Removed** ~12 sections of historical release-session content (v1.29.0 / v1.29.1 / v1.30.0 release session detail, "Just-shipped arcs", "Architecture state" mid-page, the duplicated "What's parked", the stale 20-issue table). All this info is in `CHANGELOG.md` and git history.
- **Refreshed**: "Right Now" now reflects v1.32.0 + the 13-PR post-release sweep that closed 8 issues (#1133, #1176, #1217, #1218, #1220, #1226, #1230, #1215). Plus today's conda/pip cleanup notes.
- **Open issues table** redone — 11 current entries with per-row status (was a stale "20 open" listing that included resolved items).
- **Operational pitfalls** gained two new entries from today's package cleanup (vllm 0.19's exact pins on `flashinfer`/`lark`; pylate's `st==5.1.1` exact pin with no newer version available).
- **Kept as-is**: Collaboration calibration, Eval baselines (both still load-bearing).

**ROADMAP.md: net +11 lines** but restructured.

- Added a "Post-v1.32.0 follow-up sweep" subsection under Current — 13 PRs / 8 issues / one paragraph.
- Removed the standalone "Previous: v1.31.0" section. The Done summary table absorbed the row.
- "Open Issues" section reworked: split the 11 remaining issues into perf-tier-3 / refactor-tier-3 / blocked-on-Windows-or-upstream / feature-deferred. The pre-v1.32.0 framing ("v1.29.0 audit P4 backlog empty") was replaced with current state.
- Added v1.32.0 + v1.31.0 rows to the Done summary table.
- Marked `[x] #947 Daemon: full CLI parity` as closed (it shipped in v1.30.x; was still listed `[ ]`).

## Net

Docs now match current main. The split is now:
- **CHANGELOG.md** — canonical per-release changelog (preserved unchanged).
- **PROJECT_CONTINUITY.md** — in-flight session continuity + persistent operational reminders, not a release-history archive.
- **ROADMAP.md** — forward-looking strategic items + concise Done roll-up.

## Test plan

Docs-only PR. No code paths change.
