### PR TITLE
fix: P3/P4 tier-1 smalls — V9FS coarse-mtime, filename checkpoint open, CAGRA save dedup, SQLITE_BUSY pins

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -117,14 +117,14 @@ New v1.42 findings: 107 (batch 1: 59 = 15/11/26/7; batch 2: 48 = 13/19/14/2). Ca
 | TC-V1.42-14 | parser_stage TOCTOU (file deleted mid-pipeline): parse_errors arm + mtime=0 sentinel untested | src/cli/pipeline/parsing.rs:127-176 | open |
 | CQ-V1.42-2 | gather_cross_index production-dead wrapper skews test coverage to brute-force path | src/gather.rs:561 | open |
 | CQ-V1.42-3 | CAGRA in-memory constructors test-only API masquerading as production surface | src/cagra.rs:801, :370-376 | open |
-| CQ-V1.42-4 | CagraIndex::save ~75-line test-only twin of save_with_store hardcoding splade_generation: 0 | src/cagra.rs:1013-1086 | open |
+| CQ-V1.42-4 | CagraIndex::save ~75-line test-only twin of save_with_store hardcoding splade_generation: 0 | src/cagra.rs:1013-1086 | ✅ PR #1764 |
 | CQ-V1.42-5 | CommandContext.project_cqs_dir/slot_name written never read, masked by #[allow(dead_code)] | src/cli/store.rs:162-168 | open |
 | CQ-V1.42-6 | ScoutOptions knobs unreachable from any surface | src/scout.rs:101, :135 | open |
 | CQ-V1.42-10 | Env-knob parsing re-implemented across six sites; cli/limits.rs private copy; divergent silent-swallow semantics | hnsw/persist.rs, cli/limits.rs, onboard.rs, note.rs, diff.rs, task.rs | open |
 | CQ-V1.42-15 | Library llm modules eprintln! user-facing hints directly | src/llm/summary.rs:101, doc_comments.rs:281, batch.rs:638 | open |
 | CQ-V1.42-16 | Crate root accretes utilities that have dedicated homes (serde/path/fs helpers in lib.rs) | src/lib.rs:410-645 | open |
 | SEC-V1.42-3 | Cleartext-http API-key guard split across two layers with contradictory localhost policy — local.rs re-check unreachable; under ALLOW_INSECURE=1 silently drops opted-into header | src/llm/mod.rs:357-372, local.rs:146-171 | open |
-| PB-V1.42-2 | linux_fs_resolution magic table omits V9FS_MAGIC (0x01021997) — manually mounted DrvFS gets fine-grained mtime treatment, re-opening dropped-second-save bug | src/config.rs:270-289 | open |
+| PB-V1.42-2 | linux_fs_resolution magic table omits V9FS_MAGIC (0x01021997) — manually mounted DrvFS gets fine-grained mtime treatment, re-opening dropped-second-save bug | src/config.rs:270-289 | ✅ PR #1764 |
 | RM-V1.42-1 | CAGRA interrupted-save tmp orphans never swept on load — HNSW/SPLADE both sweep theirs; multi-hundred-MB accumulation under crash-looping daemon | src/cagra.rs:1186, :1426, :1556 | open |
 | PERF-V1.42-7 | `cqs task` computes the full test-reachability BFS twice with identical inputs | src/task.rs:144, :194 | open |
 | PERF-V1.42-8 | test_reachability allocates 2-3 Strings per BFS visit — siblings in same file use Arc<str> interning (runs on every scout/task/health/review) | src/impact/bfs.rs:354-386 | open |
@@ -134,7 +134,7 @@ New v1.42 findings: 107 (batch 1: 59 = 15/11/26/7; batch 2: 48 = 13/19/14/2). Ca
 | TC-HAP-V1.42-7 | Command-core parity tests are parity-by-construction — no parity test pins a single output value; add one fixture-grounded assert each | src/cli/batch/handlers/graph.rs:862-1080 | ✅ PR #1760 |
 | TC-HAP-V1.42-8 | cache_compact_core zero coverage; cache_stats_core per-model branch never executed | src/cli/commands/infra/cache_cmd.rs:222, :117-130 | open |
 | TC-HAP-V1.42-9 | telemetry_core populated path and all:true flag have zero assertions — telemetry feeds real decisions | src/cli/commands/infra/telemetry_cmd.rs:395 | open |
