### PR TITLE
feat(cli): cqs ref reindex alias (API-V1.36-3 / #1459)

### DIFF
--- a/src/cli/commands/infra/reference.rs
+++ b/src/cli/commands/infra/reference.rs
@@ -71,7 +71,13 @@ pub(crate) enum RefCommand {
         #[command(flatten)]
         output: TextJsonArgs,
     },
-    /// Update a reference index from its source
+    /// Update a reference index from its source.
+    ///
+    /// API-V1.36-3 (#1459): exposed as both `update` and the
+    /// `reindex` visible alias so cross-command muscle memory
+    /// transfers from `cqs index --force` (the project-side
+    /// equivalent verb).
+    #[command(visible_alias = "reindex")]
     Update {
         /// Name of the reference to update
         name: String,


### PR DESCRIPTION
## Summary

`cqs ref update` is now also reachable via `cqs ref reindex`. Closes **API-V1.36-3** sub-item of #1459.

```diff
+    #[command(visible_alias = "reindex")]
     Update {
         /// Name of the reference to update
         name: String,
         ...
     },
```

## Why

Per the v1.36.2 audit API design cluster: project-side re-indexing is `cqs index --force`, but ref refresh uses the unrelated verb `cqs ref update`. Cross-command muscle memory doesn't transfer.

The full unification (parity with project-side `--llm-summaries` / `--improve-docs` / `--hyde-queries` flags) is the deeper fix and stays out of scope; this PR ships the **verb alias** as the cheap-and-correct first step so agents learning the CLI find what they expect at the synonym they reach for.

`visible_alias` puts `[aliases: reindex]` in `cqs ref --help`, matching the precedent set by `cqs refresh [aliases: invalidate]` (P2-V1.30.x).

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib reference` — 29 pass
- [x] `cargo fmt --check` clean
- [ ] Full CI green
- [ ] Smoke post-merge: `cqs ref reindex <name>` runs the same code path as `cqs ref update <name>` (regression-guarded by clap's visible_alias semantics — same Update arm fires)

## #1459 status

Closes 1 more sub-item. Remaining open in #1459:
- (1) `cqs project search` vs top-level `cqs <q>` flag-set parity (medium design)
- (2) `cqs project` vs `cqs ref` registry merge (medium design)
- (5) Model selection split across 3 commands (medium UX)
- (6) `IndexBackend::try_open` 2-of-3-error-variants-never-emitted contract (medium trait redesign)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
