### PR TITLE
test: cluster Z — TC-ADV-V1.38-{5,7} regression backfill (#1463)

### DIFF
--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -951,6 +951,14 @@ impl Embedder {
         crate::limits::parse_env_usize("CQS_MAX_QUERY_BYTES", 32 * 1024)
     }
 
+    /// Test helper for [`truncate_at_char_boundary`]. Visibility-bridges
+    /// the free function so unit tests in the same module can exercise
+    /// it without going through `embed_query`'s ONNX model load.
+    #[cfg(test)]
+    pub(super) fn truncate_for_test(text: &str, max: usize) -> &str {
+        truncate_at_char_boundary(text, max)
+    }
+
     pub fn embed_query(&self, text: &str) -> Result<Embedding, EmbedderError> {
         let _span = tracing::info_span!("embed_query").entered();
         // P3-3 (audit v1.33.0): time end-to-end so cache-hit vs. miss
@@ -964,21 +972,7 @@ impl Embedder {
         }
         // RT-RES-5: Truncate oversized input before tokenization to bound CPU work.
         let max_query_bytes = Self::max_query_bytes();
-        let text = if text.len() > max_query_bytes {
-            tracing::warn!(
-                len = text.len(),
-                max = max_query_bytes,
-                "Query text truncated before embedding"
-            );
-            // Truncate at a char boundary
-            let mut end = max_query_bytes;
-            while !text.is_char_boundary(end) && end > 0 {
-                end -= 1;
-            }
-            &text[..end]
-        } else {
-            text
-        };
+        let text = truncate_at_char_boundary(text, max_query_bytes);
 
         // Check in-memory LRU first
         {
@@ -1484,6 +1478,32 @@ impl Embedder {
 }
 
 /// Download model and tokenizer from HuggingFace Hub
+/// Truncate `text` to at most `max_bytes` bytes, snapping back to a
+/// valid UTF-8 char boundary. Returns the original `text` unchanged if
+/// it already fits.
+///
+/// RT-RES-5 / TC-ADV-V1.38-7 (#1463): factored out of `embed_query` so
+/// the boundary-snap behavior can be unit-tested without loading an
+/// ONNX session. The naive `&text[..max_bytes]` panics on multi-byte
+/// boundary crossings (a 4-byte emoji at byte position `max_bytes - 1`
+/// would slice mid-codepoint); this walks back at most `c-1 ≤ 3` bytes
+/// where `c` is the longest UTF-8 sequence length.
+fn truncate_at_char_boundary(text: &str, max_bytes: usize) -> &str {
+    if text.len() <= max_bytes {
+        return text;
+    }
+    tracing::warn!(
+        len = text.len(),
+        max = max_bytes,
+        "Query text truncated before embedding"
+    );
+    let mut end = max_bytes;
+    while !text.is_char_boundary(end) && end > 0 {
+        end -= 1;
+    }
+    &text[..end]
+}
+
 fn ensure_model(config: &ModelConfig) -> Result<(PathBuf, PathBuf), EmbedderError> {
     // CQS_ONNX_DIR: bypass HF download, load from local directory.
     // Directory must contain model.onnx and tokenizer.json.
@@ -1829,6 +1849,96 @@ fn last_token_pool(hidden: &Array3<f32>, attention_mask: &Array2<i64>) -> Vec<Ve
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ===== TC-ADV-V1.38-7 (#1463): truncate_at_char_boundary =====
+    //
+    // RT-RES-5's truncation logic was inline in `embed_query`. The audit
+    // flagged that no test exercised: (a) the truncate path firing at
+    // all (every test set max_query_bytes high enough that `text.len()
+    // <= max` short-circuits), (b) multi-byte UTF-8 boundary handling
+    // when the cap lands mid-codepoint. Pin both with cheap unit tests
+    // — refactored the inline block into the free
+    // `truncate_at_char_boundary(&str, usize) -> &str` so the test
+    // doesn't need an ONNX session.
+
+    #[test]
+    fn truncate_at_char_boundary_fits_under_cap() {
+        let s = "hello world";
+        let out = truncate_at_char_boundary(s, 100);
+        assert_eq!(out, s, "input under cap returns unchanged");
+        assert!(std::ptr::eq(out, s) || out == s); // structural identity
+    }
+
+    #[test]
+    fn truncate_at_char_boundary_ascii_truncates_at_cap() {
+        let s = "abcdefghij";
+        let out = truncate_at_char_boundary(s, 5);
+        assert_eq!(out, "abcde");
+        assert!(out.len() <= 5);
+    }
+
+    #[test]
+    fn truncate_at_char_boundary_snaps_back_on_emoji() {
+        // 99 ASCII bytes + a 4-byte emoji = 103 bytes total.
+        // Cap = 100 lands in the middle of the emoji (bytes 99..103).
+        // The naive `&text[..100]` would panic with
+        // `byte index 100 is not a char boundary`.
+        let mut s = "a".repeat(99);
+        s.push('🦀'); // 4-byte UTF-8
+        assert_eq!(s.len(), 103);
+        let out = truncate_at_char_boundary(&s, 100);
+        // Must snap back to byte 99 (just before the emoji starts) so
+        // the result is valid UTF-8.
+        assert_eq!(out.len(), 99);
+        assert!(out.chars().all(|c| c == 'a'));
+        // Sanity: the slice IS valid UTF-8 (str-typed already proves
+        // this; the assertion is the test's whole point).
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn truncate_at_char_boundary_at_exactly_cap_is_no_op() {
+        let s = "🦀🦀🦀"; // 12 bytes, 3 chars
+        let out = truncate_at_char_boundary(s, 12);
+        assert_eq!(out, s);
+    }
+
+    #[test]
+    fn truncate_at_char_boundary_zero_cap_returns_empty() {
+        let s = "🦀abc";
+        let out = truncate_at_char_boundary(s, 0);
+        assert_eq!(out, "");
+    }
+
+    /// Snap-back convergence is bounded by 3 (the longest valid
+    /// UTF-8 sequence is 4 bytes). A 4-byte emoji at the cap boundary
+    /// snaps back at most 3 bytes — pin this so a future "snap forward"
+    /// regression that walks past `text.len()` would fail the test.
+    #[test]
+    fn truncate_at_char_boundary_walk_distance_bounded() {
+        let mut s = String::new();
+        for _ in 0..50 {
+            s.push('🦀');
+        }
+        // 200 bytes, 50 chars. Try caps 1..=200, every truncation must
+        // succeed without panic and produce valid UTF-8 (str type
+        // already guarantees this; we're asserting the function never
+        // walks off the start).
+        for cap in 1..=s.len() {
+            let out = truncate_at_char_boundary(&s, cap);
+            assert!(
+                out.len() <= cap,
+                "cap={cap}: out.len()={} exceeded cap",
+                out.len()
+            );
+            // Walk distance from cap to chosen end is at most 3 bytes.
+            assert!(
+                cap - out.len() <= 3,
+                "cap={cap}: walked back {} bytes (max 3)",
+                cap - out.len()
+            );
+        }
+    }
 
     // ===== FP16 / BF16 conversion smoke tests =====
     //

--- a/src/slot/mod.rs
+++ b/src/slot/mod.rs
@@ -1287,6 +1287,78 @@ mod tests {
         assert!(write_active_slot(dir.path(), "active").is_err()); // reserved
     }
 
+    /// TC-ADV-V1.38-5 (#1463): pin DS-V1.33-2's `crate::temp_suffix()` race
+    /// fix. Pre-fix, two concurrent `write_active_slot` calls each staged
+    /// to a fixed `active_slot.tmp` and one would clobber the other's temp
+    /// file before the rename, leaving the on-disk file partially written
+    /// or truncated. The DS-V1.33-2 fix appended a 64-bit suffix to each
+    /// temp filename so concurrent writers don't share the staging path.
+    ///
+    /// This test exercises the temp-collision avoidance directly: spawn 8
+    /// threads × 50 writes each interleaving "slot_a" and "slot_b", join
+    /// all, then assert the final on-disk content is exactly one of those
+    /// two strings (not partial bytes, not empty, not mixed). A revert of
+    /// `temp_suffix()` to a fixed name would fail this test under load on
+    /// a CI runner with enough parallelism to expose the race.
+    ///
+    /// We bypass the slots lock here because the test target is
+    /// `write_active_slot`'s own atomic-replace contract — production
+    /// callers serialize via the lock, but the temp-collision-avoidance
+    /// is the function's own internal invariant.
+    #[test]
+    fn write_active_slot_two_concurrent_writers_dont_corrupt() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let dir = TempDir::new().unwrap();
+        let cqs = Arc::new(dir.path().to_path_buf());
+
+        // Pre-create the cqs dir so write_active_slot's `if !exists`
+        // branch doesn't race on `create_dir_all`.
+        std::fs::create_dir_all(cqs.as_path()).unwrap();
+
+        const THREADS: usize = 8;
+        const WRITES_PER_THREAD: usize = 50;
+        let mut handles = Vec::with_capacity(THREADS);
+        for tid in 0..THREADS {
+            let cqs = Arc::clone(&cqs);
+            handles.push(thread::spawn(move || {
+                let pick = if tid % 2 == 0 { "slot_a" } else { "slot_b" };
+                for _ in 0..WRITES_PER_THREAD {
+                    write_active_slot(cqs.as_path(), pick)
+                        .expect("concurrent write_active_slot must not error");
+                }
+            }));
+        }
+        for h in handles {
+            h.join().expect("worker panicked");
+        }
+
+        // Final on-disk content must be exactly one valid slot name —
+        // never empty, never partial, never a mix.
+        let final_path = active_slot_path(cqs.as_path());
+        let bytes = std::fs::read(&final_path).expect("active_slot exists after writers");
+        let s = std::str::from_utf8(&bytes)
+            .expect("active_slot is valid UTF-8")
+            .trim_end();
+        assert!(
+            s == "slot_a" || s == "slot_b",
+            "final active_slot must be exactly slot_a or slot_b, got {s:?} ({} bytes)",
+            bytes.len()
+        );
+
+        // No leftover .tmp files (each writer's atomic_replace consumed
+        // its own temp).
+        for entry in std::fs::read_dir(cqs.as_path()).unwrap().flatten() {
+            let name = entry.file_name();
+            let name_s = name.to_string_lossy();
+            assert!(
+                !name_s.contains(".tmp"),
+                "leftover tmp file detected: {name_s}"
+            );
+        }
+    }
+
     // ── list_slots ───────────────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the last two TC-ADV findings from the v1.38 audit cycle.

| ID | Test | Files |
|----|------|-------|
| TC-ADV-V1.38-5 | `write_active_slot_two_concurrent_writers_dont_corrupt` — pins DS-V1.33-2's `temp_suffix()` race fix; spawns 8 threads × 50 writes, asserts final file is exactly `slot_a` or `slot_b` (not partial / mixed / empty), no leftover `.tmp` files | `slot/mod.rs` |
| TC-ADV-V1.38-7 | Six tests for `truncate_at_char_boundary` (extracted from inline `embed_query` block): under-cap no-op, ASCII truncate, **emoji boundary snap-back at byte 99 / cap 100** (the audit's exact case), zero cap, exactly-at-cap, and `_walk_distance_bounded` (across caps 1..=200 of a 200-byte emoji string, walk-back is ≤ 3 bytes) | `embedder/mod.rs` |

The truncation refactor is test-surface only: `embed_query` now calls the free function whose body is byte-for-byte identical to the previous inline block.

## What's still pending in #1463

After this cluster, the v1.38 audit cycle's open work is:
- API-V1.38-6 (top-level Cli search flags ignored on subcommand) — bigger surface
- API-V1.38-9 (HfHub error variant collapse) — breaking
- API-V1.38-10 (LimitArg fan-out, 61 caller sites) — broad but mechanical
- DS-V1.38-4 (HNSW load_with_dim TOCTOU) — multi-PR architectural
- PL-V1.38-4 (WSL-DrvFS detector divergence) — medium
- SHL-V1.38-6 (parse_channel_depth byte-budget) — bigger
- SHL-V1.38-9 (summary_queue 3 knobs) — medium
- EX-V1.38-2/3/6 — separate clusters
- PL-V1.38-2 — Windows test runner needed

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib write_active_slot_two_concurrent_writers_dont_corrupt` — 1/1 green (race test runs in <1 s)
- [x] `cargo test --features gpu-index --lib truncate_at_char_boundary` — 6/6 green
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
