### PR TITLE
fix(store): embedding_base = NULL for skip-first-pass chunks (post-#1497)

### DIFF
--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -355,7 +355,23 @@ pub(super) async fn batch_insert_chunks(
                 // incoming embedding comes from raw NL (no enrichment), so on
                 // initial insert it IS the base. Enrichment pass later updates
                 // `embedding` only; `embedding_base` stays put for dual-index.
-                .push_bind(&embedding_bytes[emb_offset + i])
+                //
+                // #1452 follow-up: when `needs_embedding` is set, the bytes
+                // above are a zero-vec sentinel (skip-first-pass under
+                // `--llm-summaries`). Stamping that as `embedding_base` would
+                // poison the base HNSW (`build_hnsw_base_index` filters
+                // `WHERE embedding_base IS NOT NULL` — zero-vec passes the
+                // filter and joins the index with corrupt zeros). Bind NULL
+                // instead so partial-state chunks naturally drop out of the
+                // base index until a non-skip reindex of their content lands
+                // a real base-NL embedding. Coverage trade-off documented in
+                // CHANGELOG; the base index is the routing-fallback channel,
+                // not the main search path.
+                .push_bind(if needs_embedding {
+                    None::<&[u8]>
+                } else {
+                    Some(embedding_bytes[emb_offset + i].as_slice())
+                })
                 .push_bind(source_mtime)
                 .push_bind(now)
                 .push_bind(now)

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -1334,6 +1334,44 @@ mod tests {
         );
     }
 
+    /// #1452 follow-up: skip-first-pass writes `embedding_base = NULL`
+    /// (not the zero-vec sentinel). Otherwise `build_hnsw_base_index`
+    /// (`SELECT ... WHERE embedding_base IS NOT NULL`) would join the
+    /// base HNSW with corrupt zeros for every partial-state chunk —
+    /// the base index is the routing-fallback channel and silently
+    /// degrading it is the original-bug shape this PR fixed.
+    #[test]
+    fn unembedded_chunks_have_null_embedding_base() {
+        let (store, _dir) = setup_store();
+        let c = make_chunk("alpha", "src/a.rs");
+
+        store
+            .upsert_chunks_unembedded_batch(&[c.clone()], Some(100))
+            .unwrap();
+
+        // Pre-enrichment: embedding_base IS NULL (not zero-vec). The base
+        // index count query (`base_embedding_count`) drops these chunks.
+        assert_eq!(
+            store.base_embedding_count().unwrap(),
+            0,
+            "skip-first-pass chunks must be invisible to base_embedding_count"
+        );
+
+        // Post-enrichment: embedding overwrites with real bytes; embedding_base
+        // is intentionally LEFT NULL (the perf trade-off — base coverage is
+        // restored on a non-skip reindex of the chunk content).
+        let real_emb = mock_embedding(0.5);
+        let updates = vec![(c.id.clone(), real_emb, Some("hash".to_string()))];
+        store.update_embeddings_with_hashes_batch(&updates).unwrap();
+        assert_eq!(
+            store.base_embedding_count().unwrap(),
+            0,
+            "post-enrichment, base_embedding_count must STILL be 0 — \
+             enrichment refreshes only `embedding`, not `embedding_base`. \
+             Base coverage returns on the next non-skip reindex of the chunk."
+        );
+    }
+
     /// #1221: end-to-end vendored-flag round-trip. With the default
     /// prefix list configured on the store, a chunk whose origin
     /// passes through `vendor/` is upserted with `vendored = 1` and


### PR DESCRIPTION
## Summary

Pre-fix, `batch_insert_chunks` always seeded `embedding_base` with the same bytes as `embedding`. Under #1497's skip-first-pass path (`--llm-summaries`) that's the zero-vec sentinel — and `build_hnsw_base_index` (`base_embedding_count`) filters `WHERE embedding_base IS NOT NULL`, which zero-vec passes. So every partial-state chunk was joining the base HNSW with corrupt zeros, silently degrading the routing-fallback channel.

Fix: when the pipeline calls `batch_insert_chunks` with `needs_embedding=true`, bind NULL for `embedding_base` instead of the zero-vec. The existing `WHERE embedding_base IS NOT NULL` filter naturally drops these chunks from the base index until a non-skip reindex of their content lands a real base-NL embedding.

## Trade-off

Base index coverage degrades for chunks that only ever appear in `--llm-summaries` reindexes. Acceptable because the base index is the secondary routing channel (used for classification queries that should bypass summary text), not the main search path — better partial coverage than silently-corrupt coverage.

## Test

| name | covers |
|---|---|
| `unembedded_chunks_have_null_embedding_base` | pre-enrichment: `base_embedding_count() == 0` (NULL excludes the chunk); post-enrichment: still `0` (enrichment only writes `embedding`, not `embedding_base`) |

Refs #1452 (the bug was a follow-up gap I noticed during post-merge review of #1497).

## Test plan

- [x] `cargo test --features gpu-index --lib` — 2113 pass (1 new + 2112 from main)
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
