### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"5558b8ee-4411-4380-aa4d-60eddd2fba72","pid":427,"procStart":"1838726","acquiredAt":1777855112803}

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ cuvs-fork-push
 # directory. Their `.git` is a file, not a directory; the file walker also
 # skips them at runtime to prevent indexing duplicated source trees.
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 
 # Reranker V2 retrain artifacts (large jsonl, train weights live in ~/training-data/)
 evals/reranker_v3/


### PR DESCRIPTION
Runtime lock file from Claude Code ScheduleWakeup tooling got committed inadvertently with #1427. Removed from repo + added to .gitignore.