### PR TITLE
fix: cluster CC — SHL-V1.38-9 summary_queue env knobs (#1463)

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,9 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_HOTSPOT_MIN_CALLERS` | auto (log₂(n)·0.7 clamped `[5, 50]`) | Minimum caller count for "untested hotspot" / "high risk" detectors. Default scales with corpus size (1k→5, 100k→11, 1M→14). SHL-V1.29-7. |
 | `CQS_DEAD_CLUSTER_MIN_SIZE` | auto (log₂(n)·0.7 clamped `[5, 50]`) | Minimum dead functions in a single file to flag as a "dead code cluster" in `cqs suggest`. Scales with corpus size. SHL-V1.29-7. |
 | `CQS_SUGGEST_HOTSPOT_POOL` | auto (4× hotspot count, clamped `[20, 200]`) | Pool size `cqs suggest` evaluates for risk patterns. SHL-V1.29-7. |
+| `CQS_SUMMARY_FLUSH_INTERVAL_MS` | `200` | Time-based flush threshold (ms) for the in-memory summary queue. An idle workload that pushed one row this many milliseconds ago auto-flushes. Bump (e.g. `500`) to coalesce more on slow disks. v1.38: SHL-V1.38-9 / #1463. |
+| `CQS_SUMMARY_FLUSH_ROWS` | `64` | Row-count threshold for auto-flush of the summary queue. Bump (e.g. `256`) on a saturated local-LLM pipeline to reduce per-flush transaction overhead. v1.38: SHL-V1.38-9 / #1463. |
+| `CQS_SUMMARY_HARD_CAP_ROWS` | `10000` | Hard cap on summary-queue depth — the next `push` runs a synchronous flush before enqueueing once at the cap (backpressure). Defensive: must exceed `CQS_SUMMARY_FLUSH_ROWS` (clamped at runtime). v1.38: SHL-V1.38-9 / #1463. |
 | `CQS_SUMMARY_VALIDATION` | `loose` | LLM summary validation strictness. `strict`: drop summaries matching injection patterns; `loose`: log + keep matches; `off`: skip. Length cap (1500 chars) is always enforced via deterministic truncation. (#1170) |
 | `CQS_RISK_HIGH` | `5.0` | Risk score threshold above which a function is "High" risk. Drives `cqs review` CI gating; override on monorepos where the default classifies too aggressively. SHL-V1.29-8. |
 | `CQS_RISK_MEDIUM` | `2.0` | Risk score threshold above which a function is "Medium" risk. SHL-V1.29-8. |

--- a/src/store/summary_queue.rs
+++ b/src/store/summary_queue.rs
@@ -105,7 +105,34 @@ const DEFAULT_FLUSH_INTERVAL_MS: u64 = 200;
 /// Hard cap on queue depth. Past this, the next `push` runs a synchronous
 /// flush before enqueueing so the queue cannot grow without bound under
 /// a runaway producer.
-const HARD_CAP_ROWS: usize = 10_000;
+const DEFAULT_HARD_CAP_ROWS: usize = 10_000;
+
+/// SHL-V1.38-9 (#1463): operator-tunable summary-queue thresholds.
+/// Pre-fix all three were `const`. With the local vLLM provider sustaining
+/// ~50 chunks/sec the queue can hit 64 in <2 sec, triggering a flush every
+/// 2 sec — fine but tunable lets an operator on a slow disk push to
+/// 256+/500ms. Returns `(flush_threshold_rows, flush_interval, hard_cap_rows)`.
+fn summary_queue_config() -> (usize, Duration, usize) {
+    let rows = std::env::var("CQS_SUMMARY_FLUSH_ROWS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_FLUSH_THRESHOLD_ROWS);
+    let interval_ms = std::env::var("CQS_SUMMARY_FLUSH_INTERVAL_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_FLUSH_INTERVAL_MS);
+    let hard_cap = std::env::var("CQS_SUMMARY_HARD_CAP_ROWS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_HARD_CAP_ROWS);
+    // Defensive: hard_cap must exceed flush threshold or backpressure
+    // fires before normal flush ever can.
+    let hard_cap = hard_cap.max(rows.saturating_add(1));
+    (rows, Duration::from_millis(interval_ms), hard_cap)
+}
 
 /// After this many consecutive auto-flush failures, the conditional flush
 /// path in `push` stops trying. The explicit final flush at end of LLM
@@ -141,6 +168,10 @@ pub(crate) struct PendingSummaryQueue {
     flush_threshold_rows: usize,
     /// Time-since-last-flush threshold.
     flush_interval: Duration,
+    /// Hard cap on queue depth before backpressure (synchronous flush
+    /// in `push` before enqueueing). SHL-V1.38-9: instance field instead
+    /// of const so `CQS_SUMMARY_HARD_CAP_ROWS` can override per-process.
+    hard_cap_rows: usize,
     /// Counter of consecutive flush failures. Bumped in `flush`'s error
     /// path, reset to 0 on success. When ≥ [`MAX_CONSECUTIVE_FLUSH_FAILURES`],
     /// `should_flush` returns false so `push`'s conditional auto-flush
@@ -150,15 +181,21 @@ pub(crate) struct PendingSummaryQueue {
 }
 
 impl PendingSummaryQueue {
-    /// Build a new queue tied to `pool` + `rt`. Defaults to the constants
-    /// above; tests construct via [`PendingSummaryQueue::with_thresholds`].
+    /// Build a new queue tied to `pool` + `rt`. Reads tunables via
+    /// [`summary_queue_config`] (env-overridable since SHL-V1.38-9);
+    /// tests construct via [`PendingSummaryQueue::with_thresholds`].
     pub(crate) fn new(pool: SqlitePool, rt: Arc<Runtime>) -> Self {
-        Self::with_thresholds(
+        let (rows, interval, hard_cap) = summary_queue_config();
+        Self {
+            queue: Mutex::new(Vec::new()),
+            last_flush: Mutex::new(Instant::now()),
             pool,
             rt,
-            DEFAULT_FLUSH_THRESHOLD_ROWS,
-            Duration::from_millis(DEFAULT_FLUSH_INTERVAL_MS),
-        )
+            flush_threshold_rows: rows,
+            flush_interval: interval,
+            hard_cap_rows: hard_cap,
+            consecutive_flush_failures: AtomicU8::new(0),
+        }
     }
 
     /// Test-friendly constructor for choosing custom thresholds.
@@ -176,6 +213,7 @@ impl PendingSummaryQueue {
             rt,
             flush_threshold_rows,
             flush_interval,
+            hard_cap_rows: DEFAULT_HARD_CAP_ROWS,
             consecutive_flush_failures: AtomicU8::new(0),
         }
     }
@@ -184,6 +222,7 @@ impl PendingSummaryQueue {
     /// the `cfg(test)` gate. Kept private since callers should go through
     /// `new`.
     #[cfg(not(test))]
+    #[allow(dead_code)]
     fn with_thresholds(
         pool: SqlitePool,
         rt: Arc<Runtime>,
@@ -197,6 +236,7 @@ impl PendingSummaryQueue {
             rt,
             flush_threshold_rows,
             flush_interval,
+            hard_cap_rows: DEFAULT_HARD_CAP_ROWS,
             consecutive_flush_failures: AtomicU8::new(0),
         }
     }
@@ -216,11 +256,11 @@ impl PendingSummaryQueue {
         // enqueueing so the in-memory footprint stays bounded.
         let at_cap = {
             let q = lock_recover(&self.queue, "queue.push.cap_check");
-            q.len() >= HARD_CAP_ROWS
+            q.len() >= self.hard_cap_rows
         };
         if at_cap {
             tracing::warn!(
-                hard_cap = HARD_CAP_ROWS,
+                hard_cap = self.hard_cap_rows,
                 "summary queue at hard cap; flushing synchronously before enqueue"
             );
             if let Err(e) = self.flush() {


### PR DESCRIPTION
## Summary

SHL-V1.38-9: three summary-queue tuning constants → operator-tunable env knobs.

| Knob | Default | Purpose |
|------|---------|---------|
| `CQS_SUMMARY_FLUSH_ROWS` | `64` | Row-count auto-flush threshold |
| `CQS_SUMMARY_FLUSH_INTERVAL_MS` | `200` | Time-based auto-flush threshold (ms) |
| `CQS_SUMMARY_HARD_CAP_ROWS` | `10000` | Hard cap on queue depth before backpressure |

Single `summary_queue_config()` resolver reads all three at queue construction. `hard_cap_rows` promoted from `const` to instance field so the env override actually takes effect (was previously baked in at compile time). Defensive clamp: `hard_cap ≥ rows + 1` so backpressure can't fire before normal flush ever can.

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib summary_queue` — 7/7 green (existing tests pass unchanged — they use `with_thresholds` with static defaults)
- [x] `cargo test --features gpu-index --test env_var_docs` — green (3 new env vars in README)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
