### PR TITLE
fix(llm): consolidate CQS_LLM_* test env-mutex (#1312, #1305)

### DIFF
--- a/src/llm/doc_comments.rs
+++ b/src/llm/doc_comments.rs
@@ -618,12 +618,17 @@ mod tests {
     // function returns `Ok(Vec::new())` *before* any HTTP traffic. A
     // regression that, e.g., started making an API call before the empty-
     // candidates check would surface here as a connect error.
-    use std::sync::Mutex;
-    static DOC_ENV_LOCK: Mutex<()> = Mutex::new(());
+    //
+    // #1312 / #1305: DOC_ENV_LOCK was a file-local Mutex; replaced by the
+    // module-wide `crate::llm::LLM_ENV_LOCK` so this test serializes
+    // against `hyde::tests` and any other future caller that mutates the
+    // shared `CQS_LLM_*` env vars.
 
     #[test]
     fn doc_comment_pass_returns_empty_for_empty_store() {
-        let _g = DOC_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
         let prev_provider = std::env::var("CQS_LLM_PROVIDER").ok();
         let prev_api_base = std::env::var("CQS_LLM_API_BASE").ok();

--- a/src/llm/hyde.rs
+++ b/src/llm/hyde.rs
@@ -123,10 +123,11 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::store::{ModelInfo, Store};
-    use std::sync::Mutex;
 
-    /// Env-touching tests must serialize: `std::env::set_var` is process-global.
-    static HYDE_ENV_LOCK: Mutex<()> = Mutex::new(());
+    // #1312 / #1305: HYDE_ENV_LOCK was a file-local Mutex; replaced by the
+    // module-wide `crate::llm::LLM_ENV_LOCK` so this test serializes
+    // against `doc_comments::tests` and any other future caller that
+    // mutates the shared `CQS_LLM_*` env vars.
 
     /// Build an empty store with the canonical `ModelInfo::default()` so
     /// `init` succeeds and the dim/model metadata is in place. Returns
@@ -144,7 +145,9 @@ mod tests {
     /// Local-provider config so no real API key / network is touched.
     #[test]
     fn hyde_query_pass_returns_zero_for_empty_store() {
-        let _g = HYDE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
         // Save / restore env so we don't poison sibling tests.
         let prev_provider = std::env::var("CQS_LLM_PROVIDER").ok();

--- a/src/llm/local.rs
+++ b/src/llm/local.rs
@@ -715,9 +715,10 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
-    /// Serialize tests that manipulate CQS_LOCAL_* env vars. Env vars are
-    /// process-global; concurrent set/remove across threads races.
-    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // ENV_MUTEX hoisted to module-wide `crate::llm::LLM_ENV_LOCK`
+    // (#1312 / #1305). The local lock served `CQS_LLM_API_KEY` here; siblings
+    // mutated `CQS_LLM_*` under their own per-file mutexes and raced.
+    // Single shared lock serializes all callers.
 
     fn make_config(api_base: &str, model: &str) -> LlmConfig {
         LlmConfig {
@@ -743,7 +744,9 @@ mod tests {
     // ===== Happy-path test 1: 3-item batch, concurrency=1 =====
     #[test]
     fn happy_single_worker_three_items() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -785,7 +788,9 @@ mod tests {
     // ===== Happy-path test 2: 3-item batch, concurrency=4, order-independent =====
     #[test]
     fn happy_four_workers_order_independent() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "4");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -819,7 +824,9 @@ mod tests {
     // ===== Happy-path test 3: auth header when CQS_LLM_API_KEY is set =====
     #[test]
     fn auth_header_present_when_key_set() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::set_var("CQS_LLM_API_KEY", "secret-key-42");
 
@@ -853,7 +860,9 @@ mod tests {
     // env var — a bug.
     #[test]
     fn no_auth_header_when_key_unset() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -892,7 +901,9 @@ mod tests {
     // production integration test (item 26 in the spec).
     #[test]
     fn exhausted_retries_on_5xx_yield_failure() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -919,7 +930,9 @@ mod tests {
     // ===== Happy-path test 6: 429 once, 200 on retry =====
     #[test]
     fn retry_429_then_succeed() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -945,7 +958,9 @@ mod tests {
     // ===== Happy-path test 7: unicode preserved end-to-end =====
     #[test]
     fn unicode_preserved_end_to_end() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -973,7 +988,9 @@ mod tests {
     // ===== Happy-path test 8: very long response not truncated =====
     #[test]
     fn long_response_not_truncated() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -998,7 +1015,9 @@ mod tests {
     // ===== Happy-path test 9: stash drained after fetch_batch_results =====
     #[test]
     fn stash_drained_after_fetch() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -1029,7 +1048,9 @@ mod tests {
     // ===== Sad-path test 10: connection refused → BatchFailed with URL =====
     #[test]
     fn connection_refused_produces_error() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::set_var("CQS_LOCAL_LLM_TIMEOUT_SECS", "5");
         std::env::remove_var("CQS_LLM_API_KEY");
@@ -1052,7 +1073,9 @@ mod tests {
     // ===== Sad-path test 13: malformed JSON → skip, empty stash =====
     #[test]
     fn malformed_json_skipped() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -1079,7 +1102,9 @@ mod tests {
     // ===== Sad-path test 14: empty choices array → skip =====
     #[test]
     fn empty_choices_skipped() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -1105,7 +1130,9 @@ mod tests {
     // ===== Sad-path test 15: null content → skip =====
     #[test]
     fn null_content_skipped() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -1129,7 +1156,9 @@ mod tests {
     // ===== Sad-path test 16: 400 prompt-too-large → skip without retry =====
     #[test]
     fn non_retriable_4xx_no_retry() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -1155,7 +1184,9 @@ mod tests {
     // ===== Sad-path test 17: 404 model-not-found → skip without retry =====
     #[test]
     fn model_not_found_no_retry() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -1177,7 +1208,9 @@ mod tests {
     // ===== Sad-path test 18: all 401 → batch aborts with auth error =====
     #[test]
     fn all_401_aborts_with_auth_error() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -1208,7 +1241,9 @@ mod tests {
     // ===== Sad-path test 21: concurrency=0 clamps to 1 =====
     #[test]
     fn concurrency_zero_clamps_to_one() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "0");
         let got = local_concurrency();
         std::env::remove_var("CQS_LOCAL_LLM_CONCURRENCY");
@@ -1220,7 +1255,9 @@ mod tests {
     // before 16 workers and the unbounded shape was just stack churn.
     #[test]
     fn concurrency_too_high_clamps_to_16() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "9999");
         let got = local_concurrency();
         std::env::remove_var("CQS_LOCAL_LLM_CONCURRENCY");
@@ -1230,7 +1267,9 @@ mod tests {
     // ===== Trait-level test: is_valid_batch_id =====
     #[test]
     fn is_valid_batch_id_uuid() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let config = make_config("http://example.test/v1", "test-model");
         let provider = LocalProvider::new(config).unwrap();
         // UUIDs accepted
@@ -1246,7 +1285,9 @@ mod tests {
     // ===== Trait-level test: model_name =====
     #[test]
     fn model_name_returns_configured() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let config = make_config("http://example.test/v1", "my-custom-model");
         let provider = LocalProvider::new(config).unwrap();
         assert_eq!(provider.model_name(), "my-custom-model");
@@ -1259,7 +1300,9 @@ mod tests {
     // does not abort the batch: all items still get processed.
     #[test]
     fn callback_panic_does_not_abort_batch() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 
@@ -1302,7 +1345,9 @@ mod tests {
     // a tiny cap (1 KiB) and serve a 64 KiB body so the test stays fast.
     #[test]
     fn oversized_response_body_capped_at_max() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::set_var("CQS_LOCAL_LLM_MAX_BODY_BYTES", "1024");
         std::env::remove_var("CQS_LLM_API_KEY");
@@ -1344,7 +1389,9 @@ mod tests {
     // batch finishes and the item is recorded as failed.
     #[test]
     fn fourxx_with_large_body_does_not_buffer_entire_body() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
         std::env::remove_var("CQS_LLM_API_KEY");
 

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -23,6 +23,29 @@ pub mod redirect;
 mod summary;
 pub mod validation;
 
+/// Module-wide test mutex for serializing access to the `CQS_LLM_*` family of
+/// process-global env vars. Each test that mutates any of `CQS_LLM_PROVIDER`,
+/// `CQS_LLM_API_BASE`, `CQS_LLM_MODEL`, `CQS_LLM_API_KEY`, or
+/// `CQS_LLM_ALLOW_INSECURE` must acquire this lock before its set_var calls
+/// and hold it through the read-back so a sibling test can't see partial
+/// state.
+///
+/// Submodules used to declare their own per-file `Mutex<()>` (`HYDE_ENV_LOCK`,
+/// `DOC_ENV_LOCK`, etc.). Those are independent instances and don't actually
+/// serialize across files — `hyde::tests::hyde_query_pass_returns_zero_for_empty_store`
+/// would race against `doc_comments::tests` under `cargo test --release` /
+/// the ci-slow.yml full-suite job and pick up a different `CQS_LLM_API_BASE`
+/// than the one it had set, panicking on the read-back. (#1305 / #1312)
+///
+/// Intentionally public-to-the-crate (`pub(crate)`) and `#[cfg(test)]`-gated
+/// rather than scoped to a `tests` submodule so submodules can `use
+/// crate::llm::LLM_ENV_LOCK` directly. Same shape as the test-helper
+/// pattern in `embedder/provider.rs::tests` (#1260) — that fix used a
+/// per-file lock since only one file mutated `CQS_EMBED_*`; here multiple
+/// files mutate `CQS_LLM_*` so the lock must be at the parent module.
+#[cfg(test)]
+pub(crate) static LLM_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -636,11 +659,11 @@ pub struct SummaryEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
-    /// Mutex to serialize tests that manipulate CQS_LLM_* env vars.
-    /// Env vars are process-global — concurrent test threads race on set/remove.
-    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+    // ENV_MUTEX hoisted to module-wide `LLM_ENV_LOCK` (#1312 / #1305) so
+    // these tests serialize against `hyde::tests`, `doc_comments::tests`, and
+    // `local::tests` — all four were independent Mutex instances pre-fix and
+    // raced under cargo's parallel test runner.
 
     type SavedEnv = [Option<String>; 4];
 
@@ -691,7 +714,9 @@ mod tests {
 
     #[test]
     fn llm_config_defaults_from_empty_config() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let saved = save_llm_env_vars();
         std::env::remove_var("CQS_LLM_MODEL");
         std::env::remove_var("CQS_API_BASE");
@@ -710,7 +735,9 @@ mod tests {
 
     #[test]
     fn llm_config_from_config_file_fields() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let config = crate::config::Config {
             llm_model: Some("claude-sonnet-4-20250514".to_string()),
             llm_api_base: Some("https://custom.api/v1".to_string()),
@@ -725,7 +752,9 @@ mod tests {
 
     #[test]
     fn llm_config_env_overrides_config_file() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let config = crate::config::Config {
             llm_model: Some("from-config".to_string()),
             llm_api_base: Some("https://from-config/v1".to_string()),
@@ -754,7 +783,9 @@ mod tests {
     // AD-32: CQS_LLM_API_BASE takes priority over CQS_API_BASE
     #[test]
     fn llm_config_llm_api_base_takes_precedence() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Save all env vars that LlmConfig::resolve reads
         let saved = save_llm_env_vars();
 
@@ -777,7 +808,9 @@ mod tests {
     // AD-32: CQS_API_BASE still works as fallback
     #[test]
     fn llm_config_api_base_fallback_still_works() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let saved = save_llm_env_vars();
 
         std::env::remove_var("CQS_LLM_API_BASE");
@@ -799,7 +832,9 @@ mod tests {
     // SEC-V1.25-13: http:// is rejected unless CQS_LLM_ALLOW_INSECURE=1 is also set.
     #[test]
     fn llm_config_rejects_http_without_allow_insecure() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let saved = save_llm_env_vars();
         let saved_allow = std::env::var("CQS_LLM_ALLOW_INSECURE").ok();
 
@@ -833,7 +868,9 @@ mod tests {
     // SEC-V1.25-13: With CQS_LLM_ALLOW_INSECURE=1 the http:// override is allowed.
     #[test]
     fn llm_config_allows_http_with_allow_insecure() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let saved = save_llm_env_vars();
         let saved_allow = std::env::var("CQS_LLM_ALLOW_INSECURE").ok();
 
@@ -861,7 +898,9 @@ mod tests {
 
     #[test]
     fn llm_config_invalid_max_tokens_env_falls_through() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let config = crate::config::Config {
             llm_max_tokens: Some(300),
             ..Default::default()
@@ -1113,7 +1152,9 @@ mod tests {
     /// `create_client` returns an actionable error before any HTTP traffic.
     #[test]
     fn local_provider_missing_api_base_errors() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let saved = save_local_env();
 
         std::env::set_var("CQS_LLM_PROVIDER", "local");
@@ -1147,7 +1188,9 @@ mod tests {
     /// actionable error.
     #[test]
     fn local_provider_missing_model_errors() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let saved = save_local_env();
 
         std::env::set_var("CQS_LLM_PROVIDER", "local");
@@ -1180,7 +1223,9 @@ mod tests {
     /// rejection — opt-in required for cleartext bases.
     #[test]
     fn local_provider_rejects_http_without_allow_insecure() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let saved = save_local_env();
 
         std::env::set_var("CQS_LLM_PROVIDER", "local");
@@ -1208,7 +1253,9 @@ mod tests {
     /// Provider resolution: `CQS_LLM_PROVIDER=local` actually sets the variant.
     #[test]
     fn provider_resolves_local() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let saved = save_local_env();
 
         std::env::set_var("CQS_LLM_PROVIDER", "local");
@@ -1228,7 +1275,9 @@ mod tests {
     /// not a hand-coded match.
     #[test]
     fn provider_unknown_falls_back_to_default() {
-        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let saved = save_local_env();
 
         std::env::set_var("CQS_LLM_PROVIDER", "definitely-not-a-real-provider");


### PR DESCRIPTION
## Summary

Closes #1312 (and the twelfth post-#1305 bug class). Hyde test env-var race surfaced 2026-05-02 during ci-slow.yml validation runs — passes locally, fails non-deterministically in parallel ci-slow runs.

## Root cause

Four separate `Mutex<()>` instances guarded tests that all mutate the same `CQS_LLM_*` family of process-global env vars:

| File | Lock name | Vars mutated |
|------|-----------|--------------|
| `src/llm/mod.rs::tests::ENV_MUTEX` | `ENV_MUTEX` | `CQS_LLM_PROVIDER`, `CQS_LLM_API_BASE`, `CQS_LLM_MODEL`, `CQS_LLM_ALLOW_INSECURE` |
| `src/llm/hyde.rs::tests::HYDE_ENV_LOCK` | `HYDE_ENV_LOCK` | same set |
| `src/llm/doc_comments.rs::tests::DOC_ENV_LOCK` | `DOC_ENV_LOCK` | same set |
| `src/llm/local.rs::tests::ENV_MUTEX` | `ENV_MUTEX` | `CQS_LLM_API_KEY` |

Independent `Mutex<()>` instances don't serialize against each other. Under cargo's parallel test runner (the `--release` builds in ci-slow.yml's `full-suite` job, but in principle any parallel run), `hyde::hyde_query_pass_returns_zero_for_empty_store` could race against `doc_comments::doc_comment_pass_returns_empty_for_empty_store` and read each other's env-var writes:

```
test llm::hyde::tests::hyde_query_pass_returns_zero_for_empty_store ... FAILED
panicked at src/llm/hyde.rs:184:24: hyde_query_pass on empty store must not error
```

Test passes locally:
```
$ cargo test --features gpu-index --lib hyde_query_pass_returns_zero_for_empty_store
test result: ok. 1 passed; 0 failed
```

Same root pattern as #1268 (validation::ENV_LOCK) and #1260 (embedder::provider::tests env). Same fix shape: hoist to a single shared lock.

## Fix

Hoist all four locks to a single `pub(crate) static CQS_LLM_ENV_LOCK` at `crate::llm`. Doc comment points at the bug history so future-me / future-claude doesn't redo this.

```rust
// src/llm/mod.rs
#[cfg(test)]
pub(crate) static CQS_LLM_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
```

Each test acquires it via:
```rust
let _g = crate::llm::CQS_LLM_ENV_LOCK
    .lock()
    .unwrap_or_else(|e| e.into_inner());
```

`validation::ENV_LOCK` stays separate — it guards `CQS_SUMMARY_VALIDATION`, a different env-var family with no overlap with `CQS_LLM_*`.

## Verification

```
$ cargo test --features gpu-index --lib llm::
test result: ok. 146 passed; 0 failed; 0 ignored; 0 measured; 1825 filtered out
```

`cargo fmt --check` clean. `cargo clippy` clean.

## What this closes

- #1312 (the hyde race directly).
- The twelfth post-#1305 bug class. With this in, the next ci-slow.yml run should green out both jobs in full — no more known failures.

## Test plan

- [x] `cargo test --features gpu-index --lib llm::` 146/146 pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [ ] Eighth ci-slow.yml validation after merge — both jobs should be fully green
- [ ] If green: revert #1306 to re-enable the 06:00 UTC schedule cron
