### PR TITLE
fix(store/backup): DS-V1.40-3 — restore_from_backup deletes live sidecars first

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -127,7 +127,7 @@ Daemon hot path has no per-response size cap; `try_kind_fallback` echoes full ch
 | EH-V1.40-2 + API-V1.40-8 + OB-V1.40-3 + PB-V1.40-3 + SEC-V1.40-6 + DS-V1.40-5 | `Posture::current` / `OutputFormat::current` silent swallow + per-emit re-read + no log + TOCTOU + cross-platform case sensitivity (Cluster B) | easy-medium | ✅ Cluster B PR |
 | DS-V1.40-1 | Daemon `BatchContext` Store caches never invalidate from watch-loop WAL writes (WAL masks main-DB identity); use `PRAGMA data_version` | medium | TODO (Cluster D) |
 | DS-V1.40-2 | `cmd_telemetry_reset` non-atomic — kill between `fs::copy` and `fs::write` corrupts archive or current | easy | ✅ misc P1 PR |
-| DS-V1.40-3 | `restore_from_backup` `copy_triplet` non-atomic across (main, -wal, -shm) — kill mid-restore replays failed-migration WAL frames against pre-migrate main | medium | TODO |
+| DS-V1.40-3 | `restore_from_backup` `copy_triplet` non-atomic across (main, -wal, -shm) — kill mid-restore replays failed-migration WAL frames against pre-migrate main | medium | ✅ DS-V1.40-3 PR |
 | DS-V1.40-4 | `evals/regenerate_v3_test.py` writes fixture via `Path.write_text` non-atomically — Ctrl+C corrupts eval ground truth | easy | ✅ misc P1 PR |
 | DS-V1.40-7 | Sentiment column accepts arbitrary f32 — schema lets `cqs notes add --sentiment 0.7` corrupt ranking-boost contract; add `CHECK (sentiment IN (-1.0, -0.5, 0.0, 0.5, 1.0))` | easy | TODO |
 | SEC-V1.40-1 | V2Bare default drops `_meta.worktree_stale` warning — silent operational degradation under default Friendly posture (#1254 leakage guard regression) | medium | ✅ SEC-V1.40-1 PR |

--- a/src/store/backup.rs
+++ b/src/store/backup.rs
@@ -179,8 +179,14 @@ pub(crate) async fn backup_before_migrate(
 
 /// Restore a DB file (+ WAL/SHM sidecars) from a backup. Called on migration
 /// failure to leave the DB in its pre-migrate state. Uses `atomic_replace` so
-/// the restore itself is crash-safe — the caller sees pre-migrate or
-/// post-migrate state, never a partially-restored file.
+/// each individual file write is per-file atomic. The restore SEQUENCE is
+/// kill-safe in the following ordering: live sidecars are unlinked first
+/// (DS-V1.40-3), then the main DB is restored, then the backup's sidecars
+/// (if any). A kill at any point leaves either pre-migrate state (caller
+/// re-runs the failed migration) or pre-migrate state (SQLite recreates
+/// fresh sidecars from the restored main on next open). The pre-fix
+/// "post-migrate WAL contaminates restored pre-migrate main" failure mode
+/// is closed.
 ///
 /// # P2.59 — caller contract (must close pool first)
 ///
@@ -206,6 +212,37 @@ pub(crate) async fn backup_before_migrate(
 /// on the inode the path resolves to, not an orphaned descriptor.
 pub(crate) fn restore_from_backup(db_path: &Path, backup_db: &Path) -> Result<(), StoreError> {
     let _span = tracing::info_span!("restore_from_backup").entered();
+
+    // DS-V1.40-3: delete any live `-wal` / `-shm` sidecars BEFORE
+    // restoring the main DB. The live sidecars belong to the
+    // post-failure / failed-migration state — if they survive the
+    // restore, SQLite's next open will replay their frames against
+    // the restored main (which belongs to a different "lineage"),
+    // producing silent corruption that the integrity check can't
+    // detect. Pre-fix, `copy_triplet`'s in-order copy left the live
+    // WAL extant for the window between main restore and sidecar
+    // copy; a kill in that window (or after main, if the source had
+    // no sidecars to overwrite the live ones) produced the inverse
+    // problem of `copy_triplet`'s safe order.
+    //
+    // Removing first makes the failure ordering safe: a kill any
+    // time after this point and before the sidecar copy leaves
+    // (restored main + missing sidecars) — SQLite creates fresh
+    // sidecars on next open and the state is canonical pre-migrate.
+    for ext in ["-wal", "-shm"] {
+        let live_side = sidecar_path(db_path, ext);
+        if live_side.exists() {
+            if let Err(e) = std::fs::remove_file(&live_side) {
+                tracing::warn!(
+                    error = %e,
+                    path = %live_side.display(),
+                    "Failed to remove live sidecar before restore — \
+                     restore continues but sidecar may be stale"
+                );
+            }
+        }
+    }
+
     copy_triplet(backup_db, db_path)?;
     tracing::info!(
         db = %db_path.display(),
@@ -461,6 +498,84 @@ mod tests {
         assert!(
             !sidecar_path(&dst, "-wal").exists(),
             "stale -wal must be removed"
+        );
+    }
+
+    /// DS-V1.40-3 regression: `restore_from_backup` must delete the
+    /// live `-wal` and `-shm` BEFORE restoring the main DB. The live
+    /// sidecars belong to the failed-migration state; if they survive
+    /// the restore, SQLite's next open replays their frames against
+    /// the restored main and silently corrupts the database.
+    ///
+    /// Pre-fix, `restore_from_backup` called `copy_triplet` directly,
+    /// which copied main first then sidecars — leaving the live WAL
+    /// extant during the window between main restore and sidecar
+    /// copy. Post-fix, the live sidecars are unlinked first, so any
+    /// kill in that window leaves (restored main + missing sidecars)
+    /// → SQLite creates fresh sidecars on next open. State is
+    /// canonical pre-migrate.
+    ///
+    /// This test arranges a backup with no sidecars (the cleanly-
+    /// closed case) + a live state with a stale -wal/-shm. After
+    /// `restore_from_backup` runs, both live sidecars must be gone
+    /// (deleted before restore) and the main must match the backup.
+    #[test]
+    fn restore_from_backup_deletes_live_sidecars_before_restore() {
+        let dir = tempfile::tempdir().unwrap();
+        let backup = dir.path().join("snapshot.bak.db");
+        std::fs::write(&backup, b"pre-migrate-main").unwrap();
+        // Backup has no -wal/-shm (cleanly checkpointed before backup).
+
+        let live = dir.path().join("index.db");
+        std::fs::write(&live, b"failed-migration-main").unwrap();
+        // Live state has stale sidecars from the failed migration's tx.
+        std::fs::write(sidecar_path(&live, "-wal"), b"failed-migration-wal").unwrap();
+        std::fs::write(sidecar_path(&live, "-shm"), b"failed-migration-shm").unwrap();
+
+        restore_from_backup(&live, &backup).unwrap();
+
+        assert_eq!(
+            std::fs::read(&live).unwrap(),
+            b"pre-migrate-main",
+            "main must reflect backup contents"
+        );
+        assert!(
+            !sidecar_path(&live, "-wal").exists(),
+            "live -wal from failed migration must be removed (would corrupt restored main on next open)"
+        );
+        assert!(
+            !sidecar_path(&live, "-shm").exists(),
+            "live -shm from failed migration must be removed"
+        );
+    }
+
+    /// Sibling case: backup has its own sidecars (not cleanly closed at
+    /// snapshot time). The live sidecars must still be removed first;
+    /// the backup's sidecars then land via `copy_triplet`.
+    #[test]
+    fn restore_from_backup_replaces_live_sidecars_with_backup_sidecars() {
+        let dir = tempfile::tempdir().unwrap();
+        let backup = dir.path().join("snapshot.bak.db");
+        std::fs::write(&backup, b"pre-migrate-main").unwrap();
+        std::fs::write(sidecar_path(&backup, "-wal"), b"pre-migrate-wal").unwrap();
+        std::fs::write(sidecar_path(&backup, "-shm"), b"pre-migrate-shm").unwrap();
+
+        let live = dir.path().join("index.db");
+        std::fs::write(&live, b"failed-migration-main").unwrap();
+        std::fs::write(sidecar_path(&live, "-wal"), b"failed-migration-wal").unwrap();
+        std::fs::write(sidecar_path(&live, "-shm"), b"failed-migration-shm").unwrap();
+
+        restore_from_backup(&live, &backup).unwrap();
+
+        assert_eq!(std::fs::read(&live).unwrap(), b"pre-migrate-main");
+        assert_eq!(
+            std::fs::read(sidecar_path(&live, "-wal")).unwrap(),
+            b"pre-migrate-wal",
+            "backup -wal should land at live path"
+        );
+        assert_eq!(
+            std::fs::read(sidecar_path(&live, "-shm")).unwrap(),
+            b"pre-migrate-shm"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes audit P1 **DS-V1.40-3**. `restore_from_backup`'s doc-comment promised "crash-safe — the caller sees pre-migrate or post-migrate state, never a partially-restored file." Pre-fix that claim was a [Docs Lying Is P1] violation: `copy_triplet` restored main then sidecars sequentially, and a kill between left **(restored pre-migrate main + live failed-migration WAL)**. SQLite's next open replayed those WAL frames against the restored main, producing silent corruption invisible to the integrity check.

## Fix

Unlink the live `-wal` and `-shm` sidecars **before** running `copy_triplet`. Every kill window in the restore sequence now leaves a state SQLite can recover from on next open:

| Kill window | Live state after kill | Next-open behavior |
|------------|----------------------|--------------------|
| After sidecar deletion, before main restore | stale main + no sidecars | SQLite creates fresh sidecars from stale main → post-failure pre-restore (caller re-runs migration) |
| After main restore, before sidecar restore | restored main + no sidecars | SQLite creates fresh sidecars from restored main → **canonical pre-migrate** ✓ |
| During sidecar restore | restored main + partial restored sidecar | Both belong to same backup lineage; WAL recovery consistent ✓ |

Pre-fix the inverse was: kill mid-restore left a "Frankenstein" state where the WAL belonged to a different lineage than the main — silent corruption.

## Tests added

- **`restore_from_backup_deletes_live_sidecars_before_restore`** — cleanly-checkpointed-backup case (backup has no sidecars, live has stale `-wal`/`-shm` from failed migration). Post-fix, all live sidecars gone; main matches backup.
- **`restore_from_backup_replaces_live_sidecars_with_backup_sidecars`** — not-cleanly-closed-backup case (backup has its own sidecars). Live sidecars removed first; backup's sidecars land via `copy_triplet`.

12/12 `store::backup` tests pass (10 pre-existing + 2 new).

## Doc fixed

The pre-fix doc-comment is rewritten to spell out the kill-safe sequence explicitly. The "partially-restored file" claim is now actually true.

## Verification

```
cargo build --features gpu-index            # clean
cargo clippy -- -D warnings                 # clean
cargo fmt --check                           # clean
cargo test --features gpu-index --lib 'store::backup'   # 12/12 pass
```

## Files changed

- `src/store/backup.rs` — `restore_from_backup` deletes live sidecars first; doc-comment updated; 2 regression tests.
- `docs/audit-triage.md` — DS-V1.40-3 marked ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
