### PR TITLE
test(watch+train): TC-HAP-V1.36-9 + 10 daemon GC and train-data tests (refs #1458)

### DIFF
--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -1751,3 +1751,184 @@ fn touch_mtime_or_warn_returns_true_on_extant_file() {
         "extant file with readable mtime must succeed; FS chain returned false unexpectedly"
     );
 }
+
+// ============================================================================
+// TC-HAP-V1.36-9 — daemon GC happy-path tests
+//
+// `run_daemon_startup_gc` and `run_daemon_periodic_gc` are pub(super) helpers
+// in `super::gc`. These tests exercise the missing-file prune branch end-to-
+// end: real on-disk files + a phantom chunk for a file that never existed.
+// The gitignore-prune branch is exercised by passing `None` for the matcher
+// (covered by the dedicated `prune_gitignored` unit tests).
+// ============================================================================
+
+fn make_gc_test_chunk(file: &Path, name: &str, line_start: u32) -> cqs::parser::Chunk {
+    let content = format!("fn {name}() {{ }}");
+    let content_hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+    cqs::parser::Chunk {
+        id: format!("{}:{line_start}:{name}", file.display()),
+        file: file.to_path_buf(),
+        language: cqs::parser::Language::Rust,
+        chunk_type: cqs::parser::ChunkType::Function,
+        name: name.to_string(),
+        signature: format!("fn {name}()"),
+        content,
+        doc: None,
+        line_start,
+        line_end: line_start + 4,
+        content_hash,
+        parent_id: None,
+        window_idx: None,
+        parent_type_name: None,
+        parser_version: 0,
+    }
+}
+
+/// TC-HAP-V1.36-9: startup GC prunes phantom chunks for files no longer on disk.
+#[test]
+fn run_daemon_startup_gc_prunes_phantom_chunks() {
+    use super::gc::run_daemon_startup_gc;
+    use std::io::Write;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Create one real on-disk file.
+    let live_abs = root.join("src").join("live.rs");
+    std::fs::create_dir_all(live_abs.parent().unwrap()).unwrap();
+    std::fs::File::create(&live_abs)
+        .unwrap()
+        .write_all(b"fn live_fn() {}")
+        .unwrap();
+
+    // Open Store and seed with chunks keyed by paths matching what
+    // `enumerate_files` returns under this root: project-relative paths.
+    let store_path = root.join(cqs::INDEX_DB_FILENAME);
+    let store = Store::open(&store_path).unwrap();
+    store.init(&cqs::store::ModelInfo::default()).unwrap();
+
+    let dim = cqs::EMBEDDING_DIM;
+    let mut emb = vec![0.0_f32; dim];
+    emb[0] = 1.0;
+    let embedding = cqs::Embedding::new(emb);
+
+    let live_rel = PathBuf::from("src/live.rs");
+    let phantom_rel = PathBuf::from("src/phantom.rs");
+    let chunks = vec![
+        (
+            make_gc_test_chunk(&live_rel, "live_fn", 1),
+            embedding.clone(),
+        ),
+        (make_gc_test_chunk(&phantom_rel, "phantom_fn", 1), embedding),
+    ];
+    store.upsert_chunks_batch(&chunks, Some(0)).unwrap();
+
+    let before = store.stats().unwrap().total_chunks;
+    assert_eq!(before, 2, "fixture must seed 2 chunks");
+
+    let parser = CqParser::new().unwrap();
+
+    // No env override → startup GC runs.
+    std::env::remove_var("CQS_DAEMON_STARTUP_GC");
+    run_daemon_startup_gc(&store, root, &parser, None);
+
+    let after = store.stats().unwrap().total_chunks;
+    assert_eq!(
+        after, 1,
+        "phantom chunk for nonexistent file must be pruned (before={before}, after={after})"
+    );
+
+    let live_origin = cqs::normalize_path(&live_rel);
+    let live_chunks = store.get_chunks_by_origin(&live_origin).unwrap();
+    assert_eq!(live_chunks.len(), 1);
+    assert_eq!(live_chunks[0].name, "live_fn");
+}
+
+/// TC-HAP-V1.36-9: `CQS_DAEMON_STARTUP_GC=0` short-circuits the prune.
+/// Pre-fix this was an unobservable behavior — pinning it keeps the
+/// operator-visible escape hatch honest.
+#[test]
+fn run_daemon_startup_gc_disabled_by_env_keeps_phantoms() {
+    use super::gc::run_daemon_startup_gc;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    let store_path = root.join(cqs::INDEX_DB_FILENAME);
+    let store = Store::open(&store_path).unwrap();
+    store.init(&cqs::store::ModelInfo::default()).unwrap();
+
+    let dim = cqs::EMBEDDING_DIM;
+    let mut emb = vec![0.0_f32; dim];
+    emb[0] = 1.0;
+    let chunks = vec![(
+        make_gc_test_chunk(&PathBuf::from("src/phantom.rs"), "phantom_fn", 1),
+        cqs::Embedding::new(emb),
+    )];
+    store.upsert_chunks_batch(&chunks, Some(0)).unwrap();
+
+    let parser = CqParser::new().unwrap();
+
+    // SAFETY: env-mutation in a parallel-test world. The vars are namespaced
+    // (CQS_DAEMON_STARTUP_GC) and unset at end; concurrent watch tests don't
+    // touch this var.
+    std::env::set_var("CQS_DAEMON_STARTUP_GC", "0");
+    run_daemon_startup_gc(&store, root, &parser, None);
+    std::env::remove_var("CQS_DAEMON_STARTUP_GC");
+
+    let after = store.stats().unwrap().total_chunks;
+    assert_eq!(
+        after, 1,
+        "CQS_DAEMON_STARTUP_GC=0 must skip prune; phantom must survive"
+    );
+}
+
+/// TC-HAP-V1.36-9: periodic GC also prunes missing-file chunks.
+/// The bounded version paths through `prune_missing` the same way startup
+/// does; this test pins the missing-file branch (gitignore branch is `None`).
+#[test]
+fn run_daemon_periodic_gc_prunes_missing_files() {
+    use super::gc::run_daemon_periodic_gc;
+    use std::io::Write;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+
+    let live_abs = root.join("src").join("live.rs");
+    std::fs::create_dir_all(live_abs.parent().unwrap()).unwrap();
+    std::fs::File::create(&live_abs)
+        .unwrap()
+        .write_all(b"fn live_fn() {}")
+        .unwrap();
+
+    let store_path = root.join(cqs::INDEX_DB_FILENAME);
+    let store = Store::open(&store_path).unwrap();
+    store.init(&cqs::store::ModelInfo::default()).unwrap();
+
+    let dim = cqs::EMBEDDING_DIM;
+    let mut emb = vec![0.0_f32; dim];
+    emb[0] = 1.0;
+    let embedding = cqs::Embedding::new(emb);
+
+    let chunks = vec![
+        (
+            make_gc_test_chunk(&PathBuf::from("src/live.rs"), "live_fn", 1),
+            embedding.clone(),
+        ),
+        (
+            make_gc_test_chunk(&PathBuf::from("src/ghost.rs"), "ghost_fn", 1),
+            embedding,
+        ),
+    ];
+    store.upsert_chunks_batch(&chunks, Some(0)).unwrap();
+    assert_eq!(store.stats().unwrap().total_chunks, 2);
+
+    let parser = CqParser::new().unwrap();
+    // disk_files: None → function does its own enumerate_files walk.
+    run_daemon_periodic_gc(&store, root, &parser, None, None);
+
+    assert_eq!(
+        store.stats().unwrap().total_chunks,
+        1,
+        "periodic GC must prune missing-file chunks (ghost.rs)"
+    );
+}

