### PR TITLE
refactor(io): command cores for the io group (phase 2b-io)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `line_end`/`content`/`signature`/`score`, all preserved. The internal
   `ChunkOutput` struct and its `batch/types.rs` module were deleted.
 
+- **Command-core unification for io commands (Phase 2b io half, internal).**
+  Seven io commands now route both surfaces through a single surface-agnostic
+  core: `diff` (`diff_core`), `drift` (`drift_core`), `scout` (`scout_core`),
+  `onboard` (`onboard_core`), `gather` (`gather_core`), `context`
+  (`context_core`), and `blame` (`blame_core`). Each takes a typed `*Args`
+  struct deriving `Deserialize` with `#[serde(default)]` and doc-commented
+  fields (the param surface a future MCP tool wraps), pinned to the clap
+  defaults by a `*_args_default_matches_clap_defaults` test. The `cmd_*` and
+  `dispatch_*` functions are thin adapters. `brief` and `reconstruct` stay
+  typed-output-only (no daemon path, display-oriented, single positional arg).
+  `read` and `notes` are deferred — their two surfaces emit divergent JSON
+  schemas that need a deliberate union-schema PR first.
+
+  **Daemon io wire-schema changes (agents parse — read this).** Routing the
+  daemon through the CLI's typed outputs converged several hand-rolled inline
+  JSON shapes onto the single schema source:
+  - `cqs diff` (daemon): added/removed entries no longer carry a `similarity`
+    key (correctly skipped — they never have one); modified entries keep
+    `similarity`. `type` and the `summary` block are unchanged.
+  - `cqs drift` (daemon): `chunk_type` now serializes via `ChunkType::to_string`
+    (matching the CLI) instead of the raw enum serde form. Field set otherwise
+    unchanged (`reference`/`threshold`/`min_drift`/`drifted`/`total_compared`/
+    `unchanged`).
+  - `cqs context --json` (full mode, daemon): now emits the CLI's `FullOutput`
+    shape. **Added** per-result `external_callers`, `external_callees`,
+    `dependent_files`, per-chunk `injection_flags`, `doc`, and split
+    `line_start`/`line_end`. **Removed** the daemon-only `lines: [start, end]`
+    array, per-chunk `language`, and the top-level `total` (use
+    `chunks.len()`). `trust_level` and the `token_count`/`token_budget` packing
+    fields are preserved. Compact and summary modes already shared the CLI
+    builders — unchanged.
+  - `cqs gather` (daemon): `--tokens` packing now applies the CLI's
+    reading-order re-sort (reference chunks first, then project, each in
+    file/line order) and over-fetches ≥50 seed candidates, so packed daemon
+    output matches the CLI's chunk ordering.
+  Path fields across these commands are forward-slash-normalized on both
+  surfaces. The `GatherDirection` enum gained a `Deserialize` derive (additive;
+  its `Serialize` output is byte-identical). No retrieval/indexing path was
+  touched; paired v3.v2 eval (test .459/.743/.862, dev .514/.817/.927) confirms
+  retrieval is unchanged.
+
 ### Fixed
 
 - **Kind-fallback cap parity across all graph commands.** The

--- a/docs/plans/2026-06-10-command-core-unification.md
+++ b/docs/plans/2026-06-10-command-core-unification.md
@@ -99,9 +99,58 @@ Order: callers, callees (same file), deps, test_map, trace, impact (hardest: con
   eval path) reproduces the identical shift.
 
 #### Phase 2b — search half (daemon + schema)
