### PR TITLE
fix: cluster N — P2 pending (5 findings, #1463)

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,17 +700,27 @@ For most codebases (<100k chunks), defaults work well. Large repos may benefit f
 
 **Live codebase eval** — 218 queries (109 test + 109 dev) over the cqs source tree, each with a dual-judge (Gemma-4 + Claude) consensus gold chunk. v3.v2 fixture. Categories: `identifier_lookup`, `behavioral`, `conceptual`, `structural`, `negation`, `type_filtered`, `multi_step`, `cross_language` — every category N ≥ 16. Hard mode; measures the full production pipeline.
 
-**Per-preset:**
-
-The `embeddinggemma-300m` row reflects the v1.36.0 per-category SPLADE α retune (2026-05-03) on the gemma slot at 13,359 chunks — `Structural` 0.90→0.60, `Behavioral` 0.80→1.00, `Conceptual` 0.70→0.80, `TypeFiltered` 1.00→0.00, `CrossLanguage` 0.10→0.70, plus `Unknown` 1.00→0.80 (catch-all hedge for misroutes). Other rows are pre-retune (apples-to-apples 2026-05-02 on cqs v1.35.0, all 5 slots reindexed `--force --llm-summaries`); their numbers will shift up under the new alphas, but a fresh sweep across all five slots is queued.
+**Default preset** (`embeddinggemma-300m`, v1.36 per-category SPLADE α retune):
 
 | Preset | Params | Test R@1 | Test R@5 | Test R@20 | Dev R@1 | Dev R@5 | Dev R@20 | Agg R@1 | Agg R@5 | Agg R@20 |
 |--------|--------|---------:|---------:|----------:|--------:|--------:|---------:|--------:|--------:|---------:|
 | **embeddinggemma-300m** (default, v1.36 α) | 308M | 48.6% | **72.5%** | 83.5% | **53.2%** | **79.8%** | **93.6%** | **50.9%** | **76.2%** | **88.6%** |
+
+The retune (2026-05-03) on the gemma slot at 13,359 chunks set per-category SPLADE alphas: `Structural` 0.90→0.60, `Behavioral` 0.80→1.00, `Conceptual` 0.70→0.80, `TypeFiltered` 1.00→0.00, `CrossLanguage` 0.10→0.70, plus `Unknown` 1.00→0.80 (catch-all hedge for misroutes).
+
+<details>
+<summary><b>Other presets</b> (pre-retune — kept for reference, will shift up under v1.36+ alphas)</summary>
+
+These rows are apples-to-apples 2026-05-02 on cqs v1.35.0 (all 5 slots reindexed `--force --llm-summaries`) but use the *old* per-category α defaults. A re-sweep across the 4 non-gemma slots is queued; until it lands, do not use these rows for direct preset-vs-preset comparison against the gemma row above.
+
+| Preset | Params | Test R@1 | Test R@5 | Test R@20 | Dev R@1 | Dev R@5 | Dev R@20 | Agg R@1 | Agg R@5 | Agg R@20 |
+|--------|--------|---------:|---------:|----------:|--------:|--------:|---------:|--------:|--------:|---------:|
 | bge-large-ft (pre-retune) | 335M | 45.0% | 71.6% | 85.3% | 50.5% | 75.2% | 87.2% | 47.7% | 73.4% | 86.2% |
 | BGE-large (pre-retune) | 335M | 43.1% | 68.8% | 82.6% | 51.4% | 75.2% | 86.2% | 47.2% | 72.0% | 84.4% |
 | v9-200k (pre-retune) | 110M | 44.0% | 67.9% | 79.8% | 45.9% | 69.7% | 81.7% | 45.0% | 68.8% | 80.7% |
 | nomic-coderank (pre-retune) | 137M | 43.1% | 67.0% | 78.0% | 46.8% | 68.8% | 79.8% | 45.0% | 67.9% | 78.9% |
+
+</details>
 
 Per-slot summary coverage at measurement: `default` 62.1%, `gemma` 99.0%, `bge-ft` 62.1%, `v9` 67.6%, `coderank` 65.5%. Variance is structural — only `chunk_type.is_code()` chunks are summary-eligible (markdown / json / ini are skipped at `src/llm/mod.rs:115`), and tokenizers produce different chunk-type distributions. Each slot has all *its* eligible chunks summarized.
 
@@ -949,7 +959,7 @@ Token budgeting works across all context commands: `--tokens N` packs results by
 
 ## Performance
 
-Measured 2026-04-16 on the cqs codebase itself (562 files, 15,516 chunks) with CUDA GPU (NVIDIA RTX A6000, 48 GB) on WSL2 Ubuntu. Embedder: BGE-large (1024-dim). SPLADE: ensembledistil (110M, off-the-shelf). Raw measurements: [`evals/performance-v1.27.0.json`](evals/performance-v1.27.0.json).
+Measured 2026-04-16 on the cqs codebase itself (562 files, 15,516 chunks) with CUDA GPU (NVIDIA RTX A6000, 48 GB) on WSL2 Ubuntu. Embedder: **BGE-large (1024-dim)** — the v1.27.0 default at the time of the bench. The v1.35.0+ default switched to `embeddinggemma-300m` (768-dim, 308M params); per-doc embed latency is lower on that backbone but the rest of the table — daemon query, indexer throughput, RAM, GC — are model-agnostic. SPLADE: ensembledistil (110M, off-the-shelf). Raw measurements: [`evals/performance-v1.27.0.json`](evals/performance-v1.27.0.json). A v1.38.0 re-bench against the current default is queued; until it lands, treat the embedding-throughput rows as upper-bound for BGE-large and approximate for gemma.
 
 | Metric | Value |
 |--------|-------|

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -2236,19 +2236,33 @@ fn write_json_line(
             buf.push(b'\n');
             out.write_all(&buf)
         }
-        Err(_) => {
+        Err(first) => {
             // NaN / Infinity in the payload caused `to_writer` to fail
             // partway through. The buffer holds a half-written prefix
             // (`{"data":...`) — discard it and retry via the sanitize-
             // and-retry path that the CLI / chat surfaces share.
             // Mirrors `format_envelope_to_string`'s recovery semantics.
+            //
+            // EH-V1.38-9 (#1463): preserve the first error. NaN is the
+            // typical cause but `to_writer` can also fail on a downstream
+            // `io::Write` error (broken socket, full disk) or on serde
+            // custom Serialize errors — a sanitize-retry doesn't fix
+            // those, and the operator needs the first error to diagnose.
+            tracing::debug!(
+                error = %first,
+                "to_writer failed; retrying after float-sanitize"
+            );
             let wrapped = crate::cli::json_envelope::wrap_value(value);
             let mut sanitized = wrapped;
             sanitize_json_floats(&mut sanitized);
             match serde_json::to_string(&sanitized) {
                 Ok(s) => writeln!(out, "{}", s),
                 Err(e) => {
-                    tracing::warn!(error = %e, "JSON serialization failed after sanitization");
+                    tracing::warn!(
+                        first_error = %first,
+                        retry_error = %e,
+                        "JSON serialization failed before AND after sanitization"
+                    );
                     let fallback = crate::cli::json_envelope::wrap_error(
                         crate::cli::json_envelope::error_codes::INTERNAL,
                         "JSON serialization failed",

--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -22,6 +22,23 @@ use crate::cli::{
 /// Parses source files, generates embeddings, and stores them in the index database.
 /// Uses incremental indexing by default (only re-embeds changed files).
 pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
+    // AC-V1.38-7 (#1463): hard-fail on `cqs index --model <typo>`. The
+    // shared resolver `ModelConfig::resolve` silently falls back to the
+    // default preset when the name doesn't match any built-in — fine for
+    // read paths (`cqs <q>`), wrong for the operator-driven write path
+    // because it can produce an index built against a different model
+    // than the one the operator typed. The drift check runs against the
+    // resolved (post-fallback) name and so misses this case when default
+    // happens to align with the existing index. Catching it here before
+    // any state mutation puts the typo in front of the operator.
+    if let Some(name) = cli.model.as_deref() {
+        if cqs::embedder::ModelConfig::from_preset(name).is_none() {
+            anyhow::bail!(
+                "Unknown model preset `--model {name}`. Run `cqs model list` to see available \
+                 presets, or pass a custom HuggingFace repo via `[embedding] repo` in `cqs.toml`."
+            );
+        }
+    }
     let force = args.force;
     let dry_run = args.dry_run;
     let no_ignore = args.no_ignore;
@@ -1800,6 +1817,21 @@ mentions = []
     }
 
     // ====== #1459 item 5a — `cqs index --model` drift detection ======
+
+    /// AC-V1.38-7 (#1463): the strict-preset gate at the top of `cmd_index`
+    /// rejects unknown CLI presets so an operator typo doesn't silently
+    /// resolve to the default. The unit-level analogue: `from_preset`
+    /// returns `None` for the typo, which is what the bail-on-`is_none()`
+    /// branch keys off of. Pin the contract here so a future preset-rename
+    /// can't make the check vacuous.
+    #[test]
+    fn unknown_preset_rejected_by_from_preset() {
+        assert!(cqs::embedder::ModelConfig::from_preset("bgelarge").is_none());
+        assert!(cqs::embedder::ModelConfig::from_preset("not-a-real-preset").is_none());
+        assert!(cqs::embedder::ModelConfig::from_preset("").is_none());
+        // Sanity: a real preset still resolves.
+        assert!(cqs::embedder::ModelConfig::from_preset("embeddinggemma-300m").is_some());
+    }
 
     /// No stored model (fresh DB) → drift check is a no-op.
     #[test]

--- a/src/cli/json_envelope.rs
+++ b/src/cli/json_envelope.rs
@@ -368,10 +368,26 @@ pub(crate) fn sanitize_json_floats(value: &mut serde_json::Value) {
 pub fn format_envelope_to_string(value: &serde_json::Value) -> Result<String> {
     match serde_json::to_string_pretty(value) {
         Ok(s) => Ok(s),
-        Err(_) => {
+        Err(first) => {
+            // EH-V1.38-9 (#1463): preserve the original error so the
+            // sanitize-retry path can surface it on a retry failure. The
+            // typical case is NaN / Infinity in a leaf field (which the
+            // sanitize fixes), but `to_string_pretty` can also fail on
+            // serde custom Serialize errors or recursion limits — a
+            // retry doesn't fix those, and the operator deserves the
+            // first error in the log instead of the redundant second.
+            tracing::debug!(
+                error = %first,
+                "to_string_pretty failed; retrying after float-sanitize"
+            );
             let mut sanitized = value.clone();
             sanitize_json_floats(&mut sanitized);
-            Ok(serde_json::to_string_pretty(&sanitized)?)
+            serde_json::to_string_pretty(&sanitized).map_err(|second| {
+                anyhow::anyhow!(
+                    "JSON serialization failed; \
+                     first error: {first}; sanitize-retry error: {second}"
+                )
+            })
         }
     }
 }

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -112,7 +112,13 @@ impl BatchKind {
 /// Trait for LLM batch API providers.
 /// Abstracts the batch submission, polling, and result fetching lifecycle.
 /// Currently implemented for Anthropic's Messages Batches API.
-pub trait BatchProvider {
+///
+/// API-V1.38-3 (#1463): `Send + Sync` matches the sibling traits
+/// `VectorIndex`, `IndexBackend`, `Reranker`. Both shipping impls
+/// (`LlmClient` in `llm/batch.rs`, `LocalProvider` in `llm/local.rs`)
+/// already satisfy it; making it explicit means the next async-batch
+/// refactor doesn't surface as a confusing object-safety error.
+pub trait BatchProvider: Send + Sync {
     /// Submit a batch under the given `kind`. The kind selects which prompt
     /// builder constructs the user message from each `BatchSubmitItem`'s
     /// `(content, context, language)` triple (or, for [`BatchKind::Prebuilt`],


### PR DESCRIPTION
## Summary

Five P2 audit items the v1.38 cluster wave (#1514–#1526) didn't absorb. Three code, two doc.

| ID | Item | Files |
|----|------|-------|
| API-V1.38-3 | `BatchProvider: Send + Sync` (matches `VectorIndex` / `IndexBackend` / `Reranker` siblings) | `llm/provider.rs` |
| AC-V1.38-7 | `cqs index --model <typo>` hard-fails at top of `cmd_index` instead of silent fallback to default — closes the silent-typo footgun that `check_index_model_drift` (#1505) couldn't catch when the default preset aligned with the existing index | `cli/commands/index/build.rs` |
| EH-V1.38-9 | `format_envelope_to_string` + `write_json_line` preserve the FIRST `to_string_pretty`/`to_writer` error in the sanitize-and-retry path; broken-socket / full-disk / serde Serialize errors are now diagnosable instead of being masked by a redundant post-sanitize message | `cli/json_envelope.rs`, `cli/batch/mod.rs` |
| DOC-V1.38-6 | README `## Performance` caption distinguishes the 2026-04-16 BGE-large bench (v1.27.0 default) from v1.35.0+ EmbeddingGemma default; throughput rows flagged as upper-bound for BGE-large / approximate for gemma | `README.md` |
| DOC-V1.38-8 | README per-preset retrieval-quality table reorganized — gemma row (default, v1.36 α) is the unambiguous headline; 4 pre-retune rows folded into a `<details>` block titled "Other presets (pre-retune)" so an agent skimming the table doesn't read the old-α numbers as a direct preset comparison | `README.md` |

## What's NOT in scope

- API-V1.38-1 (ModelCommand/HookCommand → TextJsonArgs envelope) — bigger surface, deserves its own PR
- API-V1.38-10 (LimitArg fan-out across 7 sister args) — same
- Re-bench against the v1.35+ default (queued; doc fix here just stops claiming the v1.27.0 bench applies)
- Re-sweep across the 4 non-gemma slots under v1.36 α (also queued)
- AC-V1.38-10 (drift check unknown-preset companion) — collapsed into AC-V1.38-7 by gating before drift runs

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --bin cqs unknown_preset_rejected_by_from_preset` — green (new test)
- [x] `cargo test --features gpu-index --lib batch::tests / json_envelope` — green
- [x] `cargo run -- --model bgelarge index` — bails with the new error before any state mutation (smoke)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