--- a/tests/cli_train_data_test.rs
+++ b/tests/cli_train_data_test.rs
@@ -1,0 +1,161 @@
+//! TC-HAP-V1.36-10 — `cqs train-data` CLI subprocess integration test.
+//!
+//! `cmd_train_data` (`src/cli/commands/train/train_data.rs`) is a thin
+//! wrapper around `cqs::train_data::generate_training_data` plus a
+//! `println!` summary. The library function has unit tests in
+//! `src/train_data/mod.rs`; what was unverified is the CLI surface —
+//! arg parsing, summary line formatting, and exit code on a real git
+//! repo.
+//!
+//! `slow-tests`-gated and serial because the test spins a fresh git
+//! repo + invokes the cqs binary as a subprocess.
+
+#![cfg(feature = "slow-tests")]
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serial_test::serial;
+use std::fs;
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+fn cqs() -> Command {
+    #[allow(deprecated)]
+    Command::cargo_bin("cqs").expect("Failed to find cqs binary")
+}
+
+/// Spin a git repo with two commits modifying the same Rust function.
+/// `train-data` walks `git log` and emits one triplet per
+/// (commit, changed function) pair.
+fn setup_git_repo_with_history() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    let src = dir.path().join("src");
+    fs::create_dir(&src).expect("mkdir src");
+
+    fs::write(
+        src.join("lib.rs"),
+        r#"
+/// Apply discount to a price.
+pub fn discount(price: u32) -> u32 {
+    price - (price / 10)
+}
+"#,
+    )
+    .expect("write v1");
+
+    let git_init = |args: &[&str]| {
+        StdCommand::new("git")
+            .args(args)
+            .current_dir(dir.path())
+            .status()
+            .expect("git command failed");
+    };
+    git_init(&["init", "-q"]);
+    git_init(&["config", "user.email", "test@example.com"]);
+    git_init(&["config", "user.name", "Test"]);
+    git_init(&["add", "src/lib.rs"]);
+    git_init(&[
+        "commit",
+        "-q",
+        "-m",
+        "feat: implement basic discount calculation for cart pricing",
+    ]);
+
+    // Second commit: rewrite the function body, with a long enough message
+    // to clear `--min-msg-len` (default 15).
+    fs::write(
+        src.join("lib.rs"),
+        r#"
+/// Apply tiered discount based on price brackets.
+pub fn discount(price: u32) -> u32 {
+    if price > 100 { price - (price / 5) } else { price - (price / 20) }
+}
+"#,
+    )
+    .expect("write v2");
+
+    git_init(&["add", "src/lib.rs"]);
+    git_init(&[
+        "commit",
+        "-q",
+        "-m",
+        "feat: introduce tiered discount brackets for higher-priced items",
+    ]);
+
+    dir
+}
+
+/// TC-HAP-V1.36-10 happy path: `cqs train-data` runs against a real git
+/// repo, emits the canonical summary line, and writes a non-empty JSONL
+/// at `--output`. We don't pin exact triplet content (BM25 negatives
+/// depend on the corpus) — only that the structure is right.
+#[test]
+#[serial]
+fn train_data_emits_summary_line_and_writes_jsonl() {
+    let dir = setup_git_repo_with_history();
+    let output = dir.path().join("triplets.jsonl");
+
+    let output_str = output.to_string_lossy().to_string();
+    cqs()
+        .args([
+            "train-data",
+            "--repos",
+            ".",
+            "--output",
+            &output_str,
+            "--max-commits",
+            "10",
+            "--max-files",
+            "5",
+            "--dedup-cap",
+            "5",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        // `cmd_train_data` prints exactly:
+        //   "Generated N triplets from M repos (X commits processed, Y skipped)"
+        // Pin the prefix so a refactor that mangles the summary surfaces here.
+        .stdout(predicate::str::contains("Generated "))
+        .stdout(predicate::str::contains(" triplets from "))
+        .stdout(predicate::str::contains(" repos ("))
+        .stdout(predicate::str::contains(" commits processed"));
+
+    // The JSONL output must exist. Whether it's non-empty depends on
+    // whether the BM25 corpus produced enough hard negatives — for a
+    // single-function repo with no negatives, the function logs and skips
+    // the triplet. So we only assert the file was created (write path
+    // exercised) rather than line count.
+    assert!(
+        output.exists(),
+        "expected output file at {} after train-data run",
+        output.display()
+    );
+}
+
+/// TC-HAP-V1.36-10: rejects a non-git directory with a warn (skipped repo)
+/// and exits 0 — the CLI is best-effort across multiple `--repos`, so
+/// "not a repo" must not abort the whole run.
+#[test]
+#[serial]
+fn train_data_skips_non_git_repo_and_exits_zero() {
+    let dir = TempDir::new().expect("tempdir");
+    fs::write(dir.path().join("README.md"), "not a git repo").expect("write");
+    let output = dir.path().join("empty.jsonl");
+
+    let output_str = output.to_string_lossy().to_string();
+    cqs()
+        .args([
+            "train-data",
+            "--repos",
+            ".",
+            "--output",
+            &output_str,
+            "--max-commits",
+            "5",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0 triplets"));
+}


### PR DESCRIPTION
## Summary

Closes the last two TC Happy items deferred from the v1.36.2 audit (#1458):

**TC-HAP-V1.36-9** — daemon GC happy paths in `src/cli/watch/tests.rs`:

| test | covers |
|---|---|
| `run_daemon_startup_gc_prunes_phantom_chunks` | one-shot startup sweep removes chunks for files not on disk |
| `run_daemon_startup_gc_disabled_by_env_keeps_phantoms` | `CQS_DAEMON_STARTUP_GC=0` short-circuit |
| `run_daemon_periodic_gc_prunes_missing_files` | bounded idle-time periodic sweep |

These exercise the prune branch end-to-end through `enumerate_files` + `prune_missing`, not by calling `prune_missing` directly (already covered in `src/store/chunks/staleness.rs`). Chunks are seeded with project-relative paths matching what `enumerate_files` returns under the temp root.

**TC-HAP-V1.36-10** — `cqs train-data` CLI subprocess in new `tests/cli_train_data_test.rs`:

| test | covers |
|---|---|
| `train_data_emits_summary_line_and_writes_jsonl` | spins a real git repo with two commits, checks summary line + JSONL written |
| `train_data_skips_non_git_repo_and_exits_zero` | non-git repo skipped with `0 triplets` summary, exit 0 |

Same pattern as `tests/cli_train_review_test.rs`: `#![cfg(feature = "slow-tests")]` + `#[serial]`.

Refs #1458.

## Test plan

- [x] `cargo test --features gpu-index --bin cqs run_daemon` — 11 pass (3 new + 8 existing)
- [x] `cargo test --features gpu-index,slow-tests --test cli_train_data_test` — 2 pass
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
