### PR TITLE
feat(serve): idle-shutdown after CQS_SERVE_IDLE_MINUTES (closes #1345)

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,6 +864,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_SERVE_CLUSTER_MAX_NODES` | `50000` | Cap on `/api/embed/2d` nodes (cluster view). Clamped to `[1, 1_000_000]`. SEC-3. |
 | `CQS_SERVE_GRAPH_MAX_EDGES` | `500000` | Cap on `/api/graph` edges. Clamped to `[1, 10_000_000]`. SEC-3. |
 | `CQS_SERVE_GRAPH_MAX_NODES` | `50000` | Cap on `/api/graph` nodes. Clamped to `[1, 1_000_000]`. SEC-3. |
+| `CQS_SERVE_IDLE_MINUTES` | `30` | Idle-shutdown threshold for `cqs serve`. After this many minutes with no incoming requests, the server exits cleanly so the read-only mmap and tokio runtime release. `0` disables (server runs until killed). #1345 / RM-V1.33-5. |
 | `CQS_SLOT` | (unset) | Slot to use for this invocation. Overridden by `--slot` flag, overrides `.cqs/active_slot`. See `cqs slot --help`. |
 | `CQS_CACHE_ENABLED` | `1` | Set `0` to disable the project-scoped embeddings cache for this run (benchmark / debug). Cache lives at `<project>/.cqs/embeddings_cache.db`. |
 | `CQS_CACHE_MAX_BYTES` | (unset) | Soft cap; emits `tracing::warn!` when the embeddings cache DB exceeds this many bytes. Does NOT auto-prune — use `cqs cache prune` / `cqs cache compact`. |

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -415,6 +415,29 @@ pub fn parse_env_duration_secs(key: &str, default_secs: u64) -> std::time::Durat
     std::time::Duration::from_secs(parse_env_u64(key, default_secs))
 }
 
+// ============ #1345 cqs serve idle eviction ============
+
+/// Default idle-shutdown threshold for `cqs serve` in minutes. After this
+/// many minutes of no incoming requests, the server shuts down gracefully
+/// to release the `Store<ReadOnly>` mmap, the spawn-blocking semaphore,
+/// and the tokio runtime. `0` disables the idle shutdown entirely.
+pub const SERVE_IDLE_MINUTES_DEFAULT: u64 = 30;
+
+/// Resolve the idle-shutdown threshold for `cqs serve` in minutes.
+/// `CQS_SERVE_IDLE_MINUTES=0` disables idle eviction (server runs until
+/// killed). Garbage / missing values fall back to
+/// [`SERVE_IDLE_MINUTES_DEFAULT`].
+///
+/// `0` is the only special value: any other parseable u64 wins (no upper
+/// clamp — operators may legitimately want a multi-day idle window for a
+/// dashboard left open across a weekend).
+pub fn serve_idle_minutes() -> u64 {
+    match std::env::var("CQS_SERVE_IDLE_MINUTES") {
+        Ok(v) => v.parse::<u64>().unwrap_or(SERVE_IDLE_MINUTES_DEFAULT),
+        Err(_) => SERVE_IDLE_MINUTES_DEFAULT,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -60,10 +60,17 @@ pub use error::ServeError;
 /// of working set across SQLite per-connection scratch buffers.
 /// Default 32 permits is plenty for an interactive single-user UI;
 /// `CQS_SERVE_BLOCKING_PERMITS` overrides per-launch (clamped 1..1024).
+///
+/// #1345 / RM-V1.33-5: `last_request_epoch` is an epoch-seconds timestamp
+/// touched by every incoming request via [`touch_idle_clock`]. The
+/// idle-eviction future in `run_server` polls it; when the gap exceeds
+/// `CQS_SERVE_IDLE_MINUTES`, the server shuts down gracefully so the
+/// `Store<ReadOnly>` mmap and tokio runtime release. `0` disables.
 #[derive(Clone)]
 pub(crate) struct AppState {
     pub(crate) store: Arc<Store<ReadOnly>>,
     pub(crate) blocking_permits: Arc<tokio::sync::Semaphore>,
+    pub(crate) last_request_epoch: Arc<std::sync::atomic::AtomicU64>,
 }
 
 /// Allowed `Host` header values, built at router-build time from the
@@ -109,11 +116,17 @@ pub fn run_server(
     // handlers. See `AppState` doc comment.
     let permits = crate::limits::serve_blocking_permits();
     tracing::info!(permits, "serve: spawn_blocking semaphore initialised");
+    // #1345 / RM-V1.33-5: prime the idle clock to "now" so a startup that
+    // immediately backgrounds doesn't fire eviction before the first
+    // request arrives.
+    let last_request_epoch = Arc::new(std::sync::atomic::AtomicU64::new(now_epoch_secs()));
     let state = AppState {
         store: Arc::new(store),
         blocking_permits: Arc::new(tokio::sync::Semaphore::new(permits)),
+        last_request_epoch: Arc::clone(&last_request_epoch),
     };
     let allowed_hosts = allowed_host_set(&bind_addr);
+    let idle_minutes = crate::limits::serve_idle_minutes();
     let app = build_router(state, allowed_hosts, auth.clone());
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -172,8 +185,12 @@ pub fn run_server(
         }
         tracing::info!(addr = %actual, auth_enabled = auth.token().is_some(), "cqs serve started");
 
+        // #1345 / RM-V1.33-5: race the SIGINT/SIGTERM signal future
+        // against an idle-eviction future. With `idle_minutes == 0` the
+        // idle future is `pending::<()>()` and the server only exits on
+        // signal — preserves prior behavior under the explicit opt-out.
         axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown_signal())
+            .with_graceful_shutdown(idle_or_signal(last_request_epoch, idle_minutes))
             .await
             .context("axum server failed")?;
 
@@ -182,6 +199,78 @@ pub fn run_server(
     })?;
 
     Ok(())
+}
+
+/// Race a signal-driven shutdown against an idle-driven shutdown. With
+/// `idle_minutes == 0` the idle arm is `pending::<()>()` so only signals
+/// can resolve the future — matches the pre-#1345 behavior under explicit
+/// opt-out. Otherwise the server shuts down on whichever fires first.
+async fn idle_or_signal(last_request_epoch: Arc<std::sync::atomic::AtomicU64>, idle_minutes: u64) {
+    if idle_minutes == 0 {
+        tracing::info!("serve: idle eviction disabled (CQS_SERVE_IDLE_MINUTES=0)");
+        shutdown_signal().await;
+        return;
+    }
+    tracing::info!(
+        idle_minutes,
+        "serve: idle eviction armed; server will exit after this many minutes of no requests"
+    );
+    // 1-minute resolution is plenty for a 30-minute idle window. Polling
+    // faster gives no operator-visible benefit and only burns wakeups.
+    let poll = std::time::Duration::from_secs(60);
+    tokio::select! {
+        _ = shutdown_signal() => {}
+        _ = wait_for_idle(last_request_epoch, idle_minutes * 60, poll) => {
+            tracing::info!(idle_minutes, "serve: idle threshold reached, beginning graceful shutdown");
+        }
+    }
+}
+
+/// Poll `last_request_epoch` at `poll` cadence. Returns when the gap
+/// between "now" (epoch seconds) and the most recent touch exceeds
+/// `idle_secs`. `poll` is parameterized so tests can drive the loop on
+/// millisecond cadence; production passes 60 s.
+pub(crate) async fn wait_for_idle(
+    last_request_epoch: Arc<std::sync::atomic::AtomicU64>,
+    idle_secs: u64,
+    poll: std::time::Duration,
+) {
+    use std::sync::atomic::Ordering;
+    let mut tick = tokio::time::interval(poll);
+    // Skip the first immediate-fire tick; the first poll happens after
+    // one full poll interval.
+    tick.tick().await;
+    loop {
+        tick.tick().await;
+        let now = now_epoch_secs();
+        let last = last_request_epoch.load(Ordering::Relaxed);
+        if now.saturating_sub(last) >= idle_secs {
+            return;
+        }
+    }
+}
+
+/// Wall-clock epoch seconds. Saturates at 0 if the system clock is set
+/// before the unix epoch (effectively never on a real host, but the
+/// `SystemTimeError` path costs nothing to handle).
+pub(crate) fn now_epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Middleware that updates `AppState.last_request_epoch` on every request.
+/// Sits outside auth so the idle clock advances even on unauthenticated
+/// pings — the threat model is "user walked away," not "adversary keeps
+/// the server alive with 401s." Keepalive cost is negligible: an attacker
+/// who can connect already pays the request budget elsewhere (host
+/// allowlist, body limit, blocking_permits semaphore).
+async fn touch_idle_clock(State(state): State<AppState>, request: Request, next: Next) -> Response {
+    state
+        .last_request_epoch
+        .store(now_epoch_secs(), std::sync::atomic::Ordering::Relaxed);
+    next.run(request).await
 }
 
 /// Build the axum router. Public-in-crate so integration tests can
@@ -198,6 +287,7 @@ pub fn run_server(
 /// [`NoAuthAcknowledgement`] proof token inside that variant
 /// guarantees an explicit opt-in (#1136).
 pub(crate) fn build_router(state: AppState, allowed_hosts: AllowedHosts, auth: AuthMode) -> Router {
+    let touch_state = state.clone();
     let mut app = Router::new()
         .route("/health", get(handlers::health))
         .route("/api/stats", get(handlers::stats))
@@ -209,6 +299,12 @@ pub(crate) fn build_router(state: AppState, allowed_hosts: AllowedHosts, auth: A
         .route("/", get(assets::index_html))
         .route("/static/{*path}", get(assets::static_asset))
         .with_state(state);
+
+    // #1345 / RM-V1.33-5: touch the idle clock on every request. Sits
+    // inside auth (after this layer order is finalized below) so even
+    // unauthenticated pings count as activity — the threat model is "user
+    // walked away," not "adversary keeps the server alive."
+    app = app.layer(from_fn_with_state(touch_state, touch_idle_clock));
 
     // #1096 SEC-7: per-launch auth. Sits inside the host-header
     // allowlist (rejected hosts skip auth — saves a constant-time

--- a/src/serve/tests.rs
+++ b/src/serve/tests.rs
@@ -11,7 +11,8 @@ use axum::{
 use tower::util::ServiceExt;
 
 use super::{
-    allowed_host_set, build_router, AllowedHosts, AppState, AuthMode, NoAuthAcknowledgement,
+    allowed_host_set, build_router, now_epoch_secs, wait_for_idle, AllowedHosts, AppState,
+    AuthMode, NoAuthAcknowledgement,
 };
 use crate::embedder::Embedding;
 use crate::parser::{Chunk, ChunkType, Language};
@@ -92,6 +93,10 @@ fn fixture_state() -> Fixture {
             blocking_permits: Arc::new(tokio::sync::Semaphore::new(
                 crate::limits::serve_blocking_permits(),
             )),
+            // #1345: idle clock is just an `Arc<AtomicU64>` — the tests
+            // exercise handler shape, not the wall-clock-driven eviction
+            // future, so any starting value is fine.
+            last_request_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }),
         _dir: Some(dir),
     }
@@ -227,6 +232,10 @@ fn populated_fixture(n_chunks: usize, with_umap: bool) -> Fixture {
             blocking_permits: Arc::new(tokio::sync::Semaphore::new(
                 crate::limits::serve_blocking_permits(),
             )),
+            // #1345: idle clock is just an `Arc<AtomicU64>` — the tests
+            // exercise handler shape, not the wall-clock-driven eviction
+            // future, so any starting value is fine.
+            last_request_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }),
         _dir: Some(dir),
     }
@@ -1766,5 +1775,100 @@ mod auth_tests {
             cookie.starts_with(&format!("cqs_token_8081={token_str};")),
             "Set-Cookie must use per-port name: {cookie}"
         );
+    }
+
+    // ─── #1345 idle eviction ──────────────────────────────────────────────
+
+    /// `wait_for_idle` returns when the gap between "now" and the
+    /// last-request timestamp meets `idle_secs`. Drives the loop with a
+    /// 1 ms tick and a stale `last_request_epoch` so the future resolves
+    /// in the first poll iteration after the initial skip.
+    #[tokio::test]
+    async fn wait_for_idle_returns_when_gap_exceeds_threshold() {
+        use std::sync::atomic::AtomicU64;
+        // Stale clock: 600 seconds in the past, beyond any sensible
+        // idle window the test would set.
+        let last = Arc::new(AtomicU64::new(now_epoch_secs().saturating_sub(600)));
+        // 1-second idle threshold — the gap is ~600 s, so the very first
+        // post-skip tick resolves the future.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            wait_for_idle(last, 1, std::time::Duration::from_millis(1)),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "wait_for_idle did not resolve within timeout"
+        );
+    }
+
+    /// While `last_request_epoch` keeps advancing, `wait_for_idle` must
+    /// never resolve. Touch the clock from a separate task on a faster
+    /// cadence than the poll, run for ~50 ms, and assert the future is
+    /// still pending — the timeout *expiring* is the pass condition.
+    #[tokio::test]
+    async fn wait_for_idle_blocks_while_clock_advances() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        let last = Arc::new(AtomicU64::new(now_epoch_secs()));
+        let last_for_toucher = Arc::clone(&last);
+        let toucher = tokio::spawn(async move {
+            for _ in 0..20 {
+                last_for_toucher.store(now_epoch_secs(), Ordering::Relaxed);
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            }
+        });
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            wait_for_idle(last, 5, std::time::Duration::from_millis(1)),
+        )
+        .await;
+        toucher.abort();
+        assert!(
+            result.is_err(),
+            "wait_for_idle resolved while the clock was being touched — it should have stayed pending"
+        );
+    }
+
+    /// The touch middleware (`touch_idle_clock`) updates the timestamp
+    /// on every request. Drive a single `oneshot` through the router and
+    /// assert `last_request_epoch` advanced.
+    #[tokio::test]
+    async fn touch_idle_clock_updates_timestamp_on_each_request() {
+        use std::sync::atomic::Ordering;
+        // Keep `fixture` alive through end-of-test so its OS-thread Drop
+        // takes the last `Arc<Store>` out of the tokio context. Cloning
+        // via `fixture.state()` (instead of `fixture.state.take()`)
+        // preserves the Fixture's own Arc copy.
+        let fixture = fixture_state();
+        let state = fixture.state();
+        let last = Arc::clone(&state.last_request_epoch);
+        // Force an obviously-stale starting value so the post-request
+        // value can't come from the start-of-test clock alone.
+        last.store(0, Ordering::Relaxed);
+
+        let app = build_router(
+            state,
+            allowed_host_set(&"127.0.0.1:8080".parse().unwrap()),
+            AuthMode::disabled(NoAuthAcknowledgement::for_test()),
+        );
+
+        let _ = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .header("host", "127.0.0.1:8080")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("oneshot /health");
+
+        let stored = last.load(Ordering::Relaxed);
+        assert!(
+            stored >= now_epoch_secs().saturating_sub(2),
+            "touch middleware did not advance idle clock: stored={stored}, now={}",
+            now_epoch_secs()
+        );
+        drop(fixture);
     }
 }


### PR DESCRIPTION
Closes #1345 (P4-9, RM-V1.33-5).

## Problem

`cqs serve` opened a `Store::open_readonly` once at startup and held it forever. A user starting `cqs serve` in the morning and walking away pinned 64 MiB mmap + 4 MiB SQLite cache + the spawn-blocking semaphore + the tokio runtime indefinitely. Unlike `cqs watch --serve`, which has `BatchContext::sweep_idle_sessions` clearing ONNX/HNSW state after `CQS_BATCH_IDLE_MINUTES`, `cqs serve` had no idle safety net.

## Fix

Land the audit's simpler "race the server future against an idle timer" shape:

- New `crate::limits::serve_idle_minutes()` — reads `CQS_SERVE_IDLE_MINUTES` (default `30`, `0` disables, no upper clamp so dashboards left open across a weekend can configure it).
- `AppState` gains `last_request_epoch: Arc<AtomicU64>`.
- New `touch_idle_clock` middleware on the router updates the timestamp on every incoming request — sits outside auth so the idle clock advances on unauthenticated pings too (threat model is "user walked away," not "adversary keeps server alive with 401s").
- New `wait_for_idle(last, idle_secs, poll_interval)` async function polls the clock at `poll_interval` cadence; resolves when the gap reaches `idle_secs`. Production passes 60 s; tests pass 1 ms.
- `run_server` calls `idle_or_signal(last_clock, idle_minutes)` instead of `shutdown_signal()` directly. With `idle_minutes == 0` the idle arm is `pending::<()>()` so behavior matches pre-#1345 exactly under the explicit opt-out.

## Tests

- `wait_for_idle_returns_when_gap_exceeds_threshold`: stale clock, future resolves immediately.
- `wait_for_idle_blocks_while_clock_advances`: spawned toucher keeps the clock fresh; the future stays pending. Timeout-expiring is the pass condition.
- `touch_idle_clock_updates_timestamp_on_each_request`: drives a `oneshot` through the router; asserts the clock advanced.

## Verification

- `cargo test --features cuda-index --lib` — 2042 tests pass.
- `cargo clippy --features cuda-index -- -D warnings` clean.
- `cargo fmt` clean.

## Test plan

- [x] All idle eviction unit tests pass
- [x] Full lib suite green
- [x] No clippy / fmt regressions
- [x] README updated with the new env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)
