### PR TITLE
feat(splade): per-slot α tables in slot.toml (#1453)

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -232,6 +232,21 @@ fn run_with_dispatch(
             .apply_env_overrides(),
     );
 
+    // #1453: load per-slot SPLADE α overrides from `slot.toml [splade.alpha]`
+    // and install them on the search router. Done once at dispatch entry so
+    // every search/eval/batch path benefits without per-call I/O.
+    //
+    // Resolution mirrors the slot-model lookup above: pick the active slot
+    // (`--slot` > CQS_SLOT > active_slot file > "default"), read the alpha
+    // table, install. Slot-resolution failure (missing project, malformed
+    // slot.toml) → empty table → router falls through to env / preset /
+    // default precedence as before.
+    let slot_alpha_table = cqs::slot::resolve_slot_name(cli.slot.as_deref(), project_cqs_dir)
+        .ok()
+        .map(|s| cqs::slot::read_slot_splade_alpha_table(project_cqs_dir, &s.name))
+        .unwrap_or_default();
+    cqs::search::router::install_slot_splade_alpha_overrides(slot_alpha_table);
+
     // Clamp limit to prevent usize::MAX wrapping to -1 in SQLite queries
     cli.limit = cli.limit.clamp(1, 100);
 

--- a/src/search/router.rs
+++ b/src/search/router.rs
@@ -478,19 +478,69 @@ static MULTISTEP_PATTERNS_AC: LazyLock<AhoCorasick> = LazyLock::new(|| {
 
 /// Classify a query into a category with confidence level and recommended strategy.
 ///
+/// Per-slot SPLADE α overrides (#1453). Loaded once at CLI/daemon startup
+/// from `.cqs/slots/<active>/slot.toml` `[splade.alpha]` and consulted by
+/// [`resolve_splade_alpha`] between the env precedence and the hardcoded
+/// per-category default.
+///
+/// `RwLock<Option<HashMap>>` so writes are single-shot and reads are
+/// uncontended on the hot search path. The Option distinguishes "never
+/// initialised" (None — no slot context resolved, e.g. early test setup)
+/// from "initialised but empty" (Some(empty) — slot has no `[splade.alpha]`
+/// section, fall through is intended).
+static SLOT_SPLADE_ALPHA: std::sync::RwLock<Option<std::collections::HashMap<String, f32>>> =
+    std::sync::RwLock::new(None);
+
+/// Install the per-slot SPLADE α override table for this process.
+///
+/// Called once by `dispatch::run_with` after the active slot is resolved;
+/// the daemon also calls this at startup. Re-calls overwrite (e.g. a
+/// test resetting state). Production callers expect single-shot.
+///
+/// `table` keys are lowercase category names (matching `QueryCategory`'s
+/// `to_string()`); values are pre-validated to `[0.0, 1.0]` finite by
+/// [`crate::slot::read_slot_splade_alpha_table`].
+pub fn install_slot_splade_alpha_overrides(table: std::collections::HashMap<String, f32>) {
+    match SLOT_SPLADE_ALPHA.write() {
+        Ok(mut g) => {
+            *g = Some(table);
+        }
+        Err(_) => {
+            tracing::warn!(
+                "router slot α RwLock poisoned — leaving slot overrides at previous state"
+            );
+        }
+    }
+}
+
+/// Clear the per-slot SPLADE α overrides. Test-only convenience so unit
+/// tests don't leak across each other; production never needs this
+/// (process-lifetime state is fine).
+#[cfg(test)]
+pub(crate) fn clear_slot_splade_alpha_overrides() {
+    if let Ok(mut g) = SLOT_SPLADE_ALPHA.write() {
+        *g = None;
+    }
+}
+
 /// Resolve the SPLADE fusion alpha for a query category.
 ///
-/// Precedence: per-category env (`CQS_SPLADE_ALPHA_{CATEGORY}`) > global env
-/// (`CQS_SPLADE_ALPHA`) > hardcoded default (1.0 = pure dense, SPLADE off).
+/// Precedence:
+/// 1. Per-category env (`CQS_SPLADE_ALPHA_{CATEGORY}`)
+/// 2. Global env (`CQS_SPLADE_ALPHA`)
+/// 3. Per-slot `slot.toml [splade.alpha].<category>` (#1453, installed via
+///    [`install_slot_splade_alpha_overrides`])
+/// 4. Hardcoded per-category default (`category.default_alpha()`)
 ///
 /// Returns a value in [0.0, 1.0] where 1.0 means pure dense and < 1.0 activates
 /// SPLADE with that fusion weight.
 ///
-/// OB-NEW-1: emits a single structured `tracing::info!` recording the
-/// resolved alpha, its source (`per_cat_env` / `global_env` / `default`),
-/// and the category. Callers no longer need to log the decision themselves;
-/// rooting the log inside this function makes the env-precedence visible and
-/// eliminates the drift that existed between the CLI and batch-handler logs.
+/// OB-NEW-1: emits a single structured `tracing::debug!` recording the
+/// resolved alpha, its source (`per_cat_env` / `global_env` / `slot_toml` /
+/// `default`), and the category. Callers no longer need to log the decision
+/// themselves; rooting the log inside this function makes the precedence
+/// visible and eliminates the drift that existed between the CLI and
+/// batch-handler logs.
 pub fn resolve_splade_alpha(category: &QueryCategory) -> f32 {
     let _span = tracing::debug_span!("resolve_splade_alpha", category = %category).entered();
 
@@ -557,6 +607,29 @@ pub fn resolve_splade_alpha(category: &QueryCategory) -> f32 {
             }
         }
         _ => {}
+    }
+
+    // #1453: per-slot SPLADE α overrides from `slot.toml [splade.alpha]`.
+    // Sits between env vars (operator override) and hardcoded defaults
+    // (model-category guess) so a slot that's been α-tuned for its
+    // embedder doesn't silently inherit values tuned for a different
+    // model. Read-locked — write happens once at CLI/daemon startup.
+    if let Ok(guard) = SLOT_SPLADE_ALPHA.read() {
+        if let Some(table) = guard.as_ref() {
+            let key = category.to_string().to_lowercase();
+            if let Some(&alpha) = table.get(&key) {
+                if alpha.is_finite() {
+                    let alpha = alpha.clamp(0.0, 1.0);
+                    tracing::debug!(
+                        category = %category,
+                        alpha,
+                        source = "slot_toml",
+                        "SPLADE routing"
+                    );
+                    return alpha;
+                }
+            }
+        }
     }
 
     // Per-category defaults from the 21-point alpha sweep on the genuinely
@@ -1672,6 +1745,92 @@ mod tests {
     }
 
     #[test]
+    // ── #1453: per-slot SPLADE α overrides ────────────────────────────────
+
+    /// Slot table installed → that override beats the hardcoded default for
+    /// the matching category.
+    #[test]
+    #[serial_test::serial(splade_alpha_state)]
+    fn slot_splade_alpha_override_wins_over_default() {
+        clear_slot_splade_alpha_overrides();
+        // Clear env so the test doesn't accidentally pick up an outer
+        // `CQS_SPLADE_ALPHA_*` value.
+        std::env::remove_var("CQS_SPLADE_ALPHA");
+        std::env::remove_var(format!(
+            "CQS_SPLADE_ALPHA_{}",
+            QueryCategory::Behavioral.to_string().to_uppercase()
+        ));
+
+        let mut table = std::collections::HashMap::new();
+        // Default for Behavioral is 1.0 (from the gemma sweep). Override to 0.3.
+        table.insert("behavioral".to_string(), 0.3);
+        install_slot_splade_alpha_overrides(table);
+
+        let got = resolve_splade_alpha(&QueryCategory::Behavioral);
+        assert!(
+            (got - 0.3).abs() < f32::EPSILON,
+            "slot α=0.3 must beat default 1.0; got {got}"
+        );
+
+        clear_slot_splade_alpha_overrides();
+    }
+
+    /// Env vars beat slot table — operator override is highest precedence.
+    #[test]
+    #[serial_test::serial(splade_alpha_state)]
+    fn env_splade_alpha_beats_slot_override() {
+        clear_slot_splade_alpha_overrides();
+        let mut table = std::collections::HashMap::new();
+        table.insert("conceptual".to_string(), 0.1);
+        install_slot_splade_alpha_overrides(table);
+
+        // Per-cat env override.
+        std::env::set_var("CQS_SPLADE_ALPHA_CONCEPTUAL", "0.55");
+        let got = resolve_splade_alpha(&QueryCategory::Conceptual);
+        assert!(
+            (got - 0.55).abs() < f32::EPSILON,
+            "per-cat env α=0.55 must beat slot α=0.1; got {got}"
+        );
+
+        std::env::remove_var("CQS_SPLADE_ALPHA_CONCEPTUAL");
+
+        // Global env override.
+        std::env::set_var("CQS_SPLADE_ALPHA", "0.42");
+        let got = resolve_splade_alpha(&QueryCategory::Conceptual);
+        assert!(
+            (got - 0.42).abs() < f32::EPSILON,
+            "global env α=0.42 must beat slot α=0.1; got {got}"
+        );
+        std::env::remove_var("CQS_SPLADE_ALPHA");
+        clear_slot_splade_alpha_overrides();
+    }
+
+    /// Slot table without a key for the category → falls through to the default.
+    #[test]
+    #[serial_test::serial(splade_alpha_state)]
+    fn slot_splade_alpha_partial_table_falls_through_to_default() {
+        clear_slot_splade_alpha_overrides();
+        std::env::remove_var("CQS_SPLADE_ALPHA");
+        std::env::remove_var(format!(
+            "CQS_SPLADE_ALPHA_{}",
+            QueryCategory::Behavioral.to_string().to_uppercase()
+        ));
+
+        let mut table = std::collections::HashMap::new();
+        // Only `unknown` defined; Behavioral falls through.
+        table.insert("unknown".to_string(), 0.3);
+        install_slot_splade_alpha_overrides(table);
+
+        let got = resolve_splade_alpha(&QueryCategory::Behavioral);
+        let default = QueryCategory::Behavioral.default_alpha();
+        assert!(
+            (got - default).abs() < f32::EPSILON,
+            "Behavioral not in slot table → uses default α={default}; got {got}"
+        );
+
+        clear_slot_splade_alpha_overrides();
+    }
+
     fn test_structural_keyword_substring_does_not_fire() {
         // Word-split matching: "MyTraitImpl" as a CamelCase identifier does
         // NOT classify as structural just because it contains "trait".

--- a/src/slot/mod.rs
+++ b/src/slot/mod.rs
@@ -259,6 +259,95 @@ pub fn slot_config_path(project_cqs_dir: &Path, slot_name: &str) -> PathBuf {
     slot_dir(project_cqs_dir, slot_name).join(SLOT_CONFIG_FILE)
 }
 
+/// Read the per-slot SPLADE α overrides from `.cqs/slots/<name>/slot.toml`.
+///
+/// Schema (#1453):
+/// ```toml
+/// [splade.alpha]
+/// behavioral_search = 0.0
+/// conceptual_search = 0.7
+/// # ... per QueryCategory variant ...
+/// ```
+///
+/// Returns an empty map if the file is missing, unreadable, has no
+/// `[splade.alpha]` section, or has only invalid values. Each value is
+/// validated `is_finite()` and clamped to `[0.0, 1.0]` before being
+/// returned; the router falls through to the env/preset/global default
+/// precedence chain for any category not present in the result map.
+///
+/// Bounded read shares the slot.toml budget with `read_slot_model`.
+pub fn read_slot_splade_alpha_table(
+    project_cqs_dir: &Path,
+    slot_name: &str,
+) -> std::collections::HashMap<String, f32> {
+    let cfg = match read_slot_config(project_cqs_dir, slot_name) {
+        Some(c) => c,
+        None => return std::collections::HashMap::new(),
+    };
+    let raw = match cfg.splade {
+        Some(s) => s.alpha,
+        None => return std::collections::HashMap::new(),
+    };
+    raw.into_iter()
+        .filter_map(|(cat, alpha)| {
+            if alpha.is_finite() && (0.0..=1.0).contains(&alpha) {
+                Some((cat.to_lowercase(), alpha))
+            } else {
+                tracing::warn!(
+                    slot = slot_name,
+                    category = %cat,
+                    alpha,
+                    "Slot SPLADE α out of [0.0, 1.0] or non-finite — ignored, \
+                     falling through to env/preset/default precedence"
+                );
+                None
+            }
+        })
+        .collect()
+}
+
+/// Internal helper: read and parse `slot.toml` into the typed
+/// `SlotConfigFile` struct, returning `None` if missing / unreadable /
+/// malformed. Used by the per-section public readers
+/// (`read_slot_model`, `read_slot_splade_alpha_table`).
+fn read_slot_config(project_cqs_dir: &Path, slot_name: &str) -> Option<SlotConfigFile> {
+    let path = slot_config_path(project_cqs_dir, slot_name);
+    let raw = match fs::File::open(&path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "Failed to open slot config; falling back to default resolution"
+            );
+            return None;
+        }
+        Ok(f) => {
+            let mut buf = String::new();
+            if let Err(e) = f.take(SLOT_POINTER_MAX_BYTES).read_to_string(&mut buf) {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "Bounded read of slot config failed; falling back to default resolution"
+                );
+                return None;
+            }
+            buf
+        }
+    };
+    match toml::from_str::<SlotConfigFile>(&raw) {
+        Ok(cfg) => Some(cfg),
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "Slot config is malformed TOML; falling back to default resolution"
+            );
+            None
+        }
+    }
+}
+
 /// Read the embedding model preset/repo persisted in `.cqs/slots/<name>/slot.toml`.
 ///
 /// Schema (#1107):
