### PR TITLE
fix: CAGRA orphan-tmp sweep on load; task computes test reachability once; BFS interns Arc<str> keys

### DIFF
--- a/docs/audit-triage.md
+++ b/docs/audit-triage.md
@@ -125,9 +125,9 @@ New v1.42 findings: 107 (batch 1: 59 = 15/11/26/7; batch 2: 48 = 13/19/14/2). Ca
 | CQ-V1.42-16 | Crate root accretes utilities that have dedicated homes (serde/path/fs helpers in lib.rs) | src/lib.rs:410-645 | open |
 | SEC-V1.42-3 | Cleartext-http API-key guard split across two layers with contradictory localhost policy — local.rs re-check unreachable; under ALLOW_INSECURE=1 silently drops opted-into header | src/llm/mod.rs:357-372, local.rs:146-171 | ✅ PR #1765 |
 | PB-V1.42-2 | linux_fs_resolution magic table omits V9FS_MAGIC (0x01021997) — manually mounted DrvFS gets fine-grained mtime treatment, re-opening dropped-second-save bug | src/config.rs:270-289 | ✅ PR #1764 |
-| RM-V1.42-1 | CAGRA interrupted-save tmp orphans never swept on load — HNSW/SPLADE both sweep theirs; multi-hundred-MB accumulation under crash-looping daemon | src/cagra.rs:1186, :1426, :1556 | open |
-| PERF-V1.42-7 | `cqs task` computes the full test-reachability BFS twice with identical inputs | src/task.rs:144, :194 | open |
-| PERF-V1.42-8 | test_reachability allocates 2-3 Strings per BFS visit — siblings in same file use Arc<str> interning (runs on every scout/task/health/review) | src/impact/bfs.rs:354-386 | open |
+| RM-V1.42-1 | CAGRA interrupted-save tmp orphans never swept on load — HNSW/SPLADE both sweep theirs; multi-hundred-MB accumulation under crash-looping daemon | src/cagra.rs:1186, :1426, :1556 | ✅ PR #1767 |
+| PERF-V1.42-7 | `cqs task` computes the full test-reachability BFS twice with identical inputs | src/task.rs:144, :194 | ✅ PR #1767 |
+| PERF-V1.42-8 | test_reachability allocates 2-3 Strings per BFS visit — siblings in same file use Arc<str> interning (runs on every scout/task/health/review) | src/impact/bfs.rs:354-386 | ✅ PR #1767 |
 | PERF-V1.42-10 | build_chunk_detail tests-that-cover query is an unindexed full-table content LIKE scan per dashboard click — use chunks_fts | src/serve/data.rs:619-629 | open |
 | PERF-V1.42-11 | Daemon success response written unbuffered — one write() syscall per JSON fragment (fold into CF dispatch_value refactor, RM-V1.40-9 cluster) | src/cli/watch/socket.rs:298 | open |
 | TC-HAP-V1.42-5 | Gather direction filtering (Callers/Callees) tested only by is_ok() — deliberate fixture wasted | tests/gather_test.rs:185, :231 | open |

--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -1180,6 +1180,14 @@ impl CagraIndex {
             ));
         }
 
