### PR TITLE
sec(serve): concurrent-request cap (SEC-V1.36-9 / #1461)

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_SERVE_GRAPH_MAX_EDGES` | `500000` | Cap on `/api/graph` edges. Clamped to `[1, 10_000_000]`. SEC-3. |
 | `CQS_SERVE_GRAPH_MAX_NODES` | `50000` | Cap on `/api/graph` nodes. Clamped to `[1, 1_000_000]`. SEC-3. |
 | `CQS_SERVE_IDLE_MINUTES` | `30` | Idle-shutdown threshold for `cqs serve`. After this many minutes with no incoming requests, the server exits cleanly so the read-only mmap and tokio runtime release. `0` disables (server runs until killed). #1345 / RM-V1.33-5. |
+| `CQS_SERVE_MAX_CONCURRENT_REQUESTS` | `256` | Outermost cap on concurrent in-flight requests for `cqs serve`. Sits above the per-request 64 KiB body limit so an attacker on `--bind 0.0.0.0` (or `--no-auth`) can't fan out N connections each holding a pre-auth body buffer. Saturation returns `503 Service Unavailable` immediately (no queueing). Clamped `[1, 8192]`. SEC-V1.36-9 / #1461. |
 | `CQS_SLOT` | (unset) | Slot to use for this invocation. Overridden by `--slot` flag, overrides `.cqs/active_slot`. See `cqs slot --help`. |
 | `CQS_CACHE_ENABLED` | `1` | Set `0` to disable the project-scoped embeddings cache for this run (benchmark / debug). Cache lives at `<project>/.cqs/embeddings_cache.db`. |
 | `CQS_CACHE_MAX_BYTES` | (unset) | Soft cap; emits `tracing::warn!` when the embeddings cache DB exceeds this many bytes. Does NOT auto-prune — use `cqs cache prune` / `cqs cache compact`. |

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -436,6 +436,37 @@ pub fn parse_env_duration_secs(key: &str, default_secs: u64) -> std::time::Durat
 /// and the tokio runtime. `0` disables the idle shutdown entirely.
 pub const SERVE_IDLE_MINUTES_DEFAULT: u64 = 30;
 
+// ============ SEC-V1.36-9 cqs serve concurrent-request cap ============
+
+/// Default ceiling on concurrent in-flight requests in `cqs serve`. Sized
+/// for an interactive single-user UI plus a generous buffer for fan-out
+/// from agent tooling. Each request can hold up to a 64 KiB body buffer
+/// pre-auth (RequestBodyLimitLayer) plus per-handler scratch state, so
+/// 256 × 64 KiB = 16 MiB worst-case pre-auth memory ceiling — well below
+/// any sensible memory budget. Bound only by FD limit otherwise.
+pub const SERVE_MAX_CONCURRENT_REQUESTS_DEFAULT: usize = 256;
+
+/// Resolve the in-flight request cap for `cqs serve`.
+///
+/// SEC-V1.36-9 (#1461): the request body limit is per-request; without an
+/// outer cap, an attacker on `--bind 0.0.0.0` (or any LAN/--no-auth bind)
+/// can fan out N concurrent connections, each holding a 64 KiB pre-auth
+/// buffer. Bounded only by FD limit. The cap below sits on the outermost
+/// middleware layer (`enforce_concurrency_cap` in `src/serve/mod.rs`) and
+/// uses `try_acquire` so saturation returns `503 Service Unavailable`
+/// instantly — no queueing, no allocation.
+///
+/// `CQS_SERVE_MAX_CONCURRENT_REQUESTS` overrides per-launch, clamped to
+/// `[1, 8192]`. Tests can drive saturation by setting this to `1`.
+pub fn serve_max_concurrent_requests() -> usize {
+    parse_env_usize_clamped(
+        "CQS_SERVE_MAX_CONCURRENT_REQUESTS",
+        SERVE_MAX_CONCURRENT_REQUESTS_DEFAULT,
+        1,
+        8192,
+    )
+}
+
 /// Resolve the idle-shutdown threshold for `cqs serve` in minutes.
 /// `CQS_SERVE_IDLE_MINUTES=0` disables idle eviction (server runs until
 /// killed). Garbage / missing values fall back to

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -28,7 +28,7 @@ use axum::{
     extract::{Request, State},
     http::{header, StatusCode},
     middleware::{from_fn_with_state, Next},
-    response::Response,
+    response::{IntoResponse, Response},
     routing::get,
     Router,
 };
@@ -286,8 +286,38 @@ async fn touch_idle_clock(State(state): State<AppState>, request: Request, next:
 /// [`AuthMode::Disabled`], the auth layer is omitted — the
 /// [`NoAuthAcknowledgement`] proof token inside that variant
 /// guarantees an explicit opt-in (#1136).
+/// SEC-V1.36-9 (#1461): cap concurrent in-flight requests pre-everything.
+/// `try_acquire` returns immediately — saturation is `503 Service
+/// Unavailable`, never a queued allocation. Sits as the outermost
+/// middleware so it gates EVERY downstream layer (auth, host allowlist,
+/// body limit, compression, trace) — no buffer is allocated, no auth
+/// constant-time compare is run, until the request holds a permit.
+async fn enforce_concurrency_cap(
+    State(sem): State<Arc<tokio::sync::Semaphore>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let permit = match sem.try_acquire() {
+        Ok(p) => p,
+        Err(_) => {
+            tracing::warn!("serve: concurrent-request cap saturated — returning 503 (SEC-V1.36-9)");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Server at concurrency cap; retry shortly",
+            )
+                .into_response();
+        }
+    };
+    let response = next.run(req).await;
+    drop(permit);
+    response
+}
+
 pub(crate) fn build_router(state: AppState, allowed_hosts: AllowedHosts, auth: AuthMode) -> Router {
     let touch_state = state.clone();
+    let conn_sem = Arc::new(tokio::sync::Semaphore::new(
+        crate::limits::serve_max_concurrent_requests(),
+    ));
     let mut app = Router::new()
         .route("/health", get(handlers::health))
         .route("/api/stats", get(handlers::stats))
@@ -374,6 +404,15 @@ pub(crate) fn build_router(state: AppState, allowed_hosts: AllowedHosts, auth: A
                 request_id,
             )
         }))