-| DS-V1.42-9 | checkpoint_legacy_index opens via URL parsing — special-char paths silently skip the WAL drain the slot migration depends on | src/slot/mod.rs:1053 | open |
+| DS-V1.42-9 | checkpoint_legacy_index opens via URL parsing — special-char paths silently skip the WAL drain the slot migration depends on | src/slot/mod.rs:1053 | ✅ PR #1764 |
 | DS-V1.42-11 | slot create --model killed between dir creation and slot.toml write loses the model pin; retry guidance steers toward wrong-model indexing | src/cli/commands/infra/slot.rs:313-325 | open |
 | DS-V1.42-12 | `cqs convert --overwrite` writes via bare fs::write — truncated doc ingested as valid content on next index | src/convert/mod.rs:523-526 | ✅ PR #1759 |
 
@@ -143,7 +143,7 @@ New v1.42 findings: 107 (batch 1: 59 = 15/11/26/7; batch 2: 48 = 13/19/14/2). Ca
 | ID | Finding | Location | Status |
 |----|---------|----------|--------|
 | TC-V1.42-4 | read_stdin oversize-cap + invalid-UTF-8 untested (review --stdin, impact --diff, ci --stdin) | src/cli/commands/mod.rs:566-580 | open |
-| TC-V1.42-13 | No SQLITE_BUSY / concurrent-writer test anywhere; busy_timeout env fallback unpinned | src/store/helpers/sql.rs:14 | open |
+| TC-V1.42-13 | No SQLITE_BUSY / concurrent-writer test anywhere; busy_timeout env fallback unpinned | src/store/helpers/sql.rs:14 | ✅ PR #1764 |
 | TC-V1.42-15 | Read-only .cqs/ — no permission-denied test for index creation/open | src/cli/commands/index/build.rs:135-190 | open |
 | CQ-V1.42-7 | Fused-tx phantom-chunk pruning verbatim inline copy of delete_phantom_chunks | src/store/chunks/crud.rs:1059-1144 | open |
 | CQ-V1.42-9 | Ref-path query preparation duplicated, wider than deferred ledger entry; cmd_query_project double-search_hybrid is the easy first slice | src/cli/commands/search/query.rs:918-1174 vs :239-527 | open |

--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -1019,24 +1019,68 @@ pub fn cagra_persist_enabled() -> bool {
 
 #[cfg(feature = "cuda-index")]
 impl CagraIndex {
-    /// Persist the index to disk.
+    /// Persist the index to disk with a zero `splade_generation` stamp.
+    ///
+    /// Test-only convenience wrapper over [`save_inner`](Self::save_inner);
+    /// see [`save_with_store`](Self::save_with_store) for the production path.
+    #[cfg(test)]
+    pub fn save(&self, path: &Path) -> Result<(), CagraError> {
+        // Test-only convenience: stamps `splade_generation = 0`. Production
+        // callers must use `save_with_store` so the deletion counter is
+        // recorded for the coarse staleness check on load.
+        self.save_inner(path, 0)
+    }
+
+    /// Persist with an explicit `splade_generation` stamp from the caller's
+    /// `Store`. Preferred over the test-only `save` because it records the
+    /// deletion counter for coarse staleness checks on load.
+    pub fn save_with_store<Mode>(
+        &self,
+        path: &Path,
+        store: &crate::Store<Mode>,
+    ) -> Result<(), CagraError> {
+        let _span = tracing::info_span!("cagra_save_with_store", path = %path.display()).entered();
+        // splade_generation is not a perfect staleness signal (deletes only,
+        // not inserts) but it still catches the common reindex-with-GC case.
+        // Read before delegating so a store error surfaces in this span.
+        let generation = if cagra_persist_enabled() {
+            match store.splade_generation() {
+                Ok(g) => g,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to read splade_generation for CAGRA meta; defaulting to 0"
+                    );
+                    0
+                }
+            }
+        } else {
+            0
+        };
+        self.save_inner(path, generation)
+    }
+
+    /// Shared persistence body for [`save`](Self::save) and
+    /// [`save_with_store`](Self::save_with_store).
     ///
     /// Writes two files:
     /// - `{path}` — the cuVS binary blob (via `cuvsCagraSerialize`)
     /// - `{path}.meta` — a JSON sidecar with magic/version/dim/chunk_count/
