### PR TITLE
fix(embedder): bypass tokenizer truncation in windowing/count paths

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,7 +2,28 @@
 
 ## Right Now
 
-**v1.33.0 audit + close-out, 2026-05-02 (this session).** 16-category audit produced 167 findings; triaged P1=47/P2=41/P3=56/P4=23. Fix wave: **24 PRs landed today** plus PR #1381 (Retrieval Quality refresh) waiting on CI. Branch: `chore/refresh-eval-numbers-1369`. Daemon active, binary rebuilt + installed at v1.33.0.
+**v1.34.0 released 2026-05-02 (same day as v1.33.0).** Bundled the post-v1.33.0 audit close-out (24 fix PRs) + pre-audit feature work (EmbeddingGemma-300m preset, `cqs eval --reranker`, slow-tests Phase 2, ci-slow.yml stabilization). On crates.io. Tag pushed (binaries via `release.yml`).
+
+**Open in flight: PR #1384 — `fix(embedder): bypass tokenizer truncation in windowing/count paths`.** Apples-to-apples eval comparison surfaced a real correctness bug. **bge-large-ft and v9-200k tokenizers ship `truncation: {max_length: 512}` baked into `tokenizer.json`** (HF's `optimum-cli` default). cqs `split_into_windows`/`token_count` rely on `encode().get_ids().len()` to count tokens — the silent truncation cap meant long markdown sections were chunked at "fits in 1-2 windows" when they actually needed 12, so ~90% of section content was never embedded. Surgical fix: clone the tokenizer Arc and disable truncation for counting paths only (inference paths still need the cap to clamp at max_seq).
+
+Reproducer on `docs/audit-findings-v1.30.0.md` (15.5k chars, 5358 real tokens):
+- BGE-large default tokenizer (no truncation): 5358 tokens → 12 windows
+- bge-large-ft tokenizer (truncation=512): 512 tokens reported → 2 windows
+
+**Pending after #1384 merges:** rebuild binary, install, restart daemon, re-reindex bge-ft + v9 (their indexes are missing real content), re-eval all 4 slots for the clean apples-to-apples comparison. The earlier "matching coverage" eval is contaminated — bge-ft and v9 numbers were measured against indexes missing ~90% of long-section content.
+
+**v1.33.0 audit close-out (earlier in this session, all merged):** 16-category audit produced 167 findings; triaged P1=47/P2=41/P3=56/P4=23. **24 fix PRs landed**; 25 medium-effort items filed as tracking issues (#1337-#1377). Coverage: 129 ✅ closed / 15 🎫 issue-tracked / 0 ⬜ open. PR #1334 (daemon-aware `cqs index`) closed 98% of telemetry CLI error rate. PR #1380 recovered 112 lost ✅ flips after a cascade-rebase pattern silently rolled back triage updates.
+
+**Eval results pre-tokenizer-fix (apples-to-apples, all 4 slots reindexed --force --llm-summaries):**
+
+| Preset | Agg R@1 | Agg R@5 | Agg R@20 | Note |
+|--------|---:|---:|---:|------|
+| BGE-large (default) | 47.7% | 71.6% | 83.9% | clean — full-coverage tokenizer |
+| **embeddinggemma-300m** | **49.1%** | **72.5%** | **86.2%** | clean — full-coverage tokenizer |
+| bge-large-ft | 45.4% | 72.9% | 86.2% | **CONTAMINATED** — truncation bug |
+| v9-200k | 44.5% | 69.7% | 81.7% | **CONTAMINATED** — truncation bug |
+
+Take only the BGE-large vs Gemma comparison as valid: **embeddinggemma-300m wins agg R@1 by 1.4pp, R@5 by 0.9pp, R@20 by 2.3pp**. v1.35.0 default-candidate at 308M params / 768 dim. The bge-ft and v9 numbers will likely jump after the fix lands and they're reindexed; re-run before any roadmap conclusion.
 
 **Coverage now:**
 - ✅ 129 closed (all P1, all in-scope P2/P3 batches, plus 17 new tests)
@@ -146,6 +167,7 @@ Strategic frontier candidates if redirected:
 - **CI cqs test job runs ~30-40 min** serialised on a single GPU runner. Fixed-interval `/loop` heartbeats > 60min should go to cloud schedule (`/schedule`).
 - **vllm 0.19 has tight pins** on `flashinfer==0.6.6` and `lark==1.2.2`. Bumping these without bumping vllm itself breaks the Gemma server. The vllm-serve env runs a `transformers 5.6.0.dev0` build that vllm theoretically rejects — tolerated at runtime, fragile if vllm ever bumps.
 - **`pylate 1.4.0` pins `sentence-transformers==5.1.1` exactly** with no newer pylate available. Conflict is dormant unless ColBERT eval is run; cleanest fix would be a dedicated `colbert-eval` env.
+- **HF preset tokenizers may ship `truncation: {max_length: 512}` baked into `tokenizer.json`** (HF's `optimum-cli` enables it by default on export). Affects bge-large-ft and v9-200k locally. cqs windowing/counting paths must clone-and-disable truncation before counting tokens, otherwise long sections silently chunk into 1-2 windows when they need 12+ — see PR #1384. Inference paths intentionally keep truncation. When adding a new preset, sanity-check `python -c "from tokenizers import Tokenizer; print(Tokenizer.from_file('tokenizer.json').get_truncation())"` before relying on token counts.
 
 ## Collaboration calibration (still load-bearing)
 
@@ -171,5 +193,7 @@ Strategic frontier candidates if redirected:
 | nomic-coderank | 42.2% | 67.9% | 79.8% | 47.7% | 69.7% | 81.7% |
 
 Per-slot state at measurement time was uneven (default 19,857 chunks 48% summaries; bge-ft 14,460 0% summaries; gemma 13,118 90%; v9 14,468 82%; coderank 12,393 0%) — direct cross-model comparison is qualitative; tighter A/B requires reindex-from-shared-summary-set per slot. The earlier "post-v1.28.3 → refreshed" 3.7-5.5pp R@5 gap that was attributed to corpus drift was actually noise; current BGE-large numbers are *higher* than the canonical row across most metrics. The v3.v2 fixture is still the canonical slate; v4 fixtures (1526/split, 14× v3 N) exist for any future A/B that needs tighter noise floors.
+
+**Apples-to-apples reindex pass (2026-05-02, post-summary-equalization):** all 4 slots reindexed `--force --llm-summaries` to identical 90%+ coverage. Results in Right Now; bge-ft + v9 contaminated by truncation bug (PR #1384). Re-run pending after #1384 merges.
 
 The `research/models.md` file (committed in #1270) is the inaugural retrieval-research log. Future A/B writeups append there.

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -713,8 +713,18 @@ impl Embedder {
     ///
     /// Returns `EmbedderError::Tokenizer` if the tokenizer is unavailable or if encoding the text fails.
     pub fn token_count(&self, text: &str) -> Result<usize, EmbedderError> {
-        let encoding = self
-            .tokenizer()?
+        // Same truncation-bypass as `split_into_windows`: count actual
+        // tokens, not whatever the tokenizer's `truncation` cap returns.
+        // bge-large-ft and v9-200k ship tokenizer.json with
+        // truncation.max_length=512, which silently caps `token_count`
+        // and breaks every downstream "is this chunk too long?" check.
+        let tokenizer_arc = self.tokenizer()?;
+        let mut tok = (*tokenizer_arc).clone();
+        if tok.get_truncation().is_some() {
+            tok.with_truncation(None)
+                .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
+        }
+        let encoding = tok
             .encode(text, false)
             .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
         Ok(encoding.get_ids().len())
@@ -728,8 +738,15 @@ impl Embedder {
         if texts.is_empty() {
             return Ok(vec![]);
         }
-        let encodings = self
-            .tokenizer()?
+        // Same truncation-bypass as `token_count` — count actual tokens
+        // for accurate windowing decisions.
+        let tokenizer_arc = self.tokenizer()?;
+        let mut tok = (*tokenizer_arc).clone();
+        if tok.get_truncation().is_some() {
+            tok.with_truncation(None)
+                .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
+        }
+        let encodings = tok
             .encode_batch(texts.to_vec(), false)
             .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
         Ok(encodings.iter().map(|e| e.get_ids().len()).collect())
@@ -782,8 +799,26 @@ impl Embedder {
             )));
         }
 
-        let tokenizer = self.tokenizer()?;
-        let encoding = tokenizer
+        // Clone the tokenizer and disable truncation so we count the FULL
+        // token sequence, not whatever the tokenizer's `truncation` field
+        // caps it to. Some preset tokenizers (notably bge-large-ft and
+        // v9-200k, which were exported via `optimum-cli` with default
+        // truncation enabled) ship `tokenizer.json` with
+        // `truncation: {max_length: 512}`. Without this clone, encode()
+        // silently caps long content at 512 tokens, the windowing loop
+        // sees `ids.len() <= max_tokens` and returns a single window —
+        // dropping ~90% of long markdown sections from the embedding.
+        // Inference paths (embed_query/embed_batch) intentionally keep the
+        // truncation behavior because they need to clamp input to
+        // max_seq_length anyway, so we only override here.
+        let tokenizer_arc = self.tokenizer()?;
+        let mut tokenizer_no_trunc = (*tokenizer_arc).clone();
+        if tokenizer_no_trunc.get_truncation().is_some() {
+            tokenizer_no_trunc
+                .with_truncation(None)
+                .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
+        }
+        let encoding = tokenizer_no_trunc
             .encode(text, false)
             .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
 


### PR DESCRIPTION
## Summary

Some preset tokenizers (bge-large-ft, v9-200k) ship `tokenizer.json` with `truncation: {direction: "Right", max_length: 512, strategy: "LongestFirst", stride: 0}` baked in (HF's `optimum-cli` enables this by default on export). cqs `split_into_windows`, `token_count`, and `token_counts_batch` rely on `encode().get_ids().len()` to count tokens — the truncation cap silently capped that count at 512 even when the input had 5000+ tokens.

Result: the windowing loop thought long markdown sections fit in 1-2 windows when they actually needed 12, so ~90% of long-section content was never embedded. Affects bge-large-ft and v9-200k preset slots; default BGE-large and embeddinggemma-300m unaffected.

## Reproducer

`docs/audit-findings-v1.30.0.md` (15.5k chars, 5358 real tokens):

| Tokenizer | Reported tokens | Windows produced |
|-----------|----------------:|-----------------:|
| BGE-large default (no truncation) | 5358 | 12 |
| bge-large-ft (truncation=512)     |  512 |  2 |

## Fix

In `src/embedder/mod.rs`, three count/windowing paths now clone the tokenizer Arc and disable truncation before encoding:

- `split_into_windows`
- `token_count`
- `token_counts_batch`

Inference paths (`embed_query`, `embed_batch`) intentionally keep the original truncation-enabled tokenizer because they need to clamp input to `max_seq_length` anyway.

## Discovery context

Surfaced during apples-to-apples eval comparison: bge-ft and v9 indexes had ~25% fewer chunks than default at identical corpus, which initially looked like default having "garbage chunks" but turned out to be bge-ft / v9 silently under-indexing.

## Test plan

- [ ] CI green (clippy, fmt, msrv, test, codeql)
- [ ] After merge: rebuild + reinstall binary, restart cqs-watch
- [ ] Reindex bge-ft and v9 slots with `cqs index --force --slot X --llm-summaries`
- [ ] Re-eval all 4 slots on v3.v2 test+dev for clean apples-to-apples numbers (current bge-ft / v9 eval rows are contaminated)
- [ ] Document tokenizer-truncation gotcha for future preset additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
