### PR TITLE
chore: Release v1.39.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.39.2] - 2026-05-08
+
+Patch release. Two follow-ons to v1.39.1's CAGRA cliff fix, both surfaced from the same exploratory loop: (1) `identifier_lookup` SPLADE α retune 1.00 → 0.85 from a paired test+dev sweep on v3.v2 218q (#1588 — closes dev category R@5 to 100%, no regressions); (2) auto-pruning of orphaned `llm_summaries` rows accumulated across reindexes (#1589, closes #1587 — the gemma slot had 5,083 orphans, now auto-pruned at end of every `cqs index --llm-summaries`).
+
 ### Added
 
 - **`Store::prune_orphaned_llm_summaries() -> Result<u64>`** + auto-fire at end of `cqs index` (#1587). Deletes `llm_summaries` rows whose `content_hash` no longer matches any chunk. Each reindex that changes any code accumulates orphans; unpruned, the table grows arbitrarily larger than the corpus and `cqs stats llm_summary_count` (a row count) overstates real coverage. On the gemma slot before this fix: 14,400 rows / 13,175 distinct chunk hashes = 109% (vivid drift). Opt-out via `cqs index --no-prune-summaries` for cross-slot summary copy by content_hash.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.39.1"
+version = "1.39.2"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cqs-macros"]
 
 [package]
 name = "cqs"
-version = "1.39.1"
+version = "1.39.2"
 edition = "2021"
 rust-version = "1.95"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 46.3% R@1 / 74.8% R@5 / 86.2% R@20 on v3.v2 dual-judge code-search (218 queries, EmbeddingGemma-300m default with per-category SPLADE α including identifier_lookup retune in v1.39.x). Daemon mode (3-19ms queries). Local-first, GPU-accelerated."


### PR DESCRIPTION
## Summary

Patch release v1.39.2. Two follow-ons to v1.39.1's CAGRA cliff fix, both from the same exploratory loop:

1. **#1588** — `identifier_lookup` SPLADE α retune 1.00 → 0.85
2. **#1589** — orphan `llm_summaries` GC (closes #1587)

## Numbers

**α retune (#1588)** — paired test+dev sweep on v3.v2 218q dual-judge, post-LLM-summaries-refresh:

| Metric | Baseline (α=1.00) | α=0.85 | Δ |
|---|---:|---:|---:|
| dev `identifier_lookup` R@5 (n=18) | 0.8889 | **1.0000** | **+11.1pp (2 queries)** |
| test `identifier_lookup` R@1 (n=18) | 0.7222 | 0.7778 | +5.6pp (1 query) |
| dev overall R@5 (n=109) | 0.7706 | 0.7890 | +1.83pp |
| test overall R@1 (n=109) | 0.4037 | 0.4128 | +0.91pp |

Zero regressions on any metric. The α=0.80..0.90 plateau is flat — 0.85 sits in the middle so future classifier drift stays on the plateau.

**Orphan GC (#1589)** — live demo on gemma slot during this PR's prep:

| Metric | Pre-prune | Post-prune | Δ |
|---|---:|---:|---:|
| `llm_summary_count` (rows) | 14,400 | 9,317 | **-5,083 (orphans deleted)** |
| `llm_summary_chunks_covered` | 9,751 | 9,750 | preserved |
| `llm_summary_chunk_coverage_pct` | 68.64% | 68.63% | preserved |

Coverage % unchanged (correct — pruning orphans drops no live data). Auto-fires at end of every `cqs index --llm-summaries`; opt-out via `--no-prune-summaries`. New `cqs stats --json` fields `llm_summary_chunks_covered` + `llm_summary_chunk_coverage_pct` expose the honest per-chunk number alongside the row-count `llm_summary_count` (kept for backward compat).

## Loop arc

Single session, no version bumps in between #1588/#1589/v1.39.2:

1. User asked about k*2 floor → ef sweep showed hnsw_rs internally floors ef to k → pivot to candidate-floor sweep → CAGRA itopk_max=441 cliff at floor=442 → v1.39.1 cliff fix (#1584).
2. Refresh LLM summaries on gemma slot to validate post-fix stack → discovered honest coverage was 60.25% not the 92.9% row-count metric reported → filed #1587 + closed in #1589.
3. Paired α sweep on the post-refresh stack → only `identifier_lookup` had cross-fixture agreement on a retune → shipped as #1588.

## Test plan

- [x] `cargo build --features gpu-index` (1.39.2 builds clean)
- [x] `cargo test --features gpu-index --lib search::router` (60 pass)
- [x] `cargo test --features gpu-index --lib store::metadata` (39 pass — incl. 3 new GC tests)
- [x] `cargo fmt --check` clean
- [x] α retune validated via paired test+dev sweep (cross-fixture agreement)
- [x] GC validated end-to-end on gemma slot (5,083 orphans deleted, coverage % preserved)
- [x] Cargo.lock refreshed via `cargo check --features gpu-index`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