-    ///   id_map/blake3 so `load()` can validate before handing the blob
-    ///   back to cuVS.
+    ///   id_map/blake3/splade_generation so `load()` can validate before
+    ///   handing the blob back to cuVS.
     ///
-    /// The cuVS blob is written first, checksummed, then the sidecar is
-    /// written atomically (write-temp → rename). If the sidecar write fails
-    /// the partial `.cagra` file is removed so we don't leave an orphan
-    /// that would later fail metadata validation.
+    /// The cuVS blob is staged with `.bak` rollback and checksummed, then the
+    /// sidecar is written atomically (write-temp → rename) with the given
+    /// `splade_generation` stamp. If the sidecar write fails the partial
+    /// `.cagra` file is removed so we don't leave an orphan that would later
+    /// fail metadata validation. Mirrors `src/hnsw/persist.rs` and the SPLADE
+    /// pattern.
     ///
     /// Persistence is a best-effort optimisation: callers should warn-log
     /// failures and continue rather than propagate errors. The caller will
     /// rebuild on next startup.
-    pub fn save(&self, path: &Path) -> Result<(), CagraError> {
-        let _span = tracing::info_span!("cagra_save", path = %path.display()).entered();
+    fn save_inner(&self, path: &Path, generation: u64) -> Result<(), CagraError> {
+        let _span = tracing::info_span!("cagra_save_inner", path = %path.display()).entered();
         if !cagra_persist_enabled() {
             // Per-call warn — a silent skip would surface only as a missing
             // blob at next load.
@@ -1074,94 +1118,6 @@ impl CagraIndex {
         // Atomic save with `.bak` rollback: stage to a tmp path,
         // atomic_replace onto the live name, restore from `.bak` on failure
         // so a mid-save failure can't destroy the previous good blob.
-        // Mirrors `src/hnsw/persist.rs` and the SPLADE pattern.
-        let meta_path = meta_path_for(path);
-        let blob_hash = save_blob_atomic_with_rollback(self, &gpu, path)?;
-
-        let meta = CagraMeta {
-            magic: CAGRA_META_MAGIC.to_string(),
-            version: CAGRA_META_VERSION,
-            dim: self.dim,
-            chunk_count: self.id_map.len(),
-            // splade_generation default of 0 — callers wanting the coarse
-            // staleness check should use `save_with_store`.
-            splade_generation: 0,
-            // Convert Vec<Box<str>> → Vec<String> at the sidecar boundary
-            // (the on-disk schema is Vec<String> for `serde_json` decode).
-            id_map: self.id_map.iter().map(|s| s.to_string()).collect(),
-            blake3: blob_hash,
-            metric: self.metric.as_str().to_string(),
-        };
-
-        // Meta-write failure after the blob is in place leaves a blob
-        // without a sidecar — load() rejects → next caller rebuilds. Both
-        // sides are safe; clean up so we don't leave the pair half-formed.
-        if let Err(e) = write_meta_atomic(&meta_path, &meta) {
-            let _ = std::fs::remove_file(path);
-            let _ = std::fs::remove_file(&meta_path);
-            return Err(e);
-        }
-
-        tracing::info!(
-            path = %path.display(),
-            n_vectors = self.id_map.len(),
-            "CAGRA index persisted"
-        );
-        Ok(())
-    }
-
-    /// Persist with an explicit `splade_generation` stamp from the caller's
-    /// `Store`. Preferred over [`save`](Self::save) because it records the
-    /// deletion counter for coarse staleness checks on load.
-    pub fn save_with_store<Mode>(
-        &self,
-        path: &Path,
-        store: &crate::Store<Mode>,
-    ) -> Result<(), CagraError> {
-        let _span = tracing::info_span!("cagra_save_with_store", path = %path.display()).entered();
-        if !cagra_persist_enabled() {
-            tracing::warn!(path = %path.display(), "CAGRA save_with_store skipped — CQS_CAGRA_PERSIST=0");
-            return Err(CagraError::Io(
-                "CAGRA persistence disabled via CQS_CAGRA_PERSIST=0".to_string(),
-            ));
-        }
-
-        let gpu = self.gpu.lock().map_err(|_| {
-            self.poisoned.store(true, Ordering::Release);
-            CagraError::Io("CAGRA mutex poisoned, refusing to save".to_string())
-        })?;
-
-        if self.poisoned.load(Ordering::Acquire) {
-            return Err(CagraError::Io(
-                "CAGRA index is poisoned, refusing to save".to_string(),
-            ));
-        }
-
-        if let Some(parent) = path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                return Err(CagraError::Io(format!(
-                    "Failed to create parent dir {}: {}",
-                    parent.display(),
-                    e
-                )));
-            }
-        }
-
-        // splade_generation is not a perfect staleness signal (deletes only,
-        // not inserts) but it still catches the common reindex-with-GC case.
-        let generation = match store.splade_generation() {
-            Ok(g) => g,
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "Failed to read splade_generation for CAGRA meta; defaulting to 0"
-                );
-                0
-            }
-        };
-
-        // Atomic save with `.bak` rollback. See `save` above for the
-        // full rationale.
         let meta_path = meta_path_for(path);
         let blob_hash = save_blob_atomic_with_rollback(self, &gpu, path)?;
 
