### PR TITLE
feat(status): --watch exposes daemon operational stats over the socket (closes #1715)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,7 +271,7 @@ src/
       daemon.rs - spawn_daemon_thread (the --serve accept-loop closure body)
       tests.rs  - watch unit-test bench (#[cfg(test)])
       adversarial_socket_tests.rs - adversarial coverage for handle_socket_client (#[cfg(all(test, unix))])
-  watch_status.rs - WatchSnapshot state machine + Arc<RwLock<...>> shared between watch writer and daemon reader (#1182, #1208)
+  watch_status.rs - WatchSnapshot state machine + ops-stats block (`cqs status --watch`) + Arc<RwLock<...>> shared between watch writer and daemon reader (#1182, #1208, #1715)
   daemon_translate.rs - Daemon RPC client + wait_for_fresh helper + DaemonRpcError typed enum (#1211)
   fs.rs        - atomic_replace and other FS helpers
   limits.rs    - Tunable env-var-backed limits and defaults

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Ceremony commands (eval, A/B comparisons, anything that must trust the index) ga
 ```bash
 cqs status --watch-fresh                 # one-shot text summary
 cqs status --watch-fresh --json          # full WatchSnapshot
+cqs status --watch                       # + daemon operational stats: in-flight clients, queue depth, dropped events, last-reindex latency, last error, per-slot freshness (#1715)
 cqs status --watch-fresh --wait                     # block until fresh (default 30 s budget, 250 ms poll, capped at 600 s)
 cqs status --watch-fresh --wait --wait-secs 600     # extend up to the 600 s cap
 ```
@@ -592,7 +593,7 @@ Key commands (`--json` works on all commands; `--format mermaid` also accepted o
 - `cqs refresh` - invalidate daemon caches and re-open the Store. Alias `cqs invalidate`. No-op when no daemon is running
 - `cqs doctor` - check model, index, hardware (execution provider, CAGRA availability)
 - `cqs hook install/uninstall/status/fire` - manage `.git/hooks/post-{checkout,merge,rewrite}` for watch-mode reconciliation. Idempotent; respects third-party hooks via marker check (#1182)
-- `cqs status --watch-fresh [--wait [--wait-secs N]]` - report watch-loop freshness; `--wait` blocks until `state == fresh` (default 30 s, capped at 600 s) (#1182)
+- `cqs status --watch-fresh [--watch] [--wait [--wait-secs N]]` - report watch-loop freshness; `--watch` adds daemon operational stats (in-flight clients, dropped events, last-reindex latency, last error, per-slot freshness); `--wait` blocks until `state == fresh` (default 30 s, capped at 600 s) (#1182, #1715)
 - `cqs completions <shell>` - generate shell completions (bash, zsh, fish, powershell, elvish)
 
 Keep index fresh: run `cqs watch` in a background terminal, or `cqs index` after significant changes.

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -608,6 +608,7 @@ mod tests {
             last_synced_at: Some(1_700_000_000),
             snapshot_at: Some(1_700_000_001),
             active_slot: None,
+            ops: None,
         };
         // Reach into the lock through the view's clone of the Arc.
         // (Tests under `cqs::watch_status` write directly; here we
@@ -661,6 +662,7 @@ mod tests {
                 last_synced_at: Some(1_700_000_000),
                 snapshot_at: Some(1_700_000_002),
                 active_slot: None,
+                ops: None,
             };
             *snap_handle_for_publisher
                 .write()
@@ -706,6 +708,7 @@ mod tests {
             last_synced_at: Some(1_700_000_000),
             snapshot_at: Some(1_700_000_003),
             active_slot: None,
+            ops: None,
         };
         view.test_overwrite_watch_snapshot(stale);
 

--- a/src/cli/commands/dispatch_shims.rs
+++ b/src/cli/commands/dispatch_shims.rs
@@ -108,8 +108,8 @@ pub fn cmd_status_dispatch(
     _project_cqs_dir: &Path,
     cmd: &Commands,
 ) -> Result<()> {
-    must_be!(cmd, Commands::Status { watch_fresh, output, wait, wait_secs } => {
-        commands::cmd_status(cli.json || output.json, *watch_fresh, *wait, *wait_secs)
+    must_be!(cmd, Commands::Status { watch_fresh, watch, output, wait, wait_secs } => {
+        commands::cmd_status(cli.json || output.json, *watch_fresh, *watch, *wait, *wait_secs)
     })
 }
 

--- a/src/cli/commands/infra/slot.rs
+++ b/src/cli/commands/infra/slot.rs
@@ -719,6 +719,7 @@ mod tests {
             last_synced_at: Some(0),
             snapshot_at: Some(0),
             active_slot: slot.map(|s| s.to_string()),
+            ops: None,
         };
         let inner = serde_json::json!({
             "data": serde_json::to_value(&snap).unwrap(),

--- a/src/cli/commands/infra/status.rs
+++ b/src/cli/commands/infra/status.rs
@@ -1,4 +1,4 @@
-//! `cqs status` — watch-mode freshness query.
+//! `cqs status` — watch-mode freshness + daemon operational stats.
 //!
 //! Connects to the running `cqs watch --serve` daemon and reports the
 //! latest [`WatchSnapshot`]. Designed for agent loops that want to gate
@@ -6,7 +6,12 @@
 //! checks. The CLI sits next to `cqs ping`: same socket, same envelope,
 //! different command name.
 //!
-//! `--watch-fresh` is the canonical flag and currently the only mode.
+//! Two report flags compose over the same snapshot query (#1715):
+//!
+//! - `--watch-fresh` — the freshness state machine (canonical since #1182).
+//! - `--watch` — the daemon's operational stats block (in-flight clients,
+//!   queue depth, dropped events, last-reindex latency, reconcile state,
+//!   last error, per-slot freshness). Replaces journalctl grepping.
 //!
 //! `--wait` polls client-side until the snapshot reports `state == fresh`
 //! or the `--wait-secs` budget expires. Polling on the client keeps the
@@ -19,29 +24,39 @@ use anyhow::Result;
 
 use crate::cli::find_project_root;
 
-/// `cqs status --watch-fresh [--json] [--wait [--wait-secs N]]`.
+/// `cqs status (--watch-fresh|--watch) [--json] [--wait [--wait-secs N]]`.
 ///
 /// Behaviour matrix:
 ///
 /// | flags                      | exit | output                                           |
 /// |----------------------------|------|--------------------------------------------------|
-/// | (no flag)                  | 1    | error — must pass `--watch-fresh`                |
+/// | (no flag)                  | 1    | error — must pass `--watch-fresh` or `--watch`   |
 /// | `--watch-fresh`            | 0    | one-line text summary                            |
-/// | `--watch-fresh --json`     | 0    | full WatchSnapshot JSON                          |
-/// | `--wait` without `--watch-fresh` | 1 | error — `--wait` requires `--watch-fresh`     |
-/// | `--watch-fresh --wait`     | 0/1  | text summary; exit 1 if budget expired           |
-/// | `--watch-fresh --wait --json` | 0/1 | snapshot JSON; exit 1 if budget expired       |
+/// | `--watch`                  | 0    | text summary + operational stats block           |
+/// | `--watch[-fresh] --json`   | 0    | full WatchSnapshot JSON (includes `ops`)         |
+/// | `--wait` without a report flag | 1 | error — `--wait` requires `--watch-fresh`/`--watch` |
+/// | `--watch[-fresh] --wait`   | 0/1  | text summary; exit 1 if budget expired           |
+/// | `--watch[-fresh] --wait --json` | 0/1 | snapshot JSON; exit 1 if budget expired      |
 ///
 /// No daemon → exit 1, friendly stderr message (parity with `cqs ping`).
-pub(crate) fn cmd_status(json: bool, watch_fresh: bool, wait: bool, wait_secs: u64) -> Result<()> {
-    let _span = tracing::info_span!("cmd_status", json, watch_fresh, wait, wait_secs).entered();
+/// Both flags share the same `daemon_status` query and the same no-daemon
+/// error shape — `--watch` is additive output, not a second command.
+pub(crate) fn cmd_status(
+    json: bool,
+    watch_fresh: bool,
+    watch: bool,
+    wait: bool,
+    wait_secs: u64,
+) -> Result<()> {
+    let _span =
+        tracing::info_span!("cmd_status", json, watch_fresh, watch, wait, wait_secs).entered();
 
-    if !watch_fresh {
+    if !watch_fresh && !watch {
         // Gate the entire command on at least one explicit "what to report"
         // flag, and nudge the user toward the canonical combo
         // (`--watch-fresh --wait`) — agents and operators who hit the bare
         // `cqs status` probably want to wait for fresh, not poll once.
-        let msg = "cqs status: hint: try --watch-fresh --wait";
+        let msg = "cqs status: hint: try --watch-fresh --wait (or --watch for daemon stats)";
         if json {
             crate::cli::json_envelope::emit_json_error(
                 crate::cli::json_envelope::error_codes::INVALID_INPUT,
@@ -67,7 +82,7 @@ pub(crate) fn cmd_status(json: bool, watch_fresh: bool, wait: bool, wait_secs: u
         if !wait {
             return match cqs::daemon_translate::daemon_status(&cqs_dir) {
                 Ok(snap) => {
-                    emit_snapshot(&snap, json)?;
+                    emit_snapshot(&snap, json, watch)?;
                     Ok(())
                 }
                 Err(err) => emit_no_daemon(&err.as_message(), json),
@@ -79,7 +94,7 @@ pub(crate) fn cmd_status(json: bool, watch_fresh: bool, wait: bool, wait_secs: u
         // eval translates to anyhow errors.
         match cqs::daemon_translate::wait_for_fresh(&cqs_dir, budget_secs) {
             cqs::daemon_translate::FreshnessWait::Fresh(snap) => {
-                emit_snapshot(&snap, json)?;
+                emit_snapshot(&snap, json, watch)?;
                 Ok(())
             }
             cqs::daemon_translate::FreshnessWait::Timeout(snap) => {
@@ -98,7 +113,7 @@ pub(crate) fn cmd_status(json: bool, watch_fresh: bool, wait: bool, wait_secs: u
                         Some(payload),
                     )?;
                 } else {
-                    print_text(&snap);
+                    print_text(&snap, watch);
                     eprintln!("cqs: watch index still stale after {budget_secs}s wait");
                 }
                 // Budget expired before fresh — surface as exit 1
@@ -117,7 +132,7 @@ pub(crate) fn cmd_status(json: bool, watch_fresh: bool, wait: bool, wait_secs: u
 
     #[cfg(not(unix))]
     {
-        let _ = (json, wait, wait_secs);
+        let _ = (json, watch, wait, wait_secs);
         let _ = find_project_root;
         eprintln!("cqs: status is unix-only (daemon socket uses Unix domain sockets)");
         std::process::exit(1);
@@ -125,11 +140,18 @@ pub(crate) fn cmd_status(json: bool, watch_fresh: bool, wait: bool, wait_secs: u
 }
 
 #[cfg(unix)]
-fn emit_snapshot(snap: &cqs::watch_status::WatchSnapshot, json: bool) -> Result<()> {
+fn emit_snapshot(
+    snap: &cqs::watch_status::WatchSnapshot,
+    json: bool,
+    show_ops: bool,
+) -> Result<()> {
     if json {
+        // The JSON shape is the full WatchSnapshot either way — the `ops`
+        // block ships on every daemon publish since #1715, so `--watch`
+        // and `--watch-fresh` consumers parse one schema.
         crate::cli::json_envelope::emit_json(snap)?;
     } else {
-        print_text(snap);
+        print_text(snap, show_ops);
     }
     Ok(())
 }
@@ -151,7 +173,7 @@ fn emit_no_daemon(msg: &str, json: bool) -> ! {
 }
 
 #[cfg(unix)]
-fn print_text(snap: &cqs::watch_status::WatchSnapshot) {
+fn print_text(snap: &cqs::watch_status::WatchSnapshot, show_ops: bool) {
     // Single-line summary so a script can do
     //   `cqs status --watch-fresh | grep -q '^state: fresh'`
     // without parsing JSON. Counters that matter live on the second line.
@@ -164,6 +186,48 @@ fn print_text(snap: &cqs::watch_status::WatchSnapshot) {
         snap.dropped_this_cycle,
         snap.last_event_unix_secs,
     );
+    if show_ops {
+        print_ops_text(snap);
+    }
+}
+
+/// Render the `--watch` operational block (#1715). Grep-friendly
+/// `key=value` lines, same convention as the counters line above.
+#[cfg(unix)]
+fn print_ops_text(snap: &cqs::watch_status::WatchSnapshot) {
+    let Some(ops) = snap.ops.as_ref() else {
+        // Old daemon binary that predates the ops block — say so rather
+        // than printing fake zeros.
+        println!("ops: unavailable (daemon predates --watch; restart it on the current binary)");
+        return;
+    };
+    match ops.last_reindex.as_ref() {
+        Some(lr) => println!(
+            "clients_in_flight={} reconcile_pending={} last_reindex_at={} last_reindex_ms={} last_reindex_files={}",
+            ops.in_flight_clients, ops.reconcile_pending, lr.at_unix_secs, lr.duration_ms, lr.files,
+        ),
+        None => println!(
+            "clients_in_flight={} reconcile_pending={} last_reindex=none",
+            ops.in_flight_clients, ops.reconcile_pending,
+        ),
+    }
+    match ops.last_error.as_ref() {
+        Some(err) => println!(
+            "last_error_at={} last_error={}",
+            err.at_unix_secs, err.message
+        ),
+        None => println!("last_error=none"),
+    }
+    for slot in &ops.slots {
+        println!(
+            "slot={} state={} last_synced_at={}",
+            slot.name,
+            slot.state.as_str(),
+            slot.last_synced_at
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/commands/infra/status.rs
+++ b/src/cli/commands/infra/status.rs
@@ -6,7 +6,7 @@
 //! checks. The CLI sits next to `cqs ping`: same socket, same envelope,
 //! different command name.
 //!
-//! Two report flags compose over the same snapshot query (#1715):
+//! Two report flags compose over the same snapshot query:
 //!
 //! - `--watch-fresh` — the freshness state machine (canonical since #1182).
 //! - `--watch` — the daemon's operational stats block (in-flight clients,
@@ -147,7 +147,7 @@ fn emit_snapshot(
 ) -> Result<()> {
     if json {
         // The JSON shape is the full WatchSnapshot either way — the `ops`
-        // block ships on every daemon publish since #1715, so `--watch`
+        // block ships on every daemon publish since the ops block shipped, so `--watch`
         // and `--watch-fresh` consumers parse one schema.
         crate::cli::json_envelope::emit_json(snap)?;
     } else {
@@ -191,7 +191,7 @@ fn print_text(snap: &cqs::watch_status::WatchSnapshot, show_ops: bool) {
     }
 }
 
-/// Render the `--watch` operational block (#1715). Grep-friendly
+/// Render the `--watch` operational block. Grep-friendly
 /// `key=value` lines, same convention as the counters line above.
 #[cfg(unix)]
 fn print_ops_text(snap: &cqs::watch_status::WatchSnapshot) {

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -863,18 +863,26 @@ pub(super) enum Commands {
     /// agent loops that want to gate work on freshness (eval runners,
     /// pre-query checks). Exits 1 if no daemon is running.
     ///
-    /// `--watch-fresh` is the canonical flag — kept explicit (not the
-    /// implied default) so future siblings (`--last-error`, `--clients`)
-    /// can join cleanly.
+    /// `--watch-fresh` is the canonical freshness flag; `--watch` adds
+    /// the daemon's operational stats (queue depth, in-flight clients,
+    /// dropped events, last-reindex latency, last error, per-slot
+    /// freshness) — the journalctl-grep replacement (#1715). The two
+    /// flags compose: both hit the same snapshot query.
     ///
     /// `--wait` polls until the snapshot reports `state == fresh` or the
     /// `--wait-secs` budget expires. Polling happens client-side so the
     /// daemon thread is never pinned by a long wait.
     #[cqs_cmd(group = "a", batch = "cli")]
     Status {
-        /// Report watch-mode freshness (currently the only mode).
+        /// Report watch-mode freshness.
         #[arg(long)]
         watch_fresh: bool,
+        /// Report daemon operational stats: in-flight clients, queue
+        /// depth, dropped events, last-reindex latency, reconcile
+        /// state, last error, per-slot freshness. Composes with
+        /// `--watch-fresh` (same snapshot, extra output block).
+        #[arg(long)]
+        watch: bool,
         /// Block until the snapshot reports `state == fresh` (or until the
         /// `--wait-secs` budget expires). Requires `--watch-fresh`.
         #[arg(long)]

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -866,7 +866,7 @@ pub(super) enum Commands {
     /// `--watch-fresh` is the canonical freshness flag; `--watch` adds
     /// the daemon's operational stats (queue depth, in-flight clients,
     /// dropped events, last-reindex latency, last error, per-slot
-    /// freshness) — the journalctl-grep replacement (#1715). The two
+    /// freshness) — the journalctl-grep replacement. The two
     /// flags compose: both hit the same snapshot query.
     ///
     /// `--wait` polls until the snapshot reports `state == fresh` or the

--- a/src/cli/watch/daemon.rs
+++ b/src/cli/watch/daemon.rs
@@ -36,6 +36,12 @@ use super::{
 /// via [`crate::cli::batch::BatchContext::adopt_reconcile_signal`] so the
 /// daemon's `dispatch_reconcile` handler flips a flag the watch loop is
 /// actually reading.
+///
+/// `in_flight`: the shared per-connection counter. Owned by the outer
+/// `cmd_watch` scope (not local to this thread) so the watch loop can
+/// sample it into the `cqs status --watch` ops block (#1715). This
+/// thread is the only writer; the watch loop only `load`s.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn spawn_daemon_thread(
     listener: UnixListener,
     daemon_embedder: Arc<OnceLock<Arc<Embedder>>>,
@@ -44,6 +50,7 @@ pub(super) fn spawn_daemon_thread(
     daemon_watch_snapshot: cqs::watch_status::SharedWatchSnapshot,
     daemon_reconcile_signal: cqs::watch_status::SharedReconcileSignal,
     daemon_fresh_notifier: cqs::watch_status::SharedFreshNotifier,
+    in_flight: Arc<AtomicUsize>,
 ) -> JoinHandle<()> {
     std::thread::spawn(move || {
         // BatchContext created inside the thread — RefCell is !Send
@@ -113,7 +120,8 @@ pub(super) fn spawn_daemon_thread(
         // try_lock / brief lock semantics — they never block on a
         // long handler.
         let ctx = Arc::new(Mutex::new(ctx));
-        let in_flight = Arc::new(AtomicUsize::new(0));
+        // `in_flight` arrives as a parameter — shared with the watch
+        // loop's snapshot publisher (#1715).
         // Resolve cap once at startup so a `CQS_MAX_DAEMON_CLIENTS` change
         // requires daemon restart (matches the rest of the env-var surface —
         // config reload is not a goal for caps).

--- a/src/cli/watch/daemon.rs
+++ b/src/cli/watch/daemon.rs
@@ -39,7 +39,7 @@ use super::{
 ///
 /// `in_flight`: the shared per-connection counter. Owned by the outer
 /// `cmd_watch` scope (not local to this thread) so the watch loop can
-/// sample it into the `cqs status --watch` ops block (#1715). This
+/// sample it into the `cqs status --watch` ops block. This
 /// thread is the only writer; the watch loop only `load`s.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn spawn_daemon_thread(
@@ -121,7 +121,7 @@ pub(super) fn spawn_daemon_thread(
         // long handler.
         let ctx = Arc::new(Mutex::new(ctx));
         // `in_flight` arrives as a parameter — shared with the watch
-        // loop's snapshot publisher (#1715).
+        // loop's snapshot publisher.
         // Resolve cap once at startup so a `CQS_MAX_DAEMON_CLIENTS` change
         // requires daemon restart (matches the rest of the env-var surface —
         // config reload is not a goal for caps).

--- a/src/cli/watch/events.rs
+++ b/src/cli/watch/events.rs
@@ -226,7 +226,7 @@ pub(super) fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut
         return;
     }
     // Wall-clock the reindex pass so `cqs status --watch` can report
-    // last-reindex latency (#1715) — previously only visible as a
+    // last-reindex latency — previously only visible as a
     // tracing span duration in journalctl.
     let reindex_started = std::time::Instant::now();
     match reindex_files(
@@ -239,7 +239,7 @@ pub(super) fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut
         cfg.quiet,
     ) {
         Ok((count, content_hashes)) => {
-            // Publish-side stats for `cqs status --watch` (#1715): a
+            // Publish-side stats for `cqs status --watch`: a
             // timestamp + duration pair the snapshot publisher reads
             // every tick.
             state.last_reindex = Some(cqs::watch_status::ReindexLatency {
@@ -484,7 +484,7 @@ pub(super) fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut
         }
         Err(e) => {
             warn!(error = %e, "Reindex error");
-            // Surface the failure to `cqs status --watch` (#1715) so
+            // Surface the failure to `cqs status --watch` so
             // operators don't need journalctl to see why the index is
             // behind. Sticky — see `WatchErrorInfo` docs.
             state.last_error = Some(cqs::watch_status::WatchErrorInfo {
@@ -511,7 +511,7 @@ pub(super) fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut
 /// Process notes.toml changes: parse and store notes (no embedding needed).
 ///
 /// Takes `&mut WatchState` so a notes-reindex failure lands in
-/// `state.last_error` for `cqs status --watch` (#1715), same as the
+/// `state.last_error` for `cqs status --watch`, same as the
 /// file-reindex path.
 pub(super) fn process_note_changes(
     root: &Path,

--- a/src/cli/watch/events.rs
+++ b/src/cli/watch/events.rs
@@ -225,6 +225,10 @@ pub(super) fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut
         tracing::warn!(error = %e, "Cannot set base HNSW dirty flag — skipping reindex to prevent stale index on crash");
         return;
     }
+    // Wall-clock the reindex pass so `cqs status --watch` can report
+    // last-reindex latency (#1715) — previously only visible as a
+    // tracing span duration in journalctl.
+    let reindex_started = std::time::Instant::now();
     match reindex_files(
         cfg.root,
         store,
@@ -235,6 +239,15 @@ pub(super) fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut
         cfg.quiet,
     ) {
         Ok((count, content_hashes)) => {
+            // Publish-side stats for `cqs status --watch` (#1715): a
+            // timestamp + duration pair the snapshot publisher reads
+            // every tick.
+            state.last_reindex = Some(cqs::watch_status::ReindexLatency {
+                at_unix_secs: cqs::unix_secs_i64().unwrap_or(0),
+                duration_ms: u64::try_from(reindex_started.elapsed().as_millis())
+                    .unwrap_or(u64::MAX),
+                files: u64::try_from(files.len()).unwrap_or(u64::MAX),
+            });
             // Record mtimes to skip duplicate events
             for (file, mtime) in pre_mtimes {
                 state.last_indexed_mtime.insert(file, mtime);
@@ -471,6 +484,13 @@ pub(super) fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut
         }
         Err(e) => {
             warn!(error = %e, "Reindex error");
+            // Surface the failure to `cqs status --watch` (#1715) so
+            // operators don't need journalctl to see why the index is
+            // behind. Sticky — see `WatchErrorInfo` docs.
+            state.last_error = Some(cqs::watch_status::WatchErrorInfo {
+                at_unix_secs: cqs::unix_secs_i64().unwrap_or(0),
+                message: format!("reindex failed: {e}"),
+            });
             // The dirty flag was set before the reindex attempt and the
             // success path's `clear_hnsw_dirty_with_retry` is unreachable
             // from this arm. Surface that the HNSW stays marked dirty on
@@ -489,7 +509,16 @@ pub(super) fn process_file_changes(cfg: &WatchConfig, store: &Store, state: &mut
 }
 
 /// Process notes.toml changes: parse and store notes (no embedding needed).
-pub(super) fn process_note_changes(root: &Path, store: &Store, quiet: bool) {
+///
+/// Takes `&mut WatchState` so a notes-reindex failure lands in
+/// `state.last_error` for `cqs status --watch` (#1715), same as the
+/// file-reindex path.
+pub(super) fn process_note_changes(
+    root: &Path,
+    store: &Store,
+    quiet: bool,
+    state: &mut WatchState,
+) {
     if !quiet {
         println!("\nNotes changed, reindexing...");
     }
@@ -501,6 +530,10 @@ pub(super) fn process_note_changes(root: &Path, store: &Store, quiet: bool) {
         }
         Err(e) => {
             warn!(error = %e, "Notes reindex error");
+            state.last_error = Some(cqs::watch_status::WatchErrorInfo {
+                at_unix_secs: cqs::unix_secs_i64().unwrap_or(0),
+                message: format!("notes reindex failed: {e}"),
+            });
         }
     }
 }

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -177,6 +177,15 @@ struct WatchState {
     /// Owned String rather than borrow because `WatchState` outlives the
     /// per-tick `WatchSnapshotInput`.
     active_slot: String,
+    /// Latency of the most recent completed reindex pass (#1715).
+    /// Recorded in `process_file_changes` where `reindex_files` returns
+    /// Ok; published every snapshot tick for `cqs status --watch`.
+    last_reindex: Option<cqs::watch_status::ReindexLatency>,
+    /// Most recent reindex/notes-reindex error (#1715). Sticky across
+    /// subsequent successes — the timestamp disambiguates. Recorded
+    /// where the watch loop currently logs `Reindex error` /
+    /// `Notes reindex error`.
+    last_error: Option<cqs::watch_status::WatchErrorInfo>,
 }
 
 /// How often the watch loop re-stats `index.db` for the `last_synced_at`
@@ -195,11 +204,18 @@ const LAST_SYNCED_REFRESH: std::time::Duration = std::time::Duration::from_secs(
 /// Takes `&mut WatchState` so the `last_synced_at` stat call can be
 /// throttled via the cache. Without throttling this fires every ~100 ms
 /// tick, paying a syscall (ms-scale on WSL 9P) for whole-second wire data.
+///
+/// `in_flight_clients` is the daemon accept loop's shared counter
+/// (always 0 without `--serve`); `reconcile_signal` is sampled with a
+/// plain `load` (never `swap` — draining it is the loop body's job).
+/// Both feed the `cqs status --watch` ops block (#1715).
 fn publish_watch_snapshot(
     handle: &cqs::watch_status::SharedWatchSnapshot,
     fresh_notifier: &cqs::watch_status::SharedFreshNotifier,
     state: &mut WatchState,
     index_path: &std::path::Path,
+    in_flight_clients: &std::sync::atomic::AtomicUsize,
+    reconcile_signal: &std::sync::atomic::AtomicBool,
 ) {
     // Only re-stat when the cache has expired. Snapshots fire every ~100 ms
     // but `last_synced_at` is whole-second resolution — re-stating every
@@ -234,7 +250,13 @@ fn publish_watch_snapshot(
             state.last_event,
             last_synced_at,
         )
-        .with_active_slot(&state.active_slot),
+        .with_active_slot(&state.active_slot)
+        .with_ops(
+            in_flight_clients.load(std::sync::atomic::Ordering::Acquire),
+            reconcile_signal.load(std::sync::atomic::Ordering::Acquire),
+            state.last_reindex.as_ref(),
+            state.last_error.as_ref(),
+        ),
     );
     // Poison-recovery: another writer panicking shouldn't silently stop
     // freshness publishing. Recover and overwrite.
@@ -706,6 +728,13 @@ pub fn cmd_watch(
     let fresh_notifier_handle: cqs::watch_status::SharedFreshNotifier =
         cqs::watch_status::shared_fresh_notifier();
 
+    // Shared in-flight client counter (#1715). The daemon accept loop
+    // increments/decrements it per connection; the watch loop samples it
+    // every snapshot publish so `cqs status --watch` can report it.
+    // Stays at 0 when `--serve` is off (no daemon thread to count).
+    let in_flight_clients_handle: Arc<std::sync::atomic::AtomicUsize> =
+        Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
     // Pick up a leftover `.cqs/.dirty` marker from a previous session where
     // a git hook fired without a daemon listening.
     // The hook touches this file as a fallback; on next daemon start we
@@ -762,6 +791,10 @@ pub fn cmd_watch(
             // handler shares the same notifier the watch loop publishes
             // through.
             let daemon_fresh_notifier = Arc::clone(&fresh_notifier_handle);
+            // Clone the in-flight counter so the accept loop's
+            // per-connection bookkeeping is visible to the watch loop's
+            // snapshot publisher (#1715).
+            let daemon_in_flight = Arc::clone(&in_flight_clients_handle);
             // Stays non-blocking: the accept loop below polls so it can
             // notice SHUTDOWN_REQUESTED on SIGTERM.
             let thread = daemon::spawn_daemon_thread(
@@ -772,6 +805,7 @@ pub fn cmd_watch(
                 daemon_watch_snapshot,
                 daemon_reconcile_signal,
                 daemon_fresh_notifier,
+                daemon_in_flight,
             );
             Some(thread)
         } else {
@@ -1162,6 +1196,8 @@ pub fn cmd_watch(
             .unwrap_or_else(std::time::Instant::now),
         cached_last_synced_at: None,
         active_slot: active_slot.name.clone(),
+        last_reindex: None,
+        last_error: None,
     };
 
     let mut cycles_since_clear: u32 = 0;
@@ -1329,7 +1365,7 @@ pub fn cmd_watch(
 
                     if state.pending_notes {
                         state.pending_notes = false;
-                        process_note_changes(&root, &store, cli.quiet);
+                        process_note_changes(&root, &store, cli.quiet, &mut state);
                     }
 
                     // Clear stale OnceLock caches (call_graph_cache,
@@ -1597,6 +1633,8 @@ pub fn cmd_watch(
             &fresh_notifier_handle,
             &mut state,
             &index_path,
+            &in_flight_clients_handle,
+            &reconcile_signal_handle,
         );
 
         if check_interrupted() {

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -177,11 +177,11 @@ struct WatchState {
     /// Owned String rather than borrow because `WatchState` outlives the
     /// per-tick `WatchSnapshotInput`.
     active_slot: String,
-    /// Latency of the most recent completed reindex pass (#1715).
+    /// Latency of the most recent completed reindex pass.
     /// Recorded in `process_file_changes` where `reindex_files` returns
     /// Ok; published every snapshot tick for `cqs status --watch`.
     last_reindex: Option<cqs::watch_status::ReindexLatency>,
-    /// Most recent reindex/notes-reindex error (#1715). Sticky across
+    /// Most recent reindex/notes-reindex error. Sticky across
     /// subsequent successes — the timestamp disambiguates. Recorded
     /// where the watch loop currently logs `Reindex error` /
     /// `Notes reindex error`.
@@ -208,7 +208,7 @@ const LAST_SYNCED_REFRESH: std::time::Duration = std::time::Duration::from_secs(
 /// `in_flight_clients` is the daemon accept loop's shared counter
 /// (always 0 without `--serve`); `reconcile_signal` is sampled with a
 /// plain `load` (never `swap` — draining it is the loop body's job).
-/// Both feed the `cqs status --watch` ops block (#1715).
+/// Both feed the `cqs status --watch` ops block.
 fn publish_watch_snapshot(
     handle: &cqs::watch_status::SharedWatchSnapshot,
     fresh_notifier: &cqs::watch_status::SharedFreshNotifier,
@@ -728,7 +728,7 @@ pub fn cmd_watch(
     let fresh_notifier_handle: cqs::watch_status::SharedFreshNotifier =
         cqs::watch_status::shared_fresh_notifier();
 
-    // Shared in-flight client counter (#1715). The daemon accept loop
+    // Shared in-flight client counter. The daemon accept loop
     // increments/decrements it per connection; the watch loop samples it
     // every snapshot publish so `cqs status --watch` can report it.
     // Stays at 0 when `--serve` is off (no daemon thread to count).
@@ -793,7 +793,7 @@ pub fn cmd_watch(
             let daemon_fresh_notifier = Arc::clone(&fresh_notifier_handle);
             // Clone the in-flight counter so the accept loop's
             // per-connection bookkeeping is visible to the watch loop's
-            // snapshot publisher (#1715).
+            // snapshot publisher.
             let daemon_in_flight = Arc::clone(&in_flight_clients_handle);
             // Stays non-blocking: the accept loop below polls so it can
             // notice SHUTDOWN_REQUESTED on SIGTERM.

--- a/src/cli/watch/reconcile.rs
+++ b/src/cli/watch/reconcile.rs
@@ -583,7 +583,6 @@ mod tests {
     fn reconcile_detects_bulk_modify_burst() {
         use cqs::parser::{Chunk, ChunkType, Language};
         use cqs::watch_status::{FreshnessState, WatchSnapshot, WatchSnapshotInput};
-        use std::marker::PhantomData;
 
         // 47 files mirrors the acceptance test scenario. Big enough to
         // model a real branch switch; small enough to run in milliseconds
@@ -658,18 +657,16 @@ mod tests {
         // surfaced as `modified_files`. This is what
         // `cqs status --watch-fresh` and `cqs eval --require-fresh`
         // observe through the `Arc<RwLock<WatchSnapshot>>`.
-        let snap = WatchSnapshot::compute(WatchSnapshotInput {
-            pending_files_count: pending.len(),
-            pending_notes: false,
-            rebuild_in_flight: false,
-            delta_saturated: false,
-            incremental_count: 0,
-            dropped_this_cycle: 0,
-            last_event: std::time::Instant::now(),
-            last_synced_at: None,
-            active_slot: None,
-            _marker: PhantomData,
-        });
+        let snap = WatchSnapshot::compute(WatchSnapshotInput::new(
+            pending.len(),
+            false,
+            false,
+            false,
+            0,
+            0,
+            std::time::Instant::now(),
+            None,
+        ));
         assert_eq!(snap.state, FreshnessState::Stale);
         assert_eq!(snap.modified_files, N as u64);
         assert!(!snap.is_fresh());

--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -99,6 +99,8 @@ fn test_watch_state() -> WatchState {
             .unwrap_or_else(std::time::Instant::now),
         cached_last_synced_at: None,
         active_slot: cqs::slot::DEFAULT_SLOT.to_string(),
+        last_reindex: None,
+        last_error: None,
     }
 }
 
@@ -2026,4 +2028,96 @@ fn run_daemon_periodic_gc_prunes_missing_files() {
         1,
         "periodic GC must prune missing-file chunks (ghost.rs)"
     );
+}
+
+// ===== #1715: publish_watch_snapshot ops block =====
+
+/// The watch loop's snapshot publisher must carry the operational stats
+/// (#1715): the daemon's in-flight counter, the undrained reconcile
+/// signal, and the state-recorded last-reindex/last-error pair — plus a
+/// per-slot vec populated with the active slot. This drives the real
+/// producer (`publish_watch_snapshot`) end-to-end into the shared
+/// `Arc<RwLock<WatchSnapshot>>` the daemon's `dispatch_status` reads.
+#[test]
+fn publish_watch_snapshot_carries_ops_block() {
+    let tmp = tempfile::tempdir().unwrap();
+    let handle = cqs::watch_status::shared_unknown();
+    let notifier = cqs::watch_status::shared_fresh_notifier();
+    let in_flight = std::sync::atomic::AtomicUsize::new(2);
+    let reconcile = std::sync::atomic::AtomicBool::new(true);
+
+    let mut state = test_watch_state();
+    state.last_reindex = Some(cqs::watch_status::ReindexLatency {
+        at_unix_secs: 1_750_000_100,
+        duration_ms: 1234,
+        files: 3,
+    });
+    state.last_error = Some(cqs::watch_status::WatchErrorInfo {
+        at_unix_secs: 1_749_999_000,
+        message: "reindex failed: synthetic".to_string(),
+    });
+
+    publish_watch_snapshot(
+        &handle,
+        &notifier,
+        &mut state,
+        &tmp.path().join("missing-index.db"),
+        &in_flight,
+        &reconcile,
+    );
+
+    let snap = handle.read().unwrap().clone();
+    let ops = snap.ops.as_ref().expect("publish must populate ops");
+    assert_eq!(ops.in_flight_clients, 2);
+    assert!(ops.reconcile_pending, "undrained signal must surface");
+    assert_eq!(
+        ops.last_reindex.as_ref().map(|l| (l.duration_ms, l.files)),
+        Some((1234, 3))
+    );
+    assert_eq!(
+        ops.last_error.as_ref().map(|e| e.message.as_str()),
+        Some("reindex failed: synthetic")
+    );
+    // Per-slot vec: exactly the active slot, named, with matching state.
+    assert_eq!(ops.slots.len(), 1);
+    assert_eq!(ops.slots[0].name, cqs::slot::DEFAULT_SLOT);
+    assert_eq!(ops.slots[0].state, snap.state);
+    assert_eq!(
+        ops.slots[0].last_reindex.as_ref().map(|l| l.duration_ms),
+        Some(1234)
+    );
+    // Sampling must not drain the reconcile signal — the loop body owns
+    // the swap-to-false.
+    assert!(reconcile.load(std::sync::atomic::Ordering::Acquire));
+}
+
+/// Without a daemon (`--serve` off) the in-flight counter stays 0 and the
+/// reconcile signal false — the ops block reports real zeros, not `None`,
+/// so `cqs status --watch` against a non-serve watch session still
+/// renders a complete block.
+#[test]
+fn publish_watch_snapshot_ops_zeros_without_daemon() {
+    let tmp = tempfile::tempdir().unwrap();
+    let handle = cqs::watch_status::shared_unknown();
+    let notifier = cqs::watch_status::shared_fresh_notifier();
+    let in_flight = std::sync::atomic::AtomicUsize::new(0);
+    let reconcile = std::sync::atomic::AtomicBool::new(false);
+
+    let mut state = test_watch_state();
+    publish_watch_snapshot(
+        &handle,
+        &notifier,
+        &mut state,
+        &tmp.path().join("missing-index.db"),
+        &in_flight,
+        &reconcile,
+    );
+
+    let snap = handle.read().unwrap().clone();
+    let ops = snap.ops.expect("ops present even without --serve");
+    assert_eq!(ops.in_flight_clients, 0);
+    assert!(!ops.reconcile_pending);
+    assert!(ops.last_reindex.is_none());
+    assert!(ops.last_error.is_none());
+    assert_eq!(ops.slots.len(), 1, "active slot entry is always present");
 }

--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -2030,10 +2030,10 @@ fn run_daemon_periodic_gc_prunes_missing_files() {
     );
 }
 
-// ===== #1715: publish_watch_snapshot ops block =====
+// ===== publish_watch_snapshot ops block =====
 
 /// The watch loop's snapshot publisher must carry the operational stats
-/// (#1715): the daemon's in-flight counter, the undrained reconcile
+/// the daemon's in-flight counter, the undrained reconcile
 /// signal, and the state-recorded last-reindex/last-error pair — plus a
 /// per-slot vec populated with the active slot. This drives the real
 /// producer (`publish_watch_snapshot`) end-to-end into the shared

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -1185,6 +1185,7 @@ mod tests {
             last_synced_at: Some(1_734_120_000),
             snapshot_at: Some(1_734_120_500),
             active_slot: None,
+            ops: None,
         };
         let inner_envelope = serde_json::json!({
             "data": serde_json::to_value(&snap).unwrap(),
@@ -1462,6 +1463,7 @@ mod tests {
             last_synced_at: Some(1_734_120_000),
             snapshot_at: Some(1_734_120_500),
             active_slot: None,
+            ops: None,
         };
         let inner_envelope = serde_json::json!({
             "data": serde_json::to_value(&snap).unwrap(),
@@ -1599,6 +1601,7 @@ mod tests {
                 last_synced_at: Some(1_734_120_000),
                 snapshot_at: Some(1_734_120_500),
                 active_slot: None,
+                ops: None,
             };
             let inner = serde_json::json!({
                 "data": serde_json::to_value(&snap).unwrap(),

--- a/src/watch_status.rs
+++ b/src/watch_status.rs
@@ -68,6 +68,88 @@ impl std::fmt::Display for FreshnessState {
     }
 }
 
+/// Latency record for the most recent completed reindex pass.
+///
+/// Recorded by the watch loop where `reindex_files` returns (success
+/// path) — previously this only existed as a tracing span duration, so
+/// answering "how long did the last save-triggered reindex take?" meant
+/// journalctl grepping. `cqs status --watch` surfaces it instead.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReindexLatency {
+    /// Unix timestamp (UTC seconds) when the pass completed.
+    pub at_unix_secs: i64,
+    /// Wall-clock duration of the pass in milliseconds.
+    pub duration_ms: u64,
+    /// Number of files drained in the pass.
+    pub files: u64,
+}
+
+/// Most recent watch-loop error (reindex or notes-reindex failure).
+///
+/// Sticky: survives subsequent successful cycles so an operator polling
+/// `cqs status --watch` still sees an error that fired between polls.
+/// The timestamp disambiguates "current" from "historical" — compare
+/// against `last_reindex.at_unix_secs`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WatchErrorInfo {
+    /// Unix timestamp (UTC seconds) when the error was observed.
+    pub at_unix_secs: i64,
+    /// Rendered error message, verbatim from the failing operation.
+    pub message: String,
+}
+
+/// Per-slot freshness entry inside [`WatchOpsStats::slots`].
+///
+/// Today the daemon serves exactly one slot, so the vec carries one
+/// entry (the active slot). Slot-parallel work (#1717) extends the vec
+/// with additional entries rather than reshaping the output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SlotWatchStatus {
+    /// Slot name (`default` unless `--slot`/`CQS_SLOT` selected another).
+    pub name: String,
+    /// Freshness state of this slot's index.
+    pub state: FreshnessState,
+    /// Unix timestamp (UTC seconds) of the last completed reindex for
+    /// this slot (`index.db` mtime). `None` when missing/unreadable.
+    pub last_synced_at: Option<i64>,
+    /// Latency of the most recent reindex pass against this slot.
+    pub last_reindex: Option<ReindexLatency>,
+}
+
+/// Operational stats block for `cqs status --watch` (#1715).
+///
+/// Composes with the freshness fields already on [`WatchSnapshot`]:
+/// queue depth is `modified_files`, dropped events is
+/// `dropped_this_cycle`. This block carries the daemon-operational rest
+/// — what previously required journalctl grepping.
+///
+/// Embedding-cache hit rate is intentionally absent: the watch loop's
+/// cache consultation happens inside `reindex_files` with no live
+/// counters, and `cqs cache stats` already answers the offline
+/// question. A live hit-rate counter is deferred until something needs
+/// it badly enough to justify the plumbing.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WatchOpsStats {
+    /// Daemon socket clients currently being served (the accept loop's
+    /// in-flight counter, sampled at snapshot-publish time). Always 0
+    /// when the watch session runs without `--serve`.
+    pub in_flight_clients: u64,
+    /// Whether an out-of-band reconcile request is pending (the
+    /// [`SharedReconcileSignal`] is set but the watch loop hasn't
+    /// drained it yet). Together with [`WatchSnapshot::state`] this is
+    /// the reconcile-visible state.
+    pub reconcile_pending: bool,
+    /// Latency of the most recent completed reindex pass. `None` until
+    /// the first save-triggered reindex of the session.
+    pub last_reindex: Option<ReindexLatency>,
+    /// Most recent reindex/notes-reindex error. Sticky across
+    /// subsequent successes — see [`WatchErrorInfo`].
+    pub last_error: Option<WatchErrorInfo>,
+    /// Per-slot freshness. Exactly one entry today (the active slot);
+    /// #1717 extends this vec.
+    pub slots: Vec<SlotWatchStatus>,
+}
+
 /// Snapshot of the watch loop's view of "how fresh is the index?". The
 /// wire shape returned by `cqs status --watch-fresh --json`.
 ///
@@ -132,6 +214,12 @@ pub struct WatchSnapshot {
     /// daemon hasn't published a snapshot yet (still ramping up).
     #[serde(default)]
     pub active_slot: Option<String>,
+    /// Operational stats for `cqs status --watch` (#1715). `None` when
+    /// the snapshot came from a daemon that predates the field (older
+    /// binary) or from the initial `unknown()` placeholder — lets the
+    /// CLI distinguish "stats unavailable" from real zeros.
+    #[serde(default)]
+    pub ops: Option<WatchOpsStats>,
 }
 
 impl WatchSnapshot {
@@ -152,6 +240,7 @@ impl WatchSnapshot {
             last_synced_at: None,
             snapshot_at: now_unix_secs(),
             active_slot: None,
+            ops: None,
         }
     }
 
@@ -328,17 +417,21 @@ pub struct WatchSnapshotInput<'a> {
     /// currently serving. The lifetime ties this borrow to the watch
     /// loop's owned `WatchState` field.
     pub active_slot: Option<&'a str>,
-    /// Phantom keeps the API future-proof if we add borrow-only fields
-    /// (e.g. last-error string). No-op today.
-    pub _marker: std::marker::PhantomData<&'a ()>,
+    /// Daemon socket clients currently in flight (sampled by the watch
+    /// loop from the shared accept-loop counter). 0 without `--serve`.
+    pub in_flight_clients: usize,
+    /// Whether the shared reconcile signal is set but undrained.
+    pub reconcile_pending: bool,
+    /// Borrowed latency record of the last completed reindex pass.
+    pub last_reindex: Option<&'a ReindexLatency>,
+    /// Borrowed most-recent watch-loop error (sticky).
+    pub last_error: Option<&'a WatchErrorInfo>,
 }
 
 impl<'a> WatchSnapshotInput<'a> {
-    /// Named-field constructor so callers don't have to set
-    /// `_marker: PhantomData` themselves. The lifetime parameter remains in
-    /// case future additions take borrowed fields (e.g.
-    /// `last_error: Option<&str>`); today the marker is the only reason `'a`
-    /// exists.
+    /// Named-field constructor for the counter core; ops-block fields
+    /// default to zero/`None` and are layered on via the builder
+    /// methods below so existing call sites stay readable.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         pending_files_count: usize,
@@ -360,7 +453,10 @@ impl<'a> WatchSnapshotInput<'a> {
             last_event,
             last_synced_at,
             active_slot: None,
-            _marker: std::marker::PhantomData,
+            in_flight_clients: 0,
+            reconcile_pending: false,
+            last_reindex: None,
+            last_error: None,
         }
     }
 
@@ -371,6 +467,24 @@ impl<'a> WatchSnapshotInput<'a> {
     /// don't care about slot tracking compiling unchanged.
     pub fn with_active_slot(mut self, slot: &'a str) -> Self {
         self.active_slot = Some(slot);
+        self
+    }
+
+    /// Builder-style chain for the `cqs status --watch` ops block
+    /// (#1715). The watch loop samples the daemon's in-flight counter
+    /// and the reconcile signal each tick, and borrows the
+    /// last-reindex/last-error records off its owned `WatchState`.
+    pub fn with_ops(
+        mut self,
+        in_flight_clients: usize,
+        reconcile_pending: bool,
+        last_reindex: Option<&'a ReindexLatency>,
+        last_error: Option<&'a WatchErrorInfo>,
+    ) -> Self {
+        self.in_flight_clients = in_flight_clients;
+        self.reconcile_pending = reconcile_pending;
+        self.last_reindex = last_reindex;
+        self.last_error = last_error;
         self
     }
 }
@@ -429,6 +543,29 @@ impl WatchSnapshot {
         // without rebuilding the state-machine inputs.
         tracing::trace!(state = %state, "compute decision");
 
+        // Ops block (#1715). The per-slot vec carries exactly the
+        // active slot today; #1717 extends it. Built whenever the slot
+        // name is known — `active_slot == None` only happens for
+        // synthetic inputs that never reach the daemon wire.
+        let slots = input
+            .active_slot
+            .map(|name| {
+                vec![SlotWatchStatus {
+                    name: name.to_string(),
+                    state,
+                    last_synced_at: input.last_synced_at,
+                    last_reindex: input.last_reindex.cloned(),
+                }]
+            })
+            .unwrap_or_default();
+        let ops = Some(WatchOpsStats {
+            in_flight_clients: u64::try_from(input.in_flight_clients).unwrap_or(u64::MAX),
+            reconcile_pending: input.reconcile_pending,
+            last_reindex: input.last_reindex.cloned(),
+            last_error: input.last_error.cloned(),
+            slots,
+        });
+
         Self {
             state,
             // Saturating `usize → u64`. The cast is total on every supported
@@ -445,6 +582,7 @@ impl WatchSnapshot {
             last_synced_at: input.last_synced_at,
             snapshot_at: now_unix_secs(),
             active_slot: input.active_slot.map(|s| s.to_string()),
+            ops,
         }
     }
 }
@@ -475,18 +613,16 @@ mod tests {
         pending_notes: bool,
         dropped_this_cycle: usize,
     ) -> WatchSnapshotInput<'static> {
-        WatchSnapshotInput {
+        WatchSnapshotInput::new(
             pending_files_count,
             pending_notes,
             rebuild_in_flight,
-            delta_saturated: false,
-            incremental_count: 0,
+            false,
+            0,
             dropped_this_cycle,
-            last_event: std::time::Instant::now(),
-            last_synced_at: None,
-            active_slot: None,
-            _marker: std::marker::PhantomData,
-        }
+            std::time::Instant::now(),
+            None,
+        )
     }
 
     #[test]
@@ -553,18 +689,16 @@ mod tests {
     /// rebuild.
     #[test]
     fn delta_saturated_marks_stale_when_no_other_work() {
-        let snap = WatchSnapshot::compute(WatchSnapshotInput {
-            pending_files_count: 0,
-            pending_notes: false,
-            rebuild_in_flight: false,
-            delta_saturated: true,
-            incremental_count: 0,
-            dropped_this_cycle: 0,
-            last_event: std::time::Instant::now(),
-            last_synced_at: None,
-            active_slot: None,
-            _marker: std::marker::PhantomData,
-        });
+        let snap = WatchSnapshot::compute(WatchSnapshotInput::new(
+            0,
+            false,
+            false,
+            true,
+            0,
+            0,
+            std::time::Instant::now(),
+            None,
+        ));
         assert_eq!(snap.state, FreshnessState::Stale);
         assert!(snap.delta_saturated);
     }
@@ -574,18 +708,16 @@ mod tests {
     /// drains and `rebuild_in_flight` flips to false.
     #[test]
     fn rebuild_in_flight_dominates_over_delta_saturated() {
-        let snap = WatchSnapshot::compute(WatchSnapshotInput {
-            pending_files_count: 0,
-            pending_notes: false,
-            rebuild_in_flight: true,
-            delta_saturated: true,
-            incremental_count: 0,
-            dropped_this_cycle: 0,
-            last_event: std::time::Instant::now(),
-            last_synced_at: None,
-            active_slot: None,
-            _marker: std::marker::PhantomData,
-        });
+        let snap = WatchSnapshot::compute(WatchSnapshotInput::new(
+            0,
+            false,
+            true,
+            true,
+            0,
+            0,
+            std::time::Instant::now(),
+            None,
+        ));
         assert_eq!(snap.state, FreshnessState::Rebuilding);
     }
 
@@ -639,5 +771,114 @@ mod tests {
         let was_pending = s.swap(false, Ordering::AcqRel);
         assert!(was_pending);
         assert!(!s.load(Ordering::Acquire));
+    }
+
+    // ===== #1715: cqs status --watch ops block =====
+
+    fn full_ops_input<'a>(
+        last_reindex: &'a ReindexLatency,
+        last_error: &'a WatchErrorInfo,
+    ) -> WatchSnapshotInput<'a> {
+        WatchSnapshotInput::new(
+            2,
+            false,
+            false,
+            false,
+            7,
+            0,
+            std::time::Instant::now(),
+            Some(1_750_000_000),
+        )
+        .with_active_slot("default")
+        .with_ops(3, true, Some(last_reindex), Some(last_error))
+    }
+
+    #[test]
+    fn compute_populates_ops_block() {
+        let lr = ReindexLatency {
+            at_unix_secs: 1_750_000_100,
+            duration_ms: 842,
+            files: 4,
+        };
+        let le = WatchErrorInfo {
+            at_unix_secs: 1_749_999_000,
+            message: "Reindex error: disk full".to_string(),
+        };
+        let snap = WatchSnapshot::compute(full_ops_input(&lr, &le));
+
+        let ops = snap.ops.as_ref().expect("compute must populate ops");
+        assert_eq!(ops.in_flight_clients, 3);
+        assert!(ops.reconcile_pending);
+        assert_eq!(ops.last_reindex.as_ref(), Some(&lr));
+        assert_eq!(ops.last_error.as_ref(), Some(&le));
+        // Per-slot vec carries exactly the active slot, populated now —
+        // not a dead placeholder for #1717.
+        assert_eq!(ops.slots.len(), 1);
+        let slot = &ops.slots[0];
+        assert_eq!(slot.name, "default");
+        assert_eq!(slot.state, snap.state);
+        assert_eq!(slot.last_synced_at, Some(1_750_000_000));
+        assert_eq!(slot.last_reindex.as_ref(), Some(&lr));
+    }
+
+    #[test]
+    fn compute_default_ops_is_zeroed_not_missing() {
+        // Without `.with_ops(...)` the block still serializes (real
+        // zeros), distinguishing "daemon publishes, nothing happened
+        // yet" from "daemon predates the field" (`ops: None`).
+        let snap = WatchSnapshot::compute(input(0, false, false, 0).with_active_slot("default"));
+        let ops = snap.ops.expect("ops present on every computed snapshot");
+        assert_eq!(ops.in_flight_clients, 0);
+        assert!(!ops.reconcile_pending);
+        assert!(ops.last_reindex.is_none());
+        assert!(ops.last_error.is_none());
+        assert_eq!(ops.slots.len(), 1);
+    }
+
+    /// CLI==daemon parity pin: both surfaces serialize/deserialize the
+    /// same `WatchSnapshot` type (daemon's `dispatch_status` writes it,
+    /// CLI's `daemon_status` reads it). A lossless serde round-trip of
+    /// a fully-populated snapshot guarantees the two adapters can't
+    /// disagree on the wire shape.
+    #[test]
+    fn ops_snapshot_serde_round_trip_is_lossless() {
+        let lr = ReindexLatency {
+            at_unix_secs: 1_750_000_100,
+            duration_ms: 842,
+            files: 4,
+        };
+        let le = WatchErrorInfo {
+            at_unix_secs: 1_749_999_000,
+            message: "Reindex error: disk full".to_string(),
+        };
+        let snap = WatchSnapshot::compute(full_ops_input(&lr, &le));
+        let wire = serde_json::to_value(&snap).expect("serialize");
+        let back: WatchSnapshot = serde_json::from_value(wire.clone()).expect("deserialize");
+        let wire_again = serde_json::to_value(&back).expect("re-serialize");
+        assert_eq!(wire, wire_again, "round trip must be lossless");
+        assert_eq!(back.ops, snap.ops);
+    }
+
+    /// Back-compat: a snapshot from a daemon that predates #1715 (no
+    /// `ops` key on the wire) must deserialize with `ops == None`, not
+    /// error — `cqs status --watch` against an old daemon degrades to
+    /// "stats unavailable" instead of a BadResponse.
+    #[test]
+    fn snapshot_without_ops_key_deserializes_to_none() {
+        let old_wire = serde_json::json!({
+            "state": "fresh",
+            "modified_files": 0,
+            "pending_notes": false,
+            "rebuild_in_flight": false,
+            "delta_saturated": false,
+            "incremental_count": 0,
+            "dropped_this_cycle": 0,
+            "last_event_unix_secs": 1_750_000_000_i64,
+            "last_synced_at": null,
+            "snapshot_at": 1_750_000_001_i64,
+        });
+        let snap: WatchSnapshot = serde_json::from_value(old_wire).expect("old wire shape");
+        assert!(snap.ops.is_none());
+        assert!(snap.active_slot.is_none());
     }
 }

--- a/src/watch_status.rs
+++ b/src/watch_status.rs
@@ -101,7 +101,7 @@ pub struct WatchErrorInfo {
 /// Per-slot freshness entry inside [`WatchOpsStats::slots`].
 ///
 /// Today the daemon serves exactly one slot, so the vec carries one
-/// entry (the active slot). Slot-parallel work (#1717) extends the vec
+/// entry (the active slot). Slot-parallel work extends the vec
 /// with additional entries rather than reshaping the output.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SlotWatchStatus {
@@ -116,7 +116,7 @@ pub struct SlotWatchStatus {
     pub last_reindex: Option<ReindexLatency>,
 }
 
-/// Operational stats block for `cqs status --watch` (#1715).
+/// Operational stats block for `cqs status --watch`.
 ///
 /// Composes with the freshness fields already on [`WatchSnapshot`]:
 /// queue depth is `modified_files`, dropped events is
@@ -146,7 +146,7 @@ pub struct WatchOpsStats {
     /// subsequent successes — see [`WatchErrorInfo`].
     pub last_error: Option<WatchErrorInfo>,
     /// Per-slot freshness. Exactly one entry today (the active slot);
-    /// #1717 extends this vec.
+    /// The slot-parallel reindex work extends this vec.
     pub slots: Vec<SlotWatchStatus>,
 }
 
@@ -214,7 +214,7 @@ pub struct WatchSnapshot {
     /// daemon hasn't published a snapshot yet (still ramping up).
     #[serde(default)]
     pub active_slot: Option<String>,
-    /// Operational stats for `cqs status --watch` (#1715). `None` when
+    /// Operational stats for `cqs status --watch`. `None` when
     /// the snapshot came from a daemon that predates the field (older
     /// binary) or from the initial `unknown()` placeholder — lets the
     /// CLI distinguish "stats unavailable" from real zeros.
@@ -471,7 +471,7 @@ impl<'a> WatchSnapshotInput<'a> {
     }
 
     /// Builder-style chain for the `cqs status --watch` ops block
-    /// (#1715). The watch loop samples the daemon's in-flight counter
+    ///. The watch loop samples the daemon's in-flight counter
     /// and the reconcile signal each tick, and borrows the
     /// last-reindex/last-error records off its owned `WatchState`.
     pub fn with_ops(
@@ -543,8 +543,8 @@ impl WatchSnapshot {
         // without rebuilding the state-machine inputs.
         tracing::trace!(state = %state, "compute decision");
 
-        // Ops block (#1715). The per-slot vec carries exactly the
-        // active slot today; #1717 extends it. Built whenever the slot
+        // Ops block. The per-slot vec carries exactly the
+        // active slot today; the slot-parallel reindex work extends it. Built whenever the slot
         // name is known — `active_slot == None` only happens for
         // synthetic inputs that never reach the daemon wire.
         let slots = input
@@ -773,7 +773,7 @@ mod tests {
         assert!(!s.load(Ordering::Acquire));
     }
 
-    // ===== #1715: cqs status --watch ops block =====
+    // ===== cqs status --watch ops block =====
 
     fn full_ops_input<'a>(
         last_reindex: &'a ReindexLatency,
@@ -812,7 +812,7 @@ mod tests {
         assert_eq!(ops.last_reindex.as_ref(), Some(&lr));
         assert_eq!(ops.last_error.as_ref(), Some(&le));
         // Per-slot vec carries exactly the active slot, populated now —
-        // not a dead placeholder for #1717.
+        // not a dead placeholder.
         assert_eq!(ops.slots.len(), 1);
         let slot = &ops.slots[0];
         assert_eq!(slot.name, "default");
@@ -859,7 +859,7 @@ mod tests {
         assert_eq!(back.ops, snap.ops);
     }
 
-    /// Back-compat: a snapshot from a daemon that predates #1715 (no
+    /// Back-compat: a snapshot from a daemon that predates the ops block (no
     /// `ops` key on the wire) must deserialize with `ops == None`, not
     /// error — `cqs status --watch` against an old daemon degrades to
     /// "stats unavailable" instead of a BadResponse.

--- a/tests/daemon_forward_test.rs
+++ b/tests/daemon_forward_test.rs
@@ -606,7 +606,7 @@ fn test_ping_no_daemon_exits_one() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// #1715: `cqs status --watch` against a mock daemon.
+// `cqs status --watch` against a mock daemon.
 //
 // Same fixture pattern as PingMockDaemon: bind a UnixListener at the exact
 // socket path the CLI computes, reply with a canned WatchSnapshot whose
@@ -616,7 +616,7 @@ fn test_ping_no_daemon_exits_one() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Mock daemon replying to the `status` command with a canned
-/// `WatchSnapshot` carrying a fully-populated `ops` block (#1715).
+/// `WatchSnapshot` carrying a fully-populated `ops` block.
 struct StatusMockDaemon {
     conn_count: Arc<AtomicUsize>,
     last_request: Arc<std::sync::Mutex<String>>,
@@ -743,7 +743,7 @@ impl Drop for StatusMockDaemon {
 fn test_status_watch_json_round_trip_returns_all_ops_fields() {
     // `cqs status --watch --json` must connect to the daemon, issue the
     // `status` command, and emit the full WatchSnapshot — including every
-    // ops-block field (#1715 gate: "returning all fields").
+    // ops-block field (gate: every field returned).
     let (dir, sock_path) = setup_project();
     let mock = StatusMockDaemon::new(sock_path.clone());
 

--- a/tests/daemon_forward_test.rs
+++ b/tests/daemon_forward_test.rs
@@ -604,3 +604,287 @@ fn test_ping_no_daemon_exits_one() {
         "expected friendly 'no daemon running' message; stderr=<{stderr}>"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1715: `cqs status --watch` against a mock daemon.
+//
+// Same fixture pattern as PingMockDaemon: bind a UnixListener at the exact
+// socket path the CLI computes, reply with a canned WatchSnapshot whose
+// `ops` block is fully populated, and assert the CLI surfaces every field.
+// The daemon-absent path must return the structured error (exit 1 +
+// error envelope), matching `--watch-fresh`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Mock daemon replying to the `status` command with a canned
+/// `WatchSnapshot` carrying a fully-populated `ops` block (#1715).
+struct StatusMockDaemon {
+    conn_count: Arc<AtomicUsize>,
+    last_request: Arc<std::sync::Mutex<String>>,
+    stop: Arc<AtomicBool>,
+    sock_path: PathBuf,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl StatusMockDaemon {
+    fn new(sock_path: PathBuf) -> Self {
+        let listener = UnixListener::bind(&sock_path)
+            .unwrap_or_else(|e| panic!("bind {} failed: {e}", sock_path.display()));
+        listener
+            .set_nonblocking(true)
+            .expect("set_nonblocking on mock listener");
+
+        let conn_count = Arc::new(AtomicUsize::new(0));
+        let last_request = Arc::new(std::sync::Mutex::new(String::new()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let c2 = Arc::clone(&conn_count);
+        let r2 = Arc::clone(&last_request);
+        let s2 = Arc::clone(&stop);
+
+        // Canned WatchSnapshot. Field values pinned by the assertions in
+        // the round-trip tests below — this is the daemon-side wire shape
+        // `dispatch_status` produces by serializing the shared snapshot.
+        let payload = serde_json::json!({
+            "state": "fresh",
+            "modified_files": 4,
+            "pending_notes": false,
+            "rebuild_in_flight": false,
+            "delta_saturated": false,
+            "incremental_count": 12,
+            "dropped_this_cycle": 1,
+            "last_event_unix_secs": 1_750_000_000_i64,
+            "last_synced_at": 1_750_000_050_i64,
+            "snapshot_at": 1_750_000_060_i64,
+            "active_slot": "default",
+            "ops": {
+                "in_flight_clients": 3,
+                "reconcile_pending": true,
+                "last_reindex": {
+                    "at_unix_secs": 1_750_000_050_i64,
+                    "duration_ms": 842,
+                    "files": 4,
+                },
+                "last_error": {
+                    "at_unix_secs": 1_749_999_000_i64,
+                    "message": "reindex failed: synthetic disk full",
+                },
+                "slots": [{
+                    "name": "default",
+                    "state": "fresh",
+                    "last_synced_at": 1_750_000_050_i64,
+                    "last_reindex": {
+                        "at_unix_secs": 1_750_000_050_i64,
+                        "duration_ms": 842,
+                        "files": 4,
+                    },
+                }],
+            },
+        })
+        .to_string();
+        // String-payload transport form, same as PingMockDaemon.
+        let envelope = format!(
+            r#"{{"status":"ok","output":{}}}"#,
+            serde_json::to_string(&payload).unwrap()
+        );
+
+        let handle = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(30);
+            while !s2.load(Ordering::SeqCst) && Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _addr)) => {
+                        c2.fetch_add(1, Ordering::SeqCst);
+                        let mut buf = String::new();
+                        let _ = BufReader::new(&stream).read_line(&mut buf);
+                        if let Ok(mut g) = r2.lock() {
+                            *g = buf.clone();
+                        }
+                        let _ = writeln!(stream, "{envelope}");
+                        let _ = stream.flush();
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Self {
+            conn_count,
+            last_request,
+            stop,
+            sock_path,
+            handle: Some(handle),
+        }
+    }
+
+    fn conn_count(&self) -> usize {
+        self.conn_count.load(Ordering::SeqCst)
+    }
+
+    fn last_request(&self) -> String {
+        self.last_request
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default()
+    }
+}
+
+impl Drop for StatusMockDaemon {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+        let _ = std::fs::remove_file(&self.sock_path);
+    }
+}
+
+#[test]
+fn test_status_watch_json_round_trip_returns_all_ops_fields() {
+    // `cqs status --watch --json` must connect to the daemon, issue the
+    // `status` command, and emit the full WatchSnapshot — including every
+    // ops-block field (#1715 gate: "returning all fields").
+    let (dir, sock_path) = setup_project();
+    let mock = StatusMockDaemon::new(sock_path.clone());
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+    let mut cmd = cqs();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["status", "--watch", "--json"]);
+
+    let output = cmd.output().expect("cqs status spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "`cqs status --watch --json` failed; stdout=<{stdout}> stderr=<{stderr}>"
+    );
+    assert_eq!(
+        mock.conn_count(),
+        1,
+        "expected exactly one daemon connection"
+    );
+    let req = mock.last_request();
+    assert!(
+        req.contains("\"command\":\"status\""),
+        "expected status command in request, got: {req}"
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("CLI did not print valid JSON; stdout=<{stdout}> err={e}"));
+    let data = &parsed["data"];
+    // Freshness core (queue depth = modified_files, dropped events).
+    assert_eq!(data["state"], "fresh");
+    assert_eq!(data["modified_files"], 4);
+    assert_eq!(data["dropped_this_cycle"], 1);
+    // Ops block: every field from the issue's list.
+    let ops = &data["ops"];
+    assert_eq!(ops["in_flight_clients"], 3);
+    assert_eq!(ops["reconcile_pending"], true);
+    assert_eq!(ops["last_reindex"]["at_unix_secs"], 1_750_000_050_i64);
+    assert_eq!(ops["last_reindex"]["duration_ms"], 842);
+    assert_eq!(ops["last_reindex"]["files"], 4);
+    assert_eq!(
+        ops["last_error"]["message"],
+        "reindex failed: synthetic disk full"
+    );
+    assert_eq!(ops["last_error"]["at_unix_secs"], 1_749_999_000_i64);
+    // Per-slot vec carries the active slot.
+    assert_eq!(ops["slots"][0]["name"], "default");
+    assert_eq!(ops["slots"][0]["state"], "fresh");
+    assert_eq!(ops["slots"][0]["last_synced_at"], 1_750_000_050_i64);
+}
+
+#[test]
+fn test_status_watch_text_renders_ops_block() {
+    // Text mode appends the grep-friendly ops lines after the freshness
+    // summary. Pins the structurally load-bearing keys, not the full
+    // formatting.
+    let (dir, sock_path) = setup_project();
+    let _mock = StatusMockDaemon::new(sock_path.clone());
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+    let mut cmd = cqs();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["status", "--watch"]);
+
+    let output = cmd.output().expect("cqs status spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "`cqs status --watch` failed; stdout=<{stdout}> stderr=<{stderr}>"
+    );
+    assert!(
+        stdout.contains("state: fresh"),
+        "freshness line first: {stdout}"
+    );
+    assert!(
+        stdout.contains("clients_in_flight=3"),
+        "in-flight clients missing: {stdout}"
+    );
+    assert!(
+        stdout.contains("reconcile_pending=true"),
+        "reconcile state missing: {stdout}"
+    );
+    assert!(
+        stdout.contains("last_reindex_ms=842"),
+        "reindex latency missing: {stdout}"
+    );
+    assert!(
+        stdout.contains("last_error=reindex failed: synthetic disk full"),
+        "last error missing: {stdout}"
+    );
+    assert!(
+        stdout.contains("slot=default state=fresh"),
+        "per-slot line missing: {stdout}"
+    );
+}
+
+#[test]
+fn test_status_watch_no_daemon_exits_one_with_structured_error() {
+    // Daemon-absent path: `--watch` must match `--watch-fresh` — exit 1,
+    // friendly stderr in text mode, error envelope in JSON mode.
+    let (dir, _sock_path) = setup_project();
+    // No mock bound — socket file is absent.
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+
+    // Text mode.
+    let mut cmd = cqs();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["status", "--watch"]);
+    let output = cmd.output().expect("cqs status spawn");
+    assert_eq!(output.status.code(), Some(1), "no daemon must exit 1");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cqs:") || stderr.contains("daemon"),
+        "stderr should describe the no-daemon condition, got: {stderr}"
+    );
+
+    // JSON mode: structured error envelope.
+    let mut cmd = cqs();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .env("CQS_OUTPUT_FORMAT", "v1")
+        .current_dir(&canonical_dir)
+        .args(["status", "--watch", "--json"]);
+    let output = cmd.output().expect("cqs status spawn");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"error\"") || stdout.contains("\"code\""),
+        "stdout should contain a JSON error envelope, got: {stdout}"
+    );
+}


### PR DESCRIPTION
Closes #1715.

## What

`cqs status --watch` — the daemon's operational stats over the existing socket, replacing journalctl grepping.

New `WatchOpsStats` block on `WatchSnapshot` (the status core's typed Output, shared verbatim by CLI and daemon adapters — `dispatch_status` needed zero edits):

- `in_flight_clients` — daemon accept-loop counter, hoisted from thread-local to a shared `Arc<AtomicUsize>`
- `reconcile_pending` — non-draining read of the existing reconcile signal
- `last_reindex { at_unix_secs, duration_ms, files }` — recorded where `reindex_files` returns Ok
- `last_error { at_unix_secs, message }` — sticky, recorded at the reindex/notes Err arms
- `slots: Vec<SlotWatchStatus>` — active slot's entry populated now (name, state, last sync, last reindex); #1717 (slot-parallel reindex) extends the vec rather than reshaping the output
- queue depth + dropped-events were already on the snapshot; `--watch` surfaces them

Publisher is the existing ~100ms snapshot writer (`publish_watch_snapshot`), composing the block from the shared atomics. `--wait` composes with `--watch` (wait for fresh, then print stats); the pinned "`--wait` without a report flag exits 1" behavior is unchanged. Old-wire compatibility: `ops: None` round-trips.

Embedding-cache hit rate deliberately not built — no live counters exist on the reindex path and `cqs cache stats` answers the offline question; gap documented in the struct docstring.

## Verification

- lib watch_status + daemon_translate: 52 passed (serde parity pin, old-wire back-compat)
- bin watch/status/slot: 95 passed (two tests drive the real producer)
- tests/daemon_forward_test.rs: 12 passed incl. mock-daemon JSON round-trip asserting every ops field, text rendering, and daemon-absent structured error (exit 1 + envelope)
- build warning-free, clippy -D warnings clean, fmt applied; README/CONTRIBUTING status-flag mentions updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
