### PR TITLE
fix: cluster DD — PL-V1.38-4: WSL DrvFS detector unification (#1463)

### DIFF
--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -288,53 +288,16 @@ fn publish_watch_snapshot(
 /// PB-3: Check if a path is under a WSL DrvFS automount root.
 ///
 /// Default automount root is `/mnt/`, but users can customize it via `automount.root`
-/// in `/etc/wsl.conf`. Reads the config once via `OnceLock` and caches the result.
+/// in `/etc/wsl.conf`.
+///
+/// PL-V1.38-4 (#1463): delegates to `cqs::config::wsl_automount_root_or_default`
+/// so this helper and `is_wsl_drvfs_path` share a single OnceLock-cached
+/// source of truth. Pre-fix, the two helpers maintained independent
+/// caches and only the watch helper read `/etc/wsl.conf` — operators
+/// with custom `automount.root` had `coarse_fs_resolution` return 0
+/// instead of 2s for their `/win/c/...` paths.
 fn is_under_wsl_automount(path: &str) -> bool {
-    static AUTOMOUNT_ROOT: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-    let root = AUTOMOUNT_ROOT
-        .get_or_init(|| parse_wsl_automount_root().unwrap_or_else(|| "/mnt/".to_string()));
-    path.starts_with(root.as_str())
-}
-
-/// Parse the `automount.root` value from `/etc/wsl.conf`.
-/// Returns `None` if the file doesn't exist or doesn't contain the setting.
-fn parse_wsl_automount_root() -> Option<String> {
-    // RM-V1.33-7: bound the read at 64 KiB. `/etc/wsl.conf` is normally
-    // a few hundred bytes; a hostile symlink or bind mount pointing at a
-    // multi-GB file would otherwise OOM the watch loop on first event.
-    use std::io::Read;
-    const MAX_WSL_CONF_BYTES: u64 = 64 * 1024;
-    let mut content = String::new();
-    std::fs::File::open("/etc/wsl.conf")
-        .ok()?
-        .take(MAX_WSL_CONF_BYTES)
-        .read_to_string(&mut content)
-        .ok()?;
-    let mut in_automount = false;
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with('[') {
-            in_automount = trimmed
-                .trim_start_matches('[')
-                .trim_end_matches(']')
-                .trim()
-                .eq_ignore_ascii_case("automount");
-            continue;
-        }
-        if in_automount {
-            if let Some((key, value)) = trimmed.split_once('=') {
-                if key.trim().eq_ignore_ascii_case("root") {
-                    let mut root = value.trim().to_string();
-                    // Ensure trailing slash for prefix matching
-                    if !root.ends_with('/') {
-                        root.push('/');
-                    }
-                    return Some(root);
-                }
-            }
-        }
-    }
-    None
+    path.starts_with(cqs::config::wsl_automount_root_or_default())
 }
 
 /// #1002: Build a `Gitignore` matcher rooted at the project, combining the

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,11 +109,28 @@ pub fn is_wsl_drvfs_path(path: &Path) -> bool {
         Some(s) => s,
         None => return false,
     };
-    // /mnt/<letter>/  — accept upper or lowercase drive letter.
-    if let Some(rest) = s.strip_prefix("/mnt/") {
+    // PL-V1.38-4 (#1463): consult the configured `automount.root` from
+    // `/etc/wsl.conf` (cached via OnceLock) before falling back to the
+    // hardcoded `/mnt/`. Pre-fix, an operator with `automount.root=/win/`
+    // would have the watch loop's poll-mode detector recognise `/win/c/...`
+    // (via `is_under_wsl_automount`) but `is_wsl_drvfs_path` only checked
+    // `/mnt/<letter>/` — `coarse_fs_resolution` then returned 0 instead
+    // of 2s, making mtime-equality skip silently drop rapid re-saves.
+    let configured_root = wsl_automount_root_or_default();
+    if let Some(rest) = s.strip_prefix(configured_root) {
         let bytes = rest.as_bytes();
         if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b'/' {
             return true;
+        }
+    }
+    // The default `/mnt/` path is also recognised even when `automount.root`
+    // is configured non-default — operators sometimes mount both paths.
+    if configured_root != "/mnt/" {
+        if let Some(rest) = s.strip_prefix("/mnt/") {
+            let bytes = rest.as_bytes();
+            if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b'/' {
+                return true;
+            }
         }
     }
     // UNC paths reaching back into WSL from Windows-side tools.
@@ -121,6 +138,62 @@ pub fn is_wsl_drvfs_path(path: &Path) -> bool {
         return true;
     }
     false
+}
+
+/// PL-V1.38-4 (#1463): cached resolution of `automount.root` from
+/// `/etc/wsl.conf`. Single source of truth shared by `is_wsl_drvfs_path`
+/// (this module) and `is_under_wsl_automount` (`cli/watch/mod.rs`).
+/// Defaults to `"/mnt/"` when the file is missing, unreadable, or
+/// doesn't carry an `[automount] root=` setting.
+pub fn wsl_automount_root_or_default() -> &'static str {
+    static AUTOMOUNT_ROOT: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    AUTOMOUNT_ROOT
+        .get_or_init(|| parse_wsl_automount_root().unwrap_or_else(|| "/mnt/".to_string()))
+        .as_str()
+}
+
+/// Parse the `automount.root` value from `/etc/wsl.conf`.
+/// Returns `None` if the file doesn't exist or doesn't contain the setting.
+///
+/// PL-V1.38-4 (#1463): promoted from `cli/watch/mod.rs` so a single
+/// source of truth backs both watch-mode poll detection and the
+/// generic `is_wsl_drvfs_path` filesystem-resolution path.
+fn parse_wsl_automount_root() -> Option<String> {
+    // RM-V1.33-7: bound the read at 64 KiB. `/etc/wsl.conf` is normally
+    // a few hundred bytes; a hostile symlink or bind mount pointing at a
+    // multi-GB file would otherwise OOM the watch loop on first event.
+    use std::io::Read;
+    const MAX_WSL_CONF_BYTES: u64 = 64 * 1024;
+    let mut content = String::new();
+    std::fs::File::open("/etc/wsl.conf")
+        .ok()?
+        .take(MAX_WSL_CONF_BYTES)
+        .read_to_string(&mut content)
+        .ok()?;
+    let mut in_automount = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_automount = trimmed
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .trim()
+                .eq_ignore_ascii_case("automount");
+            continue;
+        }
+        if in_automount {
+            if let Some((key, value)) = trimmed.split_once('=') {
+                if key.trim().eq_ignore_ascii_case("root") {
+                    let mut root = value.trim().to_string();
+                    if !root.ends_with('/') {
+                        root.push('/');
+                    }
+                    return Some(root);
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Returns the mtime resolution (granularity) of the filesystem holding


### PR DESCRIPTION
## Summary

PL-V1.38-4: two divergent WSL-DrvFS detectors collapsed to a single source of truth.

| Pre-fix | Post-fix |
|---------|----------|
| `config::is_wsl_drvfs_path` — hardcoded `/mnt/<letter>/` only | Reads `automount.root` from `/etc/wsl.conf` via OnceLock-cached `wsl_automount_root_or_default()`, falls back to `/mnt/` if the config differs from default, plus accepts `//wsl.localhost/`, `//wsl$/` |
| `watch::is_under_wsl_automount` — own OnceLock + own `parse_wsl_automount_root` | Collapses to a one-line delegation |

## Failure mode this closes

Operator with `automount.root=/win/` in `/etc/wsl.conf`:

- Pre-fix: `cqs watch` poll-detector recognised `/win/c/...` (good), but `coarse_fs_resolution` returned 0 (Linux ext4 default) instead of 2s. Strict mtime-equality skip in `events.rs::collect_events` then silently dropped every rapid second-save — the bug class PB-V1.30.1-5 / #1225 was supposed to close on Linux/macOS, but slipped through here when only one side learned about wsl.conf.
- Post-fix: both detectors share the same cached config, so `coarse_fs_resolution` returns 2s for the operator's `/win/c/...` paths and the mtime-equality skip lets rapid re-saves through.

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib config::` — 49/49 green
- [x] `cargo test --features gpu-index --bin cqs cli::watch` — 92/92 + 3 ignored
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
