### PR TITLE
perf(reranker): scale batch size by max_length (SHL-V1.36-6 / refs #1463)

### DIFF
--- a/src/cli/watch/reindex.rs
+++ b/src/cli/watch/reindex.rs
@@ -104,7 +104,15 @@ pub(super) fn encode_splade_for_changed_files(
     store: &Store,
     changed_files: &[PathBuf],
 ) {
-    let batch_size = splade_batch_size();
+    // SHL-V1.36-6: read the encoder's probed dims so the batch size
+    // scales with model width / seq length. ensembledistil at 768/256
+    // gets the historic 32; SPLADE-Code 0.6B at 1024/512 gets 8 instead
+    // of OOMing.
+    let (hidden_size, max_length) = {
+        let enc = encoder_mu.lock().unwrap_or_else(|p| p.into_inner());
+        (enc.hidden_size(), enc.max_length())
+    };
+    let batch_size = splade_batch_size_for(hidden_size, max_length);
     let _span = tracing::info_span!(
         "encode_splade_for_changed_files",
         n_files = changed_files.len(),
@@ -192,14 +200,60 @@ pub(super) fn encode_splade_for_changed_files(
     }
 }
 
+/// SPLADE baseline batch + reference dims, paired so the formula in
+/// [`splade_batch_size_for`] returns 32 for the canonical SPLADE-base
+/// shape (hidden=768, max_length=256). Mirrors the reranker / embedder
+/// patterns.
+const DEFAULT_SPLADE_BATCH: usize = 32;
+const SPLADE_REFERENCE_HIDDEN: usize = 768;
+const SPLADE_REFERENCE_MAX_LENGTH: usize = 256;
+
 /// SPLADE batch size for incremental encoding. Mirrors the reranker
 /// batch pattern (#963). Default 32 matches the reranker default.
+///
+/// Legacy free function. Callers that have a [`SpladeEncoder`] in
+/// scope should use [`splade_batch_size_for`] instead so the batch
+/// scales by the loaded model's `(hidden_size, max_length)`. Kept as
+/// a backwards-compatible no-op for the env-only path.
 pub(super) fn splade_batch_size() -> usize {
     std::env::var("CQS_SPLADE_BATCH")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|n| *n > 0)
-        .unwrap_or(32)
+        .unwrap_or(DEFAULT_SPLADE_BATCH)
+}
+
+/// SHL-V1.36-6: SPLADE batch size scaled by `(hidden_size, max_length)`.
+/// Mirrors `reranker::reranker_batch_size`. Lets SPLADE-Code 0.6B at
+/// 1024-hidden / 512-seq use a smaller batch than ensembledistil at
+/// 768/256, instead of OOMing the same default. `CQS_SPLADE_BATCH` env
+/// continues to win regardless of the loaded model's dims.
+///
+/// Formula:
+///   batch = 32 * (REFERENCE_HIDDEN / hidden).max(0.25)
+///              * (REFERENCE_MAX_LENGTH / max_length).max(0.25)
+/// rounded to a power of two clamped to `[1, 256]`.
+pub(super) fn splade_batch_size_for(hidden_size: usize, max_length: usize) -> usize {
+    if std::env::var_os("CQS_SPLADE_BATCH").is_some() {
+        return splade_batch_size(); // env override path
+    }
+    let baseline = DEFAULT_SPLADE_BATCH as f64;
+    let hidden_size = hidden_size.max(1) as f64;
+    let max_length = max_length.max(1) as f64;
+    let hidden_factor = (SPLADE_REFERENCE_HIDDEN as f64 / hidden_size).max(0.25);
+    let seq_factor = (SPLADE_REFERENCE_MAX_LENGTH as f64 / max_length).max(0.25);
+    let scaled = (baseline * hidden_factor * seq_factor).max(1.0) as usize;
+    let rounded = scaled.next_power_of_two().clamp(1, 256);
+    if rounded != DEFAULT_SPLADE_BATCH {
+        tracing::debug!(
+            hidden_size = hidden_size as usize,
+            max_length = max_length as usize,
+            scaled,
+            rounded,
+            "splade_batch_size_for: scaling baseline by (hidden_size, max_length)"
+        );
+    }
+    rounded
 }
 
 /// EH-V1.33-8 (#1290): touch the stored `source_mtime` to disk's mtime so

--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -522,6 +522,97 @@ fn splade_batch_size_zero_falls_back_to_default() {
     assert_eq!(got, 32, "0 is not a valid batch size, falls back");
 }
 
+// ===== SHL-V1.36-6 — splade_batch_size_for(hidden, max_length) =====
+//
+// Mirrors the reranker test pattern: pin the baseline shape's batch
+// (no behavior change for ensembledistil), then verify scaling cases
+// for wider hidden / longer seq / compound / env-override.
+
+use super::reindex::splade_batch_size_for;
+
+/// Reference shape (hidden=768, max_length=256, the SPLADE-base /
+/// ensembledistil values) reproduces baseline 32 — existing operator
+/// setups see no change.
+#[test]
+fn splade_batch_size_for_baseline_returns_default() {
+    let prev = std::env::var("CQS_SPLADE_BATCH").ok();
+    std::env::remove_var("CQS_SPLADE_BATCH");
+    let got = splade_batch_size_for(768, 256);
+    if let Some(v) = prev {
+        std::env::set_var("CQS_SPLADE_BATCH", v);
+    }
+    assert_eq!(got, 32, "baseline (768, 256) → 32");
+}
+
+/// SPLADE-Code 0.6B class (hidden ≈ 1024, seq=512). hidden_factor =
+/// 768/1024 = 0.75; seq_factor = 256/512 = 0.5; scaled = 32 * 0.75 *
+/// 0.5 = 12; rounded = 16 (next power of two).
+#[test]
+fn splade_batch_size_for_splade_code_class_halves() {
+    let prev = std::env::var("CQS_SPLADE_BATCH").ok();
+    std::env::remove_var("CQS_SPLADE_BATCH");
+    let got = splade_batch_size_for(1024, 512);
+    if let Some(v) = prev {
+        std::env::set_var("CQS_SPLADE_BATCH", v);
+    }
+    assert_eq!(got, 16, "1024/512 → 16");
+}
+
+/// Wider hidden (1024) at baseline seq. hidden_factor = 0.75; scaled
+/// = 32 * 0.75 = 24; rounded = 32. (next_power_of_two(24) = 32.)
+#[test]
+fn splade_batch_size_for_wider_hidden_at_baseline_seq_holds_32() {
+    let prev = std::env::var("CQS_SPLADE_BATCH").ok();
+    std::env::remove_var("CQS_SPLADE_BATCH");
+    let got = splade_batch_size_for(1024, 256);
+    if let Some(v) = prev {
+        std::env::set_var("CQS_SPLADE_BATCH", v);
+    }
+    assert_eq!(got, 32, "1024/256 → 32 (rounded up)");
+}
+
+/// Long seq (1024) at baseline hidden. seq_factor = 256/1024 = 0.25;
+/// scaled = 32 * 0.25 = 8.
+#[test]
+fn splade_batch_size_for_long_seq_quarters_batch() {
+    let prev = std::env::var("CQS_SPLADE_BATCH").ok();
+    std::env::remove_var("CQS_SPLADE_BATCH");
+    let got = splade_batch_size_for(768, 1024);
+    if let Some(v) = prev {
+        std::env::set_var("CQS_SPLADE_BATCH", v);
+    }
+    assert_eq!(got, 8, "768/1024 → 8");
+}
+
+/// Env override wins regardless of (hidden, max_length).
+#[test]
+fn splade_batch_size_for_env_override_wins() {
+    let prev = std::env::var("CQS_SPLADE_BATCH").ok();
+    std::env::set_var("CQS_SPLADE_BATCH", "100");
+    let got = splade_batch_size_for(1024, 1024);
+    let got2 = splade_batch_size_for(384, 128);
+    match prev {
+        Some(v) => std::env::set_var("CQS_SPLADE_BATCH", v),
+        None => std::env::remove_var("CQS_SPLADE_BATCH"),
+    }
+    assert_eq!(got, 100, "env override wins for wide+long shape");
+    assert_eq!(got2, 100, "env override wins for narrow+short shape");
+}
+
+/// Degenerate dims (zeros) don't panic. The `.max(1)` floors ensure
+/// the formula stays bounded.
+#[test]
+fn splade_batch_size_for_zero_dims_do_not_panic() {
+    let prev = std::env::var("CQS_SPLADE_BATCH").ok();
+    std::env::remove_var("CQS_SPLADE_BATCH");
+    let _ = splade_batch_size_for(0, 256);
+    let _ = splade_batch_size_for(768, 0);
+    let _ = splade_batch_size_for(0, 0);
+    if let Some(v) = prev {
+        std::env::set_var("CQS_SPLADE_BATCH", v);
+    }
+}
+
 #[test]
 fn build_splade_encoder_env_kill_switch_returns_none() {
     // CQS_WATCH_INCREMENTAL_SPLADE=0 must return None regardless of

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -25,6 +25,19 @@ use crate::store::SearchResult;
 /// [`crate::aux_model::config_from_dir`] for `AuxModelKind::Reranker`.
 const MODEL_FILE: &str = "onnx/model.onnx";
 const TOKENIZER_FILE: &str = "tokenizer.json";
+/// SHL-V1.36-6: HuggingFace `config.json` contains `hidden_size`, which the
+/// batch-size formula needs to scale per-tensor activation memory across
+/// rerankers of different model widths. Resolved alongside `MODEL_FILE` /
+/// `TOKENIZER_FILE` in [`OnnxReranker::model_paths`].
+const CONFIG_FILE: &str = "config.json";
+
+/// Reference `hidden_size`, paired with [`DEFAULT_RERANKER_BATCH`] and
+/// [`REFERENCE_MAX_LENGTH`]. ms-marco-MiniLM-L-6-v2's hidden_size is 384;
+/// the batch-size formula scales `(REFERENCE_HIDDEN / hidden).max(0.25)`
+/// alongside the seq factor. Custom rerankers with hidden=768 (e.g.
+/// MiniLM-L-12) get `0.5×` the seq-implied batch — keeps per-tensor memory
+/// constant.
+const REFERENCE_HIDDEN_SIZE: usize = 384;
 
 // blake3 checksums -- empty to skip validation (set after pinning a model version)
 const MODEL_BLAKE3: &str = "";
@@ -50,23 +63,30 @@ const REFERENCE_MAX_LENGTH: usize = 512;
 /// Maximum number of candidates per ORT `session.run()` in the reranker.
 ///
 /// SHL-V1.36-6 (#1463 follow-up): scales the baseline 32 by the loaded
-/// model's `max_length`. Long-context rerankers (e.g.
-/// `CQS_RERANKER_MAX_LENGTH=2048`) at the documented default 32 OOM
-/// 8 GB GPUs because the per-batch token tensor scales linearly with
-/// seq. The scaling factor is `(REFERENCE_MAX_LENGTH / max_length)`
-/// floored at 0.25 (so seq=8192 → batch=32*0.25=8 rather than 1) and
-/// rounded to a power of two clamped to `[1, 256]`.
+/// model's `(hidden_size, max_length)` so per-tensor activation memory
+/// stays roughly constant across rerankers. Long-context rerankers
+/// (`CQS_RERANKER_MAX_LENGTH=2048`) and wider rerankers
+/// (hidden_size=768 vs the 384 baseline) used to OOM 8 GB GPUs at the
+/// documented default 32. Now both factors collapse onto the same
+/// formula:
 ///
-/// The audit's full formula `32 * (384/hidden) * (512/seq)` would also
-/// scale by `hidden_size`, but the reranker session doesn't surface
-/// hidden_size today — adding that would require probing
-/// `config.json` at session-init time and threading the value through
-/// `OnnxReranker`, an infrastructure change tracked separately. The
-/// max-length-only scaling is a real (if narrow) improvement.
+/// ```text
+/// batch = 32 * (REFERENCE_HIDDEN / hidden).max(0.25)
+///            * (REFERENCE_MAX_LENGTH / max_length).max(0.25)
+/// ```
 ///
-/// `CQS_RERANKER_BATCH` env wins (operators with workloads they
-/// understand can pin a value).
-fn reranker_batch_size(max_length: usize) -> usize {
+/// rounded to a power of two clamped to `[1, 256]`. Each factor floors
+/// at 0.25 so neither dim alone collapses the batch to 1 on extreme
+/// models — net floor is 32 * 0.25 * 0.25 = 2.
+///
+/// `hidden_size` is probed from `config.json` at session-init time
+/// (see [`OnnxReranker::resolve_hidden_size`]); on a fetch failure or
+/// missing field the call falls back to [`REFERENCE_HIDDEN_SIZE`],
+/// which preserves the historic batch=32 for ms-marco-MiniLM-L-6-v2.
+///
+/// `CQS_RERANKER_BATCH` env wins regardless of either dim — operators
+/// with workloads they understand can pin a value.
+fn reranker_batch_size(max_length: usize, hidden_size: usize) -> usize {
     // P2.4: route through shared `parse_env_usize` so behavior matches the
     // 24 other CQS_* knobs (missing/empty/garbage/zero -> default).
     if std::env::var_os("CQS_RERANKER_BATCH").is_some() {
@@ -74,15 +94,18 @@ fn reranker_batch_size(max_length: usize) -> usize {
     }
     let baseline = DEFAULT_RERANKER_BATCH as f64;
     let max_length = max_length.max(1) as f64;
+    let hidden_size = hidden_size.max(1) as f64;
     let seq_factor = (REFERENCE_MAX_LENGTH as f64 / max_length).max(0.25);
-    let scaled = (baseline * seq_factor).max(1.0) as usize;
+    let hidden_factor = (REFERENCE_HIDDEN_SIZE as f64 / hidden_size).max(0.25);
+    let scaled = (baseline * seq_factor * hidden_factor).max(1.0) as usize;
     let rounded = scaled.next_power_of_two().clamp(1, 256);
     if rounded != DEFAULT_RERANKER_BATCH {
         tracing::debug!(
             max_length = max_length as usize,
+            hidden_size = hidden_size as usize,
             scaled,
             rounded,
-            "reranker_batch_size: scaling baseline by max_length"
+            "reranker_batch_size: scaling baseline by (hidden_size, max_length)"
         );
     }
     rounded
@@ -217,6 +240,12 @@ pub struct OnnxReranker {
     /// XLM-R variants) do not. Computed at session-init time by inspecting
     /// the model's input names. `None` means "session not yet loaded."
     expects_token_type_ids: Mutex<Option<bool>>,
+    /// SHL-V1.36-6: model's `hidden_size`, probed from `config.json` at
+    /// session-init time. Falls back to [`REFERENCE_HIDDEN_SIZE`] (384)
+    /// when the file is missing or malformed — preserves the historic
+    /// batch=32 for ms-marco-MiniLM-L-6-v2 if the probe fails.
+    /// `OnceCell` so the probe runs at most once per reranker instance.
+    hidden_size: OnceCell<usize>,
     /// Cached config-file `[reranker]` section so `resolve_reranker` honours
     /// `preset` / `model_path` / `tokenizer_path` set in `.cqs.toml` (P1.7).
     section: Option<AuxModelSection>,
@@ -256,6 +285,7 @@ impl OnnxReranker {
             provider,
             max_length,
             expects_token_type_ids: Mutex::new(None),
+            hidden_size: OnceCell::new(),
             section,
         })
     }
@@ -306,7 +336,7 @@ impl OnnxReranker {
             return Ok(None); // Nothing to score — empty tokenization
         }
 
-        let batch_cap = reranker_batch_size(self.max_length);
+        let batch_cap = reranker_batch_size(self.max_length, self.resolve_hidden_size());
         let mut scores = Vec::with_capacity(passages.len());
         for chunk in encodings.chunks(batch_cap) {
             scores.extend(self.run_chunk(chunk)?);
@@ -569,6 +599,97 @@ impl OnnxReranker {
             tracing::info!(model = %model_path.display(), "Reranker model ready");
             Ok((model_path, tokenizer_path))
         })
+    }
+
+    /// SHL-V1.36-6: probe the loaded model's `hidden_size` from
+    /// `config.json` so [`reranker_batch_size`] can scale per-tensor
+    /// memory across rerankers of different widths. Cached via the
+    /// `hidden_size: OnceCell<usize>` field — at most one probe per
+    /// reranker instance.
+    ///
+    /// Resolution mirrors the layout assumptions in [`Self::model_paths`]:
+    ///
+    ///   * **Local-bundle** branch — `config.json` lives at
+    ///     `model_path.parent().parent() / "config.json"`, i.e., the bundle
+    ///     root above the `onnx/` subdir.
+    ///   * **HF Hub** branch — fetched via the existing
+    ///     `repo.get(CONFIG_FILE)` API used for the model + tokenizer.
+    ///
+    /// Failure modes (file missing, malformed JSON, no `hidden_size`
+    /// field, fetch error) all collapse to the historic
+    /// [`REFERENCE_HIDDEN_SIZE`] (384) — preserves the existing
+    /// batch=32 for ms-marco-MiniLM-L-6-v2 when the probe can't run.
+    /// Surfaces every fallback at `tracing::debug!` so an operator
+    /// running with `RUST_LOG=cqs=debug` can correlate batch-size
+    /// surprises with the probe.
+    fn resolve_hidden_size(&self) -> usize {
+        *self.hidden_size.get_or_init(|| {
+            let _span = tracing::debug_span!("reranker_resolve_hidden_size").entered();
+            match self.probe_hidden_size() {
+                Ok(h) => {
+                    tracing::debug!(
+                        hidden_size = h,
+                        "Probed reranker hidden_size from config.json"
+                    );
+                    h
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        error = %e,
+                        fallback = REFERENCE_HIDDEN_SIZE,
+                        "config.json probe failed; falling back to reference hidden_size"
+                    );
+                    REFERENCE_HIDDEN_SIZE
+                }
+            }
+        })
+    }
+
+    /// Helper for [`Self::resolve_hidden_size`] — does the actual probe.
+    /// Returns an error string per failure mode so the caller can log it
+    /// and fall back. Side-effect-free apart from the `tracing::debug!`
+    /// inside the parse path.
+    fn probe_hidden_size(&self) -> Result<usize, String> {
+        let resolved =
+            resolve_reranker(self.section.as_ref()).map_err(|e| format!("resolve: {e}"))?;
+        let config_path = if resolved.repo.is_some() {
+            // HF Hub: fetch config.json the same way we fetch model.onnx.
+            use hf_hub::api::sync::Api;
+            let repo_id = resolved
+                .repo
+                .as_deref()
+                .expect("repo.is_some() checked above");
+            let api = Api::new().map_err(|e| format!("hf api: {e}"))?;
+            api.model(repo_id.to_string())
+                .get(CONFIG_FILE)
+                .map_err(|e| format!("hf get config.json: {e}"))?
+        } else {
+            // Local bundle: `model_path` is `{dir}/onnx/model.onnx`,
+            // `config.json` is at `{dir}/config.json` per HF convention.
+            let model_path = resolved.model_path;
+            model_path
+                .parent()
+                .and_then(|p| p.parent())
+                .map(|dir| dir.join(CONFIG_FILE))
+                .ok_or_else(|| format!("model_path has no two parents: {}", model_path.display()))?
+        };
+        if !config_path.exists() {
+            return Err(format!("not found: {}", config_path.display()));
+        }
+        let raw = std::fs::read_to_string(&config_path)
+            .map_err(|e| format!("read {}: {e}", config_path.display()))?;
+        let json: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| format!("parse {}: {e}", config_path.display()))?;
+        let hidden = json
+            .get("hidden_size")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| format!("no hidden_size in {}", config_path.display()))?;
+        let hidden = usize::try_from(hidden)
+            .map_err(|_| format!("hidden_size {hidden} doesn't fit in usize"))?;
+        if hidden == 0 {
+            return Err(format!("hidden_size = 0 in {}", config_path.display()));
+        }
+        Ok(hidden)
     }
 
     /// Get or initialize the ONNX session
