### PR TITLE
fix(store): #1587 prune orphaned llm_summaries rows on reindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Store::prune_orphaned_llm_summaries() -> Result<u64>`** + auto-fire at end of `cqs index` (#1587). Deletes `llm_summaries` rows whose `content_hash` no longer matches any chunk. Each reindex that changes any code accumulates orphans; unpruned, the table grows arbitrarily larger than the corpus and `cqs stats llm_summary_count` (a row count) overstates real coverage. On the gemma slot before this fix: 14,400 rows / 13,175 distinct chunk hashes = 109% (vivid drift). Opt-out via `cqs index --no-prune-summaries` for cross-slot summary copy by content_hash.
+- **`Store::llm_summary_chunk_coverage()`** — counts chunks whose content_hash maps to at least one summary row, regardless of `purpose`. Honest per-chunk coverage that excludes orphans.
+- **`cqs stats --json`** exposes `llm_summary_chunks_covered` + `llm_summary_chunk_coverage_pct` alongside the existing `llm_summary_count` (which still counts rows including orphans for backward compatibility).
+
 ### Changed
 
 - **`identifier_lookup` SPLADE α default 1.00 → 0.85** (`src/search/router.rs`). After the post-v1.39.1 LLM summaries refresh on the gemma slot (60.25% → 68.70% per-chunk coverage), a paired α sweep on v3.v2 218q dual-judge (test+dev) showed both halves agreed more SPLADE helps for identifier lookups. Dev `identifier_lookup` R@5 0.8889 → 1.0000 (+11.1pp, 2 queries; all 18 dev identifier_lookup queries now in top-5). Test `identifier_lookup` R@1 0.7222 → 0.7778 (+5.6pp). No regressions on any metric or fixture. The α=0.80..0.90 plateau is flat at this fixture size, so 0.85 sits in the middle and tolerates classifier drift.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -760,6 +760,17 @@ pub(crate) struct IndexArgs {
     #[cfg(feature = "llm-summaries")]
     #[arg(long)]
     pub max_hyde: Option<usize>,
+    /// Skip the post-pipeline prune of orphaned `llm_summaries` rows (#1587).
+    ///
+    /// Default (when omitted): orphan rows whose `content_hash` no longer
+    /// matches any chunk are deleted at the end of the index pipeline so
+    /// `cqs stats` reports honest summary coverage. Pass `--no-prune-summaries`
+    /// when you plan to copy summaries to a sibling slot by content_hash —
+    /// orphaned rows there may match chunks in the destination slot, and
+    /// pruning before copy permanently loses those summaries (cross-slot
+    /// summary reuse is the only workflow this matters for).
+    #[arg(long)]
+    pub no_prune_summaries: bool,
     /// Project chunk embeddings into 2D via UMAP and write to `chunks.umap_x/umap_y`.
     ///
     /// Enables the `cqs serve` cluster view (`?view=cluster`). Requires

--- a/src/cli/commands/index/build.rs
+++ b/src/cli/commands/index/build.rs
@@ -687,6 +687,31 @@ pub(crate) fn cmd_index(cli: &Cli, args: &IndexArgs) -> Result<()> {
         tracing::warn!(error = %e, "cmd_index: final flush of summary queue failed; rows retained for next run");
     }
 
+    // #1587: prune orphaned llm_summaries rows whose content_hash no longer
+    // maps to any chunk. Each reindex that changes any code accumulates
+    // orphans (chunk content changed → new hash, old hash sticks around);
+    // unpruned, the table grows arbitrarily larger than the corpus and
+    // `cqs stats llm_summary_count` overstates real coverage. Runs after the
+    // final flush so any rows just written by the LLM passes are anchored
+    // to current chunks before we sweep.
+    //
+    // Opt-out via `--no-prune-summaries` (preserves orphans for cross-slot
+    // summary copy by content_hash — the only workflow that benefits from
+    // keeping them around).
+    if !args.no_prune_summaries {
+        match store.prune_orphaned_llm_summaries() {
+            Ok(0) => {}
+            Ok(pruned) => {
+                if !cli.quiet {
+                    println!("  Pruned {pruned} orphaned LLM summary rows");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "cmd_index: failed to prune orphaned llm_summaries; non-fatal");
+            }
+        }
+    }
+
     // Call-graph enrichment pass (SQ-4): re-embed chunks with caller/callee
     // context. #1452: also fires whenever any chunk is at `needs_embedding=1`
     // — the parser stage marks chunks unembedded when a `--llm-summaries`

--- a/src/cli/commands/index/stats.rs
+++ b/src/cli/commands/index/stats.rs
@@ -62,7 +62,21 @@ pub(crate) struct StatsOutput {
     /// (no GPU available, sub-threshold corpus, or persistence disabled).
     pub cagra_size_bytes: Option<u64>,
     /// Total rows in the `llm_summaries` table across all `purpose` values.
+    ///
+    /// Includes orphan rows (content_hash no longer matches any chunk) which
+    /// inflate this count over real coverage; see `llm_summary_chunks_covered`
+    /// and `llm_summary_chunk_coverage_pct` for the per-chunk number that
+    /// excludes orphans (#1587).
     pub llm_summary_count: usize,
+    /// Number of chunks that have at least one cached summary row matching
+    /// their `content_hash`, regardless of `purpose`. The numerator for the
+    /// honest "what fraction of the corpus has a summary" metric — orphans
+    /// don't contribute (#1587).
+    pub llm_summary_chunks_covered: usize,
+    /// `llm_summary_chunks_covered` as a percentage of `total_chunks`. `None`
+    /// when there are no chunks at all (avoids spurious 0/0 reporting on a
+    /// fresh DB).
+    pub llm_summary_chunk_coverage_pct: Option<f64>,
     pub schema_version: u32,
     // CLI-specific (batch omits these via Option)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -137,6 +151,18 @@ pub(crate) fn build_stats<Mode>(store: &cqs::Store<Mode>, cqs_dir: &Path) -> Res
             0
         }
     };
