### PR TITLE
fix(slot): v1.33.0 audit C6 — slot migration / temp-file races

### DIFF
--- a/src/slot/mod.rs
+++ b/src/slot/mod.rs
@@ -367,7 +367,12 @@ pub fn write_slot_model(
         source: std::io::Error::new(std::io::ErrorKind::InvalidData, e),
     })?;
 
-    let tmp_path = dir.join(format!("{}.tmp", SLOT_CONFIG_FILE));
+    // DS-V1.33-2: include `crate::temp_suffix()` so concurrent writers (e.g.
+    // legacy migration in one CLI process while another `cqs slot promote`
+    // runs) each stage to their own temp file before atomic_replace, instead
+    // of racing on a fixed `slot.toml.tmp` path.
+    let suffix = crate::temp_suffix();
+    let tmp_path = dir.join(format!("{}.{:016x}.tmp", SLOT_CONFIG_FILE, suffix));
     {
         let mut f = fs::File::create(&tmp_path).map_err(|source| SlotError::Io {
             slot: slot_name.to_string(),
@@ -504,7 +509,12 @@ pub fn write_active_slot(project_cqs_dir: &Path, slot_name: &str) -> Result<(), 
     }
 
     let final_path = active_slot_path(project_cqs_dir);
-    let tmp_path = project_cqs_dir.join(format!("{}.tmp", ACTIVE_SLOT_FILE));
+    // DS-V1.33-2: include `crate::temp_suffix()` so concurrent writers (e.g.
+    // legacy migration in one CLI process while another `cqs slot promote`
+    // runs) each stage to their own temp file before atomic_replace, instead
+    // of racing on a fixed `active_slot.tmp` path.
+    let suffix = crate::temp_suffix();
+    let tmp_path = project_cqs_dir.join(format!("{}.{:016x}.tmp", ACTIVE_SLOT_FILE, suffix));
 
     {
         let mut f = fs::File::create(&tmp_path).map_err(|source| SlotError::Io {
@@ -670,6 +680,17 @@ pub fn migrate_legacy_index_to_default_slot(project_cqs_dir: &Path) -> Result<bo
         return Ok(false);
     }
 
+    // DS-V1.33-1: serialize with other slot lifecycle operations. Two
+    // concurrent CLI invocations on a fresh-clone project (e.g. a watch
+    // daemon starting at the same moment as `cqs search`) both observed the
+    // pre-migration state, both passed the sentinel check, and both kicked
+    // off the move loop — leaving sidecars split across `.cqs/` and
+    // `slots/default/` because the rollback only ran in the loser. Acquiring
+    // the same `slots.lock` that `slot_create/promote/remove` hold makes
+    // these checks-and-mutates atomic per `.cqs/` directory. Held until the
+    // function returns (the `_lock` binding is dropped on every exit path).
+    let _lock = acquire_slots_lock(project_cqs_dir)?;
+
     let slots_dir = slots_root(project_cqs_dir);
     if slots_dir.exists() {
         return Ok(false);
@@ -713,6 +734,24 @@ pub fn migrate_legacy_index_to_default_slot(project_cqs_dir: &Path) -> Result<bo
         )));
     }
 
+    // P2.34 / DS-V1.33-9: write the sentinel FIRST — before we touch the FS
+    // for any reason, including the WAL checkpoint below. The checkpoint is a
+    // FS mutation (it truncates the WAL and removes uncommitted page state
+    // from the live DB), so a crash between checkpoint and sentinel-write
+    // leaves "WAL drained, no breadcrumb" — the next migration call cannot
+    // tell that anything happened and proceeds as a fresh migration.
+    let started_at = chrono::Utc::now().to_rfc3339();
+    if let Err(e) = fs::write(
+        &sentinel,
+        format!("started_at={}\nstate=in_progress\n", started_at),
+    ) {
+        tracing::warn!(
+            error = %e,
+            path = %sentinel.display(),
+            "Failed to write migration sentinel; migration will proceed without crash protection"
+        );
+    }
+
     // P2.62: drain WAL before moving files. Failure is non-fatal — same-fs
     // renames are atomic per file so the WAL/SHM either move with index.db or
     // not at all. Cross-device moves (EXDEV fallback) accept the residual risk
@@ -723,20 +762,6 @@ pub fn migrate_legacy_index_to_default_slot(project_cqs_dir: &Path) -> Result<bo
             db = %legacy_index.display(),
             "Failed to checkpoint legacy index.db before migration; cross-device \
              move may lose uncommitted WAL pages"
-        );
-    }
-
-    // P2.34: write the sentinel before we touch the FS so a crash between
-    // here and full success leaves a recovery breadcrumb.
-    let started_at = chrono::Utc::now().to_rfc3339();
-    if let Err(e) = fs::write(
-        &sentinel,
-        format!("started_at={}\nstate=in_progress\n", started_at),
-    ) {
-        tracing::warn!(
-            error = %e,
-            path = %sentinel.display(),
-            "Failed to write migration sentinel; migration will proceed without crash protection"
         );
     }
 

