### PR TITLE
fix(store): Store::drop checkpoint TRUNCATE → PASSIVE — fixes lock contention

### DIFF
--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1435,19 +1435,40 @@ impl<Mode> Drop for Store<Mode> {
         if self.closed.load(Ordering::Acquire) {
             return; // Already checkpointed in close()
         }
-        // Best-effort WAL checkpoint on drop to avoid leaving large WAL files.
-        // Errors are logged but not propagated (Drop can't fail).
+        // Best-effort WAL checkpoint on drop to bound the WAL.
+        //
+        // V1.36.2: PASSIVE + 1s cap, replacing the prior unbounded TRUNCATE.
+        // The previous TRUNCATE acquired the EXCLUSIVE lock, so a transient
+        // `cqs stats` (or any other read-only Store handle) drop could block
+        // the long-running `cqs index` writer until completion. Under WSL
+        // 9P/NTFS the checkpoint sometimes took long enough that the
+        // indexer's next write hit `(code: 5) database is locked` even
+        // with the 30s busy_timeout — fatal because mid-transaction BUSY
+        // isn't recoverable. PASSIVE bails immediately when active
+        // readers/writers exist (no copy), and the 1s timeout caps every
+        // other case. Operators who want truncate semantics call
+        // [`Store::close`] from the structured-shutdown path before drop.
+        // Mirrors `EmbeddingCache::drop` (#1343 / RM-V1.33-3).
+        //
         // catch_unwind guards against block_on panicking when called from
         // within an async context (e.g., if Store is dropped inside a tokio runtime).
-        // v1.22.0 audit EH-9: previously `let _ =` silently swallowed the
-        // panic payload. Now logs it so the caught panic is visible.
         if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            if let Err(e) = self.rt.block_on(async {
-                sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
-                    .execute(&self.pool)
-                    .await
-            }) {
-                tracing::warn!(error = %e, "WAL checkpoint on drop failed (non-fatal)");
+            let res = self.rt.block_on(async {
+                tokio::time::timeout(
+                    std::time::Duration::from_secs(1),
+                    sqlx::query("PRAGMA wal_checkpoint(PASSIVE)").execute(&self.pool),
+                )
+                .await
+            });
+            match res {
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => tracing::warn!(
+                    error = %e,
+                    "Store WAL checkpoint(PASSIVE) on drop failed (non-fatal)"
+                ),
+                Err(_) => tracing::warn!(
+                    "Store WAL checkpoint(PASSIVE) on drop timed out after 1s (non-fatal)"
+                ),
             }
         })) {
             let msg = crate::panic_message(&payload);


### PR DESCRIPTION
## Summary

Long-running `cqs index` runs were crashing with a fatal `Error: Database error: error returned from database: (code: 5) database is locked` *after* the main pipeline reported clean span closes. Repro on cqs's own qwen3-4b reindex: three back-to-back attempts crashed mid-pipeline, including one with #1450's 5s→30s busy_timeout bump.

## Root cause

`Store::drop` ran `PRAGMA wal_checkpoint(TRUNCATE)` for "best-effort cleanup." TRUNCATE acquires the SQLite **EXCLUSIVE lock** — which means a transient short-lived `cqs stats` invocation (or any read-only Store handle exiting) blocks every other writer until the WAL is fully copied back and zeroed. Under WSL 9P/NTFS that checkpoint sometimes takes seconds; the indexer's next `BEGIN` lands inside that window, sees EXCLUSIVE, and surfaces `SQLITE_BUSY` immediately.

Mid-transaction BUSY isn't recoverable by `busy_timeout` (it only retries at lock acquisition, not at statement-level surfaces) — so the long indexer threw away minutes of work for a transient lock from an unrelated read-only process.

Timestamp correlation that nailed it: observed 6-second gap from a `cqs stats` invocation to the crash, matching the TRUNCATE → EXCLUSIVE acquisition window.

## Fix

Switch `Store::drop` from `wal_checkpoint(TRUNCATE)` to `wal_checkpoint(PASSIVE)` with a 1-second `tokio::time::timeout` cap. PASSIVE never blocks: it checkpoints whatever pages it can without an EXCLUSIVE upgrade, then returns. Operators who want truncate semantics call the explicit `Store::close()` from a structured-shutdown path before drop.

Mirrors the exact pattern `EmbeddingCache::drop` already uses — #1343 / RM-V1.33-3 fixed the same shape of bug there months ago, but the slot store still had the original TRUNCATE.

## Test plan

- [x] `cargo build --release --features gpu-index` — green
- [x] `cargo test --features gpu-index --release --lib store::` — 321 pass, 0 fail
- [x] `cargo fmt --check` — clean
- [ ] Repro: rerun the qwen3-4b reindex with concurrent `cqs stats` polling — expectation is the indexer survives, since `cqs stats`'s drop now exits in ≤1s and never holds EXCLUSIVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
