### PR TITLE
fix(release): mark cqs-macros publishable for crates.io

### DIFF
--- a/cqs-macros/Cargo.toml
+++ b/cqs-macros/Cargo.toml
@@ -3,9 +3,11 @@ name = "cqs-macros"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.95"
-description = "Internal proc-macros for the cqs crate. Not published — workspace-local only."
+description = "Internal proc-macros for the cqs crate. The `#[derive(CqsCommands)]` and supporting attribute macros that wire CLI command variants to their dispatchers; not a standalone reusable library."
 license = "MIT"
-publish = false
+repository = "https://github.com/jamie8johnson/cqs"
+keywords = ["cqs", "proc-macro"]
+categories = ["development-tools::procedural-macro-helpers"]
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
## Summary

Drops `publish = false` on `cqs-macros/Cargo.toml` so the parent
`cqs` crate can publish to crates.io.

## Context

The cqs-macros workspace member added in #1495 was tagged
`publish = false`. v1.38.0 published cleanly because the macro split
landed AFTER the v1.38.0 tag was cut. v1.39.0 has the dep, so
`cargo publish -p cqs` fails with:

```
error: failed to prepare local package for uploading
Caused by:
  no matching package named `cqs-macros` found
  location searched: crates.io index
  required by package `cqs v1.39.0`
```

## What this PR does

`cqs-macros/Cargo.toml`:
- Drops `publish = false`
- Fills in repository, keywords, categories metadata
- Tightens description to clarify it's the cqs proc-macro and not a
  standalone reusable library

## Verification

- `cargo build --features gpu-index` — clean (unchanged surface)
- `cargo publish -p cqs-macros --dry-run` (run after merge, before
  the live publish to validate metadata)

## Release sequence after merge

1. `cargo publish -p cqs-macros`
2. `cargo publish -p cqs` (with no features per the
   PROJECT_CONTINUITY note about gpu-index verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