--- a/src/store/backup.rs
+++ b/src/store/backup.rs
@@ -57,10 +57,18 @@ pub(crate) const KEEP_BACKUPS: usize = 3;
 
 /// Build the backup path for a given migration span.
 ///
-/// Filename format: `{db_stem}.bak-v{from}-v{to}-{unix_ts}.db`.
+/// Filename format: `{db_stem}.bak-v{from}-v{to}-{unix_ts}-{pid}-{rand_hex}.db`.
 /// The filename lives in the same directory as `db_path` so the backup shares
 /// the DB's filesystem — `atomic_replace`'s cheap rename path works without
 /// falling back to cross-device copy.
+///
+/// DS-V1.33-5: includes `std::process::id()` and `crate::temp_suffix()` so
+/// two CLI processes running migrations concurrently (rare but realistic on
+/// a build farm or under a CI matrix) cannot collide on the same backup
+/// filename. Without per-process disambiguation, second-resolution timestamps
+/// (and the `0` fallback on a clock anomaly) make collisions deterministic.
+/// The `prune_old_backups` regex tolerates arbitrary middle content so the
+/// only-newest-N-mtime sort still works without changes.
 pub(crate) fn backup_path_for(db_path: &Path, from: i32, to: i32) -> PathBuf {
     let dir = db_path.parent().unwrap_or(Path::new("."));
     let stem = db_path
@@ -71,7 +79,12 @@ pub(crate) fn backup_path_for(db_path: &Path, from: i32, to: i32) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    dir.join(format!("{}.bak-v{}-v{}-{}.db", stem, from, to, ts))
+    let pid = std::process::id();
+    let rand_hex = crate::temp_suffix();
+    dir.join(format!(
+        "{}.bak-v{}-v{}-{}-{}-{:016x}.db",
+        stem, from, to, ts, pid, rand_hex
+    ))
 }
 
 /// Take a filesystem snapshot of `index.db` (+ `-wal`/`-shm` if present)


### PR DESCRIPTION
## Summary

Four P2 data-safety fixes from the v1.33.0 audit, batched as cluster C6 (slot migration / temp-file races):

- **P2-18 / DS-V1.33-1** — `migrate_legacy_index_to_default_slot` now acquires the existing `slots.lock` at entry. Two concurrent CLI invocations on a fresh-clone project (e.g. watch daemon starting alongside `cqs search`) could both pass the sentinel check and kick off the move loop; the rollback only ran in the loser, so sidecars could land split across `.cqs/` and `slots/default/`.
- **P2-19 / DS-V1.33-2** — `write_active_slot` and `write_slot_model` now include `crate::temp_suffix()` in their tmp filenames. The legacy migration path calls `write_active_slot` outside `slots.lock` and could race with `cqs slot promote` on a fixed `active_slot.tmp` / `slot.toml.tmp` path.
- **P2-22 / DS-V1.33-5** — `backup_path_for` now appends pid + `crate::temp_suffix()`. Two CLI processes running migrations in the same second (realistic on a build farm or CI matrix) could collide on the backup filename, with the loser's pre-migrate state overwriting the winner's and breaking the recovery contract on subsequent migration failure.
- **P2-26 / DS-V1.33-9** — `migrate_legacy_index_to_default_slot` now writes the sentinel **before** checkpointing the WAL. The checkpoint is a FS mutation (truncates the WAL); a crash between checkpoint and sentinel-write previously left "WAL drained, no breadcrumb" — the next call would proceed as a fresh migration with no recovery context.

Per audit suggestion: hoisted `acquire_slots_lock(...)` into the migration function itself rather than wrapping each of its three call sites (`dispatch.rs`, `index/build.rs`, `watch/mod.rs`). Keeps the lock close to the operation it protects.

## Test plan

- [x] `cargo check --features cuda-index` — clean
- [x] `cargo clippy --features cuda-index --lib -- -D warnings` — clean
- [x] `cargo fmt`
- [x] `cargo test --features cuda-index --lib slot::` — 37 passed
- [x] `cargo test --features cuda-index --lib store::backup` — 10 passed
- [ ] Existing `backup_path_for_builds_expected_stem_format` test still passes (only checks prefix + `.db` suffix; new pid+rand_hex content lives in the middle and is tolerated by `prune_old_backups` regex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
