### PR TITLE
fix: SPLADE α slot resolver warns, ref-update entry span, drift detection structured warn (Cluster J / #1463)

### DIFF
--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -1511,6 +1511,17 @@ fn check_index_model_drift(
     if target_matches {
         return Ok(());
     }
+    // OB-V1.38-2 (#1463): emit a structured warn alongside the bail
+    // string so daemon-mode operators (and journald harvesters) see
+    // the drift event in their structured log stream. Pre-fix only
+    // stderr saw it — daemon-spawned `cqs index` would silently fail
+    // an alert path.
+    tracing::warn!(
+        stored_model = %stored_name,
+        requested_model = %requested_name,
+        index_path = %index_path.display(),
+        "Index model drift detected — refusing to clobber the existing index"
+    );
     anyhow::bail!(
         "Index at {} was built for model `{stored}`, but `--model` resolved to \
          `{requested}`. Re-run with `cqs index --force --model {requested}` to rebuild \

--- a/src/cli/commands/infra/reference.rs
+++ b/src/cli/commands/infra/reference.rs
@@ -597,6 +597,25 @@ fn cmd_ref_remove(name: &str, json: bool) -> Result<()> {
 
 /// Re-index a reference from its source directory.
 fn cmd_ref_update(cli: &Cli, name: &str, json: bool, opts: RefUpdateLlmOpts) -> Result<()> {
+    // OB-V1.38-1 (#1463): per-subcommand entry span. The parent
+    // `cmd_ref` span carries `cmd_ref` only; without a child here,
+    // structured-trace consumers can't tell which ref name was reindexed
+    // or which post-pipeline pass (LLM / HyDE / docs / enrichment) is
+    // the slow leg without RUST_LOG=debug. Mirrors the
+    // `cmd_project_search` per-subcommand span pattern in
+    // `src/cli/commands/infra/project.rs`.
+    #[cfg(feature = "llm-summaries")]
+    let _span = tracing::info_span!(
+        "cmd_ref_update",
+        ref_name = %name,
+        llm_summaries = opts.llm_summaries,
+        improve_docs = opts.improve_docs,
+        hyde_queries = opts.hyde_queries
+    )
+    .entered();
+    #[cfg(not(feature = "llm-summaries"))]
+    let _span = tracing::info_span!("cmd_ref_update", ref_name = %name).entered();
+
     // #1459 item 3: enforce flag-dependency invariants up front so misuse
     // bails before the (potentially long) index pipeline runs. Mirrors
     // `cmd_index`'s pre-flight at `src/cli/commands/index/build.rs`.

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -136,10 +136,25 @@ fn run_with_dispatch(
     // table, install. Slot-resolution failure (missing project, malformed
     // slot.toml) → empty table → router falls through to env / preset /
     // default precedence as before.
-    let slot_alpha_table = cqs::slot::resolve_slot_name(cli.slot.as_deref(), project_cqs_dir)
-        .ok()
-        .map(|s| cqs::slot::read_slot_splade_alpha_table(project_cqs_dir, &s.name))
-        .unwrap_or_default();
+    // EH-V1.38-5 (#1463): mirror the EH-V1.30.1-3 fix shape applied 30
+    // lines above. Pre-fix `.ok().map(...).unwrap_or_default()` silently
+    // collapsed slot-resolution errors (typo, missing slot file) into
+    // an empty α table — operator who passed `--slot foo` saw default-
+    // slot α overrides with the only signal being different search
+    // results from what they asked for.
+    let slot_alpha_table = match cqs::slot::resolve_slot_name(cli.slot.as_deref(), project_cqs_dir)
+    {
+        Ok(resolved) => cqs::slot::read_slot_splade_alpha_table(project_cqs_dir, &resolved.name),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                slot = ?cli.slot,
+                "Slot resolution failed when looking up SPLADE α overrides — \
+                 falling back to env / preset / default α precedence"
+            );
+            Default::default()
+        }
+    };
     cqs::search::router::install_slot_splade_alpha_overrides(slot_alpha_table);
 
     // EXT-V1.36-1 (#1460): load synonym overlay from


### PR DESCRIPTION
## Summary

Three small high-leverage fixes from the v1.38.0 audit Cluster J. Refs #1463.

| ID | Site | Effect |
|---|---|---|
| **EH-V1.38-5** | `src/cli/dispatch.rs:139` SPLADE α slot resolver | `.ok().map(...).unwrap_or_default()` silently collapsed slot resolution errors into an empty α table. Operator passing `--slot foo` (typo) saw default-slot α with no signal except different search results |
| **OB-V1.38-1** | `src/cli/commands/infra/reference.rs:599` `cmd_ref_update` | No entry span. Parent `cmd_ref` carried only `cmd_ref`; structured-trace consumers couldn't tell which ref name was reindexed or which pipeline pass was the slow leg without RUST_LOG=debug |
| **OB-V1.38-2** | `src/cli/commands/index/build.rs:1514` `check_index_model_drift` | `anyhow::bail!` only — daemon-spawned `cqs index` hits the drift via stderr, but daemon-mode operators harvesting journald lost the alert path |

## Fixes

| ID | Change |
|---|---|
| **EH-V1.38-5** | `match resolve_slot_name { Ok(r) => ..., Err(e) => warn + Default }` mirroring the EH-V1.30.1-3 pattern 30 lines above |
| **OB-V1.38-1** | `info_span!("cmd_ref_update", ref_name, llm_summaries, improve_docs, hyde_queries)` (llm fields feature-gated) |
| **OB-V1.38-2** | `tracing::warn!` with `stored_model`, `requested_model`, `index_path` fields before the bail |

## Tests

- [x] `cargo build --features gpu-index` clean
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green
- [ ] Smoke post-merge: invoke `cqs --slot nonexistent search foo` → journald shows the warn line; `cqs ref reindex tokio` → trace span present; `cqs index --model embeddinggemma-300m` against a `bge-large` index → structured warn before bail

## What's NOT in scope (rest of Cluster J)

| ID | Why deferred |
|---|---|
| **RM-V1.38-1** | EmbeddingCache wall-clock eviction — needs new periodic-tick infrastructure |
| **EH-V1.38-6, -9, -10** | Hook status disambig, triple-dtype tensor extract, env-parser silent acceptance — separate cleanup pass |
| **OB-V1.38-3** | Overlay install info-level promotion — needs eval-sweep test contract coordination |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
