### PR TITLE
fix(parser): Rust struct-field-assignment edges (#1573 Tier 2a) — 52 fewer cqs-dead false positives

### DIFF
--- a/src/language/queries/rust.calls.scm
+++ b/src/language/queries/rust.calls.scm
@@ -11,3 +11,34 @@
 
 (macro_invocation
   macro: (identifier) @callee)
+
+; #1573 Tier 2a: struct-field-assignment edges. When a struct literal
+; field is initialized with a function path (`field: my_func`,
+; `field: Some(my_func)`, `field: module::my_func`), the function
+; reference doesn't appear in a `call_expression` but IS a real use.
+; Pre-fix, `cqs dead` reported 66 false positives on cqs main from
+; functions assigned to LanguageDef fields (strip_go_receiver,
+; extract_return_c, etc.) that the existing query missed.
+;
+; Capturing every field_initializer value also produces dangling
+; edges for non-function values (e.g. `field: local_var`), but
+; those reference no chunk in the index and are filtered out by
+; the `function_calls` JOIN against the chunks table at query time.
+
+(field_initializer
+  value: (identifier) @callee)
+
+(field_initializer
+  value: (scoped_identifier
+    name: (identifier) @callee))
+
+; And inside `Some(fn_path)` / `Box::new(fn_path)` wrappers — common
+; for `Option<fn>` field types in dispatch tables.
+(field_initializer
+  value: (call_expression
+    arguments: (arguments (identifier) @callee)))
+
+(field_initializer
+  value: (call_expression
+    arguments: (arguments (scoped_identifier
+      name: (identifier) @callee))))

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -1139,4 +1139,69 @@ fn another() {
              no Language has a `type_query` defined"
         );
     }
+
+    /// #1573 Tier 2a: struct-field-assignment edges — Rust call query now
+    /// captures `field: function_path` patterns inside `struct_expression`
+    /// literals so functions used as Option<fn> / fn-pointer field values
+    /// no longer surface as `cqs dead` false positives.
+    ///
+    /// Pre-fix, 66 false positives on cqs main were all functions
+    /// assigned to LanguageDef fields (strip_go_receiver,
+    /// extract_return_c, etc.). This test pins the new query patterns
+    /// against representative inputs.
+    #[test]
+    fn test_struct_field_assignment_captures_function_value() {
+        let parser = Parser::new().unwrap();
+        let source = r#"
+fn helper_fn() {}
+
+struct Config {
+    callback: Option<fn()>,
+    direct: fn(),
+}
+
+fn build_config() -> Config {
+    Config {
+        callback: Some(helper_fn),
+        direct: helper_fn,
+    }
+}
+"#;
+        let calls = parser.extract_calls(source, Language::Rust, 0, source.len(), 0);
+        let names: Vec<&str> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        // Must capture `helper_fn` (in both `Some(helper_fn)` and bare
+        // `helper_fn`) plus `Some` (the `call_expression` for `Some(...)`).
+        assert!(
+            names.contains(&"helper_fn"),
+            "expected `helper_fn` in captured calls, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn test_struct_field_assignment_captures_scoped_function_path() {
+        let parser = Parser::new().unwrap();
+        let source = r#"
+mod inner {
+    pub fn module_fn() {}
+}
+
+struct Config {
+    callback: fn(),
+}
+
+fn build() {
+    let _c = Config {
+        callback: inner::module_fn,
+    };
+}
+"#;
+        let calls = parser.extract_calls(source, Language::Rust, 0, source.len(), 0);
+        let names: Vec<&str> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(
+            names.contains(&"module_fn"),
+            "expected `module_fn` (from `inner::module_fn` field value), got: {:?}",
+            names
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes ~52 of ~66 `cqs dead` false positives in `src/language/languages.rs` on cqs main. Pre-fix, functions assigned to `LanguageDef` fields like `strip_go_receiver`, `extract_return_c`, `extract_qualified_method_cpp` were reported as dead — the call-graph extractor missed function references inside **struct literal field initializers** because they appear in `field_initializer` AST nodes (not `call_expression`).

Implements **#1573 Tier 2a** (struct-field-assignment edges).

## What changes

Adds three new Rust call-query patterns in `src/language/queries/rust.calls.scm`:

```scheme
(field_initializer
  value: (identifier) @callee)

(field_initializer
  value: (scoped_identifier
    name: (identifier) @callee))

(field_initializer
  value: (call_expression
    arguments: (arguments (identifier) @callee)))
```

The third pattern catches the common `Option<fn>` field pattern (`callback: Some(my_fn)`) and `Box::new(fn_path)` wrappers — that's how cqs's `LanguageDef` table references its per-language helpers.

## Why this works without false positives

Capturing every `field_initializer` value also produces dangling edges for non-function values (e.g. `field: local_var`). These edges reference no chunk in the `chunks` table, so the `function_calls` JOIN at query time filters them out. Net result: real function references get edges; noise gets dropped.

## Verification

```
                                  Pre-Tier-1   Pre-Tier-2a   Post-Tier-2a
total cqs-dead entries:           ~114          ~80            52
src/language/languages.rs:        ~66           66             14   ← -52 (79% drop)
```

(Pre-Tier-1 baseline from #1572 close-out comment; pre-Tier-2a measured locally before this PR; post-Tier-2a measured after `cqs index --force` with the new query.)

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib parser::calls` — 36 passed (2 new)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] End-to-end: `cqs index --force` + `cqs dead --json` → 52 total entries (was ~80+)
- [x] Spot-check: `strip_go_receiver` (pre-fix: in dead list; post-fix: not in dead list)

## Tier 2b note (macro-invocation edges)

The current `rust.calls.scm` already has `(macro_invocation macro: (identifier) @callee)`. The 6+ macro false positives mentioned in #1573 may already be covered by that rule; to be verified separately as a follow-up if cqs dead still flags `define_aux_presets` / `for_each_logged_batch_cmd` post this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
