### PR TITLE
fix(overlay): fold notes-revision into overlay fingerprint — invalidate on parent notes change (closes #1884)

### DIFF
--- a/src/cli/batch/view.rs
+++ b/src/cli/batch/view.rs
@@ -292,7 +292,17 @@ pub(crate) fn get_overlay_via_lru<M>(
         // discovery error) falls through to a rebuild below.
         match cqs::worktree_overlay::discover_delta(worktree_root, parent_root) {
             Ok(delta) => {
-                let fp = cqs::worktree_overlay::fingerprint(worktree_root, &delta);
+                // Recompute the same fingerprint the build stamped — including
+                // the notes-revision token, so a parent notes mutation since the
+                // cached build registers as a fingerprint change (rebuild) and a
+                // notes-unchanged re-validation still matches. The zero-token
+                // fallback mirrors `build_overlay` so a read failure does not
+                // spuriously diverge the two computations.
+                let notes_revision = parent_store.notes_revision().unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "overlay re-validation: failed to read parent notes-revision — using zero token");
+                    [0u8; 32]
+                });
+                let fp = cqs::worktree_overlay::fingerprint(worktree_root, &delta, &notes_revision);
                 if fp == entry.overlay.fingerprint {
                     tracing::debug!(
                         "overlay fingerprint re-validated (unchanged) — reusing cached build"

--- a/src/cli/worktree_overlay_build.rs
+++ b/src/cli/worktree_overlay_build.rs
@@ -72,7 +72,19 @@ pub(crate) fn build_overlay<M>(
     let started = Instant::now();
 
     let delta = discover_delta(worktree_root, parent_root)?;
-    let fp = fingerprint(worktree_root, &delta);
+    // Fold the parent's notes-revision token into the overlay's cache identity.
+    // Notes are copied into the shadow store below (so its `note_boost` matches
+    // the parent), so they must participate in the fingerprint too: a parent
+    // notes mutation flips the token → the LRU rebuilds with fresh notes rather
+    // than serving a stale boost until the deferrable overlay-clear. A read
+    // failure degrades to a zero token (a stable sentinel) — the overlay still
+    // serves correct hits; it just won't auto-invalidate on a notes change,
+    // which the deferrable clear still covers.
+    let notes_revision = parent_store.notes_revision().unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "overlay: failed to read parent notes-revision — fingerprint will not track notes for this build");
+        [0u8; 32]
+    });
+    let fp = fingerprint(worktree_root, &delta, &notes_revision);
 
     // A clean worktree (no touched origins) has nothing to overlay. Return
     // None so the caller skips the merge entirely rather than building an
@@ -347,6 +359,136 @@ mod tests {
             note_signal.value < 1.0,
             "note_boost reflects the -0.5 demotion, got {}",
             note_signal.value
+        );
+    }
+
+    /// End-to-end invalidation: a parent notes mutation moves the overlay's
+    /// fingerprint and the rebuilt shadow store's `note_boost` reflects the new
+    /// sentiment. Proven through the real build: the notes-revision token
+    /// folded into the fingerprint means a
+    /// `cqs notes update` on the parent invalidates the overlay's cache identity
+    /// (fingerprint differs → LRU miss → rebuild with fresh notes) instead of
+    /// serving a stale boost until the deferrable overlay-clear runs.
+    #[test]
+    fn build_overlay_fingerprint_tracks_parent_note_sentiment() {
+        use cqs::embedder::ModelConfig;
+        use cqs::note::Note;
+
+        let embedder = match cqs::Embedder::new_cpu(ModelConfig::resolve(None, None)) {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("Skipping build_overlay notes-revision e2e: embedder init failed: {e}");
+                return;
+            }
+        };
+        let parser = CqParser::new().expect("parser");
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let parent = tmp.path().join("parent");
+        std::fs::create_dir_all(parent.join("src")).unwrap();
+        std::fs::write(parent.join("src/lib.rs"), "pub fn alpha() -> i32 { 1 }\n").unwrap();
+        git(&parent, &["init", "-q", "-b", "main"]);
+        git(&parent, &["config", "user.email", "t@e.com"]);
+        git(&parent, &["config", "user.name", "T"]);
+        git(&parent, &["add", "-A"]);
+        git(&parent, &["commit", "-q", "-m", "init"]);
+
+        let wt = tmp.path().join("wt");
+        git(
+            &parent,
+            &["worktree", "add", "-q", "-b", "lane", wt.to_str().unwrap()],
+        );
+
+        // Edit lib.rs in the worktree so its origin is masked + re-served from
+        // the overlay. The worktree delta is held FIXED across the two builds —
+        // only the parent note changes — so any fingerprint move is attributable
+        // to the notes-revision token, not the delta.
+        std::fs::write(
+            wt.join("src/lib.rs"),
+            "pub fn alpha() -> i32 { 2 }\npub fn beta() -> i32 { 3 }\n",
+        )
+        .unwrap();
+
+        let parent = dunce::canonicalize(&parent).unwrap_or(parent);
+        let wt = dunce::canonicalize(&wt).unwrap_or(wt);
+
+        let parent_store = Store::open_memory().expect("parent store");
+        let parent_model = ModelInfo::new(&embedder.model_config().repo, embedder.embedding_dim());
+        parent_store.init(&parent_model).expect("init parent store");
+
+        // First build: a -0.5 (demotion) note on the edited file.
+        let note_neg = Note {
+            id: "note:0".to_string(),
+            text: "lib is load-bearing".to_string(),
+            sentiment: -0.5,
+            mentions: vec!["src/lib.rs".to_string()],
+            kind: None,
+        };
+        parent_store
+            .upsert_notes_batch(&[note_neg], std::path::Path::new("docs/notes.toml"), 100)
+            .expect("seed parent note");
+
+        let overlay0 = build_overlay(&wt, &parent, &parser, &embedder, &parent_store, None)
+            .expect("build_overlay (neg)")
+            .expect("non-clean worktree yields Some(overlay)");
+        let fp0 = overlay0.fingerprint;
+
+        // Mutate the parent note's sentiment (the `cqs notes update` path):
+        // -0.5 → +0.5. INSERT OR REPLACE on the same id is the update.
+        let note_pos = Note {
+            id: "note:0".to_string(),
+            text: "lib is load-bearing".to_string(),
+            sentiment: 0.5,
+            mentions: vec!["src/lib.rs".to_string()],
+            kind: None,
+        };
+        parent_store
+            .upsert_notes_batch(&[note_pos], std::path::Path::new("docs/notes.toml"), 200)
+            .expect("update parent note");
+
+        let overlay1 = build_overlay(&wt, &parent, &parser, &embedder, &parent_store, None)
+            .expect("build_overlay (pos)")
+            .expect("non-clean worktree yields Some(overlay)");
+        let fp1 = overlay1.fingerprint;
+
+        // The fingerprint moved — so the LRU treats overlay1 as a miss and
+        // serves the rebuilt store, not the stale overlay0.
+        assert_ne!(
+            fp0, fp1,
+            "a parent note sentiment change must move the overlay fingerprint"
+        );
+
+        // And the rebuilt overlay's note_boost reflects the NEW (+0.5) sentiment:
+        // a boost above 1.0, where overlay0 carried a demotion below 1.0.
+        let query_emb = embedder.embed_query("beta function").expect("embed query");
+        let mut filter = cqs::SearchFilter::default();
+        filter.query_text = "beta function".to_string();
+        filter.record_rank_signals = true;
+
+        let boost_of = |ov: &WorktreeOverlay| -> f32 {
+            let hits = ov
+                .store
+                .search_filtered_with_index(&query_emb, &filter, 10, 0.0, None)
+                .expect("shadow search");
+            let lib_hit = hits
+                .iter()
+                .find(|r| r.chunk.file == std::path::Path::new("src/lib.rs"))
+                .expect("a chunk from the edited+noted file is retrieved");
+            lib_hit
+                .rank_signals
+                .iter()
+                .find(|s| s.signal == "note_boost")
+                .expect("overlay hit records note_boost provenance")
+                .value
+        };
+
+        assert!(
+            boost_of(&overlay0) < 1.0,
+            "overlay0 carried the -0.5 demotion"
+        );
+        assert!(
+            boost_of(&overlay1) > 1.0,
+            "overlay1 (rebuilt after the notes update) carries the +0.5 boost"
         );
     }
 }

