### PR TITLE
fix(test): consolidate CQS_ONNX_DIR test mutex (#1305)

### DIFF
--- a/src/cli/commands/infra/doctor.rs
+++ b/src/cli/commands/infra/doctor.rs
@@ -1523,12 +1523,13 @@ fn tick(b: bool) -> colored::ColoredString {
 mod tests {
     use super::*;
     use cqs::embedder::ModelInfo;
-    use std::sync::Mutex;
     use tempfile::TempDir;
 
-    /// Tests that touch `CQS_*` env vars must serialize — env vars are
-    /// process-global and concurrent threads race on set/remove.
-    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+    // ENV_MUTEX hoisted to `cqs::ONNX_DIR_ENV_LOCK` (#1305) so this cohort
+    // serializes against `embedder::tests::ensure_model_tests` and
+    // `embedder::tests::embedder_init_failure`. Pre-fix all three were
+    // independent Mutex instances and raced on `CQS_ONNX_DIR` under
+    // cargo's parallel runner.
 
     #[test]
     fn issue_kind_maps_to_fix_action() {
@@ -1571,7 +1572,9 @@ mod tests {
 
     #[test]
     fn test_doctor_verbose_without_index() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = cqs::ONNX_DIR_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("CQS_EMBEDDING_MODEL");
         std::env::remove_var("CQS_ONNX_DIR");
         let tmp = TempDir::new().expect("tempdir");
@@ -1596,7 +1599,9 @@ mod tests {
 
     #[test]
     fn test_doctor_verbose_with_index() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = cqs::ONNX_DIR_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("CQS_EMBEDDING_MODEL");
         std::env::remove_var("CQS_ONNX_DIR");
         let tmp = TempDir::new().expect("tempdir");
@@ -1637,7 +1642,9 @@ mod tests {
 
     #[test]
     fn test_doctor_verbose_json_output() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = cqs::ONNX_DIR_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("CQS_EMBEDDING_MODEL");
         std::env::remove_var("CQS_ONNX_DIR");
         let tmp = TempDir::new().expect("tempdir");
@@ -1667,7 +1674,9 @@ mod tests {
 
     #[test]
     fn test_resolution_source_priority() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = cqs::ONNX_DIR_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("CQS_EMBEDDING_MODEL");
         // Stored preset wins over everything else.
         assert_eq!(
@@ -1696,7 +1705,9 @@ mod tests {
 
     #[test]
     fn test_collect_cqs_env_vars_filters_correctly() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = cqs::ONNX_DIR_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CQS_TEST_FOO_DOCTOR", "bar");
         std::env::set_var("NOT_CQS_VAR", "ignored");
         let vars = collect_cqs_env_vars();
@@ -1746,7 +1757,9 @@ mod tests {
     /// `cqs doctor --json | jq` and expect both top-level keys.
     #[test]
     fn doctor_report_combines_checks_and_verbose() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = cqs::ONNX_DIR_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("CQS_EMBEDDING_MODEL");
         std::env::remove_var("CQS_ONNX_DIR");
         let tmp = TempDir::new().expect("tempdir");

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -2039,10 +2039,14 @@ mod tests {
 
     mod ensure_model_tests {
         use super::*;
-        use std::sync::Mutex;
 
-        /// Mutex to serialize tests that manipulate CQS_ONNX_DIR env var.
-        static ONNX_DIR_MUTEX: Mutex<()> = Mutex::new(());
+        // ONNX_DIR_MUTEX hoisted to the crate-level shared
+        // `crate::ONNX_DIR_ENV_LOCK` (#1305) so this test mod serializes
+        // against `embedder_init_failure` (sibling) and the
+        // `cli::commands::infra::doctor::tests` cohort. Pre-fix all three
+        // had separate Mutex instances and raced on `CQS_ONNX_DIR` under
+        // cargo's parallel runner — a poisoned lock from a 401-on-CI HF
+        // download cascaded into PoisonError on the next two tests.
 
         fn test_model_config() -> ModelConfig {
             ModelConfig {
@@ -2064,7 +2068,9 @@ mod tests {
 
         #[test]
         fn cqs_onnx_dir_structured_layout() {
-            let _lock = ONNX_DIR_MUTEX.lock().unwrap();
+            let _lock = crate::ONNX_DIR_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             let dir = tempfile::TempDir::new().unwrap();
             let onnx_dir = dir.path().join("onnx");
             std::fs::create_dir_all(&onnx_dir).unwrap();
@@ -2090,7 +2096,9 @@ mod tests {
 
         #[test]
         fn cqs_onnx_dir_flat_layout() {
-            let _lock = ONNX_DIR_MUTEX.lock().unwrap();
+            let _lock = crate::ONNX_DIR_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             let dir = tempfile::TempDir::new().unwrap();
             std::fs::write(dir.path().join("model.onnx"), b"fake").unwrap();
             std::fs::write(dir.path().join("tokenizer.json"), b"fake").unwrap();
@@ -2114,7 +2122,9 @@ mod tests {
 
         #[test]
         fn cqs_onnx_dir_missing_files_falls_through() {
-            let _lock = ONNX_DIR_MUTEX.lock().unwrap();
+            let _lock = crate::ONNX_DIR_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             let dir = tempfile::TempDir::new().unwrap();
             // Empty dir -- neither structured nor flat layout
 
@@ -2135,16 +2145,18 @@ mod tests {
 
     mod embedder_init_failure {
         use super::*;
-        use std::sync::Mutex;
 
-        /// Mutex to serialize tests that manipulate CQS_ONNX_DIR env var.
-        static ONNX_DIR_MUTEX: Mutex<()> = Mutex::new(());
+        // ONNX_DIR_MUTEX hoisted to `crate::ONNX_DIR_ENV_LOCK` (#1305) so
+        // this mod serializes against `ensure_model_tests` and
+        // `doctor::tests`. See the comment in `ensure_model_tests` above.
 
         #[test]
         fn embedder_with_bogus_onnx_path_returns_err_on_embed() {
             // TC-11: Verify that an Embedder with a ModelConfig pointing to
             // a nonexistent ONNX path returns Err (not panic) when embed is called.
-            let _lock = ONNX_DIR_MUTEX.lock().unwrap();
+            let _lock = crate::ONNX_DIR_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
 
             let dir = tempfile::TempDir::new().unwrap();
             // Create only the tokenizer file, leave ONNX model missing
@@ -2198,7 +2210,9 @@ mod tests {
         fn embedder_init_failure_is_not_cached() {
             // TC-11: Verify that after an Embedder returns Err on embed,
             // calling embed again also returns Err (no cached bad state).
-            let _lock = ONNX_DIR_MUTEX.lock().unwrap();
+            let _lock = crate::ONNX_DIR_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
 
             let dir = tempfile::TempDir::new().unwrap();
             // Create empty dir -- no model files at all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,32 @@ pub mod watch_status;
 #[cfg(test)]
 pub mod test_helpers;
 
+/// Crate-wide test mutex for serializing access to the `CQS_ONNX_DIR`
+/// process-global env var. Serializes the three cohorts that mutate it:
+///
+/// - `embedder::tests::ensure_model_tests` (3 tests)
+/// - `embedder::tests::embedder_init_failure` (2 tests)
+/// - `cli::commands::infra::doctor::tests` (4 tests)
+///
+/// Pre-fix each cohort had its own `static Mutex<()>` and they didn't
+/// actually serialize against each other — under cargo's parallel
+/// runner a poisoned lock from a 401-on-CI HF download cascaded into
+/// `PoisonError` panics in the next two tests. (#1305 / ci-slow.yml run
+/// 25255950909 retry surface)
+///
+/// Same shape as `crate::llm::LLM_ENV_LOCK` from #1318 — hoist to a
+/// single shared lock so all cohorts serialize through one Mutex.
+///
+/// Visibility is `pub` (not `pub(crate)`) because `doctor::tests` lives
+/// in the binary crate and reaches the lib via `cqs::ONNX_DIR_ENV_LOCK`;
+/// `pub(crate)` doesn't cross the lib→bin boundary even within one
+/// Cargo package, and `#[cfg(test)]` doesn't either (the lib used by
+/// `cqs` bin tests is built with `cfg(test)` for the lib unit-test
+/// target only, not when serving as a dep). Public-but-cheap (an 8-byte
+/// `Mutex<()>` with `#[doc(hidden)]`) is the right escape hatch.
+#[doc(hidden)]
+pub static ONNX_DIR_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(feature = "cuda-index")]
 pub mod cagra;
 


### PR DESCRIPTION
## Summary

Fourteenth post-#1305 bug class. Same shape as #1318 (LLM_ENV_LOCK consolidation) — three independent test mutexes guarding the same process-global env var, racing under cargo's parallel runner.

## Root cause

Three separate `Mutex<()>` instances guarded tests that all mutate `CQS_ONNX_DIR`:

| Location | Lock | Tests |
|----------|------|-------|
| `src/embedder/mod.rs::tests::ensure_model_tests` | `ONNX_DIR_MUTEX` | 3 |
| `src/embedder/mod.rs::tests::embedder_init_failure` | `ONNX_DIR_MUTEX` | 2 |
| `src/cli/commands/infra/doctor.rs::tests` | `ENV_MUTEX` | 4 |

Independent locks ≠ serialization. Under cargo's parallel runner the cohorts race on `CQS_ONNX_DIR`. The flake mode observed: `cqs_onnx_dir_flat_layout` made an HF download attempt that got `401` from the CI exit IP (anonymous gating), which poisoned its lock. The next two tests in the same cohort then panicked with `PoisonError`.

Run #25255950909 (PR #1319's regular CI):

```
test embedder::tests::ensure_model_tests::cqs_onnx_dir_flat_layout ... FAILED
  HfHub("status code 401")
test embedder::tests::ensure_model_tests::cqs_onnx_dir_structured_layout ... FAILED
  PoisonError { .. }
test embedder::tests::ensure_model_tests::cqs_onnx_dir_missing_files_falls_through ... FAILED
  PoisonError { .. }
```

PR #1319 (doctest text blocks) is unrelated to this race but happens to be the PR that triggered the flake — the env mutation pattern was always racy, just rarely surfaced.

## Fix

Hoist to a single crate-level shared static `cqs::ONNX_DIR_ENV_LOCK`. All three cohorts acquire it via:

```rust
let _lock = cqs::ONNX_DIR_ENV_LOCK
    .lock()
    .unwrap_or_else(|e| e.into_inner());
```

`unwrap_or_else(|e| e.into_inner())` recovers from poison so a single test panic doesn't permanently break the suite — same as the LLM lock pattern.

## Visibility / `#[cfg(test)]`

`pub` (not `pub(crate)`) and not `#[cfg(test)]`-gated because `doctor::tests` lives in the binary crate. The lib used by `cqs` bin tests is built *without* `cfg(test)` (it's serving as a dep there, not the test target itself), so a `#[cfg(test)] pub(crate)` static disappears at the boundary. `#[doc(hidden)] pub` is the right escape hatch — public-but-marked-internal at an 8-byte `Mutex<()>` cost.

## Verification

```
$ cargo test --features gpu-index --lib embedder::tests::ensure_model_tests::
test result: ok. 3 passed; 0 failed
$ cargo check --features gpu-index --tests
Finished
```

`cargo fmt --check` clean.

## Test plan

- [x] Three ensure_model tests pass locally
- [x] Bin test target compiles clean (proves `cqs::ONNX_DIR_ENV_LOCK` is reachable from doctor.rs)
- [x] `cargo fmt --check` clean
- [ ] After merge, retry of any PR that touches the lib's parallel test path should be flake-free on this surface
