### PR TITLE
fix(daemon): text-mode invocations bypass the daemon — output is surface-independent (closes #1734)

### DIFF
--- a/src/cli/commands/io/notes.rs
+++ b/src/cli/commands/io/notes.rs
@@ -136,6 +136,22 @@ pub(crate) enum NotesCommand {
     },
 }
 
+impl NotesCommand {
+    /// The effective output format for this notes subcommand, resolving
+    /// `--json` over the default. Every arm carries a `TextJsonArgs` group, so
+    /// this is always concrete. Consumed by `Commands::effective_output_format`
+    /// so the daemon-forward text-mode gate can classify `notes list` (the
+    /// only daemon-dispatchable notes arm) by its own `--json` flag.
+    pub(crate) fn effective_output_format(&self) -> crate::cli::definitions::OutputFormat {
+        match self {
+            NotesCommand::List { output, .. }
+            | NotesCommand::Add { output, .. }
+            | NotesCommand::Update { output, .. }
+            | NotesCommand::Remove { output, .. } => output.effective_format(),
+        }
+    }
+}
+
 /// Handle all `notes` subcommands.
 ///
 /// Runs in the normal Group-B dispatch path. `ctx` is optional because

--- a/src/cli/definitions.rs
+++ b/src/cli/definitions.rs
@@ -1006,6 +1006,66 @@ pub(super) use super::commands::{
     CacheCommand, HookCommand, ModelCommand, NotesCommand, ProjectCommand, RefCommand, SlotCommand,
 };
 
+impl Commands {
+    /// The effective output format this invocation requests, for the
+    /// daemon-forward text-vs-JSON gate.
+    ///
+    /// Returns `Some(format)` for every variant carrying an `output`
+    /// (`OutputArgs` / `TextJsonArgs`) flag group, resolving `--json` over
+    /// `--format`. Returns `None` for variants with no output-format flag
+    /// (lifecycle / mutation / subcommand-dispatch variants), which are all
+    /// CLI-only and never reach the daemon-forward gate.
+    ///
+    /// The daemon wire shape is structured JSON; the CLI surface renders
+    /// prose for text mode through each command's own renderer. The gate
+    /// uses this to keep text-mode invocations on the CLI path so output is
+    /// surface-independent — a daemon never serves the JSON payload where the
+    /// CLI would have rendered text.
+    ///
+    /// Every daemon-dispatchable variant is pinned to return `Some` by
+    /// `daemon_dispatchable_variants_report_an_output_format` in the dispatch
+    /// tests, so a new daemon command without an arm here fails at test time
+    /// rather than leaking a JSON payload daemon-up.
+    pub(crate) fn effective_output_format(&self) -> Option<OutputFormat> {
+        match self {
+            Commands::Stats { output }
+            | Commands::Health { output }
+            | Commands::Refresh { output } => Some(output.effective_format()),
+            Commands::Blame { output, .. }
+            | Commands::Deps { output, .. }
+            | Commands::Callers { output, .. }
+            | Commands::Callees { output, .. }
+            | Commands::Onboard { output, .. }
+            | Commands::Explain { output, .. }
+            | Commands::Similar { output, .. }
+            | Commands::ImpactDiff { output, .. }
+            | Commands::Review { output, .. }
+            | Commands::Ci { output, .. }
+            | Commands::TestMap { output, .. }
+            | Commands::Context { output, .. }
+            | Commands::Dead { output, .. }
+            | Commands::Gather { output, .. }
+            | Commands::Stale { output, .. }
+            | Commands::Suggest { output, .. }
+            | Commands::Read { output, .. }
+            | Commands::Related { output, .. }
+            | Commands::Where { output, .. }
+            | Commands::Scout { output, .. }
+            | Commands::Plan { output, .. }
+            | Commands::Task { output, .. } => Some(output.effective_format()),
+            Commands::Impact { output, .. } | Commands::Trace { output, .. } => {
+                Some(output.effective_format())
+            }
+            // `notes` carries its `--json` on the inner subcommand. Only
+            // `notes list` is daemon-dispatchable; delegating keeps its
+            // text-mode invocation on the CLI path (the JSON payload would
+            // otherwise leak) while `notes list --json` forwards.
+            Commands::Notes { subcmd } => Some(subcmd.effective_output_format()),
+            _ => None,
+        }
+    }
+}
+
 /// Classifier used by `try_daemon_query` to decide whether a CLI command can
 /// be forwarded to the batch daemon.
 ///

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -261,6 +261,34 @@ pub(crate) fn cmd_completions(shell: clap_complete::Shell) {
     clap_complete::generate(shell, &mut Cli::command(), "cqs", &mut std::io::stdout());
 }
 
