### PR TITLE
fix(tests): HNSW/CAGRA test-concurrency hardening (closes #1693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **HNSW/CAGRA test-concurrency hardening (#1693).** Root-caused
+  `hnsw::safety::tests::test_loaded_index_lifecycle` (flaky under full-suite
+  parallelism, passed in isolation): `HnswIndex::build_with_dim` inserts via
+  `parallel_insert_data` (rayon) over hnsw_rs's OS-entropy-seeded layer RNG, and
+  under CPU saturation the concurrent entry-point race produces a degenerate
+  graph on ~1-2% of builds where even the cosine-distance-0 self-match vector is
+  unreachable (measured 52/3000 parallel inserts vs 0/3000 sequential under
+  16-core load; search on a fixed index is deterministic at 0/100k). This is an
+  hnsw_rs concurrent-build recall characteristic, not a cqs soundness bug — the
+  self-referential `LoadedHnsw` lifecycle is sound. Fixes: (a) `safety.rs`
+  lifecycle test now asserts soundness (non-empty, valid IDs, finite scores)
+  rather than recall; (b) the recall-intent tests in `build.rs`/`persist.rs`
+  (including the #1676 `tc31_*` survivors) now assert top-k containment with a
+  bounded build retry (`assert_self_match_reachable`) instead of exact rank-1;
+  (c) CAGRA self-match tests switched from `assert_eq!(results[0].id, ...)` to
+  top-k containment. Also closed a cross-module env-var race: `CQS_HNSW_*`
+  mutations in `test_hnsw_for_helpers_pick_tier` and `env_override_tests` now
+  share a single `HNSW_ENV_LOCK` static (a per-module mutex did not coordinate
+  across modules). Test-concurrency policy documented in CONTRIBUTING.md.
+
 - **Kind-fallback cap parity across all graph commands.** The
   `callers`/`callees`, `deps`, `test-map`, and `trace` kind-mismatch
   fallbacks built their `definitions[]` arrays uncapped, so a hot name like

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,78 @@ Rules:
 - Use `#[serde(skip_serializing_if = "Option::is_none")]` for optional fields so absent data is omitted (not `null`).
 - When adding `--json` to a new command, follow existing output structs (e.g., `ChunkSummary`, `CallerDetail`, `ExplainOutput`) rather than inventing new field names.
 
+## Test Concurrency
+
+`cargo test` runs tests in parallel by default. Most tests are isolated (own
+`TempDir`, own `Store`), but three classes of test need explicit serialization
+or contention-tolerant assertions. Get this wrong and you ship a flake that
+passes in isolation and fails ~1% of the time in CI (#1693).
+
+### 1. GPU / CUDA-context tests → module `GPU_LOCK`
+
+CUDA contexts require serialized access. Every test in `src/cagra.rs` that
+builds or searches a `CagraIndex` takes the module-level static:
+
+```rust
+static GPU_LOCK: Mutex<()> = Mutex::new(());
+// ...
+#[test]
+fn test_search() {
+    let _guard = GPU_LOCK.lock().unwrap();
+    if !require_gpu() { return; }
+    // ... GPU work ...
+}
+```
+
+Add `let _guard = GPU_LOCK.lock().unwrap();` as the **first line** of any new
+GPU-touching test.
+
+### 2. Env-var-mutating tests → shared lock or `#[serial]`
+
+Env vars are process-global. A test that `set_var`/`remove_var`s a key races
+every other test that *reads* that key — even across modules. Two accepted
+patterns:
+
+- **`serial_test`** (already a dev-dependency) with a **named group** so only
+  tests touching the same env are serialized:
+  ```rust
+  #[serial_test::serial(cqs_eval_require_fresh_env)]
+  ```
+  Used in `src/limits.rs`, `src/cli/commands/eval/mod.rs`.
+- **A shared module-level mutex** when several tests in one area mutate the same
+  keys. `src/hnsw/mod.rs` exposes `pub(crate) static HNSW_ENV_LOCK` for all
+  `CQS_HNSW_*` tests; `env_override_tests` and `test_hnsw_for_helpers_pick_tier`
+  both lock it. A *single* shared static is required — a per-module mutex does
+  not coordinate across modules, which is exactly the gap that caused #1693.
+
+Always restore the env (`remove_var` after `set_var`) before releasing the lock.
+
+### 3. Approximate-index recall assertions → containment + bounded build retry
+
+`HnswIndex` is built with `parallel_insert_data` (rayon) over an
+OS-entropy-seeded layer RNG, and `CagraIndex` is an approximate GPU graph.
+Under CPU saturation, `parallel_insert` produces a degenerate graph on ~1-2% of
+builds where even the cosine-distance-0 self-match vector is unreachable
+(measured: 52/3000 parallel vs 0/3000 sequential under 16-core load). Search on
+a *fixed* index is deterministic (0/100k misses) — the nondeterminism is purely
+in concurrent construction.
+
+Therefore:
+
+- **Never `assert_eq!(results[0].id, expected)`** on an HNSW/CAGRA result.
+  Assert **top-k containment** (`results.iter().any(|r| r.id == expected)`).
+- For tests whose *intent* is recall (verify the index can find the self-match),
+  **retry the build** a bounded number of times so a single degenerate graph
+  does not fail the assertion. At 8 retries a transient miss is ~2.5e-14 while a
+  systematic recall bug (miss on every build) still fails deterministically. See
+  `assert_self_match_reachable` in `src/hnsw/build.rs`.
+- For tests whose intent is **lifecycle/soundness** (e.g. `src/hnsw/safety.rs`),
+  assert only that results are non-empty and IDs are valid (no corruption) — do
+  not assert recall at all.
+
+Use unique temp paths (`TempDir::new()`, never a fixed `temp_dir().join("name")`)
+so parallel tests never collide on disk.
+
 ## Pull Request Process
 
 1. Fork the repository and create a feature branch

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -53,6 +53,10 @@ Ordered for the fix loop, all positioned relative to the command-core campaign:
 3. **#1690** — posture/output-format matrix consolidation (after campaign phase 4 — same surface; subsumes the CQ-V1.40-5/6 and TC-ADV-V1.40-1 queue entries above).
 4. **#1691** — split big-with-logic monoliths with fixture-refresh discipline (after campaign phases 2-3 to avoid diff churn).
 
+### Pending user go: upstream hnsw_rs issue (2026-06-10)
+
+#1693's root-cause produced a reproducible upstream finding: hnsw_rs `parallel_insert_data` yields self-unreachable nodes on ~1-2% of builds under CPU saturation (52/3000 parallel vs 0/3000 sequential inserts; 0/100k searching a fixed index — construction-side, entry-point write race + OS-seeded layer RNG suspected). Filing an issue on the hnsw_rs repo with this data + a deterministic-seeding suggestion needs user authorization (new upstream relationship, unlike rapidsai/cuvs).
+
 ### Still deferred (unchanged decision)
 
 - **DS-V1.40-7**: partially mitigated (CLI clamps to [-1,1], rejects NaN/Inf) but `--sentiment 0.7` still accepted — no discrete-value CHECK. Stays deferred per the v1.41.0 rationale.

--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -1711,11 +1711,21 @@ mod tests {
         let query = make_embedding(3);
         let results = index.search(&query, 5);
         assert!(!results.is_empty(), "Search returned no results");
-        assert_eq!(results[0].id, "chunk_3", "Top result should be chunk_3");
+        // CAGRA is an approximate GPU graph index; assert top-k containment
+        // of the self-match vector, not exact rank-1.
+        let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
         assert!(
-            results[0].score > 0.9,
-            "Self-match score should be high, got {}",
-            results[0].score
+            ids.contains(&"chunk_3"),
+            "chunk_3 should be in top-5, got {ids:?}"
+        );
+        let self_score = results
+            .iter()
+            .find(|r| r.id == "chunk_3")
+            .map(|r| r.score)
+            .unwrap();
+        assert!(
+            self_score > 0.9,
+            "Self-match score should be high, got {self_score}"
         );
     }
 
@@ -1776,7 +1786,12 @@ mod tests {
 
         let results2 = index.search(&make_embedding(5), 3);
         assert!(!results2.is_empty());
-        assert_eq!(results2[0].id, "chunk_5");
+        // Top-k containment, not exact rank-1: approximate GPU index.
+        let ids: Vec<&str> = results2.iter().map(|r| r.id.as_str()).collect();
+        assert!(
+            ids.contains(&"chunk_5"),
+            "chunk_5 should be in top-3, got {ids:?}"
+        );
     }
 
     #[test]

--- a/src/hnsw/build.rs
+++ b/src/hnsw/build.rs
@@ -252,23 +252,47 @@ mod tests {
 
     #[test]
     fn test_build_and_search() {
-        let embeddings = vec![
-            ("chunk1".to_string(), make_embedding(1)),
-            ("chunk2".to_string(), make_embedding(2)),
-            ("chunk3".to_string(), make_embedding(3)),
-        ];
+        // Recall-intent test: a correctly-built index returns the exact-match
+        // vector in its top-k. HNSW is built via `parallel_insert_data`
+        // (rayon) over an OS-seeded layer RNG, and under CPU contention ~1-2%
+        // of builds are degenerate enough that even the cosine-distance-0
+        // self-match is unreachable (measured 52/3000 under 16-core load vs
+        // 0/3000 sequential). That is an hnsw_rs concurrent-build
+        // characteristic, not a cqs bug — so we retry the build a bounded
+        // number of times rather than assert exact rank-1 on a single build.
+        let build = || {
+            // Hold the env lock for the build only: build_with_dim reads
+            // CQS_HNSW_* and must not race a concurrent env-override test.
+            let _env = crate::hnsw::HNSW_ENV_LOCK.lock().unwrap();
+            let embeddings = vec![
+                ("chunk1".to_string(), make_embedding(1)),
+                ("chunk2".to_string(), make_embedding(2)),
+                ("chunk3".to_string(), make_embedding(3)),
+            ];
+            HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap()
+        };
 
-        let index = HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap();
-        assert_eq!(index.len(), 3);
-
-        // Search for something similar to chunk1
-        let query = make_embedding(1);
-        let results = index.search(&query, 3);
-
-        assert!(!results.is_empty());
-        // The most similar should be chunk1 itself
-        assert_eq!(results[0].id, "chunk1");
-        assert!(results[0].score > 0.9); // Should be very similar
+        let mut last_ids = Vec::new();
+        let mut hit = None;
+        for _ in 0..8 {
+            let index = build();
+            assert_eq!(index.len(), 3);
+            let results = index.search(&make_embedding(1), 3);
+            assert!(!results.is_empty());
+            last_ids = results.iter().map(|r| r.id.clone()).collect();
+            if let Some(r) = results.iter().find(|r| r.id == "chunk1") {
+                hit = Some(r.score);
+                break;
+            }
+        }
+        let self_score = hit.unwrap_or_else(|| {
+            panic!("chunk1 unreachable across 8 builds (real recall bug, not noise); last top-3 = {last_ids:?}")
+        });
+        // Self-match score must be high (cosine distance ~0).
+        assert!(
+            self_score > 0.9,
+            "self-match score should be high, got {self_score}"
+        );
     }
 
     #[test]
@@ -382,45 +406,73 @@ mod tests {
         Embedding::new(v)
     }
 
+    /// Assert that the exact-match vector `want` is reachable in the top-`k`
+    /// results of an index produced by `build`, retrying the build to absorb
+    /// the rare degenerate concurrent-build graph. `parallel_insert_data`
+    /// under CPU contention yields a self-unreachable node on ~1-2% of builds;
+    /// at 8 retries a transient miss is ~2.5e-14 while a systematic recall bug
+    /// (miss on every build) still fails deterministically.
+    ///
+    /// Each `build()` call runs under `HNSW_ENV_LOCK` so a concurrent
+    /// env-override test cannot perturb the CQS_HNSW_* graph params
+    /// mid-build; the search phase runs unlocked.
+    fn assert_self_match_reachable(
+        build: impl Fn() -> HnswIndex,
+        query: &Embedding,
+        want: &str,
+        k: usize,
+    ) {
+        let mut last_ids = Vec::new();
+        for _ in 0..8 {
+            let index = {
+                let _env = crate::hnsw::HNSW_ENV_LOCK.lock().unwrap();
+                build()
+            };
+            let results = index.search(query, k);
+            assert!(!results.is_empty(), "search returned no results");
+            last_ids = results.iter().map(|r| r.id.clone()).collect();
+            if results.iter().any(|r| r.id == want) {
+                return;
+            }
+        }
+        panic!("{want:?} unreachable across 8 builds (real recall bug, not noise); last top-{k} = {last_ids:?}");
+    }
+
     #[test]
     fn tc31_build_batched_with_dim_1024() {
         // Build HNSW index with 1024-dim embeddings via build_batched_with_dim.
-        let all_embeddings: Vec<(String, Embedding)> = (1..=10)
-            .map(|i| (format!("chunk{}", i), make_embedding_dim(i, 1024)))
-            .collect();
-
-        let batches: Vec<Result<Vec<(String, Embedding)>, std::convert::Infallible>> =
-            all_embeddings
-                .chunks(5)
-                .map(|chunk| Ok(chunk.to_vec()))
+        let build = || {
+            let all_embeddings: Vec<(String, Embedding)> = (1..=10)
+                .map(|i| (format!("chunk{}", i), make_embedding_dim(i, 1024)))
                 .collect();
-
-        let index = HnswIndex::build_batched_with_dim(batches.into_iter(), 10, 1024).unwrap();
-        assert_eq!(index.len(), 10, "HNSW index should have 10 vectors");
-        assert_eq!(index.dim, 1024, "HNSW index dim should be 1024");
-
-        // Search should work with 1024-dim queries
-        let query = make_embedding_dim(1, 1024);
-        let results = index.search(&query, 3);
-        assert!(!results.is_empty(), "Search should return results");
-        assert_eq!(results[0].id, "chunk1", "Nearest neighbor should be chunk1");
+            let batches: Vec<Result<Vec<(String, Embedding)>, std::convert::Infallible>> =
+                all_embeddings
+                    .chunks(5)
+                    .map(|chunk| Ok(chunk.to_vec()))
+                    .collect();
+            let index = HnswIndex::build_batched_with_dim(batches.into_iter(), 10, 1024).unwrap();
+            assert_eq!(index.len(), 10, "HNSW index should have 10 vectors");
+            assert_eq!(index.dim, 1024, "HNSW index dim should be 1024");
+            index
+        };
+        // Recall check with bounded build retries.
+        assert_self_match_reachable(build, &make_embedding_dim(1, 1024), "chunk1", 3);
     }
 
     #[test]
     fn tc31_build_with_dim_1024() {
         // Single-pass build with 1024-dim.
-        let embeddings: Vec<(String, Embedding)> = (1..=5)
-            .map(|i| (format!("item{}", i), make_embedding_dim(i, 1024)))
-            .collect();
-
-        let index = HnswIndex::build_with_dim(embeddings, 1024).unwrap();
-        assert_eq!(index.len(), 5);
-        assert_eq!(index.dim, 1024);
-
-        let query = make_embedding_dim(3, 1024);
-        let results = index.search(&query, 5);
-        assert!(!results.is_empty());
-        assert_eq!(results[0].id, "item3");
+        let build = || {
+            let embeddings: Vec<(String, Embedding)> = (1..=5)
+                .map(|i| (format!("item{}", i), make_embedding_dim(i, 1024)))
+                .collect();
+            let index = HnswIndex::build_with_dim(embeddings, 1024).unwrap();
+            assert_eq!(index.len(), 5);
+            assert_eq!(index.dim, 1024);
+            index
+        };
+        // Recall check with bounded build retries.
+        assert_self_match_reachable(build, &make_embedding_dim(3, 1024), "item3", 5);
     }
 
     #[test]

--- a/src/hnsw/mod.rs
+++ b/src/hnsw/mod.rs
@@ -599,6 +599,23 @@ impl<Mode: crate::store::ClearHnswDirty> crate::index::IndexBackend<Mode> for Hn
     }
 }
 
+/// Shared lock serializing tests that read or mutate the process-global
+/// `CQS_HNSW_*` env vars. A single static (rather than one per test module) is
+/// required: `max_nb_connection_for` / `ef_construction_for` / `ef_search_for`
+/// and `build_with_dim` all read these vars, so an env-override test in one
+/// module can otherwise race a tier-default or build test in another.
+///
+/// Holders: the env-mutating tests (`env_override_tests`,
+/// `test_hnsw_for_helpers_pick_tier`) hold it across their set/read/remove
+/// sequence; the hardened recall/lifecycle tests (`assert_self_match_reachable`
+/// in `build.rs`, the retry loops in `persist.rs`, the lifecycle test in
+/// `safety.rs`) hold it just around the `build_with_dim` /
+/// `build_batched_with_dim` call so their graph params cannot be perturbed
+/// mid-build, while search phases stay parallel. Other build sites tolerate a
+/// transient env override (graph params change, soundness does not).
+#[cfg(test)]
+pub(crate) static HNSW_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Shared test helper: create a deterministic normalized embedding from a seed.
 /// Uses sin-based values for reproducible but varied vectors.
 #[cfg(test)]
@@ -689,6 +706,9 @@ mod send_sync_tests {
 
     #[test]
     fn test_hnsw_for_helpers_pick_tier() {
+        // Serialize against env_override_tests — these vars are process-global
+        // and read by max_nb_connection_for / ef_*_for.
+        let _lock = super::HNSW_ENV_LOCK.lock().unwrap();
         // No env override: helper returns the tier value verbatim.
         std::env::remove_var("CQS_HNSW_M");
         std::env::remove_var("CQS_HNSW_EF_CONSTRUCTION");
@@ -877,11 +897,10 @@ mod insert_batch_tests {
 
 #[cfg(test)]
 mod env_override_tests {
-    use std::sync::Mutex;
-
-    /// Mutex to serialize tests that manipulate CQS_HNSW_* env vars.
-    /// Env vars are process-global -- concurrent test threads race on set/remove.
-    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+    /// Serialize tests that manipulate CQS_HNSW_* env vars. Uses the shared
+    /// module-level lock so tier-default / build tests in other modules also
+    /// serialize against these process-global mutations.
+    use super::HNSW_ENV_LOCK as ENV_MUTEX;
 
     #[test]
     fn test_m_default() {

--- a/src/hnsw/persist.rs
+++ b/src/hnsw/persist.rs
@@ -1368,25 +1368,42 @@ mod tests {
 
     #[test]
     fn test_save_and_load() {
-        let tmp = TempDir::new().unwrap();
-
-        let embeddings = vec![
-            ("chunk1".to_string(), make_embedding(1)),
-            ("chunk2".to_string(), make_embedding(2)),
-        ];
-
-        let index = HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap();
-        index.save(tmp.path(), "index").unwrap();
-
-        assert!(HnswIndex::exists(tmp.path(), "index"));
-
-        let loaded = HnswIndex::load_with_dim(tmp.path(), "index", crate::EMBEDDING_DIM).unwrap();
-        assert_eq!(loaded.len(), 2);
-
-        // Verify search still works
-        let query = make_embedding(1);
-        let results = loaded.search(&query, 2);
-        assert_eq!(results[0].id, "chunk1");
+        // This test pins the save → exists → load roundtrip. The recall check
+        // (chunk1 reachable post-load) retries the build to absorb the rare
+        // degenerate concurrent-build graph: `parallel_insert_data`
+        // under CPU contention can make even the cosine-distance-0 self-match
+        // unreachable on ~1-2% of builds. The roundtrip itself (exists/len) is
+        // asserted unconditionally on every build.
+        let mut found = false;
+        let mut last_ids = Vec::new();
+        for _ in 0..8 {
+            let tmp = TempDir::new().unwrap();
+            let embeddings = vec![
+                ("chunk1".to_string(), make_embedding(1)),
+                ("chunk2".to_string(), make_embedding(2)),
+            ];
+            // Env lock scoped to the build: build_with_dim reads CQS_HNSW_*
+            // and must not race a concurrent env-override test.
+            let index = {
+                let _env = crate::hnsw::HNSW_ENV_LOCK.lock().unwrap();
+                HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap()
+            };
+            index.save(tmp.path(), "index").unwrap();
+            assert!(HnswIndex::exists(tmp.path(), "index"));
+            let loaded =
+                HnswIndex::load_with_dim(tmp.path(), "index", crate::EMBEDDING_DIM).unwrap();
+            assert_eq!(loaded.len(), 2);
+            let results = loaded.search(&make_embedding(1), 2);
+            last_ids = results.iter().map(|r| r.id.clone()).collect();
+            if results.iter().any(|r| r.id == "chunk1") {
+                found = true;
+                break;
+            }
+        }
+        assert!(
+            found,
+            "chunk1 unreachable post-load across 8 builds (real recall bug, not noise); last top-2 = {last_ids:?}"
+        );
     }
 
     // ===== multi-model dim-threading (HNSW persist) =====
@@ -1410,35 +1427,46 @@ mod tests {
     fn tc31_save_and_load_with_dim_1024() {
         // Save a 1024-dim HNSW index, load with load_with_dim(1024),
         // verify it loads and searches correctly.
-        let tmp = TempDir::new().unwrap();
+        //
+        // The save/load roundtrip (dim + len) is asserted on every build. The
+        // recall check (vec1 reachable post-load) retries the build to absorb
+        // the rare degenerate concurrent-build graph: the five
+        // sin-derived vectors are near-parallel (adjacent seeds ~0.995 cosine)
+        // and `parallel_insert_data` under CPU contention can make even the
+        // exact-match vector unreachable on ~1-2% of builds. A systematic
+        // recall bug (miss on every build) still fails deterministically.
         let basename = "test_1024";
+        let mut found = false;
+        let mut last_ids = Vec::new();
+        for _ in 0..8 {
+            let tmp = TempDir::new().unwrap();
+            let embeddings: Vec<(String, crate::embedder::Embedding)> = (1..=5)
+                .map(|i| (format!("vec{}", i), make_embedding_dim(i, 1024)))
+                .collect();
+            // Env lock scoped to the build: build_with_dim reads CQS_HNSW_*
+            // and must not race a concurrent env-override test.
+            let index = {
+                let _env = crate::hnsw::HNSW_ENV_LOCK.lock().unwrap();
+                HnswIndex::build_with_dim(embeddings, 1024).unwrap()
+            };
+            assert_eq!(index.dim, 1024);
+            index.save(tmp.path(), basename).unwrap();
 
-        let embeddings: Vec<(String, crate::embedder::Embedding)> = (1..=5)
-            .map(|i| (format!("vec{}", i), make_embedding_dim(i, 1024)))
-            .collect();
+            let loaded = HnswIndex::load_with_dim(tmp.path(), basename, 1024).unwrap();
+            assert_eq!(loaded.len(), 5, "Loaded index should have 5 vectors");
+            assert_eq!(loaded.dim, 1024, "Loaded index dim should be 1024");
 
-        let index = HnswIndex::build_with_dim(embeddings, 1024).unwrap();
-        assert_eq!(index.dim, 1024);
-        index.save(tmp.path(), basename).unwrap();
-
-        // Load with matching dim
-        let loaded = HnswIndex::load_with_dim(tmp.path(), basename, 1024).unwrap();
-        assert_eq!(loaded.len(), 5, "Loaded index should have 5 vectors");
-        assert_eq!(loaded.dim, 1024, "Loaded index dim should be 1024");
-
-        // Search should work correctly. HNSW is approximate and the five
-        // sin-derived vectors are near-parallel (adjacent seeds ~0.995
-        // cosine), so exact rank-1 is not guaranteed across hnsw_rs's
-        // internal RNG; assert top-k containment of the exact-match vector
-        // instead. If vec1 ever drops out of the top 3 entirely, that's a
-        // real reachability bug, not noise.
-        let query = make_embedding_dim(1, 1024);
-        let results = loaded.search(&query, 3);
-        assert!(!results.is_empty(), "Search should return results");
-        let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+            let results = loaded.search(&make_embedding_dim(1, 1024), 3);
+            assert!(!results.is_empty(), "Search should return results");
+            last_ids = results.iter().map(|r| r.id.clone()).collect();
+            if results.iter().any(|r| r.id == "vec1") {
+                found = true;
+                break;
+            }
+        }
         assert!(
-            ids.contains(&"vec1"),
-            "exact-match vector should be in top-3, got {ids:?}"
+            found,
+            "exact-match vec1 unreachable post-load across 8 builds (real recall bug, not noise); last top-3 = {last_ids:?}"
         );
     }
 

--- a/src/hnsw/safety.rs
+++ b/src/hnsw/safety.rs
@@ -89,17 +89,58 @@ mod tests {
             ("b".to_string(), make_embedding(200)),
             ("c".to_string(), make_embedding(300)),
         ];
-        HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM)
-            .unwrap()
-            .save(tmp.path(), "lifecycle")
-            .unwrap();
+        // Env lock scoped to the build: build_with_dim reads CQS_HNSW_*
+        // and must not race a concurrent env-override test.
+        {
+            let _env = crate::hnsw::HNSW_ENV_LOCK.lock().unwrap();
+            HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM)
+                .unwrap()
+                .save(tmp.path(), "lifecycle")
+                .unwrap();
+        }
 
-        // Load-search-drop cycle multiple times
+        // Load-search-drop cycle multiple times.
+        //
+        // This test pins the self-referential `LoadedHnsw` lifecycle — that
+        // load → search → drop does not trigger use-after-free or return
+        // corrupted IDs. It deliberately does NOT assert HNSW recall.
+        //
+        // Why no recall assertion: the graph is built via
+        // `parallel_insert_data` (rayon) and hnsw_rs seeds its layer
+        // generator from OS entropy (`StdRng::from_os_rng`). Under CPU
+        // saturation the concurrent entry-point race in `check_entry_point`
+        // produces a degenerate topology on ~1-2% of builds where even the
+        // exact self-match vector (cosine distance 0 to "a") is unreachable.
+        // Measured: parallel insert = 52/3000 self-misses under 16-core load;
+        // sequential insert = 0/3000. This is an hnsw_rs concurrent-build
+        // recall characteristic, not a cqs soundness bug — search on a fixed
+        // index is deterministic (0/100k misses). Asserting "a" appears would
+        // make this test flake under full-suite parallelism. Lifecycle
+        // soundness is what safety.rs guards; recall lives in build/persist
+        // tests with bounded build retries.
         for cycle in 0..5 {
             let loaded =
                 HnswIndex::load_with_dim(tmp.path(), "lifecycle", crate::EMBEDDING_DIM).unwrap();
+            assert_eq!(loaded.len(), 3, "Cycle {} loaded wrong count", cycle);
             let results = loaded.search(&make_embedding(100), 3);
-            assert_eq!(results[0].id, "a", "Cycle {} failed", cycle);
+            // Soundness, not recall: results are non-empty and every returned
+            // ID is one of the three we inserted (garbage IDs would indicate
+            // memory corruption in the self-cell pattern).
+            assert!(!results.is_empty(), "Cycle {} returned no results", cycle);
+            for r in &results {
+                assert!(
+                    matches!(r.id.as_str(), "a" | "b" | "c"),
+                    "Cycle {} returned corrupted ID {:?}",
+                    cycle,
+                    r.id
+                );
+                assert!(
+                    r.score.is_finite(),
+                    "Cycle {} returned non-finite score for {:?}",
+                    cycle,
+                    r.id
+                );
+            }
             // Drop happens here
         }
     }


### PR DESCRIPTION
Closes #1693 — test-suite concurrency hardening, with the root cause named and quantified rather than waved at.

## The mechanism (not a flake)

`test_loaded_index_lifecycle`'s failures trace to hnsw_rs's `parallel_insert_data`: OS-entropy-seeded layer RNG + a racing entry-point write produce a different graph topology per build under CPU saturation, leaving a node unreachable on ~1-2% of contended builds. Quantified at three isolation levels: 6/5000 full-suite saturation; 52/3000 parallel-insert vs **0/3000 sequential** at the library boundary; **0/100,000** searching a fixed index. Construction-side nondeterminism, search is sound, cqs uses the API correctly — production keeps parallel insert (the recall edge only appears on saturated test runners). The reproducible dataset is a candidate upstream hnsw_rs issue, pending owner authorization (noted in the triage doc).

## Changes (test-only — zero production diff, verified by review)

- Six exact rank-1 assertions on approximate structures → top-k containment with bounded build retry (8 fresh rebuilds: transient ~1% miss → ~1e-14, while a systematic recall regression still fails deterministically on all 8)
- Lifecycle test asserts soundness invariants only (len, valid IDs, finite scores — stronger than before on the first two)
- Real cross-module bug fixed: two uncoordinated env mutexes guarding the same CQS_HNSW_* keys → one shared HNSW_ENV_LOCK, with the hardened tests' build sites enrolled (lock scoped to the build call; module wall time unchanged)
- CONTRIBUTING gains the test-concurrency policy (GPU lock / env lock / containment+retry rules)
- #[ignore] inventory swept (the #1692 rot lesson): all ignored tests accounted for, two non-model classes run and passing

## Review

Fix-first round (provenance lint + lock-doc-vs-reality gap) — both resolved, lock enrollment implemented rather than doc-downgraded. Hardened modules 3× at --test-threads=8: 87/87 × 3. Build/clippy/fmt clean; lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
