### PR TITLE
perf(store): pin ChunkRow SELECT column order + ordinal access (#1457)

### DIFF
--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -32,9 +32,8 @@ impl<Mode> Store<Mode> {
         for batch in ids.chunks(BATCH_SIZE) {
             let placeholders = crate::store::helpers::make_placeholders(batch.len());
             let sql = format!(
-                "SELECT id, origin, language, chunk_type, name, signature, content, doc, line_start, line_end, content_hash, parent_id, parent_type_name, vendored
-                 FROM chunks WHERE id IN ({})",
-                placeholders
+                "SELECT {cols} FROM chunks WHERE id IN ({placeholders})",
+                cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS,
             );
 
             let rows: Vec<_> = {
@@ -131,10 +130,11 @@ impl<Mode> Store<Mode> {
         }
 
         let placeholders = crate::store::helpers::make_placeholders(ids.len());
+        // PERF: pinned columns first so ChunkRow::from_row ordinals stay stable;
+        // `embedding` appended after (read by index 16 below).
         let sql = format!(
-            "SELECT id, origin, language, chunk_type, name, signature, content, doc, line_start, line_end, content_hash, parent_id, parent_type_name, embedding, vendored
-             FROM chunks WHERE id IN ({})",
-            placeholders
+            "SELECT {cols}, embedding FROM chunks WHERE id IN ({placeholders})",
+            cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS,
         );
 
         let rows: Vec<_> = {

--- a/src/store/chunks/query.rs
+++ b/src/store/chunks/query.rs
@@ -152,15 +152,11 @@ impl<Mode> Store<Mode> {
     pub fn get_chunks_by_origin(&self, origin: &str) -> Result<Vec<ChunkSummary>, StoreError> {
         let _span = tracing::debug_span!("get_chunks_by_origin", origin = %origin).entered();
         self.rt.block_on(async {
-            let rows: Vec<_> = sqlx::query(
-                "SELECT id, origin, language, chunk_type, name, signature, content, doc,
-                        line_start, line_end, content_hash, parent_id, parent_type_name
-                 FROM chunks WHERE origin = ?1
-                 ORDER BY line_start",
-            )
-            .bind(origin)
-            .fetch_all(&self.pool)
-            .await?;
+            let sql = format!(
+                "SELECT {cols} FROM chunks WHERE origin = ?1 ORDER BY line_start",
+                cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS,
+            );
+            let rows: Vec<_> = sqlx::query(&sql).bind(origin).fetch_all(&self.pool).await?;
 
             Ok(rows
                 .iter()
@@ -190,11 +186,9 @@ impl<Mode> Store<Mode> {
             for batch in origins.chunks(BATCH_SIZE) {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
                 let sql = format!(
-                    "SELECT id, origin, language, chunk_type, name, signature, content, doc,
-                            line_start, line_end, content_hash, parent_id, parent_type_name
-                     FROM chunks WHERE origin IN ({})
+                    "SELECT {cols} FROM chunks WHERE origin IN ({placeholders}) \
                      ORDER BY origin, line_start",
-                    placeholders
+                    cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS,
                 );
 
                 let mut query = sqlx::query(&sql);
@@ -205,7 +199,8 @@ impl<Mode> Store<Mode> {
                 let rows: Vec<_> = query.fetch_all(&self.pool).await?;
                 for row in &rows {
                     let chunk = ChunkSummary::from(ChunkRow::from_row(row));
-                    let origin_key: String = row.get("origin");
+                    // origin is at ordinal 1 in CHUNK_ROW_SELECT_COLUMNS
+                    let origin_key: String = row.get(1);
                     result.entry(origin_key).or_default().push(chunk);
                 }
             }
@@ -235,11 +230,9 @@ impl<Mode> Store<Mode> {
             for batch in names.chunks(BATCH_SIZE) {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
                 let sql = format!(
-                    "SELECT id, origin, language, chunk_type, name, signature, content, doc,
-                            line_start, line_end, content_hash, parent_id, parent_type_name
-                     FROM chunks WHERE name IN ({})
+                    "SELECT {cols} FROM chunks WHERE name IN ({placeholders}) \
                      ORDER BY origin, line_start",
-                    placeholders
+                    cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS,
                 );
 
                 let rows: Vec<_> = {
@@ -536,21 +529,24 @@ impl<Mode> Store<Mode> {
     ) -> Result<(Vec<ChunkSummary>, i64), StoreError> {
         let _span = tracing::debug_span!("chunks_paged", after_rowid, limit).entered();
         self.rt.block_on(async {
-            let rows: Vec<_> = sqlx::query(
-                "SELECT rowid, id, origin, language, chunk_type, name, signature, content, doc, \
-                 line_start, line_end, content_hash, window_idx, parent_id, parent_type_name \
-                 FROM chunks WHERE rowid > ?1 ORDER BY rowid ASC LIMIT ?2",
-            )
-            .bind(after_rowid)
-            .bind(limit as i64)
-            .fetch_all(&self.pool)
-            .await?;
+            // rowid appended AFTER the pinned ChunkRow columns so the
+            // ordinal contract for `ChunkRow::from_row` (0..15) holds.
+            let sql = format!(
+                "SELECT {cols}, rowid FROM chunks WHERE rowid > ?1 \
+                 ORDER BY rowid ASC LIMIT ?2",
+                cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS,
+            );
+            let rows: Vec<_> = sqlx::query(&sql)
+                .bind(after_rowid)
+                .bind(limit as i64)
+                .fetch_all(&self.pool)
+                .await?;
 
             let mut max_rowid = after_rowid;
             let chunks: Vec<ChunkSummary> = rows
                 .iter()
                 .map(|row| {
-                    let rowid: i64 = row.get("rowid");
+                    let rowid: i64 = row.get(16);
                     if rowid > max_rowid {
                         max_rowid = rowid;
                     }

--- a/src/store/helpers/mod.rs
+++ b/src/store/helpers/mod.rs
@@ -25,7 +25,9 @@ mod types;
 pub use error::StoreError;
 
 // Row types (crate-internal)
-pub(crate) use rows::{CandidateRow, ChunkRow};
+pub(crate) use rows::{
+    CandidateRow, ChunkRow, CHUNK_ROW_SELECT_COLUMNS, CHUNK_ROW_SELECT_COLUMNS_PREFIXED,
+};
 
 // Line number helper (used by rows and other store modules)
 pub use rows::clamp_line_number;

--- a/src/store/helpers/rows.rs
+++ b/src/store/helpers/rows.rs
@@ -1,5 +1,33 @@
 //! Database row types for SQLite result mapping.
 
+/// Pinned SELECT column order for `ChunkRow::from_row` (#1457 / P2-14).
+///
+/// `from_row` reads each column by ordinal, so all SELECT statements that
+/// hydrate `ChunkRow` MUST use this exact column list (or the prefixed
+/// variant below). Mismatched order = wrong columns at runtime, not a
+/// compile error — extend with care.
+///
+/// Indices map 1:1 to the `row.get(N)` calls in `from_row`:
+///   0 id, 1 origin, 2 language, 3 chunk_type, 4 name, 5 signature,
+///   6 content, 7 doc, 8 line_start, 9 line_end, 10 content_hash,
+///   11 window_idx, 12 parent_id, 13 parent_type_name,
+///   14 parser_version, 15 vendored
+///
+/// SELECTs that need additional columns (rowid, embedding, target_type_name)
+/// must append them AFTER the 16 pinned columns so the ChunkRow ordinals
+/// stay stable.
+pub(crate) const CHUNK_ROW_SELECT_COLUMNS: &str =
+    "id, origin, language, chunk_type, name, signature, content, doc, \
+     line_start, line_end, content_hash, window_idx, parent_id, parent_type_name, \
+     parser_version, vendored";
+
+/// `c.`-prefixed variant of [`CHUNK_ROW_SELECT_COLUMNS`] for joins where
+/// `chunks` is aliased as `c`. Same ordinal contract.
+pub(crate) const CHUNK_ROW_SELECT_COLUMNS_PREFIXED: &str =
+    "c.id, c.origin, c.language, c.chunk_type, c.name, c.signature, c.content, c.doc, \
+     c.line_start, c.line_end, c.content_hash, c.window_idx, c.parent_id, c.parent_type_name, \
+     c.parser_version, c.vendored";
+
 /// Clamp i64 to valid u32 line number range (1-indexed)
 ///
 /// SQLite returns i64, but line numbers are u32 and 1-indexed.
@@ -66,36 +94,38 @@ pub(crate) struct ChunkRow {
 }
 
 impl ChunkRow {
-    /// Construct from a SQLite row containing columns:
-    /// id, origin, language, chunk_type, name, signature, content, doc, line_start, line_end, parent_id, parent_type_name
-    /// (parser_version is read via `try_get` so SELECTs that omit it still work).
+    /// Construct from a SQLite row whose SELECT list begins with the pinned
+    /// 16 columns from [`CHUNK_ROW_SELECT_COLUMNS`] (or its prefixed sibling).
+    /// Reads via ordinal access — no column-name strcmp scan per row.
+    ///
+    /// SELECTs may append additional columns (rowid, embedding,
+    /// target_type_name) AFTER ordinal 15; those are read by their named
+    /// callers, not here.
     pub(crate) fn from_row(row: &sqlx::sqlite::SqliteRow) -> Self {
         use sqlx::Row;
         ChunkRow {
-            id: row.get("id"),
-            origin: row.get("origin"),
-            language: row.get("language"),
-            chunk_type: row.get("chunk_type"),
-            name: row.get("name"),
-            signature: row.get("signature"),
-            content: row.get("content"),
-            doc: row.get("doc"),
-            line_start: clamp_line_number(row.get::<i64, _>("line_start")),
-            line_end: clamp_line_number(row.get::<i64, _>("line_end")),
-            content_hash: row.get("content_hash"),
-            window_idx: row.try_get("window_idx").unwrap_or(None),
-            parent_id: row.get("parent_id"),
-            parent_type_name: row.get("parent_type_name"),
-            // try_get so SELECT lists that don't pull parser_version still
-            // construct a valid row — most search/read paths don't need it.
-            parser_version: row
-                .try_get::<i64, _>("parser_version")
-                .map(|v| v.max(0).min(u32::MAX as i64) as u32)
-                .unwrap_or(0),
-            vendored: row
-                .try_get::<i64, _>("vendored")
-                .map(|v| v != 0)
-                .unwrap_or(false),
+            id: row.get(0),
+            origin: row.get(1),
+            language: row.get(2),
+            chunk_type: row.get(3),
+            name: row.get(4),
+            signature: row.get(5),
+            content: row.get(6),
+            doc: row.get(7),
+            line_start: clamp_line_number(row.get::<i64, _>(8)),
+            line_end: clamp_line_number(row.get::<i64, _>(9)),
+            content_hash: row.get(10),
+            window_idx: row.get(11),
+            parent_id: row.get(12),
+            parent_type_name: row.get(13),
+            parser_version: {
+                let v: i64 = row.get(14);
+                v.max(0).min(u32::MAX as i64) as u32
+            },
+            vendored: {
+                let v: i64 = row.get(15);
+                v != 0
+            },
         }
     }
 

--- a/src/store/search.rs
+++ b/src/store/search.rs
@@ -197,13 +197,14 @@ impl<Mode> Store<Mode> {
         // Without that column the `ChunkRow::from_row` `try_get` falls back
         // to false and every vendored chunk masquerades as user-code.
         let sql = format!(
-            "SELECT c.id, c.origin, c.language, c.chunk_type, c.name, c.signature, c.content, c.doc, c.line_start, c.line_end, c.content_hash, c.parent_id, c.parent_type_name, c.vendored
+            "SELECT {cols}
              FROM chunks c
              JOIN chunks_fts f ON c.id = f.id
              WHERE chunks_fts MATCH ?1
-             ORDER BY {}
+             ORDER BY {ord}
              LIMIT ?2",
-            super::helpers::bm25_ordering_expr()
+            cols = super::helpers::CHUNK_ROW_SELECT_COLUMNS_PREFIXED,
+            ord = super::helpers::bm25_ordering_expr(),
         );
 
         self.rt.block_on(async {

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -316,22 +316,23 @@ impl<Mode> Store<Mode> {
         tracing::debug!("querying type users");
 
         self.rt.block_on(async {
-            let rows: Vec<ChunkRow> = sqlx::query(
-                "SELECT DISTINCT c.id, c.origin, c.language, c.chunk_type, c.name,
-                        c.signature, c.content, c.doc, c.line_start, c.line_end, c.content_hash, c.parent_id, c.parent_type_name
-                 FROM type_edges te
-                 JOIN chunks c ON te.source_chunk_id = c.id
-                 WHERE te.target_type_name = ?1
-                 ORDER BY c.origin, c.line_start
+            let sql = format!(
+                "SELECT DISTINCT {cols} \
+                 FROM type_edges te \
+                 JOIN chunks c ON te.source_chunk_id = c.id \
+                 WHERE te.target_type_name = ?1 \
+                 ORDER BY c.origin, c.line_start \
                  LIMIT ?2",
-            )
-            .bind(type_name)
-            .bind(limit_to_sql(limit))
-            .fetch_all(&self.pool)
-            .await?
-            .iter()
-            .map(ChunkRow::from_row)
-            .collect();
+                cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS_PREFIXED,
+            );
+            let rows: Vec<ChunkRow> = sqlx::query(&sql)
+                .bind(type_name)
+                .bind(limit_to_sql(limit))
+                .fetch_all(&self.pool)
+                .await?
+                .iter()
+                .map(ChunkRow::from_row)
+                .collect();
 
             Ok(rows.into_iter().map(ChunkSummary::from).collect())
         })
@@ -398,14 +399,16 @@ impl<Mode> Store<Mode> {
             const BATCH_SIZE: usize = max_rows_per_statement(1);
             for batch in type_names.chunks(BATCH_SIZE) {
                 let placeholders = super::helpers::make_placeholders(batch.len());
+                // target_type_name appended AFTER the pinned ChunkRow columns
+                // so the ordinal contract for `from_row` (0..15) holds; read
+                // by ordinal 16.
                 let sql = format!(
-                    "SELECT te.target_type_name, c.id, c.origin, c.language, c.chunk_type, c.name,
-                            c.signature, c.content, c.doc, c.line_start, c.line_end, c.content_hash, c.parent_id, c.parent_type_name
-                     FROM type_edges te
-                     JOIN chunks c ON te.source_chunk_id = c.id
-                     WHERE te.target_type_name IN ({})
+                    "SELECT {cols}, te.target_type_name \
+                     FROM type_edges te \
+                     JOIN chunks c ON te.source_chunk_id = c.id \
+                     WHERE te.target_type_name IN ({placeholders}) \
                      ORDER BY te.target_type_name, c.origin, c.line_start",
-                    placeholders
+                    cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS_PREFIXED,
                 );
                 let mut q = sqlx::query(&sql);
                 for name in batch {
@@ -414,7 +417,7 @@ impl<Mode> Store<Mode> {
                 let rows: Vec<_> = q.fetch_all(&self.pool).await?;
                 for row in rows {
                     use sqlx::Row;
-                    let type_name: String = row.get("target_type_name");
+                    let type_name: String = row.get(16);
                     let chunk = ChunkSummary::from(ChunkRow::from_row(&row));
                     result.entry(type_name).or_default().push(chunk);
                 }


### PR DESCRIPTION
## Summary

- Pin `ChunkRow` SELECT column order in `CHUNK_ROW_SELECT_COLUMNS` (+ `c.`-prefixed sibling) adjacent to `ChunkRow::from_row` in `src/store/helpers/rows.rs`
- Switch `from_row` from `row.get("name")` strcmp lookups to `row.get(N)` ordinal reads
- Update all **9** production SELECT sites that hydrate `ChunkRow` to use the pinned const

Closes #1457 (P2-14 / PERF-V1.36-3 from the v1.36.2 audit).

## Why

`ChunkRow::from_row` reads ~16 columns by name. SQLite's `column_index_by_name` does a linear strcmp scan over the SELECT's column list — ~16 strcmps per row × 100–500 rows hydrated per query × 50 searches per run = up to 400k strcmps purely for column-name resolution. Ordinal access drops that to zero scans on the hot search-hydration path.

## What changed

| File | Change |
|---|---|
| `src/store/helpers/rows.rs` | New `CHUNK_ROW_SELECT_COLUMNS` + `_PREFIXED` consts; `from_row` switched to ordinal access |
| `src/store/helpers/mod.rs` | Re-export the new consts |
| `src/store/search.rs:200` | `search_by_name` FTS — uses prefixed const |
| `src/store/chunks/async_helpers.rs:35,135` | `fetch_chunks_by_ids_async`, `_with_embeddings_*` — uses const; `embedding` appended after the 16 pinned columns |
| `src/store/chunks/query.rs:155,194,238,540` | `get_chunks_by_origin`, `_batch`, `_by_names_batch`, `chunks_paged` — uses const; `chunks_paged` moved its `rowid` prefix to the end and reads it at ordinal 16 |
| `src/store/types.rs:320,402` | `get_type_users`, `_batch` — uses prefixed const; `target_type_name` appended after, read at ordinal 16 |

The audit's "5 sites" missed `query.rs:238` (batch by names) and `query.rs:540` (chunks_paged with `rowid` prefix). Both updated.

`from_row_lightweight` (single caller, find_test_chunks_async path) and `from_light_chunk` (find_dead_code Phase 2) keep named access — neither is on the hot path and they construct from non-uniform shapes.

## Trade-off

Mismatched SELECT column order produces wrong-column reads at runtime, not a compile error. Mitigation: the pinned const lives **adjacent to `from_row`**, every production SELECT site references the same const, and the doc-comment on the const enumerates the ordinal contract. New SELECT sites that build a `ChunkRow` MUST use the const.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib store::chunks` — 73 pass
- [x] `cargo test --features gpu-index --lib store::search` — 12 pass
- [x] `cargo test --features gpu-index --lib store::types` — 17 pass
- [x] `cargo clippy --features gpu-index --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