+/// `true` when this invocation requests JSON output and so is forwardable to
+/// the daemon, which serves the structured JSON payload.
+///
+/// Resolution:
+/// - Top-level `--json` (`cli.json`) forces JSON for every command.
+/// - Subcommands resolve their own `--json` / `--format json` via
+///   [`Commands::effective_output_format`].
+/// - The bare-query path (`cqs "query"`, no subcommand) has no per-command
+///   output group; it is JSON only when top-level `--json` is set.
+///
+/// Text mode (everything else) returns `false` so the caller keeps the
+/// command on the CLI path: text-mode invocations render the payload through
+/// the command's own renderer, so output is surface-independent rather than
+/// the raw daemon JSON payload.
+#[cfg(unix)]
+fn daemon_invocation_is_json(cli: &Cli) -> bool {
+    use crate::cli::definitions::OutputFormat;
+    if cli.json {
+        return true;
+    }
+    match cli.command.as_ref() {
+        Some(cmd) => matches!(cmd.effective_output_format(), Some(OutputFormat::Json)),
+        // Bare-query search: text by default, JSON only under top-level
+        // `--json` (handled above).
+        None => false,
+    }
+}
+
 /// `true` when the `CQS_SLOT` env var pins a slot — i.e. it is set to a
 /// non-empty (post-trim) value. Mirrors the semantics of
 /// `slot::resolve_slot_name`, which trims and treats empty/whitespace (and
@@ -361,6 +389,19 @@ fn try_daemon_query(cqs_dir: &std::path::Path, cli: &Cli) -> Result<Option<Strin
         if cmd.batch_support() == BatchSupport::Cli {
             return Ok(None);
         }
+    }
+
+    // Text-mode invocations stay on the CLI path. The daemon wire shape is
+    // structured JSON (the agent-facing contract); the CLI renders prose for
+    // text mode through each command's own renderer, which often needs the
+    // open store (e.g. `impact` re-resolves the relative file label) and so
+    // can't be reproduced from the JSON payload alone. Forwarding a text-mode
+    // query would print that JSON payload instead of the rendered text —
+    // output would depend on whether a daemon happened to serve it. Bypassing
+    // here keeps text output surface-independent at the cost of the daemon
+    // fast path for text mode only; `--json` keeps the fast path.
+    if !daemon_invocation_is_json(cli) {
+        return Ok(None);
     }
 
     let sock_path = super::daemon_socket_path(cqs_dir);
@@ -709,5 +750,121 @@ mod tests {
             !spec.bare_query_strip.contains("--rrf"),
             "`--rrf` is a search knob and must forward on bare queries"
         );
