### PR TITLE
test: cluster V — TC-ADV regression backfill (4 findings, #1463)

### DIFF
--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -1854,6 +1854,47 @@ mentions = []
         .expect("matching name must pass");
     }
 
+    /// TC-ADV-V1.38-6 (#1463): drift detection is byte-exact `==`. Pin
+    /// case-sensitivity so a future case-fold is a deliberate change —
+    /// `--model BGE-Large` against stored `bge-large` currently DOES bail.
+    /// Operator who hits this needs to know it's a name-not-content drift
+    /// instead of running a 30-min `--force` rebuild they don't actually
+    /// need; documenting the contract in a test puts the case-fold
+    /// migration on a clear next step.
+    #[test]
+    fn check_index_model_drift_is_case_sensitive_pin() {
+        let path = Path::new("/tmp/x/index.db");
+        let result = check_index_model_drift(
+            Some("bge-large"),
+            "BGE-Large",
+            "BAAI/bge-large-en-v1.5",
+            path,
+        );
+        assert!(
+            result.is_err(),
+            "current contract: byte-exact match — case differences trigger drift"
+        );
+    }
+
+    /// TC-ADV-V1.38-6 (#1463): whitespace in stored model name (e.g. a
+    /// migration that landed `format!("{}\n", name)`) currently fails the
+    /// `stored == requested` check. Pin so a future migration writes are
+    /// either trimmed at write-time or this test flips deliberately.
+    #[test]
+    fn check_index_model_drift_rejects_whitespace_drift() {
+        let path = Path::new("/tmp/x/index.db");
+        let result = check_index_model_drift(
+            Some("bge-large\n"),
+            "bge-large",
+            "BAAI/bge-large-en-v1.5",
+            path,
+        );
+        assert!(
+            result.is_err(),
+            "whitespace drift in stored name currently bails — pin so a future trim is deliberate"
+        );
+    }
+
     /// Stored == requested repo (but not the short name) → pass. Operators
     /// often have `model_name = "BAAI/bge-large-en-v1.5"` from a `cqs index
     /// --force` of an earlier session and pass `--model bge-large` later.

--- a/src/search/scoring/candidate.rs
+++ b/src/search/scoring/candidate.rs
@@ -779,6 +779,77 @@ mod tests {
         );
     }
 
+    /// TC-ADV-V1.38-8 (#1463): pin the contract for non-finite thresholds.
+    /// `threshold = NaN` → IEEE-754 says `score >= NaN` is always false →
+    /// silent empty result set. Pin this so a future `is_finite` rejection
+    /// at the public boundary is a deliberate change.
+    #[test]
+    fn test_score_candidate_nan_threshold_returns_empty() {
+        let emb = test_embedding(1.0);
+        let query = test_embedding(1.0);
+        let filter = SearchFilter::default();
+        let note_index = NoteBoost::Borrowed(NoteBoostIndex::new(&[]));
+        let ctx = ScoringContext {
+            query: &query,
+            filter: &filter,
+            name_matcher: None,
+            glob_matcher: None,
+            note_index: &note_index,
+            threshold: f32::NAN,
+        };
+        let score = score_candidate(&emb, None, "src/lib.rs", &ctx);
+        assert!(
+            score.is_none(),
+            "NaN threshold currently filters out all results — pin contract"
+        );
+    }
+
+    /// TC-ADV-V1.38-8 (#1463): `threshold = -∞` → all candidates pass.
+    /// Pin behavior so an operator-supplied `--threshold -inf` (e.g. via
+    /// shell typo `-1e9999`) doesn't surprise downstream callers.
+    #[test]
+    fn test_score_candidate_neg_inf_threshold_passes_all() {
+        let emb = test_embedding(1.0);
+        let query = test_embedding(1.0);
+        let filter = SearchFilter::default();
+        let note_index = NoteBoost::Borrowed(NoteBoostIndex::new(&[]));
+        let ctx = ScoringContext {
+            query: &query,
+            filter: &filter,
+            name_matcher: None,
+            glob_matcher: None,
+            note_index: &note_index,
+            threshold: f32::NEG_INFINITY,
+        };
+        let score = score_candidate(&emb, None, "src/lib.rs", &ctx);
+        assert!(
+            score.is_some(),
+            "-∞ threshold currently passes all candidates — pin contract"
+        );
+    }
+
+    /// TC-ADV-V1.38-8 (#1463): `threshold = +∞` → no candidates pass.
+    #[test]
+    fn test_score_candidate_pos_inf_threshold_returns_empty() {
+        let emb = test_embedding(1.0);
+        let query = test_embedding(1.0);
+        let filter = SearchFilter::default();
+        let note_index = NoteBoost::Borrowed(NoteBoostIndex::new(&[]));
+        let ctx = ScoringContext {
+            query: &query,
+            filter: &filter,
+            name_matcher: None,
+            glob_matcher: None,
+            note_index: &note_index,
+            threshold: f32::INFINITY,
+        };
+        let score = score_candidate(&emb, None, "src/lib.rs", &ctx);
+        assert!(
+            score.is_none(),
+            "+∞ threshold currently filters all candidates — pin contract"
+        );
+    }
+
     #[test]
     fn test_score_candidate_glob_filters() {
         let emb = test_embedding(1.0);

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -340,6 +340,22 @@ mod tests {
         );
     }
 
