### PR TITLE
chore(eval): refresh v3.v2 fixture line numbers — agg R@K +6.4/+2.7/+3.2pp

### DIFF
--- a/evals/queries/v3_dev.diff.json
+++ b/evals/queries/v3_dev.diff.json
@@ -1,12 +1,12 @@
 {
-  "generated_at": "2026-04-19T21:58:39",
+  "generated_at": "2026-05-08T03:51:43",
   "source": "v3_dev.json",
   "k": 50,
   "counts": {
-    "strict": 49,
+    "strict": 33,
     "basename": 1,
-    "name": 52,
-    "none": 7
+    "name": 71,
+    "none": 4
   },
   "records": [
     {
@@ -32,13 +32,21 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 24
+        "line_start": 36
       }
     },
     {
       "query": "Rust implementation of VectorIndex for CagraIndex compared to Java",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/cagra.rs",
+        "line_start": 471
+      },
+      "new": {
+        "origin": "src/cagra.rs",
+        "line_start": 597
+      }
     },
     {
       "query": "methods on EmbeddingCache that take a slice of tuples",
@@ -50,21 +58,13 @@
       },
       "new": {
         "origin": "src/cache.rs",
-        "line_start": 51
+        "line_start": 203
       }
     },
     {
       "query": "functions that use argparse AND define a --config argument",
-      "match_kind": "name",
-      "action": "updated",
-      "old": {
-        "origin": "evals/run_ablation.py",
-        "line_start": 33
-      },
-      "new": {
-        "origin": "evals/calibrate_reranker_labels.py",
-        "line_start": 858
-      }
+      "match_kind": "strict",
+      "action": "no_change"
     },
     {
       "query": "struct definitions in src/impact",
@@ -76,7 +76,7 @@
       },
       "new": {
         "origin": "src/cli/args.rs",
-        "line_start": 518
+        "line_start": 665
       }
     },
     {
@@ -89,7 +89,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 175
+        "line_start": 208
       }
     },
     {
@@ -108,22 +108,29 @@
     },
     {
       "query": "GPU accelerated approximate nearest neighbor index",
-      "match_kind": "none",
-      "action": "unresolved",
-      "gold_chunk": {
-        "id": null,
-        "name": "build_vector_index_with_config",
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
         "origin": "src/cli/store.rs",
-        "language": "rust",
-        "chunk_type": "function",
-        "line_start": 247,
-        "line_end": 402
+        "line_start": 247
+      },
+      "new": {
+        "origin": "src/cli/store.rs",
+        "line_start": 430
       }
     },
     {
       "query": "how does multi-index search merge results from project and reference indexes",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/reference.rs",
+        "line_start": 291
+      },
+      "new": {
+        "origin": "src/reference.rs",
+        "line_start": 342
+      }
     },
     {
       "query": "LLMClient implementation without specific identifier",
@@ -137,8 +144,16 @@
     },
     {
       "query": "EmbedStageContext",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/cli/pipeline/types.rs",
+        "line_start": 67
+      },
+      "new": {
+        "origin": "src/cli/pipeline/types.rs",
+        "line_start": 79
+      }
     },
     {
       "query": "check if a file needs reindexing based on modification time",
@@ -155,18 +170,42 @@
     },
     {
       "query": "ChunkSummary",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/store/helpers/types.rs",
+        "line_start": 15
+      },
+      "new": {
+        "origin": "src/store/helpers/types.rs",
+        "line_start": 16
+      }
     },
     {
       "query": "SearchFilter struct",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/store/helpers/search_filter.rs",
+        "line_start": 16
+      },
+      "new": {
+        "origin": "src/store/helpers/search_filter.rs",
+        "line_start": 27
+      }
     },
     {
       "query": "how does the explain command assemble a function card with callers callees and similar",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/nl/mod.rs",
+        "line_start": 65
+      },
+      "new": {
+        "origin": "src/nl/mod.rs",
+        "line_start": 44
+      }
     },
     {
       "query": "function type definitions and type aliases in the codebase",
@@ -197,13 +236,22 @@
       },
       "new": {
         "origin": "src/language/languages.rs",
-        "line_start": 4655
+        "line_start": 4692
       }
     },
     {
       "query": "print pass rate without using a loop",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "none",
+      "action": "unresolved",
+      "gold_chunk": {
+        "id": "evals/generate_from_chunks.py:210:91938f19:w1",
+        "name": "main",
+        "origin": "evals/generate_from_chunks.py",
+        "language": "python",
+        "chunk_type": "function",
+        "line_start": 210,
+        "line_end": 274
+      }
     },
     {
       "query": "Python equivalent of an async generate function that takes signature and preview strings",
@@ -246,7 +294,7 @@
       },
       "new": {
         "origin": "src/cache.rs",
-        "line_start": 982
+        "line_start": 215
       }
     },
     {
@@ -259,7 +307,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 131
+        "line_start": 164
       }
     },
     {
@@ -272,7 +320,7 @@
       },
       "new": {
         "origin": "src/cache.rs",
-        "line_start": 42
+        "line_start": 189
       }
     },
     {
@@ -285,7 +333,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 64
+        "line_start": 95
       }
     },
     {
@@ -295,13 +343,29 @@
     },
     {
       "query": "search by file path glob not by function name",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/note.rs",
+        "line_start": 376
+      },
+      "new": {
+        "origin": "src/note.rs",
+        "line_start": 525
+      }
     },
     {
       "query": "methods for formatting",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/store/calls/mod.rs",
+        "line_start": 60
+      },
+      "new": {
+        "origin": "src/cli/definitions.rs",
+        "line_start": 30
+      }
     },
     {
       "query": "shared context struct that holds store embedder and paths for commands",
@@ -326,21 +390,20 @@
       },
       "new": {
         "origin": "src/nl/mod.rs",
-        "line_start": 992
+        "line_start": 1007
       }
     },
     {
       "query": "function named reindex AND takes optional model argument",
-      "match_kind": "none",
-      "action": "unresolved",
-      "gold_chunk": {
-        "id": "evals/run_ablation.py:155:9ff05e71",
-        "name": "reindex",
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
         "origin": "evals/run_ablation.py",
-        "language": "python",
-        "chunk_type": "function",
-        "line_start": 155,
-        "line_end": 183
+        "line_start": 155
+      },
+      "new": {
+        "origin": "evals/run_ablation.py",
+        "line_start": 153
       }
     },
     {
@@ -363,7 +426,7 @@
       },
       "new": {
         "origin": "src/cli/pipeline/embedding.rs",
-        "line_start": 349
+        "line_start": 427
       }
     },
     {
@@ -381,8 +444,16 @@
     },
     {
       "query": "crossbeam channel usage for pipeline message passing",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/cli/pipeline/mod.rs",
+        "line_start": 43
+      },
+      "new": {
+        "origin": "src/cli/pipeline/mod.rs",
+        "line_start": 52
+      }
     },
     {
       "query": "functions named main AND print dense x sparse ablation",
@@ -396,22 +467,21 @@
     },
     {
       "query": "methods on HnswIndex",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/hnsw/persist.rs",
+        "line_start": 172
+      },
+      "new": {
+        "origin": "src/hnsw/build.rs",
+        "line_start": 11
+      }
     },
     {
       "query": "how to implement an async LLM client with caching in Python vs Go",
-      "match_kind": "none",
-      "action": "unresolved",
-      "gold_chunk": {
-        "id": "evals/llm_client.py:111:b21042fa:w1",
-        "name": "LLMClient",
-        "origin": "evals/llm_client.py",
-        "language": "python",
-        "chunk_type": "class",
-        "line_start": 111,
-        "line_end": 286
-      }
+      "match_kind": "strict",
+      "action": "no_change"
     },
     {
       "query": "llm based query classification",
@@ -433,7 +503,7 @@
       },
       "new": {
         "origin": "src/language/languages.rs",
-        "line_start": 4092
+        "line_start": 4124
       }
     },
     {
@@ -456,7 +526,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 64
+        "line_start": 95
       }
     },
     {
@@ -466,8 +536,16 @@
     },
     {
       "query": "how does the notes system boost or demote search results based on sentiment",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/note.rs",
+        "line_start": 72
+      },
+      "new": {
+        "origin": "src/note.rs",
+        "line_start": 119
+      }
     },
     {
       "query": "collect events without adding to pending files if max is reached",
@@ -478,8 +556,8 @@
         "line_start": 1505
       },
       "new": {
-        "origin": "src/cli/watch.rs",
-        "line_start": 2022
+        "origin": "src/cli/watch/events.rs",
+        "line_start": 23
       }
     },
     {
@@ -492,7 +570,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 64
+        "line_start": 95
       }
     },
     {
@@ -510,7 +588,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 64
+        "line_start": 95
       }
     },
     {
@@ -522,8 +600,8 @@
         "line_start": 970
       },
       "new": {
-        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
-        "line_start": 767
+        "origin": "src/reranker.rs",
+        "line_start": 1156
       }
     },
     {
@@ -536,7 +614,7 @@
       },
       "new": {
         "origin": "src/parser/mod.rs",
-        "line_start": 257
+        "line_start": 265
       }
     },
     {
@@ -549,13 +627,21 @@
       },
       "new": {
         "origin": "src/search/router.rs",
-        "line_start": 549
+        "line_start": 934
       }
     },
     {
       "query": "function load_all_sparse_vectors in Store implementation",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/store/sparse.rs",
+        "line_start": 230
+      },
+      "new": {
+        "origin": "src/store/sparse.rs",
+        "line_start": 325
+      }
     },
     {
       "query": "def main function",
@@ -590,7 +676,7 @@
       },
       "new": {
         "origin": "src/parser/l5x.rs",
-        "line_start": 274
+        "line_start": 304
       }
     },
     {
@@ -603,7 +689,7 @@
       },
       "new": {
         "origin": "src/language/mod.rs",
-        "line_start": 862
+        "line_start": 910
       }
     },
     {
@@ -616,7 +702,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 103
+        "line_start": 134
       }
     },
     {
@@ -629,7 +715,7 @@
       },
       "new": {
         "origin": "src/store/migrations.rs",
-        "line_start": 291
+        "line_start": 472
       }
     },
     {
@@ -655,7 +741,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 131
+        "line_start": 164
       }
     },
     {
@@ -668,7 +754,7 @@
       },
       "new": {
         "origin": "src/cagra.rs",
-        "line_start": 471
+        "line_start": 751
       }
     },
     {
@@ -681,7 +767,7 @@
       },
       "new": {
         "origin": "src/language/languages.rs",
-        "line_start": 8217
+        "line_start": 8272
       }
     },
     {
@@ -722,13 +808,21 @@
       },
       "new": {
         "origin": "src/cache.rs",
-        "line_start": 30
+        "line_start": 84
       }
     },
     {
       "query": "focused read showing only a function and its type dependencies",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/impact/analysis.rs",
+        "line_start": 419
+      },
+      "new": {
+        "origin": "src/impact/analysis.rs",
+        "line_start": 436
+      }
     },
     {
       "query": "methods that return a list of queries AND filter by type",
@@ -742,16 +836,15 @@
     },
     {
       "query": "tables with a TEXT primary key and BLOB columns",
-      "match_kind": "none",
-      "action": "unresolved",
-      "gold_chunk": {
-        "id": "src/schema.sql:22:ea43482c",
-        "name": "chunks",
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
         "origin": "src/schema.sql",
-        "language": "sql",
-        "chunk_type": "struct",
-        "line_start": 22,
-        "line_end": 45
+        "line_start": 22
+      },
+      "new": {
+        "origin": "src/schema.sql",
+        "line_start": 41
       }
     },
     {
@@ -769,7 +862,7 @@
       },
       "new": {
         "origin": "src/store/sparse.rs",
-        "line_start": 321
+        "line_start": 437
       }
     },
     {
@@ -787,7 +880,7 @@
       },
       "new": {
         "origin": "src/cli/commands/resolve.rs",
-        "line_start": 28
+        "line_start": 41
       }
     },
     {
@@ -800,7 +893,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 74
+        "line_start": 105
       }
     },
     {
@@ -813,7 +906,7 @@
       },
       "new": {
         "origin": "src/search/router.rs",
-        "line_start": 367
+        "line_start": 447
       }
     },
     {
@@ -831,18 +924,34 @@
       },
       "new": {
         "origin": "src/nl/mod.rs",
-        "line_start": 655
+        "line_start": 664
       }
     },
     {
       "query": "implementations of VectorIndex AND CagraIndex",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/cagra.rs",
+        "line_start": 471
+      },
+      "new": {
+        "origin": "src/cagra.rs",
+        "line_start": 597
+      }
     },
     {
       "query": "run_index_pipeline",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/cli/pipeline/mod.rs",
+        "line_start": 43
+      },
+      "new": {
+        "origin": "src/cli/pipeline/mod.rs",
+        "line_start": 52
+      }
     },
     {
       "query": "how to implement a file watch command in Rust vs Go",
@@ -853,8 +962,8 @@
         "line_start": 573
       },
       "new": {
-        "origin": "src/cli/watch.rs",
-        "line_start": 1170
+        "origin": "src/cli/watch/mod.rs",
+        "line_start": 403
       }
     },
     {
@@ -871,27 +980,34 @@
         "line_start": 1601
       },
       "new": {
-        "origin": "src/cli/watch.rs",
-        "line_start": 2118
+        "origin": "src/cli/watch/events.rs",
+        "line_start": 168
       }
     },
     {
       "query": "find_dead_code",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/cli/batch/handlers/analysis.rs",
+        "line_start": 23
+      },
+      "new": {
+        "origin": "src/cli/batch/handlers/analysis.rs",
+        "line_start": 26
+      }
     },
     {
       "query": "content based fingerprinting",
-      "match_kind": "none",
-      "action": "unresolved",
-      "gold_chunk": {
-        "id": "src/embedder/mod.rs:349:3a5cb4fc:w1",
-        "name": "model_fingerprint",
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
         "origin": "src/embedder/mod.rs",
-        "language": "rust",
-        "chunk_type": "method",
-        "line_start": 349,
-        "line_end": 423
+        "line_start": 349
+      },
+      "new": {
+        "origin": "src/embedder/mod.rs",
+        "line_start": 487
       }
     },
     {
@@ -904,13 +1020,21 @@
       },
       "new": {
         "origin": "src/reranker.rs",
-        "line_start": 487
+        "line_start": 738
       }
     },
     {
       "query": "methods in NameMatcher impl",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/search/scoring/name_match.rs",
+        "line_start": 98
+      },
+      "new": {
+        "origin": "src/search/scoring/name_match.rs",
+        "line_start": 101
+      }
     },
     {
       "query": "IndexStats",
@@ -922,7 +1046,7 @@
       },
       "new": {
         "origin": "src/store/helpers/types.rs",
-        "line_start": 399
+        "line_start": 591
       }
     },
     {
@@ -935,7 +1059,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 142
+        "line_start": 175
       }
     },
     {
@@ -948,7 +1072,7 @@
       },
       "new": {
         "origin": "src/nl/mod.rs",
-        "line_start": 655
+        "line_start": 664
       }
     },
     {
@@ -971,20 +1095,21 @@
       },
       "new": {
         "origin": "src/cache.rs",
-        "line_start": 404
+        "line_start": 784
       }
     },
     {
       "query": "lazy model loading to avoid startup overhead for simple commands",
-      "match_kind": "name",
-      "action": "updated",
-      "old": {
+      "match_kind": "none",
+      "action": "unresolved",
+      "gold_chunk": {
+        "id": null,
+        "name": "BatchContext",
         "origin": ".claude/worktrees/agent-a7cedd3c/src/cli/batch/mod.rs",
-        "line_start": 170
-      },
-      "new": {
-        "origin": "src/cli/batch/mod.rs",
-        "line_start": 222
+        "language": "rust",
+        "chunk_type": "struct",
+        "line_start": 170,
+        "line_end": 231
       }
     },
     {
@@ -1002,7 +1127,7 @@
       },
       "new": {
         "origin": "src/cli/batch/pipeline.rs",
-        "line_start": 398
+        "line_start": 416
       }
     },
     {
@@ -1015,7 +1140,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 86
+        "line_start": 117
       }
     },
     {
@@ -1028,7 +1153,7 @@
       },
       "new": {
         "origin": "src/cli/display.rs",
-        "line_start": 397
+        "line_start": 533
       }
     },
     {

--- a/evals/queries/v3_dev.v2.json
+++ b/evals/queries/v3_dev.v2.json
@@ -97,7 +97,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 17,
           "new_origin": "src/schema.sql",
-          "new_line_start": 24
+          "new_line_start": 36
         }
       },
       "judges": {
@@ -143,13 +143,13 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:24:regen",
+        "id": "src/schema.sql:36:regen",
         "name": "metadata",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 27,
-        "line_end": 30
+        "line_start": 36,
+        "line_end": 39
       },
       "gold_chunk_source": "consensus"
     },
