### PR TITLE
chore: Release v1.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.42.0] - 2026-06-09
+
+Minor release. Schema v28. Four threads: comment-canonical embedding reuse, a whole-codebase comment cleanup with a CI guard to keep it clean, retirement of the cuvs fork onto official 26.6.0, and eval-harness drift-proofing.
+
 ### Added
 
 - **Comment-canonical embedding-cache hash.** Chunks now carry a
@@ -21,6 +25,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `canonical_hash` NULL (a clean cache miss — never a wrong hit) until the next
   reindex writes it; no backfill. Old `content_hash`-keyed global-cache rows
   become unreachable under the new key and age out via `cqs cache prune`.
+- **Comment-provenance CI lint** (#1676). `scripts/check_comment_provenance.py`
+  scans PR diffs for audit-finding IDs and PR citations in added comments
+  (TODO/FIXME exempt; string literals ignored) and fails the fmt job on hits.
+  Validated against #1673's history: 0 false positives forward, 2,673 catches
+  reversed.
+
+### Changed
+
+- **Whole-codebase comment cleanup** (#1673). 231 of 264 source files: ~1,500+
+  changelog/provenance refs removed from comments (audit IDs, PR citations,
+  "previously/formerly/pre-fix" narration), rewritten present-tense.
+  Comment-only by construction — mechanically verified that every changed line
+  is a comment, blank, or trailing-comment edit on byte-identical code. One
+  doc-accuracy fix: `lib.rs` claimed `EMBEDDING_DIM` is 1024/BGE-large
+  (768/EmbeddingGemma since v1.35.0).
+- **cuvs fork retired → official 26.6.0** (#1679). Our v26.06.00 upstream
+  contributions (CAGRA serialize/deserialize + `search_with_filter` Rust
+  wrappers) shipped, so the `[patch.crates-io]` git override is gone: cuvs
+  pinned `=26.6` from crates.io, conda libcuvs 26.04 → 26.06 in lockstep,
+  fork workspace dir removed. JIT LTO CAGRA search (new in 26.06): no
+  cold-start tax measured — cold CLI 8.4s → 7.5s, warm daemon ~0.55s
+  round-trip unchanged. Next contribution tracked: IVF-SQ Rust bindings
+  (#1678).
+- **ROADMAP currency** (#1673): v1.41.0 as Current, SNR Phases 4-6 marked
+  shipped, Open Issues re-audited against GitHub (30 closed rows pruned, the
+  two deferred v1.40-cycle P1s now tracked).
+
+### Fixed
+
+- **Eval harnesses are line-drift-proof** (#1675). 16 Python eval scripts
+  matched gold chunks on the strict `(file, name, line_start)` triple; any
+  refactor that shifted line numbers (like #1673) faked a 25-30pp regression.
+  All gold↔result equality now matches `(file, name)`, mirroring the Rust
+  matcher. Drift-measurement and fixture-migration scripts deliberately keep
+  line_start.
+- **Flaky CI hardened** (#1676). `tc31_save_and_load_with_dim_1024` asserts
+  top-3 containment instead of exact rank-1 (near-parallel test vectors made
+  exact order RNG-dependent); CI caches `~/.cache/huggingface` in both
+  workflows (repeated model downloads were tripping HF 429 rate limits).
+- **clippy 1.96 `manual_option_zip`** (#1672) at two SPLADE-arg call sites.
+
+### Dependencies
+
+- sqlx 0.8.6 → 0.9.0 with `AssertSqlSafe` on dynamic SQL (#1666); tree-sitter
+  0.26.9, tree-sitter-erlang 0.18, tree-sitter-swift 0.7.3, reqwest 0.13.4,
+  similar 3.1.1, serde_json 1.0.150, log 0.4.32, serial_test 3.5.0,
+  uuid 1.23.3 (#1659–#1671).
 
 ## [1.41.0] - 2026-05-20
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,7 @@ src/
     queries/    - Tree-sitter queries (.scm files, loaded via include_str!())
       <lang>.chunks.scm, <lang>.calls.scm, <lang>.types.scm
   test_helpers.rs - Shared test fixtures module
-  store/        - SQLite storage layer (Schema v27, WAL mode)
+  store/        - SQLite storage layer (Schema v28, WAL mode)
     mod.rs      - Store struct, open/init, FTS5, split_sql_statements (BEGIN/END-aware)
     metadata.rs - Chunk metadata queries, file-level operations
     search.rs   - RRF fusion, search_filtered, search_unified_with_index
@@ -224,7 +224,7 @@ src/
     types.rs    - Type edge storage and queries
     helpers/    - Types, embedding conversion, scoring, SQL utilities
       mod.rs, embeddings.rs, error.rs, rows.rs, scoring.rs, search_filter.rs, sql.rs, types.rs
-    migrations.rs - Schema migration framework (v10-v27, including v19 FK cascade, v20 trigger, v21 splade tokens, v22 chunks.umap_x/y, v23 reconcile fingerprint, v24 vendored-code trust, v25 notes.kind, v26 composite (source_type, origin) index on chunks, v27 chunks.needs_embedding for skip-first-pass embed under --llm-summaries (#1452))
+    migrations.rs - Schema migration framework (v10-v28, including v19 FK cascade, v20 trigger, v21 splade tokens, v22 chunks.umap_x/y, v23 reconcile fingerprint, v24 vendored-code trust, v25 notes.kind, v26 composite (source_type, origin) index on chunks, v27 chunks.needs_embedding for skip-first-pass embed under --llm-summaries, v28 chunks.canonical_hash for comment-canonical embedding reuse)
   parser/       - Code parsing (tree-sitter + custom parsers, delegates to language/ registry)
     mod.rs      - Parser struct, parse_file(), parse_file_all(), supported_extensions()
     types.rs    - Chunk (incl. parent_type_name), CallSite, FunctionCalls, TypeRef, ParserError

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "cqs"
-version = "1.41.0"
+version = "1.42.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cqs-macros"]
 
 [package]
 name = "cqs"
-version = "1.41.0"
+version = "1.42.0"
 edition = "2021"
 rust-version = "1.95"
 description = "Code intelligence and RAG for AI agents. Semantic search, call graphs, impact analysis, type dependencies, and smart context assembly — in single tool calls. 54 languages + L5X/L5K PLC exports. 52.7% R@1 / 77.5% R@5 / 89.4% R@20 on v3.v2 dual-judge code-search (218 queries, EmbeddingGemma-300m default with per-category SPLADE α including identifier_lookup retune in v1.39.x; v3.v2 fixture line numbers re-anchored 2026-05-08 in #1607). Daemon mode (3-19ms queries). Local-first, GPU-accelerated."

--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,7 +2,18 @@
 
 ## Right Now
 
-**Comment hygiene + dependabot drain — 2026-06-09.** Two arcs, both closed:
+**v1.42.0 cut — 2026-06-09 (evening).** Release PR in flight. Schema v28 (canonical_hash). Contents: comment-canonical embedding reuse (#1677), comment cleanup + CI provenance lint (#1673/#1676), cuvs fork retired onto official 26.6.0 + conda libcuvs 26.06 (#1679), eval drift-proofing (#1675), sqlx 0.9 + dep bumps. Toolchain updated to 1.96.0 (local now matches CI; this morning's manual_option_zip ambush can't recur).
+
+**In flight:**
+- **IVF-SQ Rust bindings agent** (~/cuvs-contrib, branch rust-ivf-sq) — next cuvs upstream contribution, tracked #1678. No pushes; review before anything goes upstream.
+- **Standing fix loop** (session cron, 5h): merges green PRs, continues ongoing work, else pulls from the verified audit queue (`docs/audit-triage.md` § Verification 2026-06-09 — 24 confirmed-open, priority-ordered) or fixable issues (#1680 MSRV 1.96 + assert_matches sweep, #1350, #1351).
+- **Post-release housekeeping queued:** tag + crates.io publish after release PR merges, then `cargo clean` (~/.cargo-target/cqs) + /tmp scratch cleanup.
+
+**Operational notes from today:** daemon CLI client has no socket read timeout — a request racing a daemon restart blocks forever (hung cli_envelope_test 40min; noted in notes.toml, queue it). Never restart cqs-watch while a test suite runs. Telemetry reset at 23:03 (archived 33-day window: impact 71% — pre-edit hook; search 4.4%; no kind-fallback visibility until OB-V1.40-2 ships).
+
+### Earlier today — comment hygiene + dependabot drain
+
+Two arcs, both closed:
 
 - **All-source comment cleanup (#1673, merged).** 231 of 264 `.rs` files: removed ~1,500+ changelog/provenance refs from comments (audit IDs, PR citations, "previously/pre-fix" narration), rewrote present-tense. Executed by 10 parallel opus agents with disjoint file ownership; integration mechanically verified the diff was comment-only (trailing-comment edits on byte-identical code allowed) and reverted 17 string-literal leaks before commit. One real doc fix: `lib.rs` `EMBEDDING_DIM` doc said 1024/BGE-large, is 768/EmbeddingGemma. Same PR brought ROADMAP.md to v1.41.0 currency (v1.40.0 → Previous, SNR Phases 4-6 flipped to shipped, Open Issues re-audited — 30 closed rows pruned, DS-V1.40-1/DS-V1.40-7 deferred P1s now tracked).
 - **Dependabot drain (#1668–#1672, all merged).** Rust 1.96 stable's new `manual_option_zip` clippy lint broke CI on every open PR; fixed the two sites on main (#1672), `@dependabot rebase`d all four dep PRs, merged: uuid 1.23.2, log 0.4.31, serial_test 3.5.0, tree-sitter-swift 0.7.3. Two CI flakes encountered and cleared on rerun: HuggingFace 429 model download, `tc31_save_and_load_with_dim_1024` HNSW nearest-neighbor assert (noted in notes.toml — will bite again).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,14 +1,22 @@
 # Roadmap
 
-## Current: v1.41.0 (cut 2026-05-20, crates.io published)
+## Current: v1.42.0 (cut 2026-06-09)
+
+Minor release. Schema v28. Four threads:
+- **Comment-canonical embedding reuse** (#1677): `chunks.canonical_hash` (comment-stripped + whitespace-collapsed blake3) keys both embedding-reuse paths on both surfaces (bulk pipeline + watch incremental); comment/formatting-only edits no longer re-embed the corpus.
+- **Comment hygiene** (#1673 + #1676): ~1,500+ provenance refs stripped from comments across 231 files, present-tense rewrite; CI provenance lint (fmt job) keeps it clean.
+- **cuvs fork retired** (#1679): our CAGRA serialize/deserialize + search_with_filter wrappers shipped in official cuvs 26.6.0 — pin `=26.6`, conda libcuvs 26.06, `[patch.crates-io]` gone. JIT LTO CAGRA search: no cold-start tax (cold CLI 8.4s→7.5s, warm daemon ~0.55s unchanged). Next upstream contribution: **IVF-SQ Rust bindings (#1678, agent in flight)** — 4× memory reduction candidate for multi-slot A/Bs once bound.
+- **Eval drift-proofing** (#1675): 16 Python harnesses match gold on `(file, name)` like the Rust matcher; refactor line-shifts can no longer fake regressions.
+
+**Post-v1.40.0 audit verification (2026-06-09, audit-mode):** every still-open finding re-verified against code — 24 confirmed open, 6 partially fixed, 1 fixed, 2 invalidated (incl. the "missing chunks.name index" premise: `idx_chunks_name` was in base schema all along). Verified priority queue in `docs/audit-triage.md` § Verification 2026-06-09; the standing 5h fix loop works from it. Also queued: #1680 (MSRV 1.95→1.96, `assert_matches!` sweep, clippy --all-targets cleanup). New finding from live failure: daemon CLI client has no socket read timeout (request racing a daemon restart blocks forever).
+
+## Previous: v1.41.0 (cut 2026-05-20, crates.io published)
 
 Minor release. 30 commits since v1.40.0; no breaking changes (v1.40.0 carried the SNR wire-format flip). Three threads: polymorphic routing Phase 1 completion (matrix below), post-v1.40.0 audit cycle closure, `cqs dead` false-positive reduction (table below).
 
 **Post-v1.40.0 audit cycle (closed in v1.41.0):** 16-category audit, 150 raw findings → 78 triaged → 9 closeout PRs (#1626–#1634). 21 of 23 P1s closed; 2 deferred with rationale (DS-V1.40-1 daemon Store cache invalidation, DS-V1.40-7 sentiment CHECK constraint — tracked in Open Issues below). Highlights: lying-docs sweep (#1626), Tier 2b `filter_invoked_macros` correctness — LIKE → GLOB, Rust-only guard, recursive-macro self-exclusion (#1627), Posture/OutputFormat env-var caching + truthy aliases (#1629), `worktree_stale` signal restored under V2Bare (#1630), atomic backup-restore sidecar ordering (#1631), kind-fallback DoS caps (#1632), BFS sentinel + Tier 2a anchoring (#1633).
 
 Also: `cqs chat` honors `CQS_OUTPUT_FORMAT=v1` (#1650, first external-contributor fix), `cli_chat_format_test` aligned with the slim envelope — closed 8 consecutive nightly failures (#1655), screw-mcp/screw-tape moved to its own repo (#1656).
-
-**Post-release on main (ahead of v1.41.0 tag):** sqlx 0.8.6 → 0.9.0 with `AssertSqlSafe` on dynamic SQL (#1666), clippy 1.96 `manual_option_zip` fix (#1672), comment-cleanup sweep across all 264 source files, and dependabot bumps (tree-sitter 0.26.9, tree-sitter-erlang 0.18, reqwest 0.13.4, similar 3.1.1, serde_json 1.0.150, log 0.4.31, serial_test 3.5.0, uuid 1.23.2).
 
 **Polymorphic-routing Phase 1 matrix (first cell v1.40.0 #1612; completed in v1.41.0):**
 
@@ -34,8 +42,6 @@ Also: `cqs chat` honors `CQS_OUTPUT_FORMAT=v1` (#1650, first external-contributo
 | 2b correctness | #1627 (v1.41.0) | LIKE → GLOB (case-sensitive, no `_` collision), Rust-only guard, recursive-macro self-exclusion, GLOB metachar escape, +7 tests | closes the Tier 2b false-match edge cases |
 
 Cumulative: ~114 → 35 cqs-dead entries (as of v1.41.0). Remaining 35 includes 2 macros (`for_each_logged_batch_cmd`, `gen_log_query_dispatch`) flagged because their only invocation is at file scope (line 606 of `src/cli/batch/commands.rs`) — outside any chunk's byte range. Closing fully requires a chunker change to include doc comments / file-level statements; deferred as architectural.
-
-## Previous: v1.40.0 (cut 2026-05-08)
 
 **v1.40.0 (2026-05-08):** 14-PR minor release driven by agent-adoption telemetry (search rate dropped 79% → 6% mid-April → early May). **Breaking:** CLI direct `--json` emits the bare JSON payload (no envelope wrap); `CQS_OUTPUT_FORMAT=v1` is the consumer-migration hedge. Contents:
 - **SNR restoration Phases 1-4 (#1601, #1602, #1604, #1609, #1613):** `Posture` enum + per-result skip-when-default + posture-gated force-emit + slim batch/daemon envelope + CLI direct → bare payload. ~30% smaller per result + ~70 KB saved per 1000-line fixture batch.

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -19,6 +19,37 @@ After consolidation: **150 raw → 78 triage entries.** Heavy overlap: the v1.40
 
 ---
 
+## Verification 2026-06-09 (audit-mode, direct code examination)
+
+All findings still marked open after the v1.41.0 cycle were re-verified against main (post-#1677, schema v28). Verdicts below supersede the per-row Status cells; this section is the work queue for the standing fix loop.
+
+### Closed by verification (no work needed)
+
+- **SEC-V1.40-7** — FIXED/never-matched: daemon uses `String::with_capacity(8192)` + `.take(cap)` read-limit (socket.rs:101-110); the "5 MB preallocation" never existed.
+- **DS-V1.40-9** — INVALID: v26→v27 sets `needs_embedding=1` only `WHERE embedding_base IS NULL` (migrations.rs:994-996); the half-state can't be created.
+- **RB-V1.40-2 sub-claim "no chunks.name index → full scan"** — INVALID: `idx_chunks_name` is in base schema.sql:99. Only the `format!`-per-call sub-claim survives (cleanup tier).
+- **TC-HAP-V1.40-7 sub-claim "no tests"** — FIXED: kind.rs:303-340 has round-trip tests.
+- **Posture truth-table + env-read-caching sub-claims** (TC-*-V1.40-1 part, CQ-V1.40-5 part) — FIXED by #1629 (OnceLock + 12 unit tests).
+
+### Verified-open queue (priority order for the fix loop)
+
+1. **Cap parity for CLI graph fallbacks** (CQ-V1.40-3 remainder + EXT-V1.40-2): #1632's 100-def/2KB cap covers only impact + daemon; callers/callees/deps/test_map/trace CLI paths emit unbounded JSON on hot names. Extend `chunk_to_definition_value` to all four files — closes the DoS gap AND the duplication. Easy/medium.
+2. **EH-V1.40-8 + PB-V1.40-7**: `try_kind_fallback` propagates `lookup_by_name` errors as fatal (`?` at handlers/graph.rs:79,147); should warn + fall through to the normal path. Easy.
+3. **SHL-V1.40-1 + AC-V1.40-9**: `lookup_by_name` (store/chunks/query.rs:271-275) — add LIMIT and routing-priority ORDER BY (currently alphabetical chunk_type, no cap; #1632's cap is downstream of the full fetch). Easy, one query.
+4. **Cluster C architecture refactor** (CQ-V1.40-1/2/4/9, API-V1.40-1/2/4, RM-V1.40-1, EXT-V1.40-1): adopt `detect_kind_for_store` at its 8 inlined call sites; unify the 6 dispatcher signatures (`&OutputFormat` vs `json: bool`); split Kind vs KindResolution; replace `_ => {}` fallthroughs with exhaustive matches; delete `cmd_impact_const_fallback` (hand-rolled duplicate); single source of truth for the ~24 redirect-note strings. One refactor PR. Medium.
+5. **DS-V1.40-1**: daemon Store cache invalidation via `PRAGMA data_version` (identity check is inode/size/mtime only, batch/mod.rs:441-509). Medium.
+6. **DS-V1.40-8/10**: kind-detect + real query share no read snapshot. Medium; consider folding into 4.
+7. **Test backfill** (TC-ADV-V1.40-4, TC-HAP-V1.40-3, TC-ADV-V1.40-9, TC-ADV-V1.40-1 remainder): daemon try_kind_fallback has zero tests for any kind; no CLI integration tests for fallback kinds; V2Bare default + ULTRASECURITY×OUTPUT_FORMAT compose untested at binary boundary (every integration test pins CQS_OUTPUT_FORMAT=v1). Medium.
+8. **Observability bundle** (OB-V1.40-1/2/5/6): fallback-fired tracing events, telemetry category (Phase 2 prioritization signal), kind.rs entry spans, Tier 2b drop counter. Easy.
+9. **Perf bundle**: Cluster A2 N+1 GLOB scans in `filter_invoked_macros` (dead_code.rs:189-199, correctness fixed by #1627 but still per-macro full scans); daemon `dispatch_value` refactor (TODO P2 #62, socket.rs:270) + `emit_json` double-serialization; PERF-V1.40-7 build_test_map inversion (modest — loop body is O(1)). Medium.
+10. **Cleanup tier**: PERF-V1.40-8 fragment caching — NOTE the proposed per-posture LazyLock is unsafe (fragment carries dynamic worktree_stale fields); cache only the static part. CQ-V1.40-5/6 `_with_posture` plumbing — wire it or delete it (perf motivation gone post-#1629). AC-V1.40-6/7, EH-V1.40-3 (trace macro/Multiple/target-validation). SEC-V1.40-8 walk caps. PB-V1.40-9 WAL-on-9P detection. RM-V1.40-4 SQL string const. RM-V1.40-6/7 cross-project graph caching. Easy-medium each.
+
+### Still deferred (unchanged decision)
+
+- **DS-V1.40-7**: partially mitigated (CLI clamps to [-1,1], rejects NaN/Inf) but `--sentiment 0.7` still accepted — no discrete-value CHECK. Stays deferred per the v1.41.0 rationale.
+
+---
+
 ## Cross-cutting clusters
 
 These clusters drive the recommended PR order. A single PR per cluster collapses 3-7 findings into one fix-pattern review.

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -1879,3 +1879,11 @@ mentions = [
 sentiment = -0.5
 text = "tc31_save_and_load_with_dim_1024 (hnsw/persist.rs) is flaky in CI — nearest-neighbor assertion failed on an unrelated dep-bump PR (#1671, 2026-06-09), passed on rerun. HNSW approximate recall on random vectors; consider seeding or relaxing to top-k containment."
 mentions = ["src/hnsw/persist.rs"]
+
+[[note]]
+sentiment = -1.0
+text = "Daemon CLI client has no socket read timeout: a request racing a daemon restart blocks forever (cli_envelope_test hung 40min when cqs-watch restarted mid-suite). Also: never restart cqs-watch while a test suite runs — tests leak to the live daemon socket when CQS_NO_DAEMON unset."
+mentions = [
+    "src/cli/watch/socket.rs",
+    "src/daemon_translate.rs",
+]


### PR DESCRIPTION
Release v1.42.0. Schema v28. See CHANGELOG.md for the full section; headlines:

- Comment-canonical embedding-cache hash (#1677) — comment/formatting-only edits no longer re-embed the corpus
- Whole-codebase comment cleanup (#1673) + CI provenance lint (#1676)
- cuvs fork retired -> official 26.6.0 + conda libcuvs 26.06 (#1679); JIT LTO CAGRA verified no cold-start tax
- Eval harnesses line-drift-proofed (#1675); CI flake hardening (#1676)
- sqlx 0.9 + dependabot bumps; clippy 1.96 fix (#1672)

Also in this PR: ROADMAP v1.42.0 currency, tears, audit-verification queue in docs/audit-triage.md (24 confirmed-open findings, priority-ordered), CONTRIBUTING schema refs v27->v28, notes.toml additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
