### PR TITLE
feat(daemon): server-side wait_fresh — single round-trip, zero polling (closes #1228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,7 +783,6 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_EVAL_TIMEOUT_SECS` | `300` | Per-query timeout in seconds inside `evals/run_ablation.py` |
 | `CQS_FILE_BATCH_SIZE` | `5000` | Files per parse batch in pipeline |
 | `CQS_FORCE_BASE_INDEX` | (none) | Set to `1` to force search via the base (non-enriched) HNSW index |
-| `CQS_FRESHNESS_POLL_MS` | `100` | Initial poll interval (ms) for `wait_for_fresh` exponential backoff before the eval freshness gate fires. Clamped to `[25, 5000]`. Bump on slow filesystems (WSL `/mnt/c/`) where the daemon's first snapshot is rarely under 100 ms. |
 | `CQS_FTS_NORMALIZE_MAX` | `16384` | Max bytes of `normalize_for_fts` output per chunk. Truncation is emitted at warn level; bump if FTS recall on long chunks (large generated tables, monolithic functions) is degraded. |
 | `CQS_GATHER_MAX_NODES` | `200` | Max BFS nodes in `gather` context assembly |
 | `CQS_HNSW_EF_CONSTRUCTION` | `200` | HNSW construction-time search width |

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -339,6 +339,29 @@ pub(crate) enum BatchCmd {
         #[arg(long = "arg", value_name = "ARG")]
         args: Vec<String>,
     },
+    /// Block until the watch loop transitions to Fresh, or `wait_secs`
+    /// elapses. (#1228 — RM-2: server-side wait, no client-side polling.)
+    ///
+    /// One round-trip total — the daemon parks the request on a
+    /// `FreshNotifier` shared with the watch loop. When `publish_watch_snapshot`
+    /// observes a `false → true` transition it issues a `notify_all`,
+    /// the parked handler wakes, and replies with the latest snapshot.
+    /// On deadline the handler replies with the still-stale snapshot.
+    ///
+    /// Replaces the prior 250 ms-poll loop in `wait_for_fresh` (4-5k
+    /// connect/parse round-trips per 60 s wait at the default budget).
+    /// `cqs status --watch-fresh --wait` and `cqs eval --require-fresh`
+    /// route through this when talking to a daemon. Outside `cqs watch
+    /// --serve` the notifier never flips and the call hits the deadline
+    /// naturally.
+    #[command(name = "wait-fresh")]
+    WaitFresh {
+        /// Maximum seconds to block before returning the current
+        /// (still-stale) snapshot. Capped server-side at 86_400 (24 h)
+        /// for parity with the client-side cap in `wait_for_fresh`.
+        #[arg(long, default_value_t = 60)]
+        wait_secs: u64,
+    },
     /// Show help
     Help,
     /// #1127 (test-only): sleep `--ms` milliseconds before returning. Used by
@@ -408,6 +431,9 @@ macro_rules! for_each_batch_cmd_pipeability {
                 (Suggest, false)
                 (Gc, false)
                 (Reconcile, false)
+                // #1228 (RM-2): not pipeable — wait_secs is the only
+                // arg, no positional function name to receive a pipe.
+                (WaitFresh, false)
             }
             unit_variants: {
                 (Refresh, false)
@@ -676,6 +702,7 @@ pub(crate) fn dispatch(ctx: &BatchView, cmd: BatchCmd) -> Result<serde_json::Val
         BatchCmd::Ping => handlers::dispatch_ping(ctx),
         BatchCmd::Status => handlers::dispatch_status(ctx),
         BatchCmd::Reconcile { hook, args } => handlers::dispatch_reconcile(ctx, hook, args),
+        BatchCmd::WaitFresh { wait_secs } => handlers::dispatch_wait_fresh(ctx, wait_secs),
         BatchCmd::Help => handlers::dispatch_help(),
         #[cfg(test)]
         BatchCmd::TestSleep { ms } => {

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -541,6 +541,70 @@ pub(in crate::cli::batch) fn dispatch_status(ctx: &BatchView) -> Result<serde_js
         .map_err(|e| anyhow::anyhow!("Failed to serialize WatchSnapshot: {e}"))
 }
 
+/// #1228 (RM-2): block until the watch loop transitions to Fresh, or
+/// `wait_secs` elapses. Replaces the prior 250 ms-poll loop in
+/// `wait_for_fresh` — one round-trip, zero busy-poll.
+///
+/// Behaviour:
+/// 1. Read the current snapshot. If already Fresh, return it immediately
+///    (no parking) — preserves the "already fresh tree pays no latency"
+///    contract from the old polling implementation.
+/// 2. Otherwise park on the shared [`cqs::watch_status::FreshNotifier`]
+///    until either the next `false → true` transition fires
+///    `notify_all`, or `deadline` expires. The waiter loop in
+///    `FreshNotifier::wait_until_fresh` re-checks the predicate after
+///    every wake (handles spurious wake-ups + the rare `true → false`
+///    flip mid-wait).
+/// 3. Return the snapshot in either case — the caller distinguishes
+///    "Fresh" vs "Timeout" by inspecting the snapshot's `state` field.
+///    On wake the snapshot is read AFTER the wait, so the returned
+///    payload reflects the latest publish — not whatever was visible
+///    when the request first parked.
+///
+/// `wait_secs == 0` returns immediately with the current snapshot,
+/// matching how the prior client-side loop's deadline-first check
+/// behaves on a zero budget. Capped at 86_400 s (24 h) for parity
+/// with the client-side `wait_for_fresh` cap.
+pub(in crate::cli::batch) fn dispatch_wait_fresh(
+    ctx: &BatchView,
+    wait_secs: u64,
+) -> Result<serde_json::Value> {
+    let bounded_secs = wait_secs.min(86_400);
+    let _span = tracing::info_span!("batch_wait_fresh", wait_secs, bounded_secs,).entered();
+    let start = std::time::Instant::now();
+
+    let initial = ctx.watch_snapshot();
+    if initial.is_fresh() {
+        tracing::info!("wait_fresh: already fresh on entry");
+        return serde_json::to_value(&initial)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize WatchSnapshot: {e}"));
+    }
+
+    let deadline = start + std::time::Duration::from_secs(bounded_secs);
+    let notifier = ctx.fresh_notifier();
+    let woke_fresh = notifier.wait_until_fresh(deadline);
+
+    let snap = ctx.watch_snapshot();
+    if woke_fresh {
+        tracing::info!(
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            modified_files = snap.modified_files,
+            "wait_fresh: woke on Fresh transition"
+        );
+    } else {
+        tracing::info!(
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            modified_files = snap.modified_files,
+            pending_notes = snap.pending_notes,
+            rebuild_in_flight = snap.rebuild_in_flight,
+            "wait_fresh: deadline reached without Fresh transition"
+        );
+    }
+
+    serde_json::to_value(&snap)
+        .map_err(|e| anyhow::anyhow!("Failed to serialize WatchSnapshot: {e}"))
+}
+
 /// #1182 — Layer 1: git-hook-driven reconcile request. Flips the shared
 /// `SharedReconcileSignal` AtomicBool to `true`; the watch loop swaps it
 /// back to `false` and runs an immediate reconcile pass on its next tick.
@@ -624,6 +688,151 @@ mod tests {
         );
         let obj = json.as_object().unwrap();
         assert!(!obj.is_empty(), "ping snapshot must not be empty");
+    }
+
+    /// #1228 (RM-2): `dispatch_wait_fresh` returns immediately when the
+    /// snapshot is already Fresh on entry — no parking, no Condvar wait.
+    /// Pins the "already-fresh tree pays no latency" contract from the
+    /// pre-#1228 polling implementation.
+    #[test]
+    fn dispatch_wait_fresh_returns_immediately_when_already_fresh() {
+        let (_dir, _ctx, view) = empty_view();
+        // Seed the shared snapshot with a Fresh state. The handler reads
+        // through the same `Arc<RwLock<...>>`, so updates here are
+        // immediately visible.
+        let fresh_snap = cqs::watch_status::WatchSnapshot {
+            state: cqs::watch_status::FreshnessState::Fresh,
+            modified_files: 0,
+            pending_notes: false,
+            rebuild_in_flight: false,
+            delta_saturated: false,
+            incremental_count: 42,
+            dropped_this_cycle: 0,
+            last_event_unix_secs: 1_700_000_000,
+            last_synced_at: Some(1_700_000_000),
+            snapshot_at: Some(1_700_000_001),
+            active_slot: None,
+        };
+        // Reach into the lock through the view's clone of the Arc.
+        // (Tests under `cqs::watch_status` write directly; here we
+        // mutate via the `BatchView`-internal field by name.)
+        view.test_overwrite_watch_snapshot(fresh_snap.clone());
+
+        let start = std::time::Instant::now();
+        // wait_secs=10 — handler should return well before this.
+        let json = dispatch_wait_fresh(&view, 10).expect("dispatch_wait_fresh");
+        let elapsed_ms = start.elapsed().as_millis();
+
+        assert!(
+            elapsed_ms < 100,
+            "dispatch_wait_fresh on already-fresh snapshot must return immediately; took {elapsed_ms}ms"
+        );
+        assert_eq!(json.get("state").and_then(|v| v.as_str()), Some("fresh"));
+        assert_eq!(
+            json.get("incremental_count").and_then(|v| v.as_u64()),
+            Some(42)
+        );
+    }
+
+    /// #1228 (RM-2): `dispatch_wait_fresh` parks until a `false → true`
+    /// transition fires `notify_all`. Spawns a "watch loop" thread that
+    /// flips the notifier after a short sleep; the handler must wake
+    /// promptly and return the freshly-published snapshot.
+    #[test]
+    fn dispatch_wait_fresh_wakes_on_notifier_flip() {
+        let (_dir, _ctx, view) = empty_view();
+        // Clone the Arc handles that the publisher thread will use.
+        // BatchView itself is not Clone (it caches a few inner Arcs),
+        // but the shared notifier and snapshot are exactly what the
+        // watch loop holds — so cloning those is sufficient.
+        let notifier_for_publisher = view.fresh_notifier();
+        let snap_handle_for_publisher = view.test_watch_snapshot_handle();
+        let publisher = std::thread::spawn(move || {
+            // Wall-clock gap chosen to be >> the handler's 0 → park time
+            // but small enough to keep the test fast.
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            // Flip the cached snapshot to Fresh, then notify.
+            let fresh = cqs::watch_status::WatchSnapshot {
+                state: cqs::watch_status::FreshnessState::Fresh,
+                modified_files: 0,
+                pending_notes: false,
+                rebuild_in_flight: false,
+                delta_saturated: false,
+                incremental_count: 99,
+                dropped_this_cycle: 0,
+                last_event_unix_secs: 1_700_000_000,
+                last_synced_at: Some(1_700_000_000),
+                snapshot_at: Some(1_700_000_002),
+                active_slot: None,
+            };
+            *snap_handle_for_publisher
+                .write()
+                .unwrap_or_else(|p| p.into_inner()) = fresh;
+            notifier_for_publisher.set_fresh(true);
+        });
+
+        let start = std::time::Instant::now();
+        let json = dispatch_wait_fresh(&view, 5).expect("dispatch_wait_fresh");
+        let elapsed_ms = start.elapsed().as_millis();
+        publisher.join().expect("publisher thread");
+
+        // Should have woken on the notifier well within the 5 s budget,
+        // and well after the publisher's 50 ms sleep.
+        assert!(
+            (40..2000).contains(&elapsed_ms),
+            "dispatch_wait_fresh wake latency outside expected window: {elapsed_ms}ms"
+        );
+        assert_eq!(json.get("state").and_then(|v| v.as_str()), Some("fresh"));
+        assert_eq!(
+            json.get("incremental_count").and_then(|v| v.as_u64()),
+            Some(99)
+        );
+    }
+
+    /// #1228 (RM-2): `dispatch_wait_fresh` returns the still-stale
+    /// snapshot when `wait_secs` runs out without a Fresh transition.
+    /// Tight `wait_secs=1` keeps the test fast; the handler returns
+    /// after ~1 s.
+    #[test]
+    fn dispatch_wait_fresh_returns_stale_snapshot_on_deadline() {
+        let (_dir, _ctx, view) = empty_view();
+        let stale = cqs::watch_status::WatchSnapshot {
+            state: cqs::watch_status::FreshnessState::Stale,
+            modified_files: 7,
+            pending_notes: false,
+            rebuild_in_flight: false,
+            delta_saturated: false,
+            incremental_count: 0,
+            dropped_this_cycle: 0,
+            last_event_unix_secs: 1_700_000_000,
+            last_synced_at: Some(1_700_000_000),
+            snapshot_at: Some(1_700_000_003),
+            active_slot: None,
+        };
+        view.test_overwrite_watch_snapshot(stale);
+
+        let start = std::time::Instant::now();
+        let json = dispatch_wait_fresh(&view, 1).expect("dispatch_wait_fresh");
+        let elapsed = start.elapsed();
+
+        // Handler must wait the full second (within scheduler jitter)
+        // before returning the stale snapshot.
+        assert!(
+            elapsed >= std::time::Duration::from_millis(900),
+            "dispatch_wait_fresh exited too early: {}ms",
+            elapsed.as_millis()
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(3),
+            "dispatch_wait_fresh exited too late: {}ms",
+            elapsed.as_millis()
+        );
+        assert_eq!(
+            json.get("state").and_then(|v| v.as_str()),
+            Some("stale"),
+            "must return the post-deadline snapshot, got: {json}"
+        );
+        assert_eq!(json.get("modified_files").and_then(|v| v.as_u64()), Some(7));
     }
 
     /// #1182: `dispatch_status` against an empty `BatchContext` (no watch

--- a/src/cli/batch/handlers/mod.rs
+++ b/src/cli/batch/handlers/mod.rs
@@ -33,6 +33,6 @@ pub(super) use info::{
 pub(super) use misc::{
     dispatch_diff, dispatch_drift, dispatch_gather, dispatch_gc, dispatch_help, dispatch_notes,
     dispatch_ping, dispatch_plan, dispatch_reconcile, dispatch_refresh, dispatch_scout,
-    dispatch_status, dispatch_task, dispatch_where,
+    dispatch_status, dispatch_task, dispatch_wait_fresh, dispatch_where,
 };
 pub(super) use search::dispatch_search;

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -351,6 +351,14 @@ pub(crate) struct BatchContext {
     /// is a fresh `Arc<AtomicBool>` with no listener — outside `cqs watch
     /// --serve`, dispatching `reconcile` is a no-op rather than an error.
     pub(crate) reconcile_signal: cqs::watch_status::SharedReconcileSignal,
+    /// #1228 (RM-2): event-driven freshness wake-up. The watch loop's
+    /// `publish_watch_snapshot` calls `set_fresh` every cycle; the
+    /// daemon's `wait_fresh` handler parks on `wait_until_fresh` until
+    /// the state flips. Default outside `cqs watch --serve` is a fresh
+    /// notifier whose `is_fresh` flag stays `false` forever — a stray
+    /// `wait_fresh` request without an active watch loop hits the
+    /// caller's deadline naturally.
+    pub(crate) fresh_notifier: cqs::watch_status::SharedFreshNotifier,
 }
 
 /// #1127: a number of `BatchContext` accessors are unreachable from non-test
@@ -898,6 +906,14 @@ impl BatchContext {
         self.reconcile_signal = shared;
     }
 
+    /// #1228 (RM-2): install the shared `FreshNotifier`. Called from
+    /// the daemon thread alongside `adopt_watch_snapshot` so the
+    /// `wait_fresh` handler parks on the same notifier the watch loop
+    /// updates from `publish_watch_snapshot`.
+    pub fn adopt_fresh_notifier(&mut self, shared: cqs::watch_status::SharedFreshNotifier) {
+        self.fresh_notifier = shared;
+    }
+
     /// Get or create the embedder (~500ms first call).
     pub fn embedder(&self) -> Result<&Embedder> {
         if let Some(e) = self.embedder.get() {
@@ -1409,6 +1425,7 @@ impl BatchContext {
             outer_lock,
             watch_snapshot: Arc::clone(&self.watch_snapshot),
             reconcile_signal: Arc::clone(&self.reconcile_signal),
+            fresh_notifier: Arc::clone(&self.fresh_notifier),
         }
     }
 }
@@ -1714,6 +1731,11 @@ pub(crate) struct BatchView {
     /// `true` on the daemon's behalf; the watch loop swaps it back to
     /// `false` and runs an immediate reconcile pass.
     reconcile_signal: cqs::watch_status::SharedReconcileSignal,
+    /// #1228 (RM-2): shared event-driven freshness notifier. Cloned
+    /// the same way; `dispatch_wait_fresh` parks on this until the
+    /// watch loop publishes a Fresh transition or the caller's deadline
+    /// runs out.
+    fresh_notifier: cqs::watch_status::SharedFreshNotifier,
 }
 
 impl BatchView {
@@ -1982,6 +2004,33 @@ impl BatchView {
     pub fn request_reconcile(&self) -> bool {
         self.reconcile_signal
             .swap(true, std::sync::atomic::Ordering::Release)
+    }
+
+    /// #1228 (RM-2): borrow the shared freshness notifier so a
+    /// `wait_fresh` handler can park on it. Returns the `Arc` clone
+    /// so the daemon thread can call `wait_until_fresh` without
+    /// holding the BatchContext mutex (the wait can be minutes).
+    pub fn fresh_notifier(&self) -> cqs::watch_status::SharedFreshNotifier {
+        Arc::clone(&self.fresh_notifier)
+    }
+
+    /// #1228 (RM-2): test-only helpers used by `dispatch_wait_fresh`'s
+    /// unit suite to seed the shared snapshot. Production code reaches
+    /// the snapshot through the watch loop's `publish_watch_snapshot`,
+    /// not these accessors. `pub(crate)` keeps the test wiring out of
+    /// the public API.
+    #[cfg(test)]
+    pub(crate) fn test_overwrite_watch_snapshot(&self, snap: cqs::watch_status::WatchSnapshot) {
+        let mut guard = self
+            .watch_snapshot
+            .write()
+            .unwrap_or_else(|p| p.into_inner());
+        *guard = snap;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_watch_snapshot_handle(&self) -> cqs::watch_status::SharedWatchSnapshot {
+        Arc::clone(&self.watch_snapshot)
     }
 
     /// Build a [`cqs::daemon_translate::PingResponse`] from the snapshot.
@@ -2349,6 +2398,10 @@ pub(crate) fn create_context_with_runtime(
         // is harmless (the watch loop that would consume the signal
         // simply isn't running).
         reconcile_signal: cqs::watch_status::shared_reconcile_signal(),
+        // #1228 (RM-2): default no-op notifier. Outside `cqs watch
+        // --serve` the watch loop never calls `set_fresh`, so a stray
+        // `wait_fresh` request hits the caller's deadline naturally.
+        fresh_notifier: cqs::watch_status::shared_fresh_notifier(),
     })
 }
 
@@ -2412,6 +2465,9 @@ pub(in crate::cli) fn create_test_context(cqs_dir: &std::path::Path) -> Result<B
         // Tests that need to assert the daemon flipped it pull the
         // field clone before invoking dispatch.
         reconcile_signal: cqs::watch_status::shared_reconcile_signal(),
+        // #1228 (RM-2): tests get a fresh notifier; freshness-API tests
+        // pull the field clone and call `set_fresh` directly.
+        fresh_notifier: cqs::watch_status::shared_fresh_notifier(),
     })
 }
 