@@ -159,7 +159,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "cross_language",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/cagra.rs",
+          "old_line_start": 471,
+          "new_origin": "src/cagra.rs",
+          "new_line_start": 597
+        }
       },
       "judges": {
         "claude": {
@@ -200,13 +207,13 @@
       "pool_size": 22,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cagra.rs:471:7412f1b2:w0",
+        "id": "src/cagra.rs:597:regen",
         "name": "CagraIndex",
         "origin": "src/cagra.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 490,
-        "line_end": 599
+        "line_start": 597,
+        "line_end": 743
       },
       "gold_chunk_source": "consensus"
     },
@@ -222,7 +229,7 @@
           "old_origin": "src/cache.rs",
           "old_line_start": 49,
           "new_origin": "src/cache.rs",
-          "new_line_start": 51
+          "new_line_start": 203
         }
       },
       "judges": {
@@ -268,13 +275,13 @@
       "pool_size": 7,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cache.rs:51:regen",
+        "id": "src/cache.rs:203:regen",
         "name": "EmbeddingCache",
         "origin": "src/cache.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 57,
-        "line_end": 538
+        "line_start": 203,
+        "line_end": 1047
       },
       "gold_chunk_source": "consensus"
     },
@@ -284,14 +291,7 @@
       "source": "generated",
       "metadata": {
         "target_category": "multi_step",
-        "matched": true,
-        "regenerated_2026_04_17": {
-          "match_kind": "name",
-          "old_origin": "evals/run_ablation.py",
-          "old_line_start": 33,
-          "new_origin": "evals/calibrate_reranker_labels.py",
-          "new_line_start": 858
-        }
+        "matched": true
       },
       "judges": {
         "claude": {
@@ -332,13 +332,13 @@
       "pool_size": 31,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "evals/calibrate_reranker_labels.py:858:regen",
+        "id": "evals/run_ablation.py:33:75efbfad",
         "name": "parse_args",
-        "origin": "evals/calibrate_reranker_labels.py",
+        "origin": "evals/run_ablation.py",
         "language": "python",
         "chunk_type": "function",
-        "line_start": 858,
-        "line_end": 870
+        "line_start": 33,
+        "line_end": 64
       },
       "gold_chunk_source": "consensus"
     },
@@ -354,7 +354,7 @@
           "old_origin": "src/cli/args.rs",
           "old_line_start": 462,
           "new_origin": "src/cli/args.rs",
-          "new_line_start": 518
+          "new_line_start": 665
         }
       },
       "judges": {
@@ -400,13 +400,13 @@
       "pool_size": 41,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/args.rs:518:regen",
+        "id": "src/cli/args.rs:665:regen",
         "name": "ImpactDiffArgs",
         "origin": "src/cli/args.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 534,
-        "line_end": 541
+        "line_start": 665,
+        "line_end": 672
       },
       "gold_chunk_source": "consensus"
     },
@@ -422,7 +422,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 167,
           "new_origin": "src/schema.sql",
-          "new_line_start": 175
+          "new_line_start": 208
         }
       },
       "judges": {
@@ -468,13 +468,13 @@
       "pool_size": 26,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:175:regen",
+        "id": "src/schema.sql:208:regen",
         "name": "llm_summaries",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 180,
-        "line_end": 187
+        "line_start": 208,
+        "line_end": 215
       },
       "gold_chunk_source": "consensus"
     },
@@ -544,7 +544,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031081,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/cli/store.rs",
+          "old_line_start": 247,
+          "new_origin": "src/cli/store.rs",
+          "new_line_start": 430
+        }
       },
       "judges": {
         "claude": {
@@ -585,16 +592,15 @@
       "pool_size": 33,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/cli/store.rs:430:regen",
         "name": "build_vector_index_with_config",
         "origin": "src/cli/store.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 316,
-        "line_end": 469
+        "line_start": 430,
+        "line_end": 462
       },
-      "gold_chunk_source": "consensus",
-      "_unresolved": true
+      "gold_chunk_source": "consensus"
     },
     {
       "query": "how does multi-index search merge results from project and reference indexes",
@@ -602,7 +608,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031501,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/reference.rs",
+          "old_line_start": 291,
+          "new_origin": "src/reference.rs",
+          "new_line_start": 342
+        }
       },
       "judges": {
         "claude": {
@@ -647,13 +660,13 @@
       "pool_size": 33,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/reference.rs:342:regen",
         "name": "merge_results",
         "origin": "src/reference.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 291,
-        "line_end": 345
+        "line_start": 342,
+        "line_end": 396
       },
       "gold_chunk_source": "consensus"
     },
@@ -783,7 +796,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031304,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/cli/pipeline/types.rs",
+          "old_line_start": 67,
+          "new_origin": "src/cli/pipeline/types.rs",
+          "new_line_start": 79
+        }
       },
       "judges": {
         "claude": {
@@ -826,13 +846,13 @@
       "pool_size": 17,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/cli/pipeline/types.rs:79:regen",
         "name": "EmbedStageContext",
         "origin": "src/cli/pipeline/types.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 67,
-        "line_end": 72
+        "line_start": 79,
+        "line_end": 91
       },
       "gold_chunk_source": "consensus"
     },
@@ -910,7 +930,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031298,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/store/helpers/types.rs",
+          "old_line_start": 15,
+          "new_origin": "src/store/helpers/types.rs",
+          "new_line_start": 16
+        }
       },
       "judges": {
         "claude": {
@@ -953,13 +980,13 @@
       "pool_size": 34,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/store/helpers/types.rs:16:regen",
         "name": "ChunkSummary",
         "origin": "src/store/helpers/types.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 15,
-        "line_end": 49
+        "line_start": 16,
+        "line_end": 61
       },
       "gold_chunk_source": "consensus"
     },
@@ -969,7 +996,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031813,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/store/helpers/search_filter.rs",
+          "old_line_start": 16,
+          "new_origin": "src/store/helpers/search_filter.rs",
+          "new_line_start": 27
+        }
       },
       "judges": {
         "claude": {
@@ -1012,13 +1046,13 @@
       "pool_size": 33,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/store/helpers/search_filter.rs:27:regen",
         "name": "SearchFilter",
         "origin": "src/store/helpers/search_filter.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 16,
-        "line_end": 59
+        "line_start": 27,
+        "line_end": 80
       },
       "gold_chunk_source": "consensus"
     },
@@ -1028,7 +1062,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031660,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/nl/mod.rs",
+          "old_line_start": 65,
+          "new_origin": "src/nl/mod.rs",
+          "new_line_start": 44
+        }
       },
       "judges": {
         "claude": {
@@ -1071,13 +1112,13 @@
       "pool_size": 33,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/nl/mod.rs:44:regen",
         "name": "generate_nl_with_call_context_and_summary",
         "origin": "src/nl/mod.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 65,
-        "line_end": 154
+        "line_start": 44,
+        "line_end": 140
       },
       "gold_chunk_source": "consensus"
     },
@@ -1133,8 +1174,8 @@
         "origin": "src/hnsw/persist.rs",
         "language": "rust",
         "chunk_type": "typealias",
-        "line_start": 849,
-        "line_end": 849
+        "line_start": 753,
+        "line_end": 753
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -1210,7 +1251,7 @@
           "old_origin": "src/language/languages.rs",
           "old_line_start": 4529,
           "new_origin": "src/language/languages.rs",
-          "new_line_start": 4655
+          "new_line_start": 4692
         }
       },
       "judges": {
@@ -1254,13 +1295,13 @@
       "pool_size": 38,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/language/languages.rs:4655:regen",
+        "id": "src/language/languages.rs:4692:regen",
         "name": "extract_return_ocaml",
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 4662,
-        "line_end": 4681
+        "line_start": 4692,
+        "line_end": 4711
       },
       "gold_chunk_source": "consensus"
     },
@@ -1320,10 +1361,11 @@
         "origin": "evals/generate_from_chunks.py",
         "language": "python",
         "chunk_type": "function",
-        "line_start": 216,
-        "line_end": 286
+        "line_start": 210,
+        "line_end": 274
       },
-      "gold_chunk_source": "consensus"
+      "gold_chunk_source": "consensus",
+      "_unresolved": true
     },
     {
       "query": "Python equivalent of an async generate function that takes signature and preview strings",
@@ -1450,7 +1492,7 @@
         "language": "rust",
         "chunk_type": "struct",
         "line_start": 161,
-        "line_end": 166
+        "line_end": 172
       },
       "gold_chunk_source": "consensus"
     },
@@ -1534,7 +1576,7 @@
           "old_origin": ".claude/worktrees/agent-a7cedd3c/src/cache.rs",
           "old_line_start": 51,
           "new_origin": "src/cache.rs",
-          "new_line_start": 982
+          "new_line_start": 215
         }
       },
       "judges": {
@@ -1580,13 +1622,13 @@
       "pool_size": 31,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cache.rs:982:regen",
+        "id": "src/cache.rs:215:regen",
         "name": "default_path",
         "origin": "src/cache.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 1052,
-        "line_end": 1056
+        "line_start": 215,
+        "line_end": 223
       },
       "gold_chunk_source": "consensus"
     },
@@ -1602,7 +1644,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 123,
           "new_origin": "src/schema.sql",
-          "new_line_start": 131
+          "new_line_start": 164
         }
       },
       "judges": {
@@ -1644,13 +1686,13 @@
       "pool_size": 38,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:131:regen",
+        "id": "src/schema.sql:164:regen",
         "name": "notes_fts",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 136,
-        "line_end": 140
+        "line_start": 164,
+        "line_end": 168
       },
       "gold_chunk_source": "consensus"
     },
@@ -1666,7 +1708,7 @@
           "old_origin": ".claude/worktrees/agent-a7cedd3c/src/cache.rs",
           "old_line_start": 40,
           "new_origin": "src/cache.rs",
-          "new_line_start": 42
+          "new_line_start": 189
         }
       },
       "judges": {
@@ -1710,13 +1752,13 @@
       "pool_size": 4,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cache.rs:42:regen",
+        "id": "src/cache.rs:189:regen",
         "name": "EmbeddingCache",
         "origin": "src/cache.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 42,
-        "line_end": 49
+        "line_start": 189,
+        "line_end": 201
       },
       "gold_chunk_source": "consensus"
     },
@@ -1732,7 +1774,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 56,
           "new_origin": "src/schema.sql",
-          "new_line_start": 64
+          "new_line_start": 95
         }
       },
       "judges": {
@@ -1778,13 +1820,13 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:64:regen",
+        "id": "src/schema.sql:95:regen",
         "name": "chunks_fts",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 69,
-        "line_end": 76
+        "line_start": 95,
+        "line_end": 102
       },
       "gold_chunk_source": "consensus"
     },
@@ -1853,7 +1895,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031456,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/note.rs",
+          "old_line_start": 376,
+          "new_origin": "src/note.rs",
+          "new_line_start": 525
+        }
       },
       "judges": {
         "claude": {
@@ -1898,13 +1947,13 @@
       "pool_size": 38,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/note.rs:525:regen",
         "name": "path_matches_mention",
         "origin": "src/note.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 376,
-        "line_end": 393
+        "line_start": 525,
+        "line_end": 552
       },
       "gold_chunk_source": "consensus"
     },
@@ -1914,7 +1963,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "type_filtered",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/store/calls/mod.rs",
+          "old_line_start": 60,
+          "new_origin": "src/cli/definitions.rs",
+          "new_line_start": 30
+        }
       },
       "judges": {
         "claude": {
@@ -1957,13 +2013,13 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/store/calls/mod.rs:60:d50e35f2",
+        "id": "src/cli/definitions.rs:30:regen",
         "name": "fmt",
-        "origin": "src/store/calls/mod.rs",
+        "origin": "src/cli/definitions.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 60,
-        "line_end": 62
+        "line_start": 30,
+        "line_end": 36
       },
       "gold_chunk_source": "consensus"
     },
@@ -2045,7 +2101,7 @@
           "old_origin": "src/nl/mod.rs",
           "old_line_start": 983,
           "new_origin": "src/nl/mod.rs",
-          "new_line_start": 992
+          "new_line_start": 1007
         }
       },
       "judges": {
@@ -2089,13 +2145,13 @@
       "pool_size": 26,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/nl/mod.rs:992:regen",
+        "id": "src/nl/mod.rs:1007:regen",
         "name": "enrichment_nl_includes_callers_and_callees",
         "origin": "src/nl/mod.rs",
         "language": "rust",
         "chunk_type": "test",
-        "line_start": 992,
-        "line_end": 1029
+        "line_start": 1007,
+        "line_end": 1045
       },
       "gold_chunk_source": "consensus"
     },
@@ -2105,7 +2161,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "multi_step",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "evals/run_ablation.py",
+          "old_line_start": 155,
+          "new_origin": "evals/run_ablation.py",
+          "new_line_start": 153
+        }
       },
       "judges": {
         "claude": {
@@ -2146,7 +2209,7 @@
       "pool_size": 35,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "evals/run_ablation.py:155:9ff05e71",
+        "id": "evals/run_ablation.py:153:regen",
         "name": "reindex",
         "origin": "evals/run_ablation.py",
         "language": "python",
@@ -2154,8 +2217,7 @@
         "line_start": 153,
         "line_end": 181
       },
-      "gold_chunk_source": "consensus",
-      "_unresolved": true
+      "gold_chunk_source": "consensus"
     },
     {
       "query": "functions that run cqs search AND use subprocess.run",
@@ -2289,7 +2351,7 @@
           "old_origin": "src/cli/pipeline/embedding.rs",
           "old_line_start": 336,
           "new_origin": "src/cli/pipeline/embedding.rs",
-          "new_line_start": 349
+          "new_line_start": 427
         }
       },
       "judges": {
@@ -2333,13 +2395,13 @@
       "pool_size": 28,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/pipeline/embedding.rs:349:regen",
+        "id": "src/cli/pipeline/embedding.rs:427:regen",
         "name": "cpu_embed_stage",
         "origin": "src/cli/pipeline/embedding.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 349,
-        "line_end": 452
+        "line_start": 427,
+        "line_end": 599
       },
       "gold_chunk_source": "consensus"
     },
@@ -2417,7 +2479,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031760,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/cli/pipeline/mod.rs",
+          "old_line_start": 43,
+          "new_origin": "src/cli/pipeline/mod.rs",
+          "new_line_start": 52
+        }
       },
       "judges": {
         "claude": {
@@ -2460,13 +2529,13 @@
       "pool_size": 38,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/cli/pipeline/mod.rs:52:regen",
         "name": "run_index_pipeline",
         "origin": "src/cli/pipeline/mod.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 43,
-        "line_end": 198
+        "line_start": 52,
+        "line_end": 235
       },
       "gold_chunk_source": "consensus"
     },
@@ -2594,7 +2663,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "type_filtered",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/hnsw/persist.rs",
+          "old_line_start": 172,
+          "new_origin": "src/hnsw/build.rs",
+          "new_line_start": 11
+        }
       },
       "judges": {
         "claude": {
@@ -2639,13 +2715,13 @@
       "pool_size": 5,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/hnsw/persist.rs:172:39cd287a:w15",
+        "id": "src/hnsw/build.rs:11:regen",
         "name": "HnswIndex",
-        "origin": "src/hnsw/persist.rs",
+        "origin": "src/hnsw/build.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 191,
-        "line_end": 956
+        "line_start": 11,
+        "line_end": 257
       },
       "gold_chunk_source": "consensus"
     },
