### PR TITLE
chore(audit): #1245 — close v1.33.0 P3 cleanup batch (Tier 6)

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -137,8 +137,8 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 | P3-7 | Observability | `Embedder::warm` no span, no log — silent ~250 MB+ session init at startup | easy | ⬜ |
 | P3-8 | Observability | `LocalProvider` worker threads lack worker-id field on completion | easy | ⬜ |
 | P3-9 | Robustness | `set_on_item_complete` lock().unwrap() — duplicate of EH-V1.33-2 | easy | ⬜ |
-| P3-10 | Code Quality | `check_model_version()` wrapper dead in production | easy | ⬜ |
-| P3-11 | Code Quality | `is_false`/`is_zero_usize` trivial helpers duplicated 3+2 times across modules | easy | ⬜ |
+| P3-10 | Code Quality | `check_model_version()` wrapper dead in production | easy | ✅ pre-fixed (`#[cfg(test)]` already on both fns since #715/d46c8cf6) |
+| P3-11 | Code Quality | `is_false`/`is_zero_usize` trivial helpers duplicated 3+2 times across modules | easy | ✅ |
 | P3-12 | Code Quality | `search_unified_with_index` is `pub` 6-line wrapper post-SQ-9 | easy | ✅ |
 | P3-13 | Scaling | BM25 K1=1.2, B=0.75 hardcoded in train_data without rationale or env override | easy | ✅ #1363 |
 | P3-14 | Scaling | BM25 FTS5 column weights duplicated as inline SQL string at two sites | easy | ✅ #1363 |
@@ -152,13 +152,13 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 | P3-22 | TC Adversarial | `QueryCache::get` malformed-blob auto-delete path untested | easy | ⬜ |
 | P3-23 | TC Adversarial | `parse_env_usize_clamped`/`parse_env_f32` zero tests despite 10+ callers | easy | ⬜ |
 | P3-24 | TC Adversarial | `validate_and_read_file` oversized-file branch untested | easy | ⬜ |
-| P3-25 | API Design | `cqs project register` lacks `--json` and skips JSON envelope | easy | ⬜ |
-| P3-26 | API Design | `cqs notes add\|update\|remove` accept no `--json` at subcommand level | easy | ⬜ |
-| P3-27 | API Design | `cqs slot`/`cqs cache` still advertise `--slot` even though it bails | easy | ⬜ |
+| P3-25 | API Design | `cqs project register` lacks `--json` and skips JSON envelope | easy | ✅ |
+| P3-26 | API Design | `cqs notes add\|update\|remove` accept no `--json` at subcommand level | easy | ✅ |
+| P3-27 | API Design | `cqs slot`/`cqs cache` still advertise `--slot` even though it bails | easy | 🎫 #1365 (clap 4 has no clean per-subcommand global arg suppression) |
 | P3-28 | API Design | Public `Store::search_embedding_only` is `pub` footgun — visibility flip (overlaps P1-32) | easy | ✅ |
-| P3-29 | API Design | `project register` vs `ref add` — same operation, two verbs | easy | ⬜ |
-| P3-30 | API Design | `--json` declared inline on six commands instead of via shared `TextJsonArgs` | easy | ⬜ |
-| P3-31 | API Design | `StoreError::SchemaMismatch(String, i32, i32)` uses positional fields | easy | ⬜ |
+| P3-29 | API Design | `project register` vs `ref add` — same operation, two verbs | easy | ✅ |
+| P3-30 | API Design | `--json` declared inline on six commands instead of via shared `TextJsonArgs` | easy | ✅ |
+| P3-31 | API Design | `StoreError::SchemaMismatch(String, i32, i32)` uses positional fields | easy | ✅ |
 | P3-32 | TC Happy | `cqs convert` and `convert_path` have zero end-to-end tests | easy | ⬜ |
 | P3-33 | TC Happy | `cqs eval --reranker` flag (#1303) has zero CLI integration test | easy | ⬜ |
 | P3-34 | TC Happy | `cqs slot {create, remove, promote, list, active}` no CLI integration tests | easy | ⬜ |
@@ -173,10 +173,10 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 | P3-43 | Performance | `extract_imports_regex` recompiles same `Regex` set on every `cqs where`/`task` call | easy | ✅ #1363 |
 | P3-44 | Performance | `Store::search_by_name` lowercases every chunk name even though only ~100 rows scored | easy | ✅ #1363 |
 | P3-45 | Performance | `gather::bridge_scores` HashMap clones `pr.chunk.name`/`id` per result | easy | ✅ #1363 |
-| P3-46 | Extensibility | `SearchResult::to_json` and `to_json_relative` duplicate 12-field JSON shape | easy | ⬜ |
-| P3-47 | Extensibility | `BatchSubmitItem.context` is a stringly-typed bag — every prompt builder reinterprets | easy | ⬜ |
-| P3-48 | Extensibility | `run_migration` is a 16-arm hand-coded match — adding migration v26 needs three edits | easy | ⬜ |
-| P3-49 | Extensibility | Adding any new top-level CLI command needs three coordinated edits | easy | ⬜ |
+| P3-46 | Extensibility | `SearchResult::to_json` and `to_json_relative` duplicate 12-field JSON shape | easy | ✅ #1368 |
+| P3-47 | Extensibility | `BatchSubmitItem.context` is a stringly-typed bag — every prompt builder reinterprets | easy | ✅ #1368 (doc-comment schema; enum migration deferred — touches 5 readers + 5 construction sites) |
+| P3-48 | Extensibility | `run_migration` is a 16-arm hand-coded match — adding migration v26 needs three edits | easy | ✅ #1368 |
+| P3-49 | Extensibility | Adding any new top-level CLI command needs three coordinated edits | easy | 🎫 #1366 (structural — registry refactor or proc-macro out of scope for P3 batch) |
 | P3-50 | Platform Behavior | Daemon error/operator hints hardcode `systemctl --user` — broken UX for macOS | easy | ⬜ |
 | P3-51 | Platform Behavior | `process_exists` (Windows) uses PATH lookup for `tasklist` | easy | ⬜ |
 | P3-52 | API Design | Wildcard `pub use diff::* / gather::* / impact::* / scout::* / task::*` in lib.rs | medium | ⬜ |

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -61,14 +61,10 @@ pub struct CiReport {
     /// index. Field is omitted from JSON on the happy path via
     /// `skip_serializing_if` so agents consuming existing CI JSON see no
     /// shape change — the failure signal is also surfaced in `gate.reasons`.
-    #[serde(skip_serializing_if = "is_true")]
+    #[serde(skip_serializing_if = "crate::serde_helpers::is_true")]
     pub dead_scan_ok: bool,
     /// Gate evaluation result
     pub gate: GateResult,
-}
-
-fn is_true(b: &bool) -> bool {
-    *b
 }
 
 /// Run CI analysis on a unified diff.

--- a/src/cli/commands/infra/project.rs
+++ b/src/cli/commands/infra/project.rs
@@ -47,12 +47,23 @@ pub(crate) struct ProjectListEntry {
 /// Project subcommands
 #[derive(clap::Subcommand)]
 pub(crate) enum ProjectCommand {
-    /// Register a project for cross-project search
-    Register {
+    /// Add a project to the cross-project search registry
+    ///
+    /// P3-29: renamed from `register` to align with `ref add`, `slot create`,
+    /// and `cache clear`. Old `register` form preserved as a visible alias
+    /// so existing scripts and `--help` searches keep working.
+    #[command(visible_alias = "register")]
+    Add {
         /// Project name (used for identification)
         name: String,
         /// Path to project root (must have .cqs/index.db)
         path: PathBuf,
+        /// P3-25: shared `--json` arg so `cqs project add --json` emits the
+        /// envelope. Without this, `cqs --json project register` silently
+        /// dropped the top-level flag and `cqs project register --json` was
+        /// rejected at parse time as `unexpected argument`.
+        #[command(flatten)]
+        output: TextJsonArgs,
     },
     /// List registered projects
     List {
@@ -96,8 +107,8 @@ pub(crate) fn cmd_project(
     // query). The previous single `cmd_project` span collapsed four very
     // different code paths into one trace entry.
     let _span = match subcmd {
-        ProjectCommand::Register { name, .. } => {
-            tracing::info_span!("cmd_project_register", name = %name).entered()
+        ProjectCommand::Add { name, .. } => {
+            tracing::info_span!("cmd_project_add", name = %name).entered()
         }
         ProjectCommand::List { .. } => tracing::info_span!("cmd_project_list").entered(),
         ProjectCommand::Remove { name, .. } => {
@@ -108,7 +119,7 @@ pub(crate) fn cmd_project(
         }
     };
     match subcmd {
-        ProjectCommand::Register { name, path } => {
+        ProjectCommand::Add { name, path, output } => {
             let abs_path = if path.is_absolute() {
                 path.clone()
             } else {
@@ -118,7 +129,21 @@ pub(crate) fn cmd_project(
 
             let mut registry = ProjectRegistry::load()?;
             registry.register(name.clone(), abs_path.clone())?;
-            println!("Registered '{}' at {}", name, abs_path.display());
+            // P3-25: emit JSON envelope when `--json` was passed at either
+            // the top level (`cqs --json project add ...`) or the subcommand
+            // level (`cqs project add ... --json`). Mirrors the `Remove` arm
+            // shape; agents piping through `jq` no longer need to special-
+            // case `register` as the one mutation that prints text.
+            let json = cli.json || output.json;
+            if json {
+                crate::cli::json_envelope::emit_json(&serde_json::json!({
+                    "status": "registered",
+                    "name": name,
+                    "path": normalize_path(&abs_path),
+                }))?;
+            } else {
+                println!("Registered '{}' at {}", name, abs_path.display());
+            }
             Ok(())
         }
         ProjectCommand::List { output } => {

--- a/src/cli/commands/io/notes.rs
+++ b/src/cli/commands/io/notes.rs
@@ -91,6 +91,11 @@ pub(crate) enum NotesCommand {
         /// Skip re-indexing after adding (useful for batch operations)
         #[arg(long)]
         no_reindex: bool,
+        /// P3-26: shared `--json` arg so `cqs notes add ... --json` works
+        /// at the subcommand level. The `List` arm already flattens
+        /// `TextJsonArgs`; the three mutation arms were the holdouts.
+        #[command(flatten)]
+        output: TextJsonArgs,
     },
     /// Update an existing note (find by exact text match)
     Update {
@@ -117,6 +122,9 @@ pub(crate) enum NotesCommand {
         /// Skip re-indexing after update
         #[arg(long)]
         no_reindex: bool,
+        /// P3-26: shared `--json` arg — see `Add` above.
+        #[command(flatten)]
+        output: TextJsonArgs,
     },
     /// Remove a note by exact text match
     Remove {
@@ -125,6 +133,9 @@ pub(crate) enum NotesCommand {
         /// Skip re-indexing after removal
         #[arg(long)]
         no_reindex: bool,
+        /// P3-26: shared `--json` arg — see `Add` above.
+        #[command(flatten)]
+        output: TextJsonArgs,
     },
 }
 
@@ -166,6 +177,7 @@ pub(crate) fn cmd_notes(
             mentions,
             kind,
             no_reindex,
+            output,
         } => cmd_notes_add(
             cli,
             ctx,
@@ -174,6 +186,7 @@ pub(crate) fn cmd_notes(
             mentions.as_deref(),
             kind.as_deref(),
             *no_reindex,
+            output.json,
         ),
         NotesCommand::Update {
             text,
@@ -182,6 +195,7 @@ pub(crate) fn cmd_notes(
             new_mentions,
             new_kind,
             no_reindex,
+            output,
         } => cmd_notes_update(
             cli,
             ctx,
@@ -191,8 +205,13 @@ pub(crate) fn cmd_notes(
             new_mentions.as_deref(),
             new_kind.as_deref(),
             *no_reindex,
+            output.json,
         ),
-        NotesCommand::Remove { text, no_reindex } => cmd_notes_remove(cli, ctx, text, *no_reindex),
+        NotesCommand::Remove {
+            text,
+            no_reindex,
+            output,
+        } => cmd_notes_remove(cli, ctx, text, *no_reindex, output.json),
     }
 }
 
@@ -254,6 +273,12 @@ fn ensure_notes_file(root: &std::path::Path) -> Result<PathBuf> {
 }
 
 /// Add a note: validate text/sentiment, append to notes.toml, optionally reindex.
+///
+/// `output_json` accepts the subcommand-level `--json` (P3-26); combined with
+/// `cli.json` to honour the top-level flag too. 8 args is on clippy's
+/// `too_many_arguments` boundary — same rationale as `cmd_notes_update`'s
+/// allow attribute below.
+#[allow(clippy::too_many_arguments)]
 fn cmd_notes_add(
     cli: &Cli,
     ctx: Option<&crate::cli::CommandContext<'_, cqs::store::ReadOnly>>,
@@ -262,6 +287,7 @@ fn cmd_notes_add(
     mentions: Option<&[String]>,
     kind: Option<&str>,
     no_reindex: bool,
+    output_json: bool,
 ) -> Result<()> {
     // P3 #92: per-subhandler span so the shared "Note operation warning"
     // line carries enough context (op + sentiment for add, op + length
@@ -337,7 +363,7 @@ fn cmd_notes_add(
         "observation"
     };
 
-    if cli.json {
+    if cli.json || output_json {
         let result = NoteMutationOutput {
             status: "added".into(),
             note_type: Some(sentiment_label.into()),
@@ -373,11 +399,10 @@ fn cmd_notes_add(
 
 /// Update a note: match by text, apply new text/sentiment/mentions/kind, optionally reindex.
 ///
-/// 8 args is one over clippy's default `too_many_arguments` threshold.
-/// Bundling into a struct would be more shape than the call site warrants —
-/// the dispatcher at `cmd_notes` already destructures the same fields, and a
-/// helper struct just round-trips them through one extra hop. Allow the
-/// width here; if a 9th arg lands, that's the right time to factor.
+/// 9 args after P3-26 added `output_json`. Bundling into a struct would be
+/// more shape than the call site warrants — the dispatcher at `cmd_notes`
+/// already destructures the same fields, and a helper struct just round-
+/// trips them through one extra hop.
 #[allow(clippy::too_many_arguments)]
 fn cmd_notes_update(
     cli: &Cli,
@@ -388,6 +413,7 @@ fn cmd_notes_update(
     new_mentions: Option<&[String]>,
     new_kind: Option<&str>,
     no_reindex: bool,
+    output_json: bool,
 ) -> Result<()> {
     // P3 #92: per-subhandler span — see `cmd_notes_add`.
     let _span = tracing::info_span!(
@@ -485,7 +511,7 @@ fn cmd_notes_update(
     };
 
     let final_text = new_text.unwrap_or(text);
-    if cli.json {
+    if cli.json || output_json {
         let result = NoteMutationOutput {
             status: "updated".into(),
             note_type: None,
@@ -519,6 +545,7 @@ fn cmd_notes_remove(
     ctx: Option<&crate::cli::CommandContext<'_, cqs::store::ReadOnly>>,
     text: &str,
     no_reindex: bool,
+    output_json: bool,
 ) -> Result<()> {
     // P3 #92: per-subhandler span — see `cmd_notes_add`.
     let _span =
@@ -563,7 +590,7 @@ fn cmd_notes_remove(
         }
     };
 
-    if cli.json {
+    if cli.json || output_json {
         let result = NoteMutationOutput {
             status: "removed".into(),
             note_type: None,

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -315,8 +315,12 @@ pub(super) enum Commands {
         /// Keeps `cqs init` parity with the rest of the CLI's `--json`
         /// contract; without this, JSON-driven agents had no way to confirm
         /// the directory and model that got created.
-        #[arg(long)]
-        json: bool,
+        ///
+        /// P3-30: flattens shared `TextJsonArgs` so a future change to the
+        /// flag (NDJSON, `--pretty`, `--format`) is a one-file edit instead
+        /// of six.
+        #[command(flatten)]
+        output: TextJsonArgs,
     },
     /// One-line-per-function summary for a file
     Brief {
@@ -342,8 +346,10 @@ pub(super) enum Commands {
         ///
         /// Colored human-readable check progress is routed to stderr in this
         /// mode so `cqs doctor --json | jq` works.
-        #[arg(long)]
-        json: bool,
+        ///
+        /// P3-30: flattens shared `TextJsonArgs` — see `Init` above.
+        #[command(flatten)]
+        output: TextJsonArgs,
     },
     /// Index current project
     Index {
@@ -655,8 +661,12 @@ pub(super) enum Commands {
         /// File or directory to convert
         path: String,
         /// Output directory for .md files [default: same as input]
-        #[arg(short = 'o', long)]
-        output: Option<String>,
+        ///
+        /// P3-30: field renamed `output` → `output_dir` to avoid colliding
+        /// with the flattened `TextJsonArgs.output` envelope. The
+        /// user-facing flag `-o`/`--output` is preserved via `long = "output"`.
+        #[arg(short = 'o', long = "output")]
+        output_dir: Option<String>,
         /// Overwrite existing .md files
         #[arg(long)]
         overwrite: bool,
@@ -674,8 +684,12 @@ pub(super) enum Commands {
         /// P2.12: emit a structured JSON envelope summarizing conversions.
         /// Suppresses the per-file text rendering in favor of a
         /// `{converted: [...], skipped: [...], took_ms}` summary.
-        #[arg(long)]
-        json: bool,
+        ///
+        /// P3-30: flattens shared `TextJsonArgs` — see `Init` above. The
+        /// command's destination directory was previously `output`, now
+        /// `output_dir` to avoid the collision with the flattened envelope.
+        #[command(flatten)]
+        output: TextJsonArgs,
     },
     /// Export a HuggingFace model to ONNX format for use with cqs
     ExportModel {
@@ -758,9 +772,11 @@ pub(super) enum Commands {
     /// output. Reuses [`cqs::daemon_translate::daemon_ping`] under the hood
     /// so other tools (e.g. `cqs doctor --verbose`) can pull the same data.
     Ping {
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
+        /// Output as JSON.
+        ///
+        /// P3-30: flattens shared `TextJsonArgs` — see `Init` above.
+        #[command(flatten)]
+        output: TextJsonArgs,
     },
     /// Watch-mode freshness — show whether the index is caught up
     ///
@@ -780,9 +796,6 @@ pub(super) enum Commands {
         /// Report watch-mode freshness (currently the only mode).
         #[arg(long)]
         watch_fresh: bool,
-        /// Output as JSON. Without this, prints a one-line human summary.
-        #[arg(long)]
-        json: bool,
         /// Block until the snapshot reports `state == fresh` (or until the
         /// `--wait-secs` budget expires). Requires `--watch-fresh`.
         #[arg(long)]
@@ -794,6 +807,11 @@ pub(super) enum Commands {
         /// default differs by use case (eval default = 600, status = 30).
         #[arg(long, default_value_t = 30)]
         wait_secs: u64,
+        /// Output as JSON. Without this, prints a one-line human summary.
+        ///
+        /// P3-30: flattens shared `TextJsonArgs` — see `Init` above.
+        #[command(flatten)]
+        output: TextJsonArgs,
     },
     /// Invalidate daemon caches and re-open the Store
     ///
@@ -807,8 +825,10 @@ pub(super) enum Commands {
         /// P2.14: brings `cqs refresh` in line with the rest of the CLI's
         /// `--json` contract; without this, JSON-driven agents had no way to
         /// detect whether the daemon was actually running and got refreshed.
-        #[arg(long)]
-        json: bool,
+        ///
+        /// P3-30: flattens shared `TextJsonArgs` — see `Init` above.
+        #[command(flatten)]
+        output: TextJsonArgs,
     },
     /// First-class eval harness: run query set against current index, print R@K
     Eval {

--- a/src/cli/json_envelope.rs
+++ b/src/cli/json_envelope.rs
@@ -74,18 +74,13 @@ pub struct EnvelopeMeta {
     /// own `.cqs/` (#1254). Consuming agents should fall back to
     /// reading absolute worktree paths for any chunk they intend to
     /// edit — the served snapshot reflects main's branch state.
-    #[serde(skip_serializing_if = "is_false")]
+    #[serde(skip_serializing_if = "cqs::serde_helpers::is_false")]
     pub worktree_stale: bool,
     /// Worktree directory name when `worktree_stale = true`, else
     /// omitted. Lets agents distinguish two worktrees of the same
     /// repo without re-deriving from CWD.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub worktree_name: Option<String>,
-}
-
-#[inline]
-fn is_false(v: &bool) -> bool {
-    !*v
 }
 
 impl EnvelopeMeta {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn test_cmd_init() {
         let cli = Cli::try_parse_from(["cqs", "init"]).unwrap();
-        assert!(matches!(cli.command, Some(Commands::Init { json: _ })));
+        assert!(matches!(cli.command, Some(Commands::Init { output: _ })));
     }
 
     #[test]

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -67,11 +67,11 @@ macro_rules! for_each_command {
             group_a: {
                 // ── lifecycle / no-store / mutation commands ────────────
 
-                (Commands::Init { json },
+                (Commands::Init { ref output },
                  Commands::Init { .. },
                  "init",
                  BatchSupport::Cli,
-                 { cmd_init(&$cli, json) }),
+                 { cmd_init(&$cli, $cli.json || output.json) }),
 
                 (Commands::Cache { ref subcmd },
                  Commands::Cache { .. },
@@ -85,23 +85,23 @@ macro_rules! for_each_command {
                  BatchSupport::Cli,
                  { cmd_slot(&$cli, subcmd) }),
 
-                (Commands::Doctor { fix, verbose, json },
+                (Commands::Doctor { fix, verbose, ref output },
                  Commands::Doctor { .. },
                  "doctor",
                  BatchSupport::Cli,
-                 { cmd_doctor($cli.model.as_deref(), fix, verbose, $cli.json || json) }),
+                 { cmd_doctor($cli.model.as_deref(), fix, verbose, $cli.json || output.json) }),
 
-                (Commands::Ping { json },
+                (Commands::Ping { ref output },
                  Commands::Ping { .. },
                  "ping",
                  BatchSupport::Cli,
-                 { cmd_ping($cli.json || json) }),
+                 { cmd_ping($cli.json || output.json) }),
 
-                (Commands::Status { watch_fresh, json, wait, wait_secs },
+                (Commands::Status { watch_fresh, ref output, wait, wait_secs },
                  Commands::Status { .. },
                  "status",
                  BatchSupport::Cli,
-                 { cmd_status($cli.json || json, watch_fresh, wait, wait_secs) }),
+                 { cmd_status($cli.json || output.json, watch_fresh, wait, wait_secs) }),
 
                 (Commands::Hook { subcmd },
                  Commands::Hook { .. },
@@ -116,12 +116,12 @@ macro_rules! for_each_command {
                 // P2.14: Refresh now carries its own --json (in addition to
                 // honoring the global --json), so the macro pattern-match
                 // needs to bind the field.
-                (Commands::Refresh { json },
+                (Commands::Refresh { ref output },
                  Commands::Refresh { .. },
                  "refresh",
                  BatchSupport::Daemon,
                  {
-                    if $cli.json || json {
+                    if $cli.json || output.json {
                         crate::cli::json_envelope::emit_json(&serde_json::json!({
                             "status": "noop",
                             "message": "no daemon running, nothing to refresh",
@@ -225,11 +225,11 @@ macro_rules! for_each_command {
                 #[cfg(feature = "convert")]
                 (Commands::Convert {
                     ref path,
-                    ref output,
+                    ref output_dir,
                     overwrite,
                     dry_run,
                     ref clean_tags,
-                    json,
+                    ref output,
                  },
                  Commands::Convert { .. },
                  "convert",
@@ -237,11 +237,11 @@ macro_rules! for_each_command {
                  {
                     cmd_convert(
                         path,
-                        output.as_deref(),
+                        output_dir.as_deref(),
                         overwrite,
                         dry_run,
                         clean_tags.as_deref(),
-                        $cli.json || json,
+                        $cli.json || output.json,
                     )
                  }),
 

--- a/src/eval/schema.rs
+++ b/src/eval/schema.rs
@@ -80,14 +80,12 @@ pub struct EvalQuery {
     /// Marker set by the v3 generator when the gold chunk could not be
     /// resolved against the live index. The runner treats these as misses;
     /// modeled so `deny_unknown_fields` parsers don't reject them.
-    #[serde(default, rename = "_unresolved", skip_serializing_if = "is_false")]
+    #[serde(
+        default,
+        rename = "_unresolved",
+        skip_serializing_if = "crate::serde_helpers::is_false"
+    )]
     pub unresolved: bool,
-}
-
-/// `serde(skip_serializing_if)` requires a `fn(&T) -> bool`; closures and
-/// trait methods don't work here. Used by `EvalQuery::unresolved`.
-fn is_false(b: &bool) -> bool {
-    !*b
 }
 
 /// The expected matching chunk. `origin` is the file path as indexed.

--- a/src/impact/types.rs
+++ b/src/impact/types.rs
@@ -139,7 +139,7 @@ pub struct DiffImpactSummary {
     /// SHL-V1.25-7: number of changed functions dropped past the cap. `--json`
     /// consumers can detect silent truncation without scraping stderr. Zero
     /// when `truncated == false`.
-    #[serde(skip_serializing_if = "is_zero_usize")]
+    #[serde(skip_serializing_if = "crate::serde_helpers::is_zero_usize")]
     pub truncated_functions: usize,
     /// EH-V1.29-9: true when a store batch query failed during diff-impact
     /// assembly (callers or caller snippets). Callers/snippets may be
@@ -147,10 +147,6 @@ pub struct DiffImpactSummary {
     /// failed".
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub degraded: bool,
-}
-
-fn is_zero_usize(n: &usize) -> bool {
-    *n == 0
 }
 
 /// Aggregated impact result from a diff

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,12 @@ pub mod llm;
 pub mod plan;
 pub(crate) mod scout;
 pub mod search;
+// P3-11: shared `#[serde(skip_serializing_if = ...)]` predicates so envelope
+// modules don't redeclare 1-line `is_false` / `is_zero_usize` / `is_true`
+// helpers per file. See serde_helpers.rs. `pub` (not `pub(crate)`) so the
+// binary crate's `cli/` modules can reference these via path strings inside
+// `serde(skip_serializing_if = "cqs::serde_helpers::is_false")` attributes.
+pub mod serde_helpers;
 pub(crate) mod structural;
 pub(crate) mod task;
 pub(crate) mod where_to_add;

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -30,7 +30,26 @@ pub struct BatchSubmitItem {
     pub custom_id: String,
     /// Source code content or pre-built prompt
     pub content: String,
-    /// Context field: chunk_type (summaries), signature (doc comments), or unused (prebuilt/HyDE)
+    /// Stringly-typed context bag whose meaning depends on which prompt
+    /// builder (`build_summary_prompt` / `build_doc_prompt` /
+    /// `build_hyde_prompt` / pre-built path) consumes the item. P3-47:
+    /// upgrading to a `PromptContext` enum touches every reader and
+    /// every construction site (see `llm/batch.rs:874,993`,
+    /// `llm/doc_comments.rs:266`, `llm/summary.rs:86`,
+    /// `llm/hyde.rs:57`, `llm/local.rs:739`) so the enum migration is
+    /// scoped to a separate change. Until then, the field's payload is:
+    ///
+    /// | Submission path                          | Field carries           |
+    /// |------------------------------------------|-------------------------|
+    /// | `submit_batch_prebuilt` (contrastive)    | unused (`String::new`)  |
+    /// | `submit_doc_batch` (doc comments)        | function signature      |
+    /// | `submit_hyde_batch` (HyDE queries)       | unused (`String::new`)  |
+    /// | summary batches (`llm_summary_pass`)     | chunk type label        |
+    ///
+    /// The receiver decides; a typo at the call site silently sends
+    /// the wrong field. This is the same tuple-with-named-fields
+    /// problem the struct was meant to solve, just one level deeper —
+    /// hence the deferred refactor.
     pub context: String,
     /// Programming language name
     pub language: String,

--- a/src/onboard.rs
+++ b/src/onboard.rs
@@ -111,18 +111,12 @@ pub struct OnboardSummary {
     /// `CQS_ONBOARD_CALLEE_FETCH`. Zero when no truncation happened. Surfaces
     /// the cap to consumers so a user can lift it intentionally rather than
     /// silently wonder where their callees went.
-    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    #[serde(default, skip_serializing_if = "crate::serde_helpers::is_zero_usize")]
     pub callees_truncated: usize,
     /// SHL-V1.30-5: callers truncated to `CQS_ONBOARD_CALLER_FETCH`. See
     /// `callees_truncated`.
-    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    #[serde(default, skip_serializing_if = "crate::serde_helpers::is_zero_usize")]
     pub callers_truncated: usize,
-}
-
-/// Helper used by `OnboardSummary` `skip_serializing_if` to elide zero-valued
-/// truncation counters from the JSON wire shape (keeps the common case clean).
-fn is_zero_usize(n: &usize) -> bool {
-    *n == 0
 }
 
 /// Produce a guided tour of a concept in the codebase.

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -1,0 +1,52 @@
+//! Tiny serde predicates for `#[serde(skip_serializing_if = ...)]`.
+//!
+//! `serde(skip_serializing_if)` requires a free function with the signature
+//! `fn(&T) -> bool`; closures and trait methods don't qualify. Rather than
+//! redeclare these one-line helpers in every envelope-shaped module
+//! (P3-11 from the v1.33.0 audit cataloged six copies), centralize them
+//! here so new envelope additions are a single attribute import.
+//!
+//! Use as:
+//! ```ignore
+//! #[serde(skip_serializing_if = "crate::serde_helpers::is_false")]
+//! pub flag: bool,
+//! ```
+
+#[inline]
+pub fn is_false(v: &bool) -> bool {
+    !*v
+}
+
+#[inline]
+pub fn is_true(v: &bool) -> bool {
+    *v
+}
+
+#[inline]
+pub fn is_zero_usize(n: &usize) -> bool {
+    *n == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_false_correct() {
+        assert!(is_false(&false));
+        assert!(!is_false(&true));
+    }
+
+    #[test]
+    fn is_true_correct() {
+        assert!(is_true(&true));
+        assert!(!is_true(&false));
+    }
+
+    #[test]
+    fn is_zero_usize_correct() {
+        assert!(is_zero_usize(&0));
+        assert!(!is_zero_usize(&1));
+        assert!(!is_zero_usize(&usize::MAX));
+    }
+}

--- a/src/store/helpers/error.rs
+++ b/src/store/helpers/error.rs
@@ -20,12 +20,25 @@ pub enum StoreError {
     /// file-scoped resolution misses. Lets callers distinguish "doesn't exist"
     /// from other runtime errors for retry/suggest logic.
     NotFound(String),
-    #[error("Schema version mismatch in {0}: index is v{1}, cqs expects v{2}. Run 'cqs index --force' to rebuild.")]
-    SchemaMismatch(String, i32, i32),
+    /// P3-31: struct-style fields. Positional `(String, i32, i32)` made every
+    /// construction site re-derive which integer was "found" vs "expected" —
+    /// `QueryDimMismatch` further down already uses named fields and is
+    /// self-documenting; this matches.
+    ///
+    /// `db_path` (not `source`) — `thiserror` reserves the `source` field
+    /// name for the error-chain `Error::source()` accessor and rejects
+    /// non-error types in that slot.
+    #[error("Schema version mismatch in {db_path}: index is v{found}, cqs expects v{expected}. Run 'cqs index --force' to rebuild.")]
+    SchemaMismatch {
+        db_path: String,
+        found: i32,
+        expected: i32,
+    },
     #[error("Index created by newer cqs version (schema v{0}). Please upgrade cqs.")]
     SchemaNewerThanCq(i32),
-    #[error("No migration path from schema v{0} to v{1}. Run 'cqs index --force' to rebuild.")]
-    MigrationNotSupported(i32, i32),
+    /// P3-31: struct-style fields — see `SchemaMismatch` above.
+    #[error("No migration path from schema v{from} to v{to}. Run 'cqs index --force' to rebuild.")]
+    MigrationNotSupported { from: i32, to: i32 },
     #[error(
         "Model mismatch: index uses \"{0}\" but configured model is \"{1}\".\nRun `cqs index --force` to reindex with the new model."
     )]

--- a/src/store/helpers/types.rs
+++ b/src/store/helpers/types.rs
@@ -55,18 +55,13 @@ pub struct ChunkSummary {
     /// `to_json_with_origin` / `to_json_relative_with_origin`. Defaults
     /// to false when the loading SELECT omits the column or the row
     /// predates v24.
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "crate::serde_helpers::is_false")]
     pub vendored: bool,
 }
 
 #[inline]
 fn is_zero_u32(v: &u32) -> bool {
     *v == 0
-}
-
-#[inline]
-fn is_false(v: &bool) -> bool {
-    !*v
 }
 
 impl From<&ChunkSummary> for Chunk {
@@ -191,31 +186,10 @@ impl SearchResult {
     ///
     /// Closes #1167, #1169, #1221.
     pub fn to_json_with_origin(&self, ref_name: Option<&str>) -> serde_json::Value {
-        let trust_level = if ref_name.is_some() {
-            "reference-code"
-        } else if self.chunk.vendored {
-            "vendored-code"
-        } else {
-            "user-code"
-        };
-        let mut obj = serde_json::json!({
-            "file": crate::normalize_path(&self.chunk.file),
-            "line_start": self.chunk.line_start,
-            "line_end": self.chunk.line_end,
-            "name": self.chunk.name,
-            "signature": self.chunk.signature,
-            "language": self.chunk.language.to_string(),
-            "chunk_type": self.chunk.chunk_type.to_string(),
-            "score": self.score,
-            "content": maybe_wrap_content(&self.chunk.content, &self.chunk.id),
-            "has_parent": self.chunk.parent_id.is_some(),
-            "trust_level": trust_level,
-            "injection_flags": crate::llm::validation::detect_all_injection_patterns(&self.chunk.content),
-        });
-        if let Some(name) = ref_name {
-            obj["reference_name"] = serde_json::json!(name);
-        }
-        obj
+        // P3-46: routed through `build_chunk_json_inner` with `base = None`
+        // so the absolute-path branch and the relative-path branch share one
+        // 12-field literal. Adding a chunk metadata field is now a one-edit.
+        self.build_chunk_json_inner(ref_name, None)
     }
 
     /// Serialize to JSON with file paths relative to a project root.
@@ -232,6 +206,22 @@ impl SearchResult {
         root: &std::path::Path,
         ref_name: Option<&str>,
     ) -> serde_json::Value {
+        // P3-46: routed through `build_chunk_json_inner` with `base =
+        // Some(root)` — see `to_json_with_origin` above.
+        self.build_chunk_json_inner(ref_name, Some(root))
+    }
+
+    /// P3-46: shared 12-field JSON shape. `base = None` emits absolute
+    /// (normalized) paths; `base = Some(root)` strips the prefix and
+    /// normalizes. The trust-level cascade and injection-flag computation
+    /// were duplicated verbatim in `to_json_with_origin` and
+    /// `to_json_relative_with_origin` before — adding a metadata field cost
+    /// two edits; now one.
+    fn build_chunk_json_inner(
+        &self,
+        ref_name: Option<&str>,
+        base: Option<&std::path::Path>,
+    ) -> serde_json::Value {
         let trust_level = if ref_name.is_some() {
             "reference-code"
         } else if self.chunk.vendored {
@@ -239,8 +229,12 @@ impl SearchResult {
         } else {
             "user-code"
         };
+        let file = match base {
+            None => crate::normalize_path(&self.chunk.file),
+            Some(root) => crate::rel_display(&self.chunk.file, root),
+        };
         let mut obj = serde_json::json!({
-            "file": crate::rel_display(&self.chunk.file, root),
+            "file": file,
             "line_start": self.chunk.line_start,
             "line_end": self.chunk.line_end,
             "name": self.chunk.name,

--- a/src/store/metadata.rs
+++ b/src/store/metadata.rs
@@ -94,11 +94,11 @@ impl<Mode> Store<Mode> {
                 // means something bypassed open() and stamped a stale
                 // `schema_version` after migration completed — surface that
                 // as a SchemaMismatch instead of trying to re-migrate.
-                return Err(StoreError::SchemaMismatch(
-                    path_str,
-                    version,
-                    CURRENT_SCHEMA_VERSION,
-                ));
+                return Err(StoreError::SchemaMismatch {
+                    db_path: path_str,
+                    found: version,
+                    expected: CURRENT_SCHEMA_VERSION,
+                });
             }
             Ok(())
         })

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -261,11 +261,11 @@ pub async fn check_and_migrate_schema(
             );
             Ok(p)
         }
-        Err(StoreError::MigrationNotSupported(from, to)) => Err(StoreError::SchemaMismatch(
-            db_path.display().to_string(),
-            from,
-            to,
-        )),
+        Err(StoreError::MigrationNotSupported { from, to }) => Err(StoreError::SchemaMismatch {
+            db_path: db_path.display().to_string(),
+            found: from,
+            expected: to,
+        }),
         Err(e) => Err(e),
     }
 }
@@ -339,30 +339,50 @@ async fn run_migration_tx(pool: &SqlitePool, from: i32, to: i32) -> Result<(), S
     Ok(())
 }
 
+/// P3-48: registered migration step. Each row pairs a `(from, to)` pair
+/// with a function that builds a boxed future running the step. Using the
+/// `Pin<Box<dyn Future>>` shape lets us hold a slice of `fn` pointers (no
+/// closures, no trait objects) — adding a step in v26 is now one row
+/// append rather than editing a hand-coded `match` ladder.
+// `+ Send` is intentionally absent — every per-version migration enters a
+// `tracing::info_span!(...).entered()` whose `EnteredSpan` guard is `!Send`,
+// so the resulting future isn't `Send` either. `run_migration` is awaited
+// from the same task that holds the SQLite connection, so a non-`Send`
+// future is fine. If a future migration moves the connection across
+// `tokio::spawn`, that step would need its own restructure regardless.
+type MigrationFn = for<'c> fn(
+    &'c mut sqlx::SqliteConnection,
+) -> std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<(), StoreError>> + 'c>,
+>;
+
+const MIGRATIONS: &[(i32, i32, MigrationFn)] = &[
+    (10, 11, |c| Box::pin(migrate_v10_to_v11(c))),
+    (11, 12, |c| Box::pin(migrate_v11_to_v12(c))),
+    (12, 13, |c| Box::pin(migrate_v12_to_v13(c))),
+    (13, 14, |c| Box::pin(migrate_v13_to_v14(c))),
+    (14, 15, |c| Box::pin(migrate_v14_to_v15(c))),
+    (15, 16, |c| Box::pin(migrate_v15_to_v16(c))),
+    (16, 17, |c| Box::pin(migrate_v16_to_v17(c))),
+    (17, 18, |c| Box::pin(migrate_v17_to_v18(c))),
+    (18, 19, |c| Box::pin(migrate_v18_to_v19(c))),
+    (19, 20, |c| Box::pin(migrate_v19_to_v20(c))),
+    (20, 21, |c| Box::pin(migrate_v20_to_v21(c))),
+    (21, 22, |c| Box::pin(migrate_v21_to_v22(c))),
+    (22, 23, |c| Box::pin(migrate_v22_to_v23(c))),
+    (23, 24, |c| Box::pin(migrate_v23_to_v24(c))),
+    (24, 25, |c| Box::pin(migrate_v24_to_v25(c))),
+];
+
 /// Run a single migration step
-#[allow(clippy::match_single_binding)] // Intentional: migration arms will be added here
 async fn run_migration(
     conn: &mut sqlx::SqliteConnection,
     from: i32,
     to: i32,
 ) -> Result<(), StoreError> {
-    match (from, to) {
-        (10, 11) => migrate_v10_to_v11(conn).await,
-        (11, 12) => migrate_v11_to_v12(conn).await,
-        (12, 13) => migrate_v12_to_v13(conn).await,
-        (13, 14) => migrate_v13_to_v14(conn).await,
-        (14, 15) => migrate_v14_to_v15(conn).await,
-        (15, 16) => migrate_v15_to_v16(conn).await,
-        (16, 17) => migrate_v16_to_v17(conn).await,
-        (17, 18) => migrate_v17_to_v18(conn).await,
-        (18, 19) => migrate_v18_to_v19(conn).await,
-        (19, 20) => migrate_v19_to_v20(conn).await,
-        (20, 21) => migrate_v20_to_v21(conn).await,
-        (21, 22) => migrate_v21_to_v22(conn).await,
-        (22, 23) => migrate_v22_to_v23(conn).await,
-        (23, 24) => migrate_v23_to_v24(conn).await,
-        (24, 25) => migrate_v24_to_v25(conn).await,
-        _ => Err(StoreError::MigrationNotSupported(from, to)),
+    match MIGRATIONS.iter().find(|(f, t, _)| *f == from && *t == to) {
+        Some((_, _, run)) => run(conn).await,
+        None => Err(StoreError::MigrationNotSupported { from, to }),
     }
 }
 
@@ -924,7 +944,7 @@ mod tests {
     #[test]
     fn test_migration_not_supported_error() {
         // Verify unknown migrations produce clear errors
-        let err = StoreError::MigrationNotSupported(5, 6);
+        let err = StoreError::MigrationNotSupported { from: 5, to: 6 };
         let msg = err.to_string();
         assert!(msg.contains("5"));
         assert!(msg.contains("6"));
@@ -1671,7 +1691,7 @@ mod tests {
             let result = migrate(pool, &db_path, 8, 11).await;
             assert!(result.is_err(), "unsupported range should fail");
             match result.unwrap_err() {
-                StoreError::MigrationNotSupported(from, to) => {
+                StoreError::MigrationNotSupported { from, to } => {
                     assert_eq!(from, 8);
                     assert_eq!(to, 9);
                 }


### PR DESCRIPTION
Closes 11 of 13 P3 papercuts from the v1.33.0 audit (Tier 6). Two structural items land as tracking issues so the PR stays focused on per-finding ≤10-line fixes.

## Findings closed (11)

### Code Quality

- **P3-10** (already-fixed): `check_model_version()` already gated `#[cfg(test)]` since #715/d46c8cf6. Audit row was stale — marked ✅ in triage.
- **P3-11**: extract `src/serde_helpers.rs` with `is_false`, `is_true`, `is_zero_usize`. Six in-tree copies replaced (`cli/json_envelope.rs`, `eval/schema.rs`, `store/helpers/types.rs`, `onboard.rs`, `impact/types.rs`, `ci.rs`).

### API Design

- **P3-25**: `cqs project register` now flattens `TextJsonArgs` and emits the canonical envelope.
- **P3-26**: `cqs notes add | update | remove` accept subcommand-level `--json` (the `List` arm already had it).
- **P3-29**: `ProjectCommand::Register` → `Add` (with `visible_alias = "register"` for back-compat). Aligns with `ref add`, `slot create`, `cache clear`.
- **P3-30**: replace inline `json: bool` on `Init`, `Doctor`, `Convert`, `Ping`, `Status`, `Refresh` with `#[command(flatten)] output: TextJsonArgs`. `Convert` field rename `output → output_dir` keeps the user-facing `-o`/`--output` flag via `#[arg(long = "output")]`.
- **P3-31**: `StoreError::SchemaMismatch(String, i32, i32)` and `MigrationNotSupported(i32, i32)` converted to struct-style. Field `db_path` (not `source` — `thiserror` reserves that name).

### Extensibility

- **P3-46**: extract `SearchResult::build_chunk_json_inner(ref_name, base)`. Both `to_json_with_origin` (absolute) and `to_json_relative_with_origin` (relative) call it; adding a new chunk metadata field is now one edit.
- **P3-47**: `BatchSubmitItem.context` documented with a per-submission-path schema table on the field. Full enum migration deferred — touches 5 readers + 5 construction sites.
- **P3-48**: `run_migration` 16-arm hand-coded match replaced with a `MIGRATIONS: &[(i32, i32, MigrationFn)]` table. New migration v26 is now one row append.

## Findings filed as issues (2)

- **P3-27** → **#1365**: `cqs slot`/`cqs cache` `--slot` help mismatch. clap 4's derive macro can't hide a parent `global = true` arg per-subcommand; the audit's `disable_args = […]` is not real clap syntax. Issue covers three implementation paths.
- **P3-49** → **#1366**: structural CLI registry refactor. CI-lint or proc-macro derive — both larger than a P3 papercut.

## Validation

- `cargo fmt --check` clean.
- `cargo clippy --features cuda-index --lib -- -D warnings` clean.
- `cargo clippy --features cuda-index --bin cqs -- -D warnings` clean.
- Targeted lib tests pass: 24 migrations + 16 SearchResult JSON + 19 metadata/eval/notes + 3 new `serde_helpers`.
- Integration tests pass: `cli_surface_test` (15, including `project_register_list_remove_round_trips` exercising the `register` alias), `cli_envelope_test` (5), `cli_cache_test` (3).
- Manual smoke: `cqs project add foo /path --json` and `cqs project register foo /path --json` (alias) both emit the envelope; `cqs convert --help` still shows `-o, --output <OUTPUT_DIR>`; `cqs notes add "..." --no-reindex --json` works at top-level and subcommand-level.

## Test plan

- [ ] CI: `cargo build`, `cargo test --lib`, `cargo test --tests cli_*`.
- [ ] Smoke: `cqs --json project add ...`, `cqs --json notes add ...`, `cqs convert --help`, `cqs project register ...` (alias).
- [ ] No external behaviour changes other than: (a) `project register` → `add` (alias preserves old form), (b) JSON envelopes now emitted for `project add`, `notes add|update|remove`, (c) `StoreError::SchemaMismatch` Debug output now uses field names (not part of any user-facing wire shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
