### PR TITLE
feat(cli): drop legacy --rerank bool, --reranker canonical (API-V1.36-9 / #1459)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -83,22 +83,9 @@ pub(crate) enum RerankerMode {
     Onnx,
 }
 
-/// Resolve the effective reranker mode from the `(--reranker, --rerank)`
-/// pair. `--reranker` (explicit enum) wins when set; otherwise `--rerank`
-/// (bool) is mapped to `Onnx`. Both unset → `None`.
-///
-/// Used by `SearchArgs` and `Cli` (top-level search) to keep the bool flag
-/// working for muscle memory / batch scripts while exposing the full enum.
-pub(crate) fn resolve_rerank_mode(
-    explicit: Option<RerankerMode>,
-    rerank_bool: bool,
-) -> RerankerMode {
-    match (explicit, rerank_bool) {
-        (Some(m), _) => m,
-        (None, true) => RerankerMode::Onnx,
-        (None, false) => RerankerMode::None,
-    }
-}
+// API-V1.36-9 (#1459): `resolve_rerank_mode` removed along with the
+// legacy `--rerank` bool. Callers now use
+// `self.reranker.unwrap_or(RerankerMode::None)` directly.
 
 /// Shared `--limit / -n` argument for graph commands that previously had no
 /// per-subcommand limit (callers, callees, deps, impact, test-map, trace,
