### PR TITLE
fix(audit): #1245 8 P1 algorithm-correctness fixes from v1.33.0 audit

### DIFF
--- a/src/hnsw/mod.rs
+++ b/src/hnsw/mod.rs
@@ -65,12 +65,41 @@ const DEFAULT_M: usize = 24;
 const DEFAULT_EF_CONSTRUCTION: usize = 200;
 const DEFAULT_EF_SEARCH: usize = 100;
 
+/// Parse an env-var-overridable HNSW knob, validating that the value is `>= 1`.
+/// AC-V1.33-7: a value of `0` (or unparseable garbage) produces a degenerate
+/// graph; warn and fall back to the default.
+fn parse_hnsw_env_knob(env_name: &str, default: usize) -> usize {
+    match std::env::var(env_name) {
+        Ok(raw) => match raw.parse::<usize>() {
+            Ok(n) if n >= 1 => n,
+            Ok(n) => {
+                tracing::warn!(
+                    env = env_name,
+                    raw = %raw,
+                    parsed = n,
+                    fallback = default,
+                    "HNSW env knob must be >= 1 — using default"
+                );
+                default
+            }
+            Err(e) => {
+                tracing::warn!(
+                    env = env_name,
+                    raw = %raw,
+                    error = %e,
+                    fallback = default,
+                    "HNSW env knob not parseable as usize — using default"
+                );
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
 /// M parameter — connections per node. Override with `CQS_HNSW_M`.
 pub(crate) fn max_nb_connection() -> usize {
-    let m: usize = std::env::var("CQS_HNSW_M")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(DEFAULT_M);
+    let m = parse_hnsw_env_knob("CQS_HNSW_M", DEFAULT_M);
     if m != DEFAULT_M {
         tracing::info!(m, "CQS_HNSW_M override active");
     }
@@ -79,10 +108,7 @@ pub(crate) fn max_nb_connection() -> usize {
 
 /// Construction-time search width. Override with `CQS_HNSW_EF_CONSTRUCTION`.
 pub(crate) fn ef_construction() -> usize {
-    let ef: usize = std::env::var("CQS_HNSW_EF_CONSTRUCTION")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(DEFAULT_EF_CONSTRUCTION);
+    let ef = parse_hnsw_env_knob("CQS_HNSW_EF_CONSTRUCTION", DEFAULT_EF_CONSTRUCTION);
     if ef != DEFAULT_EF_CONSTRUCTION {
         tracing::info!(ef, "CQS_HNSW_EF_CONSTRUCTION override active");
     }
@@ -92,10 +118,7 @@ pub(crate) fn ef_construction() -> usize {
 /// Search width for queries (higher = more accurate but slower).
 /// Override with `CQS_HNSW_EF_SEARCH`.
 pub(crate) fn ef_search() -> usize {
-    let ef: usize = std::env::var("CQS_HNSW_EF_SEARCH")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(DEFAULT_EF_SEARCH);
+    let ef = parse_hnsw_env_knob("CQS_HNSW_EF_SEARCH", DEFAULT_EF_SEARCH);
     if ef != DEFAULT_EF_SEARCH {
         tracing::info!(ef, "CQS_HNSW_EF_SEARCH override active");
     }

--- a/src/parser/l5x.rs
+++ b/src/parser/l5x.rs
@@ -121,7 +121,8 @@ fn parse_st_regions(
                     content,
                     file: path.to_path_buf(),
                     line_start: region.line_start,
-                    line_end: region.line_start + line_count,
+                    // AC-V1.33-2: line_end is inclusive 1-indexed (see chunk.rs:93)
+                    line_end: region.line_start + line_count.saturating_sub(1),
                     language: st_lang,
                     signature: sig,
                     doc: None,

--- a/src/search/mmr.rs
+++ b/src/search/mmr.rs
@@ -144,10 +144,23 @@ fn similarity(a: &MmrCandidate<'_>, b: &MmrCandidate<'_>) -> f32 {
 /// want to silently change production search behavior. Opt-in via env
 /// or `SearchFilter.mmr_lambda`.
 pub(crate) fn mmr_lambda_from_env() -> Option<f32> {
-    std::env::var("CQS_MMR_LAMBDA")
-        .ok()
-        .and_then(|s| s.parse::<f32>().ok())
-        .map(|v| v.clamp(0.0, 1.0))
+    let raw = std::env::var("CQS_MMR_LAMBDA").ok()?;
+    match raw.parse::<f32>() {
+        // AC-V1.33-10: reject NaN/Inf so they don't slip through `clamp`
+        // (clamp propagates NaN). Downstream checks `lambda < 1.0`, which
+        // returns false for NaN, silently disabling MMR.
+        Ok(v) if v.is_finite() => Some(v.clamp(0.0, 1.0)),
+        Ok(v) => {
+            tracing::warn!(
+                env = "CQS_MMR_LAMBDA",
+                raw = %raw,
+                parsed = v,
+                "CQS_MMR_LAMBDA parsed to non-finite — MMR disabled"
+            );
+            None
+        }
+        Err(_) => None,
+    }
 }
 
 #[cfg(test)]

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -154,7 +154,13 @@ impl<Mode> Store<Mode> {
 
         self.rt.block_on(async {
             let fsql = build_filter_sql(filter);
-            let semantic_limit = if fsql.use_rrf { limit * 3 } else { limit };
+            // AC-V1.33-3: saturating mul matches sibling paths (lines 505, 696);
+            // overflow on pathological `limit` would panic in debug.
+            let semantic_limit = if fsql.use_rrf {
+                limit.saturating_mul(3)
+            } else {
+                limit
+            };
             let need_name = fsql.use_hybrid || filter.enable_demotion;
 
             // Compile glob pattern once outside the loop (not per-chunk).
@@ -353,7 +359,8 @@ impl<Mode> Store<Mode> {
             let semantic_ids: Vec<&str> = scored.iter().map(|(id, _)| id.as_str()).collect();
             // Request extra candidates from RRF to compensate for parent dedup
             // filtering below — dedup can drop results, leaving fewer than `limit`.
-            Self::rrf_fuse(&semantic_ids, &fts_ids, limit * 2)
+            // AC-V1.33-3: saturating mul to match sibling paths.
+            Self::rrf_fuse(&semantic_ids, &fts_ids, limit.saturating_mul(2))
         } else {
             scored.truncate(limit);
             scored

--- a/src/search/scoring/filter.rs
+++ b/src/search/scoring/filter.rs
@@ -8,9 +8,10 @@ use super::name_match::is_name_like_query;
 /// Extract file path from a chunk ID.
 /// Standard format: `"path:line_start:hash_prefix"` (3 segments from right)
 /// Windowed format: `"path:line_start:hash_prefix:wN"` (4 segments)
-/// The hash_prefix is always 8 hex chars. Windowed chunk IDs append `:wN` where
-/// N is a small integer (0-99). We detect windowed IDs by checking if the last
-/// segment starts with 'w' followed by digits.
+/// Markdown table-window format: `"path:line_start:hash_prefix:tNwM"` (4 segments,
+/// emitted by `parser/markdown/tables.rs::emit_table_window`)
+/// The hash_prefix is always 8 hex chars. Windowed chunk IDs append a window
+/// suffix: either `wN` (generic windowed chunks) or `tNwM` (markdown tables).
 pub(crate) fn extract_file_from_chunk_id(id: &str) -> &str {
     // Strip last segment
     let Some(last_colon) = id.rfind(':') else {
@@ -20,17 +21,11 @@ pub(crate) fn extract_file_from_chunk_id(id: &str) -> &str {
 
     // Determine how many segments to strip from the right:
     // - Standard: 2 (hash_prefix, line_start)
-    // - Windowed: 3 (wN, hash_prefix, line_start)
-    // Window suffix format: "w0", "w1", ..., "w99"
-    let segments_to_strip = if !last_seg.is_empty()
-        && last_seg.starts_with('w')
-        && last_seg.len() <= 3
-        && last_seg[1..].bytes().all(|b| b.is_ascii_digit())
-    {
-        3
-    } else {
-        2
-    };
+    // - Windowed: 3 (wN or tNwM, hash_prefix, line_start)
+    // Window suffix formats:
+    //   - "w0", "w1", ..., "w99" (generic)
+    //   - "t0w0", "t1w3", ..., "tNwM" (markdown table windows)
+    let segments_to_strip = if is_window_suffix(last_seg) { 3 } else { 2 };
 
     let mut end = id.len();
     for _ in 0..segments_to_strip {
@@ -41,6 +36,37 @@ pub(crate) fn extract_file_from_chunk_id(id: &str) -> &str {
         }
     }
     &id[..end]
+}
+
+/// Returns `true` if `seg` looks like a window suffix produced by the parser:
+/// either `wN` (generic windowed chunks) or `tNwM` (markdown table windows
+/// from `parser/markdown/tables.rs::emit_table_window`).
+fn is_window_suffix(seg: &str) -> bool {
+    let bytes = seg.as_bytes();
+    // Generic: "wN" — 'w' followed by 1+ ASCII digits, total length ≤ 3
+    if bytes.first() == Some(&b'w')
+        && bytes.len() >= 2
+        && bytes.len() <= 3
+        && bytes[1..].iter().all(u8::is_ascii_digit)
+    {
+        return true;
+    }
+    // Table-window: "tNwM" — 't' + digits + 'w' + digits
+    if bytes.first() == Some(&b't') && bytes.len() >= 4 {
+        // Find the 'w' separator after the t-digits
+        let mut i = 1;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        // Need at least one digit after 't', then 'w', then at least one digit
+        if i >= 2 && i < bytes.len() && bytes[i] == b'w' {
+            let rest = &bytes[i + 1..];
+            if !rest.is_empty() && rest.iter().all(u8::is_ascii_digit) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Compile a glob pattern into a matcher, logging and ignoring invalid patterns.
@@ -213,6 +239,41 @@ mod tests {
             extract_file_from_chunk_id("src/foo.rs:10:deadbeef"),
             "src/foo.rs"
         );
+    }
+
+    #[test]
+    fn test_extract_file_markdown_table_window() {
+        // AC-V1.33-1: markdown table windows produce `:tNwM` suffix
+        // (from src/parser/markdown/tables.rs::emit_table_window)
+        assert_eq!(
+            extract_file_from_chunk_id("docs/x.md:10:abc12345:t0w3"),
+            "docs/x.md"
+        );
+        assert_eq!(
+            extract_file_from_chunk_id("docs/x.md:42:abc12345:t1w0"),
+            "docs/x.md"
+        );
+        assert_eq!(
+            extract_file_from_chunk_id("docs/foo/bar.md:5:cafebabe:t12w99"),
+            "docs/foo/bar.md"
+        );
+    }
+
+    #[test]
+    fn test_is_window_suffix_recognizes_both_formats() {
+        // Generic wN
+        assert!(is_window_suffix("w0"));
+        assert!(is_window_suffix("w99"));
+        // Table tNwM
+        assert!(is_window_suffix("t0w0"));
+        assert!(is_window_suffix("t12w99"));
+        // Negative: hash prefixes, plain hex
+        assert!(!is_window_suffix("deadbeef"));
+        assert!(!is_window_suffix("abc12345"));
+        assert!(!is_window_suffix("w")); // no digits
+        assert!(!is_window_suffix("t1w")); // no digits after w
+        assert!(!is_window_suffix("tw0")); // no digits after t
+        assert!(!is_window_suffix(""));
     }
 
     #[test]

--- a/src/search/scoring/knob.rs
+++ b/src/search/scoring/knob.rs
@@ -193,7 +193,20 @@ pub fn resolve_knob(name: &str) -> f32 {
 
 fn resolve_uncached(knob: &ScoringKnob) -> f32 {
     if let Some(&v) = CONFIG_OVERRIDES.get().and_then(|m| m.get(knob.name)) {
-        return v.clamp(knob.min, knob.max);
+        // AC-V1.33-4: match env-path validation — reject NaN/Inf and out-of-range
+        // before the value can flow into BM25/RRF math (`f32::clamp` propagates NaN).
+        if v.is_finite() && v >= knob.min && v <= knob.max {
+            return v;
+        }
+        tracing::warn!(
+            knob = knob.name,
+            value = v,
+            min = knob.min,
+            max = knob.max,
+            fallback = knob.default,
+            "scoring knob config override out of range or non-finite — using default"
+        );
+        return knob.default;
     }
     if let Some(env_name) = knob.env_var {
         if let Ok(raw) = std::env::var(env_name) {

--- a/src/search/scoring/name_match.rs
+++ b/src/search/scoring/name_match.rs
@@ -20,10 +20,6 @@ const NAME_TOKEN_STACK: usize = 16;
 /// semantic relevance.
 pub(crate) fn is_name_like_query(query: &str) -> bool {
     let words: Vec<&str> = query.split_whitespace().collect();
-    // Single token or two-token queries are likely identifiers
-    if words.len() <= 2 {
-        return true;
-    }
     // NL indicators: common function words that never appear in identifiers
     const NL_WORDS: &[&str] = &[
         "the",
@@ -59,12 +55,19 @@ pub(crate) fn is_name_like_query(query: &str) -> bool {
         "find",
         "search",
     ];
+    // AC-V1.33-6: NL_WORDS check must run BEFORE the ≤2-token short-circuit
+    // so that "how are", "what is", "do that", etc. are correctly classified
+    // as natural language even at small lengths.
     let lower = query.to_lowercase();
     let lower_words: Vec<&str> = lower.split_whitespace().collect();
     for w in &lower_words {
         if NL_WORDS.contains(w) {
             return false;
         }
+    }
+    // Single token or two-token queries with no NL indicators are likely identifiers
+    if words.len() <= 2 {
+        return true;
     }
     // 3+ words with no NL indicators — still likely NL if all lowercase
     // (identifiers are usually camelCase or snake_case)

--- a/src/store/helpers/search_filter.rs
+++ b/src/store/helpers/search_filter.rs
@@ -155,6 +155,24 @@ impl SearchFilter {
             ));
         }
 
+        // AC-V1.33-11: include_types ∩ exclude_types is unsatisfiable —
+        // an `IN (..) AND NOT IN (..)` with overlapping sets always returns zero
+        // rows for the overlapping types, which silently drops results instead
+        // of telling the caller their filter is contradictory.
+        if let (Some(includes), Some(excludes)) = (&self.include_types, &self.exclude_types) {
+            let overlap: Vec<String> = includes
+                .iter()
+                .filter(|ct| excludes.contains(ct))
+                .map(|ct| ct.to_string())
+                .collect();
+            if !overlap.is_empty() {
+                return Err(format!(
+                    "include_types and exclude_types both contain: {} — filter is unsatisfiable",
+                    overlap.join(", ")
+                ));
+            }
+        }
+
         Ok(())
     }
 }
@@ -311,5 +329,44 @@ mod tests {
             ..Default::default()
         };
         assert!(filter.validate().is_ok());
+    }
+
+    // AC-V1.33-11: include_types ∩ exclude_types overlap detection
+    #[test]
+    fn test_search_filter_include_exclude_overlap_rejected() {
+        use crate::parser::ChunkType;
+        let filter = SearchFilter {
+            include_types: Some(vec![ChunkType::Function, ChunkType::Method]),
+            exclude_types: Some(vec![ChunkType::Function]),
+            ..Default::default()
+        };
+        let result = filter.validate();
+        assert!(
+            result.is_err(),
+            "Overlapping include/exclude must be rejected"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("unsatisfiable"),
+            "Error should mention unsatisfiability: {err}"
+        );
+        assert!(
+            err.to_lowercase().contains("function"),
+            "Error should name the overlapping type: {err}"
+        );
+    }
+
+    #[test]
+    fn test_search_filter_include_exclude_disjoint_ok() {
+        use crate::parser::ChunkType;
+        let filter = SearchFilter {
+            include_types: Some(vec![ChunkType::Function, ChunkType::Method]),
+            exclude_types: Some(vec![ChunkType::Test]),
+            ..Default::default()
+        };
+        assert!(
+            filter.validate().is_ok(),
+            "Disjoint include/exclude is fine"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Eight P1 algorithm-correctness fixes from the v1.33.0 audit (`docs/audit-triage.md` rows P1-40 through P1-47). Each fix is a surgical 1-3 line change — no architectural moves, no new modules. Targeted lib tests pass; lib clippy is clean.

## Findings fixed

| ID | File | Bug | Fix |
|---|---|---|---|
| **AC-V1.33-1** | `src/search/scoring/filter.rs` | `extract_file_from_chunk_id` only recognized `wN` window suffixes — markdown table windows (`tNwM`, emitted by `parser/markdown/tables.rs::emit_table_window`) fell through to the standard branch and returned `path:line` instead of `path`. Glob filters on `docs/*.md` silently dropped them. | New `is_window_suffix` helper recognizes both `wN` and `tNwM` shapes. Regression test uses the literal `docs/x.md:10:abc12345:t0w3` form. |
| **AC-V1.33-2** | `src/parser/l5x.rs:124` | Synthetic L5X routine fallback emitted `line_end = line_start + line_count`, breaking the inclusive-1-indexed convention (`src/parser/chunk.rs:93`). 3-line content got `line_end = line_start + 3` instead of `+ 2`. | `line_count.saturating_sub(1)`. |
| **AC-V1.33-3** | `src/search/query.rs:157, 359` | Brute-force scoring path used unchecked `limit * 3` / `limit * 2`. Sibling paths at lines 505, 696 already use `saturating_mul`. | Replace with `saturating_mul`. |
| **AC-V1.33-4** | `src/search/scoring/knob.rs:194-220` | Env-var path validated `is_finite` + range; config-override path only `clamp`. `f32::clamp(NaN, ..)` returns NaN, so `[scoring] rrf_k = nan` from TOML poisoned RRF / parent-boost / BM25 math. | Mirror env-path validation: reject non-finite or out-of-range with a warn, fall back to default. |
| **AC-V1.33-6** | `src/search/scoring/name_match.rs:21-75` | `is_name_like_query` short-circuited to `true` for `words.len() <= 2` *before* checking NL_WORDS. "how are", "what is", "do that" got name-boosted as identifiers. | Move NL_WORDS check above the length short-circuit. |
| **AC-V1.33-7** | `src/hnsw/mod.rs:69-103` | Three env-knob accessors (`max_nb_connection`, `ef_construction`, `ef_search`) accepted `0` and built a degenerate graph. | New `parse_hnsw_env_knob` helper validates `>= 1`, logs warn and falls back to default on out-of-range or unparseable input. |
| **AC-V1.33-10** | `src/search/mmr.rs:146-151` | `mmr_lambda_from_env` accepted NaN/Inf; `f32::clamp` propagates NaN; downstream `lambda < 1.0` returns false for NaN, silently disabling MMR. | Add `is_finite` check between parse and clamp; warn when env was set but parsed to non-finite. |
| **AC-V1.33-11** | `src/store/helpers/search_filter.rs:100-159` | `SearchFilter::validate()` did not detect `include_types ∩ exclude_types` overlap. Resulting SQL `IN (..) AND NOT IN (..)` silently excluded the overlapping types. | Compute the overlap; return `Err` naming the overlapping types when non-empty. |

## Test plan

- [x] `cargo check --features cuda-index` clean
- [x] `cargo clippy --features cuda-index --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Targeted lib tests pass: `parser::l5x` (16), `search::scoring::filter::tests` (29 incl. 2 new regression tests), `search::scoring::knob` (9), `search::scoring::name_match` (21), `hnsw::*` (53), `search::mmr` (9), `search::query` (18), `store::helpers::search_filter` (16 incl. 2 new tests for AC-V1.33-11)
- [ ] Full suite (will run as part of orchestrator CI)

## Notes

- AC-V1.33-5 (BM25 IDF formula variance) was on the audit list but is `medium` difficulty and outside this PR's scope (algorithm-easy).
- P1-41: only the synthetic-routine fallback path at line 108 was wrong; the sibling path at line 172 is already correct and was not touched.
- Regression tests are added where the audit explicitly recommends one (P1-40 round-trip, P1-47 overlap rejection); other fixes have surface too small to test cleanly without integration scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