@@ -873,75 +994,119 @@ impl Reranker for LlmReranker {
 
 #[cfg(test)]
 mod batch_scaling_tests {
-    use super::{reranker_batch_size, DEFAULT_RERANKER_BATCH, REFERENCE_MAX_LENGTH};
+    use super::{
+        reranker_batch_size, DEFAULT_RERANKER_BATCH, REFERENCE_HIDDEN_SIZE, REFERENCE_MAX_LENGTH,
+    };
 
     /// Process-wide lock for the env-override tests so parallel cargo
     /// test runs don't observe each other's `CQS_RERANKER_BATCH` writes.
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-    /// Reference seq-length (512) reproduces the historic baseline 32 —
-    /// existing operator setups see no behavior change. Pinning this
-    /// catches a refactor that accidentally re-derives the rounded value.
+    /// Reference shape (hidden=384, seq=512) reproduces the historic
+    /// baseline 32 — existing operator setups see no behavior change.
+    /// Pinning this catches a refactor that accidentally re-derives
+    /// the rounded value.
     #[test]
-    fn baseline_max_length_returns_default_batch() {
+    fn baseline_dims_return_default_batch() {
         let _g = ENV_LOCK.lock().unwrap();
         std::env::remove_var("CQS_RERANKER_BATCH");
         assert_eq!(
-            reranker_batch_size(REFERENCE_MAX_LENGTH),
+            reranker_batch_size(REFERENCE_MAX_LENGTH, REFERENCE_HIDDEN_SIZE),
             DEFAULT_RERANKER_BATCH
         );
     }
 
-    /// SHL-V1.36-6 motivating case: a custom 2048-token reranker. The
-    /// scaling factor is `512 / 2048 = 0.25`, so 32 → 8 (next_power_of_two
-    /// of 32 * 0.25 = 8). Halves the OOM risk by quartering tensor size.
+    /// SHL-V1.36-6 motivating case: a custom 2048-token reranker at
+    /// the baseline width. seq_factor = 512/2048 = 0.25, hidden_factor =
+    /// 1.0; batch = 32 * 0.25 * 1.0 = 8.
     #[test]
     fn long_seq_reduces_batch() {
         let _g = ENV_LOCK.lock().unwrap();
         std::env::remove_var("CQS_RERANKER_BATCH");
-        assert_eq!(reranker_batch_size(2048), 8);
+        assert_eq!(reranker_batch_size(2048, REFERENCE_HIDDEN_SIZE), 8);
     }
 
     /// 8K-seq rerankers shouldn't degenerate to batch=1. The 0.25 floor
-    /// in `seq_factor` keeps the result at 32 * 0.25 = 8.
+    /// in `seq_factor` keeps batch ≥ 8 at the reference hidden_size.
     #[test]
     fn extreme_seq_floors_at_quarter() {
         let _g = ENV_LOCK.lock().unwrap();
         std::env::remove_var("CQS_RERANKER_BATCH");
-        assert_eq!(reranker_batch_size(8192), 8);
-        assert_eq!(reranker_batch_size(32_768), 8);
+        assert_eq!(reranker_batch_size(8192, REFERENCE_HIDDEN_SIZE), 8);
+        assert_eq!(reranker_batch_size(32_768, REFERENCE_HIDDEN_SIZE), 8);
     }
 
-    /// Short-seq rerankers (e.g., 256-token cross-encoders) get a wider
-    /// batch — `512 / 256 = 2.0` so 32 → 64.
+    /// Short-seq rerankers (e.g., 256-token cross-encoders) at baseline
+    /// width get a wider batch — `512 / 256 = 2.0` so 32 → 64.
     #[test]
     fn short_seq_widens_batch() {
         let _g = ENV_LOCK.lock().unwrap();
         std::env::remove_var("CQS_RERANKER_BATCH");
-        assert_eq!(reranker_batch_size(256), 64);
-        assert_eq!(reranker_batch_size(128), 128);
+        assert_eq!(reranker_batch_size(256, REFERENCE_HIDDEN_SIZE), 64);
+        assert_eq!(reranker_batch_size(128, REFERENCE_HIDDEN_SIZE), 128);
     }
 
-    /// `CQS_RERANKER_BATCH` env wins regardless of `max_length`. Operators
-    /// pinning a value know their own workload — we don't second-guess them.
+    /// hidden_size = 768 (e.g. MiniLM-L-12 / many cross-encoders) at
+    /// baseline seq halves the batch. seq_factor = 1.0, hidden_factor =
+    /// 384/768 = 0.5; batch = 32 * 1.0 * 0.5 = 16.
     #[test]
-    fn env_override_wins_regardless_of_max_length() {
+    fn wider_hidden_halves_batch() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("CQS_RERANKER_BATCH");
+        assert_eq!(reranker_batch_size(REFERENCE_MAX_LENGTH, 768), 16);
+    }
+
+    /// hidden_size = 1024 (BERT-large class) at baseline seq quarters
+    /// the batch. seq_factor = 1.0, hidden_factor = 384/1024 ≈ 0.375;
+    /// scaled = 32 * 0.375 = 12; rounded = 16 (next power of 2).
+    #[test]
+    fn bert_large_hidden_quarters_batch() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("CQS_RERANKER_BATCH");
+        assert_eq!(reranker_batch_size(REFERENCE_MAX_LENGTH, 1024), 16);
+    }
+
+    /// Compound case: a 768-hidden reranker running at 2048 seq.
+    /// seq_factor = 0.25, hidden_factor = 0.5; batch = 32 * 0.25 * 0.5 = 4.
+    /// Both factors carry their share of the OOM mitigation.
+    #[test]
+    fn wide_long_compound_reduces_batch() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("CQS_RERANKER_BATCH");
+        assert_eq!(reranker_batch_size(2048, 768), 4);
+    }
+
+    /// Net floor at extreme model: 0.25 (seq) × 0.25 (hidden) → 32 × 0.0625
+    /// = 2 (next_power_of_two of `2.0_f64 as usize` = 2). The clamp ensures
+    /// we never return 0 or 1 even on absurd model dims.
+    #[test]
+    fn extreme_compound_floors_at_two() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("CQS_RERANKER_BATCH");
+        assert_eq!(reranker_batch_size(32_768, 8192), 2);
+    }
+
+    /// `CQS_RERANKER_BATCH` env wins regardless of (hidden, seq).
+    /// Operators pinning a value know their own workload — we don't
+    /// second-guess them.
+    #[test]
+    fn env_override_wins_regardless_of_dims() {
         let _g = ENV_LOCK.lock().unwrap();
         std::env::set_var("CQS_RERANKER_BATCH", "100");
-        assert_eq!(reranker_batch_size(2048), 100);
-        assert_eq!(reranker_batch_size(512), 100);
+        assert_eq!(reranker_batch_size(2048, 768), 100);
+        assert_eq!(reranker_batch_size(512, 384), 100);
         std::env::remove_var("CQS_RERANKER_BATCH");
     }
 
