### PR TITLE
fix: 256KiB daemon-client thread stacks + loopback URL for wildcard-bind --open (closes #1723)

### DIFF
--- a/src/cli/commands/serve.rs
+++ b/src/cli/commands/serve.rs
@@ -94,7 +94,10 @@ pub(crate) fn cmd_serve(port: u16, bind: String, open: bool, no_auth: bool) -> R
                 );
             }
             None => {
-                let url = format!("http://{bind_addr}");
+                // Wildcard binds (0.0.0.0 / [::]) are rejected by browsers
+                // as connect targets; launch the loopback equivalent instead.
+                // The bind itself (run_server below) is unchanged.
+                let url = cqs::serve::loopback_open_url(bind_addr);
                 if let Err(e) = open_browser(&url) {
                     tracing::warn!(error = %e, "failed to open browser");
                     eprintln!("WARN: --open requested but failed to launch browser: {e}");

--- a/src/cli/watch/daemon.rs
+++ b/src/cli/watch/daemon.rs
@@ -229,8 +229,13 @@ pub(super) fn spawn_daemon_thread(
                     // read/parse/write I/O happens in parallel. Only
                     // the dispatch itself is serialized via the
                     // BatchContext mutex inside handle_socket_client.
+                    // 256 KiB pinned stack: the handler path is shallow
+                    // (read/parse/dispatch/write), and at the max-clients
+                    // cap the 2 MiB platform default would reserve ~224 MiB
+                    // of virtual address space for nothing.
                     if let Err(e) = std::thread::Builder::new()
                         .name("cqs-daemon-client".to_string())
+                        .stack_size(256 * 1024)
                         .spawn(move || {
                             handle_socket_client(stream, &ctx_clone);
                             in_flight_clone.fetch_sub(1, Ordering::AcqRel);

--- a/src/serve/mod.rs
+++ b/src/serve/mod.rs
@@ -173,7 +173,7 @@ pub fn run_server(
                     }
                 }
                 None => {
-                    println!("cqs serve listening on http://{actual}");
+                    println!("{}", no_auth_banner_line(actual));
                     eprintln!(
                         "WARN: --no-auth in use — anyone with network access to {actual} \
                          can read this index"
@@ -197,6 +197,31 @@ pub fn run_server(
     })?;
 
     Ok(())
+}
+
+/// URL to show in banners and hand to the `--open` browser launch.
+///
+/// Wildcard binds (`0.0.0.0`, `[::]`) are valid listen addresses but
+/// useless connect targets — browsers reject `http://0.0.0.0:8080`.
+/// Map them to the matching loopback (`127.0.0.1` / `[::1]`) for the
+/// displayed/launched URL only; the bind itself is unchanged. Concrete
+/// addresses pass through untouched.
+pub fn loopback_open_url(bind_addr: SocketAddr) -> String {
+    let mut display = bind_addr;
+    if display.ip().is_unspecified() {
+        let loopback = match display.ip() {
+            std::net::IpAddr::V4(_) => std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            std::net::IpAddr::V6(_) => std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+        };
+        display.set_ip(loopback);
+    }
+    format!("http://{display}")
+}
+
+/// The no-auth "listening on" banner line. Uses [`loopback_open_url`] so
+/// a wildcard bind still prints a URL a browser will accept.
+fn no_auth_banner_line(actual: SocketAddr) -> String {
+    format!("cqs serve listening on {}", loopback_open_url(actual))
 }
 
 /// Race a signal-driven shutdown against an idle-driven shutdown. With

--- a/src/serve/tests.rs
+++ b/src/serve/tests.rs
@@ -2089,3 +2089,38 @@ mod auth_tests {
         drop(fixture);
     }
 }
+
+// ===== loopback URL mapping for `--open` / the no-auth banner =====
+//
+// Wildcard binds are valid listen addresses but browsers reject them as
+// connect targets; the displayed/launched URL must map to loopback while
+// concrete addresses pass through untouched.
+
+#[test]
+fn loopback_open_url_maps_ipv4_wildcard_to_localhost() {
+    let addr: SocketAddr = "0.0.0.0:8080".parse().expect("parse wildcard v4");
+    assert_eq!(super::loopback_open_url(addr), "http://127.0.0.1:8080");
+}
+
+#[test]
+fn loopback_open_url_maps_ipv6_wildcard_to_localhost() {
+    let addr: SocketAddr = "[::]:8080".parse().expect("parse wildcard v6");
+    assert_eq!(super::loopback_open_url(addr), "http://[::1]:8080");
+}
+
+#[test]
+fn loopback_open_url_passes_through_concrete_addrs() {
+    for raw in ["192.168.1.5:9090", "127.0.0.1:8080", "[fe80::1]:8080"] {
+        let addr: SocketAddr = raw.parse().expect("parse concrete addr");
+        assert_eq!(super::loopback_open_url(addr), format!("http://{addr}"));
+    }
+}
+
+#[test]
+fn no_auth_banner_uses_loopback_under_wildcard_bind() {
+    let addr: SocketAddr = "0.0.0.0:8080".parse().expect("parse wildcard v4");
+    assert_eq!(
+        super::no_auth_banner_line(addr),
+        "cqs serve listening on http://127.0.0.1:8080"
+    );
+}


### PR DESCRIPTION
Closes #1723 — the two residues salvaged from this week's stash forensics (seven 6-8-week-old stashes audited; everything else had landed via the audit-wave PRs).

## 1. Daemon-client thread stack pin

`cqs-daemon-client` handler threads now spawn with `stack_size(256 * 1024)` instead of the 2 MiB default — the handler path is shallow, and at the 128-client cap the default costs ~224 MiB of virtual address space for nothing. The spawn site already had full `thread::Builder` Result handling from #1720's in-flight-counter hoist (warn, decrement, drop connection on failure); the delta here is the pin itself. No test for the spawn-failure arm: forcing `Builder::spawn` to fail requires OS-level thread exhaustion, and a spawn-abstraction trait around a pre-existing 4-line error arm is a disproportionate seam — behavior is visible by inspection.

## 2. Loopback URL for wildcard-bind `--open`

`--no-auth --bind 0.0.0.0 --open` used to launch `http://0.0.0.0:PORT/`, which browsers reject. New `serve::loopback_open_url`: `0.0.0.0` → `127.0.0.1`, `[::]` → `[::1]` via `is_unspecified()`, concrete addrs pass through; the bind itself is unchanged. Applied to the no-auth banner line and the CLI browser-launch path. The "anyone with network access to {addr}" warning intentionally keeps the real bind address (it describes the bind, not a URL). Auth-on `--open` suppression untouched.

## Verification

4 new tests (IPv4/IPv6 wildcard mapping, concrete-addr pass-through incl. link-local, banner-line pin); serve 93 pass, daemon-filtered 36 pass. Build warning-free, clippy -D warnings clean, fmt, provenance lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