+    let llm_summary_chunks_covered = match store.llm_summary_chunk_coverage() {
+        Ok(n) => n as usize,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to count llm_summary chunk coverage");
+            0
+        }
+    };
+    let llm_summary_chunk_coverage_pct = if total_chunks > 0 {
+        Some((llm_summary_chunks_covered as f64 / total_chunks as f64) * 100.0)
+    } else {
+        None
+    };
 
     Ok(StatsOutput {
         total_chunks: total_chunks as usize,
@@ -170,6 +196,8 @@ pub(crate) fn build_stats<Mode>(store: &cqs::Store<Mode>, cqs_dir: &Path) -> Res
         hnsw_graph_bytes: file_size_bytes(&cqs_dir.join("index.hnsw.graph")),
         cagra_size_bytes: file_size_bytes(&cqs_dir.join("index.cagra")),
         llm_summary_count,
+        llm_summary_chunks_covered,
+        llm_summary_chunk_coverage_pct,
         // P3 #87: schema_version is read as i64 from SQLite; an explicit cast
         // would silently wrap a (logically impossible but observed-during-
         // migration-bugs) negative value. Surface the breach instead.
@@ -351,6 +379,8 @@ mod tests {
             hnsw_graph_bytes: None,
             cagra_size_bytes: None,
             llm_summary_count: 0,
+            llm_summary_chunks_covered: 0,
+            llm_summary_chunk_coverage_pct: None,
             schema_version: 17,
             stale_files: None,
             missing_files: None,
@@ -403,6 +433,8 @@ mod tests {
             hnsw_graph_bytes: Some(8_084_767),
             cagra_size_bytes: Some(67_527_348),
             llm_summary_count: 12_345,
+            llm_summary_chunks_covered: 11_500,
+            llm_summary_chunk_coverage_pct: Some(95.83),
             schema_version: 17,
             stale_files: Some(3),
             missing_files: Some(1),

--- a/src/cli/commands/infra/model.rs
+++ b/src/cli/commands/infra/model.rs
@@ -629,6 +629,9 @@ fn reindex_with_new_model(cli: &Cli, new_cfg: ModelConfig) -> Result<()> {
         hyde_queries: false,
         #[cfg(feature = "llm-summaries")]
         max_hyde: None,
+        // Model swap reindexes from scratch (--force) and won't run any LLM
+        // pass, so the prune is a no-op here. Default-on is fine.
+        no_prune_summaries: false,
         umap: false,
         // P2.12: model swap drives a programmatic reindex; we never want
         // the swap path to spit a JSON envelope to stdout (the caller is

--- a/src/store/metadata.rs
+++ b/src/store/metadata.rs
@@ -226,12 +226,37 @@ impl<Mode> Store<Mode> {
     /// Each row is a `(content_hash, purpose)` pair, so the count includes
     /// every cached summary regardless of purpose (`summary`, `doc-comment`,
     /// `hyde`, etc.). Returns 0 when no SQ-6/SQ-8/SQ-10b pass has run yet.
+    ///
+    /// **Includes orphans**: rows whose `content_hash` no longer matches any
+    /// chunk are counted here. For per-chunk coverage that ignores orphans,
+    /// use [`llm_summary_chunk_coverage`](Self::llm_summary_chunk_coverage).
     pub fn llm_summary_count(&self) -> Result<u64, StoreError> {
         let _span = tracing::debug_span!("llm_summary_count").entered();
         self.rt.block_on(async {
             let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM llm_summaries")
                 .fetch_one(&self.pool)
                 .await?;
+            Ok(row.0 as u64)
+        })
+    }
+
+    /// Count chunks that have at least one `llm_summaries` row matching their
+    /// `content_hash`, regardless of `purpose`.
+    ///
+    /// This is the honest "how much of the current corpus has a cached
+    /// summary" metric — orphan rows (content_hash no longer in `chunks`) do
+    /// not inflate this number, unlike [`llm_summary_count`](Self::llm_summary_count).
+    /// `cqs stats` exposes both so operators can see when orphan accumulation
+    /// is overstating the row-count metric (issue #1587).
+    pub fn llm_summary_chunk_coverage(&self) -> Result<u64, StoreError> {
+        let _span = tracing::debug_span!("llm_summary_chunk_coverage").entered();
+        self.rt.block_on(async {
+            let row: (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM chunks \
+                 WHERE content_hash IN (SELECT content_hash FROM llm_summaries)",
+            )
+            .fetch_one(&self.pool)
+            .await?;
             Ok(row.0 as u64)
         })
     }
@@ -545,6 +570,43 @@ impl Store<ReadWrite> {
     /// Store a pending HyDE batch ID so interrupted processes can resume polling.
     pub fn set_pending_hyde_batch_id(&self, batch_id: Option<&str>) -> Result<(), StoreError> {
         self.set_metadata_opt("pending_hyde_batch", batch_id)
+    }
+
+    /// Delete `llm_summaries` rows whose `content_hash` no longer matches any
+    /// chunk in the index. Returns the number of rows deleted (#1587).
+    ///
+    /// Why it's needed: `llm_summaries` is keyed by `(content_hash, purpose)`,
+    /// so when a chunk's content changes (refactor, audit-cycle line shift,
+    /// formatter pass) the old summary stays cached under the old hash forever
+    /// even though no current chunk maps to it. Each `cqs index --llm-summaries`
+    /// pass adds new rows for the new content_hashes without ever deleting
+    /// the orphans, so the table can grow arbitrarily larger than the corpus.
+    ///
+    /// The fix is a single DELETE — no transaction needed because the
+    /// statement is its own atomic unit and orphans are by definition not
+    /// referenced by anything else. Wired into `cmd_index --llm-summaries`
+    /// at the end of the enrichment pass so refreshes leave the table
+    /// consistent without operator action.
+    ///
+    /// Cross-slot summary copy by content_hash (memory note `feedback_summary_cross_slot`)
+    /// is the only workflow that benefits from keeping orphans around — copy
+    /// before pruning. The pipeline auto-fire is opt-out via
+    /// `--no-prune-summaries` for that case.
+    pub fn prune_orphaned_llm_summaries(&self) -> Result<u64, StoreError> {
+        let _span = tracing::info_span!("prune_orphaned_llm_summaries").entered();
+        self.rt.block_on(async {
+            let result = sqlx::query(
+                "DELETE FROM llm_summaries \
+                 WHERE content_hash NOT IN (SELECT content_hash FROM chunks)",
+            )
+            .execute(&self.pool)
+            .await?;
+            let pruned = result.rows_affected();
+            if pruned > 0 {
+                tracing::info!(pruned, "Pruned orphaned llm_summaries rows");
+            }
+            Ok(pruned)
+        })
     }
 }
 
@@ -1094,5 +1156,120 @@ mod tests {
             }
         });
         assert_eq!(store.llm_summary_count().unwrap(), 3);
+    }
+
+    /// #1587: orphan summaries (content_hash not in chunks) must be deletable
+    /// without touching live rows. Each `cqs index --llm-summaries` pass
+    /// folds this into the enrichment phase.
+    #[test]
+    fn test_prune_orphaned_llm_summaries() {
+        let (store, _dir) = make_test_store_initialized();
+        let now = chrono::Utc::now().to_rfc3339();
+        let dim = ModelInfo::default().dimensions;
+        let embedding_bytes: Vec<u8> = bytemuck::cast_slice(&vec![0.1f32; dim]).to_vec();
+
+        // 2 chunks (live_a, live_b) with content_hashes hash_live_a / hash_live_b.
+        // 4 summary rows: 1 live (hash_live_a/summary), 1 live with second
+        // purpose (hash_live_a/doc-comment), 1 live (hash_live_b/summary),
+        // 1 orphan (hash_orphan/summary).
+        store.rt.block_on(async {
+            for (chunk_id, hash) in [("live_a", "hash_live_a"), ("live_b", "hash_live_b")] {
+                sqlx::query(
+                    "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name,
+                         signature, content, content_hash, doc, line_start, line_end, embedding,
+                         source_mtime, created_at, updated_at)
+                         VALUES (?1, ?1, 'file', 'rust', 'function', ?1,
+                         '', '', ?2, NULL, 1, 10, ?3, 0, ?4, ?4)",
+                )
+                .bind(chunk_id)
+                .bind(hash)
+                .bind(&embedding_bytes)
+                .bind(&now)
+                .execute(&store.pool)
+                .await
+                .unwrap();
+            }
+            for (hash, purpose) in [
+                ("hash_live_a", "summary"),
+                ("hash_live_a", "doc-comment"),
+                ("hash_live_b", "summary"),
+                ("hash_orphan", "summary"),
+            ] {
+                sqlx::query(
+                    "INSERT INTO llm_summaries (content_hash, purpose, summary, model, created_at)
+                     VALUES (?1, ?2, 'test', 'test-model', ?3)",
+                )
+                .bind(hash)
+                .bind(purpose)
+                .bind(&now)
+                .execute(&store.pool)
+                .await
+                .unwrap();
+            }
+        });
+
+        assert_eq!(store.llm_summary_count().unwrap(), 4);
+        // 2 chunks, both live in summaries — coverage 2/2.
+        assert_eq!(store.llm_summary_chunk_coverage().unwrap(), 2);
+
+        // Prune drops only the orphan.
+        let pruned = store.prune_orphaned_llm_summaries().unwrap();
+        assert_eq!(pruned, 1, "exactly one orphan should be deleted");
+
+        // Live rows survive.
+        assert_eq!(store.llm_summary_count().unwrap(), 3);
+        assert_eq!(store.llm_summary_chunk_coverage().unwrap(), 2);
+
+        // Idempotent: running again deletes nothing.
+        assert_eq!(store.prune_orphaned_llm_summaries().unwrap(), 0);
+    }
+
+    /// `llm_summary_chunk_coverage` must reflect how many CHUNKS have a
+    /// summary, not how many summary rows reference chunks.
+    #[test]
+    fn test_llm_summary_chunk_coverage_per_chunk() {
+        let (store, _dir) = make_test_store_initialized();
+        let now = chrono::Utc::now().to_rfc3339();
+        let dim = ModelInfo::default().dimensions;
+        let embedding_bytes: Vec<u8> = bytemuck::cast_slice(&vec![0.1f32; dim]).to_vec();
+
+        store.rt.block_on(async {
+            // 3 chunks: c1 + c2 share a content_hash (duplicate code), c3
+            // is unique. Total chunks = 3, distinct hashes = 2.
+            for (chunk_id, hash) in [
+                ("c1", "shared_hash"),
+                ("c2", "shared_hash"),
+                ("c3", "unique"),
+            ] {
+                sqlx::query(
+                    "INSERT INTO chunks (id, origin, source_type, language, chunk_type, name,
+                         signature, content, content_hash, doc, line_start, line_end, embedding,
+                         source_mtime, created_at, updated_at)
+                         VALUES (?1, ?1, 'file', 'rust', 'function', ?1,
+                         '', '', ?2, NULL, 1, 10, ?3, 0, ?4, ?4)",
+                )
+                .bind(chunk_id)
+                .bind(hash)
+                .bind(&embedding_bytes)
+                .bind(&now)
+                .execute(&store.pool)
+                .await
+                .unwrap();
+            }
+            // Summary only for shared_hash. Both c1 AND c2 should count.
+            sqlx::query(
+                "INSERT INTO llm_summaries (content_hash, purpose, summary, model, created_at)
+                 VALUES ('shared_hash', 'summary', 'x', 'm', ?1)",
+            )
+            .bind(&now)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        });
+
+        // 2 of 3 chunks have a summary (c1 + c2 via shared_hash).
+        assert_eq!(store.llm_summary_chunk_coverage().unwrap(), 2);
+        // Row count is 1.
+        assert_eq!(store.llm_summary_count().unwrap(), 1);
     }
 }


