### PR TITLE
fix(embedding): drop redundant pre-filter routing (closes #1395)

### DIFF
--- a/src/cli/pipeline/embedding.rs
+++ b/src/cli/pipeline/embedding.rs
@@ -288,41 +288,17 @@ pub(super) fn gpu_embed_stage(
             "embed_batch start"
         );
 
-        // Pre-filter long batches to CPU (GPU hits CUDNN limits at high
-        // token counts on older CUDNN versions). Threshold is scaled by
-        // the model's `max_seq_length` so the routing decision tracks the
-        // actual constraint:
-        //
-        //   8000 chars × (max_seq_length / 512)
-        //
-        // The "8000 chars" baseline was calibrated for BERT-class models
-        // (BGE, E5: 512-token max_seq, ~3.5–4 chars/token English). When
-        // windowing produces a 512-token chunk it's typically <8000 chars,
-        // so the threshold rarely fires for those presets — preserved as
-        // a defensive cap on accidental >max_seq inputs.
-        //
-        // For larger-context models (Gemma 2K, Qwen3-8B 8K) windowing
-        // legitimately produces longer post-windowed chunks. The scale
-        // factor matches the windowing bound: a chunk that fits within
-        // `max_seq_length` tokens has at most `max_seq_length × 16` chars
-        // for any common tokenizer (BPE / WordPiece / SentencePiece).
-        // Without this scale, every windowed Qwen3 chunk (~28k chars at
-        // 8k tokens) would route to CPU, defeating CQS_DISABLE_CPU_WARM
-        // and causing memory pressure on host RAM during 8B-model runs.
-        let max_chars_threshold =
-            8000usize.saturating_mul(embedder.model_config().max_seq_length.max(512) / 512);
-        if max_len > max_chars_threshold {
-            tracing::warn!(
-                chunks = prepared.to_embed.len(),
-                max_len,
-                threshold = max_chars_threshold,
-                "Routing long batch to CPU (GPU CUDNN limit)"
-            );
-            if !flush_to_cpu(prepared, &embed_tx, &fail_tx, &ctx.embedded_count) {
-                break;
-            }
-            continue;
-        }
+        // Note: the previous "Pre-filter long batches to CPU (GPU CUDNN
+        // limit)" pre-flight check was removed in #1395. Both
+        // `apply_windowing` (`src/cli/pipeline/windowing.rs`) and
+        // `generate_nl_description_with_seq_len` already bound chunk text
+        // to `model_max_seq_length` tokens, so the pre-filter was firing
+        // on inputs the model could correctly handle — calibrated for
+        // BERT-class 512-token models, it false-positive'd nearly every
+        // windowed chunk on Gemma 2K and Qwen3-8B 8K presets and
+        // defeated `CQS_DISABLE_CPU_WARM` (#1392). Genuine GPU failures
+        // (CUDNN seq-len limits, OOM, etc.) still route to CPU via the
+        // existing `fail_tx` path inside `embed_documents` below.
 
         let text_refs: Vec<&str> = prepared.texts.iter().map(|s| s.as_str()).collect();
         let embed_start = std::time::Instant::now();


### PR DESCRIPTION
## Summary

Closes #1395.

Drop the "Routing long batch to CPU (GPU CUDNN limit)" pre-filter in `embed_batch`. The check is redundant: both `apply_windowing` and `generate_nl_description_with_seq_len` already bound chunk text to `model_max_seq_length` tokens before the routing decision is made.

## Why this is the right fix

#1396 (just merged) scaled the char-count threshold by `max_seq_length / 512` to silence false positives surfaced by the qwen3-8b probe. That stopped the immediate symptom but left the design wrong:

- **Char count is wildly miscalibrated across tokenizers.** BERT WordPiece: ~3.5 chars/token. Gemma SentencePiece: ~3. Qwen3 BPE: ~3.5. Whitespace-heavy English: ~16. Even with the scale factor, the heuristic only approximates the actual constraint.
- **Token count would be the correct metric** — but `apply_windowing` already enforces `token_count ≤ max_seq_length`. A token-count pre-filter at the same site would be checking what windowing already guaranteed.
- **Genuine GPU failures still route to CPU** via the existing `fail_tx` path inside `embed_documents` below. The qwen3-8b probe demonstrated this works: 2 actual GPU OOMs got routed cleanly during a partial run.

So the pre-filter is either dead code (when windowing works) or false-positive routing (when its heuristic disagrees with windowing). Removing it fixes both modes.

## Diff

The `(max_len, total_chars)` fold and the `tracing::debug!("embed_batch start")` call stay — they're useful breadcrumbs in batch-shape diagnostics and the fold is cheap. The `if max_len > threshold { flush_to_cpu... }` block is gone, replaced by a comment explaining why.

Net: -35 / +11 lines.

## Test plan

- [x] `cargo check --features cuda-index` — compiles
- [x] `cargo fmt && cargo clippy --features cuda-index --lib -- -D warnings` — clean
- [ ] CI green
- [ ] Live: GPU embedding still works on regular workloads (will validate in next reindex)
- [ ] Live: qwen3-8b ceiling probe still routes legitimate GPU OOMs to CPU via fail_tx (already verified pre-merge)

## Related

- Follows #1396 (interim threshold scaling)
- Follows #1394 (`CQS_DISABLE_CPU_WARM`) — both motivated by the same probe failure
- Surfaced from `~/training-data/research/models.md` Qwen3-Embedding-8B section
