### PR TITLE
fix(audit): security & data-safety cluster from v1.33.0 audit (P2-6, P2-21, P2-23, P2-25, P2-31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,6 +890,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_TRAIN_GIT_SHOW_MAX_BYTES` | `52428800` (50 MiB) | Max bytes retrieved per file via `git show` during training-data extraction. Files above the cap are skipped; bump to capture larger generated files (schema dumps, vendored corpora). |
 | `CQS_TYPE_BOOST` | `1.2` | Multiplier applied to chunks whose type matches the query filter (e.g. `--include-type function`) |
 | `CQS_TYPE_GRAPH_MAX_EDGES` | `500000` | Max `type_edges` rows loaded into the in-memory type graph. Sibling of `CQS_CALL_GRAPH_MAX_EDGES` for type-dependency analysis. |
+| `CQS_WAL_AUTOCHECKPOINT_PAGES` | `1000` | SQLite `wal_autocheckpoint` ceiling (pages) applied via every connection's `after_connect` hook. Caps WAL growth between commits so an abrupt shutdown leaves a bounded recovery walk. Lower for tighter WAL bounds; raise on long write-heavy reindex sessions to amortize checkpoint cost. (P2-25 / DS-V1.33-8) |
 | `CQS_WATCH_DEBOUNCE_MS` | `500` (inotify) / `1500` (WSL/poll auto) | Watch debounce window (milliseconds). Takes precedence over `--debounce`. |
 | `CQS_WATCH_INCREMENTAL_SPLADE` | `1` | Set to `0` to disable inline SPLADE encoding in `cqs watch`. Daemon then runs dense-only and sparse coverage drifts until a manual `cqs index`. |
 | `CQS_WATCH_MAX_PENDING` | `10000` | Max pending file changes before watch forces flush |

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -85,7 +85,7 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 | P2-3 | Error Handling | `embedder.fingerprint` silently uses `size = 0` when metadata fails — collides cache keys | medium | ✅ #1364 |
 | P2-4 | Error Handling | `IndexBackend` trait — public lib trait uses anyhow::Result instead of thiserror | medium | ⬜ |
 | P2-5 | Error Handling | Reconcile mtime-touch chain silently abandons on metadata or `modified()` failure | medium | ✅ #1379 |
-| P2-6 | Error Handling | Reference path canonicalize-failure in `Config::validate` skips SEC-4 + SEC-NEW-1 check | medium | ⬜ |
+| P2-6 | Error Handling | Reference path canonicalize-failure in `Config::validate` skips SEC-4 + SEC-NEW-1 check | medium | ✅ #1367 |
 | P2-7 | Robustness | L5X parser line arithmetic uses unchecked u32+u32 — overflow panics in debug | medium | ✅ #1379 |
 | P2-8 | Code Quality | `serve` async handlers duplicate 15-20 LOC of permit + spawn_blocking + span ×6 | medium | ⬜ |
 | P2-9 | Scaling | HNSW M/ef defaults static, don't auto-scale with corpus | medium | ⬜ |
@@ -100,17 +100,17 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 | P2-18 | Data Safety | `migrate_legacy_index_to_default_slot` does not acquire `slots.lock` | medium | ⬜ |
 | P2-19 | Data Safety | `write_active_slot`/`write_slot_model` use fixed `<file>.tmp` paths | easy | ⬜ |
 | P2-20 | Data Safety | `verify_hnsw_checksums` skips files not on disk — partial index passes verification | easy | ⬜ |
-| P2-21 | Data Safety | `EmbeddingCache::evict`/`QueryCache::evict` use deferred transactions | medium | ⬜ |
+| P2-21 | Data Safety | `EmbeddingCache::evict`/`QueryCache::evict` use deferred transactions | medium | ✅ #1367 |
 | P2-22 | Data Safety | `backup_path_for` uses 1-second timestamp with no PID — concurrent migrations collide | easy | ⬜ |
-| P2-23 | Data Safety | `evict_lock` reset on every `EmbeddingCache::open` — multiple opens don't share | medium | ⬜ |
+| P2-23 | Data Safety | `evict_lock` reset on every `EmbeddingCache::open` — multiple opens don't share | medium | ✅ #1367 |
 | P2-24 | Data Safety | `clear_session` doesn't reset `detected_dim` or `model_fingerprint` | medium | ✅ #1364 |
-| P2-25 | Data Safety | Pool `after_connect` has no `wal_autocheckpoint` ceiling | medium | ⬜ |
+| P2-25 | Data Safety | Pool `after_connect` has no `wal_autocheckpoint` ceiling | medium | ✅ #1367 |
 | P2-26 | Data Safety | `migrate_legacy_index_to_default_slot` checkpoints before sentinel | easy | ⬜ |
 | P2-27 | Security | `apply_db_file_perms` runs after pool open — embedding cache born world-readable | easy | ⬜ |
 | P2-28 | Security | `ProjectRegistry::save` writes tmp with default umask; chmod after rename | easy | ⬜ |
 | P2-29 | Security | `write_model_toml` interpolates `repo` into TOML without escaping | easy | ⬜ |
 | P2-30 | Security | `audit-mode.json` parsed without size cap — `.cqs/`-write attacker can OOM cqs | easy | ⬜ |
-| P2-31 | Security | `dispatch_read` daemon handler hardcodes `trust_level: "user-code"` | medium | ⬜ |
+| P2-31 | Security | `dispatch_read` daemon handler hardcodes `trust_level: "user-code"` | medium | ✅ #1367 |
 | P2-32 | Resource Management | `add_reference_to_config`/`remove_reference_from_config` read locked TOML unbounded | easy | ⬜ |
 | P2-33 | Resource Management | `ProjectRegistry::load` reads file *then* checks size — full alloc before cap | easy | ⬜ |
 | P2-34 | Resource Management | `parse_wsl_automount_root`/`is_slow_mmap_filesystem` read system files unbounded | easy | ⬜ |

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -10,8 +10,44 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use thiserror::Error;
+
+/// DS-V1.33-6: process-global mutex serializing `EmbeddingCache::evict()`
+/// across all `EmbeddingCache` handles in this process.
+///
+/// `EmbeddingCache::open` is called from multiple call paths (bulk pipeline
+/// `prepare_for_embedding`, watch daemon reindex, `cqs cache prune`); each
+/// returned a fresh per-instance `Mutex<()>` that pointed at the same
+/// `embeddings_cache.db` file but didn't coordinate. Two of those instances
+/// calling `evict()` concurrently from different runtimes would each measure
+/// the same logical size and issue overlapping `LIMIT ?` DELETEs — exactly
+/// the race the docstring promised to prevent.
+///
+/// Lifting the lock to module scope mirrors `WRITE_LOCK` in
+/// `src/store/mod.rs:54`. Cross-process serialization still relies on SQLite
+/// busy_timeout + the `BEGIN IMMEDIATE` evict transaction (DS-V1.33-4).
+static EMBEDDING_CACHE_EVICT_LOCK: Mutex<()> = Mutex::new(());
+
+/// DS-V1.33-6: process-global mutex serializing `QueryCache::evict()` across
+/// all `QueryCache` handles in this process. See `EMBEDDING_CACHE_EVICT_LOCK`.
+static QUERY_CACHE_EVICT_LOCK: Mutex<()> = Mutex::new(());
+
+/// DS-V1.33-8: cap the on-disk WAL at this many pages on each open so an
+/// abrupt shutdown (SIGKILL, panic, daemon worker crash) leaves a bounded
+/// WAL for the next open. Default 1000 pages mirrors SQLite's built-in
+/// autocheckpoint default; we set it explicitly so it actually applies to
+/// read-mostly cache connections that rarely COMMIT (without an explicit
+/// PRAGMA the autocheckpoint only runs on COMMIT). Override via
+/// `CQS_WAL_AUTOCHECKPOINT_PAGES`.
+fn wal_autocheckpoint_pragma() -> String {
+    let pages: u32 = std::env::var("CQS_WAL_AUTOCHECKPOINT_PAGES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1000);
+    format!("PRAGMA wal_autocheckpoint = {}", pages)
+}
 
 use crate::store::helpers::sql::{
     busy_timeout_from_env, make_placeholders_offset, max_rows_per_statement,
@@ -157,12 +193,11 @@ pub struct EmbeddingCache {
     /// constructor spinning up its own worker pool.
     rt: Arc<tokio::runtime::Runtime>,
     max_size_bytes: u64,
-    /// DS2-5: serializes `evict()` calls so two parallel invocations can't both
-    /// measure the same logical size and issue overlapping `LIMIT ?` DELETEs.
-    /// Size/AVG/DELETE inside `evict()` are further wrapped in a single
-    /// transaction so the snapshot is consistent against concurrent
-    /// `write_batch` traffic.
-    evict_lock: std::sync::Mutex<()>,
+    // DS-V1.33-6: `evict_lock` was previously a per-instance `Mutex<()>` field,
+    // but `EmbeddingCache::open` is called from multiple paths in one process
+    // and each call constructed a fresh mutex pointing at the same DB file
+    // — defeating the serialization the docstring promised. Lifted to the
+    // module-level `EMBEDDING_CACHE_EVICT_LOCK` static; see its docs.
 }
 
 impl EmbeddingCache {
@@ -263,10 +298,22 @@ impl EmbeddingCache {
         // worker, restoring before any other file-creating code runs.
         #[cfg(unix)]
         let prev_umask = unsafe { libc::umask(0o077) };
+        // DS-V1.33-8: cap the on-disk WAL via after_connect so every
+        // connection (including the read-only checkout one acquires for
+        // statistics) carries the ceiling. Same default and env override as
+        // the main store.
+        let wal_pragma = wal_autocheckpoint_pragma();
         let pool = rt.block_on(async {
             let pool = sqlx::sqlite::SqlitePoolOptions::new()
                 .max_connections(1) // RM-2: single worker thread can only use 1 connection
                 .idle_timeout(std::time::Duration::from_secs(30)) // RM-5: release idle connections
+                .after_connect(move |conn, _meta| {
+                    let wal = wal_pragma.clone();
+                    Box::pin(async move {
+                        sqlx::query(&wal).execute(&mut *conn).await?;
+                        Ok(())
+                    })
+                })
                 .connect_with(connect_opts)
                 .await?;
 
@@ -391,7 +438,6 @@ impl EmbeddingCache {
             pool,
             rt,
             max_size_bytes,
-            evict_lock: std::sync::Mutex::new(()),
         })
     }
 
@@ -541,15 +587,16 @@ impl EmbeddingCache {
             return Ok(0);
         }
 
-        // P2.66: hold `evict_lock` across the write so a concurrent `evict()`
-        // can't measure size, then DELETE rows that this in-flight write_batch
-        // committed between the SELECT and DELETE. Without this, a writer
-        // sees its INSERT succeed while a cross-session reader sees a cache
-        // miss — silently re-embedding chunks the cache "should" have. Mutex
-        // poisoning is non-fatal: a previous holder's panic shouldn't keep
-        // the cache write path locked out.
-        let _evict_guard = self
-            .evict_lock
+        // P2.66: hold `EMBEDDING_CACHE_EVICT_LOCK` across the write so a
+        // concurrent `evict()` can't measure size, then DELETE rows that this
+        // in-flight write_batch committed between the SELECT and DELETE.
+        // Without this, a writer sees its INSERT succeed while a cross-session
+        // reader sees a cache miss — silently re-embedding chunks the cache
+        // "should" have. Mutex poisoning is non-fatal: a previous holder's
+        // panic shouldn't keep the cache write path locked out.
+        // DS-V1.33-6: process-global static so all `EmbeddingCache` handles in
+        // this process share the same mutex (was per-instance, useless).
+        let _evict_guard = EMBEDDING_CACHE_EVICT_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
 
@@ -617,46 +664,69 @@ impl EmbeddingCache {
 
     /// Evict oldest entries if cache exceeds max size.
     ///
-    /// DS2-5: the size / AVG / DELETE trio runs inside a single
-    /// `pool.begin()` transaction so concurrent `write_batch` traffic cannot
-    /// invalidate the measurement between steps. An in-process `evict_lock`
-    /// mutex further prevents two `evict()` callers from overlapping their
-    /// `LIMIT ?` prefixes and each over-counting `rows_affected()`.
+    /// DS2-5: the size / AVG / DELETE trio runs inside a single transaction so
+    /// concurrent `write_batch` traffic cannot invalidate the measurement
+    /// between steps. An in-process `evict_lock` mutex further prevents two
+    /// `evict()` callers from overlapping their `LIMIT ?` prefixes and each
+    /// over-counting `rows_affected()`.
+    ///
+    /// DS-V1.33-4: the transaction uses `BEGIN IMMEDIATE` (not the sqlx
+    /// default deferred BEGIN) so the writer lock is acquired up front.
+    /// Without this, two cqs processes (e.g. `cqs cache prune` running while
+    /// the daemon is calling `write_batch`) each open their own pool, bypass
+    /// the in-process `evict_lock`, and SQLite WAL hands each a deferred
+    /// snapshot that doesn't include the other's in-flight commits — so the
+    /// cache can be evicted below `max_size_bytes / 2` even though only one
+    /// excess interval was supposed to be reclaimed. `BEGIN IMMEDIATE` makes
+    /// the second writer wait on the first instead of racing with stale data.
     pub fn evict(&self) -> Result<usize, CacheError> {
         let _span = tracing::info_span!("cache_evict").entered();
 
         // Serialize evicts across threads. Mutex poisoning is non-fatal here:
         // if the previous holder panicked we still want to attempt an evict.
-        let _guard = self
-            .evict_lock
+        // DS-V1.33-6: process-global static — see `EMBEDDING_CACHE_EVICT_LOCK`
+        // docs for why per-instance was a bug.
+        let _guard = EMBEDDING_CACHE_EVICT_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
 
         self.rt.block_on(async {
-            let mut tx = match self.pool.begin().await {
-                Ok(t) => t,
+            // DS-V1.33-4: hold one connection across the whole eviction so the
+            // BEGIN IMMEDIATE / SELECTs / DELETE / COMMIT all land on the same
+            // connection. Returning the connection to the pool with no explicit
+            // COMMIT triggers SQLite's implicit ROLLBACK — sqlx::Pool resets
+            // dirty state on `release_to_pool` — so any early `return Ok(0)` is
+            // safe.
+            let mut conn = match self.pool.acquire().await {
+                Ok(c) => c,
                 Err(e) => {
-                    tracing::warn!(error = %e, "Cache evict begin-tx failed");
+                    tracing::warn!(error = %e, "Cache evict acquire failed");
                     return Ok(0);
                 }
             };
+            if let Err(e) = sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await {
+                tracing::warn!(error = %e, "Cache evict BEGIN IMMEDIATE failed");
+                return Ok(0);
+            }
 
             // Use logical data size, not physical pages (DS-49)
             let size: i64 = match sqlx::query_scalar(
                 "SELECT COALESCE(SUM(LENGTH(embedding)), 0) + COUNT(*) * 200 FROM embedding_cache",
             )
-            .fetch_one(&mut *tx)
+            .fetch_one(&mut *conn)
             .await
             {
                 Ok(v) => v,
                 Err(e) => {
                     tracing::warn!(error = %e, "Cache evict size query failed");
+                    let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
                     return Ok(0);
                 }
             };
 
             // Guard against negative/zero size (SEC-10)
             if size <= 0 || (size as u64) <= self.max_size_bytes {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
                 return Ok(0);
             }
 
@@ -665,7 +735,7 @@ impl EmbeddingCache {
             let avg_entry: i64 = match sqlx::query_scalar(
                 "SELECT COALESCE(AVG(LENGTH(embedding) + 200), 4200) FROM embedding_cache",
             )
-            .fetch_one(&mut *tx)
+            .fetch_one(&mut *conn)
             .await
             {
                 Ok(v) => v,
@@ -682,10 +752,10 @@ impl EmbeddingCache {
                  (SELECT rowid FROM embedding_cache ORDER BY created_at ASC LIMIT ?1)",
             )
             .bind(entries_to_delete as i64)
-            .execute(&mut *tx)
+            .execute(&mut *conn)
             .await?;
 
-            tx.commit().await?;
+            sqlx::query("COMMIT").execute(&mut *conn).await?;
 
             let evicted = result.rows_affected() as usize;
             tracing::info!(evicted, "Cache eviction complete");
@@ -1374,7 +1444,6 @@ mod tests {
             pool,
             rt,
             max_size_bytes: 1, // 1 byte — everything should be evicted
-            evict_lock: std::sync::Mutex::new(()),
         };
 
         let entries: Vec<_> = (0..10)
@@ -2098,6 +2167,53 @@ mod tests {
         assert!((r2["colliding_hash"][0] - base_emb[0]).abs() < 1e-6);
         assert_eq!(cache.stats().unwrap().total_entries, 2);
     }
+
+    /// DS-V1.33-8 regression: every connection acquired from the embedding
+    /// cache pool carries `PRAGMA wal_autocheckpoint` set to a finite ceiling
+    /// (default 1000 pages). Without this, abrupt shutdown leaves the WAL
+    /// unbounded for the next open to replay. Asserting via PRAGMA query on a
+    /// freshly-opened cache pins the after_connect wiring so a refactor that
+    /// drops the hook surfaces here.
+    #[test]
+    fn wal_autocheckpoint_pragma_is_applied_after_connect() {
+        let (cache, _dir) = test_cache();
+        let pages: i64 = cache
+            .rt
+            .block_on(async {
+                sqlx::query_scalar::<_, i64>("PRAGMA wal_autocheckpoint")
+                    .fetch_one(&cache.pool)
+                    .await
+            })
+            .expect("PRAGMA wal_autocheckpoint should succeed on an open cache");
+        // Default is 1000 (mirrors SQLite's built-in autocheckpoint default).
+        // The exact value isn't load-bearing — what we're proving is the
+        // after_connect hook executed and applied a finite ceiling.
+        assert_eq!(
+            pages, 1000,
+            "expected default wal_autocheckpoint=1000 from `wal_autocheckpoint_pragma()`"
+        );
+    }
+
+    /// DS-V1.33-6 regression: `EMBEDDING_CACHE_EVICT_LOCK` is a process-global
+    /// static — opening two `EmbeddingCache` handles against different DB
+    /// paths still shares the same module-level mutex, so concurrent evicts
+    /// across handles don't race. Pinning the static's address is the
+    /// simplest structural assertion we can make without timing-sensitive
+    /// thread tests.
+    #[test]
+    fn embedding_cache_evict_lock_is_process_global() {
+        let p1 = &EMBEDDING_CACHE_EVICT_LOCK as *const Mutex<()>;
+        let p2 = &EMBEDDING_CACHE_EVICT_LOCK as *const Mutex<()>;
+        assert_eq!(
+            p1, p2,
+            "EMBEDDING_CACHE_EVICT_LOCK must resolve to a single static address"
+        );
+        // Smoke: lock and immediately unlock — the static is reachable from
+        // tests, the same way `evict()` accesses it from production code.
+        let _g = EMBEDDING_CACHE_EVICT_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+    }
 }
 
 // ─── Query Cache ────────────────────────────────────────────────────────────
@@ -2117,10 +2233,10 @@ pub struct QueryCache {
     /// default 100 MB). Read at `open` time and used by [`Self::evict`] —
     /// no resize support, daemon restart picks up env changes.
     max_size_bytes: u64,
-    /// DS2-5: serializes `evict()` calls so two parallel invocations can't
-    /// both measure the same size and issue overlapping `LIMIT ?` DELETEs.
-    /// Size/AVG/DELETE inside `evict()` are wrapped in a single transaction.
-    evict_lock: std::sync::Mutex<()>,
+    // DS-V1.33-6: `evict_lock` lifted to module-level
+    // `QUERY_CACHE_EVICT_LOCK` static for the same reason as
+    // `EmbeddingCache` — multiple opens in one process should share the
+    // mutex, not race past it.
 }
 
 impl QueryCache {
@@ -2198,10 +2314,20 @@ impl QueryCache {
         // write and `apply_db_file_perms` below.
         #[cfg(unix)]
         let prev_umask = unsafe { libc::umask(0o077) };
+        // DS-V1.33-8: cap the on-disk WAL for the query cache too. See
+        // `wal_autocheckpoint_pragma` for rationale.
+        let wal_pragma = wal_autocheckpoint_pragma();
         let pool = rt.block_on(async {
             let pool = sqlx::sqlite::SqlitePoolOptions::new()
                 .max_connections(1)
                 .idle_timeout(std::time::Duration::from_secs(30))
+                .after_connect(move |conn, _meta| {
+                    let wal = wal_pragma.clone();
+                    Box::pin(async move {
+                        sqlx::query(&wal).execute(&mut *conn).await?;
+                        Ok(())
+                    })
+                })
                 .connect_with(connect_opts)
                 .await?;
 
@@ -2244,7 +2370,6 @@ impl QueryCache {
             pool,
             rt,
             max_size_bytes,
-            evict_lock: std::sync::Mutex::new(()),
         })
     }
 
@@ -2256,25 +2381,40 @@ impl QueryCache {
     /// periodic-eviction tick so disk usage stays bounded across long
     /// sessions.
     ///
-    /// DS2-5: size / AVG / DELETE run in a single `pool.begin()` transaction
-    /// so concurrent `put()` traffic cannot invalidate the measurement
-    /// between steps. `evict_lock` serializes parallel evict callers.
+    /// DS2-5: size / AVG / DELETE run in a single transaction so concurrent
+    /// `put()` traffic cannot invalidate the measurement between steps.
+    /// `QUERY_CACHE_EVICT_LOCK` (process-global, DS-V1.33-6) serializes
+    /// parallel evict callers across all `QueryCache` handles in this process.
+    ///
+    /// DS-V1.33-4: the transaction is opened with `BEGIN IMMEDIATE` so a
+    /// peer process running its own evict can't race us via deferred
+    /// snapshots. See `EmbeddingCache::evict` for the full rationale.
     pub fn evict(&self) -> Result<usize, CacheError> {
         let _span = tracing::info_span!("query_cache_evict").entered();
 
-        let _guard = self
-            .evict_lock
+        // DS-V1.33-6: process-global static — see QUERY_CACHE_EVICT_LOCK docs.
+        let _guard = QUERY_CACHE_EVICT_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
 
         self.rt.block_on(async {
-            let mut tx = match self.pool.begin().await {
-                Ok(t) => t,
+            // DS-V1.33-4: same connection-held BEGIN IMMEDIATE pattern as
+            // `EmbeddingCache::evict`. Implicit ROLLBACK on connection return
+            // keeps early `return Ok(0)` paths safe.
+            let mut conn = match self.pool.acquire().await {
+                Ok(c) => c,
                 Err(e) => {
-                    tracing::warn!(error = %e, "Query cache evict begin-tx failed");
+                    tracing::warn!(error = %e, "Query cache evict acquire failed");
                     return Ok(0);
                 }
             };
+            if let Err(e) = sqlx::query("BEGIN IMMEDIATE")
+                .execute(&mut *conn)
+                .await
+            {
+                tracing::warn!(error = %e, "Query cache evict BEGIN IMMEDIATE failed");
+                return Ok(0);
+            }
 
             // Same logical-data measure as `EmbeddingCache::evict` (data + per-row
             // overhead). Page-count would over-report after deletions because the
@@ -2282,17 +2422,19 @@ impl QueryCache {
             let size: i64 = match sqlx::query_scalar(
                 "SELECT COALESCE(SUM(LENGTH(embedding)), 0) + COUNT(*) * 200 FROM query_cache",
             )
-            .fetch_one(&mut *tx)
+            .fetch_one(&mut *conn)
             .await
             {
                 Ok(v) => v,
                 Err(e) => {
                     tracing::warn!(error = %e, "Query cache evict size query failed");
+                    let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
                     return Ok(0);
                 }
             };
 
             if size <= 0 || (size as u64) <= self.max_size_bytes {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
                 return Ok(0);
             }
 
@@ -2300,7 +2442,7 @@ impl QueryCache {
             let avg_entry: i64 = match sqlx::query_scalar(
                 "SELECT COALESCE(AVG(LENGTH(embedding) + 200), 4200) FROM query_cache",
             )
-            .fetch_one(&mut *tx)
+            .fetch_one(&mut *conn)
             .await
             {
                 Ok(v) => v,
@@ -2316,10 +2458,10 @@ impl QueryCache {
                  (SELECT rowid FROM query_cache ORDER BY ts ASC LIMIT ?1)",
             )
             .bind(entries_to_delete as i64)
-            .execute(&mut *tx)
+            .execute(&mut *conn)
             .await?;
 
-            tx.commit().await?;
+            sqlx::query("COMMIT").execute(&mut *conn).await?;
 
             let evicted = result.rows_affected() as usize;
             tracing::info!(evicted, "Query cache eviction complete");
@@ -2534,6 +2676,29 @@ mod query_cache_malformed_blob_tests {
         assert_eq!(
             row_count, 0,
             "malformed row must be deleted after get, found {row_count} row(s)"
+        );
+    }
+
+    /// DS-V1.33-8 regression for QueryCache: same as the EmbeddingCache test,
+    /// every connection from the query-cache pool must carry a finite
+    /// wal_autocheckpoint ceiling so an abrupt shutdown doesn't leave an
+    /// unbounded WAL tail.
+    #[test]
+    fn query_cache_wal_autocheckpoint_pragma_is_applied_after_connect() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("query_cache.db");
+        let cache = QueryCache::open(&path).unwrap();
+        let pages: i64 = cache
+            .rt
+            .block_on(async {
+                sqlx::query_scalar::<_, i64>("PRAGMA wal_autocheckpoint")
+                    .fetch_one(&cache.pool)
+                    .await
+            })
+            .expect("PRAGMA wal_autocheckpoint should succeed on a fresh QueryCache");
+        assert_eq!(
+            pages, 1000,
+            "expected default wal_autocheckpoint=1000 from `wal_autocheckpoint_pragma()`"
         );
     }
 }

--- a/src/cli/batch/handlers/info.rs
+++ b/src/cli/batch/handlers/info.rs
@@ -388,11 +388,28 @@ pub(in crate::cli::batch) fn dispatch_read(
         format!("{}{}", header, content)
     };
 
+    // SEC-V1.33-9: file-read path should also honor vendored detection so
+    // `cqs read node_modules/lodash.js` reports the correct trust level
+    // matching the chunks-side labeling. Match the user-supplied relative
+    // path against the configured `[index].vendored_paths` (or defaults).
+    let cfg = ctx.config();
+    let prefixes = cqs::vendored::effective_prefixes(
+        cfg.index
+            .as_ref()
+            .and_then(|ic| ic.vendored_paths.as_deref()),
+    );
+    let normalized = cqs::normalize_path(std::path::Path::new(path));
+    let trust_level = if cqs::vendored::is_vendored_origin(&normalized, &prefixes) {
+        "vendored-code"
+    } else {
+        "user-code"
+    };
+
     Ok(serde_json::json!({
         "path": path,
         "content": enriched,
         "notes_injected": notes_injected,
-        "trust_level": "user-code",
+        "trust_level": trust_level,
     }))
 }
 
@@ -423,10 +440,20 @@ fn dispatch_read_focused(ctx: &BatchView, focus: &str) -> Result<serde_json::Val
         &notes,
     )?;
 
+    // SEC-V1.33-9: was hardcoded `"user-code"` even for chunks under
+    // `node_modules/`/`vendor/`/etc, defeating the #1221 vendored-code
+    // boundary. `build_focused_output` now surfaces the resolved chunk's
+    // `vendored` flag (schema v24) so the daemon RPC matches the index-time
+    // labeling shape used by search/scout JSON.
+    let trust_level = if result.vendored {
+        "vendored-code"
+    } else {
+        "user-code"
+    };
     let mut json = serde_json::json!({
         "focus": focus,
         "content": result.output,
-        "trust_level": "user-code",
+        "trust_level": trust_level,
     });
     if let Some(ref h) = result.hints {
         json["hints"] = serde_json::json!({
@@ -522,6 +549,94 @@ mod tests {
         assert!(
             json.get("errors").and_then(|v| v.as_u64()).is_some(),
             "stats must carry an `errors` field, got: {json}"
+        );
+    }
+
+    /// SEC-V1.33-9 regression: a vendored chunk surfaces `trust_level:
+    /// "vendored-code"` from `dispatch_read --focus`. Pre-fix the daemon
+    /// hardcoded `"user-code"` regardless of the chunk's actual origin,
+    /// defeating the #1221 vendored-code boundary.
+    fn make_chunk_at(id: &str, name: &str, file: &str) -> Chunk {
+        let content = format!("fn {name}() {{ }}");
+        let content_hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+        Chunk {
+            id: id.to_string(),
+            file: PathBuf::from(file),
+            language: Language::Rust,
+            chunk_type: ChunkType::Function,
+            name: name.to_string(),
+            signature: format!("fn {name}()"),
+            content,
+            doc: None,
+            line_start: 1,
+            line_end: 5,
+            content_hash,
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        }
+    }
+
+    fn seed_with_vendored_chunk() -> (TempDir, crate::cli::batch::BatchContext) {
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+
+        let mut emb_vec = vec![0.0_f32; cqs::EMBEDDING_DIM];
+        emb_vec[0] = 1.0;
+        let emb1 = Embedding::new(emb_vec.clone());
+        let emb2 = Embedding::new(emb_vec);
+
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            // Apply default vendored prefixes BEFORE upsert so `node_modules/`
+            // is flagged at write time. `set_vendored_prefixes` is on a
+            // OnceLock — write order matters: must precede `upsert_chunks_batch`.
+            store.set_vendored_prefixes(cqs::vendored::effective_prefixes(None));
+            let chunks = vec![
+                (
+                    make_chunk_at(
+                        "node_modules/lib.js:1:lib_fn",
+                        "lib_fn",
+                        "node_modules/lib.js",
+                    ),
+                    emb1,
+                ),
+                (
+                    make_chunk_at("src/lib.rs:1:user_fn", "user_fn", "src/lib.rs"),
+                    emb2,
+                ),
+            ];
+            store.upsert_chunks_batch(&chunks, Some(0)).expect("upsert");
+        }
+        let ctx = create_test_context(&cqs_dir).expect("ctx");
+        (dir, ctx)
+    }
+
+    #[test]
+    fn dispatch_read_focus_emits_vendored_code_for_vendored_chunk() {
+        let (_dir, ctx) = seed_with_vendored_chunk();
+        let view = ctx.build_view(None);
+        // `lib_fn` lives in `node_modules/lib.js` so it must be tagged vendored.
+        let json = dispatch_read_focused(&view, "lib_fn").expect("dispatch_read_focused");
+        assert_eq!(
+            json["trust_level"], "vendored-code",
+            "vendored chunk must surface trust_level=vendored-code, got: {json}"
+        );
+    }
+
+    #[test]
+    fn dispatch_read_focus_emits_user_code_for_normal_chunk() {
+        let (_dir, ctx) = seed_with_vendored_chunk();
+        let view = ctx.build_view(None);
+        // `user_fn` lives in `src/lib.rs` so it must be tagged user-code.
+        let json = dispatch_read_focused(&view, "user_fn").expect("dispatch_read_focused");
+        assert_eq!(
+            json["trust_level"], "user-code",
+            "non-vendored chunk must surface trust_level=user-code, got: {json}"
         );
     }
 }

