### PR TITLE
fix(index): drop never-emitted IndexBackendError variants (API-V1.36-6 / refs #1459)

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -23,27 +23,21 @@ use crate::store::{ClearHnswDirty, Store, StoreError};
 /// unused; future backends like USearch / Metal / ROCm can adopt as
 /// needed). CLI sites consume this with `?` into `anyhow::Result` exactly
 /// as today via the `From` impl.
+///
+/// API-V1.36-6 (#1459 sub-6): the previous `ChecksumMismatch` and
+/// `LoadFailed` variants were documented as never-emitted — every
+/// backend converts internal load failures to `Ok(None)` and
+/// `tracing::warn!` to fall through to the next backend. Removing
+/// them tightens the type to "store-level abort only", matching the
+/// trait contract. Backend implementations that handle integrity
+/// failures internally still log via `tracing::warn!` and return
+/// `Ok(None)`, exactly as before.
 #[derive(Debug, Error)]
 pub enum IndexBackendError {
     /// A backend-internal store query failed in a way that can't be
     /// recovered by falling through to the next backend.
     #[error("store error: {0}")]
     Store(#[from] StoreError),
-
-    /// Persisted index file failed integrity check (blake3 mismatch,
-    /// magic-bytes mismatch, dim mismatch, chunk-count mismatch).
-    /// Distinct from `LoadFailed` because the operator-facing message
-    /// differs: a checksum mismatch usually means the file is stale and
-    /// safe to delete, while a load failure may indicate a deeper
-    /// corruption.
-    #[error("index integrity check failed: {0}")]
-    ChecksumMismatch(String),
-
-    /// Persisted index file deserialization failed for reasons other
-    /// than a clean integrity mismatch (truncation, IO error during
-    /// read, library deserialization error).
-    #[error("index load failed: {0}")]
-    LoadFailed(String),
 }
 
 /// Convenience for CLI consumers that want to fold backend errors into


### PR DESCRIPTION
## Summary

Closes the **API-V1.36-6** sub-item from #1459 (P3 API design umbrella).

`IndexBackendError` (`src/index.rs:27`) had three variants — `Store`, `ChecksumMismatch`, `LoadFailed` — but `ChecksumMismatch` and `LoadFailed` were never constructed anywhere in the source tree:

```
$ grep -rn 'IndexBackendError::ChecksumMismatch\|IndexBackendError::LoadFailed' src/
(no matches)
```

The trait's own doc comment explains why: every backend handles integrity / load failures internally via `tracing::warn!` + `Ok(None)` to fall through to the next backend. So future backend authors reaching for `LoadFailed` would silently break the selector contract — the convention only existed in comments, not in types.

Drop the two unused variants, leaving `IndexBackendError::Store(StoreError)`. The trait return shape is unchanged (`Result<_, IndexBackendError>`), the `From<StoreError>` impl is unchanged, and HNSW + CAGRA backends both compile without modification because neither ever reached for the dropped variants. Updates the enum's doc comment to record the audit decision so it's preserved in source.

Refs #1459 (sub-item 6).

## Test plan

- [x] `cargo build --features gpu-index --bin cqs` — clean
- [x] `cargo test --features gpu-index --lib index::` — 24 pass (no test changes; existing index/HNSW/SPLADE tests still green)
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
