### PR TITLE
fix(daemon): WAL-blind cache invalidation - PRAGMA data_version discriminator (closes #1714)

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -37,7 +37,7 @@ All findings still marked open after the v1.41.0 cycle were re-verified against 
 2. **EH-V1.40-8 + PB-V1.40-7**: `try_kind_fallback` propagates `lookup_by_name` errors as fatal (`?` at handlers/graph.rs:79,147); should warn + fall through to the normal path. Easy.
 3. **SHL-V1.40-1 + AC-V1.40-9**: `lookup_by_name` (store/chunks/query.rs:271-275) — add LIMIT and routing-priority ORDER BY (currently alphabetical chunk_type, no cap; #1632's cap is downstream of the full fetch). Easy, one query.
 4. **Cluster C architecture refactor** (CQ-V1.40-1/2/4/9, API-V1.40-1/2/4, RM-V1.40-1, EXT-V1.40-1): adopt `detect_kind_for_store` at its 8 inlined call sites; unify the 6 dispatcher signatures (`&OutputFormat` vs `json: bool`); split Kind vs KindResolution; replace `_ => {}` fallthroughs with exhaustive matches; delete `cmd_impact_const_fallback` (hand-rolled duplicate); single source of truth for the ~24 redirect-note strings. One refactor PR. Medium.
-5. **DS-V1.40-1**: daemon Store cache invalidation via `PRAGMA data_version` (identity check is inode/size/mtime only, batch/mod.rs:441-509). Medium.
+5. **DS-V1.40-1**: ✅ FIXED (PR pending, #1714) — `PRAGMA data_version` on a long-lived probe connection added as second discriminator in `check_index_staleness` (batch/context.rs); probe rebaselined on rename-over; identity-only fallback with warn on probe failure. Two new tests pin WAL-commit-no-checkpoint invalidation and post-rename rebaseline.
 6. **DS-V1.40-8/10**: kind-detect + real query share no read snapshot. Medium; consider folding into 4.
 7. **Test backfill** (TC-ADV-V1.40-4, TC-HAP-V1.40-3, TC-ADV-V1.40-9, TC-ADV-V1.40-1 remainder): daemon try_kind_fallback has zero tests for any kind; no CLI integration tests for fallback kinds; V2Bare default + ULTRASECURITY×OUTPUT_FORMAT compose untested at binary boundary (every integration test pins CQS_OUTPUT_FORMAT=v1). Medium. *(ULTRASECURITY removed in #1703 — the compose-contract half is moot; V2Bare binary-boundary tests landed in the same PR.)*
 8. **Observability bundle** (OB-V1.40-1/2/5/6): fallback-fired tracing events, telemetry category (Phase 2 prioritization signal), kind.rs entry spans, Tier 2b drop counter. Easy.
@@ -96,7 +96,7 @@ Phase 1 landed shape across 6 commands × 2 surfaces with hand-rolled per-cell d
 ### Cluster D — Polymorphic-routing data safety (DS + RB + PERF)
 Every Phase 1 dispatcher adds a `lookup_by_name` SQL roundtrip BEFORE the existing-flow query. No `chunks.name` index → full table scan; no shared transaction → snapshot drift; `ORDER BY chunk_type` is alphabetical not routing-priority. **One PR**: schema migration (v28) adding `idx_chunks_name`, single read tx in dispatch handlers, CASE-priority ORDER BY, `lookup_by_name` LIMIT.
 - RB-V1.40-2 / PERF-V1.40-2 / RM-V1.40-4 (missing `chunks.name` index; full table scan per dispatch; `format!`-built SQL string per call)
-- DS-V1.40-1 (daemon `BatchContext` Store cache never invalidates from watch-loop WAL writes — WAL-mode masks main-DB identity; use `PRAGMA data_version`)
+- DS-V1.40-1 (daemon `BatchContext` Store cache never invalidates from watch-loop WAL writes — WAL-mode masks main-DB identity) — ✅ FIXED (PR pending, #1714): `PRAGMA data_version` probe shipped standalone, ahead of the rest of Cluster D
 - DS-V1.40-8 / DS-V1.40-10 (kind-detect + real-query share no read transaction)
 - AC-V1.40-9 (`lookup_by_name` ORDER BY alphabetical chunk_type)
 - SHL-V1.40-1 (no result cap — hot names deserialize thousands of chunks for kind classification)
@@ -169,7 +169,7 @@ Daemon hot path has no per-response size cap; `try_kind_fallback` echoes full ch
 | ID(s) | Title | Effort | Status |
 |---|---|---|---|
 | EH-V1.40-2 + API-V1.40-8 + OB-V1.40-3 + PB-V1.40-3 + SEC-V1.40-6 + DS-V1.40-5 | `Posture::current` / `OutputFormat::current` silent swallow + per-emit re-read + no log + TOCTOU + cross-platform case sensitivity (Cluster B) | easy-medium | ✅ Cluster B PR |
-| DS-V1.40-1 | Daemon `BatchContext` Store caches never invalidate from watch-loop WAL writes (WAL masks main-DB identity); use `PRAGMA data_version` | medium | DEFERRED — symptom rare; Cluster D bundling deferred to v1.41 cycle |
+| DS-V1.40-1 | Daemon `BatchContext` Store caches never invalidate from watch-loop WAL writes (WAL masks main-DB identity); use `PRAGMA data_version` | medium | ✅ FIXED (PR pending, #1714) — data_version probe as second staleness discriminator |
 | DS-V1.40-2 | `cmd_telemetry_reset` non-atomic — kill between `fs::copy` and `fs::write` corrupts archive or current | easy | ✅ misc P1 PR |
 | DS-V1.40-3 | `restore_from_backup` `copy_triplet` non-atomic across (main, -wal, -shm) — kill mid-restore replays failed-migration WAL frames against pre-migrate main | medium | ✅ DS-V1.40-3 PR |
 | DS-V1.40-4 | `evals/regenerate_v3_test.py` writes fixture via `Path.write_text` non-atomically — Ctrl+C corrupts eval ground truth | easy | ✅ misc P1 PR |

--- a/src/cli/batch/context.rs
+++ b/src/cli/batch/context.rs
@@ -8,6 +8,30 @@
 
 use super::*;
 
+// ─── Data-version probe ──────────────────────────────────────────────────────
+
+/// Long-lived `PRAGMA data_version` probe connection.
+///
+/// `data_version` is a per-connection counter that SQLite bumps when *another*
+/// connection (including one in the same process — e.g. the watch loop's
+/// read-write Store) commits a change to the database. It moves on WAL commits
+/// that never touch the main `index.db` file, which is exactly the blind spot
+/// of the `DbFileIdentity` (inode/size/mtime) check: under WAL, incremental
+/// reindex writes land in `index.db-wal` and the main file's identity is
+/// unchanged until checkpoint.
+///
+/// The classic pitfall: the counter is only meaningful when queried repeatedly
+/// on the SAME connection — a fresh connection per check re-baselines every
+/// time and never observes a change. So the connection here must live as long
+/// as the `BatchContext` (and be re-opened when `index.db` is replaced via
+/// rename-over, since the old fd then points at the orphaned inode and its
+/// data_version never moves again).
+pub(super) struct DataVersionProbe {
+    conn: sqlx::SqliteConnection,
+    /// Last observed `PRAGMA data_version` value on `conn`.
+    last: i64,
+}
+
 // ─── BatchContext ────────────────────────────────────────────────────────────
 
 /// Shared resources for a batch session.
@@ -25,10 +49,14 @@ use super::*;
 /// and live for the session. ONNX sessions are cleared after idle timeout.
 ///
 /// **Mutable caches** (hnsw, call_graph, test_chunks, file_set, notes_cache)
-/// use `RefCell<Option<T>>` and are auto-invalidated when the index.db mtime
-/// changes. This detects concurrent `cqs index` runs during long `cqs chat`
-/// sessions. On invalidation, the Store is also re-opened since it has its own
-/// internal `OnceLock` caches (call_graph_cache, test_chunks_cache).
+/// use `RefCell<Option<T>>` and are auto-invalidated when index.db changes —
+/// detected via file identity (inode/size/mtime) OR `PRAGMA data_version` on
+/// a long-lived probe connection (the latter catches WAL-mode incremental
+/// writes that never touch the main file; see [`Self::check_index_staleness`]).
+/// This detects concurrent `cqs index` runs and watch-loop reindexes during
+/// long daemon / `cqs chat` sessions. On invalidation, the Store is also
+/// re-opened since it has its own internal `OnceLock` caches
+/// (call_graph_cache, test_chunks_cache).
 ///
 /// Manual invalidation is available via the `refresh` batch command.
 pub(crate) struct BatchContext {
@@ -115,6 +143,15 @@ pub(crate) struct BatchContext {
     /// results from the orphaned inode. `DbFileIdentity` mixes in inode + size
     /// so sub-second replacements still register.
     pub(super) index_id: Cell<Option<DbFileIdentity>>,
+    /// Second staleness discriminator: a long-lived `PRAGMA data_version`
+    /// probe connection (see [`DataVersionProbe`]). Catches WAL-mode
+    /// incremental writes (watch loop → `index.db-wal`) that leave the main
+    /// file's identity untouched until checkpoint — the false-negative class
+    /// `index_id` alone cannot see (DS-V1.40-1 / #1714).
+    ///
+    /// `None` when the probe couldn't be opened (warned, identity-only
+    /// fallback); re-opened lazily on the next staleness check.
+    pub(super) data_version_probe: RefCell<Option<DataVersionProbe>>,
     /// When the staleness check last ran. Used to rate-limit `fs::metadata`
     /// on `index.db` — see [`STALENESS_CHECK_INTERVAL`].
     pub(super) last_staleness_check: Cell<Option<Instant>>,
@@ -192,7 +229,7 @@ impl BatchContext {
         index_id: Option<DbFileIdentity>,
     ) -> Self {
         let runtime = Arc::clone(store.runtime());
-        Self {
+        let ctx = Self {
             // Mutex<Arc<Store>> so `checkout_view` can clone the Arc out
             // cheaply.
             store: Mutex::new(Arc::new(store)),
@@ -214,6 +251,7 @@ impl BatchContext {
             cqs_dir,
             model_config,
             index_id: Cell::new(index_id),
+            data_version_probe: RefCell::new(None),
             // None means the first staleness check runs unconditionally; the
             // rate-limit kicks in only after the first successful stat.
             last_staleness_check: Cell::new(None),
@@ -227,7 +265,14 @@ impl BatchContext {
             watch_snapshot: cqs::watch_status::shared_unknown(),
             reconcile_signal: cqs::watch_status::shared_reconcile_signal(),
             fresh_notifier: cqs::watch_status::shared_fresh_notifier(),
-        }
+        };
+        // Baseline the data_version probe at construction (not lazily on the
+        // first staleness check) so WAL commits landing between construction
+        // and the first check are observed as a change rather than silently
+        // absorbed into a late baseline. Failure is non-fatal — the open
+        // helper warns and the check falls back to identity-only.
+        ctx.rebaseline_data_version_probe(&cqs::resolve_index_db(&ctx.cqs_dir));
+        ctx
     }
 
     /// Check idle timeout and clear ONNX sessions if enough time has passed.
@@ -315,15 +360,25 @@ impl BatchContext {
         }
     }
 
-    /// Check if index.db identity changed since last access. If so, clear
-    /// all mutable caches and re-open the Store (which resets its internal
-    /// OnceLock caches like call_graph_cache, test_chunks_cache).
+    /// Check if index.db changed since last access. If so, clear all mutable
+    /// caches and re-open the Store (which resets its internal OnceLock
+    /// caches like call_graph_cache, test_chunks_cache).
     ///
-    /// Identity is `(inode, size, mtime)` on unix and `(size, mtime)`
-    /// elsewhere. The extra discriminators catch sub-second replacements on
-    /// filesystems with 1-s mtime resolution (WSL NTFS/DrvFS): a `cqs index
-    /// --force` rename-over yields a new inode immediately, so the batch
-    /// session invalidates even when two events share the same mtime bucket.
+    /// Two discriminators, either of which fires the invalidation:
+    ///
+    /// 1. **File identity** — `(inode, size, mtime)` on unix, `(size, mtime)`
+    ///    elsewhere. Catches replacement (`cqs index --force` rename-over,
+    ///    new inode even when two events share a 1-s WSL NTFS mtime bucket)
+    ///    and in-place rewrites of the main file.
+    /// 2. **`PRAGMA data_version`** on a long-lived probe connection. Catches
+    ///    WAL-mode incremental writes: the watch loop's commits land in
+    ///    `index.db-wal`, leaving the main file's identity unchanged until
+    ///    checkpoint — identity alone would serve stale caches through any
+    ///    number of incremental reindexes (DS-V1.40-1 / #1714).
+    ///
+    /// False positives cost one cache reload; false negatives are the bug,
+    /// so the probe falls back to identity-only (with a warn) rather than
+    /// blocking the check when it can't be opened or queried.
     ///
     /// Rate-limited to at most once per [`STALENESS_CHECK_INTERVAL`]. Every
     /// `ctx.store()` and every `vector_index` / `file_set` / etc. accessor
@@ -355,10 +410,33 @@ impl BatchContext {
         };
 
         let last = self.index_id.get();
-        if last.is_some() && last != Some(current_id) {
+        let identity_changed = last.is_some() && last != Some(current_id);
+        // Only consult the probe when identity is unchanged: an identity
+        // change already invalidates, and the old probe fd points at the
+        // orphaned inode anyway (its data_version would never move again).
+        let data_version_changed = if identity_changed {
+            false
+        } else {
+            self.data_version_changed()
+        };
+
+        if identity_changed || data_version_changed {
             let _span = tracing::info_span!("batch_index_invalidation").entered();
-            tracing::info!("index.db identity changed, invalidating mutable caches");
+            tracing::info!(
+                identity_changed,
+                data_version_changed,
+                "index.db changed, invalidating mutable caches"
+            );
             self.invalidate_mutable_caches();
+
+            if identity_changed {
+                // The probe connection still points at the replaced (deleted)
+                // inode — re-open it against the new file. Re-baseline BEFORE
+                // the Store re-open below: a write landing between the two is
+                // then caught on the next check (false positive at worst);
+                // baselining after the re-open would silently absorb it.
+                self.rebaseline_data_version_probe(&index_path);
+            }
 
             // Re-open the Store to reset its internal OnceLock caches.
             // Reuse the shared runtime so this re-open doesn't spin up a
@@ -388,6 +466,97 @@ impl BatchContext {
             }
         }
         self.index_id.set(Some(current_id));
+    }
+
+    /// Open a fresh probe connection against `index_path` and read its
+    /// baseline `PRAGMA data_version`. Returns `None` (with a `warn!`) when
+    /// the open or the query fails — staleness detection then falls back to
+    /// identity-only rather than panicking or silently skipping the check.
+    fn open_data_version_probe(&self, index_path: &std::path::Path) -> Option<DataVersionProbe> {
+        use sqlx::ConnectOptions;
+        let result = self.runtime.block_on(async {
+            // Mirror the Store's read-only open shape (filename + read_only +
+            // WAL) so the probe sees the same journal-mode view of the DB.
+            let mut conn = sqlx::sqlite::SqliteConnectOptions::new()
+                .filename(index_path)
+                .read_only(true)
+                .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+                .connect()
+                .await?;
+            let last: i64 = sqlx::query_scalar("PRAGMA data_version")
+                .fetch_one(&mut conn)
+                .await?;
+            Ok::<_, sqlx::Error>(DataVersionProbe { conn, last })
+        });
+        match result {
+            Ok(probe) => Some(probe),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %index_path.display(),
+                    "Failed to open data_version probe — falling back to identity-only staleness detection"
+                );
+                None
+            }
+        }
+    }
+
+    /// Query `PRAGMA data_version` on the long-lived probe connection and
+    /// compare against the last observed value. Returns `true` when another
+    /// connection (e.g. the watch loop's read-write Store) has committed
+    /// since the previous observation — WAL or not.
+    ///
+    /// A missing probe (failed earlier open) is re-opened here, which
+    /// establishes a fresh baseline and returns `false` for this check. A
+    /// query failure warns, drops the probe so the next check re-opens it,
+    /// and returns `false` (identity-only fallback — never panics).
+    fn data_version_changed(&self) -> bool {
+        let mut slot = self.data_version_probe.borrow_mut();
+        match slot.as_mut() {
+            None => {
+                // Earlier open failed (or the probe was dropped after a query
+                // error) — retry. Freshly baselined, so nothing to compare.
+                *slot = self.open_data_version_probe(&cqs::resolve_index_db(&self.cqs_dir));
+                false
+            }
+            Some(probe) => {
+                let result = self.runtime.block_on(
+                    sqlx::query_scalar::<_, i64>("PRAGMA data_version").fetch_one(&mut probe.conn),
+                );
+                match result {
+                    Ok(v) => {
+                        let changed = v != probe.last;
+                        probe.last = v;
+                        changed
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "data_version probe query failed — dropping probe; will re-open on next staleness check"
+                        );
+                        *slot = None;
+                        false
+                    }
+                }
+            }
+        }
+    }
+
+    /// Drop the current probe connection (if any) and open a fresh one
+    /// against `index_path`, re-baselining `data_version`. Called when
+    /// `index.db` is replaced (rename-over): the old fd points at the
+    /// orphaned inode, so its counter would never move again. Also called at
+    /// construction and on manual `refresh`.
+    fn rebaseline_data_version_probe(&self, index_path: &std::path::Path) {
+        use sqlx::Connection;
+        let mut slot = self.data_version_probe.borrow_mut();
+        if let Some(old) = slot.take() {
+            // Explicit close so sqlite finalizes the old handle now instead
+            // of whenever Drop gets around to it. Best-effort — the fd is
+            // dead-weight either way.
+            let _ = self.runtime.block_on(old.conn.close());
+        }
+        *slot = self.open_data_version_probe(index_path);
     }
 
     /// Clear all mutable caches. Called on index identity change or manual refresh.
@@ -463,6 +632,10 @@ impl BatchContext {
 
         // Slot-aware index resolution.
         let index_path = cqs::resolve_index_db(&self.cqs_dir);
+        // Re-baseline the data_version probe before the Store re-open (same
+        // ordering rationale as check_index_staleness): a write landing
+        // between the two is caught on the next check instead of absorbed.
+        self.rebaseline_data_version_probe(&index_path);
         // Pass the shared runtime so manual refreshes keep using the same
         // worker pool as the session they're refreshing.
         let new_store =

--- a/src/cli/batch/context.rs
+++ b/src/cli/batch/context.rs
@@ -147,7 +147,7 @@ pub(crate) struct BatchContext {
     /// probe connection (see [`DataVersionProbe`]). Catches WAL-mode
     /// incremental writes (watch loop → `index.db-wal`) that leave the main
     /// file's identity untouched until checkpoint — the false-negative class
-    /// `index_id` alone cannot see (DS-V1.40-1 / #1714).
+    /// `index_id` alone cannot see.
     ///
     /// `None` when the probe couldn't be opened (warned, identity-only
     /// fallback); re-opened lazily on the next staleness check.
@@ -374,7 +374,7 @@ impl BatchContext {
     ///    WAL-mode incremental writes: the watch loop's commits land in
     ///    `index.db-wal`, leaving the main file's identity unchanged until
     ///    checkpoint — identity alone would serve stale caches through any
-    ///    number of incremental reindexes (DS-V1.40-1 / #1714).
+    ///    number of incremental reindexes.
     ///
     /// False positives cost one cache reload; false negatives are the bug,
     /// so the probe falls back to identity-only (with a warn) rather than

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -179,14 +179,15 @@ fn refs_lru_size() -> std::num::NonZeroUsize {
     std::num::NonZeroUsize::new(size).unwrap_or(std::num::NonZeroUsize::new(1).unwrap())
 }
 
-/// Minimum interval between `fs::metadata` calls on `index.db` during a
-/// batch session. `store()` is called on virtually every handler hop, and
-/// `ctx.store()` calls `check_index_staleness` which in turn calls
-/// `fs::metadata`. Most filesystem mtime resolutions are 1 ms on Linux ext4
-/// / WSL, so polling more often than ~100 ms cannot detect anything
-/// mtime-based — we just pay a syscall per poll. 100 ms caps the syscall
-/// rate at ~10 Hz per batch session while keeping reindex detection latency
-/// well under a second.
+/// Minimum interval between staleness probes (`fs::metadata` on `index.db`
+/// plus one `PRAGMA data_version` on the long-lived probe connection) during
+/// a batch session. `store()` is called on virtually every handler hop, and
+/// `ctx.store()` calls `check_index_staleness` which runs both probes. Most
+/// filesystem mtime resolutions are 1 ms on Linux ext4 / WSL, so polling
+/// more often than ~100 ms cannot detect anything mtime-based — we just pay
+/// a syscall per poll (the pragma is a connection-local counter read,
+/// cheaper still). 100 ms caps the probe rate at ~10 Hz per batch session
+/// while keeping reindex detection latency well under a second.
 const STALENESS_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 
 /// A cached value paired with the instant it was loaded. The accessor
@@ -574,6 +575,148 @@ mod tests {
             ctx.notes_cache.borrow().is_none(),
             "DS-V1.25-6: rename-over replacement (same mtime, new inode) should invalidate cache"
         );
+    }
+
+    /// DS-V1.40-1 / #1714: the daemon runs WAL mode — the watch loop's
+    /// incremental writes go to `index.db-wal`, and the main file's identity
+    /// (inode/size/mtime) doesn't change until checkpoint. Identity alone
+    /// would serve stale caches through any number of incremental reindexes.
+    /// The `PRAGMA data_version` probe must catch the commit anyway.
+    #[test]
+    fn test_wal_write_without_checkpoint_invalidates_cache() {
+        use sqlx::{ConnectOptions, Connection};
+
+        let (_dir, cqs_dir) = setup_test_store();
+        let ctx = create_test_context(&cqs_dir).unwrap();
+
+        // Populate a cache and run the first check to baseline both
+        // discriminators (identity + data_version).
+        *ctx.notes_cache.borrow_mut() = Some(std::sync::Arc::new(vec![]));
+        ctx.check_index_staleness();
+        assert!(
+            ctx.notes_cache.borrow().is_some(),
+            "baseline check must not invalidate"
+        );
+
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        let id_before = DbFileIdentity::from_path(&index_path).unwrap();
+
+        // Second connection, same process (the watch-loop-vs-batch-context
+        // shape): commit a write through WAL with NO checkpoint. The
+        // connection stays open across the assertions — closing the last
+        // writer would auto-checkpoint into the main file and let the
+        // identity discriminator mask the one under test.
+        let mut writer = ctx
+            .runtime
+            .block_on(
+                sqlx::sqlite::SqliteConnectOptions::new()
+                    .filename(&index_path)
+                    .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+                    .connect(),
+            )
+            .unwrap();
+        ctx.runtime
+            .block_on(async {
+                sqlx::query("CREATE TABLE IF NOT EXISTS wal_poke (x INTEGER)")
+                    .execute(&mut writer)
+                    .await?;
+                sqlx::query("INSERT INTO wal_poke (x) VALUES (1)")
+                    .execute(&mut writer)
+                    .await?;
+                Ok::<_, sqlx::Error>(())
+            })
+            .unwrap();
+
+        // Precondition: the commit landed in the WAL, not the main file —
+        // if identity moved, this test would prove nothing about the
+        // data_version discriminator.
+        assert_eq!(
+            DbFileIdentity::from_path(&index_path).unwrap(),
+            id_before,
+            "test precondition: WAL commit must leave main-file identity unchanged"
+        );
+
+        // Clear the 100ms rate limit and re-check: data_version must fire.
+        ctx.last_staleness_check.set(None);
+        ctx.check_index_staleness();
+        assert!(
+            ctx.notes_cache.borrow().is_none(),
+            "DS-V1.40-1: WAL commit with no checkpoint must invalidate caches via data_version"
+        );
+
+        let _ = ctx.runtime.block_on(writer.close());
+    }
+
+    /// After a rename-over replacement (identity invalidation), the probe
+    /// connection must be re-opened against the new file — the old fd points
+    /// at the deleted inode and its data_version would never move again.
+    /// Pin the rebaseline by WAL-committing against the NEW file (no
+    /// checkpoint) and requiring a second invalidation.
+    #[cfg(unix)]
+    #[test]
+    fn test_probe_rebaselines_after_rename_over() {
+        use sqlx::{ConnectOptions, Connection};
+
+        let (_dir, cqs_dir) = setup_test_store();
+        let ctx = create_test_context(&cqs_dir).unwrap();
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+
+        *ctx.notes_cache.borrow_mut() = Some(std::sync::Arc::new(vec![]));
+        ctx.check_index_staleness();
+        assert!(ctx.notes_cache.borrow().is_some());
+
+        // Rename-over (the `cqs index --force` shape).
+        let replacement = cqs_dir.join("index.db.replacement");
+        let store = Store::open(&replacement).unwrap();
+        store.init(&ModelInfo::default()).unwrap();
+        drop(store);
+        std::fs::rename(&replacement, &index_path).unwrap();
+
+        ctx.last_staleness_check.set(None);
+        ctx.check_index_staleness(); // identity fires; probe rebaselines here
+        assert!(
+            ctx.notes_cache.borrow().is_none(),
+            "identity change must invalidate"
+        );
+
+        // Repopulate, then WAL-commit against the NEW file with no checkpoint.
+        *ctx.notes_cache.borrow_mut() = Some(std::sync::Arc::new(vec![]));
+        let id_before = DbFileIdentity::from_path(&index_path).unwrap();
+        let mut writer = ctx
+            .runtime
+            .block_on(
+                sqlx::sqlite::SqliteConnectOptions::new()
+                    .filename(&index_path)
+                    .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+                    .connect(),
+            )
+            .unwrap();
+        ctx.runtime
+            .block_on(async {
+                sqlx::query("CREATE TABLE IF NOT EXISTS wal_poke (x INTEGER)")
+                    .execute(&mut writer)
+                    .await?;
+                sqlx::query("INSERT INTO wal_poke (x) VALUES (1)")
+                    .execute(&mut writer)
+                    .await?;
+                Ok::<_, sqlx::Error>(())
+            })
+            .unwrap();
+        assert_eq!(
+            DbFileIdentity::from_path(&index_path).unwrap(),
+            id_before,
+            "test precondition: WAL commit must leave main-file identity unchanged"
+        );
+
+        ctx.last_staleness_check.set(None);
+        ctx.check_index_staleness();
+        assert!(
+            ctx.notes_cache.borrow().is_none(),
+            "probe must be re-opened against the new inode after rename-over — \
+             a stale probe fd would never observe this commit"
+        );
+
+        let _ = ctx.runtime.block_on(writer.close());
     }
 
     #[test]

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -577,7 +577,7 @@ mod tests {
         );
     }
 
-    /// DS-V1.40-1 / #1714: the daemon runs WAL mode — the watch loop's
+    /// The daemon runs WAL mode — the watch loop's
     /// incremental writes go to `index.db-wal`, and the main file's identity
     /// (inode/size/mtime) doesn't change until checkpoint. Identity alone
     /// would serve stale caches through any number of incremental reindexes.


### PR DESCRIPTION
Closes #1714 (audit finding DS-V1.40-1, deferred to this cycle).

## Problem

The daemon's `BatchContext` invalidates mutable caches on `index.db` file-identity change (inode/size/mtime). The daemon runs WAL mode: the watch loop's incremental writes land in `index.db-wal`, main-file identity doesn't change until checkpoint, so a long-lived session serves stale file-sets/call-graphs/notes through any number of incremental reindexes — exactly our steady state under `watch --serve`.

## Fix

`PRAGMA data_version` as a second discriminator inside the existing rate-limited staleness check. Key implementation point: `data_version` is per-connection, and Store's sqlx pool recycles idle connections (which would re-baseline the counter and go blind) — so the probe is a dedicated raw read-only `SqliteConnection` held by `BatchContext`, queried on the shared runtime.

- Either discriminator (identity OR data_version) fires the existing invalidation path, preserving the documented store-swap pairing.
- Probe is baselined at construction and re-opened on identity invalidation (a rename-over leaves the old probe fd on an orphaned inode) — re-baseline ordered before the Store re-open so a racing write is a false positive, never a false negative.
- Probe failure: warn + identity-only fallback, lazy re-open next check.

## Verification

- New test: second same-process connection commits through WAL with **no checkpoint**, main-file identity asserted unchanged, caches invalidate.
- New test: rename-over → invalidation → WAL write against the new file → second invalidation (pins the stale-fd pitfall).
- Existing identity/mtime invalidation tests pass. Batch suite: 154 passed. Build/clippy/fmt clean.
- docs/audit-triage.md DS-V1.40-1 entries flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