@@ -444,6 +533,10 @@ pub fn write_slot_model(
 struct SlotConfigFile {
     #[serde(skip_serializing_if = "Option::is_none")]
     embedding: Option<SlotEmbeddingSection>,
+    /// #1453: per-slot SPLADE fusion α overrides. Optional; absence
+    /// means the router uses its env-or-preset-default precedence chain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    splade: Option<SlotSpladeSection>,
     #[serde(default, flatten, skip_serializing_if = "toml::Table::is_empty")]
     extra: toml::Table,
 }
@@ -452,6 +545,33 @@ struct SlotConfigFile {
 struct SlotEmbeddingSection {
     #[serde(skip_serializing_if = "Option::is_none")]
     model: Option<String>,
+}
+
+/// Per-slot SPLADE α overrides (#1453).
+///
+/// Schema:
+/// ```toml
+/// [splade.alpha]
+/// behavioral_search = 0.0
+/// conceptual_search = 0.7
+/// cross_language = 0.85
+/// identifier_lookup = 0.15
+/// multi_step = 0.45
+/// negation = 0.0
+/// structural_search = 0.15
+/// type_filtered = 0.0
+/// unknown = 0.85
+/// ```
+///
+/// Keys are the lowercase form of `QueryCategory::to_string()` (the same
+/// shape `CQS_SPLADE_ALPHA_<CATEGORY>` env vars accept after lowercasing).
+/// Values are clamped to [0.0, 1.0] at read time; non-finite or out-of-range
+/// values are silently skipped (caller falls through to env / preset / global
+/// default precedence).
+#[derive(Default, serde::Deserialize, serde::Serialize)]
+struct SlotSpladeSection {
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    alpha: std::collections::HashMap<String, f32>,
 }
 
 /// Path of `.cqs/active_slot` pointer file.
@@ -1485,5 +1605,136 @@ mod tests {
             slot_config_path(Path::new("/proj/.cqs"), "default"),
             Path::new("/proj/.cqs/slots/default/slot.toml")
         );
+    }
+
+    // ── slot.toml [splade.alpha] read (#1453) ────────────────────────────
+
+    #[test]
+    fn read_slot_splade_alpha_table_returns_empty_when_missing() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        fs::create_dir_all(slot_dir(&cqs, "default")).unwrap();
+        let table = read_slot_splade_alpha_table(&cqs, "default");
+        assert!(table.is_empty(), "missing slot.toml → empty table");
+    }
+
+    #[test]
+    fn read_slot_splade_alpha_table_returns_empty_when_no_splade_section() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        fs::create_dir_all(slot_dir(&cqs, "default")).unwrap();
+        // slot.toml exists but only has [embedding], no [splade.alpha]
+        write_slot_model(&cqs, "default", "bge-large").unwrap();
+        let table = read_slot_splade_alpha_table(&cqs, "default");
+        assert!(table.is_empty(), "no [splade.alpha] section → empty table");
+    }
+
+    #[test]
+    fn read_slot_splade_alpha_table_parses_typed_section() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        let slot = "tuned";
+        let cfg_path = slot_config_path(&cqs, slot);
+        fs::create_dir_all(cfg_path.parent().unwrap()).unwrap();
+        let initial = "[embedding]\nmodel = \"qwen3-embedding-4b\"\n\n\
+            [splade.alpha]\n\
+            behavioral_search = 0.0\n\
+            conceptual_search = 0.7\n\
+            cross_language = 0.85\n\
+            unknown = 0.85\n";
+        fs::write(&cfg_path, initial).unwrap();
+
+        let table = read_slot_splade_alpha_table(&cqs, slot);
+        assert_eq!(table.get("behavioral_search").copied(), Some(0.0));
+        assert_eq!(table.get("conceptual_search").copied(), Some(0.7));
+        assert_eq!(table.get("cross_language").copied(), Some(0.85));
+        assert_eq!(table.get("unknown").copied(), Some(0.85));
+        assert_eq!(
+            table.len(),
+            4,
+            "exactly the 4 keys in the source toml should resolve"
+        );
+    }
+
+    #[test]
+    fn read_slot_splade_alpha_table_filters_invalid_values() {
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        let slot = "bad-values";
+        let cfg_path = slot_config_path(&cqs, slot);
+        fs::create_dir_all(cfg_path.parent().unwrap()).unwrap();
+        // Mix of valid and out-of-range / nan values; reader must keep the
+        // valid ones and drop the rest with a warn.
+        let initial = "[splade.alpha]\n\
+            behavioral_search = 0.5\n\
+            negation = 1.5\n\
+            structural_search = -0.1\n\
+            unknown = nan\n";
+        fs::write(&cfg_path, initial).unwrap();
+
+        let table = read_slot_splade_alpha_table(&cqs, slot);
+        assert_eq!(table.get("behavioral_search").copied(), Some(0.5));
+        assert!(
+            !table.contains_key("negation"),
+            "1.5 is out of range — dropped"
+        );
+        assert!(
+            !table.contains_key("structural_search"),
+            "-0.1 is out of range — dropped"
+        );
+        assert!(
+            !table.contains_key("unknown"),
+            "NaN is non-finite — dropped"
+        );
+        assert_eq!(table.len(), 1, "only the in-range value survives");
+    }
+
+    #[test]
+    fn read_slot_splade_alpha_table_lowercases_keys() {
+        // Operators may type categories in upper/title case; the router
+        // looks up by lowercase. Reader normalizes so a hand-edited slot.toml
+        // is forgiving about case.
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        let slot = "case-test";
+        let cfg_path = slot_config_path(&cqs, slot);
+        fs::create_dir_all(cfg_path.parent().unwrap()).unwrap();
+        let initial = "[splade.alpha]\n\
+            BEHAVIORAL_SEARCH = 0.3\n\
+            Conceptual_Search = 0.4\n";
+        fs::write(&cfg_path, initial).unwrap();
+
+        let table = read_slot_splade_alpha_table(&cqs, slot);
+        assert_eq!(table.get("behavioral_search").copied(), Some(0.3));
+        assert_eq!(table.get("conceptual_search").copied(), Some(0.4));
+    }
+
+    #[test]
+    fn write_slot_model_preserves_existing_splade_section() {
+        // Round-trip safety: hand-edited [splade.alpha] survives a later
+        // `cqs slot create --model X`-style write_slot_model call. The
+        // catch-all `extra: toml::Table` makes this work without
+        // promoting splade to a typed field of SlotConfigFile — but
+        // since we DID promote it, the typed path needs the same
+        // round-trip guarantee.
+        let dir = TempDir::new().unwrap();
+        let cqs = dir.path().join(".cqs");
+        let slot = "tuned-then-rewritten";
+        let cfg_path = slot_config_path(&cqs, slot);
+        fs::create_dir_all(cfg_path.parent().unwrap()).unwrap();
+        let initial = "[embedding]\nmodel = \"old-model\"\n\n\
+            [splade.alpha]\n\
+            behavioral_search = 0.0\n\
+            conceptual_search = 0.7\n";
+        fs::write(&cfg_path, initial).unwrap();
+
+        write_slot_model(&cqs, slot, "new-model").unwrap();
+
+        // Model swapped:
+        assert_eq!(read_slot_model(&cqs, slot).as_deref(), Some("new-model"));
+        // [splade.alpha] still there:
+        let table = read_slot_splade_alpha_table(&cqs, slot);
+        assert_eq!(table.get("behavioral_search").copied(), Some(0.0));
+        assert_eq!(table.get("conceptual_search").copied(), Some(0.7));
     }
 }


