### PR TITLE
fix(graph): Cluster H — kind-fallback content size cap (DoS amplifier)

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -132,7 +132,7 @@ Daemon hot path has no per-response size cap; `try_kind_fallback` echoes full ch
 | DS-V1.40-7 | Sentiment column accepts arbitrary f32 — schema lets `cqs notes add --sentiment 0.7` corrupt ranking-boost contract; add `CHECK (sentiment IN (-1.0, -0.5, 0.0, 0.5, 1.0))` | easy | TODO |
 | SEC-V1.40-1 | V2Bare default drops `_meta.worktree_stale` warning — silent operational degradation under default Friendly posture (#1254 leakage guard regression) | medium | ✅ SEC-V1.40-1 PR |
 | SEC-V1.40-2 | `redact_userinfo` mishandles URLs with `@` in path — produces malformed redacted form (find authority boundary first via `/`) | easy | ✅ misc P1 PR |
-| EH-V1.40-9 + SEC-V1.40-4 | Kind-fallback `definitions[]` echoes full chunk content with no size cap — DoS amplifier via `Result`/`Error`/`new` hot names | medium | TODO (Cluster H) |
+| EH-V1.40-9 + SEC-V1.40-4 | Kind-fallback `definitions[]` echoes full chunk content with no size cap — DoS amplifier via `Result`/`Error`/`new` hot names | medium | ✅ Cluster H PR |
 
 ---
 

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -36,19 +36,17 @@ fn build_kind_fallback_value(
     fallback_from: &str,
     note: &str,
 ) -> serde_json::Value {
+    // Audit Cluster H (EH-V1.40-9 + SEC-V1.40-4): cap definitions at
+    // KIND_FALLBACK_MAX_DEFINITIONS and truncate per-chunk content via
+    // the shared helper. Hot names like `Result` / `Error` match
+    // hundreds of chunks; without the cap, the daemon writes multi-MB
+    // JSONL lines that peg both the wire and the receiver's parse
+    // buffer. The cap mirrors the `clamp(1, 100)` discipline the
+    // happy-path graph dispatchers already use.
     let definitions: Vec<serde_json::Value> = chunks
         .iter()
-        .map(|c| {
-            serde_json::json!({
-                "file": cqs::normalize_path(&c.file),
-                "line_start": c.line_start,
-                "line_end": c.line_end,
-                "language": c.language.to_string(),
-                "chunk_type": c.chunk_type.to_string(),
-                "signature": c.signature,
-                "content": c.content,
-            })
-        })
+        .take(crate::cli::commands::KIND_FALLBACK_MAX_DEFINITIONS)
+        .map(crate::cli::commands::chunk_to_definition_value)
         .collect();
     serde_json::json!({
         "kind": kind_label,

--- a/src/cli/commands/graph/impact.rs
+++ b/src/cli/commands/graph/impact.rs
@@ -175,21 +175,70 @@ fn impact_to_json_with_kind(result: &cqs::ImpactResult, kind: &str) -> Result<se
 /// fallback below. Each entry carries file/line/language/chunk_type/
 /// signature/content — the same shape the Const fallback shipped in
 /// #1612 (consumers learned this shape first; the other kinds match).
+///
+/// Audit Cluster H (EH-V1.40-9 + SEC-V1.40-4): cap at
+/// [`KIND_FALLBACK_MAX_DEFINITIONS`] entries and truncate per-chunk
+/// content at [`KIND_FALLBACK_MAX_CONTENT_BYTES`]. Hot names like
+/// `Result` / `Error` match hundreds of chunks across a corpus; without
+/// the cap, `cqs callers Result --json` could return multi-MB JSON
+/// (and on the daemon path, write a multi-MB JSONL line that pegs the
+/// receiver's parse buffer). The cap mirrors the `clamp(1, 100)` discipline
+/// the rest of the graph commands ship with; the per-entry truncation
+/// keeps pathological monster-chunk content from ballooning the response.
 fn chunks_to_definitions(chunks: &[cqs::store::ChunkSummary]) -> Vec<serde_json::Value> {
     chunks
         .iter()
-        .map(|c| {
-            serde_json::json!({
-                "file": cqs::normalize_path(&c.file),
-                "line_start": c.line_start,
-                "line_end": c.line_end,
-                "language": c.language.to_string(),
-                "chunk_type": c.chunk_type.to_string(),
-                "signature": c.signature,
-                "content": c.content,
-            })
-        })
+        .take(KIND_FALLBACK_MAX_DEFINITIONS)
+        .map(chunk_to_definition_value)
         .collect()
+}
+
+/// Maximum number of `definitions[]` entries returned in a kind-mismatch
+/// fallback response. Mirrors the standard graph-command result cap.
+pub(crate) const KIND_FALLBACK_MAX_DEFINITIONS: usize = 100;
+
+/// Per-entry `content` byte cap inside a kind-mismatch fallback
+/// `definitions[]` entry. Truncated content is suffixed with
+/// `"... (truncated)"` and the entry gains a `truncated: true` field
+/// so consumers can distinguish capped chunks from full ones.
+pub(crate) const KIND_FALLBACK_MAX_CONTENT_BYTES: usize = 2048;
+
+/// Shared chunk-to-definition transformation for both CLI-direct and
+/// daemon-path kind fallbacks. Truncates content per
+/// [`KIND_FALLBACK_MAX_CONTENT_BYTES`].
+pub(crate) fn chunk_to_definition_value(c: &cqs::store::ChunkSummary) -> serde_json::Value {
+    let (content, truncated) = if c.content.len() > KIND_FALLBACK_MAX_CONTENT_BYTES {
+        // Truncate at a UTF-8 char boundary at or below the byte cap.
+        // `floor_char_boundary` would be cleaner but isn't stable yet.
+        let mut end = KIND_FALLBACK_MAX_CONTENT_BYTES;
+        while !c.content.is_char_boundary(end) {
+            end -= 1;
+        }
+        (format!("{}... (truncated)", &c.content[..end]), true)
+    } else {
+        (c.content.clone(), false)
+    };
+    let mut entry = serde_json::Map::new();
+    entry.insert(
+        "file".to_string(),
+        serde_json::json!(cqs::normalize_path(&c.file)),
+    );
+    entry.insert("line_start".to_string(), serde_json::json!(c.line_start));
+    entry.insert("line_end".to_string(), serde_json::json!(c.line_end));
+    entry.insert(
+        "language".to_string(),
+        serde_json::json!(c.language.to_string()),
+    );
+    entry.insert(
+        "chunk_type".to_string(),
+        serde_json::json!(c.chunk_type.to_string()),
+    );
+    entry.insert("signature".to_string(), serde_json::json!(c.signature));
+    entry.insert("content".to_string(), serde_json::json!(content));
+    if truncated {
+        entry.insert("truncated".to_string(), serde_json::json!(true));
+    }
+    serde_json::Value::Object(entry)
 }
 
 /// Generic kind-mismatch fallback JSON builder. Polymorphic-routing
@@ -580,6 +629,95 @@ mod tests {
                 .copied()
                 .collect();
         assert_eq!(keys, expected);
+    }
+
+    // Audit Cluster H (EH-V1.40-9 + SEC-V1.40-4): kind-fallback paths
+    // must cap definitions count and per-chunk content size to prevent
+    // pathological "hot name" responses (e.g. `cqs callers Result`
+    // matching hundreds of chunks, each emitting full content) from
+    // saturating the daemon socket / agent's parse buffer.
+
+    #[test]
+    fn chunks_to_definitions_caps_count_at_max() {
+        // Build many chunks; expect the helper to truncate to
+        // KIND_FALLBACK_MAX_DEFINITIONS.
+        let chunks: Vec<ChunkSummary> = (0..(KIND_FALLBACK_MAX_DEFINITIONS + 50))
+            .map(|i| make_const_chunk(&format!("X{i}"), "src/lib.rs", i as u32))
+            .collect();
+        let defs = chunks_to_definitions(&chunks);
+        assert_eq!(
+            defs.len(),
+            KIND_FALLBACK_MAX_DEFINITIONS,
+            "definitions count must cap at KIND_FALLBACK_MAX_DEFINITIONS"
+        );
+    }
+
+    #[test]
+    fn chunks_to_definitions_truncates_oversized_content() {
+        // Single chunk with content much larger than the per-entry cap.
+        let mut big = make_const_chunk("BIG", "src/lib.rs", 1);
+        big.content = "x".repeat(KIND_FALLBACK_MAX_CONTENT_BYTES * 2);
+        let defs = chunks_to_definitions(&[big]);
+
+        let entry = &defs[0];
+        let content = entry["content"].as_str().unwrap();
+        assert!(
+            content.len() <= KIND_FALLBACK_MAX_CONTENT_BYTES + 32,
+            "truncated content must be ≤ cap + suffix; got {}",
+            content.len()
+        );
+        assert!(
+            content.ends_with("... (truncated)"),
+            "truncated entry must carry the truncation suffix; got: {}",
+            &content[content.len().saturating_sub(40)..]
+        );
+        assert_eq!(
+            entry["truncated"], true,
+            "truncated entries must carry truncated=true field"
+        );
+    }
+
+    #[test]
+    fn chunks_to_definitions_passes_small_content_unchanged() {
+        // Small content should NOT be truncated and should NOT carry
+        // a truncated:true field (skip-when-default).
+        let chunk = make_const_chunk("X", "src/lib.rs", 1);
+        let defs = chunks_to_definitions(&[chunk]);
+
+        let entry = &defs[0];
+        assert!(
+            entry.get("truncated").is_none(),
+            "non-truncated entries must omit truncated field; got: {:?}",
+            entry
+        );
+        assert!(
+            !entry["content"]
+                .as_str()
+                .unwrap()
+                .ends_with("... (truncated)"),
+            "non-truncated content must not have suffix"
+        );
+    }
+
+    #[test]
+    fn chunks_to_definitions_truncation_respects_utf8_boundary() {
+        // Pathological: content with a multi-byte UTF-8 char at the
+        // truncation boundary. Naive byte-slicing would split the
+        // codepoint and produce invalid UTF-8 (panic in `&str` slice).
+        let mut chunk = make_const_chunk("X", "src/lib.rs", 1);
+        // Build content that reaches the cap with `é` (2 bytes) at the
+        // boundary so a naive cut would split the codepoint.
+        let pad_len = KIND_FALLBACK_MAX_CONTENT_BYTES - 1;
+        chunk.content = format!("{}é{}", "x".repeat(pad_len), "y".repeat(100));
+
+        // Should not panic and should produce valid UTF-8 output.
+        let defs = chunks_to_definitions(&[chunk]);
+        let content = defs[0]["content"].as_str().unwrap();
+        assert!(
+            content.ends_with("... (truncated)"),
+            "must still emit truncation suffix on UTF-8 boundary case"
+        );
+        // Implicit: as_str() succeeded → valid UTF-8.
     }
 }
 

--- a/src/cli/commands/graph/mod.rs
+++ b/src/cli/commands/graph/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod trace;
 pub(crate) use callers::{build_callees, build_callers, cmd_callees, cmd_callers};
 pub(crate) use deps::{build_deps_forward, build_deps_reverse, cmd_deps};
 pub(crate) use explain::cmd_explain;
-pub(crate) use impact::cmd_impact;
+pub(crate) use impact::{chunk_to_definition_value, cmd_impact, KIND_FALLBACK_MAX_DEFINITIONS};
 pub(crate) use impact_diff::cmd_impact_diff;
 pub(crate) use test_map::{build_test_map, build_test_map_output, cmd_test_map};
 pub(crate) use trace::cmd_trace;

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -69,6 +69,7 @@ pub(crate) use graph::cmd_impact;
 pub(crate) use graph::cmd_impact_diff;
 pub(crate) use graph::cmd_test_map;
 pub(crate) use graph::cmd_trace;
+pub(crate) use graph::{chunk_to_definition_value, KIND_FALLBACK_MAX_DEFINITIONS};
 
 // -- review --
 pub(crate) use review::build_dead_output;


### PR DESCRIPTION
## Summary

Closes audit P1 **EH-V1.40-9 + SEC-V1.40-4** (Cluster H — kind-fallback DoS amplifier).

Polymorphic-routing Phase 1 added kind-labeled fallbacks for non-Function names. The fallback shape echoes `definitions[]` containing every matching chunk's full `content` field with no cap. Hot names like `Result` / `Error` / `new` match hundreds of chunks across a corpus; `cqs callers Result --json` returned multi-MB JSON, and the daemon path wrote multi-MB JSONL lines that pegged both the wire and the receiver's parse buffer.

The happy-path graph commands all `clamp(1, 100)` their result lists before serialization. The kind-fallback path had no analogous cap on either CLI-direct or daemon-path.

## Fix

Shared per-chunk transformation `chunk_to_definition_value` enforces:

- **Definition count cap** — `KIND_FALLBACK_MAX_DEFINITIONS = 100`. Matches the rest of the graph commands' discipline.
- **Per-entry content byte cap** — `KIND_FALLBACK_MAX_CONTENT_BYTES = 2048`. Truncated content gets a `"... (truncated)"` suffix and the entry gains a `truncated: true` field so consumers can distinguish capped chunks from full ones (skip-when-default — non-truncated entries omit the field).
- **UTF-8 boundary safety** — truncation walks back to the nearest char boundary so multi-byte codepoints at the cap don't produce invalid UTF-8 / panic on `&str` slice.

Both surfaces share the helper via re-exports through `cli::commands::graph::mod` + `cli::commands::mod` so the shape stays in lockstep — drift between CLI-direct and daemon-path was the broader Cluster C concern that this mini-refactor preempts.

## Tests added (4)

- `chunks_to_definitions_caps_count_at_max` — 150 chunks → 100 definitions.
- `chunks_to_definitions_truncates_oversized_content` — 4 KB content → truncated to ~2 KB + suffix + `truncated: true` field.
- `chunks_to_definitions_passes_small_content_unchanged` — small content unmodified, no `truncated` field present.
- `chunks_to_definitions_truncation_respects_utf8_boundary` — multi-byte codepoint at boundary → valid UTF-8 output (no panic).

12/12 `cli::commands::graph::impact` tests pass (8 pre-existing + 4 new).

## Verification

```
cargo build --features gpu-index            # clean
cargo clippy -- -D warnings                 # clean
cargo fmt --check                           # clean
cargo test --features gpu-index 'cli::commands::graph::impact'  # 12/12 pass
```

## Files changed

- `src/cli/commands/graph/impact.rs` — `chunk_to_definition_value` shared helper + 4 regression tests + new `KIND_FALLBACK_MAX_DEFINITIONS` / `KIND_FALLBACK_MAX_CONTENT_BYTES` constants.
- `src/cli/batch/handlers/graph.rs` — `build_kind_fallback_value` calls the shared helper instead of inline closure.
- `src/cli/commands/graph/mod.rs` + `src/cli/commands/mod.rs` — re-exports.
- `docs/audit-triage.md` — Cluster H entry marked ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
