### PR TITLE
fix: P3/P4 tier-2 diagnostics — one http trust model, tracked batch writes, unified env-knob parsing, telemetry/task test rigor

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,7 +863,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_LOCAL_LLM_TIMEOUT_SECS` | `120` | Per-request timeout (seconds) for `CQS_LLM_PROVIDER=local`. Local inference can be slow, so the default is 2× the Anthropic 60s ceiling. |
 | `CQS_MAX_CONNECTIONS` | `4` | SQLite write-pool max connections |
 | `CQS_MAX_REFERENCES` | `20` | Max number of reference indexes loaded from `[references]` blocks. Each reference holds a separate SQLite DB + HNSW index (~50-100 MB RAM each). Hit on a `cqs ref`-heavy workspace? Bump it; `0`/garbage falls back to default. SHL-V1.30-6. |
-| `CQS_GATHER_DEPTH` | `1` (`gather` default) | BFS expansion depth for the shared `gather` pipeline. Honored as a fallback by `task` when `CQS_TASK_GATHER_DEPTH` is unset. SHL-V1.30-4. |
+| `CQS_GATHER_DEPTH` | `2` (task fallback) | BFS expansion depth fallback for the `task` pipeline when `CQS_TASK_GATHER_DEPTH` is unset. `cqs gather` itself takes its depth from the `--depth` flag, not this env var. SHL-V1.30-4. |
 | `CQS_TASK_GATHER_DEPTH` | `2` | BFS expansion depth used inside `cqs task` (number of call-graph hops from each modify target). Takes precedence over `CQS_GATHER_DEPTH` for the task pipeline only. SHL-V1.30-4. |
 | `CQS_TASK_WATERFALL_SCOUT` | `0.15` | Fraction of `cqs task --max-tokens` allocated to the scout section (file groups + chunk roles). Operators packing more code or impact info can shift weight via this knob. Bounded `0.0..=1.0`. v1.38: EX-V1.38-5 / #1463. |
 | `CQS_TASK_WATERFALL_CODE` | `0.50` | Fraction of `cqs task --max-tokens` allocated to the code section (gathered chunks). v1.38: EX-V1.38-5 / #1463. |

--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -98,7 +98,7 @@ New v1.42 findings: 107 (batch 1: 59 = 15/11/26/7; batch 2: 48 = 13/19/14/2). Ca
 | ID | Finding | Location | Status |
 |----|---------|----------|--------|
 | DOC-V1.42-4 | README HNSW tuning table presents mid-tier values as fixed; defaults are corpus-tiered | README.md:696-710 | ✅ PR #1738 |
-| EH-V1.42-3 | Batch dispatch swallows response-write failures via `let _ =` (7 sites) — daemon side built tracked writes for exactly this | src/cli/batch/context.rs:684-797 | open |
+| EH-V1.42-3 | Batch dispatch swallows response-write failures via `let _ =` (7 sites) — daemon side built tracked writes for exactly this | src/cli/batch/context.rs:684-797 | ✅ PR #1765 |
 | EH-V1.42-4 | chunk_count().ok() blanks slot-list chunks column silently; adjacent model-name read got the warn ladder | src/cli/commands/infra/slot.rs:253 | ✅ PR #1759 |
 | RB-V1.42-3 | extract_signature UntilAs loop bound makes end-of-string guard unreachable — trailing "AS" never matched | src/parser/chunk.rs:302-306 | ✅ PR #1757 |
 | RB-V1.42-4 | injection.rs u32-cast safety comment cites nonexistent "MAX_FILE_SIZE (50MB)"; real cap 1 MiB + unbounded env override | src/parser/injection.rs:221 | ✅ PR #1738 |
@@ -120,10 +120,10 @@ New v1.42 findings: 107 (batch 1: 59 = 15/11/26/7; batch 2: 48 = 13/19/14/2). Ca
 | CQ-V1.42-4 | CagraIndex::save ~75-line test-only twin of save_with_store hardcoding splade_generation: 0 | src/cagra.rs:1013-1086 | open |
 | CQ-V1.42-5 | CommandContext.project_cqs_dir/slot_name written never read, masked by #[allow(dead_code)] | src/cli/store.rs:162-168 | open |
 | CQ-V1.42-6 | ScoutOptions knobs unreachable from any surface | src/scout.rs:101, :135 | open |
-| CQ-V1.42-10 | Env-knob parsing re-implemented across six sites; cli/limits.rs private copy; divergent silent-swallow semantics | hnsw/persist.rs, cli/limits.rs, onboard.rs, note.rs, diff.rs, task.rs | open |
+| CQ-V1.42-10 | Env-knob parsing re-implemented across six sites; cli/limits.rs private copy; divergent silent-swallow semantics | hnsw/persist.rs, cli/limits.rs, onboard.rs, note.rs, diff.rs, task.rs | ✅ PR #1765 |
 | CQ-V1.42-15 | Library llm modules eprintln! user-facing hints directly | src/llm/summary.rs:101, doc_comments.rs:281, batch.rs:638 | open |
 | CQ-V1.42-16 | Crate root accretes utilities that have dedicated homes (serde/path/fs helpers in lib.rs) | src/lib.rs:410-645 | open |
-| SEC-V1.42-3 | Cleartext-http API-key guard split across two layers with contradictory localhost policy — local.rs re-check unreachable; under ALLOW_INSECURE=1 silently drops opted-into header | src/llm/mod.rs:357-372, local.rs:146-171 | open |
+| SEC-V1.42-3 | Cleartext-http API-key guard split across two layers with contradictory localhost policy — local.rs re-check unreachable; under ALLOW_INSECURE=1 silently drops opted-into header | src/llm/mod.rs:357-372, local.rs:146-171 | ✅ PR #1765 |
 | PB-V1.42-2 | linux_fs_resolution magic table omits V9FS_MAGIC (0x01021997) — manually mounted DrvFS gets fine-grained mtime treatment, re-opening dropped-second-save bug | src/config.rs:270-289 | open |
 | RM-V1.42-1 | CAGRA interrupted-save tmp orphans never swept on load — HNSW/SPLADE both sweep theirs; multi-hundred-MB accumulation under crash-looping daemon | src/cagra.rs:1186, :1426, :1556 | open |
 | PERF-V1.42-7 | `cqs task` computes the full test-reachability BFS twice with identical inputs | src/task.rs:144, :194 | open |
@@ -133,7 +133,7 @@ New v1.42 findings: 107 (batch 1: 59 = 15/11/26/7; batch 2: 48 = 13/19/14/2). Ca
 | TC-HAP-V1.42-5 | Gather direction filtering (Callers/Callees) tested only by is_ok() — deliberate fixture wasted | tests/gather_test.rs:185, :231 | open |
 | TC-HAP-V1.42-7 | Command-core parity tests are parity-by-construction — no parity test pins a single output value; add one fixture-grounded assert each | src/cli/batch/handlers/graph.rs:862-1080 | ✅ PR #1760 |
 | TC-HAP-V1.42-8 | cache_compact_core zero coverage; cache_stats_core per-model branch never executed | src/cli/commands/infra/cache_cmd.rs:222, :117-130 | open |
-| TC-HAP-V1.42-9 | telemetry_core populated path and all:true flag have zero assertions — telemetry feeds real decisions | src/cli/commands/infra/telemetry_cmd.rs:395 | open |
+| TC-HAP-V1.42-9 | telemetry_core populated path and all:true flag have zero assertions — telemetry feeds real decisions | src/cli/commands/infra/telemetry_cmd.rs:395 | ✅ PR #1765 |
 | DS-V1.42-9 | checkpoint_legacy_index opens via URL parsing — special-char paths silently skip the WAL drain the slot migration depends on | src/slot/mod.rs:1053 | open |
 | DS-V1.42-11 | slot create --model killed between dir creation and slot.toml write loses the model pin; retry guidance steers toward wrong-model indexing | src/cli/commands/infra/slot.rs:313-325 | open |
 | DS-V1.42-12 | `cqs convert --overwrite` writes via bare fs::write — truncated doc ingested as valid content on next index | src/convert/mod.rs:523-526 | ✅ PR #1759 |
@@ -150,7 +150,7 @@ New v1.42 findings: 107 (batch 1: 59 = 15/11/26/7; batch 2: 48 = 13/19/14/2). Ca
 | CQ-V1.42-13 | serve/data.rs writes raw SQL via pub(crate) pool access — schema knowledge in two modules | src/serve/data.rs:224-1124 | open |
 | CQ-V1.42-14 | store ↔ search bidirectional coupling — Store's search API implemented in search module on private fields (root cause of CQ-V1.42-12's gate-in-dead-code) | src/search/query.rs:67, src/store/search.rs:8 | open |
 | PERF-V1.42-9 | build_cluster streams the entire function_calls table per /api/embed/2d request, aggregating degree counts Rust-side — push GROUP BY into SQL like build_graph | src/serve/data.rs:1011-1026 | open |
-| TC-HAP-V1.42-4 | task e2e tests #[ignore]d AND vacuous (assertions satisfiable by any outcome); --tokens waterfall branch never executed | tests/task_test.rs:285-327, train/task.rs:609-641 | open |
+| TC-HAP-V1.42-4 | task e2e tests #[ignore]d AND vacuous (assertions satisfiable by any outcome); --tokens waterfall branch never executed | tests/task_test.rs:285-327, train/task.rs:609-641 | ✅ PR #1765 |
 
 ## Suggested fix clustering (for the next implementation session)
 

--- a/src/cli/batch/context.rs
+++ b/src/cli/batch/context.rs
@@ -760,6 +760,29 @@ impl BatchContext {
         Ok(())
     }
 
+    /// Write a success payload to `out`, logging and counting a write failure
+    /// instead of silently dropping it. For the daemon path `out` is an
+    /// in-memory `Vec` (infallible); for the stdin batch surface `out` is
+    /// stdout, where an EPIPE or full-disk redirect would otherwise leave the
+    /// agent with no response line, no log, and no `error_count` bump. Mirrors
+    /// the daemon socket's `write_daemon_error_tracked` (socket.rs).
+    fn write_ok_tracked(&self, out: &mut impl std::io::Write, value: &serde_json::Value) {
+        if let Err(e) = write_json_line(out, value) {
+            self.error_count.fetch_add(1, Ordering::Relaxed);
+            tracing::warn!(error = %e, "Batch dispatch: failed to write response line");
+        }
+    }
+
+    /// Write an error envelope to `out`, logging a write failure. The caller
+    /// has already bumped `error_count` for the dispatch error itself, so this
+    /// only warns when the envelope write also fails (e.g. EPIPE on stdout) —
+    /// the symptom is otherwise invisible.
+    fn write_err_tracked(&self, out: &mut impl std::io::Write, code: &str, message: &str) {
+        if let Err(e) = write_envelope_error(out, code, message) {
+            tracing::warn!(error = %e, "Batch dispatch: failed to write error envelope");
+        }
+    }
+
     /// Dispatch a single command line (e.g. "search foo -n 5 --json") and
     /// write the JSON result to `out`. Used by the daemon socket handler.
     ///
@@ -785,7 +808,7 @@ impl BatchContext {
                 self.error_count.fetch_add(1, Ordering::Relaxed);
                 let msg = format!("Parse error: {e}");
                 tracing::warn!(code = error_codes::PARSE_ERROR, error = %msg, "Batch dispatch_line: tokenization failed");
-                let _ = write_envelope_error(out, error_codes::PARSE_ERROR, &msg);
+                self.write_err_tracked(out, error_codes::PARSE_ERROR, &msg);
                 return;
             }
         };
@@ -841,7 +864,7 @@ impl BatchContext {
                 error = msg,
                 "Batch dispatch: NUL byte in tokens"
             );
-            let _ = write_envelope_error(out, error_codes::INVALID_INPUT, msg);
+            self.write_err_tracked(out, error_codes::INVALID_INPUT, msg);
             return;
         }
         self.check_idle_timeout();
@@ -858,7 +881,7 @@ impl BatchContext {
                 if matches!(input.cmd, commands::BatchCmd::Refresh) {
                     match self.invalidate() {
                         Ok(()) => {
-                            let _ = write_json_line(
+                            self.write_ok_tracked(
                                 out,
                                 &serde_json::json!({
                                     "status": "ok",
@@ -869,14 +892,14 @@ impl BatchContext {
                         Err(e) => {
                             self.error_count.fetch_add(1, Ordering::Relaxed);
                             let (code, msg) = crate::cli::json_envelope::redact_error(&e);
-                            let _ = write_envelope_error(out, code.as_str(), &msg);
+                            self.write_err_tracked(out, code.as_str(), &msg);
                         }
                     }
                     return;
                 }
                 match commands::dispatch(&view, input.cmd) {
                     Ok(value) => {
-                        let _ = write_json_line(out, &value);
+                        self.write_ok_tracked(out, &value);
                     }
                     Err(e) => {
                         self.error_count.fetch_add(1, Ordering::Relaxed);
@@ -887,7 +910,7 @@ impl BatchContext {
                         // via tracing::warn! inside redact_error so an operator
                         // can correlate by chain-id.
                         let (code, msg) = crate::cli::json_envelope::redact_error(&e);
-                        let _ = write_envelope_error(out, code.as_str(), &msg);
+                        self.write_err_tracked(out, code.as_str(), &msg);
                     }
                 }
             }
@@ -898,7 +921,7 @@ impl BatchContext {
                 // correct its query. No redaction needed.
                 let msg = format!("{e:#}");
                 tracing::warn!(code = error_codes::PARSE_ERROR, error = %msg, "Batch dispatch: clap parse failed");
-                let _ = write_envelope_error(out, error_codes::PARSE_ERROR, &msg);
+                self.write_err_tracked(out, error_codes::PARSE_ERROR, &msg);
             }
         }
     }

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -892,6 +892,49 @@ mod tests {
         assert_eq!(ctx.query_count.load(Ordering::Relaxed), 2);
     }
 
+    // A response-write failure on the stdin batch surface (EPIPE, full-disk
+    // redirect) must not vanish: `write_ok_tracked` warns and bumps
+    // `error_count` so the agent's lost response line is observable. Drives the
+    // success path (`refresh` invalidates cleanly, then writes the ok payload)
+    // through a writer that errors on every write.
+    #[test]
+    fn test_dispatch_response_write_failure_bumps_error_count() {
+        struct FailingWriter;
+        impl std::io::Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "epipe"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "epipe"))
+            }
+        }
+
+        let (_dir, cqs_dir) = setup_test_store();
+        let ctx = create_test_context(&cqs_dir).unwrap();
+        assert_eq!(ctx.error_count.load(Ordering::Relaxed), 0);
+
+        // `refresh` invalidates the caches and then writes a success payload.
+        // The write fails, so write_ok_tracked must bump error_count exactly
+        // once even though the dispatch itself succeeded.
+        let mut out = FailingWriter;
+        ctx.dispatch_line("refresh", &mut out);
+        assert_eq!(
+            ctx.error_count.load(Ordering::Relaxed),
+            1,
+            "a failed response write on a successful dispatch must bump error_count"
+        );
+
+        // Sanity: the same successful dispatch against a working writer does
+        // NOT bump error_count.
+        let mut ok_out = Vec::new();
+        ctx.dispatch_line("refresh", &mut ok_out);
+        assert_eq!(
+            ctx.error_count.load(Ordering::Relaxed),
+            1,
+            "a successful dispatch+write leaves error_count unchanged"
+        );
+    }
+
     // ping_snapshot returns a coherent picture even on an empty BatchContext
     // (no commands run yet, no embedder warmed). Pins the initial values so the
     // CLI can rely on the field shape.

--- a/src/cli/commands/infra/telemetry_cmd.rs
+++ b/src/cli/commands/infra/telemetry_cmd.rs
@@ -771,6 +771,83 @@ mod tests {
         }
     }
 
+    fn write_named_telemetry(dir: &Path, name: &str, lines: &[&str]) {
+        let path = dir.join(name);
+        let mut f = fs::File::create(&path).unwrap();
+        for line in lines {
+            writeln!(f, "{line}").unwrap();
+        }
+    }
+
+    /// `telemetry_core` over a populated live file aggregates every command
+    /// entry (Reset lines don't count as events) and rolls them up by
+    /// category. Pins the count and one category total so a silently-zero
+    /// aggregation can't pass.
+    #[test]
+    fn telemetry_core_populated_counts_events_and_categories() {
+        let dir = tempfile::tempdir().unwrap();
+        // 4 command entries + 1 reset (reset is not an event).
+        // search/gather → Search (2); impact → Structural (1); read → Read/Write (1).
+        write_test_telemetry(
+            dir.path(),
+            &[
+                r#"{"cmd":"search","query":"foo","ts":1001}"#,
+                r#"{"cmd":"gather","query":"bar","ts":1002}"#,
+                r#"{"cmd":"impact","query":"baz","ts":1003}"#,
+                r#"{"event":"reset","ts":1004,"reason":"test"}"#,
+                r#"{"cmd":"read","ts":1005}"#,
+            ],
+        );
+
+        let out = telemetry_core(dir.path(), &TelemetryArgs::default()).unwrap();
+        assert_eq!(
+            out.events, 4,
+            "four command entries (reset is not an event)"
+        );
+        assert_eq!(
+            out.categories.get("Search").copied(),
+            Some(2),
+            "search + gather both roll up under Search"
+        );
+        assert_eq!(
+            out.commands.get("search").copied(),
+            Some(1),
+            "per-command count surfaces too"
+        );
+    }
+
+    /// `all: true` folds archived `telemetry*.jsonl` files in alongside the
+    /// live one. With `all: false` only the live file's events are counted.
+    #[test]
+    fn telemetry_core_all_aggregates_archived_files() {
+        let dir = tempfile::tempdir().unwrap();
+        // Live file: 1 event.
+        write_test_telemetry(dir.path(), &[r#"{"cmd":"search","query":"foo","ts":2001}"#]);
+        // Archived file: 2 events.
+        write_named_telemetry(
+            dir.path(),
+            "telemetry.1.jsonl",
+            &[
+                r#"{"cmd":"impact","query":"a","ts":1001}"#,
+                r#"{"cmd":"callers","query":"b","ts":1002}"#,
+            ],
+        );
+
+        let live_only = telemetry_core(dir.path(), &TelemetryArgs { all: false }).unwrap();
+        assert_eq!(live_only.events, 1, "all:false counts only the live file");
+
+        let everything = telemetry_core(dir.path(), &TelemetryArgs { all: true }).unwrap();
+        assert_eq!(
+            everything.events, 3,
+            "all:true folds the archived file's events in"
+        );
+        assert_eq!(
+            everything.categories.get("Structural").copied(),
+            Some(2),
+            "impact + callers from the archive roll up under Structural"
+        );
+    }
+
     #[test]
     fn test_category_assignment() {
         assert_eq!(category_for("search"), "Search");

--- a/src/cli/limits.rs
+++ b/src/cli/limits.rs
@@ -14,6 +14,13 @@
 //! so they share a single env-override pattern. Library-level caps (parser,
 //! FTS, graph, converter) live in `crate::limits` because their callers
 //! (`parser/`, `store/`, `nl/`, `convert/`) cannot reach into the CLI module.
+//!
+//! The env-knob parse/warn/default contract lives once in `cqs::limits`
+//! (warns loudly on a malformed-but-set value so a typoed
+//! `CQS_RERANK_POOL_MAX=abc` shows the silent fall-through). These CLI
+//! resolvers route through those helpers rather than carrying a private copy.
+
+use cqs::limits::{parse_env_u64, parse_env_usize};
 
 /// Hard cap on `--limit` for search, applied identically by the CLI
 /// dispatcher (`cli::dispatch`, top-level `cli.limit` clamp) and the daemon
@@ -242,53 +249,6 @@ pub(crate) const DEFAULT_MAX_BATCH_LINE_LEN: usize = MAX_DIFF_BYTES;
 /// Resolve the batch-line cap honoring `CQS_BATCH_MAX_LINE_LEN`.
 pub(crate) fn batch_max_line_len() -> usize {
     parse_env_usize("CQS_BATCH_MAX_LINE_LEN", DEFAULT_MAX_BATCH_LINE_LEN)
-}
-
-// ============ shared parsing helpers ============
-
-/// Parse a `usize`-shaped env var. Empty / unparseable / zero values fall
-/// back to the supplied default. Zero is rejected because every caller
-/// here treats the value as a non-zero size limit; a caller that wants to
-/// disable a check should remove the call, not set it to zero.
-///
-/// Warns loudly on a malformed-but-set value so an operator who typoed
-/// `CQS_RERANK_POOL_MAX=128 ` (trailing space) or `=abc` sees the
-/// silent-default fall-through instead of debugging "why isn't my env var
-/// doing anything." Mirrors the warn pattern in the other env-knob helpers.
-fn parse_env_usize(key: &str, default: usize) -> usize {
-    match std::env::var(key) {
-        Ok(v) => match v.parse::<usize>() {
-            Ok(n) if n > 0 => n,
-            _ => {
-                tracing::warn!(
-                    env = key,
-                    value = %v,
-                    "Invalid env var (must be positive usize), using default {default}"
-                );
-                default
-            }
-        },
-        Err(_) => default,
-    }
-}
-
-/// Same as [`parse_env_usize`] but for `u64`-shaped byte limits.
-/// Same warn-on-malformed contract.
-fn parse_env_u64(key: &str, default: u64) -> u64 {
-    match std::env::var(key) {
-        Ok(v) => match v.parse::<u64>() {
-            Ok(n) if n > 0 => n,
-            _ => {
-                tracing::warn!(
-                    env = key,
-                    value = %v,
-                    "Invalid env var (must be positive u64), using default {default}"
-                );
-                default
-            }
-        },
-        Err(_) => default,
-    }
 }
 
 #[cfg(test)]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -73,16 +73,20 @@ impl From<&ChunkIdentity> for ChunkKey {
     }
 }
 
+/// Default embedding-fetch batch size for `semantic_diff`. Keeps each batch
+/// ~12 MB at 1024-dim. Scales linearly with model dim.
+const EMBEDDING_BATCH_SIZE_DEFAULT: usize = 1000;
+
 /// Embedding batch size for `semantic_diff`'s embedding-fetch loop.
 ///
-/// Default 1000 keeps each batch ~12 MB at 1024-dim. Scales linearly with model dim;
-/// override via `CQS_DIFF_EMBEDDING_BATCH_SIZE` for larger models or tight memory budgets.
+/// Override via `CQS_DIFF_EMBEDDING_BATCH_SIZE` for larger models or tight
+/// memory budgets. Parse/warn/default via the shared
+/// `crate::limits::parse_env_usize` (warns on a malformed value).
 fn embedding_batch_size() -> usize {
-    std::env::var("CQS_DIFF_EMBEDDING_BATCH_SIZE")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(1000)
+    crate::limits::parse_env_usize(
+        "CQS_DIFF_EMBEDDING_BATCH_SIZE",
+        EMBEDDING_BATCH_SIZE_DEFAULT,
+    )
 }
 
 /// Run a semantic diff between two stores.

--- a/src/gather.rs
+++ b/src/gather.rs
@@ -152,28 +152,13 @@ impl GatherOptions {
 
 /// Read CQS_GATHER_MAX_NODES once via OnceLock, not on every GatherOptions::default().
 ///
-/// Public so CLI text-mode warnings can report the actual cap.
+/// Public so CLI text-mode warnings can report the actual cap. Parse/warn/
+/// default goes through the shared `crate::limits::parse_env_usize`; the
+/// OnceLock cache keeps it a single env read per process.
 pub fn gather_max_nodes() -> usize {
     static CAP: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *CAP.get_or_init(|| match std::env::var("CQS_GATHER_MAX_NODES") {
-        Ok(val) => match val.parse::<usize>() {
-            Ok(n) if n > 0 => {
-                tracing::info!(
-                    max_nodes = n,
-                    "BFS node cap overridden via CQS_GATHER_MAX_NODES"
-                );
-                n
-            }
-            _ => {
-                tracing::warn!(
-                    value = %val,
-                    "Invalid CQS_GATHER_MAX_NODES, using default {}",
-                    DEFAULT_MAX_EXPANDED_NODES
-                );
-                DEFAULT_MAX_EXPANDED_NODES
-            }
-        },
-        Err(_) => DEFAULT_MAX_EXPANDED_NODES,
+    *CAP.get_or_init(|| {
+        crate::limits::parse_env_usize("CQS_GATHER_MAX_NODES", DEFAULT_MAX_EXPANDED_NODES)
     })
 }
 

--- a/src/hnsw/persist.rs
+++ b/src/hnsw/persist.rs
@@ -12,67 +12,27 @@ use super::{HnswError, HnswGraph, HnswIndex, HnswInner, HnswIoCell, LoadedHnsw};
 
 /// Configurable HNSW graph file size limit via `CQS_HNSW_MAX_GRAPH_BYTES`
 /// env var. Defaults to 500MB. Cached in OnceLock for single parse.
+/// Parse/warn/default goes through the shared `crate::limits::parse_env_u64`.
 fn hnsw_max_graph_bytes() -> u64 {
     static MAX: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
-    *MAX.get_or_init(|| match std::env::var("CQS_HNSW_MAX_GRAPH_BYTES") {
-        Ok(val) => match val.parse::<u64>() {
-            Ok(n) if n > 0 => {
-                tracing::info!(max_bytes = n, "CQS_HNSW_MAX_GRAPH_BYTES override");
-                n
-            }
-            _ => {
-                tracing::warn!(
-                    value = %val,
-                    "Invalid CQS_HNSW_MAX_GRAPH_BYTES, using default 500MB"
-                );
-                500 * 1024 * 1024
-            }
-        },
-        Err(_) => 500 * 1024 * 1024,
-    })
+    *MAX.get_or_init(|| crate::limits::parse_env_u64("CQS_HNSW_MAX_GRAPH_BYTES", 500 * 1024 * 1024))
 }
 
 /// Configurable HNSW data file size limit via `CQS_HNSW_MAX_DATA_BYTES`
 /// env var. Defaults to 1GB. Cached in OnceLock for single parse.
+/// Parse/warn/default goes through the shared `crate::limits::parse_env_u64`.
 fn hnsw_max_data_bytes() -> u64 {
     static MAX: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
-    *MAX.get_or_init(|| match std::env::var("CQS_HNSW_MAX_DATA_BYTES") {
-        Ok(val) => match val.parse::<u64>() {
-            Ok(n) if n > 0 => {
-                tracing::info!(max_bytes = n, "CQS_HNSW_MAX_DATA_BYTES override");
-                n
-            }
-            _ => {
-                tracing::warn!(
-                    value = %val,
-                    "Invalid CQS_HNSW_MAX_DATA_BYTES, using default 1GB"
-                );
-                1024 * 1024 * 1024
-            }
-        },
-        Err(_) => 1024 * 1024 * 1024,
-    })
+    *MAX.get_or_init(|| crate::limits::parse_env_u64("CQS_HNSW_MAX_DATA_BYTES", 1024 * 1024 * 1024))
 }
 
 /// Configurable HNSW ID map file size limit via `CQS_HNSW_MAX_ID_MAP_BYTES`
 /// env var. Defaults to 500MB. Cached in OnceLock for single parse.
+/// Parse/warn/default goes through the shared `crate::limits::parse_env_u64`.
 fn hnsw_max_id_map_bytes() -> u64 {
     static MAX: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
-    *MAX.get_or_init(|| match std::env::var("CQS_HNSW_MAX_ID_MAP_BYTES") {
-        Ok(val) => match val.parse::<u64>() {
-            Ok(n) if n > 0 => {
-                tracing::info!(max_bytes = n, "CQS_HNSW_MAX_ID_MAP_BYTES override");
-                n
-            }
-            _ => {
-                tracing::warn!(
-                    value = %val,
-                    "Invalid CQS_HNSW_MAX_ID_MAP_BYTES, using default 500MB"
-                );
-                500 * 1024 * 1024
-            }
-        },
-        Err(_) => 500 * 1024 * 1024,
+    *MAX.get_or_init(|| {
+        crate::limits::parse_env_u64("CQS_HNSW_MAX_ID_MAP_BYTES", 500 * 1024 * 1024)
     })
 }
 

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -272,35 +272,50 @@ pub fn blast_high_min() -> usize {
 
 // ============ shared parsing helpers ============
 //
-// A single contract for env-driven size limits: missing/empty/garbage/zero
-// -> default, otherwise the parsed value. Zero is treated as invalid by all
-// three helpers — call sites that *want* zero to mean "disabled" need to
-// spell it (`if value == 0 { return default; }` after a custom parse).
+// A single contract for env-driven size limits: missing -> default;
+// empty/garbage/zero -> default *with a warn* so an operator who typoed the
+// value sees the silent fall-through instead of debugging "why isn't my env
+// var doing anything." Zero is treated as invalid by all three helpers —
+// call sites that *want* zero to mean "disabled" need to spell it
+// (`if value == 0 { return default; }` after a custom parse).
 
 /// Parse a finite positive `f32`-shaped env var, falling back to
 /// `default` on missing/empty/garbage/non-finite/non-positive values.
 /// Mirrors `parse_env_usize`'s "reject zero" stance so env-driven risk
 /// thresholds can't silently collapse the classification by pinning 0.
+/// Warns on a malformed-but-set value.
 pub fn parse_env_f32(key: &str, default: f32) -> f32 {
     match std::env::var(key) {
-        Ok(v) => v
-            .parse::<f32>()
-            .ok()
-            .filter(|n| n.is_finite() && *n > 0.0)
-            .unwrap_or(default),
+        Ok(v) => match v.parse::<f32>() {
+            Ok(n) if n.is_finite() && n > 0.0 => n,
+            _ => {
+                tracing::warn!(
+                    env = key,
+                    value = %v,
+                    "Invalid env var (must be a finite positive number), using default {default}"
+                );
+                default
+            }
+        },
         Err(_) => default,
     }
 }
 
 /// Parse a `usize`-shaped env var, falling back to `default` on
-/// missing/empty/garbage/zero values.
+/// missing/empty/garbage/zero values. Warns on a malformed-but-set value.
 pub fn parse_env_usize(key: &str, default: usize) -> usize {
     match std::env::var(key) {
-        Ok(v) => v
-            .parse::<usize>()
-            .ok()
-            .filter(|n| *n > 0)
-            .unwrap_or(default),
+        Ok(v) => match v.parse::<usize>() {
+            Ok(n) if n > 0 => n,
+            _ => {
+                tracing::warn!(
+                    env = key,
+                    value = %v,
+                    "Invalid env var (must be a positive usize), using default {default}"
+                );
+                default
+            }
+        },
         Err(_) => default,
     }
 }
@@ -427,9 +442,20 @@ pub fn serve_blocking_permits() -> usize {
 }
 
 /// Same as [`parse_env_usize`] but for `u64`-shaped byte limits.
+/// Warns on a malformed-but-set value.
 pub fn parse_env_u64(key: &str, default: u64) -> u64 {
     match std::env::var(key) {
-        Ok(v) => v.parse::<u64>().ok().filter(|n| *n > 0).unwrap_or(default),
+        Ok(v) => match v.parse::<u64>() {
+            Ok(n) if n > 0 => n,
+            _ => {
+                tracing::warn!(
+                    env = key,
+                    value = %v,
+                    "Invalid env var (must be a positive u64), using default {default}"
+                );
+                default
+            }
+        },
         Err(_) => default,
     }
 }

--- a/src/llm/local.rs
+++ b/src/llm/local.rs
@@ -139,36 +139,19 @@ impl LocalProvider {
 
         let concurrency = local_concurrency();
         let timeout = local_timeout();
-        let mut api_key = std::env::var("CQS_LLM_API_KEY")
+        let api_key = std::env::var("CQS_LLM_API_KEY")
             .ok()
             .filter(|s| !s.is_empty());
 
-        // Refuse to attach `Authorization: Bearer <key>` when an `http://`
-        // (plaintext) base targets a non-loopback / non-RFC1918 host. The
-        // cross-origin redirect policy and same-origin redirect both assume
-        // the operator at least started with HTTPS or a loopback bind —
-        // neither defense triggers when the intentional initial bind is
-        // plaintext to a public host, so without this refusal every prompt
-        // + the bearer token would ship in cleartext to whoever is on-path.
-        //
-        // Symmetric to `cqs serve`'s loud-warn for `--no-auth` on
-        // non-loopback — operator gets a clear refusal instead of a silent
-        // leak.
-        if api_base_lc.starts_with("http://") && api_key.is_some() {
-            let host = http_host(&llm_config.api_base);
-            if !is_local_or_private_host(host) {
-                tracing::warn!(
-                    // Redacted form so user:pass@host doesn't land in journald.
-                    api_base = %llm_config.redacted_api_base(),
-                    host = host,
-                    "Refusing to attach Authorization: Bearer over plaintext HTTP to a \
-                     non-loopback / non-RFC1918 host. Use https:// or bind to a private \
-                     network. Auth header dropped; requests will proceed without it. \
-                     SEC-V1.33-10 / #1340"
-                );
-                api_key = None;
-            }
-        }
+        // The cleartext-http trust decision lives entirely in
+        // `LlmConfig::resolve`: any `http://` base (loopback or not) is
+        // refused there unless the operator sets `CQS_LLM_ALLOW_INSECURE=1`,
+        // which means "I accept cleartext auth, send the header". By the time
+        // we reach here the base is either `https://` or an acknowledged
+        // `http://`, so the provider honors the resolved config unconditionally
+        // and attaches the bearer token. Dropping it here would silently
+        // contradict that explicit opt-in and 401 against auth-requiring local
+        // vLLM deployments.
 
         // Same-origin redirect policy. Submit requests carry
         // `Authorization: Bearer <key>` when CQS_LLM_API_KEY is set.
