### PR TITLE
fix(eval): re-pin 12 v3.v2 gold origins orphaned by #1704 file splits

### DIFF
--- a/PROJECT_CONTINUITY.md
+++ b/PROJECT_CONTINUITY.md
@@ -2,6 +2,19 @@
 
 ## Right Now
 
+**Code review + fixes + recall gate: CLOSED (2026-06-10 afternoon).** High-effort multi-agent review (Fable agents per user request) of the taste-debt queue PRs #1701-#1706: 7 finder angles → 15 verified findings (14 CONFIRMED, 1 PLAUSIBLE, 0 refuted). All 15 fixed across 5 PRs, all merged:
+- **#1707** (reuse): resolve_reuse returns Result — watch path restored to fail-and-retry (a SQLite error was silently becoming a full-corpus GPU re-embed per tick); `canon_key_ref(&Chunk) -> &str` is now THE key function for read + all 3 write-back sites (drift hazard + hot-path alloc gone); model_fingerprint gated on cache presence (was paying a ~550MB blake3 on the cache-disabled path).
+- **#1708** (docs): ULTRASECURITY removal annotations for the files #1703's sweep missed (ROADMAP, json-snr-restoration banner, json-noise-audit, polymorphic-routing, audit-triage, plan doc, tears); display.rs "posture-gated" → "skip-when-default".
+- **#1709** (tests): the 33-file copy-pasted `fn cqs()` v1-pin helper → single `tests/common::cqs_v1` (net −339 lines); REMOVED_VARS guard now token-bounded + single-pass.
+- **#1710** (hnsw): #1702 containment extended to the 3 missed single-build recall asserts (incl. integration binary via local helper); all HNSW_ENV_LOCK sites poison-safe (`PoisonError::into_inner`) + EnvVarGuard RAII; retry helper promoted to shared cfg(test) block, 4 hand-rolled copies deleted.
+- **#1711** (dedup): `connect_cache_pool` extraction (the mod.rs TODO); dead `pad_2d_i64` deleted with coverage ported to `_from_encodings`; meta_json_fragment calls meta_value_for_envelope; **src/posture.rs → src/output_format.rs**; `BatchContext::new` replaces raw struct literals.
+
+**Recall gate (user-requested, default settings):** raw run looked like −1.9pp agg R@5 — classified before believing: 12/218 golds had DEAD origins (10 from #1704's file splits, 2 stale worktree paths from fixture generation). NOTE: the eval matcher is `(origin, name)` — line_start was dropped from the key (memory note was stale, now fixed). Re-pinned all 12 (disambiguated via `git show 9e4980db:src/cache.rs` impl blocks), re-ran: **agg R@1 47.7 (+1.4) / R@5 74.8 (±0.0) / R@20 88.5 (+2.3) vs 2026-05-08 baseline — NO recall regression.** Re-pin is PR #1712 (this branch).
+
+**Mid-session WSL crash** (~14:00): lost zero work — 2 branches were already pushed, 1 committed in its worktree, 2 worktrees had complete uncommitted diffs that finisher agents verified and landed. Worktrees + branches cleaned after merge. Binary rebuilt/installed post-merge (1.42.0+main, daemon active, index reconciled 19:25).
+
+**Pending:** #1712 merge on green. v4 fixtures (1526/split) NOT re-pinned — same origin-death class applies if they're ever used for A/Bs.
+
 **v1.42.0 RELEASED — 2026-06-09.** Tagged, crates.io published, GitHub release binaries built, local binary + daemon on 1.42.0, target dir cleaned (166 GiB). Schema v28 (canonical_hash). Toolchain 1.96.0 local + CI.
 
 **cuvs upstream contribution fleet — COMPLETE, all 5 PRs submitted, awaiting maintainer review (2026-06-09/10):**

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -1913,3 +1913,11 @@ mentions = [
     "scripts/check_comment_provenance.py",
     "refactoring",
 ]
+
+[[note]]
+sentiment = -0.5
+text = "Eval gold origins die when files split/rename: matcher keys on (origin,name) — line drift is harmless, but a monolith split orphans every gold pointing at the old path, capping R@K and mimicking a recall regression. Check dead golds (SELECT 1 FROM chunks WHERE origin=? AND name=?) before suspecting retrieval; re-pin golds in the same PR as the split."
+mentions = [
+    "evals/queries",
+    "src/cli/commands/eval/runner.rs",
+]

--- a/evals/queries/v3_dev.v2.json
+++ b/evals/queries/v3_dev.v2.json
@@ -230,6 +230,13 @@
           "old_line_start": 49,
           "new_origin": "src/cache.rs",
           "new_line_start": 203
+        },
+        "repinned_2026_06_10": {
+          "reason": "origin file split/moved (#1704 monolith splits; 2 were stale worktree paths)",
+          "old_origin": "src/cache.rs",
+          "old_line_start": 203,
+          "new_origin": "src/cache/embedding_cache.rs",
+          "new_line_start": 15
         }
       },
       "judges": {
@@ -277,11 +284,11 @@
       "gold_chunk": {
         "id": "src/cache.rs:203:regen",
         "name": "EmbeddingCache",
-        "origin": "src/cache.rs",
+        "origin": "src/cache/embedding_cache.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 203,
-        "line_end": 1047
+        "line_start": 15,
+        "line_end": 24
       },
       "gold_chunk_source": "consensus"
     },
