### PR TITLE
docs(agents): route fable-seated work to opus — fable disabled by export order

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,7 +1,8 @@
 ---
 name: code-reviewer
 description: "Review current diff for risk, impact, and correctness before commit/PR"
-model: fable
+# fable is the to-restore default; disabled 2026-06-12 by US export order, opus until it returns
+model: opus
 tools:
   - Bash
   - Read

--- a/.claude/agents/seam-auditor.md
+++ b/.claude/agents/seam-auditor.md
@@ -1,7 +1,8 @@
 ---
 name: seam-auditor
-description: Composition adversary - finds two correct units whose join lies. Orthogonal to the house happy/sad-path signature; dispatch during audits, after multi-lane merges, or from the idle loop. Fable-seated (pure judgment work).
-model: fable
+description: Composition adversary - finds two correct units whose join lies. Orthogonal to the house happy/sad-path signature; dispatch during audits, after multi-lane merges, or from the idle loop. Fable-seated (pure judgment work) — but fable is disabled 2026-06-12 by US export order, so opus-seated until it returns.
+# fable is the to-restore default; disabled 2026-06-12 by US export order, opus until it returns
+model: opus
 tools: Bash, Read, Glob, Grep
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,7 @@ Use teams when dispatching 2+ agents that need coordination. Teams provide task 
 
 **Conventions:**
 - Name teams by purpose: `audit-batch-1`, `feat-streaming`, `refactor-errors`
+- ⚠️ **FABLE DISABLED 2026-06-12 by US export order (temporary, no timeline).** Until access is restored, **every `fable` below is overridden to `opus`** — wherever this file, a skill, or an agent def says to dispatch fable (reviews, seam-audits, audit finders, orchestration/judge passes), use opus instead. Dispatching fable now fails mid-run and wastes the lane. Revert to the split below when an announcement or a successful fable dispatch confirms it's back; don't assume restoration from silence.
 - Model split: `opus` implements, `fable` orchestrates/reviews/audits. EXCEPTION: security lanes (audit Security category, /red-team, security reviews) stay `opus`. Sonnet only for mechanical test-only tasks; haiku for doc-only edits.
 - Always clean up teams when done (`Teammate cleanup`)
 - Teammates can't see your text output — use `SendMessage` to communicate


### PR DESCRIPTION
Fable 5 + Mythos are disabled for all users globally as of 2026-06-12 (US export-control directive — temporary, no timeline; Opus/Sonnet/Haiku unaffected). https://www.anthropic.com/news/fable-mythos-access

A fable dispatch now fails mid-run with a model-access error — it already killed one PR review this session before the report step. This routes fable-seated work to opus until access returns:

- **code-reviewer + seam-auditor** frontmatter `model: fable` → `model: opus` (the live dead-dispatch traps; `fable` recorded as the to-restore default in a comment).
- **CLAUDE.md Agent Teams** gains an authoritative override banner: every `fable` in this repo's skills (audit, idle, archeo, red-team) resolves to opus until restored — one statement instead of rewriting each skill for a temporary condition.

Revert when an announcement or a successful fable dispatch confirms access is back. Docs/agent-defs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
