### PR TITLE
docs: lying-docs sweep from v1.33.0 audit (P1-1..P1-13, partial)

### DIFF
--- a/.claude/skills/cqs-bootstrap/SKILL.md
+++ b/.claude/skills/cqs-bootstrap/SKILL.md
@@ -98,7 +98,7 @@ mentions = ["docs/notes.toml", "PROJECT_CONTINUITY.md"]
    - `troubleshoot` — diagnose common cqs issues
    - `migrate` — handle schema version upgrades
    - `red-team` — adversarial testing against cqs
-   - `audit` — 14-category code audit with parallel agents
+   - `audit` — 16-category code audit with parallel agents
    - `pr` — WSL-safe PR creation (always --body-file)
    - `release` — version bump, changelog, publish, GitHub release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`slow-tests-feature` job** in `.github/workflows/ci-slow.yml` (#1286 Phase 2). Runs `cargo test --release --features slow-tests` nightly. Self-contained — no HuggingFace model download dependency, in contrast to the existing `full-suite` job's `--include-ignored` path. Hosts the 11 subprocess-spawning `cli_*_test` binaries that have been gated since v1.29.0 plus the two new e2e additions above. Could later graduate to PR-time CI if wall time stays under budget.
 - **`cqs eval --reranker <none|onnx|llm>`** wires the v1.32.0 `Reranker` trait (#1276) into the eval harness. Default `none` keeps the historical retrieval-only pipeline so existing baselines stay comparable. `onnx` runs the cross-encoder configured by `[reranker]` / `CQS_RERANKER_MODEL` and over-retrieves to `rerank_pool_size(limit)` (mirrors `cqs <q> --rerank`) before stage 2 truncates to `limit`. `llm` resolves to `cqs::LlmReranker` (skeleton — errors on first call) so the flag absorbs that wiring without a breaking API change later. Listed under "Outstanding follow-ups (small, optional)" in PROJECT_CONTINUITY.md.
+- **`embeddinggemma-300m` embedder preset + `CQS_DISABLE_TENSORRT` knob** (#1301). New 308M-param Google EmbeddingGemma preset (`CQS_EMBEDDING_MODEL=embeddinggemma-300m`) and an opt-out for TensorRT EP when the engine cache thrashes (`CQS_DISABLE_TENSORRT=1`). Enumerated in `README.md` env-var table.
+- **`cqs notes update --new-kind <kind>`** (#1278). In-place kind edits without re-adding; symmetric with `--new-text` and `--new-sentiment`. Same v25 normalization as `cqs notes add`.
+
+### Fixed
+
+- **ci-slow.yml stabilization series** (#1305 family — #1307, #1308, #1310, #1311, #1313, #1314, #1315, #1316, #1317, #1318, #1319, #1320, #1321). Closed all 14 surfaced bug classes after the first ci-slow.yml run. One real production correctness fix (#1310: `cqs::resolve_index_db` on the resolve path); the rest were test isolation, slot-path drift, soft-skip on missing HF cache, env-var lock consolidation, doctest visibility, and CHANGELOG/metadata cleanup. Daily 06:00 UTC cron re-enabled — first fully green run is `25256531515`.
 
 ## [1.33.0] - 2026-05-02
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,7 +310,7 @@ src/
   worktree.rs   - Git-worktree → main-project-`.cqs/` discovery (#1254). When `cqs` runs from inside a worktree without its own `.cqs/`, `resolve_index_dir` parses the worktree's `.git` file, follows `commondir` to the main project, and serves queries from main's index. Every JSON envelope from that process gets `_meta.worktree_stale: true` so consuming agents know the served snapshot is from main's branch.
   index.rs      - VectorIndex trait (HNSW, CAGRA)
   llm/          - LLM summary generation, HyDE query predictions via Anthropic Batches API
-    mod.rs, batch.rs (BatchPhase2, submit_batch_prebuilt), doc_comments.rs, hyde.rs, prompts.rs (build_contrastive_prompt), provider.rs (BatchProvider trait, BatchSubmitItem, LlmProvider), summary.rs (find_contrastive_neighbors)
+    mod.rs, batch.rs (BatchPhase2, submit_batch_prebuilt), doc_comments.rs, hyde.rs, prompts.rs (build_contrastive_prompt), provider.rs (BatchProvider trait, BatchSubmitItem, MockBatchProvider for tests), summary.rs (find_contrastive_neighbors)
   doc_writer/   - Doc comment generation and source file rewriting (SQ-8, optional "llm-summaries" feature)
     mod.rs      - DocCommentResult, module exports
     formats.rs  - Per-language doc comment formatting (prefix, position, wrapping)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,7 +855,6 @@ dependencies = [
  "ignore",
  "indicatif 0.18.4",
  "insta",
- "keyring",
  "libc",
  "log",
  "lru",
@@ -2341,16 +2340,6 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "keyring"
-version = "3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
-dependencies = [
- "log",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,6 @@ base64 = { version = "0.22", optional = true }
 
 # Storage (sqlx async SQLite)
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite"] }
-keyring = { version = "3", optional = true }
 
 # Vector search (HNSW default, cuVS optional)
 hnsw_rs = "0.3"
@@ -242,9 +241,10 @@ lang-all = ["lang-rust", "lang-python", "lang-typescript", "lang-javascript", "l
 convert = ["dep:fast_html2md", "dep:walkdir"]
 
 # Other features
-# encrypt feature removed - sqlx doesn't support SQLCipher directly
-# TODO: Re-evaluate encryption strategy with sqlx
-encrypt = ["keyring"]
+# (encrypt feature deleted — sqlx doesn't expose a SQLCipher backend, the
+# feature had zero `cfg(feature = "encrypt")` callers, and the only dep it
+# pulled in (`keyring`) had no consuming code. Revisit encryption strategy
+# if and when sqlx grows a SQLCipher driver.)
 
 # CAGRA (cuVS) ANN backend — CUDA-only. Issue #956 (Phase A): renamed
 # from `gpu-index` to make the CUDA-specificity explicit. The legacy

--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ cqs index --llm-summaries --max-hyde 200  # Limit HyDE query generation to N fun
 
 1. **Parse** — Tree-sitter extracts functions, classes, structs, enums, traits, interfaces, constants, tests, endpoints, modules, and 19 other chunk types across 54 languages (plus L5X/L5K PLC exports). Also extracts call graphs (who calls whom) and type dependencies (who uses which types).
 2. **Describe** — Each code element gets a natural language description incorporating doc comments, parameter types, return types, and parent type context (e.g., methods include their struct/class name). Type-aware embeddings append full signatures for richer type discrimination. Optionally enriched with LLM-generated one-sentence summaries via `--llm-summaries`. This bridges the gap between how developers describe code and how it's written.
-3. **Embed** — Configurable embedding model (BGE-large-en-v1.5 default, E5-base preset, or custom ONNX) generates embeddings locally on CPU or GPU. See Retrieval Quality below for measured recall.
+3. **Embed** — Configurable embedding model (BGE-large-en-v1.5 default; `bge-large-ft`, `E5-base`, `v9-200k`, `nomic-coderank`, `embeddinggemma-300m` presets, or custom ONNX) generates embeddings locally on CPU or GPU. See Retrieval Quality below for measured recall.
 4. **Enrich** — Call-graph-enriched embeddings prepend caller/callee context. Optional LLM summaries (via Claude Batches API) add one-sentence function purpose. `--improve-docs` generates and writes doc comments back to source files. Both cached by content_hash.
 5. **Index** — SQLite stores chunks, embeddings, call graph edges, and type dependency edges. HNSW provides fast approximate nearest-neighbor search. FTS5 enables keyword matching.
 6. **Search** — Hybrid RRF (Reciprocal Rank Fusion) combines semantic similarity with keyword matching. Optional cross-encoder re-ranking for highest accuracy.
@@ -720,7 +720,7 @@ Both splits are ±2-3pp noisy on a single trial; quote both when comparing confi
 
 ## Environment Variables
 
-120 knobs total. Quick index by domain (everything is searchable in the table below):
+Quick index by domain (everything is searchable in the table below):
 
 - **Trust / injection defence** — `CQS_TRUST_DELIMITERS`, `CQS_SUMMARY_VALIDATION`
 - **Retrieval & search** — `CQS_RRF_K`, `CQS_TYPE_BOOST`, `CQS_SPLADE_ALPHA*`, `CQS_RERANK*`, `CQS_RERANKER_*`, `CQS_CENTROID_*`, `CQS_MMR_LAMBDA`, `CQS_FORCE_BASE_INDEX`, `CQS_DISABLE_BASE_INDEX`, `CQS_QUERY_CACHE_*`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,7 +44,7 @@ cqs cannot reliably distinguish a legitimate doc comment from a malicious one. D
 | **Project source code** | Comments, strings, doc blocks containing injection payloads (committed by a contributor or embedded by an upstream dependency) | Yes — survives until removed from source |
 | **Reference content** (`cqs ref add`) | Third-party code indexed for cross-project search; less curated than the user's own code, blended into search results without an explicit trust signal | Yes — survives until ref is removed |
 | **Shared notes** (`docs/notes.toml`) | A cloned repo can ship committed notes that bias rankings and surface in agent context. `audit-mode` mitigates ranking influence at runtime, but not the first-encounter case | Yes — survives in the indexed repo |
-| **LLM-generated summaries** (`cqs index --llm-summaries`) | Claude is prompted with chunk content; a poisoned chunk can produce a summary that contains injection text. The summary text is cached in the `llm_summaries` table keyed by `(content_hash, purpose)` per `src/schema.sql:180-187`; the post-summary embedding flows through the normal `embeddings_cache.db` (purpose `embedding`, the same purpose served to search) and is replayed to downstream agents | Yes — cached in `llm_summaries` table + `embeddings_cache.db` |
+| **LLM-generated summaries** (`cqs index --llm-summaries`) | Claude is prompted with chunk content; a poisoned chunk can produce a summary that contains injection text. The summary text is cached in the `llm_summaries` table keyed by `(content_hash, purpose)` (search for `CREATE TABLE IF NOT EXISTS llm_summaries` in `src/schema.sql`); the post-summary embedding flows through the normal `embeddings_cache.db` (purpose `embedding`, the same purpose served to search) and is replayed to downstream agents | Yes — cached in `llm_summaries` table + `embeddings_cache.db` |
 | **Doc-comment generation** (`cqs index --llm-summaries --improve-docs`) | LLM output is **written back to source files in place**. A poisoned chunk can produce a doc comment that lands in the user's repo on commit | **Yes — commits the LLM's output into git** |
 | **Search result blending** | RRF merges chunks across project + references; the consuming agent sees a single ranked list with no in-protocol trust signal distinguishing user code from third-party content | Yes — every query |
 
@@ -107,9 +107,9 @@ No other network requests are made. Without `--llm-summaries` or `export-model`,
 | Path | Purpose | When |
 |------|---------|------|
 | Project source files | Parsing and embedding | `cqs index`, `cqs watch` |
-| `.cqs/index.db` | SQLite database | All operations |
-| `.cqs/index.hnsw.*` | HNSW vector index files | Search operations |
-| `.cqs/index_base.hnsw.*` | Base (non-enriched) HNSW index | Search operations (Phase 5 dual routing) |
+| `.cqs/slots/<name>/index.db` | SQLite database (per-slot, PR #1105). Pre-migration projects may still see the legacy `.cqs/index.db`. | All operations |
+| `.cqs/slots/<name>/index.hnsw.*` | HNSW vector index files (per-slot) | Search operations |
+| `.cqs/slots/<name>/index_base.hnsw.*` | Base (non-enriched) HNSW index (per-slot) | Search operations (Phase 5 dual routing) |
 | `.cqs/splade.index.bin` | SPLADE sparse inverted index | Search operations (`--splade` or routed cross-language) |
 | `docs/notes.toml` | Developer notes | Search, `cqs read` |
 | `~/.cache/huggingface/` | ML model cache | Embedding operations |
@@ -125,9 +125,9 @@ No other network requests are made. Without `--llm-summaries` or `export-model`,
 | Path | Purpose | When |
 |------|---------|------|
 | `.cqs/` directory | Index storage | `cqs init` |
-| `.cqs/index.db` | SQLite database | `cqs index`, note operations |
-| `.cqs/index.hnsw.*` | HNSW vector index + checksums | `cqs index` |
-| `.cqs/index_base.hnsw.*` | Base HNSW index + checksums | `cqs index` |
+| `.cqs/slots/<name>/index.db` | SQLite database (per-slot, PR #1105). Pre-migration projects may still see the legacy `.cqs/index.db`. | `cqs index`, note operations |
+| `.cqs/slots/<name>/index.hnsw.*` | HNSW vector index + checksums (per-slot) | `cqs index` |
+| `.cqs/slots/<name>/index_base.hnsw.*` | Base HNSW index + checksums (per-slot) | `cqs index` |
 | `.cqs/splade.index.bin` | SPLADE sparse inverted index | `cqs index` (with `CQS_SPLADE_MODEL` set), lazy rebuild on first `--splade` query |
 | `.cqs/index.lock` | Process lock file | `cqs watch` |
 | `.cqs/audit-mode.json` | Audit mode state (on/off, expiry) | `cqs audit-mode on`, `cqs audit-mode off` |
@@ -240,7 +240,7 @@ When the user passes a path on the command line, cqs canonicalizes it (`dunce::c
 
 ## Index Storage
 
-- Stored in `.cqs/index.db` (SQLite with WAL mode)
+- Stored in `.cqs/slots/<name>/index.db` (SQLite with WAL mode; PR #1105 introduced per-slot layout, pre-migration projects may still see the legacy `.cqs/index.db`)
 - Contains: code chunks, embeddings (1024-dim vectors for default BGE-large), file metadata
 - Add `.cqs/` to `.gitignore` to avoid committing
 - Database is **not encrypted** - it contains your code

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Features
 //!
-//! - **Semantic search**: Hybrid RRF (keyword + vector) with configurable embedding models (BGE-large default; E5-base, nomic-coderank-137M, and custom ONNX presets). 90.9% Recall@1 on 296-query expanded eval.
+//! - **Semantic search**: Hybrid RRF (keyword + vector) with configurable embedding models (BGE-large default; bge-large-ft, E5-base, v9-200k, nomic-coderank, embeddinggemma-300m, and custom ONNX presets). High recall on the curated fixture eval; see README.md#retrieval-quality for current numbers.
 //! - **Call graphs**: Callers, callees, transitive impact, shortest-path tracing between functions
 //! - **Impact analysis**: What breaks if you change X? Callers + affected tests + risk scoring
 //! - **Type dependencies**: Who uses this type? What types does this function use?

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -9,7 +9,10 @@
 //! - `axum` HTTP server reading from a `Store<ReadOnly>`
 //! - Frontend is one HTML page + Cytoscape.js, all embedded in the binary
 //!   via `include_str!` / `include_bytes!`
-//! - No auth, no WebSocket, no live updates — single-user local exploration
+//! - Per-launch 256-bit auth token gates every request (#1118 / SEC-7);
+//!   3 credential channels (Bearer / cookie / `?token=` query); `--no-auth`
+//!   requires `NoAuthAcknowledgement` proof token. No WebSocket, no live
+//!   updates — single-user local exploration
 //!
 //! # Threading
 //! `run_server` is async-friendly but synchronous from the caller's


### PR DESCRIPTION
## Summary

Fixes 11 of 13 P1 documentation findings from the v1.33.0 audit (the **lying-docs cluster** in `docs/audit-triage.md`). All edits target docs that disagreed with the code — per the "Docs Lying Is P1" project rule.

| Finding | File | Fix |
|---------|------|-----|
| P1-1, P1-2 | `src/lib.rs:9` | Drop stale 90.9% R@1 claim; list all 6 current presets |
| P1-3 | `README.md:672` | Same preset gap in "How It Works" |
| P1-4 | `README.md:723` | Drop "120 knobs" (table has ~158, drifts every release) |
| P1-7 | `SECURITY.md:110-111, 128-129, 243` | Read/Write tables + Index Storage → `.cqs/slots/<name>/...` (#1105 layout) |
| P1-8 | `src/serve/mod.rs:12` | Replace "No auth" — auth has been required since #1118 / SEC-7 |
| P1-9 | `CONTRIBUTING.md:313` | Drop nonexistent `LlmProvider` type |
| P1-10 | `Cargo.toml:245-247, 116` | Delete dead `encrypt = ["keyring"]` feature + unused `keyring` dep |
| P1-11 | `CHANGELOG.md` | Add Added entries for #1301 + #1278; Fixed entry for #1305 family |
| P1-12 | `SECURITY.md:47` | Drop brittle `schema.sql:180-187` line range; use grep pattern |
| P1-13 | `.claude/skills/cqs-bootstrap/SKILL.md:101` | 14 → 16 categories |

## Deferred

- **P1-5** (TL;DR R@5=73.4% vs per-split avg 71.1%): real mismatch but requires a fresh eval run to produce coherent numbers.
- **P1-6** (fixture table missing bge-large-ft / embeddinggemma-300m rows): same — needs fresh measurements.

## Test plan

- [x] `cargo check --features cuda-index` — passes (1m10s, no warnings)
- [x] `cargo fmt --check` clean
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
