### PR TITLE
fix(daemon): plumb stale_origins through envelope _meta — daemon-served searches warn like CLI-direct

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -62,7 +62,7 @@ New v1.42 findings: 107 (batch 1: 59 = 15/11/26/7; batch 2: 48 = 13/19/14/2). Ca
 
 | ID | Finding | Location | Status |
 |----|---------|----------|--------|
-| OB-V1.42-3 | Daemon-served searches drop staleness warnings — recommended default path never warns; WSL inotify makes it the path that needs it most | src/cli/batch/handlers/search.rs:67-129 | open |
+| OB-V1.42-3 | Daemon-served searches drop staleness warnings — recommended default path never warns; WSL inotify makes it the path that needs it most | src/cli/batch/handlers/search.rs:67-129 | ✅ PR #1752 |
 | DOC-V1.42-5 | CONTRIBUTING JSON envelope section teaches pre-V2Bare shape as universal; not_found/io_error "reserved" claim false (also json_envelope.rs:155) | CONTRIBUTING.md:63-93 | open |
 | DOC-V1.42-6 | CONTRIBUTING Architecture Overview missing ~14 files; commands/eval lists moved schema.rs | CONTRIBUTING.md:221-432 | open |
 | RB-V1.42-1 | collect_comment_ranges / find_type_identifier_recursive recurse per tree-depth — stack overflow (SIGSEGV) on rayon workers aborts index/watch | src/parser/chunk.rs:126, :756 | open |

--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -65,10 +65,13 @@ fn validate_filter_args(args: &SearchArgs) -> Result<ParsedFilters> {
 ///   always serializes, so token-budget packing estimates with the JSON
 ///   overhead the CLI uses under `--json`.
 ///
-/// `expand_parent` / `pattern` / `context` / `no_stale_check` stay at their
-/// `QueryArgs` defaults: the daemon JSON has never emitted parent context, run
-/// the pattern filter, line-context, or staleness warnings, and Phase 2b keeps
-/// that wire shape. (`SearchArgs` carries those flags for CLI parity.)
+/// `expand_parent` / `pattern` / `context` stay at their `QueryArgs`
+/// defaults: the daemon JSON has never emitted parent context, run the
+/// pattern filter, or line-context, and Phase 2b keeps that wire shape.
+/// (`SearchArgs` carries those flags for CLI parity.) Staleness is not a
+/// core concern — the adapter runs the per-origin check after the core
+/// returns and attaches `_meta.stale_origins` (see
+/// [`attach_stale_origins_meta`]), honoring `--no-stale-check`.
 fn daemon_query_args(args: &SearchArgs) -> QueryArgs {
     QueryArgs {
         query: args.query.clone(),
@@ -124,10 +127,11 @@ pub(in crate::cli::batch) fn dispatch_search(
 ) -> Result<serde_json::Value> {
     let _span = tracing::info_span!("batch_search", query = %args.query).entered();
 
-    // Accepted for CLI parity; the batch JSON doesn't surface line-context,
-    // parent expansion, or staleness warnings. Assigning to `_` documents the
-    // intentional drop and keeps clippy quiet.
-    let _ = (args.context, args.expand_parent, args.no_stale_check);
+    // Accepted for CLI parity; the batch JSON doesn't surface line-context or
+    // parent expansion. Assigning to `_` documents the intentional drop and
+    // keeps clippy quiet. (`no_stale_check` IS honored — it gates the
+    // `_meta.stale_origins` attachment below.)
+    let _ = (args.context, args.expand_parent);
 
     // `--ref` / `--include-refs` keep their reference-index retrieval in the
     // adapter (the core models only the single-store project path); they
@@ -170,7 +174,70 @@ pub(in crate::cli::batch) fn dispatch_search(
     if args.no_content {
         strip_content(&mut value);
     }
+
+    let origins = result_origins(&output.results);
+    attach_stale_origins_meta(ctx, args, &origins, &mut value);
     Ok(value)
+}
+
+/// Deduplicated result origins (chunk file paths) for the staleness check.
+fn result_origins(results: &[cqs::store::UnifiedResult]) -> Vec<String> {
+    results
+        .iter()
+        .map(|r| {
+            let cqs::store::UnifiedResult::Code(sr) = r;
+            sr.chunk.file.to_string_lossy().into_owned()
+        })
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+/// Run the cheap per-origin staleness check (mtime-stat over the result
+/// origins — O(result_count), never a corpus scan) and attach the sorted
+/// stale set as a reserved payload-level `_meta.stale_origins` key, which
+/// `write_json_line` lifts onto the envelope `_meta` (sibling of `data`,
+/// same wire position as `worktree_stale`). Skip-when-empty: a fresh index
+/// emits no `_meta` key at all. `--no-stale-check` skips the check entirely.
+///
+/// PARITY: this is the daemon-surface counterpart of the CLI render path's
+/// `warn_stale_results` call (`render_query_output` in
+/// `commands::search::query`). The CLI client reads this meta off the daemon
+/// envelope and prints the same stderr warning via
+/// `staleness::print_stale_warning`, so daemon-up and daemon-down warn
+/// identically for the same stale state. Change one side only with a reason.
+///
+/// Errors are logged and swallowed — the staleness check must never break a
+/// query (same contract as `warn_stale_results`).
+fn attach_stale_origins_meta(
+    ctx: &BatchView,
+    args: &SearchArgs,
+    origins: &[String],
+    value: &mut serde_json::Value,
+) {
+    if args.no_stale_check || origins.is_empty() {
+        return;
+    }
+    let origin_refs: Vec<&str> = origins.iter().map(String::as_str).collect();
+    let stale = match ctx.store().check_origins_stale(&origin_refs, &ctx.root) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to check staleness");
+            return;
+        }
+    };
+    if stale.is_empty() {
+        return;
+    }
+    // Sorted for a deterministic wire shape (HashSet order is arbitrary).
+    let mut stale: Vec<String> = stale.into_iter().collect();
+    stale.sort();
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "_meta".to_string(),
+            serde_json::json!({ "stale_origins": stale }),
+        );
+    }
 }
 
 /// Reference-scoped (`--ref`) and reference-merged (`--include-refs`) search.
@@ -358,6 +425,12 @@ fn dispatch_search_with_refs(ctx: &BatchView, args: &SearchArgs) -> Result<serde
         results
     };
 
