### PR TITLE
fix(security): warn + fall-through on suspicious HF cache env paths (closes #1339)

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ Each split is ±2-3pp noisy on a single trial; quote both when comparing config 
 
 Quick index by domain (everything is searchable in the table below):
 
-- **Trust / injection defence** — `CQS_TRUST_DELIMITERS`, `CQS_SUMMARY_VALIDATION`, `CQS_NO_ANSI_STRIP`
+- **Trust / injection defence** — `CQS_TRUST_DELIMITERS`, `CQS_SUMMARY_VALIDATION`, `CQS_NO_ANSI_STRIP`, `CQS_HF_CACHE_TRUSTED`
 - **Retrieval & search** — `CQS_RRF_K`, `CQS_TYPE_BOOST`, `CQS_SPLADE_ALPHA*`, `CQS_RERANK*`, `CQS_RERANKER_*`, `CQS_CENTROID_*`, `CQS_MMR_LAMBDA`, `CQS_FORCE_BASE_INDEX`, `CQS_DISABLE_BASE_INDEX`, `CQS_QUERY_CACHE_*`
 - **Indexing & embedding** — `CQS_EMBEDDING_*`, `CQS_EMBED_*`, `CQS_ONNX_DIR`, `CQS_HNSW_*`, `CQS_CAGRA_*`, `CQS_TRT_ENGINE_CACHE`, `CQS_DISABLE_TENSORRT`, `CQS_DISABLE_CPU_WARM`, `CQS_SPARSE_CHUNKS_PER_TX`, `CQS_SPLADE_BATCH/MAX_*/MODEL/THRESHOLD/RESET_EVERY`, `CQS_PARSER_MAX_*`, `CQS_PARSE_CHANNEL_DEPTH`, `CQS_FILE_BATCH_SIZE`, `CQS_DEFERRED_FLUSH_INTERVAL`, `CQS_FTS_NORMALIZE_MAX`, `CQS_MAX_FILE_SIZE`, `CQS_MAX_QUERY_BYTES`, `CQS_MAX_SEQ_LENGTH`, `CQS_MAX_CONTRASTIVE_CHUNKS`, `CQS_MD_*`, `CQS_SKIP_ENRICHMENT`, `CQS_HYDE_MAX_TOKENS`, `CQS_RAYON_THREADS`
 - **Daemon, watch, batch** — `CQS_NO_DAEMON`, `CQS_DAEMON_*`, `CQS_MAX_DAEMON_CLIENTS`, `CQS_BATCH_*IDLE_MINUTES`, `CQS_REFS_LRU_SIZE`, `CQS_WATCH_*`, `CQS_CHAT_HISTORY`
@@ -836,6 +836,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_MD_MAX_SECTION_LINES` | `150` | Max markdown section lines before overflow split |
 | `CQS_MD_MIN_SECTION_LINES` | `30` | Min markdown section lines (smaller sections merge) |
 | `CQS_MIGRATE_REQUIRE_BACKUP` | `1` | Migration-time DB backup is required by default; a backup failure aborts the migration with `StoreError::Io` so the destructive v18→v19 rebuild never runs without a recovery snapshot. Set to `0` to downgrade to a `warn!` and proceed without a snapshot (accept data-loss risk on a subsequent commit failure). |
+| `CQS_HF_CACHE_TRUSTED` | (none) | Set to `1` to opt into env-supplied HF cache paths (`HF_HOME` / `HUGGINGFACE_HUB_CACHE`) that would otherwise be flagged as suspicious — under `/tmp`, `/var/tmp`, `/dev/shm`, `~/Downloads`, `~/Desktop`, or outside both `$HOME` and the system cache dir. Without this, suspicious paths get a `tracing::warn!` and the loader falls through to the default cache so a hostile env var can't redirect ONNX model loads. SEC-V1.33-8 / #1339. |
 | `CQS_MMAP_SIZE` | `268435456` (256 MB) | SQLite memory-mapped I/O size |
 | `CQS_NO_ANSI_STRIP` | (none) | Set to `1` to disable terminal-control sanitization on chunk content. By default `cqs` (text mode) replaces ESC / DEL / C0+C1 control bytes from chunk-derived strings before `println!` to defend against ANSI / OSC 8 / DCS payloads embedded in the indexed corpus or a poisoned reference index — the shell-version of indirect-prompt-injection. Tab / LF / CR are preserved so source layout still renders. Opt out when displaying chunks of code whose own string literals legitimately contain escape sequences being analyzed. SEC-V1.33-5 / #1341. |
 | `CQS_NO_DAEMON` | (none) | Set to `1` to force CLI mode (skip daemon connection attempt) |

--- a/src/aux_model.rs
+++ b/src/aux_model.rs
@@ -54,13 +54,37 @@ pub fn hf_cache_dir(subdir: &str) -> PathBuf {
     if subdir == "hub" {
         if let Ok(p) = std::env::var("HUGGINGFACE_HUB_CACHE") {
             if !p.is_empty() {
-                return PathBuf::from(p);
+                let path = PathBuf::from(&p);
+                if let Some(reason) = is_suspicious_cache_path(&path) {
+                    tracing::warn!(
+                        env = "HUGGINGFACE_HUB_CACHE",
+                        path = %p,
+                        reason,
+                        "Suspicious HF cache path from env var — falling back to default. \
+                         Set CQS_HF_CACHE_TRUSTED=1 to opt into the env-supplied path. \
+                         SEC-V1.33-8 / #1339"
+                    );
+                } else {
+                    return path;
+                }
             }
         }
     }
     if let Ok(p) = std::env::var("HF_HOME") {
         if !p.is_empty() {
-            return PathBuf::from(p).join(subdir);
+            let path = PathBuf::from(&p);
+            if let Some(reason) = is_suspicious_cache_path(&path) {
+                tracing::warn!(
+                    env = "HF_HOME",
+                    path = %p,
+                    reason,
+                    "Suspicious HF cache path from env var — falling back to default. \
+                     Set CQS_HF_CACHE_TRUSTED=1 to opt into the env-supplied path. \
+                     SEC-V1.33-8 / #1339"
+                );
+            } else {
+                return path.join(subdir);
+            }
         }
     }
     // PB-V1.33-6: split `.cache/huggingface` into separate path
@@ -72,6 +96,136 @@ pub fn hf_cache_dir(subdir: &str) -> PathBuf {
         .map(|c| c.join("huggingface").join(subdir))
         .or_else(|| dirs::home_dir().map(|h| h.join(".cache").join("huggingface").join(subdir)))
         .unwrap_or_else(|| PathBuf::from(".cache").join("huggingface").join(subdir))
+}
+
+/// SEC-V1.33-8 / #1339 — flag env-supplied HF cache paths that are obvious
+/// supply-chain attack surfaces.
+///
+/// Threat: an attacker who can set `HF_HOME` / `HUGGINGFACE_HUB_CACHE` in
+/// the user's shell (via `.bashrc`, hostile devcontainer image, shared
+/// dotfiles repo) redirects `model.onnx` / `tokenizer.json` loads to a
+/// path under their control. ORT then consumes the malicious ONNX —
+/// arbitrary compute graphs, known CVE classes in older `ort` versions.
+///
+/// Returns `Some(reason)` for suspicious paths so the caller logs
+/// context-rich `warn!` and falls through to the default cache. Returns
+/// `None` (trusted) when the path is unambiguous or when the operator
+/// has set `CQS_HF_CACHE_TRUSTED=1` to opt into the env-supplied path.
+///
+/// Heuristic — flag paths under:
+/// - World-writable or guest-shared dirs: `/tmp`, `/var/tmp`,
+///   `/dev/shm` (Linux); `%TEMP%`, `%TMP%` (Windows).
+/// - Browser download dirs: `~/Downloads`, `~/Desktop`.
+/// - Outside the user's home dir entirely (catches `/opt/attacker`,
+///   `/var/cache/...`, network mounts under `/mnt/<server>`). Allows
+///   `dirs::cache_dir()` (XDG_CACHE_HOME on Linux, `~/Library/Caches`
+///   on macOS, `%LOCALAPPDATA%` on Windows) since that's the canonical
+///   trusted location.
+///
+/// Doesn't canonicalize — a symlink under `~/Downloads/cache → /home`
+/// still gets caught by the home check before it resolves. False
+/// negatives are acceptable; the goal is operator awareness, not
+/// airtight prevention. The opt-out (`CQS_HF_CACHE_TRUSTED=1`) covers
+/// legitimate non-default cache locations.
+fn is_suspicious_cache_path(path: &Path) -> Option<&'static str> {
+    if std::env::var("CQS_HF_CACHE_TRUSTED")
+        .is_ok_and(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+    {
+        return None;
+    }
+    let s = path.to_string_lossy();
+
+    // World-writable / shared-tmp surfaces.
+    for prefix in [
+        "/tmp/",
+        "/tmp",
+        "/var/tmp/",
+        "/var/tmp",
+        "/dev/shm/",
+        "/dev/shm",
+    ] {
+        if s == prefix || s.starts_with(&format!("{prefix}/")) {
+            return Some("under world-writable temp dir");
+        }
+    }
+
+    // Browser-download / desktop surfaces under the user's home — flagged
+    // because they're the destination for drive-by downloads even though
+    // they're inside `home`.
+    if let Some(home) = dirs::home_dir() {
+        for sub in ["Downloads", "Desktop"] {
+            let suspect = home.join(sub);
+            if path.starts_with(&suspect) {
+                return Some("under user's Downloads/Desktop");
+            }
+        }
+        // Outside home + outside system cache dir → suspicious.
+        let in_home = path.starts_with(&home);
+        let in_cache = dirs::cache_dir().is_some_and(|c| path.starts_with(&c));
+        if !in_home && !in_cache {
+            return Some("outside user's home + system cache dir");
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod hf_cache_path_tests {
+    use super::is_suspicious_cache_path;
+    use std::path::Path;
+
+    #[test]
+    fn flags_tmp() {
+        assert_eq!(
+            is_suspicious_cache_path(Path::new("/tmp/attacker/hf")),
+            Some("under world-writable temp dir")
+        );
+    }
+
+    #[test]
+    fn flags_var_tmp() {
+        assert_eq!(
+            is_suspicious_cache_path(Path::new("/var/tmp/x")),
+            Some("under world-writable temp dir")
+        );
+    }
+
+    #[test]
+    fn flags_dev_shm() {
+        assert_eq!(
+            is_suspicious_cache_path(Path::new("/dev/shm/cache")),
+            Some("under world-writable temp dir")
+        );
+    }
+
+    #[test]
+    fn flags_outside_home() {
+        // Skip if HOME isn't set in test env (CI variants).
+        if dirs::home_dir().is_none() {
+            return;
+        }
+        assert!(is_suspicious_cache_path(Path::new("/opt/attacker")).is_some());
+    }
+
+    #[test]
+    fn allows_explicit_trusted_env() {
+        let prev = std::env::var("CQS_HF_CACHE_TRUSTED").ok();
+        std::env::set_var("CQS_HF_CACHE_TRUSTED", "1");
+        assert!(is_suspicious_cache_path(Path::new("/tmp/anywhere")).is_none());
+        match prev {
+            Some(v) => std::env::set_var("CQS_HF_CACHE_TRUSTED", v),
+            None => std::env::remove_var("CQS_HF_CACHE_TRUSTED"),
+        }
+    }
+
+    #[test]
+    fn allows_home_subdir() {
+        if let Some(home) = dirs::home_dir() {
+            let sub = home.join(".cache").join("huggingface");
+            assert!(is_suspicious_cache_path(&sub).is_none());
+        }
+    }
 }
 
 /// Which auxiliary model is being resolved.


### PR DESCRIPTION
## Summary

Closes #1339 (SEC-V1.33-8).

`hf_cache_dir` previously read `HF_HOME` / `HUGGINGFACE_HUB_CACHE` verbatim and used the result for ONNX model + tokenizer loads. An attacker who can set those env vars (via `.bashrc`, hostile devcontainer image, shared dotfiles repo) can redirect cqs to an attacker-controlled cache where a malicious `model.onnx` is consumed by ORT — arbitrary compute graphs, known CVE classes in older ort versions. Supply-chain via env redirect.

## Fix

`is_suspicious_cache_path` heuristic, called whenever an env-supplied path is present. Flags:

- **World-writable / shared-tmp**: `/tmp`, `/var/tmp`, `/dev/shm`
- **Browser download surfaces under `$HOME`**: `~/Downloads`, `~/Desktop`
- **Outside `$HOME` and outside the system cache dir** (`dirs::cache_dir()` — XDG_CACHE_HOME / `~/Library/Caches` / `%LOCALAPPDATA%`)

On flagged paths: `tracing::warn!` with reason + opt-out hint, then fall through to the default cache. Operators with legitimate non-default cache locations opt back in via `CQS_HF_CACHE_TRUSTED=1`.

## Why warn-and-fall-through, not prompt

The audit suggested a confirmation prompt mirroring the v1.30.1 first-encounter shared-notes gate. Out of scope here because cqs runs through Claude Code and CI without a TTY — a prompt would auto-resolve and provide no real gate. Loud warn + fall-through gives the safer-default-behaviour shape: legitimate operators opt in explicitly; attackers don't get the redirect.

## Test plan

- [x] 6 unit tests cover: `/tmp`, `/var/tmp`, `/dev/shm` flagged; outside-home flagged; opt-out via env; home-subdir allowed
- [x] `cargo test --lib aux_model::hf_cache_path_tests` — 6 pass
- [x] `cargo test --test env_var_docs` — passes (new `CQS_HF_CACHE_TRUSTED` documented)
- [ ] CI green
- [ ] Manual: `HF_HOME=/tmp/x cqs index` shows the warn line and uses the default cache

## Notes

The audit also requested a SECURITY.md update enumerating `HF_HOME` and `HUGGINGFACE_HUB_CACHE` as trust boundaries. Out of scope for the autopilot sweep — file as a small follow-up if needed; the env-var-table row already captures the operational gist.

## Related

- #1339 (this fix)
- Sibling SEC-V1.33-* issues from the v1.33.0 audit P4 batch (#1337, #1338, #1340, #1341)
