### PR TITLE
feat(embedder): EmbeddingGemma-300m preset + CQS_DISABLE_TENSORRT knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,11 +720,11 @@ Both splits are ±2-3pp noisy on a single trial; quote both when comparing confi
 
 ## Environment Variables
 
-119 knobs total. Quick index by domain (everything is searchable in the table below):
+120 knobs total. Quick index by domain (everything is searchable in the table below):
 
 - **Trust / injection defence** — `CQS_TRUST_DELIMITERS`, `CQS_SUMMARY_VALIDATION`
 - **Retrieval & search** — `CQS_RRF_K`, `CQS_TYPE_BOOST`, `CQS_SPLADE_ALPHA*`, `CQS_RERANK*`, `CQS_RERANKER_*`, `CQS_CENTROID_*`, `CQS_MMR_LAMBDA`, `CQS_FORCE_BASE_INDEX`, `CQS_DISABLE_BASE_INDEX`, `CQS_QUERY_CACHE_*`
-- **Indexing & embedding** — `CQS_EMBEDDING_*`, `CQS_EMBED_*`, `CQS_ONNX_DIR`, `CQS_HNSW_*`, `CQS_CAGRA_*`, `CQS_TRT_ENGINE_CACHE`, `CQS_SPARSE_CHUNKS_PER_TX`, `CQS_SPLADE_BATCH/MAX_*/MODEL/THRESHOLD/RESET_EVERY`, `CQS_PARSER_MAX_*`, `CQS_PARSE_CHANNEL_DEPTH`, `CQS_FILE_BATCH_SIZE`, `CQS_DEFERRED_FLUSH_INTERVAL`, `CQS_FTS_NORMALIZE_MAX`, `CQS_MAX_FILE_SIZE`, `CQS_MAX_QUERY_BYTES`, `CQS_MAX_SEQ_LENGTH`, `CQS_MAX_CONTRASTIVE_CHUNKS`, `CQS_MD_*`, `CQS_SKIP_ENRICHMENT`, `CQS_HYDE_MAX_TOKENS`, `CQS_RAYON_THREADS`
+- **Indexing & embedding** — `CQS_EMBEDDING_*`, `CQS_EMBED_*`, `CQS_ONNX_DIR`, `CQS_HNSW_*`, `CQS_CAGRA_*`, `CQS_TRT_ENGINE_CACHE`, `CQS_DISABLE_TENSORRT`, `CQS_SPARSE_CHUNKS_PER_TX`, `CQS_SPLADE_BATCH/MAX_*/MODEL/THRESHOLD/RESET_EVERY`, `CQS_PARSER_MAX_*`, `CQS_PARSE_CHANNEL_DEPTH`, `CQS_FILE_BATCH_SIZE`, `CQS_DEFERRED_FLUSH_INTERVAL`, `CQS_FTS_NORMALIZE_MAX`, `CQS_MAX_FILE_SIZE`, `CQS_MAX_QUERY_BYTES`, `CQS_MAX_SEQ_LENGTH`, `CQS_MAX_CONTRASTIVE_CHUNKS`, `CQS_MD_*`, `CQS_SKIP_ENRICHMENT`, `CQS_HYDE_MAX_TOKENS`, `CQS_RAYON_THREADS`
 - **Daemon, watch, batch** — `CQS_NO_DAEMON`, `CQS_DAEMON_*`, `CQS_MAX_DAEMON_CLIENTS`, `CQS_BATCH_*IDLE_MINUTES`, `CQS_REFS_LRU_SIZE`, `CQS_WATCH_*`, `CQS_CHAT_HISTORY`
 - **Graph & impact** — `CQS_CALL_GRAPH_MAX_EDGES`, `CQS_TYPE_GRAPH_MAX_EDGES`, `CQS_GATHER_MAX_NODES`, `CQS_IMPACT_MAX_*`, `CQS_TRACE_MAX_NODES`, `CQS_TEST_MAP_MAX_NODES`
 - **SQLite storage** — `CQS_BUSY_TIMEOUT_MS`, `CQS_IDLE_TIMEOUT_SECS`, `CQS_MAX_CONNECTIONS`, `CQS_MMAP_SIZE`, `CQS_SQLITE_CACHE_SIZE`, `CQS_CACHE_MAX_SIZE`, `CQS_INTEGRITY_CHECK`, `CQS_SKIP_INTEGRITY_CHECK`, `CQS_MIGRATE_REQUIRE_BACKUP`
