### PR TITLE
fix(graph): callers trust-rank ordering, honest truncation, Type::method disambiguation (#1837)

### DIFF
--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -1701,6 +1701,12 @@ mod tests {
             self_caller.get("attribution").is_none(),
             "proven self-call omits attribution"
         );
+        // index_self was excluded as an other-owner caller — the count is
+        // surfaced (skip-when-zero), honoring "never silent exclusion".
+        assert_eq!(
+            daemon["excluded_other_owner"], 1,
+            "one Index-parented caller excluded + counted: {daemon}"
+        );
 
         // CLI==daemon parity.
         let core_args = CallersCoreArgs {
@@ -1712,6 +1718,140 @@ mod tests {
             serde_json::to_value(callers_core(&ctx.store(), &core_args).expect("callers_core"))
                 .unwrap();
         assert_eq!(daemon, core, "CLI==daemon parity for Type::method callers");
+    }
+
+    /// An unknown qualifier (`Banana::search` — no `Banana` type defines
+    /// `search`) returns empty callers WITH the real `Type::method` candidates,
+    /// rather than misleading free-function callers under a fabricated
+    /// qualifier. CLI==daemon agree.
+    #[test]
+    fn callers_unknown_qualifier_lists_real_owners_and_parity() {
+        use crate::cli::commands::{callers_core, CallersCoreArgs};
+        let (_dir, ctx) = seed_type_method_ctx();
+        let args = CallersArgs {
+            name: "Banana::search".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
+            edge_kind: None,
+        };
+        let daemon = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
+        assert_eq!(daemon["count"], 0, "no callers under a bogus qualifier");
+        assert!(
+            daemon["callers"].as_array().unwrap().is_empty(),
+            "callers empty: {daemon}"
+        );
+        let quals: Vec<&str> = daemon["candidates"]
+            .as_array()
+            .expect("unknown qualifier lists the real owners")
+            .iter()
+            .map(|c| c["qualified"].as_str().unwrap())
+            .collect();
+        assert!(quals.contains(&"Store::search"), "candidates: {quals:?}");
+        assert!(quals.contains(&"Index::search"), "candidates: {quals:?}");
+
+        let core_args = CallersCoreArgs {
+            name: "Banana::search".into(),
+            limit: 10,
+            edge_kind: None,
+        };
+        let core =
+            serde_json::to_value(callers_core(&ctx.store(), &core_args).expect("callers_core"))
+                .unwrap();
+        assert_eq!(daemon, core, "CLI==daemon parity for unknown qualifier");
+    }
+
+    /// `cqs callers Store::open` reaches the exact-qualified doc_reference
+    /// edge (markdown stored callee_name "Store::open") alongside attributed
+    /// code callers — through the daemon surface, with CLI==daemon parity.
+    #[test]
+    fn callers_type_method_reaches_exact_qualified_doc_edge_and_parity() {
+        use crate::cli::commands::{callers_core, CallersCoreArgs};
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        let mut emb_vec = vec![0.0_f32; cqs::EMBEDDING_DIM];
+        emb_vec[0] = 1.0;
+        let embedding = Embedding::new(emb_vec);
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            store
+                .upsert_chunks_batch(
+                    &[
+                        (
+                            type_method_chunk("store.rs", "open", 10, Some("Store")),
+                            embedding.clone(),
+                        ),
+                        (
+                            type_method_chunk("store.rs", "reopen", 30, Some("Store")),
+                            embedding.clone(),
+                        ),
+                    ],
+                    Some(0),
+                )
+                .expect("upsert chunks");
+            store
+                .upsert_function_calls(
+                    Path::new("store.rs"),
+                    &[FunctionCalls {
+                        name: "reopen".to_string(),
+                        line_start: 30,
+                        calls: vec![CallSite {
+                            callee_name: "open".to_string(),
+                            line_number: 31,
+                            kind: CallEdgeKind::Call,
+                        }],
+                    }],
+                )
+                .expect("upsert code edge");
+            store
+                .upsert_function_calls(
+                    Path::new("docs.md"),
+                    &[FunctionCalls {
+                        name: "Usage".to_string(),
+                        line_start: 1,
+                        calls: vec![CallSite {
+                            callee_name: "Store::open".to_string(),
+                            line_number: 5,
+                            kind: CallEdgeKind::DocReference,
+                        }],
+                    }],
+                )
+                .expect("upsert doc edge");
+        }
+        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
+        let args = CallersArgs {
+            name: "Store::open".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
+            edge_kind: None,
+        };
+        let daemon = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
+        let names: Vec<&str> = daemon["callers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"reopen"), "code self-call: {names:?}");
+        assert!(
+            names.contains(&"Usage"),
+            "exact-qualified doc edge reachable: {names:?}"
+        );
+
+        let core_args = CallersCoreArgs {
+            name: "Store::open".into(),
+            limit: 10,
+            edge_kind: None,
+        };
+        let core =
+            serde_json::to_value(callers_core(&ctx.store(), &core_args).expect("callers_core"))
+                .unwrap();
+        assert_eq!(
+            daemon, core,
+            "CLI==daemon parity for exact-qualified doc edge"
+        );
     }
 
     /// A bare name with more than one definition lists the `Type::method`

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -1854,6 +1854,107 @@ mod tests {
         );
     }
 
+    /// An external / module qualifier (`std::fs::read_to_string`) has NO local
+    /// definition, so the local-def gate would have short-circuited to the
+    /// candidates hint — but its only edges are exact-qualified doc references,
+    /// which the exact-only arm reaches. The result lists those doc edges, not a
+    /// did-you-mean. A co-located LOCAL bare `read_to_string` call must NOT be
+    /// mis-attributed under the fabricated `std::fs` type. CLI==daemon agree.
+    #[test]
+    fn callers_external_qualifier_reaches_doc_only_edges_and_parity() {
+        use crate::cli::commands::{callers_core, CallersCoreArgs};
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        let mut emb_vec = vec![0.0_f32; cqs::EMBEDDING_DIM];
+        emb_vec[0] = 1.0;
+        let embedding = Embedding::new(emb_vec);
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            // A local caller making a BARE read_to_string() call. No std::fs
+            // type exists — it must not be attributed under the qualifier.
+            store
+                .upsert_chunks_batch(
+                    &[(
+                        type_method_chunk("local.rs", "local_reader", 10, Some("Helper")),
+                        embedding.clone(),
+                    )],
+                    Some(0),
+                )
+                .expect("upsert chunks");
+            store
+                .upsert_function_calls(
+                    Path::new("local.rs"),
+                    &[FunctionCalls {
+                        name: "local_reader".to_string(),
+                        line_start: 10,
+                        calls: vec![CallSite {
+                            callee_name: "read_to_string".to_string(),
+                            line_number: 11,
+                            kind: CallEdgeKind::Call,
+                        }],
+                    }],
+                )
+                .expect("upsert bare code edge");
+            store
+                .upsert_function_calls(
+                    Path::new("docs.md"),
+                    &[FunctionCalls {
+                        name: "IoNotes".to_string(),
+                        line_start: 1,
+                        calls: vec![CallSite {
+                            callee_name: "std::fs::read_to_string".to_string(),
+                            line_number: 3,
+                            kind: CallEdgeKind::DocReference,
+                        }],
+                    }],
+                )
+                .expect("upsert doc edge");
+        }
+        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
+        let args = CallersArgs {
+            name: "std::fs::read_to_string".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
+            edge_kind: None,
+        };
+        let daemon = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
+        let names: Vec<&str> = daemon["callers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["name"].as_str().unwrap())
+            .collect();
+        assert!(
+            names.contains(&"IoNotes"),
+            "doc-only external qualifier edge reachable: {daemon}"
+        );
+        assert!(
+            !names.contains(&"local_reader"),
+            "local bare call must not be attributed under std::fs: {daemon}"
+        );
+        // Not the did-you-mean path: real edges were found, so no candidates.
+        assert!(
+            daemon.get("candidates").is_none(),
+            "doc-only hit is not the unknown-qualifier path: {daemon}"
+        );
+
+        let core_args = CallersCoreArgs {
+            name: "std::fs::read_to_string".into(),
+            limit: 10,
+            edge_kind: None,
+        };
+        let core =
+            serde_json::to_value(callers_core(&ctx.store(), &core_args).expect("callers_core"))
+                .unwrap();
+        assert_eq!(
+            daemon, core,
+            "CLI==daemon parity for external-qualifier doc edge"
+        );
+    }
+
     /// A bare name with more than one definition lists the `Type::method`
     /// candidate forms + per-type counts, and CLI==daemon agree.
     #[test]

--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -1520,4 +1520,234 @@ mod tests {
         );
         assert_eq!(daemon, core, "cross-project impact parity mismatch");
     }
