### PR TITLE
refactor(cli): unify --rerank and --reranker on shared RerankerMode (closes #1372)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -67,6 +67,41 @@ pub const DEFAULT_DEPTH_TEST_MAP: usize = 5;
 /// surfaces in <1s.
 pub const DEFAULT_DEPTH_TRACE: u16 = 10;
 
+/// Cross-encoder / LLM reranker mode for retrieval surfaces.
+///
+/// Lifted out of `src/cli/commands/eval/mod.rs` (P2-14, #1372) so search and
+/// eval share the same flag shape. `cqs <q> --rerank` is preserved as a
+/// boolean shorthand for `--reranker onnx`; `--reranker none|onnx|llm` is
+/// the canonical form. `Llm` is reserved for the production wiring landing
+/// in #1220 — the variant is exposed on every retrieval surface so the
+/// future implementation can plug in without a breaking CLI change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum RerankerMode {
+    /// No reranking — stage-1 retrieval is the final answer (default).
+    None,
+    /// Cross-encoder reranker via [`cqs::OnnxReranker`].
+    Onnx,
+    /// LLM reranker — reserved for #1220, currently errors on selection.
+    Llm,
+}
+
+/// Resolve the effective reranker mode from the `(--reranker, --rerank)`
+/// pair. `--reranker` (explicit enum) wins when set; otherwise `--rerank`
+/// (bool) is mapped to `Onnx`. Both unset → `None`.
+///
+/// Used by `SearchArgs` and `Cli` (top-level search) to keep the bool flag
+/// working for muscle memory / batch scripts while exposing the full enum.
+pub(crate) fn resolve_rerank_mode(
+    explicit: Option<RerankerMode>,
+    rerank_bool: bool,
+) -> RerankerMode {
+    match (explicit, rerank_bool) {
+        (Some(m), _) => m,
+        (None, true) => RerankerMode::Onnx,
+        (None, false) => RerankerMode::None,
+    }
+}
+
 /// Shared `--limit / -n` argument for graph commands that previously had no
 /// per-subcommand limit (callers, callees, deps, impact, test-map, trace,
 /// onboard, explain). Default mirrors the top-level `Cli::limit` (= 5) so a
