### PR TITLE
fix(cli): finish stored_model_name lossy-caller migration (Cluster C / #1463)

### DIFF
--- a/src/cli/commands/infra/model.rs
+++ b/src/cli/commands/infra/model.rs
@@ -236,9 +236,23 @@ fn cmd_model_show(json: bool) -> Result<()> {
     let store = Store::open_readonly(&index_path)
         .with_context(|| format!("Failed to open index at {}", index_path.display()))?;
 
-    let model = store
-        .stored_model_name()
-        .unwrap_or_else(|| "<unrecorded>".to_string());
+    // EH-V1.38-3 (#1463): `cqs model show` is the operator's first-line
+    // diagnostic for "what model built this index?". Distinguish "fresh
+    // DB / never indexed" (Ok(None) → `<unrecorded>`) from "metadata
+    // table broken / sqlite I/O failure" (Err → `<read-error>`) so the
+    // user picks `cqs index` vs `cqs doctor` correctly.
+    let model = match store.try_stored_model_name() {
+        Ok(Some(name)) => name,
+        Ok(None) => "<unrecorded>".to_string(),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                index_path = %index_path.display(),
+                "cqs model show: failed to read stored_model_name from metadata"
+            );
+            format!("<read-error: {e}>")
+        }
+    };
     let dim = store.dim();
     let total_chunks = match store.chunk_count() {
         Ok(n) => n,

--- a/src/cli/commands/infra/slot.rs
+++ b/src/cli/commands/infra/slot.rs
@@ -203,7 +203,22 @@ fn collect_slot_entry(project_cqs_dir: &Path, name: &str, active: &str) -> SlotL
     let (chunks, model, dim) = match cqs::Store::open_readonly_small(&index_path) {
         Ok(store) => {
             let count = store.chunk_count().ok();
-            let model = store.stored_model_name();
+            // EH-V1.38-4 (#1463): mirror the open-store warn ladder for
+            // metadata-read failures so a corrupt-but-openable slot
+            // surfaces in journald instead of showing a blank model
+            // column identical to a fresh slot.
+            let model = match store.try_stored_model_name() {
+                Ok(opt) => opt,
+                Err(e) => {
+                    tracing::warn!(
+                        slot = name,
+                        error = %e,
+                        path = %index_path.display(),
+                        "Slot metadata read failed during listing — model column will be empty"
+                    );
+                    None
+                }
+            };
             let dim = u64::try_from(store.dim()).ok();
             (count, model, dim)
         }

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -1034,7 +1034,28 @@ pub fn cmd_watch(
     // running `cqs watch` with `CQS_EMBEDDING_MODEL=wrong-model` would embed
     // new chunks with a different dim than the index, corrupting
     // incremental reindex.
-    let stored_model_for_watch = store.stored_model_name();
+    //
+    // EH-V1.38-1 (#1463): the lossy `stored_model_name()` returns `None`
+    // on real SQL errors (corrupt metadata, schema skew, sqlite I/O),
+    // not just on fresh DBs. Without surfacing the error the watch loop
+    // falls back to CLI/env/config resolution and silently writes
+    // wrong-dim embeddings into the live store. Use the strict variant
+    // and warn loudly on read failure so journald shows the cause.
+    let stored_model_for_watch = match store.try_stored_model_name() {
+        Ok(opt) => opt,
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                index_path = %index_path.display(),
+                "Watch loop failed to read stored_model_name from metadata — \
+                 falling back to CLI/env/config resolution. If the index \
+                 actually has a recorded model, the fallback may produce a \
+                 wrong-dim embedder and corrupt the incremental reindex; \
+                 stop the daemon and run `cqs index --force` to repair."
+            );
+            None
+        }
+    };
     let project_config_for_watch = cqs::config::Config::load(&root);
     let model_config_owned = ModelConfig::resolve_for_query(
         stored_model_for_watch.as_deref(),

--- a/src/cli/watch/rebuild.rs
+++ b/src/cli/watch/rebuild.rs
@@ -183,8 +183,25 @@ pub(super) fn resolve_index_aware_model_for_watch(
     root: &std::path::Path,
     cli_model: Option<&str>,
 ) -> Result<ModelConfig> {
+    // EH-V1.38-2 (#1463): use the strict variant so a corrupt-metadata
+    // read surfaces as an error in journald instead of silently
+    // collapsing to None and triggering a wrong-dim embedder pick. The
+    // open-readonly Err arm already warns; mirror that on the metadata
+    // read.
     let stored = match cqs::Store::open_readonly(index_path) {
-        Ok(s) => s.stored_model_name(),
+        Ok(s) => match s.try_stored_model_name() {
+            Ok(opt) => opt,
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    index_path = %index_path.display(),
+                    "Daemon thread failed to read stored_model_name from metadata — \
+                     falling back to CLI/env/config resolution. Wrong-dim \
+                     embedder risk; investigate metadata health before next reindex."
+                );
+                None
+            }
+        },
         Err(e) => {
             tracing::warn!(
                 error = %e,


### PR DESCRIPTION
## Summary

Finish the `stored_model_name` lossy → strict migration started by PR #1504. Four sibling callers were still using the lossy form, which collapses real SQL errors to `None` — indistinguishable from a fresh-DB read. Closes **Cluster C** in the v1.38.0 audit triage (EH-V1.38-1..4). Refs #1463.

## Why this matters

The lossy `stored_model_name()` returns `None` for both:
- Fresh DB (no `model_name` row) — expected behavior, fallback is correct
- Corrupt metadata table / schema skew / sqlite I/O failure — silent, fallback is wrong

For daemon paths the wrong fallback is load-bearing: the watch loop picks an embedder via CLI/env/config and writes new embeddings into the live store. If the index has a recorded model that differs from the fallback, every reindexed file goes in at the wrong dim and corrupts the index.

## Sites fixed

| ID | Site | Effect of pre-fix bug | Post-fix |
|---|---|---|---|
| **EH-V1.38-1** | `src/cli/watch/mod.rs:1037` (watch loop model resolver) | Daemon writes wrong-dim embeddings into live store on every reindexed file | `try_stored_model_name` + `tracing::error!` + recovery hint pointing at `cqs index --force` |
| **EH-V1.38-2** | `src/cli/watch/rebuild.rs:187` (`resolve_index_aware_model_for_watch`) | Same as above on daemon bring-up | Same fix |
| **EH-V1.38-3** | `src/cli/commands/infra/model.rs:240` (`cqs model show`) | Operator sees `<unrecorded>` for both fresh and corrupt DBs, picks wrong recovery (cqs index vs cqs doctor) | `<unrecorded>` only on `Ok(None)`; `<read-error: {e}>` on Err |
| **EH-V1.38-4** | `src/cli/commands/infra/slot.rs:206` (`cqs slot list`) | Empty `model` column for both fresh and corrupt slots | Mirrors open-store warn ladder; logs slot/error/path on metadata-read failure |

## Files

- `src/cli/watch/mod.rs` (+22 -1)
- `src/cli/watch/rebuild.rs` (+18 -1)
- `src/cli/commands/infra/model.rs` (+17 -3)
- `src/cli/commands/infra/slot.rs` (+16 -1)

## Why these and not others

`cqs doctor` (3 sites) and the read-only display surfaces (`cqs project list`, etc.) intentionally stay lossy — diagnostic-only; the surrounding context already points the operator at the right recovery, and the strict variant adds noise without adding signal. Only callers whose decision branches on the result get the strict treatment.

## Tests

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib stored_model_name` — 3/3 pass
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green
- [ ] Smoke post-merge: corrupt the metadata table on a test slot, run `cqs slot list` — should warn with `slot=<name> error=...`. Run `cqs model show` — should print `<read-error: ...>`. Restart daemon with the corrupt slot active — daemon should error-log on watch-loop entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
