### PR TITLE
fix(deps): bump sqlx 0.8.6 -> 0.9.0 + wrap dynamic SQL with AssertSqlSafe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1762,11 +1762,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4073,9 +4073,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4084,12 +4084,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cfg-if",
  "crc",
  "crossbeam-queue",
  "either",
@@ -4098,12 +4099,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink",
  "indexmap",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "serde",
  "sha2",
@@ -4117,9 +4117,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4130,15 +4130,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -4153,12 +4153,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -4168,7 +4169,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ regex = "1"
 aho-corasick = "1"
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 toml = "1.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ subtle = { version = "2", optional = true }
 base64 = { version = "0.22", optional = true }
 
 # Storage (sqlx async SQLite)
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite"] }
+sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "sqlite"] }
 
 # Vector search (HNSW default, cuVS optional)
 hnsw_rs = "0.3"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -314,7 +314,9 @@ impl EmbeddingCache {
                 .after_connect(move |conn, _meta| {
                     let wal = wal_pragma.clone();
                     Box::pin(async move {
-                        sqlx::query(&wal).execute(&mut *conn).await?;
+                        sqlx::query(sqlx::AssertSqlSafe(wal.as_str()))
+                            .execute(&mut *conn)
+                            .await?;
                         Ok(())
                     })
                 })
@@ -490,7 +492,7 @@ impl EmbeddingCache {
                      AND content_hash IN ({placeholders})"
                 );
 
-                let mut query = sqlx::query(&sql)
+                let mut query = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
                     .bind(model_fingerprint)
                     .bind(purpose.as_str());
                 for hash in batch {
@@ -2465,7 +2467,9 @@ impl QueryCache {
                 .after_connect(move |conn, _meta| {
                     let wal = wal_pragma.clone();
                     Box::pin(async move {
-                        sqlx::query(&wal).execute(&mut *conn).await?;
+                        sqlx::query(sqlx::AssertSqlSafe(wal.as_str()))
+                            .execute(&mut *conn)
+                            .await?;
                         Ok(())
                     })
                 })

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -258,7 +258,7 @@ impl<Mode> Store<Mode> {
 
             loop {
                 let batch: Vec<_> = {
-                    let mut q = sqlx::query(&sql);
+                    let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                     for val in &fsql.bind_values {
                         q = q.bind(val);
                     }

--- a/src/serve/data.rs
+++ b/src/serve/data.rs
@@ -295,7 +295,7 @@ pub(crate) fn build_graph(
         node_query.push_str(" ORDER BY n_callers_global DESC, c.id ASC LIMIT ?");
         binds.push(effective_cap.to_string());
 
-        let mut q = sqlx::query(&node_query);
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(node_query.as_str()));
         for b in &binds {
             q = q.bind(b);
         }
@@ -391,7 +391,7 @@ pub(crate) fn build_graph(
                          LIMIT ?"
                     );
                     let remaining = (max_graph_edges - accum.len()) as i64;
-                    let mut eq = sqlx::query(&edge_sql);
+                    let mut eq = sqlx::query(sqlx::AssertSqlSafe(edge_sql.as_str()));
                     for n in chunk {
                         eq = eq.bind(*n);
                     }
@@ -779,7 +779,7 @@ pub(crate) fn build_hierarchy(
                 "SELECT id, name, chunk_type, language, origin, line_start, line_end \
                  FROM chunks WHERE name IN ({placeholders}) ORDER BY id"
             );
-            let mut q = sqlx::query(&sql);
+            let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
             for n in batch {
                 q = q.bind(n);
             }
@@ -874,7 +874,7 @@ pub(crate) fn build_hierarchy(
                     "SELECT DISTINCT caller_name, callee_name FROM function_calls \
                      WHERE caller_name IN ({caller_ph}) AND callee_name IN ({callee_ph})"
                 );
-                let mut eq = sqlx::query(&edge_sql);
+                let mut eq = sqlx::query(sqlx::AssertSqlSafe(edge_sql.as_str()));
                 for n in caller_batch.iter() {
                     eq = eq.bind(n);
                 }

--- a/src/store/calls/crud.rs
+++ b/src/store/calls/crud.rs
@@ -175,7 +175,7 @@ impl<Mode> Store<Mode> {
                 // P3 #130: cached helper — `Cow::Borrowed(&'static str)` on hit.
                 let placeholders = make_placeholders(batch.len());
                 let sql = format!("SELECT id FROM chunks WHERE id IN ({placeholders})");
-                let mut query = sqlx::query_scalar::<_, String>(&sql);
+                let mut query = sqlx::query_scalar::<_, String>(sqlx::AssertSqlSafe(sql.as_str()));
                 for id in batch {
                     query = query.bind(*id);
                 }
@@ -303,7 +303,7 @@ impl Store<ReadWrite> {
                 let placeholders = crate::store::helpers::make_placeholders(chunk.len());
                 let sql =
                     format!("DELETE FROM function_calls WHERE file IN ({})", placeholders);
-                let mut q = sqlx::query(&sql);
+                let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for fs in chunk {
                     q = q.bind(fs);
                 }

--- a/src/store/calls/dead_code.rs
+++ b/src/store/calls/dead_code.rs
@@ -124,7 +124,9 @@ impl<Mode> Store<Mode> {
                AND c.parent_id IS NULL
              ORDER BY c.origin, c.line_start"
         );
-        let rows: Vec<_> = sqlx::query(&sql).fetch_all(&self.pool).await?;
+        let rows: Vec<_> = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
+            .fetch_all(&self.pool)
+            .await?;
 
         Ok(rows
             .into_iter()
@@ -299,7 +301,7 @@ impl<Mode> Store<Mode> {
                 "SELECT id, content, doc FROM chunks WHERE id IN ({})",
                 placeholders
             );
-            let mut q = sqlx::query(&sql);
+            let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
             for id in batch {
                 q = q.bind(id);
             }

--- a/src/store/calls/query.rs
+++ b/src/store/calls/query.rs
@@ -211,7 +211,7 @@ impl<Mode> Store<Mode> {
                      ORDER BY callee_name, file, call_line",
                     placeholders
                 );
-                let mut q = sqlx::query(&sql);
+                let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for name in batch {
                     q = q.bind(name);
                 }
@@ -264,7 +264,7 @@ impl<Mode> Store<Mode> {
                      ORDER BY callee_name, file, caller_line",
                     placeholders
                 );
-                let mut q = sqlx::query(&sql);
+                let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for name in batch {
                     q = q.bind(name);
                 }
@@ -319,7 +319,7 @@ impl<Mode> Store<Mode> {
                      ORDER BY caller_name, call_line",
                     placeholders
                 );
-                let mut q = sqlx::query(&sql);
+                let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for name in batch {
                     q = q.bind(name);
                 }

--- a/src/store/calls/related.rs
+++ b/src/store/calls/related.rs
@@ -28,7 +28,7 @@ impl<Mode> Store<Mode> {
             let sql = format!(
                 "SELECT {group_column}, {count_expr} FROM function_calls WHERE {filter_column} IN ({placeholders}) GROUP BY {group_column}",
             );
-            let mut q = sqlx::query(&sql);
+            let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
             for name in batch {
                 q = q.bind(name);
             }

--- a/src/store/calls/test_map.rs
+++ b/src/store/calls/test_map.rs
@@ -16,7 +16,9 @@ impl<Mode> Store<Mode> {
         // SQL is built once and cached in TEST_CHUNKS_SQL (LazyLock).
         // Select only lightweight columns; content/doc filtering happens in WHERE
         // but we don't need them in the result set.
-        let rows: Vec<_> = sqlx::query(&TEST_CHUNKS_SQL).fetch_all(&self.pool).await?;
+        let rows: Vec<_> = sqlx::query(sqlx::AssertSqlSafe(TEST_CHUNKS_SQL.as_str()))
+            .fetch_all(&self.pool)
+            .await?;
 
         Ok(rows
             .into_iter()
@@ -29,9 +31,10 @@ impl<Mode> Store<Mode> {
     /// the name set (e.g., `find_dead_code` exclusion filtering).
     pub(super) async fn find_test_chunk_names_async(&self) -> Result<Vec<String>, StoreError> {
         // SQL is built once and cached in TEST_CHUNK_NAMES_SQL (LazyLock).
-        let rows: Vec<(String,)> = sqlx::query_as(&TEST_CHUNK_NAMES_SQL)
-            .fetch_all(&self.pool)
-            .await?;
+        let rows: Vec<(String,)> =
+            sqlx::query_as(sqlx::AssertSqlSafe(TEST_CHUNK_NAMES_SQL.as_str()))
+                .fetch_all(&self.pool)
+                .await?;
         Ok(rows.into_iter().map(|(name,)| name).collect())
     }
 

--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -37,7 +37,7 @@ impl<Mode> Store<Mode> {
             );
 
             let rows: Vec<_> = {
-                let mut q = sqlx::query(&sql);
+                let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for id in batch {
                     q = q.bind(*id);
                 }
@@ -96,7 +96,7 @@ impl<Mode> Store<Mode> {
             );
 
             let rows: Vec<_> = {
-                let mut q = sqlx::query(&sql);
+                let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for id in batch {
                     q = q.bind(*id);
                 }
@@ -138,7 +138,7 @@ impl<Mode> Store<Mode> {
         );
 
         let rows: Vec<_> = {
-            let mut q = sqlx::query(&sql);
+            let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
             for id in ids {
                 q = q.bind(*id);
             }
@@ -273,7 +273,7 @@ pub(super) async fn snapshot_content_hashes(
             "SELECT id, content_hash, parser_version FROM chunks WHERE id IN ({})",
             placeholders
         );
-        let mut q = sqlx::query_as::<_, (String, String, i64)>(&sql);
+        let mut q = sqlx::query_as::<_, (String, String, i64)>(sqlx::AssertSqlSafe(sql.as_str()));
         for id in id_batch {
             q = q.bind(*id);
         }
@@ -487,7 +487,7 @@ pub(super) async fn upsert_fts_conditional(
     for batch in changed.chunks(max_rows_per_statement(1)) {
         let placeholders = crate::store::helpers::make_placeholders(batch.len());
         let sql = format!("DELETE FROM chunks_fts WHERE id IN ({})", placeholders);
-        let mut query = sqlx::query(&sql);
+        let mut query = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
         for chunk in batch {
             query = query.bind(&chunk.id);
         }
@@ -575,7 +575,7 @@ impl<'a, Mode> Iterator for EmbeddingBatchIterator<'a, Mode> {
                      WHERE rowid > ?1 AND {col} IS NOT NULL AND needs_embedding = 0 \
                      ORDER BY rowid ASC LIMIT ?2"
                 );
-                let rows: Vec<_> = sqlx::query(&sql)
+                let rows: Vec<_> = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
                     .bind(self.last_rowid)
                     .bind(self.batch_size as i64)
                     .fetch_all(&self.store.pool)

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -51,7 +51,7 @@ impl<Mode> Store<Mode> {
                     "SELECT id, enrichment_hash FROM chunks WHERE id IN ({}) AND enrichment_hash IS NOT NULL",
                     placeholders
                 );
-                let mut query = sqlx::query_as::<_, (String, String)>(&sql);
+                let mut query = sqlx::query_as::<_, (String, String)>(sqlx::AssertSqlSafe(sql.as_str()));
                 for id in batch {
                     query = query.bind(*id);
                 }
@@ -111,7 +111,7 @@ impl<Mode> Store<Mode> {
                     placeholders,
                     batch.len() + 1
                 );
-                let mut query = sqlx::query_as::<_, (String, String)>(&sql);
+                let mut query = sqlx::query_as::<_, (String, String)>(sqlx::AssertSqlSafe(sql.as_str()));
                 for hash in batch {
                     query = query.bind(*hash);
                 }
@@ -447,7 +447,7 @@ impl Store<ReadWrite> {
                     "INSERT INTO _update_embeddings (id, embedding, enrichment_hash) VALUES {}",
                     placeholders.join(", ")
                 );
-                let mut query = sqlx::query(&sql);
+                let mut query = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for (i, (id, _, hash)) in batch.iter().enumerate() {
                     query = query.bind(id);
                     query = query.bind(&batch_bytes[i]);
@@ -561,7 +561,7 @@ impl Store<ReadWrite> {
                     "INSERT INTO _update_umap (id, umap_x, umap_y) VALUES {}",
                     placeholders.join(", ")
                 );
-                let mut query = sqlx::query(&sql);
+                let mut query = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for (id, x, y) in batch {
                     query = query.bind(id).bind(*x).bind(*y);
                 }
@@ -1060,7 +1060,7 @@ impl Store<ReadWrite> {
                         .collect::<Vec<_>>()
                         .join(",");
                     let sql = format!("DELETE FROM calls WHERE caller_id IN ({})", placeholders);
-                    let mut query = sqlx::query(&sql);
+                    let mut query = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                     for id in batch {
                         query = query.bind(*id);
                     }
@@ -1132,7 +1132,7 @@ impl Store<ReadWrite> {
                             "INSERT OR IGNORE INTO _live_ids (id) VALUES {}",
                             placeholders.join(",")
                         );
-                        let mut stmt = sqlx::query(&insert_sql);
+                        let mut stmt = sqlx::query(sqlx::AssertSqlSafe(insert_sql.as_str()));
                         for id in batch {
                             stmt = stmt.bind(id);
                         }
@@ -1228,7 +1228,7 @@ impl Store<ReadWrite> {
                     "INSERT OR IGNORE INTO _live_ids (id) VALUES {}",
                     placeholders.join(",")
                 );
-                let mut stmt = sqlx::query(&insert_sql);
+                let mut stmt = sqlx::query(sqlx::AssertSqlSafe(insert_sql.as_str()));
                 for id in batch {
                     stmt = stmt.bind(id);
                 }

--- a/src/store/chunks/embeddings.rs
+++ b/src/store/chunks/embeddings.rs
@@ -36,7 +36,7 @@ impl<Mode> Store<Mode> {
                 );
 
                 let rows: Vec<_> = {
-                    let mut q = sqlx::query(&sql);
+                    let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                     for hash in batch {
                         q = q.bind(*hash);
                     }
@@ -115,7 +115,7 @@ impl<Mode> Store<Mode> {
                 );
 
                 let rows: Vec<_> = {
-                    let mut q = sqlx::query(&sql);
+                    let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                     for hash in batch {
                         q = q.bind(*hash);
                     }

--- a/src/store/chunks/query.rs
+++ b/src/store/chunks/query.rs
@@ -194,7 +194,10 @@ impl<Mode> Store<Mode> {
                 "SELECT {cols} FROM chunks WHERE origin = ?1 ORDER BY line_start",
                 cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS,
             );
-            let rows: Vec<_> = sqlx::query(&sql).bind(origin).fetch_all(&self.pool).await?;
+            let rows: Vec<_> = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
+                .bind(origin)
+                .fetch_all(&self.pool)
+                .await?;
 
             Ok(rows
                 .iter()
@@ -229,7 +232,7 @@ impl<Mode> Store<Mode> {
                     cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS,
                 );
 
-                let mut query = sqlx::query(&sql);
+                let mut query = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for origin in batch {
                     query = query.bind(*origin);
                 }
@@ -270,7 +273,10 @@ impl<Mode> Store<Mode> {
                  ORDER BY chunk_type, origin, line_start",
                 cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS,
             );
-            let rows = sqlx::query(&sql).bind(name).fetch_all(&self.pool).await?;
+            let rows = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
+                .bind(name)
+                .fetch_all(&self.pool)
+                .await?;
             Ok(rows
                 .into_iter()
                 .map(|row| ChunkSummary::from(ChunkRow::from_row(&row)))
@@ -305,7 +311,7 @@ impl<Mode> Store<Mode> {
                 );
 
                 let rows: Vec<_> = {
-                    let mut q = sqlx::query(&sql);
+                    let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                     for name in batch {
                         q = q.bind(*name);
                     }
@@ -392,7 +398,7 @@ impl<Mode> Store<Mode> {
                 );
 
                 let rows: Vec<_> = {
-                    let mut q = sqlx::query(&sql);
+                    let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                     for id in batch {
                         q = q.bind(*id);
                     }
@@ -484,7 +490,7 @@ impl<Mode> Store<Mode> {
                      LIMIT ?2",
                     crate::store::helpers::bm25_ordering_expr()
                 );
-                let light_rows: Vec<_> = sqlx::query(&sql)
+                let light_rows: Vec<_> = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
                     .bind(&combined_fts)
                     .bind(total_limit as i64)
                     .fetch_all(&self.pool)
@@ -605,7 +611,7 @@ impl<Mode> Store<Mode> {
                  ORDER BY rowid ASC LIMIT ?2",
                 cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS,
             );
-            let rows: Vec<_> = sqlx::query(&sql)
+            let rows: Vec<_> = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
                 .bind(after_rowid)
                 .bind(limit as i64)
                 .fetch_all(&self.pool)

--- a/src/store/chunks/staleness.rs
+++ b/src/store/chunks/staleness.rs
@@ -333,7 +333,7 @@ impl Store<ReadWrite> {
                     "DELETE FROM chunks_fts WHERE id IN (SELECT id FROM chunks WHERE origin IN ({}))",
                     placeholder_str
                 );
-                let mut fts_stmt = sqlx::query(&fts_query);
+                let mut fts_stmt = sqlx::query(sqlx::AssertSqlSafe(fts_query.as_str()));
                 for origin in batch {
                     fts_stmt = fts_stmt.bind(origin);
                 }
@@ -342,7 +342,7 @@ impl Store<ReadWrite> {
                 // Delete from chunks
                 let chunks_query =
                     format!("DELETE FROM chunks WHERE origin IN ({})", placeholder_str);
-                let mut chunks_stmt = sqlx::query(&chunks_query);
+                let mut chunks_stmt = sqlx::query(sqlx::AssertSqlSafe(chunks_query.as_str()));
                 for origin in batch {
                     chunks_stmt = chunks_stmt.bind(origin);
                 }
@@ -360,7 +360,7 @@ impl Store<ReadWrite> {
                     "DELETE FROM function_calls WHERE file IN ({})",
                     placeholder_str
                 );
-                let mut calls_stmt = sqlx::query(&calls_query);
+                let mut calls_stmt = sqlx::query(sqlx::AssertSqlSafe(calls_query.as_str()));
                 for origin in batch {
                     calls_stmt = calls_stmt.bind(origin);
                 }
@@ -453,7 +453,7 @@ impl Store<ReadWrite> {
                     "DELETE FROM chunks_fts WHERE id IN (SELECT id FROM chunks WHERE origin IN ({}))",
                     placeholder_str
                 );
-                let mut fts_stmt = sqlx::query(&fts_query);
+                let mut fts_stmt = sqlx::query(sqlx::AssertSqlSafe(fts_query.as_str()));
                 for origin in batch {
                     fts_stmt = fts_stmt.bind(origin);
                 }
@@ -462,7 +462,7 @@ impl Store<ReadWrite> {
                 // Delete from chunks
                 let chunks_query =
                     format!("DELETE FROM chunks WHERE origin IN ({})", placeholder_str);
-                let mut chunks_stmt = sqlx::query(&chunks_query);
+                let mut chunks_stmt = sqlx::query(sqlx::AssertSqlSafe(chunks_query.as_str()));
                 for origin in batch {
                     chunks_stmt = chunks_stmt.bind(origin);
                 }
@@ -619,7 +619,7 @@ impl Store<ReadWrite> {
                     "DELETE FROM chunks_fts WHERE id IN (SELECT id FROM chunks WHERE origin IN ({}))",
                     placeholder_str
                 );
-                let mut fts_stmt = sqlx::query(&fts_query);
+                let mut fts_stmt = sqlx::query(sqlx::AssertSqlSafe(fts_query.as_str()));
                 for origin in batch {
                     fts_stmt = fts_stmt.bind(origin);
                 }
@@ -628,7 +628,7 @@ impl Store<ReadWrite> {
                 // Delete from chunks
                 let chunks_query =
                     format!("DELETE FROM chunks WHERE origin IN ({})", placeholder_str);
-                let mut chunks_stmt = sqlx::query(&chunks_query);
+                let mut chunks_stmt = sqlx::query(sqlx::AssertSqlSafe(chunks_query.as_str()));
                 for origin in batch {
                     chunks_stmt = chunks_stmt.bind(origin);
                 }
@@ -893,7 +893,7 @@ impl<Mode> Store<Mode> {
                      GROUP BY origin",
                     placeholders
                 );
-                let mut query = sqlx::query_as::<_, FpRow>(&sql);
+                let mut query = sqlx::query_as::<_, FpRow>(sqlx::AssertSqlSafe(sql.as_str()));
                 for origin in batch {
                     query = query.bind(*origin);
                 }
@@ -941,7 +941,8 @@ impl<Mode> Store<Mode> {
                     placeholders
                 );
 
-                let mut query = sqlx::query_as::<_, (String, Option<i64>)>(&sql);
+                let mut query =
+                    sqlx::query_as::<_, (String, Option<i64>)>(sqlx::AssertSqlSafe(sql.as_str()));
                 for origin in batch {
                     query = query.bind(*origin);
                 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1005,11 +1005,15 @@ fn open_with_config_impl<Mode>(
                 let pragma = cache_pragma.clone();
                 let wal = wal_pragma.clone();
                 Box::pin(async move {
-                    sqlx::query(&pragma).execute(&mut *conn).await?;
+                    sqlx::query(sqlx::AssertSqlSafe(pragma.as_str()))
+                        .execute(&mut *conn)
+                        .await?;
                     sqlx::query("PRAGMA temp_store = MEMORY")
                         .execute(&mut *conn)
                         .await?;
-                    sqlx::query(&wal).execute(&mut *conn).await?;
+                    sqlx::query(sqlx::AssertSqlSafe(wal.as_str()))
+                        .execute(&mut *conn)
+                        .await?;
                     Ok(())
                 })
             })
@@ -1236,7 +1240,9 @@ impl Store<ReadWrite> {
                 if stmt.is_empty() {
                     continue;
                 }
-                sqlx::query(&stmt).execute(&mut *tx).await?;
+                sqlx::query(sqlx::AssertSqlSafe(stmt.as_str()))
+                    .execute(&mut *tx)
+                    .await?;
             }
 
             // Store metadata (OR REPLACE handles re-init after incomplete cleanup)

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -79,7 +79,7 @@ async fn insert_notes_with_fts_batched(
     for batch in notes.chunks(max_rows_per_statement(1)) {
         let placeholders = crate::store::helpers::make_placeholders(batch.len());
         let sql = format!("DELETE FROM notes_fts WHERE id IN ({})", placeholders);
-        let mut q = sqlx::query(&sql);
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
         for n in batch {
             q = q.bind(&n.id);
         }

--- a/src/store/search.rs
+++ b/src/store/search.rs
@@ -222,7 +222,7 @@ impl<Mode> Store<Mode> {
         );
 
         self.rt.block_on(async {
-            let rows: Vec<_> = sqlx::query(&sql)
+            let rows: Vec<_> = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
                 .bind(&fts_query)
                 .bind(limit as i64)
                 .fetch_all(&self.pool)

--- a/src/store/sparse.rs
+++ b/src/store/sparse.rs
@@ -448,7 +448,10 @@ impl<Mode> Store<Mode> {
         )
     }
 
-    fn chunk_splade_texts_query(&self, sql: &str) -> Result<Vec<(String, String)>, StoreError> {
+    fn chunk_splade_texts_query(
+        &self,
+        sql: &'static str,
+    ) -> Result<Vec<(String, String)>, StoreError> {
         let _span = tracing::info_span!("chunk_splade_texts").entered();
         self.rt.block_on(async {
             let rows: Vec<_> = sqlx::query(sql).fetch_all(&self.pool).await?;

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -125,7 +125,7 @@ async fn upsert_type_edges_one_file(
             "DELETE FROM type_edges WHERE source_chunk_id IN ({})",
             placeholders
         );
-        let mut q = sqlx::query(&sql);
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
         for id in batch {
             q = q.bind(id);
         }
@@ -325,7 +325,7 @@ impl<Mode> Store<Mode> {
                  LIMIT ?2",
                 cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS_PREFIXED,
             );
-            let rows: Vec<ChunkRow> = sqlx::query(&sql)
+            let rows: Vec<ChunkRow> = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
                 .bind(type_name)
                 .bind(limit_to_sql(limit))
                 .fetch_all(&self.pool)
@@ -410,7 +410,7 @@ impl<Mode> Store<Mode> {
                      ORDER BY te.target_type_name, c.origin, c.line_start",
                     cols = crate::store::helpers::CHUNK_ROW_SELECT_COLUMNS_PREFIXED,
                 );
-                let mut q = sqlx::query(&sql);
+                let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for name in batch {
                     q = q.bind(name);
                 }
@@ -457,7 +457,7 @@ impl<Mode> Store<Mode> {
                      ORDER BY c.name, te.edge_kind, te.target_type_name",
                     placeholders
                 );
-                let mut q = sqlx::query(&sql);
+                let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for name in batch {
                     q = q.bind(name);
                 }


### PR DESCRIPTION
## Summary

Supersedes #1660. Bumps sqlx 0.8.6 → 0.9.0 and fixes the 58 dynamic-SQL compile errors that the major version introduced.

- **sqlx 0.9 contract**: `query()` now requires `SqlSafeStr` (impl'd by `&'static str`). Dynamic SQL strings (`format!()`, `LazyLock<String>`) must be wrapped with `sqlx::AssertSqlSafe(...)` as an explicit audit gate against injection.
- **58 sites across 18 files** wrapped: `sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))`. All wrapped queries use bind placeholders for user values; the dynamic part is schema names and placeholder counts (`?,?,?`), so the assertion holds by construction.
- **`store::sparse::chunk_splade_texts_query`**: tightened parameter to `&'static str` since both callers pass literals. The compiler proves safety — no `AssertSqlSafe` escape hatch needed.
- **`Cargo.toml`**: enable serde `"rc"` feature. sqlx 0.8.6 transitively activated `serde/rc` via `sqlx-core`'s serde dep, which made `Arc<str>: Serialize` compile for the `CallGraph` derive. sqlx 0.9 stopped activating it transitively. Made the dep explicit instead of relying on transitive activation.

## Test plan

- [x] `cargo build --features gpu-index` — clean
- [x] `cargo test --features gpu-index --lib` — **2213 passed, 0 failed**
- [x] `cargo clippy --features gpu-index -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
