### PR TITLE
fix(dead): serde string-callback references count as live (#1573 tier 3b); GPU-gated CAGRA pins; enrichment_pass slow test

### DIFF
--- a/src/cagra.rs
+++ b/src/cagra.rs
@@ -2551,6 +2551,132 @@ mod tests {
         }
     }
 
+    /// GPU adversarial pin: the non-finite-query guard at the *actual*
+    /// `CagraIndex::search` entry returns empty results on a live index
+    /// rather than dispatching a kernel on poisoned input. The pure
+    /// predicate is covered CPU-side by `query_is_finite_rejects_nonfinite`;
+    /// this exercises the end-to-end path against real cuVS resources so a
+    /// future refactor that moves or drops the guard is caught.
+    #[test]
+    fn test_search_nonfinite_query_returns_empty_gpu() {
+        let _guard = GPU_LOCK.lock().unwrap();
+        if !require_gpu() {
+            return;
+        }
+        let index = build_test_index(10);
+
+        // A NaN somewhere in the query must short-circuit to empty.
+        let mut nan_vec = make_embedding(3).as_slice().to_vec();
+        nan_vec[0] = f32::NAN;
+        let nan_query = Embedding::new(nan_vec);
+        assert!(
+            index.search(&nan_query, 5).is_empty(),
+            "NaN query must return empty from the live search path"
+        );
+
+        // +Inf as well — the guard rejects any non-finite component.
+        let mut inf_vec = make_embedding(3).as_slice().to_vec();
+        inf_vec[1] = f32::INFINITY;
+        let inf_query = Embedding::new(inf_vec);
+        assert!(
+            index.search(&inf_query, 5).is_empty(),
+            "Inf query must return empty from the live search path"
+        );
+
+        // Sanity: the same index still answers a finite query, so the empty
+        // results above are the guard firing, not a broken index.
+        assert!(
+            !index.search(&make_embedding(3), 5).is_empty(),
+            "finite query must still return results on the same index"
+        );
+    }
+
+    /// GPU adversarial pin: a finite query against an index that *contains*
+    /// edge-case vectors (a zero vector, which is degenerate under cosine —
+    /// the L2-normalisation in `build` cannot normalise it) must still
+    /// return only finite-scored results. Documents the open uncertainty in
+    /// the `INVALID_DISTANCE` design note: whatever cuVS does internally with
+    /// a degenerate stored vector, the post-hoc `!dist.is_finite()` filter
+    /// keeps any NaN/Inf distance it might emit out of the result set.
+    #[test]
+    fn test_search_finite_query_degenerate_index_vector() {
+        let _guard = GPU_LOCK.lock().unwrap();
+        if !require_gpu() {
+            return;
+        }
+        // Mix ordinary vectors with a zero vector (degenerate direction).
+        let mut embeddings: Vec<(String, Embedding)> = (0..8)
+            .map(|i| (format!("chunk_{i}"), make_embedding(i)))
+            .collect();
+        embeddings.push((
+            "zero_vec".to_string(),
+            Embedding::new(vec![0.0f32; EMBEDDING_DIM]),
+        ));
+
+        let index = CagraIndex::build(embeddings, EMBEDDING_DIM)
+            .expect("build with a degenerate vector should still succeed");
+
+        let results = index.search(&make_embedding(2), 9);
+        // Every score that survives must be finite — the sentinel filter
+        // (and the score conversion) must never surface NaN/Inf to callers.
+        for r in &results {
+            assert!(
+                r.score.is_finite(),
+                "result {:?} has non-finite score {} — sentinel/score filter leaked",
+                r.id,
+                r.score
+            );
+        }
+        // The query's own self-match must still be retrievable.
+        assert!(
+            results.iter().any(|r| r.id == "chunk_2"),
+            "self-match lost when index contains a degenerate vector: {:?}",
+            results.iter().map(|r| &r.id).collect::<Vec<_>>()
+        );
+    }
+
+    /// GPU adversarial pin: confirm the post-hoc `!dist.is_finite()` sentinel
+    /// filter actually fires in practice. Request `k` far larger than the
+    /// corpus so cuVS cannot fill every neighbour slot; the unfilled slots
+    /// retain the `INVALID_DISTANCE` (`+∞`) seed. The filter must drop them,
+    /// so the returned count is bounded by the corpus size and never exposes
+    /// a sentinel-scored garbage neighbour.
+    #[test]
+    fn test_search_oversized_k_sentinel_filter_fires() {
+        let _guard = GPU_LOCK.lock().unwrap();
+        if !require_gpu() {
+            return;
+        }
+        let n: usize = 6;
+        let index = build_test_index(n as u32);
+
+        // k > corpus size: cuVS leaves trailing slots at INVALID_DISTANCE.
+        let k = n + 20;
+        let results = index.search(&make_embedding(1), k);
+
+        // The sentinel filter must keep the result count within the corpus.
+        assert!(
+            results.len() <= n,
+            "sentinel filter did not fire: got {} results for a {}-vector corpus",
+            results.len(),
+            n
+        );
+        // No surviving result may carry the sentinel — all scores finite.
+        for r in &results {
+            assert!(
+                r.score.is_finite(),
+                "sentinel slot leaked into results: {:?} score {}",
+                r.id,
+                r.score
+            );
+        }
+        // And we still got the real neighbours, not an empty drop-everything.
+        assert!(
+            !results.is_empty(),
+            "oversized-k search dropped all real neighbours"
+        );
+    }
+
     /// CPU-only guard test: the finite-query predicate that fronts
     /// `CagraIndex::search` must reject NaN/Inf queries (so the search
     /// returns empty rather than dispatching a kernel on poisoned input)

