### PR TITLE
chore(audit): close 10 v1.33.0 observability gaps (P2-1, P2-2, P3-1..P3-8)

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -80,8 +80,8 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 
 | ID | Category | Title | Difficulty | Status |
 |----|----------|-------|------------|--------|
-| P2-1 | Observability | `serve` axum `http_request` span has no `request_id` field | medium | ⬜ |
-| P2-2 | Observability | `WatchSnapshot::compute` and `now_unix_secs` lack tracing on freshness state machine | medium | ⬜ |
+| P2-1 | Observability | `serve` axum `http_request` span has no `request_id` field | medium | ✅ #1362 |
+| P2-2 | Observability | `WatchSnapshot::compute` and `now_unix_secs` lack tracing on freshness state machine | medium | ✅ #1362 |
 | P2-3 | Error Handling | `embedder.fingerprint` silently uses `size = 0` when metadata fails — collides cache keys | medium | ⬜ |
 | P2-4 | Error Handling | `IndexBackend` trait — public lib trait uses anyhow::Result instead of thiserror | medium | ⬜ |
 | P2-5 | Error Handling | Reconcile mtime-touch chain silently abandons on metadata or `modified()` failure | medium | ⬜ |
@@ -128,14 +128,14 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 
 | ID | Category | Title | Difficulty | Status |
 |----|----------|-------|------------|--------|
-| P3-1 | Observability | `Reranker::run_chunk` per-batch ONNX call has no tracing span | easy | ⬜ |
-| P3-2 | Observability | `SpladeEncoder::encode` debug-span lacks completion event with elapsed_ms | easy | ⬜ |
-| P3-3 | Observability | `Embedder::embed_query` cache-hit/miss completion event missing elapsed_ms | easy | ⬜ |
-| P3-4 | Observability | `notify` watcher errors swallow ErrorKind + paths fields | easy | ⬜ |
-| P3-5 | Observability | `cli/watch/events.rs:23` `collect_events` has no entry span | easy | ⬜ |
-| P3-6 | Observability | `cli/registry.rs:133` `println!` for Refresh "no daemon running" bypasses tracing | easy | ⬜ |
-| P3-7 | Observability | `Embedder::warm` no span, no log — silent ~250 MB+ session init at startup | easy | ⬜ |
-| P3-8 | Observability | `LocalProvider` worker threads lack worker-id field on completion | easy | ⬜ |
+| P3-1 | Observability | `Reranker::run_chunk` per-batch ONNX call has no tracing span | easy | ✅ #1362 |
+| P3-2 | Observability | `SpladeEncoder::encode` debug-span lacks completion event with elapsed_ms | easy | ✅ #1362 |
+| P3-3 | Observability | `Embedder::embed_query` cache-hit/miss completion event missing elapsed_ms | easy | ✅ #1362 |
+| P3-4 | Observability | `notify` watcher errors swallow ErrorKind + paths fields | easy | ✅ #1362 |
+| P3-5 | Observability | `cli/watch/events.rs:23` `collect_events` has no entry span | easy | ✅ #1362 |
+| P3-6 | Observability | `cli/registry.rs:133` `println!` for Refresh "no daemon running" bypasses tracing | easy | ✅ #1362 |
+| P3-7 | Observability | `Embedder::warm` no span, no log — silent ~250 MB+ session init at startup | easy | ✅ #1362 |
+| P3-8 | Observability | `LocalProvider` worker threads lack worker-id field on completion | easy | ✅ #1362 |
 | P3-9 | Robustness | `set_on_item_complete` lock().unwrap() — duplicate of EH-V1.33-2 | easy | ⬜ |
 | P3-10 | Code Quality | `check_model_version()` wrapper dead in production | easy | ⬜ |
 | P3-11 | Code Quality | `is_false`/`is_zero_usize` trivial helpers duplicated 3+2 times across modules | easy | ⬜ |

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -130,6 +130,16 @@ macro_rules! for_each_command {
                             "caches_invalidated": [],
                         }))
                     } else {
+                        // P3-6 (audit v1.33.0): mirror the JSON branch onto
+                        // the journal so operators correlating "user ran
+                        // refresh, no daemon" with later reindex weirdness
+                        // have a tracing breadcrumb. Keep the println for
+                        // terminal UX — log line is in addition.
+                        tracing::info!(
+                            refreshed = false,
+                            daemon_running = false,
+                            "cqs refresh: no daemon"
+                        );
                         println!("no daemon running, nothing to refresh");
                         Ok(())
                     }