@@ -2708,8 +2784,7 @@
         "line_start": 111,
         "line_end": 286
       },
-      "gold_chunk_source": "consensus",
-      "_unresolved": true
+      "gold_chunk_source": "consensus"
     },
     {
       "query": "llm based query classification",
@@ -2841,7 +2916,7 @@
           "old_origin": "src/language/languages.rs",
           "old_line_start": 3979,
           "new_origin": "src/language/languages.rs",
-          "new_line_start": 4092
+          "new_line_start": 4124
         }
       },
       "judges": {
@@ -2885,13 +2960,13 @@
       "pool_size": 37,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/language/languages.rs:4092:regen",
+        "id": "src/language/languages.rs:4124:regen",
         "name": "has_function_value_lua",
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 4099,
-        "line_end": 4120
+        "line_start": 4124,
+        "line_end": 4145
       },
       "gold_chunk_source": "consensus"
     },
@@ -3025,7 +3100,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 56,
           "new_origin": "src/schema.sql",
-          "new_line_start": 64
+          "new_line_start": 95
         }
       },
       "judges": {
@@ -3071,13 +3146,13 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:64:regen",
+        "id": "src/schema.sql:95:regen",
         "name": "chunks_fts",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 69,
-        "line_end": 76
+        "line_start": 95,
+        "line_end": 102
       },
       "gold_chunk_source": "consensus"
     },
@@ -3146,7 +3221,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031742,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/note.rs",
+          "old_line_start": 72,
+          "new_origin": "src/note.rs",
+          "new_line_start": 119
+        }
       },
       "judges": {
         "claude": {
@@ -3189,13 +3271,13 @@
       "pool_size": 31,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/note.rs:119:regen",
         "name": "Note",
         "origin": "src/note.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 72,
-        "line_end": 118
+        "line_start": 119,
+        "line_end": 177
       },
       "gold_chunk_source": "consensus"
     },
@@ -3210,8 +3292,8 @@
           "match_kind": "name",
           "old_origin": "src/cli/watch.rs",
           "old_line_start": 1505,
-          "new_origin": "src/cli/watch.rs",
-          "new_line_start": 2022
+          "new_origin": "src/cli/watch/events.rs",
+          "new_line_start": 23
         }
       },
       "judges": {
@@ -3257,13 +3339,13 @@
       "pool_size": 30,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/watch.rs:2022:regen",
+        "id": "src/cli/watch/events.rs:23:regen",
         "name": "collect_events",
-        "origin": "src/cli/watch.rs",
+        "origin": "src/cli/watch/events.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 2096,
-        "line_end": 2186
+        "line_start": 23,
+        "line_end": 162
       },
       "gold_chunk_source": "consensus"
     },
@@ -3279,7 +3361,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 56,
           "new_origin": "src/schema.sql",
-          "new_line_start": 64
+          "new_line_start": 95
         }
       },
       "judges": {
@@ -3325,13 +3407,13 @@
       "pool_size": 33,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:64:regen",
+        "id": "src/schema.sql:95:regen",
         "name": "chunks_fts",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 69,
-        "line_end": 76
+        "line_start": 95,
+        "line_end": 102
       },
       "gold_chunk_source": "consensus"
     },
@@ -3406,7 +3488,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 56,
           "new_origin": "src/schema.sql",
-          "new_line_start": 64
+          "new_line_start": 95
         }
       },
       "judges": {
@@ -3452,13 +3534,13 @@
       "pool_size": 30,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:64:regen",
+        "id": "src/schema.sql:95:regen",
         "name": "chunks_fts",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 69,
-        "line_end": 76
+        "line_start": 95,
+        "line_end": 102
       },
       "gold_chunk_source": "consensus"
     },
@@ -3473,8 +3555,8 @@
           "match_kind": "name",
           "old_origin": "src/embedder/mod.rs",
           "old_line_start": 970,
-          "new_origin": "docs/DESIGN_SPEC_27k_tokens.md",
-          "new_line_start": 767
+          "new_origin": "src/reranker.rs",
+          "new_line_start": 1156
         }
       },
       "judges": {
@@ -3520,13 +3602,13 @@
       "pool_size": 34,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "docs/DESIGN_SPEC_27k_tokens.md:767:regen",
+        "id": "src/reranker.rs:1156:regen",
         "name": "verify_checksum",
-        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
+        "origin": "src/reranker.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 767,
-        "line_end": 780
+        "line_start": 1156,
+        "line_end": 1174
       },
       "gold_chunk_source": "consensus"
     },
@@ -3542,7 +3624,7 @@
           "old_origin": "src/parser/mod.rs",
           "old_line_start": 224,
           "new_origin": "src/parser/mod.rs",
-          "new_line_start": 257
+          "new_line_start": 265
         }
       },
       "judges": {
@@ -3586,7 +3668,7 @@
       "pool_size": 33,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/parser/mod.rs:257:regen",
+        "id": "src/parser/mod.rs:265:regen",
         "name": "parse_source",
         "origin": "src/parser/mod.rs",
         "language": "rust",
@@ -3608,7 +3690,7 @@
           "old_origin": "src/search/router.rs",
           "old_line_start": 431,
           "new_origin": "src/search/router.rs",
-          "new_line_start": 549
+          "new_line_start": 934
         }
       },
       "judges": {
@@ -3654,13 +3736,13 @@
       "pool_size": 21,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/search/router.rs:549:regen",
+        "id": "src/search/router.rs:934:regen",
         "name": "classify_query",
         "origin": "src/search/router.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 561,
-        "line_end": 576
+        "line_start": 934,
+        "line_end": 949
       },
       "gold_chunk_source": "consensus"
     },
@@ -3670,7 +3752,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "type_filtered",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/store/sparse.rs",
+          "old_line_start": 230,
+          "new_origin": "src/store/sparse.rs",
+          "new_line_start": 325
+        }
       },
       "judges": {
         "claude": {
@@ -3715,13 +3804,13 @@
       "pool_size": 18,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/store/sparse.rs:230:c9d4358d:w2",
+        "id": "src/store/sparse.rs:325:regen",
         "name": "load_all_sparse_vectors",
         "origin": "src/store/sparse.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 294,
-        "line_end": 381
+        "line_start": 325,
+        "line_end": 433
       },
       "gold_chunk_source": "consensus"
     },
@@ -3905,7 +3994,7 @@
         "language": "rust",
         "chunk_type": "function",
         "line_start": 112,
-        "line_end": 455
+        "line_end": 517
       },
       "gold_chunk_source": "consensus"
     },
@@ -3921,7 +4010,7 @@
           "old_origin": "src/parser/l5x.rs",
           "old_line_start": 272,
           "new_origin": "src/parser/l5x.rs",
-          "new_line_start": 274
+          "new_line_start": 304
         }
       },
       "judges": {
@@ -3965,13 +4054,13 @@
       "pool_size": 39,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/parser/l5x.rs:274:regen",
+        "id": "src/parser/l5x.rs:304:regen",
         "name": "parse_l5x_chunks",
         "origin": "src/parser/l5x.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 274,
-        "line_end": 291
+        "line_start": 304,
+        "line_end": 321
       },
       "gold_chunk_source": "consensus"
     },
@@ -3987,7 +4076,7 @@
           "old_origin": "src/embedder/mod.rs",
           "old_line_start": 87,
           "new_origin": "src/language/mod.rs",
-          "new_line_start": 862
+          "new_line_start": 910
         }
       },
       "judges": {
@@ -4033,13 +4122,13 @@
       "pool_size": 32,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/language/mod.rs:862:regen",
+        "id": "src/language/mod.rs:910:regen",
         "name": "fmt",
         "origin": "src/language/mod.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 862,
-        "line_end": 869
+        "line_start": 910,
+        "line_end": 917
       },
       "gold_chunk_source": "consensus"
     },
@@ -4055,7 +4144,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 95,
           "new_origin": "src/schema.sql",
-          "new_line_start": 103
+          "new_line_start": 134
         }
       },
       "judges": {
@@ -4101,13 +4190,13 @@
       "pool_size": 33,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:103:regen",
+        "id": "src/schema.sql:134:regen",
         "name": "type_edges",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 108,
-        "line_end": 115
+        "line_start": 134,
+        "line_end": 141
       },
       "gold_chunk_source": "consensus"
     },
@@ -4123,7 +4212,7 @@
           "old_origin": "src/store/migrations.rs",
           "old_line_start": 281,
           "new_origin": "src/store/migrations.rs",
-          "new_line_start": 291
+          "new_line_start": 472
         }
       },
       "judges": {
@@ -4169,13 +4258,13 @@
       "pool_size": 22,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/store/migrations.rs:291:regen",
+        "id": "src/store/migrations.rs:472:regen",
         "name": "migrate_v12_to_v13",
         "origin": "src/store/migrations.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 295,
-        "line_end": 309
+        "line_start": 472,
+        "line_end": 486
       },
       "gold_chunk_source": "consensus"
     },
@@ -4259,7 +4348,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 123,
           "new_origin": "src/schema.sql",
-          "new_line_start": 131
+          "new_line_start": 164
         }
       },
       "judges": {
@@ -4305,13 +4394,13 @@
       "pool_size": 38,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:131:regen",
+        "id": "src/schema.sql:164:regen",
         "name": "notes_fts",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 136,
-        "line_end": 140
+        "line_start": 164,
+        "line_end": 168
       },
       "gold_chunk_source": "consensus"
     },
@@ -4327,7 +4416,7 @@
           "old_origin": "src/cagra.rs",
           "old_line_start": 748,
           "new_origin": "src/cagra.rs",
-          "new_line_start": 471
+          "new_line_start": 751
         }
       },
       "judges": {
@@ -4369,13 +4458,13 @@
       "pool_size": 26,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cagra.rs:471:regen",
+        "id": "src/cagra.rs:751:regen",
         "name": "CagraIndex",
         "origin": "src/cagra.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 490,
-        "line_end": 599
+        "line_start": 751,
+        "line_end": 751
       },
       "gold_chunk_source": "consensus"
     },
@@ -4391,7 +4480,7 @@
           "old_origin": "src/language/languages.rs",
           "old_line_start": 7998,
           "new_origin": "src/language/languages.rs",
-          "new_line_start": 8217
+          "new_line_start": 8272
         }
       },
       "judges": {
@@ -4435,13 +4524,13 @@
       "pool_size": 37,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/language/languages.rs:8217:regen",
+        "id": "src/language/languages.rs:8272:regen",
         "name": "post_process_yaml_yaml",
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 8230,
-        "line_end": 8250
+        "line_start": 8272,
+        "line_end": 8292
       },
       "gold_chunk_source": "consensus"
     },
@@ -4702,7 +4791,7 @@
           "old_origin": "src/cache.rs",
           "old_line_start": 28,
           "new_origin": "src/cache.rs",
-          "new_line_start": 30
+          "new_line_start": 84
         }
       },
       "judges": {
@@ -4748,13 +4837,13 @@
       "pool_size": 26,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cache.rs:30:regen",
+        "id": "src/cache.rs:84:regen",
         "name": "CacheStats",
         "origin": "src/cache.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 30,
-        "line_end": 36
+        "line_start": 84,
+        "line_end": 90
       },
       "gold_chunk_source": "consensus"
     },
@@ -4764,7 +4853,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031725,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/impact/analysis.rs",
+          "old_line_start": 419,
+          "new_origin": "src/impact/analysis.rs",
+          "new_line_start": 436
+        }
       },
       "judges": {
         "claude": {
@@ -4809,13 +4905,13 @@
       "pool_size": 32,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/impact/analysis.rs:436:regen",
         "name": "find_type_impacted",
         "origin": "src/impact/analysis.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 433,
-        "line_end": 515
+        "line_start": 436,
+        "line_end": 518
       },
       "gold_chunk_source": "consensus"
     },
@@ -4943,7 +5039,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "structural_search",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/schema.sql",
+          "old_line_start": 22,
+          "new_origin": "src/schema.sql",
+          "new_line_start": 41
+        }
       },
       "judges": {
         "claude": {
@@ -4984,16 +5087,15 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:22:ea43482c",
+        "id": "src/schema.sql:41:regen",
         "name": "chunks",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 32,
-        "line_end": 58
+        "line_start": 41,
+        "line_end": 71
       },
-      "gold_chunk_source": "consensus",
-      "_unresolved": true
+      "gold_chunk_source": "consensus"
     },
     {
       "query": "how does the plan command classify tasks and generate checklists",
@@ -5068,7 +5170,7 @@
           "old_origin": "src/store/sparse.rs",
           "old_line_start": 319,
           "new_origin": "src/store/sparse.rs",
-          "new_line_start": 321
+          "new_line_start": 437
         }
       },
       "judges": {
@@ -5114,13 +5216,13 @@
       "pool_size": 31,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/store/sparse.rs:321:regen",
+        "id": "src/store/sparse.rs:437:regen",
         "name": "chunk_splade_texts",
         "origin": "src/store/sparse.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 385,
-        "line_end": 387
+        "line_start": 437,
+        "line_end": 439
       },
       "gold_chunk_source": "consensus"
     },
@@ -5195,7 +5297,7 @@
           "old_origin": "src/cli/commands/resolve.rs",
           "old_line_start": 27,
           "new_origin": "src/cli/commands/resolve.rs",
-          "new_line_start": 28
+          "new_line_start": 41
         }
       },
       "judges": {
@@ -5239,13 +5341,13 @@
       "pool_size": 31,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/commands/resolve.rs:28:regen",
+        "id": "src/cli/commands/resolve.rs:41:regen",
         "name": "find_reference",
         "origin": "src/cli/commands/resolve.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 26,
-        "line_end": 39
+        "line_start": 41,
+        "line_end": 57
       },
       "gold_chunk_source": "consensus"
     },
@@ -5261,7 +5363,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 66,
           "new_origin": "src/schema.sql",
-          "new_line_start": 74
+          "new_line_start": 105
         }
       },
       "judges": {
@@ -5305,13 +5407,13 @@
       "pool_size": 39,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:74:regen",
+        "id": "src/schema.sql:105:regen",
         "name": "calls",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 79,
-        "line_end": 85
+        "line_start": 105,
+        "line_end": 111
       },
       "gold_chunk_source": "consensus"
     },
@@ -5327,7 +5429,7 @@
           "old_origin": "src/search/router.rs",
           "old_line_start": 267,
           "new_origin": "src/search/router.rs",
-          "new_line_start": 367
+          "new_line_start": 447
         }
       },
       "judges": {
@@ -5371,13 +5473,13 @@
       "pool_size": 35,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/search/router.rs:367:regen",
+        "id": "src/search/router.rs:447:regen",
         "name": "language_names",
         "origin": "src/search/router.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 379,
-        "line_end": 381
+        "line_start": 447,
+        "line_end": 449
       },
       "gold_chunk_source": "consensus"
     },
@@ -5452,7 +5554,7 @@
           "old_origin": "src/nl/mod.rs",
           "old_line_start": 652,
           "new_origin": "src/nl/mod.rs",
-          "new_line_start": 655
+          "new_line_start": 664
         }
       },
       "judges": {
@@ -5496,13 +5598,13 @@
       "pool_size": 38,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/nl/mod.rs:655:regen",
+        "id": "src/nl/mod.rs:664:regen",
         "name": "make_section_chunk",
         "origin": "src/nl/mod.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 655,
-        "line_end": 673
+        "line_start": 664,
+        "line_end": 682
       },
       "gold_chunk_source": "consensus"
     },
@@ -5512,7 +5614,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "multi_step",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/cagra.rs",
+          "old_line_start": 471,
+          "new_origin": "src/cagra.rs",
+          "new_line_start": 597
+        }
       },
       "judges": {
         "claude": {
@@ -5557,13 +5666,13 @@
       "pool_size": 18,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cagra.rs:471:7412f1b2:w1",
+        "id": "src/cagra.rs:597:regen",
         "name": "CagraIndex",
         "origin": "src/cagra.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 490,
-        "line_end": 599
+        "line_start": 597,
+        "line_end": 743
       },
       "gold_chunk_source": "consensus"
     },
