### PR TITLE
fix(notes): write-side size cap, mentions caps, whitespace/duplicate rejection

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -4,7 +4,7 @@ Audit date: 2026-06-10
 Main HEAD: 7284e31e
 Source: `docs/audit-findings.md` (107 findings — batch 1: 59 across 8 categories; batch 2: 48 across the other 8, run after batch-1 triage)
 Calibration: matches `docs/audit-triage-v1.40.0.md` priority matrix.
-Status: **P1 tier COMPLETE (2026-06-11)** — all 28 P1s fixed across 9 cluster PRs (#1738-#1746) plus 4 riders (DS-V1.42-6, EXT-V1.42-1, DOC-V1.42-4, RB-V1.42-4). 125 items remain open (P2/P3/P4/CF tiers).
+Status: **P1 tier COMPLETE (2026-06-11)** — all 28 P1s fixed across 9 cluster PRs (#1738-#1746) plus 4 riders (DS-V1.42-6, EXT-V1.42-1, DOC-V1.42-4, RB-V1.42-4). 123 items remain open (P2/P3/P4/CF tiers; notes-hardening TC-V1.42-1/2 closed in #1748).
 
 Fix-run review notes for the next cycle: combined-short bools (`-qv`) leak on the bare-query daemon path (pre-existing, found in #1746's review); `review`/`ci` are daemon-marked but silently ignore `--stdin` daemon-up (found by the new exhaustiveness test); remaining `clamp(1, 100)` literals on non-search commands fold into CF SHL-V1.40-2.
 
@@ -68,7 +68,7 @@ New v1.42 findings: 107 (batch 1: 59 = 15/11/26/7; batch 2: 48 = 13/19/14/2). Ca
 | RB-V1.42-1 | collect_comment_ranges / find_type_identifier_recursive recurse per tree-depth — stack overflow (SIGSEGV) on rayon workers aborts index/watch | src/parser/chunk.rs:126, :756 | open |
 | API-V1.42-3 | callers vs callees output topology asymmetry; module doc's type-discrimination claim false for callees | src/cli/commands/graph/callers.rs:74-90 | open |
 | API-V1.42-8 | Args-layer contract drift in campaign code: borrowed non-Deserialize AuditModeArgs, two no-Args conventions, adapter-only flag in core Args | infra/audit_mode.rs:38 + slot.rs/reference.rs/cache_cmd.rs + index/stale.rs:76-82 | open |
-| TC-V1.42-1 | notes add --mentions can write notes.toml past 10 MiB cap → bricks all notes ops; note.rs:30-33 doc overpromises write-side enforcement | src/cli/commands/io/notes.rs:306-311, src/note.rs:307-320 | open |
+| TC-V1.42-1 | notes add --mentions can write notes.toml past 10 MiB cap → bricks all notes ops; note.rs:30-33 doc overpromises write-side enforcement | src/cli/commands/io/notes.rs:306-311, src/note.rs:307-320 | ✅ PR #1748 |
 | TC-V1.42-8 | CAGRA accepts non-finite queries + zero/NaN build vectors HNSW guards — backend asymmetry (CPU-side prepare_index_data filter is the easy half; GPU-gated verification is P4-grade) | src/cagra.rs:424, src/hnsw/mod.rs:583-602 | open |
 | CQ-V1.42-1 | Config ef_search silently ignored on every direct-CLI search path — wrapper hardcodes None; knob only works via batch/daemon | src/cli/store.rs:397-402 | open |
 | CQ-V1.42-8 | prune_gitignored never cleans function_calls — orphan call-graph rows (ghost callers) until next prune_all; 3 prune fns already diverged | src/store/chunks/staleness.rs:266, :389, :532 | open |
@@ -107,7 +107,7 @@ New v1.42 findings: 107 (batch 1: 59 = 15/11/26/7; batch 2: 48 = 13/19/14/2). Ca
 | API-V1.42-5 | serde(default) coverage inconsistent — graph cores reject minimal wire payloads io/search cores accept | src/cli/commands/graph/callers.rs:33-39 | open |
 | API-V1.42-6 | --expand alias: bool on search, value-taking depth on gather | src/cli/args.rs:189 vs :234 | open |
 | API-V1.42-7 | drift's hand-rolled --limit accepts 0 and defaults unlimited — contradicts LimitArg contract | src/cli/args.rs:581-583 | open |
-| TC-V1.42-2 | Whitespace-only note = cross-note wildcard for update/remove; duplicate-text semantics unpinned | src/cli/commands/io/notes.rs:298-572 | open |
+| TC-V1.42-2 | Whitespace-only note = cross-note wildcard for update/remove; duplicate-text semantics unpinned | src/cli/commands/io/notes.rs:298-572 | ✅ PR #1748 |
 | TC-V1.42-3 | cmd_batch stdin line-cap rejection path (CQS_BATCH_MAX_LINE_LEN) zero tests (daemon analog is pinned) | src/cli/batch/session.rs:155-173 | open |
 | TC-V1.42-5 | parse_nonzero_usize untested while f32 siblings exhaustively pinned in same file | src/cli/definitions.rs:94-100 | open |
 | TC-V1.42-9 | HNSW zero-vector skip / id_map desync — documented past bug class, no regression test | src/hnsw/build.rs:200-222 | open |

--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -1891,3 +1891,11 @@ mentions = [
 sentiment = 0.0
 text = "Audit categories exhaust after 13+ cycles: Scaling found 1 finding, Robustness unwrap/panic sweeps came back clean — new findings concentrate in the newest code (v28 canonical_hash parser paths, campaign adapter seams). Future audits could weight scope toward recent diffs over full-codebase sweeps."
 mentions = ["audit"]
+
+[[note]]
+sentiment = -0.5
+text = "Parallel agents sharing CARGO_TARGET_DIR race: same-hash test binaries clobber each other and a test run can silently execute 0 matching tests from a stale binary. Give each parallel agent a private CARGO_TARGET_DIR (e.g. /tmp/cqs-target-<id>) when test results must be trustworthy"
+mentions = [
+    "agents",
+    "cargo",
+]

--- a/src/cli/commands/io/notes.rs
+++ b/src/cli/commands/io/notes.rs
@@ -5,7 +5,10 @@
 use anyhow::{bail, Context, Result};
 use std::path::PathBuf;
 
-use cqs::{parse_notes, rewrite_notes_file, NoteEntry, NOTES_HEADER};
+use cqs::{
+    parse_notes, rewrite_notes_file, NoteEntry, MAX_NOTE_MENTIONS, MAX_NOTE_MENTION_BYTES,
+    MAX_NOTE_TEXT_BYTES, NOTES_HEADER,
+};
 
 use crate::cli::definitions::TextJsonArgs;
 use crate::cli::{find_project_root, Cli};
@@ -239,6 +242,62 @@ fn open_rw_store(root: &std::path::Path) -> Result<cqs::Store> {
         .map_err(|e| anyhow::anyhow!("Failed to open index at {}: {}", index_path.display(), e))
 }
 
+/// Validate a note text payload: trim, reject empty/whitespace-only,
+/// enforce the byte cap. Returns the trimmed text — the trimmed form is
+/// what gets stored, so the exact-match lookups in update/remove (which
+/// also trim both sides) stay symmetric. Rejecting whitespace-only text
+/// here matters beyond hygiene: a stored whitespace-only note would trim
+/// to "" and match ANY whitespace-only query in update/remove — a
+/// cross-note wildcard.
+///
+/// `what` names the offending argument in the error ("Note text",
+/// "--new-text").
+fn validate_note_text<'a>(raw: &'a str, what: &str) -> Result<&'a str> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        bail!("{what} cannot be empty or whitespace-only");
+    }
+    if trimmed.len() > MAX_NOTE_TEXT_BYTES {
+        bail!(
+            "{what} too long: {} bytes (max {})",
+            trimmed.len(),
+            MAX_NOTE_TEXT_BYTES
+        );
+    }
+    Ok(trimmed)
+}
+
+/// Validate a mentions list: trim entries, drop empties, enforce the count
+/// and per-mention byte caps. Without these caps a single `--mentions`
+/// payload could push docs/notes.toml past the file-size limit in one shot.
+/// (The serialized-output check in `rewrite_notes_file` is the backstop;
+/// this gives a precise error before any file I/O.) `flag` names the
+/// offending argument in the error.
+fn validate_mentions(raw: &[String], flag: &str) -> Result<Vec<String>> {
+    let mentions: Vec<String> = raw
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect();
+    if mentions.len() > MAX_NOTE_MENTIONS {
+        bail!(
+            "{flag}: {} mentions exceeds the per-note limit of {}",
+            mentions.len(),
+            MAX_NOTE_MENTIONS
+        );
+    }
+    if let Some(long) = mentions.iter().find(|m| m.len() > MAX_NOTE_MENTION_BYTES) {
+        bail!(
+            "{flag}: mention '{}' is {} bytes (max {} per mention)",
+            text_preview(long),
+            long.len(),
+            MAX_NOTE_MENTION_BYTES
+        );
+    }
+    Ok(mentions)
+}
+
 /// Build a text preview (first 100 chars or full text).
 fn text_preview(text: &str) -> String {
     text.char_indices()
@@ -266,7 +325,10 @@ fn ensure_notes_file(root: &std::path::Path) -> Result<PathBuf> {
     Ok(notes_path)
 }
 
-/// Add a note: validate text/sentiment, append to notes.toml, optionally reindex.
+/// Add a note: validate text/sentiment/mentions, append to notes.toml,
+/// optionally reindex. Text is stored trimmed; whitespace-only text,
+/// over-cap text/mentions, and exact (post-trim) duplicates of an existing
+/// note are rejected.
 ///
 /// `output_json` accepts the subcommand-level `--json`; combined with
 /// `cli.json` to honour the top-level flag too. 8 args is on clippy's
@@ -295,20 +357,10 @@ fn cmd_notes_add(
         no_reindex
     )
     .entered();
-    if text.is_empty() {
-        bail!("Note text cannot be empty");
-    }
-    if text.len() > 2000 {
-        bail!("Note text too long: {} bytes (max 2000)", text.len());
-    }
+    let text = validate_note_text(text, "Note text")?;
 
     let sentiment = sentiment.clamp(-1.0, 1.0);
-    let mentions: Vec<String> = mentions
-        .unwrap_or(&[])
-        .iter()
-        .filter(|s| !s.is_empty())
-        .cloned()
-        .collect();
+    let mentions = validate_mentions(mentions.unwrap_or(&[]), "--mentions")?;
     // Normalize kind (trim + lowercase + reject empty). Mirrors the
     // parser's `normalize_kind` semantics so add and parse stay in sync —
     // `--kind ""` is silently absent, not stored as Some("").
@@ -331,7 +383,19 @@ fn cmd_notes_add(
     let root = resolve_root(ctx);
     let notes_path = ensure_notes_file(&root)?;
 
+    // Duplicate check lives inside the rewrite closure so it runs under the
+    // same exclusive lock as the append — no read-then-write race with a
+    // concurrent add. Notes carry search-ranking sentiment, and update/remove
+    // mutate only the first text match, so a duplicate would survive a
+    // "remove" and keep skewing rankings; reject it outright.
     rewrite_notes_file(&notes_path, |entries| {
+        if entries.iter().any(|e| e.text.trim() == text) {
+            return Err(cqs::NoteError::Duplicate(format!(
+                "a note with this text already exists in docs/notes.toml: '{}' \
+                 (use 'cqs notes update' or 'cqs notes remove' instead)",
+                text_preview(text)
+            )));
+        }
         entries.push(note_entry.clone());
         Ok(())
     })
@@ -393,6 +457,11 @@ fn cmd_notes_add(
 
 /// Update a note: match by text, apply new text/sentiment/mentions/kind, optionally reindex.
 ///
+/// Matching is by exact trimmed text and applies to the FIRST match in file
+/// order. The CLI rejects duplicate adds, but a hand-edited notes.toml can
+/// still contain duplicates — in that case only the first entry is updated;
+/// rerun the command to reach the next one.
+///
 /// 9 args, including `output_json`. Bundling into a struct would be
 /// more shape than the call site warrants — the dispatcher at `cmd_notes`
 /// already destructures the same fields, and a helper struct just round-
@@ -419,8 +488,11 @@ fn cmd_notes_update(
         no_reindex
     )
     .entered();
-    if text.is_empty() {
-        bail!("Note text cannot be empty");
+    // Trimmed-empty rejection (not just `is_empty`): a whitespace-only query
+    // would trim to "" and match any whitespace-only entry a hand-edited
+    // file might contain.
+    if text.trim().is_empty() {
+        bail!("Note text cannot be empty or whitespace-only");
     }
     if new_text.is_none() && new_sentiment.is_none() && new_mentions.is_none() && new_kind.is_none()
     {
@@ -429,14 +501,9 @@ fn cmd_notes_update(
              must be provided"
         );
     }
-    if let Some(t) = new_text {
-        if t.is_empty() {
-            bail!("--new-text cannot be empty");
-        }
-        if t.len() > 2000 {
-            bail!("--new-text too long: {} bytes (max 2000)", t.len());
-        }
-    }
+    let new_text = new_text
+        .map(|t| validate_note_text(t, "--new-text"))
+        .transpose()?;
 
     let root = resolve_root(ctx);
     let notes_path = root.join("docs/notes.toml");
@@ -447,12 +514,9 @@ fn cmd_notes_update(
     let text_trimmed = text.trim();
     let new_text_owned = new_text.map(|s| s.to_string());
     let new_sentiment_clamped = new_sentiment.map(|s| s.clamp(-1.0, 1.0));
-    let new_mentions_owned = new_mentions.map(|m| {
-        m.iter()
-            .filter(|s| !s.is_empty())
-            .cloned()
-            .collect::<Vec<_>>()
-    });
+    let new_mentions_owned = new_mentions
+        .map(|m| validate_mentions(m, "--new-mentions"))
+        .transpose()?;
     // Apply the same normalization `notes add --kind` uses: trim,
     // lowercase, empty → None. `Some(None)` means "the user passed
     // `--new-kind` with an empty/whitespace value, intending to
@@ -534,6 +598,10 @@ fn cmd_notes_update(
 }
 
 /// Remove a note by matching its text content, optionally reindex after.
+///
+/// Matching is by exact trimmed text and removes the FIRST match in file
+/// order — see `cmd_notes_update` for the duplicate-entry caveat with
+/// hand-edited files.
 fn cmd_notes_remove(
     cli: &Cli,
     ctx: Option<&crate::cli::CommandContext<'_, cqs::store::ReadOnly>>,
@@ -544,8 +612,10 @@ fn cmd_notes_remove(
     // Per-subhandler span — see `cmd_notes_add`.
     let _span =
         tracing::info_span!("cmd_notes_remove", text_len = text.len(), no_reindex).entered();
-    if text.is_empty() {
-        bail!("Note text cannot be empty");
+    // Trimmed-empty rejection — see `cmd_notes_update` for the
+    // whitespace-only wildcard rationale.
+    if text.trim().is_empty() {
+        bail!("Note text cannot be empty or whitespace-only");
     }
 
     let root = resolve_root(ctx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ pub use hnsw::HnswIndex;
 pub use index::{DistanceMetric, IndexResult, VectorIndex};
 pub use note::{
     parse_notes, path_matches_mention, rewrite_notes_file, NoteEntry, NoteError, NoteFile,
-    NOTES_HEADER,
+    MAX_NOTE_MENTIONS, MAX_NOTE_MENTION_BYTES, MAX_NOTE_TEXT_BYTES, NOTES_HEADER,
 };
 pub use parser::{canonical_hash_fallback, collapse_whitespace, Chunk, Parser};
 // `LlmReranker` is a scaffold-only stub (every score call returns Err), so

--- a/src/note.rs
+++ b/src/note.rs
@@ -27,10 +27,30 @@ const _: () = assert!(SENTIMENT_POSITIVE_THRESHOLD > 0.0 && SENTIMENT_POSITIVE_T
 /// Env override `CQS_NOTES_MAX_ENTRIES`.
 const MAX_NOTES_DEFAULT: usize = 10_000;
 
-/// Maximum size of `notes.toml` (in bytes) before reads/writes refuse to load
-/// the file. Both the read-only `parse_notes` path and the read-modify-write
-/// `rewrite_notes_file` path enforce the same cap so a truncated/corrupt
-/// rewrite can't exceed it either. Env override `CQS_NOTES_MAX_FILE_SIZE`.
+/// Maximum byte length of a note's `text` accepted by the CLI mutation
+/// surface (`cqs notes add`, `--new-text`). Hand-edited files may exceed
+/// this; the parser tolerates it, but the size cap below still bounds the
+/// whole file.
+pub const MAX_NOTE_TEXT_BYTES: usize = 2000;
+
+/// Maximum number of mentions a single note may carry through the CLI
+/// (`--mentions`, `--new-mentions`). Mentions are file paths or short
+/// concept names; 50 is far beyond any legitimate note while keeping the
+/// worst-case per-note payload (50 × 256 B) in the same order as the text
+/// cap.
+pub const MAX_NOTE_MENTIONS: usize = 50;
+
+/// Maximum byte length of a single mention through the CLI. 256 bytes
+/// covers deep repository paths with margin.
+pub const MAX_NOTE_MENTION_BYTES: usize = 256;
+
+/// Maximum size of `notes.toml` (in bytes) before reads/writes refuse the
+/// file. `parse_notes` checks the on-disk size before reading;
+/// `rewrite_notes_file` checks both the existing file before parsing AND the
+/// serialized output before writing, so a mutation can never produce an
+/// over-cap file — when the output would exceed the cap, the rewrite errors
+/// and the existing file is left unchanged. Env override
+/// `CQS_NOTES_MAX_FILE_SIZE`.
 const MAX_NOTES_FILE_SIZE_DEFAULT: u64 = 10 * 1024 * 1024;
 
 /// Resolve `CQS_NOTES_MAX_FILE_SIZE` (default 10 MiB).
@@ -66,6 +86,9 @@ pub enum NoteError {
     /// Note not found
     #[error("Note not found: {0}")]
     NotFound(String),
+    /// A note with the same (trimmed) text already exists
+    #[error("Duplicate note: {0}")]
+    Duplicate(String),
 }
 
 /// Raw note entry from TOML (round-trippable via serde)
@@ -372,6 +395,27 @@ pub fn rewrite_notes_file(
     } else {
         raw_output
     };
+
+    // Size guard on the OUTPUT, not just the input: the pre-parse metadata
+    // check above only protects against an already-oversized file. Without
+    // this check, a single mutation (e.g. an add with a huge payload) could
+    // write past the cap, after which every subsequent parse and rewrite
+    // refuses the file — bricking notes until a manual edit. Checked before
+    // the tmp write so a rejected mutation leaves the existing file
+    // untouched.
+    if output.len() as u64 > max_size {
+        return Err(NoteError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "{}: rewrite would produce a {} byte file, over the {} byte limit \
+                 (CQS_NOTES_MAX_FILE_SIZE); existing file left unchanged",
+                notes_path.display(),
+                output.len(),
+                max_size
+            ),
+        )));
+    }
+
     let write_result: Result<(), NoteError> = (|| {
         std::fs::write(&tmp_path, &output).map_err(|e| {
             NoteError::Io(std::io::Error::new(
@@ -760,6 +804,62 @@ text = "first note"
             "LF-only file should stay LF-only: {:?}",
             String::from_utf8_lossy(&bytes)
         );
+    }
+
+    /// The write side enforces the size cap on the serialized output: a
+    /// mutation that would push notes.toml over the limit is rejected with
+    /// `InvalidData`, the existing file is left byte-for-byte unchanged, and
+    /// a follow-up normal mutation still succeeds (the file is never
+    /// bricked by a rejected oversized write).
+    #[test]
+    fn test_rewrite_rejects_oversized_output_and_leaves_file_usable() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notes.toml");
+        std::fs::write(&path, "[[note]]\ntext = \"small\"\n").unwrap();
+        let before = std::fs::read(&path).unwrap();
+
+        // 11 MB of text serializes past the 10 MiB default cap.
+        let big_text = "x".repeat(11 * 1024 * 1024);
+        let result = rewrite_notes_file(&path, |entries| {
+            entries.push(NoteEntry {
+                sentiment: 0.0,
+                text: big_text.clone(),
+                mentions: vec![],
+                kind: None,
+            });
+            Ok(())
+        });
+        match result {
+            Err(NoteError::Io(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::InvalidData);
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("limit") && msg.contains("notes.toml"),
+                    "error should name the file and the limit, got: {msg}"
+                );
+            }
+            other => panic!("expected Io(InvalidData), got: {other:?}"),
+        }
+
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "rejected oversized rewrite must leave the existing file unchanged"
+        );
+
+        // The file is still usable: a normal-sized mutation succeeds.
+        rewrite_notes_file(&path, |entries| {
+            entries.push(NoteEntry {
+                sentiment: 0.0,
+                text: "second".into(),
+                mentions: vec![],
+                kind: None,
+            });
+            Ok(())
+        })
+        .expect("notes file must remain usable after a rejected oversized rewrite");
+        let notes = parse_notes(&path).unwrap();
+        assert_eq!(notes.len(), 2);
     }
 
     #[test]

--- a/tests/cli_notes_test.rs
+++ b/tests/cli_notes_test.rs
@@ -473,6 +473,239 @@ fn test_notes_add_rejects_nan_sentiment() {
     );
 }
 
+/// Whitespace-only text must be rejected at the validator boundary. Before
+/// the trim-first guard, `"   "` passed `is_empty()` and the stored note's
+/// trimmed text was `""` — matching ANY whitespace-only string in later
+/// update/remove calls (a cross-note wildcard).
+#[test]
+#[serial]
+fn test_notes_add_rejects_whitespace_only_text() {
+    let dir = setup_notes_project();
+    cqs()
+        .args(["notes", "add", "   ", "--sentiment", "0", "--no-reindex"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("whitespace-only"));
+    assert!(
+        !notes_path(&dir).exists(),
+        "Whitespace-only add must not create notes.toml"
+    );
+}
+
+/// Exact-duplicate (post-trim) adds are rejected: notes carry search-ranking
+/// sentiment and update/remove mutate only the first text match, so a stale
+/// duplicate would survive a "remove" and keep skewing rankings.
+#[test]
+#[serial]
+fn test_notes_add_rejects_duplicate() {
+    let dir = setup_notes_project();
+    notes_add_json(&dir, "dup note", "0", None);
+
+    cqs()
+        .args(["notes", "add", "dup note", "--no-reindex"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"));
+    assert_eq!(read_notes(&dir).len(), 1, "duplicate must not be appended");
+
+    // Whitespace-padded variant is the same note post-trim — also rejected.
+    cqs()
+        .args(["notes", "add", "  dup note  ", "--no-reindex"])
+        .current_dir(dir.path())
+        .assert()
+        .failure();
+    assert_eq!(read_notes(&dir).len(), 1);
+
+    // A genuinely different text still goes through.
+    cqs()
+        .args(["notes", "add", "dup note v2", "--no-reindex"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    assert_eq!(read_notes(&dir).len(), 2);
+}
+
+/// Text byte-cap boundary: exactly at the limit is accepted, one byte over
+/// is rejected (and leaves the file untouched).
+#[test]
+#[serial]
+fn test_notes_add_text_length_boundary() {
+    let dir = setup_notes_project();
+
+    let exact = "x".repeat(cqs::MAX_NOTE_TEXT_BYTES);
+    cqs()
+        .args(["notes", "add", &exact, "--no-reindex"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    assert_eq!(read_notes(&dir).len(), 1, "at-limit text must be accepted");
+
+    let over = "y".repeat(cqs::MAX_NOTE_TEXT_BYTES + 1);
+    cqs()
+        .args(["notes", "add", &over, "--no-reindex"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("too long"));
+    assert_eq!(
+        read_notes(&dir).len(),
+        1,
+        "over-limit text must be rejected"
+    );
+}
+
+/// `--mentions` count cap: 50 mentions is accepted, 51 is rejected before
+/// any file I/O.
+#[test]
+#[serial]
+fn test_notes_add_mentions_count_boundary() {
+    let dir = setup_notes_project();
+
+    let over: String = (0..=cqs::MAX_NOTE_MENTIONS)
+        .map(|i| format!("file{i}.rs"))
+        .collect::<Vec<_>>()
+        .join(",");
+    cqs()
+        .args([
+            "notes",
+            "add",
+            "too many mentions",
+            "--mentions",
+            &over,
+            "--no-reindex",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("limit"));
+    assert!(
+        !notes_path(&dir).exists(),
+        "Rejected --mentions must not create notes.toml"
+    );
+
+    let at_limit: String = (0..cqs::MAX_NOTE_MENTIONS)
+        .map(|i| format!("file{i}.rs"))
+        .collect::<Vec<_>>()
+        .join(",");
+    cqs()
+        .args([
+            "notes",
+            "add",
+            "at-limit mentions",
+            "--mentions",
+            &at_limit,
+            "--no-reindex",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let notes = read_notes(&dir);
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0].mentions.len(), cqs::MAX_NOTE_MENTIONS);
+}
+
+/// Per-mention byte cap: a single oversized mention is rejected with an
+/// error naming the limit.
+#[test]
+#[serial]
+fn test_notes_add_rejects_oversized_mention() {
+    let dir = setup_notes_project();
+    let huge_mention = "m".repeat(cqs::MAX_NOTE_MENTION_BYTES + 1);
+    cqs()
+        .args([
+            "notes",
+            "add",
+            "oversized mention",
+            "--mentions",
+            &huge_mention,
+            "--no-reindex",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("max"));
+    assert!(
+        !notes_path(&dir).exists(),
+        "Rejected oversized mention must not create notes.toml"
+    );
+}
+
+/// Write-side size cap (shrunk via CQS_NOTES_MAX_FILE_SIZE): an add whose
+/// serialized output would exceed the cap is rejected, the file is left
+/// byte-for-byte unchanged AND stays usable — a follow-up normal add under
+/// the same cap succeeds. Before the output-side check, the oversized add
+/// went through and every subsequent notes operation refused the file.
+#[test]
+#[serial]
+fn test_notes_add_size_cap_rejects_and_file_stays_usable() {
+    let dir = setup_notes_project();
+    let cap = "1024";
+
+    // Seed a small note under the shrunk cap.
+    cqs()
+        .env("CQS_NOTES_MAX_FILE_SIZE", cap)
+        .args(["notes", "add", "first note", "--no-reindex"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let before = fs::read(notes_path(&dir)).expect("notes.toml must exist after seed add");
+
+    // 900 bytes of text is fine by the per-note cap but pushes the
+    // serialized file past 1024 bytes.
+    let big = "x".repeat(900);
+    cqs()
+        .env("CQS_NOTES_MAX_FILE_SIZE", cap)
+        .args(["notes", "add", &big, "--no-reindex"])
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("limit"));
+
+    // Existing file untouched and still parseable.
+    assert_eq!(
+        fs::read(notes_path(&dir)).expect("notes.toml must survive a rejected add"),
+        before,
+        "rejected over-cap add must leave notes.toml unchanged"
+    );
+    assert_eq!(read_notes(&dir).len(), 1);
+
+    // The file is NOT bricked: a normal add under the same cap succeeds.
+    cqs()
+        .env("CQS_NOTES_MAX_FILE_SIZE", cap)
+        .args(["notes", "add", "second note", "--no-reindex"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let after = read_notes(&dir);
+    assert_eq!(after.len(), 2, "follow-up add must succeed after rejection");
+    assert!(after.iter().any(|n| n.text == "second note"));
+}
+
+/// Stored text is trimmed: an add with surrounding whitespace stores the
+/// trimmed form, so a later remove with the bare text matches.
+#[test]
+#[serial]
+fn test_notes_add_stores_trimmed_text() {
+    let dir = setup_notes_project();
+    cqs()
+        .args(["notes", "add", "  padded note  ", "--no-reindex"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    let notes = read_notes(&dir);
+    assert_eq!(notes.len(), 1);
+    assert_eq!(notes[0].text, "padded note");
+
+    cqs()
+        .args(["notes", "remove", "padded note", "--no-reindex"])
+        .current_dir(dir.path())
+        .assert()
+        .success();
+    assert!(read_notes(&dir).is_empty());
+}
+
 /// B.4 (companion): `cqs notes add ... --sentiment Infinity` must also be
 /// rejected — same parser path (`parse_finite_f32`).
 #[test]


### PR DESCRIPTION
## Audit v1.42.0 — notes hardening (TC-V1.42-1 P2 + TC-V1.42-2 P3)

Closes the notes-integrity cluster from `docs/audit-triage.md` (triage rows flipped in this PR).

- **Write-side size cap (TC-V1.42-1):** `rewrite_notes_file` now checks the serialized output against `CQS_NOTES_MAX_FILE_SIZE` *before* the tmp write — previously only the existing file was checked, so one huge `--mentions` add could push notes.toml past 10 MiB and brick every subsequent notes operation. On rejection the existing file is untouched and the error names the file, byte counts, and the env var. The module doc that promised this enforcement is now true.
- **Mentions caps:** `MAX_NOTE_MENTIONS = 50`, `MAX_NOTE_MENTION_BYTES = 256` (worst-case payload ~12.8 KB, same order as the text cap); the existing 2000-byte text literal is lifted into a shared `MAX_NOTE_TEXT_BYTES` const. No new env vars.
- **Whitespace/duplicate integrity (TC-V1.42-2):** add trims and rejects whitespace-only text (which previously became a cross-note wildcard for update/remove matching); exact-duplicate (post-trim) adds rejected with an update/remove hint — notes carry search-ranking sentiment, so a stale duplicate surviving a "remove" was a ranking-integrity hazard. Update/remove reject whitespace-only queries and document first-match semantics; `--new-text`/`--new-mentions` get the same validation. Validation runs inside the rewrite closure under the exclusive lock (no read-then-add race).
- Rider: notes.toml gains the session observation about parallel agents needing private `CARGO_TARGET_DIR`.

Tests: lib note suite 24 pass; cli_notes_test 19 pass (7 new: shrunk-cap rejection + file-stays-usable, whitespace-only, duplicate incl. padded, 2000/2001 boundary, 50/51 mention count, 257-byte mention, trimmed round-trip). fmt + clippy `--all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
