### PR TITLE
test: TC-ADV regression-test backfill for shipped fixes (Cluster D / #1463)

### DIFF
--- a/src/cli/commands/train/export_model.rs
+++ b/src/cli/commands/train/export_model.rs
@@ -262,6 +262,37 @@ mod tests {
         assert!(validate_repo_id("-evil/model").is_err());
     }
 
+    /// TC-ADV-V1.38-1 (#1463): SEC-V1.36-7 added an explicit `..`
+    /// path-traversal rejection at the top of `validate_repo_id` so a
+    /// hostile `org/../../etc/passwd` couldn't escape `optimum`'s CWD.
+    /// The fix shipped without a regression test — a future refactor
+    /// that simplified the validator to rely on the char-set whitelist
+    /// alone (`.` and `/` are both allowed individually) would silently
+    /// revert the fix.
+    #[test]
+    fn validate_repo_id_rejects_parent_directory_refs() {
+        assert!(
+            validate_repo_id("org/../../etc/passwd").is_err(),
+            "classic path-traversal must be rejected"
+        );
+        assert!(
+            validate_repo_id("..").is_err(),
+            "bare `..` must be rejected"
+        );
+        assert!(
+            validate_repo_id("foo/..").is_err(),
+            "`..` as a segment must be rejected"
+        );
+        assert!(
+            validate_repo_id("a..b/c").is_err(),
+            "`..` as a substring (even mid-segment) must be rejected"
+        );
+        assert!(
+            validate_repo_id("../escape/model").is_err(),
+            "`..` at start must be rejected"
+        );
+    }
+
     #[test]
     fn write_model_toml_comments_dim_when_unknown() {
         let dir = tempfile::TempDir::new().unwrap();

--- a/src/search/scoring/note_boost.rs
+++ b/src/search/scoring/note_boost.rs
@@ -496,4 +496,75 @@ mod tests {
         let index = NoteBoostIndex::new(&notes);
         assert_eq!(index.boost("src/lib.rs", "my_fn"), 1.0);
     }
+
+    /// TC-ADV-V1.38-2 (#1463): the consumer-side NaN/±Inf clamp at the
+    /// `boost` call site has only been protected by the test pinning the
+    /// SQLite round-trip (`test_upsert_notes_infinity_sentiment_roundtrips`).
+    /// A future refactor that inlined the clamp into the producer would
+    /// silently revert P1-36's BoundedScoreHeap drop fix. These tests
+    /// pin the boost-side contract directly: regardless of how a NaN or
+    /// ±Inf sentiment lands in the index, the multiplier is finite.
+    #[test]
+    fn boost_clamps_inf_sentiment_to_finite_multiplier() {
+        let pos_inf = make_note(f32::INFINITY, &["my_fn"]);
+        let neg_inf = make_note(f32::NEG_INFINITY, &["my_fn"]);
+
+        // Exact-name path: NoteBoostIndex with name-mention.
+        let idx_pos = NoteBoostIndex::new(std::slice::from_ref(&pos_inf));
+        let m_pos = idx_pos.boost("src/lib.rs", "my_fn");
+        assert!(m_pos.is_finite(), "+Inf must clamp to finite; got {m_pos}");
+        assert!(
+            (0.0..=2.0).contains(&m_pos),
+            "+Inf must clamp inside [0, 2]; got {m_pos}"
+        );
+
+        let idx_neg = NoteBoostIndex::new(std::slice::from_ref(&neg_inf));
+        let m_neg = idx_neg.boost("src/lib.rs", "my_fn");
+        assert!(m_neg.is_finite(), "-Inf must clamp to finite; got {m_neg}");
+        assert!(
+            (0.0..=2.0).contains(&m_neg),
+            "-Inf must clamp inside [0, 2]; got {m_neg}"
+        );
+
+        // OwnedNoteBoostIndex (the production hot path) — same contract.
+        let owned_pos = OwnedNoteBoostIndex::new(std::slice::from_ref(&pos_inf));
+        let m_pos = owned_pos.boost("src/lib.rs", "my_fn");
+        assert!(
+            m_pos.is_finite(),
+            "OwnedNoteBoostIndex +Inf must clamp; got {m_pos}"
+        );
+
+        let owned_neg = OwnedNoteBoostIndex::new(std::slice::from_ref(&neg_inf));
+        let m_neg = owned_neg.boost("src/lib.rs", "my_fn");
+        assert!(
+            m_neg.is_finite(),
+            "OwnedNoteBoostIndex -Inf must clamp; got {m_neg}"
+        );
+    }
+
+    /// TC-ADV-V1.38-2 follow-up: NaN sentiment must produce a finite
+    /// multiplier (the comment says "f32::clamp panics on NaN, so handle
+    /// non-finite up front" — this pins that path).
+    #[test]
+    fn boost_treats_nan_sentiment_as_finite_multiplier() {
+        let nan_note = make_note(f32::NAN, &["my_fn"]);
+
+        let idx = NoteBoostIndex::new(std::slice::from_ref(&nan_note));
+        let m = idx.boost("src/lib.rs", "my_fn");
+        assert!(m.is_finite(), "NaN must clamp to finite; got {m}");
+        // Implementation collapses NaN → 0.0 sentiment, so the multiplier
+        // is exactly 1.0. Pin that contract.
+        assert!(
+            (m - 1.0).abs() < f32::EPSILON,
+            "NaN sentiment must collapse to multiplier=1.0 (no boost); got {m}"
+        );
+
+        let owned = OwnedNoteBoostIndex::new(std::slice::from_ref(&nan_note));
+        let m = owned.boost("src/lib.rs", "my_fn");
+        assert!(m.is_finite(), "OwnedNoteBoostIndex NaN must clamp; got {m}");
+        assert!(
+            (m - 1.0).abs() < f32::EPSILON,
+            "OwnedNoteBoostIndex NaN → 1.0; got {m}"
+        );
+    }
 }

--- a/src/store/helpers/embeddings.rs
+++ b/src/store/helpers/embeddings.rs
@@ -107,6 +107,58 @@ mod tests {
         assert!(embedding_to_bytes(&emb, wrong_dim).is_err());
     }
 
+    /// TC-ADV-V1.38-10 (#1463): pin the current write-side contract for
+    /// non-finite embedding values. `embedding_to_bytes` validates dim
+    /// but NOT finiteness — `bytemuck::cast_slice` happily passes NaN /
+    /// ±Inf through to disk. The read-side counterpart
+    /// (`test_embedding_slice_passes_nan_bytes_through` below) pins
+    /// passthrough on load; this pins the same shape on save.
+    ///
+    /// Pre-fix this contract was undocumented and untested. A NaN
+    /// reaching SQLite via any of the 19 unchecked
+    /// `Embedding::new(...)` constructors poisons every cosine score
+    /// touching the chunk and only surfaces downstream as silent
+    /// drops in `BoundedScoreHeap::push` (which filters non-finite
+    /// scores). The audit recommends flipping this to the rejecting
+    /// form (mirroring `Embedding::try_new`); pinning current behavior
+    /// is the prerequisite so a follow-up PR can flip it loudly.
+    #[test]
+    fn test_embedding_to_bytes_passes_nan_through() {
+        let mut v = vec![0.5f32; crate::EMBEDDING_DIM];
+        v[0] = f32::NAN;
+        let emb = Embedding::new(v);
+        let bytes = embedding_to_bytes(&emb, crate::EMBEDDING_DIM)
+            .expect("dim is valid; current contract: NaN bytes pass through");
+        assert_eq!(bytes.len(), crate::EMBEDDING_DIM * 4);
+        // Round-trip via `embedding_slice` and verify the NaN survives.
+        let round = embedding_slice(&bytes, crate::EMBEDDING_DIM).unwrap();
+        assert!(
+            round[0].is_nan(),
+            "current contract: NaN passes write/read round-trip without rejection"
+        );
+    }
+
+    #[test]
+    fn test_embedding_to_bytes_passes_inf_through() {
+        let mut v = vec![0.5f32; crate::EMBEDDING_DIM];
+        v[0] = f32::INFINITY;
+        v[1] = f32::NEG_INFINITY;
+        let emb = Embedding::new(v);
+        let bytes = embedding_to_bytes(&emb, crate::EMBEDDING_DIM)
+            .expect("dim is valid; current contract: ±Inf bytes pass through");
+        let round = embedding_slice(&bytes, crate::EMBEDDING_DIM).unwrap();
+        assert_eq!(
+            round[0],
+            f32::INFINITY,
+            "current contract: +Inf passes write/read round-trip"
+        );
+        assert_eq!(
+            round[1],
+            f32::NEG_INFINITY,
+            "current contract: -Inf passes write/read round-trip"
+        );
+    }
+
     #[test]
     fn test_bytes_to_embedding_1024_dim() {
         let data = vec![0.5f32; 1024];


### PR DESCRIPTION
## Summary

Three TC-ADV-V1.38 regression-test backfills. All "fix shipped without test" cases — the underlying fix is in code, but a revert wouldn't fail any test. Closes **Cluster D** (TC-ADV-V1.38-1, -2, -10). Refs #1463.

## Why

Each test pins a security or correctness contract that was added without coverage. A future refactor / inlining could silently revert the fix and pass CI today.

## What ships

| ID | Test name | Pins |
|---|---|---|
| **TC-ADV-V1.38-1** | `validate_repo_id_rejects_parent_directory_refs` | SEC-V1.36-7's `..` rejection in `cqs export-model`. Five cases covered: `org/../../etc/passwd`, bare `..`, `foo/..`, `a..b/c` (mid-segment), `../escape/model` |
| **TC-ADV-V1.38-2** | `boost_clamps_inf_sentiment_to_finite_multiplier` + `boost_treats_nan_sentiment_as_finite_multiplier` | P1-36's clamp at `NoteBoostIndex::boost` / `OwnedNoteBoostIndex::boost`. Pre-fix only the SQLite round-trip was tested; the consumer-side clamp had zero direct coverage. Both borrowed and owned (production hot path) variants exercised |
| **TC-ADV-V1.38-10** | `test_embedding_to_bytes_passes_nan_through` + `test_embedding_to_bytes_passes_inf_through` | Pins the **current** write-side contract: `embedding_to_bytes` validates dim but not finiteness — NaN/±Inf bytes pass through to disk. Pre-fix this contract was undocumented and untested |

## On TC-ADV-V1.38-10

The audit's recommendation is to **flip** this contract to rejecting non-finite values (mirroring `Embedding::try_new`). This PR pins the current passthrough behavior as the prerequisite — a follow-up PR can flip the contract with a single test diff and a recovery hint, instead of guessing what the invariant was.

A NaN reaching SQLite via any of the 19 unchecked `Embedding::new(...)` sites (see `cqs callers Embedding::new`) poisons every cosine score touching the chunk and only surfaces downstream as silent drops in `BoundedScoreHeap::push`. Worth flipping; out of scope here.

## Tests

- [x] `cargo build --features gpu-index` clean
- [x] `validate_repo_id_rejects_parent_directory_refs` — pass
- [x] `boost_clamps_inf_sentiment_to_finite_multiplier` — pass
- [x] `boost_treats_nan_sentiment_as_finite_multiplier` — pass
- [x] `test_embedding_to_bytes_passes_nan_through` — pass
- [x] `test_embedding_to_bytes_passes_inf_through` — pass
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green

## What's NOT in scope

| ID | Why deferred |
|---|---|
| **TC-ADV-V1.38-3** | `upsert_sparse_vectors` write-path NaN/Inf — needs Store fixture |
| **TC-ADV-V1.38-4** | `worktree::is_dir` stray file — needs `.git/commondir` fixture |
| **TC-ADV-V1.38-5** | DS-V1.33-2 slot race — needs concurrent-writer harness |
| **TC-ADV-V1.38-6, -7, -9** | overlay caps + case-sensitivity edge cases — separate test passes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