@@ -5573,7 +5682,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031026,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/cli/pipeline/mod.rs",
+          "old_line_start": 43,
+          "new_origin": "src/cli/pipeline/mod.rs",
+          "new_line_start": 52
+        }
       },
       "judges": {
         "claude": {
@@ -5616,13 +5732,13 @@
       "pool_size": 31,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/cli/pipeline/mod.rs:52:regen",
         "name": "run_index_pipeline",
         "origin": "src/cli/pipeline/mod.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 43,
-        "line_end": 198
+        "line_start": 52,
+        "line_end": 235
       },
       "gold_chunk_source": "consensus"
     },
@@ -5637,8 +5753,8 @@
           "match_kind": "name",
           "old_origin": ".claude/worktrees/agent-a7cedd3c/src/cli/watch.rs",
           "old_line_start": 573,
-          "new_origin": "src/cli/watch.rs",
-          "new_line_start": 1170
+          "new_origin": "src/cli/watch/mod.rs",
+          "new_line_start": 403
         }
       },
       "judges": {
@@ -5680,13 +5796,13 @@
       "pool_size": 17,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/watch.rs:1170:regen",
+        "id": "src/cli/watch/mod.rs:403:regen",
         "name": "cmd_watch",
-        "origin": "src/cli/watch.rs",
+        "origin": "src/cli/watch/mod.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 1216,
-        "line_end": 2093
+        "line_start": 403,
+        "line_end": 1757
       },
       "gold_chunk_source": "consensus"
     },
@@ -5760,8 +5876,8 @@
           "match_kind": "name",
           "old_origin": "src/cli/watch.rs",
           "old_line_start": 1601,
-          "new_origin": "src/cli/watch.rs",
-          "new_line_start": 2118
+          "new_origin": "src/cli/watch/events.rs",
+          "new_line_start": 168
         }
       },
       "judges": {
@@ -5807,13 +5923,13 @@
       "pool_size": 24,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/watch.rs:2118:regen",
+        "id": "src/cli/watch/events.rs:168:regen",
         "name": "process_file_changes",
-        "origin": "src/cli/watch.rs",
+        "origin": "src/cli/watch/events.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 2192,
-        "line_end": 2434
+        "line_start": 168,
+        "line_end": 496
       },
       "gold_chunk_source": "consensus"
     },
@@ -5823,7 +5939,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031803,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/cli/batch/handlers/analysis.rs",
+          "old_line_start": 23,
+          "new_origin": "src/cli/batch/handlers/analysis.rs",
+          "new_line_start": 26
+        }
       },
       "judges": {
         "claude": {
@@ -5866,13 +5989,13 @@
       "pool_size": 34,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/cli/batch/handlers/analysis.rs:26:regen",
         "name": "dispatch_dead",
         "origin": "src/cli/batch/handlers/analysis.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 23,
-        "line_end": 43
+        "line_start": 26,
+        "line_end": 47
       },
       "gold_chunk_source": "consensus"
     },
@@ -5882,7 +6005,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "conceptual_search",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/embedder/mod.rs",
+          "old_line_start": 349,
+          "new_origin": "src/embedder/mod.rs",
+          "new_line_start": 487
+        }
       },
       "judges": {
         "claude": {
@@ -5927,16 +6057,15 @@
       "pool_size": 23,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/embedder/mod.rs:349:3a5cb4fc:w1",
+        "id": "src/embedder/mod.rs:487:regen",
         "name": "model_fingerprint",
         "origin": "src/embedder/mod.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 372,
-        "line_end": 446
+        "line_start": 487,
+        "line_end": 639
       },
-      "gold_chunk_source": "consensus",
-      "_unresolved": true
+      "gold_chunk_source": "consensus"
     },
     {
       "query": "onnx session",
@@ -5950,7 +6079,7 @@
           "old_origin": "src/embedder/mod.rs",
           "old_line_start": 432,
           "new_origin": "src/reranker.rs",
-          "new_line_start": 487
+          "new_line_start": 738
         }
       },
       "judges": {
@@ -5996,13 +6125,13 @@
       "pool_size": 22,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/reranker.rs:487:regen",
+        "id": "src/reranker.rs:738:regen",
         "name": "session",
         "origin": "src/reranker.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 514,
-        "line_end": 539
+        "line_start": 738,
+        "line_end": 763
       },
       "gold_chunk_source": "consensus"
     },
@@ -6012,7 +6141,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "type_filtered",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/search/scoring/name_match.rs",
+          "old_line_start": 98,
+          "new_origin": "src/search/scoring/name_match.rs",
+          "new_line_start": 101
+        }
       },
       "judges": {
         "claude": {
@@ -6057,13 +6193,13 @@
       "pool_size": 18,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/search/scoring/name_match.rs:98:565af07e:w1",
+        "id": "src/search/scoring/name_match.rs:101:regen",
         "name": "NameMatcher",
         "origin": "src/search/scoring/name_match.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 98,
-        "line_end": 225
+        "line_start": 101,
+        "line_end": 228
       },
       "gold_chunk_source": "consensus"
     },
@@ -6079,7 +6215,7 @@
           "old_origin": "src/store/helpers/types.rs",
           "old_line_start": 385,
           "new_origin": "src/store/helpers/types.rs",
-          "new_line_start": 399
+          "new_line_start": 591
         }
       },
       "judges": {
@@ -6125,13 +6261,13 @@
       "pool_size": 27,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/store/helpers/types.rs:399:regen",
+        "id": "src/store/helpers/types.rs:591:regen",
         "name": "IndexStats",
         "origin": "src/store/helpers/types.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 399,
-        "line_end": 418
+        "line_start": 591,
+        "line_end": 610
       },
       "gold_chunk_source": "consensus"
     },
@@ -6147,7 +6283,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 134,
           "new_origin": "src/schema.sql",
-          "new_line_start": 142
+          "new_line_start": 175
         }
       },
       "judges": {
@@ -6193,13 +6329,13 @@
       "pool_size": 27,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:142:regen",
+        "id": "src/schema.sql:175:regen",
         "name": "sparse_vectors",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 147,
-        "line_end": 153
+        "line_start": 175,
+        "line_end": 181
       },
       "gold_chunk_source": "consensus"
     },
@@ -6215,7 +6351,7 @@
           "old_origin": "src/nl/mod.rs",
           "old_line_start": 652,
           "new_origin": "src/nl/mod.rs",
-          "new_line_start": 655
+          "new_line_start": 664
         }
       },
       "judges": {
@@ -6259,13 +6395,13 @@
       "pool_size": 41,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/nl/mod.rs:655:regen",
+        "id": "src/nl/mod.rs:664:regen",
         "name": "make_section_chunk",
         "origin": "src/nl/mod.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 655,
-        "line_end": 673
+        "line_start": 664,
+        "line_end": 682
       },
       "gold_chunk_source": "consensus"
     },
@@ -6399,7 +6535,7 @@
           "old_origin": ".claude/worktrees/agent-a7cedd3c/src/cache.rs",
           "old_line_start": 373,
           "new_origin": "src/cache.rs",
-          "new_line_start": 404
+          "new_line_start": 784
         }
       },
       "judges": {
@@ -6445,13 +6581,13 @@
       "pool_size": 27,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cache.rs:404:regen",
+        "id": "src/cache.rs:784:regen",
         "name": "stats",
         "origin": "src/cache.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 456,
-        "line_end": 493
+        "line_start": 784,
+        "line_end": 821
       },
       "gold_chunk_source": "consensus"
     },
@@ -6461,14 +6597,7 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031616,
-        "source_cmd": "search",
-        "regenerated_2026_04_17": {
-          "match_kind": "name",
-          "old_origin": ".claude/worktrees/agent-a7cedd3c/src/cli/batch/mod.rs",
-          "old_line_start": 170,
-          "new_origin": "src/cli/batch/mod.rs",
-          "new_line_start": 222
-        }
+        "source_cmd": "search"
       },
       "judges": {
         "claude": {
@@ -6511,15 +6640,16 @@
       "pool_size": 43,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/batch/mod.rs:222:regen",
+        "id": null,
         "name": "BatchContext",
-        "origin": "src/cli/batch/mod.rs",
+        "origin": ".claude/worktrees/agent-a7cedd3c/src/cli/batch/mod.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 218,
-        "line_end": 307
+        "line_start": 170,
+        "line_end": 231
       },
-      "gold_chunk_source": "consensus"
+      "gold_chunk_source": "consensus",
+      "_unresolved": true
     },
     {
       "query": "implementation of DiffTestInfo",
@@ -6592,7 +6722,7 @@
           "old_origin": "src/cli/batch/pipeline.rs",
           "old_line_start": 350,
           "new_origin": "src/cli/batch/pipeline.rs",
-          "new_line_start": 398
+          "new_line_start": 416
         }
       },
       "judges": {
@@ -6636,13 +6766,13 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/batch/pipeline.rs:398:regen",
+        "id": "src/cli/batch/pipeline.rs:416:regen",
         "name": "has_pipe_token",
         "origin": "src/cli/batch/pipeline.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 398,
-        "line_end": 400
+        "line_start": 416,
+        "line_end": 418
       },
       "gold_chunk_source": "consensus"
     },
@@ -6658,7 +6788,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 78,
           "new_origin": "src/schema.sql",
-          "new_line_start": 86
+          "new_line_start": 117
         }
       },
       "judges": {
@@ -6704,13 +6834,13 @@
       "pool_size": 38,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:86:regen",
+        "id": "src/schema.sql:117:regen",
         "name": "function_calls",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 91,
-        "line_end": 98
+        "line_start": 117,
+        "line_end": 124
       },
       "gold_chunk_source": "consensus"
     },
@@ -6726,7 +6856,7 @@
           "old_origin": "src/cli/display.rs",
           "old_line_start": 390,
           "new_origin": "src/cli/display.rs",
-          "new_line_start": 397
+          "new_line_start": 533
         }
       },
       "judges": {
@@ -6770,13 +6900,13 @@
       "pool_size": 22,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/display.rs:397:regen",
+        "id": "src/cli/display.rs:533:regen",
         "name": "display_similar_results_json",
         "origin": "src/cli/display.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 397,
-        "line_end": 413
+        "line_start": 533,
+        "line_end": 549
       },
       "gold_chunk_source": "consensus"
     },
@@ -6901,12 +7031,12 @@
       "gold_chunk_source": "consensus"
     }
   ],
-  "regenerated_at": "2026-04-19",
+  "regenerated_at": "2026-05-08",
   "regenerated_against": "current index (k=50)",
   "regenerated_counts": {
-    "strict": 49,
+    "strict": 33,
     "basename": 1,
-    "name": 52,
-    "none": 7
+    "name": 71,
+    "none": 4
   }
 }

