### PR TITLE
feat(limits): named caps replace clamp literals; daemon/backup/sparse intervals gain env knobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,8 +770,11 @@ Quick index by domain (everything is searchable in the table below):
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CQS_API_BASE` | (none) | LLM API base URL (legacy alias for `CQS_LLM_API_BASE`) |
+| `CQS_BATCH_AUDIT_RELOAD_SECS` | `30` | TTL (seconds) for the batch/daemon `audit_state` reload cache. `.cqs/audit-mode.json` toggles take effect within this window without a daemon restart. Lower = faster pickup of `cqs audit-mode on/off`, more file reads. |
+| `CQS_BATCH_CONFIG_RELOAD_SECS` | `300` | TTL (seconds) for the batch/daemon `config` reload cache. `.cqs/config.toml` edits (`splade_alpha`, `ef_search`, …) take effect within this window without a daemon restart. |
 | `CQS_BATCH_DATA_IDLE_MINUTES` | `30` | Minutes of inactivity before `cqs batch` / `cqs chat` evicts heavy data caches (HNSW, SPLADE index, call graph, test chunks, file set, refs). Independent of the ONNX-session sweep above. `0` disables. |
 | `CQS_BATCH_IDLE_MINUTES` | `5` | Minutes of inactivity before `cqs batch` / `cqs chat` clears ONNX sessions (`0` disables eviction). |
+| `CQS_BATCH_STALENESS_CHECK_MS` | `100` | Minimum interval (milliseconds) between batch/daemon staleness probes (`index.db` mtime + `PRAGMA data_version`). Caps the probe rate so `store()` on every handler hop doesn't re-probe; reindex-detection latency stays under this much. |
 | `CQS_BRUTE_FORCE_BATCH_SIZE` | (auto) | Cursor-based brute-force search batch size. Default scales by query embedding dim via `dim_scaled_batch(5000, dim, 500, 50_000)` so a 4096-dim model holds ~20 MB per batch instead of 80 MB. v1.36.2 SHL-V1.36-3 — pinned override wins verbatim. |
 | `CQS_BUSY_TIMEOUT_MS` | `5000` | SQLite busy timeout in milliseconds |
 | `CQS_CACHE_MAX_SIZE` | `1073741824` (1 GB) | Global embedding cache size limit |
@@ -858,6 +861,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_LLM_MODEL` | `claude-haiku-4-5` | LLM model name for summaries. Required when `CQS_LLM_PROVIDER=local`; must match a model your server exposes. |
 | `CQS_LLM_PROVIDER` | `anthropic` | LLM provider: `anthropic` (Messages Batches API) or `local` (any OpenAI-compat `/v1/chat/completions` endpoint — llama.cpp, vLLM, Ollama, LMStudio). |
 | `CQS_LLM_RETRY_BACKOFFS_MS` | `500,1000,2000,4000` | Comma-separated millisecond backoff schedule for the `local` provider's per-item retries. Schedule length sets the max-attempts count (default 4). Bump for saturated local vLLM serving where transient 5xx bursts exceed the 7.5s default window — e.g. `500,1000,2000,4000,8000,16000` for a 31.5s window with 6 attempts. v1.38: SHL-V1.38-10 / #1463. |
+| `CQS_LOAD_SPARSE_BATCH` | `1000` | Distinct chunk_ids fetched per page when loading sparse (SPLADE) vectors into the in-memory index (`load_all_sparse_vectors`, run on daemon startup + each watch reload). Smaller = lower peak RAM per batch; larger = fewer SQLite round-trips. |
 | `CQS_LOCAL_LLM_CONCURRENCY` | `4` | Worker pool size for `CQS_LLM_PROVIDER=local`. Clamped to `[1, 64]`. |
 | `CQS_LOCAL_LLM_MAX_BODY_BYTES` | `4194304` (4 MiB) | Max response body bytes accepted from a `CQS_LLM_PROVIDER=local` server. Larger bodies are a sign of a misbehaving or hostile endpoint and abort with a clear error rather than OOMing the daemon. Must be > 0. |
 | `CQS_LOCAL_LLM_TIMEOUT_SECS` | `120` | Per-request timeout (seconds) for `CQS_LLM_PROVIDER=local`. Local inference can be slow, so the default is 2× the Anthropic 60s ceiling. |
@@ -884,6 +888,7 @@ Quick index by domain (everything is searchable in the table below):
 | `CQS_MAX_SEQ_LENGTH` | (auto) | Override max sequence length for custom ONNX models |
 | `CQS_MD_MAX_SECTION_LINES` | `150` | Max markdown section lines before overflow split |
 | `CQS_MD_MIN_SECTION_LINES` | `30` | Min markdown section lines (smaller sections merge) |
