### PR TITLE
fix(serde-helpers): switch ignore doctest to text — broke ci-slow

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,7 +2,9 @@
 
 ## Right Now
 
-**v1.35.0 in flight 2026-05-02.** **Default embedder swaps from BGE-large to EmbeddingGemma-300m.** Plus tokenizer truncation fix (PR #1384, already merged into v1.34.0 main). 5-slot apples-to-apples eval after every slot was reindexed `--force --llm-summaries` shows gemma wins agg R@1 by +1.9pp over BGE-large at half the params + 4× context. BGE-large remains a first-class preset; existing slot indexes keep their stored model.
+**v1.35.0 released 2026-05-02.** **Default embedder swaps from BGE-large to EmbeddingGemma-300m.** PR #1385 merged (3 follow-up fixes during CI iteration: doctor test default-derivation, embedder ONNX external-data sidecar download, embedder_dim_mismatch test default-derivation). Tag pushed; binaries via `release.yml`; crates.io publish in flight.
+
+5-slot apples-to-apples eval after every slot was reindexed `--force --llm-summaries` on the truncation-fixed binary (#1384):
 
 | Slot | Agg R@1 | Agg R@5 | Agg R@20 |
 |---|---:|---:|---:|
@@ -12,7 +14,9 @@
 | v9-200k | 45.0% | 68.8% | 80.7% |
 | nomic-coderank | 45.0% | 67.9% | 78.9% |
 
-Branch (TBD): release/v1.35.0. Code change: `default = true` annotation moves from `bge_large` → `embeddinggemma_300m` in `define_embedder_presets!`. All four downstream constants update via the macro. Tests adjusted to derive expected default name from `ModelConfig::default_model().name`. README + CHANGELOG + Cargo.toml description refreshed.
+Existing slot indexes keep their stored model — only fresh slots / fresh `cqs index` runs pick up the new default. BGE-large remains a first-class preset (`CQS_EMBEDDING_MODEL=bge-large`).
+
+**Side fix (#1385): ONNX external-data sidecar.** EmbeddingGemma's >2GB FP32 weights live in `model.onnx_data` next to `model.onnx`. The downloader was only fetching the graph file, not the weights file. Without the sidecar, ORT init fails on a fresh runner with `cannot get file size: No such file or directory [.../onnx/model.onnx_data]`. Fix: after the existing model.onnx + tokenizer.json fetches, also try `<onnx_path>_data`; ignore 404 since most presets don't have one.
 
 **v1.34.0 released 2026-05-02 (same day as v1.33.0).** Bundled the post-v1.33.0 audit close-out (24 fix PRs) + pre-audit feature work (EmbeddingGemma-300m preset, `cqs eval --reranker`, slow-tests Phase 2, ci-slow.yml stabilization). On crates.io. Tag pushed (binaries via `release.yml`).
 

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -7,10 +7,16 @@
 //! here so new envelope additions are a single attribute import.
 //!
 //! Use as:
-//! ```ignore
+//! ```text
 //! #[serde(skip_serializing_if = "crate::serde_helpers::is_false")]
 //! pub flag: bool,
 //! ```
+//!
+//! `text` (not `ignore`) is deliberate: the snippet is a struct-field
+//! fragment, not a full program. `ignore` skips execution but is still
+//! handed to rustc when ci-slow.yml runs `cargo test -- --include-ignored`,
+//! which treats ignored doctests as runnable. `text` opts the block out of
+//! the doctest harness entirely.
 
 #[inline]
 pub fn is_false(v: &bool) -> bool {


### PR DESCRIPTION
## Summary

Closes #1387.

Fix the `serde_helpers.rs` doctest that broke ci-slow.yml.

## Root cause

The 2026-05-03 07:55 UTC overnight ci-slow run failed on the v1.35.0 release commit. Failure was in the `full-suite` job:

```
test src/serde_helpers.rs - serde_helpers (line 10) ... FAILED
error: visibility `pub` is not followed by an item
error: expected item after attributes
```

The doctest at `src/serde_helpers.rs:10-13` is a fragment showing how to use the helper:

```text
#[serde(skip_serializing_if = "crate::serde_helpers::is_false")]
pub flag: bool,
```

That's a struct *field*, not a complete program — rustc can't parse it standalone.

It was originally marked ` ```ignore ` to opt out of execution, but ci-slow.yml runs:

```yaml
- name: Run full test suite (incl. ignored)
  run: cargo test --release --verbose -- --include-ignored
```

The `--include-ignored` flag promotes ignored doctests to runnable, so rustc tries to compile the fragment and fails the parse.

## Fix

Switch ` ```ignore ` to ` ```text `. The `text` annotation tells rustdoc to render the block as styled text but never hand it to the compiler, regardless of `--include-ignored`. Added a comment block explaining the choice so future contributors don't revert it.

## Origin

`serde_helpers.rs` was added in #1368 (PR-time CI doesn't run `--include-ignored`, so the issue didn't surface until the next overnight ci-slow run).

## Test plan

- [ ] CI green (regular path)
- [ ] Manually trigger ci-slow.yml after merge to confirm full-suite passes — alternatively wait for the next 06:00 UTC cron
- [ ] Closes auto-filed #1387

🤖 Generated with [Claude Code](https://claude.com/claude-code)