@@ -1178,6 +1134,9 @@ impl CagraIndex {
             metric: self.metric.as_str().to_string(),
         };
 
+        // Meta-write failure after the blob is in place leaves a blob
+        // without a sidecar — load() rejects → next caller rebuilds. Both
+        // sides are safe; clean up so we don't leave the pair half-formed.
         if let Err(e) = write_meta_atomic(&meta_path, &meta) {
             let _ = std::fs::remove_file(path);
             let _ = std::fs::remove_file(&meta_path);

--- a/src/config.rs
+++ b/src/config.rs
@@ -261,32 +261,50 @@ fn linux_fs_resolution(path: &Path) -> Option<std::time::Duration> {
         return None;
     }
 
-    // f_type is `__fsword_t` (signed `long` on most architectures). Cast to
-    // i64 to compare against constants written in their natural unsigned
-    // form. The CIFS / SMB2 magic numbers are 32-bit values that have the
-    // top bit set (0xff534d42 / 0xfe534d42); writing them as `u32 as i64`
-    // preserves the bit pattern across architectures where i32 vs i64
-    // sign-extension would otherwise differ.
+    let f_type = stat.f_type as i64;
+    if fs_magic_is_coarse(f_type) {
+        return Some(Duration::from_secs(2));
+    }
+    Some(Duration::ZERO)
+}
+
+/// Classify a Linux statfs `f_type` magic number as coarse-mtime (≥1 s tick).
+///
+/// Pure function over the magic constant so the table is unit-testable
+/// without mounting a filesystem. `f_type` is `__fsword_t` (signed `long`
+/// on most architectures); callers cast to `i64` so the constants below can
+/// be written in their natural unsigned form. The CIFS / SMB2 magic numbers
+/// are 32-bit values with the top bit set (`0xff534d42` / `0xfe534d42`);
+/// writing them as `u32 as i64` preserves the bit pattern across
+/// architectures where i32 vs i64 sign-extension would otherwise differ.
+#[cfg(target_os = "linux")]
+fn fs_magic_is_coarse(f_type: i64) -> bool {
     const NFS_SUPER_MAGIC: i64 = 0x6969;
     const MSDOS_SUPER_MAGIC: i64 = 0x4d44;
     const SMB_SUPER_MAGIC: i64 = 0x517b;
     const HFS_PLUS_MAGIC: i64 = 0x482b;
     const VFAT_SUPER_MAGIC: i64 = 0x4d44; // alias for MSDOS family
+                                          // WSL2 DrvFS mounts present as 9P (Plan 9) to statfs. The path-shape
+                                          // check in `coarse_fs_resolution` catches automount paths, but a manual
+                                          // `mount -t drvfs D: /data` (or a bind-mount of a /mnt/c subtree) outside
+                                          // the automount root falls through to this table; without 9P here it
+                                          // would get fine-grained treatment and silently drop same-tick saves.
+    const V9FS_MAGIC: i64 = 0x01021997;
+    // FUSE — sshfs / rclone / other userspace mounts that commonly round
+    // mtime to 1 s. Belt-and-suspenders alongside the path-shape check.
+    const FUSE_SUPER_MAGIC: i64 = 0x65735546;
     let cifs_magic: i64 = 0xff534d42_u32 as i64;
     let smb2_magic: i64 = 0xfe534d42_u32 as i64;
 
-    let f_type = stat.f_type as i64;
-    if f_type == NFS_SUPER_MAGIC
+    f_type == NFS_SUPER_MAGIC
         || f_type == MSDOS_SUPER_MAGIC
         || f_type == SMB_SUPER_MAGIC
         || f_type == HFS_PLUS_MAGIC
         || f_type == VFAT_SUPER_MAGIC
+        || f_type == V9FS_MAGIC
+        || f_type == FUSE_SUPER_MAGIC
         || f_type == cifs_magic
         || f_type == smb2_magic
-    {
-        return Some(Duration::from_secs(2));
-    }
-    Some(Duration::ZERO)
 }
 
 /// macOS: read `statfs::f_fstypename` and map known coarse-mtime FS
