### PR TITLE
fix(search): config ef_search reaches direct-CLI builds; HNSW-cosine index scores reused instead of recomputed

### DIFF
--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -394,11 +394,30 @@ impl<'a, Mode> CommandContext<'a, Mode> {
 /// CAGRA rebuilds index each CLI invocation (~1s for 474 vectors).
 /// Only worth it when search time savings exceed rebuild cost.
 /// Threshold: 5000 vectors (where CAGRA search is ~10x faster than HNSW).
+///
+/// Direct-CLI convenience wrapper: passes `None` as the explicit override,
+/// which `build_vector_index_with_config` resolves to the project config's
+/// `ef_search`. The documented knob now takes effect on this path, not only
+/// via batch/daemon.
 pub(crate) fn build_vector_index<Mode: ClearHnswDirty>(
     store: &cqs::Store<Mode>,
     cqs_dir: &Path,
 ) -> Result<Option<Box<dyn cqs::index::VectorIndex>>> {
     build_vector_index_with_config(store, cqs_dir, None)
+}
+
+/// Resolve the effective HNSW `ef_search` for an index build.
+///
+/// An explicit caller override (`arg`) wins; the batch/daemon path threads
+/// `config.ef_search` through here as that override. When the direct-CLI
+/// wrapper passes `None`, fall back to the project config's top-level
+/// `ef_search`. `None` from both means the loader applies its own default,
+/// which still honors the `CQS_HNSW_EF_SEARCH` env knob.
+///
+/// Keeping the rule in one pure function lets the direct-CLI and batch paths
+/// resolve the same effective value from the same config field.
+fn resolve_ef_search(arg: Option<usize>, config_ef: Option<usize>) -> Option<usize> {
+    arg.or(config_ef)
 }
 
 /// Builds a vector index for the store with the specified configuration.
@@ -443,6 +462,13 @@ pub(crate) fn build_vector_index_with_config<Mode: ClearHnswDirty>(
         .index
         .as_ref()
         .and_then(|ic| ic.policy.as_ref());
+
+    // An explicit caller override (batch/daemon pass `config.ef_search`)
+    // wins; when the direct-CLI wrapper passes `None`, fall back to the
+    // project config's top-level `ef_search`. Without this fallback the
+    // documented `ef_search` knob took effect only on the batch/daemon path
+    // and silently no-op'd under direct invocation (CQS_NO_DAEMON=1).
+    let ef_search = resolve_ef_search(ef_search, project_config.ef_search);
 
     let ctx = cqs::index::BackendContext {
         cqs_dir,
@@ -515,9 +541,18 @@ pub(crate) fn build_base_vector_index<Mode: ClearHnswDirty>(
             }
         }
     }
+    // Resolve `ef_search` from the project config so the base (router) index
+    // honors the same documented knob as the enriched path. The base index
+    // never takes an explicit caller override, so `arg` is always `None`
+    // here — config alone decides, and `None` lets the loader apply its env-
+    // aware default.
+    let project_root = crate::cli::find_project_root();
+    let project_config = cqs::config::Config::load(&project_root);
+    let ef_search = resolve_ef_search(None, project_config.ef_search);
+
     Ok(cqs::HnswIndex::try_load_base_with_ef(
         cqs_dir,
-        None,
+        ef_search,
         store.dim(),
     ))
 }
@@ -543,6 +578,39 @@ mod base_index_tests {
             }
         }
         cqs::embedder::Embedding::new(v)
