### PR TITLE
feat(graph): thread edge_kind + location through cross-project CallGraph (#1829)

### DIFF
--- a/src/cli/batch/handlers/graph.rs
+++ b/src/cli/batch/handlers/graph.rs
@@ -21,7 +21,7 @@ use crate::cli::args::{
 use crate::cli::commands::{
     callees_core, callees_cross_core, callers_core, callers_cross_core, deps_core, impact_core,
     parse_edge_kind, test_map_core, trace_core, CalleesArgs as CoreCalleesArgs, CallersCoreArgs,
-    DepsCoreArgs, ImpactCoreArgs, TestMapCoreArgs, TraceCoreArgs, EDGE_KIND_CROSS_PROJECT_ERR,
+    DepsCoreArgs, ImpactCoreArgs, TestMapCoreArgs, TraceCoreArgs,
 };
 use cqs::parser::CallEdgeKind;
 
@@ -109,9 +109,6 @@ pub(in crate::cli::batch) fn dispatch_callers(
     )
     .entered();
     let edge_kind = parse_dispatch_edge_kind(args.edge_kind.as_deref())?;
-    if cross_project && edge_kind.is_some() {
-        anyhow::bail!("{}", EDGE_KIND_CROSS_PROJECT_ERR);
-    }
     if cross_project {
         let cross_ctx = ctx.cross_project()?;
         let mut cross_ctx = cross_ctx.lock().unwrap_or_else(|p| p.into_inner());
@@ -161,9 +158,6 @@ pub(in crate::cli::batch) fn dispatch_callees(
     )
     .entered();
     let edge_kind = parse_dispatch_edge_kind(args.edge_kind.as_deref())?;
-    if cross_project && edge_kind.is_some() {
-        anyhow::bail!("{}", EDGE_KIND_CROSS_PROJECT_ERR);
-    }
     if cross_project {
         let cross_ctx = ctx.cross_project()?;
         let mut cross_ctx = cross_ctx.lock().unwrap_or_else(|p| p.into_inner());
@@ -629,41 +623,66 @@ mod tests {
         }
     }
 
-    /// `--edge-kind` + `--cross-project` is an honest refusal on the daemon
-    /// surface too — the cross-project path discards edge kinds. Both
-    /// `dispatch_callers` and `dispatch_callees` error with the shared message;
-    /// the parity assertion pins that the CLI constant and the daemon error
-    /// string are the same text on both commands.
+    /// `--edge-kind` + `--cross-project` now filters rather than refusing:
+    /// edge provenance is threaded through the in-memory `CallGraph`,
+    /// so the daemon cross-project callers/callees apply the kind filter the
+    /// same way the single-project path does. The seeded edge is `call`, so
+    /// `--edge-kind call` keeps it and `--edge-kind macro_heuristic` drops it.
     #[test]
-    fn dispatch_edge_kind_with_cross_project_is_refused() {
+    fn dispatch_edge_kind_with_cross_project_filters() {
         let (_dir, ctx) = seed_call_graph_ctx();
-        let view = ctx.build_view(None);
 
-        let callers_args = CallersArgs {
-            name: "callee_fn".into(),
-            cross_project: true,
-            limit_arg: crate::cli::args::LimitArg { limit: 10 },
-            edge_kind: Some("call".to_string()),
-        };
-        let callers_err = dispatch_callers(&view, &callers_args)
-            .expect_err("edge-kind + cross-project must be refused")
-            .to_string();
-        assert_eq!(callers_err, EDGE_KIND_CROSS_PROJECT_ERR);
+        // `--edge-kind call` keeps the seeded call edge on both surfaces.
+        let callers_keep = dispatch_callers(
+            &ctx.build_view(None),
+            &CallersArgs {
+                name: "callee_fn".into(),
+                cross_project: true,
+                limit_arg: crate::cli::args::LimitArg { limit: 10 },
+                edge_kind: Some("call".to_string()),
+            },
+        )
+        .expect("dispatch_callers cross + edge-kind call");
+        let callers = callers_keep["callers"].as_array().expect("callers array");
+        assert!(
+            callers.iter().any(|c| c["name"] == "caller_fn"),
+            "edge-kind=call must keep the seeded call edge, got: {callers_keep}"
+        );
 
-        let callees_args = CallersArgs {
-            name: "caller_fn".into(),
-            cross_project: true,
-            limit_arg: crate::cli::args::LimitArg { limit: 10 },
-            edge_kind: Some("call".to_string()),
-        };
-        let callees_err = dispatch_callees(&view, &callees_args)
-            .expect_err("edge-kind + cross-project must be refused")
-            .to_string();
-        assert_eq!(callees_err, EDGE_KIND_CROSS_PROJECT_ERR);
+        let callees_keep = dispatch_callees(
+            &ctx.build_view(None),
+            &CallersArgs {
+                name: "caller_fn".into(),
+                cross_project: true,
+                limit_arg: crate::cli::args::LimitArg { limit: 10 },
+                edge_kind: Some("call".to_string()),
+            },
+        )
+        .expect("dispatch_callees cross + edge-kind call");
+        let calls = callees_keep["calls"].as_array().expect("calls array");
+        assert!(
+            calls.iter().any(|c| c["name"] == "callee_fn"),
+            "edge-kind=call must keep the seeded call edge, got: {callees_keep}"
+        );
 
-        // Parity: the same constant the CLI bails with (cmd_callers /
-        // cmd_callees both `bail!(EDGE_KIND_CROSS_PROJECT_ERR)`).
-        assert_eq!(callers_err, callees_err);
+        // `--edge-kind macro_heuristic` filters the seeded call edge out.
+        let callers_drop = dispatch_callers(
+            &ctx.build_view(None),
+            &CallersArgs {
+                name: "callee_fn".into(),
+                cross_project: true,
+                limit_arg: crate::cli::args::LimitArg { limit: 10 },
+                edge_kind: Some("macro_heuristic".to_string()),
+            },
+        )
+        .expect("dispatch_callers cross + edge-kind macro_heuristic");
+        assert!(
+            callers_drop["callers"]
+                .as_array()
+                .expect("callers array")
+                .is_empty(),
+            "edge-kind=macro_heuristic must drop the call edge, got: {callers_drop}"
+        );
     }
 
     #[test]

--- a/src/cli/commands/graph/callers.rs
+++ b/src/cli/commands/graph/callers.rs
@@ -29,15 +29,6 @@ use cqs::store::{CalleeInfo, CallerInfo, ReadOnly, Store};
 use super::notes_text;
 use super::KindFallbackOutput;
 
-/// Error message when `--edge-kind` is combined with `--cross-project`. The
-/// cross-project path loads a `CallGraph` that discards edge kinds (kinds are
-/// not threaded through the multi-index merge), so applying the filter would
-/// silently return the unfiltered superset. Honest refusal until kinds are
-/// threaded through `CallGraph` (tracked as a follow-up). Shared verbatim by
-/// CLI and daemon so the parity test can pin the exact string.
-pub(crate) const EDGE_KIND_CROSS_PROJECT_ERR: &str =
-    "edge-kind filtering is not supported with --cross-project";
-
 // ─── Args (surface-agnostic, MCP-ready) ────────────────────────────────────
 
 /// Input for [`callers_core`] / [`callees_core`]. Both commands take the
@@ -636,6 +627,12 @@ pub(crate) fn callers_cross_core(
     let mut callers = cross_ctx
         .get_callers_cross(&args.name)
         .context("Failed to load cross-project callers")?;
+    // Edge-kind filter (§1, cross-project): provenance is now threaded through
+    // the in-memory CallGraph, so the filter applies cross-project exactly as it
+    // does single-project — BEFORE the cap so `--limit` pages the filtered set.
+    if let Some(want) = args.edge_kind {
+        callers.retain(|c| c.caller.edge_kind == want);
+    }
     let total = callers.len();
     callers.truncate(limit);
     let entries: Vec<CallerEntry> = callers
@@ -645,8 +642,8 @@ pub(crate) fn callers_cross_core(
             file: normalize_path(&c.caller.file).to_string(),
             line_start: c.caller.line,
             project: c.project.clone(),
-            // Cross-project edges come from the in-memory CallGraph (no
-            // edge_kind tracking) — always the default `call`, rendered omitted.
+            // Edge provenance threaded through the cross-project CallGraph,
+            // skip-when-default (a `call` edge renders omitted).
             edge_kind: edge_kind_field(c.caller.edge_kind),
             // Cross-project has no Type::method resolution (no parent_type_name
             // in the merged CallGraph) — never attributed.
@@ -677,6 +674,10 @@ pub(crate) fn callees_cross_core(
     let mut callees = cross_ctx
         .get_callees_cross(&args.name)
         .context("Failed to load cross-project callees")?;
+    // Edge-kind filter (§1, cross-project): see `callers_cross_core`.
+    if let Some(want) = args.edge_kind {
+        callees.retain(|c| c.edge_kind == want);
+    }
     let total = callees.len();
     callees.truncate(limit);
     let calls: Vec<CalleeEntry> = callees
@@ -685,9 +686,9 @@ pub(crate) fn callees_cross_core(
             name: c.name.clone(),
             line_start: c.line,
             project: c.project.clone(),
-            // Cross-project callees come from the in-memory CallGraph (no
-            // edge_kind) — default `call`, rendered omitted.
-            edge_kind: String::new(),
+            // Edge provenance threaded through the cross-project CallGraph,
+            // skip-when-default (a `call` edge renders omitted).
+            edge_kind: edge_kind_field(c.edge_kind),
         })
         .collect();
     Ok(CalleesOutput {
@@ -714,10 +715,6 @@ pub(crate) fn cmd_callers(
     let store = &ctx.store;
     let limit = limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
-    if cross_project && edge_kind.is_some() {
-        anyhow::bail!("{}", EDGE_KIND_CROSS_PROJECT_ERR);
-    }
-
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
         let output = callers_cross_core(
@@ -737,12 +734,18 @@ pub(crate) fn cmd_callers(
             println!("Functions that call '{}' (cross-project):", name);
             println!();
             for c in &output.callers {
+                let kind_suffix = if c.edge_kind.is_empty() {
+                    String::new()
+                } else {
+                    format!(" [{}]", c.edge_kind.dimmed())
+                };
                 println!(
-                    "  {} ({}:{}) [{}]",
+                    "  {} ({}:{}) [{}]{}",
                     c.name.cyan(),
                     c.file,
                     c.line_start,
-                    c.project.dimmed()
+                    c.project.dimmed(),
+                    kind_suffix
                 );
             }
             println!();
@@ -931,10 +934,6 @@ pub(crate) fn cmd_callees(
     // See cmd_callers — same clamp range.
     let limit = limit.clamp(1, crate::cli::GRAPH_LIMIT_CAP);
 
-    if cross_project && edge_kind.is_some() {
-        anyhow::bail!("{}", EDGE_KIND_CROSS_PROJECT_ERR);
-    }
-
     if cross_project {
         let mut cross_ctx = cqs::cross_project::CrossProjectContext::from_config(&ctx.root)?;
         let output = callees_cross_core(
@@ -955,7 +954,12 @@ pub(crate) fn cmd_callees(
                 println!("  (no function calls found)");
             } else {
                 for c in &output.calls {
-                    println!("  {} [{}]", c.name, c.project.dimmed());
+                    let kind_suffix = if c.edge_kind.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" [{}]", c.edge_kind.dimmed())
+                    };
+                    println!("  {} [{}]{}", c.name, c.project.dimmed(), kind_suffix);
                 }
             }
             println!();

--- a/src/cli/commands/graph/mod.rs
+++ b/src/cli/commands/graph/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod trace;
 
 pub(crate) use callers::{
     callees_core, callees_cross_core, callers_core, callers_cross_core, cmd_callees, cmd_callers,
-    parse_edge_kind, CalleesArgs, CallersArgs as CallersCoreArgs, EDGE_KIND_CROSS_PROJECT_ERR,
+    parse_edge_kind, CalleesArgs, CallersArgs as CallersCoreArgs,
 };
 pub(crate) use deps::{cmd_deps, deps_core, DepsArgs as DepsCoreArgs};
 pub(crate) use explain::cmd_explain;

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -73,7 +73,6 @@ pub(crate) use graph::cmd_impact_diff;
 pub(crate) use graph::cmd_test_map;
 pub(crate) use graph::cmd_trace;
 pub(crate) use graph::parse_edge_kind;
-pub(crate) use graph::EDGE_KIND_CROSS_PROJECT_ERR;
 // graph cores + arg types (daemon dispatch handlers call these). The
 // `*CoreOutput` types are returned by the cores and serialized via
 // `serde_json::to_value` / `to_value()` without being named at the call

--- a/src/impact/cross_project.rs
+++ b/src/impact/cross_project.rs
@@ -56,8 +56,16 @@ pub fn analyze_impact_cross(
     )
     .entered();
 
-    // BFS: reverse traversal across all projects
+    // BFS: reverse traversal across all projects.
+    //
+    // `visited` records depth + project per name. `edge_provenance` captures the
+    // metadata of the edge that FIRST discovered each caller — its file, caller
+    // line, and `edge_kind` — threaded through the in-memory `CallGraph`.
+    // The discovering edge is a stable choice: BFS visits each name once, and the
+    // file/line/kind describe that caller's own definition, independent of which
+    // callee surfaced it.
     let mut visited: HashMap<String, (usize, String)> = HashMap::new(); // name -> (depth, project)
+    let mut edge_provenance: HashMap<String, crate::store::CallerInfo> = HashMap::new();
     let mut queue: VecDeque<(String, usize)> = VecDeque::new();
 
     visited.insert(name.to_string(), (0, String::new()));
@@ -85,48 +93,46 @@ pub fn analyze_impact_cross(
                 }
 
                 visited.insert(caller.caller.name.clone(), (d + 1, caller.project.clone()));
+                edge_provenance.insert(caller.caller.name.clone(), caller.caller.clone());
                 queue.push_back((caller.caller.name.clone(), d + 1));
             }
         }
     }
 
-    // Build transitive callers (everything at depth > 0, excluding target)
-    // TODO: resolve file/line from CallGraph (cross-project stores don't track source locations in edges yet)
-    let caller_count = visited
-        .iter()
-        .filter(|(n, (d, _))| *d > 0 && n.as_str() != name)
-        .count();
-    if caller_count > 0 {
-        tracing::warn!(
-            count = caller_count,
-            "Cross-project callers have empty file/line; resolve from CallGraph when edge metadata is available"
-        );
-    }
+    // Build transitive callers (everything at depth > 0, excluding target),
+    // carrying the source location of the discovering edge.
     let mut transitive_callers: Vec<TransitiveCaller> = visited
         .iter()
         .filter(|(n, (d, _))| *d > 0 && n.as_str() != name)
-        .map(|(n, (d, _))| TransitiveCaller {
-            name: n.clone(),
-            file: std::path::PathBuf::new(),
-            line: 0,
-            depth: *d,
+        .map(|(n, (d, _))| {
+            let prov = edge_provenance.get(n);
+            TransitiveCaller {
+                name: n.clone(),
+                file: prov.map(|c| c.file.clone()).unwrap_or_default(),
+                line: prov.map(|c| c.line).unwrap_or(0),
+                depth: *d,
+            }
         })
         .collect();
     transitive_callers.sort_by_key(|tc| tc.depth);
 
-    // Build direct callers (depth == 1)
+    // Build direct callers (depth == 1), threading edge_kind + source location
+    // from the discovering edge's provenance.
     let callers = visited
         .iter()
         .filter(|(_, (d, _))| *d == 1)
-        .map(|(n, _)| super::types::CallerDetail {
-            name: n.clone(),
-            file: std::path::PathBuf::new(),
-            line: 0,
-            call_line: 0,
-            snippet: None,
-            // Cross-project edges come from the in-memory CallGraph (no
-            // edge_kind tracking) — default `call`.
-            edge_kind: crate::parser::CallEdgeKind::Call,
+        .map(|(n, _)| {
+            let prov = edge_provenance.get(n);
+            super::types::CallerDetail {
+                name: n.clone(),
+                file: prov.map(|c| c.file.clone()).unwrap_or_default(),
+                line: prov.map(|c| c.line).unwrap_or(0),
+                call_line: 0,
+                snippet: None,
+                edge_kind: prov
+                    .map(|c| c.edge_kind)
+                    .unwrap_or(crate::parser::CallEdgeKind::Call),
+            }
         })
         .collect();
 
@@ -361,6 +367,65 @@ mod tests {
             !caller_names.contains("deep"),
             "deep is at depth 2, beyond limit"
         );
+    }
+
+    /// Build a NamedStore with one fully-attributed edge so cross-project impact
+    /// can be checked for threaded provenance.
+    fn make_named_store_typed(
+        name: &str,
+        caller: &str,
+        callee: &str,
+        kind: crate::parser::CallEdgeKind,
+        file: &str,
+        caller_line: i64,
+    ) -> NamedStore {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
+        let model_info = crate::store::helpers::ModelInfo::default();
+        let store = Store::<crate::store::ReadOnly>::open_readonly_after_init(&db_path, |store| {
+            store.init(&model_info)?;
+            store.block_on(async {
+                sqlx::query(
+                    "INSERT INTO function_calls (file, caller_name, callee_name, caller_line, call_line, edge_kind)
+                     VALUES (?1, ?2, ?3, ?4, 1, ?5)",
+                )
+                .bind(file)
+                .bind(caller)
+                .bind(callee)
+                .bind(caller_line)
+                .bind(kind.as_str())
+                .execute(store.pool())
+                .await
+            })?;
+            Ok(())
+        })
+        .unwrap();
+        let _keep = dir.keep();
+        NamedStore::new(name.to_string(), store, db_path)
+    }
+
+    /// Cross-project impact's direct callers carry the edge's provenance (kind +
+    /// source location) threaded through the in-memory CallGraph, no longer
+    /// hardcoded to default-`call` with empty file/line.
+    #[test]
+    fn cross_project_impact_direct_caller_carries_provenance() {
+        use crate::parser::CallEdgeKind;
+        let store = make_named_store_typed(
+            "proj_a",
+            "caller_a",
+            "target",
+            CallEdgeKind::FnPointer,
+            "src/a.rs",
+            42,
+        );
+        let mut ctx = CrossProjectContext::new(vec![store]);
+        let result = analyze_impact_cross(&mut ctx, "target", 3, false, false).unwrap();
+        assert_eq!(result.callers.len(), 1);
+        let c = &result.callers[0];
+        assert_eq!(c.name, "caller_a");
+        assert_eq!(c.edge_kind, CallEdgeKind::FnPointer);
+        assert_eq!(c.file, std::path::PathBuf::from("src/a.rs"));
+        assert_eq!(c.line, 42);
     }
 
     // ===== Cross-project trace tests =====

--- a/src/store/calls/cross_project.rs
+++ b/src/store/calls/cross_project.rs
@@ -93,6 +93,9 @@ pub struct CrossProjectCallee {
     pub project: String,
     pub name: String,
     pub line: u32,
+    /// Provenance of the call edge, threaded through the in-memory CallGraph.
+    /// Defaults to [`CallEdgeKind::Call`] for an edge with no recorded metadata.
+    pub edge_kind: crate::parser::CallEdgeKind,
 }
 
 /// Test chunk enriched with the originating project name.
@@ -268,22 +271,25 @@ impl CrossProjectContext {
             if let Some(callers) = graph.reverse.get(callee_name) {
                 for caller_arc in callers {
                     let caller_name = caller_arc.as_ref();
+                    // Look up the edge's provenance (kind + source location)
+                    // recorded at graph load — threaded through the in-memory
+                    // CallGraph so cross-project callers carry the same
+                    // edge_kind/file/line the single-project SQL path does.
+                    let meta = graph.edge_meta(caller_name, callee_name);
                     tracing::debug!(
                         project = %ns.name,
                         caller = caller_name,
                         callee = callee_name,
+                        edge_kind = %meta.edge_kind,
                         "Cross-project caller found"
                     );
                     all_callers.push(CrossProjectCaller {
                         project: ns.name.clone(),
                         caller: CallerInfo {
                             name: caller_name.to_string(),
-                            file: std::path::PathBuf::new(),
-                            line: 0,
-                            // Cross-project edges come from the in-memory
-                            // CallGraph, which does not track edge_kind; default
-                            // to the syntactic `call`.
-                            edge_kind: crate::parser::CallEdgeKind::Call,
+                            file: std::path::PathBuf::from(meta.file),
+                            line: meta.caller_line,
+                            edge_kind: meta.edge_kind,
                         },
                     });
                 }
@@ -315,16 +321,22 @@ impl CrossProjectContext {
             if let Some(callees) = graph.forward.get(caller_name) {
                 for callee_arc in callees {
                     let callee_name = callee_arc.as_ref();
+                    // Edge provenance + call-site line from the in-memory graph;
+                    // `line` is the call_line (where the call occurs), matching
+                    // the single-project `get_callees_full` semantics.
+                    let meta = graph.edge_meta(caller_name, callee_name);
                     tracing::debug!(
                         project = %ns.name,
                         caller = caller_name,
                         callee = callee_name,
+                        edge_kind = %meta.edge_kind,
                         "Cross-project callee found"
                     );
                     all_callees.push(CrossProjectCallee {
                         project: ns.name.clone(),
                         name: callee_name.to_string(),
-                        line: 0,
+                        line: meta.call_line,
+                        edge_kind: meta.edge_kind,
                     });
                 }
             }
@@ -368,6 +380,8 @@ impl CrossProjectContext {
 
         let mut forward: HashMap<Arc<str>, Vec<Arc<str>>> = HashMap::new();
         let mut reverse: HashMap<Arc<str>, Vec<Arc<str>>> = HashMap::new();
+        let mut edges: HashMap<(Arc<str>, Arc<str>), crate::store::helpers::CallEdgeMeta> =
+            HashMap::new();
 
         for idx in 0..self.stores.len() {
             let graph = &self.graphs[&idx];
@@ -383,9 +397,28 @@ impl CrossProjectContext {
                     .or_default()
                     .extend(callers.iter().cloned());
             }
+            // Preserve each project's edge provenance. When the same
+            // `(caller, callee)` pair appears in more than one project (a shared
+            // function name), keep the most-trusted kind — mirroring the
+            // within-project MIN-rank collapse so a `call` edge in one project
+            // is never demoted to a `doc_reference` from another.
+            for (key, meta) in &graph.edges {
+                edges
+                    .entry((Arc::clone(&key.0), Arc::clone(&key.1)))
+                    .and_modify(|existing| {
+                        if meta.edge_kind.trust_rank() < existing.edge_kind.trust_rank() {
+                            *existing = meta.clone();
+                        }
+                    })
+                    .or_insert_with(|| meta.clone());
+            }
         }
 
-        Ok(CallGraph { forward, reverse })
+        Ok(CallGraph {
+            forward,
+            reverse,
+            edges,
+        })
     }
 }
 
@@ -452,6 +485,126 @@ mod tests {
         let _keep = dir.keep();
 
         NamedStore::new(name.to_string(), store, db_path)
+    }
+
+    /// Helper: a NamedStore with explicit per-edge provenance. Each tuple is
+    /// `(caller, callee, edge_kind, file, caller_line, call_line)`, written
+    /// straight into `function_calls` so the in-memory `CallGraph` carries the
+    /// kind + source location end-to-end.
+    fn make_named_store_with_edges(
+        name: &str,
+        edges: &[(&str, &str, crate::parser::CallEdgeKind, &str, i64, i64)],
+    ) -> NamedStore {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join(crate::INDEX_DB_FILENAME);
+        let model_info = crate::store::helpers::ModelInfo::default();
+
+        let store = Store::<crate::store::ReadOnly>::open_readonly_after_init(&db_path, |store| {
+            store.init(&model_info)?;
+            for (caller, callee, kind, file, caller_line, call_line) in edges {
+                store.rt.block_on(async {
+                    sqlx::query(
+                        "INSERT INTO function_calls (file, caller_name, callee_name, caller_line, call_line, edge_kind)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    )
+                    .bind(file)
+                    .bind(caller)
+                    .bind(callee)
+                    .bind(caller_line)
+                    .bind(call_line)
+                    .bind(kind.as_str())
+                    .execute(&store.pool)
+                    .await
+                })?;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        let _keep = dir.keep();
+        NamedStore::new(name.to_string(), store, db_path)
+    }
+
+    /// Edge provenance (kind + source location) survives the in-memory
+    /// `CallGraph` load and surfaces on cross-project callers/callees.
+    #[test]
+    fn cross_project_caller_carries_edge_kind_and_location() {
+        use crate::parser::CallEdgeKind;
+        let store = make_named_store_with_edges(
+            "proj_a",
+            &[(
+                "caller_a",
+                "target",
+                CallEdgeKind::MacroHeuristic,
+                "src/a.rs",
+                12,
+                34,
+            )],
+        );
+        let mut ctx = CrossProjectContext::new(vec![store]);
+
+        let callers = ctx.get_callers_cross("target").unwrap();
+        assert_eq!(callers.len(), 1);
+        let c = &callers[0];
+        assert_eq!(c.caller.name, "caller_a");
+        // Provenance threaded through, not defaulted to `call`.
+        assert_eq!(c.caller.edge_kind, CallEdgeKind::MacroHeuristic);
+        assert_eq!(c.caller.file, std::path::PathBuf::from("src/a.rs"));
+        assert_eq!(c.caller.line, 12);
+
+        // Callee side: kind threads through, line is the call_line.
+        let callees = ctx.get_callees_cross("caller_a").unwrap();
+        assert_eq!(callees.len(), 1);
+        assert_eq!(callees[0].name, "target");
+        assert_eq!(callees[0].edge_kind, CallEdgeKind::MacroHeuristic);
+        assert_eq!(callees[0].line, 34);
+    }
+
+    /// Multiple raw rows for one `(caller, callee)` pair collapse to the
+    /// most-trusted kind at graph load — a co-located `call` and `doc_reference`
+    /// surface as `call`, mirroring the single-project MIN-rank collapse.
+    #[test]
+    fn cross_project_edge_collapse_keeps_most_trusted_kind() {
+        use crate::parser::CallEdgeKind;
+        let store = make_named_store_with_edges(
+            "proj_a",
+            &[
+                ("c", "t", CallEdgeKind::DocReference, "src/a.rs", 1, 5),
+                ("c", "t", CallEdgeKind::Call, "src/a.rs", 1, 9),
+            ],
+        );
+        let mut ctx = CrossProjectContext::new(vec![store]);
+        let callers = ctx.get_callers_cross("t").unwrap();
+        assert_eq!(callers.len(), 1, "the pair collapses to one edge");
+        assert_eq!(
+            callers[0].caller.edge_kind,
+            CallEdgeKind::Call,
+            "call (rank 0) outranks doc_reference (rank 4)"
+        );
+    }
+
+    /// The cross-project MERGE keeps the most-trusted kind when the same
+    /// `(caller, callee)` appears in more than one project — a `call` in one
+    /// project is never demoted to a `doc_reference` from another.
+    #[test]
+    fn merged_call_graph_keeps_most_trusted_across_projects() {
+        use crate::parser::CallEdgeKind;
+        let store_a = make_named_store_with_edges(
+            "proj_a",
+            &[("shared", "fn", CallEdgeKind::DocReference, "src/a.rs", 1, 2)],
+        );
+        let store_b = make_named_store_with_edges(
+            "proj_b",
+            &[("shared", "fn", CallEdgeKind::Call, "src/b.rs", 3, 4)],
+        );
+        let mut ctx = CrossProjectContext::new(vec![store_a, store_b]);
+        let merged = ctx.merged_call_graph().unwrap();
+        let meta = merged.edge_meta("shared", "fn");
+        assert_eq!(
+            meta.edge_kind,
+            CallEdgeKind::Call,
+            "merge must keep the most-trusted kind across projects"
+        );
     }
 
     #[test]

--- a/src/store/calls/query.rs
+++ b/src/store/calls/query.rs
@@ -357,12 +357,27 @@ impl<Mode> Store<Mode> {
             // Cap is env-overridable via CQS_CALL_GRAPH_MAX_EDGES so
             // monorepos above 500K edges can lift the ceiling.
             let max_edges = crate::limits::call_graph_max_edges() as i64;
-            let rows: Vec<(String, String)> = sqlx::query_as(
-                "SELECT DISTINCT caller_name, callee_name FROM function_calls LIMIT ?1",
-            )
-            .bind(max_edges)
-            .fetch_all(&self.pool)
-            .await?;
+            // Collapse duplicate (caller, callee) rows to the single
+            // most-trusted edge in SQL: `MIN(rank_case)` picks the lowest trust
+            // rank (call < serde < macro < fn-pointer < doc-reference) and the
+            // sibling bare columns (`edge_kind`, `file`, `caller_line`,
+            // `call_line`) take their value from that min-rank row (SQLite
+            // bare-column rule), so the in-memory edge metadata mirrors the
+            // local `get_callers_full` collapse rather than picking an arbitrary
+            // kind. Names are read directly from the GROUP BY keys.
+            let rank_case = crate::parser::CallEdgeKind::rank_case_sql("edge_kind");
+            let sql = format!(
+                "SELECT caller_name, callee_name, edge_kind, file, caller_line, call_line,
+                        MIN({rank_case}) AS trust_rank
+                 FROM function_calls
+                 GROUP BY caller_name, callee_name
+                 LIMIT ?1"
+            );
+            let rows: Vec<(String, String, String, String, i64, i64, i64)> =
+                sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
+                    .bind(max_edges)
+                    .fetch_all(&self.pool)
+                    .await?;
 
             let edge_count = rows.len();
             if edge_count as i64 >= max_edges {
@@ -384,9 +399,13 @@ impl<Mode> Store<Mode> {
                 std::sync::Arc<str>,
                 Vec<std::sync::Arc<str>>,
             > = std::collections::HashMap::new();
+            let mut edges: std::collections::HashMap<
+                (std::sync::Arc<str>, std::sync::Arc<str>),
+                crate::store::helpers::CallEdgeMeta,
+            > = std::collections::HashMap::new();
 
             // String interner: each unique name is allocated once as Arc<str>,
-            // then shared across forward and reverse maps.
+            // then shared across forward, reverse, and the edge-metadata map.
             let mut interner: std::collections::HashMap<String, std::sync::Arc<str>> =
                 std::collections::HashMap::new();
             let mut intern = |s: String| -> std::sync::Arc<str> {
@@ -396,17 +415,33 @@ impl<Mode> Store<Mode> {
                     .clone()
             };
 
-            for (caller, callee) in rows {
+            for (caller, callee, kind, file, caller_line, call_line, _rank) in rows {
                 let caller = intern(caller);
                 let callee = intern(callee);
                 reverse
                     .entry(callee.clone())
                     .or_default()
                     .push(caller.clone());
-                forward.entry(caller).or_default().push(callee);
+                forward
+                    .entry(caller.clone())
+                    .or_default()
+                    .push(callee.clone());
+                edges.insert(
+                    (caller, callee),
+                    crate::store::helpers::CallEdgeMeta {
+                        edge_kind: crate::parser::CallEdgeKind::from_str_or_default(&kind),
+                        file,
+                        caller_line: crate::store::helpers::clamp_line_number(caller_line),
+                        call_line: crate::store::helpers::clamp_line_number(call_line),
+                    },
+                );
             }
 
-            Ok::<_, StoreError>(CallGraph { forward, reverse })
+            Ok::<_, StoreError>(CallGraph {
+                forward,
+                reverse,
+                edges,
+            })
         })?;
         let arc = std::sync::Arc::new(graph);
         let _ = self.call_graph_cache.set(std::sync::Arc::clone(&arc));

--- a/src/store/helpers/mod.rs
+++ b/src/store/helpers/mod.rs
@@ -34,9 +34,9 @@ pub use rows::clamp_line_number;
 
 // Domain types
 pub use types::{
-    AttributedCaller, CallGraph, CalleeInfo, CallerAttribution, CallerInfo, CallerWithContext,
-    ChunkIdentity, ChunkSummary, IndexStats, NoteSearchResult, NoteStats, NoteSummary,
-    ParentContext, RankSignal, SearchResult, StaleFile, StaleReport, UnifiedResult,
+    AttributedCaller, CallEdgeMeta, CallGraph, CalleeInfo, CallerAttribution, CallerInfo,
+    CallerWithContext, ChunkIdentity, ChunkSummary, IndexStats, NoteSearchResult, NoteStats,
+    NoteSummary, ParentContext, RankSignal, SearchResult, StaleFile, StaleReport, UnifiedResult,
 };
 
 // Search filter

--- a/src/store/helpers/types.rs
+++ b/src/store/helpers/types.rs
@@ -448,17 +448,71 @@ pub struct CallerWithContext {
     pub edge_kind: CallEdgeKind,
 }
 
+/// Provenance for a single `(caller, callee)` edge in an in-memory
+/// [`CallGraph`]. Carries the edge's [`CallEdgeKind`] plus its source location
+/// so the cross-project caller/callee paths can surface the same provenance the
+/// single-project SQL queries already do. When several raw
+/// `function_calls` rows share a `(caller, callee)` pair, the metadata is
+/// collapsed to the most-trusted kind (lowest [`CallEdgeKind::trust_rank`]),
+/// keeping that row's source location — mirroring the local `MIN(rank)` collapse
+/// in `get_callers_full`.
+///
+/// Read in-memory by the cross-project surfaces and projected into their own
+/// serializable shapes; never serialized directly (see the `CallGraph.edges`
+/// `#[serde(skip)]`).
+#[derive(Debug, Clone)]
+pub struct CallEdgeMeta {
+    /// Provenance of the edge (default ⇒ `call`).
+    pub edge_kind: CallEdgeKind,
+    /// File the caller is defined in (the `function_calls.file` of the
+    /// chosen row). Empty when synthesized without a source location (tests).
+    pub file: String,
+    /// Caller definition's start line (`function_calls.caller_line`).
+    pub caller_line: u32,
+    /// Line where the call to the callee occurs (`function_calls.call_line`).
+    pub call_line: u32,
+}
+
+impl CallEdgeMeta {
+    /// The default-`call` metadata with no source location — used when a graph
+    /// is synthesized from bare name adjacency (tests, ad-hoc construction).
+    pub fn default_call() -> Self {
+        Self {
+            edge_kind: CallEdgeKind::Call,
+            file: String::new(),
+            caller_line: 0,
+            call_line: 0,
+        }
+    }
+}
+
 /// In-memory call graph for BFS traversal
 ///
 /// Built from a single scan of the `function_calls` table.
 /// Both forward and reverse adjacency lists are included
 /// to support trace (forward BFS) and impact/test-map (reverse BFS).
+///
+/// `edges` is a parallel, BFS-irrelevant metadata side-table: it carries each
+/// edge's [`CallEdgeMeta`] (provenance + source location) keyed by
+/// `(caller, callee)`. BFS traversal reads only `forward`/`reverse` (name
+/// adjacency); the cross-project caller/callee paths look up `edges` to surface
+/// `edge_kind` and source location and to apply `--edge-kind` filtering, the way
+/// the single-project SQL queries already do.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct CallGraph {
     /// Forward edges: caller_name -> Vec<callee_name>
     pub forward: HashMap<Arc<str>, Vec<Arc<str>>>,
     /// Reverse edges: callee_name -> Vec<caller_name>
     pub reverse: HashMap<Arc<str>, Vec<Arc<str>>>,
+    /// Per-edge provenance keyed by `(caller, callee)`. Parallel to the
+    /// adjacency lists — not consulted by BFS. See the struct doc.
+    ///
+    /// `#[serde(skip)]`: the tuple key has no string representation for a JSON
+    /// object, and `CallGraph` is never serialized to JSON in production (the
+    /// derive exists for the adjacency maps). The cross-project surfaces read
+    /// this in-memory and project into their own serializable shapes.
+    #[serde(skip)]
+    pub edges: HashMap<(Arc<str>, Arc<str>), CallEdgeMeta>,
 }
 
 impl CallGraph {
@@ -466,6 +520,12 @@ impl CallGraph {
     ///
     /// Convenience for tests and ad-hoc graph construction. Production code uses
     /// the interner in `get_call_graph()` for shared allocation across maps.
+    ///
+    /// The synthesized graph carries no edge provenance — every edge implied by
+    /// the forward map is recorded in `edges` as default-`call` with no source
+    /// location ([`CallEdgeMeta::default_call`]), so the cross-project surfaces
+    /// stay consistent (a missing entry and a default entry both render as the
+    /// omitted `call` kind).
     pub fn from_string_maps(
         forward: HashMap<String, Vec<String>>,
         reverse: HashMap<String, Vec<String>>,
@@ -479,10 +539,34 @@ impl CallGraph {
                 })
                 .collect()
         };
-        Self {
-            forward: convert(forward),
-            reverse: convert(reverse),
+        let forward = convert(forward);
+        let reverse = convert(reverse);
+        // Synthesize default-`call` metadata for every forward edge so the
+        // cross-project paths have a consistent (if location-less) entry.
+        let mut edges: HashMap<(Arc<str>, Arc<str>), CallEdgeMeta> = HashMap::new();
+        for (caller, callees) in &forward {
+            for callee in callees {
+                edges
+                    .entry((Arc::clone(caller), Arc::clone(callee)))
+                    .or_insert_with(CallEdgeMeta::default_call);
+            }
         }
+        Self {
+            forward,
+            reverse,
+            edges,
+        }
+    }
+
+    /// Look up the provenance for a `(caller, callee)` edge, falling back to
+    /// default-`call` with no source location when the edge has no recorded
+    /// metadata (a synthesized graph, or a reverse-only edge). Both surfaces a
+    /// `call` edge, so the fallback is indistinguishable from a stored default.
+    pub fn edge_meta(&self, caller: &str, callee: &str) -> CallEdgeMeta {
+        self.edges
+            .get(&(Arc::from(caller), Arc::from(callee)))
+            .cloned()
+            .unwrap_or_else(CallEdgeMeta::default_call)
     }
 }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -68,6 +68,9 @@ pub use calls::cross_project::{
 /// In-memory call graph (forward + reverse adjacency lists).
 pub use helpers::CallGraph;
 
+/// Per-edge provenance (kind + source location) for an in-memory [`CallGraph`].
+pub use helpers::CallEdgeMeta;
+
 /// Information about a function caller (from call graph).
 pub use helpers::CallerInfo;
 

--- a/tests/cli_surface_test.rs
+++ b/tests/cli_surface_test.rs
@@ -732,48 +732,129 @@ fn session_callees_lists_seeded_callee() {
     );
 }
 
-/// `--edge-kind` + `--cross-project` is an honest refusal on the CLI
-/// surface — the cross-project path discards edge kinds, so the filter would
-/// silently return the unfiltered superset. The guard fires after the store
-/// opens, so the fixture seeds a real index first.
+/// `--edge-kind` + `--cross-project` now FILTERS rather than refusing: edge
+/// provenance is threaded through the in-memory cross-project `CallGraph`, so
+/// the filter applies the same way it does single-project. The seeded
+/// `producer → consumer` edge is `call`, so `--edge-kind call` keeps `producer`
+/// in the cross-project callers and `--edge-kind macro_heuristic` drops it.
 #[test]
-fn callers_edge_kind_with_cross_project_is_refused() {
+fn callers_edge_kind_with_cross_project_filters() {
     let dir = TempDir::new().unwrap();
     seed_session_project(dir.path());
-    cqs()
+
+    // edge-kind=call keeps the seeded call edge.
+    let out = cqs()
         .args([
             "callers",
             "consumer",
             "--cross-project",
             "--edge-kind",
             "call",
+            "--json",
         ])
+        .env("CQS_NO_DAEMON", "1")
         .current_dir(dir.path())
         .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "edge-kind filtering is not supported with --cross-project",
-        ));
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let payload: serde_json::Value =
+        serde_json::from_str(String::from_utf8(out).unwrap().trim()).expect("callers JSON");
+    let data = &payload["data"];
+    let callers = data["callers"]
+        .as_array()
+        .unwrap_or_else(|| panic!("callers must be an array, got: {payload}"));
+    assert!(
+        callers.iter().any(|c| c["name"] == "producer"),
+        "edge-kind=call must keep producer, got: {payload}"
+    );
+
+    // edge-kind=macro_heuristic filters the call edge out.
+    let out = cqs()
+        .args([
+            "callers",
+            "consumer",
+            "--cross-project",
+            "--edge-kind",
+            "macro_heuristic",
+            "--json",
+        ])
+        .env("CQS_NO_DAEMON", "1")
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let payload: serde_json::Value =
+        serde_json::from_str(String::from_utf8(out).unwrap().trim()).expect("callers JSON");
+    assert!(
+        payload["data"]["callers"]
+            .as_array()
+            .is_some_and(|a| a.is_empty()),
+        "edge-kind=macro_heuristic must drop the call edge, got: {payload}"
+    );
 }
 
 #[test]
-fn callees_edge_kind_with_cross_project_is_refused() {
+fn callees_edge_kind_with_cross_project_filters() {
     let dir = TempDir::new().unwrap();
     seed_session_project(dir.path());
-    cqs()
+
+    // edge-kind=call keeps the seeded producer → consumer edge.
+    let out = cqs()
         .args([
             "callees",
             "producer",
             "--cross-project",
             "--edge-kind",
             "call",
+            "--json",
         ])
+        .env("CQS_NO_DAEMON", "1")
         .current_dir(dir.path())
         .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "edge-kind filtering is not supported with --cross-project",
-        ));
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let payload: serde_json::Value =
+        serde_json::from_str(String::from_utf8(out).unwrap().trim()).expect("callees JSON");
+    let data = &payload["data"];
+    let calls = data["calls"]
+        .as_array()
+        .unwrap_or_else(|| panic!("calls must be an array, got: {payload}"));
+    assert!(
+        calls.iter().any(|c| c["name"] == "consumer"),
+        "edge-kind=call must keep consumer, got: {payload}"
+    );
+
+    // edge-kind=fn_pointer drops the call edge.
+    let out = cqs()
+        .args([
+            "callees",
+            "producer",
+            "--cross-project",
+            "--edge-kind",
+            "fn_pointer",
+            "--json",
+        ])
+        .env("CQS_NO_DAEMON", "1")
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let payload: serde_json::Value =
+        serde_json::from_str(String::from_utf8(out).unwrap().trim()).expect("callees JSON");
+    assert!(
+        payload["data"]["calls"]
+            .as_array()
+            .is_some_and(|a| a.is_empty()),
+        "edge-kind=fn_pointer must drop the call edge, got: {payload}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #1829 — threads `edge_kind` + source location through the cross-project `CallGraph`, so `--edge-kind` filtering and provenance work cross-project the way they do locally.

§1 (#1836) added `edge_kind` to the LOCAL call graph via dedicated SQL (`get_callers_full` etc.); the cross-project / BFS substrate (`CallGraph`) still dropped it, hardcoding default-`call` with empty location and *refusing* `--edge-kind` cross-project.

**Design (contains the blast radius):** a parallel per-edge metadata side-table (`CallEdgeMeta { edge_kind, file, caller_line, call_line }` keyed by `(caller, callee)`) instead of changing the adjacency value type — so all BFS consumers (`bfs`/`gather`/`trace`/`hints`/`serve`/`brief`) are untouched. `get_call_graph` SQL goes `SELECT DISTINCT` → `GROUP BY` with `MIN(rank_case)` most-trusted-wins (set-equivalent adjacency; metadata additive). `merged_call_graph` keeps the most-trusted kind across project collisions. The `EDGE_KIND_CROSS_PROJECT_ERR` refusal is deleted and `--edge-kind` now *filters* cross-project; `CrossProjectCallee` gains a skip-when-default `edge_kind`. Source-location threading (#1829's secondary scope) done — `analyze_impact_cross` direct + transitive callers carry the discovering edge's file/line.

No schema/PARSER_VERSION change (`function_calls.edge_kind` exists since v30; pure read-path threading). Review (opus): CLEAN — all 7 attack vectors clear (adjacency identity, BFS-untouched, refusal-removal completeness, parity, serde-skip safety, impact edge attribution, SPLADE-flake orthogonality). Full --tests sweep green (one unrelated pre-existing SPLADE env-race flake → filed #1867).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
