### PR TITLE
fix(graph): AC sweep — BFS sentinel + Tier 2a anchor + bfs_expand depth (3 P1s)

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -104,9 +104,9 @@ Daemon hot path has no per-response size cap; `try_kind_fallback` echoes full ch
 | AC-V1.40-1 | `filter_invoked_macros` `!` suffix is Rust-only — every C/C++/Elixir/Julia macro misclassified as dead | medium | ✅ Cluster A PR |
 | AC-V1.40-2 | `filter_invoked_macros` self-match — recursive `macro_rules!` keeps itself alive (no `id != ?2` filter) | easy | ✅ Cluster A PR |
 | PB-V1.40-1 | `filter_invoked_macros` LIKE is case-insensitive (no `PRAGMA case_sensitive_like` or GLOB) | easy | ✅ Cluster A PR |
-| AC-V1.40-3 | `bfs_shortest_path` predecessor sentinel `String::new()` collides with anonymous-chunk callers — path reconstruction terminates early | medium | TODO |
-| AC-V1.40-4 | Rust Tier 2a `field_initializer` query captures every argument identifier — non-callable variables pollute `function_calls` | medium | TODO |
-| AC-V1.40-5 | `bfs_expand` depth update is score-gated — lower-score shorter paths leave depth at longer-path value | medium | TODO |
+| AC-V1.40-3 | `bfs_shortest_path` predecessor sentinel `String::new()` collides with anonymous-chunk callers — path reconstruction terminates early | medium | ✅ AC sweep PR |
+| AC-V1.40-4 | Rust Tier 2a `field_initializer` query captures every argument identifier — non-callable variables pollute `function_calls` | medium | ✅ AC sweep PR |
+| AC-V1.40-5 | `bfs_expand` depth update is score-gated — lower-score shorter paths leave depth at longer-path value | medium | ✅ AC sweep PR |
 | RB-V1.40-1 | `build_test_map` `chain_limit = max_depth + 1` panics on `usize::MAX` (no clap range bound) | easy | ✅ misc P1 PR |
 | RB-V1.40-3 | `classify_hits` uses `.expect()` — violates "no unwrap outside tests" rule (replace with `unwrap_or(Kind::Other)`) | easy | ✅ misc P1 PR |
 

