### PR TITLE
perf(daemon): cache cross-project context across requests — cell pattern with config-fingerprint invalidation

### DIFF
--- a/src/cli/batch/context.rs
+++ b/src/cli/batch/context.rs
@@ -32,21 +32,39 @@ pub(super) struct DataVersionProbe {
     last: i64,
 }
 
+// ─── Cross-project cache entry ───────────────────────────────────────────────
+
+/// A cached cross-project context plus the references-config fingerprint it
+/// was built from. The fingerprint lets a reader detect a config edit
+/// (references added/removed/repointed/reweighted) and rebuild even though the
+/// underlying `index.db` files never changed.
+///
+/// The context is wrapped in `Arc<Mutex<...>>` so a [`BatchView`] can hand the
+/// `&mut CrossProjectContext` the cross cores require to a dispatch handler
+/// without holding any BatchContext lock — and so the lazily-populated
+/// per-store graph cache inside the context survives across requests.
+pub(super) struct CachedCrossProject {
+    pub(super) ctx: Arc<Mutex<cqs::cross_project::CrossProjectContext>>,
+    pub(super) fingerprint: u64,
+}
+
 // ─── BatchContext ────────────────────────────────────────────────────────────
 
 /// One bit per mutable-cache slot, used by the deferred-invalidation mask
 /// (`BatchContext::pending_invalidation`) so a retry clears only the slots
-/// that were actually deferred.
+/// that were actually deferred. `u16` rather than `u8`: the cross-project
+/// cell pushed the slot count past 8.
 mod slot {
-    pub(super) const HNSW: u8 = 1 << 0;
-    pub(super) const BASE_HNSW: u8 = 1 << 1;
-    pub(super) const CALL_GRAPH: u8 = 1 << 2;
-    pub(super) const TEST_CHUNKS: u8 = 1 << 3;
-    pub(super) const FILE_SET: u8 = 1 << 4;
-    pub(super) const NOTES: u8 = 1 << 5;
-    pub(super) const SPLADE: u8 = 1 << 6;
-    pub(super) const REFS: u8 = 1 << 7;
-    pub(super) const ALL: u8 = u8::MAX;
+    pub(super) const HNSW: u16 = 1 << 0;
+    pub(super) const BASE_HNSW: u16 = 1 << 1;
+    pub(super) const CALL_GRAPH: u16 = 1 << 2;
+    pub(super) const TEST_CHUNKS: u16 = 1 << 3;
+    pub(super) const FILE_SET: u16 = 1 << 4;
+    pub(super) const NOTES: u16 = 1 << 5;
+    pub(super) const SPLADE: u16 = 1 << 6;
+    pub(super) const REFS: u16 = 1 << 7;
+    pub(super) const CROSS_PROJECT: u16 = 1 << 8;
+    pub(super) const ALL: u16 = u16::MAX;
 }
 
 /// Shared resources for a batch session.
