### PR TITLE
fix(watch): cut HNSW rebuild Store mmap to 64 MiB (closes #1344)

### DIFF
--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -5,8 +5,31 @@
 //! Watch mode holds several resources in memory while idle:
 //!
 //! - **Parser**: ~1MB for tree-sitter queries (allocated immediately)
-//! - **Store**: SQLite connection pool with up to 4 connections (allocated immediately)
+//! - **Store**: SQLite connection pool with up to 4 connections + 256 MiB mmap
+//!   + 16 MiB page cache (allocated immediately)
 //! - **Embedder**: ~500MB for ONNX model (lazy-loaded on first file change)
+//!
+//! ### Background-rebuild peak (#1344 / RM-V1.33-4)
+//!
+//! When `spawn_hnsw_rebuild` fires, the rebuild thread opens a second
+//! read-only `Store` handle to stream chunks for the new HNSW index. As of
+//! this fix that handle uses [`Store::open_readonly`] (64 MiB mmap + 4 MiB
+//! cache) instead of the prior [`Store::open_readonly_pooled`] (256 + 16) —
+//! shaves ~200 MiB off the rebuild-window peak. The build_hnsw_index_owned
+//! pipeline streams chunks via the batched embedding API, so the smaller
+//! mmap doesn't hurt rebuild throughput. Rebuild-window peak now:
+//!
+//! ```text
+//! main store     :  ~272 MiB (256 mmap + 16 cache)
+//! rebuild store  :   ~68 MiB (64 mmap + 4 cache)        ← was 272 MiB
+//! enriched HNSW  :  ~50–200 MiB (live, in main process)
+//! rebuild HNSW   :  ~50–200 MiB (under construction, in rebuild thread)
+//! ```
+//!
+//! `incremental_count`-driven backpressure (`watch::events`) is the only
+//! guard against multiple concurrent rebuilds; in practice that holds, but
+//! a future stress on the trigger thresholds would benefit from a
+//! `Mutex<()>`-style "only one rebuild at a time" gate.
 //!
 //! The Embedder is the largest resource and is only loaded when files actually change.
 //! Once loaded, it remains in memory for fast subsequent reindexing. This tradeoff

--- a/src/cli/watch/rebuild.rs
+++ b/src/cli/watch/rebuild.rs
@@ -236,8 +236,17 @@ pub(super) fn spawn_hnsw_rebuild(
         .spawn(move || {
             let _enter = span.entered();
             let result: RebuildOutcome = (|| -> RebuildOutcome {
-                let store =
-                    cqs::Store::open_readonly_pooled(&index_path).map_err(anyhow::Error::from)?;
+                // #1344 / RM-V1.33-4: use the lower-footprint readonly open
+                // instead of `open_readonly_pooled`. The watch loop's main
+                // (read-write) store is already resident with 256 MiB mmap +
+                // 16 MiB cache; if we re-opened the rebuild store at the
+                // same size, the rebuild window peaked at 2× SQLite mapping
+                // (272 MiB) on top of the dual HNSW indexes (~50–200 MiB
+                // each). `open_readonly` keeps mmap at 64 MiB + cache at
+                // 4 MiB — `build_hnsw_index_owned` streams chunks via the
+                // batched embedding API, so the smaller mapping doesn't hurt
+                // rebuild throughput on the corpora that hit this path.
+                let store = cqs::Store::open_readonly(&index_path).map_err(anyhow::Error::from)?;
                 if store.dim() != expected_dim {
                     anyhow::bail!(
                         "store dim ({}) does not match expected ({}); refusing rebuild",


### PR DESCRIPTION
## Summary

Closes #1344 (P4-8, RM-V1.33-4): cuts the HNSW background-rebuild Store mmap from 256 MiB to 64 MiB.

`spawn_hnsw_rebuild` opened the rebuild thread's read-only Store via `Store::open_readonly_pooled` (256 MiB mmap + 16 MiB SQLite cache). The watch loop's main (read-write) Store already has the same 256 + 16 MiB mapping resident, so the rebuild window peaked at 2× SQLite mapping (~544 MiB) on top of dual HNSW indexes (~50–200 MiB each on bge-large-1024).

## Fix

Swap to `Store::open_readonly` (64 MiB mmap + 4 MiB cache) for the rebuild thread. `build_hnsw_index_owned` streams chunks via the batched embedding API, so the smaller mapping doesn't hurt rebuild throughput on the corpora that hit this path.

```text
Rebuild-window peak (post-fix):
  main store    : ~272 MiB (256 mmap + 16 cache)
  rebuild store :  ~68 MiB (64 mmap + 4 cache)        ← was 272 MiB
  enriched HNSW : ~50–200 MiB
  rebuild HNSW  : ~50–200 MiB
```

Net: ~200 MiB shaved off long-running watch sessions during background HNSW rebuilds.

Module docstring on `src/cli/watch/mod.rs` updated to call out the rebuild-window peak (the prior "Memory Usage" section only documented the idle state).

The "only one rebuild at a time" `Mutex<()>` gate suggested as optional in the audit finding is deferred — `incremental_count`-driven backpressure currently prevents concurrent spawns in practice.

## Test plan

- [x] `cargo build --features cuda-index` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI green — happy-path watch tests already exercise the rebuild path; no signature changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
