### PR TITLE
fix(embedding): scale GPU-vs-CPU char threshold by max_seq_length

### DIFF
--- a/src/cli/pipeline/embedding.rs
+++ b/src/cli/pipeline/embedding.rs
@@ -309,8 +309,8 @@ pub(super) fn gpu_embed_stage(
         // Without this scale, every windowed Qwen3 chunk (~28k chars at
         // 8k tokens) would route to CPU, defeating CQS_DISABLE_CPU_WARM
         // and causing memory pressure on host RAM during 8B-model runs.
-        let max_chars_threshold = 8000usize
-            .saturating_mul(embedder.model_config().max_seq_length.max(512) / 512);
+        let max_chars_threshold =
+            8000usize.saturating_mul(embedder.model_config().max_seq_length.max(512) / 512);
         if max_len > max_chars_threshold {
             tracing::warn!(
                 chunks = prepared.to_embed.len(),

--- a/src/cli/pipeline/embedding.rs
+++ b/src/cli/pipeline/embedding.rs
@@ -288,11 +288,34 @@ pub(super) fn gpu_embed_stage(
             "embed_batch start"
         );
 
-        // Pre-filter long batches to CPU (GPU hits CUDNN limits >8k chars)
-        if max_len > 8000 {
+        // Pre-filter long batches to CPU (GPU hits CUDNN limits at high
+        // token counts on older CUDNN versions). Threshold is scaled by
+        // the model's `max_seq_length` so the routing decision tracks the
+        // actual constraint:
+        //
+        //   8000 chars × (max_seq_length / 512)
+        //
+        // The "8000 chars" baseline was calibrated for BERT-class models
+        // (BGE, E5: 512-token max_seq, ~3.5–4 chars/token English). When
+        // windowing produces a 512-token chunk it's typically <8000 chars,
+        // so the threshold rarely fires for those presets — preserved as
+        // a defensive cap on accidental >max_seq inputs.
+        //
+        // For larger-context models (Gemma 2K, Qwen3-8B 8K) windowing
+        // legitimately produces longer post-windowed chunks. The scale
+        // factor matches the windowing bound: a chunk that fits within
+        // `max_seq_length` tokens has at most `max_seq_length × 16` chars
+        // for any common tokenizer (BPE / WordPiece / SentencePiece).
+        // Without this scale, every windowed Qwen3 chunk (~28k chars at
+        // 8k tokens) would route to CPU, defeating CQS_DISABLE_CPU_WARM
+        // and causing memory pressure on host RAM during 8B-model runs.
+        let max_chars_threshold = 8000usize
+            .saturating_mul(embedder.model_config().max_seq_length.max(512) / 512);
+        if max_len > max_chars_threshold {
             tracing::warn!(
                 chunks = prepared.to_embed.len(),
                 max_len,
+                threshold = max_chars_threshold,
                 "Routing long batch to CPU (GPU CUDNN limit)"
             );
             if !flush_to_cpu(prepared, &embed_tx, &fail_tx, &ctx.embedded_count) {


### PR DESCRIPTION
## Summary

Scale the "GPU CUDNN limit" routing threshold in `embed_batch` by `max_seq_length / 512`. The 8000-char baseline was right for BERT-class 512-token models; it was wrong for larger-context presets (Gemma 2K, Qwen3-8B 8K) where windowing legitimately produces post-windowed chunks that exceed 8000 chars while staying within the model's design envelope.

Closes the immediate symptom from the 2026-05-03 Qwen3-Embedding-8B ceiling probe — see `~/training-data/research/models.md`. #1395 tracks the proper redesign (route on token count, not char count).

## Diff

```rust
// before
if max_len > 8000 { /* route to CPU */ }

// after
let max_chars_threshold = 8000usize
    .saturating_mul(embedder.model_config().max_seq_length.max(512) / 512);
if max_len > max_chars_threshold { /* route to CPU */ }
```

| Preset | max_seq_length | Old threshold | New threshold |
|---|---:|---:|---:|
| BGE / E5 | 512 | 8000 | 8000 (unchanged) |
| Gemma | 2048 | 8000 | 32000 |
| Qwen3-8B | 8192 | 8000 | 128000 |

The 16x scale factor is the chars-per-token upper bound for any common tokenizer (BPE, WordPiece, SentencePiece) on whitespace-heavy English. Post-windowed chunks fit under the threshold across all production presets.

## Empirical validation

Same Qwen3-Embedding-8B reindex, before and after:

| Metric | Pre-fix (char-only) | Post-fix (scaled) |
|---|---:|---:|
| Routings in first ~2 min | 66 | 0 (then 2 genuine GPU OOMs) |
| Peak RSS | 91 GB / 94 GB usable | 31 GB / 94 GB |
| Outcome | killed at brink | sustained progress |
| GPU throughput | mostly idle (everything routed) | ~1.2s/batch |

`CQS_DISABLE_CPU_WARM` (#1394) now has its intended effect for 8K-context presets — without this scaling, char-routing kept dragging CPU into the picture and defeating it.

## Test plan

- [x] `cargo check --features cuda-index` — compiles
- [x] Live validation: Qwen3-8B reindex behaves as described in the table above
- [ ] CI green
- [ ] After merge: re-attempt the Qwen3-8B ceiling probe end-to-end with `CQS_DISABLE_CPU_WARM=1 CQS_DISABLE_TENSORRT=1`

## Related

- Follows #1394 (`CQS_DISABLE_CPU_WARM` env var) — that knob's effectiveness was masked by this miscalibration.
- #1395 — proper long-term fix (token-count routing or drop the branch entirely).
- Surfaced from `~/training-data/research/models.md` Qwen3-Embedding-8B section.
