### PR TITLE
fix: cluster GG — EX-V1.38-6: Markdown call extraction → trait field (#1463)

### DIFF
--- a/src/language/languages.rs
+++ b/src/language/languages.rs
@@ -59,6 +59,7 @@ const DEFAULTS: LanguageDef = LanguageDef {
     field_style: FieldStyle::None,
     skip_line_prefixes: &[],
     custom_chunk_parser: None,
+    chunk_call_parser: None,
     custom_all_parser: None,
     custom_call_parser: None,
     function_keywords: &[],
@@ -4370,6 +4371,10 @@ static LANG_MARKDOWN: LanguageDef = LanguageDef {
     ],
     line_comment_prefixes: &["<!--"],
     aliases: &["md"],
+    // EX-V1.38-6 (#1463): per-chunk reference extractor. Replaces the
+    // hardcoded `if chunk.language == Language::Markdown` literal in
+    // `Parser::extract_calls_from_chunk`.
+    chunk_call_parser: Some(crate::parser::markdown::extract_calls_from_markdown_chunk),
     ..DEFAULTS
 };
 
@@ -8545,6 +8550,7 @@ static LANG_ASPX: LanguageDef = LanguageDef {
     // `custom_call_parser` is None, so ASPX files still get call/type
     // extraction without a dedicated calls-only function.
     custom_chunk_parser: Some(crate::parser::aspx::parse_aspx_chunks),
+    chunk_call_parser: None,
     custom_all_parser: Some(crate::parser::aspx::parse_aspx_all),
     // ASPX wraps C# / VB.NET — dispatch to .NET pattern defaults.
     patterns: Some(&patterns_data::DOTNET),

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -216,6 +216,15 @@ pub type CustomAllParserFn = fn(
     crate::parser::types::ParserError,
 >;
 
+/// EX-V1.38-6 (#1463): function signature for a per-chunk call/reference
+/// extractor. Distinct from [`CustomCallParserFn`] which operates on full
+/// source files in `parse_file_relationships` — this hook fires inside
+/// `Parser::extract_calls_from_chunk` when only a single already-extracted
+/// chunk is available. Markdown registers
+/// [`crate::parser::markdown::extract_calls_from_markdown_chunk`].
+pub type ChunkCallParserFn =
+    fn(chunk: &crate::parser::types::Chunk) -> Vec<crate::parser::types::CallSite>;
+
 /// Function signature for a custom relationships-only (calls + type-refs)
 /// extractor on a grammar-less language. Invoked from
 /// `Parser::parse_file_relationships`.
@@ -423,6 +432,14 @@ pub struct LanguageDef {
     /// without setting this field routes to the markdown fallback — which
     /// is usually wrong. Closes the silent-routing class from issue #954.
     pub custom_chunk_parser: Option<CustomChunkParserFn>,
+    /// EX-V1.38-6 (#1463): per-chunk call/reference extractor. Invoked
+    /// by `Parser::extract_calls_from_chunk` for languages whose chunks
+    /// don't fit the tree-sitter call-site model (Markdown links,
+    /// future natural-language doc formats, SQL stored-proc cross-refs).
+    /// `None` means the tree-sitter call extractor handles it. Pre-fix,
+    /// `extract_calls_from_chunk` had a hardcoded `if chunk.language ==
+    /// Language::Markdown { ... }` branch that this field replaces.
+    pub chunk_call_parser: Option<ChunkCallParserFn>,
     /// Custom combined chunk+calls+type-refs extraction for grammar-less languages.
     /// Used by `parse_file_all`. When `None`, falls through to the markdown default.
     /// `parse_file_relationships` also consults this field as a fallback when

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -123,12 +123,19 @@ impl Parser {
 
     /// Extract function calls from a parsed chunk
     /// Convenience method that extracts calls from the chunk's content.
+    ///
+    /// EX-V1.38-6 (#1463): per-chunk extractor consults
+    /// `LanguageDef::chunk_call_parser` first. Markdown registers
+    /// `extract_calls_from_markdown_chunk`; future grammar-less languages
+    /// (SQL stored-proc cross-refs, L5X tag references, NL doc formats)
+    /// can opt in by populating the field on their `LanguageDef`. Falls
+    /// through to the tree-sitter call extractor when unset.
     pub fn extract_calls_from_chunk(&self, chunk: &super::types::Chunk) -> Vec<CallSite> {
-        // Markdown chunks use custom reference extraction
-        if chunk.language == Language::Markdown {
-            return crate::parser::markdown::extract_calls_from_markdown_chunk(chunk);
+        if let Some(def) = chunk.language.try_def() {
+            if let Some(extractor) = def.chunk_call_parser {
+                return extractor(chunk);
+            }
         }
-
         self.extract_calls(
             &chunk.content,
             chunk.language,


### PR DESCRIPTION
## Summary

EX-V1.38-6: replace the hardcoded `Language::Markdown` literal in `Parser::extract_calls_from_chunk` with a `LanguageDef::chunk_call_parser` trait field.

| Change | File |
|--------|------|
| New `pub type ChunkCallParserFn = fn(&Chunk) -> Vec<CallSite>` | `language/mod.rs` |
| New `LanguageDef::chunk_call_parser: Option<ChunkCallParserFn>` field | `language/mod.rs` |
| `LANG_MARKDOWN` registers `extract_calls_from_markdown_chunk`; default `None` for the other 53 languages | `language/languages.rs` |
| `extract_calls_from_chunk` consults the trait field before falling through to the tree-sitter call extractor | `parser/calls.rs` |

Behavior is byte-for-byte identical to the pre-fix Markdown branch. Future grammar-less languages (SQL stored-proc cross-refs, L5X tag references, natural-language doc formats) can opt in by populating the field on their `LanguageDef`.

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib parser::` — 217/217 green (the existing markdown chunk-call tests still pass via the trait dispatch)
- [x] `cargo test --features gpu-index --lib markdown` — 69/69 green
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
