### PR TITLE
feat(test-map, trace, deps): kind-mismatch matrix — Phase 1 complete (30/30)

### DIFF
--- a/src/cli/commands/graph/deps.rs
+++ b/src/cli/commands/graph/deps.rs
@@ -65,12 +65,85 @@ pub(crate) fn build_deps_forward(users: &[ChunkSummary], root: &Path) -> Vec<Dep
         .collect()
 }
 
+// ─── Polymorphic-routing fallback ──────────────────────────────────────────
+
+/// Polymorphic-routing kind-mismatch fallback for `cqs deps <name>`.
+/// Same shape pattern as the impact / callers / callees / test-map / trace
+/// fallbacks. Deps is dual-mode (forward = "type users", reverse =
+/// "function's used types"), so Function and Type both have valid
+/// semantics in their respective modes — the fallback fires only for
+/// kinds that don't fit deps' model at all (Const, Module, Ambiguous).
+fn deps_kind_fallback(
+    name: &str,
+    chunks: &[cqs::store::ChunkSummary],
+    json: bool,
+    kind_label: &str,
+    note: &str,
+    text_lead: &str,
+    text_redirect: &str,
+) -> Result<()> {
+    debug_assert!(
+        !chunks.is_empty(),
+        "Kind fallback called with no hits — caller must classify before dispatching"
+    );
+    if json {
+        let definitions: Vec<serde_json::Value> = chunks
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "file": cqs::normalize_path(&c.file),
+                    "line_start": c.line_start,
+                    "line_end": c.line_end,
+                    "language": c.language.to_string(),
+                    "chunk_type": c.chunk_type.to_string(),
+                    "signature": c.signature,
+                    "content": c.content,
+                })
+            })
+            .collect();
+        let payload = serde_json::json!({
+            "kind": kind_label,
+            "fallback_from": "deps",
+            "name": name,
+            "definitions": definitions,
+            "note": note,
+        });
+        crate::cli::json_envelope::emit_json(&payload)?;
+    } else {
+        println!("{text_lead}");
+        println!();
+        println!("Definitions:");
+        for c in chunks {
+            println!(
+                "  {}:{}-{} ({} {})",
+                cqs::normalize_path(&c.file),
+                c.line_start,
+                c.line_end,
+                c.language,
+                c.chunk_type
+            );
+            if !c.signature.is_empty() {
+                println!("    {}", c.signature);
+            }
+        }
+        println!();
+        println!("{text_redirect}");
+    }
+    Ok(())
+}
+
 // ─── CLI command ────────────────────────────────────────────────────────────
 
 /// Show type dependencies.
 ///
 /// Forward (default): `cqs deps Config` -- who uses this type?
 /// Reverse: `cqs deps --reverse func_name` -- what types does this function use?
