### PR TITLE
fix(skills): cqs-verify notes check parses the object shape

### DIFF
--- a/.claude/skills/cqs-verify/SKILL.md
+++ b/.claude/skills/cqs-verify/SKILL.md
@@ -52,7 +52,7 @@ echo "9. health:" && cqs health --json 2>/dev/null | python3 -c "import sys,json
 echo "10. doctor:" && cqs doctor 2>/dev/null | grep -c "✓" | xargs -I{} echo "  PASS ({} checks)"
 
 # 11. Notes
-echo "11. notes:" && cqs notes list --json 2>/dev/null | python3 -c "import sys,json; print(f'  PASS ({len(json.load(sys.stdin))} notes)')" 2>&1 || echo "  FAIL"
+echo "11. notes:" && cqs notes list --json 2>/dev/null | python3 -c "import sys,json; r=json.load(sys.stdin); print(f'  PASS ({len(r[\"notes\"])} notes)')" 2>&1 || echo "  FAIL"
 
 # 12. Dead code
 echo "12. dead:" && cqs dead --json 2>/dev/null | python3 -c "import sys,json; print('  PASS')" 2>&1 || echo "  FAIL"


### PR DESCRIPTION
The /cqs-verify notes check did `len(json.load(...))` on `notes list --json` output, which is `{"notes": [...], "count": N}` — an object, so the count always read 2 (or 1 under the pre-#1733 envelope leak). Parses `r["notes"]` now; verified live: 235 notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
