### PR TITLE
refactor(store): SQLite legacy batch sizes → max_rows_per_statement (P1-35..P1-39)

### DIFF
--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -258,12 +258,13 @@ pub(super) struct ChunkSnapshot {
 }
 
 /// Snapshot existing content_hash + parser_version before INSERT overwrites
-/// them. Batched in groups of 500 to stay within SQLite's 999-param limit.
+/// them. Single-bind IN-list batched at the modern SQLite variable limit.
 pub(super) async fn snapshot_content_hashes(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     chunks: &[(Chunk, Embedding)],
 ) -> Result<HashMap<String, ChunkSnapshot>, StoreError> {
-    const HASH_BATCH: usize = 500;
+    use crate::store::helpers::sql::max_rows_per_statement;
+    const HASH_BATCH: usize = max_rows_per_statement(1);
     let mut old: HashMap<String, ChunkSnapshot> = HashMap::new();
     let chunk_ids: Vec<&str> = chunks.iter().map(|(c, _)| c.id.as_str()).collect();
     for id_batch in chunk_ids.chunks(HASH_BATCH) {

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -878,7 +878,10 @@ impl Store<ReadWrite> {
                     query.execute(&mut *tx).await?;
                 }
 
-                const INSERT_BATCH: usize = 300;
+                // 3 binds per row → modern SQLite variable limit yields
+                // ~10822 rows per statement (was hardcoded 300).
+                use crate::store::helpers::sql::max_rows_per_statement;
+                const INSERT_BATCH: usize = max_rows_per_statement(3);
                 for batch in calls.chunks(INSERT_BATCH) {
                     let mut query_builder: sqlx::QueryBuilder<sqlx::Sqlite> =
                         sqlx::QueryBuilder::new(

--- a/src/store/chunks/embeddings.rs
+++ b/src/store/chunks/embeddings.rs
@@ -5,12 +5,14 @@ use std::collections::HashMap;
 use sqlx::Row;
 
 use crate::embedder::Embedding;
+use crate::store::helpers::sql::max_rows_per_statement;
 use crate::store::helpers::{bytes_to_embedding, StoreError};
 use crate::store::Store;
 
 impl<Mode> Store<Mode> {
     /// Get embeddings for chunks with matching content hashes (batch lookup).
-    /// Batches queries in groups of 500 to stay within SQLite's parameter limit (~999).
+    /// Single-bind IN-list; batches at the modern SQLite variable limit
+    /// (~32466 rows per statement via `max_rows_per_statement(1)`).
     pub fn get_embeddings_by_hashes(
         &self,
         hashes: &[&str],
@@ -21,7 +23,7 @@ impl<Mode> Store<Mode> {
             return Ok(HashMap::new());
         }
 
-        const BATCH_SIZE: usize = 500;
+        const BATCH_SIZE: usize = max_rows_per_statement(1);
         let dim = self.dim;
         let mut result = HashMap::new();
 
@@ -100,7 +102,7 @@ impl<Mode> Store<Mode> {
             return Ok(Vec::new());
         }
 
-        const BATCH_SIZE: usize = 500;
+        const BATCH_SIZE: usize = max_rows_per_statement(1);
         let dim = self.dim;
         let mut result = Vec::new();
 

--- a/src/store/chunks/query.rs
+++ b/src/store/chunks/query.rs
@@ -8,6 +8,7 @@ use sqlx::Row;
 use crate::embedder::Embedding;
 use crate::nl::normalize_for_fts;
 use crate::parser::{ChunkType, Language};
+use crate::store::helpers::sql::max_rows_per_statement;
 use crate::store::helpers::{
     bytes_to_embedding, clamp_line_number, ChunkIdentity, ChunkRow, ChunkSummary, IndexStats,
     StoreError,
@@ -185,7 +186,7 @@ impl<Mode> Store<Mode> {
         self.rt.block_on(async {
             let mut result: HashMap<String, Vec<ChunkSummary>> = HashMap::new();
 
-            const BATCH_SIZE: usize = 500;
+            const BATCH_SIZE: usize = max_rows_per_statement(1);
             for batch in origins.chunks(BATCH_SIZE) {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
                 let sql = format!(
@@ -215,7 +216,7 @@ impl<Mode> Store<Mode> {
 
     /// Batch-fetch chunks by multiple function names.
     /// Returns a map of name -> Vec<ChunkSummary> for all found names.
-    /// Batches queries in groups of 500 to stay within SQLite's parameter limit (~999).
+    /// Single-bind IN-list batched at the modern SQLite variable limit.
     /// Used by `cqs related` to avoid N+1 `get_chunks_by_name` calls.
     pub fn get_chunks_by_names_batch(
         &self,
@@ -230,7 +231,7 @@ impl<Mode> Store<Mode> {
         self.rt.block_on(async {
             let mut result: HashMap<String, Vec<ChunkSummary>> = HashMap::new();
 
-            const BATCH_SIZE: usize = 500;
+            const BATCH_SIZE: usize = max_rows_per_statement(1);
             for batch in names.chunks(BATCH_SIZE) {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
                 let sql = format!(
@@ -316,7 +317,7 @@ impl<Mode> Store<Mode> {
             return Ok(HashMap::new());
         }
 
-        const BATCH_SIZE: usize = 500;
+        const BATCH_SIZE: usize = max_rows_per_statement(1);
         let dim = self.dim;
         let mut result = HashMap::new();
 

--- a/src/store/chunks/staleness.rs
+++ b/src/store/chunks/staleness.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use crate::store::helpers::sql::max_rows_per_statement;
 use crate::store::helpers::{StaleFile, StaleReport, StoreError};
 use crate::store::{ReadWrite, Store};
 
@@ -309,10 +310,10 @@ impl Store<ReadWrite> {
                 return Ok(0);
             }
 
-            // Batch delete in chunks of 100 (SQLite has ~999 param limit).
-            // Single transaction wraps ALL batches — partial prune on crash
-            // would leave the index inconsistent with disk.
-            const BATCH_SIZE: usize = 100;
+            // Single-bind IN-list batched at the modern SQLite variable
+            // limit. Single transaction wraps ALL batches — partial prune
+            // on crash would leave the index inconsistent with disk.
+            const BATCH_SIZE: usize = max_rows_per_statement(1);
             let mut deleted = 0u32;
 
             for batch in missing.chunks(BATCH_SIZE) {
@@ -430,8 +431,9 @@ impl Store<ReadWrite> {
                 .map(|(origin,)| origin)
                 .collect();
 
-            // 2a. Delete chunks for missing files (batched for SQLite param limit)
-            const BATCH_SIZE: usize = 100;
+            // 2a. Delete chunks for missing files (single-bind IN-list,
+            // batched at the modern SQLite variable limit).
+            const BATCH_SIZE: usize = max_rows_per_statement(1);
             let mut pruned_chunks = 0u32;
 
             for batch in missing.chunks(BATCH_SIZE) {
@@ -597,7 +599,7 @@ impl Store<ReadWrite> {
             // Phase 2: batched delete in the SAME transaction started above.
             // Same shape as `prune_missing` so a partial prune on crash
             // leaves the index consistent with the remaining rows in `chunks`.
-            const BATCH_SIZE: usize = 100;
+            const BATCH_SIZE: usize = max_rows_per_statement(1);
             let mut deleted = 0u32;
 
             for batch in ignored.chunks(BATCH_SIZE) {

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -181,7 +181,9 @@ impl Store<ReadWrite> {
                 .execute(&mut *tx)
                 .await?;
 
-            const INSERT_BATCH: usize = 249;
+            // 4 binds per row (chunk_id, target_type_name, edge_kind, line_number);
+            // mirrors `replace_type_edges_in_tx_for_chunks` above.
+            const INSERT_BATCH: usize = max_rows_per_statement(4);
             for batch in type_refs.chunks(INSERT_BATCH) {
                 let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
                     "INSERT INTO type_edges (source_chunk_id, target_type_name, edge_kind, line_number) ",


### PR DESCRIPTION
## Summary

Eliminates the SQLite **legacy batch-size cluster** (P1-35..P1-39 in `docs/audit-triage.md`) — 11 sites across 6 files that hardcoded batch sizes against the pre-2020 SQLite 999-variable parameter limit.

All sites now use the centralized helper `max_rows_per_statement(N)` from `src/store/helpers/sql.rs`, which yields ~32466 rows per statement at single-bind queries (vs. the legacy 100/249/300/500/249) and tracks the modern 32766-variable limit.

| Finding | File:Line | Old | New |
|---------|-----------|-----|-----|
| P1-35 (SHL-V1.33-2) | `src/store/types.rs:184` | `INSERT_BATCH=249` | `max_rows_per_statement(4)` (~8116) |
| P1-36 (SHL-V1.33-3) | `src/store/chunks/embeddings.rs:24, 103` | `BATCH_SIZE=500` ×2 | `max_rows_per_statement(1)` (~32466) |
| P1-36 (SHL-V1.33-3) | `src/store/chunks/query.rs:188, 233, 319` | `BATCH_SIZE=500` ×3 | `max_rows_per_statement(1)` |
| P1-37 (SHL-V1.33-4) | `src/store/chunks/staleness.rs:315, 434, 600` | `BATCH_SIZE=100` ×3 | `max_rows_per_statement(1)` |
| P1-38 (SHL-V1.33-5) | `src/store/chunks/crud.rs:881` | `INSERT_BATCH=300` | `max_rows_per_statement(3)` (~10822) |
| P1-39 (SHL-V1.33-6) | `src/store/chunks/async_helpers.rs:266` | `HASH_BATCH=500` | `max_rows_per_statement(1)` |

Stale `(~999)` comments dropped where they appeared.

## Impact

Pure throughput improvement on the indexing / pruning hot paths:

- **Reindex**: `INSERT INTO calls` now batches at ~10800 rows/stmt instead of 300 — a 36× round-trip reduction.
- **Hash lookups** (`get_embeddings_by_hashes`, `snapshot_content_hashes`, etc.): single-bind IN-list now batches at ~32466 rows/stmt instead of 500 — 65× reduction.
- **Prune** (`prune_missing`, etc.): same 324× reduction.

No behaviour change beyond throughput.

## Test plan

- [x] `cargo check --features cuda-index` clean (9.5s)
- [x] `cargo clippy --features cuda-index --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI: full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
