### PR TITLE
chore(gitignore): re-ignore tools/screw-mcp/ + add .screw-tape/ cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,14 @@ samples/
 # Note: must be `tools/*` (contents) not `tools/` (the dir itself) so
 # negative-pattern exceptions can re-include specific subdirectories.
 tools/*
-!tools/screw-mcp/
+
+# screw-tape (designed-not-built; lives outside main repo when implemented):
+# - tools/screw-mcp/ is fully gitignored — DESIGN.md was committed earlier
+#   and stays in history, but no further files in that folder track.
+# - .screw-tape/ is the per-project runtime cache the design proposes
+#   (downloaded audio, intermediate stems, derived stretches). Defensive
+#   ignore so it can't pollute cqs commits before the tool is even built.
+.screw-tape/
 
 # ORT CUDA provider symlinks (created at runtime by ensure_ort_provider_libs)
 libonnxruntime_providers_*.so


### PR DESCRIPTION
## Summary

Per user feedback: "can we gitignore the screwtape folder, so it doesn't pollute the main repo?"

- Removed `!tools/screw-mcp/` exemption so any new files added under that folder are no longer auto-tracked. The design lives outside the cqs repo when actually implemented.
- `DESIGN.md` stays in history (already committed via #1598 / #1599) but further changes there won't surface in `git status` from this commit forward.
- Added `.screw-tape/` to gitignore — the per-project runtime cache the DESIGN.md proposes (downloaded audio, intermediate stems, derived stretches). Defensive: the folder doesn't exist yet, but the rule prevents accidental pollution if anyone runs the tool from this repo.

## Test plan

- [x] `git check-ignore -v tools/screw-mcp/anything-new.txt` → matches `tools/*`
- [x] `git check-ignore -v .screw-tape/cache.bin` → matches `.screw-tape/`
- [x] `git ls-files tools/screw-mcp/` → still lists `DESIGN.md` (already-tracked file is preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