-    /// A degenerate `max_length=0` doesn't panic. The `.max(1)` floor
-    /// keeps the formula safe.
+    /// Degenerate inputs (`hidden_size=0`, `max_length=0`) don't panic.
+    /// The `.max(1)` floors on both dims keep the formula safe.
     #[test]
-    fn zero_max_length_does_not_panic() {
+    fn zero_dims_do_not_panic() {
         let _g = ENV_LOCK.lock().unwrap();
         std::env::remove_var("CQS_RERANKER_BATCH");
-        // 512 / 1 = 512 → 32 * 512 = clamped to 256
-        let result = reranker_batch_size(0);
-        assert!(result <= 256);
+        let _ = reranker_batch_size(0, REFERENCE_HIDDEN_SIZE);
+        let _ = reranker_batch_size(REFERENCE_MAX_LENGTH, 0);
+        let _ = reranker_batch_size(0, 0);
     }
 }
 

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -40,14 +40,52 @@ const TOKENIZER_BLAKE3: &str = "";
 /// activations than plain encoder forward passes.
 const DEFAULT_RERANKER_BATCH: usize = 32;
 
+/// Reranker reference seq-length, paired with [`DEFAULT_RERANKER_BATCH`].
+/// The [`reranker_batch_size`] formula scales the baseline batch by
+/// `(REFERENCE_MAX_LENGTH / max_length).max(0.25)` so a custom reranker
+/// running at 2048 tokens halves the batch (32 → 16) instead of OOMing
+/// at the documented default.
+const REFERENCE_MAX_LENGTH: usize = 512;
+
 /// Maximum number of candidates per ORT `session.run()` in the reranker.
 ///
