### PR TITLE
fix(cli): translate the daemon slim envelope to the CLI surface shape

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -435,20 +435,46 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Result<Option<Strin
         };
         let text = match output {
             serde_json::Value::String(s) => s.clone(),
-            // Pretty-print to match CLI `emit_json` so agents diffing
-            // `cqs --json …` output between CLI and daemon modes don't hit
-            // spurious whitespace drift. One re-encode cost; worth the parity
-            // with the in-process path.
-            other => match serde_json::to_string_pretty(other) {
-                Ok(s) => s,
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        stage = "parse",
-                        "Daemon ok response missing/unserializable output — falling back to CLI"
-                    );
-                    return Ok(None);
+            // JSON outputs from the daemon arrive in the slim batch envelope
+            // (`{"data": …}` / `{"error": …}` from `wrap_value`/`wrap_error`).
+            // That envelope is the BATCH/JSONL contract — the CLI surface
+            // emits a bare payload (or the full v1 envelope under
+            // CQS_OUTPUT_FORMAT=v1), and its shape must not depend on whether
+            // a daemon happened to serve the query. Translate before
+            // printing; anything that isn't a slim envelope prints verbatim.
+            other => match cqs::daemon_translate::classify_slim_envelope(other) {
+                Some(cqs::daemon_translate::SlimEnvelope::Data { payload, meta }) => {
+                    match crate::cli::json_envelope::daemon_payload_to_cli_text(payload, meta) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                stage = "parse",
+                                "Daemon payload presentation failed — falling back to CLI"
+                            );
+                            return Ok(None);
+                        }
+                    }
                 }
+                Some(cqs::daemon_translate::SlimEnvelope::Error { code, message }) => {
+                    // Command-level failure from the daemon: surface as a real
+                    // error (non-zero exit), matching the in-process path,
+                    // instead of printing an error envelope with exit 0.
+                    return Err(anyhow::anyhow!(
+                        "daemon error: {code}: {message}\nhint: set CQS_NO_DAEMON=1 to bypass the daemon"
+                    ));
+                }
+                None => match serde_json::to_string_pretty(other) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            stage = "parse",
+                            "Daemon ok response missing/unserializable output — falling back to CLI"
+                        );
+                        return Ok(None);
+                    }
+                },
             },
         };
         return Ok(Some(text));

