### PR TITLE
fix(pipeline): fingerprint stamping on the CLI path, staleness pre-filter before parse, batched chunk transactions

### DIFF
--- a/src/cli/enrichment.rs
+++ b/src/cli/enrichment.rs
@@ -195,7 +195,8 @@ pub(crate) fn enrichment_pass(
 
                 // Chunks at `needs_embedding=1` must always be embedded
                 // regardless of context — they were written by the parser
-                // stage with a zero-vec sentinel (see `upsert_chunks_unembedded_batch`).
+                // stage with a zero-vec sentinel (see `upsert_embedded_batch`'s
+                // sentinel mode).
                 // Search and HNSW build skip them via `WHERE needs_embedding = 0`,
                 // so leaving them unembedded means they stay invisible.
                 let needs_embedding = needs_embedding_ids.contains(&cs.id);

--- a/src/cli/pipeline/embedding.rs
+++ b/src/cli/pipeline/embedding.rs
@@ -113,7 +113,7 @@ pub(super) fn prepare_for_embedding(
         to_embed,
         texts,
         relationships: batch.relationships,
-        file_mtimes: batch.file_mtimes,
+        file_fingerprints: batch.file_fingerprints,
     }
 }
 
@@ -123,7 +123,7 @@ pub(super) fn create_embedded_batch(
     to_embed: Vec<Chunk>,
     new_embeddings: Vec<Embedding>,
     relationships: RelationshipData,
-    file_mtimes: HashMap<std::path::PathBuf, i64>,
+    file_fingerprints: HashMap<std::path::PathBuf, cqs::store::FileFingerprint>,
 ) -> EmbeddedBatch {
     let cached_count = cached.len();
     let mut chunk_embeddings = cached;
@@ -132,7 +132,7 @@ pub(super) fn create_embedded_batch(
         chunk_embeddings,
         relationships,
         cached_count,
-        file_mtimes,
+        file_fingerprints,
         // Default: real embeddings throughout. The skip-first-pass path
         // builds EmbeddedBatch directly with `uncached_need_embedding: true`
         // (see `gpu_embed_stage` / `cpu_embed_stage`).
@@ -165,7 +165,7 @@ fn flush_to_cpu(
                 chunk_embeddings: prepared.cached,
                 relationships: rels,
                 cached_count,
-                file_mtimes: prepared.file_mtimes.clone(),
+                file_fingerprints: prepared.file_fingerprints.clone(),
                 uncached_need_embedding: false,
             })
             .is_err()
@@ -183,7 +183,7 @@ fn flush_to_cpu(
         .send(ParsedBatch {
             chunks: prepared.to_embed,
             relationships: rels,
-            file_mtimes: prepared.file_mtimes,
+            file_fingerprints: prepared.file_fingerprints,
         })
         .is_err()
     {
@@ -235,7 +235,7 @@ pub(super) fn gpu_embed_stage(
                     chunk_embeddings: prepared.cached,
                     relationships: prepared.relationships,
                     cached_count,
-                    file_mtimes: prepared.file_mtimes,
+                    file_fingerprints: prepared.file_fingerprints,
                     uncached_need_embedding: false,
                 })
                 .is_err()
@@ -272,7 +272,7 @@ pub(super) fn gpu_embed_stage(
                     chunk_embeddings,
                     relationships: prepared.relationships,
                     cached_count,
-                    file_mtimes: prepared.file_mtimes,
+                    file_fingerprints: prepared.file_fingerprints,
                     uncached_need_embedding: true,
                 })
                 .is_err()
@@ -360,7 +360,7 @@ pub(super) fn gpu_embed_stage(
                         chunk_embeddings,
                         relationships: prepared.relationships,
                         cached_count,
-                        file_mtimes: prepared.file_mtimes,
+                        file_fingerprints: prepared.file_fingerprints,
                         uncached_need_embedding: false,
                     })
                     .is_err()
@@ -509,7 +509,7 @@ pub(super) fn cpu_embed_stage(
                     chunk_embeddings,
                     relationships: prepared.relationships,
                     cached_count,
-                    file_mtimes: prepared.file_mtimes,
+                    file_fingerprints: prepared.file_fingerprints,
                     uncached_need_embedding: true,
                 })
                 .is_err()
@@ -563,7 +563,7 @@ pub(super) fn cpu_embed_stage(
             prepared.to_embed,
             new_embeddings,
             prepared.relationships,
-            prepared.file_mtimes,
+            prepared.file_fingerprints,
         );
 
         ctx.embedded_count

--- a/src/cli/pipeline/mod.rs
+++ b/src/cli/pipeline/mod.rs
@@ -282,9 +282,16 @@ mod tests {
         }
     }
 
-    fn test_mtimes(mtime: i64) -> std::collections::HashMap<PathBuf, i64> {
+    fn test_fps(mtime: i64) -> std::collections::HashMap<PathBuf, cqs::store::FileFingerprint> {
         let mut m = std::collections::HashMap::new();
-        m.insert(PathBuf::from("test.rs"), mtime);
+        m.insert(
+            PathBuf::from("test.rs"),
+            cqs::store::FileFingerprint {
+                mtime: Some(mtime),
+                size: None,
+                content_hash: None,
+            },
+        );
         m
     }
 
@@ -299,11 +306,14 @@ mod tests {
             vec![],
             vec![],
             RelationshipData::default(),
-            test_mtimes(12345),
+            test_fps(12345),
         );
         assert_eq!(batch.chunk_embeddings.len(), 1);
         assert_eq!(batch.cached_count, 1);
-        assert_eq!(batch.file_mtimes[&PathBuf::from("test.rs")], 12345);
+        assert_eq!(
+            batch.file_fingerprints[&PathBuf::from("test.rs")].mtime,
+            Some(12345)
+        );
     }
 
     #[test]
@@ -316,11 +326,14 @@ mod tests {
             vec![chunk],
             vec![emb],
             RelationshipData::default(),
-            test_mtimes(99),
+            test_fps(99),
         );
         assert_eq!(batch.chunk_embeddings.len(), 1);
         assert_eq!(batch.cached_count, 0);
-        assert_eq!(batch.file_mtimes[&PathBuf::from("test.rs")], 99);
+        assert_eq!(
+            batch.file_fingerprints[&PathBuf::from("test.rs")].mtime,
+            Some(99)
+        );
     }
 
     #[test]
@@ -335,7 +348,7 @@ mod tests {
             vec![new_chunk],
             vec![new_emb],
             RelationshipData::default(),
-            test_mtimes(12345),
+            test_fps(12345),
         );
         assert_eq!(batch.chunk_embeddings.len(), 2);
         assert_eq!(batch.cached_count, 1);
@@ -368,7 +381,7 @@ mod tests {
             vec![c2, c3],
             vec![e2, e3],
             RelationshipData::default(),
-            test_mtimes(0),
+            test_fps(0),
         );
 
         assert_eq!(batch.chunk_embeddings.len(), 3);
