### PR TITLE
fix(daemon): same-invocation parity — clap-derived arg translation, slot env bypass, loud transport fallback, shared limit cap

### DIFF
--- a/cqs-macros/src/lib.rs
+++ b/cqs-macros/src/lib.rs
@@ -87,6 +87,30 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let variant_name_arms = parsed.iter().map(|v| v.variant_name_arm(enum_ident));
     let batch_support_arms = parsed.iter().map(|v| v.batch_support_arm(enum_ident));
 
+    // Names of variants that can route to the daemon's batch dispatcher:
+    // `batch = "daemon"` always, plus `batch = "runtime"` (whose support is
+    // decided per-invocation but resolves to Daemon for some inner
+    // subcommands). Emitted as `daemon_capable_variant_names()` so a test can
+    // assert every name has a matching `BatchCmd` subcommand — without this,
+    // the link between the two enums is checked only at runtime, only
+    // daemon-up.
+    let daemon_capable_pushes = parsed
+        .iter()
+        .filter(|v| {
+            matches!(
+                v.batch,
+                BatchSupportKind::Daemon | BatchSupportKind::Runtime
+            )
+        })
+        .map(|v| {
+            let cfg = &v.cfg_attrs;
+            let name = &v.name_lit;
+            quote! {
+                #(#cfg)*
+                names.push(#name);
+            }
+        });
+
     let group_a_dispatch_arms = parsed
         .iter()
         .filter(|v| matches!(v.group, Group::A))
@@ -161,6 +185,22 @@ fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
                 match self {
                     #(#batch_support_arms,)*
                 }
+            }
+
+            /// Wire-level names of every variant that may forward to the
+            /// daemon's batch dispatcher (`batch = "daemon"` plus
+            /// `batch = "runtime"`). A test asserts each name resolves to a
+            /// `BatchCmd` subcommand, so a variant marked daemon-capable
+            /// without a batch handler fails at test time instead of at
+            /// runtime, daemon-up only.
+            #[allow(
+                dead_code,
+                reason = "consumed by the exhaustiveness test in cli::batch::commands"
+            )]
+            pub fn daemon_capable_variant_names() -> Vec<&'static str> {
+                let mut names = Vec::new();
+                #(#daemon_capable_pushes)*
+                names
             }
         }
 

--- a/src/cli/batch/commands.rs
+++ b/src/cli/batch/commands.rs
@@ -990,4 +990,30 @@ mod tests {
         };
         assert!(!dead.is_pipeable());
     }
+
+    /// Exhaustiveness link between the two enums the daemon-forward path
+    /// straddles: every `Commands` variant marked daemon-capable
+    /// (`#[cqs_cmd(batch = "daemon")]`, plus `"runtime"` whose support may
+    /// resolve to Daemon per-invocation) must have a same-named `BatchCmd`
+    /// subcommand. Without this pin, a variant marked daemon without a batch
+    /// handler fails only at runtime, only daemon-up — `cqs <cmd>` errors
+    /// with a daemon parse failure while working daemon-down.
+    #[test]
+    fn every_daemon_capable_command_has_a_batch_subcommand() {
+        use clap::CommandFactory;
+        let batch = BatchInput::command();
+        let names = crate::cli::definitions::Commands::daemon_capable_variant_names();
+        assert!(
+            !names.is_empty(),
+            "daemon_capable_variant_names() must not be empty — derive regression"
+        );
+        for name in names {
+            assert!(
+                batch.find_subcommand(name).is_some(),
+                "Commands::{name} is marked daemon-capable but BatchCmd has no `{name}` \
+                 subcommand — daemon-up `cqs {name}` would fail at runtime. Either add the \
+                 batch handler or reclassify the variant as batch = \"cli\""
+            );
+        }
+    }
 }

--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -5,10 +5,11 @@ use anyhow::{Context, Result};
 use super::super::BatchView;
 use crate::cli::args::SearchArgs;
 use crate::cli::commands::search::query::{query_core, QueryArgs};
-
-/// Per-result limit clamp the daemon applies. The wire surface is agent-facing
-/// and must bound an over-eager `--limit`; the CLI has no such clamp.
-const DAEMON_LIMIT_CAP: usize = 100;
+// Shared search `--limit` cap. The CLI dispatcher clamps `cli.limit` to the
+// same constant (`cli::dispatch`), so daemon-up and daemon-down invocations
+// agree on the bound — CLI==daemon parity is the requirement, not a
+// daemon-only defense.
+use crate::cli::limits::SEARCH_LIMIT_CAP;
 
 /// Validate the textual filter args (`--lang`, `--include-type`,
 /// `--exclude-type`) with flag-specific error messages, returning the parsed
