### PR TITLE
fix(parser): Rust struct-field type-cast edges (#1573 Tier 2a follow-up) — closes remaining 14 false positives

### DIFF
--- a/src/language/queries/rust.calls.scm
+++ b/src/language/queries/rust.calls.scm
@@ -42,3 +42,20 @@
   value: (call_expression
     arguments: (arguments (scoped_identifier
       name: (identifier) @callee))))
+
+; And `Some(fn_path as fn(T) -> R)` casts — Rust dispatch tables
+; sometimes use `as` to coerce a fn-item to a fn-pointer type before
+; storing in an Option<fn(...) -> ...> field. Closes the remaining
+; 14 `post_process_*_*` false positives in src/language/languages.rs.
+(field_initializer
+  value: (call_expression
+    arguments: (arguments
+      (type_cast_expression
+        value: (identifier) @callee))))
+
+(field_initializer
+  value: (call_expression
+    arguments: (arguments
+      (type_cast_expression
+        value: (scoped_identifier
+          name: (identifier) @callee)))))

--- a/src/parser/calls.rs
+++ b/src/parser/calls.rs
@@ -1204,4 +1204,33 @@ fn build() {
             names
         );
     }
+
+    /// Pin the `Some(fn_path as TypeAlias)` cast pattern — Rust dispatch
+    /// tables sometimes coerce a fn-item to a fn-pointer type before
+    /// storing in `Option<fn(...) -> ...>`. The 14 `post_process_*` false
+    /// positives in src/language/languages.rs all matched this shape.
+    #[test]
+    fn test_struct_field_assignment_captures_type_cast_function() {
+        let parser = Parser::new().unwrap();
+        let source = r#"
+type PostProcessFn = fn() -> ();
+
+fn post_process_helper() {}
+
+struct Config {
+    handler: Option<PostProcessFn>,
+}
+
+const CFG: Config = Config {
+    handler: Some(post_process_helper as PostProcessFn),
+};
+"#;
+        let calls = parser.extract_calls(source, Language::Rust, 0, source.len(), 0);
+        let names: Vec<&str> = calls.iter().map(|c| c.callee_name.as_str()).collect();
+        assert!(
+            names.contains(&"post_process_helper"),
+            "expected `post_process_helper` (from `Some(post_process_helper as PostProcessFn)`), got: {:?}",
+            names
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes the remaining 14 `cqs dead` false positives in `src/language/languages.rs` that #1621's base Tier 2a fix didn't catch. All 14 were `post_process_*_*` functions assigned to `LanguageDef` fields via the `Some(fn_name as TypeAlias)` pattern — Rust dispatch tables sometimes coerce a fn-item to a fn-pointer type before storing in `Option<fn(...) -> ...>`.

## Two new query patterns

```scheme
(field_initializer
  value: (call_expression
    arguments: (arguments
      (type_cast_expression
        value: (identifier) @callee))))

(field_initializer
  value: (call_expression
    arguments: (arguments
      (type_cast_expression
        value: (scoped_identifier
          name: (identifier) @callee)))))
```

The base Tier 2a query captured `Some(identifier)` and `Some(scoped_identifier)` directly; this PR adds the wrapped-by-cast form.

## Verification

Cumulative win across both Tier 2a PRs (#1621 + this one):

```
                              Pre-Tier-1   Pre-Tier-2a   Post-base (#1621)   Post-cast (this PR)
total cqs-dead entries:       ~114         ~80           52                  38
src/language/languages.rs:    ~66          66            14                  0
post_process_*:               14           14            14                  0
```

**100% reduction in src/language/languages.rs false positives across the two PRs.**

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib parser::calls::tests::test_struct_field` — 3 passed (1 new)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] End-to-end: full `cqs index --force` reindex + `cqs dead --json` → 38 total entries (was 52 pre-type-cast; was ~80 pre-Tier-2a)
- [x] `src/language/languages.rs` zero entries flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