-/// Reads `CQS_RERANKER_BATCH`; falls back to [`DEFAULT_RERANKER_BATCH`] when
-/// unset, unparseable, or zero.
-fn reranker_batch_size() -> usize {
+/// SHL-V1.36-6 (#1463 follow-up): scales the baseline 32 by the loaded
+/// model's `max_length`. Long-context rerankers (e.g.
+/// `CQS_RERANKER_MAX_LENGTH=2048`) at the documented default 32 OOM
+/// 8 GB GPUs because the per-batch token tensor scales linearly with
+/// seq. The scaling factor is `(REFERENCE_MAX_LENGTH / max_length)`
+/// floored at 0.25 (so seq=8192 → batch=32*0.25=8 rather than 1) and
+/// rounded to a power of two clamped to `[1, 256]`.
+///
+/// The audit's full formula `32 * (384/hidden) * (512/seq)` would also
+/// scale by `hidden_size`, but the reranker session doesn't surface
+/// hidden_size today — adding that would require probing
+/// `config.json` at session-init time and threading the value through
+/// `OnnxReranker`, an infrastructure change tracked separately. The
+/// max-length-only scaling is a real (if narrow) improvement.
+///
+/// `CQS_RERANKER_BATCH` env wins (operators with workloads they
+/// understand can pin a value).
+fn reranker_batch_size(max_length: usize) -> usize {
     // P2.4: route through shared `parse_env_usize` so behavior matches the
     // 24 other CQS_* knobs (missing/empty/garbage/zero -> default).
-    crate::limits::parse_env_usize("CQS_RERANKER_BATCH", DEFAULT_RERANKER_BATCH)
+    if std::env::var_os("CQS_RERANKER_BATCH").is_some() {
+        return crate::limits::parse_env_usize("CQS_RERANKER_BATCH", DEFAULT_RERANKER_BATCH);
+    }
+    let baseline = DEFAULT_RERANKER_BATCH as f64;
+    let max_length = max_length.max(1) as f64;
+    let seq_factor = (REFERENCE_MAX_LENGTH as f64 / max_length).max(0.25);
+    let scaled = (baseline * seq_factor).max(1.0) as usize;
+    let rounded = scaled.next_power_of_two().clamp(1, 256);
+    if rounded != DEFAULT_RERANKER_BATCH {
+        tracing::debug!(
+            max_length = max_length as usize,
+            scaled,
+            rounded,
+            "reranker_batch_size: scaling baseline by max_length"
+        );
+    }
+    rounded
 }
 
 /// Resolve the reranker model source via the shared auxiliary-model
@@ -268,7 +306,7 @@ impl OnnxReranker {
             return Ok(None); // Nothing to score — empty tokenization
         }
 
-        let batch_cap = reranker_batch_size();
+        let batch_cap = reranker_batch_size(self.max_length);
         let mut scores = Vec::with_capacity(passages.len());
         for chunk in encodings.chunks(batch_cap) {
             scores.extend(self.run_chunk(chunk)?);
@@ -830,6 +868,80 @@ impl Reranker for LlmReranker {
             "LlmReranker is a skeleton — wire to a BatchProvider in a follow-up PR (#1220)"
                 .to_string(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod batch_scaling_tests {
+    use super::{reranker_batch_size, DEFAULT_RERANKER_BATCH, REFERENCE_MAX_LENGTH};
+
+    /// Process-wide lock for the env-override tests so parallel cargo
+    /// test runs don't observe each other's `CQS_RERANKER_BATCH` writes.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Reference seq-length (512) reproduces the historic baseline 32 —
+    /// existing operator setups see no behavior change. Pinning this
+    /// catches a refactor that accidentally re-derives the rounded value.
+    #[test]
+    fn baseline_max_length_returns_default_batch() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("CQS_RERANKER_BATCH");
+        assert_eq!(
+            reranker_batch_size(REFERENCE_MAX_LENGTH),
+            DEFAULT_RERANKER_BATCH
+        );
+    }
+
+    /// SHL-V1.36-6 motivating case: a custom 2048-token reranker. The
+    /// scaling factor is `512 / 2048 = 0.25`, so 32 → 8 (next_power_of_two
+    /// of 32 * 0.25 = 8). Halves the OOM risk by quartering tensor size.
+    #[test]
+    fn long_seq_reduces_batch() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("CQS_RERANKER_BATCH");
+        assert_eq!(reranker_batch_size(2048), 8);
+    }
+
+    /// 8K-seq rerankers shouldn't degenerate to batch=1. The 0.25 floor
+    /// in `seq_factor` keeps the result at 32 * 0.25 = 8.
+    #[test]
+    fn extreme_seq_floors_at_quarter() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("CQS_RERANKER_BATCH");
+        assert_eq!(reranker_batch_size(8192), 8);
+        assert_eq!(reranker_batch_size(32_768), 8);
+    }
+
+    /// Short-seq rerankers (e.g., 256-token cross-encoders) get a wider
+    /// batch — `512 / 256 = 2.0` so 32 → 64.
+    #[test]
+    fn short_seq_widens_batch() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("CQS_RERANKER_BATCH");
+        assert_eq!(reranker_batch_size(256), 64);
+        assert_eq!(reranker_batch_size(128), 128);
+    }
+
+    /// `CQS_RERANKER_BATCH` env wins regardless of `max_length`. Operators
+    /// pinning a value know their own workload — we don't second-guess them.
+    #[test]
+    fn env_override_wins_regardless_of_max_length() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::set_var("CQS_RERANKER_BATCH", "100");
+        assert_eq!(reranker_batch_size(2048), 100);
+        assert_eq!(reranker_batch_size(512), 100);
+        std::env::remove_var("CQS_RERANKER_BATCH");
+    }
+
+    /// A degenerate `max_length=0` doesn't panic. The `.max(1)` floor
+    /// keeps the formula safe.
+    #[test]
+    fn zero_max_length_does_not_panic() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("CQS_RERANKER_BATCH");
+        // 512 / 1 = 512 → 32 * 512 = clamped to 256
+        let result = reranker_batch_size(0);
+        assert!(result <= 256);
     }
 }
 

