### PR TITLE
fix(store): bump SQLite busy_timeout 5s→30s to survive WSL WAL contention

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -143,7 +143,7 @@ impl CachePurpose {
 /// P2.3 (scope=structural): both [`EmbeddingCache::open_with_runtime`] and
 /// [`QueryCache::open_with_runtime`] share ~90 lines of parent-dir prep,
 /// runtime fallback, pool open, schema create, and 0o600 chmod loop with
-/// only `busy_timeout` (5000 vs 2000 ms) and the schema SQL differing.
+/// only `busy_timeout` (30000 vs 15000 ms) and the schema SQL differing.
 ///
 /// A full extraction would yield three private helpers (`prepare_cache_dir_perms`,
 /// `apply_db_file_perms`, `connect_cache_pool(path, busy_ms, runtime, schema_sql)`)
@@ -280,12 +280,16 @@ impl EmbeddingCache {
 
         // Use SqliteConnectOptions to avoid URL-encoding issues with special paths
         // SHL-V1.25-12: honour CQS_BUSY_TIMEOUT_MS like the main Store pool
-        // so the cache doesn't surrender at 5s while the store still waits.
+        // so the cache doesn't surrender while the store still waits.
+        // V1.36.2: default 5000→30000 — long-running `cqs index` runs on WSL
+        // surfaced `(code: 5) database is locked` at the 5s ceiling when WAL
+        // checkpoint pressure raced concurrent reads. 30s gives transient
+        // contention room without making real deadlocks invisible.
         let connect_opts = sqlx::sqlite::SqliteConnectOptions::new()
             .filename(path)
             .create_if_missing(true)
             .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
-            .busy_timeout(busy_timeout_from_env(5000))
+            .busy_timeout(busy_timeout_from_env(30_000))
             .synchronous(sqlx::sqlite::SqliteSynchronous::Normal);
 
         // SEC-V1.33-2: tighten umask to 0o077 around pool creation so the DB
@@ -2435,14 +2439,14 @@ impl QueryCache {
             )
         };
 
-        // SHL-V1.25-12: query cache honours CQS_BUSY_TIMEOUT_MS too. Default
-        // here is 2s because the query cache is write-lighter than the
-        // embedding cache — still tunable by the global env knob.
+        // SHL-V1.25-12: query cache honours CQS_BUSY_TIMEOUT_MS too. V1.36.2:
+        // default 2000→15000 — same WAL-checkpoint contention class as the
+        // embedding cache, halved because the query cache is write-lighter.
         let connect_opts = sqlx::sqlite::SqliteConnectOptions::new()
             .filename(path)
             .create_if_missing(true)
             .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
-            .busy_timeout(busy_timeout_from_env(2000))
+            .busy_timeout(busy_timeout_from_env(15_000))
             .synchronous(sqlx::sqlite::SqliteSynchronous::Normal);
 
         // SEC-V1.33-2: same umask wrap as `EmbeddingCache::open_with_runtime`.

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -50,7 +50,7 @@ use std::sync::{Arc, Mutex, RwLock};
 /// when the transaction commits/rolls back.
 ///
 /// Note: this serializes writes within a single process only. Cross-process
-/// serialization relies on SQLite's busy_timeout (5s) and the index lock file.
+/// serialization relies on SQLite's busy_timeout (30s) and the index lock file.
 static WRITE_LOCK: Mutex<()> = Mutex::new(());
 
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
@@ -934,7 +934,7 @@ fn open_with_config_impl<Mode>(
         .filename(path)
         .foreign_keys(true)
         .journal_mode(SqliteJournalMode::Wal)
-        .busy_timeout(helpers::sql::busy_timeout_from_env(5000))
+        .busy_timeout(helpers::sql::busy_timeout_from_env(30_000))
         // NORMAL synchronous in WAL mode: fsync on checkpoint, not every commit.
         // Trade-off: a crash can lose the last few committed transactions (WAL
         // tail not yet fsynced), but the database remains consistent. Acceptable

--- a/src/store/summary_queue.rs
+++ b/src/store/summary_queue.rs
@@ -9,7 +9,7 @@
 //!
 //! 1. A `cqs index` reindex running in the same process as a streaming
 //!    LLM batch could collide with the per-row implicit-tx writes the
-//!    callback fired. With WAL mode and a 5s `busy_timeout`, either side
+//!    callback fired. With WAL mode and a 30s `busy_timeout`, either side
 //!    could `SQLITE_BUSY` and abort.
 //! 2. Multiple concurrent LLM streams (Haiku + doc-comments + hyde) each
 //!    fired one INSERT-OR-IGNORE per item. sqlx wraps a bare statement in


### PR DESCRIPTION
## Summary

Long-running `cqs index` runs on WSL surfaced `Error: Database error: error returned from database: (code: 5) database is locked` fatal errors *after* the main pipeline reported clean completion. Slow-statement log captured a 4.2s `cache_evict` size query right at the 5s ceiling. Concurrent reads from another `cqs` invocation (e.g. periodic `cqs stats` polling) overlap with the indexer's WAL checkpoint; WSL's 9P/NTFS filesystem stretches the lock-acquisition window past 5s.

SQLite's `busy_timeout` only retries at BEGIN — mid-transaction BUSY isn't recoverable, so a tight ceiling means a multi-minute reindex throws away all work for a transient lock.

## Fix

Bump defaults from 5s → **30s** for the slot store + embedding cache; 2s → **15s** for the query cache (write-lighter). The `CQS_BUSY_TIMEOUT_MS` env override remains the tuning knob.

Three sites:
- `src/store/mod.rs:937` — slot DB pool
- `src/cache.rs:288` — embedding cache pool
- `src/cache.rs:2445` — query cache pool

Plus stale-comment sweep (2s/5s references in `summary_queue` + cache header).

## Why this and not retry-loops

Mid-transaction BUSY can't be retried at the cqs layer — would need to roll back and replay the whole pipeline batch, which is far more invasive. A larger `busy_timeout` is purely defensive; the happy path is unchanged. If 30s isn't enough, the operator can crank `CQS_BUSY_TIMEOUT_MS` higher; if a real deadlock surfaces it'll still trip the timer.

## Test plan

- [x] `cargo build --release --features gpu-index` — green
- [x] `cargo test --features gpu-index --release --lib` — 2048 pass, 0 fail
- [x] `cargo fmt --check` — clean
- [ ] Repro path: re-run the qwen3-4b ceiling probe that crashed three times today; expectation is the long-run survives the WAL-checkpoint contention window that previously surfaced as fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