+
+    // ===== total-count, Type::method, candidates, parity =====
+
+    /// Build a method-def chunk under an enclosing type at a given origin/line.
+    fn type_method_chunk(file: &str, name: &str, line: u32, parent: Option<&str>) -> Chunk {
+        let content = format!("fn {name}() {{}}");
+        let content_hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+        Chunk {
+            id: format!("{file}:{line}:{name}"),
+            file: PathBuf::from(file),
+            language: Language::Rust,
+            chunk_type: ChunkType::Function,
+            name: name.to_string(),
+            signature: format!("fn {name}()"),
+            content,
+            doc: None,
+            line_start: line,
+            line_end: line + 1,
+            content_hash,
+            canonical_hash: String::new(),
+            parent_id: None,
+            window_idx: None,
+            parent_type_name: parent.map(String::from),
+            parser_version: 0,
+        }
+    }
+
+    /// Seed two types (`Store`, `Index`) each defining `search`, plus a caller
+    /// in each type calling its own `search`, plus a free function calling
+    /// `search` bare. Returns a read-only daemon context over the index.
+    fn seed_type_method_ctx() -> (TempDir, crate::cli::batch::BatchContext) {
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        let mut emb_vec = vec![0.0_f32; cqs::EMBEDDING_DIM];
+        emb_vec[0] = 1.0;
+        let embedding = Embedding::new(emb_vec);
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            let chunks = vec![
+                (
+                    type_method_chunk("store.rs", "search", 10, Some("Store")),
+                    embedding.clone(),
+                ),
+                (
+                    type_method_chunk("index.rs", "search", 10, Some("Index")),
+                    embedding.clone(),
+                ),
+                (
+                    type_method_chunk("store.rs", "store_self", 20, Some("Store")),
+                    embedding.clone(),
+                ),
+                (
+                    type_method_chunk("index.rs", "index_self", 20, Some("Index")),
+                    embedding.clone(),
+                ),
+                (
+                    type_method_chunk("free.rs", "free_fn", 20, None),
+                    embedding.clone(),
+                ),
+            ];
+            store
+                .upsert_chunks_batch(&chunks, Some(0))
+                .expect("upsert chunks");
+            for (file, caller, line) in [
+                ("store.rs", "store_self", 20u32),
+                ("index.rs", "index_self", 20),
+                ("free.rs", "free_fn", 20),
+            ] {
+                let fc = FunctionCalls {
+                    name: caller.to_string(),
+                    line_start: line,
+                    calls: vec![CallSite {
+                        callee_name: "search".to_string(),
+                        line_number: line + 1,
+                        kind: CallEdgeKind::Call,
+                    }],
+                };
+                store
+                    .upsert_function_calls(Path::new(file), &[fc])
+                    .expect("upsert edge");
+            }
+        }
+        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
+        (dir, ctx)
+    }
+
+    /// A clipped window surfaces both `count` (page size) and `total` (pre-cap
+    /// count) so the truncation is visible. Seed three callers, ask for
+    /// one.
+    #[test]
+    fn callers_total_count_when_clipped() {
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            let calls: Vec<FunctionCalls> = (0..3)
+                .map(|i| FunctionCalls {
+                    name: format!("caller_{i}"),
+                    line_start: (i + 1) as u32,
+                    calls: vec![CallSite {
+                        callee_name: "hot".to_string(),
+                        line_number: (i + 1) as u32,
+                        kind: CallEdgeKind::Call,
+                    }],
+                })
+                .collect();
+            store
+                .upsert_function_calls(Path::new("src/lib.rs"), &calls)
+                .expect("upsert edges");
+        }
+        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
+        let args = CallersArgs {
+            name: "hot".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 1 },
+            edge_kind: None,
+        };
+        let json = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
+        assert_eq!(json["count"], 1, "page is one entry");
+        assert_eq!(json["total"], 3, "total reflects the full pre-cap set");
+    }
+
+    /// `Type::method` returns only the queried type's self-callers plus
+    /// ambiguous (free-function) callers; callers in a *different* type that
+    /// owns its own `search` are excluded. Verified on the daemon
+    /// surface and pinned CLI==daemon.
+    #[test]
+    fn callers_type_method_picks_right_type_and_parity() {
+        use crate::cli::commands::{callers_core, CallersCoreArgs};
+        let (_dir, ctx) = seed_type_method_ctx();
+        let args = CallersArgs {
+            name: "Store::search".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
+            edge_kind: None,
+        };
+        let daemon = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
+
+        let names: Vec<&str> = daemon["callers"]
+            .as_array()
+            .expect("callers array")
+            .iter()
+            .map(|c| c["name"].as_str().unwrap())
+            .collect();
+        assert!(
+            names.contains(&"store_self"),
+            "self-caller included: {names:?}"
+        );
+        assert!(
+            names.contains(&"free_fn"),
+            "ambiguous free fn included: {names:?}"
+        );
+        assert!(
+            !names.contains(&"index_self"),
+            "Index's own caller excluded: {names:?}"
+        );
+        // The free function's receiver is unproven → flagged ambiguous; the
+        // self-call carries no attribution (proven).
+        let free = daemon["callers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["name"] == "free_fn")
+            .unwrap();
+        assert_eq!(free["attribution"], "ambiguous");
+        let self_caller = daemon["callers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["name"] == "store_self")
+            .unwrap();
+        assert!(
+            self_caller.get("attribution").is_none(),
+            "proven self-call omits attribution"
+        );
+
+        // CLI==daemon parity.
+        let core_args = CallersCoreArgs {
+            name: "Store::search".into(),
+            limit: 10,
+            edge_kind: None,
+        };
+        let core =
+            serde_json::to_value(callers_core(&ctx.store(), &core_args).expect("callers_core"))
+                .unwrap();
+        assert_eq!(daemon, core, "CLI==daemon parity for Type::method callers");
+    }
+
+    /// A bare name with more than one definition lists the `Type::method`
+    /// candidate forms + per-type counts, and CLI==daemon agree.
+    #[test]
+    fn callers_bare_multi_def_lists_candidates_and_parity() {
+        use crate::cli::commands::{callers_core, CallersCoreArgs};
+        let (_dir, ctx) = seed_type_method_ctx();
+        let args = CallersArgs {
+            name: "search".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
+            edge_kind: None,
+        };
+        let daemon = dispatch_callers(&ctx.build_view(None), &args).expect("dispatch_callers");
+        let candidates = daemon["candidates"]
+            .as_array()
+            .expect("bare multi-def name carries candidates");
+        let quals: Vec<&str> = candidates
+            .iter()
+            .map(|c| c["qualified"].as_str().unwrap())
+            .collect();
+        assert!(quals.contains(&"Store::search"), "candidates: {quals:?}");
+        assert!(quals.contains(&"Index::search"), "candidates: {quals:?}");
+
+        let core_args = CallersCoreArgs {
+            name: "search".into(),
+            limit: 10,
+            edge_kind: None,
+        };
+        let core =
+            serde_json::to_value(callers_core(&ctx.store(), &core_args).expect("callers_core"))
+                .unwrap();
+        assert_eq!(
+            daemon, core,
+            "CLI==daemon parity for bare multi-def candidates"
+        );
+    }
 }

--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -121,6 +121,12 @@ pub(crate) struct CallerEntry {
     /// the default `call` kind; rendered omitted.
     #[serde(skip_serializing_if = "String::is_empty")]
     pub edge_kind: String,
+    /// Receiver-type attribution for a `Type::method` query. Empty on
+    /// the bare-name path (no qualifier) and on proven self-calls; `"ambiguous"`
+    /// when the caller's receiver could not be proven to be the queried Type
+    /// (over-reported with a flag rather than dropped).
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub attribution: String,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -147,22 +153,56 @@ pub(crate) fn edge_kind_field(kind: CallEdgeKind) -> String {
     }
 }
 
-/// Function-path output for `cqs callers <name>`: `{name, callers, count}`.
-/// The mirror of [`CalleesOutput`] — both commands share one object
+/// One `Type::method` disambiguation candidate: an enclosing type that
+/// defines a same-named method, and how many definitions it carries. Emitted in
+/// `CallersOutput::candidates` / `CalleesOutput::candidates` when a *bare* name
+/// resolves to more than one definition, so the user learns the qualified forms
+/// they can re-query with.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct DefCandidate {
+    /// `Type::method`, or the bare method name for a free-function definition
+    /// (no enclosing type).
+    pub qualified: String,
+    /// Number of definitions under this enclosing type.
+    pub count: usize,
+}
+
+/// Function-path output for `cqs callers <name>`: `{name, callers, count,
+/// total}`. The mirror of [`CalleesOutput`] — both commands share one object
 /// topology so agents key-probe (`callers` vs `calls`) rather than
 /// discriminating array-vs-object.
 #[derive(Debug, serde::Serialize)]
 pub(crate) struct CallersOutput {
     pub name: String,
     pub callers: Vec<CallerEntry>,
+    /// Number of entries in `callers` (the returned page after the `--limit`
+    /// truncation).
     pub count: usize,
+    /// Total callers before the `--limit` cap clipped the page. Equals `count`
+    /// when nothing was dropped. Surfacing it keeps a capped window
+    /// from reading as a complete list — a caller that sees `count < total`
+    /// knows to paginate or raise `--limit`.
+    pub total: usize,
+    /// Disambiguation candidates when a *bare* name has more than one
+    /// definition. Empty (omitted) for a single-def name or a
+    /// `Type::method`-qualified query. Tells the user the `Type::method` forms
+    /// available to narrow the query.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub candidates: Vec<DefCandidate>,
 }
 
 #[derive(Debug, serde::Serialize)]
 pub(crate) struct CalleesOutput {
     pub name: String,
     pub calls: Vec<CalleeEntry>,
+    /// Number of entries in `calls` (the returned page after `--limit`).
     pub count: usize,
+    /// Total callees before the `--limit` cap. See [`CallersOutput::total`].
+    pub total: usize,
+    /// Disambiguation candidates for a bare multi-def name. See
+    /// [`CallersOutput::candidates`].
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub candidates: Vec<DefCandidate>,
 }
 
 /// Single JSON-schema source for `cqs callers <name>`. Happy path is the
@@ -203,24 +243,30 @@ pub(crate) fn build_caller_entries(callers: &[CallerInfo]) -> Vec<CallerEntry> {
             line_start: c.line,
             project: String::new(),
             edge_kind: edge_kind_field(c.edge_kind),
+            attribution: String::new(),
         })
         .collect()
 }
 
-/// Build typed callers output (`{name, callers, count}`) -- the function-path
-/// shape both surfaces emit. Mirror of [`build_callees`].
-pub(crate) fn build_callers(name: &str, callers: &[CallerInfo]) -> CallersOutput {
+/// Build typed callers output (`{name, callers, count, total}`) -- the
+/// function-path shape both surfaces emit. Mirror of [`build_callees`].
+/// `callers` is the already-truncated page; `total` is the pre-cap count so
+/// a clipped window is visible rather than silent.
+pub(crate) fn build_callers(name: &str, callers: &[CallerInfo], total: usize) -> CallersOutput {
     let _span = tracing::info_span!("build_callers", name, count = callers.len()).entered();
     let entries = build_caller_entries(callers);
     CallersOutput {
         name: name.to_string(),
         count: entries.len(),
         callers: entries,
+        total,
+        candidates: Vec::new(),
     }
 }
 
-/// Build typed callees output -- shared between CLI and batch.
-pub(crate) fn build_callees(name: &str, callees: &[CalleeInfo]) -> CalleesOutput {
+/// Build typed callees output -- shared between CLI and batch. `callees` is
+/// the truncated page; `total` is the pre-cap count.
+pub(crate) fn build_callees(name: &str, callees: &[CalleeInfo], total: usize) -> CalleesOutput {
     let _span = tracing::info_span!("build_callees", name, count = callees.len()).entered();
     CalleesOutput {
         name: name.to_string(),
@@ -234,6 +280,8 @@ pub(crate) fn build_callees(name: &str, callees: &[CalleeInfo]) -> CalleesOutput
             })
             .collect(),
         count: callees.len(),
+        total,
+        candidates: Vec::new(),
     }
 }
 
@@ -255,6 +303,13 @@ pub(crate) fn callers_core(
     // before rendering so the user can paginate via repeated calls.
     let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
+    // `Type::method` receiver-type disambiguation. Resolved read-side
+    // from `chunks.parent_type_name`, before kind detection (which classifies
+    // the *bare* name, never the qualified form).
+    if let Some((qual_type, method)) = split_type_qualifier(&args.name) {
+        return callers_qualified(store, qual_type, method, args.edge_kind, limit);
+    }
+
     // Polymorphic-routing kind detection. Dispatch the kind-mismatch
     // fallback before the call-graph query.
     let (chunks, fallback) = super::detect_fallback(store, &args.name);
@@ -273,10 +328,128 @@ pub(crate) fn callers_core(
     if let Some(want) = args.edge_kind {
         callers.retain(|c| c.edge_kind == want);
     }
+    // Total is the post-filter, pre-cap count so `total` reflects exactly the
+    // set the user could page through with a larger `--limit`.
+    let total = callers.len();
     callers.truncate(limit);
-    Ok(CallersCoreOutput::Callers(build_callers(
-        &args.name, &callers,
-    )))
+    let mut output = build_callers(&args.name, &callers, total);
+    // A bare name with more than one definition advertises the `Type::method`
+    // forms the user can re-query with.
+    output.candidates = multi_def_candidates(store, &args.name)?;
+    Ok(CallersCoreOutput::Callers(output))
+}
+
+/// Split a `Type::method` qualifier into `(type, method)`, or `None` for a
+/// bare name. Only the *last* `::` separates the receiver type from
+/// the method, so a path-qualified `module::Type::method` keeps
+/// `module::Type` as the receiver. Empty halves (`::method`, `Type::`) are
+/// rejected — they're not a usable qualifier.
+fn split_type_qualifier(name: &str) -> Option<(&str, &str)> {
+    let (ty, method) = name.rsplit_once("::")?;
+    if ty.is_empty() || method.is_empty() {
+        return None;
+    }
+    Some((ty, method))
+}
+
+/// Build the `candidates` list for a bare multi-def name: the
+/// `Type::method` qualified forms (and free-function bare form) the user can
+/// narrow to. Returns empty when the name has a single definition (nothing to
+/// disambiguate). Best-effort — a classification read error degrades to no
+/// candidates rather than failing the whole command.
+fn multi_def_candidates(store: &Store<ReadOnly>, name: &str) -> Result<Vec<DefCandidate>> {
+    let defs = match store.count_method_defs_by_type(name) {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::warn!(error = %e, name, "candidate lookup failed; omitting candidates");
+            return Ok(Vec::new());
+        }
+    };
+    // One definition (or none) ⇒ no ambiguity to surface.
+    if defs.len() <= 1 {
+        return Ok(Vec::new());
+    }
+    Ok(defs
+        .into_iter()
+        .map(|(ty, count)| DefCandidate {
+            qualified: match ty {
+                Some(t) => format!("{t}::{name}"),
+                None => name.to_string(),
+            },
+            count,
+        })
+        .collect())
+}
+
+/// Resolve the queried `Type::method`'s callers with receiver-type
+/// attribution. `other_owner_types` (every *other* type that defines
+/// a same-named method) drives the exclusion of callers that target a
+/// different type's method; everything else is included, with unproven
+/// receivers flagged `ambiguous`.
+fn callers_qualified(
+    store: &Store<ReadOnly>,
+    qual_type: &str,
+    method: &str,
+    edge_kind: Option<CallEdgeKind>,
+    limit: usize,
+) -> Result<CallersCoreOutput> {
+    let other_owner_types = other_owner_types(store, method, qual_type)?;
+    let mut attributed = store
+        .get_callers_attributed(method, qual_type, &other_owner_types)
+        .context("Failed to load attributed callers")?;
+    if let Some(want) = edge_kind {
+        attributed.retain(|a| a.caller.edge_kind == want);
+    }
+    let total = attributed.len();
+    attributed.truncate(limit);
+    let entries: Vec<CallerEntry> = attributed
+        .iter()
+        .map(|a| CallerEntry {
+            name: a.caller.name.clone(),
+            file: normalize_path(&a.caller.file).to_string(),
+            line_start: a.caller.line,
+            project: String::new(),
+            edge_kind: edge_kind_field(a.caller.edge_kind),
+            attribution: attribution_field(a.attribution),
+        })
+        .collect();
+    Ok(CallersCoreOutput::Callers(CallersOutput {
+        name: format!("{qual_type}::{method}"),
+        count: entries.len(),
+        callers: entries,
+        total,
+        candidates: Vec::new(),
+    }))
+}
+
+/// The set of enclosing types (other than `qual_type`) that define a method
+/// named `method`. Callers parented to one of these target *that* type's
+/// method, so the `Type::method` resolution excludes them.
+fn other_owner_types(
+    store: &Store<ReadOnly>,
+    method: &str,
+    qual_type: &str,
+) -> Result<std::collections::HashSet<String>> {
+    let defs = store
+        .count_method_defs_by_type(method)
+        .context("Failed to enumerate method definitions")?;
+    Ok(defs
+        .into_iter()
+        .filter_map(|(ty, _)| ty)
+        .filter(|t| t != qual_type)
+        .collect())
+}
+
+/// Map a [`cqs::store::CallerAttribution`] to the skip-when-empty wire field:
+/// a proven self-call (`SelfType`) renders the empty string (omitted); an
+/// unproven receiver (`Ambiguous`) emits `"ambiguous"`.
+fn attribution_field(a: cqs::store::CallerAttribution) -> String {
+    match a {
+        cqs::store::CallerAttribution::SelfType => String::new(),
+        cqs::store::CallerAttribution::Ambiguous => {
+            cqs::store::CallerAttribution::Ambiguous.label().to_string()
+        }
+    }
 }
 
 /// Surface-agnostic core for `cqs callees <name>` (single-project).