--- a/src/cli/enrichment.rs
+++ b/src/cli/enrichment.rs
@@ -649,4 +649,157 @@ mod tests {
         assert_eq!(once, twice, "normalize_ws must be idempotent");
         assert_eq!(once, "foo bar baz");
     }
+
+    // ---------- enrichment_pass end-to-end (slow, real embedder) ----------
+
+    /// `slow-tests`-gated end-to-end pin for `enrichment_pass` itself. The
+    /// unit tests above cover the hash function in isolation; the store
+    /// layer covers the needs_embedding clear + splade_generation bump with
+    /// mock vectors. Neither exercises the orchestration: paging chunks,
+    /// generating enriched NL, embedding it with a real model, and writing
+    /// the result back. This builds a real CPU embedder (loads the default
+    /// ~91MB model via the HF cache), seeds a store with `needs_embedding=1`
+    /// sentinel chunks, runs the pass, and asserts the full invariant set:
+    ///
+    /// 1. `needs_embedding` flags clear for every seeded chunk.
+    /// 2. The written embeddings are real (non-zero, not the seed sentinel).
+    /// 3. `splade_generation` advances (the vector-rewrite generation bump
+    ///    the HNSW sidecar staleness check depends on).
+    ///
+    /// Runs nightly via `ci-slow.yml` with the HF cache primed. Locally:
+    /// `cargo test --features slow-tests enrichment_pass_end_to_end`.
+    #[cfg(feature = "slow-tests")]
+    #[test]
+    fn enrichment_pass_end_to_end_real_embedder() {
+        use cqs::embedder::ModelConfig;
+        use cqs::store::ModelInfo;
+        use cqs::{Embedder, Store};
+
+        // Build a real CPU embedder from the default model.
+        let model_config = ModelConfig::resolve(None, None);
+        let embedder = match Embedder::new_cpu(model_config.clone()) {
+            Ok(e) => e,
+            Err(e) => {
+                // The CI-slow job primes the HF cache; if the model is
+                // genuinely unavailable, skip rather than fail so a missing
+                // cache doesn't redden an otherwise-green run.
+                eprintln!("Skipping enrichment_pass e2e: embedder init failed: {e}");
+                return;
+            }
+        };
+        let dim = embedder.embedding_dim();
+
+        // Store wired to the embedder's actual dim (setup_store uses the
+        // default ModelInfo dim, which may not match the live model).
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join(cqs::INDEX_DB_FILENAME);
+        let mut store = Store::open(&db_path).unwrap();
+        store
+            .init(&ModelInfo::new(&embedder.model_config().repo, dim))
+            .unwrap();
+        store.set_dim(dim);
+
+        // Seed two real-looking function chunks. Give one a caller edge so
+        // the enrichment path also exercises call-context NL, not just the
+        // bare needs_embedding fallback.
+        let chunk_a = cqs::parser::Chunk {
+            id: "src/svc.rs:1:a".to_string(),
+            file: std::path::PathBuf::from("src/svc.rs"),
+            language: cqs::parser::Language::Rust,
+            chunk_type: cqs::parser::ChunkType::Function,
+            name: "process_request".to_string(),
+            signature: "fn process_request(req: Request) -> Response".to_string(),
+            content:
+                "fn process_request(req: Request) -> Response { validate(req); build_response() }"
+                    .to_string(),
+            doc: Some("Handles an inbound request and produces a response.".to_string()),
+            line_start: 1,
+            line_end: 4,
+            content_hash: "hash_a".to_string(),
+            canonical_hash: String::new(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        };
+        let chunk_b = cqs::parser::Chunk {
+            id: "src/svc.rs:10:b".to_string(),
+            file: std::path::PathBuf::from("src/svc.rs"),
+            language: cqs::parser::Language::Rust,
+            chunk_type: cqs::parser::ChunkType::Function,
+            name: "validate".to_string(),
+            signature: "fn validate(req: Request)".to_string(),
+            content: "fn validate(req: Request) { assert!(req.is_ok()); }".to_string(),
+            doc: None,
+            line_start: 10,
+            line_end: 12,
+            content_hash: "hash_b".to_string(),
+            canonical_hash: String::new(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        };
+
+        // Sentinel-mode upsert → needs_embedding=1, zero-vec embeddings.
+        store
+            .upsert_embedded_batch(
+                &[],
+                &[chunk_a.clone(), chunk_b.clone()],
+                &std::collections::HashMap::new(),
+            )
+            .unwrap();
+        assert_eq!(
+            store.needs_embedding_count().unwrap(),
+            2,
+            "both seeded chunks should start at needs_embedding=1"
+        );
+
+        let gen_before = store.splade_generation().unwrap();
+
+        // Run the pass under test.
+        let enriched = enrichment_pass(&store, &embedder, &model_config, true)
+            .expect("enrichment_pass should succeed with a real embedder");
+        assert_eq!(
+            enriched, 2,
+            "enrichment_pass should re-embed both needs_embedding chunks"
+        );
+
+        // Invariant 1: needs_embedding flags clear.
+        assert_eq!(
+            store.needs_embedding_count().unwrap(),
+            0,
+            "enrichment_pass must clear needs_embedding for every processed chunk"
+        );
+        assert!(
+            store.needs_embedding_ids().unwrap().is_empty(),
+            "no chunk IDs should remain in the needs_embedding set"
+        );
+
+        // Invariant 2: written embeddings are real (non-zero). After the
+        // flag clears, the by-hash lookup serves the stored vectors.
+        let embs = store
+            .get_embeddings_by_hashes(&["hash_a", "hash_b"])
+            .unwrap();
+        assert_eq!(
+            embs.len(),
+            2,
+            "both embeddings must be retrievable post-pass"
+        );
+        for (h, emb) in &embs {
+            let slice = emb.as_slice();
+            assert_eq!(slice.len(), dim, "embedding dim mismatch for {h}");
+            assert!(
+                slice.iter().any(|&x| x != 0.0),
+                "embedding for {h} is all-zero — the real embedder did not run"
+            );
+        }
+
+        // Invariant 3: splade_generation advanced (vector-rewrite bump).
+        let gen_after = store.splade_generation().unwrap();
+        assert!(
+            gen_after > gen_before,
+            "enrichment_pass must bump splade_generation (before={gen_before}, after={gen_after})"
+        );
+    }
 }

--- a/src/store/calls/dead_code.rs
+++ b/src/store/calls/dead_code.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
+use regex::Regex;
 use sqlx::Row;
 
 use super::{
@@ -66,6 +67,18 @@ impl<Mode> Store<Mode> {
             // under-reporting to over-reporting — comments referencing a
             // name signal intentional retention.
             candidates = self.filter_invoked_macros(candidates).await?;
+
+            // Phase 1.6: serde string-callback references. Functions named
+            // in attribute strings — `#[serde(default = "default_ref_weight")]`,
+            // `#[serde(skip_serializing_if = "is_zero_u32")]`,
+            // `#[serde(with = "...")]` — are reached by the derive-generated
+            // (de)serializer, not by a syntactic `foo()` call. The call-graph
+            // extractor walks call/macro nodes, so a string reference inside an
+            // attribute produces no edge and the callback shows as "uncalled".
+            // Drop any Rust function candidate whose name appears as the
+            // terminal segment of a serde-shaped attribute string anywhere in
+            // the corpus. Bounded content scan, same shape as the macro filter.
+            candidates = self.filter_serde_callbacks(candidates).await?;
 
             // Phase 2: Batch-fetch content and score confidence
             let active_files = self.fetch_active_files().await?;
@@ -274,6 +287,131 @@ impl<Mode> Store<Mode> {
                 dropped = drop_count,
                 rust_macro_candidates = macro_idx.len(),
                 "filter_invoked_macros dropped invoked macros from dead candidates"
+            );
+        }
+
+        let filtered = candidates
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, c)| if dropped.contains(&i) { None } else { Some(c) })
+            .collect();
+        Ok(filtered)
+    }
+
+    /// Phase 1.6: drop Rust functions that are referenced only as serde
+    /// string callbacks. serde's derive macros accept function paths as
+    /// attribute string literals:
+    ///
+    /// ```ignore
+    /// #[serde(default = "default_ref_weight")]
+    /// #[serde(skip_serializing_if = "is_zero_u32")]
+    /// #[serde(serialize_with = "crate::serialize_path_normalized")]
+    /// #[serde(with = "some::module")]
+    /// ```
+    ///
+    /// The derived (de)serializer calls these at runtime, but the reference
+    /// lives in an attribute string the call-graph walker never resolves into
+    /// an edge. So the callbacks look uncalled. This pass scans every chunk's
+    /// content for serde-shaped attribute strings, extracts the terminal path
+    /// segment of each (`crate::a::b::f` → `f`), and drops any Rust function
+    /// candidate whose name matches.
+    ///
+    /// Contract details (mirrors `filter_invoked_macros`):
+    /// - **Functions only.** serde callbacks are free functions / associated
+    ///   functions, never trait methods reached through dispatch. Method and
+    ///   macro candidates pass through untouched.
+    /// - **Terminal-segment match.** `serialize_with = "crate::foo::bar"`
+    ///   keeps a candidate named `bar` alive regardless of the module path,
+    ///   matching how a candidate chunk is keyed by bare name.
+    /// - **Self-reference is fine.** Unlike the macro filter, a callback
+    ///   referenced inside its own defining chunk is still genuinely used by
+    ///   the deriver — the attribute is on *another* type's field, not in the
+    ///   function body. We do not need (or want) a self-exclusion guard here;
+    ///   the attribute and the `fn` definition are different chunks anyway.
+    /// - **False-negative-friendly.** Matching is by substring presence of a
+    ///   serde-shaped attribute naming the candidate; a stale attribute string
+    ///   keeps the function live. Dead-code analysis prefers under-reporting.
+    async fn filter_serde_callbacks(
+        &self,
+        candidates: Vec<LightChunk>,
+    ) -> Result<Vec<LightChunk>, StoreError> {
+        // serde string callbacks resolve to free/associated functions. Build a
+        // bare-name → candidate-index map over Rust Function/Method candidates
+        // (associated fns are tagged Method when they live in an impl block, so
+        // we accept both rather than miss `Type::default_x`).
+        let mut by_name: std::collections::HashMap<&str, Vec<usize>> =
+            std::collections::HashMap::new();
+        for (i, c) in candidates.iter().enumerate() {
+            if c.language != Language::Rust {
+                continue;
+            }
+            if matches!(c.chunk_type, ChunkType::Function | ChunkType::Method) {
+                by_name.entry(c.name.as_str()).or_default().push(i);
+            }
+        }
+
+        // No Rust function candidates: skip the content scan entirely.
+        if by_name.is_empty() {
+            return Ok(candidates);
+        }
+
+        // Matches serde-shaped callback attributes and captures the quoted
+        // path: `default = "..."`, `with = "..."`, `serialize_with = "..."`,
+        // `deserialize_with = "..."`, `skip_serializing_if = "..."`,
+        // `bound = "..."` is excluded (it names types/where-clauses, not fns).
+        static SERDE_CALLBACK_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
+                r#"(?:default|with|serialize_with|deserialize_with|skip_serializing_if|skip_serializing|skip_deserializing|getter)\s*=\s*"([^"]+)""#,
+            )
+            .expect("hardcoded serde-callback regex")
+        });
+
+        let mut dropped: std::collections::HashSet<usize> = std::collections::HashSet::new();
+
+        // One read transaction, paged by rowid so peak heap is bounded by the
+        // batch size. We only scan chunks whose content contains "serde" to
+        // skip the bulk of the corpus; the regex runs only on the rest.
+        let mut tx = self.pool.begin().await?;
+        const PAGE: i64 = 2048;
+        let mut last_rowid: i64 = 0;
+        loop {
+            let rows: Vec<(i64, String)> = sqlx::query_as(
+                "SELECT rowid, content FROM chunks
+                 WHERE rowid > ?1 AND content LIKE '%serde%'
+                 ORDER BY rowid
+                 LIMIT ?2",
+            )
+            .bind(last_rowid)
+            .bind(PAGE)
+            .fetch_all(&mut *tx)
+            .await?;
+
+            if rows.is_empty() {
+                break;
+            }
+
+            for (rowid, content) in &rows {
+                last_rowid = *rowid;
+                for cap in SERDE_CALLBACK_RE.captures_iter(content) {
+                    let path = &cap[1];
+                    // Terminal path segment: `crate::a::b::f` → `f`.
+                    let terminal = path.rsplit("::").next().unwrap_or(path);
+                    if let Some(indices) = by_name.get(terminal) {
+                        for &i in indices {
+                            dropped.insert(i);
+                        }
+                    }
+                }
+            }
+        }
+        drop(tx);
+
+        let drop_count = dropped.len();
+        if drop_count > 0 {
+            tracing::debug!(
+                dropped = drop_count,
+                rust_fn_candidates = by_name.values().map(|v| v.len()).sum::<usize>(),
+                "filter_serde_callbacks dropped serde string callbacks from dead candidates"
             );
         }
 
