### PR TITLE
test(project): TC-HAP-V1.38-1 behavioral coverage for project search filter (#1463)

### DIFF
--- a/src/cli/commands/infra/project.rs
+++ b/src/cli/commands/infra/project.rs
@@ -244,59 +244,16 @@ pub(crate) fn cmd_project(
             let embedder = Embedder::new(model_config.clone())?;
             let query_embedding = embedder.embed_query(query)?;
 
-            // #1459 item 1a: assemble the SearchFilter from the same flag
-            // surface the top-level `cqs <q>` exposes so cross-project
-            // search behaves identically per-project. Use the existing
-            // helpers on `SearchFilter` so language / chunk-type strings
-            // get the same parsing rules as `cmd_search`.
-            //
-            // SearchFilter is `#[non_exhaustive]`, so cross-crate
-            // construction starts from `Default` then mutates fields.
-            let mut filter = SearchFilter::default();
-            filter.query_text = query.clone();
-            filter.name_boost = *name_boost;
-            filter.enable_rrf = *rrf;
-            filter.path_pattern = path.clone();
-            if let Some(lang_str) = lang.as_deref() {
-                if let Ok(parsed) = lang_str.parse::<cqs::parser::Language>() {
-                    filter.languages = Some(vec![parsed]);
-                } else {
-                    tracing::warn!(
-                        lang = lang_str,
-                        "Unknown language for project search; ignoring"
-                    );
-                }
-            }
-            // `--include-type` / default code-only / `--include-docs` follow
-            // the same precedence as the top-level search path
-            // (`src/cli/commands/search/query.rs`):
-            //   1. `--include-type X,Y` — explicit allowlist (wins over docs flag)
-            //   2. `--include-docs` (and no `--include-type`) — None = search everything
-            //   3. default — `ChunkType::code_types()` (callable + type defs)
-            filter.include_types = match include_type {
-                Some(types) => {
-                    let parsed: Vec<_> = types
-                        .iter()
-                        .filter_map(|s| s.parse::<cqs::parser::ChunkType>().ok())
-                        .collect();
-                    if parsed.is_empty() {
-                        None
-                    } else {
-                        Some(parsed)
-                    }
-                }
-                None if *include_docs => None,
-                None => Some(cqs::parser::ChunkType::code_types().to_vec()),
-            };
-            if let Some(types) = exclude_type {
-                let parsed: Vec<_> = types
-                    .iter()
-                    .filter_map(|s| s.parse::<cqs::parser::ChunkType>().ok())
-                    .collect();
-                if !parsed.is_empty() {
-                    filter.exclude_types = Some(parsed);
-                }
-            }
+            let filter = build_project_search_filter(
+                query,
+                *name_boost,
+                *rrf,
+                path.as_deref(),
+                lang.as_deref(),
+                include_type.as_deref(),
+                exclude_type.as_deref(),
+                *include_docs,
+            );
 
             let results = search_across_projects(&query_embedding, &filter, *limit, *threshold)?;
 
@@ -339,6 +296,80 @@ pub(crate) fn cmd_project(
     }
 }
 
+/// TC-HAP-V1.38-1 (#1463): build the per-project `SearchFilter` from the
+/// `cqs project search` flag surface. Extracted from `cmd_project`'s
+/// `Search` arm so the precedence rules between `--include-type`,
+/// `--include-docs`, and the code-only default can be tested without
+/// loading the embedder or any cross-project store.
+///
+/// Mirrors the top-level `cqs <q>` filter assembly at
+/// `src/cli/commands/search/query.rs` so per-project search behaves
+/// identically to per-project search inside `cmd_search`.
+///
+/// Precedence (top-level parity):
+///   1. `--include-type X,Y` — explicit allowlist (wins over `--include-docs`)
+///   2. `--include-docs` and no `--include-type` — `None` (search everything)
+///   3. default — `ChunkType::code_types()` (callable + type defs)
+///
+/// `--lang` strings that don't parse as a known `Language` are
+/// `tracing::warn!`-logged and ignored (filter is left unset). This
+/// matches the quiet-fallback shape of `cmd_search`.
+#[allow(clippy::too_many_arguments)] // mirrors the clap-flag surface; bundling into a struct
+                                     // would just push the unpacking one frame down.
+pub(crate) fn build_project_search_filter(
+    query: &str,
+    name_boost: f32,
+    rrf: bool,
+    path: Option<&str>,
+    lang: Option<&str>,
+    include_type: Option<&[String]>,
+    exclude_type: Option<&[String]>,
+    include_docs: bool,
+) -> SearchFilter {
+    // SearchFilter is `#[non_exhaustive]`, so cross-crate
+    // construction starts from `Default` then mutates fields.
+    let mut filter = SearchFilter::default();
+    filter.query_text = query.to_string();
+    filter.name_boost = name_boost;
+    filter.enable_rrf = rrf;
+    filter.path_pattern = path.map(|p| p.to_string());
+    if let Some(lang_str) = lang {
+        if let Ok(parsed) = lang_str.parse::<cqs::parser::Language>() {
+            filter.languages = Some(vec![parsed]);
+        } else {
+            tracing::warn!(
+                lang = lang_str,
+                "Unknown language for project search; ignoring"
+            );
+        }
+    }
+    filter.include_types = match include_type {
+        Some(types) => {
+            let parsed: Vec<_> = types
+                .iter()
+                .filter_map(|s| s.parse::<cqs::parser::ChunkType>().ok())
+                .collect();
+            if parsed.is_empty() {
+                None
+            } else {
+                Some(parsed)
+            }
+        }
+        None if include_docs => None,
+        None => Some(cqs::parser::ChunkType::code_types().to_vec()),
+    };
+    if let Some(types) = exclude_type {
+        let parsed: Vec<_> = types
+            .iter()
+            .filter_map(|s| s.parse::<cqs::parser::ChunkType>().ok())
+            .collect();
+        if !parsed.is_empty() {
+            filter.exclude_types = Some(parsed);
+        }
+    }
+    filter
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -377,5 +408,149 @@ mod tests {
         };
         let json = serde_json::to_value(&result).unwrap();
         assert!(json.get("signature").is_none());
+    }
+
+    // ===== TC-HAP-V1.38-1 (#1463) — build_project_search_filter behavior =====
+    //
+    // The parse-only test at `src/cli/mod.rs::test_cmd_project_search_full_flag_parity`
+    // confirms each flag binds to the right field on `ProjectCommand::Search`.
+    // These tests confirm the parsed flags actually produce the right
+    // `SearchFilter` — pinning the precedence rules between
+    // `--include-type`, `--include-docs`, and the code-only default.
+
+    /// Default (no `--include-type`, no `--include-docs`) — code-only filter.
+    /// Pins the bottom of the precedence cascade.
+    #[test]
+    fn build_filter_default_uses_code_types() {
+        let f = build_project_search_filter("query", 0.2, false, None, None, None, None, false);
+        assert_eq!(f.query_text, "query");
+        assert!((f.name_boost - 0.2).abs() < f32::EPSILON);
+        assert!(!f.enable_rrf);
+        assert!(f.path_pattern.is_none());
+        assert!(f.languages.is_none());
+        assert!(f.exclude_types.is_none());
+        let inc = f
+            .include_types
+            .expect("default must set code-only allowlist");
+        assert_eq!(
+            inc,
+            cqs::parser::ChunkType::code_types().to_vec(),
+            "default include_types must equal ChunkType::code_types()"
+        );
+    }
+
+    /// `--include-docs` alone (no explicit `--include-type`) — `include_types = None`
+    /// = "search everything". Pins the doc-opt-in branch.
+    #[test]
+    fn build_filter_include_docs_clears_default_allowlist() {
+        let f = build_project_search_filter("q", 0.2, false, None, None, None, None, true);
+        assert!(
+            f.include_types.is_none(),
+            "--include-docs alone must remove the code-only allowlist"
+        );
+    }
+
+    /// `--include-type X,Y` with `--include-docs` — explicit allowlist wins.
+    /// Pins the top of the cascade — the operator's explicit list always
+    /// beats the docs flag.
+    #[test]
+    fn build_filter_include_type_overrides_include_docs() {
+        let types = vec!["function".to_string(), "struct".to_string()];
+        let f = build_project_search_filter("q", 0.2, false, None, None, Some(&types), None, true);
+        let inc = f.include_types.expect("explicit allowlist must be Some");
+        assert!(inc.contains(&cqs::parser::ChunkType::Function));
+        assert!(inc.contains(&cqs::parser::ChunkType::Struct));
+        assert_eq!(
+            inc.len(),
+            2,
+            "explicit allowlist must NOT be widened by --include-docs"
+        );
+    }
+
+    /// `--exclude-type X` with valid string → set; mixed valid+invalid drops
+    /// the invalids silently.
+    #[test]
+    fn build_filter_exclude_type_filters_invalid_strings() {
+        let bad = vec![
+            "test".to_string(),
+            "this-is-not-a-real-chunk-type".to_string(),
+        ];
+        let f = build_project_search_filter("q", 0.2, false, None, None, None, Some(&bad), false);
+        let exc = f
+            .exclude_types
+            .expect("exclude must be set when at least one parses");
+        assert!(exc.contains(&cqs::parser::ChunkType::Test));
+        assert_eq!(
+            exc.len(),
+            1,
+            "invalid chunk-type strings must be dropped, not propagated"
+        );
+    }
+
+    /// `--exclude-type` with all-invalid strings → field stays None
+    /// (would otherwise be Some(vec![]) and silently filter NOTHING but
+    /// still trigger the SQL exclude branch).
+    #[test]
+    fn build_filter_exclude_type_all_invalid_stays_none() {
+        let bad = vec!["nope".to_string(), "also-nope".to_string()];
+        let f = build_project_search_filter("q", 0.2, false, None, None, None, Some(&bad), false);
+        assert!(
+            f.exclude_types.is_none(),
+            "all-invalid exclude list must stay None — not Some(vec![])"
+        );
+    }
+
+    /// `--lang rust` → languages set to `[Rust]`.
+    #[test]
+    fn build_filter_lang_parses_to_language_enum() {
+        let f = build_project_search_filter("q", 0.2, false, None, Some("rust"), None, None, false);
+        let langs = f
+            .languages
+            .expect("--lang rust must produce a languages filter");
+        assert_eq!(langs, vec![cqs::parser::Language::Rust]);
+    }
+
+    /// Unknown `--lang` is silently dropped (tracing::warn-logged, not an
+    /// error). Pin so a future change to bail on bad input is deliberate.
+    #[test]
+    fn build_filter_lang_unknown_falls_through() {
+        let f = build_project_search_filter(
+            "q",
+            0.2,
+            false,
+            None,
+            Some("not-a-real-language"),
+            None,
+            None,
+            false,
+        );
+        assert!(
+            f.languages.is_none(),
+            "unknown --lang must be ignored (warned), not bailed on"
+        );
+    }
+
+    /// `--rrf` and `--name-boost` flow through verbatim — these are the
+    /// hybrid-fusion knobs the audit found previously broken in cross-project
+    /// search (parse-only without behavior).
+    #[test]
+    fn build_filter_rrf_and_name_boost_flow_through() {
+        let f = build_project_search_filter("q", 0.5, true, None, None, None, None, false);
+        assert!(
+            f.enable_rrf,
+            "--rrf must enable hybrid fusion in the filter"
+        );
+        assert!(
+            (f.name_boost - 0.5).abs() < f32::EPSILON,
+            "name_boost must flow through verbatim"
+        );
+    }
+
+    /// `-p src/**` — path glob flows through to the filter.
+    #[test]
+    fn build_filter_path_glob_flows_through() {
+        let f =
+            build_project_search_filter("q", 0.2, false, Some("src/**"), None, None, None, false);
+        assert_eq!(f.path_pattern.as_deref(), Some("src/**"));
     }
 }


