### PR TITLE
fix(cli): read project-scoped audit-mode + read-suppression state from project dir, not slot (#1862)

### DIFF
--- a/src/cli/commands/io/read.rs
+++ b/src/cli/commands/io/read.rs
@@ -463,8 +463,11 @@ pub(crate) fn cmd_read(
     let _span = tracing::info_span!("cmd_read", path).entered();
 
     let root = &ctx.root;
-    let cqs_dir = &ctx.cqs_dir;
-    let audit_mode = load_audit_state(cqs_dir);
+    // Audit-mode is project-scoped: resolve `audit-mode.json` from the project
+    // `.cqs/`, not the slot dir, so CLI-direct `cqs read` suppresses note
+    // injection in audit mode identically to the daemon. (`ctx.cqs_dir` is the
+    // slot dir and would miss the file on slot-migrated projects.)
+    let audit_mode = load_audit_state(&ctx.project_cqs_dir);
     let notes_path = root.join("docs/notes.toml");
     let notes = if notes_path.exists() {
         parse_notes(&notes_path).unwrap_or_else(|e| {

--- a/src/cli/commands/search/search_ctx.rs
+++ b/src/cli/commands/search/search_ctx.rs
@@ -200,7 +200,13 @@ impl SearchCtx for crate::cli::CommandContext<'_, ReadOnly> {
     }
 
     fn audit_state(&self) -> cqs::audit::AuditMode {
-        cqs::audit::load_audit_state(&self.cqs_dir)
+        // Audit-mode is project-scoped: the writer (`cmd_audit_mode`) and the
+        // daemon both resolve `audit-mode.json` from the project `.cqs/`, not
+        // the slot dir. Read it from `project_cqs_dir` so CLI-direct search
+        // suppresses note-boost and forces the hybrid path identically to the
+        // daemon. Reading `cqs_dir` (the slot dir) misses the file entirely on
+        // slot-migrated projects, leaving audit-mode silently inert here.
+        cqs::audit::load_audit_state(&self.project_cqs_dir)
     }
 
     fn references(&self) -> Result<Vec<Arc<ReferenceIndex>>> {
@@ -216,5 +222,67 @@ impl SearchCtx for crate::cli::CommandContext<'_, ReadOnly> {
 
     fn reference_by_name(&self, name: &str) -> Result<Arc<ReferenceIndex>> {
         crate::cli::commands::resolve::find_reference(&self.root, name).map(Arc::new)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SearchCtx;
+    use clap::Parser;
+    use cqs::store::{ModelInfo, Store};
+
+    /// Integration pin for the project-vs-slot audit-mode split.
+    ///
+    /// Builds a slot-migrated layout on disk — index.db under
+    /// `.cqs/slots/work/`, `audit-mode.json` at the PROJECT level (`.cqs/`) —
+    /// then constructs a real `CommandContext` whose slot `cqs_dir` is the slot
+    /// dir and whose `project_cqs_dir` is the project `.cqs/`. The CLI-direct
+    /// `audit_state()` must resolve the project file (active), matching the
+    /// daemon. The earlier unit pins constructed bespoke `SearchCtx` mocks and
+    /// missed this because they never exercised the slot/project dir split that
+    /// a real `CommandContext` carries.
+    #[test]
+    fn cli_audit_state_resolves_from_project_dir_not_slot() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path().to_path_buf();
+        let project_cqs_dir = root.join(".cqs");
+        let slot_dir = project_cqs_dir.join("slots").join("work");
+        std::fs::create_dir_all(&slot_dir).unwrap();
+
+        // Real store under the slot dir.
+        let db = slot_dir.join(cqs::INDEX_DB_FILENAME);
+        {
+            let s = Store::open(&db).unwrap();
+            s.init(&ModelInfo::default()).unwrap();
+        }
+        let store = Store::open_readonly(&db).unwrap();
+
+        // Audit-mode ON, written at the PROJECT level (where `cmd_audit_mode`
+        // and the daemon both put it) — NOT in the slot dir.
+        let mode = cqs::audit::AuditMode {
+            enabled: true,
+            expires_at: Some(chrono::Utc::now() + chrono::Duration::minutes(30)),
+        };
+        cqs::audit::save_audit_state(&project_cqs_dir, &mode).unwrap();
+
+        // Sanity: the file lives at the project level, not the slot dir.
+        assert!(project_cqs_dir.join("audit-mode.json").exists());
+        assert!(!slot_dir.join("audit-mode.json").exists());
+        // Negative control: reading the slot dir alone (the old, buggy anchor)
+        // misses the file and reports inactive.
+        assert!(
+            !cqs::audit::load_audit_state(&slot_dir).is_active(),
+            "slot dir holds no audit-mode.json — the old slot-anchored read would miss it"
+        );
+
+        let cli = crate::cli::Cli::try_parse_from(["cqs", "some query"]).unwrap();
+        let ctx =
+            crate::cli::CommandContext::new_for_test(&cli, store, root, slot_dir, project_cqs_dir);
+
+        assert!(
+            ctx.audit_state().is_active(),
+            "CLI-direct audit_state() must resolve audit-mode.json from the project \
+             .cqs/, matching the daemon — reading the slot dir would report inactive"
+        );
     }
 }

--- a/src/cli/store.rs
+++ b/src/cli/store.rs
@@ -18,6 +18,11 @@ use super::definitions;
 pub(crate) struct SlotPaths {
     /// Project root (`<root>` — directory holding `.cqs/`).
     pub root: PathBuf,
+    /// Project-level `.cqs/` dir (holds project-scoped state shared across
+    /// slots: `audit-mode.json`, `config.toml`, telemetry). NOT slot-local.
+    /// Equals [`slot_dir`](Self::slot_dir) under the legacy `.cqs/index.db`
+    /// layout, where the index lives directly in `.cqs/`.
+    pub project_cqs_dir: PathBuf,
     /// Slot dir `.cqs/slots/<name>/` (holds index.db, hnsw_*, splade.*).
     pub slot_dir: PathBuf,
     /// Slot name (validated, post-resolution).
@@ -51,15 +56,19 @@ pub(crate) fn resolve_slot_paths(slot_flag: Option<&str>) -> Result<SlotPaths> {
     // clean "Index not found" error pointing at the modern path.
     if !slots_root.exists() && project_cqs_dir.join(cqs::INDEX_DB_FILENAME).exists() {
         // Pre-slots layout — index.db sits directly in `.cqs/`. Treat
-        // `.cqs/` as the slot dir for this read.
+        // `.cqs/` as the slot dir for this read. The project dir and the slot
+        // dir are the same path here, so project-scoped reads (audit-mode)
+        // still resolve correctly.
         return Ok(SlotPaths {
             root,
+            project_cqs_dir: project_cqs_dir.clone(),
             slot_dir: project_cqs_dir,
             slot_name: cqs::slot::DEFAULT_SLOT.to_string(),
         });
     }
     Ok(SlotPaths {
         root,
+        project_cqs_dir,
         slot_dir,
         slot_name: resolved.name,
     })
@@ -146,6 +155,13 @@ pub(crate) struct CommandContext<'a, Mode = cqs::store::ReadWrite> {
     /// Slot dir — `.cqs/slots/<active>/`. Holds index.db, hnsw_*, splade.*.
     /// Most call sites use this as the "where do my index files live" anchor.
     pub cqs_dir: PathBuf,
+    /// Project-level `.cqs/` dir — anchor for project-scoped state that is
+    /// shared across slots (audit-mode, config). Distinct from [`cqs_dir`],
+    /// which is the slot-local index dir. Equals `cqs_dir` only under the
+    /// legacy `.cqs/index.db` layout. The daemon resolves the same state from
+    /// its own project `.cqs/`; reading these from the slot dir on the CLI
+    /// surface silently diverges from the daemon.
+    pub project_cqs_dir: PathBuf,
     reranker: OnceLock<std::sync::Arc<dyn cqs::Reranker>>,
     embedder: OnceLock<cqs::Embedder>,
     splade_encoder: OnceLock<Option<cqs::splade::SpladeEncoder>>,
@@ -158,6 +174,33 @@ pub(crate) struct CommandContext<'a, Mode = cqs::store::ReadWrite> {
 }
 
 impl<'a> CommandContext<'a, cqs::store::ReadOnly> {
+    /// Build a context from explicit paths and an already-open read-only store,
+    /// bypassing CWD-driven slot resolution. Lets a test pin a slot-migrated
+    /// layout (`slot_dir != project_cqs_dir`) and assert that project-scoped
+    /// reads (audit-mode) resolve from `project_cqs_dir`, not the slot dir.
+    /// Mirrors the batch module's `create_test_context`.
+    #[cfg(test)]
+    pub(crate) fn new_for_test(
+        cli: &'a definitions::Cli,
+        store: cqs::Store<cqs::store::ReadOnly>,
+        root: PathBuf,
+        slot_dir: PathBuf,
+        project_cqs_dir: PathBuf,
+    ) -> Self {
+        Self {
+            cli,
+            store,
+            root,
+            cqs_dir: slot_dir,
+            project_cqs_dir,
+            reranker: OnceLock::new(),
+            embedder: OnceLock::new(),
+            splade_encoder: OnceLock::new(),
+            splade_index: OnceLock::new(),
+            index_aware_model: OnceLock::new(),
+        }
+    }
+
     /// Open the project store in read-only mode and build a command context.
     pub fn open_readonly(cli: &'a definitions::Cli) -> Result<Self> {
         let (store, paths) = open_project_store_readonly_for_slot(cli.slot.as_deref())?;
@@ -168,6 +211,7 @@ impl<'a> CommandContext<'a, cqs::store::ReadOnly> {
             store,
             root: paths.root,
             cqs_dir: paths.slot_dir,
+            project_cqs_dir: paths.project_cqs_dir,
             reranker: OnceLock::new(),
             embedder: OnceLock::new(),
             splade_encoder: OnceLock::new(),
@@ -191,6 +235,7 @@ impl<'a> CommandContext<'a, cqs::store::ReadWrite> {
             store,
             root: paths.root,
             cqs_dir: paths.slot_dir,
+            project_cqs_dir: paths.project_cqs_dir,
             reranker: OnceLock::new(),
             embedder: OnceLock::new(),
             splade_encoder: OnceLock::new(),


### PR DESCRIPTION
Closes #1862 — found via #1848's live verification (the suspicion gate: daemon suppressed note_boost under audit-mode, CLI-direct didn't).

**Root cause:** `CommandContext.cqs_dir` is the **slot** dir (`.cqs/slots/<name>/`), but audit-mode is **project-scoped** — `cmd_audit_mode` and the daemon write/read `audit-mode.json` from the project `.cqs/`. On slot-migrated layouts the CLI-direct path read the slot dir, missed the file, reported inactive — so audit-mode's note-boost suppression AND its force-hybrid routing were silently inert under `CQS_NO_DAEMON=1`. Pre-existing.

**Fix:** thread the project cqs dir (already computed in `resolve_slot_paths`) through `SlotPaths.project_cqs_dir` onto a new `CommandContext.project_cqs_dir`, and read project-scoped state from it. Legacy `.cqs/index.db` layout sets `project_cqs_dir == slot_dir`, so it keeps working.

**Two project-scoped reads corrected (same bug class):** `SearchCtx::audit_state()` (the headline) and `cmd_read`'s note-injection suppression — both had the identical slot-dir read. Scanned every other `ctx.cqs_dir` / `load_audit_state` consumer: all others are correctly slot-scoped index work. One borderline case (`chat.rs` history dir) left as-is and noted — plausibly per-slot, a separate decision.

Verified LIVE on this project's slot layout: audit-mode ON → CLI-direct drops `note_boost` (0); OFF → returns (1). New integration test builds a real slot-migrated layout + real `CommandContext` and asserts `audit_state().is_active()`, with a negative control proving the old slot-anchored read would miss it. Full bin-crate sweep (1071 pass) covers the struct-shape change. Wiring fix — no schema/PARSER_VERSION/env/envelope change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
