### PR TITLE
fix(test): cli_eval_freshness_gate uses BLAKE3 socket name (#1305)

### DIFF
--- a/tests/cli_eval_freshness_gate_test.rs
+++ b/tests/cli_eval_freshness_gate_test.rs
@@ -38,8 +38,6 @@ mod common;
 use assert_cmd::Command;
 use serde_json::json;
 use serial_test::serial;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixListener;
 use std::path::{Path, PathBuf};
@@ -60,10 +58,24 @@ fn cqs() -> Command {
 /// Mirror `cqs::daemon_translate::daemon_socket_path` but with explicit
 /// runtime-dir override so the mock and the spawned CLI agree on which
 /// path to use without mutating the test process's `XDG_RUNTIME_DIR`.
+///
+/// Must use BLAKE3 over the canonical `OsStr` bytes, truncated to 8 bytes
+/// formatted as 16 lowercase hex chars — matches AC-V1.30.1-9 in
+/// `daemon_translate.rs:216-228`. Earlier versions of this helper used
+/// `DefaultHasher`, which silently diverges from the production socket name
+/// on every Rust release; the mock would bind at one path and the spawned
+/// CLI would look at another, panicking with "no daemon running" the first
+/// time ci-slow.yml ran the slow-tests-feature suite (#1305).
 fn daemon_socket_path_with_runtime_dir(cqs_dir: &Path, runtime_dir: &Path) -> PathBuf {
-    let mut h = DefaultHasher::new();
-    cqs_dir.hash(&mut h);
-    let sock_name = format!("cqs-{:x}.sock", h.finish());
+    let canonical_path_bytes = cqs_dir.as_os_str().as_encoded_bytes();
+    let hash = blake3::hash(canonical_path_bytes);
+    let truncated = &hash.as_bytes()[..8];
+    let mut hex = String::with_capacity(16);
+    for b in truncated {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{:02x}", b);
+    }
+    let sock_name = format!("cqs-{}.sock", hex);
     runtime_dir.join(sock_name)
 }
 


### PR DESCRIPTION
## Summary

Fifth bug class surfaced by ci-slow.yml. After #1307 / #1308 / #1310 / #1311 cleared the prior failures, the third manual run got further into the slow-tests-feature suite and reached `cli_eval_freshness_gate_test`, where the happy-path test panicked:

```
gate hit the no-daemon path despite mock being live; stderr=...
Error: watch daemon not reachable: no daemon running
       (socket /tmp/.tmpluowoc/cqs-64a43c0fcfeeb7d5.sock does not exist)
```

## Root cause

Production switched the daemon socket name from `DefaultHasher` to BLAKE3 in v1.30.1 (AC-V1.30.1-9, `src/daemon_translate.rs:216-228`) so the socket name stays stable across Rust versions. The test mock at `tests/cli_eval_freshness_gate_test.rs:64` was never updated:

```rust
fn daemon_socket_path_with_runtime_dir(cqs_dir: &Path, runtime_dir: &Path) -> PathBuf {
    let mut h = DefaultHasher::new();           // ← std SipHash
    cqs_dir.hash(&mut h);
    let sock_name = format!("cqs-{:x}.sock", h.finish());
    runtime_dir.join(sock_name)
}
```

Mock binds at `cqs-<siphash>.sock`. CLI looks for `cqs-<blake3-truncated>.sock`. Every poll fails with "no daemon running" → gate returns the no-daemon diagnostic → test asserts that diagnostic should not appear → panic.

The test never ran in CI before this week (it's `#![cfg(feature = "slow-tests")]`-gated, and the slow-tests-feature job is brand new from #1302). The bug was latent for ~5 months.

## Fix

Replace the inline mock hash with the production formula:

```rust
let canonical_path_bytes = cqs_dir.as_os_str().as_encoded_bytes();
let hash = blake3::hash(canonical_path_bytes);
let truncated = &hash.as_bytes()[..8];
// format truncated bytes as 16 lowercase hex chars
let sock_name = format!("cqs-{}.sock", hex);
```

Mirrors the production code byte-for-byte. Drops two unused imports (`DefaultHasher`, `Hash`/`Hasher`).

## Verification

```
$ cargo test --features gpu-index,slow-tests --test cli_eval_freshness_gate_test
test eval_freshness_gate_fails_when_no_daemon_running ... ok
test eval_freshness_gate_passes_when_daemon_reports_fresh ... ok
test result: ok. 2 passed; 0 failed
```

`cargo fmt --check` clean. `cargo clippy` clean.

## Test plan

- [x] Both tests pass locally
- [x] `cargo fmt --check` + `cargo clippy` clean
- [ ] After merge, re-trigger `ci-slow.yml` to confirm slow-tests-feature now reaches Phase 2's `onboard_test` + `eval_subcommand_test` for the first time

Closing the fifth post-#1305 bug class.
