### PR TITLE
fix(hnsw): DS-V1.38-4 close TOCTOU window in load_with_dim existence check (#1463)

### DIFF
--- a/src/hnsw/persist.rs
+++ b/src/hnsw/persist.rs
@@ -703,9 +703,29 @@ impl HnswIndex {
         let data_path = dir.join(format!("{}.hnsw.data", basename));
         let id_map_path = dir.join(format!("{}.hnsw.ids", basename));
 
-        if !graph_path.exists() || !data_path.exists() || !id_map_path.exists() {
-            return Err(HnswError::NotFound(dir.display().to_string()));
-        }
+        // DS-V1.38-4 (#1463): existence check moved INSIDE the
+        // shared-lock critical section. Pre-fix, a reader checked
+        // file existence at line 706 BEFORE acquiring the lock at
+        // line 734 — between those two points, a concurrent `save()`
+        // could take the exclusive lock, rename the four files into
+        // `.bak`, and complete. The reader then waited up to ~1s for
+        // the shared lock; if save finished within that window, the
+        // reader proceeded with files that had already been replaced,
+        // and `verify_hnsw_checksums` failed with a confusing
+        // checksum-mismatch error during a normal concurrent rebuild.
+        //
+        // The lock-acquisition path doesn't depend on the four data
+        // files existing (the lock file is a separate `.hnsw.lock`),
+        // so this reorder is safe and closes the TOCTOU window: any
+        // saver that wants to rename files MUST first take the
+        // exclusive lock, and we now check existence only AFTER our
+        // shared lock is held.
+        //
+        // The deeper hazard — a half-renamed set where save N+1 has
+        // moved graph but not yet data — remains and is tracked as
+        // the larger "bundle into single .hnsw.bundle for atomic
+        // replace" refactor. The lock-then-existence check at least
+        // ensures we don't observe in-progress renames.
 
         // Acquire shared lock for the read phase only (released before
         // return). Protects the on-disk graph/data/ids/checksum files
@@ -758,6 +778,16 @@ impl HnswIndex {
         }
         warn_wsl_advisory_locking(dir);
         tracing::debug!(lock_path = %lock_path.display(), "Acquired HNSW load lock (shared, released after read)");
+
+        // DS-V1.38-4 (#1463): existence check NOW happens under the
+        // shared lock. A concurrent `save()` that wanted to rename
+        // these files would need the exclusive lock — which it can't
+        // get while we hold the shared lock. So the files we observe
+        // here are guaranteed to remain in place for the duration of
+        // the load.
+        if !graph_path.exists() || !data_path.exists() || !id_map_path.exists() {
+            return Err(HnswError::NotFound(dir.display().to_string()));
+        }
 
         tracing::info!(dir = %dir.display(), basename, "Loading HNSW index");
         verify_hnsw_checksums(dir, basename)?;


### PR DESCRIPTION
## Summary

DS-V1.38-4 from the v1.36.2 audit umbrella (#1463), easy-mitigation
portion: move the file-existence check inside the shared-lock critical
section in `HnswIndex::load_with_dim` to close the TOCTOU window
against concurrent `save()`.

## Why

Pre-fix, `load_with_dim` checked file existence at line 706 BEFORE
acquiring the shared lock at line 734:

```rust
// 1. Existence check (BEFORE lock)
if !graph_path.exists() || !data_path.exists() || !id_map_path.exists() {
    return Err(HnswError::NotFound(...));
}

// 2. Lock acquisition (up to 1s of retry)
let lock_acquired = (0..5).any(|attempt| { ... });

// 3. Read files
verify_hnsw_checksums(...)?;
```

Between steps 1 and 2, a concurrent `save()` could:
1. Take the exclusive lock (no contention since reader hasn't yet)
2. Rename the four data files into `.bak`
3. Complete and release the lock

The reader then waited up to ~1s for the shared lock; if save
finished within that window, the reader proceeded with files that had
already been replaced — `verify_hnsw_checksums` then read the NEW
bytes vs an OLD checksum file (or vice versa) and failed with a
confusing checksum-mismatch error during a normal concurrent rebuild.

## What this PR does

Move the existence check to AFTER the shared-lock acquisition. The
lock-acquisition path doesn't depend on the four data files existing
(the lock file is a separate `.hnsw.lock`), so this reorder is safe.

Post-fix:
1. Lock acquisition (shared)
2. Existence check (now under lock)
3. `verify_hnsw_checksums` + read

Any saver that wants to rename files MUST first take the exclusive
lock, which can't be held while we hold the shared lock. So the files
we observe at step 2 are guaranteed to remain in place for the
duration of the load.

Plus an inline doc-comment on the new ordering that points back to
the audit row + the deeper-hazard backlog item below.

## Verification

- `cargo build --features gpu-index` — clean
- `cargo test --features gpu-index --lib hnsw::persist` — 19 passed
- `cargo clippy --features gpu-index -- -D warnings` — clean
- `cargo fmt --check` — clean

## What's NOT in scope

The deeper hazard — a half-renamed set where save N+1 has moved graph
but not yet data — remains. The audit's "Even better" suggestion is
to bundle all four files into a single `<basename>.hnsw.bundle` and
atomically replace the bundle, eliminating half-state entirely. That's
a larger refactor (file-format change + migration path for existing
indexes); deferred. The lock-then-existence-check fix here at least
ensures we don't observe in-progress renames.

A concurrent-thread integration test for the TOCTOU race is also out
of scope — these tests are flaky by nature, and the reorder is small
enough that the existing `test_concurrent_load_shared` plus the
deadlock-avoidance regression `load_does_not_block_subsequent_save_in_same_process`
cover the surrounding lock contract.

Sub-item of #1463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
