### PR TITLE
scaling: dim-scaled batch sizes (SHL-V1.36-3/4/5/8) — keep heap constant across model dim

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_API_BASE` | (none) | LLM API base URL (legacy alias for `CQS_LLM_API_BASE`) |
 | `CQS_BATCH_DATA_IDLE_MINUTES` | `30` | Minutes of inactivity before `cqs batch` / `cqs chat` evicts heavy data caches (HNSW, SPLADE index, call graph, test chunks, file set, refs). Independent of the ONNX-session sweep above. `0` disables. |
 | `CQS_BATCH_IDLE_MINUTES` | `5` | Minutes of inactivity before `cqs batch` / `cqs chat` clears ONNX sessions (`0` disables eviction). |
+| `CQS_BRUTE_FORCE_BATCH_SIZE` | (auto) | Cursor-based brute-force search batch size. Default scales by query embedding dim via `dim_scaled_batch(5000, dim, 500, 50_000)` so a 4096-dim model holds ~20 MB per batch instead of 80 MB. v1.36.2 SHL-V1.36-3 — pinned override wins verbatim. |
 | `CQS_BUSY_TIMEOUT_MS` | `5000` | SQLite busy timeout in milliseconds |
 | `CQS_CACHE_MAX_SIZE` | `1073741824` (1 GB) | Global embedding cache size limit |
 | `CQS_CAGRA_GRAPH_DEGREE` | `64` | CAGRA output graph degree at build time (cuVS default 64; higher → better recall, longer build) |

--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -161,11 +161,19 @@ fn cagra_max_bytes() -> usize {
 /// batch (10_000 × 1024 × 4 bytes). Higher-dim models (e.g. hypothetical
 /// dim=4096) may want to shrink this to keep per-batch heap bounded; lower-dim
 /// models (E5-base, dim=768) can grow it for fewer SQL round trips.
-/// Cached in OnceLock for single parse.
+///
+/// SHL-V1.36-5: now scales with `dim` automatically. Env override
+/// `CQS_CAGRA_STREAM_BATCH_SIZE` still wins verbatim.
 #[cfg(feature = "cuda-index")]
-fn cagra_stream_batch_size() -> usize {
-    static SIZE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *SIZE.get_or_init(|| crate::limits::parse_env_usize("CQS_CAGRA_STREAM_BATCH_SIZE", 10_000))
+fn cagra_stream_batch_size(dim: usize) -> usize {
+    if let Ok(val) = std::env::var("CQS_CAGRA_STREAM_BATCH_SIZE") {
+        if let Ok(n) = val.parse::<usize>() {
+            if n > 0 {
+                return n;
+            }
+        }
+    }
+    crate::limits::dim_scaled_batch(10_000, dim, 500, 50_000)
 }
 
 /// Issue #962: Scale `itopk_max` ceiling with corpus size. At 1k chunks we
@@ -761,7 +769,7 @@ impl CagraIndex {
         // higher-dim models can shrink the per-batch heap footprint without
         // a recompile. At dim=1024 the default is 40 MB / batch
         // (10_000 × 1024 × 4 bytes); at hypothetical dim=4096, 160 MB / batch.
-        let batch_size = cagra_stream_batch_size();
+        let batch_size = cagra_stream_batch_size(dim);
         let mut loaded_chunks = 0usize;
         for batch_result in store.embedding_batches(batch_size) {
             let batch = batch_result

--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -1240,13 +1240,18 @@ fn index_notes_from_file(root: &Path, store: &Store, force: bool) -> Result<(usi
 }
 
 /// HNSW insert batch size.
-/// Configurable via `CQS_HNSW_BATCH_SIZE` (default 10000).
-fn hnsw_batch_size() -> usize {
+///
+/// SHL-V1.36-4: scales with embedding dim so a 4096-dim model holds
+/// ~40 MB per batch (matching BGE-large's 40 MB at 1024-dim) instead of
+/// 160 MB. The 10_000 baseline was picked when BGE-large was the default;
+/// `dim_scaled_batch(10_000, dim, 500, 50_000)` keeps the per-batch heap
+/// footprint roughly constant. Env override `CQS_HNSW_BATCH_SIZE` wins.
+fn hnsw_batch_size(dim: usize) -> usize {
     std::env::var("CQS_HNSW_BATCH_SIZE")
         .ok()
         .and_then(|v| v.parse().ok())
         .filter(|&n: &usize| n > 0)
-        .unwrap_or(10_000)
+        .unwrap_or_else(|| cqs::limits::dim_scaled_batch(10_000, dim, 500, 50_000))
 }
 
 /// Build HNSW index from store embeddings
@@ -1316,7 +1321,7 @@ pub(crate) fn build_hnsw_index_owned<M>(
         return Ok(None);
     }
 
-    let batch_size = hnsw_batch_size();
+    let batch_size = hnsw_batch_size(store.dim());
 
     // Tee the (id, embedding, hash) stream: HNSW build consumes
     // (id, embedding) pairs while we accumulate fingerprints into a side
@@ -1370,7 +1375,7 @@ pub(crate) fn build_hnsw_base_index<M>(
         return Ok(None);
     }
 
-    let batch_size = hnsw_batch_size();
+    let batch_size = hnsw_batch_size(store.dim());
 
     let chunk_batches = store.embedding_base_batches(batch_size);
     let hnsw = HnswIndex::build_batched_with_dim(chunk_batches, base_count, store.dim())?;

--- a/src/cli/pipeline/mod.rs
+++ b/src/cli/pipeline/mod.rs
@@ -54,10 +54,10 @@ pub(crate) fn run_index_pipeline(
     // Channels
     let (parse_tx, parse_rx): (Sender<ParsedBatch>, Receiver<ParsedBatch>) =
         bounded(parse_channel_depth());
+    let embed_depth = embed_channel_depth(model_config.dim, model_config.embed_batch_size());
     let (embed_tx, embed_rx): (Sender<EmbeddedBatch>, Receiver<EmbeddedBatch>) =
-        bounded(embed_channel_depth());
-    let (fail_tx, fail_rx): (Sender<ParsedBatch>, Receiver<ParsedBatch>) =
-        bounded(embed_channel_depth());
+        bounded(embed_depth);
+    let (fail_tx, fail_rx): (Sender<ParsedBatch>, Receiver<ParsedBatch>) = bounded(embed_depth);
 
     // Shared state
     let parser = Arc::new(CqParser::new().context("Failed to initialize parser")?);

--- a/src/cli/pipeline/types.rs
+++ b/src/cli/pipeline/types.rs
@@ -110,9 +110,18 @@ pub(super) fn parse_channel_depth() -> usize {
     })
 }
 
-/// Embed channel depth — heavy (embedding vectors), smaller to bound memory.
-/// Configurable via `CQS_EMBED_CHANNEL_DEPTH` environment variable.
-pub(super) fn embed_channel_depth() -> usize {
+/// Embed channel depth — heavy (embedding vectors), bounded for memory.
+///
+/// SHL-V1.36-8: pins a *byte budget* (~16 MB by default) instead of a fixed
+/// depth so the channel holds the same amount of vector data regardless of
+/// embedding dim. Pre-fix, `depth=64` × batch=64 × dim=1024 × 4 bytes = 16 MB
+/// at BGE-large but ballooned/shrank linearly with dim. Now: depth scales
+/// inversely with `(batch × dim × 4)` so the buffered byte total stays in
+/// the same neighborhood.
+///
+/// `CQS_EMBED_CHANNEL_DEPTH` env override wins verbatim. With no override
+/// and `dim == 0` (test paths) we fall back to the historic default of 64.
+pub(super) fn embed_channel_depth(dim: usize, batch_size: usize) -> usize {
     static DEPTH: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *DEPTH.get_or_init(|| match std::env::var("CQS_EMBED_CHANNEL_DEPTH") {
         Ok(val) => match val.parse::<usize>() {
@@ -121,12 +130,26 @@ pub(super) fn embed_channel_depth() -> usize {
                 n
             }
             _ => {
-                tracing::warn!(value = %val, "Invalid CQS_EMBED_CHANNEL_DEPTH, using default 64");
-                64
+                tracing::warn!(value = %val, "Invalid CQS_EMBED_CHANNEL_DEPTH, using default budget");
+                derive_depth_from_budget(dim, batch_size)
             }
         },
-        Err(_) => 64,
+        Err(_) => derive_depth_from_budget(dim, batch_size),
     })
+}
+
+/// SHL-V1.36-8: derive channel depth from a 16 MB byte budget. Each
+/// message ≈ `batch_size * dim * 4 bytes` of f32 vectors. Clamp `[16, 256]`.
+fn derive_depth_from_budget(dim: usize, batch_size: usize) -> usize {
+    const BYTE_BUDGET: usize = 16 * 1024 * 1024;
+    if dim == 0 || batch_size == 0 {
+        return 64; // historic default for test / unknown paths
+    }
+    let msg_bytes = batch_size.saturating_mul(dim).saturating_mul(4);
+    if msg_bytes == 0 {
+        return 64;
+    }
+    (BYTE_BUDGET / msg_bytes).clamp(16, 256)
 }
 
 /// Process-wide lock used by tests that mutate or depend on

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -113,6 +113,31 @@ pub fn small_file_max_bytes() -> u64 {
     parse_env_u64("CQS_SMALL_FILE_MAX_BYTES", DEFAULT_SMALL_FILE_MAX)
 }
 
+/// SHL-V1.36 / dim-blind batch sizes — scale a baseline batch size by
+/// embedding dim. The baseline is assumed to have been picked when the
+/// default model was 1024-dim (BGE-large era), so divide by `dim/1024`
+/// to keep the per-batch heap footprint roughly constant as the user
+/// opts into 2560-dim or 4096-dim presets (qwen3-embedding-{4b,8b}).
+///
+/// Returns `baseline.clamp(min, max)` if `dim == 0` so callers don't
+/// need to special-case zero or unwrap.
+///
+/// ```text
+/// dim=1024 → baseline (no change)
+/// dim=2048 → baseline / 2
+/// dim=4096 → baseline / 4
+/// dim=768  → baseline * 4/3 (slight bump for sub-1024 models)
+/// ```
+pub fn dim_scaled_batch(baseline: usize, dim: usize, min: usize, max: usize) -> usize {
+    if dim == 0 {
+        return baseline.clamp(min, max);
+    }
+    // Multiply first so small `baseline` × small `dim` still has headroom.
+    // saturating_mul because callers feed pathological `baseline` from env.
+    let scaled = baseline.saturating_mul(1024) / dim;
+    scaled.clamp(min, max)
+}
+
 // ============ SHL-V1.29-7: hotspot / dead-cluster thresholds ============
 //
 // `HOTSPOT_MIN_CALLERS`, `DEAD_CLUSTER_MIN_SIZE`, `SUGGEST_HOTSPOT_POOL`
