### PR TITLE
refactor(cli): API-V1.38-10 LimitArg fan-out across 8 sister args (#1463)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -98,10 +98,16 @@ pub(crate) enum RerankerMode {
 /// "unexpected argument"). Embedding this struct via `#[command(flatten)]`
 /// gives every subcommand its own `--limit` while keeping the default in one
 /// place.
+///
+/// API-V1.38-10 (#1463): now also rejects `--limit 0` at parse time so
+/// every flattened consumer (impact / trace / onboard / explain / test_map /
+/// deps / callers + the 7 search-shaped commands once they migrate)
+/// inherits the same parse-time validation that `cqs <q>`'s top-level Cli
+/// got in #1544. limit=0 is meaningless everywhere.
 #[derive(Args, Debug, Clone)]
 pub(crate) struct LimitArg {
     /// Max results to return (per category for impact/explain)
-    #[arg(short = 'n', long, default_value = "5")]
+    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
     pub limit: usize,
 }
 
@@ -117,13 +123,13 @@ pub(crate) struct SearchArgs {
     /// Search query (quote multi-word queries)
     pub query: String,
 
-    /// Max results
-    ///
-    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time —
-    /// search with limit=0 is semantically meaningless and previously
-    /// returned an empty result set silently.
-    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
-    pub limit: usize,
+    /// API-V1.38-10 (#1463): shared `--limit` arg via `LimitArg` flatten.
+    /// Pre-fix, every `*Args` struct inline-defined its own `pub limit: usize`
+    /// — 8 copies that drifted on validation rules (only some had
+    /// `parse_nonzero_usize`). Centralised here so future limit-shape
+    /// changes (default, cap, parser) are one-line edits.
+    #[command(flatten)]
+    pub limit_arg: LimitArg,
 
     /// Min similarity threshold
     ///
@@ -270,11 +276,10 @@ pub(crate) struct GatherArgs {
     /// Expansion direction: both, callers, callees
     #[arg(long, default_value = "both")]
     pub direction: cqs::GatherDirection,
-    /// Max chunks to return.
-    /// API-V1.36-8 (#1459): default harmonised to 5 across the CLI.
-    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time.
-    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
-    pub limit: usize,
+    /// API-V1.38-10 (#1463): shared `--limit` arg via `LimitArg` flatten.
+    /// Default 5 across all sister args.
+    #[command(flatten)]
+    pub limit_arg: LimitArg,
     /// Maximum token budget (overrides --limit with token-based packing)
     #[arg(long, value_parser = parse_nonzero_usize)]
     pub tokens: Option<usize>,
@@ -315,10 +320,9 @@ pub(crate) struct ImpactArgs {
 pub(crate) struct ScoutArgs {
     /// Search query to investigate
     pub query: String,
-    /// Max file groups to return
-    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time.
-    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
-    pub limit: usize,
+    /// API-V1.38-10 (#1463): shared `--limit` arg via `LimitArg` flatten.
+    #[command(flatten)]
+    pub limit_arg: LimitArg,
     /// Maximum token budget (includes chunk content within budget)
     #[arg(long, value_parser = parse_nonzero_usize)]
     pub tokens: Option<usize>,
@@ -356,9 +360,9 @@ pub(crate) struct DeadArgs {
 pub(crate) struct SimilarArgs {
     /// Function name or file:function (e.g., "search_filtered" or "src/search.rs:search_filtered")
     pub name: String,
-    /// Max results
-    #[arg(short = 'n', long, default_value = "5")]
-    pub limit: usize,
+    /// API-V1.38-10 (#1463): shared `--limit` arg via `LimitArg` flatten.
+    #[command(flatten)]
+    pub limit_arg: LimitArg,
     /// Min similarity threshold
     #[arg(short = 't', long, default_value = "0.3", value_parser = parse_finite_f32)]
     pub threshold: f32,
@@ -474,10 +478,9 @@ pub(crate) struct TestMapArgs {
 pub(crate) struct RelatedArgs {
     /// Function name or file:function
     pub name: String,
-    /// Max results per category
-    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time.
-    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
-    pub limit: usize,
+    /// API-V1.38-10 (#1463): shared `--limit` arg via `LimitArg` flatten.
+    #[command(flatten)]
+    pub limit_arg: LimitArg,
 }
 
 /// Arguments shared between CLI `onboard` and batch `onboard`.
@@ -522,11 +525,9 @@ pub(crate) struct ExplainArgs {
 pub(crate) struct WhereArgs {
     /// Description of the code to add
     pub description: String,
-    /// Max file suggestions.
-    /// API-V1.36-8 (#1459): default harmonised to 5 across the CLI.
-    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time.
-    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
-    pub limit: usize,
+    /// API-V1.38-10 (#1463): shared `--limit` arg via `LimitArg` flatten.
+    #[command(flatten)]
+    pub limit_arg: LimitArg,
 }
 
 /// Arguments shared between CLI `plan` and batch `plan`.
@@ -534,10 +535,9 @@ pub(crate) struct WhereArgs {
 pub(crate) struct PlanArgs {
     /// Task description to plan
     pub description: String,
-    /// Max scout file groups
-    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time.
-    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
-    pub limit: usize,
+    /// API-V1.38-10 (#1463): shared `--limit` arg via `LimitArg` flatten.
+    #[command(flatten)]
+    pub limit_arg: LimitArg,
     /// Maximum token budget
     #[arg(long, value_parser = parse_nonzero_usize)]
     pub tokens: Option<usize>,
@@ -551,10 +551,9 @@ pub(crate) struct PlanArgs {
 pub(crate) struct TaskArgs {
     /// Task description
     pub description: String,
-    /// Max file groups to return
-    /// API-V1.38-10 (#1463): rejects `--limit 0` at parse time.
-    #[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
-    pub limit: usize,
+    /// API-V1.38-10 (#1463): shared `--limit` arg via `LimitArg` flatten.
+    #[command(flatten)]
+    pub limit_arg: LimitArg,
     /// Maximum token budget (waterfall across sections)
     #[arg(long, value_parser = parse_nonzero_usize)]
     pub tokens: Option<usize>,

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -653,7 +653,7 @@ mod tests {
         match input.cmd {
             BatchCmd::Search { ref args, .. } => {
                 assert_eq!(args.query, "hello");
-                assert_eq!(args.limit, 5); // default
+                assert_eq!(args.limit_arg.limit, 5); // default
             }
             _ => panic!("Expected Search command"),
         }
@@ -666,7 +666,7 @@ mod tests {
         match input.cmd {
             BatchCmd::Search { ref args, .. } => {
                 assert_eq!(args.query, "hello");
-                assert_eq!(args.limit, 3);
+                assert_eq!(args.limit_arg.limit, 3);
                 assert!(args.name_only);
             }
             _ => panic!("Expected Search command"),
@@ -785,7 +785,7 @@ mod tests {
         match input.cmd {
             BatchCmd::Scout { ref args, .. } => {
                 assert_eq!(args.query, "error handling");
-                assert_eq!(args.limit, 5); // default
+                assert_eq!(args.limit_arg.limit, 5); // default
             }
             _ => panic!("Expected Scout command"),
         }
@@ -805,7 +805,7 @@ mod tests {
         match input.cmd {
             BatchCmd::Scout { ref args, .. } => {
                 assert_eq!(args.query, "error handling");
-                assert_eq!(args.limit, 20);
+                assert_eq!(args.limit_arg.limit, 20);
                 assert_eq!(args.tokens, Some(2000));
             }
             _ => panic!("Expected Scout command"),
@@ -819,7 +819,7 @@ mod tests {
             BatchCmd::Where { ref args, .. } => {
                 assert_eq!(args.description, "new CLI command");
                 // API-V1.36-8 (#1459): --limit defaults harmonised to 5.
-                assert_eq!(args.limit, 5);
+                assert_eq!(args.limit_arg.limit, 5);
             }
             _ => panic!("Expected Where command"),
         }
@@ -977,7 +977,7 @@ mod tests {
         let scout = BatchCmd::Scout {
             args: crate::cli::args::ScoutArgs {
                 query: "foo".into(),
-                limit: 5,
+                limit_arg: crate::cli::args::LimitArg { limit: 5 },
                 tokens: None,
             },
             output: TextJsonArgs { json: false },

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -418,7 +418,7 @@ pub(in crate::cli::batch) fn dispatch_related(
     // CQ-V1.25-2: shared with CLI's cmd_related. Previously 100 here vs
     // unbounded in CLI — lowered to 50 (per-category) to match and stop
     // quadratic blow-up on related-related queries.
-    let limit = args.limit.clamp(1, crate::cli::RELATED_LIMIT_MAX);
+    let limit = args.limit_arg.limit.clamp(1, crate::cli::RELATED_LIMIT_MAX);
 
     let result = cqs::find_related(&ctx.store(), name, limit)?;
     let output = crate::cli::commands::build_related_output(&result, &ctx.root);
@@ -592,7 +592,7 @@ mod tests {
         let (_dir, ctx) = seed_call_graph_ctx();
         let args = RelatedArgs {
             name: "caller_fn".into(),
-            limit: 10,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
         };
         let json = dispatch_related(&ctx.build_view(None), &args).expect("dispatch_related");
         // build_related_output structure varies — pin envelope shape only:

--- a/src/cli/batch/handlers/info.rs
+++ b/src/cli/batch/handlers/info.rs
@@ -113,7 +113,7 @@ pub(in crate::cli::batch) fn dispatch_similar(
     // CQ-V1.25-2: shared with CLI's cmd_similar (which currently does not
     // clamp — adding clamp here + constant would regress; keep parity and
     // let CLI gain its clamp in a separate fix).
-    let limit = args.limit.clamp(1, crate::cli::SIMILAR_LIMIT_MAX);
+    let limit = args.limit_arg.limit.clamp(1, crate::cli::SIMILAR_LIMIT_MAX);
 
     let resolved = cqs::resolve_target(&ctx.store(), name)?;
     let chunk = &resolved.chunk;

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -31,7 +31,7 @@ pub(in crate::cli::batch) fn dispatch_gather(
     let opts = cqs::GatherOptions {
         expand_depth: args.depth.clamp(0, 5),
         direction: args.direction,
-        limit: args.limit.clamp(1, 100),
+        limit: args.limit_arg.limit.clamp(1, 100),
         ..cqs::GatherOptions::default()
     };
 
@@ -194,7 +194,7 @@ pub(in crate::cli::batch) fn dispatch_task(
     let tokens = args.tokens;
     let _span = tracing::info_span!("batch_task", description).entered();
     let embedder = ctx.embedder()?;
-    let limit = args.limit.clamp(1, 10);
+    let limit = args.limit_arg.limit.clamp(1, 10);
     let graph = ctx.call_graph()?;
     let test_chunks = ctx.test_chunks()?;
     let result = cqs::task_with_resources(
@@ -237,7 +237,7 @@ pub(in crate::cli::batch) fn dispatch_scout(
     let _span = tracing::info_span!("batch_scout", query).entered();
     let embedder = ctx.embedder()?;
     // CQ-V1.25-2: shared with CLI's cmd_scout.
-    let limit = args.limit.clamp(1, crate::cli::SCOUT_LIMIT_MAX);
+    let limit = args.limit_arg.limit.clamp(1, crate::cli::SCOUT_LIMIT_MAX);
     let result = cqs::scout(&ctx.store(), embedder, query, &ctx.root, limit)?;
 
     let (content_map, token_info) = if let Some(budget) = tokens {
@@ -275,7 +275,7 @@ pub(in crate::cli::batch) fn dispatch_where(
     let description = args.description.as_str();
     let _span = tracing::info_span!("batch_where", description).entered();
     let embedder = ctx.embedder()?;
-    let limit = args.limit.clamp(1, 10);
+    let limit = args.limit_arg.limit.clamp(1, 10);
     let result = cqs::suggest_placement(&ctx.store(), embedder, description, limit)?;
 
     let output = crate::cli::commands::build_where_output(&result, description, &ctx.root);
@@ -462,8 +462,14 @@ pub(in crate::cli::batch) fn dispatch_plan(
     let _span = tracing::info_span!("batch_plan", description).entered();
 
     let embedder = ctx.embedder()?;
-    let result = cqs::plan::plan(&ctx.store(), embedder, description, &ctx.root, args.limit)
-        .context("Plan generation failed")?;
+    let result = cqs::plan::plan(
+        &ctx.store(),
+        embedder,
+        description,
+        &ctx.root,
+        args.limit_arg.limit,
+    )
+    .context("Plan generation failed")?;
 
     let mut json = serde_json::to_value(&result)?;
     if let Some(budget) = tokens {

--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -41,7 +41,7 @@ pub(in crate::cli::batch) fn dispatch_search(
     if args.name_only {
         let results = ctx
             .store()
-            .search_by_name(&args.query, args.limit.clamp(1, 100))?;
+            .search_by_name(&args.query, args.limit_arg.limit.clamp(1, 100))?;
         let json_results: Vec<serde_json::Value> = results
             .iter()
             .map(|r| {
@@ -94,7 +94,7 @@ pub(in crate::cli::batch) fn dispatch_search(
         .embed_query(&args.query)
         .context("Failed to embed query")?;
 
-    let limit = args.limit.clamp(1, 100);
+    let limit = args.limit_arg.limit.clamp(1, 100);
     // P3 #100: shared rerank pool sizing.
     let effective_limit = if args.rerank_active() {
         crate::cli::limits::rerank_pool_size(limit)

--- a/src/cli/commands/dispatch_shims.rs
+++ b/src/cli/commands/dispatch_shims.rs
@@ -599,7 +599,7 @@ pub fn cmd_similar_dispatch(
         commands::cmd_similar(
             ctx,
             &args.name,
-            args.limit,
+            args.limit_arg.limit,
             args.threshold,
             cli.json || output.json,
         )
@@ -787,7 +787,7 @@ pub fn cmd_gather_dispatch(
             query: &args.query,
             expand: args.depth,
             direction: args.direction,
-            limit: args.limit,
+            limit: args.limit_arg.limit,
             max_tokens: args.tokens,
             ref_name: args.ref_name.as_deref(),
             json: cli.json || output.json,
@@ -868,7 +868,7 @@ pub fn cmd_related_dispatch(
 ) -> Result<()> {
     let ctx = group_b_ctx!(ctx);
     must_be!(cmd, Commands::Related { args, output } => {
-        commands::cmd_related(ctx, &args.name, args.limit, cli.json || output.json)
+        commands::cmd_related(ctx, &args.name, args.limit_arg.limit, cli.json || output.json)
     })
 }
 
@@ -880,7 +880,7 @@ pub fn cmd_where_dispatch(
 ) -> Result<()> {
     let ctx = group_b_ctx!(ctx);
     must_be!(cmd, Commands::Where { args, output } => {
-        commands::cmd_where(ctx, &args.description, args.limit, cli.json || output.json)
+        commands::cmd_where(ctx, &args.description, args.limit_arg.limit, cli.json || output.json)
     })
 }
 
@@ -895,7 +895,7 @@ pub fn cmd_scout_dispatch(
         commands::cmd_scout(
             ctx,
             &args.query,
-            args.limit,
+            args.limit_arg.limit,
             cli.json || output.json,
             args.tokens,
         )
@@ -913,7 +913,7 @@ pub fn cmd_plan_dispatch(
         commands::cmd_plan(
             ctx,
             &args.description,
-            args.limit,
+            args.limit_arg.limit,
             cli.json || output.json,
             args.tokens,
         )
@@ -931,7 +931,7 @@ pub fn cmd_task_dispatch(
         commands::cmd_task(
             ctx,
             &args.description,
-            args.limit,
+            args.limit_arg.limit,
             cli.json || output.json,
             args.tokens,
             args.brief,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -694,7 +694,7 @@ mod tests {
                 ..
             }) => {
                 assert_eq!(args.tokens, Some(8000));
-                assert_eq!(args.limit, 20);
+                assert_eq!(args.limit_arg.limit, 20);
                 assert!(output.json);
             }
             _ => panic!("Expected Gather command"),


### PR DESCRIPTION
## Summary

API-V1.38-10 from the v1.36.2 audit umbrella (#1463), structural
fan-out portion: convert 8 inline `pub limit: usize` definitions to
`#[command(flatten)] pub limit_arg: LimitArg`, finishing Task A3's
unification.

## Why

Pre-fix, every `*Args` struct that wraps a search-shaped command
inline-defined its own `pub limit: usize` — 8 copies that drifted on
validation rules (only some had `parse_nonzero_usize`, only some had
specific docs). Task A3 (`args.rs:101-106`) defined `LimitArg` to
"standardise --limit across every graph subcommand" but stopped at the
graph commands; the 8 search-shaped commands were left inline.

Result: a future limit-shape change (default cap, parser, validation)
needs an N-file edit instead of one line. The concrete-bug version of
this finding (`--limit 0` rejection) shipped in #1544 (cluster BB);
this PR closes the structural fan-out part.

## What this PR does

### `LimitArg` gains the parse_nonzero_usize gate

```rust
#[arg(short = 'n', long, default_value = "5", value_parser = parse_nonzero_usize)]
pub limit: usize,
```

This means every flattened consumer (the 7 graph commands already on
LimitArg + the 8 search commands migrating now) inherits the
parse-time `--limit 0` rejection that #1544 added inline.

**Behavior change**: graph commands (impact, trace, onboard, explain,
test_map, deps, callers) — already on `LimitArg` — now also reject
`--limit 0` at parse time. Same reasoning as cluster BB: limit=0 is
meaningless everywhere.

### 8 args structs converted

| Struct | Before | After |
|---|---|---|
| `SearchArgs` | inline `pub limit: usize` | `#[command(flatten)] pub limit_arg: LimitArg` |
| `GatherArgs` | inline | LimitArg |
| `ScoutArgs` | inline | LimitArg |
| `SimilarArgs` | inline | LimitArg |
| `RelatedArgs` | inline | LimitArg |
| `WhereArgs` | inline | LimitArg |
| `PlanArgs` | inline | LimitArg |
| `TaskArgs` | inline | LimitArg |

### ~25 call sites updated

`args.limit` → `args.limit_arg.limit` across:
- `src/cli/batch/handlers/{search,info,misc,graph}.rs`
- `src/cli/commands/dispatch_shims.rs`
- `src/cli/batch/commands.rs` (1 test fixture)
- `src/cli/batch/handlers/graph.rs` (1 test fixture)

## What's NOT in scope

- `DriftArgs.limit` (`Option<usize>`, semantically different — drift
  has no default cap, `None` means "unlimited") stays inline.
- `EvalCmdArgs.limit` (default 20, intentionally larger than the
  harmonised default of 5 because eval uses it as the R@K cap) stays
  inline. Per `cli/commands/eval/mod.rs:52` doc.

## Verification

- `cargo build --features gpu-index` — clean
- `cargo build --features gpu-index --tests` — clean
- `cargo test --features gpu-index --bin cqs` — 773 passed, 10 ignored
- `cargo clippy --features gpu-index -- -D warnings` — clean
- `cargo fmt --check` — clean

Sub-item of #1463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
