### PR TITLE
chore(audit-v1.33.0): C5 — fs safety cluster (11 findings)

### DIFF
--- a/src/aux_model.rs
+++ b/src/aux_model.rs
@@ -63,10 +63,15 @@ pub fn hf_cache_dir(subdir: &str) -> PathBuf {
             return PathBuf::from(p).join(subdir);
         }
     }
+    // PB-V1.33-6: split `.cache/huggingface` into separate path
+    // components. `PathBuf::join` does NOT auto-split forward slashes
+    // on Windows, so a literal `".cache/huggingface"` becomes one
+    // mangled component (mixed separators in display, broken
+    // `Path::starts_with` round-trips).
     dirs::cache_dir()
         .map(|c| c.join("huggingface").join(subdir))
-        .or_else(|| dirs::home_dir().map(|h| h.join(".cache/huggingface").join(subdir)))
-        .unwrap_or_else(|| PathBuf::from(".cache/huggingface").join(subdir))
+        .or_else(|| dirs::home_dir().map(|h| h.join(".cache").join("huggingface").join(subdir)))
+        .unwrap_or_else(|| PathBuf::from(".cache").join("huggingface").join(subdir))
 }
 
 /// Which auxiliary model is being resolved.

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides project root detection and config file application.
 
+use std::io::Read;
 use std::path::PathBuf;
 
 use clap::parser::ValueSource;
