### PR TITLE
fix(evals): line-insensitive gold matching across Python harnesses

### DIFF
--- a/evals/alpha_sweep_v3.py
+++ b/evals/alpha_sweep_v3.py
@@ -169,12 +169,13 @@ def main() -> int:
                         errors += 1
                         continue
                     gold = q["gold_chunk"]
-                    gold_key = (gold.get("origin"), gold.get("name"), gold.get("line_start"))
+                    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+                    gold_key = (gold.get("origin"), gold.get("name"))
                     res_list = out.get("results", [])
                     cat_total += 1
                     if res_list:
                         top = res_list[0]
-                        if (top.get("file"), top.get("name"), top.get("line_start")) == gold_key:
+                        if (top.get("file"), top.get("name")) == gold_key:
                             cat_hits += 1
                 except (json.JSONDecodeError, KeyError):
                     errors += 1

--- a/evals/alpha_sweep_v3_r5.py
+++ b/evals/alpha_sweep_v3_r5.py
@@ -81,7 +81,8 @@ K_LIST = (1, 5, 20)
 
 
 def gold_key(g: dict) -> tuple:
-    return (g.get("origin"), g.get("name"), g.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (g.get("origin"), g.get("name"))
 
 
 def load_checkpoint(path: Path) -> tuple[set, dict]:
@@ -203,7 +204,8 @@ def main() -> int:
                     gold = q["gold_chunk"]
                     target = gold_key(gold)
                     for i, r in enumerate(res_list):
-                        if (r.get("file"), r.get("name"), r.get("line_start")) == target:
+                        # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+                        if (r.get("file"), r.get("name")) == target:
                             for k in K_LIST:
                                 if i + 1 <= k:
                                     cat_hits[f"r{k}"] += 1

--- a/evals/baseline_v4_eval.py
+++ b/evals/baseline_v4_eval.py
@@ -16,13 +16,15 @@ QUERIES_DIR = Path(__file__).resolve().parent / "queries"
 
 
 def gold_key(g):
-    return (g.get("origin"), g.get("name"), g.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (g.get("origin"), g.get("name"))
 
 
 def match_at_k(gold, results, k):
     target = gold_key(gold)
     for i, r in enumerate(results[:k]):
-        if (r.get("file"), r.get("name"), r.get("line_start")) == target:
+        # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+        if (r.get("file"), r.get("name")) == target:
             return i + 1
     return None
 

--- a/evals/build_contrastive_shards.py
+++ b/evals/build_contrastive_shards.py
@@ -61,11 +61,13 @@ CAT_ALIASES = {
 
 
 def gold_key(g: dict) -> tuple:
-    return (g.get("origin"), g.get("name"), g.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (g.get("origin"), g.get("name"))
 
 
 def candidate_key(c: dict) -> tuple:
-    return (c.get("file"), c.get("name"), c.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (c.get("file"), c.get("name"))
 
 
 def load_corpus() -> list[dict]:

--- a/evals/build_reranker_train.py
+++ b/evals/build_reranker_train.py
@@ -37,7 +37,8 @@ NEGATIVES_PER_POSITIVE = 6  # 1 positive + 6 negatives = 7-way pair group
 
 
 def _chunk_key(r: dict) -> tuple:
-    return (r.get("file") or r.get("origin"), r.get("name"), r.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (r.get("file") or r.get("origin"), r.get("name"))
 
 
 def _result_content(result: dict) -> str:
@@ -81,7 +82,8 @@ def main() -> int:
                     n_missing_pool += 1
                     continue
 
-                gold_key = (gold.get("origin"), gold.get("name"), gold.get("line_start"))
+                # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+                gold_key = (gold.get("origin"), gold.get("name"))
                 pool = pool_entry["pool"]
 
                 # Find positive in pool (the pool member matching gold).

--- a/evals/classifier_ab_eval.py
+++ b/evals/classifier_ab_eval.py
@@ -42,13 +42,15 @@ QUERIES_DIR = Path(__file__).resolve().parent / "queries"
 
 
 def gold_key(g):
-    return (g.get("origin"), g.get("name"), g.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (g.get("origin"), g.get("name"))
 
 
 def match_at_k(gold, results, k):
     target = gold_key(gold)
     for i, r in enumerate(results[:k]):
-        if (r.get("file"), r.get("name"), r.get("line_start")) == target:
+        # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+        if (r.get("file"), r.get("name")) == target:
             return i + 1
     return None
 

--- a/evals/colbert_rerank_eval.py
+++ b/evals/colbert_rerank_eval.py
@@ -139,22 +139,21 @@ def find_rank_in_results(gold: dict, results: list[dict]) -> tuple[int | None, s
     """Return (1-based rank, match_kind). Strict → basename → name fallback."""
     target_origin = gold.get("origin")
     target_name = gold.get("name")
-    target_lstart = gold.get("line_start")
     target_basename = (target_origin or "").split("/")[-1].split("\\")[-1]
 
     for i, r in enumerate(results):
-        if (r.get("file"), r.get("name"), r.get("line_start")) == (
+        # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+        if (r.get("file"), r.get("name")) == (
             target_origin,
             target_name,
-            target_lstart,
         ):
             return i + 1, "strict"
     for i, r in enumerate(results):
         rb = (r.get("file") or "").split("/")[-1].split("\\")[-1]
-        if (rb, r.get("name"), r.get("line_start")) == (
+        # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+        if (rb, r.get("name")) == (
             target_basename,
             target_name,
-            target_lstart,
         ):
             return i + 1, "basename"
     for i, r in enumerate(results):

--- a/evals/distilled_head_ab_daemon.py
+++ b/evals/distilled_head_ab_daemon.py
@@ -24,13 +24,15 @@ QUERIES_DIR = Path(__file__).resolve().parent / "queries"
 
 
 def gold_key(g):
-    return (g.get("origin"), g.get("name"), g.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (g.get("origin"), g.get("name"))
 
 
 def match_at_k(gold, results, k):
     target = gold_key(gold)
     for i, r in enumerate(results[:k]):
-        if (r.get("file"), r.get("name"), r.get("line_start")) == target:
+        # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+        if (r.get("file"), r.get("name")) == target:
             return i + 1
     return None
 

--- a/evals/distilled_head_ab_eval.py
+++ b/evals/distilled_head_ab_eval.py
@@ -36,13 +36,15 @@ QUERIES_DIR = Path(__file__).resolve().parent / "queries"
 
 
 def gold_key(g):
-    return (g.get("origin"), g.get("name"), g.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (g.get("origin"), g.get("name"))
 
 
 def match_at_k(gold, results, k):
     target = gold_key(gold)
     for i, r in enumerate(results[:k]):
-        if (r.get("file"), r.get("name"), r.get("line_start")) == target:
+        # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+        if (r.get("file"), r.get("name")) == target:
             return i + 1
     return None
 

--- a/evals/fused_head_ab_eval.py
+++ b/evals/fused_head_ab_eval.py
@@ -29,13 +29,15 @@ OVERRIDE_PATH = Path.home() / ".config/systemd/user/cqs-watch.service.d/ab-overr
 
 
 def gold_key(g):
-    return (g.get("origin"), g.get("name"), g.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (g.get("origin"), g.get("name"))
 
 
 def match_at_k(gold, results, k):
     target = gold_key(gold)
     for i, r in enumerate(results[:k]):
-        if (r.get("file"), r.get("name"), r.get("line_start")) == target:
+        # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+        if (r.get("file"), r.get("name")) == target:
             return i + 1
     return None
 

--- a/evals/hyde_per_category_eval.py
+++ b/evals/hyde_per_category_eval.py
@@ -80,13 +80,15 @@ async def generate_hyde(client: LLMClient, query: str) -> str:
 
 
 def gold_key(g):
-    return (g.get("origin"), g.get("name"), g.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (g.get("origin"), g.get("name"))
 
 
 def match_at_k(gold, results, k):
     target = gold_key(gold)
     for i, r in enumerate(results[:k]):
-        if (r.get("file"), r.get("name"), r.get("line_start")) == target:
+        # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+        if (r.get("file"), r.get("name")) == target:
             return i + 1
     return None
 

--- a/evals/label_reranker_v3.py
+++ b/evals/label_reranker_v3.py
@@ -129,7 +129,8 @@ def build_work_items(repo_root: Path, limit_per_split: int | None) -> list[dict]
         for q_idx, entry in enumerate(rows):
             query = entry["query"]
             gold = entry.get("gold_chunk") or {}
-            gold_key = (gold.get("origin"), gold.get("name"), gold.get("line_start"))
+            # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+            gold_key = (gold.get("origin"), gold.get("name"))
             pool_entry = pools_by_query.get(query)
             if not pool_entry:
                 missing_pool += 1
@@ -144,7 +145,8 @@ def build_work_items(repo_root: Path, limit_per_split: int | None) -> list[dict]
                 if content is None:
                     missing_file += 1
                     continue
-                is_gold = (origin, name, line_start) == gold_key
+                # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+                is_gold = (origin, name) == gold_key
                 items.append({
                     "split": split_name,
                     "query": query,

--- a/evals/note_boost_ab_eval.py
+++ b/evals/note_boost_ab_eval.py
@@ -39,13 +39,15 @@ QUERIES_DIR = REPO_ROOT / "evals" / "queries"
 
 
 def gold_key(g):
-    return (g.get("origin"), g.get("name"), g.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (g.get("origin"), g.get("name"))
 
 
 def match_at_k(gold, results, k):
     target = gold_key(gold)
     for i, r in enumerate(results[:k]):
-        if (r.get("file"), r.get("name"), r.get("line_start")) == target:
+        # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+        if (r.get("file"), r.get("name")) == target:
             return i + 1
     return None
 

--- a/evals/rerank_ab_eval.py
+++ b/evals/rerank_ab_eval.py
@@ -45,14 +45,16 @@ QUERIES_DIR = Path(__file__).parent / "queries"
 
 
 def gold_key(g: dict) -> tuple:
-    return (g.get("origin"), g.get("name"), g.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (g.get("origin"), g.get("name"))
 
 
 def match_gold(gold: dict, results: list[dict], k: int) -> int | None:
     """Return the 1-indexed rank of the gold within the top-k, else None."""
     gold_k = gold_key(gold)
     for i, r in enumerate(results[:k]):
-        rk = (r.get("file"), r.get("name"), r.get("line_start"))
+        # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+        rk = (r.get("file"), r.get("name"))
         if rk == gold_k:
             return i + 1
     return None

--- a/evals/rerank_ab_oracle_eval.py
+++ b/evals/rerank_ab_oracle_eval.py
@@ -58,13 +58,15 @@ ALPHA_DEFAULTS = {
 
 
 def gold_key(g):
-    return (g.get("origin"), g.get("name"), g.get("line_start"))
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+    return (g.get("origin"), g.get("name"))
 
 
 def match_at_k(gold, results, k):
     target = gold_key(gold)
     for i, r in enumerate(results[:k]):
-        if (r.get("file"), r.get("name"), r.get("line_start")) == target:
+        # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)
+        if (r.get("file"), r.get("name")) == target:
             return i + 1
     return None
 

--- a/evals/validate_gold.py
+++ b/evals/validate_gold.py
@@ -60,12 +60,12 @@ def _make_client(backend: str):
 
 
 def chunk_matches(result: dict, gold: dict) -> bool:
-    """Origin + name + line_start identity. Chunk ids drift across reindexes
-    but origin/name/line_start stay stable for the same logical chunk."""
+    """Origin + name identity. Chunk ids and line numbers drift across
+    reindexes/refactors, but origin/name stay stable for the same logical chunk.
+    # match (file, name) only — line numbers drift with refactors (mirrors Rust eval matcher)"""
     return (
         result.get("file") == gold.get("origin")
         and result.get("name") == gold.get("name")
-        and result.get("line_start") == gold.get("line_start")
     )
 
 


### PR DESCRIPTION
The Rust eval matcher (runner.rs) already matches (file, name) only — line_start deliberately excluded since refactor line drift fakes regressions. The #1673 comment sweep shifted lines in 231 files; 16 Python harnesses still matched the strict (file, name, line_start) triple and would all have under-reported.

Changed: gold-vs-result equality keys drop line_start in 16 scripts, mirroring the Rust matcher (comment at each site).

Deliberately kept line-strict: audit_r5_failure_modes.py (its purpose is measuring strict-vs-name drift), regenerate_v3_test.py (line_start is the fixture-migration signal), result-pool dedup keys (same-named chunks must not collapse). All changed files pass py_compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
