### PR TITLE
sec: redact api_base userinfo, drop Anthropic error.message echo, atomic patch write, ref-update symlink-redirect notice (Cluster I / #1463)

### DIFF
--- a/src/cli/commands/infra/reference.rs
+++ b/src/cli/commands/infra/reference.rs
@@ -640,6 +640,36 @@ fn cmd_ref_update(cli: &Cli, name: &str, json: bool, opts: RefUpdateLlmOpts) -> 
         );
     }
 
+    // SEC-V1.38-4 (#1463): mirror cmd_ref_add's symlink-redirect warn so
+    // an operator who pointed `vendored-deps/ → ~/work/customer-A-private/`
+    // after the original `cqs ref add` sees a loud notice on the next
+    // update / reindex. The check is cheap (lexical normalize +
+    // canonicalize) and surfaces the same threat — vendored content
+    // swap — that SEC-V1.30.1-6 was filed for.
+    if let Ok(canonical) = dunce::canonicalize(source) {
+        match symlink_redirect_warning(source, &canonical) {
+            Ok(Some(msg)) => {
+                tracing::warn!(
+                    name = %name,
+                    user_source = %source.display(),
+                    resolved = %canonical.display(),
+                    "Source path resolved via symlink during ref update — re-indexing the resolved target"
+                );
+                if !json && !cli.quiet {
+                    eprintln!("WARN: {msg}");
+                }
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::debug!(
+                    source = %source.display(),
+                    error = %e,
+                    "Could not compute absolute form of source for symlink-redirect check during update"
+                );
+            }
+        }
+    }
+
     let db_path = ref_config.path.join(cqs::INDEX_DB_FILENAME);
     let ref_dir = &ref_config.path;
 

