### PR TITLE
fix(index): harden index-time paths against poisoned inputs — non-finite filter, truncated-blob pre-check, ASCII-safe case mapping

### DIFF
--- a/src/cache/embedding_cache.rs
+++ b/src/cache/embedding_cache.rs
@@ -251,10 +251,26 @@ impl EmbeddingCache {
                         continue;
                     }
 
+                    // A blob whose length is not a multiple of 4 would panic
+                    // the bytemuck cast below (OutputSliceWouldHaveSlop); the
+                    // post-cast length check only catches whole-f32
+                    // truncation. Treat it as a miss, like the dim mismatch
+                    // above.
+                    if !blob.len().is_multiple_of(std::mem::size_of::<f32>()) {
+                        tracing::warn!(
+                            hash = &hash[..8.min(hash.len())],
+                            blob_len = blob.len(),
+                            "Cache blob length not a multiple of 4, skipping"
+                        );
+                        continue;
+                    }
+
                     // Zero-copy LE cast. `bytemuck::cast_slice` is sound here
                     // because (a) `embedding_to_bytes` is the only producer and
                     // stamps blobs as `&[f32] → &[u8]` so alignment + endianness
-                    // match, and (b) the length check below catches truncation.
+                    // match, and (b) the pre-check above rejects lengths that
+                    // are not a multiple of 4, while the length check below
+                    // catches whole-f32 truncation.
                     // cqs ships little-endian targets only; the cast is a no-op
                     // memcpy-equivalent there. Mirrors the fast path in
                     // `helpers/embeddings.rs::bytes_to_embedding`.
