### PR TITLE
fix: cluster X — API-V1.38-1: ModelCommand/HookCommand → TextJsonArgs (#1463)

### DIFF
--- a/src/cli/commands/infra/hook.rs
+++ b/src/cli/commands/infra/hook.rs
@@ -52,6 +52,9 @@ pub(crate) const MANAGED_HOOKS: &[&str] = &["post-checkout", "post-merge", "post
 
 /// `cqs hook` subcommand surface.
 #[derive(clap::Subcommand, Debug, Clone)]
+/// API-V1.38-1 (#1463): every variant flattens
+/// [`crate::cli::definitions::TextJsonArgs`] (`output: TextJsonArgs`) instead
+/// of an inline `json: bool`. Matches the codebase-wide pattern.
 pub(crate) enum HookCommand {
     /// Install cqs hooks into `.git/hooks/`. Idempotent — re-running is
     /// safe; already-installed cqs hooks are upgraded in place.
@@ -61,16 +64,14 @@ pub(crate) enum HookCommand {
         /// existing third-party hooks.
         #[arg(long)]
         no_overwrite: bool,
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
+        #[command(flatten)]
+        output: crate::cli::definitions::TextJsonArgs,
     },
     /// Remove cqs-managed hooks from `.git/hooks/`. Hooks that don't
     /// carry the cqs marker are left alone (they may be third-party).
     Uninstall {
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
+        #[command(flatten)]
+        output: crate::cli::definitions::TextJsonArgs,
     },
     /// Internal: hook scripts call this. Posts a `reconcile` socket
     /// message; falls back to touching `.cqs/.dirty` if the daemon is
@@ -85,14 +86,13 @@ pub(crate) enum HookCommand {
         args: Vec<String>,
         /// Output as JSON. Default is silent on success, brief stderr on
         /// failure — hooks shouldn't pollute git's output channel.
-        #[arg(long)]
-        json: bool,
+        #[command(flatten)]
+        output: crate::cli::definitions::TextJsonArgs,
     },
     /// Show installed hooks + daemon connectivity.
     Status {
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
+        #[command(flatten)]
+        output: crate::cli::definitions::TextJsonArgs,
     },
 }
 
@@ -150,10 +150,13 @@ struct FireReport {
 /// Top-level dispatch. Each variant handles its own JSON-vs-text output.
 pub(crate) fn cmd_hook(subcmd: HookCommand) -> Result<()> {
     match subcmd {
-        HookCommand::Install { no_overwrite, json } => cmd_install(no_overwrite, json),
-        HookCommand::Uninstall { json } => cmd_uninstall(json),
-        HookCommand::Fire { name, args, json } => cmd_fire(name, args, json),
-        HookCommand::Status { json } => cmd_status(json),
+        HookCommand::Install {
+            no_overwrite,
+            output,
+        } => cmd_install(no_overwrite, output.json),
+        HookCommand::Uninstall { output } => cmd_uninstall(output.json),
+        HookCommand::Fire { name, args, output } => cmd_fire(name, args, output.json),
+        HookCommand::Status { output } => cmd_status(output.json),
     }
 }
 

--- a/src/cli/commands/infra/model.rs
+++ b/src/cli/commands/infra/model.rs
@@ -119,19 +119,24 @@ pub(crate) fn daemon_control_hint(hint: DaemonHint) -> &'static str {
 // ---------------------------------------------------------------------------
 
 /// `cqs model` subcommand surface.
+///
+/// API-V1.38-1 (#1463): each variant flattens [`crate::cli::definitions::TextJsonArgs`]
+/// (`output: TextJsonArgs`) instead of an inline `json: bool`. Matches the
+/// pattern used across Project / Ref / Slot / Cache / Notes / Init / Doctor /
+/// Stats / Affected / Brief / Refresh / Ping / Status / Convert. Future shared
+/// output knobs (`--pretty`, `--ndjson`) become a one-line addition to
+/// `TextJsonArgs` instead of a multi-file edit.
 #[derive(clap::Subcommand)]
 pub(crate) enum ModelCommand {
     /// Show the model recorded in the current index, plus on-disk size.
     Show {
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
+        #[command(flatten)]
+        output: crate::cli::definitions::TextJsonArgs,
     },
     /// List built-in embedding model presets, marking the current one with `*`.
     List {
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
+        #[command(flatten)]
+        output: crate::cli::definitions::TextJsonArgs,
     },
     /// Swap the indexed embedder: backup `.cqs/`, reindex with the new
     /// preset, restore on failure.
@@ -142,9 +147,8 @@ pub(crate) enum ModelCommand {
         /// if the reindex fails — only use when you have a separate backup.
         #[arg(long)]
         no_backup: bool,
-        /// Output as JSON
-        #[arg(long)]
-        json: bool,
+        #[command(flatten)]
+        output: crate::cli::definitions::TextJsonArgs,
     },
 }
 
@@ -199,13 +203,13 @@ struct ModelSwapOutput {
 pub(crate) fn cmd_model(cli: &Cli, subcmd: &ModelCommand) -> Result<()> {
     let _span = tracing::info_span!("cmd_model").entered();
     match subcmd {
-        ModelCommand::Show { json } => cmd_model_show(cli.json || *json),
-        ModelCommand::List { json } => cmd_model_list(cli.json || *json),
+        ModelCommand::Show { output } => cmd_model_show(cli.json || output.json),
+        ModelCommand::List { output } => cmd_model_list(cli.json || output.json),
         ModelCommand::Swap {
             preset,
             no_backup,
-            json,
-        } => cmd_model_swap(cli, preset, *no_backup, cli.json || *json),
+            output,
+        } => cmd_model_swap(cli, preset, *no_backup, cli.json || output.json),
     }
 }
 


### PR DESCRIPTION
## Summary

API-V1.38-1: align `ModelCommand` and `HookCommand` with the codebase-wide `TextJsonArgs` flattening pattern.

| Subcommand | Variants migrated |
|------------|-------------------|
| `ModelCommand` | `Show`, `List`, `Swap` |
| `HookCommand` | `Install`, `Uninstall`, `Fire`, `Status` |

Inline `json: bool` → `#[command(flatten)] output: TextJsonArgs`. Dispatcher's `cli.json || *json` collapses to `cli.json || output.json`. User-facing `--json` flag is unchanged; this is purely an internal-shape refactor.

## Why

Every other top-level subcommand surface (Project / Ref / Slot / Cache / Notes / Init / Doctor / Stats / Affected / Brief / Refresh / Ping / Status / Convert) already uses `TextJsonArgs`. Adding a future shared output knob (`--pretty`, `--ndjson`) was a multi-file, per-variant edit on `ModelCommand` / `HookCommand`; now it's a one-line `TextJsonArgs` addition.

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --bin cqs cli::commands::infra::model` — 9/9 green
- [x] `cargo test --features gpu-index --bin cqs cli::commands::infra::hook` — 13/13 green
- [x] `cargo test --features gpu-index --test model_swap_test` — 5/5 green (integration tests pass unchanged)
- [x] `cargo run -- model list --json` — clean JSON envelope
- [x] `cargo run -- hook status` — clean text
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