--- a/evals/queries/v3_test.diff.json
+++ b/evals/queries/v3_test.diff.json
@@ -1,12 +1,12 @@
 {
-  "generated_at": "2026-04-19T21:57:39",
+  "generated_at": "2026-05-08T03:50:34",
   "source": "v3_test.json",
   "k": 50,
   "counts": {
-    "strict": 41,
-    "basename": 1,
-    "name": 57,
-    "none": 10
+    "strict": 29,
+    "basename": 0,
+    "name": 69,
+    "none": 11
   },
   "records": [
     {
@@ -19,7 +19,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 116
+        "line_start": 147
       }
     },
     {
@@ -31,8 +31,8 @@
         "line_start": 105
       },
       "new": {
-        "origin": "src/reranker.rs",
-        "line_start": 125
+        "origin": "docs/audit-fix-prompts-v1.30.0.md",
+        "line_start": 246
       }
     },
     {
@@ -45,7 +45,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 142
+        "line_start": 175
       }
     },
     {
@@ -58,7 +58,7 @@
       },
       "new": {
         "origin": "src/hnsw/persist.rs",
-        "line_start": 533
+        "line_start": 686
       }
     },
     {
@@ -90,7 +90,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 142
+        "line_start": 175
       }
     },
     {
@@ -102,8 +102,8 @@
         "line_start": 458
       },
       "new": {
-        "origin": "src/cli/watch.rs",
-        "line_start": 601
+        "origin": "src/cli/watch/rebuild.rs",
+        "line_start": 136
       }
     },
     {
@@ -121,7 +121,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 142
+        "line_start": 175
       }
     },
     {
@@ -153,7 +153,7 @@
       },
       "new": {
         "origin": "src/store/helpers/types.rs",
-        "line_start": 254
+        "line_start": 394
       }
     },
     {
@@ -166,20 +166,21 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 74
+        "line_start": 105
       }
     },
     {
       "query": "structs that have a project String AND flatten CallerInfo",
-      "match_kind": "basename",
-      "action": "updated",
-      "old": {
+      "match_kind": "none",
+      "action": "unresolved",
+      "gold_chunk": {
+        "id": ".claude/worktrees/agent-a7cedd3c/src/store/calls/cross_project.rs:36:04384a2b",
+        "name": "CrossProjectCaller",
         "origin": ".claude/worktrees/agent-a7cedd3c/src/store/calls/cross_project.rs",
-        "line_start": 36
-      },
-      "new": {
-        "origin": "src/store/calls/cross_project.rs",
-        "line_start": 36
+        "language": "rust",
+        "chunk_type": "struct",
+        "line_start": 36,
+        "line_end": 41
       }
     },
     {
@@ -192,13 +193,21 @@
       },
       "new": {
         "origin": "src/cli/batch/handlers/info.rs",
-        "line_start": 168
+        "line_start": 167
       }
     },
     {
       "query": "impl blocks for HnswIndex",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/hnsw/persist.rs",
+        "line_start": 172
+      },
+      "new": {
+        "origin": "src/hnsw/build.rs",
+        "line_start": 11
+      }
     },
     {
       "query": "how does the affected command trace from git diff to impacted functions and tests",
@@ -210,13 +219,21 @@
       },
       "new": {
         "origin": "src/cli/batch/handlers/graph.rs",
-        "line_start": 392
+        "line_start": 429
       }
     },
     {
       "query": "VectorIndex trait definition",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/index.rs",
+        "line_start": 20
+      },
+      "new": {
+        "origin": "src/index.rs",
+        "line_start": 32
+      }
     },
     {
       "query": "parse function signatures",
@@ -233,21 +250,28 @@
     },
     {
       "query": "trait definition for pluggable vector search index",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/index.rs",
+        "line_start": 20
+      },
+      "new": {
+        "origin": "src/index.rs",
+        "line_start": 32
+      }
     },
     {
       "query": "markdown table formatting for evaluation results",
-      "match_kind": "none",
-      "action": "unresolved",
-      "gold_chunk": {
-        "id": "evals/run_ablation.py:193:31486bfe",
-        "name": "format_category_table",
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
         "origin": "evals/run_ablation.py",
-        "language": "python",
-        "chunk_type": "function",
-        "line_start": 193,
-        "line_end": 209
+        "line_start": 193
+      },
+      "new": {
+        "origin": "evals/run_ablation.py",
+        "line_start": 191
       }
     },
     {
@@ -260,7 +284,7 @@
       },
       "new": {
         "origin": "src/language/mod.rs",
-        "line_start": 277
+        "line_start": 287
       }
     },
     {
@@ -287,8 +311,8 @@
         "line_start": 22
       },
       "new": {
-        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
-        "line_start": 942
+        "origin": "src/schema.sql",
+        "line_start": 41
       }
     },
     {
@@ -314,7 +338,7 @@
       },
       "new": {
         "origin": "src/language/mod.rs",
-        "line_start": 875
+        "line_start": 923
       }
     },
     {
@@ -332,7 +356,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 142
+        "line_start": 175
       }
     },
     {
@@ -344,8 +368,8 @@
         "line_start": 17
       },
       "new": {
-        "origin": "src/schema.sql",
-        "line_start": 24
+        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
+        "line_start": 937
       }
     },
     {
@@ -372,7 +396,7 @@
       },
       "new": {
         "origin": "src/cache.rs",
-        "line_start": 980
+        "line_start": 2383
       }
     },
     {
@@ -382,15 +406,16 @@
     },
     {
       "query": "audit mode that forces direct code examination without cached notes",
-      "match_kind": "name",
-      "action": "updated",
-      "old": {
+      "match_kind": "none",
+      "action": "unresolved",
+      "gold_chunk": {
+        "id": null,
+        "name": "invalidate_mutable_caches",
         "origin": "src/cli/batch/mod.rs",
-        "line_start": 373
-      },
-      "new": {
-        "origin": "src/cli/batch/mod.rs",
-        "line_start": 475
+        "language": "rust",
+        "chunk_type": "method",
+        "line_start": 373,
+        "line_end": 383
       }
     },
     {
@@ -407,8 +432,8 @@
         "line_start": 17
       },
       "new": {
-        "origin": "src/schema.sql",
-        "line_start": 24
+        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
+        "line_start": 937
       }
     },
     {
@@ -431,7 +456,7 @@
       },
       "new": {
         "origin": "src/store/migrations.rs",
-        "line_start": 439
+        "line_start": 620
       }
     },
     {
@@ -449,7 +474,7 @@
       },
       "new": {
         "origin": "src/embedder/models.rs",
-        "line_start": 320
+        "line_start": 594
       }
     },
     {
@@ -461,14 +486,22 @@
         "line_start": 17
       },
       "new": {
-        "origin": "src/schema.sql",
-        "line_start": 24
+        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
+        "line_start": 937
       }
     },
     {
       "query": "how to implement a delete_by_origin database operation in Rust vs Go",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/store/chunks/crud.rs",
+        "line_start": 427
+      },
+      "new": {
+        "origin": "src/store/chunks/crud.rs",
+        "line_start": 764
+      }
     },
     {
       "query": "LLMClient validate method that is not synchronous",
@@ -485,13 +518,21 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 131
+        "line_start": 164
       }
     },
     {
       "query": "HnswIoCell",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/hnsw/mod.rs",
+        "line_start": 146
+      },
+      "new": {
+        "origin": "src/hnsw/mod.rs",
+        "line_start": 261
+      }
     },
     {
       "query": "BoundedScoreHeap",
@@ -503,7 +544,7 @@
       },
       "new": {
         "origin": "src/search/scoring/candidate.rs",
-        "line_start": 175
+        "line_start": 199
       }
     },
     {
@@ -513,8 +554,17 @@
     },
     {
       "query": "error types in src",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "none",
+      "action": "unresolved",
+      "gold_chunk": {
+        "id": null,
+        "name": "NoteError",
+        "origin": "src/note.rs",
+        "language": "rust",
+        "chunk_type": "enum",
+        "line_start": 24,
+        "line_end": 37
+      }
     },
     {
       "query": "implementation of TextJsonArgs",
@@ -523,22 +573,29 @@
     },
     {
       "query": "embedding dimension and model configuration management",
-      "match_kind": "none",
-      "action": "unresolved",
-      "gold_chunk": {
-        "id": null,
-        "name": "Embedder",
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
         "origin": "src/embedder/mod.rs",
-        "language": "rust",
-        "chunk_type": "struct",
-        "line_start": 217,
-        "line_end": 249
+        "line_start": 217
+      },
+      "new": {
+        "origin": "src/embedder/mod.rs",
+        "line_start": 261
       }
     },
     {
       "query": "dead code detection and unused function analysis",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/cli/batch/handlers/analysis.rs",
+        "line_start": 23
+      },
+      "new": {
+        "origin": "src/cli/batch/handlers/analysis.rs",
+        "line_start": 26
+      }
     },
     {
       "query": "create notes table without allowing null text",
@@ -550,7 +607,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 116
+        "line_start": 147
       }
     },
     {
@@ -563,25 +620,34 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 116
+        "line_start": 147
       }
     },
     {
       "query": "LlmClient constructor without automatic redirects",
-      "match_kind": "strict",
-      "action": "no_change"
-    },
-    {
-      "query": "test file suggestion based on language conventions",
       "match_kind": "name",
       "action": "updated",
       "old": {
-        "origin": "src/language/languages.rs",
-        "line_start": 5896
+        "origin": "src/llm/mod.rs",
+        "line_start": 375
       },
       "new": {
+        "origin": "src/llm/mod.rs",
+        "line_start": 621
+      }
+    },
+    {
+      "query": "test file suggestion based on language conventions",
+      "match_kind": "none",
+      "action": "unresolved",
+      "gold_chunk": {
+        "id": null,
+        "name": "LANG_RUBY",
         "origin": "src/language/languages.rs",
-        "line_start": 6060
+        "language": "rust",
+        "chunk_type": "constant",
+        "line_start": 5896,
+        "line_end": 5973
       }
     },
     {
@@ -594,7 +660,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 103
+        "line_start": 134
       }
     },
     {
@@ -617,8 +683,16 @@
     },
     {
       "query": "filter configuration for search queries with language and path constraints",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/store/helpers/search_filter.rs",
+        "line_start": 16
+      },
+      "new": {
+        "origin": "src/store/helpers/search_filter.rs",
+        "line_start": 27
+      }
     },
     {
       "query": "ProjectSearchResult",
@@ -630,7 +704,7 @@
       },
       "new": {
         "origin": "src/cli/commands/infra/project.rs",
-        "line_start": 23
+        "line_start": 24
       }
     },
     {
@@ -643,7 +717,7 @@
       },
       "new": {
         "origin": "src/search/router.rs",
-        "line_start": 911
+        "line_start": 1437
       }
     },
     {
@@ -656,7 +730,7 @@
       },
       "new": {
         "origin": "src/language/mod.rs",
-        "line_start": 862
+        "line_start": 910
       }
     },
     {
@@ -669,7 +743,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 175
+        "line_start": 208
       }
     },
     {
@@ -682,7 +756,7 @@
       },
       "new": {
         "origin": "src/cache.rs",
-        "line_start": 1103
+        "line_start": 2533
       }
     },
     {
@@ -700,7 +774,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 103
+        "line_start": 134
       }
     },
     {
@@ -713,7 +787,7 @@
       },
       "new": {
         "origin": "src/cagra.rs",
-        "line_start": 241
+        "line_start": 749
       }
     },
     {
@@ -730,8 +804,8 @@
         "line_start": 281
       },
       "new": {
-        "origin": "src/cli/batch/commands.rs",
-        "line_start": 406
+        "origin": "src/cli/batch/handlers/dispatch_tests.rs",
+        "line_start": 211
       }
     },
     {
@@ -744,7 +818,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 131
+        "line_start": 164
       }
     },
     {
@@ -762,7 +836,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 86
+        "line_start": 117
       }
     },
     {
@@ -780,7 +854,7 @@
       },
       "new": {
         "origin": "src/store/search.rs",
-        "line_start": 182
+        "line_start": 324
       }
     },
     {
@@ -793,27 +867,34 @@
       },
       "new": {
         "origin": "src/nl/mod.rs",
-        "line_start": 655
+        "line_start": 664
       }
     },
     {
       "query": "method implementations on the Store struct",
-      "match_kind": "none",
-      "action": "unresolved",
-      "gold_chunk": {
-        "id": null,
-        "name": "Store",
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
         "origin": "src/store/search.rs",
-        "language": "rust",
-        "chunk_type": "impl",
-        "line_start": 37,
-        "line_end": 218
+        "line_start": 37
+      },
+      "new": {
+        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
+        "line_start": 979
       }
     },
     {
       "query": "save HNSW index to disk with checksum verification",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/hnsw/persist.rs",
+        "line_start": 189
+      },
+      "new": {
+        "origin": "src/hnsw/persist.rs",
+        "line_start": 236
+      }
     },
     {
       "query": "SQL equivalent of a TypeScript interface for a code chunk table",
@@ -824,8 +905,8 @@
         "line_start": 22
       },
       "new": {
-        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
-        "line_start": 942
+        "origin": "src/schema.sql",
+        "line_start": 41
       }
     },
     {
@@ -845,8 +926,17 @@
     },
     {
       "query": "delegate and event handler type definitions",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "none",
+      "action": "unresolved",
+      "gold_chunk": {
+        "id": null,
+        "name": "StructuralMatcherFn",
+        "origin": "src/language/mod.rs",
+        "language": "rust",
+        "chunk_type": "typealias",
+        "line_start": 191,
+        "line_end": 191
+      }
     },
     {
       "query": "SPLADE encoder encode_batch tensor shape validation",
@@ -857,14 +947,22 @@
         "line_start": 580
       },
       "new": {
-        "origin": "docs/superpowers/plans/2026-04-06-splade-sparse-dense-hybrid.md",
-        "line_start": 220
+        "origin": "src/splade/mod.rs",
+        "line_start": 769
       }
     },
     {
       "query": "convert a document file to markdown format",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/convert/html.rs",
+        "line_start": 43
+      },
+      "new": {
+        "origin": "src/convert/html.rs",
+        "line_start": 45
+      }
     },
     {
       "query": "how to parse OCaml function return types in Rust vs OCaml",
@@ -876,33 +974,35 @@
       },
       "new": {
         "origin": "src/language/languages.rs",
-        "line_start": 4655
+        "line_start": 4692
       }
     },
     {
       "query": "constructor detection across language conventions",
-      "match_kind": "name",
-      "action": "updated",
-      "old": {
+      "match_kind": "none",
+      "action": "unresolved",
+      "gold_chunk": {
+        "id": null,
+        "name": "post_process_solidity_solidity",
         "origin": "src/language/languages.rs",
-        "line_start": 6471
-      },
-      "new": {
-        "origin": "src/language/languages.rs",
-        "line_start": 6662
+        "language": "rust",
+        "chunk_type": "function",
+        "line_start": 6471,
+        "line_end": 6489
       }
     },
     {
       "query": "struct definitions in src/cli/commands/infra",
-      "match_kind": "name",
-      "action": "updated",
-      "old": {
+      "match_kind": "none",
+      "action": "unresolved",
+      "gold_chunk": {
+        "id": null,
+        "name": "BatchInput",
         "origin": "src/cli/batch/commands.rs",
-        "line_start": 25
-      },
-      "new": {
-        "origin": "src/cli/batch/commands.rs",
-        "line_start": 26
+        "language": "rust",
+        "chunk_type": "struct",
+        "line_start": 25,
+        "line_end": 28
       }
     },
     {
@@ -914,8 +1014,8 @@
         "line_start": 22
       },
       "new": {
-        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
-        "line_start": 942
+        "origin": "src/schema.sql",
+        "line_start": 41
       }
     },
     {
@@ -933,7 +1033,7 @@
       },
       "new": {
         "origin": "src/search/scoring/candidate.rs",
-        "line_start": 260
+        "line_start": 344
       }
     },
     {
@@ -946,7 +1046,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 24
+        "line_start": 36
       }
     },
     {
@@ -956,16 +1056,15 @@
     },
     {
       "query": "tables with a BLOB column and a PRIMARY KEY",
-      "match_kind": "none",
-      "action": "unresolved",
-      "gold_chunk": {
-        "id": "src/schema.sql:108:744fc0db",
-        "name": "notes",
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
         "origin": "src/schema.sql",
-        "language": "sql",
-        "chunk_type": "struct",
-        "line_start": 108,
-        "line_end": 118
+        "line_start": 108
+      },
+      "new": {
+        "origin": "src/schema.sql",
+        "line_start": 147
       }
     },
     {
@@ -978,7 +1077,7 @@
       },
       "new": {
         "origin": "src/schema.sql",
-        "line_start": 74
+        "line_start": 105
       }
     },
     {
@@ -991,7 +1090,7 @@
       },
       "new": {
         "origin": "src/language/languages.rs",
-        "line_start": 6553
+        "line_start": 6602
       }
     },
     {
@@ -1004,7 +1103,7 @@
       },
       "new": {
         "origin": "src/cli/pipeline/embedding.rs",
-        "line_start": 197
+        "line_start": 234
       }
     },
     {
@@ -1036,27 +1135,26 @@
       },
       "new": {
         "origin": "src/store/helpers/types.rs",
-        "line_start": 424
+        "line_start": 616
       }
     },
     {
       "query": "abstract base class for large language model integration",
-      "match_kind": "none",
-      "action": "unresolved",
-      "gold_chunk": {
-        "id": "evals/llm_client.py:111:b21042fa:w2",
-        "name": "LLMClient",
-        "origin": "evals/llm_client.py",
-        "language": "python",
-        "chunk_type": "class",
-        "line_start": 111,
-        "line_end": 286
-      }
+      "match_kind": "strict",
+      "action": "no_change"
     },
     {
       "query": "call graph traversal for finding transitive dependencies",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/impact/analysis.rs",
+        "line_start": 221
+      },
+      "new": {
+        "origin": "src/impact/analysis.rs",
+        "line_start": 234
+      }
     },
     {
       "query": "simple metadata storage table",
@@ -1081,27 +1179,26 @@
       },
       "new": {
         "origin": "src/hnsw/persist.rs",
-        "line_start": 806
+        "line_start": 1068
       }
     },
     {
       "query": "Python equivalent of a close method in Rust's async traits",
-      "match_kind": "none",
-      "action": "unresolved",
-      "gold_chunk": {
-        "id": "evals/llm_client.py:284:4df39237",
-        "name": "aclose",
-        "origin": "evals/llm_client.py",
-        "language": "python",
-        "chunk_type": "method",
-        "line_start": 284,
-        "line_end": 286
-      }
+      "match_kind": "strict",
+      "action": "no_change"
     },
     {
       "query": "Store::open_readonly_small reference index mmap size",
-      "match_kind": "strict",
-      "action": "no_change"
+      "match_kind": "name",
+      "action": "updated",
+      "old": {
+        "origin": "src/reference.rs",
+        "line_start": 189
+      },
+      "new": {
+        "origin": "src/reference.rs",
+        "line_start": 194
+      }
     },
     {
       "query": "TaskTemplate",

--- a/evals/queries/v3_test.v2.json
+++ b/evals/queries/v3_test.v2.json
@@ -29,7 +29,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 108,
           "new_origin": "src/schema.sql",
-          "new_line_start": 116
+          "new_line_start": 147
         }
       },
       "judges": {
@@ -75,13 +75,13 @@
       "pool_size": 34,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:116:regen",
+        "id": "src/schema.sql:147:regen",
         "name": "notes",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 121,
-        "line_end": 131
+        "line_start": 147,
+        "line_end": 158
       },
       "gold_chunk_source": "consensus"
     },
@@ -96,8 +96,8 @@
           "match_kind": "name",
           "old_origin": "src/reranker.rs",
           "old_line_start": 105,
-          "new_origin": "src/reranker.rs",
-          "new_line_start": 125
+          "new_origin": "docs/audit-fix-prompts-v1.30.0.md",
+          "new_line_start": 246
         }
       },
       "judges": {
@@ -143,13 +143,13 @@
       "pool_size": 20,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/reranker.rs:125:regen",
+        "id": "docs/audit-fix-prompts-v1.30.0.md:246:regen",
         "name": "Reranker",
-        "origin": "src/reranker.rs",
+        "origin": "docs/audit-fix-prompts-v1.30.0.md",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 125,
-        "line_end": 561
+        "line_start": 246,
+        "line_end": 261
       },
       "gold_chunk_source": "consensus"
     },
@@ -165,7 +165,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 134,
           "new_origin": "src/schema.sql",
-          "new_line_start": 142
+          "new_line_start": 175
         }
       },
       "judges": {
@@ -211,13 +211,13 @@
       "pool_size": 38,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:142:regen",
+        "id": "src/schema.sql:175:regen",
         "name": "sparse_vectors",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 147,
-        "line_end": 153
+        "line_start": 175,
+        "line_end": 181
       },
       "gold_chunk_source": "consensus"
     },
@@ -233,7 +233,7 @@
           "old_origin": "src/hnsw/persist.rs",
           "old_line_start": 525,
           "new_origin": "src/hnsw/persist.rs",
-          "new_line_start": 533
+          "new_line_start": 686
         }
       },
       "judges": {
@@ -275,13 +275,13 @@
       "pool_size": 32,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/hnsw/persist.rs:533:regen",
+        "id": "src/hnsw/persist.rs:686:regen",
         "name": "load_with_dim",
         "origin": "src/hnsw/persist.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 599,
-        "line_end": 780
+        "line_start": 686,
+        "line_end": 954
       },
       "gold_chunk_source": "consensus"
     },
