### PR TITLE
ci: nightly slow-test workflow (#1286 Phase 1)

### DIFF
--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -1,0 +1,83 @@
+name: CI (slow / overnight)
+
+# Catches the 15+ `#[ignore]`-tagged tests (model-loading, stress, daemon-env)
+# that don't run in PR-time CI. Triggered on a daily cron + manual dispatch.
+# Failures open a tracking issue rather than blocking merges (overnight runs
+# aren't gating).
+#
+# Background: see #1286.
+
+on:
+  schedule:
+    # 06:00 UTC daily ≈ 22:00 PT previous day. Once-a-day, not hourly —
+    # the suite is heavy and free-tier minutes matter.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      include_ignored:
+        description: 'Run #[ignore]-tagged tests (model-loading, stress, daemon-env)'
+        required: false
+        default: 'true'
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write  # auto-file-on-failure step
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  full-suite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/share/boost /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h /
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Distinct shared-key so the slow run doesn't poison the regular
+          # CI cache (different feature set, different output binaries).
+          shared-key: ci-slow
+
+      - name: Build (release)
+        run: cargo build --release --verbose
+
+      - name: Run full test suite (incl. ignored)
+        if: ${{ github.event_name == 'schedule' || inputs.include_ignored != 'false' }}
+        run: cargo test --release --verbose -- --include-ignored
+        # Note: model-loading tests under #[ignore] download from HF on first
+        # run (~3 GB across BGE-large + E5-base + SPLADE). Cache via separate
+        # `actions/cache` step on `~/.cache/huggingface` would help if egress
+        # becomes a concern; keeping it implicit for now since runs are daily.
+
+      - name: Run regular suite only (manual dispatch fallback)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.include_ignored == 'false' }}
+        run: cargo test --release --verbose
+
+      - name: Open issue on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `Nightly CI failed on ${context.sha.substr(0, 7)}`;
+            const body = [
+              `Nightly run [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) failed.`,
+              ``,
+              `Not a PR-blocking failure (overnight cadence). Investigate when convenient.`,
+              ``,
+              `Triggered by commit ${context.sha} on \`${context.ref}\`.`,
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['ci-flake-or-bug', 'overnight-ci'],
+            });


### PR DESCRIPTION
## Summary

Phase 1 of #1286 — adds `.github/workflows/ci-slow.yml`, a nightly cron + manual-dispatch workflow that runs `cargo test --release -- --include-ignored`. Catches the ~15 files of `#[ignore]`-tagged tests that don't run in PR-time CI.

## Why now

- **#1288's `#[ignore]` band-aid on 12 daemon_translate tests** needs an overnight runner so those tests don't fall off the regression surface entirely. (#1292 tracks the structural fix that lets them come back to PR-time.)
- **Existing `#[ignore]` tests across the codebase** (model-loading in `embedder/`, `splade/`, `reranker.rs`; stress in `tests/stress_test.rs`; ~15 files total) have been silently ignored — this gives them a regression surface again.
- **Phase 1.5 (placeholder cache fix in #1288) already cut PR-time CI from 38 min → 6 min**, so the originally-planned Phase 2 (slow-tests cargo feature) and Phase 3 (test binary collapse) are lower priority now. Keeping them open in #1286 but not blocking on them.

## What it does

| Trigger | Behavior |
|---------|----------|
| `schedule: cron '0 6 * * *'` | Runs `cargo test --release -- --include-ignored` daily. Auto-files an issue (`ci-flake-or-bug` + `overnight-ci` labels) on failure. |
| `workflow_dispatch` | Manual trigger from Actions tab. Boolean input `include_ignored` toggles `--include-ignored` (default true). No issue auto-file (operator can read the failure directly). |

`Swatinem/rust-cache@v2` with a distinct `shared-key: ci-slow` so the overnight build cache doesn't conflict with the regular CI cache.

## Cost trade-offs

- Daily ~60-90 min on GitHub Actions free tier; manageable.
- First run on a fresh runner downloads ~3 GB from HF (BGE-large + E5-base + SPLADE). Caching via `~/.cache/huggingface` is a possible future optimization if HF egress becomes an issue.

## Test plan

- [x] YAML validates (`yamllint`-equivalent through `gh` workflow viewer)
- [ ] First scheduled run completes (manual dispatch immediately after merge to verify)
- [ ] Failure path tested separately by intentionally breaking a test

## Acceptance

Closes Phase 1 of #1286. Phase 2 + 3 stay open with reduced priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
