### PR TITLE
chore(audit): #1290 P2 correctness — reconcile mtime-touch + L5X line arithmetic

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -84,9 +84,9 @@ Total findings: 167 across 16 categories. Classified into P1 (fix immediately) /
 | P2-2 | Observability | `WatchSnapshot::compute` and `now_unix_secs` lack tracing on freshness state machine | medium | ✅ #1362 |
 | P2-3 | Error Handling | `embedder.fingerprint` silently uses `size = 0` when metadata fails — collides cache keys | medium | ⬜ |
 | P2-4 | Error Handling | `IndexBackend` trait — public lib trait uses anyhow::Result instead of thiserror | medium | ⬜ |
-| P2-5 | Error Handling | Reconcile mtime-touch chain silently abandons on metadata or `modified()` failure | medium | ⬜ |
+| P2-5 | Error Handling | Reconcile mtime-touch chain silently abandons on metadata or `modified()` failure | medium | ✅ #1379 |
 | P2-6 | Error Handling | Reference path canonicalize-failure in `Config::validate` skips SEC-4 + SEC-NEW-1 check | medium | ⬜ |
-| P2-7 | Robustness | L5X parser line arithmetic uses unchecked u32+u32 — overflow panics in debug | medium | ⬜ |
+| P2-7 | Robustness | L5X parser line arithmetic uses unchecked u32+u32 — overflow panics in debug | medium | ✅ #1379 |
 | P2-8 | Code Quality | `serve` async handlers duplicate 15-20 LOC of permit + spawn_blocking + span ×6 | medium | ⬜ |
 | P2-9 | Scaling | HNSW M/ef defaults static, don't auto-scale with corpus | medium | ⬜ |
 | P2-10 | TC Adversarial | `enumerate_files` symlink-skip / oversized-skip / non-UTF8-path branches untested | medium | ✅ #1333 |

--- a/src/cli/watch/reindex.rs
+++ b/src/cli/watch/reindex.rs
@@ -201,6 +201,67 @@ pub(super) fn splade_batch_size() -> usize {
         .filter(|n| *n > 0)
         .unwrap_or(32)
 }
+
+/// EH-V1.33-8 (#1290): touch the stored `source_mtime` to disk's mtime so
+/// the next reconcile pass sees `disk == stored` and stops re-queuing the
+/// file. Returns `true` on success.
+///
+/// Pre-fix this was a four-deep `if let Ok` chain (`metadata` → `modified`
+/// → `duration_since(UNIX_EPOCH)` → `touch_source_mtime`); any one of
+/// those four steps failing silently abandoned the touch, leaving the
+/// stored mtime stale and the reconcile loop running forever for that
+/// file. Worse, `cqs status --watch-fresh` would then claim
+/// `state == fresh` while the touch never landed — operators trusting
+/// the readiness signal would proceed against a stale index.
+///
+/// The helper logs a distinct `tracing::warn!` at each failure step so
+/// operators can see exactly which FS API or store call broke the chain.
+pub(super) fn touch_mtime_or_warn(store: &Store, rel_path: &Path, abs_path: &Path) -> bool {
+    let meta = match std::fs::metadata(abs_path) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(
+                path = %rel_path.display(),
+                error = %e,
+                "Cannot touch source_mtime: metadata() failed; reconcile loop may persist"
+            );
+            return false;
+        }
+    };
+    let disk_mtime = match meta.modified() {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(
+                path = %rel_path.display(),
+                error = %e,
+                "Cannot touch source_mtime: modified() failed; reconcile loop may persist"
+            );
+            return false;
+        }
+    };
+    let d = match disk_mtime.duration_since(std::time::UNIX_EPOCH) {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::warn!(
+                path = %rel_path.display(),
+                error = %e,
+                "Cannot touch source_mtime: file mtime predates UNIX_EPOCH (clock skew?); reconcile loop may persist"
+            );
+            return false;
+        }
+    };
+    let mtime_ms = cqs::duration_to_mtime_millis(d);
+    if let Err(e) = store.touch_source_mtime(rel_path, mtime_ms) {
+        tracing::warn!(
+            path = %rel_path.display(),
+            error = %e,
+            "Failed to touch source_mtime for parse-failed file — reconcile loop may persist"
+        );
+        return false;
+    }
+    true
+}
+
 /// Reindex specific files.
 ///
 /// Returns `(chunk_count, content_hashes)` — the content hashes can be used for