--- a/src/cli/commands/io/read.rs
+++ b/src/cli/commands/io/read.rs
@@ -117,6 +117,13 @@ pub(crate) struct FocusedReadResult {
     /// silently dropped type-definition lookups; agents now see exactly
     /// what was missed instead of inferring it from absent JSON keys.
     pub warnings: Vec<String>,
+    /// SEC-V1.33-9: was the resolved focus chunk indexed under a vendored
+    /// path (`vendor/`, `node_modules/`, `third_party/`, …)? Mirrors
+    /// `ChunkSummary::vendored` (#1221, schema v24). Both CLI and daemon
+    /// JSON paths emit `trust_level: "vendored-code"` when this is true,
+    /// closing the v1.33.0 gap where `dispatch_read` and `cmd_read --focus`
+    /// hardcoded `"user-code"` regardless of the chunk's actual origin.
+    pub vendored: bool,
 }
 
 /// Build focused-read output: header + hints + notes + target + type deps.
@@ -282,6 +289,10 @@ pub(crate) fn build_focused_output<Mode>(
         output,
         hints,
         warnings,
+        // SEC-V1.33-9: surface the resolved chunk's vendored flag so
+        // both CLI and daemon JSON paths can emit the correct
+        // `trust_level` instead of hardcoding `"user-code"`.
+        vendored: chunk.vendored,
     })
 }
 
