### PR TITLE
fix(search): enforce the needs_embedding visibility gate on the live FTS leg and embedding-reuse lookups

### DIFF
--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -355,16 +355,16 @@ impl<Mode> Store<Mode> {
                 vec![]
             } else {
                 tracing::debug!(fts_query = %fts_query, "FTS MATCH query");
-                let fts_rows: Vec<(String,)> = sqlx::query_as(
-                    "SELECT id FROM chunks_fts WHERE chunks_fts MATCH ?1 ORDER BY bm25(chunks_fts) LIMIT ?2",
-                )
-                .bind(&fts_query)
-                .bind((limit * 3) as i64)
-                .fetch_all(&self.pool)
-                .await?;
-                // Apply path filter to FTS results (FTS5 doesn't support JOIN
-                // filtering). Reuses the caller's pre-compiled glob matcher.
-                let fts_all: Vec<String> = fts_rows.into_iter().map(|(id,)| id).collect();
+                // Shared gated FTS query (`fts_match_ids`) — carries the
+                // `needs_embedding = 0` visibility gate so zero-vec sentinel
+                // chunks from a partial `--llm-summaries` reindex can't
+                // surface through the keyword leg.
+                let fts_all: Vec<String> = self
+                    .fts_match_ids(&fts_query, limit.saturating_mul(3))
+                    .await?;
+                // Apply path filter to FTS results (the glob filter isn't
+                // expressible in the FTS query). Reuses the caller's
+                // pre-compiled glob matcher.
                 if let Some(gm) = glob_matcher {
                     fts_all
                         .into_iter()
@@ -1186,6 +1186,57 @@ mod tests {
         };
         let results = store.search_filtered(&emb, &filter, 10, 0.0).unwrap();
         assert!(!results.is_empty(), "RRF hybrid should return results");
+    }
+
+    /// The RRF keyword leg shares `fts_match_ids`' `needs_embedding = 0`
+    /// gate: a zero-vec sentinel chunk (parser-stage write during a
+    /// `--llm-summaries` reindex) whose text matches the FTS query must NOT
+    /// surface through `search_filtered`'s RRF path. Once enrichment lands a
+    /// real embedding (clearing the flag), the chunk surfaces.
+    #[test]
+    fn test_search_filtered_rrf_skips_unembedded_chunks() {
+        let (store, _dir) = setup_store();
+
+        let chunk = make_chunk(
+            "zetaUniqueKeyword",
+            "src/zeta.rs",
+            Language::Rust,
+            ChunkType::Function,
+        );
+        store
+            .upsert_chunks_unembedded_batch(std::slice::from_ref(&chunk), Some(12345))
+            .unwrap();
+
+        let emb = mock_embedding(1.0);
+        let filter = SearchFilter {
+            enable_rrf: true,
+            query_text: "zetaUniqueKeyword".to_string(),
+            ..Default::default()
+        };
+        // Threshold above zero keeps the zero-vec sentinel out of the
+        // semantic leg, so the FTS keyword leg is the only route the
+        // unembedded chunk could surface through.
+        let results = store.search_filtered(&emb, &filter, 10, 0.1).unwrap();
+        assert!(
+            results.iter().all(|r| r.chunk.name != "zetaUniqueKeyword"),
+            "unembedded chunk must not surface through the RRF keyword leg, got {:?}",
+            results.iter().map(|r| &r.chunk.name).collect::<Vec<_>>()
+        );
+
+        // Enrichment lands a real embedding and clears needs_embedding; the
+        // chunk becomes visible.
+        let updates = vec![(
+            chunk.id.clone(),
+            mock_embedding(1.0),
+            Some("hash".to_string()),
+        )];
+        store.update_embeddings_with_hashes_batch(&updates).unwrap();
+        let results = store.search_filtered(&emb, &filter, 10, 0.1).unwrap();
+        assert!(
+            results.iter().any(|r| r.chunk.name == "zetaUniqueKeyword"),
+            "after enrichment clears the flag, the chunk must surface, got {:?}",
+            results.iter().map(|r| &r.chunk.name).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -1433,16 +1433,34 @@ mod tests {
         assert!(ids.contains(&c1.id));
         assert!(ids.contains(&c2.id));
 
-        // The on-disk embedding is the zero-vec sentinel.
-        let embs = store
-            .get_embeddings_by_hashes(&[&c1.content_hash, &c2.content_hash])
-            .unwrap();
-        for emb in embs.values() {
+        // The on-disk embedding is the zero-vec sentinel. Read the raw
+        // bytes directly — the by-hash lookups gate on `needs_embedding = 0`
+        // so sentinels are invisible through them by design.
+        let blobs: Vec<(Vec<u8>,)> = store.rt.block_on(async {
+            sqlx::query_as("SELECT embedding FROM chunks WHERE content_hash IN (?1, ?2)")
+                .bind(&c1.content_hash)
+                .bind(&c2.content_hash)
+                .fetch_all(&store.pool)
+                .await
+                .unwrap()
+        });
+        assert_eq!(blobs.len(), 2);
+        for (bytes,) in &blobs {
+            let floats: &[f32] = bytemuck::cast_slice(bytes);
             assert!(
-                emb.as_slice().iter().all(|&x| x == 0.0),
+                floats.iter().all(|&x| x == 0.0),
                 "unembedded chunks must carry a zero-vec sentinel"
             );
         }
+
+        // The gated by-hash lookup must NOT serve the sentinel as a reuse hit.
+        let embs = store
+            .get_embeddings_by_hashes(&[&c1.content_hash, &c2.content_hash])
+            .unwrap();
+        assert!(
+            embs.is_empty(),
+            "needs_embedding=1 sentinels must be invisible to by-hash embedding lookup"
+        );
     }
 
     /// `update_embeddings_with_hashes_batch` (used by `enrichment_pass`)

--- a/src/store/chunks/embeddings.rs
+++ b/src/store/chunks/embeddings.rs
@@ -30,8 +30,15 @@ impl<Mode> Store<Mode> {
         self.rt.block_on(async {
             for batch in hashes.chunks(BATCH_SIZE) {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
+                // Exclude chunks with `needs_embedding=1` so the embedding-reuse
+                // resolver never treats a zero-vec sentinel (parser-stage write
+                // during a `--llm-summaries` reindex) as a cache hit. A zero
+                // vector is finite, so `Embedding::try_new` would accept it and
+                // the reuse path would launder it into a permanent "real"
+                // embedding.
                 let sql = format!(
-                    "SELECT content_hash, embedding FROM chunks WHERE content_hash IN ({})",
+                    "SELECT content_hash, embedding FROM chunks \
+                     WHERE needs_embedding = 0 AND content_hash IN ({})",
                     placeholders
                 );
 
@@ -107,9 +114,12 @@ impl<Mode> Store<Mode> {
         self.rt.block_on(async {
             for batch in canonical_hashes.chunks(BATCH_SIZE) {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
+                // Same `needs_embedding = 0` gate as `get_embeddings_by_hashes`:
+                // zero-vec sentinels must be a cache miss, never a reuse hit.
                 let sql = format!(
                     "SELECT canonical_hash, embedding FROM chunks \
-                     WHERE canonical_hash IS NOT NULL AND canonical_hash IN ({})",
+                     WHERE needs_embedding = 0 \
+                       AND canonical_hash IS NOT NULL AND canonical_hash IN ({})",
                     placeholders
                 );
 
@@ -184,8 +194,13 @@ impl<Mode> Store<Mode> {
         self.rt.block_on(async {
             for batch in hashes.chunks(BATCH_SIZE) {
                 let placeholders = crate::store::helpers::make_placeholders(batch.len());
+                // Same `needs_embedding = 0` gate as `get_embeddings_by_hashes`:
+                // this feeds the watch delta path straight into HNSW
+                // `insert_batch`, so a zero-vec sentinel here would be served
+                // by vector search permanently.
                 let sql = format!(
-                    "SELECT id, embedding, content_hash FROM chunks WHERE content_hash IN ({})",
+                    "SELECT id, embedding, content_hash FROM chunks \
+                     WHERE needs_embedding = 0 AND content_hash IN ({})",
                     placeholders
                 );
 
@@ -467,6 +482,80 @@ mod tests {
         assert_eq!(by_id[chunk1.id.as_str()].1, chunk1.content_hash);
         assert_eq!(by_id[chunk2.id.as_str()].1, chunk2.content_hash);
         assert_eq!(by_id[chunk3.id.as_str()].1, chunk3.content_hash);
+    }
+
+    /// All three by-hash embedding lookups gate on `needs_embedding = 0`:
+    /// a zero-vec sentinel written by `upsert_chunks_unembedded_batch`
+    /// (parser stage of a `--llm-summaries` reindex) must be a clean cache
+    /// miss. Without the gate, the sentinel is finite so
+    /// `Embedding::try_new` accepts it, the reuse resolver treats it as a
+    /// hit, and the zero vector gets laundered into a permanent "real"
+    /// embedding served by HNSW/search.
+    #[test]
+    fn test_by_hash_lookups_skip_needs_embedding_sentinels() {
+        let (store, _dir) = make_store();
+
+        // Sentinel row: same shape the parser stage writes.
+        let sentinel = test_chunk_with_canon("pending", "fn pending() { 7 }", "canon_pending");
+        store
+            .upsert_chunks_unembedded_batch(std::slice::from_ref(&sentinel), Some(100))
+            .unwrap();
+
+        // All three by-hash lookups must miss the sentinel.
+        let by_hash = store
+            .get_embeddings_by_hashes(&[sentinel.content_hash.as_str()])
+            .unwrap();
+        assert!(
+            by_hash.is_empty(),
+            "get_embeddings_by_hashes must skip needs_embedding=1 sentinels, got {:?}",
+            by_hash.keys().collect::<Vec<_>>()
+        );
+        let by_canon = store
+            .get_embeddings_by_canonical_hashes(&["canon_pending"])
+            .unwrap();
+        assert!(
+            by_canon.is_empty(),
+            "get_embeddings_by_canonical_hashes must skip needs_embedding=1 sentinels, got {:?}",
+            by_canon.keys().collect::<Vec<_>>()
+        );
+        let ids_embs = store
+            .get_chunk_ids_and_embeddings_by_hashes(&[sentinel.content_hash.as_str()])
+            .unwrap();
+        assert!(
+            ids_embs.is_empty(),
+            "get_chunk_ids_and_embeddings_by_hashes must skip needs_embedding=1 sentinels, got {:?}",
+            ids_embs.iter().map(|(id, _, _)| id).collect::<Vec<_>>()
+        );
+
+        // Control: a real embedded row with the same hash shape hits all three.
+        let real = test_chunk_with_canon("ready", "fn ready() { 8 }", "canon_ready");
+        store
+            .upsert_chunk(&real, &mock_embedding(1.0), Some(100))
+            .unwrap();
+
+        assert!(
+            store
+                .get_embeddings_by_hashes(&[real.content_hash.as_str()])
+                .unwrap()
+                .contains_key(&real.content_hash),
+            "embedded row must hit get_embeddings_by_hashes"
+        );
+        assert!(
+            store
+                .get_embeddings_by_canonical_hashes(&["canon_ready"])
+                .unwrap()
+                .contains_key("canon_ready"),
+            "embedded row must hit get_embeddings_by_canonical_hashes"
+        );
+        let hits = store
+            .get_chunk_ids_and_embeddings_by_hashes(&[real.content_hash.as_str()])
+            .unwrap();
+        assert_eq!(
+            hits.len(),
+            1,
+            "embedded row must hit get_chunk_ids_and_embeddings_by_hashes"
+        );
+        assert_eq!(hits[0].0, real.id);
     }
 
     /// `test_chunk` variant with an explicit `canonical_hash`.

--- a/src/store/search.rs
+++ b/src/store/search.rs
@@ -128,25 +128,40 @@ impl<Mode> Store<Mode> {
             return Ok(vec![]);
         }
 
-        self.rt.block_on(async {
-            // JOIN chunks + filter `needs_embedding = 0` so FTS-only
-            // candidates that haven't been embedded yet stay out of the RRF
-            // mix. They'd otherwise rank lower than expected (zero cosine
-            // score against zero-vec sentinel) and pollute the result list
-            // during a `--llm-summaries` reindex's partial state.
-            let rows: Vec<(String,)> = sqlx::query_as(
-                "SELECT f.id FROM chunks_fts f \
-                 JOIN chunks c ON c.id = f.id \
-                 WHERE chunks_fts MATCH ?1 AND c.needs_embedding = 0 \
-                 ORDER BY bm25(chunks_fts) LIMIT ?2",
-            )
-            .bind(&normalized_query)
-            .bind(limit as i64)
-            .fetch_all(&self.pool)
-            .await?;
+        self.rt
+            .block_on(async { self.fts_match_ids(&normalized_query, limit).await })
+    }
 
-            Ok(rows.into_iter().map(|(id,)| id).collect())
-        })
+    /// Run an already-sanitized FTS5 MATCH query and return chunk IDs in
+    /// bm25 order. The single home for the gated FTS id query — shared by
+    /// `search_fts` and the RRF keyword leg in `finalize_results`.
+    ///
+    /// JOIN chunks + filter `needs_embedding = 0` so FTS-only candidates
+    /// that haven't been embedded yet stay out of the RRF mix. They'd
+    /// otherwise rank lower than expected (zero cosine score against
+    /// zero-vec sentinel) and pollute the result list during a
+    /// `--llm-summaries` reindex's partial state.
+    ///
+    /// `fts_query` must already be normalized/sanitized (callers run
+    /// `normalize_for_fts` + `sanitize_fts_query`, optionally
+    /// `expand_query_for_fts`); this helper binds it to MATCH verbatim.
+    pub(crate) async fn fts_match_ids(
+        &self,
+        fts_query: &str,
+        limit: usize,
+    ) -> Result<Vec<String>, StoreError> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT f.id FROM chunks_fts f \
+             JOIN chunks c ON c.id = f.id \
+             WHERE chunks_fts MATCH ?1 AND c.needs_embedding = 0 \
+             ORDER BY bm25(chunks_fts) LIMIT ?2",
+        )
+        .bind(fts_query)
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 
     /// Search for chunks by name (definition search).


### PR DESCRIPTION
## Audit v1.42.0 — search-correctness cluster (P1)

Closes CQ-V1.42-12 and DS-V1.42-1 from `docs/audit-triage.md` — both halves of the same contract violation: the schema's `needs_embedding = 0` visibility guarantee was enforced in a production-dead method while the live paths went ungated.

- **Live RRF FTS leg gated (CQ-V1.42-12):** extracted `fts_match_ids` as the single home for the gated FTS id query (`JOIN chunks ... WHERE needs_embedding = 0`); `finalize_results`' keyword leg now routes through it instead of its ungated inline SELECT, and `search_fts` becomes a thin wrapper, so the contract lives in one place. Unembedded sentinel chunks can no longer surface through keyword matches mid-`--llm-summaries` reindex.
- **Reuse-lookup gate (DS-V1.42-1):** `AND needs_embedding = 0` added to all three by-hash embedding SELECTs, mirroring the `EmbeddingBatchIterator` gate. This closes the sentinel-laundering path: an interrupted skip-first-pass run's zero-vec sentinel can no longer be "reused" as a real embedding by `resolve_reuse` or fed into HNSW via the watch delta path.
- One pre-existing test asserted the sentinel WAS returned by the by-hash lookup — updated to assert the gated miss (on-disk zero-vec verified via raw SQL instead).

Tests: `test_search_filtered_rrf_skips_unembedded_chunks` (validated — removing the gate makes it fail) and `test_by_hash_lookups_skip_needs_embedding_sentinels`, plus surrounding suites re-run clean (store::search 12, embeddings 5, crud 34, search::query 22, store_test fts 11). fmt + clippy (`--lib` and `--tests`, `-D warnings`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
