### PR TITLE
test(property): bit-exact SPLADE round-trip + canonical_hash metamorphic properties (#1826)

### DIFF
--- a/src/parser/chunk.rs
+++ b/src/parser/chunk.rs
@@ -972,6 +972,177 @@ mod tests {
                 canonical_hash_fallback("ab")
             );
         }
+
+        // ====== Property-based: idempotence + metamorphic canonicalization ======
+        //
+        // The hand-written tests above each pin one fixed (base, edited) pair
+        // and assert their canonical hashes match. The properties below assert
+        // the underlying ALGEBRA over a generated input space:
+        //   1. `collapse_whitespace` is idempotent: f(f(x)) == f(x).
+        //   2. `canonical_hash_fallback` is whitespace-invariant: any edit that
+        //      changes only inter-token whitespace preserves the hash.
+        //   3. (metamorphic, through the real parser) inserting a `//` comment
+        //      line or reindenting a function body preserves the chunk's
+        //      `canonical_hash` — for EVERY generated body, not one fixture.
+        mod canon_proptest {
+            use super::*;
+            use proptest::prelude::*;
+
+            /// Whitespace-rich string strategy. Coverage claim: interleaves
+            /// "word" tokens with runs of mixed whitespace drawn from a set
+            /// that spans ASCII (` `, `\t`, `\n`, `\r`) AND Unicode whitespace
+            /// (`\u{00A0}` NBSP, `\u{2003}` EM SPACE, `\u{3000}` IDEOGRAPHIC
+            /// SPACE) — the chars `split_whitespace` treats as separators but
+            /// that a naive `.replace(' ', "")` would miss. Includes the
+            /// all-whitespace and empty cases via the `0..` lower bounds.
+            ///
+            /// DISTRUST: a generator that only emitted ASCII spaces would make
+            /// idempotence trivial (one pass already canonical). The Unicode
+            /// whitespace forces the first pass to actually transform, so the
+            /// second-pass-is-identity claim is non-vacuous.
+            fn whitespacey_string() -> impl Strategy<Value = String> {
+                let ws = prop::sample::select(vec![
+                    " ", "\t", "\n", "\r", "\r\n", "\u{00A0}", "\u{2003}", "\u{3000}", "  \t",
+                ]);
+                let word = "[a-zA-Z0-9_]{0,4}";
+                // Alternate up to 8 (word, whitespace-run) pairs, then a
+                // trailing word. Lower bound 0 covers empty and all-ws inputs.
+                (
+                    prop::collection::vec((word, ws.clone()), 0..8),
+                    "[a-zA-Z0-9_]{0,4}",
+                )
+                    .prop_map(|(pairs, tail)| {
+                        let mut s = String::new();
+                        for (w, sep) in pairs {
+                            s.push_str(&w);
+                            s.push_str(sep);
+                        }
+                        s.push_str(&tail);
+                        s
+                    })
+            }
+
+            proptest! {
+                #![proptest_config(ProptestConfig { cases: 512, ..ProptestConfig::default() })]
+
+                /// Idempotence: collapse_whitespace(collapse_whitespace(x))
+                ///            == collapse_whitespace(x), for all x.
+                /// A second application of a normalizer must be the identity —
+                /// example tests apply it once and never probe the fixed point.
+                #[test]
+                fn prop_collapse_whitespace_idempotent(s in whitespacey_string()) {
+                    let once = collapse_whitespace(&s);
+                    let twice = collapse_whitespace(&once);
+                    prop_assert_eq!(&once, &twice, "collapse_whitespace not idempotent on {:?}", s);
+                }
+
+                /// collapse_whitespace output is in canonical form: no leading
+                /// or trailing space, and no run of two consecutive ASCII
+                /// spaces. A cheap oracle that pins WHY idempotence holds.
+                #[test]
+                fn prop_collapse_whitespace_canonical_form(s in whitespacey_string()) {
+                    let c = collapse_whitespace(&s);
+                    prop_assert!(!c.starts_with(' '), "leading space in {:?}", c);
+                    prop_assert!(!c.ends_with(' '), "trailing space in {:?}", c);
+                    prop_assert!(!c.contains("  "), "double space in {:?}", c);
+                }
+
+                /// Whitespace invariance of the no-tree fallback hash: re-spacing
+                /// the inter-token whitespace (any run -> any other non-empty
+                /// run) must not change canonical_hash_fallback. We build two
+                /// strings with the SAME word sequence but DIFFERENT whitespace
+                /// runs and assert equal hashes.
+                #[test]
+                fn prop_fallback_hash_whitespace_invariant(
+                    words in prop::collection::vec("[a-zA-Z0-9_]{1,5}", 1..8),
+                    sep_a in prop::sample::select(vec![" ", "\t", "\n", "  ", "\r\n", "\u{00A0}"]),
+                    sep_b in prop::sample::select(vec![" ", "\t\t", "\n  ", "   ", " \t "]),
+                ) {
+                    let a = words.join(sep_a);
+                    let b = words.join(sep_b);
+                    prop_assert_eq!(
+                        canonical_hash_fallback(&a),
+                        canonical_hash_fallback(&b),
+                        "fallback hash changed under a whitespace-only re-spacing: {:?} vs {:?}",
+                        a, b
+                    );
+                }
+
+                /// Metamorphic, through the REAL tree-sitter parser: inserting
+                /// `//` line comments between the statements of a Rust function
+                /// body, and/or reindenting it, must NOT change the chunk's
+                /// `canonical_hash` (the embedding-reuse cache key). This is the
+                /// property the example tests sample at single fixtures
+                /// (`rust_line_comment_does_not_change_canonical_hash`) lifted
+                /// to a generated family of bodies and comment payloads.
+                #[test]
+                fn prop_comment_and_reindent_preserve_canonical_hash(
+                    // 1..4 simple statements that bind locals and a final expr.
+                    stmt_vals in prop::collection::vec(0i32..1000, 1..4),
+                    // Comment payloads. The class is restricted to printable
+                    // ASCII plus the Latin-1 + general-punctuation Unicode
+                    // ranges, EXCLUDING all control characters. This matters:
+                    // tree-sitter-rust terminates a `//` line_comment at a NUL
+                    // (or other C0 control) byte and emits the control as a
+                    // separate ERROR node, which `collect_comment_ranges` does
+                    // NOT strip — so a control byte in the payload would leak
+                    // into the canonicalized text and (correctly) change the
+                    // hash. That divergence is a grammar fact, not a codec bug:
+                    // the control char is genuinely not part of the comment, so
+                    // including it would make the "comment-only edit" premise
+                    // false and the property too strong — a `\0` in a `//`
+                    // payload parses as an ERROR node, not comment text.
+                    // We therefore generate only payloads that the grammar
+                    // accepts as comment continuation.
+                    comments in prop::collection::vec(
+                        "[ -~\u{00A1}-\u{024F}\u{2010}-\u{2027}]{0,20}",
+                        1..4,
+                    ),
+                    extra_indent in 0usize..6,
+                ) {
+                    // Build the base body: `let a0 = V0; let a1 = V1; ... a0`
+                    let mut base = String::from("fn f() -> i32 {\n");
+                    for (i, v) in stmt_vals.iter().enumerate() {
+                        base.push_str(&format!("    let a{i} = {v};\n"));
+                    }
+                    base.push_str("    a0\n}\n");
+
+                    // Build the edited body: the SAME statement text as base
+                    // (byte-identical `let a{i} = {v};`), but each preceded by a
+                    // `//` comment line and given `extra_indent` additional
+                    // leading spaces. The ONLY differences vs base are (a)
+                    // inserted comment lines and (b) leading-whitespace runs —
+                    // both of which `canonical_hash` must erase. Inter-token
+                    // spacing within a statement is left untouched on purpose:
+                    // changing it (e.g. `0;` -> `0 ;`) is a real textual edit
+                    // that `canonical_hash` is *not* contracted to collapse —
+                    // `collapse_whitespace` merges whitespace runs but never
+                    // inserts a token boundary, so `0;` and `0 ;` hash
+                    // differently. Introducing that here would make the property
+                    // too strong (a generator artifact, not a codec bug).
+                    let pad = " ".repeat(extra_indent);
+                    // Signature with WIDENED whitespace RUNS only (`()  ->  i32`)
+                    // — collapsing runs yields the same `fn f() -> i32` as base,
+                    // so this stays a whitespace-only edit (no new token
+                    // boundary introduced, unlike a space before `;`).
+                    let mut edited = String::from("fn f()  ->  i32 {\n");
+                    for (i, v) in stmt_vals.iter().enumerate() {
+                        let c = &comments[i % comments.len()];
+                        edited.push_str(&format!("{pad}    // {c}\n"));
+                        edited.push_str(&format!("{pad}    let a{i} = {v};\n"));
+                    }
+                    edited.push_str("    // trailing note\n    a0\n}\n");
+
+                    let base_hash = canon_of(&base, "rs", "f");
+                    let edited_hash = canon_of(&edited, "rs", "f");
+                    prop_assert_eq!(
+                        &base_hash, &edited_hash,
+                        "comment-insertion + reindent changed canonical_hash:\nBASE:\n{}\nEDITED:\n{}",
+                        base, edited
+                    );
+                }
+            }
+        }
     }
 
     mod signature_tests {

--- a/src/splade/index.rs
+++ b/src/splade/index.rs
@@ -1679,4 +1679,215 @@ mod tests {
             Err(SpladeIndexPersistError::GenerationMismatch { disk: 2, store: 1 })
         ));
     }
