### PR TITLE
refactor(index): drop IndexBackendError wrapper, return StoreError directly (post-#1493)

### DIFF
--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -1485,7 +1485,7 @@ impl<Mode: crate::store::ClearHnswDirty> crate::index::IndexBackend<Mode> for Ca
     fn try_open(
         &self,
         ctx: &crate::index::BackendContext<'_, Mode>,
-    ) -> std::result::Result<Option<Box<dyn VectorIndex>>, crate::index::IndexBackendError> {
+    ) -> std::result::Result<Option<Box<dyn VectorIndex>>, crate::store::StoreError> {
         let cagra_threshold: u64 = std::env::var("CQS_CAGRA_THRESHOLD")
             .ok()
             .and_then(|v| v.parse().ok())

--- a/src/hnsw/mod.rs
+++ b/src/hnsw/mod.rs
@@ -552,7 +552,7 @@ impl<Mode: crate::store::ClearHnswDirty> crate::index::IndexBackend<Mode> for Hn
     fn try_open(
         &self,
         ctx: &crate::index::BackendContext<'_, Mode>,
-    ) -> std::result::Result<Option<Box<dyn VectorIndex>>, crate::index::IndexBackendError> {
+    ) -> std::result::Result<Option<Box<dyn VectorIndex>>, crate::store::StoreError> {
         let dirty = match ctx.store.is_hnsw_dirty(crate::HnswKind::Enriched) {
             Ok(d) => d,
             Err(e) => {

--- a/src/index.rs
+++ b/src/index.rs
@@ -5,46 +5,17 @@
 
 use std::path::Path;
 
-use thiserror::Error;
-
 use crate::embedder::Embedding;
 use crate::store::{ClearHnswDirty, Store, StoreError};
 
-/// Errors produced by [`IndexBackend::try_open`].
-///
-/// EH-V1.33-7 / #1374: previously `try_open` returned `anyhow::Result`,
-/// which leaked the `anyhow` dependency into a public lib-side trait
-/// (cqs convention is `thiserror` for library APIs, `anyhow` only in
-/// CLI). Most error paths in current backends — checksum mismatches,
-/// failed loads, dirty-flag-reads — are already self-handled with
-/// `tracing::warn!` + `Ok(None)` so the next backend can take over.
-/// The variants below are reserved for the small set of cases where a
-/// backend wants a hard failure to bubble up to the selector (currently
-/// unused; future backends like USearch / Metal / ROCm can adopt as
-/// needed). CLI sites consume this with `?` into `anyhow::Result` exactly
-/// as today via the `From` impl.
-///
-/// API-V1.36-6 (#1459 sub-6): the previous `ChecksumMismatch` and
-/// `LoadFailed` variants were documented as never-emitted — every
-/// backend converts internal load failures to `Ok(None)` and
-/// `tracing::warn!` to fall through to the next backend. Removing
-/// them tightens the type to "store-level abort only", matching the
-/// trait contract. Backend implementations that handle integrity
-/// failures internally still log via `tracing::warn!` and return
-/// `Ok(None)`, exactly as before.
-#[derive(Debug, Error)]
-pub enum IndexBackendError {
-    /// A backend-internal store query failed in a way that can't be
-    /// recovered by falling through to the next backend.
-    #[error("store error: {0}")]
-    Store(#[from] StoreError),
-}
-
-/// Convenience for CLI consumers that want to fold backend errors into
-/// `anyhow::Error` chains. Standard `thiserror`-derived error already
-/// implements `std::error::Error`, so `anyhow::Result<...>` accepts it
-/// via `?`.
-pub type Result<T> = std::result::Result<T, IndexBackendError>;
+// API-V1.36-6 follow-up: the `IndexBackendError` wrapper enum was a
+// single-variant `Store(StoreError)` after #1493 dropped its two
+// never-emitted variants. The wrapper added no information — every
+// non-fall-through error a backend produces is a store-level error,
+// every other failure mode is self-handled via `tracing::warn!` +
+// `Ok(None)`. The trait now returns `Result<_, StoreError>` directly;
+// `anyhow::Result<_>` still consumes it via `?` exactly as before
+// because `StoreError: std::error::Error`.
 
 /// Result from a vector index search
 #[derive(Debug, Clone)]
@@ -172,7 +143,7 @@ pub trait IndexBackend<Mode: ClearHnswDirty>: Send + Sync {
     fn try_open(
         &self,
         ctx: &BackendContext<'_, Mode>,
-    ) -> std::result::Result<Option<Box<dyn VectorIndex>>, IndexBackendError>;
+    ) -> std::result::Result<Option<Box<dyn VectorIndex>>, StoreError>;
 }
 
 /// #1348 / EX-V1.33-2: declare the registered backends as a single table.


### PR DESCRIPTION
## Summary

Post-#1493 cleanup. After dropping the `ChecksumMismatch` and `LoadFailed` variants, `IndexBackendError` was a single-variant `Store(StoreError)` wrapper that added zero information — every non-fall-through error a backend produces is store-level by the trait contract, every other failure mode is self-handled via `tracing::warn!` + `Ok(None)`.

Drop the wrapper:

| change | site |
|---|---|
| `IndexBackendError` enum + `Result<T>` type alias removed | `src/index.rs` |
| `IndexBackend::try_open` return tightens to `Result<_, StoreError>` | `src/index.rs:143` |
| HNSW backend impl updated | `src/hnsw/mod.rs:555` |
| CAGRA backend impl updated | `src/cagra.rs:1488` |

No behavior change. `anyhow::Result<_>` consumers continue to use `?` unchanged because `StoreError: std::error::Error`. The wrapper was an indirection layer left over from the original `anyhow::Result` → `thiserror` migration (#1374) — single-variant wrappers are zero-information abstraction we don't need.

## Test plan

- [x] `cargo test --features gpu-index --lib` — 2112 pass (no test changes; existing index/HNSW/CAGRA tests still green)
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Refs #1459 sub-6 / #1493 (cleanup of the post-merge gap I flagged in review).

Stat: 47 lines removed, 11 added (a wrapper + 25-line type doc comment).