--- a/src/cli/watch/events.rs
+++ b/src/cli/watch/events.rs
@@ -21,6 +21,16 @@ pub(super) fn max_pending_files() -> usize {
 }
 /// Collect file system events into pending sets, filtering by extension and deduplicating.
 pub(super) fn collect_events(event: &notify::Event, cfg: &WatchConfig, state: &mut WatchState) {
+    // P3-5 (audit v1.33.0): per-event entry span so an inotify event that
+    // makes it through filtering can be correlated to its later reindex.
+    // `trace_span` keeps the per-event noise behind RUST_LOG=trace; the
+    // accept-path debug below is the level operators actually reach for.
+    let _span = tracing::trace_span!(
+        "collect_events",
+        event_kind = ?event.kind,
+        paths = event.paths.len(),
+    )
+    .entered();
     for path in &event.paths {
         // PB-26: Skip canonicalize for deleted files — dunce::canonicalize
         // requires the file to exist (calls std::fs::canonicalize internally).
@@ -125,6 +135,15 @@ pub(super) fn collect_events(event: &notify::Event, cfg: &WatchConfig, state: &m
                 state
                     .pending_files
                     .insert(super::reconcile::normalize_pending_path(rel));
+                // P3-5 (audit v1.33.0): debug the accept-and-queue branch.
+                // Operators investigating "why didn't my save get reindexed?"
+                // can `RUST_LOG=cqs::cli::watch=debug` and see the full
+                // event → queue chain.
+                tracing::debug!(
+                    path = %rel.display(),
+                    event_kind = ?event.kind,
+                    "Queued for reindex"
+                );
             } else {
                 // RM-V1.25-23: log per-event at debug (spammy on bulk
                 // drops) and accumulate a counter; the once-per-cycle

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -1155,7 +1155,16 @@ pub fn cmd_watch(
                 collect_events(&event, &watch_cfg, &mut state);
             }
             Ok(Err(e)) => {
-                warn!(error = %e, "Watch error");
+                // P3-4 (audit v1.33.0): include `kind` and `paths` so
+                // operators can distinguish MaxFilesWatch (raise sysctl) from
+                // Io(broken pipe) (restart daemon). Display alone collapses
+                // the discriminator and drops paths.
+                warn!(
+                    error = %e,
+                    kind = ?e.kind,
+                    paths = ?e.paths,
+                    "Watch error"
+                );
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 // #1182 — Layer 1: out-of-band reconcile request. The

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -824,6 +824,11 @@ impl Embedder {
 
     pub fn embed_query(&self, text: &str) -> Result<Embedding, EmbedderError> {
         let _span = tracing::info_span!("embed_query").entered();
+        // P3-3 (audit v1.33.0): time end-to-end so cache-hit vs. miss
+        // latency is queryable on the completion events. Without this
+        // operators can't tell "model is suddenly slow" from "cache hit
+        // rate cratered".
+        let start = std::time::Instant::now();
         let text = text.trim();
         if text.is_empty() {
             return Err(EmbedderError::EmptyQuery);
@@ -854,6 +859,15 @@ impl Embedder {
             });
             if let Some(cached) = cache.get(text) {
                 tracing::trace!(query = text, "Query cache hit (memory)");
+                // P3-3: emit cache-aware completion (no query text — leaks at
+                // trace level otherwise) so operators tracking hit-rate can
+                // see hits at debug without enabling trace journals.
+                tracing::debug!(
+                    dim = self.embedding_dim(),
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    cache = "memory_hit",
+                    "embed_query complete"
+                );
                 return Ok(cached.clone());
             }
         }
@@ -866,6 +880,13 @@ impl Embedder {
                 // Populate in-memory LRU for fast subsequent hits
                 let mut cache = self.query_cache.lock().unwrap_or_else(|p| p.into_inner());
                 cache.put(text.to_string(), cached.clone());
+                // P3-3: disk-hit completion mirrors memory_hit shape.
+                tracing::debug!(
+                    dim = self.embedding_dim(),
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    cache = "disk_hit",
+                    "embed_query complete"
+                );
                 return Ok(cached);
             }
         }
@@ -896,7 +917,14 @@ impl Embedder {
         // P3.10: completion event so embed_query has parity with the
         // embed_documents log line. Debug-level — embed_query runs once per
         // search and the entry span already covers timing.
-        tracing::debug!(dim = self.embedding_dim(), "embed_query complete");
+        // P3-3 (audit v1.33.0): add elapsed_ms + cache-tier so the journal
+        // distinguishes "model slow on miss" from "everything was a hit".
+        tracing::debug!(
+            dim = self.embedding_dim(),
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            cache = "miss",
+            "embed_query complete"
+        );
         Ok(embedding)
     }
 
@@ -953,7 +981,18 @@ impl Embedder {
 
     /// Warm up the model with a dummy inference
     pub fn warm(&self) -> Result<(), EmbedderError> {
+        // P3-7 (audit v1.33.0): operators investigating "daemon takes 4s
+        // to come up" need a "warm started/completed" anchor. The dummy
+        // embed_query triggers ~250 MB+ ORT session + tokenizer load (1-3s
+        // on first GPU inference) and previously emitted nothing of its own.
+        let _span = tracing::info_span!("embedder_warm", model = %self.model_config.name).entered();
+        let start = std::time::Instant::now();
         let _ = self.embed_query("warmup")?;
+        tracing::info!(
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            model = %self.model_config.name,
+            "embedder warmed"
+        );
         Ok(())
     }
 

--- a/src/llm/local.rs
+++ b/src/llm/local.rs
@@ -217,6 +217,16 @@ impl LocalProvider {
                 let self_ref = self;
                 s.spawn(move || {
                     let _worker_span = tracing::debug_span!("local_worker", worker_id).entered();
+                    // P3-8 (audit v1.33.0): per-worker counters + wall-clock
+                    // so the post-loop completion line breaks down the batch
+                    // by worker. Without these the journal has N
+                    // indistinguishable "worker complete" lines and operators
+                    // tuning `CQS_LOCAL_LLM_CONCURRENCY` can't see tail-worker
+                    // skew. `retried` would require lifting state out of
+                    // `process_one_item`; out of scope for this audit pass.
+                    let worker_start = std::time::Instant::now();
+                    let mut completed: usize = 0;
+                    let mut failed: usize = 0;
                     while let Ok(item) = rx_worker.recv() {
                         // Per-item catch_unwind — a panic on one item must not
                         // kill the worker.
@@ -234,6 +244,7 @@ impl LocalProvider {
 
                         match item_result {
                             Ok(Ok(Some(text))) => {
+                                completed += 1;
                                 // Stash the result for fetch_batch_results.
                                 if let Ok(mut map) = results_ref.lock() {
                                     map.insert(item.custom_id.clone(), text.clone());
@@ -268,6 +279,7 @@ impl LocalProvider {
                             Ok(Ok(None)) => {
                                 // Item skipped (non-retriable 4xx, malformed
                                 // JSON, etc) — already logged at call site.
+                                failed += 1;
                                 if let Ok(mut f) = failed_ref.lock() {
                                     *f += 1;
                                 }
@@ -278,6 +290,7 @@ impl LocalProvider {
                                     error = %e,
                                     "item processing failed after retries"
                                 );
+                                failed += 1;
                                 if let Ok(mut f) = failed_ref.lock() {
                                     *f += 1;
                                 }
@@ -288,12 +301,24 @@ impl LocalProvider {
                                     panic = ?panic,
                                     "worker panic, skipping item"
                                 );
+                                failed += 1;
                                 if let Ok(mut f) = failed_ref.lock() {
                                     *f += 1;
                                 }
                             }
                         }
                     }
+                    // P3-8: per-worker completion with explicit fields.
+                    // Span context isn't always carried by JSON formatters,
+                    // so emit `worker_id` directly rather than relying on
+                    // the entered span.
+                    tracing::info!(
+                        worker_id,
+                        completed,
+                        failed,
+                        elapsed_ms = worker_start.elapsed().as_millis() as u64,
+                        "local batch worker complete"
+                    );
                 });
             }
 

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -283,6 +283,10 @@ impl OnnxReranker {
     ///
     /// Returns one score per encoding in `chunk`.
     fn run_chunk(&self, chunk: &[tokenizers::Encoding]) -> Result<Vec<f32>, RerankerError> {
+        // P3-1 (audit v1.33.0): track per-chunk wall-clock so operators
+        // tuning `CQS_RERANKER_BATCH` or chasing tail latency can see
+        // per-chunk shape. Owns ~98% of reranker latency (ORT session.run).
+        let start = std::time::Instant::now();
         let batch_size = chunk.len();
         debug_assert!(batch_size > 0, "run_chunk called with empty chunk");
 
@@ -327,6 +331,10 @@ impl OnnxReranker {
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .unwrap_or(true); // session() always sets this; fallback to true matches BERT default
+
+        // P3-1: per-chunk span carries shape data for journal correlation.
+        let _chunk_span =
+            tracing::debug_span!("reranker_run_chunk", batch_size, max_len, expects_tti).entered();
 
         let ids_arr = pad_2d_i64(&input_ids, max_len, 0);
         let mask_arr = pad_2d_i64(&attention_mask, max_len, 0);
@@ -403,6 +411,13 @@ impl OnnxReranker {
         }
 
         let scores: Vec<f32> = (0..batch_size).map(|i| sigmoid(data[i * stride])).collect();
+        // P3-1: completion event with elapsed_ms so per-chunk latency
+        // is queryable without parsing the surrounding span.
+        tracing::debug!(
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            batch_size,
+            "run_chunk complete"
+        );
         Ok(scores)
     }
 

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -261,11 +261,21 @@ pub(crate) fn build_router(state: AppState, allowed_hosts: AllowedHosts, auth: A
         // full URI — the `?token=…` query param lands in span fields
         // otherwise and bleeds the per-launch token into journald /
         // RUST_LOG=debug.
+        //
+        // P2-1 (audit v1.33.0): generate a per-process monotonic
+        // `request_id` so concurrent requests for the same path can
+        // be correlated in `journalctl --user -u cqs-watch` output.
+        // `AtomicU64` counter (no extra dep) — sufficient for one
+        // daemon's journal; not globally unique by design.
         .layer(TraceLayer::new_for_http().make_span_with(|req: &Request| {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+            let request_id = REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed);
             tracing::info_span!(
                 "http_request",
                 method = %req.method(),
                 path = %req.uri().path(),
+                request_id,
             )
         }))
 }

--- a/src/splade/mod.rs
+++ b/src/splade/mod.rs
@@ -465,6 +465,10 @@ impl SpladeEncoder {
     /// sequence → ReLU + log(1+x) → threshold to keep significant weights.
     pub fn encode(&self, text: &str) -> Result<SparseVector, SpladeError> {
         let _span = tracing::debug_span!("splade_encode", text_len = text.len()).entered();
+        // P3-2 (audit v1.33.0): time encode end-to-end so cold session
+        // re-init spikes (`session_guard.is_none()` branch around line 521)
+        // surface in the journal alongside the existing per-call debug spans.
+        let start = std::time::Instant::now();
 
         if text.is_empty() {
             return Ok(Vec::new());
@@ -601,7 +605,14 @@ impl SpladeEncoder {
             )));
         };
 
-        tracing::debug!(non_zero = sparse.len(), "SPLADE encoding complete");
+        // P3-2: completion with elapsed_ms + nnz so encode-time spikes
+        // (cold session, model hiccup) are queryable without inferring
+        // from the surrounding `splade_encode` span.
+        tracing::debug!(
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            nnz = sparse.len(),
+            "splade_encode complete"
+        );
         Ok(sparse)
     }
 

--- a/src/watch_status.rs
+++ b/src/watch_status.rs
@@ -273,6 +273,19 @@ impl WatchSnapshot {
     /// Pure function — pulls only the fields it needs and resolves the
     /// `state` machine deterministically.
     pub fn compute(input: WatchSnapshotInput<'_>) -> Self {
+        // P2-2 (audit v1.33.0): trace the freshness state machine so
+        // operators investigating "why did the gate report Stale at
+        // 14:32:01?" can see what `compute()` saw at that timestamp.
+        // `debug_span` keeps the per-tick noise behind RUST_LOG=debug.
+        let _span = tracing::debug_span!(
+            "watch_snapshot_compute",
+            pending_files = input.pending_files_count,
+            pending_notes = input.pending_notes,
+            rebuilding = input.rebuild_in_flight,
+            dropped = input.dropped_this_cycle,
+            delta_saturated = input.delta_saturated,
+        )
+        .entered();
         let state = if input.rebuild_in_flight {
             FreshnessState::Rebuilding
         } else if input.pending_files_count > 0
@@ -307,6 +320,10 @@ impl WatchSnapshot {
             })
             .unwrap_or(0);
 
+        // P2-2: emit the resolved state so the per-call decision is
+        // queryable without rebuilding the state-machine inputs.
+        tracing::trace!(state = %state, "compute decision");
+
         Self {
             state,
             // RB-7: saturating `usize → u64`. On 64-bit platforms `as u64`
@@ -334,7 +351,16 @@ impl WatchSnapshot {
 /// helper. Watch-status snapshots prefer `Option<i64>` so the bad-clock
 /// case can surface as JSON `null` (versus a silent `0` lie).
 fn now_unix_secs() -> Option<i64> {
-    crate::unix_secs_i64()
+    let result = crate::unix_secs_i64();
+    if result.is_none() {
+        // P2-2 (audit v1.33.0): leave a per-call trace breadcrumb when the
+        // clock is bad. The central helper already emits a once-per-process
+        // warn, but a per-call trace lets operators correlate individual
+        // snapshot publications with the bad-clock condition under
+        // RUST_LOG=trace without re-firing the noisier warn.
+        tracing::trace!("now_unix_secs: clock before epoch — returning None");
+    }
+    result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Closes 10 v1.33.0 audit observability gaps: P2-1, P2-2, P3-1, P3-2, P3-3, P3-4, P3-5, P3-6, P3-7, P3-8.
- Adds per-process `request_id` to `serve` span, completion `elapsed_ms` on hot embedding/reranker/splade paths, structured `kind`/`paths` on notify watch errors, debug breadcrumbs on inotify queue + Refresh no-daemon, and per-worker completion fields on `LocalProvider`.
- No behavior change beyond logging — every fix is `tracing::*` calls + a few `Instant::now()` captures.

### Per-finding map

| ID | Site | What was added |
|----|------|---------------|
| P2-1 | `src/serve/mod.rs` | `static AtomicU64 REQUEST_COUNTER` → `request_id` on `http_request` span (no new dep) |
| P2-2 | `src/watch_status.rs` | `debug_span!("watch_snapshot_compute", ...)` at entry + `tracing::trace!(state)` at end + per-call trace inside `now_unix_secs` `None` branch |
| P3-1 | `src/reranker.rs` | `debug_span!("reranker_run_chunk", batch_size, max_len, expects_tti)` + completion `tracing::debug!(elapsed_ms, batch_size, ...)` |
| P3-2 | `src/splade/mod.rs` | Completion event with `elapsed_ms` + `nnz` replaces lone `non_zero` debug |
| P3-3 | `src/embedder/mod.rs` | `embed_query` completion gets `elapsed_ms` + `cache` tier (`memory_hit`/`disk_hit`/`miss`) |
| P3-4 | `src/cli/watch/mod.rs` | `notify::Error` `Watch error` warn includes `kind = ?e.kind` + `paths = ?e.paths` |
| P3-5 | `src/cli/watch/events.rs` | `trace_span!("collect_events", event_kind, paths)` at entry + `Queued for reindex` debug after successful insert |
| P3-6 | `src/cli/registry.rs` | `Refresh` no-daemon non-JSON branch adds `tracing::info!(refreshed=false, daemon_running=false, ...)` alongside the println |
| P3-7 | `src/embedder/mod.rs` | `Embedder::warm` gets `info_span!("embedder_warm", model)` + post-warm `tracing::info!(elapsed_ms, model, "embedder warmed")` |
| P3-8 | `src/llm/local.rs` | Per-worker `completed`/`failed` counters + post-loop `tracing::info!(worker_id, completed, failed, elapsed_ms, "local batch worker complete")` |

### Deviations from the audit text

- **P3-8** — audit suggested also tracking a `retried` counter at worker scope. Retries happen inside `process_one_item` and aren't surfaced to the caller; lifting that state out would require a `process_one_item` signature change which is "refactor surrounding code" the brief said to avoid. Emitted `completed` + `failed` only; commented in code.
- **P2-2 `now_unix_secs`** — the central `crate::unix_secs_i64` already emits a once-per-process `tracing::warn!` on bad-clock. The audit asked for a per-call trace inside the local `now_unix_secs` `unwrap_or` arm; since `now_unix_secs` is a thin delegator, added the per-call trace just before returning when the central helper returned `None`. Same operator visibility, no duplicated warn-level noise.
- **P2-1** — used `static AtomicU64` per the audit's "no new dep" fallback rather than `nanoid`. Counter resets on daemon restart, which is exactly the journal-correlation scope this is for.

## Test plan
- [x] `cargo check --features cuda-index` — clean
- [x] `cargo clippy --features cuda-index --lib -- -D warnings` — clean
- [x] `cargo fmt`
- [x] Targeted: `watch_status`, `reranker`, `splade`, `serve`, `llm::local`, `cli::watch`, `embedder` (~221 tests, all pass)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
