### PR TITLE
refactor(embedder): API-V1.38-9 rename HfHub variant to ModelDownload (#1463)

### DIFF
--- a/src/embedder/mod.rs
+++ b/src/embedder/mod.rs
@@ -53,8 +53,15 @@ pub enum EmbedderError {
     },
     #[error("Query cannot be empty")]
     EmptyQuery,
-    #[error("HuggingFace Hub error: {0}")]
-    HfHub(String),
+    /// HuggingFace Hub model download failure.
+    ///
+    /// API-V1.38-9 (#1463): renamed from `HfHub` for naming parity with
+    /// [`crate::reranker::RerankerError::ModelDownload`] — both wrap the
+    /// same `hf_hub::ApiError` shape and emit the same display string,
+    /// so a future shared error handler can pattern-match on a single
+    /// variant name across the embedder + reranker boundary.
+    #[error("Model download failed: {0}")]
+    ModelDownload(String),
 }
 
 /// CQ-V1.30.1-5 (P3-CQ-2): route a stringified ORT message into
@@ -1552,15 +1559,15 @@ fn ensure_model(config: &ModelConfig) -> Result<(PathBuf, PathBuf), EmbedderErro
     let api = ApiBuilder::from_env()
         .with_retries(5)
         .build()
-        .map_err(|e| EmbedderError::HfHub(e.to_string()))?;
+        .map_err(|e| EmbedderError::ModelDownload(e.to_string()))?;
     let repo = api.model(config.repo.clone());
 
     let model_path = repo
         .get(&config.onnx_path)
-        .map_err(|e| EmbedderError::HfHub(e.to_string()))?;
+        .map_err(|e| EmbedderError::ModelDownload(e.to_string()))?;
     let tokenizer_path = repo
         .get(&config.tokenizer_path)
-        .map_err(|e| EmbedderError::HfHub(e.to_string()))?;
+        .map_err(|e| EmbedderError::ModelDownload(e.to_string()))?;
 
     // Fetch the ONNX external-data sidecar for models that exceed the 2GB
     // protobuf limit. The Rust ONNX Runtime expects the .onnx_data file to


### PR DESCRIPTION
## Summary

API-V1.38-9 from the v1.36.2 audit umbrella (#1463): rename
`EmbedderError::HfHub(String)` → `EmbedderError::ModelDownload(String)`
to match `RerankerError::ModelDownload(String)`.

## Why

Both `EmbedderError::HfHub` and `RerankerError::ModelDownload` wrap the
same `hf_hub::ApiError` shape and emit the same display string
("Model download failed: …" vs "HuggingFace Hub error: …") — same
root cause, two different variant names. Pre-fix, a future shared
error handler couldn't pattern-match on a single variant across the
embedder/reranker boundary.

## What this PR does

- Rename the variant.
- Update the 3 call sites in `embedder/mod.rs` (sed-driven mechanical
  replace).
- Add a doc comment explaining the parity rationale + `#1463` audit
  reference.

Display string changes from `"HuggingFace Hub error: <msg>"` →
`"Model download failed: <msg>"`. Breaking for any operator parsing
the literal prefix, but per the project's "no external users" policy
this is fine.

## Verification

- `cargo build --features gpu-index` — clean
- `cargo test --features gpu-index --lib embedder` — 110 passed,
  8 ignored
- `cargo fmt --check` — clean

## What's NOT in scope

- Full `AuxModelError` collapse via `#[from]` (the audit's full
  recommendation): the embedder's HF download path doesn't currently
  route through `aux_model::resolve`, so wrapping its errors in an
  `AuxModelError::Download(String)` variant would be a larger
  architectural change. The variant-name harmonization captures the
  consistency win; the type collapse can follow when the embedder
  download path is migrated to the shared resolver.

Sub-item of #1463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
