### PR TITLE
fix(graph): one output topology for callers/callees incl. cross-project; cross cores parity-tested; Args conventions unified

### DIFF
--- a/src/cli/batch/handlers/analysis.rs
+++ b/src/cli/batch/handlers/analysis.rs
@@ -70,8 +70,11 @@ pub(in crate::cli::batch) fn dispatch_stale(
         &ctx.store(),
         &ctx.root,
         &file_set,
-        &crate::cli::commands::StaleArgs { count_only },
+        &crate::cli::commands::StaleArgs::default(),
     )?;
+    // `count_only` is the adapter-side render flag (read off the wire
+    // `args::StaleArgs`, not the core Args): project to the 3-field count
+    // subset here, after the core has computed the full report.
     if count_only {
         Ok(serde_json::json!({
             "stale_count": output.stale_count,
@@ -195,13 +198,17 @@ pub(in crate::cli::batch) fn dispatch_ci(
 
 // ---------------------------------------------------------------------------
 // Parity tests — each `dispatch_*` is a thin adapter over the shared `*_core`,
-// so the daemon JSON must be byte-equal to `serde_json::to_value(*_core(...))`
-// for the same inputs. dead/health/suggest are embedder-free and git-free
-// (they read the store directly), so the full dispatch path is exercised.
-// review/ci acquire their diff via `run_git_diff` (needs a real repo with a
-// diff), so their core-equivalence is asserted at the core level against the
-// empty-diff convergence shape; the dispatchers are parity-by-construction
-// (they literally call the core with `run_git_diff` output then `to_value`).
+// so the daemon JSON equals `serde_json::to_value(*_core(...))` for the same
+// inputs. This equality is parity-BY-CONSTRUCTION: the dispatcher calls the
+// very core it's compared against, so the byte-equality is structurally
+// guaranteed, not independently verified. The dead/health tests therefore also
+// carry a fixture-grounded value assert (core output reflects the seeded
+// `foo` chunk) so a both-sides-empty regression — the failure mode
+// by-construction parity can't catch — still fails the test. dead/health/
+// suggest are embedder-free and git-free (they read the store directly), so
+// the full dispatch path is exercised. review/ci acquire their diff via
+// `run_git_diff` (needs a real repo with a diff), so their core-equivalence is
+// asserted at the core level against the empty-diff convergence shape.
 // ---------------------------------------------------------------------------
 #[cfg(test)]
 mod parity_tests {
@@ -255,7 +262,10 @@ mod parity_tests {
         (dir, ctx)
     }
 
-    /// `dispatch_dead` is byte-equal to `serde_json::to_value(dead_core(...))`.
+    /// `dispatch_dead` equals `serde_json::to_value(dead_core(...))` (parity by
+    /// construction). The fixture-grounded assert pins that the seeded
+    /// callerless non-pub `foo` actually surfaces as dead, so both sides can't
+    /// silently converge on an empty list.
     #[test]
     fn parity_dead_dispatch_equals_core() {
         let (_dir, ctx) = seed_minimal_ctx();
@@ -272,6 +282,15 @@ mod parity_tests {
         .expect("dead_core");
         let core_val = serde_json::to_value(&core).expect("serialize core");
 
+        // Fixture-grounded: `foo` has no callers and isn't pub → dead.
+        let dead = core_val["dead"]
+            .as_array()
+            .unwrap_or_else(|| panic!("dead core must carry a dead array: {core_val}"));
+        assert!(
+            dead.iter().any(|d| d["name"] == "foo"),
+            "seeded callerless `foo` must be reported dead: {core_val}"
+        );
+
         let dispatched = super::dispatch_dead(
             &view,
             &crate::cli::args::DeadArgs {
@@ -284,7 +303,9 @@ mod parity_tests {
         assert_eq!(dispatched, core_val, "dispatch_dead must equal dead_core");
     }
 
-    /// `dispatch_health` is byte-equal to `serde_json::to_value(health_core(...))`.
+    /// `dispatch_health` equals `serde_json::to_value(health_core(...))` (parity
+    /// by construction). The fixture-grounded assert pins that the seeded chunk
+    /// is counted, guarding against both sides reporting an empty index.
     #[test]
     fn parity_health_dispatch_equals_core() {
         let (_dir, ctx) = seed_minimal_ctx();
@@ -300,6 +321,14 @@ mod parity_tests {
         )
         .expect("health_core");
         let core_val = serde_json::to_value(&core).expect("serialize core");
+
+        // Fixture-grounded: the index holds the seeded `foo` chunk.
+        assert!(
+            core_val["stats"]["total_chunks"]
+                .as_u64()
+                .is_some_and(|n| n >= 1),
+            "health core must count the seeded chunk: {core_val}"
+        );
 
         let dispatched = super::dispatch_health(&view).expect("dispatch_health");
 

--- a/src/cli/batch/handlers/dispatch_tests.rs
+++ b/src/cli/batch/handlers/dispatch_tests.rs
@@ -256,10 +256,13 @@ fn dispatch_callers_returns_envelope_with_callers() {
     let (_dir, ctx) = seed_ctx();
     let env = dispatch(&ctx, "callers bar");
     let data = assert_ok_envelope(&env, "callers bar");
-    // `build_callers` emits a bare JSON array of `{name, file, line}`.
+    // `callers_core` emits `{name, callers, count}` — the same object
+    // topology as callees, keyed by `callers` rather than `calls`.
+    assert_eq!(data["name"], "bar", "callers payload name: {data}");
     let callers = data
-        .as_array()
-        .unwrap_or_else(|| panic!("callers payload must be a JSON array: {data}"));
+        .get("callers")
+        .and_then(|v| v.as_array())
+        .unwrap_or_else(|| panic!("expected `callers` array in callers payload: {data}"));
     assert!(
         !callers.is_empty(),
         "foo() calls bar() in the seeded graph, so callers must be non-empty: {data}"

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -19,9 +19,9 @@ use crate::cli::args::{
     CallersArgs, DepsArgs, ImpactArgs, ImpactDiffArgs, RelatedArgs, TestMapArgs, TraceArgs,
 };
 use crate::cli::commands::{
-    callees_core, callers_core, deps_core, impact_core, test_map_core, trace_core,
-    CalleesArgs as CoreCalleesArgs, CallersCoreArgs, DepsCoreArgs, ImpactCoreArgs, TestMapCoreArgs,
-    TraceCoreArgs,
+    callees_core, callees_cross_core, callers_core, callers_cross_core, deps_core, impact_core,
+    test_map_core, trace_core, CalleesArgs as CoreCalleesArgs, CallersCoreArgs, DepsCoreArgs,
+    ImpactCoreArgs, TestMapCoreArgs, TraceCoreArgs,
 };
 
 // ─── Daemon dispatch handlers ──────────────────────────────────────────────
@@ -75,11 +75,11 @@ pub(in crate::cli::batch) fn dispatch_deps(
 /// Retrieves and serializes caller information for a given function name.
 ///
 /// The wire schema is `CallersCoreOutput` (in
-/// `cli::commands::graph::callers`), serialized as-is — a flat array of
-/// caller entries on the function path, the shared kind-fallback object on
-/// a kind mismatch. See that type for the exact field names. The
-/// cross-project branch serializes `CrossProjectContext::get_callers_cross`
-/// results directly instead.
+/// `cli::commands::graph::callers`), serialized as-is — the
+/// `{name, callers, count}` object on the function path, the shared
+/// kind-fallback object on a kind mismatch. See that type for the exact
+/// field names. The cross-project branch goes through `callers_cross_core`,
+/// which projects to the same object shape with a `project` field per entry.
 ///
 /// # Errors
 ///
@@ -98,12 +98,15 @@ pub(in crate::cli::batch) fn dispatch_callers(
     )
     .entered();
     if cross_project {
-        // Shared cap with the core. Truncate before serialization.
-        let limit = args.limit_arg.limit.clamp(1, 100);
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
-        let mut callers = cross_ctx.get_callers_cross(name)?;
-        callers.truncate(limit);
-        return Ok(serde_json::to_value(&callers)?);
+        let output = callers_cross_core(
+            &mut cross_ctx,
+            &CallersCoreArgs {
+                name: name.to_string(),
+                limit: args.limit_arg.limit,
+            },
+        )?;
+        return Ok(serde_json::to_value(&output)?);
     }
 
     let core_args = CallersCoreArgs {
@@ -120,8 +123,8 @@ pub(in crate::cli::batch) fn dispatch_callers(
 /// `cli::commands::graph::callers`), serialized as-is — the
 /// `{name, calls, count}` object on the function path, the shared
 /// kind-fallback object on a kind mismatch. See that type for the exact
-/// field names. The cross-project branch serializes
-/// `CrossProjectContext::get_callees_cross` results directly instead.
+/// field names. The cross-project branch goes through `callees_cross_core`,
+/// which projects to the same object shape with a `project` field per entry.
 ///
 /// # Errors
 ///
@@ -140,12 +143,15 @@ pub(in crate::cli::batch) fn dispatch_callees(
     )
     .entered();
     if cross_project {
-        // Shared cap with the core.
-        let limit = args.limit_arg.limit.clamp(1, 100);
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
-        let mut callees = cross_ctx.get_callees_cross(name)?;
-        callees.truncate(limit);
-        return Ok(serde_json::to_value(&callees)?);
+        let output = callees_cross_core(
+            &mut cross_ctx,
+            &CoreCalleesArgs {
+                name: name.to_string(),
+                limit: args.limit_arg.limit,
+            },
+        )?;
+        return Ok(serde_json::to_value(&output)?);
     }
 
     let core_args = CoreCalleesArgs {
@@ -189,20 +195,17 @@ pub(in crate::cli::batch) fn dispatch_impact(
     )
     .entered();
     if cross_project {
-        let depth = args.depth.clamp(1, 10);
-        let limit = args.limit_arg.limit.clamp(1, 100);
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
-        let mut result = cqs::cross_project::analyze_impact_cross(
+        let result = crate::cli::commands::impact_cross_core(
             &mut cross_ctx,
-            name,
-            depth,
-            do_suggest_tests,
-            include_types,
+            &ImpactCoreArgs {
+                name: name.to_string(),
+                depth: args.depth,
+                limit: args.limit_arg.limit,
+                suggest_tests: do_suggest_tests,
+                include_types,
+            },
         )?;
-        result.callers.truncate(limit);
-        result.transitive_callers.truncate(limit);
-        result.tests.truncate(limit);
-        result.type_impacted.truncate(limit);
         // Cross-project JSON never carried `kind` / `test_suggestions`
         // (the historical path called `impact_to_json` directly). Preserve
         // that wire shape.
@@ -251,22 +254,17 @@ pub(in crate::cli::batch) fn dispatch_test_map(
     )
     .entered();
     if cross_project {
-        let limit = args.limit_arg.limit.clamp(1, 100);
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
-        let test_chunks = cross_ctx.find_test_chunks_cross()?;
-        let graph = cross_ctx.merged_call_graph()?;
-        let summaries: Vec<cqs::store::ChunkSummary> =
-            test_chunks.iter().map(|tc| tc.chunk.clone()).collect();
-
-        let mut matches = crate::cli::commands::build_test_map(
-            name,
-            &graph,
-            &summaries,
+        let matches = crate::cli::commands::test_map_cross_core(
+            &mut cross_ctx,
             &ctx.root,
-            max_depth,
-            crate::cli::commands::test_map_max_nodes(),
-        );
-        matches.truncate(limit);
+            &TestMapCoreArgs {
+                name: name.to_string(),
+                max_depth,
+                limit: args.limit_arg.limit,
+                max_nodes: crate::cli::commands::test_map_max_nodes(),
+            },
+        )?;
         let output = crate::cli::commands::build_test_map_output(name, &matches);
         return Ok(serde_json::to_value(&output)?);
     }
@@ -318,15 +316,8 @@ pub(in crate::cli::batch) fn dispatch_trace(
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
-        let result = cqs::cross_project::trace_cross(&mut cross_ctx, source, target, max_depth)?;
-
-        let trace_result = cqs::cross_project::CrossProjectTraceResult {
-            source: source.to_string(),
-            target: target.to_string(),
-            depth: result.as_ref().map(|p| p.len().saturating_sub(1)),
-            found: result.is_some(),
-            path: result,
-        };
+        let trace_result =
+            crate::cli::commands::trace_cross_core(&mut cross_ctx, source, target, max_depth)?;
         return Ok(serde_json::to_value(&trace_result)?);
     }
 
@@ -509,11 +500,12 @@ mod tests {
             limit_arg: crate::cli::args::LimitArg { limit: 10 },
         };
         let json = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
-        // `build_callers` returns `Vec<CallerEntry>`, which serializes as a
-        // bare JSON array (no enclosing key).
-        let callers = json
+        // `callers_core` emits `{name, callers, count}` — the same object
+        // topology as callees, keyed by `callers` rather than `calls`.
+        assert_eq!(json["name"], "callee_fn");
+        let callers = json["callers"]
             .as_array()
-            .unwrap_or_else(|| panic!("response must be a JSON array, got: {json}"));
+            .unwrap_or_else(|| panic!("`callers` must be a JSON array, got: {json}"));
         assert!(
             callers.iter().any(|c| c["name"] == "caller_fn"),
             "expected caller_fn in callers list, got: {callers:?}"
@@ -577,11 +569,19 @@ mod tests {
 
     // ─── Surface-parity tests ──────────────────────────────────────────────
     //
-    // The structural payoff of the command-core refactor: the daemon
-    // dispatch adapter and a direct core call produce byte-identical
-    // `serde_json::Value` for identical inputs. These seed a const (so the
-    // kind-fallback path fires) and exercise every graph command on both a
-    // happy-path name (`callee_fn`/`caller_fn`) and the const.
+    // The structural payoff of the command-core refactor: the daemon dispatch
+    // adapter and a direct core call produce byte-identical
+    // `serde_json::Value` for identical inputs. These are parity-BY-
+    // CONSTRUCTION — each `dispatch_*` is a thin wrapper that calls the very
+    // core it's compared against, so the equality is structurally guaranteed
+    // rather than independently verified. To keep that guarantee meaningful
+    // each test also carries a fixture-grounded value assert (the core output
+    // contains the seeded caller / callee / path before the equality check),
+    // so a both-sides-empty regression — the one failure mode by-construction
+    // parity can't catch — fails the test. These seed a const (so the
+    // kind-fallback path fires) and exercise every graph command on a
+    // happy-path name (`callee_fn`/`caller_fn`) and the const, plus a
+    // cross-project variant per command.
 
     /// Seed a const chunk named `MAX_LEN` so the kind-fallback path is
     /// reachable. Returns a fresh context with the call-graph fixture plus
@@ -886,9 +886,9 @@ mod tests {
         };
         let json = dispatch_callers(&ctx.build_view(None), &args)
             .expect("kind-detect store error must not fail the request");
-        let callers = json
-            .as_array()
-            .unwrap_or_else(|| panic!("normal-path response must be an array, got: {json}"));
+        let callers = json["callers"].as_array().unwrap_or_else(|| {
+            panic!("normal-path response must carry a `callers` array, got: {json}")
+        });
         assert!(
             callers.iter().any(|c| c["name"] == "caller_fn"),
             "normal callers path must still answer, got: {callers:?}"
@@ -918,8 +918,68 @@ mod tests {
                 .expect("callers_core"),
             )
             .unwrap();
+            // Fixture-grounded: `callee_fn` has a real caller (`caller_fn`)
+            // in the seed, so the core output must be non-empty. Without this
+            // a both-sides-empty regression (e.g. the SQL stops matching)
+            // would still satisfy the byte-equality below.
+            if name == "callee_fn" {
+                let callers = core["callers"]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("function-path core must carry callers: {core}"));
+                assert!(
+                    callers.iter().any(|c| c["name"] == "caller_fn"),
+                    "seeded caller_fn must appear in callers_core output: {core}"
+                );
+            }
             assert_eq!(daemon, core, "callers parity mismatch for {name}");
         }
+    }
+
+    #[test]
+    fn parity_callers_cross_daemon_matches_core() {
+        // Cross-project parity over a single-project corpus (no references in
+        // config → `from_config` builds a one-store "local" context). Both
+        // the daemon cross branch and the CLI cross branch route through
+        // `callers_cross_core`, so this pins their shared output: the
+        // unified `{name, callers, count}` object with `project: "local"`.
+        let (dir, ctx) = seed_call_graph_ctx();
+        let view = ctx.build_view(None);
+        let root = dir.path();
+
+        let wire = CallersArgs {
+            name: "callee_fn".into(),
+            cross_project: true,
+            limit_arg: crate::cli::args::LimitArg { limit: 5 },
+        };
+        let daemon = dispatch_callers(&view, &wire).expect("dispatch_callers cross");
+
+        let mut cross_ctx =
+            cqs::cross_project::CrossProjectContext::from_config(root).expect("from_config");
+        let core = serde_json::to_value(
+            callers_cross_core(
+                &mut cross_ctx,
+                &CallersCoreArgs {
+                    name: "callee_fn".into(),
+                    limit: 5,
+                },
+            )
+            .expect("callers_cross_core"),
+        )
+        .unwrap();
+
+        // Fixture-grounded value assert: the seeded caller surfaces, tagged
+        // with its project.
+        let callers = core["callers"]
+            .as_array()
+            .unwrap_or_else(|| panic!("cross core must carry callers: {core}"));
+        assert!(
+            callers
+                .iter()
+                .any(|c| c["name"] == "caller_fn" && c["project"] == "local"),
+            "seeded cross-project caller_fn@local must appear: {core}"
+        );
+        assert_eq!(core["name"], "callee_fn");
+        assert_eq!(daemon, core, "cross-project callers parity mismatch");
     }
 
     #[test]
@@ -945,8 +1005,62 @@ mod tests {
                 .expect("callees_core"),
             )
             .unwrap();
+            // Fixture-grounded: `caller_fn` calls `callee_fn` in the seed, so
+            // the core's `calls` list must be non-empty on that name.
+            if name == "caller_fn" {
+                let calls = core["calls"]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("function-path core must carry calls: {core}"));
+                assert!(
+                    calls.iter().any(|c| c["name"] == "callee_fn"),
+                    "seeded callee_fn must appear in callees_core output: {core}"
+                );
+            }
             assert_eq!(daemon, core, "callees parity mismatch for {name}");
         }
+    }
+
+    #[test]
+    fn parity_callees_cross_daemon_matches_core() {
+        // Cross-project parity for callees over the single-project corpus.
+        // Both surfaces route through `callees_cross_core`; pin the unified
+        // `{name, calls, count}` object with `project: "local"`.
+        let (dir, ctx) = seed_call_graph_ctx();
+        let view = ctx.build_view(None);
+        let root = dir.path();
+
+        let wire = CallersArgs {
+            name: "caller_fn".into(),
+            cross_project: true,
+            limit_arg: crate::cli::args::LimitArg { limit: 5 },
+        };
+        let daemon = dispatch_callees(&view, &wire).expect("dispatch_callees cross");
+
+        let mut cross_ctx =
+            cqs::cross_project::CrossProjectContext::from_config(root).expect("from_config");
+        let core = serde_json::to_value(
+            callees_cross_core(
+                &mut cross_ctx,
+                &CoreCalleesArgs {
+                    name: "caller_fn".into(),
+                    limit: 5,
+                },
+            )
+            .expect("callees_cross_core"),
+        )
+        .unwrap();
+
+        let calls = core["calls"]
+            .as_array()
+            .unwrap_or_else(|| panic!("cross core must carry calls: {core}"));
+        assert!(
+            calls
+                .iter()
+                .any(|c| c["name"] == "callee_fn" && c["project"] == "local"),
+            "seeded cross-project callee_fn@local must appear: {core}"
+        );
+        assert_eq!(core["name"], "caller_fn");
+        assert_eq!(daemon, core, "cross-project callees parity mismatch");
     }
 
     #[test]
@@ -979,6 +1093,24 @@ mod tests {
                 .expect("deps_core"),
             )
             .unwrap();
+            // Fixture-grounded: the reverse function case ran the reverse
+            // path (object keyed by `name`), and the const case ran the
+            // kind-fallback (object keyed by `fallback_from`) — pinning which
+            // branch fired guards against both sides collapsing to the same
+            // wrong shape.
+            if name == "caller_fn" && reverse {
+                assert_eq!(core["name"], "caller_fn", "reverse-path name key: {core}");
+                assert!(
+                    core.get("fallback_from").is_none(),
+                    "not a fallback: {core}"
+                );
+            }
+            if name == "MAX_LEN" {
+                assert_eq!(
+                    core["fallback_from"], "deps",
+                    "const must fall back: {core}"
+                );
+            }
             assert_eq!(daemon, core, "deps parity mismatch for {name}");
         }
     }
@@ -1014,8 +1146,65 @@ mod tests {
                 .expect("test_map_core"),
             )
             .unwrap();
+            // Fixture-grounded: the seed has no test chunks, so the function
+            // path returns an empty `tests` list — but it must still be the
+            // function path (`{name, tests, count}`), not the kind fallback.
+            // Pinning the `name`/`tests` keys catches a both-sides-fallback
+            // regression that byte-equality alone would mask.
+            if name == "callee_fn" {
+                assert_eq!(core["name"], "callee_fn", "function-path name key: {core}");
+                assert!(
+                    core["tests"].is_array(),
+                    "function path must carry a tests array: {core}"
+                );
+            }
             assert_eq!(daemon, core, "test-map parity mismatch for {name}");
         }
+    }
+
+    #[test]
+    fn parity_test_map_cross_daemon_matches_core() {
+        // Cross-project parity for test-map. Both surfaces route through
+        // `test_map_cross_core` → `build_test_map_output`; pin the shared
+        // `{name, tests, count}` object. The seed has no tests, so `tests`
+        // is empty — the grounded assert pins the function-path keys.
+        let (dir, ctx) = seed_call_graph_ctx();
+        let view = ctx.build_view(None);
+        let root = dir.path();
+
+        let wire = TestMapArgs {
+            name: "callee_fn".into(),
+            depth: 5,
+            cross_project: true,
+            limit_arg: crate::cli::args::LimitArg { limit: 5 },
+        };
+        let daemon = dispatch_test_map(&view, &wire).expect("dispatch_test_map cross");
+
+        let mut cross_ctx =
+            cqs::cross_project::CrossProjectContext::from_config(root).expect("from_config");
+        let matches = crate::cli::commands::test_map_cross_core(
+            &mut cross_ctx,
+            root,
+            &TestMapCoreArgs {
+                name: "callee_fn".into(),
+                max_depth: 5,
+                limit: 5,
+                max_nodes: crate::cli::commands::test_map_max_nodes(),
+            },
+        )
+        .expect("test_map_cross_core");
+        let core = serde_json::to_value(crate::cli::commands::build_test_map_output(
+            "callee_fn",
+            &matches,
+        ))
+        .unwrap();
+
+        assert_eq!(core["name"], "callee_fn");
+        assert!(
+            core["tests"].is_array(),
+            "cross test-map carries tests: {core}"
+        );
+        assert_eq!(daemon, core, "cross-project test-map parity mismatch");
     }
 
     #[test]
@@ -1049,8 +1238,47 @@ mod tests {
                 .expect("trace_core"),
             )
             .unwrap();
+            // Fixture-grounded: caller_fn → callee_fn is a real edge, so the
+            // path must be found (found=true, depth=1). The const-source case
+            // is left to byte-equality (it exercises the fallback shape).
+            if source == "caller_fn" {
+                assert_eq!(core["found"], true, "seeded path must be found: {core}");
+                assert_eq!(core["depth"], 1, "caller_fn→callee_fn is one hop: {core}");
+            }
             assert_eq!(daemon, core, "trace parity mismatch for {source}->{target}");
         }
+    }
+
+    #[test]
+    fn parity_trace_cross_daemon_matches_core() {
+        // Cross-project parity for trace. Both surfaces route through
+        // `trace_cross_core`; pin the shared `CrossProjectTraceResult`
+        // (`{source, target, path?, depth?, found}`).
+        let (dir, ctx) = seed_call_graph_ctx();
+        let view = ctx.build_view(None);
+        let root = dir.path();
+
+        let wire = TraceArgs {
+            source: "caller_fn".into(),
+            target: "callee_fn".into(),
+            max_depth: 10,
+            cross_project: true,
+            limit_arg: crate::cli::args::LimitArg { limit: 5 },
+        };
+        let daemon = dispatch_trace(&view, &wire).expect("dispatch_trace cross");
+
+        let mut cross_ctx =
+            cqs::cross_project::CrossProjectContext::from_config(root).expect("from_config");
+        let core = serde_json::to_value(
+            crate::cli::commands::trace_cross_core(&mut cross_ctx, "caller_fn", "callee_fn", 10)
+                .expect("trace_cross_core"),
+        )
+        .unwrap();
+
+        assert_eq!(core["found"], true, "cross path must be found: {core}");
+        assert_eq!(core["source"], "caller_fn");
+        assert_eq!(core["target"], "callee_fn");
+        assert_eq!(daemon, core, "cross-project trace parity mismatch");
     }
 
     #[test]
@@ -1058,7 +1286,9 @@ mod tests {
         let (_dir, ctx) = seed_with_const();
         let view = ctx.build_view(None);
         let store = view.store();
-        for name in ["caller_fn", "MAX_LEN"] {
+        // `callee_fn` has a real caller (`caller_fn`); `MAX_LEN` exercises the
+        // kind-fallback path.
+        for name in ["callee_fn", "MAX_LEN"] {
             let wire = ImpactArgs {
                 name: name.into(),
                 depth: 1,
@@ -1082,7 +1312,65 @@ mod tests {
             .expect("impact_core")
             .to_value()
             .expect("to_value");
+            // Fixture-grounded: impact on `callee_fn` must list `caller_fn`
+            // among its direct callers, so the function-path output is
+            // non-empty — guarding against a both-sides-empty regression.
+            if name == "callee_fn" {
+                let callers = core["callers"]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("impact function path must carry callers: {core}"));
+                assert!(
+                    callers.iter().any(|c| c["name"] == "caller_fn"),
+                    "seeded caller_fn must appear in impact callers: {core}"
+                );
+            }
             assert_eq!(daemon, core, "impact parity mismatch for {name}");
         }
+    }
+
+    #[test]
+    fn parity_impact_cross_daemon_matches_core() {
+        // Cross-project parity for impact. Both surfaces route through
+        // `impact_cross_core`; the cross-project JSON is the bare
+        // `impact_to_json(result)` (no `kind` / `test_suggestions`).
+        let (dir, ctx) = seed_call_graph_ctx();
+        let view = ctx.build_view(None);
+        let root = dir.path();
+
+        let wire = ImpactArgs {
+            name: "callee_fn".into(),
+            depth: 1,
+            suggest_tests: false,
+            type_impact: false,
+            cross_project: true,
+            limit_arg: crate::cli::args::LimitArg { limit: 5 },
+        };
+        let daemon = dispatch_impact(&view, &wire).expect("dispatch_impact cross");
+
+        let mut cross_ctx =
+            cqs::cross_project::CrossProjectContext::from_config(root).expect("from_config");
+        let result = crate::cli::commands::impact_cross_core(
+            &mut cross_ctx,
+            &ImpactCoreArgs {
+                name: "callee_fn".into(),
+                depth: 1,
+                limit: 5,
+                suggest_tests: false,
+                include_types: false,
+            },
+        )
+        .expect("impact_cross_core");
+        let core = cqs::impact_to_json(&result).expect("impact_to_json");
+
+        // Fixture-grounded: caller_fn calls callee_fn, so the cross impact
+        // must list it among callers.
+        let callers = core["callers"]
+            .as_array()
+            .unwrap_or_else(|| panic!("cross impact must carry callers: {core}"));
+        assert!(
+            callers.iter().any(|c| c["name"] == "caller_fn"),
+            "seeded cross caller_fn must appear in impact callers: {core}"
+        );
+        assert_eq!(daemon, core, "cross-project impact parity mismatch");
     }
 }

--- a/src/cli/batch/handlers/info.rs
+++ b/src/cli/batch/handlers/info.rs
@@ -466,9 +466,11 @@ mod tests {
         );
     }
 
-    /// Daemon `dispatch_stale` (non-count-only) is byte-equal to
-    /// `stale_core(...)` over the daemon's cached file_set — the parity
-    /// contract for the cored stale command.
+    /// Daemon `dispatch_stale` (non-count-only) equals `stale_core(...)` over
+    /// the daemon's cached file_set. Parity by construction (the dispatcher
+    /// calls this core), so the test also carries a fixture-grounded value
+    /// assert — the seeded indexed file surfaces as missing — to catch a
+    /// both-sides-empty regression.
     #[test]
     fn parity_stale_dispatch_equals_core() {
         let (_dir, ctx) = seed_minimal_ctx();
@@ -479,10 +481,23 @@ mod tests {
             &view.store(),
             &view.root,
             &file_set,
-            &crate::cli::commands::StaleArgs { count_only: false },
+            &crate::cli::commands::StaleArgs::default(),
         )
         .expect("stale_core");
         let core_val = serde_json::to_value(&core).expect("serialize core");
+
+        // Fixture-grounded value assert (not just shape): the seeded chunk
+        // lives in `src/lib.rs`, which doesn't exist on disk in the tempdir,
+        // so the core must report it indexed-and-missing. Without this both
+        // sides could be empty and the equality below would still pass.
+        assert!(
+            core.total_indexed >= 1,
+            "core must count the seeded indexed file, got: {core_val}"
+        );
+        assert!(
+            core.missing.iter().any(|f| f.contains("lib.rs")),
+            "seeded src/lib.rs (absent on disk) must surface as missing, got: {core_val}"
+        );
 
         let dispatched = super::super::analysis::dispatch_stale(
             &view,
@@ -496,9 +511,10 @@ mod tests {
         );
     }
 
-    /// Daemon `dispatch_stats` is byte-equal to `stats_core(...)` plus the
-    /// daemon-only `errors` field — the parity contract for the cored stats
-    /// command. Asserts the adapter adds nothing beyond `errors`.
+    /// Daemon `dispatch_stats` equals `stats_core(...)` plus the daemon-only
+    /// `errors` field. Parity by construction (the dispatcher calls this
+    /// core); asserts the adapter adds nothing beyond `errors`, with a
+    /// fixture-grounded value assert so an empty-index regression still fails.
     #[test]
     fn parity_stats_dispatch_equals_core_plus_errors() {
         let (_dir, ctx) = seed_minimal_ctx();
@@ -513,6 +529,13 @@ mod tests {
         )
         .expect("stats_core");
         let mut core_val = serde_json::to_value(&core).expect("serialize core");
+        // Fixture-grounded: the seeded `foo` chunk must be counted, so neither
+        // side reports an empty index (which by-construction parity wouldn't
+        // catch).
+        assert!(
+            core_val["total_chunks"].as_u64().is_some_and(|n| n >= 1),
+            "stats core must count the seeded chunk: {core_val}"
+        );
         // The adapter layers on `errors`; everything else must match exactly.
         let errors = dispatched.get("errors").cloned().expect("errors present");
         core_val

--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -8,9 +8,16 @@
 //! `cqs::kind::classify_hits` against an exact-name lookup before the
 //! call-graph query (see `docs/polymorphic-routing.md`): kind-mismatch
 //! fallbacks return an object with `kind`, `fallback_from`, `name`,
-//! `definitions`, and `note` fields. The function-path success shape is a
-//! flat array of caller/callee entries; agents detect the dispatch decision
-//! by type (`isinstance(parsed, list)` ⇒ function path, `dict` ⇒ fallback).
+//! `definitions`, and `note` fields.
+//!
+//! ## Output topology (function path)
+//!
+//! Both commands emit one object shape on the function path: callers returns
+//! `{name, callers: [...], count}` and callees returns `{name, calls: [...],
+//! count}` (cross-project adds a `project` field to each entry). Agents
+//! discriminate the dispatch decision by key-probing, not by JSON type: a
+//! `fallback_from` key means the kind-mismatch fallback fired; a `callers` /
+//! `calls` key means the function path ran. Both paths are JSON objects.
 
 use anyhow::{Context as _, Result};
 use colored::Colorize;
@@ -49,12 +56,31 @@ pub(crate) struct CallerEntry {
     pub name: String,
     pub file: String,
     pub line_start: u32,
+    /// Originating project name on the cross-project path; omitted (single
+    /// project) on the standard path.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub project: String,
 }
 
 #[derive(Debug, serde::Serialize)]
 pub(crate) struct CalleeEntry {
     pub name: String,
     pub line_start: u32,
+    /// Originating project name on the cross-project path; omitted (single
+    /// project) on the standard path.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub project: String,
+}
+
+/// Function-path output for `cqs callers <name>`: `{name, callers, count}`.
+/// The mirror of [`CalleesOutput`] — both commands share one object
+/// topology so agents key-probe (`callers` vs `calls`) rather than
+/// discriminating array-vs-object.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct CallersOutput {
+    pub name: String,
+    pub callers: Vec<CallerEntry>,
+    pub count: usize,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -64,16 +90,16 @@ pub(crate) struct CalleesOutput {
     pub count: usize,
 }
 
-/// Single JSON-schema source for `cqs callers <name>`. The happy path is
-/// a flat array of caller entries (possibly empty); a kind mismatch yields
-/// the shared fallback object. `#[serde(untagged)]` reproduces the
-/// historical "array ⇒ function path, object ⇒ fallback" shape agents
-/// already discriminate on by type.
+/// Single JSON-schema source for `cqs callers <name>`. Happy path is the
+/// `{name, callers, count}` object (cross-project adds `project` per entry);
+/// a kind mismatch yields the shared fallback object. Both variants are JSON
+/// objects — agents key-probe (`callers` ⇒ function path, `fallback_from` ⇒
+/// fallback) rather than discriminating by JSON type.
 #[derive(Debug, serde::Serialize)]
 #[serde(untagged)]
 pub(crate) enum CallersCoreOutput {
-    /// Function path: flat array of callers (empty array when none).
-    Callers(Vec<CallerEntry>),
+    /// Function path: `{name, callers, count}`.
+    Callers(CallersOutput),
     /// Kind mismatch: `{kind, fallback_from, name, definitions, note}`.
     Fallback(KindFallbackOutput),
 }
@@ -91,17 +117,30 @@ pub(crate) enum CalleesCoreOutput {
 
 // ─── Shared JSON builders ──────────────────────────────────────────────────
 
-/// Build typed caller output from caller info -- shared between CLI and batch.
-pub(crate) fn build_callers(callers: &[CallerInfo]) -> Vec<CallerEntry> {
-    let _span = tracing::info_span!("build_callers", count = callers.len()).entered();
+/// Build typed caller entries from caller info -- shared between CLI and batch.
+pub(crate) fn build_caller_entries(callers: &[CallerInfo]) -> Vec<CallerEntry> {
+    let _span = tracing::info_span!("build_caller_entries", count = callers.len()).entered();
     callers
         .iter()
         .map(|c| CallerEntry {
             name: c.name.clone(),
             file: normalize_path(&c.file).to_string(),
             line_start: c.line,
+            project: String::new(),
         })
         .collect()
+}
+
+/// Build typed callers output (`{name, callers, count}`) -- the function-path
+/// shape both surfaces emit. Mirror of [`build_callees`].
+pub(crate) fn build_callers(name: &str, callers: &[CallerInfo]) -> CallersOutput {
+    let _span = tracing::info_span!("build_callers", name, count = callers.len()).entered();
+    let entries = build_caller_entries(callers);
+    CallersOutput {
+        name: name.to_string(),
+        count: entries.len(),
+        callers: entries,
+    }
 }
 
 /// Build typed callees output -- shared between CLI and batch.
@@ -114,6 +153,7 @@ pub(crate) fn build_callees(name: &str, callees: &[(String, u32)]) -> CalleesOut
             .map(|(n, line)| CalleeEntry {
                 name: n.clone(),
                 line_start: *line,
+                project: String::new(),
             })
             .collect(),
         count: callees.len(),
@@ -152,7 +192,9 @@ pub(crate) fn callers_core(
         .get_callers_full(&args.name)
         .context("Failed to load callers")?;
     callers.truncate(limit);
-    Ok(CallersCoreOutput::Callers(build_callers(&callers)))
+    Ok(CallersCoreOutput::Callers(build_callers(
+        &args.name, &callers,
+    )))
 }
 
 /// Surface-agnostic core for `cqs callees <name>` (single-project).
@@ -181,6 +223,78 @@ pub(crate) fn callees_core(
     )))
 }
 
+// ─── Cross-project cores ─────────────────────────────────────────────────────
+//
+// The cross-project path has its own (multi-index) retrieval and no
+// kind-fallback, so it gets its own core rather than a branch inside
+// `callers_core`. Both surfaces (CLI `cmd_callers --cross-project`, daemon
+// `dispatch_callers` cross branch) call these so the cap discipline and the
+// `{name, callers|calls, count}` projection can't drift. Output topology is
+// the same object shape as the single-project path; each entry gains a
+// `project` field.
+
+/// Surface-agnostic core for `cqs callers <name> --cross-project`.
+///
+/// Resolves callers across every project in `cross_ctx`, applies the shared
+/// `1..=100` cap, and projects to the same `{name, callers, count}` object
+/// the single-project core emits — entries carry their originating project.
+pub(crate) fn callers_cross_core(
+    cross_ctx: &mut cqs::cross_project::CrossProjectContext,
+    args: &CallersArgs,
+) -> Result<CallersOutput> {
+    let _span =
+        tracing::info_span!("callers_cross_core", name = %args.name, limit = args.limit).entered();
+    let limit = args.limit.clamp(1, 100);
+    let mut callers = cross_ctx
+        .get_callers_cross(&args.name)
+        .context("Failed to load cross-project callers")?;
+    callers.truncate(limit);
+    let entries: Vec<CallerEntry> = callers
+        .iter()
+        .map(|c| CallerEntry {
+            name: c.caller.name.clone(),
+            file: normalize_path(&c.caller.file).to_string(),
+            line_start: c.caller.line,
+            project: c.project.clone(),
+        })
+        .collect();
+    Ok(CallersOutput {
+        name: args.name.clone(),
+        count: entries.len(),
+        callers: entries,
+    })
+}
+
+/// Surface-agnostic core for `cqs callees <name> --cross-project`.
+///
+/// Mirror of [`callers_cross_core`]: projects to `{name, calls, count}` with
+/// a `project` field on each entry.
+pub(crate) fn callees_cross_core(
+    cross_ctx: &mut cqs::cross_project::CrossProjectContext,
+    args: &CalleesArgs,
+) -> Result<CalleesOutput> {
+    let _span =
+        tracing::info_span!("callees_cross_core", name = %args.name, limit = args.limit).entered();
+    let limit = args.limit.clamp(1, 100);
+    let mut callees = cross_ctx
+        .get_callees_cross(&args.name)
+        .context("Failed to load cross-project callees")?;
+    callees.truncate(limit);
+    let calls: Vec<CalleeEntry> = callees
+        .iter()
+        .map(|c| CalleeEntry {
+            name: c.name.clone(),
+            line_start: c.line,
+            project: c.project.clone(),
+        })
+        .collect();
+    Ok(CalleesOutput {
+        name: args.name.clone(),
+        count: calls.len(),
+        calls,
+    })
+}
+
 // ─── CLI commands (thin adapters over the cores) ───────────────────────────
 
 /// Find functions that call the specified function
@@ -197,36 +311,32 @@ pub(crate) fn cmd_callers(
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
-        let mut callers = cross_ctx
-            .get_callers_cross(name)
-            .context("Failed to load cross-project callers")?;
-        callers.truncate(limit);
-
-        if callers.is_empty() {
-            if json {
-                crate::cli::json_envelope::emit_json(&serde_json::json!([]))?;
-            } else {
-                println!("No callers found for '{}' (cross-project)", name);
-            }
-            return Ok(());
-        }
+        let output = callers_cross_core(
+            &mut cross_ctx,
+            &CallersArgs {
+                name: name.to_string(),
+                limit,
+            },
+        )?;
 
         if json {
-            crate::cli::json_envelope::emit_json(&callers)?;
+            crate::cli::json_envelope::emit_json(&output)?;
+        } else if output.callers.is_empty() {
+            println!("No callers found for '{}' (cross-project)", name);
         } else {
             println!("Functions that call '{}' (cross-project):", name);
             println!();
-            for c in &callers {
+            for c in &output.callers {
                 println!(
                     "  {} ({}:{}) [{}]",
-                    c.caller.name.cyan(),
-                    c.caller.file.display(),
-                    c.caller.line,
+                    c.name.cyan(),
+                    c.file,
+                    c.line_start,
                     c.project.dimmed()
                 );
             }
             println!();
-            println!("Total: {} caller(s)", callers.len());
+            println!("Total: {} caller(s)", output.count);
         }
         return Ok(());
     }
@@ -246,15 +356,15 @@ pub(crate) fn cmd_callers(
                 render_callers_fallback_text(name, store)?;
             }
         }
-        CallersCoreOutput::Callers(callers) => {
+        CallersCoreOutput::Callers(output) => {
             if json {
-                crate::cli::json_envelope::emit_json(&callers)?;
-            } else if callers.is_empty() {
+                crate::cli::json_envelope::emit_json(&output)?;
+            } else if output.callers.is_empty() {
                 println!("No callers found for '{}'", name);
             } else {
                 println!("Functions that call '{}':", name);
                 println!();
-                for caller in &callers {
+                for caller in &output.callers {
                     println!(
                         "  {} ({}:{})",
                         caller.name.cyan(),
@@ -263,7 +373,7 @@ pub(crate) fn cmd_callers(
                     );
                 }
                 println!();
-                println!("Total: {} caller(s)", callers.len());
+                println!("Total: {} caller(s)", output.count);
             }
         }
     }
@@ -300,25 +410,28 @@ pub(crate) fn cmd_callees(
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
-        let mut callees = cross_ctx
-            .get_callees_cross(name)
-            .context("Failed to load cross-project callees")?;
-        callees.truncate(limit);
+        let output = callees_cross_core(
+            &mut cross_ctx,
+            &CalleesArgs {
+                name: name.to_string(),
+                limit,
+            },
+        )?;
 
         if json {
-            crate::cli::json_envelope::emit_json(&callees)?;
+            crate::cli::json_envelope::emit_json(&output)?;
         } else {
             println!("Functions called by '{}' (cross-project):", name.cyan());
             println!();
-            if callees.is_empty() {
+            if output.calls.is_empty() {
                 println!("  (no function calls found)");
             } else {
-                for c in &callees {
+                for c in &output.calls {
                     println!("  {} [{}]", c.name, c.project.dimmed());
                 }
             }
             println!();
-            println!("Total: {} call(s)", callees.len());
+            println!("Total: {} call(s)", output.count);
         }
         return Ok(());
     }
@@ -382,16 +495,54 @@ mod tests {
             name: "foo".into(),
             file: "src/lib.rs".into(),
             line_start: 42,
+            project: String::new(),
         };
         let json = serde_json::to_value(&entry).unwrap();
         assert!(json.get("line_start").is_some());
         assert!(json.get("line").is_none());
+        // Single-project entry omits the empty `project` field.
+        assert!(json.get("project").is_none());
+    }
+
+    #[test]
+    fn test_caller_entry_project_field_present_when_set() {
+        let entry = CallerEntry {
+            name: "foo".into(),
+            file: "src/lib.rs".into(),
+            line_start: 42,
+            project: "openclaw".into(),
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["project"], "openclaw");
     }
 
     #[test]
     fn test_build_callers_empty() {
-        let output = build_callers(&[]);
-        assert!(output.is_empty());
+        let output = build_callers("foo", &[]);
+        assert_eq!(output.count, 0);
+        assert!(output.callers.is_empty());
+        let json = serde_json::to_value(&output).unwrap();
+        // Callers now shares the callees object topology: {name, callers, count}.
+        assert_eq!(json["name"], "foo");
+        assert!(json["callers"].as_array().unwrap().is_empty());
+        assert_eq!(json["count"], 0);
+    }
+
+    #[test]
+    fn test_build_callers_object_shape() {
+        let info = vec![CallerInfo {
+            name: "caller_fn".into(),
+            file: std::path::PathBuf::from("src/lib.rs"),
+            line: 12,
+        }];
+        let output = build_callers("target", &info);
+        let json = serde_json::to_value(&output).unwrap();
+        assert_eq!(json["name"], "target");
+        assert_eq!(json["count"], 1);
+        assert_eq!(json["callers"][0]["name"], "caller_fn");
+        assert_eq!(json["callers"][0]["line_start"], 12);
+        // Mirror of callees: agents key-probe `callers` vs `calls`.
+        assert!(json.get("calls").is_none());
     }
 
     #[test]

--- a/src/cli/commands/graph/explain.rs
+++ b/src/cli/commands/graph/explain.rs
@@ -231,6 +231,7 @@ pub(crate) fn build_explain_output(data: &ExplainData, root: &Path) -> ExplainOu
             name: c.name.clone(),
             file: rel_display(&c.file, root),
             line_start: c.line,
+            project: String::new(),
         })
         .collect();
 
@@ -240,6 +241,7 @@ pub(crate) fn build_explain_output(data: &ExplainData, root: &Path) -> ExplainOu
         .map(|(name, line)| CalleeEntry {
             name: name.clone(),
             line_start: *line,
+            project: String::new(),
         })
         .collect();
 
@@ -501,10 +503,12 @@ mod output_tests {
                 name: "caller_a".into(),
                 file: "src/a.rs".into(),
                 line_start: 42,
+                project: String::new(),
             }],
             callees: vec![CalleeEntry {
                 name: "callee_b".into(),
                 line_start: 3,
+                project: String::new(),
             }],
             similar: vec![SimilarEntry {
                 name: "baz".into(),
@@ -552,6 +556,7 @@ mod output_tests {
                 name: "call<U>".into(),
                 file: "src/a.rs".into(),
                 line_start: 5,
+                project: String::new(),
             }],
             callees: vec![],
             similar: vec![],

--- a/src/cli/commands/graph/impact.rs
+++ b/src/cli/commands/graph/impact.rs
@@ -155,6 +155,36 @@ pub(crate) fn impact_core(
     })
 }
 
+// ─── Cross-project core ──────────────────────────────────────────────────────
+
+/// Surface-agnostic core for `cqs impact <name> --cross-project`.
+///
+/// Runs the cross-project BFS impact analysis, applies the shared `1..=100`
+/// per-section cap, and returns the truncated [`ImpactResult`]. Unlike the
+/// single-project core this carries no kind-fallback and no test suggestions
+/// — the cross-project JSON has always been the bare `impact_to_json(result)`
+/// shape (no `kind` / `test_suggestions`). Both surfaces (CLI cross branch,
+/// daemon cross branch) call this so the retrieval + truncate discipline
+/// can't drift; the adapter chooses text / mermaid / JSON rendering.
+pub(crate) fn impact_cross_core(
+    cross_ctx: &mut cqs::cross_project::CrossProjectContext,
+    args: &ImpactArgs,
+) -> Result<cqs::ImpactResult> {
+    let _span =
+        tracing::info_span!("impact_cross_core", name = %args.name, limit = args.limit).entered();
+    let depth = args.depth.clamp(1, 10);
+    let limit = args.limit.clamp(1, 100);
+    let mut result = cqs::cross_project::analyze_impact_cross(
+        cross_ctx,
+        &args.name,
+        depth,
+        args.suggest_tests,
+        args.include_types,
+    )?;
+    truncate_impact_sections(&mut result, limit);
+    Ok(result)
+}
+
 // ─── CLI command (thin adapter over the core) ──────────────────────────────
 
 // The CLI dispatcher inflates a shared arg struct rather than calling this
@@ -176,17 +206,17 @@ pub(crate) fn cmd_impact(
     let root = &ctx.root;
 
     if cross_project {
-        let depth = depth.clamp(1, 10);
-        let limit = limit.clamp(1, 100);
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(root)?;
-        let mut result = cqs::cross_project::analyze_impact_cross(
+        let result = impact_cross_core(
             &mut cross_ctx,
-            name,
-            depth,
-            do_suggest_tests,
-            include_types,
+            &ImpactArgs {
+                name: name.to_string(),
+                depth,
+                limit,
+                suggest_tests: do_suggest_tests,
+                include_types,
+            },
         )?;
-        truncate_impact_sections(&mut result, limit);
 
         // Exhaustive match — adding a new `OutputFormat` variant fails to
         // compile until every render site adds an arm.

--- a/src/cli/commands/graph/mod.rs
+++ b/src/cli/commands/graph/mod.rs
@@ -10,18 +10,20 @@ mod test_map;
 pub(crate) mod trace;
 
 pub(crate) use callers::{
-    callees_core, callers_core, cmd_callees, cmd_callers, CalleesArgs,
-    CallersArgs as CallersCoreArgs,
+    callees_core, callees_cross_core, callers_core, callers_cross_core, cmd_callees, cmd_callers,
+    CalleesArgs, CallersArgs as CallersCoreArgs,
 };
 pub(crate) use deps::{cmd_deps, deps_core, DepsArgs as DepsCoreArgs};
 pub(crate) use explain::cmd_explain;
-pub(crate) use impact::{cmd_impact, impact_core, ImpactArgs as ImpactCoreArgs};
+pub(crate) use impact::{cmd_impact, impact_core, impact_cross_core, ImpactArgs as ImpactCoreArgs};
 pub(crate) use impact_diff::cmd_impact_diff;
 pub(crate) use test_map::{
-    build_test_map, build_test_map_output, cmd_test_map, test_map_core, test_map_max_nodes,
+    build_test_map_output, cmd_test_map, test_map_core, test_map_cross_core, test_map_max_nodes,
     TestMapArgs as TestMapCoreArgs,
 };
-pub(crate) use trace::{cmd_trace, trace_core, trace_max_nodes, TraceArgs as TraceCoreArgs};
+pub(crate) use trace::{
+    cmd_trace, trace_core, trace_cross_core, trace_max_nodes, TraceArgs as TraceCoreArgs,
+};
 
 use cqs::kind::{detect_kind_for_store, Kind};
 use cqs::store::{ChunkSummary, ReadOnly, Store};

--- a/src/cli/commands/graph/test_map.rs
+++ b/src/cli/commands/graph/test_map.rs
@@ -285,6 +285,40 @@ pub(crate) fn test_map_core(
     )))
 }
 
+// ─── Cross-project core ──────────────────────────────────────────────────────
+
+/// Surface-agnostic core for `cqs test-map <name> --cross-project`.
+///
+/// Loads every project's test chunks, merges their call graphs, runs the
+/// reverse-BFS [`build_test_map`], applies the shared `1..=100` cap, and
+/// returns the truncated [`TestMatch`] list. Carries no kind-fallback (the
+/// cross-project path never had one). Returns the matches rather than the
+/// projected [`TestMapOutput`] so the text adapter keeps access to the call
+/// chain; the JSON adapter wraps with [`build_test_map_output`]. Both
+/// surfaces call this so the merge + truncate discipline can't drift.
+pub(crate) fn test_map_cross_core(
+    cross_ctx: &mut cqs::cross_project::CrossProjectContext,
+    root: &Path,
+    args: &TestMapArgs,
+) -> Result<Vec<TestMatch>> {
+    let _span =
+        tracing::info_span!("test_map_cross_core", name = %args.name, limit = args.limit).entered();
+    let limit = args.limit.clamp(1, 100);
+    let test_chunks = cross_ctx.find_test_chunks_cross()?;
+    let graph = cross_ctx.merged_call_graph()?;
+    let summaries: Vec<ChunkSummary> = test_chunks.iter().map(|tc| tc.chunk.clone()).collect();
+    let mut matches = build_test_map(
+        &args.name,
+        &graph,
+        &summaries,
+        root,
+        args.max_depth,
+        args.max_nodes,
+    );
+    matches.truncate(limit);
+    Ok(matches)
+}
+
 // ─── CLI command (thin adapter over the core) ──────────────────────────────
 
 pub(crate) fn cmd_test_map(
@@ -302,22 +336,16 @@ pub(crate) fn cmd_test_map(
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
-        let test_chunks = cross_ctx.find_test_chunks_cross()?;
-
-        // Build a merged call graph from all projects
-        let graph = cross_ctx.merged_call_graph()?;
-        let summaries: Vec<cqs::store::ChunkSummary> =
-            test_chunks.iter().map(|tc| tc.chunk.clone()).collect();
-
-        let mut matches = build_test_map(
-            name,
-            &graph,
-            &summaries,
+        let matches = test_map_cross_core(
+            &mut cross_ctx,
             &ctx.root,
-            max_depth,
-            test_map_max_nodes(),
-        );
-        matches.truncate(limit);
+            &TestMapArgs {
+                name: name.to_string(),
+                max_depth,
+                limit,
+                max_nodes: test_map_max_nodes(),
+            },
+        )?;
 
         if json {
             let output = build_test_map_output(name, &matches);

--- a/src/cli/commands/graph/trace.rs
+++ b/src/cli/commands/graph/trace.rs
@@ -216,6 +216,34 @@ pub(crate) fn trace_core(
     Ok(TraceCoreOutput::Trace(output))
 }
 
+// ─── Cross-project core ──────────────────────────────────────────────────────
+
+/// Surface-agnostic core for `cqs trace <source> <target> --cross-project`.
+///
+/// Runs the cross-project shortest-path BFS and projects to the
+/// [`cqs::cross_project::CrossProjectTraceResult`] both surfaces emit
+/// (`{source, target, path?, depth?, found}` with per-hop `project`).
+/// Carries no kind-fallback — the cross-project path never had one. Both the
+/// CLI and daemon cross branches call this so the result assembly can't
+/// drift. `max_depth` is the only knob; trace returns a single shortest path
+/// so there is no `limit` cap to apply.
+pub(crate) fn trace_cross_core(
+    cross_ctx: &mut cqs::cross_project::CrossProjectContext,
+    source: &str,
+    target: &str,
+    max_depth: usize,
+) -> Result<cqs::cross_project::CrossProjectTraceResult> {
+    let _span = tracing::info_span!("trace_cross_core", source, target).entered();
+    let result = cqs::cross_project::trace_cross(cross_ctx, source, target, max_depth)?;
+    Ok(cqs::cross_project::CrossProjectTraceResult {
+        source: source.to_string(),
+        target: target.to_string(),
+        depth: result.as_ref().map(|p| p.len().saturating_sub(1)),
+        found: result.is_some(),
+        path: result,
+    })
+}
+
 // ─── CLI command ────────────────────────────────────────────────────────────
 
 pub(crate) fn cmd_trace(
@@ -235,15 +263,7 @@ pub(crate) fn cmd_trace(
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
-        let result = cqs::cross_project::trace_cross(&mut cross_ctx, source, target, max_depth)?;
-
-        let trace_result = cqs::cross_project::CrossProjectTraceResult {
-            source: source.to_string(),
-            target: target.to_string(),
-            depth: result.as_ref().map(|p| p.len().saturating_sub(1)),
-            found: result.is_some(),
-            path: result,
-        };
+        let trace_result = trace_cross_core(&mut cross_ctx, source, target, max_depth)?;
 
         // Exhaustive match instead of if/else-if chains so a future
         // `OutputFormat` variant fails to compile until every render site

--- a/src/cli/commands/index/stale.rs
+++ b/src/cli/commands/index/stale.rs
@@ -69,17 +69,14 @@ pub(crate) fn build_stale(report: &StaleReport) -> StaleOutput {
 // Args + core (surface-agnostic, MCP-ready)
 // ---------------------------------------------------------------------------
 
-/// Input for [`stale_core`]. `count_only` only affects rendering / the
-/// daemon's JSON projection — the core always returns the full
-/// [`StaleOutput`]; adapters decide whether to drop the per-file lists.
+/// Input for [`stale_core`]. The core has no tunable inputs of its own — the
+/// file set and root are passed as explicit parameters, and `--count-only` is
+/// an adapter-side render flag (it never changes what the core computes), so
+/// it lives on the adapter signature rather than here. An empty struct keeps
+/// the surface-agnostic Args convention every other core follows (a wire
+/// caller inflates it from `{}`).
 #[derive(Debug, Default, serde::Deserialize)]
-pub(crate) struct StaleArgs {
-    /// Suppress the per-file `stale` / `missing` lists in the rendered output
-    /// (counts only). The core ignores this — it is honored by the adapter so
-    /// the typed schema stays complete for callers that want the file lists.
-    #[serde(default)]
-    pub count_only: bool,
-}
+pub(crate) struct StaleArgs {}
 
 /// Surface-agnostic core for `cqs stale`.
 ///
@@ -87,10 +84,10 @@ pub(crate) struct StaleArgs {
 /// returns the full typed [`StaleOutput`]. The adapter owns file enumeration
 /// so the hot daemon path can keep its cached `file_set` (re-enumerating on
 /// every probe would be a perf regression); the CLI uses
-/// [`enumerate_for_stale`] to build the set once. `count_only` lives on
-/// [`StaleArgs`] for schema completeness but does not change what the core
-/// computes — the adapter chooses how much to render (CLI hides the file list
-/// in text mode; the daemon projects a 3-field count subset).
+/// [`enumerate_for_stale`] to build the set once. `--count-only` is an
+/// adapter-side render flag (CLI hides the file list in text mode; the daemon
+/// projects a 3-field count subset) — it never reaches the core, which always
+/// computes the full [`StaleOutput`].
 pub(crate) fn stale_core(
     store: &cqs::Store<cqs::store::ReadOnly>,
     root: &std::path::Path,
@@ -126,9 +123,10 @@ pub(crate) fn cmd_stale(
     let store = &ctx.store;
     let root = &ctx.root;
 
-    let args = StaleArgs { count_only };
+    // `--count-only` is an adapter-side render flag — the core always returns
+    // the full StaleOutput; the CLI decides whether to print the file lists.
     let file_set = enumerate_for_stale(root)?;
-    let output = stale_core(store, root, &file_set, &args)?;
+    let output = stale_core(store, root, &file_set, &StaleArgs::default())?;
 
     if json {
         crate::cli::json_envelope::emit_json(&output)?;
@@ -161,9 +159,8 @@ pub(crate) fn cmd_stale(
 
         // File list (unless --count-only). `output` already carries
         // normalized paths (build_stale normalizes), so no re-normalize here.
-        // Read `count_only` off the typed args so the field has a live reader
-        // (it is otherwise adapter-honored, not core-honored).
-        if !args.count_only && !ctx.cli.quiet {
+        // `count_only` is the adapter-side render flag (off the core Args).
+        if !count_only && !ctx.cli.quiet {
             if !output.stale.is_empty() {
                 println!("\nStale:");
                 for f in &output.stale {
@@ -191,48 +188,33 @@ pub(crate) fn cmd_stale(
 mod tests {
     use super::*;
 
-    /// `StaleArgs` defaults must match the clap `args::StaleArgs` defaults so
-    /// the wire surface and the core agree on the omitted `--count-only`
-    /// behavior. Parses a real minimal `cqs stale` invocation.
+    /// The clap-side `--count-only` flag lives on the adapter (`args::StaleArgs`),
+    /// not the core Args. Pin that the clap surface still parses it — the CLI
+    /// adapter reads it to decide whether to print the file lists.
     #[test]
-    fn stale_args_default_matches_clap_defaults() {
+    fn stale_count_only_flag_parses_on_adapter_args() {
         use clap::Parser;
         #[derive(Parser)]
         struct Wrap {
             #[command(flatten)]
             args: crate::cli::args::StaleArgs,
         }
-        let clap_args = Wrap::try_parse_from(["cqs-stale"]).unwrap().args;
-        let core = StaleArgs {
-            count_only: clap_args.count_only,
-        };
-        assert_eq!(
-            core.count_only,
-            StaleArgs::default().count_only,
-            "clap stale default drifted from StaleArgs::default"
-        );
-    }
-
-    /// `--count-only` flows into the core Args unchanged.
-    #[test]
-    fn stale_args_count_only_flag_parses() {
-        use clap::Parser;
-        #[derive(Parser)]
-        struct Wrap {
-            #[command(flatten)]
-            args: crate::cli::args::StaleArgs,
-        }
-        let clap_args = Wrap::try_parse_from(["cqs-stale", "--count-only"])
+        let default = Wrap::try_parse_from(["cqs-stale"]).unwrap().args;
+        assert!(!default.count_only, "clap default is count_only=false");
+        let flagged = Wrap::try_parse_from(["cqs-stale", "--count-only"])
             .unwrap()
             .args;
-        assert!(clap_args.count_only);
+        assert!(flagged.count_only);
     }
 
-    /// Empty-object deserialize (MCP no-params) yields the default args.
+    /// The core Args is parameterless: empty-object deserialize (MCP no-params)
+    /// succeeds and equals the default.
     #[test]
-    fn stale_args_deserialize_empty_matches_default() {
-        let from_empty: StaleArgs = serde_json::from_str("{}").unwrap();
-        assert_eq!(from_empty.count_only, StaleArgs::default().count_only);
+    fn stale_args_deserialize_empty_succeeds() {
+        let _from_empty: StaleArgs = serde_json::from_str("{}").unwrap();
+        // Empty struct → trivially equal to default; constructing both is the
+        // assertion that `{}` is a valid wire payload.
+        let _default = StaleArgs::default();
     }
 
     #[test]

--- a/src/cli/commands/infra/audit_mode.rs
+++ b/src/cli/commands/infra/audit_mode.rs
@@ -35,12 +35,25 @@ pub(crate) struct AuditModeOutput {
 
 /// Input for [`audit_mode_core`]. `state == None` is the query path (report
 /// current state without mutating); `Some(On/Off)` toggles and persists.
-pub(crate) struct AuditModeArgs<'a> {
+///
+/// Owned + `Deserialize` like every other core Args, so a wire/MCP caller can
+/// inflate it from `{"state": "on", "expires": "30m"}`. `expires` defaults to
+/// `30m` when omitted, matching the clap default.
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct AuditModeArgs {
     /// `None` → query current state; `Some(On)` / `Some(Off)` → set it.
-    pub state: Option<&'a AuditModeState>,
+    #[serde(default)]
+    pub state: Option<AuditModeState>,
     /// Expiry duration for `On` (e.g. `30m`), parsed by `parse_duration`.
     /// Ignored on the query and `Off` paths.
-    pub expires: &'a str,
+    #[serde(default = "default_audit_expires")]
+    pub expires: String,
+}
+
+/// `#[serde(default)]` for [`AuditModeArgs::expires`] — mirrors the clap
+/// `--expires` default so wire callers that omit it get the same `30m`.
+fn default_audit_expires() -> String {
+    "30m".to_string()
 }
 
 /// Surface-agnostic core for `cqs audit-mode [on|off]`. Reads or persists the
@@ -50,11 +63,11 @@ pub(crate) struct AuditModeArgs<'a> {
 /// audit-mode is process-local posture set by the CLI before a review.
 pub(crate) fn audit_mode_core(
     cqs_dir: &std::path::Path,
-    args: &AuditModeArgs<'_>,
+    args: &AuditModeArgs,
 ) -> Result<AuditModeOutput> {
     let _span = tracing::info_span!("audit_mode_core").entered();
 
-    let Some(state) = args.state else {
+    let Some(state) = args.state.as_ref() else {
         // Query path — report current state, no mutation.
         let mode = load_audit_state(cqs_dir);
         return Ok(if mode.is_active() {
@@ -76,7 +89,7 @@ pub(crate) fn audit_mode_core(
 
     match state {
         AuditModeState::On => {
-            let duration = parse_duration(args.expires)?;
+            let duration = parse_duration(&args.expires)?;
             let expires_at = Utc::now() + duration;
             let mode = AuditMode {
                 enabled: true,
@@ -123,7 +136,13 @@ pub(crate) fn cmd_audit_mode(
         bail!("No .cqs directory found. Run 'cqs init' first.");
     }
 
-    let output = audit_mode_core(&cqs_dir, &AuditModeArgs { state, expires })?;
+    let output = audit_mode_core(
+        &cqs_dir,
+        &AuditModeArgs {
+            state: state.cloned(),
+            expires: expires.to_string(),
+        },
+    )?;
 
     if json {
         crate::cli::json_envelope::emit_json(&output)?;
@@ -169,8 +188,8 @@ mod tests {
         let on = audit_mode_core(
             cqs_dir,
             &AuditModeArgs {
-                state: Some(&AuditModeState::On),
-                expires: "30m",
+                state: Some(AuditModeState::On),
+                expires: "30m".to_string(),
             },
         )
         .unwrap();
@@ -181,7 +200,7 @@ mod tests {
             cqs_dir,
             &AuditModeArgs {
                 state: None,
-                expires: "30m",
+                expires: "30m".to_string(),
             },
         )
         .unwrap();
@@ -190,8 +209,8 @@ mod tests {
         let off = audit_mode_core(
             cqs_dir,
             &AuditModeArgs {
-                state: Some(&AuditModeState::Off),
-                expires: "30m",
+                state: Some(AuditModeState::Off),
+                expires: "30m".to_string(),
             },
         )
         .unwrap();
@@ -201,11 +220,29 @@ mod tests {
             cqs_dir,
             &AuditModeArgs {
                 state: None,
-                expires: "30m",
+                expires: "30m".to_string(),
             },
         )
         .unwrap();
         assert!(!queried_off.audit_mode, "query after Off must report off");
+    }
+
+    /// `AuditModeArgs` deserializes from the wire object every other core
+    /// Args accepts. `state` accepts lowercase `"on"`/`"off"`; `expires`
+    /// defaults to `30m` when omitted (matching the clap default).
+    #[test]
+    fn audit_mode_args_deserialize_from_wire() {
+        let full: AuditModeArgs = serde_json::from_str(r#"{"state":"on","expires":"1h"}"#).unwrap();
+        assert!(matches!(full.state, Some(AuditModeState::On)));
+        assert_eq!(full.expires, "1h");
+
+        let off: AuditModeArgs = serde_json::from_str(r#"{"state":"off"}"#).unwrap();
+        assert!(matches!(off.state, Some(AuditModeState::Off)));
+        assert_eq!(off.expires, "30m", "expires default mirrors clap --expires");
+
+        let query: AuditModeArgs = serde_json::from_str("{}").unwrap();
+        assert!(query.state.is_none(), "empty object → query path");
+        assert_eq!(query.expires, "30m");
     }
 
     #[test]

--- a/src/cli/commands/infra/cache_cmd.rs
+++ b/src/cli/commands/infra/cache_cmd.rs
@@ -217,9 +217,18 @@ pub(crate) fn cache_prune_core(
     }
 }
 
+/// Input for [`cache_compact_core`]. `cqs cache compact` takes no positional
+/// or flag input; the empty struct keeps the surface-agnostic Args convention
+/// every other core follows (a wire caller inflates it from `{}`).
+#[derive(Debug, Default, serde::Deserialize)]
+pub(crate) struct CacheCompactArgs {}
+
 /// Surface-agnostic core for `cqs cache compact`. VACUUMs the DB and reports
 /// the size delta. Mutating (rewrites the DB file).
-pub(crate) fn cache_compact_core(cache: &EmbeddingCache) -> Result<CacheCompactOutput> {
+pub(crate) fn cache_compact_core(
+    cache: &EmbeddingCache,
+    _args: &CacheCompactArgs,
+) -> Result<CacheCompactOutput> {
     let _span = tracing::info_span!("cache_compact_core").entered();
     let before = cache.stats().context("Failed to read pre-compact stats")?;
     cache.compact().context("Failed to VACUUM cache DB")?;
@@ -367,7 +376,7 @@ fn cache_prune(
 }
 
 fn cache_compact(cache: &EmbeddingCache, json: bool) -> Result<()> {
-    let out = cache_compact_core(cache)?;
+    let out = cache_compact_core(cache, &CacheCompactArgs::default())?;
     if json {
         crate::cli::json_envelope::emit_json(&out)?;
     } else {

--- a/src/cli/commands/infra/reference.rs
+++ b/src/cli/commands/infra/reference.rs
@@ -59,11 +59,17 @@ pub(crate) struct RefRemoveOutput {
     pub name: String,
 }
 
+/// Input for [`ref_list_core`]. `cqs ref list` takes no positional or flag
+/// input; the empty struct keeps the surface-agnostic Args convention every
+/// other core follows (a wire caller inflates it from `{}`).
+#[derive(Debug, Default, serde::Deserialize)]
+pub(crate) struct RefListArgs {}
+
 /// Surface-agnostic core for `cqs ref list`. Loads the project config and,
 /// for each reference, opens its index read-only to read the chunk count
 /// (best-effort: a failed open shows 0 chunks and logs a warning). No daemon
 /// path — reference management is CLI-only.
-pub(crate) fn ref_list_core(root: &std::path::Path) -> RefListOutput {
+pub(crate) fn ref_list_core(root: &std::path::Path, _args: &RefListArgs) -> RefListOutput {
     let _span = tracing::info_span!("ref_list_core").entered();
     let config = cqs::config::Config::load(root);
     let references = config
@@ -509,7 +515,7 @@ fn cmd_ref_list(cli: &Cli, json: bool) -> Result<()> {
     let root = find_project_root();
     let want_json = json || cli.json;
 
-    let out = ref_list_core(&root);
+    let out = ref_list_core(&root, &RefListArgs::default());
 
     if want_json {
         // `{references: [...]}` envelope (empty list when none configured) so

--- a/src/cli/commands/infra/slot.rs
+++ b/src/cli/commands/infra/slot.rs
@@ -172,10 +172,23 @@ pub(crate) fn cmd_slot(cli: &Cli, subcmd: &SlotCommand) -> Result<()> {
     }
 }
 
+/// Input for [`slot_list_core`]. `cqs slot list` takes no positional or flag
+/// input; the empty struct keeps the surface-agnostic Args convention every
+/// other core follows (a wire caller inflates it from `{}`).
+#[derive(Debug, Default, serde::Deserialize)]
+pub(crate) struct SlotListArgs {}
+
+/// Input for [`slot_active_core`]. Parameterless, like [`SlotListArgs`].
+#[derive(Debug, Default, serde::Deserialize)]
+pub(crate) struct SlotActiveArgs {}
+
 /// Surface-agnostic core for `cqs slot list`. Reads each slot's index for
 /// chunk count + model metadata (best-effort — listing succeeds even if one
 /// slot's DB is unreadable). No daemon path: slot management is CLI-only.
-pub(crate) fn slot_list_core(project_cqs_dir: &Path) -> Result<SlotListOutput> {
+pub(crate) fn slot_list_core(
+    project_cqs_dir: &Path,
+    _args: &SlotListArgs,
+) -> Result<SlotListOutput> {
     let _span = tracing::info_span!("slot_list_core").entered();
     let names = list_slots(project_cqs_dir)?;
     let active = read_active_slot(project_cqs_dir).unwrap_or_else(|| DEFAULT_SLOT.to_string());
@@ -188,7 +201,7 @@ pub(crate) fn slot_list_core(project_cqs_dir: &Path) -> Result<SlotListOutput> {
 
 fn slot_list(project_cqs_dir: &Path, json: bool) -> Result<()> {
     let _span = tracing::info_span!("slot_list").entered();
-    let out = slot_list_core(project_cqs_dir)?;
+    let out = slot_list_core(project_cqs_dir, &SlotListArgs::default())?;
     let active = &out.active;
     let entries = &out.slots;
 
@@ -526,7 +539,10 @@ fn guard_against_active_daemon(project_cqs_dir: &Path, name: &str, force: bool) 
 
 /// Surface-agnostic core for `cqs slot active`. Resolves the active slot name
 /// and its provenance.
-pub(crate) fn slot_active_core(project_cqs_dir: &Path) -> Result<SlotActiveOutput> {
+pub(crate) fn slot_active_core(
+    project_cqs_dir: &Path,
+    _args: &SlotActiveArgs,
+) -> Result<SlotActiveOutput> {
     let _span = tracing::info_span!("slot_active_core").entered();
     let resolved =
         cqs::slot::resolve_slot_name(None, project_cqs_dir).map_err(anyhow::Error::from)?;
@@ -539,7 +555,7 @@ pub(crate) fn slot_active_core(project_cqs_dir: &Path) -> Result<SlotActiveOutpu
 
 fn slot_active(project_cqs_dir: &Path, json: bool) -> Result<()> {
     let _span = tracing::info_span!("slot_active").entered();
-    let out = slot_active_core(project_cqs_dir)?;
+    let out = slot_active_core(project_cqs_dir, &SlotActiveArgs::default())?;
     if json {
         crate::cli::json_envelope::emit_json(&out)?;
     } else {
@@ -911,7 +927,7 @@ mod tests {
         let cqs = tmp.path().join(".cqs");
         write_active_slot(&cqs, "alpha").unwrap();
 
-        let out = slot_list_core(&cqs).unwrap();
+        let out = slot_list_core(&cqs, &SlotListArgs::default()).unwrap();
         assert_eq!(out.active, "alpha");
         assert_eq!(out.slots.len(), 2);
         let json = serde_json::to_value(&out).unwrap();
@@ -931,7 +947,7 @@ mod tests {
         let cqs = tmp.path().join(".cqs");
         write_active_slot(&cqs, "only").unwrap();
 
-        let out = slot_active_core(&cqs).unwrap();
+        let out = slot_active_core(&cqs, &SlotActiveArgs::default()).unwrap();
         let json = serde_json::to_value(&out).unwrap();
         for key in ["active", "source", "active_slot_file"] {
             assert!(json.get(key).is_some(), "slot active missing `{key}`");

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -62,7 +62,6 @@ pub(crate) use search::GatherContext;
 // through `test_map_core`). The other `build_*` / `chunks_to_definitions`
 // helpers are now reached only inside the graph cores, so they no longer
 // re-export here.
-pub(crate) use graph::build_test_map;
 pub(crate) use graph::build_test_map_output;
 pub(crate) use graph::cmd_callees;
 pub(crate) use graph::cmd_callers;
@@ -77,8 +76,9 @@ pub(crate) use graph::cmd_trace;
 // `serde_json::to_value` / `to_value()` without being named at the call
 // site, so they stay internal to the graph module.
 pub(crate) use graph::{
-    callees_core, callers_core, deps_core, impact_core, test_map_core, test_map_max_nodes,
-    trace_core, trace_max_nodes, CalleesArgs, CallersCoreArgs, DepsCoreArgs, ImpactCoreArgs,
+    callees_core, callees_cross_core, callers_core, callers_cross_core, deps_core, impact_core,
+    impact_cross_core, test_map_core, test_map_cross_core, test_map_max_nodes, trace_core,
+    trace_cross_core, trace_max_nodes, CalleesArgs, CallersCoreArgs, DepsCoreArgs, ImpactCoreArgs,
     TestMapCoreArgs, TraceCoreArgs,
 };
 

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -82,7 +82,8 @@ impl TextJsonArgs {
 pub use cqs::ci::GateThreshold;
 
 /// Audit mode state for the audit-mode command
-#[derive(Clone, Debug, clap::ValueEnum)]
+#[derive(Clone, Debug, clap::ValueEnum, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum AuditModeState {
     /// Enable audit mode
     On,


### PR DESCRIPTION
## Audit v1.42.0 — command-core hygiene (API-V1.42-3/8, CQ-V1.42-11 + riders API-V1.42-4, TC-HAP-V1.42-7)

- **One graph output topology (API-V1.42-3 + API-V1.42-4 rider):** `cqs callers X --json` returns `{name, callers: [...], count}` (was a bare array; callees already used the object shape — the module doc's type-discrimination claim was only true for one of them). `--cross-project` now returns the same object for both commands with entries gaining `project` (was a flat different-schema array). Single-project entries are byte-identical except callers' new enclosing object. Breaking JSON changes, no external users; all shape-pinning tests updated deliberately (listed in the diff).
- **Cross-project branches extracted into parity-tested cores (CQ-V1.42-11):** the duplicated retrieval+truncate logic in the daemon dispatchers and `cmd_*` for callers/callees/impact/test-map/trace now lives in `*_cross_core` functions with 5 new CLI==daemon parity tests. Impact/test-map/trace cross-project output shapes unchanged — pure extraction.
- **Args-layer conventions unified (API-V1.42-8):** `AuditModeArgs` gets owned fields + `Deserialize` (was the one core Args that couldn't be a wire payload); parameterless cores standardized on empty Args structs; `count_only` moved from `StaleArgs` to the adapter signature.
- **Parity tests assert values (TC-HAP-V1.42-7 rider):** every existing parity test gained a fixture-grounded value assert (seeded caller name etc.) so a both-sides-empty regression fails; overstating docstrings corrected.

Tests: 9 new + value-assert strengthening across the parity suite; graph/dispatch/infra suites all green (full list in the commit). fmt + clippy `--all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
