### PR TITLE
fix(rm): cap subprocess output for UMAP + export-model (Cluster G / #1463)

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_PARSER_MAX_FILE_SIZE` | `52428800` (50 MiB) | Per-file size cap inside the parser. Files above this are skipped with a warn. Distinct from `CQS_MAX_FILE_SIZE` (which gates file enumeration before the parser even runs). |
 | `CQS_PDF_MAX_BYTES` | `104857600` (100 MiB) | Max stdout bytes captured from the `pdf_to_md.py` subprocess invocation. v1.36.2: previously unbounded — a hostile or pathological PDF could spew arbitrary text into an in-memory `Vec<u8>`. Bump if vendor docs legitimately produce more than 100 MiB of text. |
 | `CQS_PDF_SCRIPT` | (auto) | Path to `pdf_to_md.py` for PDF conversion |
+| `CQS_UMAP_MAX_STDOUT_BYTES` | `1073741824` (1 GiB) | Max stdout bytes captured from the `run_umap.py` subprocess invocation (one ~64-byte coord line per chunk). Default ceiling sized for ~16M-chunk corpora; bump if you index more. v1.38: previously unbounded via `wait_with_output()` — a pathological / hostile script could OOM the indexer process (RM-V1.38-4 / #1463). |
 | `CQS_QUERY_CACHE_SIZE` | `128` | Embedding query cache entries |
 | `CQS_RAYON_THREADS` | (auto) | Rayon thread pool size for parallel operations |
 | `CQS_READ_MAX_FILE_SIZE` | `10485760` (10 MiB) | Max file size that `cqs read` will open (full-file body emit + note injection). Distinct from `CQS_MAX_DISPLAY_FILE_SIZE` because `cqs read` emits the entire file, not just a snippet. |

--- a/src/cli/commands/index/umap.rs
+++ b/src/cli/commands/index/umap.rs
@@ -168,15 +168,43 @@ pub(crate) fn run_umap_projection(store: &Store, quiet: bool) -> Result<usize> {
     }
     drop(payload); // free wire buffer; child has it now
 
-    let output = child
-        .wait_with_output()
-        .context("failed to wait for UMAP subprocess")?;
+    // RM-V1.38-4 (#1463): bounded streaming read of stdout/stderr instead
+    // of `wait_with_output()` (which buffers both unbounded). Mirrors the
+    // RM-V1.36-2 PDF converter pattern. Stdout carries the coord lines
+    // (~64 bytes per chunk × N chunks); cap at a generous ceiling so
+    // pathological / hostile script output can't OOM the indexer process.
+    // Default 1 GiB (sufficient for ~16M chunks at 64 bytes/line),
+    // env-overridable via `CQS_UMAP_MAX_STDOUT_BYTES`.
+    use std::io::Read;
+    let max_stdout_bytes: usize = std::env::var("CQS_UMAP_MAX_STDOUT_BYTES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1024 * 1024 * 1024);
+    let mut stdout_buf = Vec::with_capacity(64 * 1024);
+    let mut stderr_buf = Vec::with_capacity(8 * 1024);
+    if let Some(s) = child.stdout.take() {
+        let _ = s
+            .take((max_stdout_bytes as u64) + 1)
+            .read_to_end(&mut stdout_buf);
+    }
+    if let Some(s) = child.stderr.take() {
+        // 1 MiB cap on stderr — operators only need the tail for diagnostics.
+        let _ = s.take(1024 * 1024).read_to_end(&mut stderr_buf);
+    }
+    let status = child.wait().context("failed to wait for UMAP subprocess")?;
+    if stdout_buf.len() > max_stdout_bytes {
+        anyhow::bail!(
+            "UMAP subprocess stdout exceeded CQS_UMAP_MAX_STDOUT_BYTES ({} bytes) — \
+             output truncated; run with a smaller corpus or raise the cap",
+            max_stdout_bytes
+        );
+    }
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    if !status.success() {
+        let stderr = String::from_utf8_lossy(&stderr_buf);
         anyhow::bail!(
             "UMAP projection failed (exit {}): {}",
-            output.status,
+            status,
             stderr.trim()
         );
     }
@@ -184,12 +212,12 @@ pub(crate) fn run_umap_projection(store: &Store, quiet: bool) -> Result<usize> {
     // Echo the script's stderr at info level so per-run diagnostics surface
     // in the journal (it includes per-row coords range, which is useful
     // for spotting degenerate runs).
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = String::from_utf8_lossy(&stderr_buf);
     for line in stderr.lines() {
         tracing::info!(target: "cqs::umap", "{line}");
     }
 
-    let stdout = String::from_utf8(output.stdout).context("UMAP stdout is not UTF-8")?;
+    let stdout = String::from_utf8(stdout_buf).context("UMAP stdout is not UTF-8")?;
     let mut coords: Vec<(String, f64, f64)> = Vec::with_capacity(n_rows);
     for (lineno, line) in stdout.lines().enumerate() {
         let mut parts = line.splitn(3, '\t');

--- a/src/cli/commands/train/export_model.rs
+++ b/src/cli/commands/train/export_model.rs
@@ -56,12 +56,45 @@ pub(crate) fn cmd_export_model(
     // PB-29/EH-32: Find a working Python interpreter first
     let python = find_python()?;
 
-    // OB-26: Check Python deps, capture stderr for diagnostics
-    let check = std::process::Command::new(&python)
-        .args(["-c", "import optimum; import sentence_transformers"])
-        .output()?;
-    if !check.status.success() {
-        let stderr = String::from_utf8_lossy(&check.stderr);
+    // RM-V1.38-5 (#1463): bounded subprocess output. Both `Command::output()`
+    // calls used to buffer stdout/stderr unbounded — `optimum.exporters.onnx`
+    // can print multi-MB progress logs on a large export and a wedged HF
+    // download can grow RAM for hours. Mirror the RM-V1.36-2 PDF converter
+    // pattern (spawn + take MAX_BYTES). Operators only need the tail of
+    // stderr for diagnostics; stdout is purely informational.
+    use std::io::Read;
+    use std::process::Stdio;
+
+    /// Read up to `max` bytes from the spawned child's stdout+stderr,
+    /// then wait. Returns (status, stdout_buf, stderr_buf, stdout_truncated).
+    fn run_capped(
+        cmd: &mut std::process::Command,
+        max_stdout: u64,
+        max_stderr: u64,
+    ) -> std::io::Result<(std::process::ExitStatus, Vec<u8>, Vec<u8>, bool)> {
+        let mut child = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
+        let mut stdout_buf = Vec::with_capacity(8 * 1024);
+        let mut stderr_buf = Vec::with_capacity(4 * 1024);
+        if let Some(s) = child.stdout.take() {
+            let _ = s.take(max_stdout + 1).read_to_end(&mut stdout_buf);
+        }
+        if let Some(s) = child.stderr.take() {
+            let _ = s.take(max_stderr).read_to_end(&mut stderr_buf);
+        }
+        let status = child.wait()?;
+        let truncated = stdout_buf.len() as u64 > max_stdout;
+        Ok((status, stdout_buf, stderr_buf, truncated))
+    }
+
+    // OB-26: Check Python deps. Cheap probe — 4 KiB stdout + 16 KiB stderr is plenty.
+    let (check_status, _check_out, check_err, _) = run_capped(
+        std::process::Command::new(&python)
+            .args(["-c", "import optimum; import sentence_transformers"]),
+        4 * 1024,
+        16 * 1024,
+    )?;
+    if !check_status.success() {
+        let stderr = String::from_utf8_lossy(&check_err);
         anyhow::bail!(
             "Missing Python dependencies. Install with:\n  \
              pip install optimum sentence-transformers\n\n\
@@ -70,9 +103,11 @@ pub(crate) fn cmd_export_model(
         );
     }
 
-    // Export via optimum
-    let export = std::process::Command::new(&python)
-        .args([
+    // Export via optimum. 16 MiB stdout / 1 MiB stderr — plenty of headroom
+    // for legitimate progress logs but cuts off a wedged subprocess before
+    // it OOMs the indexer.
+    let (export_status, _export_out, export_err, export_truncated) = run_capped(
+        std::process::Command::new(&python).args([
             "-m",
             "optimum.exporters.onnx",
             "--model",
@@ -82,11 +117,19 @@ pub(crate) fn cmd_export_model(
             "--opset",
             "11",
             &output.to_string_lossy(),
-        ])
-        .output()?;
+        ]),
+        16 * 1024 * 1024,
+        1024 * 1024,
+    )?;
 
-    if !export.status.success() {
-        let stderr = String::from_utf8_lossy(&export.stderr);
+    if export_truncated {
+        tracing::warn!(
+            cap_bytes = 16 * 1024 * 1024,
+            "ONNX export stdout exceeded cap; truncated. Subsequent diagnostics may be incomplete."
+        );
+    }
+    if !export_status.success() {
+        let stderr = String::from_utf8_lossy(&export_err);
         anyhow::bail!("ONNX export failed:\n{}", stderr);
     }
 


### PR DESCRIPTION
## Summary

Two RM-V1.38 sibling regressions to RM-V1.36-2/-5 that were missed in the prior subprocess-output sweep. Closes **Cluster G** (RM-V1.38-4, RM-V1.38-5). Refs #1463.

## What's broken (pre-fix)

| ID | Site | Effect |
|---|---|---|
| **RM-V1.38-4** | `cqs index --umap` (`umap.rs:171`) used `wait_with_output()` | Buffers stdout (one ~64-byte coord line per chunk = ~64 MB at 1M chunks) and unbounded stderr. Wedged Python script → OOM the indexer |
| **RM-V1.38-5** | `cqs export-model` (two `Command::output()` calls) | `optimum.exporters.onnx` prints multi-MB progress logs on big exports; a wedged HF download grows RAM for hours |

## Fix

Mirror the RM-V1.36-2 PDF converter pattern: spawn + bounded `take(MAX_BYTES + 1)` reads on each handle, then `wait()`.

| Site | Stdout cap | Stderr cap | Env override |
|---|---|---|---|
| `cqs index --umap` | 1 GiB | 1 MiB | `CQS_UMAP_MAX_STDOUT_BYTES` |
| `cqs export-model` deps probe | 4 KiB | 16 KiB | none (cheap) |
| `cqs export-model` ONNX export | 16 MiB | 1 MiB | none |

The export-model fix is factored into a small `run_capped` helper local to `cmd_export_model` so the deps-probe and the actual export both go through the same shape — easier to audit, harder to introduce a third unbounded site.

## Tests

- [x] `cargo build --features gpu-index` clean
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green
- [ ] Smoke post-merge: `cqs export-model intfloat/e5-base-v2 /tmp/m` against an active HF Hub — should complete with capped output; `cqs index --umap` against a small fixture corpus

## What's NOT in scope

| ID | Why deferred |
|---|---|
| **RM-V1.38-1** | EmbeddingCache eviction tied to file events instead of wall-clock — needs a new periodic-tick path; separate PR |
| **RM-V1.38-2** | LocalProvider stash byte-cap (vs current count-cap) — needs configurable cap shape |
| **RM-V1.38-3** | PLACEHOLDER_CACHE 32k slots — documented "by design" |
| **RM-V1.38-6** | SPLADE encoder slot lifecycle — needs idle-tick eviction |
| **RM-V1.38-7..10** | Smaller asymmetries — separate cleanup pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
