### PR TITLE
fix(reuse): propagate store errors on watch path, shared canon_key_ref, gated model_fingerprint

### DIFF
--- a/src/cli/pipeline/embedding.rs
+++ b/src/cli/pipeline/embedding.rs
@@ -28,7 +28,7 @@ pub(super) fn prepare_for_embedding(
     embedder: &Embedder,
     store: &Store,
     global_cache: Option<&cqs::cache::EmbeddingCache>,
-    model_fingerprint: &str,
+    model_fingerprint: Option<&str>,
 ) -> PreparedEmbedding {
     let _span = tracing::info_span!("prepare_for_embedding").entered();
     use cqs::generate_nl_description_with_seq_len;
@@ -49,13 +49,27 @@ pub(super) fn prepare_for_embedding(
     // the reuse DECISION so the canonical_hash key (and any future
     // reuse-semantics change) lives in exactly one place.
     let dim = embedder.embedding_dim();
-    let split = crate::cli::pipeline::resolve_reuse(
+    // A store-cache read failure is non-fatal on the bulk path: warn and
+    // degrade to re-embedding the batch (the watch path, by contrast,
+    // propagates the error so the daemon retries next tick — see
+    // `resolve_reuse`'s error contract).
+    let split = match crate::cli::pipeline::resolve_reuse(
         &windowed_chunks,
         store,
         global_cache,
         dim,
         model_fingerprint,
-    );
+    ) {
+        Ok(split) => split,
+        Err(e) => {
+            tracing::warn!(error = %e, "Embedding-reuse resolution failed; re-embedding batch");
+            super::reuse::ReuseSplit {
+                cached: Vec::new(),
+                to_embed: (0..windowed_chunks.len()).collect(),
+                global_hits: 0,
+            }
+        }
+    };
     let global_hits_total = split.global_hits;
 
     // Step 3: Map the index split into this caller's owned output shape.
@@ -189,7 +203,13 @@ pub(super) fn gpu_embed_stage(
     let _span = tracing::info_span!("embed_thread", mode = "gpu").entered();
     let embedder = Embedder::new(ctx.model_config).context("Failed to initialize GPU embedder")?;
     embedder.warm().context("Failed to warm GPU embedder")?;
-    let fingerprint = embedder.model_fingerprint().to_string();
+    // The fingerprint's only consumer is the global cache, and its first
+    // computation streams blake3 over the full ONNX model file — skip it
+    // entirely when no cache is present.
+    let fingerprint: Option<String> = ctx
+        .global_cache
+        .is_some()
+        .then(|| embedder.model_fingerprint());
 
     for batch in parse_rx {
         if check_interrupted() {
@@ -202,7 +222,7 @@ pub(super) fn gpu_embed_stage(
             &embedder,
             &ctx.store,
             ctx.global_cache.as_deref(),
-            &fingerprint,
+            fingerprint.as_deref(),
         );
 
         if prepared.to_embed.is_empty() {
@@ -306,26 +326,23 @@ pub(super) fn gpu_embed_stage(
                 // and embedding vec into an owned tuple per batch. The borrowed
                 // slices live until `write_batch` returns, well within the
                 // chunk/embedding lifetimes here.
-                if let Some(ref cache) = ctx.global_cache {
+                if let (Some(cache), Some(fp)) =
+                    (ctx.global_cache.as_deref(), fingerprint.as_deref())
+                {
                     // Write under the canonical key (v28) so a later
-                    // comment-only edit reuses this embedding. Fall back to
-                    // content_hash only for a chunk with no canonical_hash.
+                    // comment-only edit reuses this embedding — the shared
+                    // `canon_key_ref` owns the empty-canonical fallback.
                     let entries: Vec<(&str, &[f32])> = prepared
                         .to_embed
                         .iter()
                         .zip(new_embeddings.iter())
                         .map(|(chunk, emb)| {
-                            let key = if chunk.canonical_hash.is_empty() {
-                                chunk.content_hash.as_str()
-                            } else {
-                                chunk.canonical_hash.as_str()
-                            };
-                            (key, emb.as_slice())
+                            (crate::cli::pipeline::canon_key_ref(chunk), emb.as_slice())
                         })
                         .collect();
                     if let Err(e) = cache.write_batch(
                         &entries,
-                        &fingerprint,
+                        fp,
                         cqs::cache::CachePurpose::Embedding,
                         embedder.embedding_dim(),
                     ) {
@@ -449,17 +466,23 @@ pub(super) fn cpu_embed_stage(
             }
         };
 
-        // Compute fingerprint lazily (after embedder init)
-        if fingerprint.is_none() {
-            fingerprint = Some(emb.model_fingerprint().to_string());
+        // Compute fingerprint lazily (after embedder init), and only when a
+        // global cache exists — the fingerprint's only consumer is the cache,
+        // and its first computation streams blake3 over the full ONNX model.
+        if fingerprint.is_none() && ctx.global_cache.is_some() {
+            fingerprint = Some(emb.model_fingerprint());
         }
-        let fp = fingerprint.as_deref().unwrap_or("");
 
         // Prepare batch: windowing, cache check, text generation
         // (still useful in skip-first-pass mode — windowing splits long chunks
         // and cache lookup salvages real embeddings for hit chunks).
-        let prepared =
-            prepare_for_embedding(batch, emb, &ctx.store, ctx.global_cache.as_deref(), fp);
+        let prepared = prepare_for_embedding(
+            batch,
+            emb,
+            &ctx.store,
+            ctx.global_cache.as_deref(),
+            fingerprint.as_deref(),
+        );
 
         // Skip-first-pass-embed short-circuit (CPU side). Mirrors the GPU
         // stage above — emit zero-vec sentinels for to_embed chunks stamped
@@ -514,20 +537,13 @@ pub(super) fn cpu_embed_stage(
             //
             // Build with borrows so we don't clone every `content_hash` and
             // embedding vec into an owned tuple per batch.
-            if let Some(ref cache) = ctx.global_cache {
+            if let (Some(cache), Some(fp)) = (ctx.global_cache.as_deref(), fingerprint.as_deref()) {
                 // Write under the canonical key (v28) — see GPU-stage note.
                 let entries: Vec<(&str, &[f32])> = prepared
                     .to_embed
                     .iter()
                     .zip(embs.iter())
-                    .map(|(chunk, emb)| {
-                        let key = if chunk.canonical_hash.is_empty() {
-                            chunk.content_hash.as_str()
-                        } else {
-                            chunk.canonical_hash.as_str()
-                        };
-                        (key, emb.as_slice())
-                    })
+                    .map(|(chunk, e)| (crate::cli::pipeline::canon_key_ref(chunk), e.as_slice()))
                     .collect();
                 if let Err(e) = cache.write_batch(
                     &entries,

--- a/src/cli/pipeline/mod.rs
+++ b/src/cli/pipeline/mod.rs
@@ -13,7 +13,7 @@ mod upsert;
 mod windowing;
 
 // Re-export public items
-pub(crate) use reuse::resolve_reuse;
+pub(crate) use reuse::{canon_key_ref, resolve_reuse};
 pub(crate) use types::embed_batch_size_for;
 pub(crate) use types::PipelineStats;
 pub(crate) use windowing::apply_windowing;
@@ -592,7 +592,7 @@ mod tests {
         let chunk = make_test_chunk("fresh", "fn fresh() {}");
         let batch = make_parsed_batch_with_chunk(chunk);
 
-        let prepared = prepare_for_embedding(batch, &embedder, &store, None, "test-fp");
+        let prepared = prepare_for_embedding(batch, &embedder, &store, None, None);
 
         assert!(
             prepared.cached.is_empty(),
@@ -664,7 +664,7 @@ mod tests {
         );
         let batch = make_parsed_batch_with_chunk(lookup_chunk);
 
-        let prepared = prepare_for_embedding(batch, &embedder, &store, None, "test-fp");
+        let prepared = prepare_for_embedding(batch, &embedder, &store, None, None);
 
         assert_eq!(
             prepared.cached.len(),
@@ -710,7 +710,7 @@ mod tests {
             file_mtimes: std::collections::HashMap::new(),
         };
 
-        let prepared = prepare_for_embedding(batch, &embedder, &store, None, "test-fp");
+        let prepared = prepare_for_embedding(batch, &embedder, &store, None, None);
 
         assert!(prepared.cached.is_empty());
         assert!(prepared.to_embed.is_empty());

--- a/src/cli/pipeline/reuse.rs
+++ b/src/cli/pipeline/reuse.rs
@@ -33,11 +33,15 @@ use cqs::{Chunk, Embedding, Store};
 /// `content_hash` so it still gets a usable, content-exact key — the
 /// NULL/empty-canonical fallback every reuse site must share; having it in
 /// one place is the point of this module.
-pub(crate) fn canon_key(c: &Chunk) -> String {
+///
+/// Borrows from the chunk so both the read path ([`resolve_reuse`]) and the
+/// cache write-back sites (bulk GPU/CPU stages, watch reindex) share the SAME
+/// key function without per-chunk `String` allocation on hot paths.
+pub(crate) fn canon_key_ref(c: &Chunk) -> &str {
     if c.canonical_hash.is_empty() {
-        c.content_hash.clone()
+        &c.content_hash
     } else {
-        c.canonical_hash.clone()
+        &c.canonical_hash
     }
 }
 
@@ -70,8 +74,20 @@ pub(crate) struct ReuseSplit {
 ///    `.remove()`, falling through to `to_embed` on a miss.
 ///
 /// `dim` is the embedder's embedding dimension and `model_fingerprint` its
-/// model fingerprint (already computed by each caller). Both are passed in
-/// rather than re-derived so this stays decoupled from the `Embedder` type.
+/// model fingerprint (computed by each caller, and ONLY when a global cache is
+/// present — the fingerprint's first computation streams blake3 over the full
+/// ONNX model file, so callers gate it on `global_cache.is_some()`). Both are
+/// passed in rather than re-derived so this stays decoupled from the
+/// `Embedder` type. The fingerprint is only consumed by the global-cache
+/// branch; `None` with `global_cache: Some(..)` skips that branch.
+///
+/// # Errors
+///
+/// A per-slot STORE-cache read failure returns `Err` — the watch path
+/// propagates it (aborting the cycle so the daemon retries next tick with the
+/// error visible) while the bulk pipeline catches it, warns, and degrades to
+/// re-embedding the batch. The GLOBAL-cache read stays best-effort internally:
+/// a read error there logs and degrades to the store cache, never blocks.
 ///
 /// **Duplicate-key fallthrough contract (load-bearing, tested):** two chunks
 /// that share a canonical key within one batch (identical after normalization —
@@ -83,12 +99,11 @@ pub(crate) fn resolve_reuse(
     store: &Store,
     global_cache: Option<&cqs::cache::EmbeddingCache>,
     dim: usize,
-    model_fingerprint: &str,
-) -> ReuseSplit {
+    model_fingerprint: Option<&str>,
+) -> anyhow::Result<ReuseSplit> {
     let _span = tracing::debug_span!("resolve_reuse", chunks = chunks.len()).entered();
 
-    let canon_hashes: Vec<String> = chunks.iter().map(canon_key).collect();
-    let hashes: Vec<&str> = canon_hashes.iter().map(|s| s.as_str()).collect();
+    let hashes: Vec<&str> = chunks.iter().map(canon_key_ref).collect();
 
     // Step 1: global (project-scoped, cross-slot) cache. Best-effort — a read
     // error logs and degrades to the store cache, never blocks indexing.
@@ -97,10 +112,10 @@ pub(crate) fn resolve_reuse(
     // purpose. EmbeddingBase has no producer here yet — when enrichment caching
     // lands it will own its own purpose.
     let mut global_hits: HashMap<String, Embedding> = HashMap::new();
-    if let Some(cache) = global_cache {
+    if let (Some(cache), Some(fingerprint)) = (global_cache, model_fingerprint) {
         match cache.read_batch(
             &hashes,
-            model_fingerprint,
+            fingerprint,
             cqs::cache::CachePurpose::Embedding,
             dim,
         ) {
@@ -128,6 +143,11 @@ pub(crate) fn resolve_reuse(
     // Store-side reuse is also keyed by canonical_hash (v28). Rows whose
     // canonical_hash IS NULL (pre-v28) are skipped by the helper, so they
     // re-embed on first touch — a clean cache miss, never a wrong hit.
+    //
+    // A read failure here propagates as `Err` — see the function doc. The
+    // watch path needs the failure visible (a persistent SQLite error must not
+    // silently become a total cache miss that re-embeds the corpus on GPU each
+    // cycle); the bulk pipeline catches it and degrades.
     let mut store_hits: HashMap<String, Embedding> = if dim == store.dim() {
         let missed: Vec<&str> = hashes
             .iter()
@@ -137,13 +157,12 @@ pub(crate) fn resolve_reuse(
         if missed.is_empty() {
             HashMap::new()
         } else {
-            match store.get_embeddings_by_canonical_hashes(&missed) {
-                Ok(map) => map,
-                Err(e) => {
-                    tracing::warn!(error = %e, "Failed to fetch cached embeddings by canonical hash");
-                    HashMap::new()
-                }
-            }
+            store
+                .get_embeddings_by_canonical_hashes(&missed)
+                .map_err(|e| {
+                    anyhow::anyhow!(e)
+                        .context("Failed to fetch cached embeddings by canonical hash")
+                })?
         }
     } else {
         tracing::info!(
@@ -163,21 +182,21 @@ pub(crate) fn resolve_reuse(
     let global_hits_total = global_hits.len();
     let mut cached: Vec<(usize, Embedding)> = Vec::new();
     let mut to_embed: Vec<usize> = Vec::new();
-    for (i, key) in canon_hashes.iter().enumerate() {
-        if let Some(emb) = global_hits.remove(key) {
+    for (i, key) in hashes.iter().enumerate() {
+        if let Some(emb) = global_hits.remove(*key) {
             cached.push((i, emb));
-        } else if let Some(emb) = store_hits.remove(key) {
+        } else if let Some(emb) = store_hits.remove(*key) {
             cached.push((i, emb));
         } else {
             to_embed.push(i);
         }
     }
 
-    ReuseSplit {
+    Ok(ReuseSplit {
         cached,
         to_embed,
         global_hits: global_hits_total,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -235,7 +254,7 @@ mod tests {
         let mut seeded = chunk_with("seed", "fn seeded() {}", "");
         // The store binds an empty canonical_hash as NULL (async_helpers.rs),
         // so the store-side canonical lookup can never hit for such chunks; this
-        // test pins the READ-side fallback: canon_key uses content_hash when
+        // test pins the READ-side fallback: canon_key_ref uses content_hash when
         // canonical_hash is empty, letting the global cache still serve.
         seeded.canonical_hash = seeded.content_hash.clone();
         let mut v = vec![0.0_f32; dim];
@@ -244,12 +263,12 @@ mod tests {
             .upsert_chunks_batch(&[(seeded.clone(), Embedding::new(v))], Some(0))
             .unwrap();
 
-        // Lookup chunk: same content, empty canonical → canon_key == content_hash.
+        // Lookup chunk: same content, empty canonical → canon_key_ref == content_hash.
         let lookup = chunk_with("lookup", "fn seeded() {}", "");
         assert!(lookup.canonical_hash.is_empty());
-        assert_eq!(canon_key(&lookup), lookup.content_hash);
+        assert_eq!(canon_key_ref(&lookup), lookup.content_hash);
 
-        let split = resolve_reuse(&[lookup], &store, None, dim, "fp");
+        let split = resolve_reuse(&[lookup], &store, None, dim, None).unwrap();
         assert_eq!(
             split.cached.len(),
             1,
@@ -278,10 +297,10 @@ mod tests {
         // Two lookup chunks that both key on "dup".
         let a = chunk_with("a", "fn a() {}", "dup");
         let b = chunk_with("b", "fn b_but_same_canon() {}", "dup");
-        assert_eq!(canon_key(&a), "dup");
-        assert_eq!(canon_key(&b), "dup");
+        assert_eq!(canon_key_ref(&a), "dup");
+        assert_eq!(canon_key_ref(&b), "dup");
 
-        let split = resolve_reuse(&[a, b], &store, None, dim, "fp");
+        let split = resolve_reuse(&[a, b], &store, None, dim, None).unwrap();
         assert_eq!(
             split.cached.len(),
             1,
@@ -306,7 +325,7 @@ mod tests {
             chunk_with("c1", "fn one() {}", "k1"),
             chunk_with("c2", "fn two() {}", "k2"),
         ];
-        let split = resolve_reuse(&chunks, &store, None, dim, "fp");
+        let split = resolve_reuse(&chunks, &store, None, dim, None).unwrap();
         assert!(split.cached.is_empty());
         assert_eq!(split.to_embed, vec![0, 1]);
         assert_eq!(split.global_hits, 0);
@@ -328,7 +347,7 @@ mod tests {
 
         let lookup = chunk_with("a", "fn a() {}", "k1");
         // Resolve with a DIFFERENT embedder dim → store cache skipped.
-        let split = resolve_reuse(&[lookup], &store, None, store_dim + 1, "fp");
+        let split = resolve_reuse(&[lookup], &store, None, store_dim + 1, None).unwrap();
         assert!(
             split.cached.is_empty(),
             "dim mismatch must skip store cache"

--- a/src/cli/watch/reindex.rs
+++ b/src/cli/watch/reindex.rs
@@ -463,9 +463,22 @@ pub(super) fn reindex_files(
     // `resolve_reuse` returns indices into `chunks` (a borrowed slice here);
     // we rebuild the `(usize, &Chunk)` shape the order-merge below expects so
     // cache hits stay out of the incremental HNSW insert set.
+    // Compute the model fingerprint only when a global cache exists — it's
+    // the fingerprint's only consumer here (resolve_reuse's global branch +
+    // the write-back below), and its first computation streams blake3 over
+    // the full ONNX model file. Computed once and reused at both sites.
     let dim = embedder.embedding_dim();
-    let model_fp = embedder.model_fingerprint();
-    let split = crate::cli::pipeline::resolve_reuse(&chunks, store, global_cache, dim, &model_fp);
+    let model_fp: Option<String> = global_cache.is_some().then(|| embedder.model_fingerprint());
+    // `?` on a store-cache read failure aborts this cycle so the watch loop
+    // retries next tick with the error visible — a persistent SQLite failure
+    // must NOT silently degrade into re-embedding the corpus on GPU each tick.
+    let split = crate::cli::pipeline::resolve_reuse(
+        &chunks,
+        store,
+        global_cache,
+        dim,
+        model_fp.as_deref(),
+    )?;
     let global_hits_total = split.global_hits;
     let cached: Vec<(usize, Embedding)> = split.cached;
     let to_embed: Vec<(usize, &cqs::Chunk)> = split
@@ -515,30 +528,17 @@ pub(super) fn reindex_files(
     // (or another slot) hits cache instead of going through the embedder.
     // Best-effort — mirrors the bulk pipeline's write-back shape with borrowed
     // slices to skip per-entry allocations.
-    if let (Some(cache), false) = (global_cache, to_embed.is_empty()) {
+    if let (Some(cache), Some(fp), false) = (global_cache, model_fp.as_deref(), to_embed.is_empty())
+    {
         // Write under the canonical key (v28) so a later comment-only edit
-        // reuses this embedding. Falls back to content_hash when absent.
-        // Key choice must stay in sync with `pipeline::reuse::canon_key`
-        // (inlined here as &str borrows to avoid per-entry String allocation
-        // on the write-back hot path).
+        // reuses this embedding — the shared `canon_key_ref` owns the
+        // empty-canonical fallback for both read and write-back sites.
         let entries: Vec<(&str, &[f32])> = to_embed
             .iter()
             .zip(new_embeddings.iter())
-            .map(|((_, chunk), emb)| {
-                let key = if chunk.canonical_hash.is_empty() {
-                    chunk.content_hash.as_str()
-                } else {
-                    chunk.canonical_hash.as_str()
-                };
-                (key, emb.as_slice())
-            })
+            .map(|((_, chunk), emb)| (crate::cli::pipeline::canon_key_ref(chunk), emb.as_slice()))
             .collect();
-        if let Err(e) = cache.write_batch(
-            &entries,
-            &embedder.model_fingerprint(),
-            cqs::cache::CachePurpose::Embedding,
-            dim,
-        ) {
+        if let Err(e) = cache.write_batch(&entries, fp, cqs::cache::CachePurpose::Embedding, dim) {
             tracing::warn!(error = %e, "Watch global cache write failed (best-effort)");
         }
     }


### PR DESCRIPTION
Code-review follow-up to #1701 (high-effort review of the taste-debt queue, 3 confirmed findings on the reuse resolver).

## Findings fixed

1. **Watch path error downgrade (medium).** `resolve_reuse` had adopted the bulk pipeline's warn-and-continue on store-cache read failure, so a persistent SQLite error during watch reindex silently became a total cache miss — full GPU re-embed every cycle with only a `tracing::warn`. Now `resolve_reuse` returns `anyhow::Result`: the watch path propagates with `?` (restoring pre-#1701 fail-and-retry semantics), the bulk pipeline catches, warns, and degrades. The global-cache read stays best-effort as documented.

2. **canon_key triplication (medium).** The canonical-key fallback rule was centralized for reads only; three cache write-back sites (bulk GPU/CPU stages, watch reindex) hand-inlined it with "must stay in sync" comments. `canon_key_ref(&Chunk) -> &str` replaces the owned `canon_key` and is now the single key function for read and all write-back sites — kills the drift hazard and the per-chunk `String` allocation on the hot index path.

3. **Unconditional model_fingerprint (low).** #1701 hoisted `embedder.model_fingerprint()` out of the `global_cache` guard, so the cache-disabled/failed-open watch path paid a streaming blake3 over the full ONNX model file (~550 MB for EmbeddingGemma) for a value never read — and the watch write-back called it a second time. Fingerprint is now `Option<&str>` through `resolve_reuse`, computed at most once per stage/reindex, only when a global cache is present.

Review thread: findings 1, 4, 6 of the 2026-06-10 high-effort review (15 confirmed findings across 5 PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