+    }
+
+    /// Resolution-seam parity: with a config `ef_search` set, the direct-CLI
+    /// path (explicit override `None`) and the batch/daemon path (explicit
+    /// override `config.ef_search`) resolve to the same effective `ef_search`.
+    /// This pins the wiring fix that made the documented knob reach the
+    /// direct-CLI index build instead of no-op'ing under CQS_NO_DAEMON=1.
+    #[test]
+    fn ef_search_resolution_parity_cli_vs_batch() {
+        let config_ef = Some(321usize);
+
+        // Direct-CLI wrapper: passes `None`, must fall back to config.
+        let cli_resolved = resolve_ef_search(None, config_ef);
+        // Batch/daemon: threads `config.ef_search` as the explicit override.
+        let batch_resolved = resolve_ef_search(config_ef, config_ef);
+
+        assert_eq!(
+            cli_resolved, batch_resolved,
+            "CLI-direct and batch paths must resolve identical effective ef_search"
+        );
+        assert_eq!(
+            cli_resolved, config_ef,
+            "config ef_search must reach the direct-CLI index build"
+        );
+    }
+
+    /// An explicit caller override wins over the config value, and absent both
+    /// the resolver yields `None` so the loader applies its env-aware default.
+    #[test]
+    fn ef_search_resolution_precedence() {
+        assert_eq!(resolve_ef_search(Some(50), Some(200)), Some(50));
+        assert_eq!(resolve_ef_search(None, Some(200)), Some(200));
+        assert_eq!(resolve_ef_search(None, None), None);
     }
 
     /// Phase 5 invariant: `CQS_DISABLE_BASE_INDEX=1` short-circuits

--- a/src/hnsw/build.rs
+++ b/src/hnsw/build.rs
@@ -557,6 +557,80 @@ mod tests {
         assert_eq!(hits.first().map(|r| r.id.as_str()), Some("chunk_b"));
     }
 
+    /// A zero vector interleaved between valid vectors must be skipped via the
+    /// zero-vector branch (distinct from the non-finite branch), the build must
+    /// succeed, and the surviving ids must stay aligned with their insertion
+    /// indices. Companion to `test_build_batched_skips_non_finite_embedding`,
+    /// pinning the *zero-vector* arm of the id_map desync class specifically.
+    #[test]
+    fn test_build_batched_skips_interleaved_zero_vector() {
+        // One-hot vectors: cosine-orthogonal, so each query's exact match is
+        // unambiguous even at k=1.
+        fn one_hot(idx: usize) -> Embedding {
+            let mut v = vec![0.0f32; crate::EMBEDDING_DIM];
+            v[idx] = 1.0;
+            Embedding::new(v)
+        }
+
+        // All-zero vector: caught by the zero-vector check (every element 0.0).
+        let zero_vec = vec![0.0f32; crate::EMBEDDING_DIM];
+
+        let batch = vec![
+            ("chunk_a".to_string(), one_hot(0)),
+            ("chunk_zero".to_string(), Embedding::new(zero_vec)),
+            ("chunk_b".to_string(), one_hot(2)),
+        ];
+        let batches: Vec<Result<Vec<(String, Embedding)>, std::convert::Infallible>> =
+            vec![Ok(batch)];
+
+        let index = HnswIndex::build_batched_with_dim(batches.into_iter(), 3, crate::EMBEDDING_DIM)
+            .expect("build must succeed with a zero vector in the stream");
+        assert_eq!(index.len(), 2, "zero vector must be skipped, not inserted");
+
+        // Exact-embedding searches must return the correct ids — proves the
+        // interleaved zero-vector skip kept the id_map aligned with insertion
+        // indices (a desync would attribute chunk_a's vector to chunk_b's id).
+        let hits = index.search(&one_hot(0), 1);
+        assert_eq!(hits.first().map(|r| r.id.as_str()), Some("chunk_a"));
+        let hits = index.search(&one_hot(2), 1);
+        assert_eq!(hits.first().map(|r| r.id.as_str()), Some("chunk_b"));
+    }
+
+    /// HNSW search with `k` far larger than the index size must clamp to the
+    /// index and return only the real vectors — no phantom or duplicate ids.
+    /// Mirrors CAGRA's `test_search_k_greater_than_len_drops_phantoms`; the
+    /// HNSW guard is the `ef_search.max(k*2).min(index_size)` clamp.
+    #[test]
+    fn test_search_k_greater_than_index_size() {
+        let embeddings = vec![
+            ("chunk_0".to_string(), make_embedding(0)),
+            ("chunk_1".to_string(), make_embedding(1)),
+            ("chunk_2".to_string(), make_embedding(2)),
+        ];
+        let index = HnswIndex::build_with_dim(embeddings, crate::EMBEDDING_DIM).unwrap();
+        assert_eq!(index.len(), 3);
+
+        let results = index.search(&make_embedding(1), 100);
+
+        // Only three real vectors exist; the over-large k must not invent more.
+        assert!(
+            results.len() <= 3,
+            "expected at most 3 results, got {}",
+            results.len()
+        );
+        // Every id is a real chunk and the set is unique (no slot returned
+        // twice from the clamped search).
+        let mut seen = std::collections::HashSet::new();
+        for r in &results {
+            assert!(
+                matches!(r.id.as_str(), "chunk_0" | "chunk_1" | "chunk_2"),
+                "unexpected id in oversized-k search: {}",
+                r.id
+            );
+            assert!(seen.insert(r.id.clone()), "duplicate id returned: {}", r.id);
+        }
+    }
+
     // ===== HnswIndex::search_filtered predicate tests =====
 
     #[test]

