### PR TITLE
docs(skills): security-lane agents stay on opus

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -38,6 +38,8 @@ There are 16 categories split into 2 batches of 8. Each batch spawns 8 parallel 
 
 4. **Spawn teammates**: One per category. Use `model: "fable"` for every auditor (opus is an acceptable alternative) — the 2026-06-10 review/fix campaign showed Fable at or above opus quality on exactly this kind of judgment work (15/15 review findings confirmed, premise-drift catches, empirical hypothesis correction). Sonnet produces lower-quality judgments and haiku misses subtle findings. The per-category scope keeps each agent focused enough that frontier-model cost is reasonable.
 
+   **Exception — the Security category auditor uses `model: "opus"`.** Fable's documented bug-finding gains explicitly exclude security-focused analysis (its cyber classifiers apply there), and benign-adjacent security work can occasionally trigger a classifier false positive — a mid-run refusal kills that category's coverage for the whole audit. Opus carries no refusal risk on this lane, has no documented capability deficit for it, and costs half. Same reasoning applies to `/red-team`.
+
 5. **Each teammate prompt must include**:
    - Their category scope (from table below)
    - Instruction to read archived triage files (e.g., `docs/audit-triage-v*.md`) — skip anything already triaged in prior audits

--- a/.claude/skills/red-team/SKILL.md
+++ b/.claude/skills/red-team/SKILL.md
@@ -18,7 +18,7 @@ Adversarial security audit — attacker mindset, PoC-required, end-to-end attack
 ### Execution
 
 5. **Create team**: `red-team`
-6. **Spawn 4 opus agents** (one per category below)
+6. **Spawn 4 opus agents** (one per category below). Opus is deliberate here, not legacy: adversarial security testing is the lane where Fable has no documented bug-finding advantage and its cyber classifiers can false-positive on benign security tooling — a mid-run refusal silently drops a category. Do not switch these to fable in a future model sweep.
 7. **Each agent prompt must include**:
    - The threat model section (below) — calibrated from SECURITY.md
    - Their category scope, goal, key question, targets, and files


### PR DESCRIPTION
Follow-up to #1729 (audit agents default to fable). Fable's documented gains explicitly exclude security-focused analysis — the cyber classifiers apply there, and benign-adjacent work (security tooling, defensive audits) can occasionally trigger a false-positive refusal mid-run, which silently drops a category's coverage. Opus has no documented capability deficit on this lane, carries no refusal risk, and costs half.

- Audit skill: the Security category auditor is pinned to `model: "opus"` as an explicit exception to the fable default, with the rationale inline.
- Red-team skill: already used opus (never swept to fable); the choice is now annotated as deliberate so a future model sweep does not flip it.

Not a compliance matter — defensive audit of our own code is intended use — purely an engineering-reliability and cost call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
