### PR TITLE
fix(graph): Type::method callees disambiguation + tied-rank label + cap hint (#1842, #1843)

### DIFF
--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -1760,6 +1760,142 @@ mod tests {
         assert_eq!(daemon, core, "CLI==daemon parity for unknown qualifier");
     }
 
+    /// Callees mirror of the unknown-qualifier path: `cqs callees Banana::search`
+    /// (no `Banana` defines `search`) returns empty calls WITH the real owners
+    /// as candidates, rather than a bare "no calls". CLI==daemon agree.
+    #[test]
+    fn callees_unknown_qualifier_lists_real_owners_and_parity() {
+        let (_dir, ctx) = seed_type_method_ctx();
+        let args = CallersArgs {
+            name: "Banana::search".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
+            edge_kind: None,
+        };
+        let daemon = dispatch_callees(&ctx.build_view(None), &args).expect("dispatch_callees");
+        assert_eq!(daemon["count"], 0, "no callees under a bogus qualifier");
+        assert!(
+            daemon["calls"].as_array().unwrap().is_empty(),
+            "calls empty: {daemon}"
+        );
+        let quals: Vec<&str> = daemon["candidates"]
+            .as_array()
+            .expect("unknown qualifier lists the real owners")
+            .iter()
+            .map(|c| c["qualified"].as_str().unwrap())
+            .collect();
+        assert!(quals.contains(&"Store::search"), "candidates: {quals:?}");
+        assert!(quals.contains(&"Index::search"), "candidates: {quals:?}");
+
+        let core_args = CoreCalleesArgs {
+            name: "Banana::search".into(),
+            limit: 10,
+            edge_kind: None,
+        };
+        let core =
+            serde_json::to_value(callees_core(&ctx.store(), &core_args).expect("callees_core"))
+                .unwrap();
+        assert_eq!(
+            daemon, core,
+            "CLI==daemon parity for callees unknown qualifier"
+        );
+    }
+
+    /// Two same-named methods sharing a file keep disjoint callees: a
+    /// `Store::build` (line 10) and a `StoreBuilder::build` (line 50) both in
+    /// `store.rs` each call a distinct helper. The line-scoped def resolution
+    /// must return only the queried type's callees, not the union — verified
+    /// end-to-end through `callees_core`, with CLI==daemon parity.
+    #[test]
+    fn callees_same_file_same_name_methods_stay_disjoint_and_parity() {
+        let dir = TempDir::new().expect("tempdir");
+        let cqs_dir = dir.path().join(".cqs");
+        std::fs::create_dir_all(&cqs_dir).expect("mkdir .cqs");
+        let index_path = cqs_dir.join(cqs::INDEX_DB_FILENAME);
+        let mut emb_vec = vec![0.0_f32; cqs::EMBEDDING_DIM];
+        emb_vec[0] = 1.0;
+        let embedding = Embedding::new(emb_vec);
+        {
+            let store = Store::open(&index_path).expect("open store");
+            store.init(&ModelInfo::default()).expect("init");
+            store
+                .upsert_chunks_batch(
+                    &[
+                        (
+                            type_method_chunk("store.rs", "build", 10, Some("Store")),
+                            embedding.clone(),
+                        ),
+                        (
+                            type_method_chunk("store.rs", "build", 50, Some("StoreBuilder")),
+                            embedding.clone(),
+                        ),
+                    ],
+                    Some(0),
+                )
+                .expect("upsert chunks");
+            // Both defs live in store.rs; upsert_function_calls is per-file
+            // (DELETE-then-insert), so write both in one call.
+            store
+                .upsert_function_calls(
+                    Path::new("store.rs"),
+                    &[
+                        FunctionCalls {
+                            name: "build".to_string(),
+                            line_start: 10,
+                            calls: vec![CallSite {
+                                callee_name: "store_helper".to_string(),
+                                line_number: 11,
+                                kind: CallEdgeKind::Call,
+                            }],
+                        },
+                        FunctionCalls {
+                            name: "build".to_string(),
+                            line_start: 50,
+                            calls: vec![CallSite {
+                                callee_name: "builder_helper".to_string(),
+                                line_number: 51,
+                                kind: CallEdgeKind::Call,
+                            }],
+                        },
+                    ],
+                )
+                .expect("upsert edges");
+        }
+        let ctx = create_test_context(&cqs_dir).expect("create_test_context");
+
+        let args = CallersArgs {
+            name: "Store::build".into(),
+            cross_project: false,
+            limit_arg: crate::cli::args::LimitArg { limit: 10 },
+            edge_kind: None,
+        };
+        let daemon = dispatch_callees(&ctx.build_view(None), &args).expect("dispatch_callees");
+        let calls: Vec<&str> = daemon["calls"]
+            .as_array()
+            .expect("calls array")
+            .iter()
+            .map(|c| c["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            calls,
+            vec!["store_helper"],
+            "Store::build callees must exclude StoreBuilder::build's: {daemon}"
+        );
+
+        let core_args = CoreCalleesArgs {
+            name: "Store::build".into(),
+            limit: 10,
+            edge_kind: None,
+        };
+        let core =
+            serde_json::to_value(callees_core(&ctx.store(), &core_args).expect("callees_core"))
+                .unwrap();
+        assert_eq!(
+            daemon, core,
+            "CLI==daemon parity for same-file disjoint callees"
+        );
+    }
+
     /// `cqs callers Store::open` reaches the exact-qualified doc_reference
     /// edge (markdown stored callee_name "Store::open") alongside attributed
     /// code callers — through the daemon surface, with CLI==daemon parity.

--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -528,7 +528,7 @@ pub(crate) fn callees_core(
     }
 
     let mut callees = store
-        .get_callees_full(&args.name, None)
+        .get_callees_full(&args.name, None, None)
         .context("Failed to load callees")?;
     if let Some(want) = args.edge_kind {
         callees.retain(|c| c.edge_kind == want);
@@ -541,10 +541,24 @@ pub(crate) fn callees_core(
 }
 
 /// Resolve callees of `Type::method` by scoping `get_callees_full` to
-/// the origin file(s) where the type's method is defined. Callees carry no
-/// receiver-type ambiguity (they are the methods *this* method calls), so no
-/// attribution marker is emitted. A union over multiple defining files (rare)
-/// is deduplicated by `(name, line)`.
+/// the definition site(s) — origin file AND def start line — where the type's
+/// method is defined. Callees carry no receiver-type ambiguity (they are the
+/// methods *this* method calls), so no attribution marker is emitted. A union
+/// over multiple defining sites (rare) is deduplicated by `(origin, name,
+/// line)` — origin is part of the key so two same-named callees at the same
+/// line in different files don't collapse.
+///
+/// Line-level scoping (mirroring the callers side's `(origin, name,
+/// line_start)` join) prevents two same-named methods sharing a file — a
+/// `Store` and a `StoreBuilder` both defining `build` in `store.rs` — from
+/// merging their callees under either `Type::method` query.
+///
+/// When the qualifier has no local definition of `method` (an external /
+/// unknown qualifier like `std::fs::read_to_string`, or a typo like
+/// `Banana::search`), the def-site list is empty and there are no callees to
+/// show. Rather than a bare "no callees", surface the real owners as
+/// disambiguation candidates (the callers side does the same), so the user
+/// learns the qualified forms that actually resolve.
 fn callees_qualified(
     store: &Store<ReadOnly>,
     qual_type: &str,
@@ -552,18 +566,37 @@ fn callees_qualified(
     edge_kind: Option<CallEdgeKind>,
     limit: usize,
 ) -> Result<CalleesCoreOutput> {
-    let origins = store
-        .get_type_method_origins(qual_type, method)
-        .context("Failed to resolve type-method origins")?;
+    let def_sites = store
+        .get_type_method_def_sites(qual_type, method)
+        .context("Failed to resolve type-method def sites")?;
     let name = format!("{qual_type}::{method}");
+
+    // No local def under this qualifier → no callees exist for it. Mirror the
+    // callers side: if the method is defined under OTHER types, the qualifier
+    // is wrong/unknown — surface those owners as candidates instead of an empty
+    // result that reads as "this method calls nothing".
+    if def_sites.is_empty() {
+        let defs = store
+            .count_method_defs_by_type(method)
+            .context("Failed to enumerate method definitions")?;
+        let candidates = defs_to_candidates(&defs, method);
+        return Ok(CalleesCoreOutput::Callees(CalleesOutput {
+            name,
+            calls: Vec::new(),
+            count: 0,
+            total: 0,
+            candidates,
+        }));
+    }
+
     let mut callees: Vec<CalleeInfo> = Vec::new();
     let mut seen = std::collections::HashSet::new();
-    for origin in &origins {
+    for (origin, line) in &def_sites {
         let part = store
-            .get_callees_full(method, Some(origin))
+            .get_callees_full(method, Some(origin), Some(*line))
             .context("Failed to load callees")?;
         for c in part {
-            if seen.insert((c.name.clone(), c.line)) {
+            if seen.insert((origin.clone(), c.name.clone(), c.line)) {
                 callees.push(c);
             }
         }
@@ -824,14 +857,16 @@ fn print_candidate_lines(candidates: &[DefCandidate]) {
 }
 
 /// Render the caller total line, surfacing a clipped window: when the
-/// `--limit` cap dropped callers, the line reads `Showing N of M caller(s)
-/// (raise --limit to see more)` rather than a bare `Total: N` that hides the
+/// `--limit` cap dropped callers, the line reads `Showing N of M caller(s)`
+/// plus a paging hint, rather than a bare `Total: N` that hides the
 /// truncation. When nothing was dropped it stays `Total: M caller(s)`.
 fn print_caller_total(shown: usize, total: usize) {
     if total > shown {
         println!(
-            "Showing {} of {} caller(s) (raise --limit to see more)",
-            shown, total
+            "Showing {} of {} caller(s) ({})",
+            shown,
+            total,
+            paging_hint(total)
         );
     } else {
         println!("Total: {} caller(s)", total);
@@ -842,11 +877,28 @@ fn print_caller_total(shown: usize, total: usize) {
 fn print_callee_total(shown: usize, total: usize) {
     if total > shown {
         println!(
-            "Showing {} of {} call(s) (raise --limit to see more)",
-            shown, total
+            "Showing {} of {} call(s) ({})",
+            shown,
+            total,
+            paging_hint(total)
         );
     } else {
         println!("Total: {} call(s)", total);
+    }
+}
+
+/// The paging hint for a clipped window. `--limit` can only reach
+/// [`GRAPH_LIMIT_CAP`] entries, so once `total` exceeds the cap the bare
+/// "raise --limit" advice dead-ends — there's no `--limit` value that pages
+/// past it. In that case point at the working escape hatch instead: most of a
+/// hot name's tail is low-trust `doc_reference` edges, so
+/// `--edge-kind doc_reference` (or any other kind) narrows to a slice that fits
+/// under the cap.
+fn paging_hint(total: usize) -> &'static str {
+    if total > crate::cli::GRAPH_LIMIT_CAP {
+        "raise --limit, or narrow with --edge-kind (e.g. doc_reference) to page the rest"
+    } else {
+        "raise --limit to see more"
     }
 }
 
@@ -931,18 +983,29 @@ pub(crate) fn cmd_callees(
         CalleesCoreOutput::Callees(output) => {
             if json {
                 crate::cli::json_envelope::emit_json(&output)?;
+            } else if output.calls.is_empty() {
+                // An unknown qualifier (`Banana::search`) returns empty calls
+                // WITH candidates — the real owners. Mirror cmd_callers so the
+                // user sees the did-you-mean list instead of a bare "no calls".
+                if name.contains("::") && !output.candidates.is_empty() {
+                    println!("'{}' is not a known Type::method — did you mean:", name);
+                    print_candidate_lines(&output.candidates);
+                } else {
+                    println!("Functions called by '{}':", name.cyan());
+                    println!();
+                    println!("  (no function calls found)");
+                    println!();
+                    print_callee_total(output.count, output.total);
+                    print_candidates(&output.candidates);
+                }
             } else {
                 println!("Functions called by '{}':", name.cyan());
                 println!();
-                if output.calls.is_empty() {
-                    println!("  (no function calls found)");
-                } else {
-                    for callee in &output.calls {
-                        if callee.edge_kind.is_empty() {
-                            println!("  {}", callee.name);
-                        } else {
-                            println!("  {} [{}]", callee.name, callee.edge_kind.dimmed());
-                        }
+                for callee in &output.calls {
+                    if callee.edge_kind.is_empty() {
+                        println!("  {}", callee.name);
+                    } else {
+                        println!("  {} [{}]", callee.name, callee.edge_kind.dimmed());
                     }
                 }
                 println!();
@@ -1302,5 +1365,28 @@ mod tests {
         use cqs::store::CallerAttribution;
         assert_eq!(attribution_field(CallerAttribution::SelfType), "");
         assert_eq!(attribution_field(CallerAttribution::Ambiguous), "ambiguous");
+    }
+
+    // ----- Paging hint -----
+
+    /// A clipped window whose total fits under the cap advises `--limit`; a
+    /// window whose total EXCEEDS the cap (where `--limit` dead-ends, since it
+    /// clamps to `GRAPH_LIMIT_CAP`) advises the `--edge-kind` escape hatch
+    /// instead. Pinned so the hint can't silently regress to the dead-end
+    /// wording.
+    #[test]
+    fn paging_hint_switches_to_edge_kind_past_cap() {
+        // Below the cap: a larger --limit can still reach everything.
+        let under = paging_hint(crate::cli::GRAPH_LIMIT_CAP);
+        assert_eq!(under, "raise --limit to see more");
+        assert!(!under.contains("--edge-kind"));
+        // Above the cap: --limit can't page past GRAPH_LIMIT_CAP, so the hint
+        // points at --edge-kind filtering.
+        let over = paging_hint(crate::cli::GRAPH_LIMIT_CAP + 1);
+        assert!(
+            over.contains("--edge-kind"),
+            "past the cap, the hint must mention --edge-kind: {over:?}"
+        );
+        assert!(over.contains("doc_reference"));
     }
 }

--- a/src/cli/commands/graph/explain.rs
+++ b/src/cli/commands/graph/explain.rs
@@ -66,7 +66,7 @@ pub(crate) fn build_explain_data<Mode>(
     // Explain's surface doesn't carry edge_kind, so project CalleeInfo to the
     // (name, line) tuple shape its CalleeEntry expects.
     let chunk_file = chunk.file.to_string_lossy();
-    let callees = match store.get_callees_full(&chunk.name, Some(&chunk_file)) {
+    let callees = match store.get_callees_full(&chunk.name, Some(&chunk_file), None) {
         Ok(c) => c.into_iter().map(|ci| (ci.name, ci.line)).collect(),
         Err(e) => {
             tracing::warn!(error = %e, name = chunk.name, "Failed to get callees in explain");

--- a/src/cli/commands/train/train_pairs.rs
+++ b/src/cli/commands/train/train_pairs.rs
@@ -54,7 +54,7 @@ fn build_contrastive_prefix<Mode>(store: &Store<Mode>, chunk: &ChunkSummary) -> 
     let _span = tracing::debug_span!("build_contrastive_prefix", name = %chunk.name).entered();
 
     let callees = store
-        .get_callees_full(&chunk.name, None)
+        .get_callees_full(&chunk.name, None, None)
         .unwrap_or_else(|e| {
             tracing::warn!(error = %e, name = %chunk.name, "Failed to get callees for contrastive");
             Vec::new()

--- a/src/store/calls/query.rs
+++ b/src/store/calls/query.rs
@@ -10,7 +10,7 @@ use crate::store::helpers::{
 use crate::store::Store;
 
 /// One attributed-caller row from `get_callers_attributed`'s merged scan:
-/// `(file, caller_name, caller_line, edge_kind, trust_rank,
+/// `(file, caller_name, caller_line, edge_kind, pick_rank,
 /// caller_parent_type, callee_name)`. Aliased to keep the query under
 /// `clippy::type_complexity`.
 type AttributedCallerRow = (String, String, i64, String, i64, Option<String>, String);
@@ -96,16 +96,20 @@ impl<Mode> Store<Mode> {
         })
     }
 
-    /// Origins (file paths) where a `Type::method` is defined. Used by
-    /// the callees `Type::method` path to scope `get_callees_full` to the
-    /// right definition. Only callable chunk kinds qualify.
-    pub fn get_type_method_origins(
+    /// Definition sites `(origin, line_start)` where a `Type::method` is
+    /// defined. Used by the callees `Type::method` path to scope
+    /// `get_callees_full` to the right definition — both the file AND the
+    /// def's start line, so two same-named methods sharing a file (a `Store`
+    /// and a `StoreBuilder` both defining `build` in `store.rs`) resolve to
+    /// disjoint callee sets rather than merging. Only callable chunk kinds
+    /// qualify.
+    pub fn get_type_method_def_sites(
         &self,
         qualifier_type: &str,
         method: &str,
-    ) -> Result<Vec<String>, StoreError> {
+    ) -> Result<Vec<(String, i64)>, StoreError> {
         let _span = tracing::debug_span!(
-            "get_type_method_origins",
+            "get_type_method_def_sites",
             qualifier_type = %qualifier_type,
             method = %method
         )
@@ -113,16 +117,16 @@ impl<Mode> Store<Mode> {
         self.rt.block_on(async {
             let callable = crate::parser::ChunkType::callable_sql_list();
             let sql = format!(
-                "SELECT DISTINCT origin
+                "SELECT DISTINCT origin, line_start
                  FROM chunks
                  WHERE name = ?1 AND parent_type_name = ?2 AND chunk_type IN ({callable})"
             );
-            let rows: Vec<(String,)> = sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
+            let rows: Vec<(String, i64)> = sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
                 .bind(method)
                 .bind(qualifier_type)
                 .fetch_all(&self.pool)
                 .await?;
-            Ok(rows.into_iter().map(|(o,)| o).collect())
+            Ok(rows.into_iter().collect())
         })
     }
 
@@ -209,10 +213,22 @@ impl<Mode> Store<Mode> {
             } else {
                 qualified.as_str()
             };
+            // `pick_rank` is the collapse key: `rank_case * 2` plus a 0/1
+            // qualified-vs-bare tiebreaker (exact-qualified ⇒ 0). The GROUP BY
+            // bare-column rule then sources `edge_kind`, `parent_type_name`, and
+            // `callee_name` from the row with the minimum `pick_rank`. The
+            // tiebreaker makes that selection deterministic when a bare code
+            // edge and an exact-qualified doc edge tie on trust rank at the same
+            // call site: the exact edge wins, so the SelfType-vs-ambiguous label
+            // is stable across runs rather than picked arbitrarily by SQLite.
+            // `pick_rank` preserves trust order (qualified-first within a rank),
+            // so it also leads the ORDER BY.
             let sql = format!(
                 "SELECT fc.file, fc.caller_name, fc.caller_line, fc.edge_kind,
-                        MIN({rank_case}) AS trust_rank, c.parent_type_name,
-                        fc.callee_name
+                        MIN({rank_case} * 2
+                            + (CASE WHEN fc.callee_name = ?2 THEN 0 ELSE 1 END))
+                          AS pick_rank,
+                        c.parent_type_name, fc.callee_name
                  FROM function_calls fc
                  LEFT JOIN chunks c
                    ON c.origin = fc.file
@@ -220,7 +236,7 @@ impl<Mode> Store<Mode> {
                   AND c.line_start = fc.caller_line
                  WHERE fc.callee_name = ?1 OR fc.callee_name = ?2
                  GROUP BY fc.file, fc.caller_name, fc.caller_line
-                 ORDER BY trust_rank, fc.file, fc.caller_line"
+                 ORDER BY pick_rank, fc.file, fc.caller_line"
             );
             let rows: Vec<AttributedCallerRow> = sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
                 .bind(bare_bind)
@@ -273,10 +289,17 @@ impl<Mode> Store<Mode> {
     /// When `file` is provided, scopes to callees of that function in that specific file.
     /// When `None`, returns callees across all files (backwards compatible, but ambiguous
     /// for common names like `new`, `parse`, `from_str`).
+    /// When `caller_line` is provided, additionally scopes to the definition
+    /// starting at that line (`function_calls.caller_line` is the caller's
+    /// `line_start`). This disambiguates two same-named methods sharing a file —
+    /// e.g. a `Store` and a `StoreBuilder` both defining `build` in `store.rs` —
+    /// which `(caller_name, file)` alone would merge. `None` keeps the
+    /// file-or-global scope.
     pub fn get_callees_full(
         &self,
         caller_name: &str,
         file: Option<&str>,
+        caller_line: Option<i64>,
     ) -> Result<Vec<CalleeInfo>, StoreError> {
         let _span = tracing::debug_span!("get_callees_full", function = %caller_name).entered();
         self.rt.block_on(async {
@@ -289,7 +312,9 @@ impl<Mode> Store<Mode> {
             let sql = format!(
                 "SELECT callee_name, call_line, edge_kind, MIN({rank_case}) AS trust_rank
                  FROM function_calls
-                 WHERE caller_name = ?1 AND (?2 IS NULL OR file = ?2)
+                 WHERE caller_name = ?1
+                   AND (?2 IS NULL OR file = ?2)
+                   AND (?3 IS NULL OR caller_line = ?3)
                  GROUP BY callee_name, call_line
                  ORDER BY trust_rank, call_line"
             );
@@ -297,6 +322,7 @@ impl<Mode> Store<Mode> {
                 sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
                     .bind(caller_name)
                     .bind(file)
+                    .bind(caller_line)
                     .fetch_all(&self.pool)
                     .await?;
 

--- a/tests/graph_test.rs
+++ b/tests/graph_test.rs
@@ -366,7 +366,10 @@ fn explain_process_reports_callers_and_callees() {
     // Compose what the CLI's build_explain_data does at the lib level:
     // callers + callees for a target name.
     let callers = f.store.get_callers_full("process").expect("callers");
-    let callees = f.store.get_callees_full("process", None).expect("callees");
+    let callees = f
+        .store
+        .get_callees_full("process", None, None)
+        .expect("callees");
 
     let caller_names: Vec<&str> = callers.iter().map(|c| c.name.as_str()).collect();
     let callee_names: Vec<&str> = callees.iter().map(|c| c.name.as_str()).collect();
@@ -452,7 +455,7 @@ fn explain_data_integrates_callers_callees_similar_and_hints() {
     let callers = f.store.get_callers_full(&chunk.name).expect("callers");
     let callees = f
         .store
-        .get_callees_full(&chunk.name, Some(&chunk.file.to_string_lossy()))
+        .get_callees_full(&chunk.name, Some(&chunk.file.to_string_lossy()), None)
         .expect("callees");
 
     // 3. Similar via semantic search seeded with the chunk's stored

--- a/tests/index_search_test.rs
+++ b/tests/index_search_test.rs
@@ -138,7 +138,7 @@ fn callees_returns_data_for_caller() {
     )]);
     let callees = f
         .store
-        .get_callees_full("outer", None)
+        .get_callees_full("outer", None, None)
         .expect("get_callees_full");
     let names: Vec<&str> = callees.iter().map(|c| c.name.as_str()).collect();
     assert!(

--- a/tests/store_calls_test.rs
+++ b/tests/store_calls_test.rs
@@ -704,7 +704,7 @@ fn edge_kind_round_trips_through_function_calls() {
     assert_eq!(syn_callers[0].edge_kind, CallEdgeKind::Call);
 
     // Callee side: get_callees_full carries the kind too.
-    let callees = store.get_callees_full("caller_fn", None).unwrap();
+    let callees = store.get_callees_full("caller_fn", None, None).unwrap();
     let macro_callee = callees.iter().find(|c| c.name == "macro_callee").unwrap();
     assert_eq!(macro_callee.edge_kind, CallEdgeKind::MacroHeuristic);
 }
@@ -1402,10 +1402,11 @@ fn count_method_defs_groups_by_type() {
     assert!(types.contains("Index"));
 }
 
-/// `get_type_method_origins` resolves the file(s) defining `Type::method`,
-/// scoping the callees `Type::method` path.
+/// `get_type_method_def_sites` resolves the `(file, line_start)` site(s)
+/// defining `Type::method`, scoping the callees `Type::method` path to the
+/// exact definition.
 #[test]
-fn type_method_origins_resolve_def_file() {
+fn type_method_def_sites_resolve_def_file_and_line() {
     let store = TestStore::new();
     store
         .upsert_chunk(
@@ -1416,12 +1417,139 @@ fn type_method_origins_resolve_def_file() {
         .unwrap();
     store
         .upsert_chunk(
-            &method_chunk("index.rs", "search", 10, Some("Index")),
+            &method_chunk("index.rs", "search", 20, Some("Index")),
             &mock_embedding(1.0),
             Some(1),
         )
         .unwrap();
 
-    let origins = store.get_type_method_origins("Store", "search").unwrap();
-    assert_eq!(origins, vec!["store.rs".to_string()]);
+    let sites = store.get_type_method_def_sites("Store", "search").unwrap();
+    assert_eq!(sites, vec![("store.rs".to_string(), 10)]);
+}
+
+/// Two same-named methods sharing a file must keep disjoint callees
+/// under the line-scoped query. A `Store::build` (line 10) and a
+/// `StoreBuilder::build` (line 50) both in `store.rs` each call a distinct
+/// helper; without line scoping `(caller_name, file)` would merge both callee
+/// sets under either `build` query.
+#[test]
+fn callees_line_scope_separates_same_named_methods_in_one_file() {
+    use cqs::parser::FunctionCalls;
+    let store = TestStore::new();
+    // Both defs live in store.rs; `upsert_function_calls` is per-file
+    // (DELETE-then-insert), so write both in one call. Store::build at line 10
+    // calls `store_helper`; StoreBuilder::build at line 50 calls
+    // `builder_helper`.
+    store
+        .upsert_function_calls(
+            std::path::Path::new("store.rs"),
+            &[
+                FunctionCalls {
+                    name: "build".to_string(),
+                    line_start: 10,
+                    calls: vec![CallSite {
+                        callee_name: "store_helper".to_string(),
+                        line_number: 11,
+                        kind: CallEdgeKind::Call,
+                    }],
+                },
+                FunctionCalls {
+                    name: "build".to_string(),
+                    line_start: 50,
+                    calls: vec![CallSite {
+                        callee_name: "builder_helper".to_string(),
+                        line_number: 51,
+                        kind: CallEdgeKind::Call,
+                    }],
+                },
+            ],
+        )
+        .unwrap();
+
+    // Line-scoped: each def sees only its own callee.
+    let store_callees = store
+        .get_callees_full("build", Some("store.rs"), Some(10))
+        .unwrap();
+    let store_names: Vec<&str> = store_callees.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(store_names, vec!["store_helper"], "Store::build callees");
+
+    let builder_callees = store
+        .get_callees_full("build", Some("store.rs"), Some(50))
+        .unwrap();
+    let builder_names: Vec<&str> = builder_callees.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(
+        builder_names,
+        vec!["builder_helper"],
+        "StoreBuilder::build callees"
+    );
+
+    // File-scoped (no line): the old behaviour merges both — the regression the
+    // line scope fixes.
+    let merged = store
+        .get_callees_full("build", Some("store.rs"), None)
+        .unwrap();
+    assert_eq!(merged.len(), 2, "without line scope the two defs merge");
+}
+
+/// A doc chunk mentioning both `` `open()` `` and
+/// `` `Store::open()` `` yields a bare and an exact-qualified edge at the same
+/// `(file, caller_name, caller_line)`. They tie on trust rank (both
+/// `doc_reference`), so the GROUP BY collapse must pick the exact edge
+/// deterministically — otherwise the SelfType-vs-ambiguous label wobbles
+/// between runs. The qualified tiebreaker pins it to SelfType.
+#[test]
+fn attributed_callers_tied_doc_label_is_deterministic() {
+    use cqs::parser::FunctionCalls;
+    let store = TestStore::new();
+    // Store::open is defined in store.rs (so the bare arm participates and the
+    // unqualified `open` edge would otherwise be attributed by parent_type —
+    // here the doc chunk has no enclosing Store, so bare ⇒ Ambiguous).
+    store
+        .upsert_chunk(
+            &method_chunk("store.rs", "open", 10, Some("Store")),
+            &mock_embedding(1.0),
+            Some(1),
+        )
+        .unwrap();
+    // One doc chunk, one caller_line, BOTH a bare `open` and an exact
+    // `Store::open` doc_reference edge — the tied-rank collapse case.
+    store
+        .upsert_function_calls(
+            std::path::Path::new("docs.md"),
+            &[FunctionCalls {
+                name: "Usage".to_string(),
+                line_start: 1,
+                calls: vec![
+                    CallSite {
+                        callee_name: "open".to_string(),
+                        line_number: 5,
+                        kind: CallEdgeKind::DocReference,
+                    },
+                    CallSite {
+                        callee_name: "Store::open".to_string(),
+                        line_number: 5,
+                        kind: CallEdgeKind::DocReference,
+                    },
+                ],
+            }],
+        )
+        .unwrap();
+
+    let others = std::collections::HashSet::new();
+    // Run repeatedly: the collapsed label must be SelfType every time (the
+    // exact-qualified edge wins the tie), never the bare-arm Ambiguous.
+    for _ in 0..8 {
+        let (attributed, _excluded) = store
+            .get_callers_attributed("open", "Store", &others, true)
+            .unwrap();
+        let usage = attributed
+            .iter()
+            .find(|a| a.caller.name == "Usage")
+            .expect("the doc caller is present");
+        assert_eq!(
+            usage.attribution,
+            CallerAttribution::SelfType,
+            "exact-qualified edge wins the tie ⇒ stable SelfType label"
+        );
+    }
 }


### PR DESCRIPTION
Closes #1842 + #1843 — polish on the `Type::method` callers/callees machinery from #1844.

- **#1842 callees same-file merge**: `get_callees_full` gains a `caller_line` scope (the def's `line_start`, which `function_calls.caller_line` equals and windowed chunks inherit), so two same-named methods sharing a file no longer merge callees; dedup key gains `origin`.
- **#1843-1 tied-rank label**: the GROUP BY collapse used `MIN(rank_case)` and picked `callee_name` arbitrarily on ties; now `MIN(rank_case*2 + qualified?0:1)` — exact-qualified deterministically wins a same-rank tie, no cross-rank inversion (the ×2 keeps rank_case dominant).
- **#1843-2 cap-hint dead-end**: past `GRAPH_LIMIT_CAP` (where `--limit` can't page further), the truncation line now advises `--edge-kind doc_reference` filtering instead of the unreachable "raise --limit".
- **#1843-3 callees existence hint**: `callees_qualified` ports the did-you-mean candidates for unknown qualifiers. The callers-side F1 exact-arm-gate bug does NOT recur here — verified: no producer writes a qualified `caller_name` (doc edges put the `Type::method` string in `callee_name`, caller = heading text), so the gate hides nothing.

Review (opus): CLEAN — all six attack vectors check out, incl. the line-scope join soundness (window→parent `line_start` inheritance) and the callees asymmetry. No schema/PARSER_VERSION/env change. Parity tests assert the new shapes on both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
