### PR TITLE
perf: cache test-pattern registry, SPLADE id_map Box<str>, hoist redundant joins (Cluster E / #1463)

### DIFF
--- a/src/cli/watch/reindex.rs
+++ b/src/cli/watch/reindex.rs
@@ -647,8 +647,13 @@ pub(super) fn reindex_files(
             .push((chunk, embedding));
     }
     for (file, pairs) in &by_file {
+        // PF-V1.38-8 (#1463): hoist `root.join(file)` so the same PathBuf
+        // is reused by both the mtime cache and the v23 fingerprint
+        // write-back below. Pre-fix the join allocated twice per file —
+        // ms-scale on WSL 9P which adds up across a 200-file watch
+        // tick.
+        let abs_path = root.join(file);
         let mtime = *mtime_cache.entry(file.clone()).or_insert_with(|| {
-            let abs_path = root.join(file);
             // bundle-reconcile-stat: capture the stat error separately so
             // we can surface it via tracing instead of silently storing
             // `mtime=None` for the file. A `None` here means reconcile
@@ -714,7 +719,8 @@ pub(super) fn reindex_files(
         // the same path.
         // RB-V1.36-5 / P2-7: streaming blake3 + size-from-metadata so we
         // don't have to slurp the whole file into RAM just to hash it.
-        let abs_path = root.join(file);
+        // PF-V1.38-8 (#1463): `abs_path` was already hoisted above; reuse
+        // it instead of re-joining.
         let size_hint = std::fs::metadata(&abs_path).ok().map(|m| m.len());
         let fp = match std::fs::File::open(&abs_path) {
             Ok(f) => {

--- a/src/impact/analysis.rs
+++ b/src/impact/analysis.rs
@@ -180,15 +180,17 @@ pub(super) fn extract_call_snippet_from_cache(
         return None;
     }
 
-    let lines: Vec<&str> = best.chunk.content.lines().collect();
+    // PF-V1.38-7 (#1463): only the 3-line window survives, but `lines().collect()`
+    // pre-fix sized the Vec to the entire chunk's line count and walked the
+    // whole iterator. For 100+ line chunks this was a wasted allocation per
+    // caller. `skip(start).take(3)` lazy-iterates only the lines we keep.
     let offset = caller.call_line.saturating_sub(best.chunk.line_start) as usize;
-    if offset < lines.len() {
-        let start = offset.saturating_sub(1);
-        // Always show 3 lines from start (consistent window regardless of position)
-        let end = (start + 3).min(lines.len());
-        Some(lines[start..end].join("\n"))
-    } else {
+    let start = offset.saturating_sub(1);
+    let snippet: Vec<&str> = best.chunk.content.lines().skip(start).take(3).collect();
+    if snippet.is_empty() {
         None
+    } else {
+        Some(snippet.join("\n"))
     }
 }
 

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -974,17 +974,32 @@ impl LanguageRegistry {
     }
 
     /// Collect all unique test path patterns from all enabled languages.
+    ///
+    /// PF-V1.38-1 (#1463): cached behind a static `OnceLock` because the
+    /// patterns depend only on compile-time `LanguageDef::test_path_patterns`
+    /// and `is_test_chunk` is called per-candidate per-search (~500
+    /// candidates per query at default `enable_demotion = true`). Pre-fix
+    /// every call walked all 54 language defs and built a fresh `Vec` +
+    /// `HashSet`. Now the dedup runs once per process; subsequent calls
+    /// are a single static-slice clone (cheap because entries are
+    /// `&'static str`). Returns a `Vec` rather than `&'static [&str]` to
+    /// keep the API shape stable for callers that expect ownership.
     pub fn all_test_path_patterns(&self) -> Vec<&'static str> {
-        let mut patterns = Vec::new();
-        let mut seen = std::collections::HashSet::new();
-        for def in self.all() {
-            for pat in def.test_path_patterns {
-                if seen.insert(*pat) {
-                    patterns.push(*pat);
+        static CACHE: std::sync::OnceLock<Vec<&'static str>> = std::sync::OnceLock::new();
+        CACHE
+            .get_or_init(|| {
+                let mut patterns = Vec::new();
+                let mut seen = std::collections::HashSet::new();
+                for def in self.all() {
+                    for pat in def.test_path_patterns {
+                        if seen.insert(*pat) {
+                            patterns.push(*pat);
+                        }
+                    }
                 }
-            }
-        }
-        patterns
+                patterns
+            })
+            .clone()
     }
 
     /// Collect all unique test name patterns from all enabled languages,
@@ -1021,21 +1036,27 @@ impl LanguageRegistry {
             "%\\_test\\_%",
             "%.test%",
         ];
-        let mut patterns: Vec<&'static str> = Vec::new();
-        let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
-        for def in self.all() {
-            for pat in def.test_name_patterns {
-                if seen.insert(*pat) {
-                    patterns.push(*pat);
+        // PF-V1.38-1 (#1463): cached — see `all_test_path_patterns` above.
+        static CACHE: std::sync::OnceLock<Vec<&'static str>> = std::sync::OnceLock::new();
+        CACHE
+            .get_or_init(|| {
+                let mut patterns: Vec<&'static str> = Vec::new();
+                let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+                for def in self.all() {
+                    for pat in def.test_name_patterns {
+                        if seen.insert(*pat) {
+                            patterns.push(*pat);
+                        }
+                    }
                 }
-            }
-        }
-        for pat in FALLBACK {
-            if seen.insert(*pat) {
-                patterns.push(*pat);
-            }
-        }
-        patterns
+                for pat in FALLBACK {
+                    if seen.insert(*pat) {
+                        patterns.push(*pat);
+                    }
+                }
+                patterns
+            })
+            .clone()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,8 +513,17 @@ pub fn is_test_chunk(name: &str, file: &str) -> bool {
     }
     // Path-based patterns from the language registry (all 54 languages).
     // Patterns use SQL LIKE syntax: `%` = any chars, `\_` = literal underscore.
-    // Normalize backslashes to forward slashes for cross-platform matching.
-    let normalized = file.replace('\\', "/");
+    //
+    // PF-V1.38-1 (#1463): skip the `\\` → `/` replace when there's no
+    // backslash in the input. On Linux that's the common case; the
+    // pre-fix `replace('\\', "/")` allocated a fresh `String` for every
+    // candidate even when the result was byte-identical to the input.
+    // Now allocates only on Windows-style paths.
+    let normalized: std::borrow::Cow<'_, str> = if file.contains('\\') {
+        std::borrow::Cow::Owned(file.replace('\\', "/"))
+    } else {
+        std::borrow::Cow::Borrowed(file)
+    };
     for pattern in language::REGISTRY.all_test_path_patterns() {
         if sql_like_matches(&normalized, pattern) {
             return true;

--- a/src/splade/index.rs
+++ b/src/splade/index.rs
@@ -161,8 +161,14 @@ impl<'a, W: Write> Write for HashingWriter<'a, W> {
 pub struct SpladeIndex {
     /// Inverted postings: token_id → [(chunk_index, weight)]
     postings: HashMap<u32, Vec<(usize, f32)>>,
-    /// Sequential chunk ID map (chunk_index → chunk_id string)
-    id_map: Vec<String>,
+    /// Sequential chunk ID map (chunk_index → chunk_id string).
+    /// PF-V1.38-2 (#1463): `Box<str>` instead of `String` to match the
+    /// HNSW + CAGRA migration in #1502 — saves 8 bytes per entry
+    /// (24+len → 16+len) at the cost of zero ergonomics (`Box<str>`
+    /// derefs to `&str` for read access). Build-once / read-many access
+    /// pattern; `push` is the only mutator and always immediately
+    /// followed by an `into_boxed_str()`-cheap conversion.
+    id_map: Vec<Box<str>>,
 }
 
 impl SpladeIndex {
@@ -177,7 +183,7 @@ impl SpladeIndex {
             for &(token_id, weight) in &sparse {
                 postings.entry(token_id).or_default().push((idx, weight));
             }
-            id_map.push(chunk_id);
+            id_map.push(chunk_id.into_boxed_str());
         }
 
         tracing::info!(
@@ -254,7 +260,10 @@ impl SpladeIndex {
                 continue;
             }
             if let Some(id) = self.id_map.get(idx) {
-                heap.push(id.clone(), score);
+                // PF-V1.38-2 (#1463): `Box<str>` derefs to `&str`; one
+                // `String::from(&str)` allocation per accepted candidate
+                // (gated by `would_accept` above so most are skipped).
+                heap.push(id.to_string(), score);
             }
         }
         let results: Vec<IndexResult> = heap
@@ -575,7 +584,10 @@ impl SpladeIndex {
     /// body size fits in `u64` for any realistic SPLADE index.
     fn write_body<W: Write>(
         writer: &mut W,
-        id_map: &[String],
+        // PF-V1.38-2 (#1463): `&[Box<str>]` matches the in-memory storage.
+        // `Box<str>` derefs to `&str` so `id.len()` and `id.as_bytes()`
+        // work unchanged below.
+        id_map: &[Box<str>],
         postings: &HashMap<u32, Vec<(usize, f32)>>,
     ) -> Result<u64, SpladeIndexPersistError> {
         let mut bytes_written: u64 = 0;
@@ -765,7 +777,8 @@ impl SpladeIndex {
                 body.len()
             )));
         }
-        let mut id_map: Vec<String> = Vec::with_capacity(chunk_count_usize);
+        // PF-V1.38-2 (#1463): `Vec<Box<str>>` matches the build-time storage.
+        let mut id_map: Vec<Box<str>> = Vec::with_capacity(chunk_count_usize);
         let mut cursor: usize = 0;
 
         fn need(body: &[u8], cursor: usize, n: usize) -> Result<(), SpladeIndexPersistError> {
@@ -795,7 +808,7 @@ impl SpladeIndex {
                 })?
                 .to_string();
             cursor += len;
-            id_map.push(id);
+            id_map.push(id.into_boxed_str());
         }
 
         let token_count_usize: usize = token_count.try_into().map_err(|_| {
@@ -1363,7 +1376,10 @@ mod tests {
 
         // The post-save file is a valid index loadable at the new generation.
         let loaded = SpladeIndex::load(&path, 2).unwrap().unwrap();
-        assert_eq!(loaded.id_map, vec!["chunk_v2".to_string()]);
+        // PF-V1.38-2 (#1463): id_map is now Vec<Box<str>>; deref each
+        // entry to compare against the expected literal.
+        assert_eq!(loaded.id_map.len(), 1);
+        assert_eq!(&*loaded.id_map[0], "chunk_v2");
     }
 
     /// Stale `.bak` left over from a prior failed save must block the next


### PR DESCRIPTION
## Summary

Four hot-path performance fixes from the v1.38.0 audit. Closes **Cluster E** (PF-V1.38-1, -2, -7, -8). Refs #1463.

## What's broken (pre-fix)

| ID | Hot path | Cost |
|---|---|---|
| **PF-V1.38-1** | `is_test_chunk` called per-candidate per-search | ~30k-60k allocations per query (`enable_demotion = true` default). Each call rebuilt the 54-language test-pattern Vec + HashSet from scratch |
| **PF-V1.38-2** | SPLADE `id_map: Vec<String>` heap | ~144 KB wasted per slot on 18k-chunk index — same shape #1502 fixed for HNSW/CAGRA |
| **PF-V1.38-7** | `extract_call_snippet_from_cache` per-caller | `content.lines().collect()` allocated a `Vec<&str>` sized to entire chunk (often 100+ lines) just to slice 3 lines |
| **PF-V1.38-8** | Watch reindex per-file | Duplicate `root.join(file)` allocations + duplicate `metadata()` syscalls |

## Change shape

| File | Lines | Fix |
|---|---|---|
| `src/language/mod.rs` | +35 -16 | `OnceLock<Vec<&'static str>>` for `all_test_path_patterns` + `all_test_name_patterns` |
| `src/lib.rs` | +9 -2 | `is_test_chunk` `Cow<'_, str>` for `\\` → `/` replace (no-op on Linux paths now allocates nothing) |
| `src/splade/index.rs` | +21 -7 | `id_map: Vec<Box<str>>` migration matching PR #1502; `into_boxed_str()` at build/load, `id.to_string()` at search push |
| `src/impact/analysis.rs` | +6 -8 | `lines().skip(start).take(3).collect()` instead of full Vec collect |
| `src/cli/watch/reindex.rs` | +6 -2 | Hoist `let abs_path = root.join(file);` above the mtime cache block so the second `join` is gone |

## Tests

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib is_test_chunk` — 5/5 pass
- [x] `cargo test --features gpu-index --lib splade::index` — 21/21 pass
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green
- [ ] Smoke post-merge: a search query against a large indexed corpus should retain the existing test-demotion semantics; SPLADE search should produce byte-identical results

## What's NOT in scope

| ID | Why deferred |
|---|---|
| **PF-V1.38-3** | `resolve_splade_alpha` env caching — eval-sweep tests mutate env between searches; caching at process-start would break the contract |
| **PF-V1.38-4** | SPLADE encode env caching — same contract concern |
| **PF-V1.38-5** | Tree-sitter `Parser::new()` per file — needs Mutex-pool refactor across `parser/{mod,aspx,calls,injection,l5x}.rs`; separate PR |
| **PF-V1.38-6** | BFS `Arc<str>` clones in `gather` — separate |
| **PF-V1.38-9** | `analyze_type_impact` clone chain — separate |
| **PF-V1.38-10** | `find_test_chunks_cross` uncached rescan — separate |

## Notes on PF-V1.38-2 (SPLADE Box<str>)

One existing test assertion (`assert_eq!(loaded.id_map, vec!["chunk_v2".to_string()])`) updated to `&*loaded.id_map[0] == "chunk_v2"` because `Box<str>: PartialEq<String>` doesn't exist. Behavior unchanged; the assertion is still as strict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
