### PR TITLE
fix: cluster JJ — CQ-V1.38-1/2: delete confirmed dead code (#1463)

### DIFF
--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -99,20 +99,16 @@ fn open_store_with<Mode>(
     Ok((store, paths))
 }
 
-/// Open the project store, returning the store, project root, and slot dir.
-/// Bails with a user-friendly message if no index exists.
-///
-/// Kept for legacy in-tree callers that don't (yet) flow through
-/// `CommandContext`. New code should prefer
-/// [`open_project_store_for_slot`] which honors the `--slot` flag.
-#[allow(dead_code)]
-pub(crate) fn open_project_store() -> Result<(cqs::Store, PathBuf, PathBuf)> {
-    let (store, paths) = open_store_with(cqs::Store::open, None)?;
-    Ok((store, paths.root, paths.slot_dir))
-}
+// CQ-V1.38-2 (#1463): `open_project_store()` (zero-arg, slot-bypass)
+// previously parked here `#[allow(dead_code)]` for "legacy in-tree
+// callers" that don't exist. Removing it eliminates the slot-bypass
+// regression footgun — every code path now goes through
+// [`open_project_store_for_slot`] which honors the `--slot` flag.
+// If a future caller genuinely needs slot-default behavior, pass
+// `slot_flag: None` to the slot-aware variant explicitly.
 
-/// Slot-aware variant of [`open_project_store`]. Honors the resolved slot flag
-/// from CLI / env / file.
+/// Open the project store honoring the resolved `--slot` flag from CLI / env / file.
+/// Bails with a user-friendly message if no index exists.
 pub(crate) fn open_project_store_for_slot(
     slot_flag: Option<&str>,
 ) -> Result<(cqs::Store, SlotPaths)> {

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -434,19 +434,11 @@ pub fn parse_env_u64(key: &str, default: u64) -> u64 {
 // `freshness_poll_ms_initial` + matching env override) has no
 // semantic in the new architecture.
 
-/// Parse a duration-in-seconds env var into a `std::time::Duration`,
-/// falling back to `default_secs` on missing/empty/garbage/zero values.
-/// P2.4: convenience wrapper for the common `parse_env_u64(...) -> from_secs`
-/// pattern used by serve/watch timeouts.
-///
-/// Marked `#[allow(dead_code)]` because the call sites that will consume it
-/// (`serve` shutdown grace, `watch` debounce ceiling) live in agent-D-owned
-/// modules and will land in a follow-up. The helper is parked here to keep
-/// the env-var contract centralized.
-#[allow(dead_code)]
-pub fn parse_env_duration_secs(key: &str, default_secs: u64) -> std::time::Duration {
-    std::time::Duration::from_secs(parse_env_u64(key, default_secs))
-}
+// CQ-V1.38-1 (#1463): `parse_env_duration_secs` previously parked here
+// `#[allow(dead_code)]` for callers in `serve`/`watch` follow-up work
+// that never materialised — those sites use `parse_env_u64` directly.
+// Removed; if a future caller wants the duration wrapper, re-add it
+// then with the call site in the same PR.
 
 // ============ #1345 cqs serve idle eviction ============
 


### PR DESCRIPTION
## Summary

Two zero-caller functions previously parked under `#[allow(dead_code)]` removed. Both confirmed truly dead via `grep -rn` across the workspace.

| ID | Item | Files |
|----|------|-------|
| CQ-V1.38-1 | `parse_env_duration_secs` (`src/limits.rs:447`) — docstring said "parked here for serve/watch follow-up" but those call sites used `parse_env_u64` directly | `limits.rs` |
| CQ-V1.38-2 | `open_project_store()` zero-arg, slot-bypass variant (`src/cli/store.rs:109`) — doc claimed "kept for legacy in-tree callers" but none exist; the audit flagged it as inviting a slot-bypass regression | `cli/store.rs` |

The other CQ-V1.38 items the audit named:
- **CQ-V1.38-3** (`RISK_THRESHOLD_HIGH/MEDIUM`) — confirmed NOT dead. They're intentionally public consts re-exported from `impact/hints.rs` "for callers that need the compile-time default (docs, tests, telemetry)". Retained.
- **CQ-V1.38-4** (`parser::MAX_FILE_SIZE` / `MAX_CHUNK_BYTES`) — `MAX_CHUNK_BYTES` IS used (parser/mod.rs:69 references it). Retained.

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib` — 2149/2149 green
- [x] `cargo test --features gpu-index --bin cqs` — 764/764 green
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