@@ -396,8 +396,8 @@
         "origin": "evals/generate_from_chunks.py",
         "language": "python",
         "chunk_type": "function",
-        "line_start": 115,
-        "line_end": 162
+        "line_start": 109,
+        "line_end": 156
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -414,7 +414,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 134,
           "new_origin": "src/schema.sql",
-          "new_line_start": 142
+          "new_line_start": 175
         }
       },
       "judges": {
@@ -456,13 +456,13 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:142:regen",
+        "id": "src/schema.sql:175:regen",
         "name": "sparse_vectors",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 147,
-        "line_end": 153
+        "line_start": 175,
+        "line_end": 181
       },
       "gold_chunk_source": "consensus"
     },
@@ -477,8 +477,8 @@
           "match_kind": "name",
           "old_origin": ".claude/worktrees/agent-a7cedd3c/src/cli/watch.rs",
           "old_line_start": 458,
-          "new_origin": "src/cli/watch.rs",
-          "new_line_start": 601
+          "new_origin": "src/cli/watch/rebuild.rs",
+          "new_line_start": 136
         }
       },
       "judges": {
@@ -524,13 +524,13 @@
       "pool_size": 29,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/watch.rs:601:regen",
+        "id": "src/cli/watch/rebuild.rs:136:regen",
         "name": "record_failure",
-        "origin": "src/cli/watch.rs",
+        "origin": "src/cli/watch/rebuild.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 603,
-        "line_end": 612
+        "line_start": 136,
+        "line_end": 145
       },
       "gold_chunk_source": "consensus"
     },
@@ -607,7 +607,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 134,
           "new_origin": "src/schema.sql",
-          "new_line_start": 142
+          "new_line_start": 175
         }
       },
       "judges": {
@@ -653,13 +653,13 @@
       "pool_size": 33,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:142:regen",
+        "id": "src/schema.sql:175:regen",
         "name": "sparse_vectors",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 147,
-        "line_end": 153
+        "line_start": 175,
+        "line_end": 181
       },
       "gold_chunk_source": "consensus"
     },
@@ -776,8 +776,8 @@
         "origin": "src/cli/batch/handlers/info.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 100,
-        "line_end": 155
+        "line_start": 93,
+        "line_end": 148
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -794,7 +794,7 @@
           "old_origin": "src/store/helpers/types.rs",
           "old_line_start": 240,
           "new_origin": "src/store/helpers/types.rs",
-          "new_line_start": 254
+          "new_line_start": 394
         }
       },
       "judges": {
@@ -838,13 +838,13 @@
       "pool_size": 39,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/store/helpers/types.rs:254:regen",
+        "id": "src/store/helpers/types.rs:394:regen",
         "name": "ChunkIdentity",
         "origin": "src/store/helpers/types.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 254,
-        "line_end": 272
+        "line_start": 394,
+        "line_end": 412
       },
       "gold_chunk_source": "consensus"
     },
@@ -860,7 +860,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 66,
           "new_origin": "src/schema.sql",
-          "new_line_start": 74
+          "new_line_start": 105
         }
       },
       "judges": {
@@ -906,13 +906,13 @@
       "pool_size": 43,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:74:regen",
+        "id": "src/schema.sql:105:regen",
         "name": "calls",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 79,
-        "line_end": 85
+        "line_start": 105,
+        "line_end": 111
       },
       "gold_chunk_source": "consensus"
     },
@@ -922,14 +922,7 @@
       "source": "generated",
       "metadata": {
         "target_category": "multi_step",
-        "matched": true,
-        "regenerated_2026_04_17": {
-          "match_kind": "basename",
-          "old_origin": ".claude/worktrees/agent-a7cedd3c/src/store/calls/cross_project.rs",
-          "old_line_start": 36,
-          "new_origin": "src/store/calls/cross_project.rs",
-          "new_line_start": 36
-        }
+        "matched": true
       },
       "judges": {
         "claude": {
@@ -972,15 +965,16 @@
       "pool_size": 39,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/store/calls/cross_project.rs:36:regen",
+        "id": ".claude/worktrees/agent-a7cedd3c/src/store/calls/cross_project.rs:36:04384a2b",
         "name": "CrossProjectCaller",
-        "origin": "src/store/calls/cross_project.rs",
+        "origin": ".claude/worktrees/agent-a7cedd3c/src/store/calls/cross_project.rs",
         "language": "rust",
         "chunk_type": "struct",
         "line_start": 36,
         "line_end": 41
       },
-      "gold_chunk_source": "consensus"
+      "gold_chunk_source": "consensus",
+      "_unresolved": true
     },
     {
       "query": "token budget packing for fitting results into context windows",
@@ -994,7 +988,7 @@
           "old_origin": "src/cli/batch/handlers/info.rs",
           "old_line_start": 161,
           "new_origin": "src/cli/batch/handlers/info.rs",
-          "new_line_start": 168
+          "new_line_start": 167
         }
       },
       "judges": {
@@ -1040,13 +1034,13 @@
       "pool_size": 22,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/batch/handlers/info.rs:168:regen",
+        "id": "src/cli/batch/handlers/info.rs:167:regen",
         "name": "dispatch_context",
         "origin": "src/cli/batch/handlers/info.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 168,
-        "line_end": 236
+        "line_start": 167,
+        "line_end": 254
       },
       "gold_chunk_source": "consensus"
     },
@@ -1056,7 +1050,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "type_filtered",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/hnsw/persist.rs",
+          "old_line_start": 172,
+          "new_origin": "src/hnsw/build.rs",
+          "new_line_start": 11
+        }
       },
       "judges": {
         "claude": {
@@ -1101,13 +1102,13 @@
       "pool_size": 8,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/hnsw/persist.rs:172:39cd287a:w15",
+        "id": "src/hnsw/build.rs:11:regen",
         "name": "HnswIndex",
-        "origin": "src/hnsw/persist.rs",
+        "origin": "src/hnsw/build.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 191,
-        "line_end": 956
+        "line_start": 11,
+        "line_end": 257
       },
       "gold_chunk_source": "consensus"
     },
@@ -1123,7 +1124,7 @@
           "old_origin": "src/cli/batch/handlers/graph.rs",
           "old_line_start": 346,
           "new_origin": "src/cli/batch/handlers/graph.rs",
-          "new_line_start": 392
+          "new_line_start": 429
         }
       },
       "judges": {
@@ -1169,13 +1170,13 @@
       "pool_size": 26,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/batch/handlers/graph.rs:392:regen",
+        "id": "src/cli/batch/handlers/graph.rs:429:regen",
         "name": "dispatch_impact_diff",
         "origin": "src/cli/batch/handlers/graph.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 392,
-        "line_end": 422
+        "line_start": 429,
+        "line_end": 451
       },
       "gold_chunk_source": "consensus"
     },
@@ -1185,7 +1186,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031281,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/index.rs",
+          "old_line_start": 20,
+          "new_origin": "src/index.rs",
+          "new_line_start": 32
+        }
       },
       "judges": {
         "claude": {
@@ -1230,13 +1238,13 @@
       "pool_size": 24,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/index.rs:32:regen",
         "name": "VectorIndex",
         "origin": "src/index.rs",
         "language": "rust",
         "chunk_type": "trait",
-        "line_start": 20,
-        "line_end": 86
+        "line_start": 32,
+        "line_end": 114
       },
       "gold_chunk_source": "consensus"
     },
@@ -1312,7 +1320,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031101,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/index.rs",
+          "old_line_start": 20,
+          "new_origin": "src/index.rs",
+          "new_line_start": 32
+        }
       },
       "judges": {
         "claude": {
@@ -1357,13 +1372,13 @@
       "pool_size": 30,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/index.rs:32:regen",
         "name": "VectorIndex",
         "origin": "src/index.rs",
         "language": "rust",
         "chunk_type": "trait",
-        "line_start": 20,
-        "line_end": 86
+        "line_start": 32,
+        "line_end": 114
       },
       "gold_chunk_source": "consensus"
     },
@@ -1373,7 +1388,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "conceptual_search",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "evals/run_ablation.py",
+          "old_line_start": 193,
+          "new_origin": "evals/run_ablation.py",
+          "new_line_start": 191
+        }
       },
       "judges": {
         "claude": {
@@ -1414,7 +1436,7 @@
       "pool_size": 34,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "evals/run_ablation.py:193:31486bfe",
+        "id": "evals/run_ablation.py:191:regen",
         "name": "format_category_table",
         "origin": "evals/run_ablation.py",
         "language": "python",
@@ -1422,8 +1444,7 @@
         "line_start": 191,
         "line_end": 207
       },
-      "gold_chunk_source": "consensus",
-      "_unresolved": true
+      "gold_chunk_source": "consensus"
     },
     {
       "query": "struct definitions in src/llm",
@@ -1437,7 +1458,7 @@
           "old_origin": "src/language/mod.rs",
           "old_line_start": 237,
           "new_origin": "src/language/mod.rs",
-          "new_line_start": 277
+          "new_line_start": 287
         }
       },
       "judges": {
@@ -1481,13 +1502,13 @@
       "pool_size": 39,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/language/mod.rs:277:regen",
+        "id": "src/language/mod.rs:287:regen",
         "name": "LanguageDef",
         "origin": "src/language/mod.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 277,
-        "line_end": 449
+        "line_start": 287,
+        "line_end": 489
       },
       "gold_chunk_source": "consensus"
     },
@@ -1677,8 +1698,8 @@
           "match_kind": "name",
           "old_origin": "src/schema.sql",
           "old_line_start": 22,
-          "new_origin": "docs/DESIGN_SPEC_27k_tokens.md",
-          "new_line_start": 942
+          "new_origin": "src/schema.sql",
+          "new_line_start": 41
         }
       },
       "judges": {
@@ -1722,13 +1743,13 @@
       "pool_size": 37,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "docs/DESIGN_SPEC_27k_tokens.md:942:regen",
+        "id": "src/schema.sql:41:regen",
         "name": "chunks",
-        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
+        "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 942,
-        "line_end": 958
+        "line_start": 41,
+        "line_end": 71
       },
       "gold_chunk_source": "consensus"
     },
@@ -1810,7 +1831,7 @@
           "old_origin": "src/language/mod.rs",
           "old_line_start": 679,
           "new_origin": "src/language/mod.rs",
-          "new_line_start": 875
+          "new_line_start": 923
         }
       },
       "judges": {
@@ -1854,13 +1875,13 @@
       "pool_size": 37,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/language/mod.rs:875:regen",
+        "id": "src/language/mod.rs:923:regen",
         "name": "LanguageRegistry",
         "origin": "src/language/mod.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 875,
-        "line_end": 880
+        "line_start": 923,
+        "line_end": 928
       },
       "gold_chunk_source": "consensus"
     },
@@ -1935,7 +1956,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 134,
           "new_origin": "src/schema.sql",
-          "new_line_start": 142
+          "new_line_start": 175
         }
       },
       "judges": {
@@ -1981,13 +2002,13 @@
       "pool_size": 22,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:142:regen",
+        "id": "src/schema.sql:175:regen",
         "name": "sparse_vectors",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 147,
-        "line_end": 153
+        "line_start": 175,
+        "line_end": 181
       },
       "gold_chunk_source": "consensus"
     },
@@ -2002,8 +2023,8 @@
           "match_kind": "name",
           "old_origin": "src/schema.sql",
           "old_line_start": 17,
-          "new_origin": "src/schema.sql",
-          "new_line_start": 24
+          "new_origin": "docs/DESIGN_SPEC_27k_tokens.md",
+          "new_line_start": 937
         }
       },
       "judges": {
@@ -2049,13 +2070,13 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:24:regen",
+        "id": "docs/DESIGN_SPEC_27k_tokens.md:937:regen",
         "name": "metadata",
-        "origin": "src/schema.sql",
+        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 27,
-        "line_end": 30
+        "line_start": 937,
+        "line_end": 940
       },
       "gold_chunk_source": "consensus"
     },
@@ -2111,8 +2132,8 @@
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 108,
-        "line_end": 115
+        "line_start": 95,
+        "line_end": 102
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -2129,7 +2150,7 @@
           "old_origin": ".claude/worktrees/agent-a7cedd3c/src/cache.rs",
           "old_line_start": 901,
           "new_origin": "src/cache.rs",
-          "new_line_start": 980
+          "new_line_start": 2383
         }
       },
       "judges": {
@@ -2175,13 +2196,13 @@
       "pool_size": 10,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cache.rs:980:regen",
+        "id": "src/cache.rs:2383:regen",
         "name": "QueryCache",
         "origin": "src/cache.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 1050,
-        "line_end": 1369
+        "line_start": 2383,
+        "line_end": 2730
       },
       "gold_chunk_source": "consensus"
     },
@@ -2252,14 +2273,7 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031453,
-        "source_cmd": "search",
-        "regenerated_2026_04_17": {
-          "match_kind": "name",
-          "old_origin": "src/cli/batch/mod.rs",
-          "old_line_start": 373,
-          "new_origin": "src/cli/batch/mod.rs",
-          "new_line_start": 475
-        }
+        "source_cmd": "search"
       },
       "judges": {
         "claude": {
@@ -2304,15 +2318,16 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/batch/mod.rs:475:regen",
+        "id": null,
         "name": "invalidate_mutable_caches",
         "origin": "src/cli/batch/mod.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 480,
-        "line_end": 523
+        "line_start": 373,
+        "line_end": 383
       },
-      "gold_chunk_source": "consensus"
+      "gold_chunk_source": "consensus",
+      "_unresolved": true
     },
     {
       "query": "TraceHop",
@@ -2384,8 +2399,8 @@
           "match_kind": "name",
           "old_origin": "src/schema.sql",
           "old_line_start": 17,
-          "new_origin": "src/schema.sql",
-          "new_line_start": 24
+          "new_origin": "docs/DESIGN_SPEC_27k_tokens.md",
+          "new_line_start": 937
         }
       },
       "judges": {
@@ -2431,13 +2446,13 @@
       "pool_size": 37,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:24:regen",
+        "id": "docs/DESIGN_SPEC_27k_tokens.md:937:regen",
         "name": "metadata",
-        "origin": "src/schema.sql",
+        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 27,
-        "line_end": 30
+        "line_start": 937,
+        "line_end": 940
       },
       "gold_chunk_source": "consensus"
     },
@@ -2571,7 +2586,7 @@
           "old_origin": "src/store/migrations.rs",
           "old_line_start": 429,
           "new_origin": "src/store/migrations.rs",
-          "new_line_start": 439
+          "new_line_start": 620
         }
       },
       "judges": {
@@ -2617,13 +2632,13 @@
       "pool_size": 21,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/store/migrations.rs:439:regen",
+        "id": "src/store/migrations.rs:620:regen",
         "name": "migrate_v17_to_v18",
         "origin": "src/store/migrations.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 443,
-        "line_end": 452
+        "line_start": 620,
+        "line_end": 629
       },
       "gold_chunk_source": "consensus"
     },
@@ -2698,7 +2713,7 @@
           "old_origin": "src/embedder/models.rs",
           "old_line_start": 147,
           "new_origin": "src/embedder/models.rs",
-          "new_line_start": 320
+          "new_line_start": 594
         }
       },
       "judges": {
@@ -2744,13 +2759,13 @@
       "pool_size": 13,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/embedder/models.rs:320:regen",
+        "id": "src/embedder/models.rs:594:regen",
         "name": "ModelConfig",
         "origin": "src/embedder/models.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 356,
-        "line_end": 559
+        "line_start": 594,
+        "line_end": 855
       },
       "gold_chunk_source": "consensus"
     },
@@ -2765,8 +2780,8 @@
           "match_kind": "name",
           "old_origin": "src/schema.sql",
           "old_line_start": 17,
