### PR TITLE
fix: cluster HH — EX-V1.38-3 finish: rerank pool_max + over_retrieval to TOML (#1463)

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -200,6 +200,19 @@ fn run_with_dispatch(
         cqs::search::router::install_classifier_vocab_overlay(neg, multi);
     }
 
+    // EX-V1.38-3 (#1463): install reranker pool-sizing overrides from
+    // `[reranker]` TOML so cli/limits.rs::rerank_pool_max +
+    // rerank_over_retrieval_multiplier honor the durable config.
+    // Env vars still win — see those helpers for the precedence chain.
+    {
+        let (pool_max, over_retrieval) = config
+            .reranker
+            .as_ref()
+            .map(|s| (s.pool_max, s.over_retrieval))
+            .unwrap_or((None, None));
+        crate::cli::limits::install_reranker_pool_overrides(pool_max, over_retrieval);
+    }
+
     // Clamp limit to prevent usize::MAX wrapping to -1 in SQLite queries
     cli.limit = cli.limit.clamp(1, 100);
 

--- a/src/cli/limits.rs
+++ b/src/cli/limits.rs
@@ -57,20 +57,71 @@ pub(crate) const RERANK_OVER_RETRIEVAL_MULTIPLIER: usize = 4;
 /// Honored by [`rerank_pool_size`].
 pub(crate) const RERANK_POOL_MAX: usize = 20;
 
-/// Resolve the over-retrieval multiplier honoring `CQS_RERANK_OVER_RETRIEVAL`.
-/// Falls back to [`RERANK_OVER_RETRIEVAL_MULTIPLIER`] when the env var is
-/// unset, empty, or unparseable. Zero is rejected so a misconfigured env
-/// can't silently degrade reranking to single-candidate mode.
-pub(crate) fn rerank_over_retrieval_multiplier() -> usize {
-    parse_env_usize(
-        "CQS_RERANK_OVER_RETRIEVAL",
-        RERANK_OVER_RETRIEVAL_MULTIPLIER,
-    )
+/// EX-V1.38-3 (#1463): process-global cache of the resolved
+/// `[reranker] pool_max` and `over_retrieval` TOML overrides. Set once
+/// at dispatch entry via [`install_reranker_pool_overrides`]; consulted
+/// by the resolvers below as a fallback between env and the compiled
+/// default.
+static RERANKER_POOL_OVERRIDES: std::sync::OnceLock<RerankerPoolOverrides> =
+    std::sync::OnceLock::new();
+
+#[derive(Default, Debug, Clone, Copy)]
+struct RerankerPoolOverrides {
+    pool_max: Option<usize>,
+    over_retrieval: Option<usize>,
 }
 
-/// Resolve the reranker pool cap honoring `CQS_RERANK_POOL_MAX`.
+/// Install the `[reranker]` pool-max + over-retrieval overrides (read
+/// once from `.cqs.toml`) into the process-global cache. Called from
+/// `cli::dispatch` after `Config::load`. Idempotent — first writer wins,
+/// second silently no-ops (matches the OnceLock contract used by the
+/// search/router overlay installers).
+pub(crate) fn install_reranker_pool_overrides(
+    pool_max: Option<usize>,
+    over_retrieval: Option<usize>,
+) {
+    let _ = RERANKER_POOL_OVERRIDES.set(RerankerPoolOverrides {
+        pool_max,
+        over_retrieval,
+    });
+}
+
+fn reranker_pool_overrides() -> RerankerPoolOverrides {
+    RERANKER_POOL_OVERRIDES.get().copied().unwrap_or_default()
+}
+
+/// Resolve the over-retrieval multiplier honoring (in priority):
+///   1. `CQS_RERANK_OVER_RETRIEVAL` env var (operator override).
+///   2. `[reranker] over_retrieval = N` in `.cqs.toml` (durable config).
+///   3. [`RERANK_OVER_RETRIEVAL_MULTIPLIER`] compile-time default.
+///
+/// Zero is rejected at every layer so a misconfigured value can't silently
+/// degrade reranking to single-candidate mode.
+pub(crate) fn rerank_over_retrieval_multiplier() -> usize {
+    if std::env::var_os("CQS_RERANK_OVER_RETRIEVAL").is_some() {
+        return parse_env_usize(
+            "CQS_RERANK_OVER_RETRIEVAL",
+            RERANK_OVER_RETRIEVAL_MULTIPLIER,
+        );
+    }
+    reranker_pool_overrides()
+        .over_retrieval
+        .filter(|n| *n > 0)
+        .unwrap_or(RERANK_OVER_RETRIEVAL_MULTIPLIER)
+}
+
+/// Resolve the reranker pool cap honoring (in priority):
+///   1. `CQS_RERANK_POOL_MAX` env var (operator override).
+///   2. `[reranker] pool_max = N` in `.cqs.toml` (durable config).
+///   3. [`RERANK_POOL_MAX`] compile-time default.
 pub(crate) fn rerank_pool_max() -> usize {
-    parse_env_usize("CQS_RERANK_POOL_MAX", RERANK_POOL_MAX)
+    if std::env::var_os("CQS_RERANK_POOL_MAX").is_some() {
+        return parse_env_usize("CQS_RERANK_POOL_MAX", RERANK_POOL_MAX);
+    }
+    reranker_pool_overrides()
+        .pool_max
+        .filter(|n| *n > 0)
+        .unwrap_or(RERANK_POOL_MAX)
 }
 
 /// Compute the over-retrieval pool size for a given user-facing limit.

--- a/src/config.rs
+++ b/src/config.rs
@@ -388,6 +388,19 @@ pub struct AuxModelSection {
     /// (env), then the compiled-in default 512. Set via
     /// `[reranker] max_length = N` in `.cqs.toml`.
     pub max_length: Option<usize>,
+    /// EX-V1.38-3 (#1463): hard cap on the cross-encoder over-retrieval
+    /// pool. Reranker-only. `None` falls through to `CQS_RERANK_POOL_MAX`
+    /// (env), then the compiled-in default 20. Set via
+    /// `[reranker] pool_max = N` in `.cqs.toml`. Resolved at dispatch
+    /// entry into a process-global OnceLock consulted by
+    /// [`crate::cli::limits::rerank_pool_max`].
+    pub pool_max: Option<usize>,
+    /// EX-V1.38-3 (#1463): over-retrieval multiplier — at
+    /// `--rerank --limit N`, stage-1 returns `N * MULTIPLIER` candidates
+    /// for the cross-encoder. Reranker-only. `None` falls through to
+    /// `CQS_RERANK_OVER_RETRIEVAL` (env), then the compiled-in default 4.
+    /// Set via `[reranker] over_retrieval = N` in `.cqs.toml`.
+    pub over_retrieval: Option<usize>,
 }
 
 /// Optional overrides for search scoring parameters.

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -1607,6 +1607,8 @@ mod tests {
             tokenizer_path: None,
             batch: None,
             max_length: None,
+            pool_max: None,
+            over_retrieval: None,
         };
         let cfg = resolve_reranker(Some(&section)).expect("resolve must succeed for preset");
 
@@ -1665,6 +1667,8 @@ mod tests {
             tokenizer_path: None,
             batch: None,
             max_length: None,
+            pool_max: None,
+            over_retrieval: None,
         };
         let reranker = OnnxReranker::with_section(Some(section.clone()))
             .expect("with_section must construct without model load");


### PR DESCRIPTION
## Summary

Closes the second half of EX-V1.38-3. #1548 wired `[reranker] batch` and `max_length`; this PR routes `pool_max` and `over_retrieval` from `.cqs.toml` into the `cli/limits.rs` resolvers.

```toml
[reranker]
preset = "ms-marco-minilm"
batch = 32              # #1548
max_length = 512        # #1548
pool_max = 40           # NEW — this PR
over_retrieval = 6      # NEW — this PR
```

| Resolver | Precedence |
|----------|------------|
| `rerank_over_retrieval_multiplier()` | `CQS_RERANK_OVER_RETRIEVAL` > `[reranker] over_retrieval` > compile-time default `4` |
| `rerank_pool_max()` | `CQS_RERANK_POOL_MAX` > `[reranker] pool_max` > compile-time default `20` |

Implementation: `cli/limits.rs::RERANKER_POOL_OVERRIDES: OnceLock<...>` cache + `install_reranker_pool_overrides()` setter, called once at dispatch entry from `cli/dispatch.rs`. Same OnceLock contract used by the search/router overlay installers.

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib limits` — 21/21 green
- [x] `cargo test --features gpu-index --lib reranker` — 31/31 + 2 ignored green
- [x] `cargo test --features gpu-index --bin cqs cli::limits` — 2/2 green (`rerank_pool_size_uses_defaults_and_env` still pins env-precedence behavior)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

This closes EX-V1.38-3 in full.