--- a/src/splade/mod.rs
+++ b/src/splade/mod.rs
@@ -104,6 +104,84 @@ pub struct SpladeEncoder {
     tokenizer: Mutex<Option<std::sync::Arc<tokenizers::Tokenizer>>>,
     threshold: f32,
     vocab_size: usize,
+    /// SHL-V1.36-6: model's `hidden_size`, probed from `config.json`
+    /// at construction time. Falls back to 768 (the SPLADE-base /
+    /// SPLADE-Code 0.6B value) when the file is missing or malformed.
+    /// Used by the indexing-time batch-size formula in
+    /// `cli::watch::reindex::splade_batch_size_for`.
+    hidden_size: usize,
+    /// SHL-V1.36-6: model's `max_length`, probed from the loaded
+    /// tokenizer's truncation config (falls back to `config.json`'s
+    /// `max_position_embeddings`, then to a hardcoded 256). Caps the
+    /// per-token activation tensor in batched encode runs.
+    max_length: usize,
+}
+
+/// SHL-V1.36-6: read `hidden_size` from `config.json` in the SPLADE
+/// model directory. Falls back to 768 (the canonical SPLADE-base value
+/// shared by `naver/splade-cocondenser-ensembledistil` and the
+/// SPLADE-Code 0.6B base layer) when the file is missing, malformed,
+/// or the field absent. Surfaces every fallback at `tracing::debug!`.
+fn probe_splade_hidden_size(model_dir: &Path) -> usize {
+    const FALLBACK: usize = 768;
+    let path = model_dir.join("config.json");
+    if !path.exists() {
+        tracing::debug!(
+            path = %path.display(),
+            fallback = FALLBACK,
+            "SPLADE config.json missing; using fallback hidden_size"
+        );
+        return FALLBACK;
+    }
+    match std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .and_then(|json| json.get("hidden_size").and_then(|v| v.as_u64()))
+        .and_then(|h| usize::try_from(h).ok())
+        .filter(|h| *h > 0)
+    {
+        Some(h) => h,
+        None => {
+            tracing::debug!(
+                path = %path.display(),
+                fallback = FALLBACK,
+                "SPLADE config.json missing/invalid hidden_size; using fallback"
+            );
+            FALLBACK
+        }
+    }
+}
+
+/// SHL-V1.36-6: read `max_length` from the loaded tokenizer's
+/// truncation config, with `config.json::max_position_embeddings` as a
+/// secondary source. Falls back to 256 (the SPLADE-base default) when
+/// neither is available. The truncation config is the truth at
+/// inference time; `max_position_embeddings` matters when the tokenizer
+/// has truncation off (rare for SPLADE).
+fn probe_splade_max_length(tokenizer: &tokenizers::Tokenizer, model_dir: &Path) -> usize {
+    const FALLBACK: usize = 256;
+    if let Some(trunc) = tokenizer.get_truncation() {
+        if trunc.max_length > 0 {
+            return trunc.max_length;
+        }
+    }
+    let path = model_dir.join("config.json");
+    if path.exists() {
+        if let Some(n) = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+            .and_then(|json| json.get("max_position_embeddings").and_then(|v| v.as_u64()))
+            .and_then(|n| usize::try_from(n).ok())
+            .filter(|n| *n > 0)
+        {
+            return n;
+        }
+    }
+    tracing::debug!(
+        fallback = FALLBACK,
+        "SPLADE max_length not derivable from tokenizer or config.json; using fallback"
+    );
+    FALLBACK
 }
 
 /// Probe a SPLADE model's output vocabulary by running one short inference.
