### PR TITLE
fix: cluster S — extensibility sweep (2 findings, #1463)

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,6 +834,10 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_MAX_REFERENCES` | `20` | Max number of reference indexes loaded from `[references]` blocks. Each reference holds a separate SQLite DB + HNSW index (~50-100 MB RAM each). Hit on a `cqs ref`-heavy workspace? Bump it; `0`/garbage falls back to default. SHL-V1.30-6. |
 | `CQS_GATHER_DEPTH` | `1` (`gather` default) | BFS expansion depth for the shared `gather` pipeline. Honored as a fallback by `task` when `CQS_TASK_GATHER_DEPTH` is unset. SHL-V1.30-4. |
 | `CQS_TASK_GATHER_DEPTH` | `2` | BFS expansion depth used inside `cqs task` (number of call-graph hops from each modify target). Takes precedence over `CQS_GATHER_DEPTH` for the task pipeline only. SHL-V1.30-4. |
+| `CQS_TASK_WATERFALL_SCOUT` | `0.15` | Fraction of `cqs task --max-tokens` allocated to the scout section (file groups + chunk roles). Operators packing more code or impact info can shift weight via this knob. Bounded `0.0..=1.0`. v1.38: EX-V1.38-5 / #1463. |
+| `CQS_TASK_WATERFALL_CODE` | `0.50` | Fraction of `cqs task --max-tokens` allocated to the code section (gathered chunks). v1.38: EX-V1.38-5 / #1463. |
+| `CQS_TASK_WATERFALL_IMPACT` | `0.15` | Fraction of `cqs task --max-tokens` allocated to the impact section (risk + tests). v1.38: EX-V1.38-5 / #1463. |
+| `CQS_TASK_WATERFALL_PLACEMENT` | `0.10` | Fraction of `cqs task --max-tokens` allocated to the placement section (where to add). The notes section gets the remainder (default 0.10). v1.38: EX-V1.38-5 / #1463. |
 | `CQS_ONBOARD_CALLEE_FETCH` | `30` | Max callees `cqs onboard` fetches content for after BFS. Excess callees are surfaced as `summary.callees_truncated` in JSON and a `tracing::warn!`. SHL-V1.30-5. |
 | `CQS_ONBOARD_CALLER_FETCH` | `15` | Max callers `cqs onboard` fetches content for. Truncation surfaces as `summary.callers_truncated`. SHL-V1.30-5. |
 | `CQS_NOTES_MAX_FILE_SIZE` | `10485760` (10 MiB) | Max size of `notes.toml` accepted by both read and rewrite paths. A larger file is rejected with `InvalidData`. Bump on workspaces with very large note collections. SHL-V1.30-7. |

--- a/src/cli/commands/train/task.rs
+++ b/src/cli/commands/train/task.rs
@@ -266,14 +266,48 @@ pub(crate) fn build_budgeted_task(
 }
 
 /// Waterfall budget weight for the scout section (file groups, chunk roles).
-const WATERFALL_SCOUT: f64 = 0.15;
+const WATERFALL_SCOUT_DEFAULT: f64 = 0.15;
 /// Waterfall budget weight for the code section (gathered chunks with content).
-const WATERFALL_CODE: f64 = 0.50;
+const WATERFALL_CODE_DEFAULT: f64 = 0.50;
 /// Waterfall budget weight for the impact section (risk scores + tests).
-const WATERFALL_IMPACT: f64 = 0.15;
+const WATERFALL_IMPACT_DEFAULT: f64 = 0.15;
 /// Waterfall budget weight for the placement section (where to add).
-const WATERFALL_PLACEMENT: f64 = 0.10;
+const WATERFALL_PLACEMENT_DEFAULT: f64 = 0.10;
 // Notes section takes whatever budget remains (no explicit constant needed).
+
+/// EX-V1.38-5 (#1463): operator-tunable waterfall weight. Reads
+/// `CQS_TASK_WATERFALL_<name>` (e.g. `CQS_TASK_WATERFALL_CODE=0.6`),
+/// rejects non-finite / negative / >1 values, falls back to `default`.
+fn waterfall_weight(name: &str, default: f64) -> f64 {
+    let key = format!("CQS_TASK_WATERFALL_{name}");
+    match std::env::var(&key) {
+        Ok(v) => match v.parse::<f64>() {
+            Ok(n) if n.is_finite() && (0.0..=1.0).contains(&n) => n,
+            _ => {
+                tracing::warn!(
+                    env = %key,
+                    value = %v,
+                    "Invalid waterfall weight (must be finite, 0.0..=1.0); using default {default}"
+                );
+                default
+            }
+        },
+        Err(_) => default,
+    }
+}
+
+fn waterfall_scout() -> f64 {
+    waterfall_weight("SCOUT", WATERFALL_SCOUT_DEFAULT)
+}
+fn waterfall_code() -> f64 {
+    waterfall_weight("CODE", WATERFALL_CODE_DEFAULT)
+}
+fn waterfall_impact() -> f64 {
+    waterfall_weight("IMPACT", WATERFALL_IMPACT_DEFAULT)
+}
+fn waterfall_placement() -> f64 {
+    waterfall_weight("PLACEMENT", WATERFALL_PLACEMENT_DEFAULT)
+}
 
 pub(crate) fn cmd_task(
     ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
@@ -410,7 +444,7 @@ pub(crate) fn waterfall_pack(
     let mut remaining = budget;
 
     // 1. Scout section — pack file groups by relevance
-    let scout_budget = ((budget as f64 * WATERFALL_SCOUT) as usize).min(remaining);
+    let scout_budget = ((budget as f64 * waterfall_scout()) as usize).min(remaining);
     let group_texts: Vec<String> = result
         .scout
         .file_groups
@@ -440,7 +474,7 @@ pub(crate) fn waterfall_pack(
     // budget. That overshoot is absorbed here via saturating_sub on `remaining`,
     // which reduces downstream section budgets proportionally. The total output
     // may slightly exceed `budget` by at most one item's token count.
-    let code_budget = ((budget as f64 * WATERFALL_CODE) as usize
+    let code_budget = ((budget as f64 * waterfall_code()) as usize
         + scout_budget.saturating_sub(scout_used))
     .min(remaining);
     let code_refs: Vec<&str> = result.code.iter().map(|c| c.content.as_str()).collect();
@@ -451,7 +485,7 @@ pub(crate) fn waterfall_pack(
     remaining = remaining.saturating_sub(code_used);
 
     // 3. Impact section (+ surplus) — risk by score, tests by depth
-    let impact_budget = ((budget as f64 * WATERFALL_IMPACT) as usize
+    let impact_budget = ((budget as f64 * waterfall_impact()) as usize
         + code_budget.saturating_sub(code_used))
     .min(remaining);
     let risk_texts: Vec<String> = result
@@ -499,7 +533,7 @@ pub(crate) fn waterfall_pack(
     remaining = remaining.saturating_sub(risk_used + tests_used);
 
     // 4. Placement section (+ surplus)
-    let placement_budget = ((budget as f64 * WATERFALL_PLACEMENT) as usize
+    let placement_budget = ((budget as f64 * waterfall_placement()) as usize
         + impact_budget.saturating_sub(risk_used + tests_used))
     .min(remaining);
     let placement_texts: Vec<String> = result
@@ -926,7 +960,10 @@ mod tests {
     #[test]
     fn test_waterfall_allocation_percentages() {
         // Notes takes the remainder, so the explicit weights must sum to ≤1.0
-        let total = WATERFALL_SCOUT + WATERFALL_CODE + WATERFALL_IMPACT + WATERFALL_PLACEMENT;
+        let total = WATERFALL_SCOUT_DEFAULT
+            + WATERFALL_CODE_DEFAULT
+            + WATERFALL_IMPACT_DEFAULT
+            + WATERFALL_PLACEMENT_DEFAULT;
         assert!(
             (0.9..=1.0).contains(&total),
             "Explicit budget weights must leave a small remainder for notes, got {total}"
@@ -936,10 +973,10 @@ mod tests {
     #[test]
     fn test_waterfall_section_budgets() {
         let budget: usize = 1000;
-        let scout = (budget as f64 * WATERFALL_SCOUT) as usize;
-        let code = (budget as f64 * WATERFALL_CODE) as usize;
-        let impact = (budget as f64 * WATERFALL_IMPACT) as usize;
-        let placement = (budget as f64 * WATERFALL_PLACEMENT) as usize;
+        let scout = (budget as f64 * waterfall_scout()) as usize;
+        let code = (budget as f64 * waterfall_code()) as usize;
+        let impact = (budget as f64 * waterfall_impact()) as usize;
+        let placement = (budget as f64 * waterfall_placement()) as usize;
         let notes = budget - scout - code - impact - placement;
         assert_eq!(scout + code + impact + placement + notes, budget);
     }
@@ -1023,10 +1060,10 @@ mod tests {
     fn test_waterfall_surplus_forwarding() {
         let budget: usize = 1000;
         let weights = [
-            WATERFALL_SCOUT,
-            WATERFALL_CODE,
-            WATERFALL_IMPACT,
-            WATERFALL_PLACEMENT,
+            WATERFALL_SCOUT_DEFAULT,
+            WATERFALL_CODE_DEFAULT,
+            WATERFALL_IMPACT_DEFAULT,
+            WATERFALL_PLACEMENT_DEFAULT,
         ];
         let base_budgets: Vec<usize> = weights
             .iter()

--- a/src/doc_writer/formats.rs
+++ b/src/doc_writer/formats.rs
@@ -22,6 +22,16 @@ pub struct DocFormat {
     pub suffix: &'static str,
     /// Where the doc comment is inserted relative to the function.
     pub position: InsertionPosition,
+    /// EX-V1.38-8 (#1463): subject-first first-line template. Some
+    /// languages convention the first doc-comment line to lead with the
+    /// function name (Go: `// FuncName does X`). When `Some`, the
+    /// formatter prepends `func_name + " "` to the first line. `None`
+    /// = no prepend (the default for every language other than Go).
+    /// Pre-fix this was a hardcoded `if language == Language::Go { ... }`
+    /// in the formatter; promoting to the format struct removes the
+    /// language-name literal and lets a future "subject-first" preset
+    /// (Erlang `%% function/arity:`, custom house style) opt in.
+    pub prepend_func_name: bool,
 }
 
 /// Where a doc comment is placed relative to the function definition.