@@ -900,6 +916,67 @@ mod tests {
         let out = blake3_hex_or_passthrough(&bytes);
         assert_eq!(out.len(), 128); // 64 bytes × 2 hex chars per byte
         assert!(out.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    /// A cache row whose blob length is not a multiple of 4 must surface as
+    /// a miss, not a panic — the bytemuck cast in `read_batch` would
+    /// otherwise abort with `OutputSliceWouldHaveSlop` before the dim/length
+    /// checks run. Mirrors `test_query_cache_get_deletes_malformed_blob`.
+    #[test]
+    fn test_read_batch_skips_malformed_blob() {
+        let (cache, _dir) = test_cache();
+
+        // Insert a malformed (5-byte) blob and a valid sibling row directly
+        // via raw sqlx — bypassing write paths that only produce whole-f32
+        // blobs.
+        cache.rt.block_on(async {
+            sqlx::query(
+                "INSERT INTO embedding_cache \
+                 (content_hash, model_fingerprint, purpose, embedding, dim, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, 0)",
+            )
+            .bind("malformed-hash")
+            .bind("test-fp")
+            .bind(CachePurpose::Embedding.as_str())
+            .bind(vec![0u8; 5]) // 5 bytes — not a multiple of 4
+            .bind(2i64)
+            .execute(&cache.pool)
+            .await
+            .unwrap();
+
+            sqlx::query(
+                "INSERT INTO embedding_cache \
+                 (content_hash, model_fingerprint, purpose, embedding, dim, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, 0)",
+            )
+            .bind("valid-hash")
+            .bind("test-fp")
+            .bind(CachePurpose::Embedding.as_str())
+            .bind(bytemuck::cast_slice::<f32, u8>(&[0.5f32, 0.25]).to_vec())
+            .bind(2i64)
+            .execute(&cache.pool)
+            .await
+            .unwrap();
+        });
+
+        let result = cache
+            .read_batch(
+                &["malformed-hash", "valid-hash"],
+                "test-fp",
+                CachePurpose::Embedding,
+                2,
+            )
+            .expect("read_batch must not error on a malformed blob");
+
+        assert!(
+            !result.contains_key("malformed-hash"),
+            "malformed blob must produce a cache miss, got a hit"
+        );
+        assert_eq!(
+            result.get("valid-hash").map(Vec::as_slice),
+            Some(&[0.5f32, 0.25][..]),
+            "valid sibling row must still hit"
+        );
     }
 
     #[test]

--- a/src/hnsw/build.rs
+++ b/src/hnsw/build.rs
@@ -210,9 +210,17 @@ impl HnswIndex {
                 }
                 // Skip zero-vector embeddings — they produce NaN cosine
                 // distances. Short-circuit on the first non-zero element
-                // instead of computing the full L2 norm.
+                // instead of computing the full L2 norm. Note `NaN != 0.0`
+                // is true, so this check alone does not catch NaN vectors.
                 if !embedding.as_vec().iter().any(|x| *x != 0.0) {
                     tracing::warn!(chunk_id = %chunk_id, "Skipping zero-vector embedding");
+                    continue;
+                }
+                // Skip embeddings with NaN/Inf components — non-finite
+                // distances trip assertions inside hnsw_rs's parallel insert
+                // workers and would panic the whole build.
+                if embedding.as_vec().iter().any(|x| !x.is_finite()) {
+                    tracing::warn!(chunk_id = %chunk_id, "Skipping non-finite embedding");
                     continue;
                 }
                 let insert_idx = id_map.len();
@@ -507,6 +515,46 @@ mod tests {
             result.is_err(),
             "dim=0 with non-empty embeddings should error on dimension mismatch"
         );
+    }
+
+    /// A NaN vector interleaved between valid vectors must be skipped (it
+    /// passes the zero-vector check because `NaN != 0.0` is true), the build
+    /// must succeed, and the surviving ids must stay aligned with their
+    /// insertion indices — the id_map desync class documented in the build
+    /// loop.
+    #[test]
+    fn test_build_batched_skips_non_finite_embedding() {
+        // One-hot vectors: cosine-orthogonal, so each query's exact match
+        // is unambiguous even at k=1.
+        fn one_hot(idx: usize) -> Embedding {
+            let mut v = vec![0.0f32; crate::EMBEDDING_DIM];
+            v[idx] = 1.0;
+            Embedding::new(v)
+        }
+
+        // Non-zero NaN component: passes the zero-vector check, must be
+        // caught by the non-finite check.
+        let mut nan_vec = vec![0.0f32; crate::EMBEDDING_DIM];
+        nan_vec[1] = f32::NAN;
+
+        let batch = vec![
+            ("chunk_a".to_string(), one_hot(0)),
+            ("chunk_nan".to_string(), Embedding::new(nan_vec)),
+            ("chunk_b".to_string(), one_hot(2)),
+        ];
+        let batches: Vec<Result<Vec<(String, Embedding)>, std::convert::Infallible>> =
+            vec![Ok(batch)];
+
+        let index = HnswIndex::build_batched_with_dim(batches.into_iter(), 3, crate::EMBEDDING_DIM)
+            .expect("build must succeed with a non-finite vector in the stream");
+        assert_eq!(index.len(), 2, "NaN vector must be skipped, not inserted");
+
+        // Exact-embedding searches must return the correct ids — pins that
+        // the skip kept id_map positions aligned with insertion indices.
+        let hits = index.search(&one_hot(0), 1);
+        assert_eq!(hits.first().map(|r| r.id.as_str()), Some("chunk_a"));
+        let hits = index.search(&one_hot(2), 1);
+        assert_eq!(hits.first().map(|r| r.id.as_str()), Some("chunk_b"));
     }
 
     // ===== HnswIndex::search_filtered predicate tests =====

--- a/src/language/languages.rs
+++ b/src/language/languages.rs
@@ -6739,8 +6739,12 @@ pub fn definition_solidity() -> &'static LanguageDef {
 /// # Returns
 /// `Some(String)` containing a formatted return type description (e.g., "Returns int"), or `None` if no "RETURNS" keyword is found in the signature.
 fn extract_return_sql(signature: &str) -> Option<String> {
-    // SQL functions: look for RETURNS type between name and AS
-    let upper = signature.to_uppercase();
+    // SQL functions: look for RETURNS type between name and AS.
+    // ASCII-only case mapping: Unicode `to_uppercase()` is not
+    // byte-length-preserving (e.g. "ﬁ" → "FI"), so an offset found in the
+    // mapped copy could slice `signature` mid-codepoint. SQL keywords are
+    // ASCII, so `to_ascii_uppercase()` suffices and preserves byte offsets.
+    let upper = signature.to_ascii_uppercase();
     if let Some(ret_pos) = upper.find("RETURNS") {
         let after = &signature[ret_pos + 7..].trim();
         // Take the first word as the return type, lowercase it

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -2363,6 +2363,32 @@ mod tests {
         );
     }
 
+    /// SQL return extraction must survive non-ASCII identifiers before the
+    /// RETURNS keyword. Unicode `to_uppercase()` is not byte-length-preserving
+    /// ("ﬁ" → "FI" shrinks by one byte), so an offset found in the case-mapped
+    /// copy can misalign against the original — slicing mid-codepoint (panic)
+    /// or mid-keyword (garbage type). `to_ascii_uppercase()` preserves byte
+    /// offsets.
+    #[test]
+    fn test_extract_return_sql_non_ascii_identifier() {
+        let sql = Language::Sql.def().extract_return_nl;
+
+        // Single ligature: pre-fix the misaligned slice landed on the final
+        // 'S' of RETURNS, yielding "Returns s" instead of the real type.
+        assert_eq!(
+            sql("CREATE FUNCTION ﬁnance_total(@id INT) RETURNS DECIMAL(10,2)"),
+            Some("Returns decimal".to_string())
+        );
+
+        // Nine ligatures shift the case-mapped offset far enough that the
+        // pre-fix slice lands inside a multibyte codepoint — a panic, not
+        // just a wrong answer.
+        assert_eq!(
+            sql("CREATE FUNCTION ﬁﬁﬁﬁﬁﬁﬁﬁﬁ RETURNS INT"),
+            Some("Returns int".to_string())
+        );
+    }
+
     // ===== ChunkType tests =====
 
     #[test]


### PR DESCRIPTION
## Audit v1.42.0 — indexing-crash cluster (P1)

Closes TC-V1.42-6, TC-V1.42-7, RB-V1.42-2 from `docs/audit-triage.md` — three index-time panic/abort paths reachable from poisoned or unusual inputs.

- **Non-finite embedding filter (TC-V1.42-6):** `build_batched_with_dim_and_metric` now skips NaN/Inf vectors (warn + continue) — previously only zero-vectors were filtered, and `NaN != 0.0` let poisoned vectors through to `parallel_insert_data`, where the anndists `dist >= ε` assert can panic the whole index build on a rayon worker. The skip keeps the id_map insertion-index discipline intact; the new test interleaves a NaN vector between two valid ones and pins both survival and correct id attribution.
- **Truncated-blob pre-check (TC-V1.42-7):** `EmbeddingCache::read_batch` checks `blob.len().is_multiple_of(size_of::<f32>())` before the bytemuck cast (warn + skip) — a non-multiple-of-4 blob previously panicked with `OutputSliceWouldHaveSlop` *before* the length check the soundness comment claimed would catch it. Same fix shape query_cache already has; comment corrected; raw-SQL malformed-blob regression test added.
- **ASCII-safe SQL case mapping (RB-V1.42-2):** `extract_return_sql` uses `to_ascii_uppercase()` — Unicode `to_uppercase()` is not byte-length-preserving (ﬁ→FI), so the found offset could slice the original string mid-codepoint and panic during indexing. Matches the two sibling sites; test covers both the misalignment case and the multi-ligature mid-codepoint panic class.

Tests: 3 new, all pass; module suites re-run clean (hnsw::build 17, embedding_cache 43). fmt + clippy (`--lib -D warnings`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