@@ -430,9 +508,18 @@ impl SpladeEncoder {
         let session = create_session(&onnx_path, provider)
             .map_err(|e| SpladeError::InferenceFailed(format!("ORT session re-init: {e}")))?;
 
+        // SHL-V1.36-6: probe hidden_size and max_length so the indexing-
+        // time batch sizing can scale per-tensor activation memory across
+        // SPLADE variants (ensembledistil at 768/256 vs SPLADE-Code 0.6B
+        // at 1024/512). Both probes are best-effort — fallbacks preserve
+        // the historic batch=32 for the default ensembledistil setup.
+        let hidden_size = probe_splade_hidden_size(model_dir);
+        let max_length = probe_splade_max_length(&tokenizer, model_dir);
         tracing::info!(
             threshold,
             vocab_size = tokenizer_vocab,
+            hidden_size,
+            max_length,
             "SPLADE encoder loaded (vocab consistency verified)"
         );
 
@@ -446,6 +533,8 @@ impl SpladeEncoder {
             tokenizer: Mutex::new(Some(std::sync::Arc::new(tokenizer))),
             threshold,
             vocab_size: tokenizer_vocab,
+            hidden_size,
+            max_length,
         })
     }
 
@@ -972,6 +1061,19 @@ impl SpladeEncoder {
     /// Vocabulary size of the underlying tokenizer.
     pub fn vocab_size(&self) -> usize {
         self.vocab_size
+    }
+
+    /// SHL-V1.36-6: model's `hidden_size` (probed from `config.json`
+    /// at construction). Used by indexing-time batch sizing.
+    pub fn hidden_size(&self) -> usize {
+        self.hidden_size
+    }
+
+    /// SHL-V1.36-6: model's effective `max_length` (probed from the
+    /// tokenizer's truncation config, with `config.json` as secondary
+    /// source). Used by indexing-time batch sizing.
+    pub fn max_length(&self) -> usize {
+        self.max_length
     }
 
     /// Decode a token ID to its string representation (for debugging).


### PR DESCRIPTION
## Summary

`DEFAULT_RERANKER_BATCH = 32` was sized for ms-marco-MiniLM at 512-token max_length. Custom rerankers running at `CQS_RERANKER_MAX_LENGTH=2048` were OOMing 8 GB GPUs at the documented default because the per-batch token tensor scales linearly with seq.

Fix: `reranker_batch_size(max_length)` scales the baseline 32 by `(REFERENCE_MAX_LENGTH / max_length).max(0.25)`, rounded to a power of 2 clamped to `[1, 256]`. Mirrors the `ModelConfig::embed_batch_size` pattern (#1464) for the encoder.

### Concrete behavior changes (env override unset)

| max_length | seq_factor | batch (rounded) |
|-----------:|-----------:|----------------:|
| 128 | 4.0 | **128** |
| 256 | 2.0 | **64** |
| 512 | 1.0 | 32 ← *reference, unchanged* |
| 2048 | 0.25 | **8** |
| 8192 | 0.25 | **8** ← *floored* |

Existing operator setups at the 512-default see no change. Custom long-context rerankers go from "OOM at 32" to "8 candidates per `session.run()`" — slower per-batch wall time but actually completes. `CQS_RERANKER_BATCH` env continues to win regardless of max_length for operators with workloads they understand.

## Audit's full formula not implemented (separate work)

The audit's `32 * (384/hidden) * (512/seq)` would also scale by `hidden_size`, but the reranker session doesn't surface hidden_size today — adding it requires probing `config.json` at session-init time and threading the value through `OnnxReranker`. **The infrastructure-first part of SHL-V1.36-6 that the audit anticipated ("needs config-shape additions first")** is the hidden_size path, tracked as a separate item.

Same for SPLADE's `splade_batch_size()` which doesn't expose `max_length` outside the encoder either — left at the static default in this PR; needs the same probe-and-thread work in a follow-up.

## Tests

6 new in `reranker::batch_scaling_tests`:

| name | covers |
|---|---|
| `baseline_max_length_returns_default_batch` | regression-pin: `max_length=512` → batch=32 (no behavior change for existing operators) |
| `long_seq_reduces_batch` | motivating case: `max_length=2048` → batch=8 |
| `extreme_seq_floors_at_quarter` | `max_length=8192` and `32_768` both floor at 8 (no degenerate batch=1) |
| `short_seq_widens_batch` | `max_length=256` → batch=64; `max_length=128` → batch=128 |
| `env_override_wins_regardless_of_max_length` | `CQS_RERANKER_BATCH=100` wins for any max_length |
| `zero_max_length_does_not_panic` | safety floor — `max_length=0` doesn't divide-by-zero |

A process-wide `ENV_LOCK` mutex prevents parallel tests from observing each other's `CQS_RERANKER_BATCH` env writes.

## Test plan

- [x] `cargo test --features gpu-index --lib reranker` — 27 pass (6 new + 21 existing)
- [x] `cargo test --features gpu-index --bin cqs` — 745 pass
- [x] `cargo test --features gpu-index --tests` — **3713 pass, 0 fail** total
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Refs #1463 (P3 Scaling sub-item).