@@ -312,7 +323,11 @@ struct FocusedReadJsonOutput {
     content: String,
     /// SEC-V1.30.1-1: every chunk-returning JSON output must carry a
     /// trust_level. `read --focus` reads from the project store only
-    /// (no reference-store fan-in), so this is always "user-code".
+    /// (no reference-store fan-in), so the value is either `"user-code"`
+    /// or `"vendored-code"` depending on the resolved chunk's
+    /// `chunks.vendored` flag (schema v24). SEC-V1.33-9 closed the gap
+    /// where this was hardcoded `"user-code"` even for vendored chunks,
+    /// defeating the #1221 trust boundary.
     /// SECURITY.md's mitigation contract is that agents can branch
     /// safely on this field; the `read --focus` path was missing it.
     trust_level: &'static str,
@@ -417,7 +432,14 @@ fn cmd_read_focused(
         let output = FocusedReadJsonOutput {
             focus: focus.to_string(),
             content: result.output,
-            trust_level: "user-code",
+            // SEC-V1.33-9: honor the resolved chunk's vendored flag so a
+            // chunk under `node_modules/` is reported as `vendored-code`,
+            // matching the index-time labeling shape used by search/scout.
+            trust_level: if result.vendored {
+                "vendored-code"
+            } else {
+                "user-code"
+            },
             injection_flags: Vec::new(),
             hints,
             warnings: result.warnings.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -622,18 +622,38 @@ impl Config {
                 v
             };
             for (field, p) in paths_to_check {
-                if let Ok(canonical) = dunce::canonicalize(p) {
-                    let in_home = home.as_ref().is_some_and(|h| canonical.starts_with(h));
-                    let in_project = cwd.as_ref().is_some_and(|p| canonical.starts_with(p));
-                    let in_cqs_dir = canonical.components().any(|c| c.as_os_str() == ".cqs");
-                    if !in_home && !in_project && !in_cqs_dir {
+                // EH-V1.33-9: silent `if let Ok(...) = canonicalize(p)` swallowed
+                // canonicalize failures (typo'd path, ENOENT, EACCES) and skipped the
+                // SEC-4 / SEC-NEW-1 audit entirely — the protection meant to flag a
+                // malicious `.cqs.toml` was effectively opt-out by error. Fail-loud:
+                // a canonicalize error means we can't audit, so warn explicitly and
+                // treat as untrusted.
+                match dunce::canonicalize(p) {
+                    Ok(canonical) => {
+                        let in_home = home.as_ref().is_some_and(|h| canonical.starts_with(h));
+                        let in_project = cwd.as_ref().is_some_and(|p| canonical.starts_with(p));
+                        let in_cqs_dir = canonical.components().any(|c| c.as_os_str() == ".cqs");
+                        if !in_home && !in_project && !in_cqs_dir {
+                            tracing::warn!(
+                                name = %r.name,
+                                field,
+                                path = %canonical.display(),
+                                "Reference {field} is outside project and home directories — \
+                                 a malicious .cqs.toml could use this to index arbitrary files. \
+                                 Verify the source is intentional."
+                            );
+                        }
+                    }
+                    Err(e) => {
                         tracing::warn!(
                             name = %r.name,
                             field,
-                            path = %canonical.display(),
-                            "Reference {field} is outside project and home directories — \
-                             a malicious .cqs.toml could use this to index arbitrary files. \
-                             Verify the source is intentional."
+                            path = %p.display(),
+                            error = %e,
+                            "Cannot canonicalize reference {field} for SEC-4 audit; \
+                             treating as untrusted. A typo in `.cqs.toml` or a path the \
+                             user cannot access bypasses the in-home/in-project check; \
+                             verify the path is correct and reachable."
                         );
                     }
                 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -951,6 +951,23 @@ fn open_with_config_impl<Mode>(
     // Build cache_size PRAGMA string once for the after_connect closure.
     let cache_pragma = format!("PRAGMA cache_size = {}", config.cache_size);
 
+    // DS-V1.33-8: cap the WAL at N pages so an abrupt shutdown (SIGKILL,
+    // panic-without-Drop, daemon worker thread crash) leaves a bounded WAL
+    // for the next open to replay. Without this, a long-lived read-only
+    // `cqs serve` that never commits never triggers SQLite's default 1000-
+    // page autocheckpoint, and the on-disk WAL grows to whatever the kernel
+    // buffered between explicit `wal_checkpoint(TRUNCATE)` calls. 1000 pages
+    // is the SQLite default — we set it explicitly so it actually applies
+    // to read-mostly connections that rarely COMMIT. Override via
+    // `CQS_WAL_AUTOCHECKPOINT_PAGES` (e.g. for WSL-NTFS boxes where each
+    // checkpoint is expensive — set higher; for tighter recovery — set
+    // lower).
+    let wal_autocheckpoint_pages: u32 = std::env::var("CQS_WAL_AUTOCHECKPOINT_PAGES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1000);
+    let wal_pragma = format!("PRAGMA wal_autocheckpoint = {}", wal_autocheckpoint_pages);
+
     let pool = rt.block_on(async {
         SqlitePoolOptions::new()
             .max_connections(config.max_connections)
@@ -962,11 +979,13 @@ fn open_with_config_impl<Mode>(
             ))
             .after_connect(move |conn, _meta| {
                 let pragma = cache_pragma.clone();
+                let wal = wal_pragma.clone();
                 Box::pin(async move {
                     sqlx::query(&pragma).execute(&mut *conn).await?;
                     sqlx::query("PRAGMA temp_store = MEMORY")
                         .execute(&mut *conn)
                         .await?;
+                    sqlx::query(&wal).execute(&mut *conn).await?;
                     Ok(())
                 })
             })
@@ -1826,5 +1845,31 @@ mod tests {
         .expect("second attempt after closure error should succeed");
         // Sanity: the recovered handle can run a read query.
         assert!(recovered.check_model_version().is_ok());
+    }
+
+    /// DS-V1.33-8 regression: every connection from the main store pool must
+    /// carry a finite `wal_autocheckpoint` ceiling so an abrupt shutdown
+    /// (SIGKILL, panic-without-Drop, daemon worker thread crash) leaves a
+    /// bounded WAL for the next open. Asserting via PRAGMA query on a freshly-
+    /// opened store pins the after_connect wiring so a refactor that drops the
+    /// hook surfaces here.
+    #[test]
+    fn wal_autocheckpoint_pragma_is_applied_after_connect() {
+        let (store, _dir) = make_test_store_initialized();
+        let pages: i64 = store
+            .runtime()
+            .block_on(async {
+                sqlx::query_scalar::<_, i64>("PRAGMA wal_autocheckpoint")
+                    .fetch_one(&store.pool)
+                    .await
+            })
+            .expect("PRAGMA wal_autocheckpoint should succeed on a freshly opened store");
+        // Default is 1000 pages (mirrors SQLite's built-in autocheckpoint
+        // default). The exact value isn't load-bearing — we're proving the
+        // after_connect hook executed and applied a finite ceiling.
+        assert_eq!(
+            pages, 1000,
+            "expected default wal_autocheckpoint=1000 from after_connect hook"
+        );
     }
 }

--- a/src/store/search.rs
+++ b/src/store/search.rs
@@ -191,10 +191,13 @@ impl<Mode> Store<Mode> {
         }
         let fts_query = format!("name:\"{}\" OR name:\"{}\"*", normalized, normalized);
 
-        // SHL-V1.33-8: render the BM25 weights from the canonical constants
-        // in `helpers/mod.rs` so the `chunks/query.rs` sibling stays in sync.
+        // SHL-V1.33-8 + SEC-V1.33-9: BM25 weights via canonical helper, plus
+        // SELECT `c.vendored` so `resolve_target` / `read --focus` can emit the
+        // correct `trust_level` for chunks under `node_modules/`/`vendor/`.
+        // Without that column the `ChunkRow::from_row` `try_get` falls back
+        // to false and every vendored chunk masquerades as user-code.
         let sql = format!(
-            "SELECT c.id, c.origin, c.language, c.chunk_type, c.name, c.signature, c.content, c.doc, c.line_start, c.line_end, c.content_hash, c.parent_id, c.parent_type_name
+            "SELECT c.id, c.origin, c.language, c.chunk_type, c.name, c.signature, c.content, c.doc, c.line_start, c.line_end, c.content_hash, c.parent_id, c.parent_type_name, c.vendored
              FROM chunks c
              JOIN chunks_fts f ON c.id = f.id
              WHERE chunks_fts MATCH ?1


### PR DESCRIPTION
## Summary

Fixes 5 P2 security and data-safety findings from the v1.33.0 audit (Tier 2 — concrete attack or data-loss vectors).

- **P2-6 / EH-V1.33-9** — `Config::validate` silently swallowed `canonicalize` errors and skipped the SEC-4 / SEC-NEW-1 path-escape check. Switched to `match` with a `tracing::warn!` on Err so a typo'd or inaccessible reference path is loudly flagged at config load.
- **P2-21 / DS-V1.33-4** — `EmbeddingCache::evict` and `QueryCache::evict` ran on sqlx-default deferred `BEGIN`, letting a peer cqs process bypass the in-process `evict_lock` via stale WAL snapshots. Both evictors now issue raw `BEGIN IMMEDIATE` / `COMMIT` on a held connection.
- **P2-23 / DS-V1.33-6** — `evict_lock` was a per-instance `Mutex<()>` field but `EmbeddingCache::open` is called from multiple paths in one process; each call minted a fresh mutex pointing at the same DB file. Lifted to module-level statics (`EMBEDDING_CACHE_EVICT_LOCK`, `QUERY_CACHE_EVICT_LOCK`) mirroring `WRITE_LOCK` in `store/mod.rs:54`.
- **P2-25 / DS-V1.33-8** — Pool `after_connect` had no `wal_autocheckpoint` ceiling, so a daemon killed via SIGKILL or panic-without-Drop left an unbounded WAL. Added `PRAGMA wal_autocheckpoint=1000` to all three pools (Store, EmbeddingCache, QueryCache); override via `CQS_WAL_AUTOCHECKPOINT_PAGES`.
- **P2-31 / SEC-V1.33-9** — `dispatch_read --focus` (and `cmd_read --focus`) hardcoded `trust_level: "user-code"` even for chunks under `node_modules/` / `vendor/`, defeating the #1221 vendored-code boundary. `build_focused_output` now surfaces the chunk's `vendored` flag so both CLI and daemon JSON paths emit the correct trust level. Required adding `vendored` to `search_by_name`'s SELECT (`resolve_target → search_by_name` was a structural gap that silently demoted every vendored chunk to user-code through this RPC). The file-read branch of `dispatch_read` now also matches the requested path against the configured vendored prefixes so `cqs read node_modules/foo.js` reports `vendored-code`.

## Test plan

- [x] `cargo check --features cuda-index` clean
- [x] `cargo clippy --features cuda-index --lib -- -D warnings` clean
- [x] `cargo clippy --features cuda-index --bins -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] New regression tests pass:
  - `cache::tests::wal_autocheckpoint_pragma_is_applied_after_connect` (P2-25)
  - `cache::query_cache_malformed_blob_tests::query_cache_wal_autocheckpoint_pragma_is_applied_after_connect` (P2-25)
  - `store::tests::wal_autocheckpoint_pragma_is_applied_after_connect` (P2-25)
  - `cache::tests::embedding_cache_evict_lock_is_process_global` (P2-23)
  - `cli::batch::handlers::info::tests::dispatch_read_focus_emits_vendored_code_for_vendored_chunk` (P2-31)
  - `cli::batch::handlers::info::tests::dispatch_read_focus_emits_user_code_for_normal_chunk` (P2-31)
- [x] Existing tests pass: `cache::tests` (40), `config::tests` (46), `store::search::tests` (11), `vendored::tests` + related (11), `cli::commands::io::read::tests` (7), `search::tests::resolve_target_*` (4), `cli::batch::handlers::info::tests::dispatch_stats_*` (1)

## Notes / deviations

- **`search_by_name` SELECT now includes `vendored`** — the audit's primary call-out was the daemon handler hardcoding `user-code`, but the structural gap is one level deeper: `resolve_target → search_by_name` SELECT was missing the `vendored` column, so every chunk that round-tripped through this path lost its vendored bit and surfaced as `user-code` regardless. Other read paths (search, scout, similar) were unaffected because they SELECT `vendored` already; this just brings name-lookup parity.
- **`dispatch_read` file-read branch also fixed** — the audit said `user-code` was "structurally correct" for the file-read branch but suggested also tagging vendored when the relative path matches a configured prefix. Done in defense-in-depth: `cqs read node_modules/foo.js` now reports `vendored-code` matching the chunks-side labeling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