@@ -287,6 +460,12 @@ pub(crate) fn callees_core(
     let _span =
         tracing::info_span!("callees_core", name = %args.name, limit = args.limit).entered();
     let limit = args.limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
+
+    // `Type::method` scoping: callees of the method as defined under
+    // the queried type, scoped by the def's origin file(s).
+    if let Some((qual_type, method)) = split_type_qualifier(&args.name) {
+        return callees_qualified(store, qual_type, method, args.edge_kind, limit);
+    }
 
     let (chunks, fallback) = super::detect_fallback(store, &args.name);
     if let Some(fk) = fallback {
@@ -302,9 +481,48 @@ pub(crate) fn callees_core(
     if let Some(want) = args.edge_kind {
         callees.retain(|c| c.edge_kind == want);
     }
+    let total = callees.len();
+    callees.truncate(limit);
+    let mut output = build_callees(&args.name, &callees, total);
+    output.candidates = multi_def_candidates(store, &args.name)?;
+    Ok(CalleesCoreOutput::Callees(output))
+}
+
+/// Resolve callees of `Type::method` by scoping `get_callees_full` to
+/// the origin file(s) where the type's method is defined. Callees carry no
+/// receiver-type ambiguity (they are the methods *this* method calls), so no
+/// attribution marker is emitted. A union over multiple defining files (rare)
+/// is deduplicated by `(name, line)`.
+fn callees_qualified(
+    store: &Store<ReadOnly>,
+    qual_type: &str,
+    method: &str,
+    edge_kind: Option<CallEdgeKind>,
+    limit: usize,
+) -> Result<CalleesCoreOutput> {
+    let origins = store
+        .get_type_method_origins(qual_type, method)
+        .context("Failed to resolve type-method origins")?;
+    let name = format!("{qual_type}::{method}");
+    let mut callees: Vec<CalleeInfo> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for origin in &origins {
+        let part = store
+            .get_callees_full(method, Some(origin))
+            .context("Failed to load callees")?;
+        for c in part {
+            if seen.insert((c.name.clone(), c.line)) {
+                callees.push(c);
+            }
+        }
+    }
+    if let Some(want) = edge_kind {
+        callees.retain(|c| c.edge_kind == want);
+    }
+    let total = callees.len();
     callees.truncate(limit);
     Ok(CalleesCoreOutput::Callees(build_callees(
-        &args.name, &callees,
+        &name, &callees, total,
     )))
 }
 
@@ -333,6 +551,7 @@ pub(crate) fn callers_cross_core(
     let mut callers = cross_ctx
         .get_callers_cross(&args.name)
         .context("Failed to load cross-project callers")?;
+    let total = callers.len();
     callers.truncate(limit);
     let entries: Vec<CallerEntry> = callers
         .iter()
@@ -344,12 +563,17 @@ pub(crate) fn callers_cross_core(
             // Cross-project edges come from the in-memory CallGraph (no
             // edge_kind tracking) — always the default `call`, rendered omitted.
             edge_kind: edge_kind_field(c.caller.edge_kind),
+            // Cross-project has no Type::method resolution (no parent_type_name
+            // in the merged CallGraph) — never attributed.
+            attribution: String::new(),
         })
         .collect();
     Ok(CallersOutput {
         name: args.name.clone(),
         count: entries.len(),
         callers: entries,
+        total,
+        candidates: Vec::new(),
     })
 }
 
@@ -367,6 +591,7 @@ pub(crate) fn callees_cross_core(
     let mut callees = cross_ctx
         .get_callees_cross(&args.name)
         .context("Failed to load cross-project callees")?;
+    let total = callees.len();
     callees.truncate(limit);
     let calls: Vec<CalleeEntry> = callees
         .iter()
@@ -383,6 +608,8 @@ pub(crate) fn callees_cross_core(
         name: args.name.clone(),
         count: calls.len(),
         calls,
+        total,
+        candidates: Vec::new(),
     })
 }
 
@@ -433,7 +660,7 @@ pub(crate) fn cmd_callers(
                 );
             }
             println!();
-            println!("Total: {} caller(s)", output.count);
+            print_caller_total(output.count, output.total);
         }
         return Ok(());
     }
@@ -459,6 +686,7 @@ pub(crate) fn cmd_callers(
                 crate::cli::json_envelope::emit_json(&output)?;
             } else if output.callers.is_empty() {
                 println!("No callers found for '{}'", name);
+                print_candidates(&output.candidates);
             } else {
                 println!("Functions that call '{}':", name);
                 println!();
@@ -468,20 +696,74 @@ pub(crate) fn cmd_callers(
                     } else {
                         format!(" [{}]", caller.edge_kind.dimmed())
                     };
+                    // An unproven receiver (`Type::method` over-report) is
+                    // flagged inline so the user never reads it as certain.
+                    let attr_suffix = if caller.attribution.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" [{}]", caller.attribution.yellow())
+                    };
                     println!(
-                        "  {} ({}:{}){}",
+                        "  {} ({}:{}){}{}",
                         caller.name.cyan(),
                         caller.file,
                         caller.line_start,
-                        kind_suffix
+                        kind_suffix,
+                        attr_suffix
                     );
                 }
                 println!();
-                println!("Total: {} caller(s)", output.count);
+                print_caller_total(output.count, output.total);
+                print_candidates(&output.candidates);
             }
         }
     }
     Ok(())
+}
+
+/// Print the `Type::method` disambiguation candidates for a bare multi-def
+/// name. No-op when the list is empty (single-def name or a qualified
+/// query). The hint tells the user the qualified forms they can narrow to.
+fn print_candidates(candidates: &[DefCandidate]) {
+    if candidates.is_empty() {
+        return;
+    }
+    println!();
+    println!(
+        "{}",
+        "This name has multiple definitions — narrow with a Type qualifier:".dimmed()
+    );
+    for c in candidates {
+        let plural = if c.count == 1 { "def" } else { "defs" };
+        println!("  {} ({} {})", c.qualified.cyan(), c.count, plural);
+    }
+}
+
+/// Render the caller total line, surfacing a clipped window: when the
+/// `--limit` cap dropped callers, the line reads `Showing N of M caller(s)
+/// (raise --limit to see more)` rather than a bare `Total: N` that hides the
+/// truncation. When nothing was dropped it stays `Total: M caller(s)`.
+fn print_caller_total(shown: usize, total: usize) {
+    if total > shown {
+        println!(
+            "Showing {} of {} caller(s) (raise --limit to see more)",
+            shown, total
+        );
+    } else {
+        println!("Total: {} caller(s)", total);
+    }
+}
+
+/// Mirror of [`print_caller_total`] for the callees surface.
+fn print_callee_total(shown: usize, total: usize) {
+    if total > shown {
+        println!(
+            "Showing {} of {} call(s) (raise --limit to see more)",
+            shown, total
+        );
+    } else {
+        println!("Total: {} call(s)", total);
+    }
 }
 
 /// Re-classify and render the plain-text callers fallback. The core
@@ -541,7 +823,7 @@ pub(crate) fn cmd_callees(
                 }
             }
             println!();
-            println!("Total: {} call(s)", output.count);
+            print_callee_total(output.count, output.total);
         }
         return Ok(());
     }
@@ -580,7 +862,8 @@ pub(crate) fn cmd_callees(
                     }
                 }
                 println!();
-                println!("Total: {} call(s)", output.count);
+                print_callee_total(output.count, output.total);
+                print_candidates(&output.candidates);
             }
         }
     }
@@ -620,6 +903,7 @@ mod tests {
             line_start: 42,
             project: String::new(),
             edge_kind: String::new(),
+            attribution: String::new(),
         };
         let json = serde_json::to_value(&entry).unwrap();
         assert!(json.get("line_start").is_some());
@@ -628,6 +912,8 @@ mod tests {
         assert!(json.get("project").is_none());
         // Default `call` edge omits edge_kind (skip-when-default).
         assert!(json.get("edge_kind").is_none());
+        // Bare-name path omits attribution (skip-when-empty).
+        assert!(json.get("attribution").is_none());
     }
 
     #[test]
@@ -638,6 +924,7 @@ mod tests {
             line_start: 42,
             project: "openclaw".into(),
             edge_kind: String::new(),
+            attribution: String::new(),
         };
         let json = serde_json::to_value(&entry).unwrap();
         assert_eq!(json["project"], "openclaw");
@@ -645,14 +932,15 @@ mod tests {
 
     #[test]
     fn test_build_callers_empty() {
-        let output = build_callers("foo", &[]);
+        let output = build_callers("foo", &[], 0);
         assert_eq!(output.count, 0);
         assert!(output.callers.is_empty());
         let json = serde_json::to_value(&output).unwrap();
-        // Callers now shares the callees object topology: {name, callers, count}.
+        // Callers now shares the callees object topology: {name, callers, count, total}.
         assert_eq!(json["name"], "foo");
         assert!(json["callers"].as_array().unwrap().is_empty());
         assert_eq!(json["count"], 0);
+        assert_eq!(json["total"], 0);
     }
 
     #[test]
@@ -663,10 +951,11 @@ mod tests {
             line: 12,
             edge_kind: CallEdgeKind::Call,
         }];
-        let output = build_callers("target", &info);
+        let output = build_callers("target", &info, 1);
         let json = serde_json::to_value(&output).unwrap();
         assert_eq!(json["name"], "target");
         assert_eq!(json["count"], 1);
+        assert_eq!(json["total"], 1);
         assert_eq!(json["callers"][0]["name"], "caller_fn");
         assert_eq!(json["callers"][0]["line_start"], 12);
         // Mirror of callees: agents key-probe `callers` vs `calls`.
@@ -675,11 +964,29 @@ mod tests {
 
     #[test]
     fn test_build_callees_empty() {
-        let output = build_callees("foo", &[]);
+        let output = build_callees("foo", &[], 0);
         assert_eq!(output.count, 0);
         assert!(output.calls.is_empty());
         let json = serde_json::to_value(&output).unwrap();
         assert_eq!(json["name"], "foo");
+    }
+
+    /// A clipped page (page shorter than the pre-cap total) carries both the
+    /// page `count` and the larger `total`, so a capped window is visible
+    /// rather than silent.
+    #[test]
+    fn test_build_callers_total_reflects_clip() {
+        let info = vec![CallerInfo {
+            name: "shown".into(),
+            file: std::path::PathBuf::from("src/lib.rs"),
+            line: 1,
+            edge_kind: CallEdgeKind::Call,
+        }];
+        // Page of 1, but 7 callers existed before the cap.
+        let output = build_callers("target", &info, 7);
+        let json = serde_json::to_value(&output).unwrap();
+        assert_eq!(json["count"], 1);
+        assert_eq!(json["total"], 7);
     }
 
     #[test]
@@ -691,6 +998,7 @@ mod tests {
                 line: 10,
                 edge_kind: CallEdgeKind::Call,
             }],
+            1,
         );
         let json = serde_json::to_value(&output).unwrap();
         assert_eq!(json["name"], "bar");
@@ -837,7 +1145,7 @@ mod tests {
                 edge_kind: CallEdgeKind::MacroHeuristic,
             },
         ];
-        let output = build_callers("target", &info);
+        let output = build_callers("target", &info, 2);
         let json = serde_json::to_value(&output).unwrap();
         // Syntactic edge omits edge_kind.
         assert!(json["callers"][0].get("edge_kind").is_none());
@@ -853,7 +1161,7 @@ mod tests {
             line: 4,
             edge_kind: CallEdgeKind::FnPointer,
         }];
-        let output = build_callees("caller", &callees);
+        let output = build_callees("caller", &callees, 1);
         let json = serde_json::to_value(&output).unwrap();
         assert_eq!(json["calls"][0]["edge_kind"], "fn_pointer");
     }
@@ -883,5 +1191,32 @@ mod tests {
             serde_json::json!({"name":"f","edge_kind":"nope"})
         )
         .is_err());