@@ -964,6 +1102,219 @@ mod tests {
             names.contains(&"info_span"),
             "Macro `info_span` must not be falsely kept alive by `infoXspan!` content — \
              `_` was a LIKE wildcard pre-fix (EH-V1.40-1)"
+        );
+    }
+
+    // ===== filter_serde_callbacks tests =====
+
+    /// Helper: build a minimal Rust function chunk for the serde tests.
+    fn rust_fn_chunk(id: &str, file: &str, name: &str, content: &str) -> crate::parser::Chunk {
+        crate::parser::Chunk {
+            id: id.to_string(),
+            file: std::path::PathBuf::from(file),
+            language: crate::parser::Language::Rust,
+            chunk_type: crate::parser::ChunkType::Function,
+            name: name.to_string(),
+            signature: format!("fn {name}()"),
+            content: content.to_string(),
+            doc: None,
+            line_start: 1,
+            line_end: 3,
+            content_hash: format!("{id}_hash"),
+            canonical_hash: String::new(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: None,
+            parser_version: 0,
+        }
+    }
+
+    /// A function referenced only via `#[serde(default = "name")]` is reached
+    /// by the derive-generated deserializer, not a syntactic call. It must be
+    /// dropped from dead candidates when another chunk's content names it in a
+    /// serde attribute.
+    #[test]
+    fn test_serde_default_callback_dropped_from_dead() {
+        let (store, _dir) = setup_store();
+        let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
+
+        // The callback function — never called with `()`.
+        let cb = rust_fn_chunk(
+            "src/config.rs:1",
+            "src/config.rs",
+            "default_ref_weight",
+            "fn default_ref_weight() -> f32 { 1.0 }",
+        );
+        store.upsert_chunk(&cb, &emb, Some(1)).unwrap();
+
+        // A struct chunk whose field references it via serde attribute.
+        let user = rust_fn_chunk(
+            "src/config.rs:10",
+            "src/config.rs",
+            "RefConfig",
+            "#[derive(serde::Deserialize)] struct RefConfig { \
+             #[serde(default = \"default_ref_weight\")] weight: f32 }",
+        );
+        store.upsert_chunk(&user, &emb, Some(1)).unwrap();
+
+        let (confident, possibly_pub) = store.find_dead_code(true).unwrap();
+        let names: Vec<&str> = confident
+            .iter()
+            .chain(possibly_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            !names.contains(&"default_ref_weight"),
+            "serde default callback must be filtered from dead candidates: {names:?}"
+        );
+    }
+
+    /// `skip_serializing_if = "is_zero_u32"` is a predicate callback. Same
+    /// contract as `default`.
+    #[test]
+    fn test_serde_skip_serializing_if_callback_dropped() {
+        let (store, _dir) = setup_store();
+        let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
+
+        let cb = rust_fn_chunk(
+            "src/helpers.rs:1",
+            "src/helpers.rs",
+            "is_zero_u32",
+            "fn is_zero_u32(v: &u32) -> bool { *v == 0 }",
+        );
+        store.upsert_chunk(&cb, &emb, Some(1)).unwrap();
+
+        let user = rust_fn_chunk(
+            "src/model.rs:5",
+            "src/model.rs",
+            "Model",
+            "#[derive(serde::Serialize)] struct Model { \
+             #[serde(skip_serializing_if = \"is_zero_u32\")] count: u32 }",
+        );
+        store.upsert_chunk(&user, &emb, Some(1)).unwrap();
+
+        let (confident, possibly_pub) = store.find_dead_code(true).unwrap();
+        let names: Vec<&str> = confident
+            .iter()
+            .chain(possibly_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            !names.contains(&"is_zero_u32"),
+            "serde skip_serializing_if callback must be filtered: {names:?}"
+        );
+    }
+
+    /// Path-qualified callbacks (`serialize_with = "crate::a::b::f"`) resolve
+    /// to a function keyed by its bare terminal segment. The filter must match
+    /// on `f`, not the full path.
+    #[test]
+    fn test_serde_path_qualified_callback_matches_terminal_segment() {
+        let (store, _dir) = setup_store();
+        let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
+
+        let cb = rust_fn_chunk(
+            "src/lib.rs:1",
+            "src/lib.rs",
+            "serialize_path_normalized",
+            "pub fn serialize_path_normalized() {}",
+        );
+        store.upsert_chunk(&cb, &emb, Some(1)).unwrap();
+
+        let user = rust_fn_chunk(
+            "src/ref.rs:5",
+            "src/ref.rs",
+            "RefSpec",
+            "#[derive(serde::Serialize)] struct RefSpec { \
+             #[serde(serialize_with = \"crate::serialize_path_normalized\")] path: PathBuf }",
+        );
+        store.upsert_chunk(&user, &emb, Some(1)).unwrap();
+
+        let (confident, possibly_pub) = store.find_dead_code(true).unwrap();
+        let names: Vec<&str> = confident
+            .iter()
+            .chain(possibly_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            !names.contains(&"serialize_path_normalized"),
+            "path-qualified serde callback must match by terminal segment: {names:?}"
+        );
+    }
+
+    /// The filter is Rust-only and serde-shaped. A function never named in any
+    /// serde attribute must stay in the dead list — the filter is not a blanket
+    /// content-substring drop.
+    #[test]
+    fn test_serde_filter_does_not_drop_unreferenced_fn() {
+        let (store, _dir) = setup_store();
+        let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
+
+        let orphan = rust_fn_chunk(
+            "src/orphan.rs:1",
+            "src/orphan.rs",
+            "genuinely_dead_helper",
+            "fn genuinely_dead_helper() {}",
+        );
+        store.upsert_chunk(&orphan, &emb, Some(1)).unwrap();
+
+        // A serde-using struct that references a *different* function. The
+        // orphan's name appears nowhere in a serde attribute.
+        let user = rust_fn_chunk(
+            "src/model.rs:5",
+            "src/model.rs",
+            "Model",
+            "#[derive(serde::Serialize)] struct Model { \
+             #[serde(skip_serializing_if = \"Option::is_none\")] x: Option<u32> }",
+        );
+        store.upsert_chunk(&user, &emb, Some(1)).unwrap();
+
+        let (confident, possibly_pub) = store.find_dead_code(true).unwrap();
+        let names: Vec<&str> = confident
+            .iter()
+            .chain(possibly_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            names.contains(&"genuinely_dead_helper"),
+            "fn not named in any serde attribute must remain dead: {names:?}"
+        );
+    }
+
+    /// A bare function name appearing in ordinary content (not a serde-shaped
+    /// `key = \"...\"` attribute) must NOT keep the function alive. Guards
+    /// against the filter degenerating into a plain substring scan.
+    #[test]
+    fn test_serde_filter_requires_attribute_shape() {
+        let (store, _dir) = setup_store();
+        let emb = crate::embedder::Embedding::new(vec![0.0; crate::EMBEDDING_DIM]);
+
+        let cb = rust_fn_chunk(
+            "src/x.rs:1",
+            "src/x.rs",
+            "default_true",
+            "fn default_true() -> bool { true }",
+        );
+        store.upsert_chunk(&cb, &emb, Some(1)).unwrap();
+
+        // Mentions the name and the word serde, but NOT in `key = "name"` form.
+        let user = rust_fn_chunk(
+            "src/note.rs:5",
+            "src/note.rs",
+            "note_fn",
+            "fn note_fn() { /* serde: default_true is the fallback */ }",
+        );
+        store.upsert_chunk(&user, &emb, Some(1)).unwrap();
+
+        let (confident, possibly_pub) = store.find_dead_code(true).unwrap();
+        let names: Vec<&str> = confident
+            .iter()
+            .chain(possibly_pub.iter())
+            .map(|d| d.chunk.name.as_str())
+            .collect();
+        assert!(
+            names.contains(&"default_true"),
+            "serde filter must require `key = \\\"name\\\"` shape, not bare mention: {names:?}"
         );
     }
 }