@@ -150,9 +185,23 @@ pub(crate) struct SearchArgs {
     #[arg(long)]
     pub include_docs: bool,
 
-    /// Re-rank results with cross-encoder (slower, more accurate)
+    /// Re-rank results with cross-encoder (slower, more accurate).
+    ///
+    /// Boolean shorthand for `--reranker onnx`. `--reranker <mode>` (P2-14,
+    /// #1372) is the canonical form; this stays for muscle memory and batch
+    /// scripts. If both are passed, `--reranker` wins.
     #[arg(long)]
     pub rerank: bool,
+
+    /// Reranker mode: `none|onnx|llm` (#1372).
+    ///
+    /// Mirrors `cqs eval --reranker`. `none` is the default; `onnx` runs the
+    /// cross-encoder configured by `[reranker]` / `CQS_RERANKER_MODEL`; `llm`
+    /// is reserved for the production wiring landing in #1220 and currently
+    /// errors with a "not yet implemented" message. Takes precedence over
+    /// the legacy `--rerank` bool when both are passed.
+    #[arg(long = "reranker", value_enum)]
+    pub reranker: Option<RerankerMode>,
 
     /// Force-enable SPLADE sparse-dense hybrid search.
     ///
@@ -208,6 +257,19 @@ pub(crate) struct SearchArgs {
     /// Disable search-time demotion of test functions and underscore-prefixed names
     #[arg(long)]
     pub no_demote: bool,
+}
+
+impl SearchArgs {
+    /// Effective reranker mode after resolving `(--reranker, --rerank)` (#1372).
+    /// Returns `RerankerMode::None` when neither flag is set.
+    pub(crate) fn rerank_mode(&self) -> RerankerMode {
+        resolve_rerank_mode(self.reranker, self.rerank)
+    }
+
+    /// `true` if any reranker stage is selected (Onnx or Llm).
+    pub(crate) fn rerank_active(&self) -> bool {
+        !matches!(self.rerank_mode(), RerankerMode::None)
+    }
 }
 
 /// Arguments shared between CLI `gather` and batch `gather`.

--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -30,6 +30,13 @@ pub(in crate::cli::batch) fn dispatch_search(
 ) -> Result<serde_json::Value> {
     let _span = tracing::info_span!("batch_search", query = %args.query).entered();
 
+    // #1372: --reranker llm not wired in search yet — eval has the same gate.
+    if matches!(args.rerank_mode(), crate::cli::args::RerankerMode::Llm) {
+        anyhow::bail!(
+            "--reranker llm is reserved for #1220 (LLM-judge reranker) and not yet wired into search. Use --reranker onnx (or --rerank for the same effect)."
+        );
+    }
+
     // Accepted for CLI parity; batch JSON doesn't use line-context, parent
     // expansion, include-docs, pattern, or no-stale-check yet. Assigning to
     // `_` avoids clippy unused-field warnings while preserving forwards
@@ -96,7 +103,7 @@ pub(in crate::cli::batch) fn dispatch_search(
 
     let limit = args.limit.clamp(1, 100);
     // P3 #100: shared rerank pool sizing.
-    let effective_limit = if args.rerank {
+    let effective_limit = if args.rerank_active() {
         crate::cli::limits::rerank_pool_size(limit)
     } else {
         limit
@@ -154,7 +161,7 @@ pub(in crate::cli::batch) fn dispatch_search(
     if let Some(ref ref_name) = args.ref_name {
         let ref_idx = crate::cli::commands::resolve::find_reference(&ctx.root, ref_name)?;
         // P3 #100: shared rerank pool sizing.
-        let ref_limit = if args.rerank {
+        let ref_limit = if args.rerank_active() {
             crate::cli::limits::rerank_pool_size(limit)
         } else {
             limit
@@ -170,7 +177,7 @@ pub(in crate::cli::batch) fn dispatch_search(
         )?;
 
         // Re-rank ref results
-        if args.rerank && results.len() > 1 {
+        if args.rerank_active() && results.len() > 1 {
             let reranker = ctx.reranker()?;
             reranker
                 .rerank(&args.query, &mut results, limit)
@@ -275,7 +282,7 @@ pub(in crate::cli::batch) fn dispatch_search(
     };
 
     // Re-rank if requested
-    let results = if args.rerank && results.len() > 1 {
+    let results = if args.rerank_active() && results.len() > 1 {
         let mut code_results: Vec<cqs::store::SearchResult> = results
             .into_iter()
             .map(|r| match r {

--- a/src/cli/commands/eval/mod.rs
+++ b/src/cli/commands/eval/mod.rs
@@ -24,6 +24,7 @@ use anyhow::{Context as _, Result};
 
 use cqs::store::ReadOnly;
 
+use crate::cli::args::RerankerMode;
 use crate::cli::commands::{daemon_control_hint, DaemonHint};
 use crate::cli::CommandContext;
 
@@ -107,23 +108,6 @@ pub(crate) struct EvalCmdArgs {
     /// scorer (R@K loss).
     #[arg(long = "reranker", value_enum, default_value_t = RerankerMode::None)]
     pub reranker: RerankerMode,
-}
-
-/// Reranker dispatch for `cqs eval --reranker`.
-///
-/// Mirrors the production three-impl set introduced in #1276 (`OnnxReranker`,
-/// `NoopReranker`, `LlmReranker`). `None` short-circuits the entire reranker
-/// path; `Onnx` routes through [`crate::cli::CommandContext::reranker`]; `Llm`
-/// is reserved for the production wiring landing in #1220 and currently bails
-/// with a "not yet implemented" error.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
-pub(crate) enum RerankerMode {
-    /// No reranking — stage-1 retrieval is the final answer (default).
-    None,
-    /// Cross-encoder reranker via [`cqs::OnnxReranker`].
-    Onnx,
-    /// LLM reranker — reserved for #1220, currently errors on selection.
-    Llm,
 }
 
 /// CLI handler for `cqs eval`.

--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -65,9 +65,16 @@ pub(crate) fn cmd_query(
     let root = &ctx.root;
     let cqs_dir = &ctx.cqs_dir;
 
+    // #1372: --reranker llm not wired in search — eval has the same gate.
+    if matches!(cli.rerank_mode(), crate::cli::args::RerankerMode::Llm) {
+        bail!(
+            "--reranker llm is reserved for #1220 (LLM-judge reranker) and not yet wired into search. Use --reranker onnx (or --rerank for the same effect)."
+        );
+    }
+
     // Name-only mode: search by function/struct name, skip embedding entirely
     if cli.name_only {
-        if cli.rerank {
+        if cli.rerank_active() {
             bail!("--rerank requires embedding search, incompatible with --name-only");
         }
         if let Some(ref ref_name) = cli.ref_name {
@@ -79,7 +86,7 @@ pub(crate) fn cmd_query(
     // Adaptive routing: classify query BEFORE embedding to potentially skip it
     // --splade intentionally NOT here: it only controls SPLADE fusion,
     // not adaptive routing. --rrf/--rerank/--ref override the search strategy.
-    let has_explicit_flags = cli.rrf || cli.rerank || cli.ref_name.is_some();
+    let has_explicit_flags = cli.rrf || cli.rerank_active() || cli.ref_name.is_some();
     let classification = if !has_explicit_flags {
         let c = cqs::search::router::classify_query(query);
         tracing::info!(
@@ -127,7 +134,7 @@ pub(crate) fn cmd_query(
     // Over-retrieve when reranking to give the cross-encoder more candidates.
     // P3 #100: pool sizing centralized in `cli/limits.rs::rerank_pool_size`,
     // honors CQS_RERANK_OVER_RETRIEVAL / CQS_RERANK_POOL_MAX.
-    let effective_limit = if cli.rerank {
+    let effective_limit = if cli.rerank_active() {
         crate::cli::limits::rerank_pool_size(cli.limit)
     } else {
         cli.limit
@@ -239,7 +246,7 @@ pub(crate) fn cmd_query(
     filter.validate().map_err(|e| anyhow::anyhow!(e))?;
 
     // Lazily obtain reranker from CommandContext (shared across ref + project paths)
-    let reranker = if cli.rerank {
+    let reranker = if cli.rerank_active() {
         Some(ctx.reranker()?)
     } else {
         None
@@ -519,7 +526,7 @@ fn cmd_query_project(ctx: &QueryContext<'_>) -> Result<()> {
         return Ok(());
     }
 
-    if cli.rerank {
+    if cli.rerank_active() {
         tracing::warn!("--rerank is not supported with multi-index search, skipping re-ranking");
     }
 
@@ -690,7 +697,7 @@ fn cmd_query_ref_only(ctx: &RefQueryContext<'_>, ref_name: &str) -> Result<()> {
     let ref_idx = crate::cli::commands::resolve::find_reference(ctx.root, ref_name)?;
 
     // P3 #100: shared pool sizing.
-    let ref_limit = if ctx.cli.rerank {
+    let ref_limit = if ctx.cli.rerank_active() {
         crate::cli::limits::rerank_pool_size(ctx.cli.limit)
     } else {
         ctx.cli.limit

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -206,9 +206,23 @@ pub struct Cli {
     #[arg(long)]
     pub include_docs: bool,
 
-    /// Re-rank results with cross-encoder (slower, more accurate)
+    /// Re-rank results with cross-encoder (slower, more accurate).
+    ///
+    /// Boolean shorthand for `--reranker onnx`. `--reranker <mode>` (P2-14,
+    /// #1372) is the canonical form; this stays for muscle memory and batch
+    /// scripts. If both are passed, `--reranker` wins.
     #[arg(long)]
     pub rerank: bool,
+
+    /// Reranker mode: `none|onnx|llm` (#1372).
+    ///
+    /// Mirrors `cqs eval --reranker`. `none` is the default; `onnx` runs the
+    /// cross-encoder configured by `[reranker]` / `CQS_RERANKER_MODEL`; `llm`
+    /// is reserved for the production wiring landing in #1220 and currently
+    /// errors with a "not yet implemented" message. Takes precedence over
+    /// the legacy `--rerank` bool when both are passed.
+    #[arg(long = "reranker", value_enum)]
+    pub reranker: Option<args::RerankerMode>,
 
     /// Force-enable SPLADE sparse-dense hybrid search.
     ///
@@ -313,6 +327,17 @@ impl Cli {
         self.resolved_model
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("ModelConfig not resolved — call resolve_model() first"))
+    }
+
+    /// Effective reranker mode after resolving `(--reranker, --rerank)` (#1372).
+    /// Returns `RerankerMode::None` when neither flag is set.
+    pub(crate) fn rerank_mode(&self) -> args::RerankerMode {
+        args::resolve_rerank_mode(self.reranker, self.rerank)
+    }
+
+    /// `true` if any reranker stage is selected (Onnx or Llm).
+    pub(crate) fn rerank_active(&self) -> bool {
+        !matches!(self.rerank_mode(), args::RerankerMode::None)
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -490,18 +490,23 @@ mod tests {
         assert!(cli.name_only);
     }
 
-    // ===== --rerank flag tests =====
+    // ===== --rerank / --reranker flag tests =====
 
     #[test]
     fn test_cli_rerank_flag() {
         let cli = Cli::try_parse_from(["cqs", "--rerank", "search query"]).unwrap();
         assert!(cli.rerank);
+        // #1372: --rerank shorthand resolves to Onnx mode.
+        assert!(cli.rerank_active());
+        assert_eq!(cli.rerank_mode(), super::args::RerankerMode::Onnx);
     }
 
     #[test]
     fn test_cli_rerank_default_false() {
         let cli = Cli::try_parse_from(["cqs", "search query"]).unwrap();
         assert!(!cli.rerank);
+        assert!(!cli.rerank_active());
+        assert_eq!(cli.rerank_mode(), super::args::RerankerMode::None);
     }
 
     #[test]
@@ -516,6 +521,63 @@ mod tests {
         let cli = Cli::try_parse_from(["cqs", "--rerank", "-n", "20", "query"]).unwrap();
         assert!(cli.rerank);
         assert_eq!(cli.limit, 20);
+    }
+
+    /// #1372: `--reranker onnx` produces the same effective mode as `--rerank`.
+    #[test]
+    fn test_cli_reranker_onnx() {
+        let cli = Cli::try_parse_from(["cqs", "--reranker", "onnx", "query"]).unwrap();
+        assert_eq!(cli.rerank_mode(), super::args::RerankerMode::Onnx);
+        assert!(cli.rerank_active());
+    }
+
+    /// #1372: `--reranker none` is the default and stays inactive even though
+    /// the flag was passed.
+    #[test]
+    fn test_cli_reranker_none_explicit() {
+        let cli = Cli::try_parse_from(["cqs", "--reranker", "none", "query"]).unwrap();
+        assert_eq!(cli.rerank_mode(), super::args::RerankerMode::None);
+        assert!(!cli.rerank_active());
+    }
+
+    /// #1372: `--reranker llm` parses; runtime gates it with a "not yet wired"
+    /// error in `cmd_query` / `dispatch_search`. The flag exists so the LLM
+    /// reranker landing in #1220 doesn't need a breaking CLI change.
+    #[test]
+    fn test_cli_reranker_llm() {
+        let cli = Cli::try_parse_from(["cqs", "--reranker", "llm", "query"]).unwrap();
+        assert_eq!(cli.rerank_mode(), super::args::RerankerMode::Llm);
+        assert!(cli.rerank_active());
+    }
+
+    /// #1372: when both flags are passed, `--reranker` wins (explicit beats
+    /// shorthand). Lets a script with hardcoded `--rerank` opt into Llm
+    /// without having to drop the shorthand.
+    #[test]
+    fn test_cli_reranker_overrides_rerank() {
+        let cli = Cli::try_parse_from(["cqs", "--rerank", "--reranker", "none", "query"]).unwrap();
+        // `--rerank` raw bool is still set, but resolved mode is None.
+        assert!(cli.rerank);
+        assert_eq!(cli.rerank_mode(), super::args::RerankerMode::None);
+        assert!(!cli.rerank_active());
+    }
+
+    /// #1372: invalid `--reranker` value rejected at parse time (clap
+    /// `value_enum`) — keeps typos from silently downgrading to default.
+    #[test]
+    fn test_cli_reranker_invalid_rejected() {
+        let result = Cli::try_parse_from(["cqs", "--reranker", "bogus", "query"]);
+        let err = match result {
+            Ok(_) => panic!("expected clap to reject `--reranker bogus`"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid value")
+                || msg.contains("possible values")
+                || msg.contains("'bogus'"),
+            "expected clap value-enum rejection, got: {msg}"
+        );
     }
 
     // ===== --tokens flag tests =====


### PR DESCRIPTION
## Summary

Closes #1372 (P2-14): unifies search's `--rerank` (bool) and eval's `--reranker <mode>` (enum) on a shared `RerankerMode`.

- Lifts `RerankerMode { None, Onnx, Llm }` from `src/cli/commands/eval/mod.rs` to `src/cli/args.rs` so retrieval surfaces share one source of truth.
- Adds `--reranker <none|onnx|llm>` to top-level `Cli` and `SearchArgs`. Keeps `--rerank` (bool) as a shorthand for `--reranker onnx`.
- Explicit `--reranker` wins when both flags are passed. `--reranker llm` parses but errors at runtime in search (mirrors eval) — the variant exists so #1220's LLM-judge wiring lands without a breaking CLI change.
- All 14 internal `cli.rerank` / `args.rerank` boolean reads switch to `rerank_active()` / `rerank_mode()` helpers on `Cli` and `SearchArgs`.

## Test plan

- [x] `cargo test --features cuda-index --bin cqs test_cli_rerank` — 9 tests pass (4 existing + 5 new for the enum + resolver)
- [x] `cargo test --features cuda-index --bin cqs eval` — 13 tests pass (eval still parses `--reranker none|onnx|llm`)
- [x] `cargo test --features cuda-index` — full suite, no failures
- [x] `cargo clippy --features cuda-index --all-targets` — no new warnings in changed files
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
