### PR TITLE
perf(daemon): single-serialization response path — one buffer, one write

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -129,7 +129,7 @@ New v1.42 findings: 107 (batch 1: 59 = 15/11/26/7; batch 2: 48 = 13/19/14/2). Ca
 | PERF-V1.42-7 | `cqs task` computes the full test-reachability BFS twice with identical inputs | src/task.rs:144, :194 | open |
 | PERF-V1.42-8 | test_reachability allocates 2-3 Strings per BFS visit — siblings in same file use Arc<str> interning (runs on every scout/task/health/review) | src/impact/bfs.rs:354-386 | open |
 | PERF-V1.42-10 | build_chunk_detail tests-that-cover query is an unindexed full-table content LIKE scan per dashboard click — use chunks_fts | src/serve/data.rs:619-629 | open |
-| PERF-V1.42-11 | Daemon success response written unbuffered — one write() syscall per JSON fragment (fold into CF dispatch_value refactor, RM-V1.40-9 cluster) | src/cli/watch/socket.rs:298 | open |
+| PERF-V1.42-11 | Daemon success response written unbuffered — one write() syscall per JSON fragment (fold into CF dispatch_value refactor, RM-V1.40-9 cluster) | src/cli/watch/socket.rs:298 | ✅ PR #1766 |
 | TC-HAP-V1.42-5 | Gather direction filtering (Callers/Callees) tested only by is_ok() — deliberate fixture wasted | tests/gather_test.rs:185, :231 | open |
 | TC-HAP-V1.42-7 | Command-core parity tests are parity-by-construction — no parity test pins a single output value; add one fixture-grounded assert each | src/cli/batch/handlers/graph.rs:862-1080 | ✅ PR #1760 |
 | TC-HAP-V1.42-8 | cache_compact_core zero coverage; cache_stats_core per-model branch never executed | src/cli/commands/infra/cache_cmd.rs:222, :117-130 | open |