@@ -1577,6 +1584,13 @@
           "old_line_start": 51,
           "new_origin": "src/cache.rs",
           "new_line_start": 215
+        },
+        "repinned_2026_06_10": {
+          "reason": "origin file split/moved (#1704 monolith splits; 2 were stale worktree paths)",
+          "old_origin": "src/cache.rs",
+          "old_line_start": 215,
+          "new_origin": "src/cache/embedding_cache.rs",
+          "new_line_start": 36
         }
       },
       "judges": {
@@ -1624,11 +1638,11 @@
       "gold_chunk": {
         "id": "src/cache.rs:215:regen",
         "name": "default_path",
-        "origin": "src/cache.rs",
+        "origin": "src/cache/embedding_cache.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 215,
-        "line_end": 223
+        "line_start": 36,
+        "line_end": 44
       },
       "gold_chunk_source": "consensus"
     },
@@ -1709,6 +1723,13 @@
           "old_line_start": 40,
           "new_origin": "src/cache.rs",
           "new_line_start": 189
+        },
+        "repinned_2026_06_10": {
+          "reason": "origin file split/moved (#1704 monolith splits; 2 were stale worktree paths)",
+          "old_origin": "src/cache.rs",
+          "old_line_start": 189,
+          "new_origin": "src/cache/embedding_cache.rs",
+          "new_line_start": 15
         }
       },
       "judges": {
@@ -1754,11 +1775,11 @@
       "gold_chunk": {
         "id": "src/cache.rs:189:regen",
         "name": "EmbeddingCache",
-        "origin": "src/cache.rs",
+        "origin": "src/cache/embedding_cache.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 189,
-        "line_end": 201
+        "line_start": 15,
+        "line_end": 24
       },
       "gold_chunk_source": "consensus"
     },
@@ -4792,6 +4813,13 @@
           "old_line_start": 28,
           "new_origin": "src/cache.rs",
           "new_line_start": 84
+        },
+        "repinned_2026_06_10": {
+          "reason": "origin file split/moved (#1704 monolith splits; 2 were stale worktree paths)",
+          "old_origin": "src/cache.rs",
+          "old_line_start": 84,
+          "new_origin": "src/cache/mod.rs",
+          "new_line_start": 78
         }
       },
       "judges": {
@@ -4839,11 +4867,11 @@
       "gold_chunk": {
         "id": "src/cache.rs:84:regen",
         "name": "CacheStats",
-        "origin": "src/cache.rs",
+        "origin": "src/cache/mod.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 84,
-        "line_end": 90
+        "line_start": 78,
+        "line_end": 84
       },
       "gold_chunk_source": "consensus"
     },
@@ -6012,6 +6040,13 @@
           "old_line_start": 349,
           "new_origin": "src/embedder/mod.rs",
           "new_line_start": 487
+        },
+        "repinned_2026_06_10": {
+          "reason": "origin file split/moved (#1704 monolith splits; 2 were stale worktree paths)",
+          "old_origin": "src/embedder/mod.rs",
+          "old_line_start": 487,
+          "new_origin": "src/embedder/core.rs",
+          "new_line_start": 252
         }
       },
       "judges": {
@@ -6059,11 +6094,11 @@
       "gold_chunk": {
         "id": "src/embedder/mod.rs:487:regen",
         "name": "model_fingerprint",
-        "origin": "src/embedder/mod.rs",
+        "origin": "src/embedder/core.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 487,
-        "line_end": 639
+        "line_start": 252,
+        "line_end": 395
       },
       "gold_chunk_source": "consensus"
     },
@@ -6536,6 +6571,13 @@
           "old_line_start": 373,
           "new_origin": "src/cache.rs",
           "new_line_start": 784
