### PR TITLE
fix(pipeline): stamp fingerprints on file-complete; zero-chunk files prune (closes #1755)

### DIFF
--- a/src/cli/pipeline/embedding.rs
+++ b/src/cli/pipeline/embedding.rs
@@ -114,6 +114,7 @@ pub(super) fn prepare_for_embedding(
         texts,
         relationships: batch.relationships,
         file_fingerprints: batch.file_fingerprints,
+        empty_file_fingerprints: batch.empty_file_fingerprints,
     }
 }
 
@@ -124,6 +125,7 @@ pub(super) fn create_embedded_batch(
     new_embeddings: Vec<Embedding>,
     relationships: RelationshipData,
     file_fingerprints: HashMap<std::path::PathBuf, cqs::store::FileFingerprint>,
+    empty_file_fingerprints: HashMap<std::path::PathBuf, cqs::store::FileFingerprint>,
 ) -> EmbeddedBatch {
     let cached_count = cached.len();
     let mut chunk_embeddings = cached;
@@ -133,6 +135,7 @@ pub(super) fn create_embedded_batch(
         relationships,
         cached_count,
         file_fingerprints,
+        empty_file_fingerprints,
         // Default: real embeddings throughout. The skip-first-pass path
         // builds EmbeddedBatch directly with `uncached_need_embedding: true`
         // (see `gpu_embed_stage` / `cpu_embed_stage`).
@@ -151,21 +154,45 @@ fn flush_to_cpu(
     fail_tx: &Sender<ParsedBatch>,
     embedded_count: &AtomicUsize,
 ) -> bool {
+    // The cached half lands in the store FIRST (sent straight to `embed_tx`);
+    // the requeued half lands LATER (CPU re-embed → `embed_tx`). A file whose
+    // last chunk arrived in this `ParsedBatch` carries its fingerprint here —
+    // but if that file ALSO has chunks in the requeued half, stamping it with
+    // the cached (earlier) half would mark it current before its requeued
+    // chunks were written. So the cached half drops fingerprints for any file
+    // present in `to_embed`; the requeued half keeps the full set. This holds
+    // the fingerprint-strictly-after-data invariant across the GPU split.
+    let requeued_files: std::collections::HashSet<&std::path::PathBuf> =
+        prepared.to_embed.iter().map(|c| &c.file).collect();
+    let cached_fps: HashMap<std::path::PathBuf, cqs::store::FileFingerprint> = prepared
+        .file_fingerprints
+        .iter()
+        .filter(|(file, _)| !requeued_files.contains(file))
+        .map(|(file, fp)| (file.clone(), fp.clone()))
+        .collect();
+
     if !prepared.cached.is_empty() {
         let cached_count = prepared.cached.len();
         embedded_count.fetch_add(cached_count, Ordering::Relaxed);
-        // Send relationships with cached batch only if there's nothing to requeue
-        let rels = if prepared.to_embed.is_empty() {
-            prepared.relationships.clone()
+        // Send relationships with cached batch only if there's nothing to
+        // requeue. Empty-file prune entries ride with the requeued half when
+        // it exists (they reference no chunks, so ordering is irrelevant; we
+        // only avoid duplicating them).
+        let (rels, empty_fps) = if prepared.to_embed.is_empty() {
+            (
+                prepared.relationships.clone(),
+                prepared.empty_file_fingerprints.clone(),
+            )
         } else {
-            RelationshipData::default()
+            (RelationshipData::default(), HashMap::new())
         };
         if embed_tx
             .send(EmbeddedBatch {
                 chunk_embeddings: prepared.cached,
                 relationships: rels,
                 cached_count,
-                file_fingerprints: prepared.file_fingerprints.clone(),
+                file_fingerprints: cached_fps,
+                empty_file_fingerprints: empty_fps,
                 uncached_need_embedding: false,
             })
             .is_err()
@@ -173,17 +200,20 @@ fn flush_to_cpu(
             return false;
         }
     }
-    // Send relationships with the requeued batch so they reach store_stage via CPU path
-    let rels = if prepared.to_embed.is_empty() {
-        RelationshipData::default()
+    // Send relationships + empty-file prune entries with the requeued batch so
+    // they reach store_stage via the CPU path. This half keeps the full
+    // fingerprint set (it lands last, after every requeued chunk is written).
+    let (rels, empty_fps) = if prepared.to_embed.is_empty() {
+        (RelationshipData::default(), HashMap::new())
     } else {
-        prepared.relationships
+        (prepared.relationships, prepared.empty_file_fingerprints)
     };
     if fail_tx
         .send(ParsedBatch {
             chunks: prepared.to_embed,
             relationships: rels,
             file_fingerprints: prepared.file_fingerprints,
+            empty_file_fingerprints: empty_fps,
         })
         .is_err()
     {
@@ -236,6 +266,7 @@ pub(super) fn gpu_embed_stage(
                     relationships: prepared.relationships,
                     cached_count,
                     file_fingerprints: prepared.file_fingerprints,
+                    empty_file_fingerprints: prepared.empty_file_fingerprints,
                     uncached_need_embedding: false,
                 })
                 .is_err()
@@ -273,6 +304,7 @@ pub(super) fn gpu_embed_stage(
                     relationships: prepared.relationships,
                     cached_count,
                     file_fingerprints: prepared.file_fingerprints,
+                    empty_file_fingerprints: prepared.empty_file_fingerprints,
                     uncached_need_embedding: true,
                 })
                 .is_err()
@@ -361,6 +393,7 @@ pub(super) fn gpu_embed_stage(
                         relationships: prepared.relationships,
                         cached_count,
                         file_fingerprints: prepared.file_fingerprints,
+                        empty_file_fingerprints: prepared.empty_file_fingerprints,
                         uncached_need_embedding: false,
                     })
                     .is_err()
@@ -510,6 +543,7 @@ pub(super) fn cpu_embed_stage(
                     relationships: prepared.relationships,
                     cached_count,
                     file_fingerprints: prepared.file_fingerprints,
+                    empty_file_fingerprints: prepared.empty_file_fingerprints,
                     uncached_need_embedding: true,
                 })
                 .is_err()
@@ -564,6 +598,7 @@ pub(super) fn cpu_embed_stage(
             new_embeddings,
             prepared.relationships,
             prepared.file_fingerprints,
+            prepared.empty_file_fingerprints,
         );
 
         ctx.embedded_count
@@ -575,4 +610,140 @@ pub(super) fn cpu_embed_stage(
     }
     tracing::debug!("CPU embedder thread finished");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossbeam_channel::unbounded;
+
+    fn chunk(file: &str, id: &str) -> Chunk {
+        Chunk {
+            id: format!("{file}:1:{id}"),
+            file: std::path::PathBuf::from(file),
+            language: cqs::language::Language::Rust,
+            chunk_type: cqs::language::ChunkType::Function,
+            name: id.to_string(),
+            signature: String::new(),
+            content: format!("fn {id}() {{}}"),
+            doc: None,
+            line_start: 1,
+            line_end: 1,
+            content_hash: blake3::hash(id.as_bytes()).to_hex().to_string(),
+            canonical_hash: String::new(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        }
+    }
+
+    fn fp() -> cqs::store::FileFingerprint {
+        cqs::store::FileFingerprint {
+            mtime: Some(1),
+            size: Some(2),
+            content_hash: Some([7u8; 32]),
+        }
+    }
+
+    /// GPU-failure split: a file straddling the cached/requeued boundary must
+    /// keep its fingerprint with the REQUEUED half (which lands in the store
+    /// LAST, after CPU re-embed). The cached half — committed first — drops
+    /// fingerprints for any file present in `to_embed`, so a crash between the
+    /// two commits never leaves the straddling file stamped-but-incomplete.
+    /// A file fully inside the cached half keeps its fingerprint there.
+    #[test]
+    fn flush_to_cpu_keeps_straddling_fingerprint_with_requeued_half() {
+        // straddle.rs: one chunk cached, one chunk requeued (split file).
+        // done.rs: both chunks cached (complete in the cached half).
+        let cached = vec![
+            (chunk("straddle.rs", "a"), Embedding::new(vec![0.1; 4])),
+            (chunk("done.rs", "x"), Embedding::new(vec![0.1; 4])),
+            (chunk("done.rs", "y"), Embedding::new(vec![0.1; 4])),
+        ];
+        let to_embed = vec![chunk("straddle.rs", "b")];
+        let mut file_fingerprints = HashMap::new();
+        file_fingerprints.insert(std::path::PathBuf::from("straddle.rs"), fp());
+        file_fingerprints.insert(std::path::PathBuf::from("done.rs"), fp());
+
+        let prepared = PreparedEmbedding {
+            cached,
+            to_embed,
+            texts: vec![String::new()],
+            relationships: RelationshipData::default(),
+            file_fingerprints,
+            empty_file_fingerprints: HashMap::new(),
+        };
+
+        let (embed_tx, embed_rx) = unbounded::<EmbeddedBatch>();
+        let (fail_tx, fail_rx) = unbounded::<ParsedBatch>();
+        let counter = AtomicUsize::new(0);
+        assert!(flush_to_cpu(prepared, &embed_tx, &fail_tx, &counter));
+        drop(embed_tx);
+        drop(fail_tx);
+
+        let cached_batch = embed_rx.recv().expect("cached half sent");
+        let requeued = fail_rx.recv().expect("requeued half sent");
+
+        // Cached half: keeps done.rs (complete here), drops straddle.rs.
+        assert!(
+            cached_batch
+                .file_fingerprints
+                .contains_key(&std::path::PathBuf::from("done.rs")),
+            "cached half must stamp the file fully contained in it"
+        );
+        assert!(
+            !cached_batch
+                .file_fingerprints
+                .contains_key(&std::path::PathBuf::from("straddle.rs")),
+            "cached half must NOT stamp a file with chunks in the requeued half"
+        );
+
+        // Requeued half: keeps the straddling file's fingerprint (lands last).
+        assert!(
+            requeued
+                .file_fingerprints
+                .contains_key(&std::path::PathBuf::from("straddle.rs")),
+            "requeued half must carry the straddling file's fingerprint"
+        );
+    }
+
+    /// Empty-file prune entries ride with the requeued half (when one exists)
+    /// and are not duplicated onto the cached half.
+    #[test]
+    fn flush_to_cpu_routes_empty_files_to_requeued_half() {
+        let cached = vec![(chunk("a.rs", "a"), Embedding::new(vec![0.1; 4]))];
+        let to_embed = vec![chunk("b.rs", "b")];
+        let mut empties = HashMap::new();
+        empties.insert(std::path::PathBuf::from("gone.rs"), fp());
+
+        let prepared = PreparedEmbedding {
+            cached,
+            to_embed,
+            texts: vec![String::new()],
+            relationships: RelationshipData::default(),
+            file_fingerprints: HashMap::new(),
+            empty_file_fingerprints: empties,
+        };
+
+        let (embed_tx, embed_rx) = unbounded::<EmbeddedBatch>();
+        let (fail_tx, fail_rx) = unbounded::<ParsedBatch>();
+        let counter = AtomicUsize::new(0);
+        assert!(flush_to_cpu(prepared, &embed_tx, &fail_tx, &counter));
+        drop(embed_tx);
+        drop(fail_tx);
+
+        let cached_batch = embed_rx.recv().expect("cached half sent");
+        let requeued = fail_rx.recv().expect("requeued half sent");
+        assert!(
+            cached_batch.empty_file_fingerprints.is_empty(),
+            "cached half must not carry empty-file entries when a requeued half exists"
+        );
+        assert!(
+            requeued
+                .empty_file_fingerprints
+                .contains_key(&std::path::PathBuf::from("gone.rs")),
+            "requeued half must carry the empty-file prune entry"
+        );
+    }
 }

--- a/src/cli/pipeline/mod.rs
+++ b/src/cli/pipeline/mod.rs
@@ -307,6 +307,7 @@ mod tests {
             vec![],
             RelationshipData::default(),
             test_fps(12345),
+            std::collections::HashMap::new(),
         );
         assert_eq!(batch.chunk_embeddings.len(), 1);
         assert_eq!(batch.cached_count, 1);
@@ -327,6 +328,7 @@ mod tests {
             vec![emb],
             RelationshipData::default(),
             test_fps(99),
+            std::collections::HashMap::new(),
         );
         assert_eq!(batch.chunk_embeddings.len(), 1);
         assert_eq!(batch.cached_count, 0);
@@ -349,6 +351,7 @@ mod tests {
             vec![new_emb],
             RelationshipData::default(),
             test_fps(12345),
+            std::collections::HashMap::new(),
         );
         assert_eq!(batch.chunk_embeddings.len(), 2);
         assert_eq!(batch.cached_count, 1);
@@ -361,6 +364,7 @@ mod tests {
             vec![],
             vec![],
             RelationshipData::default(),
+            std::collections::HashMap::new(),
             std::collections::HashMap::new(),
         );
         assert_eq!(batch.chunk_embeddings.len(), 0);
@@ -382,6 +386,7 @@ mod tests {
             vec![e2, e3],
             RelationshipData::default(),
             test_fps(0),
+            std::collections::HashMap::new(),
         );
 
         assert_eq!(batch.chunk_embeddings.len(), 3);
@@ -585,6 +590,7 @@ mod tests {
             chunks: vec![chunk],
             relationships: super::types::RelationshipData::default(),
             file_fingerprints,
+            empty_file_fingerprints: std::collections::HashMap::new(),
         }
     }
 
@@ -728,6 +734,7 @@ mod tests {
             chunks: vec![],
             relationships: super::types::RelationshipData::default(),
             file_fingerprints: std::collections::HashMap::new(),
+            empty_file_fingerprints: std::collections::HashMap::new(),
         };
 
         let prepared = prepare_for_embedding(batch, &embedder, &store, None, None);

--- a/src/cli/pipeline/parsing.rs
+++ b/src/cli/pipeline/parsing.rs
@@ -325,44 +325,93 @@ pub(super) fn parser_stage(
 
         parsed_count.fetch_add(file_batch.len(), Ordering::Relaxed);
 
-        if !chunks.is_empty() {
-            // Send in embedding-sized batches with per-file fingerprints and relationships.
-            // Relationships are sent with the first batch only. Per-file data
-            // (function_calls, type_refs) is safe. Per-chunk data (chunk_calls,
-            // type_edges) is deferred in store_stage until all chunks are committed.
-            //
-            // Drain owned chunks into each batch instead of
-            // `chunks.chunks(n)` + `.to_vec()`, which would clone every Chunk
-            // (deep copy of id/file/signature/content/content_hash/...).
-            // We own `chunks` here and never reuse it after this loop, so
-            // moving each window out is safe and saves one full Chunk copy
-            // per indexed chunk per batch.
-            let mut remaining_rels = Some(batch_rels);
-            let mut chunks = chunks;
-            while !chunks.is_empty() {
-                let take = batch_size.min(chunks.len());
-                // Compute fingerprints from a borrow first; `drain` below
-                // will move the same chunks out, so we can't borrow after
-                // that.
-                let batch_fps: std::collections::HashMap<PathBuf, FileFingerprint> = chunks[..take]
-                    .iter()
-                    .filter_map(|c| {
-                        file_fingerprints
-                            .get(&c.file)
-                            .map(|fp| (c.file.clone(), fp.clone()))
-                    })
-                    .collect();
-                let batch: Vec<cqs::Chunk> = chunks.drain(..take).collect();
-                if parse_tx
+        // Files that survived the pre-filter (previously indexed, now
+        // divergent) but produced zero chunks this run: their stale chunks
+        // must be pruned. Count how many chunks each file contributes so the
+        // drain loop below can stamp a file's fingerprint only in the batch
+        // carrying its LAST chunk, and so we can tell which survivors are
+        // empty. A file with a parse ERROR is excluded — it has no
+        // fingerprint-or-zero-chunk entry here, so its old chunks are left
+        // untouched (the next run retries the parse).
+        let mut remaining_per_file: std::collections::HashMap<PathBuf, usize> =
+            std::collections::HashMap::with_capacity(file_fingerprints.len());
+        for c in &chunks {
+            *remaining_per_file.entry(c.file.clone()).or_insert(0) += 1;
+        }
+        let empty_file_fingerprints: std::collections::HashMap<PathBuf, FileFingerprint> =
+            file_fingerprints
+                .iter()
+                .filter(|(rel, _)| !remaining_per_file.contains_key(*rel))
+                .map(|(rel, fp)| (rel.clone(), fp.clone()))
+                .collect();
+
+        if chunks.is_empty() {
+            // No chunks at all in this file batch, but some survivors may have
+            // gone to zero chunks — send a chunk-less batch so the store stage
+            // prunes their stale rows. Skip the send when there is nothing to
+            // prune (e.g. every survivor was a parse error).
+            if !empty_file_fingerprints.is_empty()
+                && parse_tx
                     .send(ParsedBatch {
-                        chunks: batch,
-                        relationships: remaining_rels.take().unwrap_or_default(),
-                        file_fingerprints: batch_fps,
+                        chunks: Vec::new(),
+                        relationships: batch_rels,
+                        file_fingerprints: std::collections::HashMap::new(),
+                        empty_file_fingerprints,
                     })
                     .is_err()
-                {
-                    break; // Receiver dropped
+            {
+                break; // Receiver dropped
+            }
+            continue;
+        }
+
+        // Send in embedding-sized batches. Relationships ride with the first
+        // batch only; per-chunk data (chunk_calls, type_edges) is deferred in
+        // store_stage until all chunks are committed.
+        //
+        // A file's fingerprint is stamped ONLY in the batch carrying its last
+        // chunk (`remaining_per_file` hits zero), so the stamp lands strictly
+        // after every one of the file's chunks has been written — a crash
+        // between two of a file's batch commits leaves it unstamped and the
+        // next run's pre-filter reclassifies it STALE. The empty-file prune
+        // set rides with the first batch (it references no chunks, so ordering
+        // against chunk writes is irrelevant).
+        //
+        // Drain owned chunks into each batch instead of `chunks.chunks(n)` +
+        // `.to_vec()`, which would clone every Chunk. We own `chunks` here and
+        // never reuse it after this loop, so moving each window out is safe.
+        let mut remaining_rels = Some(batch_rels);
+        let mut remaining_empties = Some(empty_file_fingerprints);
+        let mut chunks = chunks;
+        while !chunks.is_empty() {
+            let take = batch_size.min(chunks.len());
+            // Compute the per-batch fingerprint stamp set from a borrow first;
+            // `drain` below moves the same chunks out. Decrement each file's
+            // remaining count as its chunks leave; a file whose count reaches
+            // zero in this window has delivered its last chunk, so stamp it.
+            let mut batch_fps: std::collections::HashMap<PathBuf, FileFingerprint> =
+                std::collections::HashMap::new();
+            for c in &chunks[..take] {
+                if let Some(remaining) = remaining_per_file.get_mut(&c.file) {
+                    *remaining -= 1;
+                    if *remaining == 0 {
+                        if let Some(fp) = file_fingerprints.get(&c.file) {
+                            batch_fps.insert(c.file.clone(), fp.clone());
+                        }
+                    }
                 }
+            }
+            let batch: Vec<cqs::Chunk> = chunks.drain(..take).collect();
+            if parse_tx
+                .send(ParsedBatch {
+                    chunks: batch,
+                    relationships: remaining_rels.take().unwrap_or_default(),
+                    file_fingerprints: batch_fps,
+                    empty_file_fingerprints: remaining_empties.take().unwrap_or_default(),
+                })
+                .is_err()
+            {
+                break; // Receiver dropped
             }
         }
     }
@@ -603,22 +652,162 @@ mod tests {
             "divergent file must be parsed, got {parsed_files:?}"
         );
 
-        // Every parsed file ships a fully-populated fingerprint for the
-        // store stage to stamp.
+        // Every parsed file ships a fully-populated fingerprint exactly once,
+        // in the batch carrying its last chunk (file-complete stamping). The
+        // union across batches must cover every parsed file.
+        let mut stamped: HashMap<PathBuf, FileFingerprint> = HashMap::new();
         for b in &batches {
-            for c in &b.chunks {
-                let fp = b
-                    .file_fingerprints
-                    .get(&c.file)
-                    .unwrap_or_else(|| panic!("missing fingerprint for {:?}", c.file));
-                assert!(fp.mtime.is_some(), "{:?} fingerprint needs mtime", c.file);
-                assert!(fp.size.is_some(), "{:?} fingerprint needs size", c.file);
+            for (file, fp) in &b.file_fingerprints {
                 assert!(
-                    fp.content_hash.is_some(),
-                    "{:?} fingerprint needs content hash",
-                    c.file
+                    stamped.insert(file.clone(), fp.clone()).is_none(),
+                    "fingerprint for {file:?} stamped in more than one batch"
                 );
             }
         }
+        for file in &parsed_files {
+            let fp = stamped
+                .get(file)
+                .unwrap_or_else(|| panic!("missing fingerprint for {file:?}"));
+            assert!(fp.mtime.is_some(), "{file:?} fingerprint needs mtime");
+            assert!(fp.size.is_some(), "{file:?} fingerprint needs size");
+            assert!(
+                fp.content_hash.is_some(),
+                "{file:?} fingerprint needs content hash"
+            );
+        }
+    }
+
+    /// File-complete fingerprint stamping: a file whose chunks straddle two
+    /// embed batches has its fingerprint stamped ONLY in the batch carrying
+    /// its last chunk — never the earlier batch. Pins the crash-safety
+    /// invariant: the fingerprint lands strictly after all of the file's
+    /// chunks, so a crash between the two batch commits leaves the file
+    /// unstamped (and therefore STALE on the next run) rather than current.
+    #[test]
+    fn parser_stage_stamps_fingerprint_only_on_last_chunk_batch() {
+        let _lock = super::super::types::TEST_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+
+        // One file with >64 functions so its chunks span at least two
+        // `embed_batch_size`-bounded batches.
+        let mut big = String::new();
+        for i in 0..70 {
+            use std::fmt::Write as _;
+            writeln!(&mut big, "pub fn straddle_{i}() {{}}").unwrap();
+        }
+        std::fs::write(root.join("straddle.rs"), &big).unwrap();
+
+        let db_path = root.join("index.db");
+        let store = Arc::new(Store::open(&db_path).unwrap());
+        store.init(&cqs::store::ModelInfo::default()).unwrap();
+        let parser = Arc::new(CqParser::new().unwrap());
+
+        let (tx, rx) = unbounded::<ParsedBatch>();
+        let ctx = ParserStageContext {
+            root: root.clone(),
+            force: true,
+            parser,
+            store,
+            parsed_count: Arc::new(AtomicUsize::new(0)),
+            parse_errors: Arc::new(AtomicUsize::new(0)),
+            model_config: cqs::embedder::ModelConfig::resolve(None, None),
+        };
+        parser_stage(vec![PathBuf::from("straddle.rs")], ctx, tx).unwrap();
+
+        let batches: Vec<ParsedBatch> = rx.try_iter().collect();
+        assert!(
+            batches.len() >= 2,
+            "fixture must straddle batches, got {}",
+            batches.len()
+        );
+        let straddle = PathBuf::from("straddle.rs");
+
+        // Fingerprint absent from every batch BEFORE the last, present in the
+        // final batch — and stamped exactly once overall.
+        let (last_idx, _) = batches
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, b)| !b.chunks.is_empty())
+            .expect("at least one non-empty batch");
+        let mut stamp_count = 0;
+        for (i, b) in batches.iter().enumerate() {
+            if b.file_fingerprints.contains_key(&straddle) {
+                stamp_count += 1;
+                assert_eq!(
+                    i, last_idx,
+                    "fingerprint stamped on batch {i}, expected only the last batch {last_idx}"
+                );
+            }
+        }
+        assert_eq!(stamp_count, 1, "fingerprint must be stamped exactly once");
+        assert!(
+            batches[last_idx].file_fingerprints.contains_key(&straddle),
+            "last batch must carry the fingerprint"
+        );
+    }
+
+    /// A previously-indexed file that now parses to ZERO chunks rides the
+    /// pipeline as an `empty_file_fingerprints` entry (not a chunk batch) so
+    /// the store stage can prune its stale chunks. Forces the all-empty
+    /// file-batch path: the only survivor produces no chunks, so a chunk-less
+    /// `ParsedBatch` must still be emitted carrying the empty-file entry.
+    #[test]
+    fn parser_stage_routes_zero_chunk_file_to_empty_set() {
+        let _lock = super::super::types::TEST_ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        // A Rust file with only comments parses to zero chunks.
+        std::fs::write(root.join("empty.rs"), "// just a comment, no items\n").unwrap();
+
+        let db_path = root.join("index.db");
+        let store = Arc::new(Store::open(&db_path).unwrap());
+        store.init(&cqs::store::ModelInfo::default()).unwrap();
+        let parser = Arc::new(CqParser::new().unwrap());
+
+        // Confirm the fixture really parses to zero chunks; otherwise the test
+        // would silently exercise the wrong path.
+        let direct = parser.parse_file_all(&root.join("empty.rs")).unwrap().0;
+        assert!(
+            direct.is_empty(),
+            "fixture must parse to zero chunks, got {}",
+            direct.len()
+        );
+
+        let (tx, rx) = unbounded::<ParsedBatch>();
+        let ctx = ParserStageContext {
+            root: root.clone(),
+            force: true, // survivor regardless of stored state
+            parser,
+            store,
+            parsed_count: Arc::new(AtomicUsize::new(0)),
+            parse_errors: Arc::new(AtomicUsize::new(0)),
+            model_config: cqs::embedder::ModelConfig::resolve(None, None),
+        };
+        parser_stage(vec![PathBuf::from("empty.rs")], ctx, tx).unwrap();
+
+        let batches: Vec<ParsedBatch> = rx.try_iter().collect();
+        let empty = PathBuf::from("empty.rs");
+        let carries_empty = batches
+            .iter()
+            .any(|b| b.empty_file_fingerprints.contains_key(&empty));
+        assert!(
+            carries_empty,
+            "zero-chunk survivor must ride as an empty_file_fingerprints entry"
+        );
+        // It must NOT appear as a chunk-bearing fingerprint anywhere.
+        assert!(
+            batches
+                .iter()
+                .all(|b| !b.file_fingerprints.contains_key(&empty)),
+            "zero-chunk file must not be stamped via the chunk path"
+        );
     }
 }

--- a/src/cli/pipeline/types.rs
+++ b/src/cli/pipeline/types.rs
@@ -25,19 +25,36 @@ pub(super) struct RelationshipData {
 pub(super) struct ParsedBatch {
     pub chunks: Vec<Chunk>,
     pub relationships: RelationshipData,
-    /// Disk fingerprint (mtime + size + BLAKE3) per file in this batch,
-    /// read by the parser stage's staleness pre-filter. The store stage
-    /// stamps these onto the chunk rows in the same transaction as the
-    /// upsert so the reconcile path always sees a populated fingerprint.
+    /// Disk fingerprint (mtime + size + BLAKE3) for the files whose **last**
+    /// chunk rides in this batch. A file's chunks can straddle batches (the
+    /// parser drain loop slices at `embed_batch_size`, and a GPU failure
+    /// re-splits a batch into a cached half and a requeued half). Stamping a
+    /// file's fingerprint only when its final chunk lands keeps the stamp
+    /// strictly *after* every one of the file's chunks has been written, so a
+    /// crash between two of a file's batch commits leaves the file unstamped
+    /// and the staleness pre-filter reclassifies it STALE on the next run
+    /// rather than skipping a half-indexed file permanently.
     pub file_fingerprints: HashMap<PathBuf, FileFingerprint>,
+    /// Files that survived the staleness pre-filter (so they *were* indexed
+    /// before and diverged) but parsed to **zero** chunks this run — e.g. a
+    /// source file whose code was deleted leaving only comments. They carry no
+    /// chunks, so they never appear in `chunks`/`file_fingerprints`; the store
+    /// stage includes them in the phantom-prune pass with an empty live set so
+    /// their stale chunks are removed instead of surviving forever.
+    pub empty_file_fingerprints: HashMap<PathBuf, FileFingerprint>,
 }
 
 pub(super) struct EmbeddedBatch {
     pub chunk_embeddings: Vec<(Chunk, Embedding)>,
     pub relationships: RelationshipData,
     pub cached_count: usize,
-    /// Per-file disk fingerprints, threaded through from `ParsedBatch`.
+    /// Per-file disk fingerprints, threaded through from `ParsedBatch`. Only
+    /// the files whose **last** chunk is in this batch are present — see
+    /// `ParsedBatch::file_fingerprints`.
     pub file_fingerprints: HashMap<PathBuf, FileFingerprint>,
+    /// Zero-chunk files threaded through from `ParsedBatch` — the store stage
+    /// prunes their stale chunks. See `ParsedBatch::empty_file_fingerprints`.
+    pub empty_file_fingerprints: HashMap<PathBuf, FileFingerprint>,
     /// When `true`, the chunks past index `cached_count` carry
     /// **zero-vec sentinel embeddings** and must be routed to
     /// `upsert_embedded_batch`'s sentinel argument so they're stamped with
@@ -74,8 +91,12 @@ pub(super) struct PreparedEmbedding {
     pub texts: Vec<String>,
     /// Relationships extracted during parsing
     pub relationships: RelationshipData,
-    /// Per-file disk fingerprints (mtime + size + BLAKE3)
+    /// Per-file disk fingerprints (mtime + size + BLAKE3) for files whose last
+    /// chunk is in this batch — see `ParsedBatch::file_fingerprints`.
     pub file_fingerprints: HashMap<PathBuf, FileFingerprint>,
+    /// Zero-chunk files threaded through for the store stage's phantom prune —
+    /// see `ParsedBatch::empty_file_fingerprints`.
+    pub empty_file_fingerprints: HashMap<PathBuf, FileFingerprint>,
 }
 
 /// Shared configuration for GPU and CPU embedding stages.

--- a/src/cli/pipeline/upsert.rs
+++ b/src/cli/pipeline/upsert.rs
@@ -119,12 +119,27 @@ pub(super) fn store_stage(
     // `upsert_chunks_calls_and_prune`; this keeps the full reindex pipeline
     // in line.
     let mut live_ids_per_file: HashMap<PathBuf, HashSet<String>> = HashMap::new();
+    // Files that survived the staleness pre-filter but parsed to zero chunks
+    // this run: their stale chunks must be pruned (empty live set) so they
+    // don't survive forever and re-classify the file STALE every run. Stored
+    // separately from `live_ids_per_file` so a file that DID produce chunks in
+    // one batch isn't clobbered into an empty live set by a stray empty entry.
+    let mut empty_file_fingerprints: HashMap<PathBuf, cqs::store::FileFingerprint> = HashMap::new();
     let mut batch_counter: usize = 0;
     let flush_interval = deferred_flush_interval();
 
     for batch in embed_rx {
         if check_interrupted() {
             break;
+        }
+
+        // Stash zero-chunk files for the post-loop prune. A later batch may
+        // still carry chunks for the same origin (a file straddling batches
+        // where only a later half is empty cannot happen — empties have no
+        // chunks anywhere — but guard anyway): the post-loop pass skips any
+        // origin that also appears in `live_ids_per_file`.
+        for (file, fp) in batch.empty_file_fingerprints {
+            empty_file_fingerprints.entry(file).or_insert(fp);
         }
 
         // Use pre-extracted chunk calls from the parse stage (rayon parallel)
@@ -244,7 +259,22 @@ pub(super) fn store_stage(
     // One transaction for the whole sweep — the per-file variant opened a
     // BEGIN/COMMIT per origin, thousands of round-trips of pure overhead
     // on a full reindex.
-    let prune_entries: Vec<(&std::path::Path, Vec<&str>)> = live_ids_per_file
+    //
+    // Zero-chunk files (survived the pre-filter, parsed to nothing this run)
+    // are pruned with an EMPTY live set: `delete_phantom_chunks_batch` deletes
+    // every chunk for an origin whose live set is empty. Without this their
+    // old chunks survive the prune (the loop above never saw them, so they
+    // have no `live_ids_per_file` entry) and keep returning stale search hits
+    // forever. Skip any origin that DID produce chunks this run — that file is
+    // handled by its real live set.
+    //
+    // The fingerprint lives only on chunk rows, so once an origin is pruned to
+    // zero rows there is nowhere to stamp it: the next run's pre-filter sees no
+    // rows, treats the file as un-indexed, and re-parses it — to zero chunks
+    // again, a cheap idempotent no-op (no embed, no writes). That is the
+    // correct steady state; the load-bearing fix is that the file's stale
+    // chunks no longer pollute search.
+    let mut prune_entries: Vec<(&std::path::Path, Vec<&str>)> = live_ids_per_file
         .iter()
         .map(|(file, live_ids)| {
             (
@@ -253,6 +283,11 @@ pub(super) fn store_stage(
             )
         })
         .collect();
+    for file in empty_file_fingerprints.keys() {
+        if !live_ids_per_file.contains_key(file) {
+            prune_entries.push((file.as_path(), Vec::new()));
+        }
+    }
     match store.delete_phantom_chunks_batch(&prune_entries) {
         Ok(deleted) if deleted > 0 => {
             tracing::info!(
@@ -303,4 +338,230 @@ pub(super) fn store_stage(
     }
 
     Ok((total_embedded, total_cached, total_type_edges, total_calls))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossbeam_channel::unbounded;
+
+    use super::super::types::RelationshipData;
+    use cqs::store::{FileFingerprint, ModelInfo};
+
+    fn chunk(file: &str, id_suffix: &str, body: &str) -> Chunk {
+        Chunk {
+            id: format!("{file}:1:{id_suffix}"),
+            file: PathBuf::from(file),
+            language: cqs::language::Language::Rust,
+            chunk_type: cqs::language::ChunkType::Function,
+            name: id_suffix.to_string(),
+            signature: format!("pub fn {id_suffix}()"),
+            content: body.to_string(),
+            doc: None,
+            line_start: 1,
+            line_end: 1,
+            content_hash: blake3::hash(body.as_bytes()).to_hex().to_string(),
+            canonical_hash: String::new(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        }
+    }
+
+    fn full_fp(content: &[u8]) -> FileFingerprint {
+        FileFingerprint {
+            mtime: Some(123_456),
+            size: Some(content.len() as u64),
+            content_hash: Some(*blake3::hash(content).as_bytes()),
+        }
+    }
+
+    fn embedded_batch(
+        chunks: Vec<Chunk>,
+        file_fingerprints: HashMap<PathBuf, FileFingerprint>,
+        empty_file_fingerprints: HashMap<PathBuf, FileFingerprint>,
+    ) -> EmbeddedBatch {
+        let emb = Embedding::new(vec![0.25_f32; cqs::EMBEDDING_DIM]);
+        EmbeddedBatch {
+            cached_count: 0,
+            chunk_embeddings: chunks.into_iter().map(|c| (c, emb.clone())).collect(),
+            relationships: RelationshipData::default(),
+            file_fingerprints,
+            empty_file_fingerprints,
+            uncached_need_embedding: false,
+        }
+    }
+
+    fn run_store_stage(store: &Store, batches: Vec<EmbeddedBatch>) {
+        let (tx, rx) = unbounded::<EmbeddedBatch>();
+        for b in batches {
+            tx.send(b).unwrap();
+        }
+        drop(tx); // closing the channel = store_stage drains and returns
+        let parsed = AtomicUsize::new(0);
+        let embedded = AtomicUsize::new(0);
+        store_stage(rx, store, &parsed, &embedded, &ProgressBar::hidden()).unwrap();
+    }
+
+    /// Simulated crash between a straddling file's two batch commits. The
+    /// pipeline stamps a file's fingerprint only in the batch carrying its
+    /// LAST chunk; if the process dies after committing the file's first
+    /// (chunk-only, no-fingerprint) batch but before the second, the file is
+    /// half-indexed and UNSTAMPED. The staleness pre-filter consumes these
+    /// fingerprints (NULL columns degrade to "not current"), so the file MUST
+    /// classify stale on the next run rather than be skipped permanently.
+    ///
+    /// Drives `store_stage` with only the first batch (no fingerprint) and
+    /// then closes the channel — exactly the post-crash on-disk state.
+    #[test]
+    fn store_stage_partial_file_leaves_fingerprint_unstamped() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = Store::open(&tmp.path().join("index.db")).unwrap();
+        store.init(&ModelInfo::default()).unwrap();
+
+        // Batch 1 of 2 for straddle.rs: chunks present, fingerprint WITHHELD
+        // (it would have ridden the second, never-committed batch).
+        let first_half = vec![
+            chunk("straddle.rs", "aaaa", "fn a() {}"),
+            chunk("straddle.rs", "bbbb", "fn b() {}"),
+        ];
+        run_store_stage(
+            &store,
+            vec![embedded_batch(first_half, HashMap::new(), HashMap::new())],
+        );
+
+        // Chunks landed...
+        assert_eq!(
+            store.get_chunks_by_origin("straddle.rs").unwrap().len(),
+            2,
+            "first-half chunks must be committed"
+        );
+
+        // ...but the reconcile fingerprint the staleness pre-filter reads is
+        // unpopulated, so the file is NOT marked current.
+        let fps = store.fingerprints_for_origins(&["straddle.rs"]).unwrap();
+        let fp = fps
+            .get("straddle.rs")
+            .expect("origin row exists for the committed chunks");
+        assert!(
+            fp.content_hash.is_none() && fp.size.is_none(),
+            "a half-indexed file must stay unstamped so it re-indexes; got {fp:?}"
+        );
+    }
+
+    /// File-complete stamping, happy path: the SECOND (last-chunk) batch
+    /// carries the fingerprint, and after it commits the file is fully
+    /// stamped — proving the stamp lands once both halves are written.
+    #[test]
+    fn store_stage_stamps_fingerprint_when_last_batch_lands() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = Store::open(&tmp.path().join("index.db")).unwrap();
+        store.init(&ModelInfo::default()).unwrap();
+
+        let content = b"fn a() {}\nfn b() {}";
+        let mut last_fp = HashMap::new();
+        last_fp.insert(PathBuf::from("straddle.rs"), full_fp(content));
+
+        run_store_stage(
+            &store,
+            vec![
+                // First half: no fingerprint.
+                embedded_batch(
+                    vec![chunk("straddle.rs", "aaaa", "fn a() {}")],
+                    HashMap::new(),
+                    HashMap::new(),
+                ),
+                // Last half: carries the fingerprint.
+                embedded_batch(
+                    vec![chunk("straddle.rs", "bbbb", "fn b() {}")],
+                    last_fp,
+                    HashMap::new(),
+                ),
+            ],
+        );
+
+        let fps = store.fingerprints_for_origins(&["straddle.rs"]).unwrap();
+        let fp = fps.get("straddle.rs").expect("origin exists");
+        assert!(
+            fp.content_hash.is_some() && fp.size.is_some() && fp.mtime.is_some(),
+            "after the last batch the file must be fully stamped; got {fp:?}"
+        );
+    }
+
+    /// Zero-chunk transition: a file previously indexed with chunks now parses
+    /// to zero chunks. It rides the pipeline as an `empty_file_fingerprints`
+    /// entry; `store_stage` must prune its stale chunks (empty live set) so
+    /// they stop polluting search. Pins the correctness fix for the
+    /// re-parse-forever / stale-results defect on the CLI path.
+    #[test]
+    fn store_stage_zero_chunk_file_prunes_old_chunks() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = Store::open(&tmp.path().join("index.db")).unwrap();
+        store.init(&ModelInfo::default()).unwrap();
+
+        // Pre-seed gone.rs with chunks + a current fingerprint.
+        let seed = vec![
+            chunk("gone.rs", "1111", "fn one() {}"),
+            chunk("gone.rs", "2222", "fn two() {}"),
+        ];
+        let mut seed_fp = HashMap::new();
+        seed_fp.insert(PathBuf::from("gone.rs"), full_fp(b"seed"));
+        let emb = Embedding::new(vec![0.25_f32; cqs::EMBEDDING_DIM]);
+        let seed_pairs: Vec<(Chunk, Embedding)> =
+            seed.into_iter().map(|c| (c, emb.clone())).collect();
+        store
+            .upsert_embedded_batch(&seed_pairs, &[], &seed_fp)
+            .unwrap();
+        assert_eq!(
+            store.get_chunks_by_origin("gone.rs").unwrap().len(),
+            2,
+            "seed chunks must be present before the zero-chunk reindex"
+        );
+
+        // Reindex run: gone.rs parses to ZERO chunks → rides the empty set.
+        let mut empties = HashMap::new();
+        empties.insert(PathBuf::from("gone.rs"), full_fp(b"now empty"));
+        run_store_stage(
+            &store,
+            vec![embedded_batch(Vec::new(), HashMap::new(), empties)],
+        );
+
+        assert_eq!(
+            store.get_chunks_by_origin("gone.rs").unwrap().len(),
+            0,
+            "zero-chunk file's stale chunks must be pruned"
+        );
+    }
+
+    /// A file that produced chunks this run must NOT be clobbered by a stray
+    /// empty-set entry for the same origin (defensive: empties never carry
+    /// chunks, but the post-loop pass must skip any origin with a real live
+    /// set). The chunks survive.
+    #[test]
+    fn store_stage_chunked_file_not_pruned_by_stray_empty_entry() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = Store::open(&tmp.path().join("index.db")).unwrap();
+        store.init(&ModelInfo::default()).unwrap();
+
+        let mut fp = HashMap::new();
+        fp.insert(PathBuf::from("live.rs"), full_fp(b"live"));
+        let mut stray_empty = HashMap::new();
+        stray_empty.insert(PathBuf::from("live.rs"), full_fp(b"live"));
+
+        run_store_stage(
+            &store,
+            vec![embedded_batch(
+                vec![chunk("live.rs", "cccc", "fn c() {}")],
+                fp,
+                stray_empty,
+            )],
+        );
+
+        assert_eq!(
+            store.get_chunks_by_origin("live.rs").unwrap().len(),
+            1,
+            "a file with a real live set must survive a stray empty entry"
+        );
+    }
 }

--- a/src/store/chunks/crud.rs
+++ b/src/store/chunks/crud.rs
@@ -849,12 +849,27 @@ impl Store<ReadWrite> {
     /// paid a BEGIN/COMMIT plus a content-hash snapshot SELECT per file
     /// (tens of thousands of transactions of pure overhead on a large
     /// corpus). Crash-atomicity contract: a crash mid-index may lose whole
-    /// uncommitted batches, but the chunks, FTS rows, and fingerprints that
-    /// DID land always committed together — the index is never left with a
-    /// chunk/FTS desync for the rows it contains. (The watch path keeps its
-    /// own per-file fused transaction in `upsert_chunks_calls_and_prune` —
-    /// that boundary is deliberate: a daemon tick must commit each file's
-    /// chunks + calls + function_calls + prune as one unit.)
+    /// uncommitted batches, but the chunks and FTS rows that DID land always
+    /// committed together — the index is never left with a chunk/FTS desync
+    /// for the rows it contains.
+    ///
+    /// Fingerprint ordering is the key crash-safety guarantee: a file's chunks
+    /// can straddle batches (the parser slices at `embed_batch_size`; a GPU
+    /// failure re-splits a batch). The pipeline stamps a file's fingerprint
+    /// only in the batch carrying its LAST chunk, so for a straddling file the
+    /// fingerprint commits in a LATER transaction than some of the file's
+    /// chunks — deliberately. If the process dies between those commits the
+    /// file is left half-indexed but UNSTAMPED, so the next run's staleness
+    /// pre-filter (`filter_stale_files`) classifies it STALE and re-indexes it
+    /// in full. (The reverse — fingerprint committed before all chunks — was
+    /// the bug this ordering fixes: it would mark a half-indexed file current
+    /// and skip it permanently.) `fingerprints` therefore only ever mentions
+    /// files whose every chunk is present in THIS batch's row sets.
+    ///
+    /// (The watch path keeps its own per-file fused transaction in
+    /// `upsert_chunks_calls_and_prune` — that boundary is deliberate: a daemon
+    /// tick must commit each file's chunks + calls + function_calls + prune as
+    /// one unit.)
     ///
     /// `sentinel` chunks are written via the same zero-vec
     /// `needs_embedding=1` contract that `enrichment_pass` and the reuse
@@ -924,11 +939,11 @@ impl Store<ReadWrite> {
             sentinel_pairs.iter().map(|(c, _)| mtime_for(c)).collect();
 
         // Only stamp fingerprints for files actually present in this batch's
-        // chunk sets. The embed stages clone the batch-level fingerprint map
-        // to both the cached and requeued halves of a GPU-failure split, so
-        // the map can mention files whose chunks travel in a different
-        // `EmbeddedBatch` — stamping those early would mark a file fresh
-        // before its rows landed.
+        // chunk sets. The pipeline already restricts `fingerprints` to files
+        // whose LAST chunk rides in this batch (file-complete stamping), and
+        // the GPU-failure split keeps a straddling file's fingerprint with the
+        // later-landing requeued half — so this intersection is a defensive
+        // belt-and-braces against stamping a file before all its rows landed.
         let batch_files: std::collections::HashSet<&std::path::PathBuf> = real
             .iter()
             .map(|(c, _)| &c.file)


### PR DESCRIPTION
## fix(pipeline): fingerprints stamp on file-complete; zero-chunk files prune

Closes #1755 (both defects from the #1753 review).

- **Batch-straddling stamping:** the parser drain loop now counts chunks per file and attaches a file's fingerprint only to the batch carrying its LAST chunk; the GPU cached/requeued split keeps the fingerprint with the later-landing half. Invariant (pinned by a simulated-crash test): a half-indexed file is never stamped current — fingerprint-after-data is crash-safe, data-after-fingerprint was the bug. The crud.rs crash-atomicity doc now states the real guarantee.
- **Zero-chunk transitions:** files that parse to zero chunks flow through to the phantom prune with an empty live set — their stale chunks no longer pollute search forever.
- **Documented residual:** once pruned to zero rows there's nowhere to persist a fingerprint (reconcile fingerprints live on chunk rows), so a zero-chunk file re-parses each run as a cheap no-op (no embed, no writes). Fully eliminating that needs a file-registry table (schema migration) — deliberately out of scope, noted in-code.

8 new tests across parsing/embedding/upsert; pipeline 49 + store crud/staleness 70 green. fmt + clippy `--all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
