### PR TITLE
refactor(batch): macro-table dispatch + uniform &args handlers (closes #1216)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -778,3 +778,32 @@ pub(crate) struct IndexArgs {
     #[arg(long)]
     pub json: bool,
 }
+
+/// #1216: args for `BatchCmd::Reconcile`. Wrapped in a struct so the
+/// dispatch table can hand the variant straight to its handler the same
+/// way every other variant does (`dispatch_x(ctx, &args)`). Fields are
+/// advisory — they ride along for tracing/logging and don't change the
+/// reconcile algorithm itself.
+#[derive(Args, Debug, Clone)]
+pub(crate) struct ReconcileArgs {
+    /// Name of the hook that fired this reconcile (e.g. `post-checkout`).
+    /// Logged for operator diagnostics; not used for the walk itself.
+    #[arg(long)]
+    pub hook: Option<String>,
+    /// Free-form positional payload from the hook (e.g. previous and
+    /// current commit SHAs). Captured for tracing only.
+    #[arg(long = "arg", value_name = "ARG")]
+    pub args: Vec<String>,
+}
+
+/// #1216 + #1228: args for `BatchCmd::WaitFresh`. Wrapped in a struct
+/// (originally inline `wait_secs: u64`) so the dispatch table can hand
+/// the variant straight to its handler under the uniform `&args` shape.
+#[derive(Args, Debug, Clone)]
+pub(crate) struct WaitFreshArgs {
+    /// Maximum seconds to block before returning the current
+    /// (still-stale) snapshot. Capped server-side at 86_400 (24 h) for
+    /// parity with the client-side cap in `wait_for_fresh`.
+    #[arg(long, default_value_t = 60)]
+    pub wait_secs: u64,
+}

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -8,8 +8,8 @@ use super::BatchView;
 use crate::cli::args::{
     BlameArgs, CallersArgs, CiArgs, ContextArgs, DeadArgs, DepsArgs, DiffArgs, DriftArgs,
     ExplainArgs, GatherArgs, ImpactArgs, ImpactDiffArgs, NotesListArgs, OnboardArgs, PlanArgs,
-    ReadArgs, RelatedArgs, ReviewArgs, ScoutArgs, SearchArgs, SimilarArgs, StaleArgs, SuggestArgs,
-    TaskArgs, TestMapArgs, TraceArgs, WhereArgs,
+    ReadArgs, ReconcileArgs, RelatedArgs, ReviewArgs, ScoutArgs, SearchArgs, SimilarArgs,
+    StaleArgs, SuggestArgs, TaskArgs, TestMapArgs, TraceArgs, WaitFreshArgs, WhereArgs,
 };
 use crate::cli::definitions::{OutputArgs, TextJsonArgs};
 
