### PR TITLE
fix(docs): switch broken ignore-doctests to text blocks (#1305)

### DIFF
--- a/src/hnsw/build.rs
+++ b/src/hnsw/build.rs
@@ -122,7 +122,13 @@ impl HnswIndex {
     /// * `dim` - Expected embedding dimension
     ///
     /// # Example
-    /// ```ignore
+    ///
+    /// `text` rather than `ignore` because the snippet references `store`
+    /// without setup; `cargo test -- --include-ignored` (the `ci-slow.yml`
+    /// shape) compiles `ignore`-tagged doctests and would surface
+    /// `cannot find value 'store' in this scope`. (#1305)
+    ///
+    /// ```text
     /// let index = HnswIndex::build_batched_with_dim(
     ///     store.embedding_batches(10_000),
     ///     store.chunk_count()?,

--- a/src/nl/fts.rs
+++ b/src/nl/fts.rs
@@ -20,7 +20,14 @@ fn is_cjk(c: char) -> bool {
 /// "XMLParser" become individual letters. This is intentional for search
 /// tokenization where "xml parser" is more useful than preserving "XML".
 /// # Examples
-/// ```ignore
+///
+/// `text` rather than `ignore` because `nl` is `pub(crate)` — external
+/// rustdoc can't actually call `cqs::nl::tokenize_identifier`. The block
+/// is illustrative; under `cargo test -- --include-ignored` (the
+/// `ci-slow.yml` shape) `ignore`-tagged doctests *are* compiled and
+/// would surface the visibility error. (#1305)
+///
+/// ```text
 /// use cqs::nl::tokenize_identifier;
 /// assert_eq!(tokenize_identifier("parseConfigFile"), vec!["parse", "config", "file"]);
 /// assert_eq!(tokenize_identifier("get_user_name"), vec!["get", "user", "name"]);

--- a/src/nl/markdown.rs
+++ b/src/nl/markdown.rs
@@ -21,7 +21,14 @@ static JSDOC_RETURNS_RE: LazyLock<Regex> =
 /// Parse JSDoc tags from a documentation comment.
 /// Extracts @param and @returns/@return tags from JSDoc-style comments.
 /// # Example
-/// ```ignore
+///
+/// `text` rather than `ignore` because `nl` is `pub(crate)` — external
+/// rustdoc can't actually call `cqs::nl::parse_jsdoc_tags`. The block
+/// is illustrative; under `cargo test -- --include-ignored` (the
+/// `ci-slow.yml` shape) `ignore`-tagged doctests *are* compiled and
+/// would surface the visibility error. (#1305)
+///
+/// ```text
 /// use cqs::nl::parse_jsdoc_tags;
 /// let doc = r#"/**
 ///  * Validates an email address


### PR DESCRIPTION
## Summary

Thirteenth post-#1305 bug class. After #1318 (env-lock consolidation) closed the hyde flake, the eighth ci-slow.yml validation surfaced three doctest failures in the `Run full test suite (incl. ignored)` step.

## Root cause

`cargo test -- --include-ignored` (the `ci-slow.yml` full-suite shape) compiles ` ```ignore`-tagged doctests, not just `#[ignore]` test fns. Three of ours never compiled when actually built:

| File:line | Failure |
|-----------|---------|
| `src/hnsw/build.rs:125` (`HnswIndex::build_batched_with_dim`) | `cannot find value 'store' in this scope` — example references `store` with no setup |
| `src/nl/fts.rs:23` (`tokenize_identifier`) | `module 'nl' is private` — example calls `cqs::nl::tokenize_identifier`, but `nl` is `pub(crate)` |
| `src/nl/markdown.rs:24` (`parse_jsdoc_tags`) | `module 'nl' is private` — same issue |

The blocks were tagged ` ```ignore` to skip compilation. That's fine for normal `cargo test`, but `--include-ignored` defeats the skip. PR-time CI uses plain `cargo test` so this never surfaced there; only ci-slow.yml's `--include-ignored` path triggers it.

## Fix

Switch all three blocks to ` ```text`. Same illustrative content, but rustdoc renders them as plain prose instead of trying to compile — both `--include-ignored` and the regular doctest path are happy. Each block grew a one-paragraph comment pointing at the rationale so nobody flips it back to ` ```ignore` in a future cleanup.

## Verification

```
$ cargo test --features gpu-index --doc -- --include-ignored
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.69s
```

`cargo fmt --check` clean.

## Where this leaves the chain

Thirteen bug classes addressed in the post-#1305 chain. With this in:
- slow-tests-feature: green for last 4 runs
- full-suite: lib (1949) + integration (28+696+9+...) all green; doctests now green
- The only known remaining non-green path is the manual `--include-ignored` doctest run, which this fixes

## Test plan

- [x] `cargo test --features gpu-index --doc -- --include-ignored` 9/9 pass
- [x] `cargo fmt --check` clean
- [ ] Ninth ci-slow.yml validation after merge — both jobs should be fully green
- [ ] If green: revert #1306 to re-enable schedule cron
