### PR TITLE
fix: cluster U — API design tightening (2 findings, #1463)

### DIFF
--- a/src/cli/commands/eval/mod.rs
+++ b/src/cli/commands/eval/mod.rs
@@ -91,7 +91,14 @@ pub(crate) struct EvalCmdArgs {
     ///
     /// Note: `cqs status --wait-secs` has the same semantics; default
     /// differs by use case (eval default = 600, status = 30).
-    #[arg(long = "require-fresh-secs", default_value_t = 600u64)]
+    ///
+    /// API-V1.38-8 (#1463): `--wait-secs` is a visible alias so an
+    /// agent learning the status-side spelling transfers cleanly.
+    #[arg(
+        long = "require-fresh-secs",
+        visible_alias = "wait-secs",
+        default_value_t = 600u64
+    )]
     pub require_fresh_secs: u64,
 
     /// Apply a reranker stage after retrieval. Default `none` (skip

--- a/src/cli/commands/train/export_model.rs
+++ b/src/cli/commands/train/export_model.rs
@@ -42,7 +42,7 @@ fn validate_repo_id(repo: &str) -> anyhow::Result<()> {
 pub(crate) fn cmd_export_model(
     repo: &str,
     output: &Path,
-    dim_override: Option<u64>,
+    dim_override: Option<usize>,
 ) -> anyhow::Result<()> {
     let _span = tracing::info_span!("export_model", repo).entered();
 
@@ -148,7 +148,7 @@ pub(crate) fn cmd_export_model(
 }
 
 /// Resolve embedding dimension: --dim override > config.json auto-detect > None.
-fn resolve_dim(dim_override: Option<u64>, output_dir: &Path) -> Option<u64> {
+fn resolve_dim(dim_override: Option<usize>, output_dir: &Path) -> Option<usize> {
     let _span = tracing::info_span!("resolve_dim").entered();
     if let Some(d) = dim_override {
         tracing::info!(dim = d, "Using --dim override");
@@ -157,7 +157,8 @@ fn resolve_dim(dim_override: Option<u64>, output_dir: &Path) -> Option<u64> {
     let detected = std::fs::read_to_string(output_dir.join("config.json"))
         .ok()
         .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
-        .and_then(|j| j["hidden_size"].as_u64());
+        .and_then(|j| j["hidden_size"].as_u64())
+        .map(|n| n as usize);
     match detected {
         Some(d) => {
             tracing::info!(dim = d, "Auto-detected dim from config.json hidden_size");
@@ -174,7 +175,7 @@ fn resolve_dim(dim_override: Option<u64>, output_dir: &Path) -> Option<u64> {
 fn write_model_toml(
     output_dir: &Path,
     repo: &str,
-    resolved_dim: Option<u64>,
+    resolved_dim: Option<usize>,
 ) -> anyhow::Result<()> {
     let toml_path = output_dir.join("model.toml");
     let dim_line = match resolved_dim {

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -783,8 +783,14 @@ pub(super) enum Commands {
         #[arg(long, default_value = ".")]
         output: std::path::PathBuf,
         /// Embedding dimension override (auto-detected from config.json if omitted)
+        ///
+        /// API-V1.38-7 (#1463): `usize` aligns with `ModelConfig.dim`,
+        /// `EmbeddingConfig.dim`, `VectorIndex::dim()` etc. — every other
+        /// dim field in the codebase. The previous `Option<u64>` parsed
+        /// identically (`--dim 768`) but required `as usize` casts at the
+        /// handler boundary.
         #[arg(long)]
-        dim: Option<u64>,
+        dim: Option<usize>,
     },
     /// Generate training data for fine-tuning from git history
     #[cqs_cmd(group = "a", batch = "cli")]
@@ -894,7 +900,12 @@ pub(super) enum Commands {
         ///
         /// Note: `cqs eval --require-fresh-secs` has the same semantics;
         /// default differs by use case (eval default = 600, status = 30).
-        #[arg(long, default_value_t = 30)]
+        ///
+        /// API-V1.38-8 (#1463): `--require-fresh-secs` exposed as a
+        /// visible alias so an agent that learned the eval-side spelling
+        /// can use it on `cqs status` too. Both spellings parse to the
+        /// same field; prefer `--wait-secs` in CI scripts (shorter).
+        #[arg(long, visible_alias = "require-fresh-secs", default_value_t = 30)]
         wait_secs: u64,
         /// Output as JSON. Without this, prints a one-line human summary.
         ///


### PR DESCRIPTION
## Summary

Two non-breaking API hygiene fixes:

| ID | Item | Files |
|----|------|-------|
| API-V1.38-7 | `ExportModel.dim: Option<u64>` → `Option<usize>` (matches `ModelConfig.dim`, `EmbeddingConfig.dim`, `VectorIndex::dim()` etc.; drops `as usize` casts at the handler boundary) | `cli/definitions.rs`, `cli/commands/train/export_model.rs` |
| API-V1.38-8 | `cqs status --wait-secs` and `cqs eval --require-fresh-secs` are semantically identical; each now exposes the other as a `visible_alias` | `cli/definitions.rs`, `cli/commands/eval/mod.rs` |

`--dim 768` parses identically. Defaults stay command-specific (30 for status, 600 for eval). Smoke-tested both alias directions.

## What's NOT in scope

The audit suggested a stable order `1, 10, 7, 5, 3, 4, 8, 6, 2, 9` for one bundled PR. I'm splitting more aggressively because the bigger items each warrant their own review:

- **API-V1.38-1** (ModelCommand/HookCommand → TextJsonArgs envelope) — separate cluster
- **API-V1.38-2** (ProjectCommand::Search flatten SearchArgs) — separate
- **API-V1.38-6** (top-level Cli search flags ignored on subcommand — silent-drop) — bigger fix, separate
- **API-V1.38-9** (HfHub error variants → ResolveError collapse) — breaking variant rename, separate
- **API-V1.38-10** (LimitArg fan-out across 7 sister args) — 61 `args.limit` / `cli.limit` caller sites; mechanical but broad. Separate cluster.

Already shipped: API-V1.38-3 (#1529), API-V1.38-4 (already had the trait fix), API-V1.38-5 (#1528).

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --bin cqs export_model` — 11/11 green (resolve_dim suite still passes after `Option<u64>` → `Option<usize>`)
- [x] `cargo run -- status --require-fresh-secs 5` — parses ✓ (visible alias)
- [x] `cargo run -- eval --wait-secs 5 --no-require-fresh foo` — parses ✓ (visible alias)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
