### PR TITLE
chore: Release v1.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Post-v1.40.0 work on `main`. Polymorphic routing Phase 1 fully completed (60/60 dispatch points across CLI-direct + daemon-path), `cqs dead` false-positive reduction (~114 → 35 entries via Tier 2a + Tier 2b partial), audit-triage doc currency.
+## [1.41.0] - 2026-05-20
+
+Minor release. 30 commits since v1.40.0. Three threads:
+
+- **Polymorphic routing Phase 1 completed** — at v1.40.0 only the CLI-direct first cell shipped; v1.41.0 delivers all 60 dispatch points (6 commands × 5 kinds × 2 surfaces) including the daemon-path sweep.
+- **Post-v1.40.0 audit cycle closure** — 16-category audit, 150 raw findings, 21 of 23 P1s closed across 9 closeout PRs (#1626–#1634). Two P1s deferred with rationale (see [1.40.0] section's "Deferred" notes).
+- **`cqs dead` false-positive reduction** — ~114 → 35 entries via Tier 2a (`field_initializer` + `type_cast_expression` patterns) + Tier 2b partial (macro content-scan filter). 70% reduction.
+
+No breaking changes since v1.40.0 (which shipped the SNR Phase 4 wire-format flip). All v1.41.0 work is feature-completion + bug fixes + dependency updates.
 
 ### Added
 
@@ -36,8 +44,27 @@ Post-v1.40.0 work on `main`. Polymorphic routing Phase 1 fully completed (60/60 
 
 ### Deferred (with rationale)
 
-- **DS-V1.40-1** (daemon Store cache invalidation via `PRAGMA data_version`) — symptom rare; caches reload on the 100ms staleness check. Cluster D bundling deferred to v1.41 cycle.
+- **DS-V1.40-1** (daemon Store cache invalidation via `PRAGMA data_version`) — symptom rare; caches reload on the 100ms staleness check. Cluster D bundling deferred to v1.42 cycle.
 - **DS-V1.40-7** (sentiment column CHECK constraint via schema migration v28) — single-user discrete-value compliance is reliable per CLAUDE.md memory; schema-migration cost > benefit. Deferred unless telemetry shows misuse.
+
+### Fixed (post-audit, slow-tests CI)
+
+- **#1650** (external contributor `patchrail`) — `cqs chat` now routes through `emit_json` so `CQS_OUTPUT_FORMAT=v1` actually applies. Pre-fix the env var was a no-op for the chat surface; post-fix it correctly flips chat back to the V1Envelope shape for consumer-migration. Closes #1649 (nightly CI failure).
+- **#1655** — `tests/cli_chat_format_test.rs` updated to match the SNR Phase 3 slim envelope contract (the slow-tests-gated test was still asserting `parsed["version"] == 1` from the pre-v1.40.0 shape). Net result: 8 consecutive nightly CI failures (May 13–20) closed.
+
+### Changed
+
+- **#1656** — Removed `tools/screw-mcp/DESIGN.md` (358 lines) and the `.gitignore` / `ROADMAP.md` references. The `screw-tape` design moved to its own repo; the cqs `tools/` directory now contains only unrelated artifacts.
+
+### Dependencies
+
+- `openssl` 0.10.79 → 0.10.80 (#1657)
+- `tower-http` 0.6.8 → 0.6.11 (#1652)
+- `tree-sitter-ocaml` 0.24.2 → 0.25.0 (#1638)
+- `tree-sitter-erlang` 0.16.0 → 0.17.0 (#1651)
+- `tokio` 1.52.2 → 1.52.3 (#1639)
+- `clap_complete` 4.6.3 → 4.6.5 (#1641)
+- `assert_cmd` 2.2.1 → 2.2.2 (#1642)
 
 ## [1.40.0] - 2026-05-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.40.0"
+version = "1.41.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cqs-macros"]
 
 [package]
 name = "cqs"
-version = "1.40.0"
+version = "1.41.0"
 edition = "2021"
 rust-version = "1.95"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 52.7% R@1 / 77.5% R@5 / 89.4% R@20 on v3.v2 dual-judge code-search (218 queries, EmbeddingGemma-300m default with per-category SPLADE α including identifier_lookup retune in v1.39.x; v3.v2 fixture line numbers re-anchored 2026-05-08 in #1607). Daemon mode (3-19ms queries). Local-first, GPU-accelerated."


### PR DESCRIPTION
## Summary

Release v1.41.0 — 30 commits since v1.40.0, three threads:

1. **Polymorphic routing Phase 1 completed.** At v1.40.0 only the CLI-direct first cell shipped; v1.41.0 delivers all **60 dispatch points** (6 commands × 5 kinds × 2 surfaces) via the CLI-direct cell-completion PRs (#1616, #1617, #1618) and the daemon-path sweep (#1620).

2. **Post-v1.40.0 audit cycle closure** — 16-category audit, 150 raw findings, **21 of 23 P1s closed** across PRs #1626–#1634. Two P1s deferred with rationale (DS-V1.40-1 daemon cache invalidation, DS-V1.40-7 sentiment CHECK constraint).

3. **`cqs dead` false-positive reduction** — Tier 2a (`field_initializer` + `type_cast_expression` patterns) and Tier 2b partial (macro content-scan) trimmed entries from **~114 to 35 (~70% reduction)**.

Plus post-audit fixes (#1650 chat output format, #1655 slow-tests fix), repo cleanup (#1656 screw-tape removed), and **7 dependency bumps** (#1638, #1639, #1641, #1642, #1651, #1652, #1657).

## No breaking changes

The breaking change (SNR Phase 4 default JSON shape flip) shipped IN v1.40.0. v1.41.0 is all feature-completion + bug fixes + dep updates. Per semver, **minor bump** (1.40 → 1.41) since the polymorphic-routing surface grew with 30 new daemon-path dispatch points + 15 new CLI-direct cells.

## Headline metrics

- **2213 lib tests** pass (`cargo test --features gpu-index --lib`)
- **`cqs dead`**: 35 entries (down from ~114 pre-cycle)
- **Polymorphic routing Phase 1**: 60/60 dispatch points complete
- **Eval baseline** (unchanged from v1.40.0 post-#1607 fixture re-anchor): test 49.5/72.5/84.4, dev 56.0/82.6/94.5, agg 52.7/77.5/89.4 R@1/R@5/R@20

## Verification

```
cargo build --features gpu-index            # clean
cargo clippy -- -D warnings                 # clean
cargo fmt --check                           # clean
cargo test --features gpu-index --lib       # 2213 pass / 0 fail / 19 ignored
```

(One flake noted in pre-flight: `hnsw::safety::tests::test_loaded_index_lifecycle` failed under parallel run, passed in isolation and on full-suite re-run. Not blocking.)

## Files changed

- `Cargo.toml` — version `1.40.0 → 1.41.0`
- `Cargo.lock` — version pin updated
- `CHANGELOG.md` — `[Unreleased]` section flipped to `[1.41.0] - 2026-05-20` with the audit-cycle + post-audit + dependency sub-sections.

## Post-merge steps

1. Tag v1.41.0 on main + push (GitHub Release workflow auto-fires)
2. `cargo publish` to crates.io
3. Sync ROADMAP.md + PROJECT_CONTINUITY.md to reflect v1.41.0 cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)
