### PR TITLE
fix: cluster Q — security sweep (6 findings, #1463)

### DIFF
--- a/src/cli/commands/io/read.rs
+++ b/src/cli/commands/io/read.rs
@@ -44,13 +44,19 @@ pub(crate) fn validate_and_read_file(root: &Path, path: &str) -> Result<(PathBuf
     if !canonical.starts_with(&project_canonical) {
         bail!("Invalid path");
     }
-    if !file_path.exists() {
-        bail!("Invalid path");
-    }
 
+    // SEC-V1.38-6 (#1463): drop the redundant `file_path.exists()` check
+    // — `dunce::canonicalize` above already proved existence — and route
+    // the size cap and the read both through `&canonical`. Pre-fix, the
+    // size cap stat'd the unresolved `file_path` while the read consumed
+    // `canonical`; a symlink swap between the two narrowed but didn't
+    // close the bypass window. Same-path stat-then-read is still TOCTOU
+    // against a swap mid-syscall, but the residual race is at the OS
+    // level rather than amplified by inconsistent path use here.
+    //
     // P3 #107: env-overridable via CQS_READ_MAX_FILE_SIZE (default 10 MiB).
     let max_file_size = crate::cli::limits::read_max_file_size();
-    let metadata = std::fs::metadata(&file_path).context("Failed to read file metadata")?;
+    let metadata = std::fs::metadata(&canonical).context("Failed to read file metadata")?;
     if metadata.len() > max_file_size {
         bail!(
             "File too large: {} bytes (max {} bytes; CQS_READ_MAX_FILE_SIZE)",

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -572,9 +572,21 @@ pub(crate) fn run_git_diff(base: Option<&str>) -> anyhow::Result<String> {
     let mut cmd = std::process::Command::new("git");
     cmd.args(["--no-pager", "diff", "--no-color"]);
     if let Some(b) = base {
-        if b.starts_with('-') || b.contains('\0') {
+        // SEC-V1.38-7 (#1463): stricter ref validation matching git's own
+        // `check-ref-format` rules. Reject leading `-` (option-injection),
+        // any of `\0\n\r\t` (newlines and tabs are control-char injections
+        // that git strips at parse time but the validation gate should
+        // assert), and cap length at 255 chars (git's own ref-name limit).
+        // The dash check is kept structural rather than relying on the
+        // arg-position not being reordered by future refactors.
+        if b.is_empty()
+            || b.len() > 255
+            || b.starts_with('-')
+            || b.contains(['\0', '\n', '\r', '\t'])
+        {
             anyhow::bail!(
-                "Invalid base ref '{}': must not start with '-' or contain null bytes",
+                "Invalid base ref '{}': must be 1..=255 chars, not start with '-', \
+                 not contain null / newline / tab",
                 b
             );
         }
@@ -1091,29 +1103,68 @@ mod tests {
         assert_eq!(used, 30);
     }
 
-    // HP-3: run_git_diff rejects base refs starting with '-' (flag injection)
+    // HP-3 + SEC-V1.38-7: run_git_diff rejects base refs starting with '-' (flag injection)
     #[test]
     fn test_run_git_diff_rejects_dash_prefix() {
         let result = run_git_diff(Some("--exec=whoami"));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("must not start with '-'"),
+            err.contains("must be 1..=255 chars"),
             "Expected dash-prefix rejection, got: {}",
             err
         );
     }
 
-    // HP-3: run_git_diff rejects base refs containing null bytes
+    // HP-3 + SEC-V1.38-7: run_git_diff rejects base refs containing null bytes
     #[test]
     fn test_run_git_diff_rejects_null_bytes() {
         let result = run_git_diff(Some("main\0--exec=whoami"));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("contain null bytes"),
+            err.contains("not contain null"),
             "Expected null-byte rejection, got: {}",
             err
+        );
+    }
+
+    // SEC-V1.38-7: run_git_diff rejects newlines + tabs (control-char injection)
+    #[test]
+    fn test_run_git_diff_rejects_newlines_and_tabs() {
+        for bad in ["main\nrm -rf /", "main\rfoo", "main\tfoo"] {
+            let result = run_git_diff(Some(bad));
+            assert!(result.is_err(), "ref `{bad:?}` must be rejected");
+            let err = result.unwrap_err().to_string();
+            assert!(
+                err.contains("not contain null / newline / tab"),
+                "ref `{bad:?}` rejection message wrong: {err}"
+            );
+        }
+    }
+
+    // SEC-V1.38-7: run_git_diff rejects refs > 255 chars (git's own ref-name limit)
+    #[test]
+    fn test_run_git_diff_rejects_oversize_ref() {
+        let big = "a".repeat(256);
+        let result = run_git_diff(Some(&big));
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("must be 1..=255 chars"),
+            "256-char ref rejection wrong: {err}"
+        );
+    }
+
+    // SEC-V1.38-7: run_git_diff rejects empty ref
+    #[test]
+    fn test_run_git_diff_rejects_empty_ref() {
+        let result = run_git_diff(Some(""));
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("must be 1..=255 chars"),
+            "empty ref rejection wrong: {err}"
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -591,7 +591,12 @@ impl Config {
         let mut merged = user_config.override_with(project_config);
         merged.validate();
 
-        tracing::debug!(?merged, "Effective config");
+        // SEC-V1.38-8 (#1463): drop `?merged` for the same reason as the
+        // per-file `Loaded config` event above — the merged Config
+        // carries `llm_api_base` userinfo and shouldn't land in journald
+        // verbatim. A future log line re-adding contents must redact
+        // userinfo at the field level (see `redact_userinfo` in `llm/mod.rs`).
+        tracing::debug!("Effective config built");
         merged
     }
 
@@ -782,7 +787,14 @@ impl Config {
 
         match toml::from_str::<Self>(&content) {
             Ok(config) => {
-                tracing::debug!(path = %path.display(), ?config, "Loaded config");
+                // SEC-V1.38-8 (#1463): drop `?config` to avoid spilling
+                // `llm_api_base` (which can carry `https://user:pass@host`
+                // userinfo) to journald at debug. The path field is enough
+                // to confirm "we loaded a config from here"; structural
+                // contents of interest land via the relevant subsystem
+                // (LLM resolve, model resolve, etc.) at their own log
+                // sites with field-level redaction.
+                tracing::debug!(path = %path.display(), "Loaded config");
                 Ok(Some(config))
             }
             Err(e) => Err(format!("Failed to parse config {}: {}", path.display(), e)),

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -301,14 +301,34 @@ pub fn parse_env_usize(key: &str, default: usize) -> usize {
 /// values are clamped (not rejected) so a misconfigured env var still
 /// yields a usable value rather than the unclamped default. Missing/zero/
 /// garbage falls back to `default` (also clamped to the range).
+///
+/// SEC-V1.38-9 (#1463): an operator setting an unrealistically large
+/// value (e.g. `CQS_SERVE_MAX_CONCURRENT_REQUESTS=4294967295` to try to
+/// "disable" the cap) sees a structured warn so the clamp isn't silent.
+/// The value still clamps to `max` — operator gets a usable value plus
+/// an audit trail.
 pub fn parse_env_usize_clamped(key: &str, default: usize, min: usize, max: usize) -> usize {
-    let clamp = |n: usize| n.clamp(min, max);
+    let clamp_with_warn = |n: usize, source: &str| {
+        let clamped = n.clamp(min, max);
+        if n != clamped {
+            tracing::warn!(
+                env = key,
+                value = n,
+                clamped,
+                min,
+                max,
+                source,
+                "env var clamped to allowed range"
+            );
+        }
+        clamped
+    };
     match std::env::var(key) {
         Ok(v) => match v.parse::<usize>() {
-            Ok(n) if n > 0 => clamp(n),
-            _ => clamp(default),
+            Ok(n) if n > 0 => clamp_with_warn(n, "env"),
+            _ => clamp_with_warn(default, "default-after-parse-failure"),
         },
-        Err(_) => clamp(default),
+        Err(_) => default.clamp(min, max),
     }
 }
 

--- a/src/serve/assets.rs
+++ b/src/serve/assets.rs
@@ -55,7 +55,15 @@ pub(crate) async fn index_html() -> Result<Response, ServeError> {
 /// Paths outside the embedded set return 404. There's no filesystem
 /// fallthrough — keeps the binary the single source of truth.
 pub(crate) async fn static_asset(Path(path): Path<String>) -> Result<Response, ServeError> {
-    tracing::info!(path = %path, "serve::static_asset");
+    // SEC-V1.38-5 (#1463): cap user-controlled path string at 256 chars
+    // before logging at info. Same shape as `chunk_detail`. Embedded-asset
+    // names are short; a hostile token-bearing client sending KB-long
+    // paths can't inflate journald via this route.
+    tracing::info!(
+        path = %path.chars().take(256).collect::<String>(),
+        path_len = path.len(),
+        "serve::static_asset"
+    );
 
     let (body, content_type) = match path.as_str() {
         "app.css" => (APP_CSS, "text/css; charset=utf-8"),

--- a/src/serve/handlers.rs
+++ b/src/serve/handlers.rs
@@ -199,7 +199,16 @@ pub(crate) async fn chunk_detail(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<ChunkDetail>, ServeError> {
-    tracing::info!(chunk_id = %id, "serve::chunk_detail");
+    // SEC-V1.38-5 (#1463): cap user-controlled path string at 256 chars
+    // before logging at info to limit journald inflation. The full id is
+    // still passed downstream for the lookup; this only bounds the log
+    // event field. Mirrors the SEC-V1.30.1-2 / OB-V1.30.1-10 pattern that
+    // demoted `serve::search` query-text logging.
+    tracing::info!(
+        chunk_id = %id.chars().take(256).collect::<String>(),
+        id_len = id.len(),
+        "serve::chunk_detail"
+    );
 
     let id_clone = id.clone();
     let detail = with_blocking(&state, "chunk_detail", move |store| {

--- a/src/store/backup.rs
+++ b/src/store/backup.rs
@@ -235,27 +235,16 @@ pub(crate) fn prune_old_backups(db_path: &Path) -> Result<(), StoreError> {
     let entries = match std::fs::read_dir(dir) {
         Ok(it) => it,
         Err(e) => {
-            // DS-V1.36-10 / P3: surface at error! with directory size context
-            // so monitoring can alert on accumulating backups when the prune
-            // step keeps failing. Non-fatal — the user's DB is at the correct
-            // version — but silent prune skip lets `.bak-v*.db` files
-            // accumulate without bound on transient permission issues.
-            let approx_size: u64 = std::fs::read_dir(dir)
-                .ok()
-                .map(|it| {
-                    it.flatten()
-                        .filter_map(|e| e.metadata().ok().map(|m| m.len()))
-                        .sum()
-                })
-                .unwrap_or(0);
-            tracing::error!(
-                error = %e,
-                dir = %dir.display(),
-                approx_dir_bytes = approx_size,
-                "Failed to read DB dir for backup pruning (non-fatal); \
-                 .bak-v*.db files may accumulate — investigate dir perms or disk"
-            );
-            return Ok(());
+            // DS-V1.38-5 (#1463): return Err so the caller's existing
+            // `if let Err(e) = prune_old_backups(...)` warn fires at the
+            // migration site every time. DS-V1.36-10 surfaced this at
+            // `error!` but returned `Ok(())` — invisible to the migration
+            // loop, so persistent permission glitches let `.bak-v*.db`
+            // accumulate without bound. The caller still treats this as
+            // non-fatal (the user's DB is at the correct version), so
+            // returning Err only changes log-stream visibility, not
+            // migration outcome.
+            return Err(StoreError::Io(e));
         }
     };
 


### PR DESCRIPTION
## Summary

Six security-themed audit items: log inflation caps, TOCTOU narrowing, ref-validation hardening, config debug-redaction, prune surfacing, clamp visibility.

| ID | Item | Files |
|----|------|-------|
| SEC-V1.38-5 | `serve::chunk_detail` / `serve::static_asset` cap user-controlled path string at 256 chars before logging at info, plus `id_len` / `path_len` for full length visibility (mirrors SEC-V1.30.1-2 `serve::search` demote pattern) | `serve/handlers.rs`, `serve/assets.rs` |
| SEC-V1.38-6 | `validate_and_read_file` stat + read both via `&canonical` (pre-fix used unresolved `file_path` for stat, narrowed but didn't close the symlink-swap window). Redundant `file_path.exists()` dropped — canonicalize already proved existence | `cli/commands/io/read.rs` |
| SEC-V1.38-7 | `run_git_diff` ref validation matches git's `check-ref-format` rules: reject empty / > 255 chars / leading `-` / `\0\n\r\t`. Three new tests pin the hardened gate (newlines, oversize, empty) | `cli/commands/mod.rs` |
| SEC-V1.38-8 | `Config::load` drops `?config` / `?merged` at debug — the Config carries `llm_api_base` which can hold userinfo. Path is still logged | `config.rs` |
| DS-V1.38-5 | `prune_old_backups` returns `Err(StoreError::Io)` on `read_dir` failure instead of `Ok(())`. Caller's existing warn now fires at every migration touching a bad directory — visible to operators without changing migration outcome (still non-fatal) | `store/backup.rs` |
| SEC-V1.38-9 | `parse_env_usize_clamped` emits `tracing::warn!` when clamping out-of-range env values (with `value`, `clamped`, `min`, `max`, `source`). Operator setting an unrealistic env override sees the clamp instead of silent saturation | `limits.rs` |

## What's NOT in scope

- SEC-V1.38-10 (`find_pdf_script` ownership check + python exec race) — separate refactor (embed script via `include_str!` mirroring `umap.rs`); tracking in #1463
- DS-V1.38-4 (HNSW `load_with_dim` TOCTOU) — multi-PR architectural change; tracking in #1463
- SEC-V1.38-1/2/3/4 — already shipped in #1519 (cluster I from earlier audit cycle)

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --bin cqs run_git_diff` — 5/5 green (3 new tests)
- [x] `cargo test --features gpu-index --lib backup::` — 10/10 green
- [x] `cargo test --features gpu-index --lib parse_env_usize_clamped` — 5/5 green
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
