### PR TITLE
feat(embedder): qwen3-embedding-8b preset (research/ceiling-probe only)

### DIFF
--- a/src/embedder/models.rs
+++ b/src/embedder/models.rs
@@ -449,6 +449,55 @@ define_embedder_presets! {
         approx_download_bytes = Some(1_300 * 1024 * 1024),
         pad_id = 0,
         default = true;
+
+    /// Qwen3-Embedding-8B: 4096-dim, ~32K context, 8B params. **Research /
+    /// ceiling-probe preset, not production.** Use to measure the empirical
+    /// ceiling of v3.v2 dual-judge code-search when model-size isn't the
+    /// constraint. Don't ship as a default — 8B inference defeats the
+    /// local-embedder positioning on the 8GB consumer-RTX class. A6000-only
+    /// (the FP32 ONNX is ~30 GB).
+    ///
+    /// Architecture: Qwen3 decoder LLM with sentence-transformers-style
+    /// pooling. The community ONNX export from
+    /// `onnx-community/Qwen3-Embedding-8B-ONNX` exposes both
+    /// `token_embeddings` (3D `[batch, seq, 4096]`) and a pre-pooled
+    /// `sentence_embedding` (2D `[batch, 4096]`) — read the pre-pooled
+    /// output directly via `PoolingStrategy::Identity`, same approach as
+    /// the EmbeddingGemma preset. Two ONNX inputs only (`input_ids` +
+    /// `attention_mask`); no `token_type_ids`.
+    ///
+    /// Tokenizer: Qwen3 BPE, 151,665-token vocab, no `add_bos_token` and
+    /// `add_eos_token` is handled by the export — cqs's preset doesn't
+    /// need to splice EOS itself. Truncation: None (clean, no #1384-style
+    /// silent-cap bug). `pad_token = <|endoftext|>` = id 151643.
+    ///
+    /// Query prompt convention: Qwen3-Embedding uses natural-language
+    /// instructions (`Instruct: ...\nQuery: ...`) rather than the BGE
+    /// "Represent this sentence ..." or Gemma "task: search result | ..."
+    /// styles. Per the model card, the instruction is the lever — different
+    /// instructions specialize the same encoder for different retrieval
+    /// targets without retraining.
+    ///
+    /// Storage: 4096-dim float32 → ~16 KB per chunk embedding. The cqs
+    /// corpus at ~19,500 chunks = ~312 MB of vectors before HNSW overhead.
+    /// Doable on the A6000 but ~4× the vector storage of BGE-large at 1024
+    /// dim. MRL (Matryoshka Representation Learning) truncation to 1024-dim
+    /// for storage parity is a future option but cqs's current pipeline
+    /// returns whatever the model produces.
+    qwen3_embedding_8b => name = "qwen3-embedding-8b", repo = "onnx-community/Qwen3-Embedding-8B-ONNX",
+        onnx_path = "model.onnx", tokenizer_path = "tokenizer.json",
+        dim = 4096, max_seq_length = 8192,
+        query_prefix = "Instruct: Find the code chunk that best matches the query.\nQuery: ", doc_prefix = "",
+        input_names = InputNames::bert_no_token_types(),
+        output_name = "sentence_embedding".to_string(),
+        pooling = PoolingStrategy::Identity,
+        // FP32 ONNX bundle: ~2 MB graph + ~30.27 GB external-data
+        // weights file at `model.onnx_data`. Plus ~14 MB tokenizer/vocab.
+        // External-data sidecar download is handled by the
+        // `<onnx_path>_data` fetch in `download_model_files` (added in
+        // PR #1385 alongside the gemma swap).
+        approx_download_bytes = Some(30_300 * 1024 * 1024),
+        pad_id = 151643;
 }
 
 impl ModelConfig {


### PR DESCRIPTION
## Summary

Add `qwen3-embedding-8b` as an opt-in research preset. This was the v1.35.0+ roadmap's planned ceiling probe — measure the practical R@K ceiling of v3.v2 dual-judge code-search at the strongest-available model size.

The 2026-05-03 ceiling-probe attempt did not yield a clean R@K number — host RAM was the binding constraint on the 96 GB / 48 GB-VRAM workstation. Full write-up at `~/training-data/research/models.md` (the 'Qwen3-Embedding-8B ceiling probe — infrastructure-bound on this rig (2026-05-03)' section).

Shipping the preset anyway:
- Single-row addition, no maintenance burden
- An operator with a bigger rig (or after #1392 lands a `CQS_DISABLE_CPU_WARM` env var) can use it without re-doing the architecture probe
- Doc-comment on the preset captures the trade-offs (research-only, A6000-class only, FP32 only)

## Configuration

| Field | Value |
|---|---|
| `name` | `qwen3-embedding-8b` |
| `repo` | `onnx-community/Qwen3-Embedding-8B-ONNX` |
| `onnx_path` | `model.onnx` (root, not `onnx/`) |
| `tokenizer_path` | `tokenizer.json` (root) |
| `dim` | 4096 |
| `max_seq_length` | 8192 (Qwen3 supports 32K but cqs chunks are short) |
| `pooling` | `Identity` (consume the export's pre-pooled `sentence_embedding` output, not the 3D `token_embeddings`) |
| `input_names` | `bert_no_token_types()` (input_ids + attention_mask only) |
| `pad_id` | 151643 (= `<\|endoftext\|>`) |
| `query_prefix` | `"Instruct: Find the code chunk that best matches the query.\nQuery: "` (Qwen3's NL-instruction convention) |
| `doc_prefix` | empty |
| `approx_download_bytes` | ~30,300 MB (FP32 ONNX `.onnx_data` sidecar dominates) |

## Test plan

- [ ] Compiles (touched single preset row + macro registration)
- [ ] `cargo test --features cuda-index --lib embedder::models` — preset count + roundtrip tests cover the new entry automatically
- [ ] Acknowledged: not a "ceiling" close-out PR — that's parked at #1392
