### PR TITLE
fix(serve): cap blocking permits at SQLite pool size (closes #1346)

### DIFF
--- a/src/limits.rs
+++ b/src/limits.rs
@@ -327,10 +327,43 @@ pub fn serve_chunk_detail_tests_limit() -> usize {
     parse_env_usize_clamped("CQS_SERVE_CHUNK_DETAIL_TESTS", 20, 1, 1_000)
 }
 
-/// P2.76 — cap on concurrent `spawn_blocking` jobs in `cqs serve`. Default 32.
-/// Env: `CQS_SERVE_BLOCKING_PERMITS`. Bounded to `[1, 1024]`.
+/// P2.76 / RM-V1.33-10 (#1346) — cap on concurrent `spawn_blocking` jobs
+/// in `cqs serve`. Default tracks the SQLite connection pool size (default
+/// 4 from `CQS_MAX_CONNECTIONS`) so the permit budget can't outrun the pool
+/// budget. Env: `CQS_SERVE_BLOCKING_PERMITS`. Bounded to `[1, 1024]` and
+/// then clamped at runtime to `<= CQS_MAX_CONNECTIONS`.
+///
+/// **Why the coupling matters.** Each handler `spawn_blocking` body holds a
+/// permit AND borrows a SQLite connection from the pool. If permits > pool
+/// connections, panicking handlers can drop their permit while the
+/// connection takes longer to return cleanly to the pool — the permit
+/// budget says "plenty of headroom" while the pool starves. Capping
+/// permits at pool size makes the actual budget the visible one.
+///
+/// Operators raising both knobs in lockstep (e.g.
+/// `CQS_SERVE_BLOCKING_PERMITS=16 CQS_MAX_CONNECTIONS=16`) get the higher
+/// concurrency they asked for. Setting only `CQS_SERVE_BLOCKING_PERMITS`
+/// without raising `CQS_MAX_CONNECTIONS` clamps to the pool size and
+/// emits a one-time warn so the misconfiguration is visible.
 pub fn serve_blocking_permits() -> usize {
-    parse_env_usize_clamped("CQS_SERVE_BLOCKING_PERMITS", 32, 1, 1024)
+    let max_connections = std::env::var("CQS_MAX_CONNECTIONS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(4);
+    let requested = parse_env_usize_clamped("CQS_SERVE_BLOCKING_PERMITS", max_connections, 1, 1024);
+    if requested > max_connections {
+        tracing::warn!(
+            requested,
+            max_connections,
+            "CQS_SERVE_BLOCKING_PERMITS exceeds CQS_MAX_CONNECTIONS — clamping. \
+             Raise CQS_MAX_CONNECTIONS in lockstep to grow the actual concurrency budget. \
+             RM-V1.33-10 / #1346"
+        );
+        max_connections
+    } else {
+        requested
+    }
 }
 
 /// Same as [`parse_env_usize`] but for `u64`-shaped byte limits.
@@ -397,6 +430,44 @@ mod tests {
         std::env::set_var("CQS_TEST_LIMITS_USZ", "42");
         assert_eq!(parse_env_usize("CQS_TEST_LIMITS_USZ", 99), 42);
         std::env::remove_var("CQS_TEST_LIMITS_USZ");
+    }
+
+    #[test]
+    fn serve_blocking_permits_defaults_to_max_connections_default() {
+        // SAFETY: this test mutates process-global env vars; cqs lib tests
+        // already run --test-threads=1 to avoid parallel env races.
+        std::env::remove_var("CQS_SERVE_BLOCKING_PERMITS");
+        std::env::remove_var("CQS_MAX_CONNECTIONS");
+        assert_eq!(serve_blocking_permits(), 4);
+    }
+
+    #[test]
+    fn serve_blocking_permits_tracks_max_connections_when_unset() {
+        std::env::remove_var("CQS_SERVE_BLOCKING_PERMITS");
+        std::env::set_var("CQS_MAX_CONNECTIONS", "8");
+        assert_eq!(serve_blocking_permits(), 8);
+        std::env::remove_var("CQS_MAX_CONNECTIONS");
+    }
+
+    #[test]
+    fn serve_blocking_permits_respects_explicit_when_under_max_connections() {
+        std::env::set_var("CQS_SERVE_BLOCKING_PERMITS", "2");
+        std::env::set_var("CQS_MAX_CONNECTIONS", "8");
+        assert_eq!(serve_blocking_permits(), 2);
+        std::env::remove_var("CQS_SERVE_BLOCKING_PERMITS");
+        std::env::remove_var("CQS_MAX_CONNECTIONS");
+    }
+
+    #[test]
+    fn serve_blocking_permits_clamps_above_max_connections() {
+        std::env::set_var("CQS_SERVE_BLOCKING_PERMITS", "32");
+        std::env::set_var("CQS_MAX_CONNECTIONS", "4");
+        // Pre-fix this returned 32 (the requested value); post-fix it
+        // clamps to max_connections so the permit budget can't outrun the
+        // SQLite pool budget.
+        assert_eq!(serve_blocking_permits(), 4);
+        std::env::remove_var("CQS_SERVE_BLOCKING_PERMITS");
+        std::env::remove_var("CQS_MAX_CONNECTIONS");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #1346 (RM-V1.33-10).

Each `cqs serve` handler holds an `AppState.blocking_permits` permit and borrows a SQLite connection from the pool. Pre-fix, permits defaulted to 32 (`CQS_SERVE_BLOCKING_PERMITS`) while the pool defaulted to 4 (`CQS_MAX_CONNECTIONS`). When permits > pool size, panicking handlers can release their permit faster than the connection returns cleanly to the pool — the budget visible to operators ("32 permits free") and the actual budget (4 connections) diverge, so even a small panic rate can starve the pool while permits report headroom.

## Fix

Two parts in `serve_blocking_permits()`:

1. **Default tracks pool size.** When `CQS_SERVE_BLOCKING_PERMITS` is unset, return `CQS_MAX_CONNECTIONS` (default 4) instead of the historical 32. Permits-and-pool stay in lockstep without operators having to know to set both.
2. **Runtime clamp.** When `CQS_SERVE_BLOCKING_PERMITS` is explicitly set higher than `CQS_MAX_CONNECTIONS`, clamp to the pool and emit a one-time `tracing::warn!` so the misconfiguration is visible. Operators raising both env vars in lockstep get the higher concurrency they asked for.

## Test plan

- [x] 4 unit tests cover: default == 4, tracks `CQS_MAX_CONNECTIONS` when permits unset, respects explicit-under-pool, clamps explicit-over-pool with warn
- [x] `cargo test --lib limits::tests::serve_blocking_permits` — 4 pass
- [ ] CI green
- [ ] Manual: `CQS_MAX_CONNECTIONS=8 cqs serve` → 8 permits

## Out of scope

The audit also suggested `std::panic::catch_unwind(AssertUnwindSafe(...))` inside each `spawn_blocking` body to guarantee the connection returns to the pool on panic. That's a structural change touching every endpoint in `serve/handlers.rs` and is more appropriate as its own PR. Capping the permit budget at pool size already eliminates the "permit budget says we have headroom" portion of the bug; the catch_unwind would address the residual broken-slot accumulation rate.

## Related

- Sibling RM-V1.33-* issues from the v1.33.0 audit P4 batch (#1342–#1346)
- The audit's panic-safety follow-up could be its own issue if needed
