### PR TITLE
fix: cluster BB — API-V1.38-10: reject --limit 0 at parse time (#1463)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -118,7 +118,11 @@ pub(crate) struct SearchArgs {
     pub query: String,
 
     /// Max results
-    #[arg(short = 'n', long, default_value = "5")]
+    ///
+    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time —
+    /// search with limit=0 is semantically meaningless and previously
+    /// returned an empty result set silently.
+    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
     pub limit: usize,
 
     /// Min similarity threshold
@@ -268,7 +272,8 @@ pub(crate) struct GatherArgs {
     pub direction: cqs::GatherDirection,
     /// Max chunks to return.
     /// API-V1.36-8 (#1459): default harmonised to 5 across the CLI.
-    #[arg(short = 'n', long, default_value = "5")]
+    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time.
+    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
     pub limit: usize,
     /// Maximum token budget (overrides --limit with token-based packing)
     #[arg(long, value_parser = parse_nonzero_usize)]
@@ -311,7 +316,8 @@ pub(crate) struct ScoutArgs {
     /// Search query to investigate
     pub query: String,
     /// Max file groups to return
-    #[arg(short = 'n', long, default_value = "5")]
+    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time.
+    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
     pub limit: usize,
     /// Maximum token budget (includes chunk content within budget)
     #[arg(long, value_parser = parse_nonzero_usize)]
@@ -469,7 +475,8 @@ pub(crate) struct RelatedArgs {
     /// Function name or file:function
     pub name: String,
     /// Max results per category
-    #[arg(short = 'n', long, default_value = "5")]
+    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time.
+    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
     pub limit: usize,
 }
 
@@ -517,7 +524,8 @@ pub(crate) struct WhereArgs {
     pub description: String,
     /// Max file suggestions.
     /// API-V1.36-8 (#1459): default harmonised to 5 across the CLI.
-    #[arg(short = 'n', long, default_value = "5")]
+    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time.
+    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
     pub limit: usize,
 }
 
@@ -527,7 +535,8 @@ pub(crate) struct PlanArgs {
     /// Task description to plan
     pub description: String,
     /// Max scout file groups
-    #[arg(short = 'n', long, default_value = "5")]
+    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time.
+    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
     pub limit: usize,
     /// Maximum token budget
     #[arg(long, value_parser = parse_nonzero_usize)]
@@ -543,7 +552,8 @@ pub(crate) struct TaskArgs {
     /// Task description
     pub description: String,
     /// Max file groups to return
-    #[arg(short = 'n', long, default_value = "5")]
+    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time.
+    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
     pub limit: usize,
     /// Maximum token budget (waterfall across sections)
     #[arg(long, value_parser = parse_nonzero_usize)]

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -154,7 +154,12 @@ pub struct Cli {
     pub query: Option<String>,
 
     /// Max results
-    #[arg(short = 'n', long, default_value = "5")]
+    ///
+    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time — search
+    /// with limit=0 is semantically meaningless and previously coerced
+    /// (via the dispatcher's `cli.limit.clamp(1, 100)` at dispatch.rs:204)
+    /// instead of failing fast at the boundary.
+    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
     pub limit: usize,
 
     /// Min similarity threshold

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1116,12 +1116,23 @@ mod tests {
         cli.limit = cli.limit.clamp(1, 100);
         assert_eq!(cli.limit, 100);
 
-        // Verify that limit 0 gets clamped to 1
+        // API-V1.38-10 (#1463): `-n 0` is now rejected at parse time
+        // (`value_parser = parse_nonzero_usize`) instead of silently
+        // clamped to 1. Pin the new contract: clap rejects 0 with a
+        // clear error rather than producing a usable cli that the
+        // dispatcher then has to fix up.
         let argv2 = ["cqs", "-n", "0", "query"];
-        let mut cli = Cli::try_parse_from(argv2).unwrap();
-        config::apply_config_defaults_with_argv(&mut cli, &config, argv2);
-        cli.limit = cli.limit.clamp(1, 100);
-        assert_eq!(cli.limit, 1);
+        let result = Cli::try_parse_from(argv2);
+        match result {
+            Ok(_) => panic!("--limit 0 must be rejected at parse time"),
+            Err(e) => {
+                let err = e.to_string();
+                assert!(
+                    err.contains("value must be at least 1"),
+                    "rejection message must guide the operator: got {err}"
+                );
+            }
+        }
 
         // Verify normal limits pass through
         let argv3 = ["cqs", "-n", "10", "query"];


### PR DESCRIPTION
## Summary

The audit's "concrete bug" portion of API-V1.38-10: search with `--limit 0` is semantically meaningless but was previously parsed successfully and clamped to 1 by the dispatcher (`cli.limit.clamp(1, 100)`), so the operator's typo never produced a clear error.

Added `value_parser = parse_nonzero_usize` to 8 inline `limit` fields:

| Args struct | File |
|-------------|------|
| `SearchArgs.limit`, `GatherArgs.limit`, `ScoutArgs.limit`, `RelatedArgs.limit`, `WhereArgs.limit`, `PlanArgs.limit`, `TaskArgs.limit` | `src/cli/args.rs` |
| `Cli.limit` (top-level bare-query path) | `src/cli/definitions.rs` |

`--limit 0` now fails at parse time with `error: invalid value '0' for '--limit <LIMIT>': value must be at least 1`.

## What's NOT in scope

The structural unification (LimitArg fan-out across the 7 sister args, replacing inline `limit: usize` with `#[command(flatten)] limit_arg: LimitArg`) that the audit also names is a separate, broader cleanup — 61 `args.limit` / `cli.limit` caller sites that all need renaming to `args.limit_arg.limit`. Deferred to its own cluster. This PR is the immediate-bug fix the audit explicitly called out.

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib` — 2149/2149 green (no behavior regressions)
- [x] `cargo test --features gpu-index --bin cqs cli::` — 764/764 green
- [x] `test_cli_limit_clamped_to_valid_range` updated to pin new contract (Err on `-n 0` instead of clamp-to-1) so a future revert is caught at test time
- [x] Smoke: `cqs foo --limit 0` rejects ✓; `cqs scout foo --limit 0` rejects ✓; `cqs gather foo --limit 0` rejects ✓; `cqs foo --limit 5` parses ✓
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
