### PR TITLE
docs(cli): clarify --slot is rejected on slot/cache subcommands (#1365)

### DIFF
--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -283,6 +283,15 @@ pub struct Cli {
     /// `.cqs/slots/<name>/`. Default behaviour is to read the active slot
     /// from `.cqs/active_slot` (falls back to `default`). Spec:
     /// `docs/plans/2026-04-24-embeddings-cache-and-slots.md`.
+    ///
+    /// **Ignored (and rejected at runtime) on `cqs slot` and `cqs cache`
+    /// subcommands** — those manage slots and the cache themselves, so
+    /// scoping them to a slot is incoherent. Use the explicit
+    /// `<subcommand> <name>` argument instead (e.g. `cqs slot remove
+    /// <name>`, `cqs cache stats <name>`). Audit P3-27 / #1365: clap-derive
+    /// can't suppress a `global = true` arg per subcommand, so the
+    /// runtime bails in `cli/commands/infra/slot.rs` and
+    /// `cli/commands/infra/cache_cmd.rs`.
     #[arg(long, global = true)]
     pub slot: Option<String>,
 


### PR DESCRIPTION
## Summary

Closes #1365.

Update the doc comment on `Cli::slot` to mention the runtime rejection on `cqs slot` and `cqs cache` subcommands, so `--help` rendering carries the warning even though clap-derive can't actually hide the global per-subcommand.

## Why option (b) and not option (a)

The issue listed three paths:

- **(a) Imperative override** at parse time: `cmd.mut_subcommand("slot", |sub| sub.mut_arg("slot", |a| a.hide(true)))`.
- **(b) Doc comment** on the global flag.
- **(c) Demote the global**, plumb `--slot` per-subcommand.

I tried (a). It compiles but panics at runtime with `"Argument `slot` is undefined"` from `clap_builder-4.6.0/src/builder/command.rs:252`. The reason: globals are added at *parse time*, not at *definition time*. When `mut_arg("slot", ...)` runs on the subcommand, the global hasn't propagated yet — there's no `slot` arg on the subcommand to mutate.

clap 4's derive macro has no clean way to suppress a global per subcommand. The path forward would be (c) — remove `global = true`, add `--slot` to every project-scoped command individually, plumb through `CommandContext`. That's a 20+ command refactor and lower priority than the doc fix.

So this PR is option (b): the smallest change. Flag is still listed under `cqs slot list --help`, but the description tells the operator what happens at runtime.

## Diff

A single doc-comment paragraph appended to `Cli::slot`. Net: +9 lines.

## Test plan

- [x] `cargo check --features cuda-index` — compiles
- [x] `cargo fmt` — clean
- [ ] CI green
- [ ] Operator running `cqs slot list --help` sees the rejection notice

## Related

Issue #1365 leaves the structural option (c) open. If the runtime bail becomes a real operator footgun, revisit and demote the global.
