### PR TITLE
perf(index): skip first-pass embed when --llm-summaries (closes #1452)

### DIFF
--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -443,6 +443,24 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
         .set_hnsw_dirty(HnswKind::Base, true)
         .context("Failed to mark base HNSW dirty before indexing")?;
 
+    // #1452: skip the first-pass embed when `--llm-summaries` is set.
+    // The post-summary `enrichment_pass` will overwrite every chunk's
+    // embedding anyway (NL = `summary + caller/callee names + content`),
+    // so the first embed is wasted work — ~30 min of GPU time on a
+    // 12k-chunk Qwen3-4B reindex. Chunks land with a zero-vec sentinel +
+    // `needs_embedding=1`; HNSW build and search hide them until
+    // enrichment lands the real vector. If enrichment fails or is
+    // interrupted, the next `cqs index` invocation observes the
+    // `needs_embedding=1` rows and re-runs enrichment to clear them.
+    //
+    // The LLM summary pass is best-effort independent of this — its
+    // failure doesn't block enrichment_pass's local embed work, just
+    // means chunks get the base NL (no summary boost) for that run.
+    #[cfg(feature = "llm-summaries")]
+    let skip_first_pass_embed = llm_summaries;
+    #[cfg(not(feature = "llm-summaries"))]
+    let skip_first_pass_embed = false;
+
     // Run the 3-stage pipeline: parse → embed → write
     // Pipeline shares the same Store via Arc (no duplicate DB connections)
     let stats = run_index_pipeline(
@@ -452,6 +470,7 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
         force,
         cli.quiet,
         cli.try_model_config()?.clone(),
+        skip_first_pass_embed,
     )?;
     let total_embedded = stats.total_embedded;
     let total_cached = stats.total_cached;
@@ -633,12 +652,32 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
         tracing::warn!(error = %e, "cmd_index: final flush of summary queue failed; rows retained for next run");
     }
 
