### PR TITLE
fix(security): sanitize terminal control sequences from chunk content (closes #1341)

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ Each split is ±2-3pp noisy on a single trial; quote both when comparing config 
 
 Quick index by domain (everything is searchable in the table below):
 
-- **Trust / injection defence** — `CQS_TRUST_DELIMITERS`, `CQS_SUMMARY_VALIDATION`
+- **Trust / injection defence** — `CQS_TRUST_DELIMITERS`, `CQS_SUMMARY_VALIDATION`, `CQS_NO_ANSI_STRIP`
 - **Retrieval & search** — `CQS_RRF_K`, `CQS_TYPE_BOOST`, `CQS_SPLADE_ALPHA*`, `CQS_RERANK*`, `CQS_RERANKER_*`, `CQS_CENTROID_*`, `CQS_MMR_LAMBDA`, `CQS_FORCE_BASE_INDEX`, `CQS_DISABLE_BASE_INDEX`, `CQS_QUERY_CACHE_*`
 - **Indexing & embedding** — `CQS_EMBEDDING_*`, `CQS_EMBED_*`, `CQS_ONNX_DIR`, `CQS_HNSW_*`, `CQS_CAGRA_*`, `CQS_TRT_ENGINE_CACHE`, `CQS_DISABLE_TENSORRT`, `CQS_DISABLE_CPU_WARM`, `CQS_SPARSE_CHUNKS_PER_TX`, `CQS_SPLADE_BATCH/MAX_*/MODEL/THRESHOLD/RESET_EVERY`, `CQS_PARSER_MAX_*`, `CQS_PARSE_CHANNEL_DEPTH`, `CQS_FILE_BATCH_SIZE`, `CQS_DEFERRED_FLUSH_INTERVAL`, `CQS_FTS_NORMALIZE_MAX`, `CQS_MAX_FILE_SIZE`, `CQS_MAX_QUERY_BYTES`, `CQS_MAX_SEQ_LENGTH`, `CQS_MAX_CONTRASTIVE_CHUNKS`, `CQS_MD_*`, `CQS_SKIP_ENRICHMENT`, `CQS_HYDE_MAX_TOKENS`, `CQS_RAYON_THREADS`
 - **Daemon, watch, batch** — `CQS_NO_DAEMON`, `CQS_DAEMON_*`, `CQS_MAX_DAEMON_CLIENTS`, `CQS_BATCH_*IDLE_MINUTES`, `CQS_REFS_LRU_SIZE`, `CQS_WATCH_*`, `CQS_CHAT_HISTORY`
@@ -837,6 +837,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_MD_MIN_SECTION_LINES` | `30` | Min markdown section lines (smaller sections merge) |
 | `CQS_MIGRATE_REQUIRE_BACKUP` | `1` | Migration-time DB backup is required by default; a backup failure aborts the migration with `StoreError::Io` so the destructive v18→v19 rebuild never runs without a recovery snapshot. Set to `0` to downgrade to a `warn!` and proceed without a snapshot (accept data-loss risk on a subsequent commit failure). |
 | `CQS_MMAP_SIZE` | `268435456` (256 MB) | SQLite memory-mapped I/O size |
+| `CQS_NO_ANSI_STRIP` | (none) | Set to `1` to disable terminal-control sanitization on chunk content. By default `cqs` (text mode) replaces ESC / DEL / C0+C1 control bytes from chunk-derived strings before `println!` to defend against ANSI / OSC 8 / DCS payloads embedded in the indexed corpus or a poisoned reference index — the shell-version of indirect-prompt-injection. Tab / LF / CR are preserved so source layout still renders. Opt out when displaying chunks of code whose own string literals legitimately contain escape sequences being analyzed. SEC-V1.33-5 / #1341. |
 | `CQS_NO_DAEMON` | (none) | Set to `1` to force CLI mode (skip daemon connection attempt) |
 | `CQS_ONNX_DIR` | (auto) | Custom ONNX model directory (must contain `model.onnx` + `tokenizer.json`) |
 | `CQS_PARSE_CHANNEL_DEPTH` | `512` | Parse pipeline channel depth |

--- a/src/cli/commands/graph/explain.rs
+++ b/src/cli/commands/graph/explain.rs
@@ -405,7 +405,10 @@ fn print_explain_terminal(data: &ExplainData, root: &Path) {
     if data.include_target_content {
         println!();
         println!("{}", "\u{2500}".repeat(50));
-        println!("{}", chunk.content);
+        println!(
+            "{}",
+            crate::cli::display::sanitize_for_terminal(&chunk.content)
+        );
     }
 
     if !data.callers.is_empty() {
@@ -438,7 +441,10 @@ fn print_explain_terminal(data: &ExplainData, root: &Path) {
             if let Some(ref set) = data.similar_content_ids {
                 if set.contains(&r.chunk.id) {
                     println!("{}", "\u{2500}".repeat(40));
-                    println!("{}", r.chunk.content);
+                    println!(
+                        "{}",
+                        crate::cli::display::sanitize_for_terminal(&r.chunk.content)
+                    );
                 }
             }
         }

--- a/src/cli/commands/io/context.rs
+++ b/src/cli/commands/io/context.rs
@@ -614,7 +614,7 @@ fn print_full_terminal(
         if let Some(included) = content_set {
             if included.contains(&c.name) {
                 println!("{}", "\u{2500}".repeat(50));
-                println!("{}", c.content);
+                println!("{}", crate::cli::display::sanitize_for_terminal(&c.content));
                 println!();
             }
         }

--- a/src/cli/commands/search/scout.rs
+++ b/src/cli/commands/search/scout.rs
@@ -127,7 +127,7 @@ pub(crate) fn cmd_scout(
                     if let Some(ref cmap) = content_map {
                         if let Some(content) = cmap.get(&chunk.name) {
                             println!("{}", "\u{2500}".repeat(50));
-                            println!("{}", content);
+                            println!("{}", crate::cli::display::sanitize_for_terminal(content));
                             println!();
                         }
                     }

--- a/src/cli/display.rs
+++ b/src/cli/display.rs
@@ -9,6 +9,135 @@ use colored::Colorize;
 use cqs::reference::TaggedResult;
 use cqs::store::{ParentContext, UnifiedResult};
 
+/// Strip terminal control sequences from chunk-derived strings before
+/// printing them to a TTY.
+///
+/// SEC-V1.33-5 (#1341): every CLI text-mode path that surfaces a chunk
+/// feeds content directly to `println!`. A malicious file in the indexed
+/// corpus (or a poisoned reference index — explicitly listed as a
+/// "semi-trusted" surface in `SECURITY.md`) can embed:
+///
+/// - ANSI cursor / line-clear codes that overwrite previous terminal
+///   output (forging "OK" status lines)
+/// - OSC 8 hyperlinks that render as innocent text but click through to
+///   attacker-chosen destinations
+/// - iTerm2 / kitty / wezterm proprietary escapes that read clipboard
+///   or execute commands in some configurations
+/// - DCS sequences interpreted as commands by some terminals
+///
+/// `SECURITY.md` flags indexed content as "Untrusted (in AI agent
+/// context)" — but the interactive CLI user is also a terminal, and so
+/// is the agent's terminal when cqs runs through Claude Code. This
+/// helper is the shell-version of indirect-prompt-injection mitigation.
+///
+/// Strategy: replace ESC (`\x1b`), DEL (`\x7f`), and most C0/C1 control
+/// chars with `'?'`. Preserves `\t` / `\n` / `\r` so source-code layout
+/// still renders. Using `'?'` (rather than dropping) keeps the byte
+/// budget identical, which preserves column alignment in fancy
+/// displays.
+///
+/// **Opt-out via `CQS_NO_ANSI_STRIP=1`** for terminals where the user
+/// trusts their corpus and wants escape passthrough (e.g., displaying
+/// chunks of code whose own string literals legitimately contain
+/// escape sequences being analyzed).
+///
+/// Returns the input unchanged when no candidate byte is present,
+/// avoiding allocation on every clean chunk.
+pub fn sanitize_for_terminal(s: &str) -> std::borrow::Cow<'_, str> {
+    if std::env::var("CQS_NO_ANSI_STRIP")
+        .is_ok_and(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+    {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    if !s.bytes().any(|b| {
+        b == 0x1b
+            || (b < 0x20 && b != b'\t' && b != b'\n' && b != b'\r')
+            || b == 0x7f
+            || (0x80..=0x9f).contains(&b)
+    }) {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c as u32 {
+            0x1b => out.push('?'), // ESC — kills all CSI / OSC / DCS introducers
+            0x00..=0x08 => out.push('?'),
+            0x0b | 0x0c => out.push('?'), // VT / FF
+            0x0e..=0x1a => out.push('?'),
+            0x1c..=0x1f => out.push('?'),
+            0x7f => out.push('?'),        // DEL
+            0x80..=0x9f => out.push('?'), // C1 controls
+            _ => out.push(c),
+        }
+    }
+    std::borrow::Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod sanitize_tests {
+    use super::sanitize_for_terminal;
+
+    #[test]
+    fn passes_clean_text_unchanged() {
+        let s = "fn foo() {\n    bar();\n}\t// trailing tab\n";
+        // Borrowed Cow proves we didn't allocate.
+        assert!(matches!(
+            sanitize_for_terminal(s),
+            std::borrow::Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn strips_ansi_csi() {
+        let s = "before\x1b[31mred\x1b[0mafter";
+        assert_eq!(sanitize_for_terminal(s).as_ref(), "before?[31mred?[0mafter");
+    }
+
+    #[test]
+    fn strips_osc8_hyperlink() {
+        let s = "\x1b]8;;file:///etc/passwd\x1b\\benign\x1b]8;;\x1b\\";
+        let out = sanitize_for_terminal(s).into_owned();
+        // Both ESC bytes replaced so the terminal doesn't interpret OSC 8;
+        // the URL text is preserved as plain text (audit-visible).
+        assert!(!out.contains('\x1b'));
+        assert!(out.contains("file:///etc/passwd"));
+    }
+
+    #[test]
+    fn preserves_tab_lf_cr() {
+        let s = "a\tb\nc\rd";
+        assert_eq!(sanitize_for_terminal(s).as_ref(), s);
+    }
+
+    #[test]
+    fn strips_c1_controls() {
+        let s = "before\u{0085}NEL\u{009b}CSIafter";
+        let out = sanitize_for_terminal(s).into_owned();
+        assert!(!out.contains('\u{0085}'));
+        assert!(!out.contains('\u{009b}'));
+    }
+
+    #[test]
+    fn strips_del() {
+        let s = "before\x7fDELafter";
+        assert_eq!(sanitize_for_terminal(s).as_ref(), "before?DELafter");
+    }
+
+    #[test]
+    fn opt_out_via_env() {
+        // SAFETY: this test mutates a process-global env var and is intentionally
+        // not parallel-safe; full test run uses --test-threads=1 already.
+        let prev = std::env::var("CQS_NO_ANSI_STRIP").ok();
+        std::env::set_var("CQS_NO_ANSI_STRIP", "1");
+        let s = "before\x1b[31mred\x1b[0mafter";
+        assert_eq!(sanitize_for_terminal(s).as_ref(), s);
+        match prev {
+            Some(v) => std::env::set_var("CQS_NO_ANSI_STRIP", v),
+            None => std::env::remove_var("CQS_NO_ANSI_STRIP"),
+        }
+    }
+}
+
 /// Read context lines before and after a range in a file
 /// # Arguments
 /// * `line_start` - 1-indexed start line (0 treated as 1)
@@ -169,10 +298,10 @@ pub fn display_unified_results(
 
                     // Show signature or truncated content
                     if r.chunk.content.lines().count() <= 10 {
-                        println!("{}", r.chunk.content);
+                        println!("{}", sanitize_for_terminal(&r.chunk.content));
                     } else {
                         for line in r.chunk.content.lines().take(8) {
-                            println!("{}", line);
+                            println!("{}", sanitize_for_terminal(line));
                         }
                         println!("    ...");
                     }
@@ -338,10 +467,10 @@ pub fn display_tagged_results(
                     }
 
                     if r.chunk.content.lines().count() <= 10 {
-                        println!("{}", r.chunk.content);
+                        println!("{}", sanitize_for_terminal(&r.chunk.content));
                     } else {
                         for line in r.chunk.content.lines().take(8) {
-                            println!("{}", line);
+                            println!("{}", sanitize_for_terminal(line));
                         }
                         println!("    ...");
                     }


### PR DESCRIPTION
## Summary

Closes #1341 (SEC-V1.33-5).

Sanitize terminal control sequences from chunk-derived strings before `println!` to defend against ANSI / OSC 8 / DCS payloads embedded in the indexed corpus or a poisoned reference index.

## Threat model

`SECURITY.md` flags indexed content as "Untrusted (in AI agent context)" but the interactive CLI user is also a terminal — and so is the agent's terminal when cqs runs through Claude Code. A malicious file in the corpus can embed:

- ANSI cursor / line-clear codes that overwrite previous terminal output (forge "OK" status lines)
- OSC 8 hyperlinks that render as innocent text but click through to attacker-chosen destinations
- iTerm2 / kitty / wezterm proprietary escapes that read clipboard or execute commands in some configurations
- DCS sequences interpreted as commands by some terminals
- Terminal-bell spam, screen reflow, etc.

This is the shell-version of indirect prompt injection.

## Fix

Add `display::sanitize_for_terminal(&str) -> Cow<'_, str>`:

```rust
pub fn sanitize_for_terminal(s: &str) -> Cow<'_, str>
```

Replaces ESC, DEL, and most C0/C1 control bytes with `'?'`. Preserves `\t` / `\n` / `\r` so source-code layout still renders. Returns the input unchanged when no candidate byte is present (Borrowed Cow), avoiding allocation on every clean chunk.

Apply at all six chunk-content `println!` sites identified in the audit:
- `src/cli/display.rs:303, 472` (full content + line-by-line truncated)
- `src/cli/commands/graph/explain.rs:408, 444`
- `src/cli/commands/io/context.rs:617`
- `src/cli/commands/search/scout.rs:130`

## Opt-out

`CQS_NO_ANSI_STRIP=1` (also accepts `true|yes|on`) for terminals where the user trusts the corpus and wants escape passthrough — e.g., displaying chunks of code whose own string literals legitimately contain escape sequences being analyzed.

Documented in the README env-var table under "Trust / injection defence".

## Test plan

- [x] 7 new unit tests covering: clean-text passthrough (Borrowed Cow proof), ANSI CSI strip, OSC 8 hyperlink defang, tab/LF/CR preservation, C1 control strip, DEL strip, env-var opt-out
- [x] `cargo test --bin cqs sanitize_tests` — 7 pass
- [x] `cargo test --test env_var_docs` — passes (new env var documented)
- [ ] CI green
- [ ] Manually exercise `cqs search` against a chunk containing OSC 8 — verify the URL renders as plain text, not a clickable hyperlink

## Notes

The audit listed `src/cli/commands/search/scout.rs:130` in addition to the four sites above — applied there too. The audit missed the line-by-line truncated print at `src/cli/display.rs:307` in the long-chunk branch (`for line in r.chunk.content.lines().take(8)`); also wrapped that one.

Why `'?'` instead of dropping the byte: keeps the byte budget identical so column alignment in fancy displays (sigil columns, prefix dimming) doesn't shift.