### PR DESCRIPTION
## Summary

TC-HAP-V1.38-1 from the v1.36.2 audit umbrella (#1463): adds behavioral
test coverage for `cqs project search`'s filter knobs (#1507) by
extracting the inline `SearchFilter` assembly into a testable helper
and pinning the precedence cascade with 9 new unit tests.

## Why

The parse-only test at
`cli/mod.rs::test_cmd_project_search_full_flag_parity` confirms each
`cqs project search` flag binds to the right field on
`ProjectCommand::Search`. It does NOT confirm the parsed flags actually
produce the right `SearchFilter`. A regression that swapped
`--include-type` vs `--exclude-type` semantics, dropped `--include-docs`
precedence, or stopped parsing `--lang rust` would not break that test
yet would silently break cross-project search behavior.

## What this PR does

### 1. Extract the filter-build helper

`cmd_project`'s `Search` arm contained ~50 lines of inline `SearchFilter`
mutation that needed an embedder + a cross-project store to exercise.
This PR extracts it into a `build_project_search_filter` function. The
handler body shrinks to:

```rust
let filter = build_project_search_filter(
    query, *name_boost, *rrf, path.as_deref(), lang.as_deref(),
    include_type.as_deref(), exclude_type.as_deref(), *include_docs,
);
```

### 2. Add 9 behavioral tests

| Test | Pins |
|---|---|
| `build_filter_default_uses_code_types` | code-only fallback (no flags) |
| `build_filter_include_docs_clears_default_allowlist` | docs-opt-in path |
| `build_filter_include_type_overrides_include_docs` | explicit allowlist beats docs flag |
| `build_filter_exclude_type_filters_invalid_strings` | partial-parse drops invalids |
| `build_filter_exclude_type_all_invalid_stays_none` | all-invalid = `None` (not `Some(vec![])` — would silently flip SQL exclude branch) |
| `build_filter_lang_parses_to_language_enum` | happy path |
| `build_filter_lang_unknown_falls_through` | quiet-fallback pin (warn, not error) |
| `build_filter_rrf_and_name_boost_flow_through` | hybrid-fusion knobs verbatim |
| `build_filter_path_glob_flows_through` | `-p src/**` flow-through |

The precedence cascade these tests pin is the same one
`src/cli/commands/search/query.rs` (top-level `cqs <q>`) implements, so
a future divergence between project-search and per-project-search will
be caught by one of these.

## Verification

- `cargo test --features gpu-index --bin cqs build_filter` — 9 passed
- `cargo clippy --features gpu-index -- -D warnings` — clean (added
  one `#[allow(clippy::too_many_arguments)]` on the helper because the
  signature mirrors the clap-flag surface; bundling into a struct just
  pushes the unpacking one frame down)
- `cargo fmt --check` — clean

## What's NOT in scope

- An end-to-end `cqs project search` test against multiple seeded
  stores — would require multi-project tempdir + mocking the registry
  + an embedder. The handler's only remaining behavior post-extraction
  is `Embedder::new + embed_query + search_across_projects + render`,
  all already covered.
- Refactoring `--include-type` / `--exclude-type` to use clap
  `value_delimiter` (would break the parse-only parity test; deferred).
- Other TC-HAP-V1.38 sub-items remain on the umbrella.

Sub-item of #1463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
