### PR TITLE
fix(robustness): cap commondir read, replace daemon panic with bail, saturating UMAP capacity (Cluster H / #1463)

### DIFF
--- a/src/cli/commands/index/umap.rs
+++ b/src/cli/commands/index/umap.rs
@@ -119,7 +119,25 @@ pub(crate) fn run_umap_projection(store: &Store, quiet: bool) -> Result<usize> {
         "UMAP id_max_len exceeds wire format: {id_max_len} > u32::MAX"
     );
 
-    let mut payload: Vec<u8> = Vec::with_capacity(12 + n_rows * (2 + id_max_len + dim * 4));
+    // RB-V1.38-5 (#1463): the per-row size formula and the n_rows
+    // multiplication can each overflow on a 64-bit host even when the
+    // individual operands fit in u32 (the `ensure!` block above only
+    // validates each operand). Use saturating arithmetic so a
+    // pathological input bails with an explicit error instead of
+    // panicking on `Vec::with_capacity` or wrapping silently and
+    // hitting an out-of-bounds extend later.
+    let per_row = 2usize
+        .saturating_add(id_max_len)
+        .saturating_add(dim.saturating_mul(4));
+    let body_bytes = n_rows.saturating_mul(per_row);
+    let total_capacity = body_bytes.saturating_add(12);
+    anyhow::ensure!(
+        total_capacity < usize::MAX,
+        "UMAP payload size overflow: n_rows={} × per_row={} would exceed usize::MAX",
+        n_rows,
+        per_row,
+    );
+    let mut payload: Vec<u8> = Vec::with_capacity(total_capacity);
     payload.extend_from_slice(&(n_rows as u32).to_le_bytes());
     payload.extend_from_slice(&(dim as u32).to_le_bytes());
     payload.extend_from_slice(&(id_max_len as u32).to_le_bytes());

--- a/src/cli/watch/reindex.rs
+++ b/src/cli/watch/reindex.rs
@@ -612,21 +612,35 @@ pub(super) fn reindex_files(
     for ((i, _), emb) in to_embed.into_iter().zip(new_embeddings) {
         by_index.insert(i, emb);
     }
-    let embeddings: Vec<Embedding> = (0..chunk_count)
-        .map(|i| {
-            by_index.remove(&i).unwrap_or_else(|| {
-                // Should be unreachable: every chunk index is filled either
-                // from `cached` or from `to_embed` above. If we ever land
-                // here, the upstream split lost a chunk.
+    // RB-V1.38-2 (#1463): replace the daemon-killing `panic!` with a
+    // graceful early return. Pre-fix any future code path where
+    // `new_embeddings.len() != to_embed.len()` (partial ORT batch
+    // failure, embedder API change, etc.) would crash the watch
+    // thread mid-reindex. The watch loop already recovers from a
+    // returned `Err` by logging and skipping the file batch on the
+    // next tick — much better than a hard crash that drops the
+    // entire daemon. The "should be unreachable" invariant is
+    // preserved as a `tracing::error!` so any real-world hit shows
+    // up in journald.
+    let mut embeddings: Vec<Embedding> = Vec::with_capacity(chunk_count);
+    for i in 0..chunk_count {
+        match by_index.remove(&i) {
+            Some(e) => embeddings.push(e),
+            None => {
                 tracing::error!(
                     chunk_index = i,
                     chunk_count,
-                    "missing embedding at chunk index — upstream split lost a chunk"
+                    by_index_remaining = by_index.len(),
+                    "missing embedding at chunk index — upstream split lost a chunk; \
+                     skipping this reindex batch (next tick will retry from SQLite)"
                 );
-                panic!("missing embedding at chunk index {i} (chunk_count={chunk_count})")
-            })
-        })
-        .collect();
+                anyhow::bail!(
+                    "watch reindex: chunk index {i} missing embedding (chunk_count={chunk_count}); \
+                     daemon will retry on next tick"
+                );
+            }
+        }
+    }
 
     // P2.67: build calls_by_id directly from `per_file_chunk_calls` (collected
     // by `parse_file_all_with_chunk_calls` above) instead of re-parsing every

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -86,9 +86,22 @@ pub fn resolve_main_project_dir(dir: &Path) -> Option<PathBuf> {
         dir.join(&gitdir)
     };
 
-    // Read `<gitdir>/commondir` → relative path back to canonical `.git/`
+    // Read `<gitdir>/commondir` → relative path back to canonical `.git/`.
+    //
+    // RB-V1.38-1 (#1463): cap the read at MAX_GIT_FILE_BYTES (4 KiB),
+    // matching the .git-file read above (RB-V1.33-2 sibling). Pre-fix
+    // `read_to_string` was unbounded — a hostile or corrupt
+    // `<gitdir>/commondir` (the path ultimately derives from the
+    // worktree's untrusted `.git` link) could OOM the CLI on every
+    // invocation from inside a worktree.
+    use std::io::Read;
     let commondir_file = gitdir.join("commondir");
-    let commondir_relative = std::fs::read_to_string(&commondir_file).ok()?;
+    let mut commondir_relative = String::with_capacity(64);
+    std::fs::File::open(&commondir_file)
+        .ok()?
+        .take(MAX_GIT_FILE_BYTES)
+        .read_to_string(&mut commondir_relative)
+        .ok()?;
     let commondir_relative = commondir_relative.trim();
     if commondir_relative.is_empty() {
         return None;


### PR DESCRIPTION
## Summary

Three RB-V1.38 panic / OOM surfaces. Closes **Cluster H** (RB-V1.38-1, -2, -5). Refs #1463.

## What's broken (pre-fix)

| ID | Site | Effect |
|---|---|---|
| **RB-V1.38-1** | `src/worktree.rs:91` `read_to_string(&commondir_file)` | Unbounded read of `<gitdir>/commondir`; path derives from the worktree's untrusted `.git` link → hostile/corrupt commondir OOMs the CLI on every invocation from inside a worktree |
| **RB-V1.38-2** | `src/cli/watch/reindex.rs:626` `panic!("missing embedding...")` | Daemon-killing `panic!` in the chunk-index merge loop. Comment says unreachable, but a partial ORT batch failure → short `new_embeddings.len()` → instant daemon crash mid-reindex |
| **RB-V1.38-5** | `src/cli/commands/index/umap.rs:122` `Vec::with_capacity(12 + n_rows * (2 + id_max_len + dim * 4))` | Each operand ≤ `u32::MAX` per `ensure!` checks; product can reach ~9.2e19, past `usize::MAX`. Release-build wrap → undersized buffer → OOB panic on `extend_from_slice` |

## What ships

| ID | Fix |
|---|---|
| **RB-V1.38-1** | `File::open(...).take(MAX_GIT_FILE_BYTES).read_to_string(...)` matching the `.git` link read pattern (RB-V1.33-2) |
| **RB-V1.38-2** | `panic!` → `anyhow::bail!`; the watch loop already recovers from `Err` returns by skipping the file batch on the next tick. `tracing::error!` preserved so any real-world hit shows up in journald |
| **RB-V1.38-5** | `saturating_mul` / `saturating_add` chain + `anyhow::ensure!(total_capacity < usize::MAX, ...)` |

## Tests

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib worktree` — 10/10 pass (no regression)
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green
- [ ] Smoke post-merge: invoke `cqs` from inside a worktree → reads `commondir` correctly; daemon survives a synthetic short-batch from the embedder (logs an error, skips batch, retries on next tick)

## What's NOT in scope

| ID | Why deferred |
|---|---|
| **RB-V1.38-3** | 9 `unwrap()` on splade body slice `try_into` — each preceded by `need(&body, cursor, n)?`; provably safe today, but doc-rule violation. Flipping to `?` requires structural load-path rework |
| **RB-V1.38-4, -6, -7, -8, -9, -10** | Latent / refactor-fragile unwraps with cross-scope invariants — bundled into a separate "rebind at the guard" follow-up |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
