### PR TITLE
fix: audit small-P1 batch — audit-state error visibility, reuse-cache warn, fused-path fetch skip, tokenizer clone cache

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -91,7 +91,19 @@ pub fn load_audit_state(cqs_dir: &Path) -> AuditMode {
     }
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
-        Err(_) => return AuditMode::default(),
+        // Missing file is the normal "audit mode never enabled" state — stay
+        // silent. Every other read failure (EACCES, EIO, ...) silently
+        // disabling audit mode would be invisible to the operator, so warn
+        // before degrading to the inactive default.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return AuditMode::default(),
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "Failed to read audit-mode.json; treating audit mode as inactive"
+            );
+            return AuditMode::default();
+        }
     };
     let file: AuditModeFile = match serde_json::from_str(&content) {
         Ok(f) => f,
@@ -307,6 +319,32 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let loaded = load_audit_state(dir.path());
         assert!(!loaded.is_active());
+    }
+
+    /// A read failure that is NOT NotFound (here: permission denied) must
+    /// still degrade to the inactive default — the warn path, not a panic
+    /// or a silent divergence from the missing-file behavior.
+    #[test]
+    #[cfg(unix)]
+    fn test_load_unreadable_file_returns_default() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit-mode.json");
+        std::fs::write(&path, r#"{"enabled":true}"#).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+        // Root bypasses permission bits; the read would succeed and this
+        // test would assert the wrong path. Skip in that case.
+        if std::fs::read_to_string(&path).is_ok() {
+            eprintln!("running as root or permissive FS — permission bits ignored; skipping");
+            return;
+        }
+        let loaded = load_audit_state(dir.path());
+        assert!(
+            !loaded.is_active(),
+            "unreadable audit-mode.json must degrade to inactive default"
+        );
+        // Restore perms so tempdir cleanup can remove the file.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
     }
 
     #[test]

