### PR TITLE
refactor(llm): collapse BatchProvider submit_*_batch trio into BatchKind enum (closes #1347)

### DIFF
--- a/src/llm/batch.rs
+++ b/src/llm/batch.rs
@@ -107,43 +107,6 @@ impl LlmClient {
         Ok(batch.id)
     }
 
-    /// Submit a batch where prompts are already built (content field IS the prompt).
-    /// Used by the contrastive summary path which pre-builds prompts with neighbor context.
-    pub(super) fn submit_batch_prebuilt(
-        &self,
-        items: &[super::provider::BatchSubmitItem],
-        max_tokens: u32,
-    ) -> Result<String, LlmError> {
-        // Identity: content is already the full prompt, ignore field3/language
-        self.submit_batch_inner(items, max_tokens, "Batch", |content, _, _| {
-            content.to_string()
-        })
-    }
-
-    /// Submit a batch of doc-comment requests to the Batches API.
-    /// Like `submit_batch` but uses `build_doc_prompt` instead of `build_prompt`.
-    /// `items` is a list of (custom_id, content, chunk_type, language).
-    /// Returns the batch ID for polling.
-    pub(super) fn submit_doc_batch(
-        &self,
-        items: &[super::provider::BatchSubmitItem],
-        max_tokens: u32,
-    ) -> Result<String, LlmError> {
-        self.submit_batch_inner(items, max_tokens, "Doc batch", Self::build_doc_prompt)
-    }
-
-    /// Submit a batch of HyDE query prediction requests to the Batches API.
-    /// Like `submit_doc_batch` but uses `build_hyde_prompt` instead of `build_doc_prompt`.
-    /// `items` is a list of (custom_id, content, signature, language).
-    /// Returns the batch ID for polling.
-    pub(super) fn submit_hyde_batch(
-        &self,
-        items: &[super::provider::BatchSubmitItem],
-        max_tokens: u32,
-    ) -> Result<String, LlmError> {
-        self.submit_batch_inner(items, max_tokens, "Hyde batch", Self::build_hyde_prompt)
-    }
-
     /// Check the current status of a batch without polling.
     pub(super) fn check_batch_status(&self, batch_id: &str) -> Result<String, LlmError> {
         let _span = tracing::debug_span!("check_batch_status", batch_id).entered();
@@ -376,28 +339,30 @@ impl LlmClient {
 }
 
 impl BatchProvider for LlmClient {
-    fn submit_batch_prebuilt(
+    fn submit_batch(
         &self,
+        kind: super::provider::BatchKind,
         items: &[super::provider::BatchSubmitItem],
         max_tokens: u32,
     ) -> Result<String, LlmError> {
-        LlmClient::submit_batch_prebuilt(self, items, max_tokens)
-    }
-
-    fn submit_doc_batch(
-        &self,
-        items: &[super::provider::BatchSubmitItem],
-        max_tokens: u32,
-    ) -> Result<String, LlmError> {
-        LlmClient::submit_doc_batch(self, items, max_tokens)
-    }
-
-    fn submit_hyde_batch(
-        &self,
-        items: &[super::provider::BatchSubmitItem],
-        max_tokens: u32,
-    ) -> Result<String, LlmError> {
-        LlmClient::submit_hyde_batch(self, items, max_tokens)
+        // #1347: dispatch on `BatchKind` once; the inner submit_batch_inner
+        // takes the chosen prompt builder + log purpose verbatim. Adding a
+        // fourth kind is one new variant + one new arm.
+        use super::provider::BatchKind;
+        let purpose = kind.purpose_label();
+        match kind {
+            BatchKind::Prebuilt => {
+                self.submit_batch_inner(items, max_tokens, purpose, |content, _ctx, _lang| {
+                    content.to_string()
+                })
+            }
+            BatchKind::DocComment => {
+                self.submit_batch_inner(items, max_tokens, purpose, Self::build_doc_prompt)
+            }
+            BatchKind::Hyde => {
+                self.submit_batch_inner(items, max_tokens, purpose, Self::build_hyde_prompt)
+            }
+        }
     }
 
     fn check_batch_status(&self, batch_id: &str) -> Result<String, LlmError> {
@@ -884,7 +849,9 @@ mod tests {
             &items,
             &|s| s.get_pending_batch_id(),
             &|s, id| s.set_pending_batch_id(id),
-            &|c, items, max_tok| c.submit_batch_prebuilt(items, max_tok),
+            &|c, items, max_tok| {
+                c.submit_batch(crate::llm::provider::BatchKind::Prebuilt, items, max_tok)
+            },
         );
 
         let map = result.unwrap();
@@ -924,7 +891,9 @@ mod tests {
             &[], // empty batch items
             &|s| s.get_pending_batch_id(),
             &|s, id| s.set_pending_batch_id(id),
-            &|c, items, max_tok| c.submit_batch_prebuilt(items, max_tok),
+            &|c, items, max_tok| {
+                c.submit_batch(crate::llm::provider::BatchKind::Prebuilt, items, max_tok)
+            },
         );
 
         let map = result.unwrap();
@@ -1003,7 +972,9 @@ mod tests {
             &items,
             &|s| s.get_pending_batch_id(),
             &|s, id| s.set_pending_batch_id(id),
-            &|c, items, max_tok| c.submit_batch_prebuilt(items, max_tok),
+            &|c, items, max_tok| {
+                c.submit_batch(crate::llm::provider::BatchKind::Prebuilt, items, max_tok)
+            },
         );
 
         let map = result.unwrap();
@@ -1041,7 +1012,9 @@ mod tests {
             &[],
             &|s| s.get_pending_batch_id(),
             &|s, id| s.set_pending_batch_id(id),
-            &|c, items, max_tok| c.submit_batch_prebuilt(items, max_tok),
+            &|c, items, max_tok| {
+                c.submit_batch(crate::llm::provider::BatchKind::Prebuilt, items, max_tok)
+            },
         );
 
         let map = result.unwrap();

--- a/src/llm/doc_comments.rs
+++ b/src/llm/doc_comments.rs
@@ -293,7 +293,9 @@ pub fn doc_comment_pass(
         &batch_items,
         &|s| s.get_pending_doc_batch_id(),
         &|s, id| s.set_pending_doc_batch_id(id),
-        &|c, items, max_tok| c.submit_doc_batch(items, max_tok),
+        &|c, items, max_tok| {
+            c.submit_batch(crate::llm::provider::BatchKind::DocComment, items, max_tok)
+        },
     );
 
     // #1126 / P2.60: drain the per-Store summary queue regardless of

--- a/src/llm/hyde.rs
+++ b/src/llm/hyde.rs
@@ -89,7 +89,7 @@ pub fn hyde_query_pass(
         &batch_items,
         &|s| s.get_pending_hyde_batch_id(),
         &|s, id| s.set_pending_hyde_batch_id(id),
-        &|c, items, max_tok| c.submit_hyde_batch(items, max_tok),
+        &|c, items, max_tok| c.submit_batch(crate::llm::provider::BatchKind::Hyde, items, max_tok),
     );
 
     // #1126 / P2.60: drain the per-Store summary queue regardless of

--- a/src/llm/local.rs
+++ b/src/llm/local.rs
@@ -828,31 +828,36 @@ fn body_preview(resp: reqwest::blocking::Response) -> String {
 }
 
 impl BatchProvider for LocalProvider {
-    fn submit_batch_prebuilt(
+    fn submit_batch(
         &self,
+        kind: super::provider::BatchKind,
         items: &[BatchSubmitItem],
         max_tokens: u32,
     ) -> Result<String, LlmError> {
-        // Prebuilt prompts: content IS the user message. Ignore context/language.
-        self.submit_via_chat_completions(items, max_tokens, "prebuilt", |content, _, _| {
-            content.to_string()
-        })
-    }
-
-    fn submit_doc_batch(
-        &self,
-        items: &[BatchSubmitItem],
-        max_tokens: u32,
-    ) -> Result<String, LlmError> {
-        self.submit_via_chat_completions(items, max_tokens, "doc", LlmClient::build_doc_prompt)
-    }
-
-    fn submit_hyde_batch(
-        &self,
-        items: &[BatchSubmitItem],
-        max_tokens: u32,
-    ) -> Result<String, LlmError> {
-        self.submit_via_chat_completions(items, max_tokens, "hyde", LlmClient::build_hyde_prompt)
+        // #1347: dispatch on `BatchKind` once. Adding a new kind is one
+        // arm. The historical purpose-label strings ("prebuilt" / "doc" /
+        // "hyde") are kept stable so existing log greps still match.
+        use super::provider::BatchKind;
+        match kind {
+            BatchKind::Prebuilt => {
+                // Prebuilt prompts: content IS the user message. Ignore context/language.
+                self.submit_via_chat_completions(items, max_tokens, "prebuilt", |content, _, _| {
+                    content.to_string()
+                })
+            }
+            BatchKind::DocComment => self.submit_via_chat_completions(
+                items,
+                max_tokens,
+                "doc",
+                LlmClient::build_doc_prompt,
+            ),
+            BatchKind::Hyde => self.submit_via_chat_completions(
+                items,
+                max_tokens,
+                "hyde",
+                LlmClient::build_hyde_prompt,
+            ),
+        }
     }
 
     fn check_batch_status(&self, _batch_id: &str) -> Result<String, LlmError> {
@@ -959,7 +964,9 @@ mod tests {
         }));
 
         let items = make_items(3);
-        let batch_id = provider.submit_batch_prebuilt(&items, 100).unwrap();
+        let batch_id = provider
+            .submit_batch(crate::llm::provider::BatchKind::Prebuilt, &items, 100)
+            .unwrap();
         assert!(provider.is_valid_batch_id(&batch_id));
 
         let results = provider.fetch_batch_results(&batch_id).unwrap();
@@ -1002,7 +1009,9 @@ mod tests {
         }));
 
         let items = make_items(3);
-        let batch_id = provider.submit_batch_prebuilt(&items, 100).unwrap();
+        let batch_id = provider
+            .submit_batch(crate::llm::provider::BatchKind::Prebuilt, &items, 100)
+            .unwrap();
         let results = provider.fetch_batch_results(&batch_id).unwrap();
 
         assert_eq!(results.len(), 3);
@@ -1032,7 +1041,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         assert_eq!(provider.fetch_batch_results(&batch_id).unwrap().len(), 1);
         m.assert();
 
@@ -1067,7 +1082,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         assert_eq!(provider.fetch_batch_results(&batch_id).unwrap().len(), 1);
         // Mock fires when the request lacks conditions mocks reject; our
         // happy-path `auth_header_present_when_key_set` already proves that
@@ -1105,7 +1126,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         let results = provider.fetch_batch_results(&batch_id).unwrap();
         assert!(
             results.is_empty(),
@@ -1139,7 +1166,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         assert_eq!(provider.fetch_batch_results(&batch_id).unwrap().len(), 1);
 
         std::env::remove_var("CQS_LOCAL_LLM_CONCURRENCY");
@@ -1165,7 +1198,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         let results = provider.fetch_batch_results(&batch_id).unwrap();
         assert_eq!(
             results.get("hash_0").map(|s| s.as_str()),
@@ -1195,7 +1234,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         let results = provider.fetch_batch_results(&batch_id).unwrap();
         assert_eq!(results.get("hash_0").map(|s| s.len()), Some(100_000));
 
@@ -1221,7 +1266,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
 
         let first = provider.fetch_batch_results(&batch_id).unwrap();
         assert_eq!(first.len(), 1);
@@ -1248,7 +1299,13 @@ mod tests {
         // Point at a closed port (high-numbered loopback) so connect fails fast.
         let config = make_config("http://127.0.0.1:1/v1", "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         let results = provider.fetch_batch_results(&batch_id).unwrap();
         // All retries exhausted → item failed → empty stash.
         assert!(
@@ -1279,7 +1336,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         let results = provider.fetch_batch_results(&batch_id).unwrap();
         assert!(
             results.is_empty(),
@@ -1307,7 +1370,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         let results = provider.fetch_batch_results(&batch_id).unwrap();
         assert!(
             results.is_empty(),
@@ -1336,7 +1405,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         let results = provider.fetch_batch_results(&batch_id).unwrap();
         assert!(results.is_empty());
 
@@ -1362,7 +1437,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         let results = provider.fetch_batch_results(&batch_id).unwrap();
         assert!(results.is_empty());
         // Only 1 HTTP call, not 4 — skip-without-retry path.
@@ -1388,7 +1469,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         let _ = provider.fetch_batch_results(&batch_id);
         m.assert_hits(1);
 
@@ -1412,7 +1499,11 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let result = provider.submit_batch_prebuilt(&make_items(1), 100);
+        let result = provider.submit_batch(
+            crate::llm::provider::BatchKind::Prebuilt,
+            &make_items(1),
+            100,
+        );
         match result {
             Err(LlmError::Api { status, message }) => {
                 assert_eq!(status, 401);
@@ -1518,7 +1609,9 @@ mod tests {
         }));
 
         let items = make_items(4);
-        let batch_id = provider.submit_batch_prebuilt(&items, 100).unwrap();
+        let batch_id = provider
+            .submit_batch(crate::llm::provider::BatchKind::Prebuilt, &items, 100)
+            .unwrap();
         let results = provider.fetch_batch_results(&batch_id).unwrap();
         // All 4 items stashed — stash insert happens before callback fires.
         assert_eq!(results.len(), 4);
@@ -1559,7 +1652,13 @@ mod tests {
         // submit_batch_prebuilt must still succeed (returns a batch id) — the
         // single item failed during parse and was recorded as failed, not
         // bubbled up. Successful items count = 0; stash is empty.
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         let results = provider.fetch_batch_results(&batch_id).unwrap();
         assert!(
             results.is_empty(),
@@ -1594,7 +1693,13 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
-        let batch_id = provider.submit_batch_prebuilt(&make_items(1), 100).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
         let results = provider.fetch_batch_results(&batch_id).unwrap();
         assert!(
             results.is_empty(),

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -41,9 +41,9 @@ pub struct BatchSubmitItem {
     ///
     /// | Submission path                          | Field carries           |
     /// |------------------------------------------|-------------------------|
-    /// | `submit_batch_prebuilt` (contrastive)    | unused (`String::new`)  |
-    /// | `submit_doc_batch` (doc comments)        | function signature      |
-    /// | `submit_hyde_batch` (HyDE queries)       | unused (`String::new`)  |
+    /// | `BatchKind::Prebuilt` (contrastive)      | unused (`String::new`)  |
+    /// | `BatchKind::DocComment` (doc comments)   | function signature      |
+    /// | `BatchKind::Hyde` (HyDE queries)         | unused (`String::new`)  |
     /// | summary batches (`llm_summary_pass`)     | chunk type label        |
     ///
     /// The receiver decides; a typo at the call site silently sends
@@ -55,28 +55,57 @@ pub struct BatchSubmitItem {
     pub language: String,
 }
 
+/// Which prompt builder a batch submission uses.
+///
+/// #1347 / EX-V1.33-1: replaces the three `submit_*_batch` trait methods
+/// (`Prebuilt` / `DocComment` / `Hyde`) that differed only in which
+/// `build_*_prompt` closure was passed to `submit_batch_inner` /
+/// `submit_via_chat_completions`. Adding a fourth purpose (e.g.
+/// `Classification`, `ContrastiveRepair`, `CodeReview`) is now a single new
+/// variant + the impl's `match` arm — instead of: a new trait method × a
+/// new impl on every `BatchProvider` (4 sites: `LlmClient`, `LocalProvider`,
+/// `MockBatchProvider`, `DefaultValidationProvider`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BatchKind {
+    /// Pre-built prompts — `BatchSubmitItem::content` IS the user message.
+    /// Used by the contrastive summary path which pre-builds prompts with
+    /// neighbor context. `context` / `language` fields ignored.
+    Prebuilt,
+    /// Doc-comment generation — uses `LlmClient::build_doc_prompt`.
+    /// `BatchSubmitItem::context` carries the function signature.
+    DocComment,
+    /// HyDE query prediction — uses `LlmClient::build_hyde_prompt`.
+    /// `BatchSubmitItem::context` carries the function signature.
+    Hyde,
+}
+
+impl BatchKind {
+    /// Short label for logging / error messages
+    /// (`"Batch"` / `"Doc batch"` / `"Hyde batch"` historically — kept
+    /// stable so log greps don't break).
+    pub fn purpose_label(&self) -> &'static str {
+        match self {
+            Self::Prebuilt => "Batch",
+            Self::DocComment => "Doc batch",
+            Self::Hyde => "Hyde batch",
+        }
+    }
+}
+
 /// Trait for LLM batch API providers.
 /// Abstracts the batch submission, polling, and result fetching lifecycle.
 /// Currently implemented for Anthropic's Messages Batches API.
 pub trait BatchProvider {
-    /// Submit a batch where prompts are already built (content field IS the prompt).
-    /// Used by the contrastive summary path which pre-builds prompts with neighbor context.
-    fn submit_batch_prebuilt(
+    /// Submit a batch under the given `kind`. The kind selects which prompt
+    /// builder constructs the user message from each `BatchSubmitItem`'s
+    /// `(content, context, language)` triple (or, for [`BatchKind::Prebuilt`],
+    /// uses `content` directly).
+    ///
+    /// #1347 / EX-V1.33-1: collapses the previous trio of `submit_batch_prebuilt`
+    /// / `submit_doc_batch` / `submit_hyde_batch` methods into one.
+    fn submit_batch(
         &self,
-        items: &[BatchSubmitItem],
-        max_tokens: u32,
-    ) -> Result<String, LlmError>;
-
-    /// Submit a batch of doc-comment requests. Returns the batch ID.
-    fn submit_doc_batch(
-        &self,
-        items: &[BatchSubmitItem],
-        max_tokens: u32,
-    ) -> Result<String, LlmError>;
-
-    /// Submit a batch of HyDE query prediction requests. Returns the batch ID.
-    fn submit_hyde_batch(
-        &self,
+        kind: BatchKind,
         items: &[BatchSubmitItem],
         max_tokens: u32,
     ) -> Result<String, LlmError>;
@@ -142,24 +171,9 @@ impl MockBatchProvider {
 
 #[cfg(test)]
 impl BatchProvider for MockBatchProvider {
-    fn submit_batch_prebuilt(
+    fn submit_batch(
         &self,
-        _items: &[BatchSubmitItem],
-        _max_tokens: u32,
-    ) -> Result<String, LlmError> {
-        Ok(self.batch_id.clone())
-    }
-
-    fn submit_doc_batch(
-        &self,
-        _items: &[BatchSubmitItem],
-        _max_tokens: u32,
-    ) -> Result<String, LlmError> {
-        Ok(self.batch_id.clone())
-    }
-
-    fn submit_hyde_batch(
-        &self,
+        _kind: BatchKind,
         _items: &[BatchSubmitItem],
         _max_tokens: u32,
     ) -> Result<String, LlmError> {
@@ -196,24 +210,9 @@ mod tests {
     struct DefaultValidationProvider;
 
     impl BatchProvider for DefaultValidationProvider {
-        fn submit_batch_prebuilt(
+        fn submit_batch(
             &self,
-            _items: &[BatchSubmitItem],
-            _max_tokens: u32,
-        ) -> Result<String, LlmError> {
-            Ok(String::new())
-        }
-
-        fn submit_doc_batch(
-            &self,
-            _items: &[BatchSubmitItem],
-            _max_tokens: u32,
-        ) -> Result<String, LlmError> {
-            Ok(String::new())
-        }
-
-        fn submit_hyde_batch(
-            &self,
+            _kind: BatchKind,
             _items: &[BatchSubmitItem],
             _max_tokens: u32,
         ) -> Result<String, LlmError> {

--- a/src/llm/summary.rs
+++ b/src/llm/summary.rs
@@ -133,7 +133,9 @@ pub fn llm_summary_pass(
         &batch_items,
         &|s| s.get_pending_batch_id(),
         &|s, id| s.set_pending_batch_id(id),
-        &|c, items, max_tok| c.submit_batch_prebuilt(items, max_tok),
+        &|c, items, max_tok| {
+            c.submit_batch(crate::llm::provider::BatchKind::Prebuilt, items, max_tok)
+        },
     );
 
     // #1126 / P2.60: drain the per-Store summary queue regardless of


### PR DESCRIPTION
## Summary

Closes #1347 (P4-11, EX-V1.33-1): collapses the three near-identical `BatchProvider::submit_*_batch` methods into a single `submit_batch(kind: BatchKind, items, max_tokens)`.

## Why

`BatchProvider` declared three trait methods that differed only in which `build_*_prompt` closure was passed to the impl's `submit_batch_inner` / `submit_via_chat_completions`. The Anthropic and Local impls each shipped three near-identical 7-line wrappers; adding a fourth purpose required a new trait method × four impl sites (`LlmClient`, `LocalProvider`, `MockBatchProvider`, `DefaultValidationProvider`) — exactly the maintenance hazard the audit flagged.

## Change

- **New `BatchKind` enum** with `Prebuilt`, `DocComment`, `Hyde` variants and a stable `purpose_label()` returning the historical log strings (`"Batch"` / `"Doc batch"` / `"Hyde batch"`) so existing greps don't break.
- **`BatchProvider` collapses to single `submit_batch`** method. Each impl pattern-matches on `kind` once and dispatches to existing `submit_batch_inner` / `submit_via_chat_completions` with the right prompt builder.
- **Dead `pub(super)` wrappers on `LlmClient`** (`submit_batch_prebuilt` / `submit_doc_batch` / `submit_hyde_batch`) deleted — `submit_batch` calls `submit_batch_inner` directly.
- **Call sites updated:**
  - `llm/summary.rs:136` → `BatchKind::Prebuilt`
  - `llm/doc_comments.rs:296` → `BatchKind::DocComment`
  - `llm/hyde.rs:92` → `BatchKind::Hyde`
  - 16+ test sites in `llm/local.rs` and `llm/batch.rs` → `BatchKind::Prebuilt`
- **`BatchSubmitItem::context` doc table updated** to refer to the new variant names.

Adding a fourth purpose (e.g. `Classification`, `ContrastiveRepair`, `CodeReview`) is now a single new variant + the impl's `match` arm — no per-impl wrapper.

## Test plan

- [x] `cargo build --features cuda-index --tests` — clean
- [x] `cargo test --features cuda-index` — full suite passes, no regressions
- [x] `cargo clippy --features cuda-index` (CI mode, no `--all-targets`) — no new warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
