### PR TITLE
feat(callers, callees): kind-mismatch matrix

### DIFF
--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -1,12 +1,27 @@
 //! Call graph commands for cqs
 //!
 //! Provides callers/callees analysis.
+//!
+//! ## Polymorphic routing (Phase 1)
+//!
+//! `cqs callers <name>` and `cqs callees <name>` historically required a
+//! function-or-method name and returned an empty `Vec` for any other
+//! chunk kind — the misrouted-to-empty failure mode the polymorphic-
+//! routing design (`docs/polymorphic-routing.md`) targets. Both commands
+//! now consult `cqs::kind::classify_hits` against an exact-name lookup
+//! before the call-graph query: kind-mismatch fallbacks return an object
+//! with `kind`, `fallback_from`, `name`, `definitions`, and `note`
+//! fields. The function-path success shape (a flat array of caller/callee
+//! entries) is unchanged so existing consumers see no change on the
+//! happy path; agents detect the dispatch decision by type
+//! (`isinstance(parsed, list)` ⇒ function path, `dict` ⇒ fallback).
 
 use anyhow::{Context as _, Result};
 use colored::Colorize;
 
+use cqs::kind::{classify_hits, Kind, KindHit};
 use cqs::normalize_path;
-use cqs::store::CallerInfo;
+use cqs::store::{CallerInfo, ChunkSummary};
 
 // ─── Output types ──────────────────────────────────────────────────────────
 
@@ -61,6 +76,78 @@ pub(crate) fn build_callees(name: &str, callees: &[(String, u32)]) -> CalleesOut
     }
 }
 
+// ─── Polymorphic-routing fallbacks ─────────────────────────────────────────
+
+/// Build a definitions list from chunks for kind-mismatch fallbacks.
+/// Mirrors `cmd_impact`'s `chunks_to_definitions` (per-command duplication
+/// is intentional for now — if the pattern stays stable across all 6
+/// commands, lift to a shared module in a follow-up).
+fn chunks_to_definitions(chunks: &[ChunkSummary]) -> Vec<serde_json::Value> {
+    chunks
+        .iter()
+        .map(|c| {
+            serde_json::json!({
+                "file": cqs::normalize_path(&c.file),
+                "line_start": c.line_start,
+                "line_end": c.line_end,
+                "language": c.language.to_string(),
+                "chunk_type": c.chunk_type.to_string(),
+                "signature": c.signature,
+                "content": c.content,
+            })
+        })
+        .collect()
+}
+
+/// Generic kind-mismatch fallback dispatcher for `cqs callers <name>`.
+/// Same shape as the impact-side fallbacks. JSON path emits an object
+/// with `{kind, fallback_from, name, definitions, note}`; text path
+/// prints the lead, definitions, and redirect note.
+fn callers_kind_fallback(
+    name: &str,
+    chunks: &[ChunkSummary],
+    json: bool,
+    kind_label: &str,
+    note: &str,
+    text_lead: &str,
+    text_redirect: &str,
+) -> Result<()> {
+    debug_assert!(
+        !chunks.is_empty(),
+        "Kind fallback called with no hits — caller must classify before dispatching"
+    );
+    if json {
+        let payload = serde_json::json!({
+            "kind": kind_label,
+            "fallback_from": "callers",
+            "name": name,
+            "definitions": chunks_to_definitions(chunks),
+            "note": note,
+        });
+        crate::cli::json_envelope::emit_json(&payload)?;
+    } else {
+        println!("{text_lead}");
+        println!();
+        println!("Definitions:");
+        for c in chunks {
+            println!(
+                "  {}:{}-{} ({} {})",
+                cqs::normalize_path(&c.file),
+                c.line_start,
+                c.line_end,
+                c.language,
+                c.chunk_type
+            );
+            if !c.signature.is_empty() {
+                println!("    {}", c.signature);
+            }
+        }
+        println!();
+        println!("{text_redirect}");
+    }
+    Ok(())
+}
+
 // ─── CLI commands ──────────────────────────────────────────────────────────
 
 /// Find functions that call the specified function
