### PR TITLE
feat(ci): #1286 Phase 2 — slow-tests gate for onboard + eval_subcommand binaries

### DIFF
--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -61,8 +61,36 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.include_ignored == 'false' }}
         run: cargo test --release --verbose
 
+  slow-tests-feature:
+    # Self-contained tests gated behind the `slow-tests` cargo feature
+    # (subprocess-spawning CLI tests + the heaviest e2e binaries — onboard,
+    # eval_subcommand). No HF model download dependency; all use mock or
+    # local-only embedders. Could later graduate to PR-time CI if the wall
+    # time stays under budget. See Cargo.toml `slow-tests` comment for
+    # the gated file inventory. (#1286 Phase 2)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/share/boost /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h /
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-slow-feature
+
+      - name: Run slow-tests feature suite
+        run: cargo test --release --features slow-tests --verbose
+
+  notify-failure:
+    needs: [full-suite, slow-tests-feature]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
       - name: Open issue on failure
-        if: failure() && github.event_name == 'schedule'
         uses: actions/github-script@v7
         with:
           script: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`onboard_test` and `eval_subcommand_test` gated behind `slow-tests`** (#1286 Phase 2). The two heaviest e2e binaries — 6.6 min + 5.3 min ≈ 12 min, 35% of regular-CI test job time on workflow `25227697806` — now only run via `cargo test --features slow-tests` or the new nightly `slow-tests-feature` job in `.github/workflows/ci-slow.yml`. Both shell out to the cqs binary per test (full index pipeline / `cqs eval` cold start), which is where the wall time goes.
+
+### Added
+
+- **`slow-tests-feature` job** in `.github/workflows/ci-slow.yml` (#1286 Phase 2). Runs `cargo test --release --features slow-tests` nightly. Self-contained — no HuggingFace model download dependency, in contrast to the existing `full-suite` job's `--include-ignored` path. Hosts the 11 subprocess-spawning `cli_*_test` binaries that have been gated since v1.29.0 plus the two new e2e additions above. Could later graduate to PR-time CI if wall time stays under budget.
+
 ## [1.33.0] - 2026-05-02
 
 Minor release. No schema bump. Themed around eval correctness, indexing performance, and a new fine-tuned embedder preset.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,21 +271,26 @@ tree-sitter-elm = ["dep:tree-sitter-elm"]
 # need the CLI.
 serve = ["dep:axum", "dep:tower", "dep:tower-http", "dep:subtle", "dep:base64"]
 
-# Slow CLI integration tests that haven't yet been converted to the
-# in-process `InProcessFixture` harness. Five binaries were converted
-# in 2026-04-23 (`health_test.rs`, `index_search_test.rs`, `graph_test.rs`,
-# `related_impact_test.rs`, plus `cli_surface_test.rs` for genuine
-# binary-surface checks) and the nightly `.github/workflows/slow-tests.yml`
-# cron was deleted alongside. The `slow-tests` feature flag itself is
-# kept alive for the 11 remaining subprocess-spawning files
-# (cli_blame_test, cli_brief_test, cli_chat_completer_test,
-# cli_chat_format_test, cli_doctor_fix_test, cli_drift_diff_test,
-# cli_envelope_test, cli_neighbors_test, cli_reconstruct_test,
-# cli_review_test, cli_train_review_test) — they cold-load the
-# embedder per invocation, so they're skipped in regular CI. Tracked
-# as a follow-up to issue #980; convert when re-touching the code
-# they test. See docs/plans/2026-04-22-cqs-slow-tests-elimination.md
-# for the conversion pattern.
+# Slow integration tests excluded from PR-time CI. Two reasons a binary
+# lands here:
+#   (a) Subprocess-spawning CLI tests that cold-load the embedder per
+#       invocation. Originally 16 such binaries; 5 were migrated to the
+#       in-process `InProcessFixture` harness on 2026-04-23 and the old
+#       `.github/workflows/slow-tests.yml` cron was deleted alongside.
+#       11 still gated: cli_blame_test, cli_brief_test,
+#       cli_chat_completer_test, cli_chat_format_test, cli_doctor_fix_test,
+#       cli_drift_diff_test, cli_envelope_test, cli_neighbors_test,
+#       cli_reconstruct_test, cli_review_test, cli_train_review_test.
+#       Tracked as follow-up to #980; convert when re-touching the code
+#       they test. See docs/plans/2026-04-22-cqs-slow-tests-elimination.md
+#       for the conversion pattern.
+#   (b) End-to-end binaries with high per-test cost. Added 2026-05-02
+#       under #1286 Phase 2: `onboard_test` (~6.6 min, full index pipeline
+#       per test) and `eval_subcommand_test` (~5.3 min, `cqs eval` subprocess
+#       per test). Together these were 12 min / 35% of regular-CI test time
+#       (CI workflow `25227697806`).
+# Run nightly via `.github/workflows/ci-slow.yml` (`slow-tests-feature` job).
+# Locally: `cargo test --features slow-tests`.
 slow-tests = []
 
 [dev-dependencies]

--- a/tests/eval_subcommand_test.rs
+++ b/tests/eval_subcommand_test.rs
@@ -7,6 +7,13 @@
 //!   2. R@1 = 0% when the gold chunk is missing from the store
 //!   3. `--save` writes a parseable JSON file with the expected fields
 //!   4. `--baseline foo.json` parses (Task C2 will implement the body)
+//!
+//! Gated behind `slow-tests` (#1286 Phase 2) — each of the five tests here
+//! seeds a store and runs `cqs eval` end-to-end via `Command::new`, paying
+//! the cqs-binary cold-start cost per test. ~5.3 min of regular-CI wall
+//! time (CI workflow `25227697806`).
+
+#![cfg(feature = "slow-tests")]
 
 mod common;
 

--- a/tests/onboard_test.rs
+++ b/tests/onboard_test.rs
@@ -3,6 +3,14 @@
 //! Uses a graph fixture with call relationships:
 //!   src/lib.rs:  process_data() -> validate(), process_data() -> format_output()
 //!   src/lib.rs:  test_process() -> process_data()
+//!
+//! Gated behind `slow-tests` (#1286 Phase 2) — every test calls
+//! `setup_graph_project()` + `init_and_index()`, which shells out to the cqs
+//! binary and runs the full index pipeline (parse + embed + HNSW build) per
+//! test. The four tests here account for ~6.6 min of regular-CI wall time
+//! (CI workflow `25227697806`, the heaviest-hitting binary by a wide margin).
+
+#![cfg(feature = "slow-tests")]
 
 use assert_cmd::Command;
 use predicates::prelude::*;


### PR DESCRIPTION
## Summary

Phase 2 of #1286 — gates the two heaviest e2e test binaries behind the `slow-tests` cargo feature so they only run nightly, and adds a `slow-tests-feature` job to `ci-slow.yml` that runs them.

| Binary | Time | What it does |
|--------|-----:|--------------|
| `onboard_test` | 6.6 min / 4 tests | each test runs `setup_graph_project()` + `init_and_index()` — full index pipeline (parse + embed + HNSW build) per test |
| `eval_subcommand_test` | 5.3 min / 5 tests | each test seeds a store and runs `cqs eval` end-to-end via `Command::new` |

Together: 12 min / 9 tests / 35% of regular-CI test job time on the last successful main run (workflow `25227697806`). Both shell out to the cqs binary per test, paying the cold-start cost for the index pipeline or eval driver.

Phase 1 (#1293) shipped in v1.33.0 — nightly cron + auto-issue-on-failure. Phase 3 (CLI subprocess test binary collapse) remains lower-priority after #1288 brought PR-time CI from 38 → 6 min.

## Changes

- `tests/onboard_test.rs` + `tests/eval_subcommand_test.rs`: `#![cfg(feature = "slow-tests")]` at top with reason in the doc-comment header.
- `.github/workflows/ci-slow.yml`: new `slow-tests-feature` job running `cargo test --release --features slow-tests`. Self-contained — no HuggingFace model download dependency, in contrast to the existing `full-suite` job's `--include-ignored` path.
- `notify-failure` job extracted from `full-suite` and given `needs: [full-suite, slow-tests-feature]` so a failure in either fires the auto-issue path on schedule runs.
- `Cargo.toml` slow-tests comment updated to enumerate the new gated binaries.
- `CHANGELOG.md` Unreleased entry.

## Verification

```text
$ cargo test --features gpu-index --no-run
$ ./onboard_test-* --list
0 tests, 0 benchmarks
$ ./eval_subcommand_test-* --list
0 tests, 0 benchmarks

$ cargo test --features gpu-index,slow-tests --no-run
$ ./onboard_test-* --list
test_onboard_cli_json: test
test_onboard_depth_limits_chain: test
test_onboard_not_found: test
test_onboard_text_matches_json: test
4 tests, 0 benchmarks
$ ./eval_subcommand_test-* --list
test_eval_baseline_flag_parses: test
test_eval_handles_missing_gold_chunk: test
test_eval_runs_against_seeded_store: test
test_eval_save_writes_valid_json: test
test_eval_top_level_json_flag_emits_envelope: test
5 tests, 0 benchmarks
```

`cargo fmt --check` clean. Default-features and slow-tests-features both `cargo check --tests` clean.

## Test plan

- [x] Default-features build excludes both binaries' tests
- [x] `--features slow-tests` includes 4 + 5 tests respectively
- [x] `cargo fmt --check` passes
- [x] Both feature sets `cargo check --tests` cleanly
- [ ] PR-time CI workflow `ci.yml` passes (verifies the gating doesn't break regular CI)
- [ ] First scheduled `ci-slow.yml` run picks up the new `slow-tests-feature` job (or trigger via `workflow_dispatch` after merge)