+    }
+
+    /// Parse `argv` (after the implicit `cqs`) into a `Cli`, returning the
+    /// JSON-mode decision the daemon-forward gate makes for it.
+    fn gate_is_json(argv: &[&str]) -> bool {
+        use clap::Parser as _;
+        let mut full = vec!["cqs"];
+        full.extend_from_slice(argv);
+        let cli = Cli::try_parse_from(full).expect("argv must parse");
+        daemon_invocation_is_json(&cli)
+    }
+
+    /// Every daemon-dispatchable command must report a concrete output format
+    /// (`Some(..)`) so the text-mode gate can classify it. A new daemon
+    /// command added without an arm in `Commands::effective_output_format`
+    /// returns `None` → treated as text → silently bypasses the daemon. That
+    /// is the safe failure direction (correct output, slower), but it also
+    /// means the new command never gets the daemon fast path even with
+    /// `--json`. This test makes that omission loud at test time.
+    ///
+    /// `daemon_capable_variant_names` is emitted by the `CqsCommands` derive;
+    /// it lists exactly the top-level variants with `batch = "daemon"`.
+    #[test]
+    fn daemon_dispatchable_variants_report_an_output_format() {
+        use crate::cli::definitions::Commands;
+        use clap::Parser as _;
+        // Representative argv per daemon-capable command. Kept minimal: only
+        // the required positionals so the parse succeeds. The gate predicate
+        // only inspects the output flags, not the args.
+        let argv_for: &[(&str, &[&str])] = &[
+            ("stats", &["stats"]),
+            ("blame", &["blame", "foo"]),
+            ("deps", &["deps", "foo"]),
+            ("callers", &["callers", "foo"]),
+            ("callees", &["callees", "foo"]),
+            ("onboard", &["onboard", "foo"]),
+            ("explain", &["explain", "foo"]),
+            ("similar", &["similar", "foo"]),
+            ("impact", &["impact", "foo"]),
+            ("impact-diff", &["impact-diff"]),
+            ("review", &["review"]),
+            ("ci", &["ci"]),
+            ("trace", &["trace", "foo", "bar"]),
+            ("test-map", &["test-map", "foo"]),
+            ("context", &["context", "foo"]),
+            ("dead", &["dead"]),
+            ("gather", &["gather", "foo"]),
+            ("health", &["health"]),
+            ("stale", &["stale"]),
+            ("read", &["read", "foo"]),
+            ("related", &["related", "foo"]),
+            ("where", &["where", "foo"]),
+            ("scout", &["scout", "foo"]),
+            ("plan", &["plan", "foo"]),
+            ("task", &["task", "foo"]),
+            ("refresh", &["refresh"]),
+            // `notes` is daemon-capable for the `list` subcommand (runtime
+            // classification); its output format lives on the subcommand.
+            ("notes", &["notes", "list"]),
+            // `suggest` is daemon-capable when no `--apply` mutation runs
+            // (runtime classification); it carries `TextJsonArgs`.
+            ("suggest", &["suggest"]),
+        ];
+        let covered: std::collections::BTreeSet<&str> =
+            argv_for.iter().map(|(name, _)| *name).collect();
+
+        // The derive lists exactly the `batch = "daemon"` top-level variants.
+        for name in Commands::daemon_capable_variant_names() {
+            assert!(
+                covered.contains(name),
+                "daemon-capable command `{name}` has no coverage in this test — \
+                 add an argv entry and an arm in Commands::effective_output_format"
+            );
+        }
+
+        for (name, argv) in argv_for {
+            let cli = {
+                let mut full = vec!["cqs"];
+                full.extend_from_slice(argv);
+                Cli::try_parse_from(full)
+                    .unwrap_or_else(|e| panic!("argv for `{name}` must parse: {e}"))
+            };
+            let cmd = cli.command.as_ref().unwrap_or_else(|| {
+                panic!("argv for `{name}` must produce a subcommand");
+            });
+            assert!(
+                cmd.effective_output_format().is_some(),
+                "daemon-capable command `{name}` must report an output format \
+                 (Some) so the text-mode gate can classify it"
+            );
+        }
+    }
+
+    /// Text-mode invocations are not daemon-forwardable; JSON-mode ones are.
+    /// Covers the three input shapes: `--json` boolean, `--format json`
+    /// (OutputArgs), and the bare-query path.
+    #[test]
+    fn daemon_gate_text_mode_is_not_forwardable() {
+        // Subcommand text mode → CLI path.
+        assert!(!gate_is_json(&["read", "src/lib.rs"]));
+        assert!(!gate_is_json(&["impact", "foo"]));
+        // Subcommand JSON mode → daemon path.
+        assert!(gate_is_json(&["read", "src/lib.rs", "--json"]));
+        // OutputArgs `--format json` is recognized as JSON.
+        assert!(gate_is_json(&["impact", "foo", "--format", "json"]));
+        assert!(gate_is_json(&["impact", "foo", "--json"]));
+        // Top-level `--json` forces JSON for any command.
+        assert!(gate_is_json(&["--json", "read", "src/lib.rs"]));
+        // Bare query: text by default, JSON under top-level `--json`.
+        assert!(!gate_is_json(&["find the thing"]));
+        assert!(gate_is_json(&["--json", "find the thing"]));
+        // `notes list` resolves its `--json` on the subcommand: text bypasses,
+        // subcommand `--json` forwards (the existing notes round-trip relies
+        // on this).
+        assert!(!gate_is_json(&["notes", "list"]));
+        assert!(gate_is_json(&["notes", "list", "--json"]));
     }
 }

