### PR TITLE
fix(store, batch): close needs_embedding wiring gaps + slot-aware staleness (Cluster A / #1463)

### DIFF
--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -480,7 +480,8 @@ impl BatchContext {
         }
         self.last_staleness_check.set(Some(now));
 
-        let index_path = self.cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        // DS-V1.38-3 (#1463): slot-aware index resolution.
+        let index_path = cqs::resolve_index_db(&self.cqs_dir);
         let current_id = match DbFileIdentity::from_path(&index_path) {
             Some(id) => id,
             None => {
@@ -604,7 +605,8 @@ impl BatchContext {
         let _span = tracing::info_span!("batch_manual_invalidation").entered();
         self.invalidate_mutable_caches();
 
-        let index_path = self.cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        // DS-V1.38-3 (#1463): slot-aware index resolution.
+        let index_path = cqs::resolve_index_db(&self.cqs_dir);
         // #968: pass the shared runtime so manual refreshes keep using
         // the same worker pool as the session they're refreshing.
         let new_store =
@@ -785,7 +787,8 @@ impl BatchContext {
         // RB-3: surface overflow as None (treated same as "missing mtime")
         // instead of silently wrapping past `i64::MAX`. Different shape from
         // `unix_secs_i64()` — reads file mtime, not wall-clock.
-        let last_indexed_at = std::fs::metadata(self.cqs_dir.join(cqs::INDEX_DB_FILENAME))
+        // DS-V1.38-3 (#1463): slot-aware index resolution.
+        let last_indexed_at = std::fs::metadata(cqs::resolve_index_db(&self.cqs_dir))
             .ok()
             .and_then(|m| m.modified().ok())
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
@@ -2040,7 +2043,8 @@ impl BatchView {
         // RB-3: surface overflow as None (treated same as "missing mtime")
         // instead of silently wrapping past `i64::MAX`. Different shape from
         // `unix_secs_i64()` — reads file mtime, not wall-clock.
-        let last_indexed_at = std::fs::metadata(self.cqs_dir.join(cqs::INDEX_DB_FILENAME))
+        // DS-V1.38-3 (#1463): slot-aware index resolution.
+        let last_indexed_at = std::fs::metadata(cqs::resolve_index_db(&self.cqs_dir))
             .ok()
             .and_then(|m| m.modified().ok())
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
@@ -2334,7 +2338,15 @@ pub(crate) fn create_context_with_runtime(
     // Capture initial index.db identity (inode/size/mtime on unix).
     // DS-V1.25-6: previously this was mtime alone, which sub-second
     // replacements on WSL NTFS could miss.
-    let index_id = DbFileIdentity::from_path(&cqs_dir.join(cqs::INDEX_DB_FILENAME));
+    // DS-V1.38-3 (#1463): stat the slot-aware index path, not
+    // `cqs_dir/index.db` directly. After PR #1105 a slot-migrated
+    // project keeps the live DB at `.cqs/slots/<active>/index.db`;
+    // a literal `cqs_dir/index.db` join points at a path that
+    // doesn't exist, `from_path` returns None, and the daemon's
+    // mutable caches never invalidate when the operator runs
+    // `cqs index`. `resolve_index_db` honors slot resolution and
+    // falls back cleanly on legacy projects.
+    let index_id = DbFileIdentity::from_path(&cqs::resolve_index_db(&cqs_dir));
     if index_id.is_none() {
         tracing::debug!("Could not stat index.db — staleness detection will be skipped until first successful stat");
     }

--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -562,9 +562,17 @@ impl<'a, Mode> Iterator for EmbeddingBatchIterator<'a, Mode> {
             };
 
             let result = self.store.rt.block_on(async {
+                // DS-V1.38-1 (#1463 / #1452 follow-up): exclude chunks with
+                // `needs_embedding=1` so production callers (CAGRA build,
+                // UMAP projection, brute-force kNN in `cqs neighbors`) don't
+                // load zero-vec sentinels into their search structures.
+                // The sibling `EmbeddingHashBatchIterator` already had this
+                // gate; without it here, `--llm-summaries` chunks land in
+                // CAGRA's flat buffer as (0,…,0) and the index advertises a
+                // search neighborhood of "things near the origin" for them.
                 let sql = format!(
                     "SELECT rowid, id, {col} FROM chunks \
-                     WHERE rowid > ?1 AND {col} IS NOT NULL \
+                     WHERE rowid > ?1 AND {col} IS NOT NULL AND needs_embedding = 0 \
                      ORDER BY rowid ASC LIMIT ?2"
                 );
                 let rows: Vec<_> = sqlx::query(&sql)

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -465,9 +465,26 @@ impl Store<ReadWrite> {
             // vector and must clear the flag so the chunk becomes
             // visible to HNSW build / search hydration. For chunks
             // already at `needs_embedding=0` this is a no-op write.
+            //
+            // DS-V1.38-2 (#1463): also repopulate `embedding_base` when
+            // it was previously NULL. The first-pass-skip path inserts
+            // chunks with `embedding_base = NULL` (per
+            // `upsert_chunks_unembedded_batch`); without this, every
+            // `--llm-summaries` reindex permanently leaves the chunk
+            // invisible to `build_hnsw_base_index` (which filters
+            // `WHERE embedding_base IS NOT NULL`), silently degrading
+            // the DenseBase routing target (conceptual / behavioral /
+            // negation queries).
+            //
+            // Using `COALESCE(chunks.embedding_base, t.embedding)`
+            // preserves the prior base bytes for chunks that were
+            // already populated, so the enrichment-time second pass
+            // (which overwrites `embedding` with the call-context
+            // enriched vector) doesn't trash their base copy.
             let result = sqlx::query(
                 "UPDATE chunks SET \
                     embedding = t.embedding, \
+                    embedding_base = COALESCE(chunks.embedding_base, t.embedding), \
                     enrichment_hash = COALESCE(t.enrichment_hash, chunks.enrichment_hash), \
                     needs_embedding = 0 \
                  FROM _update_embeddings t \
@@ -1340,6 +1357,14 @@ mod tests {
     /// base HNSW with corrupt zeros for every partial-state chunk —
     /// the base index is the routing-fallback channel and silently
     /// degrading it is the original-bug shape this PR fixed.
+    ///
+    /// DS-V1.38-2 (#1463) follow-up: `update_embeddings_with_hashes_batch`
+    /// now repopulates `embedding_base` (when previously NULL) using
+    /// `COALESCE(chunks.embedding_base, t.embedding)`. Pre-fix every
+    /// `--llm-summaries` cycle permanently degraded base-HNSW coverage
+    /// for affected chunks; post-fix the first enrichment hit fills
+    /// the base bytes and the chunk becomes routable on the DenseBase
+    /// path (conceptual / behavioral / negation queries).
     #[test]
     fn unembedded_chunks_have_null_embedding_base() {
         let (store, _dir) = setup_store();
@@ -1357,20 +1382,27 @@ mod tests {
             "skip-first-pass chunks must be invisible to base_embedding_count"
         );
 
-        // Post-enrichment: embedding overwrites with real bytes; embedding_base
-        // is intentionally LEFT NULL (the perf trade-off — base coverage is
-        // restored on a non-skip reindex of the chunk content).
+        // Post-enrichment: enrichment writes the real `embedding` AND
+        // repopulates the previously-NULL `embedding_base` (DS-V1.38-2).
+        // The base index now sees the chunk and DenseBase routing serves
+        // it correctly.
         let real_emb = mock_embedding(0.5);
         let updates = vec![(c.id.clone(), real_emb, Some("hash".to_string()))];
         store.update_embeddings_with_hashes_batch(&updates).unwrap();
         assert_eq!(
             store.base_embedding_count().unwrap(),
-            0,
-            "post-enrichment, base_embedding_count must STILL be 0 — \
-             enrichment refreshes only `embedding`, not `embedding_base`. \
-             Base coverage returns on the next non-skip reindex of the chunk."
+            1,
+            "DS-V1.38-2: post-enrichment, base_embedding_count must be 1 — \
+             enrichment refreshes `embedding` AND repopulates a previously-NULL \
+             `embedding_base` so base-HNSW coverage closes for `--llm-summaries` chunks."
         );
     }
+
+    // DS-V1.38-2 (#1463): the "preserve existing embedding_base" invariant
+    // is already covered by `test_enrichment_does_not_overwrite_base` in
+    // `src/store/chunks/async_helpers.rs`. The above test
+    // (`unembedded_chunks_have_null_embedding_base`) covers the
+    // sibling NULL → COALESCE → repopulate case introduced by DS-V1.38-2.
 
     /// #1221: end-to-end vendored-flag round-trip. With the default
     /// prefix list configured on the store, a chunk whose origin

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -1002,6 +1002,33 @@ async fn migrate_v26_to_v27(conn: &mut sqlx::SqliteConnection) -> Result<(), Sto
     .execute(&mut *conn)
     .await?;
 
+    // DS-V1.38-8 (#1463): backfill `needs_embedding=1` for any
+    // pre-v27 row that has `embedding_base IS NULL`. Combined with
+    // DS-V1.38-2 (enrichment_pass repopulates `embedding_base` from
+    // the row's `embedding` on first hit), this trips the next
+    // `cqs index --force` or `cqs index --llm-summaries` cycle into
+    // filling the missing base bytes — restoring base-HNSW coverage
+    // for `cqs <q> --rerank` / DenseBase routing on legacy projects
+    // that pre-date the v17→v18 base-column split (or that ran
+    // earlier `--llm-summaries` cycles before DS-V1.38-2 closed the
+    // permanent-NULL trap).
+    let backfilled = sqlx::query(
+        "UPDATE chunks SET needs_embedding = 1 \
+         WHERE embedding_base IS NULL AND needs_embedding = 0",
+    )
+    .execute(&mut *conn)
+    .await?
+    .rows_affected();
+
+    if backfilled > 0 {
+        tracing::info!(
+            backfilled,
+            "v27 migration: marked {backfilled} chunks with NULL embedding_base \
+             as needs_embedding=1 — they'll re-embed on the next enrichment_pass \
+             so base-HNSW coverage repopulates"
+        );
+    }
+
     tracing::info!(
         "Migrated to v27: chunks.needs_embedding flag + partial index. \
          Enables --llm-summaries first-pass-embed skip (#1452)."
@@ -3619,13 +3646,32 @@ mod tests {
                 .await
                 .unwrap();
 
-            // Seed a pre-migration v26 chunk.
+            // Seed a pre-migration v26 chunk WITH embedding_base populated
+            // (the post-v17 invariant for properly-indexed rows).
+            sqlx::query(
+                "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name, \
+                 signature, content, content_hash, line_start, line_end, embedding, \
+                 embedding_base, created_at, updated_at) \
+                 VALUES ('pre_v27', 'file:lib.rs', 'file', 'rust', 'function', 'pre_v27', \
+                 '', '', 'h', 1, 10, X'00', X'00', '2026-05-06', '2026-05-06')",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+
+            // DS-V1.38-8 (#1463): also seed a row with NULL embedding_base
+            // — represents legacy chunks where Phase 5 (#878) never filled
+            // the base column, or chunks from a `--llm-summaries` cycle
+            // that pre-dated DS-V1.38-2's enrichment-time base repopulate.
+            // The migration must mark these as needs_embedding=1 so the
+            // next index pass triggers a re-embed and the base-HNSW
+            // coverage gap closes.
             sqlx::query(
                 "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name, \
                  signature, content, content_hash, line_start, line_end, embedding, \
                  created_at, updated_at) \
-                 VALUES ('pre_v27', 'file:lib.rs', 'file', 'rust', 'function', 'pre_v27', \
-                 '', '', 'h', 1, 10, X'00', '2026-05-06', '2026-05-06')",
+                 VALUES ('pre_v27_no_base', 'file:lib.rs', 'file', 'rust', 'function', \
+                 'pre_v27_no_base', '', '', 'h_nb', 1, 10, X'00', '2026-05-06', '2026-05-06')",
             )
             .execute(&pool)
             .await
@@ -3642,10 +3688,11 @@ mod tests {
                     .unwrap();
             assert_eq!(v, "27");
 
-            // Pre-migration row has needs_embedding = 0 (DEFAULT). Existing
-            // chunks were embedded under the v26 contract; the migration must
-            // not flip them to "needs embedding" or every reindex would
-            // re-enrich them and waste GPU.
+            // Properly-indexed pre-migration row has needs_embedding = 0
+            // (DEFAULT). Existing chunks with a real `embedding_base` were
+            // embedded under the v26 contract; the migration must not flip
+            // them to "needs embedding" or every reindex would re-enrich
+            // them and waste GPU.
             let (pre_flag,): (i64,) =
                 sqlx::query_as("SELECT needs_embedding FROM chunks WHERE id = 'pre_v27'")
                     .fetch_one(&pool)
@@ -3653,7 +3700,21 @@ mod tests {
                     .unwrap();
             assert_eq!(
                 pre_flag, 0,
-                "pre-migration chunk must retain needs_embedding=0 (already embedded)"
+                "pre-migration chunk with real embedding_base must retain needs_embedding=0"
+            );
+
+            // DS-V1.38-8: rows with NULL embedding_base get backfilled to
+            // needs_embedding=1 so the next index pass repopulates the
+            // base column.
+            let (no_base_flag,): (i64,) =
+                sqlx::query_as("SELECT needs_embedding FROM chunks WHERE id = 'pre_v27_no_base'")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                no_base_flag, 1,
+                "DS-V1.38-8: pre-migration chunk with NULL embedding_base must be marked \
+                 needs_embedding=1 so the next enrichment_pass repopulates the base column"
             );
 
             // The partial index exists.


### PR DESCRIPTION
## Summary

Fix four interlocking data-safety bugs surfaced by the v1.38.0 audit (DS-V1.38-1/2/3/8). Closes **Cluster A** in the v1.38.0 triage. Refs #1463.

Together these caused **silent search-quality degradation** on `--llm-summaries` workflows and **stale daemon caches** on slot-migrated projects. None surfaces as an error — they all manifest as "search returns slightly worse results than expected."

## What's broken (pre-fix)

| Bug | Effect | Trigger |
|---|---|---|
| DS-V1.38-1 | CAGRA / UMAP / brute-force kNN load (0,…,0) sentinel embeddings | `cqs index --llm-summaries` skips first-pass embed (#1452); CAGRA build doesn't filter the unembedded rows out |
| DS-V1.38-2 | `embedding_base` permanently NULL for skip-first-pass chunks → `build_hnsw_base_index` skips them → DenseBase routing degrades | Every `--llm-summaries` cycle |
| DS-V1.38-3 | Daemon caches never invalidate after `cqs index` | Slot-migrated projects (post-#1105) — daemon watches `.cqs/index.db` which doesn't exist |
| DS-V1.38-8 | Legacy v17-pre-v18 chunks with NULL `embedding_base` invisible to base-HNSW forever | v26→v27 migration didn't backfill |

## Change shape

| File | Lines | Fix |
|---|---|---|
| `src/store/chunks/async_helpers.rs` | +2 -1 | Add `AND needs_embedding = 0` to the `EmbeddingBatchIterator` SELECT |
| `src/store/chunks/crud.rs` | +18 -5 | `embedding_base = COALESCE(chunks.embedding_base, t.embedding)` in enrichment UPDATE |
| `src/cli/batch/mod.rs` | +12 -4 | 5 staleness sites switch to `cqs::resolve_index_db(&self.cqs_dir)` |
| `src/store/migrations.rs` | +20 -0 | v27 migration UPDATE backfills `needs_embedding=1` for `embedding_base IS NULL` |
| `src/store/chunks/crud.rs` (test) | +30 -10 | Updated `unembedded_chunks_have_null_embedding_base` to expect post-enrichment count == 1 |
| `src/store/migrations.rs` (test) | +30 -8 | Extended `test_migrate_v26_to_v27_adds_needs_embedding_flag` with NULL-base seed |

## Tests

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib chunks::` — 77/77 pass
- [x] `cargo test --features gpu-index --lib test_migrate_v26_to_v27` — 1/1 pass
- [x] `cargo test --features gpu-index --lib async_helpers` — 10/10 pass (existing `test_enrichment_does_not_overwrite_base` still passes — COALESCE preserves prior bytes)
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green
- [ ] Smoke post-merge on a slot-migrated project: run `cqs index --llm-summaries`, then `cqs <conceptual-query>` and verify DenseBase routing returns the expected chunk; restart daemon, edit a file, `cqs index`, verify daemon serves fresh results

## Compatibility

- Schema unchanged (still v27)
- v27 migration is a one-shot UPDATE on `embedding_base IS NULL AND needs_embedding = 0` rows — idempotent on re-run
- No on-disk format change
- No public API change

## What's NOT in scope

- DS-V1.38-4..7 (HNSW load TOCTOU, WRITE_LOCK process-globalness, migration backup prune, write_active_slot lock contract) — separate PRs in the cluster's follow-up batch
- TC-HAP-V1.38-3 (enrichment_pass regression test) — punted to PR-D (TC-ADV regression-test backfill cluster)

## Audit context

Findings detail in `docs/audit-findings.md` (created in a sibling PR — the trail: 154 findings across 16 categories, 50 P1 / 37 P2 / 55 P3 / 12 P4). This PR fixes 4 of the 50 P1s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