--- a/src/cli/commands/graph/trace.rs
+++ b/src/cli/commands/graph/trace.rs
@@ -461,6 +461,16 @@ fn trace_max_nodes() -> usize {
 /// BFS shortest path through forward adjacency list.
 /// Capped at `CQS_TRACE_MAX_NODES` (default 10,000) visited nodes to prevent
 /// OOM on dense graphs.
+///
+/// Audit AC-V1.40-3: predecessor encoding is `Option<String>` instead of
+/// `String` — pre-fix used `String::new()` as the source-sentinel and
+/// `pred.is_empty()` as the chain-walk terminator, but the call graph
+/// can legitimately contain empty `caller_name` values (anonymous
+/// closures, expression chunks where the parent chunk has `name = ""`).
+/// A mid-graph anonymous predecessor matched the source-sentinel pattern,
+/// terminating chain reconstruction early and silently truncating paths.
+/// `None` is the unambiguous source marker; `Some("")` is a real-but-
+/// nameless predecessor and the chain walks through it correctly.
 pub(crate) fn bfs_shortest_path(
     forward: &HashMap<std::sync::Arc<str>, Vec<std::sync::Arc<str>>>,
     source: &str,
@@ -468,20 +478,17 @@ pub(crate) fn bfs_shortest_path(
     max_depth: usize,
 ) -> Option<Vec<String>> {
     let max_nodes = trace_max_nodes();
-    let mut visited: HashMap<String, String> = HashMap::new();
+    let mut visited: HashMap<String, Option<String>> = HashMap::new();
     let mut queue: VecDeque<(String, usize)> = VecDeque::new();
 
-    visited.insert(source.to_string(), String::new());
+    visited.insert(source.to_string(), None);
     queue.push_back((source.to_string(), 0));
 
     while let Some((current, depth)) = queue.pop_front() {
         if current == target {
             let mut path = vec![current.clone()];
-            let mut node = &current;
-            while let Some(pred) = visited.get(node) {
-                if pred.is_empty() {
-                    break;
-                }
+            let mut node = current.clone();
+            while let Some(Some(pred)) = visited.get(&node).cloned() {
                 path.push(pred.clone());
                 node = pred;
             }
@@ -499,7 +506,7 @@ pub(crate) fn bfs_shortest_path(
         if let Some(callees) = forward.get(current.as_str()) {
             for callee in callees {
                 if !visited.contains_key(callee.as_ref()) {
-                    visited.insert(callee.to_string(), current.clone());
+                    visited.insert(callee.to_string(), Some(current.clone()));
                     queue.push_back((callee.to_string(), depth + 1));
                 }
             }
@@ -678,6 +685,37 @@ mod tests {
         assert!(result.is_some());
         let path = result.unwrap();
         assert_eq!(path, vec!["A", "B", "C"]);
+    }
+
+    /// AC-V1.40-3 regression: anonymous nodes (`name = ""`, common for
+    /// closure / expression chunks) along the BFS path must not be
+    /// confused with the source-sentinel during path reconstruction.
+    /// Pre-fix used `String::new()` as the source marker and
+    /// `pred.is_empty()` as the chain-walk terminator — a mid-chain
+    /// empty-named node short-circuited reconstruction with the
+    /// real source missing from the front. Post-fix encodes the
+    /// predecessor as `Option<String>` so `None` is unambiguously the
+    /// source and `Some("")` is a real-but-nameless predecessor that
+    /// the chain walks through.
+    #[test]
+    fn test_bfs_path_walks_through_empty_named_node() {
+        let mut forward = HashMap::new();
+        // Source A → anonymous "" → target Z.
+        forward.insert("A".to_string(), vec!["".to_string()]);
+        forward.insert("".to_string(), vec!["Z".to_string()]);
+        let forward = arc_map(forward);
+        let result = bfs_shortest_path(&forward, "A", "Z", 10);
+        assert!(
+            result.is_some(),
+            "BFS through anonymous mid-chain node must find Z"
+        );
+        let path = result.unwrap();
+        assert_eq!(
+            path,
+            vec!["A", "", "Z"],
+            "path reconstruction must include the empty-named node, \
+             not stop at it as if it were the source"
+        );
     }
 
     // ===== TraceOutput serialization tests =====

--- a/src/gather.rs
+++ b/src/gather.rs
@@ -377,9 +377,19 @@ pub(crate) fn bfs_expand(
                 //
                 // AC-V1.30.1-3: this branch must run even when the cap
                 // has been hit — the bump doesn't grow `name_scores`.
+                //
+                // AC-V1.40-5: depth-min update lifted out of the score-gated
+                // branch. Pre-fix, a low-score-shorter-path (e.g. seed B
+                // score 0.01 reaching D in depth 1) couldn't update D's
+                // depth when D was already recorded at depth 2 from a
+                // high-score-deeper-path (seed A score 1.0 → A→C→D). The
+                // depth field surfaces in `GatheredChunk.depth` and on the
+                // JSON output, so wrong values reached agents directly.
+                // Depth-min is idempotent and cheap; running it always
+                // ensures the reported depth is the shortest path's.
+                existing.1 = existing.1.min(depth + 1);
                 if new_score > existing.0 {
                     existing.0 = new_score;
-                    existing.1 = existing.1.min(depth + 1);
                 }
             }
         }

--- a/src/language/queries/rust.calls.scm
+++ b/src/language/queries/rust.calls.scm
@@ -34,28 +34,42 @@
 
 ; And inside `Some(fn_path)` / `Box::new(fn_path)` wrappers — common
 ; for `Option<fn>` field types in dispatch tables.
+;
+; AC-V1.40-4: anchored to the FIRST argument identifier via the `.`
+; predicate. Pre-fix the pattern matched every `(identifier)` directly
+; under `arguments`, so `Foo { handler: wrap(my_func, count, &SHARED) }`
+; produced three phantom call-graph edges — the surrounding chunk's
+; `→ count` edge falsely kept any global named `count` alive in
+; cqs-dead. Wrapper functions in dispatch tables (`Some`, `Box::new`,
+; `Rc::new`) all take a single function argument, so anchoring to the
+; first child is safe for the typical case. Multi-arg wrappers that
+; legitimately want every-identifier capture would be a separate
+; pattern (none exist today).
 (field_initializer
   value: (call_expression
-    arguments: (arguments (identifier) @callee)))
+    arguments: (arguments . (identifier) @callee)))
 
 (field_initializer
   value: (call_expression
-    arguments: (arguments (scoped_identifier
+    arguments: (arguments . (scoped_identifier
       name: (identifier) @callee))))
 
 ; And `Some(fn_path as fn(T) -> R)` casts — Rust dispatch tables
 ; sometimes use `as` to coerce a fn-item to a fn-pointer type before
 ; storing in an Option<fn(...) -> ...> field. Closes the remaining
 ; 14 `post_process_*_*` false positives in src/language/languages.rs.
+;
+; AC-V1.40-4: same first-argument anchor as the un-cast variants
+; above so multi-arg wrapper calls don't pollute `function_calls`.
 (field_initializer
   value: (call_expression
     arguments: (arguments
-      (type_cast_expression
+      . (type_cast_expression
         value: (identifier) @callee))))
 
 (field_initializer
   value: (call_expression
     arguments: (arguments
-      (type_cast_expression
+      . (type_cast_expression
         value: (scoped_identifier
           name: (identifier) @callee)))))


### PR DESCRIPTION
## Summary

Closes audit P1 **AC-V1.40-3 + AC-V1.40-4 + AC-V1.40-5** — three correctness bugs in the BFS / call-graph subsystem. Bundled because they share a theme (graph metadata accuracy that surfaces in JSON output) and each fix is contained.

## Findings

### AC-V1.40-3 — `bfs_shortest_path` predecessor sentinel collision

`src/cli/commands/graph/trace.rs`. Pre-fix used `String::new()` as the source-sentinel and `pred.is_empty()` as the chain-walk terminator. The call graph CAN contain empty `caller_name` entries — anonymous closures, expression chunks where the parent has `name = ""`. Any mid-chain anonymous predecessor matched the source pattern, terminating reconstruction early and silently truncating paths.

**Fix**: encode predecessors as `Option<String>` instead — `None` is unambiguously the source, `Some("")` is a real-but-nameless predecessor that the chain walks through. Mirrors the `Option<Arc<str>>` parent encoding already used in `build_test_map` at `test_map.rs:109`.

**Regression test**: `test_bfs_path_walks_through_empty_named_node` — `A → "" → Z` reconstructs to `["A", "", "Z"]` not `["", "Z"]`.

### AC-V1.40-4 — Tier 2a `field_initializer` over-capture

`src/language/queries/rust.calls.scm`. Pre-fix:
```
(field_initializer
  value: (call_expression
    arguments: (arguments (identifier) @callee)))
```
matched **every** identifier directly under `arguments`. So `Foo { handler: wrap(my_func, count, &SHARED) }` produced three call-graph edges: `→ my_func`, `→ count`, `→ SHARED`. The phantom `→ count` edge then kept any global function named `count` alive in `cqs dead`.

The SCM's own comment claimed there was a "JOIN against the chunks table at query time" — that filter doesn't exist; the audit caught the doc-claim drift.

**Fix**: anchor each `arguments` pattern to the FIRST child via the `.` predicate:
```
(field_initializer
  value: (call_expression
    arguments: (arguments . (identifier) @callee)))
```
Wrapper functions in dispatch tables (`Some`, `Box::new`, `Rc::new`) all take a single function argument, so the anchor restriction is safe for the typical case. Multi-arg wrappers that legitimately want every-identifier capture would be a separate pattern (none exist today).

Existing 3 struct-field-assignment tests still pass — `Some(fn)`, `Some(scoped::fn)`, `Some(fn as Type)` patterns all use single-arg wrappers; the anchor doesn't affect them.

### AC-V1.40-5 — `bfs_expand` depth update score-gated

`src/gather.rs`. Pre-fix updated depth-min only inside the score-gated branch. A low-score-shorter-path (seed B score 0.01 → D depth 1) couldn't update D's depth when D was already recorded at depth 2 from a high-score-deeper-path (seed A score 1.0 → A→C→D, decay 0.9 → 0.81; 0.81 > 0.01 → branch skipped). The depth field surfaces in `GatheredChunk.depth` and on the JSON output, so wrong values reached agents directly.

**Fix**: lift the depth-min update OUT of the score-gated branch — it's idempotent and cheap. `existing.1 = existing.1.min(depth + 1)` always runs; score update remains gated to higher-score replacements.

Doc-comment on the branch updated to explain why depth-min is unconditional.

## Verification

```
cargo build --features gpu-index            # clean
cargo clippy -- -D warnings                 # clean
cargo fmt --check                           # clean
cargo test --features gpu-index 'cli::commands::graph::trace'   # 12/12 pass
cargo test --features gpu-index --lib 'parser::calls::tests::test_struct_field'  # 3/3 pass
```

## Files changed

- `src/cli/commands/graph/trace.rs` — BFS predecessor `String → Option<String>`; new regression test.
- `src/gather.rs` — depth-min update lifted out of score gate; doc-comment updated.
- `src/language/queries/rust.calls.scm` — `arguments` patterns anchored to first child via `.` predicate; comments updated.
- `docs/audit-triage.md` — AC-V1.40-3/4/5 marked ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
