### PR TITLE
feat(watch): adaptive debounce - idle-flush with max-latency cap (closes #1716)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Keep your index up to date automatically:
 ```bash
 cqs watch              # Watch for changes and reindex (foreground)
 cqs watch --serve      # + listen on Unix socket so CLI commands hit the daemon (3-19 ms vs 2 s startup)
-cqs watch --debounce 1000  # Custom debounce (ms)
+cqs watch --debounce 1000  # Custom quiet gap (ms) — changes flush after this much event silence
 ```
 
 Watch mode respects `.gitignore` by default. Use `--no-ignore` to index ignored files.
@@ -944,8 +944,9 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_TYPE_BOOST` | `1.2` | Multiplier applied to chunks whose type matches the query filter (e.g. `--include-type function`) |
 | `CQS_TYPE_GRAPH_MAX_EDGES` | `500000` | Max `type_edges` rows loaded into the in-memory type graph. Sibling of `CQS_CALL_GRAPH_MAX_EDGES` for type-dependency analysis. |
 | `CQS_WAL_AUTOCHECKPOINT_PAGES` | `1000` | SQLite `wal_autocheckpoint` ceiling (pages) applied via every connection's `after_connect` hook. Caps WAL growth between commits so an abrupt shutdown leaves a bounded recovery walk. Lower for tighter WAL bounds; raise on long write-heavy reindex sessions to amortize checkpoint cost. (P2-25 / DS-V1.33-8) |
-| `CQS_WATCH_DEBOUNCE_MS` | `500` (inotify) / `1500` (WSL/poll auto) | Watch debounce window (milliseconds). Takes precedence over `--debounce`. |
+| `CQS_WATCH_DEBOUNCE_MS` | `500` (inotify) / `1500` (WSL/poll auto) | Watch quiet gap (milliseconds): pending changes flush after this much event *silence*, so an event burst (e.g. `git checkout`) coalesces into one reindex cycle fired just after the burst ends, while a single save flushes at this latency. Takes precedence over `--debounce`. |
 | `CQS_WATCH_INCREMENTAL_SPLADE` | `1` | Set to `0` to disable inline SPLADE encoding in `cqs watch`. Daemon then runs dense-only and sparse coverage drifts until a manual `cqs index`. |
+| `CQS_WATCH_MAX_DEBOUNCE_MS` | 6× quiet gap (`3000` at the inotify default) | Max-latency cap (milliseconds) on the idle-flush debounce: an event stream that never goes quiet for a full `CQS_WATCH_DEBOUNCE_MS` still flushes within this much of its first pending event. Clamped to at least the quiet gap. |
 | `CQS_WATCH_MAX_PENDING` | `10000` | Max pending file changes before watch forces flush |
 | `CQS_WATCH_POLL_MS` | `5000` | Poll-watcher tick interval (milliseconds). Only used on WSL `/mnt/c/` and other non-inotify filesystems where notify-rs falls back to polling. Lower = faster reaction; higher = less idle CPU walking the tree. Min 100. |
 | `CQS_WATCH_REBUILD_THRESHOLD` | `100` | Files changed before watch triggers full HNSW rebuild |

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -394,10 +394,15 @@ pub(super) enum Commands {
     /// Watch for changes and reindex
     #[cqs_cmd(group = "a", batch = "cli")]
     Watch {
-        /// Debounce interval in milliseconds. Default 500ms suits inotify
-        /// on native Linux; WSL DrvFS (/mnt/) and --poll mode auto-bump to
-        /// 1500ms because NTFS mtime resolution is 1s. Override here or
-        /// via CQS_WATCH_DEBOUNCE_MS (takes precedence over the flag).
+        /// Quiet gap in milliseconds (idle-flush debounce): pending
+        /// changes reindex after this much event silence, so a bulk
+        /// burst (e.g. git checkout) coalesces into one cycle fired
+        /// just after the burst ends. Default 500ms suits inotify on
+        /// native Linux; WSL DrvFS (/mnt/) and --poll mode auto-bump
+        /// to 1500ms because NTFS mtime resolution is 1s. Override
+        /// here or via CQS_WATCH_DEBOUNCE_MS (takes precedence over
+        /// the flag). A never-quiet event stream still flushes within
+        /// CQS_WATCH_MAX_DEBOUNCE_MS (default 6x the quiet gap).
         #[arg(long, default_value = "500")]
         debounce: u64,
         /// Index files ignored by .gitignore

--- a/src/cli/watch/events.rs
+++ b/src/cli/watch/events.rs
@@ -79,6 +79,9 @@ pub(super) fn collect_events(event: &notify::Event, cfg: &WatchConfig, state: &m
         if norm_path == norm_notes {
             state.pending_notes = true;
             state.last_event = std::time::Instant::now();
+            if state.first_pending_event.is_none() {
+                state.first_pending_event = Some(state.last_event);
+            }
             continue;
         }
 
@@ -154,6 +157,13 @@ pub(super) fn collect_events(event: &notify::Event, cfg: &WatchConfig, state: &m
                 );
             }
             state.last_event = std::time::Instant::now();
+            // Arm the max-latency clock on the first event of a burst.
+            // `last_event` restarts the quiet-gap timer on every event;
+            // this one is sticky until the flush drains the pending
+            // sets, bounding total delay under a never-quiet stream.
+            if state.first_pending_event.is_none() {
+                state.first_pending_event = Some(state.last_event);
+            }
         }
     }
 }

--- a/src/cli/watch/mod.rs
+++ b/src/cli/watch/mod.rs
@@ -149,6 +149,13 @@ struct WatchState {
     pending_files: HashSet<PathBuf>,
     pending_notes: bool,
     last_event: std::time::Instant,
+    /// When the oldest still-pending event arrived. Armed by
+    /// `collect_events` (and the reconcile queue paths) on the first
+    /// event after a flush; cleared by the flush block once the pending
+    /// sets drain. Drives the max-latency cap in [`flush_due`]: a
+    /// never-quiet event stream still flushes within
+    /// `DebounceConfig::max_latency` of this instant.
+    first_pending_event: Option<std::time::Instant>,
     last_indexed_mtime: HashMap<PathBuf, SystemTime>,
     hnsw_index: Option<HnswIndex>,
     incremental_count: usize,
@@ -299,6 +306,92 @@ fn publish_watch_snapshot(
     fresh_notifier.set_fresh(next_snap.is_fresh());
 }
 
+/// Timing knobs for the watch loop's idle-flush debounce.
+///
+/// The pending event set flushes when EITHER condition holds:
+///
+/// - **quiet gap**: no accepted event for `quiet_gap` — the timer
+///   restarts on every event, so a `git checkout` burst coalesces into
+///   exactly one reindex cycle fired ~`quiet_gap` after the burst's
+///   *last* event, and a single save flushes at the same latency as a
+///   fixed window would.
+/// - **max latency**: the oldest pending event has waited
+///   `max_latency` — bounds total delay when the stream never goes
+///   quiet (e.g. a generator continuously rewriting files), which
+///   would otherwise keep restarting the quiet-gap timer forever.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DebounceConfig {
+    quiet_gap: Duration,
+    max_latency: Duration,
+}
+
+/// Multiplier applied to the quiet gap to derive the default
+/// max-latency cap when `CQS_WATCH_MAX_DEBOUNCE_MS` is unset.
+/// 6× = 3 s at the 500 ms inotify default, 9 s at the 1500 ms
+/// WSL/poll auto-bump — long enough that a normal burst (git
+/// checkout, branch switch) ends well inside it, short enough that a
+/// never-quiet stream still reindexes within seconds.
+const MAX_DEBOUNCE_FACTOR: u32 = 6;
+
+/// Resolve the idle-flush debounce config from the `--debounce` flag,
+/// poll-mode detection, and the two env overrides (passed in as already
+/// parsed values so this stays pure and unit-testable).
+///
+/// Quiet gap precedence: `CQS_WATCH_DEBOUNCE_MS` env > `--debounce`
+/// flag, with the WSL/poll auto-bump (500 → 1500 ms) applied only when
+/// the user overrode neither. The poll watcher delivers events in scan
+/// batches, so the quiet gap there must exceed NTFS's 1 s mtime
+/// resolution or a single save risks double-firing.
+///
+/// Max latency: `CQS_WATCH_MAX_DEBOUNCE_MS` env, defaulting to
+/// [`MAX_DEBOUNCE_FACTOR`] × the resolved quiet gap, and clamped to at
+/// least the quiet gap (a cap below the gap would turn the idle-flush
+/// into a fixed window at the cap, which is never what the two knobs
+/// together are asking for).
+fn resolve_debounce(
+    flag_ms: u64,
+    use_poll: bool,
+    env_gap_ms: Option<u64>,
+    env_max_ms: Option<u64>,
+) -> DebounceConfig {
+    let quiet_gap_ms = if let Some(env_ms) = env_gap_ms {
+        env_ms
+    } else if flag_ms == 500 && use_poll {
+        tracing::info!(
+            "Auto-bumping watch quiet-gap to 1500ms for WSL/poll mode (override via --debounce or CQS_WATCH_DEBOUNCE_MS)"
+        );
+        1500
+    } else {
+        flag_ms
+    };
+    let max_latency_ms = env_max_ms
+        .unwrap_or_else(|| quiet_gap_ms.saturating_mul(u64::from(MAX_DEBOUNCE_FACTOR)))
+        .max(quiet_gap_ms);
+    DebounceConfig {
+        quiet_gap: Duration::from_millis(quiet_gap_ms),
+        max_latency: Duration::from_millis(max_latency_ms),
+    }
+}
+
+/// Pre-drain decision: should the watch loop flush the pending sets
+/// into a reindex cycle right now?
+///
+/// Evaluated on every loop iteration — event arrivals included, not
+/// just recv timeouts — because a continuous stream of events arriving
+/// faster than the recv timeout never reaches the timeout arm at all;
+/// only the max-latency condition can fire there.
+fn flush_due(state: &WatchState, debounce: &DebounceConfig) -> bool {
+    if state.pending_files.is_empty() && !state.pending_notes {
+        return false;
+    }
+    if state.last_event.elapsed() >= debounce.quiet_gap {
+        return true;
+    }
+    state
+        .first_pending_event
+        .is_some_and(|first| first.elapsed() >= debounce.max_latency)
+}
+
 /// Check if a path is under a WSL DrvFS automount root.
 ///
 /// Default automount root is `/mnt/`, but users can customize it via `automount.root`
@@ -395,7 +488,9 @@ fn build_gitignore_matcher(root: &Path) -> Option<ignore::gitignore::Gitignore> 
 /// # Arguments
 ///
 /// * `cli` - Command-line interface context
-/// * `debounce_ms` - Debounce interval in milliseconds for file change events
+/// * `debounce_ms` - Quiet gap in milliseconds for the idle-flush debounce:
+///   pending changes flush after this much event silence (see
+///   [`DebounceConfig`] for the full semantics including the max-latency cap)
 /// * `no_ignore` - If true, skips `.gitignore` filtering in the watch loop.
 ///   Mirrors the `cqs index --no-ignore` flag. When false (default), the watch
 ///   loop queries the project's `.gitignore` for every event and ignores matches.
@@ -447,25 +542,27 @@ pub fn cmd_watch(
         tracing::warn!("WSL detected: inotify may be unreliable on Windows filesystem mounts. Use --poll or 'cqs index' periodically.");
     }
 
-    // The 500ms default is tuned for inotify on native Linux.
-    // WSL DrvFS (/mnt/, //wsl$) exposes NTFS which has 1s mtime
-    // resolution — anything under ~1000ms risks double-fire for a single
-    // save. Poll mode also benefits from a longer window. When the user
-    // did not override via flag or env, auto-bump to 1500ms for these
-    // paths. `CQS_WATCH_DEBOUNCE_MS` takes precedence over the flag.
-    let debounce_ms = if let Some(env_ms) = std::env::var("CQS_WATCH_DEBOUNCE_MS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-    {
-        env_ms
-    } else if debounce_ms == 500 && use_poll {
-        tracing::info!(
-            "Auto-bumping watch debounce to 1500ms for WSL/poll mode (override via --debounce or CQS_WATCH_DEBOUNCE_MS)"
-        );
-        1500
-    } else {
-        debounce_ms
-    };
+    // Idle-flush debounce resolution. `CQS_WATCH_DEBOUNCE_MS` is the
+    // quiet gap (takes precedence over --debounce; WSL/poll auto-bump
+    // 500 → 1500 ms because NTFS mtime resolution is 1 s and the poll
+    // watcher delivers scan batches); `CQS_WATCH_MAX_DEBOUNCE_MS` is
+    // the max-latency cap, defaulting to 6× the quiet gap. See
+    // `DebounceConfig` for the flush semantics.
+    let debounce = resolve_debounce(
+        debounce_ms,
+        use_poll,
+        std::env::var("CQS_WATCH_DEBOUNCE_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok()),
+        std::env::var("CQS_WATCH_MAX_DEBOUNCE_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok()),
+    );
+    tracing::info!(
+        quiet_gap_ms = debounce.quiet_gap.as_millis() as u64,
+        max_latency_ms = debounce.max_latency.as_millis() as u64,
+        "watch debounce resolved (idle-flush)"
+    );
 
     let project_cqs_dir = cqs::resolve_index_dir(&root);
 
@@ -910,7 +1007,6 @@ pub fn cmd_watch(
 
     watcher.watch(&root, RecursiveMode::Recursive)?;
 
-    let debounce = Duration::from_millis(debounce_ms);
     let notes_path = root.join("docs/notes.toml");
     let cqs_dir = dunce::canonicalize(&cqs_dir).unwrap_or_else(|e| {
         tracing::debug!(path = %cqs_dir.display(), error = %e, "canonicalize failed, using original");
@@ -1176,6 +1272,7 @@ pub fn cmd_watch(
         pending_files: HashSet::new(),
         pending_notes: false,
         last_event: std::time::Instant::now(),
+        first_pending_event: None,
         // Track last-indexed mtime per file to skip duplicate WSL/NTFS events.
         // On WSL, inotify over 9P delivers repeated events for the same file change.
         // Bounded: pruned when >10k entries or >1k entries on single-file reindex.
@@ -1289,11 +1386,15 @@ pub fn cmd_watch(
                     );
                     if queued > 0 {
                         // Reset `last_event` so the synthetic pending
-                        // entries are picked up by the very next
-                        // `should_process` tick (otherwise the debounce
-                        // window would still hold for `last_event`'s
-                        // worth of milliseconds).
+                        // entries flush one quiet-gap from queue time
+                        // (otherwise a stale `last_event` could fire
+                        // the flush mid-queue on a later tick). Arm the
+                        // max-latency clock too so a continuous event
+                        // stream can't starve the queued entries.
                         state.last_event = std::time::Instant::now();
+                        if state.first_pending_event.is_none() {
+                            state.first_pending_event = Some(state.last_event);
+                        }
                     }
                     // Sliding the periodic-tick clock keeps the two
                     // mechanisms from racing: the next periodic walk
@@ -1302,103 +1403,11 @@ pub fn cmd_watch(
                     last_reconcile = std::time::Instant::now();
                 }
 
-                let should_process = (!state.pending_files.is_empty() || state.pending_notes)
-                    && state.last_event.elapsed() >= debounce;
-
-                if should_process {
-                    cycles_since_clear = 0;
-
-                    // Acquire index lock before reindexing. If another process
-                    // (cqs index, cqs gc) holds it, skip this cycle.
-                    let lock = match try_acquire_index_lock(&cqs_dir) {
-                        Ok(Some(lock)) => lock,
-                        Ok(None) => {
-                            info!("Index lock held by another process, skipping reindex cycle");
-                            continue;
-                        }
-                        Err(e) => {
-                            warn!(error = %e, "Failed to create index lock file");
-                            continue;
-                        }
-                    };
-
-                    // Detect if `cqs index --force` replaced the database
-                    // while we were waiting. If so, reopen the Store before processing
-                    // any changes — otherwise writes go to the orphaned inode.
-                    let current_id = db_file_identity(&index_path);
-                    if current_id != db_id {
-                        info!("index.db replaced (likely cqs index --force), reopening store");
-                        drop(store);
-                        // Reuse the shared runtime on re-open so the
-                        // replacement store keeps running on the same
-                        // multi-thread worker pool as its predecessor.
-                        store = Store::open_with_runtime(&index_path, Arc::clone(&shared_rt))
-                            .with_context(|| {
-                                format!(
-                                    "Failed to re-open store at {} after DB replacement",
-                                    index_path.display()
-                                )
-                            })?;
-                        // Re-stamp the vendored prefix list on the fresh Store
-                        // — the OnceLock is per-instance and a brand-new Store
-                        // starts empty. Use the cached resolution from startup
-                        // so we don't re-read .cqs.toml mid-watch.
-                        store.set_vendored_prefixes(vendored_prefixes_for_store.clone());
-                        // db_id updated below in the cache-clear path.
-                        state.hnsw_index = None;
-                        state.incremental_count = 0;
-                        // Drop in-flight rebuild whose pending delta references
-                        // OLD DB chunk IDs. The rebuild thread sends into a
-                        // dropped receiver (no-op). Force a fresh rebuild on
-                        // the next threshold tick against the new DB.
-                        if state.pending_rebuild.take().is_some() {
-                            tracing::info!(
-                                "discarded in-flight HNSW rebuild after DB replacement; \
-                                 next threshold tick will rebuild against new DB",
-                            );
-                        }
-                    }
-
-                    if !state.pending_files.is_empty() {
-                        process_file_changes(&watch_cfg, &store, &mut state);
-                    }
-
-                    if state.pending_notes {
-                        state.pending_notes = false;
-                        process_note_changes(&root, &store, cli.quiet, &mut state);
-                    }
-
-                    // Clear stale OnceLock caches (call_graph_cache,
-                    // test_chunks_cache) after index changes. Clear caches
-                    // instead of a full re-open to avoid pool teardown +
-                    // runtime creation + PRAGMA setup on every reindex cycle
-                    // over a 24/7 systemd lifetime.
-                    store.clear_caches();
-                    db_id = db_file_identity(&index_path);
-
-                    // Periodically evict the global embedding cache so
-                    // long-running watch sessions don't let the shared
-                    // ~/.cache/cqs/embeddings.db grow past its
-                    // CQS_CACHE_MAX_SIZE cap (default 10GB). Gated by
-                    // `last_cache_evict.elapsed()` so we don't churn the
-                    // SQLite file on every single reindex cycle. Reuses the
-                    // shared runtime so this one-shot eviction piggybacks on
-                    // the existing worker pool.
-                    if last_cache_evict.elapsed() >= Duration::from_secs(3600) {
-                        let project_cqs_dir = cqs::resolve_index_dir(&root);
-                        let cache_path =
-                            cqs::cache::EmbeddingCache::project_default_path(&project_cqs_dir);
-                        super::batch::evict_embeddings_cache_with_runtime(
-                            &cache_path,
-                            "watch reindex cycle",
-                            Some(Arc::clone(&shared_rt)),
-                        );
-                        last_cache_evict = std::time::Instant::now();
-                    }
-
-                    // Release lock after all reindex work (including HNSW rebuild).
-                    drop(lock);
-                } else {
+                // Flush decision lives after the match (see the
+                // `flush_due` block below) so it is evaluated on event
+                // arrivals too, not just on quiet ticks. The idle
+                // housekeeping here only runs when no flush is due.
+                if !flush_due(&state, &debounce) {
                     // Age-only prune fires hourly on idle ticks regardless of
                     // map size. The size-gated `prune_last_indexed_mtime`
                     // still runs in the event path; this idle-tick variant
@@ -1600,11 +1609,15 @@ pub fn cmd_watch(
                                 shared_disk_files.as_ref(),
                             );
                             if queued > 0 {
-                                // Reset `last_event` so `process_file_changes`
-                                // observes the synthetic pending entries on
-                                // the very next debounce tick (otherwise the
-                                // idle threshold would still hold).
+                                // Reset `last_event` so the synthetic
+                                // pending entries flush one quiet-gap
+                                // from queue time; arm the max-latency
+                                // clock so a continuous event stream
+                                // can't starve them past the cap.
                                 state.last_event = std::time::Instant::now();
+                                if state.first_pending_event.is_none() {
+                                    state.first_pending_event = Some(state.last_event);
+                                }
                             }
                             last_reconcile = std::time::Instant::now();
                         }
@@ -1621,6 +1634,109 @@ pub fn cmd_watch(
             }
         }
 
+        // Pre-drain decision. Evaluated on every loop iteration —
+        // event arrivals included — because a continuous stream of
+        // events arriving faster than the 100 ms recv timeout never
+        // reaches the timeout arm at all; without this placement the
+        // max-latency cap could never fire under exactly the load it
+        // exists for.
+        if flush_due(&state, &debounce) {
+            cycles_since_clear = 0;
+
+            // Acquire index lock before reindexing. If another process
+            // (cqs index, cqs gc) holds it, skip this cycle.
+            let lock = match try_acquire_index_lock(&cqs_dir) {
+                Ok(Some(lock)) => lock,
+                Ok(None) => {
+                    info!("Index lock held by another process, skipping reindex cycle");
+                    continue;
+                }
+                Err(e) => {
+                    warn!(error = %e, "Failed to create index lock file");
+                    continue;
+                }
+            };
+
+            // Detect if `cqs index --force` replaced the database
+            // while we were waiting. If so, reopen the Store before processing
+            // any changes — otherwise writes go to the orphaned inode.
+            let current_id = db_file_identity(&index_path);
+            if current_id != db_id {
+                info!("index.db replaced (likely cqs index --force), reopening store");
+                drop(store);
+                // Reuse the shared runtime on re-open so the
+                // replacement store keeps running on the same
+                // multi-thread worker pool as its predecessor.
+                store = Store::open_with_runtime(&index_path, Arc::clone(&shared_rt))
+                    .with_context(|| {
+                        format!(
+                            "Failed to re-open store at {} after DB replacement",
+                            index_path.display()
+                        )
+                    })?;
+                // Re-stamp the vendored prefix list on the fresh Store
+                // — the OnceLock is per-instance and a brand-new Store
+                // starts empty. Use the cached resolution from startup
+                // so we don't re-read .cqs.toml mid-watch.
+                store.set_vendored_prefixes(vendored_prefixes_for_store.clone());
+                // db_id updated below in the cache-clear path.
+                state.hnsw_index = None;
+                state.incremental_count = 0;
+                // Drop in-flight rebuild whose pending delta references
+                // OLD DB chunk IDs. The rebuild thread sends into a
+                // dropped receiver (no-op). Force a fresh rebuild on
+                // the next threshold tick against the new DB.
+                if state.pending_rebuild.take().is_some() {
+                    tracing::info!(
+                        "discarded in-flight HNSW rebuild after DB replacement; \
+                         next threshold tick will rebuild against new DB",
+                    );
+                }
+            }
+
+            if !state.pending_files.is_empty() {
+                process_file_changes(&watch_cfg, &store, &mut state);
+            }
+
+            if state.pending_notes {
+                state.pending_notes = false;
+                process_note_changes(&root, &store, cli.quiet, &mut state);
+            }
+
+            // Clear stale OnceLock caches (call_graph_cache,
+            // test_chunks_cache) after index changes. Clear caches
+            // instead of a full re-open to avoid pool teardown +
+            // runtime creation + PRAGMA setup on every reindex cycle
+            // over a 24/7 systemd lifetime.
+            store.clear_caches();
+            db_id = db_file_identity(&index_path);
+
+            // Periodically evict the global embedding cache so
+            // long-running watch sessions don't let the shared
+            // ~/.cache/cqs/embeddings.db grow past its
+            // CQS_CACHE_MAX_SIZE cap (default 10GB). Gated by
+            // `last_cache_evict.elapsed()` so we don't churn the
+            // SQLite file on every single reindex cycle. Reuses the
+            // shared runtime so this one-shot eviction piggybacks on
+            // the existing worker pool.
+            if last_cache_evict.elapsed() >= Duration::from_secs(3600) {
+                let project_cqs_dir = cqs::resolve_index_dir(&root);
+                let cache_path = cqs::cache::EmbeddingCache::project_default_path(&project_cqs_dir);
+                super::batch::evict_embeddings_cache_with_runtime(
+                    &cache_path,
+                    "watch reindex cycle",
+                    Some(Arc::clone(&shared_rt)),
+                );
+                last_cache_evict = std::time::Instant::now();
+            }
+
+            // Release lock after all reindex work (including HNSW rebuild).
+            drop(lock);
+
+            // Pending sets drained — disarm the max-latency clock so
+            // the next accepted event starts a fresh burst.
+            state.first_pending_event = None;
+        }
         // Publish freshness snapshot once per outer iteration.
         // Cheap — counter reads, one optional `metadata()` on `index.db`,
         // and a brief write-lock acquire. Runs every ~100 ms cycle so the

--- a/src/cli/watch/tests.rs
+++ b/src/cli/watch/tests.rs
@@ -85,6 +85,7 @@ fn test_watch_state() -> WatchState {
         pending_files: HashSet::new(),
         pending_notes: false,
         last_event: std::time::Instant::now(),
+        first_pending_event: None,
         last_indexed_mtime: HashMap::new(),
         hnsw_index: None,
         incremental_count: 0,
@@ -2120,4 +2121,234 @@ fn publish_watch_snapshot_ops_zeros_without_daemon() {
     assert!(ops.last_reindex.is_none());
     assert!(ops.last_error.is_none());
     assert_eq!(ops.slots.len(), 1, "active slot entry is always present");
+}
+
+// ===== Idle-flush debounce tests =====
+//
+// The watch loop flushes the pending sets when EITHER the quiet gap
+// elapses since the last accepted event OR the oldest pending event has
+// waited out the max-latency cap. These tests pin the pure decision
+// (`flush_due`) and the knob resolution (`resolve_debounce`) without
+// touching the filesystem or sleeping.
+
+fn dbc(gap_ms: u64, max_ms: u64) -> DebounceConfig {
+    DebounceConfig {
+        quiet_gap: Duration::from_millis(gap_ms),
+        max_latency: Duration::from_millis(max_ms),
+    }
+}
+
+fn backdate(ms: u64) -> std::time::Instant {
+    std::time::Instant::now()
+        .checked_sub(Duration::from_millis(ms))
+        .expect("test instant backdate")
+}
+
+#[test]
+fn resolve_debounce_defaults() {
+    let cfg = resolve_debounce(500, false, None, None);
+    assert_eq!(cfg.quiet_gap, Duration::from_millis(500));
+    assert_eq!(
+        cfg.max_latency,
+        Duration::from_millis(500 * u64::from(MAX_DEBOUNCE_FACTOR))
+    );
+}
+
+#[test]
+fn resolve_debounce_wsl_poll_auto_bump_applies_to_quiet_gap() {
+    let cfg = resolve_debounce(500, true, None, None);
+    assert_eq!(cfg.quiet_gap, Duration::from_millis(1500));
+    assert_eq!(
+        cfg.max_latency,
+        Duration::from_millis(1500 * u64::from(MAX_DEBOUNCE_FACTOR))
+    );
+}
+
+#[test]
+fn resolve_debounce_env_gap_overrides_flag_and_suppresses_bump() {
+    let cfg = resolve_debounce(500, true, Some(800), None);
+    assert_eq!(cfg.quiet_gap, Duration::from_millis(800));
+    assert_eq!(
+        cfg.max_latency,
+        Duration::from_millis(800 * u64::from(MAX_DEBOUNCE_FACTOR))
+    );
+}
+
+#[test]
+fn resolve_debounce_explicit_flag_suppresses_bump() {
+    let cfg = resolve_debounce(1000, true, None, None);
+    assert_eq!(cfg.quiet_gap, Duration::from_millis(1000));
+}
+
+#[test]
+fn resolve_debounce_env_max_override() {
+    let cfg = resolve_debounce(500, false, None, Some(2000));
+    assert_eq!(cfg.max_latency, Duration::from_millis(2000));
+}
+
+#[test]
+fn resolve_debounce_max_clamped_to_at_least_quiet_gap() {
+    let cfg = resolve_debounce(500, false, None, Some(100));
+    assert_eq!(
+        cfg.max_latency,
+        Duration::from_millis(500),
+        "a cap below the quiet gap would invert the two knobs' contract"
+    );
+}
+
+#[test]
+fn flush_due_no_pending_never_flushes() {
+    let mut state = test_watch_state();
+    // Even with a long-stale last event and an armed burst clock,
+    // empty pending sets never flush.
+    state.last_event = backdate(60_000);
+    state.first_pending_event = Some(backdate(60_000));
+    assert!(!flush_due(&state, &dbc(500, 3000)));
+}
+
+#[test]
+fn flush_due_single_save_flushes_at_quiet_gap() {
+    // Gate: single-save latency no worse than the old fixed window —
+    // one event flushes exactly one quiet gap after it arrived.
+    let mut state = test_watch_state();
+    state.pending_files.insert(PathBuf::from("src/lib.rs"));
+    state.last_event = backdate(499);
+    state.first_pending_event = Some(backdate(499));
+    assert!(
+        !flush_due(&state, &dbc(500, 3000)),
+        "not yet — quiet gap has not elapsed"
+    );
+    state.last_event = backdate(500);
+    state.first_pending_event = Some(backdate(500));
+    assert!(flush_due(&state, &dbc(500, 3000)));
+}
+
+#[test]
+fn flush_due_burst_fires_quiet_gap_after_last_event_not_first() {
+    // Gate: a multi-file burst produces one flush fired ~quiet-gap
+    // after the LAST event. Simulated burst: first event 600 ms ago
+    // (already past one full quiet gap), last event 100 ms ago.
+    let mut state = test_watch_state();
+    for i in 0..200 {
+        state
+            .pending_files
+            .insert(PathBuf::from(format!("f{i}.rs")));
+    }
+    state.first_pending_event = Some(backdate(600));
+    state.last_event = backdate(100);
+    assert!(
+        !flush_due(&state, &dbc(500, 3000)),
+        "burst still hot — quiet gap restarts on every event"
+    );
+    state.last_event = backdate(500);
+    assert!(
+        flush_due(&state, &dbc(500, 3000)),
+        "quiet gap elapsed since the last event of the burst"
+    );
+}
+
+#[test]
+fn flush_due_disarmed_after_flush_does_not_refire() {
+    // Gate: ONE flush per burst. After the flush block drains the
+    // pending sets and clears `first_pending_event`, a stale
+    // `last_event` alone must not refire.
+    let mut state = test_watch_state();
+    state.last_event = backdate(10_000);
+    state.first_pending_event = None;
+    state.pending_files.clear();
+    state.pending_notes = false;
+    assert!(!flush_due(&state, &dbc(500, 3000)));
+}
+
+#[test]
+fn flush_due_continuous_stream_capped_by_max_latency() {
+    // Gate: a stream that never goes quiet still flushes within the
+    // cap. The quiet-gap timer keeps restarting (last_event is fresh)
+    // but the burst clock has hit the cap.
+    let mut state = test_watch_state();
+    state.pending_files.insert(PathBuf::from("gen.rs"));
+    state.last_event = backdate(50);
+    state.first_pending_event = Some(backdate(3000));
+    assert!(flush_due(&state, &dbc(500, 3000)));
+}
+
+#[test]
+fn flush_due_continuous_stream_below_cap_waits() {
+    let mut state = test_watch_state();
+    state.pending_files.insert(PathBuf::from("gen.rs"));
+    state.last_event = backdate(50);
+    state.first_pending_event = Some(backdate(2000));
+    assert!(!flush_due(&state, &dbc(500, 3000)));
+}
+
+#[test]
+fn flush_due_notes_only_pending_flushes() {
+    let mut state = test_watch_state();
+    state.pending_notes = true;
+    state.last_event = backdate(500);
+    state.first_pending_event = Some(backdate(500));
+    assert!(flush_due(&state, &dbc(500, 3000)));
+}
+
+#[test]
+fn collect_events_arms_burst_clock_once_per_burst() {
+    // `first_pending_event` is sticky: the first accepted event arms
+    // it, later events in the same burst leave it untouched (only
+    // `last_event` keeps advancing). The flush block disarms it.
+    let root = PathBuf::from("/tmp/test_project");
+    let cqs_dir = PathBuf::from("/tmp/test_project/.cqs");
+    let notes_path = PathBuf::from("/tmp/test_project/docs/notes.toml");
+    let supported: HashSet<&str> = ["rs"].iter().cloned().collect();
+    let cfg = test_watch_config(&root, &cqs_dir, &notes_path, &supported);
+    let mut state = test_watch_state();
+    assert!(state.first_pending_event.is_none());
+
+    let kind = EventKind::Modify(notify::event::ModifyKind::Data(
+        notify::event::DataChange::Content,
+    ));
+    collect_events(
+        &make_event(vec![PathBuf::from("/tmp/test_project/a.rs")], kind),
+        &cfg,
+        &mut state,
+    );
+    let armed = state
+        .first_pending_event
+        .expect("first accepted event arms the burst clock");
+
+    collect_events(
+        &make_event(vec![PathBuf::from("/tmp/test_project/b.rs")], kind),
+        &cfg,
+        &mut state,
+    );
+    assert_eq!(
+        state.first_pending_event,
+        Some(armed),
+        "second event of the burst must not restart the burst clock"
+    );
+    assert_eq!(state.pending_files.len(), 2);
+}
+
+#[test]
+fn collect_events_filtered_event_does_not_arm_burst_clock() {
+    let root = PathBuf::from("/tmp/test_project");
+    let cqs_dir = PathBuf::from("/tmp/test_project/.cqs");
+    let notes_path = PathBuf::from("/tmp/test_project/docs/notes.toml");
+    let supported: HashSet<&str> = ["rs"].iter().cloned().collect();
+    let cfg = test_watch_config(&root, &cqs_dir, &notes_path, &supported);
+    let mut state = test_watch_state();
+
+    collect_events(
+        &make_event(
+            vec![PathBuf::from("/tmp/test_project/readme.txt")],
+            EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Content,
+            )),
+        ),
+        &cfg,
+        &mut state,
+    );
+    assert!(
+        state.first_pending_event.is_none(),
+        "filtered events queue nothing and must not arm the burst clock"
+    );
 }


### PR DESCRIPTION
Closes #1716.

## What

Watch debounce becomes idle-flush with a max-latency cap. `flush_due` evaluates every loop iteration:
- pending + `last_event.elapsed() >= quiet_gap` → flush (timer restarts per accepted event, so a `git checkout` burst coalesces into one cycle fired ~quiet-gap after the burst's **last** event)
- pending + `first_pending_event.elapsed() >= max_latency` → flush (never-quiet streams still flush; new `WatchState` field armed by `collect_events` on the first event after a flush)

**Latent bug found and fixed by the restructure:** the old flush decision lived only in the `RecvTimeoutError::Timeout` arm — events arriving faster than the 100ms recv timeout starved the flush decision entirely. The decision now runs after the match, on the event path too.

## Knobs

- `CQS_WATCH_DEBOUNCE_MS` keeps its name and precedence, now means the quiet gap: 500ms inotify, WSL/poll auto-bump to 1500ms preserved.
- `CQS_WATCH_MAX_DEBOUNCE_MS` new: default 6× the gap (3s inotify / 9s WSL-poll), clamped ≥ gap. README env-var table updated (docs guard passes).
- Resolution is pure (`resolve_debounce` takes pre-parsed values) so tests don't race on env vars.

## Verification

- Watch module 81 passed — all existing `collect_events_*` unchanged; 14 new tests: burst-fires-after-last-event, max-latency cap, single-save latency unchanged, one-flush-per-burst disarm, sticky burst clock, filtered-events-don't-arm, resolution.
- env_var_docs 9 passed. Build warning-free, clippy -D warnings clean, provenance lint clean, fmt.
- One comment corrected: the on-demand-reconcile note claimed `last_event` reset flushes entries "on the very next tick" — it defers them one full gap (behavior unchanged, comment now true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
