### PR TITLE
chore(deps): cuvs fork -> official 26.6.0 + libcuvs 26.06

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ tools/*
 
 # ORT CUDA provider symlinks (created at runtime by ensure_ort_provider_libs)
 libonnxruntime_providers_*.so
-cuvs-fork-push
 
 # Parallel agent worktrees — checked out via `git worktree add` under this
 # directory. Their `.git` is a file, not a directory; the file walker also

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,26 +370,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,15 +511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,17 +555,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -662,6 +622,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cmake-package"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13cd24990b85e3c97060e03e0034a4c03266247769e573e129425404a5601639"
+dependencies = [
+ "itertools",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -1075,8 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "cuvs"
-version = "26.4.0"
-source = "git+https://github.com/jamie8johnson/cuvs-patched.git?branch=add-serialize-deserialize#5894e9336b40e90e51d3c5ec4992e69498ee2685"
+version = "26.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d56646bd3dd39d7fe93d4e4cfa2261aec55e84f7275ffa2137f2f5b42981d1c"
 dependencies = [
  "cuvs-sys",
  "ndarray 0.15.6",
@@ -1084,12 +1060,12 @@ dependencies = [
 
 [[package]]
 name = "cuvs-sys"
-version = "26.4.0"
+version = "26.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c41a89bdfe3960aae8746c43016f0909ada1c9efc933d9e26006223aeeb51"
+checksum = "d9967e6a5ade14cd3712dba72156c1a874386c48b4684c43fc6a4b7887bb0c78"
 dependencies = [
- "bindgen",
- "cmake",
+ "anyhow",
+ "cmake-package",
 ]
 
 [[package]]
@@ -1679,12 +1655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,15 +2242,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2397,16 +2358,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
 
 [[package]]
 name = "libredox"
@@ -3402,7 +3353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools 0.14.0",
+ "itertools",
  "rayon",
 ]
 
@@ -4378,7 +4329,7 @@ dependencies = [
  "getrandom 0.3.4",
  "hf-hub",
  "indicatif 0.18.4",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -5533,6 +5484,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ exclude = [
     "evals/",
     "samples/",
     "tools/",
-    "cuvs-fork-push/",
 ]
 
 [dependencies]
@@ -130,7 +129,7 @@ sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio",
 # Vector search (HNSW default, cuVS optional)
 hnsw_rs = "0.3"
 simsimd = "6"
-cuvs = { version = "=26.4", optional = true }  # pinned — strict version coupling with conda libcuvs
+cuvs = { version = "=26.6", optional = true }  # pinned — strict version coupling with conda libcuvs
 
 # Text processing
 regex = "1"
@@ -315,9 +314,6 @@ serial_test = "3"
 # Mock HTTP server for LocalProvider unit + integration tests (OpenAI-compat).
 # Used only under `cfg(test)` behind the `llm-summaries` feature.
 httpmock = "0.8"
-
-[patch.crates-io]
-cuvs = { git = "https://github.com/jamie8johnson/cuvs-patched.git", branch = "add-serialize-deserialize" }  # adds search_with_filter + CAGRA serialize/deserialize wrappers
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
Retires the cuvs fork: our v26.06.00 upstream contributions ('feat(rust): add serialize/deserialize support for CAGRA index', 'feat(rust): add search_with_filter to CAGRA Index') are in the official release.

- cuvs pin =26.4 -> =26.6 (crates.io registry, [patch.crates-io] git override removed)
- conda libcuvs 26.04.00 -> 26.06.00 (rapidsai) in lockstep — 26.06's RMM->CCCL MR migration makes ABI matching mandatory
- cuvs-fork-push/ workspace dir deleted (clean, tip pushed, content upstream); workspace exclude + .gitignore entry dropped

Verification (local GPU; CI has no CUDA):
- cargo build --features cuda-index clean
- 26/26 CAGRA tests green, including serialize/deserialize + filtered-search paths that came from the fork
- full suite 3911 passed / 0 failed
- JIT LTO CAGRA search: cold CLI 8.4s -> 7.5s, warm daemon ~0.55s round-trip (unchanged), daemon first-query 27s -> 14s. No cold-start regression.

Follow-up filed: #1678 (contribute IVF-SQ Rust bindings upstream — next contribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