+
+    // ====== Property-based round-trip: save -> load is structural identity ======
+    //
+    // The hand-written round-trip tests (`test_persist_roundtrip`,
+    // `test_streaming_save_roundtrips_through_load`) each pin one fixed
+    // 3-chunk / handful-of-token index and compare weights with
+    // `(a - b).abs() < f32::EPSILON`. That comparison structurally CANNOT
+    // distinguish:
+    //   - `+0.0` from `-0.0` (they compare equal under subtraction),
+    //   - one NaN bit pattern from another (NaN - NaN = NaN, `< EPSILON` is
+    //     false — the approx compare would actually FALSE-FAIL on NaN, so the
+    //     fixtures avoid NaN entirely and never test it),
+    //   - a weight that decoded to a nearby-but-different f32.
+    // The codec's contract is BIT-EXACT (`f32::to_le_bytes` /
+    // `f32::from_le_bytes`), so the property asserts `to_bits()` identity —
+    // a strictly sharper invariant the example suite cannot express.
+    //
+    // Invariant (one line):
+    //   for every valid index i:  load(save(i)).id_map == i.id_map
+    //                       AND   load(save(i)).postings ≡_bits i.postings
+    mod roundtrip_proptest {
+        use super::*;
+        use proptest::prelude::*;
+
+        /// A weight strategy whose coverage claim is: hits every f32 class the
+        /// LE codec must survive bit-exactly — ordinary finite values, the two
+        /// signed zeros, the f32 extrema, the smallest subnormal, and the
+        /// non-finite values (±inf, a NaN). `prop_oneof` keeps the boundary
+        /// classes at non-trivial probability instead of relying on
+        /// `prop::num::f32::ANY` (which emits NaN/inf only rarely).
+        ///
+        /// DISTRUST: `ANY` alone would almost never sample `-0.0` or a
+        /// subnormal, so the boundary that actually bites a float codec
+        /// (sign-of-zero, NaN bit pattern) would go unexercised. The explicit
+        /// `just(...)` arms force them.
+        fn weight_strategy() -> impl Strategy<Value = f32> {
+            prop_oneof![
+                4 => prop::num::f32::ANY,
+                1 => Just(0.0_f32),
+                1 => Just(-0.0_f32),
+                1 => Just(f32::MIN),
+                1 => Just(f32::MAX),
+                1 => Just(f32::MIN_POSITIVE),
+                1 => Just(f32::from_bits(1)), // smallest positive subnormal
+                1 => Just(f32::INFINITY),
+                1 => Just(f32::NEG_INFINITY),
+                1 => Just(f32::NAN),
+            ]
+        }
+
+        /// A chunk-id strategy. Coverage claim: empty string, ASCII, and
+        /// multi-byte UTF-8 (so `id.len()` byte-length prefix vs char count
+        /// can't silently diverge), bounded to 0..12 chars so shrinking stays
+        /// fast. The `\\PC*` class is proptest's "any non-control unicode
+        /// scalar", which reaches astral-plane codepoints (4-byte UTF-8).
+        fn id_strategy() -> impl Strategy<Value = String> {
+            prop_oneof![
+                1 => Just(String::new()),
+                3 => "[a-zA-Z0-9_:./-]{0,12}",
+                2 => "\\PC{0,8}",
+            ]
+        }
+
+        /// A single chunk's sparse vector. Coverage claim: empty vector
+        /// (a chunk that contributed no tokens), up to 6 (token_id, weight)
+        /// pairs, token_ids spanning the full u32 range via `prop::num::u32::ANY`
+        /// (so 0 and u32::MAX are reachable), weights from `weight_strategy`.
+        /// Allows DUPLICATE token_ids within one vector on purpose — `build`
+        /// pushes each occurrence as its own posting, and the codec must
+        /// preserve that multiplicity and order.
+        fn sparse_strategy() -> impl Strategy<Value = Vec<(u32, f32)>> {
+            prop::collection::vec((prop::num::u32::ANY, weight_strategy()), 0..6)
+        }
+
+        /// A whole index input: 0..8 chunks (0 covers the empty-index codec
+        /// path that no fixture exercises). chunk_ids are NOT required unique —
+        /// `build` doesn't dedup, so two identical ids are two id_map slots,
+        /// and the codec must round-trip both.
+        fn index_input_strategy() -> impl Strategy<Value = Vec<(String, Vec<(u32, f32)>)>> {
+            prop::collection::vec((id_strategy(), sparse_strategy()), 0..8)
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig {
+                cases: 256,
+                // Deterministic: a CI failure reproduces from the seed printed
+                // in the panic + the committed `.proptest-regressions` file.
+                ..ProptestConfig::default()
+            })]
+
+            /// load(save(idx)) is a bit-exact structural identity for EVERY
+            /// validly-built index. The fixture tests can express the
+            /// approximate version of this for one hand-picked index; the
+            /// property expresses the exact version for the whole input space,
+            /// including empty indexes, unicode/empty ids, duplicate ids,
+            /// duplicate tokens, and the full f32 boundary set.
+            #[test]
+            fn prop_splade_save_load_roundtrip_bit_exact(
+                input in index_input_strategy(),
+                generation in prop::num::u64::ANY,
+            ) {
+                let original = SpladeIndex::build(
+                    input.iter().map(|(id, sv)| (id.clone(), sv.clone())).collect(),
+                );
+
+                let dir = tempfile::TempDir::new().unwrap();
+                let path = dir.path().join("splade.index.bin");
+
+                original.save(&path, generation)?;
+                let loaded = SpladeIndex::load(&path, generation)?
+                    .ok_or_else(|| {
+                        TestCaseError::fail("load returned Ok(None) for a file we just wrote")
+                    })?;
+
+                // id_map is insertion-ordered on both sides — exact equality.
+                prop_assert_eq!(
+                    &loaded.id_map, &original.id_map,
+                    "id_map diverged across save/load"
+                );
+
+                // Same token set.
+                prop_assert_eq!(
+                    loaded.postings.len(), original.postings.len(),
+                    "unique-token count diverged across save/load"
+                );
+
+                // Per token: same posting multiplicity, same order, same
+                // chunk_idx, and BIT-EXACT weight (the assertion the fixtures
+                // cannot make).
+                for (token_id, orig_postings) in &original.postings {
+                    let loaded_postings = loaded.postings.get(token_id).ok_or_else(|| {
+                        TestCaseError::fail(format!("token {token_id} lost on round-trip"))
+                    })?;
+                    prop_assert_eq!(
+                        loaded_postings.len(), orig_postings.len(),
+                        "posting-list length diverged for token {}", token_id
+                    );
+                    for (a, b) in loaded_postings.iter().zip(orig_postings.iter()) {
+                        prop_assert_eq!(a.0, b.0, "chunk_idx diverged for token {}", token_id);
+                        prop_assert!(
+                            a.1.to_bits() == b.1.to_bits(),
+                            "weight bit pattern diverged for token {}: \
+                             loaded {:#010x} != original {:#010x} \
+                             (loaded={}, original={})",
+                            token_id, a.1.to_bits(), b.1.to_bits(), a.1, b.1
+                        );
+                    }
+                }
+            }
+
+            /// The two read backings (mmap vs forced-heap) of the SAME on-disk
+            /// file must decode to bit-identical indexes for EVERY valid input.
+            /// `test_load_mmap_matches_heap` asserts this for one fixture with
+            /// an approximate weight compare; the property generalizes it over
+            /// the input space with bit-exact weights. Serial because it
+            /// toggles `CQS_SPLADE_NO_MMAP`.
+            #[test]
+            #[serial_test::serial]
+            fn prop_splade_mmap_matches_heap_bit_exact(
+                input in index_input_strategy(),
+            ) {
+                // Skip the empty case: an all-empty index produces a 64-byte
+                // header-only file whose mmap/heap paths are trivially equal
+                // and the env toggle adds no coverage. Non-empty inputs
+                // exercise the body decode under both backings.
+                prop_assume!(!input.is_empty());
+
+                let original = SpladeIndex::build(
+                    input.iter().map(|(id, sv)| (id.clone(), sv.clone())).collect(),
+                );
+                let dir = tempfile::TempDir::new().unwrap();
+                let path = dir.path().join("splade.index.bin");
+                original.save(&path, 1)?;
+
+                let prev = std::env::var("CQS_SPLADE_NO_MMAP").ok();
+
+                std::env::remove_var("CQS_SPLADE_NO_MMAP");
+                let via_mmap = SpladeIndex::load(&path, 1)?
+                    .ok_or_else(|| TestCaseError::fail("mmap load returned None"))?;
+
+                std::env::set_var("CQS_SPLADE_NO_MMAP", "1");
+                let via_heap = SpladeIndex::load(&path, 1)?
+                    .ok_or_else(|| TestCaseError::fail("heap load returned None"))?;
+
+                match prev {
+                    Some(v) => std::env::set_var("CQS_SPLADE_NO_MMAP", v),
+                    None => std::env::remove_var("CQS_SPLADE_NO_MMAP"),
+                }
+
+                prop_assert_eq!(&via_mmap.id_map, &via_heap.id_map, "mmap/heap id_map diverged");
+                prop_assert_eq!(
+                    via_mmap.postings.len(), via_heap.postings.len(),
+                    "mmap/heap token count diverged"
+                );
+                for (token_id, mmap_list) in &via_mmap.postings {
+                    let heap_list = via_heap.postings.get(token_id).ok_or_else(|| {
+                        TestCaseError::fail(format!("token {token_id} present in mmap, absent in heap"))
+                    })?;
+                    prop_assert_eq!(mmap_list.len(), heap_list.len(), "mmap/heap posting len diverged");
+                    for (a, b) in mmap_list.iter().zip(heap_list.iter()) {
+                        prop_assert_eq!(a.0, b.0, "mmap/heap chunk_idx diverged");
+                        prop_assert!(
+                            a.1.to_bits() == b.1.to_bits(),
+                            "mmap/heap weight bits diverged: {:#010x} != {:#010x}",
+                            a.1.to_bits(), b.1.to_bits()
+                        );
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
First staffing run of the **property-auditor** (#1826) — proves its value-test on two codec/idempotence targets. **No production bug found** (both are correct); ships 6 durable property guards that a hand-written example *structurally cannot* express.

**SpladeIndex round-trip** (`src/splade/index.rs`): the existing fixtures compare weights with `(a-b).abs() < EPSILON` — which cannot distinguish `+0.0` from `-0.0` or one NaN bit-pattern from another. The new properties assert `to_bits()` identity over a generated f32 boundary set (`±0.0`, MIN/MAX, MIN_POSITIVE, smallest subnormal, `±inf`, NaN), plus empty-index, astral-unicode chunk ids, duplicate ids/tokens, full-range u32 token ids. Plus mmap-decode ≡-bits heap-decode.

**canonical_hash metamorphic** (`src/parser/chunk.rs`): lifts the single (base, edited) example pairs to a generated family of bodies × comment payloads through the real tree-sitter parser — idempotence of whitespace-collapse (forced Unicode whitespace so the first pass is non-vacuous) + comment-and-reindent preserves the hash. Two falsifiers, both hand-verified as too-strong-property and fixed in the **generator, not production** (one a genuine generator-bites-the-null win: a NUL in a `//` payload, which tree-sitter doesn't treat as a comment).

Test-only; no production change; no global-state. The auditor flagged `HnswMeta` save/load as the richest remaining round-trip target (generation-stamp / sidecar-from-previous-generation bite history) for a future property-auditor staffing.

Part of #1826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
