### PR TITLE
feat(embedder): bge-large-ft preset + v3.v2 A/B (#1289)

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,7 +774,7 @@ Both splits are ±2-3pp noisy on a single trial; quote both when comparing confi
 | `CQS_EMBED_BATCH_SIZE` | `64` | ONNX inference batch size (reduce if GPU OOM) |
 | `CQS_EMBED_CHANNEL_DEPTH` | `64` | Embedding pipeline channel depth (bounds memory) |
 | `CQS_EMBEDDING_DIM` | (auto) | Override embedding dimension for custom ONNX models |
-| `CQS_EMBEDDING_MODEL` | `bge-large` | Embedding model preset (`bge-large`, `v9-200k`, `e5-base`) or custom repo |
+| `CQS_EMBEDDING_MODEL` | `bge-large` | Embedding model preset (`bge-large`, `bge-large-ft`, `v9-200k`, `e5-base`, `nomic-coderank`) or custom HF repo. See `src/embedder/models.rs` for the full preset list and per-preset trade-offs. |
 | `CQS_EVAL_OUTPUT` | (none) | Path to write per-query eval diagnostics JSON (used by eval harness) |
 | `CQS_EVAL_REQUIRE_FRESH` | `1` | Set to `0`/`false`/`no`/`off` to disable the freshness gate that `cqs eval` applies before running (#1182). When on, the eval harness blocks until the running `cqs watch --serve` daemon reports `state == fresh`, or errors out if the daemon isn't reachable — prevents silent stale-index runs that look like 5-25pp R@K regressions. Pass `--no-require-fresh` for the same effect on a single invocation. |
 | `CQS_EVAL_TIMEOUT_SECS` | `300` | Per-query timeout in seconds inside `evals/run_ablation.py` |

--- a/research/models.md
+++ b/research/models.md
@@ -225,3 +225,48 @@ The shape is consistent with the original phase 2 finding: lexical-heavy categor
 **Closing:** code change reverted; this branch carries only the docs update. The branch `research/splade-rrf-redo` carried the change for the eval and is being thrown away (same as the original phase 2 branch was). Issue #1176 stays closed. The phase 2 entry above is updated with this caveat-note pointing at this entry; the absolute numbers in the original entry are now superseded by the corrected-matcher numbers here.
 
 **Lesson — meta:** when a relative comparison feels "barely in tolerance," check the harness before accepting "tie within noise." The 0.9pp test R@5 gap in the original phase 2 was real — it was just compressed by matcher noise. A 3.6pp gap on the corrected matcher would have been an obvious "linear-α wins" without any "barely" caveat. Compressed-by-noise differences are a known pitfall of small benchmarks; loosening the matcher made the eval's resolution match what the underlying question deserved.
+
+---
+
+## 2026-05-02 — BGE-large LoRA fine-tune A/B vs base
+
+**Issue:** #1289. The HF repo `jamie8johnson/bge-large-v1.5-code-search` (LoRA fine-tune of BGE-large on `cqs-code-search-200k`) had been published since the original training pass but never made it into the v3.v2 production-fixture comparison. Question: is the FT model strictly better than base?
+
+**Setup:** Added `bge-large-ft` preset (same architecture as `bge-large` — 1024-dim, 512 max_seq, mean pooling, BGE prefix). Tokenizer fetch failed on first attempt because `tokenizer.json` lives in `onnx/` not at repo root for this HF layout — fixed `tokenizer_path = "onnx/tokenizer.json"`. Fresh slot, reindex to 14,460 chunks, then eval against test + dev under the corrected matcher.
+
+**Headline numbers:**
+
+| split | metric | BGE-large (base) | **BGE-large + LoRA** | Δ |
+|-------|--------|-----------------:|---------------------:|--:|
+| test  | R@1    | 43.1%            | **45.0%**            | +1.9 |
+| test  | R@5    | 69.7%            | **73.4%**            | **+3.7** |
+| test  | R@20   | 83.5%            | 83.5%                |  0.0 |
+| dev   | R@1    | 45.9%            | **46.8%**            | +0.9 |
+| dev   | R@5    | **77.1%**        | 70.6%                | **−6.5** |
+| dev   | R@20   | **86.2%**        | 82.6%                | −3.6 |
+
+**Updated best-per-metric across all 5 models tested today (BGE-base, BGE-FT, EmbeddingGemma+summ, v9-200k, nomic-coderank):**
+
+| metric         | winner               | runner-up                                              |
+|----------------|----------------------|--------------------------------------------------------|
+| test R@1       | Gemma / v9 (tie 45.9%) | BGE-FT 45.0%                                         |
+| **test R@5**   | **BGE-FT 73.4%**     | v9-200k 70.6%, BGE-base 69.7%                          |
+| test R@20      | BGE-base / BGE-FT 83.5% (tied) | Gemma 82.6%                                |
+| dev R@1        | Gemma / coderank 47.7% | BGE-FT / v9 46.8%                                    |
+| **dev R@5**    | **BGE-base 77.1%**   | Gemma 71.6%, BGE-FT 70.6%                              |
+| dev R@20       | **BGE-base 86.2%**   | Gemma 85.3%, BGE-FT 82.6%                              |
+
+**The trade-off, mechanistically.** LoRA fine-tuning on a curated code-pair distribution drags the embedding space toward that distribution. Test split is closer to it (queries look more like training pairs); dev split is deliberately broader (more natural-language reasoning, more open-ended exploration). Result: BGE-FT moves +3.7pp on test R@5 and -6.5pp on dev R@5. Canonical in-vs-out-of-distribution fine-tune trade-off — not a bug.
+
+**Verdict:** ship as `bge-large-ft` opt-in preset; do NOT promote to default. Reasoning:
+1. Dev R@5 is the more conservative signal for cqs's deployment context — agents don't always issue cleanly code-shaped queries (onboarding / exploratory questions). Losing 6.5pp there means worse generalization.
+2. The test R@5 win is real but capped — at 73.4% it's the best we've seen, but BGE-base at 69.7% was already in the same band, and the test gate has been historically noisy.
+3. Cost is identical — same architecture, same 1.3GB ONNX bundle, same inference latency. Opt-in preset is the right shape.
+
+cqs default stays at BGE-base. BGE-FT joins the opt-in preset list alongside `v9-200k`, `nomic-coderank`, `embeddinggemma-300m`.
+
+**Caveat on chunk counts.** Default slot has 19,476 chunks; the new `bge-ft` slot has 14,460. Partly real chunker output, partly accumulated orphan rows in the default slot from prior chunker-ID-format changes (#1283 — fixed in PR #1295, just not yet rerun against default). The eval matcher finds the right `(file, name)` chunk if indexed, so this doesn't bias the headline numbers, but a follow-up rerun of BGE-base from a freshly-pruned default slot would tighten the comparison.
+
+**Open follow-up:** per-category breakdown of the dev R@5 gap (6.5pp) — likely concentrated in `negation` / `multi_step` / `conceptual_search` where dev queries deliberately stress NL reasoning. Tracked as a footnote in the BGE-FT HF model card.
+
+**Closing:** preset added; HF model card updated with v3.v2 results + trade-off framing; default-model decision unchanged. Eval JSONs at `/tmp/eval-bge-ft-{test,dev}.json`. Issue #1289 closed.

--- a/src/embedder/models.rs
+++ b/src/embedder/models.rs
@@ -352,6 +352,29 @@ define_embedder_presets! {
         pad_id = 0,
         default = true;
 
+    /// BGE-large-ft: LoRA fine-tune of BGE-large-en-v1.5 on cqs's
+    /// `cqs-code-search-200k` dataset (`jamie8johnson/cqs-code-search-200k`).
+    /// Same architecture, dim, max_seq, and prefixes as the upstream
+    /// BGE-large preset — adapters merged into the ONNX export.
+    ///
+    /// Opt-in candidate to dethrone the bare BGE-large default. Whether it
+    /// actually improves on v3.v2 production-fixture R@5 is the open
+    /// question (#1289). The original synthetic-fixture A/B (296q, 7
+    /// languages) showed +0.7pp R@1 vs base at the cost of broader
+    /// distribution coverage; the v3.v2 numbers are pending the eval that
+    /// motivated this preset.
+    ///
+    /// Set `CQS_EMBEDDING_MODEL=bge-large-ft` or
+    /// `cqs slot create bge-ft --model bge-large-ft` to use it.
+    bge_large_ft => name = "bge-large-ft", repo = "jamie8johnson/bge-large-v1.5-code-search",
+        onnx_path = "onnx/model.onnx", tokenizer_path = "onnx/tokenizer.json",
+        dim = 1024, max_seq_length = 512,
+        query_prefix = "Represent this sentence for searching relevant passages: ", doc_prefix = "",
+        input_names = InputNames::bert(), output_name = default_output_name(), pooling = PoolingStrategy::Mean,
+        // Same architecture as base BGE-large, ~1.3 GiB ONNX bundle.
+        approx_download_bytes = Some(1_300 * 1024 * 1024),
+        pad_id = 0;
+
     /// CodeRankEmbed: 768-dim, 2048 tokens. Code-specialized fine-tune of
     /// Snowflake Arctic Embed M Long, trained on CoRNStack (~21M code pairs).
     /// Headline: 77.9 MRR on CodeSearchNet, 60.1 NDCG@10 on CoIR.


### PR DESCRIPTION
## Summary

Closes #1289. Adds `bge-large-ft` preset (LoRA fine-tune of BGE-large on `jamie8johnson/cqs-code-search-200k`) and documents the v3.v2 A/B against base.

## Numbers

| split | metric | BGE-base | BGE-FT | Δ |
|-------|--------|--------:|------:|--:|
| test  | R@1    | 43.1%   | 45.0% | +1.9 |
| test  | R@5    | 69.7%   | **73.4%** | **+3.7** |
| test  | R@20   | 83.5%   | 83.5% |  0.0 |
| dev   | R@1    | 45.9%   | 46.8% | +0.9 |
| dev   | R@5    | **77.1%** | 70.6% | **−6.5** |
| dev   | R@20   | **86.2%** | 82.6% | −3.6 |

**BGE-FT wins test R@5 by 3.7pp (best of any model in the 5-way A/B today), loses dev R@5 by 6.5pp.** Canonical in-vs-out-of-distribution fine-tune trade-off.

## Decision

cqs default **stays at BGE-base** for the dev R@5 hedge. BGE-FT joins the opt-in preset list alongside `v9-200k`, `nomic-coderank`, `embeddinggemma-300m`. Cost is identical to base — same architecture, same 1.3GB ONNX bundle, same inference latency.

Users with heavily code-shaped query distributions can pick it up via:

```bash
cqs slot create bge-ft --model bge-large-ft
cqs index --slot bge-ft --force
```

## What's in the PR

- `src/embedder/models.rs` — `bge_large_ft` preset row. Note `tokenizer_path = "onnx/tokenizer.json"` (not root) because of HF repo layout.
- `README.md` — `CQS_EMBEDDING_MODEL` valid values updated to include all current presets.
- `research/models.md` — new entry with A/B numbers, mechanistic trade-off framing, updated 5-way best-per-metric table.
- HF model card for `jamie8johnson/bge-large-v1.5-code-search` already updated separately with the same numbers.

## Test plan

- [x] `cargo build --release --features gpu-index --bin cqs` clean
- [x] `cargo test --features gpu-index --test env_var_docs --release` passes (preset list update doesn't introduce undocumented env vars)
- [x] `cargo fmt --check` clean
- [x] End-to-end: `cqs slot create bge-ft --model bge-large-ft`, `cqs index --slot bge-ft --force` (14,460 chunks indexed clean), `cqs eval --slot bge-ft` produces the table above

## Caveat

Default slot has 19,476 chunks vs bge-ft's 14,460. Partly real chunker output, partly accumulated orphan rows (#1283 / PR #1295 — fixed in this PR cycle, just not yet rerun against default). Eval matcher finds the right `(file, name)` chunk if indexed, so the headline numbers above aren't biased — but a follow-up rerun of BGE-base from a freshly-pruned default slot would tighten the comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
