### PR TITLE
fix(watch): #1574 atomic per-file function_calls + chunks reindex

### DIFF
--- a/src/cli/watch/reindex.rs
+++ b/src/cli/watch/reindex.rs
@@ -352,6 +352,15 @@ pub(super) fn reindex_files(
     // pipeline already does this via `parse_file_all_with_chunk_calls`; the
     // watch path was paying ~14k extra tree-sitter parses per repo-wide reindex.
     let mut per_file_chunk_calls: Vec<(String, cqs::parser::CallSite)> = Vec::new();
+    // #1574: stash file-level function_calls per origin so they can be
+    // written in the SAME tx as the chunks/FTS upsert below. Pre-fix, the
+    // flat_map called `upsert_function_calls` per file synchronously,
+    // BEFORE the heavy embed phase. A daemon crash during embed (we
+    // observed SIGFPE crashes on TensorRT) left the function_calls table
+    // ahead of chunks/FTS — `cqs callers <new_fn>` worked, search /
+    // `cqs explain` didn't.
+    use std::collections::HashMap;
+    let mut all_function_calls: HashMap<PathBuf, Vec<cqs::parser::FunctionCalls>> = HashMap::new();
     let chunks: Vec<_> = files
         .iter()
         .flat_map(|rel_path| {
@@ -404,22 +413,19 @@ pub(super) fn reindex_files(
                     if !chunk_type_refs.is_empty() {
                         all_type_refs.push((rel_path.clone(), chunk_type_refs));
                     }
-                    // RT-DATA-8: Write function_calls table (file-level call graph).
-                    // Previously discarded — callers/impact/trace commands need this.
+                    // #1574: stash function_calls for atomic per-file write
+                    // alongside chunks/FTS below. Pre-fix this called
+                    // `store.upsert_function_calls` synchronously here,
+                    // BEFORE the embed phase — leaving an asymmetric state
+                    // when the daemon crashed mid-embed.
                     //
-                    // Always invoked, even on empty `calls`: the function does
-                    // DELETE WHERE file=X then INSERT current. Skipping the call
-                    // when current is empty leaks rows for files that previously
-                    // had function_calls but no longer do (audit P1 #17 / E.2:
-                    // `delete_phantom_chunks` cannot do this cleanup itself
-                    // because it would wipe the just-written rows).
-                    if let Err(e) = store.upsert_function_calls(rel_path, &calls) {
-                        tracing::warn!(
-                            path = %rel_path.display(),
-                            error = %e,
-                            "Failed to write function_calls for watched file"
-                        );
-                    }
+                    // Always stash (even with empty `calls`): the per-file
+                    // upsert below does DELETE WHERE file=X then INSERT
+                    // current. Skipping when empty leaks rows for files
+                    // that previously had function_calls but no longer do
+                    // (audit P1 #17 / E.2: `delete_phantom_chunks` cannot
+                    // do this cleanup itself).
+                    all_function_calls.insert(rel_path.clone(), calls);
                     file_chunks
                 }
                 Err(e) => {
@@ -712,13 +718,22 @@ pub(super) fn reindex_files(
         // alongside a dirty HNSW flag. `upsert_chunks_calls_and_prune` fuses
         // both operations into a single `begin_write` transaction, making the
         // reindex all-or-nothing. RT-DATA-10 / DS-37.
+        //
+        // #1574: also fold the file-level `function_calls` write into the
+        // same per-file tx (was a separate tx before the embed phase, which
+        // left an asymmetric state when the daemon crashed mid-embed).
         let live_ids: Vec<&str> = pairs.iter().map(|(c, _)| c.id.as_str()).collect();
-        store.upsert_chunks_calls_and_prune(
+        let file_fn_calls = all_function_calls
+            .get(file)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+        store.upsert_chunks_calls_and_prune_with_file_calls(
             pairs,
             mtime,
             &file_calls,
             Some(file.as_path()),
             &live_ids,
+            Some(file_fn_calls),
         )?;
 
         // #1219: populate the v23 reconcile fingerprint columns
@@ -778,6 +793,26 @@ pub(super) fn reindex_files(
                 error = %e,
                 "Reindex: failed to set v23 fingerprint columns; reconcile will use mtime fallback"
             );
+        }
+    }
+
+    // #1574: any file that parsed to ZERO chunks is in `all_function_calls`
+    // but NOT in `by_file`. The per-file upsert loop above only ran for
+    // files with at least one chunk, so empty-chunk files would leak old
+    // function_calls rows if we didn't also clear them here. Pre-fix the
+    // flat_map called `upsert_function_calls` per file unconditionally
+    // before the embed phase; this preserves that cleanup for the
+    // zero-chunk edge case (deleted-only / parser-emitted-empty) while
+    // keeping the atomic-with-chunks path for the common case.
+    for (rel_path, fcs) in &all_function_calls {
+        if !by_file.contains_key(rel_path) {
+            if let Err(e) = store.upsert_function_calls(rel_path, fcs) {
+                tracing::warn!(
+                    path = %rel_path.display(),
+                    error = %e,
+                    "Failed to write function_calls for zero-chunk watched file"
+                );
+            }
         }
     }
 

--- a/src/store/calls/crud.rs
+++ b/src/store/calls/crud.rs
@@ -9,6 +9,64 @@ use super::CallStats;
 use crate::store::helpers::StoreError;
 use crate::store::{ReadWrite, Store};
 
+/// Shared in-tx helper for writing the file-level `function_calls` table.
+///
+/// Used by both [`Store::upsert_function_calls`] (which opens its own tx) and
+/// [`Store::upsert_chunks_calls_and_prune`] (which folds the function_calls
+/// write into the same per-file tx as the chunks/FTS/calls write — see
+/// #1574 for the asymmetric-state bug this folding closes).
+///
+/// `file_str` MUST be the normalized origin path (call
+/// `crate::normalize_path` at the call site, once).
+pub(crate) async fn write_function_calls_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    file_str: &str,
+    function_calls: &[crate::parser::FunctionCalls],
+) -> Result<(), StoreError> {
+    sqlx::query("DELETE FROM function_calls WHERE file = ?1")
+        .bind(file_str)
+        .execute(&mut **tx)
+        .await?;
+
+    // Flatten all calls and batch insert (instead of N individual inserts)
+    let all_calls: Vec<_> = function_calls
+        .iter()
+        .flat_map(|fc| {
+            fc.calls
+                .iter()
+                .map(move |call| (&fc.name, fc.line_start, &call.callee_name, call.line_number))
+        })
+        .collect();
+
+    if !all_calls.is_empty() {
+        use crate::store::helpers::sql::max_rows_per_statement;
+        const INSERT_BATCH: usize = max_rows_per_statement(5);
+        for batch in all_calls.chunks(INSERT_BATCH) {
+            let mut query_builder: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+                "INSERT INTO function_calls (file, caller_name, caller_line, callee_name, call_line) ",
+            );
+            query_builder.push_values(
+                batch.iter(),
+                |mut b, (caller_name, caller_line, callee_name, call_line)| {
+                    b.push_bind(file_str)
+                        .push_bind(*caller_name)
+                        .push_bind(*caller_line as i64)
+                        .push_bind(*callee_name)
+                        .push_bind(*call_line as i64);
+                },
+            );
+            query_builder.build().execute(&mut **tx).await?;
+        }
+        tracing::info!(
+            file = %file_str,
+            functions = function_calls.len(),
+            calls = all_calls.len(),
+            "Indexed function calls"
+        );
+    }
+    Ok(())
+}
+
 impl Store<ReadWrite> {
     /// Insert or replace call sites for a chunk
     pub fn upsert_calls(
@@ -196,47 +254,7 @@ impl Store<ReadWrite> {
 
         self.rt.block_on(async {
             let (_guard, mut tx) = self.begin_write().await?;
-
-            sqlx::query("DELETE FROM function_calls WHERE file = ?1")
-                .bind(&file_str)
-                .execute(&mut *tx)
-                .await?;
-
-            // Flatten all calls and batch insert (instead of N individual inserts)
-            let all_calls: Vec<_> = function_calls
-                .iter()
-                .flat_map(|fc| {
-                    fc.calls.iter().map(move |call| {
-                        (&fc.name, fc.line_start, &call.callee_name, call.line_number)
-                    })
-                })
-                .collect();
-
-            if !all_calls.is_empty() {
-                use crate::store::helpers::sql::max_rows_per_statement;
-                const INSERT_BATCH: usize = max_rows_per_statement(5);
-                for batch in all_calls.chunks(INSERT_BATCH) {
-                    let mut query_builder: sqlx::QueryBuilder<sqlx::Sqlite> =
-                        sqlx::QueryBuilder::new(
-                            "INSERT INTO function_calls (file, caller_name, caller_line, callee_name, call_line) ",
-                        );
-                    query_builder.push_values(batch.iter(), |mut b, (caller_name, caller_line, callee_name, call_line)| {
-                        b.push_bind(&file_str)
-                            .push_bind(*caller_name)
-                            .push_bind(*caller_line as i64)
-                            .push_bind(*callee_name)
-                            .push_bind(*call_line as i64);
-                    });
-                    query_builder.build().execute(&mut *tx).await?;
-                }
-                tracing::info!(
-                    file = %file_str,
-                    functions = function_calls.len(),
-                    calls = all_calls.len(),
-                    "Indexed function calls"
-                );
-            }
-
+            write_function_calls_in_tx(&mut tx, &file_str, function_calls).await?;
             tx.commit().await?;
             Ok(())
         })

--- a/src/store/calls/mod.rs
+++ b/src/store/calls/mod.rs
@@ -14,6 +14,11 @@ mod query;
 mod related;
 mod test_map;
 
+// #1574: re-export the in-tx function_calls writer so
+// `store::chunks::crud::upsert_chunks_calls_and_prune` can fold the
+// file-level call-graph write into the same per-file transaction.
+pub(crate) use crud::write_function_calls_in_tx;
+
 use std::path::PathBuf;
 use std::sync::LazyLock;
 

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -932,12 +932,73 @@ impl Store<ReadWrite> {
         prune_file: Option<&std::path::Path>,
         live_ids: &[&str],
     ) -> Result<usize, StoreError> {
+        self.upsert_chunks_calls_and_prune_inner(
+            chunks,
+            source_mtime,
+            calls,
+            prune_file,
+            live_ids,
+            None,
+        )
+    }
+
+    /// #1574: same as [`Self::upsert_chunks_calls_and_prune`] but ALSO writes
+    /// the file-level `function_calls` table in the same transaction.
+    ///
+    /// The asymmetric-state bug this closes: pre-fix, `cli/watch/reindex.rs`
+    /// called `upsert_function_calls` per-file inside the parser flat_map
+    /// BEFORE the (heavy, crash-prone) embed phase. If the daemon crashed
+    /// during embed (we observed SIGFPE crashes on TensorRT), the
+    /// function_calls table got the new state but the chunks/FTS table did
+    /// not — `cqs callers <new_fn>` worked but `cqs explain <new_fn>` and
+    /// search-by-name didn't. Folding the function_calls write into this
+    /// per-file tx makes the reindex all-or-nothing.
+    ///
+    /// `file_function_calls` MUST be paired with `prune_file` (the file the
+    /// function_calls belong to). When `prune_file = None`, this method
+    /// asserts `file_function_calls.is_none()` because there's no file
+    /// scope to delete-then-insert against.
+    pub fn upsert_chunks_calls_and_prune_with_file_calls(
+        &self,
+        chunks: &[(Chunk, Embedding)],
+        source_mtime: Option<i64>,
+        calls: &[(String, crate::parser::CallSite)],
+        prune_file: Option<&std::path::Path>,
+        live_ids: &[&str],
+        file_function_calls: Option<&[crate::parser::FunctionCalls]>,
+    ) -> Result<usize, StoreError> {
+        if file_function_calls.is_some() {
+            debug_assert!(
+                prune_file.is_some(),
+                "file_function_calls requires prune_file to scope the DELETE"
+            );
+        }
+        self.upsert_chunks_calls_and_prune_inner(
+            chunks,
+            source_mtime,
+            calls,
+            prune_file,
+            live_ids,
+            file_function_calls,
+        )
+    }
+
+    fn upsert_chunks_calls_and_prune_inner(
+        &self,
+        chunks: &[(Chunk, Embedding)],
+        source_mtime: Option<i64>,
+        calls: &[(String, crate::parser::CallSite)],
+        prune_file: Option<&std::path::Path>,
+        live_ids: &[&str],
+        file_function_calls: Option<&[crate::parser::FunctionCalls]>,
+    ) -> Result<usize, StoreError> {
         let _span = tracing::info_span!(
             "upsert_chunks_calls_and_prune",
             chunks = chunks.len(),
             calls = calls.len(),
             prune = prune_file.is_some(),
-            live_count = live_ids.len()
+            live_count = live_ids.len(),
+            file_function_calls = file_function_calls.is_some()
         )
         .entered();
         let dim = self.dim;
@@ -1111,6 +1172,15 @@ impl Store<ReadWrite> {
                 }
             }
 
+            // #1574: fold the file-level `function_calls` write into the
+            // same tx as chunks/FTS/calls so a crash here can't leave the
+            // tables in an asymmetric state where the call graph knows
+            // about a function the chunks/FTS index doesn't.
+            if let (Some(file), Some(fcs)) = (prune_file, file_function_calls) {
+                let file_str = crate::normalize_path(file);
+                crate::store::calls::write_function_calls_in_tx(&mut tx, &file_str, fcs).await?;
+            }
+
             tx.commit().await?;
             Ok(chunks.len())
         })
@@ -1201,7 +1271,119 @@ impl Store<ReadWrite> {
 #[cfg(test)]
 mod tests {
     use super::super::test_utils::make_chunk;
+    use crate::parser::{CallSite, FunctionCalls};
     use crate::test_helpers::{mock_embedding, setup_store};
+
+    /// #1574 regression: `upsert_chunks_calls_and_prune_with_file_calls`
+    /// must write chunks/FTS/calls AND function_calls in the same SQLite
+    /// transaction. Pre-fix the watch-mode reindex called
+    /// `upsert_function_calls` separately BEFORE the embed phase, so a
+    /// daemon crash mid-embed (we observed SIGFPE crashes on TensorRT)
+    /// left function_calls ahead of chunks/FTS — search-by-name returned
+    /// 0 hits for the new function while `cqs callers <new_fn>` worked.
+    /// This test pins the post-commit invariant: after a successful
+    /// upsert, BOTH the chunks/FTS shadow AND the function_calls table
+    /// reflect the new function.
+    #[test]
+    fn test_upsert_chunks_calls_and_prune_with_file_calls_atomic() {
+        let (store, _dir) = setup_store();
+        let emb = mock_embedding(1.0);
+
+        let chunk = make_chunk("new_fn", "src/m.rs");
+        let pairs = [(chunk.clone(), emb.clone())];
+
+        // file-level function_calls: new_fn calls callee_alpha
+        let fcs = vec![FunctionCalls {
+            name: "new_fn".to_string(),
+            line_start: 1,
+            calls: vec![CallSite {
+                callee_name: "callee_alpha".to_string(),
+                line_number: 2,
+            }],
+        }];
+
+        store
+            .upsert_chunks_calls_and_prune_with_file_calls(
+                &pairs,
+                Some(123),
+                &[],
+                Some(std::path::Path::new("src/m.rs")),
+                &[chunk.id.as_str()],
+                Some(&fcs),
+            )
+            .expect("upsert with file_calls must succeed");
+
+        // chunks table has the new function
+        let stored = store.get_chunks_by_ids(&[chunk.id.as_str()]).unwrap();
+        assert_eq!(stored.len(), 1, "chunk row must be present");
+        assert_eq!(stored.get(&chunk.id).unwrap().name, "new_fn");
+
+        // FTS shadow has the new function (this is the table that backs
+        // `search_by_name` — pre-fix this was the missing piece)
+        let fts_hits = store
+            .search_by_name("new_fn", 5)
+            .expect("search_by_name must succeed");
+        assert!(
+            fts_hits.iter().any(|h| h.chunk.name == "new_fn"),
+            "search_by_name must find new_fn after upsert: got {:?}",
+            fts_hits.iter().map(|h| &h.chunk.name).collect::<Vec<_>>()
+        );
+
+        // function_calls table has the new caller (this is the call-graph
+        // table that pre-fix was being written EARLY — the asymmetric
+        // state was that this had the row but FTS didn't)
+        let callers = store
+            .get_callers_full("callee_alpha")
+            .expect("get_callers_full");
+        assert!(
+            callers.iter().any(|c| c.name == "new_fn"),
+            "function_calls must record new_fn → callee_alpha: got {:?}",
+            callers.iter().map(|c| &c.name).collect::<Vec<_>>()
+        );
+    }
+
+    /// #1574 corollary: passing `None` for file_function_calls leaves the
+    /// existing function_calls rows untouched (the legacy non-atomic path).
+    /// Pin so a future refactor that defaults to "always write" doesn't
+    /// silently wipe call-graph state for callers using the legacy method.
+    #[test]
+    fn test_upsert_chunks_calls_and_prune_none_leaves_function_calls() {
+        let (store, _dir) = setup_store();
+        let emb = mock_embedding(1.0);
+
+        // Seed function_calls via the standalone API
+        let seed_fcs = vec![FunctionCalls {
+            name: "seeded_fn".to_string(),
+            line_start: 1,
+            calls: vec![CallSite {
+                callee_name: "seeded_callee".to_string(),
+                line_number: 2,
+            }],
+        }];
+        store
+            .upsert_function_calls(std::path::Path::new("src/m.rs"), &seed_fcs)
+            .expect("seed function_calls");
+
+        // Now run the legacy upsert (None for file_function_calls)
+        let chunk = make_chunk("other_fn", "src/m.rs");
+        let pairs = [(chunk.clone(), emb)];
+        store
+            .upsert_chunks_calls_and_prune(
+                &pairs,
+                Some(123),
+                &[],
+                Some(std::path::Path::new("src/m.rs")),
+                &[chunk.id.as_str()],
+            )
+            .expect("legacy upsert must succeed");
+
+        // Seeded function_calls row must still be present
+        let callers = store.get_callers_full("seeded_callee").unwrap();
+        assert!(
+            callers.iter().any(|c| c.name == "seeded_fn"),
+            "legacy upsert path must NOT wipe pre-existing function_calls"
+        );
+    }
 
     // ===== upsert_chunks_batch tests =====
 


### PR DESCRIPTION
## Summary

Fixes #1574 — daemon incremental reindex left an asymmetric state
where new top-level functions made it into the call graph
(`function_calls` table) but NOT into chunks/FTS, breaking
search-by-name and `cqs explain` for those functions until a full
`cqs index --force` rebuild.

## Root cause

Investigated the user's session journal:

```
May 07 13:09:05 systemd[337]: cqs-watch.service: Main process exited, code=dumped, status=8/FPE
May 07 13:18:04 systemd[337]: cqs-watch.service: Main process exited, code=dumped, status=8/FPE
May 07 13:27:05 systemd[337]: cqs-watch.service: Main process exited, code=dumped, status=8/FPE
May 07 13:36:01 systemd[337]: cqs-watch.service: Main process exited, code=dumped, status=8/FPE
```

**The daemon was crashing with SIGFPE during embed (4×).** Pre-fix,
`cli/watch/reindex.rs::reindex_files` called
`store.upsert_function_calls(rel_path, &calls)` synchronously inside
the parser flat_map — BEFORE the (heavy, crash-prone) embed phase.
The chunks/FTS write happened LATER via
`upsert_chunks_calls_and_prune` after embeddings completed.

When the daemon crashed during embed:
1. Parser flat_map had already written `function_calls` for every
   parsed file (one tx per file)
2. The embedding step (TensorRT/ORT) crashed with SIGFPE
3. `upsert_chunks_calls_and_prune` never ran for any file
4. systemd restarted the daemon
5. Daemon's reconcile sees the file as "indexed" (mtime/fingerprint
   match because nothing on disk changed), so the file is NOT
   re-queued. The asymmetric state persists indefinitely.

User-facing symptom: `cqs callers <new_fn>` worked, but search-by-name
returned 0 hits and `cqs explain <new_fn>` errored with "Not found."

## Fix

Fold the file-level `function_calls` write into the SAME per-file
SQLite transaction as the chunks/FTS/calls write. A crash between
parse and embed now reverts to the prior consistent state on the
next daemon tick — no asymmetric tables.

### Mechanism

- New shared in-tx helper `store::calls::write_function_calls_in_tx`
  factored out of the existing `upsert_function_calls`.
- New `Store::upsert_chunks_calls_and_prune_with_file_calls` variant
  that takes `Option<&[FunctionCalls]>` and folds the function_calls
  DELETE+INSERT into the existing tx. The legacy
  `upsert_chunks_calls_and_prune` is preserved for callers that don't
  manage function_calls.
- `reindex_files` now stashes function_calls per rel_path in a
  HashMap during parse, and passes them to the per-file upsert.
- Files that parsed to ZERO chunks (rare: empty file or all chunks
  dropped) are handled by a post-loop pass that calls the standalone
  `upsert_function_calls` for cleanup — preserving the pre-fix
  cleanup semantics for that edge case. Deleted files (early-exit
  via `delete_by_origin`) already cleaned function_calls.

### Tests

Two regression tests in `src/store/chunks/crud.rs`:

- `test_upsert_chunks_calls_and_prune_with_file_calls_atomic` —
  pins that after a successful upsert, BOTH chunks/FTS shadow AND
  function_calls reflect the new function. This is the test that
  would have caught the asymmetric state.
- `test_upsert_chunks_calls_and_prune_none_leaves_function_calls` —
  pins that legacy callers passing `None` don't accidentally wipe
  pre-existing function_calls rows.

## Verification

- `cargo build --features gpu-index` — clean
- `cargo test --features gpu-index --lib store::chunks::crud::tests` —
  34 passed (32 existing + 2 new)
- `cargo test --features gpu-index --bin cqs cli::watch` — 92 passed,
  3 ignored (heavy-model gated)
- `cargo clippy --features gpu-index -- -D warnings` — clean
- `cargo fmt --check` — clean

## Out of scope

- The underlying SIGFPE crash (probably TensorRT inference on
  specific input shapes) is a separate root cause requiring its own
  investigation. This fix shields the index from data integrity
  problems caused by ANY crash mid-reindex, not just SIGFPE.
- Type-edges atomicity (`upsert_type_edges_for_files` runs after
  the per-file chunks loop). The audit's existing comment classifies
  type edges as "soft data — separate from chunk+call atomicity."
  Keeping consistent with that policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