--- a/src/store/notes.rs
+++ b/src/store/notes.rs
@@ -317,6 +317,66 @@ impl<Mode> Store<Mode> {
         })
     }
 
+    /// Content-identity digest over the notes table — a deterministic token
+    /// that changes iff the notes change. Used by the worktree search overlay to
+    /// fold notes into its cache identity (the `fingerprint`): a parent notes
+    /// mutation must invalidate the overlay's LRU entry so the rebuilt shadow
+    /// store carries the fresh sentiment, rather than serving a stale
+    /// `note_boost` until the deferrable overlay-clear runs.
+    ///
+    /// Digests `(id, text, sentiment, mentions)` for every row, ordered by `id`
+    /// so git/insert ordering cannot perturb the result. The field set is the
+    /// note identity that determines a boost outcome — `sentiment` and
+    /// `mentions` drive the multiplier directly, and `text` is folded in so a
+    /// text-only `notes update` (which a reader would still expect to count as
+    /// "the notes changed") also flips the token. Timestamp columns
+    /// (`created_at` / `updated_at` / `file_mtime`) are deliberately excluded:
+    /// they can churn without a meaningful note change and would over-invalidate.
+    ///
+    /// This is NOT `data_version`: `data_version` bumps on every index.db write
+    /// (code reindex, chunk upserts, …), so folding it into the fingerprint would
+    /// rebuild the overlay on unrelated parent changes even when the worktree
+    /// delta is unchanged — a perf regression. This token changes only when the
+    /// notes themselves change.
+    ///
+    /// An empty notes table yields a stable, fixed digest (the domain-separated
+    /// header with no rows), so the clean / no-notes case is deterministic.
+    pub fn notes_revision(&self) -> Result<[u8; 32], StoreError> {
+        let _span = tracing::debug_span!("notes_revision").entered();
+        self.rt.block_on(async {
+            let rows: Vec<_> =
+                sqlx::query("SELECT id, text, sentiment, mentions FROM notes ORDER BY id")
+                    .fetch_all(&self.pool)
+                    .await?;
+
+            let mut hasher = blake3::Hasher::new();
+            // Domain separation: distinguishes this preimage from any other
+            // blake3 digest in the codebase and pins the field layout.
+            hasher.update(b"cqs-notes-revision-v1\0");
+            for row in &rows {
+                let id: String = row.get(0);
+                let text: String = row.get(1);
+                let sentiment: f64 = row.get(2);
+                // `mentions` is stored as a JSON array string; hash the raw
+                // stored bytes (NULL → empty) — byte-stable and order-stable
+                // because the column is written canonically.
+                let mentions: Option<String> = row.try_get(3).unwrap_or(None);
+
+                hasher.update(id.as_bytes());
+                hasher.update(b"\0");
+                hasher.update(text.as_bytes());
+                hasher.update(b"\0");
+                // Fixed-width little-endian bits of the f64 so two equal
+                // sentiments always hash identically (avoids float-format drift).
+                hasher.update(&sentiment.to_le_bytes());
+                hasher.update(b"\0");
+                hasher.update(mentions.as_deref().unwrap_or("").as_bytes());
+                hasher.update(b"\0");
+            }
+            Ok(*hasher.finalize().as_bytes())
+        })
+    }
+
     /// Get note statistics (total, warnings, patterns).
     /// Uses `SENTIMENT_NEGATIVE_THRESHOLD` (-0.3) and `SENTIMENT_POSITIVE_THRESHOLD` (0.3)
     /// to classify notes. These thresholds work with discrete sentiment values
