### PR TITLE
perf(reconcile): stream enumerate_files + batched mtime lookup (closes #1229)

### DIFF
--- a/src/cli/watch/reconcile.rs
+++ b/src/cli/watch/reconcile.rs
@@ -64,6 +64,102 @@ pub(super) fn normalize_pending_path(p: &Path) -> PathBuf {
     }
 }
 
+/// #1229 (RM-5): per-batch fingerprint lookup + queue-divergent helper
+/// for the streaming reconcile path. Mirrors the per-file body of the
+/// pre-walked path but consumes its origin map from a 1k-wide batch
+/// rather than the full-tree `indexed_file_origins` HashMap.
+#[allow(clippy::too_many_arguments)]
+fn process_batch(
+    store: &Store,
+    root: &Path,
+    pending_files: &mut HashSet<PathBuf>,
+    max_pending: usize,
+    batch: &[PathBuf],
+    added: &mut usize,
+    modified: &mut usize,
+    queued: &mut usize,
+    skipped_at_cap: &mut usize,
+) {
+    // Build the origin string set the SQL helper expects. `Cow` saves
+    // the `replace('\\', "/")` allocation on POSIX paths (PF-V1.30.1-4).
+    let mut origins_strs: Vec<std::borrow::Cow<'_, str>> = Vec::with_capacity(batch.len());
+    let mut origins_for_sql: Vec<&str> = Vec::with_capacity(batch.len());
+    for rel in batch {
+        let cow: std::borrow::Cow<'_, str> = match rel.to_str() {
+            Some(s) if s.contains('\\') => std::borrow::Cow::Owned(s.replace('\\', "/")),
+            Some(s) => std::borrow::Cow::Borrowed(s),
+            None => continue, // non-UTF-8 — handled per-file below
+        };
+        origins_strs.push(cow);
+    }
+    for cow in &origins_strs {
+        origins_for_sql.push(cow.as_ref());
+    }
+
+    let indexed = match store.fingerprints_for_origins(&origins_for_sql) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(error = %e, "Reconcile: fingerprints_for_origins failed");
+            return;
+        }
+    };
+
+    for rel in batch {
+        if pending_files.len() >= max_pending {
+            *skipped_at_cap += 1;
+            continue;
+        }
+        let origin: std::borrow::Cow<'_, str> = match rel.to_str() {
+            Some(s) if s.contains('\\') => std::borrow::Cow::Owned(s.replace('\\', "/")),
+            Some(s) => std::borrow::Cow::Borrowed(s),
+            None => {
+                tracing::warn!(
+                    path = %rel.display(),
+                    "Reconcile: skipping non-UTF-8 path (will not be indexed until renamed)"
+                );
+                continue;
+            }
+        };
+        match indexed.get(origin.as_ref()) {
+            None => {
+                let normalized = normalize_pending_path(rel);
+                if pending_files.insert(normalized) {
+                    *added += 1;
+                    *queued += 1;
+                }
+            }
+            Some(stored_fp) => {
+                let lookup_path: PathBuf = if rel.is_absolute() {
+                    rel.clone()
+                } else {
+                    root.join(rel)
+                };
+                let needs_reindex = match FileFingerprint::read_disk(
+                    &lookup_path,
+                    stored_fp,
+                    FingerprintPolicy::MtimeOrHash,
+                ) {
+                    None => {
+                        tracing::debug!(
+                            path = %lookup_path.display(),
+                            "Reconcile: read_disk returned None, leaving file to GC"
+                        );
+                        false
+                    }
+                    Some(disk_fp) => !stored_fp.matches(&disk_fp, FingerprintPolicy::MtimeOrHash),
+                };
+                if needs_reindex {
+                    let normalized = normalize_pending_path(rel);
+                    if pending_files.insert(normalized) {
+                        *modified += 1;
+                        *queued += 1;
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Walk the project tree and queue any files that diverge from the
 /// indexed state into `pending_files`. Returns the count of files queued
 /// so the watch loop can log a summary line.
@@ -124,128 +220,165 @@ pub(super) fn run_daemon_reconcile_with_walk(
     // journalctl. Pattern matches the HNSW build sites already in tree.
     let start = std::time::Instant::now();
 
-    // Walk disk → set of relative paths visible to indexing. PF-V1.30.1-3:
-    // reuse the caller-supplied walk when present (saves one full
-    // `enumerate_files` pass on ticks that fire both gc and reconcile).
     let exts = parser.supported_extensions();
-    let walked: Option<HashSet<PathBuf>> = if disk_files.is_none() {
-        match cqs::enumerate_files(root, &exts, no_ignore) {
-            Ok(v) => Some(v.into_iter().collect()),
-            Err(e) => {
-                tracing::warn!(error = %e, "Reconcile: enumerate_files failed");
-                return 0;
-            }
-        }
-    } else {
-        None
-    };
-    let disk_files: &HashSet<PathBuf> = disk_files.unwrap_or_else(|| {
-        walked
-            .as_ref()
-            .expect("walked is Some when disk_files was None and walk succeeded")
-    });
 
-    // One SELECT pulls every indexed source-file origin + its stored
-    // mtime. Map keyed by origin string for cheap lookups in the loop.
-    let indexed = match store.indexed_file_origins() {
-        Ok(m) => m,
-        Err(e) => {
-            tracing::warn!(error = %e, "Reconcile: indexed_file_origins failed");
-            return 0;
-        }
-    };
-
+    // #1229 (RM-5): two-mode dispatch. The pre-walked path retains the
+    // legacy "fully-materialized HashSet + full-tree fingerprint map"
+    // shape because the caller (idle-tick GC + reconcile share-a-walk)
+    // already paid the materialization cost. The streaming path
+    // consumes `enumerate_files_iter` in 1k-file batches so peak heap
+    // is `O(batch_size)`, independent of tree size.
     let mut added = 0usize;
     let mut modified = 0usize;
     let mut queued = 0usize;
     let mut skipped_at_cap = 0usize;
-    for rel in disk_files {
-        // DS-V1.30.1-D2: respect the same cap as the inotify path so a
-        // bulk branch switch (50k files) doesn't drown the next
-        // `process_file_changes` cycle. Files we skip here are picked
-        // up by the next reconcile pass — the walk is idempotent.
-        if pending_files.len() >= max_pending {
-            skipped_at_cap += 1;
-            continue;
-        }
-        // Stored origins are typically relative; normalize to forward
-        // slashes for cross-platform matching parity with the rest of the
-        // store layer.
-        //
-        // RB-1: explicit `to_str()` instead of `to_string_lossy()`. Non-UTF-8
-        // path bytes get U+FFFD substitution under `to_string_lossy`, and the
-        // indexer's own lossy conversion may emit a different replacement
-        // (or skip the file entirely), so the lookup-key never matches the
-        // stored origin and the file gets requeued forever — every reconcile
-        // pass (default 30 s) wastes a parse + rewarn loop on WSL `/mnt/c/`
-        // mounts where filenames can carry stray bytes from Windows tools.
-        // Skipping with a warn is strictly better than re-queuing.
-        //
-        // PF-V1.30.1-4: skip the `replace('\\', "/")` allocation on POSIX
-        // paths (the common case on Linux/WSL/macOS). Backslashes only
-        // appear on native Windows; on Linux the path is already clean.
-        // Use `Cow::Borrowed` to reuse `&str` for the `HashMap` lookup.
-        let origin: std::borrow::Cow<'_, str> = match rel.to_str() {
-            Some(s) if s.contains('\\') => std::borrow::Cow::Owned(s.replace('\\', "/")),
-            Some(s) => std::borrow::Cow::Borrowed(s),
-            None => {
-                tracing::warn!(
-                    path = %rel.display(),
-                    "Reconcile: skipping non-UTF-8 path (will not be indexed until renamed)"
-                );
-                continue;
+
+    if let Some(disk_files) = disk_files {
+        // PF-V1.30.1-3: caller pre-walked. Reuse the materialized
+        // origins-map approach since the HashSet is already in memory.
+        let indexed = match store.indexed_file_origins() {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(error = %e, "Reconcile: indexed_file_origins failed");
+                return 0;
             }
         };
-        match indexed.get(origin.as_ref()) {
-            None => {
-                // ADDED: no chunks for this file in the index. Queue.
-                // PF-V1.30.1-9 / #1245: keep the queue keyed by the same
-                // slash-normalized form the chunks table uses, so a
-                // Windows-side reconcile and a WSL-side watcher don't
-                // double-queue the same file under both separators.
-                let normalized = normalize_pending_path(rel);
-                if pending_files.insert(normalized) {
-                    added += 1;
-                    queued += 1;
-                }
+        for rel in disk_files {
+            // DS-V1.30.1-D2: respect the same cap as the inotify path so a
+            // bulk branch switch (50k files) doesn't drown the next
+            // `process_file_changes` cycle. Files we skip here are picked
+            // up by the next reconcile pass — the walk is idempotent.
+            if pending_files.len() >= max_pending {
+                skipped_at_cap += 1;
+                continue;
             }
-            Some(stored_fp) => {
-                // MODIFIED: same path indexed, but disk content may have
-                // diverged. Use the v23 reconcile fingerprint (mtime+size
-                // fast path; BLAKE3 tiebreak on coarse-mtime FSes or
-                // content-identical-mtime-bumped flips). #1219.
-                let lookup_path: PathBuf = if rel.is_absolute() {
-                    rel.clone()
-                } else {
-                    root.join(rel)
-                };
-                let needs_reindex = match FileFingerprint::read_disk(
-                    &lookup_path,
-                    stored_fp,
-                    FingerprintPolicy::MtimeOrHash,
-                ) {
-                    // EH-V1.30.1-7 / TC-ADV-1.30.1-6: stat failures
-                    // (permission flip, transient AV scan, deleted-since-
-                    // walk) leave the file to the GC pass — we don't want
-                    // to trigger a reindex burst on a file we can't even
-                    // read.
-                    None => {
-                        tracing::debug!(
-                            path = %lookup_path.display(),
-                            "Reconcile: read_disk returned None, leaving file to GC"
-                        );
-                        false
-                    }
-                    Some(disk_fp) => !stored_fp.matches(&disk_fp, FingerprintPolicy::MtimeOrHash),
-                };
-                if needs_reindex {
+            // Stored origins are typically relative; normalize to forward
+            // slashes for cross-platform matching parity with the rest of the
+            // store layer.
+            //
+            // RB-1: explicit `to_str()` instead of `to_string_lossy()`. Non-UTF-8
+            // path bytes get U+FFFD substitution under `to_string_lossy`, and the
+            // indexer's own lossy conversion may emit a different replacement
+            // (or skip the file entirely), so the lookup-key never matches the
+            // stored origin and the file gets requeued forever — every reconcile
+            // pass (default 30 s) wastes a parse + rewarn loop on WSL `/mnt/c/`
+            // mounts where filenames can carry stray bytes from Windows tools.
+            // Skipping with a warn is strictly better than re-queuing.
+            //
+            // PF-V1.30.1-4: skip the `replace('\\', "/")` allocation on POSIX
+            // paths (the common case on Linux/WSL/macOS). Backslashes only
+            // appear on native Windows; on Linux the path is already clean.
+            // Use `Cow::Borrowed` to reuse `&str` for the `HashMap` lookup.
+            let origin: std::borrow::Cow<'_, str> = match rel.to_str() {
+                Some(s) if s.contains('\\') => std::borrow::Cow::Owned(s.replace('\\', "/")),
+                Some(s) => std::borrow::Cow::Borrowed(s),
+                None => {
+                    tracing::warn!(
+                        path = %rel.display(),
+                        "Reconcile: skipping non-UTF-8 path (will not be indexed until renamed)"
+                    );
+                    continue;
+                }
+            };
+            match indexed.get(origin.as_ref()) {
+                None => {
+                    // ADDED: no chunks for this file in the index. Queue.
+                    // PF-V1.30.1-9 / #1245: keep the queue keyed by the same
+                    // slash-normalized form the chunks table uses, so a
+                    // Windows-side reconcile and a WSL-side watcher don't
+                    // double-queue the same file under both separators.
                     let normalized = normalize_pending_path(rel);
                     if pending_files.insert(normalized) {
-                        modified += 1;
+                        added += 1;
                         queued += 1;
                     }
                 }
+                Some(stored_fp) => {
+                    // MODIFIED: same path indexed, but disk content may have
+                    // diverged. Use the v23 reconcile fingerprint (mtime+size
+                    // fast path; BLAKE3 tiebreak on coarse-mtime FSes or
+                    // content-identical-mtime-bumped flips). #1219.
+                    let lookup_path: PathBuf = if rel.is_absolute() {
+                        rel.clone()
+                    } else {
+                        root.join(rel)
+                    };
+                    let needs_reindex = match FileFingerprint::read_disk(
+                        &lookup_path,
+                        stored_fp,
+                        FingerprintPolicy::MtimeOrHash,
+                    ) {
+                        // EH-V1.30.1-7 / TC-ADV-1.30.1-6: stat failures
+                        // (permission flip, transient AV scan, deleted-since-
+                        // walk) leave the file to the GC pass — we don't want
+                        // to trigger a reindex burst on a file we can't even
+                        // read.
+                        None => {
+                            tracing::debug!(
+                                path = %lookup_path.display(),
+                                "Reconcile: read_disk returned None, leaving file to GC"
+                            );
+                            false
+                        }
+                        Some(disk_fp) => {
+                            !stored_fp.matches(&disk_fp, FingerprintPolicy::MtimeOrHash)
+                        }
+                    };
+                    if needs_reindex {
+                        let normalized = normalize_pending_path(rel);
+                        if pending_files.insert(normalized) {
+                            modified += 1;
+                            queued += 1;
+                        }
+                    }
+                }
             }
+        }
+    } else {
+        // #1229 (RM-5): streaming path. Walk the tree, buffer 1k paths
+        // at a time, query the store for that batch's fingerprints,
+        // compare disk vs stored per-file. Peak heap is `O(BATCH)` —
+        // independent of tree size.
+        const BATCH: usize = 1000;
+        let iter = match cqs::enumerate_files_iter(root, &exts, no_ignore) {
+            Ok(it) => it,
+            Err(e) => {
+                tracing::warn!(error = %e, "Reconcile: enumerate_files_iter failed");
+                return 0;
+            }
+        };
+        let mut buffer: Vec<PathBuf> = Vec::with_capacity(BATCH);
+        for rel in iter {
+            buffer.push(rel);
+            if buffer.len() < BATCH {
+                continue;
+            }
+            process_batch(
+                store,
+                root,
+                pending_files,
+                max_pending,
+                &buffer,
+                &mut added,
+                &mut modified,
+                &mut queued,
+                &mut skipped_at_cap,
+            );
+            buffer.clear();
+        }
+        // Drain the remainder.
+        if !buffer.is_empty() {
+            process_batch(
+                store,
+                root,
+                pending_files,
+                max_pending,
+                &buffer,
+                &mut added,
+                &mut modified,
+                &mut queued,
+                &mut skipped_at_cap,
+            );
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -748,12 +748,47 @@ fn max_file_size() -> u64 {
 /// both disabled by `no_ignore=true`); skips hidden files and files larger
 /// than `CQS_MAX_FILE_SIZE` bytes (default 1 MiB — generated code can
 /// exceed this). Returns relative paths from the project root.
+///
+/// Backed by [`enumerate_files_iter`] — this is a `.collect::<Vec<_>>()`
+/// wrapper that materializes the whole walk into a single allocation.
+/// Callers that don't need the count or random access (`run_daemon_reconcile`,
+/// 1k-file streaming queries) should consume the iterator directly to keep
+/// peak heap bounded by batch size rather than tree size. (#1229)
 pub fn enumerate_files(
     root: &Path,
     extensions: &[&str],
     no_ignore: bool,
 ) -> anyhow::Result<Vec<PathBuf>> {
-    let _span = tracing::debug_span!("enumerate_files", root = %root.display()).entered();
+    let iter = enumerate_files_iter(root, extensions, no_ignore)?;
+    let files: Vec<PathBuf> = iter.collect();
+    tracing::info!(file_count = files.len(), "File enumeration complete");
+    Ok(files)
+}
+
+/// Streaming variant of [`enumerate_files`]. Returns an iterator of
+/// project-relative paths under `root`, applying the same `.gitignore` /
+/// `.cqsignore` / size-cap / hidden-file filters as the eager wrapper.
+///
+/// `extensions` is borrowed and converted to owned `Vec<String>` so the
+/// returned iterator outlives the call and can be threaded into
+/// long-lived loops (the watch reconcile path is the canonical consumer).
+///
+/// Failures in the walk surface via `tracing::warn!` (first three) /
+/// `tracing::debug!` (rest), matching the pre-#1229 silent-skip-with-log
+/// contract. The iterator yields *only* the paths that successfully
+/// passed every filter — operators inspecting the walk count vs `find`
+/// output can grep journalctl for the "Skipping …" lines if the counts
+/// disagree.
+///
+/// Memory: O(WalkBuilder internals + per-iteration scratch). The
+/// `ignore` crate keeps a small per-directory ignore stack; everything
+/// else is stack-local. Peak heap is independent of tree size.
+pub fn enumerate_files_iter(
+    root: &Path,
+    extensions: &[&str],
+    no_ignore: bool,
+) -> anyhow::Result<impl Iterator<Item = PathBuf>> {
+    let _span = tracing::debug_span!("enumerate_files_iter", root = %root.display()).entered();
     use anyhow::Context;
     use ignore::WalkBuilder;
 
@@ -797,8 +832,19 @@ pub fn enumerate_files(
     // then-debug shape used by the canonicalize arm below. Silently dropping
     // files leaves operators staring at fewer chunks than expected with no
     // diagnostic trail.
-    let metadata_failures = std::sync::atomic::AtomicUsize::new(0);
-    let files: Vec<PathBuf> = walker
+    //
+    // #1229: counters live in `Arc<AtomicUsize>` so the per-row closures can
+    // each hold their own clone. The walker outlives the function call (it's
+    // returned via `impl Iterator`), so `&AtomicUsize` lifetimes wouldn't
+    // work — Arc is the cheapest move-into-closure shape.
+    let metadata_failures = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let canonicalize_failures = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    // Owned ext list so the iterator doesn't borrow caller storage.
+    let exts_owned: Vec<String> = extensions.iter().map(|s| (*s).to_string()).collect();
+    let metadata_failures_for_filter = std::sync::Arc::clone(&metadata_failures);
+    let exts_for_filter = exts_owned.clone();
+    let root_for_filter = root.clone();
+    Ok(walker
         .filter_map(|e| {
             e.map_err(|err| {
                 tracing::debug!(error = %err, "Failed to read directory entry during walk");
@@ -806,7 +852,7 @@ pub fn enumerate_files(
             .ok()
         })
         .filter(|e| e.file_type().map(|ft| ft.is_file()).unwrap_or(false))
-        .filter(|e| match e.metadata() {
+        .filter(move |e| match e.metadata() {
             Ok(m) => {
                 let len = m.len();
                 if len > size_cap {
@@ -829,8 +875,8 @@ pub fn enumerate_files(
                 // underlying io kind (e.g., "permission denied", "no such
                 // file or directory"), so the operator gets the kind
                 // implicitly via `error = %err`.
-                let count =
-                    metadata_failures.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let count = metadata_failures_for_filter
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 if count < 3 {
                     tracing::warn!(
                         path = %e.path().display(),
@@ -847,78 +893,125 @@ pub fn enumerate_files(
                 false
             }
         })
-        .filter(|e| {
+        .filter(move |e| {
             // P3 #141: `to_ascii_lowercase` allocated a fresh `String` per
             // candidate file. `eq_ignore_ascii_case` compares case-insensitively
             // without an allocation.
             e.path()
                 .extension()
                 .and_then(|ext| ext.to_str())
-                .map(|ext| extensions.iter().any(|e| ext.eq_ignore_ascii_case(e)))
+                .map(|ext| {
+                    exts_for_filter
+                        .iter()
+                        .any(|e| ext.eq_ignore_ascii_case(e.as_str()))
+                })
                 .unwrap_or(false)
         })
-        .filter_map({
-            let failure_count = std::sync::atomic::AtomicUsize::new(0);
-            move |e| {
-                let path = match dunce::canonicalize(e.path()) {
-                    Ok(p) => p,
-                    Err(err) => {
-                        let count =
-                            failure_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        if count < 3 {
-                            tracing::warn!(
-                                path = %e.path().display(),
-                                error = %err,
-                                "Failed to canonicalize path, skipping"
-                            );
-                        } else {
-                            tracing::debug!(
-                                path = %e.path().display(),
-                                error = %err,
-                                "Failed to canonicalize path, skipping"
-                            );
-                        }
-                        return None;
+        .filter_map(move |e| {
+            let path = match dunce::canonicalize(e.path()) {
+                Ok(p) => p,
+                Err(err) => {
+                    let count = canonicalize_failures
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if count < 3 {
+                        tracing::warn!(
+                            path = %e.path().display(),
+                            error = %err,
+                            "Failed to canonicalize path, skipping"
+                        );
+                    } else {
+                        tracing::debug!(
+                            path = %e.path().display(),
+                            error = %err,
+                            "Failed to canonicalize path, skipping"
+                        );
                     }
-                };
-                if path.starts_with(&root) {
-                    // RB-6: `starts_with` and `strip_prefix` can disagree on
-                    // case-insensitive filesystems (NTFS, HFS+) — `Cqs` vs
-                    // `cqs` matches under `starts_with` but `strip_prefix`
-                    // does byte-equal segment compare and refuses. The old
-                    // `unwrap_or(&path).to_path_buf()` then silently leaked
-                    // the absolute path into the relative-path workflow,
-                    // breaking every downstream lookup keyed by relative
-                    // origin. Skipping with a warn surfaces the
-                    // disagreement so the operator can fix the case skew
-                    // (or re-canonicalize the project root).
-                    match path.strip_prefix(&root) {
-                        Ok(rel) => Some(rel.to_path_buf()),
-                        Err(_) => {
-                            tracing::warn!(
-                                path = %path.display(),
-                                root = %root.display(),
-                                "enumerate_files: starts_with passed but strip_prefix failed (case-insensitive filesystem?) — skipping"
-                            );
-                            None
-                        }
-                    }
-                } else {
-                    tracing::warn!(path = %e.path().display(), "Skipping path outside project");
-                    None
+                    return None;
                 }
+            };
+            if path.starts_with(&root_for_filter) {
+                // RB-6: `starts_with` and `strip_prefix` can disagree on
+                // case-insensitive filesystems (NTFS, HFS+) — `Cqs` vs
+                // `cqs` matches under `starts_with` but `strip_prefix`
+                // does byte-equal segment compare and refuses. The old
+                // `unwrap_or(&path).to_path_buf()` then silently leaked
+                // the absolute path into the relative-path workflow,
+                // breaking every downstream lookup keyed by relative
+                // origin. Skipping with a warn surfaces the
+                // disagreement so the operator can fix the case skew
+                // (or re-canonicalize the project root).
+                match path.strip_prefix(&root_for_filter) {
+                    Ok(rel) => Some(rel.to_path_buf()),
+                    Err(_) => {
+                        tracing::warn!(
+                            path = %path.display(),
+                            root = %root_for_filter.display(),
+                            "enumerate_files: starts_with passed but strip_prefix failed (case-insensitive filesystem?) — skipping"
+                        );
+                        None
+                    }
+                }
+            } else {
+                tracing::warn!(path = %e.path().display(), "Skipping path outside project");
+                None
             }
-        })
-        .collect();
-
-    tracing::info!(file_count = files.len(), "File enumeration complete");
-
-    Ok(files)
+        }))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #1229 (RM-5): the iterator API yields the same set of files as the
+    /// eager wrapper for a small synthetic tree. Pins the contract that
+    /// `enumerate_files = enumerate_files_iter.collect()`.
+    #[test]
+    fn enumerate_files_iter_matches_eager_for_small_tree() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("src");
+        std::fs::create_dir(&src).expect("mkdir src");
+        std::fs::write(src.join("a.rs"), "fn a() {}").expect("write a.rs");
+        std::fs::write(src.join("b.rs"), "fn b() {}").expect("write b.rs");
+        std::fs::write(src.join("c.txt"), "ignored").expect("write c.txt");
+
+        let exts = ["rs"];
+        let eager: std::collections::BTreeSet<PathBuf> = enumerate_files(dir.path(), &exts, true)
+            .expect("enumerate_files")
+            .into_iter()
+            .collect();
+        let streamed: std::collections::BTreeSet<PathBuf> =
+            enumerate_files_iter(dir.path(), &exts, true)
+                .expect("enumerate_files_iter")
+                .collect();
+        assert_eq!(
+            eager, streamed,
+            "iter and eager paths must yield the same files"
+        );
+        assert_eq!(eager.len(), 2, "expected 2 .rs files, got {eager:?}");
+    }
+
+    /// #1229 (RM-5): the iterator yields paths *one at a time* — calling
+    /// `.next()` materializes a single PathBuf, not the whole walk. Pins
+    /// the contract by counting yields against an explicit `take(N)`.
+    /// Memory bounding is impractical to assert directly without a
+    /// custom allocator, but this proves the iterator surface accepts
+    /// partial consumption.
+    #[test]
+    fn enumerate_files_iter_supports_partial_consumption() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let src = dir.path().join("src");
+        std::fs::create_dir(&src).expect("mkdir src");
+        for i in 0..50 {
+            std::fs::write(src.join(format!("f{i}.rs")), "fn f() {}").expect("write");
+        }
+        let exts = ["rs"];
+        let mut iter = enumerate_files_iter(dir.path(), &exts, true).expect("iter");
+        // Consume exactly 5 — the rest of the walk should never run.
+        let first_five: Vec<_> = iter.by_ref().take(5).collect();
+        assert_eq!(first_five.len(), 5);
+        // Iterator is still alive and can produce more.
+        assert!(iter.next().is_some(), "iterator must yield more on demand");
+    }
 
     #[test]
     fn test_is_test_chunk_name_patterns() {

--- a/src/store/chunks/staleness.rs
+++ b/src/store/chunks/staleness.rs
@@ -840,6 +840,71 @@ impl<Mode> Store<Mode> {
         })
     }
 
+    /// #1229: batched per-origin fingerprint lookup. Mirror of
+    /// [`indexed_file_origins`] but bounded by the supplied `origins`
+    /// list rather than the full file table — lets `run_daemon_reconcile`
+    /// stream a 1M-file walk in 1k-row batches without materializing the
+    /// whole-tree origin map (`Vec<PathBuf>` + `HashMap<String,
+    /// FileFingerprint>` was ~12 MB transient on a 100k-file repo,
+    /// scaling linearly to ~120 MB on 1M-file).
+    ///
+    /// Same `MAX(...)` deduplication semantics as `indexed_file_origins`:
+    /// if a row briefly carries two mtimes for the same origin during an
+    /// in-flight reindex (RM-17 / #1227), `MAX` picks the newer one and
+    /// dedupes to one entry per origin.
+    ///
+    /// Origins not present in the index are simply absent from the map —
+    /// the caller treats those as `Added` (no stored fingerprint) just as
+    /// `indexed.get(origin)` returning `None` does in the eager path.
+    pub fn fingerprints_for_origins(
+        &self,
+        origins: &[&str],
+    ) -> Result<HashMap<String, FileFingerprint>, StoreError> {
+        let _span =
+            tracing::debug_span!("fingerprints_for_origins", count = origins.len()).entered();
+        if origins.is_empty() {
+            return Ok(HashMap::new());
+        }
+        self.rt.block_on(async {
+            use crate::store::helpers::sql::max_rows_per_statement;
+            // Each origin binds a single placeholder, so the per-row
+            // budget is the parameter limit divided by 1.
+            const BATCH_SIZE: usize = max_rows_per_statement(1);
+            type FpRow = (String, Option<i64>, Option<i64>, Option<Vec<u8>>);
+            let mut out: HashMap<String, FileFingerprint> = HashMap::with_capacity(origins.len());
+            for batch in origins.chunks(BATCH_SIZE) {
+                let placeholders = crate::store::helpers::make_placeholders(batch.len());
+                let sql = format!(
+                    "SELECT origin, \
+                            MAX(source_mtime) AS mtime, \
+                            MAX(source_size) AS size, \
+                            MAX(source_content_hash) AS content_hash \
+                     FROM chunks \
+                     WHERE source_type = 'file' AND origin IN ({}) \
+                     GROUP BY origin",
+                    placeholders
+                );
+                let mut query = sqlx::query_as::<_, FpRow>(&sql);
+                for origin in batch {
+                    query = query.bind(*origin);
+                }
+                for (origin, mtime, size, hash) in query.fetch_all(&self.pool).await? {
+                    let content_hash =
+                        hash.and_then(|bytes| <[u8; 32]>::try_from(bytes.as_slice()).ok());
+                    out.insert(
+                        origin,
+                        FileFingerprint {
+                            mtime,
+                            size: size.and_then(|s| u64::try_from(s).ok()),
+                            content_hash,
+                        },
+                    );
+                }
+            }
+            Ok(out)
+        })
+    }
+
     /// Check if specific origins are stale (mtime changed on disk).
     /// Lightweight per-query check: only examines the given origins, not the
     /// entire index. O(result_count), not O(index_size).


### PR DESCRIPTION
Closes #1229 (RM-5).

## Why

`run_daemon_reconcile` walks the tree on every idle tick (default 30 s). Pre-#1229 it materialized the entire `Vec<PathBuf>` from `enumerate_files` plus the entire `HashMap<String, FileFingerprint>` from `indexed_file_origins` — ~12 MB transient on a 100k-file repo, scaling linearly to ~120 MB on a 1M-file Chromium-class repo. Both allocations live for the duration of the loop body.

This PR replaces the two-fold materialization with a streaming pass sized at `O(batch_size)` regardless of tree size.

## API

- **`cqs::enumerate_files_iter(root, exts, no_ignore)`** returning `impl Iterator<Item = PathBuf>`. Same `.gitignore` / `.cqsignore` / size-cap / hidden-file filters as the eager wrapper, same warn-then-debug log shape on metadata / canonicalize failures. Failure counters live in `Arc<AtomicUsize>` so the per-row closures can each hold their own clone — the walker outlives the call.
- **`cqs::enumerate_files`** becomes a `.collect::<Vec<_>>()` wrapper over `enumerate_files_iter`. Callers that don't need the count or random access (reconcile, future 1k-file streaming queries) consume the iterator directly.
- **`Store::fingerprints_for_origins(origins: &[&str])`** — batched per-origin fingerprint lookup. Same SQL shape as `indexed_file_origins` but with `WHERE origin IN (?, ?, …)` chunked at `max_rows_per_statement(1)` (mirrors the existing `check_origins_stale` pattern).

## Reconcile changes

`run_daemon_reconcile_with_walk` two-mode dispatch:
- **Pre-walked path** (`disk_files: Some(&HashSet<PathBuf>)`) keeps the legacy fully-materialized shape — the caller already paid the cost (idle-tick GC + reconcile share-a-walk).
- **Streaming path** (`disk_files: None`) drives `enumerate_files_iter`, buffers 1000 paths, calls `fingerprints_for_origins(&origins)` for that batch, then runs the same per-file divergence check as before.

A new `process_batch` helper carries the per-file body. Existing `run_daemon_reconcile_*` test fixtures pass against both paths unchanged.

## Tests

Two new unit tests in `src/lib.rs::tests`:
- `enumerate_files_iter_matches_eager_for_small_tree`: pins the contract that `enumerate_files = enumerate_files_iter.collect()`.
- `enumerate_files_iter_supports_partial_consumption`: 50-file synth tree, `.take(5).collect()` then verifies the iterator still yields more — proves single-step materialization without needing a custom allocator.

A 100k-file synth test was scoped out: the relative win at <100k files is small (the current eager path is 50ms / a few MB), and the synthetic tempdir build dominates wall time. The contract under test is the API shape, not the asymptotic memory bound.

## Verification

- `cargo test --features cuda-index --lib` — 2043 tests pass (+2 new).
- `cargo test --features cuda-index --bin cqs reconcile` — 18 reconcile tests pass against the streaming path.
- `cargo clippy --features cuda-index -- -D warnings` clean.
- `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