### PR DESCRIPTION
Closes #1587.

## Summary

`llm_summaries` is keyed by `(content_hash, purpose)`. When chunk content changes (refactor, audit-cycle line shift, formatter pass), a new row gets cached under the new hash but the old hash sticks around forever. Each reindex adds without ever pruning, so the table grows arbitrarily larger than the corpus.

Concrete state on the gemma slot when the issue was filed:

```
chunks total:           14,244
summary rows total:     13,231
distinct hashes covered: 13,231 / 13,175 unique chunk hashes = 100.43%   ← 56 orphans
chunks with a summary:  8,582 (60.25%)   ← honest coverage
```

After the 2026-05-08 LLM summaries refresh, the orphan count grew to ~1,225 (109% drift). Each refresh leaves more behind.

## What landed

Three pieces, smallest first.

### 1. `Store::prune_orphaned_llm_summaries() -> Result<u64>`

```rust
DELETE FROM llm_summaries WHERE content_hash NOT IN (SELECT content_hash FROM chunks)
```

One statement, no transaction needed (atomic by itself; orphans are by definition not joined to anything else). Returns the deleted row count for tracing.

### 2. Auto-fire at end of `cqs index`

Folded into `cmd_index` after the final flush of `pending_summaries`. Default-on; opt-out via `--no-prune-summaries`.