@@ -559,12 +572,19 @@ mod tests {
     // ========================================================================
 
     fn make_parsed_batch_with_chunk(chunk: Chunk) -> super::types::ParsedBatch {
-        let mut file_mtimes = std::collections::HashMap::new();
-        file_mtimes.insert(chunk.file.clone(), 0);
+        let mut file_fingerprints = std::collections::HashMap::new();
+        file_fingerprints.insert(
+            chunk.file.clone(),
+            cqs::store::FileFingerprint {
+                mtime: Some(0),
+                size: None,
+                content_hash: None,
+            },
+        );
         super::types::ParsedBatch {
             chunks: vec![chunk],
             relationships: super::types::RelationshipData::default(),
-            file_mtimes,
+            file_fingerprints,
         }
     }
 
@@ -707,7 +727,7 @@ mod tests {
         let batch = super::types::ParsedBatch {
             chunks: vec![],
             relationships: super::types::RelationshipData::default(),
-            file_mtimes: std::collections::HashMap::new(),
+            file_fingerprints: std::collections::HashMap::new(),
         };
 
         let prepared = prepare_for_embedding(batch, &embedder, &store, None, None);

--- a/src/cli/pipeline/parsing.rs
+++ b/src/cli/pipeline/parsing.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use crossbeam_channel::Sender;
 use rayon::prelude::*;
 
+use cqs::store::{FileFingerprint, FingerprintPolicy};
 use cqs::{normalize_path, Parser as CqParser, Store};
 
 use super::types::{embed_batch_size_for, file_batch_size, ParsedBatch, RelationshipData};
@@ -26,6 +27,153 @@ pub(super) struct ParserStageContext {
     /// size. At batch=64 nomic-coderank (768 dim, 2048 seq) OOMs an 8 GB GPU;
     /// the model-aware helper drops it to 16.
     pub model_config: cqs::embedder::ModelConfig,
+}
+
+/// Read a full disk fingerprint (mtime + size + BLAKE3) for a file that is
+/// about to be (re)indexed. `FingerprintPolicy::HashOnly` forces the hash
+/// read regardless of stored state, so every reindexed file leaves fully
+/// populated fingerprint columns behind. Returns `Default` (all `None`)
+/// when `metadata()` fails — the parser surfaces the real I/O error.
+fn full_disk_fingerprint(abs_path: &std::path::Path) -> FileFingerprint {
+    FileFingerprint::read_disk(
+        abs_path,
+        &FileFingerprint::default(),
+        FingerprintPolicy::HashOnly,
+    )
+    .unwrap_or_default()
+}
+
+/// Result of the per-batch staleness pre-filter: which files to parse, and
+/// the disk fingerprint for each of them.
+struct StalenessFilterResult {
+    survivors: Vec<PathBuf>,
+    fingerprints: HashMap<PathBuf, FileFingerprint>,
+}
+
+/// Decide which files in `file_batch` actually need reindexing, BEFORE any
+/// parsing happens.
+///
+/// One batched `fingerprints_for_origins` SELECT per file batch replaces
+/// the old per-file `needs_reindex` round-trip (one stat + one SELECT per
+/// file), and skipped files are never parsed at all — previously every file
+/// was fully tree-sitter parsed and the staleness filter ran on the parsed
+/// chunks, making a no-op incremental index O(corpus) parses. Same batched
+/// shape as the watch daemon's reconcile pre-filter.
+///
+/// Comparison uses `FingerprintPolicy::MtimeOrHash`: mtime+size fast path,
+/// BLAKE3 tiebreak when they disagree. Rows whose fingerprint columns are
+/// still NULL (pre-v23 rows, low-level upserts) degrade to mtime equality.
+///
+/// When the tiebreak proves a mtime-bumped file content-identical
+/// (`git checkout`, formatter no-op), the stored fingerprint is refreshed
+/// in one batched write so neither the next `cqs index` nor the daemon
+/// reconcile has to re-hash the file.
+///
+/// `force` bypasses the filter entirely (every file reindexes) but still
+/// reads full fingerprints so the upsert stamps them.
+fn filter_stale_files(
+    store: &Store,
+    root: &std::path::Path,
+    file_batch: &[PathBuf],
+    force: bool,
+) -> StalenessFilterResult {
+    let _span = tracing::debug_span!("filter_stale_files", files = file_batch.len()).entered();
+    let mut fingerprints: HashMap<PathBuf, FileFingerprint> =
+        HashMap::with_capacity(file_batch.len());
+
+    if force {
+        for rel in file_batch {
+            fingerprints.insert(rel.clone(), full_disk_fingerprint(&root.join(rel)));
+        }
+        return StalenessFilterResult {
+            survivors: file_batch.to_vec(),
+            fingerprints,
+        };
+    }
+
+    let origins: Vec<String> = file_batch.iter().map(|p| normalize_path(p)).collect();
+    let origin_refs: Vec<&str> = origins.iter().map(|s| s.as_str()).collect();
+    let stored_map = match store.fingerprints_for_origins(&origin_refs) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(error = %e, "Batched fingerprint lookup failed; reindexing whole batch");
+            HashMap::new()
+        }
+    };
+
+    let mut survivors = Vec::with_capacity(file_batch.len());
+    let mut refreshes: Vec<(PathBuf, FileFingerprint)> = Vec::new();
+    for (rel, origin) in file_batch.iter().zip(origins.iter()) {
+        let abs_path = root.join(rel);
+        match stored_map.get(origin.as_str()) {
+            // Not indexed yet — always a survivor.
+            None => {
+                fingerprints.insert(rel.clone(), full_disk_fingerprint(&abs_path));
+                survivors.push(rel.clone());
+            }
+            Some(stored_fp) => {
+                match FileFingerprint::read_disk(
+                    &abs_path,
+                    stored_fp,
+                    FingerprintPolicy::MtimeOrHash,
+                ) {
+                    Some(disk_fp)
+                        if stored_fp.matches(&disk_fp, FingerprintPolicy::MtimeOrHash) =>
+                    {
+                        // Unchanged — skip the parse. If the match came from
+                        // the hash tiebreak (mtime/size moved, content
+                        // identical), refresh the stored fingerprint so the
+                        // next walk fast-paths on mtime+size again.
+                        if disk_fp.content_hash.is_some()
+                            && (disk_fp.mtime != stored_fp.mtime || disk_fp.size != stored_fp.size)
+                        {
+                            refreshes.push((rel.clone(), disk_fp));
+                        }
+                    }
+                    Some(disk_fp) => {
+                        // Divergent — reindex. `read_disk` only hashed when
+                        // the stored row had fingerprint columns; ensure the
+                        // hash is present so the upsert stamps a full
+                        // fingerprint.
+                        let fp = if disk_fp.content_hash.is_some() {
+                            disk_fp
+                        } else {
+                            full_disk_fingerprint(&abs_path)
+                        };
+                        fingerprints.insert(rel.clone(), fp);
+                        survivors.push(rel.clone());
+                    }
+                    None => {
+                        // metadata() failed (deleted mid-walk, permission
+                        // flip). Keep the file so the parser surfaces the
+                        // real error; fingerprint stays empty.
+                        fingerprints.insert(rel.clone(), FileFingerprint::default());
+                        survivors.push(rel.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    if !refreshes.is_empty() {
+        match store.set_file_fingerprints_batch(&refreshes) {
+            Ok(rows) => tracing::debug!(
+                files = refreshes.len(),
+                rows,
+                "Refreshed fingerprints for mtime-bumped content-identical files"
+            ),
+            Err(e) => tracing::warn!(
+                error = %e,
+                files = refreshes.len(),
+                "Failed to refresh fingerprints; files will re-hash on the next walk"
+            ),
+        }
+    }
+
+    StalenessFilterResult {
+        survivors,
+        fingerprints,
+    }
 }
 
 /// Stage 1: Parse files in parallel batches, filter by staleness, and send to embedder channels.
@@ -52,14 +200,28 @@ pub(super) fn parser_stage(
             break;
         }
 
+        // Staleness pre-filter BEFORE parsing: one batched SELECT decides
+        // which files diverged from the index; only those get the (much more
+        // expensive) tree-sitter parse below. `--force` bypasses the filter.
+        let StalenessFilterResult {
+            survivors,
+            fingerprints: file_fingerprints,
+        } = filter_stale_files(&store, &root, file_batch, force);
+
         tracing::info!(
             batch = batch_idx + 1,
             files = file_batch.len(),
+            to_parse = survivors.len(),
             "Processing file batch"
         );
 
-        // Parse files in parallel, collecting chunks and relationships
-        let (chunks, batch_rels): (Vec<cqs::Chunk>, RelationshipData) = file_batch
+        if survivors.is_empty() {
+            parsed_count.fetch_add(file_batch.len(), Ordering::Relaxed);
+            continue;
+        }
+
+        // Parse surviving files in parallel, collecting chunks and relationships
+        let (chunks, batch_rels): (Vec<cqs::Chunk>, RelationshipData) = survivors
             .par_iter()
             .fold(
                 || (Vec::new(), RelationshipData::default()),
@@ -155,89 +317,16 @@ pub(super) fn parser_stage(
                 },
             );
 
-        // Filter by needs_reindex unless forced, caching mtime per-file to avoid double reads
-        let mut file_mtimes: std::collections::HashMap<PathBuf, i64> =
-            std::collections::HashMap::new();
-        let chunks: Vec<cqs::Chunk> = if force {
-            // Force mode: still need to get mtimes for storage
-            for c in &chunks {
-                if !file_mtimes.contains_key(&c.file) {
-                    let abs_path = root.join(&c.file);
-                    let mtime = abs_path
-                        .metadata()
-                        .and_then(|m| m.modified())
-                        .ok()
-                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                        .map(cqs::duration_to_mtime_millis)
-                        .unwrap_or(0);
-                    file_mtimes.insert(c.file.clone(), mtime);
-                }
-            }
-            chunks
-        } else {
-            // Cache needs_reindex results per-file to avoid redundant DB queries
-            // when multiple chunks come from the same file.
-            let mut reindex_cache: HashMap<PathBuf, Option<i64>> = HashMap::new();
-            chunks
-                .into_iter()
-                .filter(|c| {
-                    if let Some(cached) = reindex_cache.get(&c.file) {
-                        if let Some(mtime) = cached {
-                            file_mtimes.entry(c.file.clone()).or_insert(*mtime);
-                        }
-                        return cached.is_some();
-                    }
-                    let abs_path = root.join(&c.file);
-                    // needs_reindex returns Some(mtime) if reindex needed, None otherwise
-                    match store.needs_reindex(&abs_path) {
-                        Ok(Some(mtime)) => {
-                            reindex_cache.insert(c.file.clone(), Some(mtime));
-                            file_mtimes.insert(c.file.clone(), mtime);
-                            true
-                        }
-                        Ok(None) => {
-                            reindex_cache.insert(c.file.clone(), None);
-                            false
-                        }
-                        Err(e) => {
-                            tracing::warn!(file = %abs_path.display(), error = %e, "mtime check failed, reindexing");
-                            true
-                        }
-                    }
-                })
-                .collect()
-        };
-
-        // Prune relationships to only include files that passed staleness filter
-        let batch_rels = if force {
-            batch_rels
-        } else {
-            // Build set of chunk IDs that survived the staleness filter
-            let surviving_ids: std::collections::HashSet<&str> =
-                chunks.iter().map(|c| c.id.as_str()).collect();
-            RelationshipData {
-                type_refs: batch_rels
-                    .type_refs
-                    .into_iter()
-                    .filter(|(file, _)| file_mtimes.contains_key(file))
-                    .collect(),
-                function_calls: batch_rels
-                    .function_calls
-                    .into_iter()
-                    .filter(|(file, _)| file_mtimes.contains_key(file))
-                    .collect(),
-                chunk_calls: batch_rels
-                    .chunk_calls
-                    .into_iter()
-                    .filter(|(id, _)| surviving_ids.contains(id.as_str()))
-                    .collect(),
-            }
-        };
+        // No post-parse staleness filter: only survivors of the pre-filter
+        // were parsed, so every chunk and relationship here belongs to a
+        // file that needs reindexing. Every parsed file has an entry in
+        // `file_fingerprints` (the old relationship pruning by mtime map
+        // membership is therefore a guaranteed no-op and was removed).
 
         parsed_count.fetch_add(file_batch.len(), Ordering::Relaxed);
 
         if !chunks.is_empty() {
-            // Send in embedding-sized batches with per-file mtimes and relationships.
+            // Send in embedding-sized batches with per-file fingerprints and relationships.
             // Relationships are sent with the first batch only. Per-file data
             // (function_calls, type_refs) is safe. Per-chunk data (chunk_calls,
             // type_edges) is deferred in store_stage until all chunks are committed.
@@ -252,18 +341,23 @@ pub(super) fn parser_stage(
             let mut chunks = chunks;
             while !chunks.is_empty() {
                 let take = batch_size.min(chunks.len());
-                // Compute mtimes from a borrow first; `drain` below will move
-                // the same chunks out, so we can't borrow after that.
-                let batch_mtimes: std::collections::HashMap<PathBuf, i64> = chunks[..take]
+                // Compute fingerprints from a borrow first; `drain` below
+                // will move the same chunks out, so we can't borrow after
+                // that.
+                let batch_fps: std::collections::HashMap<PathBuf, FileFingerprint> = chunks[..take]
                     .iter()
-                    .filter_map(|c| file_mtimes.get(&c.file).map(|&m| (c.file.clone(), m)))
+                    .filter_map(|c| {
+                        file_fingerprints
+                            .get(&c.file)
+                            .map(|fp| (c.file.clone(), fp.clone()))
+                    })
                     .collect();
                 let batch: Vec<cqs::Chunk> = chunks.drain(..take).collect();
                 if parse_tx
                     .send(ParsedBatch {
                         chunks: batch,
                         relationships: remaining_rels.take().unwrap_or_default(),
-                        file_mtimes: batch_mtimes,
+                        file_fingerprints: batch_fps,
                     })
                     .is_err()
                 {
@@ -396,5 +490,135 @@ mod tests {
             rels_seen <= 1,
             "relationships should ride with at most one batch, saw {rels_seen}"
         );
+    }
+
+    /// Incremental (`force=false`) runs must parse ONLY files whose disk
+    /// fingerprint diverges from the stored one. The staleness pre-filter
+    /// runs BEFORE the tree-sitter parse, and there is no post-parse filter
+    /// any more — so a chunk from an unchanged file appearing in the output
+    /// would prove the file was parsed. Three cases in one pass:
+    ///
+    /// * `fresh.rs` — indexed with a fingerprint matching disk → skipped
+    /// * `new.rs` — not indexed at all → parsed
+    /// * `stale.rs` — indexed with a divergent fingerprint → parsed
+    #[test]
+    fn parser_stage_incremental_parses_only_changed_files() {
+        let _lock = super::super::types::TEST_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        std::fs::write(root.join("fresh.rs"), "pub fn fresh_fn() {}\n").unwrap();
+        std::fs::write(root.join("new.rs"), "pub fn new_fn() {}\n").unwrap();
+        std::fs::write(root.join("stale.rs"), "pub fn stale_fn() {}\n").unwrap();
+
+        let db_path = root.join("index.db");
+        let store = Arc::new(Store::open(&db_path).unwrap());
+        store.init(&cqs::store::ModelInfo::default()).unwrap();
+
+        // Helper: a minimal indexed chunk for `rel` so the origin exists.
+        let seed_chunk = |rel: &str, name: &str| cqs::Chunk {
+            id: format!("{rel}:1:seed"),
+            file: PathBuf::from(rel),
+            language: cqs::language::Language::Rust,
+            chunk_type: cqs::language::ChunkType::Function,
+            name: name.to_string(),
+            signature: format!("pub fn {name}()"),
+            content: format!("pub fn {name}() {{}}"),
+            doc: None,
+            line_start: 1,
+            line_end: 1,
+            content_hash: "seed".to_string(),
+            canonical_hash: String::new(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        };
+        let emb = cqs::Embedding::new(vec![0.5; cqs::EMBEDDING_DIM]);
+
+        // fresh.rs: stored fingerprint == disk fingerprint → must be skipped.
+        let fresh_fp = FileFingerprint::read_disk(
+            &root.join("fresh.rs"),
+            &FileFingerprint::default(),
+            FingerprintPolicy::HashOnly,
+        )
+        .expect("read fresh.rs fingerprint");
+        assert!(fresh_fp.content_hash.is_some(), "HashOnly must hash");
+        let mut fps = HashMap::new();
+        fps.insert(PathBuf::from("fresh.rs"), fresh_fp);
+        store
+            .upsert_embedded_batch(
+                &[(seed_chunk("fresh.rs", "fresh_fn"), emb.clone())],
+                &[],
+                &fps,
+            )
+            .unwrap();
+
+        // stale.rs: stored fingerprint diverges (wrong mtime+size+hash).
+        let stale_fp = cqs::store::FileFingerprint {
+            mtime: Some(1_000),
+            size: Some(1),
+            content_hash: Some(*blake3::hash(b"old content").as_bytes()),
+        };
+        let mut fps = HashMap::new();
+        fps.insert(PathBuf::from("stale.rs"), stale_fp);
+        store
+            .upsert_embedded_batch(&[(seed_chunk("stale.rs", "stale_fn"), emb)], &[], &fps)
+            .unwrap();
+
+        let rel_paths = vec![
+            PathBuf::from("fresh.rs"),
+            PathBuf::from("new.rs"),
+            PathBuf::from("stale.rs"),
+        ];
+        let (tx, rx) = unbounded::<ParsedBatch>();
+        let ctx = ParserStageContext {
+            root: root.clone(),
+            force: false,
+            parser: Arc::new(CqParser::new().unwrap()),
+            store: Arc::clone(&store),
+            parsed_count: Arc::new(AtomicUsize::new(0)),
+            parse_errors: Arc::new(AtomicUsize::new(0)),
+            model_config: cqs::embedder::ModelConfig::resolve(None, None),
+        };
+        parser_stage(rel_paths, ctx, tx).unwrap();
+
+        let batches: Vec<ParsedBatch> = rx.try_iter().collect();
+        let parsed_files: HashSet<PathBuf> = batches
+            .iter()
+            .flat_map(|b| b.chunks.iter().map(|c| c.file.clone()))
+            .collect();
+        assert!(
+            !parsed_files.contains(&PathBuf::from("fresh.rs")),
+            "unchanged file must be skipped by the pre-filter, got {parsed_files:?}"
+        );
+        assert!(
+            parsed_files.contains(&PathBuf::from("new.rs")),
+            "unindexed file must be parsed, got {parsed_files:?}"
+        );
+        assert!(
+            parsed_files.contains(&PathBuf::from("stale.rs")),
+            "divergent file must be parsed, got {parsed_files:?}"
+        );
+
+        // Every parsed file ships a fully-populated fingerprint for the
+        // store stage to stamp.
+        for b in &batches {
+            for c in &b.chunks {
+                let fp = b
+                    .file_fingerprints
+                    .get(&c.file)
+                    .unwrap_or_else(|| panic!("missing fingerprint for {:?}", c.file));
+                assert!(fp.mtime.is_some(), "{:?} fingerprint needs mtime", c.file);
+                assert!(fp.size.is_some(), "{:?} fingerprint needs size", c.file);
+                assert!(
+                    fp.content_hash.is_some(),
+                    "{:?} fingerprint needs content hash",
+                    c.file
+                );
+            }
+        }
     }
 }

--- a/src/cli/pipeline/types.rs
+++ b/src/cli/pipeline/types.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use cqs::embedder::ModelConfig;
 use cqs::parser::{CallSite, ChunkTypeRefs, FunctionCalls};
+use cqs::store::FileFingerprint;
 use cqs::{Chunk, Embedding, Store};
 
 /// Relationship data extracted during parsing, keyed by file path.
@@ -24,14 +25,19 @@ pub(super) struct RelationshipData {
 pub(super) struct ParsedBatch {
     pub chunks: Vec<Chunk>,
     pub relationships: RelationshipData,
-    pub file_mtimes: HashMap<PathBuf, i64>,
+    /// Disk fingerprint (mtime + size + BLAKE3) per file in this batch,
+    /// read by the parser stage's staleness pre-filter. The store stage
+    /// stamps these onto the chunk rows in the same transaction as the
+    /// upsert so the reconcile path always sees a populated fingerprint.
+    pub file_fingerprints: HashMap<PathBuf, FileFingerprint>,
 }
 
 pub(super) struct EmbeddedBatch {
     pub chunk_embeddings: Vec<(Chunk, Embedding)>,
     pub relationships: RelationshipData,
     pub cached_count: usize,
-    pub file_mtimes: HashMap<PathBuf, i64>,
+    /// Per-file disk fingerprints, threaded through from `ParsedBatch`.
+    pub file_fingerprints: HashMap<PathBuf, FileFingerprint>,
     /// When `true`, the chunks past index `cached_count` carry
     /// **zero-vec sentinel embeddings** and must be written via
     /// `upsert_chunks_unembedded_batch` so they're stamped with
@@ -68,8 +74,8 @@ pub(super) struct PreparedEmbedding {
     pub texts: Vec<String>,
     /// Relationships extracted during parsing
     pub relationships: RelationshipData,
-    /// File modification times (per-file)
-    pub file_mtimes: HashMap<PathBuf, i64>,
+    /// Per-file disk fingerprints (mtime + size + BLAKE3)
+    pub file_fingerprints: HashMap<PathBuf, FileFingerprint>,
 }
 
 /// Shared configuration for GPU and CPU embedding stages.

--- a/src/cli/pipeline/types.rs
+++ b/src/cli/pipeline/types.rs
@@ -39,11 +39,11 @@ pub(super) struct EmbeddedBatch {
     /// Per-file disk fingerprints, threaded through from `ParsedBatch`.
     pub file_fingerprints: HashMap<PathBuf, FileFingerprint>,
     /// When `true`, the chunks past index `cached_count` carry
-    /// **zero-vec sentinel embeddings** and must be written via
-    /// `upsert_chunks_unembedded_batch` so they're stamped with
+    /// **zero-vec sentinel embeddings** and must be routed to
+    /// `upsert_embedded_batch`'s sentinel argument so they're stamped with
     /// `needs_embedding=1`. Cached chunks (indexes `0..cached_count`)
-    /// always carry real embeddings (from the global cache) and go
-    /// through the normal upsert path.
+    /// always carry real embeddings (from the global cache) and go in the
+    /// real-embedding argument of the same call.
     ///
     /// Set by the embed stages when `EmbedStageContext.skip_first_pass_embed`
     /// is `true` AND there were `to_embed` chunks (cache misses) in the

--- a/src/cli/pipeline/upsert.rs
+++ b/src/cli/pipeline/upsert.rs
@@ -134,7 +134,6 @@ pub(super) fn store_stage(
         deferred_chunk_calls.extend(batch.relationships.chunk_calls);
 
         let batch_count = batch.chunk_embeddings.len();
-        let no_calls: Vec<(String, cqs::parser::CallSite)> = Vec::new();
 
         // Upsert chunks WITHOUT calls (calls are deferred). Also accumulate
         // per-file live IDs for the post-loop prune pass.
@@ -143,40 +142,38 @@ pub(super) fn store_stage(
         // `cached_count` carry zero-vec sentinels (skip-first-pass path
         // under `--llm-summaries`). Cached chunks still carry real
         // embeddings (from the global cache). Slice the batch and route
-        // each half to the correct upsert path so cached chunks land at
+        // each half to the correct insert mode so cached chunks land at
         // `needs_embedding=0` while sentinel chunks land at
         // `needs_embedding=1`.
+        //
+        // The whole batch — real chunks, sentinel chunks, and the per-file
+        // fingerprint stamps — writes in ONE transaction
+        // (`upsert_embedded_batch`), not one transaction per file: per-file
+        // granularity existed only because the old upsert API took a single
+        // source_mtime, and it cost a BEGIN/COMMIT + content-hash snapshot
+        // SELECT per file. Chunk-level atomicity is preserved: a crash may
+        // lose whole uncommitted batches, but chunks and their FTS rows
+        // always commit together. (The watch path keeps its own per-file
+        // fused tx — see `upsert_chunks_calls_and_prune` — because a daemon
+        // tick must commit chunks + calls + function_calls + prune per file
+        // as one unit.)
         let cached_slice_end = batch.cached_count.min(batch.chunk_embeddings.len());
-        let mut by_file_real: HashMap<PathBuf, Vec<(Chunk, Embedding)>> = HashMap::new();
-        let mut by_file_sentinel: HashMap<PathBuf, Vec<Chunk>> = HashMap::new();
+        let mut real_pairs: Vec<(Chunk, Embedding)> = Vec::new();
+        let mut sentinel_chunks: Vec<Chunk> = Vec::new();
         for (i, (chunk, embedding)) in batch.chunk_embeddings.into_iter().enumerate() {
             live_ids_per_file
                 .entry(chunk.file.clone())
                 .or_default()
                 .insert(chunk.id.clone());
             if i < cached_slice_end || !batch.uncached_need_embedding {
-                by_file_real
-                    .entry(chunk.file.clone())
-                    .or_default()
-                    .push((chunk, embedding));
+                real_pairs.push((chunk, embedding));
             } else {
                 // Past cached_count and skip-first-pass mode is on — chunk
-                // carries a zero-vec sentinel; route to the unembedded upsert.
-                by_file_sentinel
-                    .entry(chunk.file.clone())
-                    .or_default()
-                    .push(chunk);
+                // carries a zero-vec sentinel; route to the unembedded mode.
+                sentinel_chunks.push(chunk);
             }
         }
-
-        for (file, pairs) in &by_file_real {
-            let mtime = batch.file_mtimes.get(file.as_path()).copied();
-            store.upsert_chunks_and_calls(pairs, mtime, &no_calls)?;
-        }
-        for (file, chunks) in &by_file_sentinel {
-            let mtime = batch.file_mtimes.get(file.as_path()).copied();
-            store.upsert_chunks_unembedded_batch(chunks, mtime)?;
-        }
+        store.upsert_embedded_batch(&real_pairs, &sentinel_chunks, &batch.file_fingerprints)?;
 
         // Store function calls extracted during parsing (for the
         // `function_calls` table). Defer-and-batch like type edges: a
@@ -243,27 +240,34 @@ pub(super) fn store_stage(
     // `cqs index --force` after a chunker bump doesn't accumulate orphans.
     // Runs before the deferred call/edge flushes so any FK-cascading delete
     // from `chunks` happens before fresh calls reference the new IDs.
-    let mut total_orphans_pruned: u32 = 0;
-    for (file, live_ids) in &live_ids_per_file {
-        let live_ids_vec: Vec<&str> = live_ids.iter().map(|s| s.as_str()).collect();
-        match store.delete_phantom_chunks(file.as_path(), &live_ids_vec) {
-            Ok(deleted) => {
-                total_orphans_pruned += deleted;
-            }
-            Err(e) => {
-                tracing::warn!(
-                    file = %file.display(),
-                    error = %e,
-                    "delete_phantom_chunks failed; orphan rows from prior chunker versions may persist for this file"
-                );
-            }
+    //
+    // One transaction for the whole sweep — the per-file variant opened a
+    // BEGIN/COMMIT per origin, thousands of round-trips of pure overhead
+    // on a full reindex.
+    let prune_entries: Vec<(&std::path::Path, Vec<&str>)> = live_ids_per_file
+        .iter()
+        .map(|(file, live_ids)| {
+            (
+                file.as_path(),
+                live_ids.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
+            )
+        })
+        .collect();
+    match store.delete_phantom_chunks_batch(&prune_entries) {
+        Ok(deleted) if deleted > 0 => {
+            tracing::info!(
+                count = deleted,
+                "Pruned phantom chunks from prior chunker versions"
+            );
         }
-    }
-    if total_orphans_pruned > 0 {
-        tracing::info!(
-            count = total_orphans_pruned,
-            "Pruned phantom chunks from prior chunker versions (#1283)"
-        );
+        Ok(_) => {}
+        Err(e) => {
+            tracing::warn!(
+                files = prune_entries.len(),
+                error = %e,
+                "Batched phantom prune failed; orphan rows from prior chunker versions may persist"
+            );
+        }
     }
 
     // Final flush: insert any remaining deferred items now that all chunks

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -1224,7 +1224,11 @@ mod tests {
             ChunkType::Function,
         );
         store
-            .upsert_chunks_unembedded_batch(std::slice::from_ref(&chunk), Some(12345))
+            .upsert_embedded_batch(
+                &[],
+                std::slice::from_ref(&chunk),
+                &std::collections::HashMap::new(),
+            )
             .unwrap();
 
         let emb = mock_embedding(1.0);

--- a/src/store/chunks/async_helpers.rs
+++ b/src/store/chunks/async_helpers.rs
@@ -317,7 +317,13 @@ pub(super) async fn snapshot_content_hashes(
 /// wiping those columns back to NULL/default.
 ///
 /// The WHERE clause on content_hash skips the UPDATE when the content is
-/// unchanged, avoiding unnecessary write amplification.
+/// unchanged, avoiding unnecessary write amplification. Note this means a
+/// row's `source_mtime` is NOT refreshed when content is unchanged — the
+/// multi-file pipeline write path (`upsert_embedded_batch`) follows up with
+/// a per-file fingerprint UPDATE in the same transaction to cover that case.
+///
+/// `source_mtimes` aligns 1:1 with `chunks` so a single statement can span
+/// files with different mtimes.
 ///
 /// `embedding_base` is seeded with the same bytes as `embedding` on initial
 /// insert. The incoming embedding is generated from `generate_nl_description`
@@ -329,7 +335,7 @@ pub(super) async fn batch_insert_chunks(
     chunks: &[(Chunk, Embedding)],
     embedding_bytes: &[Vec<u8>],
     vendored_per_chunk: &[bool],
-    source_mtime: Option<i64>,
+    source_mtimes: &[Option<i64>],
     now: &str,
     needs_embedding: bool,
 ) -> Result<(), StoreError> {
@@ -340,6 +346,11 @@ pub(super) async fn batch_insert_chunks(
         chunks.len(),
         vendored_per_chunk.len(),
         "vendored_per_chunk must align 1:1 with chunks"
+    );
+    debug_assert_eq!(
+        chunks.len(),
+        source_mtimes.len(),
+        "source_mtimes must align 1:1 with chunks"
     );
     let needs_embedding_i64: i64 = if needs_embedding { 1 } else { 0 };
     for (batch_idx, batch) in chunks.chunks(CHUNK_INSERT_BATCH).enumerate() {
@@ -380,7 +391,7 @@ pub(super) async fn batch_insert_chunks(
                 } else {
                     Some(embedding_bytes[emb_offset + i].as_slice())
                 })
-                .push_bind(source_mtime)
+                .push_bind(source_mtimes[emb_offset + i])
                 .push_bind(now)
                 .push_bind(now)
                 .push_bind(&chunk.parent_id)

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -171,33 +171,33 @@ impl<Mode> Store<Mode> {
             Ok(rows)
         })
     }
+}
 
-    /// Check if a file needs reindexing based on mtime.
-    ///
-    /// Returns `Ok(Some(mtime))` if reindex needed (with the file's current mtime),
-    /// or `Ok(None)` if no reindex needed. This avoids reading file metadata twice.
-    pub fn needs_reindex(&self, path: &Path) -> Result<Option<i64>, StoreError> {
-        let _span = tracing::debug_span!("needs_reindex", path = %path.display()).entered();
-        let current_mtime = crate::duration_to_mtime_millis(
-            path.metadata()?
-                .modified()?
-                .duration_since(std::time::UNIX_EPOCH)
-                .map_err(|_| StoreError::SystemTime)?,
-        );
-
-        self.rt.block_on(async {
-            let row: Option<(Option<i64>,)> =
-                sqlx::query_as("SELECT source_mtime FROM chunks WHERE origin = ?1 LIMIT 1")
-                    .bind(crate::normalize_path(path))
-                    .fetch_optional(&self.pool)
-                    .await?;
-
-            match row {
-                Some((Some(stored_mtime),)) if stored_mtime >= current_mtime => Ok(None),
-                _ => Ok(Some(current_mtime)),
-            }
-        })
-    }
+/// Write the reconcile fingerprint columns for one origin inside an open
+/// transaction. Shared by [`Store::set_file_fingerprint`] (own tx, watch
+/// path), [`Store::set_file_fingerprints_batch`] (one tx, many files), and
+/// [`Store::upsert_embedded_batch`] (stamp fused into the chunk-write tx).
+///
+/// `origin_str` must already be slash-normalized via `crate::normalize_path`.
+async fn set_fingerprint_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    origin_str: &str,
+    fp: &crate::store::chunks::staleness::FileFingerprint,
+) -> Result<u64, StoreError> {
+    let size_i64: Option<i64> = fp.size.and_then(|s| i64::try_from(s).ok());
+    let hash_blob: Option<Vec<u8>> = fp.content_hash.map(|h| h.to_vec());
+    let result = sqlx::query(
+        "UPDATE chunks \
+         SET source_mtime = ?1, source_size = ?2, source_content_hash = ?3 \
+         WHERE origin = ?4",
+    )
+    .bind(fp.mtime)
+    .bind(size_i64)
+    .bind(hash_blob)
+    .bind(origin_str)
+    .execute(&mut **tx)
+    .await?;
+    Ok(result.rows_affected())
 }
 
 // Write methods live on `impl Store<ReadWrite>` — the compiler refuses to
@@ -253,6 +253,7 @@ impl Store<ReadWrite> {
             })
             .collect();
 
+        let source_mtimes = vec![source_mtime; chunks.len()];
         self.rt.block_on(async {
             let (_guard, mut tx) = self.begin_write().await?;
             let old_hashes = snapshot_content_hashes(&mut tx, chunks).await?;
@@ -262,7 +263,7 @@ impl Store<ReadWrite> {
                 chunks,
                 &embedding_bytes,
                 &vendored_per_chunk,
-                source_mtime,
+                &source_mtimes,
                 &now,
                 false, // real embeddings → needs_embedding=0
             )
@@ -321,6 +322,7 @@ impl Store<ReadWrite> {
             })
             .collect();
 
+        let source_mtimes = vec![source_mtime; chunks.len()];
         self.rt.block_on(async {
             let (_guard, mut tx) = self.begin_write().await?;
             let old_hashes = snapshot_content_hashes(&mut tx, &chunks_with_zero).await?;
@@ -330,7 +332,7 @@ impl Store<ReadWrite> {
                 &chunks_with_zero,
                 &embedding_bytes,
                 &vendored_per_chunk,
-                source_mtime,
+                &source_mtimes,
                 &now,
                 true, // zero-vec sentinel → needs_embedding=1
             )
@@ -824,9 +826,11 @@ impl Store<ReadWrite> {
     /// reconciliation (`run_daemon_reconcile`) fall back to BLAKE3 when
     /// mtime/size alone is unreliable (coarse-mtime FAT32/NTFS/HFS+/SMB;
     /// `git checkout` and formatter passes that bump mtime without changing
-    /// content). Both production write paths (`cli/pipeline/upsert.rs` and
-    /// `cli/watch/reindex.rs`) call this helper after their chunk upsert so
-    /// the next reconcile pass sees a populated fingerprint.
+    /// content). The watch reindex path (`cli/watch/reindex.rs`) calls this
+    /// helper after its per-file chunk upsert; the bulk pipeline
+    /// (`cli/pipeline/upsert.rs`) stamps fingerprints inside the chunk-write
+    /// transaction via [`Self::upsert_embedded_batch`] instead, so both
+    /// production paths leave populated fingerprints for the next reconcile.
     ///
     /// `None` fields stay NULL; callers that can't read disk pass a
     /// fingerprint with all three set to `None` and get mtime-only behavior.
@@ -845,44 +849,182 @@ impl Store<ReadWrite> {
         let _span =
             tracing::debug_span!("set_file_fingerprint", origin = %origin.display()).entered();
         let origin_str = crate::normalize_path(origin);
-        let size_i64: Option<i64> = fp.size.and_then(|s| i64::try_from(s).ok());
-        let hash_blob: Option<Vec<u8>> = fp.content_hash.map(|h| h.to_vec());
-
         self.rt.block_on(async {
             let (_guard, mut tx) = self.begin_write().await?;
-            let result = sqlx::query(
-                "UPDATE chunks \
-                 SET source_mtime = ?1, source_size = ?2, source_content_hash = ?3 \
-                 WHERE origin = ?4",
-            )
-            .bind(fp.mtime)
-            .bind(size_i64)
-            .bind(hash_blob)
-            .bind(&origin_str)
-            .execute(&mut *tx)
-            .await?;
+            let rows = set_fingerprint_in_tx(&mut tx, &origin_str, fp).await?;
             tx.commit().await?;
-            Ok(result.rows_affected() as u32)
+            Ok(rows as u32)
         })
     }
 
-    /// Atomically upsert chunks and their call graph in a single transaction.
+    /// Refresh the reconcile fingerprint for many origins in one write
+    /// transaction.
     ///
-    /// Combines chunk upsert (with FTS) and call graph upsert into one transaction,
-    /// preventing inconsistency from crashes between separate operations.
-    /// Chunks are inserted in batches of 52 rows (52 * 19 = 988 < SQLite's 999 limit).
+    /// Used by the pipeline's staleness pre-filter when a file's mtime/size
+    /// moved but the BLAKE3 tiebreak proved the content identical (`git
+    /// checkout`, formatter no-op, `touch`): the chunks need no reindex, but
+    /// without refreshing the stored fingerprint every subsequent index run
+    /// and daemon reconcile pass would re-hash the file to reach the same
+    /// conclusion. One transaction for the whole batch — this path can see
+    /// hundreds of files after a branch flip.
     ///
-    /// Convenience wrapper around [`Self::upsert_chunks_calls_and_prune`] without
-    /// phantom-chunk pruning. Callers that know the full live-id set for a file
-    /// (e.g. the watch loop) should call `upsert_chunks_calls_and_prune`
-    /// directly so the upsert + phantom delete share one transaction.
-    pub fn upsert_chunks_and_calls(
+    /// Returns the total number of chunk rows updated.
+    pub fn set_file_fingerprints_batch(
         &self,
-        chunks: &[(Chunk, Embedding)],
-        source_mtime: Option<i64>,
-        calls: &[(String, crate::parser::CallSite)],
+        entries: &[(
+            std::path::PathBuf,
+            crate::store::chunks::staleness::FileFingerprint,
+        )],
+    ) -> Result<u64, StoreError> {
+        let _span =
+            tracing::info_span!("set_file_fingerprints_batch", files = entries.len()).entered();
+        if entries.is_empty() {
+            return Ok(0);
+        }
+        self.rt.block_on(async {
+            let (_guard, mut tx) = self.begin_write().await?;
+            let mut total = 0u64;
+            for (path, fp) in entries {
+                total += set_fingerprint_in_tx(&mut tx, &crate::normalize_path(path), fp).await?;
+            }
+            tx.commit().await?;
+            Ok(total)
+        })
+    }
+
+    /// Atomically upsert one pipeline batch — real-embedding chunks plus
+    /// zero-vec sentinel chunks, spanning any number of files — in a single
+    /// write transaction, and stamp each file's reconcile fingerprint
+    /// (`source_mtime`, `source_size`, `source_content_hash`) in the same
+    /// transaction.
+    ///
+    /// This is the bulk-pipeline (`cqs index`) write path. One transaction
+    /// per embedded batch replaces the old transaction-per-file loop, which
+    /// paid a BEGIN/COMMIT plus a content-hash snapshot SELECT per file
+    /// (tens of thousands of transactions of pure overhead on a large
+    /// corpus). Crash-atomicity contract: a crash mid-index may lose whole
+    /// uncommitted batches, but the chunks, FTS rows, and fingerprints that
+    /// DID land always committed together — the index is never left with a
+    /// chunk/FTS desync for the rows it contains. (The watch path keeps its
+    /// own per-file fused transaction in `upsert_chunks_calls_and_prune` —
+    /// that boundary is deliberate: a daemon tick must commit each file's
+    /// chunks + calls + function_calls + prune as one unit.)
+    ///
+    /// `sentinel` chunks are written via the same zero-vec
+    /// `needs_embedding=1` contract as [`Self::upsert_chunks_unembedded_batch`]
+    /// (skip-first-pass under `--llm-summaries`); `real` chunks land at
+    /// `needs_embedding=0`.
+    ///
+    /// `fingerprints` is keyed by `Chunk::file`. Per-row `source_mtime` binds
+    /// come from the matching fingerprint; files absent from the map get
+    /// NULL mtime and no fingerprint stamp (degraded mtime-only behavior).
+    /// The stamp runs as an `UPDATE … WHERE origin = ?` *after* the row
+    /// upserts so it also covers rows the `ON CONFLICT … WHERE`
+    /// short-circuit skipped (content unchanged, mtime bumped) — a stored
+    /// `source_content_hash` therefore never describes a previous content
+    /// version of the file.
+    pub fn upsert_embedded_batch(
+        &self,
+        real: &[(Chunk, Embedding)],
+        sentinel: &[Chunk],
+        fingerprints: &std::collections::HashMap<
+            std::path::PathBuf,
+            crate::store::chunks::staleness::FileFingerprint,
+        >,
     ) -> Result<usize, StoreError> {
-        self.upsert_chunks_calls_and_prune(chunks, source_mtime, calls, None, &[])
+        let _span = tracing::info_span!(
+            "upsert_embedded_batch",
+            real = real.len(),
+            sentinel = sentinel.len(),
+            files = fingerprints.len()
+        )
+        .entered();
+        if real.is_empty() && sentinel.is_empty() {
+            return Ok(0);
+        }
+
+        let dim = self.dim;
+        let real_bytes: Vec<Vec<u8>> = real
+            .iter()
+            .map(|(_, emb)| embedding_to_bytes(emb, dim))
+            .collect::<Result<Vec<_>, _>>()?;
+        let zero_vec = Embedding::new(vec![0.0_f32; dim]);
+        let sentinel_pairs: Vec<(Chunk, Embedding)> = sentinel
+            .iter()
+            .map(|c| (c.clone(), zero_vec.clone()))
+            .collect();
+        let sentinel_bytes: Vec<Vec<u8>> = sentinel_pairs
+            .iter()
+            .map(|(_, emb)| embedding_to_bytes(emb, dim))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let prefixes = self.vendored_prefixes_slice();
+        let vendored_for = |chunk: &Chunk| {
+            let origin = crate::normalize_path(&chunk.file);
+            crate::vendored::is_vendored_origin(&origin, prefixes)
+        };
+        let real_vendored: Vec<bool> = real.iter().map(|(c, _)| vendored_for(c)).collect();
+        let sentinel_vendored: Vec<bool> = sentinel_pairs
+            .iter()
+            .map(|(c, _)| vendored_for(c))
+            .collect();
+
+        let mtime_for = |chunk: &Chunk| fingerprints.get(&chunk.file).and_then(|fp| fp.mtime);
+        let real_mtimes: Vec<Option<i64>> = real.iter().map(|(c, _)| mtime_for(c)).collect();
+        let sentinel_mtimes: Vec<Option<i64>> =
+            sentinel_pairs.iter().map(|(c, _)| mtime_for(c)).collect();
+
+        // Only stamp fingerprints for files actually present in this batch's
+        // chunk sets. The embed stages clone the batch-level fingerprint map
+        // to both the cached and requeued halves of a GPU-failure split, so
+        // the map can mention files whose chunks travel in a different
+        // `EmbeddedBatch` — stamping those early would mark a file fresh
+        // before its rows landed.
+        let batch_files: std::collections::HashSet<&std::path::PathBuf> = real
+            .iter()
+            .map(|(c, _)| &c.file)
+            .chain(sentinel.iter().map(|c| &c.file))
+            .collect();
+
+        self.rt.block_on(async {
+            let (_guard, mut tx) = self.begin_write().await?;
+            let now = chrono::Utc::now().to_rfc3339();
+            if !real.is_empty() {
+                let old_hashes = snapshot_content_hashes(&mut tx, real).await?;
+                batch_insert_chunks(
+                    &mut tx,
+                    real,
+                    &real_bytes,
+                    &real_vendored,
+                    &real_mtimes,
+                    &now,
+                    false, // real embeddings → needs_embedding=0
+                )
+                .await?;
+                upsert_fts_conditional(&mut tx, real, &old_hashes).await?;
+            }
+            if !sentinel_pairs.is_empty() {
+                let old_hashes = snapshot_content_hashes(&mut tx, &sentinel_pairs).await?;
+                batch_insert_chunks(
+                    &mut tx,
+                    &sentinel_pairs,
+                    &sentinel_bytes,
+                    &sentinel_vendored,
+                    &sentinel_mtimes,
+                    &now,
+                    true, // zero-vec sentinel → needs_embedding=1
+                )
+                .await?;
+                upsert_fts_conditional(&mut tx, &sentinel_pairs, &old_hashes).await?;
+            }
+            for file in batch_files {
+                if let Some(fp) = fingerprints.get(file) {
+                    set_fingerprint_in_tx(&mut tx, &crate::normalize_path(file), fp).await?;
+                }
+            }
+            tx.commit().await?;
+            Ok(real.len() + sentinel_pairs.len())
+        })
     }
 
     /// Atomically upsert chunks + calls AND prune phantom chunks for a file,
@@ -989,6 +1131,7 @@ impl Store<ReadWrite> {
             })
             .collect();
 
+        let source_mtimes = vec![source_mtime; chunks.len()];
         self.rt.block_on(async {
             let (_guard, mut tx) = self.begin_write().await?;
             let old_hashes = snapshot_content_hashes(&mut tx, chunks).await?;
@@ -998,7 +1141,7 @@ impl Store<ReadWrite> {
                 chunks,
                 &embedding_bytes,
                 &vendored_per_chunk,
-                source_mtime,
+                &source_mtimes,
                 &now,
                 false, // real embeddings → needs_embedding=0
             )
@@ -1235,6 +1378,113 @@ impl Store<ReadWrite> {
                 tracing::info!(origin = %origin_str, deleted, "Removed phantom chunks");
             }
             Ok(deleted)
+        })
+    }
+
+    /// Prune phantom chunks for many files in ONE write transaction.
+    ///
+    /// Batched form of [`Self::delete_phantom_chunks`] for the bulk pipeline's
+    /// post-loop prune pass: the per-file variant opens a transaction per
+    /// origin, which on a multi-thousand-file reindex is thousands of
+    /// BEGIN/COMMIT round-trips of pure overhead. Same temp-table pattern
+    /// per file, single commit for the whole sweep.
+    ///
+    /// An entry with empty `live_ids` deletes every chunk for that origin
+    /// (FTS + chunks). Unlike `delete_phantom_chunks`'s delegation to
+    /// `delete_by_origin`, no `function_calls` DELETE is issued here — the
+    /// pipeline's `upsert_function_calls_for_files` already
+    /// DELETE-then-INSERTed the current set for every file it touched (same
+    /// reasoning as the fused-tx prune in `upsert_chunks_calls_and_prune`).
+    ///
+    /// Returns the total number of chunk rows deleted across all files.
+    pub fn delete_phantom_chunks_batch(
+        &self,
+        files: &[(&std::path::Path, Vec<&str>)],
+    ) -> Result<u32, StoreError> {
+        let _span =
+            tracing::info_span!("delete_phantom_chunks_batch", files = files.len()).entered();
+        if files.is_empty() {
+            return Ok(0);
+        }
+
+        self.rt.block_on(async {
+            let (_guard, mut tx) = self.begin_write().await?;
+
+            // Temp table created once, cleared per file. Same SQLite
+            // 999-parameter-limit rationale as `delete_phantom_chunks`.
+            sqlx::query("CREATE TEMP TABLE IF NOT EXISTS _live_ids (id TEXT PRIMARY KEY)")
+                .execute(&mut *tx)
+                .await?;
+
+            let mut deleted_total = 0u32;
+            for (file, live_ids) in files {
+                let origin_str = crate::normalize_path(file);
+
+                if live_ids.is_empty() {
+                    // Whole file emptied — delete every chunk for the origin.
+                    sqlx::query(
+                        "DELETE FROM chunks_fts WHERE id IN \
+                         (SELECT id FROM chunks WHERE origin = ?1)",
+                    )
+                    .bind(&origin_str)
+                    .execute(&mut *tx)
+                    .await?;
+                    let result = sqlx::query("DELETE FROM chunks WHERE origin = ?1")
+                        .bind(&origin_str)
+                        .execute(&mut *tx)
+                        .await?;
+                    deleted_total += result.rows_affected() as u32;
+                    continue;
+                }
+
+                sqlx::query("DELETE FROM _live_ids")
+                    .execute(&mut *tx)
+                    .await?;
+                for batch in live_ids.chunks(crate::store::helpers::sql::max_rows_per_statement(1))
+                {
+                    let placeholders: Vec<String> = batch
+                        .iter()
+                        .enumerate()
+                        .map(|(i, _)| format!("(?{})", i + 1))
+                        .collect();
+                    let insert_sql = format!(
+                        "INSERT OR IGNORE INTO _live_ids (id) VALUES {}",
+                        placeholders.join(",")
+                    );
+                    let mut stmt = sqlx::query(sqlx::AssertSqlSafe(insert_sql.as_str()));
+                    for id in batch {
+                        stmt = stmt.bind(id);
+                    }
+                    stmt.execute(&mut *tx).await?;
+                }
+
+                let fts_query = "DELETE FROM chunks_fts WHERE id IN \
+                     (SELECT id FROM chunks WHERE origin = ?1 \
+                      AND id NOT IN (SELECT id FROM _live_ids))";
+                sqlx::query(fts_query)
+                    .bind(&origin_str)
+                    .execute(&mut *tx)
+                    .await?;
+
+                let chunks_query = "DELETE FROM chunks WHERE origin = ?1 \
+                     AND id NOT IN (SELECT id FROM _live_ids)";
+                let result = sqlx::query(chunks_query)
+                    .bind(&origin_str)
+                    .execute(&mut *tx)
+                    .await?;
+                let deleted = result.rows_affected() as u32;
+                if deleted > 0 {
+                    tracing::info!(
+                        origin = %origin_str,
+                        deleted,
+                        "Removed phantom chunks (batched tx)"
+                    );
+                }
+                deleted_total += deleted;
+            }
+
+            tx.commit().await?;
+            Ok(deleted_total)
         })
     }
 }
@@ -2177,6 +2427,249 @@ mod tests {
             1,
             "file2.rs chunk should remain"
         );
+    }
+
+    // ===== upsert_embedded_batch tests =====
+
+    fn full_fp(mtime: i64, size: u64, bytes: &[u8]) -> crate::store::FileFingerprint {
+        crate::store::FileFingerprint {
+            mtime: Some(mtime),
+            size: Some(size),
+            content_hash: Some(*blake3::hash(bytes).as_bytes()),
+        }
+    }
+
+    /// The bulk-pipeline write path must stamp the full reconcile
+    /// fingerprint (mtime + size + BLAKE3) for every file in the batch, in
+    /// the same call as the chunk upsert. This is the CLI-path half of the
+    /// fingerprint contract — previously only the watch daemon stamped
+    /// these columns and CLI-indexed rows fell back to mtime-only
+    /// staleness on coarse-mtime filesystems.
+    #[test]
+    fn upsert_embedded_batch_stamps_fingerprints() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        let (store, _dir) = setup_store();
+        let c1 = make_chunk("alpha", "src/a.rs");
+        let c2 = make_chunk("beta", "src/b.rs");
+        let emb = mock_embedding(1.0);
+
+        let fp_a = full_fp(1_000, 42, b"a-bytes");
+        let fp_b = full_fp(2_000, 7, b"b-bytes");
+        let mut fps = HashMap::new();
+        fps.insert(PathBuf::from("src/a.rs"), fp_a.clone());
+        fps.insert(PathBuf::from("src/b.rs"), fp_b.clone());
+
+        let n = store
+            .upsert_embedded_batch(&[(c1.clone(), emb.clone()), (c2.clone(), emb)], &[], &fps)
+            .unwrap();
+        assert_eq!(n, 2);
+
+        // Read the columns back through the reconcile read path.
+        let map = store.indexed_file_origins().unwrap();
+        let stored_a = map.get("src/a.rs").expect("origin a present");
+        let stored_b = map.get("src/b.rs").expect("origin b present");
+        assert_eq!(stored_a, &fp_a, "size+hash must be non-NULL and correct");
+        assert_eq!(stored_b, &fp_b, "size+hash must be non-NULL and correct");
+
+        // FTS landed in the same transaction.
+        let hits = store.search_by_name("alpha", 5).unwrap();
+        assert!(hits.iter().any(|h| h.chunk.name == "alpha"));
+    }
+
+    /// A content change through `upsert_embedded_batch` must replace the
+    /// stored fingerprint — a stored `source_content_hash` may never
+    /// describe a previous content version. Also covers the
+    /// `ON CONFLICT … WHERE` short-circuit: a re-upsert with UNCHANGED
+    /// content (mtime bump only) skips the row UPDATE, but the fingerprint
+    /// stamp must still land.
+    #[test]
+    fn upsert_embedded_batch_refreshes_fingerprint_on_change_and_on_skip() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        let (store, _dir) = setup_store();
+        let mut chunk = make_chunk("evolving", "src/e.rs");
+        let file = PathBuf::from("src/e.rs");
+
+        let fp_v1 = full_fp(1_000, 10, b"v1");
+        let mut fps = HashMap::new();
+        fps.insert(file.clone(), fp_v1.clone());
+        store
+            .upsert_embedded_batch(&[(chunk.clone(), mock_embedding(0.1))], &[], &fps)
+            .unwrap();
+        assert_eq!(
+            store.indexed_file_origins().unwrap().get("src/e.rs"),
+            Some(&fp_v1)
+        );
+
+        // Content changed → row updates AND fingerprint replaced.
+        chunk.content = "fn evolving() { /* changed */ }".to_string();
+        chunk.content_hash = "new-hash-v2".to_string();
+        let fp_v2 = full_fp(2_000, 31, b"v2");
+        fps.insert(file.clone(), fp_v2.clone());
+        store
+            .upsert_embedded_batch(&[(chunk.clone(), mock_embedding(0.2))], &[], &fps)
+            .unwrap();
+        assert_eq!(
+            store.indexed_file_origins().unwrap().get("src/e.rs"),
+            Some(&fp_v2),
+            "content change must replace the stored fingerprint"
+        );
+
+        // Content unchanged, mtime bumped → ON CONFLICT WHERE skips the row
+        // UPDATE, but the fingerprint stamp still refreshes all three
+        // columns.
+        let fp_v3 = full_fp(3_000, 31, b"v2");
+        fps.insert(file.clone(), fp_v3.clone());
+        store
+            .upsert_embedded_batch(&[(chunk.clone(), mock_embedding(0.2))], &[], &fps)
+            .unwrap();
+        assert_eq!(
+            store.indexed_file_origins().unwrap().get("src/e.rs"),
+            Some(&fp_v3),
+            "fingerprint must refresh even when the ON CONFLICT WHERE skips the row"
+        );
+    }
+
+    /// One call writes real-embedding chunks AND zero-vec sentinel chunks
+    /// (skip-first-pass under `--llm-summaries`) with the correct
+    /// `needs_embedding` flags, in a single transaction, with fingerprints
+    /// for both files. Pins the sentinel contract the reuse resolver and
+    /// `enrichment_pass` depend on.
+    #[test]
+    fn upsert_embedded_batch_mixed_real_and_sentinel() {
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+        let (store, _dir) = setup_store();
+        let c_real = make_chunk("real_fn", "src/r.rs");
+        let c_sent = make_chunk("sent_fn", "src/s.rs");
+
+        let mut fps = HashMap::new();
+        fps.insert(PathBuf::from("src/r.rs"), full_fp(100, 1, b"r"));
+        fps.insert(PathBuf::from("src/s.rs"), full_fp(200, 2, b"s"));
+
+        let n = store
+            .upsert_embedded_batch(
+                &[(c_real.clone(), mock_embedding(1.0))],
+                std::slice::from_ref(&c_sent),
+                &fps,
+            )
+            .unwrap();
+        assert_eq!(n, 2);
+
+        // Sentinel chunk flagged needs_embedding=1; real chunk not.
+        assert_eq!(store.needs_embedding_count().unwrap(), 1);
+        let ids = store.needs_embedding_ids().unwrap();
+        assert!(ids.contains(&c_sent.id));
+        assert!(!ids.contains(&c_real.id));
+
+        // Sentinel invisible to the gated by-hash reuse lookup; real visible.
+        let embs = store
+            .get_embeddings_by_hashes(&[&c_real.content_hash, &c_sent.content_hash])
+            .unwrap();
+        assert!(embs.contains_key(&c_real.content_hash));
+        assert!(!embs.contains_key(&c_sent.content_hash));
+
+        // Both files got fingerprints.
+        let map = store.indexed_file_origins().unwrap();
+        assert!(map.get("src/r.rs").unwrap().content_hash.is_some());
+        assert!(map.get("src/s.rs").unwrap().content_hash.is_some());
+    }
+
+    /// Empty batch is a no-op.
+    #[test]
+    fn upsert_embedded_batch_empty_is_noop() {
+        let (store, _dir) = setup_store();
+        let n = store
+            .upsert_embedded_batch(&[], &[], &std::collections::HashMap::new())
+            .unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(store.chunk_count().unwrap(), 0);
+    }
+
+    // ===== set_file_fingerprints_batch =====
+
+    /// Batched fingerprint refresh writes all entries under one call and
+    /// round-trips through `indexed_file_origins`. Used by the pipeline's
+    /// staleness pre-filter for mtime-bumped content-identical files.
+    #[test]
+    fn set_file_fingerprints_batch_round_trips() {
+        use std::path::PathBuf;
+        let (store, _dir) = setup_store();
+        let c1 = make_chunk("a", "src/a.rs");
+        let c2 = make_chunk("b", "src/b.rs");
+        store
+            .upsert_chunks_batch(
+                &[(c1, mock_embedding(1.0)), (c2, mock_embedding(2.0))],
+                Some(100),
+            )
+            .unwrap();
+
+        let entries = vec![
+            (PathBuf::from("src/a.rs"), full_fp(1_111, 5, b"aa")),
+            (PathBuf::from("src/b.rs"), full_fp(2_222, 6, b"bb")),
+        ];
+        let rows = store.set_file_fingerprints_batch(&entries).unwrap();
+        assert_eq!(rows, 2, "one chunk row per file must be updated");
+
+        let map = store.indexed_file_origins().unwrap();
+        assert_eq!(map.get("src/a.rs"), Some(&entries[0].1));
+        assert_eq!(map.get("src/b.rs"), Some(&entries[1].1));
+    }
+
+    // ===== delete_phantom_chunks_batch =====
+
+    /// Batched prune removes phantoms across multiple files in one call
+    /// (single transaction), leaves live chunks intact, and handles the
+    /// empty-live-ids "file emptied" case inline.
+    #[test]
+    fn delete_phantom_chunks_batch_prunes_across_files() {
+        let (store, _dir) = setup_store();
+        let emb = mock_embedding(1.0);
+        let a1 = make_chunk("a1", "f1.rs");
+        let a2 = make_chunk("a2", "f1.rs");
+        let b1 = make_chunk("b1", "f2.rs");
+        let b2 = make_chunk("b2", "f2.rs");
+        let c1 = make_chunk("c1", "f3.rs");
+        let a1_id = a1.id.clone();
+        let b2_id = b2.id.clone();
+        store
+            .upsert_chunks_batch(
+                &[
+                    (a1, emb.clone()),
+                    (a2, emb.clone()),
+                    (b1, emb.clone()),
+                    (b2, emb.clone()),
+                    (c1, emb.clone()),
+                ],
+                Some(100),
+            )
+            .unwrap();
+
+        let files: Vec<(&std::path::Path, Vec<&str>)> = vec![
+            (std::path::Path::new("f1.rs"), vec![a1_id.as_str()]),
+            (std::path::Path::new("f2.rs"), vec![b2_id.as_str()]),
+            (std::path::Path::new("f3.rs"), vec![]), // file emptied
+        ];
+        let deleted = store.delete_phantom_chunks_batch(&files).unwrap();
+        assert_eq!(deleted, 3, "a2 + b1 + c1 must be pruned");
+        assert_eq!(store.chunk_count().unwrap(), 2);
+
+        // FTS rows for pruned chunks are gone in the same transaction.
+        assert!(store.search_by_name("a2", 5).unwrap().is_empty());
+        assert!(store
+            .search_by_name("a1", 5)
+            .unwrap()
+            .iter()
+            .any(|h| h.chunk.name == "a1"));
+    }
+
+    /// Empty input is a no-op.
+    #[test]
+    fn delete_phantom_chunks_batch_empty_is_noop() {
+        let (store, _dir) = setup_store();
+        let deleted = store.delete_phantom_chunks_batch(&[]).unwrap();
+        assert_eq!(deleted, 0);
     }
 
     // ===== update_umap_coords_batch happy path =====

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -274,75 +274,6 @@ impl Store<ReadWrite> {
         })
     }
 
-    /// Insert chunks without a real embedding. Each row gets a
-    /// zero-vec sentinel in the `embedding` column and `needs_embedding=1`,
-    /// signaling that `enrichment_pass` must overwrite the embedding before
-    /// the chunk becomes visible to HNSW build / search hydration.
-    ///
-    /// Used by the indexing pipeline when `--llm-summaries` is set: the
-    /// first-pass embed would just be overwritten by the post-summary
-    /// enrichment re-embed, so we skip it entirely. On a fresh
-    /// `cqs index --force --llm-summaries` for a 12k-chunk corpus this
-    /// halves the GPU time spent embedding.
-    ///
-    /// Failure modes: an interrupted enrichment pass leaves chunks at
-    /// `needs_embedding=1`. The next `cqs index` invocation observes them
-    /// via `enrichment_pass`'s `needs_embedding > 0` trigger and embeds
-    /// them. Search ignores chunks at `needs_embedding=1` so the partial
-    /// state never leaks degraded results.
-    pub fn upsert_chunks_unembedded_batch(
-        &self,
-        chunks: &[Chunk],
-        source_mtime: Option<i64>,
-    ) -> Result<usize, StoreError> {
-        let _span =
-            tracing::info_span!("upsert_chunks_unembedded_batch", count = chunks.len()).entered();
-
-        if chunks.is_empty() {
-            return Ok(0);
-        }
-
-        let dim = self.dim;
-        let zero_vec = Embedding::new(vec![0.0_f32; dim]);
-        let chunks_with_zero: Vec<(Chunk, Embedding)> = chunks
-            .iter()
-            .map(|c| (c.clone(), zero_vec.clone()))
-            .collect();
-        let embedding_bytes: Vec<Vec<u8>> = chunks_with_zero
-            .iter()
-            .map(|(_, emb)| embedding_to_bytes(emb, dim))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let prefixes = self.vendored_prefixes_slice();
-        let vendored_per_chunk: Vec<bool> = chunks
-            .iter()
-            .map(|chunk| {
-                let origin = crate::normalize_path(&chunk.file);
-                crate::vendored::is_vendored_origin(&origin, prefixes)
-            })
-            .collect();
-
-        let source_mtimes = vec![source_mtime; chunks.len()];
-        self.rt.block_on(async {
-            let (_guard, mut tx) = self.begin_write().await?;
-            let old_hashes = snapshot_content_hashes(&mut tx, &chunks_with_zero).await?;
-            let now = chrono::Utc::now().to_rfc3339();
-            batch_insert_chunks(
-                &mut tx,
-                &chunks_with_zero,
-                &embedding_bytes,
-                &vendored_per_chunk,
-                &source_mtimes,
-                &now,
-                true, // zero-vec sentinel → needs_embedding=1
-            )
-            .await?;
-            upsert_fts_conditional(&mut tx, &chunks_with_zero, &old_hashes).await?;
-            tx.commit().await?;
-            Ok(chunks.len())
-        })
-    }
-
     /// Insert or update a single chunk
     pub fn upsert_chunk(
         &self,
@@ -459,7 +390,7 @@ impl Store<ReadWrite> {
             //
             // Also repopulate `embedding_base` when it was previously NULL.
             // The first-pass-skip path inserts chunks with
-            // `embedding_base = NULL` (per `upsert_chunks_unembedded_batch`);
+            // `embedding_base = NULL` (per `upsert_embedded_batch`'s sentinel mode);
             // without this, every `--llm-summaries` reindex permanently
             // leaves the chunk invisible to `build_hnsw_base_index` (which
             // filters `WHERE embedding_base IS NOT NULL`), silently degrading
@@ -911,8 +842,11 @@ impl Store<ReadWrite> {
     /// chunks + calls + function_calls + prune as one unit.)
     ///
     /// `sentinel` chunks are written via the same zero-vec
-    /// `needs_embedding=1` contract as [`Self::upsert_chunks_unembedded_batch`]
-    /// (skip-first-pass under `--llm-summaries`); `real` chunks land at
+    /// `needs_embedding=1` contract that `enrichment_pass` and the reuse
+    /// resolver depend on (skip-first-pass under `--llm-summaries`): each
+    /// sentinel row carries a zero vector in `embedding`, NULL
+    /// `embedding_base`, and stays invisible to HNSW build / search until
+    /// enrichment lands its real vector. `real` chunks land at
     /// `needs_embedding=0`.
     ///
     /// `fingerprints` is keyed by `Chunk::file`. Per-row `source_mtime` binds
@@ -1663,9 +1597,10 @@ mod tests {
 
     // ===== needs_embedding flag round-trip =====
 
-    /// `upsert_chunks_unembedded_batch` writes chunks with `needs_embedding=1`
-    /// and a zero-vec sentinel in the `embedding` column. `needs_embedding_count`
-    /// reports them; `needs_embedding_ids` returns their IDs.
+    /// `upsert_embedded_batch`'s sentinel mode writes chunks with
+    /// `needs_embedding=1` and a zero-vec sentinel in the `embedding`
+    /// column. `needs_embedding_count` reports them; `needs_embedding_ids`
+    /// returns their IDs.
     #[test]
     fn upsert_unembedded_marks_needs_embedding_and_zero_vec() {
         let (store, _dir) = setup_store();
@@ -1673,7 +1608,11 @@ mod tests {
         let c2 = make_chunk("beta", "src/b.rs");
 
         let count = store
-            .upsert_chunks_unembedded_batch(&[c1.clone(), c2.clone()], Some(100))
+            .upsert_embedded_batch(
+                &[],
+                &[c1.clone(), c2.clone()],
+                &std::collections::HashMap::new(),
+            )
             .unwrap();
         assert_eq!(count, 2);
 
@@ -1722,7 +1661,11 @@ mod tests {
         let c = make_chunk("alpha", "src/a.rs");
 
         store
-            .upsert_chunks_unembedded_batch(std::slice::from_ref(&c), Some(100))
+            .upsert_embedded_batch(
+                &[],
+                std::slice::from_ref(&c),
+                &std::collections::HashMap::new(),
+            )
             .unwrap();
         assert_eq!(store.needs_embedding_count().unwrap(), 1);
 
@@ -1745,7 +1688,11 @@ mod tests {
         let c = make_chunk("alpha_function", "src/a.rs");
 
         store
-            .upsert_chunks_unembedded_batch(std::slice::from_ref(&c), Some(100))
+            .upsert_embedded_batch(
+                &[],
+                std::slice::from_ref(&c),
+                &std::collections::HashMap::new(),
+            )
             .unwrap();
 
         // Name search must NOT find the unembedded chunk.
@@ -1786,7 +1733,11 @@ mod tests {
         let c = make_chunk("alpha", "src/a.rs");
 
         store
-            .upsert_chunks_unembedded_batch(std::slice::from_ref(&c), Some(100))
+            .upsert_embedded_batch(
+                &[],
+                std::slice::from_ref(&c),
+                &std::collections::HashMap::new(),
+            )
             .unwrap();
 
         // Pre-enrichment: embedding_base IS NULL (not zero-vec). The base

--- a/src/store/chunks/embeddings.rs
+++ b/src/store/chunks/embeddings.rs
@@ -485,7 +485,7 @@ mod tests {
     }
 
     /// All three by-hash embedding lookups gate on `needs_embedding = 0`:
-    /// a zero-vec sentinel written by `upsert_chunks_unembedded_batch`
+    /// a zero-vec sentinel written by `upsert_embedded_batch`'s sentinel mode
     /// (parser stage of a `--llm-summaries` reindex) must be a clean cache
     /// miss. Without the gate, the sentinel is finite so
     /// `Embedding::try_new` accepts it, the reuse resolver treats it as a
@@ -498,7 +498,11 @@ mod tests {
         // Sentinel row: same shape the parser stage writes.
         let sentinel = test_chunk_with_canon("pending", "fn pending() { 7 }", "canon_pending");
         store
-            .upsert_chunks_unembedded_batch(std::slice::from_ref(&sentinel), Some(100))
+            .upsert_embedded_batch(
+                &[],
+                std::slice::from_ref(&sentinel),
+                &std::collections::HashMap::new(),
+            )
             .unwrap();
 
         // All three by-hash lookups must miss the sentinel.

--- a/src/store/chunks/staleness.rs
+++ b/src/store/chunks/staleness.rs
@@ -12,9 +12,14 @@ use crate::store::{ReadWrite, Store};
 
 /// Per-file fingerprint stored alongside each chunk for the reconcile path.
 ///
-/// All three fields are nullable: `source_size` and `source_content_hash`
-/// are `NULL` until first re-embed populates them. `mtime` is `None` when
-/// `source_mtime` is `NULL` (FS without modification time).
+/// All three fields are nullable. Both production index paths populate the
+/// full fingerprint at write time: the bulk pipeline stamps it inside the
+/// chunk-write transaction (`Store::upsert_embedded_batch`) and the watch
+/// reindex path stamps it right after its per-file upsert
+/// (`Store::set_file_fingerprint`). `source_size` / `source_content_hash`
+/// remain `NULL` only for rows written by lower-level upserts (tests,
+/// `upsert_chunks_batch` callers) or by pre-v23 binaries; `mtime` is `None`
+/// when `source_mtime` is `NULL` (FS without modification time).
 ///
 /// Comparison policy lives in [`FingerprintPolicy`]; see [`Self::matches`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -381,7 +386,7 @@ impl Store<ReadWrite> {
     //
     // The SELECT DISTINCT runs inside the write transaction. If `cqs watch`
     // (which only takes `try_acquire_index_lock`) interleaves an
-    // `upsert_chunks_and_calls` call for a freshly-added file, that file's
+    // `upsert_chunks_calls_and_prune` call for a freshly-added file, that file's
     // origin is missing from `existing_files` (caller-passed snapshot) yet
     // present in `chunks`; snapshotting inside the write transaction so we
     // observe a post-watch-reindex-consistent view prevents the DELETE from

--- a/tests/store_test.rs
+++ b/tests/store_test.rs
@@ -121,23 +121,6 @@ fn test_search_filtered_by_language() {
 }
 
 #[test]
-fn test_needs_reindex_not_indexed() {
-    let store = TestStore::new();
-
-    // Create a temp file that's not indexed
-    let dir = tempfile::TempDir::new().unwrap();
-    let file_path = dir.path().join("new_file.rs");
-    std::fs::write(&file_path, "fn test() {}").unwrap();
-
-    // File not in index should need reindexing (returns Some(mtime))
-    let needs = store.needs_reindex(&file_path).unwrap();
-    assert!(
-        needs.is_some(),
-        "File not in index should need reindexing (return Some(mtime))"
-    );
-}
-
-#[test]
 fn test_delete_by_origin() {
     let store = TestStore::new();
 


### PR DESCRIPTION
## Audit v1.42.0 — indexing-pipeline cluster (PB-V1.42-1 + PERF-V1.42-4 + PERF-V1.42-6, P2)

One coherent surgery on the bulk indexing path; the watch path's per-file fused-tx crash-atomicity contract is untouched.

- **Fingerprint stamping on the CLI path (PB-V1.42-1):** resolved the conflicting evidence — the crud.rs doc claiming both production paths stamp fingerprints was false (only the watch path did; the reconcile.rs "callers" were test seeding). The CLI pipeline now stamps `source_size`/`source_content_hash` per file inside the batch transaction, and content-changing upserts refresh them (per-file UPDATE in-tx — strictly stronger than widening the INSERT, since it also covers the ON-CONFLICT short-circuit rows). This closes both halves: mtime-only staleness fallback on coarse-mtime DrvFS, and the spurious reconcile churn wave after every branch-switch `cqs index` under a live daemon. Doc corrected.
- **Staleness pre-filter before parse (PERF-V1.42-4):** `filter_stale_files` runs one batched `fingerprints_for_origins` per file batch ahead of the rayon parse (MtimeOrHash + hash tiebreak; `--force` bypasses) — a no-op incremental index does O(changed) parses instead of O(corpus), and the per-file `needs_reindex` N+1 SELECT is gone (function deleted along with the now-orphaned `upsert_chunks_and_calls`, per the no-external-users policy). Mtime-bumped content-identical files get their fingerprint refreshed so they aren't re-hashed forever.
- **Batched transactions (PERF-V1.42-6):** new `upsert_embedded_batch` writes a whole pipeline batch (real + sentinel chunks + FTS + fingerprints) in one transaction via per-row mtimes in `batch_insert_chunks`; phantom pruning is one batched transaction across files. ~30k transactions + 15k snapshot SELECTs of overhead gone at the 100k-chunk ceiling. Per-batch tx boundary preserves chunk/FTS/calls atomicity per file.

Tests: 7 new (fingerprint round-trip, content-change refresh incl. the ON-CONFLICT-skip case, mixed real/sentinel batch pinning needs_embedding/zero-vec/reuse-lookup invisibility, batched prune across files, incremental parse-only-changed). Suites re-run green: crud 41, staleness 27, pipeline 14, reconcile 16, async_helpers 10, store_test 37, store_calls_test 15, index_drift 2. fmt + clippy `--all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
