### PR TITLE
fix(hnsw): treat missing checksum-manifest file as hard failure (P2-20 / DS-V1.33-3)

### DIFF
--- a/src/hnsw/persist.rs
+++ b/src/hnsw/persist.rs
@@ -144,43 +144,57 @@ pub fn verify_hnsw_checksums(dir: &Path, basename: &str) -> Result<(), HnswError
                 continue;
             }
             let path = dir.join(format!("{}.{}", basename, ext));
-            if path.exists() {
-                // Stream file through blake3 hasher to avoid loading entire file into memory
-                let file = std::fs::File::open(&path).map_err(|e| {
-                    tracing::warn!(
-                        error = %e,
-                        path = %path.display(),
-                        kind = ?e.kind(),
-                        "verify_hnsw_checksums IO failure"
-                    );
-                    HnswError::Internal(format!(
-                        "Failed to open {} for checksum: {}",
-                        path.display(),
-                        e
-                    ))
-                })?;
-                let mut hasher = blake3::Hasher::new();
-                std::io::copy(&mut std::io::BufReader::new(file), &mut hasher).map_err(|e| {
-                    tracing::warn!(
-                        error = %e,
-                        path = %path.display(),
-                        kind = ?e.kind(),
-                        "verify_hnsw_checksums IO failure"
-                    );
-                    HnswError::Internal(format!(
-                        "Failed to read {} for checksum: {}",
-                        path.display(),
-                        e
-                    ))
-                })?;
-                let actual = hasher.finalize().to_hex().to_string();
-                if actual != expected {
-                    return Err(HnswError::ChecksumMismatch {
-                        file: path.display().to_string(),
-                        expected: expected.to_string(),
-                        actual,
-                    });
-                }
+            // P1 / DS-V1.33-3: a missing file referenced by the checksum
+            // manifest is a hard failure, not a skip. The previous
+            // `if path.exists() { ... }` swallowed exactly the partial-save
+            // case we want to catch — a crash between writing the manifest
+            // and renaming the graph/data files into place left the
+            // verifier returning Ok, then the load path fell into
+            // `hnsw_rs::file_load` against a missing file. The
+            // `HNSW_EXTENSIONS` whitelist at the top of the loop already
+            // gates which paths can reach this branch, so the strict check
+            // is safe.
+            if !path.exists() {
+                return Err(HnswError::Internal(format!(
+                    "HNSW checksum manifest references missing file: {} (partial save?)",
+                    path.display()
+                )));
+            }
+            // Stream file through blake3 hasher to avoid loading entire file into memory
+            let file = std::fs::File::open(&path).map_err(|e| {
+                tracing::warn!(
+                    error = %e,
+                    path = %path.display(),
+                    kind = ?e.kind(),
+                    "verify_hnsw_checksums IO failure"
+                );
+                HnswError::Internal(format!(
+                    "Failed to open {} for checksum: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+            let mut hasher = blake3::Hasher::new();
+            std::io::copy(&mut std::io::BufReader::new(file), &mut hasher).map_err(|e| {
+                tracing::warn!(
+                    error = %e,
+                    path = %path.display(),
+                    kind = ?e.kind(),
+                    "verify_hnsw_checksums IO failure"
+                );
+                HnswError::Internal(format!(
+                    "Failed to read {} for checksum: {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+            let actual = hasher.finalize().to_hex().to_string();
+            if actual != expected {
+                return Err(HnswError::ChecksumMismatch {
+                    file: path.display().to_string(),
+                    expected: expected.to_string(),
+                    actual,
+                });
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes **P2-20 / DS-V1.33-3** in `docs/audit-triage.md` — `verify_hnsw_checksums` returning `Ok` for partial saves.

The previous behaviour walked the lines of `index.hnsw.checksum`, parsed `ext:hash`, then `if path.exists()` — and silently skipped when the file was missing. If a save crashed after writing the manifest and `hnsw.ids` but before `hnsw.graph` / `hnsw.data` were renamed into place, the verifier would iterate the four checksum lines, see two paths missing, *skip* them, hash the present `hnsw.ids` successfully, and return `Ok(())`. Loading would then fall into `hnsw_rs::file_load` against a missing file — a confusing late-stage error or worse, "an incomplete library write the loader can't tell apart from a fresh empty index" (per the existing module-level safety comment).

## Fix

When a checksum manifest line names a known extension (the `HNSW_EXTENSIONS` whitelist already gates which paths can reach this branch — only `hnsw.graph`, `hnsw.data`, `hnsw.ids`), treat `!path.exists()` as a hard `HnswError::Internal` instead of `continue`.

```rust
if !path.exists() {
    return Err(HnswError::Internal(format!(
        "HNSW checksum manifest references missing file: {} (partial save?)",
        path.display()
    )));
}
```

Recovery is the existing `cqs index --force` path.

## Test plan

- [x] All 19 `hnsw::persist::tests` pass against the stricter check.
- [x] `cargo check --features cuda-index` clean.
- [ ] CI: full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