--- a/src/cli/json_envelope.rs
+++ b/src/cli/json_envelope.rs
@@ -493,6 +493,51 @@ fn emit_bare_payload_stdout<T: Serialize>(value: &T) -> Result<()> {
 /// Same retry-on-NaN guarantee as [`emit_json`]. Accepts `&str` for the
 /// code so legacy callers using `error_codes::FOO` keep working; new code
 /// should prefer [`ErrorCode::as_str`] for compile-checked emission.
+/// Render a daemon slim-envelope payload exactly as the in-process CLI
+/// would have presented it: bare pretty-printed payload under the V2Bare
+/// default (with the daemon's `_meta` spliced into object payloads, mirroring
+/// [`emit_json`]'s bare path), or the full v1 envelope under
+/// `CQS_OUTPUT_FORMAT=v1`. This keeps the CLI's wire shape independent of
+/// whether a daemon happened to serve the query.
+///
+/// Non-object payloads can't carry `_meta`; the operational signal degrades
+/// to a `tracing::warn!`, same as the in-process bare path.
+pub fn daemon_payload_to_cli_text(
+    payload: &serde_json::Value,
+    meta: Option<&serde_json::Value>,
+) -> Result<String> {
+    daemon_payload_to_cli_text_with(OutputFormat::current(), payload, meta)
+}
+
+/// Format-explicit core of [`daemon_payload_to_cli_text`], split out so tests
+/// can pin both branches without racing the process-cached env read.
+fn daemon_payload_to_cli_text_with(
+    format: OutputFormat,
+    payload: &serde_json::Value,
+    meta: Option<&serde_json::Value>,
+) -> Result<String> {
+    if format.emits_bare_payload() {
+        let mut v = payload.clone();
+        if let Some(m) = meta {
+            match v {
+                serde_json::Value::Object(ref mut map) => {
+                    map.insert("_meta".to_string(), m.clone());
+                }
+                _ => tracing::warn!(
+                    "daemon _meta dropped: bare payload is not a JSON object \
+                     (signal preserved on the daemon side; see daemon logs)"
+                ),
+            }
+        }
+        // Trailing newline for parity with the in-process `println!` paths.
+        Ok(format!("{}\n", serde_json::to_string_pretty(&v)?))
+    } else {
+        let env = Envelope::ok(payload);
+        let buf = serde_json::to_value(&env)?;
+        Ok(format!("{}\n", format_envelope_to_string(&buf)?))
+    }
+}
+
 pub fn emit_json_error(code: &str, message: &str) -> Result<()> {
     let env = Envelope::<serde_json::Value>::err(code, message);
     let buf = serde_json::to_value(&env)?;
@@ -1104,5 +1149,41 @@ mod tests {
         // find their fields.
         assert_eq!(second_wrap["data"]["data"]["name"], "foo");
         assert_eq!(second_wrap["data"]["data"]["count"], 3);
+    }
+
+    #[test]
+    fn daemon_payload_bare_splices_meta_into_object() {
+        let payload = serde_json::json!({"query": "q", "results": []});
+        let meta = serde_json::json!({"worktree_stale": true});
+        let s = daemon_payload_to_cli_text_with(OutputFormat::V2Bare, &payload, Some(&meta))
+            .expect("render");
+        assert!(s.ends_with('\n'), "trailing newline for println parity");
+        let v: serde_json::Value = serde_json::from_str(&s).expect("valid JSON");
+        assert_eq!(v["query"], "q");
+        assert_eq!(v["_meta"]["worktree_stale"], true);
+        assert!(
+            v.get("data").is_none(),
+            "no envelope key on the bare surface"
+        );
+    }
+
+    #[test]
+    fn daemon_payload_bare_array_drops_meta_with_shape_intact() {
+        let payload = serde_json::json!([1, 2, 3]);
+        let meta = serde_json::json!({"worktree_stale": true});
+        let s = daemon_payload_to_cli_text_with(OutputFormat::V2Bare, &payload, Some(&meta))
+            .expect("render");
+        let v: serde_json::Value = serde_json::from_str(&s).expect("valid JSON");
+        assert_eq!(v, serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn daemon_payload_v1_rebuilds_full_envelope() {
+        let payload = serde_json::json!({"k": 1});
+        let s = daemon_payload_to_cli_text_with(OutputFormat::V1Envelope, &payload, None)
+            .expect("render");
+        let v: serde_json::Value = serde_json::from_str(&s).expect("valid JSON");
+        assert_eq!(v["data"]["k"], 1);
+        assert!(v.get("version").is_some(), "v1 envelope carries version");
     }
 }

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -148,6 +148,53 @@ pub fn resolve_daemon_timeout_ms() -> std::time::Duration {
 /// Extract the value of `--model` from the raw argv, if present. Used by the
 /// caller to emit a "daemon ignores your --model" warning without duplicating
 /// the arg-scanning logic here. Supports both `--model VAL` and `--model=VAL`.
+/// Classification of a daemon dispatch output against the slim batch
+/// envelope contract (`wrap_value` / `wrap_error` in `json_envelope`):
+/// `{"data": <payload>}` or `{"error": {"code","message"}}`, each with an
+/// optional `_meta` sibling and NO other keys. Full v1 envelopes (which
+/// carry `version`) and payloads that merely contain a `data` field among
+/// other keys deliberately do not match — they pass through verbatim.
+pub enum SlimEnvelope<'a> {
+    /// Success: the inner payload plus the daemon's `_meta`, if any.
+    Data {
+        payload: &'a serde_json::Value,
+        meta: Option<&'a serde_json::Value>,
+    },
+    /// Failure: redacted code + message from the slim error object.
+    Error { code: String, message: String },
+}
+
+/// Match `v` against the slim envelope shapes. Returns `None` for anything
+/// that isn't exactly a slim envelope, so callers print unrecognized output
+/// unchanged.
+pub fn classify_slim_envelope(v: &serde_json::Value) -> Option<SlimEnvelope<'_>> {
+    let obj = v.as_object()?;
+    if obj.is_empty()
+        || !obj
+            .keys()
+            .all(|k| k == "data" || k == "error" || k == "_meta")
+    {
+        return None;
+    }
+    let meta = obj.get("_meta");
+    match (obj.get("data"), obj.get("error")) {
+        (Some(payload), None) => Some(SlimEnvelope::Data { payload, meta }),
+        (None, Some(err)) => Some(SlimEnvelope::Error {
+            code: err
+                .get("code")
+                .and_then(|c| c.as_str())
+                .unwrap_or("internal")
+                .to_string(),
+            message: err
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("daemon error")
+                .to_string(),
+        }),
+        _ => None,
+    }
+}
+
 pub fn stripped_model_value(raw: &[String]) -> Option<String> {
     let mut it = raw.iter();
     while let Some(arg) = it.next() {
@@ -1971,5 +2018,60 @@ mod tests {
             serde_json::Value::Null,
             "the data:null payload is returned verbatim; the error field is dropped",
         );
+    }
+
+    #[test]
+    fn classify_slim_data_envelope() {
+        let v = serde_json::json!({"data": {"x": 1}});
+        match classify_slim_envelope(&v) {
+            Some(SlimEnvelope::Data { payload, meta }) => {
+                assert_eq!(payload, &serde_json::json!({"x": 1}));
+                assert!(meta.is_none());
+            }
+            other => panic!("expected Data, got {:?}", other.is_some()),
+        }
+        let v = serde_json::json!({"data": [1, 2], "_meta": {"worktree_stale": true}});
+        match classify_slim_envelope(&v) {
+            Some(SlimEnvelope::Data { payload, meta }) => {
+                assert_eq!(payload, &serde_json::json!([1, 2]));
+                assert!(meta.is_some());
+            }
+            _ => panic!("expected Data with meta"),
+        }
+    }
+
+    #[test]
+    fn classify_slim_error_envelope() {
+        let v = serde_json::json!({"error": {"code": "not_found", "message": "nope"}});
+        match classify_slim_envelope(&v) {
+            Some(SlimEnvelope::Error { code, message }) => {
+                assert_eq!(code, "not_found");
+                assert_eq!(message, "nope");
+            }
+            _ => panic!("expected Error"),
+        }
+    }
+
+    #[test]
+    fn classify_rejects_non_slim_shapes() {
+        // Full v1 envelope (has version) passes through untouched.
+        assert!(classify_slim_envelope(&serde_json::json!(
+            {"data": null, "error": null, "version": 1}
+        ))
+        .is_none());
+        // Payload that merely contains a data field among other keys.
+        assert!(classify_slim_envelope(&serde_json::json!(
+            {"data": 1, "other": 2}
+        ))
+        .is_none());
+        // Arrays, scalars, empty objects.
+        assert!(classify_slim_envelope(&serde_json::json!([1])).is_none());
+        assert!(classify_slim_envelope(&serde_json::json!(7)).is_none());
+        assert!(classify_slim_envelope(&serde_json::json!({})).is_none());
+        // data AND error together is not the slim contract.
+        assert!(classify_slim_envelope(&serde_json::json!(
+            {"data": 1, "error": {"code": "x", "message": "y"}}
+        ))
+        .is_none());
     }
 }

--- a/tests/daemon_forward_test.rs
+++ b/tests/daemon_forward_test.rs
@@ -162,7 +162,19 @@ struct MockDaemon {
 }
 
 impl MockDaemon {
+    /// Like [`MockDaemon::new`] but replies with an arbitrary pre-framed
+    /// response line (for structured `output` values rather than string
+    /// sentinels).
+    fn with_response_line(sock_path: PathBuf, response: String) -> Self {
+        Self::spawn(sock_path, response)
+    }
+
     fn new(sock_path: PathBuf, sentinel: &'static str) -> Self {
+        let response = format!(r#"{{"status":"ok","output":"{sentinel}"}}"#);
+        Self::spawn(sock_path, response)
+    }
+
+    fn spawn(sock_path: PathBuf, response: String) -> Self {
         let listener = UnixListener::bind(&sock_path)
             .unwrap_or_else(|e| panic!("bind {} failed: {e}", sock_path.display()));
         listener
@@ -174,7 +186,6 @@ impl MockDaemon {
         let c2 = Arc::clone(&conn_count);
         let s2 = Arc::clone(&stop);
 
-        let response = format!(r#"{{"status":"ok","output":"{sentinel}"}}"#);
         let handle = std::thread::spawn(move || {
             let deadline = Instant::now() + Duration::from_secs(30);
             while !s2.load(Ordering::SeqCst) && Instant::now() < deadline {
@@ -886,5 +897,110 @@ fn test_status_watch_no_daemon_exits_one_with_structured_error() {
     assert!(
         stdout.contains("\"error\"") || stdout.contains("\"code\""),
         "stdout should contain a JSON error envelope, got: {stdout}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Daemon slim-envelope translation: the CLI surface emits a bare payload
+// (or full v1 envelope under CQS_OUTPUT_FORMAT=v1) regardless of whether a
+// daemon served the query. Regression seed for the {"data": ...} leak that
+// /cqs-verify caught on 2026-06-10: daemon-forwarded output printed the
+// batch envelope verbatim, so output shape depended on daemon presence.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Bare-default binary command: cqs_v1 minus the v1 pin.
+fn cqs_bare() -> assert_cmd::Command {
+    #[allow(deprecated)]
+    let mut c = assert_cmd::Command::cargo_bin("cqs").expect("Failed to find cqs binary");
+    c.env_remove("CQS_OUTPUT_FORMAT");
+    c
+}
+
+fn slim_envelope_response() -> String {
+    r#"{"status":"ok","output":{"data":{"notes":[],"count":0},"_meta":{"worktree_stale":true}}}"#
+        .to_string()
+}
+
+#[test]
+fn test_slim_data_envelope_unwraps_to_bare_payload() {
+    let (dir, sock_path) = setup_project();
+    let _mock = MockDaemon::with_response_line(sock_path, slim_envelope_response());
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+
+    let mut cmd = cqs_bare();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["notes", "list", "--json"]);
+
+    let output = cmd.output().expect("cqs notes list spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "stdout=<{stdout}>");
+
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("stdout is JSON");
+    assert!(
+        v.get("data").is_none(),
+        "bare surface must not carry the batch envelope; got <{stdout}>"
+    );
+    assert_eq!(v["count"], 0, "payload fields at top level");
+    assert_eq!(
+        v["_meta"]["worktree_stale"], true,
+        "daemon _meta spliced onto the bare object payload"
+    );
+    assert!(
+        stdout.ends_with('\n'),
+        "trailing newline parity with println"
+    );
+}
+
+#[test]
+fn test_slim_data_envelope_rebuilds_v1_envelope() {
+    let (dir, sock_path) = setup_project();
+    let _mock = MockDaemon::with_response_line(sock_path, slim_envelope_response());
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+
+    let mut cmd = cqs(); // v1-pinned
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["notes", "list", "--json"]);
+
+    let output = cmd.output().expect("cqs notes list spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "stdout=<{stdout}>");
+
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("stdout is JSON");
+    assert_eq!(v["data"]["count"], 0, "v1 surface keeps the full envelope");
+    assert!(v.get("version").is_some(), "v1 envelope carries version");
+}
+
+#[test]
+fn test_slim_error_envelope_exits_nonzero() {
+    let (dir, sock_path) = setup_project();
+    let _mock = MockDaemon::with_response_line(
+        sock_path,
+        r#"{"status":"ok","output":{"error":{"code":"not_found","message":"no such note"}}}"#
+            .to_string(),
+    );
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+
+    let mut cmd = cqs_bare();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["notes", "list", "--json"]);
+
+    let output = cmd.output().expect("cqs notes list spawn");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "slim error envelope must exit non-zero, not print an error with exit 0"
+    );
+    assert!(
+        stderr.contains("not_found") && stderr.contains("no such note"),
+        "error code+message surfaced; stderr=<{stderr}>"
     );
 }


### PR DESCRIPTION
Found by /cqs-verify at session start: 4 of 12 checks failed with `KeyError: results` — and several false PASSes ("1 callers" = `len()` of a single-key dict). Diagnosis: since the v1.40.0 SNR split, `cqs --json` returned a bare payload in-process but the slim batch envelope `{"data": ...}` when the daemon served the query — `try_daemon_query` printed the socket output verbatim with no surface translation. Output shape depended on whether a background process happened to be running. Unnoticed for six weeks because consumers (including my own parsers all day yesterday) defensively unwrapped with `d.get("data", d)`.

## Fix (client-side only — the slim envelope IS the batch/JSONL contract)

- `daemon_translate::classify_slim_envelope` — pure matcher for exactly what `wrap_value`/`wrap_error` emit (`data`/`error` + optional `_meta`, nothing else). Full v1 envelopes (carry `version`) and payloads merely containing a `data` key pass through verbatim.
- `json_envelope::daemon_payload_to_cli_text` — renders the payload exactly as the in-process CLI would: bare pretty payload with the daemon's `_meta` spliced into object payloads (warn-on-stderr for non-object, mirroring `emit_json`), or the full v1 envelope under `CQS_OUTPUT_FORMAT=v1`; trailing-newline parity with `println!`.
- Slim **error** envelopes now surface as a real non-zero exit instead of printing an error object with exit 0.

## Verification

- Live byte-diff, daemon vs `CQS_NO_DAEMON=1`, both formats: identical shapes (remaining `stats` diffs are daemon-live vs on-disk content semantics, pre-existing).
- 9 new tests: 3 classifier units (incl. v1-envelope and coincidental-key passthrough), 3 format-explicit presentation units (meta splice, non-object meta drop, v1 rebuild), 3 binary-boundary mock-daemon tests (bare unwrap + `_meta` splice + trailing newline; v1 envelope rebuild; error → exit non-zero). daemon_forward_test: 15/15.
- clippy --all-targets clean, build warning-free, fmt, provenance lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