@@ -671,138 +654,6 @@ impl LocalProvider {
 /// Not memoised: read on each response so tests can flip the cap without a
 /// process-wide cache. The env-var cost is negligible compared to the HTTP
 /// request that just completed.
-/// Extract the host portion of an `http(s)://host[:port]/path` URL without
-/// pulling the `url` crate as a direct dep.
-///
-/// Handles IPv6 literals (`http://[::1]:8080/...` → `[::1]`), default ports
-/// (`http://example.com/...` → `example.com`), and ports
-/// (`http://10.0.0.1:8080/v1` → `10.0.0.1`). Returns the input unchanged
-/// when the URL doesn't match the expected shape — `is_local_or_private_host`
-/// will then reject it as not-loopback.
-fn http_host(api_base: &str) -> &str {
-    let rest = match api_base
-        .strip_prefix("http://")
-        .or_else(|| api_base.strip_prefix("https://"))
-    {
-        Some(r) => r,
-        None => return api_base,
-    };
-    // IPv6 literals are bracketed: [::1]:8080
-    if let Some(stripped) = rest.strip_prefix('[') {
-        if let Some(end) = stripped.find(']') {
-            return &stripped[..end];
-        }
-    }
-    // Otherwise host runs until the first `:` (port) or `/` (path).
-    let end = rest
-        .bytes()
-        .position(|b| b == b':' || b == b'/')
-        .unwrap_or(rest.len());
-    &rest[..end]
-}
-
-/// Predicate: does `host` (already extracted by [`http_host`]) refer to a
-/// loopback or RFC1918 destination, where plaintext `http://` is acceptable?
-///
-/// Loopback: `127.0.0.1` (and any `127.x.x.x`), `::1`, `localhost`.
-/// RFC1918:
-/// - `10.0.0.0/8` (any `10.x.x.x`)
-/// - `172.16.0.0/12` (`172.16.x.x` through `172.31.x.x`)
-/// - `192.168.0.0/16` (any `192.168.x.x`)
-///
-/// Returns `false` for hostnames containing dots that don't match those
-/// patterns (e.g. `internal-llm.example.com`). Returns `false` for
-/// non-IPv4-shaped strings outside the explicit-loopback names —
-/// catches `attacker.example.com`, `8.8.8.8`, etc.
-fn is_local_or_private_host(host: &str) -> bool {
-    let h = host.to_ascii_lowercase();
-    if h == "localhost" || h == "::1" {
-        return true;
-    }
-    // IPv4 dotted-quad: split into 4 octets and pattern-match the prefix.
-    let octets: Vec<_> = h.split('.').collect();
-    if octets.len() != 4 {
-        return false;
-    }
-    let parsed: Option<Vec<u8>> = octets.iter().map(|o| o.parse::<u8>().ok()).collect();
-    let Some(quad) = parsed else {
-        return false;
-    };
-    match (quad[0], quad[1]) {
-        (127, _) => true,                           // 127.0.0.0/8
-        (10, _) => true,                            // 10.0.0.0/8
-        (172, b) if (16..=31).contains(&b) => true, // 172.16.0.0/12
-        (192, 168) => true,                         // 192.168.0.0/16
-        _ => false,
-    }
-}
-
-#[cfg(test)]
-mod url_predicates_tests {
-    use super::{http_host, is_local_or_private_host};
-
-    #[test]
-    fn host_extraction_basic() {
-        assert_eq!(http_host("http://example.com/v1"), "example.com");
-        assert_eq!(http_host("https://api.openai.com/v1"), "api.openai.com");
-        assert_eq!(http_host("http://10.0.0.1:8080/v1"), "10.0.0.1");
-        assert_eq!(http_host("http://localhost:8000"), "localhost");
-        assert_eq!(http_host("http://localhost"), "localhost");
-    }
-
-    #[test]
-    fn host_extraction_ipv6() {
-        assert_eq!(http_host("http://[::1]:8080/v1"), "::1");
-        assert_eq!(http_host("https://[2001:db8::1]/api"), "2001:db8::1");
-    }
-
-    #[test]
-    fn host_extraction_unparseable_returns_input() {
-        assert_eq!(http_host("not a url"), "not a url");
-        assert_eq!(http_host("ftp://x"), "ftp://x");
-    }
-
-    #[test]
-    fn loopback_accepted() {
-        assert!(is_local_or_private_host("127.0.0.1"));
-        assert!(is_local_or_private_host("127.5.6.7"));
-        assert!(is_local_or_private_host("::1"));
-        assert!(is_local_or_private_host("localhost"));
-        assert!(is_local_or_private_host("LOCALHOST"));
-    }
-
-    #[test]
-    fn rfc1918_accepted() {
-        assert!(is_local_or_private_host("10.0.0.1"));
-        assert!(is_local_or_private_host("10.255.255.255"));
-        assert!(is_local_or_private_host("172.16.0.1"));
-        assert!(is_local_or_private_host("172.31.255.255"));
-        assert!(is_local_or_private_host("192.168.1.1"));
-    }
-
-    #[test]
-    fn rfc1918_172_boundaries() {
-        assert!(!is_local_or_private_host("172.15.0.1"), "below /12 range");
-        assert!(!is_local_or_private_host("172.32.0.1"), "above /12 range");
-    }
-
-    #[test]
-    fn public_rejected() {
-        assert!(!is_local_or_private_host("8.8.8.8"));
-        assert!(!is_local_or_private_host("example.com"));
-        assert!(!is_local_or_private_host("internal-llm.example.com"));
-        assert!(!is_local_or_private_host(""));
-    }
-
-    #[test]
-    fn rejects_non_ipv4_with_dots() {
-        // Hostname like "1.2.3" (3 parts) shouldn't be treated as IP.
-        assert!(!is_local_or_private_host("1.2.3"));
-        // Hostname with 4 parts but non-numeric.
-        assert!(!is_local_or_private_host("a.b.c.d"));
-    }
-}
-
 fn local_max_body_bytes() -> usize {
     std::env::var("CQS_LOCAL_LLM_MAX_BODY_BYTES")
         .ok()
@@ -1107,6 +958,53 @@ mod tests {
 
         let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
         let provider = LocalProvider::new(config).unwrap();
+        let batch_id = provider
+            .submit_batch(
+                crate::llm::provider::BatchKind::Prebuilt,
+                &make_items(1),
+                100,
+            )
+            .unwrap();
+        assert_eq!(provider.fetch_batch_results(&batch_id).unwrap().len(), 1);
+        m.assert();
+
+        std::env::remove_var("CQS_LOCAL_LLM_CONCURRENCY");
+        std::env::remove_var("CQS_LLM_API_KEY");
+    }
+
+    // ===== Trust model: the bearer header survives to a local http:// vLLM =====
+    //
+    // The cleartext-auth trust decision lives solely in `LlmConfig::resolve`.
+    // Once a base is resolved, `LocalProvider::new` honors the config and
+    // attaches the bearer unconditionally — it does NOT re-decide host trust
+    // and drop the header. httpmock binds to loopback `http://127.0.0.1:<port>`,
+    // i.e. exactly the auth-requiring local vLLM deployment the prior two-layer
+    // policy could have silently 401'd against. The mock REQUIRES the header,
+    // so a regression that re-introduced an auth-drop would fail `m.assert()`.
+    #[test]
+    fn local_http_provider_keeps_auth_header() {
+        let _lock = crate::llm::LLM_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("CQS_LOCAL_LLM_CONCURRENCY", "1");
+        std::env::set_var("CQS_LLM_API_KEY", "local-vllm-key");
+
+        let server = httpmock::MockServer::start();
+        // The base is plaintext http:// (httpmock never serves TLS).
+        assert!(server.base_url().starts_with("http://"));
+        let m = server.mock(|when, then| {
+            when.method("POST")
+                .path("/v1/chat/completions")
+                .header("Authorization", "Bearer local-vllm-key");
+            then.status(200).json_body(serde_json::json!({
+                "choices": [{ "message": { "content": "ok" } }]
+            }));
+        });
+
+        let config = make_config(&format!("{}/v1", server.base_url()), "test-model");
+        let provider = LocalProvider::new(config).unwrap();
+        // The provider retained the key (it is not dropped at construction).
+        assert!(provider.api_key.is_some());
         let batch_id = provider
             .submit_batch(
                 crate::llm::provider::BatchKind::Prebuilt,

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -322,6 +322,13 @@ impl LlmConfig {
     /// Returns `Err` if `CQS_LLM_API_BASE` uses cleartext `http://` and the
     /// explicit opt-in `CQS_LLM_ALLOW_INSECURE=1` is not set. Prevents the
     /// API key from being sent in the clear on every call.
+    ///
+    /// This is the *single* gate for the cleartext-auth trust decision. Any
+    /// `http://` base — loopback, RFC1918, or public — is refused here without
+    /// `CQS_LLM_ALLOW_INSECURE=1`. Setting that flag means "I accept cleartext
+    /// auth, send the header": downstream providers (`LocalProvider::new`)
+    /// then honor the resolved config unconditionally and attach the bearer
+    /// token, rather than re-deciding host trust and silently dropping it.
     pub fn resolve(config: &crate::config::Config) -> Result<Self, LlmError> {
         let _span = tracing::info_span!("resolve_llm_config").entered();
 

--- a/src/note.rs
+++ b/src/note.rs
@@ -53,22 +53,16 @@ pub const MAX_NOTE_MENTION_BYTES: usize = 256;
 /// `CQS_NOTES_MAX_FILE_SIZE`.
 const MAX_NOTES_FILE_SIZE_DEFAULT: u64 = 10 * 1024 * 1024;
 
-/// Resolve `CQS_NOTES_MAX_FILE_SIZE` (default 10 MiB).
+/// Resolve `CQS_NOTES_MAX_FILE_SIZE` (default 10 MiB). Parse/warn/default via
+/// the shared `crate::limits::parse_env_u64` (warns on a malformed value).
 fn max_notes_file_size() -> u64 {
-    std::env::var("CQS_NOTES_MAX_FILE_SIZE")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .filter(|n| *n > 0)
-        .unwrap_or(MAX_NOTES_FILE_SIZE_DEFAULT)
+    crate::limits::parse_env_u64("CQS_NOTES_MAX_FILE_SIZE", MAX_NOTES_FILE_SIZE_DEFAULT)
 }
 
-/// Resolve `CQS_NOTES_MAX_ENTRIES` (default 10_000).
+/// Resolve `CQS_NOTES_MAX_ENTRIES` (default 10_000). Parse/warn/default via
+/// the shared `crate::limits::parse_env_usize` (warns on a malformed value).
 fn max_notes() -> usize {
-    std::env::var("CQS_NOTES_MAX_ENTRIES")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|n| *n > 0)
-        .unwrap_or(MAX_NOTES_DEFAULT)
+    crate::limits::parse_env_usize("CQS_NOTES_MAX_ENTRIES", MAX_NOTES_DEFAULT)
 }
 
 /// Errors that can occur when parsing notes

--- a/src/onboard.rs
+++ b/src/onboard.rs
@@ -34,22 +34,16 @@ const MAX_CALLEE_FETCH_DEFAULT: usize = 30;
 /// `CQS_ONBOARD_CALLER_FETCH`.
 const MAX_CALLER_FETCH_DEFAULT: usize = 15;
 
-/// Resolve `CQS_ONBOARD_CALLEE_FETCH`, default 30.
+/// Resolve `CQS_ONBOARD_CALLEE_FETCH`, default 30. Parse/warn/default via
+/// the shared `crate::limits::parse_env_usize` (warns on a malformed value).
 fn max_callee_fetch() -> usize {
-    std::env::var("CQS_ONBOARD_CALLEE_FETCH")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|n| *n > 0)
-        .unwrap_or(MAX_CALLEE_FETCH_DEFAULT)
+    crate::limits::parse_env_usize("CQS_ONBOARD_CALLEE_FETCH", MAX_CALLEE_FETCH_DEFAULT)
 }
 
-/// Resolve `CQS_ONBOARD_CALLER_FETCH`, default 15.
+/// Resolve `CQS_ONBOARD_CALLER_FETCH`, default 15. Parse/warn/default via
+/// the shared `crate::limits::parse_env_usize` (warns on a malformed value).
 fn max_caller_fetch() -> usize {
-    std::env::var("CQS_ONBOARD_CALLER_FETCH")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|n| *n > 0)
-        .unwrap_or(MAX_CALLER_FETCH_DEFAULT)
+    crate::limits::parse_env_usize("CQS_ONBOARD_CALLER_FETCH", MAX_CALLER_FETCH_DEFAULT)
 }
 
 // Uses crate::COMMON_TYPES (from focused_read.rs) for type filtering — single source of truth.

--- a/src/task.rs
+++ b/src/task.rs
@@ -18,8 +18,9 @@ use crate::{AnalysisError, Embedder, Store};
 /// BFS expansion depth for gather phase (how many call-graph hops from modify targets).
 ///
 /// `CQS_TASK_GATHER_DEPTH` overrides this per-task; falls back to this constant
-/// when unset. Also honors `CQS_GATHER_DEPTH` as a cross-cutting default for any
-/// caller that wants to set both `gather` and `task` depth in one place.
+/// when unset. `CQS_GATHER_DEPTH` is honored as a lower-precedence fallback for
+/// the task pipeline only — `cqs gather` itself takes its depth from the
+/// `--depth` flag (`DEFAULT_DEPTH_BLAST`), not from this env var.
 const TASK_GATHER_DEPTH_DEFAULT: usize = 2;
 
 /// Multiplier applied to `limit` for gather phase truncation.
@@ -29,28 +30,32 @@ const TASK_GATHER_LIMIT_MULTIPLIER: usize = 3;
 ///
 /// Precedence:
 /// 1. `CQS_TASK_GATHER_DEPTH` (per-task override)
-/// 2. `CQS_GATHER_DEPTH` (shared default with `cqs gather`)
+/// 2. `CQS_GATHER_DEPTH` (task-pipeline fallback; `cqs gather` does not read it)
 /// 3. `TASK_GATHER_DEPTH_DEFAULT` (= 2)
 ///
 /// Reading on each call (vs `OnceLock`) is a single `getenv` per `task` invocation,
 /// which keeps `systemctl set-environment` and per-test overrides effective without
 /// process restart. Documented in README.md.
+///
+/// Both env reads go through the shared `crate::limits::parse_env_usize`
+/// (uniform warn-on-invalid). The helper re-reads env on each call, so the
+/// deliberate no-cache contract above is preserved. A set-but-invalid
+/// `CQS_TASK_GATHER_DEPTH` still falls through to `CQS_GATHER_DEPTH` (matching
+/// the original precedence): the per-var presence + positive-parse check is
+/// done here so an invalid override doesn't shadow the shared fallback.
 fn task_gather_depth() -> usize {
-    if let Ok(v) = std::env::var("CQS_TASK_GATHER_DEPTH") {
-        if let Ok(n) = v.parse::<usize>() {
-            if n > 0 {
-                return n;
-            }
-        }
+    let valid_positive = |key: &str| -> Option<usize> {
+        std::env::var(key)
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+    };
+    if let Some(n) = valid_positive("CQS_TASK_GATHER_DEPTH") {
+        return n;
     }
-    if let Ok(v) = std::env::var("CQS_GATHER_DEPTH") {
-        if let Ok(n) = v.parse::<usize>() {
-            if n > 0 {
-                return n;
-            }
-        }
-    }
-    TASK_GATHER_DEPTH_DEFAULT
+    // Route the resolved fallback (task var unset or invalid) through the
+    // shared helper so `CQS_GATHER_DEPTH=garbage` gets the uniform warn.
+    crate::limits::parse_env_usize("CQS_GATHER_DEPTH", TASK_GATHER_DEPTH_DEFAULT)
 }
 
 /// Per-function risk assessment from impact analysis.
@@ -137,13 +142,43 @@ pub fn task_with_resources<Mode>(
 ) -> Result<TaskResult, AnalysisError> {
     let _span = tracing::info_span!("task", description_len = description.len(), limit).entered();
 
-    // 1. Embed query
+    // 1. Embed query — the only step that needs an `&Embedder`. Everything
+    // downstream runs against the pre-built embedding via `task_core`, which
+    // is what lets the pipeline be exercised against a seeded store in tests.
     let query_embedding = embedder.embed_query(description)?;
+
+    task_core(
+        store,
+        &query_embedding,
+        description,
+        root,
+        limit,
+        graph,
+        test_chunks,
+    )
+}
+
+/// Embedder-free task pipeline core: scout → gather → impact → placement,
+/// driven by a pre-built `query_embedding`. Mirrors `scout_core`'s seam so
+/// callers (and tests) that already hold an embedding can run the whole
+/// composition without an `&Embedder` / ONNX model.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn task_core<Mode>(
+    store: &Store<Mode>,
+    query_embedding: &crate::Embedding,
+    description: &str,
+    root: &Path,
+    limit: usize,
+    graph: &crate::store::CallGraph,
+    test_chunks: &[crate::store::ChunkSummary],
+) -> Result<TaskResult, AnalysisError> {
+    let _span =
+        tracing::info_span!("task_core", description_len = description.len(), limit).entered();
 
     // 2. Scout phase
     let scout = scout_core(&ScoutResources {
         store,
-        query_embedding: &query_embedding,
+        query_embedding,
         task: description,
         root,
         limit,
@@ -211,14 +246,15 @@ pub fn task_with_resources<Mode>(
     };
     tracing::debug!(risks = risk.len(), tests = tests.len(), "Impact complete");
 
-    // 6. Placement phase — reuse query embedding to avoid redundant ONNX inference
+    // 6. Placement phase — reuse the query embedding (no redundant ONNX
+    // inference). The `_core` placement entry is embedder-free precisely so
+    // the task pipeline never needs an `&Embedder` past step 1.
     let placement_opts = crate::where_to_add::PlacementOptions {
         query_embedding: Some(query_embedding.clone()),
         ..Default::default()
     };
-    let placement: Vec<_> = match crate::where_to_add::suggest_placement_with_options(
+    let placement: Vec<_> = match crate::where_to_add::suggest_placement_with_options_core(
         store,
-        embedder,
         description,
         3,
         &placement_opts,
@@ -624,5 +660,141 @@ mod tests {
         assert_eq!(placement.len(), 1);
         assert_eq!(placement[0]["near_function"], "fn_a");
         assert_eq!(placement[0]["reason"], "same module");
+    }
+
+    // ===== task_core integration (seeded store + pre-built query embedding) =====
+
+    /// Build a normalized embedding from per-index weights (dims past
+    /// `weights.len()` are zero). Gives chunks distinct, deterministic cosine
+    /// scores against a one-hot query without an embedder — mirrors the
+    /// scout_core seeded-store pattern.
+    fn weighted_embedding(weights: &[f32]) -> crate::Embedding {
+        let mut v = vec![0.0f32; crate::EMBEDDING_DIM];
+        for (i, &w) in weights.iter().enumerate() {
+            if i < v.len() {
+                v[i] = w;
+            }
+        }
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for x in &mut v {
+                *x /= norm;
+            }
+        }
+        crate::Embedding::new(v)
+    }
+
+    fn indexed_chunk(
+        name: &str,
+        file: &str,
+        line_start: u32,
+        line_end: u32,
+    ) -> crate::parser::Chunk {
+        crate::parser::Chunk {
+            id: format!("{file}:{line_start}:{name}"),
+            file: PathBuf::from(file),
+            language: crate::parser::Language::Rust,
+            chunk_type: crate::parser::ChunkType::Function,
+            name: name.to_string(),
+            signature: format!("fn {name}()"),
+            content: format!("fn {name}() {{}}"),
+            doc: None,
+            line_start,
+            line_end,
+            content_hash: format!("{name}_hash"),
+            canonical_hash: String::new(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        }
+    }
+
+    /// The whole scout → gather → impact → placement composition runs against a
+    /// seeded store via the embedder-free `task_core`, asserting a SPECIFIC
+    /// modify target (not just "ran without panicking" the way the `#[ignore]`d
+    /// e2e tests did). A one-hot query puts `validate_input` at cosine 1.0 (the
+    /// lone ModifyTarget) and a helper below the gap as a Dependency.
+    #[test]
+    fn task_core_seeded_store_picks_modify_target() {
+        let (store, _dir) = crate::test_helpers::setup_store();
+
+        let query = weighted_embedding(&[1.0]);
+        // cosine 1.0 → ModifyTarget.
+        let target = indexed_chunk("validate_input", "src/validate.rs", 10, 30);
+        // cosine ~0.29 → above the 0.2 floor but below the gap → Dependency.
+        let dep_embedding = weighted_embedding(&[0.3, 1.0]);
+        let helper = indexed_chunk("validation_helper", "src/helper.rs", 1, 8);
+        // Test chunk in a tests/ path → TestToUpdate.
+        let test = indexed_chunk("test_validate_input", "tests/validate_test.rs", 1, 12);
+
+        store.upsert_chunk(&target, &query, Some(1)).unwrap();
+        store
+            .upsert_chunk(&helper, &dep_embedding, Some(1))
+            .unwrap();
+        store.upsert_chunk(&test, &query, Some(1)).unwrap();
+
+        // Caller edges so the target has a test caller and a non-test caller.
+        let calls = [
+            crate::parser::FunctionCalls {
+                name: "test_validate_input".to_string(),
+                line_start: 1,
+                calls: vec![crate::parser::CallSite {
+                    callee_name: "validate_input".to_string(),
+                    line_number: 3,
+                }],
+            },
+            crate::parser::FunctionCalls {
+                name: "validation_helper".to_string(),
+                line_start: 1,
+                calls: vec![crate::parser::CallSite {
+                    callee_name: "validate_input".to_string(),
+                    line_number: 2,
+                }],
+            },
+        ];
+        store
+            .upsert_function_calls(Path::new("tests/validate_test.rs"), &calls[..1])
+            .unwrap();
+        store
+            .upsert_function_calls(Path::new("src/helper.rs"), &calls[1..])
+            .unwrap();
+
+        let graph = store.get_call_graph().unwrap();
+        let test_chunks = store.find_test_chunks().unwrap();
+
+        let result = task_core(
+            &store,
+            &query,
+            "validate user input",
+            Path::new("/tmp"),
+            10,
+            &graph,
+            &test_chunks,
+        )
+        .unwrap();
+
+        // Scout phase ran and classified the cosine-1.0 chunk as the lone
+        // ModifyTarget — a real, specific outcome.
+        let targets = extract_modify_targets(&result.scout);
+        assert_eq!(
+            targets,
+            vec!["validate_input".to_string()],
+            "validate_input must be the lone modify target, got: {targets:?}"
+        );
+
+        // Impact phase produced a risk entry for that target.
+        assert!(
+            result.risk.iter().any(|r| r.name == "validate_input"),
+            "impact phase must score the modify target, got: {:?}",
+            result.risk.iter().map(|r| &r.name).collect::<Vec<_>>()
+        );
+
+        // Summary echoes the modify-target count.
+        assert_eq!(
+            result.summary.modify_targets, 1,
+            "summary must report exactly one modify target"
+        );
+        assert_eq!(result.description, "validate user input");
     }
 }

--- a/src/where_to_add.rs
+++ b/src/where_to_add.rs
@@ -137,7 +137,11 @@ pub fn suggest_placement_with_options<Mode>(
 }
 
 /// Core placement logic. Requires `opts.query_embedding` to be set.
-fn suggest_placement_with_options_core<Mode>(
+///
+/// Embedder-free: callers that already hold a query embedding (e.g.
+/// `task_core`) reach the placement logic without an `&Embedder`, which is
+/// what lets the task pipeline run against a seeded store in tests.
+pub(crate) fn suggest_placement_with_options_core<Mode>(
     store: &Store<Mode>,
     description: &str,
     limit: usize,

--- a/tests/cli_train_review_test.rs
+++ b/tests/cli_train_review_test.rs
@@ -188,6 +188,81 @@ fn test_task_json_returns_implementation_brief() {
     );
 }
 
+/// Run `cqs task ... --json` (optionally budgeted) and return the `data` value.
+fn run_task_json(dir: &std::path::Path, extra: &[&str]) -> serde_json::Value {
+    let mut args = vec!["task", "improve validation logic", "--json"];
+    args.extend_from_slice(extra);
+    let output = cqs()
+        .args(&args)
+        .current_dir(dir)
+        .output()
+        .expect("Failed to run cqs task");
+    assert!(
+        output.status.success(),
+        "task should succeed (args={args:?}). stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("envelope JSON parse");
+    parsed["data"].clone()
+}
+
+/// `cqs task --tokens N` must route through the waterfall-budget branch
+/// (`task_json_core` Some-budget → `task_to_budgeted_json` → `waterfall_pack`),
+/// which the non-`--tokens` test never exercises. Pins that the budget is
+/// echoed verbatim, that a numeric `token_count` (the packed `total_used`) is
+/// published, and that a tiny budget truncates the code section relative to
+/// the un-budgeted full result.
+///
+/// `token_count` is NOT a hard ceiling: `waterfall_pack` guarantees at least
+/// one item per section, so the documented overshoot is "at most one item's
+/// tokens" — the truncation assertion compares item *counts*, not a raw cap.
+#[test]
+#[serial]
+fn test_task_tokens_budget_publishes_token_fields() {
+    let dir = setup_git_project();
+
+    // Full (un-budgeted) result: count the code chunks the pipeline produced.
+    let full = run_task_json(dir.path(), &[]);
+    let full_code_len = full["code"].as_array().map(|a| a.len()).unwrap_or(0);
+
+    // Budgeted result with a tiny budget.
+    let budgeted = run_task_json(dir.path(), &["--tokens", "50"]);
+
+    assert_eq!(
+        budgeted["token_budget"],
+        serde_json::json!(50),
+        "data.token_budget must echo the requested budget, got: {budgeted}"
+    );
+    let used = budgeted["token_count"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("data.token_count must be numeric, got: {budgeted}"));
+    assert!(used > 0, "packed total_used must be positive, got: {used}");
+
+    // The waterfall packer publishes the full section keys even when truncated.
+    assert!(
+        budgeted["scout"].is_object(),
+        "budgeted output keeps the scout section, got: {budgeted}"
+    );
+
+    // Truncation: a 50-token budget must not pack MORE code chunks than the
+    // full result, and when the full result has multiple chunks the tiny
+    // budget must drop at least one.
+    let budgeted_code_len = budgeted["code"].as_array().map(|a| a.len()).unwrap_or(0);
+    assert!(
+        budgeted_code_len <= full_code_len,
+        "budgeted code section ({budgeted_code_len}) cannot exceed the full one ({full_code_len})"
+    );
+    if full_code_len > 1 {
+        assert!(
+            budgeted_code_len < full_code_len,
+            "a 50-token budget must truncate the code section below the full {full_code_len}"
+        );
+    }
+}
+
 // ============================================================================
 // P2 #46 (c) — `cmd_affected`
 // ============================================================================

--- a/tests/task_test.rs
+++ b/tests/task_test.rs
@@ -290,9 +290,31 @@ fn test_task_end_to_end() {
 
     let task_result = result.unwrap();
     assert_eq!(task_result.description, "search for code");
-    assert!(
-        task_result.summary.total_files > 0 || task_result.code.is_empty(),
-        "Should find files or gracefully return empty results"
+    // Cross-phase invariants that hold regardless of whether the real
+    // embedder ranks the (mock-embedded) fixture above threshold — these
+    // replace the prior `total_files > 0 || code.is_empty()` tautology with
+    // checks a pipeline regression would actually fail.
+    //
+    // 1. The summary file count is the scout file-group count it was computed
+    //    from — a divergence between the two surfaces fails here.
+    assert_eq!(
+        task_result.summary.total_files,
+        task_result.scout.file_groups.len(),
+        "summary file count must match the scout file groups it was computed from"
+    );
+    // 2. Every modify target must carry a matching impact risk entry, and the
+    //    summary modify-target count must match the extracted targets.
+    let target_names = cqs::extract_modify_targets(&task_result.scout);
+    for name in &target_names {
+        assert!(
+            task_result.risk.iter().any(|r| &r.name == name),
+            "modify target {name} must have an impact risk entry"
+        );
+    }
+    assert_eq!(
+        task_result.summary.modify_targets,
+        target_names.len(),
+        "summary modify-target count must match the extracted targets"
     );
 }
 
@@ -323,7 +345,27 @@ fn test_task_with_resources_end_to_end() {
     );
 
     let task_result = result.unwrap();
-    // Verify the pipeline ran — even if search returns no results, structure should be valid
     assert_eq!(task_result.description, "validate user input");
-    let _ = task_result.summary.total_files;
+    // Cross-phase invariants (hold regardless of model-dependent ranking),
+    // replacing the prior `let _ = task_result.summary.total_files;` no-op.
+    assert_eq!(
+        task_result.summary.total_files,
+        task_result.scout.file_groups.len(),
+        "summary file count must equal the scout file-group count"
+    );
+    // Every modify target must carry a matching impact risk entry — the
+    // gather/impact phases are wired to the same target set, so a mismatch is
+    // a pipeline regression regardless of which functions ranked highest.
+    let target_names = cqs::extract_modify_targets(&task_result.scout);
+    for name in &target_names {
+        assert!(
+            task_result.risk.iter().any(|r| &r.name == name),
+            "modify target {name} must have an impact risk entry"
+        );
+    }
+    assert_eq!(
+        task_result.summary.modify_targets,
+        target_names.len(),
+        "summary modify-target count must match the extracted targets"
+    );
 }


### PR DESCRIPTION
Closes the impact-tier-2 P3/P4 batch from docs/audit-triage.md: SEC-V1.42-3 (one trust model — the entire cleartext-http decision lives in LlmConfig::resolve; the dead local.rs re-check that silently dropped an explicitly opted-into auth header is gone; bearer-survives pin added), EH-V1.42-3 (write_ok/err_tracked helpers replace 7 let _= sites on the stdin batch surface — failures warn + bump error_count, BrokenPipe pin), CQ-V1.42-10 (all six env-knob sites route through the shared warn-on-invalid cqs::limits parsers; private cli copy deleted; task.rs per-call re-read preserved with rationale; stale CQS_GATHER_DEPTH doc claim fixed in code + README), TC-HAP-V1.42-9 (telemetry_core populated-path + all:true value pins), TC-HAP-V1.42-4 (embedder-free task_core seam + seeded modify-target test, --tokens waterfall branch driven with item-count truncation asserts — hard token cap would be wrong per waterfall_pack first-item-guarantee — and the ignored e2e tests de-vacuoused to model-independent invariants after the stronger assert exposed their mock/real embedder mismatch). Riders: gather_max_nodes through the shared helper, diff batch literal named. Targeted sweep 278 tests green incl. slow-tests task pins; fmt + clippy --all-targets clean. Triage flips ride this branch.