### PR TITLE
fix(test): align cli_chat_format_test with SNR Phase 3 slim envelope

### DIFF
--- a/tests/cli_chat_format_test.rs
+++ b/tests/cli_chat_format_test.rs
@@ -129,14 +129,26 @@ fn test_chat_emits_parseable_envelope_for_search_query() {
         })
     });
 
-    // Envelope shape from format_envelope_to_string
-    assert_eq!(parsed["version"], 1);
-    assert!(parsed["error"].is_null(), "no error on success path");
+    // SNR Phase 3 slim envelope shape (v1.40.0+, `Posture::Friendly`
+    // default): `{"data": <payload>}` — `error: null` and `version` are
+    // dropped from the success path because they were always-redundant.
+    // The original always-on shape (`{"data": ..., "error": null,
+    // "version": 1, "_meta": {...}}`) is preserved under
+    // `CQS_ULTRASECURITY=1` (Adversarial posture) and pinned by the
+    // unit tests in `src/cli/json_envelope.rs::tests::*_with_posture_*`.
     assert!(
         parsed["data"].is_array() || parsed["data"].is_object(),
         "data must be the search result array/object, got: {}",
         parsed["data"]
     );
+    // Defensive: if `error` IS present (e.g. consumer ran with
+    // CQS_ULTRASECURITY=1), it must be null on the success path.
+    if !parsed["error"].is_null() && !parsed.get("error").map_or(true, |v| v.is_null()) {
+        panic!(
+            "envelope `error` field present but non-null on success path: {}",
+            parsed["error"]
+        );
+    }
 }
 
 /// Empty input lines and meta-commands (`help`, `clear`) should NOT produce


### PR DESCRIPTION
## Summary

Closes 8 consecutive overnight slow-tests CI failures on `main` (May 13 → May 20). `test_chat_emits_parseable_envelope_for_search_query` was asserting against the pre-v1.40.0 chat envelope shape; v1.40.0's SNR Phase 3 (#1604) slimmed the Friendly-posture envelope to `{"data": <payload>}` and dropped `error: null` + `version` as always-redundant on the success path.

## Why this slipped through the v1.40.0 PR

Two reasons:

1. **slow-tests feature gate** — `#[cfg(feature = "slow-tests")]` only runs in the nightly `ci-slow.yml` workflow, not on per-PR CI. The regression has been firing nightly since v1.40.0 landed.

2. **Wrong env-var lever in the helper** — the test's `cqs()` helper pins `CQS_OUTPUT_FORMAT=v1`. That env var gates `OutputFormat::current()` (CLI-direct envelope-vs-bare choice on stdout). It has **no effect** on the chat / batch / daemon envelope's **internal shape**, which is gated by `Posture::current()` reading `CQS_ULTRASECURITY`. The pin was correct in spirit (lock to a known shape) but applied the wrong env var.

## What changed

Updated the envelope-shape assertions to match the slim Phase 3 contract. The `version: 1` assertion is dropped (field no longer emitted under Friendly). The `data` shape is still pinned. Added an explicit null-or-absent check on `error` to guard against a future drift where `error` re-appears in some non-null state.

The adversarial-posture envelope shape (which still carries `version: 1`) is pinned by the existing unit tests in `src/cli/json_envelope.rs::tests::*_with_posture_adversarial_*`.

## Verification

```
cargo test --features gpu-index,slow-tests --test cli_chat_format_test
running 2 tests
test test_chat_emits_parseable_envelope_for_search_query ... ok
test test_chat_meta_commands_do_not_emit_envelope ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 15.97s
```

Pre-fix: 1 passed + 1 failed (panic at `tests/cli_chat_format_test.rs:133`).

- `cargo build --features gpu-index` clean
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean

## Files changed

- `tests/cli_chat_format_test.rs` — 1 file, +15/-3 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
