### PR TITLE
fix(audit): #1245 5 P2 correctness bugs from v1.33.0 audit (P2-3, P2-15, P2-16, P2-17, P2-24)

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -82,7 +82,7 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 |----|----------|-------|------------|--------|
 | P2-1 | Observability | `serve` axum `http_request` span has no `request_id` field | medium | ⬜ |
 | P2-2 | Observability | `WatchSnapshot::compute` and `now_unix_secs` lack tracing on freshness state machine | medium | ⬜ |
-| P2-3 | Error Handling | `embedder.fingerprint` silently uses `size = 0` when metadata fails — collides cache keys | medium | ⬜ |
+| P2-3 | Error Handling | `embedder.fingerprint` silently uses `size = 0` when metadata fails — collides cache keys | medium | ✅ #1364 |
 | P2-4 | Error Handling | `IndexBackend` trait — public lib trait uses anyhow::Result instead of thiserror | medium | ⬜ |
 | P2-5 | Error Handling | Reconcile mtime-touch chain silently abandons on metadata or `modified()` failure | medium | ⬜ |
 | P2-6 | Error Handling | Reference path canonicalize-failure in `Config::validate` skips SEC-4 + SEC-NEW-1 check | medium | ⬜ |
@@ -94,16 +94,16 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 | P2-12 | TC Adversarial | `update_umap_coords_batch` accepts NaN/Inf coords; serializes as bare JSON `NaN` | medium | ⬜ |
 | P2-13 | API Design | Same `--depth` flag means four different defaults across five commands | medium | ⬜ |
 | P2-14 | API Design | `--rerank` (bool) on search vs `--reranker <mode>` (enum) on eval | medium | ⬜ |
-| P2-15 | Algorithm Correctness | `apply_rerank_scores` partial overwrite when `scores.len() != results.len()` | medium | ⬜ |
-| P2-16 | Algorithm Correctness | SPLADE hybrid fusion truncates+re-collects into HashMap, scrambles ordering | medium | ⬜ |
-| P2-17 | Algorithm Correctness | BM25 IDF formula uses non-standard `+1.0` (Atire) without docs; mismatches FTS5 | medium | ⬜ |
+| P2-15 | Algorithm Correctness | `apply_rerank_scores` partial overwrite when `scores.len() != results.len()` | medium | ✅ #1364 |
+| P2-16 | Algorithm Correctness | SPLADE hybrid fusion truncates+re-collects into HashMap, scrambles ordering | medium | ✅ #1364 |
+| P2-17 | Algorithm Correctness | BM25 IDF formula uses non-standard `+1.0` (Atire) without docs; mismatches FTS5 | medium | ✅ #1364 |
 | P2-18 | Data Safety | `migrate_legacy_index_to_default_slot` does not acquire `slots.lock` | medium | ⬜ |
 | P2-19 | Data Safety | `write_active_slot`/`write_slot_model` use fixed `<file>.tmp` paths | easy | ⬜ |
 | P2-20 | Data Safety | `verify_hnsw_checksums` skips files not on disk — partial index passes verification | easy | ⬜ |
 | P2-21 | Data Safety | `EmbeddingCache::evict`/`QueryCache::evict` use deferred transactions | medium | ⬜ |
 | P2-22 | Data Safety | `backup_path_for` uses 1-second timestamp with no PID — concurrent migrations collide | easy | ⬜ |
 | P2-23 | Data Safety | `evict_lock` reset on every `EmbeddingCache::open` — multiple opens don't share | medium | ⬜ |
-| P2-24 | Data Safety | `clear_session` doesn't reset `detected_dim` or `model_fingerprint` | medium | ⬜ |
+| P2-24 | Data Safety | `clear_session` doesn't reset `detected_dim` or `model_fingerprint` | medium | ✅ #1364 |
 | P2-25 | Data Safety | Pool `after_connect` has no `wal_autocheckpoint` ceiling | medium | ⬜ |
 | P2-26 | Data Safety | `migrate_legacy_index_to_default_slot` checkpoints before sentinel | easy | ⬜ |
 | P2-27 | Security | `apply_db_file_perms` runs after pool open — embedding cache born world-readable | easy | ⬜ |

