### PR TITLE
refactor(review,train): final command cores + dead posture plumbing removed (phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Command-core unification for review/train/eval commands (Phase 4, final
+  implementation phase, internal).** The review group gained surface-agnostic
+  cores routed by both surfaces where a dispatcher exists: `dead`
+  (`dead_core`), `health` (`health_core`), `suggest` (`suggest_core`), `review`
+  (`review_core`), `ci` (`ci_core`), plus a CLI-only-but-daemon-ready
+  `affected` (`affected_core`). The train group cored its two genuine pure
+  queries — `plan` (`plan_core`) and `task` (the shared `task_json_core`
+  projection both surfaces now drive) — while the orchestration commands
+  (`train-data`, `train-pairs`, `export-model`) stay adapter-owned (git / file
+  / subprocess pipelines). `eval` was already conformant (`EvalReport` is the
+  typed output, `EvalArgs` the typed input; `runner.rs` matcher/scoring is
+  eval-reachable and untouched). Each cored daemon command is pinned by a
+  parity test asserting the dispatcher is byte-equal to the core output.
+  **Additive JSON:** the daemon `review` empty-diff case now emits the full
+  CLI shape (`relevant_notes`, `stale_warning`) instead of the old
+  four-field hand-rolled object. **Field rename (daemon only):** the daemon
+  `suggest` path now emits `count` (matching the CLI's typed `SuggestOutput`)
+  instead of the old `total`; per-entry shape unchanged. `review`/`ci` token
+  telemetry (`token_count`/`token_budget`) is now skip-when-absent on both
+  surfaces. Agents parsing daemon `suggest`/`review` output should read `count`
+  and the full review shape.
+- **Dead `_with_posture` emit plumbing removed (campaign-closing cleanup).**
+  `emit_json_with_posture` / `emit_json_error_with_posture` in
+  `json_envelope.rs` had zero callers (carried under `#[allow(dead_code)]`).
+  With the core/adapter split complete, adapters are the only JSON emit sites
+  and they resolve posture through the OnceLock-cached `Posture::current()` in
+  `emit_json` — wiring an explicit posture through every adapter would add
+  indirection with no behavior change. The two functions are deleted; the live
+  posture-threaded variants (`Envelope::ok_with_posture`/`err_with_posture`,
+  `wrap_value_with_posture`, `emit_json_error_with_data_and_posture`) stay.
+  The `CQS_ULTRASECURITY` env knob is untouched here (its removal is tracked
+  separately in #1690).
+
 - **Command-core unification for infra/index commands (Phase 3, internal).**
   The infra and index command groups now carry surface-agnostic cores and/or
   typed output structs that are the single JSON-schema source. Read-query

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -214,7 +214,7 @@ Daemon hot path has no per-response size cap; `try_kind_fallback` echoes full ch
 | ID(s) | Title | Effort | Status |
 |---|---|---|---|
 | CQ-V1.40-7 + RM-V1.40-8 + PERF-V1.40-3 + PERF-V1.40-4 | Posture/OutputFormat/SPLADE-α/CAGRA-cap env reads per emit/encode/search — `OnceLock`/`LazyLock` cache (Cluster B sibling) | easy | ✅ Cluster B PR |
-| CQ-V1.40-5 + CQ-V1.40-6 | SNR Phase 1 `_with_posture` plumbing dead — every CLI caller still hits env-reading shim; `emit_json_with_posture` `#[allow(dead_code)]` | easy-medium | TODO (Cluster B follow-up) |
+| CQ-V1.40-5 + CQ-V1.40-6 | SNR Phase 1 `_with_posture` plumbing dead — every CLI caller still hits env-reading shim; `emit_json_with_posture` `#[allow(dead_code)]` | easy-medium | ✅ campaign phase 4 — dead plumbing deleted (OnceLock-cached shim is the design; wiring would add indirection for byte-identical output) |
 | RM-V1.40-9 + PERF-V1.40-5 + RM-V1.40-10 | Daemon socket triple payload allocation (Vec → Value → String); `emit_json` double serialization (`to_value` then `to_string_pretty`) — land `dispatch_value` refactor; refactor `format_envelope_to_string` to `&impl Serialize` | medium | TODO |
 | PERF-V1.40-1 + RB-V1.40-4 + EH-V1.40-10 + DS-V1.40-6 + CQ-V1.40-10 | `filter_invoked_macros` N+1 SQL with leading-`%` LIKE (full table scan × N macros) + no transaction — batch into single scan inside read tx (lands with Cluster A correctness fix) | medium | TODO (Cluster A2) |
 

--- a/docs/plans/2026-06-10-command-core-unification.md
+++ b/docs/plans/2026-06-10-command-core-unification.md
@@ -1,6 +1,9 @@
 # Command-Core Unification (agentic navigability refactor)
 
-Status: **Phase 0 in flight** — update the per-phase checkboxes as work lands; this doc is the resume point if the session dies.
+Status: **Implementation phases complete (0–4 landed 2026-06-10).** Only the
+post-campaign docs truth sweep remains. See "Campaign status (phases 0–4)" and
+the "Post-campaign deferred ledger" near the bottom for the full state. This
+doc is the resume point if the session dies.
 
 ## Motivation (evidence, 2026-06-09/10)
 
@@ -277,11 +280,122 @@ Order: callers, callees (same file), deps, test_map, trace, impact (hardest: con
 - Gate: full suite + `/cqs-verify` pass.
 
 ### Phase 4 — review/train/eval commands + sweep
-- [ ] Remaining commands; delete any now-unused `json: bool` plumbing and posture shims that became adapter-only (revisit CQ-V1.40-5/6 `_with_posture` here: adapters become the only emit sites — wire or delete)
-- [ ] Final: grep for `dispatch_.*{` bodies >20 lines (should be none); grep inline `serde_json::json!({` in command code (should be near-zero outside adapters)
+**Landed 2026-06-10 (branch `refactor/command-cores-phase4`).** This closes the
+implementation phases of the campaign.
+- [x] **review group** — cores + typed Args/Output, daemon adapters + parity:
+  - `dead` (`dead_core` + `DeadArgs`): both surfaces route through it; daemon
+    `dispatch_dead` reduced to a 6-line adapter. `DeadArgs` derives
+    `Deserialize` with a local `de_confidence` helper so the lib enum
+    `DeadConfidence` stays `Serialize`-only (no eval-reachable source touched).
+  - `health` (`health_core` + `HealthArgs`): adapter owns file enumeration
+    (CLI builds the set via `enumerate_for_health`; daemon passes its cached
+    `file_set`), mirroring the `stale_core` split. `dispatch_health` routes
+    through the core.
+  - `suggest` (`suggest_core` + `SuggestArgs`): read side cored; the `--apply`
+    write stays CLI-only (writable store). **Daemon schema converged onto the
+    CLI's typed `SuggestOutput` — `count` replaces the old `total`.**
+  - `review` (`review_core` + `ReviewArgs` + `ReviewOutput`): flattens the lib
+    `ReviewResult` + optional `token_count`/`token_budget`. CLI JSON + daemon
+    drive the core; CLI text keeps its `json=false` budgeting + dashboard. The
+    daemon empty-diff case now emits the full CLI shape (additive
+    `relevant_notes`/`stale_warning`). Deleted dead `apply_token_budget_public`
+    + `empty_review_json`.
+  - `ci` (`ci_core` + `CiArgs` + `CiOutput`): flattens the lib `CiReport` +
+    token telemetry. CLI JSON + daemon drive the core; the gate-failure
+    `process::exit` stays adapter-owned (the core only reports `gate.passed`).
+    Deleted dead `apply_ci_token_budget`.
+  - `affected` (`affected_core` + `AffectedArgs` + `AffectedOutput`): CLI-only
+    today (no dispatcher) but daemon-ready by construction. `AffectedOutput` is
+    a thin `Serialize` newtype over the lib-owned `diff_impact_to_json`
+    projection + the command-specific `overall_risk` field.
+  - Parity tests (`analysis::parity_tests`): `parity_dead_dispatch_equals_core`,
+    `parity_health_dispatch_equals_core`, `parity_suggest_dispatch_equals_core`
+    (byte-equal daemon vs core; suggest test also guards `count`-not-`total`).
+    `review`/`ci` acquire their diff via `run_git_diff` (needs a real repo
+    diff), so their core-equivalence is pinned at the core level via
+    `review_core_empty_diff_converged_shape` / `ci_core_empty_diff_shape`; the
+    dispatchers are parity-by-construction (they call the core with
+    `run_git_diff` output then `to_value`). Per-Args minimal-deserialize tests
+    added for Dead/Review/Ci/Plan.
+- [x] **train group** — orchestration-heavy → typed-output-only for most;
+  cored the genuine pure queries:
+  - `plan` (`plan_core` + `PlanArgs` + `PlanOutput`): pure read query (store +
+    embedder), dual-surface; `dispatch_plan` routes through it.
+  - `task` (`task_json_core`): the genuinely-shared JSON projection (waterfall
+    budget when `--tokens`, else full serialize) both surfaces previously
+    duplicated as an inline `if tokens { … } else { … }` branch. Resource
+    *provisioning* stays per-surface (CLI `task()` builds resources internally;
+    daemon `task_with_resources()` injects cached `graph`/`test_chunks` for
+    perf — the same per-surface split the plan blessed for `stale_core`).
+  - `train-data`, `train-pairs`, `export-model`: left adapter-owned — git
+    history walk / JSONL file writer / `optimum.exporters.onnx` subprocess.
+    Not pure queries; cores would force side effects into a "core".
+- [x] **eval command adapter** — already conformant: `EvalReport` (runner.rs)
+  is the typed Output serialized via `emit_json`; `EvalArgs` (`clap::Args`) is
+  the typed input; the error path uses `emit_json_error`. `runner.rs`
+  matcher/scoring is eval-reachable and was **not** touched (verified
+  byte-identical in the diff).
+- [x] **`_with_posture` wire-or-delete → DELETE.** `emit_json_with_posture` /
+  `emit_json_error_with_posture` had zero callers (`#[allow(dead_code)]`).
+  Decision: **delete**, per the plan's stated preference ("delete preferred if
+  wiring adds indirection without behavior"). Justification: `Posture::current()`
+  is `OnceLock`-cached and read once cheaply inside `emit_json`; the daemon-flip
+  risk is already foreclosed by the cache pinning the posture for the process
+  lifetime. Wiring an explicit `Posture` through every review/train/eval adapter
+  would thread a value purely to call a variant that produces **byte-identical**
+  output to what `emit_json` already emits — pure indirection, zero behavior
+  change. The live posture-threaded variants that DO have callers
+  (`Envelope::ok_with_posture`/`err_with_posture`, `wrap_value_with_posture`,
+  `emit_json_error_with_data_and_posture`, used by the batch JSONL surface)
+  stay. The `CQS_ULTRASECURITY` env knob is left intact (its deletion is #1690's
+  own PR). Closes CQ-V1.40-5/6.
+- [x] Final greps: no Phase-4-touched `dispatch_*` carries duplicated business
+  logic (dead/health/review/ci/plan/task are all thin adapters now; the
+  remaining >20-line dispatchers are doc-comment-heavy adapters or Phase-2b
+  deferrals like `dispatch_notes`/`dispatch_gather`). Inline `serde_json::json!`
+  in review/train command code is test fixtures + the documented lib-owned
+  `affected` projection boundary only.
+- Gate: build + clippy + fmt clean; targeted review/train/eval + 5 new parity
+  tests green. **Eval-reachable source byte-identical** — the diff is confined
+  to `src/cli/commands/{review,train}/`, `src/cli/batch/handlers/{analysis,misc}.rs`,
+  the two mod re-export files, and `src/cli/json_envelope.rs`. Paired v3 eval
+  run **provably skipped**: no eval-reachable dir
+  (search/store/pipeline/splade/hnsw/embedder/eval) appears in the diff, so
+  retrieval cannot move (amended Phase-2/3 gate).
+
+### Campaign status (phases 0–4)
+- **Phase 0** — ✅ merged (`fix/kind-fallback-cap-parity`). Cap parity + helper hoist.
+- **Phase 1** — ✅ merged. 6 graph commands × 2 surfaces cored.
+- **Phase 2a** — ✅ merged. Search core (`query_core`) + request-scoped config pattern.
+- **Phase 2b** — ✅ landed (`refactor/command-cores-io` + search-half). io commands + daemon `dispatch_search` → `query_core` + schema reconciliation.
+- **Phase 3** — ✅ landed (`refactor/command-cores-infra`). infra/index commands.
+- **Phase 4** — ✅ landed (`refactor/command-cores-phase4`, this entry). review/train/eval + `_with_posture` delete. **Implementation phases complete.**
+- **Post-campaign docs truth sweep** — ⏳ pending (see below).
+
+## Post-campaign deferred ledger
+
+Consolidated list of every deferral made across the campaign, with its reason
+and tracking. None block the campaign's structural goal (one core per behavior,
+one schema per command); each is a deliberate scope boundary.
+
+| Item | Phase | Reason deferred | Tracking |
+|------|-------|-----------------|----------|
+| `read` full/focused union-schema | 2b | Daemon emits `notes_injected`+`trust_level` the CLI omits; CLI focused emits `injection_flags` the daemon omits; daemon does vendored-path detection the CLI doesn't. Needs a union-schema decision (which fields win) — its own schema-change PR. | dedicated schema PR |
+| `notes` list union-schema | 2b | CLI list reads `docs/notes.toml` (emits `id`+`type`); daemon reads store-cached notes (emits `sentiment_label`, no shared `id`). A surface-agnostic core needs a unified data source + union schema first. | dedicated schema PR |
+| `brief`, `reconstruct` cores | 2b | Single positional `path`, trivial display logic, no daemon path, no defaults to drift → a clap-pin would be vacuous. Typed `*Output` already present. | none (typed-output-only is correct) |
+| `--ref`/`--include-refs`/ref-name-only full core-extraction | 2b | Reference-index resolution needs config load + multi-store fan-out; doesn't fit the single-store `SearchCtx`. Both surfaces already serialize through the shared `SearchResultOutput` schema. | multi-store search-context abstraction (out of scope) |
+| `ping` / `status` shared core | 3 | CLI `cmd_ping`/`cmd_status` are *socket clients*; daemon `dispatch_ping`/`dispatch_status` are *server snapshots* (`PingResponse`/`WatchSnapshot` already shared schema). Not the same logic on two surfaces — no core to extract. | none (correct as-is) |
+| `gc` daemon path | 3 | `dispatch_gc` intentionally bails — a writable store can't be shared with the serving snapshot (typestate-enforced). No daemon adapter to wire. | none (correct as-is) |
+| `doctor`, `hook`, `umap`, `model swap`, `reference update` cores | 3 | Env/hardware probes, install orchestration, python subprocess, daemon-stop→reindex→restart, full enrichment pipeline respectively. Process/subprocess/multi-store side effects belong in adapters, not cores. Typed outputs already present where JSON is emitted. | none (typed-output-only / adapter-owned is correct) |
+| `index/build` line-266 reconcile early-return envelope | 3 | Hand-rolls the full `{data,version,error}` wrapper for a special-case return; left as-is to bound risk on the index adapter. | low-value typed-shape cleanup |
+| `train-data`/`train-pairs`/`export-model` cores | 4 | Git-history walk / JSONL file writer / `optimum` subprocess — orchestration, not pure queries. | none (adapter-owned is correct) |
+| `CQS_ULTRASECURITY` env knob removal | 4 | Confirmed for deletion but owned by #1690's own PR; not removed here to keep this diff scoped. | #1690 |
+| Docs truth sweep | post | `/docs-review` across README/CONTRIBUTING/SECURITY/PRIVACY/lib.rs/Cargo.toml + repo description for campaign-stale claims and legacy references. | post-campaign docs PR |
+
 - Gate: full suite, eval paired check, `cqs health` no new dead code, CHANGELOG.
 
 ### Post-campaign — docs truth sweep
+Reviewer-supplied hunts (phase-4 review): (1) audit-triage CQ-V1.40-5/6 marked resolved — verify nothing else in that doc claims _with_posture is pending; (2) docs/audit-findings-v1.15.1.md:379 describes daemon suggest `total` — historical doc, flag as frozen-not-current; (3) pin the exact eval-runner path (src/cli/commands/eval/runner.rs vs src/eval/) wherever "eval-reachable" is defined; (4) confirm the plan's phase-status lines reflect merged state, not working-tree state.
 - [ ] Run `/docs-review` across README, CONTRIBUTING, SECURITY, PRIVACY, lib.rs docs, Cargo.toml metadata, and the GitHub repo description — hunting "tiny lies" (claims the campaign made stale: command behavior, JSON shapes, env knobs incl. the #1690 CQS_ULTRASECURITY deletion) and legacy references (removed helpers, old dispatch names, pre-core architecture descriptions in CONTRIBUTING's Architecture Overview)
 - [ ] Fix drift in one docs PR; docs-lying-is-P1 severity applies
 

--- a/src/cli/batch/handlers/analysis.rs
+++ b/src/cli/batch/handlers/analysis.rs
@@ -27,22 +27,15 @@ pub(in crate::cli::batch) fn dispatch_dead(
     ctx: &BatchView,
     args: &DeadArgs,
 ) -> Result<serde_json::Value> {
-    let include_pub = args.include_pub;
-    let min_confidence = &args.min_confidence;
     let _span = tracing::info_span!("batch_dead").entered();
 
-    let (confident, possibly_pub) = ctx.store().find_dead_code(include_pub)?;
-
-    let confident: Vec<_> = confident
-        .into_iter()
-        .filter(|d| d.confidence >= *min_confidence)
-        .collect();
-    let possibly_pub: Vec<_> = possibly_pub
-        .into_iter()
-        .filter(|d| d.confidence >= *min_confidence)
-        .collect();
-
-    let output = crate::cli::commands::build_dead_output(&confident, &possibly_pub, &ctx.root);
+    // Thin adapter over the shared `dead_core` — identical JSON shape across
+    // the CLI and daemon surfaces.
+    let core_args = crate::cli::commands::DeadArgs {
+        include_pub: args.include_pub,
+        min_confidence: args.min_confidence,
+    };
+    let output = crate::cli::commands::dead_core(&ctx.store(), &ctx.root, &core_args)?;
     Ok(serde_json::to_value(&output)?)
 }
 
@@ -102,9 +95,15 @@ pub(in crate::cli::batch) fn dispatch_health(ctx: &BatchView) -> Result<serde_js
     let _span = tracing::info_span!("batch_health").entered();
 
     // `Arc<HashSet>` auto-derefs through `&file_set` for the borrowed-only
-    // callee.
+    // callee. Thin adapter over the shared `health_core`.
     let file_set = ctx.file_set()?;
-    let report = cqs::health::health_check(&ctx.store(), &file_set, &ctx.cqs_dir, &ctx.root)?;
+    let report = crate::cli::commands::health_core(
+        &ctx.store(),
+        &file_set,
+        &ctx.cqs_dir,
+        &ctx.root,
+        &crate::cli::commands::HealthArgs::default(),
+    )?;
 
     Ok(serde_json::to_value(&report)?)
 }
@@ -134,25 +133,15 @@ pub(in crate::cli::batch) fn dispatch_suggest(
         );
     }
 
-    let suggestions = cqs::suggest::suggest_notes(&ctx.store(), &ctx.root)?;
-
-    let json_val: Vec<_> = suggestions
-        .iter()
-        .map(|s| {
-            serde_json::json!({
-                "text": s.text,
-                "sentiment": s.sentiment,
-                "mentions": s.mentions,
-                "reason": s.reason,
-            })
-        })
-        .collect();
-
-    Ok(serde_json::json!({
-        "suggestions": json_val,
-        "total": suggestions.len(),
-        "applied": false,
-    }))
+    // Thin adapter over the shared `suggest_core` — converges the daemon JSON
+    // onto the CLI's typed `SuggestOutput` schema (`count` replaces the old
+    // `total`; per-entry shape unchanged).
+    let output = crate::cli::commands::suggest_core(
+        &ctx.store(),
+        &ctx.root,
+        &crate::cli::commands::SuggestArgs::default(),
+    )?;
+    Ok(serde_json::to_value(&output)?)
 }
 
 /// Runs a diff-aware review and returns results as JSON.
@@ -166,28 +155,16 @@ pub(in crate::cli::batch) fn dispatch_review(
     let tokens = args.tokens;
     let _span = tracing::info_span!("batch_review", ?base).entered();
 
+    // Thin adapter over the shared `review_core` — same schema + budgeting as
+    // the CLI JSON surface. Adapter owns diff I/O (git only, no stdin).
     let diff_text = crate::cli::commands::run_git_diff(base)?;
-    let result = cqs::review_diff(&ctx.store(), &diff_text, &ctx.root)?;
-
-    match result {
-        None => Ok(serde_json::json!({
-            "changed_functions": [],
-            "affected_callers": [],
-            "affected_tests": [],
-            "risk_summary": { "overall": "low", "high": 0, "medium": 0, "low": 0 },
-        })),
-        Some(mut review) => {
-            // Apply token budget if specified
-            if let Some(budget) = tokens {
-                crate::cli::commands::review::apply_token_budget_public(&mut review, budget, true);
-            }
-            let mut output: serde_json::Value = serde_json::to_value(&review)?;
-            if let Some(budget) = tokens {
-                output["token_budget"] = serde_json::json!(budget);
-            }
-            Ok(output)
-        }
-    }
+    let output = crate::cli::commands::review_core(
+        &ctx.store(),
+        &ctx.root,
+        &diff_text,
+        &crate::cli::commands::ReviewArgs { tokens },
+    )?;
+    Ok(serde_json::to_value(&output)?)
 }
 
 /// Runs CI analysis (review + dead code + gate) and returns results as JSON.
@@ -198,21 +175,229 @@ pub(in crate::cli::batch) fn dispatch_ci(
     args: &CiArgs,
 ) -> Result<serde_json::Value> {
     let base = args.base.as_deref();
-    let gate = &args.gate;
+    let gate = args.gate;
     let tokens = args.tokens;
     let _span = tracing::info_span!("batch_ci", ?gate).entered();
 
+    // Thin adapter over the shared `ci_core` — same schema + budgeting as the
+    // CLI JSON surface. Gate failure is reported in the JSON (no exit) because
+    // the batch session must continue. Adapter owns diff I/O (git only).
     let diff_text = crate::cli::commands::run_git_diff(base)?;
-    let mut report = cqs::ci::run_ci_analysis(&ctx.store(), &diff_text, &ctx.root, *gate)?;
+    let output = crate::cli::commands::ci_core(
+        &ctx.store(),
+        &ctx.root,
+        &diff_text,
+        gate,
+        &crate::cli::commands::CiArgs { tokens },
+    )?;
+    Ok(serde_json::to_value(&output)?)
+}
 
-    // Apply token budget if specified
-    if let Some(budget) = tokens {
-        crate::cli::commands::ci::apply_ci_token_budget(&mut report.review, budget);
+// ---------------------------------------------------------------------------
+// Parity tests — each `dispatch_*` is a thin adapter over the shared `*_core`,
+// so the daemon JSON must be byte-equal to `serde_json::to_value(*_core(...))`
+// for the same inputs. dead/health/suggest are embedder-free and git-free
+// (they read the store directly), so the full dispatch path is exercised.
+// review/ci acquire their diff via `run_git_diff` (needs a real repo with a
+// diff), so their core-equivalence is asserted at the core level against the
+// empty-diff convergence shape; the dispatchers are parity-by-construction
+// (they literally call the core with `run_git_diff` output then `to_value`).
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod parity_tests {
+    use crate::cli::batch::create_test_context;
+    use cqs::embedder::Embedding;
+    use cqs::parser::{Chunk, ChunkType, Language};
+    use cqs::store::{DeadConfidence, ModelInfo, Store};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn make_chunk(id: &str, name: &str) -> Chunk {
+        let content = format!("fn {name}() {{ }}");
+        let content_hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+        Chunk {
+            id: id.to_string(),
+            file: PathBuf::from("src/lib.rs"),
+            language: Language::Rust,
+            chunk_type: ChunkType::Function,
+            name: name.to_string(),
+            signature: format!("fn {name}()"),
+            content,
+            doc: None,
+            line_start: 1,
+            line_end: 5,
+            content_hash,
+            canonical_hash: String::new(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        }
     }
 
-    let mut output: serde_json::Value = serde_json::to_value(&report)?;
-    if let Some(budget) = tokens {
-        output["token_budget"] = serde_json::json!(budget);
+    fn seed_minimal_ctx() -> (TempDir, crate::cli::batch::BatchContext) {
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+
+        let mut emb_vec = vec![0.0_f32; cqs::EMBEDDING_DIM];
+        emb_vec[0] = 1.0;
+        let embedding = Embedding::new(emb_vec);
+
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            let chunks = vec![(make_chunk("src/lib.rs:1:foo", "foo"), embedding)];
+            store.upsert_chunks_batch(&chunks, Some(0)).expect("upsert");
+        }
+        let ctx = create_test_context(&cqs_dir).expect("ctx");
+        (dir, ctx)
     }
-    Ok(output)
+
+    /// `dispatch_dead` is byte-equal to `serde_json::to_value(dead_core(...))`.
+    #[test]
+    fn parity_dead_dispatch_equals_core() {
+        let (_dir, ctx) = seed_minimal_ctx();
+        let view = ctx.build_view(None);
+
+        let core = crate::cli::commands::dead_core(
+            &view.store(),
+            &view.root,
+            &crate::cli::commands::DeadArgs {
+                include_pub: false,
+                min_confidence: DeadConfidence::Low,
+            },
+        )
+        .expect("dead_core");
+        let core_val = serde_json::to_value(&core).expect("serialize core");
+
+        let dispatched = super::dispatch_dead(
+            &view,
+            &crate::cli::args::DeadArgs {
+                include_pub: false,
+                min_confidence: DeadConfidence::Low,
+            },
+        )
+        .expect("dispatch_dead");
+
+        assert_eq!(dispatched, core_val, "dispatch_dead must equal dead_core");
+    }
+
+    /// `dispatch_health` is byte-equal to `serde_json::to_value(health_core(...))`.
+    #[test]
+    fn parity_health_dispatch_equals_core() {
+        let (_dir, ctx) = seed_minimal_ctx();
+        let view = ctx.build_view(None);
+
+        let file_set = view.file_set().expect("file_set");
+        let core = crate::cli::commands::health_core(
+            &view.store(),
+            &file_set,
+            &view.cqs_dir,
+            &view.root,
+            &crate::cli::commands::HealthArgs::default(),
+        )
+        .expect("health_core");
+        let core_val = serde_json::to_value(&core).expect("serialize core");
+
+        let dispatched = super::dispatch_health(&view).expect("dispatch_health");
+
+        assert_eq!(
+            dispatched, core_val,
+            "dispatch_health must equal health_core"
+        );
+    }
+
+    /// `dispatch_suggest` (apply=false) is byte-equal to
+    /// `serde_json::to_value(suggest_core(...))`. Pins the daemon-side schema
+    /// convergence (`count`, not the old `total`).
+    #[test]
+    fn parity_suggest_dispatch_equals_core() {
+        let (_dir, ctx) = seed_minimal_ctx();
+        let view = ctx.build_view(None);
+
+        let core = crate::cli::commands::suggest_core(
+            &view.store(),
+            &view.root,
+            &crate::cli::commands::SuggestArgs::default(),
+        )
+        .expect("suggest_core");
+        let core_val = serde_json::to_value(&core).expect("serialize core");
+
+        let dispatched =
+            super::dispatch_suggest(&view, &crate::cli::args::SuggestArgs { apply: false })
+                .expect("dispatch_suggest");
+
+        assert_eq!(
+            dispatched, core_val,
+            "dispatch_suggest must equal suggest_core (count, not total)"
+        );
+        // Explicit guard against the pre-unification `total` field re-appearing.
+        assert!(
+            dispatched.get("total").is_none(),
+            "daemon suggest must use `count`, not `total`: {dispatched}"
+        );
+        assert!(
+            dispatched.get("count").is_some(),
+            "daemon suggest must carry `count`: {dispatched}"
+        );
+    }
+
+    /// `review_core` on an empty diff produces the converged empty-review shape
+    /// (the daemon's old hand-rolled empty case omitted `relevant_notes` /
+    /// `stale_warning`; the core now emits the full CLI shape). `dispatch_review`
+    /// is parity-by-construction over `run_git_diff` + this core.
+    #[test]
+    fn review_core_empty_diff_converged_shape() {
+        let (_dir, ctx) = seed_minimal_ctx();
+        let view = ctx.build_view(None);
+
+        let out = crate::cli::commands::review_core(
+            &view.store(),
+            &view.root,
+            "",
+            &crate::cli::commands::ReviewArgs { tokens: None },
+        )
+        .expect("review_core");
+        let val = serde_json::to_value(&out).expect("serialize");
+
+        assert!(val.get("changed_functions").is_some());
+        assert!(val.get("affected_callers").is_some());
+        assert!(val.get("affected_tests").is_some());
+        assert!(
+            val.get("relevant_notes").is_some(),
+            "converged empty review carries relevant_notes: {val}"
+        );
+        assert_eq!(val["risk_summary"]["overall"], "low");
+        // No budget fields on the empty case even though they're optional.
+        assert!(val.get("token_count").is_none());
+        assert!(val.get("token_budget").is_none());
+    }
+
+    /// `ci_core` on an empty diff produces a gate-passing report with no budget
+    /// telemetry; `dispatch_ci` is parity-by-construction over `run_git_diff`.
+    #[test]
+    fn ci_core_empty_diff_shape() {
+        let (_dir, ctx) = seed_minimal_ctx();
+        let view = ctx.build_view(None);
+
+        let out = crate::cli::commands::ci_core(
+            &view.store(),
+            &view.root,
+            "",
+            cqs::ci::GateThreshold::High,
+            &crate::cli::commands::CiArgs { tokens: None },
+        )
+        .expect("ci_core");
+        let val = serde_json::to_value(&out).expect("serialize");
+
+        assert!(
+            val.get("review").is_some(),
+            "ci output carries review: {val}"
+        );
+        assert!(val.get("gate").is_some(), "ci output carries gate: {val}");
+        assert!(val.get("token_count").is_none());
+        assert!(val.get("token_budget").is_none());
+    }
 }

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -3,7 +3,7 @@
 //! Handlers take a single `&XArgs` argument so the macro-driven
 //! `BatchCmd::dispatch` calls every row uniformly.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 use super::super::commands::BatchInput;
 use super::super::BatchView;
@@ -199,14 +199,9 @@ pub(in crate::cli::batch) fn dispatch_task(
         &test_chunks,
     )?;
 
-    // Full waterfall budgeting (same as CLI) when --tokens is specified
-    let json = if let Some(budget) = tokens {
-        crate::cli::commands::task::task_to_budgeted_json(&result, embedder, budget)?
-    } else {
-        serde_json::to_value(&result)?
-    };
-
-    Ok(json)
+    // Shared projection: waterfall budgeting when `--tokens` is set, else full
+    // serialization. Identical to the CLI's non-brief JSON path.
+    crate::cli::commands::task::task_json_core(&result, embedder, tokens)
 }
 
 /// Performs a scout search query with optional token budget packing.
@@ -360,20 +355,15 @@ pub(in crate::cli::batch) fn dispatch_plan(
     let _span = tracing::info_span!("batch_plan", description).entered();
 
     let embedder = ctx.embedder()?;
-    let result = cqs::plan::plan(
-        &ctx.store(),
-        embedder,
-        description,
-        &ctx.root,
-        args.limit_arg.limit,
-    )
-    .context("Plan generation failed")?;
-
-    let mut json = serde_json::to_value(&result)?;
-    if let Some(budget) = tokens {
-        json["token_budget"] = serde_json::json!(budget);
-    }
-    Ok(json)
+    // Thin adapter over the shared `plan_core` — identical JSON shape across
+    // the CLI and daemon surfaces.
+    let core_args = crate::cli::commands::PlanArgs {
+        description: description.to_string(),
+        limit: args.limit_arg.limit,
+        tokens,
+    };
+    let output = crate::cli::commands::plan_core(&ctx.store(), embedder, &ctx.root, &core_args)?;
+    Ok(serde_json::to_value(&output)?)
 }
 
 /// Runs garbage collection on the index.

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -37,7 +37,6 @@ pub(crate) use io::context;
 pub(crate) use io::diff;
 pub(crate) use io::drift;
 pub(crate) use io::read;
-pub(crate) use review::ci;
 pub(crate) use search::gather;
 pub(crate) use search::onboard;
 pub(crate) use search::scout;
@@ -84,13 +83,16 @@ pub(crate) use graph::{
 };
 
 // -- review --
-pub(crate) use review::build_dead_output;
 pub(crate) use review::cmd_affected;
 pub(crate) use review::cmd_ci;
 pub(crate) use review::cmd_dead;
 pub(crate) use review::cmd_health;
 pub(crate) use review::cmd_review;
 pub(crate) use review::cmd_suggest;
+pub(crate) use review::{
+    ci_core, dead_core, health_core, review_core, suggest_core, CiArgs, DeadArgs, HealthArgs,
+    ReviewArgs, SuggestArgs,
+};
 
 // -- index --
 pub(crate) use index::build_hnsw_base_index;
@@ -142,10 +144,10 @@ pub(crate) use infra::{daemon_control_hint, DaemonHint};
 
 // -- train --
 pub(crate) use train::cmd_export_model;
-pub(crate) use train::cmd_plan;
 pub(crate) use train::cmd_task;
 pub(crate) use train::cmd_train_data;
 pub(crate) use train::cmd_train_pairs;
+pub(crate) use train::{cmd_plan, plan_core, PlanArgs};
 
 // -- eval --
 pub(crate) use eval::{cmd_eval, EvalCmdArgs};

--- a/src/cli/commands/review/affected.rs
+++ b/src/cli/commands/review/affected.rs
@@ -22,6 +22,59 @@ fn risk_label(level: &RiskLevel) -> colored::ColoredString {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Args + core (surface-agnostic, MCP-ready)
+// ---------------------------------------------------------------------------
+
+/// Input for [`affected_core`]. The diff text is acquired by the adapter
+/// (CLI: git or `--stdin`) and passed in, so the core stays I/O-free.
+#[derive(Debug, Default, serde::Deserialize)]
+pub(crate) struct AffectedArgs {}
+
+/// Typed output for `cqs affected`. The per-result JSON projection is owned by
+/// the lib (`diff_impact_to_json` handles rel-path display + field selection),
+/// so this is a thin newtype over the projected value plus the
+/// command-specific `overall_risk` field. Implementing `Serialize` by emitting
+/// the inner value keeps the schema lib-owned while giving the core a typed
+/// return (one definition site for the `affected` JSON).
+#[derive(Debug)]
+pub(crate) struct AffectedOutput(serde_json::Value);
+
+impl serde::Serialize for AffectedOutput {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> std::result::Result<S::Ok, S::Error> {
+        self.0.serialize(s)
+    }
+}
+
+/// Surface-agnostic core for `cqs affected`. Parses the diff, maps hunks to
+/// functions, runs the impact analysis, and returns the typed
+/// [`AffectedOutput`]. Empty diffs / no-indexed-functions both yield the
+/// shared empty shape (with `overall_risk: "none"`). `cqs affected` is
+/// CLI-only today, but the core is daemon-ready by construction.
+pub(crate) fn affected_core(
+    store: &cqs::Store<cqs::store::ReadOnly>,
+    root: &std::path::Path,
+    diff_text: &str,
+    _args: &AffectedArgs,
+) -> Result<AffectedOutput> {
+    let _span = tracing::info_span!("affected_core").entered();
+
+    let hunks = parse_unified_diff(diff_text);
+    if hunks.is_empty() {
+        return Ok(AffectedOutput(empty_affected_json()));
+    }
+
+    let changed = map_hunks_to_functions(store, &hunks);
+    if changed.is_empty() {
+        return Ok(AffectedOutput(empty_affected_json()));
+    }
+
+    let result = analyze_diff_impact(store, changed, root)?;
+    let mut json_val = diff_impact_to_json(&result)?;
+    json_val["overall_risk"] = serde_json::json!(overall_risk(&result).to_string());
+    Ok(AffectedOutput(json_val))
+}
+
 pub(crate) fn cmd_affected(
     ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     base: Option<&str>,
@@ -32,47 +85,33 @@ pub(crate) fn cmd_affected(
     let store = &ctx.store;
     let root = &ctx.root;
 
-    // 1. Get diff text — `--stdin` lets agents pipe a captured diff
+    // Get diff text — `--stdin` lets agents pipe a captured diff
     // (`git diff main | cqs affected --stdin --json`) without re-shelling
     // git. Mirrors the path in `cmd_review`/`cmd_ci`/`cmd_impact_diff`.
+    // Adapter owns I/O.
     let diff_text = if from_stdin {
         crate::cli::commands::read_stdin()?
     } else {
         crate::cli::commands::run_git_diff(base)?
     };
 
-    // 2. Parse hunks
-    let hunks = parse_unified_diff(&diff_text);
-    if hunks.is_empty() {
-        if json {
-            crate::cli::json_envelope::emit_json(&empty_affected_json())?;
-        } else {
-            println!("No changes detected.");
-        }
-        return Ok(());
-    }
-
-    // 3. Map hunks to functions
-    let changed = map_hunks_to_functions(store, &hunks);
-    if changed.is_empty() {
-        if json {
-            crate::cli::json_envelope::emit_json(&empty_affected_json())?;
-        } else {
-            println!("No indexed functions affected by this diff.");
-        }
-        return Ok(());
-    }
-
-    // 4. Analyze impact (callers + tests + risk)
-    let result = analyze_diff_impact(store, changed, root)?;
-
-    // 5. Display
     if json {
-        let mut json_val = diff_impact_to_json(&result)?;
-        // Add overall risk
-        json_val["overall_risk"] = serde_json::json!(overall_risk(&result).to_string());
-        crate::cli::json_envelope::emit_json(&json_val)?;
+        let output = affected_core(store, root, &diff_text, &AffectedArgs::default())?;
+        crate::cli::json_envelope::emit_json(&output)?;
     } else {
+        // Text path re-derives the analysis to drive the dashboard rendering
+        // (the typed output is a JSON projection; text needs the rich result).
+        let hunks = parse_unified_diff(&diff_text);
+        if hunks.is_empty() {
+            println!("No changes detected.");
+            return Ok(());
+        }
+        let changed = map_hunks_to_functions(store, &hunks);
+        if changed.is_empty() {
+            println!("No indexed functions affected by this diff.");
+            return Ok(());
+        }
+        let result = analyze_diff_impact(store, changed, root)?;
         display_affected_text(&result, root);
     }
 

--- a/src/cli/commands/review/ci.rs
+++ b/src/cli/commands/review/ci.rs
@@ -6,6 +6,62 @@ use cqs::ci::run_ci_analysis;
 use cqs::ReviewResult;
 use cqs::RiskLevel;
 
+// ---------------------------------------------------------------------------
+// Args + core (surface-agnostic, MCP-ready)
+// ---------------------------------------------------------------------------
+
+/// Input for [`ci_core`]. The diff text + gate threshold are supplied by the
+/// adapter (which owns I/O and the `GateThreshold` parse); `tokens` folds the
+/// request-scoped budget in.
+#[derive(Debug, Default, serde::Deserialize)]
+pub(crate) struct CiArgs {
+    /// Token budget for the embedded review (truncates callers/tests lists).
+    #[serde(default)]
+    pub tokens: Option<usize>,
+}
+
+/// Typed output for `cqs ci`. Flattens the lib [`cqs::ci::CiReport`] and adds
+/// the optional token-budget telemetry the adapters previously spliced inline.
+/// THE schema — both surfaces serialize this.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct CiOutput {
+    #[serde(flatten)]
+    pub report: cqs::ci::CiReport,
+    /// Estimated tokens used after budgeting (present only when `--tokens` set).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_count: Option<usize>,
+    /// The requested token budget (present only when `--tokens` set).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<usize>,
+}
+
+/// Surface-agnostic core for `cqs ci`. Runs the CI analysis (review + dead
+/// code + gate) on `diff_text`, applies the optional token budget, and returns
+/// the typed [`CiOutput`]. The gate `passed` flag rides along in the report;
+/// the *exit-code* reaction to a failed gate is adapter-owned (the CLI exits
+/// non-zero, the daemon just reports). Both surfaces drive this so the CI
+/// schema + budgeting live in one place.
+pub(crate) fn ci_core(
+    store: &cqs::Store<cqs::store::ReadOnly>,
+    root: &std::path::Path,
+    diff_text: &str,
+    gate: cqs::ci::GateThreshold,
+    args: &CiArgs,
+) -> Result<CiOutput> {
+    let _span = tracing::info_span!("ci_core", ?gate, tokens = ?args.tokens).entered();
+
+    let mut report = run_ci_analysis(store, diff_text, root, gate)?;
+    let token_count = args
+        .tokens
+        .map(|budget| apply_token_budget(&mut report.review, budget, true));
+
+    Ok(CiOutput {
+        report,
+        token_count,
+        token_budget: args.tokens,
+    })
+}
+
 pub(crate) fn cmd_ci(
     ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     base: Option<&str>,
@@ -29,45 +85,43 @@ pub(crate) fn cmd_ci(
     let store = &ctx.store;
     let root = &ctx.root;
 
-    // Get diff text
+    // Get diff text — adapter owns I/O (CLI supports stdin; daemon git only).
     let diff_text = if from_stdin {
         crate::cli::commands::read_stdin()?
     } else {
         crate::cli::commands::run_git_diff(base)?
     };
 
-    // Run CI analysis
-    let mut report = run_ci_analysis(store, &diff_text, root, *gate)?;
-
-    // Apply token budget
-    let token_count_used =
-        max_tokens.map(|budget| apply_token_budget(&mut report.review, budget, json));
-
-    if json {
-        let mut output: serde_json::Value = serde_json::to_value(&report)?;
-        if let Some(tokens) = token_count_used {
-            output["token_count"] = serde_json::json!(tokens);
-            output["token_budget"] = serde_json::json!(max_tokens.unwrap_or(0));
-        }
+    // The gate `passed` flag drives the process exit code below, so both
+    // branches surface it. JSON goes through the shared core (same as the
+    // daemon); text budgets with json=false accounting and renders the
+    // dashboard.
+    let gate_passed = if json {
+        let output = ci_core(
+            store,
+            root,
+            &diff_text,
+            *gate,
+            &CiArgs { tokens: max_tokens },
+        )?;
+        let gate_passed = output.report.gate.passed;
         crate::cli::json_envelope::emit_json(&output)?;
+        gate_passed
     } else {
+        let mut report = run_ci_analysis(store, &diff_text, root, *gate)?;
+        let token_count_used =
+            max_tokens.map(|budget| apply_token_budget(&mut report.review, budget, false));
         display_ci_text(&report, root, token_count_used, max_tokens);
-    }
+        report.gate.passed
+    };
 
-    // Exit with gate code if failed
-    if !report.gate.passed {
+    // Exit with gate code if failed (adapter-owned reaction; the core only
+    // reports the gate result).
+    if !gate_passed {
         std::process::exit(crate::cli::signal::ExitCode::GateFailed as i32);
     }
 
     Ok(())
-}
-
-/// Apply token budget by truncating callers and tests lists.
-/// Reuses the same logic as review.rs — changed functions and risk summary
-/// are always included, callers and tests are truncated.
-/// Public entry point for batch mode to apply CI token budgeting.
-pub(crate) fn apply_ci_token_budget(review: &mut ReviewResult, budget: usize) -> usize {
-    apply_token_budget(review, budget, true)
 }
 
 fn apply_token_budget(review: &mut ReviewResult, budget: usize, json: bool) -> usize {
@@ -393,14 +447,23 @@ mod tests {
         }
     }
 
-    /// Pin apply_ci_token_budget shape with json=true accounting (sibling
+    /// `CiArgs` deserializes from a wire/MCP object; `tokens` defaults to None.
+    #[test]
+    fn ci_args_minimal_deserialize() {
+        let def: CiArgs = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(def.tokens.is_none());
+        let with: CiArgs = serde_json::from_value(serde_json::json!({"tokens": 800})).unwrap();
+        assert_eq!(with.tokens, Some(800));
+    }
+
+    /// Pin the CI token-budget shape with json=true accounting (sibling
     /// test_apply_token_budget_truncates_when_over only covers json=false).
     /// json=true adds JSON_OVERHEAD_PER_RESULT to per-item cost, so the same
-    /// budget fits fewer items.
+    /// budget fits fewer items. This is the budgeting `ci_core` applies.
     #[test]
     fn test_apply_ci_token_budget_truncates_callers_and_tests() {
         let mut review = make_review(50, 50);
-        let used = apply_ci_token_budget(&mut review, 200);
+        let used = apply_token_budget(&mut review, 200, true);
         assert!(
             review.affected_callers.len() < 50 || review.affected_tests.len() < 50,
             "small budget must truncate at least one of callers/tests with json=true accounting"
@@ -411,7 +474,7 @@ mod tests {
     #[test]
     fn test_apply_ci_token_budget_zero_produces_zero_items() {
         let mut review = make_review(5, 5);
-        apply_ci_token_budget(&mut review, 0);
+        apply_token_budget(&mut review, 0, true);
         assert_eq!(
             review.affected_callers.len(),
             0,

--- a/src/cli/commands/review/dead.rs
+++ b/src/cli/commands/review/dead.rs
@@ -33,6 +33,77 @@ pub(crate) struct DeadOutput {
 }
 
 // ---------------------------------------------------------------------------
+// Args + core (surface-agnostic, MCP-ready)
+// ---------------------------------------------------------------------------
+
+/// Input for [`dead_core`]. Derives `Deserialize` (MCP param surface) with
+/// doc-commented fields; `min_confidence` deserializes from the same
+/// `low`/`medium`/`high` strings the CLI / wire accept.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct DeadArgs {
+    /// Include public-API functions in the main `dead` list (otherwise they
+    /// land in `possibly_dead_pub`, which agents usually skip).
+    #[serde(default)]
+    pub include_pub: bool,
+    /// Minimum confidence to report (`low` | `medium` | `high`). Entries below
+    /// this level are filtered out of both lists.
+    #[serde(
+        default = "default_dead_confidence",
+        deserialize_with = "de_confidence"
+    )]
+    pub min_confidence: DeadConfidence,
+}
+
+fn default_dead_confidence() -> DeadConfidence {
+    DeadConfidence::Low
+}
+
+/// Deserialize a [`DeadConfidence`] from its stable `low`/`medium`/`high`
+/// string. Kept local to the adapter layer so the lib enum stays
+/// `Serialize`-only (no eval-reachable source touched).
+fn de_confidence<'de, D>(de: D) -> std::result::Result<DeadConfidence, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize as _;
+    let s = String::deserialize(de)?;
+    match s.to_ascii_lowercase().as_str() {
+        "low" => Ok(DeadConfidence::Low),
+        "medium" => Ok(DeadConfidence::Medium),
+        "high" => Ok(DeadConfidence::High),
+        other => Err(serde::de::Error::custom(format!(
+            "invalid dead confidence '{other}' (expected low|medium|high)"
+        ))),
+    }
+}
+
+/// Surface-agnostic core for `cqs dead`. Finds zero-caller functions, filters
+/// by `min_confidence`, and returns the typed [`DeadOutput`]. Both the CLI
+/// (`cmd_dead`) and the daemon (`dispatch_dead`) drive this so the dead-code
+/// schema has exactly one definition site.
+pub(crate) fn dead_core(
+    store: &cqs::Store<cqs::store::ReadOnly>,
+    root: &Path,
+    args: &DeadArgs,
+) -> Result<DeadOutput> {
+    let _span = tracing::info_span!("dead_core", include_pub = args.include_pub).entered();
+    let (confident, possibly_pub) = store
+        .find_dead_code(args.include_pub)
+        .context("Failed to detect dead code")?;
+
+    let confident: Vec<_> = confident
+        .into_iter()
+        .filter(|d| d.confidence >= args.min_confidence)
+        .collect();
+    let possibly_pub: Vec<_> = possibly_pub
+        .into_iter()
+        .filter(|d| d.confidence >= args.min_confidence)
+        .collect();
+
+    Ok(build_dead_output(&confident, &possibly_pub, root))
+}
+
+// ---------------------------------------------------------------------------
 // Builder
 // ---------------------------------------------------------------------------
 
@@ -57,7 +128,7 @@ pub(crate) fn build_dead_output(
         chunk_type: d.chunk.chunk_type.to_string(),
         signature: d.chunk.signature.clone(),
         language: d.chunk.language.to_string(),
-        confidence: confidence_label(d.confidence).to_string(),
+        confidence: d.confidence.as_str().to_string(),
     };
 
     DeadOutput {
@@ -80,90 +151,62 @@ pub(crate) fn cmd_dead(
     min_level: DeadConfidence,
 ) -> Result<()> {
     let _span = tracing::info_span!("cmd_dead").entered();
-    let store = &ctx.store;
-    let root = &ctx.root;
-    let (confident, possibly_pub) = store
-        .find_dead_code(include_pub)
-        .context("Failed to detect dead code")?;
 
-    // Filter by minimum confidence
-    let confident: Vec<_> = confident
-        .into_iter()
-        .filter(|d| d.confidence >= min_level)
-        .collect();
-    let possibly_pub: Vec<_> = possibly_pub
-        .into_iter()
-        .filter(|d| d.confidence >= min_level)
-        .collect();
+    let args = DeadArgs {
+        include_pub,
+        min_confidence: min_level,
+    };
+    let output = dead_core(&ctx.store, &ctx.root, &args)?;
 
     if json {
-        let output = build_dead_output(&confident, &possibly_pub, root);
         crate::cli::json_envelope::emit_json(&output)?;
     } else {
-        display_dead_text(&confident, &possibly_pub, root, ctx.cli.quiet);
+        display_dead_text(&output, ctx.cli.quiet);
     }
 
     Ok(())
 }
 
-/// Human-readable confidence label
-fn confidence_label(c: DeadConfidence) -> &'static str {
-    c.as_str()
-}
-
-fn display_dead_text(
-    confident: &[DeadFunction],
-    possibly_pub: &[DeadFunction],
-    root: &Path,
-    quiet: bool,
-) {
-    if confident.is_empty() && possibly_pub.is_empty() {
+/// Render the typed [`DeadOutput`] as human-readable text. Reads the same
+/// struct the JSON path emits so the two renderings can't drift.
+fn display_dead_text(output: &DeadOutput, quiet: bool) {
+    if output.dead.is_empty() && output.possibly_dead_pub.is_empty() {
         println!("No dead code found.");
         return;
     }
 
-    if !confident.is_empty() {
+    if !output.dead.is_empty() {
         if !quiet {
-            println!("Dead code ({} functions):", confident.len());
+            println!("Dead code ({} functions):", output.dead.len());
             println!();
         }
-        for dead in confident {
-            let rel = cqs::rel_display(&dead.chunk.file, root);
+        for d in &output.dead {
             println!(
                 "  {} {}:{}  [{}] ({})",
-                dead.chunk.name,
-                rel,
-                dead.chunk.line_start,
-                dead.chunk.chunk_type,
-                confidence_label(dead.confidence),
+                d.name, d.file, d.line_start, d.chunk_type, d.confidence,
             );
             if !quiet {
-                println!("    {}", dead.chunk.signature.lines().next().unwrap_or(""));
+                println!("    {}", d.signature.lines().next().unwrap_or(""));
             }
         }
     }
 
-    if !possibly_pub.is_empty() {
-        if !confident.is_empty() {
+    if !output.possibly_dead_pub.is_empty() {
+        if !output.dead.is_empty() {
             println!();
         }
         println!(
             "Possibly dead (public API, {} functions):",
-            possibly_pub.len()
+            output.possibly_dead_pub.len()
         );
         if !quiet {
             println!("  (Use --include-pub to include these in the main list)");
         }
         println!();
-        for dead in possibly_pub {
-            let rel = cqs::rel_display(&dead.chunk.file, root);
+        for d in &output.possibly_dead_pub {
             println!(
                 "  {} {}:{}  [{}] ({})",
-                dead.chunk.name,
-                rel,
-                dead.chunk.line_start,
-                dead.chunk.chunk_type,
-                confidence_label(dead.confidence),
+                d.name, d.file, d.line_start, d.chunk_type, d.confidence,
             );
         }
     }
@@ -176,6 +219,27 @@ fn display_dead_text(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `DeadArgs` deserializes from a wire/MCP-shaped object, mapping the
+    /// `min_confidence` string through the local `de_confidence` helper without
+    /// the lib enum deriving `Deserialize`.
+    #[test]
+    fn dead_args_deserialize_confidence_string() {
+        let args: DeadArgs =
+            serde_json::from_value(serde_json::json!({"min_confidence": "high"})).unwrap();
+        assert_eq!(args.min_confidence, DeadConfidence::High);
+        assert!(!args.include_pub, "include_pub defaults to false");
+
+        // Empty object → defaults (include_pub=false, min_confidence=Low).
+        let def: DeadArgs = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(def.min_confidence, DeadConfidence::Low);
+
+        // Unknown confidence string is a hard error (no silent default).
+        assert!(
+            serde_json::from_value::<DeadArgs>(serde_json::json!({"min_confidence": "bogus"}))
+                .is_err()
+        );
+    }
 
     #[test]
     fn dead_output_empty() {

--- a/src/cli/commands/review/diff_review.rs
+++ b/src/cli/commands/review/diff_review.rs
@@ -5,6 +5,90 @@ use anyhow::Result;
 use cqs::ReviewResult;
 use cqs::RiskLevel;
 
+// ---------------------------------------------------------------------------
+// Args + core (surface-agnostic, MCP-ready)
+// ---------------------------------------------------------------------------
+
+/// Input for [`review_core`]. The diff text is acquired by the adapter
+/// (CLI: git or stdin; daemon: git) and passed in, so the core stays I/O-free.
+#[derive(Debug, Default, serde::Deserialize)]
+pub(crate) struct ReviewArgs {
+    /// Token budget for the output. When set, callers/tests lists are
+    /// truncated to fit; changed functions + notes are always included.
+    #[serde(default)]
+    pub tokens: Option<usize>,
+}
+
+/// Typed output for `cqs review`. Flattens the lib [`ReviewResult`] and adds
+/// the optional token-budget telemetry the adapters previously spliced inline.
+/// THE schema — both surfaces serialize this.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct ReviewOutput {
+    #[serde(flatten)]
+    pub review: ReviewResult,
+    /// Estimated tokens used after budgeting (present only when `--tokens` set).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_count: Option<usize>,
+    /// The requested token budget (present only when `--tokens` set).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<usize>,
+}
+
+/// An empty [`ReviewResult`] — emitted when the diff touches no indexed
+/// functions. Serializes to the historical empty-review shape
+/// (`changed_functions:[]`, …, `risk_summary:{…,overall:"low"}`,
+/// `stale_warning:null`).
+fn empty_review_result() -> ReviewResult {
+    ReviewResult {
+        changed_functions: vec![],
+        affected_callers: vec![],
+        affected_tests: vec![],
+        relevant_notes: vec![],
+        risk_summary: cqs::RiskSummary {
+            high: 0,
+            medium: 0,
+            low: 0,
+            overall: RiskLevel::Low,
+        },
+        stale_warning: None,
+        warnings: vec![],
+    }
+}
+
+/// Surface-agnostic core for `cqs review`. Runs the diff-review pipeline on
+/// `diff_text`, applies the optional token budget, and returns the typed
+/// [`ReviewOutput`]. Both the CLI (`cmd_review`) and daemon (`dispatch_review`)
+/// drive this so the review schema + budgeting live in one place.
+pub(crate) fn review_core(
+    store: &cqs::Store<cqs::store::ReadOnly>,
+    root: &std::path::Path,
+    diff_text: &str,
+    args: &ReviewArgs,
+) -> Result<ReviewOutput> {
+    let _span = tracing::info_span!("review_core", tokens = ?args.tokens).entered();
+
+    match cqs::review_diff(store, diff_text, root)? {
+        // No indexed functions affected: emit the empty-review shape with no
+        // budget telemetry (matches the historical empty-diff envelope on both
+        // surfaces — budget fields were never spliced onto the empty case).
+        None => Ok(ReviewOutput {
+            review: empty_review_result(),
+            token_count: None,
+            token_budget: None,
+        }),
+        Some(mut review) => {
+            let token_count = args
+                .tokens
+                .map(|budget| apply_token_budget(&mut review, budget, true));
+            Ok(ReviewOutput {
+                review,
+                token_count,
+                token_budget: args.tokens,
+            })
+        }
+    }
+}
+
 pub(crate) fn cmd_review(
     ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
     base: Option<&str>,
@@ -27,37 +111,25 @@ pub(crate) fn cmd_review(
     let store = &ctx.store;
     let root = &ctx.root;
 
-    // 1. Get diff text
+    // 1. Get diff text — adapter owns I/O (CLI supports stdin; daemon git only).
     let diff_text = if from_stdin {
         crate::cli::commands::read_stdin()?
     } else {
         crate::cli::commands::run_git_diff(base)?
     };
 
-    // 2. Run review
-    let result = cqs::review_diff(store, &diff_text, root)?;
-
-    match result {
-        None => {
-            if json {
-                crate::cli::json_envelope::emit_json(&empty_review_json())?;
-            } else {
-                println!("No indexed functions affected by this diff.");
-            }
-        }
-        Some(mut review) => {
-            // Apply token budget: truncate callers and tests lists to fit
-            let token_count_used =
-                max_tokens.map(|budget| apply_token_budget(&mut review, budget, json));
-
-            if json {
-                let mut output: serde_json::Value = serde_json::to_value(&review)?;
-                if let Some(tokens) = token_count_used {
-                    output["token_count"] = serde_json::json!(tokens);
-                    output["token_budget"] = serde_json::json!(max_tokens.unwrap_or(0));
-                }
-                crate::cli::json_envelope::emit_json(&output)?;
-            } else {
+    if json {
+        // JSON path goes through the shared core (same as the daemon).
+        let output = review_core(store, root, &diff_text, &ReviewArgs { tokens: max_tokens })?;
+        crate::cli::json_envelope::emit_json(&output)?;
+    } else {
+        // Text path budgets with json=false accounting (different per-item
+        // overhead than the JSON surface) and renders the human dashboard.
+        match cqs::review_diff(store, &diff_text, root)? {
+            None => println!("No indexed functions affected by this diff."),
+            Some(mut review) => {
+                let token_count_used =
+                    max_tokens.map(|budget| apply_token_budget(&mut review, budget, false));
                 display_review_text(&review, root, token_count_used, max_tokens);
             }
         }
@@ -71,15 +143,6 @@ pub(crate) fn cmd_review(
 /// Callers and tests are the variable-size sections that get truncated.
 /// `json` adds per-item overhead for JSON field names and structure tokens.
 /// Returns total token count used.
-/// Public entry point for batch mode to apply token budgeting to review output.
-pub(crate) fn apply_token_budget_public(
-    review: &mut ReviewResult,
-    budget: usize,
-    json: bool,
-) -> usize {
-    apply_token_budget(review, budget, json)
-}
-
 fn apply_token_budget(review: &mut ReviewResult, budget: usize, json: bool) -> usize {
     let _span = tracing::info_span!("review_token_budget", budget, json).entered();
 
@@ -152,27 +215,6 @@ fn apply_token_budget(review: &mut ReviewResult, budget: usize, json: bool) -> u
     }
 
     used
-}
-
-/// Creates and returns a JSON object representing an empty code review with no findings.
-/// This function constructs a default review structure containing empty arrays for changed functions, affected callers, and affected tests, along with empty risk assessments and a null stale warning field.
-/// # Returns
-/// A `serde_json::Value` containing a JSON object with the following fields:
-/// - `changed_functions`: empty array
-/// - `affected_callers`: empty array
-/// - `affected_tests`: empty array
-/// - `relevant_notes`: empty array
-/// - `risk_summary`: object with zero counts for high, medium, and low risk items, and overall risk set to "low"
-/// - `stale_warning`: null value
-fn empty_review_json() -> serde_json::Value {
-    serde_json::json!({
-        "changed_functions": [],
-        "affected_callers": [],
-        "affected_tests": [],
-        "relevant_notes": [],
-        "risk_summary": { "high": 0, "medium": 0, "low": 0, "overall": "low" },
-        "stale_warning": null
-    })
 }
 
 fn display_review_text(
@@ -386,6 +428,15 @@ mod tests {
             stale_warning: None,
             warnings: vec![],
         }
+    }
+
+    /// `ReviewArgs` deserializes from a wire/MCP object; `tokens` defaults to None.
+    #[test]
+    fn review_args_minimal_deserialize() {
+        let def: ReviewArgs = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(def.tokens.is_none());
+        let with: ReviewArgs = serde_json::from_value(serde_json::json!({"tokens": 500})).unwrap();
+        assert_eq!(with.tokens, Some(500));
     }
 
     #[test]

--- a/src/cli/commands/review/health.rs
+++ b/src/cli/commands/review/health.rs
@@ -1,11 +1,47 @@
 //! Health command — codebase quality snapshot
 
 use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use colored::Colorize;
 
 use cqs::Parser;
+
+// ---------------------------------------------------------------------------
+// Args + core (surface-agnostic, MCP-ready)
+// ---------------------------------------------------------------------------
+
+/// Input for [`health_core`]. The health snapshot takes no user parameters
+/// today; the struct exists so the core matches the established
+/// `*Args` + `*_core` shape and can grow Deserialize-able fields without a
+/// signature change (MCP-ready).
+#[derive(Debug, Default, serde::Deserialize)]
+pub(crate) struct HealthArgs {}
+
+/// Surface-agnostic core for `cqs health`. Returns the typed
+/// [`cqs::health::HealthReport`] (already the schema). The adapter owns file
+/// enumeration so the hot daemon path can pass its cached `file_set` (the CLI
+/// builds the set once via [`enumerate_for_health`]); mirrors the
+/// `stale_core` split.
+pub(crate) fn health_core(
+    store: &cqs::Store<cqs::store::ReadOnly>,
+    file_set: &HashSet<PathBuf>,
+    cqs_dir: &Path,
+    root: &Path,
+    _args: &HealthArgs,
+) -> Result<cqs::health::HealthReport> {
+    let _span = tracing::info_span!("health_core").entered();
+    Ok(cqs::health::health_check(store, file_set, cqs_dir, root)?)
+}
+
+/// Enumerate on-disk source files for the health staleness check. CLI helper —
+/// the daemon supplies its cached `file_set` directly to [`health_core`].
+pub(crate) fn enumerate_for_health(root: &Path) -> Result<HashSet<PathBuf>> {
+    let parser = Parser::new()?;
+    let files = crate::cli::enumerate_files(root, &parser, false)?;
+    Ok(files.into_iter().collect())
+}
 
 pub(crate) fn cmd_health(
     ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
@@ -13,16 +49,11 @@ pub(crate) fn cmd_health(
 ) -> Result<()> {
     let _span = tracing::info_span!("cmd_health").entered();
 
-    let store = &ctx.store;
     let root = &ctx.root;
     let cqs_dir = &ctx.cqs_dir;
 
-    // Enumerate current files for staleness check
-    let parser = Parser::new()?;
-    let files = crate::cli::enumerate_files(root, &parser, false)?;
-    let file_set: HashSet<_> = files.into_iter().collect();
-
-    let report = cqs::health::health_check(store, &file_set, cqs_dir, root)?;
+    let file_set = enumerate_for_health(root)?;
+    let report = health_core(&ctx.store, &file_set, cqs_dir, root, &HealthArgs::default())?;
 
     if json {
         let json_val = serde_json::to_value(&report)?;

--- a/src/cli/commands/review/mod.rs
+++ b/src/cli/commands/review/mod.rs
@@ -4,12 +4,12 @@ mod affected;
 pub(crate) mod ci;
 pub(crate) mod dead;
 pub(crate) mod diff_review;
-mod health;
+pub(crate) mod health;
 pub(crate) mod suggest;
 
 pub(crate) use affected::cmd_affected;
-pub(crate) use ci::cmd_ci;
-pub(crate) use dead::{build_dead_output, cmd_dead};
-pub(crate) use diff_review::{apply_token_budget_public, cmd_review};
-pub(crate) use health::cmd_health;
-pub(crate) use suggest::cmd_suggest;
+pub(crate) use ci::{ci_core, cmd_ci, CiArgs};
+pub(crate) use dead::{cmd_dead, dead_core, DeadArgs};
+pub(crate) use diff_review::{cmd_review, review_core, ReviewArgs};
+pub(crate) use health::{cmd_health, health_core, HealthArgs};
+pub(crate) use suggest::{cmd_suggest, suggest_core, SuggestArgs};

--- a/src/cli/commands/review/suggest.rs
+++ b/src/cli/commands/review/suggest.rs
@@ -26,6 +26,34 @@ pub(crate) struct SuggestOutput {
 }
 
 // ---------------------------------------------------------------------------
+// Args + core (surface-agnostic, MCP-ready)
+// ---------------------------------------------------------------------------
+
+/// Input for [`suggest_core`]. The core only computes the read-only suggestion
+/// set; the `--apply` side-effect (write notes + reindex) needs a writable
+/// store and is adapter-owned (CLI only), so it is not a core input. The struct
+/// exists to match the established `*Args` shape and can grow Deserialize-able
+/// fields without a signature change (MCP-ready).
+#[derive(Debug, Default, serde::Deserialize)]
+pub(crate) struct SuggestArgs {}
+
+/// Surface-agnostic core for `cqs suggest`. Detects note-worthy patterns and
+/// returns the typed [`SuggestOutput`] with `applied: false` — applying the
+/// suggestions writes notes + reindexes, which needs a writable store and so
+/// stays adapter-owned (CLI only). Both the CLI (`cmd_suggest`) and daemon
+/// (`dispatch_suggest`) drive this for the read side, so the suggest schema
+/// has one definition site.
+pub(crate) fn suggest_core(
+    store: &cqs::Store<cqs::store::ReadOnly>,
+    root: &std::path::Path,
+    _args: &SuggestArgs,
+) -> Result<SuggestOutput> {
+    let _span = tracing::info_span!("suggest_core").entered();
+    let suggestions = cqs::suggest::suggest_notes(store, root)?;
+    Ok(build_suggest_output(&suggestions, false))
+}
+
+// ---------------------------------------------------------------------------
 // Builder
 // ---------------------------------------------------------------------------
 
@@ -72,13 +100,14 @@ pub(crate) fn cmd_suggest(
 ) -> Result<()> {
     let _span = tracing::info_span!("cmd_suggest", apply).entered();
 
-    let store = &ctx.store;
     let root = &ctx.root;
-    let suggestions = cqs::suggest::suggest_notes(store, root)?;
 
-    if suggestions.is_empty() {
+    // Read side through the shared core (read-only). The apply side-effect is
+    // adapter-owned because it needs a writable store.
+    let mut output = suggest_core(&ctx.store, root, &SuggestArgs::default())?;
+
+    if output.suggestions.is_empty() {
         if json {
-            let output = build_suggest_output(&suggestions, false);
             crate::cli::json_envelope::emit_json(&output)?;
         } else {
             println!("No suggestions — codebase looks clean.");
@@ -86,24 +115,24 @@ pub(crate) fn cmd_suggest(
         return Ok(());
     }
 
+    if apply {
+        apply_suggestions(&output, root, &ctx.cqs_dir)?;
+        output.applied = true;
+    }
+
     if json {
-        if apply {
-            apply_suggestions(&suggestions, root, &ctx.cqs_dir)?;
-        }
-        let output = build_suggest_output(&suggestions, apply);
         crate::cli::json_envelope::emit_json(&output)?;
     } else if apply {
-        apply_suggestions(&suggestions, root, &ctx.cqs_dir)?;
         println!(
             "Applied {} suggestion{}.",
-            suggestions.len(),
-            if suggestions.len() == 1 { "" } else { "s" }
+            output.count,
+            if output.count == 1 { "" } else { "s" }
         );
     } else {
-        // Dry-run: display suggestions
-        println!("{} ({}):", "Suggested notes".bold(), suggestions.len());
+        // Dry-run: display suggestions from the typed output.
+        println!("{} ({}):", "Suggested notes".bold(), output.count);
         println!();
-        for s in &suggestions {
+        for s in &output.suggestions {
             let sentiment_str = match s.sentiment {
                 v if v <= -0.5 => format!("[{}]", format!("{:.1}", v).red()),
                 v if v >= 0.5 => format!("[{}]", format!("{:.1}", v).green()),
@@ -131,16 +160,17 @@ pub(crate) fn cmd_suggest(
 /// promote the store; an accidental call to a write method on `ctx.store`
 /// is now a compile error.
 fn apply_suggestions(
-    suggestions: &[cqs::suggest::SuggestedNote],
+    output: &SuggestOutput,
     root: &std::path::Path,
     cqs_dir: &std::path::Path,
 ) -> Result<()> {
     let notes_path = root.join("docs/notes.toml");
 
-    let entries: Vec<cqs::NoteEntry> = suggestions
+    let entries: Vec<cqs::NoteEntry> = output
+        .suggestions
         .iter()
         .map(|s| cqs::NoteEntry {
-            sentiment: s.sentiment,
+            sentiment: s.sentiment as f32,
             text: s.text.clone(),
             mentions: s.mentions.clone(),
             kind: None,

--- a/src/cli/commands/train/mod.rs
+++ b/src/cli/commands/train/mod.rs
@@ -7,7 +7,7 @@ mod train_data;
 mod train_pairs;
 
 pub(crate) use export_model::cmd_export_model;
-pub(crate) use plan::cmd_plan;
+pub(crate) use plan::{cmd_plan, plan_core, PlanArgs};
 pub(crate) use task::cmd_task;
 pub(crate) use train_data::cmd_train_data;
 pub(crate) use train_pairs::cmd_train_pairs;

--- a/src/cli/commands/train/plan.rs
+++ b/src/cli/commands/train/plan.rs
@@ -2,7 +2,56 @@
 
 use anyhow::{Context, Result};
 
-use cqs::plan::plan;
+use cqs::plan::{plan, PlanResult};
+use cqs::Embedder;
+
+// ---------------------------------------------------------------------------
+// Args + core (surface-agnostic, MCP-ready)
+// ---------------------------------------------------------------------------
+
+/// Input for [`plan_core`]. The embedder is a resource the adapter resolves
+/// (`ctx.embedder()`); the request-scoped fields live here.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct PlanArgs {
+    /// Natural-language task description to classify and plan.
+    pub description: String,
+    /// Max candidate results to surface per plan section.
+    #[serde(default)]
+    pub limit: usize,
+    /// Token budget echoed onto the output as `token_budget` (JSON only).
+    #[serde(default)]
+    pub tokens: Option<usize>,
+}
+
+/// Typed output for `cqs plan`. Flattens the lib [`PlanResult`] and adds the
+/// optional `token_budget` echo the adapters previously spliced inline.
+/// THE schema — both surfaces serialize this.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct PlanOutput {
+    #[serde(flatten)]
+    pub plan: PlanResult,
+    /// Echoed token budget (present only when `--tokens` set).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<usize>,
+}
+
+/// Surface-agnostic core for `cqs plan`. Runs the planning pipeline (a pure
+/// read query over the store + embedder) and returns the typed [`PlanOutput`].
+/// Both the CLI (`cmd_plan`) and daemon (`dispatch_plan`) drive this.
+pub(crate) fn plan_core(
+    store: &cqs::Store<cqs::store::ReadOnly>,
+    embedder: &Embedder,
+    root: &std::path::Path,
+    args: &PlanArgs,
+) -> Result<PlanOutput> {
+    let _span = tracing::info_span!("plan_core", description = %args.description).entered();
+    let result = plan(store, embedder, &args.description, root, args.limit)
+        .context("Plan generation failed")?;
+    Ok(PlanOutput {
+        plan: result,
+        token_budget: args.tokens,
+    })
+}
 
 pub(crate) fn cmd_plan(
     ctx: &crate::cli::CommandContext<'_, cqs::store::ReadOnly>,
@@ -13,21 +62,21 @@ pub(crate) fn cmd_plan(
 ) -> Result<()> {
     let _span = tracing::info_span!("cmd_plan", description).entered();
 
-    let store = &ctx.store;
     let root = &ctx.root;
     let embedder = ctx.embedder().context("Failed to access embedder")?;
 
-    let result =
-        plan(store, embedder, description, root, limit).context("Plan generation failed")?;
+    let args = PlanArgs {
+        description: description.to_string(),
+        limit,
+        tokens,
+    };
 
     if json {
-        let mut json_val = serde_json::to_value(&result)?;
-        if let Some(budget) = tokens {
-            json_val["token_budget"] = serde_json::json!(budget);
-        }
-        crate::cli::json_envelope::emit_json(&json_val)?;
+        let output = plan_core(&ctx.store, embedder, root, &args)?;
+        crate::cli::json_envelope::emit_json(&output)?;
     } else {
-        display_plan_text(&result, root, tokens);
+        let output = plan_core(&ctx.store, embedder, root, &args)?;
+        display_plan_text(&output.plan, root, tokens);
     }
 
     Ok(())
@@ -78,5 +127,21 @@ fn display_plan_text(
         for pattern in &result.patterns {
             println!("  - {}", pattern);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `PlanArgs` deserializes from a wire/MCP-shaped object with defaults for
+    /// the optional fields (limit, tokens).
+    #[test]
+    fn plan_args_minimal_deserialize() {
+        let args: PlanArgs =
+            serde_json::from_value(serde_json::json!({"description": "add a flag"})).unwrap();
+        assert_eq!(args.description, "add a flag");
+        assert_eq!(args.limit, 0, "limit defaults to 0 (clamped by the lib)");
+        assert!(args.tokens.is_none(), "tokens defaults to None");
     }
 }

--- a/src/cli/commands/train/task.rs
+++ b/src/cli/commands/train/task.rs
@@ -330,7 +330,9 @@ pub(crate) fn cmd_task(
     } else if let Some(budget) = max_tokens {
         output_with_budget(&result, root, embedder, budget, json)?;
     } else if json {
-        let output = serde_json::to_value(&result)?;
+        // Plain JSON (no budget) goes through the shared `task_json_core` —
+        // same projection the daemon emits.
+        let output = task_json_core(&result, embedder, None)?;
         crate::cli::json_envelope::emit_json(&output)?;
     } else {
         output_text(&result, root);
@@ -594,6 +596,25 @@ pub(crate) fn waterfall_pack(
         notes: note_indices,
         total_used,
         budget,
+    }
+}
+
+/// Surface-agnostic JSON projection for `cqs task`. Given an already-computed
+/// [`cqs::TaskResult`] (provisioning differs per surface — the CLI builds
+/// resources internally via `task()`, the daemon injects cached `graph` +
+/// `test_chunks` via `task_with_resources()` for perf), produce the final JSON:
+/// waterfall-budgeted when `tokens` is set, else the full serialization. This
+/// is the genuinely-shared projection both surfaces previously duplicated as an
+/// inline `if tokens { … } else { … }` branch.
+pub(crate) fn task_json_core(
+    result: &cqs::TaskResult,
+    embedder: &Embedder,
+    tokens: Option<usize>,
+) -> Result<serde_json::Value> {
+    let _span = tracing::info_span!("task_json_core", ?tokens).entered();
+    match tokens {
+        Some(budget) => task_to_budgeted_json(result, embedder, budget),
+        None => serde_json::to_value(result).context("Failed to serialize task output"),
     }
 }
 

--- a/src/cli/json_envelope.rs
+++ b/src/cli/json_envelope.rs
@@ -610,18 +610,6 @@ fn emit_bare_payload_stdout<T: Serialize>(value: &T, posture: Posture) -> Result
     Ok(())
 }
 
-/// Posture-aware variant of [`emit_json`]. CLI handler entry points
-/// resolve a [`Posture`] once at dispatch and pass it down the call
-/// chain so leaf serializers don't read process env independently.
-#[allow(dead_code)]
-pub fn emit_json_with_posture<T: Serialize>(value: &T, posture: Posture) -> Result<()> {
-    let env = Envelope::ok_with_posture(value, posture);
-    let buf = serde_json::to_value(&env)?;
-    let s = format_envelope_to_string(&buf)?;
-    println!("{s}");
-    Ok(())
-}
-
 /// Print an error envelope as pretty-printed JSON. Used by `cqs ping --json`
 /// (daemon-not-running path) and `cqs eval --baseline ... --json` (regression-
 /// past-tolerance path) so JSON consumers always get the published failure
@@ -633,16 +621,6 @@ pub fn emit_json_with_posture<T: Serialize>(value: &T, posture: Posture) -> Resu
 /// should prefer [`ErrorCode::as_str`] for compile-checked emission.
 pub fn emit_json_error(code: &str, message: &str) -> Result<()> {
     let env = Envelope::<serde_json::Value>::err(code, message);
-    let buf = serde_json::to_value(&env)?;
-    let s = format_envelope_to_string(&buf)?;
-    println!("{s}");
-    Ok(())
-}
-
-/// Posture-aware variant of [`emit_json_error`].
-#[allow(dead_code)]
-pub fn emit_json_error_with_posture(code: &str, message: &str, posture: Posture) -> Result<()> {
-    let env = Envelope::<serde_json::Value>::err_with_posture(code, message, posture);
     let buf = serde_json::to_value(&env)?;
     let s = format_envelope_to_string(&buf)?;
     println!("{s}");


### PR DESCRIPTION
Phase 4 — the final implementation phase of docs/plans/2026-06-10-command-core-unification.md.

## Dispositions

- **Cored + daemon-routed**: dead, health, suggest, review, ci (parity tests on the embedder-free paths; review/ci pinned at core level — their dispatchers are exactly run_git_diff + core + to_value)
- **Cored, CLI-only**: affected (no dispatcher exists; daemon-ready by construction)
- **Cored at the natural seam**: plan; task (JSON projection cored, per-surface resource provisioning kept — the stale_core pattern)
- **Adapter-owned**: train-data, train-pairs, export-model (GPU/file pipeline orchestration)
- **eval**: already conformant (EvalReport typed); runner.rs untouched

## The two structural decisions

- **`_with_posture` deleted, not wired** (resolves audit CQ-V1.40-5/6): zero callers, and wiring would thread a value through every adapter to produce byte-identical output — the OnceLock-cached shim is the design. CQS_ULTRASECURITY untouched (deletion belongs to #1690's PR).
- **Daemon suggest `total` → `count`**: the campaign's only field rename. The CLI's typed struct already used count; the daemon was the outlier. Consumer survey (implementer + reviewer, independently): zero readers of the old field. Parity test asserts total absent / count present. CHANGELOG'd.

## Campaign closure bookkeeping

Deferral ledger consolidated in the plan: 11 entries, each with structural reason and tracking (read/notes union-schema, ping/status client-server split, gc daemon bail, orchestration commands, #1690). Reviewer-supplied hunts added to the docs-sweep checklist.

## Gates

- Eval-reachable source + lib analysis modules (review.rs, health.rs, impact/, drift.rs, ci.rs) byte-identical — verified by implementer, reviewer, and orchestrator independently; eval run provably skipped
- Review: ship, LOW risk; 83 targeted + parity tests green; build/clippy(-D warnings)/fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