+    // Project-result origins for the staleness meta, captured before the
+    // reference merge consumes `results`. Reference origins are not project
+    // files — parity with the CLI multi-index path, which checks project
+    // results only.
+    let project_origins = result_origins(&results);
+
     let references = ctx.get_all_refs()?;
     let tagged: Vec<cqs::reference::TaggedResult> = if references.is_empty() {
         results
@@ -403,6 +476,7 @@ fn dispatch_search_with_refs(ctx: &BatchView, args: &SearchArgs) -> Result<serde
     if args.no_content {
         strip_content(&mut value);
     }
+    attach_stale_origins_meta(ctx, args, &project_origins, &mut value);
     Ok(value)
 }
 
@@ -542,6 +616,18 @@ mod tests {
     /// sqlx/WSL layer, not in each test.
     fn ctx_with_chunks(chunks: Vec<Chunk>) -> (TempDir, BatchContext) {
         let dir = TempDir::new().expect("Failed to create temp dir");
+        ctx_with_chunks_in(dir, chunks, Some(0))
+    }
+
+    /// Like [`ctx_with_chunks`] but with a caller-supplied project dir (so
+    /// tests can put real files on disk first) and a caller-supplied
+    /// `source_mtime` (so staleness tests can pin the stored fingerprint
+    /// against the disk one).
+    fn ctx_with_chunks_in(
+        dir: TempDir,
+        chunks: Vec<Chunk>,
+        source_mtime: Option<i64>,
+    ) -> (TempDir, BatchContext) {
         let cqs_dir = dir.path().join(".cqs");
         std::fs::create_dir_all(&cqs_dir).expect("Failed to create .cqs dir");
         let index_path = cqs_dir.join("index.db");
@@ -567,7 +653,7 @@ mod tests {
                     .map(|c| (c.clone(), embedding.clone()))
                     .collect();
                 store
-                    .upsert_chunks_batch(&pairs, Some(0))
+                    .upsert_chunks_batch(&pairs, source_mtime)
                     .expect("upsert_chunks_batch failed");
             }
         } // drop store to flush WAL
@@ -1048,16 +1134,23 @@ mod tests {
             );
         };
 
