### PR TITLE
docs(tears): cluster XX (#1569) + YY (#1570) landings + triage flips

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -19,15 +19,16 @@
 
 **Big bug surfaced**: `cross_project::from_config` slot-blindness was a 100% silent break on all post-#1105 projects using `--cross-project`. Found and fixed in #1564. Existing 12 cross_project unit tests didn't catch it because they construct `CrossProjectContext::new(stores)` directly, bypassing `from_config`.
 
-**Two more cluster PRs (#1566–#1567)** after the TC-HAP sweep, both lighter follow-up cleanup:
+**Four more cluster PRs (#1566–#1567, #1569–#1570)** after the TC-HAP sweep, picking off the architectural punchlist:
 - **#1566** (Cluster VV) — SHL-V1.38-6: `parse_channel_depth` default halved 512 → 256. Cuts the worst-case buffered ParsedBatch ceiling from ~256 MB to ~128 MB on large repos. Practical fill level is ~10 messages so the cap reduction is harmless; CQS_PARSE_CHANNEL_DEPTH env override remains.
 - **#1567** (Cluster WW) — API-V1.38-9: `EmbedderError::HfHub` renamed → `EmbedderError::ModelDownload` for naming parity with `RerankerError::ModelDownload`. The full `AuxModelError::Download` collapse via `#[from]` is deferred since the embedder's HF download path doesn't currently route through `aux_model::resolve` — variant-name harmonization captures the consistency win without restructuring the resolver chain.
+- **#1569** (Cluster XX) — API-V1.38-10 structural fan-out: 8 inline `pub limit: usize` definitions across SearchArgs/GatherArgs/ScoutArgs/SimilarArgs/RelatedArgs/WhereArgs/PlanArgs/TaskArgs converted to `#[command(flatten)] pub limit_arg: LimitArg`. LimitArg gains the `parse_nonzero_usize` gate so the 7 graph commands already on it also reject `--limit 0` at parse time. ~25 caller sites updated `args.limit` → `args.limit_arg.limit`.
+- **#1570** (Cluster YY) — DS-V1.38-4 easy mitigation: file-existence check in `HnswIndex::load_with_dim` moved INSIDE the shared-lock critical section, closing the TOCTOU window where a concurrent `save()` could rename files between the reader's existence check and lock acquisition. Bundle-rename atomic refactor for the half-renamed-set hazard remains deferred.
 
-**Audit umbrella (#1463) state after this entire post-summary sweep**: ~62 findings closed across 30+ cluster PRs of the v1.38 cycle. Truly remaining items are all genuinely big architectural refactors:
-- API-V1.38-6 (top-level Cli flag → subcommand parity) — clap conflict on duplicate flag definitions; needs SearchArgs locals removed AND every search-wrapping handler rewritten to read from cli.*. Bigger than expected.
-- API-V1.38-10 structural fan-out (LimitArg → 7 sister args, 61 caller sites)
-- DS-V1.38-4 (HNSW load_with_dim TOCTOU) — multi-PR architectural change
-- PL-V1.38-2 (SPLADE Windows umask) — needs Windows test runner
+**Audit umbrella (#1463) state after this entire post-summary sweep**: ~64 findings closed across 33+ cluster PRs of the v1.38 cycle. Truly remaining items shrunk to:
+- **API-V1.38-6** (top-level Cli flag → subcommand parity) — clap conflict on duplicate flag definitions; needs SearchArgs locals removed AND every search-wrapping handler rewritten to read from cli.*. Plus the underlying `cqs::scout()` lib function doesn't accept filter knobs at all — bigger than the audit estimated.
+- **DS-V1.38-4 deeper hazard** (HNSW half-renamed-set under a lock-then-rename window) — needs bundle-into-single-file refactor with a migration path for existing indexes.
+- **PL-V1.38-2** (SPLADE Windows umask) — needs Windows test runner.
 
 Plus 12 P4 carry-overs all on tracking issues (#1512 Windows daemon, #1461 Windows ACL, etc.) requiring infrastructure that isn't on this Linux/WSL workstation.
 

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -4,7 +4,7 @@ Audit date: 2026-05-06
 Source: `docs/audit-findings.md` (154 findings across 16 categories, batches 1+2)
 Calibration: matches `docs/audit-triage-v1.36.2-final.md` priority matrix.
 
-> **Cycle status (2026-05-07):** ~58 findings closed across 25 cluster PRs (#1514–#1552). The per-row `Status` column in this document is a **snapshot at audit time** and was not updated as cluster PRs landed. **Canonical closure list lives in the [#1463 umbrella issue comment](https://github.com/jamie8johnson/cqs/issues/1463#issuecomment-4395768972).** Items still pending are all genuinely big — multi-PR architectural changes or platform-specific scaffolding (API-V1.38-6/9/10, DS-V1.38-4, SHL-V1.38-6, PL-V1.38-2, plus 12 P4 carry-overs).
+> **Cycle status (2026-05-07):** ~64 findings closed across 33+ cluster PRs (#1514–#1570). The per-row `Status` column in this document is a **snapshot at audit time** and was updated periodically as cluster PRs landed. **Canonical closure list lives in the [#1463 umbrella issue comment](https://github.com/jamie8johnson/cqs/issues/1463#issuecomment-4395768972).** Truly remaining items: API-V1.38-6 (clap conflict — bigger than the audit estimated), DS-V1.38-4 deeper hazard (bundle-rename atomic refactor for HNSW save), PL-V1.38-2 (Windows runner), plus 12 P4 carry-overs on tracking issues.
 
 ## Summary by Priority
 
@@ -303,7 +303,7 @@ After these 10 PRs: P3 cleanup batch (single PR per category — doc tweaks, min
 ### Data Safety
 | ID | Title | Difficulty | Status |
 |---|---|---|---|
-| DS-V1.38-4 | HNSW `load_with_dim` existence check before shared lock — concurrent saver renames files out from under reader | medium | pending |
+| DS-V1.38-4 | HNSW `load_with_dim` existence check before shared lock — concurrent saver renames files out from under reader | medium | ✅ #1570 (easy mitigation; bundle-rename for half-state hazard deferred) |
 | DS-V1.38-8 | v26→v27 migration leaves `embedding_base IS NULL` rows un-flagged for re-embed | medium | pending |
 
 ### Test Coverage (happy path)
@@ -325,8 +325,8 @@ After these 10 PRs: P3 cleanup batch (single PR per category — doc tweaks, min
 | API-V1.38-5 | `Cli::resolved_model` `pub` instead of `pub(super)` | easy | pending |
 | API-V1.38-7 | `ExportModel.dim` is `Option<u64>` while every other dim field is `usize` | easy | pending |
 | API-V1.38-8 | Two flags for the same semantic — `--wait-secs` (status) vs `--require-fresh-secs` (eval) | easy | pending |
-| API-V1.38-9 | `EmbedderError::HfHub(String)` and `RerankerError::ModelDownload(String)` sibling stringified errors | medium | pending |
-| API-V1.38-10 | `LimitArg` flattened in 6 places; inline `limit: usize` still in 7 sister args | easy | pending |
+| API-V1.38-9 | `EmbedderError::HfHub(String)` and `RerankerError::ModelDownload(String)` sibling stringified errors | medium | ✅ #1567 (variant-name harmonization; full type collapse via `AuxModelError` deferred — embedder doesn't route through aux_model::resolve) |
+| API-V1.38-10 | `LimitArg` flattened in 6 places; inline `limit: usize` still in 7 sister args | easy | ✅ #1544 (concrete `--limit 0` rejection) + ✅ #1569 (structural fan-out across 8 sister args) |
 
 ### Error Handling
 | ID | Title | Difficulty | Status |
@@ -361,7 +361,7 @@ After these 10 PRs: P3 cleanup batch (single PR per category — doc tweaks, min
 | SHL-V1.38-2 | `--require-fresh-secs` capped at hardcoded `600u64` (not env-overridable) | easy | pending |
 | SHL-V1.38-3 | `PIPELINE_FAN_OUT_LIMIT = 50` silently truncates — no env override | easy | pending |
 | SHL-V1.38-5 | `STREAM_BATCH_SIZE = 1024` UMAP path dim-blind, no env | easy | pending |
-| SHL-V1.38-6 | `parse_channel_depth() = 512` ignores file size + chunk fan-out | easy | pending |
+| SHL-V1.38-6 | `parse_channel_depth() = 512` ignores file size + chunk fan-out | easy | ✅ #1566 (default halved 512 → 256; full byte-budget derivation deferred) |
 | SHL-V1.38-7 | LLM-pass `PAGE_SIZE = 500` literal duplicated in two files, no env | easy | pending |
 | SHL-V1.38-8 | Reconcile streaming `BATCH = 1000` files hardcoded | easy | pending |
 | SHL-V1.38-9 | `summary_queue` thresholds (64/200ms/10_000) hardcoded | medium | pending |


### PR DESCRIPTION
## Summary

Tears + triage doc update for cluster XX (#1569) and YY (#1570).

## What's added

- `PROJECT_CONTINUITY.md`: cluster XX (LimitArg fan-out, 8 args
  structs + ~25 caller sites) and YY (HNSW load_with_dim TOCTOU
  easy-mitigation) entries plus updated punchlist of truly-remaining
  architectural items.
- `docs/audit-triage.md`: per-row Status flips for API-V1.38-9,
  API-V1.38-10, DS-V1.38-4, SHL-V1.38-6 with PR links + deferral
  notes for the larger follow-up work.

## Verification

Doc-only change. No tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