--- a/src/hnsw/mod.rs
+++ b/src/hnsw/mod.rs
@@ -671,6 +671,15 @@ impl VectorIndex for HnswIndex {
     fn dim(&self) -> usize {
         self.dim
     }
+
+    /// HNSW with the `Cosine` metric returns `1 - DistCosine`, which on full
+    /// vectors is exactly the cosine similarity the brute-force path
+    /// recomputes — so its scores are reusable. The `DotProduct` metric
+    /// returns `1 - DistDot = a·b`, a different scale from cosine, so it leaves
+    /// the default `false`.
+    fn index_scores_are_cosine(&self) -> bool {
+        self.metric() == DistanceMetric::Cosine
+    }
 }
 
 /// Always-available CPU vector index. Priority 0 (lowest). The selector

--- a/src/index.rs
+++ b/src/index.rs
@@ -216,6 +216,25 @@ pub trait VectorIndex: Send + Sync {
     fn max_k(&self) -> Option<usize> {
         None
     }
+
+    /// Whether [`search`](Self::search)'s emitted `score` is bit-for-bit the
+    /// cosine similarity the brute-force scoring path would recompute from the
+    /// stored embedding BLOB.
+    ///
+    /// When `true`, callers may reuse the index-returned score as the dense
+    /// base instead of re-fetching the embedding and recomputing cosine — the
+    /// ranking is identical, the BLOB fetch + dot product are saved.
+    ///
+    /// The default is `false` (conservative): only the HNSW backend built with
+    /// the `Cosine` metric returns `1 - DistCosine = cos`, exactly the
+    /// brute-force value. CAGRA derives its cosine through cuVS `L2Expanded`
+    /// (`1 - d/2`, floating-point-divergent and unit-norm-dependent) and its
+    /// `DotProduct` metric returns a raw inner product on a different scale, so
+    /// CAGRA leaves the default and the optimization is gated off there to
+    /// avoid a silent ranking change.
+    fn index_scores_are_cosine(&self) -> bool {
+        false
+    }
 }
 
 /// Inputs every [`IndexBackend`] needs to decide whether it can serve, and

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -783,6 +783,29 @@ impl<Mode> Store<Mode> {
             );
 
             let candidate_ids: Vec<&str> = index_results.iter().map(|r| r.id.as_str()).collect();
