### PR TITLE
refactor(cli, llm): API ergonomics bundle — onboard --direction, BatchProvider builder, --limit defaults (#1459)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -285,8 +285,9 @@ pub(crate) struct GatherArgs {
     /// Expansion direction: both, callers, callees
     #[arg(long, default_value = "both")]
     pub direction: cqs::GatherDirection,
-    /// Max chunks to return
-    #[arg(short = 'n', long, default_value = "10")]
+    /// Max chunks to return.
+    /// API-V1.36-8 (#1459): default harmonised to 5 across the CLI.
+    #[arg(short = 'n', long, default_value = "5")]
     pub limit: usize,
     /// Maximum token budget (overrides --limit with token-based packing)
     #[arg(long, value_parser = parse_nonzero_usize)]
@@ -496,9 +497,14 @@ pub(crate) struct RelatedArgs {
 pub(crate) struct OnboardArgs {
     /// Concept or query to explore
     pub query: String,
-    /// Callee expansion depth — #1373: WALK default.
+    /// Call-chain expansion depth — #1373: WALK default.
     #[arg(short = 'd', long, default_value_t = DEFAULT_DEPTH_WALK)]
     pub depth: usize,
+    /// Expansion direction: both, callers, callees.
+    /// API-V1.36-4 (#1459): default `callees` preserves prior behavior;
+    /// gather/test-map cross-command muscle memory now transfers.
+    #[arg(long, default_value = "callees")]
+    pub direction: cqs::GatherDirection,
     /// Maximum token budget
     #[arg(long, value_parser = parse_nonzero_usize)]
     pub tokens: Option<usize>,
@@ -528,8 +534,9 @@ pub(crate) struct ExplainArgs {
 pub(crate) struct WhereArgs {
     /// Description of the code to add
     pub description: String,
-    /// Max file suggestions
-    #[arg(short = 'n', long, default_value = "3")]
+    /// Max file suggestions.
+    /// API-V1.36-8 (#1459): default harmonised to 5 across the CLI.
+    #[arg(short = 'n', long, default_value = "5")]
     pub limit: usize,
 }
 

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -818,7 +818,8 @@ mod tests {
         match input.cmd {
             BatchCmd::Where { ref args, .. } => {
                 assert_eq!(args.description, "new CLI command");
-                assert_eq!(args.limit, 3); // default
+                // API-V1.36-8 (#1459): --limit defaults harmonised to 5.
+                assert_eq!(args.limit, 5);
             }
             _ => panic!("Expected Where command"),
         }

--- a/src/cli/batch/handlers/info.rs
+++ b/src/cli/batch/handlers/info.rs
@@ -323,10 +323,12 @@ pub(in crate::cli::batch) fn dispatch_onboard(
 ) -> Result<serde_json::Value> {
     let query = args.query.as_str();
     let tokens = args.tokens;
+    let direction = args.direction;
     let _span = tracing::info_span!(
         "batch_onboard",
         query,
         depth = args.depth,
+        ?direction,
         limit = args.limit_arg.limit
     )
     .entered();
@@ -335,7 +337,7 @@ pub(in crate::cli::batch) fn dispatch_onboard(
     // Task A3: cap on call_chain + callers + tests. entry_point always kept.
     let limit = args.limit_arg.limit.clamp(1, 100);
 
-    let mut result = cqs::onboard(&ctx.store(), embedder, query, &ctx.root, depth)?;
+    let mut result = cqs::onboard(&ctx.store(), embedder, query, &ctx.root, depth, direction)?;
     result.call_chain.truncate(limit);
     result.callers.truncate(limit);
     result.tests.truncate(limit);

--- a/src/cli/commands/eval/mod.rs
+++ b/src/cli/commands/eval/mod.rs
@@ -49,6 +49,8 @@ pub(crate) struct EvalCmdArgs {
     ///
     /// API-V1.29-7: `-n` short flag added for parity with every other CLI
     /// command that accepts a result cap (search, gather, related, etc.).
+    /// API-V1.36-8 (#1459): eval is the R@K cap; intentionally larger
+    /// than the harmonised default of 5 used elsewhere.
     #[arg(short = 'n', long, default_value = "20")]
     pub limit: usize,
 

--- a/src/cli/commands/search/onboard.rs
+++ b/src/cli/commands/search/onboard.rs
@@ -9,11 +9,20 @@ pub(crate) fn cmd_onboard(
     ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     concept: &str,
     depth: usize,
+    direction: cqs::GatherDirection,
     limit: usize,
     json: bool,
     max_tokens: Option<usize>,
 ) -> Result<()> {
-    let _span = tracing::info_span!("cmd_onboard", concept, depth, limit, ?max_tokens).entered();
+    let _span = tracing::info_span!(
+        "cmd_onboard",
+        concept,
+        depth,
+        ?direction,
+        limit,
+        ?max_tokens
+    )
+    .entered();
     let store = &ctx.store;
     let root = &ctx.root;
     let embedder = ctx.embedder()?;
@@ -23,7 +32,7 @@ pub(crate) fn cmd_onboard(
     // (relevance → depth) is respected before truncation.
     let limit = limit.clamp(1, 100);
 
-    let mut result = onboard(store, embedder, concept, root, depth)?;
+    let mut result = onboard(store, embedder, concept, root, depth, direction)?;
     result.call_chain.truncate(limit);
     result.callers.truncate(limit);
     result.tests.truncate(limit);

--- a/src/cli/registry.rs
+++ b/src/cli/registry.rs
@@ -458,6 +458,7 @@ macro_rules! for_each_command {
                         &$ctx,
                         &args.query,
                         args.depth,
+                        args.direction,
                         args.limit_arg.limit,
                         $cli.json || output.json,
                         args.tokens,

--- a/src/llm/doc_comments.rs
+++ b/src/llm/doc_comments.rs
@@ -152,11 +152,11 @@ pub fn doc_comment_pass(
     );
 
     let model_name = llm_config.model.clone();
-    let mut client = super::create_client(llm_config)?;
-
-    // LocalProvider: stream per-item persist so Ctrl-C mid-batch doesn't
-    // lose completed work. The Anthropic path's default no-op ignores this.
-    client.set_on_item_complete(store.stream_summary_writer(model_name, "doc-comment".to_string()));
+    // LocalProvider: register per-item streaming-persist callback at
+    // construction so a Ctrl-C mid-batch doesn't lose completed work.
+    // Anthropic's fetch-at-end semantics ignore the callback.
+    let on_item = Some(store.stream_summary_writer(model_name, "doc-comment".to_string()));
+    let client = super::create_client(llm_config, on_item)?;
 
     // Phase 1: Collect candidates
     let mut candidates: Vec<ChunkSummary> = Vec::new();

--- a/src/llm/hyde.rs
+++ b/src/llm/hyde.rs
@@ -29,11 +29,11 @@ pub fn hyde_query_pass(
 
     let hyde_max_tokens = llm_config.hyde_max_tokens;
     let model_name = llm_config.model.clone();
-    let mut client = super::create_client(llm_config)?;
-
-    // LocalProvider: stream per-item persist so Ctrl-C mid-batch doesn't
-    // lose completed work. The Anthropic path's default no-op ignores this.
-    client.set_on_item_complete(store.stream_summary_writer(model_name, "hyde".to_string()));
+    // LocalProvider: register per-item streaming-persist callback at
+    // construction so a Ctrl-C mid-batch doesn't lose completed work.
+    // Anthropic's fetch-at-end semantics ignore the callback.
+    let on_item = Some(store.stream_summary_writer(model_name, "hyde".to_string()));
+    let client = super::create_client(llm_config, on_item)?;
 
     let max_batch_size = crate::limits::llm_max_batch_size();
     let effective_batch_size = if max_hyde > 0 {

--- a/src/llm/local.rs
+++ b/src/llm/local.rs
@@ -26,14 +26,13 @@
 //!
 //! ## Streaming persist
 //!
-//! The optional callback supplied via [`set_on_item_complete`] fires once per
+//! The optional callback supplied via [`LocalProvider::with_on_item_complete`]
+//! (or via the `on_item` arg to [`crate::llm::create_client`]) fires once per
 //! successful item, in arbitrary worker order. The outer loop (e.g.
 //! `llm_summary_pass`) uses this to `INSERT OR IGNORE` each completed summary
 //! into SQLite as soon as it lands, so a Ctrl-C at 50% doesn't lose the first
 //! 50%. The final `fetch_batch_results` pass writes the same rows again; the
 //! primary-key conflict makes the double-write a no-op.
-//!
-//! [`set_on_item_complete`]: super::provider::BatchProvider::set_on_item_complete
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -50,7 +49,7 @@ use super::{local_concurrency, local_timeout, LlmClient, LlmConfig, LlmError};
 const RETRY_BACKOFFS_MS: &[u64] = &[500, 1000, 2000, 4000];
 const MAX_ATTEMPTS: usize = 4;
 
-/// Callback signature: `(custom_id, text)`. See [`BatchProvider::set_on_item_complete`].
+/// Callback signature: `(custom_id, text)`. See [`crate::llm::provider::OnItemCallback`].
 type OnItemCb = Box<dyn Fn(&str, &str) + Send + Sync>;
 
 /// OpenAI-compat `/v1/chat/completions` provider.
@@ -894,13 +893,20 @@ impl BatchProvider for LocalProvider {
     fn model_name(&self) -> &str {
         &self.model
     }
+}
 
-    fn set_on_item_complete(&mut self, cb: Box<dyn Fn(&str, &str) + Send + Sync>) {
-        // EH-V1.33-2 / RB-V1.33-10: tolerate a poisoned mutex (a sibling
-        // worker may have panicked while sharing other LocalProvider mutexes).
-        // Match the rest of this file's `lock().unwrap_or_else(|p| p.into_inner())`
-        // recovery pattern from P1.9 / P2.35 instead of panicking the caller.
+impl LocalProvider {
+    /// Register a per-item streaming-persist callback at construction.
+    ///
+    /// API-V1.36-7 / #1459 sub-7: replaces the prior `&mut self`
+    /// `set_on_item_complete` trait method. Consuming-builder shape
+    /// keeps the trait `&self`-only and avoids the Mutex-everywhere
+    /// caller cost. Internally still uses interior mutability so the
+    /// callback can be invoked concurrently from worker threads.
+    pub fn with_on_item_complete(self, cb: super::provider::OnItemCallback) -> Self {
+        // EH-V1.33-2 / RB-V1.33-10: tolerate a poisoned mutex.
         *self.on_item.lock().unwrap_or_else(|p| p.into_inner()) = Some(cb);
+        self
     }
 }
 
@@ -954,14 +960,15 @@ mod tests {
         });
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
-        let mut provider = LocalProvider::new(config).unwrap();
 
         // Verify the callback fires 3× and matches submission count.
         let count = Arc::new(AtomicUsize::new(0));
         let count_cb = Arc::clone(&count);
-        provider.set_on_item_complete(Box::new(move |_, _| {
-            count_cb.fetch_add(1, Ordering::SeqCst);
-        }));
+        let provider = LocalProvider::new(config)
+            .unwrap()
+            .with_on_item_complete(Box::new(move |_, _| {
+                count_cb.fetch_add(1, Ordering::SeqCst);
+            }));
 
         let items = make_items(3);
         let batch_id = provider
@@ -1000,13 +1007,14 @@ mod tests {
         });
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
-        let mut provider = LocalProvider::new(config).unwrap();
 
         let count = Arc::new(AtomicUsize::new(0));
         let count_cb = Arc::clone(&count);
-        provider.set_on_item_complete(Box::new(move |_, _| {
-            count_cb.fetch_add(1, Ordering::SeqCst);
-        }));
+        let provider = LocalProvider::new(config)
+            .unwrap()
+            .with_on_item_complete(Box::new(move |_, _| {
+                count_cb.fetch_add(1, Ordering::SeqCst);
+            }));
 
         let items = make_items(3);
         let batch_id = provider
@@ -1596,17 +1604,18 @@ mod tests {
         });
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
-        let mut provider = LocalProvider::new(config).unwrap();
 
         let cb_fires = Arc::new(AtomicUsize::new(0));
         let cb_fires_cb = Arc::clone(&cb_fires);
-        provider.set_on_item_complete(Box::new(move |cid, _| {
-            cb_fires_cb.fetch_add(1, Ordering::SeqCst);
-            // Panic on every 2nd item
-            if cid.ends_with("_1") {
-                panic!("intentional panic for test");
-            }
-        }));
+        let provider = LocalProvider::new(config)
+            .unwrap()
+            .with_on_item_complete(Box::new(move |cid, _| {
+                cb_fires_cb.fetch_add(1, Ordering::SeqCst);
+                // Panic on every 2nd item
+                if cid.ends_with("_1") {
+                    panic!("intentional panic for test");
+                }
+            }));
 
         let items = make_items(4);
         let batch_id = provider

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -409,7 +409,10 @@ impl LlmConfig {
 /// and delegates construction to its `build` method. Adding a third
 /// provider is one impl + one slice row — `resolve` and `create_client`
 /// stay untouched.
-pub fn create_client(llm_config: LlmConfig) -> Result<Box<dyn BatchProvider>, LlmError> {
+pub fn create_client(
+    llm_config: LlmConfig,
+    on_item: Option<provider::OnItemCallback>,
+) -> Result<Box<dyn BatchProvider>, LlmError> {
     let _span = tracing::info_span!("create_client", provider = llm_config.provider).entered();
     let registry = PROVIDERS
         .iter()
@@ -424,7 +427,7 @@ pub fn create_client(llm_config: LlmConfig) -> Result<Box<dyn BatchProvider>, Ll
                 message: format!("unknown LLM provider: {}", llm_config.provider),
             }
         })?;
-    registry.build(llm_config)
+    registry.build(llm_config, on_item)
 }
 
 /// Static registry of available LLM providers.
@@ -439,7 +442,14 @@ impl ProviderRegistry for AnthropicRegistry {
     fn name(&self) -> &'static str {
         "anthropic"
     }
-    fn build(&self, cfg: LlmConfig) -> Result<Box<dyn BatchProvider>, LlmError> {
+    fn build(
+        &self,
+        cfg: LlmConfig,
+        _on_item: Option<provider::OnItemCallback>,
+    ) -> Result<Box<dyn BatchProvider>, LlmError> {
+        // Anthropic's Batches API uses fetch-at-end semantics; the per-item
+        // streaming-persist callback only fires for the LocalProvider's
+        // worker-pool fanout. Drop silently here.
         let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
             LlmError::ApiKeyMissing(
                 "ANTHROPIC_API_KEY environment variable required for LLM features".to_string(),
@@ -454,7 +464,11 @@ impl ProviderRegistry for LocalRegistry {
     fn name(&self) -> &'static str {
         "local"
     }
-    fn build(&self, cfg: LlmConfig) -> Result<Box<dyn BatchProvider>, LlmError> {
+    fn build(
+        &self,
+        cfg: LlmConfig,
+        on_item: Option<provider::OnItemCallback>,
+    ) -> Result<Box<dyn BatchProvider>, LlmError> {
         // Local provider needs an explicit endpoint URL and model name —
         // the Anthropic defaults do not apply. Validate here (before any
         // HTTP traffic) so misconfig surfaces with an actionable message.
@@ -476,7 +490,12 @@ impl ProviderRegistry for LocalRegistry {
                 cfg.api_base
             )));
         }
-        Ok(Box::new(local::LocalProvider::new(cfg)?))
+        let provider = local::LocalProvider::new(cfg)?;
+        let provider = match on_item {
+            Some(cb) => provider.with_on_item_complete(cb),
+            None => provider,
+        };
+        Ok(Box::new(provider))
     }
 }
 
@@ -1173,7 +1192,7 @@ mod tests {
 
         let cfg = crate::config::Config::default();
         let llm_config = LlmConfig::resolve(&cfg).unwrap();
-        let err = match create_client(llm_config) {
+        let err = match create_client(llm_config, None) {
             Ok(_) => panic!("should reject missing API_BASE"),
             Err(e) => e,
         };
@@ -1208,7 +1227,7 @@ mod tests {
 
         let cfg = crate::config::Config::default();
         let llm_config = LlmConfig::resolve(&cfg).unwrap();
-        let err = match create_client(llm_config) {
+        let err = match create_client(llm_config, None) {
             Ok(_) => panic!("should reject missing MODEL"),
             Err(e) => e,
         };

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -13,13 +13,30 @@ use super::{LlmConfig, LlmError};
 /// not three coordinated edits.
 pub(crate) trait ProviderRegistry: Sync {
     fn name(&self) -> &'static str;
-    fn build(&self, cfg: LlmConfig) -> Result<Box<dyn BatchProvider>, LlmError>;
+    /// Build a provider from resolved config, optionally registering a
+    /// per-item streaming-persist callback. The Anthropic provider
+    /// ignores the callback (fetch-at-end semantics); the Local provider
+    /// stores it for use during the worker-pool fanout.
+    fn build(
+        &self,
+        cfg: LlmConfig,
+        on_item: Option<OnItemCallback>,
+    ) -> Result<Box<dyn BatchProvider>, LlmError>;
 }
 
 /// Callback type for the per-item streaming persist hook.
 ///
-/// `(custom_id, text)` — see [`BatchProvider::set_on_item_complete`] for the
-/// full concurrency contract.
+/// `(custom_id, text)` — see provider-specific construction APIs (e.g.
+/// [`crate::llm::local::LocalProvider::with_on_item_complete`]) for the
+/// concurrency contract.
+///
+/// **Concurrency contract:** the callback may be invoked from multiple
+/// worker threads concurrently. Implementations must be `Fn + Send + Sync`
+/// and must serialize any shared mutable state internally (typically via
+/// `Mutex<Connection>`). Panics in the callback are caught and logged;
+/// they do not abort the batch. SQLite `INSERT OR IGNORE` on the
+/// `content_hash` primary key gracefully handles redundant writes from
+/// both streaming and `fetch_batch_results` paths.
 pub type OnItemCallback = Box<dyn Fn(&str, &str) + Send + Sync>;
 
 /// A single item in a batch submission.
@@ -153,23 +170,15 @@ pub trait BatchProvider {
         Ok(())
     }
 
-    /// Optional streaming callback invoked once per completed item.
-    ///
-    /// Callers (e.g. `llm_summary_pass`) can set this to persist results
-    /// to SQLite as they arrive, enabling crash-safe partial completion
-    /// without changing the store-all-at-end contract of `fetch_batch_results`.
-    ///
-    /// **Concurrency contract:** the callback may be invoked from multiple
-    /// worker threads concurrently. Implementations must be `Fn + Send + Sync`
-    /// and must serialize any shared mutable state internally (typically via
-    /// `Mutex<Connection>`). Panics in the callback are caught and logged;
-    /// they do not abort the batch. SQLite `INSERT OR IGNORE` on the
-    /// `content_hash` primary key gracefully handles redundant writes from
-    /// both streaming and `fetch_batch_results` paths.
-    ///
-    /// Default: no-op. The Anthropic path uses fetch-at-end semantics and
-    /// ignores the callback.
-    fn set_on_item_complete(&mut self, _cb: OnItemCallback) {}
+    // API-V1.36-7 / #1459 sub-7: the optional streaming per-item callback
+    // is now passed at construction (via [`crate::llm::create_client`]'s
+    // `on_item` arg, or [`LocalProvider::with_on_item_complete`] for direct
+    // construction in tests). Removing it from the trait keeps every method
+    // `&self` and lets callers hold `&dyn BatchProvider` without wrapping in
+    // a `Mutex` just to register the callback.
+    //
+    // The Anthropic provider ignores the callback (fetch-at-end semantics).
+    // The Local provider stores it under interior mutability.
 }
 
 /// Mock batch provider for testing batch orchestration without API calls.

--- a/src/llm/summary.rs
+++ b/src/llm/summary.rs
@@ -39,11 +39,11 @@ pub fn llm_summary_pass(
     // concrete config.
     let max_tokens = llm_config.max_tokens;
     let model_name = llm_config.model.clone();
-    let mut client = super::create_client(llm_config)?;
-
-    // LocalProvider: stream per-item persist so Ctrl-C mid-batch doesn't
-    // lose completed work. The Anthropic path's default no-op ignores this.
-    client.set_on_item_complete(store.stream_summary_writer(model_name, "summary".to_string()));
+    // LocalProvider: register per-item streaming-persist callback at
+    // construction so a Ctrl-C mid-batch doesn't lose completed work.
+    // Anthropic's fetch-at-end semantics ignore the callback.
+    let on_item = Some(store.stream_summary_writer(model_name, "summary".to_string()));
+    let client = super::create_client(llm_config, on_item)?;
 
     // Phase 0: Precompute contrastive neighbors from embedding similarity
     let neighbor_map = match find_contrastive_neighbors(store, 3) {

--- a/src/onboard.rs
+++ b/src/onboard.rs
@@ -122,15 +122,30 @@ pub struct OnboardSummary {
 /// Produce a guided tour of a concept in the codebase.
 ///
 /// Returns an ordered reading list: entry point → callees → callers → types → tests.
+///
+/// `direction` controls which side of the call graph gets the full BFS:
+/// - `Callees` (default): follow what the entry point calls; callers walked at depth 1.
+/// - `Callers`: follow who calls the entry point; callees walked at depth 1.
+/// - `Both`: walk both sides at the requested `depth`.
 pub fn onboard<Mode>(
     store: &Store<Mode>,
     embedder: &Embedder,
     concept: &str,
     root: &Path,
     depth: usize,
+    direction: GatherDirection,
 ) -> Result<OnboardResult, AnalysisError> {
     let _span = tracing::info_span!("onboard", concept).entered();
     let depth = depth.min(10);
+    // Per-side depths derived from the requested direction.
+    // - Callees: full depth on callees, depth=1 on callers (status-quo behavior).
+    // - Callers: depth=1 on callees, full depth on callers.
+    // - Both: full depth on both sides.
+    let (callee_depth, caller_depth) = match direction {
+        GatherDirection::Callees => (depth, 1),
+        GatherDirection::Callers => (1, depth),
+        GatherDirection::Both => (depth, depth),
+    };
 
     // 1. Search for relevant code (direct search, skip full scout overhead)
     let query_embedding = embedder.embed_query(concept)?;
@@ -172,7 +187,7 @@ pub fn onboard<Mode>(
     let mut callee_scores: HashMap<String, (f32, usize)> = HashMap::new();
     callee_scores.insert(entry_name.clone(), (1.0, 0));
     let callee_opts = GatherOptions::default()
-        .with_expand_depth(depth)
+        .with_expand_depth(callee_depth)
         .with_direction(GatherDirection::Callees)
         .with_decay_factor(0.7)
         .with_max_expanded_nodes(100);
@@ -182,11 +197,13 @@ pub fn onboard<Mode>(
     callee_scores.remove(&entry_name);
     tracing::debug!(callee_count = callee_scores.len(), "Callee BFS complete");
 
-    // 5. Caller BFS — who calls the entry point (shallow, 1 level)
+    // 5. Caller BFS — who calls the entry point.
+    // Depth is `caller_depth` (= 1 for direction=Callees back-compat,
+    // = `depth` for Callers / Both).
     let mut caller_scores: HashMap<String, (f32, usize)> = HashMap::new();
     caller_scores.insert(entry_name.clone(), (1.0, 0));
     let caller_opts = GatherOptions::default()
-        .with_expand_depth(1)
+        .with_expand_depth(caller_depth)
         .with_direction(GatherDirection::Callers)
         .with_decay_factor(0.8)
         .with_max_expanded_nodes(50);

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -613,7 +613,9 @@ impl Store<ReadWrite> {
     /// Build a streaming per-item persist callback for the local LLM provider.
     ///
     /// Returns a `Box<dyn Fn(&str, &str) + Send + Sync>` that can be handed to
-    /// [`crate::llm::BatchProvider::set_on_item_complete`]. Each invocation
+    /// [`crate::llm::create_client`] as its `on_item` arg, or to
+    /// [`crate::llm::local::LocalProvider::with_on_item_complete`] for
+    /// direct test-time construction. Each invocation
     /// `cb(custom_id, text)` enqueues one row into the per-Store
     /// `summary_queue`. The queue drains under [`Store::begin_write`] when
     /// either of its thresholds is crossed (rows ≥ N OR elapsed ≥ T), or


### PR DESCRIPTION
## Summary

Three small API parity items from the v1.36.2 P3 audit cluster, bundled. Closes **3 of 8** sub-items in #1459. Per "no external users" project policy, breaking renames without aliases.

### Item 4 — `cqs onboard --direction <both|callers|callees>`

`OnboardArgs` gains a `direction` field defaulting to `callees` (preserves prior behavior). The callee/caller BFS depths now derive from `direction`:

| direction | callee BFS depth | caller BFS depth |
|---|---|---|
| `callees` (default) | requested `depth` | 1 (back-compat) |
| `callers` | 1 | requested `depth` |
| `both` | requested `depth` | requested `depth` |

Unifies the depth+direction pair across `gather`, `onboard`, and `test-map` so cross-command muscle memory transfers.

### Item 7 — `BatchProvider` builder pattern

The audit flagged `set_on_item_complete(&mut self, _)` as forcing callers holding `&dyn BatchProvider` to wrap in a Mutex just to register the per-item streaming-persist callback. Fixed by moving registration to construction:

- `crate::llm::create_client(cfg, on_item: Option<OnItemCallback>)` — production path. Both registries (Anthropic, Local) accept the new arg; Anthropic ignores it (fetch-at-end semantics), Local stores it.
- `LocalProvider::with_on_item_complete(self, cb) -> Self` — consuming-builder for direct construction in tests.

Trait method is gone. Trait surface is now uniformly `&self`.

| File | Change |
|---|---|
| `src/llm/provider.rs` | Drop `set_on_item_complete` trait method; `ProviderRegistry::build` gains `on_item` arg |
| `src/llm/local.rs` | Drop impl method; add `with_on_item_complete` consuming builder; 3 test sites updated to chain it |
| `src/llm/mod.rs` | `create_client` gains `on_item` arg; `LocalRegistry::build` threads through; 2 missed test call sites fixed |
| `src/llm/summary.rs`, `doc_comments.rs`, `hyde.rs` | 3 production sites pass `on_item` to `create_client` instead of post-construction setter |
| `src/store/chunks/crud.rs` | Doc-comment updated to point at the new constructor APIs |

### Item 8 — `--limit` defaults harmonised to 5

| File:line | Before | After |
|---|---|---|
| `src/cli/args.rs:289` (`GatherArgs.limit`) | `"10"` | `"5"` |
| `src/cli/args.rs:532` (`WhereArgs.limit`) | `"3"` | `"5"` |
| `src/cli/commands/eval/mod.rs:52` (`eval --limit`) | `"20"` | `"20"` (kept; inline comment explains it's the R@K cap) |

Per agent's audit: `Neighbors.limit` was already 5; `BlameArgs.commits` and training `--max-files` are not `--limit` flags. No change there.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib llm::local` — 31 pass
- [x] `cargo test --features gpu-index --lib llm::summary` — 12 pass
- [x] `cargo test --features gpu-index --lib onboard` — 6 pass
- [x] `cargo clippy --features gpu-index --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green

## #1459 status after this PR

5 sub-items remain in #1459: (1) `project search` vs top-level `cqs <q>` flag-set parity, (2) `project` vs `ref` registry merge, (3) `index --force` vs `ref update` verb/flag parity, (5) model selection split across 3 commands, (6) `IndexBackend::try_open` 2-of-3-error-variants-never-emitted contract. Each needs a design discussion or is a larger refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
