### PR TITLE
fix(dead_code): macro content-scan filter (#1573 Tier 2b partial) — 3 of 5 macro false positives closed

### DIFF
--- a/src/store/calls/dead_code.rs
+++ b/src/store/calls/dead_code.rs
@@ -48,7 +48,24 @@ impl<Mode> Store<Mode> {
                 .collect();
 
             // Phase 1 filtering: name/test/path/trait checks (don't need content)
-            let candidates = Self::filter_candidates(all_uncalled, &test_names);
+            let mut candidates = Self::filter_candidates(all_uncalled, &test_names);
+
+            // Phase 1.5 (#1573 Tier 2b): macros invoked at file-scope live
+            // outside any function chunk, so their `!()` invocation never
+            // produces a `function_calls` edge. Result: every macro_rules!
+            // shows up as "uncalled" even when it's used heavily. The
+            // call-graph extractor can't fix this without chunker changes
+            // (file-level macro_invocations aren't in any chunk's byte
+            // range), so we special-case Macro chunks at this layer:
+            // scan all chunks' content for `<name>!` substring; if any
+            // hit, drop from the candidates list.
+            //
+            // False-negative-friendly: a comment like "// foo! is broken"
+            // counts as a reference, keeping the macro live even when the
+            // implementation is actually unused. Dead-code analysis prefers
+            // under-reporting to over-reporting — comments referencing a
+            // name signal intentional retention.
+            candidates = self.filter_invoked_macros(candidates).await?;
 
             // Phase 2: Batch-fetch content and score confidence
             let active_files = self.fetch_active_files().await?;
@@ -134,6 +151,44 @@ impl<Mode> Store<Mode> {
                 line_end: clamp_line_number(row.get::<i64, _>(7)),
             })
             .collect())
+    }
+
+    /// Phase 1.5: drop macros from the dead-code candidates if they're
+    /// invoked anywhere in the corpus. Closes the file-level macro-
+    /// invocation gap (#1573 Tier 2b): the call-graph extractor only
+    /// runs over chunks, but `define_languages! { ... }` and similar
+    /// invocations live at file-scope outside any chunk's byte range.
+    ///
+    /// For each Macro candidate, runs:
+    ///   `SELECT 1 FROM chunks WHERE content LIKE '%<name>!%' LIMIT 1`
+    /// LIMIT 1 short-circuits at the first match — fast even on large
+    /// indexes. Non-Macro candidates pass through untouched.
+    async fn filter_invoked_macros(
+        &self,
+        candidates: Vec<LightChunk>,
+    ) -> Result<Vec<LightChunk>, StoreError> {
+        let mut filtered = Vec::with_capacity(candidates.len());
+        for chunk in candidates {
+            if chunk.chunk_type == ChunkType::Macro {
+                // Build the LIKE pattern: `%<name>!%`. The `!` suffix
+                // distinguishes invocations (`foo!`) from references in
+                // identifier-only contexts (`foo`) — though for macros
+                // even the bare name typically appears with `!`, so the
+                // suffix is the right discriminator.
+                let pattern = format!("%{}!%", chunk.name);
+                let row: Option<(i64,)> =
+                    sqlx::query_as("SELECT 1 FROM chunks WHERE content LIKE ?1 LIMIT 1")
+                        .bind(&pattern)
+                        .fetch_optional(&self.pool)
+                        .await?;
+                if row.is_some() {
+                    // Invoked somewhere — drop from dead candidates.
+                    continue;
+                }
+            }
+            filtered.push(chunk);
+        }
+        Ok(filtered)
     }
 
     /// Phase 1 filter: exclude entry points, tests, trait methods from uncalled functions.


### PR DESCRIPTION
## Summary

Closes 3 of 5 macro false positives in `cqs dead` via a content-scan filter in the dead-code analyzer. Implements **#1573 Tier 2b** (partial — file-level invocation gap remains for the last 2).

## What changes

Adds a Phase 1.5 step in `find_dead_code`. For each `Macro` chunk in the candidate list:

```sql
SELECT 1 FROM chunks WHERE content LIKE '%<name>!%' LIMIT 1
```

If any chunk's content contains the macro-invocation form, drop the macro from the dead candidates. `LIMIT 1` short-circuits — fast on large indexes.

Comment-based references count as "invoked" (e.g. `// foo! is broken` in a doc comment keeps `foo!` macro alive). Dead-code analysis prefers under-reporting to over-reporting; references typically signal intentional retention.

## Verification

```
Pre-Tier-2b: 5 macros in dead list
Post-filter: 2 macros (-3, 60% reduction)
```

**Closed by content scan:** `define_aux_presets`, `define_languages`, `define_patterns`.

## Remaining gap (deferred)

`for_each_logged_batch_cmd` and `gen_log_query_dispatch` (both in `src/cli/batch/commands.rs`) are still flagged. Their only invocation is at file scope:

```rust
for_each_logged_batch_cmd!(gen_log_query_dispatch);  // line 606, file-scope
```

This line lives outside any chunk's byte range, so `for_each_logged_batch_cmd!` is a substring of NO chunk's content. The doc comment at line 592 referencing `for_each_logged_batch_cmd!` also isn't included in the macro_definition chunk's content (chunker stores docs in a separate field).

Closing this fully requires one of:

1. Chunker change to include doc comments in chunk content
2. File-system scan: read source files directly during macro-invocation check
3. File-level chunk type ("module preamble") capturing top-level statements

All three are architectural changes — deferred. The 2 remaining macros are a small residual; the headline 3-of-5 win ships now.

## Cumulative cqs dead reduction (today's session)

```
                              Pre-Tier-1   Pre-Tier-2a   Post-base (#1621)   Post-cast (#1622)   Post-2b (this PR)
total cqs-dead entries:       ~114         ~80           52                  38                  35
src/language/languages.rs:    ~66          66            14                  0                   0
post_process_*:               14           14            14                  0                   0
macro chunks flagged:          5            5             5                  5                   2
```

## Test plan

- [x] `cargo build --features gpu-index` clean
- [x] `cargo test --features gpu-index --lib store::calls` — 20 passed
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] End-to-end: full reindex + `cqs dead --json` → 35 total entries (was 38 pre-Tier-2b)
- [x] Spot-check: `define_languages` now absent from dead list (was flagged pre-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
