### PR TITLE
fix(scoring): audit-mode note suppression + rank_signals fidelity + SPLADE sparse leg (#1848, #1845)

### DIFF
--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -680,6 +680,17 @@ pub(crate) fn prepare_query<'a>(
 
     let audit_mode = ctx.audit_state();
 
+    // Audit-mode suppresses note-sentiment boosting so note priors don't steer
+    // the ranking during a review. Set on the filter after the filter is
+    // built but before retrieval so both the scoring fold and the rank_signals
+    // recorder see it. Note display suppression is handled separately at the
+    // read / envelope layer.
+    let filter = {
+        let mut f = filter;
+        f.suppress_note_boost = audit_mode.is_active();
+        f
+    };
+
     let search_limit = if args.pattern.is_some() {
         effective_limit * 3
     } else {

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -305,6 +305,9 @@ impl<Mode> Store<Mode> {
                 note_index: &note_boost,
                 name_matcher: name_matcher.as_ref(),
                 enable_demotion: filter.enable_demotion,
+                suppress_note_boost: filter.suppress_note_boost,
+                // Brute-force scan has no sparse leg.
+                sparse_ranks: HashMap::new(),
             });
             let results = self
                 .finalize_results(
@@ -451,8 +454,10 @@ impl<Mode> Store<Mode> {
             })
             .collect();
 
-        // Step 4: Boost container chunks when multiple child methods appear
-        apply_parent_boost(&mut results);
+        // Step 4: Boost container chunks when multiple child methods appear.
+        // Returns the per-result boost multiplier for the `rank_signals`
+        // recorder — empty when no container was boosted.
+        let parent_boosts = apply_parent_boost(&mut results);
 
         // Step 4b: Type boost from adaptive routing.
         //
@@ -529,6 +534,15 @@ impl<Mode> Store<Mode> {
                 dense_ranks.iter().map(|(k, v)| (k.as_str(), *v)).collect();
             let fts_ref: HashMap<&str, usize> =
                 fts_ranks.iter().map(|(k, v)| (k.as_str(), *v)).collect();
+            let sparse_ref: HashMap<&str, usize> = inputs
+                .sparse_ranks
+                .iter()
+                .map(|(k, v)| (k.as_str(), *v))
+                .collect();
+            let parent_boost_ref: HashMap<&str, f32> = parent_boosts
+                .iter()
+                .map(|(k, v)| (k.as_str(), *v))
+                .collect();
             let signal_ctx = RankSignalCtx {
                 note_index: inputs.note_index,
                 name_matcher: inputs.name_matcher,
@@ -537,6 +551,10 @@ impl<Mode> Store<Mode> {
                 type_boost_factor: type_boost_factor(),
                 dense_ranks: &dense_ref,
                 fts_ranks: &fts_ref,
+                sparse_ranks: &sparse_ref,
+                is_rrf: use_rrf,
+                suppress_note_boost: inputs.suppress_note_boost,
+                parent_boosts: &parent_boost_ref,
             };
             for r in &mut results {
                 r.rank_signals = signals_for(r, &signal_ctx);
@@ -759,6 +777,24 @@ impl<Mode> Store<Mode> {
         for r in fused.iter() {
             fused_map.insert(r.id.clone(), r.score);
         }
+
+        // Capture the sparse leg's per-result rank for the `rank_signals`
+        // recorder. `sparse_results` is already sorted by sparse score
+        // descending (BoundedScoreHeap::into_sorted_vec), so the enumeration
+        // index is the 1-indexed leg rank — the same shape as the dense/FTS leg
+        // maps `finalize_results` builds. Only materialized when recording is
+        // on; this is a side channel that never feeds the score.
+        let sparse_ranks = if filter.record_rank_signals {
+            let mut m: std::collections::HashMap<String, usize> =
+                std::collections::HashMap::with_capacity(sparse_results.len());
+            for (rank, r) in sparse_results.iter().enumerate() {
+                m.entry(r.id.clone()).or_insert(rank + 1);
+            }
+            Some(m)
+        } else {
+            None
+        };
+
         self.search_by_candidate_ids_with_notes(
             &candidate_ids,
             query,
@@ -767,6 +803,7 @@ impl<Mode> Store<Mode> {
             threshold,
             &notes,
             Some(&fused_map),
+            sparse_ranks,
         )
     }
 
@@ -875,6 +912,8 @@ impl<Mode> Store<Mode> {
                 threshold,
                 &notes,
                 fused_scores.as_ref(),
+                // Index-guided dense path has no sparse leg.
+                None,
             );
         }
 
@@ -908,6 +947,7 @@ impl<Mode> Store<Mode> {
             threshold,
             &notes,
             None,
+            None,
         )
     }
 
@@ -927,6 +967,9 @@ impl<Mode> Store<Mode> {
         threshold: f32,
         notes: &[NoteSummary],
         fused_scores: Option<&std::collections::HashMap<String, f32>>,
+        // Per-result sparse (SPLADE) leg rank, threaded from `search_hybrid`
+        // for the `rank_signals` recorder. `None` on the non-SPLADE paths.
+        sparse_ranks: Option<std::collections::HashMap<String, usize>>,
     ) -> Result<Vec<SearchResult>, StoreError> {
         let _span = tracing::info_span!(
             "search_by_candidates",
@@ -1066,6 +1109,8 @@ impl<Mode> Store<Mode> {
                 note_index: &note_boost,
                 name_matcher: name_matcher.as_ref(),
                 enable_demotion: filter.enable_demotion,
+                suppress_note_boost: filter.suppress_note_boost,
+                sparse_ranks: sparse_ranks.unwrap_or_default(),
             });
             self.finalize_results(
                 scored,
@@ -2261,13 +2306,11 @@ mod tests {
     }
 
     /// `rank_signals` is an honest mirror of the scoring that actually ran: the
-    /// `note_boost` entry appears iff a note moved the score. This is the
-    /// audit-mode *complement* the design names — an agent reads note influence
-    /// per-query without disabling notes. Note that audit-mode at the search
-    /// layer forces the hybrid retrieval path but does not zero note boosting
-    /// in store scoring (that suppression is a display-layer concern in `read`
-    /// / the CLI envelope), so the discriminator here is note presence, not the
-    /// audit flag: with no notes seeded, no `note_boost` is recorded.
+    /// `note_boost` entry appears iff a note moved the score. With no notes
+    /// seeded the boost is 1.0, so no `note_boost` is recorded — the
+    /// discriminator here is note presence. (Audit-mode suppression, which
+    /// forces the multiplier to 1.0 even with notes present and omits the
+    /// signal, is pinned separately by `pin_audit_mode_suppresses_note_boost`.)
     #[test]
     fn rank_signals_note_boost_tracks_actual_scoring() {
         let (store, _dir) = setup_store();
@@ -2297,6 +2340,179 @@ mod tests {
             !res.rank_signals.iter().any(|s| s.signal == "note_boost"),
             "no note seeded → no note_boost signal; got {:?}",
             res.rank_signals
+        );
+    }
+
+    /// discriminative-by-default on the `--rrf` path. With several
+    /// chunks that all match the keyword leg, "appeared in FTS" is the norm, so
+    /// the majority of results must carry NO `rank_signals` — `fts` records only
+    /// when its leg rank materially leads the dense rank. Before the fix every
+    /// fused result carried an `fts` signal (cry-wolf); after it, the typical
+    /// result is silent.
+    #[test]
+    fn rrf_discriminative_by_default_majority_silent() {
+        let (store, _dir) = setup_store();
+        // Eight chunks whose names all share the "handler" keyword so every one
+        // appears in the FTS leg for the query below. No notes, no demotion
+        // targets, no type boost — the only candidate signal is `fts`.
+        let names = [
+            "alphaHandler",
+            "betaHandler",
+            "gammaHandler",
+            "deltaHandler",
+            "epsilonHandler",
+            "zetaHandler",
+            "etaHandler",
+            "thetaHandler",
+        ];
+        let emb = mock_embedding(1.0);
+        let chunks: Vec<_> = names
+            .iter()
+            .enumerate()
+            .map(|(i, n)| {
+                (
+                    make_chunk(
+                        n,
+                        &format!("src/h{i}.rs"),
+                        Language::Rust,
+                        ChunkType::Function,
+                    ),
+                    emb.clone(),
+                )
+            })
+            .collect();
+        store.upsert_chunks_batch(&chunks, Some(1)).unwrap();
+
+        let filter = SearchFilter {
+            enable_rrf: true,
+            query_text: "handler".to_string(),
+            record_rank_signals: true,
+            ..SearchFilter::default()
+        };
+        let results = store.search_filtered(&emb, &filter, 10, 0.0).unwrap();
+        assert!(results.len() >= 5, "expected a populated result set");
+
+        let with_signals = results
+            .iter()
+            .filter(|r| !r.rank_signals.is_empty())
+            .count();
+        let fraction = with_signals as f32 / results.len() as f32;
+        assert!(
+            fraction < 0.5,
+            "discriminative-by-default: the majority of RRF results must carry no \
+             signals, but {with_signals}/{} did ({fraction:.2}); signals: {:?}",
+            results.len(),
+            results
+                .iter()
+                .map(|r| (&r.chunk.name, &r.rank_signals))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// HARD GATE: `suppress_note_boost` (the audit-mode signal) makes
+    /// note sentiment genuinely stop moving code rankings. Three runs over the
+    /// same corpus, with a positive note seeded on the target chunk:
+    ///   (a) notes live, suppression off  — note_boost moves the score;
+    ///   (b) suppression on               — boost-free scoring;
+    ///   (c) no notes at all              — the boost-free baseline.
+    /// Assert (b) == (c) bit-for-bit (suppressed == notes-free), (a) != (b)
+    /// (the note actually mattered), and that the suppressed run records NO
+    /// `note_boost` signal even with the note present.
+    #[test]
+    fn pin_audit_mode_suppresses_note_boost() {
+        let (store, dir) = setup_store();
+        let target = make_chunk(
+            "auditTarget",
+            "src/audit_target.rs",
+            Language::Rust,
+            ChunkType::Function,
+        );
+        let other = make_chunk(
+            "neighbor",
+            "src/neighbor.rs",
+            Language::Rust,
+            ChunkType::Function,
+        );
+        let emb = mock_embedding(1.0);
+        store
+            .upsert_chunks_batch(
+                &[(target.clone(), emb.clone()), (other.clone(), emb.clone())],
+                Some(1),
+            )
+            .unwrap();
+
+        // Baseline (c): score the corpus with no notes at all.
+        let plain = SearchFilter {
+            record_rank_signals: true,
+            ..SearchFilter::default()
+        };
+        let res_noteless = store.search_filtered(&emb, &plain, 10, 0.0).unwrap();
+        let noteless_target = res_noteless
+            .iter()
+            .find(|r| r.chunk.name == "auditTarget")
+            .expect("target present")
+            .score;
+
+        // Seed a strong positive note on the target.
+        seed_note(&store, dir.path(), 1.0, "auditTarget");
+
+        // (a) notes live, suppression off — the boost moves the score.
+        let live = SearchFilter {
+            record_rank_signals: true,
+            suppress_note_boost: false,
+            ..SearchFilter::default()
+        };
+        let res_live = store.search_filtered(&emb, &live, 10, 0.0).unwrap();
+        let live_target = res_live
+            .iter()
+            .find(|r| r.chunk.name == "auditTarget")
+            .expect("target present")
+            .score;
+        assert!(
+            live_target.to_bits() != noteless_target.to_bits(),
+            "control: a positive note must move the score off the boost-free baseline \
+             (live={live_target}, baseline={noteless_target})"
+        );
+
+        // (b) suppression on — note present but boost forced to 1.0.
+        let suppressed = SearchFilter {
+            record_rank_signals: true,
+            suppress_note_boost: true,
+            ..SearchFilter::default()
+        };
+        let res_suppressed = store.search_filtered(&emb, &suppressed, 10, 0.0).unwrap();
+
+        // (b) == (c): the suppressed scores are bit-identical to the notes-free
+        // baseline, position for position.
+        assert_eq!(
+            res_suppressed.len(),
+            res_noteless.len(),
+            "result count diverged under suppression"
+        );
+        for (s, n) in res_suppressed.iter().zip(res_noteless.iter()) {
+            assert_eq!(s.chunk.id, n.chunk.id, "order diverged under suppression");
+            assert_eq!(
+                s.score.to_bits(),
+                n.score.to_bits(),
+                "suppressed score must equal the notes-free baseline for {} \
+                 (suppressed={}, baseline={})",
+                s.chunk.id,
+                s.score,
+                n.score
+            );
+        }
+
+        // No `note_boost` signal anywhere on the suppressed run, even though a
+        // note is present in the store.
+        assert!(
+            res_suppressed
+                .iter()
+                .all(|r| !r.rank_signals.iter().any(|s| s.signal == "note_boost")),
+            "audit-mode suppression must omit every note_boost signal; got {:?}",
+            res_suppressed
+                .iter()
+                .map(|r| &r.rank_signals)
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/src/search/scoring/candidate.rs
+++ b/src/search/scoring/candidate.rs
@@ -51,9 +51,14 @@ pub(crate) fn chunk_importance(name: &str, file_path: &str) -> f32 {
 /// With 2 children → 1.05×, 3 → 1.10×, 4+ → 1.15×.
 ///
 /// Re-sorts results by score after boosting.
-pub(crate) fn apply_parent_boost(results: &mut [SearchResult]) {
+///
+/// Returns the per-result parent-boost multiplier keyed by chunk id, for any
+/// result the boost actually multiplied. Empty when no container was boosted.
+/// The map feeds the `rank_signals` recorder (`parent_boost` signal) — it is a
+/// faithful record of the score-moving boost, not a re-derivation.
+pub(crate) fn apply_parent_boost(results: &mut [SearchResult]) -> HashMap<String, f32> {
     if results.len() < 3 {
-        return; // Need at least a container + 2 children
+        return HashMap::new(); // Need at least a container + 2 children
     }
 
     // Compute which result indices need boosting in an immutable-borrow phase
@@ -70,7 +75,7 @@ pub(crate) fn apply_parent_boost(results: &mut [SearchResult]) {
         }
         // Only proceed if any parent_type_name appears 2+ times
         if !parent_counts.values().any(|&c| c >= 2) {
-            return;
+            return HashMap::new();
         }
         let cfg = ScoringConfig::current();
         let max_children = (cfg.parent_boost_cap - 1.0) / cfg.parent_boost_per_child;
@@ -125,17 +130,20 @@ pub(crate) fn apply_parent_boost(results: &mut [SearchResult]) {
     };
 
     if boosts.is_empty() {
-        return;
+        return HashMap::new();
     }
 
+    let mut applied: HashMap<String, f32> = HashMap::with_capacity(boosts.len());
     for (i, boost) in &boosts {
         results[*i].score *= *boost;
+        applied.insert(results[*i].chunk.id.clone(), *boost);
     }
     results.sort_by(|a, b| {
         b.score
             .total_cmp(&a.score)
             .then(a.chunk.id.cmp(&b.chunk.id))
     });
+    applied
 }
 
 /// Bounded min-heap for maintaining top-N search results by score.
@@ -455,6 +463,11 @@ impl ScoreSignal for GlobGate {
 /// of this stanza's legacy arithmetic and must stay fused with the multiply
 /// for bit-identical output. Always enabled on both paths (no-match boost
 /// is 1.0).
+///
+/// Under `filter.suppress_note_boost` (audit-mode) the multiplier is forced
+/// to 1.0 so note sentiment can't move a code score, while the `.max(0.0)`
+/// floor still runs — making the suppressed score bit-identical to a run over
+/// an empty notes table.
 struct NoteBoostSignal;
 
 impl ScoreSignal for NoteBoostSignal {
@@ -463,7 +476,12 @@ impl ScoreSignal for NoteBoostSignal {
     }
 
     fn apply(&self, current: f32, ctx: &ScoringContext<'_>, chunk: &ChunkMeta<'_>) -> Option<f32> {
-        Some(current.max(0.0) * ctx.note_index.boost(chunk.file, chunk.name_or_empty()))
+        let boost = if ctx.filter.suppress_note_boost {
+            1.0
+        } else {
+            ctx.note_index.boost(chunk.file, chunk.name_or_empty())
+        };
+        Some(current.max(0.0) * boost)
     }
 }
 

--- a/src/search/scoring/provenance.rs
+++ b/src/search/scoring/provenance.rs
@@ -3,8 +3,9 @@
 //! Records *why* a search result ranked: which scoring signals contributed and
 //! by how much. The vocabulary is the existing [`ScoreSignal`] / `SCORING_KNOBS`
 //! names — no new taxonomy. Each entry's `value` is in the signal's native
-//! unit: a 1-indexed rank for the RRF retrieval legs (`dense`, `fts`), a
-//! multiplier for the boost signals (`name_match`, `note_boost`, `type_boost`).
+//! unit: a 1-indexed rank for the retrieval legs (`dense`, `fts`, `sparse`), a
+//! multiplier for the boost signals (`name_match`, `note_boost`, `type_boost`,
+//! `parent_boost`).
 //!
 //! **Side channel, never a scoring change.** Recording reads the same inputs the
 //! scoring fold consults but reproduces them in a separate pass that never feeds
@@ -13,8 +14,15 @@
 //! is invoked only when [`SearchFilter::record_rank_signals`](crate::store::helpers::SearchFilter)
 //! is set.
 //!
-//! Discriminative-by-default: a boost is recorded only when it actually moved
-//! the score (multiplier ≠ 1.0, or a positive name-match contribution). A
+//! Discriminative-by-default: a signal is recorded only when it carries bits.
+//! A boost is recorded only when it actually moved the score (multiplier ≠ 1.0,
+//! or a positive name-match contribution), and only for results that went
+//! through the dense scoring fold — an FTS-sole RRF hit never consumed the boost
+//! multipliers, so they are not recorded for it. On the RRF path, where almost
+//! every fused result appears in the keyword leg, `fts` is recorded only when
+//! its leg rank materially leads the dense rank (or it is the sole leg);
+//! recording it on every result would be cry-wolf. Note boosting is omitted
+//! entirely under audit-mode suppression (it was forced to 1.0 in scoring). A
 //! dense-only result with no boosts records a single `dense` rank — and a result
 //! with no signals at all records nothing, so `rank_signals` stays
 //! skip-when-empty on the wire.
@@ -27,6 +35,16 @@ use crate::store::helpers::{RankSignal, SearchResult};
 use super::candidate::chunk_importance;
 use super::name_match::NameMatcher;
 use super::note_boost::NoteBoost;
+
+/// On the RRF path, record the `fts` leg only when its rank materially leads
+/// the dense rank — i.e. the keyword leg placed the chunk at least this many
+/// positions ahead of the semantic leg. On an explicit `--rrf` query nearly
+/// every fused result appears in the FTS leg, so "in the keyword leg" is the
+/// default, not a signal; requiring a material lead restores the
+/// discriminative-by-default contract. A lead of 1 (strictly ahead) was too
+/// permissive on dense-heavy corpora; a small margin keeps `fts` to the cases
+/// where the literal-string match genuinely reordered the result.
+const RRF_FTS_LEAD_MARGIN: usize = 3;
 
 /// Read-only inputs the provenance pass consults to reconstruct per-result
 /// signal contributions. Mirrors the pieces a [`super::candidate::ScoringContext`]
@@ -49,15 +67,37 @@ pub(crate) struct RankSignalCtx<'a> {
     /// type is in `type_boost_types`.
     pub type_boost_factor: f32,
     /// 1-indexed dense rank per chunk id (the semantic/base ordering fed to
-    /// fusion). Built once by the caller from the incoming `scored` list.
+    /// fusion). Built once by the caller from the incoming `scored` list. A
+    /// result with no entry here arrived only through the FTS leg (pure
+    /// rank-fusion score) and never consumed the boost multipliers — see the
+    /// `had_dense` gate in `signals_for`.
     pub dense_ranks: &'a HashMap<&'a str, usize>,
     /// 1-indexed FTS rank per chunk id, populated only on the RRF path.
     pub fts_ranks: &'a HashMap<&'a str, usize>,
+    /// 1-indexed sparse (SPLADE) leg rank per chunk id, populated only on the
+    /// hybrid SPLADE path. Mirrors the dense/FTS leg maps — the sparse leg is
+    /// consumed inside `search_hybrid`, so its per-result rank is threaded out
+    /// to the recording seam the same way.
+    pub sparse_ranks: &'a HashMap<&'a str, usize>,
+    /// Whether this search ran the RRF fusion path. On that path "appeared in
+    /// the FTS leg" is the norm, so `fts` is recorded only when its leg rank
+    /// materially leads the dense rank (or it's the sole leg). On the non-RRF
+    /// path the FTS map is empty so the flag is inert.
+    pub is_rrf: bool,
+    /// Note-boost suppression (audit-mode): when set, the `note_boost` signal
+    /// is never recorded — it never moved the score, so recording it would
+    /// be dishonest. Mirrors the `NoteBoostSignal` suppression in scoring.
+    pub suppress_note_boost: bool,
+    /// Parent-boost multiplier per chunk id — populated for results the
+    /// container hub-boost (`apply_parent_boost`) actually multiplied. Score-
+    /// moving but applied in `finalize_results` after the scoring fold, so it's
+    /// recorded here from the caller-computed map rather than reconstructed.
+    pub parent_boosts: &'a HashMap<&'a str, f32>,
 }
 
 /// Caller-supplied half of the provenance inputs: the boost-lookup pieces that
 /// live in the scoring caller (`search_filtered` / `search_by_candidate_ids`)
-/// but not in `finalize_results`. The leg rank maps are built inside
+/// but not in `finalize_results`. The dense/FTS leg rank maps are built inside
 /// `finalize_results` where the `scored` list and FTS leg are in scope, then
 /// joined with these to form a [`RankSignalCtx`]. Present only when the search
 /// opted into recording.
@@ -68,6 +108,13 @@ pub(crate) struct RankSignalInputs<'a> {
     pub name_matcher: Option<&'a NameMatcher>,
     /// Whether test/underscore demotion was active.
     pub enable_demotion: bool,
+    /// Note-boost suppression (audit-mode) — mirrors `filter.suppress_note_boost`.
+    pub suppress_note_boost: bool,
+    /// 1-indexed sparse (SPLADE) leg rank per chunk id. The sparse leg is
+    /// consumed inside `search_hybrid` before `finalize_results`, so its
+    /// per-result rank is captured there and threaded in (the dense/FTS legs are
+    /// built inside `finalize_results`). Empty on the non-SPLADE paths.
+    pub sparse_ranks: HashMap<String, usize>,
 }
 
 /// Derive the `rank_signals` array for one result. Pure function of the result
@@ -81,56 +128,112 @@ pub(crate) fn signals_for(result: &SearchResult, ctx: &RankSignalCtx<'_>) -> Vec
     // name. Use the same `origin`-derived file the candidate scoring used.
     let file_part = super::filter::extract_file_from_chunk_id(file);
 
+    // Whether the result went through the dense scoring fold. On the RRF path a
+    // result with no dense rank arrived only via the FTS leg; its score is pure
+    // rank fusion and never consumed the note/importance/name multipliers, so
+    // recording those for it would be dishonest. On the non-RRF path
+    // every result has a dense rank, so this gate is always satisfied there.
+    let dense_rank = ctx.dense_ranks.get(result.chunk.id.as_str()).copied();
+    let had_dense = dense_rank.is_some();
+
     // Discriminative signals first. The `dense` leg is the universal retrieval
-    // path — every result came through it, so a bare `dense` rank carries no
-    // bits (the cry-wolf rule: a signal on every result is a default). It is
-    // therefore recorded only as *context* for a discriminative signal below,
-    // never on its own. The FTS leg, by contrast, is discriminative: appearing
-    // in the keyword leg distinguishes a literal-string match from a pure
-    // concept match.
+    // path — every dense-scored result came through it, so a bare `dense` rank
+    // carries no bits (the cry-wolf rule: a signal on every result is a
+    // default). It is recorded only as *context* for a discriminative signal
+    // below, never on its own.
     let mut discriminative: Vec<RankSignal> = Vec::new();
 
-    if let Some(&rank) = ctx.fts_ranks.get(result.chunk.id.as_str()) {
-        discriminative.push(RankSignal {
-            signal: "fts",
-            value: rank as f32,
-        });
-    }
-
-    // name_match: the blended name-match score (native unit of the NameBlend
-    // signal). Recorded only when the matcher is active and the contribution is
-    // positive — a zero name score is the no-signal case.
-    if let Some(matcher) = ctx.name_matcher {
-        let name_score = matcher.score(name);
-        if name_score > 0.0 {
+    // FTS leg. On the non-RRF path the FTS map is empty (inert). On the RRF
+    // path nearly every fused result appears in the keyword leg, so "in FTS" is
+    // the default, not a signal: record `fts` only when its rank
+    // materially leads the dense rank, or when there's no dense rank at all
+    // (the chunk is an FTS-sole hit, where the keyword leg is the whole story).
+    if let Some(&fts_rank) = ctx.fts_ranks.get(result.chunk.id.as_str()) {
+        let record_fts = if ctx.is_rrf {
+            match dense_rank {
+                // FTS materially ahead of dense → the keyword leg reordered it.
+                Some(d) => fts_rank + RRF_FTS_LEAD_MARGIN <= d,
+                // No dense rank → FTS is the sole leg that found it.
+                None => true,
+            }
+        } else {
+            // Non-RRF path keeps the prior "FTS is discriminative on its own"
+            // semantics (the map is empty here in practice, so this is inert).
+            true
+        };
+        if record_fts {
             discriminative.push(RankSignal {
-                signal: "name_match",
-                value: name_score,
+                signal: "fts",
+                value: fts_rank as f32,
             });
         }
     }
 
-    // note_boost: the sentiment multiplier. Recorded only when it actually
-    // moved the score (≠ 1.0) — the audit-mode complement: a note that
-    // influenced ranking is visible per-query without disabling notes.
-    let note_mult = ctx.note_index.boost(file_part, name);
-    if note_mult != 1.0 {
+    // Sparse (SPLADE) leg. Recorded whenever the sparse leg contributed a rank
+    // for this chunk — a retrieval leg like dense/FTS, surfaced so an
+    // agent can distinguish "ranked by lexical sparse overlap" from "ranked by
+    // dense semantics".
+    if let Some(&sparse_rank) = ctx.sparse_ranks.get(result.chunk.id.as_str()) {
         discriminative.push(RankSignal {
-            signal: "note_boost",
-            value: note_mult,
+            signal: "sparse",
+            value: sparse_rank as f32,
         });
     }
 
-    // importance: the test/underscore demotion multiplier (the
-    // ImportanceDemotion signal). Only when demotion was active and non-trivial.
-    if ctx.enable_demotion {
-        let imp = chunk_importance(name, file_part);
-        if imp != 1.0 {
-            discriminative.push(RankSignal {
-                signal: "importance",
-                value: imp,
-            });
+    // Boost signals (name_match / note_boost / importance) only ran for
+    // dense-scored results. Gate them on `had_dense` so FTS-sole RRF hits don't
+    // report multipliers their pure-rank-fusion score never consumed.
+    if had_dense {
+        // name_match: the blended name-match score (native unit of the
+        // NameBlend signal). Recorded only when the matcher is active and the
+        // contribution is positive — a zero name score is the no-signal case.
+        if let Some(matcher) = ctx.name_matcher {
+            let name_score = matcher.score(name);
+            if name_score > 0.0 {
+                discriminative.push(RankSignal {
+                    signal: "name_match",
+                    value: name_score,
+                });
+            }
         }
+
+        // note_boost: the sentiment multiplier. Recorded only when it actually
+        // moved the score (≠ 1.0) and note boosting wasn't suppressed
+        // (audit-mode) — under suppression the multiplier was forced to 1.0 in
+        // scoring, so recording it would be dishonest.
+        if !ctx.suppress_note_boost {
+            let note_mult = ctx.note_index.boost(file_part, name);
+            if note_mult != 1.0 {
+                discriminative.push(RankSignal {
+                    signal: "note_boost",
+                    value: note_mult,
+                });
+            }
+        }
+
+        // importance: the test/underscore demotion multiplier (the
+        // ImportanceDemotion signal). Only when demotion was active and
+        // non-trivial.
+        if ctx.enable_demotion {
+            let imp = chunk_importance(name, file_part);
+            if imp != 1.0 {
+                discriminative.push(RankSignal {
+                    signal: "importance",
+                    value: imp,
+                });
+            }
+        }
+    }
+
+    // parent_boost: the container hub-boost applied in `finalize_results` after
+    // the scoring fold. Recorded from the caller-computed map for the
+    // results it actually multiplied. Not gated on `had_dense` — it operates on
+    // the final result set, which can include FTS-sole hits.
+    if let Some(&boost) = ctx.parent_boosts.get(result.chunk.id.as_str()) {
+        discriminative.push(RankSignal {
+            signal: "parent_boost",
+            value: boost,
+        });
     }
 
     // type_boost: the adaptive-routing type multiplier (finalize step 4b).
@@ -143,15 +246,16 @@ pub(crate) fn signals_for(result: &SearchResult, ctx: &RankSignalCtx<'_>) -> Vec
         }
     }
 
-    // Pure dense-only results record nothing — skip-when-empty on the wire,
-    // zero token overhead. When a discriminative signal fired, prepend the
-    // `dense` rank as context so the consumer can read the boost relative to
-    // where the semantic leg placed the chunk.
+    // No discriminative signal fired → record nothing (skip-when-empty on the
+    // wire, zero token overhead). When one did, prepend the `dense` rank as
+    // context so the consumer can read the boost relative to where the semantic
+    // leg placed the chunk — but only when the result actually has a dense rank
+    // (an FTS-sole RRF hit has no dense leg to report).
     if discriminative.is_empty() {
         return Vec::new();
     }
     let mut out: Vec<RankSignal> = Vec::with_capacity(discriminative.len() + 1);
-    if let Some(&rank) = ctx.dense_ranks.get(result.chunk.id.as_str()) {
+    if let Some(rank) = dense_rank {
         out.push(RankSignal {
             signal: "dense",
             value: rank as f32,
@@ -198,6 +302,41 @@ mod tests {
         }
     }
 
+    /// Empty leg / boost maps the simple-case tests share. Borrowing references
+    /// to these keeps `RankSignalCtx` construction terse.
+    type LegMap<'a> = HashMap<&'a str, usize>;
+    type BoostMap<'a> = HashMap<&'a str, f32>;
+
+    /// Build a `RankSignalCtx` with the common defaults. Caller passes the leg
+    /// maps + parent-boost map by reference; everything else uses the
+    /// non-discriminative defaults (no name matcher, demotion on, no type
+    /// boost, non-RRF, notes live).
+    #[allow(clippy::too_many_arguments)]
+    fn ctx<'a>(
+        note_index: &'a NoteBoost<'a>,
+        dense: &'a LegMap<'a>,
+        fts: &'a LegMap<'a>,
+        sparse: &'a LegMap<'a>,
+        parent_boosts: &'a BoostMap<'a>,
+        type_boost_types: Option<&'a [ChunkType]>,
+        is_rrf: bool,
+        suppress_note_boost: bool,
+    ) -> RankSignalCtx<'a> {
+        RankSignalCtx {
+            note_index,
+            name_matcher: None,
+            enable_demotion: true,
+            type_boost_types,
+            type_boost_factor: 1.2,
+            dense_ranks: dense,
+            fts_ranks: fts,
+            sparse_ranks: sparse,
+            is_rrf,
+            suppress_note_boost,
+            parent_boosts,
+        }
+    }
+
     #[test]
     fn dense_only_records_nothing() {
         // A pure dense-only hit (no FTS leg, no boosts) is the universal case;
@@ -207,18 +346,10 @@ mod tests {
         let note_index = NoteBoost::Borrowed(super::super::NoteBoostIndex::new(&[]));
         let mut dense = HashMap::new();
         dense.insert("src/lib.rs:1:foo", 3usize);
-        let fts = HashMap::new();
-        let ctx = RankSignalCtx {
-            note_index: &note_index,
-            name_matcher: None,
-            enable_demotion: true,
-            type_boost_types: None,
-            type_boost_factor: 1.2,
-            dense_ranks: &dense,
-            fts_ranks: &fts,
-        };
+        let (fts, sparse, pb) = (HashMap::new(), HashMap::new(), HashMap::new());
+        let c = ctx(&note_index, &dense, &fts, &sparse, &pb, None, false, false);
         let r = SearchResult::new(chunk("src/lib.rs:1:foo", "foo", ChunkType::Function), 0.9);
-        assert!(signals_for(&r, &ctx).is_empty());
+        assert!(signals_for(&r, &c).is_empty());
     }
 
     #[test]
@@ -230,18 +361,10 @@ mod tests {
         let note_index = NoteBoost::Borrowed(super::super::NoteBoostIndex::new(&notes));
         let mut dense = HashMap::new();
         dense.insert("src/lib.rs:1:foo", 2usize);
-        let fts = HashMap::new();
-        let ctx = RankSignalCtx {
-            note_index: &note_index,
-            name_matcher: None,
-            enable_demotion: true,
-            type_boost_types: None,
-            type_boost_factor: 1.2,
-            dense_ranks: &dense,
-            fts_ranks: &fts,
-        };
+        let (fts, sparse, pb) = (HashMap::new(), HashMap::new(), HashMap::new());
+        let c = ctx(&note_index, &dense, &fts, &sparse, &pb, None, false, false);
         let r = SearchResult::new(chunk("src/lib.rs:1:foo", "foo", ChunkType::Function), 0.9);
-        let sigs = signals_for(&r, &ctx);
+        let sigs = signals_for(&r, &c);
         assert_eq!(sigs[0].signal, "dense");
         assert_eq!(sigs[0].value, 2.0);
         assert!(sigs
@@ -250,48 +373,182 @@ mod tests {
     }
 
     #[test]
-    fn fts_leg_is_discriminative_on_its_own() {
-        // Appearing in the FTS keyword leg distinguishes a literal-string match
-        // and is recorded even with no boosts.
+    fn note_boost_omitted_when_suppressed() {
+        // Audit-mode: suppression forces the multiplier to 1.0 in
+        // scoring, so recording `note_boost` would be dishonest — it never
+        // moved the score. The result records nothing.
+        let notes = vec![note(1.0, &["foo"])];
+        let note_index = NoteBoost::Borrowed(super::super::NoteBoostIndex::new(&notes));
+        let mut dense = HashMap::new();
+        dense.insert("src/lib.rs:1:foo", 2usize);
+        let (fts, sparse, pb) = (HashMap::new(), HashMap::new(), HashMap::new());
+        let c = ctx(
+            &note_index,
+            &dense,
+            &fts,
+            &sparse,
+            &pb,
+            None,
+            false,
+            true, // suppress_note_boost
+        );
+        let r = SearchResult::new(chunk("src/lib.rs:1:foo", "foo", ChunkType::Function), 0.9);
+        let sigs = signals_for(&r, &c);
+        assert!(
+            !sigs.iter().any(|s| s.signal == "note_boost"),
+            "suppressed note boost must not be recorded; got {sigs:?}"
+        );
+    }
+
+    #[test]
+    fn non_rrf_fts_records_when_present() {
+        // On the non-RRF path the FTS map is empty in practice, but when a rank
+        // is present it is recorded unconditionally (the prior semantics).
         let note_index = NoteBoost::Borrowed(super::super::NoteBoostIndex::new(&[]));
         let mut dense = HashMap::new();
         dense.insert("src/lib.rs:1:foo", 1usize);
         let mut fts = HashMap::new();
         fts.insert("src/lib.rs:1:foo", 4usize);
-        let ctx = RankSignalCtx {
-            note_index: &note_index,
-            name_matcher: None,
-            enable_demotion: true,
-            type_boost_types: None,
-            type_boost_factor: 1.2,
-            dense_ranks: &dense,
-            fts_ranks: &fts,
-        };
+        let (sparse, pb) = (HashMap::new(), HashMap::new());
+        let c = ctx(&note_index, &dense, &fts, &sparse, &pb, None, false, false);
         let r = SearchResult::new(chunk("src/lib.rs:1:foo", "foo", ChunkType::Function), 0.9);
-        let sigs = signals_for(&r, &ctx);
+        let sigs = signals_for(&r, &c);
         assert!(sigs.iter().any(|s| s.signal == "fts" && s.value == 4.0));
         assert!(sigs.iter().any(|s| s.signal == "dense" && s.value == 1.0));
     }
 
     #[test]
-    fn importance_recorded_only_when_demotion_enabled() {
+    fn rrf_fts_suppressed_when_not_leading() {
+        // on the RRF path "appeared in the FTS leg" is the norm, not a
+        // signal. A chunk whose FTS rank does not materially lead its dense rank
+        // records no `fts` — and with no other signal, records nothing at all.
+        let note_index = NoteBoost::Borrowed(super::super::NoteBoostIndex::new(&[]));
+        let mut dense = HashMap::new();
+        dense.insert("src/lib.rs:1:foo", 2usize);
+        let mut fts = HashMap::new();
+        fts.insert("src/lib.rs:1:foo", 3usize); // behind dense → not discriminative
+        let (sparse, pb) = (HashMap::new(), HashMap::new());
+        let c = ctx(&note_index, &dense, &fts, &sparse, &pb, None, true, false);
+        let r = SearchResult::new(chunk("src/lib.rs:1:foo", "foo", ChunkType::Function), 0.9);
+        assert!(
+            signals_for(&r, &c).is_empty(),
+            "FTS rank trailing dense must not record on the RRF path"
+        );
+    }
+
+    #[test]
+    fn rrf_fts_recorded_when_materially_leading() {
+        // when the keyword leg places the chunk materially ahead of the
+        // semantic leg, the literal-string match genuinely reordered it — record
+        // `fts`.
+        let note_index = NoteBoost::Borrowed(super::super::NoteBoostIndex::new(&[]));
+        let mut dense = HashMap::new();
+        dense.insert("src/lib.rs:1:foo", 10usize);
+        let mut fts = HashMap::new();
+        fts.insert("src/lib.rs:1:foo", 1usize); // 9 ahead → materially leads
+        let (sparse, pb) = (HashMap::new(), HashMap::new());
+        let c = ctx(&note_index, &dense, &fts, &sparse, &pb, None, true, false);
+        let r = SearchResult::new(chunk("src/lib.rs:1:foo", "foo", ChunkType::Function), 0.9);
+        let sigs = signals_for(&r, &c);
+        assert!(sigs.iter().any(|s| s.signal == "fts" && s.value == 1.0));
+    }
+
+    #[test]
+    fn rrf_fts_sole_leg_recorded() {
+        // An FTS-sole RRF hit (no dense rank) records `fts` — the keyword leg is
+        // the whole story — but no `dense` context (there's no dense leg).
         let note_index = NoteBoost::Borrowed(super::super::NoteBoostIndex::new(&[]));
         let dense = HashMap::new();
-        let fts = HashMap::new();
+        let mut fts = HashMap::new();
+        fts.insert("src/lib.rs:1:foo", 5usize);
+        let (sparse, pb) = (HashMap::new(), HashMap::new());
+        let c = ctx(&note_index, &dense, &fts, &sparse, &pb, None, true, false);
+        let r = SearchResult::new(chunk("src/lib.rs:1:foo", "foo", ChunkType::Function), 0.9);
+        let sigs = signals_for(&r, &c);
+        assert!(sigs.iter().any(|s| s.signal == "fts" && s.value == 5.0));
+        assert!(
+            !sigs.iter().any(|s| s.signal == "dense"),
+            "FTS-sole hit has no dense leg to report"
+        );
+    }
+
+    #[test]
+    fn fts_sole_hit_records_no_phantom_boosts() {
+        // a result that arrived only through the FTS leg (no dense
+        // rank) has a pure rank-fusion score that never consumed the
+        // note/importance multipliers — they must not be recorded.
+        let notes = vec![note(1.0, &["test_foo"])];
+        let note_index = NoteBoost::Borrowed(super::super::NoteBoostIndex::new(&notes));
+        let dense = HashMap::new(); // no dense rank → FTS-sole
+        let mut fts = HashMap::new();
+        fts.insert("src/lib.rs:1:test_foo", 2usize);
+        let (sparse, pb) = (HashMap::new(), HashMap::new());
+        let c = ctx(&note_index, &dense, &fts, &sparse, &pb, None, true, false);
+        // test_foo would normally pick up both note_boost and importance.
+        let r = SearchResult::new(
+            chunk("src/lib.rs:1:test_foo", "test_foo", ChunkType::Function),
+            0.9,
+        );
+        let sigs = signals_for(&r, &c);
+        assert!(
+            !sigs.iter().any(|s| s.signal == "note_boost"),
+            "FTS-sole hit must not report note_boost; got {sigs:?}"
+        );
+        assert!(
+            !sigs.iter().any(|s| s.signal == "importance"),
+            "FTS-sole hit must not report importance; got {sigs:?}"
+        );
+        // The FTS leg itself (sole leg) still records.
+        assert!(sigs.iter().any(|s| s.signal == "fts"));
+    }
+
+    #[test]
+    fn sparse_leg_recorded() {
+        // the SPLADE sparse leg is surfaced like dense/FTS.
+        let note_index = NoteBoost::Borrowed(super::super::NoteBoostIndex::new(&[]));
+        let mut dense = HashMap::new();
+        dense.insert("src/lib.rs:1:foo", 2usize);
+        let mut sparse = HashMap::new();
+        sparse.insert("src/lib.rs:1:foo", 1usize);
+        let (fts, pb) = (HashMap::new(), HashMap::new());
+        let c = ctx(&note_index, &dense, &fts, &sparse, &pb, None, false, false);
+        let r = SearchResult::new(chunk("src/lib.rs:1:foo", "foo", ChunkType::Function), 0.9);
+        let sigs = signals_for(&r, &c);
+        assert!(sigs.iter().any(|s| s.signal == "sparse" && s.value == 1.0));
+        assert!(sigs.iter().any(|s| s.signal == "dense" && s.value == 2.0));
+    }
+
+    #[test]
+    fn parent_boost_recorded() {
+        // a result the container hub-boost multiplied records
+        // `parent_boost` with its multiplier.
+        let note_index = NoteBoost::Borrowed(super::super::NoteBoostIndex::new(&[]));
+        let mut dense = HashMap::new();
+        dense.insert("src/lib.rs:1:S", 2usize);
+        let mut pb = HashMap::new();
+        pb.insert("src/lib.rs:1:S", 1.1f32);
+        let (fts, sparse) = (HashMap::new(), HashMap::new());
+        let c = ctx(&note_index, &dense, &fts, &sparse, &pb, None, false, false);
+        let r = SearchResult::new(chunk("src/lib.rs:1:S", "S", ChunkType::Struct), 0.9);
+        let sigs = signals_for(&r, &c);
+        assert!(sigs
+            .iter()
+            .any(|s| s.signal == "parent_boost" && (s.value - 1.1).abs() < 1e-6));
+    }
+
+    #[test]
+    fn importance_recorded_only_when_demotion_enabled() {
+        let note_index = NoteBoost::Borrowed(super::super::NoteBoostIndex::new(&[]));
+        // Dense rank present so the boost-recording gate (`had_dense`) is met.
+        let mut dense = HashMap::new();
+        dense.insert("src/lib.rs:1:test_foo", 1usize);
+        let (fts, sparse, pb) = (HashMap::new(), HashMap::new(), HashMap::new());
         let r = SearchResult::new(
             chunk("src/lib.rs:1:test_foo", "test_foo", ChunkType::Function),
             0.9,
         );
 
-        let ctx_on = RankSignalCtx {
-            note_index: &note_index,
-            name_matcher: None,
-            enable_demotion: true,
-            type_boost_types: None,
-            type_boost_factor: 1.2,
-            dense_ranks: &dense,
-            fts_ranks: &fts,
-        };
+        let ctx_on = ctx(&note_index, &dense, &fts, &sparse, &pb, None, false, false);
         assert!(signals_for(&r, &ctx_on)
             .iter()
             .any(|s| s.signal == "importance"));
@@ -308,26 +565,29 @@ mod tests {
     #[test]
     fn type_boost_recorded_for_matching_type() {
         let note_index = NoteBoost::Borrowed(super::super::NoteBoostIndex::new(&[]));
-        let dense = HashMap::new();
-        let fts = HashMap::new();
+        let mut dense = HashMap::new();
+        dense.insert("src/lib.rs:1:S", 1usize);
+        dense.insert("src/lib.rs:1:f", 2usize);
+        let (fts, sparse, pb) = (HashMap::new(), HashMap::new(), HashMap::new());
         let boosted = [ChunkType::Struct];
-        let ctx = RankSignalCtx {
-            note_index: &note_index,
-            name_matcher: None,
-            enable_demotion: true,
-            type_boost_types: Some(&boosted),
-            type_boost_factor: 1.2,
-            dense_ranks: &dense,
-            fts_ranks: &fts,
-        };
+        let c = ctx(
+            &note_index,
+            &dense,
+            &fts,
+            &sparse,
+            &pb,
+            Some(&boosted),
+            false,
+            false,
+        );
         let matching = SearchResult::new(chunk("src/lib.rs:1:S", "S", ChunkType::Struct), 0.9);
-        assert!(signals_for(&matching, &ctx)
+        assert!(signals_for(&matching, &c)
             .iter()
             .any(|s| s.signal == "type_boost" && s.value == 1.2));
 
         let non_matching =
             SearchResult::new(chunk("src/lib.rs:1:f", "f", ChunkType::Function), 0.9);
-        assert!(!signals_for(&non_matching, &ctx)
+        assert!(!signals_for(&non_matching, &c)
             .iter()
             .any(|s| s.signal == "type_boost"));
     }

--- a/src/store/helpers/search_filter.rs
+++ b/src/store/helpers/search_filter.rs
@@ -85,6 +85,16 @@ pub struct SearchFilter {
     /// bit-identical with this on or off. Surfaced (skip-when-empty) in the
     /// chunk JSON; the text surface omits it. Suppress via `--no-rank-signals`.
     pub record_rank_signals: bool,
+    /// Suppress note-sentiment boosting during scoring (audit-mode).
+    ///
+    /// Off by default. When set, the `NoteBoostSignal` stage forces its
+    /// multiplier to 1.0 — note sentiment never moves a code score — and the
+    /// `rank_signals` recorder omits any `note_boost` entry. The `.max(0.0)`
+    /// floor that stanza also applies stays in place, so the suppressed score
+    /// is bit-identical to a run over an empty notes table. Wired from
+    /// audit-mode state so audits genuinely examine code without note priors
+    /// steering the ranking (the feature's stated purpose).
+    pub suppress_note_boost: bool,
 }
 
 impl Default for SearchFilter {
@@ -103,6 +113,7 @@ impl Default for SearchFilter {
             type_boost_types: None,
             mmr_lambda: None,
             record_rank_signals: false,
+            suppress_note_boost: false,
         }
     }
 }

--- a/tests/search_test.rs
+++ b/tests/search_test.rs
@@ -387,6 +387,149 @@ fn test_search_hybrid_index_guided_agrees_with_brute_force() {
     );
 }
 
+// ===== SPLADE sparse leg surfaces in rank_signals =====
+//
+// The sparse (SPLADE) leg is consumed inside `search_hybrid` before
+// `finalize_results`, so its per-result rank is threaded out to the recording
+// seam. These pin (a) bit-identical scores with recording on vs off on the
+// SPLADE path, and (b) that a chunk the sparse leg contributed to records a
+// `sparse` signal.
+
+/// Build a SPLADE filter + index + sparse query over a seeded corpus, run
+/// `search_hybrid` with recording off and on, and assert the (id, score)
+/// sequence is byte-for-byte identical — the recorder is a pure side channel
+/// even on the hybrid fusion path.
+#[test]
+fn search_hybrid_splade_rank_signals_bit_identical() {
+    use cqs::splade::index::SpladeIndex;
+
+    let store = TestStore::new();
+    let c1 = test_chunk("spladeAlpha", "fn spladeAlpha() { a }");
+    let c2 = test_chunk("spladeBeta", "fn spladeBeta() { b }");
+    let c3 = test_chunk("spladeGamma", "fn spladeGamma() { c }");
+    let ids = insert_chunks(&store, &[c1, c2, c3], 1.0);
+
+    // SPLADE index keyed by the real chunk ids so the fused path resolves them.
+    let splade_index = SpladeIndex::build(vec![
+        (ids[0].clone(), vec![(1, 0.5), (2, 0.3)]),
+        (ids[1].clone(), vec![(1, 0.9), (3, 0.4)]),
+        (ids[2].clone(), vec![(2, 0.8)]),
+    ]);
+    let sparse_query: cqs::splade::SparseVector = vec![(1, 1.0), (2, 1.0)];
+
+    let query = mock_embedding(1.0);
+    let mock = MockIndex::new(
+        ids.iter()
+            .map(|id| IndexResult {
+                id: id.clone(),
+                score: 0.9,
+            })
+            .collect(),
+    );
+
+    let mk = |record: bool| {
+        let mut f = SearchFilter::default();
+        f.enable_splade = true;
+        f.splade_alpha = 0.5;
+        f.record_rank_signals = record;
+        f
+    };
+
+    let off = store
+        .search_hybrid(
+            &query,
+            &mk(false),
+            10,
+            0.0,
+            Some(&mock),
+            Some((&splade_index, &sparse_query)),
+        )
+        .unwrap();
+    let on = store
+        .search_hybrid(
+            &query,
+            &mk(true),
+            10,
+            0.0,
+            Some(&mock),
+            Some((&splade_index, &sparse_query)),
+        )
+        .unwrap();
+
+    assert_eq!(off.len(), on.len(), "SPLADE result count changed");
+    for (a, b) in off.iter().zip(on.iter()) {
+        assert_eq!(a.chunk.id, b.chunk.id, "SPLADE result order changed");
+        assert_eq!(
+            a.score.to_bits(),
+            b.score.to_bits(),
+            "SPLADE score bits changed for {} (off={}, on={})",
+            a.chunk.id,
+            a.score,
+            b.score
+        );
+    }
+    assert!(
+        off.iter().all(|r| r.rank_signals.is_empty()),
+        "recording-off SPLADE run must carry no rank_signals"
+    );
+}
+
+/// The `sparse` signal is recorded for a result the sparse leg ranked.
+#[test]
+fn search_hybrid_records_sparse_signal() {
+    use cqs::splade::index::SpladeIndex;
+
+    let store = TestStore::new();
+    let c1 = test_chunk("sparseHit", "fn sparseHit() { a }");
+    let c2 = test_chunk("sparseOther", "fn sparseOther() { b }");
+    let ids = insert_chunks(&store, &[c1, c2], 1.0);
+
+    let splade_index = SpladeIndex::build(vec![
+        (ids[0].clone(), vec![(7, 0.9)]),
+        (ids[1].clone(), vec![(7, 0.2)]),
+    ]);
+    let sparse_query: cqs::splade::SparseVector = vec![(7, 1.0)];
+
+    let query = mock_embedding(1.0);
+    let mock = MockIndex::new(
+        ids.iter()
+            .map(|id| IndexResult {
+                id: id.clone(),
+                score: 0.9,
+            })
+            .collect(),
+    );
+    let mut filter = SearchFilter::default();
+    filter.enable_splade = true;
+    filter.splade_alpha = 0.5;
+    filter.record_rank_signals = true;
+
+    let results = store
+        .search_hybrid(
+            &query,
+            &filter,
+            10,
+            0.0,
+            Some(&mock),
+            Some((&splade_index, &sparse_query)),
+        )
+        .unwrap();
+
+    // Every result here came through the sparse leg (both chunks carry token 7),
+    // so the top sparse hit must record a `sparse` signal.
+    let any_sparse = results
+        .iter()
+        .any(|r| r.rank_signals.iter().any(|s| s.signal == "sparse"));
+    assert!(
+        any_sparse,
+        "a SPLADE query must record the sparse leg; signals: {:?}",
+        results
+            .iter()
+            .map(|r| (&r.chunk.name, &r.rank_signals))
+            .collect::<Vec<_>>()
+    );
+}
+
 // ===== #37: search_filtered with glob =====
 
 #[test]


### PR DESCRIPTION
Three related scoring-provenance fixes on the note-boost + `rank_signals` path.

**Closes #1848 (P2 bug) — audit-mode now actually suppresses note boosts in scoring.** Audit-mode previously only forced the hybrid path and suppressed note *display*; note sentiment still moved code rankings during audits, contradicting `src/audit.rs` + CLAUDE.md. New `SearchFilter::suppress_note_boost`, wired from `audit_mode.is_active()` in the shared `prepare_query` (both CLI and daemon). `NoteBoostSignal` forces multiplier 1.0 under suppression while keeping the fused `.max(0.0)` floor — so the suppressed score is **bit-identical to a run over an empty notes table** (verified at source: `NoteBoostSignal::enabled` is unconditional, so the floor is present in both baselines). The recorder omits `note_boost` under suppression.

**Closes #1845 — SPLADE sparse leg now visible in rank_signals.** The sparse leg's true per-result rank is threaded out of `search_hybrid` into `finalize_results` and recorded as a `sparse` signal (recording-only; SPLADE score math untouched).

**Addresses #1849 (items 1–3).** rrf cry-wolf: `fts` recorded only when its leg leads dense by a margin or is sole; phantom boosts: note/importance/name_match gated on `had_dense` (the result went through the dense fold); `parent_boost` added to the vocabulary. Item 4 (gather `attach_seed_signals` name-keying) deferred as the issue notes — consistent pre-existing debt.

**Hard gate held:** scoring bit-identical everywhere except the intentional audit-mode-ON path. `to_bits()` pins on RRF, non-RRF, and SPLADE; suppressed == notes-free baseline; rrf discriminative-by-default (<50% carry signals). Review (opus): CLEAN — all five attack surfaces hold, incl. the floor-equivalence claim. Full --tests sweep green; parity structural through the shared cores.

Part of #1821 §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