-        // Happy: a matching name-only query.
-        assert_parity(&["parse", "--name-only"]);
+        // Happy: a matching name-only query. `--no-stale-check` keeps the
+        // byte-equality contract pure: the staleness `_meta` is adapter
+        // surface I/O layered on top of the core output (the CLI does the
+        // same at its render layer), covered by the dedicated
+        // `*_stale_origins_*` tests below.
+        assert_parity(&["parse", "--name-only", "--no-stale-check"]);
         // Empty: a no-match query yields the bare envelope on both paths.
-        assert_parity(&["zzz_no_such_symbol", "--name-only"]);
+        assert_parity(&["zzz_no_such_symbol", "--name-only", "--no-stale-check"]);
 
         // Trust-labeled / converged schema: the daemon result objects carry the
         // store serializer's `type: "code"` field (a field the old ChunkOutput
         // shape never emitted). Confirms the convergence onto the CLI schema.
-        let happy = dispatch_search(&view, &parse_search_args(&["parse", "--name-only"]))
-            .expect("dispatch_search");
+        let happy = dispatch_search(
+            &view,
+            &parse_search_args(&["parse", "--name-only", "--no-stale-check"]),
+        )
+        .expect("dispatch_search");
         for r in happy["results"].as_array().expect("results array") {
             assert_eq!(
                 r["type"], "code",
@@ -1070,5 +1163,89 @@ mod tests {
                 assert!(tl.is_string(), "trust_level must serialize as a string");
             }
         }
+    }
+
+    // ─── Staleness meta (`_meta.stale_origins`) ─────────────────────────────
+
+    /// Build a context whose single chunk has a REAL file on disk at
+    /// `src/lib.rs`. `mtime_offset_ms` shifts the *stored* fingerprint
+    /// relative to the disk mtime: 0 → fresh (fingerprints match),
+    /// non-zero → stale (divergence in either direction counts under
+    /// `FileFingerprint::matches`).
+    fn ctx_with_file_on_disk(mtime_offset_ms: i64) -> (TempDir, BatchContext) {
+        let dir = TempDir::new().expect("Failed to create temp dir");
+        let file_path = dir.path().join("src/lib.rs");
+        std::fs::create_dir_all(file_path.parent().expect("parent")).expect("mkdir src");
+        // Disk content differs from the chunk content so a future
+        // content-hash tiebreak can never mask the mtime divergence.
+        std::fs::write(&file_path, "fn process_data() { /* edited */ }").expect("write file");
+        let disk_mtime = cqs::duration_to_mtime_millis(
+            file_path
+                .metadata()
+                .expect("metadata")
+                .modified()
+                .expect("modified")
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("duration"),
+        );
+
+        let chunk = make_chunk(
+            "src/lib.rs:1:5a1e0001",
+            "src/lib.rs",
+            Language::Rust,
+            ChunkType::Function,
+            "process_data",
+            "fn process_data()",
+            "fn process_data() {}",
+        );
+        ctx_with_chunks_in(dir, vec![chunk], Some(disk_mtime + mtime_offset_ms))
+    }
+
+    /// A stale origin (stored mtime diverges from disk) surfaces as
+    /// `_meta.stale_origins` on the dispatch payload — the machine-readable
+    /// signal `write_json_line` lifts onto the envelope and the CLI client
+    /// turns into the stderr warning.
+    #[test]
+    fn test_dispatch_search_stale_origin_lands_in_meta() {
+        let (_dir, ctx) = ctx_with_file_on_disk(-60_000);
+        let args = parse_search_args(&["process_data", "--name-only"]);
+        let json = dispatch_search(&ctx.build_view(None), &args).expect("dispatch_search");
+
+        assert_eq!(json["total"], 1, "sanity: the chunk must match");
+        assert_eq!(
+            json["_meta"]["stale_origins"],
+            serde_json::json!(["src/lib.rs"]),
+            "stale origin must surface in _meta.stale_origins; got: {json}"
+        );
+    }
+
+    /// `--no-stale-check` skips the check entirely — no `_meta` key, matching
+    /// the CLI-direct flag semantics.
+    #[test]
+    fn test_dispatch_search_no_stale_check_omits_meta() {
+        let (_dir, ctx) = ctx_with_file_on_disk(-60_000);
+        let args = parse_search_args(&["process_data", "--name-only", "--no-stale-check"]);
+        let json = dispatch_search(&ctx.build_view(None), &args).expect("dispatch_search");
+
+        assert_eq!(json["total"], 1, "sanity: the chunk must match");
+        assert!(
+            json.get("_meta").is_none(),
+            "--no-stale-check must skip the staleness meta; got: {json}"
+        );
+    }
+
+    /// Fresh index (stored fingerprint matches disk) emits NO `_meta` key —
+    /// the skip-when-empty convention `worktree_stale` established.
+    #[test]
+    fn test_dispatch_search_fresh_index_omits_meta() {
+        let (_dir, ctx) = ctx_with_file_on_disk(0);
+        let args = parse_search_args(&["process_data", "--name-only"]);
+        let json = dispatch_search(&ctx.build_view(None), &args).expect("dispatch_search");
+
+        assert_eq!(json["total"], 1, "sanity: the chunk must match");
+        assert!(
+            json.get("_meta").is_none(),
+            "fresh index must emit no _meta key (skip-when-empty); got: {json}"
+        );
     }
 }

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -322,6 +322,19 @@ fn write_json_line(
     out: &mut impl std::io::Write,
     value: &serde_json::Value,
 ) -> std::io::Result<()> {
+    // Per-response envelope meta: handlers may attach a reserved top-level
+    // `_meta` key to their payload (e.g. `stale_origins` from the search
+    // handler). Lift it out of the payload and onto the envelope — sibling
+    // of `data`, the same wire position `worktree_stale` occupies — so the
+    // CLI client's slim-envelope translation sees one meta channel. Rare
+    // path (handlers attach `_meta` skip-when-empty), so the payload clone
+    // stays off the steady-state line.
+    if let Some(obj) = value.as_object() {
+        if obj.contains_key("_meta") {
+            return write_json_line_lifting_meta(out, value);
+        }
+    }
+
     // Steady-state: build the line in a `Vec<u8>` so the entire envelope
     // is one `writeln!` (avoids interleaved partial writes if `out` is a
     // shared TcpStream / UnixStream). Buffering also amortizes allocator
@@ -380,6 +393,53 @@ fn write_json_line(
                     writeln!(out, "{}", s)
                 }
             }
