### PR TITLE
fix(audit): #1245 6 P1 error-handling fixes from v1.33.0 audit

### DIFF
--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -1003,7 +1003,19 @@ fn first_encounter_notes_gate(
             let negative = notes.iter().filter(|n| n.sentiment < 0.0).count();
             (Some(total), Some(positive), Some(negative))
         }
-        Err(_) => (None, None, None),
+        Err(e) => {
+            // EH-V1.33-5: log the underlying parse error so operators
+            // staring at a `(? entries, ? positive, ? negative)` prompt
+            // have a debuggable trail. The downstream `index_notes_from_file`
+            // surfaces the error too, but only if the user proceeds —
+            // logging here keeps the diagnostic visible at gate time.
+            tracing::warn!(
+                error = %e,
+                path = %notes_path.display(),
+                "Failed to parse docs/notes.toml during acceptance check; rendering counts as `?`"
+            );
+            (None, None, None)
+        }
     };
 
     // Empty notes file → no payload to gate. Don't write the marker either;

--- a/src/cli/commands/infra/hook.rs
+++ b/src/cli/commands/infra/hook.rs
@@ -35,6 +35,7 @@
 
 use anyhow::{Context, Result};
 use serde::Serialize;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use crate::cli::find_project_root;
@@ -167,7 +168,24 @@ fn cmd_install(no_overwrite: bool, json: bool) -> Result<()> {
 
     for &hook in MANAGED_HOOKS {
         let path = git_dir.join(hook);
-        let existing = std::fs::read_to_string(&path).ok();
+        // EH-V1.33-3: distinguish `NotFound` (no hook present, safe to
+        // install) from any other read failure (PermissionDenied, corrupt
+        // UTF-8, IO hiccup). Collapsing all errors to `None` via `.ok()`
+        // would let the `None` arm clobber a foreign hook that was simply
+        // unreadable. Refuse to write in any non-NotFound failure case.
+        let existing = match std::fs::read_to_string(&path) {
+            Ok(s) => Some(s),
+            Err(e) if e.kind() == ErrorKind::NotFound => None,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "Refusing to install over unreadable hook (may be a foreign hook with restricted perms)"
+                );
+                report.skipped_existing.push(hook.to_string());
+                continue;
+            }
+        };
         match existing {
             None => {
                 if no_overwrite {

--- a/src/cli/commands/infra/slot.rs
+++ b/src/cli/commands/infra/slot.rs
@@ -293,7 +293,19 @@ fn slot_promote(project_cqs_dir: &Path, name: &str, json: bool) -> Result<()> {
 
     let dir = slot_dir(project_cqs_dir, name);
     if !dir.exists() {
-        let available = list_slots(project_cqs_dir).unwrap_or_default().join(", ");
+        // EH-V1.33-10: surface listing failure with path context instead of
+        // masking it as "Available: []", which would tell the user to
+        // create a slot when in reality there might already be several but
+        // we can't read them (perm denied on .cqs/slots/, FS hiccup, slot
+        // dir corrupted). Mirrors P2.21's slot_remove fix.
+        let available = list_slots(project_cqs_dir)
+            .with_context(|| {
+                format!(
+                    "Failed to list slots while building slot-missing message at {}",
+                    project_cqs_dir.display()
+                )
+            })?
+            .join(", ");
         anyhow::bail!(
             "Slot '{}' does not exist. Available: [{}]. Create with: cqs slot create <name> --model <model-id>",
             name,

--- a/src/cli/telemetry.rs
+++ b/src/cli/telemetry.rs
@@ -20,7 +20,6 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::Path;
-use std::time::SystemTime;
 
 /// Maximum telemetry file size before auto-archiving (10 MB).
 const MAX_TELEMETRY_BYTES: u64 = 10 * 1024 * 1024;
@@ -77,10 +76,10 @@ pub fn log_command(
         }
     }
 
-    let timestamp = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+    // EH-V1.33-1: use `cqs::unix_secs_i64()` so a pre-epoch clock surfaces as
+    // `ts: null` (serializing `Option<i64>::None`) and emits a one-shot
+    // tracing::warn from the helper, instead of silently coercing to `ts: 0`.
+    let timestamp = cqs::unix_secs_i64();
 
     // P3 #136: redact `query` by default to keep search strings out of the
     // telemetry log. `CQS_TELEMETRY_REDACT_QUERY=0` opts back in to raw text.
@@ -123,7 +122,13 @@ pub fn log_command(
         // SHL-20: auto-archive if file exceeds 10 MB to prevent unbounded growth
         if let Ok(meta) = fs::metadata(&path) {
             if meta.len() > MAX_TELEMETRY_BYTES {
-                let archive_name = format!("telemetry_{timestamp}.jsonl");
+                // EH-V1.33-1: archive filename falls back to `0` when the
+                // clock is pre-epoch — uniqueness here is best-effort and
+                // the JSON row above already records `ts: null` so the
+                // bad-clock condition is preserved in the data, not just
+                // a swept-under filename.
+                let ts_for_filename = timestamp.unwrap_or(0);
+                let archive_name = format!("telemetry_{ts_for_filename}.jsonl");
                 let archive_path = cqs_dir.join(&archive_name);
                 if let Err(e) = fs::rename(&path, &archive_path) {
                     tracing::warn!(
@@ -192,10 +197,8 @@ pub fn log_command_complete(
         }
     }
 
-    let timestamp = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+    // EH-V1.33-1: see `log_command` above for the rationale.
+    let timestamp = cqs::unix_secs_i64();
 
     let error_field = error.map(|s| {
         if s.len() > 240 {
@@ -232,7 +235,13 @@ pub fn log_command_complete(
 
         if let Ok(meta) = fs::metadata(&path) {
             if meta.len() > MAX_TELEMETRY_BYTES {
-                let archive_name = format!("telemetry_{timestamp}.jsonl");
+                // EH-V1.33-1: archive filename falls back to `0` when the
+                // clock is pre-epoch — uniqueness here is best-effort and
+                // the JSON row above already records `ts: null` so the
+                // bad-clock condition is preserved in the data, not just
+                // a swept-under filename.
+                let ts_for_filename = timestamp.unwrap_or(0);
+                let archive_name = format!("telemetry_{ts_for_filename}.jsonl");
                 let archive_path = cqs_dir.join(&archive_name);
                 if let Err(e) = fs::rename(&path, &archive_path) {
                     tracing::warn!(error = %e, "Failed to auto-archive telemetry file");
@@ -286,10 +295,8 @@ pub fn log_routed(
         }
     }
 
-    let timestamp = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+    // EH-V1.33-1: see `log_command` above for the rationale.
+    let timestamp = cqs::unix_secs_i64();
 
     // P3 #136: redact `query` by default — see `redact_query_str` doc.
     let query_field = redact_query_str(query);
@@ -328,7 +335,13 @@ pub fn log_routed(
         // Auto-archive if file exceeds 10 MB to prevent unbounded growth
         if let Ok(meta) = fs::metadata(&path) {
             if meta.len() > MAX_TELEMETRY_BYTES {
-                let archive_name = format!("telemetry_{timestamp}.jsonl");
+                // EH-V1.33-1: archive filename falls back to `0` when the
+                // clock is pre-epoch — uniqueness here is best-effort and
+                // the JSON row above already records `ts: null` so the
+                // bad-clock condition is preserved in the data, not just
+                // a swept-under filename.
+                let ts_for_filename = timestamp.unwrap_or(0);
+                let archive_name = format!("telemetry_{ts_for_filename}.jsonl");
                 let archive_path = cqs_dir.join(&archive_name);
                 if let Err(e) = fs::rename(&path, &archive_path) {
                     tracing::warn!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -749,6 +749,12 @@ pub fn enumerate_files(
         .build();
 
     let size_cap = max_file_size();
+    // EH-V1.33-4: when `metadata()` fails (broken symlink target, transient FS
+    // error, permission flip mid-walk), surface it via the same first-3-warn-
+    // then-debug shape used by the canonicalize arm below. Silently dropping
+    // files leaves operators staring at fewer chunks than expected with no
+    // diagnostic trail.
+    let metadata_failures = std::sync::atomic::AtomicUsize::new(0);
     let files: Vec<PathBuf> = walker
         .filter_map(|e| {
             e.map_err(|err| {
@@ -775,7 +781,28 @@ pub fn enumerate_files(
                     true
                 }
             }
-            Err(_) => false,
+            Err(err) => {
+                // EH-V1.33-4: `ignore::Error::Display` already prints the
+                // underlying io kind (e.g., "permission denied", "no such
+                // file or directory"), so the operator gets the kind
+                // implicitly via `error = %err`.
+                let count =
+                    metadata_failures.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if count < 3 {
+                    tracing::warn!(
+                        path = %e.path().display(),
+                        error = %err,
+                        "Skipping file: metadata() failed"
+                    );
+                } else {
+                    tracing::debug!(
+                        path = %e.path().display(),
+                        error = %err,
+                        "Skipping file: metadata() failed"
+                    );
+                }
+                false
+            }
         })
         .filter(|e| {
             // P3 #141: `to_ascii_lowercase` allocated a fresh `String` per

--- a/src/llm/local.rs
+++ b/src/llm/local.rs
@@ -705,7 +705,11 @@ impl BatchProvider for LocalProvider {
     }
 
     fn set_on_item_complete(&mut self, cb: Box<dyn Fn(&str, &str) + Send + Sync>) {
-        *self.on_item.lock().unwrap() = Some(cb);
+        // EH-V1.33-2 / RB-V1.33-10: tolerate a poisoned mutex (a sibling
+        // worker may have panicked while sharing other LocalProvider mutexes).
+        // Match the rest of this file's `lock().unwrap_or_else(|p| p.into_inner())`
+        // recovery pattern from P1.9 / P2.35 instead of panicking the caller.
+        *self.on_item.lock().unwrap_or_else(|p| p.into_inner()) = Some(cb);
     }
 }
 


### PR DESCRIPTION
## Summary

Six P1 error-handling fixes from the v1.33.0 audit (#1245), category **C7 — Error Handling**. Each is 1-5 lines, surgical, no surrounding refactor.

| ID | File | What it was | What it is now |
|---|---|---|---|
| EH-V1.33-1 (P1-14) | `src/cli/telemetry.rs` (×3) | `SystemTime::now()...unwrap_or(0)` silently writes `ts: 0` on pre-epoch clock | `cqs::unix_secs_i64()` → `ts: null` + one-shot warn |
| EH-V1.33-2 (P1-15) | `src/llm/local.rs:707` | `lock().unwrap()` panics on poisoned mutex | `lock().unwrap_or_else(|p| p.into_inner())` |
| EH-V1.33-3 (P1-16) | `src/cli/commands/infra/hook.rs` | `read_to_string(...).ok()` collapses `PermissionDenied`/corrupt UTF-8 → `None` and clobbers foreign hook | distinguish `NotFound` from other errors; refuse to overwrite an unreadable hook |
| EH-V1.33-4 (P1-17) | `src/lib.rs::enumerate_files` | `Err(_) => false` silently drops files whose metadata fails | first-3-warn-then-debug pattern (mirrors canonicalize arm) |
| EH-V1.33-5 (P1-18) | `src/cli/commands/index/build.rs` | parse error swallowed as `(None, None, None)` → `?` rendering with no diagnostic | log `tracing::warn!` with parse error + path |
| EH-V1.33-10 (P1-19) | `src/cli/commands/infra/slot.rs:296` | `list_slots(...).unwrap_or_default()` masks listing failure | `.with_context(...)?` surfaces failure with path |

Note: triage row P1-19 maps to EH-V1.33-10 in audit-findings.md (the `embedder.fingerprint` finding numbered EH-V1.33-6 is a different ticket and is not in scope here — it's medium difficulty and not in the P1-14..P1-19 batch).

## Test plan

- [x] `cargo check --features cuda-index` clean
- [x] `cargo clippy --features cuda-index -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Targeted tests pass:
  - `log_command_complete_roundtrip`, `log_command_complete_truncates_long_error` (telemetry)
  - `cmd_uninstall_removes_only_marked_hooks`, `install_idempotent_second_run_keeps_marker`, `install_upgrade_replaces_v0_marker_with_current`, `install_writes_three_hooks_into_fresh_repo` (hook)
  - `slot_promote_requires_existing_slot`, `slot_promote_updates_active_slot_file` + 17 sibling slot tests
  - `test_enumerate_files_*` (×3)
  - All 23 `llm::local::tests::*` pass
  - All 10 `build::tests::*` pass

## Risk

Low. Each change is at most 5 lines of behavior change plus comments. No public API change. No schema change. The telemetry `ts: null` is the documented downstream-compatible signal for "skipped due to bad clock."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