+    }
+
+    // ----- Type::method qualifier parsing -----
+
+    #[test]
+    fn split_type_qualifier_splits_on_last_colon_pair() {
+        assert_eq!(
+            split_type_qualifier("Store::search"),
+            Some(("Store", "search"))
+        );
+        // Path-qualified: only the LAST `::` separates the method.
+        assert_eq!(
+            split_type_qualifier("module::Store::search"),
+            Some(("module::Store", "search"))
+        );
+        // Bare name: no qualifier.
+        assert_eq!(split_type_qualifier("search"), None);
+        // Empty halves are not a usable qualifier.
+        assert_eq!(split_type_qualifier("::search"), None);
+        assert_eq!(split_type_qualifier("Store::"), None);
+    }
+
+    #[test]
+    fn attribution_field_skips_self_emits_ambiguous() {
+        use cqs::store::CallerAttribution;
+        assert_eq!(attribution_field(CallerAttribution::SelfType), "");
+        assert_eq!(attribution_field(CallerAttribution::Ambiguous), "ambiguous");
     }
 }

--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -189,6 +189,19 @@ pub(crate) struct CallersOutput {
     /// available to narrow the query.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub candidates: Vec<DefCandidate>,
+    /// On a `Type::method` query, the count of callers heuristically excluded
+    /// because their enclosing type is a *different* type that also defines a
+    /// same-named method. Skip-when-zero (omitted on the bare path and when no
+    /// caller was excluded). The exclusion is a heuristic — a caller in type
+    /// `Index` that calls `store.search()` is excluded though its receiver is
+    /// really a `Store` — so surfacing the count keeps the narrowing visible.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub excluded_other_owner: usize,
+}
+
+/// serde skip predicate for skip-when-zero `usize` fields.
+fn is_zero(n: &usize) -> bool {
+    *n == 0
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -261,6 +274,7 @@ pub(crate) fn build_callers(name: &str, callers: &[CallerInfo], total: usize) ->
         callers: entries,
         total,
         candidates: Vec::new(),
+        excluded_other_owner: 0,
     }
 }
 
@@ -369,23 +383,22 @@ fn multi_def_candidates(store: &Store<ReadOnly>, name: &str) -> Result<Vec<DefCa
     if defs.len() <= 1 {
         return Ok(Vec::new());
     }
-    Ok(defs
-        .into_iter()
-        .map(|(ty, count)| DefCandidate {
-            qualified: match ty {
-                Some(t) => format!("{t}::{name}"),
-                None => name.to_string(),
-            },
-            count,
-        })
-        .collect())
+    Ok(defs_to_candidates(&defs, name))
 }
 
 /// Resolve the queried `Type::method`'s callers with receiver-type
-/// attribution. `other_owner_types` (every *other* type that defines
-/// a same-named method) drives the exclusion of callers that target a
-/// different type's method; everything else is included, with unproven
-/// receivers flagged `ambiguous`.
+/// attribution. `other_owner_types` (every *other* type that defines a
+/// same-named method) drives the heuristic exclusion of callers that appear to
+/// target a different type's method; everything else is included, with
+/// unproven receivers flagged `ambiguous`. The count of excluded callers is
+/// surfaced (`excluded_other_owner`) so the narrowing is visible.
+///
+/// Existence check: when `qual_type` does NOT define `method` — a typo
+/// (`Banana::search`) or a `module::function` path mistaken for a type — the
+/// query resolves no definition. Rather than silently returning bare-method
+/// callers under the bogus qualifier, the output is empty with the real
+/// `Type::method` candidates for that method name listed, so the user sees the
+/// truth.
 fn callers_qualified(
     store: &Store<ReadOnly>,
     qual_type: &str,
@@ -393,8 +406,29 @@ fn callers_qualified(
     edge_kind: Option<CallEdgeKind>,
     limit: usize,
 ) -> Result<CallersCoreOutput> {
-    let other_owner_types = other_owner_types(store, method, qual_type)?;
-    let mut attributed = store
+    // Single scan of the method's definitions feeds both the existence check
+    // and the other-owner-types exclusion set.
+    let defs = store
+        .count_method_defs_by_type(method)
+        .context("Failed to enumerate method definitions")?;
+    let qual_defines = defs.iter().any(|(ty, _)| ty.as_deref() == Some(qual_type));
+    if !qual_defines {
+        // Unknown qualifier: empty result + the real owners as candidates.
+        return Ok(CallersCoreOutput::Callers(CallersOutput {
+            name: format!("{qual_type}::{method}"),
+            callers: Vec::new(),
+            count: 0,
+            total: 0,
+            candidates: defs_to_candidates(&defs, method),
+            excluded_other_owner: 0,
+        }));
+    }
+    let other_owner_types: std::collections::HashSet<String> = defs
+        .iter()
+        .filter_map(|(ty, _)| ty.clone())
+        .filter(|t| t != qual_type)
+        .collect();
+    let (mut attributed, excluded) = store
         .get_callers_attributed(method, qual_type, &other_owner_types)
         .context("Failed to load attributed callers")?;
     if let Some(want) = edge_kind {
@@ -419,25 +453,24 @@ fn callers_qualified(
         callers: entries,
         total,
         candidates: Vec::new(),
+        excluded_other_owner: excluded,
     }))
 }
 
-/// The set of enclosing types (other than `qual_type`) that define a method
-/// named `method`. Callers parented to one of these target *that* type's
-/// method, so the `Type::method` resolution excludes them.
-fn other_owner_types(
-    store: &Store<ReadOnly>,
-    method: &str,
-    qual_type: &str,
-) -> Result<std::collections::HashSet<String>> {
-    let defs = store
-        .count_method_defs_by_type(method)
-        .context("Failed to enumerate method definitions")?;
-    Ok(defs
-        .into_iter()
-        .filter_map(|(ty, _)| ty)
-        .filter(|t| t != qual_type)
-        .collect())
+/// Project a method's definition rows (from [`Store::count_method_defs_by_type`])
+/// into `Type::method` candidate forms. Unlike [`multi_def_candidates`], this
+/// emits the list even for a single owner — the unknown-qualifier path uses it
+/// to show the one real owner of a method the bogus qualifier didn't define.
+fn defs_to_candidates(defs: &[(Option<String>, usize)], method: &str) -> Vec<DefCandidate> {
+    defs.iter()
+        .map(|(ty, count)| DefCandidate {
+            qualified: match ty {
+                Some(t) => format!("{t}::{method}"),
+                None => method.to_string(),
+            },
+            count: *count,
+        })
+        .collect()
 }
 
 /// Map a [`cqs::store::CallerAttribution`] to the skip-when-empty wire field:
@@ -574,6 +607,7 @@ pub(crate) fn callers_cross_core(
         callers: entries,
         total,
         candidates: Vec::new(),
+        excluded_other_owner: 0,
     })
 }
 
@@ -685,8 +719,16 @@ pub(crate) fn cmd_callers(
             if json {
                 crate::cli::json_envelope::emit_json(&output)?;
             } else if output.callers.is_empty() {
-                println!("No callers found for '{}'", name);
-                print_candidates(&output.candidates);
+                // An unknown qualifier (`Banana::search`) returns empty callers
+                // WITH candidates — the real owners. Distinguish it from a
+                // genuinely call-free name (empty callers, no candidates).
+                if name.contains("::") && !output.candidates.is_empty() {
+                    println!("'{}' is not a known Type::method — did you mean:", name);
+                    print_candidate_lines(&output.candidates);
+                } else {
+                    println!("No callers found for '{}'", name);
+                    print_candidates(&output.candidates);
+                }
             } else {
                 println!("Functions that call '{}':", name);
                 println!();
@@ -714,11 +756,28 @@ pub(crate) fn cmd_callers(
                 }
                 println!();
                 print_caller_total(output.count, output.total);
+                print_excluded_other_owner(output.excluded_other_owner);
                 print_candidates(&output.candidates);
             }
         }
     }
     Ok(())
+}
+
+/// Print the heuristic-exclusion notice for a `Type::method` query: N callers
+/// were dropped because they sit in a *different* type that also defines the
+/// method. No-op when nothing was excluded. Honors the "never silent
+/// exclusion" promise — the narrowing is shown.
+fn print_excluded_other_owner(excluded: usize) {
+    if excluded == 0 {
+        return;
+    }
+    let plural = if excluded == 1 { "caller" } else { "callers" };
+    println!(
+        "{}",
+        format!("({excluded} {plural} excluded: in another type that also defines this method)")
+            .dimmed()
+    );
 }
 
 /// Print the `Type::method` disambiguation candidates for a bare multi-def
@@ -733,6 +792,12 @@ fn print_candidates(candidates: &[DefCandidate]) {
         "{}",
         "This name has multiple definitions — narrow with a Type qualifier:".dimmed()
     );
