### PR TITLE
test(audit): close 17 v1.33.0 test-coverage gaps (10 adversarial + 7 happy path)

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2398,6 +2398,67 @@ impl Drop for QueryCache {
     }
 }
 
+// ─── TC-ADV-V1.33-6: QueryCache malformed-blob auto-delete ──────────────────
+//
+// EH-17 / OB-NEW-6: a malformed embedding blob (length not a multiple of
+// 4) is logged + deleted on `QueryCache::get`. Pins the auto-delete
+// behaviour so a re-poll loop on bad rows can't reintroduce the cost of
+// re-checking the same bad row.
+#[cfg(test)]
+mod query_cache_malformed_blob_tests {
+    use super::*;
+
+    /// TC-ADV-V1.33-6: insert a row whose embedding blob length isn't a
+    /// multiple of 4 (corrupt row, schema migration mid-flight, manual SQL
+    /// stomp). `get` returns `None` and deletes the row.
+    #[test]
+    fn test_query_cache_get_deletes_malformed_blob() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("query_cache.db");
+        let cache = QueryCache::open(&path).unwrap();
+
+        // Reach into the runtime to insert a malformed (7-byte) blob
+        // directly via raw sqlx — bypassing `put` which would reject
+        // non-finite floats but still requires a real Embedding.
+        cache.rt.block_on(async {
+            sqlx::query(
+                "INSERT INTO query_cache (query, model_fp, embedding) \
+                 VALUES (?1, ?2, ?3)",
+            )
+            .bind("malformed-q")
+            .bind("test-fp")
+            .bind(vec![0u8; 7]) // 7 bytes — not a multiple of 4
+            .execute(&cache.pool)
+            .await
+            .unwrap();
+        });
+
+        // First get must return None (malformed blob detected, deleted).
+        let got = cache.get("malformed-q", "test-fp");
+        assert!(
+            got.is_none(),
+            "malformed blob must produce a cache miss, got Some(_)"
+        );
+
+        // Verify the row was actually deleted (next `get` would also miss
+        // even without the malformed-blob path firing again).
+        let row_count: i64 = cache.rt.block_on(async {
+            sqlx::query_scalar(
+                "SELECT COUNT(*) FROM query_cache WHERE query = ?1 AND model_fp = ?2",
+            )
+            .bind("malformed-q")
+            .bind("test-fp")
+            .fetch_one(&cache.pool)
+            .await
+            .unwrap()
+        });
+        assert_eq!(
+            row_count, 0,
+            "malformed row must be deleted after get, found {row_count} row(s)"
+        );
+    }
+}
+
 // ─── #968 shared-runtime integration tests ──────────────────────────────────
 //
 // Confirms that one `Arc<Runtime>` can drive Store + EmbeddingCache +

--- a/src/cli/commands/io/read.rs
+++ b/src/cli/commands/io/read.rs
@@ -541,6 +541,52 @@ mod tests {
         assert!(flags.is_empty(), "no per-content heuristics fired yet");
     }
 
+    /// TC-ADV-V1.33-9: file exceeding `CQS_READ_MAX_FILE_SIZE` is rejected
+    /// with the documented error message including both the actual size
+    /// and the cap. The size-cap branch is the only DoS-prevention layer
+    /// for arbitrary-content reads — a flipped comparison sign would slip
+    /// through CI without a regression test.
+    #[test]
+    fn read_rejects_oversized_file() {
+        use std::sync::Mutex;
+        // CQS_READ_MAX_FILE_SIZE is process-global; serialise the env edit.
+        static READ_SIZE_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = READ_SIZE_LOCK.lock().unwrap();
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let big_path = dir.path().join("big.rs");
+        // 100 bytes; cap below is 50.
+        std::fs::write(&big_path, vec![b'a'; 100]).unwrap();
+
+        let prev = std::env::var("CQS_READ_MAX_FILE_SIZE").ok();
+        std::env::set_var("CQS_READ_MAX_FILE_SIZE", "50");
+        let err = super::validate_and_read_file(dir.path(), "big.rs")
+            .expect_err("oversized file must error");
+        // Restore env regardless of assert outcome.
+        match prev {
+            Some(v) => std::env::set_var("CQS_READ_MAX_FILE_SIZE", v),
+            None => std::env::remove_var("CQS_READ_MAX_FILE_SIZE"),
+        }
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("File too large"),
+            "error must mention 'File too large', got {msg:?}"
+        );
+        assert!(
+            msg.contains("100"),
+            "error must include actual size (100), got {msg:?}"
+        );
+        assert!(
+            msg.contains("50"),
+            "error must include the cap (50), got {msg:?}"
+        );
+        assert!(
+            msg.contains("CQS_READ_MAX_FILE_SIZE"),
+            "error must name the env var so users can tune, got {msg:?}"
+        );
+    }
+
     /// SEC-D.5: `validate_and_read_file` must produce identical error text
     /// for "file outside project root" and "file not found" so a daemon
     /// client can't probe filesystem layout via distinguishable messages.

--- a/src/hnsw/build.rs
+++ b/src/hnsw/build.rs
@@ -530,4 +530,27 @@ mod tests {
             results.len()
         );
     }
+
+    /// TC-ADV-V1.33-2: `HnswIndex::search` with `k=0` must return an empty
+    /// result without panicking. Pins the contract at the cqs boundary so a
+    /// future `hnsw_rs` version bump can't silently change behavior — the
+    /// internal `ef_search = self.ef_search.max(k * 2).min(index_size)` math
+    /// must not trip on `k=0`.
+    #[test]
+    fn tc18_search_k_zero_returns_empty() {
+        // Build a populated index so the k=0 path doesn't short-circuit on
+        // `id_map.is_empty()` — we want to drive into search_neighbours.
+        let embeddings: Vec<(String, Embedding)> = (0..10)
+            .map(|i| (format!("chunk_{}", i), make_embedding(i)))
+            .collect();
+        let index = HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap();
+
+        let query = make_embedding(1);
+        let results = index.search(&query, 0);
+        assert!(
+            results.is_empty(),
+            "search with k=0 must return empty, got {} results",
+            results.len()
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1201,6 +1201,116 @@ mentions = ["store.rs"]
             "Should return empty for directory with no supported files"
         );
     }