--- a/tests/daemon_forward_test.rs
+++ b/tests/daemon_forward_test.rs
@@ -523,7 +523,11 @@ fn test_blame_dash_n_forwards_as_commits_flag() {
     // remapped every `-n` to `--limit`, so `cqs blame foo -n 3` returned a
     // parse_error envelope daemon-up while working daemon-down. The frame
     // must carry `-n 3` verbatim for the batch BlameArgs parser.
-    let req = forwarded_request(&["blame", "foo", "-n", "3"]);
+    //
+    // Top-level `--json` puts the invocation in JSON mode so it forwards
+    // (text mode stays on the CLI path); the flag itself is process-local and
+    // stripped from the wire frame, so the args array is unchanged.
+    let req = forwarded_request(&["--json", "blame", "foo", "-n", "3"]);
     assert_eq!(req["command"], "blame");
     assert_eq!(
         req["args"],
@@ -537,7 +541,11 @@ fn test_top_level_verbose_flag_is_stripped_on_forward() {
     // `cqs -v callers foo`: `-v` is a top-level Cli flag the old
     // hand-mirrored strip list didn't know, so it leaked into the batch
     // `callers` parser and hard-errored daemon-up.
-    let req = forwarded_request(&["-v", "callers", "foo"]);
+    //
+    // Top-level `--json` selects JSON mode so the command forwards (text mode
+    // bypasses the daemon); both `-v` and `--json` are process-local and
+    // stripped, leaving just the positional in the wire frame.
+    let req = forwarded_request(&["--json", "-v", "callers", "foo"]);
     assert_eq!(req["command"], "callers");
     assert_eq!(
         req["args"],
@@ -548,8 +556,10 @@ fn test_top_level_verbose_flag_is_stripped_on_forward() {
 
 #[test]
 fn test_top_level_rrf_flag_is_stripped_on_forward() {
-    // `cqs --rrf callers foo`: same drift class as `-v`.
-    let req = forwarded_request(&["--rrf", "callers", "foo"]);
+    // `cqs --rrf callers foo`: same drift class as `-v`. Top-level `--json`
+    // selects JSON mode so it forwards; `--rrf` is a search knob but, on a
+    // non-search subcommand, it lives in the stripped top-level region.
+    let req = forwarded_request(&["--json", "--rrf", "callers", "foo"]);
     assert_eq!(req["command"], "callers");
     assert_eq!(
         req["args"],
@@ -1378,5 +1388,240 @@ fn test_slim_error_envelope_exits_nonzero() {
     assert!(
         stderr.contains("not_found") && stderr.contains("no such note"),
         "error code+message surfaced; stderr=<{stderr}>"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Text-mode daemon-forward gate.
+//
+// Text-mode invocations (no `--json` / `--format json`) of daemon-dispatchable
+// commands stay on the CLI path: the daemon wire shape is structured JSON, and
+// the CLI renders prose for text mode through each command's own renderer. If
+// the gate ever regresses and forwards a text-mode query, the daemon's JSON
+// payload prints where the rendered text should — the mock here would see a
+// connection and the JSON shape would leak to stdout.
+//
+// `--json` mode must still forward (the fast path), so each command pins both
+// halves: text bypasses, JSON round-trips.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Initialize an empty legacy `.cqs/index.db` so `CommandContext::open_readonly`
+/// succeeds on the CLI fallback. `read` (non-focused) reads the file and
+/// `docs/notes.toml` straight from disk — it never queries the store or loads
+/// an embedder — so an empty store is enough to render text-mode output.
+fn init_empty_index(project_dir: &Path) {
+    let db_path = project_dir.join(".cqs").join(::cqs::INDEX_DB_FILENAME);
+    let store = ::cqs::Store::open(&db_path).expect("open seed store");
+    store
+        .init(&::cqs::store::ModelInfo::default())
+        .expect("init seed store");
+}
+
+#[test]
+fn test_read_text_mode_bypasses_daemon_and_renders_file() {
+    // `cqs read <file>` (no --json) must NOT forward to the daemon — it would
+    // print the `{"content": ...}` JSON payload instead of the rendered file.
+    // The gate keeps it on the CLI path, which prints the file verbatim. The
+    // /cqs-verify check-3 shape holds: the first line of `read` output is the
+    // file's first line.
+    let (dir, sock_path) = setup_project();
+    let mock = MockDaemon::new(sock_path.clone(), "DAEMON_SHOULD_NOT_RESPOND");
+    init_empty_index(dir.path());
+
+    // A file with a recognizable first line under the project root.
+    std::fs::write(
+        dir.path().join("hello.txt"),
+        "FIRST_LINE_SENTINEL\nsecond line\nthird line\n",
+    )
+    .expect("write test file");
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+    let mut cmd = cqs_bare();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["read", "hello.txt"]);
+
+    let output = cmd.output().expect("cqs read spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "`cqs read` text mode failed; stdout=<{stdout}> stderr=<{stderr}>"
+    );
+    assert_eq!(
+        mock.conn_count(),
+        0,
+        "text-mode read reached the daemon socket (text-mode gate regressed); \
+         mock saw {} connection(s). stdout=<{stdout}> stderr=<{stderr}>",
+        mock.conn_count()
+    );
+    // The rendered file, not the JSON payload: first stdout line is the file's
+    // first line, and there is no `{"content"` envelope key.
+    let first_line = stdout.lines().next().unwrap_or("");
+    assert_eq!(
+        first_line, "FIRST_LINE_SENTINEL",
+        "first line of read output must be the file's first line; stdout=<{stdout}>"
+    );
+    assert!(
+        !stdout.contains("\"content\""),
+        "JSON payload leaked into text-mode read output; stdout=<{stdout}>"
+    );
+}
+
+#[test]
+fn test_read_json_mode_still_forwards_to_daemon() {
+    // The `--json` half: text-mode bypass must not break the daemon fast path
+    // for JSON. `cqs read <file> --json` forwards, and the slim `{"data": ...}`
+    // envelope is unwrapped to the bare payload on the V2Bare surface.
+    let (dir, sock_path) = setup_project();
+    let response = serde_json::json!({
+        "status": "ok",
+        "output": {"data": {"path": "hello.txt", "content": "DAEMON_RENDERED_CONTENT"}},
+    });
+    let mock = MockDaemon::with_response_line(sock_path.clone(), response.to_string());
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+    let mut cmd = cqs_bare();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["read", "hello.txt", "--json"]);
+
+    let output = cmd.output().expect("cqs read --json spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "`cqs read --json` failed daemon-up; stdout=<{stdout}> stderr=<{stderr}>"
+    );
+    assert_eq!(
+        mock.conn_count(),
+        1,
+        "JSON-mode read must still forward to the daemon; mock saw {} connection(s). \
+         stdout=<{stdout}> stderr=<{stderr}>",
+        mock.conn_count()
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout must be valid JSON");
+    assert!(
+        v.get("data").is_none(),
+        "bare surface must not carry the batch envelope; got <{stdout}>"
+    );
+    assert_eq!(
+        v["content"], "DAEMON_RENDERED_CONTENT",
+        "daemon payload must reach the JSON consumer; stdout=<{stdout}>"
+    );
+}
+
+#[test]
+fn test_bare_query_text_mode_bypasses_daemon() {
+    // The bare-query search path (`cqs "query"`, no subcommand) defaults to
+    // text and must bypass the daemon too — otherwise the search results JSON
+    // payload prints where the prose result list should.
+    let (dir, sock_path) = setup_project();
+    let mock = MockDaemon::new(sock_path.clone(), "DAEMON_SHOULD_NOT_RESPOND");
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+    let mut cmd = cqs_bare();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["find the thing"]);
+
+    // The CLI fallback may fail (no real index / no embedder) — the pin is
+    // purely that the daemon socket was never touched and the mock's reply
+    // never reached stdout. A text-mode bare query must not forward.
+    let output = cmd.output().expect("cqs bare query spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        mock.conn_count(),
+        0,
+        "text-mode bare query reached the daemon socket (gate regressed); \
+         mock saw {} connection(s). stdout=<{stdout}> stderr=<{stderr}>",
+        mock.conn_count()
+    );
+    assert!(
+        !stdout.contains("DAEMON_SHOULD_NOT_RESPOND"),
+        "mock response leaked into text-mode bare query stdout: {stdout}"
+    );
+}
+
+#[test]
+fn test_impact_format_json_forwards_to_daemon() {
+    // `impact` carries `OutputArgs` (`--format json` as well as `--json`).
+    // Pin that the `--format json` spelling is recognized by the text-mode
+    // gate as JSON and still forwards to the daemon — the gate resolves the
+    // effective format, not just the `--json` boolean.
+    let (dir, sock_path) = setup_project();
+    let response = serde_json::json!({
+        "status": "ok",
+        "output": {"data": {"function_name": "foo", "callers": []}},
+    });
+    let mock = MockDaemon::with_response_line(sock_path.clone(), response.to_string());
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+    let mut cmd = cqs_bare();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["impact", "foo", "--format", "json"]);
+
+    let output = cmd.output().expect("cqs impact spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "`cqs impact foo --format json` failed daemon-up; stdout=<{stdout}> stderr=<{stderr}>"
+    );
+    assert_eq!(
+        mock.conn_count(),
+        1,
+        "`--format json` must be recognized as JSON and forward to the daemon; \
+         mock saw {} connection(s). stdout=<{stdout}> stderr=<{stderr}>",
+        mock.conn_count()
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout must be valid JSON");
+    assert_eq!(v["function_name"], "foo", "daemon payload reached stdout");
+}
+
+#[test]
+fn test_impact_text_mode_bypasses_daemon() {
+    // The text half for an `OutputArgs` command: `cqs impact foo` (default
+    // text) must bypass the daemon. Before the fix it printed the impact JSON
+    // payload daemon-up instead of the rendered impact report.
+    let (dir, sock_path) = setup_project();
+    let mock = MockDaemon::new(sock_path.clone(), "DAEMON_SHOULD_NOT_RESPOND");
+
+    let canonical_dir =
+        dunce::canonicalize(dir.path()).expect("canonicalize temp dir for CWD override");
+    let mut cmd = cqs_bare();
+    clean_cqs_env(&mut cmd);
+    cmd.env("XDG_RUNTIME_DIR", dir.path())
+        .current_dir(&canonical_dir)
+        .args(["impact", "foo"]);
+
+    let output = cmd.output().expect("cqs impact spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        mock.conn_count(),
+        0,
+        "text-mode impact reached the daemon socket (gate regressed); \
+         mock saw {} connection(s). stdout=<{stdout}> stderr=<{stderr}>",
+        mock.conn_count()
+    );
+    assert!(
+        !stdout.contains("DAEMON_SHOULD_NOT_RESPOND"),
+        "mock response leaked into text-mode impact stdout: {stdout}"
     );
 }


### PR DESCRIPTION
## Text-mode invocations bypass the daemon — output is surface-independent

Closes #1734. `cqs read <file>` (and, per the audit, **every** daemon-dispatchable command with a prose default — ~28 commands plus the bare-query search path) printed the structured JSON payload when a daemon happened to be serving, instead of the text CLI-direct renders.

**Fix shape — text-mode bypass, chosen over client-side rendering on the merits:** the CLI text renderers are not pure functions of the daemon payload (e.g. `cmd_impact`'s text path re-queries the store for the relative-file header), so rendering daemon payloads client-side would mean re-opening the store (defeating the fast path) or growing every wire schema to feed text presentation. Text mode now classifies as not-forwardable at the `try_daemon_query` gate; `--json` / `--format json` (the agent path) keeps the daemon fast path unchanged.

- `Commands::effective_output_format` resolves each variant's `--json`/`--format` (nested `notes list` delegated); `daemon_invocation_is_json` gates the forward.
- Exhaustiveness pin: every daemon-capable variant must report an output format — a future command can't silently dodge the gate.
- 5 new mock-daemon tests: read text-mode bypasses + renders the file (the issue's gate — first line is the file's first line, daemon untouched), read `--json` still forwards, bare-query text bypasses, impact `--format json` forwards / text bypasses. Three pre-existing wire-frame tests gained a process-local `--json` (they inspect the frame; asserted frames unchanged).

`/cqs-verify` check 3 passes daemon-up after this (the verify skill's daemon-bug workaround can be reverted next time it's touched).

Tests: cli::dispatch 5, daemon_forward_test 30 — green. fmt + clippy `--all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
