### PR TITLE
refactor(daemon): scope-flag forwarding derives from clap (closes #1806)

### DIFF
--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -348,15 +348,35 @@ const SEARCH_KNOB_ARG_IDS: &[&str] = &[
     "no_demote",
 ];
 
+/// Top-level `Cli` arg IDs whose value is a *search scope* (`lang`, `path`)
+/// the subcommand handlers honor when the same flag is present on their own
+/// batch surface. On daemon forwarding these are re-spliced onto the tail of
+/// any subcommand whose batch `*Args` accepts them — see
+/// [`cqs::daemon_translate::CliArgSpec::scope_targets`]. A subset of
+/// [`SEARCH_KNOB_ARG_IDS`]; the membership is pinned by
+/// `scope_arg_ids_are_search_knobs` below so a scope ID can't drift out of the
+/// search-knob set silently.
+#[cfg(unix)]
+const SCOPE_ARG_IDS: &[&str] = &["lang", "path"];
+
 /// Build the [`cqs::daemon_translate::CliArgSpec`] from the live clap
 /// definition. Derived at runtime (like `telemetry::describe_command`) so a
 /// new top-level flag is classified automatically — hand-mirrored flag lists
 /// are how `-v <cmd>` / `--rrf <cmd>` came to hard-error daemon-up while
-/// working daemon-down.
+/// working daemon-down. The batch command is passed so the scope-forward
+/// target set is derived from each subcommand's live `*Args` surface rather
+/// than a hardcoded subcommand match.
 #[cfg(unix)]
 fn cli_arg_spec() -> cqs::daemon_translate::CliArgSpec {
     use clap::CommandFactory;
-    cqs::daemon_translate::CliArgSpec::from_clap(&Cli::command(), PROCESS_LOCAL_ARG_IDS)
+    let daemon_capable = crate::cli::definitions::Commands::daemon_capable_variant_names();
+    cqs::daemon_translate::CliArgSpec::from_clap(
+        &Cli::command(),
+        PROCESS_LOCAL_ARG_IDS,
+        &crate::cli::batch::BatchInput::command(),
+        SCOPE_ARG_IDS,
+        &daemon_capable,
+    )
 }
 
 /// Try to forward the current command to a running daemon.
@@ -729,6 +749,161 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Every `SCOPE_ARG_IDS` entry must be a top-level search knob — a scope
+    /// flag is a filter the search path honors, never a process-local flag.
+    /// If a scope ID drifts out of `SEARCH_KNOB_ARG_IDS` (e.g. a rename) this
+    /// fails instead of silently forwarding a flag the batch parser rejects.
+    #[test]
+    fn scope_arg_ids_are_search_knobs() {
+        for id in SCOPE_ARG_IDS {
+            assert!(
+                SEARCH_KNOB_ARG_IDS.contains(id),
+                "SCOPE_ARG_IDS entry `{id}` must also be in SEARCH_KNOB_ARG_IDS — \
+                 a scope flag is a search knob, not a process-local flag"
+            );
+        }
+    }
+
+    /// The scope-forward target set is *derived* from the live batch clap
+    /// definition, not a hand-maintained list. This pins the derivation: the
+    /// set of subcommands the daemon translator forwards top-level scope flags
+    /// to must equal exactly the set of batch subcommands whose flattened
+    /// `*Args` surface accepts a scope-flag spelling.
+    ///
+    /// Concretely, this FAILS if someone adds `lang`/`path` to another wire
+    /// `*Args` struct without the forwarding picking it up — the independent
+    /// recomputation here grows, `spec.scope_targets` must grow with it, and a
+    /// mismatch means the derivation broke (someone re-introduced a hardcoded
+    /// list). It equally fails if `scope_targets` lists a subcommand whose
+    /// batch surface does *not* take the flag (a spurious forward).
+    #[test]
+    fn scope_targets_track_the_batch_wire_surface() {
+        let spec = cli_arg_spec();
+        assert!(
+            !spec.scope_flags.is_empty(),
+            "scope_flags empty — derivation regression (SCOPE_ARG_IDS not picked up from clap)"
+        );
+
+        // Independently recompute the expected targets straight from the batch
+        // clap surface: a *daemon-capable* subcommand is a target iff one of
+        // its non-positional args spells a scope flag. This mirrors the
+        // production derivation but is written separately here so a bug in the
+        // production walk is caught by divergence rather than copied.
+        let daemon_capable: std::collections::BTreeSet<&str> =
+            crate::cli::definitions::Commands::daemon_capable_variant_names()
+                .into_iter()
+                .collect();
+        let batch_app = crate::cli::batch::BatchInput::command();
+        let expected: std::collections::BTreeSet<String> = batch_app
+            .get_subcommands()
+            .filter(|sub| daemon_capable.contains(sub.get_name()))
+            .filter(|sub| {
+                sub.get_arguments()
+                    .filter(|a| !a.is_positional())
+                    .flat_map(spellings)
+                    .any(|s| spec.scope_flags.contains(&s))
+            })
+            .map(|sub| sub.get_name().to_string())
+            .collect();
+
+        assert_eq!(
+            spec.scope_targets, expected,
+            "scope-forward targets diverged from the batch wire surface — \
+             the derivation must equal exactly the subcommands whose `*Args` \
+             accept a scope flag, never a hardcoded list"
+        );
+
+        // Anchor current behavior: `similar` carries lang/path on its
+        // `SimilarArgs`, so it must be a target; `callers` does not, so it must
+        // not. These guard against the derivation collapsing to empty/all.
+        assert!(
+            spec.scope_targets.contains("similar"),
+            "`similar` accepts --lang/--path on its batch surface and must be a scope-forward target"
+        );
+        assert!(
+            !spec.scope_targets.contains("callers"),
+            "`callers` has no --lang/--path on its batch surface and must not be a scope-forward target"
+        );
+    }
+
+    /// Behavioral pin on the *translator*, driven by the production-derived
+    /// spec: for every daemon-capable subcommand whose batch `*Args` accepts
+    /// `--lang`, a top-level `cqs --lang rust <sub> <pos>` must forward the
+    /// scope flag onto that subcommand's tail; for every daemon-capable
+    /// subcommand that does NOT accept it, the flag must be dropped.
+    ///
+    /// This is the real guard the issue asks for: it FAILS if someone adds
+    /// `lang`/`path` to another daemon-routed wire `*Args` struct but the
+    /// forwarding doesn't pick it up — e.g. if the derivation regressed to a
+    /// hardcoded `["similar"]` list, the newly-eligible subcommand would land
+    /// in the "accepts but not forwarded" branch here and trip the assert.
+    /// It probes the live batch clap surface for eligibility, so the
+    /// expectation tracks the wire structs, never a copy of the target list.
+    #[test]
+    fn translator_forwards_scope_flags_for_every_eligible_daemon_command() {
+        let spec = cli_arg_spec();
+        let batch_app = crate::cli::batch::BatchInput::command();
+
+        let mut checked_forward = 0u32;
+        let mut checked_dropped = 0u32;
+        for name in crate::cli::definitions::Commands::daemon_capable_variant_names() {
+            let Some(sub) = batch_app.find_subcommand(name) else {
+                // Pinned separately by `every_daemon_capable_command_has_a_batch_subcommand`.
+                continue;
+            };
+            // Does this subcommand's batch surface accept `--lang`? (a single
+            // representative scope spelling — `scope_flags` membership is the
+            // same set the production derivation consults).
+            let accepts_lang = sub
+                .get_arguments()
+                .filter(|a| !a.is_positional())
+                .flat_map(spellings)
+                .any(|s| s == "--lang");
+
+            // Build a top-level-scoped argv. A bare positional (`x`) satisfies
+            // every daemon-capable subcommand's required arg or is ignored by
+            // arg-less ones; the translator never parses it, only splices.
+            let argv: Vec<String> = ["--lang", "rust", name, "x"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+            let (cmd, args) =
+                cqs::daemon_translate::translate_cli_args_to_batch(&argv, true, &spec);
+            assert_eq!(
+                cmd, name,
+                "subcommand name must round-trip through the translator"
+            );
+
+            if accepts_lang {
+                assert!(
+                    args.windows(2).any(|w| w[0] == "--lang" && w[1] == "rust"),
+                    "daemon-capable `{name}` accepts --lang on its batch surface but the \
+                     translator did not forward the top-level `--lang rust` onto its tail \
+                     (got {args:?}) — the scope-forward derivation missed it"
+                );
+                checked_forward += 1;
+            } else {
+                assert!(
+                    !args.iter().any(|a| a == "--lang"),
+                    "daemon-capable `{name}` does NOT accept --lang on its batch surface, \
+                     so the top-level scope flag must be dropped, not forwarded (got {args:?})"
+                );
+                checked_dropped += 1;
+            }
+        }
+        // Guard the loop actually exercised both branches — a derivation that
+        // silently excluded every command would make the asserts vacuous.
+        assert!(
+            checked_forward >= 1,
+            "no daemon-capable subcommand was found to accept --lang — derivation regression \
+             (expected at least `similar`)"
+        );
+        assert!(
+            checked_dropped >= 1,
+            "no daemon-capable subcommand was found to reject --lang — fixture regression"
+        );
     }
 
     /// The derived spec marks value-taking flags correctly: `--model` /

--- a/src/daemon_translate.rs
+++ b/src/daemon_translate.rs
@@ -61,6 +61,22 @@ pub struct CliArgSpec {
     /// a search knob shared spelling-for-spelling with `args::SearchArgs` and
     /// forwards verbatim.
     pub bare_query_strip: std::collections::BTreeSet<String>,
+    /// Every spelling (`--lang`/`-l`, `--path`/`-p`, …) of a top-level
+    /// *scope* flag — a filter the top-level `Cli` consumes that also exists,
+    /// spelling-for-spelling, on at least one subcommand's batch surface.
+    /// These reach a CLI subcommand through the top-level region
+    /// (`cqs --lang rust similar foo`) and so are re-forwarded onto the
+    /// subcommand tail rather than dropped with the rest of that region.
+    /// Derived from the live clap definitions by [`CliArgSpec::from_clap`];
+    /// the per-subcommand decision lives in [`Self::scope_targets`].
+    pub scope_flags: std::collections::BTreeSet<String>,
+    /// Subcommand names whose batch `*Args` surface accepts at least one
+    /// [`Self::scope_flags`] spelling. Top-level scope flags are forwarded
+    /// onto exactly these subcommands' tails; every other subcommand drops
+    /// the whole top-level region. Derived from the batch clap definition,
+    /// not hand-listed — adding `lang`/`path` to another wire `*Args` struct
+    /// extends this set automatically.
+    pub scope_targets: std::collections::BTreeSet<String>,
 }
 
 impl CliArgSpec {
@@ -75,9 +91,28 @@ impl CliArgSpec {
     /// top-level flag is picked up without touching this module. A
     /// classification test on the caller side pins that every top-level arg
     /// ID is explicitly process-local or search-forwarded.
-    pub fn from_clap(cmd: &clap::Command, process_local_ids: &[&str]) -> Self {
+    ///
+    /// `scope_ids` lists the top-level arg IDs (struct field names) whose
+    /// value is a *search scope* the subcommand handler honors when the same
+    /// flag is present on its own batch surface (`lang`, `path`). Their
+    /// spellings are collected into [`Self::scope_flags`]; the batch clap
+    /// definition (`batch_cmd`) is probed per *daemon-capable* subcommand
+    /// (`daemon_capable_subcommands`) to populate [`Self::scope_targets`]
+    /// with exactly the subcommands whose `*Args` accept at least one of those
+    /// spellings — so forwarding tracks the wire structs, not a hand-maintained
+    /// list. The daemon-capability filter keeps a CLI-only subcommand that
+    /// happens to carry `lang` (e.g. batch `diff`/`drift`) out of the set: those
+    /// never reach the daemon translator, so listing them would be inert noise.
+    pub fn from_clap(
+        cmd: &clap::Command,
+        process_local_ids: &[&str],
+        batch_cmd: &clap::Command,
+        scope_ids: &[&str],
+        daemon_capable_subcommands: &[&str],
+    ) -> Self {
         let mut value_flags = std::collections::BTreeSet::new();
         let mut bare_query_strip = std::collections::BTreeSet::new();
+        let mut scope_flags = std::collections::BTreeSet::new();
         for arg in cmd.get_arguments() {
             if arg.is_positional() {
                 continue;
@@ -86,34 +121,84 @@ impl CliArgSpec {
                 arg.get_action(),
                 clap::ArgAction::Set | clap::ArgAction::Append
             );
-            let mut spellings: Vec<String> = Vec::new();
-            if let Some(long) = arg.get_long() {
-                spellings.push(format!("--{long}"));
-            }
-            for alias in arg.get_all_aliases().unwrap_or_default() {
-                spellings.push(format!("--{alias}"));
-            }
-            if let Some(short) = arg.get_short() {
-                spellings.push(format!("-{short}"));
-            }
-            for alias in arg.get_all_short_aliases().unwrap_or_default() {
-                spellings.push(format!("-{alias}"));
-            }
+            let spellings = arg_spellings(arg);
             let is_local = process_local_ids.contains(&arg.get_id().as_str());
+            let is_scope = scope_ids.contains(&arg.get_id().as_str());
             for spelling in spellings {
                 if takes_value {
                     value_flags.insert(spelling.clone());
                 }
                 if is_local {
-                    bare_query_strip.insert(spelling);
+                    bare_query_strip.insert(spelling.clone());
+                }
+                if is_scope {
+                    scope_flags.insert(spelling);
                 }
             }
         }
+        let scope_targets =
+            derive_scope_targets(batch_cmd, &scope_flags, daemon_capable_subcommands);
         Self {
             value_flags,
             bare_query_strip,
+            scope_flags,
+            scope_targets,
         }
     }
+}
+
+/// Every spelling of a clap arg: `--long`, every `--alias`, `-s`, every
+/// `-a` short alias. Shared by the top-level and per-subcommand scans so
+/// both derive flag spellings the same way.
+fn arg_spellings(arg: &clap::Arg) -> Vec<String> {
+    let mut spellings: Vec<String> = Vec::new();
+    if let Some(long) = arg.get_long() {
+        spellings.push(format!("--{long}"));
+    }
+    for alias in arg.get_all_aliases().unwrap_or_default() {
+        spellings.push(format!("--{alias}"));
+    }
+    if let Some(short) = arg.get_short() {
+        spellings.push(format!("-{short}"));
+    }
+    for alias in arg.get_all_short_aliases().unwrap_or_default() {
+        spellings.push(format!("-{alias}"));
+    }
+    spellings
+}
+
+/// Walk every daemon-capable batch subcommand and collect the names whose
+/// flattened `*Args` surface accepts at least one `scope_flags` spelling.
+/// This is the derivation that replaces the old `cmd == "similar"` string
+/// match: a subcommand is a forward target iff its batch clap definition
+/// actually carries the scope flag, so adding `lang`/`path` to another
+/// daemon-routed wire `*Args` struct enrolls that subcommand automatically.
+///
+/// `daemon_capable` gates the walk to subcommands the daemon translator can
+/// actually receive — a CLI-only batch subcommand that carries `lang` (batch
+/// `diff`/`drift`) never reaches this code path, so it's excluded rather than
+/// listed as an inert target.
+fn derive_scope_targets(
+    batch_cmd: &clap::Command,
+    scope_flags: &std::collections::BTreeSet<String>,
+    daemon_capable: &[&str],
+) -> std::collections::BTreeSet<String> {
+    let mut targets = std::collections::BTreeSet::new();
+    for sub in batch_cmd.get_subcommands() {
+        let name = sub.get_name();
+        if !daemon_capable.contains(&name) {
+            continue;
+        }
+        let accepts_scope = sub
+            .get_arguments()
+            .filter(|a| !a.is_positional())
+            .flat_map(arg_spellings)
+            .any(|s| scope_flags.contains(&s));
+        if accepts_scope {
+            targets.insert(name.to_string());
+        }
+    }
+    targets
 }
 
 /// Translate raw CLI argv into a `(subcommand, args)` pair for the batch
@@ -146,13 +231,15 @@ pub fn translate_cli_args_to_batch(
 /// differ per subcommand (blame's `-n` is `--commits`).
 fn translate_subcommand_args(raw: &[String], spec: &CliArgSpec) -> (String, Vec<String>) {
     let mut idx = 0;
-    // Top-level scope flags (`--lang`/`-l`, `--path`/`-p`) reach the CLI's
-    // `cmd_similar` through the top-level `Cli` region (`cqs --lang rust similar
-    // foo`); they're dropped with the rest of that region below. For the
-    // `similar` subcommand — whose batch `SimilarArgs` accepts `--lang`/`--path`
-    // — capture them here so they can be re-appended to the forwarded tail,
-    // keeping daemon-routed scoping on par with the CLI-direct path. Other
-    // subcommands don't take these flags, so the forward is gated on `similar`.
+    // Top-level scope flags (`--lang`/`-l`, `--path`/`-p`) reach a CLI
+    // subcommand handler through the top-level `Cli` region (`cqs --lang rust
+    // similar foo`); they're dropped with the rest of that region below.
+    // Capture them here so they can be re-forwarded onto the subcommand tail
+    // for subcommands whose batch `*Args` surface accepts them — keeping
+    // daemon-routed scoping on par with the CLI-direct path. Which subcommands
+    // those are is derived from the batch clap definition (`spec.scope_targets`),
+    // not hand-listed: a subcommand enrolls automatically when its wire
+    // `*Args` struct carries the scope flags.
     let mut scope_forward: Vec<String> = Vec::new();
     while idx < raw.len() {
         let tok = &raw[idx];
@@ -164,7 +251,7 @@ fn translate_subcommand_args(raw: &[String], spec: &CliArgSpec) -> (String, Vec<
         // spaced-form value flags consume their following value token too;
         // boolean flags consume only themselves.
         if !tok.contains('=') && spec.value_flags.contains(tok.as_str()) {
-            if is_scope_flag(tok) {
+            if spec.scope_flags.contains(tok.as_str()) {
                 // Spaced form: capture the flag and its following value token.
                 if let Some(val) = raw.get(idx + 1) {
                     scope_forward.push(tok.clone());
@@ -175,7 +262,7 @@ fn translate_subcommand_args(raw: &[String], spec: &CliArgSpec) -> (String, Vec<
         } else {
             if let Some((key, _)) = tok.split_once('=') {
                 // Attached form (`--lang=rust`): forward the whole token.
-                if is_scope_flag(key) {
+                if spec.scope_flags.contains(key) {
                     scope_forward.push(tok.clone());
                 }
             }
@@ -188,13 +275,12 @@ fn translate_subcommand_args(raw: &[String], spec: &CliArgSpec) -> (String, Vec<
         return (String::new(), Vec::new());
     };
     let mut tail: Vec<String> = raw[idx + 1..].to_vec();
-    if cmd == "similar" && !scope_forward.is_empty() {
+    if spec.scope_targets.contains(&cmd) && !scope_forward.is_empty() {
         // Splice the captured top-level scope flags in *front* of the tail so
-        // the daemon's `dispatch_similar` builds the same `--lang`/`--path`
-        // filter the CLI would. A subcommand tail can also carry these directly
-        // (`cqs similar foo --lang rust`); putting the top-level capture first
-        // means clap's last-wins resolution keeps any tail-explicit value
-        // authoritative.
+        // the daemon dispatch builds the same `--lang`/`--path` filter the CLI
+        // would. A subcommand tail can also carry these directly (`cqs similar
+        // foo --lang rust`); putting the top-level capture first means clap's
+        // last-wins resolution keeps any tail-explicit value authoritative.
         scope_forward.extend(tail);
         tail = scope_forward;
     }
@@ -211,15 +297,6 @@ fn translate_subcommand_args(raw: &[String], spec: &CliArgSpec) -> (String, Vec<
         tail.remove(0);
     }
     (cmd, tail)
-}
-
-/// Whether `flag` is a top-level scope flag (`--lang`/`-l` or `--path`/`-p`)
-/// that the `similar` subcommand accepts on its batch tail. Used by
-/// [`translate_subcommand_args`] to re-forward these from the dropped top-level
-/// region onto a daemon-routed `similar` invocation. Spellings mirror the
-/// `args::SimilarArgs` clap definition (`-l`/`--lang`, `-p`/`--path`).
-fn is_scope_flag(flag: &str) -> bool {
-    matches!(flag, "--lang" | "-l" | "--path" | "-p")
 }
 
 /// Whether `tok` is a combined-short cluster (`-qv`, `-qn5`): a single `-`
@@ -1189,6 +1266,14 @@ mod tests {
                 "--model",
                 "--slot",
             ]),
+            // The production spec derives these from the live clap definitions
+            // (`CliArgSpec::from_clap`); the hand-built subset here mirrors the
+            // scope flags and the one current forward target (`similar`) so the
+            // translator-rule tests below exercise the same path. The
+            // derivation itself is pinned by `scope_targets_track_the_batch_wire_surface`
+            // in `cli::dispatch`.
+            scope_flags: set(&["-l", "--lang", "-p", "--path"]),
+            scope_targets: set(&["similar"]),
         }
     }
 

--- a/tests/daemon_forward_test.rs
+++ b/tests/daemon_forward_test.rs
@@ -78,6 +78,14 @@ fn spec() -> cqs::daemon_translate::CliArgSpec {
             "--model",
             "--slot",
         ]),
+        // Production derives these from the live clap definitions; the
+        // hand-built subset here mirrors the scope flags and the one current
+        // forward target (`similar`). The derivation that the production set
+        // tracks the wire `*Args` surfaces is pinned by a binary-crate unit
+        // test (`scope_targets_track_the_batch_wire_surface` in
+        // `cli::dispatch`) — `BatchInput` is `pub(crate)`, unreachable here.
+        scope_flags: set(&["-l", "--lang", "-p", "--path"]),
+        scope_targets: set(&["similar"]),
     }
 }
 


### PR DESCRIPTION
Closes #1806 — top-level scope-flag forwarding derives from the live clap definitions instead of the `similar`-only string match #1807 introduced.

`CliArgSpec` gains `scope_flags` (derived spellings of top-level `lang`/`path`) and `scope_targets` (daemon-capable subcommands whose batch wire surface actually accepts them, probed from `BatchInput::command()` — the wire `*Args` structs flatten into clap, so the batch surface IS the truth). The translator gates on the derived set; the hardcoded helper is deleted; tail-wins splicing unchanged. CLI-only batch commands that carry `lang` (`diff`/`drift`) are filtered out — they never reach the translator.

Runtime probing over a new cqs-macros derive because the machinery already exists (`from_clap` already derives `value_flags`/`bare_query_strip` this way per #1746) — least new surface to maintain.

Pin quality: the recompute-and-compare test fails if the derivation drops an eligible command, and the behavioral pin was sabotage-verified (derivation forced empty → test trips on `similar`). A future wire Args struct gaining lang/path fields gets forwarding automatically; the dispatch-side pin flags the hand-built test fixtures that would then need updating.

Gates: daemon_translate 47 + daemon_forward 34 + dispatch 8 green, fmt + clippy --all-targets clean, provenance lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
