### PR TITLE
fix: cluster M — P3 mechanical sweep (10 findings, #1463)

### DIFF
--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -1537,12 +1537,19 @@ impl<Mode: crate::store::ClearHnswDirty> crate::index::IndexBackend<Mode> for Ca
         let dim = ctx.store.dim();
         let gpu_available = CagraIndex::gpu_available_for(chunk_count as usize, dim);
         if chunk_count < cagra_threshold || !gpu_available {
-            tracing::debug!(
+            // OB-V1.38-5 (#1463): info-level so an operator with default log
+            // filtering can see the GPU/CPU fallback decision in journald.
+            // One line per Store init (not per query), tagged with the same
+            // `backend` / `source` shape as the success arms (cagra=persisted
+            // / built; hnsw=cagra-ineligible) so log filters work uniformly.
+            tracing::info!(
+                backend = "hnsw",
+                source = "cagra-ineligible",
                 chunk_count,
                 cagra_threshold,
                 dim,
                 gpu_available,
-                "CAGRA backend ineligible — falling through"
+                "Vector index backend selected"
             );
             return Ok(None);
         }

--- a/src/cli/commands/infra/hook.rs
+++ b/src/cli/commands/infra/hook.rs
@@ -389,8 +389,25 @@ fn do_uninstall(git_dir: &Path) -> Result<UninstallReport> {
         let path = git_dir.join(hook);
         // RB-V1.36-3: capped read; oversize files are treated as not-present
         // to fall through to the "leave foreign hook alone" branch.
+        //
+        // EH-V1.38-6 (#1463): distinguish NotFound (expected, fine) from
+        // permission-denied / oversize / other I/O errors so an operator
+        // doesn't see "hook not present" while a perm-locked or oversize
+        // file silently survives. The report bucket stays the same to avoid
+        // a schema change; the warn is the operator-facing signal.
         match read_hook_capped(&path) {
-            Err(_) => report.not_present.push(hook.to_string()),
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    tracing::warn!(
+                        hook = hook,
+                        path = %path.display(),
+                        error = %e,
+                        kind = ?e.kind(),
+                        "Hook present but unreadable; treating as not-present (uninstall will not touch it)"
+                    );
+                }
+                report.not_present.push(hook.to_string());
+            }
             Ok(content) => {
                 if content.contains(HOOK_MARKER_PREFIX) {
                     std::fs::remove_file(&path)
@@ -532,8 +549,24 @@ fn do_hook_status(git_dir: &Path) -> Result<StatusReport> {
         let path = git_dir.join(hook);
         // RB-V1.36-3: capped read; oversize files are reported as foreign
         // (since we can't tell whether they contain HOOK_MARKER_PREFIX).
+        //
+        // EH-V1.38-6 (#1463): same NotFound-vs-other split as `do_uninstall`
+        // — an operator running `cqs hook status` should see a warn for
+        // permission-denied / oversize files instead of the discrepancy
+        // hiding under a "missing" label.
         match read_hook_capped(&path) {
-            Err(_) => report.missing.push(hook.to_string()),
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    tracing::warn!(
+                        hook = hook,
+                        path = %path.display(),
+                        error = %e,
+                        kind = ?e.kind(),
+                        "Hook present but unreadable; reporting as missing"
+                    );
+                }
+                report.missing.push(hook.to_string());
+            }
             Ok(content) => {
                 if content.contains(HOOK_MARKER_PREFIX) {
                     report.installed.push(hook.to_string());

--- a/src/cli/commands/infra/model.rs
+++ b/src/cli/commands/infra/model.rs
@@ -85,7 +85,10 @@ pub(crate) fn daemon_control_hint(hint: DaemonHint) -> &'static str {
             }
         }
     }
-    #[cfg(target_os = "macos")]
+    // PL-V1.38-6 (#1463): cfg(unix) covers macOS + every BSD + illumos —
+    // pkill works identically on all of them, and the daemon (cfg(unix))
+    // builds on FreeBSD/OpenBSD/NetBSD/illumos too.
+    #[cfg(all(unix, not(target_os = "linux")))]
     {
         match hint {
             DaemonHint::Start => "cqs watch --serve &",
@@ -97,7 +100,7 @@ pub(crate) fn daemon_control_hint(hint: DaemonHint) -> &'static str {
             }
         }
     }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[cfg(not(unix))]
     {
         match hint {
             DaemonHint::Start => "cqs watch --serve",

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -311,8 +311,13 @@ pub struct Cli {
     pub verbose: bool,
 
     /// Resolved model config (set by dispatch, not CLI).
+    ///
+    /// API-V1.38-5 (#1463): `pub(super)` because the field is `#[arg(skip)]`
+    /// — clap doesn't need it `pub`, and only `cli::dispatch` (writer) and
+    /// `cli::definitions::Cli::try_model_config` (reader) touch it. External
+    /// readers should go through `try_model_config()` (still `pub`).
     #[arg(skip)]
-    pub resolved_model: Option<cqs::embedder::ModelConfig>,
+    pub(super) resolved_model: Option<cqs::embedder::ModelConfig>,
 }
 
 impl Cli {

--- a/src/llm/batch.rs
+++ b/src/llm/batch.rs
@@ -153,7 +153,17 @@ impl LlmClient {
     }
 
     /// Poll until a batch completes. Returns when status is "ended".
+    ///
+    /// OB-V1.38-4 (#1463): Anthropic batches typically take 10-30 minutes;
+    /// this is the leaf span where the wall-clock waiting actually happens.
+    /// Entry span + closing `elapsed_ms` make "why did the LLM summary pass
+    /// take 47 minutes?" attributable to API slowness vs local processing.
+    /// The non-success terminal arms (canceling/canceled/expired) also fire
+    /// a structured `tracing::warn!` with the same field shape so an
+    /// operator sees them in journald instead of just `Err(...)`.
     pub(super) fn wait_for_batch(&self, batch_id: &str, quiet: bool) -> Result<(), LlmError> {
+        let _span = tracing::info_span!("wait_for_batch", batch_id).entered();
+        let started = std::time::Instant::now();
         if !super::is_valid_anthropic_batch_id(batch_id) {
             return Err(LlmError::InvalidBatchId(batch_id.to_string()));
         }
@@ -189,10 +199,20 @@ impl LlmClient {
 
             match batch.processing_status.as_str() {
                 "ended" => {
-                    tracing::info!(batch_id, "Batch complete");
+                    tracing::info!(
+                        batch_id,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "Batch complete"
+                    );
                     return Ok(());
                 }
-                "canceling" | "canceled" | "expired" => {
+                status @ ("canceling" | "canceled" | "expired") => {
+                    tracing::warn!(
+                        batch_id,
+                        status,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "Batch ended in non-success state"
+                    );
                     return Err(LlmError::BatchFailed(format!(
                         "Batch {} ended with status: {}",
                         batch_id, batch.processing_status

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -1092,24 +1092,29 @@ fn another() {
     }
 
     /// Diagnostic: verify type queries compile for all languages with type_query defined
+    ///
+    /// EX-V1.38-10 (#1463): iterate `Language::all_variants()` filtered by
+    /// `def().type_query.is_some()` instead of a hand-rolled array — a
+    /// new language with a type query gets covered automatically. FSharp
+    /// has a `type_query` registered on its LanguageDef but the query
+    /// has a pre-existing tree-sitter-fsharp node-type mismatch (`type`
+    /// is not a valid node), so we skip it here. Removing the registration
+    /// is a separate cleanup; the test should still cover every other
+    /// language whose `type_query.is_some()`.
     #[test]
     fn test_type_queries_compile() {
         let parser = Parser::new().unwrap();
-        let languages_with_types = [
-            Language::Rust,
-            Language::TypeScript,
-            Language::Python,
-            Language::Go,
-            Language::Java,
-            Language::C,
-            Language::CSharp,
-            // FSharp type query has pre-existing compile issues (#node-type mismatch)
-            Language::Scala,
-            Language::Cpp,
-            Language::Php,
-            Language::Zig,
-        ];
-        for lang in languages_with_types {
+        let mut covered = 0usize;
+        for lang in Language::all_variants().iter().copied() {
+            if lang == Language::FSharp {
+                continue;
+            }
+            let Some(def) = lang.try_def() else {
+                continue;
+            };
+            if def.type_query.is_none() {
+                continue;
+            }
             let result = parser.get_type_query(lang);
             assert!(
                 result.is_ok(),
@@ -1117,6 +1122,12 @@ fn another() {
                 lang,
                 result.err()
             );
+            covered += 1;
         }
+        assert!(
+            covered > 0,
+            "test_type_queries_compile asserted nothing — \
+             no Language has a `type_query` defined"
+        );
     }
 }

--- a/src/parser/l5x.rs
+++ b/src/parser/l5x.rs
@@ -260,8 +260,16 @@ fn extract_l5x_regions(source: &str) -> Vec<StRegion> {
     let mut regions = Vec::new();
 
     for st_match in L5X_ST_CONTENT_RE.captures_iter(source) {
-        let full = st_match.get(0).unwrap();
-        let inner = st_match.get(1).unwrap();
+        // RB-V1.38-6 (#1463): group 0 is the full match (always present
+        // when an iter yields a Captures); group 1 is the unconditional
+        // capture in `<STContent>(.*?)</STContent>`. `.expect()` documents
+        // the invariant — a regex tweak that adds an alternation or
+        // optional group would surface here at panic time instead of
+        // hiding behind `.unwrap()`.
+        let full = st_match.get(0).expect("captures group 0 always present");
+        let inner = st_match
+            .get(1)
+            .expect("L5X_ST_CONTENT_RE: group 1 is unconditional");
         let start_byte = full.start();
         let line_start = line_of(source, start_byte);
 
@@ -363,9 +371,23 @@ fn extract_l5k_regions(source: &str) -> Vec<StRegion> {
     let mut regions = Vec::new();
 
     for block in L5K_ROUTINE_BLOCK_RE.captures_iter(source) {
-        let routine_name = block.get(1).unwrap().as_str().to_string();
-        let block_content = block.get(2).unwrap().as_str();
-        let block_start = block.get(0).unwrap().start();
+        // RB-V1.38-6 (#1463): groups 1 and 2 are unconditional captures in
+        // L5K_ROUTINE_BLOCK_RE (`(\w+)\b([^\x00]*?)`); group 0 is always
+        // present on an iter Captures. `.expect()` over `.unwrap()` makes
+        // the invariant survive a regex refactor at panic message time.
+        let routine_name = block
+            .get(1)
+            .expect("L5K_ROUTINE_BLOCK_RE: group 1 (routine name) unconditional")
+            .as_str()
+            .to_string();
+        let block_content = block
+            .get(2)
+            .expect("L5K_ROUTINE_BLOCK_RE: group 2 (block content) unconditional")
+            .as_str();
+        let block_start = block
+            .get(0)
+            .expect("captures group 0 always present")
+            .start();
 
         // Check if this routine is type ST
         let is_st = block_content
@@ -384,7 +406,13 @@ fn extract_l5k_regions(source: &str) -> Vec<StRegion> {
 
         // Try ST_CONTENT := [ ... ]; block first
         let st_source = if let Some(st_block) = L5K_ST_CONTENT_BLOCK_RE.captures(block_content) {
-            let inner = st_block.get(1).unwrap().as_str();
+            // RB-V1.38-6 (#1463): group 1 is the unconditional `(.*?)` in
+            // `ST_CONTENT\s*:=\s*\[(.*?)\]\s*;` — present whenever the outer
+            // captures matched.
+            let inner = st_block
+                .get(1)
+                .expect("L5K_ST_CONTENT_BLOCK_RE: group 1 (inner) unconditional")
+                .as_str();
             // Lines inside the bracket block, trimmed
             inner
                 .lines()

--- a/src/search/router.rs
+++ b/src/search/router.rs
@@ -520,6 +520,11 @@ pub fn install_classifier_vocab_overlay(extra_negation: Vec<String>, extra_multi
     if extra_negation.is_empty() && extra_multistep.is_empty() {
         return;
     }
+    // OB-V1.38-3 (#1463): info-level so operators editing
+    // `~/.config/cqs/classifier.toml` see their config land in journald
+    // without RUST_LOG=debug. Fires only when at least one set is non-empty.
+    let neg_count = extra_negation.len();
+    let multi_count = extra_multistep.len();
     if !extra_negation.is_empty() {
         let mut g = NEGATION_TOKENS.write().unwrap_or_else(|p| p.into_inner());
         for tok in extra_negation {
@@ -551,6 +556,11 @@ pub fn install_classifier_vocab_overlay(extra_negation: Vec<String>, extra_multi
             .unwrap_or_else(|p| p.into_inner());
         *g = std::sync::Arc::new(new_ac);
     }
+    tracing::info!(
+        negation_added = neg_count,
+        multistep_added = multi_count,
+        "Installed classifier vocab overlay"
+    );
 }
 
 /// Test-only: reset both vocab tables to the compile-time builtins.
@@ -687,9 +697,18 @@ static SLOT_SPLADE_ALPHA: std::sync::RwLock<Option<std::collections::HashMap<Str
 /// `to_string()`); values are pre-validated to `[0.0, 1.0]` finite by
 /// [`crate::slot::read_slot_splade_alpha_table`].
 pub fn install_slot_splade_alpha_overrides(table: std::collections::HashMap<String, f32>) {
+    // OB-V1.38-3 (#1463): info-level when an operator's slot α overrides
+    // actually take, so the journald audit trail records whether the
+    // `slot.toml [splade.alpha]` table was applied. Empty tables stay
+    // silent — every dispatch installs an empty table when no overlay
+    // exists, and we don't want a per-command log line for that case.
+    let entries = table.len();
     match SLOT_SPLADE_ALPHA.write() {
         Ok(mut g) => {
             *g = Some(table);
+            if entries > 0 {
+                tracing::info!(entries, "Installed per-slot SPLADE α overrides");
+            }
         }
         Err(_) => {
             tracing::warn!(

--- a/src/search/synonyms.rs
+++ b/src/search/synonyms.rs
@@ -82,10 +82,17 @@ pub fn install_synonym_overlay(extras: HashMap<String, Vec<String>>) {
     if extras.is_empty() {
         return;
     }
+    // OB-V1.38-3 (#1463): info-level so an operator who edited
+    // `~/.config/cqs/synonyms.toml` (or the project-local override) sees
+    // their config landing in journald without RUST_LOG=debug. Fires only
+    // when the merged input is non-empty, so the default no-overlay case
+    // stays silent.
+    let entries = extras.len();
     let mut g = SYNONYMS.write().unwrap_or_else(|p| p.into_inner());
     for (k, v) in extras {
         g.insert(k.to_lowercase(), v);
     }
+    tracing::info!(entries, "Installed synonym overlay");
 }
 
 /// Test-only: reset the synonym table to the compile-time builtins.

--- a/src/train_data/query.rs
+++ b/src/train_data/query.rs
@@ -11,7 +11,10 @@ fn conventional_prefix_re() -> &'static Regex {
 fn leading_verb_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"(?i)^(add|added|adds|implement|implemented|implements|fix|fixed|fixes|update|updated|updates|remove|removed|removes|refactor|refactored|refactors|move|moved|moves|rename|renamed|renames|change|changed|changes|improve|improved|improves|introduce|introduced|introduces|replace|replaced|replaces|convert|converted|converts|use|wip|bump|bumped|bumps|extract|extracted|extracts|simplify|simplified|simplifies|handle|handled|handles|make|delete|deleted|deletes|clean|cleaned|cleans|create|created|creates|merge|merged|merges|revert|reverted|reverts|enable|enabled|enables|disable|disabled|disables|drop|dropped|drops|migrate|migrated|migrates|switch|switched|switches|allow|allowed|allows|prevent|prevented|prevents|ensure|ensured|ensures|apply|applied|applies|adjust|adjusted|adjusts|correct|corrected|corrects|set|support|supported|supports)\s+").unwrap()
+        // RB-V1.38-7 (#1463): match siblings (`conventional_prefix_re`,
+        // `trailing_noise_re`) which use `.expect("valid regex")` — a typo
+        // in the 90+ alternation should give a useful breadcrumb on init.
+        Regex::new(r"(?i)^(add|added|adds|implement|implemented|implements|fix|fixed|fixes|update|updated|updates|remove|removed|removes|refactor|refactored|refactors|move|moved|moves|rename|renamed|renames|change|changed|changes|improve|improved|improves|introduce|introduced|introduces|replace|replaced|replaces|convert|converted|converts|use|wip|bump|bumped|bumps|extract|extracted|extracts|simplify|simplified|simplifies|handle|handled|handles|make|delete|deleted|deletes|clean|cleaned|cleans|create|created|creates|merge|merged|merges|revert|reverted|reverts|enable|enabled|enables|disable|disabled|disables|drop|dropped|drops|migrate|migrated|migrates|switch|switched|switches|allow|allowed|allows|prevent|prevented|prevents|ensure|ensured|ensures|apply|applied|applies|adjust|adjusted|adjusts|correct|corrected|corrects|set|support|supported|supports)\s+").expect("valid leading-verb regex")
     })
 }
 

--- a/src/vendored.rs
+++ b/src/vendored.rs
@@ -63,9 +63,27 @@ pub fn is_vendored_origin(origin: &str, prefixes: &[String]) -> bool {
 /// empty (operators can disable vendored detection by passing an
 /// explicit empty list in `.cqs.toml`). `override_list = None` falls
 /// back to [`DEFAULT_VENDORED_PREFIXES`].
+///
+/// AC-V1.38-8 (#1463): each override entry is matched as an exact path
+/// segment. Entries containing `/` (e.g. `"vendor/oss-lib"`) will never
+/// match — the match is segment-equality, not sub-path containment.
+/// Warn at resolution so an operator who set `vendored_paths = [...]`
+/// in `.cqs.toml` sees that their entry is dead config instead of
+/// silently failing to tag any chunks.
 pub fn effective_prefixes(override_list: Option<&[String]>) -> Vec<String> {
     match override_list {
-        Some(ov) => ov.to_vec(),
+        Some(ov) => {
+            for entry in ov {
+                if entry.contains('/') || entry.contains('\\') {
+                    tracing::warn!(
+                        entry = %entry,
+                        "vendored_paths entry contains a path separator and will never match — \
+                         use a bare directory segment (e.g. `vendor`, not `vendor/oss-lib`)"
+                    );
+                }
+            }
+            ov.to_vec()
+        }
         None => DEFAULT_VENDORED_PREFIXES
             .iter()
             .map(|s| s.to_string())


### PR DESCRIPTION
## Summary

P3 mechanical sweep — 10 small audit findings bundled. No behavior change in hot paths; each finding is a one-spot edit.

| ID | Item | Files |
|----|------|-------|
| API-V1.38-5 | `Cli::resolved_model` `pub` → `pub(super)` (clap doesn't need pub on `#[arg(skip)]`) | `cli/definitions.rs` |
| PL-V1.38-6 | `daemon_control_hint` non-Linux Unix arm via `cfg(unix)` (covers BSD/illumos, not just macOS) | `cli/commands/infra/model.rs` |
| EH-V1.38-6 | `cqs hook status / uninstall` distinguish `NotFound` from perm-denied/oversize via `tracing::warn!` | `cli/commands/infra/hook.rs` |
| RB-V1.38-6 | `parser/l5x.rs` 6× regex `.unwrap()` → `.expect()` with invariant comments (matches #1525 SPLADE pattern) | `parser/l5x.rs` |
| RB-V1.38-7 | `train_data/query.rs` leading-verb regex `.unwrap()` → `.expect("valid leading-verb regex")` (matches sibling regex builders) | `train_data/query.rs` |
| AC-V1.38-8 | `vendored::effective_prefixes` warns on operator override entries containing `/` or `\` (segment-equality matcher would silently never match) | `vendored.rs` |
| EX-V1.38-10 | `test_type_queries_compile` iterates `Language::all_variants()` filtered by `def().type_query.is_some()` (FSharp explicitly skipped due to pre-existing tree-sitter-fsharp node-type issue) | `parser/calls.rs` |
| OB-V1.38-3 | 3× TOML overlay installers (synonym, classifier vocab, per-slot SPLADE α) emit `tracing::info!` with counts when non-empty | `search/synonyms.rs`, `search/router.rs` |
| OB-V1.38-4 | `wait_for_batch` got entry span + `elapsed_ms` + structured warn on cancel/expire terminal arms | `llm/batch.rs` |
| OB-V1.38-5 | CAGRA "ineligible — falling through" promoted to `tracing::info!` with `backend = "hnsw", source = "cagra-ineligible"` shape | `cagra.rs` |

## What's NOT in scope

- `stop_daemon_best_effort` cfg-gate widening (uses macOS-specific `LOCAL_PEERPID` FFI — out of scope for the hint-only fix)
- Removing FSharp's `type_query` registration (separate cleanup; the test's explicit skip preserves current behavior)
- Hook report schema extension to surface a third "unreadable" bucket (the warn is sufficient signal; a v2 follow-up if operators ask)
- Promoting `RUST_LOG=debug` overlay-load to a top-level dispatch span (OB-V1.38-9 — separate finding)

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib hook|synonym|classifier|vendored|l5x|type_queries_compile|cagra::tests|batch::tests` — all green
- [x] `cargo test --features gpu-index --test env_var_docs` — green (no new env vars)
- [x] `cargo clippy -- -D warnings` — clean (matches CI)
- [x] `cargo fmt --check` — clean
