### PR TITLE
fix(ref): resolve_reference_db drops spurious .cqs/ segment (#1305)

### DIFF
--- a/src/cli/commands/resolve.rs
+++ b/src/cli/commands/resolve.rs
@@ -65,12 +65,20 @@ fn resolve_reference_db(root: &Path, ref_name: &str) -> Result<std::path::PathBu
     let config = Config::load(root);
     let ref_cfg = find_reference_config(&config, ref_name)?;
 
-    // Refs use the same `.cqs/` layout as projects, so honor slot resolution
-    // (post-migration: `.cqs/slots/<active>/index.db`; pre-migration:
-    // `.cqs/index.db`). `resolve_index_db` falls back to the legacy path for
-    // refs that were built against an older cqs version and never migrated.
-    let ref_cqs_dir = cqs::resolve_index_dir(&ref_cfg.path);
-    let ref_db = cqs::resolve_index_db(&ref_cqs_dir);
+    // Refs are stored at `~/.local/share/cqs/refs/<name>/` with the DB
+    // written directly into that directory (`cmd_ref_add` at
+    // `infra/reference.rs:204`: `ref_dir.join(INDEX_DB_FILENAME)`). The
+    // ref directory IS the cqs index dir — it does NOT have an outer
+    // project `.cqs/` segment. `resolve_index_db` then picks the slot
+    // layout (`slots/<active>/index.db`) over the legacy bare-file path,
+    // matching the writer's behavior post-#1105.
+    //
+    // Pre-fix this called `resolve_index_dir(&ref_cfg.path)`, which
+    // appended a spurious `.cqs/` segment and then `resolve_index_db`
+    // looked at `<ref_dir>/.cqs/slots/default/index.db` — a path the
+    // writer never produces. `cqs drift` / `cqs diff` against any newly
+    // added ref would error with "no index, run cqs ref update". (#1305)
+    let ref_db = cqs::resolve_index_db(&ref_cfg.path);
     if !ref_db.exists() {
         bail!(
             "Reference '{}' has no index at {}. Run 'cqs ref update {}' first.",


### PR DESCRIPTION
## Summary

Third bug class surfaced by ci-slow.yml. After #1307 (slot-path drift in `cli_doctor_fix_test`) and #1308 (HF model-load soft-skip), the `slow-tests-feature` job got further into the suite and hit `cli_drift_diff_test`, where two tests failed identically:

```
Error: Reference 'baseline' has no index at /tmp/.tmp.../cqs/refs/baseline/.cqs/slots/default/index.db. Run 'cqs ref update baseline' first.
```

Both `cqs ref add` and the explicit `cqs ref update` write the DB to `<ref_dir>/index.db` (per `infra/reference.rs:204`: `ref_dir.join(INDEX_DB_FILENAME)`). But `resolve_reference_db` was calling `cqs::resolve_index_dir(&ref_cfg.path)` first, which appends a `.cqs/` segment that the writer never produces — then `resolve_index_db` looked at `<ref_dir>/.cqs/slots/default/index.db` and hit the bail.

## Root cause

`resolve_index_dir` is meant for project roots — given `<project>/`, it returns `<project>/.cqs/`. References are different: their `ref_cfg.path` is *already* the cqs index directory (`~/.local/share/cqs/refs/<name>/`), so wrapping it in `resolve_index_dir` adds a layer that doesn't exist on disk.

`resolve_index_db` itself already does the right thing for refs — it picks the slot path (`<ref_dir>/slots/<active>/index.db`) when present and falls back to the bare `<ref_dir>/index.db` (the writer's path) otherwise.

## Fix

Drop the `resolve_index_dir` wrapper in `resolve_reference_db`. Pass `ref_cfg.path` directly to `resolve_index_db`. One line of code; the surrounding comment is rewritten to point at the bug history so this doesn't regress.

```diff
-    let ref_cqs_dir = cqs::resolve_index_dir(&ref_cfg.path);
-    let ref_db = cqs::resolve_index_db(&ref_cqs_dir);
+    let ref_db = cqs::resolve_index_db(&ref_cfg.path);
```

## Verification

```
$ cargo test --features gpu-index,slow-tests --test cli_drift_diff_test
test test_diff_json_emits_envelope_baseline_to_project ... ok
test test_drift_unknown_reference_errors ... ok
test test_drift_json_emits_envelope_for_baseline_reference ... ok
test result: ok. 3 passed; 0 failed
```

Test pre-#1308 was hidden by the cli_doctor_fix_test panic, then by the model-load panics. Now exposed and fixed.

## Test plan

- [x] `cargo test --features gpu-index,slow-tests --test cli_drift_diff_test` — 3/3 pass locally
- [x] `cargo fmt --check` clean, `cargo clippy` clean
- [ ] After merge, re-trigger `ci-slow.yml` to confirm the slow-tests-feature job now reaches Phase 2's `onboard_test` + `eval_subcommand_test`. If that goes green, file the one-line revert of #1306 to re-enable the schedule cron.

Closes the third post-#1305 bug class.