-          "new_origin": "src/schema.sql",
-          "new_line_start": 24
+          "new_origin": "docs/DESIGN_SPEC_27k_tokens.md",
+          "new_line_start": 937
         }
       },
       "judges": {
@@ -2812,13 +2827,13 @@
       "pool_size": 39,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:24:regen",
+        "id": "docs/DESIGN_SPEC_27k_tokens.md:937:regen",
         "name": "metadata",
-        "origin": "src/schema.sql",
+        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 27,
-        "line_end": 30
+        "line_start": 937,
+        "line_end": 940
       },
       "gold_chunk_source": "consensus"
     },
@@ -2828,7 +2843,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "cross_language",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/store/chunks/crud.rs",
+          "old_line_start": 427,
+          "new_origin": "src/store/chunks/crud.rs",
+          "new_line_start": 764
+        }
       },
       "judges": {
         "claude": {
@@ -2873,13 +2895,13 @@
       "pool_size": 34,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/store/chunks/crud.rs:427:9352f991",
+        "id": "src/store/chunks/crud.rs:764:regen",
         "name": "delete_by_origin",
         "origin": "src/store/chunks/crud.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 506,
-        "line_end": 538
+        "line_start": 764,
+        "line_end": 796
       },
       "gold_chunk_source": "consensus"
     },
@@ -2956,7 +2978,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 123,
           "new_origin": "src/schema.sql",
-          "new_line_start": 131
+          "new_line_start": 164
         }
       },
       "judges": {
@@ -3002,13 +3024,13 @@
       "pool_size": 37,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:131:regen",
+        "id": "src/schema.sql:164:regen",
         "name": "notes_fts",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 136,
-        "line_end": 140
+        "line_start": 164,
+        "line_end": 168
       },
       "gold_chunk_source": "consensus"
     },
@@ -3018,7 +3040,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031291,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/hnsw/mod.rs",
+          "old_line_start": 146,
+          "new_origin": "src/hnsw/mod.rs",
+          "new_line_start": 261
+        }
       },
       "judges": {
         "claude": {
@@ -3061,13 +3090,13 @@
       "pool_size": 14,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/hnsw/mod.rs:261:regen",
         "name": "HnswIoCell",
         "origin": "src/hnsw/mod.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 146,
-        "line_end": 146
+        "line_start": 261,
+        "line_end": 261
       },
       "gold_chunk_source": "consensus"
     },
@@ -3083,7 +3112,7 @@
           "old_origin": "src/search/scoring/candidate.rs",
           "old_line_start": 167,
           "new_origin": "src/search/scoring/candidate.rs",
-          "new_line_start": 175
+          "new_line_start": 199
         }
       },
       "judges": {
@@ -3129,13 +3158,13 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/search/scoring/candidate.rs:175:regen",
+        "id": "src/search/scoring/candidate.rs:199:regen",
         "name": "BoundedScoreHeap",
         "origin": "src/search/scoring/candidate.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 175,
-        "line_end": 254
+        "line_start": 199,
+        "line_end": 338
       },
       "gold_chunk_source": "consensus"
     },
@@ -3257,7 +3286,8 @@
         "line_start": 24,
         "line_end": 37
       },
-      "gold_chunk_source": "consensus"
+      "gold_chunk_source": "consensus",
+      "_unresolved": true
     },
     {
       "query": "implementation of TextJsonArgs",
@@ -3326,7 +3356,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031433,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/embedder/mod.rs",
+          "old_line_start": 217,
+          "new_origin": "src/embedder/mod.rs",
+          "new_line_start": 261
+        }
       },
       "judges": {
         "claude": {
@@ -3371,16 +3408,15 @@
       "pool_size": 26,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/embedder/mod.rs:261:regen",
         "name": "Embedder",
         "origin": "src/embedder/mod.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 225,
-        "line_end": 271
+        "line_start": 261,
+        "line_end": 338
       },
-      "gold_chunk_source": "consensus",
-      "_unresolved": true
+      "gold_chunk_source": "consensus"
     },
     {
       "query": "dead code detection and unused function analysis",
@@ -3388,7 +3424,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031071,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/cli/batch/handlers/analysis.rs",
+          "old_line_start": 23,
+          "new_origin": "src/cli/batch/handlers/analysis.rs",
+          "new_line_start": 26
+        }
       },
       "judges": {
         "claude": {
@@ -3431,13 +3474,13 @@
       "pool_size": 37,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/cli/batch/handlers/analysis.rs:26:regen",
         "name": "dispatch_dead",
         "origin": "src/cli/batch/handlers/analysis.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 23,
-        "line_end": 43
+        "line_start": 26,
+        "line_end": 47
       },
       "gold_chunk_source": "consensus"
     },
@@ -3453,7 +3496,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 108,
           "new_origin": "src/schema.sql",
-          "new_line_start": 116
+          "new_line_start": 147
         }
       },
       "judges": {
@@ -3499,13 +3542,13 @@
       "pool_size": 34,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:116:regen",
+        "id": "src/schema.sql:147:regen",
         "name": "notes",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 121,
-        "line_end": 131
+        "line_start": 147,
+        "line_end": 158
       },
       "gold_chunk_source": "consensus"
     },
@@ -3521,7 +3564,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 108,
           "new_origin": "src/schema.sql",
-          "new_line_start": 116
+          "new_line_start": 147
         }
       },
       "judges": {
@@ -3563,13 +3606,13 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:116:regen",
+        "id": "src/schema.sql:147:regen",
         "name": "notes",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 121,
-        "line_end": 131
+        "line_start": 147,
+        "line_end": 158
       },
       "gold_chunk_source": "consensus"
     },
@@ -3579,7 +3622,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "negation",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/llm/mod.rs",
+          "old_line_start": 375,
+          "new_origin": "src/llm/mod.rs",
+          "new_line_start": 621
+        }
       },
       "judges": {
         "claude": {
@@ -3624,13 +3674,13 @@
       "pool_size": 16,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/llm/mod.rs:375:873dd6d6",
+        "id": "src/llm/mod.rs:621:regen",
         "name": "LlmClient",
         "origin": "src/llm/mod.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 375,
-        "line_end": 402
+        "line_start": 621,
+        "line_end": 648
       },
       "gold_chunk_source": "consensus"
     },
@@ -3640,14 +3690,7 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031683,
-        "source_cmd": "search",
-        "regenerated_2026_04_17": {
-          "match_kind": "name",
-          "old_origin": "src/language/languages.rs",
-          "old_line_start": 5896,
-          "new_origin": "src/language/languages.rs",
-          "new_line_start": 6060
-        }
+        "source_cmd": "search"
       },
       "judges": {
         "claude": {
@@ -3690,15 +3733,16 @@
       "pool_size": 29,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/language/languages.rs:6060:regen",
+        "id": null,
         "name": "LANG_RUBY",
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "constant",
-        "line_start": 6067,
-        "line_end": 6148
+        "line_start": 5896,
+        "line_end": 5973
       },
-      "gold_chunk_source": "consensus"
+      "gold_chunk_source": "consensus",
+      "_unresolved": true
     },
     {
       "query": "how to define a table with foreign key constraints in SQLite vs PostgreSQL",
@@ -3712,7 +3756,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 95,
           "new_origin": "src/schema.sql",
-          "new_line_start": 103
+          "new_line_start": 134
         }
       },
       "judges": {
@@ -3758,13 +3802,13 @@
       "pool_size": 32,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:103:regen",
+        "id": "src/schema.sql:134:regen",
         "name": "type_edges",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 108,
-        "line_end": 115
+        "line_start": 134,
+        "line_end": 141
       },
       "gold_chunk_source": "consensus"
     },
@@ -3901,7 +3945,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031160,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/store/helpers/search_filter.rs",
+          "old_line_start": 16,
+          "new_origin": "src/store/helpers/search_filter.rs",
+          "new_line_start": 27
+        }
       },
       "judges": {
         "claude": {
@@ -3944,13 +3995,13 @@
       "pool_size": 32,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/store/helpers/search_filter.rs:27:regen",
         "name": "SearchFilter",
         "origin": "src/store/helpers/search_filter.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 16,
-        "line_end": 59
+        "line_start": 27,
+        "line_end": 80
       },
       "gold_chunk_source": "consensus"
     },
@@ -3966,7 +4017,7 @@
           "old_origin": "src/cli/commands/infra/project.rs",
           "old_line_start": 20,
           "new_origin": "src/cli/commands/infra/project.rs",
-          "new_line_start": 23
+          "new_line_start": 24
         }
       },
       "judges": {
@@ -4010,13 +4061,13 @@
       "pool_size": 30,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/commands/infra/project.rs:23:regen",
+        "id": "src/cli/commands/infra/project.rs:24:regen",
         "name": "ProjectSearchResult",
         "origin": "src/cli/commands/infra/project.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 23,
-        "line_end": 31
+        "line_start": 24,
+        "line_end": 32
       },
       "gold_chunk_source": "consensus"
     },
@@ -4032,7 +4083,7 @@
           "old_origin": "src/search/router.rs",
           "old_line_start": 851,
           "new_origin": "src/search/router.rs",
-          "new_line_start": 911
+          "new_line_start": 1437
         }
       },
       "judges": {
@@ -4078,13 +4129,13 @@
       "pool_size": 19,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/search/router.rs:911:regen",
+        "id": "src/search/router.rs:1437:regen",
         "name": "extract_type_hints",
         "origin": "src/search/router.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 950,
-        "line_end": 970
+        "line_start": 1437,
+        "line_end": 1457
       },
       "gold_chunk_source": "consensus"
     },
@@ -4100,7 +4151,7 @@
           "old_origin": "src/language/mod.rs",
           "old_line_start": 666,
           "new_origin": "src/language/mod.rs",
-          "new_line_start": 862
+          "new_line_start": 910
         }
       },
       "judges": {
@@ -4144,13 +4195,13 @@
       "pool_size": 25,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/language/mod.rs:862:regen",
+        "id": "src/language/mod.rs:910:regen",
         "name": "fmt",
         "origin": "src/language/mod.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 862,
-        "line_end": 869
+        "line_start": 910,
+        "line_end": 917
       },
       "gold_chunk_source": "consensus"
     },
@@ -4166,7 +4217,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 167,
           "new_origin": "src/schema.sql",
-          "new_line_start": 175
+          "new_line_start": 208
         }
       },
       "judges": {
@@ -4212,13 +4263,13 @@
       "pool_size": 35,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:175:regen",
+        "id": "src/schema.sql:208:regen",
         "name": "llm_summaries",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 180,
-        "line_end": 187
+        "line_start": 208,
+        "line_end": 215
       },
       "gold_chunk_source": "consensus"
     },
@@ -4234,7 +4285,7 @@
           "old_origin": "src/cache.rs",
           "old_line_start": 321,
           "new_origin": "src/cache.rs",
-          "new_line_start": 1103
+          "new_line_start": 2533
         }
       },
       "judges": {
@@ -4280,13 +4331,13 @@
       "pool_size": 30,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cache.rs:1103:regen",
+        "id": "src/cache.rs:2533:regen",
         "name": "evict",
         "origin": "src/cache.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 1189,
-        "line_end": 1255
+        "line_start": 2533,
+        "line_end": 2611
       },
       "gold_chunk_source": "consensus"
     },
@@ -4359,7 +4410,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 95,
           "new_origin": "src/schema.sql",
-          "new_line_start": 103
+          "new_line_start": 134
         }
       },
       "judges": {
@@ -4405,13 +4456,13 @@
       "pool_size": 32,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:103:regen",
+        "id": "src/schema.sql:134:regen",
         "name": "type_edges",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 108,
-        "line_end": 115
+        "line_start": 134,
+        "line_end": 141
       },
       "gold_chunk_source": "consensus"
     },
@@ -4427,7 +4478,7 @@
           "old_origin": "src/cagra.rs",
           "old_line_start": 748,
           "new_origin": "src/cagra.rs",
-          "new_line_start": 241
+          "new_line_start": 749
         }
       },
       "judges": {
@@ -4471,13 +4522,13 @@
       "pool_size": 16,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cagra.rs:241:regen",
+        "id": "src/cagra.rs:749:regen",
         "name": "CagraIndex",
         "origin": "src/cagra.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 250,
-        "line_end": 257
+        "line_start": 749,
+        "line_end": 749
       },
       "gold_chunk_source": "consensus"
     },
@@ -4551,8 +4602,8 @@
           "match_kind": "name",
           "old_origin": "src/cli/batch/commands.rs",
           "old_line_start": 281,
-          "new_origin": "src/cli/batch/commands.rs",
-          "new_line_start": 406
+          "new_origin": "src/cli/batch/handlers/dispatch_tests.rs",
+          "new_line_start": 211
         }
       },
       "judges": {
@@ -4598,13 +4649,13 @@
       "pool_size": 21,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/batch/commands.rs:406:regen",
+        "id": "src/cli/batch/handlers/dispatch_tests.rs:211:regen",
         "name": "dispatch",
-        "origin": "src/cli/batch/commands.rs",
+        "origin": "src/cli/batch/handlers/dispatch_tests.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 406,
-        "line_end": 537
+        "line_start": 211,
+        "line_end": 224
       },
       "gold_chunk_source": "consensus"
     },
@@ -4620,7 +4671,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 123,
           "new_origin": "src/schema.sql",
-          "new_line_start": 131
+          "new_line_start": 164
         }
       },
       "judges": {
@@ -4666,13 +4717,13 @@
       "pool_size": 33,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:131:regen",
+        "id": "src/schema.sql:164:regen",
         "name": "notes_fts",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 136,
-        "line_end": 140
+        "line_start": 164,
+        "line_end": 168
       },
       "gold_chunk_source": "consensus"
     },
@@ -4749,7 +4800,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 78,
           "new_origin": "src/schema.sql",
-          "new_line_start": 86
+          "new_line_start": 117
         }
       },
       "judges": {
@@ -4793,13 +4844,13 @@
       "pool_size": 38,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:86:regen",
+        "id": "src/schema.sql:117:regen",
         "name": "function_calls",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 91,
-        "line_end": 98
+        "line_start": 117,
+        "line_end": 124
       },
       "gold_chunk_source": "consensus"
     },
@@ -4874,7 +4925,7 @@
           "old_origin": "src/store/search.rs",
           "old_line_start": 159,
           "new_origin": "src/store/search.rs",
-          "new_line_start": 182
+          "new_line_start": 324
         }
       },
       "judges": {
@@ -4920,13 +4971,13 @@
       "pool_size": 32,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/store/search.rs:182:regen",
+        "id": "src/store/search.rs:324:regen",
         "name": "rrf_fuse",
         "origin": "src/store/search.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 182,
-        "line_end": 229
+        "line_start": 324,
+        "line_end": 331
       },
       "gold_chunk_source": "consensus"
     },
@@ -4942,7 +4993,7 @@
           "old_origin": "src/nl/mod.rs",
           "old_line_start": 652,
           "new_origin": "src/nl/mod.rs",
-          "new_line_start": 655
+          "new_line_start": 664
         }
       },
       "judges": {
@@ -4986,13 +5037,13 @@
       "pool_size": 34,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/nl/mod.rs:655:regen",
+        "id": "src/nl/mod.rs:664:regen",
         "name": "make_section_chunk",
         "origin": "src/nl/mod.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 655,
-        "line_end": 673
+        "line_start": 664,
+        "line_end": 682
       },
       "gold_chunk_source": "consensus"
     },
@@ -5002,7 +5053,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031690,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/store/search.rs",
+          "old_line_start": 37,
+          "new_origin": "docs/DESIGN_SPEC_27k_tokens.md",
+          "new_line_start": 979
+        }
       },
       "judges": {
         "claude": {
@@ -5047,16 +5105,15 @@
       "pool_size": 20,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "docs/DESIGN_SPEC_27k_tokens.md:979:regen",
         "name": "Store",
-        "origin": "src/store/search.rs",
+        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 37,
-        "line_end": 218
+        "line_start": 979,
+        "line_end": 1035
       },
-      "gold_chunk_source": "consensus",
-      "_unresolved": true
+      "gold_chunk_source": "consensus"
     },
     {
       "query": "save HNSW index to disk with checksum verification",
@@ -5064,7 +5121,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031060,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/hnsw/persist.rs",
+          "old_line_start": 189,
+          "new_origin": "src/hnsw/persist.rs",
+          "new_line_start": 236
+        }
       },
       "judges": {
         "claude": {
@@ -5109,13 +5173,13 @@
       "pool_size": 19,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/hnsw/persist.rs:236:regen",
         "name": "save",
         "origin": "src/hnsw/persist.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 208,
-        "line_end": 593
+        "line_start": 236,
+        "line_end": 680
       },
       "gold_chunk_source": "consensus"
     },