@@ -771,10 +771,11 @@ Both splits are ±2-3pp noisy on a single trial; quote both when comparing confi
 | `CQS_DEFERRED_FLUSH_INTERVAL` | `50` | Chunks between deferred flushes during indexing |
 | `CQS_DIFF_EMBEDDING_BATCH_SIZE` | `64` | Batch size for embedding `cqs review --diff` / `cqs impact --diff` chunks. Default scales to ~12 MB at 1024-dim; override for larger models or tight memory budgets. |
 | `CQS_DISABLE_BASE_INDEX` | (none) | Set to `1` to force queries through the enriched HNSW only, skipping the base (non-enriched) HNSW. Used to A/B the dual-index router during config testing. |
+| `CQS_DISABLE_TENSORRT` | (none) | Set to `1` to skip the TensorRT execution-provider probe in `detect_provider`, falling through to CUDA. Useful when a model's ONNX graph uses ops TensorRT can't compile — e.g. EmbeddingGemma's bidirectional-attention head emits a plugin op TRT 10 doesn't recognise, and `create_session` fails at engine build time. CUDA's op coverage is broader (it falls back to ORT's own kernel for unknown ops) at the cost of TRT's perf wins. |
 | `CQS_EMBED_BATCH_SIZE` | `64` | ONNX inference batch size (reduce if GPU OOM) |
 | `CQS_EMBED_CHANNEL_DEPTH` | `64` | Embedding pipeline channel depth (bounds memory) |
 | `CQS_EMBEDDING_DIM` | (auto) | Override embedding dimension for custom ONNX models |
-| `CQS_EMBEDDING_MODEL` | `bge-large` | Embedding model preset (`bge-large`, `bge-large-ft`, `v9-200k`, `e5-base`, `nomic-coderank`) or custom HF repo. See `src/embedder/models.rs` for the full preset list and per-preset trade-offs. |
+| `CQS_EMBEDDING_MODEL` | `bge-large` | Embedding model preset (`bge-large`, `bge-large-ft`, `v9-200k`, `e5-base`, `nomic-coderank`, `embeddinggemma-300m`) or custom HF repo. See `src/embedder/models.rs` for the full preset list and per-preset trade-offs. |
 | `CQS_EVAL_OUTPUT` | (none) | Path to write per-query eval diagnostics JSON (used by eval harness) |
 | `CQS_EVAL_REQUIRE_FRESH` | `1` | Set to `0`/`false`/`no`/`off` to disable the freshness gate that `cqs eval` applies before running (#1182). When on, the eval harness blocks until the running `cqs watch --serve` daemon reports `state == fresh`, or errors out if the daemon isn't reachable — prevents silent stale-index runs that look like 5-25pp R@K regressions. Pass `--no-require-fresh` for the same effect on a single invocation. |
 | `CQS_EVAL_TIMEOUT_SECS` | `300` | Per-query timeout in seconds inside `evals/run_ablation.py` |

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -1076,9 +1076,53 @@ impl Embedder {
         })?;
         let (shape, data) = output.try_extract_tensor::<f32>().map_err(ort_err)?;
 
-        // Validate tensor shape: expect [batch_size, seq_len, dim]
         let batch_size = texts.len();
         let seq_len = max_len;