### PR DESCRIPTION
## Summary

Per-slot SPLADE α overrides via `slot.toml [splade.alpha]`. Closes #1453.

## Why

SPLADE per-category α defaults baked into `src/search/router.rs` were tuned for **embeddinggemma-300m** on the v3.v2 fixtures (PROJECT_CONTINUITY.md "Eval baselines"). The Qwen3-Embedding-4B sweep showed **5 of 8 categories diverged by ≥0.4 absolute α** (e.g. `identifier_lookup` 1.00→0.15, `structural_search` 0.60→0.15). Without per-slot overrides, operators ship new embedders handicapped — must use env vars or recompile.

## Schema

```toml
# .cqs/slots/<name>/slot.toml
[embedding]
model = "qwen3-embedding-4b"

[splade.alpha]
behavioral_search = 0.0
conceptual_search = 0.7
cross_language    = 0.85
identifier_lookup = 0.15
multi_step        = 0.45
negation          = 0.0
structural_search = 0.15
type_filtered     = 0.0
unknown           = 0.85
```

Keys are the lowercase form of `QueryCategory::to_string()`. Values are clamped to `[0.0, 1.0]` finite at read time; out-of-range / NaN values are dropped with a `tracing::warn!` and the router falls through to env / default precedence.

## Resolution precedence