@@ -78,6 +165,57 @@ pub(crate) fn cmd_callers(
     // (no offset surfaced yet — by design, agents pass `--limit N` once and
     // ask for more by name if needed).
     let limit = limit.clamp(1, 100);
+
+    // Polymorphic-routing kind detection (Phase 1). Dispatch kind-
+    // mismatch fallbacks before the call-graph query, except on the
+    // cross-project path which has its own (cross-project)
+    // resolution semantics.
+    if !cross_project {
+        let chunks = store.lookup_by_name(name)?;
+        let hits: Vec<KindHit> = chunks.iter().map(KindHit::from).collect();
+        let kind = classify_hits(&hits);
+        match kind {
+            Kind::Const => {
+                return callers_kind_fallback(
+                    name, &chunks, json, "const",
+                    "consts don't have callers; here are the definition sites. \
+                     Use `cqs <name>` or `cqs search <name>` to find references.",
+                    &format!("(callers) `{name}` is a const, not a function — call-graph callers analysis doesn't apply."),
+                    "Use `cqs <name>` or `cqs search <name>` to find references.",
+                );
+            }
+            Kind::Type => {
+                return callers_kind_fallback(
+                    name, &chunks, json, "type",
+                    "types don't have callers in the call-graph sense; here are the definition sites. \
+                     Use `cqs deps <name>` for type-dependency callers or `cqs <name>` to find usage references.",
+                    &format!("(callers) `{name}` is a type, not a function — call-graph callers analysis doesn't apply."),
+                    "Use `cqs deps <name>` for type-dependency analysis or `cqs <name>` to find usage references.",
+                );
+            }
+            Kind::Module => {
+                return callers_kind_fallback(
+                    name, &chunks, json, "module",
+                    "modules don't have callers in the call-graph sense; here are the declaration sites. \
+                     Use `cqs <name>` to find files that reference this module.",
+                    &format!("(callers) `{name}` is a module/namespace, not a function — call-graph callers analysis doesn't apply."),
+                    "Use `cqs <name>` to find files that reference this module.",
+                );
+            }
+            Kind::Ambiguous => {
+                return callers_kind_fallback(
+                    name, &chunks, json, "ambiguous",
+                    "name resolves across multiple kinds (function/type/const/etc.); here are all matches. \
+                     Re-run `cqs callers <name>` against a more specific name (e.g. `Type::method`) or use `cqs <name>` to disambiguate.",
+                    &format!("(callers) `{name}` is ambiguous — matches multiple chunk kinds."),
+                    "Re-run with a more specific name (e.g. `Type::method`) or use `cqs <name>` to disambiguate.",
+                );
+            }
+            // Function | Multiple | Other | NotFound: fall through to
+            // the existing call-graph query.
+            _ => {}
+        }
+    }
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
@@ -151,6 +289,52 @@ pub(crate) fn cmd_callers(
     Ok(())
 }
 
+/// Generic kind-mismatch fallback dispatcher for `cqs callees <name>`.
+fn callees_kind_fallback(
+    name: &str,
+    chunks: &[ChunkSummary],
+    json: bool,
+    kind_label: &str,
+    note: &str,
+    text_lead: &str,
+    text_redirect: &str,
+) -> Result<()> {
+    debug_assert!(
+        !chunks.is_empty(),
+        "Kind fallback called with no hits — caller must classify before dispatching"
+    );
+    if json {
+        let payload = serde_json::json!({
+            "kind": kind_label,
+            "fallback_from": "callees",
+            "name": name,
+            "definitions": chunks_to_definitions(chunks),
+            "note": note,
+        });
+        crate::cli::json_envelope::emit_json(&payload)?;
+    } else {
+        println!("{text_lead}");
+        println!();
+        println!("Definitions:");
+        for c in chunks {
+            println!(
+                "  {}:{}-{} ({} {})",
+                cqs::normalize_path(&c.file),
+                c.line_start,
+                c.line_end,
+                c.language,
+                c.chunk_type
+            );
+            if !c.signature.is_empty() {
+                println!("    {}", c.signature);
+            }
+        }
+        println!();
+        println!("{text_redirect}");
+    }
+    Ok(())
+}
+
 /// Find functions called by the specified function
 pub(crate) fn cmd_callees(
     ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
@@ -163,6 +347,53 @@ pub(crate) fn cmd_callees(
     let store = &ctx.store;
     // Task A3: see cmd_callers — same clamp range.
     let limit = limit.clamp(1, 100);
+
+    // Polymorphic-routing kind detection (Phase 1). Same dispatch
+    // pattern as cmd_callers above.
+    if !cross_project {
+        let chunks = store.lookup_by_name(name)?;
+        let hits: Vec<KindHit> = chunks.iter().map(KindHit::from).collect();
+        let kind = classify_hits(&hits);
+        match kind {
+            Kind::Const => {
+                return callees_kind_fallback(
+                    name, &chunks, json, "const",
+                    "consts don't have callees; the const's value is its content. \
+                     Use `cqs explain <name>` or `cqs read --focus <name>` to inspect.",
+                    &format!("(callees) `{name}` is a const, not a function — call-graph callees analysis doesn't apply."),
+                    "Use `cqs explain <name>` or `cqs read --focus <name>` to inspect the value.",
+                );
+            }
+            Kind::Type => {
+                return callees_kind_fallback(
+                    name, &chunks, json, "type",
+                    "types don't have callees; here are the definition sites. \
+                     Use `cqs deps <name>` for the type's type dependencies or `cqs callees <Type::method>` for a specific method's callees.",
+                    &format!("(callees) `{name}` is a type, not a function — call-graph callees analysis doesn't apply."),
+                    "Use `cqs deps <name>` for type-dependency analysis or call against a specific method (`Type::method`).",
+                );
+            }
+            Kind::Module => {
+                return callees_kind_fallback(
+                    name, &chunks, json, "module",
+                    "modules don't have callees; here are the declaration sites. \
+                     Use `cqs callees <function-in-module>` for a specific function's callees.",
+                    &format!("(callees) `{name}` is a module/namespace, not a function — call-graph callees analysis doesn't apply."),
+                    "Use `cqs callees <function-in-module>` for a specific function's callees.",
+                );
+            }
+            Kind::Ambiguous => {
+                return callees_kind_fallback(
+                    name, &chunks, json, "ambiguous",
+                    "name resolves across multiple kinds (function/type/const/etc.); here are all matches. \
+                     Re-run `cqs callees <name>` against a more specific name (e.g. `Type::method`).",
+                    &format!("(callees) `{name}` is ambiguous — matches multiple chunk kinds."),
+                    "Re-run with a more specific name (e.g. `Type::method`).",
+                );
+            }
+            _ => {}
+        }
+    }
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
@@ -253,5 +484,96 @@ mod tests {
         assert_eq!(json["name"], "bar"); // was "function"
         assert!(json.get("function").is_none());
         assert_eq!(json["calls"][0]["line_start"], 10);
+    }
+
+    // Polymorphic-routing Phase 1: callers + callees kind-mismatch fallback
+    // shape. Each test pins the JSON-builder contract so future schema
+    // tweaks are deliberate, not accidental.
+
+    fn make_chunk(
+        chunk_type: cqs::parser::ChunkType,
+        name: &str,
+        file: &str,
+        line: u32,
+    ) -> ChunkSummary {
+        ChunkSummary {
+            id: format!("{}:{}:{}", file, line, "abcd1234"),
+            file: std::path::PathBuf::from(file),
+            language: cqs::parser::Language::Rust,
+            chunk_type,
+            name: name.to_string(),
+            signature: format!("test sig for {}", name),
+            content: format!("test content for {}", name),
+            doc: None,
+            line_start: line,
+            line_end: line,
+            content_hash: "abcd1234".to_string(),
+            window_idx: None,
+            parent_id: None,
+            parent_type_name: None,
+            parser_version: 0,
+            vendored: false,
+        }
+    }
+
+    #[test]
+    fn test_chunks_to_definitions_shape() {
+        let chunk = make_chunk(cqs::parser::ChunkType::Constant, "X", "src/a.rs", 5);
+        let defs = chunks_to_definitions(&[chunk]);
+        assert_eq!(defs.len(), 1);
+        let d = &defs[0];
+        // The 7 fields every kind-mismatch fallback emits.
+        for key in &[
+            "file",
+            "line_start",
+            "line_end",
+            "language",
+            "chunk_type",
+            "signature",
+            "content",
+        ] {
+            assert!(d.get(*key).is_some(), "missing field: {key}");
+        }
+        assert_eq!(d["chunk_type"], "constant");
+        assert_eq!(d["language"], "rust");
+    }
+
+    /// Pin the `{kind, fallback_from, name, definitions, note}` shape
+    /// for the callers fallback. The test mirrors the impact module's
+    /// `build_impact_kind_fallback_json_shape_invariants` — same shape,
+    /// different `fallback_from` value.
+    #[test]
+    fn test_callers_fallback_payload_shape() {
+        // Build the payload by mimicking what `callers_kind_fallback`
+        // assembles before calling `emit_json`. Direct unit test of the
+        // dispatcher would need stdout capture; this asserts the shape
+        // contract instead.
+        let chunk = make_chunk(cqs::parser::ChunkType::Constant, "X", "src/a.rs", 5);
+        let payload = serde_json::json!({
+            "kind": "const",
+            "fallback_from": "callers",
+            "name": "X",
+            "definitions": chunks_to_definitions(&[chunk]),
+            "note": "test note",
+        });
+        assert_eq!(payload["kind"], "const");
+        assert_eq!(payload["fallback_from"], "callers");
+        assert_eq!(payload["name"], "X");
+        assert_eq!(payload["definitions"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_callees_fallback_payload_shape() {
+        // Mirror of the callers payload, with `fallback_from: "callees"`.
+        let chunk = make_chunk(cqs::parser::ChunkType::Class, "MyClass", "src/a.rs", 5);
+        let payload = serde_json::json!({
+            "kind": "type",
+            "fallback_from": "callees",
+            "name": "MyClass",
+            "definitions": chunks_to_definitions(&[chunk]),
+            "note": "test note",
+        });
+        assert_eq!(payload["fallback_from"], "callees");
+        assert_eq!(payload["definitions"][0]["chunk_type"], "class");
     }
 }


### PR DESCRIPTION
## Summary

Wires the polymorphic-routing kind classifier into `cqs callers <name>` and `cqs callees <name>`. Same per-(command × kind) behavior matrix that #1612/#1616 shipped for `cqs impact`.

Both commands previously returned an empty `Vec` for any non-Function name (the misrouted-to-empty failure). Now they return kind-labeled definitions + redirect notes.

## Behavior matrix coverage

| Kind | `callers` behavior | `callees` behavior |
|---|---|---|
| `Function` | call-graph callers (unchanged: array) | call-graph callees (unchanged: `CalleesOutput`) |
| `Const` | NEW: kind-labeled defs, redirect to `cqs <name>` | NEW: redirect to `cqs explain` / `cqs read --focus` |
| `Type` | NEW: redirect to `cqs deps` / `cqs <name>` | NEW: redirect to `cqs callees <Type::method>` |
| `Module` | NEW: redirect to file-import search | NEW: redirect to specific function in module |
| `Ambiguous` | NEW: aggregate across kinds | NEW: aggregate across kinds |
| `Multiple` / `Other` / `NotFound` | fall through to existing flow | fall through to existing flow |

## Wire shape

Every kind-mismatch cell emits the same shape:

```json
{
  "kind": "<const|type|module|ambiguous>",
  "fallback_from": "callers" | "callees",
  "name": "<queried>",
  "definitions": [{"file": "...", "line_start": ..., "chunk_type": "...", ...}],
  "note": "<command + kind specific redirect>"
}
```

The function-path JSON shape is **unchanged**: `callers` returns a bare array of `CallerEntry`; `callees` returns a bare `CalleesOutput` object. Agents detect the dispatch decision by type — array ⇒ function path, object with `kind` field ⇒ kind-mismatch fallback. This avoids breaking existing consumers that index `parsed[i]["name"]` for callers.

## Implementation note

`chunks_to_definitions` and the kind-fallback dispatcher are duplicated between `impact.rs` and `callers.rs`. Per-command duplication is intentional for now — once the pattern proves stable across all 6 commands (test-map, trace, deps still TODO), lift to a shared module in a follow-up. Premature factoring would couple the per-command notes/redirects.

Cross-project paths skip the polymorphic dispatch — those have their own (cross-project) resolution semantics; revisit if needed.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --bin cqs cli::commands::graph::callers` — 7 passed (4 existing + 3 new)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Phase 1 progress (cumulative)

| Command | Function | Type | Const | Module | Ambiguous | Cells |
|---|---|---|---|---|---|---|
| **impact** | ✓ | ✓ | ✓ | ✓ | ✓ | **5/5** |
| **callers** | ✓ | ✓ | ✓ | ✓ | ✓ | **5/5** ← this PR |
| **callees** | ✓ | ✓ | ✓ | ✓ | ✓ | **5/5** ← this PR |
| test-map | TODO | TODO | TODO | TODO | TODO | 0/5 |
| trace | TODO | TODO | TODO | TODO | TODO | 0/5 |
| deps | TODO | TODO | TODO | TODO | TODO | 0/5 |

After this PR: **15/30 cells done**. Remaining 3 commands × 5 kinds = 15 cells, each ~30 min following the established template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