+        // SEC-V1.36-9 (#1461): outermost middleware. Caps concurrent
+        // in-flight requests so an attacker on `--bind 0.0.0.0` can't
+        // fan out N connections each holding a 64 KiB pre-auth body
+        // buffer (bound only by FD limit otherwise). `try_acquire`
+        // makes saturation return 503 immediately — no queueing, no
+        // allocation past the permit check. Sits OUTSIDE every other
+        // layer (auth, host, body-limit, compression, trace) so the
+        // body buffer is never allocated for over-cap requests.
+        .layer(from_fn_with_state(conn_sem, enforce_concurrency_cap))
 }
 
 /// Build the allowed-`Host` set for DNS-rebinding protection.

--- a/src/serve/tests.rs
+++ b/src/serve/tests.rs
@@ -11,8 +11,8 @@ use axum::{
 use tower::util::ServiceExt;
 
 use super::{
-    allowed_host_set, build_router, now_epoch_secs, wait_for_idle, AllowedHosts, AppState,
-    AuthMode, NoAuthAcknowledgement,
+    allowed_host_set, build_router, enforce_concurrency_cap, now_epoch_secs, wait_for_idle,
+    AllowedHosts, AppState, AuthMode, NoAuthAcknowledgement,
 };
 use crate::embedder::Embedding;
 use crate::parser::{Chunk, ChunkType, Language};
@@ -1920,6 +1920,93 @@ mod auth_tests {
         assert!(
             body.contains("Failed to deserialize query string"),
             "expected serde-style rejection body, got: {body:?}"
+        );
+    }
+
+    // ─── SEC-V1.36-9 concurrent-request cap ────────────────────────────
+    //
+    // Outermost middleware caps in-flight requests so an attacker on
+    // `--bind 0.0.0.0` can't fan out N connections each holding a 64 KiB
+    // pre-auth body buffer. `try_acquire` makes saturation return 503
+    // immediately, never queue.
+
+    /// Saturation: when no permit is available, `enforce_concurrency_cap`
+    /// returns 503 without invoking the downstream service. Drives a tiny
+    /// router with just the cap middleware so the assertion is on the
+    /// middleware itself, not threaded through the production layer stack.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sec_v136_9_concurrency_cap_returns_503_when_saturated() {
+        use axum::middleware::from_fn_with_state;
+        use axum::{routing::get, Router};
+
+        let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(1));
+        // Pre-acquire the only permit so the middleware sees a saturated
+        // semaphore on `try_acquire`.
+        let _held = sem.clone().try_acquire_owned().expect("initial permit");
+
+        let app: Router =
+            Router::new()
+                .route("/", get(|| async { "ok" }))
+                .layer(from_fn_with_state(
+                    std::sync::Arc::clone(&sem),
+                    enforce_concurrency_cap,
+                ));
+
+        let resp = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .expect("oneshot");
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "saturated semaphore must return 503"
+        );
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024)
+            .await
+            .expect("body");
+        let body = std::str::from_utf8(&bytes).unwrap_or("<non-utf8>");
+        assert!(
+            body.contains("concurrency cap"),
+            "503 body should name the cap, got: {body:?}"
+        );
+    }
+
+    /// Pass-through: when a permit is available, requests succeed and the
+    /// permit is released after the response. A second back-to-back request
+    /// should also succeed (permit dropped, semaphore re-permits).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sec_v136_9_concurrency_cap_passes_through_with_permits() {
+        use axum::middleware::from_fn_with_state;
+        use axum::{routing::get, Router};
+
+        let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(1));
+
+        let make_app = || {
+            Router::new()
+                .route("/", get(|| async { "ok" }))
+                .layer(from_fn_with_state(
+                    std::sync::Arc::clone(&sem),
+                    enforce_concurrency_cap,
+                ))
+        };
+
+        // First request: permit acquired, dropped after the response.
+        let resp1 = make_app()
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .expect("oneshot 1");
+        assert_eq!(resp1.status(), StatusCode::OK);
+
+        // Second request: permit available again.
+        let resp2 = make_app()
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .expect("oneshot 2");
+        assert_eq!(
+            resp2.status(),
+            StatusCode::OK,
+            "permit must be released after first request"
         );
     }
 