+        }
+    }
+}
+
+/// Cold path of [`write_json_line`]: the payload carries a reserved
+/// top-level `_meta` key. Remove it from the payload, merge its entries
+/// with the process-level meta (worktree state), and emit
+/// `{"data": <payload-without-_meta>, "_meta": {...merged...}}`.
+///
+/// Sanitizes NaN / Infinity up front — this path already owns a payload
+/// clone, so the streamed `to_writer` + retry dance of the hot path buys
+/// nothing here.
+fn write_json_line_lifting_meta(
+    out: &mut impl std::io::Write,
+    value: &serde_json::Value,
+) -> std::io::Result<()> {
+    let mut payload = value.clone();
+    let per_meta = match payload.as_object_mut().and_then(|o| o.remove("_meta")) {
+        Some(serde_json::Value::Object(m)) => m,
+        // Non-object `_meta` (handler bug) — drop it rather than emit a
+        // malformed meta block.
+        Some(other) => {
+            tracing::warn!(
+                meta = %other,
+                "Payload _meta is not a JSON object; dropping per-response meta"
+            );
+            serde_json::Map::new()
+        }
+        None => serde_json::Map::new(),
+    };
+
+    let mut env = serde_json::Map::with_capacity(2);
+    env.insert("data".to_string(), payload);
+    if let Some(meta) = crate::cli::json_envelope::merged_meta_value(per_meta) {
+        env.insert("_meta".to_string(), meta);
+    }
+    let mut env = serde_json::Value::Object(env);
+    sanitize_json_floats(&mut env);
+    match serde_json::to_string(&env) {
+        Ok(s) => writeln!(out, "{}", s),
+        Err(e) => {
+            tracing::warn!(error = %e, "JSON serialization failed after sanitization");
+            write_envelope_error(
+                out,
+                crate::cli::json_envelope::error_codes::INTERNAL,
+                "JSON serialization failed",
+            )
         }
     }
 }