+
+    /// TC-ADV-V1.33-5: SECURITY.md promises `follow_links=false` per
+    /// SEC-V1.30.1-2. A symlink to a real `.rs` file inside the project
+    /// must NOT appear in the enumerated list — the walker is configured
+    /// to skip links, not to dereference them. Pins the security policy.
+    #[test]
+    #[cfg(unix)]
+    fn test_enumerate_files_skips_symlinks_to_files() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        // A real source file the symlink will point at.
+        let real_rs = dir.path().join("real.rs");
+        std::fs::write(&real_rs, "fn real() {}").unwrap();
+        // A symlink alongside the real file, both `.rs`.
+        let link_rs = dir.path().join("link.rs");
+        symlink(&real_rs, &link_rs).unwrap();
+
+        let files = enumerate_files(dir.path(), &["rs"], false).unwrap();
+        let names: Vec<String> = files
+            .iter()
+            .map(|f| f.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+
+        // The real file is included; the symlink is filtered out by
+        // `follow_links(false)`.
+        assert!(
+            names.contains(&"real.rs".to_string()),
+            "real.rs should be enumerated, got {names:?}"
+        );
+        assert!(
+            !names.contains(&"link.rs".to_string()),
+            "symlink link.rs must be skipped (SEC-V1.30.1-2), got {names:?}"
+        );
+    }
+
+    /// TC-ADV-V1.33-5: files exceeding `CQS_MAX_FILE_SIZE` must be
+    /// silently filtered. Pins the size cap behaviour at lines 759-779.
+    #[test]
+    fn test_enumerate_files_skips_oversized_files() {
+        use std::sync::Mutex;
+        // Cross-test serialisation lock for CQS_MAX_FILE_SIZE — env vars
+        // are process-global so parallel tests would race.
+        static MAX_SIZE_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = MAX_SIZE_LOCK.lock().unwrap();
+
+        let dir = tempfile::TempDir::new().unwrap();
+        // Small file should pass.
+        std::fs::write(dir.path().join("small.rs"), b"fn s() {}").unwrap();
+        // Big file (200 bytes) exceeds the cap (100 bytes) we set below.
+        std::fs::write(dir.path().join("big.rs"), vec![b'a'; 200]).unwrap();
+
+        let prev = std::env::var("CQS_MAX_FILE_SIZE").ok();
+        std::env::set_var("CQS_MAX_FILE_SIZE", "100");
+        let files = enumerate_files(dir.path(), &["rs"], false).unwrap();
+        // Restore env before any further work.
+        match prev {
+            Some(v) => std::env::set_var("CQS_MAX_FILE_SIZE", v),
+            None => std::env::remove_var("CQS_MAX_FILE_SIZE"),
+        }
+
+        let names: Vec<String> = files
+            .iter()
+            .map(|f| f.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        assert!(
+            names.contains(&"small.rs".to_string()),
+            "small.rs must be enumerated, got {names:?}"
+        );
+        assert!(
+            !names.contains(&"big.rs".to_string()),
+            "big.rs (200B > 100B cap) must be filtered, got {names:?}"
+        );
+    }
+
+    /// TC-ADV-V1.33-5: file with a non-UTF8 byte sequence in its name on
+    /// Linux must not crash `enumerate_files`. The walker may either skip
+    /// or include it (both are defensible) but a panic is unacceptable —
+    /// a hostile filename should never bring down the indexer.
+    #[test]
+    #[cfg(unix)]
+    fn test_enumerate_files_handles_non_utf8_filename_on_unix() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        // Build a filename with a `.rs` suffix preceded by non-UTF8 bytes.
+        // Linux file APIs accept arbitrary bytes; UTF-8 is just a
+        // convention.
+        let bad_name_bytes: &[u8] = b"bad\xFF\xFEname.rs";
+        let bad_path = dir.path().join(OsStr::from_bytes(bad_name_bytes));
+        // Some filesystems on Linux refuse arbitrary byte sequences (NTFS
+        // mounts, zfs with `-o utf8only`). Skip silently if the write
+        // can't land — the test asserts panic-free behaviour, not a
+        // specific filesystem capability.
+        if std::fs::write(&bad_path, b"fn b() {}").is_err() {
+            eprintln!("test env rejects non-UTF8 filenames; soft pass");
+            return;
+        }
+
+        let files = enumerate_files(dir.path(), &["rs"], false)
+            .expect("enumerate_files must not panic on non-UTF8 filenames");
+        // Either included or silently skipped — both are defensible.
+        // The contract under test is "no panic, returns Ok".
+        assert!(
+            files.len() <= 1,
+            "non-UTF8 file should yield at most 1 result, got {}",
+            files.len()
+        );
+    }
     /// Verifies that the `is_test_chunk` function correctly identifies test files based on filename patterns.
     ///
     /// # Arguments

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -436,4 +436,65 @@ mod tests {
         assert_eq!(freshness_poll_ms_initial(), 250);
         std::env::remove_var("CQS_FRESHNESS_POLL_MS");
     }
+
+    // ============ TC-ADV-V1.33-7: parse_env_usize_clamped + parse_env_f32 ====
+
+    /// TC-ADV-V1.33-7: above-max value clamps to max (not "use default").
+    #[test]
+    fn parse_env_usize_clamped_clamps_above_max() {
+        let key = "CQS_TEST_CLAMP_ABOVE_MAX";
+        std::env::set_var(key, "9999999");
+        // default=10, range [1, 100] — 9999999 must clamp to 100.
+        assert_eq!(parse_env_usize_clamped(key, 10, 1, 100), 100);
+        std::env::remove_var(key);
+    }
+
+    /// TC-ADV-V1.33-7: below-min value clamps to min.
+    #[test]
+    fn parse_env_usize_clamped_clamps_below_min() {
+        let key = "CQS_TEST_CLAMP_BELOW_MIN";
+        // Note: parse_env_usize_clamped requires `n > 0` to not fall back
+        // to default — pick min=5 so 1 is parseable but below-floor.
+        std::env::set_var(key, "1");
+        assert_eq!(parse_env_usize_clamped(key, 10, 5, 100), 5);
+        std::env::remove_var(key);
+    }
+
+    /// TC-ADV-V1.33-7: garbage value triggers fallback to (clamped) default.
+    /// Out-of-range default also gets clamped — pin the "default also
+    /// passes through clamp()" path documented in the helper.
+    #[test]
+    fn parse_env_usize_clamped_garbage_uses_clamped_default() {
+        let key = "CQS_TEST_CLAMP_GARBAGE";
+        std::env::set_var(key, "not_a_number");
+        // default=200 is above max=100 — clamp must apply to the default
+        // too, returning 100 not 200.
+        assert_eq!(parse_env_usize_clamped(key, 200, 1, 100), 100);
+        std::env::remove_var(key);
+    }
+
+    /// TC-ADV-V1.33-7: NaN string for `parse_env_f32` falls back to default
+    /// (`is_finite` filter rejects NaN before the unwrap_or).
+    #[test]
+    fn parse_env_f32_rejects_nan() {
+        let key = "CQS_TEST_F32_NAN";
+        std::env::set_var(key, "NaN");
+        assert_eq!(parse_env_f32(key, 0.5), 0.5);
+        std::env::remove_var(key);
+    }
+
+    /// TC-ADV-V1.33-7: `parse_env_f32` rejects negative and zero — the
+    /// helper's `*n > 0.0` filter is load-bearing for risk thresholds
+    /// (a 0.0 threshold would silently collapse the classification).
+    #[test]
+    fn parse_env_f32_rejects_negative_and_zero() {
+        let key = "CQS_TEST_F32_NEG";
+        std::env::set_var(key, "-1.5");
+        assert_eq!(parse_env_f32(key, 0.5), 0.5, "negative falls back");
+        std::env::set_var(key, "0.0");
+        assert_eq!(parse_env_f32(key, 0.5), 0.5, "zero falls back");
+        std::env::set_var(key, "0");
+        assert_eq!(parse_env_f32(key, 0.5), 0.5, "integer zero falls back");
+        std::env::remove_var(key);
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1151,6 +1151,62 @@ mod tests {
         );
     }
 