### PR DESCRIPTION
## fix(dead): serde string-callback references count as live (#1573 tier 3b) + GPU pins + enrichment test

- **Tier 3b:** new `filter_serde_callbacks` pass mirrors the macro content-scan: a bounded regex over serde-containing chunks extracts string-path attribute callbacks (`default`/`with`/`serialize_with`/…, terminal path segment) and drops matching Function/Method dead-candidates. Production delta: 7 functions referenced only via serde attributes leave confident-dead. Issue-naming drift noted: `visit_seq` is tier-3a (trait method), `default_output_name` no longer exists — current grep is ground truth.
- **TC-V1.42-8 GPU half:** 3 cuda-gated adversarial pins ran live on the A6000 (single-threaded, daemon-only context verified): non-finite query → empty at the live entry; degenerate stored vector + finite query → all finite scores (exit filter holds); oversized k → sentinel filter drops unfilled slots.
- **TC-HAP-V1.38-3:** `enrichment_pass` end-to-end slow-test with the real embedder (flags clear, embeddings real, `splade_generation` bumps per the #1754 invariant) — passed locally in 4.1s.

Residual filed-worthy: serde callbacks are now dead-code-visible but still absent from the call graph (`cqs callers` won't show them) — extractor-side edge emission is a separate, larger change.

fmt + clippy `--all-targets` clean; targeted suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
