### PR TITLE
feat(eval): cqs eval --reranker <none|onnx|llm>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`slow-tests-feature` job** in `.github/workflows/ci-slow.yml` (#1286 Phase 2). Runs `cargo test --release --features slow-tests` nightly. Self-contained — no HuggingFace model download dependency, in contrast to the existing `full-suite` job's `--include-ignored` path. Hosts the 11 subprocess-spawning `cli_*_test` binaries that have been gated since v1.29.0 plus the two new e2e additions above. Could later graduate to PR-time CI if wall time stays under budget.
+- **`cqs eval --reranker <none|onnx|llm>`** wires the v1.32.0 `Reranker` trait (#1276) into the eval harness. Default `none` keeps the historical retrieval-only pipeline so existing baselines stay comparable. `onnx` runs the cross-encoder configured by `[reranker]` / `CQS_RERANKER_MODEL` and over-retrieves to `rerank_pool_size(limit)` (mirrors `cqs <q> --rerank`) before stage 2 truncates to `limit`. `llm` resolves to `cqs::LlmReranker` (skeleton — errors on first call) so the flag absorbs that wiring without a breaking API change later. Listed under "Outstanding follow-ups (small, optional)" in PROJECT_CONTINUITY.md.
 
 ## [1.33.0] - 2026-05-02
 

--- a/src/cli/commands/eval/mod.rs
+++ b/src/cli/commands/eval/mod.rs
@@ -89,6 +89,38 @@ pub(crate) struct EvalCmdArgs {
     /// differs by use case (eval default = 600, status = 30).
     #[arg(long = "require-fresh-secs", default_value_t = 600u64)]
     pub require_fresh_secs: u64,
+
+    /// Apply a reranker stage after retrieval. Default `none` (skip
+    /// reranking) preserves the historical eval pipeline. `onnx` runs
+    /// the cross-encoder configured by `[reranker]` / `CQS_RERANKER_MODEL`.
+    /// `llm` resolves to [`cqs::LlmReranker`], which is a skeleton today
+    /// (errors on first call) and is included so the flag can absorb the
+    /// LlmReranker landing without a breaking API change.
+    ///
+    /// When `onnx` or `llm` is selected, stage 1 over-retrieves to the
+    /// `rerank_pool_size(limit)` cap (mirrors `cqs <q> --rerank`); stage 2
+    /// truncates to `limit` after scoring. R@K can shift in either direction
+    /// — reranker promotes the gold to position 1 (R@1 win) but a gold
+    /// hovering near the pool edge can fall out of top-K under a poor
+    /// scorer (R@K loss).
+    #[arg(long = "reranker", value_enum, default_value_t = RerankerMode::None)]
+    pub reranker: RerankerMode,
+}
+
+/// Reranker dispatch for `cqs eval --reranker`.
+///
+/// Mirrors the production three-impl set introduced in #1276 (`OnnxReranker`,
+/// `NoopReranker`, `LlmReranker`). `None` short-circuits the entire reranker
+/// path; `Onnx` and `Llm` route through [`crate::cli::CommandContext::reranker`]
+/// in a follow-up wiring pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum RerankerMode {
+    /// No reranking — stage-1 retrieval is the final answer (default).
+    None,
+    /// Cross-encoder reranker via [`cqs::OnnxReranker`].
+    Onnx,
+    /// LLM reranker via [`cqs::LlmReranker`]. Skeleton today; errors on first call.
+    Llm,
 }
 
 /// CLI handler for `cqs eval`.
@@ -149,7 +181,30 @@ pub(crate) fn cmd_eval(ctx: &CommandContext<'_, ReadOnly>, args: &EvalCmdArgs) -
     // reports `state == fresh`, surface a clear error if it can't.
     require_fresh_gate(&args.no_require_fresh, args.require_fresh_secs)?;
 
-    let report = runner::run_eval(ctx, &args.query_file, args.category.as_deref(), args.limit)?;
+    // Resolve the reranker once before the search loop. `None` short-circuits
+    // the entire stage-2 path; `Onnx` / `Llm` build via the same lazy factory
+    // the CLI search path uses (`CommandContext::reranker`), so the eval
+    // path doesn't accidentally diverge from production reranker config.
+    let reranker = match args.reranker {
+        RerankerMode::None => None,
+        RerankerMode::Onnx => Some(ctx.reranker()?),
+        RerankerMode::Llm => {
+            // LlmReranker is a skeleton — eagerly construct so the eval
+            // user sees the "not yet implemented" error before the search
+            // loop spins up the index, not after spending minutes on
+            // retrieval.
+            let r: std::sync::Arc<dyn cqs::Reranker> = std::sync::Arc::new(cqs::LlmReranker::new());
+            Some(r)
+        }
+    };
+
+    let report = runner::run_eval(
+        ctx,
+        &args.query_file,
+        args.category.as_deref(),
+        args.limit,
+        reranker.as_deref(),
+    )?;
 
     // When --baseline is set, prefer the diff output over the raw report —
     // a CI-shaped invocation just wants the diff. The raw report still
@@ -680,6 +735,37 @@ mod tests {
         // every other flag.
         assert!(!w.args.no_require_fresh);
         assert_eq!(w.args.require_fresh_secs, 600);
+        // Default reranker mode is None — preserves the historical
+        // retrieval-only pipeline so existing baselines stay comparable.
+        assert_eq!(w.args.reranker, RerankerMode::None);
+    }
+
+    /// Pin the `--reranker` flag's three accepted values. Default is
+    /// already covered in `test_args_default_limit_is_20`; here we drive
+    /// every variant to catch typos in clap's value-enum derivation.
+    #[test]
+    fn reranker_flag_parses_each_variant() {
+        use clap::Parser;
+        #[derive(Parser)]
+        struct Wrapper {
+            #[command(flatten)]
+            args: EvalCmdArgs,
+        }
+        for (input, expected) in [
+            ("none", RerankerMode::None),
+            ("onnx", RerankerMode::Onnx),
+            ("llm", RerankerMode::Llm),
+        ] {
+            let w = Wrapper::try_parse_from(["test", "queries.json", "--reranker", input]).unwrap();
+            assert_eq!(
+                w.args.reranker, expected,
+                "--reranker {input} should parse to {expected:?}"
+            );
+        }
+        // Garbage values must error — covers the contract that clap rejects
+        // unknown reranker spellings instead of silently falling back to None.
+        let err = Wrapper::try_parse_from(["test", "queries.json", "--reranker", "fancy"]);
+        assert!(err.is_err(), "--reranker fancy should be a clap error");
     }
 
     /// TC-HAP-1.30.1-9: pin the canonical row-by-row format so a

--- a/src/cli/commands/eval/runner.rs
+++ b/src/cli/commands/eval/runner.rs
@@ -273,6 +273,11 @@ pub(crate) fn run_eval(
 ///   - Centroid reclassification with α floor
 ///   - DenseBase / Enriched index routing
 ///   - `code_types()` default include filter
+//
+// 8 args is one over clippy's default. Factoring into a `SearchContext`
+// struct mirrors `cmd_query_project::QueryContext` but offers no real
+// readability win for a one-arg addition; revisit if this grows again.
+#[allow(clippy::too_many_arguments)]
 fn search_for_rank(
     ctx: &CommandContext<'_, ReadOnly>,
     embedder: &cqs::Embedder,

--- a/src/cli/commands/eval/runner.rs
+++ b/src/cli/commands/eval/runner.rs
@@ -83,17 +83,21 @@ struct QueryHit {
 /// `query_file` is the path to a JSON queries file (v3 format).
 /// `category_filter` restricts the run to one category (None = all).
 /// `limit` is the per-query result count used to compute R@K (typically 20).
+/// `reranker` opts each query into stage-2 cross-encoder / LLM scoring;
+/// `None` preserves the historical retrieval-only pipeline.
 pub(crate) fn run_eval(
     ctx: &CommandContext<'_, ReadOnly>,
     query_file: &Path,
     category_filter: Option<&str>,
     limit: usize,
+    reranker: Option<&dyn cqs::Reranker>,
 ) -> Result<EvalReport> {
     let _span = tracing::info_span!(
         "run_eval",
         query_file = %query_file.display(),
         category = ?category_filter,
-        limit
+        limit,
+        reranker_enabled = reranker.is_some(),
     )
     .entered();
 
@@ -144,7 +148,9 @@ pub(crate) fn run_eval(
             .clone()
             .unwrap_or_else(|| "uncategorized".to_string());
 
-        let rank = match search_for_rank(ctx, embedder, store, index_ref, &q.query, gold, limit) {
+        let rank = match search_for_rank(
+            ctx, embedder, store, index_ref, &q.query, gold, limit, reranker,
+        ) {
             Ok(r) => r,
             Err(e) => {
                 tracing::warn!(
@@ -275,8 +281,19 @@ fn search_for_rank(
     query: &str,
     gold: &GoldChunk,
     limit: usize,
+    reranker: Option<&dyn cqs::Reranker>,
 ) -> Result<Option<usize>> {
     let query_embedding = embedder.embed_query(query)?;
+
+    // Mirror cmd_query: when reranking, over-retrieve so the cross-encoder
+    // sees more candidates than the user-facing limit. Cap respects
+    // `CQS_RERANK_POOL_MAX` / `RERANK_POOL_MAX` (currently 20). Without
+    // reranking, retrieval limit equals the requested limit.
+    let stage1_limit = if reranker.is_some() {
+        crate::cli::limits::rerank_pool_size(limit).max(limit)
+    } else {
+        limit
+    };
 
     // Adaptive routing: classify, then refine via centroid.
     let classification = cqs::search::router::classify_query(query);
@@ -332,18 +349,50 @@ fn search_for_rank(
 
     let threshold = 0.0_f32; // Don't drop low-similarity results — we want full top-K for R@K.
 
-    let results: Vec<UnifiedResult> = if splade_arg.is_some() {
+    let stage1_results: Vec<UnifiedResult> = if splade_arg.is_some() {
         let code = store.search_hybrid(
             &query_embedding,
             &filter,
-            limit,
+            stage1_limit,
             threshold,
             index,
             splade_arg,
         )?;
         code.into_iter().map(UnifiedResult::Code).collect()
     } else {
-        store.search_unified_with_index(&query_embedding, &filter, limit, threshold, index)?
+        store.search_unified_with_index(
+            &query_embedding,
+            &filter,
+            stage1_limit,
+            threshold,
+            index,
+        )?
+    };
+
+    // Apply reranker (when enabled): pull out the SearchResult payloads,
+    // hand them to the trait, truncate the reordered list to `limit`.
+    // `NoopReranker` is a valid mode but never reaches here — cmd_eval
+    // only constructs a reranker for `Onnx` / `Llm`, leaving `None` to
+    // fall through to retrieval-only.
+    let results: Vec<UnifiedResult> = if let Some(reranker) = reranker {
+        let mut code_results: Vec<cqs::store::SearchResult> = stage1_results
+            .into_iter()
+            .map(|r| match r {
+                UnifiedResult::Code(sr) => sr,
+            })
+            .collect();
+        if code_results.len() > 1 {
+            reranker
+                .rerank(query, &mut code_results, limit)
+                .map_err(|e| anyhow::anyhow!("Reranking failed: {e}"))?;
+        }
+        // `Reranker::rerank` truncates to `limit` internally for impls that
+        // honor the contract; double-truncate as defense-in-depth so a
+        // misbehaving impl can't silently return more rows than asked.
+        code_results.truncate(limit);
+        code_results.into_iter().map(UnifiedResult::Code).collect()
+    } else {
+        stage1_results
     };
 
     // Find gold rank (1-indexed). Match on (file == origin) AND


### PR DESCRIPTION
## Summary

Wires the v1.32.0 `Reranker` trait (#1276) into the eval harness via a new `--reranker <none|onnx|llm>` flag on `cqs eval`. The infrastructure landed alongside the `OnnxReranker` / `NoopReranker` / `LlmReranker` split; the eval-runner just needed a dispatch.

Listed under "Outstanding follow-ups (small, optional)" in `PROJECT_CONTINUITY.md`.

## Behavior

| Mode | What it does |
|------|--------------|
| `none` (default) | retrieval-only — preserves the historical eval pipeline. Existing baselines stay comparable. |
| `onnx` | cross-encoder via `[reranker]` / `CQS_RERANKER_MODEL`. Stage 1 over-retrieves to `rerank_pool_size(limit)` (mirrors `cqs <q> --rerank`); stage 2 truncates to `limit`. |
| `llm` | resolves to `cqs::LlmReranker`, the skeleton from #1276 (errors on first call). Pre-wired so the flag absorbs LlmReranker production wiring without a breaking API change. |

R@K can shift in either direction under reranking — the cross-encoder promotes the gold to position 1 (R@1 win) but a gold near the over-retrieval pool edge can fall out of top-K under a poor scorer (R@K loss).

## Why pre-wire `llm`?

Because the alternative is breaking the flag's value-enum when LlmReranker becomes real. PROJECT_CONTINUITY.md lists "LlmReranker production wiring against BatchProvider" as a separate follow-up; this PR pays the cost of having the value in `clap::ValueEnum` now so that follow-up doesn't have to extend the public eval CLI surface again.

## Changes

- `src/cli/commands/eval/mod.rs`: new `RerankerMode` value-enum + `--reranker` arg on `EvalCmdArgs`. `cmd_eval` resolves the trait object via `ctx.reranker()` (mirrors the search command) for `Onnx`, eagerly constructs `LlmReranker` for `Llm` (so its skeleton error fires before retrieval, not after).
- `src/cli/commands/eval/runner.rs`: `run_eval` and `search_for_rank` take an optional `&dyn Reranker`. When set, stage 1 retrieves `rerank_pool_size(limit)` candidates (still capped by `RERANK_POOL_MAX = 20` per the V2 post-mortem cross-encoder degradation finding); stage 2 reranks and truncates to `limit`.
- Two new unit tests pinning the value-enum: default is `None`, all three variants parse, garbage values error.
- CHANGELOG `Unreleased` entry.

## Verification

```text
$ cqs eval --help | grep -A2 reranker
      --reranker <RERANKER>
          Apply a reranker stage after retrieval. Default `none` (skip reranking) ...
          Possible values:
          - none: No reranking — stage-1 retrieval is the final answer (default)
          - onnx: Cross-encoder reranker via [`cqs::OnnxReranker`]
          - llm:  LLM reranker via [`cqs::LlmReranker`]. Skeleton today; errors on first call

$ cargo test --features gpu-index --bin cqs cli::commands::eval::tests::
running 9 tests
test cli::commands::eval::tests::reranker_flag_parses_each_variant ... ok
... (8 others, all ok)
test result: ok. 9 passed; 0 failed
```

`cargo fmt --check` clean. `cargo check --features gpu-index --tests` clean.

## Test plan

- [x] Default-args parsing leaves `reranker = None`
- [x] `--reranker none|onnx|llm` parses each variant
- [x] `--reranker fancy` errors at clap layer
- [x] Build clean with `--features gpu-index`
- [ ] Live eval run with `--reranker onnx` against v3.v2 fixture (deferred to user — needs `cqs watch` daemon up; doesn't gate merge)