@@ -2024,5 +2042,30 @@ llm_max_tokens = 200
             coarse_fs_resolution(Path::new("/mnt/c/this/path/does/not/exist")),
             two_sec
         );
+    }
+
+    /// The statfs magic table classifies coarse-mtime filesystems directly,
+    /// independent of path shape. 9P (`V9FS_MAGIC`) and FUSE are the entries
+    /// that catch manually mounted WSL2 DrvFS shares / sshfs mounts which
+    /// fall outside the automount path-shape shortcut. Native filesystems
+    /// (ext4 / tmpfs / btrfs) are fine-grained and must stay out of the table.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn fs_magic_table_classifies_coarse_filesystems() {
+        // Coarse: rounded-mtime network / FAT / WSL / FUSE filesystems.
+        assert!(fs_magic_is_coarse(0x01021997), "9P (WSL2 DrvFS)");
+        assert!(fs_magic_is_coarse(0x65735546), "FUSE (sshfs/rclone)");
+        assert!(fs_magic_is_coarse(0x6969), "NFS");
+        assert!(fs_magic_is_coarse(0x4d44), "MSDOS/VFAT");
+        assert!(fs_magic_is_coarse(0x517b), "SMB");
+        assert!(fs_magic_is_coarse(0x482b), "HFS+");
+        assert!(fs_magic_is_coarse(0xff534d42_u32 as i64), "CIFS");
+        assert!(fs_magic_is_coarse(0xfe534d42_u32 as i64), "SMB2");
+
+        // Fine-grained: native Linux filesystems keep nanosecond mtime.
+        assert!(!fs_magic_is_coarse(0xef53), "ext2/3/4");
+        assert!(!fs_magic_is_coarse(0x01021994), "tmpfs");
+        assert!(!fs_magic_is_coarse(0x9123683e), "btrfs");
+        assert!(!fs_magic_is_coarse(0), "zeroed/unknown");
     }
 }