+        },
+        "repinned_2026_06_10": {
+          "reason": "origin file split/moved (#1704 monolith splits; 2 were stale worktree paths)",
+          "old_origin": "src/cache.rs",
+          "old_line_start": 784,
+          "new_origin": "src/cache/embedding_cache.rs",
+          "new_line_start": 510
         }
       },
       "judges": {
@@ -6583,11 +6625,11 @@
       "gold_chunk": {
         "id": "src/cache.rs:784:regen",
         "name": "stats",
-        "origin": "src/cache.rs",
+        "origin": "src/cache/embedding_cache.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 784,
-        "line_end": 821
+        "line_start": 510,
+        "line_end": 547
       },
       "gold_chunk_source": "consensus"
     },
@@ -6597,7 +6639,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031616,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "repinned_2026_06_10": {
+          "reason": "origin file split/moved (#1704 monolith splits; 2 were stale worktree paths)",
+          "old_origin": ".claude/worktrees/agent-a7cedd3c/src/cli/batch/mod.rs",
+          "old_line_start": 170,
+          "new_origin": "src/cli/batch/context.rs",
+          "new_line_start": 34
+        }
       },
       "judges": {
         "claude": {
@@ -6642,11 +6691,11 @@
       "gold_chunk": {
         "id": null,
         "name": "BatchContext",
-        "origin": ".claude/worktrees/agent-a7cedd3c/src/cli/batch/mod.rs",
+        "origin": "src/cli/batch/context.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 170,
-        "line_end": 231
+        "line_start": 34,
+        "line_end": 163
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -7038,5 +7087,6 @@
     "basename": 1,
     "name": 71,
     "none": 4
-  }
+  },
+  "repinned_at": "2026-06-10"
 }

--- a/evals/queries/v3_test.v2.json
+++ b/evals/queries/v3_test.v2.json
@@ -922,7 +922,14 @@
       "source": "generated",
       "metadata": {
         "target_category": "multi_step",
-        "matched": true
+        "matched": true,
+        "repinned_2026_06_10": {
+          "reason": "origin file split/moved (#1704 monolith splits; 2 were stale worktree paths)",
+          "old_origin": ".claude/worktrees/agent-a7cedd3c/src/store/calls/cross_project.rs",
+          "old_line_start": 36,
+          "new_origin": "src/store/calls/cross_project.rs",
+          "new_line_start": 36
+        }
       },
       "judges": {
         "claude": {
@@ -967,7 +974,7 @@
       "gold_chunk": {
         "id": ".claude/worktrees/agent-a7cedd3c/src/store/calls/cross_project.rs:36:04384a2b",
         "name": "CrossProjectCaller",
-        "origin": ".claude/worktrees/agent-a7cedd3c/src/store/calls/cross_project.rs",
+        "origin": "src/store/calls/cross_project.rs",
         "language": "rust",
         "chunk_type": "struct",
         "line_start": 36,
@@ -2151,6 +2158,13 @@
           "old_line_start": 901,
           "new_origin": "src/cache.rs",
           "new_line_start": 2383
+        },
+        "repinned_2026_06_10": {
+          "reason": "origin file split/moved (#1704 monolith splits; 2 were stale worktree paths)",
+          "old_origin": "src/cache.rs",
+          "old_line_start": 2383,
+          "new_origin": "src/cache/query_cache.rs",
+          "new_line_start": 18
         }
       },
       "judges": {
@@ -2198,11 +2212,11 @@
       "gold_chunk": {
         "id": "src/cache.rs:2383:regen",
         "name": "QueryCache",
-        "origin": "src/cache.rs",
+        "origin": "src/cache/query_cache.rs",
         "language": "rust",
         "chunk_type": "impl",
-        "line_start": 2383,
-        "line_end": 2730
+        "line_start": 18,
+        "line_end": 30
       },
       "gold_chunk_source": "consensus"
     },
@@ -2273,7 +2287,14 @@
       "source": "telemetry",
       "metadata": {
         "first_seen_ts": 1776031453,
-        "source_cmd": "search"
+        "source_cmd": "search",
+        "repinned_2026_06_10": {
+          "reason": "origin file split/moved (#1704 monolith splits; 2 were stale worktree paths)",
+          "old_origin": "src/cli/batch/mod.rs",
+          "old_line_start": 373,
+          "new_origin": "src/cli/batch/context.rs",
+          "new_line_start": 401
+        }
       },
       "judges": {
         "claude": {
@@ -2320,11 +2341,11 @@
       "gold_chunk": {
         "id": null,
         "name": "invalidate_mutable_caches",
-        "origin": "src/cli/batch/mod.rs",
+        "origin": "src/cli/batch/context.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 373,
-        "line_end": 383
+        "line_start": 401,
+        "line_end": 456
       },
       "gold_chunk_source": "consensus",
       "_unresolved": true
@@ -3363,6 +3384,13 @@
           "old_line_start": 217,
           "new_origin": "src/embedder/mod.rs",
           "new_line_start": 261
+        },
+        "repinned_2026_06_10": {
+          "reason": "origin file split/moved (#1704 monolith splits; 2 were stale worktree paths)",
+          "old_origin": "src/embedder/mod.rs",
+          "old_line_start": 261,
+          "new_origin": "src/embedder/core.rs",
+          "new_line_start": 34
         }
       },
       "judges": {
@@ -3410,11 +3438,11 @@
       "gold_chunk": {
         "id": "src/embedder/mod.rs:261:regen",
         "name": "Embedder",
-        "origin": "src/embedder/mod.rs",
+        "origin": "src/embedder/core.rs",
         "language": "rust",
         "chunk_type": "struct",
-        "line_start": 261,
-        "line_end": 338
+        "line_start": 34,
+        "line_end": 105
       },
       "gold_chunk_source": "consensus"
     },
@@ -4286,6 +4314,13 @@
           "old_line_start": 321,
           "new_origin": "src/cache.rs",
           "new_line_start": 2533
+        },
+        "repinned_2026_06_10": {
+          "reason": "origin file split/moved (#1704 monolith splits; 2 were stale worktree paths)",
+          "old_origin": "src/cache.rs",
+          "old_line_start": 2533,
+          "new_origin": "src/cache/query_cache.rs",
+          "new_line_start": 114
         }
       },
       "judges": {
@@ -4333,11 +4368,11 @@
       "gold_chunk": {
         "id": "src/cache.rs:2533:regen",
         "name": "evict",
-        "origin": "src/cache.rs",
+        "origin": "src/cache/query_cache.rs",
         "language": "rust",
         "chunk_type": "method",
-        "line_start": 2533,
-        "line_end": 2611
+        "line_start": 114,
+        "line_end": 192
       },
       "gold_chunk_source": "consensus"
     },
