### PR TITLE
fix(audit): footgun-pub cluster - P1-31, P1-32, P1-33, P3-12, P3-28

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -58,9 +58,9 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 | P1-28 | Code Quality | `generate_nl_description` legacy 1-arg wrapper still on watch + bulk hot paths | medium | ⬜ |
 | P1-29 | Code Quality | `embed_documents` inner batch loop hardcodes 64, ignores model dim/seq | easy | ⬜ |
 | P1-30 | Code Quality | `model_repo()` discards override and silently lies in `cmd_doctor` | easy | ⬜ |
-| P1-31 | Code Quality | `index_pack` uses `break` while `token_pack` uses `continue` (P1.18 mirror miss) | easy | ⬜ |
-| P1-32 | Code Quality | `search_embedding_only` `pub` wrapper with zero callers + self-warning footgun | easy | ⬜ |
-| P1-33 | Code Quality | `LlmReranker` exported `pub` but stub returns `Err` from every score call | easy | ⬜ |
+| P1-31 | Code Quality | `index_pack` uses `break` while `token_pack` uses `continue` (P1.18 mirror miss) | easy | ✅ |
+| P1-32 | Code Quality | `search_embedding_only` `pub` wrapper with zero callers + self-warning footgun | easy | ✅ |
+| P1-33 | Code Quality | `LlmReranker` exported `pub` but stub returns `Err` from every score call | easy | ✅ |
 | P1-34 | Scaling | CagraBackend gate uses zero-arg `gpu_available()`, defeats P2.42 VRAM check | easy | ⬜ |
 | P1-35 | Scaling | type_edges INSERT_BATCH=249 still uses pre-2020 SQLite limit | easy | ⬜ |
 | P1-36 | Scaling | chunks/embeddings.rs and chunks/query.rs BATCH_SIZE=500 legacy SQLite limit | easy | ⬜ |
@@ -139,7 +139,7 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 | P3-9 | Robustness | `set_on_item_complete` lock().unwrap() — duplicate of EH-V1.33-2 | easy | ⬜ |
 | P3-10 | Code Quality | `check_model_version()` wrapper dead in production | easy | ⬜ |
 | P3-11 | Code Quality | `is_false`/`is_zero_usize` trivial helpers duplicated 3+2 times across modules | easy | ⬜ |
-| P3-12 | Code Quality | `search_unified_with_index` is `pub` 6-line wrapper post-SQ-9 | easy | ⬜ |
+| P3-12 | Code Quality | `search_unified_with_index` is `pub` 6-line wrapper post-SQ-9 | easy | ✅ |
 | P3-13 | Scaling | BM25 K1=1.2, B=0.75 hardcoded in train_data without rationale or env override | easy | ⬜ |
 | P3-14 | Scaling | BM25 FTS5 column weights duplicated as inline SQL string at two sites | easy | ⬜ |
 | P3-15 | Scaling | cagra build_from_store BATCH_SIZE=10_000 hardcoded, doesn't scale with dim | easy | ⬜ |
@@ -155,7 +155,7 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 | P3-25 | API Design | `cqs project register` lacks `--json` and skips JSON envelope | easy | ⬜ |
 | P3-26 | API Design | `cqs notes add\|update\|remove` accept no `--json` at subcommand level | easy | ⬜ |
 | P3-27 | API Design | `cqs slot`/`cqs cache` still advertise `--slot` even though it bails | easy | ⬜ |
-| P3-28 | API Design | Public `Store::search_embedding_only` is `pub` footgun — visibility flip (overlaps P1-32) | easy | ⬜ |
+| P3-28 | API Design | Public `Store::search_embedding_only` is `pub` footgun — visibility flip (overlaps P1-32) | easy | ✅ |
 | P3-29 | API Design | `project register` vs `ref add` — same operation, two verbs | easy | ⬜ |
 | P3-30 | API Design | `--json` declared inline on six commands instead of via shared `TextJsonArgs` | easy | ⬜ |
 | P3-31 | API Design | `StoreError::SchemaMismatch(String, i32, i32)` uses positional fields | easy | ⬜ |

