### PR TITLE
chore(ci): disable ci-slow.yml schedule cron — #1305 triage

### DIFF
--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -8,10 +8,15 @@ name: CI (slow / overnight)
 # Background: see #1286.
 
 on:
-  schedule:
-    # 06:00 UTC daily ≈ 22:00 PT previous day. Once-a-day, not hourly —
-    # the suite is heavy and free-tier minutes matter.
-    - cron: '0 6 * * *'
+  # Schedule cron disabled until #1305 is triaged — the first run on
+  # 2026-05-02 surfaced two pre-existing instabilities (cli_doctor_fix_test
+  # panics on the runner, 9 model-loading tests fail without an HF cache /
+  # token). Re-enable by uncommenting the schedule block once the underlying
+  # bugs are addressed; until then, run via workflow_dispatch when needed.
+  # schedule:
+  #   # 06:00 UTC daily ≈ 22:00 PT previous day. Once-a-day, not hourly —
+  #   # the suite is heavy and free-tier minutes matter.
+  #   - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       include_ignored:


### PR DESCRIPTION
## Summary

Disable the daily 06:00 UTC cron on `ci-slow.yml` until #1305 is triaged. `workflow_dispatch` stays wired up so the workflow can be exercised manually when fixes land.

## Why

The first-ever `ci-slow.yml` run (2026-05-02 manual dispatch on main `ec4fd4dd`, post-#1302) failed in both jobs:

- `slow-tests-feature` — `cli_doctor_fix_test::{test_doctor_fix_creates_missing_index, test_init_rerun_preserves_existing_index}` panic on the runner (tempdir-based `cqs init` + `cqs index` doesn't successfully create `.cqs/index.db`). Tests pass locally; CI-environment issue.
- `full-suite` — 9 model-loading tests panic because SPLADE/BGE downloads return error pages on the CI exit IP (anonymous rate-limit or gating); the existing tokenizer parses HTML and panics with `Tokenizer("expected ident at line 1 column 3")`.

Both are **pre-existing instabilities exposed for the first time** by `slow-tests-feature` (#1302 / #1286 Phase 2) and `full-suite`'s `--include-ignored` run, not new failures introduced by Phase 2.

The `notify-failure` job is gated on `failure() && github.event_name == 'schedule'`, so without disabling the cron, every 06:00 UTC run files a fresh GitHub issue. Daily issue noise > triage value until the underlying bugs are addressed.

Tracking issue: #1305.

## Changes

`.github/workflows/ci-slow.yml`: comment out the `schedule:` block with a comment explaining why and pointing at #1305 for re-enablement.

## Test plan

- [x] `workflow_dispatch` still triggerable manually (`gh workflow run ci-slow.yml`)
- [x] Schedule cron block commented, not deleted — easy to re-enable
- [x] Comment cross-references #1305 so future-me / next-session-claude finds the trail
