### PR TITLE
refactor(tests): single cqs_v1 helper in tests/common (was 33 copies), token-bounded REMOVED_VARS guard

### DIFF
--- a/tests/cli_blame_test.rs
+++ b/tests/cli_blame_test.rs
@@ -14,25 +14,14 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use std::process::Command as StdCommand;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Set up a tiny git repo with a single Rust source file containing a
 /// known function, run `git init` + commit + `cqs init` + `cqs index`.

--- a/tests/cli_brief_test.rs
+++ b/tests/cli_brief_test.rs
@@ -12,24 +12,13 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Build a project with three functions and a test exercising one of them.
 /// `process` is called by `main` (1 caller) and by `test_process` (1 test);

--- a/tests/cli_cache_test.rs
+++ b/tests/cli_cache_test.rs
@@ -19,22 +19,12 @@
 //! sqlite cache), so they are NOT gated `slow-tests` — they execute on
 //! every PR run.
 
+mod common;
+
 use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use serial_test::serial;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Force CLI mode (no daemon) so a daemon attached to the dev machine's
 /// real cache can't intercept the call.

--- a/tests/cli_chat_completer_test.rs
+++ b/tests/cli_chat_completer_test.rs
@@ -17,24 +17,13 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 fn setup_chat_project() -> TempDir {
     let dir = TempDir::new().expect("tempdir");

--- a/tests/cli_convert_test.rs
+++ b/tests/cli_convert_test.rs
@@ -11,23 +11,12 @@
 //! SEC-4 canonicalize/warn logic, and the `clean_tags` CSV split — was
 //! reachable only by the binary at runtime. These tests pin the orchestrator.
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// TC-HAP-V1.33-1: single-file HTML conversion writes Markdown to the
 /// inferred output dir (parent of the source). Pins the happy path

--- a/tests/cli_doctor_fix_test.rs
+++ b/tests/cli_doctor_fix_test.rs
@@ -20,24 +20,13 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Build a minimal project with one indexable Rust function so `cqs index`
 /// has work to do.

--- a/tests/cli_drift_diff_test.rs
+++ b/tests/cli_drift_diff_test.rs
@@ -18,24 +18,13 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Build the project to be compared against. Two functions; the body of
 /// `process` is large enough that a real semantic embedding gets a

--- a/tests/cli_eval_freshness_gate_test.rs
+++ b/tests/cli_eval_freshness_gate_test.rs
@@ -35,7 +35,7 @@
 
 mod common;
 
-use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use serde_json::json;
 use serial_test::serial;
 use std::io::{BufRead, BufReader, Write};
@@ -49,19 +49,6 @@ use tempfile::TempDir;
 
 use common::mock_embedding;
 use cqs::parser::{Chunk, ChunkType, Language};
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Mirror `cqs::daemon_translate::daemon_socket_path` but with explicit
 /// runtime-dir override so the mock and the spawned CLI agree on which

--- a/tests/cli_eval_reranker_test.rs
+++ b/tests/cli_eval_reranker_test.rs
@@ -12,24 +12,14 @@
 //! pin the `none` and `llm` branches at the binary level — `onnx` requires
 //! the model fixture, deferred to ci-slow's full-suite.
 
+mod common;
+
 use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use serde_json::json;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 fn cqs_no_daemon() -> Command {
     let mut c = cqs();

--- a/tests/cli_explain_test.rs
+++ b/tests/cli_explain_test.rs
@@ -19,26 +19,16 @@
 //! embedder needed — explain only loads ONNX when `--tokens` is set,
 //! and `resolve_target` uses FTS `search_by_name`.
 
+mod common;
+
 use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use cqs::parser::{CallSite, Chunk, ChunkType, FunctionCalls, Language};
 use cqs::store::ModelInfo;
 use cqs::Store;
 use serde_json::Value;
 use std::path::PathBuf;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 fn cqs_no_daemon() -> Command {
     let mut c = cqs();

--- a/tests/cli_gather_test.rs
+++ b/tests/cli_gather_test.rs
@@ -13,24 +13,13 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Set up a tiny indexed project with a handful of functions and a
 /// plausible call graph. `cqs gather` needs code to seed-search on and

--- a/tests/cli_gc_test.rs
+++ b/tests/cli_gc_test.rs
@@ -23,24 +23,13 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use serde_json::Value;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Two-file project so the dirty branch can delete one and still leave
 /// chunks behind for the post-rebuild HNSW assertion to be meaningful.

--- a/tests/cli_hook_test.rs
+++ b/tests/cli_hook_test.rs
@@ -16,26 +16,16 @@
 //! No embedder needed — `cqs hook` does not load ONNX. No `slow-tests`
 //! gate.
 
+mod common;
+
 use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use serde_json::Value;
 use std::fs;
 use tempfile::TempDir;
 
 const MANAGED_HOOKS: &[&str] = &["post-checkout", "post-merge", "post-rewrite"];
 const HOOK_MARKER_PREFIX: &str = "# cqs:hook";
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Force CLI mode — different dev machines may have leftover daemon sockets.
 fn cqs_no_daemon() -> Command {

--- a/tests/cli_index_drift_test.rs
+++ b/tests/cli_index_drift_test.rs
@@ -18,23 +18,13 @@
 //! exit non-zero with stderr that names BOTH model identifiers so the
 //! operator gets the actionable error.
 
+mod common;
+
 use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use cqs::store::ModelInfo;
 use cqs::Store;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 fn cqs_no_daemon() -> Command {
     let mut c = cqs();

--- a/tests/cli_neighbors_test.rs
+++ b/tests/cli_neighbors_test.rs
@@ -12,24 +12,13 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Build a project with a handful of distinct functions so the brute-force
 /// neighbor scan has something to rank. We need >= 2 chunks for a non-empty

--- a/tests/cli_notes_test.rs
+++ b/tests/cli_notes_test.rs
@@ -19,7 +19,9 @@
 //! `#[serial]` is required because the notes file locking is per-process and
 //! the shared assert_cmd binary cache can otherwise produce flaky CI.
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use cqs::note::Note;
 use predicates::prelude::*;
 use serde_json::Value;
@@ -27,19 +29,6 @@ use serial_test::serial;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Spin up an empty project with a `.cqs` directory so `find_project_root`
 /// resolves to the temp dir. Notes commands auto-create `docs/notes.toml`

--- a/tests/cli_project_search_test.rs
+++ b/tests/cli_project_search_test.rs
@@ -26,23 +26,13 @@
 
 #![cfg(feature = "slow-tests")]
 
+mod common;
+
 use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Builder that adds the XDG isolation envs to a `cqs` invocation.
 /// `xdg` is the tempdir that stands in as both config and data root.

--- a/tests/cli_reconstruct_test.rs
+++ b/tests/cli_reconstruct_test.rs
@@ -23,24 +23,13 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Build a tiny indexed project with two distinct functions in one file
 /// so we can verify chunk reassembly preserves order + content.

--- a/tests/cli_ref_reindex_validation_test.rs
+++ b/tests/cli_ref_reindex_validation_test.rs
@@ -29,21 +29,11 @@
 
 #![cfg(feature = "llm-summaries")]
 
-use assert_cmd::Command;
-use tempfile::TempDir;
+mod common;
 
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
+use assert_cmd::Command;
+use common::cqs_v1 as cqs;
+use tempfile::TempDir;
 
 fn cqs_no_daemon() -> Command {
     let mut c = cqs();

--- a/tests/cli_ref_test.rs
+++ b/tests/cli_ref_test.rs
@@ -23,25 +23,15 @@
 
 #![cfg(feature = "slow-tests")]
 
+mod common;
+
 use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use serde_json::Value;
 use serial_test::serial;
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Write a small Rust source tree to `dir` with a single public function,
 /// one per file. Returns the set of (file-path, function-name) for callers

--- a/tests/cli_review_test.rs
+++ b/tests/cli_review_test.rs
@@ -12,24 +12,13 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Build a tiny indexed project. Reuses the call-graph fixture pattern
 /// from `cli_graph_test.rs::setup_graph_project`.

--- a/tests/cli_similar_test.rs
+++ b/tests/cli_similar_test.rs
@@ -12,24 +12,13 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Tiny project with 4 related functions. `cqs similar add --json -n 3`
 /// should return sub/mul/divide (in some order) and exclude add itself.

--- a/tests/cli_slot_test.rs
+++ b/tests/cli_slot_test.rs
@@ -11,24 +11,14 @@
 //! the `bail!` when global `--slot` is passed (P2.13), exit-code
 //! stability, and `cqs slot promote` swapping the active pointer.
 
+mod common;
+
 use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use serde_json::Value;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 fn cqs_no_daemon() -> Command {
     let mut c = cqs();

--- a/tests/cli_surface_test.rs
+++ b/tests/cli_surface_test.rs
@@ -12,22 +12,11 @@
 //! gated `cli_test.rs` is now in `tests/index_search_test.rs` and
 //! `tests/health_test.rs`, both of which are in-process.
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 #[test]
 fn help_output_lists_subcommands() {

--- a/tests/cli_telemetry_reset_test.rs
+++ b/tests/cli_telemetry_reset_test.rs
@@ -25,23 +25,12 @@
 //! works on the raw `<cqs_dir>/telemetry.jsonl` path with no embedder
 //! load. NOT gated `slow-tests`.
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Build a tempdir with `.cqs/telemetry.jsonl` containing a few command
 /// entries. The reset path uses `find_project_root` which falls back to

--- a/tests/cli_trace_cross_project_test.rs
+++ b/tests/cli_trace_cross_project_test.rs
@@ -24,26 +24,16 @@
 //! load-bearing field that distinguishes cross-project from local
 //! envelope.
 
+mod common;
+
 use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use cqs::parser::{CallSite, Chunk, ChunkType, FunctionCalls, Language};
 use cqs::store::ModelInfo;
 use cqs::Store;
 use serde_json::Value;
 use std::path::PathBuf;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 fn cqs_no_daemon() -> Command {
     let mut c = cqs();

--- a/tests/cli_train_data_test.rs
+++ b/tests/cli_train_data_test.rs
@@ -12,25 +12,14 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use std::process::Command as StdCommand;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Spin a git repo with two commits modifying the same Rust function.
 /// `train-data` walks `git log` and emits one triplet per

--- a/tests/cli_train_review_test.rs
+++ b/tests/cli_train_review_test.rs
@@ -12,25 +12,14 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use std::process::Command as StdCommand;
 use tempfile::TempDir;
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Set up a tiny git-tracked indexed project. `cmd_affected` and `cmd_ci`
 /// run `git diff` so the working tree must be a real git repo.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -37,6 +37,23 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use tempfile::TempDir;
 
+/// `cqs` CLI invocation pinned to the v1 output envelope.
+///
+/// Kept-v1 compat set: the default wire shape is V2Bare since
+/// v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
+/// surviving legacy-envelope contract, so `parsed["data"][...]`
+/// assertions keep working. The bare default is asserted end-to-end in
+/// tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
+/// tests/cli_chat_format_test.rs.
+///
+/// Import as `use common::cqs_v1 as cqs;` to keep call sites short.
+pub fn cqs_v1() -> assert_cmd::Command {
+    #[allow(deprecated)]
+    let mut c = assert_cmd::Command::cargo_bin("cqs").expect("Failed to find cqs binary");
+    c.env("CQS_OUTPUT_FORMAT", "v1");
+    c
+}
+
 /// Test store with automatic cleanup
 ///
 /// Wraps a `Store` with its backing `TempDir`, ensuring the directory

--- a/tests/daemon_forward_test.rs
+++ b/tests/daemon_forward_test.rs
@@ -26,7 +26,10 @@ use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
+mod common;
+
 use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use tempfile::TempDir;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -256,19 +259,6 @@ fn daemon_socket_path_with_runtime_dir(cqs_dir: &Path, runtime_dir: &Path) -> Pa
     }
     let sock_name = format!("cqs-{}.sock", hex);
     runtime_dir.join(sock_name)
-}
-
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
 }
 
 /// Strip stray env vars so the CLI under test doesn't accidentally inherit

--- a/tests/env_var_docs.rs
+++ b/tests/env_var_docs.rs
@@ -73,31 +73,28 @@ fn is_ident_byte(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_'
 }
 
-/// Files under src/ whose text contains `var` — used by the REMOVED_VARS
-/// inverted guard (a removed env knob must not regain production reads).
-fn grep_src_for_var(workspace: &str, var: &str) -> Vec<String> {
-    let mut files = Vec::new();
-    collect_rs_files(&Path::new(workspace).join("src"), &mut files);
-    files
-        .iter()
-        .filter(|f| {
-            fs::read_to_string(f)
-                .map(|t| t.contains(var))
-                .unwrap_or(false)
-        })
-        .map(|f| f.display().to_string())
-        .collect()
-}
-
 #[test]
 fn all_cqs_env_vars_are_documented_in_readme() {
     let workspace = env!("CARGO_MANIFEST_DIR");
-    let mut files = Vec::new();
-    collect_rs_files(&Path::new(workspace).join("src"), &mut files);
-    collect_rs_files(&Path::new(workspace).join("tests"), &mut files);
+    let mut src_files = Vec::new();
+    collect_rs_files(&Path::new(workspace).join("src"), &mut src_files);
+    let mut test_files = Vec::new();
+    collect_rs_files(&Path::new(workspace).join("tests"), &mut test_files);
 
+    // Single read pass over src/: each file's token-bounded var set feeds
+    // both the documentation check and the REMOVED_VARS inverted guard
+    // below. Using `extract_env_vars` for the guard keeps the matching
+    // word-boundary-exact — a raw `contains(var)` substring match would
+    // re-introduce the pre-fix bug that `readme_documents` documents.
     let mut all_vars: Vec<String> = Vec::new();
-    for f in &files {
+    let mut src_file_vars: Vec<(PathBuf, Vec<String>)> = Vec::new();
+    for f in &src_files {
+        let text = fs::read_to_string(f).expect("readable source file");
+        let vars = extract_env_vars(&text);
+        all_vars.extend(vars.iter().cloned());
+        src_file_vars.push((f.clone(), vars));
+    }
+    for f in &test_files {
         let text = fs::read_to_string(f).expect("readable source file");
         all_vars.extend(extract_env_vars(&text));
     }
@@ -129,9 +126,14 @@ fn all_cqs_env_vars_are_documented_in_readme() {
 
     // Inverted guard: a removed var must stay removed. If any REMOVED_VARS
     // entry reappears in src/ (a production read), this test fails — the
-    // allowlist exempts test-only references, never live knobs.
+    // allowlist exempts test-only references, never live knobs. Checked
+    // against the per-file var sets from the single src/ pass above.
     for v in REMOVED_VARS {
-        let hits = grep_src_for_var(workspace, v);
+        let hits: Vec<String> = src_file_vars
+            .iter()
+            .filter(|(_, vars)| vars.iter().any(|x| x == v))
+            .map(|(f, _)| f.display().to_string())
+            .collect();
         assert!(
             hits.is_empty(),
             "{v} is in REMOVED_VARS but has production reads in src/: {hits:?} — \

--- a/tests/eval_baseline_test.rs
+++ b/tests/eval_baseline_test.rs
@@ -14,25 +14,13 @@
 //! test paths that need the full CLI surface, and through file I/O +
 //! JSON roundtrip for everything else.
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use serde_json::json;
 use std::collections::BTreeMap;
 use std::fs;
 use tempfile::TempDir;
-
-/// Get a Command for the cqs binary.
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Minimal `EvalReport` JSON. Mirrors `runner::EvalReport` exactly — if the
 /// shape ever drifts, every test in this file will fail loudly with a

--- a/tests/eval_subcommand_test.rs
+++ b/tests/eval_subcommand_test.rs
@@ -18,6 +18,7 @@
 mod common;
 
 use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use serde_json::json;
 use serial_test::serial;
 use std::fs;
@@ -26,20 +27,6 @@ use tempfile::TempDir;
 use common::mock_embedding;
 use cqs::parser::{Chunk, ChunkType, Language};
 use std::path::PathBuf;
-
-/// Get a Command for the cqs binary.
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Build a chunk with deterministic ID/hash and given metadata.
 ///

--- a/tests/model_swap_test.rs
+++ b/tests/model_swap_test.rs
@@ -16,25 +16,14 @@
 //! 3. `cqs model swap <current_model>` is a no-op (does not delete `.cqs/`).
 //! 4. `cqs model swap garbage` errors with a hint about valid presets.
 
+mod common;
+
 use assert_cmd::Command;
+use common::cqs_v1 as cqs;
 use serde_json::Value;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-/// Get a Command for the cqs binary.
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Force CLI mode — different dev machines may have leftover daemon sockets
 /// in `$XDG_RUNTIME_DIR` that would otherwise serve our test queries.

--- a/tests/onboard_test.rs
+++ b/tests/onboard_test.rs
@@ -12,25 +12,13 @@
 
 #![cfg(feature = "slow-tests")]
 
-use assert_cmd::Command;
+mod common;
+
+use common::cqs_v1 as cqs;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
-
-/// Get a Command for the cqs binary.
-fn cqs() -> Command {
-    #[allow(deprecated)]
-    let mut c = Command::cargo_bin("cqs").expect("Failed to find cqs binary");
-    // Kept-v1 compat set: the default wire shape is V2Bare since
-    // v1.40.0. These tests pin `CQS_OUTPUT_FORMAT=v1` to exercise the
-    // surviving legacy-envelope contract, so `parsed["data"][...]`
-    // assertions keep working. The bare default is asserted end-to-end in
-    // tests/cli_envelope_test.rs, tests/cli_dead_test.rs, and
-    // tests/cli_chat_format_test.rs.
-    c.env("CQS_OUTPUT_FORMAT", "v1");
-    c
-}
 
 /// Create a project with call relationships suitable for onboard testing.
 fn setup_graph_project() -> TempDir {


### PR DESCRIPTION
Code-review follow-up (high-effort review of the taste-debt queue, 2 confirmed test-infrastructure findings).

## Findings fixed

1. **`fn cqs()` copy-pasted into 33 integration test files (low).** A byte-identical 12-line v1-pin helper (md5-verified identical across all 33) plus its "Kept-v1 compat set" comment lived in every file — the recent comment reword in #1698 paid a 33-file sweep just to change its wording. Now a single `pub fn cqs_v1()` in tests/common/mod.rs carries the contract and comment once; each file does `mod common; use common::cqs_v1 as cqs;` with zero call sites changed. Net −339 lines. The three intentionally-different bare-default V2 helpers (cli_envelope/cli_dead/cli_chat_format tests) are untouched.

2. **REMOVED_VARS guard: substring matching + redundant I/O (low).** The #1703 inverted guard matched with raw substring `t.contains(var)` — the exact "pre-fix bug" this file's own doc comment describes for the README check — and re-walked/re-read all of src/ per removed var. Now token-bounded (same `\b`-regex as `extract_env_vars`) and runs against the single existing src/ read pass; `grep_src_for_var` deleted.

## Verification

- `cargo test --features cuda-index --test env_var_docs` → 9 passed
- `cargo check --tests --features cuda-index` and `--features cuda-index,slow-tests` both clean (20 of the 33 files are slow-tests-gated; both feature sets verified)
- Smoke: `cli_blame_test` → 4 passed, `cli_telemetry_reset_test` → 2 passed

Review thread: 2 below-cut findings of the 2026-06-10 high-effort review (15 confirmed findings across 5 PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