### PR DESCRIPTION
## Summary

Outermost middleware caps concurrent in-flight requests on `cqs serve`. Closes **SEC-V1.36-9** sub-item of #1461.

```
inbound → enforce_concurrency_cap (NEW)
        → TraceLayer
        → CompressionLayer
        → RequestBodyLimitLayer (64 KiB)
        → host allowlist
        → auth
        → handler
```

`try_acquire` returns immediately. Saturation → `503 Service Unavailable`. No queueing, no allocation past the permit check.

## Why

The existing 64 KiB request body limit is per-request. Without an outer cap, an attacker on `--bind 0.0.0.0` (or any LAN / `--no-auth` bind) can fan out N concurrent connections, each holding a 64 KiB pre-auth body buffer. Bound only by FD limit. The audit's recommendation:

> Cap concurrent inbound connections with a `tokio::sync::Semaphore` outside the body-limit layer.

## Default cap

| Cap | Worst-case pre-auth memory |
|---|---|
| 256 (default) | 256 × 64 KiB = **16 MiB** |
| 8192 (max) | 8192 × 64 KiB = 512 MiB |
| 1 (test min) | 1 × 64 KiB = 64 KiB |

256 is sized for an interactive single-user UI plus generous fan-out from agent tooling.

`CQS_SERVE_MAX_CONCURRENT_REQUESTS` overrides per-launch, clamped to `[1, 8192]`. Tests set `=1` to drive saturation deterministically.

## Files changed

| File | Change |
|---|---|
| `src/limits.rs` | New `serve_max_concurrent_requests()` + `SERVE_MAX_CONCURRENT_REQUESTS_DEFAULT = 256` |
| `src/serve/mod.rs` | `enforce_concurrency_cap` middleware, wired as the outermost layer in `build_router`. Per-launch `Arc<Semaphore>` constructed at router-build time. |
| `src/serve/tests.rs` | 2 new tests in `auth_tests`: saturation → 503; pass-through with available permit, including back-to-back to verify permit-release-on-response |

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib serve::tests::auth_tests::sec_v136_9` — 2 pass
- [x] `cargo clippy --features gpu-index --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green
- [ ] Smoke post-merge: `CQS_SERVE_MAX_CONCURRENT_REQUESTS=1 cqs serve --no-auth --port 0` + concurrent fan-out reproduces the 503

## #1461 status

Closes **SEC-V1.36-9**. Remaining: **SEC-V1.36-10** (daemon socket TOCTOU) is the last open security sub-item; SEC-V1.36-6 already shipped as a regression test in #1469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