-- [ ] Cores + typed outputs for the io commands (read, context, gather, scout,
+- [~] Cores + typed outputs for the io commands (read, context, gather, scout,
   onboard, brief, notes, diff, blame, drift, reconstruct). *(io half — separate
-  PR; not part of the search-half landing.)*
+  PR.)* **Landed 2026-06-10 (branch `refactor/command-cores-io`):**
+  - **Cored + daemon-routed** (typed `*Args` w/ Deserialize + `#[serde(default)]`
+    clap-pinned, named `*_core`, both surfaces drive it): `diff` (`diff_core`),
+    `drift` (`drift_core`), `scout` (`scout_core`), `onboard` (`onboard_core`),
+    `gather` (`gather_core`), `context` (`context_core`), `blame` (`blame_core`).
+  - **Schema convergence on the daemon side** (the 2b "reconciliation" note):
+    `dispatch_diff`/`dispatch_drift` dropped their hand-rolled inline JSON and
+    now serialize the CLI's typed `DiffOutput`/`DriftOutput` (drift's
+    `chunk_type` now goes through `ChunkType::to_string`; diff added/removed
+    `similarity` is correctly skipped, modified present). `dispatch_context`
+    full-mode dropped its inline per-chunk JSON and now emits the CLI's
+    `FullOutput` shape (gains `external_callers`/`external_callees`/
+    `dependent_files`/`injection_flags`, per-chunk `line_start`/`line_end`
+    replacing `lines:[s,e]`, drops `language`/`total`). `dispatch_gather` gains
+    the CLI's reading-order re-sort + ≥50 over-fetch on `--tokens`. Compact /
+    summary context already shared builders — unchanged.
+  - **gather/scout/onboard env audit (audit-queue convergence):** cores read no
+    env. scout/onboard clamp via the `SCOUT_LIMIT_MAX` const, gather's
+    `gather_max_nodes()` stays an adapter-side text-display read; the only
+    request-scoped knob folded into Args is gather's `json_overhead` (resolved
+    at the adapter boundary, CLI format-dependent / daemon always-serialize).
+  - **`GatherDirection` gained `#[derive(Deserialize)]`** (additive; Serialize
+    output byte-identical — no `rename_all`) so `OnboardArgs`/`GatherArgs`
+    deserialize. `src/gather.rs` is not an eval-reachable dir; retrieval
+    untouched.
+  - **Typed-output-only (no daemon path, display-oriented, trivial logic — plan
+    option 3):** `brief`, `reconstruct`. Already carried typed `*Output`
+    structs; left as-is. No `*Args`/`*_core` added (single positional `path`,
+    no defaults to drift, so the clap-pin would be vacuous).
+  - **Deferred (schema divergence needs a deliberate union-schema PR):**
+    - `read`: full-read JSON diverges *in both directions* (daemon emits
+      `notes_injected`+`trust_level` the CLI omits; CLI focused emits
+      `injection_flags` the daemon omits) plus the daemon full-read does
+      file-path vendored detection the CLI doesn't. Reconciling needs a
+      union-schema decision (which fields win) — its own schema-change PR.
+    - `notes`: the CLI list path reads `docs/notes.toml` while the daemon reads
+      the store-cached notes, and the two emit *different* schemas (CLI `id`+
+      `type`, daemon `sentiment_label`, no shared `id`). A single
+      surface-agnostic core needs a unified data source + union schema first.
+  - **Parity tests:** `parity_context_compact_daemon_equals_core` +
+    `parity_context_full_daemon_equals_core` (byte-equal daemon vs core,
+    embedder-free) pin the biggest schema change. The other cored commands are
+    structurally parity-by-construction (the `dispatch_*` adapter literally
+    calls the same `*_core`). Per-command clap-pin tests
+    (`*_args_default_matches_clap_defaults`) + minimal-deserialize tests added
+    for diff/drift/scout/onboard/gather/blame/context.
+  - **Eval (gate b):** paired v3.v2, release build, against a force-rebuilt
+    index — TEST .459/.743/.862, DEV .514/.817/.927; both at/above the brief's
+    bands. No eval-reachable source touched (gate a); the force-reindex was
+    incidental (refreshed line anchors), not required by the diff.
 - [x] Daemon `dispatch_search` → `query_core` via a shared search-context trait.
   `SearchCtx` (in `commands/search/search_ctx.rs`) is the lean common surface
   (store / cqs_dir / root / embedder / reranker / splade_encode / splade_index /

--- a/src/cli/batch/handlers/info.rs
+++ b/src/cli/batch/handlers/info.rs
@@ -8,7 +8,6 @@ use anyhow::Result;
 use super::super::BatchView;
 use crate::cli::args::{BlameArgs, ContextArgs, ExplainArgs, OnboardArgs, ReadArgs, SimilarArgs};
 use crate::cli::validate_finite_f32;
-use cqs::normalize_path;
 
 /// Dispatches a blame analysis request for a specified target and returns the results as JSON.
 /// This function orchestrates the blame operation by building blame data for the given target and converting it to JSON format. It uses tracing instrumentation to log the operation.
@@ -26,16 +25,15 @@ pub(in crate::cli::batch) fn dispatch_blame(
     args: &BlameArgs,
 ) -> Result<serde_json::Value> {
     let target = args.name.as_str();
-    let depth = args.commits;
-    let show_callers = args.callers;
     let _span = tracing::info_span!("batch_blame", target).entered();
-    let data = crate::cli::commands::blame::build_blame_data(
-        &ctx.store(),
-        &ctx.root,
-        target,
-        depth,
-        show_callers,
-    )?;
+    // Thin adapter over the shared `blame_core` — identical JSON shape across
+    // the CLI and daemon surfaces (both serialize via `blame_to_json`).
+    let core_args = crate::cli::commands::blame::BlameArgs {
+        name: target.to_string(),
+        commits: args.commits,
+        callers: args.callers,
+    };
+    let data = crate::cli::commands::blame::blame_core(&ctx.store(), &ctx.root, &core_args)?;
     Ok(crate::cli::commands::blame::blame_to_json(&data, &ctx.root))
 }
 
@@ -167,88 +165,26 @@ pub(in crate::cli::batch) fn dispatch_context(
     args: &ContextArgs,
 ) -> Result<serde_json::Value> {
     let path = args.path.as_str();
-    let summary = args.summary;
-    let compact = args.compact;
-    let tokens = args.tokens;
     let _span = tracing::info_span!("batch_context", path).entered();
 
-    // Normalize backslash input from Windows / agent pipelines.
-    // `get_chunks_by_origin` matches on the stored `origin` column which is
-    // forward-slash-normalized; unnormalized `src\foo.rs` silently returns empty.
-    // `build_compact_data` / `build_full_data` also normalize internally, but
-    // we use the canonical form here for the fall-through full-context path
-    // below and the JSON `file:` field so cross-platform consumers see slashes.
-    let normalized = normalize_path(std::path::Path::new(path));
-
-    if compact {
-        let data = crate::cli::commands::context::build_compact_data(&ctx.store(), &normalized)?;
-        return Ok(crate::cli::commands::context::compact_to_json(
-            &data,
-            &normalized,
-        )?);
-    }
-
-    if summary {
-        let data =
-            crate::cli::commands::context::build_full_data(&ctx.store(), &normalized, &ctx.root)?;
-        return Ok(crate::cli::commands::context::summary_to_json(
-            &data,
-            &normalized,
-        )?);
-    }
-
-    // Full context -- with optional token packing
-    let chunks = ctx.store().get_chunks_by_origin(&normalized)?;
-    if chunks.is_empty() {
-        anyhow::bail!(
-            "No indexed chunks found for '{}'. Is the file indexed?",
-            path
-        );
-    }
-
-    let (chunks, token_info) = if let Some(budget) = tokens {
-        let embedder = ctx.embedder()?;
-        let names: Vec<&str> = chunks.iter().map(|c| c.name.as_str()).collect();
-        let caller_counts = ctx.store().get_caller_counts_batch(&names)?;
-        let (included, used) = crate::cli::commands::context::pack_by_relevance(
-            &chunks,
-            &caller_counts,
-            budget,
-            embedder,
-        );
-        let filtered: Vec<_> = chunks
-            .into_iter()
-            .filter(|c| included.contains(&c.name))
-            .collect();
-        (filtered, Some((used, budget)))
+    // Thin adapter over the shared `context_core` — identical JSON shape across
+    // the CLI and daemon surfaces (compact / summary / full all route through
+    // the same schema sources, so the daemon's full-context path now carries
+    // the external_callers / external_callees / dependent_files /
+    // injection_flags / line_start/line_end shape the CLI always emitted).
+    // The embedder for full-mode `--tokens` packing comes from the cached view.
+    let embedder = if args.tokens.is_some() && !args.compact && !args.summary {
+        Some(ctx.embedder()?)
     } else {
-        (chunks, None)
+        None
     };
-
-    let entries: Vec<_> = chunks
-        .iter()
-        .map(|c| {
-            // Chunks from `get_chunks_by_origin` come straight from the
-            // user's project store, so they're always user-code.
-            serde_json::json!({
-                "name": c.name,
-                "chunk_type": c.chunk_type.to_string(),
-                "language": c.language.to_string(),
-                "lines": [c.line_start, c.line_end],
-                "signature": c.signature,
-                "content": c.content,
-                "trust_level": "user-code",
-            })
-        })
-        .collect();
-
-    let mut response = serde_json::json!({
-        "file": normalized,
-        "chunks": entries,
-        "total": entries.len(),
-    });
-    crate::cli::commands::inject_token_info(&mut response, token_info);
-    Ok(response)
+    let core_args = crate::cli::commands::context::ContextArgs {
+        path: path.to_string(),
+        summary: args.summary,
+        compact: args.compact,
+        tokens: args.tokens,
+    };
+    crate::cli::commands::context::context_core(&ctx.store(), &ctx.root, &core_args, embedder)
 }
 
 /// Collects and aggregates statistics from the batch processing context into a JSON response.
@@ -318,7 +254,6 @@ pub(in crate::cli::batch) fn dispatch_onboard(
     args: &OnboardArgs,
 ) -> Result<serde_json::Value> {
     let query = args.query.as_str();
-    let tokens = args.tokens;
     let direction = args.direction;
     let _span = tracing::info_span!(
         "batch_onboard",
@@ -329,33 +264,17 @@ pub(in crate::cli::batch) fn dispatch_onboard(
     )
     .entered();
     let embedder = ctx.embedder()?;
-    let depth = args.depth.clamp(1, 5);
-    // Cap on call_chain + callers + tests. entry_point always kept.
-    let limit = args.limit_arg.limit.clamp(1, 100);
 
-    let mut result = cqs::onboard(&ctx.store(), embedder, query, &ctx.root, depth, direction)?;
-    result.call_chain.truncate(limit);
-    result.callers.truncate(limit);
-    result.tests.truncate(limit);
-
-    let Some(budget) = tokens else {
-        let mut json = serde_json::to_value(&result)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize onboard: {e}"))?;
-        crate::cli::commands::tag_user_code_trust_level(&mut json);
-        return Ok(json);
+    // Thin adapter over the shared `onboard_core` — identical JSON shape across
+    // the CLI and daemon surfaces.
+    let core_args = crate::cli::commands::onboard::OnboardArgs {
+        query: query.to_string(),
+        depth: args.depth,
+        direction,
+        limit: args.limit_arg.limit,
+        tokens: args.tokens,
     };
-
-    let named_items = crate::cli::commands::onboard_scored_names(&result);
-    let (content_map, used) =
-        crate::cli::commands::fetch_and_pack_content(&ctx.store(), embedder, &named_items, budget);
-
-    let mut json = serde_json::to_value(&result)
-        .map_err(|e| anyhow::anyhow!("Failed to serialize onboard: {e}"))?;
-    crate::cli::commands::inject_content_into_onboard_json(&mut json, &content_map, &result);
-    crate::cli::commands::inject_token_info(&mut json, Some((used, budget)));
-    // Onboard only queries the project store — every chunk is user-code.
-    crate::cli::commands::tag_user_code_trust_level(&mut json);
-    Ok(json)
+    crate::cli::commands::onboard::onboard_core(&ctx.store(), embedder, &ctx.root, &core_args)
 }
 
 /// Dispatches a read operation on a file within a batch context, optionally with focused reading on a specific note.
@@ -646,5 +565,77 @@ mod tests {
             json["trust_level"], "user-code",
             "non-vendored chunk must surface trust_level=user-code, got: {json}"
         );
+    }
+
+    /// Parity: `dispatch_context` (the daemon adapter) is byte-equal to
+    /// `context_core` driven with the same args. Compact mode is embedder-free,
+    /// so this runs without an ONNX load. Pins the Phase-2b convergence — the
+    /// daemon no longer hand-rolls per-chunk JSON.
+    #[test]
+    fn parity_context_compact_daemon_equals_core() {
+        let (_dir, ctx) = seed_minimal_ctx();
+        let view = ctx.build_view(None);
+
+        let args = ContextArgs {
+            path: "src/lib.rs".into(),
+            summary: false,
+            compact: true,
+            tokens: None,
+        };
+        let daemon = dispatch_context(&view, &args).expect("dispatch_context");
+        let core = crate::cli::commands::context::context_core(
+            &view.store(),
+            &view.root,
+            &crate::cli::commands::context::ContextArgs {
+                path: "src/lib.rs".into(),
+                summary: false,
+                compact: true,
+                tokens: None,
+            },
+            None,
+        )
+        .expect("context_core");
+        assert_eq!(
+            daemon, core,
+            "daemon dispatch_context must equal context_core (compact)"
+        );
+    }
+
+    /// Parity for the full-context path (the path whose schema converged onto
+    /// the CLI's `FullOutput` in Phase 2b). Embedder-free because `tokens` is
+    /// `None`.
+    #[test]
+    fn parity_context_full_daemon_equals_core() {
+        let (_dir, ctx) = seed_minimal_ctx();
+        let view = ctx.build_view(None);
+
+        let args = ContextArgs {
+            path: "src/lib.rs".into(),
+            summary: false,
+            compact: false,
+            tokens: None,
+        };
+        let daemon = dispatch_context(&view, &args).expect("dispatch_context");
+        let core = crate::cli::commands::context::context_core(
+            &view.store(),
+            &view.root,
+            &crate::cli::commands::context::ContextArgs {
+                path: "src/lib.rs".into(),
+                summary: false,
+                compact: false,
+                tokens: None,
+            },
+            None,
+        )
+        .expect("context_core");
+        assert_eq!(
+            daemon, core,
+            "daemon dispatch_context must equal context_core (full)"
+        );
+        // The full path carries the converged schema — these keys were absent
+        // from the daemon's old inline JSON.
+        assert!(daemon.get("external_callers").is_some());
+        assert!(daemon.get("external_callees").is_some());
+        assert!(daemon.get("dependent_files").is_some());
     }
 }

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -28,50 +28,42 @@ pub(in crate::cli::batch) fn dispatch_gather(
 
     let embedder = ctx.embedder()?;
 
-    let opts = cqs::GatherOptions {
-        expand_depth: args.depth.clamp(0, 5),
+    // Thin adapter over the shared `gather_core`. The daemon always serializes,
+    // so it charges the per-result JSON overhead in token packing. Reference
+    // resolution differs by surface (cached LRU here), so the adapter resolves
+    // the reference index + project vector index and hands them to the core.
+    let core_args = crate::cli::commands::gather::GatherArgs {
+        query: query.to_string(),
+        depth: args.depth,
         direction: args.direction,
-        limit: args.limit_arg.limit.clamp(1, 100),
-        ..cqs::GatherOptions::default()
+        limit: args.limit_arg.limit,
+        tokens: args.tokens,
+        json_overhead: crate::cli::commands::JSON_OVERHEAD_PER_RESULT,
     };
 
-    let mut result = if let Some(rn) = ref_name {
-        let query_embedding = embedder
-            .embed_query(query)
-            .context("Failed to embed query")?;
+    let (result, token_info) = if let Some(rn) = ref_name {
         ctx.get_ref(rn)?;
         let ref_idx = ctx
             .borrow_ref(rn)
             .ok_or_else(|| anyhow::anyhow!("Reference '{}' not loaded", rn))?;
         let index = ctx.vector_index()?;
-        let index = index.as_deref();
-        cqs::gather_cross_index_with_index(
+        crate::cli::commands::gather::gather_core(
             &ctx.store(),
-            &ref_idx,
-            &query_embedding,
-            query,
-            &opts,
+            embedder,
             &ctx.root,
-            index,
+            &core_args,
+            Some(ref_idx.as_ref()),
+            index.as_deref(),
         )?
     } else {
-        cqs::gather(&ctx.store(), embedder, query, &opts, &ctx.root)?
-    };
-
-    // Token-budget packing
-    let token_info: Option<(usize, usize)> = if let Some(budget) = args.tokens {
-        let embedder = ctx.embedder()?;
-        let chunks = std::mem::take(&mut result.chunks);
-        let (packed, used) = crate::cli::commands::pack_gather_chunks(
-            chunks,
+        crate::cli::commands::gather::gather_core(
+            &ctx.store(),
             embedder,
-            budget,
-            crate::cli::commands::JSON_OVERHEAD_PER_RESULT,
-        );
-        result.chunks = packed;
-        Some((used, budget))
-    } else {
-        None
+            &ctx.root,
+            &core_args,
+            None,
+            None,
+        )?
     };
 
     let output = crate::cli::commands::build_gather_output(&result, query, token_info);
@@ -233,28 +225,18 @@ pub(in crate::cli::batch) fn dispatch_scout(
     args: &ScoutArgs,
 ) -> Result<serde_json::Value> {
     let query = args.query.as_str();
-    let tokens = args.tokens;
     let _span = tracing::info_span!("batch_scout", query).entered();
     let embedder = ctx.embedder()?;
-    // Shared with CLI's cmd_scout.
-    let limit = args.limit_arg.limit.clamp(1, crate::cli::SCOUT_LIMIT_MAX);
-    let result = cqs::scout(&ctx.store(), embedder, query, &ctx.root, limit)?;
-
-    let (content_map, token_info) = if let Some(budget) = tokens {
-        let named_items = crate::cli::commands::scout_scored_names(&result);
-        let (cmap, used) = crate::cli::commands::fetch_and_pack_content(
-            &ctx.store(),
-            embedder,
-            &named_items,
-            budget,
-        );
-        (Some(cmap), Some((used, budget)))
-    } else {
-        (None, None)
+    // Thin adapter over the shared `scout_core` — identical JSON shape across
+    // the CLI and daemon surfaces.
+    let core_args = crate::cli::commands::scout::ScoutArgs {
+        query: query.to_string(),
+        limit: args.limit_arg.limit,
+        tokens: args.tokens,
     };
-
-    // Shared with CLI's cmd_scout — same JSON shape across both dispatch paths.
-    crate::cli::commands::build_scout_output(&result, content_map.as_ref(), token_info)
+    let (output, _token_info) =
+        crate::cli::commands::scout::scout_core(&ctx.store(), embedder, &ctx.root, &core_args)?;
+    Ok(output)
 }
 
 /// Suggests optimal file placements for code based on a natural language description.
@@ -307,8 +289,6 @@ pub(in crate::cli::batch) fn dispatch_drift(
     args: &DriftArgs,
 ) -> Result<serde_json::Value> {
     let reference = args.reference.as_str();
-    let lang = args.lang.as_deref();
-    let limit = args.limit;
     let _span = tracing::info_span!("batch_drift", reference).entered();
     let threshold = validate_finite_f32(args.threshold, "threshold")?;
     let min_drift = validate_finite_f32(args.min_drift, "min_drift")?;
@@ -319,135 +299,55 @@ pub(in crate::cli::batch) fn dispatch_drift(
         .borrow_ref(reference)
         .ok_or_else(|| anyhow::anyhow!("Reference '{}' not loaded", reference))?;
 
-    let result = cqs::drift::detect_drift(
-        &ref_idx.store,
-        &ctx.store(),
-        reference,
+    // Thin adapter: build the surface-agnostic args, then drive the shared
+    // `drift_core` so the wire shape matches the CLI's typed `DriftOutput`
+    // (normalized forward-slash paths, `chunk_type` via `ChunkType::to_string`).
+    let core_args = crate::cli::commands::drift::DriftArgs {
+        reference: reference.to_string(),
         threshold,
         min_drift,
-        lang,
-    )?;
-
-    let mut drifted_json: Vec<_> = result
-        .drifted
-        .iter()
-        .map(|e| {
-            // Emit normalized forward-slash paths (match sister
-            // handlers in info.rs) so agents chaining `drift` → `context --json`
-            // don't trip on Windows backslashes.
-            serde_json::json!({
-                "name": e.name,
-                "file": cqs::normalize_path(&e.file),
-                "chunk_type": e.chunk_type,
-                "similarity": e.similarity,
-                "drift": e.drift,
-            })
-        })
-        .collect();
-    if let Some(lim) = limit {
-        drifted_json.truncate(lim);
-    }
-
-    Ok(serde_json::json!({
-        "reference": result.reference,
-        "threshold": result.threshold,
-        "min_drift": result.min_drift,
-        "drifted": drifted_json,
-        "total_compared": result.total_compared,
-        "unchanged": result.unchanged,
-    }))
+        lang: args.lang.clone(),
+        limit: args.limit,
+    };
+    let output = crate::cli::commands::drift::drift_core(&ref_idx.store, &ctx.store(), &core_args)?;
+    Ok(serde_json::to_value(&output)?)
 }
 
-/// Runs semantic diff between a reference and the project (or another reference).
+/// Runs semantic diff between a reference and the project (or another
+/// reference). Thin adapter: resolve the source/target stores (needs the
+/// reference LRU + config), build a surface-agnostic
+/// [`crate::cli::commands::diff::DiffArgs`], then drive the shared
+/// `diff_core` so the wire shape matches the CLI's typed `DiffOutput`.
 pub(in crate::cli::batch) fn dispatch_diff(
     ctx: &BatchView,
     args: &DiffArgs,
 ) -> Result<serde_json::Value> {
     let source = args.source.as_str();
     let target = args.target.as_deref();
-    let lang = args.lang.as_deref();
     let _span = tracing::info_span!("batch_diff", source).entered();
     let threshold = validate_finite_f32(args.threshold, "threshold")?;
 
     let source_store = crate::cli::commands::resolve::resolve_reference_store(&ctx.root, source)?;
 
     let target_label = target.unwrap_or("project");
+    let core_args = crate::cli::commands::diff::DiffArgs {
+        source: source.to_string(),
+        target: target_label.to_string(),
+        threshold,
+        lang: args.lang.clone(),
+    };
+
     // `project` diffs against the open store; any other target resolves a
-    // reference store in the else arm.
-    let result = if target_label == "project" {
-        cqs::semantic_diff(
-            &source_store,
-            &ctx.store(),
-            source,
-            target_label,
-            threshold,
-            lang,
-        )?
+    // reference store first.
+    let output = if target_label == "project" {
+        crate::cli::commands::diff::diff_core(&source_store, &ctx.store(), &core_args)?
     } else {
         let target_ref_store =
             crate::cli::commands::resolve::resolve_reference_store(&ctx.root, target_label)?;
-        cqs::semantic_diff(
-            &source_store,
-            &target_ref_store,
-            source,
-            target_label,
-            threshold,
-            lang,
-        )?
+        crate::cli::commands::diff::diff_core(&source_store, &target_ref_store, &core_args)?
     };
 
-    // Emit normalized forward-slash paths (same rationale as
-    // `dispatch_drift` above) across added/removed/modified.
-    let added: Vec<_> = result
-        .added
-        .iter()
-        .map(|e| {
-            serde_json::json!({
-                "name": e.name,
-                "file": cqs::normalize_path(&e.file),
-                "type": e.chunk_type.to_string(),
-            })
-        })
-        .collect();
-
-    let removed: Vec<_> = result
-        .removed
-        .iter()
-        .map(|e| {
-            serde_json::json!({
-                "name": e.name,
-                "file": cqs::normalize_path(&e.file),
-                "type": e.chunk_type.to_string(),
-            })
-        })
-        .collect();
-
-    let modified: Vec<_> = result
-        .modified
-        .iter()
-        .map(|e| {
-            serde_json::json!({
-                "name": e.name,
-                "file": cqs::normalize_path(&e.file),
-                "type": e.chunk_type.to_string(),
-                "similarity": e.similarity,
-            })
-        })
-        .collect();
-
-    Ok(serde_json::json!({
-        "source": result.source,
-        "target": result.target,
-        "added": added,
-        "removed": removed,
-        "modified": modified,
-        "summary": {
-            "added": result.added.len(),
-            "removed": result.removed.len(),
-            "modified": result.modified.len(),
-            "unchanged": result.unchanged_count,
-        }
-    }))
+    Ok(serde_json::to_value(&output)?)
 }
 
 /// Runs task planning with template classification and returns results as JSON.

--- a/src/cli/commands/io/blame.rs
+++ b/src/cli/commands/io/blame.rs
@@ -1,14 +1,65 @@
 //! Blame command — semantic git blame for a function
 //!
-//! Core logic is in `build_blame_data()` so batch mode can reuse it.
+//! ## Command-core split (Phase 2b)
+//!
+//! Blame is display-oriented: the surface-agnostic logic is
+//! [`build_blame_data`] (resolve target → `git log -L` → parse → optional
+//! callers) and the single JSON-schema source is [`blame_to_json`] (via the
+//! borrowing `BlameOutput`). [`blame_core`] is the named entry point both the
+//! CLI [`cmd_blame`] and the daemon `dispatch_blame` drive; it takes a typed
+//! [`BlameArgs`] and returns the [`BlameData`] the serializer + terminal
+//! renderer share. Reads no env.
 
 use std::path::Path;
 
 use anyhow::{Context, Result};
 use colored::Colorize;
 
-use cqs::store::{CallerInfo, ChunkSummary, Store};
+use cqs::store::{CallerInfo, ChunkSummary, ReadOnly, Store};
 use cqs::{normalize_path, rel_display, resolve_target};
+
+// ─── Args (surface-agnostic, MCP-ready) ──────────────────────────────────────
+
+/// Input for [`blame_core`] — the blame knobs both the CLI and a future MCP
+/// `blame` tool deserialize into. Store/root come from the adapter.
+///
+/// `#[serde(default)]` so a wire caller can supply just `name` and inherit the
+/// production defaults (commits mirrors clap's `--commits` default of 10).
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(default)]
+pub(crate) struct BlameArgs {
+    /// Function name or `file:function` to blame.
+    pub name: String,
+    /// Max commits to show from `git log -L`.
+    pub commits: usize,
+    /// Also resolve and show the function's callers.
+    pub callers: bool,
+}
+
+impl Default for BlameArgs {
+    fn default() -> Self {
+        BlameArgs {
+            name: String::new(),
+            commits: 10,
+            callers: false,
+        }
+    }
+}
+
+// ─── Core ─────────────────────────────────────────────────────────────────────
+
+/// Surface-agnostic core for `cqs blame`. Thin wrapper over
+/// [`build_blame_data`] keyed on the typed [`BlameArgs`]; returns the
+/// [`BlameData`] both the JSON serializer ([`blame_to_json`]) and the terminal
+/// renderer consume. Reads no env and never prints.
+pub(crate) fn blame_core(
+    store: &Store<ReadOnly>,
+    root: &Path,
+    args: &BlameArgs,
+) -> Result<BlameData> {
+    let _span = tracing::info_span!("blame_core", name = %args.name).entered();
+    build_blame_data(store, root, &args.name, args.commits, args.callers)
+}
 
 // ─── Data structures ─────────────────────────────────────────────────────────
 
@@ -306,7 +357,12 @@ pub(crate) fn cmd_blame(
 
     let store = &ctx.store;
     let root = &ctx.root;
-    let data = build_blame_data(store, root, target, commits, show_callers)?;
+    let args = BlameArgs {
+        name: target.to_string(),
+        commits,
+        callers: show_callers,
+    };
+    let data = blame_core(store, root, &args)?;
 
     if json {
         let value = blame_to_json(&data, root);
@@ -324,6 +380,43 @@ pub(crate) fn cmd_blame(
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    /// A wire/MCP caller can supply only `name` and inherit defaults.
+    #[test]
+    fn blame_args_deserialize_minimal() {
+        let args: BlameArgs = serde_json::from_str(r#"{"name": "my_fn"}"#).unwrap();
+        assert_eq!(args.name, "my_fn");
+        assert_eq!(args.commits, 10);
+        assert!(!args.callers);
+    }
+
+    /// `BlameArgs::default` must match the clap `BlameArgs` defaults.
+    /// Parses `cqs blame <name>` via a throwaway `clap::Parser` wrapper.
+    #[test]
+    fn blame_args_default_matches_clap_defaults() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Wrap {
+            #[command(flatten)]
+            args: crate::cli::args::BlameArgs,
+        }
+
+        let clap_args = Wrap::try_parse_from(["cqs-blame", "my_fn"]).unwrap().args;
+        let core = BlameArgs {
+            name: clap_args.name.clone(),
+            commits: clap_args.commits,
+            callers: clap_args.callers,
+        };
+        let expected = BlameArgs {
+            name: "my_fn".to_string(),
+            ..BlameArgs::default()
+        };
+        assert_eq!(
+            core, expected,
+            "clap blame defaults drifted from BlameArgs::default — update both together"
+        );
+    }
 
     #[test]
     fn test_parse_git_log_output_single() {

--- a/src/cli/commands/io/context.rs
+++ b/src/cli/commands/io/context.rs
@@ -1,16 +1,99 @@
 //! Context command — module-level understanding
 //!
-//! Core logic is in shared functions (`build_compact_data`, `build_full_data`,
-//! `compact_to_json`, `full_to_json`) so batch mode can reuse them without
-//! duplicating ~120 lines.
+//! ## Command-core split (Phase 2b)
+//!
+//! [`context_core`] is the surface-agnostic JSON producer for all three modes
+//! (compact / summary / full). It routes through the shared data builders
+//! (`build_compact_data`, `build_full_data`) and the single JSON-schema sources
+//! (`compact_to_json`, `summary_to_json`, [`full_to_json`]). Both the CLI
+//! ([`cmd_context`] JSON path) and the daemon (`dispatch_context`) drive it, so
+//! the wire shape is identical — the daemon's full-context path now carries the
+//! same `external_callers` / `external_callees` / `dependent_files` /
+//! `injection_flags` / `line_start`/`line_end` shape the CLI always emitted.
+//! Reads no env; the embedder for `--tokens` packing is passed by the adapter.
 
 use anyhow::{bail, Context as _, Result};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use cqs::store::{ChunkSummary, Store};
+use cqs::store::{ChunkSummary, ReadOnly, Store};
+use cqs::Embedder;
 
 use crate::cli::staleness;
+
+// ─── Args (surface-agnostic, MCP-ready) ──────────────────────────────────────
+
+/// Input for [`context_core`] — the context knobs both the CLI and a future
+/// MCP `context` tool deserialize into. Store/root and the optional embedder
+/// (for `--tokens` packing) come from the adapter.
+///
+/// `#[serde(default)]` so a wire caller can supply just `path` and inherit the
+/// production defaults. `summary`/`compact` are mutually-exclusive modes (clap
+/// enforces; the core treats `compact` as winning if both are somehow set).
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize)]
+#[serde(default)]
+pub(crate) struct ContextArgs {
+    /// File path (relative to project root) to build context for.
+    pub path: String,
+    /// Summary mode: aggregated caller/callee counts + chunk TOC.
+    pub summary: bool,
+    /// Compact mode: signatures-only TOC with per-chunk caller/callee counts.
+    pub compact: bool,
+    /// Token budget — full mode only; packs chunk content into the budget.
+    pub tokens: Option<usize>,
+}
+
+// ─── Core ─────────────────────────────────────────────────────────────────────
+
+/// Surface-agnostic JSON core for `cqs context`. Dispatches on mode (compact /
+/// summary / full) and returns the assembled `serde_json::Value` from the
+/// shared schema sources. The `--tokens` full-mode packing needs an embedder;
+/// the adapter supplies one (lazily built CLI-side, cached daemon-side) only
+/// when `tokens` is set. Reads no env and never prints.
+pub(crate) fn context_core(
+    store: &Store<ReadOnly>,
+    root: &Path,
+    args: &ContextArgs,
+    embedder: Option<&Embedder>,
+) -> Result<serde_json::Value> {
+    let _span = tracing::info_span!("context_core", path = %args.path).entered();
+
+    // Normalize backslash input from Windows / agent pipelines so the
+    // `origin`-column match (forward-slash-normalized) and the JSON `file`
+    // field are canonical across surfaces.
+    let normalized = cqs::normalize_path(Path::new(&args.path));
+
+    if args.compact {
+        let data = build_compact_data(store, &normalized)?;
+        return Ok(compact_to_json(&data, &normalized)?);
+    }
+
+    let data = build_full_data(store, &normalized, root)?;
+
+    if args.summary {
+        return Ok(summary_to_json(&data, &normalized)?);
+    }
+
+    // Full mode — optional token-budgeted content.
+    let (content_set, token_info) = match (args.tokens, embedder) {
+        (Some(budget), Some(emb)) => {
+            let names: Vec<&str> = data.chunks.iter().map(|c| c.name.as_str()).collect();
+            let caller_counts = store.get_caller_counts_batch(&names).context(
+                "Failed to fetch caller counts for token packing — ranking signal required",
+            )?;
+            let (included, used) = pack_by_relevance(&data.chunks, &caller_counts, budget, emb);
+            (Some(included), Some((used, budget)))
+        }
+        _ => (None, None),
+    };
+
+    Ok(full_to_json(
+        &data,
+        &normalized,
+        content_set.as_ref(),
+        token_info,
+    )?)
+}
 
 // ─── Shared core ────────────────────────────────────────────────────────────
 
@@ -395,6 +478,32 @@ pub(crate) fn cmd_context(
         bail!("--tokens cannot be used with --compact or --summary");
     }
 
+    // JSON path routes through the shared `context_core` (same code the daemon
+    // runs), so the wire shape is identical across surfaces. The embedder for
+    // full-mode `--tokens` packing is built lazily here only when needed.
+    if json {
+        // Proactive staleness warning (surface I/O — adapter owns it).
+        if !ctx.cli.quiet && !ctx.cli.no_stale_check {
+            staleness::warn_stale_results(store, &[path], root);
+        }
+        let embedder = if max_tokens.is_some() && !compact && !summary {
+            Some(cqs::Embedder::new(ctx.model_config().clone())?)
+        } else {
+            None
+        };
+        let args = ContextArgs {
+            path: path.to_string(),
+            summary,
+            compact,
+            tokens: max_tokens,
+        };
+        let output = context_core(store, root, &args, embedder.as_ref())?;
+        crate::cli::json_envelope::emit_json(&output)?;
+        return Ok(());
+    }
+
+    // Text path keeps the raw data structs for rendering.
+
     // Compact mode: signatures-only TOC with caller/callee counts
     if compact {
         let data = build_compact_data(store, path)?;
@@ -404,12 +513,7 @@ pub(crate) fn cmd_context(
             staleness::warn_stale_results(store, &[path], root);
         }
 
-        if json {
-            let output = compact_to_json(&data, path)?;
-            crate::cli::json_envelope::emit_json(&output)?;
-        } else {
-            print_compact_terminal(&data, path);
-        }
+        print_compact_terminal(&data, path);
         return Ok(());
     }
 
@@ -422,17 +526,7 @@ pub(crate) fn cmd_context(
     }
 
     if summary {
-        if json {
-            let output = summary_to_json(&data, path)?;
-            crate::cli::json_envelope::emit_json(&output)?;
-        } else {
-            print_summary_terminal(&data, path);
-        }
-    } else if json {
-        let (content_set, token_info) =
-            build_token_pack(store, &data.chunks, max_tokens, ctx.model_config())?;
-        let output = full_to_json(&data, path, content_set.as_ref(), token_info)?;
-        crate::cli::json_envelope::emit_json(&output)?;
+        print_summary_terminal(&data, path);
     } else {
         let (content_set, token_info) =
             build_token_pack(store, &data.chunks, max_tokens, ctx.model_config())?;
@@ -659,6 +753,47 @@ mod tests {
     use cqs::language::{ChunkType, Language};
     use cqs::store::ChunkSummary;
     use std::path::PathBuf;
+
+    /// A wire/MCP caller can supply only `path` and inherit defaults.
+    #[test]
+    fn context_args_deserialize_minimal() {
+        let args: ContextArgs = serde_json::from_str(r#"{"path": "src/lib.rs"}"#).unwrap();
+        assert_eq!(args.path, "src/lib.rs");
+        assert!(!args.summary);
+        assert!(!args.compact);
+        assert!(args.tokens.is_none());
+    }
+
+    /// `ContextArgs::default` must match the clap `ContextArgs` defaults.
+    /// Parses `cqs context <path>` via a throwaway `clap::Parser` wrapper.
+    #[test]
+    fn context_args_default_matches_clap_defaults() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Wrap {
+            #[command(flatten)]
+            args: crate::cli::args::ContextArgs,
+        }
+
+        let clap_args = Wrap::try_parse_from(["cqs-context", "src/lib.rs"])
+            .unwrap()
+            .args;
+        let core = ContextArgs {
+            path: clap_args.path.clone(),
+            summary: clap_args.summary,
+            compact: clap_args.compact,
+            tokens: clap_args.tokens,
+        };
+        let expected = ContextArgs {
+            path: "src/lib.rs".to_string(),
+            ..ContextArgs::default()
+        };
+        assert_eq!(
+            core, expected,
+            "clap context defaults drifted from ContextArgs::default — update both together"
+        );
+    }
 
     fn make_chunk(name: &str, line_start: u32, line_end: u32) -> ChunkSummary {
         ChunkSummary {

--- a/src/cli/commands/io/diff.rs
+++ b/src/cli/commands/io/diff.rs
@@ -1,4 +1,13 @@
 //! Diff command — semantic diff between indexed snapshots
+//!
+//! ## Command-core split (Phase 2b)
+//!
+//! [`diff_core`] owns the surface-agnostic diff logic: it takes the two
+//! already-resolved stores plus a typed [`DiffArgs`] and returns the typed
+//! [`DiffOutput`] (the single JSON-schema source). Store resolution
+//! (`project` vs. a named reference) needs config load + the reference LRU, so
+//! it stays in each adapter (CLI [`cmd_diff`] / daemon `dispatch_diff`); both
+//! drive the same core afterward, so the wire shape is identical.
 
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
@@ -9,12 +18,49 @@ use cqs::{normalize_path, semantic_diff, DiffResult};
 use crate::cli::find_project_root;
 
 // ---------------------------------------------------------------------------
+// Args (surface-agnostic, MCP-ready)
+// ---------------------------------------------------------------------------
+
+/// Input for [`diff_core`] — the diff knobs both the CLI and a future MCP
+/// `diff` tool deserialize into. Store resolution (which reference / project)
+/// is the adapter's job; the core takes the resolved stores plus these
+/// settings.
+///
+/// `#[serde(default)]` so a wire caller can omit `target`/`lang` and inherit
+/// the production defaults; `threshold` defaults to the clap value.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(default)]
+pub(crate) struct DiffArgs {
+    /// Source reference name (echoed into the output label).
+    pub source: String,
+    /// Target label — `project` or another reference name.
+    pub target: String,
+    /// Similarity threshold for the "modified" bucket: pairs above are
+    /// unchanged, below are modified.
+    pub threshold: f32,
+    /// Restrict the comparison to this language (e.g. `rust`).
+    pub lang: Option<String>,
+}
+
+impl Default for DiffArgs {
+    fn default() -> Self {
+        // Mirrors clap's `DiffArgs` defaults (threshold 0.95, target "project").
+        DiffArgs {
+            source: String::new(),
+            target: "project".to_string(),
+            threshold: 0.95,
+            lang: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Output structs
 // ---------------------------------------------------------------------------
 
 /// A single entry in the diff output (added, removed, or modified).
 #[derive(Debug, serde::Serialize)]
-struct DiffEntryOutput {
+pub(crate) struct DiffEntryOutput {
     name: String,
     file: String,
     #[serde(rename = "type")]
@@ -25,16 +71,17 @@ struct DiffEntryOutput {
 
 /// Summary counts for the diff.
 #[derive(Debug, serde::Serialize)]
-struct DiffSummary {
+pub(crate) struct DiffSummary {
     added: usize,
     removed: usize,
     modified: usize,
     unchanged: usize,
 }
 
-/// Top-level JSON output for the diff command.
+/// Top-level JSON output for the diff command — the single JSON-schema source
+/// shared by the CLI and daemon adapters.
 #[derive(Debug, serde::Serialize)]
-struct DiffOutput {
+pub(crate) struct DiffOutput {
     source: String,
     target: String,
     added: Vec<DiffEntryOutput>,
@@ -79,6 +126,33 @@ fn build_diff_output(result: &DiffResult) -> DiffOutput {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Core
+// ---------------------------------------------------------------------------
+
+/// Surface-agnostic core for `cqs diff`. Takes the two already-resolved stores
+/// (the adapter owns reference/project resolution) plus a [`DiffArgs`], runs
+/// the `semantic_diff` primitive, and assembles the typed [`DiffOutput`].
+/// Reads no env and never prints — the adapter renders text or JSON from the
+/// returned struct.
+pub(crate) fn diff_core<Mode1, Mode2>(
+    source_store: &Store<Mode1>,
+    target_store: &Store<Mode2>,
+    args: &DiffArgs,
+) -> Result<DiffOutput> {
+    let _span =
+        tracing::info_span!("diff_core", source = %args.source, target = %args.target).entered();
+    let result = semantic_diff(
+        source_store,
+        target_store,
+        &args.source,
+        &args.target,
+        args.threshold,
+        args.lang.as_deref(),
+    )?;
+    Ok(build_diff_output(&result))
+}
+
 pub(crate) fn cmd_diff(
     source: &str,
     target: Option<&str>,
@@ -106,72 +180,59 @@ pub(crate) fn cmd_diff(
         crate::cli::commands::resolve::resolve_reference_store(&root, target_label)?
     };
 
-    let result = semantic_diff(
-        &source_store,
-        &target_store,
-        source,
-        target_label,
+    let args = DiffArgs {
+        source: source.to_string(),
+        target: target_label.to_string(),
         threshold,
-        lang,
-    )?;
+        lang: lang.map(str::to_string),
+    };
+    let output = diff_core(&source_store, &target_store, &args)?;
 
     if json {
-        display_diff_json(&result)?;
+        crate::cli::json_envelope::emit_json(&output)?;
     } else {
-        display_diff(&result)?;
+        display_diff_from_output(&output);
     }
 
     Ok(())
 }
 
-/// Displays a formatted diff report showing changes between two versions.
-fn display_diff(result: &DiffResult) -> Result<()> {
-    println!("Diff: {} → {}", result.source.bold(), result.target.bold());
+/// Displays a formatted diff report from the typed [`DiffOutput`] — the same
+/// struct the JSON path serializes, so text and JSON share one data source.
+fn display_diff_from_output(output: &DiffOutput) {
+    println!("Diff: {} → {}", output.source.bold(), output.target.bold());
     println!();
 
-    if !result.added.is_empty() {
-        println!("{} ({}):", "Added".green().bold(), result.added.len());
-        for entry in &result.added {
-            println!(
-                "  + {} {} ({})",
-                entry.chunk_type,
-                entry.name,
-                entry.file.display()
-            );
+    if !output.added.is_empty() {
+        println!("{} ({}):", "Added".green().bold(), output.added.len());
+        for entry in &output.added {
+            println!("  + {} {} ({})", entry.chunk_type, entry.name, entry.file);
         }
         println!();
     }
 
-    if !result.removed.is_empty() {
-        println!("{} ({}):", "Removed".red().bold(), result.removed.len());
-        for entry in &result.removed {
-            println!(
-                "  - {} {} ({})",
-                entry.chunk_type,
-                entry.name,
-                entry.file.display()
-            );
+    if !output.removed.is_empty() {
+        println!("{} ({}):", "Removed".red().bold(), output.removed.len());
+        for entry in &output.removed {
+            println!("  - {} {} ({})", entry.chunk_type, entry.name, entry.file);
         }
         println!();
     }
 
-    if !result.modified.is_empty() {
+    if !output.modified.is_empty() {
         println!(
             "{} ({}):",
             "Modified".yellow().bold(),
-            result.modified.len()
+            output.modified.len()
         );
-        for entry in &result.modified {
+        for entry in &output.modified {
             let sim = entry
                 .similarity
                 .map(|s| format!("[{:.2}]", s))
                 .unwrap_or_else(|| "[?]".to_string());
             println!(
                 "  ~ {} {} ({}) {}",
-                entry.chunk_type,
-                entry.name,
-                entry.file.display(),
-                sim
+                entry.chunk_type, entry.name, entry.file, sim
             );
         }
         println!();
@@ -179,20 +240,11 @@ fn display_diff(result: &DiffResult) -> Result<()> {
 
     println!(
         "Summary: {} added, {} removed, {} modified, {} unchanged",
-        result.added.len(),
-        result.removed.len(),
-        result.modified.len(),
-        result.unchanged_count,
+        output.summary.added,
+        output.summary.removed,
+        output.summary.modified,
+        output.summary.unchanged,
     );
-
-    Ok(())
-}
-
-/// Formats and outputs a diff result as a formatted JSON document to stdout.
-fn display_diff_json(result: &DiffResult) -> Result<()> {
-    let output = build_diff_output(result);
-    crate::cli::json_envelope::emit_json(&output)?;
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -202,6 +254,50 @@ fn display_diff_json(result: &DiffResult) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A wire/MCP caller can supply only `source` and inherit the production
+    /// defaults via `#[serde(default)]`.
+    #[test]
+    fn diff_args_deserialize_minimal() {
+        let args: DiffArgs = serde_json::from_str(r#"{"source": "v1.0"}"#).unwrap();
+        assert_eq!(args.source, "v1.0");
+        assert_eq!(args.target, "project");
+        assert!((args.threshold - 0.95).abs() < 1e-6);
+        assert!(args.lang.is_none());
+    }
+
+    /// `DiffArgs::default` must match the clap `DiffArgs` defaults exactly so
+    /// the wire surface and the CLI agree on omitted-field behavior. Parses a
+    /// real minimal CLI invocation (`cqs diff <source>`) via a throwaway
+    /// `clap::Parser` wrapper around the shared clap `DiffArgs`; a changed clap
+    /// default breaks this test instead of silently diverging.
+    #[test]
+    fn diff_args_default_matches_clap_defaults() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Wrap {
+            #[command(flatten)]
+            args: crate::cli::args::DiffArgs,
+        }
+
+        let clap_args = Wrap::try_parse_from(["cqs-diff", "v1.0"]).unwrap().args;
+        // Build the surface-agnostic args the way the adapter does.
+        let core = DiffArgs {
+            source: clap_args.source.clone(),
+            target: clap_args.target.clone().unwrap_or_else(|| "project".into()),
+            threshold: clap_args.threshold,
+            lang: clap_args.lang.clone(),
+        };
+        let expected = DiffArgs {
+            source: "v1.0".to_string(),
+            ..DiffArgs::default()
+        };
+        assert_eq!(
+            core, expected,
+            "clap diff defaults drifted from DiffArgs::default — update both together"
+        );
+    }
 
     #[test]
     fn diff_output_empty() {

--- a/src/cli/commands/io/drift.rs
+++ b/src/cli/commands/io/drift.rs
@@ -1,4 +1,12 @@
 //! Drift command — semantic change detection between reference snapshots
+//!
+//! ## Command-core split (Phase 2b)
+//!
+//! [`drift_core`] owns the surface-agnostic drift logic: it takes the
+//! already-resolved reference + project stores plus a typed [`DriftArgs`] and
+//! returns the typed [`DriftOutput`] (the single JSON-schema source). Store
+//! resolution stays in each adapter (CLI [`cmd_drift`] / daemon
+//! `dispatch_drift`); both drive the same core, so the wire shape is identical.
 
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
@@ -8,12 +16,49 @@ use cqs::{normalize_path, Store};
 use crate::cli::find_project_root;
 
 // ---------------------------------------------------------------------------
+// Args (surface-agnostic, MCP-ready)
+// ---------------------------------------------------------------------------
+
+/// Input for [`drift_core`] — the drift knobs both the CLI and a future MCP
+/// `drift` tool deserialize into. Store resolution is the adapter's job.
+///
+/// `#[serde(default)]` so a wire caller can supply just `reference` and inherit
+/// the production defaults (matching clap's `DriftArgs`).
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(default)]
+pub(crate) struct DriftArgs {
+    /// Reference name to compare the project against (echoed into output).
+    pub reference: String,
+    /// Similarity threshold: pairs below are reported as drifted.
+    pub threshold: f32,
+    /// Minimum drift value to include in the output.
+    pub min_drift: f32,
+    /// Restrict the comparison to this language (e.g. `rust`).
+    pub lang: Option<String>,
+    /// Cap on the number of drifted entries returned (`None` = all).
+    pub limit: Option<usize>,
+}
+
+impl Default for DriftArgs {
+    fn default() -> Self {
+        // Mirrors clap's `DriftArgs` defaults (threshold 0.95, min_drift 0.0).
+        DriftArgs {
+            reference: String::new(),
+            threshold: 0.95,
+            min_drift: 0.0,
+            lang: None,
+            limit: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Output structs
 // ---------------------------------------------------------------------------
 
 /// A single entry in the drift output.
 #[derive(Debug, serde::Serialize)]
-struct DriftEntryOutput {
+pub(crate) struct DriftEntryOutput {
     name: String,
     file: String,
     chunk_type: String,
@@ -21,9 +66,10 @@ struct DriftEntryOutput {
     drift: f32,
 }
 
-/// Top-level JSON output for the drift command.
+/// Top-level JSON output for the drift command — the single JSON-schema source
+/// shared by the CLI and daemon adapters.
 #[derive(Debug, serde::Serialize)]
-struct DriftOutput {
+pub(crate) struct DriftOutput {
     reference: String,
     threshold: f32,
     min_drift: f32,
@@ -73,6 +119,31 @@ fn build_drift_output(result: &cqs::drift::DriftResult, limit: Option<usize>) ->
     }
 }
 
+// ---------------------------------------------------------------------------
+// Core
+// ---------------------------------------------------------------------------
+
+/// Surface-agnostic core for `cqs drift`. Takes the already-resolved reference
+/// + project stores (the adapter owns resolution) plus a [`DriftArgs`], runs
+/// the `detect_drift` primitive, and assembles the typed [`DriftOutput`]
+/// (applying the optional limit). Reads no env and never prints.
+pub(crate) fn drift_core<Mode1, Mode2>(
+    ref_store: &Store<Mode1>,
+    project_store: &Store<Mode2>,
+    args: &DriftArgs,
+) -> Result<DriftOutput> {
+    let _span = tracing::info_span!("drift_core", reference = %args.reference).entered();
+    let result = cqs::drift::detect_drift(
+        ref_store,
+        project_store,
+        &args.reference,
+        args.threshold,
+        args.min_drift,
+        args.lang.as_deref(),
+    )?;
+    Ok(build_drift_output(&result, args.limit))
+}
+
 /// Detect semantic drift between a reference and the current project.
 pub(crate) fn cmd_drift(
     reference: &str,
@@ -98,17 +169,27 @@ pub(crate) fn cmd_drift(
     let project_store = Store::open(&index_path)
         .with_context(|| format!("Failed to open project store at {}", index_path.display()))?;
 
+    let args = DriftArgs {
+        reference: reference.to_string(),
+        threshold,
+        min_drift,
+        lang: lang.map(str::to_string),
+        limit,
+    };
     let result = cqs::drift::detect_drift(
         &ref_store,
         &project_store,
-        reference,
-        threshold,
-        min_drift,
-        lang,
+        &args.reference,
+        args.threshold,
+        args.min_drift,
+        args.lang.as_deref(),
     )?;
+    // Full (pre-limit) drifted count for the text summary — the limit only
+    // truncates the displayed/serialized list, never the reported totals.
+    let total_drifted = result.drifted.len();
+    let output = build_drift_output(&result, args.limit);
 
     if json {
-        let output = build_drift_output(&result, limit);
         crate::cli::json_envelope::emit_json(&output)?;
     } else {
         println!(
@@ -118,31 +199,23 @@ pub(crate) fn cmd_drift(
             min_drift
         );
 
-        let entries = if let Some(lim) = limit {
-            &result.drifted[..result.drifted.len().min(lim)]
-        } else {
-            &result.drifted
-        };
-
-        if entries.is_empty() {
+        if output.drifted.is_empty() {
             println!("  No drift detected.");
         } else {
-            for entry in entries {
+            for entry in &output.drifted {
                 println!(
                     "  {:.2}  {}  {}  {}",
                     entry.drift,
                     entry.name,
-                    entry.file.display().to_string().dimmed(),
-                    entry.chunk_type.to_string().dimmed()
+                    entry.file.dimmed(),
+                    entry.chunk_type.dimmed()
                 );
             }
         }
 
         println!(
             "\n{} drifted of {} compared ({} unchanged)",
-            result.drifted.len(),
-            result.total_compared,
-            result.unchanged
+            total_drifted, output.total_compared, output.unchanged
         );
     }
 
@@ -156,6 +229,47 @@ pub(crate) fn cmd_drift(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A wire/MCP caller can supply only `reference` and inherit defaults.
+    #[test]
+    fn drift_args_deserialize_minimal() {
+        let args: DriftArgs = serde_json::from_str(r#"{"reference": "v1.0"}"#).unwrap();
+        assert_eq!(args.reference, "v1.0");
+        assert!((args.threshold - 0.95).abs() < 1e-6);
+        assert!((args.min_drift - 0.0).abs() < 1e-6);
+        assert!(args.lang.is_none());
+        assert!(args.limit.is_none());
+    }
+
+    /// `DriftArgs::default` must match the clap `DriftArgs` defaults exactly.
+    /// Parses `cqs drift <reference>` via a throwaway `clap::Parser` wrapper.
+    #[test]
+    fn drift_args_default_matches_clap_defaults() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Wrap {
+            #[command(flatten)]
+            args: crate::cli::args::DriftArgs,
+        }
+
+        let clap_args = Wrap::try_parse_from(["cqs-drift", "v1.0"]).unwrap().args;
+        let core = DriftArgs {
+            reference: clap_args.reference.clone(),
+            threshold: clap_args.threshold,
+            min_drift: clap_args.min_drift,
+            lang: clap_args.lang.clone(),
+            limit: clap_args.limit,
+        };
+        let expected = DriftArgs {
+            reference: "v1.0".to_string(),
+            ..DriftArgs::default()
+        };
+        assert_eq!(
+            core, expected,
+            "clap drift defaults drifted from DriftArgs::default — update both together"
+        );
+    }
 
     #[test]
     fn drift_output_empty() {

--- a/src/cli/commands/io/mod.rs
+++ b/src/cli/commands/io/mod.rs
@@ -3,8 +3,8 @@
 pub(crate) mod blame;
 mod brief;
 pub(crate) mod context;
-mod diff;
-mod drift;
+pub(crate) mod diff;
+pub(crate) mod drift;
 mod notes;
 pub(crate) mod read;
 mod reconstruct;

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -34,14 +34,18 @@ pub(crate) use dispatch_shims::*;
 pub(crate) use graph::explain;
 pub(crate) use io::blame;
 pub(crate) use io::context;
+pub(crate) use io::diff;
+pub(crate) use io::drift;
 pub(crate) use io::read;
 pub(crate) use review::ci;
+pub(crate) use search::gather;
+pub(crate) use search::onboard;
+pub(crate) use search::scout;
 pub(crate) use train::task;
 
 // -- search --
 pub(crate) use search::build_gather_output;
 pub(crate) use search::build_related_output;
-pub(crate) use search::build_scout_output;
 pub(crate) use search::build_where_output;
 pub(crate) use search::cmd_gather;
 pub(crate) use search::cmd_neighbors;

--- a/src/cli/commands/search/gather.rs
+++ b/src/cli/commands/search/gather.rs
@@ -5,12 +5,137 @@
 use anyhow::Result;
 use colored::Colorize;
 
+use cqs::index::VectorIndex;
+use cqs::reference::ReferenceIndex;
+use cqs::store::{ReadOnly, Store};
+use cqs::Embedder;
 use cqs::{
     gather, gather_cross_index_with_index, normalize_path, GatherDirection, GatherOptions,
     GatherResult,
 };
 
 use crate::cli::staleness;
+
+// ─── Args (surface-agnostic, MCP-ready) ─────────────────────────────────────
+
+/// Input for [`gather_core`] — the gather knobs both the CLI and a future MCP
+/// `gather` tool deserialize into. Store/embedder/root and the resolved
+/// reference index come from the adapter (reference resolution differs by
+/// surface); these are the request-shaped settings.
+///
+/// `#[serde(default)]` so a wire caller can supply just `query` and inherit the
+/// production defaults (depth/direction/limit mirror clap).
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(default)]
+pub(crate) struct GatherArgs {
+    /// Search query / question.
+    pub query: String,
+    /// Call-graph BFS depth for expansion (clamped 0..=5).
+    pub depth: usize,
+    /// Expansion direction: both / callers / callees.
+    pub direction: GatherDirection,
+    /// Max seed chunks before expansion (clamped 1..=100).
+    pub limit: usize,
+    /// Token budget — when set, packs chunks into the budget.
+    pub tokens: Option<usize>,
+    /// Per-result JSON overhead the token packer charges (the CLI sets this to
+    /// the per-result envelope cost under `--json`, 0 for text; a wire caller
+    /// that always serializes should set the constant). `#[serde(default)]` 0.
+    pub json_overhead: usize,
+}
+
+impl Default for GatherArgs {
+    fn default() -> Self {
+        GatherArgs {
+            query: String::new(),
+            // Mirrors clap: DEFAULT_DEPTH_BLAST = 1, direction = both,
+            // LimitArg default = 5.
+            depth: crate::cli::args::DEFAULT_DEPTH_BLAST,
+            direction: GatherDirection::Both,
+            limit: 5,
+            tokens: None,
+            json_overhead: 0,
+        }
+    }
+}
+
+// ─── Core ───────────────────────────────────────────────────────────────────
+
+/// Surface-agnostic core for `cqs gather`. Runs the gather lib primitive
+/// (project, or cross-index when `ref_idx` is `Some`), then applies the shared
+/// token-budget packing + reading-order re-sort. Returns the assembled
+/// [`GatherResult`] plus `(used, budget)` token accounting; the adapter renders
+/// text/JSON and owns staleness warnings. Reads no env — the
+/// `json_overhead` and reference resolution arrive via `args` / parameters.
+///
+/// Unifying the packing here gives the daemon the same reading-order re-sort
+/// the CLI always had (previously the daemon left packed chunks in score order).
+pub(crate) fn gather_core(
+    store: &Store<ReadOnly>,
+    embedder: &Embedder,
+    root: &std::path::Path,
+    args: &GatherArgs,
+    ref_idx: Option<&ReferenceIndex>,
+    project_index: Option<&dyn VectorIndex>,
+) -> Result<(GatherResult, Option<(usize, usize)>)> {
+    let _span = tracing::info_span!("gather_core", query_len = args.query.len()).entered();
+
+    // When token-budgeted, fetch more seeds than the limit so the packer has
+    // candidates to choose from.
+    let fetch_limit = if args.tokens.is_some() {
+        args.limit.clamp(1, 100).max(50)
+    } else {
+        args.limit.clamp(1, 100)
+    };
+
+    let opts = GatherOptions {
+        expand_depth: args.depth.clamp(0, 5),
+        direction: args.direction,
+        limit: fetch_limit,
+        ..GatherOptions::default()
+    };
+
+    let mut result = if let Some(ref_idx) = ref_idx {
+        let query_embedding = embedder.embed_query(&args.query)?;
+        gather_cross_index_with_index(
+            store,
+            ref_idx,
+            &query_embedding,
+            &args.query,
+            &opts,
+            root,
+            project_index,
+        )?
+    } else {
+        gather(store, embedder, &args.query, &opts, root)?
+    };
+
+    let token_info = if let Some(budget) = args.tokens {
+        let chunks = std::mem::take(&mut result.chunks);
+        let (mut packed, used) =
+            crate::cli::commands::pack_gather_chunks(chunks, embedder, budget, args.json_overhead);
+
+        // Re-sort to reading order (ref first, then project, each in
+        // file/line order) so chained reads are coherent.
+        packed.sort_by(|a, b| {
+            let source_ord = match (&a.source, &b.source) {
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                _ => std::cmp::Ordering::Equal,
+            };
+            source_ord
+                .then(a.file.cmp(&b.file))
+                .then(a.line_start.cmp(&b.line_start))
+                .then(a.name.cmp(&b.name))
+        });
+        result.chunks = packed;
+        Some((used, budget))
+    } else {
+        None
+    };
+
+    Ok((result, token_info))
+}
 
 // ─── Output types ──────────────────────────────────────────────────────────
 
@@ -121,66 +246,38 @@ pub(crate) fn cmd_gather(gctx: &GatherContext<'_>) -> Result<()> {
     let cqs_dir = &ctx.cqs_dir;
     let embedder = ctx.embedder()?;
 
-    // When token-budgeted, fetch more chunks than limit so we have candidates to pack
-    let fetch_limit = if max_tokens.is_some() {
-        limit.max(50) // Fetch at least 50 candidates for token packing
+    let json_overhead = if json {
+        crate::cli::commands::JSON_OVERHEAD_PER_RESULT
     } else {
-        limit
+        0
     };
-
-    let opts = GatherOptions {
-        expand_depth: expand.clamp(0, 5),
+    let args = GatherArgs {
+        query: query.to_string(),
+        depth: expand,
         direction,
-        limit: fetch_limit,
-        ..GatherOptions::default()
+        limit,
+        tokens: max_tokens,
+        json_overhead,
     };
 
-    // Cross-index gather: seed from reference, bridge into project code
-    let mut result = if let Some(rn) = ref_name {
-        let query_embedding = embedder.embed_query(query)?;
+    // Resolve the reference index + project vector index for cross-index
+    // gather (CLI-side resolution; the daemon resolves its own), then drive
+    // the shared core.
+    let (result, token_info) = if let Some(rn) = ref_name {
         let ref_idx = crate::cli::commands::resolve::find_reference(root, rn)?;
         let index = crate::cli::build_vector_index(store, cqs_dir)?;
-        gather_cross_index_with_index(
+        gather_core(
             store,
-            &ref_idx,
-            &query_embedding,
-            query,
-            &opts,
+            embedder,
             root,
+            &args,
+            Some(&ref_idx),
             index.as_deref(),
         )?
     } else {
-        gather(store, embedder, query, &opts, root)?
+        gather_core(store, embedder, root, &args, None, None)?
     };
-
-    // Token-budgeted packing: keep highest-scoring chunks within token budget
-    let token_count_used = if let Some(budget) = max_tokens {
-        let overhead = if json {
-            crate::cli::commands::JSON_OVERHEAD_PER_RESULT
-        } else {
-            0
-        };
-        let chunks = std::mem::take(&mut result.chunks);
-        let (mut packed, used) =
-            crate::cli::commands::pack_gather_chunks(chunks, embedder, budget, overhead);
-
-        // Re-sort to reading order (ref first, then project, each in file/line order)
-        packed.sort_by(|a, b| {
-            let source_ord = match (&a.source, &b.source) {
-                (Some(_), None) => std::cmp::Ordering::Less,
-                (None, Some(_)) => std::cmp::Ordering::Greater,
-                _ => std::cmp::Ordering::Equal,
-            };
-            source_ord
-                .then(a.file.cmp(&b.file))
-                .then(a.line_start.cmp(&b.line_start))
-                .then(a.name.cmp(&b.name))
-        });
-        result.chunks = packed;
-        Some(used)
-    } else {
-        None
-    };
+    let token_count_used = token_info.map(|(used, _)| used);
 
     // Proactive staleness warning (only for project chunks)
     if !ctx.cli.quiet && !ctx.cli.no_stale_check && !result.chunks.is_empty() {
@@ -294,6 +391,50 @@ pub(crate) fn cmd_gather(gctx: &GatherContext<'_>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A wire/MCP caller can supply only `query` and inherit defaults.
+    #[test]
+    fn gather_args_deserialize_minimal() {
+        let args: GatherArgs = serde_json::from_str(r#"{"query": "search path"}"#).unwrap();
+        assert_eq!(args.query, "search path");
+        assert_eq!(args.depth, 1);
+        assert_eq!(args.direction, GatherDirection::Both);
+        assert_eq!(args.limit, 5);
+        assert!(args.tokens.is_none());
+        assert_eq!(args.json_overhead, 0);
+    }
+
+    /// `GatherArgs::default` must match the clap `GatherArgs` defaults.
+    /// Parses `cqs gather <query>` via a throwaway `clap::Parser` wrapper.
+    #[test]
+    fn gather_args_default_matches_clap_defaults() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Wrap {
+            #[command(flatten)]
+            args: crate::cli::args::GatherArgs,
+        }
+
+        let clap_args = Wrap::try_parse_from(["cqs-gather", "q"]).unwrap().args;
+        let core = GatherArgs {
+            query: clap_args.query.clone(),
+            depth: clap_args.depth,
+            direction: clap_args.direction,
+            limit: clap_args.limit_arg.limit,
+            tokens: clap_args.tokens,
+            // json_overhead is an adapter-resolved field, not a clap flag.
+            json_overhead: 0,
+        };
+        let expected = GatherArgs {
+            query: "q".to_string(),
+            ..GatherArgs::default()
+        };
+        assert_eq!(
+            core, expected,
+            "clap gather defaults drifted from GatherArgs::default — update both together"
+        );
+    }
 
     fn make_result(chunks: Vec<cqs::GatheredChunk>) -> GatherResult {
         GatherResult {

--- a/src/cli/commands/search/mod.rs
+++ b/src/cli/commands/search/mod.rs
@@ -2,10 +2,10 @@
 
 pub(crate) mod gather;
 mod neighbors;
-mod onboard;
+pub(crate) mod onboard;
 pub(crate) mod query;
 mod related;
-mod scout;
+pub(crate) mod scout;
 pub(crate) mod search_ctx;
 mod similar;
 mod where_cmd;
@@ -15,6 +15,6 @@ pub(crate) use neighbors::cmd_neighbors;
 pub(crate) use onboard::cmd_onboard;
 pub(crate) use query::cmd_query;
 pub(crate) use related::{build_related_output, cmd_related};
-pub(crate) use scout::{build_scout_output, cmd_scout};
+pub(crate) use scout::cmd_scout;
 pub(crate) use similar::cmd_similar;
 pub(crate) use where_cmd::{build_where_output, cmd_where};

--- a/src/cli/commands/search/onboard.rs
+++ b/src/cli/commands/search/onboard.rs
@@ -1,9 +1,93 @@
 //! Onboard command — guided codebase tour for understanding a concept
+//!
+//! ## Command-core split (Phase 2b)
+//!
+//! [`onboard_core`] owns the surface-agnostic JSON assembly (run the `onboard`
+//! lib primitive, truncate to the limit, serialize, token-pack, trust-tag).
+//! Both the CLI ([`cmd_onboard`] JSON path) and the daemon (`dispatch_onboard`)
+//! drive it, so the wire shape is identical. The CLI text path keeps the raw
+//! [`cqs::OnboardResult`] for rendering.
 
 use anyhow::{Context, Result};
 use colored::Colorize;
 
 use cqs::onboard;
+use cqs::store::{ReadOnly, Store};
+use cqs::{Embedder, GatherDirection};
+
+// ─── Args (surface-agnostic, MCP-ready) ─────────────────────────────────────
+
+/// Input for [`onboard_core`] — the onboard knobs both the CLI and a future
+/// MCP `onboard` tool deserialize into. Store/embedder/root come from the
+/// adapter.
+///
+/// `#[serde(default)]` so a wire caller can supply just `query` and inherit the
+/// production defaults (depth/direction/limit mirror clap).
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(default)]
+pub(crate) struct OnboardArgs {
+    /// Concept or query to explore.
+    pub query: String,
+    /// Call-chain expansion depth (clamped 1..=5).
+    pub depth: usize,
+    /// Expansion direction: both / callers / callees.
+    pub direction: GatherDirection,
+    /// Cap on call_chain + callers + tests entries (entry_point always kept).
+    pub limit: usize,
+    /// Token budget — when set, packs chunk content into the budget.
+    pub tokens: Option<usize>,
+}
+
+impl Default for OnboardArgs {
+    fn default() -> Self {
+        OnboardArgs {
+            query: String::new(),
+            // Mirrors clap: DEFAULT_DEPTH_WALK = 3, direction = callees,
+            // LimitArg default = 5.
+            depth: crate::cli::args::DEFAULT_DEPTH_WALK,
+            direction: GatherDirection::Callees,
+            limit: 5,
+            tokens: None,
+        }
+    }
+}
+
+// ─── Core ───────────────────────────────────────────────────────────────────
+
+/// Surface-agnostic core for `cqs onboard` (JSON path). Runs the `onboard`
+/// lib primitive, truncates each section to the limit, then assembles the
+/// shared JSON (serialize → optional token-pack → trust-tag). Reads no env.
+/// Returns the assembled value; the CLI adapter renders text from the raw
+/// result instead.
+pub(crate) fn onboard_core(
+    store: &Store<ReadOnly>,
+    embedder: &Embedder,
+    root: &std::path::Path,
+    args: &OnboardArgs,
+) -> Result<serde_json::Value> {
+    let _span = tracing::info_span!("onboard_core", query = %args.query).entered();
+    let depth = args.depth.clamp(1, 5);
+    let limit = args.limit.clamp(1, 100);
+
+    let mut result = onboard(store, embedder, &args.query, root, depth, args.direction)?;
+    result.call_chain.truncate(limit);
+    result.callers.truncate(limit);
+    result.tests.truncate(limit);
+
+    let mut output = serde_json::to_value(&result).context("Failed to serialize onboard result")?;
+
+    if let Some(budget) = args.tokens {
+        let named_items = crate::cli::commands::onboard_scored_names(&result);
+        let (content_map, used) =
+            crate::cli::commands::fetch_and_pack_content(store, embedder, &named_items, budget);
+        crate::cli::commands::inject_content_into_onboard_json(&mut output, &content_map, &result);
+        crate::cli::commands::inject_token_info(&mut output, Some((used, budget)));
+    }
+
+    // Onboard only queries the project store — every chunk is user-code.
+    crate::cli::commands::tag_user_code_trust_level(&mut output);
+    Ok(output)
+}
 
 pub(crate) fn cmd_onboard(
     ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
@@ -26,6 +110,22 @@ pub(crate) fn cmd_onboard(
     let store = &ctx.store;
     let root = &ctx.root;
     let embedder = ctx.embedder()?;
+
+    // JSON path routes through the shared `onboard_core` (same code the daemon
+    // runs), so the wire shape is identical across surfaces.
+    if json {
+        let args = OnboardArgs {
+            query: concept.to_string(),
+            depth,
+            direction,
+            limit,
+            tokens: max_tokens,
+        };
+        let output = onboard_core(store, embedder, root, &args)?;
+        crate::cli::json_envelope::emit_json(&output)?;
+        return Ok(());
+    }
+
     let depth = depth.clamp(1, 5);
     // Cap on call_chain + callers + tests entries. Applied AFTER the
     // BFS+search so the entry_point is always preserved and so the order
@@ -37,28 +137,7 @@ pub(crate) fn cmd_onboard(
     result.callers.truncate(limit);
     result.tests.truncate(limit);
 
-    if json {
-        let mut output =
-            serde_json::to_value(&result).context("Failed to serialize onboard result")?;
-
-        // Token budgeting via shared helpers (same path as batch dispatch)
-        if let Some(budget) = max_tokens {
-            let named_items = crate::cli::commands::onboard_scored_names(&result);
-            let (content_map, used) =
-                crate::cli::commands::fetch_and_pack_content(store, embedder, &named_items, budget);
-            crate::cli::commands::inject_content_into_onboard_json(
-                &mut output,
-                &content_map,
-                &result,
-            );
-            crate::cli::commands::inject_token_info(&mut output, Some((used, budget)));
-        }
-
-        // Onboard only queries the project store — every chunk is user-code.
-        crate::cli::commands::tag_user_code_trust_level(&mut output);
-
-        crate::cli::json_envelope::emit_json(&output)?;
-    } else {
+    {
         // Text output
         println!(
             "{} {}",
@@ -184,5 +263,51 @@ fn print_entry(entry: &cqs::OnboardEntry, root: &std::path::Path) {
             );
         }
         println!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OnboardArgs;
+
+    /// A wire/MCP caller can supply only `query` and inherit defaults.
+    #[test]
+    fn onboard_args_deserialize_minimal() {
+        let args: OnboardArgs = serde_json::from_str(r#"{"query": "indexing"}"#).unwrap();
+        assert_eq!(args.query, "indexing");
+        assert_eq!(args.depth, 3);
+        assert_eq!(args.direction, cqs::GatherDirection::Callees);
+        assert_eq!(args.limit, 5);
+        assert!(args.tokens.is_none());
+    }
+
+    /// `OnboardArgs::default` must match the clap `OnboardArgs` defaults.
+    /// Parses `cqs onboard <query>` via a throwaway `clap::Parser` wrapper.
+    #[test]
+    fn onboard_args_default_matches_clap_defaults() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Wrap {
+            #[command(flatten)]
+            args: crate::cli::args::OnboardArgs,
+        }
+
+        let clap_args = Wrap::try_parse_from(["cqs-onboard", "q"]).unwrap().args;
+        let core = OnboardArgs {
+            query: clap_args.query.clone(),
+            depth: clap_args.depth,
+            direction: clap_args.direction,
+            limit: clap_args.limit_arg.limit,
+            tokens: clap_args.tokens,
+        };
+        let expected = OnboardArgs {
+            query: "q".to_string(),
+            ..OnboardArgs::default()
+        };
+        assert_eq!(
+            core, expected,
+            "clap onboard defaults drifted from OnboardArgs::default — update both together"
+        );
     }
 }

--- a/src/cli/commands/search/scout.rs
+++ b/src/cli/commands/search/scout.rs
@@ -9,6 +9,68 @@ use anyhow::Result;
 use colored::Colorize;
 
 use cqs::scout;
+use cqs::store::{ReadOnly, Store};
+use cqs::Embedder;
+
+// ─── Args (surface-agnostic, MCP-ready) ─────────────────────────────────────
+
+/// Input for [`scout_core`] — the scout knobs both the CLI and a future MCP
+/// `scout` tool deserialize into. The core takes the store/embedder/root from
+/// the adapter; these are the request-shaped settings.
+///
+/// `#[serde(default)]` so a wire caller can supply just `query` and inherit the
+/// production defaults (limit mirrors clap's `LimitArg`).
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(default)]
+pub(crate) struct ScoutArgs {
+    /// Search query to investigate.
+    pub query: String,
+    /// Max file groups to return (clamped to `SCOUT_LIMIT_MAX`).
+    pub limit: usize,
+    /// Token budget — when set, packs chunk content into the budget.
+    pub tokens: Option<usize>,
+}
+
+impl Default for ScoutArgs {
+    fn default() -> Self {
+        ScoutArgs {
+            query: String::new(),
+            // Mirrors clap `LimitArg` default (5).
+            limit: 5,
+            tokens: None,
+        }
+    }
+}
+
+// ─── Core ───────────────────────────────────────────────────────────────────
+
+/// Surface-agnostic core for `cqs scout` (JSON path). Runs the `scout` lib
+/// primitive, optionally token-packs chunk content, and assembles the shared
+/// JSON via [`build_scout_output`]. Returns the assembled `(value, token_info)`
+/// so the CLI adapter can also drive its text rendering; the daemon takes only
+/// the value. Reads no env (the limit clamp uses the `SCOUT_LIMIT_MAX` const).
+pub(crate) fn scout_core(
+    store: &Store<ReadOnly>,
+    embedder: &Embedder,
+    root: &std::path::Path,
+    args: &ScoutArgs,
+) -> Result<(serde_json::Value, Option<(usize, usize)>)> {
+    let _span = tracing::info_span!("scout_core", query = %args.query).entered();
+    let limit = args.limit.clamp(1, crate::cli::SCOUT_LIMIT_MAX);
+    let result = scout(store, embedder, &args.query, root, limit)?;
+
+    let (content_map, token_info) = if let Some(budget) = args.tokens {
+        let named_items = crate::cli::commands::scout_scored_names(&result);
+        let (cmap, used) =
+            crate::cli::commands::fetch_and_pack_content(store, embedder, &named_items, budget);
+        (Some(cmap), Some((used, budget)))
+    } else {
+        (None, None)
+    };
+
+    let output = build_scout_output(&result, content_map.as_ref(), token_info)?;
+    Ok((output, token_info))
+}
 
 /// Build the typed scout JSON object shared between CLI and batch.
 ///
@@ -49,8 +111,22 @@ pub(crate) fn cmd_scout(
     let store = &ctx.store;
     let root = &ctx.root;
     let embedder = ctx.embedder()?;
-    // Clamp via shared constant so CLI and batch return the same number of
-    // groups.
+
+    // JSON path routes through the shared `scout_core` (same code the daemon
+    // runs), so the wire shape is identical across surfaces.
+    if json {
+        let args = ScoutArgs {
+            query: task.to_string(),
+            limit,
+            tokens: max_tokens,
+        };
+        let (output, _token_info) = scout_core(store, embedder, root, &args)?;
+        crate::cli::json_envelope::emit_json(&output)?;
+        return Ok(());
+    }
+
+    // Text path keeps the raw `ScoutResult` for rendering. Clamp via the shared
+    // constant so it returns the same number of groups as the core.
     let limit = limit.clamp(1, crate::cli::SCOUT_LIMIT_MAX);
 
     let result = scout(store, embedder, task, root, limit)?;
@@ -65,10 +141,7 @@ pub(crate) fn cmd_scout(
         (None, None)
     };
 
-    if json {
-        let output = build_scout_output(&result, content_map.as_ref(), token_info)?;
-        crate::cli::json_envelope::emit_json(&output)?;
-    } else {
+    {
         let token_label = match token_info {
             Some((used, budget)) => format!(" ({} of {} tokens)", used, budget),
             None => String::new(),
@@ -186,6 +259,43 @@ pub(crate) fn cmd_scout(
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+
+    /// A wire/MCP caller can supply only `query` and inherit defaults.
+    #[test]
+    fn scout_args_deserialize_minimal() {
+        let args: super::ScoutArgs = serde_json::from_str(r#"{"query": "auth flow"}"#).unwrap();
+        assert_eq!(args.query, "auth flow");
+        assert_eq!(args.limit, 5);
+        assert!(args.tokens.is_none());
+    }
+
+    /// `ScoutArgs::default` must match the clap `ScoutArgs` defaults exactly.
+    /// Parses `cqs scout <query>` via a throwaway `clap::Parser` wrapper.
+    #[test]
+    fn scout_args_default_matches_clap_defaults() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Wrap {
+            #[command(flatten)]
+            args: crate::cli::args::ScoutArgs,
+        }
+
+        let clap_args = Wrap::try_parse_from(["cqs-scout", "q"]).unwrap().args;
+        let core = super::ScoutArgs {
+            query: clap_args.query.clone(),
+            limit: clap_args.limit_arg.limit,
+            tokens: clap_args.tokens,
+        };
+        let expected = super::ScoutArgs {
+            query: "q".to_string(),
+            ..super::ScoutArgs::default()
+        };
+        assert_eq!(
+            core, expected,
+            "clap scout defaults drifted from ScoutArgs::default — update both together"
+        );
+    }
 
     // ===== inject_content_into_scout_json tests =====
 

--- a/src/gather.rs
+++ b/src/gather.rs
@@ -200,7 +200,9 @@ impl Default for GatherOptions {
 }
 
 /// Direction of call graph expansion
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, clap::ValueEnum)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, clap::ValueEnum,
+)]
 pub enum GatherDirection {
     Both,
     Callers,


### PR DESCRIPTION
Phase 2b-io of docs/plans/2026-06-10-command-core-unification.md — closes phase 2 except two honestly-deferred commands.

## Per-command

| Command | Disposition |
|---|---|
| diff, drift, scout, onboard, gather, context, blame | cored + daemon-routed (thin adapters, parity by construction; context additionally pinned by two byte-equal parity tests) |
| brief, reconstruct | typed-output-only (no daemon path; display-oriented) |
| read, notes | **deferred** — CLI/daemon schemas diverge in both directions; needs a union-schema decision as its own PR (documented in the plan) |

## Daemon deltas (all consumer-surveyed by the reviewer, independently)

- context full-mode converges on the CLI FullOutput shape — the only real consumer (.claude/hooks/pre-edit-context.py) reads fields present in the new shape and gains external_callers on the daemon path
- gather daemon gains the CLI reading-order re-sort + token-mode over-fetch; no order-dependent consumer exists
- drift chunk_type via Display — verified byte-identical to the old serde lowercase rename for every variant
- diff/drift text paths slash-normalized (JSON unchanged)

## Gates

- Eval-reachable source untouched (sole lib change: additive Deserialize derive on GatherDirection)
- Paired v3 evals: test .459/.743/.862, dev .514/.817/.927 — above band due to a (procedurally unnecessary, course-corrected mid-flight) force-reindex realigning fixture line anchors; gate (a) source-identity is the binding check
- Review: ship, zero blocking findings; 76 targeted + parity tests green; build/clippy/fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