@@ -182,18 +183,34 @@ pub(crate) fn find_project_root() -> PathBuf {
 fn find_cargo_workspace_root(from: &std::path::Path) -> Option<PathBuf> {
     let mut candidate = from.parent()?;
 
+    // Cap each Cargo.toml read at 1 MiB. Real Cargo.toml files are well
+    // under 100 KB; a hostile parent directory with a multi-GB file at
+    // `<parent>/Cargo.toml` would otherwise OOM `cqs` during config
+    // resolution before any user-facing arg parsing runs (RB-V1.33-3).
+    const MAX_CARGO_TOML_BYTES: u64 = 1 << 20;
     loop {
         let cargo_toml = candidate.join("Cargo.toml");
         if cargo_toml.exists() {
-            if let Ok(content) = std::fs::read_to_string(&cargo_toml) {
-                if content.contains("[workspace]") {
-                    tracing::info!(
-                        workspace_root = %candidate.display(),
-                        member = %from.display(),
-                        "Detected Cargo workspace root"
-                    );
-                    return Some(candidate.to_path_buf());
-                }
+            let mut content = String::new();
+            let read_ok = match std::fs::File::open(&cargo_toml) {
+                Ok(f) => f
+                    .take(MAX_CARGO_TOML_BYTES)
+                    .read_to_string(&mut content)
+                    .is_ok(),
+                Err(_) => false,
+            };
+            if read_ok && content.contains("[workspace]") {
+                tracing::info!(
+                    workspace_root = %candidate.display(),
+                    member = %from.display(),
+                    "Detected Cargo workspace root"
+                );
+                return Some(candidate.to_path_buf());
+            } else if !read_ok {
+                tracing::warn!(
+                    path = %cargo_toml.display(),
+                    "Cargo.toml exceeds 1 MiB cap or read failed; skipping workspace detection at this candidate"
+                );
             }
         }
 

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -2,10 +2,28 @@
 //!
 //! Provides file enumeration and index locking.
 
-use std::io::{Seek, Write};
+use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
+
+/// Cap on PID-file reads. A PID file holds an ASCII integer (max 7
+/// digits + newline = 8 bytes); 64 bytes is several orders of
+/// magnitude above realistic content while bounding hostile DoS
+/// allocations (RB-V1.33-4).
+const MAX_PID_FILE_BYTES: u64 = 64;
+
+/// Read a PID file with a 64-byte cap, returning the parsed PID if any.
+/// Returns `None` on missing file, IO error, or unparseable content.
+fn read_pid_capped(path: &Path) -> Option<u32> {
+    let mut buf = String::new();
+    std::fs::File::open(path)
+        .ok()?
+        .take(MAX_PID_FILE_BYTES)
+        .read_to_string(&mut buf)
+        .ok()?;
+    buf.trim().parse::<u32>().ok()
+}
 
 #[cfg(unix)]
 /// Derive the daemon socket path for a given cqs_dir.
@@ -218,9 +236,7 @@ pub(crate) fn acquire_index_lock(cqs_dir: &Path) -> Result<std::fs::File> {
             Err(_) => {
                 // Lock is held - check if the owning process is still alive
                 if !retried {
-                    let stale_pid = std::fs::read_to_string(&lock_path)
-                        .ok()
-                        .and_then(|c| c.trim().parse::<u32>().ok());
+                    let stale_pid = read_pid_capped(&lock_path);
                     if let Some(pid) = stale_pid {
                         if !process_exists(pid) {
                             // Stale lock by best-effort PID check: drop the
@@ -237,10 +253,7 @@ pub(crate) fn acquire_index_lock(cqs_dir: &Path) -> Result<std::fs::File> {
                         }
                     }
                 }
-                let pid_msg = match std::fs::read_to_string(&lock_path)
-                    .ok()
-                    .and_then(|c| c.trim().parse::<u32>().ok())
-                {
+                let pid_msg = match read_pid_capped(&lock_path) {
                     Some(pid) => format!(" (PID {pid} may be stale)"),
                     None => String::new(),
                 };

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -265,7 +265,17 @@ fn is_under_wsl_automount(path: &str) -> bool {
 /// Parse the `automount.root` value from `/etc/wsl.conf`.
 /// Returns `None` if the file doesn't exist or doesn't contain the setting.
 fn parse_wsl_automount_root() -> Option<String> {
-    let content = std::fs::read_to_string("/etc/wsl.conf").ok()?;
+    // RM-V1.33-7: bound the read at 64 KiB. `/etc/wsl.conf` is normally
+    // a few hundred bytes; a hostile symlink or bind mount pointing at a
+    // multi-GB file would otherwise OOM the watch loop on first event.
+    use std::io::Read;
+    const MAX_WSL_CONF_BYTES: u64 = 64 * 1024;
+    let mut content = String::new();
+    std::fs::File::open("/etc/wsl.conf")
+        .ok()?
+        .take(MAX_WSL_CONF_BYTES)
+        .read_to_string(&mut content)
+        .ok()?;
     let mut in_automount = false;
     for line in content.lines() {
         let trimmed = line.trim();

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,13 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+/// Cap on config-file reads. Used by `Config::load_file` (stat-then-read)
+/// and by the locked read-modify-write paths (`add_reference_to_config` /
+/// `remove_reference_from_config`) which take the cap at the I/O layer
+/// via `Read::take`. Real `cqs` config files are typically a few KB; 1
+/// MiB is several orders of magnitude above realistic content.
+const MAX_CONFIG_SIZE: u64 = 1024 * 1024;
+
 /// Typed error for config file operations (EH-15).
 /// Used by `add_reference_to_config` and `remove_reference_from_config`.
 /// CLI callers convert to `anyhow::Error` at the boundary via the blanket `From`.
@@ -598,8 +605,13 @@ impl Config {
         // malicious checked-in `.cqs.toml` with `source = "/home/user/.ssh"`
         // would cause `cqs ref update` to index arbitrary files into the
         // reference DB (data exfiltration).
-        let home = dirs::home_dir();
-        let cwd = std::env::current_dir().ok();
+        // PB-V1.33-1: use `dunce::canonicalize` and canonicalize both
+        // sides of the comparison so Windows verbatim (`\\?\C:\...`) vs
+        // non-verbatim differences don't trip the SEC-4/SEC-NEW-1 warn.
+        let home = dirs::home_dir().and_then(|h| dunce::canonicalize(h).ok());
+        let cwd = std::env::current_dir()
+            .ok()
+            .and_then(|c| dunce::canonicalize(c).ok());
         for r in &self.references {
             // Check both path and source (if present)
             let paths_to_check: Vec<(&str, &std::path::Path)> = {
@@ -610,7 +622,7 @@ impl Config {
                 v
             };
             for (field, p) in paths_to_check {
-                if let Ok(canonical) = p.canonicalize() {
+                if let Ok(canonical) = dunce::canonicalize(p) {
                     let in_home = home.as_ref().is_some_and(|h| canonical.starts_with(h));
                     let in_project = cwd.as_ref().is_some_and(|p| canonical.starts_with(p));
                     let in_cqs_dir = canonical.components().any(|c| c.as_os_str() == ".cqs");
@@ -681,8 +693,9 @@ impl Config {
 
     /// Load configuration from a specific file
     fn load_file(path: &Path) -> Result<Option<Self>, String> {
-        // Size guard: config files should be well under 1MB
-        const MAX_CONFIG_SIZE: u64 = 1024 * 1024;
+        // Size guard: config files should be well under 1MB.
+        // Module-level `MAX_CONFIG_SIZE` is also used by the locked
+        // read-modify-write paths.
         if let Ok(meta) = std::fs::metadata(path) {
             if meta.len() > MAX_CONFIG_SIZE {
                 return Err(format!(
@@ -784,7 +797,7 @@ pub fn add_reference_to_config(
     // NOTE: File locking is advisory only on WSL over 9P (DrvFs/NTFS mounts).
     // This prevents concurrent cqs processes from corrupting the config,
     // but cannot protect against external Windows process modifications.
-    let mut lock_file = std::fs::OpenOptions::new()
+    let lock_file = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
@@ -792,9 +805,22 @@ pub fn add_reference_to_config(
         .open(config_path)?;
     lock_file.lock()?;
 
+    // Bounded read via `Read::take` so a hostile `<MAX_CONFIG_SIZE>+1`-byte
+    // config can't OOM us before the size check fires (RM-V1.33-1). The
+    // cap is enforced at the I/O layer, eliminating the stat→read TOCTOU
+    // window that a plain `metadata()`-then-`read_to_string` would have.
     let mut content = String::new();
     use std::io::Read;
-    lock_file.read_to_string(&mut content)?;
+    (&lock_file)
+        .take(MAX_CONFIG_SIZE + 1)
+        .read_to_string(&mut content)?;
+    if content.len() as u64 > MAX_CONFIG_SIZE {
+        return Err(ConfigError::InvalidFormat(format!(
+            "Config file too large: > {}KB (limit {}KB)",
+            MAX_CONFIG_SIZE / 1024,
+            MAX_CONFIG_SIZE / 1024
+        )));
+    }
     let mut table: toml::Table = if content.is_empty() {
         toml::Table::new()
     } else {
@@ -877,7 +903,7 @@ pub fn remove_reference_from_config(config_path: &Path, name: &str) -> Result<bo
     // NOTE: File locking is advisory only on WSL over 9P (DrvFs/NTFS mounts).
     // This prevents concurrent cqs processes from corrupting the config,
     // but cannot protect against external Windows process modifications.
-    let mut lock_file = match std::fs::OpenOptions::new()
+    let lock_file = match std::fs::OpenOptions::new()
         .read(true)
         .write(true)
         .open(config_path)
@@ -888,9 +914,20 @@ pub fn remove_reference_from_config(config_path: &Path, name: &str) -> Result<bo
     };
     lock_file.lock()?;
 
+    // Bounded read via `Read::take` — see add_reference_to_config above
+    // (RM-V1.33-1).
     let mut content = String::new();
     use std::io::Read;
-    lock_file.read_to_string(&mut content)?;
+    (&lock_file)
+        .take(MAX_CONFIG_SIZE + 1)
+        .read_to_string(&mut content)?;
+    if content.len() as u64 > MAX_CONFIG_SIZE {
+        return Err(ConfigError::InvalidFormat(format!(
+            "Config file too large: > {}KB (limit {}KB)",
+            MAX_CONFIG_SIZE / 1024,
+            MAX_CONFIG_SIZE / 1024
+        )));
+    }
 
     let mut table: toml::Table = content.parse()?;
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -59,13 +59,22 @@ impl ProjectRegistry {
         if !path.exists() {
             return Ok(Self::default());
         }
-        // Read first, then enforce the size guard — avoids TOCTOU between stat and read.
+        // RM-V1.33-2: bound the allocation at the I/O layer with
+        // `Read::take(MAX+1)` so a hostile multi-GiB registry file can
+        // never be fully read into memory before the cap fires. Reading
+        // through an opened file descriptor keeps the TOCTOU window
+        // identical to a stat-then-read; the win is that the buffer is
+        // bounded regardless of file size.
         const MAX_REGISTRY_SIZE: usize = 1024 * 1024;
-        let content = std::fs::read_to_string(&path)?;
+        use std::io::Read;
+        let mut content = String::new();
+        std::fs::File::open(&path)?
+            .take(MAX_REGISTRY_SIZE as u64 + 1)
+            .read_to_string(&mut content)?;
         if content.len() > MAX_REGISTRY_SIZE {
             return Err(ProjectError::FileTooLarge(format!(
-                "Project registry too large: {}KB (limit {}KB)",
-                content.len() / 1024,
+                "Project registry too large: > {}KB (limit {}KB)",
+                MAX_REGISTRY_SIZE / 1024,
                 MAX_REGISTRY_SIZE / 1024
             )));
         }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -87,9 +87,14 @@ fn load_single_reference(cfg: &ReferenceConfig) -> Option<ReferenceIndex> {
 
     // SEC-4: Warn if reference path is outside project and home directories.
     // Canonicalize to resolve any `..` segments, then check containment.
-    if let Ok(canonical) = cfg.path.canonicalize() {
-        let home = dirs::home_dir();
-        let cwd = std::env::current_dir().ok();
+    // PB-V1.33-1: use `dunce::canonicalize` and canonicalize both sides
+    // so Windows verbatim (`\\?\C:\...`) vs non-verbatim mismatches
+    // don't defeat the comparison.
+    if let Ok(canonical) = dunce::canonicalize(&cfg.path) {
+        let home = dirs::home_dir().and_then(|h| dunce::canonicalize(h).ok());
+        let cwd = std::env::current_dir()
+            .ok()
+            .and_then(|c| dunce::canonicalize(c).ok());
         let in_home = home.as_ref().is_some_and(|h| canonical.starts_with(h));
         let in_project = cwd.as_ref().is_some_and(|p| canonical.starts_with(p));
         let in_cqs_dir = canonical.components().any(|c| c.as_os_str() == ".cqs");

--- a/src/search/router.rs
+++ b/src/search/router.rs
@@ -1016,13 +1016,19 @@ impl CentroidClassifier {
         }
 
         let path = dirs::data_dir()?.join("cqs/classifier_centroids.v1.json");
-        let text = match std::fs::read_to_string(&path) {
-            Ok(t) => t,
-            Err(e) => {
-                tracing::debug!(path = %path.display(), error = %e, "centroid file not found — rule-only mode");
-                return None;
-            }
-        };
+        // RM-V1.33-9: cap centroid file reads at 16 MiB. Real centroid
+        // registries are 50-200 KiB even with 100 categories × 1024-dim
+        // floats; 16 MiB rejects hostile or corrupted multi-GB files
+        // before the daemon OOMs at first search.
+        use std::io::Read;
+        const MAX_CENTROID_BYTES: u64 = 16 * 1024 * 1024;
+        let mut text = String::new();
+        let read_result = std::fs::File::open(&path)
+            .and_then(|f| f.take(MAX_CENTROID_BYTES).read_to_string(&mut text));
+        if let Err(e) = read_result {
+            tracing::debug!(path = %path.display(), error = %e, "centroid file not found — rule-only mode");
+            return None;
+        }
         let data: serde_json::Value = match serde_json::from_str(&text) {
             Ok(d) => d,
             Err(e) => {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -440,10 +440,21 @@ fn is_slow_mmap_fs(path: &Path) -> bool {
             Ok(p) => p,
             Err(_) => return false,
         };
-        let mountinfo = match std::fs::read_to_string("/proc/self/mountinfo") {
-            Ok(c) => c,
-            Err(_) => return false,
-        };
+        // RM-V1.33-7: bound `/proc/self/mountinfo` reads at 1 MiB. The
+        // file is reliably small in practice (a few KiB) but a system
+        // with thousands of mounts (containers, network FS, btrfs
+        // subvols) plus a malformed mount table could exceed reasonable
+        // size. 1 MiB is several orders of magnitude above realistic
+        // content; rejection falls through to "not slow".
+        use std::io::Read;
+        const MAX_MOUNTINFO_BYTES: u64 = 1 << 20;
+        let mut mountinfo = String::new();
+        if std::fs::File::open("/proc/self/mountinfo")
+            .and_then(|f| f.take(MAX_MOUNTINFO_BYTES).read_to_string(&mut mountinfo))
+            .is_err()
+        {
+            return false;
+        }
         match fstype_for_path(&mountinfo, &abs) {
             Some(fstype) => SLOW_MMAP_FSTYPES.iter().any(|&s| s == fstype),
             None => false,

--- a/src/train_data/git.rs
+++ b/src/train_data/git.rs
@@ -23,7 +23,12 @@ use super::TrainDataError;
 ///     entry present). This doubles as a clearer error message than
 ///     git's own "not a git repository".
 fn validate_git_repo(repo: &Path) -> Result<PathBuf, TrainDataError> {
-    let canonical = repo.canonicalize().map_err(|e| {
+    // PB-V1.33-2: use `dunce::canonicalize` so the verbatim `\\?\C:\...`
+    // prefix is stripped on Windows before the path is fed to `git -C`.
+    // Older git-for-Windows builds reject extended-length paths in some
+    // subcommand combinations, and downstream display/log surfaces the
+    // ugly prefix to operators when raw `canonicalize` is used.
+    let canonical = dunce::canonicalize(repo).map_err(|e| {
         TrainDataError::Git(format!(
             "cannot resolve repo path {}: {}",
             repo.display(),

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -21,7 +21,14 @@
 //! signal in the JSON `_meta` block lets consuming agents know the
 //! results came from main's snapshot, not the worktree's branch.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
+
+/// Cap on `.git` worktree file reads. A `.git` link file is normally
+/// ~30 bytes (just `gitdir: <path>\n`); 4 KiB rejects pathological
+/// content while leaving plenty of headroom for unusual but legitimate
+/// layouts. Mirrors the bounded-read pattern used in `slot/mod.rs`.
+const MAX_GIT_FILE_BYTES: u64 = 4 * 1024;
 
 /// Detect a git worktree at `dir` and return the main project's root
 /// directory if so. Returns `None` for the non-worktree happy path
@@ -53,8 +60,15 @@ pub fn resolve_main_project_dir(dir: &Path) -> Option<PathBuf> {
         return None;
     }
 
-    // Read `.git` file → "gitdir: <path>"
-    let raw = std::fs::read_to_string(&dot_git).ok()?;
+    // Read `.git` file → "gitdir: <path>" with a bounded cap to defend
+    // against a hostile or accidentally-huge file at this path
+    // (RB-V1.33-2). 4 KiB is far above realistic content (~30 bytes).
+    let mut raw = String::new();
+    std::fs::File::open(&dot_git)
+        .ok()?
+        .take(MAX_GIT_FILE_BYTES)
+        .read_to_string(&mut raw)
+        .ok()?;
     let gitdir_path_str = raw
         .lines()
         .find_map(|line| line.strip_prefix("gitdir:"))?
@@ -81,8 +95,11 @@ pub fn resolve_main_project_dir(dir: &Path) -> Option<PathBuf> {
     }
 
     // Resolve `<gitdir>/<commondir_relative>` → canonical `.git/`.
+    // Use `dunce::canonicalize` so Windows returns the non-`\\?\`-prefixed
+    // form — downstream `WorktreeUseMain.main_root` is surfaced via JSON
+    // envelopes and string-compared by agents (PB-V1.33-3).
     let canonical_git = gitdir.join(commondir_relative);
-    let canonical_git = std::fs::canonicalize(&canonical_git).ok()?;
+    let canonical_git = dunce::canonicalize(&canonical_git).ok()?;
 
     // Canonical `.git/`'s parent = main project root.
     let main_root = canonical_git.parent()?.to_path_buf();
@@ -158,7 +175,13 @@ pub fn worktree_name(dir: &Path) -> Option<String> {
     if std::fs::metadata(&dot_git).ok()?.is_dir() {
         return None;
     }
-    let raw = std::fs::read_to_string(&dot_git).ok()?;
+    // Bounded read — see RB-V1.33-2 / `MAX_GIT_FILE_BYTES`.
+    let mut raw = String::new();
+    std::fs::File::open(&dot_git)
+        .ok()?
+        .take(MAX_GIT_FILE_BYTES)
+        .read_to_string(&mut raw)
+        .ok()?;
     let gitdir_path_str = raw
         .lines()
         .find_map(|line| line.strip_prefix("gitdir:"))?


### PR DESCRIPTION
## Summary

Combined v1.33.0 audit C5 cluster: P1 unbounded-read defenses + P2 Windows-canonicalize fixes (11 findings, all filesystem-safety theme).

### Unbounded-read fixes (Read::take cap)

- **P1-21 RB-V1.33-2** `worktree::resolve_main_project_dir` + `worktree_name` — cap `.git` file at 4 KiB (normal content ~30 bytes)
- **P1-22 RB-V1.33-3** `cli::config::find_cargo_workspace_root` — cap each parent `Cargo.toml` at 1 MiB; warn + skip if exceeded
- **P1-23 RB-V1.33-4** `cli::files::acquire_lock` — cap PID file at 64 bytes via new local `read_pid_capped` helper (used at both call sites)
- **P2-32 RM-V1.33-1** `config::add_reference_to_config` / `remove_reference_from_config` — cap locked TOML reads via `(&lock_file).take(MAX+1).read_to_string`. Promoted `MAX_CONFIG_SIZE` from `Config::load_file`-local to module scope so all three readers share it.
- **P2-33 RM-V1.33-2** `ProjectRegistry::load` — replace read-then-check with `File::open(...)?.take(MAX+1).read_to_string(...)` so the allocation is bounded at the I/O layer.
- **P2-34 RM-V1.33-7** `cli::watch::parse_wsl_automount_root` (`/etc/wsl.conf`, 64 KiB cap) + `store::is_slow_mmap_filesystem` (`/proc/self/mountinfo`, 1 MiB cap).
- **P2-35 RM-V1.33-9** `search::router::CentroidClassifier::load` — cap centroid JSON at 16 MiB; rejection falls through to rule-only mode.

### Windows canonicalize fixes (`std::fs::canonicalize` → `dunce::canonicalize`)

- **P2-38 PB-V1.33-1** `config::Config::validate` (SEC-4/SEC-NEW-1) and `reference.rs` SEC-4 path-containment. Also routes `home`/`cwd` through `dunce` so both sides of `starts_with` are canonicalized.
- **P2-39 PB-V1.33-2** `train_data::git::validate_git_repo` — strips `\\?\` before path is fed to `git -C`.
- **P2-40 PB-V1.33-3** `worktree::resolve_main_project_dir` — JSON envelopes (`WorktreeUseMain.main_root`) get non-verbatim paths so agent string-comparisons succeed.
- **P2-41 PB-V1.33-6** `aux_model::hf_cache_dir` — split `".cache/huggingface"` literal into two separate `Path::join` components so Windows display + `Path::starts_with` round-trips behave correctly.

### Notes / deviations

- The `MAX_CONFIG_SIZE` constant existed only inside `Config::load_file`. Promoted it to module scope rather than duplicating — same value (1 MiB), single source of truth.
- `acquire_lock` had two unbounded reads of the lock file plus identical `.trim().parse::<u32>()` boilerplate at each site. Folded both into a 5-line `read_pid_capped` helper (worth the helper at 2 call sites since each was an 8-line `match` block).
- For `add/remove_reference_to_config` the lock_file no longer needs `mut` after the read switched to `(&lock_file).take(...)`. Removed the `mut`.
- `worktree.rs` `commondir` read was not flagged in the audit and was left as-is (audit scope was the `.git` file specifically).

## Test plan

- [x] `cargo check --features cuda-index` clean
- [x] `cargo clippy --features cuda-index --lib -- -D warnings` clean
- [x] `cargo fmt`
- [x] `cargo test --features cuda-index --lib worktree::` (8 passed)
- [x] `cargo test --features cuda-index --lib config::` (46 passed)
- [x] `cargo test --features cuda-index --lib project::` (18 passed)
- [x] `cargo test --features cuda-index --lib reference::` (12 passed)
- [x] `cargo test --features cuda-index --lib aux_model::` (22 passed)
- [x] `cargo test --features cuda-index --lib router::` (47 passed)
- [x] `cargo test --features cuda-index --lib store::` (312 passed)
- [x] `cargo test --features cuda-index --lib train_data::` (45 passed)