@@ -7024,5 +7059,6 @@
     "basename": 0,
     "name": 69,
     "none": 11
-  }
+  },
+  "repinned_at": "2026-06-10"
 }


### PR DESCRIPTION
Post-merge recall check for today's 11 PRs (taste-debt queue #1701–#1704 + review fixes #1707–#1711) surfaced a fixture-side problem, not a retrieval one.

## What happened

Raw eval on v3.v2 with defaults showed agg R@5 72.9 (−1.9 vs the 2026-05-08 v1.39.2 baseline) and R@20 84.4 (−1.8). Classification of the misses found 12 golds (5 test, 7 dev) whose `(origin, name)` no longer exists in the index — guaranteed misses regardless of retrieval quality, a 5.5% ceiling loss that fully covers the observed dip:

- 10 golds pointed at pre-split paths from #1704's monolith splits: `src/cache.rs` → `cache/{mod,embedding_cache,query_cache}.rs`, `src/embedder/mod.rs` → `embedder/core.rs`, `src/cli/batch/mod.rs` → `batch/context.rs`
- 2 golds pointed into a stale `.claude/worktrees/agent-a7cedd3c/` path from fixture-generation time

## The fix

Re-pinned all 12 origins to the current paths. Ambiguous symbols (`evict`, `default_path`, `stats` — present in both cache files post-split) were disambiguated by locating the gold's original `line_start` within the pre-split `impl` blocks via `git show 9e4980db:src/cache.rs`. Each re-pinned query carries `repinned_2026_06_10` provenance metadata (old/new origin + line_start), matching the existing `regenerated_2026_04_17` convention. Line numbers refreshed from the current index (informational — the matcher keys on `(origin, name)` only).

## Result: no recall regression

Re-pinned eval, defaults, vs the 2026-05-08 baseline:

| | R@1 | R@5 | R@20 |
|---|---|---|---|
| test (n=109) | 45.9 (+5.5) | 69.7 (−1.9) | 83.5 (+1.8) |
| dev (n=109) | 49.5 (−2.8) | 79.8 (+1.8) | 93.6 (+2.8) |
| **aggregate (n=218)** | **47.7 (+1.4)** | **74.8 (±0.0)** | **88.5 (+2.3)** |

Aggregate R@5 lands exactly on baseline; R@1/R@20 slightly up. The symmetric test/dev R@1 swing (±) is single-query split noise (each query = 0.9pp at n=109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
