### PR TITLE
fix(serve): suppress --open under auth to keep token off subprocess argv (closes #1337)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -149,6 +149,13 @@ No other network requests are made. Without `--llm-summaries` or `export-model`,
 | Operation | Purpose |
 |-----------|---------|
 | `libc::kill(pid, 0)` | Check if watch process is running (signal 0 = existence check only) |
+| `cmd /C start "" <url>` (Windows / WSL) / `xdg-open <url>` (Linux) / `open <url>` (macOS) | Browser launch for `cqs serve --open`. Token-bearing URLs are suppressed from argv (see below). |
+
+#### Browser-launch token handling (`cqs serve --open`)
+
+`cqs serve --open` historically spawned the OS browser launcher with the full `http://<bind>/?token=<token>` URL on argv. That places the token in `/proc/<pid>/cmdline` (Linux) / `wmic process get CommandLine` (Windows) for any local user to read until the launcher exits, and audit subsystems (auditd, ETW) typically capture exec command lines independently of process lifetime — same surface the per-launch banner already avoids by routing the token to stderr instead of journald.
+
+**Mitigation (#1337 / SEC-V1.33-1):** when `cqs serve` runs with auth enabled (the default), `--open` no longer spawns a browser. The CLI prints a notice instructing the user to paste the banner URL manually; the token is never written to a subprocess argv. With `--no-auth` there is no token to leak and `--open` continues to launch the browser normally.
 
 ### Document Conversion (`cqs convert`)
 

--- a/src/cli/commands/serve.rs
+++ b/src/cli/commands/serve.rs
@@ -80,19 +80,33 @@ pub(crate) fn cmd_serve(port: u16, bind: String, open: bool, no_auth: bool) -> R
     };
 
     if open {
-        // The launched URL embeds the token as a query parameter; the
-        // post-auth redirect strips it from the address bar and hands
-        // it off to a `cqs_token_<port>` cookie, so reload + bookmark
-        // stay working without leaving the token visible. With
-        // --no-auth the URL is the bare bind addr.
-        let url = match auth.token() {
-            Some(token) => format!("http://{bind_addr}/?token={}", token.as_str()),
-            None => format!("http://{bind_addr}"),
-        };
-        if let Err(e) = open_browser(&url) {
-            tracing::warn!(error = %e, "failed to open browser");
-            eprintln!("WARN: --open requested but failed to launch browser: {e}");
-            eprintln!("       open the URL printed in the listening banner manually");
+        // SEC-V1.33-1 (#1337): with auth on, the token-bearing URL would
+        // land in the spawned browser-launcher's argv (`xdg-open`,
+        // `cmd /C start`, `open`), readable by any local user via
+        // `/proc/<pid>/cmdline` / `wmic process get CommandLine` and
+        // typically captured by audit subsystems (auditd, ETW). Banner
+        // routing already pulled the token off journald/stdout for the
+        // same threat model; spawning a subprocess re-leaks it through
+        // a parallel surface. Min-viable mitigation: skip the launch
+        // when the URL would carry a token, and tell the user to paste
+        // the banner URL manually. With `--no-auth` the URL is bare,
+        // nothing to leak — proceed normally.
+        match auth.token() {
+            Some(_) => {
+                eprintln!(
+                    "NOTE: --open suppressed under auth (token in argv would be readable\n       \
+                     to other local users via /proc/<pid>/cmdline). Paste the URL\n       \
+                     printed in the listening banner into your browser instead."
+                );
+            }
+            None => {
+                let url = format!("http://{bind_addr}");
+                if let Err(e) = open_browser(&url) {
+                    tracing::warn!(error = %e, "failed to open browser");
+                    eprintln!("WARN: --open requested but failed to launch browser: {e}");
+                    eprintln!("       open the URL printed in the listening banner manually");
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #1337 (P4-1, SEC-V1.33-1).

## What

`cqs serve --open` was spawning the OS browser launcher with the full `http://<bind>/?token=<token>` URL on argv. That landed the per-launch token in `/proc/<pid>/cmdline` (Linux) / `wmic process get CommandLine` (Windows) for any local user to read until the launcher exited, and audit subsystems (auditd, ETW) typically capture exec command lines independently of process lifetime.

Banner output already avoids that surface by routing the token to stderr; the browser-launch path was a parallel leak.

## Fix

Apply the audit's min-viable mitigation: when auth is on (the default), skip the browser spawn and print a notice telling the user to paste the banner URL manually. With `--no-auth` there is no token to leak, so `--open` continues to launch the browser as before.

## Files

- `src/cli/commands/serve.rs` — match on `auth.token()`: `Some(_)` prints a paste-the-URL notice and skips the spawn; `None` calls `open_browser` with the bare URL exactly as before.
- `SECURITY.md` — adds a *Browser-launch token handling* subsection under Process Operations documenting the surface and the suppression behavior.

## Test plan

- [x] `cargo build --features cuda-index` clean
- [x] `cargo clippy --features cuda-index --bin cqs -- -D warnings` clean
- [x] `cargo fmt` clean
- Manual: `cqs serve --open` (default auth) prints the suppression notice and does not spawn `cmd.exe` / `xdg-open`. `cqs serve --open --no-auth` continues to launch the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
