### PR TITLE
fix(test): test_noise_eval_143q skips without external noise corpora (#1305)

### DIFF
--- a/tests/pipeline_eval.rs
+++ b/tests/pipeline_eval.rs
@@ -1214,6 +1214,22 @@ fn test_noise_eval_143q() {
         ("Chi (Go)", "/tmp/chi/", &["go"]),
     ];
 
+    // Pre-check: the test is designed around the *combined* noise corpus from
+    // all five repos. If the four /tmp/* sources aren't present the loop
+    // would still run, but only against cqs's own ~1700 .rs files — that
+    // takes 30+ min on a CPU embedder (CI runner) and isn't measuring what
+    // the test claims to measure. Skip cleanly instead. (#1305)
+    let any_external_noise_present = noise_sources
+        .iter()
+        .skip(1) // cqs's own src/ doesn't count — that's intra-repo, not noise
+        .any(|(_, dir_path, _)| Path::new(dir_path).exists());
+    if !any_external_noise_present {
+        eprintln!(
+            "test_noise_eval_143q: external noise corpora absent (need flask/zod/express/chi at /tmp/*); skipping (#1305)"
+        );
+        return;
+    }
+
     let mut noise_chunks = 0;
     let mut batch_texts: Vec<String> = Vec::new();
     let mut batch_chunks: Vec<cqs::parser::Chunk> = Vec::new();


### PR DESCRIPTION
## Summary

Eleventh post-#1305 bug class. With #1316 in, the sixth ci-slow.yml run got `slow-tests-feature` fully green for the first time and `full-suite` deeper into the test stage — but `full-suite` then hit the 90-min timeout instead of completing. The hung test: `test_noise_eval_143q` in `tests/pipeline_eval.rs`.

## Root cause

The test indexes 5 codebases for noise:

```rust
let noise_sources: Vec<(&str, &str, &[&str])> = vec![
    ("cqs (Rust)", "src/", &["rs"]),
    ("Flask (Python)", "/tmp/flask/src/flask/", &["py"]),
    ("Zod (TypeScript)", "/tmp/zod/src/", &["ts"]),
    ("Express (JS)", "/tmp/express/lib/", &["js"]),
    ("Chi (Go)", "/tmp/chi/", &["go"]),
];
```

The four `/tmp/*` paths are dev-machine clones that don't exist on the GitHub-hosted runner. Each gets skipped via `if !base.exists() { continue; }`. But `src/` — cqs's own — does exist relative to the workspace, so the loop walks all ~1700 .rs files and embeds them sequentially on the runner's CPU embedder. That's >30 minutes per run, hitting the 90-min full-suite timeout.

Run #25251426655 cancelled at 90:01:

```
12:48:06.21  test test_fixture_eval_296q has been running for over 60 seconds
12:48:06.22  test test_holdout_eval has been running for over 60 seconds
12:48:06.22  test test_noise_eval_143q has been running for over 60 seconds
12:56:52.09  test test_holdout_eval ... ok
12:56:57.67  test test_fixture_eval_296q ... ok
13:31:19.03  ##[error]The operation was canceled.   ← test_noise_eval_143q hung
```

## Fix

Pre-check that at least one *external* noise corpus is present (cqs's own src/ doesn't count — that's intra-repo, no cross-language signal). Skip cleanly if not. The test claims to measure noise resilience; running it with only intra-repo content isn't measuring what it says.

Same shape as #1315's `test_eval_matrix` precheck.

## Verification

```
$ cargo check --features gpu-index --tests
Finished
$ cargo fmt --check
(clean)
```

Test isn't run in regular CI (it's `#[ignore]`). Will exercise on the next ci-slow.yml dispatch.

## What's next

- After this merges, seventh ci-slow.yml validation. With this fix, full-suite should complete inside 90min.
- If green: revert #1306 to re-enable the daily 06:00 UTC schedule cron.
- If another timeout-shaped failure: same triage approach.

## Test plan

- [x] `cargo check --features gpu-index --tests` clean
- [x] `cargo fmt --check` clean
- [ ] Re-trigger `ci-slow.yml -f include_ignored=true` after merge — full-suite should green out

Closing the eleventh post-#1305 bug class.