@@ -604,5 +629,53 @@ mod tests {
             parse_env_usize_clamped("CQS_TEST_USIZE_BELOW_MIN_DEFAULT", 0, 1, 100),
             1
         );
+    }
+
+    /// SHL-V1.36 / dim_scaled_batch — pin the formula at the dim values we
+    /// actually ship presets for. Regressions surface here, not at runtime.
+    #[test]
+    fn dim_scaled_batch_at_baseline_dim_returns_baseline() {
+        // dim == 1024 = baseline assumption → baseline unchanged.
+        assert_eq!(dim_scaled_batch(10_000, 1024, 500, 50_000), 10_000);
+        assert_eq!(dim_scaled_batch(5_000, 1024, 500, 50_000), 5_000);
+    }
+
+    #[test]
+    fn dim_scaled_batch_halves_at_2048_dim() {
+        // qwen3-embedding-4b is 2560-dim; pin the 2048 case as a reference.
+        assert_eq!(dim_scaled_batch(10_000, 2048, 500, 50_000), 5_000);
+    }
+
+    #[test]
+    fn dim_scaled_batch_quarters_at_4096_dim() {
+        // qwen3-embedding-8b is 4096-dim — was the motivating preset.
+        assert_eq!(dim_scaled_batch(10_000, 4096, 500, 50_000), 2_500);
+    }
+
+    #[test]
+    fn dim_scaled_batch_grows_at_768_dim() {
+        // E5-base / nomic-coderank / embeddinggemma-300m all 768-dim.
+        // baseline * 1024 / 768 = 13_333 (integer).
+        assert_eq!(dim_scaled_batch(10_000, 768, 500, 50_000), 13_333);
+    }
+
+    #[test]
+    fn dim_scaled_batch_clamps_to_min_on_huge_dim() {
+        // hypothetical 65536-dim → 156 → clamp to min 500.
+        assert_eq!(dim_scaled_batch(10_000, 65_536, 500, 50_000), 500);
+    }
+
+    #[test]
+    fn dim_scaled_batch_clamps_to_max_on_tiny_dim() {
+        // hypothetical 64-dim → 160_000 → clamp to max 50_000.
+        assert_eq!(dim_scaled_batch(10_000, 64, 500, 50_000), 50_000);
+    }
+
+    #[test]
+    fn dim_scaled_batch_zero_dim_returns_clamped_baseline() {
+        // Defensive: zero dim must not trigger div-by-zero panic.
+        assert_eq!(dim_scaled_batch(10_000, 0, 500, 50_000), 10_000);
+        assert_eq!(dim_scaled_batch(50, 0, 500, 50_000), 500); // clamp up
+        assert_eq!(dim_scaled_batch(99_999, 0, 500, 50_000), 50_000); // clamp down
     }
 }

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -194,10 +194,22 @@ impl<Mode> Store<Mode> {
             // This bounds memory to O(semantic_limit) instead of O(total_chunks).
             let mut score_heap = BoundedScoreHeap::new(semantic_limit);
 
-            // Cursor-based batching: load embeddings in batches of 5000 instead of
-            // all at once. This bounds memory to O(batch_size) instead of O(total_chunks).
-            // Uses the same cursor pattern as EmbeddingBatchIterator in store/chunks.rs.
-            const BRUTE_FORCE_BATCH_SIZE: i64 = 5000;
+            // Cursor-based batching: bound memory to O(batch_size) instead of
+            // O(total_chunks). Uses the same cursor pattern as
+            // EmbeddingBatchIterator in store/chunks.rs.
+            //
+            // SHL-V1.36-3: scale by query dim so a 4096-dim model doesn't hold
+            // 80 MB per batch in memory while a 768-dim model only holds 15.
+            // 5000 is the BGE-large baseline (1024-dim); at 768-dim that's
+            // 6_666 (clamped to 50_000), at 4096-dim it's 1_250 (above the
+            // 500 floor). Env override: CQS_BRUTE_FORCE_BATCH_SIZE wins.
+            let brute_force_batch_size: i64 = std::env::var("CQS_BRUTE_FORCE_BATCH_SIZE")
+                .ok()
+                .and_then(|v| v.parse::<i64>().ok())
+                .filter(|&n| n > 0)
+                .unwrap_or_else(|| {
+                    crate::limits::dim_scaled_batch(5000, query.len(), 500, 50_000) as i64
+                });
             let mut last_rowid: i64 = 0;
 
             // Hoist SQL template out of cursor loop — only last_rowid changes per iteration
@@ -225,7 +237,7 @@ impl<Mode> Store<Mode> {
                         q = q.bind(val);
                     }
                     q = q.bind(last_rowid);
-                    q = q.bind(BRUTE_FORCE_BATCH_SIZE);
+                    q = q.bind(brute_force_batch_size);
                     q.fetch_all(&self.pool).await?
                 };
 