-    // Call-graph enrichment pass (SQ-4): re-embed chunks with caller/callee context
-    if !check_interrupted() && stats.total_calls > 0 {
+    // Call-graph enrichment pass (SQ-4): re-embed chunks with caller/callee
+    // context. #1452: also fires whenever any chunk is at `needs_embedding=1`
+    // — the parser stage marks chunks unembedded when a `--llm-summaries`
+    // run skipped the first-pass embed, and `enrichment_pass` is the gate
+    // that clears those flags. Without this trigger extension, a project
+    // with no calls would leave first-pass-skipped chunks invisible
+    // forever.
+    let needs_embed_count = match store.needs_embedding_count() {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to count needs_embedding chunks; assuming zero");
+            0
+        }
+    };
+    if !check_interrupted() && (stats.total_calls > 0 || needs_embed_count > 0) {
         use crate::cli::enrichment_pass;
 
         if !cli.quiet {
-            println!("Enriching embeddings with call graph context...");
+            if needs_embed_count > 0 {
+                println!(
+                    "Enriching embeddings with call graph context ({} chunks awaiting first embedding)...",
+                    needs_embed_count
+                );
+            } else {
+                println!("Enriching embeddings with call graph context...");
+            }
         }
         let model_config = cli.try_model_config()?.clone();
         let embedder = Embedder::new(model_config.clone())

--- a/src/cli/commands/infra/reference.rs
+++ b/src/cli/commands/infra/reference.rs
@@ -239,6 +239,9 @@ fn cmd_ref_add(
         false,
         cli.quiet,
         cli.try_model_config()?.clone(),
+        // #1452: ref add does not run the LLM summary pass, so first-pass
+        // embed is the only embed — never skip it for refs.
+        false,
     )?;
 
     if !cli.quiet && !json {
@@ -594,6 +597,9 @@ fn cmd_ref_update(cli: &Cli, name: &str, json: bool) -> Result<()> {
         false,
         cli.quiet,
         cli.try_model_config()?.clone(),
+        // #1452: ref update does not run the LLM summary pass, so
+        // first-pass embed is the only embed — never skip it for refs.
+        false,
     )?;
 
     if !cli.quiet && !json {

--- a/src/cli/enrichment.rs
+++ b/src/cli/enrichment.rs
@@ -62,6 +62,27 @@ pub(crate) fn enrichment_pass(
         *name_file_count.entry(ci.name.as_str()).or_insert(0) += 1;
     }
 
+    // #1452: chunks at `needs_embedding=1` MUST be processed even if they
+    // have no callers/callees/summary/hyde — they have no embedding at all
+    // (zero-vec sentinel), so the standard early-skip would leave them
+    // invisible to search forever. The HashSet is built once per pass; on
+    // a fresh `--llm-summaries` reindex it covers every chunk, on
+    // incremental runs it's empty (≈ no overhead) or has only the
+    // newly-changed chunks.
+    let needs_embedding_ids = match store.needs_embedding_ids() {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to fetch needs_embedding_ids; falling back to context-only enrichment");
+            std::collections::HashSet::new()
+        }
+    };
+    if !needs_embedding_ids.is_empty() {
+        tracing::info!(
+            count = needs_embedding_ids.len(),
+            "Enrichment pass: chunks at needs_embedding=1 will be processed regardless of context"
+        );
+    }
+
     let progress = if quiet {
         ProgressBar::hidden()
     } else {
@@ -171,19 +192,32 @@ pub(crate) fn enrichment_pass(
                 let summary_norm = all_summaries_norm.get(&cs.content_hash).map(|s| s.as_str());
                 let hyde_norm = all_hyde_norm.get(&cs.content_hash).map(|s| s.as_str());
 
-                // Skip chunks with nothing to add: no call context, no summary, no hyde
-                if !has_callers && !has_callees && summary.is_none() && hyde.is_none() {
-                    continue;
-                }
+                // #1452: chunks at `needs_embedding=1` must always be embedded
+                // regardless of context — they were written by the parser
+                // stage with a zero-vec sentinel (see `upsert_chunks_unembedded_batch`).
+                // Search and HNSW build skip them via `WHERE needs_embedding = 0`,
+                // so leaving them unembedded means they stay invisible.
+                let needs_embedding = needs_embedding_ids.contains(&cs.id);
 
-                // Skip ambiguous names — functions like `new`, `parse`, `build`
-                // appear in multiple chunks and would get merged callers from
-                // unrelated functions. (RB-B1)
-                // But still process if they have a summary or hyde (neither depends on call graph)
-                if name_file_count.get(cs.name.as_str()).copied().unwrap_or(0) > 1
+                // Skip chunks with nothing to add: no call context, no summary,
+                // no hyde — UNLESS they need an embedding at all (#1452).
+                if !needs_embedding
+                    && !has_callers
+                    && !has_callees
                     && summary.is_none()
                     && hyde.is_none()
                 {
+                    continue;
+                }
+
+                // Ambiguous names (RB-B1): functions like `new`, `parse`,
+                // `build` appear in multiple files. Today's contract: skip
+                // them so we don't merge callers from unrelated functions.
+                // #1452: even ambiguous names need a base-NL embedding when
+                // `needs_embedding=1` — pass an empty CallContext below so
+                // they get the bare-name vector without false call context.
+                let ambiguous = name_file_count.get(cs.name.as_str()).copied().unwrap_or(0) > 1;
+                if ambiguous && summary.is_none() && hyde.is_none() && !needs_embedding {
                     continue;
                 }
 
@@ -191,13 +225,26 @@ pub(crate) fn enrichment_pass(
                 // Borrowing would require lifetime parameters through CallContext → generate_nl,
                 // cascading across 5+ modules. At ~5 callers + ~5 callees per chunk, these
                 // clones are negligible (~500 bytes) compared to the embedding cost (~3ms each).
-                let ctx = cqs::CallContext {
-                    callers: callers
-                        .map(|v| v.iter().map(|c| c.name.clone()).collect())
-                        .unwrap_or_default(),
-                    callees: callees
-                        .map(|v| v.iter().map(|(name, _)| name.clone()).collect())
-                        .unwrap_or_default(),
+                //
+                // #1452: ambiguous-name chunks at `needs_embedding=1` get an
+                // EMPTY ctx so the NL is base-only (`generate_nl_description_with_seq_len`)
+                // — equivalent to what the first-pass embed would have produced.
+                // Without this, an ambiguous `new()` on a 50-class project
+                // would inherit 50 unrelated callers.
+                let ctx = if ambiguous && needs_embedding {
+                    cqs::CallContext {
+                        callers: Vec::new(),
+                        callees: Vec::new(),
+                    }
+                } else {
+                    cqs::CallContext {
+                        callers: callers
+                            .map(|v| v.iter().map(|c| c.name.clone()).collect())
+                            .unwrap_or_default(),
+                        callees: callees
+                            .map(|v| v.iter().map(|(name, _)| name.clone()).collect())
+                            .unwrap_or_default(),
+                    }
                 };
 
                 // Compute enrichment hash from post-filtered call context + summary (RT-DATA-2, SQ-6).

--- a/src/cli/pipeline/embedding.rs
+++ b/src/cli/pipeline/embedding.rs
@@ -171,6 +171,10 @@ pub(super) fn create_embedded_batch(
         relationships,
         cached_count,
         file_mtimes,
+        // Default: real embeddings throughout. The skip-first-pass path
+        // builds EmbeddedBatch directly with `uncached_need_embedding: true`
+        // (see #1452 paths in `gpu_embed_stage` / `cpu_embed_stage`).
+        uncached_need_embedding: false,
     }
 }
 
@@ -200,6 +204,7 @@ fn flush_to_cpu(
                 relationships: rels,
                 cached_count,
                 file_mtimes: prepared.file_mtimes.clone(),
+                uncached_need_embedding: false,
             })
             .is_err()
         {
@@ -263,6 +268,44 @@ pub(super) fn gpu_embed_stage(
                     relationships: prepared.relationships,
                     cached_count,
                     file_mtimes: prepared.file_mtimes,
+                    uncached_need_embedding: false,
+                })
+                .is_err()
+            {
+                break;
+            }
+            continue;
+        }
+
+        // #1452: skip-first-pass-embed short-circuit. When set, we do NOT
+        // call `embed_documents()` for cache-miss chunks — instead we
+        // emit zero-vec sentinels stamped `needs_embedding=1` so the
+        // post-summary `enrichment_pass` can land their real vectors
+        // without the wasted GPU time of a discarded first pass.
+        // Cache hits still pass through with their real embeddings.
+        if ctx.skip_first_pass_embed {
+            let dim = embedder.embedding_dim();
+            let zero_vec_count = prepared.to_embed.len();
+            let zero_vecs: Vec<Embedding> = (0..zero_vec_count)
+                .map(|_| Embedding::new(vec![0.0_f32; dim]))
+                .collect();
+            let cached_count = prepared.cached.len();
+            let mut chunk_embeddings = prepared.cached;
+            chunk_embeddings.extend(prepared.to_embed.into_iter().zip(zero_vecs));
+            ctx.embedded_count
+                .fetch_add(chunk_embeddings.len(), Ordering::Relaxed);
+            tracing::debug!(
+                cache_hits = cached_count,
+                stamped_unembedded = zero_vec_count,
+                "skip-first-pass: emitted zero-vec batch"
+            );
+            if embed_tx
+                .send(EmbeddedBatch {
+                    chunk_embeddings,
+                    relationships: prepared.relationships,
+                    cached_count,
+                    file_mtimes: prepared.file_mtimes,
+                    uncached_need_embedding: true,
                 })
                 .is_err()
             {
@@ -345,6 +388,7 @@ pub(super) fn gpu_embed_stage(
                         relationships: prepared.relationships,
                         cached_count,
                         file_mtimes: prepared.file_mtimes,
+                        uncached_need_embedding: false,
                     })
                     .is_err()
                 {
@@ -457,8 +501,45 @@ pub(super) fn cpu_embed_stage(
         let fp = fingerprint.as_deref().unwrap_or("");
 
         // Prepare batch: windowing, cache check, text generation
+        // (still useful in skip-first-pass mode — windowing splits long chunks
+        // and cache lookup salvages real embeddings for hit chunks).
         let prepared =
             prepare_for_embedding(batch, emb, &ctx.store, ctx.global_cache.as_deref(), fp);
+
+        // #1452: skip-first-pass-embed short-circuit (CPU side). Mirrors the
+        // GPU stage above — emit zero-vec sentinels for to_embed chunks
+        // stamped `needs_embedding=1`. Cache hits still pass through with
+        // their real embeddings.
+        if ctx.skip_first_pass_embed && !prepared.to_embed.is_empty() {
+            let dim = emb.embedding_dim();
+            let zero_vec_count = prepared.to_embed.len();
+            let zero_vecs: Vec<Embedding> = (0..zero_vec_count)
+                .map(|_| Embedding::new(vec![0.0_f32; dim]))
+                .collect();
+            let cached_count = prepared.cached.len();
+            let mut chunk_embeddings = prepared.cached;
+            chunk_embeddings.extend(prepared.to_embed.into_iter().zip(zero_vecs));
+            ctx.embedded_count
+                .fetch_add(chunk_embeddings.len(), Ordering::Relaxed);
+            tracing::debug!(
+                cache_hits = cached_count,
+                stamped_unembedded = zero_vec_count,
+                "skip-first-pass: emitted zero-vec batch (cpu)"
+            );
+            if embed_tx
+                .send(EmbeddedBatch {
+                    chunk_embeddings,
+                    relationships: prepared.relationships,
+                    cached_count,
+                    file_mtimes: prepared.file_mtimes,
+                    uncached_need_embedding: true,
+                })
+                .is_err()
+            {
+                break;
+            }
+            continue;
+        }
 
         // Embed new chunks (CPU only)
         let new_embeddings: Vec<Embedding> = if prepared.to_embed.is_empty() {

--- a/src/cli/pipeline/mod.rs
+++ b/src/cli/pipeline/mod.rs
@@ -40,6 +40,15 @@ use upsert::store_stage;
 /// 1. Parser: Parse files in parallel batches
 /// 2. Embedder: Embed chunks (GPU with CPU fallback)
 /// 3. Writer: Write to SQLite
+///
+/// `skip_first_pass_embed` (#1452): when `true`, the embedder stages
+/// emit zero-vec sentinels stamped `needs_embedding=1` for cache-miss
+/// chunks instead of running real inference. The post-summary
+/// `enrichment_pass` lands their real embeddings, halving the GPU time
+/// on `--llm-summaries` reindexes (which already overwrite every
+/// chunk's embedding via enrichment). Cache hits still pass through
+/// with their real embeddings. HNSW build + search filter
+/// `WHERE needs_embedding = 0` so partial-state chunks are invisible.
 pub(crate) fn run_index_pipeline(
     root: &Path,
     files: Vec<PathBuf>,
@@ -47,6 +56,7 @@ pub(crate) fn run_index_pipeline(
     force: bool,
     quiet: bool,
     model_config: ModelConfig,
+    skip_first_pass_embed: bool,
 ) -> Result<PipelineStats> {
     let _span = tracing::info_span!("run_index_pipeline", file_count = files.len()).entered();
     let total_files = files.len();
@@ -138,6 +148,7 @@ pub(crate) fn run_index_pipeline(
             embedded_count: Arc::clone(&embedded_count),
             model_config: model_config.clone(),
             global_cache: global_cache.clone(),
+            skip_first_pass_embed,
         };
         let gpu_failures = Arc::clone(&gpu_failures);
         thread::spawn(move || gpu_embed_stage(parse_rx, embed_tx, fail_tx, ctx, gpu_failures))
@@ -150,6 +161,7 @@ pub(crate) fn run_index_pipeline(
             embedded_count: Arc::clone(&embedded_count),
             model_config,
             global_cache: global_cache.clone(),
+            skip_first_pass_embed,
         };
         thread::spawn(move || cpu_embed_stage(parse_rx_cpu, fail_rx, embed_tx_cpu, ctx))
     };

--- a/src/cli/pipeline/types.rs
+++ b/src/cli/pipeline/types.rs
@@ -32,6 +32,18 @@ pub(super) struct EmbeddedBatch {
     pub relationships: RelationshipData,
     pub cached_count: usize,
     pub file_mtimes: HashMap<PathBuf, i64>,
+    /// #1452: when `true`, the chunks past index `cached_count` carry
+    /// **zero-vec sentinel embeddings** and must be written via
+    /// `upsert_chunks_unembedded_batch` so they're stamped with
+    /// `needs_embedding=1`. Cached chunks (indexes `0..cached_count`)
+    /// always carry real embeddings (from the global cache) and go
+    /// through the normal upsert path.
+    ///
+    /// Set by the embed stages when `EmbedStageContext.skip_first_pass_embed`
+    /// is `true` AND there were `to_embed` chunks (cache misses) in the
+    /// batch. When all chunks were cache hits, the embed stages already
+    /// short-circuit to a "send cached" branch with this flag `false`.
+    pub uncached_need_embedding: bool,
 }
 
 /// Stats returned from pipelined indexing
@@ -69,6 +81,13 @@ pub(super) struct EmbedStageContext {
     pub embedded_count: Arc<AtomicUsize>,
     pub model_config: ModelConfig,
     pub global_cache: Option<Arc<cqs::cache::EmbeddingCache>>,
+    /// #1452: when `true`, skip the actual `embed_documents()` call for
+    /// cache-miss chunks and emit zero-vec sentinels stamped
+    /// `needs_embedding=1` instead. The post-summary `enrichment_pass`
+    /// will overwrite every chunk's embedding anyway, so the first-pass
+    /// embed is wasted work under `--llm-summaries`. Cache hits still
+    /// pass through with their real embeddings.
+    pub skip_first_pass_embed: bool,
 }
 
 // Pipeline tuning constants

--- a/src/cli/pipeline/upsert.rs
+++ b/src/cli/pipeline/upsert.rs
@@ -136,38 +136,46 @@ pub(super) fn store_stage(
         let batch_count = batch.chunk_embeddings.len();
         let no_calls: Vec<(String, cqs::parser::CallSite)> = Vec::new();
 
-        // Upsert chunks WITHOUT calls (calls are deferred)
+        // Upsert chunks WITHOUT calls (calls are deferred).
         // #1283: also accumulate per-file live IDs for the post-loop prune pass.
-        if batch.file_mtimes.len() <= 1 {
-            // Fast path: single file or no mtimes
-            let mtime = batch.file_mtimes.values().next().copied();
-            for (chunk, _) in &batch.chunk_embeddings {
-                live_ids_per_file
-                    .entry(chunk.file.clone())
-                    .or_default()
-                    .insert(chunk.id.clone());
-            }
-            store.upsert_chunks_and_calls(&batch.chunk_embeddings, mtime, &no_calls)?;
-        } else {
-            // Multi-file batch: group by file and upsert with correct per-file mtime.
-            let mut by_file: HashMap<PathBuf, Vec<(Chunk, Embedding)>> = HashMap::new();
-            for (chunk, embedding) in batch.chunk_embeddings {
-                by_file
+        //
+        // #1452: when `uncached_need_embedding` is set, the chunks past
+        // index `cached_count` carry zero-vec sentinels (skip-first-pass
+        // path under `--llm-summaries`). Cached chunks still carry real
+        // embeddings (from the global cache). Slice the batch and route
+        // each half to the correct upsert path so cached chunks land at
+        // `needs_embedding=0` while sentinel chunks land at
+        // `needs_embedding=1`.
+        let cached_slice_end = batch.cached_count.min(batch.chunk_embeddings.len());
+        let mut by_file_real: HashMap<PathBuf, Vec<(Chunk, Embedding)>> = HashMap::new();
+        let mut by_file_sentinel: HashMap<PathBuf, Vec<Chunk>> = HashMap::new();
+        for (i, (chunk, embedding)) in batch.chunk_embeddings.into_iter().enumerate() {
+            live_ids_per_file
+                .entry(chunk.file.clone())
+                .or_default()
+                .insert(chunk.id.clone());
+            if i < cached_slice_end || !batch.uncached_need_embedding {
+                by_file_real
                     .entry(chunk.file.clone())
                     .or_default()
                     .push((chunk, embedding));
+            } else {
+                // Past cached_count and skip-first-pass mode is on — chunk
+                // carries a zero-vec sentinel; route to the unembedded upsert.
+                by_file_sentinel
+                    .entry(chunk.file.clone())
+                    .or_default()
+                    .push(chunk);
             }
+        }
 
-            for (file, pairs) in &by_file {
-                let mtime = batch.file_mtimes.get(file.as_path()).copied();
-                for (chunk, _) in pairs {
-                    live_ids_per_file
-                        .entry(file.clone())
-                        .or_default()
-                        .insert(chunk.id.clone());
-                }
-                store.upsert_chunks_and_calls(pairs, mtime, &no_calls)?;
-            }
+        for (file, pairs) in &by_file_real {
+            let mtime = batch.file_mtimes.get(file.as_path()).copied();
+            store.upsert_chunks_and_calls(pairs, mtime, &no_calls)?;
+        }
+        for (file, chunks) in &by_file_sentinel {
+            let mtime = batch.file_mtimes.get(file.as_path()).copied();
+            store.upsert_chunks_unembedded_batch(chunks, mtime)?;
         }
 
         // Store function calls extracted during parsing (for the `function_calls` table).

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1,4 +1,13 @@
--- cq index schema v26 (see src/store/helpers/mod.rs::CURRENT_SCHEMA_VERSION; v22+v23+v24+v25+v26 columns annotated inline below)
+-- cq index schema v27 (see src/store/helpers/mod.rs::CURRENT_SCHEMA_VERSION; v22+v23+v24+v25+v26+v27 columns annotated inline below)
+-- v27: chunks.needs_embedding INTEGER NOT NULL DEFAULT 0 + partial index on
+--      needs_embedding=1. Set on chunks written by the parser stage during a
+--      `--llm-summaries` reindex without a first-pass embed (#1452); cleared
+--      by `enrichment_pass` once a real embedding is written. The
+--      `embedding` column stays BLOB NOT NULL (zero-vec sentinel for
+--      unembedded chunks); HNSW build + search hydration filter
+--      `WHERE needs_embedding = 0` so partial-state chunks are invisible
+--      until enrichment lands their real vector. The visibility gate is
+--      local — LLM summary failure does not block it.
 -- v22: umap_x / umap_y REAL columns on chunks for the cqs serve cluster view.
 --      Both nullable; populated only when `cqs index --umap` runs the
 --      umap-learn projection. /api/embed/2d skips chunks where coords are NULL.
@@ -57,8 +66,12 @@ CREATE TABLE IF NOT EXISTS chunks (
     umap_y REAL,                              -- v22: 2D projection Y coord (NULL until `cqs index --umap` runs)
     source_size INTEGER,                      -- v23: file size in bytes for reconcile fingerprint (#1219); nullable on pre-migration rows
     source_content_hash BLOB,                 -- v23: BLAKE3 hash of file bytes for reconcile fingerprint (#1219); nullable on pre-migration rows
-    vendored INTEGER NOT NULL DEFAULT 0       -- v24: 1 if origin matches a vendored-path prefix at index time (#1221); search emits trust_level="vendored-code" for these
+    vendored INTEGER NOT NULL DEFAULT 0,      -- v24: 1 if origin matches a vendored-path prefix at index time (#1221); search emits trust_level="vendored-code" for these
+    needs_embedding INTEGER NOT NULL DEFAULT 0 -- v27: 1 when chunk was written without a real embedding (#1452 first-pass-skip); cleared by enrichment_pass
 );
+
+CREATE INDEX IF NOT EXISTS idx_chunks_needs_embedding
+    ON chunks(needs_embedding) WHERE needs_embedding = 1;
 
 CREATE INDEX IF NOT EXISTS idx_chunks_origin ON chunks(origin);
 CREATE INDEX IF NOT EXISTS idx_chunks_source_type ON chunks(source_type);

--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -321,19 +321,21 @@ pub(super) async fn batch_insert_chunks(
     vendored_per_chunk: &[bool],
     source_mtime: Option<i64>,
     now: &str,
+    needs_embedding: bool,
 ) -> Result<(), StoreError> {
     use crate::store::helpers::sql::max_rows_per_statement;
-    // 22 binds per row (v24 / #1221: vendored added after parser_version).
-    const CHUNK_INSERT_BATCH: usize = max_rows_per_statement(22);
+    // 23 binds per row (v27 / #1452: needs_embedding added after vendored).
+    const CHUNK_INSERT_BATCH: usize = max_rows_per_statement(23);
     debug_assert_eq!(
         chunks.len(),
         vendored_per_chunk.len(),
         "vendored_per_chunk must align 1:1 with chunks"
     );
+    let needs_embedding_i64: i64 = if needs_embedding { 1 } else { 0 };
     for (batch_idx, batch) in chunks.chunks(CHUNK_INSERT_BATCH).enumerate() {
         let emb_offset = batch_idx * CHUNK_INSERT_BATCH;
         let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
-            "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name, signature, content, content_hash, doc, line_start, line_end, embedding, embedding_base, source_mtime, created_at, updated_at, parent_id, window_idx, parent_type_name, parser_version, vendored)",
+            "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name, signature, content, content_hash, doc, line_start, line_end, embedding, embedding_base, source_mtime, created_at, updated_at, parent_id, window_idx, parent_type_name, parser_version, vendored, needs_embedding)",
         );
         qb.push_values(batch.iter().enumerate(), |mut b, (i, (chunk, _))| {
             b.push_bind(&chunk.id)
@@ -369,7 +371,12 @@ pub(super) async fn batch_insert_chunks(
                     1_i64
                 } else {
                     0_i64
-                });
+                })
+                // v27 / #1452: 1 when this chunk was written without a real
+                // embedding (skip-first-pass for `--llm-summaries`); 0 when
+                // the embedding bytes are real. Cleared by `enrichment_pass`
+                // via `update_embeddings_with_hashes_batch`.
+                .push_bind(needs_embedding_i64);
         });
         // DS-2: ON CONFLICT upsert preserves enrichment_hash and enrichment_version.
         //
@@ -407,6 +414,7 @@ pub(super) async fn batch_insert_chunks(
              parent_type_name=excluded.parent_type_name, \
              parser_version=excluded.parser_version, \
              vendored=excluded.vendored, \
+             needs_embedding=excluded.needs_embedding, \
              umap_x=CASE WHEN chunks.content_hash != excluded.content_hash \
                          THEN NULL ELSE chunks.umap_x END, \
              umap_y=CASE WHEN chunks.content_hash != excluded.content_hash \
@@ -628,8 +636,14 @@ impl<'a, Mode> Iterator for EmbeddingHashBatchIterator<'a, Mode> {
             }
 
             let result = self.store.rt.block_on(async {
+                // #1452: filter `needs_embedding = 0` so HNSW build skips
+                // chunks that were written by the parser stage during a
+                // first-pass-skip reindex but haven't yet been re-embedded
+                // by `enrichment_pass`. Their `embedding` column carries a
+                // zero-vec sentinel that would corrupt the index.
                 let sql = "SELECT rowid, id, embedding, content_hash FROM chunks \
                            WHERE rowid > ?1 AND embedding IS NOT NULL \
+                             AND needs_embedding = 0 \
                            ORDER BY rowid ASC LIMIT ?2";
                 let rows: Vec<_> = sqlx::query(sql)
                     .bind(self.last_rowid)

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -269,9 +269,79 @@ impl Store<ReadWrite> {
                 &vendored_per_chunk,
                 source_mtime,
                 &now,
+                false, // #1452: real embeddings → needs_embedding=0
             )
             .await?;
             upsert_fts_conditional(&mut tx, chunks, &old_hashes).await?;
+            tx.commit().await?;
+            Ok(chunks.len())
+        })
+    }
+
+    /// #1452: insert chunks without a real embedding. Each row gets a
+    /// zero-vec sentinel in the `embedding` column and `needs_embedding=1`,
+    /// signaling that `enrichment_pass` must overwrite the embedding before
+    /// the chunk becomes visible to HNSW build / search hydration.
+    ///
+    /// Used by the indexing pipeline when `--llm-summaries` is set: the
+    /// first-pass embed would just be overwritten by the post-summary
+    /// enrichment re-embed, so we skip it entirely. On a fresh
+    /// `cqs index --force --llm-summaries` for a 12k-chunk corpus this
+    /// halves the GPU time spent embedding (~30 min → ~30 min total
+    /// instead of ~60 min for the discard-and-redo shape).
+    ///
+    /// Failure modes: an interrupted enrichment pass leaves chunks at
+    /// `needs_embedding=1`. The next `cqs index` invocation observes them
+    /// via `enrichment_pass`'s `needs_embedding > 0` trigger and embeds
+    /// them. Search ignores chunks at `needs_embedding=1` so the partial
+    /// state never leaks degraded results.
+    pub fn upsert_chunks_unembedded_batch(
+        &self,
+        chunks: &[Chunk],
+        source_mtime: Option<i64>,
+    ) -> Result<usize, StoreError> {
+        let _span =
+            tracing::info_span!("upsert_chunks_unembedded_batch", count = chunks.len()).entered();
+
+        if chunks.is_empty() {
+            return Ok(0);
+        }
+
+        let dim = self.dim;
+        let zero_vec = Embedding::new(vec![0.0_f32; dim]);
+        let chunks_with_zero: Vec<(Chunk, Embedding)> = chunks
+            .iter()
+            .map(|c| (c.clone(), zero_vec.clone()))
+            .collect();
+        let embedding_bytes: Vec<Vec<u8>> = chunks_with_zero
+            .iter()
+            .map(|(_, emb)| embedding_to_bytes(emb, dim))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let prefixes = self.vendored_prefixes_slice();
+        let vendored_per_chunk: Vec<bool> = chunks
+            .iter()
+            .map(|chunk| {
+                let origin = crate::normalize_path(&chunk.file);
+                crate::vendored::is_vendored_origin(&origin, prefixes)
+            })
+            .collect();
+
+        self.rt.block_on(async {
+            let (_guard, mut tx) = self.begin_write().await?;
+            let old_hashes = snapshot_content_hashes(&mut tx, &chunks_with_zero).await?;
+            let now = chrono::Utc::now().to_rfc3339();
+            batch_insert_chunks(
+                &mut tx,
+                &chunks_with_zero,
+                &embedding_bytes,
+                &vendored_per_chunk,
+                source_mtime,
+                &now,
+                true, // #1452: zero-vec sentinel → needs_embedding=1
+            )
+            .await?;
+            upsert_fts_conditional(&mut tx, &chunks_with_zero, &old_hashes).await?;
             tx.commit().await?;
             Ok(chunks.len())
         })
@@ -386,11 +456,20 @@ impl Store<ReadWrite> {
                 query.execute(&mut *tx).await?;
             }
 
-            // 3. Single UPDATE...FROM join (SQLite 3.33+)
+            // 3. Single UPDATE...FROM join (SQLite 3.33+).
+            //
+            // #1452: clear `needs_embedding=0` on rows that get a real
+            // embedding written. The first-pass-skip path writes
+            // chunks with `needs_embedding=1` + zero-vec sentinel; a
+            // subsequent enrichment_pass call lands here with the real
+            // vector and must clear the flag so the chunk becomes
+            // visible to HNSW build / search hydration. For chunks
+            // already at `needs_embedding=0` this is a no-op write.
             let result = sqlx::query(
                 "UPDATE chunks SET \
                     embedding = t.embedding, \
-                    enrichment_hash = COALESCE(t.enrichment_hash, chunks.enrichment_hash) \
+                    enrichment_hash = COALESCE(t.enrichment_hash, chunks.enrichment_hash), \
+                    needs_embedding = 0 \
                  FROM _update_embeddings t \
                  WHERE chunks.id = t.id",
             )
@@ -872,6 +951,7 @@ impl Store<ReadWrite> {
                 &vendored_per_chunk,
                 source_mtime,
                 &now,
+                false, // #1452: real embeddings → needs_embedding=0
             )
             .await?;
             upsert_fts_conditional(&mut tx, chunks, &old_hashes).await?;
@@ -1163,6 +1243,95 @@ mod tests {
         let count = store.upsert_chunks_batch(&[], Some(100)).unwrap();
         assert_eq!(count, 0);
         assert_eq!(store.chunk_count().unwrap(), 0);
+    }
+
+    // ===== #1452: needs_embedding flag round-trip =====
+
+    /// `upsert_chunks_unembedded_batch` writes chunks with `needs_embedding=1`
+    /// and a zero-vec sentinel in the `embedding` column. `needs_embedding_count`
+    /// reports them; `needs_embedding_ids` returns their IDs.
+    #[test]
+    fn upsert_unembedded_marks_needs_embedding_and_zero_vec() {
+        let (store, _dir) = setup_store();
+        let c1 = make_chunk("alpha", "src/a.rs");
+        let c2 = make_chunk("beta", "src/b.rs");
+
+        let count = store
+            .upsert_chunks_unembedded_batch(&[c1.clone(), c2.clone()], Some(100))
+            .unwrap();
+        assert_eq!(count, 2);
+
+        // Both chunks visible to the count query.
+        assert_eq!(store.needs_embedding_count().unwrap(), 2);
+        let ids = store.needs_embedding_ids().unwrap();
+        assert!(ids.contains(&c1.id));
+        assert!(ids.contains(&c2.id));
+
+        // The on-disk embedding is the zero-vec sentinel.
+        let embs = store
+            .get_embeddings_by_hashes(&[&c1.content_hash, &c2.content_hash])
+            .unwrap();
+        for (_, emb) in &embs {
+            assert!(
+                emb.as_slice().iter().all(|&x| x == 0.0),
+                "unembedded chunks must carry a zero-vec sentinel"
+            );
+        }
+    }
+
+    /// `update_embeddings_with_hashes_batch` (used by `enrichment_pass`)
+    /// clears `needs_embedding=0` on every row it writes, so the next
+    /// HNSW build / search picks up the chunk.
+    #[test]
+    fn enrichment_update_clears_needs_embedding() {
+        let (store, _dir) = setup_store();
+        let c = make_chunk("alpha", "src/a.rs");
+
+        store
+            .upsert_chunks_unembedded_batch(&[c.clone()], Some(100))
+            .unwrap();
+        assert_eq!(store.needs_embedding_count().unwrap(), 1);
+
+        // Land a real embedding (mimics enrichment_pass.flush_enrichment_batch).
+        let real_emb = mock_embedding(0.5);
+        let updates = vec![(c.id.clone(), real_emb, Some("hash".to_string()))];
+        store.update_embeddings_with_hashes_batch(&updates).unwrap();
+
+        // Flag cleared, count zero, ID gone from the set.
+        assert_eq!(store.needs_embedding_count().unwrap(), 0);
+        assert!(store.needs_embedding_ids().unwrap().is_empty());
+    }
+
+    /// First-pass-skip → enrichment-clear contract: search and HNSW build
+    /// both filter `needs_embedding=0`, so an unembedded chunk is invisible
+    /// from FTS-name search until enrichment lands its real vector.
+    #[test]
+    fn unembedded_chunks_invisible_from_name_search() {
+        let (store, _dir) = setup_store();
+        let c = make_chunk("alpha_function", "src/a.rs");
+
+        store
+            .upsert_chunks_unembedded_batch(&[c.clone()], Some(100))
+            .unwrap();
+
+        // Name search must NOT find the unembedded chunk.
+        let hits = store.search_by_name("alpha_function", 10).unwrap();
+        assert!(
+            hits.is_empty(),
+            "unembedded chunk must be invisible from name search; got {} hit(s)",
+            hits.len()
+        );
+
+        // After enrichment, the chunk surfaces.
+        let real_emb = mock_embedding(0.5);
+        let updates = vec![(c.id.clone(), real_emb, Some("hash".to_string()))];
+        store.update_embeddings_with_hashes_batch(&updates).unwrap();
+        let hits_post = store.search_by_name("alpha_function", 10).unwrap();
+        assert_eq!(
+            hits_post.len(),
+            1,
+            "after enrichment, the chunk must surface from name search"
+        );
     }
 
     /// #1221: end-to-end vendored-flag round-trip. With the default

--- a/src/store/chunks/query.rs
+++ b/src/store/chunks/query.rs
@@ -44,6 +44,44 @@ impl<Mode> Store<Mode> {
         })
     }
 
+    /// #1452: count of chunks awaiting a real embedding.
+    ///
+    /// Triggers `enrichment_pass` from `cmd_index` whenever `> 0` so the
+    /// first-pass-skip (`--llm-summaries` flow) doesn't leave chunks at
+    /// `needs_embedding=1` indefinitely. Backed by the partial index
+    /// `idx_chunks_needs_embedding` (v27 migration), so the lookup is
+    /// O(needs) regardless of total chunk count.
+    pub fn needs_embedding_count(&self) -> Result<u64, StoreError> {
+        let _span = tracing::debug_span!("needs_embedding_count").entered();
+        self.rt.block_on(async {
+            let row: (i64,) =
+                sqlx::query_as("SELECT COUNT(*) FROM chunks WHERE needs_embedding = 1")
+                    .fetch_one(&self.pool)
+                    .await?;
+            Ok(row.0 as u64)
+        })
+    }
+
+    /// #1452: chunk IDs awaiting a real embedding.
+    ///
+    /// Used by `enrichment_pass` to bypass the
+    /// "skip-chunks-with-no-enrichment-context" early-out for any chunk
+    /// that's still at `needs_embedding=1`. The base NL embedding is
+    /// equivalent to what the first-pass would have produced
+    /// (see `nl/mod.rs:104-108` — empty ctx + None summary collapses to
+    /// `generate_nl_description_with_seq_len`), so the chunk gets a
+    /// meaningful vector either way.
+    pub fn needs_embedding_ids(&self) -> Result<std::collections::HashSet<String>, StoreError> {
+        let _span = tracing::debug_span!("needs_embedding_ids").entered();
+        self.rt.block_on(async {
+            let rows: Vec<(String,)> =
+                sqlx::query_as("SELECT id FROM chunks WHERE needs_embedding = 1")
+                    .fetch_all(&self.pool)
+                    .await?;
+            Ok(rows.into_iter().map(|(id,)| id).collect())
+        })
+    }
+
     /// Get index statistics
     /// Uses batched queries to minimize database round trips:
     /// 1. Single query for counts with GROUP BY using CTEs

--- a/src/store/helpers/mod.rs
+++ b/src/store/helpers/mod.rs
@@ -139,7 +139,16 @@ pub(crate) fn bm25_ordering_expr() -> String {
 /// - v12: parent_type_name column for method->class association
 /// - v11: type_edges table for type-level dependency tracking
 /// - v10: sentiment in embeddings, call graph, notes
-pub const CURRENT_SCHEMA_VERSION: i32 = 26;
+///
+/// - v27: chunks.needs_embedding flag (#1452). Set on chunks written by
+///   the parser stage during a `--llm-summaries` reindex without a
+///   first-pass embed; cleared by `enrichment_pass` once a real embedding
+///   is written. `embedding` column stays `BLOB NOT NULL` (zero-vec
+///   sentinel for unembedded chunks); search-time and HNSW build paths
+///   filter `WHERE needs_embedding = 0` so chunks in the partial state
+///   are invisible until enrichment lands their real vector. The
+///   visibility gate is local — LLM summary failure does not block it.
+pub const CURRENT_SCHEMA_VERSION: i32 = 27;
 
 /// Default model name for metadata checks (used by test-only `check_model_version`).
 /// Canonical definition is `embedder::DEFAULT_MODEL_REPO`.

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -395,6 +395,7 @@ const MIGRATIONS: &[(i32, i32, MigrationFn)] = &[
     (23, 24, |c| Box::pin(migrate_v23_to_v24(c))),
     (24, 25, |c| Box::pin(migrate_v24_to_v25(c))),
     (25, 26, |c| Box::pin(migrate_v25_to_v26(c))),
+    (26, 27, |c| Box::pin(migrate_v26_to_v27(c))),
 ];
 
 /// Run a single migration step
@@ -973,6 +974,41 @@ async fn migrate_v25_to_v26(conn: &mut sqlx::SqliteConnection) -> Result<(), Sto
     Ok(())
 }
 
+/// v27: add `chunks.needs_embedding` flag for #1452. Pipeline can now skip
+/// the wasted first-pass embed when `--llm-summaries` is set (which guarantees
+/// `enrichment_pass` will overwrite every chunk's embedding anyway).
+/// Chunks written without a real embedding get `needs_embedding = 1` and a
+/// zero-vec sentinel in the `embedding` column; HNSW build + search paths
+/// filter `WHERE needs_embedding = 0` so those chunks are invisible until
+/// `enrichment_pass` lands their real vector and clears the flag.
+async fn migrate_v26_to_v27(conn: &mut sqlx::SqliteConnection) -> Result<(), StoreError> {
+    let _span = tracing::info_span!("migrate_v26_to_v27").entered();
+
+    // Add the flag with a default of 0 so every existing row is treated
+    // as embedded (which they are — pre-v27 there was no skip-first-pass
+    // path). Fresh DBs use the same default via schema.sql.
+    sqlx::query("ALTER TABLE chunks ADD COLUMN needs_embedding INTEGER NOT NULL DEFAULT 0")
+        .execute(&mut *conn)
+        .await?;
+
+    // Partial index on `needs_embedding = 1` so the rare "find chunks that
+    // still need embedding" lookup in `enrichment_pass` is O(needs)
+    // instead of O(total_chunks). Most chunks are embedded most of the
+    // time, so a partial index keeps the disk footprint negligible.
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_chunks_needs_embedding \
+         ON chunks(needs_embedding) WHERE needs_embedding = 1",
+    )
+    .execute(&mut *conn)
+    .await?;
+
+    tracing::info!(
+        "Migrated to v27: chunks.needs_embedding flag + partial index. \
+         Enables --llm-summaries first-pass-embed skip (#1452)."
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1005,7 +1041,7 @@ mod tests {
     #[test]
     fn test_current_schema_version_documented() {
         // Ensure the current version matches what we document
-        assert_eq!(CURRENT_SCHEMA_VERSION, 26);
+        assert_eq!(CURRENT_SCHEMA_VERSION, 27);
     }
 
     #[test]
@@ -3519,6 +3555,138 @@ mod tests {
                 assert_eq!(rsize, *size, "source_size round-trip for {id}");
                 assert_eq!(&rhash, hash, "source_content_hash round-trip for {id}");
             }
+        });
+    }
+
+    /// v27 / #1452: `chunks.needs_embedding` column added with DEFAULT 0.
+    /// Pre-migration rows must default to 0 (preserves "all chunks are
+    /// embedded" invariant from v26 era). The partial index
+    /// `idx_chunks_needs_embedding WHERE needs_embedding=1` is created so
+    /// `needs_embedding_count` is O(needs) regardless of total rows.
+    #[test]
+    fn test_migrate_v26_to_v27_adds_needs_embedding_flag() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        rt.block_on(async {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(
+                    sqlx::sqlite::SqliteConnectOptions::new()
+                        .filename(&db_path)
+                        .create_if_missing(true)
+                        .foreign_keys(true),
+                )
+                .await
+                .unwrap();
+
+            // Minimal v26 schema — pre-needs_embedding shape.
+            sqlx::query("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+                .execute(&pool)
+                .await
+                .unwrap();
+            sqlx::query(
+                "CREATE TABLE chunks (
+                    id TEXT PRIMARY KEY,
+                    origin TEXT NOT NULL,
+                    source_type TEXT NOT NULL,
+                    language TEXT NOT NULL,
+                    chunk_type TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    signature TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    content_hash TEXT NOT NULL,
+                    line_start INTEGER NOT NULL,
+                    line_end INTEGER NOT NULL,
+                    embedding BLOB NOT NULL,
+                    embedding_base BLOB,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    enrichment_version INTEGER NOT NULL DEFAULT 0,
+                    parser_version INTEGER NOT NULL DEFAULT 0,
+                    vendored INTEGER NOT NULL DEFAULT 0
+                )",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            sqlx::query("INSERT INTO metadata (key, value) VALUES ('schema_version', '26')")
+                .execute(&pool)
+                .await
+                .unwrap();
+
+            // Seed a pre-migration v26 chunk.
+            sqlx::query(
+                "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name, \
+                 signature, content, content_hash, line_start, line_end, embedding, \
+                 created_at, updated_at) \
+                 VALUES ('pre_v27', 'file:lib.rs', 'file', 'rust', 'function', 'pre_v27', \
+                 '', '', 'h', 1, 10, X'00', '2026-05-06', '2026-05-06')",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+
+            // Run v26 → v27 migration.
+            let pool = migrate(pool, &db_path, 26, 27).await.unwrap();
+
+            // Schema version bumped.
+            let (v,): (String,) =
+                sqlx::query_as("SELECT value FROM metadata WHERE key = 'schema_version'")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert_eq!(v, "27");
+
+            // Pre-migration row has needs_embedding = 0 (DEFAULT). Existing
+            // chunks were embedded under the v26 contract; the migration must
+            // not flip them to "needs embedding" or every reindex would
+            // re-enrich them and waste GPU.
+            let (pre_flag,): (i64,) =
+                sqlx::query_as("SELECT needs_embedding FROM chunks WHERE id = 'pre_v27'")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                pre_flag, 0,
+                "pre-migration chunk must retain needs_embedding=0 (already embedded)"
+            );
+
+            // The partial index exists.
+            let (idx_count,): (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type = 'index' AND name = 'idx_chunks_needs_embedding'",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(
+                idx_count, 1,
+                "v27 must create idx_chunks_needs_embedding partial index"
+            );
+
+            // Insert a fresh chunk with needs_embedding=1 and round-trip it.
+            sqlx::query(
+                "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name, \
+                 signature, content, content_hash, line_start, line_end, embedding, \
+                 created_at, updated_at, needs_embedding) \
+                 VALUES ('post_v27_unembedded', 'file:lib.rs', 'file', 'rust', 'function', \
+                 'post_v27_unembedded', '', '', 'h2', 1, 10, X'00', '2026-05-06', '2026-05-06', 1)",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            let (round_flag,): (i64,) = sqlx::query_as(
+                "SELECT needs_embedding FROM chunks WHERE id = 'post_v27_unembedded'",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(round_flag, 1);
         });
     }
 }

--- a/src/store/search.rs
+++ b/src/store/search.rs
@@ -129,8 +129,17 @@ impl<Mode> Store<Mode> {
         }
 
         self.rt.block_on(async {
+            // #1452: JOIN chunks + filter `needs_embedding = 0` so
+            // FTS-only candidates that haven't been embedded yet stay
+            // out of the RRF mix. They'd otherwise rank lower than
+            // expected (zero cosine score against zero-vec sentinel)
+            // and pollute the result list during a `--llm-summaries`
+            // reindex's partial state.
             let rows: Vec<(String,)> = sqlx::query_as(
-                "SELECT id FROM chunks_fts WHERE chunks_fts MATCH ?1 ORDER BY bm25(chunks_fts) LIMIT ?2",
+                "SELECT f.id FROM chunks_fts f \
+                 JOIN chunks c ON c.id = f.id \
+                 WHERE chunks_fts MATCH ?1 AND c.needs_embedding = 0 \
+                 ORDER BY bm25(chunks_fts) LIMIT ?2",
             )
             .bind(&normalized_query)
             .bind(limit as i64)
@@ -196,11 +205,16 @@ impl<Mode> Store<Mode> {
         // correct `trust_level` for chunks under `node_modules/`/`vendor/`.
         // Without that column the `ChunkRow::from_row` `try_get` falls back
         // to false and every vendored chunk masquerades as user-code.
+        // #1452: filter `c.needs_embedding = 0` so chunks in the partial
+        // state of a `--llm-summaries` reindex (parser stage written, not
+        // yet enriched) are invisible from name-search until enrichment
+        // lands their real embedding. Same visibility gate as HNSW build.
         let sql = format!(
             "SELECT {cols}
              FROM chunks c
              JOIN chunks_fts f ON c.id = f.id
              WHERE chunks_fts MATCH ?1
+               AND c.needs_embedding = 0
              ORDER BY {ord}
              LIMIT ?2",
             cols = super::helpers::CHUNK_ROW_SELECT_COLUMNS_PREFIXED,

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -17,7 +17,7 @@ fn test_store_init() {
     let stats = store.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
     assert_eq!(stats.total_files, 0);
-    assert_eq!(stats.schema_version, 26); // v26: idx_chunks_source_type_origin composite index for list_stale_files / prune_missing_files (#1371); chains v23→v24→v25→v26
+    assert_eq!(stats.schema_version, 27); // v27: chunks.needs_embedding flag for #1452 first-pass-skip; chains v23→v24→v25→v26→v27
     assert_eq!(stats.model_name, cqs::embedder::DEFAULT_MODEL_REPO);
 }
 
@@ -1115,7 +1115,7 @@ fn test_open_readonly_on_initialized_store() {
     let ro = cqs::store::Store::open_readonly(&db_path).unwrap();
     let stats = ro.stats().unwrap();
     assert_eq!(stats.total_chunks, 0);
-    assert_eq!(stats.schema_version, 26);
+    assert_eq!(stats.schema_version, 27);
     assert_eq!(stats.model_name, cqs::embedder::DEFAULT_MODEL_REPO);
 }
 


### PR DESCRIPTION
## Summary

Closes #1452. `cqs index --llm-summaries` previously embedded every chunk twice — once in the parser→embedder→writer pipeline and again in `enrichment_pass` (which produces NL = `summary + caller/callee names + chunk text` and overwrites the embedding). On a 12k-chunk Qwen3-4B reindex that's ~30 min of GPU time spent on embeddings that get discarded.

This PR routes the first pass to a sentinel write under `--llm-summaries`. Chunks land at `needs_embedding=1` with a zero-vec sentinel; HNSW build + search hide them; `enrichment_pass` lands the real vectors and clears the flag. Halves the GPU time on `--llm-summaries` reindexes.

## Schema

v27 migration adds `chunks.needs_embedding INTEGER NOT NULL DEFAULT 0` plus partial index `idx_chunks_needs_embedding WHERE needs_embedding=1`. Pre-migration rows default to 0 (preserves the v26 invariant — no false re-enrichment of existing data). `embedding` stays `BLOB NOT NULL` to avoid a table rebuild.

## Pipeline

| component | change |
|---|---|
| `EmbedStageContext` | new `skip_first_pass_embed: bool` field |
| `run_index_pipeline` | accepts `skip_first_pass_embed` (set by `cmd_index` when `--llm-summaries` is on; refs always pass `false`) |
| GPU + CPU embed stages | when set, cache hits pass through with real embeddings; cache-miss chunks get zero-vec sentinels and the batch is stamped `EmbeddedBatch::uncached_need_embedding = true` — `embed_documents()` is NEVER called for them |
| `store_stage` | slices each batch by `cached_count`; cached half → `upsert_chunks_and_calls` (real); sentinel half → new `Store::upsert_chunks_unembedded_batch` (`needs_embedding=1`) |

## Enrichment

- **Trigger condition extended**: `enrichment_pass` now fires when `needs_embedding > 0` in addition to today's `total_calls > 0`. Without this, a project with no call-graph would leave first-pass-skipped chunks invisible forever.
- **Per-chunk gate carve-out**: chunks at `needs_embedding=1` bypass the "no callers/callees/summary/hyde" early-skip — they have no embedding at all and need the base NL embedding minimum.
- **Ambiguous-name handling**: chunks at `needs_embedding=1` with ambiguous names use an EMPTY `CallContext` so they get the base NL embedding without inheriting unrelated callers. The base NL is byte-identical to what the first-pass would have produced (see `nl/mod.rs:104-108`), so no quality drift.
- **Flag clear-on-write**: `update_embeddings_with_hashes_batch` (the enrichment flush) now sets `needs_embedding=0` on every row it writes.

## Visibility

| path | filter |
|---|---|
| HNSW build (`IdHashEmbeddingIter`) | `WHERE embedding IS NOT NULL AND needs_embedding = 0` |
| `Store::search_by_name` (FTS-name) | JOIN + `WHERE c.needs_embedding = 0` |
| `Store::search_fts_only` (RRF candidates) | JOIN + `WHERE c.needs_embedding = 0` |

LLM is a **quality** dependency, not a visibility dependency: if the summary pass fails, `enrichment_pass` still runs and embeds chunks with whatever context exists (falling back to base NL when no summary). Failure modes leave chunks at `needs_embedding=1` so the next `cqs index` run picks them up — recoverable state.

## End-to-end smoke (this branch)

```
$ cd /tmp/cqs-smoke && CQS_CACHE_ENABLED=0 cqs index --force --llm-summaries
Embedding cache stats total=5 global_hits=0 store_hits=0 to_embed=5
Index complete:
Enriching embeddings with call graph context (5 chunks awaiting first embedding)...
  Enriched: 5 chunks

# Post-enrichment: schema=v27, all needs_embedding=0, embeddings nonzero, search returns hits
total chunks: 5
needs_embedding=1: 0
embedding bytes nonzero: True
search hits: 1
```

## Tests

| name | covers |
|---|---|
| `test_migrate_v26_to_v27_adds_needs_embedding_flag` | pre-migration rows default to 0, partial index created, flag round-trips |
| `upsert_unembedded_marks_needs_embedding_and_zero_vec` | `upsert_chunks_unembedded_batch` writes `needs_embedding=1` + zero-vec sentinel |
| `enrichment_update_clears_needs_embedding` | enrichment flush clears the flag (count 1 → 0) |
| `unembedded_chunks_invisible_from_name_search` | end-to-end visibility gate: chunk invisible from `search_by_name` while flagged, surfaces after enrichment |

## Test plan

- [x] `cargo test --features gpu-index --lib` — 2112 pass (4 new + 2108 existing)
- [x] `cargo test --features gpu-index --bin cqs` — 744 pass
- [x] `cargo test --features gpu-index --tests` — 2111 pass + 1 pre-existing HNSW concurrency flake (passes serially)
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] End-to-end smoke against fresh project: skip-first-pass fires, enrichment clears flags, search returns expected hits

Closes #1452.