@@ -5130,8 +5194,8 @@
           "match_kind": "name",
           "old_origin": "src/schema.sql",
           "old_line_start": 22,
-          "new_origin": "docs/DESIGN_SPEC_27k_tokens.md",
-          "new_line_start": 942
+          "new_origin": "src/schema.sql",
+          "new_line_start": 41
         }
       },
       "judges": {
@@ -5173,13 +5237,13 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "docs/DESIGN_SPEC_27k_tokens.md:942:regen",
+        "id": "src/schema.sql:41:regen",
         "name": "chunks",
-        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
+        "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 942,
-        "line_end": 958
+        "line_start": 41,
+        "line_end": 71
       },
       "gold_chunk_source": "consensus"
     },
@@ -5419,7 +5483,8 @@
         "line_start": 191,
         "line_end": 191
       },
-      "gold_chunk_source": "consensus"
+      "gold_chunk_source": "consensus",
+      "_unresolved": true
     },
     {
       "query": "SPLADE encoder encode_batch tensor shape validation",
@@ -5432,8 +5497,8 @@
           "match_kind": "name",
           "old_origin": "src/splade/mod.rs",
           "old_line_start": 580,
-          "new_origin": "docs/superpowers/plans/2026-04-06-splade-sparse-dense-hybrid.md",
-          "new_line_start": 220
+          "new_origin": "src/splade/mod.rs",
+          "new_line_start": 769
         }
       },
       "judges": {
@@ -5479,13 +5544,13 @@
       "pool_size": 19,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "docs/superpowers/plans/2026-04-06-splade-sparse-dense-hybrid.md:220:regen",
+        "id": "src/splade/mod.rs:769:regen",
         "name": "encode_batch",
-        "origin": "docs/superpowers/plans/2026-04-06-splade-sparse-dense-hybrid.md",
+        "origin": "src/splade/mod.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 220,
-        "line_end": 223
+        "line_start": 769,
+        "line_end": 1077
       },
       "gold_chunk_source": "consensus"
     },
@@ -5495,7 +5560,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031391,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/convert/html.rs",
+          "old_line_start": 43,
+          "new_origin": "src/convert/html.rs",
+          "new_line_start": 45
+        }
       },
       "judges": {
         "claude": {
@@ -5538,7 +5610,7 @@
       "pool_size": 31,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/convert/html.rs:45:regen",
         "name": "html_file_to_markdown",
         "origin": "src/convert/html.rs",
         "language": "rust",
@@ -5560,7 +5632,7 @@
           "old_origin": "src/language/languages.rs",
           "old_line_start": 4529,
           "new_origin": "src/language/languages.rs",
-          "new_line_start": 4655
+          "new_line_start": 4692
         }
       },
       "judges": {
@@ -5604,13 +5676,13 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/language/languages.rs:4655:regen",
+        "id": "src/language/languages.rs:4692:regen",
         "name": "extract_return_ocaml",
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 4662,
-        "line_end": 4681
+        "line_start": 4692,
+        "line_end": 4711
       },
       "gold_chunk_source": "consensus"
     },
@@ -5620,14 +5692,7 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031568,
-        "source_cmd": "search",
-        "regenerated_2026_04_17": {
-          "match_kind": "name",
-          "old_origin": "src/language/languages.rs",
-          "old_line_start": 6471,
-          "new_origin": "src/language/languages.rs",
-          "new_line_start": 6662
-        }
+        "source_cmd": "search"
       },
       "judges": {
         "claude": {
@@ -5670,15 +5735,16 @@
       "pool_size": 40,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/language/languages.rs:6662:regen",
+        "id": null,
         "name": "post_process_solidity_solidity",
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 6672,
-        "line_end": 6690
+        "line_start": 6471,
+        "line_end": 6489
       },
-      "gold_chunk_source": "consensus"
+      "gold_chunk_source": "consensus",
+      "_unresolved": true
     },
     {
       "query": "struct definitions in src/cli/commands/infra",
@@ -5686,14 +5752,7 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031354,
-        "source_cmd": "search",
-        "regenerated_2026_04_17": {
-          "match_kind": "name",
-          "old_origin": "src/cli/batch/commands.rs",
-          "old_line_start": 25,
-          "new_origin": "src/cli/batch/commands.rs",
-          "new_line_start": 26
-        }
+        "source_cmd": "search"
       },
       "judges": {
         "claude": {
@@ -5736,15 +5795,16 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/batch/commands.rs:26:regen",
+        "id": null,
         "name": "BatchInput",
         "origin": "src/cli/batch/commands.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 26,
-        "line_end": 29
+        "line_start": 25,
+        "line_end": 28
       },
-      "gold_chunk_source": "consensus"
+      "gold_chunk_source": "consensus",
+      "_unresolved": true
     },
     {
       "query": "table named chunks AND columns with NOT NULL constraints",
@@ -5757,8 +5817,8 @@
           "match_kind": "name",
           "old_origin": "src/schema.sql",
           "old_line_start": 22,
-          "new_origin": "docs/DESIGN_SPEC_27k_tokens.md",
-          "new_line_start": 942
+          "new_origin": "src/schema.sql",
+          "new_line_start": 41
         }
       },
       "judges": {
@@ -5800,13 +5860,13 @@
       "pool_size": 40,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "docs/DESIGN_SPEC_27k_tokens.md:942:regen",
+        "id": "src/schema.sql:41:regen",
         "name": "chunks",
-        "origin": "docs/DESIGN_SPEC_27k_tokens.md",
+        "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 942,
-        "line_end": 958
+        "line_start": 41,
+        "line_end": 71
       },
       "gold_chunk_source": "consensus"
     },
@@ -5881,7 +5941,7 @@
           "old_origin": "src/search/scoring/candidate.rs",
           "old_line_start": 240,
           "new_origin": "src/search/scoring/candidate.rs",
-          "new_line_start": 260
+          "new_line_start": 344
         }
       },
       "judges": {
@@ -5927,13 +5987,13 @@
       "pool_size": 18,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/search/scoring/candidate.rs:260:regen",
+        "id": "src/search/scoring/candidate.rs:344:regen",
         "name": "ScoringContext",
         "origin": "src/search/scoring/candidate.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 260,
-        "line_end": 270
+        "line_start": 344,
+        "line_end": 354
       },
       "gold_chunk_source": "consensus"
     },
@@ -5949,7 +6009,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 17,
           "new_origin": "src/schema.sql",
-          "new_line_start": 24
+          "new_line_start": 36
         }
       },
       "judges": {
@@ -5993,13 +6053,13 @@
       "pool_size": 38,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:24:regen",
+        "id": "src/schema.sql:36:regen",
         "name": "metadata",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 27,
-        "line_end": 30
+        "line_start": 36,
+        "line_end": 39
       },
       "gold_chunk_source": "consensus"
     },
@@ -6068,7 +6128,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "structural_search",
-        "matched": true
+        "matched": true,
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/schema.sql",
+          "old_line_start": 108,
+          "new_origin": "src/schema.sql",
+          "new_line_start": 147
+        }
       },
       "judges": {
         "claude": {
@@ -6109,16 +6176,15 @@
       "pool_size": 35,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:108:744fc0db",
+        "id": "src/schema.sql:147:regen",
         "name": "notes",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 121,
-        "line_end": 131
+        "line_start": 147,
+        "line_end": 158
       },
-      "gold_chunk_source": "consensus",
-      "_unresolved": true
+      "gold_chunk_source": "consensus"
     },
     {
       "query": "columns for callee_name AND line_number OR caller_id",
@@ -6132,7 +6198,7 @@
           "old_origin": "src/schema.sql",
           "old_line_start": 66,
           "new_origin": "src/schema.sql",
-          "new_line_start": 74
+          "new_line_start": 105
         }
       },
       "judges": {
@@ -6178,13 +6244,13 @@
       "pool_size": 34,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/schema.sql:74:regen",
+        "id": "src/schema.sql:105:regen",
         "name": "calls",
         "origin": "src/schema.sql",
         "language": "sql",
         "chunk_type": "struct",
-        "line_start": 79,
-        "line_end": 85
+        "line_start": 105,
+        "line_end": 111
       },
       "gold_chunk_source": "consensus"
     },
@@ -6200,7 +6266,7 @@
           "old_origin": "src/language/languages.rs",
           "old_line_start": 6366,
           "new_origin": "src/language/languages.rs",
-          "new_line_start": 6553
+          "new_line_start": 6602
         }
       },
       "judges": {
@@ -6244,13 +6310,13 @@
       "pool_size": 36,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/language/languages.rs:6553:regen",
+        "id": "src/language/languages.rs:6602:regen",
         "name": "extract_return_solidity",
         "origin": "src/language/languages.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 6563,
-        "line_end": 6580
+        "line_start": 6602,
+        "line_end": 6619
       },
       "gold_chunk_source": "consensus"
     },
@@ -6266,7 +6332,7 @@
           "old_origin": "src/cli/pipeline/embedding.rs",
           "old_line_start": 189,
           "new_origin": "src/cli/pipeline/embedding.rs",
-          "new_line_start": 197
+          "new_line_start": 234
         }
       },
       "judges": {
@@ -6308,13 +6374,13 @@
       "pool_size": 40,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/cli/pipeline/embedding.rs:197:regen",
+        "id": "src/cli/pipeline/embedding.rs:234:regen",
         "name": "gpu_embed_stage",
         "origin": "src/cli/pipeline/embedding.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 197,
-        "line_end": 344
+        "line_start": 234,
+        "line_end": 422
       },
       "gold_chunk_source": "consensus"
     },
@@ -6449,7 +6515,7 @@
           "old_origin": "src/store/helpers/types.rs",
           "old_line_start": 410,
           "new_origin": "src/store/helpers/types.rs",
-          "new_line_start": 424
+          "new_line_start": 616
         }
       },
       "judges": {
@@ -6493,13 +6559,13 @@
       "pool_size": 35,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/store/helpers/types.rs:424:regen",
+        "id": "src/store/helpers/types.rs:616:regen",
         "name": "make_chunk",
         "origin": "src/store/helpers/types.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 424,
-        "line_end": 442
+        "line_start": 616,
+        "line_end": 635
       },
       "gold_chunk_source": "consensus"
     },
@@ -6558,8 +6624,7 @@
         "line_start": 111,
         "line_end": 286
       },
-      "gold_chunk_source": "consensus",
-      "_unresolved": true
+      "gold_chunk_source": "consensus"
     },
     {
       "query": "call graph traversal for finding transitive dependencies",
@@ -6567,7 +6632,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031421,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/impact/analysis.rs",
+          "old_line_start": 221,
+          "new_origin": "src/impact/analysis.rs",
+          "new_line_start": 234
+        }
       },
       "judges": {
         "claude": {
@@ -6612,13 +6684,13 @@
       "pool_size": 35,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/impact/analysis.rs:234:regen",
         "name": "find_transitive_callers",
         "origin": "src/impact/analysis.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 232,
-        "line_end": 279
+        "line_start": 234,
+        "line_end": 282
       },
       "gold_chunk_source": "consensus"
     },
@@ -6702,7 +6774,7 @@
           "old_origin": "src/hnsw/persist.rs",
           "old_line_start": 798,
           "new_origin": "src/hnsw/persist.rs",
-          "new_line_start": 806
+          "new_line_start": 1068
         }
       },
       "judges": {
@@ -6748,13 +6820,13 @@
       "pool_size": 28,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": "src/hnsw/persist.rs:806:regen",
+        "id": "src/hnsw/persist.rs:1068:regen",
         "name": "try_load_with_ef",
         "origin": "src/hnsw/persist.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 894,
-        "line_end": 900
+        "line_start": 1068,
+        "line_end": 1074
       },
       "gold_chunk_source": "consensus"
     },
@@ -6815,8 +6887,7 @@
         "line_start": 284,
         "line_end": 286
       },
-      "gold_chunk_source": "consensus",
-      "_unresolved": true
+      "gold_chunk_source": "consensus"
     },
     {
       "query": "Store::open_readonly_small reference index mmap size",
@@ -6824,7 +6895,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776273951,
-        "source_cmd": "scout"
+        "source_cmd": "scout",
+        "regenerated_2026_04_17": {
+          "match_kind": "name",
+          "old_origin": "src/reference.rs",
+          "old_line_start": 189,
+          "new_origin": "src/reference.rs",
+          "new_line_start": 194
+        }
       },
       "judges": {
         "claude": {
@@ -6869,13 +6947,13 @@
       "pool_size": 31,
       "tier": "high_confidence",
       "gold_chunk": {
-        "id": null,
+        "id": "src/reference.rs:194:regen",
         "name": "load_references",
         "origin": "src/reference.rs",
         "language": "rust",
         "chunk_type": "function",
-        "line_start": 189,
-        "line_end": 224
+        "line_start": 194,
+        "line_end": 235
       },
       "gold_chunk_source": "consensus"
     },
@@ -6939,12 +7017,12 @@
       "gold_chunk_source": "consensus"
     }
   ],
-  "regenerated_at": "2026-04-19",
+  "regenerated_at": "2026-05-08",
   "regenerated_against": "current index (k=50)",
   "regenerated_counts": {
-    "strict": 41,
-    "basename": 1,
-    "name": 57,
-    "none": 10
+    "strict": 29,
+    "basename": 0,
+    "name": 69,
+    "none": 11
   }
 }


### PR DESCRIPTION
## Summary

Re-anchored the `v3.v2` test+dev gold_chunk pointers to current corpus state via `evals/regenerate_v3_test.py`. Audit-driven line shifts since the 2026-04-25 v2 generation had drifted ~30% of fixture matches into "miss" territory at the (file, name, line_start) strict comparator. This refresh keeps the **same queries** but updates `line_start` to where each gold chunk lives now.

No retrieval-side changes — purely fixture re-anchoring.

## Resolution counts

| Split | strict | basename | name (refresh) | unresolved |
|---|---:|---:|---:|---:|
| test (109) | 29 | 0 | 69 | 11 |
| dev (109) | 33 | 1 | 71 | 4 |

The 15 unresolved queries are ones whose original gold chunk was renamed/deleted/moved out of indexable surface since v3.v2 was cut. They stay in-fixture as null-gold so per-query counts stay fixed; they'll reliably miss until a human re-judges or removes them.

## Eval impact

Post-v1.39.2 default slot (EmbeddingGemma-300m + per-cat α + Unknown=0.80):

| Split | R@1 | R@5 | R@20 |
|---|---:|---:|---:|
| test (post-refresh) | 49.5% | 72.5% | 84.4% |
| dev (post-refresh) | 56.0% | 82.6% | 94.5% |
| **agg pre-refresh** | **46.3%** | **74.8%** | **86.2%** |
| **agg post-refresh** | **~52.7%** | **~77.5%** | **~89.4%** |
| **Δ (line-shift recovery)** | **+6.4pp** | **+2.7pp** | **+3.2pp** |

Brings headline R@K back to (slightly above) the v1.36-snapshot range (50.9 / 76.2 / 88.6) — the refresh recovers the line-shift dilution that the 2026-05-08 telemetry capture was compensating for.

## Test plan

- [x] `python3 evals/regenerate_v3_test.py --split test` → 69 of 109 lines refreshed
- [x] `python3 evals/regenerate_v3_test.py --split dev` → 71 of 109 lines refreshed
- [x] `cqs eval --json evals/queries/v3_test.v2.json` → R@1 49.5%, R@5 72.5%, R@20 84.4%
- [x] `cqs eval --json evals/queries/v3_dev.v2.json` → R@1 56.0%, R@5 82.6%, R@20 94.5%
- [x] Diff records (`*.diff.json`) preserved for audit trail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
