### PR TITLE
refactor(nl): drop legacy env-only NL-gen wrappers (CQ-V1.36-3/5 / #1462)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,8 +228,7 @@ pub use impact::{
     TestMatch, TestSuggestion, TransitiveCaller, TypeImpacted, DEFAULT_MAX_TEST_SEARCH_DEPTH,
 };
 pub use nl::{
-    generate_nl_description, generate_nl_description_with_seq_len,
-    generate_nl_with_call_context_and_summary, generate_nl_with_template,
+    generate_nl_description_with_seq_len, generate_nl_with_call_context_and_summary,
     generate_nl_with_template_and_seq_len, normalize_for_fts, tokenize_identifier, CallContext,
     NlTemplate,
 };

--- a/src/nl/mod.rs
+++ b/src/nl/mod.rs
@@ -142,11 +142,13 @@ pub fn generate_nl_with_call_context_and_summary(
 /// Generate natural language description from chunk metadata.
 ///
 /// Produces text like: "parse config. Takes path parameter. Returns config. Keywords: path, config."
+/// Caller passes the active model's `max_seq_length`; section chunks scale
+/// their content budget with that.
 ///
 /// # Example
 ///
 /// ```
-/// use cqs::generate_nl_description;
+/// use cqs::generate_nl_description_with_seq_len;
 /// use cqs::parser::{Chunk, ChunkType, Language};
 /// use std::path::PathBuf;
 ///
@@ -168,18 +170,17 @@ pub fn generate_nl_with_call_context_and_summary(
 ///     parser_version: 0,
 /// };
 ///
-/// let nl = generate_nl_description(&chunk);
+/// let nl = generate_nl_description_with_seq_len(&chunk, 512);
 /// assert!(nl.contains("parse config"));
 /// assert!(nl.contains("Parse configuration"));
 /// ```
-pub fn generate_nl_description(chunk: &Chunk) -> String {
-    generate_nl_with_template(chunk, NlTemplate::Compact)
-}
-
-/// P2.38: same as [`generate_nl_description`] but takes the active model's
-/// `max_seq_length` so the section-chunk content budget scales with model
-/// capacity. New embedding-pipeline callers should prefer this over the
-/// env-only path.
+///
+/// CQ-V1.36-3/5 (#1462): the legacy 1-arg `generate_nl_description` and
+/// `generate_nl_with_template` that read `CQS_MAX_SEQ_LENGTH` env at the
+/// call site are gone — they were a configurable-models trap that masked
+/// the bug CQ-V1.36-1 closed at the embedding sites. Callers must pass
+/// the active model's `max_seq_length` explicitly so a future caller
+/// can't accidentally re-introduce the drift.
 pub fn generate_nl_description_with_seq_len(chunk: &Chunk, model_max_seq_len: usize) -> String {
     generate_nl_with_template_and_seq_len(chunk, NlTemplate::Compact, model_max_seq_len)
 }
@@ -198,16 +199,6 @@ fn is_enrichment_skipped(layer: &str) -> bool {
             .collect()
     });
     skipped.iter().any(|s| s == layer)
-}
-
-/// P2.38: legacy 1-arg API kept for compatibility — defers to the
-/// `_with_seq_len` variant using the env override (or 512 default).
-pub fn generate_nl_with_template(chunk: &Chunk, template: NlTemplate) -> String {
-    let model_max_seq = std::env::var("CQS_MAX_SEQ_LENGTH")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(512);
-    generate_nl_with_template_and_seq_len(chunk, template, model_max_seq)
 }
 
 /// P2.38: new entry point that takes the active model's `max_seq_length`
@@ -616,7 +607,7 @@ mod tests {
             parser_version: 0,
         };
 
-        let nl = generate_nl_description(&chunk);
+        let nl = generate_nl_description_with_seq_len(&chunk, 512);
         assert!(nl.contains("Load config from path"));
         assert!(nl.contains("parse config"));
         assert!(nl.contains("Takes parameters:"));
@@ -651,7 +642,7 @@ mod tests {
             parser_version: 0,
         };
 
-        let nl = generate_nl_description(&chunk);
+        let nl = generate_nl_description_with_seq_len(&chunk, 512);
         assert!(nl.contains("Validates an email"));
         assert!(nl.contains("validate email"));
         // Params come from signature (no types in JS), return type from JSDoc