@@ -54,72 +64,85 @@ fn doc_format_from_tag(tag: &str) -> DocFormat {
             line_prefix: "/// ",
             suffix: "",
             position: InsertionPosition::BeforeFunction,
+            prepend_func_name: false,
         },
         "python_docstring" => DocFormat {
             prefix: "\"\"\"",
             line_prefix: "",
             suffix: "\"\"\"",
             position: InsertionPosition::InsideBody,
+            prepend_func_name: false,
         },
         "go_comment" => DocFormat {
             prefix: "",
             line_prefix: "// ",
             suffix: "",
             position: InsertionPosition::BeforeFunction,
+            // EX-V1.38-8 (#1463): Go convention is "// FuncName does X".
+            prepend_func_name: true,
         },
         "javadoc" => DocFormat {
             prefix: "/**",
             line_prefix: " * ",
             suffix: " */",
             position: InsertionPosition::BeforeFunction,
+            prepend_func_name: false,
         },
         "hash_comment" => DocFormat {
             prefix: "",
             line_prefix: "# ",
             suffix: "",
             position: InsertionPosition::BeforeFunction,
+            prepend_func_name: false,
         },
         "elixir_doc" => DocFormat {
             prefix: "@doc \"\"\"",
             line_prefix: "",
             suffix: "\"\"\"",
             position: InsertionPosition::BeforeFunction,
+            prepend_func_name: false,
         },
         "lua_ldoc" => DocFormat {
             prefix: "",
             line_prefix: "--- ",
             suffix: "",
             position: InsertionPosition::BeforeFunction,
+            prepend_func_name: false,
         },
         "haskell_haddock" => DocFormat {
             prefix: "",
             line_prefix: "-- | ",
             suffix: "",
             position: InsertionPosition::BeforeFunction,
+            prepend_func_name: false,
         },
         "ocaml_doc" => DocFormat {
             prefix: "(** ",
             line_prefix: "",
             suffix: " *)",
             position: InsertionPosition::BeforeFunction,
+            prepend_func_name: false,
         },
         "erlang_edoc" => DocFormat {
             prefix: "",
             line_prefix: "%% ",
             suffix: "",
             position: InsertionPosition::BeforeFunction,
+            prepend_func_name: false,
         },
         "r_roxygen" => DocFormat {
             prefix: "",
             line_prefix: "#' ",
             suffix: "",
             position: InsertionPosition::BeforeFunction,
+            prepend_func_name: false,
         },
         "block_comment" => DocFormat {
             prefix: "(*",
             line_prefix: "",
             suffix: "*)",
             position: InsertionPosition::BeforeFunction,
+            prepend_func_name: false,
         },
         // "default" and any unknown tag
         _ => DocFormat {
@@ -127,6 +150,7 @@ fn doc_format_from_tag(tag: &str) -> DocFormat {
             line_prefix: "// ",
             suffix: "",
             position: InsertionPosition::BeforeFunction,
+            prepend_func_name: false,
         },
     }
 }
