### PR TITLE
refactor(search): query_core + typed search output (campaign phase 2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parity tests asserting the daemon adapter and the core produce identical
   values.
 
+- **Command-core unification for search (Phase 2a, internal).** The CLI search
+  path now routes the plain (non-`--ref`, non-`--include-refs`) project search
+  and the non-ref name-only search through a single surface-agnostic
+  `query_core(ctx, &QueryArgs) -> QueryOutput`. The core owns routing,
+  classification, embedding, the search invocation, and result assembly;
+  `cmd_query` is a thin adapter that renders text/JSON and owns the
+  `NoResults` exit code. `QueryArgs` derives `Deserialize` with doc-commented
+  fields (the param surface a future MCP `search` tool wraps). The CLI search
+  JSON is now built from typed `SearchResultOutput` / `SearchOutput` structs in
+  the display module (the single schema source), replacing the inline
+  `serde_json::json!` builders; per-result trust/injection fields still come
+  from the canonical store serializer, so the wire shape is byte-stable. The
+  `--ref`, `--include-refs`, and ref-name-only sub-paths remain in the adapter
+  (marked `TODO(phase-2b)`). Request-scoped config: the graph BFS node-cap env
+  vars (`CQS_TRACE_MAX_NODES`, `CQS_TEST_MAP_MAX_NODES`) and search's
+  `CQS_FORCE_BASE_INDEX` are now read once at each adapter boundary and threaded
+  into the cores via args, so the cores read no env. No JSON field was removed
+  or renamed.
+
 ### Fixed
 
 - **Kind-fallback cap parity across all graph commands.** The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ cqs - semantic code search with local embeddings
 - Push back when warranted.
 - Ask rather than guess wrong.
 - Efficiency over ceremony.
+- Rhetorical emphasis was rewarded in training, so it gets deployed uniformly — and emphasis applied to everything marks nothing. When every paragraph has something load-bearing in it, the building is just bricks.
 - **Never suggest ending a session.** We have 1M context. Keep working until the user stops. Don't offer to "wrap up", "call it", or "save for next session." If context runs low, update tears and keep going.
 - **Read files before acting on them.** Don't work from memory of what a file "probably" contains. Open it, read the relevant section, then act. This applies to source code, configs, scripts, docs, and especially function signatures. The cost of a Read is negligible; the cost of guessing wrong is a wasted round trip or a subtle bug. If you last read a file more than a few tool calls ago, read it again.
 

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -44,6 +44,15 @@ All findings still marked open after the v1.41.0 cycle were re-verified against 
 9. **Perf bundle**: Cluster A2 N+1 GLOB scans in `filter_invoked_macros` (dead_code.rs:189-199, correctness fixed by #1627 but still per-macro full scans); daemon `dispatch_value` refactor (TODO P2 #62, socket.rs:270) + `emit_json` double-serialization; PERF-V1.40-7 build_test_map inversion (modest — loop body is O(1)). Medium.
 10. **Cleanup tier**: PERF-V1.40-8 fragment caching — NOTE the proposed per-posture LazyLock is unsafe (fragment carries dynamic worktree_stale fields); cache only the static part. CQ-V1.40-5/6 `_with_posture` plumbing — wire it or delete it (perf motivation gone post-#1629). AC-V1.40-6/7, EH-V1.40-3 (trace macro/Multiple/target-validation). SEC-V1.40-8 walk caps. PB-V1.40-9 WAL-on-9P detection. RM-V1.40-4 SQL string const. RM-V1.40-6/7 cross-project graph caching. Easy-medium each.
 
+### Taste-debt issues (filed 2026-06-10, distilled from whole-codebase review)
+
+Ordered for the fix loop, all positioned relative to the command-core campaign:
+
+1. **#1692** — unify the duplicated embedding-reuse chains (pipeline vs watch/reindex). Standalone, any time.
+2. **#1693** — HNSW/GPU test concurrency policy + `test_loaded_index_lifecycle` containment (promote to immediate on next flake; `safety.rs` location means root-cause before trusting the flake explanation).
+3. **#1690** — posture/output-format matrix consolidation (after campaign phase 4 — same surface; subsumes the CQ-V1.40-5/6 and TC-ADV-V1.40-1 queue entries above).
+4. **#1691** — split big-with-logic monoliths with fixture-refresh discipline (after campaign phases 2-3 to avoid diff churn).
+
 ### Still deferred (unchanged decision)
 
 - **DS-V1.40-7**: partially mitigated (CLI clamps to [-1,1], rejects NaN/Inf) but `--sentiment 0.7` still accepted — no discrete-value CHECK. Stays deferred per the v1.41.0 rationale.

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -1882,7 +1882,7 @@ mentions = ["src/hnsw/persist.rs"]
 
 [[note]]
 sentiment = -1.0
-text = "Daemon CLI client has no socket read timeout: a request racing a daemon restart blocks forever (cli_envelope_test hung 40min when cqs-watch restarted mid-suite). Also: never restart cqs-watch while a test suite runs — tests leak to the live daemon socket when CQS_NO_DAEMON unset."
+text = "I restarted cqs-watch while a test suite was running and hung cli_envelope_test for 40min — operator error first: never bounce the daemon mid-suite. The hang exposed two real defects underneath: the daemon CLI client has no socket read timeout (a request racing a restart blocks forever), and tests leak to the live daemon socket when CQS_NO_DAEMON is unset (missing test isolation)."
 mentions = [
     "src/cli/watch/socket.rs",
     "src/daemon_translate.rs",

--- a/docs/plans/2026-06-10-command-core-unification.md
+++ b/docs/plans/2026-06-10-command-core-unification.md
@@ -60,10 +60,53 @@ Order: callers, callees (same file), deps, test_map, trace, impact (hardest: con
 - Gate: targeted graph + handler + kind tests green; CHANGELOG entry added. Full-suite + `cqs eval` fixture-sensitivity check deferred to the orchestrator's post-collection run (cores produce byte-stable JSON; no retrieval path touched).
 
 ### Phase 2 — search/io commands
-- [ ] Request-scoped config pattern: fold the BFS-ceiling env caps (`CQS_TRACE_MAX_NODES`, `CQS_TEST_MAP_MAX_NODES`) into Args/ctx so the core-purity invariant (no env reads) becomes literally true for the Phase 1 cores too (search/query, read, context, gather, scout, onboard, brief, notes, diff, blame, drift, reconstruct)
-- [ ] Cores + typed outputs (unblocks the `TODO(json-schema)` in query.rs — requires display module typed structs; do display first)
-- [ ] `display_unified_results_json` replaced by `SearchOutput` struct
-- Gate: same as Phase 1 + eval guard (search path touched — paired test+dev eval, both within noise).
+
+**Split into 2a (search — eval-sensitive) and 2b (io commands).**
+
+#### Phase 2a — search (done)
+- [x] Request-scoped config pattern established: the BFS-ceiling env caps
+  (`CQS_TRACE_MAX_NODES`, `CQS_TEST_MAP_MAX_NODES`) are folded into
+  `TraceArgs::max_nodes` / `TestMapArgs::max_nodes`, resolved once at each
+  adapter boundary (CLI + daemon) via the now-`pub(crate)` `trace_max_nodes`
+  / `test_map_max_nodes` helpers. The Phase-1 graph cores no longer read env;
+  `bfs_shortest_path` / `build_test_map` take `max_nodes` as a parameter.
+  Search's own `CQS_FORCE_BASE_INDEX` is folded into `QueryArgs::force_base_index`
+  the same way.
+- [x] Display module typed structs: `SearchResultOutput` (per-result; delegates
+  the chunk base + posture-gated trust fields to the store serializer) +
+  `SearchOutput` (envelope: `results`/`query`/`total` + optional
+  `token_count`/`token_budget`/`source`). Both CLI search-JSON paths
+  (`display_unified_results_json`, `display_tagged_results_json`) build them;
+  the `TODO(json-schema)` in query.rs is unblocked. Wire shape byte-stable.
+- [x] `query_core(ctx, &QueryArgs) -> Result<QueryOutput>` extracted in-place
+  for the plain (non-`--ref`, non-`--include-refs`) project path + the non-ref
+  name-only path, incl. audit-mode and NameOnly-FTS-first. `QueryArgs` derives
+  `Deserialize` (MCP param surface) with doc-commented fields. `cmd_query` is
+  the CLI adapter (render + `NoResults` exit). The `--ref` / `--include-refs` /
+  ref-name-only sub-paths stay in the adapter, marked `TODO(phase-2b)`, because
+  they emit the tagged-result shape rather than the core's `UnifiedResult`
+  model. The daemon `dispatch_search` keeps its own `ChunkOutput` wire shape
+  and distinct retrieval semantics; a CLI-vs-daemon parity test pins the shared
+  name-only retrieval primitive. Full daemon→`query_core` unification is
+  `TODO(phase-2b)` (needs a shared search-context trait spanning
+  `CommandContext` + `BatchView`).
+- Gate: build + targeted tests + clippy + fmt clean. Retrieval semantics
+  provably untouched (eval's `runner.rs` is byte-identical; the shared
+  primitives `search_hybrid`/`search_code_results`/`classify_query` are
+  unchanged). Observed eval movement is confined to two rank-20-cliff queries
+  whose position is decided by `codegen-units=1` FP coalescing, NOT logic —
+  confirmed because a graph-only subset of this change (which cannot reach the
+  eval path) reproduces the identical shift.
+
+#### Phase 2b — io commands (not started)
+- [ ] Cores + typed outputs for the io commands (read, context, gather, scout,
+  onboard, brief, notes, diff, blame, drift, reconstruct).
+- [ ] `--ref` / `--include-refs` / ref-name-only search sub-paths adopt the
+  shared output model (lift them out of the `cmd_query` adapter).
+- [ ] Daemon `dispatch_search` → `query_core` via a shared search-context trait.
+- Gate: same as Phase 1 + eval guard — amended 2026-06-10: byte-exact eval match is unachievable under codegen-units=1 (any code change re-coalesces FP ops and can flip rank-boundary ties; proven via graph-only-subset A/B in phase 2a). The enforceable invariant: (a) eval-reachable source (search/store/pipeline/splade/hnsw/embedder/eval) byte-identical in the diff, AND (b) paired test+dev numbers within the clean-HEAD rebuild variance band.
+
+**2b friction note (from 2a review):** the daemon search path projects per-result JSON through `ChunkOutput` while the CLI now projects through `SearchResultOutput`/`to_json_with_origin` — two different schemas, not just two call sites. 2b's shared-context-trait work must reconcile the schema, not only the dispatch. The graph commands had already converged on one schema before coring; search has not.
 
 ### Phase 3 — infra/index commands (index, gc, stats, doctor, status, slot, cache, model, reference, hook, telemetry, audit-mode, init, ping, watch-adjacent)
 - [ ] Cores + typed outputs; daemon adapters

--- a/docs/plans/2026-06-10-command-core-unification.md
+++ b/docs/plans/2026-06-10-command-core-unification.md
@@ -74,6 +74,10 @@ Order: callers, callees (same file), deps, test_map, trace, impact (hardest: con
 - [ ] Final: grep for `dispatch_.*{` bodies >20 lines (should be none); grep inline `serde_json::json!({` in command code (should be near-zero outside adapters)
 - Gate: full suite, eval paired check, `cqs health` no new dead code, CHANGELOG.
 
+### Post-campaign — docs truth sweep
+- [ ] Run `/docs-review` across README, CONTRIBUTING, SECURITY, PRIVACY, lib.rs docs, Cargo.toml metadata, and the GitHub repo description — hunting "tiny lies" (claims the campaign made stale: command behavior, JSON shapes, env knobs incl. the #1690 CQS_ULTRASECURITY deletion) and legacy references (removed helpers, old dispatch names, pre-core architecture descriptions in CONTRIBUTING's Architecture Overview)
+- [ ] Fix drift in one docs PR; docs-lying-is-P1 severity applies
+
 ## Invariants for every phase
 
 1. One PR per phase (or per command-group within a phase if a phase grows); main protected, CI green before merge.

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -270,8 +270,14 @@ pub(in crate::cli::batch) fn dispatch_test_map(
         let summaries: Vec<cqs::store::ChunkSummary> =
             test_chunks.iter().map(|tc| tc.chunk.clone()).collect();
 
-        let mut matches =
-            crate::cli::commands::build_test_map(name, &graph, &summaries, &ctx.root, max_depth);
+        let mut matches = crate::cli::commands::build_test_map(
+            name,
+            &graph,
+            &summaries,
+            &ctx.root,
+            max_depth,
+            crate::cli::commands::test_map_max_nodes(),
+        );
         matches.truncate(limit);
         let output = crate::cli::commands::build_test_map_output(name, &matches);
         return Ok(serde_json::to_value(&output)?);
@@ -286,6 +292,8 @@ pub(in crate::cli::batch) fn dispatch_test_map(
         name: name.to_string(),
         max_depth,
         limit: args.limit_arg.limit,
+        // Resolve the env ceiling once at this (daemon) adapter boundary.
+        max_nodes: crate::cli::commands::test_map_max_nodes(),
     };
     let output = test_map_core(&ctx.store(), &graph, &test_chunks, &ctx.root, &core_args)?;
     Ok(serde_json::to_value(&output)?)
@@ -340,6 +348,8 @@ pub(in crate::cli::batch) fn dispatch_trace(
         source: source.to_string(),
         target: target.to_string(),
         max_depth,
+        // Resolve the env ceiling once at this (daemon) adapter boundary.
+        max_nodes: crate::cli::commands::trace_max_nodes(),
     };
     let output = trace_core(&ctx.store(), &graph, &ctx.root, &core_args)?;
     Ok(serde_json::to_value(&output)?)
@@ -748,6 +758,7 @@ mod tests {
                         name: name.into(),
                         max_depth: 5,
                         limit: 5,
+                        max_nodes: crate::cli::commands::test_map_max_nodes(),
                     },
                 )
                 .expect("test_map_core"),
@@ -782,6 +793,7 @@ mod tests {
                         source: source.into(),
                         target: target.into(),
                         max_depth: 10,
+                        max_nodes: crate::cli::commands::trace_max_nodes(),
                     },
                 )
                 .expect("trace_core"),

--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -23,6 +23,10 @@ use crate::cli::args::SearchArgs;
 /// * Query embedding fails
 /// * The language parameter is invalid
 /// * Store operations fail
+// TODO(phase-2b): route through search::query::query_core via a shared
+// context trait (CommandContext vs BatchView), and reconcile the per-result
+// schema divergence — this path emits ChunkOutput while the CLI emits the
+// typed SearchResultOutput / to_json_with_origin shape.
 pub(in crate::cli::batch) fn dispatch_search(
     ctx: &BatchView,
     args: &SearchArgs,
@@ -861,5 +865,72 @@ mod tests {
             msg.contains("bogusbogus"),
             "Error must surface the offending input, got: {msg}"
         );
+    }
+
+    /// CLI-vs-daemon parity for the name-only search path (Phase 2a).
+    ///
+    /// The CLI core (`query_core`, name-only branch) and the daemon
+    /// (`dispatch_search`, name-only branch) both retrieve via the same
+    /// `store.search_by_name` primitive. This test pins that contract: the
+    /// chunk names + scores the daemon emits match exactly what the shared
+    /// primitive returns (which is what the CLI core wraps into
+    /// `UnifiedResult`). A future edit that gave one surface a different
+    /// name-only retrieval (a sort tweak, a different clamp) would break here.
+    ///
+    /// Name-only is the cheap parity surface: it skips the embedder entirely,
+    /// so the test runs in well under a second without the ONNX stack.
+    #[test]
+    fn parity_name_only_daemon_matches_shared_primitive() {
+        let (_dir, ctx) = ctx_with_chunks(vec![
+            make_chunk(
+                "src/lib.rs:1:ffff0001",
+                "src/lib.rs",
+                Language::Rust,
+                ChunkType::Function,
+                "parse_config",
+                "fn parse_config() -> Config",
+                "fn parse_config() -> Config { Config::default() }",
+            ),
+            make_chunk(
+                "src/lib.rs:7:ffff0002",
+                "src/lib.rs",
+                Language::Rust,
+                ChunkType::Function,
+                "do_parse_config",
+                "fn do_parse_config()",
+                "fn do_parse_config() { parse_config(); }",
+            ),
+        ]);
+        let view = ctx.build_view(None);
+
+        // The shared retrieval primitive both surfaces call for name-only.
+        let limit = 5usize;
+        let primitive = view.store().search_by_name("parse", limit).unwrap();
+
+        // Daemon name-only path.
+        let args = parse_search_args(&["parse", "--name-only"]);
+        let daemon = dispatch_search(&view, &args).expect("dispatch_search");
+        let daemon_results = daemon["results"].as_array().expect("results array");
+
+        // Same count and same ordered (name, score) pairs — the daemon JSON is
+        // a thin projection of the primitive, identical to what the CLI core
+        // wraps into UnifiedResult.
+        assert_eq!(
+            daemon_results.len(),
+            primitive.len(),
+            "daemon and shared primitive must return the same number of name-only hits"
+        );
+        for (i, sr) in primitive.iter().enumerate() {
+            assert_eq!(
+                daemon_results[i]["name"], sr.chunk.name,
+                "name mismatch at rank {i}"
+            );
+            let dscore = daemon_results[i]["score"].as_f64().unwrap() as f32;
+            assert!(
+                (dscore - sr.score).abs() < 1e-6,
+                "score mismatch at rank {i}: daemon={dscore} primitive={}",
+                sr.score
+            );
+        }
     }
 }

--- a/src/cli/commands/graph/mod.rs
+++ b/src/cli/commands/graph/mod.rs
@@ -18,10 +18,10 @@ pub(crate) use explain::cmd_explain;
 pub(crate) use impact::{cmd_impact, impact_core, ImpactArgs as ImpactCoreArgs};
 pub(crate) use impact_diff::cmd_impact_diff;
 pub(crate) use test_map::{
-    build_test_map, build_test_map_output, cmd_test_map, test_map_core,
+    build_test_map, build_test_map_output, cmd_test_map, test_map_core, test_map_max_nodes,
     TestMapArgs as TestMapCoreArgs,
 };
-pub(crate) use trace::{cmd_trace, trace_core, TraceArgs as TraceCoreArgs};
+pub(crate) use trace::{cmd_trace, trace_core, trace_max_nodes, TraceArgs as TraceCoreArgs};
 
 use cqs::kind::{detect_kind_for_store, Kind};
 use cqs::store::{ChunkSummary, ReadOnly, Store, StoreError};

--- a/src/cli/commands/graph/test_map.rs
+++ b/src/cli/commands/graph/test_map.rs
@@ -34,6 +34,12 @@ pub(crate) struct TestMapArgs {
     pub max_depth: usize,
     /// Cap on test matches returned (clamped 1..=100 inside the core).
     pub limit: usize,
+    /// Reverse-BFS visited-node ceiling (OOM guard on dense graphs). Resolved
+    /// once at the adapter boundary from `CQS_TEST_MAP_MAX_NODES` (default
+    /// 10,000) via [`test_map_max_nodes`]; the core never reads the env.
+    /// `#[serde(default)]` so a wire caller that omits it gets the default.
+    #[serde(default = "test_map_max_nodes")]
+    pub max_nodes: usize,
 }
 
 // ─── Shared data structures ─────────────────────────────────────────────────
@@ -82,7 +88,11 @@ pub(crate) enum TestMapCoreOutput {
 const DEFAULT_TEST_MAP_MAX_NODES: usize = 10_000;
 
 /// Returns the test-map BFS node cap, reading `CQS_TEST_MAP_MAX_NODES` once on first call.
-fn test_map_max_nodes() -> usize {
+///
+/// Resolved at the adapter boundary (CLI `cmd_test_map`, daemon
+/// `dispatch_test_map`) and threaded into [`TestMapArgs::max_nodes`] so the
+/// core stays env-free. Also serves as the `#[serde(default)]` for `max_nodes`.
+pub(crate) fn test_map_max_nodes() -> usize {
     use std::sync::OnceLock;
     static CAP: OnceLock<usize> = OnceLock::new();
     *CAP.get_or_init(|| match std::env::var("CQS_TEST_MAP_MAX_NODES") {
@@ -119,9 +129,9 @@ pub(crate) fn build_test_map(
     test_chunks: &[ChunkSummary],
     root: &Path,
     max_depth: usize,
+    max_nodes: usize,
 ) -> Vec<TestMatch> {
-    let _span = tracing::info_span!("build_test_map", target_name, max_depth).entered();
-    let max_nodes = test_map_max_nodes();
+    let _span = tracing::info_span!("build_test_map", target_name, max_depth, max_nodes).entered();
 
     // Reverse BFS from target.
     // Keys + parent-pointers are `Arc<str>` so the BFS reuses the
@@ -260,7 +270,14 @@ pub(crate) fn test_map_core(
     let resolved = resolve_target(store, &args.name)?;
     let target_name = resolved.chunk.name.clone();
 
-    let mut matches = build_test_map(&target_name, graph, test_chunks, root, args.max_depth);
+    let mut matches = build_test_map(
+        &target_name,
+        graph,
+        test_chunks,
+        root,
+        args.max_depth,
+        args.max_nodes,
+    );
     matches.truncate(limit);
     Ok(TestMapCoreOutput::Tests(build_test_map_output(
         &target_name,
@@ -292,7 +309,14 @@ pub(crate) fn cmd_test_map(
         let summaries: Vec<cqs::store::ChunkSummary> =
             test_chunks.iter().map(|tc| tc.chunk.clone()).collect();
 
-        let mut matches = build_test_map(name, &graph, &summaries, &ctx.root, max_depth);
+        let mut matches = build_test_map(
+            name,
+            &graph,
+            &summaries,
+            &ctx.root,
+            max_depth,
+            test_map_max_nodes(),
+        );
         matches.truncate(limit);
 
         if json {
@@ -334,6 +358,8 @@ pub(crate) fn cmd_test_map(
         name: name.to_string(),
         max_depth,
         limit,
+        // Resolve the env ceiling once here, at the adapter boundary.
+        max_nodes: test_map_max_nodes(),
     };
     match test_map_core(store, &graph, &test_chunks, root, &args)? {
         TestMapCoreOutput::Fallback(fb) => {

--- a/src/cli/commands/graph/trace.rs
+++ b/src/cli/commands/graph/trace.rs
@@ -35,6 +35,12 @@ pub(crate) struct TraceArgs {
     pub target: String,
     /// Max search depth — "give up after N hops."
     pub max_depth: usize,
+    /// BFS visited-node ceiling (OOM guard on dense graphs). Resolved once at
+    /// the adapter boundary from `CQS_TRACE_MAX_NODES` (default 10,000) via
+    /// [`trace_max_nodes`]; the core never reads the env itself. `#[serde(default)]`
+    /// so an MCP/wire caller that omits it falls back to the default ceiling.
+    #[serde(default = "trace_max_nodes")]
+    pub max_nodes: usize,
 }
 
 // ─── Output types ──────────────────────────────────────────────────────────
@@ -199,7 +205,13 @@ pub(crate) fn trace_core(
         return Ok(TraceCoreOutput::Trace(output));
     }
 
-    let path = bfs_shortest_path(&graph.forward, &source_name, &target_name, args.max_depth);
+    let path = bfs_shortest_path(
+        &graph.forward,
+        &source_name,
+        &target_name,
+        args.max_depth,
+        args.max_nodes,
+    );
     let output = build_trace_output(store, &source_name, &target_name, path.as_deref(), root)?;
     Ok(TraceCoreOutput::Trace(output))
 }
@@ -322,6 +334,9 @@ pub(crate) fn cmd_trace(
         source: source.to_string(),
         target: target.to_string(),
         max_depth,
+        // Resolve the env ceiling once here, at the adapter boundary, so the
+        // core receives a value instead of reading the process env.
+        max_nodes: trace_max_nodes(),
     };
     match trace_core(store, &graph, root, &args)? {
         TraceCoreOutput::Fallback(fb) => match format {
@@ -477,7 +492,11 @@ fn mermaid_escape(s: &str) -> String {
 const DEFAULT_TRACE_MAX_NODES: usize = 10_000;
 
 /// Returns the trace BFS node cap, reading `CQS_TRACE_MAX_NODES` once on first call.
-fn trace_max_nodes() -> usize {
+///
+/// Resolved at the adapter boundary (CLI `cmd_trace`, daemon `dispatch_trace`)
+/// and threaded into [`TraceArgs::max_nodes`] so the core stays env-free. Also
+/// serves as the `#[serde(default)]` for `max_nodes` when a wire caller omits it.
+pub(crate) fn trace_max_nodes() -> usize {
     use std::sync::OnceLock;
     static CAP: OnceLock<usize> = OnceLock::new();
     *CAP.get_or_init(|| match std::env::var("CQS_TRACE_MAX_NODES") {
@@ -518,8 +537,8 @@ pub(crate) fn bfs_shortest_path(
     source: &str,
     target: &str,
     max_depth: usize,
+    max_nodes: usize,
 ) -> Option<Vec<String>> {
-    let max_nodes = trace_max_nodes();
     let mut visited: HashMap<String, Option<String>> = HashMap::new();
     let mut queue: VecDeque<(String, usize)> = VecDeque::new();
 
@@ -615,7 +634,7 @@ mod tests {
         let mut forward = HashMap::new();
         forward.insert("A".to_string(), vec!["B".to_string()]);
         let forward = arc_map(forward);
-        let result = bfs_shortest_path(&forward, "A", "B", 10);
+        let result = bfs_shortest_path(&forward, "A", "B", 10, 10_000);
         assert!(result.is_some());
         let path = result.unwrap();
         assert_eq!(path, vec!["A", "B"]);
@@ -626,7 +645,7 @@ mod tests {
         let mut forward = HashMap::new();
         forward.insert("A".to_string(), vec!["B".to_string()]);
         let forward = arc_map(forward);
-        let result = bfs_shortest_path(&forward, "A", "C", 10);
+        let result = bfs_shortest_path(&forward, "A", "C", 10, 10_000);
         assert!(result.is_none(), "No path from A to C");
     }
 
@@ -638,7 +657,7 @@ mod tests {
         forward.insert("C".to_string(), vec!["D".to_string()]);
         let forward = arc_map(forward);
         // Path A->B->C->D exists but depth=2 should not reach D
-        let result = bfs_shortest_path(&forward, "A", "D", 2);
+        let result = bfs_shortest_path(&forward, "A", "D", 2, 10_000);
         assert!(result.is_none(), "Should not find path beyond max_depth=2");
     }
 
@@ -648,7 +667,7 @@ mod tests {
         forward.insert("A".to_string(), vec!["B".to_string()]);
         forward.insert("B".to_string(), vec!["C".to_string()]);
         let forward = arc_map(forward);
-        let result = bfs_shortest_path(&forward, "A", "C", 10);
+        let result = bfs_shortest_path(&forward, "A", "C", 10, 10_000);
         assert!(result.is_some());
         let path = result.unwrap();
         assert_eq!(path, vec!["A", "B", "C"]);
@@ -667,7 +686,7 @@ mod tests {
         forward.insert("A".to_string(), vec!["".to_string()]);
         forward.insert("".to_string(), vec!["Z".to_string()]);
         let forward = arc_map(forward);
-        let result = bfs_shortest_path(&forward, "A", "Z", 10);
+        let result = bfs_shortest_path(&forward, "A", "Z", 10, 10_000);
         assert!(
             result.is_some(),
             "BFS through anonymous mid-chain node must find Z"

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -74,8 +74,9 @@ pub(crate) use graph::cmd_trace;
 // `serde_json::to_value` / `to_value()` without being named at the call
 // site, so they stay internal to the graph module.
 pub(crate) use graph::{
-    callees_core, callers_core, deps_core, impact_core, test_map_core, trace_core, CalleesArgs,
-    CallersCoreArgs, DepsCoreArgs, ImpactCoreArgs, TestMapCoreArgs, TraceCoreArgs,
+    callees_core, callers_core, deps_core, impact_core, test_map_core, test_map_max_nodes,
+    trace_core, trace_max_nodes, CalleesArgs, CallersCoreArgs, DepsCoreArgs, ImpactCoreArgs,
+    TestMapCoreArgs, TraceCoreArgs,
 };
 
 // -- review --

--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -2,9 +2,17 @@
 //!
 //! Executes semantic search queries.
 //!
-//! TODO(json-schema): Extract typed QueryOutput struct. Depends on display module
-//! refactoring — search results use display::display_unified_results_json which
-//! builds JSON inline. Blocked until display module has typed output structs.
+//! ## Command-core split (Phase 2a)
+//!
+//! [`query_core`] owns the surface-agnostic search logic for the project and
+//! name-only paths: routing/classification, embedding, search invocation, and
+//! assembly into the typed [`QueryOutput`]. It never prints, never reads env
+//! posture, and never branches on its surface — the CLI adapter [`cmd_query`]
+//! renders the result (text or JSON via the [`crate::cli::display`] typed
+//! structs) and owns the `NoResults` exit code. The `--ref`-scoped and
+//! `--include-refs` paths stay in the adapter for now (see the
+//! `TODO(phase-2b)` markers) because their reference-index resolution and
+//! tagged-result shape don't yet share the core's `UnifiedResult` model.
 
 use std::collections::HashMap;
 
@@ -15,6 +23,148 @@ use cqs::store::{ParentContext, UnifiedResult};
 use cqs::{reference, Embedder, Embedding, Pattern, SearchFilter, Store};
 
 use crate::cli::{display, signal, staleness, Cli};
+
+// ─── Args (surface-agnostic, MCP-ready) ────────────────────────────────────
+
+/// Input for [`query_core`]: the full search-knob surface both the CLI and a
+/// future MCP `search` tool deserialize into. Every field a search consumer
+/// can set lives here; the core reads only these, never the process env or a
+/// CLI struct.
+///
+/// `#[serde(default)]` on the whole struct so a wire/MCP caller can supply just
+/// `query` and inherit the production defaults for the rest.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(default)]
+pub(crate) struct QueryArgs {
+    /// Search query (quote multi-word queries).
+    pub query: String,
+    /// Max results to return.
+    pub limit: usize,
+    /// Definition search: match by function/struct name only, skip embedding.
+    pub name_only: bool,
+    /// Filter results to this language (e.g. `rust`, `python`).
+    pub lang: Option<String>,
+    /// Restrict results to these chunk types (e.g. `function`, `struct`).
+    pub include_type: Option<Vec<String>>,
+    /// Exclude these chunk types from results.
+    pub exclude_type: Option<Vec<String>>,
+    /// Glob path filter.
+    pub path: Option<String>,
+    /// Structural pattern filter (builder, async, unsafe, …).
+    pub pattern: Option<String>,
+    /// Include documentation / markdown / config chunks (default: code only).
+    pub include_docs: bool,
+    /// Enable RRF hybrid (keyword + semantic) fusion.
+    pub rrf: bool,
+    /// `true` when a cross-encoder reranker stage is requested.
+    pub rerank: bool,
+    /// Force SPLADE on even for Unknown-category queries.
+    pub splade: bool,
+    /// Constant SPLADE fusion weight (None = per-category router).
+    pub splade_alpha: Option<f32>,
+    /// Minimum similarity threshold.
+    pub threshold: f32,
+    /// Name-match weight in hybrid scoring (0.0–1.0).
+    pub name_boost: f32,
+    /// Disable test/underscore-prefix demotion.
+    pub no_demote: bool,
+    /// Token budget — packs the highest-scoring results into the budget.
+    pub tokens: Option<usize>,
+    /// Expand results with parent type/module context (small-to-big).
+    pub expand_parent: bool,
+    /// Force the non-enriched base HNSW. Resolved once at the adapter boundary
+    /// from `CQS_FORCE_BASE_INDEX` so the core stays env-free.
+    pub force_base_index: bool,
+    /// Per-result JSON overhead the token-budget packer adds when estimating
+    /// how many results fit the `tokens` budget. The CLI resolves this from
+    /// its output format (the per-result envelope cost under `--json`, 0 for
+    /// text) so packing picks the same survivors as before the core split.
+    /// A wire/MCP caller that always serializes should set the per-result
+    /// overhead constant; the `#[serde(default)]` value is 0.
+    pub json_overhead: usize,
+}
+
+impl Default for QueryArgs {
+    fn default() -> Self {
+        // Mirrors the clap defaults on `Cli` / `SearchArgs` so a wire caller
+        // omitting a field gets the same value the CLI would.
+        QueryArgs {
+            query: String::new(),
+            limit: 5,
+            name_only: false,
+            lang: None,
+            include_type: None,
+            exclude_type: None,
+            path: None,
+            pattern: None,
+            include_docs: false,
+            rrf: false,
+            rerank: false,
+            splade: false,
+            splade_alpha: None,
+            threshold: 0.3,
+            name_boost: 0.2,
+            no_demote: false,
+            tokens: None,
+            expand_parent: false,
+            force_base_index: false,
+            json_overhead: 0,
+        }
+    }
+}
+
+impl QueryArgs {
+    /// Build `QueryArgs` from the top-level CLI struct, resolving the
+    /// `CQS_FORCE_BASE_INDEX` env override and the format-dependent JSON
+    /// overhead once here at the adapter boundary.
+    fn from_cli(cli: &Cli) -> Self {
+        QueryArgs {
+            query: cli.query.clone().unwrap_or_default(),
+            limit: cli.limit,
+            name_only: cli.name_only,
+            lang: cli.lang.clone(),
+            include_type: cli.include_type.clone(),
+            exclude_type: cli.exclude_type.clone(),
+            path: cli.path.clone(),
+            pattern: cli.pattern.clone(),
+            include_docs: cli.include_docs,
+            rrf: cli.rrf,
+            rerank: cli.rerank_active(),
+            splade: cli.splade,
+            splade_alpha: cli.splade_alpha,
+            threshold: cli.threshold,
+            name_boost: cli.name_boost,
+            no_demote: cli.no_demote,
+            tokens: cli.tokens,
+            expand_parent: cli.expand_parent,
+            force_base_index: std::env::var("CQS_FORCE_BASE_INDEX").as_deref() == Ok("1"),
+            json_overhead: if cli.json {
+                crate::cli::commands::JSON_OVERHEAD_PER_RESULT
+            } else {
+                0
+            },
+        }
+    }
+}
+
+// ─── Output (the typed result the adapters render) ─────────────────────────
+
+/// Surface-agnostic result of [`query_core`] for the project + name-only
+/// paths. Carries the assembled results plus everything the adapter needs to
+/// render text or JSON without re-running retrieval: the resolved parent
+/// context and the token-budget accounting. Empty `results` is a valid output
+/// (the adapter maps it to the `NoResults` exit code).
+pub(crate) struct QueryOutput {
+    /// The original query string (echoed into the JSON envelope).
+    pub query: String,
+    /// Assembled, ranked, token-packed results.
+    pub results: Vec<UnifiedResult>,
+    /// Resolved parent context keyed by chunk id (empty unless
+    /// `expand_parent`).
+    pub parents: HashMap<String, ParentContext>,
+    /// `(used, budget)` when `--tokens` packed the results.
+    pub token_info: Option<(usize, usize)>,
+}
 
 /// Compute JSON overhead for token budgeting based on output format.
 fn json_overhead_for(cli: &Cli) -> usize {
@@ -42,6 +192,398 @@ fn emit_empty_results(query: &str, json: bool, context: Option<&str>) -> ! {
     std::process::exit(signal::ExitCode::NoResults as i32);
 }
 
+// ─── Core ───────────────────────────────────────────────────────────────────
+
+/// Surface-agnostic core for the plain (non-`--ref`, non-`--include-refs`)
+/// search path and the non-ref name-only path.
+///
+/// Owns routing/classification, embedding, the search invocation, and
+/// assembly into [`QueryOutput`] (pattern filter, rerank, token-budget
+/// packing, parent-context resolution). Returns an empty `results` vec rather
+/// than printing or exiting — the adapter maps empty to the `NoResults` exit
+/// code. Reads no env: the base-index override arrives via
+/// [`QueryArgs::force_base_index`].
+pub(crate) fn query_core(
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
+    args: &QueryArgs,
+) -> Result<QueryOutput> {
+    let query = args.query.as_str();
+    let _span = tracing::info_span!("query_core", query_len = query.len()).entered();
+
+    let store = &ctx.store;
+    let cqs_dir = &ctx.cqs_dir;
+
+    // Name-only path: FTS by name, skip embedding entirely.
+    if args.name_only {
+        let results = store
+            .search_by_name(query, args.limit)
+            .context("Failed to search by name")?;
+        let unified: Vec<UnifiedResult> = results.into_iter().map(UnifiedResult::Code).collect();
+        return assemble_output(ctx, args, unified);
+    }
+
+    // Adaptive routing: classify query BEFORE embedding to potentially skip it.
+    // --splade is NOT a routing override (it only controls SPLADE fusion);
+    // --rrf/--rerank override the search strategy. (--ref never reaches the
+    // core.)
+    let has_explicit_flags = args.rrf || args.rerank;
+    let classification = if !has_explicit_flags {
+        let c = cqs::search::router::classify_query(query);
+        tracing::info!(
+            category = %c.category,
+            confidence = %c.confidence,
+            strategy = %c.strategy,
+            "Query classified"
+        );
+        Some(c)
+    } else {
+        tracing::debug!("Explicit flags set, skipping adaptive routing");
+        None
+    };
+
+    // NameOnly strategy: try FTS5 first, fall back to dense on 0 results.
+    if let Some(ref c) = classification {
+        if c.strategy == cqs::search::router::SearchStrategy::NameOnly {
+            let results = store.search_by_name(query, args.limit)?;
+            if !results.is_empty() {
+                tracing::info!(results = results.len(), "NameOnly search succeeded");
+                crate::cli::telemetry::log_routed(
+                    cqs_dir,
+                    query,
+                    &c.category.to_string(),
+                    &c.confidence.to_string(),
+                    &c.strategy.to_string(),
+                    false,
+                    Some(results.len()),
+                );
+                let unified: Vec<UnifiedResult> =
+                    results.into_iter().map(UnifiedResult::Code).collect();
+                return assemble_output(ctx, args, unified);
+            }
+            tracing::info!("NameOnly returned 0 results, falling back to dense");
+            crate::cli::telemetry::log_routed(
+                cqs_dir,
+                query,
+                &c.category.to_string(),
+                &c.confidence.to_string(),
+                &c.strategy.to_string(),
+                true, // fallback triggered
+                None,
+            );
+        }
+    }
+
+    // Over-retrieve when reranking to give the cross-encoder more candidates.
+    let effective_limit = if args.rerank {
+        crate::cli::limits::rerank_pool_size(args.limit)
+    } else {
+        args.limit
+    };
+
+    let embedder = ctx.embedder()?;
+    let query_embedding = embedder.embed_query(query)?;
+
+    // Centroid reclassification + α-floor tracking.
+    let pre_centroid_cat = classification.as_ref().map(|c| c.category);
+    let classification = classification
+        .map(|c| cqs::search::router::reclassify_with_centroid(c, query_embedding.as_slice()));
+    let centroid_applied = classification.as_ref().map(|c| c.category) != pre_centroid_cat;
+
+    let languages = match &args.lang {
+        Some(l) => Some(vec![l.parse().context(format!(
+            "Invalid language. Valid: {}",
+            cqs::parser::Language::valid_names_display()
+        ))?]),
+        None => None,
+    };
+
+    let include_types = match &args.include_type {
+        Some(types) => {
+            let parsed: Result<Vec<ChunkType>, _> = types.iter().map(|t| t.parse()).collect();
+            Some(parsed.with_context(|| {
+                format!(
+                    "Invalid chunk type. Valid: {}",
+                    ChunkType::valid_names().join(", ")
+                )
+            })?)
+        }
+        None if args.include_docs => None, // --include-docs: search everything
+        None => {
+            // Default: search code only (callable types + type definitions).
+            Some(ChunkType::code_types())
+        }
+    };
+
+    let exclude_types = match &args.exclude_type {
+        Some(types) => {
+            let parsed: Result<Vec<ChunkType>, _> = types.iter().map(|t| t.parse()).collect();
+            Some(parsed.with_context(|| {
+                format!(
+                    "Invalid chunk type for --exclude-type. Valid: {}",
+                    ChunkType::valid_names().join(", ")
+                )
+            })?)
+        }
+        None => None,
+    };
+
+    // Type boost from adaptive routing (boost, not filter — won't exclude).
+    let type_boost_types = classification.as_ref().and_then(|c| c.type_hints.clone());
+
+    // Resolve SPLADE alpha: explicit α wins; else per-category router on a
+    // classified query; else `--splade` forces α=0.7; else SPLADE off. SPLADE
+    // stays on even at α=1.0 when a category classified — the α knob is the
+    // scoring weight, not the candidate-pool switch.
+    let (use_splade, mut splade_alpha) = match (args.splade_alpha, classification.as_ref()) {
+        (Some(alpha), _) => (true, alpha),
+        (None, Some(c)) => (true, cqs::search::router::resolve_splade_alpha(&c.category)),
+        (None, None) if args.splade => (true, 0.7),
+        (None, None) => (false, 1.0),
+    };
+    // Centroid α floor: a centroid-driven reclassification can't zero SPLADE.
+    if centroid_applied {
+        splade_alpha = splade_alpha.max(0.7);
+    }
+
+    let filter = {
+        let mut f = SearchFilter::default();
+        f.languages = languages;
+        f.include_types = include_types;
+        f.exclude_types = exclude_types;
+        f.path_pattern = args.path.clone();
+        f.name_boost = args.name_boost;
+        f.query_text = query.to_string();
+        f.enable_rrf = args.rrf;
+        f.enable_demotion = !args.no_demote;
+        f.enable_splade = use_splade;
+        f.splade_alpha = splade_alpha;
+        f.type_boost_types = type_boost_types;
+        f
+    };
+    filter.validate().map_err(|e| anyhow::anyhow!(e))?;
+
+    let reranker = if args.rerank {
+        Some(ctx.reranker()?)
+    } else {
+        None
+    };
+
+    // SPLADE sparse encoding (if enabled by --splade or per-category routing).
+    let splade_query = if use_splade {
+        ctx.splade_encoder().and_then(|enc| match enc.encode(query) {
+            Ok(sv) => Some(sv),
+            Err(e) => {
+                tracing::warn!(error = %e, "SPLADE query encoding failed, falling back to cosine-only");
+                None
+            }
+        })
+    } else {
+        None
+    };
+    let splade_index = if use_splade { ctx.splade_index() } else { None };
+
+    // Phase 5: when the classifier picked DenseBase (or the env override is
+    // resolved into args.force_base_index), try the base HNSW; fall back to
+    // enriched if it's absent/corrupt.
+    let use_base = matches!(
+        classification.as_ref().map(|c| c.strategy),
+        Some(cqs::search::router::SearchStrategy::DenseBase)
+    ) || args.force_base_index;
+    let mut base_fallback = false;
+    let index = if use_base {
+        match crate::cli::build_base_vector_index(store, cqs_dir)? {
+            Some(base_idx) => {
+                tracing::info!(
+                    basename = "index_base",
+                    "Router selected base HNSW for non-enriched query"
+                );
+                Some(base_idx)
+            }
+            None => {
+                tracing::info!(
+                    "Base HNSW unavailable — falling back to enriched index for DenseBase query"
+                );
+                base_fallback = true;
+                crate::cli::build_vector_index(store, cqs_dir)?
+            }
+        }
+    } else {
+        crate::cli::build_vector_index(store, cqs_dir)?
+    };
+
+    if use_base {
+        crate::cli::telemetry::log_routed(
+            cqs_dir,
+            query,
+            "routed_to_base",
+            "medium",
+            if base_fallback {
+                "dense_base_fallback_to_enriched"
+            } else {
+                "dense_base"
+            },
+            base_fallback,
+            None,
+        );
+    }
+
+    let audit_mode = cqs::audit::load_audit_state(cqs_dir);
+
+    let search_limit = if args.pattern.is_some() {
+        effective_limit * 3
+    } else {
+        effective_limit
+    };
+    let splade_arg = splade_index.zip(splade_query.as_ref());
+
+    // Audit mode and SPLADE both require the hybrid path (search_unified
+    // doesn't support SPLADE yet); only the plain dense path uses
+    // search_code_results.
+    let results = if audit_mode.is_active() || splade_arg.is_some() {
+        let code_results = store.search_hybrid(
+            &query_embedding,
+            &filter,
+            search_limit,
+            args.threshold,
+            index.as_deref(),
+            splade_arg,
+        )?;
+        code_results.into_iter().map(UnifiedResult::Code).collect()
+    } else {
+        store.search_code_results(
+            &query_embedding,
+            &filter,
+            search_limit,
+            args.threshold,
+            index.as_deref(),
+        )?
+    };
+
+    // Pattern filter.
+    let pattern: Option<Pattern> = args
+        .pattern
+        .as_ref()
+        .map(|p| p.parse())
+        .transpose()
+        .context("Invalid pattern")?;
+    let results = if let Some(ref pat) = pattern {
+        let mut filtered: Vec<UnifiedResult> = results
+            .into_iter()
+            .filter(|r| match r {
+                UnifiedResult::Code(sr) => {
+                    pat.matches(&sr.chunk.content, &sr.chunk.name, Some(sr.chunk.language))
+                }
+            })
+            .collect();
+        filtered.truncate(args.limit);
+        filtered
+    } else {
+        results
+    };
+
+    // Cross-encoder re-ranking.
+    let results = if let Some(reranker) = reranker.as_deref() {
+        rerank_unified(reranker, query, results, args.limit)?
+    } else {
+        results
+    };
+
+    assemble_output(ctx, args, results)
+}
+
+/// Final assembly shared by the core's name-only, NameOnly-FTS, and dense
+/// paths: token-budget packing + parent-context resolution. The input is
+/// already a ranked `Vec<UnifiedResult>`.
+fn assemble_output(
+    ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
+    args: &QueryArgs,
+    results: Vec<UnifiedResult>,
+) -> Result<QueryOutput> {
+    let store = &ctx.store;
+    let root = &ctx.root;
+
+    // Token-budget packing. The per-result JSON overhead is resolved by the
+    // adapter into `args.json_overhead` (the CLI's format-dependent estimate),
+    // so packing keeps the exact same survivors as before the core split.
+    let (results, token_info) = if let Some(budget) = args.tokens {
+        // Lazy embedder: the name-only path may not have built one yet.
+        let embedder = ctx.embedder()?;
+        crate::cli::commands::token_pack_results(
+            results,
+            budget,
+            args.json_overhead,
+            embedder,
+            unified_text,
+            unified_score,
+            "query_core",
+        )
+    } else {
+        (results, None)
+    };
+
+    let parents = if args.expand_parent {
+        resolve_parent_context(&results, store, root)
+    } else {
+        HashMap::new()
+    };
+
+    Ok(QueryOutput {
+        query: args.query.clone(),
+        results,
+        parents,
+        token_info,
+    })
+}
+
+/// Render a [`QueryOutput`] for the CLI: staleness warning, empty-result exit,
+/// and text/JSON emission via the typed display structs.
+fn render_query_output(
+    cli: &Cli,
+    root: &std::path::Path,
+    store: &Store<cqs::store::ReadOnly>,
+    output: QueryOutput,
+) -> Result<()> {
+    let QueryOutput {
+        query,
+        results,
+        parents,
+        token_info,
+    } = output;
+
+    // Staleness warning (surface I/O — adapter owns it).
+    if !cli.quiet && !cli.no_stale_check {
+        let origins: Vec<&str> = results
+            .iter()
+            .map(|r| {
+                let UnifiedResult::Code(sr) = r;
+                sr.chunk.file.to_str().unwrap_or("")
+            })
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        if !origins.is_empty() {
+            staleness::warn_stale_results(store, &origins, root);
+        }
+    }
+
+    if results.is_empty() {
+        emit_empty_results(&query, cli.json, None);
+    }
+
+    let parents_ref = if cli.expand_parent {
+        Some(&parents)
+    } else {
+        None
+    };
+
+    if cli.json {
+        display::display_unified_results_json(&results, &query, parents_ref, token_info)?;
+    } else {
+        display::display_unified_results(&results, root, cli.no_content, cli.context, parents_ref)?;
+    }
+    Ok(())
+}
+
 /// Execute a semantic search query and display results
 pub(crate) fn cmd_query(
     ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
@@ -65,15 +607,34 @@ pub(crate) fn cmd_query(
     let root = &ctx.root;
     let cqs_dir = &ctx.cqs_dir;
 
-    // Name-only mode: search by function/struct name, skip embedding entirely
+    // Name-only mode: search by function/struct name, skip embedding entirely.
     if cli.name_only {
         if cli.rerank_active() {
             bail!("--rerank requires embedding search, incompatible with --name-only");
         }
         if let Some(ref ref_name) = cli.ref_name {
+            // TODO(phase-2b): ref-name-only search resolves a reference index
+            // and emits the tagged-result shape — distinct from the core's
+            // `UnifiedResult` model. Stays in the adapter until the ref paths
+            // adopt the shared output type.
             return cmd_query_ref_name_only(cli, ref_name, query, root);
         }
-        return cmd_query_name_only(cli, store, query, root);
+        // Non-ref name-only routes through the shared core (which performs the
+        // FTS-by-name lookup + assembly). `--include-refs` is ignored on the
+        // name-only path, matching prior behavior.
+        let args = QueryArgs::from_cli(cli);
+        let output = query_core(ctx, &args)?;
+        return render_query_output(cli, root, store, output);
+    }
+
+    // Plain (non-ref, non-multi-index) search routes through the shared core.
+    // The `--ref`-scoped and `--include-refs` paths keep the adapter-local
+    // retrieval below (TODO(phase-2b)) because they emit the tagged-result
+    // shape rather than the core's `UnifiedResult` envelope.
+    if cli.ref_name.is_none() && !cli.include_refs {
+        let args = QueryArgs::from_cli(cli);
+        let output = query_core(ctx, &args)?;
+        return render_query_output(cli, root, store, output);
     }
 
     // Adaptive routing: classify query BEFORE embedding to potentially skip it
@@ -928,4 +1489,111 @@ fn resolve_parent_context<Mode>(
     }
 
     parents
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The MCP-readiness contract: a wire/tool caller can supply only `query`
+    /// and the rest fall back to the production defaults via `#[serde(default)]`.
+    #[test]
+    fn query_args_deserialize_minimal() {
+        let args: QueryArgs = serde_json::from_str(r#"{"query": "find me"}"#).unwrap();
+        assert_eq!(args.query, "find me");
+        assert_eq!(args.limit, 5, "limit default mirrors clap");
+        assert!((args.threshold - 0.3).abs() < 1e-6);
+        assert!((args.name_boost - 0.2).abs() < 1e-6);
+        assert!(!args.name_only);
+        assert!(!args.rerank);
+        assert!(args.tokens.is_none());
+        assert_eq!(args.json_overhead, 0);
+        assert!(!args.force_base_index);
+    }
+
+    /// Every field is wire-settable (the future MCP `search` tool's param
+    /// surface). A regression that dropped `#[serde(default)]` or renamed a
+    /// field would break deserialization here.
+    #[test]
+    fn query_args_deserialize_full() {
+        let json = r#"{
+            "query": "q",
+            "limit": 12,
+            "name_only": true,
+            "lang": "rust",
+            "include_type": ["function", "struct"],
+            "exclude_type": ["test"],
+            "path": "src/**",
+            "pattern": "async",
+            "include_docs": true,
+            "rrf": true,
+            "rerank": true,
+            "splade": true,
+            "splade_alpha": 0.5,
+            "threshold": 0.1,
+            "name_boost": 0.7,
+            "no_demote": true,
+            "tokens": 4000,
+            "expand_parent": true,
+            "force_base_index": true,
+            "json_overhead": 30
+        }"#;
+        let args: QueryArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.limit, 12);
+        assert!(args.name_only);
+        assert_eq!(args.lang.as_deref(), Some("rust"));
+        assert_eq!(
+            args.include_type.as_deref(),
+            Some(&["function".to_string(), "struct".to_string()][..])
+        );
+        assert_eq!(
+            args.exclude_type.as_deref(),
+            Some(&["test".to_string()][..])
+        );
+        assert_eq!(args.path.as_deref(), Some("src/**"));
+        assert_eq!(args.pattern.as_deref(), Some("async"));
+        assert!(args.include_docs);
+        assert!(args.rrf);
+        assert!(args.rerank);
+        assert!(args.splade);
+        assert_eq!(args.splade_alpha, Some(0.5));
+        assert_eq!(args.tokens, Some(4000));
+        assert!(args.expand_parent);
+        assert!(args.force_base_index);
+        assert_eq!(args.json_overhead, 30);
+    }
+
+    /// `QueryArgs::default` must match the clap defaults exactly — the wire
+    /// surface and the CLI surface have to agree on omitted-field behavior.
+    /// Parses a real minimal CLI invocation so a changed clap default breaks
+    /// this test instead of silently diverging from the wire default.
+    #[test]
+    fn query_args_default_matches_clap_defaults() {
+        use clap::Parser;
+        let cli = crate::cli::Cli::try_parse_from(["cqs", "q"]).unwrap();
+        let from_clap = QueryArgs::from_cli(&cli);
+        let expected = QueryArgs {
+            query: "q".to_string(),
+            ..QueryArgs::default()
+        };
+        assert_eq!(
+            from_clap, expected,
+            "clap defaults drifted from QueryArgs::default — update both together"
+        );
+    }
+
+    /// The `QueryOutput` envelope is a plain data carrier: an empty result set
+    /// is a valid output (the adapter, not the core, maps it to NoResults).
+    #[test]
+    fn query_output_allows_empty_results() {
+        let out = QueryOutput {
+            query: "nothing".to_string(),
+            results: Vec::new(),
+            parents: HashMap::new(),
+            token_info: None,
+        };
+        assert!(out.results.is_empty());
+        assert_eq!(out.query, "nothing");
+        assert!(out.token_info.is_none());
+    }
 }

--- a/src/cli/display.rs
+++ b/src/cli/display.rs
@@ -5,9 +5,115 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use colored::Colorize;
+use serde::Serialize;
 
 use cqs::reference::TaggedResult;
 use cqs::store::{ParentContext, UnifiedResult};
+
+/// One search result in the CLI search JSON, the typed schema source for the
+/// per-result shape emitted by `cqs <query> --json` (and `--name-only`,
+/// `--ref`, `--include-refs`).
+///
+/// The base chunk fields and the posture-gated / skip-when-default behavior
+/// (`has_parent`, `trust_level`, `injection_flags`, `reference_name`,
+/// `type: "code"`) are owned by `UnifiedResult::to_json_with_origin` in the
+/// store layer — the single serializer for a chunk's trust-aware wire shape.
+/// This struct layers the search-display-only fields on top:
+///   - `parent_*`: parent context emitted under `--expand-parent`.
+///   - `source`: originating reference name under `--include-refs` / `--ref`
+///     (distinct from the typed `reference_name` that `to_json_with_origin`
+///     already carries — kept for backward-compatible consumers).
+///
+/// `to_value` reconstructs the exact historical object: chunk base via the
+/// store serializer, then the optional fields layered in the same order the
+/// previous inline `serde_json::json!` builder used. Keeping the chunk base in
+/// the store serializer guarantees the posture-gated fields stay byte-identical
+/// to every other surface that renders a chunk.
+pub struct SearchResultOutput<'a> {
+    /// The matched result. Provides the canonical chunk base fields.
+    result: &'a UnifiedResult,
+    /// Reference origin for trust tagging (`to_json_with_origin`). `None` for
+    /// project results; `Some(name)` for `--ref` / `--include-refs` results.
+    ref_name: Option<&'a str>,
+    /// Parent context (small-to-big retrieval) when `--expand-parent` is set
+    /// and the chunk has a resolved parent.
+    parent: Option<&'a ParentContext>,
+    /// Originating reference name surfaced as the legacy `source` field
+    /// (multi-index / `--ref` paths only).
+    source: Option<&'a str>,
+}
+
+impl<'a> SearchResultOutput<'a> {
+    /// Build the per-result JSON value, preserving the exact field set and
+    /// ordering of the previous inline builders.
+    fn to_value(&self) -> serde_json::Value {
+        // Chunk base + posture-gated trust fields + `type: "code"` come from
+        // the canonical store serializer so this surface can never drift from
+        // the rest of the CLI on the injection/trust schema.
+        let mut obj = self.result.to_json_with_origin(self.ref_name);
+        if let Some(parent) = self.parent {
+            obj["parent_name"] = serde_json::json!(parent.name);
+            obj["parent_content"] = serde_json::json!(parent.content);
+            obj["parent_line_start"] = serde_json::json!(parent.line_start);
+            obj["parent_line_end"] = serde_json::json!(parent.line_end);
+        }
+        if let Some(source) = self.source {
+            obj["source"] = serde_json::json!(source);
+        }
+        obj
+    }
+}
+
+/// The envelope for CLI search JSON: `{results, query, total}` plus the
+/// optional token-budget pair and the optional multi-index `source` label.
+///
+/// This is the single schema source for the search-result envelope. Field
+/// names and optionality match the historical inline `serde_json::json!`
+/// builders exactly: `token_count` / `token_budget` are present only under
+/// `--tokens`, and `source` only on a `--ref`-scoped top-level response.
+#[derive(Serialize)]
+pub struct SearchOutput {
+    /// Per-result objects (see [`SearchResultOutput`]).
+    pub results: Vec<serde_json::Value>,
+    /// The original query string.
+    pub query: String,
+    /// Number of results returned.
+    pub total: usize,
+    /// Tokens consumed by the packed results (only under `--tokens`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_count: Option<usize>,
+    /// Token budget requested (only under `--tokens`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<usize>,
+    /// Reference name for a `--ref`-scoped top-level response. `None` for
+    /// project and `--include-refs` responses (those tag per-result instead).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+impl SearchOutput {
+    /// Assemble an envelope from already-built per-result values.
+    fn new(
+        results: Vec<serde_json::Value>,
+        query: &str,
+        token_info: Option<(usize, usize)>,
+        source: Option<String>,
+    ) -> Self {
+        let total = results.len();
+        let (token_count, token_budget) = match token_info {
+            Some((used, budget)) => (Some(used), Some(budget)),
+            None => (None, None),
+        };
+        SearchOutput {
+            results,
+            query: query.to_string(),
+            total,
+            token_count,
+            token_budget,
+            source,
+        }
+    }
+}
 
 /// Strip terminal control sequences from chunk-derived strings before
 /// printing them to a TTY.
@@ -367,30 +473,21 @@ pub fn display_unified_results_json(
     let json_results: Vec<_> = results
         .iter()
         .map(|r| {
-            // Delegate to UnifiedResult::to_json() for the canonical base keys,
-            // then layer on parent context fields.
-            let mut obj = r.to_json();
+            // Per-result schema lives in `SearchResultOutput`; it delegates the
+            // chunk base + posture-gated trust fields to the store serializer
+            // and layers parent context on top.
             let UnifiedResult::Code(sr) = r;
-            if let Some(parent) = parents.and_then(|p| p.get(&sr.chunk.id)) {
-                obj["parent_name"] = serde_json::json!(parent.name);
-                obj["parent_content"] = serde_json::json!(parent.content);
-                obj["parent_line_start"] = serde_json::json!(parent.line_start);
-                obj["parent_line_end"] = serde_json::json!(parent.line_end);
+            SearchResultOutput {
+                result: r,
+                ref_name: None,
+                parent: parents.and_then(|p| p.get(&sr.chunk.id)),
+                source: None,
             }
-            obj
+            .to_value()
         })
         .collect();
 
-    let mut output = serde_json::json!({
-        "results": json_results,
-        "query": query,
-        "total": results.len(),
-    });
-    if let Some((used, budget)) = token_info {
-        output["token_count"] = serde_json::json!(used);
-        output["token_budget"] = serde_json::json!(budget);
-    }
-
+    let output = SearchOutput::new(json_results, query, token_info, None);
     super::json_envelope::emit_json(&output)?;
     Ok(())
 }
@@ -557,36 +654,22 @@ pub fn display_tagged_results_json(
     let json_results: Vec<_> = results
         .iter()
         .map(|t| {
-            // Delegate to UnifiedResult::to_json_with_origin() for the
-            // canonical base keys + the trust_level/reference_name pair,
-            // then layer on parent context and the `source` field. Consumers
-            // can read `source`, or prefer the typed `trust_level` +
-            // `reference_name`.
-            let mut json = t.result.to_json_with_origin(t.source.as_deref());
+            // Same per-result schema as the project path, with the reference
+            // origin threaded for trust tagging AND surfaced as the legacy
+            // `source` field. Consumers can read `source`, or prefer the typed
+            // `trust_level` + `reference_name` the store serializer emits.
             let UnifiedResult::Code(sr) = &t.result;
-            if let Some(parent) = parents.and_then(|p| p.get(&sr.chunk.id)) {
-                json["parent_name"] = serde_json::json!(parent.name);
-                json["parent_content"] = serde_json::json!(parent.content);
-                json["parent_line_start"] = serde_json::json!(parent.line_start);
-                json["parent_line_end"] = serde_json::json!(parent.line_end);
+            SearchResultOutput {
+                result: &t.result,
+                ref_name: t.source.as_deref(),
+                parent: parents.and_then(|p| p.get(&sr.chunk.id)),
+                source: t.source.as_deref(),
             }
-            if let Some(source) = &t.source {
-                json["source"] = serde_json::json!(source);
-            }
-            json
+            .to_value()
         })
         .collect();
 
-    let mut output = serde_json::json!({
-        "results": json_results,
-        "query": query,
-        "total": results.len(),
-    });
-    if let Some((used, budget)) = token_info {
-        output["token_count"] = serde_json::json!(used);
-        output["token_budget"] = serde_json::json!(budget);
-    }
-
+    let output = SearchOutput::new(json_results, query, token_info, None);
     super::json_envelope::emit_json(&output)?;
     Ok(())
 }


### PR DESCRIPTION
Phase 2a of docs/plans/2026-06-10-command-core-unification.md — the eval-sensitive half of phase 2.

## What

- query_core: cmd_query's plain + name-only project search extracted into a surface-agnostic core (typed QueryArgs/QueryOutput, MCP-tool-shaped). Ref-scoped, include-refs, and daemon search deliberately deferred to 2b with in-code TODOs (entangled wire shapes — the daemon ChunkOutput schema divergence is flagged in the plan as 2b's real work).
- Typed display: SearchOutput/SearchResultOutput replace inline JSON; per-result base fields delegate to the store's to_json_with_origin (single trust-aware serializer). Byte-identical output verified against clean HEAD on an --expand-parent query.
- Request-scoped config: BFS max_nodes caps + CQS_FORCE_BASE_INDEX folded into Args, resolved once at adapter boundaries — phase-1 graph cores now read zero env.

## Eval gate

Retrieval stack (search/store/pipeline/splade/hnsw/embedder/eval) byte-identical in the diff — verified independently twice. Paired v3 fixtures land within the clean-HEAD rebuild variance band; byte-exact match is unachievable under codegen-units=1 (FP re-coalescing flips two rank-20-cliff ties on ANY recompile — proven via a graph-only-subset A/B that cannot reach search code). Gate definition amended in the plan accordingly.

## Review

Ship verdict. Both findings fixed pre-commit: the clap-defaults test now parses a real Cli invocation (as written it could never fail), and dispatch_search carries the 2b TODO. 46 targeted tests + parity green; build/clippy/fmt clean.

Also riding: CLAUDE.md emphasis-discipline line, notes.toml honesty rewrite, four taste-debt issues queued in the triage doc (#1690–#1693), plan-doc gate amendment + 2b friction note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
