### PR TITLE
fix: cluster KK — API-V1.38-4: LocalProvider validates model up front (#1463)

### DIFF
--- a/src/llm/local.rs
+++ b/src/llm/local.rs
@@ -889,6 +889,18 @@ impl BatchProvider for LocalProvider {
         items: &[BatchSubmitItem],
         max_tokens: u32,
     ) -> Result<String, LlmError> {
+        // API-V1.38-4 (#1463): mirror `LlmClient::submit_batch`'s
+        // contract — validate the configured model up front so a wrong
+        // provider/model combo (`--provider local --model claude-haiku-4-5`)
+        // fails fast with the offending name in the error instead of
+        // surfacing as an opaque vLLM/Ollama API error after the batch
+        // has been built. The default `validate_model` impl on the
+        // trait accepts any non-empty name, so the local provider
+        // currently rejects empty strings only — but the call site is
+        // now in place so a future provider-level tightening flows
+        // through both providers symmetrically.
+        self.validate_model(&self.model)?;
+
         // #1347: dispatch on `BatchKind` once. Adding a new kind is one
         // arm. The historical purpose-label strings ("prebuilt" / "doc" /
         // "hyde") are kept stable so existing log greps still match.


### PR DESCRIPTION
## Summary

API-V1.38-4: `LocalProvider::submit_batch` now validates the model up front via `self.validate_model(&self.model)?;`, mirroring `LlmClient::submit_batch`'s existing contract.

The trait method existed but was never invoked on the local-provider side — a wrong provider/model combo (`--provider local --model claude-haiku-4-5`) would surface as an opaque vLLM/Ollama API error after the batch was built rather than failing fast at submission with the offending name.

The default trait impl accepts any non-empty name, so the local provider currently rejects empty strings only. The fix is the call-site placement — a future provider-level tightening (e.g. rejecting `claude-*` names obviously misrouted from `--provider anthropic`) flows through both providers symmetrically.

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib llm::local::tests` — 23/23 green
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