@@ -185,7 +185,7 @@ Source of truth: `docs/audit-triage-v1.40.0.md` — its "Verification 2026-06-09
 |---|---|---|---|
 | DS-V1.40-8 + DS-V1.40-10 | Kind-detect + real query share no read snapshot — dispatcher/existing-flow drift (v1.40 queue item 6) | medium | open |
 | CQ-V1.40-10 + RB-V1.40-4 + EH-V1.40-10 + DS-V1.40-6 + PERF-V1.40-1 | Cluster A2: `filter_invoked_macros` N+1 GLOB full scans, no transaction (correctness fixed in #1627; perf half remains) | medium | open |
-| RM-V1.40-9 + PERF-V1.40-5 + RM-V1.40-10 | Daemon socket triple payload allocation + `emit_json` double serialization — `dispatch_value` refactor (socket.rs TODO P2 #62) | medium | open |
+| RM-V1.40-9 + PERF-V1.40-5 + RM-V1.40-10 | Daemon socket triple payload allocation + `emit_json` double serialization — `dispatch_value` refactor (socket.rs TODO P2 #62) | medium | ✅ PR #1766 (socket single-write; envelope to_value kept as wire canonicalization) |
 | PERF-V1.40-7 | `build_test_map` iterates all test chunks per call — invert to iterate ancestors (modest; loop body O(1)) | easy | open |
 | RM-V1.40-6 + RM-V1.40-7 | `CrossProjectContext::merged_call_graph` rebuilt per request; reference stores reopened (64 MB mmap × N refs) — cache in BatchContext (note: new CQ-V1.42-11 touches the same surface) | medium | open |
 | AC-V1.40-6 + AC-V1.40-7 + EH-V1.40-3 | trace: macro falls through to empty BFS; `Multiple` masks ambiguity; `target` kind unvalidated | medium | open |
@@ -236,5 +236,5 @@ Source of truth: `docs/audit-triage-v1.40.0.md` — its "Verification 2026-06-09
 | RM-V1.40-2 | `dispatch_via_view` reconstructs token Vec — second full clone per dispatch | easy | open |
 | RM-V1.40-3 | `current_worktree_name` clones cached String per envelope emit | easy | open |
 | RM-V1.40-5 | `dispatch_test_map` clones every test chunk per cross-project request | easy | open |
-| PERF-V1.40-6 | `upsert_chunks_unembedded_batch` clones every chunk + zero-vec | easy | open |
+| PERF-V1.40-6 | `upsert_chunks_unembedded_batch` clones every chunk + zero-vec | easy | ✅ fixed by #1753 (verified by CF sweep) |
 | PERF-V1.40-9 | Telemetry write ~5 syscalls per CLI command — daemon-path handle caching | medium | open |

--- a/src/cli/json_envelope.rs
+++ b/src/cli/json_envelope.rs
@@ -382,18 +382,35 @@ pub(crate) fn sanitize_json_floats(value: &mut serde_json::Value) {
     }
 }
 
-/// Format a pre-built envelope [`serde_json::Value`] as a pretty-printed
-/// string. Tries `serde_json::to_string_pretty` first, falls back to the
-/// sanitize-and-retry pattern on serialization failure (NaN / Infinity in
-/// a leaf field). Used by both [`emit_json`] (CLI handlers) and `cmd_chat`
-/// so the chat REPL inherits the same retry behavior as the batch and CLI
-/// surfaces — no envelope leaks bare stderr text on a non-finite leaf.
+/// Serialize any envelope value (typed or a pre-built
+/// [`serde_json::Value`]) to a pretty-printed string, alphabetizing keys.
+///
+/// Accepts `&impl Serialize` so callers hand the typed `Envelope` (or a
+/// hand-built map) directly rather than each pre-building a
+/// `serde_json::Value` via `to_value` first. The single `to_value` here
+/// is load-bearing, not redundant: the wire contract is alphabetical key
+/// order (consumers diff envelope shapes), and serde_json has no
+/// single-pass key-sorting serializer without the crate-wide
+/// `preserve_order` feature. Routing through a `Value` (BTreeMap-backed,
+/// so sorted) then `to_string_pretty` is the minimal pass count that
+/// yields sorted output — the canonicalization, not waste.
+///
+/// On the steady-state path this serializes once to a `Value` and once to
+/// a `String`. The sanitize-and-retry arm (NaN / Infinity in a leaf field)
+/// reuses the already-built `Value`, so the failure path adds no extra
+/// serialization over the happy path. Used by [`emit_json`] and the
+/// chat / daemon-to-CLI surfaces so all inherit the same retry behavior —
+/// no envelope leaks bare stderr text on a non-finite leaf.
 ///
 /// Returns the final stringified envelope, or an `Err` only if even the
 /// sanitized tree fails to serialize (in practice impossible: after
 /// [`sanitize_json_floats`] no `Value::Number` can hold a non-finite f64).
-pub fn format_envelope_to_string(value: &serde_json::Value) -> Result<String> {
-    match serde_json::to_string_pretty(value) {
+pub fn format_envelope_to_string<T: Serialize>(value: &T) -> Result<String> {
+    // One serialization into a `Value` to canonicalize key order; the
+    // owned tree is then reused by the sanitize-retry arm without a
+    // re-serialize.
+    let mut buf = serde_json::to_value(value)?;
+    match serde_json::to_string_pretty(&buf) {
         Ok(s) => Ok(s),
         Err(first) => {
             // Preserve the original error so the sanitize-retry path can
@@ -407,9 +424,8 @@ pub fn format_envelope_to_string(value: &serde_json::Value) -> Result<String> {
                 error = %first,
                 "to_string_pretty failed; retrying after float-sanitize"
             );
-            let mut sanitized = value.clone();
-            sanitize_json_floats(&mut sanitized);
-            serde_json::to_string_pretty(&sanitized).map_err(|second| {
+            sanitize_json_floats(&mut buf);
+            serde_json::to_string_pretty(&buf).map_err(|second| {
                 anyhow::anyhow!(
                     "JSON serialization failed; \
                      first error: {first}; sanitize-retry error: {second}"
@@ -442,8 +458,7 @@ pub fn emit_json<T: Serialize>(value: &T) -> Result<()> {
         emit_bare_payload_stdout(value)
     } else {
         let env = Envelope::ok(value);
-        let buf = serde_json::to_value(&env)?;
-        let s = format_envelope_to_string(&buf)?;
+        let s = format_envelope_to_string(&env)?;
         println!("{s}");
         Ok(())
     }
@@ -559,15 +574,13 @@ fn daemon_payload_to_cli_text_with(
         Ok(format!("{}\n", serde_json::to_string_pretty(&v)?))
     } else {
         let env = Envelope::ok(payload);
-        let buf = serde_json::to_value(&env)?;
-        Ok(format!("{}\n", format_envelope_to_string(&buf)?))
+        Ok(format!("{}\n", format_envelope_to_string(&env)?))
     }
 }
 
 pub fn emit_json_error(code: &str, message: &str) -> Result<()> {
     let env = Envelope::<serde_json::Value>::err(code, message);
-    let buf = serde_json::to_value(&env)?;
-    let s = format_envelope_to_string(&buf)?;
+    let s = format_envelope_to_string(&env)?;
     println!("{s}");
     Ok(())
 }

--- a/src/cli/watch/socket.rs
+++ b/src/cli/watch/socket.rs
@@ -10,7 +10,6 @@
 
 #![cfg(unix)]
 
-use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -267,9 +266,11 @@ pub(super) fn handle_socket_client(
         // This eliminates the per-byte JSON-escape inflation that would
         // double large search responses on the wire.
         //
-        // TODO(P2 #62): replace this parse with a `dispatch_value` call once
-        // `batch/mod.rs` exposes it. The bytes-then-parse shape here keeps the
-        // wire compatible while removing the escape pass.
+        // The parse also canonicalizes key order (serde_json `Value` is
+        // BTreeMap-backed without `preserve_order`); the response is then
+        // serialized exactly once into a byte buffer and written with a
+        // single `write_all` (see `write_daemon_ok`), rather than
+        // re-stringified through `Display` / `writeln!` per JSON fragment.
         let trimmed = trim_trailing_newline(&output);
         match serde_json::from_slice::<serde_json::Value>(trimmed) {
             Ok(v) => Ok(v),
@@ -291,17 +292,7 @@ pub(super) fn handle_socket_client(
 
     let (status, delivered) = match result {
         Ok(Ok(output_value)) => {
-            let resp = serde_json::json!({
-                "status": "ok",
-                "output": output_value,
-            });
-            let delivered = match writeln!(stream, "{}", resp) {
-                Ok(()) => true,
-                Err(e) => {
-                    tracing::debug!(error = %e, "Failed to write daemon response");
-                    false
-                }
-            };
+            let delivered = write_daemon_ok(&mut stream, output_value);
             ("ok", delivered)
         }
         Ok(Err(e)) => {
@@ -331,13 +322,58 @@ pub(super) fn handle_socket_client(
         "Daemon query complete"
     );
 }
+/// Serialize a daemon response `Value` as one JSONL frame
+/// (`<json>\n`) into a single buffer and emit it with one `write_all`.
+///
+/// `UnixStream` is unbuffered: writing through `writeln!("{}", value)`
+/// drives `Value`'s `Display` impl, whose `write_fmt` adapter issues a
+/// `write_all` per JSON fragment (every key, string, and delimiter). A
+/// multi-KB search response becomes hundreds of write syscalls — material
+/// against the daemon's single-digit-millisecond budget, and worse on WSL
+/// where syscalls are slow. Serializing into a `Vec<u8>` first collapses
+/// the whole frame to one syscall, and `to_writer` serializes the value
+/// exactly once (no intermediate `String`).
+///
+/// Returns whether the frame reached the client. Serialization of a
+/// `serde_json::Value` cannot fail except on a downstream `io::Write`
+/// error, and the buffer is in-memory, so the only failure mode is the
+/// final socket write.
+fn write_response_frame(
+    stream: &mut impl std::io::Write,
+    value: &serde_json::Value,
+) -> std::io::Result<()> {
+    let mut buf: Vec<u8> = Vec::with_capacity(256);
+    // Infallible for an in-memory `Vec<u8>` sink with a `Value` payload.
+    serde_json::to_writer(&mut buf, value).map_err(std::io::Error::other)?;
+    buf.push(b'\n');
+    stream.write_all(&buf)
+}
+
+/// Write the success envelope `{"status":"ok","output":<value>}` as one
+/// frame. The wrapped `Value` carries the canonicalized dispatch output
+/// (already parsed in `handle_socket_client`), so this is the sole
+/// serialization of the response on the success path. Returns whether the
+/// frame was delivered.
+fn write_daemon_ok(stream: &mut impl std::io::Write, output: serde_json::Value) -> bool {
+    let resp = serde_json::json!({
+        "status": "ok",
+        "output": output,
+    });
+    match write_response_frame(stream, &resp) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::debug!(error = %e, "Failed to write daemon response");
+            false
+        }
+    }
+}
+
 pub(super) fn write_daemon_error(
     stream: &mut std::os::unix::net::UnixStream,
     message: &str,
 ) -> std::io::Result<()> {
-    use std::io::Write;
     let resp = serde_json::json!({ "status": "error", "message": message });
-    writeln!(stream, "{}", resp)
+    write_response_frame(stream, &resp)
 }
 
 /// Trim a trailing `\n` (and optional `\r`) from `buf` and return the
@@ -369,5 +405,86 @@ fn write_daemon_error_tracked(stream: &mut std::os::unix::net::UnixStream, messa
             tracing::debug!(error = %e, "Failed to write daemon error response");
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// `io::Write` sink that records every `write` / `write_all` call so a
+    /// test can assert the response frame reaches the socket in exactly one
+    /// syscall (`UnixStream` is unbuffered — fragmented writes there are
+    /// fragmented syscalls).
+    #[derive(Default)]
+    struct CountingWriter {
+        buf: Vec<u8>,
+        writes: usize,
+    }
+
+    impl Write for CountingWriter {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            self.writes += 1;
+            self.buf.extend_from_slice(data);
+            Ok(data.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    // The response frame is emitted with a single `write_all` of one
+    // pre-serialized buffer. `write_all` on a `Vec`-extending sink that
+    // never short-writes calls `write` exactly once — so one logical write,
+    // one syscall against a real unbuffered `UnixStream`. Pins the
+    // PERF-fix: no per-JSON-fragment Display write storm.
+    #[test]
+    fn response_frame_is_one_write() {
+        let mut w = CountingWriter::default();
+        let resp = serde_json::json!({
+            "status": "ok",
+            "output": {"data": {"a": 1, "b": [2, 3]}},
+        });
+        write_response_frame(&mut w, &resp).expect("frame writes");
+        assert_eq!(
+            w.writes, 1,
+            "response must reach the socket in a single write; got {}",
+            w.writes
+        );
+        assert!(w.buf.ends_with(b"\n"), "frame must end with a newline");
+    }
+
+    // `write_daemon_ok` wraps the dispatch output in
+    // `{"status":"ok","output":<value>}` and serializes once. Pin the exact
+    // wire bytes of a representative envelope so the single-serialization
+    // path stays byte-identical to the prior parse → wrap → serialize shape:
+    // serde_json `Value` is BTreeMap-backed (no `preserve_order`), so keys
+    // emit alphabetically — `output` before `status` on the frame, and
+    // `data` before everything in the slim envelope.
+    #[test]
+    fn daemon_ok_frame_exact_bytes() {
+        let mut w = CountingWriter::default();
+        // The dispatch output value, already parsed/canonicalized by the
+        // handler before it reaches `write_daemon_ok`.
+        let output = serde_json::json!({"data": {"zebra": 1, "alpha": 2}});
+        let delivered = write_daemon_ok(&mut w, output);
+        assert!(delivered, "frame must be delivered");
+        let bytes = String::from_utf8(w.buf).expect("utf-8 frame");
+        assert_eq!(
+            bytes, "{\"output\":{\"data\":{\"alpha\":2,\"zebra\":1}},\"status\":\"ok\"}\n",
+            "exact wire bytes must stay alphabetized + single-line + newline-terminated"
+        );
+    }
+
+    // The error frame shares the single-serialization path and the same
+    // byte contract: `{"message":...,"status":"error"}` alphabetized.
+    #[test]
+    fn daemon_error_frame_exact_bytes() {
+        let mut w = CountingWriter::default();
+        let resp = serde_json::json!({ "status": "error", "message": "boom" });
+        write_response_frame(&mut w, &resp).expect("frame writes");
+        let bytes = String::from_utf8(w.buf).expect("utf-8 frame");
+        assert_eq!(bytes, "{\"message\":\"boom\",\"status\":\"error\"}\n");
     }
 }


### PR DESCRIPTION
Closes the carried-forward daemon serialization cluster (CF RM-V1.40-9 + PERF-V1.40-5 + RM-V1.40-10) and PERF-V1.42-11. Socket success/error frames now serialize once into a Vec and hit the unbuffered UnixStream with ONE write_all (previously Value Display drove one syscall per JSON fragment — hundreds per response against the 3-19ms budget). format_envelope_to_string takes &impl Serialize; call sites stop pre-building Values; the retry arm reuses the internal Value. Honest scope note: the remaining to_value inside the envelope path is the alphabetical-key canonicalization the wire contract depends on (BTreeMap Value, no preserve_order) — removing it would change wire bytes, so it is kept and documented as canonicalization, not waste. Exact-byte frame pins + counting-writer single-write pin; socket/adversarial/envelope/daemon_forward suites green (94 tests); v1-format output byte-identical to pre-refactor capture. fmt + clippy --all-targets clean. Triage flips ride this branch.