@@ -323,22 +384,19 @@ pub(super) fn reindex_files(
                     // piece; the file's previous chunks remain visible
                     // in search until the user fixes the syntax error
                     // and the next save retriggers a successful re-parse.
-                    if let Ok(meta) = std::fs::metadata(&abs_path) {
-                        if let Ok(disk_mtime) = meta.modified() {
-                            if let Ok(d) = disk_mtime.duration_since(std::time::UNIX_EPOCH) {
-                                let mtime_ms = cqs::duration_to_mtime_millis(d);
-                                if let Err(touch_err) =
-                                    store.touch_source_mtime(rel_path, mtime_ms)
-                                {
-                                    tracing::warn!(
-                                        path = %rel_path.display(),
-                                        error = %touch_err,
-                                        "Failed to touch source_mtime for parse-failed file — reconcile loop may persist"
-                                    );
-                                }
-                            }
-                        }
-                    }
+                    //
+                    // EH-V1.33-8 (#1290): the previous nested `if let Ok`
+                    // chain swallowed metadata / modified / duration_since
+                    // failures silently. A clock-skewed mtime, a deleted
+                    // file mid-walk, or a permission flake on the second
+                    // FS read would silently abandon the touch — and
+                    // `cqs status --watch-fresh` would then claim the
+                    // index is fresh while the touch never landed.
+                    // Refactored to a fail-loud helper that logs a
+                    // distinct warn at each step so operators can see
+                    // *why* a touch failed and the reconcile loop
+                    // persisted.
+                    touch_mtime_or_warn(store, rel_path, &abs_path);
                     vec![]
                 }
             }

--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -1697,3 +1697,54 @@ fn process_file_changes_zero_files_is_noop_when_embedder_blocked() {
         "no work was attempted, no counter to clear or preserve"
     );
 }
+
+// ===== EH-V1.33-8 (#1290): touch_mtime_or_warn fail-loud helper =====
+
+/// EH-V1.33-8 (#1290): the parse-failure mtime-touch chain previously
+/// nested four `if let Ok(...)` checks. Any one failing silently
+/// abandoned the touch, leaving `cqs status --watch-fresh` reporting
+/// fresh while the touch never landed. The helper now returns false
+/// and logs a distinct warn at each failure step. This test exercises
+/// the metadata() failure branch (most common — file was deleted between
+/// the parse attempt and the touch).
+#[test]
+fn touch_mtime_or_warn_returns_false_on_missing_file() {
+    use super::reindex::touch_mtime_or_warn;
+
+    let fix = drain_test_fixture(4);
+    let rel = PathBuf::from("nonexistent.rs");
+    let abs = fix.tmp.path().join(&rel);
+    // Deliberately do NOT create the file. metadata() will fail.
+    assert!(!abs.exists(), "test setup: file must not exist");
+
+    let ok = touch_mtime_or_warn(&fix.store, &rel, &abs);
+    assert!(
+        !ok,
+        "metadata() failure must short-circuit and return false, not silently succeed"
+    );
+}
+
+/// EH-V1.33-8 (#1290): the success path — when the file exists, the
+/// helper must read its mtime and call `touch_source_mtime` on the
+/// store. Returns true even if no rows were affected (origin format
+/// mismatch with stored chunks would produce 0 rows but still indicate
+/// the FS chain succeeded). Pins the happy path so a future refactor
+/// that breaks the success branch is caught.
+#[test]
+fn touch_mtime_or_warn_returns_true_on_extant_file() {
+    use super::reindex::touch_mtime_or_warn;
+    use std::io::Write;
+
+    let fix = drain_test_fixture(4);
+    let abs = fix.tmp.path().join("present.rs");
+    let mut f = std::fs::File::create(&abs).unwrap();
+    f.write_all(b"fn x() {}").unwrap();
+    drop(f);
+    let rel = PathBuf::from("present.rs");
+
+    let ok = touch_mtime_or_warn(&fix.store, &rel, &abs);
+    assert!(
+        ok,
+        "extant file with readable mtime must succeed; FS chain returned false unexpectedly"
+    );
+}

