### PR TITLE
fix: cluster R — resource management sweep (2 findings, #1463)

### DIFF
--- a/src/cli/watch/gc.rs
+++ b/src/cli/watch/gc.rs
@@ -61,6 +61,20 @@ pub(super) fn prune_last_indexed_mtime(map: &mut HashMap<PathBuf, SystemTime>) -
     if map.len() <= last_indexed_prune_size_threshold() {
         return 0;
     }
+    prune_last_indexed_mtime_by_age(map)
+}
+
+/// RM-V1.38-7 (#1463): age-only prune of `last_indexed_mtime`. Identical
+/// retention policy to [`prune_last_indexed_mtime`] but ignores the
+/// size-threshold gate. Called from the watch loop's idle branch on a
+/// time-shaped cadence so a daemon that sits below the size threshold
+/// for weeks still ages out stale entries (deleted/moved files) instead
+/// of accumulating them indefinitely. Pre-fix the trigger was peak-shaped:
+/// only when the map crossed the threshold did the prune fire, and the
+/// trigger never re-armed once the map quiesced below it.
+///
+/// Cheap: pure in-memory `SystemTime` comparison. No I/O.
+pub(super) fn prune_last_indexed_mtime_by_age(map: &mut HashMap<PathBuf, SystemTime>) -> usize {
     let before = map.len();
     let cutoff = SystemTime::now()
         .checked_sub(Duration::from_secs(LAST_INDEXED_PRUNE_AGE_SECS))

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -78,7 +78,10 @@ use rebuild::{
 use rebuild::{RebuildOutcome, RebuildResult};
 
 mod gc;
-use gc::{prune_last_indexed_mtime, run_daemon_periodic_gc, run_daemon_startup_gc};
+use gc::{
+    prune_last_indexed_mtime, prune_last_indexed_mtime_by_age, run_daemon_periodic_gc,
+    run_daemon_startup_gc,
+};
 #[cfg(test)]
 use gc::{LAST_INDEXED_PRUNE_AGE_SECS, LAST_INDEXED_PRUNE_SIZE_THRESHOLD_DEFAULT};
 
@@ -1246,6 +1249,14 @@ pub fn cmd_watch(
     }
     let mut last_periodic_gc = std::time::Instant::now();
 
+    // RM-V1.38-7 (#1463): cadence for the age-only prune of
+    // `last_indexed_mtime`. Pre-fix the prune only fired when the map
+    // crossed `CQS_WATCH_PRUNE_SIZE_THRESHOLD`; daemons running below
+    // the threshold for weeks accumulated stale entries forever. This
+    // tick fires once per hour from the idle branch.
+    const LAST_INDEXED_AGE_PRUNE_INTERVAL_SECS: u64 = 3600;
+    let mut last_age_prune = std::time::Instant::now();
+
     // #1182 Layer 2: periodic full-tree reconciliation cadence. Same
     // gating model as the GC tick — `--serve` only, opt-out via
     // `CQS_WATCH_RECONCILE=0`. Initialised to "now" so the first tick
@@ -1423,6 +1434,27 @@ pub fn cmd_watch(
                     // DS-1: Release lock after all reindex work (including HNSW rebuild)
                     drop(lock);
                 } else {
+                    // RM-V1.38-7 (#1463): age-only prune fires hourly on
+                    // idle ticks regardless of map size. The size-gated
+                    // `prune_last_indexed_mtime` still runs in the event
+                    // path; this idle-tick variant catches daemons that
+                    // sit below the threshold but accumulate stale
+                    // entries from deleted/moved files.
+                    if last_age_prune.elapsed()
+                        >= Duration::from_secs(LAST_INDEXED_AGE_PRUNE_INTERVAL_SECS)
+                    {
+                        let removed =
+                            prune_last_indexed_mtime_by_age(&mut state.last_indexed_mtime);
+                        if removed > 0 {
+                            tracing::debug!(
+                                removed,
+                                remaining = state.last_indexed_mtime.len(),
+                                "Age-only prune of last_indexed_mtime fired (idle tick)"
+                            );
+                        }
+                        last_age_prune = std::time::Instant::now();
+                    }
+
                     cycles_since_clear += 1;
                     // Clear embedder session and HNSW index after ~5 minutes idle
                     // (3000 cycles at 100ms). Frees GPU/memory when watch is idle.

--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -845,6 +845,29 @@ fn test_last_indexed_mtime_recency_prune() {
     );
 }
 
+#[test]
+fn prune_last_indexed_mtime_by_age_ignores_size_threshold() {
+    // RM-V1.38-7 (#1463): age-only prune fires regardless of map size,
+    // so a daemon below the threshold still ages out stale entries.
+    let now = SystemTime::now();
+    let two_days = Duration::from_secs(LAST_INDEXED_PRUNE_AGE_SECS + 86_400);
+    let one_minute = Duration::from_secs(60);
+    let old = now.checked_sub(two_days).unwrap();
+    let fresh = now.checked_sub(one_minute).unwrap();
+
+    let mut tiny: HashMap<PathBuf, SystemTime> = HashMap::new();
+    tiny.insert(PathBuf::from("old_a.rs"), old);
+    tiny.insert(PathBuf::from("old_b.rs"), old);
+    tiny.insert(PathBuf::from("fresh.rs"), fresh);
+    // Size = 3, well below LAST_INDEXED_PRUNE_SIZE_THRESHOLD_DEFAULT (5_000).
+    // Size-gated `prune_last_indexed_mtime` would be a no-op here; the
+    // age-only variant still drops the two stale entries.
+    let pruned = super::gc::prune_last_indexed_mtime_by_age(&mut tiny);
+    assert_eq!(pruned, 2, "age-only prune must drop entries past cutoff");
+    assert_eq!(tiny.len(), 1, "fresh entry survives");
+    assert!(tiny.contains_key(&PathBuf::from("fresh.rs")));
+}
+
 // ===== Constants tests =====
 
 #[test]

--- a/src/llm/local.rs
+++ b/src/llm/local.rs
@@ -459,13 +459,26 @@ impl LocalProvider {
             )));
         }
 