+    /// TC-ADV-V1.33-8: oversized files are silently skipped (Ok(vec![])),
+    /// not surfaced as an error. This is the documented contract — a
+    /// future refactor that surfaced the size cap as Err would break the
+    /// watch loop's "parse failures are recoverable" invariant.
+    #[test]
+    fn parse_file_returns_empty_vec_for_oversized_file() {
+        use std::sync::Mutex;
+        // CQS_PARSER_MAX_FILE_SIZE is process-global; serialise.
+        static PARSER_SIZE_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = PARSER_SIZE_LOCK.lock().unwrap();
+
+        let parser = Parser::new().unwrap();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("big.rs");
+        // Write a 200-byte Rust file; cap is set to 100 below.
+        std::fs::write(&path, vec![b'a'; 200]).unwrap();
+
+        let prev = std::env::var("CQS_PARSER_MAX_FILE_SIZE").ok();
+        std::env::set_var("CQS_PARSER_MAX_FILE_SIZE", "100");
+        let result = parser.parse_file(&path);
+        // Restore env immediately.
+        match prev {
+            Some(v) => std::env::set_var("CQS_PARSER_MAX_FILE_SIZE", v),
+            None => std::env::remove_var("CQS_PARSER_MAX_FILE_SIZE"),
+        }
+
+        let chunks = result.expect("oversized file must skip silently, not error");
+        assert!(
+            chunks.is_empty(),
+            "oversized file must produce empty Vec, got {} chunk(s)",
+            chunks.len()
+        );
+    }
+
+    /// TC-ADV-V1.33-8: non-UTF8 file content is silently skipped
+    /// (Ok(vec![])). Documented behaviour ("Returns an empty Vec for
+    /// non-UTF8 files (with a warning logged)") — pinning so a future
+    /// refactor that surfaced this as an error doesn't break the indexer.
+    #[test]
+    fn parse_file_returns_empty_vec_for_non_utf8_content() {
+        let parser = Parser::new().unwrap();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bad_utf8.rs");
+        // Write bytes that are not valid UTF-8 (lone continuation bytes).
+        std::fs::write(&path, [0xFFu8, 0xFE, 0xFD, 0xFC]).unwrap();
+
+        let chunks = parser
+            .parse_file(&path)
+            .expect("non-UTF8 file must skip silently, not error");
+        assert!(
+            chunks.is_empty(),
+            "non-UTF8 file must produce empty Vec, got {} chunk(s)",
+            chunks.len()
+        );
+    }
+
     /// P2 #63: property test pinning the equivalence between
     /// `parse_file_all_with_chunk_calls` (Pass-2 emit) and the previous
     /// per-chunk `extract_calls_from_chunk` loop the indexing pipeline used

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -1110,6 +1110,38 @@ mod tests {
         );
     }
 
+    /// TC-ADV-V1.33-4: pin that the length-mismatch error message contains
+    /// both lengths. P3.11 surfaced this as `InvalidArguments` so callers
+    /// can pattern-match the caller-bug case distinctly from model errors;
+    /// a future refactor that flipped the variant or dropped the lengths
+    /// from the message would break operator log-grep loops.
+    #[test]
+    fn test_rerank_with_passages_length_mismatch_returns_invalid_arguments() {
+        let reranker = NoopReranker::new();
+        // Three results, two passages — mismatch.
+        let mut results = vec![
+            stub_result("a", "first"),
+            stub_result("b", "second"),
+            stub_result("c", "third"),
+        ];
+        let passages = ["first passage", "second passage"];
+        let err = reranker
+            .rerank_with_passages("q", &mut results, &passages, 10)
+            .expect_err("length mismatch must error");
+        let msg = match err {
+            RerankerError::InvalidArguments(s) => s,
+            other => panic!("expected InvalidArguments, got {other:?}"),
+        };
+        assert!(
+            msg.contains("3"),
+            "error message must mention results.len()=3, got: {msg:?}"
+        );
+        assert!(
+            msg.contains("2"),
+            "error message must mention passages.len()=2, got: {msg:?}"
+        );
+    }
+
     /// `LlmReranker` is a skeleton — every score-producing call returns
     /// `RerankerError::Inference` so an integration test against the
     /// production search path can verify trait wiring without any
@@ -1127,6 +1159,101 @@ mod tests {
         assert!(
             msg.contains("skeleton"),
             "skeleton error must self-identify; got: {msg}"
+        );
+    }
+
+    // ===== TC-HAP-V1.33-10: resolve_reranker config-path coverage =====
+    //
+    // P1.7 fix shipped `OnnxReranker::with_section(section: Option<...>)`
+    // so `.cqs.toml` `[reranker]` `preset` / `model_path` / `tokenizer_path`
+    // override the hardcoded default. These tests pin the precedence chain
+    // documented at line 57-58 ("CLI → CQS_RERANKER_MODEL → [reranker]
+    // model_path → [reranker] preset → hardcoded ms-marco-minilm").
+    //
+    // Pure-config — no ONNX runtime needed, just `aux_model::resolve`
+    // dispatch. CQS_RERANKER_MODEL must be unset for deterministic
+    // results, hence the cross-test lock.
+
+    use std::sync::Mutex;
+    static RERANKER_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// TC-HAP-V1.33-10: `[reranker] preset = "ms-marco-minilm"` resolves
+    /// to the canonical preset config. Pins the preset branch (line 5 of
+    /// the precedence chain documented at reranker.rs:57-58).
+    #[test]
+    fn resolve_reranker_with_preset_resolves_to_preset_path() {
+        let _guard = RERANKER_ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("CQS_RERANKER_MODEL").ok();
+        std::env::remove_var("CQS_RERANKER_MODEL");
+
+        let section = AuxModelSection {
+            preset: Some("ms-marco-minilm".to_string()),
+            model_path: None,
+            tokenizer_path: None,
+        };
+        let cfg = resolve_reranker(Some(&section)).expect("resolve must succeed for preset");
+
+        // Restore env before any assertion so a panic doesn't leak state.
+        match prev {
+            Some(v) => std::env::set_var("CQS_RERANKER_MODEL", v),
+            None => std::env::remove_var("CQS_RERANKER_MODEL"),
+        }
+
+        assert_eq!(
+            cfg.preset.as_deref(),
+            Some("ms-marco-minilm"),
+            "preset name must round-trip through resolve"
+        );
+        assert_eq!(
+            cfg.repo.as_deref(),
+            Some("cross-encoder/ms-marco-MiniLM-L-6-v2"),
+            "ms-marco-minilm preset must point at the cross-encoder repo"
+        );
+    }
+
+    /// TC-HAP-V1.33-10: when no `[reranker]` section is provided,
+    /// `resolve_reranker` falls back to the hardcoded default preset
+    /// (`ms-marco-minilm`). Pins the last branch of the precedence chain.
+    #[test]
+    fn resolve_reranker_with_no_section_falls_back_to_default_preset() {
+        let _guard = RERANKER_ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("CQS_RERANKER_MODEL").ok();
+        std::env::remove_var("CQS_RERANKER_MODEL");
+
+        let cfg = resolve_reranker(None).expect("default-preset fallback must succeed");
+
+        match prev {
+            Some(v) => std::env::set_var("CQS_RERANKER_MODEL", v),
+            None => std::env::remove_var("CQS_RERANKER_MODEL"),
+        }
+
+        assert_eq!(
+            cfg.preset.as_deref(),
+            Some("ms-marco-minilm"),
+            "default fallback must be ms-marco-minilm"
+        );
+    }
+
+    /// TC-HAP-V1.33-10: model-loading variant — covers the full
+    /// `OnnxReranker::with_section` construction path. Gated `#[ignore]`
+    /// because the lazy session load that follows construction needs the
+    /// real ONNX model, but with_section itself only stores the section
+    /// (no model download). Runs in ci-slow.yml's full-suite job.
+    #[test]
+    #[ignore = "construction-only smoke; full reranker uses ms-marco-MiniLM model from ~/.cache/huggingface; runs in ci-slow.yml full-suite job"]
+    fn test_onnx_reranker_with_section() {
+        let section = AuxModelSection {
+            preset: Some("ms-marco-minilm".to_string()),
+            model_path: None,
+            tokenizer_path: None,
+        };
+        let reranker = OnnxReranker::with_section(Some(section.clone()))
+            .expect("with_section must construct without model load");
+        // The cached section is stored for lazy `model_paths` resolution.
+        // Sanity-check: the field is populated.
+        assert!(
+            reranker.section.is_some(),
+            "with_section must store the section for lazy resolve_reranker"
         );
     }
 }

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -1180,6 +1180,82 @@ mod tests {
         assert!(results.is_empty());
     }
 