--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -265,7 +265,7 @@ pub(in crate::cli::batch) fn dispatch_search(
             .map(cqs::store::UnifiedResult::Code)
             .collect()
     } else {
-        ctx.store().search_unified_with_index(
+        ctx.store().search_code_results(
             &query_embedding,
             &filter,
             effective_limit,

--- a/src/cli/commands/eval/mod.rs
+++ b/src/cli/commands/eval/mod.rs
@@ -93,9 +93,10 @@ pub(crate) struct EvalCmdArgs {
     /// Apply a reranker stage after retrieval. Default `none` (skip
     /// reranking) preserves the historical eval pipeline. `onnx` runs
     /// the cross-encoder configured by `[reranker]` / `CQS_RERANKER_MODEL`.
-    /// `llm` resolves to [`cqs::LlmReranker`], which is a skeleton today
-    /// (errors on first call) and is included so the flag can absorb the
-    /// LlmReranker landing without a breaking API change.
+    /// `llm` is reserved for the LLM-judge reranker landing in #1220 and
+    /// currently bails with a "not yet implemented" error; the variant is
+    /// kept on the flag so the production wiring can land without a
+    /// breaking CLI change.
     ///
     /// When `onnx` or `llm` is selected, stage 1 over-retrieves to the
     /// `rerank_pool_size(limit)` cap (mirrors `cqs <q> --rerank`); stage 2
@@ -111,15 +112,16 @@ pub(crate) struct EvalCmdArgs {
 ///
 /// Mirrors the production three-impl set introduced in #1276 (`OnnxReranker`,
 /// `NoopReranker`, `LlmReranker`). `None` short-circuits the entire reranker
-/// path; `Onnx` and `Llm` route through [`crate::cli::CommandContext::reranker`]
-/// in a follow-up wiring pass.
+/// path; `Onnx` routes through [`crate::cli::CommandContext::reranker`]; `Llm`
+/// is reserved for the production wiring landing in #1220 and currently bails
+/// with a "not yet implemented" error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub(crate) enum RerankerMode {
     /// No reranking — stage-1 retrieval is the final answer (default).
     None,
     /// Cross-encoder reranker via [`cqs::OnnxReranker`].
     Onnx,
-    /// LLM reranker via [`cqs::LlmReranker`]. Skeleton today; errors on first call.
+    /// LLM reranker — reserved for #1220, currently errors on selection.
     Llm,
 }
 
@@ -189,12 +191,15 @@ pub(crate) fn cmd_eval(ctx: &CommandContext<'_, ReadOnly>, args: &EvalCmdArgs) -
         RerankerMode::None => None,
         RerankerMode::Onnx => Some(ctx.reranker()?),
         RerankerMode::Llm => {
-            // LlmReranker is a skeleton — eagerly construct so the eval
-            // user sees the "not yet implemented" error before the search
-            // loop spins up the index, not after spending minutes on
-            // retrieval.
-            let r: std::sync::Arc<dyn cqs::Reranker> = std::sync::Arc::new(cqs::LlmReranker::new());
-            Some(r)
+            // CQ-V1.33.0-8: the underlying `LlmReranker` is a SCAFFOLD-ONLY
+            // crate-private stub (every score call returns Err). Bail before
+            // the search loop spins up so the eval user sees the unsupported
+            // mode immediately instead of after minutes of retrieval. When
+            // the production wiring lands (#1220), this branch goes back to
+            // constructing the real reranker.
+            anyhow::bail!(
+                "--reranker llm is not yet implemented (#1220). Use `--reranker onnx` or omit the flag."
+            );
         }
     };
 

--- a/src/cli/commands/eval/runner.rs
+++ b/src/cli/commands/eval/runner.rs
@@ -1,6 +1,6 @@
 //! Eval runner: load query set, run search per query, score against gold chunks.
 //!
-//! Reuses the production search path (`search_unified_with_index` /
+//! Reuses the production search path (`search_code_results` /
 //! `search_hybrid`) so eval results match what `cqs <query>` returns. The
 //! filter construction mirrors `cmd_query` in
 //! `src/cli/commands/search/query.rs` — same SPLADE alpha resolution, same
@@ -365,13 +365,7 @@ fn search_for_rank(
         )?;
         code.into_iter().map(UnifiedResult::Code).collect()
     } else {
-        store.search_unified_with_index(
-            &query_embedding,
-            &filter,
-            stage1_limit,
-            threshold,
-            index,
-        )?
+        store.search_code_results(&query_embedding, &filter, stage1_limit, threshold, index)?
     };
 
     // Apply reranker (when enabled): pull out the SearchResult payloads,

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -518,7 +518,11 @@ pub(crate) fn index_pack(
     for idx in order {
         let cost = token_counts[idx] + overhead_per_item;
         if used + cost > budget && !kept.is_empty() {
-            break;
+            // P1.18 parity (CQ-V1.33.0-4): skip oversized mid-stream items but
+            // keep probing — smaller, lower-scored items may still fit in the
+            // remaining budget. Mirrors `token_pack`'s behavior so waterfall
+            // budgeting in `task::pack_section` doesn't silently truncate.
+            continue;
         }
         // Mirror token_pack's 10x guard: skip items that vastly exceed budget
         // to avoid pathological cases (e.g., 50K-token item with 300-token budget)
@@ -712,6 +716,26 @@ mod tests {
         let (indices, used) = index_pack(&counts, 30, 0, |_| 1.0);
         assert_eq!(indices, vec![0]);
         assert_eq!(used, 100);
+    }
+
+    // CQ-V1.33.0-4: index_pack must `continue` (not `break`) when an oversized
+    // mid-stream item won't fit, so smaller lower-scored items still pack.
+    // Mirrors the P1.18 fix in token_pack.
+    #[test]
+    fn test_index_pack_continues_after_oversized_item() {
+        // 3 items, budget 30. Score order: idx0 (10), idx1 (50, won't fit), idx2 (10).
+        // Pre-fix `break` after idx1 would drop idx2. Post-fix `continue` keeps it.
+        let counts = vec![10, 50, 10];
+        let (indices, used) = index_pack(&counts, 30, 0, |i| match i {
+            0 => 3.0, // highest -> always picked first
+            1 => 2.0, // middle score, oversized after first pick
+            2 => 1.0, // lowest score, smaller — should still fit
+            _ => 0.0,
+        });
+        // After idx0 (used=10), idx1 (cost=50, used+50=60 > 30) must be skipped
+        // via `continue`, then idx2 (cost=10, used+10=20 <= 30) fits.
+        assert_eq!(indices, vec![0, 2]);
+        assert_eq!(used, 20);
     }
 
     // HP-2: inject_token_info adds fields when Some

--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -409,7 +409,7 @@ fn cmd_query_project(ctx: &QueryContext<'_>) -> Result<()> {
             )?;
             code_results.into_iter().map(UnifiedResult::Code).collect()
         } else {
-            store.search_unified_with_index(
+            store.search_code_results(
                 query_embedding,
                 filter,
                 search_limit,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,10 @@ pub use note::{
     NOTES_HEADER,
 };
 pub use parser::{Chunk, Parser};
-pub use reranker::{LlmReranker, NoopReranker, OnnxReranker, Reranker};
+// CQ-V1.33.0-8: `LlmReranker` is a SCAFFOLD-ONLY stub (every score call
+// returns Err). Demoted to `pub(crate)` and dropped from this re-export
+// until the production wiring lands in #1220.
+pub use reranker::{NoopReranker, OnnxReranker, Reranker};
 pub use store::{HnswKind, ModelInfo, SearchFilter, Store};
 
 // Re-exports for binary crate (CLI) - these are NOT part of the public library API

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -762,8 +762,14 @@ impl Reranker for NoopReranker {
 /// `(query, passage)` pairs, parses scores from the response, and feeds
 /// them through `apply_rerank_scores`. The trait surface here doesn't
 /// change.
-pub struct LlmReranker;
+// SCAFFOLD-ONLY (#1220): demoted to `pub(crate)` and gated behind `#[cfg(test)]`
+// per CQ-V1.33.0-8 because every score call returns `Err`. The trait-surface
+// pin lives in the `tests` module below. Promote back to `pub` (and re-export
+// from `lib.rs`) when the LLM provider wiring lands.
+#[cfg(test)]
+pub(crate) struct LlmReranker;
 
+#[cfg(test)]
 impl LlmReranker {
     /// Construct a skeleton instance. The skeleton returns
     /// `RerankerError::Inference` on every score call so an integration
@@ -774,12 +780,14 @@ impl LlmReranker {
     }
 }
 
+#[cfg(test)]
 impl Default for LlmReranker {
     fn default() -> Self {
         Self::new()
     }
 }
 
+#[cfg(test)]
 impl Reranker for LlmReranker {
     fn rerank(
         &self,

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -1,9 +1,8 @@
 //! Search query execution on `Store`.
 //!
 //! Contains the `impl Store` block with all search methods:
-//! `search_embedding_only`, `search_filtered`, `finalize_results`,
-//! `search_filtered_with_index`, `search_by_candidate_ids`, and
-//! `search_unified_with_index`.
+//! `search_filtered`, `finalize_results`, `search_filtered_with_index`,
+//! `search_by_candidate_ids`, and `search_code_results`.
 
 use std::collections::HashSet;
 
@@ -76,21 +75,6 @@ impl<Mode> Store<Mode> {
             index_model,
             query_model,
         })
-    }
-
-    /// Raw embedding-only cosine similarity search (no RRF, no keyword matching).
-    ///
-    /// **You almost certainly want `search_filtered()` instead.** This method skips
-    /// hybrid RRF ranking, name boosting, and all filters. It exists for tests and
-    /// internal building blocks only. Two production bugs came from calling this
-    /// directly (PR #305).
-    pub fn search_embedding_only(
-        &self,
-        query: &Embedding,
-        limit: usize,
-        threshold: f32,
-    ) -> Result<Vec<SearchResult>, StoreError> {
-        self.search_filtered(query, &SearchFilter::default(), limit, threshold)
     }
 
     /// Searches for embeddings matching a query with optional filtering and ranking.
@@ -928,11 +912,15 @@ impl<Mode> Store<Mode> {
         })
     }
 
-    /// Unified search with optional vector index.
+    /// Code-only search returning [`UnifiedResult::Code`] variants.
     ///
-    /// Returns code-only results (SQ-9: notes removed from search pipeline).
-    /// When an HNSW index is provided, uses O(log n) candidate retrieval.
-    pub fn search_unified_with_index(
+    /// CQ-V1.33.0-10: renamed from `search_unified_with_index` post-SQ-9
+    /// (notes removed from the search pipeline). The function maps
+    /// `search_filtered_with_index` results into the `UnifiedResult::Code`
+    /// variant so callers that historically dispatched on the unified
+    /// enum keep compiling. When an HNSW index is provided, uses
+    /// O(log n) candidate retrieval.
+    pub fn search_code_results(
         &self,
         query: &Embedding,
         filter: &SearchFilter,
@@ -944,7 +932,8 @@ impl<Mode> Store<Mode> {
             return Ok(vec![]);
         }
 
-        let _span = tracing::info_span!("search_unified", limit, threshold = %threshold).entered();
+        let _span =
+            tracing::info_span!("search_code_results", limit, threshold = %threshold).entered();
 
         let code_results =
             self.search_filtered_with_index(query, filter, limit, threshold, index)?;

--- a/tests/real_eval_expanded.json
+++ b/tests/real_eval_expanded.json
@@ -53,7 +53,7 @@
     {"query": "extract body keywords from function source for search boosting", "expected": "extract_body_keywords", "also_accept": []}
   ],
   "conceptual": [
-    {"query": "how does the search pipeline combine keyword and vector results", "expected_functions": ["search_filtered", "search_fts", "search_unified_with_index", "rrf_fuse", "finalize_results"], "category": "search_pipeline"},
+    {"query": "how does the search pipeline combine keyword and vector results", "expected_functions": ["search_filtered", "search_fts", "search_code_results", "rrf_fuse", "finalize_results"], "category": "search_pipeline"},
     {"query": "what happens when you index a file for the first time", "expected_functions": ["parse_file", "generate_nl_description", "embed_documents", "upsert_chunks_batch", "upsert_calls_batch"], "category": "indexing"},
     {"query": "how does the enrichment pipeline transform code before embedding", "expected_functions": ["generate_nl_description", "generate_nl_with_call_context", "generate_nl_with_template", "embedding_text"], "category": "enrichment"},
     {"query": "what is the complete flow for analyzing the impact of a code change", "expected_functions": ["analyze_impact", "analyze_diff_impact", "compute_risk_batch", "find_test_chunks", "reverse_bfs"], "category": "impact"},

--- a/tests/search_test.rs
+++ b/tests/search_test.rs
@@ -214,10 +214,10 @@ fn test_search_filtered_with_index_falls_back_without_index() {
     assert_eq!(results.len(), 1);
 }
 
-// ===== #36: search_unified_with_index (SQ-9: code-only) =====
+// ===== #36: search_code_results (SQ-9: code-only; renamed CQ-V1.33.0-10) =====
 
 #[test]
-fn test_search_unified_with_index_returns_code_only() {
+fn test_search_code_results_returns_code_only() {
     let store = TestStore::new();
     let c1 = test_chunk("unified_fn", "fn unified_fn() { code }");
     let ids = insert_chunks(&store, &[c1], 1.0);
@@ -240,7 +240,7 @@ fn test_search_unified_with_index_returns_code_only() {
     ]);
 
     let results = store
-        .search_unified_with_index(&query, &filter, 10, 0.0, Some(&mock))
+        .search_code_results(&query, &filter, 10, 0.0, Some(&mock))
         .unwrap();
 
     let has_code = results.iter().any(|r| matches!(r, UnifiedResult::Code(_)));
@@ -265,7 +265,7 @@ fn test_search_unified_without_index() {
 
     // No index -- brute-force
     let results = store
-        .search_unified_with_index(&query, &filter, 10, 0.0, None)
+        .search_code_results(&query, &filter, 10, 0.0, None)
         .unwrap();
 
     let has_code = results.iter().any(|r| matches!(r, UnifiedResult::Code(_)));

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -31,7 +31,9 @@ fn test_upsert_and_search() {
     store.upsert_chunk(&chunk, &embedding, Some(12345)).unwrap();
 
     // Search should find it
-    let results = store.search_embedding_only(&embedding, 5, 0.0).unwrap();
+    let results = store
+        .search_filtered(&embedding, &SearchFilter::default(), 5, 0.0)
+        .unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].chunk.name, "add");
     assert!(
@@ -57,7 +59,9 @@ fn test_search_with_threshold() {
 
     // Search with query similar to chunk1
     let query = mock_embedding(0.9);
-    let results = store.search_embedding_only(&query, 5, 0.5).unwrap();
+    let results = store
+        .search_filtered(&query, &SearchFilter::default(), 5, 0.5)
+        .unwrap();
 
     // Should find chunk1 (similar) but not chunk2 (dissimilar)
     assert!(results.iter().any(|r| r.chunk.name == "add"));
@@ -76,7 +80,9 @@ fn test_search_limit() {
 
     // Search with limit
     let query = mock_embedding(1.0);
-    let results = store.search_embedding_only(&query, 3, 0.0).unwrap();
+    let results = store
+        .search_filtered(&query, &SearchFilter::default(), 3, 0.0)
+        .unwrap();
 
     assert_eq!(results.len(), 3);
 }
@@ -153,7 +159,7 @@ fn test_delete_by_origin() {
 
     // Only chunk2 should remain
     let results = store
-        .search_embedding_only(&mock_embedding(1.0), 10, 0.0)
+        .search_filtered(&mock_embedding(1.0), &SearchFilter::default(), 10, 0.0)
         .unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].chunk.name, "fn2");
@@ -191,7 +197,7 @@ fn test_prune_missing() {
 
     // Only chunk1 should remain
     let results = store
-        .search_embedding_only(&mock_embedding(1.0), 10, 0.0)
+        .search_filtered(&mock_embedding(1.0), &SearchFilter::default(), 10, 0.0)
         .unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].chunk.name, "fn1");
@@ -874,7 +880,7 @@ fn test_store_close() {
 
     // Search should still work
     let results = store
-        .search_embedding_only(&mock_embedding(1.0), 5, 0.0)
+        .search_filtered(&mock_embedding(1.0), &SearchFilter::default(), 5, 0.0)
         .unwrap();
     assert_eq!(results.len(), 1, "Should find the persisted chunk");
 }
@@ -1144,7 +1150,7 @@ fn test_open_readonly_preserves_data() {
 
     // Search should find the chunk
     let results = ro
-        .search_embedding_only(&mock_embedding(1.0), 5, 0.0)
+        .search_filtered(&mock_embedding(1.0), &SearchFilter::default(), 5, 0.0)
         .unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].chunk.name, "preserved_fn");

--- a/tests/stress_test.rs
+++ b/tests/stress_test.rs
@@ -8,6 +8,7 @@
 mod common;
 
 use common::{mock_embedding, test_chunk, TestStore};
+use cqs::store::SearchFilter;
 use std::sync::Arc;
 use std::thread;
 
@@ -65,7 +66,7 @@ fn test_concurrent_searches() {
             thread::spawn(move || {
                 for i in 0..searches_per_thread {
                     let query = mock_embedding((t * searches_per_thread + i) as f32 / 1000.0);
-                    let results = store.search_embedding_only(&query, 5, 0.0);
+                    let results = store.search_filtered(&query, &SearchFilter::default(), 5, 0.0);
                     assert!(results.is_ok(), "Search should succeed");
                 }
             })
@@ -100,7 +101,7 @@ fn test_many_small_operations() {
     for i in 0..200 {
         let query = mock_embedding(i as f32 / 200.0);
         let results = ts
-            .search_embedding_only(&query, 5, 0.0)
+            .search_filtered(&query, &SearchFilter::default(), 5, 0.0)
             .expect("Search failed");
         assert!(!results.is_empty(), "Should find results");
     }
@@ -127,7 +128,7 @@ fn test_search_threshold_performance() {
 
     // Low threshold - should return more results
     let results_low = ts
-        .search_embedding_only(&query, 100, 0.0)
+        .search_filtered(&query, &SearchFilter::default(), 100, 0.0)
         .expect("Search failed");
     assert!(
         !results_low.is_empty(),
@@ -136,7 +137,7 @@ fn test_search_threshold_performance() {
 
     // High threshold - should return fewer results
     let results_high = ts
-        .search_embedding_only(&query, 100, 0.8)
+        .search_filtered(&query, &SearchFilter::default(), 100, 0.8)
         .expect("Search failed");
     assert!(
         results_high.len() <= results_low.len(),


### PR DESCRIPTION
Closes the footgun-pub cluster from the v1.33.0 audit. Five findings:

- **P1-31** (CQ-V1.33.0-4) - index_pack break -> continue parity fix + regression test
- **P1-32** (CQ-V1.33.0-6) - Store::search_embedding_only deleted; 11 test sites inlined  
- **P1-33** (CQ-V1.33.0-8) - LlmReranker demoted to pub(crate), gated cfg(test), dropped from lib.rs re-export; eval --reranker llm bails early with a clear error
- **P3-12** (CQ-V1.33.0-10) - search_unified_with_index renamed to search_code_results (3 production callers + 1 test + 1 eval fixture updated)
- **P3-28** (CQ-V1.33.0-6 / API-Design framing) - auto-resolved by P1-32 deletion

This closes P1 entirely (47 of 47 P1 fixes shipped or in flight). Full agent details in commit message.