### PR TITLE
fix(test): cli_doctor_fix_test resolve index.db via slot helper (#1305)

### DIFF
--- a/tests/cli_doctor_fix_test.rs
+++ b/tests/cli_doctor_fix_test.rs
@@ -63,7 +63,10 @@ fn test_doctor_fix_creates_missing_index() {
         .assert()
         .success();
 
-    let index_db = dir.path().join(".cqs").join("index.db");
+    // PR #1105 moved the DB into per-project slots: .cqs/slots/<name>/index.db
+    // (no `.cqs/index.db` in the new layout for fresh-init projects). Resolve
+    // via the public helper so any future layout shift stays in one place.
+    let index_db = cqs::resolve_index_db(&dir.path().join(".cqs"));
     assert!(
         !index_db.exists(),
         "precondition: index.db must not exist before --fix"
@@ -134,7 +137,10 @@ fn test_init_rerun_preserves_existing_index() {
         .success()
         .stdout(predicate::str::contains("Index complete"));
 
-    let index_db = dir.path().join(".cqs").join("index.db");
+    // PR #1105 moved the DB into per-project slots: .cqs/slots/<name>/index.db
+    // (no `.cqs/index.db` in the new layout for fresh-init projects). Resolve
+    // via the public helper so any future layout shift stays in one place.
+    let index_db = cqs::resolve_index_db(&dir.path().join(".cqs"));
     assert!(
         index_db.exists(),
         "precondition: index.db must exist after first index"


### PR DESCRIPTION
## Summary

Half of #1305: the two `cli_doctor_fix_test` panics were stale-test bugs, not CI-environment issues. PR #1105 (per-project slots) moved `.cqs/index.db` to `.cqs/slots/<name>/index.db`; the tests still checked the legacy path and asserted the DB was missing even though `cqs init` + `cqs index` had succeeded.

Switching to the public `cqs::resolve_index_db(&cqs_dir)` helper picks up the slot layout (and falls back to legacy if a pre-slot `.cqs/index.db` exists).

Reproduced locally:

```
$ cargo test --features gpu-index,slow-tests --test cli_doctor_fix_test  # before:
test test_doctor_fix_creates_missing_index ... FAILED
test test_init_rerun_preserves_existing_index ... FAILED
panicked: precondition: index.db must exist after first index

$ ls /tmp/.tmpXXX/.cqs                  # actual layout post-#1105:
.gitignore  embeddings_cache.db  slots/  telemetry.jsonl  telemetry.lock
$ ls /tmp/.tmpXXX/.cqs/slots/default/
index.db  index.hnsw.*               # ← here, not at .cqs/index.db
```

After the fix:

```
$ cargo test --features gpu-index,slow-tests --test cli_doctor_fix_test
test test_init_rerun_preserves_existing_index ... ok
test test_doctor_fix_creates_missing_index ... ok
2 passed; 0 failed
```

## Remaining work for #1305

The 9 HF-model-loading tests in `full-suite` still fail without a populated `~/.cache/huggingface`. That's not a stale-path bug; the runner genuinely can't fetch BGE / SPLADE / E5 anonymously and the tests panic with `"SPLADE model not downloaded"` / `Tokenizer("expected ident at line 1 column 3")` (HF returning HTML for anonymous downloads). Two paths forward:

1. **`actions/cache@v4`** keyed on `~/.cache/huggingface` — works only after a successful seeding run. First run still fails.
2. **`HF_TOKEN`** repo secret + `HUGGINGFACE_HUB_TOKEN` env — robust but needs user to provision the secret.

I'm leaving that to user direction since both involve out-of-band setup.

## Changes

`tests/cli_doctor_fix_test.rs`: replace the two `dir.path().join(".cqs").join("index.db")` calls (one per test) with a single `cqs::resolve_index_db(&dir.path().join(".cqs"))` per test, plus a comment explaining the slot layout.

## Test plan

- [x] `cargo test --features gpu-index,slow-tests --test cli_doctor_fix_test` — 2/2 pass locally
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features gpu-index,slow-tests --tests` clean
- [ ] Manual `gh workflow run ci-slow.yml -f include_ignored=false` after merge to verify the slow-tests-feature job now reaches `onboard_test` + `eval_subcommand_test` (Phase 2's actual additions)