@@ -407,6 +467,119 @@ mod tests {
     }
     // Sentiment threshold positioning relative to the discrete values is a
     // compile-time `const` assertion next to the constants in `crate::note`.
+
+    /// The notes-revision token is the overlay's notes cache-identity. Empty
+    /// table → a stable, fixed digest; a sentiment change → a different digest;
+    /// a text-only change → a different digest. These are the invalidation
+    /// signals the overlay fingerprint folds in.
+    #[test]
+    fn notes_revision_tracks_note_changes() {
+        let (store, _dir) = setup_store();
+        let source = Path::new("notes.toml");
+
+        // Empty table: stable across repeated reads, equal to a second empty
+        // store's token (the clean / no-notes case).
+        let empty = store.notes_revision().unwrap();
+        assert_eq!(
+            empty,
+            store.notes_revision().unwrap(),
+            "empty-table token must be stable"
+        );
+        let (other_empty_store, _d2) = setup_store();
+        assert_eq!(
+            empty,
+            other_empty_store.notes_revision().unwrap(),
+            "two empty notes tables must yield the same token"
+        );
+
+        // Seed a note: token moves off the empty digest.
+        let mut note = make_note("n1", "load-bearing", -0.5);
+        note.mentions = vec!["src/lib.rs".to_string()];
+        store
+            .upsert_notes_batch(&[note.clone()], source, 100)
+            .unwrap();
+        let after_seed = store.notes_revision().unwrap();
+        assert_ne!(empty, after_seed, "seeding a note must move the token");
+
+        // Sentiment change (the notes-coherence hazard's exact trigger): flips.
+        let mut flipped = note.clone();
+        flipped.sentiment = 0.5;
+        store.upsert_notes_batch(&[flipped], source, 200).unwrap();
+        let after_sentiment = store.notes_revision().unwrap();
+        assert_ne!(
+            after_seed, after_sentiment,
+            "a sentiment change must flip the notes-revision token"
+        );
+
+        // Text-only change (a `notes update` that leaves sentiment+mentions):
+        // still counts as "the notes changed".
+        let mut retext = note;
+        retext.sentiment = 0.5; // keep the sentiment from the prior step
+        retext.text = "rewritten note text".to_string();
+        store.upsert_notes_batch(&[retext], source, 300).unwrap();
+        let after_text = store.notes_revision().unwrap();
+        assert_ne!(
+            after_sentiment, after_text,
+            "a text-only change must flip the notes-revision token"
+        );
+    }
+
+    /// Over-invalidation guard: a parent index write that does NOT touch notes
+    /// must leave the notes-revision token unchanged. This is the property that
+    /// distinguishes the targeted token from `data_version` (which bumps on
+    /// every index.db write). Here a re-read with no intervening notes mutation
+    /// returns the identical token, and re-inserting the byte-identical note set
+    /// is a no-op for the token.
+    #[test]
+    fn notes_revision_stable_across_no_notes_change() {
+        let (store, _dir) = setup_store();
+        let source = Path::new("notes.toml");
+
+        let mut a = make_note("a", "alpha", 0.5);
+        a.mentions = vec!["src/a.rs".to_string()];
+        let mut b = make_note("b", "beta", -1.0);
+        b.mentions = vec!["src/b.rs".to_string()];
+        store
+            .upsert_notes_batch(&[a.clone(), b.clone()], source, 100)
+            .unwrap();
+
+        let token = store.notes_revision().unwrap();
+        // Re-read with no mutation: identical.
+        assert_eq!(
+            token,
+            store.notes_revision().unwrap(),
+            "re-read without a notes change must return the same token"
+        );
+
+        // Re-insert the byte-identical note set (an idempotent write): the
+        // content identity is unchanged, so the token must not move. (mtime is
+        // deliberately excluded from the digest precisely so this holds.)
+        store.upsert_notes_batch(&[a, b], source, 999).unwrap();
+        assert_eq!(
+            token,
+            store.notes_revision().unwrap(),
+            "re-writing identical notes (only mtime differs) must not move the token"
+        );
+    }
+
+    /// Order independence: the token is computed `ORDER BY id`, so the insertion
+    /// order of the same note set cannot perturb it.
+    #[test]
+    fn notes_revision_is_order_independent() {
+        let (s1, _d1) = setup_store();
+        let (s2, _d2) = setup_store();
+        let source = Path::new("notes.toml");
+        let a = make_note("a", "alpha", 0.5);
+        let b = make_note("b", "beta", -0.5);
+        s1.upsert_notes_batch(&[a.clone(), b.clone()], source, 100)
+            .unwrap();
+        s2.upsert_notes_batch(&[b, a], source, 100).unwrap();
+        assert_eq!(
+            s1.notes_revision().unwrap(),
+            s2.notes_revision().unwrap(),
+            "same note set in either insertion order must yield the same token"
+        );
+    }
 
     #[test]
     fn test_replace_notes_replaces_not_appends() {

--- a/src/worktree_overlay.rs
+++ b/src/worktree_overlay.rs
@@ -550,8 +550,9 @@ fn is_parse_candidate(worktree_root: &Path, rel: &str) -> bool {
 /// Domain-separated preimage (plan §6):
 /// ```text
 /// blake3(
-///   "cqs-overlay-v1\0"
+///   "cqs-overlay-v2\0"
 ///   ‖ parent_head_oid ‖ "\0"
+///   ‖ notes_revision ‖ "\0"
 ///   ‖ for each record, sorted by (new, old):
 ///       status_letter ‖ "\0" ‖ old ‖ "\0" ‖ new ‖ "\0"
 ///       ‖ blake3(worktree file bytes)   // 32 zero bytes for D / unreadable
@@ -565,11 +566,23 @@ fn is_parse_candidate(worktree_root: &Path, rel: &str) -> bool {
 /// preimage means a parent commit (the usual index-rebuild cause)
 /// automatically rebuilds the overlay. Sorting makes the fingerprint
 /// order-independent across git output orderings.
-pub fn fingerprint(worktree_root: &Path, delta: &Delta) -> [u8; 32] {
+///
+/// `notes_revision` is a digest of the parent's notes (see
+/// `Store::notes_revision`). Notes participate in the overlay's *state* (they
+/// are copied into the shadow store so its `note_boost` matches the parent),
+/// so they must participate in the overlay's *cache identity* too: a parent
+/// notes mutation flips this token, the fingerprint differs, and the LRU
+/// treats the cached overlay as a miss and rebuilds with the fresh notes —
+/// invalidation by content-identity, not the deferrable overlay-clear. Both
+/// production fingerprint sites (build and re-validation) must pass the same
+/// token so a notes-unchanged re-validation still matches the cached build.
+pub fn fingerprint(worktree_root: &Path, delta: &Delta, notes_revision: &[u8; 32]) -> [u8; 32] {
     let _span = tracing::debug_span!("overlay_fingerprint").entered();
     let mut hasher = blake3::Hasher::new();
-    hasher.update(b"cqs-overlay-v1\0");
+    hasher.update(b"cqs-overlay-v2\0");
     hasher.update(delta.parent_head_oid.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(notes_revision);
     hasher.update(b"\0");
 
     // Sort records by (new, old) so git ordering doesn't change the result.
@@ -751,6 +764,13 @@ mod tests {
         assert!(recs.is_empty(), "truncated rename yields no record");
     }
 
+    /// A fixed notes-revision token for the fingerprint-structure tests below.
+    /// These tests exercise the record/content terms of the preimage; the notes
+    /// term is held constant here and varied in the overlay-build tests that own
+    /// a parent `Store`. (Value is arbitrary but non-zero so a regression that
+    /// dropped the notes term would still alter every digest.)
+    const TEST_NOTES_REV: [u8; 32] = [7u8; 32];
+
     /// Build a minimal `Delta` with known records (no git, no FS) for
     /// fingerprint determinism / order-independence tests.
     fn delta_with(records: Vec<DeltaRecord>) -> Delta {
@@ -779,9 +799,39 @@ mod tests {
                 new: "src/b.rs".into(),
             },
         ];
-        let fp1 = fingerprint(dir, &delta_with(recs.clone()));
-        let fp2 = fingerprint(dir, &delta_with(recs));
+        let fp1 = fingerprint(dir, &delta_with(recs.clone()), &TEST_NOTES_REV);
+        let fp2 = fingerprint(dir, &delta_with(recs), &TEST_NOTES_REV);
         assert_eq!(fp1, fp2);
+    }
+
+    #[test]
+    fn fingerprint_folds_in_notes_revision() {
+        // Same worktree delta, different notes-revision tokens → different
+        // fingerprints. This is the structural property the notes-coherence
+        // hazard needed: a parent notes mutation (which flips the token) must
+        // move the cache identity so the overlay LRU rebuilds with the fresh
+        // notes. The inverse — identical token → identical fingerprint — guards
+        // against a notes-unchanged re-validation spuriously rebuilding (the
+        // over-invalidation trap).
+        let dir = std::path::Path::new("/nonexistent");
+        let rec = DeltaRecord {
+            status: DeltaStatus::Deleted,
+            old: None,
+            new: "src/a.rs".into(),
+        };
+        let token_a = [1u8; 32];
+        let token_b = [2u8; 32];
+        let fp_a = fingerprint(dir, &delta_with(vec![rec.clone()]), &token_a);
+        let fp_a2 = fingerprint(dir, &delta_with(vec![rec.clone()]), &token_a);
+        let fp_b = fingerprint(dir, &delta_with(vec![rec]), &token_b);
+        assert_eq!(
+            fp_a, fp_a2,
+            "same delta + same notes token → same fingerprint"
+        );
+        assert_ne!(
+            fp_a, fp_b,
+            "same delta + different notes token → different fingerprint"
+        );
     }
 
     #[test]
@@ -799,8 +849,12 @@ mod tests {
             old: None,
             new: "src/b.rs".into(),
         };
-        let fp_ab = fingerprint(dir, &delta_with(vec![a.clone(), b.clone()]));
-        let fp_ba = fingerprint(dir, &delta_with(vec![b, a]));
+        let fp_ab = fingerprint(
+            dir,
+            &delta_with(vec![a.clone(), b.clone()]),
+            &TEST_NOTES_REV,
+        );
+        let fp_ba = fingerprint(dir, &delta_with(vec![b, a]), &TEST_NOTES_REV);
         assert_eq!(fp_ab, fp_ba);
     }
 
@@ -819,8 +873,8 @@ mod tests {
             old: None,
             new: "src/b.rs".into(),
         };
-        let fp_two = fingerprint(dir, &delta_with(vec![a.clone(), b]));
-        let fp_one = fingerprint(dir, &delta_with(vec![a]));
+        let fp_two = fingerprint(dir, &delta_with(vec![a.clone(), b]), &TEST_NOTES_REV);
+        let fp_one = fingerprint(dir, &delta_with(vec![a]), &TEST_NOTES_REV);
         assert_ne!(fp_two, fp_one);
     }
 
@@ -836,9 +890,9 @@ mod tests {
             old: None,
             new: "a.rs".into(),
         };
-        let fp_before = fingerprint(root, &delta_with(vec![rec.clone()]));
+        let fp_before = fingerprint(root, &delta_with(vec![rec.clone()]), &TEST_NOTES_REV);
         std::fs::write(root.join("a.rs"), b"fn edited() {}").unwrap();
-        let fp_after = fingerprint(root, &delta_with(vec![rec]));
+        let fp_after = fingerprint(root, &delta_with(vec![rec]), &TEST_NOTES_REV);
         assert_ne!(
             fp_before, fp_after,
             "content change must move the fingerprint"
@@ -863,11 +917,11 @@ mod tests {
             old: None,
             new: "link.rs".into(),
         };
-        let fp_before = fingerprint(root, &delta_with(vec![rec.clone()]));
+        let fp_before = fingerprint(root, &delta_with(vec![rec.clone()]), &TEST_NOTES_REV);
 
         // Mutate the target the symlink points at.
         std::fs::write(root.join("target.rs"), b"fn edited_target() {}").unwrap();
-        let fp_after = fingerprint(root, &delta_with(vec![rec.clone()]));
+        let fp_after = fingerprint(root, &delta_with(vec![rec.clone()]), &TEST_NOTES_REV);
         assert_eq!(
             fp_before, fp_after,
             "symlink target change must NOT move the fingerprint"
@@ -880,7 +934,7 @@ mod tests {
             old: None,
             new: "link.rs".into(),
         };
-        let fp_sentinel = fingerprint(root, &delta_with(vec![del]));
+        let fp_sentinel = fingerprint(root, &delta_with(vec![del]), &TEST_NOTES_REV);
         // Only the status letter differs in the preimage; re-derive with a
         // Modified record over a path whose content_digest errors (the symlink)
         // to confirm the sentinel path is taken.

--- a/tests/worktree_overlay_delta_test.rs
+++ b/tests/worktree_overlay_delta_test.rs
@@ -13,6 +13,11 @@ mod common;
 use common::{git_in, worktree_fixture};
 use cqs::worktree::overlay_root;
 use cqs::worktree_overlay::{discover_delta, fingerprint, DeltaStatus};
+
+/// These tests exercise the delta record + content terms of the overlay
+/// fingerprint; the notes-revision term is held at a fixed token so the
+/// content-sensitivity assertions isolate the delta.
+const NO_NOTES: [u8; 32] = [0u8; 32];
 use std::path::PathBuf;
 
 /// Helper: does `masked_origins` contain a repo-relative path?
@@ -175,9 +180,9 @@ fn fingerprint_stable_across_repeated_discovery() {
     )
     .unwrap();
     let d1 = discover_delta(&wt, &parent).expect("discover 1");
-    let fp1 = fingerprint(&wt, &d1);
+    let fp1 = fingerprint(&wt, &d1, &NO_NOTES);
     let d2 = discover_delta(&wt, &parent).expect("discover 2");
-    let fp2 = fingerprint(&wt, &d2);
+    let fp2 = fingerprint(&wt, &d2, &NO_NOTES);
     assert_eq!(fp1, fp2, "fingerprint stable when nothing changed");
 }
 
@@ -189,7 +194,7 @@ fn fingerprint_changes_on_edit_and_reverts() {
 
     // Clean baseline.
     let d_clean = discover_delta(&wt, &parent).expect("discover clean");
-    let fp_clean = fingerprint(&wt, &d_clean);
+    let fp_clean = fingerprint(&wt, &d_clean, &NO_NOTES);
 
     // Edit → fingerprint moves.
     std::fs::write(
@@ -198,14 +203,14 @@ fn fingerprint_changes_on_edit_and_reverts() {
     )
     .unwrap();
     let d_edit = discover_delta(&wt, &parent).expect("discover edit");
-    let fp_edit = fingerprint(&wt, &d_edit);
+    let fp_edit = fingerprint(&wt, &d_edit, &NO_NOTES);
     assert_ne!(fp_clean, fp_edit, "edit must move the fingerprint");
 
     // Revert to byte-identical original → back to the clean fingerprint
     // (working tree == parent HEAD → file falls out of the delta).
     std::fs::write(&lib, original).unwrap();
     let d_revert = discover_delta(&wt, &parent).expect("discover revert");
-    let fp_revert = fingerprint(&wt, &d_revert);
+    let fp_revert = fingerprint(&wt, &d_revert, &NO_NOTES);
     assert!(
         d_revert.masked_origins.is_empty(),
         "reverted file is no longer in the delta"
@@ -229,7 +234,7 @@ fn fingerprint_content_sensitive_for_same_record_set() {
     )
     .unwrap();
     let d1 = discover_delta(&wt, &parent).expect("discover 1");
-    let fp1 = fingerprint(&wt, &d1);
+    let fp1 = fingerprint(&wt, &d1, &NO_NOTES);
 
     std::fs::write(
         &lib,
@@ -237,7 +242,7 @@ fn fingerprint_content_sensitive_for_same_record_set() {
     )
     .unwrap();
     let d2 = discover_delta(&wt, &parent).expect("discover 2");
-    let fp2 = fingerprint(&wt, &d2);
+    let fp2 = fingerprint(&wt, &d2, &NO_NOTES);
 
     assert_ne!(
         fp1, fp2,


### PR DESCRIPTION
## Fold a notes-revision token into the worktree-overlay fingerprint

closes #1884

After #1885 the overlay `:memory:` store copies parent notes (so an edited-and-noted file keeps its `note_boost`), but the overlay's cache *identity* — `fingerprint()` — didn't include notes. A parent `cqs notes update` therefore didn't move the fingerprint, didn't invalidate the overlay LRU entry, and the overlay leg served a **stale `note_boost`** until the deferrable `slot::OVERLAYS` clear ran — while the parent leg read fresh notes. Concurrent window → inconsistent `note_boost` across two note-sharing files in one response.

### Fix
- **`Store::notes_revision()`** (`src/store/notes.rs`): domain-separated blake3 digest over `(id, text, sentiment, mentions)` of every note `ORDER BY id`. `sentiment`+`mentions` are exactly what `NoteBoostIndex` consumes, so any boost-affecting change flips the token; `text` is folded for "notes changed" semantics. **Timestamps deliberately excluded** — and crucially it is **not** `data_version` (which bumps on every index.db write), so it changes IFF the notes change. A negative test (`notes_revision_stable_across_no_notes_change`) guards against the over-invalidation trap.
- **`fingerprint()`** (`src/worktree_overlay.rs`) gained a `notes_revision: &[u8;32]` param folded into the preimage; domain tag bumped `cqs-overlay-v1`→`v2`.
- Both production sites compute the token from the parent store with a matched `[0u8;32]` read-failure fallback: `build_overlay` (stamps it) and `get_overlay_via_lru` re-validation (recomputes to compare). The matched computation is load-bearing — a notes-unchanged re-validation still equals the cached build, preserving the debounce.

### Defense-in-depth, not a replacement
This is a faster invalidator layered over the pre-existing `data_version`→`slot::OVERLAYS`-clear path. A parent notes mutation always bumps `data_version`, so even in the degraded double-zero-token path (persistent notes-read failure) the slot clear still invalidates — strictly no worse than pre-fix. The token closes the deferred-clear / LRU-survived windows faster and self-heals at re-validation.

### Tests
4 lib tests (token moves on sentiment/text change, stable on no-notes-change, order-independent, fingerprint composition) + a slow e2e (`build_overlay_fingerprint_tracks_parent_note_sentiment`: real embedder, F0≠F1 across a sentiment flip, the rebuilt shadow's `note_boost` flips <1.0→>1.0). Module sweeps green (`store::notes` 17/17, `worktree_overlay` 13/13, overlay bin 27/27, delta integration 14/14). fmt / clippy --all-targets cuda / provenance clean.

### Review (magnet-area gates)
- **Opus code-review: APPROVE** — digest covers a strict superset of boost fields; timestamps excluded; both sites byte-identical; domain-tag bump clean (fingerprint is `:memory:`-only, never persisted); deterministic. One P3 (transient one-site read-fail → spurious rebuild, perf-only).
- **Seam-audit: no composition lie** — all three seams cleared (token∘copy, double-fallback, audit-mode) plus adjacent compositions (within-query coherence, store-cache vs token, cross-view re-validation).

### Known harmless non-atomicity (caveat)
`build_overlay`'s two parent-notes reads (`notes_revision()` then `copy_notes_from()`) are not snapshot-atomic — a concurrent `notes update` between them can stamp a fingerprint token for notes-state A over a shadow copied at state B. Harmless: re-validation recomputes the token and rebuilds on mismatch, and the 2s debounce window serves the *fresher* copy (correct boost); only the internal fingerprint identity is briefly inconsistent, never the served data.

### Scope
Not a schema/PARSER_VERSION/env change. The fingerprint is `:memory:`-only → no persisted state, **no reindex needed** (overlay caches rebuild in-memory per process). Binary rebuild + daemon restart on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
