### PR TITLE
chore: Release v1.39.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.39.1] - 2026-05-07
+
+Patch release closing a silent CAGRA / SPLADE-fusion interaction discovered while probing `CQS_SEARCH_CANDIDATE_FLOOR` (the v1.39.0 #1583 floor). One PR (#1584).
+
+### Fixed
+
+- **CAGRA `itopk_max` cliff in the SPLADE-fusion path** (#1584). CAGRA enforces `itopk_size >= k` and `itopk_size <= itopk_max`, where `itopk_max = (log2(n_vectors) * 32).clamp(128, 4096)` — 441 at 14k chunks, 532 at 100k. A search request with `k > itopk_max` returned an empty `Vec` from `cagra::search_impl` with a comment claiming the caller would fall back to HNSW. `search_filtered_with_index` did fall back via the `index_results.is_empty()` brute-force escape hatch. `search_hybrid` (the SPLADE-fusion path used by every production query) did not — empty dense leg + α-weighted sum collapsed every fused score to `1.0·0 + 0.0·s = 0` at α=1.0. On a 14k-chunk corpus with #1583's default floor=500, R@5 dropped from 0.7156 to 0.5963 (-12pp) on v3.v2 test in hybrid mode, and from 0.6606 to 0.1651 (-49pp, basically random) in dense-only.
+
+### Added
+
+- **`VectorIndex::max_k() -> Option<usize>` trait method** (#1584). Backends declare their per-call upper bound. `None` (default) for backends with no cap (HNSW, brute force). `Some(itopk_max)` for `CagraIndex`, honouring `CQS_CAGRA_ITOPK_MAX` so the reported cap matches what `search_impl` enforces.
+- **`cap_k_to_backend(idx, k)` dispatch helper** in `src/search/query.rs`. Trims `k` to the backend's `max_k` with a debug log tagging the trimmed backend. Both dispatch sites (`search_hybrid` line ~540, `search_filtered_with_index` line ~752/754) call it before issuing the search.
+
+### Changed
+
+- **`CagraIndex::search_impl`** retains the `return Vec::new()` branch as defense-in-depth and warns that a caller bypassed `cap_k_to_backend` when the branch fires.
+
 ## [1.39.0] - 2026-05-07
 
 Minor release. Schema v27 (bumped from v26 in #1497). 88 commits since v1.38.0. Three threads: (a) v1.38.0-cohort audit follow-ups (#1487–#1511), (b) the post-v1.38 audit cycle of 154 findings catalogued in PR #1515 (#1514 et seq., shipped across ~33 cluster PRs from #1514 through #1570), (c) post-cycle hardening of the watch/reindex path against daemon crashes (#1572, #1575, #1577).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.39.0"
+version = "1.39.1"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cqs-macros"]
 
 [package]
 name = "cqs"
-version = "1.39.0"
+version = "1.39.1"
 edition = "2021"
 rust-version = "1.95"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 50.9% R@1 / 76.2% R@5 / 88.6% R@20 on v3.v2 dual-judge code-search (218 queries, EmbeddingGemma-300m default with per-category SPLADE α retuned for the new dense backbone). Daemon mode (3-19ms queries). Local-first, GPU-accelerated."


### PR DESCRIPTION
## Summary

Patch release v1.39.1 closing the CAGRA `itopk_max` cliff in the SPLADE-fusion path. One PR (#1584) since v1.39.0.

## What was broken

CAGRA enforces `itopk_size >= k` and `itopk_size <= itopk_max(n_vectors)`. A search with `k > itopk_max` returned an empty `Vec` from `cagra::search_impl` — with a comment claiming the caller would fall back to HNSW. `search_filtered_with_index` did fall back via its brute-force escape hatch. `search_hybrid` (the SPLADE-fusion path used by every production query) did not. With the v1.39.0 floor=500 (#1583) and a 14k-chunk corpus (`itopk_max=441`), every production hybrid query hit the broken path:

```
v3.v2 test (109q), pre-v1.39.1:
  hybrid (router α):  R@5 0.5963  R@20 0.7339   ← dropped from 0.7156 / 0.8165
  dense-only (α=1.0): R@5 0.1651  R@20 0.2110   ← cratered from 0.6606 / 0.7982
```

## What's fixed

`VectorIndex::max_k() -> Option<usize>` declares per-call backend capacity. `cap_k_to_backend(idx, k)` trims `k` to the cap before issuing the search at both dispatch sites. CAGRA returns `Some(itopk_max)`; HNSW returns `None`.

```
v3.v2 test (109q), post-v1.39.1:
  hybrid (router α):  R@5 0.7156  R@20 0.8165   (restored)
  dense-only (α=1.0): R@5 0.6606  R@20 0.7982   (capped at max_k=441, no cliff)
```

Dev set (109q) is flat across floor=500..1000, confirming floor=500 is still the right default for v1.39.x.

## Test plan

- [x] `cargo test --features gpu-index --lib search::query` (21 pass, including new `test_cap_k_to_backend_trims_to_max_k`)
- [x] `cargo test --features gpu-index --lib --tests index::` (clean, including new `test_max_k_default_none`)
- [x] `cargo clippy --features gpu-index --lib -- -D warnings`
- [x] `cargo fmt --check`
- [x] v3.v2 test + dev floor sweeps verify cliff closure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
