### PR TITLE
fix(overlay): faithful-shadow parent notes into the worktree overlay store (closes #1878)

### DIFF
--- a/src/cli/batch/handlers/search.rs
+++ b/src/cli/batch/handlers/search.rs
@@ -1435,6 +1435,7 @@ mod tests {
             &view.root,
             &parser,
             embedder_ref,
+            &view.store,
             None,
             std::time::Duration::from_millis(0),
         )

--- a/src/cli/batch/view.rs
+++ b/src/cli/batch/view.rs
@@ -250,12 +250,14 @@ pub(crate) fn get_all_refs_via_refs_lru(
 /// worktree of `parent_root`) by the caller — this function reads + embeds its
 /// files, so an unvalidated path would be an arbitrary-directory read primitive
 /// (the security seam, plan §8).
-pub(crate) fn get_overlay_via_lru(
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn get_overlay_via_lru<M>(
     overlays: &Mutex<lru::LruCache<PathBuf, Arc<super::OverlayCacheEntry>>>,
     worktree_root: &Path,
     parent_root: &Path,
     parser: &cqs::parser::Parser,
     embedder: &Embedder,
+    parent_store: &Store<M>,
     global_cache: Option<&cqs::cache::EmbeddingCache>,
     debounce: std::time::Duration,
 ) -> Result<Option<Arc<cqs::worktree_overlay::WorktreeOverlay>>, cqs::worktree_overlay::OverlayError>
@@ -321,6 +323,7 @@ pub(crate) fn get_overlay_via_lru(
         parent_root,
         parser,
         embedder,
+        parent_store,
         global_cache,
     )?;
 
@@ -1026,6 +1029,7 @@ impl BatchView {
             &self.root,
             &parser,
             embedder,
+            &self.store,
             cache.as_ref(),
             super::overlay_fp_debounce(),
         ) {

--- a/src/cli/commands/search/query.rs
+++ b/src/cli/commands/search/query.rs
@@ -2219,6 +2219,75 @@ mod tests {
             }
         }
 
+        /// Regression guard at the overlay *search* seam: a file noted in the
+        /// parent index and re-served from the overlay leg must carry the note's
+        /// sentiment multiplier AND record `note_boost` provenance. This
+        /// exercises the EXACT production call `apply_overlay` makes
+        /// (`overlay.store.search_filtered_with_index`) after `build_overlay`
+        /// copied the parent's notes into the shadow store. With an empty
+        /// overlay notes table the multiplier collapses to 1.0 and `note_boost`
+        /// is never recorded — the score divergence + provenance lie this
+        /// guards against.
+        #[test]
+        fn overlay_search_records_note_boost_for_noted_edited_file() {
+            use cqs::note::Note;
+
+            // Parent index carries a -0.5 note on `src/fragile.rs`. An in-memory
+            // store is a sufficient notes source — `copy_notes_from` reads the
+            // parent's notes table over SQLite, no on-disk index needed.
+            let parent = Store::open_memory().expect("parent store");
+            parent
+                .init(&ModelInfo::default())
+                .expect("init parent store");
+            let note = Note {
+                id: "note:0".to_string(),
+                text: "fragile — handle with care".to_string(),
+                sentiment: -0.5,
+                mentions: vec!["src/fragile.rs".to_string()],
+                kind: None,
+            };
+            parent
+                .upsert_notes_batch(&[note], std::path::Path::new("docs/notes.toml"), 100)
+                .expect("seed parent note");
+
+            // Overlay shadow store: one chunk for the edited+noted file at slot 0,
+            // plus the parent's notes copied in (the fix under test).
+            let overlay = overlay_with(&[("src/fragile.rs", "fragile_fn", 0)], &["src/fragile.rs"]);
+            let copied = overlay
+                .store
+                .copy_notes_from(&parent)
+                .expect("copy parent notes into shadow");
+            assert_eq!(copied, 1, "the parent note crossed into the shadow store");
+
+            // Search the shadow store exactly as `apply_overlay` does, with
+            // rank-signal recording on so we can read the provenance.
+            let mut filter = SearchFilter::default();
+            filter.query_text = "fragile".to_string();
+            filter.record_rank_signals = true;
+            let hits = overlay
+                .store
+                .search_filtered_with_index(&one_hot(0), &filter, 10, 0.0, None)
+                .expect("overlay store search");
+
+            let hit = hits
+                .iter()
+                .find(|r| r.chunk.name == "fragile_fn")
+                .expect("the noted chunk is retrieved from the overlay store");
+
+            // Provenance: `note_boost` is recorded with the -0.5 multiplier
+            // (< 1.0). Absence here is the provenance lie the fix closes.
+            let note_signal = hit
+                .rank_signals
+                .iter()
+                .find(|s| s.signal == "note_boost")
+                .expect("overlay hit must record note_boost provenance");
+            assert!(
+                note_signal.value < 1.0,
+                "note_boost multiplier must reflect the -0.5 demotion, got {}",
+                note_signal.value
+            );
+        }
+
         /// A `PreparedQuery` carrying `emb` + a default filter and nothing else
         /// (no SPLADE, no index, no reranker) — exactly what `apply_overlay`
         /// reads (`query_embedding`, `filter`).

--- a/src/cli/worktree_overlay_build.rs
+++ b/src/cli/worktree_overlay_build.rs
@@ -40,6 +40,11 @@ use cqs::worktree_overlay::{discover_delta, fingerprint, OverlayStats, WorktreeO
 /// - `parser` / `embedder`: the session's resident parser + embedder (the
 ///   daemon's, so overlay embeddings are dimension-compatible with prepared
 ///   queries by construction).
+/// - `parent_store`: the resident parent index. Its SQLite notes are copied
+///   into the overlay store so the overlay leg's note-boost index computes the
+///   same sentiment multiplier and records the same `note_boost` provenance the
+///   parent would — notes are project-level metadata keyed on mentions, not on
+///   uncommitted content, so they belong in a faithful shadow.
 /// - `global_cache`: optional embedding cache (see the cache-write note in
 ///   the module docs).
 ///
@@ -51,11 +56,12 @@ use cqs::worktree_overlay::{discover_delta, fingerprint, OverlayStats, WorktreeO
 // (PR-3) is the production caller. Exercised under `slow-tests` by
 // `build_overlay_indexes_dirty_delta` below.
 #[allow(dead_code)]
-pub(crate) fn build_overlay(
+pub(crate) fn build_overlay<M>(
     worktree_root: &Path,
     parent_root: &Path,
     parser: &CqParser,
     embedder: &Embedder,
+    parent_store: &Store<M>,
     global_cache: Option<&cqs::cache::EmbeddingCache>,
 ) -> Result<Option<WorktreeOverlay>, cqs::worktree_overlay::OverlayError> {
     let _span = tracing::info_span!(
@@ -84,6 +90,24 @@ pub(crate) fn build_overlay(
     let model_info = ModelInfo::new(&embedder.model_config().repo, embedder.embedding_dim());
     store.init(&model_info)?;
     store.set_dim(model_info.dimensions);
+
+    // Copy the parent's notes into the shadow store so the overlay leg's
+    // note-boost index demotes/promotes a noted-and-edited file the same way
+    // the parent leg would — and records the `note_boost` provenance. Notes are
+    // keyed on mentions, not on the dirty content the overlay replaces, so the
+    // shadow is faithful only with them. A copy failure is non-fatal: the
+    // overlay still serves correct hits, just without the note multiplier on
+    // the masked-and-re-served files (degrade, don't drop the overlay).
+    match store.copy_notes_from(parent_store) {
+        Ok(n) => {
+            if n > 0 {
+                tracing::debug!(notes = n, "overlay: copied parent notes into shadow store");
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "overlay: failed to copy parent notes — note boosts will be absent on overlay hits");
+        }
+    }
 
     // Parse + embed the parse set into the overlay store via the incremental
     // pipeline. `reindex_files` tolerates per-file parse failure and rewrites
@@ -191,7 +215,13 @@ mod tests {
         let parent = dunce::canonicalize(&parent).unwrap_or(parent);
         let wt = dunce::canonicalize(&wt).unwrap_or(wt);
 
-        let overlay = build_overlay(&wt, &parent, &parser, &embedder, None)
+        // A minimal parent store (no notes) — this test exercises masking, not
+        // the note copy; the empty-notes case must leave the overlay unchanged.
+        let parent_store = Store::open_memory().expect("parent store");
+        let parent_model = ModelInfo::new(&embedder.model_config().repo, embedder.embedding_dim());
+        parent_store.init(&parent_model).expect("init parent store");
+
+        let overlay = build_overlay(&wt, &parent, &parser, &embedder, &parent_store, None)
             .expect("build_overlay")
             .expect("non-clean worktree yields Some(overlay)");
 
@@ -206,5 +236,117 @@ mod tests {
             "overlay indexed at least one chunk from the new file"
         );
         assert_eq!(overlay.worktree_root, wt);
+    }
+
+    /// `build_overlay` copies the parent's notes into the shadow store so a
+    /// file that is both noted in the parent AND edited in the worktree keeps
+    /// its note multiplier when re-served from the overlay leg. End-to-end
+    /// through `build_overlay` (not the unit `copy_notes_from`): proves the copy
+    /// is actually wired into the production build, against a real parse+embed.
+    #[test]
+    fn build_overlay_copies_parent_notes_into_shadow() {
+        use cqs::embedder::ModelConfig;
+        use cqs::note::Note;
+
+        let embedder = match cqs::Embedder::new_cpu(ModelConfig::resolve(None, None)) {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("Skipping build_overlay notes e2e: embedder init failed: {e}");
+                return;
+            }
+        };
+        let parser = CqParser::new().expect("parser");
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let parent = tmp.path().join("parent");
+        std::fs::create_dir_all(parent.join("src")).unwrap();
+        std::fs::write(parent.join("src/lib.rs"), "pub fn alpha() -> i32 { 1 }\n").unwrap();
+        git(&parent, &["init", "-q", "-b", "main"]);
+        git(&parent, &["config", "user.email", "t@e.com"]);
+        git(&parent, &["config", "user.name", "T"]);
+        git(&parent, &["add", "-A"]);
+        git(&parent, &["commit", "-q", "-m", "init"]);
+
+        let wt = tmp.path().join("wt");
+        git(
+            &parent,
+            &["worktree", "add", "-q", "-b", "lane", wt.to_str().unwrap()],
+        );
+
+        // Edit lib.rs in the worktree — this masks `src/lib.rs` out of the
+        // parent leg and re-serves it from the overlay. The parent has a -0.5
+        // note on exactly this file.
+        std::fs::write(
+            wt.join("src/lib.rs"),
+            "pub fn alpha() -> i32 { 2 }\npub fn beta() -> i32 { 3 }\n",
+        )
+        .unwrap();
+
+        let parent = dunce::canonicalize(&parent).unwrap_or(parent);
+        let wt = dunce::canonicalize(&wt).unwrap_or(wt);
+
+        // Parent store with a note mentioning the edited file.
+        let parent_store = Store::open_memory().expect("parent store");
+        let parent_model = ModelInfo::new(&embedder.model_config().repo, embedder.embedding_dim());
+        parent_store.init(&parent_model).expect("init parent store");
+        let note = Note {
+            id: "note:0".to_string(),
+            text: "lib is load-bearing".to_string(),
+            sentiment: -0.5,
+            mentions: vec!["src/lib.rs".to_string()],
+            kind: None,
+        };
+        parent_store
+            .upsert_notes_batch(&[note], std::path::Path::new("docs/notes.toml"), 100)
+            .expect("seed parent note");
+
+        let overlay = build_overlay(&wt, &parent, &parser, &embedder, &parent_store, None)
+            .expect("build_overlay")
+            .expect("non-clean worktree yields Some(overlay)");
+
+        // The note crossed into the shadow store's notes table (public API:
+        // `cached_note_boost_index` is lib-crate-private, so assert through the
+        // public notes surface + a real search instead).
+        assert_eq!(
+            overlay.store.note_count().expect("shadow note count"),
+            1,
+            "build_overlay must copy the parent note into the shadow store"
+        );
+        let summaries = overlay
+            .store
+            .list_notes_summaries()
+            .expect("shadow note summaries");
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(
+            summaries[0].mentions,
+            vec!["src/lib.rs".to_string()],
+            "the copied note keeps its mention"
+        );
+
+        // End-to-end provenance: a search of the shadow store for the edited
+        // file records `note_boost` with the -0.5 demotion — the multiplier the
+        // empty-notes overlay would have silently dropped.
+        let query_emb = embedder.embed_query("beta function").expect("embed query");
+        let mut filter = cqs::SearchFilter::default();
+        filter.query_text = "beta function".to_string();
+        filter.record_rank_signals = true;
+        let hits = overlay
+            .store
+            .search_filtered_with_index(&query_emb, &filter, 10, 0.0, None)
+            .expect("shadow search");
+        let lib_hit = hits
+            .iter()
+            .find(|r| r.chunk.file == std::path::Path::new("src/lib.rs"))
+            .expect("a chunk from the edited+noted file is retrieved");
+        let note_signal = lib_hit
+            .rank_signals
+            .iter()
+            .find(|s| s.signal == "note_boost")
+            .expect("overlay hit records note_boost provenance");
+        assert!(
+            note_signal.value < 1.0,
+            "note_boost reflects the -0.5 demotion, got {}",
+            note_signal.value
+        );
     }
 }

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -124,6 +124,108 @@ impl Store<ReadWrite> {
         })
     }
 
+    /// Copy every note row from `parent` into this store, preserving the
+    /// note id, text, sentiment, mentions, kind, source file, and mtime.
+    ///
+    /// Notes are project-level metadata keyed on their `mentions` (file +
+    /// name); they do not change with uncommitted code edits. A faithful
+    /// shadow of a parent index — e.g. the worktree search overlay's fresh
+    /// `:memory:` store — must therefore carry the parent's notes so its
+    /// note-boost index computes the same sentiment multiplier and records the
+    /// same `note_boost` provenance the parent would. Without this the overlay
+    /// store's notes table is empty, so a file that is both noted in the
+    /// parent and edited in the worktree (masked out of the parent leg,
+    /// re-served from the overlay leg) loses its note multiplier and its
+    /// `note_boost` signal.
+    ///
+    /// The parent's SQLite notes are the source of truth, not `docs/notes.toml`
+    /// — the file can be stale relative to notes added via `cqs notes add`
+    /// since the last index. Notes copied here already satisfy the discrete-
+    /// sentiment CHECK constraint (they were written through the same schema),
+    /// so the re-insert cannot violate it.
+    ///
+    /// Returns the number of notes copied. A parent with no notes is a no-op.
+    pub fn copy_notes_from<M>(&self, parent: &Store<M>) -> Result<usize, StoreError> {
+        let _span = tracing::info_span!("copy_notes_from").entered();
+
+        // Read the parent's full note rows, including source_file + file_mtime
+        // so the shadow preserves them. Grouped by (source_file, file_mtime)
+        // because the batched insert helper stamps one source/mtime per call;
+        // today notes.toml is the only source, but the schema permits several.
+        let rows = parent.rt.block_on(async {
+            let rows: Vec<_> = sqlx::query(
+                "SELECT id, text, sentiment, mentions, kind, source_file, file_mtime \
+                 FROM notes ORDER BY source_file, created_at",
+            )
+            .fetch_all(&parent.pool)
+            .await?;
+            Ok::<_, StoreError>(rows)
+        })?;
+
+        if rows.is_empty() {
+            return Ok(0);
+        }
+
+        // (source_file, file_mtime) → notes for that group, insertion order
+        // preserved by the ORDER BY above.
+        let mut groups: Vec<(String, i64, Vec<Note>)> = Vec::new();
+        for row in &rows {
+            let id: String = row.get(0);
+            let text: String = row.get(1);
+            let sentiment: f64 = row.get(2);
+            let mentions_json: Option<String> = row.try_get(3).unwrap_or(None);
+            let kind: Option<String> = row.try_get(4).unwrap_or(None);
+            let source_file: String = row.get(5);
+            let file_mtime: i64 = row.get(6);
+
+            let mentions: Vec<String> = mentions_json
+                .as_deref()
+                .map(|j| {
+                    serde_json::from_str(j).unwrap_or_else(|e| {
+                        tracing::warn!(note_id = %id, error = %e, "Failed to deserialize note mentions during copy");
+                        Vec::new()
+                    })
+                })
+                .unwrap_or_default();
+
+            let note = Note {
+                id,
+                text,
+                sentiment: sentiment as f32,
+                mentions,
+                kind,
+            };
+
+            match groups
+                .iter_mut()
+                .find(|(sf, mt, _)| *sf == source_file && *mt == file_mtime)
+            {
+                Some((_, _, notes)) => notes.push(note),
+                None => groups.push((source_file, file_mtime, vec![note])),
+            }
+        }
+
+        let copied = rows.len();
+        self.rt.block_on(async {
+            let (_guard, mut tx) = self.begin_write().await?;
+            let now = chrono::Utc::now().to_rfc3339();
+            for (source_str, file_mtime, notes) in &groups {
+                insert_notes_with_fts_batched(&mut tx, notes, source_str, *file_mtime, &now)
+                    .await?;
+            }
+            tx.commit().await?;
+            self.invalidate_notes_cache();
+            Ok::<_, StoreError>(())
+        })?;
+
+        tracing::debug!(
+            copied,
+            groups = groups.len(),
+            "copied parent notes into shadow store"
+        );
+        Ok(copied)
+    }
+
     /// Replace all notes for a source file in a single transaction.
     /// Atomically deletes existing notes and inserts new ones, preventing
     /// data loss if the process crashes mid-operation.
@@ -284,6 +386,7 @@ impl<Mode> Store<Mode> {
 mod tests {
     use crate::note::Note;
     use crate::test_helpers::setup_store;
+    use crate::Store;
     use std::path::Path;
 
     /// Creates a new Note with the specified id, text, and sentiment.
@@ -558,5 +661,185 @@ mod tests {
         // INSERT-OR-REPLACE + FTS DELETE/INSERT contract).
         let summaries = store.list_notes_summaries().unwrap();
         assert_eq!(summaries.len(), 500);
+    }
+
+    fn note_with_mentions(id: &str, sentiment: f32, mentions: &[&str]) -> Note {
+        Note {
+            id: id.to_string(),
+            text: format!("note {id}"),
+            sentiment,
+            mentions: mentions.iter().map(|s| s.to_string()).collect(),
+            kind: None,
+        }
+    }
+
+    /// The defect's core fix: a parent note crosses into a fresh shadow store
+    /// (the worktree overlay's `:memory:` store) so the shadow's note-boost
+    /// index computes the SAME multiplier the parent would. A `-0.5` note on a
+    /// file must demote a chunk in that file in BOTH stores — the masked-and-
+    /// re-served overlay hit can no longer skip the sentiment multiplier.
+    #[test]
+    fn test_copy_notes_from_crosses_boost_into_shadow() {
+        let (parent, _pdir) = setup_store();
+        let source = Path::new("docs/notes.toml");
+        parent
+            .upsert_notes_batch(
+                &[note_with_mentions("note:0", -0.5, &["src/fragile.rs"])],
+                source,
+                100,
+            )
+            .unwrap();
+
+        // The parent demotes a chunk in the noted file.
+        let parent_boost = parent
+            .cached_note_boost_index()
+            .unwrap()
+            .boost("src/fragile.rs", "do_thing");
+        assert!(
+            parent_boost < 1.0,
+            "parent must demote the noted file, got {parent_boost}"
+        );
+
+        // A fresh shadow store starts empty — boost is the 1.0 no-op (this is
+        // the bug: the overlay leg would lose the demotion here).
+        let shadow = Store::open_memory().unwrap();
+        shadow
+            .init(&crate::store::helpers::ModelInfo::default())
+            .unwrap();
+        let before = shadow
+            .cached_note_boost_index()
+            .unwrap()
+            .boost("src/fragile.rs", "do_thing");
+        assert_eq!(before, 1.0, "empty shadow has no note opinion");
+
+        // Copy the parent's notes into the shadow → the note crosses.
+        let copied = shadow.copy_notes_from(&parent).unwrap();
+        assert_eq!(copied, 1, "one note copied");
+        assert_eq!(shadow.note_count().unwrap(), 1);
+
+        // The shadow now computes the IDENTICAL boost the parent does.
+        let after = shadow
+            .cached_note_boost_index()
+            .unwrap()
+            .boost("src/fragile.rs", "do_thing");
+        assert_eq!(
+            after, parent_boost,
+            "shadow boost must equal parent boost after copy"
+        );
+
+        // Metadata crossed faithfully (id, sentiment, mentions, kind).
+        let summaries = shadow.list_notes_summaries().unwrap();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].id, "note:0");
+        assert_eq!(summaries[0].sentiment, -0.5);
+        assert_eq!(summaries[0].mentions, vec!["src/fragile.rs".to_string()]);
+
+        // FTS crossed too — note keyword search works in the shadow.
+        assert_eq!(
+            shadow.list_notes_summaries().unwrap().len(),
+            shadow.note_count().unwrap() as usize,
+            "FTS and main table agree in the shadow"
+        );
+    }
+
+    /// Copying from a parent with no notes is a no-op — the clean-worktree /
+    /// no-notes case must leave the shadow's empty notes table untouched and
+    /// its boost at the 1.0 no-op.
+    #[test]
+    fn test_copy_notes_from_empty_parent_is_noop() {
+        let (parent, _pdir) = setup_store();
+        let shadow = Store::open_memory().unwrap();
+        shadow
+            .init(&crate::store::helpers::ModelInfo::default())
+            .unwrap();
+
+        let copied = shadow.copy_notes_from(&parent).unwrap();
+        assert_eq!(copied, 0, "no notes to copy");
+        assert_eq!(shadow.note_count().unwrap(), 0);
+        assert_eq!(
+            shadow
+                .cached_note_boost_index()
+                .unwrap()
+                .boost("src/any.rs", "anything"),
+            1.0,
+            "empty copy leaves the no-op boost"
+        );
+    }
+
+    /// Notes spanning multiple source files all cross, and a positive-sentiment
+    /// note promotes its mention in the shadow — both boost directions survive
+    /// the copy, not just demotion.
+    #[test]
+    fn test_copy_notes_from_multiple_sources_and_signs() {
+        let (parent, _pdir) = setup_store();
+        parent
+            .upsert_notes_batch(
+                &[note_with_mentions("note:0", -1.0, &["src/a.rs"])],
+                Path::new("docs/notes.toml"),
+                100,
+            )
+            .unwrap();
+        parent
+            .upsert_notes_batch(
+                &[note_with_mentions("note:1", 1.0, &["src/b.rs"])],
+                Path::new("design/notes.toml"),
+                200,
+            )
+            .unwrap();
+
+        let shadow = Store::open_memory().unwrap();
+        shadow
+            .init(&crate::store::helpers::ModelInfo::default())
+            .unwrap();
+        let copied = shadow.copy_notes_from(&parent).unwrap();
+        assert_eq!(copied, 2, "both notes across both source files copied");
+        assert_eq!(shadow.note_count().unwrap(), 2);
+
+        let idx = shadow.cached_note_boost_index().unwrap();
+        assert!(
+            idx.boost("src/a.rs", "f") < 1.0,
+            "negative note demotes in shadow"
+        );
+        assert!(
+            idx.boost("src/b.rs", "g") > 1.0,
+            "positive note promotes in shadow"
+        );
+    }
+
+    /// All five discrete sentiment values survive the copy's f64→f32→REAL
+    /// round-trip without tripping the discrete-value CHECK constraint on the
+    /// re-insert. These values are exact in both f32 and f64, so the cast can't
+    /// drift one off-grid — this pins that property so a future float-handling
+    /// change can't silently start rejecting copied notes.
+    #[test]
+    fn test_copy_notes_from_preserves_discrete_sentiments() {
+        let (parent, _pdir) = setup_store();
+        let notes: Vec<Note> = [-1.0_f32, -0.5, 0.0, 0.5, 1.0]
+            .iter()
+            .enumerate()
+            .map(|(i, &s)| note_with_mentions(&format!("note:{i}"), s, &["src/x.rs"]))
+            .collect();
+        parent
+            .upsert_notes_batch(&notes, Path::new("docs/notes.toml"), 100)
+            .unwrap();
+
+        let shadow = Store::open_memory().unwrap();
+        shadow
+            .init(&crate::store::helpers::ModelInfo::default())
+            .unwrap();
+        let copied = shadow
+            .copy_notes_from(&parent)
+            .expect("copy must not violate the discrete-sentiment CHECK");
+        assert_eq!(copied, 5);
+        assert_eq!(shadow.note_count().unwrap(), 5);
+
+        let mut sentiments: Vec<f32> = shadow
+            .list_notes_summaries()
+            .unwrap()
+            .into_iter()
+            .map(|n| n.sentiment)
+            .collect();
+        sentiments.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_eq!(sentiments, vec![-1.0, -0.5, 0.0, 0.5, 1.0]);
     }
 }


### PR DESCRIPTION
## Faithful-shadow parent notes into the worktree overlay store

closes #1878

The default-on worktree search overlay built a fresh `:memory:` store but never copied the parent's notes. So for a file that is **both noted in the parent index AND edited in the worktree** (masked out of the parent leg, re-served from the overlay leg), the overlay leg's note-boost index was a 1.0 no-op — dropping the sentiment multiplier from its score (a `-0.5`-flagged fragile file stopped being demoted, exactly when the agent is editing it) and never recording `note_boost` provenance (absence read as "un-noted"). The overlay is meant to be a faithful shadow of the parent with only the dirty *content* replaced; notes are project-level metadata keyed on `(file, name)` and belong in the shadow.

### Fix

- **New `Store::copy_notes_from<M>(&self, parent: &Store<M>)`** (`src/store/notes.rs`) — reads the parent's full note rows from SQLite, bulk-inserts via the existing `insert_notes_with_fts_batched` (so FTS stays in sync), in a single transaction (no half-copied skew on failure), then `invalidate_notes_cache()` so the lazy boost cache rebuilds from the copied rows. Parent SQLite is the source of truth (not the worktree's possibly-stale `docs/notes.toml`).
- **`build_overlay`** calls it right after `init`+`set_dim`, before reindex; copy failure degrades (warn, keep the notes-less overlay) rather than dropping the overlay.
- **`get_overlay_via_lru` / `BatchView::resolve_overlay`** thread `&self.store` (the resident parent store). Both made generic over parent store mode `<M>`; production passes `ReadOnly`, tests pass `ReadWrite`.

The overlay store's note-boost index is built per-store from its own notes table at search time, so populating the table is sufficient — `apply_overlay`'s `search_filtered_with_index` then applies the multiplier and records `note_boost` for free.

### Verification

10 new tests: lib `store::notes` (boost crosses into the shadow; empty-parent no-op; both demotion + promotion survive; all 5 discrete sentiments survive the f64→f32→REAL round-trip without tripping the v29 CHECK), bin `overlay_merge` (the production `search_filtered_with_index` call records `note_boost` with the demotion multiplier), slow e2e (`build_overlay` copies notes against a real parse+embed). All green; fmt / clippy --all-targets cuda / provenance clean. Not a global-state change (no schema / PARSER_VERSION / envelope).

### Review (magnet-area gates)
- **Opus code-review: APPROVE** — copy fidelity (every field via the FTS-synced helper, exact sentiment round-trip), lazy-cache invalidation correct, generic-`<M>` purely additive, single-tx atomicity, single overlay-build path so no daemon/CLI parallel-surface gap.
- **Re-seam-audit:** 3 of 4 seams refuted with evidence (no double-boost — `parse_set ⊆ masked_origins`; no cross-project note bleed; audit-mode suppression parity holds). The 4th is a **low-severity, self-healing, concurrency-gated** residual (the overlay fingerprint omits notes, so a concurrent notes-write can leave the overlay leg's `note_boost` transiently stale vs the parent leg) — filed as **#1884** for a targeted notes-revision-token frame fix. Strictly an improvement over the pre-fix constant-wrong 1.0; not a release blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