@@ -153,13 +177,15 @@ pub fn format_doc_comment(text: &str, language: Language, indent: &str, func_nam
 
     let mut result = String::new();
 
-    // For Go: prepend function name to first line per convention
-    let go_first_line: String;
-    let effective_lines: Vec<&str> = if language == Language::Go {
+    // EX-V1.38-8 (#1463): subject-first prepend driven by `DocFormat
+    // .prepend_func_name` instead of a `Language::Go` literal. Go is the
+    // only currently-shipped language with this convention; other languages
+    // can opt in by setting the flag in `doc_format_from_tag`.
+    let prepended_first_line: String;
+    let effective_lines: Vec<&str> = if format.prepend_func_name {
         if let Some(&first) = lines.first() {
-            // "FuncName does X" — capitalize first char of description if needed
-            go_first_line = format!("{func_name} {first}");
-            let mut v = vec![go_first_line.as_str()];
+            prepended_first_line = format!("{func_name} {first}");
+            let mut v = vec![prepended_first_line.as_str()];
             v.extend_from_slice(&lines[1..]);
             v
         } else {


### PR DESCRIPTION
## Summary

Two extensibility findings: operator-tunable `cqs task` waterfall + Go's "// FuncName does X" convention parameterized.

| ID | Item | Files |
|----|------|-------|
| EX-V1.38-5 | `cqs task` waterfall weights tunable via `CQS_TASK_WATERFALL_{SCOUT,CODE,IMPACT,PLACEMENT}`. Each helper validates `0.0..=1.0`, warns on garbage, falls back to compiled default | `cli/commands/train/task.rs` |
| EX-V1.38-8 | Go's first-line `// FuncName does X` convention now driven by `DocFormat.prepend_func_name: bool` instead of `if language == Language::Go { ... }` in the formatter. Other languages opt in via `doc_format_from_tag` | `doc_writer/formats.rs` |

Plus 4 README env-var entries for the new `CQS_TASK_WATERFALL_*` knobs.

## What's NOT in scope

- **EX-V1.38-2** (test_markers re-hardcoded in C#/Java/Kotlin/Python `post_process_chunk_*` blocks) — touches 4 language-specific post-processors, separate cluster
- **EX-V1.38-3** (Reranker tunables → `[reranker]` TOML config) — `AuxModelSection` promotion, separate cluster
- **EX-V1.38-6** (Markdown call-extraction → trait field) — would need a NEW `chunk_call_parser: Option<fn(&Chunk) -> Vec<CallSite>>` field on `LanguageDef` (existing `custom_call_parser` has a different signature `(source, path, parser) -> (Vec<FunctionCalls>, Vec<ChunkTypeRefs>)`). Separate cluster.
- EX-V1.38-7/9 — P4 tracking (Python docstring, Go method receiver) under #1463

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --bin cqs waterfall` — 3/3 green
- [x] `cargo test --features gpu-index --lib doc_writer::formats` — 32/32 green (Go format test still passes — flag-driven prepend matches the old literal-driven behavior)
- [x] `cargo test --features gpu-index --test env_var_docs` — green (4 new env vars added to README)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
