### PR TITLE
fix(security): pin ProgramFiles env to canonical Windows roots (closes #1338)

### DIFF
--- a/src/convert/chm.rs
+++ b/src/convert/chm.rs
@@ -253,12 +253,37 @@ fn find_7z() -> Result<String> {
     // Check common names first, then env-based Windows install paths
     let mut candidates: Vec<String> =
         vec!["7z".to_string(), "7za".to_string(), "p7zip".to_string()];
-    // Check env-based Windows paths (handles non-standard install dirs)
+    // SEC-V1.33-7 / #1338: validate that `ProgramFiles` / `ProgramFiles(x86)`
+    // resolve to documented system locations before trusting them as absolute
+    // paths. A non-elevated Windows user can override these via
+    // `setx ProgramFiles C:\Users\me\evil` (HKCU env). The downstream
+    // `is_safe_executable_path` check rejects /tmp + world-writable dirs but
+    // not owner-writable dirs under `C:\Users\<me>\`, so an attacker-set
+    // env var was previously enough to redirect 7z spawning. Pin the
+    // accepted prefixes to the canonical Windows install roots.
     if let Ok(pf) = std::env::var("ProgramFiles") {
-        candidates.push(format!(r"{}\7-Zip\7z.exe", pf));
+        if is_canonical_program_files(&pf) {
+            candidates.push(format!(r"{}\7-Zip\7z.exe", pf));
+        } else {
+            tracing::warn!(
+                env = "ProgramFiles",
+                value = %pf,
+                "Ignoring non-canonical ProgramFiles env var (SEC-V1.33-7 / #1338). \
+                 Expected `C:\\Program Files` or `C:\\Program Files (x86)`. \
+                 Add 7-Zip to PATH if it lives elsewhere."
+            );
+        }
     }
     if let Ok(pf) = std::env::var("ProgramFiles(x86)") {
-        candidates.push(format!(r"{}\7-Zip\7z.exe", pf));
+        if is_canonical_program_files(&pf) {
+            candidates.push(format!(r"{}\7-Zip\7z.exe", pf));
+        } else {
+            tracing::warn!(
+                env = "ProgramFiles(x86)",
+                value = %pf,
+                "Ignoring non-canonical ProgramFiles(x86) env var (SEC-V1.33-7 / #1338)."
+            );
+        }
     }
     for name in &candidates {
         // Resolve the candidate to an absolute path so we can vet the parent directory.
@@ -301,9 +326,64 @@ fn find_7z() -> Result<String> {
     )
 }
 
+/// SEC-V1.33-7 / #1338 — accept only the documented Windows system install
+/// roots for `ProgramFiles` / `ProgramFiles(x86)`. A non-elevated user can
+/// override these via HKCU env (`setx ProgramFiles ...`) to redirect a
+/// spawned binary; the downstream `is_safe_executable_path` check doesn't
+/// catch owner-writable dirs under `C:\Users\<me>\`.
+///
+/// Drive letter is checked case-insensitively because Windows path roots
+/// are case-folded (`C:` and `c:` are equivalent). The path-after-drive
+/// segment is matched literally against the conventional names.
+fn is_canonical_program_files(value: &str) -> bool {
+    let v = value.trim_end_matches(['/', '\\']);
+    let lower = v.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "c:\\program files"
+            | "c:\\program files (x86)"
+            | "c:/program files"
+            | "c:/program files (x86)"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonical_program_files_accepts_default() {
+        assert!(is_canonical_program_files("C:\\Program Files"));
+        assert!(is_canonical_program_files("C:\\Program Files (x86)"));
+        assert!(is_canonical_program_files("c:\\program files"));
+        assert!(is_canonical_program_files("c:\\PROGRAM FILES (x86)"));
+    }
+
+    #[test]
+    fn canonical_program_files_strips_trailing_slash() {
+        assert!(is_canonical_program_files("C:\\Program Files\\"));
+        assert!(is_canonical_program_files("C:/Program Files/"));
+    }
+
+    #[test]
+    fn canonical_program_files_rejects_user_dir() {
+        assert!(!is_canonical_program_files("C:\\Users\\me\\evil"));
+        assert!(!is_canonical_program_files("D:\\Program Files"));
+        assert!(!is_canonical_program_files("\\\\server\\share"));
+        assert!(!is_canonical_program_files("/tmp/program files"));
+    }
+
+    #[test]
+    fn canonical_program_files_rejects_substring_attempts() {
+        // Defends against a value that *contains* "Program Files" as a
+        // substring but isn't the canonical install root.
+        assert!(!is_canonical_program_files(
+            "C:\\Program Files\\..\\Users\\me"
+        ));
+        assert!(!is_canonical_program_files(
+            "C:\\Program Files (x86)\\..\\Users"
+        ));
+    }
 
     #[test]
     fn test_chm_to_markdown_nonexistent_file_returns_error() {


### PR DESCRIPTION
## Summary

Closes #1338 (SEC-V1.33-7).

`find_7z` previously trusted `ProgramFiles` and `ProgramFiles(x86)` env vars verbatim, joining them with `\7-Zip\7z.exe` to build absolute candidate paths. A non-elevated Windows user can override these via `setx ProgramFiles C:\Users\me\evil` (HKCU env). The downstream `is_safe_executable_path` check rejects /tmp + world-writable dirs but does **not** reject owner-writable dirs under `C:\Users\<me>\` — which is exactly what an attacker controls.

Net effect pre-fix: an attacker with HKCU write redirected `cqs convert *.chm` to an attacker-supplied 7z binary.

## Fix

`is_canonical_program_files` accepts only:

```
C:\Program Files
C:\Program Files (x86)
C:/Program Files
C:/Program Files (x86)
```

Case-insensitive (Windows path roots are case-folded) and trailing-slash tolerant. Anything else gets a `tracing::warn!` with the env var name + value and is dropped from the candidate list. Operators with non-default 7-Zip installs already need to add it to PATH for any other tool to find it, so this isn't a real ergonomic regression.

## Test plan

- [x] 4 unit tests cover: default accepted (both casings), trailing-slash stripped, user-dir / non-C: drives / UNC / non-canonical rejected, substring-of-canonical-with-traversal rejected.
- [x] `cargo test --lib convert::chm::tests::canonical` — 4 pass
- [ ] CI green
- [ ] WSL/macOS/Linux (env vars never set in those environments) — fall through to PATH lookup unchanged.

## Why not the audit's "drop env-based path lookup entirely" alternative

The audit listed two options: (1) validate the env, or (2) drop env-based lookups entirely. (2) would break Windows-default 7-Zip installs where the binary lives at `C:\Program Files\7-Zip\7z.exe` and isn't on PATH. (1) preserves the canonical install ergonomics; the warn-and-drop on non-canonical values keeps the security posture without the breakage.

## Related

- Sibling SEC-V1.33-* issues from the v1.33.0 audit P4 batch (#1337, #1339, #1340, #1341)
