### PR TITLE
fix(tests): close #1702 containment gaps - shared retry helper, integration coverage, poison-safe env lock

### DIFF
--- a/src/hnsw/build.rs
+++ b/src/hnsw/build.rs
@@ -248,46 +248,27 @@ impl HnswIndex {
 mod tests {
     use super::*;
 
+    use crate::hnsw::assert_self_match_reachable;
     use crate::hnsw::make_test_embedding as make_embedding;
 
     #[test]
     fn test_build_and_search() {
         // Recall-intent test: a correctly-built index returns the exact-match
-        // vector in its top-k. HNSW is built via `parallel_insert_data`
-        // (rayon) over an OS-seeded layer RNG, and under CPU contention ~1-2%
-        // of builds are degenerate enough that even the cosine-distance-0
-        // self-match is unreachable (measured 52/3000 under 16-core load vs
-        // 0/3000 sequential). That is an hnsw_rs concurrent-build
-        // characteristic, not a cqs bug — so we retry the build a bounded
-        // number of times rather than assert exact rank-1 on a single build.
+        // vector in its top-k. `assert_self_match_reachable` retries the build
+        // (and takes HNSW_ENV_LOCK around it) to absorb the rare degenerate
+        // concurrent-build graph — see the helper docs in hnsw/mod.rs.
         let build = || {
-            // Hold the env lock for the build only: build_with_dim reads
-            // CQS_HNSW_* and must not race a concurrent env-override test.
-            let _env = crate::hnsw::HNSW_ENV_LOCK.lock().unwrap();
             let embeddings = vec![
                 ("chunk1".to_string(), make_embedding(1)),
                 ("chunk2".to_string(), make_embedding(2)),
                 ("chunk3".to_string(), make_embedding(3)),
             ];
-            HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap()
+            let index = HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap();
+            assert_eq!(index.len(), 3);
+            index
         };
 
-        let mut last_ids = Vec::new();
-        let mut hit = None;
-        for _ in 0..8 {
-            let index = build();
-            assert_eq!(index.len(), 3);
-            let results = index.search(&make_embedding(1), 3);
-            assert!(!results.is_empty());
-            last_ids = results.iter().map(|r| r.id.clone()).collect();
-            if let Some(r) = results.iter().find(|r| r.id == "chunk1") {
-                hit = Some(r.score);
-                break;
-            }
-        }
-        let self_score = hit.unwrap_or_else(|| {
-            panic!("chunk1 unreachable across 8 builds (real recall bug, not noise); last top-3 = {last_ids:?}")
-        });
+        let self_score = assert_self_match_reachable(build, &make_embedding(1), "chunk1", 3);
         // Self-match score must be high (cosine distance ~0).
         assert!(
             self_score > 0.9,
@@ -404,38 +385,6 @@ mod tests {
             }
         }
         Embedding::new(v)
-    }
-
-    /// Assert that the exact-match vector `want` is reachable in the top-`k`
-    /// results of an index produced by `build`, retrying the build to absorb
-    /// the rare degenerate concurrent-build graph. `parallel_insert_data`
-    /// under CPU contention yields a self-unreachable node on ~1-2% of builds;
-    /// at 8 retries a transient miss is ~2.5e-14 while a systematic recall bug
-    /// (miss on every build) still fails deterministically.
-    ///
-    /// Each `build()` call runs under `HNSW_ENV_LOCK` so a concurrent
-    /// env-override test cannot perturb the CQS_HNSW_* graph params
-    /// mid-build; the search phase runs unlocked.
-    fn assert_self_match_reachable(
-        build: impl Fn() -> HnswIndex,
-        query: &Embedding,
-        want: &str,
-        k: usize,
-    ) {
-        let mut last_ids = Vec::new();
-        for _ in 0..8 {
-            let index = {
-                let _env = crate::hnsw::HNSW_ENV_LOCK.lock().unwrap();
-                build()
-            };
-            let results = index.search(query, k);
-            assert!(!results.is_empty(), "search returned no results");
-            last_ids = results.iter().map(|r| r.id.clone()).collect();
-            if results.iter().any(|r| r.id == want) {
-                return;
-            }
-        }
-        panic!("{want:?} unreachable across 8 builds (real recall bug, not noise); last top-{k} = {last_ids:?}");
     }
 
     #[test]

--- a/src/hnsw/mod.rs
+++ b/src/hnsw/mod.rs
@@ -607,12 +607,18 @@ impl<Mode: crate::store::ClearHnswDirty> crate::index::IndexBackend<Mode> for Hn
 ///
 /// Holders: the env-mutating tests (`env_override_tests`,
 /// `test_hnsw_for_helpers_pick_tier`) hold it across their set/read/remove
-/// sequence; the hardened recall/lifecycle tests (`assert_self_match_reachable`
-/// in `build.rs`, the retry loops in `persist.rs`, the lifecycle test in
-/// `safety.rs`) hold it just around the `build_with_dim` /
-/// `build_batched_with_dim` call so their graph params cannot be perturbed
+/// sequence; the hardened recall tests hold it via the shared
+/// `assert_self_match_reachable` helper (below), which takes it around each
+/// `build()` closure, and the lifecycle test in `safety.rs` holds it just
+/// around its `build_with_dim` call — so graph params cannot be perturbed
 /// mid-build, while search phases stay parallel. Other build sites tolerate a
 /// transient env override (graph params change, soundness does not).
+///
+/// All acquisitions are poison-safe
+/// (`.lock().unwrap_or_else(PoisonError::into_inner)`): the lock guards
+/// process-global env vars with no data invariant, and a single test failure
+/// while holding it must not cascade PoisonError panics into every later
+/// HNSW test.
 #[cfg(test)]
 pub(crate) static HNSW_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -631,6 +637,49 @@ pub(crate) fn make_test_embedding(seed: u32) -> Embedding {
         }
     }
     Embedding::new(v)
+}
+
+/// Shared test helper: assert that the exact-match vector `want` is reachable
+/// in the top-`k` results of an index produced by `build`, retrying the build
+/// to absorb the rare degenerate concurrent-build graph. `parallel_insert_data`
+/// under CPU contention yields a self-unreachable node on ~1-2% of builds
+/// (measured 52/3000 under 16-core load vs 0/3000 sequential — an hnsw_rs
+/// concurrent-build characteristic, filed upstream as hnswlib-rs#32, not a cqs
+/// bug); at 8 retries a transient miss is ~2.5e-14 while a systematic recall
+/// bug (miss on every build) still fails deterministically.
+///
+/// The `build` closure returns the searchable index, so save/load roundtrips
+/// (and any per-build invariant asserts) live inside the closure and are
+/// re-exercised on every retry. Returns the matched result's score so callers
+/// can additionally pin the self-match score.
+///
+/// Each `build()` call runs under `HNSW_ENV_LOCK` so a concurrent env-override
+/// test cannot perturb the CQS_HNSW_* graph params mid-build; the search phase
+/// runs unlocked. (Only `build_with_dim` reads CQS_HNSW_* vars, so holding the
+/// lock across an in-closure save/load roundtrip is harmless.)
+#[cfg(test)]
+pub(crate) fn assert_self_match_reachable(
+    build: impl Fn() -> HnswIndex,
+    query: &Embedding,
+    want: &str,
+    k: usize,
+) -> f32 {
+    let mut last_ids = Vec::new();
+    for _ in 0..8 {
+        let index = {
+            let _env = HNSW_ENV_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            build()
+        };
+        let results = index.search(query, k);
+        assert!(!results.is_empty(), "search returned no results");
+        last_ids = results.iter().map(|r| r.id.clone()).collect();
+        if let Some(r) = results.iter().find(|r| r.id == want) {
+            return r.score;
+        }
+    }
+    panic!("{want:?} unreachable across 8 builds (real recall bug, not noise); last top-{k} = {last_ids:?}");
 }
 
 #[cfg(test)]
