### PR TITLE
fix(error-handling): tensor cascade error preservation, %e for tree-sitter, warn on malformed env (Cluster L / #1463)

### DIFF
--- a/src/cli/limits.rs
+++ b/src/cli/limits.rs
@@ -204,21 +204,46 @@ pub(crate) fn batch_max_line_len() -> usize {
 /// back to the supplied default. Zero is rejected because every caller
 /// here treats the value as a non-zero size limit; a caller that wants to
 /// disable a check should remove the call, not set it to zero.
+///
+/// EH-V1.38-10 (#1463): warn loudly on a malformed-but-set value so an
+/// operator who typoed `CQS_RERANK_POOL_MAX=128 ` (trailing space) or
+/// `=abc` sees the silent-default fall-through instead of debugging
+/// "why isn't my env var doing anything." Mirrors the warn pattern in
+/// every other env-knob helper in the repo (gather.rs, trace.rs,
+/// pipeline/types.rs, etc.).
 fn parse_env_usize(key: &str, default: usize) -> usize {
     match std::env::var(key) {
-        Ok(v) => v
-            .parse::<usize>()
-            .ok()
-            .filter(|n| *n > 0)
-            .unwrap_or(default),
+        Ok(v) => match v.parse::<usize>() {
+            Ok(n) if n > 0 => n,
+            _ => {
+                tracing::warn!(
+                    env = key,
+                    value = %v,
+                    "Invalid env var (must be positive usize), using default {default}"
+                );
+                default
+            }
+        },
         Err(_) => default,
     }
 }
 
 /// Same as [`parse_env_usize`] but for `u64`-shaped byte limits.
+///
+/// EH-V1.38-10 (#1463): same warn-on-malformed contract.
 fn parse_env_u64(key: &str, default: u64) -> u64 {
     match std::env::var(key) {
-        Ok(v) => v.parse::<u64>().ok().filter(|n| *n > 0).unwrap_or(default),
+        Ok(v) => match v.parse::<u64>() {
+            Ok(n) if n > 0 => n,
+            _ => {
+                tracing::warn!(
+                    env = key,
+                    value = %v,
+                    "Invalid env var (must be positive u64), using default {default}"
+                );
+                default
+            }
+        },
         Err(_) => default,
     }
 }

--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -1322,15 +1322,41 @@ impl Embedder {
         // `Vec<f32>`; the f32 fast path pays one extra `.to_vec()`
         // (~few MB/batch) for shape uniformity vs branching the rest
         // of the function body.
+        // EH-V1.38-7 (#1463): preserve the swallowed f32 / f16 errors when
+        // the bf16 fallback also fails, so the surfaced error reflects
+        // the real root cause instead of just the last branch's
+        // "wrong-dtype" trail. Pre-fix all three branches collapsed to a
+        // bare bf16 error: an actual ORT failure ("session output index
+        // out of range", "tensor backing memory invalid") on the f32
+        // path was invisible.
+        //
+        // Each non-bf16 error is also logged at debug as the cascade
+        // walks past it — operators with `RUST_LOG=cqs=debug` see the
+        // dtype-probe progression directly. The chain stays cheap: the
+        // happy f32 path returns immediately; only fallback hits the
+        // logging + carry overhead.
         let (shape_vec, data_vec): (Vec<i64>, Vec<f32>) = match output.try_extract_tensor::<f32>() {
             Ok((s, d)) => (s.to_vec(), d.to_vec()),
-            Err(_) => match output.try_extract_tensor::<half::f16>() {
-                Ok((s, d)) => (s.to_vec(), d.iter().map(|h| h.to_f32()).collect()),
-                Err(_) => {
-                    let (s, d) = output.try_extract_tensor::<half::bf16>().map_err(ort_err)?;
-                    (s.to_vec(), d.iter().map(|h| h.to_f32()).collect())
+            Err(e_f32) => {
+                tracing::debug!(error = %e_f32, "f32 tensor extract failed, trying f16");
+                match output.try_extract_tensor::<half::f16>() {
+                    Ok((s, d)) => (s.to_vec(), d.iter().map(|h| h.to_f32()).collect()),
+                    Err(e_f16) => {
+                        tracing::debug!(error = %e_f16, "f16 tensor extract failed, trying bf16");
+                        match output.try_extract_tensor::<half::bf16>() {
+                            Ok((s, d)) => (s.to_vec(), d.iter().map(|h| h.to_f32()).collect()),
+                            Err(e_bf16) => {
+                                // Surface all three so the operator sees which dtype
+                                // probe was the real failure, not just the last one.
+                                return Err(EmbedderError::InferenceFailed(format!(
+                                    "tensor extract failed for all dtypes — f32: {e_f32}; \
+                                     f16: {e_f16}; bf16: {e_bf16}"
+                                )));
+                            }
+                        }
+                    }
                 }
-            },
+            }
         };
         let shape: &[i64] = &shape_vec;
         let data: &[f32] = &data_vec;

--- a/src/parser/aspx.rs
+++ b/src/parser/aspx.rs
@@ -233,7 +233,9 @@ fn parse_server_code(
 
     let mut ts_parser = tree_sitter::Parser::new();
     if let Err(e) = ts_parser.set_language(&grammar) {
-        tracing::warn!(error = ?e, %language, "Failed to set tree-sitter language for ASPX server code");
+        // EH-V1.38-8 (#1463): Display matches the sibling `%e` pattern
+        // 5 lines below at the `set_included_ranges` warn.
+        tracing::warn!(error = %e, %language, "Failed to set tree-sitter language for ASPX server code");
         return vec![];
     }
 

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -49,8 +49,10 @@ impl Parser {
         };
         let mut parser = tree_sitter::Parser::new();
         if let Err(e) = parser.set_language(&grammar) {
+            // EH-V1.38-8 (#1463): Display, not Debug — matches the
+            // sibling `error = %e` pattern at line 79.
             tracing::warn!(
-                error = ?e,
+                error = %e,
                 %language,
                 start_byte,
                 end_byte,

--- a/src/parser/injection.rs
+++ b/src/parser/injection.rs
@@ -274,8 +274,10 @@ fn build_injection_tree(
     let grammar = language.try_grammar()?;
     let mut parser = tree_sitter::Parser::new();
     if let Err(e) = parser.set_language(&grammar) {
+        // EH-V1.38-8 (#1463): Display, not Debug — matches the
+        // sibling `error = %e` pattern at line 287.
         tracing::warn!(
-            error = ?e,
+            error = %e,
             %language,
             "Failed to set language for injection"
         );


### PR DESCRIPTION
## Summary

Three small EH-V1.38 polish items. Closes **Cluster L** (EH-V1.38-7, -8, -10). Refs #1463.

## What ships

| ID | Site | Effect |
|---|---|---|
| **EH-V1.38-7** | `src/embedder/mod.rs:1325` triple-cascade `f32 → f16 → bf16` tensor extract | Silently swallowed f32+f16 errors; surfaced only bf16 failure. Real ORT errors on the f32 path were invisible behind misleading "bf16 extract failed" |
| **EH-V1.38-8** | `src/parser/{calls,injection,aspx}.rs` (3 sites) | Logged tree-sitter `LanguageError` via `error = ?e` (Debug multi-line) when sibling lines used `error = %e` (Display one-line) |
| **EH-V1.38-10** | `src/cli/limits.rs::parse_env_{usize,u64}` | Collapsed `Ok(unparseable)`, `Ok("0")`, `Ok("abc")` into the default with no warn. Operator typoing `CQS_RERANK_POOL_SIZE=128 ` (trailing space) got the default with zero signal. Six production knobs flow through these helpers |

## Fixes

| ID | Change |
|---|---|
| **EH-V1.38-7** | Capture all three errors; debug-log cascade progression; on bf16 failure surface single error string with all three for triage. Happy f32 path stays zero-cost; only fallback hits the new error-carry overhead |
| **EH-V1.38-8** | Three-site sweep `?e` → `%e` to match siblings already using Display |
| **EH-V1.38-10** | Match-with-warn ladder mirroring `gather.rs::gather_max_nodes` etc. — `tracing::warn!(env = key, value = %v, "Invalid env var ...")` on malformed-but-set values |

## Tests

- [x] `cargo build --features gpu-index` clean
- [x] `cargo clippy --features gpu-index --lib --bin cqs -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI green
- [ ] Smoke post-merge: set `CQS_RERANK_POOL_SIZE=abc` and run `cqs <q> --reranker onnx` → journald shows the warn line; run an embedder query against a model whose ONNX outputs an unexpected dtype (synthetic stress) → log shows all three dtype probes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