+    /// TC-ADV-V1.33-1: `search_filtered` with `limit=0` must return an empty
+    /// result without panicking, even when the store has matching chunks.
+    /// Pins the contract that downstream `BoundedScoreHeap::new(0)` and
+    /// `semantic_limit = limit * 3 = 0` arithmetic don't blow up.
+    #[test]
+    fn test_search_filtered_limit_zero_returns_empty() {
+        let (store, _dir) = setup_store();
+        // Seed a chunk so the path actually traverses the cursor scan.
+        let c = make_chunk("alpha", "src/a.rs", Language::Rust, ChunkType::Function);
+        let emb = mock_embedding(1.0);
+        store
+            .upsert_chunks_batch(&[(c, emb.clone())], Some(12345))
+            .unwrap();
+
+        let filter = SearchFilter::default();
+        let results = store
+            .search_filtered(&emb, &filter, 0, 0.0)
+            .expect("limit=0 must not error");
+        assert!(
+            results.is_empty(),
+            "limit=0 must return empty result, got {} entries",
+            results.len()
+        );
+    }
+
+    /// TC-ADV-V1.33-1: same contract for `search_filtered_with_index` —
+    /// even with a vector index supplying candidate IDs, `limit=0` must
+    /// short-circuit (or naturally produce empty) without panic.
+    #[test]
+    fn test_search_filtered_with_index_limit_zero_returns_empty() {
+        use crate::embedder::Embedding;
+        use crate::index::{IndexResult, VectorIndex};
+
+        struct MockIdx {
+            candidate_id: String,
+        }
+        impl VectorIndex for MockIdx {
+            fn search(&self, _query: &Embedding, _k: usize) -> Vec<IndexResult> {
+                vec![IndexResult {
+                    id: self.candidate_id.clone(),
+                    score: 0.9,
+                }]
+            }
+            fn len(&self) -> usize {
+                1
+            }
+            fn name(&self) -> &'static str {
+                "MockIdx"
+            }
+            fn dim(&self) -> usize {
+                crate::EMBEDDING_DIM
+            }
+        }
+
+        let (store, _dir) = setup_store();
+        let c = make_chunk("alpha", "src/a.rs", Language::Rust, ChunkType::Function);
+        let chunk_id = c.id.clone();
+        let emb = mock_embedding(1.0);
+        store
+            .upsert_chunks_batch(&[(c, emb.clone())], Some(12345))
+            .unwrap();
+
+        let idx = MockIdx {
+            candidate_id: chunk_id,
+        };
+        let filter = SearchFilter::default();
+        let results = store
+            .search_filtered_with_index(&emb, &filter, 0, 0.0, Some(&idx))
+            .expect("limit=0 must not error");
+        assert!(
+            results.is_empty(),
+            "limit=0 with index must return empty result, got {} entries",
+            results.len()
+        );
+    }
+
     /// TC-7: Verify HNSW-guided path produces RRF results when enable_rrf is true.
     ///
     /// The search_by_candidate_ids path must apply the same RRF fusion as

--- a/src/splade/index.rs
+++ b/src/splade/index.rs
@@ -916,6 +916,60 @@ mod tests {
         assert_eq!(results.len(), 2);
     }
 
+    /// TC-ADV-V1.33-3: `SpladeIndex::search` with `k=0` must return empty
+    /// even on a populated index. `BoundedScoreHeap::new(0)` is tested
+    /// elsewhere; this pins the SPLADE call path that passes `k` straight in.
+    #[test]
+    fn test_search_k_zero_returns_empty() {
+        let index = make_test_index();
+        // Use a query that would otherwise match all three chunks.
+        let results = index.search(&vec![(1, 1.0), (2, 1.0), (3, 1.0)], 0);
+        assert!(
+            results.is_empty(),
+            "k=0 must return empty, got {} results",
+            results.len()
+        );
+    }
+
+    /// TC-ADV-V1.33-3: a query SparseVector with NaN weights must not
+    /// panic — the search loop's `query_weight * doc_weight` accumulator
+    /// must remain panic-free under the hostile input. NaN is allowed to
+    /// propagate into scores (current behaviour) but the call must complete.
+    #[test]
+    fn test_search_handles_nan_query_weights() {
+        let index = make_test_index();
+        // NaN on token 1 (which exists in the index for chunk_a + chunk_b).
+        let results = index.search(&vec![(1, f32::NAN)], 10);
+        // Contract: no panic. Today NaN propagates into the score comparator
+        // via `total_cmp`, so results may or may not be present — the
+        // load-bearing assertion is "did not crash".
+        for r in &results {
+            // Score may be NaN; just ensure id is a known chunk.
+            assert!(
+                r.id == "chunk_a" || r.id == "chunk_b",
+                "unexpected id in results: {}",
+                r.id
+            );
+        }
+    }
+
+    /// TC-ADV-V1.33-3: same panic-free contract for `f32::INFINITY`.
+    #[test]
+    fn test_search_handles_inf_query_weights() {
+        let index = make_test_index();
+        let results = index.search(&vec![(1, f32::INFINITY)], 10);
+        // Inf * positive doc_weight = Inf — sortable; first should be the
+        // matching chunk. We don't pin score values; just no crash + no
+        // unexpected ids.
+        for r in &results {
+            assert!(
+                r.id == "chunk_a" || r.id == "chunk_b",
+                "unexpected id in results: {}",
+                r.id
+            );
+        }
+    }
+
     #[test]
     fn test_persist_roundtrip() {
         let dir = tempfile::TempDir::new().unwrap();

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -1745,4 +1745,113 @@ mod tests {
             "file2.rs chunk should remain"
         );
     }
