### PR TITLE
docs(agents): surface cqs review --base (result-trust §5)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -14,7 +14,7 @@ You review uncommitted changes for risk and correctness. Your output is a review
 ## Process
 
 1. Run `git diff --stat` to see what changed
-2. Run `cqs review --json` for diff-aware impact analysis + risk scoring (single command, fastest first signal)
+2. Run `cqs review --json` for diff-aware impact analysis + risk scoring (single command, fastest first signal). Default diffs unstaged changes; for committed branch work use `cqs review --base <ref>` (e.g. `--base main`) — don't fall back to raw git plumbing.
 3. Optionally run `cqs ci --json` for the fuller pipeline view (impact + risk + dead-code + gate). Use this when the diff is large or touches multiple modules.
 4. For each high-risk function (risk > 0.5), run `cqs test-map FUNCTION --json` to check coverage
 5. For any function with 0 test coverage, flag it

--- a/.claude/skills/check-my-work/SKILL.md
+++ b/.claude/skills/check-my-work/SKILL.md
@@ -13,7 +13,7 @@ None — operates on the current git diff.
 
 ## Process
 
-1. Run `cqs review --json` via Bash (analyzes current diff)
+1. Run `cqs review --json` via Bash (analyzes current diff). Default covers unstaged changes; if the work is already committed on a branch, use `cqs review --base <ref>` (e.g. `--base main`) to diff against the base instead of raw git plumbing.
 2. If no diff, say "No changes to review" and stop
 3. Present results as a review checklist
 


### PR DESCRIPTION
Result-trust program §5 (the doc-gap correction from `docs/plans/2026-06-12-edge-provenance-dead-verdicts-worktree-overlay.md`): `cqs review --base <ref>` has long existed, but the code-reviewer agent def and /check-my-work skill never mentioned it, so agents reviewing committed branch work fell back to raw git plumbing. Two doc lines; no code change.

Part of #1821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
