### PR TITLE
fix(cli): cmd_model_swap bails on metadata read error (P1-18 / #1456)

### DIFF
--- a/src/cli/commands/infra/model.rs
+++ b/src/cli/commands/infra/model.rs
@@ -380,10 +380,25 @@ fn cmd_model_swap(cli: &Cli, preset: &str, no_backup: bool, json: bool) -> Resul
 
     // 2. Read current model. Used both for the no-op short-circuit and the
     //    backup-directory name.
+    //
+    // P1-18 (#1456 follow-up): use the strict variant so a corrupted-metadata
+    // read isn't conflated with "fresh DB". A lossy `None` here would make
+    // `already_on_target` false and we'd proceed with the destructive
+    // backup+rebuild against an unreadable but possibly recoverable index.
     let current_model = {
         let store = Store::open_readonly(&index_path)
             .with_context(|| format!("Failed to open index at {}", index_path.display()))?;
-        store.stored_model_name().unwrap_or_default()
+        store
+            .try_stored_model_name()
+            .with_context(|| {
+                format!(
+                    "Failed to read model_name from {} metadata — refusing to swap; \
+                     re-run `cqs index --force --model {preset}` if the index is \
+                     known-bad",
+                    index_path.display()
+                )
+            })?
+            .unwrap_or_default()
     };
 
     let already_on_target = !current_model.is_empty()


### PR DESCRIPTION
## Summary

`cqs model swap` now propagates SQLite errors from metadata reads instead of treating them as "fresh DB". Closes **P1-18** from #1456 follow-up table.

## Why

`cmd_model_swap` read `current_model` via `stored_model_name()` — the lossy accessor that converts a real read error into `None`. The downstream no-op short-circuit then sees an empty `current_model`, sets `already_on_target = false`, and proceeds with the destructive `mv .cqs/ → .cqs.<old>.bak/` + reindex against an unreadable but possibly recoverable index.

EH-V1.36-6 already shipped the strict variant `try_stored_model_name` for exactly this case. Wire it in here.

## Change

```diff
-    let current_model = {
-        let store = Store::open_readonly(&index_path)
-            .with_context(|| format!("Failed to open index at {}", index_path.display()))?;
-        store.stored_model_name().unwrap_or_default()
-    };
+    let current_model = {
+        let store = Store::open_readonly(&index_path)
+            .with_context(|| format!("Failed to open index at {}", index_path.display()))?;
+        store
+            .try_stored_model_name()
+            .with_context(|| {
+                format!(
+                    "Failed to read model_name from {} metadata — refusing to swap; \
+                     re-run `cqs index --force --model {preset}` if the index is \
+                     known-bad",
+                    index_path.display()
+                )
+            })?
+            .unwrap_or_default()
+    };
```

## What's NOT in scope

Other callers of `stored_model_name()` are intentionally left lossy:

| Caller | Path | Why lossy is correct |
|---|---|---|
| `cqs model show` | `model.rs:240` | Read-only display — `<unrecorded>` is informative, not load-bearing |
| `slot list` | `slot.rs:206` | Render slot table — None means "couldn't read", caller already logs |
| `cqs doctor` | `doctor.rs:154,344,1028` | Diagnostic — corrupt-metadata is one of the things doctor reports |
| Watch rebuild | `rebuild.rs:187` | Best-effort: falls through to CLI/env/config resolution + warns |
| Batch dispatch | `batch/mod.rs:2348` | Same chain as watch rebuild |
| Shell completion | `model.rs:999` | Tab help — None = empty completion is fine |

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo clippy --features gpu-index --lib -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --features gpu-index --lib model_swap` — pass (existing tests cover output shape; the underlying `try_stored_model_name` error contract is tested in `src/store/metadata.rs`)
- [ ] Full CI green
- [ ] Smoke post-merge: `cqs model swap <preset>` against a known-good index still works (regression-guarded by clippy + existing `cmd_model_swap` integration paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
