### PR TITLE
fix: cluster LL — PF-V1.38-4: cache splade env vars via OnceLock (#1463)

### DIFF
--- a/src/splade/mod.rs
+++ b/src/splade/mod.rs
@@ -384,21 +384,39 @@ pub fn resolve_splade_model_dir_with_config(
 
 /// Maximum characters for SPLADE input truncation.
 /// Configurable via `CQS_SPLADE_MAX_CHARS` (default 4000).
+///
+/// PF-V1.38-4 (#1463): cached via OnceLock at first call. Pre-fix, every
+/// `encode_*` invocation re-read the env var — at 17k chunks per reindex
+/// that's ~18k getenv syscalls per pass. The env value is read at
+/// process-start (or first encode call); operators tuning the knob need
+/// to restart the daemon to pick up a change, which matches the contract
+/// of every other compiled-in default in the SPLADE encode hot path.
 fn splade_max_chars() -> usize {
-    std::env::var("CQS_SPLADE_MAX_CHARS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .filter(|&n: &usize| n > 0)
-        .unwrap_or(4000)
+    static CACHED: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::env::var("CQS_SPLADE_MAX_CHARS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&n: &usize| n > 0)
+            .unwrap_or(4000)
+    })
 }
 
 impl SpladeEncoder {
     /// Default SPLADE threshold, overridable via `CQS_SPLADE_THRESHOLD` env var.
+    ///
+    /// PF-V1.38-4 (#1463): cached via OnceLock at first call. Same
+    /// rationale as `splade_max_chars` — env-thrash on the encode hot
+    /// path, no test fixtures mutate this var (no daemon-time reload
+    /// expected).
     pub fn default_threshold() -> f32 {
-        std::env::var("CQS_SPLADE_THRESHOLD")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(0.01)
+        static CACHED: std::sync::OnceLock<f32> = std::sync::OnceLock::new();
+        *CACHED.get_or_init(|| {
+            std::env::var("CQS_SPLADE_THRESHOLD")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0.01)
+        })
     }
 
     /// Load SPLADE model from a directory containing model.onnx and tokenizer.json.


### PR DESCRIPTION
## Summary

PF-V1.38-4: cache `splade_max_chars` and `SpladeEncoder::default_threshold` via OnceLock so the env-var read fires once per process, not per encode batch.

| Function | Before | After |
|----------|--------|-------|
| `splade::splade_max_chars` | env read on every call (~18k getenv per 17k-chunk reindex) | OnceLock-cached at first call |
| `SpladeEncoder::default_threshold` | env read on every query | OnceLock-cached at first call |

`grep -rn` confirmed no test fixtures mutate `CQS_SPLADE_MAX_CHARS` or `CQS_SPLADE_THRESHOLD`. Operators changing either now need to restart the daemon to pick up the change — matches the compile-time-default contract of the rest of the SPLADE encode hot path.

## What's NOT in scope

- **PF-V1.38-3** (`resolve_splade_alpha` env-thrash) — explicitly deferred per the audit: eval sweeps mutate `CQS_SPLADE_ALPHA*` between searches; caching at process-start would break the eval-script contract.

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib splade::` — 39/39 + 8 ignored green
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