+        // Sweep orphan tmp files from interrupted saves before loading. A hard
+        // kill during the cuVS serialize step leaves a `.<blob>.<hex>.tmp` (or
+        // sidecar `.<blob>.meta.<hex>.tmp`) behind; the random suffix means no
+        // later save ever overwrites it, so they accumulate. Both `.<blob>.`-
+        // prefixed `.tmp` names are caught here. Mirrors the HNSW load sweep
+        // (hnsw/persist.rs) and SPLADE loader sweep (splade/index.rs).
+        cleanup_orphan_temp_files(path);
+
         if !path.exists() {
             return Err(CagraError::Io(format!(
                 "CAGRA blob not found at {}",
@@ -1353,6 +1361,66 @@ fn meta_path_for(path: &Path) -> std::path::PathBuf {
     let mut s = path.as_os_str().to_os_string();
     s.push(".meta");
     std::path::PathBuf::from(s)
+}
+
+/// Remove orphan tmp files left by interrupted CAGRA saves.
+///
+/// Both the blob (`save_blob_atomic_with_rollback`) and the meta sidecar
+/// (`write_meta_atomic`) stage to `.<blob_file_name>.<hex16>.tmp` (the sidecar
+/// adds a `.meta` segment, so it shares the `.<blob_file_name>.` prefix) before
+/// atomic-replacing the live path. A hard kill (SIGKILL on daemon-stop timeout,
+/// OOM-kill, power loss) during the cuVS serialize — the longest save window —
+/// leaves the tmp behind, and the random suffix means no later save overwrites
+/// it. Sweeping on load matches the HNSW (`hnsw/persist.rs`) and SPLADE
+/// (`splade/index.rs`) loaders. Best-effort: a leftover tmp is wasteful, not
+/// fatal, so errors are logged and not propagated.
+///
+/// GPU-free (pure filesystem) so the sweep test runs without touching cuVS,
+/// though the whole `cagra` module is `cuda-index`-gated.
+#[cfg(feature = "cuda-index")]
+fn cleanup_orphan_temp_files(path: &std::path::Path) {
+    let parent = match path.parent() {
+        Some(p) => p,
+        None => return,
+    };
+    let blob_name = match path.file_name().and_then(|s| s.to_str()) {
+        Some(n) => n,
+        None => return,
+    };
+    // Live blob is `<blob_name>` and live meta is `<blob_name>.meta`; neither
+    // has a leading dot, and `.bak` rollbacks end in `.bak`, so this prefix +
+    // suffix only ever matches staged tmp files.
+    let prefix = format!(".{}.", blob_name);
+    let entries = match std::fs::read_dir(parent) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                parent = %parent.display(),
+                "read_dir for CAGRA orphan cleanup failed, skipping"
+            );
+            return;
+        }
+    };
+    for entry in entries.flatten() {
+        let name = match entry.file_name().into_string() {
+            Ok(n) => n,
+            Err(_) => continue, // non-utf8 filename, leave it alone
+        };
+        if name.starts_with(&prefix) && name.ends_with(".tmp") {
+            match std::fs::remove_file(entry.path()) {
+                Ok(_) => tracing::info!(
+                    orphan = %name,
+                    "Cleaning up interrupted CAGRA save"
+                ),
+                Err(e) => tracing::debug!(
+                    error = %e,
+                    orphan = %name,
+                    "Failed to remove orphan CAGRA temp file"
+                ),
+            }
+        }
+    }
 }
 
 /// Stream-hash a file with blake3.
@@ -2501,5 +2569,55 @@ mod tests {
 
         let neg_inf = Embedding::new(vec![0.1, 0.2, 0.3, f32::NEG_INFINITY]);
         assert!(!super::query_is_finite(&neg_inf), "-Inf query rejected");
+    }
+}
+
+/// CPU-side tests for the orphan-tmp sweep. The sweep is GPU-free (pure
+/// filesystem), so these run without the `cuda-index` feature.
+#[cfg(test)]
+mod orphan_sweep_tests {
+    use std::fs;
+
+    #[test]
+    fn sweep_removes_blob_and_meta_orphans_keeps_live_and_unrelated() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let blob = dir.path().join("cagra.index.bin");
+        let meta = dir.path().join("cagra.index.bin.meta");
+
+        // Live artifacts an interrupted-on-next-save state would have.
+        fs::write(&blob, b"live blob").unwrap();
+        fs::write(&meta, b"live meta").unwrap();
+
+        // Orphan tmp files: blob-staged and sidecar-staged, with the random
+        // hex suffix the real save paths use.
+        let blob_orphan = dir.path().join(".cagra.index.bin.0123456789abcdef.tmp");
+        let meta_orphan = dir
+            .path()
+            .join(".cagra.index.bin.meta.fedcba9876543210.tmp");
+        fs::write(&blob_orphan, b"orphan blob").unwrap();
+        fs::write(&meta_orphan, b"orphan meta").unwrap();
+
+        // A `.bak` rollback breadcrumb and an unrelated file must survive.
+        let bak = dir.path().join("cagra.index.bin.bak");
+        let unrelated = dir.path().join("other.index.bin.0000000000000000.tmp");
+        fs::write(&bak, b"bak").unwrap();
+        fs::write(&unrelated, b"unrelated").unwrap();
+
+        super::cleanup_orphan_temp_files(&blob);
+
+        assert!(!blob_orphan.exists(), "blob orphan tmp swept");
+        assert!(!meta_orphan.exists(), "meta orphan tmp swept");
+        assert!(blob.exists(), "live blob preserved");
+        assert!(meta.exists(), "live meta preserved");
+        assert!(bak.exists(), "`.bak` rollback preserved");
+        assert!(unrelated.exists(), "unrelated tmp preserved");
+    }
+
+    #[test]
+    fn sweep_is_noop_when_parent_missing() {
+        // Non-existent path with a parent that does not exist: best-effort,
+        // no panic.
+        let path = std::path::Path::new("/nonexistent-cqs-dir-xyz/cagra.index.bin");
+        super::cleanup_orphan_temp_files(path);
     }
 }

