### PR TITLE
fix(daemon): cache vector index/file_set/notes across daemon queries — shared write-back cells with invalidation epochs

### DIFF
--- a/src/cli/batch/context.rs
+++ b/src/cli/batch/context.rs
@@ -48,8 +48,11 @@ pub(super) struct DataVersionProbe {
 /// **Stable caches** (embedder, reranker, config, audit_state) use `OnceLock`
 /// and live for the session. ONNX sessions are cleared after idle timeout.
 ///
-/// **Mutable caches** (hnsw, call_graph, test_chunks, file_set, notes_cache)
-/// use `RefCell<Option<T>>` and are auto-invalidated when index.db changes —
+/// **Mutable caches** (hnsw, base_hnsw, file_set, notes_cache, splade_index)
+/// are shared `Arc<Mutex<Option<Arc<T>>>>` write-back cells carried by every
+/// `BatchView`; call_graph / test_chunks stay view-local `RefCell`s (their
+/// rebuild is a Store-internal cache hit). All are auto-invalidated when
+/// index.db changes —
 /// detected via file identity (inode/size/mtime) OR `PRAGMA data_version` on
 /// a long-lived probe connection (the latter catches WAL-mode incremental
 /// writes that never touch the main file; see [`Self::check_index_staleness`]).
@@ -104,18 +107,42 @@ pub(crate) struct BatchContext {
     /// 30 s); the file carries its own embedded `expires_at` so the load
     /// itself respects expiration.
     pub(super) audit_state: RefCell<Option<CachedReload<cqs::audit::AuditMode>>>,
-    // Mutable caches — RefCell<Option<T>> for invalidation on index change
-    pub(super) hnsw: RefCell<Option<Arc<dyn VectorIndex>>>,
-    pub(super) base_hnsw: RefCell<Option<Arc<dyn VectorIndex>>>,
+    // Mutable caches — invalidated on index change.
+    //
+    // `hnsw` / `base_hnsw` / `file_set` / `notes_cache` are shared write-back
+    // cells (`Arc<Mutex<Option<Arc<T>>>>`, same shape as `splade_index`):
+    // `BatchView` carries a clone of each cell, and a view that builds the
+    // value on a cache miss publishes it back (epoch-guarded, see
+    // `invalidation_epoch`) so the next checkout snapshots it instead of
+    // rebuilding. Without the write-back, every daemon search rebuilt the
+    // vector index from disk (~400 ms per query against a 3-19 ms budget).
+    //
+    // `call_graph` / `test_chunks` stay view-local `RefCell`s: their view
+    // fallback goes through the snapshot Store, which holds its own internal
+    // `OnceLock` caches, so a per-view rebuild is a cheap cache hit there.
+    pub(super) hnsw: Arc<Mutex<Option<Arc<dyn VectorIndex>>>>,
+    pub(super) base_hnsw: Arc<Mutex<Option<Arc<dyn VectorIndex>>>>,
     pub(super) call_graph: RefCell<Option<Arc<cqs::store::CallGraph>>>,
     pub(super) test_chunks: RefCell<Option<Arc<Vec<cqs::store::ChunkSummary>>>>,
     /// Cache returns `Arc<HashSet<PathBuf>>` so callers don't clone the full
-    /// set on every invocation. Mirrors `call_graph` / `test_chunks`.
-    pub(super) file_set: RefCell<Option<Arc<HashSet<PathBuf>>>>,
+    /// set on every invocation.
+    pub(super) file_set: Arc<Mutex<Option<Arc<HashSet<PathBuf>>>>>,
     /// Cached notes returned as `Arc<Vec<Note>>` so callers don't clone the
-    /// full Vec on every dispatch. Mirrors `call_graph` / `test_chunks` /
-    /// `file_set`.
-    pub(super) notes_cache: RefCell<Option<Arc<Vec<cqs::note::Note>>>>,
+    /// full Vec on every dispatch.
+    pub(super) notes_cache: Arc<Mutex<Option<Arc<Vec<cqs::note::Note>>>>>,
+    /// Monotonic counter bumped at the start of every mutable-cache
+    /// invalidation. Views snapshot it at checkout; a view-side cache build
+    /// publishes into the shared cells only while the epoch is unchanged, so
+    /// a value built from a pre-invalidation store snapshot can never land
+    /// after (and survive) a fresh invalidation.
+    pub(super) invalidation_epoch: Arc<AtomicU64>,
+    /// Sticky flag set when [`Self::invalidate_mutable_caches`] had to defer
+    /// at least one slot (a handler held its borrow/lock mid-invalidation).
+    /// [`Self::check_index_staleness`] honors it regardless of the identity /
+    /// data_version discriminators — those were already consumed when the
+    /// invalidation first fired, so without the flag the deferred slots would
+    /// never be retried. Cleared only when every slot actually cleared.
+    pub(super) pending_invalidation: Cell<bool>,
     // LRU caps at 2 — each ReferenceIndex holds Store + HNSW (50-200MB).
     // Values are `Arc` so `get_all_refs` can fan out refs to parallel
     // `--include-refs` searches without cloning the index bytes.
@@ -238,12 +265,14 @@ impl BatchContext {
             config: RefCell::new(None),
             reranker: Arc::new(OnceLock::new()),
             audit_state: RefCell::new(None),
-            hnsw: RefCell::new(None),
-            base_hnsw: RefCell::new(None),
+            hnsw: Arc::new(Mutex::new(None)),
+            base_hnsw: Arc::new(Mutex::new(None)),
             call_graph: RefCell::new(None),
             test_chunks: RefCell::new(None),
-            file_set: RefCell::new(None),
-            notes_cache: RefCell::new(None),
+            file_set: Arc::new(Mutex::new(None)),
+            notes_cache: Arc::new(Mutex::new(None)),
+            invalidation_epoch: Arc::new(AtomicU64::new(0)),
+            pending_invalidation: Cell::new(false),
             splade_encoder: Arc::new(OnceLock::new()),
             splade_index: Arc::new(Mutex::new(None)),
             refs: Arc::new(Mutex::new(lru::LruCache::new(refs_lru_size()))),
@@ -380,14 +409,23 @@ impl BatchContext {
     /// so the probe falls back to identity-only (with a warn) rather than
     /// blocking the check when it can't be opened or queried.
     ///
-    /// Rate-limited to at most once per [`STALENESS_CHECK_INTERVAL`]. Every
-    /// `ctx.store()` and every `vector_index` / `file_set` / etc. accessor
-    /// calls this.
+    /// Rate-limited to at most once per [`STALENESS_CHECK_INTERVAL`] —
+    /// except when a prior invalidation deferred a busy slot, in which case
+    /// the sticky `pending_invalidation` flag forces a retry. Every
+    /// `ctx.store()`, every `build_view` checkout, and the remaining
+    /// BatchContext accessors call this.
     pub(crate) fn check_index_staleness(&self) {
+        // A pending (deferred) invalidation bypasses the rate limit: the
+        // discriminators below were already consumed when the invalidation
+        // first fired (probe baseline advanced, index_id refreshed), so
+        // waiting on them would never retry the deferred slots.
+        let pending = self.pending_invalidation.get();
         let now = Instant::now();
-        if let Some(prev) = self.last_staleness_check.get() {
-            if now.duration_since(prev) < STALENESS_CHECK_INTERVAL {
-                return;
+        if !pending {
+            if let Some(prev) = self.last_staleness_check.get() {
+                if now.duration_since(prev) < STALENESS_CHECK_INTERVAL {
+                    return;
+                }
             }
         }
         self.last_staleness_check.set(Some(now));
@@ -464,6 +502,12 @@ impl BatchContext {
                     tracing::warn!(error = %e, "Failed to re-open Store after index change");
                 }
             }
+        } else if pending {
+            // Retry a deferred invalidation. The Store re-open and probe
+            // rebaseline already happened when the invalidation first fired;
+            // only the slots that were busy still need clearing.
+            let _span = tracing::info_span!("batch_index_invalidation_retry").entered();
+            self.invalidate_mutable_caches();
         }
         self.index_id.set(Some(current_id));
     }
@@ -564,21 +608,32 @@ impl BatchContext {
     /// `splade_index` must be cleared here too — otherwise a long-lived batch
     /// session that had loaded the SPLADE posting map once would serve results
     /// from the pre-reindex generation forever after a concurrent `cqs index`.
-    /// Clearing the RefCell lets `ensure_splade_index` see `None` on the next
+    /// Clearing the cell lets `ensure_splade_index` see `None` on the next
     /// call and rebuild from
     /// the freshly persisted `splade.index.bin` (or SQLite fallback).
-    fn invalidate_mutable_caches(&self) {
-        // Use try_borrow_mut: a search handler may still hold a Ref<...>
-        // to splade_index or hnsw across an accessor call that triggers
+    /// Returns `true` when every slot actually cleared; `false` when at
+    /// least one slot was deferred (a handler held its borrow/lock). On
+    /// deferral the sticky `pending_invalidation` flag is set so
+    /// [`Self::check_index_staleness`] retries the clear even though the
+    /// identity / data_version discriminators were already consumed.
+    fn invalidate_mutable_caches(&self) -> bool {
+        // Bump the epoch BEFORE clearing any slot: a view that snapshotted
+        // the previous epoch at checkout sees the mismatch when it tries to
+        // publish a freshly built value, so an index built from the
+        // pre-invalidation store snapshot is discarded instead of being
+        // re-published over the cleared cell.
+        self.invalidation_epoch.fetch_add(1, Ordering::SeqCst);
+
+        // Use try_borrow_mut / try_lock: a search handler may still hold a
+        // borrow on a cache slot across an accessor call that triggers a
         // staleness re-check (for example handlers/search.rs does
         // `let splade_index_ref = ctx.borrow_splade_index()` then later
         // calls `ctx.store().search_hybrid(...)`). Panicking on
         // borrow_mut() would crash the whole batch session for what is
-        // just a deferral case. Slots that are busy stay populated; we
-        // reset the rate-limit so the next accessor retries the
-        // invalidation as soon as the in-flight handler releases its Ref.
+        // just a deferral case. Slots that are busy stay populated; the
+        // sticky flag set below makes the next staleness check retry.
         let mut all_clear = true;
-        macro_rules! try_clear_to_none {
+        macro_rules! try_clear_refcell {
             ($field:expr, $name:literal) => {
                 match $field.try_borrow_mut() {
                     Ok(mut g) => *g = None,
@@ -589,25 +644,29 @@ impl BatchContext {
                 }
             };
         }
-        try_clear_to_none!(self.hnsw, "hnsw");
-        try_clear_to_none!(self.base_hnsw, "base_hnsw");
-        try_clear_to_none!(self.call_graph, "call_graph");
-        try_clear_to_none!(self.test_chunks, "test_chunks");
-        try_clear_to_none!(self.file_set, "file_set");
-        try_clear_to_none!(self.notes_cache, "notes_cache");
-        // splade_index is `Arc<Mutex<...>>`. Use try_lock to mirror the
-        // borrow-deferral semantics of the RefCell branches.
-        match self.splade_index.try_lock() {
-            Ok(mut g) => *g = None,
-            Err(_) => {
-                all_clear = false;
-                tracing::debug!(slot = "splade_index", "lock held; deferring invalidation");
-            }
+        // Shared write-back cells are `Arc<Mutex<...>>`; `try_lock` mirrors
+        // the borrow-deferral semantics of the RefCell branches.
+        macro_rules! try_clear_cell {
+            ($field:expr, $name:literal) => {
+                match $field.try_lock() {
+                    Ok(mut g) => *g = None,
+                    Err(_) => {
+                        all_clear = false;
+                        tracing::debug!(slot = $name, "lock held; deferring invalidation");
+                    }
+                }
+            };
         }
-        // refs LRU is `Arc<Mutex<...>>` (shared with BatchView).
-        // `try_lock` is the read-only equivalent of `try_borrow_mut`: if a
+        try_clear_cell!(self.hnsw, "hnsw");
+        try_clear_cell!(self.base_hnsw, "base_hnsw");
+        try_clear_refcell!(self.call_graph, "call_graph");
+        try_clear_refcell!(self.test_chunks, "test_chunks");
+        try_clear_cell!(self.file_set, "file_set");
+        try_clear_cell!(self.notes_cache, "notes_cache");
+        try_clear_cell!(self.splade_index, "splade_index");
+        // refs LRU is `Arc<Mutex<...>>` (shared with BatchView). If a
         // handler thread holds the mutex (e.g. iterating refs in a parallel
-        // search), the eviction is deferred to the next sweep.
+        // search), the eviction is deferred to the next retry.
         match self.refs.try_lock() {
             Ok(mut g) => g.clear(),
             Err(_) => {
@@ -616,12 +675,14 @@ impl BatchContext {
             }
         }
 
+        // Sticky: stays set across checks until a retry clears every slot.
+        self.pending_invalidation.set(!all_clear);
         if !all_clear {
-            // Reset rate-limit so the next accessor reattempts immediately
-            // (rather than waiting STALENESS_CHECK_INTERVAL with stale caches).
-            self.last_staleness_check.set(None);
-            tracing::debug!("partial cache invalidation; will retry on next accessor");
+            tracing::debug!(
+                "partial cache invalidation; pending flag set — next staleness check retries"
+            );
         }
+        all_clear
     }
 
     /// Manually invalidate all mutable caches and re-open the Store.
@@ -1079,61 +1140,6 @@ impl BatchContext {
             .map(Arc::clone)
     }
 
-    /// Get or build the vector index (CAGRA/HNSW/brute-force, cached).
-    ///
-    /// Checks index staleness before returning cached value. If the index.db
-    /// changed, rebuilds the vector index from the fresh Store.
-    /// Returns a cloneable Arc so callers can hold a reference past RefCell borrow scope.
-    ///
-    /// If the cached index reports `is_poisoned()` (only the CAGRA GPU backend
-    /// currently does), the cache slot is cleared and a fresh index is built.
-    /// Reusing a poisoned CUDA context risks double-free and CUDA faults.
-    pub fn vector_index(&self) -> Result<Option<std::sync::Arc<dyn VectorIndex>>> {
-        self.check_index_staleness();
-        {
-            let cached = self.hnsw.borrow();
-            if let Some(arc) = cached.as_ref() {
-                if arc.is_poisoned() {
-                    tracing::warn!(
-                        name = arc.name(),
-                        "Cached vector index is poisoned — discarding and rebuilding"
-                    );
-                } else {
-                    return Ok(Some(std::sync::Arc::clone(arc)));
-                }
-            }
-        }
-        // Clear any poisoned cache before rebuilding.
-        *self.hnsw.borrow_mut() = None;
-        let _span = tracing::info_span!("batch_vector_index_init").entered();
-        // Pull a snapshot Arc and pass `&Store<...>` via auto-deref.
-        let store = self.store_arc_locked();
-        let idx = build_vector_index(&store, &self.cqs_dir, self.config().ef_search)?;
-        let result = idx.map(|boxed| -> Arc<dyn VectorIndex> { boxed.into() });
-        let ret = result.clone();
-        *self.hnsw.borrow_mut() = result;
-        Ok(ret)
-    }
-
-    /// Get or build the base (non-enriched) vector index, cached.
-    /// Returns `None` if the base index files don't exist or `CQS_DISABLE_BASE_INDEX=1`.
-    pub fn base_vector_index(&self) -> Result<Option<Arc<dyn VectorIndex>>> {
-        self.check_index_staleness();
-        {
-            let cached = self.base_hnsw.borrow();
-            if let Some(arc) = cached.as_ref() {
-                return Ok(Some(Arc::clone(arc)));
-            }
-        }
-        let _span = tracing::info_span!("batch_base_vector_index_init").entered();
-        let store = self.store_arc_locked();
-        let idx = crate::cli::build_base_vector_index(&store, &self.cqs_dir)?;
-        let result = idx.map(|boxed| -> Arc<dyn VectorIndex> { boxed.into() });
-        let ret = result.clone();
-        *self.base_hnsw.borrow_mut() = result;
-        Ok(ret)
-    }
-
     /// Get a cached reference index by name, loading on first access.
     ///
     /// Uses cached config and loads only the target reference, not all
@@ -1166,27 +1172,6 @@ impl BatchContext {
         get_all_refs_via_refs_lru(&self.refs, &self.config())
     }
 
-    /// Get or build the file set for staleness checks (cached).
-    ///
-    /// Returns `Arc<HashSet<PathBuf>>` so callers don't clone the full set per
-    /// invocation. Mirrors `call_graph` / `test_chunks`.
-    pub(super) fn file_set(&self) -> Result<std::sync::Arc<HashSet<PathBuf>>> {
-        self.check_index_staleness();
-        {
-            let cached = self.file_set.borrow();
-            if let Some(fs) = cached.as_ref() {
-                return Ok(std::sync::Arc::clone(fs));
-            }
-        }
-        let _span = tracing::info_span!("batch_file_set").entered();
-        let exts: Vec<&str> = cqs::language::REGISTRY.supported_extensions().collect();
-        let files = cqs::enumerate_files(&self.root, &exts, false)?;
-        let set: HashSet<PathBuf> = files.into_iter().collect();
-        let arc = std::sync::Arc::new(set);
-        *self.file_set.borrow_mut() = Some(std::sync::Arc::clone(&arc));
-        Ok(arc)
-    }
-
     /// Get cached audit state. Reloads from `.cqs/audit-mode.json` when the
     /// cached value is older than [`AUDIT_STATE_RELOAD_INTERVAL`] (default
     /// 30 s), then returns an owned snapshot.
@@ -1216,59 +1201,6 @@ impl BatchContext {
             .expect("audit_state populated above")
             .value
             .clone()
-    }
-
-    /// Get cached notes (parsed once per session, invalidated on index change).
-    /// Returns `Arc<Vec<Note>>` so repeat calls bump a refcount instead of
-    /// cloning the full Vec — mirrors `call_graph` / `test_chunks`.
-    pub(super) fn notes(&self) -> std::sync::Arc<Vec<cqs::note::Note>> {
-        self.check_index_staleness();
-        {
-            let cached = self.notes_cache.borrow();
-            if let Some(notes) = cached.as_ref() {
-                return std::sync::Arc::clone(notes);
-            }
-        }
-        let notes_path = self.root.join("docs/notes.toml");
-        let notes = if notes_path.exists() {
-            match cqs::note::parse_notes(&notes_path) {
-                Ok(notes) => notes,
-                // Split absent-file (TOCTOU after the .exists() check above)
-                // from genuine parse failures, and include the path in the
-                // warn so the journal isn't ambiguous about which notes file
-                // failed.
-                Err(e) => {
-                    if let cqs::NoteError::Io(ref io_err) = e {
-                        if io_err.kind() == std::io::ErrorKind::NotFound {
-                            tracing::debug!(
-                                path = %notes_path.display(),
-                                "notes.toml disappeared between exists() and parse — treating as empty"
-                            );
-                            vec![]
-                        } else {
-                            tracing::warn!(
-                                path = %notes_path.display(),
-                                error = %e,
-                                "Failed to parse notes.toml for batch"
-                            );
-                            vec![]
-                        }
-                    } else {
-                        tracing::warn!(
-                            path = %notes_path.display(),
-                            error = %e,
-                            "Failed to parse notes.toml for batch"
-                        );
-                        vec![]
-                    }
-                }
-            }
-        } else {
-            vec![]
-        };
-        let arc = std::sync::Arc::new(notes);
-        *self.notes_cache.borrow_mut() = Some(std::sync::Arc::clone(&arc));
-        arc
     }
 
     /// Borrow a reference index by name (must be loaded via `get_ref` first).
@@ -1394,18 +1326,24 @@ impl BatchContext {
             let guard = self.store.lock().unwrap_or_else(|p| p.into_inner());
             Arc::clone(&guard)
         };
-        let vector_index = self.hnsw.borrow().as_ref().map(Arc::clone);
-        let base_vector_index = self.base_hnsw.borrow().as_ref().map(Arc::clone);
+        // Epoch is captured after the staleness check above, in the same
+        // critical section as the store snapshot — the pair is coherent. A
+        // later invalidation bumps the shared counter, and the view's
+        // publish-back path compares against this captured value.
+        let checkout_epoch = self.invalidation_epoch.load(Ordering::SeqCst);
+        fn snapshot_cell<T: ?Sized>(cell: &Mutex<Option<Arc<T>>>) -> Option<Arc<T>> {
+            cell.lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .as_ref()
+                .map(Arc::clone)
+        }
+        let vector_index = snapshot_cell(&self.hnsw);
+        let base_vector_index = snapshot_cell(&self.base_hnsw);
         let call_graph = self.call_graph.borrow().as_ref().map(Arc::clone);
         let test_chunks = self.test_chunks.borrow().as_ref().map(Arc::clone);
-        let notes_cache = self.notes_cache.borrow().as_ref().map(Arc::clone);
-        let file_set = self.file_set.borrow().as_ref().map(Arc::clone);
-        let splade_index_snapshot = self
-            .splade_index
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .as_ref()
-            .map(Arc::clone);
+        let notes_cache = snapshot_cell(&self.notes_cache);
+        let file_set = snapshot_cell(&self.file_set);
+        let splade_index_snapshot = snapshot_cell(&self.splade_index);
         let config = self.config();
         let audit_state = self.audit_state();
         BatchView {
@@ -1417,7 +1355,13 @@ impl BatchContext {
             cached_notes: notes_cache,
             cached_file_set: file_set,
             cached_splade_index: splade_index_snapshot,
+            vector_index_cell: Arc::clone(&self.hnsw),
+            base_vector_index_cell: Arc::clone(&self.base_hnsw),
+            file_set_cell: Arc::clone(&self.file_set),
+            notes_cell: Arc::clone(&self.notes_cache),
             splade_index_cell: Arc::clone(&self.splade_index),
+            invalidation_epoch: Arc::clone(&self.invalidation_epoch),
+            checkout_epoch,
             embedder_slot: Arc::clone(&self.embedder),
             reranker_slot: Arc::clone(&self.reranker),
             splade_encoder_slot: Arc::clone(&self.splade_encoder),

--- a/src/cli/batch/context.rs
+++ b/src/cli/batch/context.rs
@@ -34,6 +34,21 @@ pub(super) struct DataVersionProbe {
 
 // ─── BatchContext ────────────────────────────────────────────────────────────
 
+/// One bit per mutable-cache slot, used by the deferred-invalidation mask
+/// (`BatchContext::pending_invalidation`) so a retry clears only the slots
+/// that were actually deferred.
+mod slot {
+    pub(super) const HNSW: u8 = 1 << 0;
+    pub(super) const BASE_HNSW: u8 = 1 << 1;
+    pub(super) const CALL_GRAPH: u8 = 1 << 2;
+    pub(super) const TEST_CHUNKS: u8 = 1 << 3;
+    pub(super) const FILE_SET: u8 = 1 << 4;
+    pub(super) const NOTES: u8 = 1 << 5;
+    pub(super) const SPLADE: u8 = 1 << 6;
+    pub(super) const REFS: u8 = 1 << 7;
+    pub(super) const ALL: u8 = u8::MAX;
+}
+
 /// Shared resources for a batch session.
 ///
 /// Store is opened once. Embedder and vector index are lazily initialized on
@@ -136,13 +151,18 @@ pub(crate) struct BatchContext {
     /// a value built from a pre-invalidation store snapshot can never land
     /// after (and survive) a fresh invalidation.
     pub(super) invalidation_epoch: Arc<AtomicU64>,
-    /// Sticky flag set when [`Self::invalidate_mutable_caches`] had to defer
-    /// at least one slot (a handler held its borrow/lock mid-invalidation).
-    /// [`Self::check_index_staleness`] honors it regardless of the identity /
-    /// data_version discriminators — those were already consumed when the
-    /// invalidation first fired, so without the flag the deferred slots would
-    /// never be retried. Cleared only when every slot actually cleared.
-    pub(super) pending_invalidation: Cell<bool>,
+    /// Sticky per-slot deferral mask (bits from the `slot` constants below;
+    /// `0` = nothing pending). Set when [`Self::invalidate_mutable_caches`]
+    /// had to defer at least one slot (a handler held its borrow/lock
+    /// mid-invalidation). [`Self::check_index_staleness`] honors it
+    /// regardless of the identity / data_version discriminators — those were
+    /// already consumed when the invalidation first fired, so without the
+    /// mask the deferred slots would never be retried. The retry clears ONLY
+    /// the masked slots and does NOT bump the epoch: re-bumping would
+    /// discard every in-flight fresh publish and wipe freshly rebuilt slots
+    /// on every dispatch while one slot stays contended. Cleared (to 0) only
+    /// when every deferred slot actually cleared.
+    pub(super) pending_invalidation: Cell<u8>,
     // LRU caps at 2 — each ReferenceIndex holds Store + HNSW (50-200MB).
     // Values are `Arc` so `get_all_refs` can fan out refs to parallel
     // `--include-refs` searches without cloning the index bytes.
@@ -272,7 +292,7 @@ impl BatchContext {
             file_set: Arc::new(Mutex::new(None)),
             notes_cache: Arc::new(Mutex::new(None)),
             invalidation_epoch: Arc::new(AtomicU64::new(0)),
-            pending_invalidation: Cell::new(false),
+            pending_invalidation: Cell::new(0),
             splade_encoder: Arc::new(OnceLock::new()),
             splade_index: Arc::new(Mutex::new(None)),
             refs: Arc::new(Mutex::new(lru::LruCache::new(refs_lru_size()))),
@@ -421,7 +441,7 @@ impl BatchContext {
         // waiting on them would never retry the deferred slots.
         let pending = self.pending_invalidation.get();
         let now = Instant::now();
-        if !pending {
+        if pending == 0 {
             if let Some(prev) = self.last_staleness_check.get() {
                 if now.duration_since(prev) < STALENESS_CHECK_INTERVAL {
                     return;
@@ -502,12 +522,15 @@ impl BatchContext {
                     tracing::warn!(error = %e, "Failed to re-open Store after index change");
                 }
             }
-        } else if pending {
-            // Retry a deferred invalidation. The Store re-open and probe
-            // rebaseline already happened when the invalidation first fired;
-            // only the slots that were busy still need clearing.
+        } else if pending != 0 {
+            // Retry a deferred invalidation. The Store re-open, probe
+            // rebaseline, and epoch bump already happened when the
+            // invalidation first fired; only the slots that were busy still
+            // need clearing. Clear-only, masked: no epoch re-bump (which
+            // would discard in-flight fresh publishes) and no wipe of slots
+            // that were already cleared and freshly rebuilt since.
             let _span = tracing::info_span!("batch_index_invalidation_retry").entered();
-            self.invalidate_mutable_caches();
+            self.clear_cache_slots(pending);
         }
         self.index_id.set(Some(current_id));
     }
@@ -613,9 +636,10 @@ impl BatchContext {
     /// the freshly persisted `splade.index.bin` (or SQLite fallback).
     /// Returns `true` when every slot actually cleared; `false` when at
     /// least one slot was deferred (a handler held its borrow/lock). On
-    /// deferral the sticky `pending_invalidation` flag is set so
-    /// [`Self::check_index_staleness`] retries the clear even though the
-    /// identity / data_version discriminators were already consumed.
+    /// deferral the sticky `pending_invalidation` mask records the deferred
+    /// slots so [`Self::check_index_staleness`] retries the clear even
+    /// though the identity / data_version discriminators were already
+    /// consumed.
     fn invalidate_mutable_caches(&self) -> bool {
         // Bump the epoch BEFORE clearing any slot: a view that snapshotted
         // the previous epoch at checkout sees the mismatch when it tries to
@@ -623,23 +647,36 @@ impl BatchContext {
         // pre-invalidation store snapshot is discarded instead of being
         // re-published over the cleared cell.
         self.invalidation_epoch.fetch_add(1, Ordering::SeqCst);
+        self.clear_cache_slots(slot::ALL)
+    }
 
-        // Use try_borrow_mut / try_lock: a search handler may still hold a
-        // borrow on a cache slot across an accessor call that triggers a
-        // staleness re-check (for example handlers/search.rs does
-        // `let splade_index_ref = ctx.borrow_splade_index()` then later
-        // calls `ctx.store().search_hybrid(...)`). Panicking on
-        // borrow_mut() would crash the whole batch session for what is
-        // just a deferral case. Slots that are busy stay populated; the
-        // sticky flag set below makes the next staleness check retry.
-        let mut all_clear = true;
+    /// Clear the cache slots named in `mask`. Does NOT bump the epoch — the
+    /// deferred-invalidation retry path depends on that: any value that can
+    /// be published into a slot after the original invalidation was built at
+    /// or after the already-bumped epoch (older builds fail the publish
+    /// guard), so re-bumping here would only discard legitimate fresh
+    /// publishes and re-clear freshly rebuilt slots on every dispatch while
+    /// one slot stays contended.
+    ///
+    /// Uses `try_borrow_mut` / `try_lock`: a search handler may still hold a
+    /// borrow on a cache slot across an accessor call that triggers a
+    /// staleness re-check (for example handlers/search.rs does
+    /// `let splade_index_ref = ctx.borrow_splade_index()` then later calls
+    /// `ctx.store().search_hybrid(...)`). Panicking on borrow_mut() would
+    /// crash the whole batch session for what is just a deferral case.
+    /// Busy slots stay populated and are recorded in the sticky
+    /// `pending_invalidation` mask for the next retry.
+    fn clear_cache_slots(&self, mask: u8) -> bool {
+        let mut deferred: u8 = 0;
         macro_rules! try_clear_refcell {
-            ($field:expr, $name:literal) => {
-                match $field.try_borrow_mut() {
-                    Ok(mut g) => *g = None,
-                    Err(_) => {
-                        all_clear = false;
-                        tracing::debug!(slot = $name, "borrow held; deferring invalidation");
+            ($field:expr, $bit:expr, $name:literal) => {
+                if mask & $bit != 0 {
+                    match $field.try_borrow_mut() {
+                        Ok(mut g) => *g = None,
+                        Err(_) => {
+                            deferred |= $bit;
+                            tracing::debug!(slot = $name, "borrow held; deferring invalidation");
+                        }
                     }
                 }
             };
@@ -647,42 +684,48 @@ impl BatchContext {
         // Shared write-back cells are `Arc<Mutex<...>>`; `try_lock` mirrors
         // the borrow-deferral semantics of the RefCell branches.
         macro_rules! try_clear_cell {
-            ($field:expr, $name:literal) => {
-                match $field.try_lock() {
-                    Ok(mut g) => *g = None,
-                    Err(_) => {
-                        all_clear = false;
-                        tracing::debug!(slot = $name, "lock held; deferring invalidation");
+            ($field:expr, $bit:expr, $name:literal) => {
+                if mask & $bit != 0 {
+                    match $field.try_lock() {
+                        Ok(mut g) => *g = None,
+                        Err(_) => {
+                            deferred |= $bit;
+                            tracing::debug!(slot = $name, "lock held; deferring invalidation");
+                        }
                     }
                 }
             };
         }
-        try_clear_cell!(self.hnsw, "hnsw");
-        try_clear_cell!(self.base_hnsw, "base_hnsw");
-        try_clear_refcell!(self.call_graph, "call_graph");
-        try_clear_refcell!(self.test_chunks, "test_chunks");
-        try_clear_cell!(self.file_set, "file_set");
-        try_clear_cell!(self.notes_cache, "notes_cache");
-        try_clear_cell!(self.splade_index, "splade_index");
+        try_clear_cell!(self.hnsw, slot::HNSW, "hnsw");
+        try_clear_cell!(self.base_hnsw, slot::BASE_HNSW, "base_hnsw");
+        try_clear_refcell!(self.call_graph, slot::CALL_GRAPH, "call_graph");
+        try_clear_refcell!(self.test_chunks, slot::TEST_CHUNKS, "test_chunks");
+        try_clear_cell!(self.file_set, slot::FILE_SET, "file_set");
+        try_clear_cell!(self.notes_cache, slot::NOTES, "notes_cache");
+        try_clear_cell!(self.splade_index, slot::SPLADE, "splade_index");
         // refs LRU is `Arc<Mutex<...>>` (shared with BatchView). If a
         // handler thread holds the mutex (e.g. iterating refs in a parallel
         // search), the eviction is deferred to the next retry.
-        match self.refs.try_lock() {
-            Ok(mut g) => g.clear(),
-            Err(_) => {
-                all_clear = false;
-                tracing::debug!(slot = "refs", "lock held; deferring invalidation");
+        if mask & slot::REFS != 0 {
+            match self.refs.try_lock() {
+                Ok(mut g) => g.clear(),
+                Err(_) => {
+                    deferred |= slot::REFS;
+                    tracing::debug!(slot = "refs", "lock held; deferring invalidation");
+                }
             }
         }
 
-        // Sticky: stays set across checks until a retry clears every slot.
-        self.pending_invalidation.set(!all_clear);
-        if !all_clear {
+        // Sticky: stays set across checks until a retry clears every
+        // deferred slot.
+        self.pending_invalidation.set(deferred);
+        if deferred != 0 {
             tracing::debug!(
-                "partial cache invalidation; pending flag set — next staleness check retries"
+                deferred_mask = deferred,
+                "partial cache invalidation; pending mask set — next staleness check retries"
             );
         }
-        all_clear
+        deferred == 0
     }
 
     /// Manually invalidate all mutable caches and re-open the Store.

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -474,9 +474,10 @@ mod tests {
             ctx.invalidation_epoch.load(Ordering::SeqCst) > epoch_before,
             "invalidation must bump the epoch"
         );
-        assert!(
-            !ctx.pending_invalidation.get(),
-            "full clear must not leave the pending flag set"
+        assert_eq!(
+            ctx.pending_invalidation.get(),
+            0,
+            "full clear must not leave the pending mask set"
         );
     }
 
@@ -1454,9 +1455,10 @@ mod tests {
             ctx.notes_cache.lock().unwrap().is_none(),
             "unborrowed slots clear immediately"
         );
-        assert!(
+        assert_ne!(
             ctx.pending_invalidation.get(),
-            "deferral must set the sticky pending flag"
+            0,
+            "deferral must set the sticky pending mask"
         );
 
         // Nothing changed on disk since invalidate() (identity refreshed,
@@ -1467,9 +1469,10 @@ mod tests {
             ctx.call_graph.borrow().is_none(),
             "pending retry must clear the deferred slot"
         );
-        assert!(
-            !ctx.pending_invalidation.get(),
-            "flag clears once every slot actually cleared"
+        assert_eq!(
+            ctx.pending_invalidation.get(),
+            0,
+            "mask clears once every deferred slot actually cleared"
         );
     }
 
@@ -1499,5 +1502,110 @@ mod tests {
             ctx.notes_cache.lock().unwrap().is_none(),
             "stale-epoch notes publish must be discarded"
         );
+    }
+
+    /// The read direction of the epoch guard: a view checked out BEFORE an
+    /// invalidation must not serve cell values published AFTER it — those
+    /// belong to the next index generation, and mixing them with the view's
+    /// older store snapshot returns silently wrong rowids. The stale view
+    /// must fall back to building from its own snapshot (whose publish is
+    /// then discarded), leaving the sibling's published values untouched.
+    #[test]
+    fn test_stale_view_does_not_read_post_invalidation_cells() {
+        let (_dir, cqs_dir) = setup_test_store();
+        let ctx = create_test_context(&cqs_dir).unwrap();
+
+        // Checkout with empty snapshots at the pre-invalidation epoch.
+        let view = ctx.build_view(None);
+
+        // Invalidation runs, then a post-invalidation sibling publishes
+        // next-generation values into the shared cells (simulated by
+        // writing the cells directly).
+        ctx.invalidate().unwrap();
+        *ctx.hnsw.lock().unwrap() = Some(std::sync::Arc::new(MockIdx));
+        let sentinel = PathBuf::from("/sentinel/from/next/generation");
+        *ctx.file_set.lock().unwrap() = Some(std::sync::Arc::new(
+            [sentinel.clone()].into_iter().collect::<HashSet<_>>(),
+        ));
+
+        // The stale view must not serve either next-generation value.
+        if let Some(idx) = view.vector_index().unwrap() {
+            assert_ne!(
+                idx.name(),
+                "mock",
+                "stale view must not serve a post-invalidation cell index"
+            );
+        }
+        let fs = view.file_set().unwrap();
+        assert!(
+            !fs.contains(&sentinel),
+            "stale view must enumerate from its own snapshot, not read the newer cell"
+        );
+
+        // And its own (discarded) rebuilds must not overwrite the sibling's
+        // published next-generation values.
+        assert_eq!(
+            ctx.hnsw
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|i| i.name())
+                .unwrap_or("<cleared>"),
+            "mock",
+            "stale view's rebuild must not displace the published index"
+        );
+        assert!(
+            ctx.file_set
+                .lock()
+                .unwrap()
+                .as_ref()
+                .is_some_and(|fs| fs.contains(&sentinel)),
+            "stale view's rebuild must not displace the published file set"
+        );
+    }
+
+    /// The sticky retry is clear-only and masked: it must not re-bump the
+    /// epoch (which would discard every in-flight fresh publish) and must
+    /// not wipe slots that already cleared and were freshly rebuilt —
+    /// otherwise one contended slot reintroduces the rebuild-per-query cost
+    /// for all the others.
+    #[test]
+    fn test_sticky_retry_is_clear_only_and_masked() {
+        let (_dir, cqs_dir) = setup_test_store();
+        let ctx = create_test_context(&cqs_dir).unwrap();
+
+        *ctx.notes_cache.lock().unwrap() = Some(std::sync::Arc::new(vec![]));
+        *ctx.call_graph.borrow_mut() = Some(std::sync::Arc::new(
+            cqs::store::CallGraph::from_string_maps(Default::default(), Default::default()),
+        ));
+        ctx.check_index_staleness(); // baseline discriminators
+
+        // Invalidation fires while a handler holds the call_graph borrow —
+        // that slot defers, everything else clears.
+        let held = ctx.call_graph.borrow();
+        ctx.invalidate().unwrap();
+        drop(held);
+        assert_ne!(ctx.pending_invalidation.get(), 0);
+
+        // A fresh post-invalidation rebuild lands in a non-deferred slot.
+        *ctx.notes_cache.lock().unwrap() = Some(std::sync::Arc::new(vec![]));
+        let epoch_after_invalidate = ctx.invalidation_epoch.load(Ordering::SeqCst);
+
+        // The retry clears ONLY the deferred slot.
+        ctx.check_index_staleness();
+        assert_eq!(
+            ctx.invalidation_epoch.load(Ordering::SeqCst),
+            epoch_after_invalidate,
+            "retry must not re-bump the epoch"
+        );
+        assert!(
+            ctx.notes_cache.lock().unwrap().is_some(),
+            "retry must not wipe freshly rebuilt non-deferred slots"
+        );
+        assert!(
+            ctx.call_graph.borrow().is_none(),
+            "retry must clear the deferred slot"
+        );
+        assert_eq!(ctx.pending_invalidation.get(), 0);
     }
 }

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -445,28 +445,39 @@ mod tests {
         let ctx = create_test_context(&cqs_dir).unwrap();
 
         // Populate mutable caches
-        *ctx.file_set.borrow_mut() = Some(std::sync::Arc::new(HashSet::new()));
-        *ctx.notes_cache.borrow_mut() = Some(std::sync::Arc::new(vec![]));
+        *ctx.file_set.lock().unwrap() = Some(std::sync::Arc::new(HashSet::new()));
+        *ctx.notes_cache.lock().unwrap() = Some(std::sync::Arc::new(vec![]));
         *ctx.call_graph.borrow_mut() = Some(std::sync::Arc::new(
             cqs::store::CallGraph::from_string_maps(Default::default(), Default::default()),
         ));
         *ctx.test_chunks.borrow_mut() = Some(std::sync::Arc::new(vec![]));
 
         // Verify caches are populated
-        assert!(ctx.file_set.borrow().is_some());
-        assert!(ctx.notes_cache.borrow().is_some());
+        assert!(ctx.file_set.lock().unwrap().is_some());
+        assert!(ctx.notes_cache.lock().unwrap().is_some());
         assert!(ctx.call_graph.borrow().is_some());
         assert!(ctx.test_chunks.borrow().is_some());
 
         // Invalidate
+        let epoch_before = ctx.invalidation_epoch.load(Ordering::SeqCst);
         ctx.invalidate().unwrap();
 
         // Verify all mutable caches are cleared
-        assert!(ctx.file_set.borrow().is_none());
-        assert!(ctx.notes_cache.borrow().is_none());
+        assert!(ctx.file_set.lock().unwrap().is_none());
+        assert!(ctx.notes_cache.lock().unwrap().is_none());
         assert!(ctx.call_graph.borrow().is_none());
         assert!(ctx.test_chunks.borrow().is_none());
-        assert!(ctx.hnsw.borrow().is_none());
+        assert!(ctx.hnsw.lock().unwrap().is_none());
+        assert!(ctx.base_hnsw.lock().unwrap().is_none());
+        // Epoch bumps so in-flight view builds can't republish stale values.
+        assert!(
+            ctx.invalidation_epoch.load(Ordering::SeqCst) > epoch_before,
+            "invalidation must bump the epoch"
+        );
+        assert!(
+            !ctx.pending_invalidation.get(),
+            "full clear must not leave the pending flag set"
+        );
     }
 
     #[test]
@@ -475,13 +486,13 @@ mod tests {
         let ctx = create_test_context(&cqs_dir).unwrap();
 
         // Populate a cache
-        *ctx.notes_cache.borrow_mut() = Some(std::sync::Arc::new(vec![]));
-        assert!(ctx.notes_cache.borrow().is_some());
+        *ctx.notes_cache.lock().unwrap() = Some(std::sync::Arc::new(vec![]));
+        assert!(ctx.notes_cache.lock().unwrap().is_some());
 
         // First staleness check — sets baseline mtime, no invalidation
         ctx.check_index_staleness();
         assert!(
-            ctx.notes_cache.borrow().is_some(),
+            ctx.notes_cache.lock().unwrap().is_some(),
             "First check should not invalidate"
         );
 
@@ -503,7 +514,7 @@ mod tests {
         // Second staleness check — mtime changed, should invalidate
         ctx.check_index_staleness();
         assert!(
-            ctx.notes_cache.borrow().is_none(),
+            ctx.notes_cache.lock().unwrap().is_none(),
             "Mtime change should invalidate cache"
         );
     }
@@ -522,10 +533,10 @@ mod tests {
         let ctx = create_test_context(&cqs_dir).unwrap();
 
         // Populate a cache and run the first check to capture baseline identity.
-        *ctx.notes_cache.borrow_mut() = Some(std::sync::Arc::new(vec![]));
+        *ctx.notes_cache.lock().unwrap() = Some(std::sync::Arc::new(vec![]));
         ctx.check_index_staleness();
         assert!(
-            ctx.notes_cache.borrow().is_some(),
+            ctx.notes_cache.lock().unwrap().is_some(),
             "First check should not invalidate"
         );
 
@@ -573,7 +584,7 @@ mod tests {
         // identical (rename-over with same mtime, new inode).
         ctx.check_index_staleness();
         assert!(
-            ctx.notes_cache.borrow().is_none(),
+            ctx.notes_cache.lock().unwrap().is_none(),
             "DS-V1.25-6: rename-over replacement (same mtime, new inode) should invalidate cache"
         );
     }
@@ -592,10 +603,10 @@ mod tests {
 
         // Populate a cache and run the first check to baseline both
         // discriminators (identity + data_version).
-        *ctx.notes_cache.borrow_mut() = Some(std::sync::Arc::new(vec![]));
+        *ctx.notes_cache.lock().unwrap() = Some(std::sync::Arc::new(vec![]));
         ctx.check_index_staleness();
         assert!(
-            ctx.notes_cache.borrow().is_some(),
+            ctx.notes_cache.lock().unwrap().is_some(),
             "baseline check must not invalidate"
         );
 
@@ -641,7 +652,7 @@ mod tests {
         ctx.last_staleness_check.set(None);
         ctx.check_index_staleness();
         assert!(
-            ctx.notes_cache.borrow().is_none(),
+            ctx.notes_cache.lock().unwrap().is_none(),
             "DS-V1.40-1: WAL commit with no checkpoint must invalidate caches via data_version"
         );
 
@@ -662,9 +673,9 @@ mod tests {
         let ctx = create_test_context(&cqs_dir).unwrap();
         let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
 
-        *ctx.notes_cache.borrow_mut() = Some(std::sync::Arc::new(vec![]));
+        *ctx.notes_cache.lock().unwrap() = Some(std::sync::Arc::new(vec![]));
         ctx.check_index_staleness();
-        assert!(ctx.notes_cache.borrow().is_some());
+        assert!(ctx.notes_cache.lock().unwrap().is_some());
 
         // Rename-over (the `cqs index --force` shape).
         let replacement = cqs_dir.join("index.db.replacement");
@@ -676,12 +687,12 @@ mod tests {
         ctx.last_staleness_check.set(None);
         ctx.check_index_staleness(); // identity fires; probe rebaselines here
         assert!(
-            ctx.notes_cache.borrow().is_none(),
+            ctx.notes_cache.lock().unwrap().is_none(),
             "identity change must invalidate"
         );
 
         // Repopulate, then WAL-commit against the NEW file with no checkpoint.
-        *ctx.notes_cache.borrow_mut() = Some(std::sync::Arc::new(vec![]));
+        *ctx.notes_cache.lock().unwrap() = Some(std::sync::Arc::new(vec![]));
         let id_before = DbFileIdentity::from_path(&index_path).unwrap();
         let mut writer = ctx
             .runtime
@@ -712,7 +723,7 @@ mod tests {
         ctx.last_staleness_check.set(None);
         ctx.check_index_staleness();
         assert!(
-            ctx.notes_cache.borrow().is_none(),
+            ctx.notes_cache.lock().unwrap().is_none(),
             "probe must be re-opened against the new inode after rename-over — \
              a stale probe fd would never observe this commit"
         );
@@ -1325,5 +1336,168 @@ mod tests {
         // Counter invariant — success bumps query, leaves errors alone.
         assert_eq!(ctx.query_count.load(Ordering::Relaxed), 1);
         assert_eq!(ctx.error_count.load(Ordering::Relaxed), 0);
+    }
+
+    // ===== Shared write-back cells + invalidation epoch =====
+    //
+    // All production dispatch goes through BatchView. The view snapshots the
+    // BatchContext caches at checkout; on a miss it builds the value and
+    // publishes it back into the shared cell (epoch-guarded) so the daemon
+    // doesn't rebuild the vector index / file set / notes on every query.
+
+    /// Minimal `VectorIndex` for cell-plumbing tests — no GPU, no disk.
+    struct MockIdx;
+    impl VectorIndex for MockIdx {
+        fn search(&self, _query: &cqs::embedder::Embedding, _k: usize) -> Vec<cqs::IndexResult> {
+            vec![]
+        }
+        fn len(&self) -> usize {
+            1
+        }
+        fn name(&self) -> &'static str {
+            "mock"
+        }
+        fn dim(&self) -> usize {
+            cqs::EMBEDDING_DIM
+        }
+    }
+
+    /// A view whose checkout snapshotted empty caches must (1) serve a
+    /// populated shared cell without rebuilding, and (2) publish its own
+    /// fallback builds back into the cells so the next checkout snapshots
+    /// them instead of rebuilding.
+    #[test]
+    fn test_view_fallback_writes_back_to_shared_cells() {
+        let (_dir, cqs_dir) = setup_test_store();
+        let ctx = create_test_context(&cqs_dir).unwrap();
+
+        let view = ctx.build_view(None);
+        assert!(view.cached_file_set.is_none(), "first checkout is a miss");
+        assert!(view.cached_notes.is_none(), "first checkout is a miss");
+
+        let _ = view.file_set().unwrap();
+        let _ = view.notes();
+
+        assert!(
+            ctx.file_set.lock().unwrap().is_some(),
+            "view fallback must write the file set back into the shared cell"
+        );
+        assert!(
+            ctx.notes_cache.lock().unwrap().is_some(),
+            "view fallback must write notes back into the shared cell"
+        );
+
+        let second = ctx.build_view(None);
+        assert!(
+            second.cached_file_set.is_some(),
+            "second checkout must snapshot the published file set"
+        );
+        assert!(
+            second.cached_notes.is_some(),
+            "second checkout must snapshot the published notes"
+        );
+    }
+
+    /// The vector-index cell is shared: a view checked out before the cell
+    /// was populated still serves the cell value (no rebuild), and a later
+    /// checkout snapshots it.
+    #[test]
+    fn test_view_vector_index_served_from_shared_cell() {
+        let (_dir, cqs_dir) = setup_test_store();
+        let ctx = create_test_context(&cqs_dir).unwrap();
+
+        // Checkout while the cell is empty — snapshot is a miss.
+        let view = ctx.build_view(None);
+        assert!(view.cached_vector_index.is_none());
+
+        // A sibling view publishes (simulated by writing the cell directly).
+        *ctx.hnsw.lock().unwrap() = Some(std::sync::Arc::new(MockIdx));
+
+        // The earlier view falls back to the live cell — no rebuild.
+        let idx = view.vector_index().unwrap().expect("cell value served");
+        assert_eq!(idx.name(), "mock");
+
+        // The next checkout snapshots the published value.
+        let second = ctx.build_view(None);
+        assert!(
+            second.cached_vector_index.is_some(),
+            "checkout must snapshot the populated vector-index cell"
+        );
+    }
+
+    /// A deferred invalidation (handler held a borrow on a cache slot while
+    /// invalidation fired) must be retried by the next staleness check even
+    /// though the identity / data_version discriminators were already
+    /// consumed — the sticky pending flag is the only remaining trigger.
+    #[test]
+    fn test_deferred_invalidation_retries_via_sticky_flag() {
+        let (_dir, cqs_dir) = setup_test_store();
+        let ctx = create_test_context(&cqs_dir).unwrap();
+
+        *ctx.notes_cache.lock().unwrap() = Some(std::sync::Arc::new(vec![]));
+        *ctx.call_graph.borrow_mut() = Some(std::sync::Arc::new(
+            cqs::store::CallGraph::from_string_maps(Default::default(), Default::default()),
+        ));
+        ctx.check_index_staleness(); // baseline both discriminators
+
+        // Hold a borrow across the invalidation — the live shape is a search
+        // handler holding a cache value while a concurrent refresh fires.
+        let held = ctx.call_graph.borrow();
+        ctx.invalidate().unwrap();
+        drop(held);
+
+        assert!(
+            ctx.call_graph.borrow().is_some(),
+            "borrowed slot must be deferred, not cleared (and not panic)"
+        );
+        assert!(
+            ctx.notes_cache.lock().unwrap().is_none(),
+            "unborrowed slots clear immediately"
+        );
+        assert!(
+            ctx.pending_invalidation.get(),
+            "deferral must set the sticky pending flag"
+        );
+
+        // Nothing changed on disk since invalidate() (identity refreshed,
+        // probe rebaselined, rate-limit freshly armed) — only the sticky
+        // flag can drive this retry.
+        ctx.check_index_staleness();
+        assert!(
+            ctx.call_graph.borrow().is_none(),
+            "pending retry must clear the deferred slot"
+        );
+        assert!(
+            !ctx.pending_invalidation.get(),
+            "flag clears once every slot actually cleared"
+        );
+    }
+
+    /// A view-side cache build that races an invalidation must not publish:
+    /// the value was built from the pre-invalidation store snapshot, and
+    /// re-publishing it would serve stale data indefinitely on a quiet repo.
+    #[test]
+    fn test_stale_epoch_publish_is_discarded() {
+        let (_dir, cqs_dir) = setup_test_store();
+        let ctx = create_test_context(&cqs_dir).unwrap();
+
+        let view = ctx.build_view(None);
+        // Invalidation runs after checkout — mid-dispatch from the view's
+        // perspective. Bumps the epoch and clears the cells.
+        ctx.invalidate().unwrap();
+
+        // The in-flight dispatch still gets its (snapshot-consistent) values…
+        let _ = view.file_set().unwrap();
+        let _ = view.notes();
+
+        // …but the stale-snapshot builds must not land in the shared cells.
+        assert!(
+            ctx.file_set.lock().unwrap().is_none(),
+            "stale-epoch file_set publish must be discarded"
+        );
+        assert!(
+            ctx.notes_cache.lock().unwrap().is_none(),
+            "stale-epoch notes publish must be discarded"
+        );
     }
 }

--- a/src/cli/batch/view.rs
+++ b/src/cli/batch/view.rs
@@ -252,11 +252,11 @@ pub(crate) fn get_all_refs_via_refs_lru(
 // daemon-dispatchable command that mutates BatchContext interior.
 pub(crate) struct BatchView {
     pub(super) store: Arc<Store<ReadOnly>>,
-    /// HNSW snapshot taken at checkout. Handlers that need a fresh build
-    /// fall back to `lazy_vector_index` which rebuilds via the store; the
-    /// rebuild path doesn't touch BatchContext (the Arc<dyn VectorIndex>
-    /// is constructed fresh each time the cached snapshot is None and
-    /// stays local to this view).
+    /// Vector-index snapshot taken at checkout. When `None`, the accessor
+    /// falls back to the shared cell (another view may have built and
+    /// published since checkout), then to a fresh build from the snapshot
+    /// store — which is published back into the shared cell (epoch-guarded)
+    /// so subsequent checkouts snapshot it instead of rebuilding.
     pub(super) cached_vector_index: Option<Arc<dyn VectorIndex>>,
     pub(super) cached_base_vector_index: Option<Arc<dyn VectorIndex>>,
     pub(super) cached_call_graph: Option<Arc<cqs::store::CallGraph>>,
@@ -264,11 +264,23 @@ pub(crate) struct BatchView {
     pub(super) cached_notes: Option<Arc<Vec<cqs::note::Note>>>,
     pub(super) cached_file_set: Option<Arc<HashSet<PathBuf>>>,
     pub(super) cached_splade_index: Option<Arc<cqs::splade::index::SpladeIndex>>,
-    /// Shared `Arc<Mutex<...>>` to the BatchContext's splade_index cell.
-    /// `ensure_splade_index` populates it for handlers running through
-    /// the view; the BatchContext path picks up the same value on its
-    /// next `checkout_view`.
+    /// Shared `Arc<Mutex<...>>` write-back cells aliasing the BatchContext's
+    /// mutable caches. A view-side cache miss builds the value, then
+    /// publishes it back through [`Self::publish_if_current`]; the
+    /// BatchContext path picks the same value up on its next
+    /// `checkout_view`. Cleared by `invalidate_mutable_caches`.
+    pub(super) vector_index_cell: Arc<Mutex<Option<Arc<dyn VectorIndex>>>>,
+    pub(super) base_vector_index_cell: Arc<Mutex<Option<Arc<dyn VectorIndex>>>>,
+    pub(super) file_set_cell: Arc<Mutex<Option<Arc<HashSet<PathBuf>>>>>,
+    pub(super) notes_cell: Arc<Mutex<Option<Arc<Vec<cqs::note::Note>>>>>,
     pub(super) splade_index_cell: Arc<Mutex<Option<Arc<cqs::splade::index::SpladeIndex>>>>,
+    /// Shared invalidation-epoch counter plus the value it held when this
+    /// view was checked out. `publish_if_current` compares the two under
+    /// the cell lock: any invalidation since checkout bumped the counter,
+    /// so a value built from this view's (now stale) store snapshot is
+    /// discarded instead of being published over the fresh invalidation.
+    pub(super) invalidation_epoch: Arc<AtomicU64>,
+    pub(super) checkout_epoch: u64,
     /// Shared `Arc<OnceLock<...>>` to the BatchContext embedder slot. Init
     /// from the view propagates to the BatchContext (and any other view
     /// holding the same Arc).
@@ -319,9 +331,35 @@ impl BatchView {
         Arc::clone(&self.store)
     }
 
-    /// HNSW vector index for this snapshot. If the cache was empty at
-    /// checkout, build a fresh one from the snapshot store (no BatchContext
-    /// access needed).
+    /// Publish a freshly built cache value into a shared BatchContext cell —
+    /// unless an invalidation ran since this view was checked out. The epoch
+    /// is compared under the cell lock, and `invalidate_mutable_caches`
+    /// bumps the counter before clearing the cells, so a build from a
+    /// pre-invalidation store snapshot can never land after (and survive) a
+    /// fresh invalidation. The discarded value still serves the in-flight
+    /// dispatch: it matches the view's own store snapshot, so the current
+    /// query stays internally consistent.
+    fn publish_if_current<T: ?Sized>(
+        &self,
+        cell: &Mutex<Option<Arc<T>>>,
+        value: &Arc<T>,
+        slot: &'static str,
+    ) {
+        let mut guard = cell.lock().unwrap_or_else(|p| p.into_inner());
+        if self.invalidation_epoch.load(Ordering::SeqCst) == self.checkout_epoch {
+            *guard = Some(Arc::clone(value));
+        } else {
+            tracing::debug!(
+                slot,
+                "invalidation ran since view checkout — discarding freshly built cache value"
+            );
+        }
+    }
+
+    /// Vector index for this snapshot. Falls back to the shared cell (a
+    /// sibling view may have built it since checkout), then to a fresh build
+    /// from the snapshot store — published back into the shared cell so the
+    /// next checkout snapshots it instead of rebuilding from disk.
     pub fn vector_index(&self) -> Result<Option<Arc<dyn VectorIndex>>> {
         if let Some(arc) = &self.cached_vector_index {
             if !arc.is_poisoned() {
@@ -332,18 +370,49 @@ impl BatchView {
                 "BatchView vector index is poisoned — rebuilding from snapshot store"
             );
         }
+        {
+            // The cell is cleared on invalidation, so a populated cell is
+            // current. A poisoned cell value falls through to the rebuild,
+            // which publishes over it.
+            let guard = self
+                .vector_index_cell
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            if let Some(arc) = guard.as_ref() {
+                if !arc.is_poisoned() {
+                    return Ok(Some(Arc::clone(arc)));
+                }
+            }
+        }
         let _span = tracing::info_span!("batch_view_vector_index_init").entered();
         let idx = build_vector_index(&self.store, &self.cqs_dir, self.config.ef_search)?;
-        Ok(idx.map(|boxed| -> Arc<dyn VectorIndex> { boxed.into() }))
+        let result = idx.map(|boxed| -> Arc<dyn VectorIndex> { boxed.into() });
+        if let Some(arc) = &result {
+            self.publish_if_current(&self.vector_index_cell, arc, "hnsw");
+        }
+        Ok(result)
     }
 
     pub fn base_vector_index(&self) -> Result<Option<Arc<dyn VectorIndex>>> {
         if let Some(arc) = &self.cached_base_vector_index {
             return Ok(Some(Arc::clone(arc)));
         }
+        {
+            let guard = self
+                .base_vector_index_cell
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            if let Some(arc) = guard.as_ref() {
+                return Ok(Some(Arc::clone(arc)));
+            }
+        }
         let _span = tracing::info_span!("batch_view_base_vector_index_init").entered();
         let idx = crate::cli::build_base_vector_index(&self.store, &self.cqs_dir)?;
-        Ok(idx.map(|boxed| -> Arc<dyn VectorIndex> { boxed.into() }))
+        let result = idx.map(|boxed| -> Arc<dyn VectorIndex> { boxed.into() });
+        if let Some(arc) = &result {
+            self.publish_if_current(&self.base_vector_index_cell, arc, "base_hnsw");
+        }
+        Ok(result)
     }
 
     pub fn embedder(&self) -> Result<&Embedder> {
@@ -456,10 +525,10 @@ impl BatchView {
                 "SPLADE index loaded from disk (view)"
             );
         }
-        *self
-            .splade_index_cell
-            .lock()
-            .unwrap_or_else(|p| p.into_inner()) = Some(Arc::new(idx));
+        // Epoch-guarded publish: if an invalidation cleared the cell while
+        // the (potentially long) build above ran, the index was built from a
+        // stale snapshot and must not be re-published over the clear.
+        self.publish_if_current(&self.splade_index_cell, &Arc::new(idx), "splade_index");
     }
 
     pub fn borrow_splade_index(&self) -> Option<Arc<cqs::splade::index::SpladeIndex>> {
@@ -494,9 +563,16 @@ impl BatchView {
         if let Some(notes) = &self.cached_notes {
             return Arc::clone(notes);
         }
-        // Snapshot was empty at checkout — load once from disk into a fresh
-        // Arc; we don't write back into the BatchContext cache because the next
-        // `checkout_view` after a real reindex will re-stat notes.toml anyway.
+        if let Some(notes) = self
+            .notes_cell
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_ref()
+        {
+            return Arc::clone(notes);
+        }
+        // Snapshot and cell were both empty — load once from disk and
+        // publish back so subsequent dispatches reuse the parse.
         let notes_path = self.root.join("docs/notes.toml");
         let notes = if notes_path.exists() {
             cqs::note::parse_notes(&notes_path).unwrap_or_else(|e| {
@@ -510,18 +586,30 @@ impl BatchView {
         } else {
             vec![]
         };
-        Arc::new(notes)
+        let arc = Arc::new(notes);
+        self.publish_if_current(&self.notes_cell, &arc, "notes_cache");
+        arc
     }
 
     pub fn file_set(&self) -> Result<Arc<HashSet<PathBuf>>> {
         if let Some(fs) = &self.cached_file_set {
             return Ok(Arc::clone(fs));
         }
+        if let Some(fs) = self
+            .file_set_cell
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_ref()
+        {
+            return Ok(Arc::clone(fs));
+        }
         let _span = tracing::info_span!("batch_view_file_set").entered();
         let exts: Vec<&str> = cqs::language::REGISTRY.supported_extensions().collect();
         let files = cqs::enumerate_files(&self.root, &exts, false)?;
         let set: HashSet<PathBuf> = files.into_iter().collect();
-        Ok(Arc::new(set))
+        let arc = Arc::new(set);
+        self.publish_if_current(&self.file_set_cell, &arc, "file_set");
+        Ok(arc)
     }
 
     pub fn call_graph(&self) -> Result<Arc<cqs::store::CallGraph>> {

--- a/src/cli/batch/view.rs
+++ b/src/cli/batch/view.rs
@@ -346,14 +346,38 @@ impl BatchView {
         slot: &'static str,
     ) {
         let mut guard = cell.lock().unwrap_or_else(|p| p.into_inner());
-        if self.invalidation_epoch.load(Ordering::SeqCst) == self.checkout_epoch {
-            *guard = Some(Arc::clone(value));
-        } else {
+        if self.invalidation_epoch.load(Ordering::SeqCst) != self.checkout_epoch {
             tracing::debug!(
                 slot,
                 "invalidation ran since view checkout — discarding freshly built cache value"
             );
+            return;
         }
+        *guard = Some(Arc::clone(value));
+        // An invalidation may have bumped the epoch between the check above
+        // and the store: it found this cell locked and deferred the clear to
+        // the lock holder. Re-check and perform that deferred clear here,
+        // while the lock is still held — otherwise the just-published stale
+        // value would survive until the next sticky retry.
+        if self.invalidation_epoch.load(Ordering::SeqCst) != self.checkout_epoch {
+            *guard = None;
+            tracing::debug!(slot, "invalidation raced the publish — clearing the cell");
+        }
+    }
+
+    /// Read a shared cell — but only when no invalidation has run since this
+    /// view's checkout. A cell populated after an invalidation belongs to a
+    /// NEWER index generation than this view's store snapshot; serving it
+    /// against the old store would mix generations (reindex reassigns chunk
+    /// rowids, so results would be silently wrong). On epoch mismatch the
+    /// caller falls back to building from its own snapshot store, and the
+    /// matching publish guard then discards that build.
+    fn read_cell_if_current<T: ?Sized>(&self, cell: &Mutex<Option<Arc<T>>>) -> Option<Arc<T>> {
+        let guard = cell.lock().unwrap_or_else(|p| p.into_inner());
+        if self.invalidation_epoch.load(Ordering::SeqCst) != self.checkout_epoch {
+            return None;
+        }
+        guard.as_ref().map(Arc::clone)
     }
 
     /// Vector index for this snapshot. Falls back to the shared cell (a
@@ -371,15 +395,23 @@ impl BatchView {
             );
         }
         {
-            // The cell is cleared on invalidation, so a populated cell is
-            // current. A poisoned cell value falls through to the rebuild,
-            // which publishes over it.
-            let guard = self
+            // Hand-rolled (not `read_cell_if_current`) because of the poison
+            // handling: a poisoned value is nulled out under the same guard
+            // regardless of epoch — leaving it would let a later reader or
+            // checkout snapshot revive a dead CUDA context — while serving a
+            // healthy value is epoch-gated like every other cell read.
+            let mut guard = self
                 .vector_index_cell
                 .lock()
                 .unwrap_or_else(|p| p.into_inner());
             if let Some(arc) = guard.as_ref() {
-                if !arc.is_poisoned() {
+                if arc.is_poisoned() {
+                    tracing::warn!(
+                        name = arc.name(),
+                        "Poisoned vector index in shared cell — discarding"
+                    );
+                    *guard = None;
+                } else if self.invalidation_epoch.load(Ordering::SeqCst) == self.checkout_epoch {
                     return Ok(Some(Arc::clone(arc)));
                 }
             }
@@ -397,14 +429,8 @@ impl BatchView {
         if let Some(arc) = &self.cached_base_vector_index {
             return Ok(Some(Arc::clone(arc)));
         }
-        {
-            let guard = self
-                .base_vector_index_cell
-                .lock()
-                .unwrap_or_else(|p| p.into_inner());
-            if let Some(arc) = guard.as_ref() {
-                return Ok(Some(Arc::clone(arc)));
-            }
+        if let Some(arc) = self.read_cell_if_current(&self.base_vector_index_cell) {
+            return Ok(Some(arc));
         }
         let _span = tracing::info_span!("batch_view_base_vector_index_init").entered();
         let idx = crate::cli::build_base_vector_index(&self.store, &self.cqs_dir)?;
@@ -464,12 +490,12 @@ impl BatchView {
     }
 
     pub fn ensure_splade_index(&self) {
-        if self
-            .splade_index_cell
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .is_some()
-        {
+        // Epoch-gated: a cell populated after an invalidation belongs to a
+        // newer generation than this view's snapshot store — don't treat it
+        // as "already ensured" for this view. The stale-view rebuild below
+        // is then discarded by the publish guard; that dispatch falls back
+        // to dense-only rather than mixing generations.
+        if self.read_cell_if_current(&self.splade_index_cell).is_some() {
             return;
         }
         let generation = match self.store.splade_generation() {
@@ -534,15 +560,13 @@ impl BatchView {
     pub fn borrow_splade_index(&self) -> Option<Arc<cqs::splade::index::SpladeIndex>> {
         // Prefer the snapshot taken at checkout; fall back to the live
         // cell so a freshly populated index (via `ensure_splade_index`
-        // during this dispatch) is observable without re-checkout.
+        // during this dispatch) is observable without re-checkout. The
+        // cell read is epoch-gated — a post-invalidation cell value would
+        // mix generations with this view's store snapshot.
         if let Some(arc) = &self.cached_splade_index {
             return Some(Arc::clone(arc));
         }
-        self.splade_index_cell
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .as_ref()
-            .map(Arc::clone)
+        self.read_cell_if_current(&self.splade_index_cell)
     }
 
     /// Borrowed access keeps the snapshot Config in place; clone-on-access
@@ -563,26 +587,39 @@ impl BatchView {
         if let Some(notes) = &self.cached_notes {
             return Arc::clone(notes);
         }
-        if let Some(notes) = self
-            .notes_cell
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .as_ref()
-        {
-            return Arc::clone(notes);
+        if let Some(notes) = self.read_cell_if_current(&self.notes_cell) {
+            return notes;
         }
         // Snapshot and cell were both empty — load once from disk and
         // publish back so subsequent dispatches reuse the parse.
         let notes_path = self.root.join("docs/notes.toml");
         let notes = if notes_path.exists() {
-            cqs::note::parse_notes(&notes_path).unwrap_or_else(|e| {
-                tracing::warn!(
-                    path = %notes_path.display(),
-                    error = %e,
-                    "Failed to parse notes.toml for view"
-                );
-                vec![]
-            })
+            match cqs::note::parse_notes(&notes_path) {
+                Ok(notes) => notes,
+                // Split absent-file (TOCTOU after the .exists() check above)
+                // from genuine parse failures, and include the path in the
+                // warn so the journal isn't ambiguous about which notes file
+                // failed.
+                Err(e) => {
+                    if matches!(
+                        &e,
+                        cqs::NoteError::Io(io_err)
+                            if io_err.kind() == std::io::ErrorKind::NotFound
+                    ) {
+                        tracing::debug!(
+                            path = %notes_path.display(),
+                            "notes.toml disappeared between exists() and parse — treating as empty"
+                        );
+                    } else {
+                        tracing::warn!(
+                            path = %notes_path.display(),
+                            error = %e,
+                            "Failed to parse notes.toml for view"
+                        );
+                    }
+                    vec![]
+                }
+            }
         } else {
             vec![]
         };
@@ -595,13 +632,8 @@ impl BatchView {
         if let Some(fs) = &self.cached_file_set {
             return Ok(Arc::clone(fs));
         }
-        if let Some(fs) = self
-            .file_set_cell
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .as_ref()
-        {
-            return Ok(Arc::clone(fs));
+        if let Some(fs) = self.read_cell_if_current(&self.file_set_cell) {
+            return Ok(fs);
         }
         let _span = tracing::info_span!("batch_view_file_set").entered();
         let exts: Vec<&str> = cqs::language::REGISTRY.supported_extensions().collect();


### PR DESCRIPTION
## Audit v1.42.0 — daemon cache-lifecycle cluster (P1)

Closes PERF-V1.42-1 (P1, the audit headline), DS-V1.42-7 (P1), and DS-V1.42-6 (P2 rider) from `docs/audit-triage.md`.

**The headline:** the daemon was rebuilding the vector index from disk on every search-class query (journal-confirmed ~358-386ms `cagra_load` per query against the 3-19ms budget) because `BatchView`'s fallback built indexes view-locally and never wrote back — the only cache-populating code was unreachable from production dispatch. The SPLADE index already had the correct shared-cell pattern; this PR extends it.

- `hnsw` / `base_hnsw` / `file_set` / `notes_cache` become `Arc<Mutex<Option<Arc<T>>>>` write-back cells shared between `BatchContext` and `BatchView`; the view fallback publishes after building, so the first query pays the load and subsequent queries hit the cell. The dead `BatchContext` accessors are deleted. `dispatch_stale`/`dispatch_health` stop re-enumerating the repo tree per request as a result.
- **Stale-publish protection (DS-V1.42-6, generalized):** a new `invalidation_epoch` (`AtomicU64`) is captured at view checkout; `publish_if_current` compares it under the cell lock, so an index built from a pre-invalidation snapshot is discarded instead of published. `ensure_splade_index` now goes through the same guard.
- **Lost deferred invalidation (DS-V1.42-7):** `invalidate_mutable_caches` returns `all_clear`; when a slot is deferred (handler holding a borrow), a sticky `pending_invalidation` flag makes `check_index_staleness` retry regardless of the already-consumed `data_version`/identity discriminators, clearing only when every slot actually cleared. Same fix applied to the manual `refresh` path.

Deviations from the triage's suggested fixes (rationale in commit):
- One epoch mechanism covers all five cells uniformly instead of a per-cell `(generation, index)` pair.
- Epoch captured at checkout, not build start — the build uses the checkout-time store snapshot, so invalidation in the checkout→build gap must also block the publish.
- `call_graph`/`test_chunks` stay view-local: their fallback hits the snapshot Store's internal OnceLock caches, so shared cells buy nothing.

Tests (new): view fallback write-back, cell-served second checkout, invalidation clears cells + bumps epoch, deferred-invalidation sticky retry, stale-epoch publish discarded. `cli::batch` suite: 143 pass; `cli::commands::search`: 47 pass. fmt + clippy (`--lib` and `--bin cqs`, `-D warnings`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
