### PR TITLE
fix: cluster Y — gitignore + slot-lock contract (2 findings, #1463)

### DIFF
--- a/src/cli/commands/infra/init.rs
+++ b/src/cli/commands/infra/init.rs
@@ -38,13 +38,31 @@ pub(crate) fn cmd_init(cli: &Cli, json: bool) -> Result<()> {
     }
 
     // Create .gitignore
-    // PB-V1.29-4: Windows git with `core.autocrlf=true` renders LF-only files
-    // as modified. Use CRLF on Windows so the initial commit stays quiet.
+    //
+    // PL-V1.38-5 (#1463): the original 9-entry literal listed only
+    // index.db / index.hnsw.* / *.tmp — but `.cqs/` actually carries
+    // 14+ files including `audit-mode.json` (deliberately marked SEC-1),
+    // `embeddings_cache.db`, `index.cagra*`, `index_base.hnsw.*`,
+    // `splade.index.bin*`, `slots/`, `slots.lock`, `store.db`,
+    // `telemetry*.jsonl`, `telemetry.lock`, `active_slot`. Operators
+    // running `cqs init && git add .` were committing the audit-mode
+    // SEC-1 file, telemetry hostnames + exec timing, and ~hundreds of
+    // MB of binary index data.
+    //
+    // The fix uses a `*\n!.gitignore\n` ignore-everything-but-self
+    // pattern, which survives every future addition to `.cqs/` without
+    // a corresponding `init.rs` edit. Operators who want to commit
+    // specific `.cqs/` artifacts (e.g. `notes.toml`) explicitly add a
+    // `!notes.toml` line — opt-in rather than opt-out.
+    //
+    // PB-V1.29-4: Windows git with `core.autocrlf=true` renders LF-only
+    // files as modified. Use CRLF on Windows so the initial commit
+    // stays quiet.
     let gitignore = cqs_dir.join(".gitignore");
     #[cfg(windows)]
-    let gitignore_contents = "index.db\r\nindex.db-wal\r\nindex.db-shm\r\nindex.lock\r\nindex.hnsw.graph\r\nindex.hnsw.data\r\nindex.hnsw.ids\r\nindex.hnsw.checksum\r\nindex.hnsw.lock\r\n*.tmp\r\n";
+    let gitignore_contents = "*\r\n!.gitignore\r\n";
     #[cfg(not(windows))]
-    let gitignore_contents = "index.db\nindex.db-wal\nindex.db-shm\nindex.lock\nindex.hnsw.graph\nindex.hnsw.data\nindex.hnsw.ids\nindex.hnsw.checksum\nindex.hnsw.lock\n*.tmp\n";
+    let gitignore_contents = "*\n!.gitignore\n";
     std::fs::write(&gitignore, gitignore_contents).context("Failed to create .gitignore")?;
 
     // Download model

--- a/src/slot/mod.rs
+++ b/src/slot/mod.rs
@@ -644,6 +644,28 @@ pub fn read_active_slot(project_cqs_dir: &Path) -> Option<String> {
 /// P3.39: routes through `crate::fs::atomic_replace` so the parent directory
 /// is fsynced after the rename — matches the durability contract of
 /// `notes.toml` / `audit-mode.json`.
+///
+/// # Caller contract (DS-V1.38-7 / #1463)
+///
+/// **The caller MUST hold the slots lock** ([`acquire_slots_lock`]) before
+/// calling this function. The atomic-replace primitive is concurrency-safe
+/// for the rename itself, but the broader read-modify-update pattern that
+/// every production caller performs (read current active slot, validate
+/// against the slots metadata, write the new pointer) needs serialization
+/// against concurrent `slot promote` / `slot create` / `migrate_legacy_*`
+/// flows. Without the lock, two writers can both validate against the same
+/// pre-state and one's update is silently overwritten.
+///
+/// Production callers verified holding the lock:
+/// - [`slot_promote`] (`acquire_slots_lock` at the top of the function)
+/// - [`slot_create`] (same)
+/// - [`migrate_legacy_index_to_default_slot`] (runs inside the slots lock)
+///
+/// Test callers run single-threaded by `serial_test::serial`. A future
+/// caller (e.g. a hypothetical `cqs slot set-default` shortcut) that
+/// forgets the lock silently loses updates under concurrency. This
+/// contract was previously implicit; making it explicit prevents that
+/// regression class.
 pub fn write_active_slot(project_cqs_dir: &Path, slot_name: &str) -> Result<(), SlotError> {
     validate_slot_name(slot_name)?;
     let _span = tracing::info_span!(


### PR DESCRIPTION
## Summary

Two small defensive fixes plus a P3 confirmation.

| ID | Item | Files |
|----|------|-------|
| PL-V1.38-5 | `cqs init` writes `.cqs/.gitignore` as `*\n!.gitignore\n` (ignore-everything-but-self) instead of the 9-entry literal — pre-fix, `cqs init && git add .` committed `audit-mode.json` (SEC-1), `telemetry*.jsonl` (hostnames + exec timing), and hundreds of MB of binary index data | `cli/commands/infra/init.rs` |
| DS-V1.38-7 | `write_active_slot` doc comment now explicitly names the slots-lock caller contract — every production caller already holds it, but the requirement was implicit. Future `cqs slot set-default` shortcut that forgets the lock would have silently lost updates | `slot/mod.rs` |
| API-V1.38-2 | **Already addressed** by #1459 item 1 — `parse_finite_f32` validator + `--lang/--include-type/--exclude-type/--rrf/--reranker` knobs are wired at `cli/commands/infra/project.rs:99`. No code change needed. |

## What's NOT in scope

- **API-V1.38-6** (top-level Cli search flags ignored on subcommand) — needs either `global = true` on 20+ flags or a shared `SearchKnobsArgs` struct flattened into 7 search-wrapping commands. Bigger surface; separate cluster.
- **API-V1.38-9** (HfHub error variant collapse) — breaking variant rename; separate
- **API-V1.38-10** (LimitArg fan-out across 7 sister args) — 61 caller sites; separate cluster
- **DS-V1.38-4** (HNSW load_with_dim TOCTOU) — multi-PR architectural change; separate
- **PL-V1.38-4** (WSL-DrvFS detector divergence) — needs `parse_wsl_automount_root` promotion to `cqs::config` + plumbing; separate

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --bin cqs init` — 31 cli-related tests green
- [x] `cargo test --features gpu-index --lib slot::` — 43/43 green (existing slot lock-acquisition tests still pass)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