--- a/src/impact/bfs.rs
+++ b/src/impact/bfs.rs
@@ -318,9 +318,14 @@ pub(crate) fn test_reachability(
     graph: &CallGraph,
     test_names: &[&str],
     max_depth: usize,
-) -> HashMap<String, usize> {
+) -> HashMap<Arc<str>, usize> {
     let _span = tracing::info_span!("test_reachability", tests = test_names.len()).entered();
-    let mut counts: HashMap<String, usize> = HashMap::new();
+    // Keys are `Arc<str>` so each visit/merge is an `Arc::clone` (RC bump)
+    // rather than a `callee.to_string()` heap allocation — the same interning
+    // rationale as `reverse_bfs`/`forward_bfs_multi`. The graph's node names are
+    // already interned `Arc<str>`, so we clone those keys via `get_key_value`.
+    // Callers index by `&str` because `Arc<str>: Borrow<str>`.
+    let mut counts: HashMap<Arc<str>, usize> = HashMap::new();
 
     // Step 1: Group tests by their first-hop callee set.
     // Tests with the same direct callees will traverse the same subgraph
@@ -336,8 +341,8 @@ pub(crate) fn test_reachability(
     }
 
     // Step 2: BFS once per unique callee set, multiply counts by class size.
-    let mut visited: HashMap<String, usize> = HashMap::new();
-    let mut queue: VecDeque<(String, usize)> = VecDeque::new();
+    let mut visited: HashMap<Arc<str>, usize> = HashMap::new();
+    let mut queue: VecDeque<(Arc<str>, usize)> = VecDeque::new();
 
     for (callee_set, class_size) in &equivalence_classes {
         if callee_set.is_empty() {
@@ -350,10 +355,13 @@ pub(crate) fn test_reachability(
         queue.clear();
 
         // Seed BFS from the shared callees at depth 1 (the test node itself
-        // is excluded from counts, so we start at depth 1 directly)
+        // is excluded from counts, so we start at depth 1 directly). Reuse the
+        // interned key from `graph.forward` when the callee is a key there
+        // (i.e. has outgoing edges); a leaf callee falls back to `Arc::from`.
         for &callee in callee_set {
-            visited.insert(callee.to_string(), 1);
-            queue.push_back((callee.to_string(), 1));
+            let arc = intern_node(graph, callee);
+            visited.insert(Arc::clone(&arc), 1);
+            queue.push_back((arc, 1));
         }
 
         while let Some((current, d)) = queue.pop_front() {
@@ -367,14 +375,14 @@ pub(crate) fn test_reachability(
                 );
                 break;
             }
-            if let Some(callees) = graph.forward.get(current.as_str()) {
+            if let Some(callees) = graph.forward.get(current.as_ref()) {
                 for callee in callees {
                     if visited.len() >= bfs_max_nodes() {
                         break;
                     }
                     if !visited.contains_key(callee.as_ref()) {
-                        visited.insert(callee.to_string(), d + 1);
-                        queue.push_back((callee.to_string(), d + 1));
+                        visited.insert(Arc::clone(callee), d + 1);
+                        queue.push_back((Arc::clone(callee), d + 1));
                     }
                 }
             }
@@ -382,11 +390,21 @@ pub(crate) fn test_reachability(
 
         // Every function visited is reachable from all tests in this class
         for name in visited.keys() {
-            *counts.entry(name.clone()).or_default() += class_size;
+            *counts.entry(Arc::clone(name)).or_default() += class_size;
         }
     }
 
     counts
+}
+
+/// Return the interned `Arc<str>` for `name` from the graph's forward map when
+/// present (nodes with outgoing edges), else allocate a fresh `Arc`. Lets the
+/// BFS reuse the graph's existing interning for the common case.
+fn intern_node(graph: &CallGraph, name: &str) -> Arc<str> {
+    match graph.forward.get_key_value(name) {
+        Some((k, _)) => Arc::clone(k),
+        None => Arc::from(name),
+    }
 }
 
 #[cfg(test)]

--- a/src/impact/hints.rs
+++ b/src/impact/hints.rs
@@ -6,6 +6,7 @@ use crate::limits::{
 };
 use crate::store::{CallGraph, StoreError};
 use crate::Store;
+use std::sync::Arc;
 
 use super::bfs::{reverse_bfs, reverse_bfs_multi_attributed, test_reachability};
 use super::types::{FunctionHints, RiskLevel, RiskScore};
@@ -90,18 +91,56 @@ pub fn compute_hints<Mode>(
     ))
 }
 
+/// Borrow a precomputed test-reachability map when the caller supplied one,
+/// otherwise compute it once into `owned_slot` and borrow that. Lets `cqs task`
+/// share a single forward-BFS result across the scout and risk phases instead
+/// of recomputing it per phase, while standalone callers (`scout`, `health`,
+/// `review`, `suggest`) keep passing `None` and compute on demand.
+fn resolve_reachability<'a>(
+    graph: &CallGraph,
+    test_chunks: &[crate::store::ChunkSummary],
+    precomputed: Option<&'a std::collections::HashMap<Arc<str>, usize>>,
+    owned_slot: &'a mut Option<std::collections::HashMap<Arc<str>, usize>>,
+) -> &'a std::collections::HashMap<Arc<str>, usize> {
+    match precomputed {
+        Some(map) => map,
+        None => {
+            let test_names: Vec<&str> = test_chunks.iter().map(|t| t.name.as_str()).collect();
+            owned_slot.insert(test_reachability(
+                graph,
+                &test_names,
+                DEFAULT_MAX_TEST_SEARCH_DEPTH,
+            ))
+        }
+    }
+}
+
 /// Batch compute hints for multiple functions using forward BFS.
 /// A single `test_reachability` call covers all functions, instead of N
 /// independent `reverse_bfs` calls.
