### PR TITLE
docs(triage): hnsw_rs recall issue filed upstream (hnswlib-rs#32)

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -53,9 +53,9 @@ Ordered for the fix loop, all positioned relative to the command-core campaign:
 3. **#1690** — posture/output-format matrix consolidation (after campaign phase 4 — same surface; subsumes the CQ-V1.40-5/6 and TC-ADV-V1.40-1 queue entries above).
 4. **#1691** — split big-with-logic monoliths with fixture-refresh discipline (after campaign phases 2-3 to avoid diff churn).
 
-### Pending user go: upstream hnsw_rs issue (2026-06-10)
+### Upstream hnsw_rs issue — FILED (2026-06-10, user-authorized)
 
-#1693's root-cause produced a reproducible upstream finding: hnsw_rs `parallel_insert_data` yields self-unreachable nodes on ~1-2% of builds under CPU saturation (52/3000 parallel vs 0/3000 sequential inserts; 0/100k searching a fixed index — construction-side, entry-point write race + OS-seeded layer RNG suspected). Filing an issue on the hnsw_rs repo with this data + a deterministic-seeding suggestion needs user authorization (new upstream relationship, unlike rapidsai/cuvs).
+#1693's root-cause produced a reproducible upstream finding: hnsw_rs `parallel_insert_data` yields self-unreachable nodes on ~1-2% of builds under CPU saturation (52/3000 parallel vs 0/3000 sequential inserts; 0/100k searching a fixed index — construction-side, entry-point write race at `check_entry_point` hnsw.rs:529 + OS-seeded layer RNG `StdRng::from_os_rng()` hnsw.rs:328, refs verified against the 0.3.4 crate source). Filed as **jean-pierreBoth/hnswlib-rs#32** with three suggested fixes (deterministic-seed option, layer-height-guarded entry-point CAS, or documenting the recall characteristic) and an offer of the stress harness / a PR. Our side is already hardened (#1702 containment + bounded retry), so nothing blocks on the maintainer's response.
 
 ### Still deferred (unchanged decision)
 


### PR DESCRIPTION
Flips the triage doc's "Pending user go" entry to FILED: the hnsw_rs `parallel_insert_data` recall finding from #1693 is now upstream as jean-pierreBoth/hnswlib-rs#32 (user-authorized). Source refs in the issue were verified against the 0.3.4 crate source before filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