--- a/src/parser/l5x.rs
+++ b/src/parser/l5x.rs
@@ -106,7 +106,10 @@ fn parse_st_regions(
         if all_chunks.len() == region_chunk_start {
             if let Some(ref name) = region.routine_name {
                 let content = region.source.clone();
-                let line_count = content.lines().count() as u32;
+                // RB-V1.33-7 (#1290): clamp on the `usize -> u32` cast so
+                // a pathological file with >4 B lines saturates instead of
+                // silently truncating to a tiny line_count.
+                let line_count: u32 = content.lines().count().try_into().unwrap_or(u32::MAX);
                 let sig = content.lines().next().unwrap_or("").to_string();
                 let content_hash = blake3::hash(content.as_bytes()).to_hex().to_string();
                 all_chunks.push(Chunk {
@@ -122,7 +125,13 @@ fn parse_st_regions(
                     file: path.to_path_buf(),
                     line_start: region.line_start,
                     // AC-V1.33-2: line_end is inclusive 1-indexed (see chunk.rs:93)
-                    line_end: region.line_start + line_count.saturating_sub(1),
+                    // RB-V1.33-7 (#1290): saturating_add so a high
+                    // `region.line_start` plus a large line_count clamps
+                    // at u32::MAX instead of overflow-panicking in debug
+                    // (test runs!) and silently wrapping in release.
+                    line_end: region
+                        .line_start
+                        .saturating_add(line_count.saturating_sub(1)),
                     language: st_lang,
                     signature: sig,
                     doc: None,
@@ -169,8 +178,20 @@ fn extract_st_chunk(
     }
 
     let content = source[node.byte_range()].to_string();
-    let line_start = region.line_start + node.start_position().row as u32;
-    let line_end = region.line_start + node.end_position().row as u32;
+    // RB-V1.33-7 (#1290): tree-sitter row indices are usize internally; the
+    // `as u32` cast silently truncates on files >4 B lines. `try_into +
+    // unwrap_or(u32::MAX)` clamps the cast so the saturating_add below
+    // reaches u32::MAX deterministically rather than wrapping.
+    let start_row: u32 = node.start_position().row.try_into().unwrap_or(u32::MAX);
+    let end_row: u32 = node.end_position().row.try_into().unwrap_or(u32::MAX);
+    // saturating_add so `region.line_start + tree-sitter row` clamps at
+    // u32::MAX on a pathological L5X (large `Routine` with many rungs and
+    // a high `region.line_start` offset). Pre-fix this overflowed in
+    // debug (test panic!) and silently wrapped in release, producing a
+    // chunk with `line_start ≈ 0`, `line_end ≈ u32::MAX` — a nonsense
+    // span that corrupts the index for that chunk.
+    let line_start = region.line_start.saturating_add(start_row);
+    let line_end = region.line_start.saturating_add(end_row);
 
     let signature = content
         .lines()
@@ -841,6 +862,88 @@ END_PROGRAM
         assert!(!chunks.is_empty(), "CRLF L5X source should produce chunks");
         for chunk in &chunks {
             assert_eq!(chunk.language, Language::StructuredText);
+        }
+    }
+
+    /// RB-V1.33-7 (#1290): synthetic-chunk path must saturate on overflow.
+    ///
+    /// When the routine has a name but tree-sitter produces no matches
+    /// (no parseable ST inside), the synthetic-chunk fallback computes
+    /// `line_end = region.line_start + (line_count - 1)`. With a high
+    /// `region.line_start` (near `u32::MAX`) and a multi-line region,
+    /// pre-fix this overflowed `u32 + u32` — panics in debug (test
+    /// runs!), wraps in release. Post-fix uses `saturating_add` so it
+    /// clamps at `u32::MAX` and produces a valid chunk.
+    #[test]
+    fn test_l5x_synthetic_chunk_saturates_on_line_overflow() {
+        // The fallback only triggers when the ST source has *no* tree-sitter
+        // matches. Use a comment-only payload so `parse_st_regions` produces
+        // zero matches and falls through to the synthetic path.
+        let source = "// just a comment\n// no statements\n// nothing parseable";
+        let regions = vec![StRegion {
+            source: source.to_string(),
+            line_start: u32::MAX - 1, // forces overflow on `+ (line_count - 1)`
+            routine_name: Some("OverflowRoutine".to_string()),
+            program_name: Some("OverflowProg".to_string()),
+        }];
+
+        let parser = Parser::new().unwrap();
+        let chunks = parse_st_regions(&regions, Path::new("overflow.l5x"), &parser)
+            .expect("parse_st_regions must not panic on near-MAX line_start");
+
+        assert_eq!(
+            chunks.len(),
+            1,
+            "Synthetic fallback should produce exactly one chunk"
+        );
+        let c = &chunks[0];
+        assert_eq!(
+            c.line_start,
+            u32::MAX - 1,
+            "line_start should match region.line_start"
+        );
+        assert_eq!(
+            c.line_end,
+            u32::MAX,
+            "line_end must saturate at u32::MAX, not wrap"
+        );
+        assert!(
+            c.line_end >= c.line_start,
+            "line_end must be >= line_start (no wrap)"
+        );
+    }
+
+    /// RB-V1.33-7 (#1290): tree-sitter chunk path must saturate on
+    /// overflow. With a high `region.line_start` and a tree-sitter row
+    /// index, pre-fix `region.line_start + node.row as u32` overflowed.
+    /// Post-fix uses `saturating_add` and a clamping cast so both line
+    /// bounds clamp at `u32::MAX`.
+    #[test]
+    fn test_l5x_tree_sitter_chunk_saturates_on_line_overflow() {
+        // Real ST function so the tree-sitter parser produces a chunk.
+        let source = "FUNCTION_BLOCK MyFB\nVAR x : INT; END_VAR\nx := 1;\nEND_FUNCTION_BLOCK";
+        let regions = vec![StRegion {
+            source: source.to_string(),
+            line_start: u32::MAX, // any tree-sitter row added overflows u32
+            routine_name: Some("Saturate".to_string()),
+            program_name: Some("Prog".to_string()),
+        }];
+
+        let parser = Parser::new().unwrap();
+        let chunks = parse_st_regions(&regions, Path::new("saturate.l5x"), &parser)
+            .expect("parse_st_regions must not panic on u32::MAX line_start");
+
+        for c in &chunks {
+            assert_eq!(
+                c.line_start,
+                u32::MAX,
+                "line_start must saturate at u32::MAX, not wrap"
+            );
+            assert_eq!(
+                c.line_end,
+                u32::MAX,
+                "line_end must saturate at u32::MAX, not wrap"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

Two P2 correctness items from the v1.33.0 audit (`docs/audit-findings.md`).

### EH-V1.33-8 (P2-5) — reconcile mtime-touch chain silently abandons

`reindex_files`'s parse-failure mtime touch was a four-deep `if let Ok` nest. Any one of `metadata` / `modified` / `duration_since(UNIX_EPOCH)` / `touch_source_mtime` failing silently abandoned the touch with no log. `cqs status --watch-fresh` would then claim `state == fresh` while the touch never landed — agents running `cqs eval --require-fresh` would proceed against a stale index.

Refactored to `touch_mtime_or_warn(store, rel, abs) -> bool` in `src/cli/watch/reindex.rs`. The helper logs a distinct `tracing::warn!` at each failure step (metadata, modified, duration_since, store touch) so operators can see exactly which FS API or store call broke the chain. Returns `false` on any failure so a future snapshot counter (`mtime_failures > 0`) can surface the signal to `cqs status --watch-fresh` callers — for now the warn-on-each-step diagnostic is the operator-facing signal.

### RB-V1.33-7 (P2-7) — L5X line arithmetic overflow

Three sites in `src/parser/l5x.rs` used unchecked `u32 + u32`:
- `region.line_start + line_count.saturating_sub(1)` (synthetic-chunk fallback)
- `region.line_start + node.start_position().row as u32` (tree-sitter chunk)
- `region.line_start + node.end_position().row as u32` (tree-sitter chunk)

A pathological L5X (large `Routine` with thousands of rungs and a high `region.line_start`) overflowed in debug (panic — test runs!) and silently wrapped in release, producing a chunk with `line_start ≈ 0`, `line_end ≈ u32::MAX`. The two `as u32` casts on tree-sitter's `usize` rows also silently truncated on >4 B-line files.

Switched to `saturating_add` on the three additions and `try_into().unwrap_or(u32::MAX)` on the two `usize → u32` casts. Mirrors the project pattern PR #1311 used for the splade batch fix.

## Tests

- `parser::l5x::tests::test_l5x_synthetic_chunk_saturates_on_line_overflow` — `region.line_start = u32::MAX - 1` plus a 3-line region. Pre-fix: panic in debug. Post-fix: `line_end == u32::MAX`.
- `parser::l5x::tests::test_l5x_tree_sitter_chunk_saturates_on_line_overflow` — `region.line_start = u32::MAX` plus a real ST function. Pre-fix: panic in debug. Post-fix: both bounds at `u32::MAX`.
- `cli::watch::tests::touch_mtime_or_warn_returns_false_on_missing_file` — exercises the metadata() failure branch.
- `cli::watch::tests::touch_mtime_or_warn_returns_true_on_extant_file` — pins the happy path.

## Test plan

- [x] `cargo check --features cuda-index`
- [x] `cargo clippy --features cuda-index --lib -- -D warnings`
- [x] `cargo clippy --features cuda-index --bin cqs -- -D warnings`
- [x] `cargo fmt`
- [x] `cargo test --features cuda-index --lib parser::l5x::` — 18/18 pass (incl. 2 new)
- [x] `cargo test --features cuda-index --bin cqs cli::watch::tests` — 51/51 pass (incl. 2 new)
- [x] No new env vars; no schema changes; no public-API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