--- a/src/cli/watch/daemon.rs
+++ b/src/cli/watch/daemon.rs
@@ -42,6 +42,7 @@ pub(super) fn spawn_daemon_thread(
     daemon_runtime: Arc<tokio::runtime::Runtime>,
     daemon_watch_snapshot: cqs::watch_status::SharedWatchSnapshot,
     daemon_reconcile_signal: cqs::watch_status::SharedReconcileSignal,
+    daemon_fresh_notifier: cqs::watch_status::SharedFreshNotifier,
 ) -> JoinHandle<()> {
     std::thread::spawn(move || {
         // BatchContext created inside the thread — RefCell is !Send
@@ -90,6 +91,10 @@ pub(super) fn spawn_daemon_thread(
         // git hook posts to the socket) flips a flag the watch loop is
         // actually checking.
         ctx.adopt_reconcile_signal(daemon_reconcile_signal);
+        // #1228 (RM-2): same shape for the freshness notifier. After
+        // this swap, `dispatch_wait_fresh` parks on the same notifier
+        // the watch loop signals from `publish_watch_snapshot`.
+        ctx.adopt_fresh_notifier(daemon_fresh_notifier);
 
         // SEC-V1.25-1: wrap the BatchContext in Arc<Mutex> so each
         // accepted connection gets its own handler thread. Without

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -199,6 +199,7 @@ const LAST_SYNCED_REFRESH: std::time::Duration = std::time::Duration::from_secs(
 /// wire data — wasted budget.
 fn publish_watch_snapshot(
     handle: &cqs::watch_status::SharedWatchSnapshot,
+    fresh_notifier: &cqs::watch_status::SharedFreshNotifier,
     state: &mut WatchState,
     index_path: &std::path::Path,
 ) {
@@ -272,6 +273,13 @@ fn publish_watch_snapshot(
             "watch state transition",
         );
     }
+
+    // #1228 (RM-2): event-driven freshness wake-up. The notifier
+    // dedupes on idempotent `false → false` and `true → true` calls
+    // (cheap mutex acquire + boolean compare), so calling it every
+    // 100 ms tick is fine — only `false → true` transitions issue a
+    // `notify_all` to parked `wait_fresh` clients.
+    fresh_notifier.set_fresh(next_snap.is_fresh());
 }
 
 /// PB-3: Check if a path is under a WSL DrvFS automount root.
@@ -702,6 +710,14 @@ pub fn cmd_watch(
     let reconcile_signal_handle: cqs::watch_status::SharedReconcileSignal =
         cqs::watch_status::shared_reconcile_signal();
 
+    // #1228 (RM-2): cross-thread event-driven freshness notifier. Watch
+    // loop's `publish_watch_snapshot` calls `set_fresh` every cycle;
+    // the daemon's `wait_fresh` handler parks on `wait_until_fresh`.
+    // Replaces the prior client-side 250 ms-poll loop in
+    // `wait_for_fresh` — single round-trip, zero busy-poll.
+    let fresh_notifier_handle: cqs::watch_status::SharedFreshNotifier =
+        cqs::watch_status::shared_fresh_notifier();
+
     // #1182 — Layer 1: pick up a leftover `.cqs/.dirty` marker from a
     // previous session where a git hook fired without a daemon listening.
     // The hook touches this file as a fallback; on next daemon start we
@@ -756,6 +772,10 @@ pub fn cmd_watch(
             let daemon_watch_snapshot = Arc::clone(&watch_snapshot_handle);
             // #1182 — Layer 1: clone the reconcile-signal Arc too.
             let daemon_reconcile_signal = Arc::clone(&reconcile_signal_handle);
+            // #1228 (RM-2): clone the freshness notifier so the daemon's
+            // `wait_fresh` handler shares the same notifier the watch
+            // loop publishes through.
+            let daemon_fresh_notifier = Arc::clone(&fresh_notifier_handle);
             // Stays non-blocking: the accept loop below polls so it can
             // notice SHUTDOWN_REQUESTED on SIGTERM (RM-V1.25-9).
             let thread = daemon::spawn_daemon_thread(
@@ -765,6 +785,7 @@ pub fn cmd_watch(
                 daemon_runtime,
                 daemon_watch_snapshot,
                 daemon_reconcile_signal,
+                daemon_fresh_notifier,
             );
             Some(thread)
         } else {
@@ -1548,7 +1569,12 @@ pub fn cmd_watch(
         // tick old. The `RwLock` on `watch_snapshot_handle` is acquired
         // for the duration of a struct-move; readers (daemon clients)
         // never wait more than that.
-        publish_watch_snapshot(&watch_snapshot_handle, &mut state, &index_path);
+        publish_watch_snapshot(
+            &watch_snapshot_handle,
+            &fresh_notifier_handle,
+            &mut state,
+            &index_path,
+        );
 
         if check_interrupted() {
             println!("\nStopping watch...");

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -414,6 +414,27 @@ fn daemon_request<T: serde::de::DeserializeOwned>(
     args: serde_json::Value,
     payload_label: &str,
 ) -> Result<T, DaemonRpcError> {
+    daemon_request_with_timeout(cqs_dir, command, args, payload_label, None)
+}
+
+/// Like [`daemon_request`] but accepts a per-call read/write timeout
+/// override. `None` uses the default 5 s; `Some(d)` sets both timeouts
+/// to `d`. Used by [`wait_for_fresh`] (#1228 — RM-2) where the daemon
+/// holds the connection while parking on its `FreshNotifier` for up to
+/// the caller's wait budget.
+///
+/// The override applies before the request is written, so a misbehaving
+/// daemon that never replies still hits a deadline. Callers should pass
+/// `wait_secs + small_grace` so the client-side timeout can't beat the
+/// server-side `wait_until_fresh` deadline by accident.
+#[cfg(unix)]
+fn daemon_request_with_timeout<T: serde::de::DeserializeOwned>(
+    cqs_dir: &std::path::Path,
+    command: &str,
+    args: serde_json::Value,
+    payload_label: &str,
+    timeout_override: Option<std::time::Duration>,
+) -> Result<T, DaemonRpcError> {
     use std::io::{BufRead, Read as _, Write};
     use std::os::unix::net::UnixStream;
     use std::time::Duration;
@@ -447,7 +468,12 @@ fn daemon_request<T: serde::de::DeserializeOwned>(
     // 5s is generous: every daemon RPC's handler does at most a single
     // RwLock read + clone + a `metadata()` syscall. No real I/O on the
     // daemon side.
-    let timeout = Duration::from_secs(5);
+    //
+    // #1228 (RM-2): `wait_fresh` parks server-side for up to `wait_secs`
+    // before responding, so the caller passes a longer timeout via
+    // `timeout_override`. All other RPCs leave it `None` and inherit
+    // the 5 s default.
+    let timeout = timeout_override.unwrap_or(Duration::from_secs(5));
     if let Err(e) = stream.set_read_timeout(Some(timeout)) {
         tracing::debug!(stage = "set_read_timeout", error = %e, command, "daemon request failed");
         return Err(DaemonRpcError::Transport(format!(
@@ -709,73 +735,81 @@ pub fn wait_for_fresh(cqs_dir: &std::path::Path, wait_secs: u64) -> FreshnessWai
     let start = std::time::Instant::now();
     // RB-2: defensive cap so a `pub fn` can't panic on
     // `Instant + Duration::from_secs(u64::MAX)`. Caller should pass a
-    // sane budget but we bound it here regardless.
+    // sane budget but we bound it here regardless. Daemon-side mirrors
+    // the same cap in `dispatch_wait_fresh` so a malicious / buggy
+    // client can't request a wait longer than 24 h either.
     let bounded_secs = wait_secs.min(86_400);
-    let deadline = start + std::time::Duration::from_secs(bounded_secs);
 
-    let mut poll_interval =
-        std::time::Duration::from_millis(crate::limits::freshness_poll_ms_initial());
-    let max_interval = std::time::Duration::from_secs(2);
+    // RB-9: deadline-first. A zero-budget wait short-circuits to
+    // `Timeout(unknown)` without a socket round-trip, matching the
+    // pre-#1228 behaviour. Real callers always pass a non-zero budget;
+    // the zero path is a defensive contract that "give me 0 budget"
+    // never spawns network I/O.
+    if bounded_secs == 0 {
+        tracing::info!(
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "wait_for_fresh: deadline reached before first fresh poll",
+        );
+        return FreshnessWait::Timeout(crate::watch_status::WatchSnapshot::unknown());
+    }
 
-    loop {
-        // RB-9: deadline-first so a slow daemon timeout can't push us
-        // past the user's budget. If the deadline already passed before
-        // we got our first response, return Timeout with the unknown
-        // snapshot — the caller's bail message will explain.
-        if std::time::Instant::now() >= deadline {
-            tracing::info!(
-                elapsed_ms = start.elapsed().as_millis() as u64,
-                "wait_for_fresh: deadline reached before first fresh poll",
-            );
-            return FreshnessWait::Timeout(crate::watch_status::WatchSnapshot::unknown());
+    // #1228 (RM-2): single-round-trip server-side wait. Daemon parks
+    // the request on its shared `FreshNotifier` until either the watch
+    // loop publishes a Fresh transition or the deadline expires, then
+    // replies with the current snapshot. Replaces the prior 250 ms-poll
+    // loop (4-5k connect/parse round-trips per 60 s wait at the default
+    // budget) — see issue #1228 RM-2 for the cost-shape rationale.
+    //
+    // Client-side timeout is `bounded_secs + 5` so a slow-but-honest
+    // daemon (handler scheduling jitter, write-buffer flush) gets a
+    // small grace period before the read times out. A genuinely wedged
+    // daemon still hits the budget plus grace, not minutes-of-pin.
+    let timeout = std::time::Duration::from_secs(bounded_secs.saturating_add(5));
+    let request = serde_json::json!(["--wait-secs", bounded_secs.to_string()]);
+    let result: Result<crate::watch_status::WatchSnapshot, DaemonRpcError> =
+        daemon_request_with_timeout(
+            cqs_dir,
+            "wait-fresh",
+            request,
+            "WatchSnapshot",
+            Some(timeout),
+        );
+
+    match result {
+        Ok(snap) => {
+            if snap.is_fresh() {
+                tracing::info!(
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    modified_files = snap.modified_files,
+                    "wait_for_fresh: index reached Fresh",
+                );
+                FreshnessWait::Fresh(snap)
+            } else {
+                tracing::info!(
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    modified_files = snap.modified_files,
+                    pending_notes = snap.pending_notes,
+                    rebuild_in_flight = snap.rebuild_in_flight,
+                    "wait_for_fresh: timeout — index still stale",
+                );
+                FreshnessWait::Timeout(snap)
+            }
         }
-
-        match daemon_status(cqs_dir) {
-            Ok(snap) => {
-                if snap.is_fresh() {
-                    tracing::info!(
-                        elapsed_ms = start.elapsed().as_millis() as u64,
-                        modified_files = snap.modified_files,
-                        "wait_for_fresh: index reached Fresh",
-                    );
-                    return FreshnessWait::Fresh(snap);
-                }
-                if std::time::Instant::now() >= deadline {
-                    tracing::info!(
-                        elapsed_ms = start.elapsed().as_millis() as u64,
-                        modified_files = snap.modified_files,
-                        pending_notes = snap.pending_notes,
-                        rebuild_in_flight = snap.rebuild_in_flight,
-                        "wait_for_fresh: timeout — index still stale",
-                    );
-                    return FreshnessWait::Timeout(snap);
-                }
-                std::thread::sleep(poll_interval);
-                // Exponential backoff with a 2 s ceiling. Linearly
-                // doubling beats fixed cadence on long waits because the
-                // socket budget cost is per round-trip, not per second.
-                poll_interval = (poll_interval * 2).min(max_interval);
-            }
-            Err(DaemonRpcError::SocketMissing(msg)) => {
-                tracing::info!(error = %msg, "wait_for_fresh: daemon socket missing");
-                return FreshnessWait::NoDaemon(msg);
-            }
-            Err(DaemonRpcError::Transport(msg)) => {
-                tracing::info!(error = %msg, "wait_for_fresh: transport failure");
-                return FreshnessWait::Transport(msg);
-            }
-            Err(DaemonRpcError::BadResponse(msg)) => {
-                tracing::warn!(error = %msg, "wait_for_fresh: malformed daemon response");
-                return FreshnessWait::BadResponse(msg);
-            }
-            Err(DaemonRpcError::DaemonError(msg)) => {
-                // The daemon answered with `status: "err"`. From the
-                // freshness-poll perspective this is the daemon refusing
-                // to provide a snapshot — surface as transport-class so
-                // the caller's message points at the daemon log.
-                tracing::warn!(error = %msg, "wait_for_fresh: daemon-side error");
-                return FreshnessWait::Transport(msg);
-            }
+        Err(DaemonRpcError::SocketMissing(msg)) => {
+            tracing::info!(error = %msg, "wait_for_fresh: daemon socket missing");
+            FreshnessWait::NoDaemon(msg)
+        }
+        Err(DaemonRpcError::Transport(msg)) => {
+            tracing::info!(error = %msg, "wait_for_fresh: transport failure");
+            FreshnessWait::Transport(msg)
+        }
+        Err(DaemonRpcError::BadResponse(msg)) => {
+            tracing::warn!(error = %msg, "wait_for_fresh: malformed daemon response");
+            FreshnessWait::BadResponse(msg)
+        }
+        Err(DaemonRpcError::DaemonError(msg)) => {
+            tracing::warn!(error = %msg, "wait_for_fresh: daemon-side error");
+            FreshnessWait::Transport(msg)
         }
     }
 }
@@ -1509,136 +1543,22 @@ mod tests {
         }
     }
 
-    /// TC-HAP-1.30.1-5: `wait_for_fresh` polls past stale snapshots and
-    /// returns `Fresh` once the daemon flips. Listener accepts three
-    /// connections: stale, stale, fresh. Pins both the polling loop AND
-    /// the exponential backoff (elapsed must be at least the initial
-    /// poll interval × 1 sleep — a fresh-on-first wouldn't sleep at all).
+    /// #1228 (RM-2): `wait_for_fresh` is now a single round-trip.
+    /// When the mock daemon replies with a Stale snapshot (i.e. the
+    /// daemon's `dispatch_wait_fresh` parked, hit its deadline, and
+    /// returned the still-stale snapshot), the helper must surface
+    /// `Timeout(snap)` so the eval gate's bail message can quote the
+    /// `modified_files` / `pending_notes` counters.
     #[cfg(unix)]
     #[test]
-    fn wait_for_fresh_returns_fresh_after_two_stale_polls() {
+    fn wait_for_fresh_returns_timeout_with_stale_snapshot_from_server() {
         use std::io::{BufRead, BufReader, Write};
         use std::os::unix::net::UnixListener;
 
         let dir = tempfile::tempdir().unwrap();
         let cqs_dir = dir.path().join(".cqs");
         std::fs::create_dir_all(&cqs_dir).unwrap();
-
-        // #1292: thread-local override avoids the unsafe set_var race that hangs CI.
         set_socket_dir_override_for_test(Some(dir.path().to_path_buf()));
-        // CQS_FRESHNESS_POLL_MS still uses set_var because freshness_poll_ms_initial
-        // reads it directly (no thread-local hook); this is one isolated env mutation,
-        // not a serialization-group dance, and the 25ms value is read once on test
-        // entry. The structural fix for `freshness_poll_ms_initial` is the same shape
-        // as #1292 (parameter / thread-local) but is out of scope for this PR.
-        let prev_poll = std::env::var("CQS_FRESHNESS_POLL_MS").ok();
-        // SAFETY: a single-set, single-restore env touch — racy in principle but the
-        // mutator and reader are both in this test thread and the value is a poll
-        // interval, not a path computed against contemporaneous state.
-        unsafe {
-            std::env::set_var("CQS_FRESHNESS_POLL_MS", "25");
-        }
-
-        let sock_path = daemon_socket_path(&cqs_dir);
-        let listener = UnixListener::bind(&sock_path).unwrap();
-
-        // Helper: build the outer envelope wrapping a snapshot.
-        let envelope = |state: crate::watch_status::FreshnessState| -> String {
-            let snap = crate::watch_status::WatchSnapshot {
-                state,
-                modified_files: if matches!(state, crate::watch_status::FreshnessState::Fresh) {
-                    0
-                } else {
-                    3
-                },
-                pending_notes: false,
-                rebuild_in_flight: false,
-                delta_saturated: false,
-                incremental_count: 0,
-                dropped_this_cycle: 0,
-                last_event_unix_secs: 1_734_120_488,
-                last_synced_at: Some(1_734_120_000),
-                snapshot_at: Some(1_734_120_500),
-                active_slot: None,
-            };
-            let inner = serde_json::json!({
-                "data": serde_json::to_value(&snap).unwrap(),
-                "error": null,
-                "version": 1,
-            });
-            serde_json::json!({"status": "ok", "output": inner}).to_string()
-        };
-
-        let stale1 = envelope(crate::watch_status::FreshnessState::Stale);
-        let stale2 = envelope(crate::watch_status::FreshnessState::Stale);
-        let fresh = envelope(crate::watch_status::FreshnessState::Fresh);
-
-        let handle = std::thread::spawn(move || {
-            for body in [stale1, stale2, fresh] {
-                let (mut stream, _) = listener.accept().unwrap();
-                let mut req = String::new();
-                BufReader::new(&stream).read_line(&mut req).unwrap();
-                writeln!(stream, "{body}").unwrap();
-                stream.flush().unwrap();
-            }
-        });
-
-        let start = std::time::Instant::now();
-        let result = wait_for_fresh(&cqs_dir, 5);
-        let elapsed = start.elapsed();
-
-        handle.join().unwrap();
-        let _ = std::fs::remove_file(&sock_path);
-
-        set_socket_dir_override_for_test(None);
-        // SAFETY: matched single-set/restore with the entry block above.
-        unsafe {
-            match prev_poll {
-                Some(v) => std::env::set_var("CQS_FRESHNESS_POLL_MS", v),
-                None => std::env::remove_var("CQS_FRESHNESS_POLL_MS"),
-            }
-        }
-
-        match result {
-            FreshnessWait::Fresh(snap) => {
-                assert_eq!(snap.state, crate::watch_status::FreshnessState::Fresh);
-                assert_eq!(snap.modified_files, 0);
-            }
-            other => panic!("expected Fresh after stale polls, got: {other:?}"),
-        }
-        // We slept at least once (after first stale poll). At a 25ms
-        // initial interval the test must take >= 25ms total. Use a loose
-        // 20ms floor to allow scheduler jitter.
-        assert!(
-            elapsed.as_millis() >= 20,
-            "expected at least one sleep cycle, got {}ms",
-            elapsed.as_millis()
-        );
-    }
-
-    /// TC-ADV-1.30.1-4: `wait_for_fresh` returns `Transport(_)` (not
-    /// `NoDaemon`) when the daemon socket file exists but the daemon
-    /// process has died — i.e. the listener was bound, accepted one
-    /// connection, then dropped. The socket file persists (until we
-    /// `remove_file`) but `UnixStream::connect` returns ECONNREFUSED
-    /// because no listener is bound to it.
-    #[cfg(unix)]
-    #[test]
-    fn wait_for_fresh_returns_transport_when_daemon_dies_mid_poll() {
-        use std::io::{BufRead, BufReader, Write};
-        use std::os::unix::net::UnixListener;
-
-        let dir = tempfile::tempdir().unwrap();
-        let cqs_dir = dir.path().join(".cqs");
-        std::fs::create_dir_all(&cqs_dir).unwrap();
-
-        // #1292: thread-local override avoids the unsafe set_var race that hangs CI.
-        set_socket_dir_override_for_test(Some(dir.path().to_path_buf()));
-        let prev_poll = std::env::var("CQS_FRESHNESS_POLL_MS").ok();
-        // SAFETY: see above.
-        unsafe {
-            std::env::set_var("CQS_FRESHNESS_POLL_MS", "25");
-        }
 
         let sock_path = daemon_socket_path(&cqs_dir);
         let listener = UnixListener::bind(&sock_path).unwrap();
@@ -1646,7 +1566,7 @@ mod tests {
         let stale_envelope = {
             let snap = crate::watch_status::WatchSnapshot {
                 state: crate::watch_status::FreshnessState::Stale,
-                modified_files: 5,
+                modified_files: 7,
                 pending_notes: false,
                 rebuild_in_flight: false,
                 delta_saturated: false,
@@ -1665,40 +1585,68 @@ mod tests {
             serde_json::json!({"status": "ok", "output": inner}).to_string()
         };
 
-        // Listener thread: accept once, send Stale, drop listener. The
-        // socket file persists on disk so subsequent connects see the
-        // file but hit ECONNREFUSED (no listener bound) — exercises
-        // Transport, not SocketMissing.
         let handle = std::thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let mut req = String::new();
             BufReader::new(&stream).read_line(&mut req).unwrap();
+            // Mock acts as the post-deadline server: replies with the
+            // still-stale snapshot. No artificial sleep — the helper
+            // doesn't depend on wall-clock for this path.
             writeln!(stream, "{stale_envelope}").unwrap();
             stream.flush().unwrap();
-            drop(stream);
-            drop(listener);
         });
 
         let result = wait_for_fresh(&cqs_dir, 5);
         handle.join().unwrap();
         let _ = std::fs::remove_file(&sock_path);
-
         set_socket_dir_override_for_test(None);
-        // SAFETY: matched single-set/restore with the entry block above.
-        unsafe {
-            match prev_poll {
-                Some(v) => std::env::set_var("CQS_FRESHNESS_POLL_MS", v),
-                None => std::env::remove_var("CQS_FRESHNESS_POLL_MS"),
-            }
-        }
 
-        // The socket file existed at every poll, but the daemon was
-        // gone for the second one — must surface as Transport, not
-        // NoDaemon, so the eval gate's advice points at journalctl
-        // rather than at "start the daemon".
+        match result {
+            FreshnessWait::Timeout(snap) => {
+                assert_eq!(snap.state, crate::watch_status::FreshnessState::Stale);
+                assert_eq!(snap.modified_files, 7);
+            }
+            other => panic!("expected Timeout(stale), got: {other:?}"),
+        }
+    }
+
+    /// #1228 (RM-2): `wait_for_fresh` returns `Transport(_)` when the
+    /// daemon socket exists but the daemon dies mid-call. Listener
+    /// accepts once, drops without writing a response — the helper's
+    /// read times out and surfaces as Transport so the eval gate's
+    /// advice points at journalctl rather than "start the daemon."
+    #[cfg(unix)]
+    #[test]
+    fn wait_for_fresh_returns_transport_when_daemon_drops_mid_call() {
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).unwrap();
+        set_socket_dir_override_for_test(Some(dir.path().to_path_buf()));
+
+        let sock_path = daemon_socket_path(&cqs_dir);
+        let listener = UnixListener::bind(&sock_path).unwrap();
+
+        // Listener thread: accept once and drop both stream and listener
+        // without writing. The helper's read times out → Transport.
+        let handle = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            drop(stream);
+            drop(listener);
+        });
+
+        // Use wait_secs=1 so the test wraps up quickly. Client-side
+        // timeout is 1 + 5 = 6 s; the read times out at the per-call
+        // timeout.
+        let result = wait_for_fresh(&cqs_dir, 1);
+        handle.join().unwrap();
+        let _ = std::fs::remove_file(&sock_path);
+        set_socket_dir_override_for_test(None);
+
         match result {
             FreshnessWait::Transport(_) => { /* expected */ }
-            other => panic!("expected Transport after daemon death, got: {other:?}"),
+            other => panic!("expected Transport after daemon drop, got: {other:?}"),
         }
     }
 

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -374,32 +374,10 @@ pub fn parse_env_u64(key: &str, default: u64) -> u64 {
     }
 }
 
-// ============ #1182 wait_for_fresh poll cadence ============
-
-/// Default initial poll interval (milliseconds) for `wait_for_fresh`. The
-/// poll loop starts here and doubles up to a 2 s ceiling. 100 ms is fast
-/// enough that an already-fresh tree returns within a tick, slow enough
-/// that 600 s × 100 ms ≈ 6000 connect/parse round-trips can't pin a
-/// host's socket budget on a stuck-stale daemon.
-///
-/// SHL-V1.30-2: env override `CQS_FRESHNESS_POLL_MS` clamped to
-/// `[25, 5000]` so a misconfigured `=1` doesn't burn CPU and `=60000`
-/// doesn't masquerade as a hang.
-pub const FRESHNESS_POLL_MS_INITIAL_DEFAULT: u64 = 100;
-
-/// Resolve the initial poll interval honoring `CQS_FRESHNESS_POLL_MS`.
-/// Floor 25 ms, ceiling 5000 ms. See [`FRESHNESS_POLL_MS_INITIAL_DEFAULT`].
-pub fn freshness_poll_ms_initial() -> u64 {
-    match std::env::var("CQS_FRESHNESS_POLL_MS") {
-        Ok(v) => v
-            .parse::<u64>()
-            .ok()
-            .filter(|n| *n > 0)
-            .map(|n| n.clamp(25, 5000))
-            .unwrap_or(FRESHNESS_POLL_MS_INITIAL_DEFAULT),
-        Err(_) => FRESHNESS_POLL_MS_INITIAL_DEFAULT,
-    }
-}
+// `freshness_poll_ms_initial` and `FRESHNESS_POLL_MS_INITIAL_DEFAULT`
+// were removed in #1228 (RM-2): `wait_for_fresh` is now a single
+// server-parked round-trip, so the poll-cadence knob has no semantic.
+// The `CQS_FRESHNESS_POLL_MS` env var that drove them is also gone.
 
 /// Parse a duration-in-seconds env var into a `std::time::Duration`,
 /// falling back to `default_secs` on missing/empty/garbage/zero values.
@@ -523,31 +501,6 @@ mod tests {
         std::env::set_var("CQS_TEST_LIMITS_U64", "42");
         assert_eq!(parse_env_u64("CQS_TEST_LIMITS_U64", 99), 42);
         std::env::remove_var("CQS_TEST_LIMITS_U64");
-    }
-
-    /// SHL-V1.30-2: `freshness_poll_ms_initial` honors the env override and
-    /// clamps to `[25, 5000]`. Missing / garbage / zero falls back to the
-    /// 100 ms default.
-    #[test]
-    fn freshness_poll_ms_initial_default_and_clamp() {
-        // Default path
-        std::env::remove_var("CQS_FRESHNESS_POLL_MS");
-        assert_eq!(freshness_poll_ms_initial(), 100);
-        // Garbage / zero falls back to default
-        std::env::set_var("CQS_FRESHNESS_POLL_MS", "garbage");
-        assert_eq!(freshness_poll_ms_initial(), 100);
-        std::env::set_var("CQS_FRESHNESS_POLL_MS", "0");
-        assert_eq!(freshness_poll_ms_initial(), 100);
-        // Below floor → clamped to 25
-        std::env::set_var("CQS_FRESHNESS_POLL_MS", "1");
-        assert_eq!(freshness_poll_ms_initial(), 25);
-        // Above ceiling → clamped to 5000
-        std::env::set_var("CQS_FRESHNESS_POLL_MS", "60000");
-        assert_eq!(freshness_poll_ms_initial(), 5000);
-        // In-range value passes through
-        std::env::set_var("CQS_FRESHNESS_POLL_MS", "250");
-        assert_eq!(freshness_poll_ms_initial(), 250);
-        std::env::remove_var("CQS_FRESHNESS_POLL_MS");
     }
 
     // ============ TC-ADV-V1.33-7: parse_env_usize_clamped + parse_env_f32 ====

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -374,10 +374,10 @@ pub fn parse_env_u64(key: &str, default: u64) -> u64 {
     }
 }
 
-// `freshness_poll_ms_initial` and `FRESHNESS_POLL_MS_INITIAL_DEFAULT`
-// were removed in #1228 (RM-2): `wait_for_fresh` is now a single
-// server-parked round-trip, so the poll-cadence knob has no semantic.
-// The `CQS_FRESHNESS_POLL_MS` env var that drove them is also gone.
+// Removed in #1228 (RM-2): `wait_for_fresh` is now a single
+// server-parked round-trip, so the poll-cadence knob (formerly
+// `freshness_poll_ms_initial` + matching env override) has no
+// semantic in the new architecture.
 
 /// Parse a duration-in-seconds env var into a `std::time::Duration`,
 /// falling back to `default_secs` on missing/empty/garbage/zero values.

--- a/src/watch_status.rs
+++ b/src/watch_status.rs
@@ -200,6 +200,116 @@ pub fn shared_reconcile_signal() -> SharedReconcileSignal {
     Arc::new(AtomicBool::new(false))
 }
 
+/// #1228 (RM-2): event-driven freshness notifier. Replaces the
+/// client-side 250 ms-poll loop in `wait_for_fresh` with a single
+/// server-side park-and-wake.
+///
+/// The watch loop calls [`FreshNotifier::set_fresh`] on every
+/// `publish_watch_snapshot` cycle (cheap when the value is unchanged —
+/// just acquires the mutex, compares, releases). On a `false → true`
+/// transition the inner `Condvar` notifies all parked waiters in one
+/// shot. The daemon's `wait_fresh` handler parks on
+/// [`FreshNotifier::wait_until_fresh`] until the notifier flips or the
+/// caller's deadline expires.
+///
+/// Predicate-under-the-mutex pattern (not a generation counter): the
+/// `is_fresh` boolean is mutated under the same lock the waiters park
+/// on, so a publish that flips `false → true` between a waiter's
+/// initial predicate read and its `wait_timeout` cannot be missed.
+/// `Condvar::wait_timeout` re-checks the predicate after spurious
+/// wake-ups (per `wait_until_fresh`'s loop body).
+#[derive(Debug, Default)]
+pub struct FreshNotifier {
+    /// `true` ⇔ the most recent watch publish was `FreshnessState::Fresh`.
+    is_fresh: std::sync::Mutex<bool>,
+    /// Notified on every `false → true` transition. `notify_all` because
+    /// the daemon may have multiple parked `wait_fresh` clients (one per
+    /// blocked CLI eval gate); we want the lot to wake at once.
+    cv: std::sync::Condvar,
+}
+
+impl FreshNotifier {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Update the cached freshness state. Notifies parked waiters when
+    /// the value transitions `false → true`. Idempotent on
+    /// `true → true` and `false → false` — the watch loop calls this
+    /// every cycle (~100 ms) and the no-op path costs one mutex
+    /// acquire + boolean compare.
+    ///
+    /// On a `RwLock` poison the function logs and returns without
+    /// notifying — a poisoned mutex means a parked waiter panicked
+    /// while holding the predicate, in which case the safest behaviour
+    /// is silence rather than re-entering and risking a double panic.
+    /// The waiter's own `wait_timeout` deadline still triggers a clean
+    /// timeout.
+    pub fn set_fresh(&self, fresh: bool) {
+        let mut guard = match self.is_fresh.lock() {
+            Ok(g) => g,
+            Err(poisoned) => {
+                tracing::warn!("FreshNotifier mutex poisoned — recovering");
+                poisoned.into_inner()
+            }
+        };
+        if !*guard && fresh {
+            *guard = fresh;
+            // Drop guard before notify so a freshly-woken waiter doesn't
+            // immediately block on us re-acquiring the lock.
+            drop(guard);
+            self.cv.notify_all();
+        } else {
+            *guard = fresh;
+        }
+    }
+
+    /// Park until either the cached state is `fresh` or `deadline`
+    /// expires. Returns `true` if the wake happened because the state
+    /// flipped to fresh; `false` on deadline.
+    ///
+    /// Race-free against `set_fresh`: the predicate is read under the
+    /// same mutex the notifier writes under, so a `false → true`
+    /// transition between the initial read and the `wait_timeout` call
+    /// would be observed by the predicate check inside the loop.
+    /// Spurious wake-ups (allowed by `Condvar`) re-enter the loop and
+    /// re-check.
+    pub fn wait_until_fresh(&self, deadline: std::time::Instant) -> bool {
+        let mut guard = match self.is_fresh.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        loop {
+            if *guard {
+                return true;
+            }
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            let timeout = deadline - now;
+            let (g, result) = match self.cv.wait_timeout(guard, timeout) {
+                Ok(pair) => pair,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            guard = g;
+            if result.timed_out() && !*guard {
+                return false;
+            }
+        }
+    }
+}
+
+/// Shared notifier handle for the watch loop (writer) and the daemon
+/// thread (waiters). Cloned at startup, mirrors [`SharedWatchSnapshot`].
+pub type SharedFreshNotifier = Arc<FreshNotifier>;
+
+/// Build the canonical handle, initialised to `not fresh` (the watch
+/// loop's first publish updates it).
+pub fn shared_fresh_notifier() -> SharedFreshNotifier {
+    Arc::new(FreshNotifier::new())
+}
+
 /// Inputs the watch loop hands to [`WatchSnapshot::compute`] every cycle.
 ///
 /// All fields are cheap reads off the loop's owned `WatchState`. Keep


### PR DESCRIPTION
Closes #1228 (RM-2).

## What

Replaces the client-side 250 ms-poll loop in `wait_for_fresh` with a daemon-side park-and-wake. One socket round-trip total instead of 4-5k connect/parse cycles in a 60 s wait.

## Architecture

- **`cqs::watch_status::FreshNotifier`** — `Mutex<bool> + Condvar` pair. Predicate-under-the-mutex (not a generation counter): the `is_fresh` boolean is mutated under the same lock waiters park on, so a publish that flips `false → true` between a waiter's predicate read and its `wait_timeout` cannot be missed. `wait_until_fresh`'s loop body handles spurious wake-ups.
- **BatchContext / BatchView** gain a `fresh_notifier` Arc field, mirror of `watch_snapshot` and `reconcile_signal`. Threaded through `spawn_daemon_thread` and adopted alongside the existing handles.
- **New `BatchCmd::WaitFresh { wait_secs }` variant** with `dispatch_wait_fresh` handler:
  1. Returns immediately if the snapshot is already Fresh on entry (preserves the "already-fresh tree pays no latency" contract).
  2. Otherwise parks on `notifier.wait_until_fresh(deadline)`.
  3. On wake re-reads the snapshot and returns it. Caller distinguishes Fresh vs Timeout by inspecting `state`.
- **Watch loop's `publish_watch_snapshot`** calls `notifier.set_fresh(...)` every cycle. Idempotent on `false → false` and `true → true` (cheap mutex acquire + boolean compare); only `false → true` issues `notify_all`.
- **Client-side `wait_for_fresh`** issues a single `daemon_request_with_timeout("wait-fresh", ..., wait_secs + 5s)` and translates the response. The 5 s grace covers handler scheduling jitter + write-buffer flush.
- **Zero-budget (`wait_secs == 0`)** preserves the deadline-first short-circuit — returns `Timeout(unknown)` without socket I/O. Matches the pre-#1228 semantic.

## Removals

The polling architecture is gone:
- `freshness_poll_ms_initial()` + `FRESHNESS_POLL_MS_INITIAL_DEFAULT` in `src/limits.rs`.
- `CQS_FRESHNESS_POLL_MS` env var (no longer read).
- `freshness_poll_ms_initial_default_and_clamp` test.
- README env-var row.

## Tests

Client-side (`daemon_translate.rs::tests`):
- Existing `wait_for_fresh_returns_fresh_on_first_poll` reused (already a single-mock-accept test).
- Existing `wait_for_fresh_returns_timeout_when_budget_expires` pins the zero-budget short-circuit.
- Existing `wait_for_fresh_returns_no_daemon_without_socket` unchanged.
- New `wait_for_fresh_returns_timeout_with_stale_snapshot_from_server` — server-side timeout returns a Stale snapshot to the client.
- New `wait_for_fresh_returns_transport_when_daemon_drops_mid_call` (replaces the multi-poll variant) — daemon accepts and drops without writing → Transport.

Daemon-side (`handlers/misc.rs::tests`):
- `dispatch_wait_fresh_returns_immediately_when_already_fresh` — pre-Fresh snapshot, handler returns within 100 ms.
- `dispatch_wait_fresh_wakes_on_notifier_flip` — publisher thread flips notifier after 50 ms; handler wakes within ~50-2000 ms.
- `dispatch_wait_fresh_returns_stale_snapshot_on_deadline` — handler parks 1 s, returns Stale snapshot.

## Verification

- `cargo test --features cuda-index --lib` — 2041 tests pass (5 wait_for_fresh + 3 dispatch_wait_fresh).
- `cargo test --features cuda-index --bin cqs` — 726 tests pass.
- `cargo clippy --features cuda-index -- -D warnings` clean.
- `cargo fmt` clean.

## Test plan

- [x] All wait_for_fresh tests pass
- [x] All dispatch_wait_fresh tests pass
- [x] Full lib + bin suites green
- [x] No clippy / fmt regressions
- [x] README env-var table updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