@@ -59,7 +60,7 @@ fn validate_filter_args(args: &SearchArgs) -> Result<ParsedFilters> {
 /// - `fts_first = false`: the daemon never had the NameOnly-FTS-first
 ///   short-circuit; it stays on the dense hybrid path for non-`--name-only`
 ///   queries.
-/// - limit clamped to [`DAEMON_LIMIT_CAP`].
+/// - limit clamped to [`SEARCH_LIMIT_CAP`].
 /// - `json_overhead` is the constant per-result envelope cost — the daemon
 ///   always serializes, so token-budget packing estimates with the JSON
 ///   overhead the CLI uses under `--json`.
@@ -71,7 +72,7 @@ fn validate_filter_args(args: &SearchArgs) -> Result<ParsedFilters> {
 fn daemon_query_args(args: &SearchArgs) -> QueryArgs {
     QueryArgs {
         query: args.query.clone(),
-        limit: args.limit_arg.limit.clamp(1, DAEMON_LIMIT_CAP),
+        limit: args.limit_arg.limit.clamp(1, SEARCH_LIMIT_CAP),
         name_only: args.name_only,
         lang: args.lang.clone(),
         include_type: args.include_type.clone(),
@@ -184,7 +185,7 @@ fn dispatch_search_with_refs(ctx: &BatchView, args: &SearchArgs) -> Result<serde
     // user typos that must fast-fail with the offending flag's name.
     let (languages, include_types, exclude_types) = validate_filter_args(args)?;
 
-    let limit = args.limit_arg.limit.clamp(1, DAEMON_LIMIT_CAP);
+    let limit = args.limit_arg.limit.clamp(1, SEARCH_LIMIT_CAP);
     let threshold = args.threshold;
 
     let query_embedding = ctx

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -416,7 +416,15 @@ pub(super) enum Commands {
         serve: bool,
     },
     /// What functions, callers, and tests are affected by current diff
-    #[cqs_cmd(group = "b", batch = "daemon")]
+    ///
+    /// `batch = "cli"`: the batch dispatcher has no `affected` subcommand, so
+    /// a daemon-marked classification made `cqs affected` error daemon-up
+    /// while working daemon-down (the exhaustiveness test in
+    /// `cli::batch::commands` now pins the link). The command also reads the
+    /// diff from `--stdin`/git in the *CLI* process, which a daemon dispatch
+    /// cannot reproduce. Flip back to `daemon` only together with a
+    /// `BatchCmd::Affected` handler.
+    #[cqs_cmd(group = "b", batch = "cli")]
     Affected {
         /// Git ref to diff against (default: unstaged changes)
         #[arg(long)]

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -645,7 +645,7 @@ mod tests {
             .find_subcommand("search")
             .expect("batch parser must have a `search` subcommand");
         let accepted: std::collections::BTreeSet<String> =
-            search.get_arguments().flat_map(|a| spellings(a)).collect();
+            search.get_arguments().flat_map(spellings).collect();
 
         for arg in cli_app.get_arguments() {
             let id = arg.get_id().as_str();

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -216,7 +216,7 @@ fn run_with_dispatch(
     // flag is propagated into `CQS_SLOT` above, so the env check covers both.
     #[cfg(unix)]
     if cli.slot.is_none()
-        && std::env::var_os("CQS_SLOT").is_none()
+        && !cqs_slot_env_pins_slot()
         && std::env::var("CQS_NO_DAEMON").as_deref() != Ok("1")
     {
         // Daemon protocol errors surface as `Err`. Transport-level failures
@@ -259,6 +259,18 @@ fn run_with_dispatch(
 pub(crate) fn cmd_completions(shell: clap_complete::Shell) {
     use clap::CommandFactory;
     clap_complete::generate(shell, &mut Cli::command(), "cqs", &mut std::io::stdout());
+}
+
+/// `true` when the `CQS_SLOT` env var pins a slot — i.e. it is set to a
+/// non-empty (post-trim) value. Mirrors the semantics of
+/// `slot::resolve_slot_name`, which trims and treats empty/whitespace (and
+/// non-UTF-8) as UNSET: `CQS_SLOT= cqs …` — a script clearing the var — must
+/// keep the daemon fast path, not silently bypass it.
+#[cfg(unix)]
+fn cqs_slot_env_pins_slot() -> bool {
+    std::env::var("CQS_SLOT")
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false)
 }
 
 /// Top-level `Cli` arg IDs (clap IDs = struct field names) that configure the

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -203,15 +203,22 @@ fn run_with_dispatch(
         crate::cli::limits::install_reranker_pool_overrides(pool_max, over_retrieval);
     }
 
-    // Clamp limit to prevent usize::MAX wrapping to -1 in SQLite queries
-    cli.limit = cli.limit.clamp(1, 100);
+    // Clamp limit to prevent usize::MAX wrapping to -1 in SQLite queries.
+    // Same cap as the daemon batch handler — see `limits::SEARCH_LIMIT_CAP`.
+    cli.limit = cli.limit.clamp(1, crate::cli::limits::SEARCH_LIMIT_CAP);
 
     // ── Daemon client: forward to running daemon if available ──────────────
     // The daemon binds to whichever slot was active at *its* startup (per
-    // spec). If the user passed `--slot <name>`, bypass the daemon so the
-    // requested slot wins instead of silently getting the daemon's slot.
+    // spec). If the user requested a slot — `--slot <name>` flag OR the
+    // documented-equivalent `CQS_SLOT` env var (honored by
+    // `slot::resolve_slot_name`) — bypass the daemon so the requested slot
+    // wins instead of silently getting the daemon's startup slot. Note the
+    // flag is propagated into `CQS_SLOT` above, so the env check covers both.
     #[cfg(unix)]
-    if cli.slot.is_none() && std::env::var("CQS_NO_DAEMON").as_deref() != Ok("1") {
+    if cli.slot.is_none()
+        && std::env::var_os("CQS_SLOT").is_none()
+        && std::env::var("CQS_NO_DAEMON").as_deref() != Ok("1")
+    {
         // Daemon protocol errors surface as `Err`. Transport-level failures
         // return `Ok(None)` so CLI fallback works for those.
         if let Some(output) = try_daemon_query(project_cqs_dir, &cli)? {
@@ -254,6 +261,64 @@ pub(crate) fn cmd_completions(shell: clap_complete::Shell) {
     clap_complete::generate(shell, &mut Cli::command(), "cqs", &mut std::io::stdout());
 }
 
+/// Top-level `Cli` arg IDs (clap IDs = struct field names) that configure the
+/// CLI *process* — output shaping, logging, model/slot selection — rather
+/// than the search. On daemon forwarding these are stripped from bare-query
+/// argv; every other top-level flag is a search knob mirrored by
+/// `args::SearchArgs` and forwards verbatim.
+///
+/// Kept in lock-step with [`SEARCH_KNOB_ARG_IDS`] by
+/// `every_top_level_cli_arg_is_classified_for_daemon_translation` — adding a
+/// top-level flag without classifying it here or there fails that test
+/// instead of failing daemon-up at runtime.
+#[cfg(unix)]
+const PROCESS_LOCAL_ARG_IDS: &[&str] = &["json", "quiet", "model", "slot", "verbose"];
+
+/// Top-level `Cli` arg IDs that are search knobs, mirrored spelling-for-
+/// spelling by `args::SearchArgs` (plus `LimitArg` for `limit`). Forwarded
+/// verbatim to the batch `search` parser on bare-query daemon dispatch.
+#[cfg(unix)]
+#[allow(
+    dead_code,
+    reason = "consumed by the classification tests below — the forwarded set is \
+              'everything not process-local', so production only needs the strip list"
+)]
+const SEARCH_KNOB_ARG_IDS: &[&str] = &[
+    "limit",
+    "threshold",
+    "name_boost",
+    "lang",
+    "include_type",
+    "exclude_type",
+    "path",
+    "pattern",
+    "name_only",
+    "rrf",
+    "include_docs",
+    "reranker",
+    "splade",
+    "splade_alpha",
+    "no_content",
+    "context",
+    "expand_parent",
+    "ref_name",
+    "include_refs",
+    "tokens",
+    "no_stale_check",
+    "no_demote",
+];
+
+/// Build the [`cqs::daemon_translate::CliArgSpec`] from the live clap
+/// definition. Derived at runtime (like `telemetry::describe_command`) so a
+/// new top-level flag is classified automatically — hand-mirrored flag lists
+/// are how `-v <cmd>` / `--rrf <cmd>` came to hard-error daemon-up while
+/// working daemon-down.
+#[cfg(unix)]
+fn cli_arg_spec() -> cqs::daemon_translate::CliArgSpec {
+    use clap::CommandFactory;
+    cqs::daemon_translate::CliArgSpec::from_clap(&Cli::command(), PROCESS_LOCAL_ARG_IDS)
+}
+
 /// Try to forward the current command to a running daemon.
 ///
 /// Returns:
@@ -294,14 +359,22 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Result<Option<Strin
     use std::io::{BufRead, Write};
     use std::os::unix::net::UnixStream;
 
+    // From here on the socket file exists, so transport failures are
+    // anomalous (wedged or crashed daemon) — they log at warn so the default
+    // `cqs=info` filter surfaces why a 3 ms daemon query silently became a
+    // multi-second CLI cold start. Only the socket-absent path above stays
+    // quiet: that's the normal no-daemon case.
+    const FALLBACK_HINT: &str = "daemon unresponsive — falling back to CLI; \
+         check `systemctl --user status cqs-watch` (or set CQS_NO_DAEMON=1 to silence)";
+
     let stream = match UnixStream::connect(&sock_path) {
         Ok(s) => s,
         Err(e) => {
-            tracing::debug!(
+            tracing::warn!(
                 path = %sock_path.display(),
                 error = %e,
                 stage = "connect",
-                "Daemon transport failed, falling back to CLI"
+                "{FALLBACK_HINT}"
             );
             return Ok(None);
         }
@@ -340,8 +413,11 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Result<Option<Strin
              Set CQS_NO_DAEMON=1 to force CLI mode with the requested model."
         );
     }
-    let (command, cmd_args) =
-        cqs::daemon_translate::translate_cli_args_to_batch(&raw_args, cli.command.is_some());
+    let (command, cmd_args) = cqs::daemon_translate::translate_cli_args_to_batch(
+        &raw_args,
+        cli.command.is_some(),
+        &cli_arg_spec(),
+    );
     let request = serde_json::json!({
         "command": command,
         "args": cmd_args,
@@ -349,11 +425,11 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Result<Option<Strin
 
     let mut stream = stream;
     if let Err(e) = writeln!(stream, "{}", request) {
-        tracing::debug!(error = %e, stage = "write", "Daemon transport failed, falling back to CLI");
+        tracing::warn!(error = %e, stage = "write", "{FALLBACK_HINT}");
         return Ok(None);
     }
     if let Err(e) = stream.flush() {
-        tracing::debug!(error = %e, stage = "flush", "Daemon transport failed, falling back to CLI");
+        tracing::warn!(error = %e, stage = "flush", "{FALLBACK_HINT}");
         return Ok(None);
     }
 
@@ -369,11 +445,7 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Result<Option<Strin
     let bytes_read = match reader.read_line(&mut response_line) {
         Ok(n) => n,
         Err(e) => {
-            tracing::debug!(
-                error = %e,
-                stage = "read",
-                "Daemon transport failed, falling back to CLI"
-            );
+            tracing::warn!(error = %e, stage = "read", "{FALLBACK_HINT}");
             return Ok(None);
         }
     };
@@ -396,20 +468,16 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Result<Option<Strin
     let resp: serde_json::Value = match serde_json::from_str(response_line.trim()) {
         Ok(v) => v,
         Err(e) => {
-            tracing::debug!(
-                error = %e,
-                stage = "parse",
-                "Daemon transport failed, falling back to CLI"
-            );
+            tracing::warn!(error = %e, stage = "parse", "{FALLBACK_HINT}");
             return Ok(None);
         }
     };
     let status = match resp.get("status").and_then(|v| v.as_str()) {
         Some(s) => s,
         None => {
-            tracing::debug!(
+            tracing::warn!(
                 stage = "parse",
-                "Daemon response missing 'status' field, falling back to CLI"
+                "Daemon response missing 'status' field — {FALLBACK_HINT}"
             );
             return Ok(None);
         }
@@ -494,4 +562,128 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Result<Option<Strin
     Err(anyhow::anyhow!(
         "daemon error: {msg}\nhint: set CQS_NO_DAEMON=1 to bypass the daemon"
     ))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    /// Collect every spelling (long, long aliases, short, short aliases) of a
+    /// clap arg.
+    fn spellings(arg: &clap::Arg) -> Vec<String> {
+        let mut out = Vec::new();
+        if let Some(long) = arg.get_long() {
+            out.push(format!("--{long}"));
+        }
+        for alias in arg.get_all_aliases().unwrap_or_default() {
+            out.push(format!("--{alias}"));
+        }
+        if let Some(short) = arg.get_short() {
+            out.push(format!("-{short}"));
+        }
+        for alias in arg.get_all_short_aliases().unwrap_or_default() {
+            out.push(format!("-{alias}"));
+        }
+        out
+    }
+
+    /// Exhaustiveness pin for the daemon arg translation: every top-level
+    /// `Cli` flag must be explicitly classified as process-local (stripped on
+    /// daemon forwarding) or a search knob (forwarded to the batch `search`
+    /// parser on bare queries) — and never both. A new top-level flag fails
+    /// here at test time instead of failing daemon-up at runtime, which is
+    /// how `-v <cmd>` / `--rrf <cmd>` regressed.
+    #[test]
+    fn every_top_level_cli_arg_is_classified_for_daemon_translation() {
+        let app = Cli::command();
+        for arg in app.get_arguments() {
+            if arg.is_positional() {
+                continue; // `query` — the bare-query payload itself.
+            }
+            if matches!(
+                arg.get_action(),
+                clap::ArgAction::Help
+                    | clap::ArgAction::HelpShort
+                    | clap::ArgAction::HelpLong
+                    | clap::ArgAction::Version
+            ) {
+                continue; // clap-handled before dispatch ever runs.
+            }
+            let id = arg.get_id().as_str();
+            let local = PROCESS_LOCAL_ARG_IDS.contains(&id);
+            let knob = SEARCH_KNOB_ARG_IDS.contains(&id);
+            assert!(
+                local ^ knob,
+                "top-level Cli arg `{id}` must be classified in exactly one of \
+                 PROCESS_LOCAL_ARG_IDS / SEARCH_KNOB_ARG_IDS (local={local}, knob={knob}); \
+                 unclassified flags break daemon/CLI parity"
+            );
+        }
+    }
+
+    /// Every search-knob spelling the bare-query path forwards must be
+    /// accepted by the batch `search` parser — otherwise a daemon-up bare
+    /// query with that flag returns a parse error while daemon-down works.
+    #[test]
+    fn forwarded_search_knob_spellings_are_accepted_by_batch_search() {
+        let cli_app = Cli::command();
+        let batch_app = crate::cli::batch::BatchInput::command();
+        let search = batch_app
+            .find_subcommand("search")
+            .expect("batch parser must have a `search` subcommand");
+        let accepted: std::collections::BTreeSet<String> =
+            search.get_arguments().flat_map(|a| spellings(a)).collect();
+
+        for arg in cli_app.get_arguments() {
+            let id = arg.get_id().as_str();
+            if !SEARCH_KNOB_ARG_IDS.contains(&id) {
+                continue;
+            }
+            for spelling in spellings(arg) {
+                assert!(
+                    accepted.contains(&spelling),
+                    "top-level search knob `{id}` spelling `{spelling}` is forwarded to the \
+                     daemon but the batch `search` parser does not accept it"
+                );
+            }
+        }
+    }
+
+    /// The derived spec marks value-taking flags correctly: `--model` /
+    /// `--slot` / `-n` consume a value; `--json` / `-v` / `--rrf` don't.
+    #[test]
+    fn derived_spec_value_flag_classification() {
+        let spec = cli_arg_spec();
+        for flag in ["--model", "--slot", "-n", "--limit", "-t", "--tokens"] {
+            assert!(
+                spec.value_flags.contains(flag),
+                "`{flag}` must be classified as a value flag"
+            );
+        }
+        for flag in ["--json", "-q", "-v", "--rrf", "--name-only"] {
+            assert!(
+                !spec.value_flags.contains(flag),
+                "`{flag}` must not be classified as a value flag"
+            );
+        }
+        for flag in [
+            "--json",
+            "-q",
+            "--quiet",
+            "-v",
+            "--verbose",
+            "--model",
+            "--slot",
+        ] {
+            assert!(
+                spec.bare_query_strip.contains(flag),
+                "`{flag}` is process-local and must be stripped on bare queries"
+            );
+        }
+        assert!(
+            !spec.bare_query_strip.contains("--rrf"),
+            "`--rrf` is a search knob and must forward on bare queries"
+        );
+    }
 }

--- a/src/cli/limits.rs
+++ b/src/cli/limits.rs
@@ -15,6 +15,13 @@
 //! FTS, graph, converter) live in `crate::limits` because their callers
 //! (`parser/`, `store/`, `nl/`, `convert/`) cannot reach into the CLI module.
 
+/// Hard cap on `--limit` for search, applied identically by the CLI
+/// dispatcher (`cli::dispatch`, top-level `cli.limit` clamp) and the daemon
+/// batch search handler (`batch::handlers::search`). One constant for both
+/// surfaces is a parity requirement: `cqs <query> -n 500` must return the
+/// same result count whether or not a daemon happens to serve it.
+pub(crate) const SEARCH_LIMIT_CAP: usize = 100;
+
 /// Maximum `--limit` accepted by `cqs scout` and the batch `scout`
 /// handler. Scout's downstream grouping and token packing scale roughly
 /// linearly in this number, so we keep the ceiling modest.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1096,12 +1096,13 @@ mod tests {
     #[test]
     fn test_cli_limit_clamped_to_valid_range() {
         let config = cqs::config::Config::default();
-        // Verify that extremely large limits get clamped to 100
+        // Verify that extremely large limits get clamped to the shared
+        // search cap (same constant the daemon batch handler applies).
         let argv1 = ["cqs", "-n", "999", "query"];
         let mut cli = Cli::try_parse_from(argv1).unwrap();
         config::apply_config_defaults_with_argv(&mut cli, &config, argv1);
-        cli.limit = cli.limit.clamp(1, 100);
-        assert_eq!(cli.limit, 100);
+        cli.limit = cli.limit.clamp(1, limits::SEARCH_LIMIT_CAP);
+        assert_eq!(cli.limit, limits::SEARCH_LIMIT_CAP);
 
         // `-n 0` is rejected at parse time (`value_parser =
         // parse_nonzero_usize`) with a clear error rather than producing a cli
@@ -1123,7 +1124,7 @@ mod tests {
         let argv3 = ["cqs", "-n", "10", "query"];
         let mut cli = Cli::try_parse_from(argv3).unwrap();
         config::apply_config_defaults_with_argv(&mut cli, &config, argv3);
-        cli.limit = cli.limit.clamp(1, 100);
+        cli.limit = cli.limit.clamp(1, limits::SEARCH_LIMIT_CAP);
         assert_eq!(cli.limit, 10);
     }
 

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -11,117 +11,215 @@
 //! The daemon speaks the same syntax as `cqs batch`: one JSON object per line
 //! with `{"command": "<sub>", "args": [...]}`. The CLI args that reach
 //! `try_daemon_query` are the raw argv post-`cqs` (i.e. `std::env::args()
-//! .skip(1)`) — still mixed with global flags the top-level `Cli` struct
-//! consumes (`--json`, `-q`, `--model VAL`) and sub-command flags that the
+//! .skip(1)`) — still mixed with top-level flags the `Cli` struct consumes
+//! (`--json`, `-v`, `--model VAL`, `--rrf`, …) and sub-command flags that the
 //! batch parser consumes on the subcommand side.
 //!
 //! Responsibilities:
 //!
-//! - Strip global boolean flags (`--json`, `-q`, `--quiet`) — they live on
-//!   `Cli` not on the subcommand, and the batch handler always emits JSON.
-//! - Strip global key/value flags (`--model VAL`). The daemon runs a single
-//!   loaded model; reporting the stripped value is the caller's concern
-//!   (see `stripped_model_value`).
-//! - Remap `-n <N>` / `--limit <N>` to the canonical `--limit` form the
-//!   batch parser expects on the subcommand. Also handles `-n=N` /
-//!   `--limit=N` attached-value forms.
-//! - Auto-prepend `search` for bare-query invocations (no subcommand, e.g.
-//!   `cqs "hello world"`) so the batch parser can route them.
+//! - **With a subcommand**: drop every top-level token before the subcommand
+//!   name (those flags configure the CLI process — output shape, logging,
+//!   model selection — and do not reach subcommand handlers on the in-process
+//!   path either), then forward everything after the subcommand verbatim.
+//!   The CLI and batch sides flatten the *same* shared `args::*Args` structs,
+//!   so post-subcommand tokens parse identically on both surfaces — including
+//!   per-command short flags whose meaning differs from the top level (e.g.
+//!   blame's `-n` means `--commits`, not `--limit`).
+//! - **Bare query** (`cqs "find something"`): prepend `search` and translate
+//!   the top-level flags for the batch `search` parser. Search knobs
+//!   (`--rrf`, `-t`, `-n`, `--tokens`, …) mirror `args::SearchArgs` spelling
+//!   for spelling and forward verbatim; process-local flags (`--json`, `-q`,
+//!   `-v`, `--model`, `--slot`) are dropped.
 //!
-//! Keeping the translation pure (no I/O, no tracing) makes the whole surface
-//! unit-testable. The caller owns side effects (warning on stripped
-//! `--model`, socket I/O, response parsing).
+//! Which top-level flags exist, which take values, and which are
+//! process-local is not hardcoded here: the caller derives a [`CliArgSpec`]
+//! from the live clap definition ([`CliArgSpec::from_clap`]) so a new
+//! top-level flag is classified automatically instead of hand-mirrored —
+//! hand-mirroring is how `-v <cmd>` / `--rrf <cmd>` came to hard-error
+//! daemon-up while working daemon-down.
+//!
+//! Keeping the translation pure (no I/O, no tracing, no clap statics) makes
+//! the whole surface unit-testable. The caller owns side effects (warning on
+//! stripped `--model`, socket I/O, response parsing).
+
+/// Classification of the top-level CLI flag surface, consumed by
+/// [`translate_cli_args_to_batch`]. Plain data — the helper stays pure and
+/// testable without a clap `Command` in hand.
+///
+/// Built from the live clap definition via [`CliArgSpec::from_clap`] in
+/// production (see `cli::dispatch`), or by hand in tests.
+#[derive(Debug, Clone, Default)]
+pub struct CliArgSpec {
+    /// Every spelling (`--long`, `--alias`, `-s`) of a top-level flag that
+    /// consumes a following value token. Needed to skip `--flag value` pairs
+    /// when scanning for the subcommand name, and to forward the value token
+    /// verbatim on the bare-query path.
+    pub value_flags: std::collections::BTreeSet<String>,
+    /// Spellings of top-level flags that are process-local (output shaping,
+    /// logging, model/slot selection) and must be dropped when forwarding a
+    /// bare query to the batch `search` parser. Every other top-level flag is
+    /// a search knob shared spelling-for-spelling with `args::SearchArgs` and
+    /// forwards verbatim.
+    pub bare_query_strip: std::collections::BTreeSet<String>,
+}
+
+impl CliArgSpec {
+    /// Derive the spec from a clap `Command` (the top-level `Cli`
+    /// definition). `process_local_ids` lists the clap arg IDs (struct field
+    /// names) of flags that configure the CLI process rather than the search:
+    /// those are stripped on the bare-query path; everything else forwards.
+    ///
+    /// Mirrors the runtime-derivation pattern in
+    /// `cli::telemetry::describe_command`: value-flag-ness comes from the arg
+    /// action, spellings include long/short forms and all aliases, so a new
+    /// top-level flag is picked up without touching this module. A
+    /// classification test on the caller side pins that every top-level arg
+    /// ID is explicitly process-local or search-forwarded.
+    pub fn from_clap(cmd: &clap::Command, process_local_ids: &[&str]) -> Self {
+        let mut value_flags = std::collections::BTreeSet::new();
+        let mut bare_query_strip = std::collections::BTreeSet::new();
+        for arg in cmd.get_arguments() {
+            if arg.is_positional() {
+                continue;
+            }
+            let takes_value = matches!(
+                arg.get_action(),
+                clap::ArgAction::Set | clap::ArgAction::Append
+            );
+            let mut spellings: Vec<String> = Vec::new();
+            if let Some(long) = arg.get_long() {
+                spellings.push(format!("--{long}"));
+            }
+            for alias in arg.get_all_aliases().unwrap_or_default() {
+                spellings.push(format!("--{alias}"));
+            }
+            if let Some(short) = arg.get_short() {
+                spellings.push(format!("-{short}"));
+            }
+            for alias in arg.get_all_short_aliases().unwrap_or_default() {
+                spellings.push(format!("-{alias}"));
+            }
+            let is_local = process_local_ids.contains(&arg.get_id().as_str());
+            for spelling in spellings {
+                if takes_value {
+                    value_flags.insert(spelling.clone());
+                }
+                if is_local {
+                    bare_query_strip.insert(spelling);
+                }
+            }
+        }
+        Self {
+            value_flags,
+            bare_query_strip,
+        }
+    }
+}
 
 /// Translate raw CLI argv into a `(subcommand, args)` pair for the batch
-/// handler, stripping global flags and normalising `-n`/`--limit`.
+/// handler.
 ///
-/// `raw` is the argv after `cqs` (i.e. what `std::env::args().skip(1)` yields).
-/// `has_subcommand` is `true` iff `Cli::command` parsed a subcommand — i.e.
-/// the first post-strip token is the subcommand name. When `false`, the input
-/// is a bare query (e.g. `cqs "find something"`) and `search` is prepended.
+/// `raw` is the argv after `cqs` (i.e. what `std::env::args().skip(1)`
+/// yields). `has_subcommand` is `true` iff `Cli::command` parsed a
+/// subcommand; when `false` the input is a bare query (e.g. `cqs "find
+/// something"`) and `search` is prepended. `spec` classifies the top-level
+/// flag surface — see [`CliArgSpec`].
 ///
 /// Behaviour is pinned by `tests/daemon_forward_test.rs`. See the module
-/// docs for the full stripping/remapping rules.
-pub fn translate_cli_args_to_batch(raw: &[String], has_subcommand: bool) -> (String, Vec<String>) {
-    // Boolean global flags: drop entirely (no value to track).
-    const GLOBAL_FLAGS: &[&str] = &["--json", "-q", "--quiet"];
-    // Key/value global flags (space-separated form): drop the flag AND its
-    // value. `-n` and `--limit` are intercepted here to rewrite to the
-    // canonical `--limit`.
-    const GLOBAL_WITH_VALUE: &[&str] = &["--model", "-n", "--limit"];
-
-    let mut args: Vec<String> = Vec::with_capacity(raw.len());
-    let mut skip_next = false;
-    for arg in raw.iter() {
-        if skip_next {
-            skip_next = false;
-            continue;
-        }
-        // `--json` / `-q` / `--quiet` → drop.
-        if GLOBAL_FLAGS.contains(&arg.as_str()) {
-            continue;
-        }
-        // Attached-value forms (`-n=5`, `--limit=5`, `--model=foo`). Handle
-        // here so we don't emit them verbatim and rely on the batch parser
-        // to tolerate them. The spaced forms fall through to the next branch.
-        if let Some((key, value)) = arg.split_once('=') {
-            if key == "-n" || key == "--limit" {
-                args.push(format!("--limit={}", value));
-                continue;
-            }
-            if key == "--model" {
-                // Strip `--model=VAL` entirely; caller handles the warning.
-                continue;
-            }
-            if GLOBAL_FLAGS.contains(&key) {
-                // Edge case: `--json=true` etc. — drop.
-                continue;
-            }
-            // Non-global attached-value flag: pass through verbatim.
-        }
-        // Spaced-form global key/value flags.
-        if GLOBAL_WITH_VALUE.contains(&arg.as_str()) {
-            if arg == "-n" || arg == "--limit" {
-                // Remap `-n 5` → `--limit 5`. The value is the next token and
-                // is forwarded verbatim on the next iteration (skip_next
-                // stays false).
-                args.push("--limit".to_string());
-                continue;
-            }
-            // `--model VAL` → strip both tokens. Caller uses
-            // `stripped_model_value` to recover VAL for its warning.
-            skip_next = true;
-            continue;
-        }
-        args.push(arg.clone());
-    }
-
-    if !has_subcommand {
-        // Bare query: `cqs "hello world"` → ("search", ["hello world"]).
-        return ("search".to_string(), args);
-    }
-    // With a subcommand: the first surviving token is the subcommand name.
-    if let Some((first, rest)) = args.split_first() {
-        let cmd = first.clone();
-        let mut tail = rest.to_vec();
-        // `cqs notes list ...` → daemon `notes ...`. The CLI's `Notes`
-        // command takes a NotesCommand subcommand enum (`list`/`add`/
-        // `update`/`remove`) but the batch dispatcher only ever receives
-        // `list` — `add`/`update`/`remove` route through `BatchSupport::Cli`
-        // and never hit the daemon. The batch parser's `BatchCmd::Notes`
-        // accepts `--warnings`/`--patterns` directly (no `list` token), so
-        // we strip the redundant subcommand name here. Without this strip
-        // every `cqs notes list` query through the daemon errors with
-        // `unexpected argument 'list' found`.
-        if cmd == "notes" && tail.first().map(|s| s.as_str()) == Some("list") {
-            tail.remove(0);
-        }
-        (cmd, tail)
+/// docs for the full rules.
+pub fn translate_cli_args_to_batch(
+    raw: &[String],
+    has_subcommand: bool,
+    spec: &CliArgSpec,
+) -> (String, Vec<String>) {
+    if has_subcommand {
+        translate_subcommand_args(raw, spec)
     } else {
+        ("search".to_string(), translate_bare_query_args(raw, spec))
+    }
+}
+
+/// Subcommand form: drop the top-level region (every flag before the
+/// subcommand name), forward the tail verbatim. The batch parser flattens
+/// the same shared args structs as the CLI subcommand, so no per-flag
+/// rewriting is needed — and none is safe, because short-flag meanings
+/// differ per subcommand (blame's `-n` is `--commits`).
+fn translate_subcommand_args(raw: &[String], spec: &CliArgSpec) -> (String, Vec<String>) {
+    let mut idx = 0;
+    while idx < raw.len() {
+        let tok = &raw[idx];
+        if !tok.starts_with('-') {
+            // First non-flag token in the top-level region: the subcommand.
+            break;
+        }
+        // `--key=value` / `-k=value` are self-contained single tokens;
+        // spaced-form value flags consume their following value token too;
+        // boolean flags consume only themselves.
+        if !tok.contains('=') && spec.value_flags.contains(tok.as_str()) {
+            idx += 2;
+        } else {
+            idx += 1;
+        }
+    }
+    let Some(cmd) = raw.get(idx).cloned() else {
         // Unreachable in practice: if clap parsed a subcommand the argv
         // contained its name. Defensive empty fallback.
-        (String::new(), Vec::new())
+        return (String::new(), Vec::new());
+    };
+    let mut tail: Vec<String> = raw[idx + 1..].to_vec();
+    // `cqs notes list ...` → daemon `notes ...`. The CLI's `Notes`
+    // command takes a NotesCommand subcommand enum (`list`/`add`/
+    // `update`/`remove`) but the batch dispatcher only ever receives
+    // `list` — `add`/`update`/`remove` route through `BatchSupport::Cli`
+    // and never hit the daemon. The batch parser's `BatchCmd::Notes`
+    // accepts `--warnings`/`--patterns` directly (no `list` token), so
+    // we strip the redundant subcommand name here. Without this strip
+    // every `cqs notes list` query through the daemon errors with
+    // `unexpected argument 'list' found`.
+    if cmd == "notes" && tail.first().map(|s| s.as_str()) == Some("list") {
+        tail.remove(0);
     }
+    (cmd, tail)
+}
+
+/// Bare-query form: every token is top-level. Process-local flags
+/// (`spec.bare_query_strip`) are dropped — with their value, when they take
+/// one; everything else forwards verbatim to the batch `search` parser,
+/// whose `args::SearchArgs` mirrors the top-level search knobs spelling for
+/// spelling (including `-n`/`--limit` via the shared `LimitArg`).
+fn translate_bare_query_args(raw: &[String], spec: &CliArgSpec) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(raw.len());
+    let mut iter = raw.iter();
+    while let Some(tok) = iter.next() {
+        // Attached-value forms (`--model=foo`, `--json=true`, `-n=5`):
+        // self-contained tokens — drop or forward whole.
+        if let Some((key, _value)) = tok.split_once('=') {
+            if key.starts_with('-') && spec.bare_query_strip.contains(key) {
+                continue;
+            }
+            out.push(tok.clone());
+            continue;
+        }
+        if spec.bare_query_strip.contains(tok.as_str()) {
+            if spec.value_flags.contains(tok.as_str()) {
+                // Spaced form: drop the flag's value token too.
+                iter.next();
+            }
+            continue;
+        }
+        if tok.starts_with('-') && spec.value_flags.contains(tok.as_str()) {
+            // Forwarded value flag: emit the flag and its value verbatim so
+            // a value that happens to start with `-` isn't re-scanned as a
+            // flag.
+            out.push(tok.clone());
+            if let Some(value) = iter.next() {
+                out.push(value.clone());
+            }
+            continue;
+        }
+        out.push(tok.clone());
+    }
+    out
 }
 
 /// Resolve the daemon socket read/write timeout used on both the CLI client
@@ -920,6 +1018,41 @@ mod tests {
         tokens.iter().map(|s| s.to_string()).collect()
     }
 
+    /// Hand-built spec mirroring the production classification (derived from
+    /// the live clap definition in `cli::dispatch`). Subset is enough for the
+    /// translation-rule tests here; the full derived spec is exercised
+    /// end-to-end by `tests/daemon_forward_test.rs`.
+    fn spec() -> CliArgSpec {
+        let set = |items: &[&str]| {
+            items
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<std::collections::BTreeSet<String>>()
+        };
+        CliArgSpec {
+            value_flags: set(&[
+                "--model",
+                "--slot",
+                "-n",
+                "--limit",
+                "-t",
+                "--threshold",
+                "--tokens",
+                "-l",
+                "--lang",
+            ]),
+            bare_query_strip: set(&[
+                "--json",
+                "-q",
+                "--quiet",
+                "-v",
+                "--verbose",
+                "--model",
+                "--slot",
+            ]),
+        }
+    }
+
     // Env-var-driven timeout helper used by both daemon and CLI sides.
     // Test only the unset path; mutating env vars in a parallel test runner
     // is fragile, and the floor / honor logic is small enough to inspect.
@@ -939,16 +1072,71 @@ mod tests {
 
     #[test]
     fn strips_json_bare_query() {
-        let (cmd, args) = translate_cli_args_to_batch(&v(&["--json", "search me"]), false);
+        let (cmd, args) = translate_cli_args_to_batch(&v(&["--json", "search me"]), false, &spec());
         assert_eq!(cmd, "search");
         assert_eq!(args, v(&["search me"]));
     }
 
+    /// Subcommand args forward verbatim — the batch parser flattens the same
+    /// shared args structs, and `LimitArg` accepts `-n` directly. No remap:
+    /// remapping `-n` → `--limit` is what broke blame, whose `-n` means
+    /// `--commits`.
     #[test]
-    fn remaps_dash_n_spaced() {
-        let (cmd, args) = translate_cli_args_to_batch(&v(&["impact", "foo", "-n", "5"]), true);
+    fn forwards_subcommand_dash_n_verbatim() {
+        let (cmd, args) =
+            translate_cli_args_to_batch(&v(&["impact", "foo", "-n", "5"]), true, &spec());
         assert_eq!(cmd, "impact");
-        assert_eq!(args, v(&["foo", "--limit", "5"]));
+        assert_eq!(args, v(&["foo", "-n", "5"]));
+
+        let (cmd, args) =
+            translate_cli_args_to_batch(&v(&["blame", "foo", "-n", "3"]), true, &spec());
+        assert_eq!(cmd, "blame");
+        assert_eq!(args, v(&["foo", "-n", "3"]));
+    }
+
+    /// Top-level flags before the subcommand are dropped wholesale — they
+    /// configure the CLI process, not the subcommand handler. Boolean flags
+    /// drop one token; value flags drop two.
+    #[test]
+    fn drops_top_level_region_before_subcommand() {
+        let (cmd, args) = translate_cli_args_to_batch(&v(&["-v", "callers", "foo"]), true, &spec());
+        assert_eq!(cmd, "callers");
+        assert_eq!(args, v(&["foo"]));
+
+        let (cmd, args) =
+            translate_cli_args_to_batch(&v(&["--rrf", "callers", "foo"]), true, &spec());
+        assert_eq!(cmd, "callers");
+        assert_eq!(args, v(&["foo"]));
+
+        // Value flag pre-subcommand consumes its value token too — the value
+        // must not be mistaken for the subcommand name.
+        let (cmd, args) =
+            translate_cli_args_to_batch(&v(&["-n", "3", "callers", "foo"]), true, &spec());
+        assert_eq!(cmd, "callers");
+        assert_eq!(args, v(&["foo"]));
+
+        // Attached-value form is one token.
+        let (cmd, args) = translate_cli_args_to_batch(
+            &v(&["--model=bge-large", "callers", "foo"]),
+            true,
+            &spec(),
+        );
+        assert_eq!(cmd, "callers");
+        assert_eq!(args, v(&["foo"]));
+    }
+
+    /// Bare-query search knobs forward verbatim (`-n` included — the batch
+    /// `search` parser accepts it via the shared `LimitArg`); process-local
+    /// flags are stripped, with their value when they take one.
+    #[test]
+    fn bare_query_forwards_search_knobs_strips_process_local() {
+        let (cmd, args) = translate_cli_args_to_batch(
+            &v(&["hello", "--rrf", "-n", "8", "--model", "bge-large", "-v"]),
+            false,
+            &spec(),
+        );
+        assert_eq!(cmd, "search");
+        assert_eq!(args, v(&["hello", "--rrf", "-n", "8"]));
     }
 
     #[test]
@@ -975,14 +1163,15 @@ mod tests {
     /// `--warnings`/`--patterns` flags through unchanged.
     #[test]
     fn notes_list_subcommand_stripped() {
-        let (cmd, args) = translate_cli_args_to_batch(&v(&["notes", "list"]), true);
+        let (cmd, args) = translate_cli_args_to_batch(&v(&["notes", "list"]), true, &spec());
         assert_eq!(cmd, "notes");
         assert!(args.is_empty(), "got {args:?}");
     }
 
     #[test]
     fn notes_list_with_warnings_strips_only_list() {
-        let (cmd, args) = translate_cli_args_to_batch(&v(&["notes", "list", "--warnings"]), true);
+        let (cmd, args) =
+            translate_cli_args_to_batch(&v(&["notes", "list", "--warnings"]), true, &spec());
         assert_eq!(cmd, "notes");
         assert_eq!(args, v(&["--warnings"]));
     }
@@ -990,7 +1179,7 @@ mod tests {
     /// Bare `cqs notes` (no `list` token) is unaffected.
     #[test]
     fn notes_without_list_unchanged() {
-        let (cmd, args) = translate_cli_args_to_batch(&v(&["notes", "--patterns"]), true);
+        let (cmd, args) = translate_cli_args_to_batch(&v(&["notes", "--patterns"]), true, &spec());
         assert_eq!(cmd, "notes");
         assert_eq!(args, v(&["--patterns"]));
     }
@@ -998,7 +1187,7 @@ mod tests {
     /// Other commands with a `list` first-arg are NOT touched — only `notes`.
     #[test]
     fn list_arg_is_only_stripped_for_notes() {
-        let (cmd, args) = translate_cli_args_to_batch(&v(&["impact", "list"]), true);
+        let (cmd, args) = translate_cli_args_to_batch(&v(&["impact", "list"]), true, &spec());
         assert_eq!(cmd, "impact");
         assert_eq!(args, v(&["list"]));
     }

--- a/tests/daemon_forward_test.rs
+++ b/tests/daemon_forward_test.rs
@@ -4,9 +4,10 @@
 //! Two concerns:
 //!
 //! 1. **Pure arg-translation** — `cqs::daemon_translate::translate_cli_args_to_batch`
-//!    is the extracted helper. Black-box tests here pin the stripping and
-//!    `-n` → `--limit` remap so a future edit to the helper doesn't silently
-//!    ship a different wire format to the daemon.
+//!    is the extracted helper. Black-box tests here pin the top-level-region
+//!    stripping and the verbatim forwarding of subcommand args so a future
+//!    edit to the helper doesn't silently ship a different wire format to
+//!    the daemon.
 //!
 //! 2. **Daemon bypass + forwarding** — exercised end-to-end by spawning the
 //!    real `cqs` binary against a mock `UnixListener` bound at the exact
@@ -43,44 +44,101 @@ fn v(tokens: &[&str]) -> Vec<String> {
     tokens.iter().map(|s| s.to_string()).collect()
 }
 
+/// Hand-built [`cqs::daemon_translate::CliArgSpec`] mirroring the production
+/// classification (which `cli::dispatch` derives from the live clap
+/// definition — its derivation is pinned by unit tests in the binary crate
+/// and exercised end-to-end by the socket-mock tests below).
+fn spec() -> cqs::daemon_translate::CliArgSpec {
+    let set = |items: &[&str]| {
+        items
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<std::collections::BTreeSet<String>>()
+    };
+    cqs::daemon_translate::CliArgSpec {
+        value_flags: set(&[
+            "--model",
+            "--slot",
+            "-n",
+            "--limit",
+            "-t",
+            "--threshold",
+            "--tokens",
+            "-l",
+            "--lang",
+        ]),
+        bare_query_strip: set(&[
+            "--json",
+            "-q",
+            "--quiet",
+            "-v",
+            "--verbose",
+            "--model",
+            "--slot",
+        ]),
+    }
+}
+
 #[test]
-fn test_translate_strips_global_json_flag() {
-    // `--json` is a top-level `Cli` flag, not a subcommand flag; the batch
-    // handler always emits JSON. The translator drops it entirely.
-    let (cmd, args) =
-        cqs::daemon_translate::translate_cli_args_to_batch(&v(&["impact", "foo", "--json"]), true);
-    assert_eq!(cmd, "impact");
-    assert!(
-        !args.iter().any(|a| a == "--json"),
-        "--json must be stripped; got {args:?}"
+fn test_translate_strips_top_level_json_flag() {
+    // `--json` before the subcommand is a top-level `Cli` flag: the whole
+    // top-level region is dropped on daemon forwarding.
+    let (cmd, args) = cqs::daemon_translate::translate_cli_args_to_batch(
+        &v(&["--json", "impact", "foo"]),
+        true,
+        &spec(),
     );
+    assert_eq!(cmd, "impact");
+    assert_eq!(args, v(&["foo"]));
 
     // Bare-query form: `cqs --json "hello"` also drops --json.
-    let (cmd, args) =
-        cqs::daemon_translate::translate_cli_args_to_batch(&v(&["--json", "hello"]), false);
+    let (cmd, args) = cqs::daemon_translate::translate_cli_args_to_batch(
+        &v(&["--json", "hello"]),
+        false,
+        &spec(),
+    );
     assert_eq!(cmd, "search");
     assert_eq!(args, v(&["hello"]));
 }
 
 #[test]
-fn test_translate_remaps_n_to_limit() {
-    // Spaced form: `-n 5` → `--limit 5` (two tokens).
-    let (cmd, args) =
-        cqs::daemon_translate::translate_cli_args_to_batch(&v(&["impact", "foo", "-n", "5"]), true);
+fn test_translate_forwards_subcommand_args_verbatim() {
+    // Post-subcommand tokens forward verbatim — the batch parser flattens
+    // the same shared args structs as the CLI, so `-n` keeps its
+    // per-subcommand meaning (`LimitArg` for impact, `--commits` for blame).
+    let (cmd, args) = cqs::daemon_translate::translate_cli_args_to_batch(
+        &v(&["impact", "foo", "-n", "5"]),
+        true,
+        &spec(),
+    );
     assert_eq!(cmd, "impact");
-    assert_eq!(args, v(&["foo", "--limit", "5"]));
+    assert_eq!(args, v(&["foo", "-n", "5"]));
 
-    // Equals form: `-n=5` → `--limit=5` (one token).
-    let (cmd, args) =
-        cqs::daemon_translate::translate_cli_args_to_batch(&v(&["impact", "foo", "-n=5"]), true);
+    // Equals form is one token, forwarded whole.
+    let (cmd, args) = cqs::daemon_translate::translate_cli_args_to_batch(
+        &v(&["impact", "foo", "-n=5"]),
+        true,
+        &spec(),
+    );
     assert_eq!(cmd, "impact");
-    assert_eq!(args, v(&["foo", "--limit=5"]));
+    assert_eq!(args, v(&["foo", "-n=5"]));
 
-    // Already-canonical `--limit` is preserved verbatim (with a remap through
-    // the same branch — no double-insertion).
+    // blame's `-n` means `--commits` — the old `-n` → `--limit` remap made
+    // `cqs blame foo -n 3` a parse error daemon-up. Verbatim forwarding is
+    // the fix.
+    let (cmd, args) = cqs::daemon_translate::translate_cli_args_to_batch(
+        &v(&["blame", "foo", "-n", "3"]),
+        true,
+        &spec(),
+    );
+    assert_eq!(cmd, "blame");
+    assert_eq!(args, v(&["foo", "-n", "3"]));
+
+    // `--limit` long form forwards verbatim too.
     let (cmd, args) = cqs::daemon_translate::translate_cli_args_to_batch(
         &v(&["impact", "foo", "--limit", "7"]),
         true,
+        &spec(),
     );
     assert_eq!(cmd, "impact");
     assert_eq!(args, v(&["foo", "--limit", "7"]));
@@ -91,7 +149,7 @@ fn test_translate_prepends_search_for_bare_query() {
     // `cqs "hello world"` → the caller passes `has_subcommand = false`; the
     // translator synthesises `search` as the subcommand.
     let (cmd, args) =
-        cqs::daemon_translate::translate_cli_args_to_batch(&v(&["hello world"]), false);
+        cqs::daemon_translate::translate_cli_args_to_batch(&v(&["hello world"]), false, &spec());
     assert_eq!(cmd, "search");
     assert_eq!(args, v(&["hello world"]));
 
@@ -100,6 +158,7 @@ fn test_translate_prepends_search_for_bare_query() {
     let (cmd, args) = cqs::daemon_translate::translate_cli_args_to_batch(
         &v(&["alpha", "beta", "--quiet"]),
         false,
+        &spec(),
     );
     assert_eq!(cmd, "search");
     assert_eq!(args, v(&["alpha", "beta"]));
@@ -108,26 +167,63 @@ fn test_translate_prepends_search_for_bare_query() {
 #[test]
 fn test_translate_preserves_subcommand_flags() {
     // With an explicit subcommand, the subcommand name stays first and its
-    // flags (those we don't strip as global) pass through untouched. Here
-    // `--threshold 0.5` is subcommand-scoped for `impact` and must reach
-    // the daemon unchanged; `--json` is global and gets dropped.
+    // flags pass through untouched: `--threshold 0.5` is subcommand-scoped
+    // for `impact` and must reach the daemon unchanged. `--json` after the
+    // subcommand is the subcommand's own flag (the shared output structs
+    // accept it on the batch side too) and also forwards.
     let (cmd, args) = cqs::daemon_translate::translate_cli_args_to_batch(
         &v(&["impact", "foo", "--threshold", "0.5", "--json"]),
         true,
+        &spec(),
     );
     assert_eq!(cmd, "impact");
-    assert_eq!(args, v(&["foo", "--threshold", "0.5"]));
+    assert_eq!(args, v(&["foo", "--threshold", "0.5", "--json"]));
+}
 
-    // Another spot-check: subcommand-level `-n` still gets remapped to
-    // `--limit`, so the batch clap parser sees the canonical long form.
-    // This is the one case where "subcommand flag" is rewritten on purpose
-    // — same flag, canonical name. Not a behaviour change vs. pre-#972.
+#[test]
+fn test_translate_drops_top_level_region_with_subcommand() {
+    // `-v` / `--rrf` before the subcommand are top-level `Cli` flags. The
+    // old hand-mirrored strip list forwarded them into the batch subcommand
+    // parser, hard-erroring daemon-up while working daemon-down.
     let (cmd, args) = cqs::daemon_translate::translate_cli_args_to_batch(
-        &v(&["similar", "bar", "-n", "3"]),
+        &v(&["-v", "callers", "foo"]),
         true,
+        &spec(),
     );
-    assert_eq!(cmd, "similar");
-    assert_eq!(args, v(&["bar", "--limit", "3"]));
+    assert_eq!(cmd, "callers");
+    assert_eq!(args, v(&["foo"]));
+
+    let (cmd, args) = cqs::daemon_translate::translate_cli_args_to_batch(
+        &v(&["--rrf", "callers", "foo"]),
+        true,
+        &spec(),
+    );
+    assert_eq!(cmd, "callers");
+    assert_eq!(args, v(&["foo"]));
+
+    // Top-level value flag consumes its value: the value must not be
+    // mistaken for the subcommand name.
+    let (cmd, args) = cqs::daemon_translate::translate_cli_args_to_batch(
+        &v(&["--model", "bge-large", "callers", "foo"]),
+        true,
+        &spec(),
+    );
+    assert_eq!(cmd, "callers");
+    assert_eq!(args, v(&["foo"]));
+}
+
+#[test]
+fn test_translate_bare_query_forwards_search_knobs() {
+    // Search knobs (`--rrf`, `-n`) forward verbatim to the batch `search`
+    // parser, which accepts them via the shared `SearchArgs`/`LimitArg`;
+    // process-local flags (`--model VAL`, `-v`) are stripped.
+    let (cmd, args) = cqs::daemon_translate::translate_cli_args_to_batch(
+        &v(&["hello", "--rrf", "-n", "8", "--model", "bge-large", "-v"]),
+        false,
+        &spec(),
+    );
+    assert_eq!(cmd, "search");
+    assert_eq!(args, v(&["hello", "--rrf", "-n", "8"]));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -156,6 +252,7 @@ fn test_translate_preserves_subcommand_flags() {
 /// the fixture signals the thread to exit and removes the socket file.
 struct MockDaemon {
     conn_count: Arc<AtomicUsize>,
+    last_request: Arc<std::sync::Mutex<String>>,
     stop: Arc<AtomicBool>,
     sock_path: PathBuf,
     handle: Option<JoinHandle<()>>,
@@ -182,8 +279,10 @@ impl MockDaemon {
             .expect("set_nonblocking on mock listener");
 
         let conn_count = Arc::new(AtomicUsize::new(0));
+        let last_request = Arc::new(std::sync::Mutex::new(String::new()));
         let stop = Arc::new(AtomicBool::new(false));
         let c2 = Arc::clone(&conn_count);
+        let r2 = Arc::clone(&last_request);
         let s2 = Arc::clone(&stop);
 
         let handle = std::thread::spawn(move || {
@@ -192,10 +291,13 @@ impl MockDaemon {
                 match listener.accept() {
                     Ok((mut stream, _addr)) => {
                         c2.fetch_add(1, Ordering::SeqCst);
-                        // Drain the request line. We don't care what the CLI
-                        // sent — any valid frame is treated as a ping.
+                        // Drain the request line and record it so tests can
+                        // assert on the translated wire frame.
                         let mut buf = String::new();
                         let _ = BufReader::new(&stream).read_line(&mut buf);
+                        if let Ok(mut g) = r2.lock() {
+                            *g = buf.clone();
+                        }
                         // Reply with the sentinel output frame. The CLI side
                         // will `print!("{output}")` for status=ok and exit 0.
                         let _ = writeln!(stream, "{response}");
@@ -211,6 +313,7 @@ impl MockDaemon {
 
         Self {
             conn_count,
+            last_request,
             stop,
             sock_path,
             handle: Some(handle),
@@ -219,6 +322,13 @@ impl MockDaemon {
 
     fn conn_count(&self) -> usize {
         self.conn_count.load(Ordering::SeqCst)
+    }
+
+    fn last_request(&self) -> String {
+        self.last_request
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default()
     }
 }
 
@@ -370,6 +480,133 @@ fn test_mock_socket_round_trip_for_daemon_command() {
     assert!(
         stdout.contains("DAEMON_MOCK_SENTINEL"),
         "daemon sentinel missing from stdout; stdout=<{stdout}> stderr=<{stderr}>"
+    );
+}
+
+/// Spawn the binary with `args` against a `MockDaemon`, assert it exited 0
+/// and reached the socket exactly once, and return the parsed request frame
+/// `{"command": ..., "args": [...]}` the CLI sent. Shared by the
+/// arg-translation parity tests below — they pin the *production* derived
+/// `CliArgSpec`, not the hand-built one the pure tests use.
+fn forwarded_request(cli_args: &[&str]) -> serde_json::Value {
+    let (dir, sock_path) = setup_project();
+    let mock = MockDaemon::new(sock_path.clone(), "DAEMON_MOCK_SENTINEL");
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+    let mut cmd = cqs();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(cli_args);
+
+    let output = cmd.output().expect("cqs spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "`cqs {cli_args:?}` failed daemon-up; stdout=<{stdout}> stderr=<{stderr}>"
+    );
+    assert_eq!(
+        mock.conn_count(),
+        1,
+        "expected exactly one daemon connection for {cli_args:?}; stdout=<{stdout}> stderr=<{stderr}>"
+    );
+    let req = mock.last_request();
+    serde_json::from_str(req.trim())
+        .unwrap_or_else(|e| panic!("request frame is not JSON: {req} ({e})"))
+}
+
+#[test]
+fn test_blame_dash_n_forwards_as_commits_flag() {
+    // blame's `-n` means `--commits`, not `--limit`. The old translation
+    // remapped every `-n` to `--limit`, so `cqs blame foo -n 3` returned a
+    // parse_error envelope daemon-up while working daemon-down. The frame
+    // must carry `-n 3` verbatim for the batch BlameArgs parser.
+    let req = forwarded_request(&["blame", "foo", "-n", "3"]);
+    assert_eq!(req["command"], "blame");
+    assert_eq!(
+        req["args"],
+        serde_json::json!(["foo", "-n", "3"]),
+        "blame args must forward verbatim, got: {req}"
+    );
+}
+
+#[test]
+fn test_top_level_verbose_flag_is_stripped_on_forward() {
+    // `cqs -v callers foo`: `-v` is a top-level Cli flag the old
+    // hand-mirrored strip list didn't know, so it leaked into the batch
+    // `callers` parser and hard-errored daemon-up.
+    let req = forwarded_request(&["-v", "callers", "foo"]);
+    assert_eq!(req["command"], "callers");
+    assert_eq!(
+        req["args"],
+        serde_json::json!(["foo"]),
+        "top-level -v must be stripped, got: {req}"
+    );
+}
+
+#[test]
+fn test_top_level_rrf_flag_is_stripped_on_forward() {
+    // `cqs --rrf callers foo`: same drift class as `-v`.
+    let req = forwarded_request(&["--rrf", "callers", "foo"]);
+    assert_eq!(req["command"], "callers");
+    assert_eq!(
+        req["args"],
+        serde_json::json!(["foo"]),
+        "top-level --rrf must be stripped, got: {req}"
+    );
+}
+
+#[test]
+fn test_bare_query_forwards_search_knobs_to_daemon() {
+    // Bare-query search knobs forward to the batch `search` parser; the
+    // process-local `--json` is dropped.
+    let req = forwarded_request(&["--json", "find the thing", "--rrf", "-n", "8"]);
+    assert_eq!(req["command"], "search");
+    assert_eq!(
+        req["args"],
+        serde_json::json!(["find the thing", "--rrf", "-n", "8"]),
+        "search knobs must forward verbatim, got: {req}"
+    );
+}
+
+#[test]
+fn test_cqs_slot_env_bypasses_daemon() {
+    // `CQS_SLOT` is documented as equivalent to `--slot` and honored by
+    // `slot::resolve_slot_name`. The daemon serves whichever slot was active
+    // at *its* startup, so a slot-pinned invocation must bypass the daemon —
+    // same rationale as the `--slot` flag gate. Before the fix,
+    // `CQS_SLOT=experiment cqs <query>` silently returned the daemon's
+    // startup-slot results.
+    let (dir, sock_path) = setup_project();
+    let mock = MockDaemon::new(sock_path.clone(), "DAEMON_SHOULD_NOT_RESPOND");
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+    let mut cmd = cqs();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .env("CQS_SLOT", "experiment")
+        .current_dir(&canonical_dir)
+        .args(["notes", "list", "--json"]);
+
+    // The CLI fallback may fail (no index in the temp project) — the pin is
+    // purely that the daemon socket was never touched and the mock's reply
+    // never reached stdout.
+    let output = cmd.output().expect("cqs notes list spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        mock.conn_count(),
+        0,
+        "CQS_SLOT must bypass the daemon (slot-pinned queries can't be served by the \
+         daemon's startup slot); mock saw {} connection(s). stdout=<{stdout}> stderr=<{stderr}>",
+        mock.conn_count()
+    );
+    assert!(
+        !stdout.contains("DAEMON_SHOULD_NOT_RESPOND"),
+        "mock response leaked into stdout despite CQS_SLOT: {stdout}"
     );
 }
 

--- a/tests/daemon_forward_test.rs
+++ b/tests/daemon_forward_test.rs
@@ -610,6 +610,46 @@ fn test_cqs_slot_env_bypasses_daemon() {
     );
 }
 
+#[test]
+fn test_empty_cqs_slot_env_keeps_daemon_path() {
+    // `slot::resolve_slot_name` trims `CQS_SLOT` and treats empty/whitespace
+    // as UNSET, so the daemon gate must too: `CQS_SLOT= cqs …` (a script
+    // clearing the var) pins no slot and must keep the daemon fast path. A
+    // bare `is_some()` env check would silently lose it.
+    let (dir, sock_path) = setup_project();
+    let mock = MockDaemon::new(sock_path.clone(), "DAEMON_MOCK_SENTINEL");
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+
+    for (case, slot_value) in [("empty", ""), ("whitespace", "   ")] {
+        let mut cmd = cqs();
+        clean_cqs_env(&mut cmd);
+        cmd.env("XDG_RUNTIME_DIR", dir.path())
+            .env("CQS_SLOT", slot_value)
+            .current_dir(&canonical_dir)
+            .args(["notes", "list", "--json"]);
+
+        let output = cmd.output().expect("cqs notes list spawn");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "`cqs notes list` ({case} CQS_SLOT) failed; stdout=<{stdout}> stderr=<{stderr}>"
+        );
+        assert!(
+            stdout.contains("DAEMON_MOCK_SENTINEL"),
+            "{case} CQS_SLOT pins no slot and must take the daemon path; \
+             stdout=<{stdout}> stderr=<{stderr}>"
+        );
+    }
+    assert_eq!(
+        mock.conn_count(),
+        2,
+        "both unset-equivalent CQS_SLOT values must reach the daemon"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Task B2: `cqs ping` against a mock listener.
 //


### PR DESCRIPTION
## Audit v1.42.0 — daemon-surface parity cluster (P1)

Closes API-V1.42-1, EXT-V1.42-1/2, EH-V1.42-2, OB-V1.42-2, SHL-V1.42-1 from `docs/audit-triage.md`. Theme: the same `cqs` invocation must behave identically daemon-up and daemon-down.

- **Clap-derived arg translation (API-V1.42-1 + EXT-V1.42-1):** `translate_cli_args_to_batch` no longer hand-mirrors 5 of ~25 top-level flags — a `CliArgSpec` is derived from `Cli::command()` at the dispatch boundary. Subcommand invocations forward their tail **verbatim** (the `-n`→`--limit` remap is gone entirely: both surfaces flatten the same shared arg structs, so `cqs blame foo -n 3`, `cqs -v callers X`, and `cqs --rrf callers X` — all previously hard-erroring daemon-up, verified live — now work identically in both modes).
- **Exhaustiveness test (EXT-V1.42-2):** the derive emits `daemon_capable_variant_names()`; a new test asserts every daemon-marked `Commands` variant has a matching `BatchCmd` subcommand. **It immediately caught a live bug beyond the audit: `Commands::Affected` was daemon-marked with no `BatchCmd::Affected` — `cqs affected` errored daemon-up.** Reclassified `batch = "cli"` (matches `affected_core`'s own CLI-only doc) with a comment describing the proper flip-back. Related latent hole noted for a follow-up issue: `review`/`ci` are daemon-marked but silently ignore `--stdin` daemon-up.
- **`CQS_SLOT` daemon bypass (EH-V1.42-2):** the forward gate now bypasses when `CQS_SLOT` is set, matching the documented `--slot` equivalence — no more silent wrong-slot results.
- **Loud transport fallback (OB-V1.42-2):** connect/write/flush/read/parse/missing-status fallbacks promoted `debug!`→`warn!` with a `systemctl --user status cqs-watch` hint (visible under the default `cqs=info` filter, which was the gap); socket-absent stays silent.
- **Shared limit cap (SHL-V1.42-1):** single `SEARCH_LIMIT_CAP = 100` in `cli::limits` read by both surfaces; `DAEMON_LIMIT_CAP` and its false "the CLI has no such clamp" comment deleted; test pins reference the constant.

Tests: daemon_translate 41, dispatch/exhaustiveness/clamp pins, batch::commands 27, handlers::search 9, daemon_forward integration 22 (5 new end-to-end: blame `-n` verbatim, `-v`/`--rrf` stripping, bare-query knob forwarding, `CQS_SLOT` bypass). fmt + clippy (`--lib --bins -D warnings`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
