### PR TITLE
refactor(index): collapse backend registration into register_index_backends! macro (closes #1348)

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -179,17 +179,45 @@ pub trait IndexBackend<Mode: ClearHnswDirty>: Send + Sync {
     ) -> std::result::Result<Option<Box<dyn VectorIndex>>, IndexBackendError>;
 }
 
-/// Build the ordered backend slice for this build (`cuda-index` feature on/off).
-/// Sorted highest-priority first. The selector iterates and takes the first
-/// backend whose `try_open` succeeds.
-pub fn backends<Mode: ClearHnswDirty>() -> Vec<&'static dyn IndexBackend<Mode>> {
-    #[cfg(feature = "cuda-index")]
-    let mut v: Vec<&'static dyn IndexBackend<Mode>> =
-        vec![&crate::cagra::CagraBackend, &crate::hnsw::HnswBackend];
-    #[cfg(not(feature = "cuda-index"))]
-    let mut v: Vec<&'static dyn IndexBackend<Mode>> = vec![&crate::hnsw::HnswBackend];
-    v.sort_by_key(|b| std::cmp::Reverse(b.priority()));
-    v
+/// #1348 / EX-V1.33-2: declare the registered backends as a single table.
+///
+/// Each row is either an unconditional `name => path` or a feature-gated
+/// `name => path, cfg(feature = "...")`. The macro emits a private const
+/// `INDEX_BACKEND_REGISTRY: &[fn() -> &'static dyn IndexBackend<Mode>]`
+/// (well — actually a `&[&dyn …]`) covering only the cfg-active rows, so
+/// adding a backend is a single new row no matter how many cfg permutations
+/// the build matrix has. `[`backends`]` reads the table, copies it, and
+/// sorts.
+///
+/// Backends that ship in the future (USearch / Metal / ROCm / SIMD
+/// brute-force) drop in as one extra `Backend, cfg(feature = "<flag>"),`
+/// row each. The cfg-permutation matrix at the call site collapses; before
+/// this refactor a USearch backend would have required four `#[cfg]` arms
+/// (cuda+usearch, cuda only, usearch only, neither) per `backends()`
+/// definition.
+macro_rules! register_index_backends {
+    (
+        $(
+            $backend:expr
+            $(, cfg( $($cfg:tt)+ ))?
+            ;
+        )+
+    ) => {
+        pub fn backends<Mode: ClearHnswDirty>() -> Vec<&'static dyn IndexBackend<Mode>> {
+            let mut v: Vec<&'static dyn IndexBackend<Mode>> = Vec::new();
+            $(
+                $( #[cfg( $($cfg)+ )] )?
+                v.push(& $backend);
+            )+
+            v.sort_by_key(|b| std::cmp::Reverse(b.priority()));
+            v
+        }
+    };
+}
+
+register_index_backends! {
+    crate::hnsw::HnswBackend;
+    crate::cagra::CagraBackend, cfg(feature = "cuda-index");
 }
 
 #[cfg(test)]

--- a/src/index.rs
+++ b/src/index.rs
@@ -203,6 +203,16 @@ macro_rules! register_index_backends {
             ;
         )+
     ) => {
+        // `vec_init_then_push` fires when only one cfg-arm is active for a
+        // given build (no `cuda-index` → just HNSW, single `push` after
+        // `Vec::new()`). The macro can't statically know how many backends
+        // will be registered for a given build matrix, and `vec![...]`
+        // doesn't compose cleanly with per-row `#[cfg]` attributes (the
+        // closest equivalent — `vec![a, $(#[cfg] b,)?]` — trips on
+        // trailing-comma quirks under cfg pruning). The allow is
+        // load-bearing: removing it breaks `cargo clippy -- -D warnings` for
+        // every backend permutation that ends up with one row active.
+        #[allow(clippy::vec_init_then_push)]
         pub fn backends<Mode: ClearHnswDirty>() -> Vec<&'static dyn IndexBackend<Mode>> {
             let mut v: Vec<&'static dyn IndexBackend<Mode>> = Vec::new();
             $(


### PR DESCRIPTION
## Summary

Closes #1348 (P4-12, EX-V1.33-2): collapses the hand-rolled `backends<Mode>()` cfg-arm cluster into a single `register_index_backends!` macro table.

## Why

`pub fn backends<Mode>()` previously held two hardcoded `vec![]` literals gated on `#[cfg(feature = "cuda-index")]`:

```rust
pub fn backends<Mode>() -> Vec<&'static dyn IndexBackend<Mode>> {
    #[cfg(feature = "cuda-index")]
    let mut v = vec![&CagraBackend, &HnswBackend];
    #[cfg(not(feature = "cuda-index"))]
    let mut v = vec![&HnswBackend];
    v.sort_by_key(|b| std::cmp::Reverse(b.priority()));
    v
}
```

Adding a third backend (USearch / Metal / ROCm / SIMD brute-force) would have required **four `#[cfg]` permutations** per the cuda+new feature-flag matrix (cuda+new, cuda only, new only, neither). Every additional feature flag squared the cfg arms.

## Change

A local `register_index_backends!` macro takes a declarative table of `Backend; … cfg(feature = "X");` rows and emits the `backends<Mode>()` function with `#[cfg]` only on the rows that need it:

```rust
register_index_backends! {
    crate::hnsw::HnswBackend;
    crate::cagra::CagraBackend, cfg(feature = "cuda-index");
}
```

The cfg matrix collapses: each backend is one row, regardless of how many other feature-gated backends are registered. Adding a fourth or fifth backend is a one-line change.

No `inventory` / `linkme` dep — the local macro covers the same distributed-slice ergonomics for the small (currently 2-row, projected ≤6-row) backend table without pulling in another crate.

## Test plan

- [x] `cargo build` (default features, no cuda-index) — clean
- [x] `cargo build --features cuda-index` — clean
- [x] `cargo test --features cuda-index --lib backends_slice` — 2 tests pass (`test_backends_slice_ordering_readwrite`, `test_backends_slice_ordering_readonly`)
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
