### PR TITLE
test(project): TC-HAP-V1.38-10 align perms test gate with production cfg (#1463)

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -490,7 +490,16 @@ mod tests {
         );
     }
 
-    #[cfg(all(unix, target_os = "linux"))]
+    /// TC-HAP-V1.38-10 (#1463): the production `save()` writes the
+    /// registry with `mode(0o600)` under `#[cfg(unix)]` — the test was
+    /// previously gated `#[cfg(all(unix, target_os = "linux"))]`, which
+    /// arbitrarily excluded macOS even though the same Unix
+    /// `OpenOptionsExt::mode()` path runs there. Dropping the
+    /// `target_os = "linux"` constraint aligns the test gate with the
+    /// production gate so a developer running `cargo test` on macOS
+    /// catches a regression in the SEC-V1.33-3 atomic-write path the
+    /// same way Linux CI does.
+    #[cfg(unix)]
     #[test]
     fn test_save_writes_file_with_0o600_perms() {
         // SEC-V1.33-3 regression coverage: the saved registry file must be


### PR DESCRIPTION
## Summary

TC-HAP-V1.38-10 from the v1.36.2 audit umbrella (#1463): aligns the
`test_save_writes_file_with_0o600_perms` cfg gate with the production
`save()` cfg gate so macOS coverage stops being arbitrarily excluded.

## Why

The `save()` registry-write path uses `#[cfg(unix)]` to apply
`mode(0o600)` via `OpenOptionsExt::mode()`:

```rust
#[cfg(unix)]
{
    use std::os::unix::fs::OpenOptionsExt;
    let mut f = std::fs::OpenOptions::new()
        .write(true)
        .create(true)
        .truncate(true)
        .mode(0o600)
        .open(&tmp)?;
    ...
}
```

The corresponding regression test was gated
`#[cfg(all(unix, target_os = "linux"))]`, which arbitrarily excluded
macOS even though the same Unix path runs there.

## What this PR does

Drops the `target_os = "linux"` constraint on the test so:

- A developer running `cargo test` on macOS catches a regression in
  the SEC-V1.33-3 atomic-write path the same way Linux CI does.
- The test gate matches the production cfg (`#[cfg(unix)]`) — no
  semantic mismatch between what's being asserted and where.
- Future macOS CI matrix expansion picks up the coverage automatically
  (today the release workflow only builds, doesn't run tests, on
  `macos-latest`).

Plus an explanatory doc comment on the test pinning the rationale so a
future agent doesn't silently re-narrow the gate.

## Verification

- `cargo test --features gpu-index --lib project::tests::test_save_writes_file_with_0o600_perms`
  — passes (0.01s)
- `cargo fmt --check` — clean

## What's NOT in scope

- Adding macOS to the CI matrix (separate concern; macOS minutes
  cost more, and the cqs-watch daemon has Linux-specific bits).
- Windows ACL parity (no production code path for it; `save()`
  falls through to `std::fs::write` on `#[cfg(not(unix))]`).
- Other TC-HAP-V1.38 sub-items remain on the umbrella.

Sub-item of #1463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