+
+            // The index already computed the dense cosine for every candidate;
+            // when its score scale is exactly the brute-force cosine
+            // (`index_scores_are_cosine`), reuse those scores as the fused base
+            // instead of re-fetching each embedding BLOB and recomputing the
+            // identical dot product. The downstream scoring pipeline still
+            // applies name/note boost, demotion, and threshold on top — passing
+            // the scores via `fused_scores` only replaces the base, so the
+            // ranking is unchanged. Backends whose scale differs (CAGRA cosine
+            // via L2Expanded, any DotProduct metric) report `false` and keep
+            // the recompute path to avoid a silent ranking shift.
+            let reuse_scores = idx.index_scores_are_cosine();
+            let fused_scores: Option<std::collections::HashMap<String, f32>> = if reuse_scores {
+                Some(
+                    index_results
+                        .iter()
+                        .map(|r| (r.id.clone(), r.score))
+                        .collect(),
+                )
+            } else {
+                None
+            };
+
             return self.search_by_candidate_ids_with_notes(
                 &candidate_ids,
                 query,
@@ -790,7 +813,7 @@ impl<Mode> Store<Mode> {
                 limit,
                 threshold,
                 &notes,
-                None,
+                fused_scores.as_ref(),
             );
         }
 
@@ -1637,6 +1660,129 @@ mod tests {
             "result count must be bounded by fixture, got {}",
             results.len()
         );
+    }
+
+    /// PERF wiring: when a backend reports `index_scores_are_cosine() == true`,
+    /// `search_filtered_with_index` reuses the index-returned scores as the
+    /// dense base instead of re-fetching each embedding and recomputing cosine.
+    /// This pins that the reuse path and the recompute path produce identical
+    /// scores AND identical ranking — the optimization must be score-neutral.
+    ///
+    /// Two mock indexes return the same candidates and the same per-candidate
+    /// scores (the exact cosine, computed here from the stored embeddings); one
+    /// reports cosine parity (reuse path) and one does not (recompute path).
+    /// The store's recompute path independently derives cosine from the BLOB,
+    /// so agreement proves the reused score equals the recomputed one.
+    #[test]
+    fn test_index_score_reuse_matches_recompute() {
+        use crate::embedder::Embedding;
+        use crate::index::{IndexResult, VectorIndex};
+
+        // Backend that serves fixed (id, score) pairs and advertises whether
+        // its scores are the brute-force cosine.
+        struct ParityMock {
+            results: Vec<IndexResult>,
+            cosine: bool,
+        }
+        impl VectorIndex for ParityMock {
+            fn search(&self, _query: &Embedding, k: usize) -> Vec<IndexResult> {
+                self.results.iter().take(k).cloned().collect()
+            }
+            fn len(&self) -> usize {
+                self.results.len()
+            }
+            fn name(&self) -> &'static str {
+                "ParityMock"
+            }
+            fn dim(&self) -> usize {
+                crate::EMBEDDING_DIM
+            }
+            fn index_scores_are_cosine(&self) -> bool {
+                self.cosine
+            }
+        }
+
+        // Build two distinct, non-collinear embeddings so their cosines to the
+        // query differ — `mock_embedding` collapses every positive seed to the
+        // same unit vector, which can't distinguish ranking.
+        fn embedding_with_lead(lead: f32) -> Embedding {
+            let mut v = vec![0.05f32; crate::EMBEDDING_DIM];
+            v[0] = lead;
+            let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            for x in &mut v {
+                *x /= norm;
+            }
+            Embedding::new(v)
+        }
+
+        let (store, _dir) = setup_store();
+        let query = embedding_with_lead(1.0);
+        let emb_a = embedding_with_lead(0.9);
+        let emb_b = embedding_with_lead(0.3);
+
+        let c_a = make_chunk("alpha", "src/a.rs", Language::Rust, ChunkType::Function);
+        let c_b = make_chunk("beta", "src/b.rs", Language::Rust, ChunkType::Function);
+        let id_a = c_a.id.clone();
+        let id_b = c_b.id.clone();
+        store
+            .upsert_chunks_batch(&[(c_a, emb_a.clone()), (c_b, emb_b.clone())], Some(12345))
+            .unwrap();
+
+        // Exact cosine the index would have returned (HNSW DistCosine yields
+        // `1 - dist = cos`). Same value the brute-force path recomputes.
+        let cos_a = crate::math::cosine_similarity(query.as_slice(), emb_a.as_slice()).unwrap();
+        let cos_b = crate::math::cosine_similarity(query.as_slice(), emb_b.as_slice()).unwrap();
+
+        let results = vec![
+            IndexResult {
+                id: id_a.clone(),
+                score: cos_a,
+            },
+            IndexResult {
+                id: id_b.clone(),
+                score: cos_b,
+            },
+        ];
+
+        let reuse_idx = ParityMock {
+            results: results.clone(),
+            cosine: true,
+        };
+        let recompute_idx = ParityMock {
+            results,
+            cosine: false,
+        };
+
+        let filter = SearchFilter::default();
+        let reuse = store
+            .search_filtered_with_index(&query, &filter, 10, 0.0, Some(&reuse_idx))
+            .expect("reuse path must succeed");
+        let recompute = store
+            .search_filtered_with_index(&query, &filter, 10, 0.0, Some(&recompute_idx))
+            .expect("recompute path must succeed");
+
+        assert_eq!(
+            reuse.len(),
+            recompute.len(),
+            "reuse and recompute must return the same number of results"
+        );
+        // Ranking parity: identical id order.
+        let reuse_ids: Vec<&str> = reuse.iter().map(|r| r.chunk.id.as_str()).collect();
+        let recompute_ids: Vec<&str> = recompute.iter().map(|r| r.chunk.id.as_str()).collect();
+        assert_eq!(
+            reuse_ids, recompute_ids,
+            "index-score reuse must not change ranking order"
+        );
+        // Score parity: each result's score matches within f32 epsilon.
+        for (r, rc) in reuse.iter().zip(recompute.iter()) {
+            assert!(
+                (r.score - rc.score).abs() < 1e-6,
+                "reused score {} must equal recomputed score {} for {}",
+                r.score,
+                rc.score,
+                r.chunk.id
+            );
+        }
     }
 
     // ===== type_boost_factor() tests =====