@@ -330,14 +330,8 @@ pub(crate) enum BatchCmd {
     ///   `cqs hook fire post-checkout <prev_HEAD> <new_HEAD> <branch_flag>`
     /// `--hook` carries the hook name; everything else lands in `--arg`.
     Reconcile {
-        /// Name of the hook that fired this reconcile (e.g. `post-checkout`).
-        /// Logged for operator diagnostics; not used for the walk itself.
-        #[arg(long)]
-        hook: Option<String>,
-        /// Free-form positional payload from the hook (e.g. previous and
-        /// current commit SHAs). Captured for tracing only.
-        #[arg(long = "arg", value_name = "ARG")]
-        args: Vec<String>,
+        #[command(flatten)]
+        args: ReconcileArgs,
     },
     /// Block until the watch loop transitions to Fresh, or `wait_secs`
     /// elapses. (#1228 — RM-2: server-side wait, no client-side polling.)
@@ -356,11 +350,8 @@ pub(crate) enum BatchCmd {
     /// naturally.
     #[command(name = "wait-fresh")]
     WaitFresh {
-        /// Maximum seconds to block before returning the current
-        /// (still-stale) snapshot. Capped server-side at 86_400 (24 h)
-        /// for parity with the client-side cap in `wait_for_fresh`.
-        #[arg(long, default_value_t = 60)]
-        wait_secs: u64,
+        #[command(flatten)]
+        args: WaitFreshArgs,
     },
     /// Show help
     Help,
@@ -376,7 +367,26 @@ pub(crate) enum BatchCmd {
     },
 }
 
-/// Per-variant pipeability table — single source of truth for `BatchCmd::is_pipeable`.
+/// Per-variant dispatch table — single source of truth for both
+/// `BatchCmd::is_pipeable` and `dispatch()`. (#1216, EX-V1.30.1-2.)
+///
+/// Each row carries `(Variant, handler_fn, pipeable)`. Three buckets:
+/// - `args_variants`: struct variants with `args: XArgs`. Handler signature
+///   is `fn(ctx: &BatchView, args: &XArgs) -> Result<Value>`.
+/// - `ctx_only_variants`: struct variants without `args` (e.g. `Stats`,
+///   `Health` — output-flag-only). Handler signature is `fn(ctx: &BatchView)`.
+/// - `unit_variants`: zero-field variants (e.g. `Refresh`, `Ping`).
+///   Handler signature is `fn(ctx: &BatchView)`.
+///
+/// Adding a new variant requires:
+/// 1. Adding the variant to `BatchCmd`.
+/// 2. Writing the handler.
+/// 3. Adding one row to this macro.
+///
+/// All three steps are compile-enforced by the exhaustive match the macro
+/// emits — a missing row produces a `non-exhaustive patterns` error, not a
+/// silent drop. The previous design had three coordinated edits + zero
+/// compile-time check that the dispatch arm matched the pipeability row.
 ///
 /// Issue #1137 (audit finding EX-V1.30-1): the pipeability classification used
 /// to live in a hand-maintained match arm, decoupled from the variant declaration.
@@ -392,54 +402,65 @@ pub(crate) enum BatchCmd {
 ///
 /// Pipeable: primary input is a function name (so a previous segment's output
 /// can be piped in). Not pipeable: queries, paths, git refs, or no positional arg.
-macro_rules! for_each_batch_cmd_pipeability {
+/// #1216 (EX-V1.30.1-2): single source of truth for both
+/// `BatchCmd::is_pipeable` AND `dispatch()`. Each row is
+/// `(Variant, handler_fn, pipeable)`.
+///
+/// Adding a new variant: declare it on `BatchCmd`, write the handler,
+/// add one row here. The macro emits exhaustive matches for both
+/// consumers, so a missing row fails to compile.
+macro_rules! for_each_batch_cmd {
     ($emit:ident) => {
         $emit! {
-            struct_variants: {
+            args_variants: {
                 // Pipeable — primary input is a function name.
-                (Blame, true)
-                (Callers, true)
-                (Callees, true)
-                (Deps, true)
-                (Explain, true)
-                (Similar, true)
-                (Impact, true)
-                (TestMap, true)
-                (Related, true)
-                (Scout, true)
+                (Blame,      dispatch_blame,        true)
+                (Callers,    dispatch_callers,      true)
+                (Callees,    dispatch_callees,      true)
+                (Deps,       dispatch_deps,         true)
+                (Explain,    dispatch_explain,      true)
+                (Similar,    dispatch_similar,      true)
+                (Impact,     dispatch_impact,       true)
+                (TestMap,    dispatch_test_map,     true)
+                (Related,    dispatch_related,      true)
+                (Scout,      dispatch_scout,        true)
 
-                // Not pipeable — queries, paths, git refs, or no positional arg.
-                (Search, false)
-                (Gather, false)
-                (Trace, false)
-                (Dead, false)
-                (Context, false)
-                (Stats, false)
-                (Onboard, false)
-                (Where, false)
-                (Read, false)
-                (Stale, false)
-                (Health, false)
-                (Drift, false)
-                (Notes, false)
-                (Task, false)
-                (Review, false)
-                (Ci, false)
-                (Diff, false)
-                (ImpactDiff, false)
-                (Plan, false)
-                (Suggest, false)
-                (Gc, false)
-                (Reconcile, false)
-                // #1228 (RM-2): not pipeable — wait_secs is the only
-                // arg, no positional function name to receive a pipe.
-                (WaitFresh, false)
+                // Not pipeable — queries, paths, git refs.
+                (Search,     dispatch_search,       false)
+                (Gather,     dispatch_gather,       false)
+                (Trace,      dispatch_trace,        false)
+                (Dead,       dispatch_dead,         false)
+                (Context,    dispatch_context,      false)
+                (Onboard,    dispatch_onboard,      false)
+                (Where,      dispatch_where,        false)
+                (Read,       dispatch_read,         false)
+                (Stale,      dispatch_stale,        false)
+                (Drift,      dispatch_drift,        false)
+                (Notes,      dispatch_notes,        false)
+                (Task,       dispatch_task,         false)
+                (Review,     dispatch_review,       false)
+                (Ci,         dispatch_ci,           false)
+                (Diff,       dispatch_diff,         false)
+                (ImpactDiff, dispatch_impact_diff,  false)
+                (Plan,       dispatch_plan,         false)
+                (Suggest,    dispatch_suggest,      false)
+                (Reconcile,  dispatch_reconcile,    false)
+                // #1228 (RM-2): wait_secs-only — no positional function
+                // name to receive a pipe.
+                (WaitFresh,  dispatch_wait_fresh,   false)
+            }
+            ctx_only_variants: {
+                // Struct variants with only `output: TextJsonArgs` (no
+                // primary `args` payload). Dispatched as `handler(ctx)`.
+                (Stats,   dispatch_stats,   false)
+                (Health,  dispatch_health,  false)
+                (Gc,      dispatch_gc,      false)
             }
             unit_variants: {
-                (Refresh, false)
-                (Ping, false)
-                (Status, false)
-                (Help, false)
+                (Refresh,  dispatch_refresh,  false)
+                (Ping,     dispatch_ping,     false)
+                (Status,   dispatch_status,   false)
+                (Help,     dispatch_help,     false)
             }
         }
     };
@@ -447,21 +468,26 @@ macro_rules! for_each_batch_cmd_pipeability {
 
 /// Emits `BatchCmd::is_pipeable` from the table above.
 ///
-/// API-V1.25-6: the generated `match` is intentionally exhaustive (no wildcard
-/// arm), so a new `BatchCmd` variant without a pipeability row fails to compile.
-/// `test_is_pipeable_exhaustive` below double-pins this behaviour.
+/// API-V1.25-6: the generated `match` is intentionally exhaustive (no
+/// wildcard arm), so a new `BatchCmd` variant without a row fails to
+/// compile. `test_is_pipeable_exhaustive` below double-pins this.
 macro_rules! gen_is_pipeable_impl {
     (
-        struct_variants: { $(($svar:ident, $sp:expr))* }
-        unit_variants:   { $(($uvar:ident, $up:expr))* }
+        args_variants:     { $(($v:ident, $h:ident, $p:expr))* }
+        ctx_only_variants: { $(($v2:ident, $h2:ident, $p2:expr))* }
+        unit_variants:     { $(($v3:ident, $h3:ident, $p3:expr))* }
     ) => {
         impl BatchCmd {
             /// Whether this command accepts a piped function name as its first positional arg.
             /// Used by pipeline execution to validate downstream segments.
             pub(crate) fn is_pipeable(&self) -> bool {
+                // The handler-fn idents are consumed by `gen_dispatch_impl`,
+                // not this one — `let _` arms keep them in scope without
+                // tripping the unused-ident lint.
                 match self {
-                    $(BatchCmd::$svar { .. } => $sp,)*
-                    $(BatchCmd::$uvar => $up,)*
+                    $(BatchCmd::$v { .. } => { let _ = stringify!($h); $p },)*
+                    $(BatchCmd::$v2 { .. } => { let _ = stringify!($h2); $p2 },)*
+                    $(BatchCmd::$v3 => { let _ = stringify!($h3); $p3 },)*
                     #[cfg(test)]
                     BatchCmd::TestSleep { .. } => false,
                 }
@@ -470,7 +496,63 @@ macro_rules! gen_is_pipeable_impl {
     };
 }
 
-for_each_batch_cmd_pipeability!(gen_is_pipeable_impl);
+for_each_batch_cmd!(gen_is_pipeable_impl);
+
+/// Emits `dispatch(ctx, cmd)` from the same table. One arm per row;
+/// the exhaustive match is the compile-time guarantee that every variant
+/// has a handler.
+macro_rules! gen_dispatch_impl {
+    (
+        args_variants:     { $(($v:ident, $h:ident, $p:expr))* }
+        ctx_only_variants: { $(($v2:ident, $h2:ident, $p2:expr))* }
+        unit_variants:     { $(($v3:ident, $h3:ident, $p3:expr))* }
+    ) => {
+        /// Execute a batch command and return a JSON value. The
+        /// BatchCmd → handler mapping lives in `for_each_batch_cmd!`
+        /// — the only edit needed when adding a new command is one row
+        /// in that table plus the handler implementation.
+        ///
+        /// #1127: takes a [`BatchView`] (snapshot of BatchContext caches built
+        /// under a brief critical section) instead of `&BatchContext`.
+        pub(crate) fn dispatch(ctx: &BatchView, cmd: BatchCmd) -> Result<serde_json::Value> {
+            let _span = tracing::debug_span!("batch_dispatch").entered();
+            // EX-V1.30.1-3 (P3-EX-1): single table-driven query-log call
+            // replaces six hand-sprinkled `log_query(...)` invocations.
+            log_query_for(&cmd);
+            // `output` field on each variant is intentionally dropped —
+            // batch always emits JSON. Pattern-match `..` so the
+            // destructure stays exhaustive even if future fields are
+            // added to a variant.
+            match cmd {
+                $(BatchCmd::$v { args, .. } => {
+                    let _ = $p; // keep the pipeability column referenced
+                    handlers::$h(ctx, &args)
+                },)*
+                $(BatchCmd::$v2 { .. } => {
+                    let _ = $p2;
+                    handlers::$h2(ctx)
+                },)*
+                $(BatchCmd::$v3 => {
+                    let _ = $p3;
+                    handlers::$h3(ctx)
+                },)*
+                #[cfg(test)]
+                BatchCmd::TestSleep { ms } => {
+                    // #1127 regression test fixture. Sleeps the dispatcher
+                    // thread for `ms` milliseconds, then returns a tiny
+                    // envelope. Two concurrent daemon connections both
+                    // running `test-sleep --ms N` must finish in
+                    // ~max(N, N) — *not* 2*N — when the lock is held only
+                    // across checkout_view.
+                    std::thread::sleep(std::time::Duration::from_millis(ms));
+                    Ok(serde_json::json!({"slept_ms": ms}))
+                }
+            }
+        }
+    };
+}
+
+for_each_batch_cmd!(gen_dispatch_impl);
 
 // ─── Query logging ───────────────────────────────────────────────────────────
 
@@ -556,165 +638,6 @@ fn log_query(command: &str, query: &str) {
         command,
         serde_json::to_string(query).unwrap_or_else(|_| "\"\"".to_string())
     );
-}
-
-// ─── Dispatch ────────────────────────────────────────────────────────────────
-
-/// Execute a batch command and return a JSON value.
-/// This is the seam for step 3 (REPL): import `BatchView` + `dispatch`, wrap
-/// with readline.
-///
-/// #1127: takes a [`BatchView`] (snapshot of BatchContext caches built under a
-/// brief critical section) instead of `&BatchContext`. Handlers operate on the
-/// view's `Arc`-cloned data; the daemon's outer mutex is released before
-/// dispatch, so concurrent reads no longer serialize through one lock.
-pub(crate) fn dispatch(ctx: &BatchView, cmd: BatchCmd) -> Result<serde_json::Value> {
-    let _span = tracing::debug_span!("batch_dispatch").entered();
-    // EX-V1.30.1-3 (P3-EX-1): single table-driven query-log call replaces
-    // six hand-sprinkled `log_query(...)` invocations inside the match arms.
-    // The `for_each_logged_batch_cmd!` table at the top of this module
-    // owns the variant → log-name + field-accessor mapping.
-    log_query_for(&cmd);
-    // Task #8: every variant now also carries `output` (TextJsonArgs or
-    // OutputArgs) for CLI flag parity, but batch always emits JSON via the
-    // socket framer / stdout JSONL — the output field is intentionally
-    // dropped here. Pattern-match `..` so the destructure stays exhaustive
-    // even if future fields are added to the variant.
-    match cmd {
-        BatchCmd::Blame { args, .. } => {
-            handlers::dispatch_blame(ctx, &args.name, args.commits, args.callers)
-        }
-        BatchCmd::Search { args, .. } => handlers::dispatch_search(ctx, &args),
-        BatchCmd::Deps { args, .. } => handlers::dispatch_deps(
-            ctx,
-            &args.name,
-            args.reverse,
-            args.limit_arg.limit,
-            args.cross_project,
-        ),
-        BatchCmd::Callers { args, .. } => {
-            handlers::dispatch_callers(ctx, &args.name, args.limit_arg.limit, args.cross_project)
-        }
-        BatchCmd::Callees { args, .. } => {
-            handlers::dispatch_callees(ctx, &args.name, args.limit_arg.limit, args.cross_project)
-        }
-        BatchCmd::Explain { args, .. } => {
-            handlers::dispatch_explain(ctx, &args.name, args.limit_arg.limit, args.tokens)
-        }
-        BatchCmd::Similar { args, .. } => {
-            handlers::dispatch_similar(ctx, &args.name, args.limit, args.threshold)
-        }
-        BatchCmd::Gather { args, .. } => handlers::dispatch_gather(ctx, &args),
-        BatchCmd::Impact { args, .. } => handlers::dispatch_impact(
-            ctx,
-            &args.name,
-            args.depth,
-            args.limit_arg.limit,
-            args.suggest_tests,
-            args.type_impact,
-            args.cross_project,
-        ),
-        BatchCmd::TestMap { args, .. } => handlers::dispatch_test_map(
-            ctx,
-            &args.name,
-            args.depth,
-            args.limit_arg.limit,
-            args.cross_project,
-        ),
-        BatchCmd::Trace { args, .. } => handlers::dispatch_trace(
-            ctx,
-            &args.source,
-            &args.target,
-            args.max_depth as usize,
-            args.limit_arg.limit,
-            args.cross_project,
-        ),
-        BatchCmd::Dead { args, .. } => {
-            handlers::dispatch_dead(ctx, args.include_pub, &args.min_confidence)
-        }
-        BatchCmd::Related { args, .. } => handlers::dispatch_related(ctx, &args.name, args.limit),
-        BatchCmd::Context { args, .. } => {
-            handlers::dispatch_context(ctx, &args.path, args.summary, args.compact, args.tokens)
-        }
-        BatchCmd::Stats { .. } => handlers::dispatch_stats(ctx),
-        BatchCmd::Onboard { args, .. } => handlers::dispatch_onboard(
-            ctx,
-            &args.query,
-            args.depth,
-            args.limit_arg.limit,
-            args.tokens,
-        ),
-        BatchCmd::Scout { args, .. } => {
-            handlers::dispatch_scout(ctx, &args.query, args.limit, args.tokens)
-        }
-        BatchCmd::Where { args, .. } => {
-            handlers::dispatch_where(ctx, &args.description, args.limit)
-        }
-        BatchCmd::Read { args, .. } => {
-            handlers::dispatch_read(ctx, &args.path, args.focus.as_deref())
-        }
-        BatchCmd::Stale { args, .. } => handlers::dispatch_stale(ctx, args.count_only),
-        BatchCmd::Health { .. } => handlers::dispatch_health(ctx),
-        BatchCmd::Drift { args, .. } => handlers::dispatch_drift(
-            ctx,
-            &args.reference,
-            args.threshold,
-            args.min_drift,
-            args.lang.as_deref(),
-            args.limit,
-        ),
-        BatchCmd::Notes { args, .. } => {
-            // API-V1.29-4: pass `check` through so the daemon path matches
-            // `cqs notes list --check` when routed via the socket.
-            handlers::dispatch_notes(
-                ctx,
-                args.warnings,
-                args.patterns,
-                args.kind.as_deref(),
-                args.check,
-            )
-        }
-        BatchCmd::Task { args, .. } => {
-            handlers::dispatch_task(ctx, &args.description, args.limit, args.tokens)
-        }
-        BatchCmd::Review { args, .. } => {
-            handlers::dispatch_review(ctx, args.base.as_deref(), args.tokens)
-        }
-        BatchCmd::Ci { args, .. } => {
-            handlers::dispatch_ci(ctx, args.base.as_deref(), &args.gate, args.tokens)
-        }
-        BatchCmd::Diff { args, .. } => handlers::dispatch_diff(
-            ctx,
-            &args.source,
-            args.target.as_deref(),
-            args.threshold,
-            args.lang.as_deref(),
-        ),
-        BatchCmd::ImpactDiff { args, .. } => {
-            handlers::dispatch_impact_diff(ctx, args.base.as_deref())
-        }
-        BatchCmd::Plan { args, .. } => {
-            handlers::dispatch_plan(ctx, &args.description, args.limit, args.tokens)
-        }
-        BatchCmd::Suggest { args, .. } => handlers::dispatch_suggest(ctx, args.apply),
-        BatchCmd::Gc { .. } => handlers::dispatch_gc(ctx),
-        BatchCmd::Refresh => handlers::dispatch_refresh(ctx),
-        BatchCmd::Ping => handlers::dispatch_ping(ctx),
-        BatchCmd::Status => handlers::dispatch_status(ctx),
-        BatchCmd::Reconcile { hook, args } => handlers::dispatch_reconcile(ctx, hook, args),
-        BatchCmd::WaitFresh { wait_secs } => handlers::dispatch_wait_fresh(ctx, wait_secs),
-        BatchCmd::Help => handlers::dispatch_help(),
-        #[cfg(test)]
-        BatchCmd::TestSleep { ms } => {
-            // #1127 regression test fixture. Sleeps the dispatcher thread for
-            // `ms` milliseconds, then returns a tiny envelope. Two concurrent
-            // daemon connections both running `test-sleep --ms N` must finish
-            // in ~max(N, N) — *not* 2*N — when the lock is held only across
-            // checkout_view.
-            std::thread::sleep(std::time::Duration::from_millis(ms));
-            Ok(serde_json::json!({"slept_ms": ms}))
-        }
-    }
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/src/cli/batch/handlers/analysis.rs
+++ b/src/cli/batch/handlers/analysis.rs
@@ -1,9 +1,12 @@
 //! Analysis dispatch handlers: dead, health, stale, suggest, review, ci.
+//!
+//! #1216: handlers take a single `&XArgs` argument so the macro-driven
+//! `BatchCmd::dispatch` calls every row uniformly.
 
 use anyhow::Result;
 
 use super::super::BatchView;
-use cqs::store::DeadConfidence;
+use crate::cli::args::{CiArgs, DeadArgs, ReviewArgs, StaleArgs, SuggestArgs};
 
 /// Identifies and reports dead code in a codebase.
 /// Analyzes code to find functions that are never called, filtering results based on confidence level and visibility. Returns structured JSON containing categorized dead code findings.
@@ -22,9 +25,10 @@ use cqs::store::DeadConfidence;
 /// Returns an error if the code store query fails.
 pub(in crate::cli::batch) fn dispatch_dead(
     ctx: &BatchView,
-    include_pub: bool,
-    min_confidence: &DeadConfidence,
+    args: &DeadArgs,
 ) -> Result<serde_json::Value> {
+    let include_pub = args.include_pub;
+    let min_confidence = &args.min_confidence;
     let _span = tracing::info_span!("batch_dead").entered();
 
     let (confident, possibly_pub) = ctx.store().find_dead_code(include_pub)?;
@@ -60,8 +64,9 @@ pub(in crate::cli::batch) fn dispatch_dead(
 /// Returns an error if the file set cannot be retrieved from the context or if the store query fails.
 pub(in crate::cli::batch) fn dispatch_stale(
     ctx: &BatchView,
-    count_only: bool,
+    args: &StaleArgs,
 ) -> Result<serde_json::Value> {
+    let count_only = args.count_only;
     let _span = tracing::info_span!("batch_stale", count_only).entered();
 
     // P3 #123: `file_set` is now `Arc<HashSet<PathBuf>>`. Auto-deref hands
@@ -112,8 +117,9 @@ pub(in crate::cli::batch) fn dispatch_health(ctx: &BatchView) -> Result<serde_js
 /// invariant instead of silently producing a stale (unapplied) result.
 pub(in crate::cli::batch) fn dispatch_suggest(
     ctx: &BatchView,
-    apply: bool,
+    args: &SuggestArgs,
 ) -> Result<serde_json::Value> {
+    let apply = args.apply;
     let _span = tracing::info_span!("batch_suggest", apply).entered();
 
     if apply {
@@ -150,9 +156,10 @@ pub(in crate::cli::batch) fn dispatch_suggest(
 /// review pipeline: diff impact, risk scoring, note matching, staleness.
 pub(in crate::cli::batch) fn dispatch_review(
     ctx: &BatchView,
-    base: Option<&str>,
-    tokens: Option<usize>,
+    args: &ReviewArgs,
 ) -> Result<serde_json::Value> {
+    let base = args.base.as_deref();
+    let tokens = args.tokens;
     let _span = tracing::info_span!("batch_review", ?base).entered();
 
     let diff_text = crate::cli::commands::run_git_diff(base)?;
@@ -184,10 +191,11 @@ pub(in crate::cli::batch) fn dispatch_review(
 /// causing a process exit, since the batch session must continue.
 pub(in crate::cli::batch) fn dispatch_ci(
     ctx: &BatchView,
-    base: Option<&str>,
-    gate: &crate::cli::GateThreshold,
-    tokens: Option<usize>,
+    args: &CiArgs,
 ) -> Result<serde_json::Value> {
+    let base = args.base.as_deref();
+    let gate = &args.gate;
+    let tokens = args.tokens;
     let _span = tracing::info_span!("batch_ci", ?gate).entered();
 
     let diff_text = crate::cli::commands::run_git_diff(base)?;

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -1,8 +1,15 @@
 //! Call graph dispatch handlers: callers, callees, deps, impact, test-map, trace, related, impact-diff.
+//!
+//! #1216: handlers take a single `&XArgs` argument (not destructured
+//! positionals) so the macro-driven `BatchCmd::dispatch` can call every
+//! row uniformly.
 
 use anyhow::Result;
 
 use super::super::BatchView;
+use crate::cli::args::{
+    CallersArgs, DepsArgs, ImpactArgs, ImpactDiffArgs, RelatedArgs, TestMapArgs, TraceArgs,
+};
 
 /// Dispatches a dependency query for a given name, returning either the types used by it or the code locations that use it.
 ///
@@ -23,18 +30,25 @@ use super::super::BatchView;
 /// Returns an error if the store query fails.
 pub(in crate::cli::batch) fn dispatch_deps(
     ctx: &BatchView,
-    name: &str,
-    reverse: bool,
-    limit: usize,
-    cross_project: bool,
+    args: &DepsArgs,
 ) -> Result<serde_json::Value> {
-    let _span = tracing::info_span!("batch_deps", name, reverse, limit, cross_project).entered();
+    let name = args.name.as_str();
+    let reverse = args.reverse;
+    let cross_project = args.cross_project;
+    let _span = tracing::info_span!(
+        "batch_deps",
+        name,
+        reverse,
+        limit = args.limit_arg.limit,
+        cross_project
+    )
+    .entered();
     if cross_project {
         tracing::warn!("cross-project deps not yet supported, returning local result");
     }
     // Task A3: shared cap with `cmd_deps`. Truncates after fetch so the
     // fetched set is bounded by the same value the CLI path would.
-    let limit = limit.clamp(1, 100);
+    let limit = args.limit_arg.limit.clamp(1, 100);
 
     if reverse {
         // P2 #65: bind the limit at SQL time.
@@ -62,13 +76,19 @@ pub(in crate::cli::batch) fn dispatch_deps(
 /// A `Result` containing a JSON array of caller objects, each with `name`, `file`, and `line` fields. Returns an error if the store query fails.
 pub(in crate::cli::batch) fn dispatch_callers(
     ctx: &BatchView,
-    name: &str,
-    limit: usize,
-    cross_project: bool,
+    args: &CallersArgs,
 ) -> Result<serde_json::Value> {
-    let _span = tracing::info_span!("batch_callers", name, limit, cross_project).entered();
+    let name = args.name.as_str();
+    let cross_project = args.cross_project;
+    let _span = tracing::info_span!(
+        "batch_callers",
+        name,
+        limit = args.limit_arg.limit,
+        cross_project
+    )
+    .entered();
     // Task A3: shared cap with `cmd_callers`. Truncate before serialization.
-    let limit = limit.clamp(1, 100);
+    let limit = args.limit_arg.limit.clamp(1, 100);
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
@@ -102,13 +122,19 @@ pub(in crate::cli::batch) fn dispatch_callers(
 /// Returns an error if the store fails to retrieve the callees for the given function name.
 pub(in crate::cli::batch) fn dispatch_callees(
     ctx: &BatchView,
-    name: &str,
-    limit: usize,
-    cross_project: bool,
+    args: &CallersArgs,
 ) -> Result<serde_json::Value> {
-    let _span = tracing::info_span!("batch_callees", name, limit, cross_project).entered();
+    let name = args.name.as_str();
+    let cross_project = args.cross_project;
+    let _span = tracing::info_span!(
+        "batch_callees",
+        name,
+        limit = args.limit_arg.limit,
+        cross_project
+    )
+    .entered();
     // Task A3: shared cap with `cmd_callees`.
-    let limit = limit.clamp(1, 100);
+    let limit = args.limit_arg.limit.clamp(1, 100);
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
@@ -142,19 +168,24 @@ pub(in crate::cli::batch) fn dispatch_callees(
 /// Returns an error if the target cannot be resolved or if the impact analysis fails.
 pub(in crate::cli::batch) fn dispatch_impact(
     ctx: &BatchView,
-    name: &str,
-    depth: usize,
-    limit: usize,
-    do_suggest_tests: bool,
-    include_types: bool,
-    cross_project: bool,
+    args: &ImpactArgs,
 ) -> Result<serde_json::Value> {
-    let _span = tracing::info_span!("batch_impact", name, limit, cross_project).entered();
-    let depth = depth.clamp(1, 10);
+    let name = args.name.as_str();
+    let do_suggest_tests = args.suggest_tests;
+    let include_types = args.type_impact;
+    let cross_project = args.cross_project;
+    let _span = tracing::info_span!(
+        "batch_impact",
+        name,
+        limit = args.limit_arg.limit,
+        cross_project
+    )
+    .entered();
+    let depth = args.depth.clamp(1, 10);
     // Task A3: shared per-section cap with `cmd_impact`. Test suggestions are
     // computed off the un-truncated result so the engine sees every untested
     // caller; truncation happens immediately before serialization.
-    let limit = limit.clamp(1, 100);
+    let limit = args.limit_arg.limit.clamp(1, 100);
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
@@ -232,14 +263,20 @@ fn truncate_impact_sections(result: &mut cqs::ImpactResult, limit: usize) {
 /// Returns an error if the target chunk cannot be resolved, if the call graph cannot be built, or if test chunks cannot be retrieved from the store.
 pub(in crate::cli::batch) fn dispatch_test_map(
     ctx: &BatchView,
-    name: &str,
-    max_depth: usize,
-    limit: usize,
-    cross_project: bool,
+    args: &TestMapArgs,
 ) -> Result<serde_json::Value> {
-    let _span = tracing::info_span!("batch_test_map", name, limit, cross_project).entered();
+    let name = args.name.as_str();
+    let max_depth = args.depth;
+    let cross_project = args.cross_project;
+    let _span = tracing::info_span!(
+        "batch_test_map",
+        name,
+        limit = args.limit_arg.limit,
+        cross_project
+    )
+    .entered();
     // Task A3: shared cap with `cmd_test_map`.
-    let limit = limit.clamp(1, 100);
+    let limit = args.limit_arg.limit.clamp(1, 100);
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
@@ -291,16 +328,16 @@ pub(in crate::cli::batch) fn dispatch_test_map(
 /// Returns an error if target resolution fails or if the call graph cannot be constructed.
 pub(in crate::cli::batch) fn dispatch_trace(
     ctx: &BatchView,
-    source: &str,
-    target: &str,
-    max_depth: usize,
-    _limit: usize,
-    cross_project: bool,
+    args: &TraceArgs,
 ) -> Result<serde_json::Value> {
+    let source = args.source.as_str();
+    let target = args.target.as_str();
+    let max_depth = args.max_depth as usize;
+    let cross_project = args.cross_project;
     let _span = tracing::info_span!("batch_trace", source, target, cross_project).entered();
     // Task A3: `--limit` is accepted for parity with other graph commands. See
     // `cmd_trace` for rationale (single shortest path today; reserved for
-    // future k-shortest-paths variants).
+    // future k-shortest-paths variants). args.limit_arg.limit intentionally unused.
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
@@ -374,14 +411,14 @@ pub(in crate::cli::batch) fn dispatch_trace(
 /// Returns an error if the database query fails.
 pub(in crate::cli::batch) fn dispatch_related(
     ctx: &BatchView,
-    name: &str,
-    limit: usize,
+    args: &RelatedArgs,
 ) -> Result<serde_json::Value> {
+    let name = args.name.as_str();
     let _span = tracing::info_span!("batch_related", name).entered();
     // CQ-V1.25-2: shared with CLI's cmd_related. Previously 100 here vs
     // unbounded in CLI — lowered to 50 (per-category) to match and stop
     // quadratic blow-up on related-related queries.
-    let limit = limit.clamp(1, crate::cli::RELATED_LIMIT_MAX);
+    let limit = args.limit.clamp(1, crate::cli::RELATED_LIMIT_MAX);
 
     let result = cqs::find_related(&ctx.store(), name, limit)?;
     let output = crate::cli::commands::build_related_output(&result, &ctx.root);
@@ -391,8 +428,9 @@ pub(in crate::cli::batch) fn dispatch_related(
 /// Runs diff-aware impact analysis and returns results as JSON.
 pub(in crate::cli::batch) fn dispatch_impact_diff(
     ctx: &BatchView,
-    base: Option<&str>,
+    args: &ImpactDiffArgs,
 ) -> Result<serde_json::Value> {
+    let base = args.base.as_deref();
     let _span = tracing::info_span!("batch_impact_diff", ?base).entered();
 
     let diff_text = crate::cli::commands::run_git_diff(base)?;
@@ -511,8 +549,12 @@ mod tests {
     #[test]
     fn dispatch_callers_returns_seeded_caller() {
         let (_dir, ctx) = seed_call_graph_ctx();
-        let json = dispatch_callers(&ctx.build_view(None), "callee_fn", 10, false)
-            .expect("dispatch_callers");
+        let args = CallersArgs {
+            name: "callee_fn".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
+        };
+        let json = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
         // `build_callers` returns `Vec<CallerEntry>`, which serializes as a
         // bare JSON array (no enclosing key).
         let callers = json
@@ -527,8 +569,12 @@ mod tests {
     #[test]
     fn dispatch_callees_returns_seeded_callee() {
         let (_dir, ctx) = seed_call_graph_ctx();
-        let json = dispatch_callees(&ctx.build_view(None), "caller_fn", 10, false)
-            .expect("dispatch_callees");
+        let args = CallersArgs {
+            name: "caller_fn".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
+        };
+        let json = dispatch_callees(&ctx.build_view(None), &args).expect("dispatch_callees");
         // `build_callees` emits `CalleesOutput { name, calls, count }` —
         // `name` field, not `function`.
         assert_eq!(json["name"], "caller_fn");
@@ -544,8 +590,11 @@ mod tests {
     #[test]
     fn dispatch_related_returns_envelope_for_seeded_chunk() {
         let (_dir, ctx) = seed_call_graph_ctx();
-        let json =
-            dispatch_related(&ctx.build_view(None), "caller_fn", 10).expect("dispatch_related");
+        let args = RelatedArgs {
+            name: "caller_fn".into(),
+            limit: 10,
+        };
+        let json = dispatch_related(&ctx.build_view(None), &args).expect("dispatch_related");
         // build_related_output structure varies — pin envelope shape only:
         // it must be an object (not an array, not null) with at least one
         // top-level key.
@@ -565,6 +614,10 @@ mod tests {
         // either succeeds (returning empty) or errors. Either way the
         // handler returns Result, so this test simply asserts no-panic and
         // a Result outcome.
-        let _ = dispatch_impact_diff(&ctx.build_view(None), None);
+        let args = ImpactDiffArgs {
+            base: None,
+            stdin: false,
+        };
+        let _ = dispatch_impact_diff(&ctx.build_view(None), &args);
     }
 }

--- a/src/cli/batch/handlers/info.rs
+++ b/src/cli/batch/handlers/info.rs
@@ -1,8 +1,12 @@
 //! Info dispatch handlers: stats, context, explain, similar, read, blame, onboard.
+//!
+//! #1216: handlers take a single `&XArgs` argument so the macro-driven
+//! `BatchCmd::dispatch` calls every row uniformly.
 
 use anyhow::Result;
 
 use super::super::BatchView;
+use crate::cli::args::{BlameArgs, ContextArgs, ExplainArgs, OnboardArgs, ReadArgs, SimilarArgs};
 use crate::cli::validate_finite_f32;
 use cqs::normalize_path;
 
@@ -19,10 +23,11 @@ use cqs::normalize_path;
 /// Returns an error if building the blame data fails, such as when the target cannot be found or accessed in the store.
 pub(in crate::cli::batch) fn dispatch_blame(
     ctx: &BatchView,
-    target: &str,
-    depth: usize,
-    show_callers: bool,
+    args: &BlameArgs,
 ) -> Result<serde_json::Value> {
+    let target = args.name.as_str();
+    let depth = args.commits;
+    let show_callers = args.callers;
     let _span = tracing::info_span!("batch_blame", target).entered();
     let data = crate::cli::commands::blame::build_blame_data(
         &ctx.store(),
@@ -45,14 +50,15 @@ pub(in crate::cli::batch) fn dispatch_blame(
 /// Returns an error if the vector index cannot be retrieved, the embedder fails to initialize (when tokens are specified), or if the explanation data cannot be built or converted to JSON.
 pub(in crate::cli::batch) fn dispatch_explain(
     ctx: &BatchView,
-    target: &str,
-    limit: usize,
-    tokens: Option<usize>,
+    args: &ExplainArgs,
 ) -> Result<serde_json::Value> {
-    let _span = tracing::info_span!("batch_explain", target, limit).entered();
+    let target = args.name.as_str();
+    let tokens = args.tokens;
+    let _span =
+        tracing::info_span!("batch_explain", target, limit = args.limit_arg.limit).entered();
     // Task A3: shared cap with `cmd_explain`. Truncates the per-section
     // lists (callers / callees / similar) before serialization.
-    let limit = limit.clamp(1, 100);
+    let limit = args.limit_arg.limit.clamp(1, 100);
 
     let index = ctx.vector_index()?;
     let index = index.as_deref();
@@ -99,16 +105,15 @@ pub(in crate::cli::batch) fn dispatch_explain(
 /// * The vector index is unavailable or search fails
 pub(in crate::cli::batch) fn dispatch_similar(
     ctx: &BatchView,
-    name: &str,
-    limit: usize,
-    threshold: f32,
+    args: &SimilarArgs,
 ) -> Result<serde_json::Value> {
+    let name = args.name.as_str();
     let _span = tracing::info_span!("batch_similar", name).entered();
-    let threshold = validate_finite_f32(threshold, "threshold")?;
+    let threshold = validate_finite_f32(args.threshold, "threshold")?;
     // CQ-V1.25-2: shared with CLI's cmd_similar (which currently does not
     // clamp — adding clamp here + constant would regress; keep parity and
     // let CLI gain its clamp in a separate fix).
-    let limit = limit.clamp(1, crate::cli::SIMILAR_LIMIT_MAX);
+    let limit = args.limit.clamp(1, crate::cli::SIMILAR_LIMIT_MAX);
 
     let resolved = cqs::resolve_target(&ctx.store(), name)?;
     let chunk = &resolved.chunk;
@@ -161,11 +166,12 @@ pub(in crate::cli::batch) fn dispatch_similar(
 /// Returns an error if the file at `path` is not indexed or if data retrieval from the store fails.
 pub(in crate::cli::batch) fn dispatch_context(
     ctx: &BatchView,
-    path: &str,
-    summary: bool,
-    compact: bool,
-    tokens: Option<usize>,
+    args: &ContextArgs,
 ) -> Result<serde_json::Value> {
+    let path = args.path.as_str();
+    let summary = args.summary;
+    let compact = args.compact;
+    let tokens = args.tokens;
     let _span = tracing::info_span!("batch_context", path).entered();
 
     // PB-V1.29-1: normalize backslash input from Windows / agent pipelines.
@@ -313,16 +319,21 @@ pub(in crate::cli::batch) fn dispatch_stats(ctx: &BatchView) -> Result<serde_jso
 /// Returns an error if embedder initialization fails, onboarding query fails, or serialization fails.
 pub(in crate::cli::batch) fn dispatch_onboard(
     ctx: &BatchView,
-    query: &str,
-    depth: usize,
-    limit: usize,
-    tokens: Option<usize>,
+    args: &OnboardArgs,
 ) -> Result<serde_json::Value> {
-    let _span = tracing::info_span!("batch_onboard", query, depth, limit).entered();
+    let query = args.query.as_str();
+    let tokens = args.tokens;
+    let _span = tracing::info_span!(
+        "batch_onboard",
+        query,
+        depth = args.depth,
+        limit = args.limit_arg.limit
+    )
+    .entered();
     let embedder = ctx.embedder()?;
-    let depth = depth.clamp(1, 5);
+    let depth = args.depth.clamp(1, 5);
     // Task A3: cap on call_chain + callers + tests. entry_point always kept.
-    let limit = limit.clamp(1, 100);
+    let limit = args.limit_arg.limit.clamp(1, 100);
 
     let mut result = cqs::onboard(&ctx.store(), embedder, query, &ctx.root, depth)?;
     result.call_chain.truncate(limit);
@@ -363,9 +374,10 @@ pub(in crate::cli::batch) fn dispatch_onboard(
 /// Returns an error if file validation or reading fails.
 pub(in crate::cli::batch) fn dispatch_read(
     ctx: &BatchView,
-    path: &str,
-    focus: Option<&str>,
+    args: &ReadArgs,
 ) -> Result<serde_json::Value> {
+    let path = args.path.as_str();
+    let focus = args.focus.as_deref();
     let _span = tracing::info_span!("batch_read", path).entered();
 
     // Focused read mode

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -1,10 +1,16 @@
 //! Misc dispatch handlers: notes, gc, plan, task, scout, where, gather, diff, drift, refresh, help.
+//!
+//! #1216: handlers take a single `&XArgs` argument so the macro-driven
+//! `BatchCmd::dispatch` calls every row uniformly.
 
 use anyhow::{Context, Result};
 
 use super::super::commands::BatchInput;
 use super::super::BatchView;
-use crate::cli::args::GatherArgs;
+use crate::cli::args::{
+    DiffArgs, DriftArgs, GatherArgs, NotesListArgs, PlanArgs, ReconcileArgs, ScoutArgs, TaskArgs,
+    WaitFreshArgs, WhereArgs,
+};
 use crate::cli::validate_finite_f32;
 
 /// Performs a semantic search gather operation with optional cross-index querying and token budget constraints.
@@ -100,11 +106,12 @@ pub(in crate::cli::batch) fn dispatch_gather(
 /// Returns an error if JSON serialization or the staleness check fails.
 pub(in crate::cli::batch) fn dispatch_notes(
     ctx: &BatchView,
-    warnings: bool,
-    patterns: bool,
-    kind: Option<&str>,
-    check: bool,
+    args: &NotesListArgs,
 ) -> Result<serde_json::Value> {
+    let warnings = args.warnings;
+    let patterns = args.patterns;
+    let kind = args.kind.as_deref();
+    let check = args.check;
     let _span = tracing::info_span!("batch_notes", warnings, patterns, kind, check).entered();
 
     let notes = ctx.notes();
@@ -181,13 +188,13 @@ pub(in crate::cli::batch) fn dispatch_notes(
 /// Returns an error if the embedder, call graph, test chunks cannot be retrieved from the context, or if task execution fails.
 pub(in crate::cli::batch) fn dispatch_task(
     ctx: &BatchView,
-    description: &str,
-    limit: usize,
-    tokens: Option<usize>,
+    args: &TaskArgs,
 ) -> Result<serde_json::Value> {
+    let description = args.description.as_str();
+    let tokens = args.tokens;
     let _span = tracing::info_span!("batch_task", description).entered();
     let embedder = ctx.embedder()?;
-    let limit = limit.clamp(1, 10);
+    let limit = args.limit.clamp(1, 10);
     let graph = ctx.call_graph()?;
     let test_chunks = ctx.test_chunks()?;
     let result = cqs::task_with_resources(
@@ -223,14 +230,14 @@ pub(in crate::cli::batch) fn dispatch_task(
 /// Returns an error if embedder initialization fails or if the core scout search operation fails.
 pub(in crate::cli::batch) fn dispatch_scout(
     ctx: &BatchView,
-    query: &str,
-    limit: usize,
-    tokens: Option<usize>,
+    args: &ScoutArgs,
 ) -> Result<serde_json::Value> {
+    let query = args.query.as_str();
+    let tokens = args.tokens;
     let _span = tracing::info_span!("batch_scout", query).entered();
     let embedder = ctx.embedder()?;
     // CQ-V1.25-2: shared with CLI's cmd_scout.
-    let limit = limit.clamp(1, crate::cli::SCOUT_LIMIT_MAX);
+    let limit = args.limit.clamp(1, crate::cli::SCOUT_LIMIT_MAX);
     let result = cqs::scout(&ctx.store(), embedder, query, &ctx.root, limit)?;
 
     let (content_map, token_info) = if let Some(budget) = tokens {
@@ -263,12 +270,12 @@ pub(in crate::cli::batch) fn dispatch_scout(
 /// Returns an error if the embedder cannot be initialized or if the placement suggestion operation fails.
 pub(in crate::cli::batch) fn dispatch_where(
     ctx: &BatchView,
-    description: &str,
-    limit: usize,
+    args: &WhereArgs,
 ) -> Result<serde_json::Value> {
+    let description = args.description.as_str();
     let _span = tracing::info_span!("batch_where", description).entered();
     let embedder = ctx.embedder()?;
-    let limit = limit.clamp(1, 10);
+    let limit = args.limit.clamp(1, 10);
     let result = cqs::suggest_placement(&ctx.store(), embedder, description, limit)?;
 
     let output = crate::cli::commands::build_where_output(&result, description, &ctx.root);
@@ -298,15 +305,14 @@ pub(in crate::cli::batch) fn dispatch_where(
 /// - Drift detection fails during comparison
 pub(in crate::cli::batch) fn dispatch_drift(
     ctx: &BatchView,
-    reference: &str,
-    threshold: f32,
-    min_drift: f32,
-    lang: Option<&str>,
-    limit: Option<usize>,
+    args: &DriftArgs,
 ) -> Result<serde_json::Value> {
+    let reference = args.reference.as_str();
+    let lang = args.lang.as_deref();
+    let limit = args.limit;
     let _span = tracing::info_span!("batch_drift", reference).entered();
-    let threshold = validate_finite_f32(threshold, "threshold")?;
-    let min_drift = validate_finite_f32(min_drift, "min_drift")?;
+    let threshold = validate_finite_f32(args.threshold, "threshold")?;
+    let min_drift = validate_finite_f32(args.min_drift, "min_drift")?;
 
     // Use cached reference store (PERF-27/RM-17)
     ctx.get_ref(reference)?;
@@ -356,13 +362,13 @@ pub(in crate::cli::batch) fn dispatch_drift(
 /// Runs semantic diff between a reference and the project (or another reference).
 pub(in crate::cli::batch) fn dispatch_diff(
     ctx: &BatchView,
-    source: &str,
-    target: Option<&str>,
-    threshold: f32,
-    lang: Option<&str>,
+    args: &DiffArgs,
 ) -> Result<serde_json::Value> {
+    let source = args.source.as_str();
+    let target = args.target.as_deref();
+    let lang = args.lang.as_deref();
     let _span = tracing::info_span!("batch_diff", source).entered();
-    let threshold = validate_finite_f32(threshold, "threshold")?;
+    let threshold = validate_finite_f32(args.threshold, "threshold")?;
 
     let source_store = crate::cli::commands::resolve::resolve_reference_store(&ctx.root, source)?;
 
@@ -449,14 +455,14 @@ pub(in crate::cli::batch) fn dispatch_diff(
 /// Runs task planning with template classification and returns results as JSON.
 pub(in crate::cli::batch) fn dispatch_plan(
     ctx: &BatchView,
-    description: &str,
-    limit: usize,
-    tokens: Option<usize>,
+    args: &PlanArgs,
 ) -> Result<serde_json::Value> {
+    let description = args.description.as_str();
+    let tokens = args.tokens;
     let _span = tracing::info_span!("batch_plan", description).entered();
 
     let embedder = ctx.embedder()?;
-    let result = cqs::plan::plan(&ctx.store(), embedder, description, &ctx.root, limit)
+    let result = cqs::plan::plan(&ctx.store(), embedder, description, &ctx.root, args.limit)
         .context("Plan generation failed")?;
 
     let mut json = serde_json::to_value(&result)?;
@@ -506,7 +512,10 @@ pub(in crate::cli::batch) fn dispatch_refresh(ctx: &BatchView) -> Result<serde_j
 /// A Result containing a JSON object with a "help" key mapped to the formatted help text for the BatchInput command.
 /// # Errors
 /// Returns an error if writing help text to the buffer fails or if UTF-8 conversion fails.
-pub(in crate::cli::batch) fn dispatch_help() -> Result<serde_json::Value> {
+pub(in crate::cli::batch) fn dispatch_help(_ctx: &BatchView) -> Result<serde_json::Value> {
+    // #1216: takes `&BatchView` to match the unit-variant handler shape
+    // even though help generation is fully static. Keeps the macro-driven
+    // dispatch table uniform.
     use clap::CommandFactory;
     let mut buf = Vec::new();
     BatchInput::command().write_help(&mut buf)?;
@@ -567,8 +576,9 @@ pub(in crate::cli::batch) fn dispatch_status(ctx: &BatchView) -> Result<serde_js
 /// with the client-side `wait_for_fresh` cap.
 pub(in crate::cli::batch) fn dispatch_wait_fresh(
     ctx: &BatchView,
-    wait_secs: u64,
+    args: &WaitFreshArgs,
 ) -> Result<serde_json::Value> {
+    let wait_secs = args.wait_secs;
     let bounded_secs = wait_secs.min(86_400);
     let _span = tracing::info_span!("batch_wait_fresh", wait_secs, bounded_secs,).entered();
     let start = std::time::Instant::now();
@@ -622,18 +632,15 @@ pub(in crate::cli::batch) fn dispatch_wait_fresh(
 /// per replayed commit).
 pub(in crate::cli::batch) fn dispatch_reconcile(
     ctx: &BatchView,
-    hook: Option<String>,
-    args: Vec<String>,
+    args: &ReconcileArgs,
 ) -> Result<serde_json::Value> {
-    let _span = tracing::info_span!(
-        "batch_reconcile",
-        hook = hook.as_deref().unwrap_or("(unknown)")
-    )
-    .entered();
+    let hook = args.hook.as_deref();
+    let _span =
+        tracing::info_span!("batch_reconcile", hook = hook.unwrap_or("(unknown)")).entered();
     let was_pending = ctx.request_reconcile();
     tracing::info!(
-        hook = hook.as_deref().unwrap_or("(unknown)"),
-        args_count = args.len(),
+        hook = hook.unwrap_or("(unknown)"),
+        args_count = args.args.len(),
         was_pending,
         "Reconcile requested"
     );
@@ -641,8 +648,8 @@ pub(in crate::cli::batch) fn dispatch_reconcile(
     // already conveys "accepted by daemon". Dropped from the wire.
     Ok(serde_json::json!({
         "was_pending": was_pending,
-        "hook": hook,
-        "args": args,
+        "hook": args.hook,
+        "args": args.args,
     }))
 }
 
@@ -720,7 +727,8 @@ mod tests {
 
         let start = std::time::Instant::now();
         // wait_secs=10 — handler should return well before this.
-        let json = dispatch_wait_fresh(&view, 10).expect("dispatch_wait_fresh");
+        let args = WaitFreshArgs { wait_secs: 10 };
+        let json = dispatch_wait_fresh(&view, &args).expect("dispatch_wait_fresh");
         let elapsed_ms = start.elapsed().as_millis();
 
         assert!(
@@ -772,7 +780,8 @@ mod tests {
         });
 
         let start = std::time::Instant::now();
-        let json = dispatch_wait_fresh(&view, 5).expect("dispatch_wait_fresh");
+        let args = WaitFreshArgs { wait_secs: 5 };
+        let json = dispatch_wait_fresh(&view, &args).expect("dispatch_wait_fresh");
         let elapsed_ms = start.elapsed().as_millis();
         publisher.join().expect("publisher thread");
 
@@ -812,7 +821,8 @@ mod tests {
         view.test_overwrite_watch_snapshot(stale);
 
         let start = std::time::Instant::now();
-        let json = dispatch_wait_fresh(&view, 1).expect("dispatch_wait_fresh");
+        let args = WaitFreshArgs { wait_secs: 1 };
+        let json = dispatch_wait_fresh(&view, &args).expect("dispatch_wait_fresh");
         let elapsed = start.elapsed();
 
         // Handler must wait the full second (within scheduler jitter)
@@ -896,12 +906,11 @@ mod tests {
         assert!(!signal.load(std::sync::atomic::Ordering::Acquire));
 
         // First dispatch flips it; was_pending must be false.
-        let json = dispatch_reconcile(
-            &view,
-            Some("post-checkout".to_string()),
-            vec!["abc".to_string(), "def".to_string(), "1".to_string()],
-        )
-        .expect("dispatch_reconcile #1");
+        let args1 = ReconcileArgs {
+            hook: Some("post-checkout".to_string()),
+            args: vec!["abc".to_string(), "def".to_string(), "1".to_string()],
+        };
+        let json = dispatch_reconcile(&view, &args1).expect("dispatch_reconcile #1");
         // API-V1.30.1-6: `queued` field dropped; Ok(...) implies queued.
         assert!(
             json.get("queued").is_none(),
@@ -920,8 +929,11 @@ mod tests {
 
         // Second dispatch (without the loop draining the flag in
         // between) coalesces — was_pending must be true.
-        let json2 = dispatch_reconcile(&view, Some("post-merge".to_string()), Vec::new())
-            .expect("dispatch_reconcile #2");
+        let args2 = ReconcileArgs {
+            hook: Some("post-merge".to_string()),
+            args: Vec::new(),
+        };
+        let json2 = dispatch_reconcile(&view, &args2).expect("dispatch_reconcile #2");
         assert_eq!(
             json2.get("was_pending").and_then(|v| v.as_bool()),
             Some(true),
@@ -935,7 +947,11 @@ mod tests {
         // must not require one — hand-rolled `cqs batch reconcile`
         // sessions skip it.
         let (_dir, _ctx, view) = empty_view();
-        let json = dispatch_reconcile(&view, None, Vec::new()).expect("dispatch_reconcile");
+        let args = ReconcileArgs {
+            hook: None,
+            args: Vec::new(),
+        };
+        let json = dispatch_reconcile(&view, &args).expect("dispatch_reconcile");
         // API-V1.30.1-6: `queued` field dropped; Ok(...) implies queued.
         assert!(
             json.get("queued").is_none(),
@@ -946,7 +962,8 @@ mod tests {
 
     #[test]
     fn dispatch_help_carries_help_text() {
-        let json = dispatch_help().expect("dispatch_help");
+        let (_dir, _ctx, view) = empty_view();
+        let json = dispatch_help(&view).expect("dispatch_help");
         let help = json
             .get("help")
             .and_then(|v| v.as_str())


### PR DESCRIPTION
Closes #1216 (EX-V1.30.1-2).

## What

Collapses the 33-arm hand-maintained match in `BatchCmd::dispatch` into a single macro-driven generation from `for_each_batch_cmd!`.

Adding a new batch variant now requires:
1. Declare the variant on `BatchCmd`.
2. Write the handler.
3. Add one row `(Variant, dispatch_fn, pipeable)` to the macro.

All three are compile-enforced. The audit complaint was that the dispatch arm was the third coordinated edit; this PR collapses it into the same row that owns pipeability.

## Stage 1 — uniform handler signatures

Every dispatch handler that took destructured positionals now takes a single `&XArgs`:

```rust
fn dispatch_X(ctx: &BatchView, args: &XArgs) -> Result<Value>
```

Field access happens inside the handler. Handlers without a payload (unit variants and `Stats`/`Health`/`Gc` which carry only `output`) keep the `fn(ctx: &BatchView)` shape. ~30 handlers touched across `analysis.rs`, `graph.rs`, `info.rs`, `misc.rs`, `search.rs`.

`BatchCmd::Reconcile` had inline `hook` / `args` fields; wrapped them in a new `ReconcileArgs` struct in `cli/args.rs` and flattened via `#[command(flatten)]` so the variant matches the uniform shape.

`dispatch_help` gains an unused `_ctx: &BatchView` parameter to fit the unit-variant handler shape.

## Stage 2 — macro-driven dispatch

The old `for_each_batch_cmd_pipeability!` table emitted only `is_pipeable`. Renamed to `for_each_batch_cmd!` and extended each row with a handler fn pointer. Three buckets:

- `args_variants` (29 variants with `args: XArgs`):
  `BatchCmd::X { args, .. } => handlers::dispatch_x(ctx, &args)`
- `ctx_only_variants` (`Stats`, `Health`, `Gc`):
  `BatchCmd::X { .. } => handlers::dispatch_x(ctx)`
- `unit_variants` (`Refresh`, `Ping`, `Status`, `Help`):
  `BatchCmd::X => handlers::dispatch_x(ctx)`

`#[cfg(test)] BatchCmd::TestSleep` stays as a manual special-case in the macro template — it's the only inline-field shape that doesn't fit the three buckets.

Both `gen_is_pipeable_impl!` and `gen_dispatch_impl!` consume the same table. Generated matches are exhaustive (no `_` arm) so a missing row fails to compile. The hand-written 33-arm `dispatch()` body is removed.

## Verification

- `cargo test --features cuda-index --lib` — 2042 tests pass.
- `cargo test --features cuda-index --bin cqs` — 723 tests pass.
- `cargo clippy --features cuda-index -- -D warnings` clean.
- `cargo fmt` clean.

## Test plan

- [x] All existing batch tests pass with handler-signature changes
- [x] Test fixtures updated for the new `&args` shape (callers/callees/related/impact_diff/reconcile/help)
- [x] No clippy / fmt regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