The opt-out exists for the cross-slot summary copy workflow (memory note `feedback_summary_cross_slot`) — keeping orphans lets a future-created sibling slot inherit them by content_hash before its first reindex. The default still tilts toward honest coverage; cross-slot reuse is a manual workflow with `--no-prune-summaries` available when you want it.

### 3. Honest coverage in `cqs stats`

Added `Store::llm_summary_chunk_coverage()` — counts chunks with a content_hash matching `llm_summaries`, regardless of purpose. `cqs stats --json` exposes:

- `llm_summary_count` (existing) — row count, INCLUDES orphans, kept for backward compatibility.
- `llm_summary_chunks_covered` (new) — per-chunk distinct count.
- `llm_summary_chunk_coverage_pct` (new) — `chunks_covered / total_chunks`.

So `cqs stats` now reports both numbers and operators can see drift directly.

## Tests

Three unit tests in `src/store/metadata.rs`:

- `test_prune_orphaned_llm_summaries` — 2 chunks + 4 summary rows (3 live across 2 chunks, 1 orphan). Prune deletes exactly 1, live rows survive, second prune is idempotent.
- `test_llm_summary_chunk_coverage_per_chunk` — 3 chunks where 2 share a content_hash, 1 summary row → 2/3 chunks covered (per-chunk arithmetic, not row count).
- `test_llm_summary_count_includes_all_purposes` (existing) still passes — row-count semantics unchanged.

## Out of scope

- Migrating `llm_summaries` to `chunk_id` PK instead of `content_hash` — loses cross-slot reuse, separate design call (out-of-scope per #1587).
- Pruning during the watch reindex path — daemon reindex is per-file scoped, not whole-corpus, so a per-file prune would do nothing useful. Once-per-`cqs index` is the right cadence.

## Test plan

- [x] `cargo build --features gpu-index`
- [x] `cargo test --features gpu-index --lib store::metadata` (39 pass)
- [x] `cargo test --features gpu-index --lib build_stats` (1 pass)
- [x] `cargo fmt`
- [ ] Live demo on gemma slot (reindex with new binary, validate `cqs stats` reports the post-prune coverage delta) — running

🤖 Generated with [Claude Code](https://claude.com/claude-code)
