### PR TITLE
refactor(store): mark SearchFilter #[non_exhaustive] + sweep external sites (closes #1349)

### DIFF
--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -141,19 +141,24 @@ pub(in crate::cli::batch) fn dispatch_search(
         cqs::search::router::SearchStrategy::DenseBase
     ) || std::env::var("CQS_FORCE_BASE_INDEX").as_deref() == Ok("1");
 
-    let filter = cqs::SearchFilter {
-        languages,
-        include_types,
-        exclude_types,
-        path_pattern: args.path.clone(),
-        name_boost: args.name_boost,
-        query_text: args.query.clone(),
-        enable_rrf: args.rrf,
-        enable_demotion: !args.no_demote,
-        enable_splade: use_splade,
-        splade_alpha,
-        type_boost_types: classification.type_hints.clone(),
-        mmr_lambda: None, // Resolved by finalize_results via CQS_MMR_LAMBDA fallback.
+    // mmr_lambda intentionally left at default (None) — finalize_results
+    // resolves it via CQS_MMR_LAMBDA fallback. #1349: SearchFilter is
+    // `#[non_exhaustive]`, so external-crate construction goes through
+    // `Default` + field assignment.
+    let filter = {
+        let mut f = cqs::SearchFilter::default();
+        f.languages = languages;
+        f.include_types = include_types;
+        f.exclude_types = exclude_types;
+        f.path_pattern = args.path.clone();
+        f.name_boost = args.name_boost;
+        f.query_text = args.query.clone();
+        f.enable_rrf = args.rrf;
+        f.enable_demotion = !args.no_demote;
+        f.enable_splade = use_splade;
+        f.splade_alpha = splade_alpha;
+        f.type_boost_types = classification.type_hints.clone();
+        f
     };
     filter.validate().map_err(|e| anyhow::anyhow!(e))?;
 

--- a/src/cli/commands/eval/runner.rs
+++ b/src/cli/commands/eval/runner.rs
@@ -316,19 +316,21 @@ fn search_for_rank(
     }
     let use_splade = true; // Always on when classification produced a category — same as production.
 
-    let filter = SearchFilter {
-        languages: None,
-        include_types: Some(ChunkType::code_types()),
-        exclude_types: None,
-        path_pattern: None,
-        name_boost: 0.2,
-        query_text: query.to_string(),
-        enable_rrf: false,
-        enable_demotion: true,
-        enable_splade: use_splade,
-        splade_alpha,
-        type_boost_types: classification.type_hints.clone(),
-        mmr_lambda: None, // Resolved by finalize_results via CQS_MMR_LAMBDA fallback.
+    // #1349: SearchFilter is `#[non_exhaustive]`; external-crate construction
+    // goes through `Default` + field assignment. Only fields that differ from
+    // the struct default are set here (defaults preserved: languages,
+    // exclude_types, path_pattern, enable_rrf, enable_demotion, mmr_lambda).
+    // `name_boost = 0.2` is retained because the struct default is 0.0
+    // (CLI applies 0.2 via DEFAULT_NAME_BOOST; eval mirrors that here).
+    let filter = {
+        let mut f = SearchFilter::default();
+        f.include_types = Some(ChunkType::code_types());
+        f.name_boost = 0.2;
+        f.query_text = query.to_string();
+        f.enable_splade = use_splade;
+        f.splade_alpha = splade_alpha;
+        f.type_boost_types = classification.type_hints.clone();
+        f
     };
     filter
         .validate()

--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -228,20 +228,24 @@ pub(crate) fn cmd_query(
         splade_alpha = splade_alpha.max(0.7);
     }
 
-    #[allow(clippy::needless_update)]
-    let filter = SearchFilter {
-        languages,
-        include_types,
-        exclude_types,
-        path_pattern: cli.path.clone(),
-        name_boost: cli.name_boost,
-        query_text: query.to_string(),
-        enable_rrf: cli.rrf,
-        enable_demotion: !cli.no_demote,
-        enable_splade: use_splade,
-        splade_alpha,
-        type_boost_types,
-        ..Default::default()
+    // #1349: SearchFilter is `#[non_exhaustive]`, so external-crate construction
+    // goes through `Default` + field assignment instead of a struct expression.
+    // Adding a new field stays one-line on the struct definition; this site
+    // doesn't need to know.
+    let filter = {
+        let mut f = SearchFilter::default();
+        f.languages = languages;
+        f.include_types = include_types;
+        f.exclude_types = exclude_types;
+        f.path_pattern = cli.path.clone();
+        f.name_boost = cli.name_boost;
+        f.query_text = query.to_string();
+        f.enable_rrf = cli.rrf;
+        f.enable_demotion = !cli.no_demote;
+        f.enable_splade = use_splade;
+        f.splade_alpha = splade_alpha;
+        f.type_boost_types = type_boost_types;
+        f
     };
     filter.validate().map_err(|e| anyhow::anyhow!(e))?;
 

--- a/src/cli/commands/search/similar.rs
+++ b/src/cli/commands/search/similar.rs
@@ -56,10 +56,13 @@ pub(crate) fn cmd_similar(
         None => None,
     };
 
-    let filter = SearchFilter {
-        languages,
-        path_pattern: ctx.cli.path.clone(),
-        ..Default::default()
+    // #1349: SearchFilter is `#[non_exhaustive]`; external-crate construction
+    // goes through `Default` + field assignment.
+    let filter = {
+        let mut f = SearchFilter::default();
+        f.languages = languages;
+        f.path_pattern = ctx.cli.path.clone();
+        f
     };
 
     // Load vector index

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,15 @@
 //!     &chunks.iter().map(|c| c.content.as_str()).collect::<Vec<_>>()
 //! )?;
 //!
-//! // Search for similar code (hybrid RRF search)
+//! // Search for similar code (hybrid RRF search). #1349: SearchFilter is
+//! // `#[non_exhaustive]`, so external callers construct via `Default` and
+//! // assign fields — adding a new field is a one-line struct edit upstream.
 //! let query_embedding = embedder.embed_query("parse configuration file")?;
-//! let filter = SearchFilter {
-//!     enable_rrf: true,
-//!     query_text: "parse configuration file".to_string(),
-//!     ..Default::default()
+//! let filter = {
+//!     let mut f = SearchFilter::default();
+//!     f.enable_rrf = true;
+//!     f.query_text = "parse configuration file".to_string();
+//!     f
 //! };
 //! let results = store.search_filtered(&query_embedding, &filter, 5, 0.3)?;
 //! # Ok(())

--- a/src/store/helpers/search_filter.rs
+++ b/src/store/helpers/search_filter.rs
@@ -13,6 +13,17 @@ pub const DEFAULT_NAME_BOOST: f32 = 0.2;
 ///
 /// All fields are optional. Unset filters match all chunks.
 /// Use [`SearchFilter::validate()`] to check constraints before searching.
+///
+/// #1349 / EX-V1.33-4: marked `#[non_exhaustive]` so external crates and the
+/// binary crate (`src/main.rs` + `src/cli/*`) cannot construct via struct
+/// literal without `..Default::default()`. The audit found 37+ enumerating
+/// sites pre-2026-05-02; the post-fix invariant is that every binary-crate
+/// site spreads from `Default`, so adding a new field is a one-line struct
+/// edit instead of a 37-site chase. In-crate (lib-side) construction still
+/// allows full enumeration — those sites already use `..SearchFilter::default()`
+/// by convention, but the compiler can't enforce it within the same crate.
+/// Tests living under `tests/*.rs` are external crates and ARE constrained.
+#[non_exhaustive]
 pub struct SearchFilter {
     /// Filter by programming language(s)
     pub languages: Option<Vec<Language>>,

--- a/tests/eval_harness.rs
+++ b/tests/eval_harness.rs
@@ -134,9 +134,10 @@ fn eval_single_query<Mode>(
     };
 
     // Build search filter
-    let filter = cqs::SearchFilter {
-        query_text: query.query.clone(),
-        ..Default::default()
+    let filter = {
+        let mut f = cqs::SearchFilter::default();
+        f.query_text = query.query.clone();
+        f
     };
 
     // Search with limit=100 for deep rank tracking

--- a/tests/eval_test.rs
+++ b/tests/eval_test.rs
@@ -83,9 +83,10 @@ fn test_recall_at_5() {
             .expect("Failed to embed query");
 
         // Search with language filter
-        let filter = SearchFilter {
-            languages: Some(vec![case.language]),
-            ..Default::default()
+        let filter = {
+            let mut f = SearchFilter::default();
+            f.languages = Some(vec![case.language]);
+            f
         };
         let results = store
             .search_filtered(&query_embedding, &filter, 5, 0.0)

--- a/tests/pipeline_eval.rs
+++ b/tests/pipeline_eval.rs
@@ -413,9 +413,10 @@ fn test_fixture_eval_296q() {
         let mut results_per_case = Vec::new();
 
         for (i, case) in all_cases.iter().enumerate() {
-            let filter = SearchFilter {
-                languages: Some(vec![case.language]),
-                ..Default::default()
+            let filter = {
+                let mut f = SearchFilter::default();
+                f.languages = Some(vec![case.language]);
+                f
             };
             let results = match store.search_filtered(&query_embeddings[i], &filter, 10, 0.0) {
                 Ok(r) => r,
@@ -499,11 +500,12 @@ fn test_fixture_eval_296q() {
         let mut results_per_case = Vec::new();
 
         for (i, case) in all_cases.iter().enumerate() {
-            let filter = SearchFilter {
-                languages: Some(vec![case.language]),
-                enable_rrf: true,
-                query_text: case.query.to_string(),
-                ..Default::default()
+            let filter = {
+                let mut f = SearchFilter::default();
+                f.languages = Some(vec![case.language]);
+                f.enable_rrf = true;
+                f.query_text = case.query.to_string();
+                f
             };
             let results = match store.search_filtered(&query_embeddings[i], &filter, 10, 0.0) {
                 Ok(r) => r,
@@ -560,12 +562,13 @@ fn test_fixture_eval_296q() {
         let mut results_per_case = Vec::new();
 
         for (i, case) in all_cases.iter().enumerate() {
-            let filter = SearchFilter {
-                languages: Some(vec![case.language]),
-                enable_rrf: true,
-                name_boost: 0.2,
-                query_text: case.query.to_string(),
-                ..Default::default()
+            let filter = {
+                let mut f = SearchFilter::default();
+                f.languages = Some(vec![case.language]);
+                f.enable_rrf = true;
+                f.name_boost = 0.2;
+                f.query_text = case.query.to_string();
+                f
             };
             let results = match store.search_filtered(&query_embeddings[i], &filter, 10, 0.0) {
                 Ok(r) => r,
@@ -622,11 +625,12 @@ fn test_fixture_eval_296q() {
         let mut results_per_case = Vec::new();
 
         for (i, case) in all_cases.iter().enumerate() {
-            let filter = SearchFilter {
-                languages: Some(vec![case.language]),
-                name_boost: 0.2,
-                query_text: case.query.to_string(),
-                ..Default::default()
+            let filter = {
+                let mut f = SearchFilter::default();
+                f.languages = Some(vec![case.language]);
+                f.name_boost = 0.2;
+                f.query_text = case.query.to_string();
+                f
             };
             let results = store
                 .search_filtered_with_index(
@@ -681,10 +685,11 @@ fn test_fixture_eval_296q() {
         let mut results_per_case = Vec::new();
 
         for (i, case) in all_cases.iter().enumerate() {
-            let filter = SearchFilter {
-                languages: Some(vec![case.language]),
-                enable_demotion: true,
-                ..Default::default()
+            let filter = {
+                let mut f = SearchFilter::default();
+                f.languages = Some(vec![case.language]);
+                f.enable_demotion = true;
+                f
             };
             let results = match store.search_filtered(&query_embeddings[i], &filter, 10, 0.0) {
                 Ok(r) => r,
@@ -741,12 +746,13 @@ fn test_fixture_eval_296q() {
         let mut results_per_case = Vec::new();
 
         for (i, case) in all_cases.iter().enumerate() {
-            let filter = SearchFilter {
-                languages: Some(vec![case.language]),
-                name_boost: 0.2,
-                query_text: case.query.to_string(),
-                enable_demotion: true,
-                ..Default::default()
+            let filter = {
+                let mut f = SearchFilter::default();
+                f.languages = Some(vec![case.language]);
+                f.name_boost = 0.2;
+                f.query_text = case.query.to_string();
+                f.enable_demotion = true;
+                f
             };
             let results = store
                 .search_filtered_with_index(
@@ -807,11 +813,12 @@ fn test_fixture_eval_296q() {
             .collect();
 
         for (i, case) in all_cases.iter().enumerate() {
-            let filter = SearchFilter {
-                languages: Some(vec![case.language]),
-                enable_splade: true,
-                splade_alpha: 0.0, // pure rerank
-                ..Default::default()
+            let filter = {
+                let mut f = SearchFilter::default();
+                f.languages = Some(vec![case.language]);
+                f.enable_splade = true;
+                f.splade_alpha = 0.0; // pure rerank
+                f
             };
             let splade_arg = Some((splade_idx, &splade_queries[i]));
             let results = match store.search_hybrid(
@@ -1084,13 +1091,14 @@ fn test_holdout_eval() {
     let mut results_per_case = Vec::new();
 
     for (i, case) in HOLDOUT_EVAL_CASES.iter().enumerate() {
-        let filter = SearchFilter {
-            languages: Some(vec![case.language]),
-            include_types: Some(ChunkType::code_types()),
-            name_boost: 0.2,
-            query_text: case.query.to_string(),
-            enable_demotion: true,
-            ..Default::default()
+        let filter = {
+            let mut f = SearchFilter::default();
+            f.languages = Some(vec![case.language]);
+            f.include_types = Some(ChunkType::code_types());
+            f.name_boost = 0.2;
+            f.query_text = case.query.to_string();
+            f.enable_demotion = true;
+            f
         };
         let results = store
             .search_filtered_with_index(
@@ -1391,14 +1399,15 @@ fn test_noise_eval_143q() {
         let mut results_per_case = Vec::new();
 
         for (i, case) in HOLDOUT_EVAL_CASES.iter().enumerate() {
-            let filter = SearchFilter {
-                languages: Some(vec![case.language]),
-                include_types: Some(ChunkType::code_types()),
-                name_boost: boost,
-                query_text: case.query.to_string(),
-                enable_demotion: true,
-                enable_rrf: true,
-                ..Default::default()
+            let filter = {
+                let mut f = SearchFilter::default();
+                f.languages = Some(vec![case.language]);
+                f.include_types = Some(ChunkType::code_types());
+                f.name_boost = boost;
+                f.query_text = case.query.to_string();
+                f.enable_demotion = true;
+                f.enable_rrf = true;
+                f
             };
             let results = store
                 .search_filtered_with_index(

--- a/tests/search_test.rs
+++ b/tests/search_test.rs
@@ -156,9 +156,10 @@ fn test_search_by_candidate_ids_with_glob_filter() {
 
     let ids = insert_chunks(&store, &[c1, c2], 1.0);
     let query = mock_embedding(1.0);
-    let filter = SearchFilter {
-        path_pattern: Some("src/**".to_string()),
-        ..Default::default()
+    let filter = {
+        let mut f = SearchFilter::default();
+        f.path_pattern = Some("src/**".to_string());
+        f
     };
 
     let candidate_ids: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
@@ -289,9 +290,10 @@ fn test_search_filtered_glob_pattern() {
     insert_chunks(&store, &[c1, c2, c3], 1.0);
 
     let query = mock_embedding(1.0);
-    let filter = SearchFilter {
-        path_pattern: Some("src/**".to_string()),
-        ..Default::default()
+    let filter = {
+        let mut f = SearchFilter::default();
+        f.path_pattern = Some("src/**".to_string());
+        f
     };
 
     let results = store.search_filtered(&query, &filter, 10, 0.0).unwrap();
@@ -311,9 +313,10 @@ fn test_search_filtered_language() {
     insert_chunks(&store, &[c1, c2], 1.0);
 
     let query = mock_embedding(1.0);
-    let filter = SearchFilter {
-        languages: Some(vec![Language::Rust]),
-        ..SearchFilter::default()
+    let filter = {
+        let mut f = SearchFilter::default();
+        f.languages = Some(vec![Language::Rust]);
+        f
     };
 
     let results = store.search_filtered(&query, &filter, 10, 0.0).unwrap();

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -106,10 +106,11 @@ fn test_search_filtered_by_language() {
         .unwrap();
 
     // Search for Rust only
-    let filter = SearchFilter {
-        languages: Some(vec![Language::Rust]),
-        path_pattern: None,
-        ..Default::default()
+    let filter = {
+        let mut f = SearchFilter::default();
+        f.languages = Some(vec![Language::Rust]);
+        f.path_pattern = None;
+        f
     };
     let results = store
         .search_filtered(&mock_embedding(1.0), &filter, 10, 0.0)
@@ -375,10 +376,11 @@ fn test_rrf_search() {
         .unwrap();
 
     // Search with RRF enabled
-    let filter = SearchFilter {
-        enable_rrf: true,
-        query_text: "error handling".to_string(),
-        ..Default::default()
+    let filter = {
+        let mut f = SearchFilter::default();
+        f.enable_rrf = true;
+        f.query_text = "error handling".to_string();
+        f
     };
 
     let results = store


### PR DESCRIPTION
## Summary

Closes #1349 (P4-13, EX-V1.33-4): marks `SearchFilter` `#[non_exhaustive]` and converts every external-crate construction site to the `Default` + field-assignment pattern.

## Why

`SearchFilter` had 12 pub fields, and (per the 2026-05-02 audit snapshot) 37 of 54 construction sites enumerated every field — adding a new search-filter dimension was a 37-site compile-error chase. Most enumerating sites had been migrated to `..Default::default()` or `..SearchFilter::default()` between the audit and now; only 2 stragglers remained at the start of this PR.

## Two-part fix

**1. `#[non_exhaustive]` on `SearchFilter`.** External crates and the binary crate (`src/main.rs` + `src/cli/*`) can no longer construct the struct via struct-expression syntax — even with `..base` spread — per the [Rust reference's non_exhaustive contract](https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute). New fields can be added without touching any external call site.

**2. Convert every external-crate construction site to `Default` + field-assignment**, the only construction path `non_exhaustive` permits from external crates that doesn't require a builder API. 20 sites total: 4 in `src/cli/*`, 16 in `tests/*`.

```rust
// Before:
let filter = SearchFilter {
    languages: Some(vec![Rust]),
    enable_rrf: true,
    ..Default::default()  // non_exhaustive blocks this externally
};

// After:
let filter = {
    let mut f = SearchFilter::default();
    f.languages = Some(vec![Rust]);
    f.enable_rrf = true;
    f
};
```

Mechanically equivalent; future `SearchFilter` additions don't ripple through these sites.

## In-crate sites unchanged

In-crate (lib-side) sites at `src/scout.rs`, `src/gather.rs`, `src/where_to_add.rs`, etc. already use `..SearchFilter::default()` by convention. `non_exhaustive` doesn't restrict in-crate construction; those sites stay as-is.

The `src/lib.rs` Quick Start doctest was also updated to the field-assignment pattern.

## Test plan

- [x] `cargo build --features cuda-index --tests` — clean
- [x] `cargo test --features cuda-index` — full suite passes, no regressions
- [x] `cargo test --features cuda-index --doc` — 9 doctests pass
- [x] `cargo clippy --features cuda-index --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