`router.rs::resolve_splade_alpha`:

1. `CQS_SPLADE_ALPHA_<CATEGORY>` — per-category env override
2. `CQS_SPLADE_ALPHA` — global env override
3. **NEW**: `slot.toml [splade.alpha].<cat>` — per-slot tuning
4. `category.default_alpha()` — hardcoded gemma-tuned default

## Wiring

| File | Change |
|---|---|
| `src/slot/mod.rs` | Typed `SlotSpladeSection { alpha: HashMap }` on SlotConfigFile (round-trip-safe via the existing typed catch-all). Public `read_slot_splade_alpha_table` reader. Helper `read_slot_config` (used by both readers — DRY refactor). |
| `src/search/router.rs` | `RwLock<Option<HashMap>>` static for active-slot α. `install_slot_splade_alpha_overrides` (pub) for dispatch / daemon startup; `clear_slot_splade_alpha_overrides` (pub(crate), test only). `resolve_splade_alpha` consults the table between env and default. |
| `src/cli/dispatch.rs` | After slot resolution, loads the table and installs on the router. Failures → empty table → router falls through unchanged. |

## Tests

- **5 slot tests**: missing toml; no `[splade.alpha]` section; valid 4-key parse; invalid-value filtering (out-of-range + NaN); case-insensitive key normalisation; `write_slot_model` round-trip preserves an existing `[splade.alpha]`.
- **3 router tests** (with `serial_test::serial(splade_alpha_state)` for cross-test isolation): slot beats default; env beats slot (both per-cat and global); partial table falls through to default for unset categories.

## What's NOT in this PR

Pre-bundling **per-preset defaults** (so `cqs slot create --model qwen3-embedding-4b` inherits a sensible α set automatically) is deferred. That requires committing α tables for each known preset after the per-preset sweep — separate PR. Operators get the override knob now without waiting.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib slot::` — 43 pass (5 new)
- [x] `cargo test --features gpu-index --lib search::router::tests::slot_splade` — 2 pass
- [x] `cargo test --features gpu-index --lib search::router::tests::env_splade` — 1 pass
- [x] `cargo clippy --features gpu-index --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green
- [ ] Smoke test post-merge: hand-edit a slot.toml `[splade.alpha]`, restart daemon, run a search, verify the SPLADE routing log shows `source = "slot_toml"` for the matching category

🤖 Generated with [Claude Code](https://claude.com/claude-code)