@@ -977,6 +1037,50 @@ mod tests {
         assert_eq!(parsed["data"], val);
         assert!(parsed.get("error").is_none(), "got: {parsed}");
         assert!(parsed.get("version").is_none(), "got: {parsed}");
+    }
+
+    // Payload-level `_meta` is lifted onto the envelope, sibling of `data` —
+    // the same wire position `worktree_stale` occupies. The payload itself
+    // arrives meta-free so consumers never see `data._meta`.
+    #[test]
+    fn test_write_json_line_lifts_payload_meta_to_envelope() {
+        let val = serde_json::json!({
+            "query": "q",
+            "results": [],
+            "_meta": {"stale_origins": ["src/lib.rs"]},
+        });
+        let mut buf = Vec::new();
+        write_json_line(&mut buf, &val).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(String::from_utf8(buf).unwrap().trim()).unwrap();
+        assert_eq!(
+            parsed["_meta"]["stale_origins"],
+            serde_json::json!(["src/lib.rs"]),
+            "per-response meta must land on the envelope; got: {parsed}"
+        );
+        assert!(
+            parsed["data"].get("_meta").is_none(),
+            "lifted meta must be removed from the data payload; got: {parsed}"
+        );
+        assert_eq!(parsed["data"]["query"], "q");
+    }
+
+    // Lifted-meta path sanitizes non-finite floats like the hot path does.
+    #[test]
+    fn test_write_json_line_lifts_meta_and_sanitizes_nan() {
+        let val = serde_json::json!({
+            "score": f64::NAN,
+            "_meta": {"stale_origins": ["a.rs"]},
+        });
+        let mut buf = Vec::new();
+        write_json_line(&mut buf, &val).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(String::from_utf8(buf).unwrap().trim()).unwrap();
+        assert!(parsed["data"]["score"].is_null());
+        assert_eq!(
+            parsed["_meta"]["stale_origins"],
+            serde_json::json!(["a.rs"])
+        );
     }
 
     // D.2: reject_null_tokens helper unit test. Pure function, no fixture

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -524,6 +524,18 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Result<Option<Strin
             // printing; anything that isn't a slim envelope prints verbatim.
             other => match cqs::daemon_translate::classify_slim_envelope(other) {
                 Some(cqs::daemon_translate::SlimEnvelope::Data { payload, meta }) => {
+                    // PARITY: the daemon's search handler runs the per-origin
+                    // staleness check (`attach_stale_origins_meta` in
+                    // `batch::handlers::search`) and reports stale files via
+                    // `_meta.stale_origins`. Print the same stderr warning the
+                    // CLI-direct path emits (`warn_stale_results` →
+                    // `print_stale_warning`), gated on `--quiet` exactly like
+                    // `render_query_output`. `--no-stale-check` needs no gate
+                    // here: it forwards to the daemon, which skips the check,
+                    // so the meta is absent.
+                    if !cli.quiet {
+                        crate::cli::staleness::print_stale_warning_from_meta(meta);
+                    }
                     match crate::cli::json_envelope::daemon_payload_to_cli_text(payload, meta) {
                         Ok(s) => s,
                         Err(e) => {

--- a/src/cli/json_envelope.rs
+++ b/src/cli/json_envelope.rs
@@ -277,6 +277,30 @@ fn meta_value_for_envelope(meta: &EnvelopeMeta) -> serde_json::Value {
     })
 }
 
+/// Merge per-response meta entries (e.g. `stale_origins` from a search
+/// handler) with the process-level [`EnvelopeMeta`] fields, returning the
+/// combined `_meta` object — or `None` when both are empty, so callers keep
+/// the skip-when-empty emission convention `worktree_stale` established.
+///
+/// Per-response keys never collide with the process-level ones
+/// (`worktree_stale` / `worktree_name`); insertion order is process-level
+/// first, then per-response.
+pub fn merged_meta_value(
+    per_response: serde_json::Map<String, serde_json::Value>,
+) -> Option<serde_json::Value> {
+    let meta = EnvelopeMeta::current();
+    if meta.is_empty() && per_response.is_empty() {
+        return None;
+    }
+    let mut combined = match meta_value_for_envelope(&meta) {
+        serde_json::Value::Object(m) => m,
+        // meta_value_for_envelope always returns an object; defensive arm.
+        _ => serde_json::Map::new(),
+    };
+    combined.extend(per_response);
+    Some(serde_json::Value::Object(combined))
+}
+
 /// Pre-serialized `,"_meta":{...}` JSON fragment for the hot-path
 /// streamed envelope writer (`write_json_line` in `crate::cli::batch`).
 /// Builds fresh on each call so the worktree-stale fields reflect
@@ -778,6 +802,26 @@ mod tests {
             v.get("handling_advice").is_none(),
             "EnvelopeMeta must not serialize a handling_advice field; got: {v}"
         );
+    }
+
+    // merged_meta_value: the per-response merge keeps the skip-when-empty
+    // convention — `None` when both the process meta and the per-response
+    // entries are empty (tests run with non-stale worktree state, so the
+    // process side is empty here).
+    #[test]
+    fn merged_meta_value_none_when_both_empty() {
+        assert!(
+            merged_meta_value(serde_json::Map::new()).is_none(),
+            "empty per-response + empty process meta must skip _meta entirely"
+        );
+    }
+
+    #[test]
+    fn merged_meta_value_carries_per_response_entries() {
+        let mut per = serde_json::Map::new();
+        per.insert("stale_origins".to_string(), serde_json::json!(["src/a.rs"]));
+        let v = merged_meta_value(per).expect("non-empty per-response meta must emit _meta");
+        assert_eq!(v["stale_origins"], serde_json::json!(["src/a.rs"]));
     }
 
     #[test]

--- a/src/cli/staleness.rs
+++ b/src/cli/staleness.rs
@@ -12,6 +12,54 @@ use colored::Colorize;
 use cqs::normalize_slashes;
 use cqs::Store;
 
+/// Print the canonical stale-results warning to stderr. No-op on an empty
+/// slice.
+///
+/// This is the single formatting seam shared by the CLI-direct path
+/// ([`warn_stale_results`]) and the daemon-client translation path
+/// (`dispatch.rs` reading `_meta.stale_origins` from a daemon envelope) —
+/// one formatter so the two surfaces emit byte-identical warnings and
+/// can't drift.
+pub fn print_stale_warning<S: AsRef<str>>(files: &[S]) {
+    let count = files.len();
+    if count == 0 {
+        return;
+    }
+    eprintln!(
+        "{} {} result file{} changed since last index. Run 'cqs index' to update.",
+        "warning:".yellow().bold(),
+        count,
+        if count == 1 { "" } else { "s" }
+    );
+    for file in files {
+        eprintln!("  {}", normalize_slashes(file.as_ref()).dimmed());
+    }
+}
+
+/// Extract `stale_origins` from a daemon envelope `_meta` value. Returns an
+/// empty vec when the meta is absent, has no `stale_origins` key, or the key
+/// isn't an array of strings. Pure extraction — split from the printing so
+/// the seam is unit-testable without capturing stderr.
+pub fn stale_origins_from_meta(meta: Option<&serde_json::Value>) -> Vec<String> {
+    meta.and_then(|m| m.get("stale_origins"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Read `_meta.stale_origins` from a daemon envelope and print the same
+/// stderr warning the CLI-direct path emits. Called from the daemon-response
+/// translation in `dispatch.rs` so daemon-served searches warn exactly like
+/// CLI-direct ones.
+pub fn print_stale_warning_from_meta(meta: Option<&serde_json::Value>) {
+    let files = stale_origins_from_meta(meta);
+    print_stale_warning(&files);
+}
+
 /// Check result origins for staleness and print warning to stderr.
 /// Returns the set of stale origins for callers that want to annotate results.
 /// Errors are logged and swallowed — staleness check should never break a query.
@@ -24,17 +72,12 @@ pub fn warn_stale_results<Mode>(
     match store.check_origins_stale(origins, root) {
         Ok(stale) => {
             if !stale.is_empty() {
-                let count = stale.len();
-                tracing::info!(count, "Stale result files detected");
-                eprintln!(
-                    "{} {} result file{} changed since last index. Run 'cqs index' to update.",
-                    "warning:".yellow().bold(),
-                    count,
-                    if count == 1 { "" } else { "s" }
-                );
-                for file in &stale {
-                    eprintln!("  {}", normalize_slashes(file).dimmed());
-                }
+                tracing::info!(count = stale.len(), "Stale result files detected");
+                // Sorted for deterministic output (HashSet iteration order
+                // is arbitrary).
+                let mut files: Vec<&String> = stale.iter().collect();
+                files.sort();
+                print_stale_warning(&files);
             }
             stale
         }
@@ -79,6 +122,40 @@ mod tests {
         assert!(
             result.is_empty(),
             "Nonexistent origins should produce empty stale set"
+        );
+    }
+
+    #[test]
+    fn test_stale_origins_from_meta_extracts_strings() {
+        let meta = serde_json::json!({"stale_origins": ["src/a.rs", "src/b.rs"]});
+        let files = stale_origins_from_meta(Some(&meta));
+        assert_eq!(files, vec!["src/a.rs".to_string(), "src/b.rs".to_string()]);
+    }
+
+    #[test]
+    fn test_stale_origins_from_meta_absent_meta_is_empty() {
+        assert!(stale_origins_from_meta(None).is_empty());
+    }
+
+    #[test]
+    fn test_stale_origins_from_meta_missing_key_is_empty() {
+        let meta = serde_json::json!({"worktree_stale": true});
+        assert!(stale_origins_from_meta(Some(&meta)).is_empty());
+    }
+
+    #[test]
+    fn test_stale_origins_from_meta_non_array_is_empty() {
+        // Defensive: a malformed daemon response must not panic or print.
+        let meta = serde_json::json!({"stale_origins": "src/a.rs"});
+        assert!(stale_origins_from_meta(Some(&meta)).is_empty());
+    }
+
+    #[test]
+    fn test_stale_origins_from_meta_skips_non_string_elements() {
+        let meta = serde_json::json!({"stale_origins": ["src/a.rs", 42, null]});
+        assert_eq!(
+            stale_origins_from_meta(Some(&meta)),
+            vec!["src/a.rs".to_string()]
         );
     }
 }

--- a/tests/daemon_forward_test.rs
+++ b/tests/daemon_forward_test.rs
@@ -572,6 +572,105 @@ fn test_bare_query_forwards_search_knobs_to_daemon() {
 }
 
 #[test]
+fn test_daemon_stale_origins_meta_prints_cli_warning() {
+    // Staleness parity: when the daemon's search response carries
+    // `_meta.stale_origins`, the CLI client must print the SAME stderr
+    // warning the CLI-direct path emits (`print_stale_warning`, shared by
+    // `warn_stale_results` and the dispatch.rs translation path). Before the
+    // fix, daemon-served searches silently dropped the staleness signal.
+    let (dir, sock_path) = setup_project();
+    let response = serde_json::json!({
+        "status": "ok",
+        "output": {
+            "data": {"query": "find the thing", "results": [], "total": 0},
+            "_meta": {"stale_origins": ["src/lib.rs", "src/other.rs"]},
+        },
+    });
+    let mock = MockDaemon::with_response_line(sock_path.clone(), response.to_string());
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+    // Bare default surface (no CQS_OUTPUT_FORMAT pin) — the `_meta` splice
+    // assertion below targets the V2Bare shape.
+    let mut cmd = cqs_bare();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["find the thing", "--json"]);
+
+    let output = cmd.output().expect("cqs spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "bare query failed daemon-up; stdout=<{stdout}> stderr=<{stderr}>"
+    );
+    assert_eq!(
+        mock.conn_count(),
+        1,
+        "expected exactly one daemon connection; stdout=<{stdout}> stderr=<{stderr}>"
+    );
+    // The canonical warning line from `print_stale_warning` — same text the
+    // CLI-direct path produces for two stale files.
+    assert!(
+        stderr.contains("2 result files changed since last index"),
+        "stale warning missing from stderr; stderr=<{stderr}>"
+    );
+    assert!(
+        stderr.contains("src/lib.rs") && stderr.contains("src/other.rs"),
+        "stale file list missing from stderr; stderr=<{stderr}>"
+    );
+    // Machine-readable signal: the daemon's `_meta` is spliced into the bare
+    // JSON payload on stdout (V2Bare default), same as `worktree_stale`.
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout must be valid JSON");
+    assert_eq!(
+        parsed["_meta"]["stale_origins"],
+        serde_json::json!(["src/lib.rs", "src/other.rs"]),
+        "stale_origins must reach the JSON consumer; stdout=<{stdout}>"
+    );
+}
+
+#[test]
+fn test_daemon_quiet_suppresses_stale_warning() {
+    // `--quiet` parity: CLI-direct gates the staleness warning on
+    // `!cli.quiet` (`render_query_output`); the daemon-client translation
+    // must do the same. The JSON signal stays — only the human warning goes.
+    let (dir, sock_path) = setup_project();
+    let response = serde_json::json!({
+        "status": "ok",
+        "output": {
+            "data": {"query": "find the thing", "results": [], "total": 0},
+            "_meta": {"stale_origins": ["src/lib.rs"]},
+        },
+    });
+    let mock = MockDaemon::with_response_line(sock_path.clone(), response.to_string());
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+    let mut cmd = cqs();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["--quiet", "find the thing", "--json"]);
+
+    let output = cmd.output().expect("cqs spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "bare query failed daemon-up; stdout=<{stdout}> stderr=<{stderr}>"
+    );
+    assert_eq!(mock.conn_count(), 1);
+    assert!(
+        !stderr.contains("changed since last index"),
+        "--quiet must suppress the stale warning; stderr=<{stderr}>"
+    );
+}
+
+#[test]
 fn test_cqs_slot_env_bypasses_daemon() {
     // `CQS_SLOT` is documented as equivalent to `--slot` and honored by
     // `slot::resolve_slot_name`. The daemon serves whichever slot was active


### PR DESCRIPTION
## Audit v1.42.0 — staleness plumbing through the daemon (OB-V1.42-3, P2)

The recommended default path (`cqs watch --serve`, CLI auto-connects) never surfaced staleness warnings — `dispatch_search` documented the drop, and WSL inotify unreliability makes the daemon deployment exactly the one where the index goes stale. With the AC-V1.42-2 predicate fix already landed (#1744), the signal being plumbed is the corrected divergence check.

- `dispatch_search` honors `no_stale_check` and runs `check_origins_stale` over deduplicated result origins (bounded by result count — no corpus scan per query); stale set rides the envelope as `_meta.stale_origins`, skip-when-empty, same wire position as `worktree_stale`. Covers both the daemon socket and batch-stdin surfaces via the single `write_json_line` wrap point.
- The CLI client prints the same stderr warning CLI-direct produces, from a shared formatting seam extracted out of `warn_stale_results` (the two paths can't drift), gated on `--quiet` identically.
- Scope parity with CLI-direct: plain and `--include-refs` searches warn on project origins; `--ref`-scoped searches don't (CLI-direct never warned there either).
- v1-format note: the daemon `_meta` isn't rebuilt into the legacy v1 envelope (pre-existing `worktree_stale` behavior); the stderr warning still prints on every format.

Tests: 14 new across handlers/envelope/staleness/dispatch + 2 mock-daemon integration tests (warning on stderr, `_meta` spliced into bare JSON, `--quiet` suppression); parity test pinned. fmt + clippy `--all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