+
+    // ===== TC-HAP-V1.33-7: update_umap_coords_batch happy path =====
+
+    /// TC-HAP-V1.33-7: seed chunks, call `update_umap_coords_batch` with
+    /// finite values, verify the rows are written and `umap_x`/`umap_y`
+    /// round-trip via raw SELECT (matching how `build_cluster` reads them
+    /// in `serve/data.rs`).
+    #[test]
+    fn test_update_umap_coords_batch_writes_coords_atomically() {
+        let (store, _dir) = setup_store();
+
+        // Seed two chunks first (need real chunk rows for UPDATE-FROM
+        // semantics to land).
+        let c1 = make_chunk("alpha", "src/a.rs");
+        let c2 = make_chunk("beta", "src/b.rs");
+        let id1 = c1.id.clone();
+        let id2 = c2.id.clone();
+        let emb = mock_embedding(1.0);
+        store
+            .upsert_chunks_batch(&[(c1, emb.clone()), (c2, emb)], Some(100))
+            .unwrap();
+
+        // Apply UMAP coords.
+        let coords = vec![
+            (id1.clone(), 1.5_f64, -2.25_f64),
+            (id2.clone(), 0.25_f64, 3.75_f64),
+        ];
+        let updated = store.update_umap_coords_batch(&coords).unwrap();
+        assert_eq!(updated, 2, "expected 2 rows updated, got {updated}");
+
+        // Read back via raw SELECT (mirrors build_cluster's path).
+        store.runtime().block_on(async {
+            let (x1, y1): (f64, f64) =
+                sqlx::query_as("SELECT umap_x, umap_y FROM chunks WHERE id = ?1")
+                    .bind(&id1)
+                    .fetch_one(&store.pool)
+                    .await
+                    .unwrap();
+            assert!((x1 - 1.5).abs() < 1e-9, "x1 round-trip: got {x1}");
+            assert!((y1 - (-2.25)).abs() < 1e-9, "y1 round-trip: got {y1}");
+
+            let (x2, y2): (f64, f64) =
+                sqlx::query_as("SELECT umap_x, umap_y FROM chunks WHERE id = ?1")
+                    .bind(&id2)
+                    .fetch_one(&store.pool)
+                    .await
+                    .unwrap();
+            assert!((x2 - 0.25).abs() < 1e-9, "x2 round-trip: got {x2}");
+            assert!((y2 - 3.75).abs() < 1e-9, "y2 round-trip: got {y2}");
+        });
+    }
+
+    /// TC-HAP-V1.33-7: passing an extra unknown ID — the warn fires +
+    /// `updated` is < input length. Documents the partial-update path
+    /// the function uses when the projection script's input drifts.
+    #[test]
+    fn test_update_umap_coords_batch_handles_missing_ids() {
+        let (store, _dir) = setup_store();
+
+        // Seed one real chunk; submit two coords (one real id, one fake).
+        let c = make_chunk("gamma", "src/g.rs");
+        let real_id = c.id.clone();
+        let emb = mock_embedding(1.0);
+        store.upsert_chunks_batch(&[(c, emb)], Some(100)).unwrap();
+
+        let coords = vec![
+            (real_id.clone(), 0.5_f64, 0.5_f64),
+            ("not-an-id".to_string(), 1.0_f64, 1.0_f64),
+        ];
+        let updated = store.update_umap_coords_batch(&coords).unwrap();
+        assert_eq!(
+            updated, 1,
+            "fake id must not be written; expected 1 row updated, got {updated}"
+        );
+        assert!(
+            updated < coords.len(),
+            "updated ({updated}) < input.len() ({}) — pins the partial-update warn path",
+            coords.len()
+        );
+    }
+
+    // ===== TC-ADV-V1.33-10: update_umap_coords_batch NaN/Inf handling =====
+
+    /// TC-ADV-V1.33-10: pin current behaviour around NaN/Inf coords.
+    /// Today the temp table's `umap_x REAL NOT NULL` schema rejects NaN
+    /// (sqlx binds NaN as NULL → constraint violation), so the call
+    /// surfaces a SQLite error rather than panicking or silently
+    /// writing corrupt floats to `chunks`. This test pins that
+    /// observed status quo: a future fix that adds an explicit
+    /// `is_finite` guard at the helper boundary should produce a
+    /// different, more user-friendly error — flipping this test signals
+    /// that contract change.
+    #[test]
+    fn test_update_umap_coords_batch_rejects_nan_today() {
+        let (store, _dir) = setup_store();
+        let c = make_chunk("delta", "src/d.rs");
+        let id = c.id.clone();
+        let emb = mock_embedding(1.0);
+        store.upsert_chunks_batch(&[(c, emb)], Some(100)).unwrap();
+
+        // Hostile input: a NaN coord. Today this fails the temp table's
+        // NOT NULL constraint (NaN binds as NULL via sqlx).
+        let coords = vec![(id.clone(), f64::NAN, 0.5_f64)];
+        let result = store.update_umap_coords_batch(&coords);
+        assert!(
+            result.is_err(),
+            "NaN coord must surface as an error today, got {result:?}"
+        );
+    }
 }