--- a/src/doc_writer/rewriter.rs
+++ b/src/doc_writer/rewriter.rs
@@ -614,7 +614,14 @@ pub fn write_proposed_patch(
     if let Some(parent) = patch_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(&patch_path, unified.as_bytes())?;
+    // SEC-V1.38-3 (#1463): atomic write so a SIGINT / OOM kill / power
+    // loss between `create_dir_all` and the write completion doesn't
+    // leave a truncated `.patch` file at the final path. The user's
+    // review workflow is `git apply .cqs/proposed-docs/**/*.patch`;
+    // `git apply` on a truncated unified diff produces partial source
+    // changes — silent corruption. Reuse the existing `atomic_write`
+    // helper in this file (line 634, used by `rewrite_file`).
+    atomic_write(&patch_path, unified.as_bytes())?;
 
     tracing::info!(
         patch = %patch_path.display(),

--- a/src/llm/batch.rs
+++ b/src/llm/batch.rs
@@ -79,15 +79,24 @@ impl LlmClient {
                 tracing::warn!(error = %e, "Failed to read HTTP error response body");
                 String::new()
             });
-            // P2 #33 (LLM half): keep the full body for operator-visible debug
+            // P2 #33 (LLM half): keep body length for operator-visible debug
             // logs, but the user-visible LlmError::Api message must NOT carry
             // remote-controlled text (raw HTTP body or parsed `error.message`,
             // both of which can echo prompt fragments).
+            //
+            // SEC-V1.38-2 (#1463): also drop `parsed_anthropic_message` from
+            // the debug record. Anthropic's 400-class responses populate
+            // `error.message` with input fragments — schema validation
+            // includes failing JSON path values, content-policy
+            // `invalid_request_error` includes the rejected snippet. With
+            // `RUST_LOG=cqs=debug` the echo lands in journald. Keep the
+            // structural `parsed.error.type` (e.g. `"invalid_request_error"`)
+            // because that doesn't echo input.
             let parsed = serde_json::from_str::<ApiError>(&body).ok();
             tracing::debug!(
                 purpose,
                 status = %status,
-                parsed_anthropic_message = parsed.as_ref().map(|p| p.error.message.as_str()).unwrap_or(""),
+                anthropic_error_type = parsed.as_ref().map(|p| p.error.r#type.as_str()).unwrap_or(""),
                 body_len = body.len(),
                 "{purpose} submission failed at LLM API",
             );

--- a/src/llm/doc_comments.rs
+++ b/src/llm/doc_comments.rs
@@ -143,7 +143,8 @@ pub fn doc_comment_pass(
 
     let llm_config = LlmConfig::resolve(config)?;
     tracing::debug!(
-        api_base = %llm_config.api_base,
+        // SEC-V1.38-1 (#1463): redacted form so user:pass@host doesn't land in journald.
+        api_base = %llm_config.redacted_api_base(),
         "LLM API base"
     );
     tracing::info!(

--- a/src/llm/hyde.rs
+++ b/src/llm/hyde.rs
@@ -19,7 +19,8 @@ pub fn hyde_query_pass(
 
     let llm_config = LlmConfig::resolve(config)?;
     tracing::debug!(
-        api_base = %llm_config.api_base,
+        // SEC-V1.38-1 (#1463): redacted form so user:pass@host doesn't land in journald.
+        api_base = %llm_config.redacted_api_base(),
         "LLM API base"
     );
     tracing::info!(

--- a/src/llm/local.rs
+++ b/src/llm/local.rs
@@ -126,7 +126,8 @@ impl LocalProvider {
             let host = http_host(&llm_config.api_base);
             if !is_local_or_private_host(host) {
                 tracing::warn!(
-                    api_base = %llm_config.api_base,
+                    // SEC-V1.38-1 (#1463): redacted form so user:pass@host doesn't land in journald.
+                    api_base = %llm_config.redacted_api_base(),
                     host = host,
                     "Refusing to attach Authorization: Bearer over plaintext HTTP to a \
                      non-loopback / non-RFC1918 host. Use https:// or bind to a private \
@@ -162,7 +163,8 @@ impl LocalProvider {
             .build()?;
 
         tracing::info!(
-            api_base = %llm_config.api_base,
+            // SEC-V1.38-1 (#1463): redact userinfo from journald.
+            api_base = %llm_config.redacted_api_base(),
             model = %llm_config.model,
             concurrency,
             timeout_secs = timeout.as_secs(),

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -247,7 +247,11 @@ const DEFAULT_PROVIDER: &str = "anthropic";
 /// [`PROVIDERS`]. The factory [`create_client`] looks the entry up by
 /// name; tests compare it as a plain `&str` (e.g. `"anthropic"`,
 /// `"local"`).
-#[derive(Debug)]
+///
+/// SEC-V1.38-1 (#1463): hand-written `Debug` redacts `api_base` userinfo
+/// before emitting. The five downstream sites that log `LlmConfig` /
+/// `?config` previously echoed `https://user:pass@host` shapes verbatim
+/// to journald.
 pub struct LlmConfig {
     pub provider: &'static str,
     pub api_base: String,
@@ -255,6 +259,48 @@ pub struct LlmConfig {
     pub max_tokens: u32,
     /// Max tokens for HyDE query predictions (default: 150).
     pub hyde_max_tokens: u32,
+}
+
+impl LlmConfig {
+    /// Render `api_base` with any `user[:pass]@host` userinfo segment
+    /// stripped. Use this in every `tracing::*` site instead of
+    /// `%self.api_base`. Pre-fix the userinfo could land in journald
+    /// at `info!` level whenever the daemon started up.
+    ///
+    /// Returns `"[redacted]"` for unparseable URLs (so a misformatted
+    /// env var doesn't accidentally leak the raw bytes through this
+    /// helper either).
+    pub fn redacted_api_base(&self) -> String {
+        redact_userinfo(&self.api_base)
+    }
+}
+
+impl std::fmt::Debug for LlmConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LlmConfig")
+            .field("provider", &self.provider)
+            .field("api_base", &self.redacted_api_base())
+            .field("model", &self.model)
+            .field("max_tokens", &self.max_tokens)
+            .field("hyde_max_tokens", &self.hyde_max_tokens)
+            .finish()
+    }
+}
+
+/// Strip `user[:pass]@` userinfo from a URL, leaving scheme + host + path.
+/// Returns `[redacted]` for inputs that don't look like a URL.
+fn redact_userinfo(url: &str) -> String {
+    if let Some(scheme_end) = url.find("://") {
+        let after_scheme = &url[scheme_end + 3..];
+        let host_part = if let Some(at_pos) = after_scheme.find('@') {
+            &after_scheme[at_pos + 1..]
+        } else {
+            after_scheme
+        };
+        format!("{}://{}", &url[..scheme_end], host_part)
+    } else {
+        "[redacted]".to_string()
+    }
 }
 
 impl LlmConfig {
@@ -674,7 +720,18 @@ struct ApiError {
 
 #[derive(Deserialize)]
 struct ApiErrorDetail {
+    /// Anthropic's `error.message` is intentionally NOT logged anywhere
+    /// (SEC-V1.38-2 #1463 + SEC-V1.36-2 / P2 #33) — it can echo prompt
+    /// fragments. Field still deserialized to keep parse-or-skip
+    /// semantics if Anthropic ships a response missing `type`.
+    #[allow(dead_code)]
     message: String,
+    /// SEC-V1.38-2 (#1463): structural error type
+    /// (`invalid_request_error`, `authentication_error`, …). Safe to
+    /// log; does not echo input fragments. Optional because not every
+    /// upstream populates it.
+    #[serde(default)]
+    r#type: String,
 }
 
 /// A summary entry ready for storage.
@@ -687,6 +744,45 @@ pub struct SummaryEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// SEC-V1.38-1 (#1463): verify both `LlmConfig::redacted_api_base()`
+    /// and the hand-rolled `Debug` impl strip `user[:pass]@host` userinfo.
+    /// A regression that exposed the userinfo would surface here AND in
+    /// every downstream `tracing::*` site at once (those all route through
+    /// `redacted_api_base` after this PR).
+    #[test]
+    fn redacted_api_base_strips_userinfo() {
+        let cfg = LlmConfig {
+            provider: "anthropic",
+            api_base: "https://user:supersecret@vllm.internal/v1".to_string(),
+            model: "test".to_string(),
+            max_tokens: 100,
+            hyde_max_tokens: 50,
+        };
+        let redacted = cfg.redacted_api_base();
+        assert!(
+            !redacted.contains("supersecret") && !redacted.contains("user:"),
+            "redacted_api_base must strip userinfo; got {redacted}"
+        );
+        assert!(
+            redacted.contains("vllm.internal"),
+            "redacted_api_base must keep host; got {redacted}"
+        );
+        let debug_str = format!("{cfg:?}");
+        assert!(
+            !debug_str.contains("supersecret") && !debug_str.contains("user:"),
+            "LlmConfig Debug must redact userinfo; got {debug_str}"
+        );
+    }
+
+    /// `redact_userinfo` returns `[redacted]` for inputs that don't look
+    /// like URLs so a misformatted env var doesn't accidentally leak its
+    /// raw bytes through the helper.
+    #[test]
+    fn redact_userinfo_handles_non_url_inputs() {
+        assert_eq!(redact_userinfo("not-a-url"), "[redacted]");
+        assert_eq!(redact_userinfo(""), "[redacted]");
+    }
 
     // ENV_MUTEX hoisted to module-wide `LLM_ENV_LOCK` (#1312 / #1305) so
     // these tests serialize against `hyde::tests`, `doc_comments::tests`, and

--- a/src/llm/summary.rs
+++ b/src/llm/summary.rs
@@ -25,7 +25,8 @@ pub fn llm_summary_pass(
 
     let llm_config = LlmConfig::resolve(config)?;
     tracing::debug!(
-        api_base = %llm_config.api_base,
+        // SEC-V1.38-1 (#1463): redacted form so user:pass@host doesn't land in journald.
+        api_base = %llm_config.redacted_api_base(),
         "LLM API base"
     );
     tracing::info!(


### PR DESCRIPTION
## Summary

Four security easy-wins from the v1.38.0 audit. Closes **Cluster I** (SEC-V1.38-1, -2, -3, -4). Refs #1463.

## What ships

| ID | Bug | Surface | Fix |
|---|---|---|---|
| **SEC-V1.38-1** | `LlmConfig::api_base` logged raw at 5 sites (info / debug). `CQS_LLM_API_BASE=https://user:secret@vllm.internal/v1` ends up in journald | `src/llm/{local, hyde, summary, doc_comments}.rs` | New `LlmConfig::redacted_api_base()` + hand-rolled `Debug` impl. All 5 sites route through it |
| **SEC-V1.38-2** | `parsed_anthropic_message` debug log echoed prompt fragments via Anthropic's 400-class `error.message` (schema validation includes failing JSON path values; content-policy includes rejected snippet) | `src/llm/batch.rs:90` | Drop `error.message`; keep structural `error.type` |
| **SEC-V1.38-3** | `write_proposed_patch` used bare `fs::write` — SIGINT / OOM kill / power loss left truncated `.patch` files; `git apply` on truncated diff = silent partial source change | `src/doc_writer/rewriter.rs:617` | Route through existing `atomic_write` helper (already used by `rewrite_file`) |
| **SEC-V1.38-4** | `cmd_ref_update` (and #1506's flag-parity reindex path) silently re-indexed through swapped symlinks. SEC-V1.30.1-6 / #1222 added the warn to `cmd_ref_add`; update path never inherited it | `src/cli/commands/infra/reference.rs:631` | Mirror the warn ladder: `WARN:` stderr + structured `tracing::warn!` |

## Tests

- [x] `cargo build --features gpu-index` clean
- [x] `redacted_api_base_strips_userinfo` — pins both helper AND `Debug` impl against userinfo leak
- [x] `redact_userinfo_handles_non_url_inputs` — `[redacted]` fallback for malformed inputs
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green
- [ ] Smoke post-merge: `CQS_LLM_API_BASE=https://user:secret@host/v1 cqs index --llm-summaries` → grep journald for "secret" should return nothing

## What's NOT in scope

| ID | Why deferred |
|---|---|
| **SEC-V1.38-5** | `serve` handler log size cap — separate observability pass |
| **SEC-V1.38-6** | `cqs read` TOCTOU — needs canonical-file-handle plumbing |
| **SEC-V1.38-7** | `git diff` ref validation — defensive thinning, separate PR |
| **SEC-V1.38-8** | `Config::Debug ?config` — **already mitigated**; `Config::Debug` already routes `llm_api_base` through `redact_url` at `config.rs:472`. Auditor missed the existing redaction |
| **SEC-V1.38-9** | `serve` concurrent cap upper bound — separate |
| **SEC-V1.38-10** | PDF script swap window — needs `include_str!` shape refactor |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