+///
+/// `precomputed_reachability`: when `Some`, the forward-BFS test-reachability
+/// map is reused instead of recomputed (the `cqs task` pipeline shares one
+/// across phases); `None` computes it internally.
 pub fn compute_hints_batch(
     graph: &CallGraph,
     test_chunks: &[crate::store::ChunkSummary],
     names: &[&str],
     caller_counts: &std::collections::HashMap<String, u64>,
+    precomputed_reachability: Option<&std::collections::HashMap<Arc<str>, usize>>,
 ) -> Vec<FunctionHints> {
     let _span = tracing::info_span!("compute_hints_batch", count = names.len()).entered();
-    let test_names: Vec<&str> = test_chunks.iter().map(|t| t.name.as_str()).collect();
-    let reachability = test_reachability(graph, &test_names, DEFAULT_MAX_TEST_SEARCH_DEPTH);
+    // Reuse a caller-supplied reachability map when present (e.g. `cqs task`
+    // computes it once and shares it across scout + risk phases) instead of
+    // re-running the forward BFS over every test node. When absent, compute it
+    // here once and borrow the owned copy.
+    let mut owned_slot = None;
+    let reachability = resolve_reachability(
+        graph,
+        test_chunks,
+        precomputed_reachability,
+        &mut owned_slot,
+    );
 
     names
         .iter()
@@ -208,13 +247,21 @@ pub fn compute_risk_and_tests(
     targets: &[&str],
     graph: &CallGraph,
     test_chunks: &[crate::store::ChunkSummary],
+    precomputed_reachability: Option<&std::collections::HashMap<Arc<str>, usize>>,
 ) -> (Vec<RiskScore>, Vec<super::TestInfo>) {
     let _span = tracing::info_span!("compute_risk_and_tests", targets = targets.len()).entered();
 
     // Use test_reachability (forward BFS) for risk scoring — same algorithm
     // as compute_risk_batch — to prevent divergent test counts between commands.
-    let test_names: Vec<&str> = test_chunks.iter().map(|t| t.name.as_str()).collect();
-    let reachability = test_reachability(graph, &test_names, DEFAULT_MAX_TEST_SEARCH_DEPTH);
+    // Reuse a caller-supplied map (shared with the scout phase by `cqs task`)
+    // when present, else compute it once here.
+    let mut owned_slot = None;
+    let reachability = resolve_reachability(
+        graph,
+        test_chunks,
+        precomputed_reachability,
+        &mut owned_slot,
+    );
 
     // A single reverse_bfs_multi_attributed call covers all targets. The
     // attributed variant tracks which target (by index) first reached each
@@ -770,7 +817,7 @@ mod tests {
         let mut caller_counts = HashMap::new();
         caller_counts.insert("target".to_string(), 7u64);
 
-        let hints = compute_hints_batch(&graph, &test_chunks, &["target"], &caller_counts);
+        let hints = compute_hints_batch(&graph, &test_chunks, &["target"], &caller_counts, None);
         assert_eq!(hints.len(), 1);
         assert_eq!(
             hints[0].caller_count, 7,
@@ -792,7 +839,7 @@ mod tests {
         let test_chunks: Vec<crate::store::ChunkSummary> = Vec::new();
         let caller_counts: std::collections::HashMap<String, u64> = HashMap::new();
 
-        let hints = compute_hints_batch(&graph, &test_chunks, &["target"], &caller_counts);
+        let hints = compute_hints_batch(&graph, &test_chunks, &["target"], &caller_counts, None);
         assert_eq!(
             hints[0].caller_count, 2,
             "fallback should count the two reverse edges"
@@ -816,6 +863,7 @@ mod tests {
             &test_chunks,
             &["target", "unrelated"],
             &caller_counts,
+            None,
         );
         assert_eq!(hints.len(), 2);
         assert_eq!(
@@ -837,8 +885,37 @@ mod tests {
         let graph = CallGraph::from_string_maps(HashMap::new(), HashMap::new());
         let test_chunks: Vec<crate::store::ChunkSummary> = Vec::new();
         let caller_counts: std::collections::HashMap<String, u64> = HashMap::new();
-        let hints = compute_hints_batch(&graph, &test_chunks, &[], &caller_counts);
+        let hints = compute_hints_batch(&graph, &test_chunks, &[], &caller_counts, None);
         assert!(hints.is_empty(), "empty name list yields empty hints");
+    }
+
+    #[test]
+    fn test_compute_hints_batch_uses_precomputed_reachability() {
+        // When a precomputed reachability map is supplied, the batch reads
+        // test counts from it rather than recomputing from `test_chunks`.
+        // The graph here has no forward edges and the test_chunks are empty,
+        // so an internally-computed map would report 0 — the supplied map's
+        // count of 3 proves the precomputed path is exercised.
+        let graph = CallGraph::from_string_maps(HashMap::new(), HashMap::new());
+        let test_chunks: Vec<crate::store::ChunkSummary> = Vec::new();
+        let caller_counts: std::collections::HashMap<String, u64> = HashMap::new();
+
+        let mut precomputed: std::collections::HashMap<Arc<str>, usize> =
+            std::collections::HashMap::new();
+        precomputed.insert(Arc::from("target"), 3);
+
+        let hints = compute_hints_batch(
+            &graph,
+            &test_chunks,
+            &["target"],
+            &caller_counts,
+            Some(&precomputed),
+        );
+        assert_eq!(hints.len(), 1);
+        assert_eq!(
+            hints[0].test_count, 3,
+            "supplied reachability map should be used verbatim, not recomputed"
+        );
     }
 
     #[test]

--- a/src/impact/mod.rs
+++ b/src/impact/mod.rs
@@ -22,6 +22,7 @@ pub use types::{
 // Re-export public functions
 pub(crate) use analysis::find_affected_tests_with_chunks;
 pub use analysis::{analyze_impact, suggest_tests, ImpactOptions};
+pub(crate) use bfs::test_reachability;
 pub use diff::{analyze_diff_impact, analyze_diff_impact_with_graph, map_hunks_to_functions};
 pub use format::{
     diff_impact_empty_json, diff_impact_to_json, format_test_suggestions, impact_to_json,

--- a/src/scout.rs
+++ b/src/scout.rs
@@ -159,6 +159,7 @@ pub fn scout_with_options<Mode>(
         opts,
         graph: &graph,
         test_chunks: &test_chunks,
+        reachability: None,
     })
 }
 
@@ -172,6 +173,10 @@ pub(crate) struct ScoutResources<'a, Mode> {
     pub opts: &'a ScoutOptions,
     pub graph: &'a crate::store::CallGraph,
     pub test_chunks: &'a [ChunkSummary],
+    /// Precomputed test-reachability map, shared by callers that already ran
+    /// the forward BFS (e.g. `cqs task`). `None` means `scout_core` computes it
+    /// on demand inside `compute_hints_batch`.
+    pub reachability: Option<&'a std::collections::HashMap<std::sync::Arc<str>, usize>>,
 }
 
 /// Core scout implementation accepting pre-loaded resources.
@@ -189,6 +194,7 @@ pub(crate) fn scout_core<Mode>(
     let opts = res.opts;
     let graph = res.graph;
     let test_chunks = res.test_chunks;
+    let reachability = res.reachability;
     let _span = tracing::info_span!("scout_core", %task, limit).entered();
 
     // 1. Search
@@ -263,8 +269,13 @@ pub(crate) fn scout_core<Mode>(
 
     // 7. Batch-compute hints for all result chunks (single forward BFS)
     let all_chunk_names: Vec<&str> = results.iter().map(|r| r.chunk.name.as_str()).collect();
-    let hints_batch =
-        crate::impact::compute_hints_batch(graph, test_chunks, &all_chunk_names, &caller_counts);
+    let hints_batch = crate::impact::compute_hints_batch(
+        graph,
+        test_chunks,
+        &all_chunk_names,
+        &caller_counts,
+        reachability,
+    );
     let hints_map: std::collections::HashMap<&str, &crate::impact::FunctionHints> = all_chunk_names
         .iter()
         .zip(hints_batch.iter())
@@ -719,6 +730,7 @@ mod tests {
             opts: &opts,
             graph: &graph,
             test_chunks: &test_chunks,
+            reachability: None,
         })
         .unwrap();
 
@@ -796,6 +808,7 @@ mod tests {
             opts: &opts,
             graph: &graph,
             test_chunks: &test_chunks,
+            reachability: None,
         })
         .unwrap();
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -175,6 +175,18 @@ pub(crate) fn task_core<Mode>(
     let _span =
         tracing::info_span!("task_core", description_len = description.len(), limit).entered();
 
+    // Compute test-reachability once and share it across the scout and impact
+    // phases. Both `compute_hints_batch` (via scout) and `compute_risk_and_tests`
+    // need the same forward-BFS map over byte-identical inputs (same graph, same
+    // test chunks, same depth), so computing it twice doubles the largest cost
+    // in the command.
+    let test_names: Vec<&str> = test_chunks.iter().map(|t| t.name.as_str()).collect();
+    let reachability = crate::impact::test_reachability(
+        graph,
+        &test_names,
+        crate::impact::DEFAULT_MAX_TEST_SEARCH_DEPTH,
+    );
+
     // 2. Scout phase
     let scout = scout_core(&ScoutResources {
         store,
@@ -185,6 +197,7 @@ pub(crate) fn task_core<Mode>(
         opts: &ScoutOptions::default(),
         graph,
         test_chunks,
+        reachability: Some(&reachability),
     })?;
     tracing::debug!(
         file_groups = scout.file_groups.len(),
@@ -226,7 +239,8 @@ pub(crate) fn task_core<Mode>(
         (Vec::new(), Vec::new())
     } else {
         let target_refs: Vec<&str> = targets.iter().map(|s| s.as_str()).collect();
-        let (scores, raw_tests) = compute_risk_and_tests(&target_refs, graph, test_chunks);
+        let (scores, raw_tests) =
+            compute_risk_and_tests(&target_refs, graph, test_chunks, Some(&reachability));
         let risk = target_refs
             .iter()
             .zip(scores)

--- a/tests/task_test.rs
+++ b/tests/task_test.rs
@@ -254,8 +254,12 @@ fn test_compute_risk_and_tests_integration() {
         vendored: false,
     }];
 
-    let (scores, tests) =
-        compute_risk_and_tests(&["search_filtered", "validate_query"], &graph, &test_chunks);
+    let (scores, tests) = compute_risk_and_tests(
+        &["search_filtered", "validate_query"],
+        &graph,
+        &test_chunks,
+        None,
+    );
 
     assert_eq!(scores.len(), 2);
     // search_filtered: 2 callers, test_search reachable → has test coverage


### PR DESCRIPTION
Third-pass wave 1: RM-V1.42-1 (CAGRA now sweeps interrupted-save .tmp orphans on load like its HNSW/SPLADE siblings — one pattern catches blob + meta tmps, .baks and live files untouched; pure-filesystem seam tested CPU-only), PERF-V1.42-7 (task_core computes test_reachability once and threads it through scout_core/compute_hints_batch and compute_risk_and_tests via an Option<&map> precomputed param; standalone callers unchanged), PERF-V1.42-8 (test_reachability interns Arc<str> keys matching its sibling BFS fns — millions of per-visit String allocs gone from every scout/task/health/review). Targeted suites green: impact 88, scout 20, task 8, orphan sweep 2. fmt + clippy --all-targets clean. Triage flips ride this branch.