### PR TITLE
docs(notes): record cqs callers false-absence for name-ambiguous functions

### DIFF
--- a/docs/notes.toml
+++ b/docs/notes.toml
@@ -1933,3 +1933,12 @@ mentions = [
     "seam-auditor",
     "escalation",
 ]
+
+[[note]]
+sentiment = -0.5
+text = "cqs callers reports zero direct callers for name-ambiguous functions (two defs sharing a name, e.g. search_filtered = hnsw method + store method): the name-based resolver drops the edge rather than guess, so a fn with 23 call sites shows 0 direct (only doc_reference). False-absence — verify callers of overloaded names by grep. Tracked #1837."
+mentions = [
+    "src/impact",
+    "callers",
+    "search_filtered",
+]


### PR DESCRIPTION
Records a cqs gotcha found during trust-v30 live verification: `cqs callers` returns zero direct callers for name-ambiguous functions (two definitions sharing a name), because the name-based resolver drops the edge rather than guess. Note warns to grep-verify callers of overloaded names. Tracked separately in the issue tracker.

Notes-only. Lands on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
