### PR TITLE
fix(test): cli_ref envelope shape + eval_harness DB precheck (#1305)

### DIFF
--- a/tests/cli_ref_test.rs
+++ b/tests/cli_ref_test.rs
@@ -139,9 +139,12 @@ fn test_ref_add_then_list_shows_reference() {
 
     let envelope = ref_list_json(xdg.path(), host.path());
     // emit_json envelope: {data: [...], error: null, version: 1}
-    let entries = envelope["data"]
+    // P2.15: list envelopes wrap the array in `{references: [...]}` so
+    // every list-shaped command (slot/project/notes/ref) shares the same
+    // outer accessor. Drill in via `data.references` rather than `data`.
+    let entries = envelope["data"]["references"]
         .as_array()
-        .unwrap_or_else(|| panic!("data must be an array: {envelope}"));
+        .unwrap_or_else(|| panic!("data.references must be an array: {envelope}"));
     assert_eq!(
         entries.len(),
         1,
@@ -175,7 +178,7 @@ fn test_ref_remove_deletes_from_config() {
     ref_add(xdg.path(), host.path(), "tmpref", source.path());
     // Sanity: present before remove.
     assert_eq!(
-        ref_list_json(xdg.path(), host.path())["data"]
+        ref_list_json(xdg.path(), host.path())["data"]["references"]
             .as_array()
             .map(|a| a.len()),
         Some(1),
@@ -188,9 +191,12 @@ fn test_ref_remove_deletes_from_config() {
         .success();
 
     let envelope = ref_list_json(xdg.path(), host.path());
-    let entries = envelope["data"]
+    // P2.15: list envelopes wrap the array in `{references: [...]}` so
+    // every list-shaped command (slot/project/notes/ref) shares the same
+    // outer accessor. Drill in via `data.references` rather than `data`.
+    let entries = envelope["data"]["references"]
         .as_array()
-        .unwrap_or_else(|| panic!("data must be an array: {envelope}"));
+        .unwrap_or_else(|| panic!("data.references must be an array: {envelope}"));
     assert!(
         entries.is_empty(),
         "list must be empty after remove, got {entries:?}"
@@ -211,7 +217,9 @@ fn test_ref_update_reindexes_source() {
 
     ref_add(xdg.path(), host.path(), "evolving", source.path());
     let before = ref_list_json(xdg.path(), host.path());
-    let chunks_before = before["data"][0]["chunks"].as_u64().expect("chunks before");
+    let chunks_before = before["data"]["references"][0]["chunks"]
+        .as_u64()
+        .expect("chunks before");
 
     // Add a new public function to lib_a.rs — `ref update` should pick
     // up the new chunk.
@@ -238,7 +246,9 @@ pub fn process_gamma(z: i32) -> i32 {
         .success();
 
     let after = ref_list_json(xdg.path(), host.path());
-    let chunks_after = after["data"][0]["chunks"].as_u64().expect("chunks after");
+    let chunks_after = after["data"]["references"][0]["chunks"]
+        .as_u64()
+        .expect("chunks after");
     assert!(
         chunks_after > chunks_before,
         "chunk count must grow after adding a new function. before={chunks_before} after={chunks_after}"
@@ -302,9 +312,12 @@ fn test_ref_add_weight_rejects_out_of_range() {
 
     // And nothing should have landed in the config — both attempts bailed.
     let envelope = ref_list_json(xdg.path(), host.path());
-    let entries = envelope["data"]
+    // P2.15: list envelopes wrap the array in `{references: [...]}` so
+    // every list-shaped command (slot/project/notes/ref) shares the same
+    // outer accessor. Drill in via `data.references` rather than `data`.
+    let entries = envelope["data"]["references"]
         .as_array()
-        .unwrap_or_else(|| panic!("data must be an array: {envelope}"));
+        .unwrap_or_else(|| panic!("data.references must be an array: {envelope}"));
     assert!(
         entries.is_empty(),
         "rejected ref add must not add entries to config, got {entries:?}"

--- a/tests/eval_harness.rs
+++ b/tests/eval_harness.rs
@@ -488,11 +488,25 @@ fn test_eval_matrix() {
         query_set.queries.len() - train_queries.len()
     );
 
-    // Open cqs index (uses CARGO_MANIFEST_DIR as project root)
+    // Open cqs index (uses CARGO_MANIFEST_DIR as project root). On a fresh
+    // GitHub-hosted runner the repo is just-checked-out — no `cqs index` has
+    // ever run, so the DB doesn't exist. Skip cleanly instead of panicking
+    // on the misleading "unable to open database file" sqlite diagnostic.
+    // Same shape as #1308 / #1311 — the test is fundamentally for a populated
+    // dev workstation. (#1305)
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
     let root = PathBuf::from(&manifest_dir);
     let cqs_dir = cqs::resolve_index_dir(&root);
-    let db_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+    // PR #1105 moved index.db to .cqs/slots/<active>/index.db; resolve_index_db
+    // honors that and falls back to legacy .cqs/index.db if present.
+    let db_path = cqs::resolve_index_db(&cqs_dir);
+    if !db_path.exists() {
+        eprintln!(
+            "cqs index not present at {} — run `cqs index` first; skipping (#1305)",
+            db_path.display()
+        );
+        return;
+    }
     let store = cqs::Store::open_readonly_pooled(&db_path).expect("Failed to open store");
     let model_config = cqs::embedder::ModelConfig::resolve(None, None);
     let embedder = cqs::Embedder::new_cpu(model_config).expect("Failed to init embedder");


### PR DESCRIPTION
## Summary

Seventh and eighth bug classes surfaced by ci-slow.yml. After the prior six fixes (#1307, #1308, #1310, #1311, #1313, #1314), the slow-tests-feature suite reached `cli_ref_test` and the full-suite job reached `test_eval_matrix`. Both fail for unrelated stale-test reasons; bundling them since they're tiny.

## tests/cli_ref_test.rs — envelope shape drift (4 tests)

`API-V1.29-2` + `P2.15` standardized list envelopes to wrap the array in `{<plural>: [...]}` so every list-shaped command (slot/project/notes/ref) shares the same outer accessor:

```json
{ "data": { "references": [ {...}, ... ] }, "error": null, "version": 1 }
```

The cli_ref tests still drilled in via `envelope["data"]` as if the array was at the top level — panic'd with "data must be an array" on every list assertion. Switched to `envelope["data"]["references"]` at all five sites.

```
test test_ref_add_then_list_shows_reference ... ok
test test_ref_add_weight_rejects_out_of_range ... ok
test test_ref_remove_deletes_from_config ... ok
test test_ref_update_reindexes_source ... ok
```

## tests/eval_harness.rs::test_eval_matrix — DB existence precheck

`test_eval_matrix` opens `<CARGO_MANIFEST_DIR>/.cqs/index.db` directly. On a fresh GitHub-hosted runner there's no populated index — the runner just checked out the repo and built; nobody ran `cqs index`. SQLite errors with `"unable to open database file"`.

Also fixed the path drift: PR #1105 moved index.db into `.cqs/slots/<active>/index.db`. The test was still hitting `.cqs/index.db` (legacy bare path that no longer exists for fresh projects). Switched to `cqs::resolve_index_db(&cqs_dir)` which honors the slot layout and falls back to legacy.

Pre-check whether the DB exists, skip cleanly if absent.

## Verification

```
$ cargo test --features gpu-index,slow-tests --test cli_ref_test
4 passed; 0 failed

$ cargo check --features gpu-index --tests
Finished
```

`cargo fmt --check` clean.

## Test plan

- [x] cli_ref_test: 4/4 pass locally
- [x] eval_harness: compiles clean (test isn't run on lib filter; will exercise via the next ci-slow run)
- [x] `cargo fmt --check` clean
- [ ] After merge, fifth ci-slow.yml run — expecting both jobs to finally green out, including reaching Phase 2's `onboard_test` + `eval_subcommand_test` for the first time

Closing the seventh + eighth post-#1305 bug classes. Next step after this merges and ci-slow validates: revert #1306 (re-enable schedule cron).