@@ -162,7 +180,7 @@ pub(crate) struct BatchContext {
     /// discard every in-flight fresh publish and wipe freshly rebuilt slots
     /// on every dispatch while one slot stays contended. Cleared (to 0) only
     /// when every deferred slot actually cleared.
-    pub(super) pending_invalidation: Cell<u8>,
+    pub(super) pending_invalidation: Cell<u16>,
     // LRU caps at 2 — each ReferenceIndex holds Store + HNSW (50-200MB).
     // Values are `Arc` so `get_all_refs` can fan out refs to parallel
     // `--include-refs` searches without cloning the index bytes.
@@ -179,6 +197,38 @@ pub(crate) struct BatchContext {
     /// the inner `Arc<SpladeIndex>`; existing readers that already cloned the
     /// previous Arc keep their snapshot until the next dispatch.
     pub(super) splade_index: Arc<Mutex<Option<Arc<cqs::splade::index::SpladeIndex>>>>,
+    /// Cached cross-project context (opened reference stores + per-store call
+    /// graphs), shared with every `BatchView` so the daemon's
+    /// `--cross-project` graph dispatchers (callers/callees/impact/test-map/
+    /// trace) stop rebuilding it per request. Without this, each cross-project
+    /// query reopened N reference stores (~64 MB mmap × N) and re-merged every
+    /// project's call graph.
+    ///
+    /// The inner `Arc<Mutex<CrossProjectContext>>` gives the dispatch handlers
+    /// the `&mut` they need (the cross cores lazily populate the per-store
+    /// graph cache), while the outer cell follows the same write-back shape as
+    /// the other mutable caches.
+    ///
+    /// # Staleness contract
+    ///
+    /// Three independent triggers force a rebuild:
+    ///
+    /// 1. **Local reindex** — the merged graph includes the local project's
+    ///    edges, so a primary-`index.db` change must drop it. The
+    ///    `CROSS_PROJECT` slot is in [`slot::ALL`], so `invalidate_mutable_caches`
+    ///    (fired by the identity / data_version staleness check) clears it
+    ///    alongside the other caches.
+    /// 2. **Reference store update** (`cqs ref update <name>`) — rewrites a
+    ///    reference's `index.db` without touching the primary file. The cached
+    ///    context captures each store's `(mtime, size)` at open; the view
+    ///    accessor calls `CrossProjectContext::is_stale()` before serving and
+    ///    rebuilds on a mismatch.
+    /// 3. **References config edit** (`.cqs.toml` / `slot.toml`) — the cell is
+    ///    keyed by a fingerprint of the `references` config; a fingerprint
+    ///    mismatch (config reload picks up the edit after
+    ///    `CONFIG_RELOAD_INTERVAL`) rebuilds. The fingerprint rides alongside
+    ///    the context so a stale cell whose config moved is never served.
+    pub(super) cross_project: Arc<Mutex<Option<CachedCrossProject>>>,
     pub root: PathBuf,
     pub cqs_dir: PathBuf,
     pub model_config: cqs::embedder::ModelConfig,
@@ -295,6 +345,7 @@ impl BatchContext {
             pending_invalidation: Cell::new(0),
             splade_encoder: Arc::new(OnceLock::new()),
             splade_index: Arc::new(Mutex::new(None)),
+            cross_project: Arc::new(Mutex::new(None)),
             refs: Arc::new(Mutex::new(lru::LruCache::new(refs_lru_size()))),
             root,
             cqs_dir,
@@ -666,8 +717,8 @@ impl BatchContext {
     /// crash the whole batch session for what is just a deferral case.
     /// Busy slots stay populated and are recorded in the sticky
     /// `pending_invalidation` mask for the next retry.
-    fn clear_cache_slots(&self, mask: u8) -> bool {
-        let mut deferred: u8 = 0;
+    fn clear_cache_slots(&self, mask: u16) -> bool {
+        let mut deferred: u16 = 0;
         macro_rules! try_clear_refcell {
             ($field:expr, $bit:expr, $name:literal) => {
                 if mask & $bit != 0 {
@@ -703,6 +754,10 @@ impl BatchContext {
         try_clear_cell!(self.file_set, slot::FILE_SET, "file_set");
         try_clear_cell!(self.notes_cache, slot::NOTES, "notes_cache");
         try_clear_cell!(self.splade_index, slot::SPLADE, "splade_index");
+        // The cross-project cell holds `Option<CachedCrossProject>` (not the
+        // `Option<Arc<T>>` shape the macro's siblings carry), but the clear is
+        // identical: drop the cached context so the next view rebuilds it.
+        try_clear_cell!(self.cross_project, slot::CROSS_PROJECT, "cross_project");
         // refs LRU is `Arc<Mutex<...>>` (shared with BatchView). If a
         // handler thread holds the mutex (e.g. iterating refs in a parallel
         // search), the eviction is deferred to the next retry.
@@ -1426,6 +1481,7 @@ impl BatchContext {
             file_set_cell: Arc::clone(&self.file_set),
             notes_cell: Arc::clone(&self.notes_cache),
             splade_index_cell: Arc::clone(&self.splade_index),
+            cross_project_cell: Arc::clone(&self.cross_project),
             invalidation_epoch: Arc::clone(&self.invalidation_epoch),
             checkout_epoch,
             embedder_slot: Arc::clone(&self.embedder),

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -98,7 +98,8 @@ pub(in crate::cli::batch) fn dispatch_callers(
     )
     .entered();
     if cross_project {
-        let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
+        let cross_ctx = ctx.cross_project()?;
+        let mut cross_ctx = cross_ctx.lock().unwrap_or_else(|p| p.into_inner());
         let output = callers_cross_core(
             &mut cross_ctx,
             &CallersCoreArgs {
@@ -143,7 +144,8 @@ pub(in crate::cli::batch) fn dispatch_callees(
     )
     .entered();
     if cross_project {
-        let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
+        let cross_ctx = ctx.cross_project()?;
+        let mut cross_ctx = cross_ctx.lock().unwrap_or_else(|p| p.into_inner());
         let output = callees_cross_core(
             &mut cross_ctx,
             &CoreCalleesArgs {
@@ -195,7 +197,8 @@ pub(in crate::cli::batch) fn dispatch_impact(
     )
     .entered();
     if cross_project {
-        let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
+        let cross_ctx = ctx.cross_project()?;
+        let mut cross_ctx = cross_ctx.lock().unwrap_or_else(|p| p.into_inner());
         let result = crate::cli::commands::impact_cross_core(
             &mut cross_ctx,
             &ImpactCoreArgs {
@@ -254,7 +257,8 @@ pub(in crate::cli::batch) fn dispatch_test_map(
     )
     .entered();
     if cross_project {
-        let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
+        let cross_ctx = ctx.cross_project()?;
+        let mut cross_ctx = cross_ctx.lock().unwrap_or_else(|p| p.into_inner());
         let matches = crate::cli::commands::test_map_cross_core(
             &mut cross_ctx,
             &ctx.root,
@@ -315,7 +319,8 @@ pub(in crate::cli::batch) fn dispatch_trace(
     // future k-shortest-paths variants). args.limit_arg.limit intentionally unused.
 
     if cross_project {
-        let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
+        let cross_ctx = ctx.cross_project()?;
+        let mut cross_ctx = cross_ctx.lock().unwrap_or_else(|p| p.into_inner());
         let trace_result =
             crate::cli::commands::trace_cross_core(&mut cross_ctx, source, target, max_depth)?;
         return Ok(serde_json::to_value(&trace_result)?);

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -511,12 +511,23 @@ mod tests {
             cqs::store::CallGraph::from_string_maps(Default::default(), Default::default()),
         ));
         *ctx.test_chunks.borrow_mut() = Some(std::sync::Arc::new(vec![]));
+        // Build a real cross-project context (no references → one local store)
+        // and seat it in the cell so the post-invalidate clear is meaningful.
+        {
+            let cross = cqs::cross_project::CrossProjectContext::from_config(&ctx.root).unwrap();
+            let fingerprint = cross.fingerprint().unwrap_or(0);
+            *ctx.cross_project.lock().unwrap() = Some(context::CachedCrossProject {
+                ctx: std::sync::Arc::new(Mutex::new(cross)),
+                fingerprint,
+            });
+        }
 
         // Verify caches are populated
         assert!(ctx.file_set.lock().unwrap().is_some());
         assert!(ctx.notes_cache.lock().unwrap().is_some());
         assert!(ctx.call_graph.borrow().is_some());
         assert!(ctx.test_chunks.borrow().is_some());
+        assert!(ctx.cross_project.lock().unwrap().is_some());
 
         // Invalidate
         let epoch_before = ctx.invalidation_epoch.load(Ordering::SeqCst);
@@ -529,6 +540,12 @@ mod tests {
         assert!(ctx.test_chunks.borrow().is_none());
         assert!(ctx.hnsw.lock().unwrap().is_none());
         assert!(ctx.base_hnsw.lock().unwrap().is_none());
+        assert!(
+            ctx.cross_project.lock().unwrap().is_none(),
+            "cross-project cell must clear on invalidation — the merged graph \
+             includes the local project's edges, so a local reindex must not \
+             serve a stale graph"
+        );
         // Epoch bumps so in-flight view builds can't republish stale values.
         assert!(
             ctx.invalidation_epoch.load(Ordering::SeqCst) > epoch_before,
@@ -538,6 +555,110 @@ mod tests {
             ctx.pending_invalidation.get(),
             0,
             "full clear must not leave the pending mask set"
+        );
+    }
+
+    /// First `cross_project()` call on a view builds the context and writes it
+    /// back into the shared cell; a second checkout serves the SAME `Arc`
+    /// instead of rebuilding.
+    #[test]
+    fn test_cross_project_cell_write_back_and_served_from_cell() {
+        let (_dir, cqs_dir) = setup_test_store();
+        let ctx = create_test_context(&cqs_dir).unwrap();
+
+        // Cell starts empty.
+        assert!(
+            ctx.cross_project.lock().unwrap().is_none(),
+            "cross-project cell starts empty"
+        );
+
+        // First view builds and publishes.
+        let view1 = ctx.build_view(None);
+        let cross1 = view1.cross_project().expect("first cross_project build");
+        assert!(
+            ctx.cross_project.lock().unwrap().is_some(),
+            "first cross_project() must write the context back into the cell"
+        );
+
+        // Second checkout (fresh view) must serve the same cached Arc — no
+        // rebuild. Arc pointer identity proves the cell was reused.
+        let view2 = ctx.build_view(None);
+        let cross2 = view2.cross_project().expect("second cross_project served");
+        assert!(
+            Arc::ptr_eq(&cross1, &cross2),
+            "second checkout must serve the cached context, not rebuild a fresh one"
+        );
+    }
+
+    /// A reference-config fingerprint mismatch forces a rebuild even though
+    /// the cell is populated and the epoch is unchanged. Simulated by seating
+    /// a context with a deliberately wrong fingerprint and confirming the next
+    /// `cross_project()` replaces it.
+    #[test]
+    fn test_cross_project_cell_rebuilds_on_fingerprint_mismatch() {
+        let (_dir, cqs_dir) = setup_test_store();
+        let ctx = create_test_context(&cqs_dir).unwrap();
+
+        let stale = cqs::cross_project::CrossProjectContext::from_config(&ctx.root).unwrap();
+        let stale_arc = std::sync::Arc::new(Mutex::new(stale));
+        *ctx.cross_project.lock().unwrap() = Some(context::CachedCrossProject {
+            ctx: Arc::clone(&stale_arc),
+            // Fingerprint that cannot match the real (empty-references) config.
+            fingerprint: u64::MAX,
+        });
+
+        let view = ctx.build_view(None);
+        let fresh = view
+            .cross_project()
+            .expect("rebuild on fingerprint mismatch");
+        assert!(
+            !Arc::ptr_eq(&stale_arc, &fresh),
+            "fingerprint mismatch must rebuild, not serve the stale cached context"
+        );
+    }
+
+    /// The 5 cross-project dispatch sites hit the cache: a cross-project
+    /// `callers` dispatch through a view leaves the cell populated, and a
+    /// second dispatch serves the same context (no rebuild). This is the
+    /// representative dispatch-path assertion for the cluster — the other four
+    /// sites route through the identical `ctx.cross_project()` accessor.
+    #[test]
+    fn test_cross_project_dispatch_populates_and_reuses_cell() {
+        use super::handlers::dispatch_callers;
+        use crate::cli::args::{CallersArgs, LimitArg};
+
+        let (_dir, cqs_dir) = setup_test_store();
+        let ctx = create_test_context(&cqs_dir).unwrap();
+
+        let args = CallersArgs {
+            name: "anything".into(),
+            cross_project: true,
+            limit_arg: LimitArg { limit: 5 },
+        };
+
+        let view1 = ctx.build_view(None);
+        let _ = dispatch_callers(&view1, &args).expect("first cross-project dispatch");
+        let cached_after_first = {
+            let guard = ctx.cross_project.lock().unwrap();
+            guard
+                .as_ref()
+                .map(|c| Arc::clone(&c.ctx))
+                .expect("dispatch must populate the cross-project cell")
+        };
+
+        let view2 = ctx.build_view(None);
+        let _ = dispatch_callers(&view2, &args).expect("second cross-project dispatch");
+        let cached_after_second = {
+            let guard = ctx.cross_project.lock().unwrap();
+            guard
+                .as_ref()
+                .map(|c| Arc::clone(&c.ctx))
+                .expect("cell still populated")
+        };
+
+        assert!(
+            Arc::ptr_eq(&cached_after_first, &cached_after_second),
+            "second cross-project dispatch must reuse the cached context"
         );
     }
 

--- a/src/cli/batch/view.rs
+++ b/src/cli/batch/view.rs
@@ -274,6 +274,11 @@ pub(crate) struct BatchView {
     pub(super) file_set_cell: Arc<Mutex<Option<Arc<HashSet<PathBuf>>>>>,
     pub(super) notes_cell: Arc<Mutex<Option<Arc<Vec<cqs::note::Note>>>>>,
     pub(super) splade_index_cell: Arc<Mutex<Option<Arc<cqs::splade::index::SpladeIndex>>>>,
+    /// Shared cross-project cache cell. Unlike the other cells the view holds
+    /// no checkout-time snapshot — the cached context is itself mutable
+    /// (`Arc<Mutex<CrossProjectContext>>`), so [`Self::cross_project`] reads or
+    /// builds it live under the same epoch / fingerprint / staleness guards.
+    pub(super) cross_project_cell: Arc<Mutex<Option<super::context::CachedCrossProject>>>,
     /// Shared invalidation-epoch counter plus the value it held when this
     /// view was checked out. `publish_if_current` compares the two under
     /// the cell lock: any invalidation since checkout bumped the counter,
@@ -567,6 +572,97 @@ impl BatchView {
             return Some(Arc::clone(arc));
         }
         self.read_cell_if_current(&self.splade_index_cell)
+    }
+
+    /// Get the cached cross-project context, building it on a miss and caching
+    /// it in the shared cell for subsequent requests.
+    ///
+    /// Returns `Arc<Mutex<CrossProjectContext>>` so the daemon's cross-project
+    /// graph dispatchers get the `&mut CrossProjectContext` the cross cores
+    /// require (lock the inner mutex) without holding any BatchContext lock.
+    ///
+    /// # Staleness
+    ///
+    /// A cached context is served only when all three hold:
+    ///
+    /// 1. **Epoch matches.** A populated cell built after an invalidation
+    ///    belongs to a newer index generation than this view's store snapshot;
+    ///    the epoch guard discards it (same contract as every other cell). A
+    ///    local reindex invalidates via the `CROSS_PROJECT` slot, so the
+    ///    merged graph — which folds in the local project's edges — is never
+    ///    served stale.
+    /// 2. **Fingerprint matches.** The cached entry carries the references-
+    ///    config fingerprint it was built from; a `.cqs.toml` / `slot.toml`
+    ///    references edit (visible after `CONFIG_RELOAD_INTERVAL`) moves the
+    ///    fingerprint and forces a rebuild.
+    /// 3. **Underlying DBs unchanged.** `CrossProjectContext::is_stale()` is
+    ///    checked before serving so a `cqs ref update <name>` (which rewrites a
+    ///    reference's `index.db` without touching the primary file or bumping
+    ///    the epoch) forces a reload.
+    ///
+    /// A freshly built context is published back into the cell under the same
+    /// epoch guard as the other write-back caches: an invalidation that ran
+    /// during the (potentially slow) build discards the publish rather than
+    /// resurrecting a stale generation.
+    pub fn cross_project(&self) -> Result<Arc<Mutex<cqs::cross_project::CrossProjectContext>>> {
+        let current_fingerprint =
+            cqs::cross_project::CrossProjectContext::config_fingerprint(&self.config.references);
+
+        // Fast path: serve the cached context when epoch, fingerprint, and the
+        // underlying DB identities all still hold.
+        {
+            let guard = self
+                .cross_project_cell
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            if let Some(cached) = guard.as_ref() {
+                let epoch_ok =
+                    self.invalidation_epoch.load(Ordering::SeqCst) == self.checkout_epoch;
+                let fingerprint_ok = cached.fingerprint == current_fingerprint;
+                // `is_stale` stats each store's index.db; cheap relative to a
+                // full reopen + graph rebuild, and only runs on the cache-hit
+                // path.
+                let dbs_fresh = !cached
+                    .ctx
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .is_stale();
+                if epoch_ok && fingerprint_ok && dbs_fresh {
+                    return Ok(Arc::clone(&cached.ctx));
+                }
+                tracing::debug!(
+                    epoch_ok,
+                    fingerprint_ok,
+                    dbs_fresh,
+                    "cross-project cache miss — rebuilding context"
+                );
+            }
+        }
+
+        // Build outside the cell lock (reopening stores is slow).
+        let _span = tracing::info_span!("batch_view_cross_project_init").entered();
+        let built = cqs::cross_project::CrossProjectContext::from_config(&self.root)?;
+        let arc = Arc::new(Mutex::new(built));
+
+        // Publish back, epoch-guarded. An invalidation since checkout means a
+        // newer generation arrived; don't overwrite it with this stale build.
+        {
+            let mut guard = self
+                .cross_project_cell
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            if self.invalidation_epoch.load(Ordering::SeqCst) == self.checkout_epoch {
+                *guard = Some(super::context::CachedCrossProject {
+                    ctx: Arc::clone(&arc),
+                    fingerprint: current_fingerprint,
+                });
+            } else {
+                tracing::debug!(
+                    "invalidation ran since checkout — not publishing cross-project context"
+                );
+            }
+        }
+        Ok(arc)
     }
 
     /// Borrowed access keeps the snapshot Config in place; clone-on-access

--- a/src/impact/cross_project.rs
+++ b/src/impact/cross_project.rs
@@ -316,10 +316,7 @@ mod tests {
         // `into_path` disables automatic cleanup; tests are short-lived so this is fine.
         let _keep = dir.keep();
 
-        NamedStore {
-            name: name.to_string(),
-            store,
-        }
+        NamedStore::new(name.to_string(), store, db_path)
     }
 
     // ===== Cross-project impact tests =====

--- a/src/store/calls/cross_project.rs
+++ b/src/store/calls/cross_project.rs
@@ -20,6 +20,37 @@ pub struct NamedStore {
     pub name: String,
     /// The open Store handle.
     pub store: Store<crate::store::ReadOnly>,
+    /// The `index.db` path this store was opened from, plus the
+    /// `(mtime, size)` identity captured at open time. Used by
+    /// [`CrossProjectContext::is_stale`] so a daemon caching the context
+    /// across requests self-heals after a `cqs ref update <name>` (which
+    /// rewrites a reference's `index.db` without touching the primary
+    /// project's). `None` when the file was unstattable at open — the
+    /// staleness check then keeps the cached store rather than thrashing on
+    /// a transient glitch.
+    db_path: std::path::PathBuf,
+    loaded_identity: Option<(std::time::SystemTime, u64)>,
+}
+
+impl NamedStore {
+    /// Construct a `NamedStore`, capturing the `index.db` identity from
+    /// `path` for later staleness detection. `path` is the file the store was
+    /// opened from; callers that already hold it (e.g.
+    /// [`CrossProjectContext::from_config`]) avoid a redundant stat by passing
+    /// it through rather than re-deriving it.
+    pub fn new(
+        name: String,
+        store: Store<crate::store::ReadOnly>,
+        path: std::path::PathBuf,
+    ) -> Self {
+        let loaded_identity = stat_identity(&path);
+        Self {
+            name,
+            store,
+            db_path: path,
+            loaded_identity,
+        }
+    }
 }
 
 impl std::fmt::Debug for NamedStore {
@@ -29,6 +60,15 @@ impl std::fmt::Debug for NamedStore {
             .field("store", &"<Store>")
             .finish()
     }
+}
+
+/// Stat `path` and return `(mtime, size)` if readable. Mirrors the helper
+/// in `reference.rs`; an unreadable path yields `None` (treated as
+/// "unknown", caller keeps the cached value).
+fn stat_identity(path: &std::path::Path) -> Option<(std::time::SystemTime, u64)> {
+    let md = std::fs::metadata(path).ok()?;
+    let mtime = md.modified().ok()?;
+    Some((mtime, md.len()))
 }
 
 /// Caller info enriched with the originating project name.
@@ -65,6 +105,12 @@ pub struct CrossProjectContext {
     stores: Vec<NamedStore>,
     /// Cached call graphs, keyed by index into `stores`.
     graphs: HashMap<usize, Arc<CallGraph>>,
+    /// Fingerprint of the `references` config this context was built from.
+    /// `None` for contexts assembled directly via [`Self::new`] (tests).
+    /// The daemon caches a `CrossProjectContext` across requests and compares
+    /// this against the current config's fingerprint so a `.cqs.toml` /
+    /// `slot.toml` references edit forces a rebuild — see [`Self::config_fingerprint`].
+    config_fingerprint: Option<u64>,
 }
 
 impl CrossProjectContext {
@@ -73,13 +119,37 @@ impl CrossProjectContext {
         Self {
             stores,
             graphs: HashMap::new(),
+            config_fingerprint: None,
         }
+    }
+
+    /// Stable fingerprint of a `references` config slice: each reference's
+    /// `(name, path, weight)` folded into a single hash. Two configs with the
+    /// same references (order included) produce the same fingerprint; adding,
+    /// removing, repointing, or reweighting a reference changes it.
+    ///
+    /// Used as the daemon cache key so a config edit invalidates a cached
+    /// cross-project context even though `index.db` (the primary staleness
+    /// discriminator) never moved.
+    pub fn config_fingerprint(references: &[crate::config::ReferenceConfig]) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        references.len().hash(&mut hasher);
+        for r in references {
+            r.name.hash(&mut hasher);
+            r.path.hash(&mut hasher);
+            // f32 isn't Hash; fold the bit pattern so a weight tweak still
+            // moves the fingerprint.
+            r.weight.to_bits().hash(&mut hasher);
+        }
+        hasher.finish()
     }
 
     /// Build from the local store and `.cqs.toml` reference config.
     pub fn from_config(root: &std::path::Path) -> Result<Self, crate::store::helpers::StoreError> {
         let _span = tracing::info_span!("cross_project_from_config").entered();
         let config = crate::config::Config::load(root);
+        let fingerprint = Self::config_fingerprint(&config.references);
 
         // Use the slot-aware resolver so slot layouts
         // (`.cqs/slots/<active>/index.db`) work for `cqs trace
@@ -91,21 +161,25 @@ impl CrossProjectContext {
         // Cross-project reads only — open read-only. If the DB doesn't exist
         // yet, propagate the error; creating it here would corrupt the
         // invariant that cross-project queries never mutate.
+        //
+        // The local project is the throughput-sensitive store on this path
+        // (it backs the BFS traversals), so it keeps the 64MB-mmap
+        // `open_readonly`. Reference stores below use `open_readonly_small`.
         let local_store = Store::open_readonly(&db_path)?;
-        let mut stores = vec![NamedStore {
-            name: "local".to_string(),
-            store: local_store,
-        }];
+        let mut stores = vec![NamedStore::new("local".to_string(), local_store, db_path)];
 
         for ref_cfg in &config.references {
             let db_path = ref_cfg.path.join(crate::INDEX_DB_FILENAME);
-            match Store::open_readonly(&db_path) {
+            // `open_readonly_small` (16MB mmap) rather than `open_readonly`
+            // (64MB): a cached cross-project session holding N references
+            // would otherwise reserve 64MB × N of virtual address space, which
+            // has bitten us on WSL via address-space fragmentation. Reference
+            // corpora are read for graph edges, not full-scan search, so the
+            // smaller mmap costs nothing here.
+            match Store::open_readonly_small(&db_path) {
                 Ok(store) => {
                     tracing::debug!(name = %ref_cfg.name, "Reference store opened");
-                    stores.push(NamedStore {
-                        name: ref_cfg.name.clone(),
-                        store,
-                    });
+                    stores.push(NamedStore::new(ref_cfg.name.clone(), store, db_path));
                 }
                 Err(e) => {
                     tracing::warn!(name = %ref_cfg.name, error = %e, "Failed to open reference, skipping");
@@ -114,7 +188,37 @@ impl CrossProjectContext {
         }
 
         tracing::info!(projects = stores.len(), "Cross-project context loaded");
-        Ok(Self::new(stores))
+        Ok(Self {
+            stores,
+            graphs: HashMap::new(),
+            config_fingerprint: Some(fingerprint),
+        })
+    }
+
+    /// The config fingerprint this context was built from, if it came from
+    /// [`Self::from_config`]. `None` for test-assembled contexts.
+    pub fn fingerprint(&self) -> Option<u64> {
+        self.config_fingerprint
+    }
+
+    /// Has any underlying `index.db` been rewritten since this context was
+    /// built? Catches `cqs ref update <name>` (rewrites a reference's
+    /// `index.db`) and a local reindex (rewrites the primary `index.db`) —
+    /// both leave the cached `graphs` map and the merged graph pointing at a
+    /// stale generation.
+    ///
+    /// Returns `true` on the first store whose current `(mtime, size)`
+    /// differs from the value captured at open. Stores with no captured
+    /// identity (unstattable at open) or that are now unstattable are
+    /// skipped — a transient glitch shouldn't force a rebuild.
+    pub fn is_stale(&self) -> bool {
+        self.stores.iter().any(|ns| match ns.loaded_identity {
+            Some(loaded) => match stat_identity(&ns.db_path) {
+                Some(current) => current != loaded,
+                None => false,
+            },
+            None => false,
+        })
     }
 
     /// Number of projects in this context.
@@ -338,10 +442,7 @@ mod tests {
         // `into_path` disables automatic cleanup; tests are short-lived so this is fine.
         let _keep = dir.keep();
 
-        NamedStore {
-            name: name.to_string(),
-            store,
-        }
+        NamedStore::new(name.to_string(), store, db_path)
     }
 
     #[test]
@@ -401,5 +502,109 @@ mod tests {
         let mut ctx = CrossProjectContext::new(vec![store_a]);
         let callers = ctx.get_callers_cross("nonexistent").unwrap();
         assert!(callers.is_empty());
+    }
+
+    #[test]
+    fn test_config_fingerprint_changes_on_reference_edit() {
+        use crate::config::ReferenceConfig;
+        use std::path::PathBuf;
+
+        let base = vec![ReferenceConfig {
+            name: "a".to_string(),
+            path: PathBuf::from("/refs/a"),
+            source: None,
+            weight: 0.8,
+        }];
+        let fp_base = CrossProjectContext::config_fingerprint(&base);
+
+        // Same config → same fingerprint (deterministic).
+        assert_eq!(
+            fp_base,
+            CrossProjectContext::config_fingerprint(&base),
+            "identical config must fingerprint identically"
+        );
+
+        // Repointing the path moves the fingerprint.
+        let repointed = vec![ReferenceConfig {
+            path: PathBuf::from("/refs/a2"),
+            ..base[0].clone()
+        }];
+        assert_ne!(
+            fp_base,
+            CrossProjectContext::config_fingerprint(&repointed),
+            "path change must move the fingerprint"
+        );
+
+        // Reweighting moves it.
+        let reweighted = vec![ReferenceConfig {
+            weight: 0.5,
+            ..base[0].clone()
+        }];
+        assert_ne!(
+            fp_base,
+            CrossProjectContext::config_fingerprint(&reweighted),
+            "weight change must move the fingerprint"
+        );
+
+        // Adding a reference moves it.
+        let mut grown = base.clone();
+        grown.push(ReferenceConfig {
+            name: "b".to_string(),
+            path: PathBuf::from("/refs/b"),
+            source: None,
+            weight: 0.8,
+        });
+        assert_ne!(
+            fp_base,
+            CrossProjectContext::config_fingerprint(&grown),
+            "adding a reference must move the fingerprint"
+        );
+
+        // Empty config fingerprints stably (and differently from non-empty).
+        assert_ne!(
+            fp_base,
+            CrossProjectContext::config_fingerprint(&[]),
+            "empty vs non-empty must differ"
+        );
+    }
+
+    #[test]
+    fn test_is_stale_detects_db_rewrite() {
+        // A NamedStore captures its db identity at construction. Rewriting the
+        // underlying index.db (the `cqs ref update` / local-reindex shape)
+        // must flip is_stale() true.
+        let mut forward = StdMap::new();
+        forward.insert("caller_a".to_string(), vec!["target".to_string()]);
+        let ns = make_named_store("proj_a", forward, StdMap::new());
+        let db_path = ns.db_path.clone();
+        let ctx = CrossProjectContext::new(vec![ns]);
+
+        assert!(!ctx.is_stale(), "freshly built context is not stale");
+
+        // Append a byte and bump mtime past the 1s FS granularity floor so the
+        // (mtime, size) identity changes.
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&db_path)
+                .unwrap();
+            f.write_all(b" ").unwrap();
+            f.sync_all().unwrap();
+        }
+
+        assert!(
+            ctx.is_stale(),
+            "rewriting the underlying index.db must mark the context stale"
+        );
+    }
+
+    #[test]
+    fn test_new_context_has_no_fingerprint() {
+        // Test-assembled contexts (via `new`) carry no fingerprint — only
+        // `from_config` sets one, since only it reads the references config.
+        let ctx = CrossProjectContext::new(vec![]);
+        assert_eq!(ctx.fingerprint(), None);
     }
 }

--- a/tests/cross_project_test.rs
+++ b/tests/cross_project_test.rs
@@ -23,6 +23,15 @@ where
     .expect("open_readonly_after_init")
 }
 
+/// Build a `NamedStore` from a fixture store + its backing `TempDir`, passing
+/// the `index.db` path through to `NamedStore::new` so staleness tracking is
+/// seeded. Replaces the old struct-literal construction now that the identity
+/// fields are private.
+fn named_store(name: &str, dir: &TempDir, store: Store<ReadOnly>) -> NamedStore {
+    let db_path = dir.path().join(cqs::INDEX_DB_FILENAME);
+    NamedStore::new(name.to_string(), store, db_path)
+}
+
 fn insert_chunk_and_call(
     store: &Store<ReadWrite>,
     caller: &str,
@@ -75,14 +84,8 @@ fn test_cross_project_callers_finds_both() {
     });
 
     let mut ctx = CrossProjectContext::new(vec![
-        NamedStore {
-            name: "local".into(),
-            store: store_a,
-        },
-        NamedStore {
-            name: "project_b".into(),
-            store: store_b,
-        },
+        named_store("local", &dir_a, store_a),
+        named_store("project_b", &dir_b, store_b),
     ]);
 
     let callers = ctx.get_callers_cross("target").unwrap();
@@ -108,14 +111,8 @@ fn test_cross_project_callees_finds_both() {
     });
 
     let mut ctx = CrossProjectContext::new(vec![
-        NamedStore {
-            name: "local".into(),
-            store: store_a,
-        },
-        NamedStore {
-            name: "project_b".into(),
-            store: store_b,
-        },
+        named_store("local", &dir_a, store_a),
+        named_store("project_b", &dir_b, store_b),
     ]);
 
     let callees = ctx.get_callees_cross("source").unwrap();
@@ -131,10 +128,7 @@ fn test_cross_project_no_references_local_only() {
     let dir = TempDir::new().unwrap();
     let store = build_readonly_store(&dir, |s| insert_chunk_and_call(s, "foo", "target", "a.rs"));
 
-    let mut ctx = CrossProjectContext::new(vec![NamedStore {
-        name: "local".into(),
-        store,
-    }]);
+    let mut ctx = CrossProjectContext::new(vec![named_store("local", &dir, store)]);
 
     let callers = ctx.get_callers_cross("target").unwrap();
     assert_eq!(callers.len(), 1);
@@ -146,10 +140,7 @@ fn test_cross_project_function_not_found() {
     let dir = TempDir::new().unwrap();
     let store = build_readonly_store(&dir, |_s| Ok(()));
 
-    let mut ctx = CrossProjectContext::new(vec![NamedStore {
-        name: "local".into(),
-        store,
-    }]);
+    let mut ctx = CrossProjectContext::new(vec![named_store("local", &dir, store)]);
 
     let callers = ctx.get_callers_cross("nonexistent").unwrap();
     assert!(callers.is_empty());
@@ -167,14 +158,8 @@ fn test_cross_project_same_name_different_sources() {
     });
 
     let mut ctx = CrossProjectContext::new(vec![
-        NamedStore {
-            name: "local".into(),
-            store: store_a,
-        },
-        NamedStore {
-            name: "project_b".into(),
-            store: store_b,
-        },
+        named_store("local", &dir_a, store_a),
+        named_store("project_b", &dir_b, store_b),
     ]);
 
     let callers = ctx.get_callers_cross("target").unwrap();


### PR DESCRIPTION
## perf(daemon): cache cross-project context across requests (CF RM-V1.40-6/7)

The constructed `CrossProjectContext` (opened reference stores + lazily-built per-store call graphs) is now a `#[1739]`-pattern cache cell shared between BatchContext and BatchView — previously rebuilt at all 5 cross-project dispatch sites per request (~64 MB mmap reopen × N refs + merged-graph rebuild). Cached layer argued: the refs LRU caches a *different* type (`ReferenceIndex`); `from_config` opened its own stores, so the whole context was the missing piece, not a double-cache.

Staleness contract (in-code): (1) local reindex clears the slot via the standard invalidation (merged graph includes local edges); (2) `ref update` caught by per-store `(mtime, size)` identity + `is_stale()` before serving; (3) references-config edits caught by a `(name, path, weight)` fingerprint key after the config reload interval. Ref stores open via `open_readonly_small`. Slot mask widened u8→u16 for the new slot.

Tests: 3 new cell tests + invalidation assertion; cross_project 7, batch 161, graph handlers 21 (incl. #1760 parity), integration 5 — green. fmt + clippy `--all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
