### PR TITLE
fix(ci): nightly doctest crash — separate doctest step without --include-ignored

### DIFF
--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -70,7 +70,16 @@ jobs:
 
       - name: Run full test suite (incl. ignored)
         if: ${{ github.event_name == 'schedule' || inputs.include_ignored != 'false' }}
-        run: cargo test --release --verbose -- --include-ignored
+        # --include-ignored is for #[ignore]d unit/integration tests (GPU,
+        # model-download). Doctests run in their own step below WITHOUT it:
+        # rustdoc maps ```ignore blocks to #[ignore] doctests, so a combined
+        # run force-compiles examples that are ignore-marked precisely
+        # because they cannot compile (e.g. pub(crate) item references).
+        run: cargo test --release --verbose --lib --bins --tests -- --include-ignored
+
+      - name: Run doctests (normal ignore semantics)
+        if: ${{ github.event_name == 'schedule' || inputs.include_ignored != 'false' }}
+        run: cargo test --release --verbose --doc
 
       - name: Run regular suite only (manual dispatch fallback)
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.include_ignored == 'false' }}

--- a/src/search/scoring/candidate.rs
+++ b/src/search/scoring/candidate.rs
@@ -380,7 +380,7 @@ impl ChunkMeta<'_> {
 ///
 /// One struct + one slice entry — no edits to either search path:
 ///
-/// ```ignore
+/// ```text
 /// struct RecencyBoost;
 /// impl ScoreSignal for RecencyBoost {
 ///     fn enabled(&self, ctx: &ScoringContext<'_>) -> bool {


### PR DESCRIPTION
Nightly full-suite ran cargo test -- --include-ignored, which force-runs ignore-marked doctests (rustdoc maps them to #[ignore]); the ScoreSignal example from #1719 references pub(crate) items and can never compile as a doctest. Split the nightly into --lib --bins --tests with --include-ignored plus a separate --doc step with normal semantics, and mark the example block text (it is illustrative, not compilable). Verified: cargo test --doc passes 9/9 with 0 ignored. Closes #1749.