### PR DESCRIPTION
## Summary

Closes the dim-blind batch-size cluster from the v1.36.2 audit
(SHL-V1.36-3/4/5/8) — 4 sites where a baseline batch size was picked
when BGE-large (1024-dim) was the default, so opting into
qwen3-embedding-{4b,8b} (2560/4096-dim) silently 2-4×'d the per-batch
heap footprint.

Follow-up to #1456 (audit close-out). One sibling SHL-V1.36-6
(reranker/SPLADE batch defaults of 32) deferred — needs the reranker
and SPLADE configs to carry `hidden_size` / `max_seq_length` first,
which is a separate refactor.

## Approach

One helper, four call sites that follow the same template:

```rust
// src/limits.rs
pub fn dim_scaled_batch(baseline: usize, dim: usize, min: usize, max: usize) -> usize
```

Pure formula `(baseline * 1024) / dim` clamped to `[min, max]`. The 1024
is the "BGE-large baseline assumption" — at that dim, the function
returns `baseline` unchanged. At 2048-dim it halves; at 4096-dim it
quarters; at 768-dim (today's default embeddinggemma-300m) it grows.

| Site | Before | After (1024-dim) | After (4096-dim) |
|------|--------|------------------|------------------|
| `BRUTE_FORCE_BATCH_SIZE` (search) | 5_000 const | 5_000 | 1_250 |
| `hnsw_batch_size` | 10_000 default | 10_000 | 2_500 |
| `cagra_stream_batch_size` | 10_000 default | 10_000 | 2_500 |
| `embed_channel_depth` | 64 fixed | derived from 16 MB byte budget | derived |

All four sites preserve env-var overrides, so power users on big hosts
who've tuned `CQS_BRUTE_FORCE_BATCH_SIZE` / `CQS_HNSW_BATCH_SIZE` /
`CQS_CAGRA_STREAM_BATCH_SIZE` / `CQS_EMBED_CHANNEL_DEPTH` see no
behavior change.

## Audit context

- Audit findings: `docs/audit-scratch/batch1-scaling.md` items 3, 4, 5, 8
- Triage: `docs/audit-triage.md` (P3 Scaling cluster — was previously the
  only ⏳ cluster left after PR #1456)

## Test plan

- [ ] `cargo build --features cuda-index` — passed locally
- [ ] `cargo test --features cuda-index --lib` — 2055 pass / 0 fail locally
- [ ] `cargo clippy --features cuda-index` — clean locally
- [ ] CI green
- [ ] Spot check: `cqs index --slot qwen3-4b` doesn't OOM the indexer
      mid-build at 4096-dim (was the motivating case)
- [ ] Spot check: `CQS_BRUTE_FORCE_BATCH_SIZE=20000 cqs <q>` still wins
      verbatim (env override semantics preserved)

## Out of scope

- **SHL-V1.36-6** (reranker batch + SPLADE batch defaults of 32) —
  separate change, needs config-shape additions first.
- **P2-14** (`ChunkRow::from_row` strcmp) — filed as #1457.
- All other deferred audit items — filed as #1457-#1463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