### PR DESCRIPTION
## Audit v1.42.0 — search wiring (CQ-V1.42-1, PERF-V1.42-3 + riders TC-V1.42-9/10)

- **Config `ef_search` reaches direct-CLI builds (CQ-V1.42-1):** `build_vector_index_with_config` defaults `ef_search` from `project_config.ef_search` when the caller passes `None` (pure `resolve_ef_search` seam, parity-tested), and `build_base_vector_index` resolves the same config value instead of hardcoding `None`. The documented `.cqs/config.toml` knob now works identically under `CQS_NO_DAEMON=1`/direct invocation and via batch/daemon. Resolution order preserved: explicit caller > config > env-aware loader default.
- **Index-returned scores reused (PERF-V1.42-3), CAGRA gated off on the merits:** score-scale audit — HNSW Cosine returns exactly `1 - DistCosine = cos` (qualifies); HNSW DotProduct, CAGRA Cosine (cuVS `L2Expanded`-derived, FP-divergent), and CAGRA DotProduct (raw inner product) do not. Implemented as a `VectorIndex::index_scores_are_cosine()` trait accessor (default false; HNSW true only for Cosine); `search_filtered_with_index` passes index scores as `fused_scores` only when the flag holds — which also suppresses the embedding-BLOB fetch via the existing `with_embeddings` gate. Ranking unchanged by construction (same base into the scoring pipeline); pinned by a reuse-parity test.
- **Riders:** TC-V1.42-10 — HNSW k>index-size pin added (mirrors the CAGRA phantom test); TC-V1.42-9 — the recent NaN-interleave test covers the NaN arm only, so an explicit interleaved zero-vector id-attribution test was added, closing the finding unambiguously.

Tests: search 301, hnsw::build 19 (2 new), cli::store 8 (2 new) — all pass. fmt + clippy `--all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