@@ -695,7 +686,7 @@ mod tests {
         // 3000 chars of content — should use 1800 char preview
         let content = "a".repeat(3000);
         let chunk = make_section_chunk(&content, "Title > Section", "Section");
-        let nl = generate_nl_description(&chunk);
+        let nl = generate_nl_description_with_seq_len(&chunk, 512);
         // Breadcrumb + name + 1800 chars of content
         assert!(nl.contains("Title > Section"));
         assert!(nl.contains("Section"));
@@ -712,7 +703,7 @@ mod tests {
     #[test]
     fn test_markdown_nl_short_content() {
         let chunk = make_section_chunk("Short section content here.", "Guide > Intro", "Intro");
-        let nl = generate_nl_description(&chunk);
+        let nl = generate_nl_description_with_seq_len(&chunk, 512);
         assert!(nl.contains("Guide > Intro"));
         assert!(nl.contains("Intro"));
         assert!(nl.contains("Short section content here."));
@@ -739,7 +730,7 @@ mod tests {
             parent_type_name: Some("CircuitBreaker".to_string()),
             parser_version: 0,
         };
-        let nl = generate_nl_description(&chunk);
+        let nl = generate_nl_description_with_seq_len(&chunk, 512);
         assert!(
             nl.contains("circuit breaker method"),
             "NL should contain tokenized parent type: {}",
@@ -767,7 +758,7 @@ mod tests {
             parent_type_name: None,
             parser_version: 0,
         };
-        let nl = generate_nl_description(&chunk);
+        let nl = generate_nl_description_with_seq_len(&chunk, 512);
         // Compact: no "A method named" prefix, just tokenized name
         assert!(nl.contains("process"));
         // Without parent_type_name, should not have any "X method" prefix
@@ -797,7 +788,7 @@ mod tests {
             parent_type_name: None,
             parser_version: 0,
         };
-        let nl = generate_nl_description(&chunk);
+        let nl = generate_nl_description_with_seq_len(&chunk, 512);
         assert!(nl.contains("standalone"));
     }
 
@@ -820,7 +811,7 @@ mod tests {
             parent_type_name: Some("CircuitBreaker".to_string()),
             parser_version: 0,
         };
-        let nl = generate_nl_with_template(&chunk, NlTemplate::DocFirst);
+        let nl = generate_nl_with_template_and_seq_len(&chunk, NlTemplate::DocFirst, 512);
         // DocFirst returns early: doc + name only, no parent type context
         assert!(
             !nl.contains("circuit breaker"),
@@ -934,7 +925,7 @@ mod tests {
         let chunk = test_chunk("lonely");
         let ctx = CallContext::default();
         let freq = std::collections::HashMap::new();
-        let base = generate_nl_description(&chunk);
+        let base = generate_nl_description_with_seq_len(&chunk, 512);
         let enriched =
             generate_nl_with_call_context_and_summary(&chunk, &ctx, &freq, 5, 5, None, None, 512);
         assert_eq!(base, enriched);

--- a/tests/eval_test.rs
+++ b/tests/eval_test.rs
@@ -6,7 +6,7 @@
 mod eval_common;
 
 use cqs::embedder::{Embedder, Embedding, ModelConfig};
-use cqs::generate_nl_description;
+use cqs::generate_nl_description_with_seq_len;
 use cqs::parser::{Chunk, ChunkType, Language};
 use cqs::store::{ModelInfo, SearchFilter, Store};
 use eval_common::{fixture_path, EVAL_CASES};
@@ -54,7 +54,11 @@ fn test_recall_at_5() {
 
         for chunk in &chunks {
             // Generate embedding using NL pipeline (same as production)
-            let text = generate_nl_description(chunk);
+            // CQ-V1.36-3 (#1462): legacy 1-arg `generate_nl_description` is
+            // crate-internal; pass the model's max_seq_length explicitly.
+            // 512 matches the BGE-large default; eval correctness is not
+            // affected by the choice (chunks are short fixtures).
+            let text = generate_nl_description_with_seq_len(chunk, 512);
             let embeddings = embedder
                 .embed_documents(&[&text])
                 .expect("Failed to embed chunk");

--- a/tests/model_eval.rs
+++ b/tests/model_eval.rs
@@ -13,7 +13,9 @@
 mod eval_common;
 
 use cqs::parser::{Language, Parser};
-use cqs::{generate_nl_description, generate_nl_with_template, NlTemplate};
+use cqs::{
+    generate_nl_description_with_seq_len, generate_nl_with_template_and_seq_len, NlTemplate,
+};
 use eval_common::{fixture_path, hard_fixture_path, EvalCase, EVAL_CASES, HARD_EVAL_CASES};
 use ndarray::Array2;
 use ort::session::Session;
@@ -422,7 +424,7 @@ fn test_model_comparison() {
         let path = fixture_path(*lang);
         let chunks = parser.parse_file(&path).expect("Failed to parse fixture");
         for chunk in &chunks {
-            let nl = generate_nl_description(chunk);
+            let nl = generate_nl_description_with_seq_len(chunk, 512);
             chunk_descs.push(ChunkDesc {
                 name: chunk.name.clone(),
                 language: *lang,
@@ -620,7 +622,7 @@ fn test_template_comparison() {
         // Generate NL descriptions with this template
         let nl_texts: Vec<String> = chunks
             .iter()
-            .map(|c| generate_nl_with_template(c, *template))
+            .map(|c| generate_nl_with_template_and_seq_len(c, *template, 512))
             .collect();
 
         // Show a sample
@@ -805,7 +807,7 @@ fn test_hard_template_comparison() {
         // Generate NL descriptions with this template
         let nl_texts: Vec<String> = chunks
             .iter()
-            .map(|c| generate_nl_with_template(c, *template))
+            .map(|c| generate_nl_with_template_and_seq_len(c, *template, 512))
             .collect();
 
         if let Some(first) = nl_texts.first() {
@@ -1093,7 +1095,7 @@ fn test_hard_model_comparison() {
             .parse_file(&path)
             .expect("Failed to parse original fixture");
         for chunk in &chunks {
-            let nl = generate_nl_description(chunk);
+            let nl = generate_nl_description_with_seq_len(chunk, 512);
             chunk_descs.push(ChunkDesc {
                 name: chunk.name.clone(),
                 language: *lang,
@@ -1107,7 +1109,7 @@ fn test_hard_model_comparison() {
                 .parse_file(&hard_path)
                 .expect("Failed to parse hard fixture");
             for chunk in &chunks {
-                let nl = generate_nl_description(chunk);
+                let nl = generate_nl_description_with_seq_len(chunk, 512);
                 chunk_descs.push(ChunkDesc {
                     name: chunk.name.clone(),
                     language: *lang,
@@ -1357,7 +1359,7 @@ fn test_hard_reranker_comparison() {
             .parse_file(&path)
             .expect("Failed to parse original fixture");
         for chunk in &chunks {
-            let nl = generate_nl_description(chunk);
+            let nl = generate_nl_description_with_seq_len(chunk, 512);
             chunk_descs.push(ChunkDesc {
                 name: chunk.name.clone(),
                 language: *lang,
@@ -1371,7 +1373,7 @@ fn test_hard_reranker_comparison() {
                 .parse_file(&hard_path)
                 .expect("Failed to parse hard fixture");
             for chunk in &chunks {
-                let nl = generate_nl_description(chunk);
+                let nl = generate_nl_description_with_seq_len(chunk, 512);
                 chunk_descs.push(ChunkDesc {
                     name: chunk.name.clone(),
                     language: *lang,
@@ -1756,7 +1758,7 @@ fn load_fixture_summaries() -> HashMap<String, String> {
 /// Generate enriched NL: prepend summary (if available) to base NL description.
 /// Matches production behavior in `generate_nl_with_call_context_and_summary`.
 fn generate_enriched_nl(chunk: &cqs::parser::Chunk, summary: Option<&str>) -> String {
-    let base_nl = generate_nl_description(chunk);
+    let base_nl = generate_nl_description_with_seq_len(chunk, 512);
     match summary {
         Some(s) if !s.is_empty() => format!("{} {}", s, base_nl),
         _ => base_nl,
@@ -2231,7 +2233,7 @@ fn test_type_aware_embeddings() {
             }
             let parsed = parser.parse_file(&path).expect("Parse failed");
             for chunk in &parsed {
-                let base_nl = generate_nl_description(chunk);
+                let base_nl = generate_nl_description_with_seq_len(chunk, 512);
                 let sig = &chunk.signature;
 
                 // Variant 1: prepend signature
@@ -2477,7 +2479,7 @@ fn test_weight_sweep() {
                     name: chunk.name.clone(),
                     language: *lang,
                     content: chunk.content.clone(),
-                    nl_text: generate_nl_description(chunk),
+                    nl_text: generate_nl_description_with_seq_len(chunk, 512),
                 });
             }
         }

--- a/tests/pipeline_eval.rs
+++ b/tests/pipeline_eval.rs
@@ -15,7 +15,9 @@ use cqs::hnsw::HnswIndex;
 use cqs::parser::{ChunkType, Language, Parser};
 use cqs::store::{ModelInfo, SearchFilter, Store};
 use cqs::VectorIndex;
-use cqs::{generate_nl_description, generate_nl_with_call_context_and_summary, CallContext};
+use cqs::{
+    generate_nl_description_with_seq_len, generate_nl_with_call_context_and_summary, CallContext,
+};
 use eval_common::{fixture_path, hard_fixture_path, EvalCase, HARD_EVAL_CASES, HOLDOUT_EVAL_CASES};
 use std::collections::HashMap;
 use tempfile::TempDir;
@@ -318,7 +320,7 @@ fn test_fixture_eval_296q() {
             eprintln!("    Found {} chunks", chunks.len());
 
             for chunk in &chunks {
-                let text = generate_nl_description(chunk);
+                let text = generate_nl_description_with_seq_len(chunk, 512);
                 let embeddings = embedder
                     .embed_documents(&[&text])
                     .expect("Failed to embed chunk");
@@ -1051,7 +1053,7 @@ fn test_holdout_eval() {
             }
             let chunks = parser.parse_file(&path).expect("Failed to parse fixture");
             for chunk in &chunks {
-                let text = generate_nl_description(chunk);
+                let text = generate_nl_description_with_seq_len(chunk, 512);
                 let embeddings = embedder
                     .embed_documents(&[&text])
                     .expect("Failed to embed chunk");
@@ -1195,7 +1197,7 @@ fn test_noise_eval_143q() {
                 .parse_file_all(&path)
                 .expect("Failed to parse fixture");
             for chunk in &chunks {
-                let text = generate_nl_description(chunk);
+                let text = generate_nl_description_with_seq_len(chunk, 512);
                 let embeddings = embedder
                     .embed_documents(&[&text])
                     .expect("Failed to embed chunk");
@@ -1272,7 +1274,7 @@ fn test_noise_eval_143q() {
                     store.upsert_function_calls(path, &calls).ok();
                 }
                 for chunk in &chunks {
-                    batch_texts.push(generate_nl_description(chunk));
+                    batch_texts.push(generate_nl_description_with_seq_len(chunk, 512));
                     batch_chunks.push(chunk.clone());
                     repo_chunks += 1;
 
@@ -1342,7 +1344,7 @@ fn test_noise_eval_143q() {
             for cs in &chunks {
                 if let Some(summary) = summaries.get(&cs.content_hash) {
                     let chunk: cqs::Chunk = cs.into();
-                    let base_nl = generate_nl_description(&chunk);
+                    let base_nl = generate_nl_description_with_seq_len(&chunk, 512);
                     let nl_with_summary = format!("{} {}", summary, base_nl);
                     let embs = embedder
                         .embed_documents(&[&nl_with_summary])


### PR DESCRIPTION
## Summary

Drops the legacy 1-arg NL-gen wrappers in `src/nl/mod.rs`. Closes **CQ-V1.36-3** and **CQ-V1.36-5** sub-items of #1462. Per "no external users" project policy: no deprecation alias, breaking rename is a clean cut.

```diff
-pub fn generate_nl_description(chunk: &Chunk) -> String { … }
-pub fn generate_nl_with_template(chunk: &Chunk, template: NlTemplate) -> String { … }
```

## Why

Both wrappers read `CQS_MAX_SEQ_LENGTH` env at the call site (default 512). After v1.37.0's **CQ-V1.36-1 fix** threaded `model_max_seq_len` through the production embedding sites end-to-end, leaving these legacy `pub` APIs invited the same drift back: any new caller reaching for `generate_nl_description(chunk)` would silently re-introduce the configurable-models bug at every preset where 512 ≠ the model's actual `max_seq_length` (qwen3-{4b,8b}: 4096-8192; nomic-coderank: 2048).

## What changed

| File | Change |
|---|---|
| `src/nl/mod.rs` | Delete `generate_nl_description` and `generate_nl_with_template`. Update doctest to use `_with_seq_len` directly. |
| `src/lib.rs` | Drop the deleted fns from the `pub use nl::{...}` re-export list. |
| `tests/eval_test.rs`, `tests/pipeline_eval.rs`, `tests/model_eval.rs` | 3 integration test files updated to call `generate_nl_description_with_seq_len(chunk, 512)` / `generate_nl_with_template_and_seq_len(chunk, template, 512)` with an inline comment naming the value (test fixtures are short — 512 is fine). |
| Internal `src/nl/mod.rs::tests` | ~10 sites updated to the explicit-seq-len variant so the lib build is dead-code-clean. |

`generate_nl_description_with_seq_len` and `generate_nl_with_template_and_seq_len` remain `pub`; their doc comments now carry the rationale for the legacy removal so a future maintainer doesn't reintroduce a 1-arg shim.

## Test plan

- [x] `cargo build --features gpu-index` clean (was warning about dead `generate_nl_description` — gone after delete)
- [x] `cargo test --features gpu-index --lib nl::tests` — 22 pass
- [x] `cargo build --features gpu-index --tests` — clean (no breakage in eval_test / pipeline_eval / model_eval)
- [x] `cargo clippy --features gpu-index --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