@@ -183,21 +170,15 @@ pub(crate) struct SearchArgs {
     #[arg(long)]
     pub include_docs: bool,
 
-    /// Re-rank results with cross-encoder (slower, more accurate).
-    ///
-    /// Boolean shorthand for `--reranker onnx`. `--reranker <mode>` (P2-14,
-    /// #1372) is the canonical form; this stays for muscle memory and batch
-    /// scripts. If both are passed, `--reranker` wins.
-    #[arg(long)]
-    pub rerank: bool,
-
-    /// Reranker mode: `none|onnx|llm` (#1372).
+    /// Reranker mode: `none|onnx` (#1372).
     ///
     /// Mirrors `cqs eval --reranker`. `none` is the default; `onnx` runs the
-    /// cross-encoder configured by `[reranker]` / `CQS_RERANKER_MODEL`; `llm`
-    /// is reserved for the production wiring landing in #1220 and currently
-    /// errors with a "not yet implemented" message. Takes precedence over
-    /// the legacy `--rerank` bool when both are passed.
+    /// cross-encoder configured by `[reranker]` / `CQS_RERANKER_MODEL`.
+    ///
+    /// API-V1.36-9 (#1459): the legacy `--rerank` bool was a "two flags for
+    /// one knob" shorthand for `--reranker onnx`. Per "no external users"
+    /// project policy, dropped without an alias — `--reranker onnx` is the
+    /// canonical form.
     #[arg(long = "reranker", value_enum)]
     pub reranker: Option<RerankerMode>,
 
@@ -258,10 +239,10 @@ pub(crate) struct SearchArgs {
 }
 
 impl SearchArgs {
-    /// Effective reranker mode after resolving `(--reranker, --rerank)` (#1372).
-    /// Returns `RerankerMode::None` when neither flag is set.
+    /// Effective reranker mode. Returns `RerankerMode::None` when no flag is set.
+    /// API-V1.36-9 (#1459): legacy `--rerank` bool gone; `--reranker` is canonical.
     pub(crate) fn rerank_mode(&self) -> RerankerMode {
-        resolve_rerank_mode(self.reranker, self.rerank)
+        self.reranker.unwrap_or(RerankerMode::None)
     }
 
     /// `true` if any reranker stage is selected (Onnx or Llm).

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -206,21 +206,14 @@ pub struct Cli {
     #[arg(long)]
     pub include_docs: bool,
 
-    /// Re-rank results with cross-encoder (slower, more accurate).
-    ///
-    /// Boolean shorthand for `--reranker onnx`. `--reranker <mode>` (P2-14,
-    /// #1372) is the canonical form; this stays for muscle memory and batch
-    /// scripts. If both are passed, `--reranker` wins.
-    #[arg(long)]
-    pub rerank: bool,
-
-    /// Reranker mode: `none|onnx|llm` (#1372).
+    /// Reranker mode: `none|onnx` (#1372).
     ///
     /// Mirrors `cqs eval --reranker`. `none` is the default; `onnx` runs the
-    /// cross-encoder configured by `[reranker]` / `CQS_RERANKER_MODEL`; `llm`
-    /// is reserved for the production wiring landing in #1220 and currently
-    /// errors with a "not yet implemented" message. Takes precedence over
-    /// the legacy `--rerank` bool when both are passed.
+    /// cross-encoder configured by `[reranker]` / `CQS_RERANKER_MODEL`.
+    ///
+    /// API-V1.36-9 (#1459): the legacy `--rerank` bool was dropped; per
+    /// "no external users" project policy, breaking renames without
+    /// aliases are clean cuts. `--reranker onnx` is the canonical form.
     #[arg(long = "reranker", value_enum)]
     pub reranker: Option<args::RerankerMode>,
 
@@ -329,10 +322,10 @@ impl Cli {
             .ok_or_else(|| anyhow::anyhow!("ModelConfig not resolved — call resolve_model() first"))
     }
 
-    /// Effective reranker mode after resolving `(--reranker, --rerank)` (#1372).
-    /// Returns `RerankerMode::None` when neither flag is set.
+    /// Effective reranker mode. Returns `RerankerMode::None` when no flag is set.
+    /// API-V1.36-9 (#1459): legacy `--rerank` bool gone; `--reranker` is canonical.
     pub(crate) fn rerank_mode(&self) -> args::RerankerMode {
-        args::resolve_rerank_mode(self.reranker, self.rerank)
+        self.reranker.unwrap_or(args::RerankerMode::None)
     }
 
     /// `true` if any reranker stage is selected (Onnx or Llm).

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -492,34 +492,37 @@ mod tests {
 
     // ===== --rerank / --reranker flag tests =====
 
+    /// API-V1.36-9 (#1459): legacy `--rerank` bool was dropped — clap now
+    /// rejects the spelling outright instead of mapping it to `--reranker
+    /// onnx`. Callers must use the canonical `--reranker onnx`.
     #[test]
-    fn test_cli_rerank_flag() {
-        let cli = Cli::try_parse_from(["cqs", "--rerank", "search query"]).unwrap();
-        assert!(cli.rerank);
-        // #1372: --rerank shorthand resolves to Onnx mode.
-        assert!(cli.rerank_active());
-        assert_eq!(cli.rerank_mode(), super::args::RerankerMode::Onnx);
+    fn test_cli_rerank_bool_rejected_post_api_v136_9() {
+        let result = Cli::try_parse_from(["cqs", "--rerank", "search query"]);
+        assert!(
+            result.is_err(),
+            "--rerank bool should be rejected post-API-V1.36-9; use --reranker onnx"
+        );
     }
 
     #[test]
-    fn test_cli_rerank_default_false() {
+    fn test_cli_rerank_default_none() {
         let cli = Cli::try_parse_from(["cqs", "search query"]).unwrap();
-        assert!(!cli.rerank);
         assert!(!cli.rerank_active());
         assert_eq!(cli.rerank_mode(), super::args::RerankerMode::None);
     }
 
     #[test]
-    fn test_cli_rerank_with_ref() {
-        let cli = Cli::try_parse_from(["cqs", "--rerank", "--ref", "aveva", "query"]).unwrap();
-        assert!(cli.rerank);
+    fn test_cli_reranker_onnx_with_ref() {
+        let cli =
+            Cli::try_parse_from(["cqs", "--reranker", "onnx", "--ref", "aveva", "query"]).unwrap();
+        assert_eq!(cli.rerank_mode(), super::args::RerankerMode::Onnx);
         assert_eq!(cli.ref_name, Some("aveva".to_string()));
     }
 
     #[test]
-    fn test_cli_rerank_with_limit() {
-        let cli = Cli::try_parse_from(["cqs", "--rerank", "-n", "20", "query"]).unwrap();
-        assert!(cli.rerank);
+    fn test_cli_reranker_onnx_with_limit() {
+        let cli = Cli::try_parse_from(["cqs", "--reranker", "onnx", "-n", "20", "query"]).unwrap();
+        assert_eq!(cli.rerank_mode(), super::args::RerankerMode::Onnx);
         assert_eq!(cli.limit, 20);
     }
 
@@ -549,16 +552,16 @@ mod tests {
         assert!(res.is_err(), "--reranker llm should be rejected by clap");
     }
 
-    /// #1372: when both flags are passed, `--reranker` wins (explicit beats
-    /// shorthand). Lets a script with hardcoded `--rerank` opt into Llm
-    /// without having to drop the shorthand.
+    /// API-V1.36-9 (#1459): the previous "both flags passed → --reranker
+    /// wins" coexistence test no longer applies — `--rerank` is gone.
+    /// Pin that the dual-flag form is now a parse-time rejection.
     #[test]
-    fn test_cli_reranker_overrides_rerank() {
-        let cli = Cli::try_parse_from(["cqs", "--rerank", "--reranker", "none", "query"]).unwrap();
-        // `--rerank` raw bool is still set, but resolved mode is None.
-        assert!(cli.rerank);
-        assert_eq!(cli.rerank_mode(), super::args::RerankerMode::None);
-        assert!(!cli.rerank_active());
+    fn test_cli_dual_rerank_flag_rejected_post_api_v136_9() {
+        let result = Cli::try_parse_from(["cqs", "--rerank", "--reranker", "none", "query"]);
+        assert!(
+            result.is_err(),
+            "the legacy dual-flag form `--rerank --reranker` should be rejected"
+        );
     }
 
     /// #1372: invalid `--reranker` value rejected at parse time (clap


### PR DESCRIPTION
## Summary

Removes the legacy `--rerank` bool. Closes **API-V1.36-9** sub-item of #1459. Per "no external users" project policy: breaking renames without aliases are clean cuts.

```diff
-    /// Re-rank results with cross-encoder ...
-    /// Boolean shorthand for `--reranker onnx`. ... If both are passed, `--reranker` wins.
-    #[arg(long)]
-    pub rerank: bool,
```

## Why

The audit flagged `--rerank` (bool) and `--reranker` (enum) as the canonical "two flags for one knob" anti-pattern the project elsewhere flags as agent-confusion. The bool was kept "for muscle memory and batch scripts" but per the project's [no-deprecation-cycles] policy, that argument doesn't apply.

Removed:
- `pub rerank: bool` field on `Cli` (top-level search) and `SearchArgs` (graph-search subcommand)
- `pub(crate) fn resolve_rerank_mode(...)` helper

Both `Cli::rerank_mode()` and `SearchArgs::rerank_mode()` simplify to `self.reranker.unwrap_or(RerankerMode::None)`.

## Surface

| Before | After |
|---|---|
| `cqs --rerank query` | rejected — use `cqs --reranker onnx query` |
| `cqs --rerank --reranker none query` | rejected — use `cqs --reranker none query` |
| `cqs --reranker onnx query` | unchanged |
| `cqs --reranker none query` | unchanged |
| `cqs query` (no flag) | unchanged — `RerankerMode::None` |

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --bin cqs cli::tests::` — 90 pass
- [x] 2 new regression tests pin the parse-time rejection of `--rerank`
- [x] 4 existing tests renamed + rewritten against canonical `--reranker onnx`
- [x] `cargo clippy --features gpu-index --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