+///
+/// **Polymorphic routing (Phase 1):** detects the name's kind up-front.
+/// `Function` (with `--reverse`) and `Type` (default forward) both have
+/// valid deps semantics — the existing flow runs as today. `Const`,
+/// `Module`, and `Ambiguous` get a kind-labeled fallback because deps'
+/// "uses-of-type" / "uses-of-function" model doesn't fit those.
 pub(crate) fn cmd_deps(
     ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     name: &str,
@@ -87,6 +160,48 @@ pub(crate) fn cmd_deps(
     let root = &ctx.root;
     // Task A3: cap on user list (forward) or used-types list (reverse).
     let limit = limit.clamp(1, 100);
+
+    // Polymorphic-routing kind detection (Phase 1). Const/Module/Ambiguous
+    // don't fit deps' model — fall back with a redirect note. Function
+    // and Type continue to the existing dual-mode flow below.
+    let chunks = store.lookup_by_name(name)?;
+    let hits: Vec<cqs::kind::KindHit> = chunks.iter().map(cqs::kind::KindHit::from).collect();
+    let kind = cqs::kind::classify_hits(&hits);
+    match kind {
+        cqs::kind::Kind::Const => {
+            return deps_kind_fallback(
+                name, &chunks, json, "const",
+                "consts don't have type dependencies in either direction; here are the definition sites. \
+                 Use `cqs <name>` to find references to this const.",
+                &format!("(deps) `{name}` is a const, not a function or type — type-dependency analysis doesn't apply."),
+                "Use `cqs <name>` to find references to this const.",
+            );
+        }
+        cqs::kind::Kind::Module => {
+            return deps_kind_fallback(
+                name, &chunks, json, "module",
+                "modules don't have type dependencies in this view; here are the declaration sites. \
+                 Use `cqs deps <type-or-function-in-module>` for an item-level analysis.",
+                &format!("(deps) `{name}` is a module/namespace, not a function or type — type-dependency analysis doesn't apply at this granularity."),
+                "Use `cqs deps <type-or-function-in-module>` for an item-level analysis.",
+            );
+        }
+        cqs::kind::Kind::Ambiguous => {
+            return deps_kind_fallback(
+                name, &chunks, json, "ambiguous",
+                "name resolves across multiple kinds (function/type/const/etc.); here are all matches. \
+                 Re-run `cqs deps <name>` against a more specific name (e.g. `Type::method`).",
+                &format!("(deps) `{name}` is ambiguous — matches multiple chunk kinds."),
+                "Re-run with a more specific name (e.g. `Type::method`).",
+            );
+        }
+        // Function | Type | Multiple | Other | NotFound: continue to
+        // existing flow. Function with --reverse and Type forward both
+        // have valid semantics; Multiple typically resolves via the
+        // store query's deterministic ordering; NotFound surfaces an
+        // empty result naturally.
+        _ => {}
+    }
 
     if reverse {
         // P2 #65: limit at SQL time so we don't fetch every edge of a popular

--- a/src/cli/commands/graph/test_map.rs
+++ b/src/cli/commands/graph/test_map.rs
@@ -1,6 +1,14 @@
 //! Test map command — find tests that exercise a function
 //!
 //! Core BFS logic is in `build_test_map()` so batch mode can reuse it.
+//!
+//! ## Polymorphic routing (Phase 1)
+//!
+//! `cqs test-map <name>` historically required a function-or-method name
+//! and returned an empty match list for any other chunk kind. This module
+//! now consults `cqs::kind::classify_hits` against an exact-name lookup
+//! before the BFS query — kind-mismatch fallbacks emit a kind-labeled
+//! definition list with a redirect note.
 
 use std::collections::{HashMap, VecDeque};
 use std::path::Path;
@@ -8,6 +16,7 @@ use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
 
+use cqs::kind::{classify_hits, Kind, KindHit};
 use cqs::store::{CallGraph, ChunkSummary};
 
 use crate::cli::commands::resolve::resolve_target;
@@ -239,6 +248,52 @@ pub(crate) fn cmd_test_map(
 
     let store = &ctx.store;
     let root = &ctx.root;
+
+    // Polymorphic-routing kind detection (Phase 1). Same dispatch
+    // pattern as cmd_impact / cmd_callers / cmd_callees.
+    let chunks = store.lookup_by_name(name)?;
+    let hits: Vec<KindHit> = chunks.iter().map(KindHit::from).collect();
+    let kind = classify_hits(&hits);
+    match kind {
+        Kind::Const => {
+            return test_map_kind_fallback(
+                name, &chunks, json, "const",
+                "consts don't have a call-graph; tests don't 'cover' a const value the way they cover a function. \
+                 Use `cqs <name>` to find tests that reference this const by name.",
+                &format!("(test-map) `{name}` is a const, not a function — call-graph test-map analysis doesn't apply."),
+                "Use `cqs <name>` to find tests that reference this const by name.",
+            );
+        }
+        Kind::Type => {
+            return test_map_kind_fallback(
+                name, &chunks, json, "type",
+                "types don't have a call-graph in the same sense; here are the type's definition sites. \
+                 Use `cqs <name>` to find tests that reference this type, or `cqs test-map <Type::method>` for a specific method's coverage.",
+                &format!("(test-map) `{name}` is a type, not a function — call-graph test-map analysis doesn't apply."),
+                "Use `cqs <name>` to find tests that reference this type or call against a specific method.",
+            );
+        }
+        Kind::Module => {
+            return test_map_kind_fallback(
+                name, &chunks, json, "module",
+                "modules don't have a call-graph; tests cover specific functions inside the module, not the module itself. \
+                 Use `cqs <name>` to find tests in this module's files.",
+                &format!("(test-map) `{name}` is a module/namespace, not a function — call-graph test-map analysis doesn't apply."),
+                "Use `cqs <name>` to find tests in the module's files.",
+            );
+        }
+        Kind::Ambiguous => {
+            return test_map_kind_fallback(
+                name, &chunks, json, "ambiguous",
+                "name resolves across multiple kinds (function/type/const/etc.); here are all matches. \
+                 Re-run `cqs test-map <name>` against a more specific name (e.g. `Type::method`).",
+                &format!("(test-map) `{name}` is ambiguous — matches multiple chunk kinds."),
+                "Re-run with a more specific name (e.g. `Type::method`).",
+            );
+        }
+        _ => {}
+    }
+
     let resolved = resolve_target(store, name)?;
     let target_name = resolved.chunk.name.clone();
 
@@ -274,6 +329,69 @@ pub(crate) fn cmd_test_map(
     Ok(())
 }
 
+/// Polymorphic-routing kind-mismatch fallback for `cqs test-map <name>`.
+/// Same shape as the impact / callers / callees fallbacks — emits a
+/// `{kind, fallback_from: "test-map", name, definitions, note}` object
+/// under JSON, plain-text definitions + redirect under text mode.
+fn test_map_kind_fallback(
+    name: &str,
+    chunks: &[ChunkSummary],
+    json: bool,
+    kind_label: &str,
+    note: &str,
+    text_lead: &str,
+    text_redirect: &str,
+) -> Result<()> {
+    debug_assert!(
+        !chunks.is_empty(),
+        "Kind fallback called with no hits — caller must classify before dispatching"
+    );
+    if json {
+        let definitions: Vec<serde_json::Value> = chunks
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "file": cqs::normalize_path(&c.file),
+                    "line_start": c.line_start,
+                    "line_end": c.line_end,
+                    "language": c.language.to_string(),
+                    "chunk_type": c.chunk_type.to_string(),
+                    "signature": c.signature,
+                    "content": c.content,
+                })
+            })
+            .collect();
+        let payload = serde_json::json!({
+            "kind": kind_label,
+            "fallback_from": "test-map",
+            "name": name,
+            "definitions": definitions,
+            "note": note,
+        });
+        crate::cli::json_envelope::emit_json(&payload)?;
+    } else {
+        println!("{text_lead}");
+        println!();
+        println!("Definitions:");
+        for c in chunks {
+            println!(
+                "  {}:{}-{} ({} {})",
+                cqs::normalize_path(&c.file),
+                c.line_start,
+                c.line_end,
+                c.language,
+                c.chunk_type
+            );
+            if !c.signature.is_empty() {
+                println!("    {}", c.signature);
+            }
+        }
+        println!();
+        println!("{text_redirect}");
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod output_tests {
     use super::*;
@@ -302,5 +420,62 @@ mod output_tests {
         let output = build_test_map_output("no_tests", &[]);
         assert_eq!(output.count, 0);
         assert!(output.tests.is_empty());
+    }
+
+    // Polymorphic-routing Phase 1: test-map kind-mismatch fallback shape.
+    fn make_chunk(
+        chunk_type: cqs::parser::ChunkType,
+        name: &str,
+        file: &str,
+        line: u32,
+    ) -> ChunkSummary {
+        ChunkSummary {
+            id: format!("{}:{}:{}", file, line, "abcd1234"),
+            file: std::path::PathBuf::from(file),
+            language: cqs::parser::Language::Rust,
+            chunk_type,
+            name: name.to_string(),
+            signature: format!("test sig for {}", name),
+            content: format!("test content for {}", name),
+            doc: None,
+            line_start: line,
+            line_end: line,
+            content_hash: "abcd1234".to_string(),
+            window_idx: None,
+            parent_id: None,
+            parent_type_name: None,
+            parser_version: 0,
+            vendored: false,
+        }
+    }
+
+    #[test]
+    fn test_map_fallback_payload_shape() {
+        // Pin the {kind, fallback_from: "test-map", name, definitions, note} shape.
+        let chunk = make_chunk(cqs::parser::ChunkType::Constant, "X", "src/a.rs", 5);
+        let definitions: Vec<serde_json::Value> = std::iter::once(&chunk)
+            .map(|c| {
+                serde_json::json!({
+                    "file": cqs::normalize_path(&c.file),
+                    "line_start": c.line_start,
+                    "line_end": c.line_end,
+                    "language": c.language.to_string(),
+                    "chunk_type": c.chunk_type.to_string(),
+                    "signature": c.signature,
+                    "content": c.content,
+                })
+            })
+            .collect();
+        let payload = serde_json::json!({
+            "kind": "const",
+            "fallback_from": "test-map",
+            "name": "X",
+            "definitions": definitions,
+            "note": "test note",
+        });
+        assert_eq!(payload["kind"], "const");
+        assert_eq!(payload["fallback_from"], "test-map");
+        assert_eq!(payload["name"], "X");
+        assert_eq!(payload["definitions"].as_array().unwrap().len(), 1);
     }
 }

--- a/src/cli/commands/graph/trace.rs
+++ b/src/cli/commands/graph/trace.rs
@@ -1,10 +1,22 @@
 //! Trace command — find shortest call path between two functions
+//!
+//! ## Polymorphic routing (Phase 1)
+//!
+//! `cqs trace <source> <target>` historically required both names to be
+//! function-or-method names. If either resolves to a non-Function chunk
+//! the call-graph BFS returns no path. Polymorphic-routing Phase 1
+//! detects the source name's kind up-front: a non-Function source
+//! short-circuits with a kind-labeled definition list + redirect note
+//! instead of "no path found". The target name is left to
+//! `resolve_target` (which produces its own typed error if missing).
 
 use std::collections::{HashMap, VecDeque};
 
 use anyhow::{Context as _, Result};
 use colored::Colorize;
 
+use cqs::kind::{classify_hits, Kind, KindHit};
+use cqs::store::ChunkSummary;
 use cqs::Store;
 
 use crate::cli::commands::resolve::resolve_target;
@@ -199,6 +211,54 @@ pub(crate) fn cmd_trace(
 
     let store = &ctx.store;
     let root = &ctx.root;
+
+    // Polymorphic-routing kind detection (Phase 1) on the source name.
+    // The trace BFS requires a callable starting node; if `source` is a
+    // const/type/module/ambiguous name, dispatch a kind-labeled fallback
+    // instead of running the BFS to "no path found" — `target`'s kind is
+    // left to `resolve_target` to surface its own error if missing.
+    let source_chunks = store.lookup_by_name(source)?;
+    let source_hits: Vec<KindHit> = source_chunks.iter().map(KindHit::from).collect();
+    let source_kind = classify_hits(&source_hits);
+    match source_kind {
+        Kind::Const => {
+            return trace_kind_fallback(
+                source, target, &source_chunks, format, "const",
+                "consts don't participate in the call-graph; no call path can originate from a const value. \
+                 Use `cqs <source>` to find references and trace from the calling functions.",
+                &format!("(trace) source `{source}` is a const, not a function — no call path applies."),
+                "Use `cqs <source>` to find references and trace from the calling functions.",
+            );
+        }
+        Kind::Type => {
+            return trace_kind_fallback(
+                source, target, &source_chunks, format, "type",
+                "types don't have call chains; here are the type's definition sites. \
+                 Use `cqs <source>` to find usage references or `cqs trace <method-on-type> <target>` for a specific method.",
+                &format!("(trace) source `{source}` is a type, not a function — no call path applies."),
+                "Use `cqs <source>` to find usage references or trace from a specific method.",
+            );
+        }
+        Kind::Module => {
+            return trace_kind_fallback(
+                source, target, &source_chunks, format, "module",
+                "modules don't participate in the call-graph as nodes. \
+                 Use `cqs <source>` to find files that reference this module, or `cqs trace <function-in-module> <target>`.",
+                &format!("(trace) source `{source}` is a module/namespace, not a function — no call path applies."),
+                "Use `cqs trace <function-in-module> <target>` for a specific function.",
+            );
+        }
+        Kind::Ambiguous => {
+            return trace_kind_fallback(
+                source, target, &source_chunks, format, "ambiguous",
+                "source name resolves across multiple kinds (function/type/const/etc.); here are all matches. \
+                 Re-run `cqs trace <source> <target>` against a more specific name.",
+                &format!("(trace) source `{source}` is ambiguous — matches multiple chunk kinds."),
+                "Re-run with a more specific name (e.g. `Type::method`).",
+            );
+        }
+        _ => {}
+    }
 
     // Resolve source and target to chunk names
     let source_resolved = resolve_target(store, source)?;
@@ -446,6 +506,81 @@ pub(crate) fn bfs_shortest_path(
         }
     }
     None
+}
+
+/// Polymorphic-routing kind-mismatch fallback for `cqs trace <source> <target>`.
+/// Same shape pattern as the impact / callers / callees / test-map
+/// fallbacks. JSON path emits `{kind, fallback_from: "trace", source,
+/// target, definitions, note}`; text path prints the lead, definitions,
+/// and redirect.
+///
+/// 8 args is intentional: each per-kind dispatcher (Const/Type/Module/
+/// Ambiguous) passes its kind label, JSON note, text lead, and text
+/// redirect — collapsing into a struct would just be 4 fields no caller
+/// reuses, so the `allow` is the simpler tradeoff.
+#[allow(clippy::too_many_arguments)]
+fn trace_kind_fallback(
+    source: &str,
+    target: &str,
+    chunks: &[ChunkSummary],
+    format: &OutputFormat,
+    kind_label: &str,
+    note: &str,
+    text_lead: &str,
+    text_redirect: &str,
+) -> Result<()> {
+    debug_assert!(
+        !chunks.is_empty(),
+        "Kind fallback called with no source hits — caller must classify before dispatching"
+    );
+    match format {
+        OutputFormat::Json => {
+            let definitions: Vec<serde_json::Value> = chunks
+                .iter()
+                .map(|c| {
+                    serde_json::json!({
+                        "file": cqs::normalize_path(&c.file),
+                        "line_start": c.line_start,
+                        "line_end": c.line_end,
+                        "language": c.language.to_string(),
+                        "chunk_type": c.chunk_type.to_string(),
+                        "signature": c.signature,
+                        "content": c.content,
+                    })
+                })
+                .collect();
+            let payload = serde_json::json!({
+                "kind": kind_label,
+                "fallback_from": "trace",
+                "source": source,
+                "target": target,
+                "definitions": definitions,
+                "note": note,
+            });
+            crate::cli::json_envelope::emit_json(&payload)?;
+        }
+        OutputFormat::Text | OutputFormat::Mermaid => {
+            println!("{text_lead}");
+            println!();
+            println!("Source definitions:");
+            for c in chunks {
+                println!(
+                    "  {}:{}-{} ({} {})",
+                    cqs::normalize_path(&c.file),
+                    c.line_start,
+                    c.line_end,
+                    c.language,
+                    c.chunk_type
+                );
+                if !c.signature.is_empty() {
+                    println!("    {}", c.signature);
+                }
+            }
+            println!();
+            println!("{text_redirect}");
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

**Completes the polymorphic-routing per-(command × kind) behavior matrix.** Wires the kind classifier into the remaining 3 of 6 commands (`test-map`, `trace`, `deps`).

After this PR: **30/30 cells complete**, all 6 commands handle kind-mismatch dispatch with kind-labeled fallbacks instead of misrouted-to-empty results.

## Cells shipped

| Kind | `test-map` | `trace` (source) | `deps` |
|---|---|---|---|
| `Function` | existing BFS | existing BFS | reverse mode (existing) |
| `Type` | NEW: definitions, redirect to `Type::method` | NEW: redirect to method-level trace | forward mode (existing) |
| `Const` | NEW: redirect to `cqs <name>` | NEW: redirect to caller-side trace | NEW: kind-labeled fallback |
| `Module` | NEW: redirect to module's tests | NEW: redirect to function-in-module | NEW: kind-labeled fallback |
| `Ambiguous` | NEW: aggregate | NEW: aggregate | NEW: kind-labeled fallback |
| `Multiple` / `Other` / `NotFound` | fall through | fall through | fall through |

## Wire shape

Every kind-mismatch cell across all 6 commands now emits:

```json
{
  "kind": "<const|type|module|ambiguous>",
  "fallback_from": "<impact|callers|callees|test-map|trace|deps>",
  "name" or "source"+"target": ...,
  "definitions": [{"file": "...", "line_start": ..., "chunk_type": "...", ...}],
  "note": "<command + kind specific redirect>"
}
```

## Per-command notes

- **test-map**: fallbacks redirect to `cqs <name>` (find tests that reference the name) since tests don't "cover" non-function chunks in the call-graph sense.
- **trace**: detects the **source** name's kind. Target name is left to `resolve_target` for its own typed error. Fallback shape includes both `source` + `target` for context.
- **deps**: dual-mode (forward = type users; reverse = function's used types). Function and Type both have valid deps semantics — they continue to the existing flow. Const/Module/Ambiguous fall back since deps' "uses-of-type" / "uses-of-function" model doesn't fit those.

## Phase 1 cumulative progress

| Command | Function | Type | Const | Module | Ambiguous | Cells |
|---|---|---|---|---|---|---|
| **impact** | ✓ | ✓ | ✓ | ✓ | ✓ | **5/5** |
| **callers** | ✓ | ✓ | ✓ | ✓ | ✓ | **5/5** |
| **callees** | ✓ | ✓ | ✓ | ✓ | ✓ | **5/5** |
| **test-map** | ✓ | ✓ | ✓ | ✓ | ✓ | **5/5** ← this PR |
| **trace** | ✓ | ✓ | ✓ | ✓ | ✓ | **5/5** ← this PR |
| **deps** | ✓ | ✓ | ✓ | ✓ | ✓ | **5/5** ← this PR |

**Phase 1 complete: 30/30 cells.** Phase 2 (`cqs about` unified entry) is contingent on telemetry per the design doc; do not preemptively ship.

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --bin cqs cli::commands::graph` — 34 passed
- [x] `cargo clippy -- -D warnings` clean (`#[allow(clippy::too_many_arguments)]` on `trace_kind_fallback` with rationale)
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
