### PR TITLE
feat(index): DistanceMetric threaded through HNSW/CAGRA, persisted in header (closes #1351)

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,6 +817,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_FTS_NORMALIZE_MAX` | `16384` | Max bytes of `normalize_for_fts` output per chunk. Truncation is emitted at warn level; bump if FTS recall on long chunks (large generated tables, monolithic functions) is degraded. |
 | `CQS_GATHER_MAX_NODES` | `200` | Max BFS nodes in `gather` context assembly |
 | `CQS_HNSW_EF_CONSTRUCTION` | `200` | HNSW construction-time search width |
+| `CQS_DISTANCE_METRIC` | `cosine` | Distance metric at index build (`cosine`, `dot`). Stored in the index; a conflicting value at load is a typed error |
 | `CQS_HNSW_EF_SEARCH` | `100` | HNSW query-time search width |
 | `CQS_HNSW_BATCH_SIZE` | `10000` | Vectors per HNSW build batch |
 | `CQS_HNSW_M` | `24` | HNSW connections per node |

--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -193,7 +193,7 @@ fn cagra_itopk_max_default(n_vectors: usize) -> usize {
 /// graph degree. Both map to the corresponding cuVS `IndexParams` setters.
 /// Returns `IndexParams` with those setters applied (and traces the choice).
 ///
-/// `metric` threads the cqs [`DistanceMetric`] into cuVS (#1351):
+/// `metric` threads the cqs [`DistanceMetric`] into cuVS:
 /// - `Cosine` keeps cuVS's default `L2Expanded`, which is rank-equivalent to
 ///   cosine on the unit-norm embeddings cqs produces (`d² = 2 − 2·cos`) and
 ///   is exactly what every pre-#1351 build used.
@@ -244,7 +244,7 @@ fn cagra_build_params(metric: DistanceMetric) -> Result<cuvs::cagra::IndexParams
 pub struct CagraIndex {
     /// Embedding dimensionality (runtime, from model config)
     dim: usize,
-    /// Distance metric the index was built with (#1351). Drives the
+    /// Distance metric the index was built with. Drives the
     /// distance → similarity conversion in `search_impl` and is stamped
     /// into the persisted sidecar.
     metric: DistanceMetric,
@@ -593,7 +593,7 @@ impl CagraIndex {
             return Vec::new();
         }
 
-        // Convert results: distance → similarity, per build metric (#1351).
+        // Convert results: distance → similarity, per build metric.
         // - Cosine: the index is built with cuVS's default L2Expanded
         //   (squared L2). For unit-norm vectors d = 2 - 2*cos_sim, so
         //   cos_sim = 1 - d/2.
@@ -960,7 +960,7 @@ struct CagraMeta {
     id_map: Vec<String>,
     /// Blake3 checksum over the `.cagra` binary blob as a hex string.
     blake3: String,
-    /// [`DistanceMetric::as_str`] value the index was built with (#1351).
+    /// [`DistanceMetric::as_str`] value the index was built with.
     /// Legacy sidecars (pre-#1351) omit the field and default to cosine —
     /// which is what every legacy build used.
     #[serde(default = "default_metric_string")]
@@ -1283,7 +1283,7 @@ impl CagraIndex {
             )));
         }
 
-        // Distance metric (#1351): the stored value wins; an explicitly set,
+        // Distance metric: the stored value wins; an explicitly set,
         // conflicting CQS_DISTANCE_METRIC marks the blob stale so the caller
         // rebuilds with the requested metric (CAGRA is a derived index — the
         // rebuild path is the remedy, unlike HNSW where the same conflict is
@@ -1695,7 +1695,7 @@ impl<Mode: crate::store::ClearHnswDirty> crate::index::IndexBackend<Mode> for Ca
             }
         }
 
-        // Resolve the metric for a fresh build (#1351): explicit env wins;
+        // Resolve the metric for a fresh build: explicit env wins;
         // otherwise follow the slot's stored HNSW metric so the two backends
         // can't drift apart; cosine when neither exists. An invalid env
         // value falls through to HNSW, whose load/build path surfaces the
@@ -2338,7 +2338,7 @@ mod tests {
         let _: bool = enabled;
     }
 
-    // ===== distance metric (#1351) =====
+    // ===== distance metric =====
 
     /// DotProduct build + search on the GPU backend. The self-match score
     /// pins the InnerProduct distance → similarity conversion in

--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -56,7 +56,7 @@ use thiserror::Error;
 #[cfg(feature = "cuda-index")]
 use crate::embedder::Embedding;
 #[cfg(feature = "cuda-index")]
-use crate::index::{IndexResult, VectorIndex};
+use crate::index::{DistanceMetric, IndexResult, VectorIndex};
 
 /// On-disk magic bytes for the CAGRA sidecar. Changes force a rebuild.
 #[cfg(feature = "cuda-index")]
@@ -84,9 +84,10 @@ const CAGRA_META_VERSION: u32 = 1;
 ///
 /// The fix is to pre-fill `distances_host` with this sentinel before the
 /// kernel launch and drop any slot whose distance still holds it after
-/// copy-back. CAGRA writes squared-L2 distances, so every real hit is a
-/// finite non-negative value strictly less than `+∞` — the sentinel is
-/// therefore unambiguous.
+/// copy-back. CAGRA writes finite distances for every real hit — squared-L2
+/// values are non-negative, InnerProduct (raw dot product, #1351) values may
+/// be negative but are still finite — so the `+∞` sentinel is unambiguous
+/// for both metrics.
 ///
 /// # Why `f32::INFINITY` specifically?
 ///
@@ -191,8 +192,14 @@ fn cagra_itopk_max_default(n_vectors: usize) -> usize {
 /// `CQS_CAGRA_INTERMEDIATE_GRAPH_DEGREE` (default 128) is the pruned-input
 /// graph degree. Both map to the corresponding cuVS `IndexParams` setters.
 /// Returns `IndexParams` with those setters applied (and traces the choice).
+///
+/// `metric` threads the cqs [`DistanceMetric`] into cuVS (#1351):
+/// - `Cosine` keeps cuVS's default `L2Expanded`, which is rank-equivalent to
+///   cosine on the unit-norm embeddings cqs produces (`d² = 2 − 2·cos`) and
+///   is exactly what every pre-#1351 build used.
+/// - `DotProduct` sets `InnerProduct`.
 #[cfg(feature = "cuda-index")]
-fn cagra_build_params() -> Result<cuvs::cagra::IndexParams, CagraError> {
+fn cagra_build_params(metric: DistanceMetric) -> Result<cuvs::cagra::IndexParams, CagraError> {
     // Use parse_env_usize_clamped so a literal "0" or empty string falls back
     // to the default. cuvs treats 0 as "library default" on some versions,
     // errors on others — silent-misconfig surface.
@@ -204,9 +211,24 @@ fn cagra_build_params() -> Result<cuvs::cagra::IndexParams, CagraError> {
         .map_err(|e| CagraError::Cuvs(e.to_string()))?
         .set_graph_degree(graph_degree)
         .set_intermediate_graph_degree(intermediate_graph_degree);
+    match metric {
+        // Default L2Expanded — deliberately untouched (see doc comment).
+        DistanceMetric::Cosine => {}
+        DistanceMetric::DotProduct => {
+            // The cuvs 26.6 Rust wrapper exposes no `set_metric` builder, but
+            // `IndexParams.0` is the pub raw `cuvsCagraIndexParams_t`.
+            // SAFETY: identical access pattern to the wrapper's own setters
+            // (e.g. `set_graph_degree`) — the pointer is valid for the
+            // lifetime of `params` and we hold exclusive access here.
+            unsafe {
+                (*params.0).metric = cuvs::distance_type::DistanceType::InnerProduct;
+            }
+        }
+    }
     tracing::info!(
         graph_degree,
         intermediate_graph_degree,
+        metric = %metric,
         "CAGRA build params"
     );
     Ok(params)
@@ -222,6 +244,10 @@ fn cagra_build_params() -> Result<cuvs::cagra::IndexParams, CagraError> {
 pub struct CagraIndex {
     /// Embedding dimensionality (runtime, from model config)
     dim: usize,
+    /// Distance metric the index was built with (#1351). Drives the
+    /// distance → similarity conversion in `search_impl` and is stamped
+    /// into the persisted sidecar.
+    metric: DistanceMetric,
     /// cuVS resources + index, protected by Mutex (CUDA contexts require serialized access)
     gpu: Mutex<GpuState>,
     /// Mapping from internal index to chunk ID.
@@ -338,20 +364,32 @@ impl CagraIndex {
         true
     }
 
-    /// Build a CAGRA index from embeddings
+    /// Build a CAGRA index from embeddings. The distance metric is resolved
+    /// from `CQS_DISTANCE_METRIC` (default cosine); use
+    /// [`Self::build_with_metric`] to pin it explicitly.
     pub fn build(embeddings: Vec<(String, Embedding)>, dim: usize) -> Result<Self, CagraError> {
-        let _span = tracing::debug_span!("cagra_build").entered();
+        let metric = DistanceMetric::resolve().map_err(CagraError::Build)?;
+        Self::build_with_metric(embeddings, dim, metric)
+    }
+
+    /// [`Self::build`] with an explicit [`DistanceMetric`].
+    pub fn build_with_metric(
+        embeddings: Vec<(String, Embedding)>,
+        dim: usize,
+        metric: DistanceMetric,
+    ) -> Result<Self, CagraError> {
+        let _span = tracing::debug_span!("cagra_build", metric = %metric).entered();
         let (id_map, flat_data, n_vectors) = crate::hnsw::prepare_index_data(embeddings, dim)
             .map_err(|e| CagraError::Build(e.to_string()))?;
 
-        tracing::info!(n_vectors, "Building CAGRA index");
+        tracing::info!(n_vectors, metric = %metric, "Building CAGRA index");
 
         let resources = cuvs::Resources::new().map_err(|e| CagraError::Cuvs(e.to_string()))?;
 
         let dataset = Array2::from_shape_vec((n_vectors, dim), flat_data)
             .map_err(|e| CagraError::Cuvs(format!("Failed to create array: {}", e)))?;
 
-        let build_params = cagra_build_params()?;
+        let build_params = cagra_build_params(metric)?;
 
         let index = cuvs::cagra::Index::build(&resources, &build_params, &dataset)
             .map_err(|e| CagraError::Cuvs(e.to_string()))?;
@@ -360,10 +398,16 @@ impl CagraIndex {
 
         Ok(Self {
             dim,
+            metric,
             gpu: Mutex::new(GpuState { resources, index }),
             id_map,
             poisoned: AtomicBool::new(false),
         })
+    }
+
+    /// The distance metric this index was built (or loaded) with.
+    pub fn metric(&self) -> DistanceMetric {
+        self.metric
     }
 
     /// Number of vectors in the index
@@ -549,8 +593,15 @@ impl CagraIndex {
             return Vec::new();
         }
 
-        // Convert results: CAGRA uses squared L2 distance. For unit-norm vectors:
-        // d = 2 - 2*cos_sim, so cos_sim = 1 - d/2.
+        // Convert results: distance → similarity, per build metric (#1351).
+        // - Cosine: the index is built with cuVS's default L2Expanded
+        //   (squared L2). For unit-norm vectors d = 2 - 2*cos_sim, so
+        //   cos_sim = 1 - d/2.
+        // - DotProduct: cuVS InnerProduct returns the RAW inner product in
+        //   the distances buffer, best-first (descending) — verified
+        //   empirically on cuVS 26.06 by `test_dot_product_build_and_search`
+        //   (self-match slot holds ≈ +1.0 on unit-norm vectors). The
+        //   similarity is the value itself.
         let mut results = Vec::with_capacity(k);
         let neighbor_row = neighbors_host.row(0);
         let distance_row = distances_host.row(0);
@@ -569,7 +620,10 @@ impl CagraIndex {
                 continue;
             }
             if idx < self.id_map.len() {
-                let score = 1.0 - dist / 2.0;
+                let score = match self.metric {
+                    DistanceMetric::Cosine => 1.0 - dist / 2.0,
+                    DistanceMetric::DotProduct => dist,
+                };
                 results.push(IndexResult {
                     id: self.id_map[idx].to_string(),
                     score,
@@ -748,7 +802,20 @@ impl CagraIndex {
         store: &crate::Store<Mode>,
         dim: usize,
     ) -> Result<Self, CagraError> {
-        let _span = tracing::debug_span!("cagra_build_from_store").entered();
+        let metric = DistanceMetric::resolve().map_err(CagraError::Build)?;
+        Self::build_from_store_with_metric(store, dim, metric)
+    }
+
+    /// [`Self::build_from_store`] with an explicit [`DistanceMetric`].
+    /// `CagraBackend::try_open` uses this to keep a rebuilt CAGRA index
+    /// consistent with the slot's stored HNSW metric instead of silently
+    /// re-resolving to the default.
+    pub fn build_from_store_with_metric<Mode>(
+        store: &crate::Store<Mode>,
+        dim: usize,
+        metric: DistanceMetric,
+    ) -> Result<Self, CagraError> {
+        let _span = tracing::debug_span!("cagra_build_from_store", metric = %metric).entered();
         let chunk_count = store
             .chunk_count()
             .map_err(|e| CagraError::Cuvs(format!("Failed to count chunks: {}", e)))?
@@ -819,7 +886,7 @@ impl CagraIndex {
             );
         }
 
-        Self::build_from_flat(id_map, flat_data, dim)
+        Self::build_from_flat(id_map, flat_data, dim, metric)
     }
 
     /// Build CAGRA index from pre-collected flat data (also used by tests)
@@ -827,20 +894,21 @@ impl CagraIndex {
         id_map: Vec<String>,
         flat_data: Vec<f32>,
         dim: usize,
+        metric: DistanceMetric,
     ) -> Result<Self, CagraError> {
         let n_vectors = id_map.len();
         if n_vectors == 0 {
             return Err(CagraError::Cuvs("Cannot build empty index".into()));
         }
 
-        tracing::info!(n_vectors, "Building CAGRA index");
+        tracing::info!(n_vectors, metric = %metric, "Building CAGRA index");
 
         let resources = cuvs::Resources::new().map_err(|e| CagraError::Cuvs(e.to_string()))?;
 
         let dataset = Array2::from_shape_vec((n_vectors, dim), flat_data)
             .map_err(|e| CagraError::Cuvs(format!("Failed to create array: {}", e)))?;
 
-        let build_params = cagra_build_params()?;
+        let build_params = cagra_build_params(metric)?;
 
         let index = cuvs::cagra::Index::build(&resources, &build_params, &dataset)
             .map_err(|e| CagraError::Cuvs(e.to_string()))?;
@@ -855,6 +923,7 @@ impl CagraIndex {
 
         Ok(Self {
             dim,
+            metric,
             gpu: Mutex::new(GpuState { resources, index }),
             id_map: id_map_boxed,
             poisoned: AtomicBool::new(false),
@@ -891,6 +960,17 @@ struct CagraMeta {
     id_map: Vec<String>,
     /// Blake3 checksum over the `.cagra` binary blob as a hex string.
     blake3: String,
+    /// [`DistanceMetric::as_str`] value the index was built with (#1351).
+    /// Legacy sidecars (pre-#1351) omit the field and default to cosine —
+    /// which is what every legacy build used.
+    #[serde(default = "default_metric_string")]
+    metric: String,
+}
+
+/// serde default for [`CagraMeta::metric`]: legacy sidecars are cosine.
+#[cfg(feature = "cuda-index")]
+fn default_metric_string() -> String {
+    DistanceMetric::Cosine.as_str().to_string()
 }
 
 /// Whether CAGRA persistence is enabled (via `CQS_CAGRA_PERSIST`).
@@ -985,6 +1065,7 @@ impl CagraIndex {
             // (the on-disk schema is Vec<String> for `serde_json` decode).
             id_map: self.id_map.iter().map(|s| s.to_string()).collect(),
             blake3: blob_hash,
+            metric: self.metric.as_str().to_string(),
         };
 
         // Meta-write failure after the blob is in place leaves a blob
@@ -1069,6 +1150,7 @@ impl CagraIndex {
             // (the on-disk schema is Vec<String> for `serde_json` decode).
             id_map: self.id_map.iter().map(|s| s.to_string()).collect(),
             blake3: blob_hash,
+            metric: self.metric.as_str().to_string(),
         };
 
         if let Err(e) = write_meta_atomic(&meta_path, &meta) {
@@ -1201,6 +1283,23 @@ impl CagraIndex {
             )));
         }
 
+        // Distance metric (#1351): the stored value wins; an explicitly set,
+        // conflicting CQS_DISTANCE_METRIC marks the blob stale so the caller
+        // rebuilds with the requested metric (CAGRA is a derived index — the
+        // rebuild path is the remedy, unlike HNSW where the same conflict is
+        // a hard typed error).
+        let stored_metric: DistanceMetric = meta
+            .metric
+            .parse()
+            .map_err(|e| CagraError::BadMeta(format!("sidecar has invalid metric: {e}")))?;
+        if let Some(requested) = DistanceMetric::from_env().map_err(CagraError::Build)? {
+            if requested != stored_metric {
+                return Err(CagraError::Stale {
+                    reason: format!("distance metric '{stored_metric}' != requested '{requested}'"),
+                });
+            }
+        }
+
         // Verify the `.cagra` blob matches the hash in the sidecar before
         // handing it to cuVS — cheap insurance against silent disk rot
         // and against someone (or us) overwriting the blob without
@@ -1225,11 +1324,13 @@ impl CagraIndex {
             n_vectors = meta.chunk_count,
             dim = meta.dim,
             splade_generation = meta.splade_generation,
+            metric = %stored_metric,
             "CAGRA index loaded from disk"
         );
 
         Ok(Self {
             dim: meta.dim,
+            metric: stored_metric,
             gpu: Mutex::new(GpuState { resources, index }),
             // Convert Vec<String> → Vec<Box<str>> at the load boundary.
             // Zero-copy via `String::into_boxed_str()`.
@@ -1594,7 +1695,29 @@ impl<Mode: crate::store::ClearHnswDirty> crate::index::IndexBackend<Mode> for Ca
             }
         }
 
-        match CagraIndex::build_from_store(ctx.store, ctx.store.dim()) {
+        // Resolve the metric for a fresh build (#1351): explicit env wins;
+        // otherwise follow the slot's stored HNSW metric so the two backends
+        // can't drift apart; cosine when neither exists. An invalid env
+        // value falls through to HNSW, whose load/build path surfaces the
+        // typed error.
+        let metric = match DistanceMetric::from_env() {
+            Ok(Some(m)) => m,
+            Ok(None) => {
+                crate::hnsw::HnswIndex::stored_metric(ctx.cqs_dir, "index").unwrap_or_else(|e| {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to read stored HNSW metric for CAGRA build — using cosine"
+                    );
+                    DistanceMetric::Cosine
+                })
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Invalid CQS_DISTANCE_METRIC — falling through to HNSW");
+                return Ok(None);
+            }
+        };
+
+        match CagraIndex::build_from_store_with_metric(ctx.store, ctx.store.dim(), metric) {
             Ok(idx) => {
                 tracing::info!(
                     backend = "cagra",
@@ -2213,5 +2336,166 @@ mod tests {
         // valid pass — the important thing is the helper returned without
         // panicking and the type is correct.
         let _: bool = enabled;
+    }
+
+    // ===== distance metric (#1351) =====
+
+    /// DotProduct build + search on the GPU backend. The self-match score
+    /// pins the InnerProduct distance → similarity conversion in
+    /// `search_impl` (cuVS returns the raw inner product, best-first; on
+    /// unit-norm vectors the self-match similarity must come back ≈ 1).
+    #[test]
+    fn test_dot_product_build_and_search() {
+        let _guard = GPU_LOCK.lock().unwrap();
+        if !require_gpu() {
+            return;
+        }
+        let embeddings: Vec<(String, Embedding)> = (0..10)
+            .map(|i| (format!("chunk_{}", i), make_embedding(i)))
+            .collect();
+        let index =
+            CagraIndex::build_with_metric(embeddings, EMBEDDING_DIM, DistanceMetric::DotProduct)
+                .expect("DotProduct CAGRA build should succeed");
+        assert_eq!(index.metric(), DistanceMetric::DotProduct);
+
+        let results = index.search(&make_embedding(3), 5);
+        assert!(!results.is_empty(), "search returned no results");
+        let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+        assert!(
+            ids.contains(&"chunk_3"),
+            "chunk_3 should be in top-5, got {ids:?}"
+        );
+        let self_score = results
+            .iter()
+            .find(|r| r.id == "chunk_3")
+            .map(|r| r.score)
+            .unwrap();
+        assert!(
+            self_score > 0.9,
+            "unit-norm self-match under InnerProduct should score ≈ 1, got {self_score} \
+             (full results: {results:?}) — if this fails the distance→similarity \
+             conversion for InnerProduct is wrong"
+        );
+        // Descending score order must hold for the negated-IP conversion too.
+        for window in results.windows(2) {
+            assert!(
+                window[0].score >= window[1].score,
+                "results not sorted: {} < {}",
+                window[0].score,
+                window[1].score
+            );
+        }
+    }
+
+    /// Sidecar metric roundtrip: a DotProduct index persists its metric and
+    /// loads back as DotProduct with env unset (the stored value wins).
+    /// Holds `HNSW_ENV_LOCK` so the hnsw mismatch test's transient
+    /// `CQS_DISTANCE_METRIC=cosine` can't mark this dot sidecar stale
+    /// mid-load. Lock order is GPU_LOCK → HNSW_ENV_LOCK in every CAGRA test
+    /// that takes both.
+    #[test]
+    fn test_metric_sidecar_roundtrip_dot() {
+        let _guard = GPU_LOCK.lock().unwrap();
+        if !require_gpu() {
+            return;
+        }
+        let _env = crate::hnsw::HNSW_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.cagra");
+
+        let embeddings: Vec<(String, Embedding)> = (0..8)
+            .map(|i| (format!("chunk_{}", i), make_embedding(i)))
+            .collect();
+        let original =
+            CagraIndex::build_with_metric(embeddings, EMBEDDING_DIM, DistanceMetric::DotProduct)
+                .unwrap();
+        original.save(&path).expect("save should succeed");
+        drop(original);
+
+        let loaded = CagraIndex::load(&path, EMBEDDING_DIM, 8)
+            .expect("dot-product sidecar should load with env unset (stored wins)");
+        assert_eq!(loaded.metric(), DistanceMetric::DotProduct);
+
+        let results = loaded.search(&make_embedding(2), 3);
+        let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+        assert!(
+            ids.contains(&"chunk_2"),
+            "chunk_2 should be in top-3 after reload, got {ids:?}"
+        );
+    }
+
+    /// A legacy (pre-#1351) sidecar has no `metric` field; serde's default
+    /// must decode it as cosine — that is what every legacy build used.
+    #[test]
+    fn test_legacy_sidecar_without_metric_loads_as_cosine() {
+        let _guard = GPU_LOCK.lock().unwrap();
+        if !require_gpu() {
+            return;
+        }
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.cagra");
+
+        let original = build_test_index(8);
+        original.save(&path).expect("save should succeed");
+        drop(original);
+
+        // Strip the `metric` field from the sidecar to simulate a legacy
+        // file. The blob checksum only covers the `.cagra` blob, so the
+        // sidecar rewrite doesn't invalidate it.
+        let meta_path = super::meta_path_for(&path);
+        let mut meta: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&meta_path).unwrap()).unwrap();
+        assert!(
+            meta.as_object_mut().unwrap().remove("metric").is_some(),
+            "current save must stamp the metric field"
+        );
+        std::fs::write(&meta_path, serde_json::to_string(&meta).unwrap()).unwrap();
+
+        let loaded = CagraIndex::load(&path, EMBEDDING_DIM, 8)
+            .expect("legacy sidecar without metric field must load");
+        assert_eq!(loaded.metric(), DistanceMetric::Cosine);
+    }
+
+    /// Loading a DotProduct sidecar with `CQS_DISTANCE_METRIC` explicitly
+    /// set to cosine marks the blob stale (the rebuild path is CAGRA's
+    /// mismatch remedy, unlike HNSW's hard typed error). Test discipline:
+    /// the env var is only ever set to "cosine" so concurrent cosine loads
+    /// are unaffected; held under `HNSW_ENV_LOCK` (taken after GPU_LOCK).
+    #[test]
+    fn test_metric_mismatch_marks_stale() {
+        let _guard = GPU_LOCK.lock().unwrap();
+        if !require_gpu() {
+            return;
+        }
+        let _env = crate::hnsw::HNSW_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.cagra");
+
+        let embeddings: Vec<(String, Embedding)> = (0..8)
+            .map(|i| (format!("chunk_{}", i), make_embedding(i)))
+            .collect();
+        let original =
+            CagraIndex::build_with_metric(embeddings, EMBEDDING_DIM, DistanceMetric::DotProduct)
+                .unwrap();
+        original.save(&path).expect("save should succeed");
+        drop(original);
+
+        let _var = crate::hnsw::EnvVarGuard::set("CQS_DISTANCE_METRIC", "cosine");
+        match CagraIndex::load(&path, EMBEDDING_DIM, 8) {
+            Err(CagraError::Stale { reason }) => {
+                assert!(
+                    reason.contains("metric"),
+                    "stale reason should mention the metric: {reason}"
+                );
+            }
+            Err(other) => panic!("expected Stale, got: {other:?}"),
+            Ok(_) => panic!("conflicting metric must not load"),
+        }
     }
 }

--- a/src/hnsw/build.rs
+++ b/src/hnsw/build.rs
@@ -1,12 +1,9 @@
 //! HNSW index construction
 
-use hnsw_rs::anndists::dist::distances::DistCosine;
-use hnsw_rs::api::AnnT;
-use hnsw_rs::hnsw::Hnsw;
-
 use crate::embedder::Embedding;
+use crate::index::DistanceMetric;
 
-use super::{HnswError, HnswIndex, HnswInner, MAX_LAYER};
+use super::{HnswError, HnswGraph, HnswIndex, HnswInner, MAX_LAYER};
 
 impl HnswIndex {
     /// Build a new HNSW index from embeddings (single-pass).
@@ -35,22 +32,37 @@ impl HnswIndex {
     /// # Arguments
     /// * `embeddings` - Vector of (chunk_id, embedding) pairs
     /// * `dim` - Expected embedding dimension
+    ///
+    /// The distance metric is resolved from `CQS_DISTANCE_METRIC` (default
+    /// cosine) — see [`DistanceMetric::resolve`]. Use
+    /// [`Self::build_with_dim_and_metric`] to pin it explicitly.
     pub fn build_with_dim(
         embeddings: Vec<(String, Embedding)>,
         dim: usize,
     ) -> Result<Self, HnswError> {
-        let _span = tracing::debug_span!("hnsw_build").entered();
+        let metric = DistanceMetric::resolve().map_err(HnswError::Build)?;
+        Self::build_with_dim_and_metric(embeddings, dim, metric)
+    }
+
+    /// [`Self::build_with_dim`] with an explicit [`DistanceMetric`] instead
+    /// of the `CQS_DISTANCE_METRIC` env resolution.
+    pub fn build_with_dim_and_metric(
+        embeddings: Vec<(String, Embedding)>,
+        dim: usize,
+        metric: DistanceMetric,
+    ) -> Result<Self, HnswError> {
+        let _span = tracing::debug_span!("hnsw_build", metric = %metric).entered();
         if dim == 0 {
             return Err(HnswError::Build("Embedding dimension must be > 0".into()));
         }
         if embeddings.is_empty() {
             // Create empty index — fall back to the small-tier default.
-            let hnsw = Hnsw::new(
+            let hnsw = HnswGraph::new(
+                metric,
                 super::max_nb_connection_for(0),
                 1,
                 MAX_LAYER,
                 super::ef_construction_for(0),
-                DistCosine,
             );
             return Ok(Self {
                 inner: HnswInner::Owned(hnsw),
@@ -63,16 +75,16 @@ impl HnswIndex {
 
         let (id_map, data, nb_elem) = super::prepare_index_data(embeddings, dim)?;
 
-        tracing::info!(count = nb_elem, "Building HNSW index");
+        tracing::info!(count = nb_elem, metric = %metric, "Building HNSW index");
 
         // Corpus-size-aware tier defaults. Env overrides still win — see
         // `hnsw_tier_defaults` for the table.
-        let mut hnsw = Hnsw::new(
+        let mut hnsw = HnswGraph::new(
+            metric,
             super::max_nb_connection_for(nb_elem),
             nb_elem,
             MAX_LAYER,
             super::ef_construction_for(nb_elem),
-            DistCosine,
         );
 
         // Test-only path: allocates the full Vec<Vec<f32>> double-buffer here.
@@ -134,24 +146,42 @@ impl HnswIndex {
         I: Iterator<Item = Result<Vec<(String, Embedding)>, E>>,
         E: std::fmt::Display,
     {
-        let _span = tracing::debug_span!("hnsw_build_batched", estimated_total).entered();
+        let metric = DistanceMetric::resolve().map_err(HnswError::Build)?;
+        Self::build_batched_with_dim_and_metric(batches, estimated_total, dim, metric)
+    }
+
+    /// [`Self::build_batched_with_dim`] with an explicit [`DistanceMetric`]
+    /// instead of the `CQS_DISTANCE_METRIC` env resolution.
+    pub fn build_batched_with_dim_and_metric<I, E>(
+        batches: I,
+        estimated_total: usize,
+        dim: usize,
+        metric: DistanceMetric,
+    ) -> Result<Self, HnswError>
+    where
+        I: Iterator<Item = Result<Vec<(String, Embedding)>, E>>,
+        E: std::fmt::Display,
+    {
+        let _span =
+            tracing::debug_span!("hnsw_build_batched", estimated_total, metric = %metric).entered();
         if dim == 0 {
             return Err(HnswError::Build("Embedding dimension must be > 0".into()));
         }
         let capacity = estimated_total.max(1);
         tracing::info!(
+            metric = %metric,
             "Building HNSW index incrementally (estimated {} vectors)",
             capacity
         );
 
         // Tier defaults read from `capacity`, the estimated vector count
         // for this build.
-        let mut hnsw = Hnsw::new(
+        let mut hnsw = HnswGraph::new(
+            metric,
             super::max_nb_connection_for(capacity),
             capacity,
             MAX_LAYER,
             super::ef_construction_for(capacity),
-            DistCosine,
         );
 
         let mut id_map: Vec<Box<str>> = Vec::with_capacity(capacity);
@@ -218,12 +248,12 @@ impl HnswIndex {
         if id_map.is_empty() {
             tracing::info!("HNSW index built (empty)");
             return Ok(Self {
-                inner: HnswInner::Owned(Hnsw::new(
+                inner: HnswInner::Owned(HnswGraph::new(
+                    metric,
                     super::max_nb_connection_for(0),
                     1,
                     MAX_LAYER,
                     super::ef_construction_for(0),
-                    DistCosine,
                 )),
                 id_map: Vec::new(),
                 ef_search: super::ef_search_for(0),

--- a/src/hnsw/mod.rs
+++ b/src/hnsw/mod.rs
@@ -31,15 +31,15 @@ pub use persist::{verify_hnsw_checksums, HNSW_ALL_EXTENSIONS};
 
 use std::cell::UnsafeCell;
 
-use hnsw_rs::anndists::dist::distances::DistCosine;
+use hnsw_rs::anndists::dist::distances::{DistCosine, DistDot};
 use hnsw_rs::api::AnnT;
-use hnsw_rs::hnsw::Hnsw;
+use hnsw_rs::hnsw::{Hnsw, Neighbour};
 use hnsw_rs::hnswio::HnswIo;
 use self_cell::self_cell;
 use thiserror::Error;
 
 use crate::embedder::Embedding;
-use crate::index::{IndexResult, VectorIndex};
+use crate::index::{DistanceMetric, IndexResult, VectorIndex};
 
 // HNSW tuning parameters
 //
@@ -230,13 +230,139 @@ pub enum HnswError {
         expected: String,
         actual: String,
     },
+    /// The index on disk was built with one distance metric, but
+    /// `CQS_DISTANCE_METRIC` explicitly requests a different one. The stored
+    /// metric always wins for an existing index; a conflicting explicit
+    /// request is surfaced as this typed error rather than silently
+    /// reinterpreting distances. Mirrors `Store::stored_model_name()`.
+    #[error(
+        "Distance metric mismatch: index was built with '{stored}' but CQS_DISTANCE_METRIC \
+         requests '{requested}'. Unset CQS_DISTANCE_METRIC to use the stored metric, or run \
+         'cqs index --force' to rebuild with '{requested}'."
+    )]
+    MetricMismatch {
+        stored: DistanceMetric,
+        requested: DistanceMetric,
+    },
 }
 
 // Note: Uses crate::index::IndexResult instead of a separate HnswResult type
 // since they have identical structure (id: String, score: f32)
 
-/// Type alias for the HNSW graph — needed by the `self_cell!` macro.
-type HnswGraph<'a> = Hnsw<'a, f32, DistCosine>;
+/// Metric-dispatching wrapper over the concrete `Hnsw<f32, D>` types.
+///
+/// hnsw_rs bakes the distance into the type parameter (`Hnsw<'a, f32, D>`),
+/// and its API doesn't lend itself to `dyn Distance` erasure, so metric
+/// polymorphism is an enum over the concrete dist types with forwarding
+/// methods (#1351). One variant per [`DistanceMetric`] — both must stay
+/// buildable AND loadable, since the load path instantiates the variant
+/// from the persisted `{basename}.hnsw.meta` header.
+///
+/// Also the dependent type of the `self_cell!` below, which is why it must
+/// carry exactly one lifetime parameter.
+pub(crate) enum HnswGraph<'a> {
+    /// `DistCosine` — the default metric.
+    Cosine(Hnsw<'a, f32, DistCosine>),
+    /// `DistDot` (`dist = 1 − a·b`). NOTE: anndists asserts `a·b <= 1`, so
+    /// this variant expects unit-norm (or sub-unit-dot) embeddings.
+    Dot(Hnsw<'a, f32, DistDot>),
+}
+
+/// Dispatch a method body across every [`HnswGraph`] variant. Local macro
+/// (not a visitor trait): the body is monomorphized per concrete dist type,
+/// which is exactly what hnsw_rs's generic API requires.
+macro_rules! with_graph {
+    ($graph:expr, $h:ident => $body:expr) => {
+        match $graph {
+            HnswGraph::Cosine($h) => $body,
+            HnswGraph::Dot($h) => $body,
+        }
+    };
+}
+
+impl<'a> HnswGraph<'a> {
+    /// Construct an empty graph for `metric` with the given hnsw_rs
+    /// parameters (mirrors `Hnsw::new`'s argument order).
+    pub(crate) fn new(
+        metric: DistanceMetric,
+        max_nb_connection: usize,
+        nb_elem: usize,
+        max_layer: usize,
+        ef_construction: usize,
+    ) -> Self {
+        match metric {
+            DistanceMetric::Cosine => HnswGraph::Cosine(Hnsw::new(
+                max_nb_connection,
+                nb_elem,
+                max_layer,
+                ef_construction,
+                DistCosine,
+            )),
+            DistanceMetric::DotProduct => HnswGraph::Dot(Hnsw::new(
+                max_nb_connection,
+                nb_elem,
+                max_layer,
+                ef_construction,
+                DistDot,
+            )),
+        }
+    }
+
+    /// Load a graph from `io`, instantiating the dist type recorded in the
+    /// persisted meta header. hnsw_rs independently verifies the distance
+    /// name embedded in the `.hnsw.graph` file against the requested type,
+    /// so a meta/graph disagreement fails loudly here.
+    pub(crate) fn load(io: &'a mut HnswIo, metric: DistanceMetric) -> Result<Self, HnswError> {
+        match metric {
+            DistanceMetric::Cosine => io.load_hnsw::<f32, DistCosine>().map(HnswGraph::Cosine),
+            DistanceMetric::DotProduct => io.load_hnsw::<f32, DistDot>().map(HnswGraph::Dot),
+        }
+        .map_err(|e| HnswError::Internal(format!("Failed to load HNSW: {}", e)))
+    }
+
+    /// The metric this graph was built with.
+    pub(crate) fn metric(&self) -> DistanceMetric {
+        match self {
+            HnswGraph::Cosine(_) => DistanceMetric::Cosine,
+            HnswGraph::Dot(_) => DistanceMetric::DotProduct,
+        }
+    }
+
+    /// Number of points in the graph.
+    pub(crate) fn get_nb_point(&self) -> usize {
+        with_graph!(self, h => h.get_nb_point())
+    }
+
+    /// Dump graph + data files via `AnnT::file_dump`.
+    pub(crate) fn file_dump(
+        &self,
+        dir: &std::path::Path,
+        basename: &str,
+    ) -> Result<String, String> {
+        with_graph!(self, h => h.file_dump(dir, basename).map_err(|e| e.to_string()))
+    }
+
+    /// Parallel insert (used by both the build and incremental paths).
+    pub(crate) fn parallel_insert_data(&mut self, data: &[(&Vec<f32>, usize)]) {
+        with_graph!(self, h => h.parallel_insert_data(data))
+    }
+
+    /// Unfiltered k-NN search.
+    pub(crate) fn search_neighbours(&self, query: &[f32], k: usize, ef: usize) -> Vec<Neighbour> {
+        with_graph!(self, h => h.search_neighbours(query, k, ef))
+    }
+
+    /// Traversal-time filtered k-NN search.
+    pub(crate) fn search_filter(
+        &self,
+        query: &[f32],
+        k: usize,
+        ef: usize,
+        filter: Option<&dyn hnsw_rs::filter::FilterT>,
+    ) -> Vec<Neighbour> {
+        with_graph!(self, h => h.search_filter(query, k, ef, filter))
+    }
+}
 
 /// Wrapper to allow `&mut HnswIo` access from self_cell's `&Owner` builder.
 ///
@@ -268,7 +394,8 @@ self_cell!(
 
 // SAFETY: LoadedHnsw is Send+Sync because:
 // - HnswIoCell wraps HnswIo (file paths + data buffers)
-// - Hnsw<f32, DistCosine> contains read-only graph data
+// - HnswGraph wraps Hnsw<f32, D> (read-only graph data; the dist types
+//   DistCosine/DistDot are stateless unit structs)
 // - After construction, only immutable search access occurs
 unsafe impl Send for LoadedHnsw {}
 unsafe impl Sync for LoadedHnsw {}
@@ -316,7 +443,7 @@ pub struct HnswIndex {
 /// Internal HNSW state
 pub(crate) enum HnswInner {
     /// Built in memory - owns its data with 'static lifetime
-    Owned(Hnsw<'static, f32, DistCosine>),
+    Owned(HnswGraph<'static>),
     /// Loaded from disk - self-referential via self_cell
     Loaded(LoadedHnsw),
 }
@@ -325,8 +452,10 @@ impl HnswInner {
     /// Access the underlying HNSW graph regardless of variant.
     ///
     /// Uses a closure because `Hnsw` is invariant over its lifetime parameter,
-    /// so `self_cell` cannot provide a direct reference accessor.
-    pub(crate) fn with_hnsw<R>(&self, f: impl FnOnce(&Hnsw<'_, f32, DistCosine>) -> R) -> R {
+    /// so `self_cell` cannot provide a direct reference accessor. The closure
+    /// receives the metric-dispatching [`HnswGraph`] wrapper; call its
+    /// forwarding methods rather than matching on variants.
+    pub(crate) fn with_hnsw<R>(&self, f: impl FnOnce(&HnswGraph<'_>) -> R) -> R {
         match self {
             HnswInner::Owned(hnsw) => f(hnsw),
             HnswInner::Loaded(loaded) => loaded.with_dependent(|_, hnsw| f(hnsw)),
@@ -338,6 +467,13 @@ impl HnswIndex {
     /// Override the ef_search parameter (from config)
     pub fn set_ef_search(&mut self, ef: usize) {
         self.ef_search = ef;
+    }
+
+    /// The distance metric this index was built (or loaded) with. Single
+    /// source of truth is the graph variant itself — there is no separate
+    /// field that could drift.
+    pub fn metric(&self) -> DistanceMetric {
+        self.inner.with_hnsw(|g| g.metric())
     }
 
     /// Get the number of vectors in the index
@@ -621,6 +757,28 @@ impl<Mode: crate::store::ClearHnswDirty> crate::index::IndexBackend<Mode> for Hn
 /// HNSW test.
 #[cfg(test)]
 pub(crate) static HNSW_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// RAII guard pairing `set_var` with `remove_var` on drop, so an assertion
+/// failure mid-test cannot leak a process-global env var into later tests.
+/// Use together with [`HNSW_ENV_LOCK`] for any var the HNSW build/load
+/// paths read (`CQS_HNSW_*`, `CQS_DISTANCE_METRIC`).
+#[cfg(test)]
+pub(crate) struct EnvVarGuard(&'static str);
+
+#[cfg(test)]
+impl EnvVarGuard {
+    pub(crate) fn set(key: &'static str, value: &str) -> Self {
+        std::env::set_var(key, value);
+        Self(key)
+    }
+}
+
+#[cfg(test)]
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        std::env::remove_var(self.0);
+    }
+}
 
 /// Shared test helper: create a deterministic normalized embedding from a seed.
 /// Uses sin-based values for reproducible but varied vectors.
@@ -965,23 +1123,10 @@ mod env_override_tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
-    /// RAII guard pairing `set_var` with `remove_var` on drop, so an
-    /// assertion failure mid-test cannot leak a CQS_HNSW_* var into later
-    /// tests (these tests assert while holding the env lock).
-    struct EnvVarGuard(&'static str);
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            std::env::set_var(key, value);
-            Self(key)
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            std::env::remove_var(self.0);
-        }
-    }
+    /// RAII guard pairing `set_var` with `remove_var` on drop — shared
+    /// definition in `hnsw/mod.rs` (these tests assert while holding the
+    /// env lock).
+    use super::EnvVarGuard;
 
     #[test]
     fn test_m_default() {
@@ -1044,5 +1189,24 @@ mod env_override_tests {
         let _lock = lock();
         let _var = EnvVarGuard::set("CQS_HNSW_EF_SEARCH", "");
         assert_eq!(super::ef_search(), 100);
+    }
+
+    /// Unset env → cosine default on the env-resolving build wrapper.
+    ///
+    /// NOTE (#1351 test discipline): no test sets `CQS_DISTANCE_METRIC` to a
+    /// non-"cosine" value — concurrent unlocked loads would observe it and
+    /// fail with a metric mismatch. Non-default metrics are exercised
+    /// through the explicit `*_and_metric` builders; the env *parse* logic
+    /// is covered by the pure `parse_env_value` tests in `index.rs`.
+    #[test]
+    fn test_distance_metric_default_build_is_cosine() {
+        let _lock = lock();
+        std::env::remove_var("CQS_DISTANCE_METRIC");
+        let idx = super::HnswIndex::build_with_dim(
+            vec![("a".to_string(), crate::hnsw::make_test_embedding(1))],
+            crate::EMBEDDING_DIM,
+        )
+        .unwrap();
+        assert_eq!(idx.metric(), crate::index::DistanceMetric::Cosine);
     }
 }

--- a/src/hnsw/mod.rs
+++ b/src/hnsw/mod.rs
@@ -254,7 +254,7 @@ pub enum HnswError {
 /// hnsw_rs bakes the distance into the type parameter (`Hnsw<'a, f32, D>`),
 /// and its API doesn't lend itself to `dyn Distance` erasure, so metric
 /// polymorphism is an enum over the concrete dist types with forwarding
-/// methods (#1351). One variant per [`DistanceMetric`] — both must stay
+/// methods. One variant per [`DistanceMetric`] — both must stay
 /// buildable AND loadable, since the load path instantiates the variant
 /// from the persisted `{basename}.hnsw.meta` header.
 ///

--- a/src/hnsw/persist.rs
+++ b/src/hnsw/persist.rs
@@ -109,7 +109,7 @@ pub const HNSW_ALL_EXTENSIONS: &[&str] = &[
     "hnsw.lock",
 ];
 
-/// Magic string for the `{basename}.hnsw.meta` JSON header (#1351). A
+/// Magic string for the `{basename}.hnsw.meta` JSON header. A
 /// mismatch is a typed load error, not a silent default.
 const HNSW_META_MAGIC: &str = "CQSHNSW";
 
@@ -936,7 +936,7 @@ impl HnswIndex {
         tracing::info!(dir = %dir.display(), basename, "Loading HNSW index");
         verify_hnsw_checksums(dir, basename)?;
 
-        // Resolve the distance metric (#1351). The stored value (meta
+        // Resolve the distance metric. The stored value (meta
         // header; legacy indexes without one are cosine) always wins — but
         // an *explicit* conflicting CQS_DISTANCE_METRIC is a typed error
         // rather than a silent reinterpretation of distances.
@@ -1112,7 +1112,7 @@ impl HnswIndex {
     }
 
     /// Read the stored distance metric for a persisted index without
-    /// loading it (#1351). Missing meta header → `Cosine` (legacy indexes,
+    /// loading it. Missing meta header → `Cosine` (legacy indexes,
     /// and the build default when no index exists yet). Used by derived
     /// backends (CAGRA rebuild path) to stay consistent with the slot's
     /// HNSW metric when `CQS_DISTANCE_METRIC` is unset.
@@ -1857,7 +1857,7 @@ mod tests {
         );
     }
 
-    // ===== distance metric persistence (#1351) =====
+    // ===== distance metric persistence =====
 
     /// Roundtrip: build with DotProduct → save → load → metric preserved
     /// and search still finds the self-match with a near-1 score (the
@@ -1945,7 +1945,7 @@ mod tests {
     /// metric than the stored one is a typed `MetricMismatch` error, never
     /// a silent reinterpretation.
     ///
-    /// Test discipline (#1351): the env var is only ever set to "cosine" —
+    /// Test discipline: the env var is only ever set to "cosine" —
     /// a concurrent unlocked test loading a cosine index then still sees
     /// `requested == stored` and is unaffected. The conflict is created by
     /// the *stored* side (a DotProduct index built via the explicit-metric

--- a/src/hnsw/persist.rs
+++ b/src/hnsw/persist.rs
@@ -4,13 +4,11 @@ use std::cell::UnsafeCell;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use hnsw_rs::anndists::dist::distances::DistCosine;
-use hnsw_rs::api::AnnT;
 use hnsw_rs::hnswio::HnswIo;
 
-use crate::index::VectorIndex;
+use crate::index::{DistanceMetric, VectorIndex};
 
-use super::{HnswError, HnswIndex, HnswInner, HnswIoCell, LoadedHnsw};
+use super::{HnswError, HnswGraph, HnswIndex, HnswInner, HnswIoCell, LoadedHnsw};
 
 /// Configurable HNSW graph file size limit via `CQS_HNSW_MAX_GRAPH_BYTES`
 /// env var. Defaults to 500MB. Cached in OnceLock for single parse.
@@ -94,18 +92,128 @@ fn warn_wsl_advisory_locking(dir: &Path) {
     }
 }
 
-/// Core HNSW file extensions (graph, data, IDs)
-const HNSW_EXTENSIONS: &[&str] = &["hnsw.graph", "hnsw.data", "hnsw.ids"];
+/// Core HNSW file extensions (graph, data, IDs, meta header). These are the
+/// extensions allowed in the checksum manifest. `hnsw.meta` is absent from
+/// legacy (pre-#1351) indexes — the load path treats a missing meta as
+/// cosine, which is what every legacy index is.
+const HNSW_EXTENSIONS: &[&str] = &["hnsw.graph", "hnsw.data", "hnsw.ids", "hnsw.meta"];
 
 /// All HNSW file extensions including checksum (for cleanup/deletion).
-/// NOTE: Keep in sync with HNSW_EXTENSIONS above — first 3 elements must match.
+/// NOTE: Keep in sync with HNSW_EXTENSIONS above — first 4 elements must match.
 pub const HNSW_ALL_EXTENSIONS: &[&str] = &[
     "hnsw.graph",
     "hnsw.data",
     "hnsw.ids",
+    "hnsw.meta",
     "hnsw.checksum",
     "hnsw.lock",
 ];
+
+/// Magic string for the `{basename}.hnsw.meta` JSON header (#1351). A
+/// mismatch is a typed load error, not a silent default.
+const HNSW_META_MAGIC: &str = "CQSHNSW";
+
+/// Version of the `.hnsw.meta` header. Bump when adding fields an older
+/// binary must not misinterpret; the load path rejects versions newer than
+/// this binary understands.
+const HNSW_META_VERSION: u32 = 1;
+
+/// JSON header persisted next to the HNSW graph/data/ids files.
+///
+/// Carries index-level configuration that the raw hnsw_rs dump does not
+/// expose up front — today that is the distance metric, which the load path
+/// needs *before* it can instantiate the right `Hnsw<f32, D>` type
+/// parameter. Mirrors the CAGRA `.cagra.meta` sidecar pattern
+/// (`src/cagra.rs`).
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+struct HnswMeta {
+    /// Format magic. See [`HNSW_META_MAGIC`].
+    magic: String,
+    /// Header schema version. See [`HNSW_META_VERSION`].
+    version: u32,
+    /// [`DistanceMetric::as_str`] value the index was built with.
+    metric: String,
+}
+
+/// Read the persisted distance metric for an index, if any.
+///
+/// - Missing meta file → `Ok(Cosine)`: every pre-#1351 index was built with
+///   `DistCosine` by construction.
+/// - Present but malformed / unknown magic / newer version / unknown metric
+///   → typed error. Never a silent cosine fallback: misreading a dot-product
+///   index as cosine produces wrong distances, not a crash.
+fn read_hnsw_meta_metric(dir: &Path, basename: &str) -> Result<DistanceMetric, HnswError> {
+    let meta_path = dir.join(format!("{}.hnsw.meta", basename));
+    if !meta_path.exists() {
+        tracing::debug!(
+            path = %meta_path.display(),
+            "No HNSW meta header (legacy index) — metric is cosine"
+        );
+        return Ok(DistanceMetric::Cosine);
+    }
+
+    // Size cap: the header is a 3-field JSON object; anything beyond a few
+    // KB is corruption or tampering.
+    const MAX_META_SIZE: u64 = 64 * 1024;
+    let meta_size = std::fs::metadata(&meta_path)
+        .map_err(|e| {
+            HnswError::Internal(format!(
+                "Failed to stat HNSW meta {}: {}",
+                meta_path.display(),
+                e
+            ))
+        })?
+        .len();
+    if meta_size > MAX_META_SIZE {
+        return Err(HnswError::Internal(format!(
+            "HNSW meta {} is {} bytes, exceeds {} byte limit",
+            meta_path.display(),
+            meta_size,
+            MAX_META_SIZE
+        )));
+    }
+
+    let raw = std::fs::read(&meta_path).map_err(|e| {
+        HnswError::Internal(format!(
+            "Failed to read HNSW meta {}: {}",
+            meta_path.display(),
+            e
+        ))
+    })?;
+    let meta: HnswMeta = serde_json::from_slice(&raw).map_err(|e| {
+        HnswError::Internal(format!(
+            "Failed to parse HNSW meta {}: {}",
+            meta_path.display(),
+            e
+        ))
+    })?;
+
+    if meta.magic != HNSW_META_MAGIC {
+        return Err(HnswError::Internal(format!(
+            "HNSW meta {} has unexpected magic {:?} (want {:?})",
+            meta_path.display(),
+            meta.magic,
+            HNSW_META_MAGIC
+        )));
+    }
+    if meta.version > HNSW_META_VERSION {
+        return Err(HnswError::Internal(format!(
+            "HNSW meta {} has version {} — newer than this binary understands ({}). \
+             Run 'cqs index --force' or upgrade cqs.",
+            meta_path.display(),
+            meta.version,
+            HNSW_META_VERSION
+        )));
+    }
+
+    meta.metric.parse::<DistanceMetric>().map_err(|e| {
+        HnswError::Internal(format!(
+            "HNSW meta {} has invalid metric: {}",
+            meta_path.display(),
+            e
+        ))
+    })
+}
 
 /// Verify HNSW index file checksums using blake3.
 ///
@@ -221,6 +329,7 @@ impl HnswIndex {
     /// - `{basename}.hnsw.data` - Vector data
     /// - `{basename}.hnsw.graph` - HNSW graph structure
     /// - `{basename}.hnsw.ids` - Chunk ID mapping
+    /// - `{basename}.hnsw.meta` - JSON header (distance metric, #1351)
     /// - `{basename}.hnsw.checksum` - Blake3 checksums for integrity
     ///
     /// # Crash safety
@@ -258,7 +367,13 @@ impl HnswIndex {
         // behind. The operator must clear them manually so we don't silently
         // overwrite a known-good index with a stale .bak on a future
         // rollback. Runs before any writes.
-        let all_exts = ["hnsw.graph", "hnsw.data", "hnsw.ids", "hnsw.checksum"];
+        let all_exts = [
+            "hnsw.graph",
+            "hnsw.data",
+            "hnsw.ids",
+            "hnsw.meta",
+            "hnsw.checksum",
+        ];
         let stale_baks: Vec<std::path::PathBuf> = all_exts
             .iter()
             .filter_map(|ext| {
@@ -316,7 +431,7 @@ impl HnswIndex {
 
         // Save the HNSW graph and data to temp directory
         self.inner
-            .with_hnsw(|h| h.file_dump(&temp_dir, basename))
+            .with_hnsw(|g| g.file_dump(&temp_dir, basename))
             .map_err(|e| {
                 HnswError::Internal(format!(
                     "Failed to dump HNSW to {}/{}: {}",
@@ -325,6 +440,48 @@ impl HnswIndex {
                     e
                 ))
             })?;
+
+        // Write the meta header (distance metric) to the temp directory.
+        // Small JSON; written with mode 0600 + fsync like the id map so a
+        // power cut can't promote a checksum manifest that references a
+        // page-cache-only meta file.
+        let meta_temp = temp_dir.join(format!("{}.hnsw.meta", basename));
+        {
+            let meta = HnswMeta {
+                magic: HNSW_META_MAGIC.to_string(),
+                version: HNSW_META_VERSION,
+                metric: self.metric().as_str().to_string(),
+            };
+            let meta_json = serde_json::to_vec(&meta).map_err(|e| {
+                HnswError::Internal(format!("Failed to serialize HNSW meta: {}", e))
+            })?;
+            let mut file = {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::OpenOptionsExt;
+                    std::fs::OpenOptions::new()
+                        .write(true)
+                        .create(true)
+                        .truncate(true)
+                        .mode(0o600)
+                        .open(&meta_temp)
+                }
+                #[cfg(not(unix))]
+                {
+                    std::fs::File::create(&meta_temp)
+                }
+            }
+            .map_err(|e| {
+                HnswError::Internal(format!("Failed to create {}: {}", meta_temp.display(), e))
+            })?;
+            use std::io::Write;
+            file.write_all(&meta_json).map_err(|e| {
+                HnswError::Internal(format!("Failed to write {}: {}", meta_temp.display(), e))
+            })?;
+            file.sync_all().map_err(|e| {
+                HnswError::Internal(format!("Failed to fsync {}: {}", meta_temp.display(), e))
+            })?;
+        }
 
         // Stream ID map directly to file via BufWriter rather than
         // serializing to an in-memory JSON string first.
@@ -387,7 +544,7 @@ impl HnswIndex {
             hasher.finalize()
         };
         let mut checksums = vec![format!("hnsw.ids:{}", ids_hash.to_hex())];
-        for ext in &["hnsw.graph", "hnsw.data"] {
+        for ext in &["hnsw.graph", "hnsw.data", "hnsw.meta"] {
             let path = temp_dir.join(format!("{}.{}", basename, ext));
             if path.exists() {
                 let file = std::fs::File::open(&path).map_err(|e| {
@@ -779,6 +936,20 @@ impl HnswIndex {
         tracing::info!(dir = %dir.display(), basename, "Loading HNSW index");
         verify_hnsw_checksums(dir, basename)?;
 
+        // Resolve the distance metric (#1351). The stored value (meta
+        // header; legacy indexes without one are cosine) always wins — but
+        // an *explicit* conflicting CQS_DISTANCE_METRIC is a typed error
+        // rather than a silent reinterpretation of distances.
+        let stored_metric = read_hnsw_meta_metric(dir, basename)?;
+        if let Some(requested) = DistanceMetric::from_env().map_err(HnswError::Internal)? {
+            if requested != stored_metric {
+                return Err(HnswError::MetricMismatch {
+                    stored: stored_metric,
+                    requested,
+                });
+            }
+        }
+
         // Check ID map file size to prevent OOM (limit configurable via CQS_HNSW_MAX_ID_MAP_BYTES)
         let max_id_map_size = hnsw_max_id_map_bytes();
         let id_map_size = std::fs::metadata(&id_map_path)
@@ -903,8 +1074,10 @@ impl HnswIndex {
             // SAFETY: Exclusive access during construction — no other references exist.
             // After this closure returns, the UnsafeCell is never accessed again directly.
             let io = unsafe { &mut *cell.0.get() };
-            io.load_hnsw::<f32, DistCosine>()
-                .map_err(|e| HnswError::Internal(format!("Failed to load HNSW: {}", e)))
+            // Instantiate the dist type recorded in the meta header. hnsw_rs
+            // additionally cross-checks the distance name embedded in the
+            // graph file, so a forged meta cannot misread distances.
+            HnswGraph::load(io, stored_metric)
         })?;
 
         // Validate id_map size matches HNSW vector count
@@ -917,7 +1090,7 @@ impl HnswIndex {
             )));
         }
 
-        tracing::info!(count = id_map.len(), "HNSW index loaded");
+        tracing::info!(count = id_map.len(), metric = %stored_metric, "HNSW index loaded");
 
         // Release the load-phase shared lock before returning. The
         // in-memory `Loaded(...)` variant is fully self-contained
@@ -936,6 +1109,15 @@ impl HnswIndex {
             dim,
             _lock_file: None,
         })
+    }
+
+    /// Read the stored distance metric for a persisted index without
+    /// loading it (#1351). Missing meta header → `Cosine` (legacy indexes,
+    /// and the build default when no index exists yet). Used by derived
+    /// backends (CAGRA rebuild path) to stay consistent with the slot's
+    /// HNSW metric when `CQS_DISTANCE_METRIC` is unset.
+    pub fn stored_metric(dir: &Path, basename: &str) -> Result<DistanceMetric, HnswError> {
+        read_hnsw_meta_metric(dir, basename)
     }
 
     /// Check if an HNSW index exists at the given path
@@ -1673,6 +1855,187 @@ mod tests {
             stale_bak.exists(),
             "guard must NOT delete the stale .bak (it's the operator's recovery breadcrumb)"
         );
+    }
+
+    // ===== distance metric persistence (#1351) =====
+
+    /// Roundtrip: build with DotProduct → save → load → metric preserved
+    /// and search still finds the self-match with a near-1 score (the
+    /// embeddings are unit-norm, so self-dot ≈ 1 and `1 − dist` ≈ 1).
+    /// Uses the shared retry helper so the rare degenerate concurrent-build
+    /// graph can't flake the assertion; the metric roundtrip itself is
+    /// asserted on every build inside the closure.
+    #[test]
+    fn test_metric_dot_save_load_roundtrip() {
+        use crate::index::DistanceMetric;
+        let basename = "test_dot_metric";
+        let build = || {
+            let tmp = TempDir::new().unwrap();
+            let embeddings = vec![
+                ("chunk1".to_string(), make_embedding(1)),
+                ("chunk2".to_string(), make_embedding(2)),
+            ];
+            let index = HnswIndex::build_with_dim_and_metric(
+                embeddings,
+                crate::EMBEDDING_DIM,
+                DistanceMetric::DotProduct,
+            )
+            .unwrap();
+            assert_eq!(index.metric(), DistanceMetric::DotProduct);
+            index.save(tmp.path(), basename).unwrap();
+
+            // The meta header must be on disk and covered by the manifest.
+            assert!(
+                tmp.path().join(format!("{basename}.hnsw.meta")).exists(),
+                "save must write the .hnsw.meta header"
+            );
+
+            let loaded =
+                HnswIndex::load_with_dim(tmp.path(), basename, crate::EMBEDDING_DIM).unwrap();
+            assert_eq!(
+                loaded.metric(),
+                DistanceMetric::DotProduct,
+                "metric must survive the save/load roundtrip"
+            );
+            assert_eq!(loaded.len(), 2);
+            // TempDir drops here; the loaded index is self-contained.
+            loaded
+        };
+        let score =
+            crate::hnsw::assert_self_match_reachable(build, &make_embedding(1), "chunk1", 2);
+        assert!(
+            score > 0.9,
+            "unit-norm self-match under DistDot should score ≈ 1, got {score}"
+        );
+    }
+
+    /// A pre-#1351 index has no `.hnsw.meta` and a 3-line checksum manifest.
+    /// It must load as cosine — that is what every legacy index was built
+    /// with.
+    #[test]
+    fn test_legacy_index_without_meta_loads_as_cosine() {
+        use crate::index::DistanceMetric;
+        let tmp = TempDir::new().unwrap();
+        let basename = "test_legacy";
+
+        let embeddings = vec![
+            ("a".to_string(), make_embedding(1)),
+            ("b".to_string(), make_embedding(2)),
+        ];
+        let index = HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap();
+        index.save(tmp.path(), basename).unwrap();
+
+        // Simulate the legacy layout: drop the meta header and rewrite the
+        // manifest with only the three legacy extensions (`write_checksums`
+        // covers exactly graph/data/ids).
+        std::fs::remove_file(tmp.path().join(format!("{basename}.hnsw.meta"))).unwrap();
+        write_checksums(tmp.path(), basename);
+
+        let loaded = HnswIndex::load_with_dim(tmp.path(), basename, crate::EMBEDDING_DIM)
+            .expect("legacy index without meta header must load");
+        assert_eq!(
+            loaded.metric(),
+            DistanceMetric::Cosine,
+            "legacy index must load as cosine"
+        );
+        assert_eq!(loaded.len(), 2);
+    }
+
+    /// Loading with `CQS_DISTANCE_METRIC` explicitly set to a different
+    /// metric than the stored one is a typed `MetricMismatch` error, never
+    /// a silent reinterpretation.
+    ///
+    /// Test discipline (#1351): the env var is only ever set to "cosine" —
+    /// a concurrent unlocked test loading a cosine index then still sees
+    /// `requested == stored` and is unaffected. The conflict is created by
+    /// the *stored* side (a DotProduct index built via the explicit-metric
+    /// API). Held under `HNSW_ENV_LOCK` for the var's whole lifetime.
+    #[test]
+    fn test_metric_mismatch_is_typed_error() {
+        use crate::hnsw::{EnvVarGuard, HNSW_ENV_LOCK};
+        use crate::index::DistanceMetric;
+
+        let tmp = TempDir::new().unwrap();
+        let basename = "test_metric_mismatch";
+
+        let _lock = HNSW_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let embeddings = vec![
+            ("a".to_string(), make_embedding(1)),
+            ("b".to_string(), make_embedding(2)),
+        ];
+        let index = HnswIndex::build_with_dim_and_metric(
+            embeddings.clone(),
+            crate::EMBEDDING_DIM,
+            DistanceMetric::DotProduct,
+        )
+        .unwrap();
+        index.save(tmp.path(), basename).unwrap();
+
+        let _var = EnvVarGuard::set("CQS_DISTANCE_METRIC", "cosine");
+
+        // Explicit conflicting request → typed error.
+        match HnswIndex::load_with_dim(tmp.path(), basename, crate::EMBEDDING_DIM) {
+            Err(crate::hnsw::HnswError::MetricMismatch { stored, requested }) => {
+                assert_eq!(stored, DistanceMetric::DotProduct);
+                assert_eq!(requested, DistanceMetric::Cosine);
+            }
+            Err(other) => panic!("expected MetricMismatch, got: {other}"),
+            Ok(_) => panic!("conflicting metric must not load"),
+        }
+
+        // Matching explicit request → loads fine. Same env value ("cosine"),
+        // conflict-free because this index IS cosine.
+        let cosine_index = HnswIndex::build_with_dim_and_metric(
+            embeddings,
+            crate::EMBEDDING_DIM,
+            DistanceMetric::Cosine,
+        )
+        .unwrap();
+        let basename2 = "test_metric_match";
+        cosine_index.save(tmp.path(), basename2).unwrap();
+        let loaded = HnswIndex::load_with_dim(tmp.path(), basename2, crate::EMBEDDING_DIM)
+            .expect("matching explicit metric must load");
+        assert_eq!(loaded.metric(), DistanceMetric::Cosine);
+        // _var's Drop removes the env var before the lock releases.
+    }
+
+    /// The meta header is covered by the blake3 manifest: tampering with it
+    /// after save must fail checksum verification before the metric is even
+    /// read.
+    #[test]
+    fn test_tampered_meta_fails_checksum() {
+        let tmp = TempDir::new().unwrap();
+        let basename = "test_meta_tamper";
+
+        let embeddings = vec![
+            ("a".to_string(), make_embedding(1)),
+            ("b".to_string(), make_embedding(2)),
+        ];
+        let index = HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap();
+        index.save(tmp.path(), basename).unwrap();
+
+        // Rewrite the meta to claim a different metric WITHOUT updating the
+        // manifest.
+        let meta_path = tmp.path().join(format!("{basename}.hnsw.meta"));
+        std::fs::write(
+            &meta_path,
+            r#"{"magic":"CQSHNSW","version":1,"metric":"dot"}"#,
+        )
+        .unwrap();
+
+        match HnswIndex::load_with_dim(tmp.path(), basename, crate::EMBEDDING_DIM) {
+            Err(HnswError::ChecksumMismatch { file, .. }) => {
+                assert!(
+                    file.contains("hnsw.meta"),
+                    "checksum failure should point at the meta file: {file}"
+                );
+            }
+            Err(other) => panic!("expected ChecksumMismatch, got: {other}"),
+            Ok(_) => panic!("tampered meta must not load"),
+        }
     }
 
     // ===== id_map edge cases =====

--- a/src/hnsw/search.rs
+++ b/src/hnsw/search.rs
@@ -124,7 +124,7 @@ impl HnswIndex {
                     // Distance → similarity. Holds for both supported
                     // metrics: DistCosine returns 1 − cos (score = cos) and
                     // DistDot returns 1 − a·b (score = a·b) — see
-                    // `DistanceMetric` (#1351).
+                    // `DistanceMetric`.
                     let score = 1.0 - n.distance;
                     if !score.is_finite() {
                         tracing::warn!(

--- a/src/hnsw/search.rs
+++ b/src/hnsw/search.rs
@@ -1,6 +1,5 @@
 //! HNSW search implementation
 
-use hnsw_rs::api::AnnT;
 use hnsw_rs::filter::FilterT;
 use hnsw_rs::prelude::DataId;
 
@@ -122,6 +121,10 @@ impl HnswIndex {
             .filter_map(|n| {
                 let idx = n.d_id;
                 if idx < self.id_map.len() {
+                    // Distance → similarity. Holds for both supported
+                    // metrics: DistCosine returns 1 − cos (score = cos) and
+                    // DistDot returns 1 − a·b (score = a·b) — see
+                    // `DistanceMetric` (#1351).
                     let score = 1.0 - n.distance;
                     if !score.is_finite() {
                         tracing::warn!(

--- a/src/index.rs
+++ b/src/index.rs
@@ -489,7 +489,7 @@ mod tests {
         assert_eq!(backends[0].name(), "cagra");
     }
 
-    // ===== DistanceMetric (#1351) =====
+    // ===== DistanceMetric =====
 
     #[test]
     fn test_distance_metric_default_is_cosine() {

--- a/src/index.rs
+++ b/src/index.rs
@@ -14,6 +14,115 @@ use crate::store::{ClearHnswDirty, Store, StoreError};
 // `Ok(None)`. `anyhow::Result<_>` consumes it via `?` because
 // `StoreError: std::error::Error`.
 
+/// Distance metric a vector index is built and searched with.
+///
+/// The metric is an **index-time** choice: it is resolved from
+/// `CQS_DISTANCE_METRIC` when an index is built, persisted alongside the
+/// index (HNSW: `{basename}.hnsw.meta`; CAGRA: the `.cagra.meta` sidecar),
+/// and the stored value wins on every subsequent load. Loading with
+/// `CQS_DISTANCE_METRIC` explicitly set to a *different* metric is a typed
+/// error ([`crate::hnsw::HnswError::MetricMismatch`]) — never a silent
+/// reinterpretation. This mirrors how the embedding model is selected at
+/// index time and pinned thereafter (`Store::stored_model_name()`).
+///
+/// ## Variants and backend support
+///
+/// - [`Cosine`](Self::Cosine) (default): HNSW uses `DistCosine`; CAGRA keeps
+///   cuVS's default `L2Expanded`, which is rank-equivalent to cosine on the
+///   unit-norm embeddings cqs produces (`d² = 2 − 2·cos`).
+/// - [`DotProduct`](Self::DotProduct): HNSW uses `DistDot`
+///   (`dist = 1 − a·b`); CAGRA sets cuVS `InnerProduct`. Note hnsw_rs's
+///   `DistDot` asserts `a·b <= 1`, so un-normalized embedding models whose
+///   pairwise dot products exceed 1 are not usable on the HNSW backend
+///   without a scaling pass.
+///
+/// `L2` is deliberately absent: both score-conversion paths
+/// (`1 − dist` for HNSW, `1 − d²/2` for CAGRA) are cosine-similarity-shaped
+/// and an L2 variant needs its own score normalization design before it can
+/// honor the documented 0..1 score contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DistanceMetric {
+    /// Cosine similarity (the cqs default since v0.1).
+    #[default]
+    Cosine,
+    /// Inner product / dot product. For models whose reference
+    /// implementations score with un-normalized dot product
+    /// (e.g. CodeRankEmbed) or Matryoshka-truncated embeddings.
+    DotProduct,
+}
+
+impl DistanceMetric {
+    /// Stable on-disk / display name. The persisted index headers store this
+    /// string; keep values stable across releases.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DistanceMetric::Cosine => "cosine",
+            DistanceMetric::DotProduct => "dot",
+        }
+    }
+
+    /// Read `CQS_DISTANCE_METRIC` if set. `Ok(None)` when unset; a set but
+    /// unparseable value is a hard error — a typo must not silently build a
+    /// cosine index when the operator asked for dot product.
+    ///
+    /// TEST DISCIPLINE: load paths call this, so a test that sets
+    /// `CQS_DISTANCE_METRIC` to anything other than `"cosine"` makes every
+    /// concurrent cosine load in the suite fail with a metric mismatch.
+    /// Tests cover the parse/error behavior through the pure
+    /// [`Self::parse_env_value`] instead, and only ever set the var to
+    /// `"cosine"` (observationally identical to unset), under
+    /// `HNSW_ENV_LOCK`.
+    pub fn from_env() -> Result<Option<Self>, String> {
+        let _span = tracing::info_span!("distance_metric_from_env").entered();
+        match std::env::var("CQS_DISTANCE_METRIC") {
+            Ok(raw) => Self::parse_env_value(&raw).map(Some),
+            Err(std::env::VarError::NotPresent) => Ok(None),
+            Err(std::env::VarError::NotUnicode(_)) => {
+                Err("CQS_DISTANCE_METRIC is not valid UTF-8".to_string())
+            }
+        }
+    }
+
+    /// Pure parse of a `CQS_DISTANCE_METRIC` value, factored out of
+    /// [`Self::from_env`] so tests can pin the error mapping without
+    /// mutating process-global env (see the test-discipline note above).
+    fn parse_env_value(raw: &str) -> Result<Self, String> {
+        raw.parse::<Self>().map_err(|e| {
+            tracing::warn!(value = %raw, error = %e, "Invalid CQS_DISTANCE_METRIC");
+            format!("Invalid CQS_DISTANCE_METRIC={raw:?}: {e}")
+        })
+    }
+
+    /// Build-time resolution: `CQS_DISTANCE_METRIC` if set, else
+    /// [`Cosine`](Self::Cosine). Load paths must NOT use this to pick the
+    /// metric — the stored value wins there; they use [`Self::from_env`]
+    /// only to detect an explicit conflict.
+    pub fn resolve() -> Result<Self, String> {
+        Ok(Self::from_env()?.unwrap_or_default())
+    }
+}
+
+impl std::fmt::Display for DistanceMetric {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for DistanceMetric {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "cosine" => Ok(DistanceMetric::Cosine),
+            "dot" | "dotproduct" | "dot_product" | "dot-product" | "innerproduct"
+            | "inner_product" | "ip" => Ok(DistanceMetric::DotProduct),
+            other => Err(format!(
+                "unknown distance metric {other:?} (supported: cosine, dot)"
+            )),
+        }
+    }
+}
+
 /// Result from a vector index search
 #[derive(Debug, Clone)]
 pub struct IndexResult {
@@ -378,5 +487,77 @@ mod tests {
         assert_eq!(backends.last().unwrap().name(), "hnsw");
         #[cfg(feature = "cuda-index")]
         assert_eq!(backends[0].name(), "cagra");
+    }
+
+    // ===== DistanceMetric (#1351) =====
+
+    #[test]
+    fn test_distance_metric_default_is_cosine() {
+        assert_eq!(DistanceMetric::default(), DistanceMetric::Cosine);
+    }
+
+    #[test]
+    fn test_distance_metric_parse_and_roundtrip() {
+        for (raw, want) in [
+            ("cosine", DistanceMetric::Cosine),
+            ("Cosine", DistanceMetric::Cosine),
+            ("dot", DistanceMetric::DotProduct),
+            ("DotProduct", DistanceMetric::DotProduct),
+            ("dot_product", DistanceMetric::DotProduct),
+            ("dot-product", DistanceMetric::DotProduct),
+            ("ip", DistanceMetric::DotProduct),
+        ] {
+            assert_eq!(raw.parse::<DistanceMetric>().unwrap(), want, "raw={raw}");
+        }
+        // as_str → parse roundtrip (the on-disk header contract).
+        for m in [DistanceMetric::Cosine, DistanceMetric::DotProduct] {
+            assert_eq!(m.as_str().parse::<DistanceMetric>().unwrap(), m);
+        }
+    }
+
+    #[test]
+    fn test_distance_metric_parse_rejects_unknown() {
+        let err = "euclidean".parse::<DistanceMetric>().unwrap_err();
+        assert!(
+            err.contains("euclidean"),
+            "error should name the value: {err}"
+        );
+        assert!("l2".parse::<DistanceMetric>().is_err());
+        assert!("".parse::<DistanceMetric>().is_err());
+    }
+
+    /// Env-value handling, via the pure `parse_env_value` seam (no
+    /// process-global env mutation — see the test-discipline note on
+    /// `from_env`: a non-"cosine" value would fail concurrent loads).
+    #[test]
+    fn test_distance_metric_parse_env_value() {
+        assert_eq!(
+            DistanceMetric::parse_env_value("dot").unwrap(),
+            DistanceMetric::DotProduct
+        );
+        assert_eq!(
+            DistanceMetric::parse_env_value("cosine").unwrap(),
+            DistanceMetric::Cosine
+        );
+        // Unparseable value is a hard error, not a silent cosine fallback,
+        // and the error names the env var for the operator.
+        let err = DistanceMetric::parse_env_value("manhattan").unwrap_err();
+        assert!(
+            err.contains("CQS_DISTANCE_METRIC") && err.contains("manhattan"),
+            "error should name the var and value: {err}"
+        );
+    }
+
+    /// `from_env`/`resolve` with the var unset (the suite-wide steady
+    /// state): `None` / cosine. Held under the shared HNSW env lock so a
+    /// concurrent "cosine"-setting test can't perturb the read.
+    #[test]
+    fn test_distance_metric_env_unset_resolves_cosine() {
+        let _lock = crate::hnsw::HNSW_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        std::env::remove_var("CQS_DISTANCE_METRIC");
+        assert_eq!(DistanceMetric::from_env().unwrap(), None);
+        assert_eq!(DistanceMetric::resolve().unwrap(), DistanceMetric::Cosine);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ pub mod cagra;
 pub use audit::parse_duration;
 pub use embedder::{Embedder, Embedding};
 pub use hnsw::HnswIndex;
-pub use index::{IndexResult, VectorIndex};
+pub use index::{DistanceMetric, IndexResult, VectorIndex};
 pub use note::{
     parse_notes, path_matches_mention, rewrite_notes_file, NoteEntry, NoteError, NoteFile,
     NOTES_HEADER,


### PR DESCRIPTION
Closes #1351 (audit finding P4-15 / EX-V1.33-7). Implements option (a): `DistanceMetric` threaded through both vector backends, persisted in the index artifacts, with typed mismatch errors — mirroring the `stored_model_name` contract.

## Design

- **`DistanceMetric { Cosine (default), DotProduct }`** (src/index.rs, re-exported from lib.rs). L2 deliberately skipped: both distance→score paths are cosine-similarity-shaped; L2 needs its own score-normalization design to honor the 0..1 contract (documented on the enum).
- **HNSW**: `HnswGraph` enum over `Hnsw<f32, DistCosine|DistDot>` with forwarding methods (hnsw_rs generics don't dyn-erase; `with_hnsw` dispatch shape unchanged). `1 − dist` conversion valid for both. Documented: anndists' DistDot asserts `a·b ≤ 1`, so un-normalized models need scaling.
- **CAGRA**: Cosine keeps cuVS's default `L2Expanded` (rank-equivalent on unit-norm vectors — exact prior behavior); DotProduct sets `metric = InnerProduct` through the raw-params pointer (cuvs 26.6 wrapper has no setter). Empirical finding pinned by test: cuVS CAGRA returns the **raw inner product** best-first, so `score = dist` — the first hypothesis (negated IP) was wrong and a failing GPU test caught it.

## Persistence + mismatch contract

- New `{basename}.hnsw.meta` JSON header (magic, version, metric): atomic temp-dir write with 0600+fsync, included in the blake3 checksum manifest, backup/rollback ext lists, and GC's extension list. Legacy 3-file indexes load as Cosine; a tampered meta fails the checksum first (test); hnsw_rs's own distance-name check backstops.
- CAGRA sidecar gains `#[serde(default)] metric` — legacy sidecars decode as Cosine, no version bump.
- Stored always wins; explicitly conflicting `CQS_DISTANCE_METRIC` → typed `HnswError::MetricMismatch`; CAGRA (derived index) treats mismatch as stale → rebuild, resolving env > stored-HNSW-meta > cosine so the backends can't drift.

## Verification

- HNSW lib 71 passed (new: dot roundtrip via the shared retry helper, legacy-load-as-cosine, typed mismatch, tampered-meta)
- CAGRA single-threaded 30 passed (dot build+search, sidecar roundtrip, legacy sidecar, mismatch-stale)
- Build warning-free, clippy -D warnings clean, fmt clean. Env-var tests only ever set "cosine" (observationally identical to unset for concurrent unlocked loads, under HNSW_ENV_LOCK); parse/error behavior covered through a pure parse seam. `EnvVarGuard` promoted to the shared cfg(test) block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
