### PR TITLE
chore(ci): re-enable ci-slow.yml schedule cron — #1305 closed

### DIFF
--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -8,15 +8,18 @@ name: CI (slow / overnight)
 # Background: see #1286.
 
 on:
-  # Schedule cron disabled until #1305 is triaged — the first run on
-  # 2026-05-02 surfaced two pre-existing instabilities (cli_doctor_fix_test
-  # panics on the runner, 9 model-loading tests fail without an HF cache /
-  # token). Re-enable by uncommenting the schedule block once the underlying
-  # bugs are addressed; until then, run via workflow_dispatch when needed.
-  # schedule:
-  #   # 06:00 UTC daily ≈ 22:00 PT previous day. Once-a-day, not hourly —
-  #   # the suite is heavy and free-tier minutes matter.
-  #   - cron: '0 6 * * *'
+  schedule:
+    # 06:00 UTC daily ≈ 22:00 PT previous day. Once-a-day, not hourly —
+    # the suite is heavy and free-tier minutes matter.
+    #
+    # Re-enabled 2026-05-02 after the #1305 triage closed all 14 surfaced
+    # bug classes (slot path, model soft-skip, ref resolution, corrupt
+    # cache, BLAKE3 socket, windowing probe, envelope shape, eval DB
+    # precheck, format flag, R@1 gate, noise corpus, LLM env-lock,
+    # doctest text blocks, ONNX_DIR env-lock). Run #25256531515 was the
+    # first fully-green ci-slow.yml execution; both jobs (full-suite and
+    # slow-tests-feature) completed cleanly.
+    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       include_ignored:


### PR DESCRIPTION
## Summary

Effective revert of #1306. The disable was put in place because the first manual `ci-slow.yml` run failed in both jobs and the auto-issue mechanism would have filed an issue every 06:00 UTC. Fourteen bug classes later, all #1305 surfaces are addressed:

| PR | Theme |
|---|---|
| #1307 | `cli_doctor_fix_test` slot path drift |
| #1308 | 9 model-loading tests soft-skip on missing HF cache |
| #1310 | `cli_drift_diff` ref resolution / spurious `.cqs/` segment |
| #1311 | `split_into_windows` + `token_count` corrupt-cache soft-skip |
| #1313 | `cli_eval_freshness_gate` mock used `DefaultHasher`; fixed to BLAKE3 |
| #1314 | `apply_windowing` test tokenizer probe |
| #1315 | cli_ref envelope shape + `test_eval_matrix` DB precheck |
| #1316 | `cli_train_review` `--format json` → `--json` + R@1 gate demote |
| #1317 | `test_noise_eval_143q` external corpus precheck |
| #1318 | `LLM_ENV_LOCK` consolidation (closed #1312) |
| #1319 | broken `ignore`-doctests → `text` blocks |
| #1320 | `ONNX_DIR_ENV_LOCK` consolidation |

Plus `--include-ignored` env-disable comment fixes folded into PR bodies.

## Validation

ci-slow.yml run [#25256531515](https://github.com/jamie8johnson/cqs/actions/runs/25256531515) was the **first fully-green ci-slow.yml execution**:

```
Run: completed / success
  slow-tests-feature: completed / success
  full-suite: completed / success
  notify-failure: completed / skipped
```

Both jobs:
- `full-suite` — lib (1949) + integration tests + `--include-ignored` ignored tests, no HF model assumptions left
- `slow-tests-feature` — the new Phase 2 host (#1302), runs the 11 subprocess-spawning `cli_*` tests + `onboard_test` + `eval_subcommand_test`

## Changes

`.github/workflows/ci-slow.yml`: uncomment the `schedule:` block; replace the temporary "disabled until #1305" comment with a "re-enabled after #1305 closed" note pointing at the run that proved it.

## Test plan

- [x] Workflow syntax valid (`yaml` parser; uncommenting an existing block can't break it)
- [x] First-ever fully-green ci-slow.yml run already on record (#25256531515)
- [ ] First scheduled cron firing tomorrow at 06:00 UTC will validate end-to-end on a fresh runner

Closes the #1305 triage chain. Daily nightly signal restored.
