### PR TITLE
fix(search, hnsw, cagra): algorithm correctness sweep — total_cmp adoption + saturating math (Cluster F / #1463)

### DIFF
--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -445,7 +445,10 @@ impl CagraIndex {
         // the caller as an empty Vec — a silent zero-result regression.
         // Force `itopk_size >= k` and refuse the search if the cap can't
         // honour it; the caller falls back to HNSW.
-        let itopk_size = (k * 2).clamp(itopk_min, itopk_max).max(k);
+        // AC-V1.38-9 (#1463): saturating_mul mirrors the HNSW search
+        // path — pathological `k` values now saturate rather than
+        // panic/wrap.
+        let itopk_size = k.saturating_mul(2).clamp(itopk_min, itopk_max).max(k);
         if itopk_size > itopk_max {
             tracing::warn!(
                 k,

--- a/src/gather.rs
+++ b/src/gather.rs
@@ -321,11 +321,15 @@ pub(crate) fn bfs_expand(
         .iter()
         .map(|(k, (s, _))| (k.as_str(), *s))
         .collect();
+    // AC-V1.38-3 (#1463): use `total_cmp` to match the rest of the
+    // search/scoring pipeline (BoundedScoreHeap, MMR, apply_parent_boost
+    // re-sort, search_across_projects merge). `partial_cmp().unwrap_or(Equal)`
+    // collapses NaN to "equal to everyone", which makes the secondary
+    // `name asc` tiebreak inherit the input slice's NaN position (not
+    // stable under sort). `total_cmp` gives a deterministic total order
+    // over all f32 values including NaN.
     seeds.sort_by(|(a_name, a_score), (b_name, b_score)| {
-        b_score
-            .partial_cmp(a_score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a_name.cmp(b_name))
+        b_score.total_cmp(a_score).then_with(|| a_name.cmp(b_name))
     });
 
     let mut queue: VecDeque<(Arc<str>, usize)> = VecDeque::new();

--- a/src/hnsw/search.rs
+++ b/src/hnsw/search.rs
@@ -89,8 +89,15 @@ impl HnswIndex {
 
         // Adaptive ef_search: baseline self.ef_search or 2*k (whichever is larger),
         // capped at index size (searching more than the index is pointless for small indexes).
+        //
+        // AC-V1.38-9 (#1463): `saturating_mul` instead of `*` so a
+        // pathological caller that smuggles in `k = usize::MAX-1` (e.g. a
+        // misbehaving daemon client) saturates at usize::MAX rather than
+        // panicking on debug or wrapping silently in release. The
+        // `.min(index_size)` immediately after still bounds the value
+        // for the underlying library.
         let index_size = self.id_map.len();
-        let ef_search = self.ef_search.max(k * 2).min(index_size);
+        let ef_search = self.ef_search.max(k.saturating_mul(2)).min(index_size);
 
         let neighbors = match filter {
             Some(f) => {

--- a/src/search/mmr.rs
+++ b/src/search/mmr.rs
@@ -90,9 +90,26 @@ pub(crate) fn mmr_rerank(candidates: &[MmrCandidate<'_>], limit: usize, lambda: 
             };
 
             let mmr = lambda * cand.score - (1.0 - lambda) * max_sim;
-            // Tie-break on score (then implicit input-order via i ordering)
-            // so the result is deterministic across runs.
-            if mmr > best_mmr || (mmr == best_mmr && best_idx == usize::MAX) {
+            // AC-V1.38-2 (#1463): use `total_cmp` instead of `f32 ==`. Raw
+            // float comparison treats NaN as `not greater AND not equal`,
+            // so a NaN MMR (which would imply an upstream bug — degenerate
+            // cosine, etc.) silently skips the candidate; the loop may
+            // exit with `best_idx == usize::MAX` and return short.
+            // `total_cmp` gives a deterministic total order over all
+            // f32 values including NaN, matching the rest of the
+            // search/scoring pipeline (BoundedScoreHeap, parent_boost
+            // re-sort, etc.).
+            //
+            // Tie-break: only the first candidate with the best MMR
+            // wins (i ascending). The `best_idx == usize::MAX` guard is
+            // preserved so the very first iteration always seeds the
+            // winner.
+            let take = match mmr.total_cmp(&best_mmr) {
+                std::cmp::Ordering::Greater => true,
+                std::cmp::Ordering::Equal => best_idx == usize::MAX,
+                std::cmp::Ordering::Less => false,
+            };
+            if take {
                 best_mmr = mmr;
                 best_idx = i;
             }

--- a/src/search/router.rs
+++ b/src/search/router.rs
@@ -777,6 +777,15 @@ pub fn resolve_splade_alpha(category: &QueryCategory) -> f32 {
     }
 
     // Global env override: CQS_SPLADE_ALPHA
+    //
+    // AC-V1.38-5 (#1463): mirror the per-cat arm's structure so a
+    // malformed `CQS_SPLADE_ALPHA=NaN` / `CQS_SPLADE_ALPHA=foo` /
+    // non-unicode value warns instead of silently falling through. Pre-
+    // fix the catch-all `_ => {}` collapsed parse errors, non-finite
+    // values, and `NotUnicode` together — operator who typoed
+    // `CQS_SPLADE_ALPHA=O.7` (capital O) got the per-cat default
+    // silently and chased an A/B that didn't reflect the env they
+    // thought was active.
     #[allow(clippy::collapsible_match)]
     match std::env::var("CQS_SPLADE_ALPHA") {
         Ok(val) if let Ok(alpha) = val.parse::<f32>() => {
@@ -791,8 +800,27 @@ pub fn resolve_splade_alpha(category: &QueryCategory) -> f32 {
                 );
                 return alpha;
             }
+            tracing::warn!(
+                var = "CQS_SPLADE_ALPHA",
+                value = %val,
+                "Non-finite global SPLADE alpha, using default"
+            );
         }
-        _ => {}
+        Ok(val) => {
+            tracing::warn!(
+                var = "CQS_SPLADE_ALPHA",
+                value = %val,
+                "Invalid global SPLADE alpha (parse error), using default"
+            );
+        }
+        Err(std::env::VarError::NotPresent) => {}
+        Err(e) => {
+            tracing::warn!(
+                var = "CQS_SPLADE_ALPHA",
+                error = %e,
+                "Global SPLADE alpha env var has non-unicode value — ignored"
+            );
+        }
     }
 
     // #1453: per-slot SPLADE α overrides from `slot.toml [splade.alpha]`.

--- a/src/search/scoring/candidate.rs
+++ b/src/search/scoring/candidate.rs
@@ -101,8 +101,18 @@ pub(crate) fn apply_parent_boost(results: &mut [SearchResult]) {
                 }
                 let count = *parent_counts.get(r.chunk.name.as_str())?;
                 if count >= 2 {
-                    let boost =
-                        1.0 + cfg.parent_boost_per_child * (count as f32 - 1.0).min(max_children);
+                    // AC-V1.38-6 (#1463): final clamp on the boost value
+                    // covers the ULP overshoot AC-V1.25-4's count clamp
+                    // doesn't reach — operator overrides like
+                    // `parent_boost_cap=1.20, parent_boost_per_child=0.03`
+                    // produce `max_children = 6.6666665` and the
+                    // multiplied-back value can land at
+                    // 1.0000004... above the documented cap. One f32.min
+                    // matches the doc-comment promise ("capped at
+                    // `parent_boost_cap`").
+                    let boost = (1.0
+                        + cfg.parent_boost_per_child * (count as f32 - 1.0).min(max_children))
+                    .min(cfg.parent_boost_cap);
                     tracing::debug!(
                         name = %r.chunk.name,
                         child_count = count,
@@ -235,13 +245,34 @@ impl BoundedScoreHeap {
         if !score.is_finite() {
             return false;
         }
+        // AC-V1.38-1 (#1463): a capacity-zero heap accepts nothing. Pre-fix
+        // the `peek() == None` arm fell through to `true` here, but `push`
+        // unconditionally rejects everything at capacity 0; trusting the
+        // mismatch yielded `would_accept(any) == true` followed by silent
+        // drop. Now both branches agree.
+        if self.capacity == 0 {
+            return false;
+        }
         if self.heap.len() < self.capacity {
             return true;
         }
         if let Some(Reverse((OrderedFloat(worst_score), _))) = self.heap.peek() {
-            // total_cmp matches the eviction comparator in push().
-            score.total_cmp(worst_score).is_gt()
+            // AC-V1.38-1 (#1463): the at-capacity branch must match the
+            // eviction-comparator contract documented above (`(score, id)`
+            // ascending: tied score → smaller id wins). Pre-fix
+            // `total_cmp(worst_score).is_gt()` returned `false` on tied
+            // scores, so the SPLADE caller `continue`d and never invoked
+            // `push()` — silently dropping a smaller-id incoming chunk
+            // that should have evicted the largest-id heap entry. We
+            // don't have the incoming `id` here, so the safe move is to
+            // be permissive on tied scores and let `push()` apply the
+            // full comparator: an extra cheap `id.to_string()` per tied
+            // score is cheaper than a wrong-result regression. Strict
+            // `Greater` for the score-strictly-better fast path; `Equal`
+            // falls through to `push()`'s eviction-on-id-less branch.
+            !score.total_cmp(worst_score).is_lt()
         } else {
+            // capacity > 0 but heap empty → space available.
             true
         }
     }


### PR DESCRIPTION
## Summary

Six AC-V1.38 algorithm-correctness findings, all easy fixes. Closes **Cluster F** in the v1.38.0 audit triage. Refs #1463.

## What's broken (pre-fix)

| ID | Bug | Trigger | Effect |
|---|---|---|---|
| **AC-V1.38-1** | `BoundedScoreHeap::would_accept` strict-`is_gt()` violates the heap's documented `(score, id)` tiebreak | Tied dot-products in SPLADE search at the eviction boundary | Silently drops a smaller-id incoming chunk that should evict the largest-id heap entry |
| **AC-V1.38-2** | `mmr_rerank` uses raw `f32 ==` for tiebreak | NaN MMR score (e.g. degenerate cosine) | Silently skips the candidate; loop may exit short |
| **AC-V1.38-3** | `bfs_expand` seed sort uses `partial_cmp().unwrap_or(Equal)` | NaN score in seed | Position depends on input slice ordering, not stable across runs |
| **AC-V1.38-5** | `CQS_SPLADE_ALPHA` global env arm collapses parse errors / non-finite / NotUnicode into `_ => {}` | Operator typo (e.g. `O.7`) | Silent fallback to default; A/B doesn't reflect what operator thinks is active |
| **AC-V1.38-6** | `apply_parent_boost` final value can overshoot `parent_boost_cap` by ~1 ULP | Operator override like `cap=1.20, per=0.03` | Boost lands at 1.2000000476 — strictly above doc-comment'd cap |
| **AC-V1.38-9** | HNSW + CAGRA search compute `k * 2` unchecked | Pathological `k = usize::MAX-1` (smuggled through daemon client) | Panic in debug, wrap in release |

## What ships

| Site | Change |
|---|---|
| `src/search/scoring/candidate.rs:234` (`would_accept`) | capacity-zero short-circuit; at-capacity branch returns `true` on tied scores so `push()` applies the full (score, id) comparator |
| `src/search/mmr.rs:92` | `mmr.total_cmp(&best_mmr)` match instead of `>` / `==` |
| `src/gather.rs:324` | seed sort uses `total_cmp` |
| `src/search/router.rs:780` | `CQS_SPLADE_ALPHA` arm mirrors per-cat warn ladder |
| `src/search/scoring/candidate.rs:104` (`apply_parent_boost`) | final `.min(parent_boost_cap)` clamp |
| `src/hnsw/search.rs:93` | `k.saturating_mul(2)` |
| `src/cagra.rs:448` | `k.saturating_mul(2)` |

## The AC-V1.38-1 footgun in detail

`BoundedScoreHeap` documents (`candidate.rs:142-149`, AC-V1.25-1/2 fix): "deterministic on id ascending — when scores are equal, the smaller id wins."

Pre-#1463 PERF-V1.36-9 added `would_accept` as a pre-flight gate so SPLADE could skip cloning chunk-id strings for candidates that wouldn't enter the heap. The gate used `total_cmp(worst).is_gt()` for the at-capacity branch — strict greater. This returns `false` on tied scores. The SPLADE caller (`splade/index.rs:253-258`) treats `would_accept == false` as "skip this candidate":

```rust
if !heap.would_accept(score) { continue; }
let id = chunk_id_at(idx).to_string();
heap.push(id, score);
```

So a smaller-id incoming chunk at the eviction boundary with a tied score got `would_accept == false`, hit `continue`, and was silently dropped — never giving the heap's full comparator a chance to evict the larger-id entry. Tied dot-products are common at small k against large posting lists, so this isn't a contrived corner case.

Fix: capacity-zero short-circuit (so the bonus footgun where `peek() == None` returned `true` despite `push` rejecting everything is gone), then in the at-capacity branch, **be permissive on tied scores and let `push()` apply the full comparator**. One extra `id.to_string()` per tied score trades for the determinism invariant.

## Tests

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib search::` — 232/232 pass (1 ignored for slow eval)
- [x] `cargo test --features gpu-index --lib mmr` — 9/9 pass
- [x] `cargo test --features gpu-index --lib gather` — 12/12 pass
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green
- [ ] Smoke post-merge: confirm SPLADE search at small `k` against a tie-rich query (multiple candidates with identical posting-list dot products) returns the smallest-id candidates first

## What's NOT in scope

- **AC-V1.38-4** (negation routing fires on bare "exclude"/"avoid"/"no") — needs a routing-policy decision, not a code edit
- **AC-V1.38-7, -10** (`ModelConfig::from_preset` silent fallback to default for unknown names) — needs a contract change to the preset registry
- **AC-V1.38-8** (`vendored_paths` slash-bearing entries silently skip) — separate validation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