+| `CQS_MIGRATE_KEEP_BACKUPS` | `3` | Number of version-tagged migration backups retained in the DB's parent directory; older ones are pruned after every successful migrate. `3` = the current run's backup plus the two prior runs'. `0` is honored verbatim (prune all after a successful migrate) for tight-quota mounts. |
 | `CQS_MIGRATE_REQUIRE_BACKUP` | `1` | Migration-time DB backup is required by default; a backup failure aborts the migration with `StoreError::Io` so the destructive v18→v19 rebuild never runs without a recovery snapshot. Set to `0` to downgrade to a `warn!` and proceed without a snapshot (accept data-loss risk on a subsequent commit failure). |
 | `CQS_HF_CACHE_TRUSTED` | (none) | Set to `1` to opt into env-supplied HF cache paths (`HF_HOME` / `HUGGINGFACE_HUB_CACHE`) that would otherwise be flagged as suspicious — under `/tmp`, `/var/tmp`, `/dev/shm`, `~/Downloads`, `~/Desktop`, or outside both `$HOME` and the system cache dir. Without this, suspicious paths get a `tracing::warn!` and the loader falls through to the default cache so a hostile env var can't redirect ONNX model loads. SEC-V1.33-8 / #1339. |
 | `CQS_MMAP_SIZE` | `268435456` (256 MB) | SQLite memory-mapped I/O size |

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -334,6 +334,10 @@ pub(crate) struct BlameArgs {
     /// Spelled `--commits`/`-n` rather than `--depth` so blame doesn't share
     /// the `--depth` spelling with `onboard` (callee expansion depth) and
     /// `test-map` (call-chain BFS depth), which carry different semantics.
+    ///
+    /// Default 10 (not `LimitArg`'s 5) is intentional: this counts commits to
+    /// show in the blame walk, not a result-set size, so it does not share
+    /// `LimitArg`'s ceiling or default.
     #[arg(short = 'n', long, default_value = "10")]
     pub commits: usize,
     /// Also show callers of the function

--- a/src/cli/batch/context.rs
+++ b/src/cli/batch/context.rs
@@ -108,7 +108,7 @@ pub(crate) struct BatchContext {
     // other view sharing the Arc.
     pub(super) embedder: Arc<OnceLock<Arc<Embedder>>>,
     /// `RefCell<Option<CachedReload<Config>>>` so a `.cqs/config.toml` edit
-    /// shows up after `CONFIG_RELOAD_INTERVAL` (default 5 min) without a daemon
+    /// shows up after `config_reload_interval` (default 5 min) without a daemon
     /// restart. The reload is a sub-ms file read; cost is negligible per query.
     pub(super) config: RefCell<Option<CachedReload<cqs::config::Config>>>,
     /// `Arc<OnceLock<...>>` so views share one slot with the BatchContext. The
@@ -118,7 +118,7 @@ pub(crate) struct BatchContext {
     pub(super) reranker: Arc<OnceLock<Arc<dyn cqs::Reranker>>>,
     /// `RefCell<Option<CachedReload<AuditMode>>>` so the 30-min audit
     /// auto-expire fires while the daemon is up. Reloads from
-    /// `.cqs/audit-mode.json` every `AUDIT_STATE_RELOAD_INTERVAL` (default
+    /// `.cqs/audit-mode.json` every `audit_state_reload_interval` (default
     /// 30 s); the file carries its own embedded `expires_at` so the load
     /// itself respects expiration.
     pub(super) audit_state: RefCell<Option<CachedReload<cqs::audit::AuditMode>>>,
@@ -200,7 +200,7 @@ pub(crate) struct BatchContext {
     /// fallback); re-opened lazily on the next staleness check.
     pub(super) data_version_probe: RefCell<Option<DataVersionProbe>>,
     /// When the staleness check last ran. Used to rate-limit `fs::metadata`
-    /// on `index.db` — see [`STALENESS_CHECK_INTERVAL`].
+    /// on `index.db` — see [`staleness_check_interval`].
     pub(super) last_staleness_check: Cell<Option<Instant>>,
     /// `Arc<AtomicU64>` so `BatchView` carries a cheap clone of the counter
     /// handle and handlers can read/bump without re-locking the outer
@@ -429,7 +429,7 @@ impl BatchContext {
     /// so the probe falls back to identity-only (with a warn) rather than
     /// blocking the check when it can't be opened or queried.
     ///
-    /// Rate-limited to at most once per [`STALENESS_CHECK_INTERVAL`] —
+    /// Rate-limited to at most once per [`staleness_check_interval`] —
     /// except when a prior invalidation deferred a busy slot, in which case
     /// the sticky `pending_invalidation` flag forces a retry. Every
     /// `ctx.store()`, every `build_view` checkout, and the remaining
@@ -443,7 +443,7 @@ impl BatchContext {
         let now = Instant::now();
         if pending == 0 {
             if let Some(prev) = self.last_staleness_check.get() {
-                if now.duration_since(prev) < STALENESS_CHECK_INTERVAL {
+                if now.duration_since(prev) < staleness_check_interval() {
                     return;
                 }
             }
@@ -1239,7 +1239,7 @@ impl BatchContext {
     }
 
     /// Get cached audit state. Reloads from `.cqs/audit-mode.json` when the
-    /// cached value is older than [`AUDIT_STATE_RELOAD_INTERVAL`] (default
+    /// cached value is older than [`audit_state_reload_interval`] (default
     /// 30 s), then returns an owned snapshot.
     ///
     /// The file is sub-ms to read; the 30 s interval bounds staleness while
@@ -1248,7 +1248,7 @@ impl BatchContext {
     /// &audit` call-site pattern work without juggling `Ref<'_, ...>` lifetimes.
     pub(super) fn audit_state(&self) -> cqs::audit::AuditMode {
         let needs_reload = match self.audit_state.borrow().as_ref() {
-            Some(c) => c.loaded_at.elapsed() >= AUDIT_STATE_RELOAD_INTERVAL,
+            Some(c) => c.loaded_at.elapsed() >= audit_state_reload_interval(),
             None => true,
         };
         if needs_reload {
@@ -1316,7 +1316,7 @@ impl BatchContext {
     }
 
     /// Get cached project config. Reloads from `.cqs/config.toml` when the
-    /// cached value is older than [`CONFIG_RELOAD_INTERVAL`] (default 5 min),
+    /// cached value is older than [`config_reload_interval`] (default 5 min),
     /// then returns an owned snapshot.
     ///
     /// `.cqs/config.toml` edits (e.g. `splade_alpha`, `ef_search`) take effect
@@ -1327,7 +1327,7 @@ impl BatchContext {
     /// auto-deref.
     pub(super) fn config(&self) -> cqs::config::Config {
         let needs_reload = match self.config.borrow().as_ref() {
-            Some(c) => c.loaded_at.elapsed() >= CONFIG_RELOAD_INTERVAL,
+            Some(c) => c.loaded_at.elapsed() >= config_reload_interval(),
             None => true,
         };
         if needs_reload {

--- a/src/cli/batch/handlers/info.rs
+++ b/src/cli/batch/handlers/info.rs
@@ -56,7 +56,7 @@ pub(in crate::cli::batch) fn dispatch_explain(
         tracing::info_span!("batch_explain", target, limit = args.limit_arg.limit).entered();
     // Shared cap with `cmd_explain`. Truncates the per-section lists
     // (callers / callees / similar) before serialization.
-    let limit = args.limit_arg.limit.clamp(1, 100);
+    let limit = args.limit_arg.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     let index = ctx.vector_index()?;
     let index = index.as_deref();

--- a/src/cli/batch/handlers/misc.rs
+++ b/src/cli/batch/handlers/misc.rs
@@ -186,7 +186,10 @@ pub(in crate::cli::batch) fn dispatch_task(
     let tokens = args.tokens;
     let _span = tracing::info_span!("batch_task", description).entered();
     let embedder = ctx.embedder()?;
-    let limit = args.limit_arg.limit.clamp(1, 10);
+    let limit = args
+        .limit_arg
+        .limit
+        .clamp(1, crate::cli::PLACEMENT_LIMIT_CAP);
     let graph = ctx.call_graph()?;
     let test_chunks = ctx.test_chunks()?;
     let result = cqs::task_with_resources(
@@ -251,7 +254,10 @@ pub(in crate::cli::batch) fn dispatch_where(
     let description = args.description.as_str();
     let _span = tracing::info_span!("batch_where", description).entered();
     let embedder = ctx.embedder()?;
-    let limit = args.limit_arg.limit.clamp(1, 10);
+    let limit = args
+        .limit_arg
+        .limit
+        .clamp(1, crate::cli::PLACEMENT_LIMIT_CAP);
     let result = cqs::suggest_placement(&ctx.store(), embedder, description, limit)?;
 
     let output = crate::cli::commands::build_where_output(&result, description, &ctx.root);

--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -814,7 +814,7 @@ mod tests {
     }
 
     /// `--name-only --limit N` honours the limit *and* clamps out-of-range
-    /// values via `limit.clamp(1, 100)`. A regression
+    /// values via `limit.clamp(1, SEARCH_LIMIT_CAP)`. A regression
     /// that passed the raw limit through would return unlimited rows.
     #[test]
     fn test_dispatch_search_name_only_limit_clamp() {

--- a/src/cli/batch/mod.rs
+++ b/src/cli/batch/mod.rs
@@ -150,18 +150,39 @@ fn data_cache_idle_timeout_minutes() -> u64 {
         .unwrap_or(DEFAULT_DATA_CACHE_IDLE_MINUTES)
 }
 
-/// TTL for the `audit_state` reload cache. The audit-mode file
-/// (`.cqs/audit-mode.json`) carries its own embedded `expires_at`. Re-reading
-/// every 30 s on each query is cheap (sub-ms file read) and bounds the
-/// staleness so the 30-min audit-mode auto-expire fires while the daemon is
-/// up, and `cqs audit-mode on` after daemon boot takes effect.
-const AUDIT_STATE_RELOAD_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+/// Default TTL (seconds) for the `audit_state` reload cache. The audit-mode
+/// file (`.cqs/audit-mode.json`) carries its own embedded `expires_at`.
+/// Re-reading every 30 s on each query is cheap (sub-ms file read) and bounds
+/// the staleness so the 30-min audit-mode auto-expire fires while the daemon
+/// is up, and `cqs audit-mode on` after daemon boot takes effect.
+const AUDIT_STATE_RELOAD_SECS_DEFAULT: u64 = 30;
 
-/// TTL for the `config` reload cache. `.cqs/config.toml` edits (e.g. tuning
-/// `splade_alpha` or `ef_search`) take effect after this interval without a
-/// daemon restart. 5 min is long enough to avoid hot-loop file reads while
-/// keeping ad-hoc config tweaks usable without `systemctl restart cqs-watch`.
-const CONFIG_RELOAD_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+/// Resolve the `audit_state` reload TTL honoring `CQS_BATCH_AUDIT_RELOAD_SECS`.
+/// Falls back to [`AUDIT_STATE_RELOAD_SECS_DEFAULT`] when unset, empty,
+/// unparseable, or zero.
+fn audit_state_reload_interval() -> std::time::Duration {
+    std::time::Duration::from_secs(cqs::limits::parse_env_u64(
+        "CQS_BATCH_AUDIT_RELOAD_SECS",
+        AUDIT_STATE_RELOAD_SECS_DEFAULT,
+    ))
+}
+
+/// Default TTL (seconds) for the `config` reload cache. `.cqs/config.toml`
+/// edits (e.g. tuning `splade_alpha` or `ef_search`) take effect after this
+/// interval without a daemon restart. 5 min is long enough to avoid hot-loop
+/// file reads while keeping ad-hoc config tweaks usable without
+/// `systemctl restart cqs-watch`.
+const CONFIG_RELOAD_SECS_DEFAULT: u64 = 5 * 60;
+
+/// Resolve the `config` reload TTL honoring `CQS_BATCH_CONFIG_RELOAD_SECS`.
+/// Falls back to [`CONFIG_RELOAD_SECS_DEFAULT`] when unset, empty,
+/// unparseable, or zero.
+fn config_reload_interval() -> std::time::Duration {
+    std::time::Duration::from_secs(cqs::limits::parse_env_u64(
+        "CQS_BATCH_CONFIG_RELOAD_SECS",
+        CONFIG_RELOAD_SECS_DEFAULT,
+    ))
+}
 
 /// Default number of reference indexes kept in the LRU cache. A "reference"
 /// is a sibling cqs project loaded via `@name` syntax. Memory-constrained
@@ -188,7 +209,17 @@ fn refs_lru_size() -> std::num::NonZeroUsize {
 /// a syscall per poll (the pragma is a connection-local counter read,
 /// cheaper still). 100 ms caps the probe rate at ~10 Hz per batch session
 /// while keeping reindex detection latency well under a second.
-const STALENESS_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+const STALENESS_CHECK_MS_DEFAULT: u64 = 100;
+
+/// Resolve the minimum staleness-probe interval honoring
+/// `CQS_BATCH_STALENESS_CHECK_MS`. Falls back to
+/// [`STALENESS_CHECK_MS_DEFAULT`] when unset, empty, unparseable, or zero.
+fn staleness_check_interval() -> std::time::Duration {
+    std::time::Duration::from_millis(cqs::limits::parse_env_u64(
+        "CQS_BATCH_STALENESS_CHECK_MS",
+        STALENESS_CHECK_MS_DEFAULT,
+    ))
+}
 
 /// A cached value paired with the instant it was loaded. The accessor
 /// consults `loaded_at.elapsed()` against a per-field reload interval; once
@@ -1754,5 +1785,43 @@ mod tests {
             "retry must clear the deferred slot"
         );
         assert_eq!(ctx.pending_invalidation.get(), 0);
+    }
+
+    /// Each daemon-interval resolver returns its compiled default when the
+    /// env var is unset and the env value when set. Garbage/zero falls back
+    /// to the default (per `parse_env_u64`).
+    #[test]
+    fn daemon_interval_resolvers_honor_env() {
+        std::env::remove_var("CQS_BATCH_STALENESS_CHECK_MS");
+        assert_eq!(
+            staleness_check_interval(),
+            Duration::from_millis(STALENESS_CHECK_MS_DEFAULT)
+        );
+        std::env::set_var("CQS_BATCH_STALENESS_CHECK_MS", "250");
+        assert_eq!(staleness_check_interval(), Duration::from_millis(250));
+        std::env::set_var("CQS_BATCH_STALENESS_CHECK_MS", "garbage");
+        assert_eq!(
+            staleness_check_interval(),
+            Duration::from_millis(STALENESS_CHECK_MS_DEFAULT)
+        );
+        std::env::remove_var("CQS_BATCH_STALENESS_CHECK_MS");
+
+        std::env::remove_var("CQS_BATCH_AUDIT_RELOAD_SECS");
+        assert_eq!(
+            audit_state_reload_interval(),
+            Duration::from_secs(AUDIT_STATE_RELOAD_SECS_DEFAULT)
+        );
+        std::env::set_var("CQS_BATCH_AUDIT_RELOAD_SECS", "5");
+        assert_eq!(audit_state_reload_interval(), Duration::from_secs(5));
+        std::env::remove_var("CQS_BATCH_AUDIT_RELOAD_SECS");
+
+        std::env::remove_var("CQS_BATCH_CONFIG_RELOAD_SECS");
+        assert_eq!(
+            config_reload_interval(),
+            Duration::from_secs(CONFIG_RELOAD_SECS_DEFAULT)
+        );
+        std::env::set_var("CQS_BATCH_CONFIG_RELOAD_SECS", "120");
+        assert_eq!(config_reload_interval(), Duration::from_secs(120));
+        std::env::remove_var("CQS_BATCH_CONFIG_RELOAD_SECS");
     }
 }

--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -176,7 +176,7 @@ pub(crate) fn callers_core(
         tracing::info_span!("callers_core", name = %args.name, limit = args.limit).entered();
     // Standardised cap. The store query returns every caller; we truncate
     // before rendering so the user can paginate via repeated calls.
-    let limit = args.limit.clamp(1, 100);
+    let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     // Polymorphic-routing kind detection. Dispatch the kind-mismatch
     // fallback before the call-graph query.
@@ -204,7 +204,7 @@ pub(crate) fn callees_core(
 ) -> Result<CalleesCoreOutput> {
     let _span =
         tracing::info_span!("callees_core", name = %args.name, limit = args.limit).entered();
-    let limit = args.limit.clamp(1, 100);
+    let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     let (chunks, fallback) = super::detect_fallback(store, &args.name);
     if let Some(fk) = fallback {
@@ -244,7 +244,7 @@ pub(crate) fn callers_cross_core(
 ) -> Result<CallersOutput> {
     let _span =
         tracing::info_span!("callers_cross_core", name = %args.name, limit = args.limit).entered();
-    let limit = args.limit.clamp(1, 100);
+    let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
     let mut callers = cross_ctx
         .get_callers_cross(&args.name)
         .context("Failed to load cross-project callers")?;
@@ -275,7 +275,7 @@ pub(crate) fn callees_cross_core(
 ) -> Result<CalleesOutput> {
     let _span =
         tracing::info_span!("callees_cross_core", name = %args.name, limit = args.limit).entered();
-    let limit = args.limit.clamp(1, 100);
+    let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
     let mut callees = cross_ctx
         .get_callees_cross(&args.name)
         .context("Failed to load cross-project callees")?;
@@ -307,7 +307,7 @@ pub(crate) fn cmd_callers(
 ) -> Result<()> {
     let _span = tracing::info_span!("cmd_callers", name, limit, cross_project).entered();
     let store = &ctx.store;
-    let limit = limit.clamp(1, 100);
+    let limit = limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
@@ -406,7 +406,7 @@ pub(crate) fn cmd_callees(
     let _span = tracing::info_span!("cmd_callees", name, limit, cross_project).entered();
     let store = &ctx.store;
     // See cmd_callers — same clamp range.
-    let limit = limit.clamp(1, 100);
+    let limit = limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;

--- a/src/cli/commands/graph/deps.rs
+++ b/src/cli/commands/graph/deps.rs
@@ -117,7 +117,7 @@ pub(crate) fn deps_core(
     let _span =
         tracing::info_span!("deps_core", name = %args.name, reverse = args.reverse, limit = args.limit)
             .entered();
-    let limit = args.limit.clamp(1, 100);
+    let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     // Const/Module/Ambiguous don't fit deps' model. `notes_text::deps`
     // returns `None` for Type, encoding "deps runs the forward query for a

--- a/src/cli/commands/graph/explain.rs
+++ b/src/cli/commands/graph/explain.rs
@@ -314,7 +314,7 @@ pub(crate) fn cmd_explain(
     let root = &ctx.root;
     let cqs_dir = &ctx.cqs_dir;
     // Cap on callers/callees/similar lists in the function card.
-    let limit = limit.clamp(1, 100);
+    let limit = limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     let embedder = if max_tokens.is_some() {
         Some(ctx.embedder()?)

--- a/src/cli/commands/graph/impact.rs
+++ b/src/cli/commands/graph/impact.rs
@@ -114,8 +114,8 @@ pub(crate) fn impact_core(
     args: &ImpactArgs,
 ) -> Result<ImpactCoreOutput> {
     let _span = tracing::info_span!("impact_core", name = %args.name, limit = args.limit).entered();
-    let depth = args.depth.clamp(1, 10);
-    let limit = args.limit.clamp(1, 100);
+    let depth = args.depth.clamp(1, crate::cli::IMPACT_DEPTH_CAP);
+    let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     let (chunks, fallback) = super::detect_fallback(store, &args.name);
     if let Some(fk) = fallback {
@@ -172,8 +172,8 @@ pub(crate) fn impact_cross_core(
 ) -> Result<cqs::ImpactResult> {
     let _span =
         tracing::info_span!("impact_cross_core", name = %args.name, limit = args.limit).entered();
-    let depth = args.depth.clamp(1, 10);
-    let limit = args.limit.clamp(1, 100);
+    let depth = args.depth.clamp(1, crate::cli::IMPACT_DEPTH_CAP);
+    let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
     let mut result = cqs::cross_project::analyze_impact_cross(
         cross_ctx,
         &args.name,

--- a/src/cli/commands/graph/test_map.rs
+++ b/src/cli/commands/graph/test_map.rs
@@ -257,7 +257,7 @@ pub(crate) fn test_map_core(
         tracing::info_span!("test_map_core", name = %args.name, limit = args.limit).entered();
     // Cap on rendered matches. Truncates the BFS-derived matches AFTER
     // sorting so the "closest" tests rank first.
-    let limit = args.limit.clamp(1, 100);
+    let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     let (chunks, fallback) = super::detect_fallback(store, &args.name);
     if let Some(fk) = fallback {
@@ -303,7 +303,7 @@ pub(crate) fn test_map_cross_core(
 ) -> Result<Vec<TestMatch>> {
     let _span =
         tracing::info_span!("test_map_cross_core", name = %args.name, limit = args.limit).entered();
-    let limit = args.limit.clamp(1, 100);
+    let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
     let test_chunks = cross_ctx.find_test_chunks_cross()?;
     let graph = cross_ctx.merged_call_graph()?;
     let summaries: Vec<ChunkSummary> = test_chunks.iter().map(|tc| tc.chunk.clone()).collect();
@@ -332,7 +332,7 @@ pub(crate) fn cmd_test_map(
     let _span = tracing::info_span!("cmd_test_map", name, limit, cross_project).entered();
     // Cap on rendered matches. Default is 5 (LimitArg). Truncates the
     // BFS-derived matches AFTER sorting so the "closest" tests rank first.
-    let limit = limit.clamp(1, 100);
+    let limit = limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;

--- a/src/cli/commands/search/gather.rs
+++ b/src/cli/commands/search/gather.rs
@@ -83,9 +83,9 @@ pub(crate) fn gather_core(
     // When token-budgeted, fetch more seeds than the limit so the packer has
     // candidates to choose from.
     let fetch_limit = if args.tokens.is_some() {
-        args.limit.clamp(1, 100).max(50)
+        args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP).max(50)
     } else {
-        args.limit.clamp(1, 100)
+        args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP)
     };
 
     let opts = GatherOptions {

--- a/src/cli/commands/search/onboard.rs
+++ b/src/cli/commands/search/onboard.rs
@@ -66,8 +66,8 @@ pub(crate) fn onboard_core(
     args: &OnboardArgs,
 ) -> Result<serde_json::Value> {
     let _span = tracing::info_span!("onboard_core", query = %args.query).entered();
-    let depth = args.depth.clamp(1, 5);
-    let limit = args.limit.clamp(1, 100);
+    let depth = args.depth.clamp(1, crate::cli::ONBOARD_DEPTH_CAP);
+    let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     let mut result = onboard(store, embedder, &args.query, root, depth, args.direction)?;
     result.call_chain.truncate(limit);
@@ -126,11 +126,11 @@ pub(crate) fn cmd_onboard(
         return Ok(());
     }
 
-    let depth = depth.clamp(1, 5);
+    let depth = depth.clamp(1, crate::cli::ONBOARD_DEPTH_CAP);
     // Cap on call_chain + callers + tests entries. Applied AFTER the
     // BFS+search so the entry_point is always preserved and so the order
     // (relevance → depth) is respected before truncation.
-    let limit = limit.clamp(1, 100);
+    let limit = limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
     let mut result = onboard(store, embedder, concept, root, depth, direction)?;
     result.call_chain.truncate(limit);

--- a/src/cli/commands/search/where_cmd.rs
+++ b/src/cli/commands/search/where_cmd.rs
@@ -88,7 +88,7 @@ pub(crate) fn cmd_where(
     let store = &ctx.store;
     let root = &ctx.root;
     let embedder = ctx.embedder()?;
-    let limit = limit.clamp(1, 10);
+    let limit = limit.clamp(1, crate::cli::PLACEMENT_LIMIT_CAP);
 
     let result = suggest_placement(store, embedder, description, limit)?;
 

--- a/src/cli/commands/train/task.rs
+++ b/src/cli/commands/train/task.rs
@@ -321,7 +321,7 @@ pub(crate) fn cmd_task(
     let store = &ctx.store;
     let root = &ctx.root;
     let embedder = ctx.embedder()?;
-    let limit = limit.clamp(1, 10);
+    let limit = limit.clamp(1, crate::cli::PLACEMENT_LIMIT_CAP);
 
     let result = task(store, embedder, description, root, limit)?;
 

--- a/src/cli/limits.rs
+++ b/src/cli/limits.rs
@@ -44,6 +44,33 @@ pub(crate) const SIMILAR_LIMIT_MAX: usize = 100;
 /// types) each get their own top-N, so the total return cap is 3× this.
 pub(crate) const RELATED_LIMIT_MAX: usize = 50;
 
+/// Shared `--limit` ceiling for the graph-surface commands and the
+/// `explain`/`onboard`/`gather` result lists: `callers`, `callees`,
+/// `deps`, `impact`, `test-map`, `explain` (CLI + batch), plus the
+/// `onboard` and `gather` seed-fetch limits. All truncate a result list
+/// (or per-section list) to at most this many entries before rendering;
+/// the underlying store query is unbounded, so callers paginate by
+/// re-querying. One constant keeps the truncation ceiling identical
+/// across every surface that shares the semantic.
+pub(crate) const GRAPH_LIMIT_CAP: usize = 100;
+
+/// `--limit` ceiling for the placement-suggestion commands: `where`,
+/// `task`, and the batch `where` / `task` handlers. These rank candidate
+/// insertion sites; a short list is the useful output, so the ceiling is
+/// deliberately tighter than [`GRAPH_LIMIT_CAP`].
+pub(crate) const PLACEMENT_LIMIT_CAP: usize = 10;
+
+/// `--depth` ceiling for `cqs impact` (and the cross-project impact core).
+/// Bounds the reverse-call-graph BFS depth so an adversarial `--depth`
+/// can't fan the traversal out unbounded. Distinct from a result-count
+/// limit — it caps traversal hops, not rendered rows.
+pub(crate) const IMPACT_DEPTH_CAP: usize = 10;
+
+/// `--depth` ceiling for `cqs onboard`. Bounds the callee-expansion BFS
+/// depth in the guided-tour walk. Smaller than [`IMPACT_DEPTH_CAP`]
+/// because onboard's tour stays shallow by design — a deep tour is noise.
+pub(crate) const ONBOARD_DEPTH_CAP: usize = 5;
+
 // ============ reranker pool sizing ============
 
 /// Default over-retrieval multiplier for the cross-encoder reranker.
@@ -282,6 +309,18 @@ mod tests {
 
         std::env::remove_var("CQS_RERANK_OVER_RETRIEVAL");
         std::env::remove_var("CQS_RERANK_POOL_MAX");
+    }
+
+    /// Pin the shared clamp ceilings. These values are duplicated at ~19
+    /// call sites via the constants; if a refactor changes one, this test
+    /// catches the drift before it ships a surface that clamps differently
+    /// from its siblings.
+    #[test]
+    fn limit_caps_have_expected_values() {
+        assert_eq!(GRAPH_LIMIT_CAP, 100);
+        assert_eq!(PLACEMENT_LIMIT_CAP, 10);
+        assert_eq!(IMPACT_DEPTH_CAP, 10);
+        assert_eq!(ONBOARD_DEPTH_CAP, 5);
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -31,7 +31,10 @@ pub use dispatch::run_with;
 
 // Shared clamp ceilings for commands that are dispatched from both
 // CLI and batch paths.
-pub(crate) use limits::{RELATED_LIMIT_MAX, SCOUT_LIMIT_MAX, SIMILAR_LIMIT_MAX};
+pub(crate) use limits::{
+    GRAPH_LIMIT_CAP, IMPACT_DEPTH_CAP, ONBOARD_DEPTH_CAP, PLACEMENT_LIMIT_CAP, RELATED_LIMIT_MAX,
+    SCOUT_LIMIT_MAX, SIMILAR_LIMIT_MAX,
+};
 
 // Re-export for watch.rs and commands
 pub(crate) use config::find_project_root;

--- a/src/store/backup.rs
+++ b/src/store/backup.rs
@@ -47,14 +47,39 @@ use super::helpers::StoreError;
 /// value (including unset) keeps the default hard-error behaviour.
 pub(crate) const REQUIRE_BACKUP_ENV: &str = "CQS_MIGRATE_REQUIRE_BACKUP";
 
-/// Number of version-tagged backups to retain in the DB's parent directory.
-/// The most recent `KEEP_BACKUPS` (by mtime) survive; older ones are pruned
-/// on every successful migrate.
+/// Default number of version-tagged backups to retain in the DB's parent
+/// directory. The most recent `keep_backups()` (by mtime) survive; older ones
+/// are pruned on every successful migrate.
 ///
 /// Value of 3 = the backup from the current migrate run + the two prior
 /// runs' backups. That gives the user two additional recovery points if a
 /// migration bug is discovered after a subsequent migrate has completed.
-pub(crate) const KEEP_BACKUPS: usize = 3;
+pub(crate) const KEEP_BACKUPS_DEFAULT: usize = 3;
+
+/// Resolve the backup-retention count honoring `CQS_MIGRATE_KEEP_BACKUPS`.
+///
+/// Unlike most size knobs, `0` is a valid override here — "prune every
+/// backup after a successful migrate" is a legitimate choice on tight-quota
+/// mounts (the just-written backup only guards the current run; once migrate
+/// commits it is no longer needed). So this resolver accepts `0` verbatim
+/// rather than treating it as "unset" the way `parse_env_usize` does.
+/// Missing / empty / unparseable falls back to [`KEEP_BACKUPS_DEFAULT`].
+pub(crate) fn keep_backups() -> usize {
+    match std::env::var("CQS_MIGRATE_KEEP_BACKUPS") {
+        Ok(v) => match v.parse::<usize>() {
+            Ok(n) => n,
+            Err(_) => {
+                tracing::warn!(
+                    env = "CQS_MIGRATE_KEEP_BACKUPS",
+                    value = %v,
+                    "Invalid env var (must be a non-negative usize), using default {KEEP_BACKUPS_DEFAULT}"
+                );
+                KEEP_BACKUPS_DEFAULT
+            }
+        },
+        Err(_) => KEEP_BACKUPS_DEFAULT,
+    }
+}
 
 /// Build the backup path for a given migration span.
 ///
@@ -261,7 +286,7 @@ pub(crate) fn restore_from_backup(db_path: &Path, backup_db: &Path) -> Result<()
 }
 
 /// Prune `*.bak-v*.db` files in the DB's parent directory, keeping the
-/// newest `KEEP_BACKUPS` by mtime. Logs each removal at `info!`.
+/// newest `keep_backups()` by mtime. Logs each removal at `info!`.
 ///
 /// The WAL/SHM sidecars (if any) for a pruned backup are removed too so the
 /// directory doesn't fill with orphan `.bak-v*.db-wal` files.
@@ -317,9 +342,9 @@ pub(crate) fn prune_old_backups(db_path: &Path) -> Result<(), StoreError> {
         candidates.push((path, mtime));
     }
 
-    // Sort newest-first. The newest KEEP_BACKUPS survive; the rest are pruned.
+    // Sort newest-first. The newest `keep_backups()` survive; the rest are pruned.
     candidates.sort_by_key(|c| std::cmp::Reverse(c.1));
-    for (path, _) in candidates.into_iter().skip(KEEP_BACKUPS) {
+    for (path, _) in candidates.into_iter().skip(keep_backups()) {
         if let Err(e) = std::fs::remove_file(&path) {
             tracing::warn!(
                 error = %e,
@@ -445,6 +470,23 @@ fn sidecar_path(db: &Path, ext: &str) -> PathBuf {
 mod tests {
     use super::*;
     use std::assert_matches;
+
+    /// `keep_backups()` returns the compiled default when unset, the env
+    /// value when set (including `0`, which is a valid "prune all" choice),
+    /// and the default on a garbage value.
+    #[test]
+    fn keep_backups_honors_env_including_zero() {
+        std::env::remove_var("CQS_MIGRATE_KEEP_BACKUPS");
+        assert_eq!(keep_backups(), KEEP_BACKUPS_DEFAULT);
+        std::env::set_var("CQS_MIGRATE_KEEP_BACKUPS", "7");
+        assert_eq!(keep_backups(), 7);
+        // Zero is honored verbatim, unlike the parse_env_usize "reject zero".
+        std::env::set_var("CQS_MIGRATE_KEEP_BACKUPS", "0");
+        assert_eq!(keep_backups(), 0);
+        std::env::set_var("CQS_MIGRATE_KEEP_BACKUPS", "garbage");
+        assert_eq!(keep_backups(), KEEP_BACKUPS_DEFAULT);
+        std::env::remove_var("CQS_MIGRATE_KEEP_BACKUPS");
+    }
 
     #[test]
     fn sidecar_path_appends_suffix_to_full_filename() {

--- a/src/store/chunks/query.rs
+++ b/src/store/chunks/query.rs
@@ -22,6 +22,14 @@ use crate::store::Store;
 /// kind classifier enough evidence to route a hot name.
 pub const LOOKUP_BY_NAME_LIMIT: usize = 100;
 
+/// Hard ceiling on the page size [`Store::chunks_paged`] accepts. The
+/// enrichment / doc-comment loops pass an operator-tunable page size
+/// (`CQS_ENRICHMENT_PAGE_SIZE`, default 500); this caps a pathological or
+/// hostile value so a single page can't materialize an unbounded row Vec.
+/// 10k rows × the per-`ChunkSummary` footprint stays comfortably bounded
+/// while leaving every realistic page size untouched.
+const CHUNKS_PAGED_MAX_LIMIT: usize = 10_000;
+
 /// SQL `CASE chunk_type ... END` expression ranking rows by routing
 /// priority for [`Store::lookup_by_name`]'s ORDER BY. Generated from
 /// `ChunkType::ALL` through `classify_chunk_type` + `routing_priority`,
@@ -648,6 +656,10 @@ impl<Mode> Store<Mode> {
         after_rowid: i64,
         limit: usize,
     ) -> Result<(Vec<ChunkSummary>, i64), StoreError> {
+        // Clamp the caller-supplied page size to a module ceiling so a
+        // pathological env-tuned page size can't materialize an unbounded
+        // row Vec in a single query.
+        let limit = limit.min(CHUNKS_PAGED_MAX_LIMIT);
         let _span = tracing::debug_span!("chunks_paged", after_rowid, limit).entered();
         self.rt.block_on(async {
             // rowid appended AFTER the pinned ChunkRow columns so the
@@ -836,6 +848,28 @@ mod tests {
         let (chunks, max_rowid) = store.chunks_paged(0, 10).unwrap();
         assert_eq!(chunks.len(), 3);
         assert!(max_rowid > 0);
+    }
+
+    /// An above-ceiling page size is clamped to `CHUNKS_PAGED_MAX_LIMIT`
+    /// before binding to SQL, but still returns every available row when
+    /// the table is smaller than the ceiling — the clamp guards the bind
+    /// against a pathological value without breaking correctness.
+    #[test]
+    fn test_chunks_paged_clamps_oversized_limit() {
+        assert_eq!(super::CHUNKS_PAGED_MAX_LIMIT, 10_000);
+        let (store, _dir) = setup_store();
+        let pairs: Vec<_> = (0..3)
+            .map(|i| {
+                let c = make_chunk(&format!("fn_{}", i), &format!("src/{}.rs", i));
+                (c, mock_embedding(i as f32))
+            })
+            .collect();
+        store.upsert_chunks_batch(&pairs, Some(100)).unwrap();
+
+        // Pass a limit far above the ceiling — the clamp applies but all 3
+        // rows still come back.
+        let (chunks, _max_rowid) = store.chunks_paged(0, usize::MAX).unwrap();
+        assert_eq!(chunks.len(), 3);
     }
 
     #[test]

--- a/src/store/migrations.rs
+++ b/src/store/migrations.rs
@@ -3003,7 +3003,7 @@ mod tests {
     }
 
     /// Prune policy: after a successful migrate, only the newest
-    /// `KEEP_BACKUPS` (2) backups survive. Older ones are deleted.
+    /// `keep_backups()` (default 3) backups survive. Older ones are deleted.
     ///
     /// Setup seeds 5 fake `.bak-v*.db` files with staggered mtimes so there
     /// is a deterministic ordering, runs migrate which creates a 6th (the
@@ -3057,7 +3057,7 @@ mod tests {
             let _pool = migrate(pool, &db_path, 19, 20).await.unwrap();
         });
 
-        // After migrate, the prune keeps KEEP_BACKUPS (2) newest. This run
+        // After migrate, the prune keeps keep_backups() (default 3) newest. This run
         // just produced a new backup (newer mtime than any fake), so the
         // survivors must be: the two newest fakes (v13-v14, v14-v15) +
         // this run's v19-v20. That is three files total.

--- a/src/store/sparse.rs
+++ b/src/store/sparse.rs
@@ -31,14 +31,29 @@ use crate::store::StoreError;
 
 use sqlx::Row;
 
-/// Number of distinct chunk_ids fetched per page by [`Store::load_all_sparse_vectors`].
+/// Default number of distinct chunk_ids fetched per page by
+/// [`Store::load_all_sparse_vectors`].
 ///
 /// Sized so the per-batch row Vec fits comfortably in a few MB even at the
 /// upper bound of tokens-per-chunk (~100-500). With 1000 chunks × 200 avg
 /// tokens/row × ~80B/row ≈ 16 MB per batch. An unpaginated single-query
 /// `fetch_all` could hit multiple GB on a large index. Larger values reduce
 /// round-trip count but cap the memory win.
-const LOAD_SPARSE_CHUNK_ID_BATCH: i64 = 1000;
+const LOAD_SPARSE_CHUNK_ID_BATCH_DEFAULT: i64 = 1000;
+
+/// Resolve the SPLADE load page size honoring `CQS_LOAD_SPARSE_BATCH`.
+/// Falls back to [`LOAD_SPARSE_CHUNK_ID_BATCH_DEFAULT`] when unset, empty,
+/// unparseable, or zero. Resolved as a `u64` (the page size is always
+/// positive) and narrowed to the `i64` the SQL `LIMIT` bind expects;
+/// `i64::MAX`-and-up clamps to `i64::MAX` so a pathological env value can't
+/// wrap negative.
+fn load_sparse_chunk_id_batch() -> i64 {
+    let n = crate::limits::parse_env_u64(
+        "CQS_LOAD_SPARSE_BATCH",
+        LOAD_SPARSE_CHUNK_ID_BATCH_DEFAULT as u64,
+    );
+    n.min(i64::MAX as u64) as i64
+}
 
 /// Bump the SPLADE generation counter inside an existing write transaction.
 ///
@@ -318,7 +333,7 @@ impl<Mode> Store<Mode> {
     /// Returns Vec of (chunk_id, sparse_vector).
     ///
     /// Paginates by chunk_id in batches of up to
-    /// [`LOAD_SPARSE_CHUNK_ID_BATCH`] distinct chunk_ids, using a cursor on
+    /// [`load_sparse_chunk_id_batch`] distinct chunk_ids, using a cursor on
     /// `chunk_id`. Each batch's rows are fully grouped before discarding
     /// the row Vec, so peak memory is bounded to one batch (~5-20 MB) plus
     /// the growing result. A single unpaginated `SELECT ... ORDER BY chunk_id`
@@ -327,6 +342,7 @@ impl<Mode> Store<Mode> {
     pub fn load_all_sparse_vectors(&self) -> Result<Vec<(String, SparseVector)>, StoreError> {
         let _span = tracing::info_span!("load_all_sparse_vectors").entered();
         self.rt.block_on(async {
+            let batch_size = load_sparse_chunk_id_batch();
             let mut result: Vec<(String, SparseVector)> = Vec::new();
             let mut total_entries: usize = 0;
             // Cursor: chunk_id ordering. Empty string sorts before any real id
@@ -335,7 +351,7 @@ impl<Mode> Store<Mode> {
             let mut last_chunk_id = String::new();
 
             loop {
-                // Fetch up to LOAD_SPARSE_CHUNK_ID_BATCH distinct chunk_ids
+                // Fetch up to `batch_size` distinct chunk_ids
                 // past the cursor, and all their rows, in one query. The
                 // subquery's LIMIT bounds the outer rows to one batch.
                 let rows: Vec<_> = sqlx::query(
@@ -349,7 +365,7 @@ impl<Mode> Store<Mode> {
                      ORDER BY chunk_id, token_id",
                 )
                 .bind(&last_chunk_id)
-                .bind(LOAD_SPARSE_CHUNK_ID_BATCH)
+                .bind(batch_size)
                 .fetch_all(&self.pool)
                 .await?;
 
@@ -418,7 +434,7 @@ impl<Mode> Store<Mode> {
                 // page budget, the next query would find nothing — skip
                 // the empty round-trip. Otherwise advance the cursor past
                 // the last-seen id and loop.
-                if distinct_ids_in_batch < LOAD_SPARSE_CHUNK_ID_BATCH {
+                if distinct_ids_in_batch < batch_size {
                     break;
                 }
                 last_chunk_id = last_id_in_batch;
@@ -560,6 +576,30 @@ impl<Mode> Store<Mode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `load_sparse_chunk_id_batch()` returns the compiled default when
+    /// unset, the env value when set, and clamps a pathological value to
+    /// `i64::MAX` rather than wrapping negative.
+    #[test]
+    fn load_sparse_batch_honors_env() {
+        std::env::remove_var("CQS_LOAD_SPARSE_BATCH");
+        assert_eq!(
+            load_sparse_chunk_id_batch(),
+            LOAD_SPARSE_CHUNK_ID_BATCH_DEFAULT
+        );
+        std::env::set_var("CQS_LOAD_SPARSE_BATCH", "256");
+        assert_eq!(load_sparse_chunk_id_batch(), 256);
+        // Garbage / zero falls back to default (parse_env_u64 rejects them).
+        std::env::set_var("CQS_LOAD_SPARSE_BATCH", "0");
+        assert_eq!(
+            load_sparse_chunk_id_batch(),
+            LOAD_SPARSE_CHUNK_ID_BATCH_DEFAULT
+        );
+        // Above-i64::MAX clamps, never wraps negative.
+        std::env::set_var("CQS_LOAD_SPARSE_BATCH", "18446744073709551615");
+        assert_eq!(load_sparse_chunk_id_batch(), i64::MAX);
+        std::env::remove_var("CQS_LOAD_SPARSE_BATCH");
+    }
 
     /// Insert a minimal valid `chunks` row so a sparse_vectors insert can
     /// satisfy the v19 FK constraint. Pattern mirrored from


### PR DESCRIPTION
## feat(limits): named caps replace clamp literals; daemon/backup/sparse knobs (CF SHL sweep)

Closes SHL-V1.40-2/4/5/7/8/10 + the #1746-review residual clamp literals + the #1459-item-8 evaluation.

- Named caps: `GRAPH_LIMIT_CAP=100` (all result-list `clamp(1,100)` sites across graph/batch/search-seed surfaces — shared value AND semantic), `PLACEMENT_LIMIT_CAP=10`, `IMPACT_DEPTH_CAP=10` and `ONBOARD_DEPTH_CAP=5` kept separate (depth is not a result-count semantic). Value-pinning test added.
- New env knobs, defaults unchanged, warn-on-invalid via `cqs::limits`, README rows gated by env_var_docs: `CQS_BATCH_STALENESS_CHECK_MS` (100), `CQS_BATCH_AUDIT_RELOAD_SECS` (30), `CQS_BATCH_CONFIG_RELOAD_SECS` (300), `CQS_MIGRATE_KEEP_BACKUPS` (3 — custom parse accepts 0 = prune all), `CQS_LOAD_SPARSE_BATCH` (1000, i64-clamped for the SQL bind).
- `chunks_paged` gains a 10k module ceiling with min-clamp before bind.
- Blame `-n/--commits` default-10 verdict: deliberate, distinct semantic (commits shown, not result limit) — documented with one comment, no change.

5 new unit tests + regression suites green; fmt + clippy `--all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