+    print_candidate_lines(candidates);
+}
+
+/// Render the candidate lines (`Type::method (N defs)`) shared by the
+/// multi-def hint and the unknown-qualifier "did you mean" path.
+fn print_candidate_lines(candidates: &[DefCandidate]) {
     for c in candidates {
         let plural = if c.count == 1 { "def" } else { "defs" };
         println!("  {} ({} {})", c.qualified.cyan(), c.count, plural);

--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -393,12 +393,21 @@ fn multi_def_candidates(store: &Store<ReadOnly>, name: &str) -> Result<Vec<DefCa
 /// unproven receivers flagged `ambiguous`. The count of excluded callers is
 /// surfaced (`excluded_other_owner`) so the narrowing is visible.
 ///
-/// Existence check: when `qual_type` does NOT define `method` — a typo
-/// (`Banana::search`) or a `module::function` path mistaken for a type — the
-/// query resolves no definition. Rather than silently returning bare-method
-/// callers under the bogus qualifier, the output is empty with the real
-/// `Type::method` candidates for that method name listed, so the user sees the
-/// truth.
+/// Local-definition gate and the unknown-qualifier fallback compose carefully
+/// (see the order below): the exact-qualified arm must run even when
+/// `qual_type` has no local definition, because external / module qualifiers
+/// (`std::fs::read_to_string`, `serde_json::to_value`) exist ONLY as
+/// exact-qualified doc edges with no local type to attribute against.
+///
+/// 1. When `qual_type` has a local def → run the full attributed query
+///    (bare + exact arms), with the other-owner exclusion set.
+/// 2. When it does not → run the EXACT-ONLY query (no bare arm, so local
+///    same-named call sites aren't mis-attributed under a fabricated type).
+///    If that returns any rows, they are real doc edges naming this receiver —
+///    surface them.
+/// 3. Only when BOTH the local def is absent AND the exact arm is empty is it a
+///    genuine typo (`Banana::search`) or a misused path: return empty with the
+///    real `Type::method` candidates listed so the user sees the truth.
 fn callers_qualified(
     store: &Store<ReadOnly>,
     qual_type: &str,
@@ -406,14 +415,34 @@ fn callers_qualified(
     edge_kind: Option<CallEdgeKind>,
     limit: usize,
 ) -> Result<CallersCoreOutput> {
-    // Single scan of the method's definitions feeds both the existence check
-    // and the other-owner-types exclusion set.
+    // Single scan of the method's definitions feeds the local-def gate and the
+    // other-owner-types exclusion set.
     let defs = store
         .count_method_defs_by_type(method)
         .context("Failed to enumerate method definitions")?;
     let qual_defines = defs.iter().any(|(ty, _)| ty.as_deref() == Some(qual_type));
-    if !qual_defines {
-        // Unknown qualifier: empty result + the real owners as candidates.
+
+    // The bare-method arm runs only when the qualifier has a local def; the
+    // exact-qualified arm always runs (see `get_callers_attributed`).
+    let other_owner_types: std::collections::HashSet<String> = if qual_defines {
+        defs.iter()
+            .filter_map(|(ty, _)| ty.clone())
+            .filter(|t| t != qual_type)
+            .collect()
+    } else {
+        std::collections::HashSet::new()
+    };
+    let (mut attributed, excluded) = store
+        .get_callers_attributed(method, qual_type, &other_owner_types, qual_defines)
+        .context("Failed to load attributed callers")?;
+    if let Some(want) = edge_kind {
+        attributed.retain(|a| a.caller.edge_kind == want);
+    }
+
+    // Genuine unknown qualifier: no local def AND no exact-qualified edges.
+    // Surface the real owners as candidates instead of an empty result that
+    // looks like "no callers".
+    if !qual_defines && attributed.is_empty() {
         return Ok(CallersCoreOutput::Callers(CallersOutput {
             name: format!("{qual_type}::{method}"),
             callers: Vec::new(),
@@ -423,17 +452,7 @@ fn callers_qualified(
             excluded_other_owner: 0,
         }));
     }
-    let other_owner_types: std::collections::HashSet<String> = defs
-        .iter()
-        .filter_map(|(ty, _)| ty.clone())
-        .filter(|t| t != qual_type)
-        .collect();
-    let (mut attributed, excluded) = store
-        .get_callers_attributed(method, qual_type, &other_owner_types)
-        .context("Failed to load attributed callers")?;
-    if let Some(want) = edge_kind {
-        attributed.retain(|a| a.caller.edge_kind == want);
-    }
+
     let total = attributed.len();
     attributed.truncate(limit);
     let entries: Vec<CallerEntry> = attributed

--- a/src/cli/commands/graph/explain.rs
+++ b/src/cli/commands/graph/explain.rs
@@ -235,6 +235,9 @@ pub(crate) fn build_explain_output(data: &ExplainData, root: &Path) -> ExplainOu
             line_start: c.line,
             project: String::new(),
             edge_kind: super::callers::edge_kind_field(c.edge_kind),
+            // explain renders the bare-name caller list — no Type::method
+            // receiver resolution here.
+            attribution: String::new(),
         })
         .collect();
 
@@ -511,6 +514,7 @@ mod output_tests {
                 line_start: 42,
                 project: String::new(),
                 edge_kind: String::new(),
+                attribution: String::new(),
             }],
             callees: vec![CalleeEntry {
                 name: "callee_b".into(),
@@ -566,6 +570,7 @@ mod output_tests {
                 line_start: 5,
                 project: String::new(),
                 edge_kind: String::new(),
+                attribution: String::new(),
             }],
             callees: vec![],
             similar: vec![],

--- a/src/store/calls/query.rs
+++ b/src/store/calls/query.rs
@@ -19,17 +19,20 @@ impl<Mode> Store<Mode> {
             // Collapse duplicate (file, caller, line) edges to a single row,
             // keeping the most-trusted kind. `MIN(rank_case)` over the explicit
             // trust rank (call < serde < macro < fn-pointer < doc-reference)
-            // replaces the old lexical `MIN(edge_kind)` — alphabetical ordering
-            // was a coincidence and `doc_reference` ('d') breaks it. SQLite's
+            // replaces a lexical `MIN(edge_kind)` — alphabetical ordering was a
+            // coincidence and `doc_reference` ('d') breaks it. SQLite's
             // bare-column rule lets the sibling `edge_kind` take its value from
             // the same min-rank row, so we read the kind and discard the rank.
+            // Trust rank also leads the ORDER BY so a limited window can never
+            // be filled by low-trust `doc_reference` edges while direct `call`
+            // edges sit below it.
             let rank_case = crate::parser::CallEdgeKind::rank_case_sql("edge_kind");
             let sql = format!(
-                "SELECT file, caller_name, caller_line, edge_kind, MIN({rank_case})
+                "SELECT file, caller_name, caller_line, edge_kind, MIN({rank_case}) AS trust_rank
                  FROM function_calls
                  WHERE callee_name = ?1
                  GROUP BY file, caller_name, caller_line
-                 ORDER BY file, caller_line"
+                 ORDER BY trust_rank, file, caller_line"
             );
             let rows: Vec<(String, String, i64, String, i64)> =
                 sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
@@ -51,6 +54,157 @@ impl<Mode> Store<Mode> {
         })
     }
 
+    /// Group a method name's definitions by enclosing type. Returns
+    /// `(parent_type_name, count)` rows — `None` covers free functions and any
+    /// def with no enclosing type. Used to (a) detect that a bare name has
+    /// more than one definition so `cqs callers`/`callees` can advertise the
+    /// `Type::method` disambiguation, and (b) decide, during `Type::method`
+    /// resolution, which *other* types own a same-named method (so callers
+    /// parented to those types are excluded rather than over-reported).
+    ///
+    /// Only callable chunk kinds are counted — a same-named struct/const is
+    /// not a method definition and must not inflate the candidate list.
+    pub fn count_method_defs_by_type(
+        &self,
+        method: &str,
+    ) -> Result<Vec<(Option<String>, usize)>, StoreError> {
+        let _span = tracing::debug_span!("count_method_defs_by_type", method = %method).entered();
+        self.rt.block_on(async {
+            let callable = crate::parser::ChunkType::callable_sql_list();
+            let sql = format!(
+                "SELECT parent_type_name, COUNT(*) AS n
+                 FROM chunks
+                 WHERE name = ?1 AND chunk_type IN ({callable})
+                 GROUP BY parent_type_name
+                 ORDER BY n DESC, parent_type_name"
+            );
+            let rows: Vec<(Option<String>, i64)> =
+                sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
+                    .bind(method)
+                    .fetch_all(&self.pool)
+                    .await?;
+            Ok(rows
+                .into_iter()
+                .map(|(ty, n)| (ty, n.max(0) as usize))
+                .collect())
+        })
+    }
+
+    /// Origins (file paths) where a `Type::method` is defined. Used by
+    /// the callees `Type::method` path to scope `get_callees_full` to the
+    /// right definition. Only callable chunk kinds qualify.
+    pub fn get_type_method_origins(
+        &self,
+        qualifier_type: &str,
+        method: &str,
+    ) -> Result<Vec<String>, StoreError> {
+        let _span = tracing::debug_span!(
+            "get_type_method_origins",
+            qualifier_type = %qualifier_type,
+            method = %method
+        )
+        .entered();
+        self.rt.block_on(async {
+            let callable = crate::parser::ChunkType::callable_sql_list();
+            let sql = format!(
+                "SELECT DISTINCT origin
+                 FROM chunks
+                 WHERE name = ?1 AND parent_type_name = ?2 AND chunk_type IN ({callable})"
+            );
+            let rows: Vec<(String,)> = sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
+                .bind(method)
+                .bind(qualifier_type)
+                .fetch_all(&self.pool)
+                .await?;
+            Ok(rows.into_iter().map(|(o,)| o).collect())
+        })
+    }
+
+    /// Callers of `Type::method`, attributed by receiver type.
+    ///
+    /// Resolution is read-side from `chunks.parent_type_name` — no new
+    /// columns, no parser changes. For each caller of the bare `method`, the
+    /// caller's own enclosing type is looked up by joining `function_calls`
+    /// back to `chunks` on `(file=origin, caller_name=name,
+    /// caller_line=line_start)`. Attribution:
+    ///
+    /// - caller's enclosing type == `qualifier_type` → self-call, included as
+    ///   [`CallerAttribution::SelfType`];
+    /// - caller's enclosing type is a *different* type that itself defines a
+    ///   `method` (per `other_owner_types`) → excluded (it calls that other
+    ///   type's method, not ours);
+    /// - caller has no enclosing type, an enclosing type with no `method` def,
+    ///   or no resolvable chunk → included as [`CallerAttribution::Ambiguous`]
+    ///   (over-report with a flag, never silent exclusion, never false
+    ///   certainty).
+    ///
+    /// `other_owner_types` is the set of enclosing types (other than
+    /// `qualifier_type`) that define a same-named method, derived once by the
+    /// caller from [`count_method_defs_by_type`] so this method stays a single
+    /// scan.
+    pub fn get_callers_attributed(
+        &self,
+        method: &str,
+        qualifier_type: &str,
+        other_owner_types: &std::collections::HashSet<String>,
+    ) -> Result<Vec<crate::store::AttributedCaller>, StoreError> {
+        use crate::store::{AttributedCaller, CallerAttribution, CallerInfo};
+        let _span = tracing::debug_span!(
+            "get_callers_attributed",
+            method = %method,
+            qualifier_type = %qualifier_type
+        )
+        .entered();
+        self.rt.block_on(async {
+            // LEFT JOIN so callers with no matching chunk (e.g. >100-line
+            // functions skipped at extraction) still appear — they resolve to
+            // a NULL enclosing type and fall into the Ambiguous bucket rather
+            // than vanishing. Trust rank leads the collapse + ordering exactly
+            // as `get_callers_full`.
+            let rank_case = crate::parser::CallEdgeKind::rank_case_sql("fc.edge_kind");
+            let sql = format!(
+                "SELECT fc.file, fc.caller_name, fc.caller_line, fc.edge_kind,
+                        MIN({rank_case}) AS trust_rank, c.parent_type_name
+                 FROM function_calls fc
+                 LEFT JOIN chunks c
+                   ON c.origin = fc.file
+                  AND c.name = fc.caller_name
+                  AND c.line_start = fc.caller_line
+                 WHERE fc.callee_name = ?1
+                 GROUP BY fc.file, fc.caller_name, fc.caller_line
+                 ORDER BY trust_rank, fc.file, fc.caller_line"
+            );
+            let rows: Vec<(String, String, i64, String, i64, Option<String>)> =
+                sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
+                    .bind(method)
+                    .fetch_all(&self.pool)
+                    .await?;
+
+            let mut out = Vec::new();
+            for (file, name, line, kind, _rank, parent_type) in rows {
+                let attribution = match parent_type.as_deref() {
+                    Some(t) if t == qualifier_type => CallerAttribution::SelfType,
+                    // Parented to a different type that owns its own `method`:
+                    // this caller targets that type's method, not ours.
+                    Some(t) if other_owner_types.contains(t) => continue,
+                    // No enclosing type, or an enclosing type with no same-named
+                    // method, or an unresolved chunk: receiver unproven.
+                    _ => CallerAttribution::Ambiguous,
+                };
+                out.push(AttributedCaller {
+                    caller: CallerInfo {
+                        file: PathBuf::from(file),
+                        name,
+                        line: clamp_line_number(line),
+                        edge_kind: crate::parser::CallEdgeKind::from_str_or_default(&kind),
+                    },
+                    attribution,
+                });
+            }
+            Ok(out)
+        })
+    }
+
     /// Get all callees of a function (from full call graph)
     /// When `file` is provided, scopes to callees of that function in that specific file.
     /// When `None`, returns callees across all files (backwards compatible, but ambiguous
@@ -65,13 +219,15 @@ impl<Mode> Store<Mode> {
             // MIN over the explicit trust rank per (callee, line) — same
             // most-trusted-wins collapse as get_callers_full, replacing the old
             // lexical `MIN(edge_kind)` that `doc_reference` would break.
+            // Trust rank leads the ORDER BY so direct call edges
+            // outrank doc_reference within any `--limit` window.
             let rank_case = crate::parser::CallEdgeKind::rank_case_sql("edge_kind");
             let sql = format!(
-                "SELECT callee_name, call_line, edge_kind, MIN({rank_case})
+                "SELECT callee_name, call_line, edge_kind, MIN({rank_case}) AS trust_rank
                  FROM function_calls
                  WHERE caller_name = ?1 AND (?2 IS NULL OR file = ?2)
                  GROUP BY callee_name, call_line
-                 ORDER BY call_line"
+                 ORDER BY trust_rank, call_line"
             );
             let rows: Vec<(String, i64, String, i64)> =
                 sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
@@ -177,15 +333,21 @@ impl<Mode> Store<Mode> {
         let _span =
             tracing::debug_span!("get_callers_with_context", function = %callee_name).entered();
         self.rt.block_on(async {
-            let rows: Vec<(String, String, i64, i64, String)> = sqlx::query_as(
+            // Trust rank leads the ORDER BY: `cqs impact` flows through
+            // here, so doc_reference edges must never displace direct call
+            // edges in a capped impact window.
+            let rank_case = crate::parser::CallEdgeKind::rank_case_sql("edge_kind");
+            let sql = format!(
                 "SELECT file, caller_name, caller_line, call_line, edge_kind
                  FROM function_calls
                  WHERE callee_name = ?1
-                 ORDER BY file, call_line",
-            )
-            .bind(callee_name)
-            .fetch_all(&self.pool)
-            .await?;
+                 ORDER BY {rank_case}, file, call_line"
+            );
+            let rows: Vec<(String, String, i64, i64, String)> =
+                sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
+                    .bind(callee_name)
+                    .fetch_all(&self.pool)
+                    .await?;
 
             Ok(rows
                 .into_iter()
@@ -226,14 +388,17 @@ impl<Mode> Store<Mode> {
             // name), so a 5k-name batch runs as a single statement.
             use crate::store::helpers::sql::max_rows_per_statement;
             let batch_size = max_rows_per_statement(1);
+            // Trust rank leads the per-callee ORDER BY, matching the
+            // single-name `get_callers_with_context`.
+            let rank_case = crate::parser::CallEdgeKind::rank_case_sql("edge_kind");
             for batch in callee_names.chunks(batch_size) {
                 let placeholders = super::super::helpers::make_placeholders(batch.len());
                 let sql = format!(
                     "SELECT callee_name, file, caller_name, caller_line, call_line, edge_kind
                      FROM function_calls
                      WHERE callee_name IN ({})
-                     ORDER BY callee_name, file, call_line",
-                    placeholders
+                     ORDER BY callee_name, {}, file, call_line",
+                    placeholders, rank_case
                 );
                 let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for name in batch {
@@ -289,12 +454,14 @@ impl<Mode> Store<Mode> {
             for batch in callee_names.chunks(batch_size) {
                 let placeholders = super::super::helpers::make_placeholders(batch.len());
                 let sql = format!(
-                    "SELECT callee_name, file, caller_name, caller_line, edge_kind, MIN({})
+                    "SELECT callee_name, file, caller_name, caller_line, edge_kind, \
+                            MIN({rank_case}) AS trust_rank
                      FROM function_calls
-                     WHERE callee_name IN ({})
+                     WHERE callee_name IN ({placeholders})
                      GROUP BY callee_name, file, caller_name, caller_line
-                     ORDER BY callee_name, file, caller_line",
-                    rank_case, placeholders
+                     ORDER BY callee_name, trust_rank, file, caller_line",
+                    rank_case = rank_case,
+                    placeholders = placeholders
                 );
                 let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for name in batch {
@@ -345,14 +512,21 @@ impl<Mode> Store<Mode> {
             // 32466-slot budget.
             use crate::store::helpers::sql::max_rows_per_statement;
             let batch_size = max_rows_per_statement(1);
+            // Trust rank leads the per-caller ORDER BY. GROUP BY
+            // collapses a (callee, line) pair appearing as both a call and a
+            // doc_reference edge to a single row at its most-trusted rank,
+            // replacing the old DISTINCT.
+            let rank_case = crate::parser::CallEdgeKind::rank_case_sql("edge_kind");
             for batch in caller_names.chunks(batch_size) {
                 let placeholders = super::super::helpers::make_placeholders(batch.len());
                 let sql = format!(
-                    "SELECT DISTINCT caller_name, callee_name, call_line
+                    "SELECT caller_name, callee_name, call_line, MIN({rank_case}) AS trust_rank
                      FROM function_calls
-                     WHERE caller_name IN ({})
-                     ORDER BY caller_name, call_line",
-                    placeholders
+                     WHERE caller_name IN ({placeholders})
+                     GROUP BY caller_name, callee_name, call_line
+                     ORDER BY caller_name, trust_rank, call_line",
+                    rank_case = rank_case,
+                    placeholders = placeholders
                 );
                 let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()));
                 for name in batch {

--- a/src/store/calls/query.rs
+++ b/src/store/calls/query.rs
@@ -9,6 +9,12 @@ use crate::store::helpers::{
 };
 use crate::store::Store;
 
+/// One attributed-caller row from `get_callers_attributed`'s merged scan:
+/// `(file, caller_name, caller_line, edge_kind, trust_rank,
+/// caller_parent_type, callee_name)`. Aliased to keep the query under
+/// `clippy::type_complexity`.
+type AttributedCallerRow = (String, String, i64, String, i64, Option<String>, String);
+
 impl<Mode> Store<Mode> {
     /// Find all callers of a function (from full call graph)
     pub fn get_callers_full(&self, callee_name: &str) -> Result<Vec<CallerInfo>, StoreError> {
@@ -120,34 +126,52 @@ impl<Mode> Store<Mode> {
         })
     }
 
-    /// Callers of `Type::method`, attributed by receiver type.
+    /// Callers of `Type::method`, attributed by receiver type. Returns the
+    /// attributed callers plus the count of callers excluded as belonging to a
+    /// different owning type (`other_owner_types`).
     ///
     /// Resolution is read-side from `chunks.parent_type_name` — no new
-    /// columns, no parser changes. For each caller of the bare `method`, the
-    /// caller's own enclosing type is looked up by joining `function_calls`
-    /// back to `chunks` on `(file=origin, caller_name=name,
-    /// caller_line=line_start)`. Attribution:
+    /// columns, no parser changes. Two edge populations are merged:
     ///
-    /// - caller's enclosing type == `qualifier_type` → self-call, included as
-    ///   [`CallerAttribution::SelfType`];
-    /// - caller's enclosing type is a *different* type that itself defines a
-    ///   `method` (per `other_owner_types`) → excluded (it calls that other
-    ///   type's method, not ours);
-    /// - caller has no enclosing type, an enclosing type with no `method` def,
-    ///   or no resolvable chunk → included as [`CallerAttribution::Ambiguous`]
-    ///   (over-report with a flag, never silent exclusion, never false
-    ///   certainty).
+    /// 1. **Bare-method edges** (`callee_name = method`): code call sites
+    ///    extracted with the receiver stripped (`store.search()` records
+    ///    callee `search`). The caller's own enclosing type is looked up by
+    ///    joining `function_calls` back to `chunks` on `(file=origin,
+    ///    caller_name=name, caller_line=line_start)`, then attributed:
+    ///    - enclosing type == `qualifier_type` → self-call,
+    ///      [`CallerAttribution::SelfType`];
+    ///    - enclosing type is a *different* type that itself defines a
+    ///      same-named method (per `other_owner_types`) → **heuristically**
+    ///      excluded and counted. This is a heuristic, not a proof: a method
+    ///      on `Index` that calls `store.search()` genuinely targets
+    ///      `Store::search`, yet is excluded because `Index` also defines
+    ///      `search`. The exclusion count is surfaced so the narrowing is
+    ///      visible.
+    ///    - no enclosing type / enclosing type without a same-named method /
+    ///      unresolved chunk → [`CallerAttribution::Ambiguous`] (over-report
+    ///      with a flag, never a silent drop).
+    /// 2. **Exact-qualified edges** (`callee_name = 'Type::method'`): doc
+    ///    references store the full backticked string verbatim (markdown
+    ///    `` `Store::open()` `` records callee `Store::open`). These name the
+    ///    receiver explicitly, so they are unambiguously this method's edges —
+    ///    included at [`CallerAttribution::SelfType`]. Without this merge a
+    ///    `Type::method` query would never reach them (the bare-method query
+    ///    can't match a qualified callee), making them unreachable.
+    ///
+    /// Rows are de-duplicated by `(file, caller_name, caller_line)` so a
+    /// caller that appears in both populations is reported once (the exact
+    /// edge, being proven, wins).
     ///
     /// `other_owner_types` is the set of enclosing types (other than
     /// `qualifier_type`) that define a same-named method, derived once by the
-    /// caller from [`count_method_defs_by_type`] so this method stays a single
-    /// scan.
+    /// caller from [`count_method_defs_by_type`] so this method stays few
+    /// scans.
     pub fn get_callers_attributed(
         &self,
         method: &str,
         qualifier_type: &str,
         other_owner_types: &std::collections::HashSet<String>,
-    ) -> Result<Vec<crate::store::AttributedCaller>, StoreError> {
+    ) -> Result<(Vec<crate::store::AttributedCaller>, usize), StoreError> {
         use crate::store::{AttributedCaller, CallerAttribution, CallerInfo};
         let _span = tracing::debug_span!(
             "get_callers_attributed",
@@ -155,41 +179,62 @@ impl<Mode> Store<Mode> {
             qualifier_type = %qualifier_type
         )
         .entered();
+        let qualified = format!("{qualifier_type}::{method}");
         self.rt.block_on(async {
-            // LEFT JOIN so callers with no matching chunk (e.g. >100-line
-            // functions skipped at extraction) still appear — they resolve to
-            // a NULL enclosing type and fall into the Ambiguous bucket rather
-            // than vanishing. Trust rank leads the collapse + ordering exactly
-            // as `get_callers_full`.
             let rank_case = crate::parser::CallEdgeKind::rank_case_sql("fc.edge_kind");
+            // Both populations in one scan: `callee_name = bare` (code sites,
+            // attributed via the LEFT JOIN to the caller's enclosing type) OR
+            // `callee_name = 'Type::method'` (exact-qualified doc edges, always
+            // this method's). A NULL `parent_type_name` either means the caller
+            // chunk didn't resolve (>100-line skip) or the row is an exact edge.
+            // LEFT JOIN keeps unresolved callers rather than dropping them.
+            // Trust rank leads the collapse + ordering exactly as
+            // `get_callers_full`.
             let sql = format!(
                 "SELECT fc.file, fc.caller_name, fc.caller_line, fc.edge_kind,
-                        MIN({rank_case}) AS trust_rank, c.parent_type_name
+                        MIN({rank_case}) AS trust_rank, c.parent_type_name,
+                        fc.callee_name
                  FROM function_calls fc
                  LEFT JOIN chunks c
                    ON c.origin = fc.file
                   AND c.name = fc.caller_name
                   AND c.line_start = fc.caller_line
-                 WHERE fc.callee_name = ?1
+                 WHERE fc.callee_name = ?1 OR fc.callee_name = ?2
                  GROUP BY fc.file, fc.caller_name, fc.caller_line
                  ORDER BY trust_rank, fc.file, fc.caller_line"
             );
-            let rows: Vec<(String, String, i64, String, i64, Option<String>)> =
-                sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
-                    .bind(method)
-                    .fetch_all(&self.pool)
-                    .await?;
+            let rows: Vec<AttributedCallerRow> = sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
+                .bind(method)
+                .bind(&qualified)
+                .fetch_all(&self.pool)
+                .await?;
 
             let mut out = Vec::new();
-            for (file, name, line, kind, _rank, parent_type) in rows {
-                let attribution = match parent_type.as_deref() {
-                    Some(t) if t == qualifier_type => CallerAttribution::SelfType,
-                    // Parented to a different type that owns its own `method`:
-                    // this caller targets that type's method, not ours.
-                    Some(t) if other_owner_types.contains(t) => continue,
-                    // No enclosing type, or an enclosing type with no same-named
-                    // method, or an unresolved chunk: receiver unproven.
-                    _ => CallerAttribution::Ambiguous,
+            let mut excluded = 0usize;
+            // The GROUP BY (file, caller_name, caller_line) already yields one
+            // row per call site, collapsing a co-located bare code edge and
+            // exact doc edge into a single min-trust-rank row — so the Call
+            // edge (rank 0) wins over the doc edge (rank 4) and the site is
+            // attributed via its enclosing type. No further de-dupe needed.
+            for (file, name, line, kind, _rank, parent_type, callee) in rows {
+                // An exact-qualified edge names the receiver — proven self.
+                let is_exact = callee == qualified;
+                let attribution = if is_exact {
+                    CallerAttribution::SelfType
+                } else {
+                    match parent_type.as_deref() {
+                        Some(t) if t == qualifier_type => CallerAttribution::SelfType,
+                        // Parented to a different type that owns its own
+                        // same-named method — heuristically excluded (the
+                        // receiver could still be ours; the count surfaces it).
+                        Some(t) if other_owner_types.contains(t) => {
+                            excluded += 1;
+                            continue;
+                        }
+                        // No enclosing type, enclosing type without a same-named
+                        // method, or an unresolved chunk: receiver unproven.
+                        _ => CallerAttribution::Ambiguous,
+                    }
                 };
                 out.push(AttributedCaller {
                     caller: CallerInfo {
@@ -201,7 +246,7 @@ impl<Mode> Store<Mode> {
                     attribution,
                 });
             }
-            Ok(out)
+            Ok((out, excluded))
         })
     }
 

--- a/src/store/calls/query.rs
+++ b/src/store/calls/query.rs
@@ -131,13 +131,15 @@ impl<Mode> Store<Mode> {
     /// different owning type (`other_owner_types`).
     ///
     /// Resolution is read-side from `chunks.parent_type_name` — no new
-    /// columns, no parser changes. Two edge populations are merged:
+    /// columns, no parser changes. Up to two edge populations are matched,
+    /// gated by `include_bare`:
     ///
-    /// 1. **Bare-method edges** (`callee_name = method`): code call sites
-    ///    extracted with the receiver stripped (`store.search()` records
-    ///    callee `search`). The caller's own enclosing type is looked up by
-    ///    joining `function_calls` back to `chunks` on `(file=origin,
-    ///    caller_name=name, caller_line=line_start)`, then attributed:
+    /// 1. **Bare-method edges** (`callee_name = method`, only when
+    ///    `include_bare` is true): code call sites extracted with the receiver
+    ///    stripped (`store.search()` records callee `search`). The caller's own
+    ///    enclosing type is looked up by joining `function_calls` back to
+    ///    `chunks` on `(file=origin, caller_name=name, caller_line=line_start)`,
+    ///    then attributed:
     ///    - enclosing type == `qualifier_type` → self-call,
     ///      [`CallerAttribution::SelfType`];
     ///    - enclosing type is a *different* type that itself defines a
@@ -150,46 +152,63 @@ impl<Mode> Store<Mode> {
     ///    - no enclosing type / enclosing type without a same-named method /
     ///      unresolved chunk → [`CallerAttribution::Ambiguous`] (over-report
     ///      with a flag, never a silent drop).
-    /// 2. **Exact-qualified edges** (`callee_name = 'Type::method'`): doc
-    ///    references store the full backticked string verbatim (markdown
-    ///    `` `Store::open()` `` records callee `Store::open`). These name the
-    ///    receiver explicitly, so they are unambiguously this method's edges —
-    ///    included at [`CallerAttribution::SelfType`]. Without this merge a
-    ///    `Type::method` query would never reach them (the bare-method query
+    /// 2. **Exact-qualified edges** (`callee_name = 'Type::method'`, always
+    ///    matched): doc references store the full backticked string verbatim
+    ///    (markdown `` `Store::open()` `` records callee `Store::open`). These
+    ///    name the receiver explicitly, so they are unambiguously this method's
+    ///    edges — included at [`CallerAttribution::SelfType`]. Without this arm
+    ///    a `Type::method` query would never reach them (the bare-method query
     ///    can't match a qualified callee), making them unreachable.
     ///
-    /// Rows are de-duplicated by `(file, caller_name, caller_line)` so a
-    /// caller that appears in both populations is reported once (the exact
-    /// edge, being proven, wins).
+    /// `include_bare` is set false when `qualifier_type` has no local
+    /// definition of `method` — an external / module qualifier like
+    /// `std::fs::read_to_string`, whose only edges are the exact-qualified doc
+    /// references. Running the bare arm there would mis-attribute every local
+    /// `read_to_string` call site as an ambiguous caller under a fabricated
+    /// `std::fs` type, so the bare arm is gated off and only the exact arm runs.
+    ///
+    /// The GROUP BY on `(file, caller_name, caller_line)` collapses a co-located
+    /// bare code edge and exact doc edge to one row (the most-trusted kind), so
+    /// a caller present in both populations is reported once.
     ///
     /// `other_owner_types` is the set of enclosing types (other than
     /// `qualifier_type`) that define a same-named method, derived once by the
     /// caller from [`count_method_defs_by_type`] so this method stays few
-    /// scans.
+    /// scans. It is unused (and typically empty) when `include_bare` is false.
     pub fn get_callers_attributed(
         &self,
         method: &str,
         qualifier_type: &str,
         other_owner_types: &std::collections::HashSet<String>,
+        include_bare: bool,
     ) -> Result<(Vec<crate::store::AttributedCaller>, usize), StoreError> {
         use crate::store::{AttributedCaller, CallerAttribution, CallerInfo};
         let _span = tracing::debug_span!(
             "get_callers_attributed",
             method = %method,
-            qualifier_type = %qualifier_type
+            qualifier_type = %qualifier_type,
+            include_bare
         )
         .entered();
         let qualified = format!("{qualifier_type}::{method}");
         self.rt.block_on(async {
             let rank_case = crate::parser::CallEdgeKind::rank_case_sql("fc.edge_kind");
-            // Both populations in one scan: `callee_name = bare` (code sites,
-            // attributed via the LEFT JOIN to the caller's enclosing type) OR
-            // `callee_name = 'Type::method'` (exact-qualified doc edges, always
-            // this method's). A NULL `parent_type_name` either means the caller
-            // chunk didn't resolve (>100-line skip) or the row is an exact edge.
-            // LEFT JOIN keeps unresolved callers rather than dropping them.
-            // Trust rank leads the collapse + ordering exactly as
-            // `get_callers_full`.
+            // The exact-qualified arm always runs. The bare-method arm is gated
+            // by `include_bare` — off for external/module qualifiers with no
+            // local def, so their local same-named call sites aren't
+            // mis-attributed. A NULL `parent_type_name` means the caller chunk
+            // didn't resolve (>100-line skip) or the row is an exact edge. LEFT
+            // JOIN keeps unresolved callers rather than dropping them. Trust rank
+            // leads the collapse + ordering exactly as `get_callers_full`.
+            //
+            // `?1` binds the bare name only when `include_bare`; otherwise it is
+            // bound to the exact-qualified string too, so the predicate reduces
+            // to the exact arm (no extra placeholder shape to manage).
+            let bare_bind = if include_bare {
+                method
+            } else {
+                qualified.as_str()
+            };
             let sql = format!(
                 "SELECT fc.file, fc.caller_name, fc.caller_line, fc.edge_kind,
                         MIN({rank_case}) AS trust_rank, c.parent_type_name,
@@ -204,7 +223,7 @@ impl<Mode> Store<Mode> {
                  ORDER BY trust_rank, fc.file, fc.caller_line"
             );
             let rows: Vec<AttributedCallerRow> = sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
-                .bind(method)
+                .bind(bare_bind)
                 .bind(&qualified)
                 .fetch_all(&self.pool)
                 .await?;

--- a/src/store/helpers/mod.rs
+++ b/src/store/helpers/mod.rs
@@ -34,9 +34,9 @@ pub use rows::clamp_line_number;
 
 // Domain types
 pub use types::{
-    CallGraph, CalleeInfo, CallerInfo, CallerWithContext, ChunkIdentity, ChunkSummary, IndexStats,
-    NoteSearchResult, NoteStats, NoteSummary, ParentContext, SearchResult, StaleFile, StaleReport,
-    UnifiedResult,
+    AttributedCaller, CallGraph, CalleeInfo, CallerAttribution, CallerInfo, CallerWithContext,
+    ChunkIdentity, ChunkSummary, IndexStats, NoteSearchResult, NoteStats, NoteSummary,
+    ParentContext, SearchResult, StaleFile, StaleReport, UnifiedResult,
 };
 
 // Search filter

--- a/src/store/helpers/types.rs
+++ b/src/store/helpers/types.rs
@@ -318,6 +318,47 @@ pub struct CallerInfo {
     pub edge_kind: CallEdgeKind,
 }
 
+/// How a caller of a `Type::method`-qualified query was attributed to the
+/// queried Type's definition. The qualifier resolution is
+/// receiver-type disambiguation done read-side from `chunks.parent_type_name`
+/// — no new columns, no parser changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallerAttribution {
+    /// The caller's own enclosing type equals the queried Type — a self-call,
+    /// unambiguously attributed to this Type's method.
+    SelfType,
+    /// The caller has no enclosing type, or an enclosing type that does not
+    /// define a same-named method, or it could not be resolved to a chunk.
+    /// Over-reported (included) but flagged so the user knows the receiver is
+    /// unproven — never silently dropped, never falsely certain.
+    Ambiguous,
+}
+
+impl CallerAttribution {
+    /// Stable wire label for the JSON `attribution` field. `SelfType` is the
+    /// default (proven) attribution and is rendered omitted; only `Ambiguous`
+    /// emits a label, so a marked entry stands out.
+    pub fn label(self) -> &'static str {
+        match self {
+            CallerAttribution::SelfType => "self",
+            CallerAttribution::Ambiguous => "ambiguous",
+        }
+    }
+}
+
+/// A caller of a `Type::method` query, carrying the base [`CallerInfo`] plus
+/// the receiver-type [`CallerAttribution`]. Callers parented to a *different*
+/// type that has its own same-named method are excluded upstream and never
+/// reach this struct.
+#[derive(Debug, Clone)]
+pub struct AttributedCaller {
+    /// The underlying caller (name, file, line, edge kind).
+    pub caller: CallerInfo,
+    /// Whether the receiver was proven (`SelfType`) or is unproven
+    /// (`Ambiguous`).
+    pub attribution: CallerAttribution,
+}
+
 /// Callee information from the full call graph: the called function's name,
 /// the line of the call, and the provenance of the edge. Returned by
 /// `get_callees_full` so the `callees` surface can carry `edge_kind` and the

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -71,6 +71,9 @@ pub use helpers::CallGraph;
 /// Information about a function caller (from call graph).
 pub use helpers::CallerInfo;
 
+/// A caller of a `Type::method` query plus its receiver-type attribution.
+pub use helpers::{AttributedCaller, CallerAttribution};
+
 /// Information about a function callee (from call graph), carrying edge_kind.
 pub use helpers::CalleeInfo;
 

--- a/tests/store_calls_test.rs
+++ b/tests/store_calls_test.rs
@@ -1208,8 +1208,9 @@ fn attributed_callers_pick_right_type() {
     // other_owner_types for Store::search = {Index} (Index also owns `search`).
     let mut others = std::collections::HashSet::new();
     others.insert("Index".to_string());
+    // Store has a local def → bare arm participates.
     let (attributed, excluded) = store
-        .get_callers_attributed("search", "Store", &others)
+        .get_callers_attributed("search", "Store", &others, true)
         .unwrap();
     let names: Vec<_> = attributed
         .iter()
@@ -1286,8 +1287,9 @@ fn attributed_callers_include_exact_qualified_doc_edge() {
         .unwrap();
 
     let others = std::collections::HashSet::new();
+    // Store::open has a local def → bare arm participates.
     let (attributed, _excluded) = store
-        .get_callers_attributed("open", "Store", &others)
+        .get_callers_attributed("open", "Store", &others, true)
         .unwrap();
     let names: Vec<&str> = attributed.iter().map(|a| a.caller.name.as_str()).collect();
     // Both the bare code self-call and the exact-qualified doc edge are present.
@@ -1306,6 +1308,70 @@ fn attributed_callers_include_exact_qualified_doc_edge() {
         .unwrap();
     assert_eq!(doc.attribution, CallerAttribution::SelfType);
     assert_eq!(doc.caller.edge_kind, CallEdgeKind::DocReference);
+}
+
+/// Exact-only path (`include_bare = false`): an external / module qualifier
+/// like `std::fs::read_to_string` has no local def, so the bare arm is gated
+/// off. Its doc edges (callee_name "std::fs::read_to_string") must still be
+/// reached, while a LOCAL bare `read_to_string` call site must NOT be
+/// mis-attributed under the fabricated `std::fs` type.
+#[test]
+fn attributed_callers_exact_only_skips_bare_arm() {
+    let store = TestStore::new();
+    // A local caller making a BARE `read_to_string()` call — must be ignored on
+    // the exact-only path (no `std::fs` type to attribute it to).
+    store
+        .upsert_chunk(
+            &method_chunk("local.rs", "local_reader", 10, Some("Helper")),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+    store
+        .upsert_function_calls(
+            std::path::Path::new("local.rs"),
+            &[FunctionCalls {
+                name: "local_reader".to_string(),
+                line_start: 10,
+                calls: vec![CallSite {
+                    callee_name: "read_to_string".to_string(),
+                    line_number: 11,
+                    kind: CallEdgeKind::Call,
+                }],
+            }],
+        )
+        .unwrap();
+    // A doc reference to `std::fs::read_to_string()` — stored verbatim.
+    store
+        .upsert_function_calls(
+            std::path::Path::new("docs.md"),
+            &[FunctionCalls {
+                name: "IoNotes".to_string(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "std::fs::read_to_string".to_string(),
+                    line_number: 3,
+                    kind: CallEdgeKind::DocReference,
+                }],
+            }],
+        )
+        .unwrap();
+
+    let others = std::collections::HashSet::new();
+    // include_bare = false: external qualifier, no local def.
+    let (attributed, excluded) = store
+        .get_callers_attributed("read_to_string", "std::fs", &others, false)
+        .unwrap();
+    let names: Vec<&str> = attributed.iter().map(|a| a.caller.name.as_str()).collect();
+    assert!(
+        names.contains(&"IoNotes"),
+        "exact-qualified doc edge must be reached on the exact-only path: {names:?}"
+    );
+    assert!(
+        !names.contains(&"local_reader"),
+        "a local bare read_to_string call must NOT be attributed under std::fs: {names:?}"
+    );
+    assert_eq!(excluded, 0);
 }
 
 /// `count_method_defs_by_type` groups a name's callable definitions by

--- a/tests/store_calls_test.rs
+++ b/tests/store_calls_test.rs
@@ -1008,3 +1008,272 @@ fn min_collapse_uses_trust_rank_not_lexical() {
         "serde (rank 1) beats doc_reference (rank 4) despite lexical order"
     );
 }
+
+// ===== trust-rank ordering + Type::method attribution =====
+
+use cqs::parser::FunctionCalls;
+use cqs::store::CallerAttribution;
+
+/// Build a method-def chunk under an enclosing type, located at a given
+/// origin/line so `get_callers_attributed`'s `(origin, name, line_start)` join
+/// resolves it. `chunk_type` is Function (callable) so the candidate/owner
+/// queries count it.
+fn method_chunk(
+    file: &str,
+    name: &str,
+    line: u32,
+    parent_type: Option<&str>,
+) -> cqs::parser::Chunk {
+    use cqs::parser::{ChunkType, Language};
+    let content = format!("fn {name}() {{}}");
+    let hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+    cqs::parser::Chunk {
+        id: format!("{file}:{line}:{}", &hash[..8]),
+        file: std::path::PathBuf::from(file),
+        language: Language::Rust,
+        chunk_type: ChunkType::Function,
+        name: name.to_string(),
+        signature: format!("fn {name}()"),
+        content,
+        doc: None,
+        line_start: line,
+        line_end: line + 1,
+        content_hash: hash,
+        canonical_hash: String::new(),
+        parent_id: None,
+        window_idx: None,
+        parent_type_name: parent_type.map(String::from),
+        parser_version: 0,
+    }
+}
+
+/// A single doc_reference edge must never displace a direct call edge within a
+/// limited window: trust rank leads the ORDER BY. The doc edge sits in
+/// a file (`docs.md`) that sorts before the call edge's file (`src.rs`), so a
+/// lexical `ORDER BY file` would surface it first — the regression this guards.
+#[test]
+fn doc_reference_never_displaces_call_in_window() {
+    let store = TestStore::new();
+    // doc_reference edge from a file that sorts FIRST lexically.
+    store
+        .upsert_function_calls(
+            std::path::Path::new("docs.md"),
+            &[FunctionCalls {
+                name: "doc_mention".to_string(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "target".to_string(),
+                    line_number: 1,
+                    kind: CallEdgeKind::DocReference,
+                }],
+            }],
+        )
+        .unwrap();
+    // Direct call edge from a file that sorts AFTER.
+    store
+        .upsert_function_calls(
+            std::path::Path::new("src.rs"),
+            &[FunctionCalls {
+                name: "real_caller".to_string(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "target".to_string(),
+                    line_number: 2,
+                    kind: CallEdgeKind::Call,
+                }],
+            }],
+        )
+        .unwrap();
+
+    let callers = store.get_callers_full("target").unwrap();
+    assert_eq!(callers.len(), 2);
+    // Trust rank leads: the direct call edge is first despite its file sorting
+    // last. A `--limit 1` window would therefore show the call edge, not the
+    // doc reference.
+    assert_eq!(callers[0].name, "real_caller");
+    assert_eq!(callers[0].edge_kind, CallEdgeKind::Call);
+    assert_eq!(callers[1].edge_kind, CallEdgeKind::DocReference);
+}
+
+/// Same property on the impact path (`get_callers_with_context`, no GROUP BY):
+/// the call edge leads the doc edge regardless of file order.
+#[test]
+fn context_callers_trust_rank_leads() {
+    let store = TestStore::new();
+    store
+        .upsert_function_calls(
+            std::path::Path::new("aaa_docs.md"),
+            &[FunctionCalls {
+                name: "doc_mention".to_string(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "target".to_string(),
+                    line_number: 1,
+                    kind: CallEdgeKind::DocReference,
+                }],
+            }],
+        )
+        .unwrap();
+    store
+        .upsert_function_calls(
+            std::path::Path::new("zzz_src.rs"),
+            &[FunctionCalls {
+                name: "real_caller".to_string(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "target".to_string(),
+                    line_number: 2,
+                    kind: CallEdgeKind::Call,
+                }],
+            }],
+        )
+        .unwrap();
+
+    let callers = store.get_callers_with_context("target").unwrap();
+    assert_eq!(callers[0].edge_kind, CallEdgeKind::Call);
+    assert_eq!(callers[0].name, "real_caller");
+}
+
+/// `Type::method` attribution: a caller whose own enclosing type IS the queried
+/// type is a self-call (`SelfType`); a caller parented to a DIFFERENT type that
+/// has its own same-named method is excluded; a free-function caller (no
+/// enclosing type) is included but flagged `Ambiguous`.
+#[test]
+fn attributed_callers_pick_right_type() {
+    let store = TestStore::new();
+
+    // Two types each define `search`. Store::search lives in store.rs:10,
+    // Index::search in index.rs:10.
+    store
+        .upsert_chunk(
+            &method_chunk("store.rs", "search", 10, Some("Store")),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+    store
+        .upsert_chunk(
+            &method_chunk("index.rs", "search", 10, Some("Index")),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+
+    // Caller chunks: a Store method that self-calls search; an Index method that
+    // calls its own search; a free function that calls search bare.
+    store
+        .upsert_chunk(
+            &method_chunk("store.rs", "store_self", 20, Some("Store")),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+    store
+        .upsert_chunk(
+            &method_chunk("index.rs", "index_self", 20, Some("Index")),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+    store
+        .upsert_chunk(
+            &method_chunk("free.rs", "free_fn", 20, None),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+
+    // Edges: each caller calls `search`.
+    for (file, caller) in [
+        ("store.rs", "store_self"),
+        ("index.rs", "index_self"),
+        ("free.rs", "free_fn"),
+    ] {
+        store
+            .upsert_function_calls(
+                std::path::Path::new(file),
+                &[FunctionCalls {
+                    name: caller.to_string(),
+                    line_start: 20,
+                    calls: vec![CallSite {
+                        callee_name: "search".to_string(),
+                        line_number: 21,
+                        kind: CallEdgeKind::Call,
+                    }],
+                }],
+            )
+            .unwrap();
+    }
+
+    // other_owner_types for Store::search = {Index} (Index also owns `search`).
+    let mut others = std::collections::HashSet::new();
+    others.insert("Index".to_string());
+    let attributed = store
+        .get_callers_attributed("search", "Store", &others)
+        .unwrap();
+    let names: Vec<_> = attributed
+        .iter()
+        .map(|a| (a.caller.name.as_str(), a.attribution))
+        .collect();
+    // index_self is parented to Index (owns its own search) → excluded.
+    assert!(
+        !names.iter().any(|(n, _)| *n == "index_self"),
+        "caller in a different type that owns the method must be excluded, got {names:?}"
+    );
+    // store_self → self-call.
+    assert!(names.contains(&("store_self", CallerAttribution::SelfType)));
+    // free_fn → no enclosing type → ambiguous, included.
+    assert!(names.contains(&("free_fn", CallerAttribution::Ambiguous)));
+}
+
+/// `count_method_defs_by_type` groups a name's callable definitions by
+/// enclosing type, powering the bare-name candidate list and the
+/// other-owner-types exclusion set.
+#[test]
+fn count_method_defs_groups_by_type() {
+    let store = TestStore::new();
+    store
+        .upsert_chunk(
+            &method_chunk("store.rs", "search", 10, Some("Store")),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+    store
+        .upsert_chunk(
+            &method_chunk("index.rs", "search", 10, Some("Index")),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+
+    let defs = store.count_method_defs_by_type("search").unwrap();
+    assert_eq!(defs.len(), 2, "two enclosing types define `search`");
+    let types: std::collections::HashSet<_> = defs.iter().filter_map(|(t, _)| t.clone()).collect();
+    assert!(types.contains("Store"));
+    assert!(types.contains("Index"));
+}
+
+/// `get_type_method_origins` resolves the file(s) defining `Type::method`,
+/// scoping the callees `Type::method` path.
+#[test]
+fn type_method_origins_resolve_def_file() {
+    let store = TestStore::new();
+    store
+        .upsert_chunk(
+            &method_chunk("store.rs", "search", 10, Some("Store")),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+    store
+        .upsert_chunk(
+            &method_chunk("index.rs", "search", 10, Some("Index")),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+
+    let origins = store.get_type_method_origins("Store", "search").unwrap();
+    assert_eq!(origins, vec!["store.rs".to_string()]);
+}

--- a/tests/store_calls_test.rs
+++ b/tests/store_calls_test.rs
@@ -1208,22 +1208,104 @@ fn attributed_callers_pick_right_type() {
     // other_owner_types for Store::search = {Index} (Index also owns `search`).
     let mut others = std::collections::HashSet::new();
     others.insert("Index".to_string());
-    let attributed = store
+    let (attributed, excluded) = store
         .get_callers_attributed("search", "Store", &others)
         .unwrap();
     let names: Vec<_> = attributed
         .iter()
         .map(|a| (a.caller.name.as_str(), a.attribution))
         .collect();
-    // index_self is parented to Index (owns its own search) → excluded.
+    // index_self is parented to Index (owns its own search) → excluded + counted.
     assert!(
         !names.iter().any(|(n, _)| *n == "index_self"),
         "caller in a different type that owns the method must be excluded, got {names:?}"
+    );
+    assert_eq!(
+        excluded, 1,
+        "the one Index-parented caller is counted as excluded"
     );
     // store_self → self-call.
     assert!(names.contains(&("store_self", CallerAttribution::SelfType)));
     // free_fn → no enclosing type → ambiguous, included.
     assert!(names.contains(&("free_fn", CallerAttribution::Ambiguous)));
+}
+
+/// An exact-qualified doc_reference edge (markdown
+/// `` `Store::open()` `` stores callee_name "Store::open") must be reachable
+/// from `callers Store::open`. The bare-method query can't match a qualified
+/// callee, so `get_callers_attributed` merges the exact-qualified rows in at
+/// proven self-attribution. Without the merge these doc edges are unreachable.
+#[test]
+fn attributed_callers_include_exact_qualified_doc_edge() {
+    let store = TestStore::new();
+    // Store::open is defined in store.rs.
+    store
+        .upsert_chunk(
+            &method_chunk("store.rs", "open", 10, Some("Store")),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+    // A code caller of bare `open` inside Store (self-call).
+    store
+        .upsert_chunk(
+            &method_chunk("store.rs", "reopen", 30, Some("Store")),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+    store
+        .upsert_function_calls(
+            std::path::Path::new("store.rs"),
+            &[FunctionCalls {
+                name: "reopen".to_string(),
+                line_start: 30,
+                calls: vec![CallSite {
+                    callee_name: "open".to_string(),
+                    line_number: 31,
+                    kind: CallEdgeKind::Call,
+                }],
+            }],
+        )
+        .unwrap();
+    // A doc file that references `Store::open()` — stored verbatim as the
+    // qualified callee_name.
+    store
+        .upsert_function_calls(
+            std::path::Path::new("docs.md"),
+            &[FunctionCalls {
+                name: "Usage".to_string(),
+                line_start: 1,
+                calls: vec![CallSite {
+                    callee_name: "Store::open".to_string(),
+                    line_number: 5,
+                    kind: CallEdgeKind::DocReference,
+                }],
+            }],
+        )
+        .unwrap();
+
+    let others = std::collections::HashSet::new();
+    let (attributed, _excluded) = store
+        .get_callers_attributed("open", "Store", &others)
+        .unwrap();
+    let names: Vec<&str> = attributed.iter().map(|a| a.caller.name.as_str()).collect();
+    // Both the bare code self-call and the exact-qualified doc edge are present.
+    assert!(
+        names.contains(&"reopen"),
+        "code self-call present: {names:?}"
+    );
+    assert!(
+        names.contains(&"Usage"),
+        "exact-qualified doc edge must be reachable: {names:?}"
+    );
+    // The doc edge is proven self (the receiver is named in the reference).
+    let doc = attributed
+        .iter()
+        .find(|a| a.caller.name == "Usage")
+        .unwrap();
+    assert_eq!(doc.attribution, CallerAttribution::SelfType);
+    assert_eq!(doc.caller.edge_kind, CallEdgeKind::DocReference);
 }
 
 /// `count_method_defs_by_type` groups a name's callable definitions by


### PR DESCRIPTION
Fixes #1837 — the `cqs callers` false-absence — per the corrected diagnosis (read-side ordering + silent truncation, not extraction). Three deliverables, no schema/PARSER_VERSION change, plus two fable-review rounds.

## Deliverables

1. **Trust-rank ordering.** All callers/callees read queries (`get_callers_full`, `get_callers_with_context`, `get_callees_full`, batch variants) lead ORDER BY with the edge-kind trust rank via the existing `CallEdgeKind::rank_case_sql`, then `(file, line)`. Direct call edges can no longer be displaced out of a `--limit` window by `doc_reference` edges (the #1836 regression: `cqs callers search_filtered` default window was 100% CHANGELOG/docs rows; now 100% direct). `cqs impact` inherits via `get_callers_with_context`.
2. **No silent truncation.** `total` (pre-cap count) on `CallersOutput`/`CalleesOutput` + "Showing N of M" text line; a capped window can never read as a complete list. Daemon inherits through the command core; parity tests assert the new fields.
3. **Receiver-type disambiguation (resolution-side).** `cqs callers Type::method` works from the already-indexed `chunks.parent_type_name` — the syntax `CALLERS_AMBIGUOUS_NOTE` always advertised. Self-call attribution via line-level chunk join; callers owned by a *different* type that defines the same method are excluded with a visible `excluded_other_owner` count; unresolvable receivers are included and marked `attribution: "ambiguous"` (over-report with a flag, never fabricate certainty). Bare multi-def names list their qualified candidates.

## Review rounds (fable)

- **Round 1 (F1, blocker):** the qualified path orphaned 1,425 exact-qualified doc edges (`Store::open` ×34 …). Fixed: the attributed query scans both populations (bare + exact-qualified) in one pass, GROUP BY collapsing co-located pairs to the most-trusted row.
- **Round 2 (R1, blocker):** the F3 existence gate pre-empted the F1 exact arm — 72% of qualified edges (external qualifiers: `std::fs::*`, `serde_json::*`) went dark. Fixed: exact arm always runs (`include_bare` gates only the bare-attribution arm); did-you-mean candidates only on genuine typos (no local def AND no exact edges).
- Residuals filed: #1842 (callees same-file merge), #1843 (tied-rank label, cap hint, callees parity).

## Verified live (lane binary, parent index)

- `callers std::fs::read_to_string` → 35 edges (0 before R1 fix)
- `callers Store::open` → total 327 incl. exact-qualified doc edges
- `callers Banana::search_filtered` → candidates `Store::`/`HnswIndex::search_filtered`
- `callers search_filtered` default window → 5/5 direct edges, total 67
- No bare local call mis-attributed under an external qualifier

Part of the #1821 result-trust program (§2 calibration: absence you can trust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