+    /// TC-ADV-V1.38-4 (#1463): a stray `.cqs` *file* (mistaken
+    /// `touch .cqs`, packaged tarball with the wrong entry) must NOT be
+    /// treated as an index dir. P1-43 changed `own_cqs.exists()` →
+    /// `own_cqs.is_dir()`; pin the `is_dir()` contract so a future
+    /// regression to `.exists()` is caught at test time.
+    #[test]
+    fn lookup_ignores_stray_cqs_file_falls_through() {
+        let dir = TempDir::new().unwrap();
+        // Create a stray FILE named `.cqs` instead of a directory.
+        std::fs::write(dir.path().join(crate::INDEX_DIR), b"oops").unwrap();
+        match lookup_main_cqs_dir(dir.path()) {
+            MainIndexLookup::NotWorktree => { /* expected */ }
+            other => panic!("stray .cqs file must fall through to NotWorktree, got {other:?}"),
+        }
+    }
+
     /// `lookup_main_cqs_dir` returns `OwnIndex` when the directory
     /// has its own `.cqs/` regardless of worktree status — the
     /// worktree's own index always wins.


### PR DESCRIPTION
## Summary

Six new regression tests pinning behavioral contracts where the underlying fix shipped without a test. A revert-style regression on any of these previously passed all current tests.

| ID | Tests | Files |
|----|-------|-------|
| TC-ADV-V1.38-4 | `lookup_ignores_stray_cqs_file_falls_through` — P1-43 `is_dir()` contract for stray `.cqs` FILE | `worktree.rs` |
| TC-ADV-V1.38-6 | `check_index_model_drift_is_case_sensitive_pin` + `..._rejects_whitespace_drift` — PR #1505 byte-exact `==` contract | `cli/commands/index/build.rs` |
| TC-ADV-V1.38-8 | `test_score_candidate_nan_threshold_returns_empty` + `..._neg_inf_threshold_passes_all` + `..._pos_inf_threshold_returns_empty` — pin IEEE-754 behavior of non-finite threshold values flowing into `score_candidate` | `search/scoring/candidate.rs` |

## What's NOT in scope

- **TC-ADV-V1.38-3** (sparse vectors NaN/Inf write-path) — needs schema/constraint inspection
- **TC-ADV-V1.38-5** (write_active_slot multi-thread race) — needs thread::spawn harness; separate
- **TC-ADV-V1.38-7** (embed_query truncation at char boundary) — needs `CQS_MAX_QUERY_BYTES` env mutation harness
- **TC-ADV-V1.38-9** (synonym/classifier overlay 4 KiB cap) — easy but separate
- TC-ADV-V1.38-1, -2, -10 — already shipped in #1521 (cluster D)

## Test plan

- [x] `cargo test --features gpu-index --lib lookup_ignores_stray` — 1/1 green
- [x] `cargo test --features gpu-index --lib *threshold*` — 3/3 green
- [x] `cargo test --features gpu-index --bin cqs check_index_model_drift_{is_case_sensitive_pin,rejects_whitespace_drift}` — 2/2 green
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

No production code touched; tests-only PR.