--- a/src/cli/watch/reindex.rs
+++ b/src/cli/watch/reindex.rs
@@ -369,7 +369,7 @@ pub(super) fn reindex_files(
     let mut global_hits: HashMap<String, Embedding> = HashMap::new();
     if let Some(cache) = global_cache {
         let model_fp = embedder.model_fingerprint();
-        match cache.read_batch(&hashes, model_fp, cqs::cache::CachePurpose::Embedding, dim) {
+        match cache.read_batch(&hashes, &model_fp, cqs::cache::CachePurpose::Embedding, dim) {
             Ok(hits) => {
                 if !hits.is_empty() {
                     tracing::debug!(hits = hits.len(), "Watch global cache hits");
@@ -477,7 +477,7 @@ pub(super) fn reindex_files(
             .collect();
         if let Err(e) = cache.write_batch(
             &entries,
-            embedder.model_fingerprint(),
+            &embedder.model_fingerprint(),
             cqs::cache::CachePurpose::Embedding,
             dim,
         ) {

--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -1424,7 +1424,7 @@ fn test_reindex_files_hits_global_cache_skipping_embedder() {
     cache
         .write_batch_owned(
             &[(target_hash.clone(), sentinel_clone)],
-            embedder.model_fingerprint(),
+            &embedder.model_fingerprint(),
             CachePurpose::Embedding,
             dim,
         )

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -293,12 +293,27 @@ pub struct Embedder {
     /// successfully, `None` if it failed (best-effort fallback).
     disk_query_cache: std::sync::OnceLock<Option<crate::cache::QueryCache>>,
     /// Detected embedding dimension from the model. Set on first inference.
-    detected_dim: std::sync::OnceLock<usize>,
+    ///
+    /// DS-V1.33-7: switched from `OnceLock<usize>` to `Mutex<Option<usize>>`
+    /// so [`Self::clear_session`] can reset the slot. `OnceLock` cannot be
+    /// reset under `&self`, which would have left a model swap reading the
+    /// first-loaded model's dim forever — silently feeding the wrong dim to
+    /// `EmbeddingCache::read_batch`'s dimension filter (which then drops
+    /// every cache hit on dim mismatch). Mutex contention is irrelevant: a
+    /// single quick lock per `embedding_dim()` call.
+    detected_dim: Mutex<Option<usize>>,
     /// Model configuration (repo, paths, prefixes, dimensions)
     model_config: ModelConfig,
     /// blake3 fingerprint of the ONNX model file, computed lazily on first access.
     /// Used as cache key to distinguish models with the same name but different weights.
-    model_fingerprint: std::sync::OnceLock<String>,
+    ///
+    /// DS-V1.33-7: switched from `OnceLock<String>` to `Mutex<Option<String>>`
+    /// so [`Self::clear_session`] can reset the slot alongside the session
+    /// drop. `OnceLock` cannot be reset under `&self`, which would have
+    /// left a model swap reading the first-loaded model's fingerprint —
+    /// silently caching every new embedding under the wrong model_id key
+    /// in the on-disk embedding cache.
+    model_fingerprint: Mutex<Option<String>>,
     /// SHL-V1.29-1: Pad token id resolved at tokenizer-init time.
     ///
     /// Cache set once per embedder lifetime on first call to [`Self::pad_id`].
@@ -407,9 +422,9 @@ impl Embedder {
             max_length,
             query_cache,
             disk_query_cache: std::sync::OnceLock::new(),
-            detected_dim: std::sync::OnceLock::new(),
+            detected_dim: Mutex::new(None),
             model_config,
-            model_fingerprint: std::sync::OnceLock::new(),
+            model_fingerprint: Mutex::new(None),
             pad_id: std::sync::OnceLock::new(),
         })
     }
@@ -456,7 +471,7 @@ impl Embedder {
     /// Computed lazily on first access. Used as cache key to distinguish
     /// models with the same name but different weights (fine-tuned, different
     /// HF revision, different ONNX export).
-    pub fn model_fingerprint(&self) -> &str {
+    pub fn model_fingerprint(&self) -> String {
         // P2.63: stable fallback fingerprint — must NOT include any value
         // that changes across process restarts. Cross-slot embedding cache
         // copy by content_hash relies on the model fingerprint matching
@@ -465,7 +480,21 @@ impl Embedder {
         fn fallback_fingerprint(repo: &str, size: u64) -> String {
             format!("{}:fallback:size={}", repo, size)
         }
-        self.model_fingerprint.get_or_init(|| {
+        // DS-V1.33-7: lock-and-init pattern replaces the previous
+        // `OnceLock::get_or_init`. Returns owned `String` (not `&str`) so
+        // the value lives independently of the mutex guard. `clear_session`
+        // resets the inner Option to None so a model swap re-fingerprints
+        // on next access. Fast-path: lock, see Some, clone, return.
+        {
+            let guard = self
+                .model_fingerprint
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            if let Some(fp) = guard.as_ref() {
+                return fp.clone();
+            }
+        }
+        let computed: String = {
             let _span = tracing::info_span!("compute_model_fingerprint").entered();
             match self.model_paths() {
                 Ok((model_path, _)) => {
@@ -500,8 +529,7 @@ impl Embedder {
                                     let mut hasher = blake3::Hasher::new();
                                     match hasher.update_reader(file) {
                                         Ok(_) => {
-                                            let hash =
-                                                hasher.finalize().to_hex().to_string();
+                                            let hash = hasher.finalize().to_hex().to_string();
                                             tracing::info!(
                                                 hash = &hash[..16],
                                                 "Model fingerprint computed (streaming)"
@@ -514,29 +542,56 @@ impl Embedder {
                                             // restart with a transient hash
                                             // failure used to mint a NEW
                                             // fingerprint and thrash the cache.
+                                            // EH-V1.33-6: when metadata also
+                                            // fails (the same FS hiccup that
+                                            // broke the hash), distinguish by
+                                            // failure mode instead of
+                                            // collapsing every model under
+                                            // `:fallback:size=0`.
                                             tracing::warn!(
                                                 error = %e,
                                                 "Failed to stream-hash model, using repo+size fallback (cache may miss until next successful hash)"
                                             );
-                                            let size = std::fs::metadata(model_path)
-                                                .ok()
-                                                .map(|m| m.len())
-                                                .unwrap_or(0);
-                                            fallback_fingerprint(&self.model_config.repo, size)
+                                            match std::fs::metadata(model_path) {
+                                                Ok(m) => fallback_fingerprint(
+                                                    &self.model_config.repo,
+                                                    m.len(),
+                                                ),
+                                                Err(meta_err) => {
+                                                    tracing::warn!(
+                                                        error = %meta_err,
+                                                        "Failed to stat model for size fallback after hash failure; using no-stat fingerprint"
+                                                    );
+                                                    format!(
+                                                        "{}:fallback:no-stat",
+                                                        self.model_config.repo
+                                                    )
+                                                }
+                                            }
                                         }
                                     }
                                 }
                                 Err(e) => {
                                     // P1.8 / P2.63: stable size-based fallback (see above).
+                                    // EH-V1.33-6: when metadata also fails,
+                                    // emit a no-stat sentinel so distinct
+                                    // models don't all share `:fallback:size=0`.
                                     tracing::warn!(
                                         error = %e,
                                         "Failed to open model for fingerprint, using repo+size fallback"
                                     );
-                                    let size = std::fs::metadata(model_path)
-                                        .ok()
-                                        .map(|m| m.len())
-                                        .unwrap_or(0);
-                                    fallback_fingerprint(&self.model_config.repo, size)
+                                    match std::fs::metadata(model_path) {
+                                        Ok(m) => {
+                                            fallback_fingerprint(&self.model_config.repo, m.len())
+                                        }
+                                        Err(meta_err) => {
+                                            tracing::warn!(
+                                                error = %meta_err,
+                                                "Failed to stat model for size fallback after open failure; using no-stat fingerprint"
+                                            );
+                                            format!("{}:fallback:no-stat", self.model_config.repo)
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -553,7 +608,21 @@ impl Embedder {
                     format!("{}:fallback:no-path", self.model_config.repo)
                 }
             }
-        })
+        };
+        // Race: a parallel caller could have populated the slot between our
+        // initial check and the compute. The first writer wins; subsequent
+        // readers (including this caller's clone return) see the same value.
+        let mut guard = self
+            .model_fingerprint
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        match guard.as_ref() {
+            Some(existing) => existing.clone(),
+            None => {
+                *guard = Some(computed.clone());
+                computed
+            }
+        }
     }
 
     /// Get or initialize model paths (lazy download)
@@ -875,7 +944,7 @@ impl Embedder {
         // Check disk cache (survives across CLI invocations)
         let model_fp = self.model_fingerprint();
         if let Some(disk) = self.disk_query_cache() {
-            if let Some(cached) = disk.get(text, model_fp) {
+            if let Some(cached) = disk.get(text, &model_fp) {
                 tracing::trace!(query = text, "Query cache hit (disk)");
                 // Populate in-memory LRU for fast subsequent hits
                 let mut cache = self.query_cache.lock().unwrap_or_else(|p| p.into_inner());
@@ -911,7 +980,7 @@ impl Embedder {
             cache.put(text.to_string(), embedding.clone());
         }
         if let Some(disk) = self.disk_query_cache() {
-            disk.put(text, model_fp, &embedding);
+            disk.put(text, &model_fp, &embedding);
         }
 
         // P3.10: completion event so embed_query has parity with the
@@ -976,7 +1045,26 @@ impl Embedder {
             }
         }
         *tok = None;
-        tracing::info!("Embedder session, query cache, and tokenizer cleared");
+        // DS-V1.33-7: also reset detected_dim and model_fingerprint so a
+        // model swap re-detects dim and re-fingerprints on next inference.
+        // Without this reset, the OnceLock-replaced Mutex<Option<...>>
+        // slots would carry the first-loaded model's values forever,
+        // silently feeding the wrong dim to `EmbeddingCache::read_batch`'s
+        // dimension filter and the wrong fingerprint to the disk cache key.
+        {
+            let mut dim_guard = self.detected_dim.lock().unwrap_or_else(|p| p.into_inner());
+            *dim_guard = None;
+        }
+        {
+            let mut fp_guard = self
+                .model_fingerprint
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            *fp_guard = None;
+        }
+        tracing::info!(
+            "Embedder session, query cache, tokenizer, detected_dim, and model_fingerprint cleared"
+        );
     }
 
     /// Warm up the model with a dummy inference
@@ -999,7 +1087,16 @@ impl Embedder {
     /// Returns the embedding dimension detected from the model.
     /// Falls back to the model config's declared dimension if no inference has been run yet.
     pub fn embedding_dim(&self) -> usize {
-        let dim = *self.detected_dim.get().unwrap_or(&self.model_config.dim);
+        // DS-V1.33-7: read through the Mutex<Option<usize>> slot. Falls
+        // back to the model config's declared dim when no inference has
+        // populated the slot yet (or after `clear_session` reset it).
+        let detected = self
+            .detected_dim
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_ref()
+            .copied();
+        let dim = detected.unwrap_or(self.model_config.dim);
         if dim == 0 {
             EMBEDDING_DIM
         } else {
@@ -1138,20 +1235,24 @@ impl Embedder {
                 )));
             }
             let embedding_dim = shape[1] as usize;
-            match self.detected_dim.get() {
-                Some(&expected) if expected != embedding_dim => {
-                    return Err(EmbedderError::InferenceFailed(format!(
-                        "Embedding dimension changed: expected {expected}, got {embedding_dim}"
-                    )));
+            {
+                // DS-V1.33-7: lock-and-set the Mutex<Option<usize>> slot.
+                let mut guard = self.detected_dim.lock().unwrap_or_else(|p| p.into_inner());
+                match *guard {
+                    Some(expected) if expected != embedding_dim => {
+                        return Err(EmbedderError::InferenceFailed(format!(
+                            "Embedding dimension changed: expected {expected}, got {embedding_dim}"
+                        )));
+                    }
+                    None => {
+                        *guard = Some(embedding_dim);
+                        tracing::info!(
+                            dim = embedding_dim,
+                            "Detected embedding dimension from model (Identity pooling)"
+                        );
+                    }
+                    _ => {}
                 }
-                None => {
-                    let _ = self.detected_dim.set(embedding_dim);
-                    tracing::info!(
-                        dim = embedding_dim,
-                        "Detected embedding dimension from model (Identity pooling)"
-                    );
-                }
-                _ => {}
             }
             let results: Vec<Embedding> = (0..batch_size)
                 .map(|b| {
@@ -1172,20 +1273,24 @@ impl Embedder {
         }
         let embedding_dim = shape[2] as usize;
         // Set or validate embedding dimension from model output
-        match self.detected_dim.get() {
-            Some(&expected) if expected != embedding_dim => {
-                return Err(EmbedderError::InferenceFailed(format!(
-                    "Embedding dimension changed: expected {expected}, got {embedding_dim}"
-                )));
+        // DS-V1.33-7: lock-and-set the Mutex<Option<usize>> slot.
+        {
+            let mut guard = self.detected_dim.lock().unwrap_or_else(|p| p.into_inner());
+            match *guard {
+                Some(expected) if expected != embedding_dim => {
+                    return Err(EmbedderError::InferenceFailed(format!(
+                        "Embedding dimension changed: expected {expected}, got {embedding_dim}"
+                    )));
+                }
+                None => {
+                    *guard = Some(embedding_dim);
+                    tracing::info!(
+                        dim = embedding_dim,
+                        "Detected embedding dimension from model"
+                    );
+                }
+                _ => {} // matches expected — OK
             }
-            None => {
-                let _ = self.detected_dim.set(embedding_dim);
-                tracing::info!(
-                    dim = embedding_dim,
-                    "Detected embedding dimension from model"
-                );
-            }
-            _ => {} // matches expected — OK
         }
         if shape[0] as usize != batch_size {
             return Err(EmbedderError::InferenceFailed(format!(
@@ -1905,6 +2010,55 @@ mod tests {
         let embedder = Embedder::new_cpu(ModelConfig::e5_base()).unwrap();
         embedder.clear_session(); // clear before init -- should not panic
         embedder.clear_session(); // clear again -- should not panic
+    }
+
+    /// DS-V1.33-7: `clear_session` must reset `detected_dim` and
+    /// `model_fingerprint` so a model swap re-detects on the next inference.
+    /// Pre-fix, both fields were `OnceLock` and could not be cleared under
+    /// `&self`, leaving the first-loaded model's values in place forever.
+    /// This test directly mutates the Mutex<Option<...>> slots to simulate
+    /// post-inference state, calls clear_session, and verifies the slots
+    /// are now None — no model load required.
+    #[test]
+    fn clear_session_resets_detected_dim_and_model_fingerprint() {
+        let embedder = Embedder::new_cpu(ModelConfig::e5_base()).unwrap();
+        // Simulate post-inference state: detected_dim populated.
+        {
+            let mut g = embedder.detected_dim.lock().unwrap();
+            *g = Some(1024);
+        }
+        // Simulate post-fingerprint state: model_fingerprint populated.
+        {
+            let mut g = embedder.model_fingerprint.lock().unwrap();
+            *g = Some("stale-model-hash-from-old-load".to_string());
+        }
+        // Sanity: read-through via the public APIs returns the staged values.
+        assert_eq!(
+            embedder.embedding_dim(),
+            1024,
+            "embedding_dim must read the staged detected_dim"
+        );
+        assert_eq!(
+            embedder.model_fingerprint(),
+            "stale-model-hash-from-old-load",
+            "model_fingerprint must read the staged value"
+        );
+        // Clear and verify both slots reset to None.
+        embedder.clear_session();
+        assert!(
+            embedder.detected_dim.lock().unwrap().is_none(),
+            "detected_dim must be None after clear_session"
+        );
+        assert!(
+            embedder.model_fingerprint.lock().unwrap().is_none(),
+            "model_fingerprint must be None after clear_session"
+        );
+        // Public API now falls back to model_config.dim (model never loaded).
+        assert_eq!(
+            embedder.embedding_dim(),
+            ModelConfig::e5_base().dim,
+            "embedding_dim falls back to config dim when detected_dim is None"
+        );
     }
 
     // ===== Integration tests (require model) =====

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -881,6 +881,23 @@ fn apply_rerank_scores(results: &mut Vec<SearchResult>, scores: Vec<f32>, limit:
         return;
     }
     let n = scores.len().min(results.len());
+    // AC-V1.33-9: if the reranker returned fewer scores than results
+    // (`compute_scores_opt` currently can't, but a future ONNX backend that
+    // short-circuits on a per-batch failure could), drop the un-rescored
+    // tail rather than mixing cross-encoder cohort scores ([0, 1] post
+    // sigmoid) with the surviving cosine cohort ([-1, 1]) inside the same
+    // sort comparator. The mixed comparison would interleave the two
+    // cohorts arbitrarily, producing neither pure rerank nor pure semantic
+    // ranking. Truncating the un-rescored tail keeps the surviving cohort
+    // homogeneous.
+    if n < results.len() {
+        tracing::warn!(
+            scores = scores.len(),
+            results = results.len(),
+            "Reranker returned fewer scores than results; dropping un-rescored tail to keep cohort homogeneous"
+        );
+        results.truncate(n);
+    }
     for (i, score) in scores.into_iter().take(n).enumerate() {
         results[i].score = score;
     }
@@ -1163,6 +1180,59 @@ mod tests {
             msg.contains("2"),
             "error message must mention passages.len()=2, got: {msg:?}"
         );
+    }
+
+    /// AC-V1.33-9: when a reranker backend returns fewer scores than results
+    /// (a future per-batch-failure short-circuit), `apply_rerank_scores`
+    /// must NOT mix cross-encoder cohort scores ([0, 1] post-sigmoid) with
+    /// the surviving cosine cohort ([-1, 1]) — the partial-overwrite path.
+    /// Truncating the un-rescored tail is the contract: every survivor in
+    /// the output must have come from the rerank cohort, never from the
+    /// pre-rerank cosine cohort.
+    #[test]
+    fn apply_rerank_scores_drops_unrescored_tail_on_length_mismatch() {
+        // Five results, only three scores. The last two carry pre-rerank
+        // cosine-style scores (here: 0.99) that, if mixed with the
+        // sigmoid-mapped rerank scores ([0, 1]), would arbitrarily
+        // outrank the rerank survivors.
+        let mut results = vec![
+            stub_result("a", "first"),
+            stub_result("b", "second"),
+            stub_result("c", "third"),
+            stub_result("d", "fourth"),
+            stub_result("e", "fifth"),
+        ];
+        // Pre-rerank: tail has high cosine scores that should NOT survive.
+        results[3].score = 0.99;
+        results[4].score = 0.95;
+        // Rerank cohort: low sigmoid scores that, before this fix, would
+        // have lost the sort to the cosine tail.
+        let scores = vec![0.1f32, 0.05, 0.2];
+        super::apply_rerank_scores(&mut results, scores, 10);
+        assert_eq!(
+            results.len(),
+            3,
+            "un-rescored tail must be dropped (5 results -> 3 after truncate to scores.len())"
+        );
+        let survivors: std::collections::HashSet<&str> =
+            results.iter().map(|r| r.chunk.id.as_str()).collect();
+        assert!(survivors.contains("a"), "rescored a must survive");
+        assert!(survivors.contains("b"), "rescored b must survive");
+        assert!(survivors.contains("c"), "rescored c must survive");
+        assert!(
+            !survivors.contains("d") && !survivors.contains("e"),
+            "un-rescored cosine cohort must be dropped, got {survivors:?}"
+        );
+        // Every surviving score must be from the rerank cohort (<= 0.2),
+        // never from the cosine tail (>= 0.95) — the cohort-mixing bug.
+        for r in &results {
+            assert!(
+                r.score <= 0.2 + f32::EPSILON,
+                "survivor {} carries score {} — must be from rerank cohort, not cosine tail",
+                r.chunk.id,
+                r.score
+            );
+        }
     }
 
     /// `LlmReranker` is a skeleton — every score-producing call returns

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -632,26 +632,27 @@ impl<Mode> Store<Mode> {
 
         tracing::debug!(fused = fused.len(), alpha, "Hybrid fusion complete");
 
-        // PF-V1.25-16: drain `fused` into the score map (ids move, no clone).
-        // Previously the code ran `fused.iter().map(|r| (r.id.clone(), ...))`
-        // followed by a second `fused.iter().map(|r| r.id.as_str()).collect()`
-        // pass — one extra Vec allocation plus N string clones after having
-        // already owned the ids in `fused`.
+        // AC-V1.33-8: build `candidate_ids` from the sorted `fused` Vec
+        // BEFORE populating the score-lookup HashMap so the positional
+        // order of candidate_ids matches the fusion sort. The previous
+        // `PF-V1.25-16` shape drained ids into the HashMap first, then
+        // iterated `fused_map.keys()` to build candidate_ids — HashMap
+        // iteration order is unspecified, scrambling the tie-broken sort
+        // order computed by the `fused.sort_by(...)` above. The downstream
+        // re-sort in `search_by_candidate_ids_with_notes` recovers final
+        // ranking, but the contract that "candidate_ids order == fusion
+        // order" was load-bearing for any future tie-breaker that uses
+        // positional rank — and the silent scramble was only documented
+        // by an in-line comment, not enforced by the code structure.
         //
-        // Tie-break determinism downstream depends on the final
-        // `scored.sort_by(b.1.total_cmp(&a.1).then(a.0.id.cmp(&b.0.id)))` in
-        // `search_by_candidate_ids_with_notes`, which carries its own id
-        // secondary key. The order of `candidate_ids` only affects DB fetch
-        // order, not final ranking.
+        // Cost: N clones of chunk-id strings (typically ~32 hex chars,
+        // N <= candidate_count ~= 200). Negligible vs the search work.
+        let candidate_ids: Vec<&str> = fused.iter().map(|r| r.id.as_str()).collect();
         let mut fused_map: std::collections::HashMap<String, f32> =
             std::collections::HashMap::with_capacity(fused.len());
-        for r in fused.drain(..) {
-            fused_map.insert(r.id, r.score);
+        for r in fused.iter() {
+            fused_map.insert(r.id.clone(), r.score);
         }
-        // HashMap iteration order is unspecified but STABLE across a single
-        // iteration within one call, which is all `fetch_candidates_by_ids_async`
-        // needs for its positional tie-breaker. No clone required.
-        let candidate_ids: Vec<&str> = fused_map.keys().map(|id| id.as_str()).collect();
         self.search_by_candidate_ids_with_notes(
             &candidate_ids,
             query,

--- a/src/train_data/bm25.rs
+++ b/src/train_data/bm25.rs
@@ -62,10 +62,23 @@ impl Bm25Index {
 
         let avg_dl = if docs.is_empty() { 0.0 } else { total_dl / n };
 
-        // Compute IDF: ln((N - df + 0.5) / (df + 0.5) + 1)
+        // Compute IDF using the Robertson-Sparck-Jones formula:
+        //   ln((N - df + 0.5) / (df + 0.5))
+        //
+        // AC-V1.33-5: Previously this used the Atire/Lucene `+ 1.0` variant
+        // (`ln((N - df + 0.5) / (df + 0.5) + 1.0)`), which prevents negative
+        // IDF when `df > N/2` but mismatches the FTS5-backed BM25 path at
+        // `src/store/search.rs` (`ORDER BY bm25(chunks_fts, ...)`). SQLite
+        // FTS5's built-in BM25 uses the standard Robertson-Sparck-Jones
+        // formula without the `+ 1.0` shift. Aligning the hard-negative
+        // selection scoring with FTS5 means A/B comparisons of negative-
+        // mining quality against FTS5-derived candidates compare the same
+        // ranking function. Negative IDF on extremely-common terms is
+        // acceptable for hard-negative selection: the per-doc score is
+        // still monotonic in match strength.
         let mut idf = HashMap::new();
         for (term, doc_freq) in &df {
-            let idf_val = ((n - doc_freq + 0.5) / (doc_freq + 0.5) + 1.0).ln();
+            let idf_val = ((n - doc_freq + 0.5) / (doc_freq + 0.5)).ln();
             idf.insert(term.clone(), idf_val);
         }
 


### PR DESCRIPTION
## Summary

Five P2 correctness bugs from the v1.33.0 audit's Tier-1 silent-wrong-answer cluster (C13).

- **P2-3 / EH-V1.33-6** — `embedder.fingerprint` fallback collapsed every distinct fine-tune under `:fallback:size=0` when metadata also failed. Now distinguishes by failure mode via `:fallback:no-stat` sentinel.
- **P2-15 / AC-V1.33-9** — `apply_rerank_scores` mixed cross-encoder cohort scores ([0, 1]) with un-rescored cosine cohort ([-1, 1]) when reranker returned fewer scores than results. Now truncates the un-rescored tail before sorting, keeping the survivor cohort homogeneous.
- **P2-16 / AC-V1.33-8** — SPLADE hybrid fusion scrambled tie-broken sort order by draining into a HashMap then iterating `keys()`. Now builds `candidate_ids` from sorted `fused.iter()` before populating the score map.
- **P2-17 / AC-V1.33-5** — BM25 IDF used the Atire/Lucene `+ 1.0` variant, mismatching FTS5's Robertson-Sparck-Jones formula. Now matches FTS5 so negative-mining A/Bs compare like-for-like.
- **P2-24 / DS-V1.33-7** — `clear_session` didn't reset `detected_dim` or `model_fingerprint` because both were `OnceLock`. Switched to `Mutex<Option<T>>`; `clear_session` now resets both slots alongside the session drop.

## Test plan

- [x] `cargo check --features cuda-index --tests` — clean (no errors)
- [x] `cargo clippy --features cuda-index --lib -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --features cuda-index --lib reranker` — 21 passed (incl. new `apply_rerank_scores_drops_unrescored_tail_on_length_mismatch`)
- [x] `cargo test --features cuda-index --lib embedder` — 98 passed (incl. new `clear_session_resets_detected_dim_and_model_fingerprint`)
- [x] `cargo test --features cuda-index --lib search` — 209 passed (SPLADE fusion ordering)
- [x] `cargo test --features cuda-index --lib store` — 317 passed
- [x] `cargo test --features cuda-index --lib cache` — 44 passed
- [x] `cargo test --features cuda-index --lib train_data` — 46 passed (BM25 IDF formula change)
- [x] `cargo test --features cuda-index --lib watch` — 12 passed (model_fingerprint API change downstream)

## Notes / deviations

- **`model_fingerprint()` signature change**: returns `String` instead of `&str` because the slot moved from `OnceLock<String>` (allows borrowing) to `Mutex<Option<String>>` (guard scoped to call). Three callers updated to take `&fp` where `&str` is required (cli/watch/reindex.rs ×2, cli/watch/tests.rs ×1). The two `cli/pipeline/embedding.rs` callers already chained `.to_string()` so they're unchanged.
- **P2-16 regression test deferred**: the SPLADE-fusion contract is now structurally enforced (sort precedes HashMap population), and pinning it via a unit test would require building the full SPLADE index + dense index + Embedder fixture, which is heavyweight for a one-line ordering invariant. The structural change (use `fused.iter()` to build candidate_ids before drain) makes the bug impossible without re-introducing the HashMap-keys iteration pattern that was removed.
- **BM25 IDF formula change** affects absolute scores but not relative ordering for the existing tests (all 8 BM25 unit tests pass without modification). Operators running historical negative-mining A/Bs against pre-change pickled corpora will see different absolute scores; the relative quality of the selected hard negatives stays comparable since the IDF transformation is monotonic in `df`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