--- a/src/slot/mod.rs
+++ b/src/slot/mod.rs
@@ -1040,7 +1040,6 @@ pub fn migrate_legacy_index_to_default_slot(project_cqs_dir: &Path) -> Result<bo
 fn checkpoint_legacy_index(legacy_index: &Path) -> Result<(), SlotError> {
     use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
     use sqlx::{ConnectOptions, Connection};
-    use std::str::FromStr;
 
     // Build a single-thread runtime for the pragma — slot migration is the
     // only caller and runs at most once per project lifetime.
@@ -1050,9 +1049,15 @@ fn checkpoint_legacy_index(legacy_index: &Path) -> Result<(), SlotError> {
         .map_err(|e| SlotError::Migration(format!("checkpoint runtime: {e}")))?;
 
     rt.block_on(async {
-        let opts = SqliteConnectOptions::from_str(&format!("sqlite://{}", legacy_index.display()))
-            .map_err(|e| SlotError::Migration(format!("checkpoint open: {e}")))?
+        // Use SqliteConnectOptions::filename() rather than from_str("sqlite://..")
+        // so special characters in the path (spaces, #, ?, %, unicode — common
+        // on Windows-origin trees) don't get URL-parsed and silently target the
+        // wrong file. busy_timeout lets a concurrent reader settle instead of
+        // failing the checkpoint outright.
+        let opts = SqliteConnectOptions::new()
+            .filename(legacy_index)
             .journal_mode(SqliteJournalMode::Wal)
+            .busy_timeout(crate::store::helpers::sql::busy_timeout_from_env(30_000))
             .create_if_missing(false);
         let mut conn = opts
             .connect()
@@ -1457,6 +1462,57 @@ mod tests {
 
         // Active slot pointer is in place
         assert_eq!(read_active_slot(&cqs).as_deref(), Some(DEFAULT_SLOT));
+    }
+
+    /// `checkpoint_legacy_index` must open via `.filename()` so a project path
+    /// containing URL-significant characters (spaces, `#`, `%`) still drains the
+    /// WAL rather than silently targeting a wrong/empty path. Builds a real WAL
+    /// DB under a special-char directory, commits a row to grow the WAL, then
+    /// asserts the checkpoint succeeds and truncates the `-wal` sidecar.
+    #[test]
+    fn checkpoint_legacy_index_drains_wal_on_special_char_path() {
+        use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+        use sqlx::{ConnectOptions, Connection, Executor};
+
+        let dir = TempDir::new().unwrap();
+        // Directory name with spaces, '#', and '%' — the URL-parse trap.
+        let weird = dir.path().join("My Project #1 (50%)");
+        fs::create_dir_all(&weird).unwrap();
+        let db = weird.join("index.db");
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let mut conn = SqliteConnectOptions::new()
+                .filename(&db)
+                .journal_mode(SqliteJournalMode::Wal)
+                .create_if_missing(true)
+                .connect()
+                .await
+                .unwrap();
+            conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+                .await
+                .unwrap();
+            conn.execute("INSERT INTO t (v) VALUES ('hello')")
+                .await
+                .unwrap();
+            // Leave the connection open so the WAL is non-empty on disk.
+            let wal = db.with_file_name("index.db-wal");
+            assert!(wal.exists(), "WAL sidecar should exist before checkpoint");
+            let _ = conn.close().await;
+        });
+
+        // The checkpoint must succeed (URL parsing would have failed the open
+        // or targeted the wrong path) and truncate the WAL to zero bytes.
+        checkpoint_legacy_index(&db).expect("checkpoint should drain WAL");
+
+        let wal = db.with_file_name("index.db-wal");
+        if wal.exists() {
+            let len = fs::metadata(&wal).unwrap().len();
+            assert_eq!(len, 0, "WAL should be truncated after checkpoint");
+        }
     }
 
     #[test]

--- a/src/store/helpers/sql.rs
+++ b/src/store/helpers/sql.rs
@@ -163,3 +163,44 @@ pub(crate) fn make_placeholders_offset(n: usize, start: usize) -> std::borrow::C
     }
     std::borrow::Cow::Owned(s)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::time::Duration;
+
+    /// `busy_timeout_from_env` is the single source of truth for every SQLite
+    /// pool's lock-wait. These tests pin the three branches: unset → default,
+    /// valid override → parsed value, garbage → fallback. `#[serial]` guards
+    /// the process-global env var against parallel test interference.
+    #[test]
+    #[serial]
+    fn busy_timeout_from_env_defaults_when_unset() {
+        std::env::remove_var("CQS_BUSY_TIMEOUT_MS");
+        assert_eq!(busy_timeout_from_env(30_000), Duration::from_millis(30_000));
+    }
+
+    #[test]
+    #[serial]
+    fn busy_timeout_from_env_honours_valid_override() {
+        std::env::set_var("CQS_BUSY_TIMEOUT_MS", "500");
+        assert_eq!(busy_timeout_from_env(30_000), Duration::from_millis(500));
+        // Zero is a valid, deliberately-low value (used by the busy-writer
+        // test to force an immediate SQLITE_BUSY rather than a 30 s block).
+        std::env::set_var("CQS_BUSY_TIMEOUT_MS", "0");
+        assert_eq!(busy_timeout_from_env(30_000), Duration::from_millis(0));
+        std::env::remove_var("CQS_BUSY_TIMEOUT_MS");
+    }
+
+    #[test]
+    #[serial]
+    fn busy_timeout_from_env_falls_back_on_garbage() {
+        std::env::set_var("CQS_BUSY_TIMEOUT_MS", "not-a-number");
+        assert_eq!(busy_timeout_from_env(1234), Duration::from_millis(1234));
+        // Negative values fail u64 parse too → fallback.
+        std::env::set_var("CQS_BUSY_TIMEOUT_MS", "-5");
+        assert_eq!(busy_timeout_from_env(1234), Duration::from_millis(1234));
+        std::env::remove_var("CQS_BUSY_TIMEOUT_MS");
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1723,6 +1723,133 @@ mod tests {
         drop(writer);
     }
 
+    /// A second connection holding `BEGIN IMMEDIATE` (an exclusive write
+    /// reservation) while the `Store` attempts a write must surface a
+    /// recognizable "database is locked" error within the busy_timeout
+    /// window — not hang, not panic. Set `CQS_BUSY_TIMEOUT_MS=0` so the
+    /// store fails immediately instead of blocking for the 30 s default.
+    ///
+    /// This is the daemon+CLI concurrent-writer topology (two processes,
+    /// two connections, no shared in-process `WRITE_LOCK`); the raw sqlx
+    /// connection below stands in for the other process. SQLITE_BUSY caused
+    /// a production bug once and had zero test coverage before this.
+    #[test]
+    #[serial_test::serial]
+    fn busy_writer_surfaces_locked_error_not_hang() {
+        use sqlx::sqlite::SqliteConnectOptions;
+        use sqlx::{ConnectOptions, Connection, Executor};
+
+        // Force an immediate fail rather than a 30 s block.
+        std::env::set_var("CQS_BUSY_TIMEOUT_MS", "0");
+
+        let (store, dir) = make_test_store_initialized();
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
+
+        // Open a competing raw connection and hold an exclusive write
+        // reservation on it. This does NOT take the in-process WRITE_LOCK,
+        // so it models a separate process holding the SQLite-level lock.
+        let blocker = store
+            .rt
+            .block_on(async {
+                let mut conn = SqliteConnectOptions::new()
+                    .filename(&db_path)
+                    .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+                    .connect()
+                    .await?;
+                conn.execute("BEGIN IMMEDIATE").await?;
+                conn.execute("INSERT INTO metadata (key, value) VALUES ('busy_probe', '1')")
+                    .await?;
+                Ok::<_, sqlx::Error>(conn)
+            })
+            .expect("blocker should acquire the write reservation");
+
+        // The store's write must error (locked) rather than hang or panic.
+        let result = store.upsert_function_calls(
+            std::path::Path::new("busy.rs"),
+            &[crate::parser::FunctionCalls {
+                name: "f".to_string(),
+                line_start: 1,
+                calls: vec![],
+            }],
+        );
+
+        let err = result.expect_err("write should fail while blocker holds the lock");
+        let msg = err.to_string().to_lowercase();
+        assert!(
+            msg.contains("locked") || msg.contains("busy"),
+            "expected a recognizable locked/busy error, got: {msg}"
+        );
+
+        // Release the reservation; the store can then write successfully.
+        store
+            .rt
+            .block_on(async move {
+                let mut b = blocker;
+                b.execute("ROLLBACK").await?;
+                let _ = b.close().await;
+                Ok::<_, sqlx::Error>(())
+            })
+            .expect("blocker rollback should succeed");
+
+        std::env::remove_var("CQS_BUSY_TIMEOUT_MS");
+
+        store
+            .upsert_function_calls(
+                std::path::Path::new("busy.rs"),
+                &[crate::parser::FunctionCalls {
+                    name: "f".to_string(),
+                    line_start: 1,
+                    calls: vec![],
+                }],
+            )
+            .expect("write should succeed once the lock is released");
+    }
+
+    /// WAL mode lets a read-only open succeed while another connection holds
+    /// an open write transaction — the daemon-mid-write + CLI-read case.
+    /// A blocking writer reservation must not stop a fresh read-only Store
+    /// from opening and querying committed data.
+    #[test]
+    #[serial_test::serial]
+    fn wal_reader_succeeds_during_writer_transaction() {
+        use sqlx::sqlite::SqliteConnectOptions;
+        use sqlx::{ConnectOptions, Connection, Executor};
+
+        let (store, dir) = make_test_store_initialized();
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
+
+        // Hold an open write transaction on a competing connection.
+        let blocker = store
+            .rt
+            .block_on(async {
+                let mut conn = SqliteConnectOptions::new()
+                    .filename(&db_path)
+                    .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+                    .connect()
+                    .await?;
+                conn.execute("BEGIN IMMEDIATE").await?;
+                conn.execute("INSERT INTO metadata (key, value) VALUES ('wal_probe', '1')")
+                    .await?;
+                Ok::<_, sqlx::Error>(conn)
+            })
+            .expect("blocker should acquire the write reservation");
+
+        // A read-only open + query must succeed despite the live writer.
+        let ro = Store::open_readonly(&db_path)
+            .expect("readonly open should succeed during a writer transaction (WAL)");
+        assert!(ro.check_model_version().is_ok());
+
+        store
+            .rt
+            .block_on(async move {
+                let mut b = blocker;
+                b.execute("ROLLBACK").await?;
+                let _ = b.close().await;
+                Ok::<_, sqlx::Error>(())
+            })
+            .expect("blocker rollback should succeed");
+    }
+
     #[test]
     fn onclock_cache_not_invalidated_by_writes() {
         // get_call_graph() populates the OnceLock cache on first call.


### PR DESCRIPTION
Closes the impact-tier-1 P3/P4 batch from docs/audit-triage.md: PB-V1.42-2 (V9FS_MAGIC + FUSE in the coarse-mtime table, closing the silent dropped-save on manual drvfs mounts; pure fs_magic_is_coarse seam + table test), DS-V1.42-9 (checkpoint_legacy_index opens by filename, not URL string — special-char paths now drain the WAL before slot migration; pinned with a real WAL DB under a percent-and-space path), CQ-V1.42-4 (CagraIndex::save -> cfg(test) shim over a shared save_inner; the splade_generation:0 footgun twin is gone), TC-V1.42-13 (busy_timeout_from_env units + two-connection BEGIN IMMEDIATE locked-error pin + WAL reader-during-writer pin). 13 targeted tests green; fmt + clippy --all-targets clean. Triage flips ride this branch.