### PR TITLE
fix: apply clippy 1.96 manual_option_zip lint

### DIFF
--- a/src/cli/commands/eval/runner.rs
+++ b/src/cli/commands/eval/runner.rs
@@ -350,9 +350,7 @@ fn search_for_rank(
         None
     };
     let splade_index = if use_splade { ctx.splade_index() } else { None };
-    let splade_arg = splade_query
-        .as_ref()
-        .and_then(|sq| splade_index.map(|si| (si, sq)));
+    let splade_arg = splade_index.zip(splade_query.as_ref());
 
     let threshold = 0.0_f32; // Don't drop low-similarity results — we want full top-K for R@K.
 

--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -385,10 +385,7 @@ fn cmd_query_project(ctx: &QueryContext<'_>) -> Result<()> {
         effective_limit
     };
     // Build SPLADE argument for search_hybrid
-    let splade_arg = ctx
-        .splade_query
-        .as_ref()
-        .and_then(|sq| ctx.splade_index.map(|si| (si, sq)));
+    let splade_arg = ctx.splade_index.zip(ctx.splade_query.as_ref());
 
     let results = if audit_mode.is_active() {
         let code_results = store.search_hybrid(


### PR DESCRIPTION
Rust 1.96 hit stable with the new `manual_option_zip` clippy lint, which fails CI (`-D warnings`) on main and every open dependabot PR (#1668–#1671).

Two sites flagged, both the same hand-rolled `Option` zip:

- `src/cli/commands/eval/runner.rs` — `splade_arg` construction
- `src/cli/commands/search/query.rs` — `splade_arg` construction

Replaced with `Option::zip` per clippy's suggestion. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