--- a/tests/cli_convert_test.rs
+++ b/tests/cli_convert_test.rs
@@ -1,0 +1,130 @@
+#![cfg(feature = "slow-tests")]
+//! Reason this file is gated: subprocess-spawning CLI tests for `cqs convert`.
+//! Each test runs the full cqs binary cold start which is too expensive for
+//! PR-time CI. Run via `cargo test --features slow-tests` or nightly
+//! ci-slow.yml.
+//!
+//! TC-HAP-V1.33-1: `cqs convert` and `convert_path` had zero end-to-end
+//! tests. The submodules (html.rs, pdf.rs, chm.rs, cleaning.rs, naming.rs)
+//! have unit tests for their own helpers, but the entry-point glue —
+//! `cmd_convert` orchestrating overwrite-vs-skip, dry-run, the `output_dir`
+//! SEC-4 canonicalize/warn logic, and the `clean_tags` CSV split — was
+//! reachable only by the binary at runtime. These tests pin the orchestrator.
+
+use assert_cmd::Command;
+use serial_test::serial;
+use std::fs;
+use tempfile::TempDir;
+
+fn cqs() -> Command {
+    #[allow(deprecated)]
+    Command::cargo_bin("cqs").expect("Failed to find cqs binary")
+}
+
+/// TC-HAP-V1.33-1: single-file HTML conversion writes Markdown to the
+/// inferred output dir (parent of the source). Pins the happy path
+/// through `cmd_convert` → `convert_path` → `convert_file`.
+#[test]
+#[serial]
+fn convert_html_file_writes_markdown_to_inferred_dir() {
+    let dir = TempDir::new().expect("tempdir");
+    let html_path = dir.path().join("page.html");
+    fs::write(
+        &html_path,
+        "<html><body><h1>Title</h1><p>Body text.</p></body></html>",
+    )
+    .expect("write html");
+
+    let assert = cqs()
+        .args(["convert", html_path.to_str().unwrap()])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let out = assert.get_output();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Default: output dir is parent of source (the tempdir itself).
+    // The converter writes a file with a name derived from the title.
+    let entries: Vec<_> = fs::read_dir(dir.path())
+        .expect("readdir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    let md_files: Vec<&String> = entries.iter().filter(|n| n.ends_with(".md")).collect();
+    assert!(
+        !md_files.is_empty(),
+        "convert must write at least one .md file. \
+         dir contents: {entries:?}\nstdout: {stdout}"
+    );
+}
+
+/// TC-HAP-V1.33-1: directory containing multiple HTML files converts
+/// each. Pins the `convert_directory` branch of `convert_path`.
+#[test]
+#[serial]
+fn convert_directory_processes_multiple_files() {
+    let dir = TempDir::new().expect("tempdir");
+    let src_dir = dir.path().join("docs");
+    fs::create_dir_all(&src_dir).expect("mkdir docs");
+    fs::write(
+        src_dir.join("alpha.html"),
+        "<html><body><h1>Alpha</h1><p>A.</p></body></html>",
+    )
+    .expect("write alpha");
+    fs::write(
+        src_dir.join("beta.html"),
+        "<html><body><h1>Beta</h1><p>B.</p></body></html>",
+    )
+    .expect("write beta");
+
+    cqs()
+        .args(["convert", src_dir.to_str().unwrap()])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // Output goes into the source dir by default.
+    let entries: Vec<_> = fs::read_dir(&src_dir)
+        .expect("readdir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    let md_count = entries.iter().filter(|n| n.ends_with(".md")).count();
+    assert!(
+        md_count >= 2,
+        "directory convert must produce ≥2 .md files for 2 inputs. \
+         got: {entries:?}"
+    );
+}
+
+/// TC-HAP-V1.33-1: `--dry-run` must NOT write any files. Pins the
+/// dry-run branch in `convert_file` / `finalize_output`.
+#[test]
+#[serial]
+fn convert_dry_run_does_not_write_files() {
+    let dir = TempDir::new().expect("tempdir");
+    let html_path = dir.path().join("page.html");
+    fs::write(
+        &html_path,
+        "<html><body><h1>Dry</h1><p>Run.</p></body></html>",
+    )
+    .expect("write html");
+
+    cqs()
+        .args(["convert", html_path.to_str().unwrap(), "--dry-run"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // No .md files should exist.
+    let entries: Vec<_> = fs::read_dir(dir.path())
+        .expect("readdir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    let md_count = entries.iter().filter(|n| n.ends_with(".md")).count();
+    assert_eq!(
+        md_count, 0,
+        "dry-run must not write any .md files; got: {entries:?}"
+    );
+}

--- a/tests/cli_eval_reranker_test.rs
+++ b/tests/cli_eval_reranker_test.rs
@@ -1,0 +1,150 @@
+#![cfg(feature = "slow-tests")]
+//! Reason this file is gated: subprocess-spawning CLI tests for
+//! `cqs eval --reranker`. Each test runs the full cqs binary cold start
+//! which is too expensive for PR-time CI. Run via
+//! `cargo test --features slow-tests` or nightly ci-slow.yml.
+//!
+//! TC-HAP-V1.33-2: `cqs eval --reranker` flag (#1303 / v1.33.0) had zero
+//! CLI integration test. `RerankerMode::{None, Onnx, Llm}` was added with
+//! three branches in `cmd_eval`: `None` short-circuits, `Onnx` builds via
+//! `ctx.reranker()`, `Llm` eagerly constructs `LlmReranker::new()` so the
+//! "not yet implemented" error fires before the search loop. These tests
+//! pin the `none` and `llm` branches at the binary level — `onnx` requires
+//! the model fixture, deferred to ci-slow's full-suite.
+
+use assert_cmd::Command;
+use serde_json::json;
+use serial_test::serial;
+use std::fs;
+use tempfile::TempDir;
+
+fn cqs() -> Command {
+    #[allow(deprecated)]
+    Command::cargo_bin("cqs").expect("Failed to find cqs binary")
+}
+
+fn cqs_no_daemon() -> Command {
+    let mut c = cqs();
+    c.env("CQS_NO_DAEMON", "1");
+    // Tests are independent of freshness gating — turn it off so the
+    // binary doesn't spin trying to connect to a daemon.
+    c.env("CQS_EVAL_REQUIRE_FRESH", "0");
+    c
+}
+
+fn write_minimal_queries(dir: &TempDir) -> std::path::PathBuf {
+    let queries = json!({
+        "queries": [
+            {
+                "query": "any query",
+                "category": "structural_search",
+                "gold_chunk": {
+                    "name": "missing_function",
+                    "origin": "src/missing.rs",
+                    "line_start": 1,
+                }
+            }
+        ]
+    });
+    let q_path = dir.path().join("queries.json");
+    fs::write(&q_path, queries.to_string()).expect("write queries");
+    q_path
+}
+
+fn seed_minimal_store(dir: &TempDir) {
+    let cqs_dir = dir.path().join(".cqs");
+    fs::create_dir_all(&cqs_dir).expect("create .cqs dir");
+    let store_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+    let store = cqs::Store::open(&store_path).expect("open seed store");
+    store
+        .init(&cqs::store::ModelInfo::default())
+        .expect("init seed store");
+}
+
+/// TC-HAP-V1.33-2: `--reranker none` is the historical retrieval-only
+/// pipeline. The flag must parse and the binary must reach the eval
+/// handler without complaining about an unrecognized option.
+#[test]
+#[serial]
+fn eval_with_reranker_none_parses_and_reaches_handler() {
+    let dir = TempDir::new().expect("tempdir");
+    seed_minimal_store(&dir);
+    let q_path = write_minimal_queries(&dir);
+
+    let result = cqs_no_daemon()
+        .args([
+            "eval",
+            q_path.to_str().unwrap(),
+            "--reranker",
+            "none",
+            "--json",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .expect("run cqs eval");
+
+    let stdout = String::from_utf8_lossy(&result.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&result.stderr).to_string();
+
+    // Pin: clap accepts `--reranker none` (no "unrecognized" error).
+    assert!(
+        !stderr.contains("error: unrecognized")
+            && !stderr.contains("error: invalid value")
+            && !stderr.contains("error: a value is required"),
+        "args must parse — got CLI parse error. stderr={stderr}"
+    );
+    // The binary may fail at embedder init if the model isn't on disk —
+    // that's acceptable. What matters is it reached the eval path.
+    assert!(
+        !stderr.contains("Index not found"),
+        "should find seeded store. stdout={stdout} stderr={stderr}"
+    );
+}
+
+/// TC-HAP-V1.33-2: `--reranker llm` eagerly constructs the skeleton
+/// `LlmReranker`, which surfaces "not yet implemented" before the
+/// search loop spins up. Pins the early-construction contract — a
+/// regression that delayed construction until first scoring would
+/// burn minutes on retrieval before failing.
+#[test]
+#[serial]
+fn eval_with_reranker_llm_returns_skeleton_error() {
+    let dir = TempDir::new().expect("tempdir");
+    seed_minimal_store(&dir);
+    let q_path = write_minimal_queries(&dir);
+
+    let result = cqs_no_daemon()
+        .args([
+            "eval",
+            q_path.to_str().unwrap(),
+            "--reranker",
+            "llm",
+            "--json",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .expect("run cqs eval");
+
+    let stdout = String::from_utf8_lossy(&result.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&result.stderr).to_string();
+    let combined = format!("{stdout}\n{stderr}");
+
+    // Either the skeleton error fires (preferred), or the embedder
+    // fails to load (acceptable in test env without a model). The
+    // load-bearing assertion: the binary did NOT silently succeed with
+    // an unimplemented LLM scorer.
+    let skeleton_hit = combined.to_ascii_lowercase().contains("skeleton")
+        || combined
+            .to_ascii_lowercase()
+            .contains("not yet implemented");
+    let embedder_failed = combined.contains("Embedder")
+        || combined.contains("ModelDownload")
+        || combined.contains("model")
+        || stderr.contains("Failed to");
+
+    assert!(
+        skeleton_hit || embedder_failed,
+        "llm reranker mode must surface skeleton error or embedder failure, \
+         not silently succeed.\nstdout={stdout}\nstderr={stderr}"
+    );
+}

--- a/tests/cli_notes_test.rs
+++ b/tests/cli_notes_test.rs
@@ -270,6 +270,129 @@ fn test_notes_add_sentiment_clamps() {
     );
 }
 
+/// TC-HAP-V1.33-6: `notes update --new-kind` sets `kind` on a kind-less
+/// note. Pins the field-mutation path added in PR #1278.
+#[test]
+#[serial]
+fn test_notes_update_changes_kind() {
+    let dir = setup_notes_project();
+    notes_add_json(&dir, "kind change note", "0.0", None);
+
+    cqs()
+        .args([
+            "--json",
+            "notes",
+            "update",
+            "kind change note",
+            "--new-kind",
+            "deprecation",
+            "--no-reindex",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let notes = read_notes(&dir);
+    assert_eq!(notes.len(), 1);
+    assert_eq!(
+        notes[0].kind.as_deref(),
+        Some("deprecation"),
+        "expected kind=deprecation after update, got {:?}",
+        notes[0].kind
+    );
+}
+
+/// TC-HAP-V1.33-6: passing an empty/whitespace `--new-kind` clears the
+/// kind. Pins the three-state normalization at notes.rs:441-448
+/// (`Some(None)` means "clear", distinct from `None` meaning "leave alone").
+#[test]
+#[serial]
+fn test_notes_update_clears_kind_with_empty_value() {
+    let dir = setup_notes_project();
+    // Seed a note that already has a kind.
+    cqs()
+        .args([
+            "--json",
+            "notes",
+            "add",
+            "note with kind",
+            "--sentiment",
+            "0.0",
+            "--kind",
+            "todo",
+            "--no-reindex",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // Sanity: kind landed.
+    let before = read_notes(&dir);
+    assert_eq!(before[0].kind.as_deref(), Some("todo"));
+
+    // Now clear it via empty `--new-kind`.
+    cqs()
+        .args([
+            "notes",
+            "update",
+            "note with kind",
+            "--new-kind",
+            "",
+            "--no-reindex",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let after = read_notes(&dir);
+    assert_eq!(after.len(), 1);
+    assert!(
+        after[0].kind.is_none(),
+        "empty --new-kind must clear, got {:?}",
+        after[0].kind
+    );
+}
+
+/// TC-HAP-V1.33-6: `--new-mentions` replaces the mentions list. Pins
+/// the mentions-merge clone at notes.rs:467-469.
+#[test]
+#[serial]
+fn test_notes_update_changes_mentions() {
+    let dir = setup_notes_project();
+    notes_add_json(&dir, "mention swap note", "0.0", Some("foo.rs,bar"));
+    let before = read_notes(&dir);
+    assert!(before[0].mentions.iter().any(|m| m == "foo.rs"));
+
+    cqs()
+        .args([
+            "notes",
+            "update",
+            "mention swap note",
+            "--new-mentions",
+            "baz.rs,qux",
+            "--no-reindex",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let after = read_notes(&dir);
+    assert_eq!(after.len(), 1);
+    let mentions = &after[0].mentions;
+    assert!(
+        mentions.iter().any(|m| m == "baz.rs"),
+        "new mentions must include baz.rs, got {mentions:?}"
+    );
+    assert!(
+        mentions.iter().any(|m| m == "qux"),
+        "new mentions must include qux, got {mentions:?}"
+    );
+    assert!(
+        !mentions.iter().any(|m| m == "foo.rs"),
+        "old mentions must be replaced, got {mentions:?}"
+    );
+}
+
 /// TC-HP-2f: update against a non-existent text errors cleanly instead of
 /// silently rewriting the notes file.
 #[test]

--- a/tests/cli_slot_test.rs
+++ b/tests/cli_slot_test.rs
@@ -1,0 +1,135 @@
+#![cfg(feature = "slow-tests")]
+//! Reason this file is gated: subprocess-spawning CLI tests for `cqs slot
+//! {list,create,promote,remove,active}`. Each test runs the full cqs binary
+//! cold start which is too expensive for PR-time CI. Run via
+//! `cargo test --features slow-tests` or nightly ci-slow.yml.
+//!
+//! TC-HAP-V1.33-3: the slot subcommand surface (5 verbs) had zero
+//! binary-level integration tests. `tests/slots_and_cache_integration.rs`
+//! covers the library-level helpers but skips the entire `cmd_slot`
+//! dispatch path including `--json` envelope shape per subcommand,
+//! the `bail!` when global `--slot` is passed (P2.13), exit-code
+//! stability, and `cqs slot promote` swapping the active pointer.
+
+use assert_cmd::Command;
+use serde_json::Value;
+use serial_test::serial;
+use std::fs;
+use tempfile::TempDir;
+
+fn cqs() -> Command {
+    #[allow(deprecated)]
+    Command::cargo_bin("cqs").expect("Failed to find cqs binary")
+}
+
+fn cqs_no_daemon() -> Command {
+    let mut c = cqs();
+    c.env("CQS_NO_DAEMON", "1");
+    c
+}
+
+/// Spin up an empty project with a `.cqs` directory so `find_project_root`
+/// resolves to the temp dir.
+fn setup_project() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    let cqs_dir = dir.path().join(".cqs");
+    fs::create_dir_all(&cqs_dir).expect("create .cqs dir");
+    dir
+}
+
+fn run_slot_json(dir: &TempDir, args: &[&str]) -> Value {
+    let output = cqs_no_daemon()
+        .arg("--json")
+        .arg("slot")
+        .args(args)
+        .current_dir(dir.path())
+        .output()
+        .expect("cqs slot failed to spawn");
+    assert!(
+        output.status.success(),
+        "cqs slot {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("slot JSON parse failed: {e}\nstdout={stdout}"))
+}
+
+/// TC-HAP-V1.33-3: `cqs slot list --json` against a fresh `.cqs/` returns
+/// a parseable envelope. Empty before any slot creation.
+#[test]
+#[serial]
+fn slot_list_after_init_shows_no_slots() {
+    let dir = setup_project();
+    let envelope = run_slot_json(&dir, &["list"]);
+    assert!(envelope["data"].is_object(), "data must be object");
+    let slots = envelope["data"]["slots"]
+        .as_array()
+        .expect("slots must be array");
+    assert!(slots.is_empty(), "fresh .cqs/ has no slots; got: {slots:?}");
+}
+
+/// TC-HAP-V1.33-3: `slot create` adds a slot dir and `slot list` reflects it.
+#[test]
+#[serial]
+fn slot_create_then_list_includes_new_slot() {
+    let dir = setup_project();
+    run_slot_json(&dir, &["create", "test_slot_a"]);
+
+    let envelope = run_slot_json(&dir, &["list"]);
+    let slots = envelope["data"]["slots"].as_array().unwrap();
+    let names: Vec<&str> = slots.iter().map(|s| s["name"].as_str().unwrap()).collect();
+    assert!(
+        names.contains(&"test_slot_a"),
+        "list must include created slot, got: {names:?}"
+    );
+    // Slot dir on disk
+    let slot_dir = dir.path().join(".cqs/slots/test_slot_a");
+    assert!(slot_dir.exists(), "slot dir must exist on disk");
+}
+
+/// TC-HAP-V1.33-3: `slot promote` swaps the active pointer. Pins the
+/// atomic-pointer-update contract.
+#[test]
+#[serial]
+fn slot_promote_swaps_active_pointer() {
+    let dir = setup_project();
+    run_slot_json(&dir, &["create", "alpha"]);
+    run_slot_json(&dir, &["create", "beta"]);
+
+    // Promote beta and verify `slot active` reflects it.
+    run_slot_json(&dir, &["promote", "beta"]);
+    let active = run_slot_json(&dir, &["active"]);
+    let active_name = active["data"]
+        .as_str()
+        .or_else(|| active["data"]["active"].as_str())
+        .expect("active envelope must carry name");
+    assert_eq!(
+        active_name, "beta",
+        "after promote beta, active must be beta. envelope: {active}"
+    );
+}
+
+/// TC-HAP-V1.33-3: P2.13 — `--slot` global flag is rejected on `slot`
+/// subcommands (positional name overrides the global). Pins the bail.
+#[test]
+#[serial]
+fn slot_subcommand_rejects_global_slot_flag() {
+    let dir = setup_project();
+    let result = cqs_no_daemon()
+        .args(["--slot", "ignored", "slot", "list"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn cqs");
+
+    assert!(
+        !result.status.success(),
+        "global --slot on `cqs slot` must fail (P2.13)"
+    );
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("--slot has no effect") || stderr.contains("project-scoped"),
+        "P2.13 bail message must explain why; got: {stderr}"
+    );
+}

--- a/tests/graph_test.rs
+++ b/tests/graph_test.rs
@@ -236,6 +236,46 @@ fn trace_no_path_returns_none() {
     );
 }
 
+/// TC-HAP-V1.33-4: pin the lib-level integration the CLI's
+/// `build_trace_output` orchestrates — BFS over the call graph followed
+/// by `search_by_names_batch` to resolve each hop's chunk metadata.
+/// `build_trace_output` itself is `pub(crate)` of the binary crate so
+/// this test exercises the same primitives in the same order.
+#[test]
+fn trace_resolves_hop_metadata_via_search_by_names_batch() {
+    let f = graph_corpus();
+    let graph = f.store.get_call_graph().expect("get_call_graph");
+    // BFS gives us the path of names; resolve each via batch search
+    // (same call build_trace_output makes at line 54).
+    let path = shortest_call_path(&graph.forward, "main", "validate", 5).expect("path must exist");
+    let name_refs: Vec<&str> = path.iter().map(|s| s.as_str()).collect();
+    let batch = f
+        .store
+        .search_by_names_batch(&name_refs, 1)
+        .expect("search_by_names_batch");
+
+    // Every hop must resolve to at least one chunk — that's the
+    // load-bearing invariant; without it the JSON envelope's `path` array
+    // ships hops with empty file/line_start and `build_trace_output`'s
+    // tracing::warn fires (which itself is a regression signal).
+    for name in &path {
+        let hits = batch
+            .get(name.as_str())
+            .unwrap_or_else(|| panic!("name {name:?} missing from batch"));
+        // `build_trace_output` takes `.first()` (line 59) — pin the
+        // contract that every hop resolves to AT LEAST ONE chunk so
+        // no hop falls into the warn-fallback path that emits empty
+        // file/line_start in the JSON envelope.
+        let first = hits.first().expect("first hit");
+        assert!(
+            first.chunk.line_start > 0,
+            "resolved hop {name:?} must have non-zero line_start \
+             (would be 0 in the warn-fallback path); first match: name={:?}",
+            first.chunk.name
+        );
+    }
+}
+
 // ---------------------------------------------------------------------
 // impact (2 tests)
 // ---------------------------------------------------------------------
@@ -337,6 +377,64 @@ fn explain_process_reports_callers_and_callees() {
     assert!(
         callee_names.contains(&"validate") || callee_names.contains(&"transform"),
         "process calls validate + transform; got callees {callee_names:?}"
+    );
+}
+
+/// TC-HAP-V1.33-5: pin the full `build_explain_data` contract at the lib
+/// level — callers, callees, similar (semantic search), and hints all
+/// firing together for a real chunk. The CLI handler `build_explain_data`
+/// is `pub(crate)` of the binary crate so this test exercises the same
+/// primitives in the same orchestration order.
+#[test]
+fn explain_data_integrates_callers_callees_similar_and_hints() {
+    let f = graph_corpus();
+    // 1. Resolve target chunk via search (same path build_explain_data uses
+    //    via `cqs::resolve_target`).
+    let hits = f.search("process", 10).expect("search process");
+    let chunk = hits
+        .iter()
+        .find(|h| h.chunk.name == "process")
+        .map(|h| h.chunk.clone())
+        .expect("process chunk must be indexed");
+
+    // 2. Callers + callees (call graph integration).
+    let callers = f.store.get_callers_full(&chunk.name).expect("callers");
+    let callees = f
+        .store
+        .get_callees_full(&chunk.name, Some(&chunk.file.to_string_lossy()))
+        .expect("callees");
+
+    // 3. Similar via semantic search seeded with the chunk's stored
+    //    embedding (same path build_explain_data uses).
+    let (_chunk_again, embedding) = f
+        .store
+        .get_chunk_with_embedding(&chunk.id)
+        .expect("get_chunk_with_embedding")
+        .expect("chunk must have an embedding");
+    let filter = cqs::store::SearchFilter::default();
+    let similar = f
+        .store
+        .search_filtered(&embedding, &filter, 4, 0.0)
+        .expect("search_filtered for similar");
+
+    // 4. Hints (cqs::compute_hints — same call build_explain_data makes
+    //    when chunk_type.is_callable()).
+    let hints = cqs::compute_hints(&f.store.store, &chunk.name, Some(callers.len()))
+        .expect("compute_hints");
+
+    // Pin the integrated contract: every primitive yields data, and the
+    // hint counter aligns with the caller list — that alignment is the
+    // load-bearing invariant build_explain_data depends on.
+    assert!(!callers.is_empty(), "process has callers");
+    assert!(!callees.is_empty(), "process has callees");
+    assert!(
+        similar.iter().any(|r| r.chunk.id == chunk.id),
+        "similar must surface the seed chunk itself"
+    );
+    assert_eq!(
+        hints.caller_count,
+        callers.len(),
+        "compute_hints caller_count must match the explicit callers list"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes the C11 test-coverage tranche of the v1.33.0 audit (`docs/audit-findings.md` `## Test Coverage (adversarial)` + `## Test Coverage (happy path)`). Adds **17 tests** covering the documented gaps without changing any production code.

### Adversarial (TC-ADV-V1.33-1..-10)

| ID | Test | File |
|----|------|------|
| TC-ADV-V1.33-1 | `search_filtered`/`search_filtered_with_index` `limit=0` returns empty | `src/search/query.rs` |
| TC-ADV-V1.33-2 | `HnswIndex::search` `k=0` returns empty | `src/hnsw/build.rs` |
| TC-ADV-V1.33-3 | `SpladeIndex::search` `k=0` + NaN/Inf query weights | `src/splade/index.rs` |
| TC-ADV-V1.33-4 | `rerank_with_passages` length-mismatch error message contains both lengths | `src/reranker.rs` |
| TC-ADV-V1.33-5 | `enumerate_files` symlink / oversized / non-UTF8 filename | `src/lib.rs` |
| TC-ADV-V1.33-6 | `QueryCache::get` malformed-blob auto-delete | `src/cache.rs` |
| TC-ADV-V1.33-7 | `parse_env_usize_clamped` clamp branches + `parse_env_f32` NaN/zero rejection | `src/limits.rs` |
| TC-ADV-V1.33-8 | `CqParser::parse_file` non-UTF8 + oversized skip | `src/parser/mod.rs` |
| TC-ADV-V1.33-9 | `validate_and_read_file` `CQS_READ_MAX_FILE_SIZE` branch | `src/cli/commands/io/read.rs` |
| TC-ADV-V1.33-10 | `update_umap_coords_batch` NaN today (NOT NULL constraint) | `src/store/chunks/crud.rs` |

### Happy path (TC-HAP-V1.33-1..-7, -10)

| ID | Test | File | Gating |
|----|------|------|--------|
| TC-HAP-V1.33-1 | `cqs convert` HTML / dir / dry-run | `tests/cli_convert_test.rs` | `slow-tests` (new file) |
| TC-HAP-V1.33-2 | `cqs eval --reranker none/llm` | `tests/cli_eval_reranker_test.rs` | `slow-tests` (new file) |
| TC-HAP-V1.33-3 | `cqs slot {list,create,promote}` + P2.13 global-flag bail | `tests/cli_slot_test.rs` | `slow-tests` (new file) |
| TC-HAP-V1.33-4 | trace BFS + `search_by_names_batch` integration | `tests/graph_test.rs` | fast lib unit |
| TC-HAP-V1.33-5 | explain callers/callees/similar/hints integration | `tests/graph_test.rs` | fast lib unit |
| TC-HAP-V1.33-6 | `cqs notes update --new-kind / --new-mentions` (#1278) | `tests/cli_notes_test.rs` | fast lib unit |
| TC-HAP-V1.33-7 | `update_umap_coords_batch` happy path + missing-id partial update | `src/store/chunks/crud.rs` | fast lib unit |
| TC-HAP-V1.33-10 | `OnnxReranker::with_section` construction smoke | `src/reranker.rs` | `#[ignore]` (model in HF cache) |

### Notes

- TC-HAP-V1.33-8/9/11 (`run_umap_projection`, `cmd_gc`, `cqs serve` end-to-end) are not in this PR — gating table excluded them.
- TC-ADV-V1.33-10 was rewritten from "accepts NaN today" to "rejects NaN today via NOT NULL constraint" — first-run revealed sqlx binds NaN as NULL, hitting the temp-table constraint. Test pins observed behaviour; a future `is_finite` guard at the helper boundary would flip the test.
- Slow-tests files start with the documented `#![cfg(feature = "slow-tests")]` guard + reason comment.
- TC-HAP-V1.33-4 / -5 exercise lib primitives in the same orchestration order as the binary-crate `build_trace_output` / `build_explain_data` (those handlers themselves are `pub(crate)` of the binary crate so unreachable from `tests/`).

## Test plan

- [x] `cargo check --features cuda-index --tests --features slow-tests` clean
- [x] All 17 fast-lib tests pass (`cargo test --features cuda-index --lib <name>` per finding)
- [x] All 4 graph_test / cli_notes_test integration tests pass
- [x] All 3 slow-tests files pass under `cargo test --features slow-tests`
- [x] `cargo fmt --check` clean
- [x] No production code changed (verify via `git diff main -- src/` — only test additions in `mod tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