@@ -708,7 +757,9 @@ mod send_sync_tests {
     fn test_hnsw_for_helpers_pick_tier() {
         // Serialize against env_override_tests — these vars are process-global
         // and read by max_nb_connection_for / ef_*_for.
-        let _lock = super::HNSW_ENV_LOCK.lock().unwrap();
+        let _lock = super::HNSW_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // No env override: helper returns the tier value verbatim.
         std::env::remove_var("CQS_HNSW_M");
         std::env::remove_var("CQS_HNSW_EF_CONSTRUCTION");
@@ -731,34 +782,37 @@ mod insert_batch_tests {
 
     #[test]
     fn test_insert_batch_on_owned() {
-        // Build a small Owned HNSW index
-        let embeddings: Vec<(String, Embedding)> = (0..5)
-            .map(|i| (format!("chunk_{}", i), make_test_embedding(i)))
-            .collect();
+        // Both the initial build and insert_batch go through
+        // parallel_insert_data, so the recall assert (chunk_6 reachable) uses
+        // the shared retry helper rather than a single un-retried build. The
+        // insert-count invariants are asserted on every build.
+        let build = || {
+            // Build a small Owned HNSW index
+            let embeddings: Vec<(String, Embedding)> = (0..5)
+                .map(|i| (format!("chunk_{}", i), make_test_embedding(i)))
+                .collect();
 
-        let mut index = HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap();
-        let initial_len = index.len();
-        assert_eq!(initial_len, 5);
+            let mut index = HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap();
+            let initial_len = index.len();
+            assert_eq!(initial_len, 5);
 
-        // Insert new items
-        let new_embeddings: Vec<(String, Embedding)> = (5..8)
-            .map(|i| (format!("chunk_{}", i), make_test_embedding(i)))
-            .collect();
-        let refs: Vec<(String, &[f32])> = new_embeddings
-            .iter()
-            .map(|(id, emb)| (id.clone(), emb.as_slice()))
-            .collect();
+            // Insert new items
+            let new_embeddings: Vec<(String, Embedding)> = (5..8)
+                .map(|i| (format!("chunk_{}", i), make_test_embedding(i)))
+                .collect();
+            let refs: Vec<(String, &[f32])> = new_embeddings
+                .iter()
+                .map(|(id, emb)| (id.clone(), emb.as_slice()))
+                .collect();
 
-        let inserted = index.insert_batch(&refs).unwrap();
-        assert_eq!(inserted, 3);
-        assert_eq!(index.len(), initial_len + 3);
+            let inserted = index.insert_batch(&refs).unwrap();
+            assert_eq!(inserted, 3);
+            assert_eq!(index.len(), initial_len + 3);
+            index
+        };
 
-        // Search should find both original and newly inserted items
-        let query = make_test_embedding(6);
-        let results = index.search(&query, 3);
-        assert!(!results.is_empty());
-        // chunk_6 should be in top results
-        assert!(results.iter().any(|r| r.id == "chunk_6"));
+        // Search should find the newly inserted chunk_6 in top results.
+        assert_self_match_reachable(build, &make_test_embedding(6), "chunk_6", 3);
     }
 
     #[test]
@@ -899,75 +953,96 @@ mod insert_batch_tests {
 mod env_override_tests {
     /// Serialize tests that manipulate CQS_HNSW_* env vars. Uses the shared
     /// module-level lock so tier-default / build tests in other modules also
-    /// serialize against these process-global mutations.
+    /// serialize against these process-global mutations. Acquisition is
+    /// poison-safe (`PoisonError::into_inner`): the lock guards a process
+    /// global with no invariant of its own, and a poisoned static would
+    /// otherwise cascade panics into every later HNSW test.
     use super::HNSW_ENV_LOCK as ENV_MUTEX;
+
+    fn lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// RAII guard pairing `set_var` with `remove_var` on drop, so an
+    /// assertion failure mid-test cannot leak a CQS_HNSW_* var into later
+    /// tests (these tests assert while holding the env lock).
+    struct EnvVarGuard(&'static str);
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            std::env::set_var(key, value);
+            Self(key)
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(self.0);
+        }
+    }
 
     #[test]
     fn test_m_default() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = lock();
         std::env::remove_var("CQS_HNSW_M");
         assert_eq!(super::max_nb_connection(), 24);
     }
 
     #[test]
     fn test_m_override() {
-        let _lock = ENV_MUTEX.lock().unwrap();
-        std::env::set_var("CQS_HNSW_M", "32");
+        let _lock = lock();
+        let _var = EnvVarGuard::set("CQS_HNSW_M", "32");
         assert_eq!(super::max_nb_connection(), 32);
-        std::env::remove_var("CQS_HNSW_M");
     }
 
     #[test]
     fn test_m_invalid_falls_back() {
-        let _lock = ENV_MUTEX.lock().unwrap();
-        std::env::set_var("CQS_HNSW_M", "not_a_number");
+        let _lock = lock();
+        let _var = EnvVarGuard::set("CQS_HNSW_M", "not_a_number");
         assert_eq!(super::max_nb_connection(), 24);
-        std::env::remove_var("CQS_HNSW_M");
     }
 
     #[test]
     fn test_ef_construction_default() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = lock();
         std::env::remove_var("CQS_HNSW_EF_CONSTRUCTION");
         assert_eq!(super::ef_construction(), 200);
     }
 
     #[test]
     fn test_ef_construction_override() {
-        let _lock = ENV_MUTEX.lock().unwrap();
-        std::env::set_var("CQS_HNSW_EF_CONSTRUCTION", "400");
+        let _lock = lock();
+        let _var = EnvVarGuard::set("CQS_HNSW_EF_CONSTRUCTION", "400");
         assert_eq!(super::ef_construction(), 400);
-        std::env::remove_var("CQS_HNSW_EF_CONSTRUCTION");
     }
 
     #[test]
     fn test_ef_construction_invalid_falls_back() {
-        let _lock = ENV_MUTEX.lock().unwrap();
-        std::env::set_var("CQS_HNSW_EF_CONSTRUCTION", "xyz");
+        let _lock = lock();
+        let _var = EnvVarGuard::set("CQS_HNSW_EF_CONSTRUCTION", "xyz");
         assert_eq!(super::ef_construction(), 200);
-        std::env::remove_var("CQS_HNSW_EF_CONSTRUCTION");
     }
 
     #[test]
     fn test_ef_search_default() {
-        let _lock = ENV_MUTEX.lock().unwrap();
+        let _lock = lock();
         std::env::remove_var("CQS_HNSW_EF_SEARCH");
         assert_eq!(super::ef_search(), 100);
     }
 
     #[test]
     fn test_ef_search_override() {
-        let _lock = ENV_MUTEX.lock().unwrap();
-        std::env::set_var("CQS_HNSW_EF_SEARCH", "250");
+        let _lock = lock();
+        let _var = EnvVarGuard::set("CQS_HNSW_EF_SEARCH", "250");
         assert_eq!(super::ef_search(), 250);
-        std::env::remove_var("CQS_HNSW_EF_SEARCH");
     }
 
     #[test]
     fn test_ef_search_invalid_falls_back() {
-        let _lock = ENV_MUTEX.lock().unwrap();
-        std::env::set_var("CQS_HNSW_EF_SEARCH", "");
+        let _lock = lock();
+        let _var = EnvVarGuard::set("CQS_HNSW_EF_SEARCH", "");
         assert_eq!(super::ef_search(), 100);
-        std::env::remove_var("CQS_HNSW_EF_SEARCH");
     }
 }

--- a/src/hnsw/persist.rs
+++ b/src/hnsw/persist.rs
@@ -1369,41 +1369,27 @@ mod tests {
     #[test]
     fn test_save_and_load() {
         // This test pins the save → exists → load roundtrip. The recall check
-        // (chunk1 reachable post-load) retries the build to absorb the rare
-        // degenerate concurrent-build graph: `parallel_insert_data`
-        // under CPU contention can make even the cosine-distance-0 self-match
-        // unreachable on ~1-2% of builds. The roundtrip itself (exists/len) is
-        // asserted unconditionally on every build.
-        let mut found = false;
-        let mut last_ids = Vec::new();
-        for _ in 0..8 {
+        // (chunk1 reachable post-load) goes through the shared
+        // `assert_self_match_reachable` helper, which retries the build to
+        // absorb the rare degenerate concurrent-build graph (see the helper
+        // docs in hnsw/mod.rs). The roundtrip itself (exists/len) is asserted
+        // unconditionally on every build inside the closure.
+        let build = || {
             let tmp = TempDir::new().unwrap();
             let embeddings = vec![
                 ("chunk1".to_string(), make_embedding(1)),
                 ("chunk2".to_string(), make_embedding(2)),
             ];
-            // Env lock scoped to the build: build_with_dim reads CQS_HNSW_*
-            // and must not race a concurrent env-override test.
-            let index = {
-                let _env = crate::hnsw::HNSW_ENV_LOCK.lock().unwrap();
-                HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap()
-            };
+            let index = HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap();
             index.save(tmp.path(), "index").unwrap();
             assert!(HnswIndex::exists(tmp.path(), "index"));
             let loaded =
                 HnswIndex::load_with_dim(tmp.path(), "index", crate::EMBEDDING_DIM).unwrap();
             assert_eq!(loaded.len(), 2);
-            let results = loaded.search(&make_embedding(1), 2);
-            last_ids = results.iter().map(|r| r.id.clone()).collect();
-            if results.iter().any(|r| r.id == "chunk1") {
-                found = true;
-                break;
-            }
-        }
-        assert!(
-            found,
-            "chunk1 unreachable post-load across 8 builds (real recall bug, not noise); last top-2 = {last_ids:?}"
-        );
+            // TempDir drops here; the loaded index is self-contained.
+            loaded
+        };
+        crate::hnsw::assert_self_match_reachable(build, &make_embedding(1), "chunk1", 2);
     }
 
     // ===== multi-model dim-threading (HNSW persist) =====
@@ -1428,46 +1414,30 @@ mod tests {
         // Save a 1024-dim HNSW index, load with load_with_dim(1024),
         // verify it loads and searches correctly.
         //
-        // The save/load roundtrip (dim + len) is asserted on every build. The
-        // recall check (vec1 reachable post-load) retries the build to absorb
-        // the rare degenerate concurrent-build graph: the five
-        // sin-derived vectors are near-parallel (adjacent seeds ~0.995 cosine)
-        // and `parallel_insert_data` under CPU contention can make even the
-        // exact-match vector unreachable on ~1-2% of builds. A systematic
-        // recall bug (miss on every build) still fails deterministically.
+        // The save/load roundtrip (dim + len) is asserted on every build
+        // inside the closure. The recall check (vec1 reachable post-load)
+        // goes through the shared `assert_self_match_reachable` helper, which
+        // retries the build to absorb the rare degenerate concurrent-build
+        // graph (see the helper docs in hnsw/mod.rs): the five sin-derived
+        // vectors are near-parallel (adjacent seeds ~0.995 cosine), making
+        // them especially exposed to it.
         let basename = "test_1024";
-        let mut found = false;
-        let mut last_ids = Vec::new();
-        for _ in 0..8 {
+        let build = || {
             let tmp = TempDir::new().unwrap();
             let embeddings: Vec<(String, crate::embedder::Embedding)> = (1..=5)
                 .map(|i| (format!("vec{}", i), make_embedding_dim(i, 1024)))
                 .collect();
-            // Env lock scoped to the build: build_with_dim reads CQS_HNSW_*
-            // and must not race a concurrent env-override test.
-            let index = {
-                let _env = crate::hnsw::HNSW_ENV_LOCK.lock().unwrap();
-                HnswIndex::build_with_dim(embeddings, 1024).unwrap()
-            };
+            let index = HnswIndex::build_with_dim(embeddings, 1024).unwrap();
             assert_eq!(index.dim, 1024);
             index.save(tmp.path(), basename).unwrap();
 
             let loaded = HnswIndex::load_with_dim(tmp.path(), basename, 1024).unwrap();
             assert_eq!(loaded.len(), 5, "Loaded index should have 5 vectors");
             assert_eq!(loaded.dim, 1024, "Loaded index dim should be 1024");
-
-            let results = loaded.search(&make_embedding_dim(1, 1024), 3);
-            assert!(!results.is_empty(), "Search should return results");
-            last_ids = results.iter().map(|r| r.id.clone()).collect();
-            if results.iter().any(|r| r.id == "vec1") {
-                found = true;
-                break;
-            }
-        }
-        assert!(
-            found,
-            "exact-match vec1 unreachable post-load across 8 builds (real recall bug, not noise); last top-3 = {last_ids:?}"
-        );
+            // TempDir drops here; the loaded index is self-contained.
+            loaded
+        };
+        crate::hnsw::assert_self_match_reachable(build, &make_embedding_dim(1, 1024), "vec1", 3);
     }
 
     #[test]

--- a/src/hnsw/safety.rs
+++ b/src/hnsw/safety.rs
@@ -92,7 +92,9 @@ mod tests {
         // Env lock scoped to the build: build_with_dim reads CQS_HNSW_*
         // and must not race a concurrent env-override test.
         {
-            let _env = crate::hnsw::HNSW_ENV_LOCK.lock().unwrap();
+            let _env = crate::hnsw::HNSW_ENV_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM)
                 .unwrap()
                 .save(tmp.path(), "lifecycle")

--- a/tests/hnsw_test.rs
+++ b/tests/hnsw_test.rs
@@ -22,6 +22,35 @@ fn make_embedding(seed: u32) -> Embedding {
     Embedding::new(v)
 }
 
+/// Local mirror of the lib-side `assert_self_match_reachable` policy (the
+/// crate-private helper in `src/hnsw/mod.rs` is unreachable from this
+/// integration binary): assert that the exact-match vector `want` is
+/// reachable in the top-`k` results of an index produced by `build`,
+/// retrying the build up to 8 times to absorb the rare degenerate
+/// concurrent-build graph (`parallel_insert_data` under CPU contention
+/// yields a self-unreachable node on ~1-2% of builds — hnswlib-rs#32).
+/// A systematic recall bug (miss on every build) still fails
+/// deterministically. No env lock needed here: nothing in this test binary
+/// mutates CQS_HNSW_* vars, and lib tests run in a separate process.
+fn assert_self_match_reachable(
+    build: impl Fn() -> HnswIndex,
+    query: &Embedding,
+    want: &str,
+    k: usize,
+) {
+    let mut last_ids = Vec::new();
+    for _ in 0..8 {
+        let index = build();
+        let results = index.search(query, k);
+        assert!(!results.is_empty(), "search returned no results");
+        last_ids = results.iter().map(|r| r.id.clone()).collect();
+        if results.iter().any(|r| r.id == want) {
+            return;
+        }
+    }
+    panic!("{want:?} unreachable across 8 builds (real recall bug, not noise); last top-{k} = {last_ids:?}");
+}
+
 #[test]
 fn test_truncated_data_file_detected() {
     let tmp = TempDir::new().unwrap();
@@ -270,20 +299,23 @@ fn test_build_batched_handles_rebuild_after_initial_build() {
     assert_eq!(index1.len(), 2);
 
     // Second build with different data (simulates rebuild)
-    let batch2: Vec<Result<Vec<(String, Embedding)>, &str>> = vec![Ok(vec![
-        ("chunk3".to_string(), make_embedding(3)),
-        ("chunk4".to_string(), make_embedding(4)),
-        ("chunk5".to_string(), make_embedding(5)),
-    ])];
+    let build = || {
+        let batch2: Vec<Result<Vec<(String, Embedding)>, &str>> = vec![Ok(vec![
+            ("chunk3".to_string(), make_embedding(3)),
+            ("chunk4".to_string(), make_embedding(4)),
+            ("chunk5".to_string(), make_embedding(5)),
+        ])];
 
-    let index2 =
-        HnswIndex::build_batched_with_dim(batch2.into_iter(), 3, cqs::EMBEDDING_DIM).unwrap();
-    assert_eq!(index2.len(), 3);
+        let index2 =
+            HnswIndex::build_batched_with_dim(batch2.into_iter(), 3, cqs::EMBEDDING_DIM).unwrap();
+        assert_eq!(index2.len(), 3);
+        index2
+    };
 
-    // Verify search works on rebuilt index
-    let query = make_embedding(3);
-    let results = index2.search(&query, 1);
-    assert_eq!(results[0].id, "chunk3");
+    // Verify search works on rebuilt index: the exact-match query must win
+    // rank-1 (k=1 containment). Retried via the helper because a single
+    // un-retried parallel build can be degenerate (self-match unreachable).
+    assert_self_match_reachable(build, &make_embedding(3), "chunk3", 1);
 }
 
 #[test]
@@ -315,34 +347,38 @@ fn test_build_batched_large_number_of_batches() {
 #[test]
 fn test_build_batched_uneven_batch_sizes() {
     // Test with varying batch sizes (realistic scenario)
-    let batches: Vec<Result<Vec<(String, Embedding)>, &str>> = vec![
-        Ok(vec![
-            ("a".to_string(), make_embedding(1)),
-            ("b".to_string(), make_embedding(2)),
-            ("c".to_string(), make_embedding(3)),
-        ]),
-        Ok(vec![("d".to_string(), make_embedding(4))]), // Small batch
-        Ok(vec![
-            ("e".to_string(), make_embedding(5)),
-            ("f".to_string(), make_embedding(6)),
-            ("g".to_string(), make_embedding(7)),
-            ("h".to_string(), make_embedding(8)),
-            ("i".to_string(), make_embedding(9)),
-        ]), // Large batch
-        Ok(vec![
-            ("j".to_string(), make_embedding(10)),
-            ("k".to_string(), make_embedding(11)),
-        ]),
-    ];
+    let build = || {
+        let batches: Vec<Result<Vec<(String, Embedding)>, &str>> = vec![
+            Ok(vec![
+                ("a".to_string(), make_embedding(1)),
+                ("b".to_string(), make_embedding(2)),
+                ("c".to_string(), make_embedding(3)),
+            ]),
+            Ok(vec![("d".to_string(), make_embedding(4))]), // Small batch
+            Ok(vec![
+                ("e".to_string(), make_embedding(5)),
+                ("f".to_string(), make_embedding(6)),
+                ("g".to_string(), make_embedding(7)),
+                ("h".to_string(), make_embedding(8)),
+                ("i".to_string(), make_embedding(9)),
+            ]), // Large batch
+            Ok(vec![
+                ("j".to_string(), make_embedding(10)),
+                ("k".to_string(), make_embedding(11)),
+            ]),
+        ];
 
-    let index =
-        HnswIndex::build_batched_with_dim(batches.into_iter(), 11, cqs::EMBEDDING_DIM).unwrap();
-    assert_eq!(index.len(), 11);
+        let index =
+            HnswIndex::build_batched_with_dim(batches.into_iter(), 11, cqs::EMBEDDING_DIM).unwrap();
+        assert_eq!(index.len(), 11);
+        index
+    };
 
-    // Verify IDs are correctly mapped
-    let query = make_embedding(5);
-    let results = index.search(&query, 1);
-    assert_eq!(results[0].id, "e");
+    // Verify IDs are correctly mapped across uneven batches: the exact-match
+    // query for "e" (mid-large-batch) must win rank-1 (k=1 containment).
+    // Retried via the helper because a single un-retried parallel build can
+    // be degenerate (self-match unreachable).
+    assert_self_match_reachable(build, &make_embedding(5), "e", 1);
 }
 
 #[test]


### PR DESCRIPTION
Code-review follow-up to #1702 (high-effort review of the taste-debt queue, 3 confirmed findings on the HNSW test hardening).

## Findings fixed

1. **Containment gaps (medium).** #1702's retry containment missed three recall assertions on single un-retried parallel builds: `test_insert_batch_on_owned` (src/hnsw/mod.rs, top-3 containment, no env lock) and tests/hnsw_test.rs:286/:345 (k=1 exact-rank; the helper and lock are crate-private, unreachable from the integration binary). All three still flaked the ~1-2% CPU-contended rate measured for hnswlib-rs#32. Now: the owned-insert test routes through the shared retry helper under the env lock; the integration binary gets its own local 8-retry helper and both exact-rank asserts are retried containment.

2. **Poison cascade (low).** Every `HNSW_ENV_LOCK` site used `.lock().unwrap()`, and env-override tests assert while holding the guard — one failure poisons the static, leaks CQS_HNSW_* vars, and cascades PoisonError panics into every later HNSW lib test, burying the root cause. Now all sites use `unwrap_or_else(PoisonError::into_inner)` (the pattern already used 10× in batch/context.rs), and env_override_tests use an `EnvVarGuard` RAII drop-guard so a failed assert can't leak vars.

3. **Retry-loop dedup (low).** The 8-retry helper `assert_self_match_reachable` was private to build.rs's test mod while three sibling tests hand-rolled the same loop (build.rs `test_build_and_search`, both persist.rs save/load tests). Promoted a generalized version to the shared `#[cfg(test)] pub(crate)` block in hnsw/mod.rs (build closure returns the searchable index so save→load fits inside; returns the matched score for the >0.9 check; same panic shape). All four sites now share one implementation — one edit point when hnswlib-rs#32 lands upstream.

## Verification

- `cargo test --features cuda-index --lib hnsw` → 66 passed
- `cargo test --features cuda-index --test hnsw_test` → 20 passed
- `grep -rn "HNSW_ENV_LOCK" src/ | grep "unwrap()"` → empty
- `cargo fmt` clean

Review thread: findings 2, 5, 7 of the 2026-06-10 high-effort review (15 confirmed findings across 5 PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
