### PR TITLE
docs: audit v1.42.0 docs-sweep cluster — README/SECURITY/CONTRIBUTING accuracy + migration contiguity test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -446,14 +446,16 @@ Checklist for every new command:
 1. **Implementation** — `src/cli/commands/<category>/<name>.rs` with the core logic (pick category: search/, graph/, review/, index/, io/, infra/, train/). Follow the surface-agnostic core pattern established by the command-core unification (#1688–#1698): a typed `<Name>Args` (input, derives `Deserialize`), a typed `<Name>Output` (the single JSON schema, derives `Serialize`), and a `<name>_core(ctx, args) -> Result<<Name>Output>` holding all logic and never printing or reading env posture. The CLI `cmd_<name>` and, where one exists, the daemon `dispatch_<name>` are thin adapters that build `Args`, call the core, and render. Logic lives in the core, not the adapters.
 2. **Category mod.rs** — add `mod <name>;` + `pub(crate) use <name>::*;` in `src/cli/commands/<category>/mod.rs`
 3. **CLI definition** — `Commands` enum variant in `src/cli/definitions.rs` with clap args
-4. **Derive surfaces** — `Commands` enum variants pick up dispatch + `variant_name()` + `batch_support()` from `#[derive(cqs_macros::CqsCommands)]` automatically (PR #1495 / #1500). Per-variant attribute knobs: `#[cqs(handler = "cmd_foo")]` for the dispatch fn, `#[cqs(batch_support = "yes")]` to opt into batch mode. See existing variants in `src/cli/definitions.rs` and the macro in `cqs-macros/`. A missing handler is a compile error from the derive expansion.
-5. **`--json` support** — serde serialization for programmatic output
-6. **Tracing** — `tracing::info_span!` at entry, `tracing::warn!` on error fallback
-7. **Error handling** — `Result` propagation, no bare `.unwrap_or_default()` in production
-8. **Tests** — happy path + empty input + error path + edge cases
-9. **CLAUDE.md** — add to the command reference section
-10. **Skills** — add to `.claude/skills/cqs/SKILL.md` and `.claude/skills/cqs-bootstrap/SKILL.md`
-11. **CHANGELOG** — entry in the next release section
+4. **Derive surfaces** — `Commands` enum variants pick up `variant_name()`, `batch_support()`, and dispatch routing from `#[derive(cqs_macros::CqsCommands)]` automatically (PR #1495 / #1500). Every variant needs a `#[cqs_cmd(...)]` attribute with two required keys: `group = "a"` (no-store / lifecycle / mutation) or `group = "b"` (store-using), and `batch = "cli"` (in-process only), `"daemon"` (answerable by the daemon), or `"runtime"` (defers to a `<variant_snake>_batch_support` helper — used when support depends on the inner subcommand). An optional `name = "..."` overrides the telemetry label when the kebab-case default doesn't match. See existing variants in `src/cli/definitions.rs` and the macro in `cqs-macros/src/lib.rs`.
+5. **Dispatch shim** — handlers bind by naming convention, not attribute: the derive calls `cmd_<variant_snake>_dispatch`, which you write by hand in `src/cli/commands/dispatch_shims.rs` (standardized signature; destructure the variant with `must_be!` and call your `cmd_<name>`). A missing or mis-shaped shim is a single compile error from the derive's const existence guard.
+6. **Daemon wiring** (only for `batch = "daemon"`) — three more edit sites: a `BatchCmd` variant in `src/cli/batch/commands.rs` (reuse the shared `*Args` struct so CLI and batch share one source of flags), a `dispatch_<name>` adapter in the matching `src/cli/batch/handlers/` module (thin: parse wire args into the core's `*Args`, call the core, serialize the typed output), and a CLI==daemon parity test following the `src/cli/batch/handlers/dispatch_tests.rs` pattern (dispatch one line, assert the envelope shape).
+7. **`--json` support** — serde serialization for programmatic output
+8. **Tracing** — `tracing::info_span!` at entry, `tracing::warn!` on error fallback
+9. **Error handling** — `Result` propagation, no bare `.unwrap_or_default()` in production
+10. **Tests** — happy path + empty input + error path + edge cases
+11. **CLAUDE.md** — add to the command reference section
+12. **Skills** — add to `.claude/skills/cqs/SKILL.md` and `.claude/skills/cqs-bootstrap/SKILL.md`
+13. **CHANGELOG** — entry in the next release section
 
 Pattern to follow: look at `src/cli/commands/io/blame.rs` or `src/cli/commands/review/dead.rs` for a minimal example.
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Code intelligence and RAG for AI agents. Semantic search, call graph analysis, i
 
 ## Install
 
-**Requires Rust 1.95+**
+**Requires Rust 1.96+**
 
 ```bash
 cargo install cqs
 ```
 
-> **Note:** `cargo install` clones a patched `cuvs` fork from [github.com/jamie8johnson/cuvs-patched](https://github.com/jamie8johnson/cuvs-patched) even for CPU builds, because it is wired in via `[patch.crates-io]`. The patch exposes `search_with_filter` for GPU-native bitset filtering and will be dropped once upstream [rapidsai/cuvs#2019](https://github.com/rapidsai/cuvs/pull/2019) merges.
+> **Note:** GPU builds (`--features cuda-index`) depend on the official `cuvs` crate from crates.io, pinned to `=26.6` to match the installed conda `libcuvs` version. CPU-only builds (the default) don't pull in cuvs at all.
 
 **Upgrading?** A reindex is recommended after major version bumps:
 ```bash
@@ -693,21 +693,27 @@ Local-first ML, GPU-accelerated. Optional LLM enrichment via Claude API.
 
 ## HNSW Index Tuning
 
-The HNSW (Hierarchical Navigable Small World) index provides fast approximate nearest neighbor search. Current parameters:
+The HNSW (Hierarchical Navigable Small World) index provides fast approximate nearest neighbor search. Defaults are corpus-size-tiered — small projects pay less build cost, large monorepos get more recall headroom:
 
-| Parameter | Value | Description |
-|-----------|-------|-------------|
-| M (connections) | 24 | Max edges per node. Higher = better recall, more memory |
-| ef_construction | 200 | Search width during build. Higher = better index, slower build |
-| max_layers | 16 | Graph layers. ~log(N) is typical |
-| ef_search | 100 (adaptive) | Baseline search width; actual value scales with k and index size |
+| Corpus size | M (connections) | ef_construction | ef_search |
+|-------------|-----------------|-----------------|-----------|
+| < 5k chunks | 16 | 100 | 50 |
+| 5k–100k chunks | 24 | 200 | 100 |
+| ≥ 100k chunks | 32 | 400 | 200 |
+
+- **M** — max edges per node. Higher = better recall, more memory
+- **ef_construction** — search width during build. Higher = better index, slower build
+- **ef_search** — baseline search width at query time; the effective value also adapts with k and index size
+- **max_layers** is fixed at 16 (~log(N) is typical)
+
+The `CQS_HNSW_M`, `CQS_HNSW_EF_CONSTRUCTION`, and `CQS_HNSW_EF_SEARCH` env vars override the tier defaults — a set value is taken verbatim, regardless of corpus size.
 
 **Trade-offs:**
-- **Recall vs speed**: Higher ef_search baseline improves recall but slows queries. ef_search adapts automatically based on k and index size
-- **Index size**: ~4KB per vector with current settings
+- **Recall vs speed**: Higher ef_search improves recall but slows queries
+- **Index size**: ~4KB per vector with mid-tier settings
 - **Build time**: O(N * M * ef_construction) complexity
 
-For most codebases (<100k chunks), defaults work well. Large repos may benefit from tuning ef_search higher (200+) if recall matters more than latency.
+The tiered defaults work well for most codebases; reach for the env overrides only when measured recall or latency says otherwise.
 
 ## Retrieval Quality
 
@@ -781,7 +787,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_CAGRA_MAX_BYTES` | (auto) | Max GPU memory for CAGRA index |
 | `CQS_CAGRA_PERSIST` | `1` | Persist the CAGRA graph to `{cqs_dir}/index.cagra` after build and reload it on restart. Set to `0` to disable (daemon rebuilds from scratch every startup). |
 | `CQS_CAGRA_STREAM_BATCH_SIZE` | `10000` | Embedding rows streamed per batch during CAGRA index construction. At dim=1024 this is ~40 MB/batch; raise/lower to fit a per-batch byte budget for non-default-dim models. (P3-15 / SHL-V1.33-9) |
-| `CQS_CAGRA_THRESHOLD` | `50000` | Min chunks to trigger CAGRA over HNSW |
+| `CQS_CAGRA_THRESHOLD` | `5000` | Min chunks to trigger CAGRA over HNSW |
 | `CQS_CENTROID_ALPHA_FLOOR` | `0.7` | Minimum α when the centroid classifier overrides the rule-based classifier. Caps downside of wrong-category alpha routing. |
 | `CQS_CENTROID_CLASSIFIER` | `1` | Embedding-centroid query classifier — fills `Unknown` gaps from the rule-based classifier with embedding-space matching. Enabled by default; set to `0` to opt out. |
 | `CQS_CAGRA_MAX_GPU_BYTES` | (unset) | Hard cap (bytes) on GPU memory the CAGRA index is allowed to allocate. When set, exceeding the cap aborts the build with a clear error rather than OOM-ing the GPU. P2.42. |
@@ -817,11 +823,11 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_FORCE_BASE_INDEX` | (none) | Set to `1` to force search via the base (non-enriched) HNSW index |
 | `CQS_FTS_NORMALIZE_MAX` | `16384` | Max bytes of `normalize_for_fts` output per chunk. Truncation is emitted at warn level; bump if FTS recall on long chunks (large generated tables, monolithic functions) is degraded. |
 | `CQS_GATHER_MAX_NODES` | `200` | Max BFS nodes in `gather` context assembly |
-| `CQS_HNSW_EF_CONSTRUCTION` | `200` | HNSW construction-time search width |
+| `CQS_HNSW_EF_CONSTRUCTION` | corpus-tiered: `100`/`200`/`400` | HNSW construction-time search width (see HNSW Index Tuning) |
 | `CQS_DISTANCE_METRIC` | `cosine` | Distance metric at index build (`cosine`, `dot`). Stored in the index; a conflicting value at load is a typed error |
-| `CQS_HNSW_EF_SEARCH` | `100` | HNSW query-time search width |
+| `CQS_HNSW_EF_SEARCH` | corpus-tiered: `50`/`100`/`200` | HNSW query-time search width (see HNSW Index Tuning) |
 | `CQS_HNSW_BATCH_SIZE` | `10000` | Vectors per HNSW build batch |
-| `CQS_HNSW_M` | `24` | HNSW connections per node |
+| `CQS_HNSW_M` | corpus-tiered: `16`/`24`/`32` | HNSW connections per node (see HNSW Index Tuning) |
 | `CQS_HNSW_MAX_DATA_BYTES` | `1073741824` (1 GB) | Max HNSW data file size |
 | `CQS_HNSW_MAX_GRAPH_BYTES` | `524288000` (500 MB) | Max HNSW graph file size |
 | `CQS_HNSW_MAX_ID_MAP_BYTES` | `524288000` (500 MB) | Max HNSW ID map file size |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -301,7 +301,8 @@ Known advisories and mitigations:
 
 | Crate | Advisory | Status |
 |-------|----------|--------|
-| `bincode` | RUSTSEC-2025-0141 | Mitigated: checksums validate data before deserialization |
+| `bincode` | RUSTSEC-2025-0141 | Mitigated: transitive via `hnsw_rs` 0.3.4 with no upgrade path; blake3 checksums validate data before deserialization |
+| `number_prefix` | RUSTSEC-2025-0119 | Accepted: unmaintained, transitive via `hf-hub` → `indicatif` 0.17, progress bars only |
 | `paste` | RUSTSEC-2024-0436 | Accepted: proc-macro, no runtime impact, transitive via tokenizers |
 
 Run `cargo audit` to check current status.

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -34,19 +34,12 @@ use crate::cli::commands::{
 // their adapter-side branch (separate cross-project context, no
 // kind-fallback).
 
-/// Dispatches a dependency query for a given name, returning either the types used by it or the code locations that use it.
+/// Dispatches a dependency query for a given name, returning either the
+/// types used by it (`reverse`) or the code locations that use it.
 ///
-/// # Arguments
-///
-/// * `ctx` - The batch processing context containing the store and root path
-/// * `name` - The name of the type or function to query dependencies for
-/// * `reverse` - If `true`, returns types used by `name`; if `false`, returns code locations that use `name`
-///
-/// # Returns
-///
-/// A JSON value containing:
-/// - When `reverse` is `true`: an object with the queried function name, a list of types it uses (with type names and edge kinds), and the count of types
-/// - When `reverse` is `false`: an array of objects describing code locations that use the type, each with name, file path, line number, and chunk type
+/// The wire schema is `DepsCoreOutput` (in `cli::commands::graph::deps`),
+/// serialized as-is — see that type for the exact field names of the
+/// reverse, forward, and kind-fallback shapes.
 ///
 /// # Errors
 ///
@@ -81,16 +74,16 @@ pub(in crate::cli::batch) fn dispatch_deps(
 
 /// Retrieves and serializes caller information for a given function name.
 ///
-/// This function fetches the complete caller data for the specified function name from the batch context's store, then transforms it into a JSON array containing the caller's name, normalized file path, and line number.
+/// The wire schema is `CallersCoreOutput` (in
+/// `cli::commands::graph::callers`), serialized as-is — a flat array of
+/// caller entries on the function path, the shared kind-fallback object on
+/// a kind mismatch. See that type for the exact field names. The
+/// cross-project branch serializes `CrossProjectContext::get_callers_cross`
+/// results directly instead.
 ///
-/// # Arguments
+/// # Errors
 ///
-/// * `ctx` - The batch context containing the store to query for caller information
-/// * `name` - The name of the function for which to retrieve callers
-///
-/// # Returns
-///
-/// A `Result` containing a JSON array of caller objects, each with `name`, `file`, and `line` fields. Returns an error if the store query fails.
+/// Returns an error if the store query fails.
 pub(in crate::cli::batch) fn dispatch_callers(
     ctx: &BatchView,
     args: &CallersArgs,
@@ -123,17 +116,12 @@ pub(in crate::cli::batch) fn dispatch_callers(
 
 /// Dispatches a request to retrieve all functions called by a specified function.
 ///
-/// # Arguments
-///
-/// * `ctx` - The batch processing context containing the store for querying callees
-/// * `name` - The name of the function whose callees should be retrieved
-///
-/// # Returns
-///
-/// Returns a JSON object containing:
-/// - `function`: the name of the queried function
-/// - `calls`: an array of objects with `name` and `line` fields for each callee
-/// - `count`: the total number of callees found
+/// The wire schema is `CalleesCoreOutput` (in
+/// `cli::commands::graph::callers`), serialized as-is — the
+/// `{name, calls, count}` object on the function path, the shared
+/// kind-fallback object on a kind mismatch. See that type for the exact
+/// field names. The cross-project branch serializes
+/// `CrossProjectContext::get_callees_cross` results directly instead.
 ///
 /// # Errors
 ///

--- a/src/parser/injection.rs
+++ b/src/parser/injection.rs
@@ -218,9 +218,11 @@ fn walk_for_containers(
                                     end_point: child.end_position(),
                                 };
 
-                                // Safe: row count fits u32 because MAX_FILE_SIZE (50MB)
-                                // limits files to ~50M lines at minimum 1 byte/line,
-                                // well within u32::MAX.
+                                // Cast assumes the row count is < u32::MAX. The
+                                // per-file cap (CQS_MAX_FILE_SIZE, default 1 MiB)
+                                // keeps line counts far below that; the env override
+                                // is unbounded, but a >4-billion-line file is not a
+                                // realistic input.
                                 //
                                 // content_scoped_lines: use the content child's line
                                 // range instead of the container's. Required for PHP

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -6,8 +6,10 @@
 //! ## Adding a new migration
 //!
 //! 1. Increment `CURRENT_SCHEMA_VERSION` in `helpers/mod.rs`
-//! 2. Add a new migration function: `async fn migrate_vN_to_vM(pool: &SqlitePool) -> Result<()>`
-//! 3. Add the case to `run_migration()`: `(N, M) => migrate_vN_to_vM(pool).await`
+//! 2. Add a new migration function:
+//!    `async fn migrate_vN_to_vM(conn: &mut sqlx::SqliteConnection) -> Result<(), StoreError>`
+//! 3. Append a row to the `MIGRATIONS` table:
+//!    `(N, M, |c| Box::pin(migrate_vN_to_vM(c)))`
 //! 4. Update `schema.sql` with the new schema
 //!
 //! ## Migration guidelines
@@ -1087,6 +1089,22 @@ mod tests {
     fn test_current_schema_version_documented() {
         // Ensure the current version matches what we document
         assert_eq!(CURRENT_SCHEMA_VERSION, 28);
+    }
+
+    #[test]
+    fn test_migrations_table_contiguous() {
+        // Every step from the oldest migratable version (v10) up to
+        // CURRENT_SCHEMA_VERSION must have a (v, v+1) row in MIGRATIONS.
+        // A forgotten row fails here instead of at a user's upgrade.
+        for v in 10..CURRENT_SCHEMA_VERSION {
+            assert!(
+                MIGRATIONS.iter().any(|(f, t, _)| *f == v && *t == v + 1),
+                "MIGRATIONS is missing the (v{}, v{}) step — append a row \
+                 when bumping CURRENT_SCHEMA_VERSION",
+                v,
+                v + 1
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Audit v1.42.0 — docs sweep (P1 cluster)

Closes the doc-accuracy P1s from `docs/audit-triage.md`: DOC-V1.42-1/2/3/7, EXT-V1.42-3/4, API-V1.42-9, RB-V1.42-4 (+ DOC-V1.42-4, P3 rider).

- **README**: MSRV 1.96+; cuvs install note reflects the retired fork (official crates.io `=26.6`); `CQS_CAGRA_THRESHOLD` default corrected 50000 → 5000; HNSW tuning section rewritten as the real three corpus tiers with env-override note (env-table default cells updated to match).
- **SECURITY.md**: added the missing `number_prefix` RUSTSEC-2025-0119 row; bincode row now states both the hnsw_rs-transitive pin and the blake3-checksum mitigation (matches deny.toml).
- **CONTRIBUTING.md**: "Adding a New CLI Command" step 4 rewritten to the real `#[cqs_cmd(name/group/batch)]` grammar; new steps for the `dispatch_shims.rs` shim convention and the daemon wiring (BatchCmd variant + handler adapter + parity test).
- **migrations.rs**: module-doc recipe now describes the `MIGRATIONS` table append (old text described the removed match ladder + a stale signature); new `test_migrations_table_contiguous` makes a forgotten migration row a test failure instead of a user-upgrade error.
- **graph.rs dispatch doc comments**: defer to the core output types instead of hand-enumerating wire fields that had drifted (`line`/`function` vs actual `line_start`/`name`).
- **injection.rs**: u32-cast safety comment cites the real cap (`CQS_MAX_FILE_SIZE`, 1 MiB default) instead of a nonexistent constant.

Tests: `test_migrations_table_contiguous` passes; fmt + clippy (`--lib --bins -D warnings`) clean.

Verification note: deny.toml carries two further stale ignores (`derivative`, `instant` — crates no longer in the lockfile); left for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