+
+        // PoolingStrategy::Identity: the ONNX output is already pooled to
+        // `[batch, dim]`. Skip the 3D reshape + pool dispatch and emit
+        // L2-normalized rows directly. Used by EmbeddingGemma's
+        // `sentence_embedding` output (#1220 follow-up).
+        if self.model_config.pooling == PoolingStrategy::Identity {
+            if shape.len() != 2 {
+                return Err(EmbedderError::InferenceFailed(format!(
+                    "PoolingStrategy::Identity expects 2D [batch, dim] output; got {} dimensions",
+                    shape.len()
+                )));
+            }
+            if shape[0] as usize != batch_size {
+                return Err(EmbedderError::InferenceFailed(format!(
+                    "Tensor batch size mismatch: expected {}, got {}",
+                    batch_size, shape[0]
+                )));
+            }
+            let embedding_dim = shape[1] as usize;
+            match self.detected_dim.get() {
+                Some(&expected) if expected != embedding_dim => {
+                    return Err(EmbedderError::InferenceFailed(format!(
+                        "Embedding dimension changed: expected {expected}, got {embedding_dim}"
+                    )));
+                }
+                None => {
+                    let _ = self.detected_dim.set(embedding_dim);
+                    tracing::info!(
+                        dim = embedding_dim,
+                        "Detected embedding dimension from model (Identity pooling)"
+                    );
+                }
+                _ => {}
+            }
+            let results: Vec<Embedding> = (0..batch_size)
+                .map(|b| {
+                    let start = b * embedding_dim;
+                    let v = data[start..start + embedding_dim].to_vec();
+                    Embedding::new(normalize_l2(v))
+                })
+                .collect();
+            return Ok(results);
+        }
+
+        // Validate tensor shape: expect [batch_size, seq_len, dim]
         if shape.len() != 3 {
             return Err(EmbedderError::InferenceFailed(format!(
                 "Unexpected tensor shape: expected 3 dimensions [batch, seq, dim], got {} dimensions",
@@ -1120,6 +1164,12 @@ impl Embedder {
             PoolingStrategy::Mean => mean_pool(&hidden, &attention_mask, embedding_dim),
             PoolingStrategy::Cls => cls_pool(&hidden),
             PoolingStrategy::LastToken => last_token_pool(&hidden, &attention_mask),
+            // Already handled by the early-return above; this arm is only
+            // reachable if the model output had 3 dims AND pooling = Identity,
+            // which is a config error (Identity expects 2D).
+            PoolingStrategy::Identity => unreachable!(
+                "PoolingStrategy::Identity should be handled before the 3D pool dispatch"
+            ),
         };
 
         let results = pooled_batch

--- a/src/embedder/models.rs
+++ b/src/embedder/models.rs
@@ -96,6 +96,18 @@ pub enum PoolingStrategy {
     /// Used by autoregressive / decoder-only embedders (rare: Qwen3-Embedding,
     /// some Mistral-based embedders).
     LastToken,
+    /// The ONNX output is already pooled — return it as-is, after L2 norm.
+    ///
+    /// Used by models whose ONNX export includes a task-aware pooling head
+    /// that cannot be reproduced by mean/cls/last over the per-token hidden
+    /// state. Example: EmbeddingGemma's `sentence_embedding` output is
+    /// computed by an internal projection layer; mean-pooling
+    /// `last_hidden_state` produces a vector that has cosine ≈ 0 with the
+    /// model's own pooled output (verified empirically — this isn't a
+    /// missing-attention-mask issue, it's a fundamentally different head).
+    /// The strategy expects a 2D `[batch, dim]` output tensor; the embed
+    /// loop skips the 3D reshape + pool dispatch and emits the rows directly.
+    Identity,
 }
 
 /// Configuration for an embedding model.
@@ -395,6 +407,47 @@ define_embedder_presets! {
         input_names = InputNames::bert_no_token_types(), output_name = "token_embeddings".to_string(), pooling = PoolingStrategy::Cls,
         // ONNX bundle: 522 MiB model + 712 KiB tokenizer.
         approx_download_bytes = Some(523 * 1024 * 1024),
+        pad_id = 0;
+
+    /// EmbeddingGemma-300m: 768-dim, 2048 tokens. Google's Gemma3-backbone
+    /// embedder (Sep 2025), 308M params. #1 multilingual under 500M on MTEB
+    /// at release. **2K context** (vs BERT-family 512), MRL-truncatable to
+    /// 768/512/256/128, task-instruction prompt format.
+    ///
+    /// Architecture: Gemma3 decoder + bidirectional-attention head. Two ONNX
+    /// inputs (`input_ids` + `attention_mask`, no `token_type_ids`). The
+    /// FP16 ONNX export from `onnx-community/embeddinggemma-300m-ONNX` ships
+    /// both `last_hidden_state` (3D `[batch, seq, 768]`) and
+    /// `sentence_embedding` (2D `[batch, 768]`) — but the latter is computed
+    /// by a task-aware projection head that cannot be reproduced by
+    /// mean/cls/last over `last_hidden_state` (verified: cosine ≈ 0 between
+    /// any naive pool and the model's own pooled output). Use
+    /// `PoolingStrategy::Identity` to consume the pre-pooled output
+    /// directly.
+    ///
+    /// Tokenizer: Gemma3 SentencePiece, 256k vocab, `<bos>`-prefixed +
+    /// `<eos>`-suffixed via the post-processor in `tokenizer.json`. The
+    /// tokenizer file is ~20 MB (vs BERT's ~700 KB) due to the larger vocab.
+    ///
+    /// Query/doc prefix follows Google's recommended task-instruction
+    /// format: `task: search result | query: …` for queries,
+    /// `title: none | text: …` for documents. cqs's existing
+    /// `query_prefix` / `doc_prefix` plumbing handles this directly — the
+    /// prefix is just a longer string than E5/BGE use.
+    embeddinggemma_300m => name = "embeddinggemma-300m", repo = "onnx-community/embeddinggemma-300m-ONNX",
+        onnx_path = "onnx/model.onnx", tokenizer_path = "tokenizer.json",
+        dim = 768, max_seq_length = 2048,
+        query_prefix = "task: search result | query: ", doc_prefix = "title: none | text: ",
+        input_names = InputNames::bert_no_token_types(),
+        output_name = "sentence_embedding".to_string(),
+        pooling = PoolingStrategy::Identity,
+        // FP32 ONNX bundle: ~1.2 GB model + ~20 MB tokenizer + small configs.
+        // FP16 (`onnx/model_fp16.onnx`, ~617 MB) is also published but
+        // produces NaN/Inf in attention layers under CUDA EP — the
+        // mixed-precision auto-fallback that TensorRT/TRT-RTX would
+        // provide isn't there. Stay on FP32 until we wire TRT-RTX or
+        // confirm a different EP handles FP16 cleanly.
+        approx_download_bytes = Some(1_300 * 1024 * 1024),
         pad_id = 0;
 }
 

--- a/src/embedder/provider.rs
+++ b/src/embedder/provider.rs
@@ -228,7 +228,16 @@ fn detect_provider() -> ExecutionProvider {
     ensure_ort_provider_libs();
 
     // ── NVIDIA TensorRT ────────────────────────────────────────────
-    {
+    //
+    // `CQS_DISABLE_TENSORRT=1` skips the TRT probe entirely (falls
+    // through to CUDA). Useful when a model's ONNX graph uses ops
+    // TensorRT can't compile — e.g. Gemma3's bidirectional-attention
+    // head emits a plugin op TRT 10 doesn't recognise, and
+    // `create_session` fails at engine build time. CUDA's op coverage
+    // is broader (it falls back to ORT's own kernel for unknown ops),
+    // so it accepts more graph shapes at the cost of TRT's specific
+    // perf wins.
+    if std::env::var("CQS_DISABLE_TENSORRT").as_deref() != Ok("1") {
         use ort::ep::TensorRT;
         let tensorrt = TensorRT::default();
         if tensorrt.is_available().unwrap_or(false) {
@@ -236,6 +245,8 @@ fn detect_provider() -> ExecutionProvider {
             tracing::info!(provider = ?provider, "Execution provider selected");
             return provider;
         }
+    } else {
+        tracing::info!("CQS_DISABLE_TENSORRT=1 — skipping TensorRT probe");
     }
 
     // ── NVIDIA CUDA ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Ships the EmbeddingGemma-300m preset code that's been sitting in a stash since the eval ran on 2026-05-01. The eval verdict (opt-in preset at best, not a default replacement) was already documented in `research/models.md` (matcher-loosen entry); this PR is the productization half — landing the preset row + supporting infrastructure.

## What lands

1. **`PoolingStrategy::Identity`** (`src/embedder/models.rs`, `src/embedder/mod.rs`)
   For ONNX exports whose output is already pooled to `[batch, dim]` and can't be reproduced by mean / cls / last over `last_hidden_state`. EmbeddingGemma's `sentence_embedding` output is exactly this shape; mean-pooling `last_hidden_state` produces a vector with cosine ≈ 0 to the model's own pooled output (verified empirically). The embed loop's existing 3D pool dispatch gets an early-return for Identity that emits L2-normalized rows directly from the 2D output.

2. **`embeddinggemma_300m` preset row** (`src/embedder/models.rs`)
   - Repo: `onnx-community/embeddinggemma-300m-ONNX`
   - 308M params, 768-dim, 2048 max_seq
   - FP32 ONNX (`onnx/model.onnx`, ~1.2 GB), not FP16 (`onnx/model_fp16.onnx`, ~617 MB) — FP16 produces NaN/Inf in attention layers under CUDA EP without mixed-precision auto-fallback that only TensorRT-RTX provides
   - Query/doc prefixes follow Google's recommended task-instruction format

3. **`CQS_DISABLE_TENSORRT=1` env knob** (`src/embedder/provider.rs`, README)
   Skips the TRT probe in `detect_provider`, falls through to CUDA EP. TRT 10 fails the engine build on Gemma3's bidirectional-attention head plugin op (`"Plugin not found"` at engine build time); CUDA's op coverage is broader at the cost of TRT's perf wins.

## Eval recap (already in research/models.md)

| split | metric | BGE-base | EmbeddingGemma | Δ |
|-------|--------|--------:|--------------:|--:|
| test  | R@1    | 43.1%   | **45.9%**     | +2.8 |
| test  | R@5    | **69.7%** | 67.9%       | -1.8 |
| test  | R@20   | **83.5%** | 82.6%       | -0.9 |
| dev   | R@1    | 45.9%   | **47.7%**     | +1.8 |
| dev   | R@5    | **77.1%** | 71.6%       | -5.5 |
| dev   | R@20   | **86.2%** | 85.3%       | -0.9 |

Edges BGE-base on R@1 (top-1 precision likely from the projection-head's task-aware pooling) but loses on R@5/R@20. Opt-in candidate, not default. Bare and with-summaries variants land within 0.1pp of each other — summaries don't help this model.

## Usage

```bash
# Slot-based comparison
cqs slot create gemma --model embeddinggemma-300m
env CQS_DISABLE_TENSORRT=1 cqs index --slot gemma --force
```

`CQS_DISABLE_TENSORRT=1` is required on systems with NVIDIA + TensorRT installed; cqs's preferred provider order is TRT → CUDA → CPU, and TRT will fail at session-creation time on Gemma3's graph. The knob falls cleanly through to CUDA. ROADMAP has a separate item to wire TRT-RTX (which has the right op coverage) for future Gemma-class models.

## License

EmbeddingGemma is subject to [Google's Gemma Terms of Use](https://ai.google.dev/gemma/terms). Commercial use is allowed; restrictions on weapons / biometric ID / dangerous critical infrastructure don't apply to semantic code search. cqs doesn't redistribute the model — the preset just routes to a HuggingFace repo. Users accept Gemma terms via HF on first download.

## Test plan

- [x] `cargo build --release --features gpu-index --bin cqs` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features gpu-index --lib -- -D warnings` clean
- [x] `cargo test --features gpu-index --test env_var_docs --release` passes (CQS_DISABLE_TENSORRT documented)
- [x] End-to-end indexing on cqs's own corpus (13,118 chunks indexed cleanly with `CQS_DISABLE_TENSORRT=1`)
- [x] Eval ran against test + dev splits, numbers match the table above (saved at `/tmp/eval-gemma-{test,dev}-summaries-hnsw.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
