### PR TITLE
test(hnsw): stabilize build_batched flake by spacing seeds

### DIFF
--- a/src/hnsw/build.rs
+++ b/src/hnsw/build.rs
@@ -294,9 +294,12 @@ mod tests {
 
     #[test]
     fn test_build_batched() {
-        // Simulate streaming batches like Store::embedding_batches would provide
+        // Simulate streaming batches like Store::embedding_batches would
+        // provide. Seeds spaced by 1000 so the sin-based embeddings are
+        // genuinely distinct in cosine space — see the rationale on
+        // `test_build_batched_vs_regular_equivalence`.
         let all_embeddings: Vec<(String, Embedding)> = (1..=25)
-            .map(|i| (format!("chunk{}", i), make_embedding(i)))
+            .map(|i| (format!("chunk{}", i), make_embedding(i * 1000)))
             .collect();
 
         // Split into batches of 10 (simulating LIMIT/OFFSET pagination)
@@ -311,14 +314,10 @@ mod tests {
                 .unwrap();
         assert_eq!(index.len(), 25);
 
-        // Wiring check: top-N from N. The test exists to verify the batched
-        // build round-trips every chunk into a searchable graph, not to pin
-        // recall — `make_test_embedding`'s adjacent-seed vectors are very
-        // close in cosine space, and the small-tier defaults from #1370
-        // (M=16, ef_c=100, ef_s=50 for <5k chunks, dropped from M=24/ef_c=200
-        // /ef_s=100) flake on top-K windows smaller than N. Issue #1104
-        // and the post-#1425 main-CI flake both surface as exactly that.
-        let query = make_embedding(1);
+        // Wiring check: query the seed directly — nearest neighbour must
+        // be itself. With spaced seeds the small-tier graph reliably
+        // returns the queried point in top-K=N.
+        let query = make_embedding(1 * 1000);
         let results = index.search(&query, 25);
         assert!(!results.is_empty());
         assert!(
@@ -339,9 +338,20 @@ mod tests {
 
     #[test]
     fn test_build_batched_vs_regular_equivalence() {
-        // Build same index both ways, verify similar search results
+        // Build same index both ways, verify similar search results.
+        //
+        // Seeds spaced by 1000 so the sin-based embeddings are genuinely
+        // distinct in cosine space — adjacent seeds (1..=20) produced
+        // near-collinear vectors that flaked on the small-tier HNSW
+        // defaults (post-#1425: M=16, ef_c=100, ef_s=50 for <5k chunks).
+        // The widened top-N=N window from #1431 wasn't enough; sin'(0.1)
+        // ≈ sin(0.2) and HNSW's approximate graph dropped one of them
+        // out of recall non-deterministically. Spaced seeds drop
+        // sin(100), sin(200), ... — uniformly distributed in [-1, 1] —
+        // so recall@N is deterministic.
+        let item_id = |i: u32| format!("item{}", i);
         let embeddings: Vec<(String, Embedding)> = (1..=20)
-            .map(|i| (format!("item{}", i), make_embedding(i)))
+            .map(|i| (item_id(i), make_embedding(i * 1000)))
             .collect();
 
         let regular = HnswIndex::build_with_dim(embeddings.clone(), crate::EMBEDDING_DIM).unwrap();
@@ -356,12 +366,9 @@ mod tests {
 
         assert_eq!(regular.len(), batched.len());
 
-        // Both should find item10. Top-N from N — see the rationale in
-        // `test_build_batched`: post-#1425 small-tier defaults plus the
-        // adjacent-seed clustering of `make_test_embedding` make any
-        // partial-K window flaky on N=20. Wiring + parity is what we
-        // care about here, not recall.
-        let query = make_embedding(10);
+        // Both should find item10 — query embedding matches its seed
+        // exactly, so the nearest neighbour is itself.
+        let query = make_embedding(10 * 1000);
         let regular_results = regular.search(&query, 20);
         let batched_results = batched.search(&query, 20);
 


### PR DESCRIPTION
## Summary

Stabilizes `test_build_batched_vs_regular_equivalence` (and its sibling `test_build_batched`) by spacing the seed scale so the sin-based embeddings are genuinely distinct in cosine space. Pre-release blocker — main CI on `84cfd0b9` failed with this flake.

## Root cause

`make_test_embedding(seed)` produces a normalized vector from `((seed * 0.1) + (i * 0.001)).sin()`. With seeds `1..=20` the inputs to `sin` become `0.1, 0.2, ..., 2.0` — nearly collinear because `sin'(x) ≈ 1` is large in that range and adjacent seeds differ by 0.1. The post-#1425 small-tier HNSW defaults (M=16, ef_c=100, ef_s=50 for <5k chunks) approximate-prune one collinear point out of recall non-deterministically.

PR #1431 widened the search window to top-N=N. That stopped some flakes but not the cosine-space-collinearity one. PROJECT_CONTINUITY.md flagged it as recurring, and main CI on `84cfd0b9` confirmed it still surfaces.

## Fix

Multiply the seed by 1000. Sin inputs become `100, 200, ..., 2000` — uniformly distributed in `[-1, 1]` — so adjacent seeds produce genuinely distinct cosine-space points. HNSW recall@N=N is now deterministic on both N=20 and N=25 sample sizes.

`make_test_embedding` itself is unchanged. The seed multiplier is scoped to the two test bodies so any sibling that depends on the original near-collinear semantics for proximity assertions stays untouched.

## Test plan

- [x] `cargo test --features gpu-index --lib hnsw::build::tests::test_build_batched` — 3 pass (including the previously-flaky equivalence test)
- [x] **10/10 sequential runs** of `test_build_batched_vs_regular_equivalence` pass post-fix (was occasionally failing pre-fix)
- [ ] CI green
- [ ] Next overnight slow CI green

## Related

PROJECT_CONTINUITY.md "Recent shipped (today)" → #1431. The widened-window fix shipped there + this seed-space fix together close the small-tier corner case.