-        // P2.73: cap the stash so a long-running daemon submitting batches
-        // without ever calling `fetch_batch_results` doesn't grow memory
-        // unbounded. 128 batches is plenty — production callers drain in
-        // submit order, so when this cap fires it's a leak signal.
+        // P2.73 + RM-V1.38-2 (#1463): cap the stash so a long-running
+        // daemon submitting batches without ever calling
+        // `fetch_batch_results` doesn't grow memory unbounded. Two caps:
+        // (1) batch count (production callers drain in submit order, so
+        // this firing is a leak signal), (2) total bytes — a single
+        // un-fetched batch holding 5-10 KB responses × tens of thousands
+        // of items can be 100s of MB; 128 such batches would be multi-GB.
+        // Evict while EITHER cap is over budget.
         const MAX_STASH_BATCHES: usize = 128;
+        const MAX_STASH_BYTES: usize = 256 * 1024 * 1024;
         let mut stash = self.stash.lock().unwrap_or_else(|p| p.into_inner());
-        while stash.len() >= MAX_STASH_BATCHES {
+        loop {
+            let count = stash.len();
+            let bytes: usize = stash
+                .values()
+                .flat_map(|m| m.values().map(|v| v.len()))
+                .sum();
+            if count < MAX_STASH_BATCHES && bytes <= MAX_STASH_BYTES {
+                break;
+            }
             // Pick the lexicographically smallest UUID as a stable evictee —
             // HashMap insertion order isn't preserved, and the alternative
             // (rebuild as IndexMap) is more invasive than this finding warrants.
@@ -476,8 +489,11 @@ impl LocalProvider {
             stash.remove(&stale_key);
             tracing::warn!(
                 batch_id = %stale_key,
-                cap = MAX_STASH_BATCHES,
-                "LocalProvider stash exceeded cap; evicting unfetched entry — \
+                count_cap = MAX_STASH_BATCHES,
+                bytes_cap = MAX_STASH_BYTES,
+                count_now = count,
+                bytes_now = bytes,
+                "LocalProvider stash exceeded count or byte cap; evicting unfetched entry — \
                  callers should drain via fetch_batch_results"
             );
         }


### PR DESCRIPTION
## Summary

Two resource-management findings: byte-budget cap on `LocalProvider` stash + idle-tick age prune on `last_indexed_mtime`.

| ID | Item | Files |
|----|------|-------|
| RM-V1.38-2 | `LocalProvider` stash now caps on EITHER count (128, unchanged) OR byte budget (256 MiB) — pre-fix a single un-fetched batch holding 5–10 KB × tens of thousands of items could be 100s of MB, 128 of them multi-GB | `llm/local.rs` |
| RM-V1.38-7 | `prune_last_indexed_mtime` was peak-shaped (size threshold gate). New `prune_last_indexed_mtime_by_age` is age-only and called from the watch loop's idle branch on 1-hour cadence — daemons below the size threshold now still age out stale entries from deleted/moved files | `cli/watch/{gc,mod,tests}.rs` |

## What's NOT in scope

- **PF-V1.38-10** (find_test_chunks per-store cache) — already fixed: `Store::test_chunks_cache: OnceLock<Arc<Vec<ChunkSummary>>>` exists. The audit was looking at older code.
- PF-V1.38-5 (tree-sitter Parser pool) — medium effort, separate cluster
- PF-V1.38-6 (gather Arc<str> key) — type-change ripples across callers, separate cluster
- PF-V1.38-9 (analyze_type_impact entry_ref) — narrow optimization, separate cluster
- RM-V1.38-9 (Notes cache size cap) — medium scope, separate cluster
- RM-V1.38-10 (LocalProvider Drop logging) — minor, low priority
- Eviction-order switch from `keys().min()` to FIFO via IndexMap — invasive, audit explicitly says "more invasive than this finding warrants"

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib llm::local::tests` — 23/23 green
- [x] `cargo test --features gpu-index --bin cqs prune_last_indexed_mtime_by_age_ignores_size_threshold` — 1/1 green (new test)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