--- a/src/cli/pipeline/reuse.rs
+++ b/src/cli/pipeline/reuse.rs
@@ -120,13 +120,31 @@ pub(crate) fn resolve_reuse(
             dim,
         ) {
             Ok(hits) => {
-                if !hits.is_empty() {
-                    tracing::debug!(hits = hits.len(), "Global cache hits");
-                }
+                let total = hits.len();
+                let mut dropped = 0usize;
                 for (hash, emb_vec) in hits {
-                    if let Ok(emb) = Embedding::try_new(emb_vec) {
-                        global_hits.insert(hash, emb);
+                    // Same finiteness guard as the store-cache path
+                    // (`get_embeddings_by_canonical_hashes`): reject NaN/Inf
+                    // before they can poison HNSW build or query paths. A
+                    // dropped hit falls through to re-embedding, so warn —
+                    // a silent drop hides cache corruption indefinitely.
+                    match Embedding::try_new(emb_vec) {
+                        Ok(emb) => {
+                            global_hits.insert(hash, emb);
+                        }
+                        Err(e) => {
+                            dropped += 1;
+                            tracing::warn!(
+                                hash = %hash,
+                                error = %e,
+                                "Non-finite embedding values (NaN/Inf) in global cache, \
+                                 re-embedding — run 'cqs cache clear' to purge corrupt entries"
+                            );
+                        }
                     }
+                }
+                if total > 0 {
+                    tracing::debug!(hits = total, dropped, "Global cache hits");
                 }
             }
             Err(e) => {
@@ -329,6 +347,78 @@ mod tests {
         assert!(split.cached.is_empty());
         assert_eq!(split.to_embed, vec![0, 1]);
         assert_eq!(split.global_hits, 0);
+    }
+
+    /// A corrupt (non-finite) global-cache vector must be dropped (with a
+    /// warn) and the chunk routed to `to_embed` — never served as a hit, and
+    /// never counted in `global_hits`.
+    #[test]
+    fn non_finite_global_cache_entry_falls_through_to_embed() {
+        let dim = 8;
+        let (_tmp, store) = open_store(dim);
+
+        let cache_dir = tempfile::TempDir::new().unwrap();
+        let cache_path = cache_dir.path().join("embeddings_cache.db");
+        let cache = cqs::cache::EmbeddingCache::open(&cache_path).unwrap();
+        let fp = "test-fingerprint";
+
+        let chunk = chunk_with("a", "fn a() {}", "k1");
+        let key = canon_key_ref(&chunk).to_string();
+
+        // `write_batch` rejects non-finite vectors at write time, so seed a
+        // valid row first, then corrupt the stored blob through a direct
+        // connection — modeling on-disk corruption or a cache written before
+        // the write-side finiteness guard existed.
+        let written = cache
+            .write_batch_owned(
+                &[(key.clone(), vec![0.5_f32; dim])],
+                fp,
+                cqs::cache::CachePurpose::Embedding,
+                dim,
+            )
+            .unwrap();
+        assert_eq!(written, 1);
+
+        let mut nan_blob = Vec::with_capacity(dim * 4);
+        for _ in 0..dim {
+            nan_blob.extend_from_slice(&f32::NAN.to_le_bytes());
+        }
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let url = format!("sqlite:{}?mode=rw", cache_path.display());
+            let pool = sqlx::sqlite::SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect(&url)
+                .await
+                .unwrap();
+            let res =
+                sqlx::query("UPDATE embedding_cache SET embedding = ?1 WHERE content_hash = ?2")
+                    .bind(&nan_blob)
+                    .bind(&key)
+                    .execute(&pool)
+                    .await
+                    .unwrap();
+            assert_eq!(res.rows_affected(), 1, "corruption seed must hit the row");
+            pool.close().await;
+        });
+
+        let split = resolve_reuse(&[chunk], &store, Some(&cache), dim, Some(fp)).unwrap();
+        assert!(
+            split.cached.is_empty(),
+            "non-finite cache entry must not be served as a hit"
+        );
+        assert_eq!(
+            split.to_embed,
+            vec![0],
+            "chunk with corrupt cache entry falls through to embedding"
+        );
+        assert_eq!(
+            split.global_hits, 0,
+            "dropped entry must not count as a global hit"
+        );
     }
 
     /// Dim mismatch (model swap): the store cache is skipped, so a stored row at

--- a/src/embedder/core.rs
+++ b/src/embedder/core.rs
@@ -46,6 +46,21 @@ pub struct Embedder {
     /// using `arc.encode(...)` work via `Arc` deref without touching the mutex
     /// during inference.
     tokenizer: Mutex<Option<Arc<tokenizers::Tokenizer>>>,
+    /// Lazy truncation-disabled clone of [`Self::tokenizer`].
+    ///
+    /// `split_into_windows`, `token_count`, and `token_counts_batch` all need
+    /// full-sequence token counts, but some preset tokenizers ship
+    /// `tokenizer.json` with `truncation: {max_length: 512}` baked in (see
+    /// `split_into_windows` for the windowing-loss failure mode). Cloning the
+    /// tokenizer per call to flip truncation off deep-copies the full vocab
+    /// (~262k entries for EmbeddingGemma) — ~14k clones per reindex. Clone
+    /// once here instead and hand out `Arc` clones.
+    ///
+    /// Same `Mutex<Option<Arc<..>>>` shape as `tokenizer` (not `OnceLock`) so
+    /// [`Self::clear_session`] can drop it for a model swap — a stale
+    /// no-trunc tokenizer from the previous model would silently mis-tokenize
+    /// everything after the swap.
+    tokenizer_no_trunc: Mutex<Option<Arc<tokenizers::Tokenizer>>>,
     /// Lazy-loaded model paths (avoids HuggingFace API calls until actually embedding)
     model_paths: OnceCell<(PathBuf, PathBuf)>,
     /// Lazy execution-provider resolution. `select_provider()` probes for CUDA
@@ -195,6 +210,7 @@ impl Embedder {
         Ok(Self {
             session: Mutex::new(None),
             tokenizer: Mutex::new(None),
+            tokenizer_no_trunc: Mutex::new(None),
             model_paths: OnceCell::new(),
             // Lazy. Both `new_lazy_provider` and `new_with_provider`
             // overwrite this slot before returning.
@@ -440,6 +456,46 @@ impl Embedder {
         Ok(loaded)
     }
 
+    /// Get or initialize the truncation-disabled tokenizer.
+    ///
+    /// First call deep-clones the base tokenizer and flips truncation off;
+    /// every subsequent call returns an `Arc` clone of that one copy. The
+    /// result is immutable after creation (call sites only `encode`), so
+    /// sharing is safe. See the `tokenizer_no_trunc` field doc for why the
+    /// per-call clone this replaces was expensive.
+    fn tokenizer_no_trunc(&self) -> Result<Arc<tokenizers::Tokenizer>, EmbedderError> {
+        {
+            let guard = self
+                .tokenizer_no_trunc
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            if let Some(t) = guard.as_ref() {
+                return Ok(Arc::clone(t));
+            }
+        }
+        // Build outside the lock — the clone of a 262k-entry vocab is the
+        // expensive part and shouldn't serialize concurrent callers.
+        let base = self.tokenizer()?;
+        let mut no_trunc = (*base).clone();
+        if no_trunc.get_truncation().is_some() {
+            no_trunc
+                .with_truncation(None)
+                .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
+        }
+        let built = Arc::new(no_trunc);
+        let mut guard = self
+            .tokenizer_no_trunc
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        // Another thread may have initialized while we were cloning; prefer
+        // the first winner so Arc identity is stable.
+        if let Some(existing) = guard.as_ref() {
+            return Ok(Arc::clone(existing));
+        }
+        *guard = Some(Arc::clone(&built));
+        Ok(built)
+    }
+
     /// Resolve the pad token id once, caching on the embedder.
     ///
     /// Returns the id used to fill `input_ids` below `max_length` during
@@ -504,12 +560,7 @@ impl Embedder {
         // bge-large-ft and v9-200k ship tokenizer.json with
         // truncation.max_length=512, which silently caps `token_count`
         // and breaks every downstream "is this chunk too long?" check.
-        let tokenizer_arc = self.tokenizer()?;
-        let mut tok = (*tokenizer_arc).clone();
-        if tok.get_truncation().is_some() {
-            tok.with_truncation(None)
-                .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
-        }
+        let tok = self.tokenizer_no_trunc()?;
         let encoding = tok
             .encode(text, false)
             .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
@@ -527,12 +578,7 @@ impl Embedder {
         let _span = tracing::debug_span!("token_counts_batch", count = texts.len()).entered();
         // Same truncation-bypass as `token_count` — count actual tokens
         // for accurate windowing decisions.
-        let tokenizer_arc = self.tokenizer()?;
-        let mut tok = (*tokenizer_arc).clone();
-        if tok.get_truncation().is_some() {
-            tok.with_truncation(None)
-                .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
-        }
+        let tok = self.tokenizer_no_trunc()?;
         let encodings = tok
             .encode_batch(texts.to_vec(), false)
             .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
@@ -586,25 +632,19 @@ impl Embedder {
             )));
         }
 
-        // Clone the tokenizer and disable truncation so we count the FULL
+        // Use the cached truncation-disabled tokenizer so we count the FULL
         // token sequence, not whatever the tokenizer's `truncation` field
         // caps it to. Some preset tokenizers (notably bge-large-ft and
         // v9-200k, which were exported via `optimum-cli` with default
         // truncation enabled) ship `tokenizer.json` with
-        // `truncation: {max_length: 512}`. Without this clone, encode()
+        // `truncation: {max_length: 512}`. Without the override, encode()
         // silently caps long content at 512 tokens, the windowing loop
         // sees `ids.len() <= max_tokens` and returns a single window —
         // dropping ~90% of long markdown sections from the embedding.
         // Inference paths (embed_query/embed_batch) intentionally keep the
         // truncation behavior because they need to clamp input to
         // max_seq_length anyway, so we only override here.
-        let tokenizer_arc = self.tokenizer()?;
-        let mut tokenizer_no_trunc = (*tokenizer_arc).clone();
-        if tokenizer_no_trunc.get_truncation().is_some() {
-            tokenizer_no_trunc
-                .with_truncation(None)
-                .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
-        }
+        let tokenizer_no_trunc = self.tokenizer_no_trunc()?;
         let encoding = tokenizer_no_trunc
             .encode(text, false)
             .map_err(|e| EmbedderError::Tokenizer(e.to_string()))?;
@@ -842,6 +882,17 @@ impl Embedder {
             }
         }
         *tok = None;
+        drop(tok);
+        // Drop the cached truncation-disabled clone alongside the base
+        // tokenizer — a model swap must not leave the old model's no-trunc
+        // tokenizer serving `split_into_windows` / `token_count`.
+        {
+            let mut no_trunc = self
+                .tokenizer_no_trunc
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            *no_trunc = None;
+        }
         // Reset detected_dim and model_fingerprint so a model swap re-detects
         // dim and re-fingerprints on next inference. Without this reset, the
         // Mutex<Option<...>> slots would carry the first-loaded model's values
@@ -1998,6 +2049,43 @@ mod tests {
             };
             let windows = embedder.split_into_windows("any text", 0, 0).unwrap();
             assert!(windows.is_empty());
+        }
+
+        /// Two calls to `tokenizer_no_trunc()` must return the SAME cached
+        /// tokenizer (Arc identity), not a fresh deep clone per call — the
+        /// per-call vocab clone was ~14k clones per reindex.
+        #[test]
+        #[ignore]
+        fn tokenizer_no_trunc_is_cached_across_calls() {
+            let embedder = match Embedder::new(ModelConfig::e5_base()) {
+                Ok(e) => e,
+                Err(err) => {
+                    eprintln!("E5-base unavailable in test env: {err}; skipping (#1305)");
+                    return;
+                }
+            };
+            let first = match embedder.tokenizer_no_trunc() {
+                Ok(t) => t,
+                Err(err) => {
+                    eprintln!(
+                        "tokenizer load failed (likely corrupt tokenizer.json from a partial \
+                         HF cache): {err}; skipping (#1305)"
+                    );
+                    return;
+                }
+            };
+            let second = embedder.tokenizer_no_trunc().unwrap();
+            assert!(
+                std::sync::Arc::ptr_eq(&first, &second),
+                "second call must reuse the cached no-trunc tokenizer"
+            );
+            // clear_session drops the cache; the next call rebuilds a NEW Arc.
+            embedder.clear_session();
+            let third = embedder.tokenizer_no_trunc().unwrap();
+            assert!(
+                !std::sync::Arc::ptr_eq(&first, &third),
+                "clear_session must drop the cached no-trunc tokenizer"
+            );
         }
 
         /// overlap >= max_tokens/2 must error out, not

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -861,9 +861,16 @@ impl<Mode> Store<Mode> {
         let use_rrf = flags.use_rrf;
 
         self.rt.block_on(async {
-            // Phase 1: Lightweight candidate fetch — only scoring fields +
-            // embedding. Excludes heavy content/doc/signature columns.
-            let candidates = self.fetch_candidates_by_ids_async(candidate_ids).await?;
+            // Phase 1: Lightweight candidate fetch — only scoring fields.
+            // Excludes heavy content/doc/signature columns. The embedding
+            // BLOB is fetched only when there are no pre-fused scores:
+            // `search_hybrid` builds `candidate_ids` and `fused_scores` from
+            // the same fusion result, so fused coverage is total by
+            // construction and the cosine fallback below never needs the
+            // embedding on that path.
+            let candidates = self
+                .fetch_candidates_by_ids_async(candidate_ids, fused_scores.is_none())
+                .await?;
 
             // Compile glob pattern once outside the loop (not per-chunk).
             let glob_matcher = compile_glob_filter(filter.path_pattern.as_ref());
@@ -938,7 +945,20 @@ impl<Mode> Store<Mode> {
                                 &scoring_ctx,
                             )?
                         } else {
-                            let embedding = embedding_slice(&embedding_bytes, self.dim).ok()?;
+                            // `embedding_bytes` is `Some` whenever
+                            // `fused_scores` is `None` (the fetch above keys
+                            // on it), and the fused map covers every
+                            // candidate id by construction — so a `None`
+                            // here means that invariant broke upstream.
+                            // Drop the candidate loudly rather than panic.
+                            let Some(bytes) = embedding_bytes.as_deref() else {
+                                tracing::warn!(
+                                    id = %candidate.id,
+                                    "candidate missing both fused score and embedding; dropping"
+                                );
+                                return None;
+                            };
+                            let embedding = embedding_slice(bytes, self.dim).ok()?;
                             score_candidate(
                                 embedding,
                                 Some(&candidate.name),

--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -58,10 +58,17 @@ impl<Mode> Store<Mode> {
     /// `doc`, `signature`, `line_start`, `line_end` columns. Full content is
     /// loaded only for top-k survivors via `fetch_chunks_by_ids_async`.
     /// Batch size derives from `max_rows_per_statement(1)`.
+    ///
+    /// When `with_embeddings` is false, the embedding BLOB column is skipped
+    /// entirely (every tuple carries `None`). The hybrid-fused search path
+    /// scores from pre-fused dense+sparse scores and never reads the
+    /// embedding, so fetching ~candidate_count BLOBs per query (768-dim ×
+    /// 4 bytes × ~450 candidates ≈ 1.4 MB) was pure waste there.
     pub(crate) async fn fetch_candidates_by_ids_async(
         &self,
         ids: &[&str],
-    ) -> Result<Vec<(CandidateRow, Vec<u8>)>, StoreError> {
+        with_embeddings: bool,
+    ) -> Result<Vec<(CandidateRow, Option<Vec<u8>>)>, StoreError> {
         if ids.is_empty() {
             return Ok(vec![]);
         }
@@ -79,16 +86,24 @@ impl<Mode> Store<Mode> {
         // tie-break sorts rely on.
         let id_pos: std::collections::HashMap<&str, usize> =
             ids.iter().enumerate().map(|(i, &id)| (id, i)).collect();
-        let mut positioned: Vec<Option<(CandidateRow, Vec<u8>)>> =
+        let mut positioned: Vec<Option<(CandidateRow, Option<Vec<u8>>)>> =
             (0..ids.len()).map(|_| None).collect();
 
         for batch in ids.chunks(BATCH_SIZE) {
             let placeholders = crate::store::helpers::make_placeholders(batch.len());
-            let sql = format!(
-                "SELECT id, name, origin, language, chunk_type, embedding
-                 FROM chunks WHERE id IN ({})",
-                placeholders
-            );
+            let sql = if with_embeddings {
+                format!(
+                    "SELECT id, name, origin, language, chunk_type, embedding
+                     FROM chunks WHERE id IN ({})",
+                    placeholders
+                )
+            } else {
+                format!(
+                    "SELECT id, name, origin, language, chunk_type
+                     FROM chunks WHERE id IN ({})",
+                    placeholders
+                )
+            };
 
             let rows: Vec<_> = {
                 let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
@@ -100,7 +115,11 @@ impl<Mode> Store<Mode> {
 
             for r in &rows {
                 let candidate = CandidateRow::from_row(r);
-                let embedding_bytes: Vec<u8> = r.get("embedding");
+                let embedding_bytes: Option<Vec<u8>> = if with_embeddings {
+                    Some(r.get("embedding"))
+                } else {
+                    None
+                };
                 if let Some(&pos) = id_pos.get(candidate.id.as_str()) {
                     positioned[pos] = Some((candidate, embedding_bytes));
                 }


### PR DESCRIPTION
## Audit v1.42.0 — small-P1 batch

Closes EH-V1.42-1, OB-V1.42-1, PERF-V1.42-2, PERF-V1.42-5 from `docs/audit-triage.md` — four independent easy/high-impact fixes.

- **`load_audit_state` error visibility (EH-V1.42-1):** read errors match on `e.kind()` — NotFound stays silent (normal), everything else warns with path + error, so EACCES/EIO can no longer silently disable audit mode. `#[cfg(unix)]` permission-denied test (root/permissive-FS guarded).
- **Reuse-cache corruption warn (OB-V1.42-1):** `resolve_reuse` now warns with hash + error + actionable hint when a cached embedding fails `Embedding::try_new`, mirroring the store-cache sibling, and the "Global cache hits" debug line carries `dropped` so bulk corruption shows in one event. Test corrupts a blob to NaN via direct SQL and pins the fallthrough. (Hint says `cqs cache clear`, not `prune` — prune is age-based and wouldn't remove a corrupt entry.)
- **Fused-path embedding fetch skip (PERF-V1.42-2):** `fetch_candidates_by_ids_async` gains `with_embeddings: bool`; the single caller passes `fused_scores.is_none()`, eliminating ~1.4 MB of provably-unread BLOB fetch + decode per hybrid query. Fused coverage verified total by construction; the now-unreachable else branch degrades with a warn instead of panicking if the invariant ever breaks.
- **Tokenizer clone cache (PERF-V1.42-5):** the truncation-disabled tokenizer is cached on the Embedder (`Mutex<Option<Arc<Tokenizer>>>` — OnceLock can't reset under `&self`, and `clear_session` must drop it on model swap); `split_into_windows`, `token_count`, and `token_counts_batch` all had the identical per-call deep-clone and now share it. ~14k 262k-vocab clones per reindex gone. The suggested `text.len() <= max_tokens` short-circuit was deliberately skipped: NFD-expanding normalizers break the "bytes bound tokens" invariant, so it isn't provable across presets.

Tests: audit 21, pipeline::reuse 5, search 242, store::search 12, windowing/token suites green incl. new pins. fmt + clippy `--all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
