### PR TITLE
perf(impact): Arc<str> keys in reverse-BFS + build_test_map (closes #1377 — P3-55)

### DIFF
--- a/src/cli/commands/graph/test_map.rs
+++ b/src/cli/commands/graph/test_map.rs
@@ -4,6 +4,7 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
 
@@ -87,11 +88,20 @@ pub(crate) fn build_test_map(
     let _span = tracing::info_span!("build_test_map", target_name, max_depth).entered();
     let max_nodes = test_map_max_nodes();
 
-    // Reverse BFS from target
-    let mut ancestors: HashMap<String, (usize, String)> = HashMap::new();
-    let mut queue: VecDeque<(String, usize)> = VecDeque::new();
-    ancestors.insert(target_name.to_string(), (0, String::new()));
-    queue.push_back((target_name.to_string(), 0));
+    // Reverse BFS from target.
+    // PERF-V1.33-1 / #1377 / P3-55: keys + parent-pointers are `Arc<str>`
+    // so the BFS reuses the already-interned names from `graph.reverse`
+    // instead of allocating a fresh `String` per visit. The chain walk
+    // also clones via `Arc::clone` (RC bump) instead of full `String`
+    // duplication. Pre-fix: ~10k `caller.to_string()` + `current.clone()`
+    // allocations per call on hub functions; post-fix: `Arc::clone`.
+    // `None` parent encodes "this is the target" — replaces the
+    // `String::new()` sentinel.
+    let mut ancestors: HashMap<Arc<str>, (usize, Option<Arc<str>>)> = HashMap::new();
+    let mut queue: VecDeque<(Arc<str>, usize)> = VecDeque::new();
+    let target_arc: Arc<str> = Arc::from(target_name);
+    ancestors.insert(Arc::clone(&target_arc), (0, None));
+    queue.push_back((target_arc, 0));
 
     while let Some((current, depth)) = queue.pop_front() {
         if depth >= max_depth {
@@ -105,14 +115,14 @@ pub(crate) fn build_test_map(
             );
             break;
         }
-        if let Some(callers) = graph.reverse.get(current.as_str()) {
+        if let Some(callers) = graph.reverse.get(current.as_ref()) {
             for caller in callers {
                 if ancestors.len() >= max_nodes {
                     break;
                 }
                 if !ancestors.contains_key(caller.as_ref()) {
-                    ancestors.insert(caller.to_string(), (depth + 1, current.clone()));
-                    queue.push_back((caller.to_string(), depth + 1));
+                    ancestors.insert(Arc::clone(caller), (depth + 1, Some(Arc::clone(&current))));
+                    queue.push_back((Arc::clone(caller), depth + 1));
                 }
             }
         }
@@ -121,20 +131,24 @@ pub(crate) fn build_test_map(
     // Collect matching tests
     let mut matches: Vec<TestMatch> = Vec::new();
     for test in test_chunks.iter() {
-        if let Some((depth, _)) = ancestors.get(&test.name) {
+        if let Some((depth, _)) = ancestors.get(test.name.as_str()) {
             if *depth > 0 {
-                let mut chain = Vec::new();
-                let mut current = test.name.clone();
+                let mut chain: Vec<String> = Vec::new();
+                // The chain walk needs an owned `Arc<str>` cursor to iterate
+                // parent pointers. Each step clones via `Arc::clone` (RC
+                // bump only); the rendered chain entries are `String` for
+                // the public TestMatch API.
+                let mut cursor: Arc<str> = Arc::from(test.name.as_str());
                 let chain_limit = max_depth + 1;
-                while !current.is_empty() && chain.len() < chain_limit {
-                    chain.push(current.clone());
-                    if current == target_name {
+                while chain.len() < chain_limit {
+                    chain.push(cursor.as_ref().to_string());
+                    if cursor.as_ref() == target_name {
                         break;
                     }
-                    current = match ancestors.get(&current) {
-                        Some((_, p)) if !p.is_empty() => p.clone(),
+                    cursor = match ancestors.get(&cursor) {
+                        Some((_, Some(p))) => Arc::clone(p),
                         _ => {
-                            tracing::debug!(node = %current, "Chain walk hit dead end");
+                            tracing::debug!(node = %cursor, "Chain walk hit dead end");
                             break;
                         }
                     };

--- a/src/impact/analysis.rs
+++ b/src/impact/analysis.rs
@@ -205,7 +205,7 @@ pub(crate) fn find_affected_tests_with_chunks(
     let mut tests: Vec<TestInfo> = test_chunks
         .iter()
         .filter_map(|test| {
-            ancestors.get(&test.name).and_then(|&d| {
+            ancestors.get(test.name.as_str()).and_then(|&d| {
                 if d > 0 {
                     Some(TestInfo {
                         name: test.name.clone(),
@@ -239,11 +239,12 @@ fn find_transitive_callers<Mode>(
     // Single graph traversal to collect all ancestors + depths
     let ancestors = reverse_bfs(graph, target_name, depth);
 
-    // Filter out the target itself and depth-0 entries
+    // Filter out the target itself and depth-0 entries.
+    // #1377/P3-55: keys are `Arc<str>`; use `as_ref()` to borrow `&str`.
     let caller_entries: Vec<(&str, usize)> = ancestors
         .iter()
-        .filter(|(name, &d)| d > 0 && name.as_str() != target_name)
-        .map(|(name, &d)| (name.as_str(), d))
+        .filter(|(name, &d)| d > 0 && name.as_ref() != target_name)
+        .map(|(name, &d)| (name.as_ref(), d))
         .collect();
 
     if caller_entries.is_empty() {

--- a/src/impact/bfs.rs
+++ b/src/impact/bfs.rs
@@ -39,15 +39,24 @@ pub(super) fn bfs_max_nodes() -> usize {
 /// Expansion stops when either `max_depth` or `bfs_max_nodes()` is reached.
 ///
 /// When `max_depth == 0`, returns only the target node at depth 0 (no traversal).
+///
+/// PERF-V1.33-1 / #1377 / P3-55: keys are `Arc<str>` so the BFS reuses the
+/// already-interned names from `graph.reverse` instead of allocating a
+/// fresh `String` per visit. On a hub function with thousands of
+/// transitive callers (default cap = 10k), pre-fix this was ~10k
+/// `caller.to_string()` heap allocations per call; post-fix it's
+/// `Arc::clone` (RC bump only). Lookup callers can still index by `&str`
+/// because `Arc<str>: Borrow<str>`.
 pub(super) fn reverse_bfs(
     graph: &CallGraph,
     target: &str,
     max_depth: usize,
-) -> HashMap<String, usize> {
-    let mut ancestors: HashMap<String, usize> = HashMap::new();
-    let mut queue: VecDeque<(String, usize)> = VecDeque::new();
-    ancestors.insert(target.to_string(), 0);
-    queue.push_back((target.to_string(), 0));
+) -> HashMap<Arc<str>, usize> {
+    let mut ancestors: HashMap<Arc<str>, usize> = HashMap::new();
+    let mut queue: VecDeque<(Arc<str>, usize)> = VecDeque::new();
+    let target_arc: Arc<str> = Arc::from(target);
+    ancestors.insert(Arc::clone(&target_arc), 0);
+    queue.push_back((target_arc, 0));
 
     while let Some((current, d)) = queue.pop_front() {
         if d >= max_depth {
@@ -61,14 +70,14 @@ pub(super) fn reverse_bfs(
             );
             break;
         }
-        if let Some(callers) = graph.reverse.get(current.as_str()) {
+        if let Some(callers) = graph.reverse.get(current.as_ref()) {
             for caller in callers {
                 if ancestors.len() >= bfs_max_nodes() {
                     break;
                 }
                 if !ancestors.contains_key(caller.as_ref()) {
-                    ancestors.insert(caller.to_string(), d + 1);
-                    queue.push_back((caller.to_string(), d + 1));
+                    ancestors.insert(Arc::clone(caller), d + 1);
+                    queue.push_back((Arc::clone(caller), d + 1));
                 }
             }
         }
@@ -145,18 +154,22 @@ pub(super) fn forward_bfs_multi(
 ///
 /// Production code uses `reverse_bfs_multi_attributed` instead (same traversal
 /// but also tracks which source produced each path). Kept for tests.
+///
+/// PERF-V1.33-1 / #1377 / P3-55: same `Arc<str>` rationale as
+/// [`reverse_bfs`].
 #[cfg(test)]
 pub(super) fn reverse_bfs_multi(
     graph: &CallGraph,
     targets: &[&str],
     max_depth: usize,
-) -> HashMap<String, usize> {
-    let mut ancestors: HashMap<String, usize> = HashMap::new();
-    let mut queue: VecDeque<(String, usize)> = VecDeque::new();
+) -> HashMap<Arc<str>, usize> {
+    let mut ancestors: HashMap<Arc<str>, usize> = HashMap::new();
+    let mut queue: VecDeque<(Arc<str>, usize)> = VecDeque::new();
 
     for &target in targets {
-        ancestors.insert(target.to_string(), 0);
-        queue.push_back((target.to_string(), 0));
+        let arc: Arc<str> = Arc::from(target);
+        ancestors.insert(Arc::clone(&arc), 0);
+        queue.push_back((arc, 0));
     }
 
     while let Some((current, d)) = queue.pop_front() {
@@ -176,21 +189,21 @@ pub(super) fn reverse_bfs_multi(
         if ancestors.get(&current).is_some_and(|&stored| d > stored) {
             continue;
         }
-        if let Some(callers) = graph.reverse.get(current.as_str()) {
+        if let Some(callers) = graph.reverse.get(current.as_ref()) {
             for caller in callers {
                 if ancestors.len() >= bfs_max_nodes() {
                     break;
                 }
-                match ancestors.entry(caller.to_string()) {
+                match ancestors.entry(Arc::clone(caller)) {
                     std::collections::hash_map::Entry::Vacant(e) => {
                         e.insert(d + 1);
-                        queue.push_back((caller.to_string(), d + 1));
+                        queue.push_back((Arc::clone(caller), d + 1));
                     }
                     std::collections::hash_map::Entry::Occupied(mut e) => {
                         // Update if we found a shorter path
                         if d + 1 < *e.get() {
                             *e.get_mut() = d + 1;
-                            queue.push_back((caller.to_string(), d + 1));
+                            queue.push_back((Arc::clone(caller), d + 1));
                         }
                     }
                 }
@@ -209,21 +222,26 @@ pub(super) fn reverse_bfs_multi(
 ///
 /// Returns `HashMap<node_name, (min_depth, source_index)>` where `source_index` is
 /// the index into `targets` that first reached the node at minimum depth.
+///
+/// PERF-V1.33-1 / #1377 / P3-55: keys are `Arc<str>` so the BFS reuses
+/// the already-interned names from `graph.reverse`. See [`reverse_bfs`]
+/// for the full rationale.
 pub(super) fn reverse_bfs_multi_attributed(
     graph: &CallGraph,
     targets: &[&str],
     max_depth: usize,
-) -> HashMap<String, (usize, usize)> {
+) -> HashMap<Arc<str>, (usize, usize)> {
     // (depth, source_index)
-    let mut ancestors: HashMap<String, (usize, usize)> = HashMap::new();
+    let mut ancestors: HashMap<Arc<str>, (usize, usize)> = HashMap::new();
     // Queue entries: (node_name, depth, source_index)
-    let mut queue: VecDeque<(String, usize, usize)> = VecDeque::new();
+    let mut queue: VecDeque<(Arc<str>, usize, usize)> = VecDeque::new();
 
     for (idx, &target) in targets.iter().enumerate() {
-        match ancestors.entry(target.to_string()) {
+        let arc: Arc<str> = Arc::from(target);
+        match ancestors.entry(Arc::clone(&arc)) {
             std::collections::hash_map::Entry::Vacant(e) => {
                 e.insert((0, idx));
-                queue.push_back((target.to_string(), 0, idx));
+                queue.push_back((arc, 0, idx));
             }
             std::collections::hash_map::Entry::Occupied(_) => {
                 // Duplicate target name — first occurrence wins at depth 0
@@ -249,20 +267,20 @@ pub(super) fn reverse_bfs_multi_attributed(
         {
             continue;
         }
-        if let Some(callers) = graph.reverse.get(current.as_str()) {
+        if let Some(callers) = graph.reverse.get(current.as_ref()) {
             for caller in callers {
                 if ancestors.len() >= bfs_max_nodes() {
                     break;
                 }
-                match ancestors.entry(caller.to_string()) {
+                match ancestors.entry(Arc::clone(caller)) {
                     std::collections::hash_map::Entry::Vacant(e) => {
                         e.insert((d + 1, src));
-                        queue.push_back((caller.to_string(), d + 1, src));
+                        queue.push_back((Arc::clone(caller), d + 1, src));
                     }
                     std::collections::hash_map::Entry::Occupied(mut e) => {
                         if d + 1 < e.get().0 {
                             *e.get_mut() = (d + 1, src);
-                            queue.push_back((caller.to_string(), d + 1, src));
+                            queue.push_back((Arc::clone(caller), d + 1, src));
                         }
                     }
                 }

--- a/src/impact/diff.rs
+++ b/src/impact/diff.rs
@@ -248,7 +248,7 @@ pub fn analyze_diff_impact_with_graph<Mode>(
         reverse_bfs_multi_attributed(graph, &start_names, DEFAULT_MAX_TEST_SEARCH_DEPTH);
 
     for test in test_chunks {
-        if let Some(&(depth, source_idx)) = attributed.get(&test.name) {
+        if let Some(&(depth, source_idx)) = attributed.get(test.name.as_str()) {
             if depth > 0 {
                 let via = changed
                     .get(source_idx)

--- a/src/impact/hints.rs
+++ b/src/impact/hints.rs
@@ -58,7 +58,7 @@ pub fn compute_hints_with_graph(
     let ancestors = reverse_bfs(graph, function_name, DEFAULT_MAX_TEST_SEARCH_DEPTH);
     let test_count = test_chunks
         .iter()
-        .filter(|t| ancestors.get(&t.name).is_some_and(|&d| d > 0))
+        .filter(|t| ancestors.get(t.name.as_str()).is_some_and(|&d| d > 0))
         .count();
 
     FunctionHints {
@@ -230,7 +230,7 @@ pub fn compute_risk_and_tests(
         vec![std::collections::HashSet::new(); targets.len()];
 
     for test in test_chunks {
-        if let Some(&(depth, source_idx)) = ancestors.get(&test.name) {
+        if let Some(&(depth, source_idx)) = ancestors.get(test.name.as_str()) {
             if depth > 0 {
                 if source_idx < targets.len() {
                     tests_per_target[source_idx].insert(&test.name);


### PR DESCRIPTION
## Summary

Closes #1377 fully — last sub-item (P3-55, PERF-V1.33-1). The earlier 3-of-4 landed in #1424.

## Why

`CallGraph` stores `forward: HashMap<Arc<str>, Vec<Arc<str>>>` and `reverse: HashMap<Arc<str>, ...>` — PERF-30 added the interning specifically so callers wouldn't re-allocate names. The reverse-BFS implementations defeated that:

- `reverse_bfs` used `HashMap<String, usize>` with per-visit `caller.to_string()` allocations
- `reverse_bfs_multi_attributed` did the same with `(usize, usize)` values
- `build_test_map` did the same plus `chain.push(current.clone())` on every parent-pointer walk step (full `String` duplication)

`forward_bfs_multi` already showed the right shape (`HashSet<Arc<str>>` with `Arc::clone`); the reverse impls were an inconsistency, not a forced trade-off.

## Change

Every reverse-BFS map switches to `HashMap<Arc<str>, ...>`, queue switches to `VecDeque<(Arc<str>, ...)>`, every `caller.to_string()` becomes `Arc::clone(caller)` (RC bump only).

The chain walk in `build_test_map` keeps an `Arc<str>` cursor and uses `Arc::clone` for parent-pointer hops; the rendered `chain: Vec<String>` in the public `TestMatch` API is built once at output time. The parent-pointer sentinel (was `String::new()` for "this is the target") is now `None` in `Option<Arc<str>>` — same encoding, no degenerate empty-string case to handle.

## Caller cascade

`impact/analysis.rs`, `impact/diff.rs`, `impact/hints.rs` all switched their `ancestors.get(&t.name)` lookups to `ancestors.get(t.name.as_str())` because `Arc<str>` borrows as `&str`, not `&String`.

## Impact

Per the audit: **2-3× speedup on hub functions (>1000 callers)** where the `String` alloc + 8-byte hash dominates the per-node cost. With `CQS_IMPACT_MAX_NODES` at its 10k default, every `cqs impact` / `cqs test-map` call previously paid up to 10k heap allocations on the BFS hot path; post-fix it's RC bumps.

## Test plan

- [x] `cargo test --features cuda-index --lib bfs` — 32 BFS unit tests pass
- [x] `cargo test --features cuda-index --bin cqs test_map` — output + dispatch tests pass
- [x] `cargo test --features cuda-index --tests` — no integration regressions
- [x] `cargo build --features cuda-index --tests` — clean
- [x] `cargo clippy --features cuda-index` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
