### PR TITLE
perf(store): composite (source_type, origin) index on chunks (closes #1371)

### DIFF
--- a/src/schema.sql
+++ b/src/schema.sql
@@ -62,6 +62,16 @@ CREATE TABLE IF NOT EXISTS chunks (
 
 CREATE INDEX IF NOT EXISTS idx_chunks_origin ON chunks(origin);
 CREATE INDEX IF NOT EXISTS idx_chunks_source_type ON chunks(source_type);
+-- v26 / #1371 / PERF-V1.33-10: composite index covering the
+-- `WHERE source_type = ? + DISTINCT origin` pattern used by
+-- `list_stale_files` (every reconcile + `cqs status --watch-fresh`)
+-- and `prune_missing_files` (GC). With the single-column indexes
+-- above, SQLite probes one then row-visits the other; with the
+-- composite, both the filter and the DISTINCT walk satisfy from a
+-- single index pass. Expected ~50× speedup at 50k+ chunk corpora;
+-- index size ~5-15% of the chunks table.
+CREATE INDEX IF NOT EXISTS idx_chunks_source_type_origin
+    ON chunks(source_type, origin);
 CREATE INDEX IF NOT EXISTS idx_chunks_content_hash ON chunks(content_hash);
 CREATE INDEX IF NOT EXISTS idx_chunks_name ON chunks(name);
 CREATE INDEX IF NOT EXISTS idx_chunks_language ON chunks(language);

--- a/src/store/helpers/mod.rs
+++ b/src/store/helpers/mod.rs
@@ -88,6 +88,13 @@ pub(crate) fn bm25_ordering_expr() -> String {
 /// against the stored version and returns StoreError::SchemaMismatch if different.
 ///
 /// History:
+/// - v26: composite index `idx_chunks_source_type_origin` covering the
+///   `WHERE source_type = ? + DISTINCT origin` pattern in `list_stale_files`
+///   (every reconcile + `cqs status --watch-fresh`) and `prune_missing_files`.
+///   Pre-v26, SQLite probed `idx_chunks_source_type` then row-visited; with
+///   the composite, both filter and DISTINCT walk satisfy from a single
+///   index pass. ~50× speedup expected at 50k+ chunk corpora; index size
+///   ~5-15% of the chunks table. PERF-V1.33-10 / #1371.
 /// - v23: source_size INTEGER + source_content_hash BLOB columns on chunks for
 ///   the reconcile fingerprint (issue #1219 / EX-V1.30.1-6). Layer 2 periodic
 ///   reconciliation previously diverged on `disk_mtime != stored_mtime` only,
@@ -130,7 +137,7 @@ pub(crate) fn bm25_ordering_expr() -> String {
 /// - v12: parent_type_name column for method->class association
 /// - v11: type_edges table for type-level dependency tracking
 /// - v10: sentiment in embeddings, call graph, notes
-pub const CURRENT_SCHEMA_VERSION: i32 = 25;
+pub const CURRENT_SCHEMA_VERSION: i32 = 26;
 
 /// Default model name for metadata checks (used by test-only `check_model_version`).
 /// Canonical definition is `embedder::DEFAULT_MODEL_REPO`.

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -372,6 +372,7 @@ const MIGRATIONS: &[(i32, i32, MigrationFn)] = &[
     (22, 23, |c| Box::pin(migrate_v22_to_v23(c))),
     (23, 24, |c| Box::pin(migrate_v23_to_v24(c))),
     (24, 25, |c| Box::pin(migrate_v24_to_v25(c))),
+    (25, 26, |c| Box::pin(migrate_v25_to_v26(c))),
 ];
 
 /// Run a single migration step
@@ -921,6 +922,30 @@ async fn migrate_v24_to_v25(conn: &mut sqlx::SqliteConnection) -> Result<(), Sto
     Ok(())
 }
 
+/// PERF-V1.33-10 / #1371 — add composite `(source_type, origin)` index on
+/// `chunks` so `list_stale_files` and `prune_missing_files` can satisfy
+/// their `WHERE source_type = ? + DISTINCT origin` queries from a single
+/// index pass. Pre-v26 SQLite would probe `idx_chunks_source_type`, then
+/// row-visit (or fall through to a full scan + sort). Mirrors the
+/// schema.sql change so fresh DBs match.
+async fn migrate_v25_to_v26(conn: &mut sqlx::SqliteConnection) -> Result<(), StoreError> {
+    let _span = tracing::info_span!("migrate_v25_to_v26").entered();
+
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_chunks_source_type_origin \
+         ON chunks(source_type, origin)",
+    )
+    .execute(&mut *conn)
+    .await?;
+
+    tracing::info!(
+        "Migrated to v26: idx_chunks_source_type_origin composite index. \
+         Speeds up reconcile / status --watch-fresh / GC at 50k+ chunk corpora. \
+         PERF-V1.33-10 / #1371."
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -953,7 +978,7 @@ mod tests {
     #[test]
     fn test_current_schema_version_documented() {
         // Ensure the current version matches what we document
-        assert_eq!(CURRENT_SCHEMA_VERSION, 25);
+        assert_eq!(CURRENT_SCHEMA_VERSION, 26);
     }
 
     #[test]

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -17,7 +17,7 @@ fn test_store_init() {
     let stats = store.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
     assert_eq!(stats.total_files, 0);
-    assert_eq!(stats.schema_version, 25); // v25: notes.kind column for structured tag taxonomy (#1133); chains v23→v24→v25
+    assert_eq!(stats.schema_version, 26); // v26: idx_chunks_source_type_origin composite index for list_stale_files / prune_missing_files (#1371); chains v23→v24→v25→v26
     assert_eq!(stats.model_name, cqs::embedder::DEFAULT_MODEL_REPO);
 }
 
@@ -1113,7 +1113,7 @@ fn test_open_readonly_on_initialized_store() {
     let ro = cqs::store::Store::open_readonly(&db_path).unwrap();
     let stats = ro.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
-    assert_eq!(stats.schema_version, 25);
+    assert_eq!(stats.schema_version, 26);
     assert_eq!(stats.model_name, cqs::embedder::DEFAULT_MODEL_REPO);
 }
 


### PR DESCRIPTION
Closes #1371 / PERF-V1.33-10. Add composite index covering the WHERE source_type = ? + DISTINCT origin pattern in list_stale_files (every reconcile + cqs status --watch-fresh) and prune_missing_files. Schema v25 → v26 with migration. Expected ~50× speedup at 50k+ chunk corpora.